### PR TITLE
[mono][sgen] Make color visible to client permanent

### DIFF
--- a/src/mono/mono/metadata/sgen-tarjan-bridge.c
+++ b/src/mono/mono/metadata/sgen-tarjan-bridge.c
@@ -1105,9 +1105,9 @@ processing_build_callback_data (int generation)
 	for (cur = root_color_bucket; cur; cur = cur->next) {
 		ColorData *cd;
 		for (cd = &cur->data [0]; cd < cur->next_data; ++cd) {
-			int bridges = dyn_array_ptr_size (&cd->bridges);
-			if (!(bridges || bridgeless_color_is_heavy (cd)))
+			if (!color_visible_to_client (cd))
 				continue;
+			int bridges = dyn_array_ptr_size (&cd->bridges);
 
 			api_sccs [api_index] = (MonoGCBridgeSCC *)sgen_alloc_internal_dynamic (sizeof (MonoGCBridgeSCC) + sizeof (MonoObject*) * bridges, INTERNAL_MEM_BRIDGE_DATA, TRUE);
 			api_sccs [api_index]->is_alive = FALSE;

--- a/src/tests/GC/Features/Bridge/Bridge.cs
+++ b/src/tests/GC/Features/Bridge/Bridge.cs
@@ -89,6 +89,12 @@ public class Bridge1 : BridgeBase
     }
 }
 
+[InlineArray(14)]
+public struct InlineData
+{
+    public object obj;
+}
+
 // 128 size
 public class Bridge14 : BridgeBase
 {
@@ -107,7 +113,7 @@ public class NonBridge2 : NonBridge
 
 public class NonBridge14
 {
-    public object a,b,c,d,e,f,g,h,i,j,k,l,m,n;
+    public InlineData Data;
 }
 
 
@@ -403,6 +409,27 @@ public class BridgeTest
         }
     }
 
+    public static void BridgelessHeavyColorChanging()
+    {
+        Bridge1[] left = new Bridge1[8];
+        for (int i = 0; i < 8; i++)
+            left[i] = new Bridge1();
+        Bridge[] right = new Bridge[7];
+        for (int i = 0; i < 7; i++)
+            right[i] = new Bridge();
+        NonBridge2 right7 = new NonBridge2();
+
+        NonBridge14 mid = new NonBridge14();
+
+        for (int i = 0; i < 8; i++)
+            left[i].Link = mid;
+        for (int i = 0; i < 7; i++)
+            mid.Data[i] = right[i];
+        mid.Data[7] = right7;
+        right7.Link = right[6];
+        right7.Link2 = right[5];
+    }
+
     public static int Main(string[] args)
     {
         TestLinkedList();
@@ -417,6 +444,7 @@ public class BridgeTest
         RunGraphTest(NestedCycles);
         RunGraphTest(FauxHeavyNodeWithCycles);
         RunGraphTest(Spider);
+        RunGraphTest(BridgelessHeavyColorChanging);
         return 100;
     }
 }


### PR DESCRIPTION
A color (SCC) that isn't containing any bridge objects is made visible to client if xrefs_in * xrefs_out is greater than 60. Later on in bridge processing, we need to build the callback to pass for .net android. During this stage, we reduce from the full set of SCCs to SCCs that should be visible to client (containing bridge objects or satisfying the above condition). If an SCC has an xref to a color that is not visible to client, we need to do a recursive traversal to find all neighbors that are visible to client. The problem is that this process can end up making an SCC no longer visible to client, leading to inconsistencies in the computation. Consider a color(C1) that has a neighbor that is not visible to client(C2). In this final stage, we compute the neighbors of C1 by traversing recursively through the neighbors of C2. If C2 ends up pointing to colors that were already neighbors of C1, then, following this computation, C1 would end up with fewer xrefs_out, making the color no longer visible to client. This make future checks incorrect, resulting in building incorrect graph for client.

This scenario seems rare in practice, we should have gotten way more reports otherwise. We fix this by pinning the visible_to_client property for a color once it first satisfies it, so it will no longer matter how many actual xrefs the color has.

Fixes assertions like:
```
* Assertion at /home/vbrezae/Xamarin/repos/runtime/src/mono/mono/metadata/sgen-tarjan-bridge.c:1151, condition `color_visible_to_client (cd)' not met
```