### PR TITLE
Fix building the repo with Android NDK R29

### DIFF
--- a/src/native/libs/System.Native/pal_ifaddrs.c
+++ b/src/native/libs/System.Native/pal_ifaddrs.c
@@ -457,7 +457,7 @@ static struct ifaddrs *get_link_address(struct nlmsghdr *message, struct ifaddrs
     abort_if_invalid_pointer_argument(message);
     net_address = (struct ifaddrmsg*)(NLMSG_DATA(message));
     length = (ssize_t)(IFA_PAYLOAD(message));
-    LOG_DEBUG("   address data length: %zu", length);
+    LOG_DEBUG("   address data length: %zd", length);
     if (length <= 0) {
         goto error;
     }

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c
@@ -441,7 +441,7 @@ EC_KEY* AndroidCryptoNative_EcKeyCreateByExplicitParameters(ECCurveType curveTyp
     // Java only supports Weierstrass and characteristic-2 type curves.
     if (curveType != PrimeShortWeierstrass && curveType != Characteristic2)
     {
-        LOG_ERROR("Unuspported curve type specified: %d", curveType);
+        LOG_ERROR("Unuspported curve type specified: %u", curveType);
         return NULL;
     }
 

--- a/src/native/libs/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c
@@ -441,7 +441,7 @@ EC_KEY* AndroidCryptoNative_EcKeyCreateByExplicitParameters(ECCurveType curveTyp
     // Java only supports Weierstrass and characteristic-2 type curves.
     if (curveType != PrimeShortWeierstrass && curveType != Characteristic2)
     {
-        LOG_ERROR("Unuspported curve type specified: %u", curveType);
+        LOG_ERROR("Unsupported curve type specified: %u", curveType);
         return NULL;
     }
 


### PR DESCRIPTION
Drive-by fix while I'm looking at #121172.

```
  D:/git/runtime1/src/native/libs/System.Security.Cryptography.Native.Android/pal_ecc_import_export.c:444:59: error: format specifies type 'int' but the argument has underlying type 'unsigned int' [-Werror,-Wformat]
    444 |         LOG_ERROR("Unuspported curve type specified: %d", curveType);
        |                                                      ~~   ^~~~~~~~~
        |                                                      %u

  D:/git/runtime1/src/native/libs/System.Native/pal_ifaddrs.c:460:46: error: format specifies type 'size_t' (aka 'unsigned long') but the argument has type 'ssize_t' (aka 'long') [-Werror,-Wformat]
    460 |     LOG_DEBUG("   address data length: %zu", length);
        |                                        ~~~   ^~~~~~
        |                                        %zd
```

Cc @dotnet/ncl @dotnet/area-system-security 