### PR TITLE
Enable setting the TypeMap entrypoint assembly via a RuntimeHostConfigurationOption

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.targets
@@ -277,6 +277,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <IlcArg Condition="$(IlcMaxVectorTBitWidth) != ''" Include="--max-vectort-bitwidth:$(IlcMaxVectorTBitWidth)" />
       <IlcArg Condition="$(IlcSingleThreaded) == 'true'" Include="--parallelism:1" />
       <IlcArg Condition="$(IlcSystemModule) != ''" Include="--systemmodule:$(IlcSystemModule)" />
+      <IlcArg Condition="$(TypeMapEntryAssembly) != ''" Include="--typemap-entry-assembly:$(TypeMapEntryAssembly)" />
       <IlcArg Condition="'$(_targetOS)' == 'win' and $(IlcMultiModule) != 'true' and '$(IlcGenerateWin32Resources)' != 'false' and '$(NativeLib)' != 'Static'" Include="--win32resourcemodule:%(ManagedBinary.Filename)" />
       <IlcArg Condition="$(IlcDumpIL) == 'true'" Include="--ildump:$(NativeIntermediateOutputPath)%(ManagedBinary.Filename).il" />
       <IlcArg Condition="$(NoWarn) != ''" Include='--nowarn:"$([MSBuild]::Escape($(NoWarn)).Replace(`%0A`, ``).Replace(`%0D`, ``))"' />

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ILCompilerOptions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ILCompilerOptions.cs
@@ -23,5 +23,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
         public Dictionary<int, bool> WarningsAsErrors = new Dictionary<int, bool>();
         public List<string> SuppressedWarningCategories = new List<string>();
         public bool DisableGeneratedCodeHeuristics;
+        public string? TypeMapEntryAssembly;
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ILCompilerOptions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ILCompilerOptions.cs
@@ -14,7 +14,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
         public List<string> AdditionalRootAssemblies = new List<string>();
         public List<string> RootEntireAssemblies = new List<string>();
         public Dictionary<string, bool> FeatureSwitches = new Dictionary<string, bool>();
-        public Dictionary<string, string> RuntimeKnobs = new Dictionary<string, string>();
         public List<string> Descriptors = new List<string>();
         public bool FrameworkCompilation;
         public bool SingleWarn;

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ILCompilerOptions.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/ILCompilerOptions.cs
@@ -14,6 +14,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
         public List<string> AdditionalRootAssemblies = new List<string>();
         public List<string> RootEntireAssemblies = new List<string>();
         public Dictionary<string, bool> FeatureSwitches = new Dictionary<string, bool>();
+        public Dictionary<string, string> RuntimeKnobs = new Dictionary<string, string>();
         public List<string> Descriptors = new List<string>();
         public bool FrameworkCompilation;
         public bool SingleWarn;

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingArgumentBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingArgumentBuilder.cs
@@ -163,9 +163,13 @@ namespace Mono.Linker.Tests.TestCasesRunner
             {
                 Options.FeatureSwitches.Add(values[0], bool.Parse(values[1]));
             }
-            if (flag == "--runtimeknob")
+            else if (flag == "--runtimeknob")
             {
                 Options.RuntimeKnobs.Add(values[0], values[1]);
+            }
+            else if (flag == "--typemap-entry-assembly")
+            {
+                Options.TypeMapEntryAssembly = values[0];
             }
             else if (flag == "--singlewarn")
             {

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingArgumentBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingArgumentBuilder.cs
@@ -163,10 +163,6 @@ namespace Mono.Linker.Tests.TestCasesRunner
             {
                 Options.FeatureSwitches.Add(values[0], bool.Parse(values[1]));
             }
-            else if (flag == "--runtimeknob")
-            {
-                Options.RuntimeKnobs.Add(values[0], values[1]);
-            }
             else if (flag == "--typemap-entry-assembly")
             {
                 Options.TypeMapEntryAssembly = values[0];

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingArgumentBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingArgumentBuilder.cs
@@ -163,6 +163,10 @@ namespace Mono.Linker.Tests.TestCasesRunner
             {
                 Options.FeatureSwitches.Add(values[0], bool.Parse(values[1]));
             }
+            if (flag == "--runtimeknob")
+            {
+                Options.RuntimeKnobs.Add(values[0], values[1]);
+            }
             else if (flag == "--singlewarn")
             {
                 Options.SingleWarn = true;

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
@@ -147,8 +147,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
             InteropStubManager interopStubManager = new UsageBasedInteropStubManager(interopStateManager, pinvokePolicy, logger);
 
             TypeMapManager typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.Empty);
-            if (options.RuntimeKnobs.TryGetValue("System.Runtime.InteropServices.TypeMappingEntryAssembly", out string? typeMappingEntryAssemblyName)
-                && typeSystemContext.ResolveAssembly(AssemblyNameInfo.Parse(typeMappingEntryAssemblyName), throwIfNotFound: true) is EcmaAssembly typeMapEntryAssembly)
+            if (options.TypeMapEntryAssembly is not null
+                && typeSystemContext.ResolveAssembly(AssemblyNameInfo.Parse(options.TypeMapEntryAssembly), throwIfNotFound: true) is EcmaAssembly typeMapEntryAssembly)
             {
                 typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(typeMapEntryAssembly, typeSystemContext));
             }

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
@@ -149,7 +149,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
             TypeMapManager typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.Empty);
             if (entrypointModule is { Assembly: EcmaAssembly entryAssembly })
             {
-                typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(entryAssembly, typeSystemContext));
+                // Pass null for typeMappingEntryAssembly to use default entry assembly behavior in tests
+                typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(entryAssembly, typeSystemContext, typeMappingEntryAssemblyName: null));
             }
 
             CompilationBuilder builder = new RyuJitCompilationBuilder(typeSystemContext, compilationGroup)

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
@@ -147,7 +147,12 @@ namespace Mono.Linker.Tests.TestCasesRunner
             InteropStubManager interopStubManager = new UsageBasedInteropStubManager(interopStateManager, pinvokePolicy, logger);
 
             TypeMapManager typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.Empty);
-            if (entrypointModule is { Assembly: EcmaAssembly entryAssembly })
+            if (options.RuntimeKnobs.TryGetValue("System.Runtime.InteropServices.TypeMappingEntryAssembly", out string? typeMappingEntryAssemblyName)
+                && typeSystemContext.ResolveAssembly(AssemblyNameInfo.Parse(typeMappingEntryAssemblyName), throwIfNotFound: true) is EcmaAssembly typeMapEntryAssembly)
+            {
+                typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(typeMapEntryAssembly, typeSystemContext));
+            }
+            else if (entrypointModule is { Assembly: EcmaAssembly entryAssembly })
             {
                 // Pass null for typeMappingEntryAssembly to use default entry assembly behavior in tests
                 typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(entryAssembly, typeSystemContext));

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
@@ -150,7 +150,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
             if (entrypointModule is { Assembly: EcmaAssembly entryAssembly })
             {
                 // Pass null for typeMappingEntryAssembly to use default entry assembly behavior in tests
-                typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(entryAssembly, typeSystemContext, typeMappingEntryAssemblyName: null));
+                typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(entryAssembly, typeSystemContext));
             }
 
             CompilationBuilder builder = new RyuJitCompilationBuilder(typeSystemContext, compilationGroup)

--- a/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
+++ b/src/coreclr/tools/aot/ILCompiler/ILCompilerRootCommand.cs
@@ -182,6 +182,8 @@ namespace ILCompiler
             new("--generateunmanagedentrypoints") { DefaultValueFactory = _ => Array.Empty<string>(), Description = "Generate unmanaged entrypoints for a given assembly" };
         public Option<bool> DisableGeneratedCodeHeuristics { get; } =
             new("--disable-generated-code-heuristics") { Description = "Disable heuristics for detecting compiler-generated code" };
+        public Option<string> TypeMapEntryAssembly { get; } =
+            new("--typemap-entry-assembly") { Description = "Assembly name to use as entry point for TypeMap generation" };
 
         public OptimizationMode OptimizationMode { get; private set; }
         public ParseResult Result;
@@ -273,6 +275,7 @@ namespace ILCompiler
             Options.Add(MakeReproPath);
             Options.Add(UnmanagedEntryPointsAssemblies);
             Options.Add(DisableGeneratedCodeHeuristics);
+            Options.Add(TypeMapEntryAssembly);
 
             this.SetAction(result =>
             {

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -314,17 +314,8 @@ namespace ILCompiler
                     compilationRoots.Add(new ILCompiler.DependencyAnalysis.TrimmingDescriptorNode(linkTrimFilePath));
                 }
 
-                // Get TypeMappingEntryAssembly from runtime knobs if specified
-                string typeMappingEntryAssembly = null;
-                foreach (var runtimeKnob in runtimeKnobs)
-                {
-                    var knobAndValue = runtimeKnob.Split('=', 2);
-                    if (knobAndValue.Length == 2 && knobAndValue[0] == "System.Runtime.InteropServices.TypeMappingEntryAssembly")
-                    {
-                        typeMappingEntryAssembly = knobAndValue[1];
-                        break;
-                    }
-                }
+                // Get TypeMappingEntryAssembly from command-line option if specified
+                string typeMappingEntryAssembly = Get(_command.TypeMapEntryAssembly);
                 if (typeMappingEntryAssembly is not null)
                 {
                     var typeMapEntryAssembly = (EcmaAssembly)typeSystemContext.ResolveAssembly(AssemblyNameInfo.Parse(typeMappingEntryAssembly), throwIfNotFound: true);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TypeMapLazyDictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TypeMapLazyDictionary.cs
@@ -189,7 +189,16 @@ namespace System.Runtime.InteropServices
             delegate* unmanaged<CallbackContext*, ProcessAttributesCallbackArg*, Interop.BOOL> newExternalTypeEntry,
             delegate* unmanaged<CallbackContext*, ProcessAttributesCallbackArg*, Interop.BOOL> newProxyTypeEntry)
         {
-            RuntimeAssembly? startingAssembly = (RuntimeAssembly?)Assembly.GetEntryAssembly();
+            RuntimeAssembly? startingAssembly;
+            if (AppContext.GetData("System.Runtime.InteropServices.TypeMappingEntryAssembly") is string entryAssemblyName)
+            {
+                startingAssembly = Assembly.Load(entryAssemblyName) as RuntimeAssembly;
+            }
+            else
+            {
+                startingAssembly = Assembly.GetEntryAssembly() as RuntimeAssembly;
+            }
+
             if (startingAssembly is null)
             {
                 throw new InvalidOperationException(SR.InvalidOperation_TypeMapMissingEntryAssembly);

--- a/src/tests/Interop/TypeMap/Lib5.cs
+++ b/src/tests/Interop/TypeMap/Lib5.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+// This library defines TypeMap entries that should be used when
+// TypeMapLib5 is specified as the TypeMappingEntryAssembly
+[assembly: TypeMap<AlternateEntryPoint>("lib5_type1", typeof(Lib5Type1))]
+[assembly: TypeMap<AlternateEntryPoint>("lib5_type2", typeof(Lib5Type2))]
+
+[assembly: TypeMapAssociation<AlternateEntryPoint>(typeof(Lib5Type1), typeof(Lib5Proxy1))]
+[assembly: TypeMapAssociation<AlternateEntryPoint>(typeof(Lib5Type2), typeof(Lib5Proxy2))]
+
+public class Lib5Type1 { }
+public class Lib5Type2 { }
+public class Lib5Proxy1 { }
+public class Lib5Proxy2 { }
+
+public class AlternateEntryPoint { }

--- a/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.cs
+++ b/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.cs
@@ -37,21 +37,11 @@ public class TypeMapEntryAssemblyTest
     {
         Console.WriteLine(nameof(Validate_TypeMappingEntryAssembly_ProxyMap));
 
-        // For NativeAOT, instantiate the type to ensure the mappings are marked
-        _ = new Lib5Type1();
-        _ = new Lib5Type2();
-
         // These proxy mappings should be resolved from TypeMapLib5's type maps
         IReadOnlyDictionary<Type, Type> proxyMap = TypeMapping.GetOrCreateProxyTypeMapping<AlternateEntryPoint>();
 
-        Assert.Equal(typeof(Lib5Proxy1), proxyMap[typeof(Lib5Type1)]);
-        Assert.Equal(typeof(Lib5Proxy2), proxyMap[typeof(Lib5Type2)]);
-
-        Assert.True(proxyMap.TryGetValue(typeof(Lib5Type1), out Type? proxy1));
-        Assert.Equal(typeof(Lib5Proxy1), proxy1);
-
-        Assert.True(proxyMap.TryGetValue(typeof(Lib5Type2), out Type? proxy2));
-        Assert.Equal(typeof(Lib5Proxy2), proxy2);
+        Assert.Equal(typeof(Lib5Proxy1), proxyMap[new Lib5Type1().GetType()]);
+        Assert.Equal(typeof(Lib5Proxy2), proxyMap[new Lib5Type2().GetType()]);
 
         Assert.False(proxyMap.TryGetValue(typeof(string), out Type? _));
     }

--- a/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.cs
+++ b/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.cs
@@ -37,6 +37,10 @@ public class TypeMapEntryAssemblyTest
     {
         Console.WriteLine(nameof(Validate_TypeMappingEntryAssembly_ProxyMap));
 
+        // For NativeAOT, instantiate the type to ensure the mappings are marked
+        _ = new Lib5Type1();
+        _ = new Lib5Type2();
+
         // These proxy mappings should be resolved from TypeMapLib5's type maps
         IReadOnlyDictionary<Type, Type> proxyMap = TypeMapping.GetOrCreateProxyTypeMapping<AlternateEntryPoint>();
 

--- a/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.cs
+++ b/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Xunit;
+
+// Note: This test does NOT define any TypeMap attributes.
+// The TypeMappingEntryAssembly is set to TypeMapLib5 via RuntimeHostConfigurationOption,
+// so the type maps should be resolved from TypeMapLib5 instead of this assembly.
+
+public class TypeMapEntryAssemblyTest
+{
+    [Fact]
+    public static void Validate_TypeMappingEntryAssembly_ExternalMap()
+    {
+        Console.WriteLine(nameof(Validate_TypeMappingEntryAssembly_ExternalMap));
+
+        // These types should be resolved from TypeMapLib5's type maps
+        IReadOnlyDictionary<string, Type> externalMap = TypeMapping.GetOrCreateExternalTypeMapping<AlternateEntryPoint>();
+
+        Assert.Equal(typeof(Lib5Type1), externalMap["lib5_type1"]);
+        Assert.Equal(typeof(Lib5Type2), externalMap["lib5_type2"]);
+
+        Assert.True(externalMap.TryGetValue("lib5_type1", out Type? type1));
+        Assert.Equal(typeof(Lib5Type1), type1);
+
+        Assert.True(externalMap.TryGetValue("lib5_type2", out Type? type2));
+        Assert.Equal(typeof(Lib5Type2), type2);
+
+        Assert.False(externalMap.TryGetValue("nonexistent", out Type? _));
+    }
+
+    [Fact]
+    public static void Validate_TypeMappingEntryAssembly_ProxyMap()
+    {
+        Console.WriteLine(nameof(Validate_TypeMappingEntryAssembly_ProxyMap));
+
+        // These proxy mappings should be resolved from TypeMapLib5's type maps
+        IReadOnlyDictionary<Type, Type> proxyMap = TypeMapping.GetOrCreateProxyTypeMapping<AlternateEntryPoint>();
+
+        Assert.Equal(typeof(Lib5Proxy1), proxyMap[typeof(Lib5Type1)]);
+        Assert.Equal(typeof(Lib5Proxy2), proxyMap[typeof(Lib5Type2)]);
+
+        Assert.True(proxyMap.TryGetValue(typeof(Lib5Type1), out Type? proxy1));
+        Assert.Equal(typeof(Lib5Proxy1), proxy1);
+
+        Assert.True(proxyMap.TryGetValue(typeof(Lib5Type2), out Type? proxy2));
+        Assert.Equal(typeof(Lib5Proxy2), proxy2);
+
+        Assert.False(proxyMap.TryGetValue(typeof(string), out Type? _));
+    }
+}

--- a/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.csproj
+++ b/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.csproj
@@ -13,8 +13,7 @@
 
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.TypeMappingEntryAssembly"
-                                    Value="$(TypeMapEntryAssembly)"
-                                    Trim="true" />
+                                    Value="$(TypeMapEntryAssembly)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.csproj
+++ b/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.csproj
@@ -12,18 +12,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.TypeMappingEntryAssembly"
+                                    Value="$(TypeMapEntryAssembly)"
+                                    Trim="true" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="TypeMapEntryAssemblyApp.cs" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="TypeMapLib5.csproj" />
     <ProjectReference Include="TypeMapLib1.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.TypeMappingEntryAssembly"
-      Value="$(TypeMapEntryAssembly)"
-      Condition="'$(TypeMapEntryAssembly)' != ''"
-      Trim="true" />
   </ItemGroup>
 </Project>

--- a/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.csproj
+++ b/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TypeMapEntryAssembly>TypeMapLib5</TypeMapEntryAssembly>
+    <MonoAotIncompatible>true</MonoAotIncompatible>
+    <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
+    <IlcGenerateMstatFile>true</IlcGenerateMstatFile>
+    <IlcGenerateDgmlFile>true</IlcGenerateDgmlFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="TypeMapEntryAssemblyApp.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="TypeMapLib5.csproj" />
+    <ProjectReference Include="TypeMapLib1.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.TypeMappingEntryAssembly"
+      Value="$(TypeMapEntryAssembly)"
+      Condition="'$(TypeMapEntryAssembly)' != ''"
+      Trim="true" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.csproj
+++ b/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <BuildAsStandalone>true</BuildAsStandalone>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <TypeMapEntryAssembly>TypeMapLib5</TypeMapEntryAssembly>
     <MonoAotIncompatible>true</MonoAotIncompatible>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>

--- a/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.csproj
+++ b/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <BuildAsStandalone>true</BuildAsStandalone>
     <TypeMapEntryAssembly>TypeMapLib5</TypeMapEntryAssembly>
     <MonoAotIncompatible>true</MonoAotIncompatible>
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>

--- a/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.csproj
+++ b/src/tests/Interop/TypeMap/TypeMapEntryAssemblyApp.csproj
@@ -6,6 +6,7 @@
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono'">true</DisableProjectBuild>
     <IlcGenerateMstatFile>true</IlcGenerateMstatFile>
     <IlcGenerateDgmlFile>true</IlcGenerateDgmlFile>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/Interop/TypeMap/TypeMapLib5.csproj
+++ b/src/tests/Interop/TypeMap/TypeMapLib5.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Lib5.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="TypeMapLib1.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
+++ b/src/tools/illink/src/ILLink.Tasks/build/Microsoft.NET.ILLink.targets
@@ -80,6 +80,11 @@ Copyright (c) .NET Foundation. All rights reserved.
     <EnableTrimAnalyzer Condition="'$(EnableTrimAnalyzer)' == ''">false</EnableTrimAnalyzer>
   </PropertyGroup>
 
+  <!-- Configure TypeMap entry assembly -->
+  <PropertyGroup Condition="'$(TypeMapEntryAssembly)' != ''">
+    <_ExtraTrimmerArgs>$(_ExtraTrimmerArgs) --typemap-entry-assembly "$(TypeMapEntryAssembly)"</_ExtraTrimmerArgs>
+  </PropertyGroup>
+
   <!-- Disable Redundant Warning Suppressions by default-->
   <PropertyGroup Condition="'$(_TrimmerShowRedundantSuppressions)' != 'true' And '$(PublishTrimmed)' == 'true'">
     <NoWarn>$(NoWarn);IL2121</NoWarn>

--- a/src/tools/illink/src/linker/CompatibilitySuppressions.xml
+++ b/src/tools/illink/src/linker/CompatibilitySuppressions.xml
@@ -1548,6 +1548,14 @@
     <Right>lib/net10.0/illink.dll</Right>
   </Suppression>
   <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Mono.Linker.LinkContext.get_TypeMapEntryAssembly</Target>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0002</DiagnosticId>
+    <Target>M:Mono.Linker.LinkContext.set_TypeMapEntryAssembly(System.String)</Target>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0008</DiagnosticId>
     <Target>T:Mono.Linker.LinkContext</Target>
   </Suppression>

--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -255,11 +255,11 @@ namespace Mono.Linker.Steps
             InitializeCorelibAttributeXml();
             Context.Pipeline.InitializeMarkHandlers(Context, MarkContext);
 
-            // Check for TypeMappingEntryAssembly override from Features
+            // Check for TypeMappingEntryAssembly override
             AssemblyDefinition? startingAssembly = null;
-            if (Context.Features.TryGetValue("System.Runtime.InteropServices.TypeMappingEntryAssembly", out string? assemblyNameString))
+            if (Context.TypeMapEntryAssembly is not null)
             {
-                var assemblyName = AssemblyNameReference.Parse(assemblyNameString);
+                var assemblyName = AssemblyNameReference.Parse(Context.TypeMapEntryAssembly);
                 startingAssembly = Context.TryResolve(assemblyName);
             }
             // If resolution fails, fall back to entry point assembly

--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -254,7 +254,18 @@ namespace Mono.Linker.Steps
         {
             InitializeCorelibAttributeXml();
             Context.Pipeline.InitializeMarkHandlers(Context, MarkContext);
-            _typeMapHandler.Initialize(Context, this, Annotations.GetEntryPointAssembly());
+
+            // Check for TypeMappingEntryAssembly override from Features
+            AssemblyDefinition? startingAssembly = null;
+            if (Context.Features.TryGetValue("System.Runtime.InteropServices.TypeMappingEntryAssembly", out string? assemblyNameString))
+            {
+                var assemblyName = AssemblyNameReference.Parse(assemblyNameString);
+                startingAssembly = Context.TryResolve(assemblyName);
+            }
+            // If resolution fails, fall back to entry point assembly
+            startingAssembly ??= Annotations.GetEntryPointAssembly();
+
+            _typeMapHandler.Initialize(Context, this, startingAssembly);
             ProcessMarkedPending();
         }
 

--- a/src/tools/illink/src/linker/Linker/Driver.cs
+++ b/src/tools/illink/src/linker/Linker/Driver.cs
@@ -465,6 +465,13 @@ namespace Mono.Linker
 
                             continue;
 
+                        case "--typemap-entry-assembly":
+                            if (!GetStringParam(token, out string? typeMapEntryAssembly))
+                                return -1;
+
+                            context.TypeMapEntryAssembly = typeMapEntryAssembly;
+                            continue;
+
                         case "--ignore-descriptors":
                             if (!GetBoolParam(token, l => context.IgnoreDescriptors = l))
                                 return -1;
@@ -1528,6 +1535,7 @@ namespace Mono.Linker
             Console.WriteLine("                               sealer: Any method or type which does not have override is marked as sealed");
             Console.WriteLine("  --explicit-reflection      Adds to members never used through reflection DisablePrivateReflection attribute. Defaults to false");
             Console.WriteLine("  --feature FEATURE VALUE    Set feature setting as a constant known at link time. The trimmer may be able to optimize code based on the value.");
+            Console.WriteLine("  --typemap-entry-assembly NAME  Set the assembly name to use as entry point for TypeMap generation.");
             Console.WriteLine("  --keep-com-interfaces      Keep COM interfaces implemented by kept types. Defaults to true");
             Console.WriteLine("  --keep-compilers-resources Keep assembly resources used for F# compilation resources. Defaults to false");
             Console.WriteLine("  --keep-dep-attributes      Keep attributes used for manual dependency tracking. Defaults to false");

--- a/src/tools/illink/src/linker/Linker/Driver.cs
+++ b/src/tools/illink/src/linker/Linker/Driver.cs
@@ -522,21 +522,14 @@ namespace Mono.Linker
                             if (!GetStringParam(token, out string? featureName))
                                 return -1;
 
-                            if (!GetStringParam(token, out string? featureValue))
-                                return -1;
-
-                            // Store all features as strings
-                            context.Features[featureName] = featureValue;
-
-                            // Store boolean features also as booleans
-                            if (bool.TryParse(featureValue, out bool boolValue))
+                            if (!GetBoolParam(token, value =>
                             {
-                                context.SetFeatureValue(featureName, boolValue);
-                            }
+                                context.SetFeatureValue(featureName, value);
+                            }))
+                                return -1;
 
                             continue;
                         }
-
                         case "--new-mvid":
                             //
                             // This is not same as --deterministic which calculates MVID
@@ -1523,35 +1516,35 @@ namespace Mono.Linker
 
             Console.WriteLine();
             Console.WriteLine("Trimming");
-            Console.WriteLine("  --disable-opt NAME [ASM]   Disable one of the default optimizations globaly or for a specific assembly name");
-            Console.WriteLine("                               beforefieldinit: Unused static fields are removed if there is no static ctor");
-            Console.WriteLine("                               ipconstprop: Interprocedural constant propagation on return values");
-            Console.WriteLine("                               overrideremoval: Overrides of virtual methods on types that are never instantiated are removed");
-            Console.WriteLine("                               unreachablebodies: Instance methods that are marked but not executed are converted to throws");
-            Console.WriteLine("                               unusedinterfaces: Removes interface types from declaration when not used");
-            Console.WriteLine("                               unusedtypechecks: Inlines never successful type checks");
-            Console.WriteLine("                               substitutefeatureguards: Substitutes properties annotated as FeatureGuard(typeof(RequiresUnreferencedCodeAttribute)) to false");
-            Console.WriteLine("  --enable-opt NAME [ASM]    Enable one of the additional optimizations globaly or for a specific assembly name");
-            Console.WriteLine("                               sealer: Any method or type which does not have override is marked as sealed");
-            Console.WriteLine("  --explicit-reflection      Adds to members never used through reflection DisablePrivateReflection attribute. Defaults to false");
-            Console.WriteLine("  --feature FEATURE VALUE    Set feature setting as a constant known at link time. The trimmer may be able to optimize code based on the value.");
+            Console.WriteLine("  --disable-opt NAME [ASM]       Disable one of the default optimizations globaly or for a specific assembly name");
+            Console.WriteLine("                                   beforefieldinit: Unused static fields are removed if there is no static ctor");
+            Console.WriteLine("                                   ipconstprop: Interprocedural constant propagation on return values");
+            Console.WriteLine("                                   overrideremoval: Overrides of virtual methods on types that are never instantiated are removed");
+            Console.WriteLine("                                   unreachablebodies: Instance methods that are marked but not executed are converted to throws");
+            Console.WriteLine("                                   unusedinterfaces: Removes interface types from declaration when not used");
+            Console.WriteLine("                                   unusedtypechecks: Inlines never successful type checks");
+            Console.WriteLine("                                   substitutefeatureguards: Substitutes properties annotated as FeatureGuard(typeof(RequiresUnreferencedCodeAttribute)) to false");
+            Console.WriteLine("  --enable-opt NAME [ASM]        Enable one of the additional optimizations globaly or for a specific assembly name");
+            Console.WriteLine("                                   sealer: Any method or type which does not have override is marked as sealed");
+            Console.WriteLine("  --explicit-reflection          Adds to members never used through reflection DisablePrivateReflection attribute. Defaults to false");
+            Console.WriteLine("  --feature FEATURE VALUE        Apply any optimizations defined when this feature setting is a constant known at link time");
             Console.WriteLine("  --typemap-entry-assembly NAME  Set the assembly name to use as entry point for TypeMap generation.");
-            Console.WriteLine("  --keep-com-interfaces      Keep COM interfaces implemented by kept types. Defaults to true");
-            Console.WriteLine("  --keep-compilers-resources Keep assembly resources used for F# compilation resources. Defaults to false");
-            Console.WriteLine("  --keep-dep-attributes      Keep attributes used for manual dependency tracking. Defaults to false");
-            Console.WriteLine("  --keep-metadata NAME       Keep metadata which would otherwise be removed if not used");
-            Console.WriteLine("                               all: Metadata for any member are all kept");
-            Console.WriteLine("                               parametername: All parameter names are kept");
-            Console.WriteLine("  --new-mvid                 Generate a new guid for each linked assembly (short -g). Defaults to true");
-            Console.WriteLine("  --strip-descriptors        Remove XML descriptor resources for linked assemblies. Defaults to true");
-            Console.WriteLine("  --strip-security           Remove metadata and code related to Code Access Security. Defaults to true");
-            Console.WriteLine("  --substitutions FILE       Configuration file with field or methods substitution rules");
-            Console.WriteLine("  --ignore-substitutions     Skips reading embedded substitutions. Defaults to false");
-            Console.WriteLine("  --strip-substitutions      Remove XML substitution resources for linked assemblies. Defaults to true");
-            Console.WriteLine("  --used-attrs-only          Attribute usage is removed if the attribute type is not used. Defaults to false");
-            Console.WriteLine("  --link-attributes FILE     Supplementary custom attribute definitions for attributes controlling the trimming behavior.");
-            Console.WriteLine("  --ignore-link-attributes   Skips reading embedded attributes. Defaults to false");
-            Console.WriteLine("  --strip-link-attributes    Remove XML link attributes resources for linked assemblies. Defaults to true");
+            Console.WriteLine("  --keep-com-interfaces          Keep COM interfaces implemented by kept types. Defaults to true");
+            Console.WriteLine("  --keep-compilers-resources     Keep assembly resources used for F# compilation resources. Defaults to false");
+            Console.WriteLine("  --keep-dep-attributes          Keep attributes used for manual dependency tracking. Defaults to false");
+            Console.WriteLine("  --keep-metadata NAME           Keep metadata which would otherwise be removed if not used");
+            Console.WriteLine("                                   all: Metadata for any member are all kept");
+            Console.WriteLine("                                   parametername: All parameter names are kept");
+            Console.WriteLine("  --new-mvid                     Generate a new guid for each linked assembly (short -g). Defaults to true");
+            Console.WriteLine("  --strip-descriptors            Remove XML descriptor resources for linked assemblies. Defaults to true");
+            Console.WriteLine("  --strip-security               Remove metadata and code related to Code Access Security. Defaults to true");
+            Console.WriteLine("  --substitutions FILE           Configuration file with field or methods substitution rules");
+            Console.WriteLine("  --ignore-substitutions         Skips reading embedded substitutions. Defaults to false");
+            Console.WriteLine("  --strip-substitutions          Remove XML substitution resources for linked assemblies. Defaults to true");
+            Console.WriteLine("  --used-attrs-only              Attribute usage is removed if the attribute type is not used. Defaults to false");
+            Console.WriteLine("  --link-attributes FILE         Supplementary custom attribute definitions for attributes controlling the trimming behavior.");
+            Console.WriteLine("  --ignore-link-attributes       Skips reading embedded attributes. Defaults to false");
+            Console.WriteLine("  --strip-link-attributes        Remove XML link attributes resources for linked assemblies. Defaults to true");
 
             Console.WriteLine();
             Console.WriteLine("Analyzer");

--- a/src/tools/illink/src/linker/Linker/Driver.cs
+++ b/src/tools/illink/src/linker/Linker/Driver.cs
@@ -515,14 +515,21 @@ namespace Mono.Linker
                             if (!GetStringParam(token, out string? featureName))
                                 return -1;
 
-                            if (!GetBoolParam(token, value =>
-                            {
-                                context.SetFeatureValue(featureName, value);
-                            }))
+                            if (!GetStringParam(token, out string? featureValue))
                                 return -1;
+
+                            // Store all features as strings
+                            context.Features[featureName] = featureValue;
+
+                            // Store boolean features also as booleans
+                            if (bool.TryParse(featureValue, out bool boolValue))
+                            {
+                                context.SetFeatureValue(featureName, boolValue);
+                            }
 
                             continue;
                         }
+
                         case "--new-mvid":
                             //
                             // This is not same as --deterministic which calculates MVID
@@ -1520,7 +1527,7 @@ namespace Mono.Linker
             Console.WriteLine("  --enable-opt NAME [ASM]    Enable one of the additional optimizations globaly or for a specific assembly name");
             Console.WriteLine("                               sealer: Any method or type which does not have override is marked as sealed");
             Console.WriteLine("  --explicit-reflection      Adds to members never used through reflection DisablePrivateReflection attribute. Defaults to false");
-            Console.WriteLine("  --feature FEATURE VALUE    Apply any optimizations defined when this feature setting is a constant known at link time");
+            Console.WriteLine("  --feature FEATURE VALUE    Set feature setting as a constant known at link time. The trimmer may be able to optimize code based on the value.");
             Console.WriteLine("  --keep-com-interfaces      Keep COM interfaces implemented by kept types. Defaults to true");
             Console.WriteLine("  --keep-compilers-resources Keep assembly resources used for F# compilation resources. Defaults to false");
             Console.WriteLine("  --keep-dep-attributes      Keep attributes used for manual dependency tracking. Defaults to false");

--- a/src/tools/illink/src/linker/Linker/LinkContext.cs
+++ b/src/tools/illink/src/linker/Linker/LinkContext.cs
@@ -121,6 +121,8 @@ namespace Mono.Linker
 
         public bool DisableGeneratedCodeHeuristics { get; set; }
 
+        public string? TypeMapEntryAssembly { get; set; }
+
         /// <summary>
         /// Option to not special case EventSource.
         /// Currently, values are hard-coded and does not have a command line option to control

--- a/src/tools/illink/src/linker/Linker/LinkContext.cs
+++ b/src/tools/illink/src/linker/Linker/LinkContext.cs
@@ -137,8 +137,6 @@ namespace Mono.Linker
 
         public Dictionary<string, bool> FeatureSettings { get; init; }
 
-        public Dictionary<string, string> Features { get; init; }
-
         public List<PInvokeInfo> PInvokes { get; private set; }
 
         public string? PInvokesListFile;
@@ -223,7 +221,6 @@ namespace Mono.Linker
             _isTrimmable = new Dictionary<AssemblyDefinition, bool>();
             OutputDirectory = outputDirectory;
             FeatureSettings = new Dictionary<string, bool>(StringComparer.Ordinal);
-            Features = new Dictionary<string, string>(StringComparer.Ordinal);
 
             SymbolReaderProvider = new DefaultSymbolReaderProvider(false);
 

--- a/src/tools/illink/src/linker/Linker/LinkContext.cs
+++ b/src/tools/illink/src/linker/Linker/LinkContext.cs
@@ -135,6 +135,8 @@ namespace Mono.Linker
 
         public Dictionary<string, bool> FeatureSettings { get; init; }
 
+        public Dictionary<string, string> Features { get; init; }
+
         public List<PInvokeInfo> PInvokes { get; private set; }
 
         public string? PInvokesListFile;
@@ -219,6 +221,7 @@ namespace Mono.Linker
             _isTrimmable = new Dictionary<AssemblyDefinition, bool>();
             OutputDirectory = outputDirectory;
             FeatureSettings = new Dictionary<string, bool>(StringComparer.Ordinal);
+            Features = new Dictionary<string, string>(StringComparer.Ordinal);
 
             SymbolReaderProvider = new DefaultSymbolReaderProvider(false);
 

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/ReflectionTests.cs
@@ -185,6 +185,12 @@ namespace ILLink.RoslynAnalyzer.Tests
         }
 
         [Fact]
+        public Task TypeMapEntryAssembly()
+        {
+            return RunTest();
+        }
+
+        [Fact]
         public Task TypeBaseTypeUseViaReflection()
         {
             return RunTest();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/TypeMapEntryAssemblyLib.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/TypeMapEntryAssemblyLib.cs
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using Mono.Linker.Tests.Cases.Reflection.Dependencies;
+
+[assembly: TypeMap<TypeMapEntryAssemblyGroup>("entry_type1", typeof(EntryType1))]
+[assembly: TypeMap<TypeMapEntryAssemblyGroup>("entry_type2", typeof(EntryType2))]
+
+[assembly: TypeMapAssociation<TypeMapEntryAssemblyGroup>(typeof(EntrySource1), typeof(EntryProxy1))]
+[assembly: TypeMapAssociation<TypeMapEntryAssemblyGroup>(typeof(EntrySource2), typeof(EntryProxy2))]
+
+namespace Mono.Linker.Tests.Cases.Reflection.Dependencies
+{
+	public class TypeMapEntryAssemblyGroup { }
+
+	public class EntryType1 { }
+	public class EntryType2 { }
+
+	public class EntrySource1 { }
+	public class EntrySource2 { }
+
+	public class EntryProxy1 { }
+	public class EntryProxy2 { }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/TypeMapReferencedAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/TypeMapReferencedAssembly.cs
@@ -18,7 +18,7 @@ namespace Mono.Linker.Tests.Cases.Reflection.Dependencies
 {
     public class TypeMapReferencedAssembly
     {
-        public static void Main()
+        public static void Run()
         {
             // Mark expected trim targets
             _ = new TrimTarget1();

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMap.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMap.cs
@@ -179,7 +179,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
             Console.WriteLine(new ConstructedNoTypeCheckNoBoxStruct(42).Value);
 
-            TypeMapReferencedAssembly.Main();
+            TypeMapReferencedAssembly.Run();
 
             // TypeMapUniverses are independent between External and Proxy type maps.
             // That is, if the External type map is used for a given universe, that doesn't keep the Proxy type map, and vice versa.

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMap.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMap.cs
@@ -73,7 +73,7 @@ namespace Mono.Linker.Tests.Cases.Reflection
     [KeptAssembly("library.dll")]
     [KeptAssembly("library2.dll")]
     [KeptTypeInAssembly("library.dll", typeof(TypeMapReferencedAssembly))]
-    [KeptMemberInAssembly("library.dll", typeof(TypeMapReferencedAssembly), "Main()")]
+    [KeptMemberInAssembly("library.dll", typeof(TypeMapReferencedAssembly), "Run()")]
     [KeptTypeInAssembly("library.dll", typeof(TargetTypeUnconditional1), Tool = Tool.Trimmer)]
     [KeptTypeInAssembly("library.dll", typeof(TrimTarget1))]
     [KeptMemberInAssembly("library.dll", typeof(TrimTarget1), ".ctor()")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMapEntryAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMapEntryAssembly.cs
@@ -10,11 +10,7 @@ using Mono.Linker.Tests.Cases.Reflection.Dependencies;
 namespace Mono.Linker.Tests.Cases.Reflection
 {
 	[SetupCompileBefore("TypeMapEntryAssemblyLib.dll", new[] { "Dependencies/TypeMapEntryAssemblyLib.cs" })]
-#if NATIVEAOT
-	[SetupLinkerArgument("--runtimeknob", "System.Runtime.InteropServices.TypeMappingEntryAssembly", "TypeMapEntryAssemblyLib")]
-#else
-	[SetupLinkerArgument("--feature", "System.Runtime.InteropServices.TypeMappingEntryAssembly", "TypeMapEntryAssemblyLib")]
-#endif
+	[SetupLinkerArgument("--typemap-entry-assembly", "TypeMapEntryAssemblyLib")]
 
 	// The TypeMapEntryAssemblyGroup is defined in TypeMapEntryAssemblyLib, so its attributes should be kept
 	[KeptTypeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(TypeMapEntryAssemblyGroup))]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMapEntryAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMapEntryAssembly.cs
@@ -20,6 +20,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 	[KeptTypeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(TypeMapEntryAssemblyGroup))]
 	[KeptTypeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(EntryType1))]
 	[KeptTypeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(EntryType2))]
+	[KeptTypeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(EntrySource1))]
+	[KeptTypeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(EntrySource2))]
 	[KeptTypeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(EntryProxy1))]
 	[KeptTypeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(EntryProxy2))]
 
@@ -36,6 +38,8 @@ namespace Mono.Linker.Tests.Cases.Reflection
 
 			Console.WriteLine(externalMap);
 			Console.WriteLine(proxyMap);
+			_ = new EntrySource1();
+			_ = new EntrySource2();
 		}
 	}
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMapEntryAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMapEntryAssembly.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+using Mono.Linker.Tests.Cases.Reflection.Dependencies;
+
+namespace Mono.Linker.Tests.Cases.Reflection
+{
+	[SetupCompileBefore("TypeMapEntryAssemblyLib.dll", new[] { "Dependencies/TypeMapEntryAssemblyLib.cs" })]
+	[SetupLinkerArgument("--feature", "System.Runtime.InteropServices.TypeMappingEntryAssembly", "TypeMapEntryAssemblyLib")]
+
+	// The TypeMapEntryAssemblyGroup is defined in TypeMapEntryAssemblyLib, so its attributes should be kept
+	[KeptTypeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(TypeMapEntryAssemblyGroup))]
+	[KeptTypeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(EntryType1))]
+	[KeptTypeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(EntryType2))]
+	[KeptTypeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(EntryProxy1))]
+	[KeptTypeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(EntryProxy2))]
+
+	[KeptAttributeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(TypeMapAttribute<TypeMapEntryAssemblyGroup>))]
+	[KeptAttributeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(TypeMapAssociationAttribute<TypeMapEntryAssemblyGroup>))]
+
+	public class TypeMapEntryAssembly
+	{
+		public static void Main()
+		{
+			// Access the type map to ensure it gets used
+			var externalMap = TypeMapping.GetOrCreateExternalTypeMapping<TypeMapEntryAssemblyGroup>();
+			var proxyMap = TypeMapping.GetOrCreateProxyTypeMapping<TypeMapEntryAssemblyGroup>();
+
+			Console.WriteLine(externalMap);
+			Console.WriteLine(proxyMap);
+		}
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMapEntryAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMapEntryAssembly.cs
@@ -10,7 +10,11 @@ using Mono.Linker.Tests.Cases.Reflection.Dependencies;
 namespace Mono.Linker.Tests.Cases.Reflection
 {
 	[SetupCompileBefore("TypeMapEntryAssemblyLib.dll", new[] { "Dependencies/TypeMapEntryAssemblyLib.cs" })]
+#if NATIVEAOT
+	[SetupLinkerArgument("--runtimeknob", "System.Runtime.InteropServices.TypeMappingEntryAssembly", "TypeMapEntryAssemblyLib")]
+#else
 	[SetupLinkerArgument("--feature", "System.Runtime.InteropServices.TypeMappingEntryAssembly", "TypeMapEntryAssemblyLib")]
+#endif
 
 	// The TypeMapEntryAssemblyGroup is defined in TypeMapEntryAssemblyLib, so its attributes should be kept
 	[KeptTypeInAssembly("TypeMapEntryAssemblyLib.dll", typeof(TypeMapEntryAssemblyGroup))]


### PR DESCRIPTION
Implements the alternative to https://github.com/dotnet/runtime/issues/121138 mentioned in https://github.com/dotnet/runtime/issues/121138#issuecomment-3459953860

Enables the TypeMap to be used in Library output types. Projects can set the following RuntimeHostConfigurationOption to enable this behavior. If it exists, this option takes priority over the entrypoint assembly.

```
<ItemGroup>
    <RuntimeHostConfigurationOption Include="System.Runtime.InteropServices.TypeMappingEntryAssembly"
        Value="$(TypeMapEntryAssembly)"
        Condition="$(TypeMapEntryAssembly) != ''" />
</ItemGroup>
```