### PR TITLE
[wasm][coreclr] Fix native calls to instance methods with 0 parameters

### DIFF
--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -2193,8 +2193,8 @@ void ArgIteratorTemplate<ARGITERATOR_BASE>::ForceSigWalk()
 #ifdef TARGET_WASM
     if (this->NumFixedArgs() == 0)
     {
-        // we have zero arguments, but we still need to reserve space for hidden arguments which are in registers on other architectures
-        // in non-zero argument cases, the offset is already included in first argument offset
+        // We have zero arguments, but we still need to reserve space for hidden arguments which are in registers on other architectures
+        // in non-zero argument cases, the offset is already included in first argument offset.
         maxOffset += m_ofsStack;
     }
 #endif // TARGET_WASM

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -2194,6 +2194,7 @@ void ArgIteratorTemplate<ARGITERATOR_BASE>::ForceSigWalk()
     if (this->NumFixedArgs() == 0)
     {
         // we have zero arguments, but we still need to reserve space for hidden arguments which are in registers on other architectures
+        // in non-zero argument cases, the offset is already included in first argument offset
         maxOffset += m_ofsStack;
     }
 #endif // TARGET_WASM

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -2190,6 +2190,14 @@ void ArgIteratorTemplate<ARGITERATOR_BASE>::ForceSigWalk()
     // Clear the iterator started flag
     m_dwFlags &= ~ITERATION_STARTED;
 
+#ifdef TARGET_WASM
+    if (this->NumFixedArgs() == 0)
+    {
+        // we have zero arguments, but we still need to reserve space for hidden arguments which are in registers on other architectures
+        maxOffset += m_ofsStack;
+    }
+#endif // TARGET_WASM
+
     int nSizeOfArgStack = maxOffset - TransitionBlock::GetOffsetOfArgs();
 
 #if defined(TARGET_AMD64) && !defined(UNIX_AMD64_ABI)


### PR DESCRIPTION
The `nSizeOfArgStack` was calculated wrong, because the size of This argument was not included. For cases with more than zero parameters it is included in first arg offset.

It is different on wasm, because we don't use register for This argument as all the other architectures.

It fixes the problem in
https://github.com/dotnet/runtime/issues/121107 where the `GetExceptionMessage` call ended without the `OBJECTREF throwable` on the stack, resulting in random pointer instead.