### PR TITLE
Add .devcontainer and .github to report-green.yml triggers

### DIFF
--- a/eng/pipelines/report-green.yml
+++ b/eng/pipelines/report-green.yml
@@ -12,6 +12,8 @@ pr:
     - '*'
   paths:
     include:
+    - .devcontainer/*
+    - .github/*
     - docs/*
     - '**/*.md'
     - '**/*.txt'


### PR DESCRIPTION
To make sure Build Analysis runs even when we only touch these folders.