### PR TITLE
Make `EnumAllVirtualSlots` return slots for interfaces

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -973,24 +973,25 @@ namespace Internal.TypeSystem
         // Enumerate all possible virtual slots of a type
         public static IEnumerable<MethodDesc> EnumAllVirtualSlots(MetadataType type)
         {
+            return type.IsInterface ? type.GetAllVirtualMethods() : EnumAllVirtualSlotsOnClass(type);
+        }
+        private static IEnumerable<MethodDesc> EnumAllVirtualSlotsOnClass(MetadataType type)
+        {
             MethodDescHashtable alreadyEnumerated = new MethodDescHashtable();
-            if (!type.IsInterface)
+            do
             {
-                do
+                foreach (MethodDesc m in type.GetAllVirtualMethods())
                 {
-                    foreach (MethodDesc m in type.GetAllVirtualMethods())
+                    MethodDesc possibleVirtual = FindSlotDefiningMethodForVirtualMethod(m);
+                    if (!alreadyEnumerated.Contains(possibleVirtual))
                     {
-                        MethodDesc possibleVirtual = FindSlotDefiningMethodForVirtualMethod(m);
-                        if (!alreadyEnumerated.Contains(possibleVirtual))
-                        {
-                            alreadyEnumerated.AddOrGetExisting(possibleVirtual);
-                            yield return possibleVirtual;
-                        }
+                        alreadyEnumerated.AddOrGetExisting(possibleVirtual);
+                        yield return possibleVirtual;
                     }
+                }
 
-                    type = type.BaseType;
-                } while (type != null);
-            }
+                type = type.BaseType;
+            } while (type != null);
         }
 
         /// <summary>

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -1055,30 +1055,6 @@ namespace ILCompiler.DependencyAnalysis
 
             return SetSavedVertex(layoutInfo);
         }
-
-        private static IEnumerable<MethodDesc> EnumVirtualSlotsDeclaredOnType(TypeDesc declType)
-        {
-            // VirtualMethodUse of Foo<SomeType>.Method will bring in VirtualMethodUse
-            // of Foo<__Canon>.Method. This in turn should bring in Foo<OtherType>.Method.
-            DefType defType = declType.GetClosestDefType();
-
-            Debug.Assert(!declType.IsInterface);
-
-            IEnumerable<MethodDesc> allSlots = defType.EnumAllVirtualSlots();
-
-            foreach (var method in allSlots)
-            {
-                // Generic virtual methods are tracked by an orthogonal mechanism.
-                if (method.HasInstantiation)
-                    continue;
-
-                // Current type doesn't define this slot. Another VTableSlice will take care of this.
-                if (method.OwningType != defType)
-                    continue;
-
-                yield return method;
-            }
-        }
     }
 
     public abstract class NativeLayoutGenericDictionarySlotNode : NativeLayoutVertexNode

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeGVMEntriesNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/TypeGVMEntriesNode.cs
@@ -46,6 +46,7 @@ namespace ILCompiler.DependencyAnalysis
         public TypeGVMEntriesNode(TypeDesc associatedType)
         {
             Debug.Assert(associatedType.IsTypeDefinition);
+            Debug.Assert(!associatedType.IsInterface);
             _associatedType = associatedType;
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VTableSliceNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/VTableSliceNode.cs
@@ -33,8 +33,7 @@ namespace ILCompiler.DependencyAnalysis
             bool isObjectType = type.IsObject;
             DefType defType = type.GetClosestDefType();
 
-            IEnumerable<MethodDesc> allSlots = type.IsInterface ?
-                type.GetAllVirtualMethods() : defType.EnumAllVirtualSlots();
+            IEnumerable<MethodDesc> allSlots = defType.EnumAllVirtualSlots();
 
             foreach (var method in allSlots)
             {
@@ -224,8 +223,7 @@ namespace ILCompiler.DependencyAnalysis
             // of Foo<__Canon>.Method. This in turn should bring in Foo<OtherType>.Method.
             DefType defType = _type.GetClosestDefType();
 
-            IEnumerable<MethodDesc> allSlots = _type.IsInterface ?
-                _type.GetAllVirtualMethods() : defType.EnumAllVirtualSlots();
+            IEnumerable<MethodDesc> allSlots = defType.EnumAllVirtualSlots();
 
             foreach (var method in allSlots)
             {


### PR DESCRIPTION
(Review with whitespace changes off, this is not a big diff.)

Calling `EnumAllVirtualSlots` on classes returns all `newslot` methods that exist in the class hierarchy. Calling this on interfaces produced an empty enumeration.

For runtime-async, it would be convenient if this returned the logical slots on interfaces. While interfaces don't have physical slots, they still have logical slots, so it's not a big stretch.

Doing this now simplifies things in some places, and requires an extra `if` check in other places. But it will be really convenient for runtime-async.

Cc @dotnet/ilc-contrib 