### PR TITLE
Fix md-lint and copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,7 @@ In addition to the rules enforced by `.editorconfig`, you SHOULD:
 - When running tests, if possible use filters and check test run counts, or look at test logs, to ensure they actually ran.
 - Do not finish work with any tests commented out or disabled that were not previously commented out or disabled.
 - When writing tests, do not emit "Act", "Arrange" or "Assert" comments.
+- For markdown (`.md`) files, ensure there is no trailing whitespace at the end of any line.
 
 ---
 

--- a/docs/project/library-servicing.md
+++ b/docs/project/library-servicing.md
@@ -7,7 +7,7 @@ Servicing branches represent shipped versions of .NET. The branch naming convent
 - **For .NET 8 and .NET 9**: Branch names use the format `release/X.0-staging`. Examples:
   - `release/9.0-staging`
   - `release/8.0-staging`
-  
+
 - **For .NET 10+**: Branch names use the format `release/X.0` (no `-staging` suffix). Examples:
   - `release/10.0`
   - `release/11.0`
@@ -36,7 +36,7 @@ All the servicing change must go through an approval process. You have two ways 
   For .NET 8 and .NET 9 (use `-staging` suffix):
   - `/backport to release/9.0-staging`
   - `/backport to release/8.0-staging`
-  
+
   For .NET 10+ (no `-staging` suffix):
   - `/backport to release/10.0`
   - `/backport to release/11.0`

--- a/docs/project/library-servicing.md
+++ b/docs/project/library-servicing.md
@@ -54,5 +54,3 @@ For all cases, you must:
   - Add the `Servicing-approved` label.
 
 The area owner can then merge the PR once the CI looks good (it's either green or the failures are investigated and determined to be unrelated to the PR).
-
-**Note**: Applying the `Servicing-approved` label ensures the `check-service-labels` CI job passes, which is a mandatory requirement for merging a PR in a servicing branch.

--- a/docs/project/library-servicing.md
+++ b/docs/project/library-servicing.md
@@ -54,3 +54,5 @@ For all cases, you must:
   - Add the `Servicing-approved` label.
 
 The area owner can then merge the PR once the CI looks good (it's either green or the failures are investigated and determined to be unrelated to the PR).
+
+**Note**: Applying the `Servicing-approved` label ensures the `check-service-labels` CI job passes, which is a mandatory requirement for merging a PR in a servicing branch.


### PR DESCRIPTION
* Fixes md-lint issue from copilot in https://github.com/dotnet/runtime/pull/121328
* Updates copilot instructions to not have trailing whitespace in md files
