### PR TITLE
Add `runtime-report-green` pipeline to Build Analysis

### DIFF
--- a/eng/build-analysis-configuration.json
+++ b/eng/build-analysis-configuration.json
@@ -27,6 +27,10 @@
     {
       "PipelineId": 108,
       "PipelineName": "runtime-coreclr outerloop"
+    },
+    {
+      "PipelineId": 324,
+      "PipelineName": "runtime-report-green"
     }
   ]
 }


### PR DESCRIPTION
This PR adds a pipeline to config file that defines which pipelines are taken into consideration during Build Analysis.

Contributes to https://github.com/dotnet/runtime/pull/120752.