### PR TITLE
Catch exception in SerialStream constructor if DTR or RTS is not available (Windows)

### DIFF
--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -638,7 +638,7 @@ namespace System.IO.Ports
                 {
                     DtrEnable = dtrEnable;
                 }
-                catch (IOException) when (dtrEnable == false)
+                catch (IOException) when (!dtrEnable)
                 {
                     // An IOException can be thrown when using a port which doesn't implement
                     // the required termios command for setting DtrEnable, but it still works without setting the value
@@ -658,7 +658,7 @@ namespace System.IO.Ports
                     if ((handshake != Handshake.RequestToSend && handshake != Handshake.RequestToSendXOnXOff))
                         RtsEnable = rtsEnable;
                 }
-                catch (IOException) when (rtsEnable == false)
+                catch (IOException) when (!rtsEnable)
                 {
                     // An IOException can be thrown when using a port which doesn't implement
                     // the required termios command for setting RtsEnable, but it still works without setting the value


### PR DESCRIPTION
Catch IOException in SerialStream constructor when setting DTR or RTS is not possible. This will allow ports that do not support setting DTR or RTS to function normally.

This is the Windows equivalent of #48577.

Fixes #27729.