### PR TITLE
Micro-optimization in IsAsciiLetterOrDigit

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Char.cs
@@ -326,7 +326,7 @@ namespace System
         /// This determines whether the character is in the range 'A' through 'Z', inclusive,
         /// 'a' through 'z', inclusive, or '0' through '9', inclusive.
         /// </remarks>
-        public static bool IsAsciiLetterOrDigit(char c) => IsAsciiLetter(c) | IsBetween(c, '0', '9');
+        public static bool IsAsciiLetterOrDigit(char c) => IsBetween(c, '0', '9') | IsAsciiLetter(c);
 
         /// <summary>Indicates whether a character is categorized as an ASCII hexadecimal digit.</summary>
         /// <param name="c">The character to evaluate.</param>


### PR DESCRIPTION
Saves an instruction on XARCH:
`lea` vs `mov`, `add`

Example diff:

```diff
        mov      edx, edi
        movzx    rdx, word  ptr [r12+2*rdx]
-       mov      esi, edx
-       or       esi, 32
-       add      esi, -97
-       cmp      esi, 25
+       lea      esi, [rdx-0x30]
+       cmp      esi, 9
        setbe    sil
        movzx    rsi, sil
-       add      edx, -48
-       cmp      edx, 9
+       or       edx, 32
+       add      edx, -97
+       cmp      edx, 25
        setbe    dl
        movzx    rdx, dl
        or       edx, esi
-       je       G_M15724_IG11
+       je       SHORT G_M15724_IG11
        inc      edi
        cmp      edi, 8
        jge      G_M15724_IG11
        jmp      SHORT G_M15724_IG14
-						;; size=59 bbWeight=0.64 PerfScore 7.04
+						;; size=53 bbWeight=0.64 PerfScore 7.04
```