### PR TITLE
Update our local copy of the Crossgen2 tasks from the SDK to the most recent copy on dotnet/sdk's main

### DIFF
--- a/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/BuildErrorException.cs
+++ b/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/BuildErrorException.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Globalization;
 
 namespace Microsoft.NET.Build.Tasks
@@ -10,7 +9,7 @@ namespace Microsoft.NET.Build.Tasks
     /// Represents an error that is neither avoidable in all cases nor indicative of a bug in this library.
     /// It will be logged as a plain build error without the exception type or stack.
     /// </summary>
-    internal sealed class BuildErrorException : Exception
+    internal class BuildErrorException : Exception
     {
         public BuildErrorException()
         {

--- a/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/LogAdapter.cs
+++ b/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/LogAdapter.cs
@@ -1,26 +1,18 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    internal sealed class LogAdapter : Logger
+    internal sealed class LogAdapter(TaskLoggingHelper taskLogger) : Logger
     {
-        private TaskLoggingHelper _taskLogger;
-
-        public LogAdapter(TaskLoggingHelper taskLogger)
-        {
-            _taskLogger = taskLogger;
-        }
-
         protected override void LogCore(in Message message)
         {
             switch (message.Level)
             {
                 case MessageLevel.Error:
-                    _taskLogger.LogError(
+                    taskLogger.LogError(
                         subcategory: default,
                         errorCode: message.Code,
                         helpKeyword: default,
@@ -33,7 +25,7 @@ namespace Microsoft.NET.Build.Tasks
                     break;
 
                 case MessageLevel.Warning:
-                    _taskLogger.LogWarning(
+                    taskLogger.LogWarning(
                         subcategory: default,
                         warningCode: message.Code,
                         helpKeyword: default,
@@ -53,12 +45,12 @@ namespace Microsoft.NET.Build.Tasks
                         // use shorter overload when there is no code and no file. Otherwise, msbuild
                         // will display:
                         //
-                        // <project file>(<line>,<colunmn>): message : <text>
-                        _taskLogger.LogMessage(message.Level.ToImportance(), message.Text);
+                        // <project file>(<line>,<column>): message : <text>
+                        taskLogger.LogMessage(message.Level.ToImportance(), message.Text);
                     }
                     else
                     {
-                        _taskLogger.LogMessage(
+                        taskLogger.LogMessage(
                             subcategory: default,
                             code: message.Code,
                             helpKeyword: default,

--- a/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/Logger.cs
+++ b/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/Logger.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Diagnostics;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -40,8 +39,8 @@ namespace Microsoft.NET.Build.Tasks
     /// Results in LogCore getting a Message instance with Code="NETSDK1234"
     /// and Text="Something is wrong."
     ///
-    /// Pattern inspired by <se cref="TaskLoggingHelper.LogErrorWithCodeFromResources"/>,
-    /// but retains completion via generated <see cref="Strings"/> instead of
+    /// Pattern inspired by TaskLoggingHelper.LogErrorWithCodeFromResources,
+    /// but retains completion via generated Strings instead of
     /// passing resource keys by name.
     ///
     /// All actual logging is deferred to subclass in <see cref="LogCore"/>,
@@ -65,9 +64,6 @@ namespace Microsoft.NET.Build.Tasks
         public void LogError(string format, params string[] args)
             => Log(CreateMessage(MessageLevel.Error, format, args));
 
-        public void LogNonSdkError(string code, string format, params string[] args)
-            => Log(new Message(MessageLevel.Error, string.Format(format, args), code));
-
         public void Log(in Message message)
         {
             HasLoggedErrors |= message.Level == MessageLevel.Error;
@@ -78,7 +74,7 @@ namespace Microsoft.NET.Build.Tasks
 
         private static Message CreateMessage(MessageLevel level, string format, string[] args)
         {
-            string code;
+            string? code;
 
             if (format.Length >= 12
                 && format[0] == 'N'
@@ -111,7 +107,7 @@ namespace Microsoft.NET.Build.Tasks
         }
 
         [Conditional("DEBUG")]
-        private static void DebugThrowMissingOrIncorrectCode(string code, string message, MessageLevel level)
+        private static void DebugThrowMissingOrIncorrectCode(string? code, string message, MessageLevel level)
         {
             // NB: This is not localized because it represents a bug in our code base, not a user error.
             //     To log message with external codes, use Log.Log(in Message, string[]) directly.
@@ -130,11 +126,14 @@ namespace Microsoft.NET.Build.Tasks
                     break;
 
                 default:
+
                     if (code != null)
                     {
-                       throw new ArgumentException(
-                           "Message is prefixed with NETSDK error, but error codes should not be used for informational messages: "
-                           + $"{code}:{message}");
+                        //  Previously we would throw an error here, but that makes it hard to allow errors to be turned off but still displayed as messages
+                        //  (which ResolveApppHosts does).  So let's just let messages have NETSDK error codes if they want to also.
+                        //throw new ArgumentException(
+                        //    "Message is prefixed with NETSDK error, but error codes should not be used for informational messages: "
+                        //    + $"{code}:{message}");
                     }
                     break;
             }

--- a/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/Message.cs
+++ b/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/Message.cs
@@ -6,15 +6,15 @@ namespace Microsoft.NET.Build.Tasks
     internal readonly struct Message
     {
         public readonly MessageLevel Level;
-        public readonly string Code;
+        public readonly string? Code;
         public readonly string Text;
-        public readonly string File;
+        public readonly string? File;
 
         public Message(
             MessageLevel level,
             string text,
-            string code = default,
-            string file = default)
+            string? code = default,
+            string? file = default)
         {
             Level = level;
             Code = code;

--- a/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/MessageLevel.cs
+++ b/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/MessageLevel.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using Microsoft.Build.Framework;
 
 namespace Microsoft.NET.Build.Tasks

--- a/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/MetadataKeys.cs
+++ b/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/MetadataKeys.cs
@@ -27,7 +27,6 @@ namespace Microsoft.NET.Build.Tasks
         public const string FrameworkVersion = "FrameworkVersion";
         public const string IsTrimmable = "IsTrimmable";
         public const string RuntimeFrameworkName = "RuntimeFrameworkName";
-        public const string RuntimePackRuntimeIdentifiers = "RuntimePackRuntimeIdentifiers";
 
         // SDK Metadata
         public const string SDKPackageItemSpec = "SDKPackageItemSpec";
@@ -83,11 +82,16 @@ namespace Microsoft.NET.Build.Tasks
 
         // Targeting packs
         public const string PackageConflictPreferredPackages = "PackageConflictPreferredPackages";
+        public const string RuntimePackRuntimeIdentifiers = "RuntimePackRuntimeIdentifiers";
+        public const string RuntimePackExcludedRuntimeIdentifiers = "RuntimePackExcludedRuntimeIdentifiers";
 
         // Runtime packs
         public const string DropFromSingleFile = "DropFromSingleFile";
         public const string RuntimePackLabels = "RuntimePackLabels";
         public const string AdditionalFrameworkReferences = "AdditionalFrameworkReferences";
+
+        //  Apphost packs
+        public const string ExcludedRuntimeIdentifiers = "ExcludedRuntimeIdentifiers";
 
         // Content files
         public const string PPOutputPath = "PPOutputPath";
@@ -125,5 +129,15 @@ namespace Microsoft.NET.Build.Tasks
         public const string IsVersion5 = "IsVersion5";
         public const string CreateCompositeImage = "CreateCompositeImage";
         public const string PerfmapFormatVersion = "PerfmapFormatVersion";
+
+        // Debug symbols
+        public const string RelatedProperty = "related";
+        public const string XmlExtension = ".xml";
+        public const string XmlFilePath = "XmlFilePath";
+        public const string PdbExtension = ".pdb";
+        public const string PdbFilePath = "PdbFilePath";
+
+        // Dependencies design time
+        public const string Resolved = "Resolved";
     }
 }

--- a/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/RuntimeGraphCache.cs
+++ b/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/RuntimeGraphCache.cs
@@ -1,16 +1,14 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
+#nullable disable
+
 using Microsoft.Build.Framework;
 using NuGet.RuntimeModel;
 
 namespace Microsoft.NET.Build.Tasks
 {
-    internal sealed class RuntimeGraphCache
+    internal class RuntimeGraphCache
     {
         private IBuildEngine4 _buildEngine;
         private Logger _log;

--- a/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/TaskBase.cs
+++ b/src/tasks/Crossgen2Tasks/CommonFilePulledFromSdkRepo/TaskBase.cs
@@ -1,19 +1,17 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using Microsoft.Build.Utilities;
-using Microsoft.Build.Framework;
-using System.Collections.Generic;
 using System.Globalization;
+using Microsoft.Build.Framework;
+using Task = Microsoft.Build.Utilities.Task;
 
 namespace Microsoft.NET.Build.Tasks
 {
     public abstract class TaskBase : Task
     {
-        private Logger _logger;
+        private Logger? _logger;
 
-        internal TaskBase(Logger logger = null)
+        internal TaskBase(Logger? logger = null)
         {
             _logger = logger;
         }
@@ -22,7 +20,10 @@ namespace Microsoft.NET.Build.Tasks
         {
             get
             {
-                _logger ??= new LogAdapter(base.Log);
+                if (_logger == null)
+                {
+                    _logger = new LogAdapter(base.Log);
+                }
 
                 return _logger;
             }

--- a/src/tasks/Crossgen2Tasks/Crossgen2Tasks.csproj
+++ b/src/tasks/Crossgen2Tasks/Crossgen2Tasks.csproj
@@ -3,8 +3,21 @@
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <OutputType>Library</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>$(NoWarn),CA1050</NoWarn>
+    <NoWarn>$(NoWarn);CA1050;CA1852;CA1861;CA2249;IDE0059;IDE0060;IDE0074</NoWarn>
+    <Nullable>annotations</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <!--
+      This repository generally does not use global usings, but the SDK does.
+      Use the minimum set of usings required to avoid modifying the copied code.
+    -->
+    <Using Include="System" />
+    <Using Include="System.Collections.Generic" />
+    <Using Include="System.IO" />
+    <Using Include="System.Linq" />
+    <Using Include="System.Runtime.InteropServices" />
+    <Using Include="System.Text" />
+  </ItemGroup>
   <ItemGroup>
     <!-- Bring in references for these assemblies which are provided by the SDK.
          We do this to avoid bringing the package closure for assemblies we don't use here. -->

--- a/src/tasks/Crossgen2Tasks/Microsoft.NET.CrossGen.targets
+++ b/src/tasks/Crossgen2Tasks/Microsoft.NET.CrossGen.targets
@@ -18,6 +18,7 @@ Copyright (c) .NET Foundation. All rights reserved.
   -->
   <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and '$(_TargetFrameworkVersionWithoutV)' >= '3.0'">
     <PublishReadyToRunUseCrossgen2 Condition="'$(_TargetFrameworkVersionWithoutV)' >= '6.0'">true</PublishReadyToRunUseCrossgen2>
+    <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == '' and '$(PublishSingleFile)' == 'true'  and '$(PublishReadyToRun)' == 'true' and '$(_TargetFrameworkVersionWithoutV)' >= '7.0'">true</PublishReadyToRunComposite>
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == '' and '$(_TargetFrameworkVersionWithoutV)' >= '6.0'">false</PublishReadyToRunComposite>
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunComposite)' == ''">true</PublishReadyToRunComposite>
     <PublishReadyToRunComposite Condition="'$(PublishReadyToRunUseCrossgen2)' != 'true' or '$(SelfContained)' != 'true'">false</PublishReadyToRunComposite>
@@ -311,7 +312,8 @@ Copyright (c) .NET Foundation. All rights reserved.
 
     <ResolveRuntimePackAssets Condition="'$(_TargetFrameworkVersionWithoutV)' >= '3.0'"
                               FrameworkReferences="@(FrameworkReference)"
-                              ResolvedRuntimePacks="@(_CrossgenRuntimePack)">
+                              ResolvedRuntimePacks="@(_CrossgenRuntimePack)"
+                              DisableTransitiveFrameworkReferenceDownloads="$(DisableTransitiveFrameworkReferenceDownloads)">
       <Output TaskParameter="RuntimePackAssets" ItemName="CrossgenResolvedAssembliesToPublish" />
     </ResolveRuntimePackAssets>
 
@@ -340,14 +342,13 @@ Copyright (c) .NET Foundation. All rights reserved.
           DependsOnTargets="_PrepareForReadyToRunCompilation;
                             _CreateR2RImages;
                             _CreateR2RSymbols">
-
     <ItemGroup>
-       <_R2RCrossgenTelemetry Include="PublishReadyToRunUseCrossgen2" Value="$(PublishReadyToRunUseCrossgen2)" />
-       <_R2RCrossgenTelemetry Include="Crossgen2PackVersion" Value="%(ResolvedCrossgen2Pack.NuGetPackageVersion)" />
-       <_R2RCrossgenTelemetry Include="CompileListCount" Value="@(_ReadyToRunCompileList->Count())" />
-       <_R2RCrossgenTelemetry Include="FailedCount" Value="@(_ReadyToRunCompilationFailures->Count())" />
+      <R2RTelemetry Include="PublishReadyToRunUseCrossgen2" Value="$(PublishReadyToRunUseCrossgen2)" />
+      <R2RTelemetry Include="Crossgen2PackVersion" Value="%(ResolvedCrossgen2Pack.NuGetPackageVersion)" />
+      <R2RTelemetry Include="CompileListCount" Value="@(_ReadyToRunCompileList->Count())" />
+      <R2RTelemetry Include="FailedCount" Value="@(_ReadyToRunCompilationFailures->Count())" />
     </ItemGroup>
-    <AllowEmptyTelemetry EventName="ReadyToRun" EventData="@(_R2RCrossgenTelemetry)" />
+    <AllowEmptyTelemetry EventName="ReadyToRun" EventData="@(R2RTelemetry)" />
 
     <NETSdkError Condition="'@(_ReadyToRunCompilationFailures)' != ''" ResourceName="ReadyToRunCompilationFailed" />
 
@@ -374,7 +375,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     Prepare build for ReadyToRun compilations. Builds list of assemblies to compile, and computes paths to ReadyToRun compiler bits
     ============================================================
     -->
-  <UsingTask Condition="'$(Crossgen2TasksOverriden)' != 'true'"  TaskName="PrepareForReadyToRunCompilation" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)"/>
+  <UsingTask Condition="'$(Crossgen2TasksOverriden)' != 'true'" TaskName="PrepareForReadyToRunCompilation" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="_PrepareForReadyToRunCompilation" DependsOnTargets="ResolveReadyToRunCompilers;_ComputeManagedRuntimePackAssemblies;_ComputeAssembliesToPostprocessOnPublish">
 
     <PropertyGroup>
@@ -420,7 +421,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                                      IncludeSymbolsInSingleFile="$(IncludeSymbolsInSingleFile)"
                                      ReadyToRunUseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
                                      Crossgen2Composite="$(PublishReadyToRunComposite)"
-                                     PublishReadyToRunCompositeExclusions="@(PublishReadyToRunCompositeExclusions)">
+                                     PublishReadyToRunCompositeExclusions="@(PublishReadyToRunCompositeExclusions)"
+                                     PublishReadyToRunCompositeRoots="@(PublishReadyToRunCompositeRoots)">
 
       <Output TaskParameter="ReadyToRunCompileList" ItemName="_ReadyToRunCompileList" />
       <Output TaskParameter="ReadyToRunSymbolsCompileList" ItemName="_ReadyToRunSymbolsCompileList" />
@@ -429,6 +431,7 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="ReadyToRunAssembliesToReference" ItemName="_ReadyToRunAssembliesToReference" />
       <Output TaskParameter="ReadyToRunCompositeBuildReferences" ItemName="_ReadyToRunCompositeBuildReferences" />
       <Output TaskParameter="ReadyToRunCompositeBuildInput" ItemName="_ReadyToRunCompositeBuildInput" />
+      <Output TaskParameter="ReadyToRunCompositeUnrootedBuildInput" ItemName="_ReadyToRunCompositeUnrootedBuildInput" />
 
     </PrepareForReadyToRunCompilation>
   </Target>
@@ -438,7 +441,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <ResolveReadyToRunCompilers RuntimePacks="@(ResolvedRuntimePack)"
                                 Crossgen2Packs="@(ResolvedCrossgen2Pack)"
                                 TargetingPacks="@(ResolvedTargetingPack)"
-                                RuntimeGraphPath="$([MSBuild]::ValueOrDefault('$(RuntimeIdentifierGraphPath)', '$(BundledRuntimeIdentifierGraphFile)'))"
+                                RuntimeGraphPath="$(RuntimeIdentifierGraphPath)"
                                 NETCoreSdkRuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)"
                                 EmitSymbols="$(PublishReadyToRunEmitSymbols)"
                                 ReadyToRunUseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
@@ -458,7 +461,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     -->
   <UsingTask Condition="'$(Crossgen2TasksOverriden)' != 'true'" TaskName="RunReadyToRunCompiler" AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />
   <Target Name="_CreateR2RImages"
-          Inputs="@(_ReadyToRunCompileList);@(_ReadyToRunCompositeBuildInput);@(_ReadyToRunPgoFiles)"
+          Inputs="$(MSBuildAllProjects);@(_ReadyToRunCompileList);@(_ReadyToRunCompositeBuildInput);@(_ReadyToRunPgoFiles)"
           Outputs="%(_ReadyToRunCompileList.OutputR2RImage);%(_ReadyToRunCompileList.OutputPDBImage)">
 
     <RunReadyToRunCompiler CrossgenTool="@(CrossgenTool)"
@@ -471,7 +474,8 @@ Copyright (c) .NET Foundation. All rights reserved.
                            CompilationEntry="@(_ReadyToRunCompileList)"
                            ContinueOnError="ErrorAndContinue"
                            ReadyToRunCompositeBuildReferences="@(_ReadyToRunCompositeBuildReferences)"
-                           ReadyToRunCompositeBuildInput="@(_ReadyToRunCompositeBuildInput)">
+                           ReadyToRunCompositeBuildInput="@(_ReadyToRunCompositeBuildInput)"
+                           ReadyToRunCompositeUnrootedBuildInput="@(_ReadyToRunCompositeUnrootedBuildInput)">
       <Output TaskParameter="ExitCode" PropertyName="_ReadyToRunCompilerExitCode" />
       <Output TaskParameter="WarningsDetected" PropertyName="_ReadyToRunWarningsDetected" />
     </RunReadyToRunCompiler>
@@ -495,7 +499,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     ============================================================
     -->
   <Target Name="_CreateR2RSymbols"
-          Inputs="@(_ReadyToRunSymbolsCompileList)"
+          Inputs="$(MSBuildAllProjects);@(_ReadyToRunSymbolsCompileList)"
           Outputs="%(_ReadyToRunSymbolsCompileList.OutputPDBImage)"
           Condition="'$(PublishReadyToRunUseCrossgen2)' != 'true' or '@(Crossgen2Tool -> '%(IsVersion5)')' == 'true'">
     <RunReadyToRunCompiler CrossgenTool="@(CrossgenTool)"

--- a/src/tasks/Crossgen2Tasks/PrepareForReadyToRunCompilation.cs
+++ b/src/tasks/Crossgen2Tasks/PrepareForReadyToRunCompilation.cs
@@ -1,17 +1,13 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.IO;
-using System.Runtime.InteropServices;
+#nullable disable
+
+using System.Reflection;
+using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
-using System.Reflection.Metadata;
-using System.Reflection;
 
 namespace Microsoft.NET.Build.Tasks
 {
@@ -31,6 +27,11 @@ namespace Microsoft.NET.Build.Tasks
         public bool IncludeSymbolsInSingleFile { get; set; }
 
         public string[] PublishReadyToRunCompositeExclusions { get; set; }
+
+        // When specified, only these assemblies will be fully compiled into the composite image.
+        // All other input (non-reference) assemblies will only have code compiled for methods
+        // called by a method in a rooted assembly (possibly transitively).
+        public string[] PublishReadyToRunCompositeRoots { get; set; }
 
         public ITaskItem CrossgenTool { get; set; }
         public ITaskItem Crossgen2Tool { get; set; }
@@ -56,15 +57,43 @@ namespace Microsoft.NET.Build.Tasks
         [Output]
         public ITaskItem[] ReadyToRunCompositeBuildInput => _r2rCompositeInput.ToArray();
 
+        [Output]
+        public ITaskItem[] ReadyToRunCompositeUnrootedBuildInput => _r2rCompositeUnrootedInput.ToArray();
+
         private bool _crossgen2IsVersion5;
         private int _perfmapFormatVersion;
 
-        private List<ITaskItem> _compileList = new List<ITaskItem>();
-        private List<ITaskItem> _symbolsCompileList = new List<ITaskItem>();
-        private List<ITaskItem> _r2rFiles = new List<ITaskItem>();
-        private List<ITaskItem> _r2rReferences = new List<ITaskItem>();
-        private List<ITaskItem> _r2rCompositeReferences = new List<ITaskItem>();
-        private List<ITaskItem> _r2rCompositeInput = new List<ITaskItem>();
+        private List<ITaskItem> _compileList = new();
+        private List<ITaskItem> _symbolsCompileList = new();
+        private List<ITaskItem> _r2rFiles = new();
+        private List<ITaskItem> _r2rReferences = new();
+        private List<ITaskItem> _r2rCompositeReferences = new();
+        private List<ITaskItem> _r2rCompositeInput = new();
+        private List<ITaskItem> _r2rCompositeUnrootedInput = new();
+
+        private bool IsTargetWindows
+        {
+            get
+            {
+                // Crossgen2 V6 and above always has TargetOS metadata available
+                if (ReadyToRunUseCrossgen2 && !string.IsNullOrEmpty(Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS)))
+                    return Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS) == "windows";
+                else
+                    return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            }
+        }
+
+        private bool IsTargetLinux
+        {
+            get
+            {
+                // Crossgen2 V6 and above always has TargetOS metadata available
+                if (ReadyToRunUseCrossgen2 && !string.IsNullOrEmpty(Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS)))
+                    return Crossgen2Tool.GetMetadata(MetadataKeys.TargetOS) == "linux";
+                else
+                    return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            }
+        }
 
         protected override void ExecuteCore()
         {
@@ -90,7 +119,7 @@ namespace Microsoft.NET.Build.Tasks
                 !string.IsNullOrEmpty(diaSymReaderPath) && File.Exists(diaSymReaderPath);
 
             // Process input lists of files
-            ProcessInputFileList(Assemblies, _compileList, _symbolsCompileList, _r2rFiles, _r2rReferences, _r2rCompositeReferences, _r2rCompositeInput, hasValidDiaSymReaderLib);
+            ProcessInputFileList(Assemblies, _compileList, _symbolsCompileList, _r2rFiles, _r2rReferences, _r2rCompositeReferences, _r2rCompositeInput, _r2rCompositeUnrootedInput, hasValidDiaSymReaderLib);
         }
 
         private void ProcessInputFileList(
@@ -101,6 +130,7 @@ namespace Microsoft.NET.Build.Tasks
             List<ITaskItem> r2rReferenceList,
             List<ITaskItem> r2rCompositeReferenceList,
             List<ITaskItem> r2rCompositeInputList,
+            List<ITaskItem> r2rCompositeUnrootedInput,
             bool hasValidDiaSymReaderLib)
         {
             if (inputFiles == null)
@@ -110,10 +140,11 @@ namespace Microsoft.NET.Build.Tasks
 
             var exclusionSet = ExcludeList == null || Crossgen2Composite ? null : new HashSet<string>(ExcludeList, StringComparer.OrdinalIgnoreCase);
             var compositeExclusionSet = PublishReadyToRunCompositeExclusions == null || !Crossgen2Composite ? null : new HashSet<string>(PublishReadyToRunCompositeExclusions, StringComparer.OrdinalIgnoreCase);
+            var compositeRootSet = PublishReadyToRunCompositeRoots == null || !Crossgen2Composite ? null : new HashSet<string>(PublishReadyToRunCompositeRoots, StringComparer.OrdinalIgnoreCase);
 
             foreach (var file in inputFiles)
             {
-                var eligibility = GetInputFileEligibility(file, Crossgen2Composite, exclusionSet, compositeExclusionSet);
+                var eligibility = GetInputFileEligibility(file, Crossgen2Composite, exclusionSet, compositeExclusionSet, compositeRootSet);
 
                 if (eligibility.NoEligibility)
                 {
@@ -140,13 +171,16 @@ namespace Microsoft.NET.Build.Tasks
 
                 if (EmitSymbols)
                 {
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && hasValidDiaSymReaderLib)
+                    if (IsTargetWindows)
                     {
-                        outputPDBImage = Path.ChangeExtension(outputR2RImage, "ni.pdb");
-                        outputPDBImageRelativePath = Path.ChangeExtension(outputR2RImageRelativePath, "ni.pdb");
-                        crossgen1CreatePDBCommand = $"/CreatePDB \"{Path.GetDirectoryName(outputPDBImage)}\"";
+                        if (hasValidDiaSymReaderLib)
+                        {
+                            outputPDBImage = Path.ChangeExtension(outputR2RImage, "ni.pdb");
+                            outputPDBImageRelativePath = Path.ChangeExtension(outputR2RImageRelativePath, "ni.pdb");
+                            crossgen1CreatePDBCommand = $"/CreatePDB \"{Path.GetDirectoryName(outputPDBImage)}\"";
+                        }
                     }
-                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    else if ((ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5) || IsTargetLinux)
                     {
                         string perfmapExtension;
                         if (ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5 && _perfmapFormatVersion >= 1)
@@ -155,9 +189,9 @@ namespace Microsoft.NET.Build.Tasks
                         }
                         else
                         {
-                            using (FileStream fs = new FileStream(file.ItemSpec, FileMode.Open, FileAccess.Read))
+                            using (FileStream fs = new(file.ItemSpec, FileMode.Open, FileAccess.Read))
                             {
-                                PEReader pereader = new PEReader(fs);
+                                PEReader pereader = new(fs);
                                 MetadataReader mdReader = pereader.GetMetadataReader();
                                 Guid mvid = mdReader.GetGuid(mdReader.GetModuleDefinition().Mvid);
                                 perfmapExtension = ".ni.{" + mvid + "}.map";
@@ -174,7 +208,7 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     // This TaskItem is the IL->R2R entry, for an input assembly that needs to be compiled into a R2R image. This will be used as
                     // an input to the ReadyToRunCompiler task
-                    TaskItem r2rCompilationEntry = new TaskItem(file);
+                    TaskItem r2rCompilationEntry = new(file);
                     r2rCompilationEntry.SetMetadata(MetadataKeys.OutputR2RImage, outputR2RImage);
                     if (outputPDBImage != null && ReadyToRunUseCrossgen2 && !_crossgen2IsVersion5)
                     {
@@ -184,6 +218,10 @@ namespace Microsoft.NET.Build.Tasks
                     r2rCompilationEntry.RemoveMetadata(MetadataKeys.OriginalItemSpec);
                     imageCompilationList.Add(r2rCompilationEntry);
                 }
+                else if (eligibility.CompileUnrootedIntoCompositeImage)
+                {
+                    r2rCompositeUnrootedInput.Add(file);
+                }
                 else if (eligibility.CompileIntoCompositeImage)
                 {
                     r2rCompositeInputList.Add(file);
@@ -191,8 +229,10 @@ namespace Microsoft.NET.Build.Tasks
 
                 // This TaskItem corresponds to the output R2R image. It is equivalent to the input TaskItem, only the ItemSpec for it points to the new path
                 // for the newly created R2R image
-                TaskItem r2rFileToPublish = new TaskItem(file);
-                r2rFileToPublish.ItemSpec = outputR2RImage;
+                TaskItem r2rFileToPublish = new(file)
+                {
+                    ItemSpec = outputR2RImage
+                };
                 r2rFileToPublish.RemoveMetadata(MetadataKeys.OriginalItemSpec);
                 r2rFilesPublishList.Add(r2rFileToPublish);
 
@@ -206,8 +246,10 @@ namespace Microsoft.NET.Build.Tasks
                     {
                         // This TaskItem is the R2R->R2RPDB entry, for a R2R image that was just created, and for which we need to create native PDBs. This will be used as
                         // an input to the ReadyToRunCompiler task
-                        TaskItem pdbCompilationEntry = new TaskItem(file);
-                        pdbCompilationEntry.ItemSpec = outputR2RImage;
+                        TaskItem pdbCompilationEntry = new(file)
+                        {
+                            ItemSpec = outputR2RImage
+                        };
                         pdbCompilationEntry.SetMetadata(MetadataKeys.OutputPDBImage, outputPDBImage);
                         pdbCompilationEntry.SetMetadata(MetadataKeys.CreatePDBCommand, crossgen1CreatePDBCommand);
                         symbolsCompilationList.Add(pdbCompilationEntry);
@@ -215,8 +257,10 @@ namespace Microsoft.NET.Build.Tasks
 
                     // This TaskItem corresponds to the output PDB image. It is equivalent to the input TaskItem, only the ItemSpec for it points to the new path
                     // for the newly created PDB image.
-                    TaskItem r2rSymbolsFileToPublish = new TaskItem(file);
-                    r2rSymbolsFileToPublish.ItemSpec = outputPDBImage;
+                    TaskItem r2rSymbolsFileToPublish = new(file)
+                    {
+                        ItemSpec = outputPDBImage
+                    };
                     r2rSymbolsFileToPublish.SetMetadata(MetadataKeys.RelativePath, outputPDBImageRelativePath);
                     r2rSymbolsFileToPublish.RemoveMetadata(MetadataKeys.OriginalItemSpec);
                     if (!IncludeSymbolsInSingleFile)
@@ -236,8 +280,10 @@ namespace Microsoft.NET.Build.Tasks
                 compositeR2RImageRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, "r2r" + Path.GetExtension(compositeR2RImageRelativePath));
                 var compositeR2RImage = Path.Combine(OutputPath, compositeR2RImageRelativePath);
 
-                TaskItem r2rCompilationEntry = new TaskItem(MainAssembly);
-                r2rCompilationEntry.ItemSpec = r2rCompositeInputList[0].ItemSpec;
+                TaskItem r2rCompilationEntry = new(MainAssembly)
+                {
+                    ItemSpec = r2rCompositeInputList[0].ItemSpec
+                };
                 r2rCompilationEntry.SetMetadata(MetadataKeys.OutputR2RImage, compositeR2RImage);
                 r2rCompilationEntry.SetMetadata(MetadataKeys.CreateCompositeImage, "true");
                 r2rCompilationEntry.RemoveMetadata(MetadataKeys.OriginalItemSpec);
@@ -246,12 +292,15 @@ namespace Microsoft.NET.Build.Tasks
                 {
                     string compositePDBImage = null;
                     string compositePDBRelativePath = null;
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && hasValidDiaSymReaderLib)
+                    if (IsTargetWindows)
                     {
-                        compositePDBImage = Path.ChangeExtension(compositeR2RImage, ".ni.pdb");
-                        compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.pdb");
+                        if (hasValidDiaSymReaderLib)
+                        {
+                            compositePDBImage = Path.ChangeExtension(compositeR2RImage, ".ni.pdb");
+                            compositePDBRelativePath = Path.ChangeExtension(compositeR2RImageRelativePath, ".ni.pdb");
+                        }
                     }
-                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                    else
                     {
                         string perfmapExtension = (_perfmapFormatVersion >= 1 ? ".ni.r2rmap" : ".ni.{composite}.map");
                         compositePDBImage = Path.ChangeExtension(compositeR2RImage, perfmapExtension);
@@ -264,8 +313,10 @@ namespace Microsoft.NET.Build.Tasks
                         r2rCompilationEntry.SetMetadata(MetadataKeys.OutputPDBImage, compositePDBImage);
 
                         // Publish composite PDB file
-                        TaskItem r2rSymbolsFileToPublish = new TaskItem(MainAssembly);
-                        r2rSymbolsFileToPublish.ItemSpec = compositePDBImage;
+                        TaskItem r2rSymbolsFileToPublish = new(MainAssembly)
+                        {
+                            ItemSpec = compositePDBImage
+                        };
                         r2rSymbolsFileToPublish.SetMetadata(MetadataKeys.RelativePath, compositePDBRelativePath);
                         r2rSymbolsFileToPublish.RemoveMetadata(MetadataKeys.OriginalItemSpec);
                         if (!IncludeSymbolsInSingleFile)
@@ -280,8 +331,10 @@ namespace Microsoft.NET.Build.Tasks
                 imageCompilationList.Add(r2rCompilationEntry);
 
                 // Publish it
-                TaskItem compositeR2RFileToPublish = new TaskItem(MainAssembly);
-                compositeR2RFileToPublish.ItemSpec = compositeR2RImage;
+                TaskItem compositeR2RFileToPublish = new(MainAssembly)
+                {
+                    ItemSpec = compositeR2RImage
+                };
                 compositeR2RFileToPublish.RemoveMetadata(MetadataKeys.OriginalItemSpec);
                 compositeR2RFileToPublish.SetMetadata(MetadataKeys.RelativePath, compositeR2RImageRelativePath);
                 r2rFilesPublishList.Add(compositeR2RFileToPublish);
@@ -298,18 +351,20 @@ namespace Microsoft.NET.Build.Tasks
                 HideReferenceFromComposite = 2,
                 CompileSeparately = 4,
                 CompileIntoCompositeImage = 8,
+                CompileUnrootedIntoCompositeImage = 16,
             }
 
             private readonly EligibilityEnum _flags;
 
-            public static Eligibility None => new Eligibility(EligibilityEnum.None);
+            public static Eligibility None => new(EligibilityEnum.None);
 
             public bool NoEligibility => _flags == EligibilityEnum.None;
             public bool IsReference => (_flags & EligibilityEnum.Reference) == EligibilityEnum.Reference;
             public bool ReferenceHiddenFromCompositeBuild => (_flags & EligibilityEnum.HideReferenceFromComposite) == EligibilityEnum.HideReferenceFromComposite;
             public bool CompileIntoCompositeImage => (_flags & EligibilityEnum.CompileIntoCompositeImage) == EligibilityEnum.CompileIntoCompositeImage;
+            public bool CompileUnrootedIntoCompositeImage => (_flags & EligibilityEnum.CompileUnrootedIntoCompositeImage) == EligibilityEnum.CompileUnrootedIntoCompositeImage;
             public bool CompileSeparately => (_flags & EligibilityEnum.CompileSeparately) == EligibilityEnum.CompileSeparately;
-            public bool Compile => CompileIntoCompositeImage || CompileSeparately;
+            public bool Compile => CompileIntoCompositeImage || CompileUnrootedIntoCompositeImage || CompileSeparately;
 
             private Eligibility(EligibilityEnum flags)
             {
@@ -324,12 +379,14 @@ namespace Microsoft.NET.Build.Tasks
                     return new Eligibility(EligibilityEnum.Reference);
             }
 
-            public static Eligibility CreateCompileEligibility(bool doNotBuildIntoComposite)
+            public static Eligibility CreateCompileEligibility(bool doNotBuildIntoComposite, bool rootedInComposite)
             {
                 if (doNotBuildIntoComposite)
                     return new Eligibility(EligibilityEnum.Reference | EligibilityEnum.HideReferenceFromComposite | EligibilityEnum.CompileSeparately);
-                else
+                else if (rootedInComposite)
                     return new Eligibility(EligibilityEnum.Reference | EligibilityEnum.CompileIntoCompositeImage);
+                else
+                    return new Eligibility(EligibilityEnum.Reference | EligibilityEnum.CompileUnrootedIntoCompositeImage);
             }
         };
 
@@ -352,7 +409,7 @@ namespace Microsoft.NET.Build.Tasks
             }
         }
 
-        private static Eligibility GetInputFileEligibility(ITaskItem file, bool compositeCompile, HashSet<string> exclusionSet, HashSet<string> r2rCompositeExclusionSet)
+        private static Eligibility GetInputFileEligibility(ITaskItem file, bool compositeCompile, HashSet<string> exclusionSet, HashSet<string> r2rCompositeExclusionSet, HashSet<string> r2rCompositeRootSet)
         {
             // Check to see if this is a valid ILOnly image that we can compile
             if (!file.ItemSpec.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && !file.ItemSpec.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
@@ -361,7 +418,7 @@ namespace Microsoft.NET.Build.Tasks
                 return Eligibility.None;
             }
 
-            using (FileStream fs = new FileStream(file.ItemSpec, FileMode.Open, FileAccess.Read))
+            using (FileStream fs = new(file.ItemSpec, FileMode.Open, FileAccess.Read))
             {
                 try
                 {
@@ -387,6 +444,10 @@ namespace Microsoft.NET.Build.Tasks
                         bool excludeFromR2R = (exclusionSet != null && exclusionSet.Contains(Path.GetFileName(file.ItemSpec)));
                         bool excludeFromComposite = (r2rCompositeExclusionSet != null && r2rCompositeExclusionSet.Contains(Path.GetFileName(file.ItemSpec))) || excludeFromR2R;
 
+                        // Default to rooting all assemblies.
+                        // If a root set is specified, only root if in the set.
+                        bool rootedInComposite = (r2rCompositeRootSet == null || r2rCompositeRootSet.Contains(Path.GetFileName(file.ItemSpec)));
+
                         if ((pereader.PEHeaders.CorHeader.Flags & CorFlags.ILOnly) != CorFlags.ILOnly)
                         {
                             // This can happen due to C++/CLI binaries or due to previously R2R compiled binaries.
@@ -398,7 +459,7 @@ namespace Microsoft.NET.Build.Tasks
                             }
                             else
                             {
-                                // If previously compiled as R2R, treat as reference if this would be compiled separately
+                                // If previously compiled as R2R, treat as reference if this would be compiled seperately
                                 if (!compositeCompile || excludeFromComposite)
                                 {
                                     return Eligibility.CreateReferenceEligibility(excludeFromComposite);
@@ -417,14 +478,14 @@ namespace Microsoft.NET.Build.Tasks
                         }
 
                         // save these most expensive checks for last. We don't want to scan all references for IL code
-                        if (ReferencesWinMD(mdReader) || !HasILCode(mdReader))
+                        if (ReferencesWinMD(mdReader) || !HasILCode(pereader, mdReader))
                         {
                             // Forwarder assemblies are not separately compiled via R2R, but when performing composite compilation, they are included in the bundle
                             if (excludeFromComposite || !compositeCompile)
                                 return Eligibility.CreateReferenceEligibility(excludeFromComposite);
                         }
 
-                        return Eligibility.CreateCompileEligibility(!compositeCompile || excludeFromComposite);
+                        return Eligibility.CreateCompileEligibility(!compositeCompile || excludeFromComposite, rootedInComposite);
                     }
                 }
                 catch (BadImageFormatException)
@@ -488,7 +549,7 @@ namespace Microsoft.NET.Build.Tasks
             return false;
         }
 
-        private static bool HasILCode(MetadataReader mdReader)
+        private static bool HasILCode(PEReader peReader, MetadataReader mdReader)
         {
             foreach (var methoddefHandle in mdReader.MethodDefinitions)
             {


### PR DESCRIPTION
Let's rebaseline these now so we can add logic to support Mach-O ReadyToRun files in the right places and then port over to the SDK repo easily.