### PR TITLE
Allow the other async variant in AsyncMaskingILProvider

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/AsyncMaskingILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/AsyncMaskingILProvider.cs
@@ -43,9 +43,8 @@ namespace ILCompiler.Dataflow
         public static MethodIL WrapIL(MethodIL methodIL)
         {
             MethodDesc owningMethod = methodIL.OwningMethod;
-            if (owningMethod.IsAsyncVariant())
+            if (owningMethod.IsAsync && owningMethod.IsAsyncVariant())
             {
-                Debug.Assert(owningMethod.IsAsync);
                 return new AsyncMaskedMethodIL(((CompilerTypeSystemContext)owningMethod.Context).GetTargetOfAsyncVariantMethod(owningMethod), methodIL);
             }
 


### PR DESCRIPTION
This codepath is hittable since we still scan compiler generated code (we do not generate any warnings for it).

Cc @dotnet/ilc-contrib 