### PR TITLE
JIT: Improve block IL offset range selection when splitting

### DIFF
--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -4847,7 +4847,7 @@ BasicBlock* Compiler::fgSplitBlockAfterNode(BasicBlock* curr, GenTree* node)
             {
                 if (node->OperIs(GT_IL_OFFSET))
                 {
-                    GenTreeILOffset* ilOffset = (*riter)->AsILOffset();
+                    GenTreeILOffset* ilOffset = node->AsILOffset();
                     DebugInfo        rootDI   = ilOffset->gtStmtDI.GetRoot();
                     if (rootDI.IsValid())
                     {

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -4866,7 +4866,7 @@ BasicBlock* Compiler::fgSplitBlockAfterNode(BasicBlock* curr, GenTree* node)
             splitPointILOffset = curr->bbCodeOffsEnd == BAD_IL_OFFSET ? curr->bbCodeOffs : curr->bbCodeOffsEnd;
         }
 
-        curr->bbCodeOffsEnd = splitPointILOffset;
+        curr->bbCodeOffsEnd  = splitPointILOffset;
         newBlock->bbCodeOffs = splitPointILOffset;
     }
     else

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -4840,11 +4840,34 @@ BasicBlock* Compiler::fgSplitBlockAfterNode(BasicBlock* curr, GenTree* node)
             }
         }
 
-        curr->bbCodeOffsEnd = max(curr->bbCodeOffs, splitPointILOffset);
+        if (splitPointILOffset == BAD_IL_OFFSET)
+        {
+            // Try to look forwards in the next block
+            for (GenTree* node : LIR::AsRange(newBlock))
+            {
+                if (node->OperIs(GT_IL_OFFSET))
+                {
+                    GenTreeILOffset* ilOffset = (*riter)->AsILOffset();
+                    DebugInfo        rootDI   = ilOffset->gtStmtDI.GetRoot();
+                    if (rootDI.IsValid())
+                    {
+                        splitPointILOffset = rootDI.GetLocation().GetOffset();
+                        break;
+                    }
+                }
+            }
+        }
 
-        // Also use this as the beginning offset of the next block. Presumably we could/should
-        // look to see if the first node is a GT_IL_OFFSET node, and use that instead.
-        newBlock->bbCodeOffs = min(splitPointILOffset, newBlock->bbCodeOffsEnd);
+        if (splitPointILOffset == BAD_IL_OFFSET)
+        {
+            // If we found no IL_OFFSET in the block then we cannot do anything
+            // but guess. Let's make the old block (upper part) contain
+            // everything if we have an end, and otherwise nothing.
+            splitPointILOffset = curr->bbCodeOffsEnd == BAD_IL_OFFSET ? curr->bbCodeOffs : curr->bbCodeOffsEnd;
+        }
+
+        curr->bbCodeOffsEnd = splitPointILOffset;
+        newBlock->bbCodeOffs = splitPointILOffset;
     }
     else
     {


### PR DESCRIPTION
In debug codegen we expect basic blocks to have valid start IL offsets, potentially to an invalid IL end offset.

When we split a block at a node, we find the end offset by looking backwards from that node for an `IL_OFFSET` node. If we find such a node, we use it as the split point IL offset. Otherwise we use `BAD_IL_OFFSET` and start the next block at the end offset (making it have a 0 byte range).

This latter behavior is problematic if the bottom portion of the split has its own `IL_OFFSET` nodes. In that case we can end up with `IL_OFFSET` nodes pointing outside the region of the basic block. If we later split again, then we can end up creating illegal IL offset ranges for unoptimized code. In an example case we first ended up with the bottom block having an IL offset range of `[0aa..0aa)` but still containing an `IL_OFFSET` with an offset of `092`. When we later split the bottom block again we ended up with `[0aa..0aa), [092..0aa)` and hit an assert.

To address the problem change the behavior in the following way:
* If we find no `IL_OFFSET` node in the upper block, then look for one in the lower block, and use its value as the split point
* If we find no `IL_OFFSET` in both blocks then consider the lower block empty and the upper block to have everything (same behavior as before).
* One exception to above: if the end was already `BAD_IL_OFFSET` then we have to consider the upper block to be empty as we cannot represent the other case

This fixes #119616. However for that specific case, which is inside async code, we will have the exact IL offset of the async call we are splitting at after #120303, so we will be able to do better. I'll make that change as part of that PR.