### PR TITLE
JIT: Handle possibility of late optimized out async calls

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -6774,7 +6774,7 @@ void CodeGen::genReportAsyncDebugInfo()
     for (size_t i = 0; i < suspPoints->size(); i++)
     {
         emitLocation& emitLoc                   = ((emitLocation*)genAsyncResumeInfoTable->dsCont)[i];
-        (*suspPoints)[i].DiagnosticNativeOffset = emitLoc.CodeOffset(GetEmitter());
+        (*suspPoints)[i].DiagnosticNativeOffset = emitLoc.Valid() ? emitLoc.CodeOffset(GetEmitter()) : 0;
     }
 
     ICorDebugInfo::AsyncInfo asyncInfo;


### PR DESCRIPTION
If we optimize an async call away after the suspension/resumption code has been created then the emit locations used for resumption info and diagnostic info will not be valid. Handle this rare case by just storing 0. The value should not matter as we will never suspend here.

Suspension blocks can be removed in this case, but resumption blocks cannot as they are referenced by the resumption switch. Ideally we would model things so that resumption blocks could too be removed in these cases, but that's not so simple.

Fixes issue reported in https://github.com/dotnet/runtime/pull/121298#issuecomment-3499620124