### PR TITLE
Bump container image in jit-format.yml

### DIFF
--- a/.github/workflows/jit-format.yml
+++ b/.github/workflows/jit-format.yml
@@ -15,7 +15,7 @@ jobs:
         os:
           - name: linux
             image: ubuntu-latest
-            container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net10.0-cross-amd64
+            container: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64
             extension: '.sh'
             cross: '--cross'
             rootfs: '/crossrootfs/x64'


### PR DESCRIPTION
This was missed when the rest of the images was bumped in https://github.com/dotnet/runtime/commit/97669b0781f679d7831f64e879779c8723e2a07d