### PR TITLE
Report CALLCONV_ASYNCCALL and FLAG_ASYNC on AsyncExplicitImpl methods

### DIFF
--- a/src/coreclr/tools/Common/Compiler/AsyncMethodVariant.cs
+++ b/src/coreclr/tools/Common/Compiler/AsyncMethodVariant.cs
@@ -34,12 +34,10 @@ namespace ILCompiler
         private MethodSignature InitializeSignature()
         {
             var signature = _wrappedMethod.Signature;
-            Debug.Assert(!signature.IsAsyncCall);
             Debug.Assert(signature.ReturnsTaskOrValueTask());
             TypeDesc md = signature.ReturnType;
             MethodSignatureBuilder builder = new MethodSignatureBuilder(signature);
             builder.ReturnType = md.HasInstantiation ? md.Instantiation[0] : this.Context.GetWellKnownType(WellKnownType.Void);
-            builder.Flags = signature.Flags | MethodSignatureFlags.AsyncCall;
             return (_asyncSignature = builder.ToSignature());
         }
 

--- a/src/coreclr/tools/Common/Compiler/MethodExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/MethodExtensions.cs
@@ -153,5 +153,12 @@ namespace ILCompiler
             }
             return false;
         }
+
+        /// <summary>
+        /// Determines whether a method uses the async calling convention.
+        /// Returns true for async variants (compiler-generated wrappers around Task-returning methods)
+        /// and for special async intrinsics that don't return Task/ValueTask but use async calling convention.
+        /// </summary>
+        public static bool IsAsyncCall(this MethodDesc method) => method.IsAsync && (method.IsAsyncVariant() || !method.Signature.ReturnsTaskOrValueTask());
     }
 }

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -833,9 +833,7 @@ namespace Internal.JitInterface
         {
             Get_CORINFO_SIG_INFO(method.Signature, sig, scope);
 
-            // Get_CORINFO_SIG_INFO above will have correctly set CORINFO_CALLCONV_ASYNCCALL for async variants,
-            // however the special async intrinsics don't set the async bit in their signature. Compensate for that.
-            if (method.IsAsync && !method.Signature.ReturnsTaskOrValueTask())
+            if (method.IsAsyncCall())
                 sig->callConv |= CorInfoCallConv.CORINFO_CALLCONV_ASYNCCALL;
 
             // Does the method have a hidden parameter?
@@ -882,7 +880,6 @@ namespace Internal.JitInterface
 
             if (!signature.IsStatic) sig->callConv |= CorInfoCallConv.CORINFO_CALLCONV_HASTHIS;
             if (signature.IsExplicitThis) sig->callConv |= CorInfoCallConv.CORINFO_CALLCONV_EXPLICITTHIS;
-            if (signature.IsAsyncCall) sig->callConv |= CorInfoCallConv.CORINFO_CALLCONV_ASYNCCALL;
 
             TypeDesc returnType = signature.ReturnType;
 
@@ -4337,10 +4334,7 @@ namespace Internal.JitInterface
                 flags.Set(CorJitFlag.CORJIT_FLAG_SOFTFP_ABI);
             }
 
-            // Signature.IsAsyncCall will do the right thing for async variants, however the special async
-            // intrinsics don't set the async bit in their signature. Compensate for that.
-            if (this.MethodBeingCompiled.Signature.IsAsyncCall
-                || (this.MethodBeingCompiled.IsAsync && !this.MethodBeingCompiled.Signature.ReturnsTaskOrValueTask()))
+            if (this.MethodBeingCompiled.IsAsyncCall())
             {
                 flags.Set(CorJitFlag.CORJIT_FLAG_ASYNC);
             }

--- a/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MethodDesc.cs
@@ -23,8 +23,6 @@ namespace Internal.TypeSystem
 
         Static = 0x0010,
         ExplicitThis = 0x0020,
-
-        AsyncCall                            = 0x0100,
     }
 
     public enum EmbeddedSignatureDataKind
@@ -137,14 +135,6 @@ namespace Internal.TypeSystem
             get
             {
                 return (_flags & MethodSignatureFlags.ExplicitThis) != 0;
-            }
-        }
-
-        public bool IsAsyncCall
-        {
-            get
-            {
-                return (_flags & MethodSignatureFlags.AsyncCall) != 0;
             }
         }
 


### PR DESCRIPTION
`Signature.IsAsyncCall` is not true for these because we currently only set it on variants.

We could also fix this when we materialize the signature from the ECMA file, but I'm not sure we want to go there.

Cc @dotnet/ilc-contrib 