### PR TITLE
JIT: Handle multi-reg async calls stored to promoted locals

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1342,7 +1342,33 @@ CallDefinitionInfo AsyncTransformation::CanonicalizeCallDefinition(BasicBlock*  
             bool     gotUse = LIR::AsRange(block).TryGetUse(call, &use);
             assert(gotUse);
 
-            use.ReplaceWithLclVar(m_comp);
+            unsigned newLclNum = use.ReplaceWithLclVar(m_comp);
+
+            // In some cases we may have been assigning a multireg promoted local from the call.
+            // That's not supported with a LCL_VAR source. We need to decompose.
+            if (call->IsMultiRegCall() && use.User()->OperIs(GT_STORE_LCL_VAR))
+            {
+                LclVarDsc* dsc = m_comp->lvaGetDesc(use.User()->AsLclVar());
+                if (m_comp->lvaGetPromotionType(dsc) == Compiler::PROMOTION_TYPE_INDEPENDENT)
+                {
+                    JITDUMP("  Call is multi-reg stored to an independently promoted local; decomposing store\n");
+                    for (unsigned i = 0; i < dsc->lvFieldCnt; i++)
+                    {
+                        unsigned   fieldLclNum = dsc->lvFieldLclStart + i;
+                        LclVarDsc* fieldDsc    = m_comp->lvaGetDesc(fieldLclNum);
+
+                        GenTree* value = m_comp->gtNewLclFldNode(newLclNum, fieldDsc->TypeGet(), fieldDsc->lvFldOffset);
+                        GenTree* store = m_comp->gtNewStoreLclVarNode(fieldLclNum, value);
+                        LIR::AsRange(block).InsertBefore(use.User(), value, store);
+                        DISPTREERANGE(LIR::AsRange(block), store);
+                    }
+
+                    // Remove the store that was created by ReplaceWithLclVar above
+                    assert(use.Def()->OperIs(GT_LCL_VAR));
+                    LIR::AsRange(block).Remove(use.Def());
+                    LIR::AsRange(block).Remove(use.User());
+                }
+            }
         }
         else
         {

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1364,7 +1364,7 @@ CallDefinitionInfo AsyncTransformation::CanonicalizeCallDefinition(BasicBlock*  
                         DISPTREERANGE(LIR::AsRange(block), store);
                     }
 
-                    // Remove the store that was created by ReplaceWithLclVar above
+                    // Remove the local and store that were created by ReplaceWithLclVar above
                     assert(use.Def()->OperIs(GT_LCL_VAR));
                     LIR::AsRange(block).Remove(use.Def());
                     LIR::AsRange(block).Remove(use.User());

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1351,6 +1351,7 @@ CallDefinitionInfo AsyncTransformation::CanonicalizeCallDefinition(BasicBlock*  
                 LclVarDsc* dsc = m_comp->lvaGetDesc(use.User()->AsLclVar());
                 if (m_comp->lvaGetPromotionType(dsc) == Compiler::PROMOTION_TYPE_INDEPENDENT)
                 {
+                    m_comp->lvaSetVarDoNotEnregister(newLclNum DEBUGARG(DoNotEnregisterReason::LocalField));
                     JITDUMP("  Call is multi-reg stored to an independently promoted local; decomposing store\n");
                     for (unsigned i = 0; i < dsc->lvFieldCnt; i++)
                     {


### PR DESCRIPTION
In some cases the async transformation needs to introduce a new local to store the result of an async call to. If the previous store was a multi-reg call stored to an independently promoted local then we would produce illegal IR. For example, the IR

```
  t79 = ▌  CALL      struct <unknown method> (async) $702
        ┌──▌  t79    struct
        ▌  STORE_LCL_VAR struct<System.ValueTuple`3, 16>(P) V25 tmp9
        ▌    ref    field V25.Item3 (fldOffset=0x0) -> V275 tmp259      d:2
        ▌    int    field V25.Item2 (fldOffset=0x8) -> V276 tmp260      d:1
        ▌    ubyte  field V25.Item1 (fldOffset=0xc) -> V277 tmp261      d:1 $VN.Void
```

would be canonicalized into

```

  t79 = ▌  CALL      struct <unknown method> (async) $702
        ┌──▌  t79    struct
        ▌  STORE_LCL_VAR struct<System.ValueTuple`3, 16> V337 rat6
t5027 =    LCL_VAR   struct<System.ValueTuple`3, 16> V337 rat6
        ┌──▌  t5027  struct
        ▌  STORE_LCL_VAR struct<System.ValueTuple`3, 16>(P) V25 tmp9
        ▌    ref    field V25.Item3 (fldOffset=0x0) -> V275 tmp259      d:2
        ▌    int    field V25.Item2 (fldOffset=0x8) -> V276 tmp260      d:1
        ▌    ubyte  field V25.Item1 (fldOffset=0xc) -> V277 tmp261      d:1 $VN.Void

```
but that store to the promoted local with a LCL_VAR source is not legal.

Fix the problem by decomposing the store when necessary.

Fixes https://github.com/dotnet/runtime/pull/119432#issuecomment-3543900366