### PR TITLE
Map `CORINFO_HELP_THROWEXACT` to `THROW`

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -466,6 +466,7 @@ namespace Internal.JitInterface
             switch (ftnNum)
             {
                 case CorInfoHelpFunc.CORINFO_HELP_THROW:
+                case CorInfoHelpFunc.CORINFO_HELP_THROWEXACT: // TODO: (async): THROWEXACT
                     id = ReadyToRunHelper.Throw;
                     break;
                 case CorInfoHelpFunc.CORINFO_HELP_RETHROW:


### PR DESCRIPTION
This is temporary. It will not do the right thing wrt exception stack at runtime, but it's better than crashing at compile time (which is what it does now).

Not filing a bug on this; we either fix this before we start running the tests or hit it during test async bringup (I assume there's a test) and then ActiveIssue it as needed.

Cc @dotnet/ilc-contrib 