### PR TITLE
[Mono] Fix ParameterInfo.Name to return null for unnamed parameters

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -9324,7 +9324,7 @@ method_commands_internal (int command, MonoMethod *method, MonoDomain *domain, g
 		names = g_new (char *, sig->param_count);
 		mono_method_get_param_names_internal (method, (const char **) names);
 		for (guint16 i = 0; i < sig->param_count; ++i)
-			buffer_add_string (buf, names [i]);
+			buffer_add_string (buf, names [i] ? names [i] : "");
 		g_free (names);
 
 		break;

--- a/src/mono/mono/metadata/loader.c
+++ b/src/mono/mono/metadata/loader.c
@@ -1446,7 +1446,7 @@ mono_method_get_param_names_internal (MonoMethod *method, const char **names)
 		return;
 
 	for (i = 0; i < signature->param_count; ++i)
-		names [i] = "";
+		names [i] = NULL;
 
 	klass = method->klass;
 	if (m_class_get_rank (klass))

--- a/src/mono/mono/metadata/reflection.c
+++ b/src/mono/mono/metadata/reflection.c
@@ -1017,8 +1017,13 @@ add_parameter_object_to_array (MonoMethod *method, MonoObjectHandle member, int 
 	goto_if_nok (error, leave);
 
 	MonoStringHandle name_str;
-	name_str = mono_string_new_handle (name, error);
-	goto_if_nok (error, leave);
+	if (name != NULL) {
+		name_str = mono_string_new_handle (name, error);
+		goto_if_nok (error, leave);
+	} else {
+		// Keep NULL as NULL instead of converting to empty string
+		name_str = MONO_HANDLE_NEW (MonoString, NULL);
+	}
 
 	MonoObjectHandle def_value;
 

--- a/src/mono/mono/mini/dwarfwriter.c
+++ b/src/mono/mono/mini/dwarfwriter.c
@@ -1865,7 +1865,7 @@ mono_dwarf_writer_emit_method (MonoDwarfWriter *w, MonoCompile *cfg, MonoMethod 
 
 		emit_uleb128 (w, need_loclist ? ABBREV_PARAM_LOCLIST : ABBREV_PARAM);
 		/* name */
-		if (pname[0] == '\0') {
+		if (!pname || pname[0] == '\0') {
 			sprintf (pname_buf, "param%d", i - sig->hasthis);
 			pname = pname_buf;
 		}


### PR DESCRIPTION
# [Mono] Fix ParameterInfo.Name to return null for unnamed parameters

## Summary

Fixes runtime inconsistency where Mono's `ParameterInfo.Name` returns empty string (`""`) for unnamed parameters while CoreCLR correctly returns `null`.

## Problem

**Failing Tests:**
- `OpenApiOperationGeneratorTests.ThrowsInvalidOperationExceptionGivenUnnamedParameter`
- `RequestDelegateFactoryTests.CreateThrowsInvalidOperationExceptionGivenUnnamedArgument`

**Root Cause:**
```csharp
// CoreCLR behavior (correct)
var param = lambda.Compile().Method.GetParameters()[0];
param.Name == null  // true

// Mono behavior (bug)
param.Name == ""    //  empty string, not null
```

ASP.NET Core validation checks `if (parameter.Name is null)` - this works on CoreCLR but fails on Mono.

## Reproduction

```csharp
using System;
using System.Linq.Expressions;

var unnamed = Expression.Parameter(typeof(int));
var lambda = Expression.Lambda(Expression.Block(), unnamed);
var param = lambda.Compile().Method.GetParameters()[0];

// CoreCLR: param.Name is null 
// Mono: param.Name is "" 
Console.WriteLine($"Name is null: {param.Name is null}");
```


**Test Results:**
- With only `loader.c` fix:  `param.Name` still returns `""`
- With both fixes: `param.Name` correctly returns `null`






### Why 

 `ParameterInfo.Name` is nullable (`string?`) per [API Contract](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.parameterinfo.name?view=net-9.0&viewFallbackFrom=net-9.0))



## Related Issues

Fixes failures in dotnet/aspnetcore test suite when running on Mono runtime.


cc: @giritrivedi
