### PR TITLE
Clarify structure within .CodeQL.yml

### DIFF
--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -8,6 +8,7 @@ path_classifiers:
     # be excluded from analysis. If there is a problem at the API layer, the analysis
     # engine will detect the problem in the src/ implementations anyway.
     - src/libraries/**/ref/*
+  cmake_internal:
     # exclude artifacts/obj/**/CMakeFiles/**/CheckFunctionExists.c since CMake 
     # generates random directory names causing creation of duplicate issues 
     # related to obsolete encryption algorithm used. Note that CheckFuntionExists 


### PR DESCRIPTION
This is a clarification of the structure within the existing YAML file. The cmake suppressions are not related to the ref suppressions and should be in their own independent section.

This is basically a code comment-equivalent change and doesn't impact how the analysis is performed or how suppressions are interpreted.