### PR TITLE
Don't add the filled in template file to FileWries

### DIFF
--- a/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/Microsoft.NET.Sdk.IL.proj
+++ b/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/Microsoft.NET.Sdk.IL.proj
@@ -27,9 +27,7 @@
 
     <GenerateFileFromTemplate TemplateFile="$(ILTargetsTemplateFile)"
                               OutputPath="$(ILTargetsOutputFile)"
-                              Properties="IlAsmVersion=$(Version)">
-      <Output TaskParameter="ResolvedOutputPath" ItemName="FileWrites" />
-    </GenerateFileFromTemplate>
+                              Properties="IlAsmVersion=$(Version)" />
 
     <ItemGroup>
       <None Include="$(ILTargetsOutputFile)" Pack="true" PackagePath="targets/" />


### PR DESCRIPTION
MSBuild cleans up intermediate file writes from previous builds that weren't also written in the current build after the build but before running the Pack task. This breaks every-other build (as we were actively using the cached copy here if it didn't change).

Fixes #121068