### PR TITLE
[cleanup] improve comment alignment in gtlist.h

### DIFF
--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -9,11 +9,16 @@
 /*****************************************************************************/
 //
 //     Node enum
-//                       , GenTree struct flavor
-//                                           ,commutative
-//                                             ,illegal as VN func
-//                                               ,oper kind | DEBUG oper kind
-
+//     |
+//     |                , GenTree struct flavor
+//     |                  |                  
+//     |                  |                  ,commutative
+//     |                  |                   |
+//     |                  |                   |,illegal as VN func
+//     |                  |                   | |
+//     |                  |                   | |,(oper kind | DEBUG oper kind)
+//     |                  |                   | |  |
+//     v                  v                   v v  v
 GTNODE(NONE             , char               ,0,0,GTK_SPECIAL)
 
 //-----------------------------------------------------------------------------

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -11,7 +11,7 @@
 //     Node enum
 //     |
 //     |                , GenTree struct flavor
-//     |                  |                  
+//     |                  |
 //     |                  |                  ,commutative
 //     |                  |                   |
 //     |                  |                   |,illegal as VN func

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -9,16 +9,10 @@
 /*****************************************************************************/
 //
 //     Node enum
-//     |
-//     |                , GenTree struct flavor
-//     |                  |
-//     |                  |                  ,commutative
-//     |                  |                   |
-//     |                  |                   |,illegal as VN func
-//     |                  |                   | |
-//     |                  |                   | |,(oper kind | DEBUG oper kind)
-//     |                  |                   | |  |
-//     v                  v                   v v  v
+//                      , GenTree struct flavor
+//                      ,                    ,commutative
+//                      ,                    , ,illegal as VN func
+//                      ,                    , , ,(oper kind | DEBUG oper kind)
 GTNODE(NONE             , char               ,0,0,GTK_SPECIAL)
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This change improves the readability of comments in `gtlist.h`.

Previously, the comment columns were visually aligned by placing commas in the
same positions as the actual argument separators. While this kept the columns
technically aligned, the presence of "floating commas" in the comments made the
structure harder to parse at a glance.

The updated version replaces those comma placeholders with clearer alignment
cues, making the layout easier to understand.

No behavioral changes.

Part of https://github.com/dotnet/runtime/issues/84834, cc @dotnet/samsung
@SkyShield @namu-lee