### PR TITLE
Look up the correct `MethodTable` on COM methods.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/StubHelpers.cs
@@ -1390,14 +1390,18 @@ namespace System.StubHelpers
         }
 
 #if FEATURE_COMINTEROP
-        internal static Exception GetCOMHRExceptionObject(int hr, IntPtr pCPCMD, IntPtr pUnk)
+        internal static unsafe Exception GetCOMHRExceptionObject(int hr, IntPtr pCPCMD, IntPtr pUnk)
         {
-            RuntimeMethodHandle handle = RuntimeMethodHandle.FromIntPtr(pCPCMD);
-            RuntimeType declaringType = RuntimeMethodHandle.GetDeclaringType(handle.GetMethodInfo());
+            Debug.Assert(pCPCMD != IntPtr.Zero);
+            MethodTable* interfaceType = GetComInterfaceFromMethodDesc(pCPCMD);
+            RuntimeType declaringType = RuntimeTypeHandle.GetRuntimeType(interfaceType);
             Exception ex = Marshal.GetExceptionForHR(hr, declaringType.GUID, pUnk)!;
             ex.InternalPreserveStackTrace();
             return ex;
         }
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern unsafe MethodTable* GetComInterfaceFromMethodDesc(IntPtr pCPCMD);
 #endif // FEATURE_COMINTEROP
 
         [ThreadStatic]

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -355,6 +355,7 @@ FCFuncStart(gStubHelperFuncs)
     FCFuncElement("SetLastError", StubHelpers::SetLastError)
     FCFuncElement("ClearLastError", StubHelpers::ClearLastError)
 #ifdef FEATURE_COMINTEROP
+    FCFuncElement("GetComInterfaceFromMethodDesc", StubHelpers::GetComInterfaceFromMethodDesc)
     FCFuncElement("GetCOMIPFromRCW", StubHelpers::GetCOMIPFromRCW)
 #endif // FEATURE_COMINTEROP
     FCFuncElement("CalcVaListSize", StubHelpers::CalcVaListSize)

--- a/src/coreclr/vm/stubhelpers.cpp
+++ b/src/coreclr/vm/stubhelpers.cpp
@@ -266,6 +266,14 @@ FORCEINLINE static IUnknown* GetCOMIPFromRCW_GetTargetFromRCWCache(SOleTlsData* 
     return NULL;
 }
 
+FCIMPL1(MethodTable*, StubHelpers::GetComInterfaceFromMethodDesc, MethodDesc* pMD)
+{
+    FCALL_CONTRACT;
+    _ASSERTE(pMD != NULL);
+    return CLRToCOMCallInfo::FromMethodDesc(pMD)->m_pInterfaceMT;
+}
+FCIMPLEND
+
 //==================================================================================================================
 // The GetCOMIPFromRCW helper exists in four specialized versions to optimize CLR->COM perf. Please be careful when
 // changing this code as one of these methods is executed as part of every CLR->COM call so every instruction counts.

--- a/src/coreclr/vm/stubhelpers.h
+++ b/src/coreclr/vm/stubhelpers.h
@@ -26,6 +26,7 @@ public:
     //-------------------------------------------------------
 
 #ifdef FEATURE_COMINTEROP
+    static FCDECL1(MethodTable*,    GetComInterfaceFromMethodDesc, MethodDesc* pMD);
     static FCDECL3(IUnknown*,       GetCOMIPFromRCW,    Object* pSrcUNSAFE, MethodDesc* pMD, void **ppTarget);
 #endif // FEATURE_COMINTEROP
 

--- a/src/tests/Interop/COM/NETClients/ComDisabled/Program.cs
+++ b/src/tests/Interop/COM/NETClients/ComDisabled/Program.cs
@@ -22,7 +22,7 @@ namespace NetClient
 
             try
             {
-                var server = (Server.Contract.Servers.NumericTesting)new Server.Contract.Servers.NumericTestingClass();
+                var server = new Server.Contract.Servers.NumericTesting();
             }
             catch (NotSupportedException) when (OperatingSystem.IsWindows())
             {

--- a/src/tests/Interop/COM/NETClients/Events/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Events/Program.cs
@@ -20,7 +20,7 @@ namespace NetClient
         {
             Console.WriteLine($"{nameof(Validate_BasicCOMEvent)}...");
 
-            var eventTesting = (EventTesting)new EventTestingClass();
+            var eventTesting = new EventTesting();
 
             // Verify event handler subscription
 
@@ -57,7 +57,7 @@ namespace NetClient
         {
             Console.WriteLine($"{nameof(Validate_COMEventViaComAwareEventInfo)}...");
 
-            var eventTesting = (EventTesting)new EventTestingClass();
+            var eventTesting = new EventTesting();
 
             // Verify event handler subscription
 

--- a/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IDispatch/Program.cs
@@ -19,7 +19,7 @@ namespace NetClient
     {
         static void Validate_Numeric_In_ReturnByRef()
         {
-            var dispatchTesting = (DispatchTesting)new DispatchTestingClass();
+            var dispatchTesting = new DispatchTesting();
 
             byte b1 = 1;
             byte b2 = b1;
@@ -74,7 +74,7 @@ namespace NetClient
 
         static void Validate_Float_In_ReturnAndUpdateByRef()
         {
-            var dispatchTesting = (DispatchTesting)new DispatchTestingClass();
+            var dispatchTesting = new DispatchTesting();
 
             float a = .1f;
             float b = .2f;
@@ -91,7 +91,7 @@ namespace NetClient
 
         static void Validate_Double_In_ReturnAndUpdateByRef()
         {
-            var dispatchTesting = (DispatchTesting)new DispatchTestingClass();
+            var dispatchTesting = new DispatchTesting();
 
             double a = .1;
             double b = .2;
@@ -114,7 +114,7 @@ namespace NetClient
 
         static void Validate_Exception()
         {
-            var dispatchTesting = (DispatchTesting)new DispatchTestingClass();
+            var dispatchTesting = new DispatchTesting();
 
             int errorCode = 1127;
             string resultString = errorCode.ToString("x");
@@ -174,7 +174,7 @@ namespace NetClient
         static void Validate_StructNotSupported()
         {
             Console.WriteLine($"IDispatch with structs not supported...");
-            var dispatchTesting = (DispatchTesting)new DispatchTestingClass();
+            var dispatchTesting = new DispatchTesting();
 
             var input = new HFA_4() { x = 1f, y = 2f, z = 3f, w = 4f };
             Assert.Throws<NotSupportedException>(() => dispatchTesting.DoubleHVAValues(ref input));
@@ -182,7 +182,7 @@ namespace NetClient
 
         static void Validate_LCID_Marshaled()
         {
-            var dispatchTesting = (DispatchTesting)new DispatchTestingClass();
+            var dispatchTesting = new DispatchTesting();
             CultureInfo oldCulture = CultureInfo.CurrentCulture;
             CultureInfo newCulture = new CultureInfo("es-ES", false);
             try
@@ -200,7 +200,7 @@ namespace NetClient
 
         static void Validate_Enumerator()
         {
-            var dispatchTesting = (DispatchTesting)new DispatchTestingClass();
+            var dispatchTesting = new DispatchTesting();
             var expected = System.Linq.Enumerable.Range(0, 10);
 
             {
@@ -251,7 +251,7 @@ namespace NetClient
 
         static void Validate_ValueCoerce_ReturnToManaged()
         {
-            var dispatchCoerceTesting = (DispatchCoerceTesting)new DispatchCoerceTestingClass();
+            var dispatchCoerceTesting = new DispatchCoerceTesting();
 
             Console.WriteLine($"Calling {nameof(DispatchCoerceTesting.ReturnToManaged)} ...");
 

--- a/src/tests/Interop/COM/NETClients/IInspectable/Program.cs
+++ b/src/tests/Interop/COM/NETClients/IInspectable/Program.cs
@@ -18,7 +18,7 @@ namespace NetClient
     {
         static void Validate_IInspectable()
         {
-            var server = (InspectableTesting)new InspectableTestingClass();
+            var server = new InspectableTesting();
             Assert.Throws<PlatformNotSupportedException>(() => _ = (IInspectableTesting2)server);
         }
 

--- a/src/tests/Interop/COM/NETClients/Licensing/Program.cs
+++ b/src/tests/Interop/COM/NETClients/Licensing/Program.cs
@@ -23,13 +23,13 @@ namespace NetClient
             Console.WriteLine($"Calling {nameof(ActivateLicensedObject)}...");
 
             // Validate activation
-            var licenseTesting = (LicenseTesting)new LicenseTestingClass();
+            var licenseTesting = new LicenseTesting();
 
             // Validate license denial
             licenseTesting.SetNextDenyLicense(true);
             try
             {
-                var tmp = (LicenseTesting)new LicenseTestingClass();
+                var tmp = new LicenseTesting();
                 Assert.Fail("Activation of licensed class should fail");
             }
             catch (COMException e)
@@ -86,7 +86,7 @@ namespace NetClient
                 LicenseManager.CurrentContext = new MockLicenseContext(typeof(LicenseTestingClass), LicenseUsageMode.Designtime);
                 LicenseManager.CurrentContext.SetSavedLicenseKey(typeof(LicenseTestingClass), licKey);
 
-                var licenseTesting = (LicenseTesting)new LicenseTestingClass();
+                var licenseTesting = new LicenseTesting();
 
                 // During design time the IClassFactory::CreateInstance will be called - no license
                 Assert.Null(licenseTesting.GetLicense());
@@ -111,7 +111,7 @@ namespace NetClient
                 LicenseManager.CurrentContext = new MockLicenseContext(typeof(LicenseTestingClass), LicenseUsageMode.Runtime);
                 LicenseManager.CurrentContext.SetSavedLicenseKey(typeof(LicenseTestingClass), licKey);
 
-                var licenseTesting = (LicenseTesting)new LicenseTestingClass();
+                var licenseTesting = new LicenseTesting();
 
                 // During runtime the IClassFactory::CreateInstance2 will be called with license from context
                 Assert.Equal(licKey, licenseTesting.GetLicense());

--- a/src/tests/Interop/COM/NETClients/MiscTypes/Program.cs
+++ b/src/tests/Interop/COM/NETClients/MiscTypes/Program.cs
@@ -87,7 +87,7 @@ namespace NetClient
         {
             Console.WriteLine($"Running {nameof(ValidationTests)} ...");
 
-            var miscTypeTesting = (Server.Contract.Servers.MiscTypesTesting)new Server.Contract.Servers.MiscTypesTestingClass();
+            var miscTypeTesting = new Server.Contract.Servers.MiscTypesTesting();
 
             Console.WriteLine("-- Primitives <=> VARIANT...");
             {
@@ -226,7 +226,7 @@ namespace NetClient
         {
             Console.WriteLine($"Running {nameof(ValidateNegativeTests)} ...");
 
-            var miscTypeTesting = (Server.Contract.Servers.MiscTypesTesting)new Server.Contract.Servers.MiscTypesTestingClass();
+            var miscTypeTesting = new Server.Contract.Servers.MiscTypesTesting();
 
             Console.WriteLine("-- DispatchWrapper with non-IDispatch object <=> VARIANT...");
             {

--- a/src/tests/Interop/COM/NETClients/Primitives/ArrayTests.cs
+++ b/src/tests/Interop/COM/NETClients/Primitives/ArrayTests.cs
@@ -17,7 +17,7 @@ namespace NetClient
 
         public ArrayTests()
         {
-            this.server = (Server.Contract.Servers.ArrayTesting)new Server.Contract.Servers.ArrayTestingClass();
+            this.server = new Server.Contract.Servers.ArrayTesting();
 
             double acc = 0.0;
             int[] rawData = BaseData.ToArray();
@@ -31,6 +31,7 @@ namespace NetClient
 
         public void Run()
         {
+            Console.WriteLine(nameof(ArrayTests));
             this.Marshal_ByteArray();
             this.Marshal_ShortArray();
             this.Marshal_UShortArray();

--- a/src/tests/Interop/COM/NETClients/Primitives/CallViaReflectionTests.cs
+++ b/src/tests/Interop/COM/NETClients/Primitives/CallViaReflectionTests.cs
@@ -13,7 +13,7 @@ namespace NetClient
 
         public CallViaReflectionTests()
         {
-            this.server = (Server.Contract.Servers.NumericTesting)new Server.Contract.Servers.NumericTestingClass();
+            this.server = new Server.Contract.Servers.NumericTesting();
         }
 
         public void Run()

--- a/src/tests/Interop/COM/NETClients/Primitives/ColorTests.cs
+++ b/src/tests/Interop/COM/NETClients/Primitives/ColorTests.cs
@@ -13,11 +13,12 @@ namespace NetClient
         private readonly Server.Contract.Servers.ColorTesting server;
         public ColorTests()
         {
-            this.server = (Server.Contract.Servers.ColorTesting)new Server.Contract.Servers.ColorTestingClass();
+            this.server = new Server.Contract.Servers.ColorTesting();
         }
 
         public void Run()
         {
+            Console.WriteLine(nameof(ColorTests));
             this.VerifyColorMarshalling();
             this.VerifyGetRed();
         }

--- a/src/tests/Interop/COM/NETClients/Primitives/ErrorTests.cs
+++ b/src/tests/Interop/COM/NETClients/Primitives/ErrorTests.cs
@@ -12,11 +12,12 @@ namespace NetClient
         private readonly Server.Contract.Servers.ErrorMarshalTesting server;
         public ErrorTests()
         {
-            this.server = (Server.Contract.Servers.ErrorMarshalTesting)new Server.Contract.Servers.ErrorMarshalTestingClass();
+            this.server = new Server.Contract.Servers.ErrorMarshalTesting();
         }
 
         public void Run()
         {
+            Console.WriteLine(nameof(ErrorTests));
             this.VerifyExpectedException();
             this.VerifyReturnHResult();
             this.VerifyHelpLink();

--- a/src/tests/Interop/COM/NETClients/Primitives/NumericTests.cs
+++ b/src/tests/Interop/COM/NETClients/Primitives/NumericTests.cs
@@ -18,11 +18,12 @@ namespace NetClient
             Console.WriteLine($"Numeric RNG seed: {this.seed}");
 
             this.rng = new Random(this.seed);
-            this.server = (Server.Contract.Servers.NumericTesting)new Server.Contract.Servers.NumericTestingClass();
+            this.server = new Server.Contract.Servers.NumericTesting();
         }
 
         public void Run()
         {
+            Console.WriteLine(nameof(NumericTests));
             int a = this.rng.Next();
             int b = this.rng.Next();
 

--- a/src/tests/Interop/COM/NETClients/Primitives/StringTests.cs
+++ b/src/tests/Interop/COM/NETClients/Primitives/StringTests.cs
@@ -46,11 +46,12 @@ namespace NetClient
 
         public StringTests()
         {
-            this.server = (Server.Contract.Servers.StringTesting)new Server.Contract.Servers.StringTestingClass();
+            this.server = new Server.Contract.Servers.StringTesting();
         }
 
         public void Run()
         {
+            Console.WriteLine(nameof(StringTests));
             this.Marshal_LPString();
             this.Marshal_LPWString();
             this.Marshal_BStrString();


### PR DESCRIPTION
Fixes #121252

Update tests to activate correctly.