### PR TITLE
Initialize variable in mono_utility_thread_send_sync

### DIFF
--- a/src/mono/mono/utils/mono-utility-thread.c
+++ b/src/mono/mono/utils/mono-utility-thread.c
@@ -152,7 +152,7 @@ mono_utility_thread_send_sync (MonoUtilityThread *thread, gpointer message)
 	mono_os_sem_init (&sem, 0);
 
 	UtilityThreadQueueEntry *entry = (UtilityThreadQueueEntry*)mono_lock_free_alloc (&thread->message_allocator);
-	gboolean done;
+	gboolean done = FALSE;
 
 	entry->finished = &done;
 	entry->response_sem = &sem;


### PR DESCRIPTION
By design `done` variable should be set to false and changed to true, when thread finished. But for now, `done` is not initialized.

`done` is used in the loop to check finish status and then as the return value. An uninitialized variable contains a random value. In most cases, this is  interpreted as true and leads to early function termination and an incorrect return value.

Signed-off-by: Aleksandr Dovydenkov <asd@altlinux.org>.
Found by Linux Verification Center (linuxtesting.org) with SVACE.