### PR TITLE
Fix native aot outerloop

### DIFF
--- a/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/Repro.cs
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/Repro.cs
@@ -15,7 +15,7 @@ namespace Tests
         public static int TestEntryPoint()
         {
             if ((TestManyFields() == 100)
-                && (TestManyFieldsPlusOne() == 100))
+                && (TestManyFieldsPlusTwo() == 100))
             {
                 return 100;
             }
@@ -36,11 +36,11 @@ namespace Tests
             return 100;
         }
 
-        public static int TestManyFieldsPlusOne()
+        public static int TestManyFieldsPlusTwo()
         {
             try
             {
-                TestLdManyFieldsPlusOne();
+                TestLdManyFieldsPlusTwo();
             }
             catch (TargetInvocationException)
             {
@@ -63,9 +63,9 @@ namespace Tests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        internal static void TestLdManyFieldsPlusOne()
+        internal static void TestLdManyFieldsPlusTwo()
         {
-            object o = Activator.CreateInstance(typeof(ManyFieldsPlusOne));
+            object o = Activator.CreateInstance(typeof(ManyFieldsPlusTwo));
         }
     }
 
@@ -65605,11 +65605,11 @@ namespace Tests
         public int m65532 = 65532;
         public int m65533 = 65533;
         public int m65534 = 65534;
-        public int m65535 = 65535;
     }
 
-    public class ManyFieldsPlusOne : ManyFields
+    public class ManyFieldsPlusTwo : ManyFields
     {
+        public int m65535 = 65535;
         public int m65536 = 65536;
     }
 }


### PR DESCRIPTION
Test merging in #121078 caused us to start compiling this test again. We were not compiling it because more than 64k fields hits CodeView limitations in LF_STRUCTURE/LF_CLASS (can't have more than 65534 _introduced fields_). We assert and crash compilation.

CoreCLR has it's own limitation of 65535 fields, including inherited, but not counting `object.m_pEEType` (that doesn't exist in CoreCLR CoreLib).

This changes the test to not have a class with > 65534 introduced fields. This avoids the CodeView assert. We still don't generate correct CodeView for bigger classes. Not sure if it's worth adding blocking. We could block loading such types but 65534 is an odd number and CodeView is an odd reason.

Cc @dotnet/ilc-contrib 