### PR TITLE
Fix collided unwind detection

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -4102,7 +4102,7 @@ CLR_BOOL SfiNextWorker(StackFrameIterator* pThis, uint* uExCollideClauseIdx, CLR
             goto Exit;
         }
 
-        if (doingFuncletUnwind && pThis->GetNextExInfo() != NULL && GetRegdisplaySP(pThis->m_crawl.GetRegisterSet()) > (TADDR)pTopExInfo)
+        if (doingFuncletUnwind && pThis->GetNextExInfo() != NULL && pThis->GetFrameState() != StackFrameIterator::SFITER_FRAMELESS_METHOD)
         {
             // Detected collided unwind
             if ((pThis->GetNextExInfo()->m_passNumber == 1) ||

--- a/src/tests/Regressions/coreclr/GitHub_121578/test121578.cs
+++ b/src/tests/Regressions/coreclr/GitHub_121578/test121578.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Test121578
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        try
+        {
+            bool internalFinally, externalFinally, internalCatch;
+
+            try
+            {
+                throw new Exception("foo");
+            }
+            catch (Exception)
+            {
+                try
+                {
+                    try
+                    {
+                    }
+                    finally
+                    {
+                        // Throw in non-exceptionally called finally
+                        throw new Exception();
+                    }
+                }
+                catch(Exception)
+                {
+                    // Swallow
+                }
+                finally
+                {
+                    internalFinally = true;
+                }
+            }
+            finally
+            {
+                externalFinally = true;
+            }
+
+            Assert.True(internalFinally);
+            Assert.True(externalFinally);
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail("The exceptioon should have been handled. Exception: " + ex.ToString());
+        }
+    }
+}

--- a/src/tests/Regressions/coreclr/GitHub_121578/test121578.cs
+++ b/src/tests/Regressions/coreclr/GitHub_121578/test121578.cs
@@ -49,7 +49,7 @@ public class Test121578
         }
         catch (Exception ex)
         {
-            Assert.Fail("The exceptioon should have been handled. Exception: " + ex.ToString());
+            Assert.Fail("The exception should have been handled. Exception: " + ex.ToString());
         }
     }
 }

--- a/src/tests/Regressions/coreclr/GitHub_121578/test121578.csproj
+++ b/src/tests/Regressions/coreclr/GitHub_121578/test121578.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="test121578.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
A recent fix that has moved 2nd pass of the exception handling to native
code has accidentally broken detectin of collided unwind, that means
detection of when exception escapes a catch or exceptionally called finally
funclets. Unfortunately none of our coreclr and libraries test exercise
the specific case when the problem occurs, which is as follows:
* There is a try / catch inside of an outer catch
* The try block contains try / finally and the non-exceptionally called
  finally throws.
In this case, the stack walk out of the throwing finally funclet was
incorrectly classifed as an exception collision and the catch was
skipped.

The problem was that the last part of the condition to detect the collided
unwind was wrong. In fact, it was always true, so any unwind out of a
funclet was considered to be a collision even if the funclet was a
finally that was called non-exceptionally.

This change fixes it by identifying the collision by the fact that the
stack walker has moved from a funclet to native code, which is the only
case when the exception is really escaping an exceptionally called
funclet.

I have also added a regression test for the issue.

Close https://github.com/dotnet/runtime/issues/121578