### PR TITLE
Remove bounds checks for Phi indices

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5437,8 +5437,7 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
             {
                 return dropBoundsCheck(INDEBUG("a[*] followed by a[0]"));
             }
-            // Do we have two constant indexes?
-            else if (vnStore->IsVNConstant(vnCurIdx))
+            else
             {
                 // index1 doesn't have to be a constant, it can be a Phi each predecessor of which is a constant.
                 // The smallest of those is what we can rely on. Example:

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5453,7 +5453,7 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
                 auto tryGetMaxOrMinConst = [this](ValueNum vn, bool getMin, int* index) -> bool {
                     *index = getMin ? INT_MAX : INT_MIN;
                     return vnStore->VNVisitReachingVNs(vn,
-                                                       [this, &index, &getMin](ValueNum vn) -> ValueNumStore::VNVisit {
+                                                       [this, index, getMin](ValueNum vn) -> ValueNumStore::VNVisit {
                         int cns = 0;
                         if (vnStore->IsVNIntegralConstant(vn, &cns))
                         {

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5438,20 +5438,38 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
                 return dropBoundsCheck(INDEBUG("a[*] followed by a[0]"));
             }
             // Do we have two constant indexes?
-            else if (vnStore->IsVNConstant(curAssertion->op1.bnd.vnIdx) && vnStore->IsVNConstant(vnCurIdx))
+            else if (vnStore->IsVNConstant(vnCurIdx))
             {
-                // Make sure the types match.
-                var_types type1 = vnStore->TypeOfVN(curAssertion->op1.bnd.vnIdx);
-                var_types type2 = vnStore->TypeOfVN(vnCurIdx);
+                // index1 doesn't have to be a constant, it can be a Phi each predecessor of which is a constant.
+                // The smallest of those is what we can rely on. Example:
+                //
+                //  arr[cond ? 10 : 5] = 0;  // arr is at least 6 elements long
+                //  arr[2] = 0;              // arr must be at least 3 elements long
+                //
+                // or even:
+                //
+                //  arr[cond ? 10 : 5] = 0; // arr is at least 6 elements long
+                //  arr[cond ? 1 : 2] = 0;  // arr must be at least 3 elements long
+                //
+                auto tryGetMaxOrMinConst = [this](ValueNum vn, bool getMin, int* index) -> bool {
+                    *index = INT_MAX;
+                    return vnStore->VNVisitReachingVNs(vn,
+                                                       [this, &index, &getMin](ValueNum vn) -> ValueNumStore::VNVisit {
+                        int cns = 0;
+                        if (vnStore->IsVNIntegralConstant(vn, &cns))
+                        {
+                            *index = getMin ? max(*index, cns) : min(*index, cns);
+                            return ValueNumStore::VNVisit::Continue;
+                        }
+                        return ValueNumStore::VNVisit::Abort;
+                    }) == ValueNumStore::VNVisit::Continue;
+                };
 
-                if (type1 == type2 && type1 == TYP_INT)
+                int index1;
+                int index2;
+                if (tryGetMaxOrMinConst(curAssertion->op1.bnd.vnIdx, /*min*/ true, &index1) &&
+                    tryGetMaxOrMinConst(vnCurIdx, /*max*/ false, &index2))
                 {
-                    int index1 = vnStore->ConstantValue<int>(curAssertion->op1.bnd.vnIdx);
-                    int index2 = vnStore->ConstantValue<int>(vnCurIdx);
-
-                    // the case where index1 == index2 should have been handled above
-                    assert(index1 != index2);
-
                     // It can always be considered as redundant with any previous higher constant value
                     //       a[K1] followed by a[K2], with K2 >= 0 and K1 >= K2
                     if (index2 >= 0 && index1 >= index2)

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5451,13 +5451,13 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
                 //  arr[cond ? 1 : 2] = 0;  // arr must be at least 3 elements long
                 //
                 auto tryGetMaxOrMinConst = [this](ValueNum vn, bool getMin, int* index) -> bool {
-                    *index = INT_MAX;
+                    *index = getMin ? INT_MAX : INT_MIN;
                     return vnStore->VNVisitReachingVNs(vn,
                                                        [this, &index, &getMin](ValueNum vn) -> ValueNumStore::VNVisit {
                         int cns = 0;
                         if (vnStore->IsVNIntegralConstant(vn, &cns))
                         {
-                            *index = getMin ? max(*index, cns) : min(*index, cns);
+                            *index = getMin ? min(*index, cns) : max(*index, cns);
                             return ValueNumStore::VNVisit::Continue;
                         }
                         return ValueNumStore::VNVisit::Abort;


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/121617

In global assertion prop we have an optimization that tries to optimize bound checks for `arr[cns]` if we already have ArrBnds assertion for the same array with another constant index that is greater than this one, e.g.:
```
arr[2] = 0; // creates an assertion that arr is at least 3 elements.
arr[1] = 0; // bound check is optimized away
```
This PR extends this logic by handling Phi indices.

Should remove bounds checks for cases like:
```cs
arr[cond1 ? 10 : 12] = 0; // means arr has at least 11 elements
arr[8] = 0; // redundant bounds check
```
or even:
```cs
arr[cond1 ? 10 : 12] = 0;
arr[cond2 ? 1 : 2] = 0;
```

Some nice [diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1203834&view=ms.vss-build-web.run-extensions-tab) (although, mostly because I removed unnecessary TypeOfVN checks)