### PR TITLE
Fix build fail in JIT/Directed/jmp/genericjmp test

### DIFF
--- a/src/tests/JIT/Directed/jmp/genericjmp.il
+++ b/src/tests/JIT/Directed/jmp/genericjmp.il
@@ -110,3 +110,13 @@
         ret
     }
 }
+
+.method public static int32 Main() il managed
+{
+    .entrypoint
+    call void [genericjmp]JmpGenericToGeneric::TestEntryPoint()
+    call void [genericjmp]JmpGenericToRegular::TestEntryPoint()
+    call void [genericjmp]JmpRegularToGeneric::TestEntryPoint()
+    ldc.i4 100
+    ret
+}


### PR DESCRIPTION
Missing Main method with BuildAllTestsAsStandalone=true.