### PR TITLE
[wasm][coreclr] Implement IsInCalleesFrames

### DIFF
--- a/src/coreclr/inc/regdisp.h
+++ b/src/coreclr/inc/regdisp.h
@@ -358,6 +358,7 @@ struct REGDISPLAY : public REGDISPLAY_BASE {
 
 // This function tells us if the given stack pointer is in one of the frames of the functions called by the given frame
 inline BOOL IsInCalleesFrames(REGDISPLAY *display, LPVOID stackPointer) {
+    LIMITED_METHOD_CONTRACT;
     return stackPointer < (LPVOID)(display->SP);
 }
 

--- a/src/coreclr/inc/regdisp.h
+++ b/src/coreclr/inc/regdisp.h
@@ -358,8 +358,7 @@ struct REGDISPLAY : public REGDISPLAY_BASE {
 
 // This function tells us if the given stack pointer is in one of the frames of the functions called by the given frame
 inline BOOL IsInCalleesFrames(REGDISPLAY *display, LPVOID stackPointer) {
-    _ASSERTE("IsInCalleesFrames is not implemented on wasm");
-    return FALSE;
+    return stackPointer < (LPVOID)(display->SP);
 }
 
 #else // none of the above processors


### PR DESCRIPTION
This fixes `Thread::MakeStackwalkerCallback` and thus also `AssemblyNative_GetExecutingAssembly`.

Fixes https://github.com/dotnet/runtime/issues/120905