### PR TITLE
[release/8.0-staging] Add required MSBuild package dependencies

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -414,6 +414,18 @@
       <Uri>https://github.com/dotnet/msbuild</Uri>
       <Sha>195e7f5a3a8e51c37d83cd9e54cb99dc3fc69c22</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.Build.Framework" Version="17.8.3">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>195e7f5a3a8e51c37d83cd9e54cb99dc3fc69c22</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Build.Tasks.Core" Version="17.8.3">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>195e7f5a3a8e51c37d83cd9e54cb99dc3fc69c22</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.Build.Utilities.Core" Version="17.8.3">
+      <Uri>https://github.com/dotnet/msbuild</Uri>
+      <Sha>195e7f5a3a8e51c37d83cd9e54cb99dc3fc69c22</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.SourceBuild.Intermediate.msbuild" Version="17.8.3-preview-23613-06">
       <Uri>https://github.com/dotnet/msbuild</Uri>
       <Sha>195e7f5a3a8e51c37d83cd9e54cb99dc3fc69c22</Sha>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -183,9 +183,9 @@
     <MicrosoftDiagnosticsToolsRuntimeClientVersion>1.0.4-preview6.19326.1</MicrosoftDiagnosticsToolsRuntimeClientVersion>
     <DNNEVersion>2.0.5</DNNEVersion>
     <MicrosoftBuildVersion>17.8.3</MicrosoftBuildVersion>
-    <MicrosoftBuildTasksCoreVersion>$(MicrosoftBuildVersion)</MicrosoftBuildTasksCoreVersion>
-    <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildVersion)</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>$(MicrosoftBuildVersion)</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildTasksCoreVersion>17.8.3</MicrosoftBuildTasksCoreVersion>
+    <MicrosoftBuildFrameworkVersion>17.8.3</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>17.8.3</MicrosoftBuildUtilitiesCoreVersion>
     <NugetFrameworksVersion>6.2.4</NugetFrameworksVersion>
     <NugetProjectModelVersion>6.2.4</NugetProjectModelVersion>
     <NugetPackagingVersion>6.2.4</NugetPackagingVersion>


### PR DESCRIPTION
Backport of https://github.com/dotnet/installer/blob/release/8.0.1xx/src/SourceBuild/patches/runtime/0002-Update-MSBuild-dependencies.patch

Fixes: https://github.com/dotnet/runtime/issues/101395

Source-build requires explicit package versions and references for all dependencies. This PR backports the long-standing patch. It would help avoid issues with frequent patch updates.