### PR TITLE
Cleanup Windows error mode setting with media insertion propmt

### DIFF
--- a/src/coreclr/inc/holder.h
+++ b/src/coreclr/inc/holder.h
@@ -1166,7 +1166,7 @@ public:
     ErrorModeHolder()
         : m_revert{ FALSE }
     {
-        DWORD newMode = SEM_NOOPENFILEERRORBOX | SEM_FAILCRITICALERRORS;
+        DWORD newMode = SEM_FAILCRITICALERRORS;
         m_revert = ::SetThreadErrorMode(newMode, &m_oldMode);
     }
     ~ErrorModeHolder() noexcept

--- a/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs
+++ b/src/libraries/System.IO.FileSystem.DriveInfo/src/System/IO/DriveInfo.Windows.cs
@@ -48,18 +48,12 @@ namespace System.IO
             get
             {
                 long userBytes, totalBytes, freeBytes;
-                uint oldMode;
-                bool success = Interop.Kernel32.SetThreadErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS, out oldMode);
-                try
+
+                using (DisableMediaInsertionPrompt.Create())
                 {
                     bool r = Interop.Kernel32.GetDiskFreeSpaceEx(Name, out userBytes, out totalBytes, out freeBytes);
                     if (!r)
                         throw Error.GetExceptionForLastWin32DriveError(Name);
-                }
-                finally
-                {
-                    if (success)
-                        Interop.Kernel32.SetThreadErrorMode(oldMode, out _);
                 }
                 return userBytes;
             }
@@ -70,18 +64,12 @@ namespace System.IO
             get
             {
                 long userBytes, totalBytes, freeBytes;
-                uint oldMode;
-                bool success = Interop.Kernel32.SetThreadErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS, out oldMode);
-                try
+
+                using (DisableMediaInsertionPrompt.Create())
                 {
                     bool r = Interop.Kernel32.GetDiskFreeSpaceEx(Name, out userBytes, out totalBytes, out freeBytes);
                     if (!r)
                         throw Error.GetExceptionForLastWin32DriveError(Name);
-                }
-                finally
-                {
-                    if (success)
-                        Interop.Kernel32.SetThreadErrorMode(oldMode, out _);
                 }
                 return freeBytes;
             }
@@ -94,17 +82,12 @@ namespace System.IO
                 // Don't cache this, to handle variable sized floppy drives
                 // or other various removable media drives.
                 long userBytes, totalBytes, freeBytes;
-                uint oldMode;
-                Interop.Kernel32.SetThreadErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS, out oldMode);
-                try
+
+                using (DisableMediaInsertionPrompt.Create())
                 {
                     bool r = Interop.Kernel32.GetDiskFreeSpaceEx(Name, out userBytes, out totalBytes, out freeBytes);
                     if (!r)
                         throw Error.GetExceptionForLastWin32DriveError(Name);
-                }
-                finally
-                {
-                    Interop.Kernel32.SetThreadErrorMode(oldMode, out _);
                 }
                 return totalBytes;
             }
@@ -142,9 +125,7 @@ namespace System.IO
             [SupportedOSPlatform("windows")]
             set
             {
-                uint oldMode;
-                bool success = Interop.Kernel32.SetThreadErrorMode(Interop.Kernel32.SEM_FAILCRITICALERRORS, out oldMode);
-                try
+                using (DisableMediaInsertionPrompt.Create())
                 {
                     bool r = Interop.Kernel32.SetVolumeLabel(Name, value);
                     if (!r)
@@ -155,11 +136,6 @@ namespace System.IO
                             throw new UnauthorizedAccessException(SR.InvalidOperation_SetVolumeLabelFailed);
                         throw Error.GetExceptionForWin32DriveError(errorCode, Name);
                     }
-                }
-                finally
-                {
-                    if (success)
-                        Interop.Kernel32.SetThreadErrorMode(oldMode, out _);
                 }
             }
         }

--- a/src/mono/mono/metadata/domain.c
+++ b/src/mono/mono/metadata/domain.c
@@ -114,7 +114,7 @@ mono_init_internal (const char *root_domain_name)
 
 #if defined(HOST_WIN32) && HAVE_API_SUPPORT_WIN32_SET_ERROR_MODE
 	/* Avoid system error message boxes. */
-	SetErrorMode (SEM_FAILCRITICALERRORS | SEM_NOOPENFILEERRORBOX);
+	SetErrorMode (SEM_FAILCRITICALERRORS);
 #endif
 
 #ifndef HOST_WIN32


### PR DESCRIPTION
According to https://devblogs.microsoft.com/oldnewthing/20170330-00/ , SEM_NOOPENFILEERRORBOX only has effect on Win16 API.