### PR TITLE
Unify KC/KD normalization behavior on Wasm

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -50,6 +50,7 @@ namespace System
         public static bool IsSolaris => RuntimeInformation.IsOSPlatform(OSPlatform.Create("SOLARIS"));
         public static bool IsBrowser => RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER"));
         public static bool IsWasi => RuntimeInformation.IsOSPlatform(OSPlatform.Create("WASI"));
+        public static bool IsWasm => IsBrowser || IsWasi;
         public static bool IsNotBrowser => !IsBrowser;
         public static bool IsNotWasi => !IsWasi;
         public static bool IsMobile => IsBrowser || IsWasi || IsAppleMobile || IsAndroid;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Icu.cs
@@ -199,7 +199,7 @@ namespace System.Globalization
 
         private static void ValidateArguments(ReadOnlySpan<char> strInput, NormalizationForm normalizationForm, string paramName = "strInput")
         {
-            ThrowIfCompatibilityFormUnsupported(normalizationForm);
+            CheckNormalizationForm(normalizationForm);
 
             if (HasInvalidUnicodeSequence(strInput))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Icu.cs
@@ -15,11 +15,11 @@ namespace System.Globalization
             Debug.Assert(!GlobalizationMode.Invariant);
             Debug.Assert(!GlobalizationMode.UseNls);
             Debug.Assert(!source.IsEmpty);
-#pragma warning disable CA1416 // FormKC and FormKD are unsupported on browser, ValidateArguments is throwing PlatformNotSupportedException in that case so suppressing the warning here
+#pragma warning disable CA1416 // FormKC and FormKD are unsupported on browser, CheckNormalizationForm is throwing PlatformNotSupportedException in that case so suppressing the warning here
             Debug.Assert(normalizationForm is NormalizationForm.FormC or NormalizationForm.FormD or NormalizationForm.FormKC or NormalizationForm.FormKD);
 #pragma warning restore CA1416
 
-            ValidateArguments(source, normalizationForm, nameof(source));
+            ValidateArguments(source, nameof(source));
 
             int ret;
             fixed (char* pInput = source)
@@ -50,7 +50,7 @@ namespace System.Globalization
             Debug.Assert(!GlobalizationMode.UseNls);
             Debug.Assert(normalizationForm == NormalizationForm.FormC || normalizationForm == NormalizationForm.FormD || normalizationForm == NormalizationForm.FormKC || normalizationForm == NormalizationForm.FormKD);
 
-            ValidateArguments(strInput, normalizationForm);
+            ValidateArguments(strInput);
 
             char[]? toReturn = null;
             try
@@ -132,7 +132,7 @@ namespace System.Globalization
                 return false;
             }
 
-            ValidateArguments(source, normalizationForm, nameof(source));
+            ValidateArguments(source, nameof(source));
 
             int realLen;
             fixed (char* pInput = source)
@@ -172,7 +172,7 @@ namespace System.Globalization
             Debug.Assert(!source.IsEmpty);
             Debug.Assert(normalizationForm == NormalizationForm.FormC || normalizationForm == NormalizationForm.FormD || normalizationForm == NormalizationForm.FormKC || normalizationForm == NormalizationForm.FormKD);
 
-            ValidateArguments(source, normalizationForm, nameof(source));
+            ValidateArguments(source, nameof(source));
 
             int realLen;
             fixed (char* pInput = source)
@@ -197,10 +197,8 @@ namespace System.Globalization
             return realLen;
         }
 
-        private static void ValidateArguments(ReadOnlySpan<char> strInput, NormalizationForm normalizationForm, string paramName = "strInput")
+        private static void ValidateArguments(ReadOnlySpan<char> strInput, string paramName = "strInput")
         {
-            CheckNormalizationForm(normalizationForm);
-
             if (HasInvalidUnicodeSequence(strInput))
             {
                 throw new ArgumentException(SR.Argument_InvalidCharSequenceNoIndex, paramName);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.Icu.cs
@@ -199,11 +199,7 @@ namespace System.Globalization
 
         private static void ValidateArguments(ReadOnlySpan<char> strInput, NormalizationForm normalizationForm, string paramName = "strInput")
         {
-            if ((OperatingSystem.IsBrowser() || OperatingSystem.IsWasi()) && (normalizationForm == NormalizationForm.FormKC || normalizationForm == NormalizationForm.FormKD))
-            {
-                // Browser's ICU doesn't contain data needed for FormKC and FormKD
-                throw new PlatformNotSupportedException(SR.Argument_UnsupportedNormalizationFormInBrowser);
-            }
+            ThrowIfCompatibilityFormUnsupported(normalizationForm);
 
             if (HasInvalidUnicodeSequence(strInput))
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.cs
@@ -11,7 +11,7 @@ namespace System.Globalization
         internal static bool IsNormalized(ReadOnlySpan<char> source, NormalizationForm normalizationForm = NormalizationForm.FormC)
         {
             CheckNormalizationForm(normalizationForm);
-            
+
             // In Invariant mode we assume all characters are normalized because we don't support any linguistic operations on strings.
             // If it's ASCII && one of the 4 main forms, then it's already normalized.
             if (GlobalizationMode.Invariant || Ascii.IsValid(source))

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Normalization.cs
@@ -95,16 +95,10 @@ namespace System.Globalization
                 throw new ArgumentException(SR.Argument_InvalidNormalizationForm, nameof(normalizationForm));
             }
 
-            ThrowIfCompatibilityFormUnsupported(normalizationForm);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void ThrowIfCompatibilityFormUnsupported(NormalizationForm normalizationForm)
-        {
-            if ((normalizationForm == NormalizationForm.FormKC || normalizationForm == NormalizationForm.FormKD) &&
+            if ((OperatingSystem.IsBrowser() || OperatingSystem.IsWasi()) &&
                 !GlobalizationMode.Invariant &&
                 !GlobalizationMode.UseNls &&
-                (OperatingSystem.IsBrowser() || OperatingSystem.IsWasi()))
+                (normalizationForm == NormalizationForm.FormKC || normalizationForm == NormalizationForm.FormKD))
             {
                 // Browser/WASI builds ship without compatibility normalization data.
                 throw new PlatformNotSupportedException(SR.Argument_UnsupportedNormalizationFormInBrowser);

--- a/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/Normalization/StringNormalizationTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/Normalization/StringNormalizationTests.cs
@@ -154,8 +154,11 @@ namespace System.Globalization.Tests
                 Assert.Throws<PlatformNotSupportedException>(() => value.AsSpan().IsNormalized(normalizationForm));
                 Assert.Throws<PlatformNotSupportedException>(() => value.Normalize(normalizationForm));
 
-                Span<char> destination = stackalloc char[32];
-                Assert.Throws<PlatformNotSupportedException>(() => value.AsSpan().TryNormalize(destination, out _, normalizationForm));
+                Assert.Throws<PlatformNotSupportedException>(() =>
+                {
+                    Span<char> destination = stackalloc char[32];
+                    value.AsSpan().TryNormalize(destination, out _, normalizationForm);
+                });
                 Assert.Throws<PlatformNotSupportedException>(() => value.AsSpan().GetNormalizedLength(normalizationForm));
             }
         }

--- a/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/Normalization/StringNormalizationTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/Normalization/StringNormalizationTests.cs
@@ -138,5 +138,26 @@ namespace System.Globalization.Tests
         {
             AssertExtensions.Throws<ArgumentNullException>("strInput", () => StringNormalizationExtensions.Normalize(null));
         }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWasm))]
+        public void NormalizationForms_ThrowOnNotSupportedPlatforms()
+        {
+            AssertNormalizationFormThrows(NormalizationForm.FormKC);
+            AssertNormalizationFormThrows(NormalizationForm.FormKD);
+        }
+
+        private static void AssertNormalizationFormThrows(NormalizationForm normalizationForm)
+        {
+            foreach (string value in new[] { "ascii", "😊" })
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => value.IsNormalized(normalizationForm));
+                Assert.Throws<PlatformNotSupportedException>(() => value.AsSpan().IsNormalized(normalizationForm));
+                Assert.Throws<PlatformNotSupportedException>(() => value.Normalize(normalizationForm));
+
+                Span<char> destination = stackalloc char[32];
+                Assert.Throws<PlatformNotSupportedException>(() => value.AsSpan().TryNormalize(destination, out _, normalizationForm));
+                Assert.Throws<PlatformNotSupportedException>(() => value.AsSpan().GetNormalizedLength(normalizationForm));
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/117116.

- Call `CheckNormalizationForm` before the ASCII fast path so Browser/WASI throw `PlatformNotSupportedException` for FormKC/FormKD regardless of input.
- Add wasm-specific test for checking if PNSE was thrown for both, ASCII and non-ASCII with KC and KD.

Why didn't we catch it in tests?
Because we do not test KC/KD at all, considering them not supported (`IsNotUsingLimitedCultures` -> Browser with its ICU):
https://github.com/dotnet/runtime/blob/0c185bc65473f89bdadabe345d76222f3a0d565f/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/Normalization/StringNormalizationTests.cs#L60