### PR TITLE
Runtime-async continuation object reading with Cordb

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -2315,10 +2315,7 @@ void DacDbiInterfaceImpl::GetClassTypeInfo(TypeHandle                      typeH
                                            DebuggerIPCE_ExpandedTypeData * pTypeInfo,
                                            AppDomain *                     pAppDomain)
 {
-    if (typeHandle.AsMethodTable()->IsContinuation())
-    {
-        typeHandle = TypeHandle(g_pContinuationClassIfSubTypeCreated);
-    }
+    typeHandle = typeHandle.UpCastTypeIfNeeded();
     Module * pModule = typeHandle.GetModule();
 
     if (typeHandle.HasInstantiation()) // the type handle represents a generic instantiation
@@ -2406,10 +2403,7 @@ void DacDbiInterfaceImpl::TypeHandleToBasicTypeInfo(TypeHandle                  
         case ELEMENT_TYPE_CLASS:
         case ELEMENT_TYPE_VALUETYPE:
         {
-            if (typeHandle.AsMethodTable()->IsContinuation())
-            {
-                typeHandle = TypeHandle(g_pContinuationClassIfSubTypeCreated);
-            }
+            typeHandle = typeHandle.UpCastTypeIfNeeded();
 
             Module * pModule = typeHandle.GetModule();
             if (typeHandle.HasInstantiation()) // only set if instantiated

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -2315,6 +2315,10 @@ void DacDbiInterfaceImpl::GetClassTypeInfo(TypeHandle                      typeH
                                            DebuggerIPCE_ExpandedTypeData * pTypeInfo,
                                            AppDomain *                     pAppDomain)
 {
+    if (typeHandle.AsMethodTable()->IsContinuation())
+    {
+        typeHandle = TypeHandle(g_pContinuationClassIfSubTypeCreated);
+    }
     Module * pModule = typeHandle.GetModule();
 
     if (typeHandle.HasInstantiation()) // the type handle represents a generic instantiation
@@ -2402,9 +2406,13 @@ void DacDbiInterfaceImpl::TypeHandleToBasicTypeInfo(TypeHandle                  
         case ELEMENT_TYPE_CLASS:
         case ELEMENT_TYPE_VALUETYPE:
         {
-            Module * pModule = typeHandle.GetModule();
+            if (typeHandle.AsMethodTable()->IsContinuation())
+            {
+                typeHandle = TypeHandle(g_pContinuationClassIfSubTypeCreated);
+            }
 
-            if (typeHandle.HasInstantiation())   // only set if instantiated
+            Module * pModule = typeHandle.GetModule();
+            if (typeHandle.HasInstantiation()) // only set if instantiated
             {
                 pTypeInfo->vmTypeHandle.SetDacTargetPtr(typeHandle.AsTAddr());
             }

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -11657,10 +11657,7 @@ void Debugger::TypeHandleToBasicTypeInfo(AppDomain *pAppDomain, TypeHandle th, D
     case ELEMENT_TYPE_CLASS:
     case ELEMENT_TYPE_VALUETYPE:
         {
-            if (th.AsMethodTable()->IsContinuation())
-            {
-                th = TypeHandle(g_pContinuationClassIfSubTypeCreated);
-            }
+            th = th.UpCastTypeIfNeeded();
             res->vmTypeHandle = th.HasInstantiation() ? WrapTypeHandle(th) : VMPTR_TypeHandle::NullPtr();
                                                                              // only set if instantiated
             res->metadataToken = th.GetCl();
@@ -11743,10 +11740,7 @@ void Debugger::TypeHandleToExpandedTypeInfo(AreValueTypesBoxed boxed,
     case ELEMENT_TYPE_CLASS:
         {
 treatAllValuesAsBoxed:
-            if (th.AsMethodTable()->IsContinuation())
-            {
-                th = TypeHandle(g_pContinuationClassIfSubTypeCreated);
-            }
+            th = th.UpCastTypeIfNeeded();
             res->ClassTypeData.typeHandle = th.HasInstantiation() ? WrapTypeHandle(th) : VMPTR_TypeHandle::NullPtr(); // only set if instantiated
             res->ClassTypeData.metadataToken = th.GetCl();
             DebuggerModule * pModule = LookupOrCreateModule(th.GetModule());

--- a/src/coreclr/debug/ee/debugger.cpp
+++ b/src/coreclr/debug/ee/debugger.cpp
@@ -11657,6 +11657,10 @@ void Debugger::TypeHandleToBasicTypeInfo(AppDomain *pAppDomain, TypeHandle th, D
     case ELEMENT_TYPE_CLASS:
     case ELEMENT_TYPE_VALUETYPE:
         {
+            if (th.AsMethodTable()->IsContinuation())
+            {
+                th = TypeHandle(g_pContinuationClassIfSubTypeCreated);
+            }
             res->vmTypeHandle = th.HasInstantiation() ? WrapTypeHandle(th) : VMPTR_TypeHandle::NullPtr();
                                                                              // only set if instantiated
             res->metadataToken = th.GetCl();
@@ -11739,6 +11743,10 @@ void Debugger::TypeHandleToExpandedTypeInfo(AreValueTypesBoxed boxed,
     case ELEMENT_TYPE_CLASS:
         {
 treatAllValuesAsBoxed:
+            if (th.AsMethodTable()->IsContinuation())
+            {
+                th = TypeHandle(g_pContinuationClassIfSubTypeCreated);
+            }
             res->ClassTypeData.typeHandle = th.HasInstantiation() ? WrapTypeHandle(th) : VMPTR_TypeHandle::NullPtr(); // only set if instantiated
             res->ClassTypeData.metadataToken = th.GetCl();
             DebuggerModule * pModule = LookupOrCreateModule(th.GetModule());

--- a/src/coreclr/vm/typehandle.h
+++ b/src/coreclr/vm/typehandle.h
@@ -386,6 +386,7 @@ public:
     // And some types (like ByRef or generic type parameters) have no
     // method table and this function returns NULL for them.
     inline PTR_MethodTable GetMethodTable() const;
+    inline TypeHandle UpCastTypeIfNeeded() const;
 
     // Returns the type which should be used for visibility checking.
     inline MethodTable* GetMethodTableOfRootTypeParam() const;

--- a/src/coreclr/vm/typehandle.inl
+++ b/src/coreclr/vm/typehandle.inl
@@ -27,6 +27,24 @@ inline PTR_MethodTable TypeHandle::GetMethodTable() const
         return AsMethodTable();
 }
 
+// This method allows you to get the "upcasted" type handle. Currently we need this
+// because continuation types for runtime-async methods are dynamically created subtypes of a
+// parent continuation class that have no metadata of their own. This way, when we need to get
+// the TypeHandle to retrieve metadata, we are able to get a reasonable approximation.
+// If we need to handle more such types in the future we can add them here.
+inline TypeHandle TypeHandle::UpCastTypeIfNeeded() const
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+
+    if (IsTypeDesc())
+        return *this;
+    if (AsMethodTable()->IsContinuation())
+    {
+        return TypeHandle(g_pContinuationClassIfSubTypeCreated);
+    }
+    return *this;
+}
+
 inline void TypeHandle::SetIsFullyLoaded()
 {
     LIMITED_METHOD_CONTRACT;


### PR DESCRIPTION
This PR ensures that we are able to access continuation objects through APIs such as CordbObjectValue::GetFieldValue. As the dynamically generated continuation types with the local variable fields do not have metadata, we use the parent class which does have metadata. We will therefore not be able to view the locals fields through these APIs, but with the low likelihood that someone is digging this deep into implementation details, this should be an acceptable trade-off.