### PR TITLE
Remove staging branches from stress test pipelines

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -12,8 +12,7 @@ schedules:
   branches:
     include:
     - main
-    - release/*-staging  # .NET 8 and .NET 9
-    - release/*.0        # .NET 10+
+    - release/*.0
 
 variables:
   - template: ../variables.yml

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -12,8 +12,7 @@ schedules:
   branches:
     include:
     - main
-    - release/*-staging  # .NET 8 and .NET 9
-    - release/*.0        # .NET 10+
+    - release/*.0
 
 variables:
   - template: ../variables.yml


### PR DESCRIPTION
Since futuer release branches will not use the -staging suffix, remove them from the stress test yml files. This does not affect runs on release/9.0-staging etc because the schedule is always checked against the version on that particular branch.