### PR TITLE
Report bad code when localloc is in a funclet

### DIFF
--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -293,7 +293,6 @@ enum InterpBBState
 enum InterpBBClauseType
 {
     BBClauseNone,
-    BBClauseTry,
     BBClauseCatch,
     BBClauseFinally,
     BBClauseFilter,


### PR DESCRIPTION
The interpreter didn't check that localloc is not valid in funclets. Couple of coreclr tests were failing due to that.

To make this work properly, I've removed marking blocks with BBClauseTry as it was not used for anything and preventing the check for code being in funclet working properly.