### PR TITLE
Fix / disable several coreclr tests with interpreter

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1002,6 +1002,10 @@ void ValidateEmittedSequenceTermination(InterpInst *lastIns)
 
     if (InterpOpIsUncondBranch(lastIns->opcode) ||
         (lastIns->opcode == INTOP_RET) ||
+        (lastIns->opcode == INTOP_RET_I1) ||
+        (lastIns->opcode == INTOP_RET_U1) ||
+        (lastIns->opcode == INTOP_RET_I2) ||
+        (lastIns->opcode == INTOP_RET_U2) ||
         (lastIns->opcode == INTOP_RET_VOID) ||
         (lastIns->opcode == INTOP_RET_VT) ||
         (lastIns->opcode == INTOP_THROW) ||
@@ -2654,7 +2658,7 @@ void InterpCompiler::EmitBinaryArithmeticOp(int32_t opBase)
             }
         }
     }
-    else if (opBase == INTOP_SUB_I4 && type1 == StackTypeByRef)
+    else if (opBase == INTOP_SUB_I4 && ((type1 == StackTypeByRef) || (type2 == StackTypeByRef)))
     {
         if (type2 == StackTypeI4)
         {
@@ -2862,6 +2866,18 @@ static int32_t GetLdindForType(InterpType interpType)
             assert(0);
     }
     return -1;
+}
+
+static int32_t GetRetForType(InterpType interpType)
+{
+    switch (interpType)
+    {
+        case InterpTypeI1: return INTOP_RET_I1;
+        case InterpTypeU1: return INTOP_RET_U1;
+        case InterpTypeI2: return INTOP_RET_I2;
+        case InterpTypeU2: return INTOP_RET_U2;
+        default: return INTOP_RET;
+    }
 }
 
 static bool DoesValueTypeContainGCRefs(COMP_HANDLE compHnd, CORINFO_CLASS_HANDLE clsHnd)
@@ -4573,7 +4589,8 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
     if (injectRet)
     {
         // Jmp to PInvoke was converted to normal pinvoke, so we need to inject a ret after the call
-        switch (GetInterpType(callInfo.sig.retType))
+        InterpType retType = GetInterpType(m_methodInfo->args.retType);
+        switch (retType)
         {
             case InterpTypeVT:
             {
@@ -4586,7 +4603,7 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
                 AddIns(INTOP_RET_VOID);
                 break;
             default:
-                AddIns(INTOP_RET);
+                AddIns(GetRetForType(retType));
                 m_pLastNewIns->SetSVar(dVar);
                 break;
         }
@@ -4710,8 +4727,24 @@ void InterpCompiler::EmitStind(InterpType interpType, CORINFO_CLASS_HANDLE clsHn
     m_pStackPointer -= 2;
 }
 
+void InterpCompiler::EmitNintIndexCheck(StackInfo *sp)
+{
+    // In the rare case when array is indexed by nint instead of int, we emit an extra check
+    // to ensure the nint value fits in int32_t
+    AddIns(INTOP_CONV_NI);
+    m_pLastNewIns->SetSVar(sp->var);
+    int32_t var = CreateVarExplicit(g_interpTypeFromStackType[StackTypeI4], NULL, INTERP_STACK_SLOT_SIZE);
+    new (sp) StackInfo(StackTypeI4, NULL, var);
+    m_pLastNewIns->SetDVar(var);
+}
+
 void InterpCompiler::EmitLdelem(int32_t opcode, InterpType interpType)
 {
+    // handle nint index case
+    if (m_pStackPointer[-1].GetStackType() == StackTypeI8)
+    {
+        EmitNintIndexCheck(m_pStackPointer - 1);
+    }
     m_pStackPointer -= 2;
     AddIns(opcode);
     m_pLastNewIns->SetSVars2(m_pStackPointer[0].var, m_pStackPointer[1].var);
@@ -4721,6 +4754,12 @@ void InterpCompiler::EmitLdelem(int32_t opcode, InterpType interpType)
 
 void InterpCompiler::EmitStelem(InterpType interpType)
 {
+    // handle nint index case
+    if (m_pStackPointer[-2].GetStackType() == StackTypeI8)
+    {
+        EmitNintIndexCheck(m_pStackPointer - 2);
+    }
+
     m_pStackPointer[-1].BashStackTypeToI_ForLocalVariableAddress();
 #ifdef TARGET_64BIT
     // nint and int32 can be used interchangeably. Add implicit conversions.
@@ -6121,7 +6160,7 @@ retry_emit:
                         }
                     }
 
-                    AddIns(INTOP_RET);
+                    AddIns(GetRetForType(retType));
                     m_pStackPointer--;
                     m_pLastNewIns->SetSVar(m_pStackPointer[0].var);
                 }
@@ -8346,6 +8385,13 @@ DO_LDFTN:
                 CorInfoType elemCorType = m_compHnd->asCorInfoType(elemClsHnd);
 
                 m_pStackPointer -= 2;
+
+                // handle nint index
+                if (m_pStackPointer[1].GetStackType() == StackTypeI8)
+                {
+                    EmitNintIndexCheck(m_pStackPointer + 1);
+                }
+
                 if ((elemCorType == CORINFO_TYPE_CLASS) && !readonly)
                 {
                     CORINFO_GENERICHANDLE_RESULT embedInfo;

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -4741,7 +4741,7 @@ void InterpCompiler::EmitNintIndexCheck(StackInfo *spArray, StackInfo *spIndex)
 void InterpCompiler::EmitLdelem(int32_t opcode, InterpType interpType)
 {
     // handle nint index case
-    if (m_pStackPointer[1].GetStackType() == StackTypeI8)
+    if (m_pStackPointer[-1].GetStackType() == StackTypeI8)
     {
         EmitNintIndexCheck(m_pStackPointer - 2, m_pStackPointer - 1);
     }

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -827,6 +827,7 @@ private:
     bool    EmitNamedIntrinsicCall(NamedIntrinsic ni, bool nonVirtualCall, CORINFO_CLASS_HANDLE clsHnd, CORINFO_METHOD_HANDLE method, CORINFO_SIG_INFO sig);
     void    EmitLdind(InterpType type, CORINFO_CLASS_HANDLE clsHnd, int32_t offset);
     void    EmitStind(InterpType type, CORINFO_CLASS_HANDLE clsHnd, int32_t offset, bool reverseSVarOrder, bool enableImplicitArgConversionRules);
+    void    EmitNintIndexCheck(StackInfo *sp);
     void    EmitLdelem(int32_t opcode, InterpType type);
     void    EmitStelem(InterpType type);
     void    EmitStaticFieldAddress(CORINFO_FIELD_INFO *pFieldInfo, CORINFO_RESOLVED_TOKEN *pResolvedToken);

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -827,7 +827,7 @@ private:
     bool    EmitNamedIntrinsicCall(NamedIntrinsic ni, bool nonVirtualCall, CORINFO_CLASS_HANDLE clsHnd, CORINFO_METHOD_HANDLE method, CORINFO_SIG_INFO sig);
     void    EmitLdind(InterpType type, CORINFO_CLASS_HANDLE clsHnd, int32_t offset);
     void    EmitStind(InterpType type, CORINFO_CLASS_HANDLE clsHnd, int32_t offset, bool reverseSVarOrder, bool enableImplicitArgConversionRules);
-    void    EmitNintIndexCheck(StackInfo *sp);
+    void    EmitNintIndexCheck(StackInfo *spArray, StackInfo *spIndex);
     void    EmitLdelem(int32_t opcode, InterpType type);
     void    EmitStelem(InterpType type);
     void    EmitStaticFieldAddress(CORINFO_FIELD_INFO *pFieldInfo, CORINFO_RESOLVED_TOKEN *pResolvedToken);

--- a/src/coreclr/interpreter/inc/intops.def
+++ b/src/coreclr/interpreter/inc/intops.def
@@ -7,6 +7,10 @@
 // we should add compact opcodes where all data is in uint16_t slots.
 
 OPDEF(INTOP_RET, "ret", 2, 0, 1, InterpOpNoArgs)
+OPDEF(INTOP_RET_I1, "ret.i1", 2, 0, 1, InterpOpNoArgs)
+OPDEF(INTOP_RET_U1, "ret.u1", 2, 0, 1, InterpOpNoArgs)
+OPDEF(INTOP_RET_I2, "ret.i2", 2, 0, 1, InterpOpNoArgs)
+OPDEF(INTOP_RET_U2, "ret.u2", 2, 0, 1, InterpOpNoArgs)
 OPDEF(INTOP_RET_VT, "ret.vt", 3, 0, 1, InterpOpInt)
 OPDEF(INTOP_RET_VOID, "ret.void", 1, 0, 0, InterpOpNoArgs)
 
@@ -55,6 +59,8 @@ OPDEF(INTOP_STELEM_VT_NOREF, "stelem.vt.noref", 5, 0, 3, InterpOpInt)
 OPDEF(INTOP_LDELEMA, "ldelema", 5, 1, 2, InterpOpInt)
 OPDEF(INTOP_LDELEMA_REF, "ldelema.ref", 5, 1, 2, InterpOpClassHandle)
 OPDEF(INTOP_LDELEMA_REF_GENERIC, "ldelema.ref.generic", 6, 1, 3, InterpOpGenericLookup)
+
+OPDEF(INTOP_CONV_NI, "conv.ni", 3, 1, 1, InterpOpNoArgs)
 
 OPDEF(INTOP_MOV_I4_I1, "mov.i4.i1", 3, 1, 1, InterpOpNoArgs)
 OPDEF(INTOP_MOV_I4_U1, "mov.i4.u1", 3, 1, 1, InterpOpNoArgs)

--- a/src/coreclr/interpreter/inc/intops.def
+++ b/src/coreclr/interpreter/inc/intops.def
@@ -60,7 +60,7 @@ OPDEF(INTOP_LDELEMA, "ldelema", 5, 1, 2, InterpOpInt)
 OPDEF(INTOP_LDELEMA_REF, "ldelema.ref", 5, 1, 2, InterpOpClassHandle)
 OPDEF(INTOP_LDELEMA_REF_GENERIC, "ldelema.ref.generic", 6, 1, 3, InterpOpGenericLookup)
 
-OPDEF(INTOP_CONV_NI, "conv.ni", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_NI, "conv.ni", 4, 1, 2, InterpOpNoArgs)
 
 OPDEF(INTOP_MOV_I4_I1, "mov.i4.i1", 3, 1, 1, InterpOpNoArgs)
 OPDEF(INTOP_MOV_I4_U1, "mov.i4.u1", 3, 1, 1, InterpOpNoArgs)

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -3346,7 +3346,7 @@ do {                                                                           \
                 case INTOP_CONV_NI:
                 {
                     int64_t value = LOCAL_VAR(ip[2], int64_t);
-                    if ((value < 0) || (value > INT_MAX))
+                    if ((value < 0) || (value > UINT_MAX))
                     {
                         COMPlusThrow(kIndexOutOfRangeException);
                     }

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -3345,13 +3345,14 @@ do {                                                                           \
 
                 case INTOP_CONV_NI:
                 {
-                    int64_t value = LOCAL_VAR(ip[2], int64_t);
-                    if ((value < 0) || (value > UINT_MAX))
+                    NULL_CHECK(LOCAL_VAR(ip[2], void*));
+                    int64_t index = LOCAL_VAR(ip[3], int64_t);
+                    if ((index < 0) || (index > UINT_MAX))
                     {
                         COMPlusThrow(kIndexOutOfRangeException);
                     }
-                    LOCAL_VAR(ip[1], int64_t) = value;
-                    ip += 3;
+                    LOCAL_VAR(ip[1], int64_t) = index;
+                    ip += 4;
                     break;
                 }
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -862,6 +862,22 @@ MAIN_LOOP:
                     // Return stack slot sized value
                     *(int64_t*)pFrame->pRetVal = LOCAL_VAR(ip[1], int64_t);
                     goto EXIT_FRAME;
+                case INTOP_RET_I1:
+                    // Return int8 value
+                    *(int64_t*)pFrame->pRetVal = (int8_t)LOCAL_VAR(ip[1], int32_t);
+                    goto EXIT_FRAME;
+                case INTOP_RET_U1:
+                    // Return uint8 value
+                    *(int64_t*)pFrame->pRetVal = (uint8_t)LOCAL_VAR(ip[1], int32_t);
+                    goto EXIT_FRAME;
+                case INTOP_RET_I2:
+                    // Return int16 value
+                    *(int64_t*)pFrame->pRetVal = (int16_t)LOCAL_VAR(ip[1], int32_t);
+                    goto EXIT_FRAME;
+                case INTOP_RET_U2:
+                    // Return uint16 value
+                    *(int64_t*)pFrame->pRetVal = (uint16_t)LOCAL_VAR(ip[1], int32_t);
+                    goto EXIT_FRAME;
                 case INTOP_RET_VT:
                     memmove(pFrame->pRetVal, LOCAL_VAR_ADDR(ip[1], void), ip[2]);
                     goto EXIT_FRAME;
@@ -2817,6 +2833,8 @@ CALL_INTERP_METHOD:
                     int32_t vtSize = ip[4];
                     void *vtThis = LOCAL_VAR_ADDR(returnOffset, void);
 
+                    memset(vtThis, 0, vtSize);
+
                     // pass the address of the valuetype
                     LOCAL_VAR(callArgsOffset, void*) = vtThis;
 
@@ -3322,6 +3340,18 @@ do {                                                                           \
 
                     LOCAL_VAR(ip[1], void*) = elemAddr;
                     ip += 6;
+                    break;
+                }
+
+                case INTOP_CONV_NI:
+                {
+                    int64_t value = LOCAL_VAR(ip[2], int64_t);
+                    if ((value < 0) || (value > INT_MAX))
+                    {
+                        COMPlusThrow(kIndexOutOfRangeException);
+                    }
+                    LOCAL_VAR(ip[1], int64_t) = value;
+                    ip += 3;
                     break;
                 }
 

--- a/src/tests/JIT/Directed/aliasing_retbuf/aliasing_retbuf.cs
+++ b/src/tests/JIT/Directed/aliasing_retbuf/aliasing_retbuf.cs
@@ -56,7 +56,7 @@ public unsafe class AliasingRetBuf
             failures |= 16;
         }
 
-        // This requires pinvoke marshalling which is not currently supported by the interpreter. See https://github.com/dotnet/runtime/issues/118965
+        // This requires pinvoke marshalling with calli which is not currently supported by the interpreter. See https://github.com/dotnet/runtime/issues/118965
         if (!TestLibrary.Utilities.IsCoreClrInterpreter)
         {
             f = new Foo { A = 3, B = 2, C = 1 };

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58259/Runtime_58259.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58259/Runtime_58259.cs
@@ -9,6 +9,8 @@ public unsafe class Runtime_58259
 {
     [OuterLoop]
     [Fact]
+    // This test uses pinvoke marshalling
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestEntryPoint()
     {
         M(out _);

--- a/src/tests/JIT/Regression/JitBlue/Runtime_58259/Runtime_58259.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_58259/Runtime_58259.cs
@@ -9,7 +9,7 @@ public unsafe class Runtime_58259
 {
     [OuterLoop]
     [Fact]
-    // This test uses pinvoke marshalling
+    // This test uses pinvoke marshalling with calli which is not currently supported by the interpreter.
     [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestEntryPoint()
     {

--- a/src/tests/baseservices/callconvs/TestCallingConventions.cs
+++ b/src/tests/baseservices/callconvs/TestCallingConventions.cs
@@ -170,7 +170,7 @@ public unsafe class Program
         try
         {
             BlittableFunctionPointers();
-            // This requires pinvoke marshalling which is not currently supported by the interpreter. See https://github.com/dotnet/runtime/issues/118965
+            // This requires pinvoke marshalling with calli which is not currently supported by the interpreter. See https://github.com/dotnet/runtime/issues/118965
             if (!TestLibrary.Utilities.IsCoreClrInterpreter)
             {
                 NonblittableFunctionPointers();


### PR DESCRIPTION
This change contains the following:
* Fix cases when returning smaller than 32 bit int / uint values - introduce new INTOP_RET variants like Mono
* Fix index out of range check case when native int is used as an index to an array. To avoid adding an explosion of array element access IR opcodes, it adds a range check opcode that is used only when the index is nint.
* put back zeroing to INTOP_NEWOBJ_VT, few tests were failing because it was missing and we've already fixed the issue we had with the zeroing before by setting the "noCallArgs"
* Disable a test that uses pinvoke marshalling with calli