### PR TITLE
Make a test scenario less stressful.

### DIFF
--- a/src/tests/GC/API/GC/GetTotalAllocatedBytes.cs
+++ b/src/tests/GC/API/GC/GetTotalAllocatedBytes.cs
@@ -110,7 +110,7 @@ public class Test_GetTotalAllocatedBytes
             object lck = new object();
 
             tsk = Task.Run(() => {
-                while (running)
+                for (int i = 0; i < 1000; i++)
                 {
                     Thread thd = new Thread(() => {
                         lock (lck)
@@ -121,11 +121,14 @@ public class Test_GetTotalAllocatedBytes
 
                     thd.Start();
                     thd.Join();
+
+                    if (!running)
+                        break;
                 }
             });
 
             Counts previous = default(Counts);
-            for (int i = 0; i < 1000; ++i)
+            for (int i = 0; i < 100; ++i)
             {
                 lock (lck)
                 {


### PR DESCRIPTION
Test-only fix.

Fixes: #119187

The testcase creates and joins threads in a loop while another thread calls `GetTotalAllocatedBytes` and checks various invariants: if the result is not negative, grows over time, ...
This is not a stress test. The purpose is just to demonstrate that `GetTotalAllocatedBytes` works in the presence of threads starting and exiting. It does not need to run for very long.

Creating/joining threads nonstop appear to cause issues on arm32. Sometimes we see OOMs. 
In particular there is a concern that the thread that creates threads + the actual threads may starve the main thread, thus arbitrarily prolonging the scenario.

Thie fix tries to limit the total number of threads that the test creates, making its completion more deterministic.