### PR TITLE
[release/10.0] [QUIC] Update Windows version of MsQuic

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -149,7 +149,7 @@
     <!-- Docs -->
     <MicrosoftPrivateIntellisenseVersion>10.0.0-preview-20250912.1</MicrosoftPrivateIntellisenseVersion>
     <!-- MsQuic -->
-    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.15</MicrosoftNativeQuicMsQuicSchannelVersion>
+    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.16</MicrosoftNativeQuicMsQuicSchannelVersion>
     <SystemNetMsQuicTransportVersion>9.0.0-alpha.1.24167.3</SystemNetMsQuicTransportVersion>
     <!-- emscripten / Node
          Note: when the name is updated, make sure to update dependency name in eng/pipelines/common/xplat-setup.yml


### PR DESCRIPTION
## Customer Impact

- [ ] Customer reported
- [x] Found internally

Back port of #121170.
Updates MsQuic library in released Windows runtime. The MsQuic change removed unnecessary dependency.

## Regression

- [ ] Yes
- [x] No

## Testing

CI, making sure the right version of MsQuic is used on Windows and all tests are passing.

## Risk

Low, major and minor are the same.
