### PR TITLE
Support references to unmanaged function pointers in Reflection.Emit

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/FieldOnTypeBuilderInstantiation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/FieldOnTypeBuilderInstantiation.cs
@@ -56,6 +56,7 @@ namespace System.Reflection.Emit
         #region Public Abstract\Virtual Members
         public override Type[] GetRequiredCustomModifiers() { return _field.GetRequiredCustomModifiers(); }
         public override Type[] GetOptionalCustomModifiers() { return _field.GetOptionalCustomModifiers(); }
+        public override Type GetModifiedFieldType() => _field.GetModifiedFieldType();
         public override void SetValueDirect(TypedReference obj, object value)
         {
             throw new NotImplementedException();

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/MethodOnTypeBuilderInstantiation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/MethodOnTypeBuilderInstantiation.cs
@@ -118,7 +118,7 @@ namespace System.Reflection.Emit
 
         #region Public Abstract\Virtual Members
         public override Type ReturnType => _method.ReturnType;
-        public override ParameterInfo ReturnParameter => throw new NotSupportedException();
+        public override ParameterInfo ReturnParameter => _method.ReturnParameter;
         public override ICustomAttributeProvider ReturnTypeCustomAttributes => throw new NotSupportedException();
         public override MethodInfo GetBaseDefinition() { throw new NotSupportedException(); }
         #endregion

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/ModifiedType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/ModifiedType.cs
@@ -172,8 +172,10 @@ namespace System.Reflection
         public override bool IsEnum => _unmodifiedType.IsEnum;
         protected override bool IsPrimitiveImpl() => _unmodifiedType.IsPrimitive;
         protected override bool IsByRefImpl() => _unmodifiedType.IsByRef;
+        public override bool IsGenericParameter => _unmodifiedType.IsGenericParameter;
         public override bool IsGenericTypeParameter => _unmodifiedType.IsGenericTypeParameter;
         public override bool IsGenericMethodParameter => _unmodifiedType.IsGenericMethodParameter;
+        public override int GenericParameterPosition => _unmodifiedType.GenericParameterPosition;
         protected override bool IsPointerImpl() => _unmodifiedType.IsPointer;
         protected override bool IsValueTypeImpl() => _unmodifiedType.IsValueType;
         protected override bool IsCOMObjectImpl() => _unmodifiedType.IsCOMObject;

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/FieldBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/FieldBuilderImpl.cs
@@ -113,6 +113,8 @@ namespace System.Reflection.Emit
 
         public override Type[] GetOptionalCustomModifiers() => _optionalCustomModifiers ?? Type.EmptyTypes;
 
+        public override Type GetModifiedFieldType() => FieldType;
+
         #endregion
 
         #region ICustomAttributeProvider Implementation

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -794,7 +794,7 @@ namespace System.Reflection.Emit
         }
 
         private BlobBuilder GetMethodSignature(MethodInfo method, Type[]? optionalParameterTypes) =>
-            MetadataSignatureHelper.GetMethodSignature(this, ParameterTypes(method.GetParameters()), method.ReturnParameter.GetModifiedParameterType(),
+            MetadataSignatureHelper.GetMethodSignature(this, MetadataSignatureHelper.GetParameterTypes(method.GetParameters()), method.ReturnParameter.GetModifiedParameterType(),
                 GetSignatureConvention(method.CallingConvention), method.GetGenericArguments().Length, !method.IsStatic, optionalParameterTypes);
 
         private BlobBuilder GetMethodArrayMethodSignature(ArrayMethod method) => MetadataSignatureHelper.GetMethodSignature(
@@ -830,23 +830,6 @@ namespace System.Reflection.Emit
             }
 
             return memberInfo;
-        }
-
-        internal static Type[] ParameterTypes(ParameterInfo[] parameterInfos)
-        {
-            if (parameterInfos.Length == 0)
-            {
-                return Type.EmptyTypes;
-            }
-
-            Type[] parameterTypes = new Type[parameterInfos.Length];
-
-            for (int i = 0; i < parameterInfos.Length; i++)
-            {
-                parameterTypes[i] = parameterInfos[i].GetModifiedParameterType();
-            }
-
-            return parameterTypes;
         }
 
         private AssemblyReferenceHandle GetAssemblyReference(Assembly assembly)

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.SymbolStore;
-using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ModuleBuilderImpl.cs
@@ -800,7 +800,6 @@ namespace System.Reflection.Emit
         private BlobBuilder GetMethodSignature(MethodInfo method, Type[]? optionalParameterTypes)
         {
             Type returnType = method.ReturnType;
-
             if (returnType.IsUnmanagedFunctionPointer)
                 returnType = method.ReturnParameter.GetModifiedParameterType();
 
@@ -855,7 +854,6 @@ namespace System.Reflection.Emit
             for (int i = 0; i < parameterInfos.Length; i++)
             {
                 Type paramType = parameterInfos[i].ParameterType;
-
                 if (paramType.IsUnmanagedFunctionPointer)
                     paramType = parameterInfos[i].GetModifiedParameterType();
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ParameterBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ParameterBuilderImpl.cs
@@ -68,8 +68,7 @@ namespace System.Reflection.Emit
     internal sealed class ParameterInfoWrapper : ParameterInfo
     {
         private readonly ParameterBuilderImpl _pb;
-        private readonly Type _type
-;
+        private readonly Type _type;
         public ParameterInfoWrapper(ParameterBuilderImpl pb, Type type)
         {
             _pb = pb;
@@ -87,5 +86,7 @@ namespace System.Reflection.Emit
         public override bool HasDefaultValue => _pb._defaultValue != DBNull.Value;
 
         public override object? DefaultValue => HasDefaultValue ? _pb._defaultValue : null;
+
+        public override Type GetModifiedParameterType() => ParameterType;
     }
 }

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -122,6 +122,8 @@ namespace System.Reflection.Emit
 
         private static void WriteCustomModifiers(CustomModifiersEncoder encoder, Type[] customModifiers, bool isOptional, ModuleBuilderImpl module)
         {
+            // GetOptionalCustomModifiers and GetRequiredCustomModifiers return modifiers in reverse order
+            Array.Reverse(customModifiers);
             foreach (Type modifier in customModifiers)
             {
                 encoder.AddModifier(module.GetTypeHandle(modifier), isOptional);
@@ -271,16 +273,10 @@ namespace System.Reflection.Emit
             CustomModifiersEncoder retModifiersEncoder = retTypeEncoder.CustomModifiers();
 
             if (returnType.GetOptionalCustomModifiers() is Type[] retModOpts)
-            {
-                Array.Reverse(retModOpts);
                 WriteCustomModifiers(retModifiersEncoder, retModOpts, isOptional: true, module);
-            }
 
             if (returnType.GetRequiredCustomModifiers() is Type[] retModReqs)
-            {
-                Array.Reverse(retModReqs);
                 WriteCustomModifiers(retModifiersEncoder, retModReqs, isOptional: false, module);
-            }
 
             WriteSignatureForType(retTypeEncoder.Type(), returnType, module);
 
@@ -290,16 +286,10 @@ namespace System.Reflection.Emit
                 CustomModifiersEncoder paramModifiersEncoder = paramEncoder.CustomModifiers();
 
                 if (paramType.GetOptionalCustomModifiers() is Type[] paramModOpts)
-                {
-                    Array.Reverse(paramModOpts);
                     WriteCustomModifiers(paramModifiersEncoder, paramModOpts, isOptional: true, module);
-                }
 
                 if (paramType.GetRequiredCustomModifiers() is Type[] paramModReqs)
-                {
-                    Array.Reverse(paramModReqs);
                     WriteCustomModifiers(paramModifiersEncoder, paramModReqs, isOptional: false, module);
-                }
 
                 WriteSignatureForType(paramEncoder.Type(), paramType, module);
             }

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -48,7 +48,7 @@ namespace System.Reflection.Emit
 
             retType.Void();
 
-            WriteParametersSignature(module, Array.ConvertAll(parameters, p => p.ParameterType), parameterEncoder);
+            WriteParametersSignature(module, ModuleBuilderImpl.ParameterTypes(parameters), parameterEncoder);
 
             return constructorSignature;
         }
@@ -203,13 +203,13 @@ namespace System.Reflection.Emit
                     module.GetTypeHandle(type.GetGenericTypeDefinition()), genericArguments.Length, type.IsValueType);
                 foreach (Type gType in genericArguments)
                 {
-                    if (gType.IsGenericMethodParameter)
+                    if (gType.UnderlyingSystemType.IsGenericMethodParameter)
                     {
-                        encoder.AddArgument().GenericMethodTypeParameter(gType.GenericParameterPosition);
+                        encoder.AddArgument().GenericMethodTypeParameter(gType.UnderlyingSystemType.GenericParameterPosition);
                     }
-                    else if (gType.IsGenericParameter)
+                    else if (gType.UnderlyingSystemType.IsGenericParameter)
                     {
-                        encoder.AddArgument().GenericTypeParameter(gType.GenericParameterPosition);
+                        encoder.AddArgument().GenericTypeParameter(gType.UnderlyingSystemType.GenericParameterPosition);
                     }
                     else
                     {
@@ -217,13 +217,13 @@ namespace System.Reflection.Emit
                     }
                 }
             }
-            else if (type.IsGenericMethodParameter)
+            else if (type.UnderlyingSystemType.IsGenericMethodParameter)
             {
-                signature.GenericMethodTypeParameter(type.GenericParameterPosition);
+                signature.GenericMethodTypeParameter(type.UnderlyingSystemType.GenericParameterPosition);
             }
-            else if (type.IsGenericParameter)
+            else if (type.UnderlyingSystemType.IsGenericParameter)
             {
-                signature.GenericTypeParameter(type.GenericParameterPosition);
+                signature.GenericTypeParameter(type.UnderlyingSystemType.GenericParameterPosition);
             }
             else if (type.IsFunctionPointer)
             {

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -123,9 +123,9 @@ namespace System.Reflection.Emit
         private static void WriteCustomModifiers(CustomModifiersEncoder encoder, Type[] customModifiers, bool isOptional, ModuleBuilderImpl module)
         {
             // GetOptionalCustomModifiers and GetRequiredCustomModifiers return modifiers in reverse order
-            Array.Reverse(customModifiers);
-            foreach (Type modifier in customModifiers)
+            for (int i = customModifiers.Length - 1; i >= 0; i--)
             {
+                Type modifier = customModifiers[i];
                 encoder.AddModifier(module.GetTypeHandle(modifier), isOptional);
             }
         }
@@ -203,13 +203,13 @@ namespace System.Reflection.Emit
                     module.GetTypeHandle(type.GetGenericTypeDefinition()), genericArguments.Length, type.IsValueType);
                 foreach (Type gType in genericArguments)
                 {
-                    if (gType.UnderlyingSystemType.IsGenericMethodParameter)
+                    if (gType.IsGenericMethodParameter)
                     {
-                        encoder.AddArgument().GenericMethodTypeParameter(gType.UnderlyingSystemType.GenericParameterPosition);
+                        encoder.AddArgument().GenericMethodTypeParameter(gType.GenericParameterPosition);
                     }
-                    else if (gType.UnderlyingSystemType.IsGenericParameter)
+                    else if (gType.IsGenericParameter)
                     {
-                        encoder.AddArgument().GenericTypeParameter(gType.UnderlyingSystemType.GenericParameterPosition);
+                        encoder.AddArgument().GenericTypeParameter(gType.GenericParameterPosition);
                     }
                     else
                     {
@@ -217,13 +217,13 @@ namespace System.Reflection.Emit
                     }
                 }
             }
-            else if (type.UnderlyingSystemType.IsGenericMethodParameter)
+            else if (type.IsGenericMethodParameter)
             {
-                signature.GenericMethodTypeParameter(type.UnderlyingSystemType.GenericParameterPosition);
+                signature.GenericMethodTypeParameter(type.GenericParameterPosition);
             }
-            else if (type.UnderlyingSystemType.IsGenericParameter)
+            else if (type.IsGenericParameter)
             {
-                signature.GenericTypeParameter(type.UnderlyingSystemType.GenericParameterPosition);
+                signature.GenericTypeParameter(type.GenericParameterPosition);
             }
             else if (type.IsFunctionPointer)
             {

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -276,11 +276,7 @@ namespace System.Reflection.Emit
             if (returnType.GetRequiredCustomModifiers() is Type[] retModReqs)
                 WriteCustomModifiers(retModifiersEncoder, retModReqs, isOptional: false, module);
 
-            Type returnTypeToWrite = returnType;
-            if (!returnTypeToWrite.IsFunctionPointer)
-                returnTypeToWrite = returnTypeToWrite.UnderlyingSystemType;
-
-            WriteSignatureForType(retTypeEncoder.Type(), returnTypeToWrite, module);
+            WriteSignatureForType(retTypeEncoder.Type(), returnType, module);
 
             foreach (Type paramType in paramTypes)
             {
@@ -293,16 +289,13 @@ namespace System.Reflection.Emit
                 if (paramType.GetRequiredCustomModifiers() is Type[] paramModReqs)
                     WriteCustomModifiers(paramModifiersEncoder, paramModReqs, isOptional: false, module);
 
-                Type paramTypeToWrite = paramType;
-                if (!paramTypeToWrite.IsFunctionPointer)
-                    paramTypeToWrite = paramTypeToWrite.UnderlyingSystemType;
-
-                WriteSignatureForType(paramEncoder.Type(), paramTypeToWrite, module);
+                WriteSignatureForType(paramEncoder.Type(), paramType, module);
             }
         }
 
         private static void WriteSimpleSignature(SignatureTypeEncoder signature, Type type, ModuleBuilderImpl module)
         {
+            type = type.UnderlyingSystemType;
             CoreTypeId? typeId = module.GetTypeIdFromCoreTypes(type);
 
             switch (typeId)

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -276,7 +276,11 @@ namespace System.Reflection.Emit
             if (returnType.GetRequiredCustomModifiers() is Type[] retModReqs)
                 WriteCustomModifiers(retModifiersEncoder, retModReqs, isOptional: false, module);
 
-            WriteSignatureForType(retTypeEncoder.Type(), returnType, module);
+            Type returnTypeToWrite = returnType;
+            if (!returnTypeToWrite.IsFunctionPointer)
+                returnTypeToWrite = returnTypeToWrite.UnderlyingSystemType;
+
+            WriteSignatureForType(retTypeEncoder.Type(), returnTypeToWrite, module);
 
             foreach (Type paramType in paramTypes)
             {
@@ -289,7 +293,11 @@ namespace System.Reflection.Emit
                 if (paramType.GetRequiredCustomModifiers() is Type[] paramModReqs)
                     WriteCustomModifiers(paramModifiersEncoder, paramModReqs, isOptional: false, module);
 
-                WriteSignatureForType(paramEncoder.Type(), paramType, module);
+                Type paramTypeToWrite = paramType;
+                if (!paramTypeToWrite.IsFunctionPointer)
+                    paramTypeToWrite = paramTypeToWrite.UnderlyingSystemType;
+
+                WriteSignatureForType(paramEncoder.Type(), paramTypeToWrite, module);
             }
         }
 

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -48,7 +48,7 @@ namespace System.Reflection.Emit
 
             retType.Void();
 
-            WriteParametersSignature(module, ModuleBuilderImpl.ParameterTypes(parameters), parameterEncoder);
+            WriteParametersSignature(module, GetParameterTypes(parameters), parameterEncoder);
 
             return constructorSignature;
         }
@@ -104,6 +104,23 @@ namespace System.Reflection.Emit
             }
 
             return methodSignature;
+        }
+
+        internal static Type[] GetParameterTypes(ParameterInfo[] parameterInfos)
+        {
+            if (parameterInfos.Length == 0)
+            {
+                return Type.EmptyTypes;
+            }
+
+            Type[] parameterTypes = new Type[parameterInfos.Length];
+
+            for (int i = 0; i < parameterInfos.Length; i++)
+            {
+                parameterTypes[i] = parameterInfos[i].GetModifiedParameterType();
+            }
+
+            return parameterTypes;
         }
 
         private static void WriteReturnTypeCustomModifiers(CustomModifiersEncoder encoder,

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -271,10 +271,16 @@ namespace System.Reflection.Emit
             CustomModifiersEncoder retModifiersEncoder = retTypeEncoder.CustomModifiers();
 
             if (returnType.GetOptionalCustomModifiers() is Type[] retModOpts)
+            {
+                Array.Reverse(retModOpts);
                 WriteCustomModifiers(retModifiersEncoder, retModOpts, isOptional: true, module);
+            }
 
             if (returnType.GetRequiredCustomModifiers() is Type[] retModReqs)
+            {
+                Array.Reverse(retModReqs);
                 WriteCustomModifiers(retModifiersEncoder, retModReqs, isOptional: false, module);
+            }
 
             WriteSignatureForType(retTypeEncoder.Type(), returnType, module);
 
@@ -284,10 +290,16 @@ namespace System.Reflection.Emit
                 CustomModifiersEncoder paramModifiersEncoder = paramEncoder.CustomModifiers();
 
                 if (paramType.GetOptionalCustomModifiers() is Type[] paramModOpts)
+                {
+                    Array.Reverse(paramModOpts);
                     WriteCustomModifiers(paramModifiersEncoder, paramModOpts, isOptional: true, module);
+                }
 
                 if (paramType.GetRequiredCustomModifiers() is Type[] paramModReqs)
+                {
+                    Array.Reverse(paramModReqs);
                     WriteCustomModifiers(paramModifiersEncoder, paramModReqs, isOptional: false, module);
+                }
 
                 WriteSignatureForType(paramEncoder.Type(), paramType, module);
             }

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderAPIsTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderAPIsTests.cs
@@ -633,8 +633,8 @@ namespace System.Reflection.Emit.Tests
                     Type[] par0RequiredMods = allModMethod.GetParameters()[0].GetRequiredCustomModifiers();
                     Type[] par0OptionalMods = allModMethod.GetParameters()[0].GetOptionalCustomModifiers();
                     Assert.Equal(2, returnReqMods.Length);
-                    Assert.Equal(mlc.CoreAssembly.GetType(typeof(short).FullName), returnReqMods[0]);
-                    Assert.Equal(mlc.CoreAssembly.GetType(typeof(int).FullName), returnReqMods[1]);
+                    Assert.Equal(mlc.CoreAssembly.GetType(typeof(int).FullName), returnReqMods[0]);
+                    Assert.Equal(mlc.CoreAssembly.GetType(typeof(short).FullName), returnReqMods[1]);
                     Assert.Equal(1, returnOptMods.Length);
                     Assert.Equal(mlc.CoreAssembly.GetType(typeof(Version).FullName), returnOptMods[0]);
                     Assert.Equal(cmodsReq1.Length, par0RequiredMods.Length);

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderAPIsTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderAPIsTests.cs
@@ -638,8 +638,8 @@ namespace System.Reflection.Emit.Tests
                     Assert.Equal(1, returnOptMods.Length);
                     Assert.Equal(mlc.CoreAssembly.GetType(typeof(Version).FullName), returnOptMods[0]);
                     Assert.Equal(cmodsReq1.Length, par0RequiredMods.Length);
-                    Assert.Equal(mlc.CoreAssembly.GetType(cmodsReq1[1].FullName), par0RequiredMods[0]);
-                    Assert.Equal(mlc.CoreAssembly.GetType(cmodsReq1[0].FullName), par0RequiredMods[1]);
+                    Assert.Equal(mlc.CoreAssembly.GetType(cmodsReq1[0].FullName), par0RequiredMods[0]);
+                    Assert.Equal(mlc.CoreAssembly.GetType(cmodsReq1[1].FullName), par0RequiredMods[1]);
                     Assert.Equal(cmodsOpt1.Length, par0OptionalMods.Length);
                     Assert.Equal(mlc.CoreAssembly.GetType(cmodsOpt1[0].FullName), par0OptionalMods[0]);
                     Assert.Equal(cmodsReq2.Length, allModMethod.GetParameters()[1].GetRequiredCustomModifiers().Length);

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderTests.cs
@@ -864,7 +864,7 @@ namespace System.Reflection.Emit.Tests
         }
 
         [Fact]
-        public void ConsumeFunctionPointerFields()
+        public void ConsumeFunctionPointerMembers()
         {
             // public unsafe class Container
             // {
@@ -915,16 +915,23 @@ namespace System.Reflection.Emit.Tests
             MethodBuilder mainMethod = programType.DefineMethod("Main", MethodAttributes.Public | MethodAttributes.Static);
             mainMethod.SetReturnType(typeof(int));
             ILGenerator il = mainMethod.GetILGenerator();
-            il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerFields).GetField("field1"));
+            il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerMembers).GetField("field1"));
             il.Emit(OpCodes.Pop);
-            // References to fields with unmanaged calling convention are broken
-            // [ActiveIssue("https://github.com/dotnet/runtime/issues/120909")]
-            // il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerFields).GetField("field2"));
-            // il.Emit(OpCodes.Pop);
-            // il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerFields).GetField("field3"));
-            // il.Emit(OpCodes.Pop);
-            // il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerFields).GetField("field4"));
-            // il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerMembers).GetField("field2"));
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerMembers).GetField("field3"));
+            il.Emit(OpCodes.Pop);
+            //il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerMembers).GetField("field4"));
+            //il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Call, typeof(ClassWithFunctionPointerMembers).GetMethod("Method1"));
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Call, typeof(ClassWithFunctionPointerMembers).GetMethod("Method2"));
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Call, typeof(ClassWithFunctionPointerMembers).GetMethod("Method3"));
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Call, typeof(ClassWithFunctionPointerMembers).GetMethod("Method4"));
+            il.Emit(OpCodes.Call, typeof(ClassWithFunctionPointerMembers).GetMethod("Method5"));
+            il.Emit(OpCodes.Pop);
             il.Emit(OpCodes.Call, assembly1FromDisk.GetType("Container").GetMethod("Init"));
             il.Emit(OpCodes.Ldc_I4_2);
             il.Emit(OpCodes.Ldc_I4_3);
@@ -989,11 +996,17 @@ namespace System.Reflection.Emit.Tests
         public byte field2;
     }
 
-    public unsafe class ClassWithFunctionPointerFields
+    public unsafe class ClassWithFunctionPointerMembers
     {
-        public static delegate*<ClassWithFunctionPointerFields> field1;
+        public static delegate*<ClassWithFunctionPointerMembers> field1;
         public static delegate* unmanaged<int> field2;
         public static delegate* unmanaged[Cdecl]<Guid> field3;
         public static delegate* unmanaged[Cdecl, SuppressGCTransition]<Vector<int>, Vector<int>> field4;
+
+        public static delegate*<int> Method1() => null;
+        public static delegate* unmanaged<string> Method2() => null;
+        public static delegate* unmanaged[Fastcall]<double> Method3() => null;
+        public static delegate* unmanaged[Cdecl]<delegate* unmanaged<int>, Guid> Method4() => null;
+        public static delegate* unmanaged[Cdecl]<int> Method5(delegate* unmanaged[Cdecl]<delegate* unmanaged<int>, Guid> funcPtr) => null;
     }
 }

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderTests.cs
@@ -921,8 +921,10 @@ namespace System.Reflection.Emit.Tests
             il.Emit(OpCodes.Pop);
             il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerMembers).GetField("field3"));
             il.Emit(OpCodes.Pop);
-            //il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerMembers).GetField("field4"));
-            //il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerMembers).GetField("field4"));
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerMembers).GetField("field5"));
+            il.Emit(OpCodes.Pop);
             il.Emit(OpCodes.Call, typeof(ClassWithFunctionPointerMembers).GetMethod("Method1"));
             il.Emit(OpCodes.Pop);
             il.Emit(OpCodes.Call, typeof(ClassWithFunctionPointerMembers).GetMethod("Method2"));
@@ -931,6 +933,10 @@ namespace System.Reflection.Emit.Tests
             il.Emit(OpCodes.Pop);
             il.Emit(OpCodes.Call, typeof(ClassWithFunctionPointerMembers).GetMethod("Method4"));
             il.Emit(OpCodes.Call, typeof(ClassWithFunctionPointerMembers).GetMethod("Method5"));
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Ldsfld, typeof(GenericClassWithFunctionPointerMembers<int>).GetField("Field"));
+            il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Call, typeof(GenericClassWithFunctionPointerMembers<Guid>).GetMethod("Method").MakeGenericMethod(typeof(string)));
             il.Emit(OpCodes.Pop);
             il.Emit(OpCodes.Call, assembly1FromDisk.GetType("Container").GetMethod("Init"));
             il.Emit(OpCodes.Ldc_I4_2);
@@ -1002,11 +1008,18 @@ namespace System.Reflection.Emit.Tests
         public static delegate* unmanaged<int> field2;
         public static delegate* unmanaged[Cdecl]<Guid> field3;
         public static delegate* unmanaged[Cdecl, SuppressGCTransition]<Vector<int>, Vector<int>> field4;
+        public static List<delegate* unmanaged[Stdcall]<long>*[]> field5;
 
         public static delegate*<int> Method1() => null;
         public static delegate* unmanaged<string> Method2() => null;
         public static delegate* unmanaged[Fastcall]<double> Method3() => null;
         public static delegate* unmanaged[Cdecl]<delegate* unmanaged<int>, Guid> Method4() => null;
         public static delegate* unmanaged[Cdecl]<int> Method5(delegate* unmanaged[Cdecl]<delegate* unmanaged<int>, Guid> funcPtr) => null;
+    }
+
+    public unsafe class GenericClassWithFunctionPointerMembers<T>
+    {
+        public static delegate* unmanaged[Cdecl]<T> Field;
+        public static delegate* unmanaged[Fastcall, MemberFunction]<T, U> Method<U>() => null;
     }
 }

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderTests.cs
@@ -864,6 +864,7 @@ namespace System.Reflection.Emit.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/2383", TestRuntimes.Mono)]
         public void ConsumeFunctionPointerMembers()
         {
             // public unsafe class Container

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderTests.cs
@@ -1008,7 +1008,7 @@ namespace System.Reflection.Emit.Tests
         public static delegate* unmanaged<int> field2;
         public static delegate* unmanaged[Cdecl]<Guid> field3;
         public static delegate* unmanaged[Cdecl, SuppressGCTransition]<Vector<int>, Vector<int>> field4;
-        public static List<delegate* unmanaged[Stdcall]<long>*[]> field5;
+        public static List<delegate* unmanaged[Stdcall, MemberFunction, SuppressGCTransition]<long>*[]> field5;
 
         public static delegate*<int> Method1() => null;
         public static delegate* unmanaged<string> Method2() => null;


### PR DESCRIPTION
This fixes #120909.

There is one small issue with the tests when the calling conventions are encoded as modopts: The ``PersistedAssemblyBuilder`` from the test specifies ``System.Private.CoreLib`` as its core assembly, which prevents the runtime from matching the signatures with the ones defined in C# (where the modifier types are from ``System.Runtime``). This is seemingly not an issue with parameter types, but only with modifiers. @jkotas or anyone else, do you have an idea how to fix this? If the AssemblyBuilder used the same core assembly as the C# program, it should work. For now, I have commented out this specific field reference.