### PR TITLE
Move JIT/HardwareIntrinsics tests to run in Pri1

### DIFF
--- a/eng/pipelines/coreclr/hardware-intrinsics.yml
+++ b/eng/pipelines/coreclr/hardware-intrinsics.yml
@@ -1,0 +1,141 @@
+trigger: none
+pr:
+  branches:
+    include:
+    - main
+  paths:
+    include:
+    - eng/pipelines/**
+    - src/coreclr/jit/**
+    - src/tests/Common/GenerateHWIntrinsicTests/**
+    - src/tests/JIT/HardwareIntrinsics/**
+
+variables:
+  - template: /eng/pipelines/common/variables.yml
+
+extends:
+  template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
+  parameters:
+    isOfficialBuild: false
+    stages:
+    - stage: Build
+      jobs:
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          buildConfig: Release
+          platforms:
+            - windows_x86
+            - windows_x64
+          variables:
+            - name: timeoutPerTestInMinutes
+              value: 60
+            - name: timeoutPerTestCollectionInMinutes
+              value: 180
+          jobParameters:
+            testGroup: outerloop
+            nameSuffix: CoreCLR
+            buildArgs: -s clr+libs -c $(_BuildConfig)
+            timeoutInMinutes: 360
+            postBuildSteps:
+              - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+                parameters:
+                  creator: dotnet-bot
+                  testBuildArgs: 'tree JIT/HardwareIntrinsics'
+                  testRunNamePrefixSuffix: CoreCLR
+            extraVariablesTemplates:
+              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+                parameters:
+                  testGroup: outerloop
+
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          buildConfig: Release
+          platforms:
+            - linux_arm
+            - linux_x64
+            - osx_arm64
+          variables:
+            - name: timeoutPerTestInMinutes
+              value: 60
+            - name: timeoutPerTestCollectionInMinutes
+              value: 180
+          jobParameters:
+            testGroup: outerloop
+            nameSuffix: CoreCLR
+            buildArgs: -s clr+libs -c $(_BuildConfig)
+            timeoutInMinutes: 360
+            postBuildSteps:
+              - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+                parameters:
+                  creator: dotnet-bot
+                  testBuildArgs: '-tree:JIT/HardwareIntrinsics'
+                  testRunNamePrefixSuffix: CoreCLR
+            extraVariablesTemplates:
+              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+                parameters:
+                  testGroup: outerloop
+
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          buildConfig: Release
+          platforms:
+            - windows_x86
+            - windows_x64
+          variables:
+            - name: timeoutPerTestInMinutes
+              value: 60
+            - name: timeoutPerTestCollectionInMinutes
+              value: 180
+          jobParameters:
+            testGroup: outerloop
+            nameSuffix: NativeAOT
+            buildArgs: -s clr.aot+libs.native+libs.sfx -c $(_BuildConfig)
+            timeoutInMinutes: 360
+            postBuildSteps:
+              - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+                parameters:
+                  creator: dotnet-bot
+                  testBuildArgs: 'tree JIT/HardwareIntrinsics'
+                  testRunNamePrefixSuffix: NativeAOT
+                  nativeAotTest: true
+            extraVariablesTemplates:
+              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+                parameters:
+                  testGroup: outerloop
+
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          buildConfig: Release
+          platforms:
+            - linux_arm
+            - linux_x64
+            - osx_arm64
+          variables:
+            - name: timeoutPerTestInMinutes
+              value: 60
+            - name: timeoutPerTestCollectionInMinutes
+              value: 180
+          jobParameters:
+            testGroup: outerloop
+            nameSuffix: NativeAOT
+            buildArgs: -s clr.aot+libs.native+libs.sfx -c $(_BuildConfig)
+            timeoutInMinutes: 360
+            postBuildSteps:
+              - template: /eng/pipelines/common/templates/runtimes/build-runtime-tests-and-send-to-helix.yml
+                parameters:
+                  creator: dotnet-bot
+                  testBuildArgs: '-tree:JIT/HardwareIntrinsics'
+                  testRunNamePrefixSuffix: NativeAOT
+                  nativeAotTest: true
+            extraVariablesTemplates:
+              - template: /eng/pipelines/common/templates/runtimes/test-variables.yml
+                parameters:
+                  testGroup: outerloop

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -604,7 +604,7 @@ extends:
               - template: /eng/pipelines/coreclr/nativeaot-post-build-steps.yml
                 parameters:
                   creator: dotnet-bot
-                  testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;JIT/HardwareIntrinsics;" /p:BuildNativeAotFrameworkObjects=true'
+                  testBuildArgs: 'nativeaot tree ";nativeaot;Loader;Interop;" /p:BuildNativeAotFrameworkObjects=true'
                   liveLibrariesBuildConfig: Release
                   testRunNamePrefixSuffix: NativeAOT_$(_BuildConfig)
             extraVariablesTemplates:

--- a/src/tests/JIT/HardwareIntrinsics/Directory.Build.props
+++ b/src/tests/JIT/HardwareIntrinsics/Directory.Build.props
@@ -9,5 +9,6 @@
   <PropertyGroup>
     <RunAnalyzers>true</RunAnalyzers>
     <EnableNETAnalyzers>false</EnableNETAnalyzers>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
These tests take a very long time to build on CI (I've seen upwards of 10 minutes) because they generate millions of lines of test code and then build it, pegging the IO of the machine.

As far as I understand, most of the interesting cases only happen on outerloop runs (primarily in the jitstress-isas- pipelines), which already run all pri0 and pri1 tests. As a result, I'd like to move these tests out to Pri1 to help speed up CI for those of us that don't work on these tests.

We can also add another pipeline that runs the standard CI test modes with just these tests that triggers on a smaller subset of directories if we feel that we want said additional coverage.