### PR TITLE
Extract the generic integer formatting helper APIs to live on a generic type instead

### DIFF
--- a/src/libraries/Common/src/System/Number.Formatting.Common.cs
+++ b/src/libraries/Common/src/System/Number.Formatting.Common.cs
@@ -12,7 +12,7 @@ namespace System
 {
     internal static partial class Number
     {
-        private const int CharStackBufferSize = 32;
+        internal const int CharStackBufferSize = 32;
 
         private const int DefaultPrecisionExponentialFormat = 6;
 
@@ -950,7 +950,11 @@ namespace System
             }
 
             TChar* digits = stackalloc TChar[MaxUInt32DecDigits];
+#if !SYSTEM_PRIVATE_CORELIB
             TChar* p = UInt32ToDecChars(digits + MaxUInt32DecDigits, (uint)value, minDigits);
+#else
+            TChar* p = NumberFormat<TChar>.UInt32ToDecChars(digits + MaxUInt32DecDigits, (uint)value, minDigits);
+#endif
             vlb.Append(new ReadOnlySpan<TChar>(p, (int)(digits + MaxUInt32DecDigits - p)));
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -603,6 +603,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Number.Grisu3.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Number.NumberToFloatingPointBits.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Number.Parsing.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\NumberFormat_1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Numerics\BFloat16.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Numerics\BitOperations.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Numerics\Matrix3x2.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Formatter/Utf8Formatter.Integer.cs
@@ -135,16 +135,16 @@ namespace System.Buffers.Text
         {
             if (format.IsDefault)
             {
-                return Number.TryUInt32ToDecStr(value, destination, out bytesWritten);
+                return NumberFormat<byte>.TryUInt32ToDecStr(value, destination, out bytesWritten);
             }
 
             switch (format.Symbol | 0x20)
             {
                 case 'd':
-                    return Number.TryUInt32ToDecStr(value, format.PrecisionOrZero, destination, out bytesWritten);
+                    return NumberFormat<byte>.TryUInt32ToDecStr(value, format.PrecisionOrZero, destination, out bytesWritten);
 
                 case 'x':
-                    return Number.TryInt32ToHexStr((int)value, Number.GetHexBase(format.Symbol), format.PrecisionOrZero, destination, out bytesWritten);
+                    return NumberFormat<byte>.TryInt32ToHexStr((int)value, Number.GetHexBase(format.Symbol), format.PrecisionOrZero, destination, out bytesWritten);
 
                 case 'n':
                     return FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
@@ -192,19 +192,19 @@ namespace System.Buffers.Text
             if (format.IsDefault)
             {
                 return value >= 0 ?
-                    Number.TryUInt32ToDecStr((uint)value, destination, out bytesWritten) :
-                    Number.TryNegativeInt32ToDecStr(value, format.PrecisionOrZero, "-"u8, destination, out bytesWritten);
+                    NumberFormat<byte>.TryUInt32ToDecStr((uint)value, destination, out bytesWritten) :
+                    NumberFormat<byte>.TryNegativeInt32ToDecStr(value, format.PrecisionOrZero, "-"u8, destination, out bytesWritten);
             }
 
             switch (format.Symbol | 0x20)
             {
                 case 'd':
                     return value >= 0 ?
-                        Number.TryUInt32ToDecStr((uint)value, format.PrecisionOrZero, destination, out bytesWritten) :
-                        Number.TryNegativeInt32ToDecStr(value, format.PrecisionOrZero, "-"u8, destination, out bytesWritten);
+                        NumberFormat<byte>.TryUInt32ToDecStr((uint)value, format.PrecisionOrZero, destination, out bytesWritten) :
+                        NumberFormat<byte>.TryNegativeInt32ToDecStr(value, format.PrecisionOrZero, "-"u8, destination, out bytesWritten);
 
                 case 'x':
-                    return Number.TryInt32ToHexStr(value & hexMask, Number.GetHexBase(format.Symbol), format.PrecisionOrZero, destination, out bytesWritten);
+                    return NumberFormat<byte>.TryInt32ToHexStr(value & hexMask, Number.GetHexBase(format.Symbol), format.PrecisionOrZero, destination, out bytesWritten);
 
                 case 'n':
                     return FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
@@ -249,16 +249,16 @@ namespace System.Buffers.Text
         {
             if (format.IsDefault)
             {
-                return Number.TryUInt64ToDecStr(value, destination, out bytesWritten);
+                return NumberFormat<byte>.TryUInt64ToDecStr(value, destination, out bytesWritten);
             }
 
             switch (format.Symbol | 0x20)
             {
                 case 'd':
-                    return Number.TryUInt64ToDecStr(value, format.PrecisionOrZero, destination, out bytesWritten);
+                    return NumberFormat<byte>.TryUInt64ToDecStr(value, format.PrecisionOrZero, destination, out bytesWritten);
 
                 case 'x':
-                    return Number.TryInt64ToHexStr((long)value, Number.GetHexBase(format.Symbol), format.PrecisionOrZero, destination, out bytesWritten);
+                    return NumberFormat<byte>.TryInt64ToHexStr((long)value, Number.GetHexBase(format.Symbol), format.PrecisionOrZero, destination, out bytesWritten);
 
                 case 'n':
                     return FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);
@@ -303,19 +303,19 @@ namespace System.Buffers.Text
             if (format.IsDefault)
             {
                 return value >= 0 ?
-                    Number.TryUInt64ToDecStr((ulong)value, destination, out bytesWritten) :
-                    Number.TryNegativeInt64ToDecStr(value, format.PrecisionOrZero, "-"u8, destination, out bytesWritten);
+                    NumberFormat<byte>.TryUInt64ToDecStr((ulong)value, destination, out bytesWritten) :
+                    NumberFormat<byte>.TryNegativeInt64ToDecStr(value, format.PrecisionOrZero, "-"u8, destination, out bytesWritten);
             }
 
             switch (format.Symbol | 0x20)
             {
                 case 'd':
                     return value >= 0 ?
-                        Number.TryUInt64ToDecStr((ulong)value, format.PrecisionOrZero, destination, out bytesWritten) :
-                        Number.TryNegativeInt64ToDecStr(value, format.PrecisionOrZero, "-"u8, destination, out bytesWritten);
+                        NumberFormat<byte>.TryUInt64ToDecStr((ulong)value, format.PrecisionOrZero, destination, out bytesWritten) :
+                        NumberFormat<byte>.TryNegativeInt64ToDecStr(value, format.PrecisionOrZero, "-"u8, destination, out bytesWritten);
 
                 case 'x':
-                    return Number.TryInt64ToHexStr(value, Number.GetHexBase(format.Symbol), format.PrecisionOrZero, destination, out bytesWritten);
+                    return NumberFormat<byte>.TryInt64ToHexStr(value, Number.GetHexBase(format.Symbol), format.PrecisionOrZero, destination, out bytesWritten);
 
                 case 'n':
                     return FormattingHelpers.TryFormat(value, destination, out bytesWritten, format);

--- a/src/libraries/System.Private.CoreLib/src/System/Byte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Byte.cs
@@ -161,13 +161,13 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatUInt32(m_value, format, provider, destination, out charsWritten);
+            return NumberFormat<char>.TryFormatUInt32(m_value, format, provider, destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatUInt32(m_value, format, provider, utf8Destination, out bytesWritten);
+            return NumberFormat<byte>.TryFormatUInt32(m_value, format, provider, utf8Destination, out bytesWritten);
         }
 
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.cs
@@ -501,13 +501,13 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatDecimal(this, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
+            return NumberFormat<char>.TryFormatDecimal(this, format, NumberFormatInfo.GetInstance(provider), destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatDecimal(this, format, NumberFormatInfo.GetInstance(provider), utf8Destination, out bytesWritten);
+            return NumberFormat<byte>.TryFormatDecimal(this, format, NumberFormatInfo.GetInstance(provider), utf8Destination, out bytesWritten);
         }
 
         // Converts a string to a Decimal. The string must consist of an optional

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeFormat.cs
@@ -175,20 +175,20 @@ namespace System
                 case 2 when value < 100:
                     fixed (TChar* ptr = &MemoryMarshal.GetReference(outputBuffer.AppendSpan(2)))
                     {
-                        Number.WriteTwoDigits((uint)value, ptr);
+                        NumberFormat<TChar>.WriteTwoDigits((uint)value, ptr);
                     }
                     break;
 
                 case 4 when value < 10000:
                     fixed (TChar* ptr = &MemoryMarshal.GetReference(outputBuffer.AppendSpan(4)))
                     {
-                        Number.WriteFourDigits((uint)value, ptr);
+                        NumberFormat<TChar>.WriteFourDigits((uint)value, ptr);
                     }
                     break;
 
                 default:
                     TChar* buffer = stackalloc TChar[16];
-                    TChar* p = Number.UInt32ToDecChars(buffer + 16, (uint)value, minimumLength);
+                    TChar* p = NumberFormat<TChar>.UInt32ToDecChars(buffer + 16, (uint)value, minimumLength);
                     outputBuffer.Append(new ReadOnlySpan<TChar>(p, (int)(buffer + 16 - p)));
                     break;
             }
@@ -833,7 +833,7 @@ namespace System
                 // 'zz' format e.g "-07"
                 fixed (TChar* p = &MemoryMarshal.GetReference(result.AppendSpan(2)))
                 {
-                    Number.WriteTwoDigits((uint)offset.Hours, p);
+                    NumberFormat<TChar>.WriteTwoDigits((uint)offset.Hours, p);
                 }
             }
             else
@@ -841,9 +841,9 @@ namespace System
                 Debug.Assert(tokenLen >= 3);
                 fixed (TChar* p = &MemoryMarshal.GetReference(result.AppendSpan(5)))
                 {
-                    Number.WriteTwoDigits((uint)offset.Hours, p);
+                    NumberFormat<TChar>.WriteTwoDigits((uint)offset.Hours, p);
                     p[2] = TChar.CastFrom(':');
-                    Number.WriteTwoDigits((uint)offset.Minutes, p + 3);
+                    NumberFormat<TChar>.WriteTwoDigits((uint)offset.Minutes, p + 3);
                 }
             }
         }
@@ -887,9 +887,9 @@ namespace System
 
             fixed (TChar* hoursMinutes = &MemoryMarshal.GetReference(result.AppendSpan(5)))
             {
-                Number.WriteTwoDigits((uint)offset.Hours, hoursMinutes);
+                NumberFormat<TChar>.WriteTwoDigits((uint)offset.Hours, hoursMinutes);
                 hoursMinutes[2] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)offset.Minutes, hoursMinutes + 3);
+                NumberFormat<TChar>.WriteTwoDigits((uint)offset.Minutes, hoursMinutes + 3);
             }
         }
 
@@ -1326,13 +1326,13 @@ namespace System
 
             fixed (TChar* dest = &MemoryMarshal.GetReference(destination))
             {
-                Number.WriteTwoDigits((uint)hour, dest);
+                NumberFormat<TChar>.WriteTwoDigits((uint)hour, dest);
                 dest[2] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)minute, dest + 3);
+                NumberFormat<TChar>.WriteTwoDigits((uint)minute, dest + 3);
                 dest[5] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)second, dest + 6);
+                NumberFormat<TChar>.WriteTwoDigits((uint)second, dest + 6);
                 dest[8] = TChar.CastFrom('.');
-                Number.WriteDigits((uint)fraction, dest + 9, 7);
+                NumberFormat<TChar>.WriteDigits((uint)fraction, dest + 9, 7);
             }
 
             return true;
@@ -1354,11 +1354,11 @@ namespace System
 
             fixed (TChar* dest = &MemoryMarshal.GetReference(destination))
             {
-                Number.WriteTwoDigits((uint)hour, dest);
+                NumberFormat<TChar>.WriteTwoDigits((uint)hour, dest);
                 dest[2] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)minute, dest + 3);
+                NumberFormat<TChar>.WriteTwoDigits((uint)minute, dest + 3);
                 dest[5] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)second, dest + 6);
+                NumberFormat<TChar>.WriteTwoDigits((uint)second, dest + 6);
             }
 
             return true;
@@ -1381,11 +1381,11 @@ namespace System
 
             fixed (TChar* dest = &MemoryMarshal.GetReference(destination))
             {
-                Number.WriteFourDigits((uint)year, dest);
+                NumberFormat<TChar>.WriteFourDigits((uint)year, dest);
                 dest[4] = TChar.CastFrom('-');
-                Number.WriteTwoDigits((uint)month, dest + 5);
+                NumberFormat<TChar>.WriteTwoDigits((uint)month, dest + 5);
                 dest[7] = TChar.CastFrom('-');
-                Number.WriteTwoDigits((uint)day, dest + 8);
+                NumberFormat<TChar>.WriteTwoDigits((uint)day, dest + 8);
             }
 
             return true;
@@ -1420,14 +1420,14 @@ namespace System
                 dest[2] = TChar.CastFrom(c);
                 dest[3] = TChar.CastFrom(',');
                 dest[4] = TChar.CastFrom(' ');
-                Number.WriteTwoDigits((uint)day, dest + 5);
+                NumberFormat<TChar>.WriteTwoDigits((uint)day, dest + 5);
                 dest[7] = TChar.CastFrom(' ');
                 c = monthAbbrev[2]; // remove bounds checks on remaining monthAbbrev accesses
                 dest[8] = TChar.CastFrom(monthAbbrev[0]);
                 dest[9] = TChar.CastFrom(monthAbbrev[1]);
                 dest[10] = TChar.CastFrom(c);
                 dest[11] = TChar.CastFrom(' ');
-                Number.WriteFourDigits((uint)year, dest + 12);
+                NumberFormat<TChar>.WriteFourDigits((uint)year, dest + 12);
             }
 
             return true;
@@ -1473,20 +1473,20 @@ namespace System
 
             fixed (TChar* dest = &MemoryMarshal.GetReference(destination))
             {
-                Number.WriteFourDigits((uint)year, dest);
+                NumberFormat<TChar>.WriteFourDigits((uint)year, dest);
                 dest[4] = TChar.CastFrom('-');
-                Number.WriteTwoDigits((uint)month, dest + 5);
+                NumberFormat<TChar>.WriteTwoDigits((uint)month, dest + 5);
                 dest[7] = TChar.CastFrom('-');
-                Number.WriteTwoDigits((uint)day, dest + 8);
+                NumberFormat<TChar>.WriteTwoDigits((uint)day, dest + 8);
                 dest[10] = TChar.CastFrom('T');
                 dateTime.GetTimePrecise(out int hour, out int minute, out int second, out int tick);
-                Number.WriteTwoDigits((uint)hour, dest + 11);
+                NumberFormat<TChar>.WriteTwoDigits((uint)hour, dest + 11);
                 dest[13] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)minute, dest + 14);
+                NumberFormat<TChar>.WriteTwoDigits((uint)minute, dest + 14);
                 dest[16] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)second, dest + 17);
+                NumberFormat<TChar>.WriteTwoDigits((uint)second, dest + 17);
                 dest[19] = TChar.CastFrom('.');
-                Number.WriteDigits((uint)tick, dest + 20, 7);
+                NumberFormat<TChar>.WriteDigits((uint)tick, dest + 20, 7);
 
                 if (kind == DateTimeKind.Local)
                 {
@@ -1502,9 +1502,9 @@ namespace System
                     (int offsetHours, int offsetMinutes) = Math.DivRem(offsetTotalMinutes, 60);
 
                     dest[27] = TChar.CastFrom(sign);
-                    Number.WriteTwoDigits((uint)offsetHours, dest + 28);
+                    NumberFormat<TChar>.WriteTwoDigits((uint)offsetHours, dest + 28);
                     dest[30] = TChar.CastFrom(':');
-                    Number.WriteTwoDigits((uint)offsetMinutes, dest + 31);
+                    NumberFormat<TChar>.WriteTwoDigits((uint)offsetMinutes, dest + 31);
                 }
                 else if (kind == DateTimeKind.Utc)
                 {
@@ -1533,18 +1533,18 @@ namespace System
 
             fixed (TChar* dest = &MemoryMarshal.GetReference(destination))
             {
-                Number.WriteFourDigits((uint)year, dest);
+                NumberFormat<TChar>.WriteFourDigits((uint)year, dest);
                 dest[4] = TChar.CastFrom('-');
-                Number.WriteTwoDigits((uint)month, dest + 5);
+                NumberFormat<TChar>.WriteTwoDigits((uint)month, dest + 5);
                 dest[7] = TChar.CastFrom('-');
-                Number.WriteTwoDigits((uint)day, dest + 8);
+                NumberFormat<TChar>.WriteTwoDigits((uint)day, dest + 8);
                 dest[10] = TChar.CastFrom('T');
                 dateTime.GetTime(out int hour, out int minute, out int second);
-                Number.WriteTwoDigits((uint)hour, dest + 11);
+                NumberFormat<TChar>.WriteTwoDigits((uint)hour, dest + 11);
                 dest[13] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)minute, dest + 14);
+                NumberFormat<TChar>.WriteTwoDigits((uint)minute, dest + 14);
                 dest[16] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)second, dest + 17);
+                NumberFormat<TChar>.WriteTwoDigits((uint)second, dest + 17);
             }
 
             return true;
@@ -1573,18 +1573,18 @@ namespace System
 
             fixed (TChar* dest = &MemoryMarshal.GetReference(destination))
             {
-                Number.WriteFourDigits((uint)year, dest);
+                NumberFormat<TChar>.WriteFourDigits((uint)year, dest);
                 dest[4] = TChar.CastFrom('-');
-                Number.WriteTwoDigits((uint)month, dest + 5);
+                NumberFormat<TChar>.WriteTwoDigits((uint)month, dest + 5);
                 dest[7] = TChar.CastFrom('-');
-                Number.WriteTwoDigits((uint)day, dest + 8);
+                NumberFormat<TChar>.WriteTwoDigits((uint)day, dest + 8);
                 dest[10] = TChar.CastFrom(' ');
                 dateTime.GetTime(out int hour, out int minute, out int second);
-                Number.WriteTwoDigits((uint)hour, dest + 11);
+                NumberFormat<TChar>.WriteTwoDigits((uint)hour, dest + 11);
                 dest[13] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)minute, dest + 14);
+                NumberFormat<TChar>.WriteTwoDigits((uint)minute, dest + 14);
                 dest[16] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)second, dest + 17);
+                NumberFormat<TChar>.WriteTwoDigits((uint)second, dest + 17);
                 dest[19] = TChar.CastFrom('Z');
             }
 
@@ -1627,21 +1627,21 @@ namespace System
                 dest[2] = TChar.CastFrom(c);
                 dest[3] = TChar.CastFrom(',');
                 dest[4] = TChar.CastFrom(' ');
-                Number.WriteTwoDigits((uint)day, dest + 5);
+                NumberFormat<TChar>.WriteTwoDigits((uint)day, dest + 5);
                 dest[7] = TChar.CastFrom(' ');
                 c = monthAbbrev[2]; // remove bounds checks on remaining monthAbbrev accesses
                 dest[8] = TChar.CastFrom(monthAbbrev[0]);
                 dest[9] = TChar.CastFrom(monthAbbrev[1]);
                 dest[10] = TChar.CastFrom(c);
                 dest[11] = TChar.CastFrom(' ');
-                Number.WriteFourDigits((uint)year, dest + 12);
+                NumberFormat<TChar>.WriteFourDigits((uint)year, dest + 12);
                 dest[16] = TChar.CastFrom(' ');
                 dateTime.GetTime(out int hour, out int minute, out int second);
-                Number.WriteTwoDigits((uint)hour, dest + 17);
+                NumberFormat<TChar>.WriteTwoDigits((uint)hour, dest + 17);
                 dest[19] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)minute, dest + 20);
+                NumberFormat<TChar>.WriteTwoDigits((uint)minute, dest + 20);
                 dest[22] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)second, dest + 23);
+                NumberFormat<TChar>.WriteTwoDigits((uint)second, dest + 23);
                 dest[25] = TChar.CastFrom(' ');
                 dest[26] = TChar.CastFrom('G');
                 dest[27] = TChar.CastFrom('M');
@@ -1680,19 +1680,19 @@ namespace System
 
             fixed (TChar* dest = &MemoryMarshal.GetReference(destination))
             {
-                Number.WriteTwoDigits((uint)month, dest);
+                NumberFormat<TChar>.WriteTwoDigits((uint)month, dest);
                 dest[2] = TChar.CastFrom('/');
-                Number.WriteTwoDigits((uint)day, dest + 3);
+                NumberFormat<TChar>.WriteTwoDigits((uint)day, dest + 3);
                 dest[5] = TChar.CastFrom('/');
-                Number.WriteFourDigits((uint)year, dest + 6);
+                NumberFormat<TChar>.WriteFourDigits((uint)year, dest + 6);
                 dest[10] = TChar.CastFrom(' ');
 
                 value.GetTime(out int hour, out int minute, out int second);
-                Number.WriteTwoDigits((uint)hour, dest + 11);
+                NumberFormat<TChar>.WriteTwoDigits((uint)hour, dest + 11);
                 dest[13] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)minute, dest + 14);
+                NumberFormat<TChar>.WriteTwoDigits((uint)minute, dest + 14);
                 dest[16] = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)second, dest + 17);
+                NumberFormat<TChar>.WriteTwoDigits((uint)second, dest + 17);
 
                 if (offset.Ticks != NullOffset)
                 {
@@ -1707,9 +1707,9 @@ namespace System
 
                     dest[19] = TChar.CastFrom(' ');
                     dest[20] = sign;
-                    Number.WriteTwoDigits((uint)offsetHours, dest + 21);
+                    NumberFormat<TChar>.WriteTwoDigits((uint)offsetHours, dest + 21);
                     dest[23] = TChar.CastFrom(':');
-                    Number.WriteTwoDigits((uint)offsetMinutes, dest + 24);
+                    NumberFormat<TChar>.WriteTwoDigits((uint)offsetMinutes, dest + 24);
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TimeSpanFormat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TimeSpanFormat.cs
@@ -242,7 +242,7 @@ namespace System.Globalization
                 // Write day and separator, if necessary
                 if (dayDigits != 0)
                 {
-                    Number.WriteDigits(days, p, dayDigits);
+                    NumberFormat<TChar>.WriteDigits(days, p, dayDigits);
                     p += dayDigits;
                     *p++ = TChar.CastFrom(format == StandardFormat.C ? '.' : ':');
                 }
@@ -251,7 +251,7 @@ namespace System.Globalization
                 Debug.Assert(hourDigits == 1 || hourDigits == 2);
                 if (hourDigits == 2)
                 {
-                    Number.WriteTwoDigits(hours, p);
+                    NumberFormat<TChar>.WriteTwoDigits(hours, p);
                     p += 2;
                 }
                 else
@@ -259,10 +259,10 @@ namespace System.Globalization
                     *p++ = TChar.CastFrom('0' + hours);
                 }
                 *p++ = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)minutes, p);
+                NumberFormat<TChar>.WriteTwoDigits((uint)minutes, p);
                 p += 2;
                 *p++ = TChar.CastFrom(':');
-                Number.WriteTwoDigits((uint)seconds, p);
+                NumberFormat<TChar>.WriteTwoDigits((uint)seconds, p);
                 p += 2;
 
                 // Write fraction and separator, if necessary
@@ -282,7 +282,7 @@ namespace System.Globalization
                         p += decimalSeparator.Length;
                     }
 
-                    Number.WriteDigits(fraction, p, fractionDigits);
+                    NumberFormat<TChar>.WriteDigits(fraction, p, fractionDigits);
                     p += fractionDigits;
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Int128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int128.cs
@@ -117,13 +117,13 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatInt128(this, format, provider, destination, out charsWritten);
+            return NumberFormat<char>.TryFormatInt128(this, format, provider, destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatInt128(this, format, provider, utf8Destination, out bytesWritten);
+            return NumberFormat<byte>.TryFormatInt128(this, format, provider, utf8Destination, out bytesWritten);
         }
 
         public static Int128 Parse(string s) => Parse(s, NumberStyles.Integer, provider: null);

--- a/src/libraries/System.Private.CoreLib/src/System/Int16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int16.cs
@@ -117,13 +117,13 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatInt32(m_value, 0x0000FFFF, format, provider, destination, out charsWritten);
+            return NumberFormat<char>.TryFormatInt32(m_value, 0x0000FFFF, format, provider, destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatInt32(m_value, 0x0000FFFF, format, provider, utf8Destination, out bytesWritten);
+            return NumberFormat<byte>.TryFormatInt32(m_value, 0x0000FFFF, format, provider, utf8Destination, out bytesWritten);
         }
 
         public static short Parse(string s) => Parse(s, NumberStyles.Integer, provider: null);

--- a/src/libraries/System.Private.CoreLib/src/System/Int32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int32.cs
@@ -133,13 +133,13 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatInt32(m_value, ~0, format, provider, destination, out charsWritten);
+            return NumberFormat<char>.TryFormatInt32(m_value, ~0, format, provider, destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatInt32(m_value, ~0, format, provider, utf8Destination, out bytesWritten);
+            return NumberFormat<byte>.TryFormatInt32(m_value, ~0, format, provider, utf8Destination, out bytesWritten);
         }
 
         public static int Parse(string s) => Parse(s, NumberStyles.Integer, provider: null);

--- a/src/libraries/System.Private.CoreLib/src/System/Int64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Int64.cs
@@ -130,13 +130,13 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatInt64(m_value, format, provider, destination, out charsWritten);
+            return NumberFormat<char>.TryFormatInt64(m_value, format, provider, destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatInt64(m_value, format, provider, utf8Destination, out bytesWritten);
+            return NumberFormat<byte>.TryFormatInt64(m_value, format, provider, utf8Destination, out bytesWritten);
         }
 
         public static long Parse(string s) => Parse(s, NumberStyles.Integer, provider: null);

--- a/src/libraries/System.Private.CoreLib/src/System/NumberFormat_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/NumberFormat_1.cs
@@ -1,0 +1,1082 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers.Text;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    internal static partial class NumberFormat<TChar>
+        where TChar : unmanaged, IUtfChar<TChar>
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe TChar* Int32ToHexChars(TChar* buffer, uint value, int hexBase, int digits)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            while (--digits >= 0 || value != 0)
+            {
+                byte digit = (byte)(value & 0xF);
+                *(--buffer) = TChar.CastFrom(digit + (digit < 10 ? (byte)'0' : hexBase));
+                value >>= 4;
+            }
+            return buffer;
+        }
+
+#if TARGET_64BIT
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static unsafe TChar* Int64ToHexChars(TChar* buffer, ulong value, int hexBase, int digits)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+#if TARGET_32BIT
+            uint lower = (uint)value;
+            uint upper = (uint)(value >> 32);
+
+            if (upper != 0)
+            {
+                buffer = Int32ToHexChars(buffer, lower, hexBase, 8);
+                return Int32ToHexChars(buffer, upper, hexBase, digits - 8);
+            }
+            else
+            {
+                return Int32ToHexChars(buffer, lower, hexBase, Math.Max(digits, 1));
+            }
+#else
+            while (--digits >= 0 || value != 0)
+            {
+                byte digit = (byte)(value & 0xF);
+                *(--buffer) = TChar.CastFrom(digit + (digit < 10 ? (byte)'0' : hexBase));
+                value >>= 4;
+            }
+            return buffer;
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe TChar* Int128ToHexChars(TChar* buffer, UInt128 value, int hexBase, int digits)
+        {
+            ulong lower = value.Lower;
+            ulong upper = value.Upper;
+
+            if (upper != 0)
+            {
+                buffer = Int64ToHexChars(buffer, lower, hexBase, 16);
+                return Int64ToHexChars(buffer, upper, hexBase, digits - 16);
+            }
+            else
+            {
+                return Int64ToHexChars(buffer, lower, hexBase, Math.Max(digits, 1));
+            }
+        }
+
+        public static unsafe bool TryFormatDecimal(decimal value, ReadOnlySpan<char> format, NumberFormatInfo info, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            char fmt = Number.ParseFormatSpecifier(format, out int digits);
+
+            byte* pDigits = stackalloc byte[Number.DecimalNumberBufferLength];
+            Number.NumberBuffer number = new Number.NumberBuffer(Number.NumberBufferKind.Decimal, pDigits, Number.DecimalNumberBufferLength);
+
+            Number.DecimalToNumber(ref value, ref number);
+
+            TChar* stackPtr = stackalloc TChar[Number.CharStackBufferSize];
+            var vlb = new ValueListBuilder<TChar>(new Span<TChar>(stackPtr, Number.CharStackBufferSize));
+
+            if (fmt != 0)
+            {
+                Number.NumberToString(ref vlb, ref number, fmt, digits, info);
+            }
+            else
+            {
+                Number.NumberToStringFormat(ref vlb, ref number, format, info);
+            }
+
+            bool success = vlb.TryCopyTo(destination, out charsWritten);
+            vlb.Dispose();
+            return success;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // expose to caller's likely-const format to trim away slow path
+        public static bool TryFormatInt32(int value, int hexMask, ReadOnlySpan<char> format, IFormatProvider? provider, Span<TChar> destination, out int charsWritten)
+        {
+            // Fast path for default format
+            if (format.Length == 0)
+            {
+                return value >= 0 ?
+                    TryUInt32ToDecStr((uint)value, destination, out charsWritten) :
+                    TryNegativeInt32ToDecStr(value, digits: -1, NumberFormatInfo.GetInstance(provider).NegativeSignTChar<TChar>(), destination, out charsWritten);
+            }
+
+            return TryFormatInt32Slow(value, hexMask, format, provider, destination, out charsWritten);
+
+            static unsafe bool TryFormatInt32Slow(int value, int hexMask, ReadOnlySpan<char> format, IFormatProvider? provider, Span<TChar> destination, out int charsWritten)
+            {
+                char fmt = Number.ParseFormatSpecifier(format, out int digits);
+                char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
+                if (fmtUpper == 'G' ? digits < 1 : fmtUpper == 'D')
+                {
+                    return value >= 0 ?
+                        TryUInt32ToDecStr((uint)value, digits, destination, out charsWritten) :
+                        TryNegativeInt32ToDecStr(value, digits, NumberFormatInfo.GetInstance(provider).NegativeSignTChar<TChar>(), destination, out charsWritten);
+                }
+                else if (fmtUpper == 'X')
+                {
+                    return TryInt32ToHexStr(value & hexMask, Number.GetHexBase(fmt), digits, destination, out charsWritten);
+                }
+                else if (fmtUpper == 'B')
+                {
+                    return TryUInt32ToBinaryStr((uint)(value & hexMask), digits, destination, out charsWritten);
+                }
+                else
+                {
+                    NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
+
+                    byte* pDigits = stackalloc byte[Number.Int32NumberBufferLength];
+                    Number.NumberBuffer number = new Number.NumberBuffer(Number.NumberBufferKind.Integer, pDigits, Number.Int32NumberBufferLength);
+
+                    Number.Int32ToNumber(value, ref number);
+
+                    TChar* stackPtr = stackalloc TChar[Number.CharStackBufferSize];
+                    var vlb = new ValueListBuilder<TChar>(new Span<TChar>(stackPtr, Number.CharStackBufferSize));
+
+                    if (fmt != 0)
+                    {
+                        Number.NumberToString(ref vlb, ref number, fmt, digits, info);
+                    }
+                    else
+                    {
+                        Number.NumberToStringFormat(ref vlb, ref number, format, info);
+                    }
+
+                    bool success = vlb.TryCopyTo(destination, out charsWritten);
+                    vlb.Dispose();
+                    return success;
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // expose to caller's likely-const format to trim away slow path
+        public static bool TryFormatInt64(long value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            // Fast path for default format
+            if (format.Length == 0)
+            {
+                return value >= 0 ?
+                    TryUInt64ToDecStr((ulong)value, destination, out charsWritten) :
+                    TryNegativeInt64ToDecStr(value, digits: -1, NumberFormatInfo.GetInstance(provider).NegativeSignTChar<TChar>(), destination, out charsWritten);
+            }
+
+            return TryFormatInt64Slow(value, format, provider, destination, out charsWritten);
+
+            static unsafe bool TryFormatInt64Slow(long value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<TChar> destination, out int charsWritten)
+            {
+                char fmt = Number.ParseFormatSpecifier(format, out int digits);
+                char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
+                if (fmtUpper == 'G' ? digits < 1 : fmtUpper == 'D')
+                {
+                    return value >= 0 ?
+                        TryUInt64ToDecStr((ulong)value, digits, destination, out charsWritten) :
+                        TryNegativeInt64ToDecStr(value, digits, NumberFormatInfo.GetInstance(provider).NegativeSignTChar<TChar>(), destination, out charsWritten);
+                }
+                else if (fmtUpper == 'X')
+                {
+                    return TryInt64ToHexStr(value, Number.GetHexBase(fmt), digits, destination, out charsWritten);
+                }
+                else if (fmtUpper == 'B')
+                {
+                    return TryUInt64ToBinaryStr((ulong)value, digits, destination, out charsWritten);
+                }
+                else
+                {
+                    NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
+
+                    byte* pDigits = stackalloc byte[Number.Int64NumberBufferLength];
+                    Number.NumberBuffer number = new Number.NumberBuffer(Number.NumberBufferKind.Integer, pDigits, Number.Int64NumberBufferLength);
+
+                    Number.Int64ToNumber(value, ref number);
+
+                    char* stackPtr = stackalloc char[Number.CharStackBufferSize];
+                    var vlb = new ValueListBuilder<TChar>(new Span<TChar>(stackPtr, Number.CharStackBufferSize));
+
+                    if (fmt != 0)
+                    {
+                        Number.NumberToString(ref vlb, ref number, fmt, digits, info);
+                    }
+                    else
+                    {
+                        Number.NumberToStringFormat(ref vlb, ref number, format, info);
+                    }
+
+                    bool success = vlb.TryCopyTo(destination, out charsWritten);
+                    vlb.Dispose();
+                    return success;
+                }
+            }
+        }
+
+        public static bool TryFormatInt128(Int128 value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            // Fast path for default format
+            if (format.Length == 0)
+            {
+                return Int128.IsPositive(value)
+                     ? TryUInt128ToDecStr((UInt128)value, digits: -1, destination, out charsWritten)
+                     : TryNegativeInt128ToDecStr(value, digits: -1, NumberFormatInfo.GetInstance(provider).NegativeSignTChar<TChar>(), destination, out charsWritten);
+            }
+
+            return TryFormatInt128Slow(value, format, provider, destination, out charsWritten);
+
+            static unsafe bool TryFormatInt128Slow(Int128 value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<TChar> destination, out int charsWritten)
+            {
+                char fmt = Number.ParseFormatSpecifier(format, out int digits);
+                char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
+
+                if (fmtUpper == 'G' ? digits < 1 : fmtUpper == 'D')
+                {
+                    return Int128.IsPositive(value)
+                        ? TryUInt128ToDecStr((UInt128)value, digits, destination, out charsWritten)
+                        : TryNegativeInt128ToDecStr(value, digits, NumberFormatInfo.GetInstance(provider).NegativeSignTChar<TChar>(), destination, out charsWritten);
+                }
+                else if (fmtUpper == 'X')
+                {
+                    return TryInt128ToHexStr(value, Number.GetHexBase(fmt), digits, destination, out charsWritten);
+                }
+                else if (fmtUpper == 'B')
+                {
+                    return TryUInt128ToBinaryStr(value, digits, destination, out charsWritten);
+                }
+                else
+                {
+                    NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
+
+                    byte* pDigits = stackalloc byte[Number.Int128NumberBufferLength];
+                    Number.NumberBuffer number = new Number.NumberBuffer(Number.NumberBufferKind.Integer, pDigits, Number.Int128NumberBufferLength);
+
+                    Number.Int128ToNumber(value, ref number);
+
+                    TChar* stackPtr = stackalloc TChar[Number.CharStackBufferSize];
+                    var vlb = new ValueListBuilder<TChar>(new Span<TChar>(stackPtr, Number.CharStackBufferSize));
+
+                    if (fmt != 0)
+                    {
+                        Number.NumberToString(ref vlb, ref number, fmt, digits, info);
+                    }
+                    else
+                    {
+                        Number.NumberToStringFormat(ref vlb, ref number, format, info);
+                    }
+
+                    bool success = vlb.TryCopyTo(destination, out charsWritten);
+                    vlb.Dispose();
+                    return success;
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // expose to caller's likely-const format to trim away slow path
+        public static bool TryFormatUInt32(uint value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            // Fast path for default format
+            if (format.Length == 0)
+            {
+                return TryUInt32ToDecStr(value, destination, out charsWritten);
+            }
+
+            return TryFormatUInt32Slow(value, format, provider, destination, out charsWritten);
+
+            static unsafe bool TryFormatUInt32Slow(uint value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<TChar> destination, out int charsWritten)
+            {
+                char fmt = Number.ParseFormatSpecifier(format, out int digits);
+                char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
+                if (fmtUpper == 'G' ? digits < 1 : fmtUpper == 'D')
+                {
+                    return TryUInt32ToDecStr(value, digits, destination, out charsWritten);
+                }
+                else if (fmtUpper == 'X')
+                {
+                    return TryInt32ToHexStr((int)value, Number.GetHexBase(fmt), digits, destination, out charsWritten);
+                }
+                else if (fmtUpper == 'B')
+                {
+                    return TryUInt32ToBinaryStr(value, digits, destination, out charsWritten);
+                }
+                else
+                {
+                    NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
+
+                    byte* pDigits = stackalloc byte[Number.UInt32NumberBufferLength];
+                    Number.NumberBuffer number = new Number.NumberBuffer(Number.NumberBufferKind.Integer, pDigits, Number.UInt32NumberBufferLength);
+
+                    Number.UInt32ToNumber(value, ref number);
+
+                    TChar* stackPtr = stackalloc TChar[Number.CharStackBufferSize];
+                    var vlb = new ValueListBuilder<TChar>(new Span<TChar>(stackPtr, Number.CharStackBufferSize));
+
+                    if (fmt != 0)
+                    {
+                        Number.NumberToString(ref vlb, ref number, fmt, digits, info);
+                    }
+                    else
+                    {
+                        Number.NumberToStringFormat(ref vlb, ref number, format, info);
+                    }
+
+                    bool success = vlb.TryCopyTo(destination, out charsWritten);
+                    vlb.Dispose();
+                    return success;
+                }
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)] // expose to caller's likely-const format to trim away slow path
+        public static bool TryFormatUInt64(ulong value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            // Fast path for default format
+            if (format.Length == 0)
+            {
+                return TryUInt64ToDecStr(value, destination, out charsWritten);
+            }
+
+            return TryFormatUInt64Slow(value, format, provider, destination, out charsWritten);
+
+            static unsafe bool TryFormatUInt64Slow(ulong value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<TChar> destination, out int charsWritten)
+            {
+                char fmt = Number.ParseFormatSpecifier(format, out int digits);
+                char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
+                if (fmtUpper == 'G' ? digits < 1 : fmtUpper == 'D')
+                {
+                    return TryUInt64ToDecStr(value, digits, destination, out charsWritten);
+                }
+                else if (fmtUpper == 'X')
+                {
+                    return TryInt64ToHexStr((long)value, Number.GetHexBase(fmt), digits, destination, out charsWritten);
+                }
+                else if (fmtUpper == 'B')
+                {
+                    return TryUInt64ToBinaryStr(value, digits, destination, out charsWritten);
+                }
+                else
+                {
+                    NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
+
+                    byte* pDigits = stackalloc byte[Number.UInt64NumberBufferLength];
+                    Number.NumberBuffer number = new Number.NumberBuffer(Number.NumberBufferKind.Integer, pDigits, Number.UInt64NumberBufferLength);
+
+                    Number.UInt64ToNumber(value, ref number);
+
+                    TChar* stackPtr = stackalloc TChar[Number.CharStackBufferSize];
+                    var vlb = new ValueListBuilder<TChar>(new Span<TChar>(stackPtr, Number.CharStackBufferSize));
+
+                    if (fmt != 0)
+                    {
+                        Number.NumberToString(ref vlb, ref number, fmt, digits, info);
+                    }
+                    else
+                    {
+                        Number.NumberToStringFormat(ref vlb, ref number, format, info);
+                    }
+
+                    bool success = vlb.TryCopyTo(destination, out charsWritten);
+                    vlb.Dispose();
+                    return success;
+                }
+            }
+        }
+
+        public static bool TryFormatUInt128(UInt128 value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            // Fast path for default format
+            if (format.Length == 0)
+            {
+                return TryUInt128ToDecStr(value, digits: -1, destination, out charsWritten);
+            }
+
+            return TryFormatUInt128Slow(value, format, provider, destination, out charsWritten);
+
+            static unsafe bool TryFormatUInt128Slow(UInt128 value, ReadOnlySpan<char> format, IFormatProvider? provider, Span<TChar> destination, out int charsWritten)
+            {
+                char fmt = Number.ParseFormatSpecifier(format, out int digits);
+                char fmtUpper = (char)(fmt & 0xFFDF); // ensure fmt is upper-cased for purposes of comparison
+
+                if (fmtUpper == 'G' ? digits < 1 : fmtUpper == 'D')
+                {
+                    return TryUInt128ToDecStr(value, digits, destination, out charsWritten);
+                }
+                else if (fmtUpper == 'X')
+                {
+                    return TryInt128ToHexStr((Int128)value, Number.GetHexBase(fmt), digits, destination, out charsWritten);
+                }
+                else if (fmtUpper == 'B')
+                {
+                    return TryUInt128ToBinaryStr((Int128)value, digits, destination, out charsWritten);
+                }
+                else
+                {
+                    NumberFormatInfo info = NumberFormatInfo.GetInstance(provider);
+
+                    byte* pDigits = stackalloc byte[Number.UInt128NumberBufferLength];
+                    Number.NumberBuffer number = new Number.NumberBuffer(Number.NumberBufferKind.Integer, pDigits, Number.UInt128NumberBufferLength);
+
+                    Number.UInt128ToNumber(value, ref number);
+
+                    TChar* stackPtr = stackalloc TChar[Number.CharStackBufferSize];
+                    var vlb = new ValueListBuilder<TChar>(new Span<TChar>(stackPtr, Number.CharStackBufferSize));
+
+                    if (fmt != 0)
+                    {
+                        Number.NumberToString(ref vlb, ref number, fmt, digits, info);
+                    }
+                    else
+                    {
+                        Number.NumberToStringFormat(ref vlb, ref number, format, info);
+                    }
+
+                    bool success = vlb.TryCopyTo(destination, out charsWritten);
+                    vlb.Dispose();
+                    return success;
+                }
+            }
+        }
+
+        public static unsafe bool TryInt32ToHexStr(int value, char hexBase, int digits, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            if (digits < 1)
+            {
+                digits = 1;
+            }
+
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountHexDigits((uint)value));
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            charsWritten = bufferLength;
+            fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                TChar* p = Int32ToHexChars(buffer + bufferLength, (uint)value, hexBase, digits);
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
+
+        public static unsafe bool TryInt64ToHexStr(long value, char hexBase, int digits, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            if (digits < 1)
+            {
+                digits = 1;
+            }
+
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountHexDigits((ulong)value));
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            charsWritten = bufferLength;
+            fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                TChar* p = Int64ToHexChars(buffer + bufferLength, (ulong)value, hexBase, digits);
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
+
+        public static unsafe bool TryInt128ToHexStr(Int128 value, char hexBase, int digits, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            if (digits < 1)
+            {
+                digits = 1;
+            }
+
+            UInt128 uValue = (UInt128)value;
+
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountHexDigits(uValue));
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            charsWritten = bufferLength;
+            fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                TChar* p = Int128ToHexChars(buffer + bufferLength, uValue, hexBase, digits);
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
+
+        public static unsafe bool TryNegativeInt32ToDecStr(int value, int digits, ReadOnlySpan<TChar> sNegative, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+            Debug.Assert(value < 0);
+
+            if (digits < 1)
+            {
+                digits = 1;
+            }
+
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits((uint)(-value))) + sNegative.Length;
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            charsWritten = bufferLength;
+            fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                TChar* p = UInt32ToDecChars(buffer + bufferLength, (uint)(-value), digits);
+                Debug.Assert(p == buffer + sNegative.Length);
+
+                for (int i = sNegative.Length - 1; i >= 0; i--)
+                {
+                    *(--p) = sNegative[i];
+                }
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
+
+        public static unsafe bool TryNegativeInt64ToDecStr(long value, int digits, ReadOnlySpan<TChar> sNegative, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+            Debug.Assert(value < 0);
+
+            if (digits < 1)
+            {
+                digits = 1;
+            }
+
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits((ulong)(-value))) + sNegative.Length;
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            charsWritten = bufferLength;
+            fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                TChar* p = UInt64ToDecChars(buffer + bufferLength, (ulong)(-value), digits);
+                Debug.Assert(p == buffer + sNegative.Length);
+
+                for (int i = sNegative.Length - 1; i >= 0; i--)
+                {
+                    *(--p) = sNegative[i];
+                }
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
+
+        public static unsafe bool TryNegativeInt128ToDecStr(Int128 value, int digits, ReadOnlySpan<TChar> sNegative, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+            Debug.Assert(Int128.IsNegative(value));
+
+            if (digits < 1)
+            {
+                digits = 1;
+            }
+
+            UInt128 absValue = (UInt128)(-value);
+
+            int bufferLength = Math.Max(digits, FormattingHelpers.CountDigits(absValue)) + sNegative.Length;
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            charsWritten = bufferLength;
+            fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                TChar* p = UInt128ToDecChars(buffer + bufferLength, absValue, digits);
+                Debug.Assert(p == buffer + sNegative.Length);
+
+                for (int i = sNegative.Length - 1; i >= 0; i--)
+                {
+                    *(--p) = sNegative[i];
+                }
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
+
+        public static unsafe bool TryUInt32ToBinaryStr(uint value, int digits, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            if (digits < 1)
+            {
+                digits = 1;
+            }
+
+            int bufferLength = Math.Max(digits, 32 - (int)uint.LeadingZeroCount(value));
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            charsWritten = bufferLength;
+            fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                TChar* p = UInt32ToBinaryChars(buffer + bufferLength, value, digits);
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
+
+        public static unsafe bool TryUInt32ToDecStr(uint value, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            int bufferLength = FormattingHelpers.CountDigits(value);
+            if (bufferLength <= destination.Length)
+            {
+                charsWritten = bufferLength;
+                fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+                {
+                    TChar* p = UInt32ToDecChars(buffer + bufferLength, value);
+                    Debug.Assert(p == buffer);
+                }
+                return true;
+            }
+
+            charsWritten = 0;
+            return false;
+        }
+
+        public static unsafe bool TryUInt32ToDecStr(uint value, int digits, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            int countedDigits = FormattingHelpers.CountDigits(value);
+            int bufferLength = Math.Max(digits, countedDigits);
+            if (bufferLength <= destination.Length)
+            {
+                charsWritten = bufferLength;
+                fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+                {
+                    TChar* p = buffer + bufferLength;
+                    p = digits > countedDigits ?
+                        UInt32ToDecChars(p, value, digits) :
+                        UInt32ToDecChars(p, value);
+                    Debug.Assert(p == buffer);
+                }
+                return true;
+            }
+
+            charsWritten = 0;
+            return false;
+        }
+
+        public static unsafe bool TryUInt64ToBinaryStr(ulong value, int digits, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            if (digits < 1)
+            {
+                digits = 1;
+            }
+
+            int bufferLength = Math.Max(digits, 64 - (int)ulong.LeadingZeroCount(value));
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            charsWritten = bufferLength;
+            fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                TChar* p = UInt64ToBinaryChars(buffer + bufferLength, value, digits);
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
+
+        public static unsafe bool TryUInt64ToDecStr(ulong value, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            int bufferLength = FormattingHelpers.CountDigits(value);
+            if (bufferLength <= destination.Length)
+            {
+                charsWritten = bufferLength;
+                fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+                {
+                    TChar* p = buffer + bufferLength;
+                    p = UInt64ToDecChars(p, value);
+                    Debug.Assert(p == buffer);
+                }
+                return true;
+            }
+
+            charsWritten = 0;
+            return false;
+        }
+
+        public static unsafe bool TryUInt64ToDecStr(ulong value, int digits, Span<TChar> destination, out int charsWritten)
+        {
+            int countedDigits = FormattingHelpers.CountDigits(value);
+            int bufferLength = Math.Max(digits, countedDigits);
+            if (bufferLength <= destination.Length)
+            {
+                charsWritten = bufferLength;
+                fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+                {
+                    TChar* p = buffer + bufferLength;
+                    p = digits > countedDigits ?
+                        UInt64ToDecChars(p, value, digits) :
+                        UInt64ToDecChars(p, value);
+                    Debug.Assert(p == buffer);
+                }
+                return true;
+            }
+
+            charsWritten = 0;
+            return false;
+        }
+
+        public static unsafe bool TryUInt128ToBinaryStr(Int128 value, int digits, Span<TChar> destination, out int charsWritten)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            if (digits < 1)
+            {
+                digits = 1;
+            }
+
+            UInt128 uValue = (UInt128)value;
+
+            int bufferLength = Math.Max(digits, 128 - (int)UInt128.LeadingZeroCount((UInt128)value));
+            if (bufferLength > destination.Length)
+            {
+                charsWritten = 0;
+                return false;
+            }
+
+            charsWritten = bufferLength;
+            fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+            {
+                TChar* p = UInt128ToBinaryChars(buffer + bufferLength, uValue, digits);
+                Debug.Assert(p == buffer);
+            }
+            return true;
+        }
+
+        public static unsafe bool TryUInt128ToDecStr(UInt128 value, int digits, Span<TChar> destination, out int charsWritten)
+        {
+            int countedDigits = FormattingHelpers.CountDigits(value);
+            int bufferLength = Math.Max(digits, countedDigits);
+            if (bufferLength <= destination.Length)
+            {
+                charsWritten = bufferLength;
+                fixed (TChar* buffer = &MemoryMarshal.GetReference(destination))
+                {
+                    TChar* p = buffer + bufferLength;
+                    p = digits > countedDigits ?
+                        UInt128ToDecChars(p, value, digits) :
+                        UInt128ToDecChars(p, value);
+                    Debug.Assert(p == buffer);
+                }
+                return true;
+            }
+
+            charsWritten = 0;
+            return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe TChar* UInt32ToBinaryChars(TChar* buffer, uint value, int digits)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            while (--digits >= 0 || value != 0)
+            {
+                *(--buffer) = TChar.CastFrom('0' + (byte)(value & 0x1));
+                value >>= 1;
+            }
+            return buffer;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe TChar* UInt32ToDecChars(TChar* bufferEnd, uint value)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            if (value >= 10)
+            {
+                // Handle all values >= 100 two-digits at a time so as to avoid expensive integer division operations.
+                while (value >= 100)
+                {
+                    bufferEnd -= 2;
+                    (value, uint remainder) = Math.DivRem(value, 100);
+                    WriteTwoDigits(remainder, bufferEnd);
+                }
+
+                // If there are two digits remaining, store them.
+                if (value >= 10)
+                {
+                    bufferEnd -= 2;
+                    WriteTwoDigits(value, bufferEnd);
+                    return bufferEnd;
+                }
+            }
+
+            // Otherwise, store the single digit remaining.
+            *(--bufferEnd) = TChar.CastFrom(value + '0');
+            return bufferEnd;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe TChar* UInt32ToDecChars(TChar* bufferEnd, uint value, int digits)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            uint remainder;
+            while (value >= 100)
+            {
+                bufferEnd -= 2;
+                digits -= 2;
+                (value, remainder) = Math.DivRem(value, 100);
+                WriteTwoDigits(remainder, bufferEnd);
+            }
+
+            while (value != 0 || digits > 0)
+            {
+                digits--;
+                (value, remainder) = Math.DivRem(value, 10);
+                *(--bufferEnd) = TChar.CastFrom(remainder + '0');
+            }
+
+            return bufferEnd;
+        }
+
+#if TARGET_64BIT
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static unsafe TChar* UInt64ToBinaryChars(TChar* buffer, ulong value, int digits)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+#if TARGET_32BIT
+            uint lower = (uint)value;
+            uint upper = (uint)(value >> 32);
+
+            if (upper != 0)
+            {
+                buffer = UInt32ToBinaryChars(buffer, lower, 32);
+                return UInt32ToBinaryChars(buffer, upper, digits - 32);
+            }
+            else
+            {
+                return UInt32ToBinaryChars(buffer, lower, Math.Max(digits, 1));
+            }
+#else
+            while (--digits >= 0 || value != 0)
+            {
+                *(--buffer) = TChar.CastFrom('0' + (byte)(value & 0x1));
+                value >>= 1;
+            }
+            return buffer;
+#endif
+        }
+
+#if TARGET_64BIT
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static unsafe TChar* UInt64ToDecChars(TChar* bufferEnd, ulong value)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+#if TARGET_32BIT
+            while ((uint)(value >> 32) != 0)
+            {
+                bufferEnd = UInt32ToDecChars(bufferEnd, Number.Int64DivMod1E9(ref value), 9);
+            }
+            return UInt32ToDecChars(bufferEnd, (uint)value);
+#else
+            if (value >= 10)
+            {
+                // Handle all values >= 100 two-digits at a time so as to avoid expensive integer division operations.
+                while (value >= 100)
+                {
+                    bufferEnd -= 2;
+                    (value, ulong remainder) = Math.DivRem(value, 100);
+                    WriteTwoDigits((uint)remainder, bufferEnd);
+                }
+
+                // If there are two digits remaining, store them.
+                if (value >= 10)
+                {
+                    bufferEnd -= 2;
+                    WriteTwoDigits((uint)value, bufferEnd);
+                    return bufferEnd;
+                }
+            }
+
+            // Otherwise, store the single digit remaining.
+            *(--bufferEnd) = TChar.CastFrom(value + '0');
+            return bufferEnd;
+#endif
+        }
+
+#if TARGET_64BIT
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static unsafe TChar* UInt64ToDecChars(TChar* bufferEnd, ulong value, int digits)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+#if TARGET_32BIT
+            while ((uint)(value >> 32) != 0)
+            {
+                bufferEnd = UInt32ToDecChars(bufferEnd, Number.Int64DivMod1E9(ref value), 9);
+                digits -= 9;
+            }
+            return UInt32ToDecChars(bufferEnd, (uint)value, digits);
+#else
+            ulong remainder;
+            while (value >= 100)
+            {
+                bufferEnd -= 2;
+                digits -= 2;
+                (value, remainder) = Math.DivRem(value, 100);
+                WriteTwoDigits((uint)remainder, bufferEnd);
+            }
+
+            while (value != 0 || digits > 0)
+            {
+                digits--;
+                (value, remainder) = Math.DivRem(value, 10);
+                *(--bufferEnd) = TChar.CastFrom(remainder + '0');
+            }
+
+            return bufferEnd;
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe TChar* UInt128ToBinaryChars(TChar* buffer, UInt128 value, int digits)
+        {
+            ulong lower = value.Lower;
+            ulong upper = value.Upper;
+
+            if (upper != 0)
+            {
+                buffer = UInt64ToBinaryChars(buffer, lower, 64);
+                return UInt64ToBinaryChars(buffer, upper, digits - 64);
+            }
+            else
+            {
+                return UInt64ToBinaryChars(buffer, lower, Math.Max(digits, 1));
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe TChar* UInt128ToDecChars(TChar* bufferEnd, UInt128 value)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            while (value.Upper != 0)
+            {
+                bufferEnd = UInt64ToDecChars(bufferEnd, Number.Int128DivMod1E19(ref value), 19);
+            }
+            return UInt64ToDecChars(bufferEnd, value.Lower);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe TChar* UInt128ToDecChars(TChar* bufferEnd, UInt128 value, int digits)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+
+            while (value.Upper != 0)
+            {
+                bufferEnd = UInt64ToDecChars(bufferEnd, Number.Int128DivMod1E19(ref value), 19);
+                digits -= 19;
+            }
+            return UInt64ToDecChars(bufferEnd, value.Lower, digits);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void WriteDigits(uint value, TChar* ptr, int count)
+        {
+            TChar* cur;
+            for (cur = ptr + count - 1; cur > ptr; cur--)
+            {
+                uint temp = '0' + value;
+                value /= 10;
+                *cur = TChar.CastFrom(temp - (value * 10));
+            }
+
+            Debug.Assert(value < 10);
+            Debug.Assert(cur == ptr);
+            *cur = TChar.CastFrom('0' + value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void WriteTwoDigits(uint value, TChar* ptr)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+            Debug.Assert(value <= 99);
+
+            Unsafe.CopyBlockUnaligned(
+                ref *(byte*)ptr,
+                ref Unsafe.Add(ref Number.GetTwoDigitsBytesRef(typeof(TChar) == typeof(char)), (uint)sizeof(TChar) * 2 * value),
+                (uint)sizeof(TChar) * 2);
+        }
+
+        /// <summary>
+        /// Writes a value [ 0000 .. 9999 ] to the buffer starting at the specified offset.
+        /// This method performs best when the starting index is a constant literal.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe void WriteFourDigits(uint value, TChar* ptr)
+        {
+            Debug.Assert(typeof(TChar) == typeof(char) || typeof(TChar) == typeof(byte));
+            Debug.Assert(value <= 9999);
+
+            (value, uint remainder) = Math.DivRem(value, 100);
+
+            ref byte charsArray = ref Number.GetTwoDigitsBytesRef(typeof(TChar) == typeof(char));
+
+            Unsafe.CopyBlockUnaligned(
+                ref *(byte*)ptr,
+                ref Unsafe.Add(ref charsArray, (uint)sizeof(TChar) * 2 * value),
+                (uint)sizeof(TChar) * 2);
+
+            Unsafe.CopyBlockUnaligned(
+                ref *(byte*)(ptr + 2),
+                ref Unsafe.Add(ref charsArray, (uint)sizeof(TChar) * 2 * remainder),
+                (uint)sizeof(TChar) * 2);
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/SByte.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SByte.cs
@@ -120,13 +120,13 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatInt32(m_value, 0x000000FF, format, provider, destination, out charsWritten);
+            return NumberFormat<char>.TryFormatInt32(m_value, 0x000000FF, format, provider, destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatInt32(m_value, 0x000000FF, format, provider, utf8Destination, out bytesWritten);
+            return NumberFormat<byte>.TryFormatInt32(m_value, 0x000000FF, format, provider, utf8Destination, out bytesWritten);
         }
 
         public static sbyte Parse(string s) => Parse(s, NumberStyles.Integer, provider: null);

--- a/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt128.cs
@@ -119,13 +119,13 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatUInt128(this, format, provider, destination, out charsWritten);
+            return NumberFormat<char>.TryFormatUInt128(this, format, provider, destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatUInt128(this, format, provider, utf8Destination, out bytesWritten);
+            return NumberFormat<byte>.TryFormatUInt128(this, format, provider, utf8Destination, out bytesWritten);
         }
 
         public static UInt128 Parse(string s) => Parse(s, NumberStyles.Integer, provider: null);

--- a/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt16.cs
@@ -112,13 +112,13 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatUInt32(m_value, format, provider, destination, out charsWritten);
+            return NumberFormat<char>.TryFormatUInt32(m_value, format, provider, destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatUInt32(m_value, format, provider, utf8Destination, out bytesWritten);
+            return NumberFormat<byte>.TryFormatUInt32(m_value, format, provider, utf8Destination, out bytesWritten);
         }
 
         public static ushort Parse(string s) => Parse(s, NumberStyles.Integer, provider: null);

--- a/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt32.cs
@@ -128,13 +128,13 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatUInt32(m_value, format, provider, destination, out charsWritten);
+            return NumberFormat<char>.TryFormatUInt32(m_value, format, provider, destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatUInt32(m_value, format, provider, utf8Destination, out bytesWritten);
+            return NumberFormat<byte>.TryFormatUInt32(m_value, format, provider, utf8Destination, out bytesWritten);
         }
 
         public static uint Parse(string s) => Parse(s, NumberStyles.Integer, provider: null);

--- a/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UInt64.cs
@@ -127,13 +127,13 @@ namespace System
 
         public bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatUInt64(m_value, format, provider, destination, out charsWritten);
+            return NumberFormat<char>.TryFormatUInt64(m_value, format, provider, destination, out charsWritten);
         }
 
         /// <inheritdoc cref="IUtf8SpanFormattable.TryFormat" />
         public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default, IFormatProvider? provider = null)
         {
-            return Number.TryFormatUInt64(m_value, format, provider, utf8Destination, out bytesWritten);
+            return NumberFormat<byte>.TryFormatUInt64(m_value, format, provider, utf8Destination, out bytesWritten);
         }
 
         public static ulong Parse(string s) => Parse(s, NumberStyles.Integer, provider: null);


### PR DESCRIPTION
This was raised by @davidwrighton as something that might help with the number of types being loaded (https://github.com/dotnet/runtime/issues/120407) on startup paths due to requiring less resolutions (at the tradeoff of slightly more instantiation overhead for unused methods)

This is just a simple first pass to see if it does benefit. More cleanup can be done if the approach shows to be effective and we desire more consolidation. This namely targets the integer APIs. We could isolate it specifically to groups that call eachother (i.e. break apart Int32/Int64/Int128 into their own classes), but in many cases the larger sizes invoke the smaller sizes for some work, so it's probably not that meaningful.

CC. @jkotas, @EgorBo 