### PR TITLE
JIT: Reset last-use flag for live defs in liveness

### DIFF
--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -944,6 +944,8 @@ bool Compiler::fgComputeLifeTrackedLocalDef(VARSET_TP&           life,
     if (VarSetOps::IsMember(this, life, varIndex))
     {
         // The variable is live
+        node->gtFlags &= ~GTF_VAR_DEATH;
+
         if ((node->gtFlags & GTF_VAR_USEASG) == 0)
         {
             // Remove the variable from the live set if it is not in the keepalive set.


### PR DESCRIPTION
We would leave `GTF_VAR_DEATH` set if it had already been set on the node from a previous run of liveness.

In the issue that resulted in `TreeLifeUpdater` computing the wrong liveness set resulting in us not saving a live local around a suspension.

Fix #121552