### PR TITLE
Add `--no-optimistic-instruction-set` option for crossgen2.

### DIFF
--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -17,7 +17,7 @@ namespace System.CommandLine
     internal static partial class Helpers
     {
         public static InstructionSetSupport ConfigureInstructionSetSupport(string instructionSet, int maxVectorTBitWidth, bool isVectorTOptimistic, TargetArchitecture targetArchitecture, TargetOS targetOS,
-            string mustNotBeMessage, string invalidImplicationMessage, Logger logger, bool optimizingForSize, bool isReadyToRun)
+            string mustNotBeMessage, string invalidImplicationMessage, Logger logger, bool noOptimisticInstructionSet, bool optimizingForSize, bool isReadyToRun)
         {
             InstructionSetSupportBuilder instructionSetSupportBuilder = new(targetArchitecture);
 
@@ -90,7 +90,7 @@ namespace System.CommandLine
             // Whether to allow optimistically expanding the instruction sets beyond what was specified.
             // We seed this from optimizingForSize - if we're size-optimizing, we don't want to unnecessarily
             // compile both branches of IsSupported checks.
-            bool allowOptimistic = !optimizingForSize;
+            bool allowOptimistic = !noOptimisticInstructionSet && !optimizingForSize;
 
             bool throttleAvx512 = false;
 

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -116,6 +116,8 @@ namespace ILCompiler
             new("--parallelism") { CustomParser = MakeParallelism, DefaultValueFactory = MakeParallelism, Description = "Maximum number of threads to use during compilation" };
         public Option<string> InstructionSet { get; } =
             new("--instruction-set") { Description = "Instruction set to allow or disallow" };
+        public Option<bool> NoOptimisticInstructionSet { get; } =
+            new("--no-optimistic-instruction-set") { Description = "Disallow optimistic instruction set" };
         public Option<int> MaxVectorTBitWidth { get; } =
             new("--max-vectort-bitwidth") { Description = "Maximum width, in bits, that Vector<T> is allowed to be" };
         public Option<string> Guard { get; } =
@@ -240,6 +242,7 @@ namespace ILCompiler
             Options.Add(RuntimeKnobs);
             Options.Add(Parallelism);
             Options.Add(InstructionSet);
+            Options.Add(NoOptimisticInstructionSet);
             Options.Add(MaxVectorTBitWidth);
             Options.Add(Guard);
             Options.Add(Dehydrate);

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -108,7 +108,7 @@ namespace ILCompiler
             TargetOS targetOS = Get(_command.TargetOS);
             InstructionSetSupport instructionSetSupport = Helpers.ConfigureInstructionSetSupport(Get(_command.InstructionSet), Get(_command.MaxVectorTBitWidth), isVectorTOptimistic, targetArchitecture, targetOS,
                 "Unrecognized instruction set {0}", "Unsupported combination of instruction sets: {0}/{1}", logger,
-                optimizingForSize: _command.OptimizationMode == OptimizationMode.PreferSize,
+                Get(_command.NoOptimisticInstructionSet), optimizingForSize: _command.OptimizationMode == OptimizationMode.PreferSize,
                 isReadyToRun: false);
 
             string systemModuleName = Get(_command.SystemModuleName);

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -24,6 +24,8 @@ namespace ILCompiler
             new("--reference", "-r") { CustomParser = result => Helpers.BuildPathDictionary(result.Tokens, false), DefaultValueFactory = result => Helpers.BuildPathDictionary(result.Tokens, false), Description = SR.ReferenceFiles };
         public Option<string> InstructionSet { get; } =
             new("--instruction-set") { Description = SR.InstructionSets };
+        public Option<bool> NoOptimisticInstructionSet { get; } =
+            new("--no-optimistic-instruction-set") { Description = SR.NoOptimisticInstructionSets };
         public Option<int> MaxVectorTBitWidth { get; } =
             new("--max-vectort-bitwidth") { Description = SR.MaxVectorTBitWidths };
         public Option<string[]> MibcFilePaths { get; } =
@@ -160,6 +162,7 @@ namespace ILCompiler
             Options.Add(UnrootedInputFilePaths);
             Options.Add(ReferenceFilePaths);
             Options.Add(InstructionSet);
+            Options.Add(NoOptimisticInstructionSet);
             Options.Add(MaxVectorTBitWidth);
             Options.Add(MibcFilePaths);
             Options.Add(OutputFilePath);

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -87,7 +87,7 @@ namespace ILCompiler
             TargetOS targetOS = Get(_command.TargetOS);
             InstructionSetSupport instructionSetSupport = Helpers.ConfigureInstructionSetSupport(Get(_command.InstructionSet), Get(_command.MaxVectorTBitWidth), isVectorTOptimistic, targetArchitecture, targetOS,
                 SR.InstructionSetMustNotBe, SR.InstructionSetInvalidImplication, logger,
-                optimizingForSize: _command.OptimizationMode == OptimizationMode.PreferSize,
+                Get(_command.NoOptimisticInstructionSet), optimizingForSize: _command.OptimizationMode == OptimizationMode.PreferSize,
                 isReadyToRun: true);
             SharedGenericsMode genericsMode = SharedGenericsMode.CanonicalReferenceTypes;
             var targetDetails = new TargetDetails(targetArchitecture, targetOS, Crossgen2RootCommand.IsArmel ? TargetAbi.NativeAotArmel : TargetAbi.NativeAot, instructionSetSupport.GetVectorTSimdVector());

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -174,6 +174,9 @@
   <data name="InstructionSets" xml:space="preserve">
     <value>Instruction set(s) to use for compilation</value>
   </data>
+  <data name="NoOptimisticInstructionSets" xml:space="preserve">
+    <value>Disallow optimistic instruction set(s) to use for compilation</value>
+  </data>
   <data name="InstructionSetMustNotBe" xml:space="preserve">
     <value>Instruction set '{0}' is not valid for this architecture and operating system</value>
   </data>


### PR DESCRIPTION
Could be used for compile on x64 host for arm64 target (for example, during Tizen OS image creation).

CC @gbalykov 