### PR TITLE
Enable thread abort support in the interpreter

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1245,24 +1245,22 @@ MAIN_LOOP:
                 }
 
                 case INTOP_SAFEPOINT:
-                {
-                    Thread *pThread = GetThread();
-                    if (pThread->IsAbortRequested())
-                    {
-                        CallWithSEHWrapper(
-                        [&pThread]() {
-                            pThread->HandleThreadAbort();
-                            return 0;
-                        });
-                    }
                     if (g_TrapReturningThreads)
                     {
+                        Thread *pThread = GetThread();
+                        if (pThread->IsAbortRequested())
+                        {
+                            CallWithSEHWrapper(
+                            [&pThread]() {
+                                pThread->HandleThreadAbort();
+                                return 0;
+                            });
+                        }
                         // Transition into preemptive mode to allow the GC to suspend us
                         GCX_PREEMP();
                     }
                     ip++;
                     break;
-                }
 
                 case INTOP_BR:
                     ip += ip[1];


### PR DESCRIPTION
This change adds check for thread abort to the INTOP_SAFEPOINT and also to the code resuming after catch. This makes all the libraries controlled execution tests pass.