### PR TITLE
Add missing `goto` for checking encapsulation invariants.

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/pal_evp_kem.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_evp_kem.c
@@ -187,6 +187,7 @@ int32_t CryptoNative_EvpKemEncapsulate(EVP_PKEY* pKey,
             sharedSecretLengthT != Int32ToSizeT(sharedSecretLength))
         {
             ret = -1;
+            goto done;
         }
 
         ret = 1;


### PR DESCRIPTION
When we encapsulate something with ML-KEM on OpenSSL, we were checking that the amount written is what we expected, but a missing `goto` caused it to be marked as a success.

This isn't really a reliability problem since we already know how much encapsulation sizes are, we're just making sure OpenSSL and the managed side agree on it.