### PR TITLE
Failfast from async inst+unbox thunks

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.BoxedTypes.cs
@@ -423,6 +423,16 @@ namespace ILCompiler
                         Array.Empty<object>());
                 }
 
+                // TODO: (async) https://github.com/dotnet/runtime/issues/121781
+                if (_targetMethod.IsAsyncCall())
+                {
+                    ILEmitter e = new ILEmitter();
+                    ILCodeStream c = e.NewCodeStream();
+
+                    c.EmitCallThrowHelper(e, Context.GetCoreLibEntryPoint("System.Runtime"u8, "InternalCalls"u8, "RhpFallbackFailFast"u8, null));
+                    return e.Link(this);
+                }
+
                 // Generate the unboxing stub. This loosely corresponds to following C#:
                 // return BoxedValue.InstanceMethod(this.m_pEEType, [rest of parameters])
 
@@ -518,6 +528,16 @@ namespace ILCompiler
                         new byte[] { (byte)ILOpcode.ldnull, (byte)ILOpcode.throw_ },
                         Array.Empty<LocalVariableDefinition>(),
                         Array.Empty<object>());
+                }
+
+                // TODO: (async) https://github.com/dotnet/runtime/issues/121781
+                if (_targetMethod.IsAsyncCall())
+                {
+                    ILEmitter e = new ILEmitter();
+                    ILCodeStream c = e.NewCodeStream();
+
+                    c.EmitCallThrowHelper(e, Context.GetCoreLibEntryPoint("System.Runtime"u8, "InternalCalls"u8, "RhpFallbackFailFast"u8, null));
+                    return e.Link(this);
                 }
 
                 // Generate the unboxing stub. This loosely corresponds to following C#:

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.InterfaceThunks.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.InterfaceThunks.cs
@@ -217,6 +217,16 @@ namespace ILCompiler
 
             public override MethodIL EmitIL()
             {
+                // TODO: (async) https://github.com/dotnet/runtime/issues/121781
+                if (_targetMethod.IsAsyncCall())
+                {
+                    ILEmitter e = new ILEmitter();
+                    ILCodeStream c = e.NewCodeStream();
+
+                    c.EmitCallThrowHelper(e, Context.GetCoreLibEntryPoint("System.Runtime"u8, "InternalCalls"u8, "RhpFallbackFailFast"u8, null));
+                    return e.Link(this);
+                }
+
                 // Generate the instantiating stub. This loosely corresponds to following C#:
                 // return Interface.Method(this, GetOrdinalInterface(this.m_pEEType, Index), [rest of parameters])
 

--- a/src/tests/async/inst-unbox-thunks/inst-unbox-thunks.cs
+++ b/src/tests/async/inst-unbox-thunks/inst-unbox-thunks.cs
@@ -115,24 +115,28 @@ public class InstUnBoxThunks
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/121781", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void NoArgGenericUnbox()
     {
         Assert.Equal("System.String", CallStruct1M0().Result);
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/121781", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void ManyArgGenericUnbox()
     {
         Assert.Equal("System.String", CallStruct1M1().Result);
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/121781", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void NoArgGenericInstantiating()
     {
         Assert.Equal("System.String", CallStruct1M0b().Result);
     }
 
     [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/121781", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void ManyArgGenericInstantiating()
     {
         Assert.Equal("System.String", CallStruct1M1b().Result);
@@ -182,5 +186,49 @@ public class InstUnBoxThunks
     public static void ManyArgGVM()
     {
         Assert.Equal("System.String", CallClass2M1().Result);
+    }
+
+    interface I3<T>
+    {
+        async Task<string> M0()
+        {
+            await Task.Yield();
+            return typeof(T).ToString();
+        }
+
+        async Task<string> M1(object a0, object a1, object a2, object a3, object a4, object a5, object a6, object a7, object a8)
+        {
+            await Task.Yield();
+            return typeof(T).ToString();
+        }
+    }
+
+    class Class3 : I3<string>;
+
+    static I3<string> o3;
+    static async Task<string> CallClass3M0()
+    {
+        o3 = new Class3();
+        return await o3.M0();
+    }
+
+    static async Task<string> CallClass3M1()
+    {
+        o3 = new Class3();
+        return await o3.M1(default, default, default, default, default, default, default, default, default);
+    }
+
+    [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/121781", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
+    public static void NoArgDefaultMethod()
+    {
+        Assert.Equal("System.String", CallClass3M0().Result);
+    }
+
+    [Fact]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/121781", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
+    public static void ManyArgDefaultMethod()
+    {
+        Assert.Equal("System.String", CallClass3M1().Result);
     }
 }

--- a/src/tests/async/inst-unbox-thunks/inst-unbox-thunks.csproj
+++ b/src/tests/async/inst-unbox-thunks/inst-unbox-thunks.csproj
@@ -5,4 +5,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
and block tests on ActiveIssue.

FailFast is better than memory corruptions.

Cc @dotnet/ilc-contrib 