### PR TITLE
Add support for passing 128 and 32 bit HFA args to call stubs on arm64

### DIFF
--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -1005,9 +1005,11 @@ NESTED_END InterpreterStubRet4Vector128, _TEXT
 // Copy arguments from the processor stack to the interpreter stack
 // The CPU stack slots are aligned to pointer size.
 
+#ifndef TARGET_APPLE
+
 LEAF_ENTRY Store_Stack
     ldr w11, [x10], #4 // SP offset
-    ldr w12, [x10], #4 // number of stack slots
+    ldr w12, [x10], #4 // size (multiple of stack slot size)
     add x11, sp, x11
     add x11, x11, #__PWTB_TransitionBlock + SIZEOF__TransitionBlock
 LOCAL_LABEL(StoreCopyLoop):
@@ -1018,6 +1020,39 @@ LOCAL_LABEL(StoreCopyLoop):
     ldr x11, [x10], #8
     EPILOG_BRANCH_REG x11
 LEAF_END Store_Stack
+
+#else // TARGET_APPLE
+
+LEAF_ENTRY Store_Stack
+    ldr w11, [x10], #4 // SP offset
+    ldr w12, [x10], #4 // size
+    add x11, sp, x11
+    add x11, x11, #__PWTB_TransitionBlock + SIZEOF__TransitionBlock
+    subs x12, x12, #8
+    blt LOCAL_LABEL(StoreCopyBy1)
+LOCAL_LABEL(StoreCopyLoop):
+    ldr x13, [x11], #8
+    str x13, [x9], #8
+    subs x12, x12, #8
+    bge LOCAL_LABEL(StoreCopyLoop)
+LOCAL_LABEL(StoreCopyBy1):
+    add x12, x12, #8
+    subs x12, x12, #1
+    blt LOCAL_LABEL(StoreDone)
+LOCAL_LABEL(StoreCopyLoop1):
+    ldrb w13, [x11], #1
+    strb w13, [x9], #1
+    subs x12, x12, #1
+    bge LOCAL_LABEL(StoreCopyLoop1)
+LOCAL_LABEL(StoreDone):
+    // Align x9 to the stack slot size
+    add x9, x9, 7
+    and x9, x9, 0xfffffffffffffff8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Stack
+
+#endif // TARGET_APPLE
 
 LEAF_ENTRY Load_Stack_Ref, _TEXT
         ldr w11, [x10], #4 // SP offset
@@ -1259,6 +1294,142 @@ ALTERNATE_ENTRY Store_X7
     ldr x11, [x10], #8
     EPILOG_BRANCH_REG x11
 LEAF_END Store_X1_X2_X3_X4_X5_X6_X7
+
+// Floating point stores for S registers using stp wherever possible
+// Due to the need to alignment, we need to add interpreter stack slot size alignment
+// to stores of odd numbers of registers
+
+LEAF_ENTRY Store_S0
+    str s0, [x9], #8 // align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S0
+
+LEAF_ENTRY Store_S1
+    str s1, [x9], #8 // align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S1
+
+LEAF_ENTRY Store_S0_S1
+    stp s0, s1, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S0_S1
+
+LEAF_ENTRY Store_S0_S1_S2
+    stp s0, s1, [x9], #8
+ALTERNATE_ENTRY Store_S2
+    str s2, [x9], #8 // align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S0_S1_S2
+
+LEAF_ENTRY Store_S0_S1_S2_S3
+    stp s0, s1, [x9], #8
+ALTERNATE_ENTRY Store_S2_S3
+    stp s2, s3, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S0_S1_S2_S3
+
+LEAF_ENTRY Store_S0_S1_S2_S3_S4
+    stp s0, s1, [x9], #8
+ALTERNATE_ENTRY Store_S2_S3_S4
+    stp s2, s3, [x9], #8
+ALTERNATE_ENTRY Store_S4
+    str s4, [x9], #8 // align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S0_S1_S2_S3_S4
+
+LEAF_ENTRY Store_S0_S1_S2_S3_S4_S5
+    stp s0, s1, [x9], #8
+ALTERNATE_ENTRY Store_S2_S3_S4_S5
+    stp s2, s3, [x9], #8
+ALTERNATE_ENTRY Store_S4_S5
+    stp s4, s5, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S0_S1_S2_S3_S4_S5
+
+LEAF_ENTRY Store_S0_S1_S2_S3_S4_S5_S6
+    stp s0, s1, [x9], #8
+ALTERNATE_ENTRY Store_S2_S3_S4_S5_S6
+    stp s2, s3, [x9], #8
+ALTERNATE_ENTRY Store_S4_S5_S6
+    stp s4, s5, [x9], #8
+ALTERNATE_ENTRY Store_S6
+    str s6, [x9], #8 // align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S0_S1_S2_S3_S4_S5_S6
+
+LEAF_ENTRY Store_S0_S1_S2_S3_S4_S5_S6_S7
+    stp s0, s1, [x9], #8
+ALTERNATE_ENTRY Store_S2_S3_S4_S5_S6_S7
+    stp s2, s3, [x9], #8
+ALTERNATE_ENTRY Store_S4_S5_S6_S7
+    stp s4, s5, [x9], #8
+ALTERNATE_ENTRY Store_S6_S7
+    stp s6, s7, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S0_S1_S2_S3_S4_S5_S6_S7
+
+LEAF_ENTRY Store_S1_S2
+    stp s1, s2, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S1_S2
+
+LEAF_ENTRY Store_S1_S2_S3
+    stp s1, s2, [x9], #8
+ALTERNATE_ENTRY Store_S3
+    str s3, [x9], #8// align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S1_S2_S3
+
+LEAF_ENTRY Store_S1_S2_S3_S4
+    stp s1, s2, [x9], #8
+ALTERNATE_ENTRY Store_S3_S4
+    stp s3, s4, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S1_S2_S3_S4
+
+LEAF_ENTRY Store_S1_S2_S3_S4_S5
+    stp s1, s2, [x9], #8
+ALTERNATE_ENTRY Store_S3_S4_S5
+    stp s3, s4, [x9], #8
+ALTERNATE_ENTRY Store_S5
+    str s5, [x9], #8// align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S1_S2_S3_S4_S5
+
+LEAF_ENTRY Store_S1_S2_S3_S4_S5_S6
+    stp s1, s2, [x9], #8
+ALTERNATE_ENTRY Store_S3_S4_S5_S6
+    stp s3, s4, [x9], #8
+ALTERNATE_ENTRY Store_S5_S6
+    stp s5, s6, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S1_S2_S3_S4_S5_S6
+
+LEAF_ENTRY Store_S1_S2_S3_S4_S5_S6_S7
+    stp s1, s2, [x9], #8
+ALTERNATE_ENTRY Store_S3_S4_S5_S6_S7
+    stp s3, s4, [x9], #8
+ALTERNATE_ENTRY Store_S5_S6_S7
+    stp s5, s6, [x9], #8
+ALTERNATE_ENTRY Store_S7
+    str s7, [x9], #8// align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_S1_S2_S3_S4_S5_S6_S7
 
 // Floating point stores using stp wherever possible
 
@@ -1755,6 +1926,142 @@ ALTERNATE_ENTRY Load_X7
     ldr x11, [x10], #8
     EPILOG_BRANCH_REG x11
 LEAF_END Load_X1_X2_X3_X4_X5_X6_X7
+
+// Routines for passing arguments in floating point registers S0..S7
+// Due to the need to alignment, we need to add interpreter stack slot size alignment
+// to stores of odd numbers of registers
+
+LEAF_ENTRY Load_S0
+    ldr s0, [x9], #8// align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S0
+
+LEAF_ENTRY Load_S1
+    ldr s1, [x9], #8// align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S1
+
+LEAF_ENTRY Load_S0_S1
+    ldp s0, s1, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S0_S1
+
+LEAF_ENTRY Load_S0_S1_S2
+    ldp s0, s1, [x9], #8
+ALTERNATE_ENTRY Load_S2
+    ldr s2, [x9], #8// align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S0_S1_S2
+
+LEAF_ENTRY Load_S0_S1_S2_S3
+    ldp s0, s1, [x9], #8
+ALTERNATE_ENTRY Load_S2_S3
+    ldp s2, s3, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S0_S1_S2_S3
+
+LEAF_ENTRY Load_S0_S1_S2_S3_S4
+    ldp s0, s1, [x9], #8
+ALTERNATE_ENTRY Load_S2_S3_S4
+    ldp s2, s3, [x9], #8
+ALTERNATE_ENTRY Load_S4
+    ldr s4, [x9], #8// align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S0_S1_S2_S3_S4
+
+LEAF_ENTRY Load_S0_S1_S2_S3_S4_S5
+    ldp s0, s1, [x9], #8
+ALTERNATE_ENTRY Load_S2_S3_S4_S5
+    ldp s2, s3, [x9], #8
+ALTERNATE_ENTRY Load_S4_S5
+    ldp s4, s5, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S0_S1_S2_S3_S4_S5
+
+LEAF_ENTRY Load_S0_S1_S2_S3_S4_S5_S6
+    ldp s0, s1, [x9], #8
+ALTERNATE_ENTRY Load_S2_S3_S4_S5_S6
+    ldp s2, s3, [x9], #8
+ALTERNATE_ENTRY Load_S4_S5_S6
+    ldp s4, s5, [x9], #8
+ALTERNATE_ENTRY Load_S6
+    ldr s6, [x9], #8// align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S0_S1_S2_S3_S4_S5_S6
+
+LEAF_ENTRY Load_S0_S1_S2_S3_S4_S5_S6_S7
+    ldp s0, s1, [x9], #8
+ALTERNATE_ENTRY Load_S2_S3_S4_S5_S6_S7
+    ldp s2, s3, [x9], #8
+ALTERNATE_ENTRY Load_S4_S5_S6_S7
+    ldp s4, s5, [x9], #8
+ALTERNATE_ENTRY Load_S6_S7
+    ldp s6, s7, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S0_S1_S2_S3_S4_S5_S6_S7
+
+LEAF_ENTRY Load_S1_S2
+    ldp s1, s2, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S1_S2
+
+LEAF_ENTRY Load_S1_S2_S3
+    ldp s1, s2, [x9], #8
+ALTERNATE_ENTRY Load_S3
+    ldr s3, [x9], #8// align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S1_S2_S3
+
+LEAF_ENTRY Load_S1_S2_S3_S4
+    ldp s1, s2, [x9], #8
+ALTERNATE_ENTRY Load_S3_S4
+    ldp s3, s4, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S1_S2_S3_S4
+
+LEAF_ENTRY Load_S1_S2_S3_S4_S5
+    ldp s1, s2, [x9], #8
+ALTERNATE_ENTRY Load_S3_S4_S5
+    ldp s3, s4, [x9], #8
+ALTERNATE_ENTRY Load_S5
+    ldr s5, [x9], #8// align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S1_S2_S3_S4_S5
+
+LEAF_ENTRY Load_S1_S2_S3_S4_S5_S6
+    ldp s1, s2, [x9], #8
+ALTERNATE_ENTRY Load_S3_S4_S5_S6
+    ldp s3, s4, [x9], #8
+ALTERNATE_ENTRY Load_S5_S6
+    ldp s5, s6, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S1_S2_S3_S4_S5
+
+LEAF_ENTRY Load_S1_S2_S3_S4_S5_S6_S7
+    ldp s1, s2, [x9], #8
+ALTERNATE_ENTRY Load_S3_S4_S5_S6_S7
+    ldp s3, s4, [x9], #8
+ALTERNATE_ENTRY Load_S5_S6_S7
+    ldp s5, s6, [x9], #8
+ALTERNATE_ENTRY Load_S7
+    ldr s7, [x9], #8// align to the interpreter stack slot size
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_S1_S2_S3_S4_S5_S6_S7
 
 // Routines for passing arguments in floating point registers D0..D7
 

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -1394,6 +1394,140 @@ ALTERNATE_ENTRY Store_D7
     EPILOG_BRANCH_REG x11
 LEAF_END Store_D1_D2_D3_D4_D5_D6_D7
 
+// Floating point stores for Q registers using stp wherever possible
+
+LEAF_ENTRY Store_Q0
+    str q0, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q0
+
+LEAF_ENTRY Store_Q1
+    str q1, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q1
+
+LEAF_ENTRY Store_Q0_Q1
+    stp q0, q1, [x9], #32
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q0_Q1
+
+LEAF_ENTRY Store_Q0_Q1_Q2
+    stp q0, q1, [x9], #32
+ALTERNATE_ENTRY Store_Q2
+    str q2, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q0_Q1_Q2
+
+LEAF_ENTRY Store_Q0_Q1_Q2_Q3
+    stp q0, q1, [x9], #32
+ALTERNATE_ENTRY Store_Q2_Q3
+    stp q2, q3, [x9], #32
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q0_Q1_Q2_Q3
+
+LEAF_ENTRY Store_Q0_Q1_Q2_Q3_Q4
+    stp q0, q1, [x9], #32
+ALTERNATE_ENTRY Store_Q2_Q3_Q4
+    stp q2, q3, [x9], #32
+ALTERNATE_ENTRY Store_Q4
+    str q4, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q0_Q1_Q2_Q3_Q4
+
+LEAF_ENTRY Store_Q0_Q1_Q2_Q3_Q4_Q5
+    stp q0, q1, [x9], #32
+ALTERNATE_ENTRY Store_Q2_Q3_Q4_Q5
+    stp q2, q3, [x9], #32
+ALTERNATE_ENTRY Store_Q4_Q5
+    stp q4, q5, [x9], #32
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q0_Q1_Q2_Q3_Q4_Q5
+
+LEAF_ENTRY Store_Q0_Q1_Q2_Q3_Q4_Q5_Q6
+    stp q0, q1, [x9], #32
+ALTERNATE_ENTRY Store_Q2_Q3_Q4_Q5_Q6
+    stp q2, q3, [x9], #32
+ALTERNATE_ENTRY Store_Q4_Q5_Q6
+    stp q4, q5, [x9], #32
+ALTERNATE_ENTRY Store_Q6
+    str q6, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q0_Q1_Q2_Q3_Q4_Q5_Q6
+
+LEAF_ENTRY Store_Q0_Q1_Q2_Q3_Q4_Q5_Q6_Q7
+    stp q0, q1, [x9], #32
+ALTERNATE_ENTRY Store_Q2_Q3_Q4_Q5_Q6_Q7
+    stp q2, q3, [x9], #32
+ALTERNATE_ENTRY Store_Q4_Q5_Q6_Q7
+    stp q4, q5, [x9], #32
+ALTERNATE_ENTRY Store_Q6_Q7
+    stp q6, q7, [x9], #32
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q0_Q1_Q2_Q3_Q4_Q5_Q6_Q7
+
+LEAF_ENTRY Store_Q1_Q2
+    stp q1, q2, [x9], #32
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q1_Q2
+
+LEAF_ENTRY Store_Q1_Q2_Q3
+    stp q1, q2, [x9], #32
+ALTERNATE_ENTRY Store_Q3
+    str q3, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q1_Q2_Q3
+
+LEAF_ENTRY Store_Q1_Q2_Q3_Q4
+    stp q1, q2, [x9], #32
+ALTERNATE_ENTRY Store_Q3_Q4
+    stp q3, q4, [x9], #32
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q1_Q2_Q3_Q4
+
+LEAF_ENTRY Store_Q1_Q2_Q3_Q4_Q5
+    stp q1, q2, [x9], #32
+ALTERNATE_ENTRY Store_Q3_Q4_Q5
+    stp q3, q4, [x9], #32
+ALTERNATE_ENTRY Store_Q5
+    str q5, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q1_Q2_Q3_Q4_Q5
+
+LEAF_ENTRY Store_Q1_Q2_Q3_Q4_Q5_Q6
+    stp q1, q2, [x9], #32
+ALTERNATE_ENTRY Store_Q3_Q4_Q5_Q6
+    stp q3, q4, [x9], #32
+ALTERNATE_ENTRY Store_Q5_Q6
+    stp q5, q6, [x9], #32
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q1_Q2_Q3_Q4_Q5_Q6
+
+LEAF_ENTRY Store_Q1_Q2_Q3_Q4_Q5_Q6_Q7
+    stp q1, q2, [x9], #32
+ALTERNATE_ENTRY Store_Q3_Q4_Q5_Q6_Q7
+    stp q3, q4, [x9], #32
+ALTERNATE_ENTRY Store_Q5_Q6_Q7
+    stp q5, q6, [x9], #32
+ALTERNATE_ENTRY Store_Q7
+    str q7, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_Q1_Q2_Q3_Q4_Q5_Q6_Q7
+
 LEAF_ENTRY InjectInterpStackAlign
     add x9, x9, #8
     ldr x11, [x10], #8
@@ -1735,6 +1869,120 @@ ALTERNATE_ENTRY Load_D7
     ldr x11, [x10], #8
     EPILOG_BRANCH_REG x11
 LEAF_END Load_D1_D2_D3_D4_D5_D6_D7
+
+// Routines for passing arguments in floating point registers Q0..Q7
+
+LEAF_ENTRY Load_Q0
+    ldr q0, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_Q0
+
+LEAF_ENTRY Load_Q1
+    ldr q1, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_Q1
+
+LEAF_ENTRY Load_Q0_Q1
+    ldp q0, q1, [x9], #32
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_Q0_Q1
+
+LEAF_ENTRY Load_Q0_Q1_Q2
+    ldr q0, [x9], #16
+ALTERNATE_ENTRY Load_Q1_Q2
+    ldr q1, [x9], #16
+ALTERNATE_ENTRY Load_Q2
+    ldr q2, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_Q0_Q1_Q2
+
+LEAF_ENTRY Load_Q0_Q1_Q2_Q3
+    ldr q0, [x9], #16
+ALTERNATE_ENTRY Load_Q1_Q2_Q3
+    ldr q1, [x9], #16
+ALTERNATE_ENTRY Load_Q2_Q3
+    ldr q2, [x9], #16
+ALTERNATE_ENTRY Load_Q3
+    ldr q3, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_Q0_Q1_Q2_Q3
+
+LEAF_ENTRY Load_Q0_Q1_Q2_Q3_Q4
+    ldr q0, [x9], #16
+ALTERNATE_ENTRY Load_Q1_Q2_Q3_Q4
+    ldr q1, [x9], #16
+ALTERNATE_ENTRY Load_Q2_Q3_Q4
+    ldr q2, [x9], #16
+ALTERNATE_ENTRY Load_Q3_Q4
+    ldr q3, [x9], #16
+ALTERNATE_ENTRY Load_Q4
+    ldr q4, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_Q0_Q1_Q2_Q3_Q4
+
+LEAF_ENTRY Load_Q0_Q1_Q2_Q3_Q4_Q5
+    ldr q0, [x9], #16
+ALTERNATE_ENTRY Load_Q1_Q2_Q3_Q4_Q5
+    ldr q1, [x9], #16
+ALTERNATE_ENTRY Load_Q2_Q3_Q4_Q5
+    ldr q2, [x9], #16
+ALTERNATE_ENTRY Load_Q3_Q4_Q5
+    ldr q3, [x9], #16
+ALTERNATE_ENTRY Load_Q4_Q5
+    ldr q4, [x9], #16
+ALTERNATE_ENTRY Load_Q5
+    ldr q5, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_Q0_Q1_Q2_Q3_Q4_Q5
+
+LEAF_ENTRY Load_Q0_Q1_Q2_Q3_Q4_Q5_Q6
+    ldr q0, [x9], #16
+ALTERNATE_ENTRY Load_Q1_Q2_Q3_Q4_Q5_Q6
+    ldr q1, [x9], #16
+ALTERNATE_ENTRY Load_Q2_Q3_Q4_Q5_Q6
+    ldr q2, [x9], #16
+ALTERNATE_ENTRY Load_Q3_Q4_Q5_Q6
+    ldr q3, [x9], #16
+ALTERNATE_ENTRY Load_Q4_Q5_Q6
+    ldr q4, [x9], #16
+ALTERNATE_ENTRY Load_Q5_Q6
+    ldr q5, [x9], #16
+ALTERNATE_ENTRY Load_Q6
+    ldr q6, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_Q0_Q1_Q2_Q3_Q4_Q5_Q6
+
+LEAF_ENTRY Load_Q0_Q1_Q2_Q3_Q4_Q5_Q6_Q7
+    ldp q0, q1, [x9], #32
+ALTERNATE_ENTRY Load_Q2_Q3_Q4_Q5_Q6_Q7
+    ldp q2, q3, [x9], #32
+ALTERNATE_ENTRY Load_Q4_Q5_Q6_Q7
+    ldp q4, q5, [x9], #32
+ALTERNATE_ENTRY Load_Q6_Q7
+    ldp q6, q7, [x9], #32
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_Q0_Q1_Q2_Q3_Q4_Q5_Q6_Q7
+
+LEAF_ENTRY Load_Q1_Q2_Q3_Q4_Q5_Q6_Q7
+    ldp q1, q2, [x9], #32
+ALTERNATE_ENTRY Load_Q3_Q4_Q5_Q6_Q7
+    ldp q3, q4, [x9], #32
+ALTERNATE_ENTRY Load_Q5_Q6_Q7
+    ldp q5, q6, [x9], #32
+ALTERNATE_ENTRY Load_Q7
+    ldr q7, [x9], #16
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Load_Q1_Q2_Q3_Q4_Q5_Q6_Q7
 
 // Functions to invoke a sequence of routines to:
 // 1. load arguments from the interpreter stack to registers / stack based on the calling convention

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -1575,6 +1575,142 @@ RefCopyDone$argReg
         EPILOG_BRANCH_REG x11
     LEAF_END Store_X1_X2_X3_X4_X5_X6_X7
 
+    ; Floating point stores for S registers using stp wherever possible
+    ; Due to the need to alignment, we need to add interpreter stack slot size alignment
+    ; to stores of odd numbers of registers
+
+    LEAF_ENTRY Store_S0
+        str s0, [x9], #8 ; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S0
+
+    LEAF_ENTRY Store_S1
+        str s1, [x9], #8 ; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S1
+
+    LEAF_ENTRY Store_S0_S1
+        stp s0, s1, [x9], #8
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S0_S1
+
+    LEAF_ENTRY Store_S0_S1_S2
+        stp s0, s1, [x9], #8
+    ALTERNATE_ENTRY Store_S2
+        str s2, [x9], #8 ; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S0_S1_S2
+
+    LEAF_ENTRY Store_S0_S1_S2_S3
+        stp s0, s1, [x9], #8
+    ALTERNATE_ENTRY Store_S2_S3
+        stp s2, s3, [x9], #8
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S0_S1_S2_S3
+
+    LEAF_ENTRY Store_S0_S1_S2_S3_S4
+        stp s0, s1, [x9], #8
+    ALTERNATE_ENTRY Store_S2_S3_S4
+        stp s2, s3, [x9], #8
+    ALTERNATE_ENTRY Store_S4
+        str s4, [x9], #8 ; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S0_S1_S2_S3_S4
+
+    LEAF_ENTRY Store_S0_S1_S2_S3_S4_S5
+        stp s0, s1, [x9], #8
+    ALTERNATE_ENTRY Store_S2_S3_S4_S5
+        stp s2, s3, [x9], #8
+    ALTERNATE_ENTRY Store_S4_S5
+        stp s4, s5, [x9], #8
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S0_S1_S2_S3_S4_S5
+
+    LEAF_ENTRY Store_S0_S1_S2_S3_S4_S5_S6
+        stp s0, s1, [x9], #8
+    ALTERNATE_ENTRY Store_S2_S3_S4_S5_S6
+        stp s2, s3, [x9], #8
+    ALTERNATE_ENTRY Store_S4_S5_S6
+        stp s4, s5, [x9], #8
+    ALTERNATE_ENTRY Store_S6
+        str s6, [x9], #8 ; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S0_S1_S2_S3_S4_S5_S6
+
+    LEAF_ENTRY Store_S0_S1_S2_S3_S4_S5_S6_S7
+        stp s0, s1, [x9], #8
+    ALTERNATE_ENTRY Store_S2_S3_S4_S5_S6_S7
+        stp s2, s3, [x9], #8
+    ALTERNATE_ENTRY Store_S4_S5_S6_S7
+        stp s4, s5, [x9], #8
+    ALTERNATE_ENTRY Store_S6_S7
+        stp s6, s7, [x9], #8
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S0_S1_S2_S3_S4_S5_S6_S7
+
+    LEAF_ENTRY Store_S1_S2
+        stp s1, s2, [x9], #8
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S1_S2
+
+    LEAF_ENTRY Store_S1_S2_S3
+        stp s1, s2, [x9], #8
+    ALTERNATE_ENTRY Store_S3
+        str s3, [x9], #8; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S1_S2_S3
+
+    LEAF_ENTRY Store_S1_S2_S3_S4
+        stp s1, s2, [x9], #8
+    ALTERNATE_ENTRY Store_S3_S4
+        stp s3, s4, [x9], #8
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S1_S2_S3_S4
+
+    LEAF_ENTRY Store_S1_S2_S3_S4_S5
+        stp s1, s2, [x9], #8
+    ALTERNATE_ENTRY Store_S3_S4_S5
+        stp s3, s4, [x9], #8
+    ALTERNATE_ENTRY Store_S5
+        str s5, [x9], #8; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S1_S2_S3_S4_S5
+
+    LEAF_ENTRY Store_S1_S2_S3_S4_S5_S6
+        stp s1, s2, [x9], #8
+    ALTERNATE_ENTRY Store_S3_S4_S5_S6
+        stp s3, s4, [x9], #8
+    ALTERNATE_ENTRY Store_S5_S6
+        stp s5, s6, [x9], #8
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S1_S2_S3_S4_S5_S6
+
+    LEAF_ENTRY Store_S1_S2_S3_S4_S5_S6_S7
+        stp s1, s2, [x9], #8
+    ALTERNATE_ENTRY Store_S3_S4_S5_S6_S7
+        stp s3, s4, [x9], #8
+    ALTERNATE_ENTRY Store_S5_S6_S7
+        stp s5, s6, [x9], #8
+    ALTERNATE_ENTRY Store_S7
+        str s7, [x9], #8; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_S1_S2_S3_S4_S5_S6_S7
+
     ; Floating point stores using stp wherever possible
 
     LEAF_ENTRY Store_D0
@@ -2023,6 +2159,142 @@ CopyLoop
         ldr x11, [x10], #8
         EPILOG_BRANCH_REG x11
     LEAF_END Load_X1_X2_X3_X4_X5_X6_X7
+
+    ; Routines for passing arguments in floating point registers S0..S7
+    ; Due to the need to alignment, we need to add interpreter stack slot size alignment
+    ; to stores of odd numbers of registers
+
+    LEAF_ENTRY Load_S0
+        ldr s0, [x9], #8; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S0
+
+    LEAF_ENTRY Load_S1
+        ldr s1, [x9], #8; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S1
+
+    LEAF_ENTRY Load_S0_S1
+        ldp s0, s1, [x9], #8
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S0_S1
+
+    LEAF_ENTRY Load_S0_S1_S2
+        ldp s0, s1, [x9], #8
+    ALTERNATE_ENTRY Load_S2
+        ldr s2, [x9], #8; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S0_S1_S2
+
+    LEAF_ENTRY Load_S0_S1_S2_S3
+        ldp s0, s1, [x9], #8
+    ALTERNATE_ENTRY Load_S2_S3
+        ldp s2, s3, [x9], #8
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S0_S1_S2_S3
+
+    LEAF_ENTRY Load_S0_S1_S2_S3_S4
+        ldp s0, s1, [x9], #8
+    ALTERNATE_ENTRY Load_S2_S3_S4
+        ldp s2, s3, [x9], #8
+    ALTERNATE_ENTRY Load_S4
+        ldr s4, [x9], #8; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S0_S1_S2_S3_S4
+
+    LEAF_ENTRY Load_S0_S1_S2_S3_S4_S5
+        ldp s0, s1, [x9], #8
+    ALTERNATE_ENTRY Load_S2_S3_S4_S5
+        ldp s2, s3, [x9], #8
+    ALTERNATE_ENTRY Load_S4_S5
+        ldp s4, s5, [x9], #8
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S0_S1_S2_S3_S4_S5
+
+    LEAF_ENTRY Load_S0_S1_S2_S3_S4_S5_S6
+        ldp s0, s1, [x9], #8
+    ALTERNATE_ENTRY Load_S2_S3_S4_S5_S6
+        ldp s2, s3, [x9], #8
+    ALTERNATE_ENTRY Load_S4_S5_S6
+        ldp s4, s5, [x9], #8
+    ALTERNATE_ENTRY Load_S6
+        ldr s6, [x9], #8; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S0_S1_S2_S3_S4_S5_S6
+
+    LEAF_ENTRY Load_S0_S1_S2_S3_S4_S5_S6_S7
+        ldp s0, s1, [x9], #8
+    ALTERNATE_ENTRY Load_S2_S3_S4_S5_S6_S7
+        ldp s2, s3, [x9], #8
+    ALTERNATE_ENTRY Load_S4_S5_S6_S7
+        ldp s4, s5, [x9], #8
+    ALTERNATE_ENTRY Load_S6_S7
+        ldp s6, s7, [x9], #8
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S0_S1_S2_S3_S4_S5_S6_S7
+
+    LEAF_ENTRY Load_S1_S2
+        ldp s1, s2, [x9], #8
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S1_S2
+
+    LEAF_ENTRY Load_S1_S2_S3
+        ldp s1, s2, [x9], #8
+    ALTERNATE_ENTRY Load_S3
+        ldr s3, [x9], #8; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S1_S2_S3
+
+    LEAF_ENTRY Load_S1_S2_S3_S4
+        ldp s1, s2, [x9], #8
+    ALTERNATE_ENTRY Load_S3_S4
+        ldp s3, s4, [x9], #8
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S1_S2_S3_S4
+
+    LEAF_ENTRY Load_S1_S2_S3_S4_S5
+        ldp s1, s2, [x9], #8
+    ALTERNATE_ENTRY Load_S3_S4_S5
+        ldp s3, s4, [x9], #8
+    ALTERNATE_ENTRY Load_S5
+        ldr s5, [x9], #8; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S1_S2_S3_S4_S5
+
+    LEAF_ENTRY Load_S1_S2_S3_S4_S5_S6
+        ldp s1, s2, [x9], #8
+    ALTERNATE_ENTRY Load_S3_S4_S5_S6
+        ldp s3, s4, [x9], #8
+    ALTERNATE_ENTRY Load_S5_S6
+        ldp s5, s6, [x9], #8
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S1_S2_S3_S4_S5
+
+    LEAF_ENTRY Load_S1_S2_S3_S4_S5_S6_S7
+        ldp s1, s2, [x9], #8
+    ALTERNATE_ENTRY Load_S3_S4_S5_S6_S7
+        ldp s3, s4, [x9], #8
+    ALTERNATE_ENTRY Load_S5_S6_S7
+        ldp s5, s6, [x9], #8
+    ALTERNATE_ENTRY Load_S7
+        ldr s7, [x9], #8; align to the interpreter stack slot size
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_S1_S2_S3_S4_S5_S6_S7
 
     ; Routines for passing arguments in floating point registers D0..D7
 

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -1709,6 +1709,140 @@ RefCopyDone$argReg
         EPILOG_BRANCH_REG x11
     LEAF_END Store_D1_D2_D3_D4_D5_D6_D7
 
+    ; Floating point stores for Q registers using stp wherever possible
+
+    LEAF_ENTRY Store_Q0
+        str q0, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q0
+
+    LEAF_ENTRY Store_Q1
+        str q1, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q1
+
+    LEAF_ENTRY Store_Q0_Q1
+        stp q0, q1, [x9], #32
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q0_Q1
+
+    LEAF_ENTRY Store_Q0_Q1_Q2
+        stp q0, q1, [x9], #32
+    ALTERNATE_ENTRY Store_Q2
+        str q2, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q0_Q1_Q2
+
+    LEAF_ENTRY Store_Q0_Q1_Q2_Q3
+        stp q0, q1, [x9], #32
+    ALTERNATE_ENTRY Store_Q2_Q3
+        stp q2, q3, [x9], #32
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q0_Q1_Q2_Q3
+
+    LEAF_ENTRY Store_Q0_Q1_Q2_Q3_Q4
+        stp q0, q1, [x9], #32
+    ALTERNATE_ENTRY Store_Q2_Q3_Q4
+        stp q2, q3, [x9], #32
+    ALTERNATE_ENTRY Store_Q4
+        str q4, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q0_Q1_Q2_Q3_Q4
+
+    LEAF_ENTRY Store_Q0_Q1_Q2_Q3_Q4_Q5
+        stp q0, q1, [x9], #32
+    ALTERNATE_ENTRY Store_Q2_Q3_Q4_Q5
+        stp q2, q3, [x9], #32
+    ALTERNATE_ENTRY Store_Q4_Q5
+        stp q4, q5, [x9], #32
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q0_Q1_Q2_Q3_Q4_Q5
+
+    LEAF_ENTRY Store_Q0_Q1_Q2_Q3_Q4_Q5_Q6
+        stp q0, q1, [x9], #32
+    ALTERNATE_ENTRY Store_Q2_Q3_Q4_Q5_Q6
+        stp q2, q3, [x9], #32
+    ALTERNATE_ENTRY Store_Q4_Q5_Q6
+        stp q4, q5, [x9], #32
+    ALTERNATE_ENTRY Store_Q6
+        str q6, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q0_Q1_Q2_Q3_Q4_Q5_Q6
+
+    LEAF_ENTRY Store_Q0_Q1_Q2_Q3_Q4_Q5_Q6_Q7
+        stp q0, q1, [x9], #32
+    ALTERNATE_ENTRY Store_Q2_Q3_Q4_Q5_Q6_Q7
+        stp q2, q3, [x9], #32
+    ALTERNATE_ENTRY Store_Q4_Q5_Q6_Q7
+        stp q4, q5, [x9], #32
+    ALTERNATE_ENTRY Store_Q6_Q7
+        stp q6, q7, [x9], #32
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q0_Q1_Q2_Q3_Q4_Q5_Q6_Q7
+
+    LEAF_ENTRY Store_Q1_Q2
+        stp q1, q2, [x9], #32
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q1_Q2
+
+    LEAF_ENTRY Store_Q1_Q2_Q3
+        stp q1, q2, [x9], #32
+    ALTERNATE_ENTRY Store_Q3
+        str q3, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q1_Q2_Q3
+
+    LEAF_ENTRY Store_Q1_Q2_Q3_Q4
+        stp q1, q2, [x9], #32
+    ALTERNATE_ENTRY Store_Q3_Q4
+        stp q3, q4, [x9], #32
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q1_Q2_Q3_Q4
+
+    LEAF_ENTRY Store_Q1_Q2_Q3_Q4_Q5
+        stp q1, q2, [x9], #32
+    ALTERNATE_ENTRY Store_Q3_Q4_Q5
+        stp q3, q4, [x9], #32
+    ALTERNATE_ENTRY Store_Q5
+        str q5, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q1_Q2_Q3_Q4_Q5
+
+    LEAF_ENTRY Store_Q1_Q2_Q3_Q4_Q5_Q6
+        stp q1, q2, [x9], #32
+    ALTERNATE_ENTRY Store_Q3_Q4_Q5_Q6
+        stp q3, q4, [x9], #32
+    ALTERNATE_ENTRY Store_Q5_Q6
+        stp q5, q6, [x9], #32
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q1_Q2_Q3_Q4_Q5_Q6
+
+    LEAF_ENTRY Store_Q1_Q2_Q3_Q4_Q5_Q6_Q7
+        stp q1, q2, [x9], #32
+    ALTERNATE_ENTRY Store_Q3_Q4_Q5_Q6_Q7
+        stp q3, q4, [x9], #32
+    ALTERNATE_ENTRY Store_Q5_Q6_Q7
+        stp q5, q6, [x9], #32
+    ALTERNATE_ENTRY Store_Q7
+        str q7, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Store_Q1_Q2_Q3_Q4_Q5_Q6_Q7
+
     LEAF_ENTRY InjectInterpStackAlign
         add x9, x9, #8
         ldr x11, [x10], #8
@@ -2003,6 +2137,120 @@ CopyLoop
         ldr x11, [x10], #8
         EPILOG_BRANCH_REG x11
     LEAF_END Load_D0_D1_D2_D3_D4_D5_D6_D7
+
+    ; Routines for passing arguments in floating point registers Q0..Q7
+
+    LEAF_ENTRY Load_Q0
+        ldr q0, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_Q0
+
+    LEAF_ENTRY Load_Q1
+        ldr q1, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_Q1
+
+    LEAF_ENTRY Load_Q0_Q1
+        ldp q0, q1, [x9], #32
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_Q0_Q1
+
+    LEAF_ENTRY Load_Q0_Q1_Q2
+        ldr q0, [x9], #16
+    ALTERNATE_ENTRY Load_Q1_Q2
+        ldr q1, [x9], #16
+    ALTERNATE_ENTRY Load_Q2
+        ldr q2, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_Q0_Q1_Q2
+
+    LEAF_ENTRY Load_Q0_Q1_Q2_Q3
+        ldr q0, [x9], #16
+    ALTERNATE_ENTRY Load_Q1_Q2_Q3
+        ldr q1, [x9], #16
+    ALTERNATE_ENTRY Load_Q2_Q3
+        ldr q2, [x9], #16
+    ALTERNATE_ENTRY Load_Q3
+        ldr q3, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_Q0_Q1_Q2_Q3
+
+    LEAF_ENTRY Load_Q0_Q1_Q2_Q3_Q4
+        ldr q0, [x9], #16
+    ALTERNATE_ENTRY Load_Q1_Q2_Q3_Q4
+        ldr q1, [x9], #16
+    ALTERNATE_ENTRY Load_Q2_Q3_Q4
+        ldr q2, [x9], #16
+    ALTERNATE_ENTRY Load_Q3_Q4
+        ldr q3, [x9], #16
+    ALTERNATE_ENTRY Load_Q4
+        ldr q4, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_Q0_Q1_Q2_Q3_Q4
+
+    LEAF_ENTRY Load_Q0_Q1_Q2_Q3_Q4_Q5
+        ldr q0, [x9], #16
+    ALTERNATE_ENTRY Load_Q1_Q2_Q3_Q4_Q5
+        ldr q1, [x9], #16
+    ALTERNATE_ENTRY Load_Q2_Q3_Q4_Q5
+        ldr q2, [x9], #16
+    ALTERNATE_ENTRY Load_Q3_Q4_Q5
+        ldr q3, [x9], #16
+    ALTERNATE_ENTRY Load_Q4_Q5
+        ldr q4, [x9], #16
+    ALTERNATE_ENTRY Load_Q5
+        ldr q5, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_Q0_Q1_Q2_Q3_Q4_Q5
+
+    LEAF_ENTRY Load_Q0_Q1_Q2_Q3_Q4_Q5_Q6
+        ldr q0, [x9], #16
+    ALTERNATE_ENTRY Load_Q1_Q2_Q3_Q4_Q5_Q6
+        ldr q1, [x9], #16
+    ALTERNATE_ENTRY Load_Q2_Q3_Q4_Q5_Q6
+        ldr q2, [x9], #16
+    ALTERNATE_ENTRY Load_Q3_Q4_Q5_Q6
+        ldr q3, [x9], #16
+    ALTERNATE_ENTRY Load_Q4_Q5_Q6
+        ldr q4, [x9], #16
+    ALTERNATE_ENTRY Load_Q5_Q6
+        ldr q5, [x9], #16
+    ALTERNATE_ENTRY Load_Q6
+        ldr q6, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_Q0_Q1_Q2_Q3_Q4_Q5_Q6
+
+    LEAF_ENTRY Load_Q0_Q1_Q2_Q3_Q4_Q5_Q6_Q7
+        ldp q0, q1, [x9], #32
+    ALTERNATE_ENTRY Load_Q2_Q3_Q4_Q5_Q6_Q7
+        ldp q2, q3, [x9], #32
+    ALTERNATE_ENTRY Load_Q4_Q5_Q6_Q7
+        ldp q4, q5, [x9], #32
+    ALTERNATE_ENTRY Load_Q6_Q7
+        ldp q6, q7, [x9], #32
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_Q0_Q1_Q2_Q3_Q4_Q5_Q6_Q7
+
+    LEAF_ENTRY Load_Q1_Q2_Q3_Q4_Q5_Q6_Q7
+        ldp q1, q2, [x9], #32
+    ALTERNATE_ENTRY Load_Q3_Q4_Q5_Q6_Q7
+        ldp q3, q4, [x9], #32
+    ALTERNATE_ENTRY Load_Q5_Q6_Q7
+        ldp q5, q6, [x9], #32
+    ALTERNATE_ENTRY Load_Q7
+        ldr q7, [x9], #16
+        ldr x11, [x10], #8
+        EPILOG_BRANCH_REG x11
+    LEAF_END Load_Q1_Q2_Q3_Q4_Q5_Q6_Q7
 
     ; X0 - routines array
     ; X1 - interpreter stack args location

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -917,6 +917,81 @@ extern "C" void Store_Q6();
 extern "C" void Store_Q6_Q7();
 extern "C" void Store_Q7();
 
+// S register function prototypes
+extern "C" void Load_S0();
+extern "C" void Load_S0_S1();
+extern "C" void Load_S0_S1_S2();
+extern "C" void Load_S0_S1_S2_S3();
+extern "C" void Load_S0_S1_S2_S3_S4();
+extern "C" void Load_S0_S1_S2_S3_S4_S5();
+extern "C" void Load_S0_S1_S2_S3_S4_S5_S6();
+extern "C" void Load_S0_S1_S2_S3_S4_S5_S6_S7();
+extern "C" void Load_S1();
+extern "C" void Load_S1_S2();
+extern "C" void Load_S1_S2_S3();
+extern "C" void Load_S1_S2_S3_S4();
+extern "C" void Load_S1_S2_S3_S4_S5();
+extern "C" void Load_S1_S2_S3_S4_S5_S6();
+extern "C" void Load_S1_S2_S3_S4_S5_S6_S7();
+extern "C" void Load_S2();
+extern "C" void Load_S2_S3();
+extern "C" void Load_S2_S3_S4();
+extern "C" void Load_S2_S3_S4_S5();
+extern "C" void Load_S2_S3_S4_S5_S6();
+extern "C" void Load_S2_S3_S4_S5_S6_S7();
+extern "C" void Load_S3();
+extern "C" void Load_S3_S4();
+extern "C" void Load_S3_S4_S5();
+extern "C" void Load_S3_S4_S5_S6();
+extern "C" void Load_S3_S4_S5_S6_S7();
+extern "C" void Load_S4();
+extern "C" void Load_S4_S5();
+extern "C" void Load_S4_S5_S6();
+extern "C" void Load_S4_S5_S6_S7();
+extern "C" void Load_S5();
+extern "C" void Load_S5_S6();
+extern "C" void Load_S5_S6_S7();
+extern "C" void Load_S6();
+extern "C" void Load_S6_S7();
+extern "C" void Load_S7();
+
+extern "C" void Store_S0();
+extern "C" void Store_S0_S1();
+extern "C" void Store_S0_S1_S2();
+extern "C" void Store_S0_S1_S2_S3();
+extern "C" void Store_S0_S1_S2_S3_S4();
+extern "C" void Store_S0_S1_S2_S3_S4_S5();
+extern "C" void Store_S0_S1_S2_S3_S4_S5_S6();
+extern "C" void Store_S0_S1_S2_S3_S4_S5_S6_S7();
+extern "C" void Store_S1();
+extern "C" void Store_S1_S2();
+extern "C" void Store_S1_S2_S3();
+extern "C" void Store_S1_S2_S3_S4();
+extern "C" void Store_S1_S2_S3_S4_S5();
+extern "C" void Store_S1_S2_S3_S4_S5_S6();
+extern "C" void Store_S1_S2_S3_S4_S5_S6_S7();
+extern "C" void Store_S2();
+extern "C" void Store_S2_S3();
+extern "C" void Store_S2_S3_S4();
+extern "C" void Store_S2_S3_S4_S5();
+extern "C" void Store_S2_S3_S4_S5_S6();
+extern "C" void Store_S2_S3_S4_S5_S6_S7();
+extern "C" void Store_S3();
+extern "C" void Store_S3_S4();
+extern "C" void Store_S3_S4_S5();
+extern "C" void Store_S3_S4_S5_S6();
+extern "C" void Store_S3_S4_S5_S6_S7();
+extern "C" void Store_S4();
+extern "C" void Store_S4_S5();
+extern "C" void Store_S4_S5_S6();
+extern "C" void Store_S4_S5_S6_S7();
+extern "C" void Store_S5();
+extern "C" void Store_S5_S6();
+extern "C" void Store_S5_S6_S7();
+extern "C" void Store_S6();
+extern "C" void Store_S6_S7();
+extern "C" void Store_S7();
+
 PCODE FPRegsStoreRoutines[] =
 {
     (PCODE)Store_D0,                         // 00
@@ -1189,6 +1264,142 @@ PCODE FPRegs128LoadRoutines[] =
     (PCODE)Load_Q7                          // 77
 };
 
+PCODE FPRegs32StoreRoutines[] =
+{
+    (PCODE)Store_S0,                         // 00
+    (PCODE)Store_S0_S1,                      // 01
+    (PCODE)Store_S0_S1_S2,                   // 02
+    (PCODE)Store_S0_S1_S2_S3,                // 03
+    (PCODE)Store_S0_S1_S2_S3_S4,             // 04
+    (PCODE)Store_S0_S1_S2_S3_S4_S5,          // 05
+    (PCODE)Store_S0_S1_S2_S3_S4_S5_S6,       // 06
+    (PCODE)Store_S0_S1_S2_S3_S4_S5_S6_S7,    // 07
+    (PCODE)0,                                // 10
+    (PCODE)Store_S1,                         // 11
+    (PCODE)Store_S1_S2,                      // 12
+    (PCODE)Store_S1_S2_S3,                   // 13
+    (PCODE)Store_S1_S2_S3_S4,                // 14
+    (PCODE)Store_S1_S2_S3_S4_S5,             // 15
+    (PCODE)Store_S1_S2_S3_S4_S5_S6,          // 16
+    (PCODE)Store_S1_S2_S3_S4_S5_S6_S7,       // 17
+    (PCODE)0,                                // 20
+    (PCODE)0,                                // 21
+    (PCODE)Store_S2,                         // 22
+    (PCODE)Store_S2_S3,                      // 23
+    (PCODE)Store_S2_S3_S4,                   // 24
+    (PCODE)Store_S2_S3_S4_S5,                // 25
+    (PCODE)Store_S2_S3_S4_S5_S6,             // 26
+    (PCODE)Store_S2_S3_S4_S5_S6_S7,          // 27
+    (PCODE)0,                                // 30
+    (PCODE)0,                                // 31
+    (PCODE)0,                                // 32
+    (PCODE)Store_S3,                         // 33
+    (PCODE)Store_S3_S4,                      // 34
+    (PCODE)Store_S3_S4_S5,                   // 35
+    (PCODE)Store_S3_S4_S5_S6,                // 36
+    (PCODE)Store_S3_S4_S5_S6_S7,             // 37
+    (PCODE)0,                                // 40
+    (PCODE)0,                                // 41
+    (PCODE)0,                                // 42
+    (PCODE)0,                                // 43
+    (PCODE)Store_S4,                         // 44
+    (PCODE)Store_S4_S5,                      // 45
+    (PCODE)Store_S4_S5_S6,                   // 46
+    (PCODE)Store_S4_S5_S6_S7,                // 47
+    (PCODE)0,                                // 50
+    (PCODE)0,                                // 51
+    (PCODE)0,                                // 52
+    (PCODE)0,                                // 53
+    (PCODE)0,                                // 54
+    (PCODE)Store_S5,                         // 55
+    (PCODE)Store_S5_S6,                      // 56
+    (PCODE)Store_S5_S6_S7,                   // 57
+    (PCODE)0,                                // 60
+    (PCODE)0,                                // 61
+    (PCODE)0,                                // 62
+    (PCODE)0,                                // 63
+    (PCODE)0,                                // 64
+    (PCODE)0,                                // 65
+    (PCODE)Store_S6,                         // 66
+    (PCODE)Store_S6_S7,                      // 67
+    (PCODE)0,                                // 70
+    (PCODE)0,                                // 71
+    (PCODE)0,                                // 72
+    (PCODE)0,                                // 73
+    (PCODE)0,                                // 74
+    (PCODE)0,                                // 75
+    (PCODE)0,                                // 76
+    (PCODE)Store_S7                          // 77
+};
+
+PCODE FPRegs32LoadRoutines[] =
+{
+    (PCODE)Load_S0,                         // 00
+    (PCODE)Load_S0_S1,                      // 01
+    (PCODE)Load_S0_S1_S2,                   // 02
+    (PCODE)Load_S0_S1_S2_S3,                // 03
+    (PCODE)Load_S0_S1_S2_S3_S4,             // 04
+    (PCODE)Load_S0_S1_S2_S3_S4_S5,          // 05
+    (PCODE)Load_S0_S1_S2_S3_S4_S5_S6,       // 06
+    (PCODE)Load_S0_S1_S2_S3_S4_S5_S6_S7,    // 07
+    (PCODE)0,                               // 10
+    (PCODE)Load_S1,                         // 11
+    (PCODE)Load_S1_S2,                      // 12
+    (PCODE)Load_S1_S2_S3,                   // 13
+    (PCODE)Load_S1_S2_S3_S4,                // 14
+    (PCODE)Load_S1_S2_S3_S4_S5,             // 15
+    (PCODE)Load_S1_S2_S3_S4_S5_S6,          // 16
+    (PCODE)Load_S1_S2_S3_S4_S5_S6_S7,       // 17
+    (PCODE)0,                               // 20
+    (PCODE)0,                               // 21
+    (PCODE)Load_S2,                         // 22
+    (PCODE)Load_S2_S3,                      // 23
+    (PCODE)Load_S2_S3_S4,                   // 24
+    (PCODE)Load_S2_S3_S4_S5,                // 25
+    (PCODE)Load_S2_S3_S4_S5_S6,             // 26
+    (PCODE)Load_S2_S3_S4_S5_S6_S7,          // 27
+    (PCODE)0,                               // 30
+    (PCODE)0,                               // 31
+    (PCODE)0,                               // 32
+    (PCODE)Load_S3,                         // 33
+    (PCODE)Load_S3_S4,                      // 34
+    (PCODE)Load_S3_S4_S5,                   // 35
+    (PCODE)Load_S3_S4_S5_S6,                // 36
+    (PCODE)Load_S3_S4_S5_S6_S7,             // 37
+    (PCODE)0,                               // 40
+    (PCODE)0,                               // 41
+    (PCODE)0,                               // 42
+    (PCODE)0,                               // 43
+    (PCODE)Load_S4,                         // 44
+    (PCODE)Load_S4_S5,                      // 45
+    (PCODE)Load_S4_S5_S6,                   // 46
+    (PCODE)Load_S4_S5_S6_S7,                // 47
+    (PCODE)0,                               // 50
+    (PCODE)0,                               // 51
+    (PCODE)0,                               // 52
+    (PCODE)0,                               // 53
+    (PCODE)0,                               // 54
+    (PCODE)Load_S5,                         // 55
+    (PCODE)Load_S5_S6,                      // 56
+    (PCODE)Load_S5_S6_S7,                   // 57
+    (PCODE)0,                               // 60
+    (PCODE)0,                               // 61
+    (PCODE)0,                               // 62
+    (PCODE)0,                               // 63
+    (PCODE)0,                               // 64
+    (PCODE)0,                               // 65
+    (PCODE)Load_S6,                         // 66
+    (PCODE)Load_S6_S7,                      // 67
+    (PCODE)0,                               // 70
+    (PCODE)0,                               // 71
+    (PCODE)0,                               // 72
+    (PCODE)0,                               // 73
+    (PCODE)0,                               // 74
+    (PCODE)0,                               // 75
+    (PCODE)0,                               // 76
+    (PCODE)Load_S7                          // 77
+};
+
 #endif // TARGET_ARM64
 
 #define LOG_COMPUTE_CALL_STUB 0
@@ -1279,6 +1490,15 @@ PCODE CallStubGenerator::GetFPReg128RangeRoutine(int x1, int x2)
     PCODE routine = m_interpreterToNative ? FPRegs128LoadRoutines[index] : FPRegs128StoreRoutines[index];
     _ASSERTE(routine != 0);
     return routine;
+}
+
+PCODE CallStubGenerator::GetFPReg32RangeRoutine(int x1, int x2)
+{
+#if LOG_COMPUTE_CALL_STUB
+    printf("GetFPReg32RangeRoutine %d %d\n", x1, x2);
+#endif
+    int index = x1 * NUM_FLOAT_ARGUMENT_REGISTERS + x2;
+    return m_interpreterToNative ? FPRegs32LoadRoutines[index] : FPRegs32StoreRoutines[index];
 }
 #endif // TARGET_ARM64
 
@@ -1683,12 +1903,20 @@ void CallStubGenerator::TerminateCurrentRoutineIfNotOfNewType(RoutineType type, 
         m_x1 = NoRange;
         m_currentRoutineType = RoutineType::None;
     }
+#ifdef TARGET_ARM64
+    else if ((m_currentRoutineType == RoutineType::FPReg32) && (type != RoutineType::FPReg32))
+    {
+        pRoutines[m_routineIndex++] = GetFPReg32RangeRoutine(m_x1, m_x2);
+        m_x1 = NoRange;
+        m_currentRoutineType = RoutineType::None;
+    }
     else if ((m_currentRoutineType == RoutineType::FPReg128) && (type != RoutineType::FPReg128))
     {
         pRoutines[m_routineIndex++] = GetFPReg128RangeRoutine(m_x1, m_x2);
         m_x1 = NoRange;
         m_currentRoutineType = RoutineType::None;
     }
+#endif // TARGET_ARM64
     else if ((m_currentRoutineType == RoutineType::Stack) && (type != RoutineType::Stack))
     {
         pRoutines[m_routineIndex++] = GetStackRoutine();
@@ -1705,6 +1933,7 @@ void CallStubGenerator::ComputeCallStub(MetaSig &sig, PCODE *pRoutines)
     ArgIterator argIt(&sig);
     int32_t interpreterStackOffset = 0;
 
+    m_currentRoutineType = RoutineType::None;
     m_r1 = NoRange; // indicates that there is no active range of general purpose registers
     m_r2 = 0;
     m_x1 = NoRange; // indicates that there is no active range of FP registers
@@ -1873,13 +2102,19 @@ void CallStubGenerator::ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocD
 
     RoutineType argType = RoutineType::None;
     if (argLocDesc.m_cGenReg != 0)
+    {
         argType = RoutineType::GPReg;
+    }
     else if (argLocDesc.m_cFloatReg != 0)
     {
 #ifdef TARGET_ARM64
         if (argLocDesc.m_hfaFieldSize == 16)
         {
             argType = RoutineType::FPReg128;
+        }
+        else if (argLocDesc.m_hfaFieldSize == 4)
+        {
+            argType = RoutineType::FPReg32;
         }
         else
 #endif // TARGET_ARM64
@@ -1888,7 +2123,9 @@ void CallStubGenerator::ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocD
         }
     }
     else if (argLocDesc.m_byteStackSize != 0)
+    {
         argType = RoutineType::Stack;
+    }
     
     TerminateCurrentRoutineIfNotOfNewType(argType, pRoutines);
 
@@ -1941,14 +2178,32 @@ void CallStubGenerator::ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocD
             {
                 pRoutines[m_routineIndex++] = GetFPRegRangeRoutine(m_x1, m_x2);
             }
-            else
+#ifdef TARGET_ARM64
+            else if (m_currentRoutineType == RoutineType::FPReg32)
+            {
+                pRoutines[m_routineIndex++] = GetFPReg32RangeRoutine(m_x1, m_x2);
+            }
+            else if (m_currentRoutineType == RoutineType::FPReg128)
             {
                 pRoutines[m_routineIndex++] = GetFPReg128RangeRoutine(m_x1, m_x2);
             }
-
+#endif // TARGET_ARM64
             m_x1 = argLocDesc.m_idxFloatReg;
             m_x2 = m_x1 + argLocDesc.m_cFloatReg - 1;
         }
+
+#ifdef TARGET_ARM64
+        if ((argType == RoutineType::FPReg32) && ((argLocDesc.m_cFloatReg & 1) != 0))
+        {
+            // HFA Arguments using odd number of 32 bit FP registers cannot be merged with further ranges due to the
+            // interpreter stack slot size alignment needs. The range copy routines for these registers
+            // ensure that the interpreter stack is properly aligned after the odd number of registers are 
+            // loaded / stored.
+            pRoutines[m_routineIndex++] = GetFPReg32RangeRoutine(m_x1, m_x2);
+            argType = RoutineType::None;
+            m_x1 = NoRange;
+        }
+#endif // TARGET_ARM64
     }
 
     if (argLocDesc.m_byteStackSize != 0)
@@ -2215,19 +2470,18 @@ CallStubGenerator::ReturnType CallStubGenerator::GetReturnType(ArgIterator *pArg
                 }
                 else
                 {
-                    switch (thReturnValueType.GetSize())
+                    unsigned size = thReturnValueType.GetSize();
+                    if (size <= 8)
                     {
-                        case 1:
-                        case 2:
-                        case 4:
-                        case 8:
-                            return ReturnTypeI8;
-                            break;
-                        case 16:
-                            return ReturnType2I8;
-                        default:
-                            _ASSERTE(!"The return types that are not HFA should be <= 16 bytes in size");
-                            break;
+                        return ReturnTypeI8;
+                    }
+                    else if (size <= 16)
+                    {
+                        return ReturnType2I8;
+                    }
+                    else
+                    {
+                        _ASSERTE(!"The return types that are not HFA should be <= 16 bytes in size");
                     }
                 }
 #else

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -1234,7 +1234,9 @@ PCODE CallStubGenerator::GetGPRegRangeRoutine(int r1, int r2)
 #endif
 
     int index = r1 * NUM_ARGUMENT_REGISTERS + r2;
-    return m_interpreterToNative ? GPRegsRoutines[index] : GPRegsStoreRoutines[index];
+    PCODE routine = m_interpreterToNative ? GPRegsRoutines[index] : GPRegsStoreRoutines[index];
+    _ASSERTE(routine != 0);
+    return routine;
 }
 
 #ifndef UNIX_AMD64_ABI
@@ -1262,7 +1264,9 @@ PCODE CallStubGenerator::GetFPRegRangeRoutine(int x1, int x2)
     printf("GetFPRegRangeRoutine %d %d\n", x1, x2);
 #endif
     int index = x1 * NUM_FLOAT_ARGUMENT_REGISTERS + x2;
-    return m_interpreterToNative ? FPRegsRoutines[index] : FPRegsStoreRoutines[index];
+    PCODE routine = m_interpreterToNative ? FPRegsRoutines[index] : FPRegsStoreRoutines[index];
+    _ASSERTE(routine != 0);
+    return routine;
 }
 
 #ifdef TARGET_ARM64
@@ -1272,7 +1276,9 @@ PCODE CallStubGenerator::GetFPReg128RangeRoutine(int x1, int x2)
     printf("GetFPReg128RangeRoutine %d %d\n", x1, x2);
 #endif
     int index = x1 * NUM_FLOAT_ARGUMENT_REGISTERS + x2;
-    return m_interpreterToNative ? FPRegs128LoadRoutines[index] : FPRegs128StoreRoutines[index];
+    PCODE routine = m_interpreterToNative ? FPRegs128LoadRoutines[index] : FPRegs128StoreRoutines[index];
+    _ASSERTE(routine != 0);
+    return routine;
 }
 #endif // TARGET_ARM64
 
@@ -1870,13 +1876,13 @@ void CallStubGenerator::ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocD
         argType = RoutineType::GPReg;
     else if (argLocDesc.m_cFloatReg != 0)
     {
-#ifdef TARGET_ARM64        
+#ifdef TARGET_ARM64
         if (argLocDesc.m_hfaFieldSize == 16)
         {
             argType = RoutineType::FPReg128;
         }
         else
-#endif // TARGET_ARM64        
+#endif // TARGET_ARM64
         {
             argType = RoutineType::FPReg;
         }

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -842,6 +842,81 @@ extern "C" void Store_D6();
 extern "C" void Store_D6_D7();
 extern "C" void Store_D7();
 
+// Q register function prototypes
+extern "C" void Load_Q0();
+extern "C" void Load_Q0_Q1();
+extern "C" void Load_Q0_Q1_Q2();
+extern "C" void Load_Q0_Q1_Q2_Q3();
+extern "C" void Load_Q0_Q1_Q2_Q3_Q4();
+extern "C" void Load_Q0_Q1_Q2_Q3_Q4_Q5();
+extern "C" void Load_Q0_Q1_Q2_Q3_Q4_Q5_Q6();
+extern "C" void Load_Q0_Q1_Q2_Q3_Q4_Q5_Q6_Q7();
+extern "C" void Load_Q1();
+extern "C" void Load_Q1_Q2();
+extern "C" void Load_Q1_Q2_Q3();
+extern "C" void Load_Q1_Q2_Q3_Q4();
+extern "C" void Load_Q1_Q2_Q3_Q4_Q5();
+extern "C" void Load_Q1_Q2_Q3_Q4_Q5_Q6();
+extern "C" void Load_Q1_Q2_Q3_Q4_Q5_Q6_Q7();
+extern "C" void Load_Q2();
+extern "C" void Load_Q2_Q3();
+extern "C" void Load_Q2_Q3_Q4();
+extern "C" void Load_Q2_Q3_Q4_Q5();
+extern "C" void Load_Q2_Q3_Q4_Q5_Q6();
+extern "C" void Load_Q2_Q3_Q4_Q5_Q6_Q7();
+extern "C" void Load_Q3();
+extern "C" void Load_Q3_Q4();
+extern "C" void Load_Q3_Q4_Q5();
+extern "C" void Load_Q3_Q4_Q5_Q6();
+extern "C" void Load_Q3_Q4_Q5_Q6_Q7();
+extern "C" void Load_Q4();
+extern "C" void Load_Q4_Q5();
+extern "C" void Load_Q4_Q5_Q6();
+extern "C" void Load_Q4_Q5_Q6_Q7();
+extern "C" void Load_Q5();
+extern "C" void Load_Q5_Q6();
+extern "C" void Load_Q5_Q6_Q7();
+extern "C" void Load_Q6();
+extern "C" void Load_Q6_Q7();
+extern "C" void Load_Q7();
+
+extern "C" void Store_Q0();
+extern "C" void Store_Q0_Q1();
+extern "C" void Store_Q0_Q1_Q2();
+extern "C" void Store_Q0_Q1_Q2_Q3();
+extern "C" void Store_Q0_Q1_Q2_Q3_Q4();
+extern "C" void Store_Q0_Q1_Q2_Q3_Q4_Q5();
+extern "C" void Store_Q0_Q1_Q2_Q3_Q4_Q5_Q6();
+extern "C" void Store_Q0_Q1_Q2_Q3_Q4_Q5_Q6_Q7();
+extern "C" void Store_Q1();
+extern "C" void Store_Q1_Q2();
+extern "C" void Store_Q1_Q2_Q3();
+extern "C" void Store_Q1_Q2_Q3_Q4();
+extern "C" void Store_Q1_Q2_Q3_Q4_Q5();
+extern "C" void Store_Q1_Q2_Q3_Q4_Q5_Q6();
+extern "C" void Store_Q1_Q2_Q3_Q4_Q5_Q6_Q7();
+extern "C" void Store_Q2();
+extern "C" void Store_Q2_Q3();
+extern "C" void Store_Q2_Q3_Q4();
+extern "C" void Store_Q2_Q3_Q4_Q5();
+extern "C" void Store_Q2_Q3_Q4_Q5_Q6();
+extern "C" void Store_Q2_Q3_Q4_Q5_Q6_Q7();
+extern "C" void Store_Q3();
+extern "C" void Store_Q3_Q4();
+extern "C" void Store_Q3_Q4_Q5();
+extern "C" void Store_Q3_Q4_Q5_Q6();
+extern "C" void Store_Q3_Q4_Q5_Q6_Q7();
+extern "C" void Store_Q4();
+extern "C" void Store_Q4_Q5();
+extern "C" void Store_Q4_Q5_Q6();
+extern "C" void Store_Q4_Q5_Q6_Q7();
+extern "C" void Store_Q5();
+extern "C" void Store_Q5_Q6();
+extern "C" void Store_Q5_Q6_Q7();
+extern "C" void Store_Q6();
+extern "C" void Store_Q6_Q7();
+extern "C" void Store_Q7();
+
 PCODE FPRegsStoreRoutines[] =
 {
     (PCODE)Store_D0,                         // 00
@@ -978,6 +1053,142 @@ PCODE FPRegsRoutines[] =
     (PCODE)Load_D7                          // 77
 };
 
+PCODE FPRegs128StoreRoutines[] =
+{
+    (PCODE)Store_Q0,                         // 00
+    (PCODE)Store_Q0_Q1,                      // 01
+    (PCODE)Store_Q0_Q1_Q2,                   // 02
+    (PCODE)Store_Q0_Q1_Q2_Q3,                // 03
+    (PCODE)Store_Q0_Q1_Q2_Q3_Q4,             // 04
+    (PCODE)Store_Q0_Q1_Q2_Q3_Q4_Q5,          // 05
+    (PCODE)Store_Q0_Q1_Q2_Q3_Q4_Q5_Q6,       // 06
+    (PCODE)Store_Q0_Q1_Q2_Q3_Q4_Q5_Q6_Q7,    // 07
+    (PCODE)0,                                // 10
+    (PCODE)Store_Q1,                         // 11
+    (PCODE)Store_Q1_Q2,                      // 12
+    (PCODE)Store_Q1_Q2_Q3,                   // 13
+    (PCODE)Store_Q1_Q2_Q3_Q4,                // 14
+    (PCODE)Store_Q1_Q2_Q3_Q4_Q5,             // 15
+    (PCODE)Store_Q1_Q2_Q3_Q4_Q5_Q6,          // 16
+    (PCODE)Store_Q1_Q2_Q3_Q4_Q5_Q6_Q7,       // 17
+    (PCODE)0,                                // 20
+    (PCODE)0,                                // 21
+    (PCODE)Store_Q2,                         // 22
+    (PCODE)Store_Q2_Q3,                      // 23
+    (PCODE)Store_Q2_Q3_Q4,                   // 24
+    (PCODE)Store_Q2_Q3_Q4_Q5,                // 25
+    (PCODE)Store_Q2_Q3_Q4_Q5_Q6,             // 26
+    (PCODE)Store_Q2_Q3_Q4_Q5_Q6_Q7,          // 27
+    (PCODE)0,                                // 30
+    (PCODE)0,                                // 31
+    (PCODE)0,                                // 32
+    (PCODE)Store_Q3,                         // 33
+    (PCODE)Store_Q3_Q4,                      // 34
+    (PCODE)Store_Q3_Q4_Q5,                   // 35
+    (PCODE)Store_Q3_Q4_Q5_Q6,                // 36
+    (PCODE)Store_Q3_Q4_Q5_Q6_Q7,             // 37
+    (PCODE)0,                                // 40
+    (PCODE)0,                                // 41
+    (PCODE)0,                                // 42
+    (PCODE)0,                                // 43
+    (PCODE)Store_Q4,                         // 44
+    (PCODE)Store_Q4_Q5,                      // 45
+    (PCODE)Store_Q4_Q5_Q6,                   // 46
+    (PCODE)Store_Q4_Q5_Q6_Q7,                // 47
+    (PCODE)0,                                // 50
+    (PCODE)0,                                // 51
+    (PCODE)0,                                // 52
+    (PCODE)0,                                // 53
+    (PCODE)0,                                // 54
+    (PCODE)Store_Q5,                         // 55
+    (PCODE)Store_Q5_Q6,                      // 56
+    (PCODE)Store_Q5_Q6_Q7,                   // 57
+    (PCODE)0,                                // 60
+    (PCODE)0,                                // 61
+    (PCODE)0,                                // 62
+    (PCODE)0,                                // 63
+    (PCODE)0,                                // 64
+    (PCODE)0,                                // 65
+    (PCODE)Store_Q6,                         // 66
+    (PCODE)Store_Q6_Q7,                      // 67
+    (PCODE)0,                                // 70
+    (PCODE)0,                                // 71
+    (PCODE)0,                                // 72
+    (PCODE)0,                                // 73
+    (PCODE)0,                                // 74
+    (PCODE)0,                                // 75
+    (PCODE)0,                                // 76
+    (PCODE)Store_Q7                          // 77
+};
+
+PCODE FPRegs128LoadRoutines[] =
+{
+    (PCODE)Load_Q0,                         // 00
+    (PCODE)Load_Q0_Q1,                      // 01
+    (PCODE)Load_Q0_Q1_Q2,                   // 02
+    (PCODE)Load_Q0_Q1_Q2_Q3,                // 03
+    (PCODE)Load_Q0_Q1_Q2_Q3_Q4,             // 04
+    (PCODE)Load_Q0_Q1_Q2_Q3_Q4_Q5,          // 05
+    (PCODE)Load_Q0_Q1_Q2_Q3_Q4_Q5_Q6,       // 06
+    (PCODE)Load_Q0_Q1_Q2_Q3_Q4_Q5_Q6_Q7,    // 07
+    (PCODE)0,                               // 10
+    (PCODE)Load_Q1,                         // 11
+    (PCODE)Load_Q1_Q2,                      // 12
+    (PCODE)Load_Q1_Q2_Q3,                   // 13
+    (PCODE)Load_Q1_Q2_Q3_Q4,                // 14
+    (PCODE)Load_Q1_Q2_Q3_Q4_Q5,             // 15
+    (PCODE)Load_Q1_Q2_Q3_Q4_Q5_Q6,          // 16
+    (PCODE)Load_Q1_Q2_Q3_Q4_Q5_Q6_Q7,       // 17
+    (PCODE)0,                               // 20
+    (PCODE)0,                               // 21
+    (PCODE)Load_Q2,                         // 22
+    (PCODE)Load_Q2_Q3,                      // 23
+    (PCODE)Load_Q2_Q3_Q4,                   // 24
+    (PCODE)Load_Q2_Q3_Q4_Q5,                // 25
+    (PCODE)Load_Q2_Q3_Q4_Q5_Q6,             // 26
+    (PCODE)Load_Q2_Q3_Q4_Q5_Q6_Q7,          // 27
+    (PCODE)0,                               // 30
+    (PCODE)0,                               // 31
+    (PCODE)0,                               // 32
+    (PCODE)Load_Q3,                         // 33
+    (PCODE)Load_Q3_Q4,                      // 34
+    (PCODE)Load_Q3_Q4_Q5,                   // 35
+    (PCODE)Load_Q3_Q4_Q5_Q6,                // 36
+    (PCODE)Load_Q3_Q4_Q5_Q6_Q7,             // 37
+    (PCODE)0,                               // 40
+    (PCODE)0,                               // 41
+    (PCODE)0,                               // 42
+    (PCODE)0,                               // 43
+    (PCODE)Load_Q4,                         // 44
+    (PCODE)Load_Q4_Q5,                      // 45
+    (PCODE)Load_Q4_Q5_Q6,                   // 46
+    (PCODE)Load_Q4_Q5_Q6_Q7,                // 47
+    (PCODE)0,                               // 50
+    (PCODE)0,                               // 51
+    (PCODE)0,                               // 52
+    (PCODE)0,                               // 53
+    (PCODE)0,                               // 54
+    (PCODE)Load_Q5,                         // 55
+    (PCODE)Load_Q5_Q6,                      // 56
+    (PCODE)Load_Q5_Q6_Q7,                   // 57
+    (PCODE)0,                               // 60
+    (PCODE)0,                               // 61
+    (PCODE)0,                               // 62
+    (PCODE)0,                               // 63
+    (PCODE)0,                               // 64
+    (PCODE)0,                               // 65
+    (PCODE)Load_Q6,                         // 66
+    (PCODE)Load_Q6_Q7,                      // 67
+    (PCODE)0,                               // 70
+    (PCODE)0,                               // 71
+    (PCODE)0,                               // 72
+    (PCODE)0,                               // 73
+    (PCODE)0,                               // 74
+    (PCODE)0,                               // 75
+    (PCODE)0,                               // 76
+    (PCODE)Load_Q7                          // 77
+};
+
 #endif // TARGET_ARM64
 
 #define LOG_COMPUTE_CALL_STUB 0
@@ -1053,6 +1264,17 @@ PCODE CallStubGenerator::GetFPRegRangeRoutine(int x1, int x2)
     int index = x1 * NUM_FLOAT_ARGUMENT_REGISTERS + x2;
     return m_interpreterToNative ? FPRegsRoutines[index] : FPRegsStoreRoutines[index];
 }
+
+#ifdef TARGET_ARM64
+PCODE CallStubGenerator::GetFPReg128RangeRoutine(int x1, int x2)
+{
+#if LOG_COMPUTE_CALL_STUB
+    printf("GetFPReg128RangeRoutine %d %d\n", x1, x2);
+#endif
+    int index = x1 * NUM_FLOAT_ARGUMENT_REGISTERS + x2;
+    return m_interpreterToNative ? FPRegs128LoadRoutines[index] : FPRegs128StoreRoutines[index];
+}
+#endif // TARGET_ARM64
 
 extern "C" void CallJittedMethodRetVoid(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize);
 extern "C" void CallJittedMethodRetDouble(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize);
@@ -1443,21 +1665,30 @@ CallStubHeader *CallStubGenerator::GenerateCallStubForSig(MetaSig &sig)
 
 void CallStubGenerator::TerminateCurrentRoutineIfNotOfNewType(RoutineType type, PCODE *pRoutines)
 {
-    if ((m_r1 != NoRange) && (type != RoutineType::GPReg))
+    if ((m_currentRoutineType == RoutineType::GPReg) && (type != RoutineType::GPReg))
     {
         pRoutines[m_routineIndex++] = GetGPRegRangeRoutine(m_r1, m_r2);
         m_r1 = NoRange;
+        m_currentRoutineType = RoutineType::None;
     }
-    else if (m_x1 != NoRange && type != RoutineType::FPReg)
+    else if ((m_currentRoutineType == RoutineType::FPReg) && (type != RoutineType::FPReg))
     {
         pRoutines[m_routineIndex++] = GetFPRegRangeRoutine(m_x1, m_x2);
         m_x1 = NoRange;
+        m_currentRoutineType = RoutineType::None;
     }
-    else if (m_s1 != NoRange && type != RoutineType::Stack)
+    else if ((m_currentRoutineType == RoutineType::FPReg128) && (type != RoutineType::FPReg128))
+    {
+        pRoutines[m_routineIndex++] = GetFPReg128RangeRoutine(m_x1, m_x2);
+        m_x1 = NoRange;
+        m_currentRoutineType = RoutineType::None;
+    }
+    else if ((m_currentRoutineType == RoutineType::Stack) && (type != RoutineType::Stack))
     {
         pRoutines[m_routineIndex++] = GetStackRoutine();
         pRoutines[m_routineIndex++] = ((int64_t)(m_s2 - m_s1 + 1) << 32) | m_s1;
         m_s1 = NoRange;
+        m_currentRoutineType = RoutineType::None;
     }
 
     return;
@@ -1490,6 +1721,7 @@ void CallStubGenerator::ComputeCallStub(MetaSig &sig, PCODE *pRoutines)
         // we need to "inject" it here.
         // CLR ABI specifies that unlike the native Windows x64 calling convention, it is passed in the first argument register.
         m_r1 = 0;
+        m_currentRoutineType = RoutineType::GPReg;
         interpreterStackOffset += INTERP_STACK_SLOT_SIZE;
     }
 
@@ -1637,7 +1869,18 @@ void CallStubGenerator::ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocD
     if (argLocDesc.m_cGenReg != 0)
         argType = RoutineType::GPReg;
     else if (argLocDesc.m_cFloatReg != 0)
-        argType = RoutineType::FPReg;
+    {
+#ifdef TARGET_ARM64        
+        if (argLocDesc.m_hfaFieldSize == 16)
+        {
+            argType = RoutineType::FPReg128;
+        }
+        else
+#endif // TARGET_ARM64        
+        {
+            argType = RoutineType::FPReg;
+        }
+    }
     else if (argLocDesc.m_byteStackSize != 0)
         argType = RoutineType::Stack;
     
@@ -1680,7 +1923,7 @@ void CallStubGenerator::ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocD
             m_x1 = argLocDesc.m_idxFloatReg;
             m_x2 = m_x1 + argLocDesc.m_cFloatReg - 1;
         }
-        else if (argLocDesc.m_idxFloatReg == m_x2 + 1)
+        else if ((argLocDesc.m_idxFloatReg == m_x2 + 1) && (m_currentRoutineType == argType))
         {
             // Extend an existing range
             m_x2 += argLocDesc.m_cFloatReg;
@@ -1688,7 +1931,15 @@ void CallStubGenerator::ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocD
         else
         {
             // Discontinuous range - store a routine for the current and start a new one
-            pRoutines[m_routineIndex++] = GetFPRegRangeRoutine(m_x1, m_x2);
+            if (m_currentRoutineType == RoutineType::FPReg)
+            {
+                pRoutines[m_routineIndex++] = GetFPRegRangeRoutine(m_x1, m_x2);
+            }
+            else
+            {
+                pRoutines[m_routineIndex++] = GetFPReg128RangeRoutine(m_x1, m_x2);
+            }
+
             m_x1 = argLocDesc.m_idxFloatReg;
             m_x2 = m_x1 + argLocDesc.m_cFloatReg - 1;
         }
@@ -1743,6 +1994,7 @@ void CallStubGenerator::ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocD
             }
             pRoutines[m_routineIndex++] = m_s1;
             m_s1 = NoRange;
+            argType = RoutineType::None;
         }
 #endif // TARGET_APPLE && TARGET_ARM64
     }
@@ -1769,6 +2021,7 @@ void CallStubGenerator::ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocD
             pRoutines[m_routineIndex++] = GetGPRegRefRoutine(argLocDesc.m_idxGenReg);
             pRoutines[m_routineIndex++] = alignedArgSize;
             m_r1 = NoRange;
+            argType = RoutineType::None;
         }
         else
         {
@@ -1776,9 +2029,12 @@ void CallStubGenerator::ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocD
             pRoutines[m_routineIndex++] = GetStackRefRoutine();
             pRoutines[m_routineIndex++] = ((int64_t)alignedArgSize << 32) | argLocDesc.m_byteStackIndex;
             m_s1 = NoRange;
+            argType = RoutineType::None;
         }
     }
 #endif // UNIX_AMD64_ABI
+
+    m_currentRoutineType = argType;
 }
 
 CallStubGenerator::ReturnType CallStubGenerator::GetReturnType(ArgIterator *pArgIt)

--- a/src/coreclr/vm/callstubgenerator.h
+++ b/src/coreclr/vm/callstubgenerator.h
@@ -107,7 +107,7 @@ class CallStubGenerator
         None,
         GPReg,
         FPReg,
-#ifdef TARGET_ARM64        
+#ifdef TARGET_ARM64
         FPReg128,
 #endif
         Stack
@@ -148,7 +148,7 @@ class CallStubGenerator
     PCODE GetFPRegRangeRoutine(int x1, int x2);
 #ifdef TARGET_ARM64
     PCODE GetFPReg128RangeRoutine(int x1, int x2);
-#endif    
+#endif
     PCODE GetGPRegRangeRoutine(int r1, int r2);
     ReturnType GetReturnType(ArgIterator *pArgIt);
     CallStubHeader::InvokeFunctionPtr GetInvokeFunctionPtr(ReturnType returnType);

--- a/src/coreclr/vm/callstubgenerator.h
+++ b/src/coreclr/vm/callstubgenerator.h
@@ -149,12 +149,8 @@ class CallStubGenerator
     PCODE GetFPRegRangeRoutine(int x1, int x2);
 #ifdef TARGET_ARM64
     PCODE GetFPReg128RangeRoutine(int x1, int x2);
-<<<<<<< Updated upstream
-#endif
-=======
     PCODE GetFPReg32RangeRoutine(int x1, int x2);
 #endif    
->>>>>>> Stashed changes
     PCODE GetGPRegRangeRoutine(int r1, int r2);
     ReturnType GetReturnType(ArgIterator *pArgIt);
     CallStubHeader::InvokeFunctionPtr GetInvokeFunctionPtr(ReturnType returnType);

--- a/src/coreclr/vm/callstubgenerator.h
+++ b/src/coreclr/vm/callstubgenerator.h
@@ -102,8 +102,21 @@ class CallStubGenerator
 #endif // TARGET_ARM64
     };
 
+    enum class RoutineType
+    {
+        None,
+        GPReg,
+        FPReg,
+#ifdef TARGET_ARM64        
+        FPReg128,
+#endif
+        Stack
+    };
+
     // When the m_r1, m_x1 or m_s1 are set to NoRange, it means that there is no active range of registers or stack arguments.
     static const int NoRange = -1;
+
+    RoutineType m_currentRoutineType = RoutineType::None;
 
     // Current sequential range of general purpose registers used to pass arguments.
     int m_r1 = NoRange;
@@ -133,6 +146,9 @@ class CallStubGenerator
     PCODE GetStackRoutine_4B();
 #endif // TARGET_APPLE && TARGET_ARM64
     PCODE GetFPRegRangeRoutine(int x1, int x2);
+#ifdef TARGET_ARM64
+    PCODE GetFPReg128RangeRoutine(int x1, int x2);
+#endif    
     PCODE GetGPRegRangeRoutine(int r1, int r2);
     ReturnType GetReturnType(ArgIterator *pArgIt);
     CallStubHeader::InvokeFunctionPtr GetInvokeFunctionPtr(ReturnType returnType);
@@ -155,14 +171,6 @@ private:
         return sizeof(CallStubHeader) + ((numArgs + 1) * 3 + 1) * sizeof(PCODE);
     }
     void ComputeCallStub(MetaSig &sig, PCODE *pRoutines);
-
-    enum class RoutineType
-    {
-        None,
-        GPReg,
-        FPReg,
-        Stack
-    };
 
     void TerminateCurrentRoutineIfNotOfNewType(RoutineType type, PCODE *pRoutines);
 };

--- a/src/coreclr/vm/callstubgenerator.h
+++ b/src/coreclr/vm/callstubgenerator.h
@@ -108,6 +108,7 @@ class CallStubGenerator
         GPReg,
         FPReg,
 #ifdef TARGET_ARM64
+        FPReg32,
         FPReg128,
 #endif
         Stack
@@ -148,7 +149,12 @@ class CallStubGenerator
     PCODE GetFPRegRangeRoutine(int x1, int x2);
 #ifdef TARGET_ARM64
     PCODE GetFPReg128RangeRoutine(int x1, int x2);
+<<<<<<< Updated upstream
 #endif
+=======
+    PCODE GetFPReg32RangeRoutine(int x1, int x2);
+#endif    
+>>>>>>> Stashed changes
     PCODE GetGPRegRangeRoutine(int r1, int r2);
     ReturnType GetReturnType(ArgIterator *pArgIt);
     CallStubHeader::InvokeFunctionPtr GetInvokeFunctionPtr(ReturnType returnType);


### PR DESCRIPTION
The interpreter call stubs were missing support for HFA 128 bit and 32 bit args passing. That was causing a lot of failures in the HardwareIntrinsics coreclr tests on macOS arm64.

With this change, the results basically match the x64 Windows.