### PR TITLE
JIT: Indicate usage of TYP_LONG for x86 in async transformation

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1121,6 +1121,11 @@ ContinuationLayout AsyncTransformation::LayOutContinuation(BasicBlock*          
             inf.Alignment = genTypeAlignments[dsc->TypeGet()];
             inf.Size      = genTypeSize(dsc);
         }
+
+        // Saving/storing of longs here may be the first place we introduce
+        // long IR. We need to potentially decompose this on x86, so indicate
+        // that to the backend.
+        m_comp->compLongUsed |= dsc->TypeIs(TYP_LONG);
     }
 
     jitstd::sort(liveLocals.begin(), liveLocals.end(), [=](const LiveLocalInfo& lhs, const LiveLocalInfo& rhs) {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -11924,6 +11924,10 @@ void Compiler::gtGetLclVarNameInfo(unsigned lclNum, const char** ilKindOut, cons
                 ilName = "LocAllocSP";
             }
 #endif // JIT32_GCENCODER
+            else if (lclNum == lvaAsyncContinuationArg)
+            {
+                ilName = "AsyncCont";
+            }
             else
             {
                 ilKind = "tmp";
@@ -11943,10 +11947,6 @@ void Compiler::gtGetLclVarNameInfo(unsigned lclNum, const char** ilKindOut, cons
         if (ilNum == 0 && !info.compIsStatic)
         {
             ilName = "this";
-        }
-        else if (lclNum == lvaAsyncContinuationArg)
-        {
-            ilName = "AsyncCont";
         }
         else
         {


### PR DESCRIPTION
Also fix the name for the async continuation parameter; it was showing up as "tmp-1" since a recent change to `compMap2ILvarNum`.

Fix #120341