### PR TITLE
Use `Dictionary.TryAdd` instead of `ContainsKey` and indexer by reducing lookups.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Attribute.CoreCLR.cs
@@ -372,8 +372,7 @@ namespace System
 
                 Type attrType = attributes[i].GetType();
 
-                if (!types.ContainsKey(attrType))
-                    types[attrType] = InternalGetAttributeUsage(attrType);
+                types.TryAdd(attrType, InternalGetAttributeUsage(attrType));
             }
         }
 


### PR DESCRIPTION
This PR refactors Attribute.CopyToAttributeList to use Dictionary.TryAdd instead of ContainsKey and indexer by reducing lookups.