### PR TITLE
Capture PDBs in `--make-repro-path`

### DIFF
--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -321,7 +321,8 @@ namespace System.CommandLine
                             // The compiler probes for .pdb files next to input assemblies. For simplicity, just try to look
                             // for PDB next to any file we package.
                             string originalPdbPath = Path.ChangeExtension(originalPath, "pdb");
-                            if (File.Exists(originalPdbPath))
+                            if (!string.Equals(originalPath, originalPdbPath, StringComparison.InvariantCultureIgnoreCase)
+                                && File.Exists(originalPdbPath))
                             {
                                 archive.CreateEntryFromFile(originalPdbPath, Path.ChangeExtension(reproPackagePath, "pdb"));
                             }

--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -311,9 +311,21 @@ namespace System.CommandLine
                         string reproFileDir = prefix + originalToReproPackageFileName.Count.ToString() + Path.DirectorySeparatorChar;
                         reproPackagePath = Path.Combine(reproFileDir, Path.GetFileName(originalPath));
                         if (!input)
+                        {
                             archive.CreateEntry(reproFileDir); // for outputs just create output directory
+                        }
                         else
+                        {
                             archive.CreateEntryFromFile(originalPath, reproPackagePath);
+
+                            // The compiler probes for .pdb files next to input assemblies. For simplicity, just try to look
+                            // for PDB next to any file we package.
+                            string originalPdbPath = Path.ChangeExtension(originalPath, "pdb");
+                            if (File.Exists(originalPdbPath))
+                            {
+                                archive.CreateEntryFromFile(originalPdbPath, Path.ChangeExtension(reproPackagePath, "pdb"));
+                            }
+                        }
                         originalToReproPackageFileName.Add(originalPath, reproPackagePath);
 
                         return reproPackagePath;


### PR DESCRIPTION
Repro for dotnet/roslyn#80952 was somewhat harder to obtain because we don't pack PDBs into the repro package (they are not command line arguments and the compiler looks for them next to the assembly).

This is a simple change to just look for .pdb files next to the files we're packing.

Cc @dotnet/ilc-contrib 