### PR TITLE
Fix static interface dispatch issue in the managed type system

### DIFF
--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -484,7 +484,9 @@ namespace ILCompiler
                     }
                 }
 
-                Debug.Assert(potentialMatchingInterfaces != 0);
+                Debug.Assert(potentialMatchingInterfaces != 0
+                    // We didn't consider default-implemented methods above and we're fine taking the !(potentialMatchingInterfaces > 1) path below.
+                    || (isStaticVirtualMethod && !interfaceMethod.IsAbstract));
 
                 if (potentialMatchingInterfaces > 1)
                 {

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/SimpleStaticVirtual.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/SimpleStaticVirtual.cs
@@ -8,6 +8,7 @@ namespace SimpleStaticVirtual
     public class Tests
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/122863", TestRuntimes.Mono)]
         public static void TestEntryPoint()
         {
             Assert.Equal(nameof(IGetter), Get<IGetter>());

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/SimpleStaticVirtual.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/SimpleStaticVirtual.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace SimpleStaticVirtual
+{
+    public class Tests
+    {
+        [Fact]
+        public static void TestEntryPoint()
+        {
+            Assert.Equal(nameof(IGetter), Get<IGetter>());
+            Assert.Equal("Object", GetVariant<IGetter<object>, string>());
+        }
+
+        static string Get<T>() where T : IGetter => T.Get();
+        static string GetVariant<T, U>() where T : IGetter<U> => T.Get();
+    }
+
+    interface IGetter
+    {
+        static virtual string Get() => nameof(IGetter);
+    }
+
+    interface IGetter<in T>
+    {
+        static virtual string Get() => typeof(T).Name;
+    }
+}

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/SimpleStaticVirtual.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/SimpleStaticVirtual.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Ran into this in an Android MAUI app. We don't hit this codepath at runtime, probably, but the compiler was hitting "invalid IL" codepaths and recovering from this.

Cc @dotnet/ilc-contrib 