### PR TITLE
Couple fixes to AsyncResumptionStub

### DIFF
--- a/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AsyncResumptionStub.cs
+++ b/src/coreclr/tools/Common/TypeSystem/IL/Stubs/AsyncResumptionStub.cs
@@ -38,7 +38,7 @@ namespace ILCompiler
         {
             TypeDesc objectType = Context.GetWellKnownType(WellKnownType.Object);
             TypeDesc byrefByte = Context.GetWellKnownType(WellKnownType.Byte).MakeByRefType();
-            return _signature = new MethodSignature(0, 0, objectType, [objectType, byrefByte]);
+            return _signature = new MethodSignature(MethodSignatureFlags.Static, 0, objectType, [objectType, byrefByte]);
         }
 
         public override MethodIL EmitIL()
@@ -132,11 +132,18 @@ namespace ILCompiler
     internal sealed partial class ExplicitContinuationAsyncMethod : MethodDesc
     {
         private MethodSignature _signature;
-        private MethodDesc _wrappedMethod;
+        private readonly MethodDesc _wrappedMethod;
+        private readonly MethodDesc _typicalDefinition;
 
         public ExplicitContinuationAsyncMethod(MethodDesc target)
         {
             _wrappedMethod = target;
+
+            MethodDesc targetTypicalDefinition = target.GetTypicalMethodDefinition();
+            if (targetTypicalDefinition != target)
+                _typicalDefinition = new ExplicitContinuationAsyncMethod(targetTypicalDefinition);
+            else
+                _typicalDefinition = this;
         }
 
         public MethodDesc Target => _wrappedMethod;
@@ -231,6 +238,8 @@ namespace ILCompiler
         public override TypeSystemContext Context => _wrappedMethod.Context;
 
         public override bool IsInternalCall => true;
+
+        public override MethodDesc GetTypicalMethodDefinition() => _typicalDefinition;
     }
 
     public static class AsyncResumptionStubExtensions


### PR DESCRIPTION
* The stub is static
* The fake continuation method can act weird if the continuation owning method is on a generic type since we'll report the fake continuation method as homed on the same type. It can hit asserts expecting calling `GetTypicalMethodDefinition` will uninstantiate owning type. Make it so that this invariant holds.

Cc @dotnet/ilc-contrib 