### PR TITLE
First part of async support in native AOT

### DIFF
--- a/src/coreclr/tools/Common/Compiler/AsyncMethodVariant.Mangling.cs
+++ b/src/coreclr/tools/Common/Compiler/AsyncMethodVariant.Mangling.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler
+{
+    public partial class AsyncMethodVariant : MethodDelegator, IPrefixMangledMethod
+    {
+        MethodDesc IPrefixMangledMethod.BaseMethod => _wrappedMethod;
+
+        string IPrefixMangledMethod.Prefix => "AsyncCallable";
+    }
+}

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1828,11 +1828,6 @@ namespace Internal.JitInterface
 
             if (result is MethodDesc method)
             {
-                pResolvedToken.hMethod = ObjectToHandle(method);
-
-                TypeDesc owningClass = method.OwningType;
-                pResolvedToken.hClass = ObjectToHandle(owningClass);
-
 #if !SUPPORT_JIT
                 _compilation.TypeSystemContext.EnsureLoadableMethod(method);
 #endif
@@ -1848,6 +1843,27 @@ namespace Internal.JitInterface
 #else
                 _compilation.NodeFactory.MetadataManager.GetDependenciesDueToAccess(ref _additionalDependencies, _compilation.NodeFactory, (MethodIL)methodIL, method);
 #endif
+
+                if (pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Await)
+                {
+                    // in rare cases a method that returns Task is not actually TaskReturning (i.e. returns T).
+                    // we cannot resolve to an Async variant in such case.
+                    // return NULL, so that caller would re-resolve as a regular method call
+                    method = method.IsAsync && method.GetMethodDefinition().Signature.ReturnsTaskOrValueTask()
+                        ? _compilation.TypeSystemContext.GetAsyncVariantMethod(method)
+                        : null;
+                }
+
+                if (method != null)
+                {
+                    pResolvedToken.hMethod = ObjectToHandle(method);
+                    pResolvedToken.hClass = ObjectToHandle(method.OwningType);
+                }
+                else
+                {
+                    pResolvedToken.hMethod = null;
+                    pResolvedToken.hClass = null;
+                }
             }
             else
             if (result is FieldDesc)
@@ -4316,7 +4332,7 @@ namespace Internal.JitInterface
                 flags.Set(CorJitFlag.CORJIT_FLAG_SOFTFP_ABI);
             }
 
-            if (this.MethodBeingCompiled.IsAsync)
+            if (this.MethodBeingCompiled.Signature.IsAsyncCall)
             {
                 flags.Set(CorJitFlag.CORJIT_FLAG_ASYNC);
             }

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -1366,6 +1366,9 @@ namespace Internal.JitInterface
 
         // token comes from resolved static virtual method
         CORINFO_TOKENKIND_ResolvedStaticVirtualMethod = 0x1000 | CORINFO_TOKENKIND_Method,
+
+        // token comes from runtime async awaiting pattern
+        CORINFO_TOKENKIND_Await = 0x2000 | CORINFO_TOKENKIND_Method,
     };
 
     // These are error codes returned by CompileMethod

--- a/src/coreclr/tools/Common/TypeSystem/IL/NativeAotILProvider.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/NativeAotILProvider.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+using ILCompiler;
+
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
@@ -309,6 +311,20 @@ namespace Internal.IL
                         return result;
                 }
 
+                if (ecmaMethod.IsAsync)
+                {
+                    if (ecmaMethod.Signature.ReturnsTaskOrValueTask())
+                    {
+                        return AsyncThunkILEmitter.EmitTaskReturningThunk(ecmaMethod, ((CompilerTypeSystemContext)ecmaMethod.Context).GetAsyncVariantMethod(ecmaMethod));
+                    }
+                    else
+                    {
+                        // We only allow non-Task returning runtime async methods in CoreLib
+                        if (ecmaMethod.OwningType.Module != ecmaMethod.Context.SystemModule)
+                            ThrowHelper.ThrowBadImageFormatException();
+                    }
+                }
+
                 MethodIL methodIL = EcmaMethodIL.Create(ecmaMethod);
                 if (methodIL != null)
                     return methodIL;
@@ -352,6 +368,11 @@ namespace Internal.IL
             if (method is ArrayMethod)
             {
                 return ArrayMethodILEmitter.EmitIL((ArrayMethod)method);
+            }
+            else
+            if (method is AsyncMethodVariant asyncVariantImpl)
+            {
+                return EcmaMethodIL.Create(asyncVariantImpl.Target);
             }
             else
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/NativeAotILProvider.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/NativeAotILProvider.cs
@@ -372,7 +372,15 @@ namespace Internal.IL
             else
             if (method is AsyncMethodVariant asyncVariantImpl)
             {
-                return EcmaMethodIL.Create(asyncVariantImpl.Target);
+                if (asyncVariantImpl.IsAsync)
+                {
+                    return EcmaMethodIL.Create(asyncVariantImpl.Target);
+                }
+                else
+                {
+                    // TODO: Emit thunk with async calling convention
+                    throw new NotImplementedException();
+                }
             }
             else
             {

--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AsyncThunks.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AsyncThunks.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Internal.TypeSystem;
+
+namespace Internal.IL.Stubs
+{
+    public static class AsyncThunkILEmitter
+    {
+        public static MethodIL EmitTaskReturningThunk(MethodDesc taskReturningMethod, MethodDesc asyncMethod)
+        {
+            TypeSystemContext context = taskReturningMethod.Context;
+
+            var emitter = new ILEmitter();
+            var codestream = emitter.NewCodeStream();
+
+            // TODO: match EmitTaskReturningThunk in CoreCLR VM
+
+            MethodSignature sig = asyncMethod.Signature;
+            int numParams = (sig.IsStatic || sig.IsExplicitThis) ? sig.Length : sig.Length + 1;
+            for (int i = 0; i < numParams; i++)
+                codestream.EmitLdArg(i);
+
+            codestream.Emit(ILOpcode.call, emitter.NewToken(asyncMethod));
+
+            if (sig.ReturnType.IsVoid)
+            {
+                codestream.Emit(ILOpcode.call, emitter.NewToken(context.SystemModule.GetKnownType("System.Threading.Tasks"u8, "Task"u8).GetKnownMethod("get_CompletedTask"u8, null)));
+            }
+            else
+            {
+                codestream.Emit(ILOpcode.call, emitter.NewToken(context.SystemModule.GetKnownType("System.Threading.Tasks"u8, "Task"u8).GetKnownMethod("FromResult"u8, null).MakeInstantiatedMethod(sig.ReturnType)));
+            }
+
+            codestream.Emit(ILOpcode.ret);
+
+            return emitter.Link(taskReturningMethod);
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -33,6 +33,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Common\Compiler\AsyncMethodVariant.cs" Link="Compiler\AsyncMethodVariant.cs" />
+    <Compile Include="..\..\Common\Compiler\AsyncMethodVariant.Mangling.cs" Link="Compiler\AsyncMethodVariant.Mangling.cs" />
+    <Compile Include="..\..\Common\Compiler\CompilerTypeSystemContext.Async.cs" Link="Compiler\CompilerTypeSystemContext.Async.cs" />
     <Compile Include="..\..\Common\Compiler\Win32Resources\ResourceData.cs" Link="Compiler\Win32Resources\ResourceData.cs" />
     <Compile Include="..\..\Common\Compiler\Win32Resources\ResourceData.Reader.cs" Link="Compiler\Win32Resources\ResourceData.Reader.cs" />
     <Compile Include="..\..\Common\Compiler\Win32Resources\ResourceData.ResourcesDataModel.cs" Link="Compiler\Win32Resources\ResourceData.ResourcesDataModel.cs" />
@@ -42,6 +45,7 @@
     <Compile Include="..\..\Common\TypeSystem\IL\DelegateInfo.cs">
       <Link>IL\DelegateInfo.cs</Link>
     </Compile>
+    <Compile Include="..\..\Common\TypeSystem\IL\Stubs\AsyncThunks.cs" Link="IL\Stubs\AsyncThunks.cs" />
     <Compile Include="..\..\Common\TypeSystem\IL\Stubs\DelegateThunks.Sorting.cs">
       <Link>IL\Stubs\DelegateThunks.Sorting.cs</Link>
     </Compile>

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.cs
@@ -220,10 +220,35 @@ namespace System.Runtime.CompilerServices
         public static void UnsafeAwaitAwaiter<TAwaiter>(TAwaiter awaiter) where TAwaiter : ICriticalNotifyCompletion { throw new NotImplementedException(); }
         [RequiresPreviewFeatures]
         public static void AwaitAwaiter<TAwaiter>(TAwaiter awaiter) where TAwaiter : INotifyCompletion { throw new NotImplementedException(); }
+#if NATIVEAOT
+        [RequiresPreviewFeatures]
+        public static void Await(System.Threading.Tasks.Task task)
+        {
+            TaskAwaiter awaiter = task.GetAwaiter();
+            if (!awaiter.IsCompleted)
+            {
+                throw new NotImplementedException();
+            }
+
+            awaiter.GetResult();
+        }
+        [RequiresPreviewFeatures]
+        public static T Await<T>(System.Threading.Tasks.Task<T> task)
+        {
+            TaskAwaiter<T> awaiter = task.GetAwaiter();
+            if (!awaiter.IsCompleted)
+            {
+                throw new NotImplementedException();
+            }
+
+            return awaiter.GetResult();
+        }
+#else
         [RequiresPreviewFeatures]
         public static void Await(System.Threading.Tasks.Task task) { throw new NotImplementedException(); }
         [RequiresPreviewFeatures]
         public static T Await<T>(System.Threading.Tasks.Task<T> task) { throw new NotImplementedException(); }
+#endif
         [RequiresPreviewFeatures]
         public static void Await(System.Threading.Tasks.ValueTask task) { throw new NotImplementedException(); }
         [RequiresPreviewFeatures]


### PR DESCRIPTION
Following works with runtime async enabled in Roslyn on native AOT:

```csharp
public class Async2Void
{
    public static void Main()
    {
        var t = AsyncTestEntryPoint(123, 456);
        t.Wait();
        Console.WriteLine(t.Result);
    }

    private static async Task<int> AsyncTestEntryPoint(int x, int y)
    {
        int result = await OtherAsync(x, y);
        return result;
    }

    private static async Task<int> OtherAsync(int x, int y)
    {
        Console.WriteLine(x);
        Console.WriteLine(y);
        return x + y;
    }
}
```

The implementation strategy is as follows:

* In the compiler, whenever someone holds an `EcmaMethod` of an asyncv2 method, it means they're holding the `RuntimeAsync` flavor of the method in CoreCLR VM parlance. The return value is a `Task`, `MethodDesc.IsAsync` is true, `MethodSignature.IsAsyncCallConv` is false. The IL is a thunk to the `AsyncVariantImplMethod` flavor.
* In the compiler, we have a new `MethodDesc` descendant: `AsyncVariantImplMethod`. This is the actual method with async calling convention that corresponds to some `EcmaMethod` with `IsAsync`==true. For this one: the return value is unwrapped from `Task`, `MethodDesc.IsAsync` is true, `MethodSignature.IsAsyncCallConv` is true. The IL is the actual IL that corresponds to the wrapped `EcmaMethod` on disk.

Cc @dotnet/ilc-contrib 