### PR TITLE
[Bounds checks] Tighten pRange in MergeEdgeAssertions via X != CNS assertions

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -863,8 +863,28 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             }
             else
             {
-                // We have a != assertion, but it doesn't tell us much about the interval. So just skip it.
-                continue;
+                assert(curAssertion->assertionKind == Compiler::OAK_NOT_EQUAL);
+
+                // We have an assertion of the form "var != cnstLimit".
+                // Say we have "var != 100" and we already have [100, X] as range for var,
+                // then we can tighten it to [101, X]
+                // Similarly, if we have [Y, 100], we can tighten it to [Y, 99].
+
+                if (pRange->LowerLimit().IsConstant() && pRange->LowerLimit().GetConstant() == cnstLimit)
+                {
+                    limit   = Limit(Limit::keConstant, cnstLimit);
+                    cmpOper = GT_GT;
+                }
+                else if (pRange->UpperLimit().IsConstant() && pRange->UpperLimit().GetConstant() == cnstLimit)
+                {
+                    limit   = Limit(Limit::keConstant, cnstLimit);
+                    cmpOper = GT_LT;
+                }
+                else
+                {
+                    // We can't make any useful deduction from this assertion.
+                    continue;
+                }
             }
 
             isConstantAssertion = true;

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -865,10 +865,10 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             {
                 assert(curAssertion->assertionKind == Compiler::OAK_NOT_EQUAL);
 
-                // We have an assertion of the form "var != cnstLimit".
-                // Say we have "var != 100" and we already have [100, X] as range for var,
-                // then we can tighten it to [101, X]
-                // Similarly, if we have [Y, 100], we can tighten it to [Y, 99].
+                // We have an assertion of the form "X != constLimit".
+                // For example, if the assertion is "X != 100" and the current range for X is [100, X],
+                // we can tighten the range to [101, X].
+                // Similarly, if the range is [Y, 100], we can tighten it to [Y, 99].
 
                 if (pRange->LowerLimit().IsConstant() && pRange->LowerLimit().GetConstant() == cnstLimit)
                 {


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/121259

When we already have, say, `[1..10]` range for `X` and we encounter `X != 1` assertion, we can tighten the range to `[2..10]`

Removes bounds checks for the following snippet:
```cs
void Test(ReadOnlySpan<char> name)
{
    if (name is [] or [':'] or [':', not ':', ..])
    {
        Console.WriteLine("test");
    }    
}
```

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1191071&view=ms.vss-build-web.run-extensions-tab)