### PR TITLE
Improve HttpEnvironmentProxy uri parsing

### DIFF
--- a/src/libraries/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
+++ b/src/libraries/System.Net.Http/tests/UnitTests/HttpEnvironmentProxyTest.cs
@@ -137,14 +137,22 @@ namespace System.Net.Http.Tests
         [InlineData("[::1]", "[::1]", "80", null, null)]
         [InlineData("domain\\foo:PLACEHOLDER@1.1.1.1", "1.1.1.1", "80", "foo", "PLACEHOLDER")]
         [InlineData("domain%5Cfoo:PLACEHOLDER@1.1.1.1", "1.1.1.1", "80", "foo", "PLACEHOLDER")]
+        [InlineData("placeholder@1.2.3.4/foo", "1.2.3.4", "80", "placeholder", "")]
+        [InlineData("placeholder@1.2.3?.4", "1.2.0.3", "80", "placeholder", "")]
+        [InlineData("placeholder:@1.2.3.4/foo:", "1.2.3.4", "80", "placeholder", "")]
         [InlineData("HTTP://ABC.COM/", "abc.com", "80", null, null)]
         [InlineData("http://10.30.62.64:7890/", "10.30.62.64", "7890", null, null)]
+        [InlineData("http://1.2.3.4/foo", "1.2.3.4", "80", null, null)]
+        [InlineData("http://1.2.3.4/foo:", "1.2.3.4", "80", null, null)]
+        [InlineData("http://1.2.3.4?foo", "1.2.3.4", "80", null, null)]
         [InlineData("http://1.2.3.4:8888/foo", "1.2.3.4", "8888", null, null)]
         [InlineData("socks4://1.2.3.4:8888/foo", "1.2.3.4", "8888", null, null)]
         [InlineData("socks4a://1.2.3.4:8888/foo", "1.2.3.4", "8888", null, null)]
         [InlineData("socks5://1.2.3.4:8888/foo", "1.2.3.4", "8888", null, null)]
         [InlineData("https://1.1.1.5:3005", "1.1.1.5", "3005", null, null)]
         [InlineData("https://1.1.1.5", "1.1.1.5", "443", null, null)]
+        // Everything before the last '@' is considered as user info (unlike regular Uri parsing).
+        [InlineData("https://host1:123@foo/@host2/path", "host2", "443", "host1", "123@foo/")]
         public async Task HttpProxy_Uri_Parsing(string _input, string _host, string _port, string? _user, string? _password)
         {
             await RemoteExecutor.Invoke((input, host, port, user, password) =>


### PR DESCRIPTION
We have a test that the path may be present, but while that particular input happens to work, the parsing logic isn't actually accounting for paths as a possibility.
If the path/query/fragment contains `:` or `@`, it'd break.

This change strips out the path/query/fragment portion so that our `host` that we pass to `UriBuilder` is more likely to be just the host.
Hit in #121083 that tries to add more validation to the `UriBuilder.Host` setter.

This does break some weird edge cases that we happened to support currently, e.g. `host:8080abc` (garbage after the port).
But I kept other weird cases like `user:p@ss@host` as-is (`@` as part of user info), which does mean that a `@` in the path can still break things.

Ideally this method would be using `Uri.TryCreate` instead, but we currently accept some _interesting_ inputs like `domain\foo:pass@1.1.1.1`, so we'd still have to do some manual processing.
https://github.com/dotnet/corefx/pull/31232#discussion_r204175495