### PR TITLE
Remove obsolete NativeExceptionHolder

### DIFF
--- a/src/coreclr/dlls/mscordac/mscordac_unixexports.src
+++ b/src/coreclr/dlls/mscordac/mscordac_unixexports.src
@@ -30,7 +30,6 @@ nativeStringResourceTable_mscorrc
 #PAL_GetTransportName
 #PAL_GetCurrentThread
 #PAL_GetCpuLimit
-#PAL_GetNativeExceptionHolderHead
 #PAL_GetPalHostModule
 #PAL_GetSymbolModuleBase
 #PAL_GetTransportPipeName

--- a/src/coreclr/inc/ex.h
+++ b/src/coreclr/inc/ex.h
@@ -7,9 +7,7 @@
 
 #ifdef HOST_UNIX
 #define EX_TRY_HOLDER                                   \
-    HardwareExceptionHolder                             \
-    NativeExceptionHolderCatchAll __exceptionHolder;    \
-    __exceptionHolder.Push();                           \
+    HardwareExceptionHolder
 
 #else // HOST_UNIX
 #define EX_TRY_HOLDER

--- a/src/coreclr/pal/src/exception/seh.cpp
+++ b/src/coreclr/pal/src/exception/seh.cpp
@@ -365,37 +365,4 @@ bool CatchHardwareExceptionHolder::IsEnabled()
     return pThread ? pThread->IsHardwareExceptionsEnabled() : false;
 }
 
-/*++
-
-  NativeExceptionHolderBase implementation
-
---*/
-
-static thread_local NativeExceptionHolderBase *t_nativeExceptionHolderHead = nullptr;
-
-extern "C"
-NativeExceptionHolderBase **
-PAL_GetNativeExceptionHolderHead()
-{
-    return &t_nativeExceptionHolderHead;
-}
-
-NativeExceptionHolderBase *
-NativeExceptionHolderBase::FindNextHolder(NativeExceptionHolderBase *currentHolder, PVOID stackLowAddress, PVOID stackHighAddress)
-{
-    NativeExceptionHolderBase *holder = (currentHolder == nullptr) ? t_nativeExceptionHolderHead : currentHolder->m_next;
-
-    while (holder != nullptr)
-    {
-        if (((void *)holder >= stackLowAddress) && ((void *)holder < stackHighAddress))
-        {
-            return holder;
-        }
-        // Get next holder
-        holder = holder->m_next;
-    }
-
-    return nullptr;
-}
-
 #include "seh-unwind.cpp"

--- a/src/coreclr/vm/callhelpers.h
+++ b/src/coreclr/vm/callhelpers.h
@@ -468,20 +468,6 @@ void FillInRegTypeMap(int argOffset, CorElementType typ, BYTE * pMap);
 /* Macros used to indicate a call to managed code is starting/ending   */
 /***********************************************************************/
 
-#ifdef TARGET_UNIX
-// Install a native exception holder that doesn't catch any exceptions but its presence
-// in a stack range of native frames indicates that there was a call from native to
-// managed code. It is used by the DispatchManagedException to detect the case when
-// the INSTALL_MANAGED_EXCEPTION_DISPATCHER was not at the managed to native boundary.
-// For example in the PreStubWorker, which can be called from both native and managed
-// code.
-#define INSTALL_CALL_TO_MANAGED_EXCEPTION_HOLDER() \
-    NativeExceptionHolderNoCatch __exceptionHolder;    \
-    __exceptionHolder.Push();
-#else // TARGET_UNIX
-#define INSTALL_CALL_TO_MANAGED_EXCEPTION_HOLDER()
-#endif // TARGET_UNIX
-
 enum EEToManagedCallFlags
 {
     EEToManagedDefault                  = 0x0000,
@@ -509,7 +495,6 @@ enum EEToManagedCallFlags
             CURRENT_THREAD->HandleThreadAbort();                                \
         }                                                                       \
     }                                                                           \
-    INSTALL_CALL_TO_MANAGED_EXCEPTION_HOLDER();                                 \
     INSTALL_COMPLUS_EXCEPTION_HANDLER_NO_DECLARE();
 
 #define END_CALL_TO_MANAGED()                                                   \


### PR DESCRIPTION
This holder was used for the old EH on Unix. Now that the old EH has been removed from the runtime quite some time ago, it is of no use anymore. 

This change removes it.