### PR TITLE
[release/10.0] [mono][sgen] Make color visible to client permanent 

### DIFF
--- a/src/mono/mono/metadata/sgen-bridge.c
+++ b/src/mono/mono/metadata/sgen-bridge.c
@@ -713,6 +713,8 @@ sgen_bridge_handle_gc_param (const char *opt)
 
 	if (!strcmp (opt, "bridge-require-precise-merge")) {
 		bridge_processor_config.scc_precise_merge = TRUE;
+	} else if (!strcmp (opt, "disable-non-bridge-scc")) {
+		bridge_processor_config.disable_non_bridge_scc = TRUE;
 	} else {
 		return FALSE;
 	}

--- a/src/mono/mono/metadata/sgen-tarjan-bridge.c
+++ b/src/mono/mono/metadata/sgen-tarjan-bridge.c
@@ -96,6 +96,11 @@ typedef struct {
 	// Count of colors that list this color in their other_colors
 	unsigned incoming_colors : INCOMING_COLORS_BITS;
 	unsigned visited : 1;
+	// color_visible_to_client for a ColorData* can change over the course of bridge processing which
+	// is problematic. We fix this by setting this flag when a color is detected as visible to client.
+	// Once the flag is set, the color is pinned to being visible to client, even though it could lose
+	// some xrefs, making it not satisfy the bridgeless_color_is_heavy condition.
+	unsigned visible_to_client : 1;
 } ColorData;
 
 // Represents one managed object. Equivalent of new/old bridge "HashEntry"
@@ -140,8 +145,17 @@ bridgeless_color_is_heavy (ColorData *data) {
 
 // Should color be made visible to client?
 static gboolean
-color_visible_to_client (ColorData *data) {
-	return dyn_array_ptr_size (&data->bridges) || bridgeless_color_is_heavy (data);
+color_visible_to_client (ColorData *data)
+{
+	if (data->visible_to_client)
+		return TRUE;
+
+	if (dyn_array_ptr_size (&data->bridges) || bridgeless_color_is_heavy (data)) {
+		data->visible_to_client = TRUE;
+		return TRUE;
+	} else {
+		return FALSE;
+	}
 }
 
 // Stacks of ScanData objects used for tarjan algorithm.
@@ -1105,9 +1119,9 @@ processing_build_callback_data (int generation)
 	for (cur = root_color_bucket; cur; cur = cur->next) {
 		ColorData *cd;
 		for (cd = &cur->data [0]; cd < cur->next_data; ++cd) {
-			int bridges = dyn_array_ptr_size (&cd->bridges);
-			if (!(bridges || bridgeless_color_is_heavy (cd)))
+			if (!color_visible_to_client (cd))
 				continue;
+			int bridges = dyn_array_ptr_size (&cd->bridges);
 
 			api_sccs [api_index] = (MonoGCBridgeSCC *)sgen_alloc_internal_dynamic (sizeof (MonoGCBridgeSCC) + sizeof (MonoObject*) * bridges, INTERNAL_MEM_BRIDGE_DATA, TRUE);
 			api_sccs [api_index]->is_alive = FALSE;

--- a/src/mono/mono/metadata/sgen-tarjan-bridge.c
+++ b/src/mono/mono/metadata/sgen-tarjan-bridge.c
@@ -944,9 +944,9 @@ dump_color_table (const char *why, gboolean do_index)
 	int i = 0, j;
 	printf ("colors%s:\n", why);
 
-	for (cur = root_color_bucket; cur; cur = cur->next, ++i) {
+	for (cur = root_color_bucket; cur; cur = cur->next) {
 		ColorData *cd;
-		for (cd = &cur->data [0]; cd < cur->next_data; ++cd) {
+		for (cd = &cur->data [0]; cd < cur->next_data; ++cd, ++i) {
 			if (do_index)
 				printf ("\t%d(%d):", i, cd->api_index);
 			else

--- a/src/tests/GC/Features/Bridge/Bridge.cs
+++ b/src/tests/GC/Features/Bridge/Bridge.cs
@@ -89,6 +89,12 @@ public class Bridge1 : BridgeBase
     }
 }
 
+[InlineArray(14)]
+public struct InlineData
+{
+    public object obj;
+}
+
 // 128 size
 public class Bridge14 : BridgeBase
 {
@@ -107,7 +113,7 @@ public class NonBridge2 : NonBridge
 
 public class NonBridge14
 {
-    public object a,b,c,d,e,f,g,h,i,j,k,l,m,n;
+    public InlineData Data;
 }
 
 
@@ -403,6 +409,27 @@ public class BridgeTest
         }
     }
 
+    public static void BridgelessHeavyColorChanging()
+    {
+        Bridge1[] left = new Bridge1[8];
+        for (int i = 0; i < 8; i++)
+            left[i] = new Bridge1();
+        Bridge[] right = new Bridge[7];
+        for (int i = 0; i < 7; i++)
+            right[i] = new Bridge();
+        NonBridge2 right7 = new NonBridge2();
+
+        NonBridge14 mid = new NonBridge14();
+
+        for (int i = 0; i < 8; i++)
+            left[i].Link = mid;
+        for (int i = 0; i < 7; i++)
+            mid.Data[i] = right[i];
+        mid.Data[7] = right7;
+        right7.Link = right[6];
+        right7.Link2 = right[5];
+    }
+
     public static int Main(string[] args)
     {
         TestLinkedList();
@@ -417,6 +444,7 @@ public class BridgeTest
         RunGraphTest(NestedCycles);
         RunGraphTest(FauxHeavyNodeWithCycles);
         RunGraphTest(Spider);
+        RunGraphTest(BridgelessHeavyColorChanging);
         return 100;
     }
 }


### PR DESCRIPTION
Backport https://github.com/dotnet/runtime/pull/121247 and https://github.com/dotnet/runtime/pull/121243 to release/10.0.
This fixes assertions like
```
* Assertion at /home/vbrezae/Xamarin/repos/runtime/src/mono/mono/metadata/sgen-tarjan-bridge.c:1151, condition `color_visible_to_client (cd)' not met
```

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Some applications on maui-android can randomly crash during GC, when using the default gc bridge (the tarjan bridge). We've had a few fixes for the tarjan bridge merged a few months ago, but there is still this one issue. The workaround used by customers is to fallback to an older GC bridge which has worse performance. For some this performance impact is not acceptable. This backport also fixes the same issue in the CoreCLR gcbridge implementation. CoreCLR doesn't have a fallback GC bridge implementation, so this fix is essential for the successful use of CoreCLR/NativeAOT on android, at least for some customers.

## Regression

- [ ] Yes
- [x] No

## Testing

Tested on our own gc bridge tests, with scenario causing the issue.

## Risk

The GC bridge is a sensitive area and fixes here typically have some carried risk. This fix however is quite straightforward, it simply pins the value of a property inside an SCC node, rather than having it recomputed with unstable value that was leading to problems. No changes are done to the core algorithm. Low risk.