### PR TITLE
Remove unsafe code in CreateUriInfo and fix edge-case IndexOutOfRangeExceptions

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -2341,8 +2341,8 @@ namespace System
             }
 
             // UnknownHostType / DosPath can't have a port.
-            if (((cF & Flags.HostTypeMask) != Flags.UnknownHostType && (cF & Flags.DosPath) == 0) &&
-                (uint)idx < (uint)str.Length && str[idx] == ':' && (cF & Flags.DosPath) == 0)
+            if ((cF & Flags.HostTypeMask) != Flags.UnknownHostType && (cF & Flags.DosPath) == 0 &&
+                (uint)idx < (uint)str.Length && str[idx] == ':')
             {
                 Debug.Assert(!IsUnc);
 

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -124,7 +124,7 @@ namespace System
                         e = null;
                     // will return from here
 
-                    if (hasUnicode)
+                    if (e is null && hasUnicode)
                     {
                         // In this scenario we need to parse the whole string
                         try
@@ -134,7 +134,6 @@ namespace System
                         catch (UriFormatException ex)
                         {
                             e = ex;
-                            return;
                         }
                     }
                 }
@@ -175,7 +174,7 @@ namespace System
                             e = GetException(ParsingError.CannotCreateRelative);
                         }
 
-                        if (hasUnicode)
+                        if (e is null && hasUnicode)
                         {
                             // In this scenario we need to parse the whole string
                             try
@@ -185,7 +184,6 @@ namespace System
                             catch (UriFormatException ex)
                             {
                                 e = ex;
-                                return;
                             }
                         }
                     }

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UncTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UncTest.cs
@@ -136,5 +136,18 @@ namespace System.PrivateUri.Tests
             Assert.True(uri.IsUnc);
             Assert.Equal("file://host/share", uri.AbsoluteUri);
         }
+
+        [Theory]
+        [InlineData("/\\\u200E//")]
+        [InlineData("\\\\/\u200e")]
+        [InlineData("\\\\\\\\\\\u200E")]
+        [InlineData("\\\\\\\\\\\u200E/")]
+        [InlineData("\\\\\\\\\\\u200E/ab")]
+        public static void UncWithWithBidiControlCharacters_CanBeParsed(string uriString)
+        {
+            Uri uri = new Uri(uriString, UriKind.Absolute);
+            Assert.True(uri.IsUnc);
+            Assert.Empty(uri.Host);
+        }
     }
 }

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UncTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UncTest.cs
@@ -143,7 +143,7 @@ namespace System.PrivateUri.Tests
         [InlineData("\\\\\\\\\\\u200E")]
         [InlineData("\\\\\\\\\\\u200E/")]
         [InlineData("\\\\\\\\\\\u200E/ab")]
-        public static void UncWithWithBidiControlCharacters_CanBeParsed(string uriString)
+        public static void UncWithBidiControlCharacters_CanBeParsed(string uriString)
         {
             Uri uri = new Uri(uriString, UriKind.Absolute);
             Assert.True(uri.IsUnc);


### PR DESCRIPTION
Fixes #1487

Uri parsing happens in stages:
- `PrivateParseMinimal` - The ctor will only do minimal validation to see whether it should throw
- `CreateUriInfo` - Accessing properties will allocate `UriInfo` and populate some offsets of various Uri components (scheme, userinfo, host, port). This is enough to access the `Host`.
- `ParseRemaining` - Accessing properties like `PathAndQuery` will populate the rest of the offsets and check whether the input is in the canonical form (whether we'll have to do some text changes for the properties).

If the input contains non-ASCII, we'll also rebuild the string representation and do all parts as part of the ctor. While recreating the string, we're dealing with two separate offsets (into the original and into the (partial) new string).
The issue with #1487 was that we were indexing into the new string instead of the original inside `CreateUriInfo`, which broke implicit files where the host got reduced in length (by removing bidi chars).

This PR fixes that, and also removes the use of unsafe code in that method.

No real perf impact - https://github.com/MihuBot/runtime-utils/issues/1635, https://github.com/MihuBot/runtime-utils/issues/1636

As alaways, easier to review without space changes.