### PR TITLE
Disable several tests incompatible with interpreter

### DIFF
--- a/src/tests/Interop/COM/Directory.Build.props
+++ b/src/tests/Interop/COM/Directory.Build.props
@@ -6,6 +6,8 @@
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
     <!-- COM is not supported on Mono -->
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
+    <!-- COM is not supported with Interpreter. See https://github.com/dotnet/runtime/issues/118965 -->
+    <InterpreterIncompatible>true</InterpreterIncompatible>
   </PropertyGroup>
 
 </Project>

--- a/src/tests/Interop/IJW/NativeVarargs/NativeVarargsTest.csproj
+++ b/src/tests/Interop/IJW/NativeVarargs/NativeVarargsTest.csproj
@@ -4,6 +4,8 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Native varargs not supported on ARM -->
     <CLRTestTargetUnsupported Condition="'$(TargetArchitecture)' == 'arm' or '$(TargetArchitecture)' == 'armel'">true</CLRTestTargetUnsupported>
+    <!-- Native varargs are not supported with Interpreter. See https://github.com/dotnet/runtime/issues/118965 -->
+    <InterpreterIncompatible>true</InterpreterIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <CopyDebugCRTDllsToOutputDirectory>true</CopyDebugCRTDllsToOutputDirectory>

--- a/src/tests/JIT/Directed/pinvoke/calli_excep.il
+++ b/src/tests/JIT/Directed/pinvoke/calli_excep.il
@@ -27,6 +27,11 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
+      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ActiveIssueAttribute::.ctor(string, class [mscorlib]System.Type, string[]) = {
+          string('https://github.com/dotnet/runtime/issues/118965')
+          type([TestLibrary]TestLibrary.Utilities)
+          string[1] ('IsCoreClrInterpreter')
+      }
       .entrypoint
       .custom instance void [mscorlib]System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptionsAttribute::.ctor() = ( 01 00 00 00 ) 
       .custom instance void [mscorlib]System.Security.SecurityCriticalAttribute::.ctor() = ( 01 00 00 00 ) 

--- a/src/tests/baseservices/callconvs/TestCallingConventions.cs
+++ b/src/tests/baseservices/callconvs/TestCallingConventions.cs
@@ -170,7 +170,11 @@ public unsafe class Program
         try
         {
             BlittableFunctionPointers();
-            NonblittableFunctionPointers();
+            // This requires pinvoke marshalling which is not currently supported by the interpreter. See https://github.com/dotnet/runtime/issues/118965
+            if (!TestLibrary.Utilities.IsCoreClrInterpreter)
+            {
+                NonblittableFunctionPointers();
+            }
         }
         catch (Exception e)
         {


### PR DESCRIPTION
These tests use COM interop, native varargs, marshalled pinvoke or handle exception thrown in pinvoked native code.