### PR TITLE
Add missing TestLibrary reference for BuildAllTestsAsStandalone

### DIFF
--- a/src/tests/JIT/jit64/opt/cse/HugeArray1.csproj
+++ b/src/tests/JIT/jit64/opt/cse/HugeArray1.csproj
@@ -5,5 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="HugeArray1.cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/opt/cse/hugeSimpleExpr1.csproj
+++ b/src/tests/JIT/jit64/opt/cse/hugeSimpleExpr1.csproj
@@ -5,5 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="hugeSimpleExpr1.cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/jit64/opt/rngchk/ArrayWithThread_o.csproj
+++ b/src/tests/JIT/jit64/opt/rngchk/ArrayWithThread_o.csproj
@@ -5,5 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ArrayWithThread.cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes test build fails like this:
```
/runtime/artifacts/tests/coreclr/obj/linux.riscv64.Checked/Managed/JIT/jit64/opt/rngchk/ArrayWithThread_o/XUnitWrapperGenerator/XUnitWrapperGenerator.XUnitWrapperGenerator/SimpleRunner.g.cs(7,18): error CS0103: The name 'TestLibrary' does not exist in the current context [/runtime/src/tests/JIT/jit64/opt/rngchk/ArrayWithThread_o.csproj] [/runtime/src/tests/build.proj]
```