### PR TITLE
[ci-test] disable lse outlining

### DIFF
--- a/eng/native/configureplatform.cmake
+++ b/eng/native/configureplatform.cmake
@@ -516,6 +516,10 @@ else()
     endif()
 endif()
 
+if(CLR_CMAKE_HOST_UNIX_ARM64)
+    add_compile_options(-mno-outline-atomics)
+endif()
+
 if (CLR_CMAKE_HOST_ANDROID)
     # Google requires all the native libraries to be aligned to 16 bytes (for 16k memory page size)
     # This applies only to 64-bit binaries

--- a/src/coreclr/pal/inc/pal.h
+++ b/src/coreclr/pal/inc/pal.h
@@ -3109,16 +3109,9 @@ Lse_##METHOD_DECL                                               \
                                                                 \
 EXTERN_C PALIMPORT inline RETURN_TYPE PALAPI METHOD_DECL        \
 {                                                               \
-    if (g_arm64_atomics_present)                                \
-    {                                                           \
-        return Lse_##METHOD_INVOC;                              \
-    }                                                           \
-    else                                                        \
-    {                                                           \
         RETURN_TYPE result = INTRINSIC_NAME;                    \
         PAL_InterlockedOperationBarrier();                      \
         return result;                                          \
-    }                                                           \
 }                                                               \
 
 #endif  // LSE_INSTRUCTIONS_ENABLED_BY_DEFAULT

--- a/src/coreclr/vm/util.hpp
+++ b/src/coreclr/vm/util.hpp
@@ -81,14 +81,7 @@ FORCEINLINE LONG  FastInterlockedCompareExchange(
     LONG Exchange,
     LONG Comperand)
 {
-    if (g_arm64_atomics_present)
-    {
-        return (LONG) __casal32((unsigned __int32*) Destination, (unsigned  __int32)Comperand, (unsigned __int32)Exchange);
-    }
-    else
-    {
-        return InterlockedCompareExchange(Destination, Exchange, Comperand);
-    }
+    return InterlockedCompareExchange(Destination, Exchange, Comperand);
 }
 
 FORCEINLINE LONG FastInterlockedCompareExchangeAcquire(
@@ -97,14 +90,7 @@ FORCEINLINE LONG FastInterlockedCompareExchangeAcquire(
   IN LONG Comperand
 )
 {
-    if (g_arm64_atomics_present)
-    {
-        return (LONG) __casa32((unsigned __int32*) Destination, (unsigned  __int32)Comperand, (unsigned __int32)Exchange);
-    }
-    else
-    {
-        return InterlockedCompareExchangeAcquire(Destination, Exchange, Comperand);
-    }
+    return InterlockedCompareExchangeAcquire(Destination, Exchange, Comperand);
 }
 
 FORCEINLINE LONG FastInterlockedCompareExchangeRelease(
@@ -113,14 +99,7 @@ FORCEINLINE LONG FastInterlockedCompareExchangeRelease(
   IN LONG Comperand
 )
 {
-    if (g_arm64_atomics_present)
-    {
-        return (LONG) __casl32((unsigned __int32*) Destination, (unsigned  __int32)Comperand, (unsigned __int32)Exchange);
-    }
-    else
-    {
-        return InterlockedCompareExchangeRelease(Destination, Exchange, Comperand);
-    }
+    return InterlockedCompareExchangeRelease(Destination, Exchange, Comperand);
 }
 
 #endif // defined(TARGET_WINDOWS) && defined(TARGET_ARM64)


### PR DESCRIPTION
It seems that `lock()`'s bottleneck (no contention, ThinLock) is CompareExchange. Since it's a Thin Lock we effectively know there is no thread contention. It seems like in that case we might want to avoid LSE outlining since LSE is more about high-contention scenarios.

this is a no-merge PR, just to run a benchmark.