### PR TITLE
Track async variants when generating generic dictionaries

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -652,7 +652,7 @@ namespace ILCompiler.DependencyAnalysis
                     //   - As a matter of policy, the type and its methods may be exported for use in another module. The policy
                     //     may wish to specify that if a type is to be placed into a shared module, all of the methods associated with
                     //     it should be also be exported.
-                    foreach (var method in _type.GetClosestDefType().ConvertToCanonForm(CanonicalFormKind.Specific).GetAllMethods())
+                    foreach (var method in _type.GetClosestDefType().ConvertToCanonForm(CanonicalFormKind.Specific).GetAllMethodsAndAsyncVariants())
                     {
                         if (!MethodHasNonGenericILMethodBody(method))
                             continue;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericDictionaryNode.cs
@@ -149,7 +149,7 @@ namespace ILCompiler.DependencyAnalysis
             // The generic dictionary layout is shared between all the canonically equivalent
             // instantiations. We need to track the dependencies of all canonical method bodies
             // that use the same dictionary layout.
-            foreach (var method in _owningType.GetAllMethods())
+            foreach (var method in _owningType.GetAllMethodsAndAsyncVariants())
             {
                 if (!EETypeNode.MethodHasNonGenericILMethodBody(method))
                     continue;


### PR DESCRIPTION
In `GenericDictionaryNode` we have a piece of code that ensures whenever a canonical method body of a method on a type depends on something and we have a concrete instance of such type, the specialized thing is also created.

For example, `class Foo<T> { Type GrabType() => typeof(List<T>); }`: when we compile `Foo<__Canon>.GrabType` we find out we need `List<T>`. Elsewhere we find out we need `Foo<object>`. The code in GenericDictionaryNode that I'm modifying ensures we also generate `List<object>`.

We do this by walking all methods on the type and generating special `ShadowConcrete` dependencies for any canonical bodies of the methods on the type. We were missing async variants from this reporting.

The change in EETypeNode is related, but only affects multifile compilation that we don't care much about. I'm fixing it because it has the same problem.

Cc @dotnet/ilc-contrib 