### PR TITLE
[clr-interp] Fix CEE_ISINST to push object reference instead of InterpTypeI

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -461,7 +461,7 @@ void InterpCompiler::LinkBBs(InterpBasicBlock *from, InterpBasicBlock *to)
         if (newCapacity > prevCapacity)
         {
             InterpBasicBlock **newa = (InterpBasicBlock**)AllocMemPool(newCapacity * sizeof(InterpBasicBlock*));
-            if (from->outCount != 0) 
+            if (from->outCount != 0)
             {
                 memcpy(newa, from->ppOutBBs, from->outCount * sizeof(InterpBasicBlock*));
             }
@@ -1878,8 +1878,8 @@ int32_t InterpCompiler::GetInterpTypeStackSize(CORINFO_CLASS_HANDLE clsHnd, Inte
         if (align < INTERP_STACK_SLOT_SIZE)
             align = INTERP_STACK_SLOT_SIZE;
 
-        // We do not align beyond the stack alignment 
-        // (This is relevant for structs with very high alignment requirements, 
+        // We do not align beyond the stack alignment
+        // (This is relevant for structs with very high alignment requirements,
         // where we align within struct layout, but the structs are not actually
         // aligned on the stack)
         if (align > INTERP_STACK_ALIGNMENT)
@@ -4886,7 +4886,7 @@ public:
     OpcodePeep peepTypeValueType = { peepTypeValueTypeOpcodes, &InterpCompiler::IsTypeValueTypePeep, &InterpCompiler::ApplyTypeValueTypePeep, "TypeValueType" };
 
 public:
-    OpcodePeep* Peeps[10] = { 
+    OpcodePeep* Peeps[10] = {
         &peepTypeEqualityCheck,
         &peepStoreLoad,
         &peepStoreLoad1,
@@ -4901,7 +4901,7 @@ public:
     bool FindAndApplyPeep(InterpCompiler* compiler)
     {
         const uint8_t* ip = compiler->m_ip;
-        
+
         for (int i = 0; Peeps[i] != NULL; i++)
         {
             OpcodePeep *peep = Peeps[i];
@@ -5027,7 +5027,7 @@ bool InterpCompiler::IsTypeEqualityCheckPeep(const uint8_t* ip, OpcodePeepElemen
         *ppComputedInfo = (void*)(size_t)((ni == NI_System_Type_op_Equality) ? 0 : 1);
         return true;
     }
-    else 
+    else
     {
         assert(compareResult == TypeCompareState::Must);
         // The types are definitely equal, so we can optimize this to a constant result
@@ -5612,7 +5612,7 @@ retry_emit:
 #endif
 
         // Check for IL opcode peephole optimizations
-        
+
         if (ILOpcodePeeps.FindAndApplyPeep(this))
             continue;
 
@@ -8254,7 +8254,7 @@ DO_LDFTN:
                 m_compHnd->embedGenericHandle(&resolvedToken, false, m_methodInfo->ftn, &embedInfo);
                 m_pStackPointer--;
                 DeclarePointerIsClass((CORINFO_CLASS_HANDLE)embedInfo.compileTimeHandle);
-                EmitPushHelperCall_2(castingHelper, embedInfo, m_pStackPointer[0].var, g_stackTypeFromInterpType[*m_ip == CEE_CASTCLASS ? InterpTypeO : InterpTypeI], NULL);
+                EmitPushHelperCall_2(castingHelper, embedInfo, m_pStackPointer[0].var, g_stackTypeFromInterpType[InterpTypeO], NULL);
                 m_ip += 5;
                 break;
             }


### PR DESCRIPTION
## Description

According to ECMA, CEE_ISINST must push an object reference onto stack, but it currently pushes InterpTypeI, which propagates an invalid IR stack type.

In the example below, by IL_0022 the stind.ref takes an i8 instead of object reference, triggering OBJECTREF validation failure.
```
Interpreter compile method Microsoft.Maui.Controls.Platform.GesturePlatformManager:TryGetTapGestureRecognizer(Microsoft.Maui.Controls.IGestureRecognizer,byref)

Create IL Vars:
alloc arg var 0 to offset 0
alloc arg var 1 to offset 8
alloc arg var 2 to offset 16

Create clause Vars:
BB1 (IL_0000):
Chaining BB0 -> BB1
IL_0000 ldarg.2   , sp 0,   
IL_0001 ldarg.1   , sp 1, MP
IL_0002 isinst    , sp 2, O 
IL_0007 dup       , sp 2, I8
IL_0008 brtrue.s  , sp 3, I8
BB3 (IL_000a):
Chaining BB1 -> BB3
IL_000a pop       , sp 2, I8
IL_000b ldarg.1   , sp 1, MP
IL_000c isinst    , sp 2, O 
IL_0011 dup       , sp 2, I8
IL_0012 brtrue.s  , sp 3, I8
BB5 (IL_0014):
Chaining BB3 -> BB5
IL_0014 pop       , sp 2, I8
IL_0015 ldnull    , sp 1, MP
IL_0016 br.s      , sp 2, O 
BB4 (IL_0018):
Chaining BB5 -> BB4
IL_0018 call      , sp 2, I8
BB6 (IL_001d):
Chaining BB4 -> BB6
IL_001d isinst    , sp 2, O 
BB2 (IL_0022):
Chaining BB6 -> BB2
IL_0022 stind.ref , sp 2, I8
IL_0023 ldarg.2   , sp 0,   
IL_0024 ldind.ref , sp 1, MP
IL_0025 ldnull    , sp 1, O 
IL_0026 cgt.un    , sp 2, O 
IL_0028 ret     
 ```