### PR TITLE
[Bounds checks] Merge inter-block assertions in RangeCheck::MergeAssertion

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1211,7 +1211,8 @@ void RangeCheck::MergeAssertion(BasicBlock* block, GenTree* op, Range* pRange DE
         // (ArrBnds assertions), so we limit the search to only those blocks that may have bounds
         // checks. It also helps reduce the cost of this search as it's not cheap.
         //
-        if (block->HasFlag(BBF_MAY_HAVE_BOUNDS_CHECKS))
+        if (m_pCompiler->GetAssertionCount() > BitVecOps::Count(m_pCompiler->apTraits, assertions) &&
+            block->HasFlag(BBF_MAY_HAVE_BOUNDS_CHECKS))
         {
             // We're going to be adding to 'assertions', so make a copy first.
             assertions = BitVecOps::MakeCopy(m_pCompiler->apTraits, assertions);

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1211,15 +1211,13 @@ void RangeCheck::MergeAssertion(BasicBlock* block, GenTree* op, Range* pRange DE
         // (ArrBnds assertions), so we limit the search to only those blocks that may have bounds
         // checks. It also helps reduce the cost of this search as it's not cheap.
         //
-        if (m_pCompiler->GetAssertionCount() > BitVecOps::Count(m_pCompiler->apTraits, assertions) &&
-            block->HasFlag(BBF_MAY_HAVE_BOUNDS_CHECKS))
+        if (block->HasFlag(BBF_MAY_HAVE_BOUNDS_CHECKS))
         {
             // We're going to be adding to 'assertions', so make a copy first.
             assertions = BitVecOps::MakeCopy(m_pCompiler->apTraits, assertions);
 
             // JIT-TP: Limit the search budget to avoid spending too much time here.
-            int budget = 50;
-
+            int budget = 32;
             for (Statement* stmt : block->Statements())
             {
                 AssertionsAccumulator visitor(m_pCompiler, &budget, &assertions, op);

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1211,8 +1211,7 @@ void RangeCheck::MergeAssertion(BasicBlock* block, GenTree* op, Range* pRange DE
         // (ArrBnds assertions), so we limit the search to only those blocks that may have bounds
         // checks. It also helps reduce the cost of this search as it's not cheap.
         //
-        // TODO-Review: EH successor/predecessor iteration seems broken.
-        if ((block->bbCatchTyp != BBCT_FAULT) && block->HasFlag(BBF_MAY_HAVE_BOUNDS_CHECKS))
+        if (block->HasFlag(BBF_MAY_HAVE_BOUNDS_CHECKS))
         {
             // We're going to be adding to 'assertions', so make a copy first.
             assertions = BitVecOps::MakeCopy(m_pCompiler->apTraits, assertions);


### PR DESCRIPTION
When RangeCheck inspects, say, "i + cns" tree, it tries to get the "assertion-based" range for `i` via its block's `bbAssertionIn`. It's too conservative and doesn't take into account assertions created before that `i` in the block (inter-block assertions). Let's see if we can cheaply just accumulate those by hands (@AndyAyersMS's idea).

A simplified version of the repro is the following (thanks @BoyBaykiller for the repro):
```cs
void Test(int[] arr, int i)
{
    arr[i] = 0;  // creates 'i >= 0 && i < arr.Length' assertion
    i++;         // same block as ^

    if (i < arr.Length)
        arr[i] = 0;
}
```
Codegen diff:
```diff
; Method Benchmarks:Test(int[],int):this (FullOpts)
G_M59621_IG01:
       sub      rsp, 40
G_M59621_IG02:
       mov      eax, dword ptr [rdx+0x08]
       cmp      r8d, eax
       jae      SHORT G_M59621_IG05
       mov      ecx, r8d
       xor      r10d, r10d
       mov      dword ptr [rdx+4*rcx+0x10], r10d
       inc      r8d
       cmp      eax, r8d
       jle      SHORT G_M59621_IG04
G_M59621_IG03:
-      cmp      r8d, eax
-      jae      SHORT G_M59621_IG05
       mov      eax, r8d
       xor      ecx, ecx
       mov      dword ptr [rdx+4*rax+0x10], ecx
G_M59621_IG04:
       add      rsp, 40
       ret      
G_M59621_IG05:
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
-; Total bytes of code: 56
+; Total bytes of code: 51
```