### PR TITLE
Update ImportThunk for community architectures to use PC-relative addressing

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Relocation.cs
@@ -627,9 +627,9 @@ namespace ILCompiler.DependencyAnalysis
                 RelocType.IMAGE_REL_BASED_ARM64_PAGEOFFSET_12L => 4,
                 RelocType.IMAGE_REL_BASED_THUMB_MOV32 => 8,
                 RelocType.IMAGE_REL_BASED_THUMB_MOV32_PCREL => 8,
-                RelocType.IMAGE_REL_BASED_LOONGARCH64_PC => 16,
-                RelocType.IMAGE_REL_BASED_LOONGARCH64_JIR => 16,
-                RelocType.IMAGE_REL_BASED_RISCV64_PC => 16,
+                RelocType.IMAGE_REL_BASED_LOONGARCH64_PC => 8,
+                RelocType.IMAGE_REL_BASED_LOONGARCH64_JIR => 8,
+                RelocType.IMAGE_REL_BASED_RISCV64_PC => 8,
                 _ => throw new NotSupportedException(),
             };
         }

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64Emitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64Emitter.cs
@@ -92,6 +92,16 @@ namespace ILCompiler.DependencyAnalysis.LoongArch64
             Builder.EmitUInt((uint)(0x28c00000 | (uint)((offset & 0xfff) << 10) | ((uint)regSrc << 5) | (uint)regDst));
         }
 
+        public void EmitLD(Register regDst, ISymbolNode symbol)
+        {
+            Builder.EmitReloc(symbol, RelocType.IMAGE_REL_BASED_LOONGARCH64_PC);
+            // pcalau12i  reg, off-hi-20bits
+            EmitPCALAU12I(regDst);
+
+            // ld_d  reg, reg, off-lo-12bits
+            EmitLD(regDst, regDst, 0);
+        }
+
         public void EmitRET()
         {
             // jirl R0,R1,0
@@ -107,21 +117,7 @@ namespace ILCompiler.DependencyAnalysis.LoongArch64
         {
             if (symbol.RepresentsIndirectionCell)
             {
-                Builder.RequireInitialPointerAlignment();
-
-                if (Builder.CountBytes % Builder.TargetPointerSize != 0)
-                {
-                    // Emit a NOP instruction to align the 64-bit reloc below.
-                    EmitNOP();
-                }
-
-                // pcaddi R21, 0
-                EmitPCADDI(Register.R21);
-
-                EmitLD(Register.R21, Register.R21, 0x10);
-
-                // ld_d R21, R21, 0
-                EmitLD(Register.R21, Register.R21, 0);
+                EmitLD(Register.R21, symbol);
 
                 // jirl R0,R21,0
                 EmitJMP(Register.R21);

--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64Emitter.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/Target_LoongArch64/LoongArch64Emitter.cs
@@ -121,8 +121,6 @@ namespace ILCompiler.DependencyAnalysis.LoongArch64
 
                 // jirl R0,R21,0
                 EmitJMP(Register.R21);
-
-                Builder.EmitReloc(symbol, RelocType.IMAGE_REL_BASED_DIR64);
             }
             else
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ImportThunk.cs
@@ -28,8 +28,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
         private readonly ImportSectionNode _containingImportSection;
 
-        private readonly int _symbolOffset = 0;
-
         /// <summary>
         /// Import thunks are used to call a runtime-provided helper which fixes up an indirection cell in a particular
         /// import section. Optionally they may also contain a relocation for a specific indirection cell to fix up.
@@ -62,20 +60,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             {
                 _thunkKind = Kind.Eager;
             }
-
-            if (_thunkKind != Kind.Eager
-                && factory.Target.Architecture is Internal.TypeSystem.TargetArchitecture.LoongArch64
-                    or Internal.TypeSystem.TargetArchitecture.RiscV64)
-            {
-                // We stuff the reloc to the module import pointer before the start of the thunk
-                // to ensure alignment.
-                // The thunk itself starts immediately after the reloc.
-                // We don't need this for an Eager thunk.
-                _symbolOffset = 8;
-            }
         }
-
-        int ISymbolNode.Offset => base.Offset + _symbolOffset;
 
         public override void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_ARM64/ImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_ARM64/ImportThunk.cs
@@ -21,14 +21,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 return;
             }
 
-            if (relocsOnly)
-            {
-                // When doing relocs only, we don't need to generate the actual instructions
-                // as they will be ignored. Just emit the jump so we record the dependency.
-                instructionEncoder.EmitJMP(_helperCell);
-                return;
-            }
-
             switch (_thunkKind)
             {
                 case Kind.DelayLoadHelper:

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_ARM64/ImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_ARM64/ImportThunk.cs
@@ -20,6 +20,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 instructionEncoder.EmitJMP(_helperCell);
                 return;
             }
+            if (relocsOnly)
+            {
+                // When doing relocs only, we don't need to generate the actual instructions
+                // as they will be ignored. Just emit the module import load and jump so we record the dependencies.
+                instructionEncoder.EmitADRP(Register.X1, factory.ModuleImport);
+                instructionEncoder.EmitLDR(Register.X1, Register.X1, factory.ModuleImport);
+                instructionEncoder.EmitJMP(_helperCell);
+                return;
+            }
 
             switch (_thunkKind)
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_LoongArch64/ImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_LoongArch64/ImportThunk.cs
@@ -21,6 +21,14 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 instructionEncoder.EmitJMP(_helperCell);
                 return;
             }
+            if (relocsOnly)
+            {
+                // When doing relocs only, we don't need to generate the actual instructions
+                // as they will be ignored. Just emit the module import load and jump so we record the dependencies.
+                instructionEncoder.EmitLD(Register.R5, factory.ModuleImport);
+                instructionEncoder.EmitJMP(_helperCell);
+                return;
+            }
 
             switch (_thunkKind)
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_LoongArch64/ImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_LoongArch64/ImportThunk.cs
@@ -22,21 +22,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 return;
             }
 
-            instructionEncoder.Builder.RequireInitialPointerAlignment();
-            Debug.Assert(instructionEncoder.Builder.CountBytes == 0);
-
-            instructionEncoder.Builder.EmitReloc(factory.ModuleImport, RelocType.IMAGE_REL_BASED_DIR64);
-
-            Debug.Assert(instructionEncoder.Builder.CountBytes == ((ISymbolNode)this).Offset);
-
-            if (relocsOnly)
-            {
-                // When doing relocs only, we don't need to generate the actual instructions
-                // as they will be ignored. Just emit the jump so we record the dependency.
-                instructionEncoder.EmitJMP(_helperCell);
-                return;
-            }
-
             switch (_thunkKind)
             {
                 case Kind.DelayLoadHelper:
@@ -50,32 +35,13 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     int index = _containingImportSection.IndexFromBeginningOfArray;
                     instructionEncoder.EmitMOV(Register.R12, checked((ushort)index));
 
-                    int offset = -instructionEncoder.Builder.CountBytes;
-
-                    // get pc
-                    // pcaddi T1=R13, 0
-                    instructionEncoder.EmitPCADDI(Register.R13);
-
-                    // load Module* -> T1
-                    instructionEncoder.EmitLD(Register.R13, Register.R13, offset);
-
-                    // ld_d R13, R13, 0
-                    instructionEncoder.EmitLD(Register.R13, Register.R13, 0);
+                    instructionEncoder.EmitLD(Register.R13, factory.ModuleImport);
                     break;
                 }
 
                 case Kind.Lazy:
                 {
-                    int offset = -instructionEncoder.Builder.CountBytes;
-                    // get pc
-                    // pcaddi R5, 0
-                    instructionEncoder.EmitPCADDI(Register.R5);
-
-                    // load Module* -> R5=A1
-                    instructionEncoder.EmitLD(Register.R5, Register.R5, offset);
-
-                    // ld_d R5, R5, 0
-                    instructionEncoder.EmitLD(Register.R5, Register.R5, 0);
+                    instructionEncoder.EmitLD(Register.R5, factory.ModuleImport);
                     break;
                 }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_RiscV64/ImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_RiscV64/ImportThunk.cs
@@ -21,6 +21,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 return;
             }
 
+            if (relocsOnly)
+            {
+                // When doing relocs only, we don't need to generate the actual instructions
+                // as they will be ignored. Just emit the module import load and jump so we record the dependencies.
+                instructionEncoder.EmitLD(Register.X11, factory.ModuleImport);
+                instructionEncoder.EmitJMP(_helperCell);
+                return;
+            }
+
             switch (_thunkKind)
             {
                 case Kind.Eager:

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_RiscV64/ImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_RiscV64/ImportThunk.cs
@@ -21,21 +21,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 return;
             }
 
-            instructionEncoder.Builder.RequireInitialPointerAlignment();
-            Debug.Assert(instructionEncoder.Builder.CountBytes == 0);
-
-            instructionEncoder.Builder.EmitReloc(factory.ModuleImport, RelocType.IMAGE_REL_BASED_DIR64);
-
-            Debug.Assert(instructionEncoder.Builder.CountBytes == ((ISymbolNode)this).Offset);
-
-            if (relocsOnly)
-            {
-                // When doing relocs only, we don't need to generate the actual instructions
-                // as they will be ignored. Just emit the jump so we record the dependency.
-                instructionEncoder.EmitJMP(_helperCell);
-                return;
-            }
-
             switch (_thunkKind)
             {
                 case Kind.Eager:
@@ -51,31 +36,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     int index = _containingImportSection.IndexFromBeginningOfArray;
                     instructionEncoder.EmitLI(Register.X5, index);
 
-                    int offset = -instructionEncoder.Builder.CountBytes;
+                    // Move Module* -> t1
+                    instructionEncoder.EmitLD(Register.X6, factory.ModuleImport);
 
-                    // get pc
-                    // auipc t1, 0
-                    instructionEncoder.EmitPC(Register.X6);
-
-                    // load Module* -> t1
-                    instructionEncoder.EmitLD(Register.X6, Register.X6, offset);
-
-                    // ld t1, t1, 0
-                    instructionEncoder.EmitLD(Register.X6, Register.X6, 0);
                     break;
                 }
                 case Kind.Lazy:
                 {
-                    int offset = -instructionEncoder.Builder.CountBytes;
-
-                    // get pc
-                    instructionEncoder.EmitPC(Register.X11);
-
-                    // load Module* -> a1
-                    instructionEncoder.EmitLD(Register.X11, Register.X11, offset);
-
                     // ld a1, a1, 0
-                    instructionEncoder.EmitLD(Register.X11, Register.X11, 0);
+                    instructionEncoder.EmitLD(Register.X11, factory.ModuleImport);
                     break;
                 }
                 default:

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_RiscV64/ImportThunk.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/Target_RiscV64/ImportThunk.cs
@@ -43,7 +43,7 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 }
                 case Kind.Lazy:
                 {
-                    // ld a1, a1, 0
+                    // Load Module* -> a1
                     instructionEncoder.EmitLD(Register.X11, factory.ModuleImport);
                     break;
                 }


### PR DESCRIPTION
They now match the ARM64 model we just moved to in #121352

Also, clean up the ARM64 import thunk code while we're at it.