### PR TITLE
[RuntimeAsync] Remove async TODOs where issues are not blocking and tracked in some other way

### DIFF
--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -666,7 +666,6 @@ HRESULT EEClass::AddMethodDesc(
     MethodReturnKind returnKind = ClassifyMethodReturnKind(sigParser, pModule, &offsetOfAsyncDetails, &isValueTask);
     if (returnKind != MethodReturnKind::NormalMethod)
     {
-        // TODO: (async) revisit and examine if this can be supported
         LOG((LF_ENC, LL_INFO100, "**Error** EnC for Async methods is NYI"));
         return E_FAIL;
     }

--- a/src/coreclr/vm/class.cpp
+++ b/src/coreclr/vm/class.cpp
@@ -660,11 +660,7 @@ HRESULT EEClass::AddMethodDesc(
     if (FAILED(hr = pImport->GetSigOfMethodDef(methodDef, &sigLen, &sig)))
         return hr;
 
-    SigParser sigParser(sig, sigLen);
-    ULONG offsetOfAsyncDetails;
-    bool isValueTask;
-    MethodReturnKind returnKind = ClassifyMethodReturnKind(sigParser, pModule, &offsetOfAsyncDetails, &isValueTask);
-    if (returnKind != MethodReturnKind::NormalMethod)
+    if (IsMiAsync(dwImplFlags))
     {
         LOG((LF_ENC, LL_INFO100, "**Error** EnC for Async methods is NYI"));
         return E_FAIL;

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -400,6 +400,7 @@ HRESULT MulticoreJitRecorder::WriteOutput(FILE * fp)
         MethodDesc * pMethod = m_JitInfoArray[i].GetMethodDescAndClean();
         if (pMethod->IsAsyncVariantMethod())
         {
+            // TODO: (async) Multicore JIT https://github.com/dotnet/runtime/issues/115097
             skipped++;
             continue;
         }

--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -400,7 +400,6 @@ HRESULT MulticoreJitRecorder::WriteOutput(FILE * fp)
         MethodDesc * pMethod = m_JitInfoArray[i].GetMethodDescAndClean();
         if (pMethod->IsAsyncVariantMethod())
         {
-            // TODO: (async) consider adding support for async variants in the future
             skipped++;
             continue;
         }

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -1120,7 +1120,6 @@ bool ReadyToRunInfo::GetPgoInstrumentationData(MethodDesc * pMD, BYTE** pAllocat
     if (ReadyToRunCodeDisabled())
         return false;
 
-    // TODO: (async) PGO support for async variants
     if (pMD->IsAsyncVariantMethod())
         return false;
 
@@ -1196,7 +1195,6 @@ PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig
     if (ReadyToRunCodeDisabled())
         goto done;
 
-    // TODO: (async) R2R support for async variants
     if (pMD->IsAsyncVariantMethod())
         goto done;
 

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -1120,6 +1120,7 @@ bool ReadyToRunInfo::GetPgoInstrumentationData(MethodDesc * pMD, BYTE** pAllocat
     if (ReadyToRunCodeDisabled())
         return false;
 
+    // TODO: (async) PGO support for async variants (https://github.com/dotnet/runtime/issues/121755)
     if (pMD->IsAsyncVariantMethod())
         return false;
 
@@ -1195,6 +1196,7 @@ PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig
     if (ReadyToRunCodeDisabled())
         goto done;
 
+    // TODO: (async) R2R support for async variants (https://github.com/dotnet/runtime/issues/121559)
     if (pMD->IsAsyncVariantMethod())
         goto done;
 


### PR DESCRIPTION

Trivial change removing some TODOs. 
All these TODOs are for known NYIs that are not blocking and are all tracked in some other way. 

Ex: 
Multicore JIT: https://github.com/dotnet/runtime/issues/115097
R2R: https://github.com/dotnet/runtime/issues/121559
PGO: https://github.com/dotnet/runtime/issues/121755
