### PR TITLE
Use SSA-based GetRange for ArrLen in OptimizeRangeCheck

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -296,7 +296,6 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree*
         {
             JITDUMP("Looking for array size assertions for: " FMT_VN "\n", arrLenVn);
             Range arrLength = Range(Limit(Limit::keUnknown));
-
             MergeEdgeAssertions(m_pCompiler, arrLenVn, ValueNumStore::NoVN, block->bbAssertionIn, &arrLength);
             if (arrLength.lLimit.IsConstant())
             {
@@ -304,7 +303,7 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree*
             }
             else
             {
-                // Fast path didn't find anything - do the slow SSA-based search:
+                // Fast path didn't find anything - do the slow SSA-based search.
                 arrLength = GetRangeWorker(block, bndsChk->GetArrayLength(), false DEBUGARG(0));
                 if (arrLength.lLimit.IsConstant())
                 {

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -295,8 +295,8 @@ void RangeCheck::OptimizeRangeCheck(BasicBlock* block, Statement* stmt, GenTree*
         if (arrSize <= 0)
         {
             JITDUMP("Looking for array size assertions for: " FMT_VN "\n", arrLenVn);
-            Range arrLength = Range(Limit(Limit::keUnknown));
-            MergeEdgeAssertions(m_pCompiler, arrLenVn, ValueNumStore::NoVN, block->bbAssertionIn, &arrLength);
+            Range arrLength = Range(Limit(Limit::keDependent));
+            MergeEdgeAssertions(m_pCompiler, arrLenVn, arrLenVn, block->bbAssertionIn, &arrLength);
             if (arrLength.lLimit.IsConstant())
             {
                 arrSize = arrLength.lLimit.GetConstant();


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/121682

Removes the bounds checks in ^

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1204755&view=ms.vss-build-web.run-extensions-tab)