### PR TITLE
Remove unsafe from EqualStartingCharacterCount

### DIFF
--- a/src/libraries/Common/src/System/IO/PathInternal.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.cs
@@ -52,23 +52,24 @@ namespace System.IO
         /// </summary>
         private static int EqualStartingCharacterCount(string? first, string? second, bool ignoreCase)
         {
-            if (string.IsNullOrEmpty(first) || string.IsNullOrEmpty(second)) return 0;
-
-            int i = first.AsSpan().CommonPrefixLength(second);
-            if (!ignoreCase)
+            if (string.IsNullOrEmpty(first) || string.IsNullOrEmpty(second))
             {
-                return i;
+                return 0;
             }
 
-            for (; i < first.Length; i++)
+            int commonLength = first.AsSpan().CommonPrefixLength(second);
+            if (ignoreCase)
             {
-                if (i >= second.Length ||
-                    char.ToUpperInvariant(first[i]) != char.ToUpperInvariant(second[i]))
+                for (; commonLength < first.Length; commonLength++)
                 {
-                    return i;
+                    if (commonLength >= second.Length ||
+                        char.ToUpperInvariant(first[commonLength]) != char.ToUpperInvariant(second[commonLength]))
+                    {
+                        break;
+                    }
                 }
             }
-            return first.Length;
+            return commonLength;
         }
 
         /// <summary>

--- a/src/libraries/Common/src/System/IO/PathInternal.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.cs
@@ -57,13 +57,13 @@ namespace System.IO
             for (int i = 0; i < first.Length; i++)
             {
                 // Reached the end of the second string
-                if (i >= second.Length) 
+                if (i >= second.Length)
                 {
                     return i;
                 }
 
                 // Check for character mismatch
-                if ((first[i] != second[i]) && 
+                if ((first[i] != second[i]) &&
                     (!ignoreCase || char.ToUpperInvariant(first[i]) != char.ToUpperInvariant(second[i])))
                 {
                     return i;

--- a/src/libraries/Common/src/System/IO/PathInternal.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.cs
@@ -50,30 +50,26 @@ namespace System.IO
         /// <summary>
         /// Gets the count of common characters from the left optionally ignoring case
         /// </summary>
-        internal static unsafe int EqualStartingCharacterCount(string? first, string? second, bool ignoreCase)
+        internal static int EqualStartingCharacterCount(string? first, string? second, bool ignoreCase)
         {
             if (string.IsNullOrEmpty(first) || string.IsNullOrEmpty(second)) return 0;
 
-            int commonChars = 0;
-
-            fixed (char* f = first)
-            fixed (char* s = second)
+            for (int i = 0; i < first.Length; i++)
             {
-                char* l = f;
-                char* r = s;
-                char* leftEnd = l + first.Length;
-                char* rightEnd = r + second.Length;
-
-                while (l != leftEnd && r != rightEnd
-                    && (*l == *r || (ignoreCase && char.ToUpperInvariant(*l) == char.ToUpperInvariant(*r))))
+                // Reached the end of the second string
+                if (i >= second.Length) 
                 {
-                    commonChars++;
-                    l++;
-                    r++;
+                    return i;
+                }
+
+                // Check for character mismatch
+                if ((first[i] != second[i]) && 
+                    (!ignoreCase || char.ToUpperInvariant(first[i]) != char.ToUpperInvariant(second[i])))
+                {
+                    return i;
                 }
             }
-
-            return commonChars;
+            return first.Length;
         }
 
         /// <summary>

--- a/src/libraries/Common/src/System/IO/PathInternal.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.cs
@@ -54,22 +54,15 @@ namespace System.IO
         {
             if (string.IsNullOrEmpty(first) || string.IsNullOrEmpty(second)) return 0;
 
+            int i = first.AsSpan().CommonPrefixLength(second);
             if (!ignoreCase)
             {
-                // We can use the existing accelerated API for case-sensitive comparison
-                return first.AsSpan().CommonPrefixLength(second);
+                return i;
             }
 
-            for (int i = 0; i < first.Length; i++)
+            for (; i < first.Length; i++)
             {
-                // Reached the end of the second string
-                if (i >= second.Length)
-                {
-                    return i;
-                }
-
-                // Check for character mismatch. first[i] != second[i] is a fast path for the common case.
-                if (first[i] != second[i] &&
+                if (i >= second.Length ||
                     char.ToUpperInvariant(first[i]) != char.ToUpperInvariant(second[i]))
                 {
                     return i;

--- a/src/libraries/Common/src/System/IO/PathInternal.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.cs
@@ -50,7 +50,7 @@ namespace System.IO
         /// <summary>
         /// Gets the count of common characters from the left optionally ignoring case
         /// </summary>
-        private static int EqualStartingCharacterCount(string? first, string? second, bool ignoreCase)
+        internal static int EqualStartingCharacterCount(string? first, string? second, bool ignoreCase)
         {
             if (string.IsNullOrEmpty(first) || string.IsNullOrEmpty(second))
             {

--- a/src/libraries/Common/src/System/IO/PathInternal.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.cs
@@ -60,7 +60,7 @@ namespace System.IO
             int commonLength = first.AsSpan().CommonPrefixLength(second);
             if (ignoreCase)
             {
-                for (; commonLength < first.Length; commonLength++)
+                for (; (uint)commonLength < (uint)first.Length; commonLength++)
                 {
                     if (commonLength >= second.Length ||
                         char.ToUpperInvariant(first[commonLength]) != char.ToUpperInvariant(second[commonLength]))

--- a/src/libraries/Common/src/System/IO/PathInternal.cs
+++ b/src/libraries/Common/src/System/IO/PathInternal.cs
@@ -50,9 +50,15 @@ namespace System.IO
         /// <summary>
         /// Gets the count of common characters from the left optionally ignoring case
         /// </summary>
-        internal static int EqualStartingCharacterCount(string? first, string? second, bool ignoreCase)
+        private static int EqualStartingCharacterCount(string? first, string? second, bool ignoreCase)
         {
             if (string.IsNullOrEmpty(first) || string.IsNullOrEmpty(second)) return 0;
+
+            if (!ignoreCase)
+            {
+                // We can use the existing accelerated API for case-sensitive comparison
+                return first.AsSpan().CommonPrefixLength(second);
+            }
 
             for (int i = 0; i < first.Length; i++)
             {
@@ -62,9 +68,9 @@ namespace System.IO
                     return i;
                 }
 
-                // Check for character mismatch
-                if ((first[i] != second[i]) &&
-                    (!ignoreCase || char.ToUpperInvariant(first[i]) != char.ToUpperInvariant(second[i])))
+                // Check for character mismatch. first[i] != second[i] is a fast path for the common case.
+                if (first[i] != second[i] &&
+                    char.ToUpperInvariant(first[i]) != char.ToUpperInvariant(second[i]))
                 {
                     return i;
                 }


### PR DESCRIPTION
I wasn't able to detect any difference for `Path.GetRelativePath` and the codegen is fairly close.
if we want extra perf, we can vectorize this routine trivially for Linux/macOS (where paths are case-sensitives).

Given this API allocates a new string, it probably isn't supposed to be used on a hot path.