### PR TITLE
Disable failing Apple mobile tests in extra-platforms

### DIFF
--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateClient.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.CreateClient.cs
@@ -157,6 +157,7 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS path length exceeds character limit for domain sockets")]
         public static async Task ConnectOnPipeFromExistingHandle_Throws_InvalidOperationException()
         {
             string pipeName = PipeStreamConformanceTests.GetUniquePipeName();

--- a/src/tests/JIT/jit64/opt/cse/HugeArray1.csproj
+++ b/src/tests/JIT/jit64/opt/cse/HugeArray1.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
+    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/46622 -->
+    <DisableProjectBuild Condition="'$(RuntimeVariant)' == 'monointerpreter'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="HugeArray1.cs" />

--- a/src/tests/JIT/jit64/opt/cse/HugeArray1.csproj
+++ b/src/tests/JIT/jit64/opt/cse/HugeArray1.csproj
@@ -3,7 +3,7 @@
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
     <!-- Tracking issue: https://github.com/dotnet/runtime/issues/46622 -->
-    <DisableProjectBuild Condition="'$(RuntimeVariant)' == 'monointerpreter'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(RuntimeVariant)' == 'monointerpreter' or '$(MonoForceInterpreter)' == 'true'">true</DisableProjectBuild>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="HugeArray1.cs" />


### PR DESCRIPTION
## Description

This PR adds platform-specific skip for iOS/tvOS in NamedPipeClientStream test and disables HugeArray1 with tracking issue.