### PR TITLE
Add runtime async support to reflection dataflow analysis

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/AsyncMaskingILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/AsyncMaskingILProvider.cs
@@ -1,0 +1,82 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+using Internal.IL;
+using Internal.TypeSystem;
+
+using Debug = System.Diagnostics.Debug;
+
+namespace ILCompiler.Dataflow
+{
+    /// <summary>
+    /// Removes the concept of async variants from <see cref="MethodIL"/> by reporting
+    /// <see cref="MethodILScope.OwningMethod"/> how it's generated in the metadata.
+    /// Dataflow infrastructure doesn't expect async variant method signatures.
+    /// </summary>
+    internal sealed class AsyncMaskingILProvider : ILProvider
+    {
+        private readonly ILProvider _wrappedProvider;
+
+        public AsyncMaskingILProvider(ILProvider wrappedProvider)
+        {
+            Debug.Assert(wrappedProvider is not AsyncMaskingILProvider);
+            _wrappedProvider = wrappedProvider;
+        }
+
+        public override MethodIL GetMethodIL(MethodDesc method)
+        {
+            Debug.Assert(!method.IsAsyncVariant());
+
+            MethodDesc methodForIL;
+            if (method.IsAsync && method.GetTypicalMethodDefinition().Signature.ReturnsTaskOrValueTask())
+                methodForIL = ((CompilerTypeSystemContext)method.Context).GetAsyncVariantMethod(method);
+            else
+                methodForIL = method;
+
+            MethodIL methodIL = _wrappedProvider.GetMethodIL(methodForIL);
+
+            return methodForIL == method ? methodIL : new AsyncMaskedMethodIL(method, methodIL);
+        }
+
+        public static MethodIL WrapIL(MethodIL methodIL)
+        {
+            MethodDesc owningMethod = methodIL.OwningMethod;
+            if (owningMethod.IsAsyncVariant())
+            {
+                Debug.Assert(owningMethod.IsAsync);
+                return new AsyncMaskedMethodIL(((CompilerTypeSystemContext)owningMethod.Context).GetTargetOfAsyncVariantMethod(owningMethod), methodIL);
+            }
+
+            return methodIL;
+        }
+
+        private sealed class AsyncMaskedMethodIL : MethodIL
+        {
+            private readonly MethodDesc _owner;
+            private readonly MethodIL _wrappedIL;
+
+            public AsyncMaskedMethodIL(MethodDesc owner, MethodIL wrappedIL)
+                => (_owner, _wrappedIL) = (owner, wrappedIL);
+
+            // Change the owner
+            public override MethodDesc OwningMethod => _owner;
+
+            // Everything else dispatches to the wrapper MethodIL
+            public override MethodDebugInformation GetDebugInfo() => _wrappedIL.GetDebugInfo();
+            public override ILExceptionRegion[] GetExceptionRegions() => _wrappedIL.GetExceptionRegions();
+            public override byte[] GetILBytes() => _wrappedIL.GetILBytes();
+            public override LocalVariableDefinition[] GetLocals() => _wrappedIL.GetLocals();
+            public override object GetObject(int token, NotFoundBehavior notFoundBehavior = NotFoundBehavior.Throw) => _wrappedIL.GetObject(token, notFoundBehavior);
+            public override bool IsInitLocals => _wrappedIL.IsInitLocals;
+            public override int MaxStack => _wrappedIL.MaxStack;
+
+            public override MethodIL GetMethodILDefinition()
+            {
+                Debug.Assert(_wrappedIL.GetMethodILDefinition() == _wrappedIL);
+                return this;
+            }
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
@@ -35,7 +35,7 @@ namespace ILCompiler.Dataflow
 
         public CompilerGeneratedState(ILProvider ilProvider, Logger logger, bool disableGeneratedCodeHeuristics)
         {
-            _typeCacheHashtable = new TypeCacheHashtable(ilProvider);
+            _typeCacheHashtable = new TypeCacheHashtable(new AsyncMaskingILProvider(ilProvider));
             _logger = logger;
             _disableGeneratedCodeHeuristics = disableGeneratedCodeHeuristics;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
@@ -298,7 +298,8 @@ namespace ILLink.Shared.TrimAnalysis
             private readonly Logger _logger;
             private readonly CompilerGeneratedState _compilerGeneratedState;
 
-            public TypeAnnotationsHashtable(Logger logger, ILProvider ilProvider, CompilerGeneratedState compilerGeneratedState) => (_logger, _ilProvider, _compilerGeneratedState) = (logger, ilProvider, compilerGeneratedState);
+            public TypeAnnotationsHashtable(Logger logger, ILProvider ilProvider, CompilerGeneratedState compilerGeneratedState) =>
+                (_logger, _ilProvider, _compilerGeneratedState) = (logger, new AsyncMaskingILProvider(ilProvider), compilerGeneratedState);
 
             private static DynamicallyAccessedMemberTypes GetMemberTypesForDynamicallyAccessedMembersAttribute(MetadataReader reader, CustomAttributeHandleCollection customAttributeHandles)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
@@ -55,7 +55,7 @@ namespace ILCompiler.Dataflow
         protected MethodBodyScanner(FlowAnnotations annotations)
         {
             _annotations = annotations;
-            InterproceduralStateLattice = new InterproceduralStateLattice(annotations.ILProvider, default, default);
+            InterproceduralStateLattice = new InterproceduralStateLattice(new AsyncMaskingILProvider(annotations.ILProvider), default, default);
         }
 
         protected virtual void WarnAboutInvalidILInMethod(MethodIL method, int ilOffset)
@@ -793,12 +793,15 @@ namespace ILCompiler.Dataflow
 
                     case ILOpcode.ret:
                         {
-                            bool hasReturnValue = !methodIL.OwningMethod.Signature.ReturnType.IsVoid;
-                            if (currentStack.Count != (hasReturnValue ? 1 : 0))
+                            if (!methodIL.OwningMethod.IsAsync)
                             {
-                                WarnAboutInvalidILInMethod(methodIL, offset);
+                                bool ilHasReturnValue = !methodIL.OwningMethod.Signature.ReturnType.IsVoid;
+                                if (currentStack.Count != (ilHasReturnValue ? 1 : 0))
+                                {
+                                    WarnAboutInvalidILInMethod(methodIL, offset);
+                                }
                             }
-                            if (hasReturnValue)
+                            if (currentStack.Count == 1)
                             {
                                 StackSlot retStackSlot = PopUnknown(currentStack, 1, methodIL, offset);
                                 // If the return value is a reference, treat it as the value itself for now

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ReflectionMethodBodyScanner.cs
@@ -126,6 +126,8 @@ namespace ILCompiler.Dataflow
 
         public static DependencyList ScanAndProcessReturnValue(NodeFactory factory, FlowAnnotations annotations, Logger logger, MethodIL methodIL, out List<INodeWithRuntimeDeterminedDependencies> runtimeDependencies)
         {
+            methodIL = AsyncMaskingILProvider.WrapIL(methodIL);
+
             var scanner = new ReflectionMethodBodyScanner(factory, annotations, logger, new MessageOrigin(methodIL.OwningMethod));
 
             scanner.InterproceduralScan(methodIL);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/ILCompiler.Compiler.csproj
@@ -401,6 +401,7 @@
     <Compile Include="Compiler\CompilerGeneratedInteropStubManager.cs" />
     <Compile Include="Compiler\CustomAttributeExtensions.cs" />
     <Compile Include="Compiler\Dataflow\ArrayValue.cs" />
+    <Compile Include="Compiler\Dataflow\AsyncMaskingILProvider.cs" />
     <Compile Include="Compiler\Dataflow\AttributeDataFlow.cs" />
     <Compile Include="Compiler\Dataflow\CompilerGeneratedCallGraph.cs" />
     <Compile Include="Compiler\Dataflow\CompilerGeneratedState.cs" />

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TestCaseCompiler.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TestCaseCompiler.cs
@@ -267,6 +267,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
             // Default debug info format for the current platform.
             DebugInformationFormat debugType = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? DebugInformationFormat.Pdb : DebugInformationFormat.PortablePdb;
             bool emitPdb = false;
+            Dictionary<string, string> features = [];
             if (options.AdditionalArguments != null)
             {
                 foreach (var option in options.AdditionalArguments)
@@ -306,11 +307,27 @@ namespace Mono.Linker.Tests.TestCasesRunner
                                 compilationOptions = compilationOptions.WithMainTypeName(mainTypeName);
                                 break;
                             }
+                            else if (splitIndex != -1 && option[..splitIndex] == "/features")
+                            {
+                                var feature = option[(splitIndex + 1)..];
+                                var featureSplit = feature.IndexOf('=');
+                                if (featureSplit == -1)
+                                    throw new InvalidOperationException($"Argument is malformed: '{option}'");
+                                features.Add(feature[..featureSplit], feature[(featureSplit + 1)..]);
+                                break;
+                            }
+                            else if (splitIndex != -1 && option[..splitIndex] == "/nowarn")
+                            {
+                                var nowarn = option[(splitIndex + 1)..];
+                                var withNoWarn = compilationOptions.SpecificDiagnosticOptions.SetItem(nowarn, ReportDiagnostic.Suppress);
+                                compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(withNoWarn);
+                                break;
+                            }
                             throw new NotImplementedException(option);
                     }
                 }
             }
-            var parseOptions = new CSharpParseOptions(preprocessorSymbols: options.Defines, languageVersion: languageVersion);
+            var parseOptions = new CSharpParseOptions(preprocessorSymbols: options.Defines, languageVersion: languageVersion).WithFeatures(features);
             var emitOptions = new EmitOptions(debugInformationFormat: debugType);
             var pdbPath = (!emitPdb || debugType == DebugInformationFormat.Embedded) ? null : options.OutputPath.ChangeExtension(".pdb").ToString();
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/RuntimeAsyncMethods.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/RuntimeAsyncMethods.cs
@@ -12,7 +12,6 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.DataFlow
 {
     [SkipKeptItemsValidation]
-    [IgnoreTestCase("NativeAOT doesn't support runtime async yet", IgnoredBy = Tool.NativeAot)]
     [SetupCompileArgument("/features:runtime-async=on")]
     [SetupCompileArgument("/nowarn:SYSLIB5007")]
     public class RuntimeAsyncMethods


### PR DESCRIPTION
This is a port of #120683, with an extra.

The `MethodIL` that we deal with in the compiler does async variant method signature munging. The dataflow analysis really doesn't like that. So munge the method signatures back to how they look in metadata and in Cecil on dataflow analysis boundaries. I don't like having to do this, but this is a shared codebase and fewer differences is better.

Cc @dotnet/ilc-contrib 