### PR TITLE
Add MethodDesc comments

### DIFF
--- a/src/coreclr/vm/method.inl
+++ b/src/coreclr/vm/method.inl
@@ -137,7 +137,7 @@ inline bool MethodDesc::IsILStub()
 // code viewing, stepping, etc). Partly this is a user experience consideration to preserve the
 // abstraction users would expect based on source code and assembly contents. Partly it is also a technical
 // limitation that many parts of diagnostics don't know how to work with methods that aren't backed by
-// metadata and IL in a module. Currently this method only triages methods whose code was generated from IL.
+// metadata and IL in a module.
 inline bool MethodDesc::IsDiagnosticsHidden()
 {
     // Although good user experience can be subjective these are guidelines:
@@ -151,10 +151,8 @@ inline bool MethodDesc::IsDiagnosticsHidden()
     //   one frame for these calls as well but we haven't always done this consistently. For calls that redirect to another managed method users
     //   tolerate if the runtime-implemented frame is missing because they can still see the managed target method.
 
-    // NOTE: Currently this method doesn't filter out unboxing stubs although it seems like it should. I haven't identified a concrete
-    // scenario that produces a bad user experience but more exploration might find one.
     WRAPPER_NO_CONTRACT;
-    return IsILStub() || IsAsyncThunkMethod();
+    return IsILStub() || IsAsyncThunkMethod() || IsWrapperStub();
 }
 
 inline BOOL MethodDesc::IsQCall()

--- a/src/coreclr/vm/method.inl
+++ b/src/coreclr/vm/method.inl
@@ -135,10 +135,10 @@ inline bool MethodDesc::IsILStub()
 
 // This method is intended to identify runtime defined methods that don't have a corresponding Metadata or
 // LCG definition so they can be filtered from diagnostic introspection (stacktraces, code viewing, stepping, etc). 
-// Partly this is this is a user experience consideration to preserve the abstraction users would expect based on
+// Partly this is a user experience consideration to preserve the abstraction users would expect based on
 // source code and assembly contents. Partly it is also a technical limitation that many parts of
 // diagnostics don't know how to work with methods that aren't backed by metadata and IL in a module.
-// Currently this method only triages methods whose code was generated from IL. We rely on filtering that occurs implictly
+// Currently this method only triages methods whose code was generated from IL. We rely on filtering that occurs implicitly
 // elsewhere to avoid including other kinds of stubs like prestubs or unboxing stubs.
 inline bool MethodDesc::IsDiagnosticsHidden()
 {

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1057,6 +1057,9 @@ bool MethodDesc::TryGenerateTransientILImplementation(DynamicResolver** resolver
 {
     STANDARD_VM_CONTRACT;
 
+    // When adding new methods implemented by Transient IL, consider if MethodDesc::IsDiagnosticsHidden() needs to be
+    // updated as well.
+
     if (TryGenerateAsyncThunk(resolver, methodILDecoder))
     {
         return true;


### PR DESCRIPTION
Added clarifying comments on some MethodDesc APIs related to TransientIL and diagnostics.


Fyi @rcj1 @davidwrighton @hoyosjs @jkotas 
This is a follow up to https://github.com/dotnet/runtime/pull/120982