### PR TITLE
Remove redundant #endif/#if

### DIFF
--- a/src/coreclr/nativeaot/Runtime/portable.cpp
+++ b/src/coreclr/nativeaot/Runtime/portable.cpp
@@ -135,8 +135,6 @@ FCIMPL2(String *, RhNewString, MethodTable * pArrayEEType, intptr_t numElements)
 }
 FCIMPLEND
 
-#endif
-#if defined(FEATURE_PORTABLE_HELPERS)
 #if defined(FEATURE_64BIT_ALIGNMENT)
 
 GPTR_DECL(MethodTable, g_pFreeObjectEEType);


### PR DESCRIPTION
This PR removes are a pair of `#endif` and `#if define` where it just ends and restarts the same macro.