### PR TITLE
Call PlatformDetection checks manually in IL tests

### DIFF
--- a/src/tests/JIT/Directed/PREFIX/unaligned/1/arglist.il
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/1/arglist.il
@@ -21,7 +21,6 @@ arg1==arg4, arg2==arg5, arg3==arg6.
 .assembly extern legacy library mscorlib {}
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .assembly 'arglist_Target_32BIT_unaligned_1'{ //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
@@ -82,12 +81,25 @@ REALLYDONE:
 // Entry point - Main     -
 //-------------------------
 .class public auto ansi arglist_ {
-.method public static int32 main() {
-.custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-    type([TestLibrary]TestLibrary.PlatformDetection)
-    string[2] ('IsVarArgSupported' 'Is32BitProcess')
-}
+.method public static int32 Main() {
+.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+    01 00 00 00
+)
 .entrypoint
+.maxstack	2
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_Is32BitProcess()
+	and
+	brtrue.s   DoTest
+	ldc.i4     100
+	ret
+
+DoTest:
+	call       int32 arglist_::Test()
+	ret
+}
+
+.method public static int32 Test() {
 .locals	()
 .maxstack	10
 

--- a/src/tests/JIT/Directed/PREFIX/unaligned/1/arglist64.il
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/1/arglist64.il
@@ -92,12 +92,25 @@ REALLYDONE:
 // Entry point - Main     -
 //-------------------------
 .class public auto ansi arglist64 {
-.method public static int32 main() {
-.custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-    type([TestLibrary]TestLibrary.PlatformDetection)
-    string[2] ('IsVarArgSupported' 'Is64BitProcess')
-}
+.method public static int32 Main() {
+.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+    01 00 00 00
+)
 .entrypoint
+.maxstack	2
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_Is64BitProcess()
+	and
+	brtrue.s   DoTest
+	ldc.i4     100
+	ret
+
+DoTest:
+	call       int32 arglist64::Test()
+	ret
+}
+
+.method public static int32 Test() {
 .locals	()
 .maxstack	10
 

--- a/src/tests/JIT/Directed/PREFIX/unaligned/2/arglist.il
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/2/arglist.il
@@ -21,7 +21,6 @@ arg1==arg4, arg2==arg5, arg3==arg6.
 .assembly extern legacy library mscorlib {}
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .assembly 'arglist_Target_32BIT_unaligned_2'{ //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
@@ -83,12 +82,25 @@ REALLYDONE:
 // Entry point - Main     -
 //-------------------------
 .class public auto ansi arglist_ {
-.method public static int32 main() {
-.custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-    type([TestLibrary]TestLibrary.PlatformDetection)
-    string[2] ('IsVarArgSupported' 'Is32BitProcess')
-}
+.method public static int32 Main() {
+.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+    01 00 00 00
+)
 .entrypoint
+.maxstack	2
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_Is32BitProcess()
+	and
+	brtrue.s   DoTest
+	ldc.i4     100
+	ret
+
+DoTest:
+	call       int32 arglist_::Test()
+	ret
+}
+
+.method public static int32 Test() {
 .locals	()
 .maxstack	10
 

--- a/src/tests/JIT/Directed/PREFIX/unaligned/2/arglist64.il
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/2/arglist64.il
@@ -21,7 +21,6 @@ arg1==arg4, arg2==arg5, arg3==arg6.
 .assembly extern legacy library mscorlib {}
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .assembly 'arglist_Target_64BIT_unaligned_2'{ //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
@@ -92,12 +91,25 @@ REALLYDONE:
 // Entry point - Main     -
 //-------------------------
 .class public auto ansi arglist64 {
-.method public static int32 main() {
-.custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-    type([TestLibrary]TestLibrary.PlatformDetection)
-    string[2] ('IsVarArgSupported' 'Is64BitProcess')
-}
+.method public static int32 Main() {
+.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+    01 00 00 00
+)
 .entrypoint
+.maxstack	2
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_Is64BitProcess()
+	and
+	brtrue.s   DoTest
+	ldc.i4     100
+	ret
+
+DoTest:
+	call       int32 arglist64::Test()
+	ret
+}
+
+.method public static int32 Test() {
 .locals	()
 .maxstack	10
 

--- a/src/tests/JIT/Directed/PREFIX/unaligned/4/arglist.il
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/4/arglist.il
@@ -21,7 +21,6 @@ arg1==arg4, arg2==arg5, arg3==arg6.
 .assembly extern legacy library mscorlib {}
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .assembly 'arglist_Target_32BIT_unaligned_4'{ //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
@@ -82,12 +81,25 @@ REALLYDONE:
 // Entry point - Main     -
 //-------------------------
 .class public auto ansi arglist_ {
-.method public static int32 main() {
-.custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-    type([TestLibrary]TestLibrary.PlatformDetection)
-    string[2] ('IsVarArgSupported' 'Is32BitProcess')
-}
+.method public static int32 Main() {
+.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+    01 00 00 00
+)
 .entrypoint
+.maxstack	2
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_Is32BitProcess()
+	and
+	brtrue.s   DoTest
+	ldc.i4     100
+	ret
+
+DoTest:
+	call       int32 arglist_::Test()
+	ret
+}
+
+.method public static int32 Test() {
 .locals	()
 .maxstack	10
 

--- a/src/tests/JIT/Directed/PREFIX/unaligned/4/arglist64.il
+++ b/src/tests/JIT/Directed/PREFIX/unaligned/4/arglist64.il
@@ -21,7 +21,6 @@ arg1==arg4, arg2==arg5, arg3==arg6.
 .assembly extern legacy library mscorlib {}
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .assembly 'arglist_Target_64BIT_unaligned_4'{ //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
@@ -92,12 +91,25 @@ REALLYDONE:
 // Entry point - Main     -
 //-------------------------
 .class public auto ansi arglist64 {
-.method public static int32 main() {
-.custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-    type([TestLibrary]TestLibrary.PlatformDetection)
-    string[2] ('IsVarArgSupported' 'Is64BitProcess')
-}
+.method public static int32 Main() {
+.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+    01 00 00 00
+)
 .entrypoint
+.maxstack	2
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_Is64BitProcess()
+	and
+	brtrue.s   DoTest
+	ldc.i4     100
+	ret
+
+DoTest:
+	call       int32 arglist64::Test()
+	ret
+}
+
+.method public static int32 Test() {
 .locals	()
 .maxstack	10
 

--- a/src/tests/JIT/Directed/PREFIX/volatile/1/arglist.il
+++ b/src/tests/JIT/Directed/PREFIX/volatile/1/arglist.il
@@ -21,7 +21,6 @@ arg1==arg4, arg2==arg5, arg3==arg6.
 .assembly extern legacy library mscorlib {}
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .assembly 'arglist_Target_32BIT_volatile'{ //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
@@ -84,12 +83,25 @@ REALLYDONE:
 // Entry point - Main     -
 //-------------------------
 .class public auto ansi arglist_ {
-.method public static int32 main() {
-.custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-    type([TestLibrary]TestLibrary.PlatformDetection)
-    string[2] ('IsVarArgSupported' 'Is32BitProcess')
-}
+.method public static int32 Main() {
+.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+    01 00 00 00
+)
 .entrypoint
+.maxstack	2
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_Is32BitProcess()
+	and
+	brtrue.s   DoTest
+	ldc.i4     100
+	ret
+
+DoTest:
+	call       int32 arglist_::Test()
+	ret
+}
+
+.method public static int32 Test() {
 .locals	()
 .maxstack	10
 

--- a/src/tests/JIT/Directed/PREFIX/volatile/1/arglist64.il
+++ b/src/tests/JIT/Directed/PREFIX/volatile/1/arglist64.il
@@ -21,7 +21,6 @@ arg1==arg4, arg2==arg5, arg3==arg6.
 .assembly extern legacy library mscorlib {}
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .assembly 'arglist_Target_64BIT_volatile'{ //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
@@ -92,12 +91,25 @@ REALLYDONE:
 // Entry point - Main     -
 //-------------------------
 .class public auto ansi arglist64 {
-.method public static int32 main() {
-.custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-    type([TestLibrary]TestLibrary.PlatformDetection)
-    string[2] ('IsVarArgSupported' 'Is64BitProcess')
-}
+.method public static int32 Main() {
+.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+    01 00 00 00
+)
 .entrypoint
+.maxstack	2
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_Is64BitProcess()
+	and
+	brtrue.s   DoTest
+	ldc.i4     100
+	ret
+
+DoTest:
+	call       int32 arglist64::Test()
+	ret
+}
+
+.method public static int32 Test() {
 .locals	()
 .maxstack	10
 

--- a/src/tests/JIT/Methodical/Coverage/arglist_pos.il
+++ b/src/tests/JIT/Methodical/Coverage/arglist_pos.il
@@ -16,7 +16,6 @@
   .ver 0:0:0:0
 }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 
 .class public auto ansi arglist_pos extends [mscorlib]System.Object
@@ -29,18 +28,29 @@
     arglist
     call       instance void [mscorlib]System.ArgIterator::.ctor(value class [mscorlib]System.RuntimeArgumentHandle)
     ldloca.s   args
-	call       instance int32 [mscorlib]System.ArgIterator::GetRemainingCount()
+    call       instance int32 [mscorlib]System.ArgIterator::GetRemainingCount()
     call       void [System.Console]System.Console::WriteLine(int32)
     ret
   }
 
   .method public hidebysig static int32 Main() il managed
   {
-    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-        type([TestLibrary]TestLibrary.PlatformDetection)
-        string[1] ('IsVarArgSupported')
-    }
-	.entrypoint
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+      01 00 00 00
+    )
+    .entrypoint
+    call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+    brtrue.s   DoTest
+    ldc.i4     100
+    ret
+
+  DoTest:
+    call       int32 arglist_pos::TestEntry()
+    ret
+  }
+
+  .method public hidebysig static int32 TestEntry() il managed
+  {
 	.try
 	{
 		call       vararg void arglist_pos::Test()

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_32BIT.il
@@ -13,17 +13,28 @@
 .assembly ASSEMBLY_NAME
 { }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .class public auto ansi Test_i_array_merge_Target_32BIT extends [mscorlib]System.Object
 {
 .method public hidebysig static int32 Main() il managed
 {
-    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-        type([TestLibrary]TestLibrary.PlatformDetection)
-        string[1] ('Is32BitProcess')
-    }
+	.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+		01 00 00 00
+	)
 	.entrypoint
+	.maxstack  1
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_Is32BitProcess()
+	brtrue.s   DoTest
+	ldc.i4     100
+	ret
+
+DoTest:
+	call       int32 Test_i_array_merge_Target_32BIT::Test()
+	ret
+}
+
+.method public hidebysig static int32 Test() il managed
+{
 	.maxstack  8
 	.locals (int32[0...], native int[0...], native int, native int)
 	ldc.i4 16
@@ -110,7 +121,7 @@ end_c:
 	
 	ldc.i4 0x64
 	ret
-} // end of method 'Test::Main'
+} // end of method 'Test::Test'
 
 .method public hidebysig specialname rtspecialname 
         instance void .ctor() il managed

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge_Target_64BIT.il
@@ -13,17 +13,28 @@
 .assembly ASSEMBLY_NAME
 { }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .class public auto ansi Test_i_array_merge_Target_64BIT extends [mscorlib]System.Object
 {
 .method public hidebysig static int32 Main() il managed
 {
-    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-        type([TestLibrary]TestLibrary.PlatformDetection)
-        string[1] ('Is64BitProcess')
-    }
+	.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+		01 00 00 00
+	)
 	.entrypoint
+	.maxstack  1
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_Is64BitProcess()
+	brtrue.s   DoTest
+	ldc.i4     100
+	ret
+
+DoTest:
+	call       int32 Test_i_array_merge_Target_64BIT::Test()
+	ret
+}
+
+.method public hidebysig static int32 Test() il managed
+{
 	.maxstack  8
 	.locals (int64[0...], native int[0...], native int, native int)
 	ldc.i4 16
@@ -110,7 +121,7 @@ end_c:
 	
 	ldc.i4 0x64
 	ret
-} // end of method 'Test::Main'
+} // end of method 'Test::Test'
 
 .method public hidebysig specialname rtspecialname 
         instance void .ctor() il managed

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_32BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_32BIT.il
@@ -18,7 +18,6 @@
 {
 }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 // MVID: {BCA6096F-DF11-4FA3-BF16-EEDA01729535}
 .namespace AvgTest_sizeof_Target_32BIT
@@ -28,13 +27,25 @@
   {
     .method public hidebysig static int32 Main() il managed
     {
-        .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-            type([TestLibrary]TestLibrary.PlatformDetection)
-            string[1] ('Is32BitProcess')
-        }
+		.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+			01 00 00 00
+		)
 		.entrypoint
-		// Code size       48 (0x30)
+		.maxstack  1
+		call       bool [TestLibrary]TestLibrary.PlatformDetection::get_Is32BitProcess()
+		brtrue.s   DoTest
+		ldc.i4     100
+		ret
+
+	DoTest:
+		call       int32 AvgTest_sizeof_Target_32BIT::Test()
+		ret
+	}
+
+    .method public hidebysig static int32 Test() il managed
+    {
 		.maxstack  5
+		.locals (int32[0...], native int[0...], native int, native int)
 		ldc.i4.4
 		dup 
 		dup
@@ -63,7 +74,7 @@
 		ldc.i4.1
 	return:		
 		ret
-    } // end of method 'Test::Main'
+    } // end of method 'Test::Test'
 
     .method public hidebysig specialname rtspecialname 
             instance void .ctor() il managed

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_32BIT_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_32BIT_d.ilproj
@@ -9,5 +9,6 @@
   <ItemGroup>
     <Compile Include="sizeof_Target_32BIT_d.il" />
     <Compile Include="sizeof_Target_32BIT.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_32BIT_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_32BIT_r.ilproj
@@ -9,5 +9,6 @@
   <ItemGroup>
     <Compile Include="sizeof_Target_32BIT_r.il" />
     <Compile Include="sizeof_Target_32BIT.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_64BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_64BIT.il
@@ -18,7 +18,6 @@
 {
 }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 // MVID: {BCA6096F-DF11-4FA3-BF16-EEDA01729535}
 .namespace AvgTest_sizeof_Target_64BIT
@@ -28,13 +27,25 @@
   {
     .method public hidebysig static int32 Main() il managed
     {
-        .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-            type([TestLibrary]TestLibrary.PlatformDetection)
-            string[1] ('Is64BitProcess')
-        }
+		.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+			01 00 00 00
+		)
 		.entrypoint
-		// Code size       48 (0x30)
+		.maxstack  1
+		call       bool [TestLibrary]TestLibrary.PlatformDetection::get_Is64BitProcess()
+		brtrue.s   DoTest
+		ldc.i4     100
+		ret
+
+	DoTest:
+		call       int32 AvgTest_sizeof_Target_64BIT.Test::Test()
+		ret
+	}
+
+    .method public hidebysig static int32 Test() il managed
+    {
 		.maxstack  5
+		.locals (int32[0...], native int[0...], native int, native int)
 		ldc.i4.8
 		ldc.i4.8
 		ldc.i4.8
@@ -63,7 +74,7 @@
 		ldc.i4.1
 	return:		
 		ret
-    } // end of method 'Test::Main'
+    } // end of method 'Test::Test'
 
     .method public hidebysig specialname rtspecialname 
             instance void .ctor() il managed

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_64BIT_d.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_64BIT_d.ilproj
@@ -9,5 +9,6 @@
   <ItemGroup>
     <Compile Include="sizeof_Target_64BIT_d.il" />
     <Compile Include="sizeof_Target_64BIT.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_64BIT_r.ilproj
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/sizeof_Target_64BIT_r.ilproj
@@ -9,5 +9,6 @@
   <ItemGroup>
     <Compile Include="sizeof_Target_64BIT_r.il" />
     <Compile Include="sizeof_Target_64BIT.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_32BIT.il
@@ -13,17 +13,28 @@
 .assembly ASSEMBLY_NAME
 { }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .class public auto ansi Test_u_array_merge_Target_32BIT extends [mscorlib]System.Object
 {
 .method public hidebysig static int32 Main() il managed
 {
-    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-        type([TestLibrary]TestLibrary.PlatformDetection)
-        string[1] ('Is32BitProcess')
-    }
+	.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+		01 00 00 00
+	)
 	.entrypoint
+	.maxstack  1
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_Is32BitProcess()
+	brtrue.s   DoTest
+	ldc.i4     100
+	ret
+
+DoTest:
+	call       int32 Test_u_array_merge_Target_32BIT::Test()
+	ret
+}
+
+.method public hidebysig static int32 Test() il managed
+{
 	.maxstack  8
 	.locals (unsigned int32[0...], native unsigned int[0...], native unsigned int, native unsigned int)
 	ldc.i4 16
@@ -110,7 +121,7 @@ end_c:
 	
 	ldc.i4 0x64
 	ret
-} // end of method 'Test::Main'
+} // end of method 'Test::Test'
 
 .method public hidebysig specialname rtspecialname 
         instance void .ctor() il managed

--- a/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT.il
+++ b/src/tests/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge_Target_64BIT.il
@@ -13,17 +13,28 @@
 .assembly ASSEMBLY_NAME
 { }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .class public auto ansi Test_u_array_merge_Target_64BIT extends [mscorlib]System.Object
 {
 .method public hidebysig static int32 Main() il managed
 {
-    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-        type([TestLibrary]TestLibrary.PlatformDetection)
-        string[1] ('Is64BitProcess')
-    }
+	.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+		01 00 00 00
+	)
 	.entrypoint
+	.maxstack  1
+	call       bool [TestLibrary]TestLibrary.PlatformDetection::get_Is64BitProcess()
+	brtrue.s   DoTest
+	ldc.i4     100
+	ret
+
+DoTest:
+	call       int32 Test_u_array_merge_Target_64BIT::Test()
+	ret
+}
+
+.method public hidebysig static int32 Test() il managed
+{
 	.maxstack  8
 	.locals (unsigned int64[0...], native unsigned int[0...], native unsigned int, native unsigned int)
 	ldc.i4 16
@@ -110,7 +121,7 @@ end_c:
 	
 	ldc.i4 0x64
 	ret
-} // end of method 'Test::Main'
+} // end of method 'Test::Test'
 
 .method public hidebysig specialname rtspecialname 
         instance void .ctor() il managed

--- a/src/tests/JIT/Methodical/refany/seq.il
+++ b/src/tests/JIT/Methodical/refany/seq.il
@@ -16,7 +16,6 @@
 {
 }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .namespace JitTest_seq_refany_il
 {
@@ -116,11 +115,22 @@
 
     .method public hidebysig static int32 Main() il managed
     {
-        .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-            type([TestLibrary]TestLibrary.PlatformDetection)
-            string[1] ('IsVarArgSupported')
-        }
+		.custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+			01 00 00 00
+		)
 		.entrypoint
+		.maxstack  1
+		call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+		brtrue.s   DoTest
+		ldc.i4     100
+		ret
+
+DoTest:
+		call       int32 JitTest_seq_refany_il.Test::Test()
+		ret
+	}
+
+	.method public static int32 Test() {
 		.maxstack  8
 		.locals (unsigned int64)
 		ldc.i4.0
@@ -128,7 +138,7 @@
 		dup
 		tail. call vararg native unsigned int JitTest_seq_refany_il.Test::TestFunc(unsigned int64, ..., unsigned int64)
 		ret
-    } // end of method Test::Main
+    } // end of method Test::Test
 
     .method public hidebysig specialname rtspecialname instance void .ctor() il managed
     {

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_32Bit_x86.il
@@ -6,7 +6,6 @@
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly ASSEMBLY_NAME { }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 )
 .namespace JitTest_sizeof32_Target_32Bit_x86_il
@@ -39,11 +38,24 @@
     .method public hidebysig static int32
             Main() cil managed
     {
-      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-          type([TestLibrary]TestLibrary.PlatformDetection)
-          string[1] ('IsX86Process')
-      }
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+      )
       .entrypoint
+      .maxstack 1
+      call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsX86Process()
+      brtrue.s   DoTest
+      ldc.i4     100
+      ret
+
+DoTest:
+      call       int32 JitTest_sizeof32_Target_32Bit_x86_il.Test::Test()
+      ret
+    }
+
+    .method public hidebysig static int32
+            Test() cil managed
+    {
       .maxstack  4
       .locals (int32 V_0,
                int32 V_1,

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof32_Target_64Bit_and_arm.il
@@ -5,7 +5,6 @@
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly ASSEMBLY_NAME { }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .namespace JitTest_sizeof32_Target_64Bit_and_arm_il
@@ -38,11 +37,24 @@
     .method public hidebysig static int32
             Main() cil managed
     {
-      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-          type([TestLibrary]TestLibrary.PlatformDetection)
-          string[1] ('IsNotX86Process')
-      }
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+      )
       .entrypoint
+      .maxstack 1
+      call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsNotX86Process()
+      brtrue.s   DoTest
+      ldc.i4     100
+      ret
+
+DoTest:
+      call       int32 JitTest_sizeof32_Target_64Bit_and_arm_il.Test::Test()
+      ret
+    }
+
+    .method public hidebysig static int32
+            Test() cil managed
+    {
       .maxstack  4
       .locals (int32 V_0,
                int32 V_1,

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_32Bit_x86.il
@@ -6,7 +6,6 @@
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly ASSEMBLY_NAME { }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .namespace JitTest_sizeof64_Target_32Bit_x86_il
@@ -40,11 +39,24 @@
     .method public hidebysig static int32
             Main() cil managed
     {
-      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-          type([TestLibrary]TestLibrary.PlatformDetection)
-          string[1] ('IsX86Process')
-      }
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+      )
       .entrypoint
+      .maxstack 1
+      call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsX86Process()
+      brtrue.s   DoTest
+      ldc.i4     100
+      ret
+
+DoTest:
+      call       int32 JitTest_sizeof64_Target_32Bit_x86_il::Test()
+      ret
+    }
+
+    .method public hidebysig static int32
+            Test() cil managed
+    {
       .maxstack  4
       .locals (int64 V_0,
                int32 V_1,

--- a/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm.il
+++ b/src/tests/JIT/Methodical/xxobj/sizeof/sizeof64_Target_64Bit_and_arm.il
@@ -5,7 +5,6 @@
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly ASSEMBLY_NAME { }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
 .namespace JitTest_sizeof64_Target_64Bit_and_arm_il
@@ -39,11 +38,24 @@
     .method public hidebysig static int32
             Main() cil managed
     {
-      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-          type([TestLibrary]TestLibrary.PlatformDetection)
-          string[1] ('IsNotX86Process')
-      }
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+      )
       .entrypoint
+      .maxstack 1
+      call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsNotX86Process()
+      brtrue.s   DoTest
+      ldc.i4     100
+      ret
+
+DoTest:
+      call       int32 JitTest_sizeof64_Target_64Bit_and_arm_il.Test::Test()
+      ret
+    }
+
+    .method public hidebysig static int32
+            Test() cil managed
+    {
       .maxstack  4
       .locals (int64 V_0,
                int32 V_1,

--- a/src/tests/JIT/Regression/CLR-x86-EJIT/V1-M12-Beta2/b26323/b26323.il
+++ b/src/tests/JIT/Regression/CLR-x86-EJIT/V1-M12-Beta2/b26323/b26323.il
@@ -10,7 +10,6 @@
 }
 .assembly b26323 { }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .namespace Test
 {
@@ -32,11 +31,23 @@
 
     .method public static int32 Main() il managed
     {
-      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-          type([TestLibrary]TestLibrary.PlatformDetection)
-          string[1] ('IsVarArgSupported')
-      }
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+      )
       .entrypoint
+      .maxstack  1
+      call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+      brtrue.s   DoTest
+      ldc.i4     100
+      ret
+
+  DoTest:
+      call       int32 Test.App::Test()
+      ret
+    }
+
+    .method public static int32 Test() il managed
+    {
       .maxstack  2
       .locals ([0] class Test.App app)
       IL_0001:  newobj     instance vararg void Test.App::.ctor(...)

--- a/src/tests/JIT/Regression/CLR-x86-EJIT/V1-M12-Beta2/b26323/b26323.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-EJIT/V1-M12-Beta2/b26323/b26323.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324a.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324a.il
@@ -14,7 +14,6 @@
   
 }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .namespace Test
 {
@@ -129,11 +128,23 @@
     .field private static initonly class [mscorlib]System.String expResult
     .method public static int32 Main() il managed
     {
-      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-          type([TestLibrary]TestLibrary.PlatformDetection)
-          string[1] ('IsVarArgSupported')
-      }
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+      )
       .entrypoint
+      .maxstack  1
+      call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+      brtrue.s   DoTest
+      ldc.i4     100
+      ret
+
+  DoTest:
+      call       int32 Test.App::Test()
+      ret
+    }
+
+    .method public static int32 Test() il managed
+    {
       .maxstack  12
       .locals ([0] class Test.GCClass inst)
                

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324a.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324a.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="b26324a.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324b.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324b.il
@@ -14,7 +14,6 @@
   
 }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .namespace Test
 {
@@ -129,11 +128,23 @@
     .field private static initonly class [mscorlib]System.String expResult
     .method public static int32 Main() il managed
     {
-      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-          type([TestLibrary]TestLibrary.PlatformDetection)
-          string[1] ('IsVarArgSupported')
-      }
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+      )
       .entrypoint
+      .maxstack  1
+      call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+      brtrue.s   DoTest
+      ldc.i4     100
+      ret
+
+  DoTest:
+      call       int32 Test.App::Test()
+      ret
+    }
+
+    .method public static int32 Test() il managed
+    {
       .maxstack  12
       .locals ([0] class Test.GCClass inst)
                

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324b.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324b.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="b26324b.il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b28901/b28901.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b28901/b28901.il
@@ -4,7 +4,6 @@
 .assembly extern legacy library mscorlib {}
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .assembly extern System.Console
 {
@@ -46,11 +45,23 @@
 {
   .method public static int32 main() il managed
   {
-    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-        type([TestLibrary]TestLibrary.PlatformDetection)
-        string[1] ('IsVarArgSupported')
-    }
+    .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+      01 00 00 00
+    )
     .entrypoint
+    .maxstack  1
+    call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+    brtrue.s   DoTest
+    ldc.i4     100
+    ret
+
+DoTest:
+    call       int32 b28901::Test()
+    ret
+  }
+
+  .method public static int32 Test() il managed
+  {
     .maxstack  3
     .locals init (class [mscorlib]System.Text.StringBuilder V_0,
             int32 V_1,
@@ -84,5 +95,5 @@
 
     IL_00eb:  ldc.i4     0x1
     IL_00f0:  ret
-  } // end of global method 'main'
+  } // end of global method 'Test'
 }

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b28901/b28901.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b28901/b28901.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b30838/b30838.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b30838/b30838.il
@@ -4,7 +4,6 @@
 .assembly extern legacy library mscorlib {}
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .assembly extern System.Console
 {
@@ -27,13 +26,25 @@
 } // end of global method 'foo'
 
 .class public auto ansi Test_b30838 extends [mscorlib] System.Object {
-.method public static int32 main() il managed
+.method public static int32 Main() il managed
 {
-  .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-      type([TestLibrary]TestLibrary.PlatformDetection)
-      string[1] ('IsVarArgSupported')
-  }
+  .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+    01 00 00 00
+  )
   .entrypoint
+  .maxstack  1
+  call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+  brtrue.s   DoTest
+  ldc.i4     100
+  ret
+
+DoTest:
+  call       int32 Test_b30838::Test()
+  ret
+}
+
+.method public static int32 Test() il managed
+{
   // Code size       19 (0x13)
   .maxstack  8
   IL_0000:  ldnull
@@ -45,7 +56,7 @@
 ldc.i4 100
 add
   IL_0012:  ret
-} // end of global method 'main'
+} // end of global method 'Test'
 }
 
 //*********** DISASSEMBLY COMPLETE ***********************

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b30838/b30838.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b30838/b30838.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b30864/b30864.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b30864/b30864.il
@@ -10,7 +10,6 @@
 }
 .assembly 'b30864' { }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .namespace BoxTest
 {
@@ -142,12 +141,24 @@
     } // end of method 'Test::Fibonacci2'
 
     .method public hidebysig static int32 Main() il managed 
-{
-      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-          type([TestLibrary]TestLibrary.PlatformDetection)
-          string[1] ('IsVarArgSupported')
-      }
+    {
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+      )
       .entrypoint
+      .maxstack  1
+      call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+      brtrue.s   DoTest
+      ldc.i4     100
+      ret
+
+    DoTest:
+      call       int32 BoxTest.Test::Test()
+      ret
+    }
+
+    .method public hidebysig static int32 Test() il managed
+    {
       // Code size       67 (0x43)
       .maxstack  3
       .locals (int32 V_0,
@@ -179,7 +190,7 @@
 
       IL_0041:  ldc.i4 100
       IL_0042:  ret
-    } // end of method 'Test::Main'
+    } // end of method 'Test::Test'
 
     .method public hidebysig specialname rtspecialname instance void .ctor() il managed 
 {

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b30864/b30864.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b30864/b30864.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b32374/b32374.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b32374/b32374.il
@@ -10,7 +10,6 @@
 }
 .assembly 'b32374' { }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .namespace Test
 {
@@ -55,11 +54,23 @@
     .method public hidebysig static int32
             Main() il managed
     {
-      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-          type([TestLibrary]TestLibrary.PlatformDetection)
-          string[1] ('IsVarArgSupported')
-      }
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+      )
       .entrypoint
+      .maxstack  1
+      call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+      brtrue.s   DoTest
+      ldc.i4     100
+      ret
+
+    DoTest:
+      call       int32 Test.BB::Test()
+      ret
+    }
+
+    .method public hidebysig static int32 Test() il managed
+    {
       // Code size       97 (0x61)
       .maxstack  6
       .locals (class Test.BB V_0,
@@ -119,7 +130,7 @@
 		ldc.i4 100
 		add
       IL_0060:  ret
-    } // end of method 'BB::Main'
+    } // end of method 'BB::Test'
 
     .method public hidebysig specialname rtspecialname static 
             void .cctor() il managed

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b32374/b32374.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b32374/b32374.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b35784/b35784.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b35784/b35784.il
@@ -12,7 +12,6 @@
 {
 }
 .assembly extern xunit.core {}
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 .namespace BoxTest
 {
@@ -145,11 +144,23 @@
 
     .method public hidebysig static int32 Main() il managed 
 {
-      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-          type([TestLibrary]TestLibrary.PlatformDetection)
-          string[1] ('IsVarArgSupported')
-      }
+      .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+        01 00 00 00
+      )
       .entrypoint
+      .maxstack  1
+      call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+      brtrue.s   DoTest
+      ldc.i4     100
+      ret
+
+    DoTest:
+      call       int32 BoxTest.Test::Test()
+      ret
+    }
+
+    .method public hidebysig static int32 Test() il managed
+    {
       // Code size       67 (0x43)
       .maxstack  3
       .locals (int32 V_0,
@@ -181,7 +192,7 @@
 
       IL_0041:  ldc.i4 100
       IL_0042:  ret
-    } // end of method 'Test::Main'
+    } // end of method 'Test::Test'
 
     .method public hidebysig specialname rtspecialname instance void .ctor() il managed 
 {

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b35784/b35784.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b35784/b35784.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b409748/b409748.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b409748/b409748.il
@@ -5,7 +5,6 @@
 .assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly extern xunit.core {}
 .assembly 'b409748' { }
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .assembly extern TestLibrary { .ver 0:0:0:0 }
 
 .method public static vararg void Foo(int32)
@@ -13,14 +12,25 @@
    ret
 }
 .class public auto ansi Test_b409748 extends [mscorlib] System.Object {
-.method public static int32 Exec()
+.method public static int32 Main()
 {
-   .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ConditionalFactAttribute::.ctor(class [System.Runtime]System.Type, string[]) = {
-       type([TestLibrary]TestLibrary.PlatformDetection)
-       string[1] ('IsVarArgSupported')
-   }
+   .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
+      01 00 00 00
+   )
    .entrypoint
+   .maxstack  1
+   call       bool [TestLibrary]TestLibrary.PlatformDetection::get_IsVarArgSupported()
+   brtrue.s   DoTest
+   ldc.i4     100
+   ret
 
+DoTest:
+   call       int32 Test_b409748::Test()
+   ret
+}
+
+.method public static int32 Test() il managed
+{
    ldc.i4 1
    call mdtoken(0x06000001)
 

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b409748/b409748.ilproj
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b409748/b409748.ilproj
@@ -8,5 +8,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).il" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Regression after #119878, these tests were entered with `BuildAllTestsAsStandalone` despite `ConditionalFact`s. See https://github.com/dotnet/runtime/pull/112399#issuecomment-2721661913 for context.