### PR TITLE
[mono][interp] Add max limit to the imported IL when inlining

### DIFF
--- a/src/mono/mono/mini/interp/transform.c
+++ b/src/mono/mono/mini/interp/transform.c
@@ -2990,6 +2990,8 @@ interp_get_icall_sig (MonoMethodSignature *sig)
 /* larger than mono jit; chosen to ensure that List<T>.get_Item can be inlined */
 #define INLINE_LENGTH_LIMIT 30
 #define INLINE_DEPTH_LIMIT 10
+// How much imported IL we allow before we stop inlining
+#define INLINE_IL_BUDGET 1000000
 
 static gboolean
 is_metadata_update_disabled (void)
@@ -3007,6 +3009,9 @@ interp_method_check_inlining (TransformData *td, MonoMethod *method, MonoMethodS
 	MonoMethodHeaderSummary header;
 
 	if (td->disable_inlining)
+		return FALSE;
+
+	if (td->total_il_size > INLINE_IL_BUDGET)
 		return FALSE;
 
 	// Exception handlers are always uncommon, with the exception of finally.
@@ -3090,6 +3095,7 @@ interp_inline_method (TransformData *td, MonoMethod *target_method, MonoMethodHe
 	int *prev_in_offsets;
 	gboolean ret;
 	unsigned int prev_max_stack_height, prev_locals_size;
+	unsigned int prev_total_il_size;
 	int prev_n_data_items;
 	int i;
 	int prev_sp_offset;
@@ -3129,6 +3135,7 @@ interp_inline_method (TransformData *td, MonoMethod *target_method, MonoMethodHe
 	prev_aggressive_inlining = td->aggressive_inlining;
 	prev_imethod_items = td->imethod_items;
 	prev_has_inlined_one_call = td->has_inlined_one_call;
+	prev_total_il_size = td->total_il_size;
 	td->has_inlined_one_call = FALSE;
 	td->inlined_method = target_method;
 
@@ -3165,6 +3172,7 @@ interp_inline_method (TransformData *td, MonoMethod *target_method, MonoMethodHe
 			g_print ("Inline aborted method %s.%s\n", m_class_get_name (target_method->klass), target_method->name);
 		td->max_stack_height = prev_max_stack_height;
 		td->vars_size = prev_locals_size;
+		td->total_il_size = prev_total_il_size;
 
 		/* Remove any newly added items */
 		for (i = prev_n_data_items; i < td->n_data_items; i++) {
@@ -5352,6 +5360,8 @@ generate_code (TransformData *td, MonoMethod *method, MonoMethodHeader *header, 
 	td->il_code = header->code;
 	td->in_start = td->ip = header->code;
 	end = td->ip + header->code_size;
+
+	td->total_il_size += header->code_size;
 
 	td->cbb = td->entry_bb = interp_alloc_bb (td);
 	td->entry_bb->emit_state = BB_STATE_EMITTING;

--- a/src/mono/mono/mini/interp/transform.h
+++ b/src/mono/mono/mini/interp/transform.h
@@ -340,6 +340,7 @@ typedef struct
 	GPtrArray *relocs;
 	gboolean verbose_level;
 	GArray *line_numbers;
+	int total_il_size;
 	gboolean prof_coverage;
 	MonoProfilerCoverageInfo *coverage_info;
 	GList *dont_inline;


### PR DESCRIPTION
While we have some simple heuristics on whether we should inline a method or not, we have no limit on how many methods we can inline. So, if a method has 1000 callsites to methods that are inlineable, we will inline each one of them, significantly bloating the code. This is made worse by more advanced SSA optimizations, because the compilation time becomes very slow and uses a lot of memory.

The limit is set as a simple upper limit on the total amount of IL code being imported as part of method compilation. This is set to a generous initial value of 1MB, since local testing showed that it is still handled decently well. The largest value obtained from running System.Runtime libtests suite is 100K. A customer provided sample was hitting 8MB of imported code, which was causing GBs of mem usage and several seconds to compile the method. In the end, all this code was discarded anyway, since it was exceeding interpreter offset limits, and we had to retry compilation with inlining disabled.