### PR TITLE
Add -optimistic for crossgen2 option --instruction-set.

### DIFF
--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -182,6 +182,11 @@ namespace System.CommandLine
                     {
                         instructionSet = "+" + instructionSet;
                     }
+                    else if (instructionSet == "-optimistic")
+                    {
+                        allowOptimistic = false;
+                        continue;
+                    }
 
                     instructionSetParams.Add(instructionSet);
                 }

--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -183,15 +183,14 @@ namespace System.CommandLine
                         instructionSet = "+" + instructionSet;
                     }
 
-                    if (instructionSet == "-optimistic")
-                    {
-                        allowOptimistic = false;
-                        continue;
-                    }
-
                     if (instructionSet == "+optimistic")
                     {
                         allowOptimistic = true;
+                        continue;
+                    }
+                    if (instructionSet == "-optimistic")
+                    {
+                        allowOptimistic = false;
                         continue;
                     }
 

--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -188,6 +188,12 @@ namespace System.CommandLine
                         continue;
                     }
 
+                    if (instructionSet == "+optimistic")
+                    {
+                        allowOptimistic = true;
+                        continue;
+                    }
+
                     instructionSetParams.Add(instructionSet);
                 }
 

--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -182,7 +182,8 @@ namespace System.CommandLine
                     {
                         instructionSet = "+" + instructionSet;
                     }
-                    else if (instructionSet == "-optimistic")
+
+                    if (instructionSet == "-optimistic")
                     {
                         allowOptimistic = false;
                         continue;

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -357,7 +357,7 @@ namespace ILCompiler
                 "instruction sets, and multiple instruction sets may be specified by separating the instructions sets by a ','. By default other instruction sets not " +
                 "specified may light-up optimistically via dynamic checks. Individual instruction sets can be disallowed from such light-up by prefixing them with '-'. " +
                 "All such light-up can be disallowed by specifying '-optimistic'. The instruction sets supported by the machine invoking the tool can be targeted by " +
-                "specifying 'native'. For example 'native', 'avx,aes', 'avx,aes,-avx2', or 'avx,aes,-optimistic'</value>
+                "specifying 'native'. For example 'native', 'avx,aes', 'avx,aes,-avx2', or 'avx,aes,-optimistic'");
 
             foreach (string arch in ValidArchitectures)
             {

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -354,9 +354,10 @@ namespace ILCompiler
             Console.WriteLine(string.Format("Valid switches for {0} are: '{1}'. The default value is '{2}'\n", "--targetarch", string.Join("', '", ValidArchitectures), Helpers.GetTargetArchitecture(null).ToString().ToLowerInvariant()));
 
             Console.WriteLine("The allowable values for the --instruction-set option are described in the table below. Each architecture has a different set of valid " +
-                "instruction sets, and multiple instruction sets may be specified by separating the instructions sets by a ','. Instruction set 'native' expand to " +
-                "specific host chip architecture instructions sets. In order to forced allow or disallow optimistic preset of instructions sets for target architecture, " +
-                "'optimistic' value could be used. For example 'native', 'avx,aes,apx' or 'avx,aes,apx,-optimistic'");
+                "instruction sets, and multiple instruction sets may be specified by separating the instructions sets by a ','. By default other instruction sets not " +
+                "specified may light-up optimistically via dynamic checks. Individual instruction sets can be disallowed from such light-up by prefixing them with '-'. " +
+                "All such light-up can be disallowed by specifying '-optimistic'. The instruction sets supported by the machine invoking the tool can be targeted by " +
+                "specifying 'native'. For example 'native', 'avx,aes', 'avx,aes,-avx2', or 'avx,aes,-optimistic'</value>
 
             foreach (string arch in ValidArchitectures)
             {

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -354,7 +354,9 @@ namespace ILCompiler
             Console.WriteLine(string.Format("Valid switches for {0} are: '{1}'. The default value is '{2}'\n", "--targetarch", string.Join("', '", ValidArchitectures), Helpers.GetTargetArchitecture(null).ToString().ToLowerInvariant()));
 
             Console.WriteLine("The allowable values for the --instruction-set option are described in the table below. Each architecture has a different set of valid " +
-                "instruction sets, and multiple instruction sets may be specified by separating the instructions sets by a ','. For example 'avx,aes,apx'");
+                "instruction sets, and multiple instruction sets may be specified by separating the instructions sets by a ','. Instruction set 'native' expand to " +
+                "specific host chip architecture instructions sets. In order to forced allow or disallow optimistic preset of instructions sets for target architecture, " +
+                "'optimistic' value could be used. For example 'native', 'avx,aes,apx' or 'avx,aes,apx,-optimistic'");
 
             foreach (string arch in ValidArchitectures)
             {

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -373,7 +373,7 @@
     <value>Valid switches for {0} are: '{1}'. The default value is '{2}'.</value>
   </data>
   <data name="InstructionSetHelp" xml:space="preserve">
-    <value>The allowable values for the --instruction-set option are described in the table below. Each architecture has a different set of valid instruction sets, and multiple instruction sets may be specified by separating the instructions sets by a ','. For example 'avx,aes,apx'</value>
+    <value>The allowable values for the --instruction-set option are described in the table below. Each architecture has a different set of valid instruction sets, and multiple instruction sets may be specified by separating the instructions sets by a ','. Instruction set 'native' expand to specific host chip architecture instructions sets. In order to forced allow or disallow optimistic preset of instructions sets for target architecture, 'optimistic' value could be used. For example 'native', 'avx,aes,apx' or 'avx,aes,apx,-optimistic'</value>
   </data>
   <data name="MakeReproPathHelp" xml:space="preserve">
     <value>Make a repro zip file in the specified path. This is used for sending error reports to the .NET team.</value>

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -373,7 +373,7 @@
     <value>Valid switches for {0} are: '{1}'. The default value is '{2}'.</value>
   </data>
   <data name="InstructionSetHelp" xml:space="preserve">
-    <value>The allowable values for the --instruction-set option are described in the table below. Each architecture has a different set of valid instruction sets, and multiple instruction sets may be specified by separating the instructions sets by a ','. Instruction set 'native' expand to specific host chip architecture instructions sets. In order to forced allow or disallow optimistic preset of instructions sets for target architecture, 'optimistic' value could be used. For example 'native', 'avx,aes,apx' or 'avx,aes,apx,-optimistic'</value>
+    <value>The allowable values for the --instruction-set option are described in the table below. Each architecture has a different set of valid instruction sets, and multiple instruction sets may be specified by separating the instructions sets by a ','. By default other instruction sets not specified may light-up optimistically via dynamic checks. Individual instruction sets can be disallowed from such light-up by prefixing them with '-'. All such light-up can be disallowed by specifying '-optimistic'. The instruction sets supported by the machine invoking the tool can be targeted by specifying 'native'. For example 'native', 'avx,aes', 'avx,aes,-avx2', or 'avx,aes,-optimistic'</value>
   </data>
   <data name="MakeReproPathHelp" xml:space="preserve">
     <value>Make a repro zip file in the specified path. This is used for sending error reports to the .NET team.</value>


### PR DESCRIPTION
Could be used for compile on x64 host for arm64 target (for example, during Tizen OS image creation).

Related to https://github.com/dotnet/runtime/pull/121175, another approach for disable optimistic instruction set to be added.

CC @gbalykov @tannergooding @MichalStrehovsky