### PR TITLE
Fix CborWriter.Reset.

### DIFF
--- a/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.cs
+++ b/src/libraries/System.Formats.Cbor/src/System/Formats/Cbor/Writer/CborWriter.cs
@@ -110,7 +110,7 @@ namespace System.Formats.Cbor
                 _offset = 0;
                 _nestedDataItems?.Clear();
                 _currentMajorType = null;
-                _definiteLength = null;
+                _definiteLength = AllowMultipleRootLevelValues ? null : (int?)1;
                 _itemsWritten = 0;
                 _frameOffset = 0;
                 _isTagContext = false;
@@ -120,6 +120,7 @@ namespace System.Formats.Cbor
                 _keysRequireSorting = false;
                 _keyValuePairEncodingRanges?.Clear();
                 _keyEncodingRanges?.Clear();
+                _currentIndefiniteLengthStringRanges?.Clear();
             }
         }
 

--- a/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.cs
+++ b/src/libraries/System.Formats.Cbor/tests/Writer/CborWriterTests.cs
@@ -124,6 +124,33 @@ namespace System.Formats.Cbor.Tests
         }
 
         [Fact]
+        public static void Reset_PreservesMultipleRootLevels()
+        {
+            var writer = new CborWriter(allowMultipleRootLevelValues: false);
+            writer.WriteBoolean(true);
+            writer.Reset();
+            writer.WriteInt32(6);
+            Assert.Throws<InvalidOperationException>(() => writer.WriteInt32(7));
+        }
+
+        [Fact]
+        public static void Reset_ClearsIndefiniteLengthRanges()
+        {
+            var writer = new CborWriter(convertIndefiniteLengthEncodings: true);
+
+            writer.WriteStartIndefiniteLengthByteString();
+            writer.WriteByteString([1, 2, 3]);
+            writer.Reset();
+
+            writer.WriteStartIndefiniteLengthByteString();
+            writer.WriteByteString([1, 2, 3]);
+            writer.WriteEndIndefiniteLengthByteString();
+            ReadOnlySpan<byte> encoded = writer.Encode();
+            ReadOnlySpan<byte> expected = [0x43, 0x01, 0x02, 0x03];
+            AssertExtensions.SequenceEqual(expected, encoded);
+        }
+
+        [Fact]
         public static void ConformanceMode_DefaultValue_ShouldEqualStrict()
         {
             var writer = new CborWriter();


### PR DESCRIPTION
The first issue is that Reset did not correctly set _definiteLength back after a reset. If allowMultipleRootLevelValues from the constructor is false, the default, it should be initialized to 1. However Reset set it as null, which behaves as if allowMultipleRootLevelValues is true. This sets _definiteLength back to the same way the constructor does.

The second is that _currentIndefiniteLengthStringRanges is not cleared during Reset. This means if a Reset occurred while in the middle of writing an indefinite length value and convertIndefiniteLengthEncodings is true, the next time an encode tried to re-encode segments as definite encoding where the list indicated would be pointing to incorrect locations.

Fixes #121183
Fixes #121182