### PR TITLE
Fix generic argument access in filter funclets

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5729,6 +5729,29 @@ retry_emit:
             {
                 AddIns(INTOP_LOAD_EXCEPTION);
                 m_pLastNewIns->SetDVar(m_pCBB->clauseVarIndex);
+
+                // To allow filter clauses in generic methods to access the generic argument,
+                // we copy that argument variable from the parent frame to the filter's frame.
+                // The target variable offset is the same as the one in the parent frame.
+                if ((m_pCBB->clauseType == BBClauseFilter) && (m_paramArgIndex != -1))
+                {
+                    AddIns(INTOP_LOAD_FRAMEVAR);
+                    PushInterpType(InterpTypeI, NULL);
+                    m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
+
+                    m_pStackPointer--;
+                    InterpVar *pParamArgVar = &m_pVars[m_paramArgIndex];
+                    int32_t opcode = GetLdindForType(pParamArgVar->interpType);
+                    AddIns(opcode);
+                    m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
+                    m_pLastNewIns->SetDVar(pParamArgVar->offset);
+                    m_pLastNewIns->data[0] = pParamArgVar->offset;
+                    if (pParamArgVar->interpType == InterpTypeVT)
+                    {
+                        int size = m_compHnd->getClassSize(pParamArgVar->clsHnd);
+                        m_pLastNewIns->data[1] = size;
+                    }
+                }
             }
         }
 

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5740,17 +5740,11 @@ retry_emit:
                     m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
 
                     m_pStackPointer--;
-                    InterpVar *pParamArgVar = &m_pVars[m_paramArgIndex];
-                    int32_t opcode = GetLdindForType(pParamArgVar->interpType);
+                    int32_t opcode = GetLdindForType(m_pVars[m_paramArgIndex].interpType);
                     AddIns(opcode);
                     m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
-                    m_pLastNewIns->SetDVar(pParamArgVar->offset);
-                    m_pLastNewIns->data[0] = pParamArgVar->offset;
-                    if (pParamArgVar->interpType == InterpTypeVT)
-                    {
-                        int size = m_compHnd->getClassSize(pParamArgVar->clsHnd);
-                        m_pLastNewIns->data[1] = size;
-                    }
+                    m_pLastNewIns->SetDVar(m_pVars[m_paramArgIndex].offset);
+                    m_pLastNewIns->data[0] = m_pVars[m_paramArgIndex].offset;
                 }
             }
         }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5743,7 +5743,7 @@ retry_emit:
                     int32_t opcode = GetLdindForType(m_pVars[m_paramArgIndex].interpType);
                     AddIns(opcode);
                     m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
-                    m_pLastNewIns->SetDVar(m_pVars[m_paramArgIndex].offset);
+                    m_pLastNewIns->SetDVar(m_paramArgIndex);
                     m_pLastNewIns->data[0] = m_pVars[m_paramArgIndex].offset;
                 }
             }

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -756,7 +756,7 @@ private:
     int32_t m_varsSize = 0;
     int32_t m_varsCapacity = 0;
     int32_t m_numILVars = 0;
-    int32_t m_paramArgIndex = 0; // Index of the type parameter argument in the m_pVars array.
+    int32_t m_paramArgIndex = -1; // Index of the type parameter argument in the m_pVars array.
     // For each catch or filter clause, we create a variable that holds the exception object.
     // This is the index of the first such variable.
     int32_t m_clauseVarsIndex = 0;


### PR DESCRIPTION
In funclets of generic methods, access to the generic argument may be needed. It doesn't work correctly, because the filter funclet has its own locals and various IR instructions that use that argument cannot access it.

This change adds copying of that argument from the parent frame to the funclet frame at the same offset so that the access to it just works.