### PR TITLE
Fix up reflection with runtime async

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/MetadataManager.cs
@@ -396,6 +396,13 @@ namespace ILCompiler
             if (method.IsStaticConstructor)
                 return false;
 
+            // Non-task returning async methods have special calling convention
+            if (method.IsAsync && !method.GetTypicalMethodDefinition().Signature.ReturnsTaskOrValueTask())
+                return false;
+
+            // And so do async variants but we shouldn't even see them here
+            Debug.Assert(!method.IsAsyncVariant());
+
             if (method.IsConstructor)
             {
                 // Delegate construction is only allowed through specific IL sequences

--- a/src/tests/async/reflection/reflection-simple.cs
+++ b/src/tests/async/reflection/reflection-simple.cs
@@ -27,7 +27,11 @@ public class Async2Reflection
     {
         var mi = typeof(System.Runtime.CompilerServices.AsyncHelpers).GetMethod("Await", BindingFlags.Static | BindingFlags.Public, new Type[] { typeof(Task) })!;
         Assert.NotNull(mi);
-        Assert.Throws<TargetInvocationException>(() => mi.Invoke(null, new object[] { FooTask() }));
+
+        if (TestLibrary.Utilities.IsNativeAot)
+            Assert.Throws<NotSupportedException>(() => mi.Invoke(null, new object[] { FooTask() }));
+        else
+            Assert.Throws<TargetInvocationException>(() => mi.Invoke(null, new object[] { FooTask() }));
 
         // Sadly the following does not throw and results in UB
         // We cannot completely prevent putting a token of an Async method into IL stream.
@@ -128,7 +132,7 @@ public class Async2Reflection
             $"{map.InterfaceMethods[1]?.ToString()} --> {map.TargetMethods[1]?.ToString()}");
     }
 
-    [Fact]
+    [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsReflectionEmitSupported))]
     public static void TypeBuilder_DefineMethod()
     {
         //  we will be compiling a dynamic vesion of this method

--- a/src/tests/async/reflection/reflection-simple.csproj
+++ b/src/tests/async/reflection/reflection-simple.csproj
@@ -5,4 +5,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
The reflection-simple test passes with this fix (when I remove `<Optimize>True</Optimize>`). The general reflection just falls out naturally. The only thing needed fixing was blocking direct invocation of `AsyncExplicitImpl` methods.

We just block this when generating reflection mapping tables. We could also block this within the runtime reflection stack so that we can match the exception type, but given this is only reachable for CoreLib privates, it's really not worth the extra code.

Cc @dotnet/ilc-contrib 