### PR TITLE
Add MemoryBarrier to SyncBlock Lock upgrade path

### DIFF
--- a/src/coreclr/gc/gc.h
+++ b/src/coreclr/gc/gc.h
@@ -141,8 +141,6 @@ extern size_t gc_global_mechanisms[MAX_GLOBAL_GC_MECHANISMS_COUNT];
 class DacHeapWalker;
 #endif
 
-#define MP_LOCKS
-
 #ifdef FEATURE_MANUALLY_MANAGED_CARD_BUNDLES
 extern "C" uint32_t* g_gc_card_bundle_table;
 #endif
@@ -243,11 +241,11 @@ struct alloc_context : gc_alloc_context
     }
 
     // How the alloc_count field is organized -
-    // 
+    //
     // high 16-bits are for the handle info, out of which
-    // high 10 bits store the cpu index. 
+    // high 10 bits store the cpu index.
     // low 6 bits store the number of handles allocated so far (before the next reset).
-    // 
+    //
     // low 16-bits are for the actual alloc_count used by balance_heaps
     inline void init_alloc_count()
     {

--- a/src/coreclr/vm/syncblk.cpp
+++ b/src/coreclr/vm/syncblk.cpp
@@ -1765,6 +1765,8 @@ OBJECTHANDLE SyncBlock::GetOrCreateLock(OBJECTREF lockObj)
         return existingHandle;
     }
 
+    MemoryBarrier(); // Ensure that subsequent reads of m_Lock see the handle before we clear the thin lock info.
+
     // Our lock instance is in the sync block now.
     // Don't release it.
     lockHandle.SuppressRelease();

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -451,7 +451,7 @@ class SyncBlock
   public:
     SyncBlock(DWORD indx)
         : m_Lock((OBJECTHANDLE)NULL)
-        , m_thinLock(0)
+        , m_thinLock()
         , m_dwSyncIndex(indx)
 #ifdef FEATURE_METADATA_UPDATER
         , m_pEnCInfo(PTR_NULL)

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -991,13 +991,6 @@ struct cdac_data<ObjHeader>
 
 typedef DPTR(class ObjHeader) PTR_ObjHeader;
 
-
-#define ENTER_SPIN_LOCK(pOh)        \
-    pOh->EnterSpinLock();
-
-#define LEAVE_SPIN_LOCK(pOh)        \
-    pOh->ReleaseSpinLock();
-
 #ifdef TARGET_X86
 #include <poppack.h>
 #endif // TARGET_X86


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/121287

Validation: Every run of runtime-coreclr gcstress-extra has at least one hit of the failure in the link for some out-of-proc test. This PR has no failures of the sort. This is not my favorite form of validation, but I don't think I'm going to get much better as I can't repro locally.

May also fix https://github.com/dotnet/runtime/issues/121285, but I'm not sure.