### PR TITLE
MethodEntrypointOrTentativeMethod should tolerate same entrypoints for different MethodDescs

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -305,9 +305,9 @@ namespace ILCompiler.DependencyAnalysis
                     tentative.RealBody : (IMethodBodyNode)entrypoint);
             });
 
-            _tentativeMethods = new NodeCache<MethodDesc, TentativeInstanceMethodNode>(method =>
+            _tentativeMethods = new NodeCache<IMethodBodyNode, TentativeInstanceMethodNode>(method =>
             {
-                return new TentativeInstanceMethodNode((IMethodBodyNode)MethodEntrypoint(method));
+                return new TentativeInstanceMethodNode(method);
             });
 
             _unboxingStubs = new NodeCache<MethodDesc, IMethodNode>(CreateUnboxingStubNode);
@@ -1106,14 +1106,14 @@ namespace ILCompiler.DependencyAnalysis
             return _tentativeMethodEntrypoints.GetOrAdd(method);
         }
 
-        private NodeCache<MethodDesc, TentativeInstanceMethodNode> _tentativeMethods;
+        private NodeCache<IMethodBodyNode, TentativeInstanceMethodNode> _tentativeMethods;
         public IMethodNode MethodEntrypointOrTentativeMethod(MethodDesc method, bool unboxingStub = false)
         {
             // We might be able to optimize the method body away if the owning type was never seen as allocated.
             if (method.NotCallableWithoutOwningEEType() && CompilationModuleGroup.AllowInstanceMethodOptimization(method))
             {
                 Debug.Assert(!unboxingStub);
-                return _tentativeMethods.GetOrAdd(method);
+                return _tentativeMethods.GetOrAdd((IMethodBodyNode)MethodEntrypoint(method, unboxingStub));
             }
 
             return MethodEntrypoint(method, unboxingStub);


### PR DESCRIPTION
Ran into this as I was trying something with #121456. That PR introduces a situation where two MethodDescs could map to the same EntryPoint. We didn't previously have that since MethodEntrypointOrTentativeMethod doesn't support unboxing thunks (that do a similar trick).

Without this fix we would end up with two `TentativeInstanceMethodNode` that point to the same EntryPoint and that doesn't lead to anything good. These need to be 1:1 with entrypoints.

Cc @dotnet/ilc-contrib 