### PR TITLE
Avoid shipping libclrinterpreter in wasm runtime packs

### DIFF
--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -223,7 +223,6 @@
 
       <LibrariesRuntimeFiles Condition="'$(TargetOS)' == 'browser' and '$(RuntimeFlavor)' == 'CoreCLR'"
                              Include="
-        $(CoreCLRSharedFrameworkDir)libclrinterpreter.a;
         $(CoreCLRSharedFrameworkDir)libcoreclr_static.a;
         $(CoreCLRSharedFrameworkDir)libcoreclrminipal.a;
         $(CoreCLRSharedFrameworkDir)libcoreclrpal.a;

--- a/src/coreclr/interpreter/CMakeLists.txt
+++ b/src/coreclr/interpreter/CMakeLists.txt
@@ -67,7 +67,7 @@ target_link_libraries(clrinterpreter
         ${INTERPRETER_LINK_LIBRARIES}
     )
 
-if (CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS OR CLR_CMAKE_TARGET_MACCATALYST)
+if (FEATURE_STATICALLY_LINKED)
     install_clr(TARGETS clrinterpreter DESTINATIONS . COMPONENT runtime OPTIONAL)
 else()
     install_clr(TARGETS clrinterpreter DESTINATIONS . sharedFramework COMPONENT runtime OPTIONAL)

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -262,7 +262,6 @@
     <PlatformManifestFileEntry Include="ILLink.Substitutions.WasmIntrinsics.xml" IsNative="true" />
     <PlatformManifestFileEntry Include="ILLink.Substitutions.NoWasmIntrinsics.xml" IsNative="true" />
     <!-- CoreCLR WASM-specific files -->
-    <PlatformManifestFileEntry Include="libclrinterpreter.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libcoreclrminipal.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libcoreclrpal.a" IsNative="true" />
     <PlatformManifestFileEntry Include="libgcinfo_unix_wasm.a" IsNative="true" />

--- a/src/native/corehost/browserhost/CMakeLists.txt
+++ b/src/native/corehost/browserhost/CMakeLists.txt
@@ -57,7 +57,6 @@ set(SHARED_CLR_DESTINATION
 # these dependencies assume that you built `libs.native+clr.runtime` subsets first
 LIST(APPEND NATIVE_LIBS
     ${SHARED_CLR_DESTINATION}/libcoreclr_static.a
-    ${SHARED_CLR_DESTINATION}/libclrinterpreter.a
     ${SHARED_CLR_DESTINATION}/libnativeresourcestring.a
     ${SHARED_CLR_DESTINATION}/libgcinfo_unix_wasm.a
     ${SHARED_CLR_DESTINATION}/libcoreclrminipal.a


### PR DESCRIPTION
## Description

The libclrinterpreter is already linked into the coreclr_static library for wasm in:
https://github.com/dotnet/runtime/blob/e0837be345978738d0387055e0eb1e2b989dd787/src/coreclr/dlls/mscoree/coreclr/CMakeLists.txt#L201

This PR updates the build to avoid shipping libclrinterpreter in the wasm runtime packs as separate static librariy, which resolves the manifest errors:
```
The following files are missing entries in the templated manifest: libclrinterpreter.dylib. 
```

Fixes https://github.com/dotnet/runtime/issues/121399