### PR TITLE
Remove more unsafe code from Uri internals

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -4147,9 +4147,13 @@ namespace System
             {
                 char c = span[i];
 
-                // Control chars usually should be escaped in any case
-                if (c <= '\x1F' || (c >= '\x7F' && c <= '\x9F'))
+                if (char.IsAsciiLetterOrDigit(c))
                 {
+                    // The most common case - unreserved chars.
+                }
+                else if (c <= '\x1F' || (c >= '\x7F' && c <= '\x9F'))
+                {
+                    // Control chars usually should be escaped in any case
                     needsEscaping = true;
                     foundEscaping = true;
                     res |= Check.ReservedFound;

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -423,147 +423,122 @@ namespace System
             return result.IsWellFormedOriginalString();
         }
 
-        //
-        // Internal stuff
-        //
-
         // Returns false if OriginalString value
         // (1) is not correctly escaped as per URI spec excluding intl UNC name case
         // (2) or is an absolute Uri that represents implicit file Uri "c:\dir\file"
         // (3) or is an absolute Uri that misses a slash before path "file://c:/dir/file"
         // (4) or contains unescaped backslashes even if they will be treated
         //     as forward slashes like http:\\host/path\file or file:\\\c:\path
-        //
-        internal unsafe bool InternalIsWellFormedOriginalString()
+        internal bool InternalIsWellFormedOriginalString()
         {
             if (UserDrivenParsing)
                 throw new InvalidOperationException(SR.Format(SR.net_uri_UserDrivenParsing, this.GetType()));
 
-            fixed (char* str = _string)
+            string str = _string;
+
+            // For a relative Uri we only care about escaping and backslashes
+            if (!IsAbsoluteUri)
             {
-                int idx = 0;
-                //
-                // For a relative Uri we only care about escaping and backslashes
-                //
-                if (!IsAbsoluteUri)
-                {
-                    // my:scheme/path?query is not well formed because the colon is ambiguous
-                    if (CheckForColonInFirstPathSegment(_string))
-                    {
-                        return false;
-                    }
-                    return (CheckCanonical(str, ref idx, _string.Length, c_EOL)
-                            & (Check.BackslashInPath | Check.EscapedCanonical)) == Check.EscapedCanonical;
-                }
-
-                //
-                // (2) or is an absolute Uri that represents implicit file Uri "c:\dir\file"
-                //
-                if (IsImplicitFile)
-                    return false;
-
-                //This will get all the offsets, a Host name will be checked separately below
-                EnsureParseRemaining();
-
-                Flags nonCanonical = (_flags & (Flags.E_CannotDisplayCanonical | Flags.IriCanonical));
-
-                // Cleanup canonical IRI from nonCanonical
-                if ((nonCanonical & (Flags.UserIriCanonical | Flags.PathIriCanonical | Flags.QueryIriCanonical | Flags.FragmentIriCanonical)) != 0)
-                {
-                    if ((nonCanonical & (Flags.E_UserNotCanonical | Flags.UserIriCanonical)) == (Flags.E_UserNotCanonical | Flags.UserIriCanonical))
-                    {
-                        nonCanonical &= ~(Flags.E_UserNotCanonical | Flags.UserIriCanonical);
-                    }
-
-                    if ((nonCanonical & (Flags.E_PathNotCanonical | Flags.PathIriCanonical)) == (Flags.E_PathNotCanonical | Flags.PathIriCanonical))
-                    {
-                        nonCanonical &= ~(Flags.E_PathNotCanonical | Flags.PathIriCanonical);
-                    }
-
-                    if ((nonCanonical & (Flags.E_QueryNotCanonical | Flags.QueryIriCanonical)) == (Flags.E_QueryNotCanonical | Flags.QueryIriCanonical))
-                    {
-                        nonCanonical &= ~(Flags.E_QueryNotCanonical | Flags.QueryIriCanonical);
-                    }
-
-                    if ((nonCanonical & (Flags.E_FragmentNotCanonical | Flags.FragmentIriCanonical)) == (Flags.E_FragmentNotCanonical | Flags.FragmentIriCanonical))
-                    {
-                        nonCanonical &= ~(Flags.E_FragmentNotCanonical | Flags.FragmentIriCanonical);
-                    }
-                }
-
-                // User, Path, Query or Fragment may have some non escaped characters
-                if (((nonCanonical & Flags.E_CannotDisplayCanonical & (Flags.E_UserNotCanonical | Flags.E_PathNotCanonical |
-                                        Flags.E_QueryNotCanonical | Flags.E_FragmentNotCanonical)) != Flags.Zero))
+                // my:scheme/path?query is not well formed because the colon is ambiguous
+                if (CheckForColonInFirstPathSegment(str))
                 {
                     return false;
                 }
 
-                // checking on scheme:\\ or file:////
-                if (InFact(Flags.AuthorityFound))
-                {
-                    idx = _info.Offset.Scheme + _syntax.SchemeName.Length + 2;
-                    if (idx >= _info.Offset.User || _string[idx - 1] == '\\' || _string[idx] == '\\')
-                        return false;
+                return (CheckCanonical(str, c_EOL, out _) & (Check.BackslashInPath | Check.EscapedCanonical)) == Check.EscapedCanonical;
+            }
 
-                    if (InFact(Flags.UncPath | Flags.DosPath))
-                    {
-                        while (++idx < _info.Offset.User && (_string[idx] == '/' || _string[idx] == '\\'))
-                            return false;
-                    }
+            // (2) or is an absolute Uri that represents implicit file Uri "c:\dir\file"
+            if (IsImplicitFile)
+                return false;
+
+            // This will get all the offsets, a Host name will be checked separately below
+            EnsureParseRemaining();
+
+            Flags nonCanonical = (_flags & (Flags.E_CannotDisplayCanonical | Flags.IriCanonical));
+
+            // Cleanup canonical IRI from nonCanonical
+            if ((nonCanonical & (Flags.UserIriCanonical | Flags.PathIriCanonical | Flags.QueryIriCanonical | Flags.FragmentIriCanonical)) != 0)
+            {
+                if ((nonCanonical & (Flags.E_UserNotCanonical | Flags.UserIriCanonical)) == (Flags.E_UserNotCanonical | Flags.UserIriCanonical))
+                {
+                    nonCanonical &= ~(Flags.E_UserNotCanonical | Flags.UserIriCanonical);
                 }
 
-
-                // (3) or is an absolute Uri that misses a slash before path "file://c:/dir/file"
-                // Note that for this check to be more general we assert that if Path is non empty and if it requires a first slash
-                // (which looks absent) then the method has to fail.
-                // Today it's only possible for a Dos like path, i.e. file://c:/bla would fail below check.
-                if (InFact(Flags.FirstSlashAbsent) && _info.Offset.Query > _info.Offset.Path)
-                    return false;
-
-                // (4) or contains unescaped backslashes even if they will be treated
-                //     as forward slashes like http:\\host/path\file or file:\\\c:\path
-                // Note we do not check for Flags.ShouldBeCompressed i.e. allow // /./ and alike as valid
-                if (InFact(Flags.BackslashInPath))
-                    return false;
-
-                // Capturing a rare case like file:///c|/dir
-                if (IsDosPath && _string[_info.Offset.Path + SecuredPathIndex - 1] == '|')
-                    return false;
-
-                //
-                // May need some real CPU processing to answer the request
-                //
-                //
-                // Check escaping for authority
-                //
-                // IPv6 hosts cannot be properly validated by CheckCanonical
-                if ((_flags & Flags.CanonicalDnsHost) == 0 && HostType != Flags.IPv6HostType)
+                if ((nonCanonical & (Flags.E_PathNotCanonical | Flags.PathIriCanonical)) == (Flags.E_PathNotCanonical | Flags.PathIriCanonical))
                 {
-                    idx = _info.Offset.User;
-                    Check result = CheckCanonical(str, ref idx, _info.Offset.Path, '/');
-                    if (((result & (Check.ReservedFound | Check.BackslashInPath | Check.EscapedCanonical))
-                        != Check.EscapedCanonical)
-                        && (!IriParsing || (result & (Check.DisplayCanonical | Check.FoundNonAscii | Check.NotIriCanonical))
-                                != (Check.DisplayCanonical | Check.FoundNonAscii)))
-                    {
-                        return false;
-                    }
+                    nonCanonical &= ~(Flags.E_PathNotCanonical | Flags.PathIriCanonical);
                 }
 
-                // Want to ensure there are slashes after the scheme
-                if ((_flags & (Flags.SchemeNotCanonical | Flags.AuthorityFound))
-                    == (Flags.SchemeNotCanonical | Flags.AuthorityFound))
+                if ((nonCanonical & (Flags.E_QueryNotCanonical | Flags.QueryIriCanonical)) == (Flags.E_QueryNotCanonical | Flags.QueryIriCanonical))
                 {
-                    idx = _syntax.SchemeName.Length;
-                    while (str[idx++] != ':');
-                    if (idx + 1 >= _string.Length || str[idx] != '/' || str[idx + 1] != '/')
-                        return false;
+                    nonCanonical &= ~(Flags.E_QueryNotCanonical | Flags.QueryIriCanonical);
+                }
+
+                if ((nonCanonical & (Flags.E_FragmentNotCanonical | Flags.FragmentIriCanonical)) == (Flags.E_FragmentNotCanonical | Flags.FragmentIriCanonical))
+                {
+                    nonCanonical &= ~(Flags.E_FragmentNotCanonical | Flags.FragmentIriCanonical);
                 }
             }
-            //
-            // May be scheme, host, port or path need some canonicalization but still the uri string is found to be a
-            // "well formed" one
-            //
+
+            // User, Path, Query or Fragment may have some non escaped characters
+            if (((nonCanonical & Flags.E_CannotDisplayCanonical & (Flags.E_UserNotCanonical | Flags.E_PathNotCanonical |
+                                    Flags.E_QueryNotCanonical | Flags.E_FragmentNotCanonical)) != Flags.Zero))
+            {
+                return false;
+            }
+
+            // checking on scheme:\\ or file:////
+            if (InFact(Flags.AuthorityFound))
+            {
+                if (InFact(Flags.SchemeNotCanonical_NoTrailingSlashes))
+                {
+                    return false;
+                }
+
+                if (InFact(Flags.UncPath | Flags.DosPath))
+                {
+                    int idx = _info.Offset.Scheme + _syntax.SchemeName.Length + 3;
+
+                    if (idx < _info.Offset.User && str[idx] is '/' or '\\')
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            // (3) or is an absolute Uri that misses a slash before path "file://c:/dir/file"
+            // Note that for this check to be more general we assert that if Path is non empty and if it requires a first slash
+            // (which looks absent) then the method has to fail.
+            // Today it's only possible for a Dos like path, i.e. file://c:/bla would fail below check.
+            if (InFact(Flags.FirstSlashAbsent) && _info.Offset.Query > _info.Offset.Path)
+                return false;
+
+            // (4) or contains unescaped backslashes even if they will be treated
+            //     as forward slashes like http:\\host/path\file or file:\\\c:\path
+            // Note we do not check for Flags.ShouldBeCompressed i.e. allow // /./ and alike as valid
+            if (InFact(Flags.BackslashInPath))
+                return false;
+
+            // Capturing a rare case like file:///c|/dir
+            if (IsDosPath && str[_info.Offset.Path + SecuredPathIndex - 1] == '|')
+                return false;
+
+            // Check escaping for authority
+            // IPv6 hosts cannot be properly validated by CheckCanonical
+            if ((_flags & Flags.CanonicalDnsHost) == 0 && HostType != Flags.IPv6HostType)
+            {
+                int idx = _info.Offset.User;
+                Check result = CheckCanonical(str.AsSpan(idx, _info.Offset.Path - idx), '/', out _);
+
+                if ((result & (Check.ReservedFound | Check.BackslashInPath | Check.EscapedCanonical)) != Check.EscapedCanonical
+                    && (!IriParsing || (result & (Check.DisplayCanonical | Check.FoundNonAscii | Check.NotIriCanonical)) != (Check.DisplayCanonical | Check.FoundNonAscii)))
+                {
+                    return false;
+                }
+            }
+
+            // The scheme, host, port or path may need some canonicalization, but the uri string is found to be a "well formed" one.
             return true;
         }
 

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriIsWellFormedUriStringTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriIsWellFormedUriStringTest.cs
@@ -287,6 +287,13 @@ namespace System.PrivateUri.Tests
             new object[] { "file://c:/directory/filename", false },
             new object[] { "\\\\?\\UNC\\Server01\\user\\docs\\Letter.txt", false },
 
+            // Test Scheme
+            new object[] { @"http:/host/path", false },
+            new object[] { @"http:\host/path", false },
+            new object[] { @"http:/\host/path", false },
+            new object[] { @"http:\/host/path", false },
+            new object[] { @"http:\\host/path", false },
+
             // Test Host
             new object[] { "http://www.contoso.com", true },
             new object[] { "http://\u00E4.contos.com", true },
@@ -306,7 +313,6 @@ namespace System.PrivateUri.Tests
             // Test Path
             new object[] { "http://www.contoso.com/path???/file name", false },
             new object[] { "http://www.contoso.com/\u00E4???/file name", false },
-            new object[] { "http:\\host/path/file", false },
 
             new object[] { "http://www.contoso.com/a/sek http://test.com", false },
             new object[] { "http://www.contoso.com/\u00E4/sek http://test.com", false },
@@ -437,14 +443,15 @@ namespace System.PrivateUri.Tests
             new object[] { "http://www.contoso.com/path?a# a ", false },
             new object[] { "http://www.contoso.com/path?\u00E4# \u00E4 ", false },
 
-
             new object[] { "http://www.contoso.com/path?a#a?a", true },
             new object[] { "http://www.contoso.com/\u00E4?\u00E4#u00E4?\u00E4", true },
 
-            // Sample in "private unsafe Check CheckCanonical(char* str, ref ushort idx, ushort end, char delim)" code comments
             new object[] { "http://www.contoso.com/\u00E4/ path2/ param=val", false },
             new object[] { "http://www.contoso.com/\u00E4? param=val", false },
             new object[] { "http://www.contoso.com/\u00E4?param=val# fragment", false },
+
+            // Surrogate pairs
+            new object[] { "http://www.contoso.com/path/\uD83C\uDF49?query\uD83C\uDF49=\uD83C\uDF49#\uD83C\uDF49", true },
         };
 
         [Theory]


### PR DESCRIPTION
Removes unsafe code from `CheckCanonical` and all its callers.

`InternalIsWellFormedOriginalString` was also checking the same thing twice, and we also check for it during parsing, so I added a new flag for it to avoid the duplication (`SchemeNotCanonical_NoTrailingSlashes`).

Reviewing is easier without whitespace diffs.

Due to the new fast path check for `IsAsciiLetterOrDigit` in `CheckCanonical`, it's now faster - https://github.com/MihuBot/runtime-utils/issues/1632. E.g.
| Method                  | Toolchain               | input                                | Mean       | Error   | Ratio | Allocated | Alloc Ratio |
|------------------------ |------------------------ |------------------------------------- |-----------:|--------:|------:|----------:|------------:|
| **CtorIdnHostPathAndQuery** | **Main** | **http://dot.ne(...)alue#fragment [43]** |   **188.0 ns** | **1.44 ns** |  **1.00** |     **248 B** |        **1.00** |
| CtorIdnHostPathAndQuery | PR   | http://dot.ne(...)alue#fragment [43] |   160.6 ns | 0.37 ns |  0.85 |     248 B |        1.00 |