### PR TITLE
Build the test tree with TrimMode=full

### DIFF
--- a/src/tests/CoreMangLib/system/delegate/VSD/OpenDelegate.cs
+++ b/src/tests/CoreMangLib/system/delegate/VSD/OpenDelegate.cs
@@ -13,7 +13,7 @@ public class Program
     }
 
     public delegate int Delegate_TC_Int(ClassA tc);
-    public static MethodInfo GetMethod(Type t, string method)
+    public static MethodInfo GetMethod([DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] Type t, string method)
     {
         TypeInfo typeInfo = t.GetTypeInfo();
         IEnumerator<MethodInfo> enumerator = typeInfo.DeclaredMethods.GetEnumerator();

--- a/src/tests/CoreMangLib/system/delegate/VSD/OpenDelegate.cs
+++ b/src/tests/CoreMangLib/system/delegate/VSD/OpenDelegate.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Collections.Generic;
 using Xunit;

--- a/src/tests/Directory.Build.targets
+++ b/src/tests/Directory.Build.targets
@@ -532,10 +532,6 @@
     <!-- IL projects often have mismatches assembly names vs file names and that breaks Win32 resource generation option -->
     <IlcGenerateWin32Resources Condition="'$(Language)' == 'IL'">false</IlcGenerateWin32Resources>
 
-    <!-- The default TrimMode in the SDK is full. But trimming most of the tests would just make them fail,
-         so the default for the test tree is partial. -->
-    <TrimMode Condition="'$(EnableAggressiveTrimming)' != 'true'">partial</TrimMode>
-
     <IlcTreatWarningsAsErrors>false</IlcTreatWarningsAsErrors>
 
     <IlcToolsPath>$(CoreCLRCrossILCompilerDir)</IlcToolsPath>
@@ -560,16 +556,6 @@
 
     <!-- Bump the generic cycle tolerance. There's at least one test with a cycle that is reachable at runtime to depth 6 -->
     <IlcArg Include="--maxgenericcycle:7" />
-
-    <!-- We set TrimMode to partial so that we don't trim parts of the tests,
-         but don't make this apply to xunit cruft -->
-    <IlcArg Include="--trim:Microsoft.DotNet.XUnitExtensions" />
-    <IlcArg Include="--trim:xunit.abstractions" />
-    <IlcArg Include="--trim:xunit.assert" />
-    <IlcArg Include="--trim:xunit.console" />
-    <IlcArg Include="--trim:xunit.core" />
-    <IlcArg Include="--trim:xunit.execution.dotnet" />
-    <IlcArg Include="--trim:xunit.abstractions" />
 
     <!-- NativeAOT compiled output is placed into a 'native' subdirectory: we need to set
          rpath so that the test can load its native library dependencies if there's any -->

--- a/src/tests/JIT/Directed/forceinlining/AttributeConflict.il
+++ b/src/tests/JIT/Directed/forceinlining/AttributeConflict.il
@@ -14,6 +14,8 @@
   .ver 4:0:0:0
 }
 
+.assembly extern System.Diagnostics.StackTrace { }
+
 .assembly AttributeConflict
 {
 }
@@ -160,8 +162,8 @@
     IL_00c7:  newobj     instance void [mscorlib]System.Diagnostics.StackTrace::.ctor()
     IL_00cc:  ldc.i4.0
     IL_00cd:  callvirt   instance class [mscorlib]System.Diagnostics.StackFrame [mscorlib]System.Diagnostics.StackTrace::GetFrame(int32)
-    IL_00d2:  callvirt   instance class [mscorlib]System.Reflection.MethodBase [mscorlib]System.Diagnostics.StackFrame::GetMethod()
-    IL_00d7:  callvirt   instance string [mscorlib]System.Reflection.MemberInfo::get_Name()
+    IL_00d2:  call       class [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::Create(class [mscorlib]System.Diagnostics.StackFrame)
+    IL_00d7:  callvirt   instance string [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::get_Name()
     IL_00dc:  stloc.0
     IL_00dd:  ldloc.0
     IL_00de:  ldstr      "A1"
@@ -308,8 +310,8 @@
     IL_00c7:  newobj     instance void [mscorlib]System.Diagnostics.StackTrace::.ctor()
     IL_00cc:  ldc.i4.0
     IL_00cd:  callvirt   instance class [mscorlib]System.Diagnostics.StackFrame [mscorlib]System.Diagnostics.StackTrace::GetFrame(int32)
-    IL_00d2:  callvirt   instance class [mscorlib]System.Reflection.MethodBase [mscorlib]System.Diagnostics.StackFrame::GetMethod()
-    IL_00d7:  callvirt   instance string [mscorlib]System.Reflection.MemberInfo::get_Name()
+    IL_00d2:  call       class [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::Create(class [mscorlib]System.Diagnostics.StackFrame)
+    IL_00d7:  callvirt   instance string [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::get_Name()
     IL_00dc:  stloc.0
     IL_00dd:  ldloc.0
     IL_00de:  ldstr      "A2"
@@ -456,8 +458,8 @@
     IL_00c7:  newobj     instance void [mscorlib]System.Diagnostics.StackTrace::.ctor()
     IL_00cc:  ldc.i4.0
     IL_00cd:  callvirt   instance class [mscorlib]System.Diagnostics.StackFrame [mscorlib]System.Diagnostics.StackTrace::GetFrame(int32)
-    IL_00d2:  callvirt   instance class [mscorlib]System.Reflection.MethodBase [mscorlib]System.Diagnostics.StackFrame::GetMethod()
-    IL_00d7:  callvirt   instance string [mscorlib]System.Reflection.MemberInfo::get_Name()
+    IL_00d2:  call       class [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::Create(class [mscorlib]System.Diagnostics.StackFrame)
+    IL_00d7:  callvirt   instance string [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::get_Name()
     IL_00dc:  stloc.0
     IL_00dd:  ldloc.0
     IL_00de:  ldstr      "A3"
@@ -604,8 +606,8 @@
     IL_00c7:  newobj     instance void [mscorlib]System.Diagnostics.StackTrace::.ctor()
     IL_00cc:  ldc.i4.0
     IL_00cd:  callvirt   instance class [mscorlib]System.Diagnostics.StackFrame [mscorlib]System.Diagnostics.StackTrace::GetFrame(int32)
-    IL_00d2:  callvirt   instance class [mscorlib]System.Reflection.MethodBase [mscorlib]System.Diagnostics.StackFrame::GetMethod()
-    IL_00d7:  callvirt   instance string [mscorlib]System.Reflection.MemberInfo::get_Name()
+    IL_00d2:  call       class [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::Create(class [mscorlib]System.Diagnostics.StackFrame)
+    IL_00d7:  callvirt   instance string [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::get_Name()
     IL_00dc:  stloc.0
     IL_00dd:  ldloc.0
     IL_00de:  ldstr      "A4"
@@ -634,8 +636,8 @@
     IL_000e:  newobj     instance void [mscorlib]System.Diagnostics.StackTrace::.ctor()
     IL_0013:  ldc.i4.0
     IL_0014:  callvirt   instance class [mscorlib]System.Diagnostics.StackFrame [mscorlib]System.Diagnostics.StackTrace::GetFrame(int32)
-    IL_0019:  callvirt   instance class [mscorlib]System.Reflection.MethodBase [mscorlib]System.Diagnostics.StackFrame::GetMethod()
-    IL_001e:  callvirt   instance string [mscorlib]System.Reflection.MemberInfo::get_Name()
+    IL_0019:  call       class [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::Create(class [mscorlib]System.Diagnostics.StackFrame)
+    IL_001e:  callvirt   instance string [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::get_Name()
     IL_0023:  stloc.0
     IL_0024:  ldloc.0
     IL_0025:  ldstr      "A5"

--- a/src/tests/JIT/Directed/forceinlining/NegativeCases.il
+++ b/src/tests/JIT/Directed/forceinlining/NegativeCases.il
@@ -14,6 +14,8 @@
   .ver 4:0:0:0
 }
 
+.assembly extern System.Diagnostics.StackTrace { }
+
 .assembly NegativeCases
 {
 }
@@ -34,8 +36,8 @@
     IL_0001:  newobj     instance void [mscorlib]System.Diagnostics.StackTrace::.ctor()
     IL_0006:  ldc.i4.0
     IL_0007:  callvirt   instance class [mscorlib]System.Diagnostics.StackFrame [mscorlib]System.Diagnostics.StackTrace::GetFrame(int32)
-    IL_000c:  callvirt   instance class [mscorlib]System.Reflection.MethodBase [mscorlib]System.Diagnostics.StackFrame::GetMethod()
-    IL_0011:  callvirt   instance string [mscorlib]System.Reflection.MemberInfo::get_Name()
+    IL_000c:  call       class [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::Create(class [mscorlib]System.Diagnostics.StackFrame)
+    IL_0011:  callvirt   instance string [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::get_Name()
     IL_0016:  stloc.0
     .try
     {

--- a/src/tests/JIT/Directed/forceinlining/PositiveCases.il
+++ b/src/tests/JIT/Directed/forceinlining/PositiveCases.il
@@ -14,6 +14,8 @@
   .ver 4:0:0:0
 }
 
+.assembly extern System.Diagnostics.StackTrace { }
+
 .assembly PositiveCases
 {
 }
@@ -178,8 +180,8 @@
     IL_00c7:  newobj     instance void [mscorlib]System.Diagnostics.StackTrace::.ctor()
     IL_00cc:  ldc.i4.0
     IL_00cd:  callvirt   instance class [mscorlib]System.Diagnostics.StackFrame [mscorlib]System.Diagnostics.StackTrace::GetFrame(int32)
-    IL_00d2:  callvirt   instance class [mscorlib]System.Reflection.MethodBase [mscorlib]System.Diagnostics.StackFrame::GetMethod()
-    IL_00d7:  callvirt   instance string [mscorlib]System.Reflection.MemberInfo::get_Name()
+    IL_00d2:  call       class [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::Create(class [mscorlib]System.Diagnostics.StackFrame)
+    IL_00d7:  callvirt   instance string [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::get_Name()
     IL_00dc:  stloc.0
     IL_00dd:  ldloc.0
     IL_00de:  ldstr      "A1"
@@ -326,8 +328,8 @@
     IL_00c7:  newobj     instance void [mscorlib]System.Diagnostics.StackTrace::.ctor()
     IL_00cc:  ldc.i4.0
     IL_00cd:  callvirt   instance class [mscorlib]System.Diagnostics.StackFrame [mscorlib]System.Diagnostics.StackTrace::GetFrame(int32)
-    IL_00d2:  callvirt   instance class [mscorlib]System.Reflection.MethodBase [mscorlib]System.Diagnostics.StackFrame::GetMethod()
-    IL_00d7:  callvirt   instance string [mscorlib]System.Reflection.MemberInfo::get_Name()
+    IL_00d2:  call       class [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::Create(class [mscorlib]System.Diagnostics.StackFrame)
+    IL_00d7:  callvirt   instance string [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::get_Name()
     IL_00dc:  stloc.0
     IL_00dd:  ldloc.0
     IL_00de:  ldstr      "A2"
@@ -354,8 +356,8 @@
     IL_000d:  newobj     instance void [mscorlib]System.Diagnostics.StackTrace::.ctor()
     IL_0012:  ldc.i4.0
     IL_0013:  callvirt   instance class [mscorlib]System.Diagnostics.StackFrame [mscorlib]System.Diagnostics.StackTrace::GetFrame(int32)
-    IL_0018:  callvirt   instance class [mscorlib]System.Reflection.MethodBase [mscorlib]System.Diagnostics.StackFrame::GetMethod()
-    IL_001d:  callvirt   instance string [mscorlib]System.Reflection.MemberInfo::get_Name()
+    IL_0018:  call       class [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::Create(class [mscorlib]System.Diagnostics.StackFrame)
+    IL_001d:  callvirt   instance string [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::get_Name()
     IL_0022:  stloc.0
     IL_0023:  ldloc.0
     IL_0024:  ldstr      "A3"
@@ -382,8 +384,8 @@
     IL_000d:  newobj     instance void [mscorlib]System.Diagnostics.StackTrace::.ctor()
     IL_0012:  ldc.i4.0
     IL_0013:  callvirt   instance class [mscorlib]System.Diagnostics.StackFrame [mscorlib]System.Diagnostics.StackTrace::GetFrame(int32)
-    IL_0018:  callvirt   instance class [mscorlib]System.Reflection.MethodBase [mscorlib]System.Diagnostics.StackFrame::GetMethod()
-    IL_001d:  callvirt   instance string [mscorlib]System.Reflection.MemberInfo::get_Name()
+    IL_0018:  call       class [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::Create(class [mscorlib]System.Diagnostics.StackFrame)
+    IL_001d:  callvirt   instance string [System.Diagnostics.StackTrace]System.Diagnostics.DiagnosticMethodInfo::get_Name()
     IL_0022:  stloc.0
     IL_0023:  ldloc.0
     IL_0024:  ldstr      "A4"

--- a/src/tests/JIT/Generics/ConstrainedCall/class1.il
+++ b/src/tests/JIT/Generics/ConstrainedCall/class1.il
@@ -9,6 +9,7 @@
 }
 .assembly extern xunit.core {}
 .assembly extern mscorlib {}
+.assembly extern System.Runtime {}
 .assembly ASSEMBLY_NAME {}
 .class interface private abstract auto ansi IncrDecr
 {
@@ -90,6 +91,7 @@
 {
   .param type T 
   .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
   .field private !T counter
   .field private !T[] counters
   .method public hidebysig instance void 

--- a/src/tests/JIT/Generics/ConstrainedCall/class1.il
+++ b/src/tests/JIT/Generics/ConstrainedCall/class1.il
@@ -8,7 +8,7 @@
   .ver 4:0:0:0
 }
 .assembly extern xunit.core {}
-.assembly extern System.Runtime {}
+.assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly ASSEMBLY_NAME {}
 .class interface private abstract auto ansi IncrDecr
 {

--- a/src/tests/JIT/Generics/ConstrainedCall/class1.il
+++ b/src/tests/JIT/Generics/ConstrainedCall/class1.il
@@ -8,7 +8,6 @@
   .ver 4:0:0:0
 }
 .assembly extern xunit.core {}
-.assembly extern mscorlib {}
 .assembly extern System.Runtime {}
 .assembly ASSEMBLY_NAME {}
 .class interface private abstract auto ansi IncrDecr
@@ -31,7 +30,7 @@
 } 
 
 .class private auto ansi beforefieldinit MyInt
-       extends [mscorlib]System.Object
+       extends [System.Runtime]System.Object
        implements IncrDecr
 {
   .field private int32 x
@@ -80,17 +79,17 @@
   {
     .maxstack  8
     IL_0000:  ldarg.0
-    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
     IL_0006:  ret
   } 
 
 } 
 
 .class private auto ansi beforefieldinit MyCounter<(IncrDecr) T>
-       extends [mscorlib]System.Object
+       extends [System.Runtime]System.Object
 {
   .param type T 
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [System.Runtime]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
   .field private !T counter
   .field private !T[] counters
@@ -128,8 +127,8 @@
     IL_0001:  ldfld      !0[] class MyCounter<!T>::counters
     IL_0006:  ldarg.1
     IL_0007:  ldtoken    !T
-    IL_000c:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    IL_0011:  call       object [mscorlib]System.Activator::CreateInstance(class [mscorlib]System.Type)
+    IL_000c:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_0011:  call       object [System.Runtime]System.Activator::CreateInstance(class [System.Runtime]System.Type)
     IL_0016:  unbox.any  !T
     IL_001b:  stelem     !T
     IL_0020:  ldarg.0
@@ -228,8 +227,8 @@
     .maxstack  8
     IL_0000:  ldarg.0
     IL_0001:  ldtoken    !T
-    IL_0006:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    IL_000b:  call       object [mscorlib]System.Activator::CreateInstance(class [mscorlib]System.Type)
+    IL_0006:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_000b:  call       object [System.Runtime]System.Activator::CreateInstance(class [System.Runtime]System.Type)
     IL_0010:  unbox.any  !T
     IL_0015:  stfld      !0 class MyCounter<!T>::counter
     IL_001a:  ldarg.0
@@ -237,14 +236,14 @@
     IL_001c:  newarr     !T
     IL_0021:  stfld      !0[] class MyCounter<!T>::counters
     IL_0026:  ldarg.0
-    IL_0027:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0027:  call       instance void [System.Runtime]System.Object::.ctor()
     IL_002c:  ret
   } 
 
 } 
 
 .class public auto ansi beforefieldinit test
-       extends [mscorlib]System.Object
+       extends [System.Runtime]System.Object
 {
   .method public hidebysig static int32  Main() cil managed
   {
@@ -270,7 +269,7 @@
     IL_0020:  ldstr      "Expected: 100, Actual: {0}"
     IL_0025:  ldloc.0
     IL_0026:  callvirt   instance int32 class MyCounter<class MyInt>::Val()
-    IL_002b:  box        [mscorlib]System.Int32
+    IL_002b:  box        [System.Runtime]System.Int32
     IL_0030:  call       void [System.Console]System.Console::WriteLine(string,
                                                                   object)
     IL_0035:  ldc.i4.1
@@ -288,7 +287,7 @@
     IL_0054:  ldstr      "Expected: 100, Actual: {0}"
     IL_0059:  ldloc.0
     IL_005a:  callvirt   instance int32 class MyCounter<class MyInt>::Val()
-    IL_005f:  box        [mscorlib]System.Int32
+    IL_005f:  box        [System.Runtime]System.Int32
     IL_0064:  call       void [System.Console]System.Console::WriteLine(string,
                                                                   object)
     IL_0069:  ldc.i4.2
@@ -310,7 +309,7 @@
     IL_0091:  ldloc.0
     IL_0092:  ldc.i4.0
     IL_0093:  callvirt   instance int32 class MyCounter<class MyInt>::Val(int32)
-    IL_0098:  box        [mscorlib]System.Int32
+    IL_0098:  box        [System.Runtime]System.Int32
     IL_009d:  call       void [System.Console]System.Console::WriteLine(string,
                                                                   object)
     IL_00a2:  ldc.i4.3
@@ -331,7 +330,7 @@
     IL_00c8:  ldloc.0
     IL_00c9:  ldc.i4.0
     IL_00ca:  callvirt   instance int32 class MyCounter<class MyInt>::Val(int32)
-    IL_00cf:  box        [mscorlib]System.Int32
+    IL_00cf:  box        [System.Runtime]System.Int32
     IL_00d4:  call       void [System.Console]System.Console::WriteLine(string,
                                                                   object)
     IL_00d9:  ldc.i4.4
@@ -353,7 +352,7 @@
     IL_00fe:  ldstr      "Expected: 100, Actual: {0}"
     IL_0103:  ldloc.0
     IL_0104:  callvirt   instance int32 class MyCounter<class MyInt>::Val()
-    IL_0109:  box        [mscorlib]System.Int32
+    IL_0109:  box        [System.Runtime]System.Int32
     IL_010e:  call       void [System.Console]System.Console::WriteLine(string,
                                                                   object)
     IL_0113:  ldc.i4.5
@@ -372,7 +371,7 @@
     IL_0130:  ldstr      "Expected: 100, Actual: {0}"
     IL_0135:  ldloc.0
     IL_0136:  callvirt   instance int32 class MyCounter<class MyInt>::Val()
-    IL_013b:  box        [mscorlib]System.Int32
+    IL_013b:  box        [System.Runtime]System.Int32
     IL_0140:  call       void [System.Console]System.Console::WriteLine(string,
                                                                   object)
     IL_0145:  ldc.i4.6
@@ -394,7 +393,7 @@
   {
     .maxstack  8
     IL_0000:  ldarg.0
-    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
     IL_0006:  ret
   } 
 }

--- a/src/tests/JIT/Generics/ConstrainedCall/class2.il
+++ b/src/tests/JIT/Generics/ConstrainedCall/class2.il
@@ -8,7 +8,7 @@
   .ver 4:0:0:0
 }
 .assembly extern xunit.core {}
-.assembly extern System.Runtime {}
+.assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly ASSEMBLY_NAME {}
 .class interface private abstract auto ansi IncrDecr
 {

--- a/src/tests/JIT/Generics/ConstrainedCall/class2.il
+++ b/src/tests/JIT/Generics/ConstrainedCall/class2.il
@@ -9,6 +9,7 @@
 }
 .assembly extern xunit.core {}
 .assembly extern mscorlib {}
+.assembly extern System.Runtime {}
 .assembly ASSEMBLY_NAME {}
 .class interface private abstract auto ansi IncrDecr
 {
@@ -90,6 +91,7 @@
 {
   .param type T 
   .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
   .field private !T counter
   .field private !T[] counters
   .method public hidebysig instance void 
@@ -97,6 +99,7 @@
   {
     .param type T2 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
     .maxstack  2
     .locals init (!!T2 V_0)
     IL_0000:  ldtoken    !!T2
@@ -122,6 +125,7 @@
   {
     .param type T2 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
     .maxstack  2
     .locals init (!!T2 V_0)
     IL_0000:  ldarg.0
@@ -146,6 +150,7 @@
   {
     .param type T2 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
     .maxstack  4
     .locals init (!!T2[] V_0)
     IL_0000:  ldc.i4.1
@@ -182,6 +187,7 @@
   {
     .param type T2 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
     .maxstack  4
     .locals init (!!T2[] V_0)
     IL_0000:  ldc.i4.1
@@ -219,6 +225,7 @@
   {
     .param type T2 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
     .maxstack  8
     IL_0000:  ldarga 1
     IL_0001:  
@@ -238,6 +245,7 @@
   {
     .param type T2 
     .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
     .maxstack  8
     IL_0000:  ldarg.1
     IL_0001:  box        !!T2

--- a/src/tests/JIT/Generics/ConstrainedCall/class2.il
+++ b/src/tests/JIT/Generics/ConstrainedCall/class2.il
@@ -8,7 +8,6 @@
   .ver 4:0:0:0
 }
 .assembly extern xunit.core {}
-.assembly extern mscorlib {}
 .assembly extern System.Runtime {}
 .assembly ASSEMBLY_NAME {}
 .class interface private abstract auto ansi IncrDecr
@@ -31,7 +30,7 @@
 } 
 
 .class private auto ansi beforefieldinit MyInt
-       extends [mscorlib]System.Object
+       extends [System.Runtime]System.Object
        implements IncrDecr
 {
   .field private int32 x
@@ -80,17 +79,17 @@
   {
     .maxstack  8
     IL_0000:  ldarg.0
-    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
     IL_0006:  ret
   } 
 
 } 
 
 .class private auto ansi beforefieldinit MyCounter<(IncrDecr) T>
-       extends [mscorlib]System.Object
+       extends [System.Runtime]System.Object
 {
   .param type T 
-  .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+  .custom instance void [System.Runtime]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
   .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
   .field private !T counter
   .field private !T[] counters
@@ -98,13 +97,13 @@
           Increment<(IncrDecr) T2>() cil managed
   {
     .param type T2 
-    .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
     .maxstack  2
     .locals init (!!T2 V_0)
     IL_0000:  ldtoken    !!T2
-    IL_0005:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    IL_000a:  call       object [mscorlib]System.Activator::CreateInstance(class [mscorlib]System.Type)
+    IL_0005:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_000a:  call       object [System.Runtime]System.Activator::CreateInstance(class [System.Runtime]System.Type)
     IL_000f:  unbox.any  !!T2
     IL_0014:  stloc.0
     IL_0015:  ldloca 0
@@ -124,7 +123,7 @@
           Decrement<(IncrDecr) T2>() cil managed
   {
     .param type T2 
-    .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
     .maxstack  2
     .locals init (!!T2 V_0)
@@ -149,7 +148,7 @@
           Increment<(IncrDecr) T2>(int32 index) cil managed
   {
     .param type T2 
-    .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
     .maxstack  4
     .locals init (!!T2[] V_0)
@@ -159,8 +158,8 @@
     IL_0007:  ldloc.0
     IL_0008:  ldarg.1
     IL_0009:  ldtoken    !!T2
-    IL_000e:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    IL_0013:  call       object [mscorlib]System.Activator::CreateInstance(class [mscorlib]System.Type)
+    IL_000e:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_0013:  call       object [System.Runtime]System.Activator::CreateInstance(class [System.Runtime]System.Type)
     IL_0018:  unbox.any  !!T2
     IL_001d:  stelem     !!T2
     IL_0022:  ldloc.0
@@ -186,7 +185,7 @@
           Decrement<(IncrDecr) T2>(int32 index) cil managed
   {
     .param type T2 
-    .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
     .maxstack  4
     .locals init (!!T2[] V_0)
@@ -224,7 +223,7 @@
           instance void  Increment2<(IncrDecr) T2>(!!T2 cnter) cil managed
   {
     .param type T2 
-    .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
     .maxstack  8
     IL_0000:  ldarga 1
@@ -244,7 +243,7 @@
           instance void  Decrement2<(IncrDecr) T2>(!!T2 cnter) cil managed
   {
     .param type T2 
-    .custom instance void [mscorlib]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.NewConstraintAttribute::.ctor() = ( 01 00 00 00 ) 
     .custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 01 00 00 00 00 00 )
     .maxstack  8
     IL_0000:  ldarg.1
@@ -299,8 +298,8 @@
     .maxstack  8
     IL_0000:  ldarg.0
     IL_0001:  ldtoken    !T
-    IL_0006:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
-    IL_000b:  call       object [mscorlib]System.Activator::CreateInstance(class [mscorlib]System.Type)
+    IL_0006:  call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+    IL_000b:  call       object [System.Runtime]System.Activator::CreateInstance(class [System.Runtime]System.Type)
     IL_0010:  unbox.any  !T
     IL_0015:  stfld      !0 class MyCounter<!T>::counter
     IL_001a:  ldarg.0
@@ -308,14 +307,14 @@
     IL_001c:  newarr     !T
     IL_0021:  stfld      !0[] class MyCounter<!T>::counters
     IL_0026:  ldarg.0
-    IL_0027:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0027:  call       instance void [System.Runtime]System.Object::.ctor()
     IL_002c:  ret
   } 
 
 } 
 
 .class public auto ansi beforefieldinit test
-       extends [mscorlib]System.Object
+       extends [System.Runtime]System.Object
 {
   .method public hidebysig static int32  Main() cil managed
   {
@@ -341,7 +340,7 @@
     IL_0020:  ldstr      "Expected: 100, Actual: {0}"
     IL_0025:  ldloc.0
     IL_0026:  callvirt   instance int32 class MyCounter<class MyInt>::Val()
-    IL_002b:  box        [mscorlib]System.Int32
+    IL_002b:  box        [System.Runtime]System.Int32
     IL_0030:  call       void [System.Console]System.Console::WriteLine(string,
                                                                   object)
     IL_0035:  ldc.i4.1
@@ -359,7 +358,7 @@
     IL_0054:  ldstr      "Expected: 100, Actual: {0}"
     IL_0059:  ldloc.0
     IL_005a:  callvirt   instance int32 class MyCounter<class MyInt>::Val()
-    IL_005f:  box        [mscorlib]System.Int32
+    IL_005f:  box        [System.Runtime]System.Int32
     IL_0064:  call       void [System.Console]System.Console::WriteLine(string,
                                                                   object)
     IL_0069:  ldc.i4.2
@@ -381,7 +380,7 @@
     IL_0091:  ldloc.0
     IL_0092:  ldc.i4.0
     IL_0093:  callvirt   instance int32 class MyCounter<class MyInt>::Val(int32)
-    IL_0098:  box        [mscorlib]System.Int32
+    IL_0098:  box        [System.Runtime]System.Int32
     IL_009d:  call       void [System.Console]System.Console::WriteLine(string,
                                                                   object)
     IL_00a2:  ldc.i4.3
@@ -402,7 +401,7 @@
     IL_00c8:  ldloc.0
     IL_00c9:  ldc.i4.0
     IL_00ca:  callvirt   instance int32 class MyCounter<class MyInt>::Val(int32)
-    IL_00cf:  box        [mscorlib]System.Int32
+    IL_00cf:  box        [System.Runtime]System.Int32
     IL_00d4:  call       void [System.Console]System.Console::WriteLine(string,
                                                                   object)
     IL_00d9:  ldc.i4.4
@@ -424,7 +423,7 @@
     IL_00fe:  ldstr      "Expected: 100, Actual: {0}"
     IL_0103:  ldloc.0
     IL_0104:  callvirt   instance int32 class MyCounter<class MyInt>::Val()
-    IL_0109:  box        [mscorlib]System.Int32
+    IL_0109:  box        [System.Runtime]System.Int32
     IL_010e:  call       void [System.Console]System.Console::WriteLine(string,
                                                                   object)
     IL_0113:  ldc.i4.5
@@ -443,7 +442,7 @@
     IL_0130:  ldstr      "Expected: 100, Actual: {0}"
     IL_0135:  ldloc.0
     IL_0136:  callvirt   instance int32 class MyCounter<class MyInt>::Val()
-    IL_013b:  box        [mscorlib]System.Int32
+    IL_013b:  box        [System.Runtime]System.Int32
     IL_0140:  call       void [System.Console]System.Console::WriteLine(string,
                                                                   object)
     IL_0145:  ldc.i4.6
@@ -465,7 +464,7 @@
   {
     .maxstack  8
     IL_0000:  ldarg.0
-    IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
     IL_0006:  ret
   } 
 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_61486/Runtime_61486.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_61486/Runtime_61486.cs
@@ -15,7 +15,7 @@ public class Runtime_61486
     public static int TestEntryPoint()
     {
         var my = new My(new My(null));
-        var m = my.GetType().GetMethod("M");
+        var m = typeof(My).GetMethod("M");
         try
         {
             m.Invoke(my, null);

--- a/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-M01/b12425/b12425.il
+++ b/src/tests/JIT/Regression/VS-ia64-JIT/V1.2-M01/b12425/b12425.il
@@ -4,6 +4,8 @@
 .assembly extern mscorlib{}
 .assembly 'b12425'{}
 .assembly extern xunit.core {}
+.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
+.assembly extern TestLibrary { .ver 0:0:0:0 }
 
 .class interface public abstract auto ansi ITrees
 {
@@ -43,6 +45,12 @@
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
     )
+    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ActiveIssueAttribute::.ctor(string, class [mscorlib]System.Type, string[]) = {
+        string('https://github.com/dotnet/runtime/issues/89157')
+        type([TestLibrary]TestLibrary.Utilities)
+        string[1] ('IsNativeAot')
+    }
+
     .entrypoint
 
 	ldtoken    Garden

--- a/src/tests/JIT/opt/Tailcall/TailcallVerifyWithPrefix.ilproj
+++ b/src/tests/JIT/opt/Tailcall/TailcallVerifyWithPrefix.ilproj
@@ -1,9 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for CLRTestTargetUnsupported, JitOptimizationSensitive -->
+    <!-- Needed for CLRTestTargetUnsupported, JitOptimizationSensitive, TrimMode=partial -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- Test unsupported outside of windows -->
     <CLRTestTargetUnsupported Condition="'$(TargetsWindows)' != 'true'">true</CLRTestTargetUnsupported>
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
   <PropertyGroup>
     <DebugType>None</DebugType>

--- a/src/tests/JIT/opt/Vectorization/UnrollEqualsStartsWith.csproj
+++ b/src/tests/JIT/opt/Vectorization/UnrollEqualsStartsWith.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Optimize>True</Optimize>
-    <!-- Needed for GCStressIncompatible -->
+    <!-- Needed for GCStressIncompatible and TrimMode=partial -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <!-- This test takes very long time under gcstress and causes timeouts -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="UnrollEqualsStartsWith.cs" />

--- a/src/tests/Loader/classloader/TypeForwarding/UnitTest/UnitTest.il
+++ b/src/tests/Loader/classloader/TypeForwarding/UnitTest/UnitTest.il
@@ -66,6 +66,7 @@
               ldstr      "MyDep.Enclosing2+Nested1+SubNested2, MyDep, Versio"
               + "n=1.0.0.0, Culture=neutral, PublicKeyToken=null"
               call       class [mscorlib]System.Type [mscorlib]System.Type::GetType(string)
+              call       object [mscorlib]System.Activator::CreateInstance(class [mscorlib]System.Type)
               pop
 
     IL_0066:  ldstr      "MyDep.Enclosing2+Nested2+SubNested1, MyDep, Versio"
@@ -119,6 +120,7 @@
               ldstr      "MyDep2.Enclosing2+Nested1+SubNested2, MyDep, Versi"
               + "on=1.0.0.0, Culture=neutral, PublicKeyToken=null"
               call       class [mscorlib]System.Type [mscorlib]System.Type::GetType(string)
+              call       object [mscorlib]System.Activator::CreateInstance(class [mscorlib]System.Type)
               pop
 
     IL_00ec:  ldstr      "MyDep2.Enclosing2+Nested2+SubNested1, MyDep, Versi"
@@ -172,6 +174,7 @@
               ldstr      "MyDep3.Enclosing2+Nested1+SubNested2, MyDep, Versi"
               + "on=1.0.0.0, Culture=neutral, PublicKeyToken=null"
               call       class [mscorlib]System.Type [mscorlib]System.Type::GetType(string)
+              call       object [mscorlib]System.Activator::CreateInstance(class [mscorlib]System.Type)
               pop
 
 

--- a/src/tests/Loader/classloader/TypeForwarding/UnitTest/UnitTest.il
+++ b/src/tests/Loader/classloader/TypeForwarding/UnitTest/UnitTest.il
@@ -62,6 +62,12 @@
                                                                                                 bool)
     IL_0060:  call       object [mscorlib]System.Activator::CreateInstance(class [mscorlib]System.Type)
     IL_0065:  pop
+
+              ldstr      "MyDep.Enclosing2+Nested1+SubNested2, MyDep, Versio"
+              + "n=1.0.0.0, Culture=neutral, PublicKeyToken=null"
+              call       class [mscorlib]System.Type [mscorlib]System.Type::GetType(string)
+              pop
+
     IL_0066:  ldstr      "MyDep.Enclosing2+Nested2+SubNested1, MyDep, Versio"
     + "n=1.0.0.0, Culture=neutral, PublicKeyToken=null"
     IL_006b:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetType(string)
@@ -109,6 +115,12 @@
                                                                                                 bool)
     IL_00e6:  call       object [mscorlib]System.Activator::CreateInstance(class [mscorlib]System.Type)
     IL_00eb:  pop
+
+              ldstr      "MyDep2.Enclosing2+Nested1+SubNested2, MyDep, Versi"
+              + "on=1.0.0.0, Culture=neutral, PublicKeyToken=null"
+              call       class [mscorlib]System.Type [mscorlib]System.Type::GetType(string)
+              pop
+
     IL_00ec:  ldstr      "MyDep2.Enclosing2+Nested2+SubNested1, MyDep, Versi"
     + "on=1.0.0.0, Culture=neutral, PublicKeyToken=null"
     IL_00f1:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetType(string)
@@ -156,6 +168,13 @@
                                                                                                 bool)
     IL_016c:  call       object [mscorlib]System.Activator::CreateInstance(class [mscorlib]System.Type)
     IL_0171:  pop
+
+              ldstr      "MyDep3.Enclosing2+Nested1+SubNested2, MyDep, Versi"
+              + "on=1.0.0.0, Culture=neutral, PublicKeyToken=null"
+              call       class [mscorlib]System.Type [mscorlib]System.Type::GetType(string)
+              pop
+
+
     IL_0172:  ldstr      "MyDep3.Enclosing2+Nested2+SubNested1, MyDep, Versi"
     + "on=1.0.0.0, Culture=neutral, PublicKeyToken=null"
     IL_0177:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetType(string)

--- a/src/tests/Loader/classloader/generics/Variance/IL/CastClass001.cs
+++ b/src/tests/Loader/classloader/generics/Variance/IL/CastClass001.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 public class Base {}
@@ -48,23 +49,23 @@ public class TestClass
 		IPlusTMinusU<T,U> t = (IPlusTMinusU<T,U>) v;
 	}
 		
-	private static void CastClassUToTWrapperIPlusT<T,U>()
+	private static void CastClassUToTWrapperIPlusT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>()
 	{
 		CastClassUToTInternalIPlusT<T,U>((U)Activator.CreateInstance(typeof(U)));
 	}
 
-	private static void CastClassUToTWrapperIMinusT<T,U>()
+	private static void CastClassUToTWrapperIMinusT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>()
 	{
 		CastClassUToTInternalIMinusT<T,U>((U)Activator.CreateInstance(typeof(U)));
 	}
 
-	private static void CastClassUToTWrapper<T,U,V>()
+	private static void CastClassUToTWrapper<T,U,[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] V>()
 	{
 		CastClassVToITUInternalIPlusTMinusU<T,U,V>((V)Activator.CreateInstance(typeof(V)));
 	}
 
 	
-	public static bool CastClassUToTIPlusT<T,U>(bool expected)
+	public static bool CastClassUToTIPlusT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>(bool expected)
 	{
 		try
 		{
@@ -97,7 +98,7 @@ public class TestClass
 		}
 	}
 
-	public static bool CastClassUToTIMinusT<T,U>(bool expected)
+	public static bool CastClassUToTIMinusT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>(bool expected)
 	{
 		try
 		{
@@ -130,7 +131,7 @@ public class TestClass
 		}
 	}
 
-	public static bool CastClassUToT<T,U,V>(bool expected)
+	public static bool CastClassUToT<T,U, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] V>(bool expected)
 	{
 		try
 		{

--- a/src/tests/Loader/classloader/generics/Variance/IL/IsInst001.cs
+++ b/src/tests/Loader/classloader/generics/Variance/IL/IsInst001.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 public class Base {}
@@ -33,7 +34,7 @@ public class TestClass
 		}
 	}
 
-	public static bool UIsInstT<T,U>(bool expected)
+	public static bool UIsInstT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>(bool expected)
 	{
 		try
 		{

--- a/src/tests/Loader/classloader/generics/Variance/IL/IsInst002.cs
+++ b/src/tests/Loader/classloader/generics/Variance/IL/IsInst002.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 public class Base {}
@@ -35,7 +36,7 @@ public class TestClass
 		}
 	}
 
-	public static bool UIsInstT<T,U>(bool expected)
+	public static bool UIsInstT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>(bool expected)
 	{
 		try
 		{

--- a/src/tests/Loader/classloader/generics/Variance/IL/IsInst003.cs
+++ b/src/tests/Loader/classloader/generics/Variance/IL/IsInst003.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 public class Base {}
@@ -33,7 +34,7 @@ public class TestClass
 		}
 	}
 
-	public static bool UIsInstT<T,U>(bool expected)
+	public static bool UIsInstT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>(bool expected)
 	{
 		try
 		{

--- a/src/tests/Loader/classloader/generics/Variance/IL/IsInst004.cs
+++ b/src/tests/Loader/classloader/generics/Variance/IL/IsInst004.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 public class Base {}
@@ -33,7 +34,7 @@ public class TestClass
 		}
 	}
 
-	public static bool UIsInstT<T,U>(bool expected)
+	public static bool UIsInstT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>(bool expected)
 	{
 		try
 		{

--- a/src/tests/Loader/classloader/generics/Variance/IL/IsInst005.cs
+++ b/src/tests/Loader/classloader/generics/Variance/IL/IsInst005.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 public class Base {}
@@ -33,7 +34,7 @@ public class TestClass
 		}
 	}
 
-	public static bool UIsInstT<T,U>(bool expected)
+	public static bool UIsInstT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>(bool expected)
 	{
 		try
 		{

--- a/src/tests/Loader/classloader/generics/Variance/IL/IsInst006.cs
+++ b/src/tests/Loader/classloader/generics/Variance/IL/IsInst006.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 public class Base {}
@@ -33,7 +34,7 @@ public class TestClass
 		}
 	}
 
-	public static bool UIsInstT<T,U>(bool expected)
+	public static bool UIsInstT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>(bool expected)
 	{
 		try
 		{

--- a/src/tests/Loader/classloader/generics/Variance/IL/Unbox001.cs
+++ b/src/tests/Loader/classloader/generics/Variance/IL/Unbox001.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 public class Base {}
@@ -32,17 +33,17 @@ public class TestClass
 			Console.WriteLine("Test Failed at location: {0} @ count {1} ", location, iTestCount);
 		}
 	}
-	private static void UnboxUToTInternal<T,U>()
+	private static void UnboxUToTInternal<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>()
 	{
 		T t = (T) Activator.CreateInstance(typeof(U));
 	}
 
-	private static void CaseClassUToTWrapper<T,U>()
+	private static void CaseClassUToTWrapper<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>()
 	{
 		UnboxUToTInternal<T,U>();
 	}
 
-	public static bool UnboxUToT<T,U>(bool expected)
+	public static bool UnboxUToT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>(bool expected)
 	{
 		try
 		{

--- a/src/tests/Loader/classloader/generics/Variance/IL/Unbox002.cs
+++ b/src/tests/Loader/classloader/generics/Variance/IL/Unbox002.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 public class Base {}
@@ -32,17 +33,17 @@ public class TestClass
 			Console.WriteLine("Test Failed at location: {0} @ count {1} ", location, iTestCount);
 		}
 	}
-	private static void UnboxUToTInternal<T,U>()
+	private static void UnboxUToTInternal<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>()
 	{
 		T t = (T) Activator.CreateInstance(typeof(U));
 	}
 
-	private static void CaseClassUToTWrapper<T,U>()
+	private static void CaseClassUToTWrapper<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>()
 	{
 		UnboxUToTInternal<T,U>();
 	}
 
-	public static bool UnboxUToT<T,U>(bool expected)
+	public static bool UnboxUToT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>(bool expected)
 	{
 		try
 		{

--- a/src/tests/Loader/classloader/generics/Variance/IL/Unbox003.cs
+++ b/src/tests/Loader/classloader/generics/Variance/IL/Unbox003.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 public class Base {}
@@ -32,17 +33,17 @@ public class TestClass
 			Console.WriteLine("Test Failed at location: {0} @ count {1} ", location, iTestCount);
 		}
 	}
-	private static void UnboxUToTInternal<T,U>()
+	private static void UnboxUToTInternal<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>()
 	{
 		T t = (T) Activator.CreateInstance(typeof(U));
 	}
 
-	private static void CaseClassUToTWrapper<T,U>()
+	private static void CaseClassUToTWrapper<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>()
 	{
 		UnboxUToTInternal<T,U>();
 	}
 
-	public static bool UnboxUToT<T,U>(bool expected)
+	public static bool UnboxUToT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>(bool expected)
 	{
 		try
 		{

--- a/src/tests/Loader/classloader/generics/Variance/IL/Unbox004.cs
+++ b/src/tests/Loader/classloader/generics/Variance/IL/Unbox004.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 public class Base {}
@@ -32,17 +33,17 @@ public class TestClass
 			Console.WriteLine("Test Failed at location: {0} @ count {1} ", location, iTestCount);
 		}
 	}
-	private static void UnboxUToTInternal<T,U>()
+	private static void UnboxUToTInternal<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>()
 	{
 		T t = (T) Activator.CreateInstance(typeof(U));
 	}
 
-	private static void CaseClassUToTWrapper<T,U>()
+	private static void CaseClassUToTWrapper<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>()
 	{
 		UnboxUToTInternal<T,U>();
 	}
 
-	public static bool UnboxUToT<T,U>(bool expected)
+	public static bool UnboxUToT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>(bool expected)
 	{
 		try
 		{

--- a/src/tests/Loader/classloader/generics/Variance/IL/Unbox005.cs
+++ b/src/tests/Loader/classloader/generics/Variance/IL/Unbox005.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 public class Base {}
@@ -32,17 +33,17 @@ public class TestClass
 			Console.WriteLine("Test Failed at location: {0} @ count {1} ", location, iTestCount);
 		}
 	}
-	private static void UnboxUToTInternal<T,U>()
+	private static void UnboxUToTInternal<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>()
 	{
 		T t = (T) Activator.CreateInstance(typeof(U));
 	}
 
-	private static void CaseClassUToTWrapper<T,U>()
+	private static void CaseClassUToTWrapper<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>()
 	{
 		UnboxUToTInternal<T,U>();
 	}
 
-	public static bool UnboxUToT<T,U>(bool expected)
+	public static bool UnboxUToT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>(bool expected)
 	{
 		try
 		{

--- a/src/tests/Loader/classloader/generics/Variance/IL/Unbox006.cs
+++ b/src/tests/Loader/classloader/generics/Variance/IL/Unbox006.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Xunit;
 
 public class Base {}
@@ -32,17 +33,17 @@ public class TestClass
 			Console.WriteLine("Test Failed at location: {0} @ count {1} ", location, iTestCount);
 		}
 	}
-	private static void UnboxUToTInternal<T,U>()
+	private static void UnboxUToTInternal<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>()
 	{
 		T t = (T) Activator.CreateInstance(typeof(U));
 	}
 
-	private static void CaseClassUToTWrapper<T,U>()
+	private static void CaseClassUToTWrapper<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>()
 	{
 		UnboxUToTInternal<T,U>();
 	}
 
-	public static bool UnboxUToT<T,U>(bool expected)
+	public static bool UnboxUToT<T, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] U>(bool expected)
 	{
 		try
 		{

--- a/src/tests/Loader/classloader/regressions/dev10_720779/dev10_720779.il
+++ b/src/tests/Loader/classloader/regressions/dev10_720779/dev10_720779.il
@@ -15,7 +15,7 @@ where MyClosedDel is:
 
 
 */
-.assembly extern mscorlib {}
+.assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
 .assembly 'dev10_720779' {}
 
 
@@ -40,7 +40,7 @@ where MyClosedDel is:
 	}
 	.method public hidebysig specialname rtspecialname instance void .ctor() cil managed { 
 		ldarg.0
-		call instance void [mscorlib]System.Object::.ctor()
+		call instance void [System.Runtime]System.Object::.ctor()
 		ret
 	}
 }
@@ -53,14 +53,17 @@ where MyClosedDel is:
 
 
 
-.class public sealed myClosedDel extends [mscorlib]System.MulticastDelegate {
+.class public sealed myClosedDel extends [System.Runtime]System.MulticastDelegate {
   .method public hidebysig specialname rtspecialname instance void .ctor(object 'object', native int 'method') runtime managed {}
-  .method public hidebysig newslot virtual instance class [mscorlib]System.IAsyncResult BeginInvoke(class [mscorlib]System.AsyncCallback callback, object 'object') runtime managed {}
+  .method public hidebysig newslot virtual instance class [System.Runtime]System.IAsyncResult BeginInvoke(class [System.Runtime]System.AsyncCallback callback, object 'object') runtime managed {}
   .method public hidebysig newslot virtual instance string Invoke() runtime managed {}
-  .method public hidebysig newslot virtual instance string EndInvoke(class [mscorlib]System.IAsyncResult result) runtime managed {}
+  .method public hidebysig newslot virtual instance string EndInvoke(class [System.Runtime]System.IAsyncResult result) runtime managed {}
 }
 .class public auto ansi beforefieldinit Framework {
-	.method public hidebysig static string DelCall0(object inst, class [mscorlib]System.Type t, string mName) cil managed {
+	.method public hidebysig static string DelCall0(object inst, class [System.Runtime]System.Type t, string mName) cil managed {
+
+		.param [2]
+		.custom instance void [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMembersAttribute::.ctor(valuetype [System.Runtime]System.Diagnostics.CodeAnalysis.DynamicallyAccessedMemberTypes) = ( 01 00 08 00 00 00 00 00 ) 
 	
 		//CS:
 	    //Delegate d = Delegate.CreateDelegate(typeof(myClosedDel), inst, t.GetMethod(mName));
@@ -68,30 +71,30 @@ where MyClosedDel is:
 
 		.maxstack  10
 		ldtoken    myClosedDel
-		call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+		call       class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		ldarg.0
 		ldarg.1
 		ldarg.2
-		callvirt   instance class [mscorlib]System.Reflection.MethodInfo [mscorlib]System.Type::GetMethod(string)
-		call       class [mscorlib]System.Delegate [mscorlib]System.Delegate::CreateDelegate(class [mscorlib]System.Type,object,class [mscorlib]System.Reflection.MethodInfo)
+		callvirt   instance class [System.Runtime]System.Reflection.MethodInfo [System.Runtime]System.Type::GetMethod(string)
+		call       class [System.Runtime]System.Delegate [System.Runtime]System.Delegate::CreateDelegate(class [System.Runtime]System.Type,object,class [System.Runtime]System.Reflection.MethodInfo)
 		ldnull
-		callvirt   instance object [mscorlib]System.Delegate::DynamicInvoke(object[])
-		castclass  [mscorlib]System.String
+		callvirt   instance object [System.Runtime]System.Delegate::DynamicInvoke(object[])
+		castclass  [System.Runtime]System.String
 		ret
 	}
 	.method private hidebysig static int32  CheckResult(string expected, string actual) cil managed {
 	  .maxstack  8
 	    ldstr      "EXPECTED : "
 	    ldarg.0
-	    call       string [mscorlib]System.String::Concat(string,string)
+	    call       string [System.Runtime]System.String::Concat(string,string)
 	    call       void [System.Console]System.Console::WriteLine(string)
 	    ldstr      "ACTUAL   : "
 	    ldarg.1
-	    call       string [mscorlib]System.String::Concat(string,string)
+	    call       string [System.Runtime]System.String::Concat(string,string)
 	    call       void [System.Console]System.Console::WriteLine(string)
 	    ldarg.0
 	    ldarg.1
-	    call       bool [mscorlib]System.String::op_Inequality(string,string)
+	    call       bool [System.Runtime]System.String::op_Inequality(string,string)
 	    brfalse.s  PASSING
 		
 		ldstr "FAIL"
@@ -122,9 +125,9 @@ where MyClosedDel is:
 		ldstr "Derived::Method"
 		newobj instance void class Derived::.ctor()
 		ldtoken class IBaseInterface2`2<string,int32>
-		call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+		call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
 		ldstr "Method"
-		call string Framework::DelCall0(object,class [mscorlib]System.Type,string)
+		call string Framework::DelCall0(object,class [System.Runtime]System.Type,string)
 		call int32 Framework::CheckResult(string,string)
 
 		

--- a/src/tests/Regressions/coreclr/15647/interfacestatics.ilproj
+++ b/src/tests/Regressions/coreclr/15647/interfacestatics.ilproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
   <PropertyGroup>
-    <!-- Needed for mechanical merging of all remaining tests, this particular project may not actually need process isolation -->
+    <!-- Needed for TrimMode -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <!-- Partial trimming works around https://github.com/dotnet/runtime/issues/122013 -->
+    <TrimMode>partial</TrimMode>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="interfacestatics.il" />

--- a/src/tests/Regressions/coreclr/20616/UnicodeBug.il
+++ b/src/tests/Regressions/coreclr/20616/UnicodeBug.il
@@ -93,6 +93,54 @@
   call class [mscorlib]System.Type class [mscorlib]System.Type::GetType(string, bool, bool)
   pop
 
+  // Trimming doesn't analyze case insensitive searches, so do one more case sensitive
+  // search of everything for trimming analysis sake
+
+  ldstr "л"
+  ldc.i4.1
+  call class [mscorlib]System.Type class [mscorlib]System.Type::GetType(string, bool)
+  pop
+
+  ldstr "Общеязыковаяисполняющаясреда"
+  ldc.i4.1
+  call class [mscorlib]System.Type class [mscorlib]System.Type::GetType(string, bool)
+  pop
+
+  ldstr "ꯀ"
+  ldc.i4.1
+  call class [mscorlib]System.Type class [mscorlib]System.Type::GetType(string, bool)
+  pop
+
+  ldstr "Ａ"
+  ldc.i4.1
+  call class [mscorlib]System.Type class [mscorlib]System.Type::GetType(string, bool)
+  pop
+
+  ldstr "Ｂｕｇ"
+  ldc.i4.1
+  call class [mscorlib]System.Type class [mscorlib]System.Type::GetType(string, bool)
+  pop
+
+  ldstr "𐐨"
+  ldc.i4.1
+  call class [mscorlib]System.Type class [mscorlib]System.Type::GetType(string, bool)
+  pop
+
+  ldstr "𐐩𐐪"
+  ldc.i4.1
+  call class [mscorlib]System.Type class [mscorlib]System.Type::GetType(string, bool)
+  pop
+
+  ldstr "𐐪A𐐪"
+  ldc.i4.1
+  call class [mscorlib]System.Type class [mscorlib]System.Type::GetType(string, bool)
+  pop
+
+  ldstr "𐐪Z𐐪"
+  ldc.i4.1
+  call class [mscorlib]System.Type class [mscorlib]System.Type::GetType(string, bool)
+  pop
+
   ldc.i4 100
   ret
 }


### PR DESCRIPTION
We're likely losing out on test coverage by not testing the recommended mainstream shipping configuration.

The test changes are all to make sure we don't trim what's needed.

Where I could, I avoided just putting TrimMode=full on the assembly (because that makes the test case RequiresProcessIsolation and that's not great). For some I had to give up because there was no clean way to do it.

Cc @dotnet/ilc-contrib 