### PR TITLE
Disable TLS optimization for musl riscv64

### DIFF
--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -9,7 +9,7 @@ LEAF_ENTRY GetCurrentIP, _TEXT
     ret
 LEAF_END GetCurrentIP, _TEXT
 
-//  void* GetCurrentSP(void)//
+// void* GetCurrentSP(void)//
 LEAF_ENTRY GetCurrentSP, _TEXT
     addi  a0, sp, 0
     ret

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -9,7 +9,7 @@ LEAF_ENTRY GetCurrentIP, _TEXT
     ret
 LEAF_END GetCurrentIP, _TEXT
 
-// LPVOID __stdcall GetCurrentSP(void)//
+//  void* GetCurrentSP(void)//
 LEAF_ENTRY GetCurrentSP, _TEXT
     addi  a0, sp, 0
     ret

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -9,7 +9,7 @@ LEAF_ENTRY GetCurrentIP, _TEXT
     ret
 LEAF_END GetCurrentIP, _TEXT
 
-// void* GetCurrentSP(void)//
+// LPVOID __stdcall GetCurrentSP(void)//
 LEAF_ENTRY GetCurrentSP, _TEXT
     addi  a0, sp, 0
     ret
@@ -848,10 +848,14 @@ LEAF_END JIT_PatchpointForced, _TEXT
 // size_t GetThreadStaticsVariableOffset()
 
 // Load offset of native thread local variable `t_ThreadStatics` in TCB and return it in `a0` register.
+#if !defined(TARGET_LINUX_MUSL)
+// Uses initial-exec TLS model which is faster but incompatible with musl's dynamic loading.
+// On musl, this function is not compiled and the optimization is disabled in threadstatics.cpp.
 LEAF_ENTRY GetThreadStaticsVariableOffset, _TEXT
     la.tls.ie   a0, t_ThreadStatics
     EPILOG_RETURN
 LEAF_END GetThreadStaticsVariableOffset, _TEXT
+#endif // !TARGET_LINUX_MUSL
 
 LEAF_ENTRY JIT_PollGC, _TEXT
         PREPARE_EXTERNAL_VAR g_TrapReturningThreads, t0

--- a/src/coreclr/vm/threadstatics.cpp
+++ b/src/coreclr/vm/threadstatics.cpp
@@ -917,6 +917,8 @@ bool CanJITOptimizeTLSAccess()
     // Optimization is disabled for linux/x86
 #elif defined(TARGET_LINUX_MUSL) && defined(TARGET_ARM64)
     // Optimization is disabled for linux musl arm64
+#elif defined(TARGET_LINUX_MUSL) && defined(TARGET_RISCV64)
+    // Optimization is disabled for linux musl riscv64
 #elif defined(TARGET_FREEBSD) && defined(TARGET_ARM64)
     // Optimization is disabled for FreeBSD/arm64
 #elif defined(TARGET_ANDROID)
@@ -1096,7 +1098,10 @@ void GetThreadLocalStaticBlocksInfo(CORINFO_THREAD_STATIC_BLOCKS_INFO* pInfo)
     // For Linux arm64/loongarch64/riscv64, just get the offset of thread static variable, and during execution,
     // this offset, arm64 taken from trpid_elp0 system register gives back the thread variable address.
     // this offset, loongarch64 taken from $tp register gives back the thread variable address.
+#if !(defined(TARGET_LINUX_MUSL) && defined(TARGET_RISCV64))
+    // On musl riscv64, this optimization is disabled due to initial-exec TLS incompatibility.
     threadStaticBaseOffset = GetThreadStaticsVariableOffset();
+#endif
 
 #else
     _ASSERTE_MSG(false, "Unsupported scenario of optimizing TLS access on Linux Arm32/x86 and Android");


### PR DESCRIPTION
On linux-musl-riscv64, when corehost (dotnet) dlopen()s libcoreclr, we get:

> \# dotnet --version
> Failed to load /root/.dotnet/shared/Microsoft.NETCore.App/10.0.0-rtm.25564.199/libcoreclr.so, error: Error relocating /root/.dotnet/shared/Microsoft.NETCore.App/10.0.0-rtm.25564.199/libcoreclr.so: Uq???&?J?N?R?V?Z?	.????: initial-exec TLS resolves to dynamic definition in /root/.dotnet/shared/Microsoft.NETCore.App/10.0.0-rtm.25564.199/libcoreclr.so
Failed to bind to CoreCLR at '/root/.dotnet/shared/Microsoft.NETCore.App/10.0.0-rtm.25564.199/'
Failed to create CoreCLR, HRESULT: 0x80008088

musl maintainer described the issue on this golang thread: https://github.com/golang/go/issues/54805#issuecomment-1253972041. When I tried `LD_PRELOAD=/root/.dotnet/shared/Microsoft.NETCore.App/10.0.0-rtm.25564.199/libcoreclr.so dotnet --version`, the SDK started working.

By disabling the optimization as we have done for linux-musl-arm64 and removing `la.tls.ie` from binary works without the `LD_PRELOAD` hack.