### PR TITLE
Unify SEH wrapping for method calls in the interpexec.cpp

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2451,8 +2451,8 @@ MAIN_LOOP:
                     // This needs to be optimized, not operating at MethodDesc level, rather with ftnptr
                     // slots containing the interpreter IR pointer
                     targetMethod = CallWithSEHWrapper(
-                        [&pMD, &callArgsOffset, &stack]() {
-                            return pMD->GetMethodDescOfVirtualizedCode(LOCAL_VAR_ADDR(callArgsOffset + INTERP_STACK_SLOT_SIZE, OBJECTREF), pMD->GetMethodTable());
+                        [&pMD, &pThisArg]() {
+                            return pMD->GetMethodDescOfVirtualizedCode(pMD, pThisArg);
                         });
 
                     ip += 4;

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2418,7 +2418,7 @@ MAIN_LOOP:
                     // slots containing the interpreter IR pointer
                     targetMethod = CallWithSEHWrapper(
                         [&pMD, &pThisArg]() {
-                            return pMD->GetMethodDescOfVirtualizedCode(pMD, pThisArg);
+                            return pMD->GetMethodDescOfVirtualizedCode(pThisArg, pMD->GetMethodTable());
                         });
 
                     ip += 4;

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -722,40 +722,6 @@ void* DoGenericLookup(void* genericVarAsPtr, InterpGenericLookup* pLookup)
     return result;
 }
 
-MethodDesc* CallGetMethodDescOfVirtualizedCode(MethodDesc *pMD, OBJECTREF *orThis)
-{
-    STATIC_STANDARD_VM_CONTRACT;
-    _ASSERTE(pMD != NULL);
-
-    struct Param
-    {
-        MethodDesc *pMD;
-        OBJECTREF *orThis;
-        MethodDesc *pRetMD;
-    }
-    param = { pMD, orThis, NULL };
-
-    PAL_TRY(Param *, pParam, &param)
-    {
-        pParam->pRetMD = pParam->pMD->GetMethodDescOfVirtualizedCode(pParam->orThis, pParam->pMD->GetMethodTable());
-    }
-    PAL_EXCEPT_FILTER(IgnoreCppExceptionFilter)
-    {
-        // There can be both C++ (thrown by the COMPlusThrow) and managed exceptions thrown
-        // from the GetMethodDescOfVirtualizedCode call chain.
-        // We need to process only managed ones here, the C++ ones are handled by the
-        // INSTALL_/UNINSTALL_UNWIND_AND_CONTINUE_HANDLER in the InterpExecMethod.
-        // The managed ones are represented by SEH exception, which cannot be handled there
-        // because it is not possible to handle both SEH and C++ exceptions in the same frame.
-        GCX_COOP_NO_DTOR();
-        OBJECTREF ohThrowable = GetThread()->LastThrownObject();
-        DispatchManagedException(ohThrowable);
-    }
-    PAL_ENDTRY
-
-    return param.pRetMD;
-}
-
 void InterpExecMethod(InterpreterFrame *pInterpreterFrame, InterpMethodContextFrame *pFrame, InterpThreadContext *pThreadContext, ExceptionClauseArgs *pExceptionClauseArgs)
 {
     CONTRACTL


### PR DESCRIPTION
This change adds a way to wrap any method call in a SEH exception try / catch. Until now, we were adding a new function for each case that needed this wrapping.

I've verified that the generated code in the release build is the same as before this change.