### PR TITLE
Baseline failing async tests

### DIFF
--- a/src/tests/async/collectible-alc/collectible-alc.cs
+++ b/src/tests/async/collectible-alc/collectible-alc.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 public class Async2CollectibleAlc
 {
-    [Fact]
+    [ConditionalFact(typeof(TestLibrary.PlatformDetection), nameof(TestLibrary.PlatformDetection.IsCollectibleAssembliesSupported))]
     public static void TestEntryPoint()
     {
         AsyncEntryPoint().Wait();

--- a/src/tests/async/collectible-alc/collectible-alc.csproj
+++ b/src/tests/async/collectible-alc/collectible-alc.csproj
@@ -7,4 +7,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
* `dynamic` keyword is unsupported with AOT
* So are ALCs
* `GetInterfaceMap` API has known issues (the test actually passes right now, but will fail with #121697 so just disabling now)

Cc @dotnet/ilc-contrib 