### PR TITLE
Don't cast the pointer type for delete

### DIFF
--- a/src/coreclr/pal/src/include/pal/synchcache.hpp
+++ b/src/coreclr/pal/src/include/pal/synchcache.hpp
@@ -153,7 +153,7 @@ namespace CorUnix
             }
             else
             {
-                delete (char *)pNode;
+                delete pNode;
             }
             Unlock(pthrCurrent);
         }


### PR DESCRIPTION
This was causing asan errors.

Fixes https://github.com/dotnet/runtime/issues/121339