### PR TITLE
Fix missing Main method in Runtime_8980 test

### DIFF
--- a/src/tests/JIT/Regression/JitBlue/Runtime_8980/Runtime_8980.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_8980/Runtime_8980.cs
@@ -13,8 +13,9 @@ using Xunit;
 
 public class Runtime_8980
 {
+    // Use the [Fact] attribute directly on Main since we can't run the generator on this project.
     [Fact]
-    public static int TestEntryPoint()
+    public static int Main()
     {
         // Large dictionary with ValueTuple values using collection initializer
         var dict = new Dictionary<int, (double lat, double lon)>


### PR DESCRIPTION
Fix test build with `BuildAllTestsAsStandalone`, regression after #121120

Fixed similar to `src/tests/JIT/Regression/JitBlue/GitHub_10215/GitHub_10215.cs`