### PR TITLE
[RuntimeAsync] Make a testcase compatible with runtime async

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
@@ -819,7 +819,7 @@ namespace System.Net.Sockets.Tests
             })).WaitAsync(timeout);
         }
 
-        // NoInlining is to strip off any posible state holding to sockets. We only want the List.
+        // NoInlining is to strip off any possible state holding to sockets. We only want the List.
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static async Task<List<WeakReference>> CreateHandlesAsyncWithTimeout(bool clientAsync, TimeSpan timeout) =>
             await CreateHandlesAsync(clientAsync).WaitAsync(timeout);

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/DisposedSocketTests.cs
@@ -810,7 +810,7 @@ namespace System.Net.Sockets.Tests
         public async Task NonDisposedSocket_SafeHandlesCollected(bool clientAsync)
         {
             TimeSpan timeout = TimeSpan.FromMilliseconds(TestSettings.PassingTestTimeout);
-            List<WeakReference> handles = await CreateHandlesAsync(clientAsync).WaitAsync(timeout);
+            List<WeakReference> handles = await CreateHandlesAsyncWithTimeout(clientAsync, timeout);
             await RetryHelper.ExecuteAsync(() => Task.Run(() =>
             {
                 GC.Collect();
@@ -819,7 +819,11 @@ namespace System.Net.Sockets.Tests
             })).WaitAsync(timeout);
         }
 
+        // NoInlining is to strip off any posible state holding to sockets. We only want the List.
         [MethodImpl(MethodImplOptions.NoInlining)]
+        private static async Task<List<WeakReference>> CreateHandlesAsyncWithTimeout(bool clientAsync, TimeSpan timeout) =>
+            await CreateHandlesAsync(clientAsync).WaitAsync(timeout);
+
         private static async Task<List<WeakReference>> CreateHandlesAsync(bool clientAsync)
         {
             var handles = new List<WeakReference>();


### PR DESCRIPTION
Test-only change. 

Just moving `[MethodImpl(MethodImplOptions.NoInlining)]` higher in the call chain to have the intended effect.

The test relies on GC collection/finalization and thus needs to make sure the lifetime of sockets is not accidentally extended. There is a `NoInlining` that tries to control that, but it should be one level higher. 

I am not sure `NoInlining` made a difference with async1 as it is unlikely anything was inlined. It does make a difference with runtime async and thus needs to be in the right place. Otherwise we see failures when runtime async is enabled.

