### PR TITLE
JIT: Fix assertion in fgGetFirstILBlock for async methods with internal conditional blocks

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13699,9 +13699,14 @@ PhaseStatus Compiler::fgMorphBlocks()
         {
             genReturnBB->SetFlags(BBF_CAN_ADD_PRED);
         }
-        // TODO-Cleanup: Remove this by transforming tailcalls to loops earlier.
-        BasicBlock* firstILBB = opts.IsOSR() ? fgEntryBB : fgGetFirstILBlock();
-        firstILBB->SetFlags(BBF_CAN_ADD_PRED);
+
+        BasicBlock* firstILBB = nullptr;
+        if (doesMethodHaveRecursiveTailcall())
+        {
+            // TODO-Cleanup: Remove this by transforming tailcalls to loops earlier.
+            firstILBB = opts.IsOSR() ? fgEntryBB : fgGetFirstILBlock();
+            firstILBB->SetFlags(BBF_CAN_ADD_PRED);
+        }
 
         // Remember this so we can sanity check that no new blocks will get created.
         //
@@ -13726,7 +13731,10 @@ PhaseStatus Compiler::fgMorphBlocks()
         {
             genReturnBB->RemoveFlags(BBF_CAN_ADD_PRED);
         }
-        firstILBB->RemoveFlags(BBF_CAN_ADD_PRED);
+        if (firstILBB != nullptr)
+        {
+            firstILBB->RemoveFlags(BBF_CAN_ADD_PRED);
+        }
     }
 
     // Under OSR, we no longer need to specially protect the original method entry


### PR DESCRIPTION
The fgGetFirstILBlock() function was being called unconditionally during morph to allow edge creation for tail-call-to-loop optimization. However, this function assumes all BBF_INTERNAL blocks before the first IL block are BBJ_ALWAYS, which is not true for async methods with exception save/restore context where internal blocks can be conditional (because of introducing and inlining a call to save contexts).

Fix by only calling fgGetFirstILBlock() when the method actually has recursive tail calls that need to be converted to loops, checked via doesMethodHaveRecursiveTailcall().