### PR TITLE
Disable more tests for interpreter

### DIFF
--- a/src/tests/JIT/Directed/aliasing_retbuf/aliasing_retbuf.cs
+++ b/src/tests/JIT/Directed/aliasing_retbuf/aliasing_retbuf.cs
@@ -56,12 +56,16 @@ public unsafe class AliasingRetBuf
             failures |= 16;
         }
 
-        f = new Foo { A = 3, B = 2, C = 1 };
-        CallRefFPtr(ref f, (delegate* unmanaged[Cdecl, SuppressGCTransition]<ref Foo, Foo>)export);
-        if (f.A != 2 || f.B != 1 || f.C != 3)
+        // This requires pinvoke marshalling which is not currently supported by the interpreter. See https://github.com/dotnet/runtime/issues/118965
+        if (!TestLibrary.Utilities.IsCoreClrInterpreter)
         {
-            Console.WriteLine("FAIL: After CallRefFPtr: {0}", f);
-            failures |= 32;
+            f = new Foo { A = 3, B = 2, C = 1 };
+            CallRefFPtr(ref f, (delegate* unmanaged[Cdecl, SuppressGCTransition]<ref Foo, Foo>)export);
+            if (f.A != 2 || f.B != 1 || f.C != 3)
+            {
+                Console.WriteLine("FAIL: After CallRefFPtr: {0}", f);
+                failures |= 32;
+            }
         }
 
         if (failures == 0)

--- a/src/tests/JIT/Directed/aliasing_retbuf/aliasing_retbuf.csproj
+++ b/src/tests/JIT/Directed/aliasing_retbuf/aliasing_retbuf.csproj
@@ -11,4 +11,7 @@
   <ItemGroup>
     <CMakeProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
 </Project>

--- a/src/tests/JIT/Directed/pinvoke/calli_excep.il
+++ b/src/tests/JIT/Directed/pinvoke/calli_excep.il
@@ -9,6 +9,9 @@
 .assembly extern xunit.core {}
 
 .assembly extern mscorlib { }
+.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
+.assembly extern TestLibrary { .ver 0:0:0:0 }
+
 .assembly calli_excep { }
 .namespace JitTest
 {

--- a/src/tests/JIT/Directed/pinvoke/calli_excep.ilproj
+++ b/src/tests/JIT/Directed/pinvoke/calli_excep.ilproj
@@ -4,6 +4,8 @@
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Native exception interop is not supported with interpreter. See https://github.com/dotnet/runtime/issues/118965 -->
+    <InterpreterIncompatible>true</InterpreterIncompatible>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
@@ -11,5 +13,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="calli_excep.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/Dev11/Dev11_468598/Test_HndIndex_10_Plain.il
+++ b/src/tests/JIT/Regression/Dev11/Dev11_468598/Test_HndIndex_10_Plain.il
@@ -39,6 +39,10 @@
             string('Needs triage')
             int32(0x2) // Mono
         }
+        .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = {
+            string('Test checks for an issue that cannot occur with the interpreter')
+            int32(0x400) // InterpreterActive
+        }
         .entrypoint
         .maxstack 8
         .locals init (class Test.DerivedClass derivedInstance, int32 exitCode)

--- a/src/tests/JIT/Regression/Dev11/Dev11_468598/Test_HndIndex_10_Reordered.il
+++ b/src/tests/JIT/Regression/Dev11/Dev11_468598/Test_HndIndex_10_Reordered.il
@@ -22,6 +22,8 @@
   .ver 0:0:0:0
 }
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
+
 // MVID: {68AEE7ED-2AC8-4330-9EC7-4EBFD6BD74E0}
 .imagebase 0x00400000
 .file alignment 0x00000200
@@ -42,6 +44,10 @@
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
     )
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.SkipOnCoreClrAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.RuntimeTestModes) = {
+        string('Test checks for an issue that cannot occur with the interpreter')
+        int32(0x400) // InterpreterActive
+    }
     .entrypoint
     // Code size       106 (0x6a)
     .maxstack  8

--- a/src/tests/baseservices/threading/commitstackonlyasneeded/DefaultStackCommit.csproj
+++ b/src/tests/baseservices/threading/commitstackonlyasneeded/DefaultStackCommit.csproj
@@ -6,6 +6,8 @@
     <CLRTestPriority>1</CLRTestPriority>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <!-- Expects a local variable address to be on CPU stack which is not the case with interpreted code -->
+    <InterpreterIncompatible>true</InterpreterIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DefaultStackCommit.cs" />


### PR DESCRIPTION
Disable one part of the aliasing_retbuf that uses pinvoke with marshalling, fix disabling of calli_excep test that needs to be disabled on the project level as it is executed as isolated and finally Test_HndIndex_10_Reordered that has the same issue as previously disabled Test_HndIndex_10_Plain.