### PR TITLE
[RyuJit/WASM] Reach the NYI in "genCodeForTreeNode"

### DIFF
--- a/src/coreclr/jit/CMakeLists.txt
+++ b/src/coreclr/jit/CMakeLists.txt
@@ -97,6 +97,7 @@ set( JIT_SOURCES
   block.cpp
   buildstring.cpp
   codegencommon.cpp
+  codegenlinear.cpp
   compiler.cpp
   copyprop.cpp
   debuginfo.cpp
@@ -184,7 +185,6 @@ set ( JIT_NATIVE_TARGET_SOURCES
   lsrabuild.cpp
   regalloc.cpp
   regMaskTPOps.cpp
-  codegenlinear.cpp
   gcdecode.cpp
   gcencode.cpp
   unwind.cpp
@@ -297,6 +297,7 @@ set( JIT_WASM_SOURCES
   regallocwasm.cpp
   registeropswasm.cpp
   targetwasm.cpp
+  unwindwasm.cpp
 )
 
 # We include the headers here for better experience in IDEs.
@@ -399,6 +400,7 @@ set( JIT_HEADERS
   ssarenamestate.h
   stacklevelsetter.h
   target.h
+  targetcommon.h
   targetx86.h
   targetamd64.h
   targetarm.h

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -8,14 +8,15 @@
 
 #include "codegen.h"
 
-void CodeGen::genGenerateCode(void** codePtr, uint32_t* nativeSizeOfCode)
+void CodeGen::genMarkLabelsForCodegen()
 {
-    NYI_WASM("Undef genGenerateCode in codegencommon.cpp and proceed from there");
+    // TODO-WASM: serialize fgWasmControlFlow results into codegen-level metadata/labels
+    // (or use them directly and leave this empty).
 }
 
-void CodeGen::genSpillVar(GenTree* tree)
+void CodeGen::genFnProlog()
 {
-    NYI_WASM("Put all spillng to memory under '#if HAS_FIXED_REGISTER_SET'");
+    NYI_WASM("Uncomment CodeGen::genFnProlog and proceed from there");
 }
 
 void CodeGen::genFnEpilog(BasicBlock* block)
@@ -28,6 +29,10 @@ void CodeGen::genFnEpilog(BasicBlock* block)
 #endif // DEBUG
 
     NYI_WASM("genFnEpilog");
+}
+
+void CodeGen::genCaptureFuncletPrologEpilogInfo()
+{
 }
 
 void CodeGen::genFuncletProlog(BasicBlock* block)
@@ -52,6 +57,53 @@ void CodeGen::genFuncletEpilog()
 #endif
 
     NYI_WASM("genFuncletEpilog");
+}
+
+void CodeGen::genCodeForTreeNode(GenTree* node)
+{
+    NYI_WASM("genCodeForTreeNode");
+}
+
+BasicBlock* CodeGen::genCallFinally(BasicBlock* block)
+{
+    assert(block->KindIs(BBJ_CALLFINALLY));
+    NYI_WASM("genCallFinally");
+    return nullptr;
+}
+
+void CodeGen::genEHCatchRet(BasicBlock* block)
+{
+    NYI_WASM("genEHCatchRet");
+}
+
+void CodeGen::genEmitGSCookieCheck(bool tailCall)
+{
+    // TODO-WASM: GS cookie checks have limited utility on WASM since they can only help
+    // with detecting linear memory stack corruption. Decide if we want them anyway.
+    NYI_WASM("genEmitGSCookieCheck");
+}
+
+void CodeGen::genSpillVar(GenTree* tree)
+{
+    NYI_WASM("Put all spillng to memory under '#if HAS_FIXED_REGISTER_SET'");
+}
+
+//------------------------------------------------------------------------
+// inst_JMP: Generate a jump instruction.
+//
+void CodeGen::inst_JMP(emitJumpKind jmp, BasicBlock* tgtBlock)
+{
+    NYI_WASM("inst_JMP");
+}
+
+void CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUGARG(void* code))
+{
+    // GCInfo not captured/created by codegen.
+}
+
+void CodeGen::genReportEH()
+{
+    // EHInfo not captured/created by codegen.
 }
 
 //---------------------------------------------------------------------

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -10871,10 +10871,12 @@ public:
 
     unsigned compLclFrameSize; // secObject+lclBlk+locals+temps
 
+#if HAS_FIXED_REGISTER_SET
     // Count of callee-saved regs we pushed in the prolog.
     // Does not include EBP for isFramePointerUsed() and double-aligned frames.
     // In case of Amd64 this doesn't include float regs saved on stack.
     unsigned compCalleeRegsPushed;
+#endif // HAS_FIXED_REGISTER_SET
 
 #if defined(TARGET_XARCH)
     // Mask of callee saved float regs on stack.

--- a/src/coreclr/jit/emitjmps.h
+++ b/src/coreclr/jit/emitjmps.h
@@ -59,7 +59,9 @@ JMP_SMALL(jmp   , jmp   , j      )
 JMP_SMALL(eq    , ne    , beq    )  // EQ
 JMP_SMALL(ne    , eq    , bne    )  // NE
 
-#elif defined(TARGET_WASM) // No jump kinds needed for WASM.
+#elif defined(TARGET_WASM)
+
+JMP_SMALL(jmp   , jmp   ,  br    )
 
 #else
   #error Unsupported or unset target architecture

--- a/src/coreclr/jit/instrswasm.h
+++ b/src/coreclr/jit/instrswasm.h
@@ -25,6 +25,7 @@
 INST(invalid,     "INVALID",     0, BAD_CODE)
 INST(unreachable, "unreachable", 0, 0x00)
 INST(nop,         "nop",         0, 0x01)
+INST(br,          "br",          0, 0x0C)
 INST(i32_add,     "i32.add",     0, 0x6a)
 // clang-format on
 

--- a/src/coreclr/jit/optcse.cpp
+++ b/src/coreclr/jit/optcse.cpp
@@ -56,14 +56,14 @@ const size_t Compiler::s_optCSEhashBucketSize   = 4;
 // For other architecture and platforms these values dynamically change
 // based upon the number of callee saved and callee scratch registers.
 //
-#define CNT_AGGRESSIVE_ENREG ((CNT_CALLEE_ENREG * 3) / 2)
-#define CNT_MODERATE_ENREG   ((CNT_CALLEE_ENREG * 3) + (CNT_CALLEE_TRASH * 2))
+#define CNT_AGGRESSIVE_ENREG ((CNT_CALLEE_ENREG_FOR_CSE * 3) / 2)
+#define CNT_MODERATE_ENREG   ((CNT_CALLEE_ENREG_FOR_CSE * 3) + (CNT_CALLEE_TRASH_FOR_CSE * 2))
 
-#define CNT_AGGRESSIVE_ENREG_FLT ((CNT_CALLEE_ENREG_FLOAT * 3) / 2)
-#define CNT_MODERATE_ENREG_FLT   ((CNT_CALLEE_ENREG_FLOAT * 3) + (CNT_CALLEE_TRASH_FLOAT * 2))
+#define CNT_AGGRESSIVE_ENREG_FLT ((CNT_CALLEE_ENREG_FLOAT_FOR_CSE * 3) / 2)
+#define CNT_MODERATE_ENREG_FLT   ((CNT_CALLEE_ENREG_FLOAT_FOR_CSE * 3) + (CNT_CALLEE_TRASH_FLOAT_FOR_CSE * 2))
 
-#define CNT_AGGRESSIVE_ENREG_MSK ((CNT_CALLEE_ENREG_MASK * 3) / 2)
-#define CNT_MODERATE_ENREG_MSK   ((CNT_CALLEE_ENREG_MASK * 3) + (CNT_CALLEE_TRASH_MASK * 2))
+#define CNT_AGGRESSIVE_ENREG_MSK ((CNT_CALLEE_ENREG_MASK_FOR_CSE * 3) / 2)
+#define CNT_MODERATE_ENREG_MSK   ((CNT_CALLEE_ENREG_MASK_FOR_CSE * 3) + (CNT_CALLEE_TRASH_MASK_FOR_CSE * 2))
 
 /*****************************************************************************
  *
@@ -2326,7 +2326,7 @@ CSE_HeuristicParameterized::CSE_HeuristicParameterized(Compiler* pCompiler)
 
     // Stopping "parameter"
     //
-    m_registerPressure = CNT_CALLEE_TRASH + CNT_CALLEE_SAVED;
+    m_registerPressure = CNT_CALLEE_TRASH_FOR_CSE + CNT_CALLEE_SAVED_FOR_CSE;
 
     // Verbose
     //
@@ -4667,11 +4667,11 @@ bool CSE_Heuristic::PromotionCheck(CSE_Candidate* candidate)
 
             if (varTypeUsesIntReg(candidate->Expr()))
             {
-                assert(CNT_CALLEE_SAVED != 0);
+                assert(CNT_CALLEE_SAVED_FOR_CSE != 0);
             }
             else if (varTypeUsesMaskReg(candidate->Expr()))
             {
-                if (CNT_CALLEE_SAVED_MASK == 0)
+                if (CNT_CALLEE_SAVED_MASK_FOR_CSE == 0)
                 {
                     hasRequiredSpill = true;
                 }
@@ -4680,7 +4680,7 @@ bool CSE_Heuristic::PromotionCheck(CSE_Candidate* candidate)
             {
                 assert(varTypeUsesFloatReg(candidate->Expr()));
 
-                if (CNT_CALLEE_SAVED_FLOAT == 0)
+                if (CNT_CALLEE_SAVED_FLOAT_FOR_CSE == 0)
                 {
                     hasRequiredSpill = true;
                 }

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -615,6 +615,8 @@ static uint32_t BitScanForward(const regMaskTP& mask)
 #error Unsupported or unset target architecture
 #endif
 
+#include "targetcommon.h"
+
 #ifdef TARGET_XARCH
 
   #define JMP_DIST_SMALL_MAX_NEG  (-128)

--- a/src/coreclr/jit/targetcommon.h
+++ b/src/coreclr/jit/targetcommon.h
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+//
+// Common defines set based on the target-specific ones in target<target>.h files.
+//
+
+// clang-format off
+#ifndef CNT_CALLEE_SAVED_FOR_CSE
+#define CNT_CALLEE_SAVED_FOR_CSE CNT_CALLEE_SAVED
+#endif
+#ifndef CNT_CALLEE_TRASH_FOR_CSE
+#define CNT_CALLEE_TRASH_FOR_CSE CNT_CALLEE_TRASH
+#endif
+#ifndef CNT_CALLEE_ENREG_FOR_CSE
+#define CNT_CALLEE_ENREG_FOR_CSE CNT_CALLEE_ENREG
+#endif
+
+#ifndef CNT_CALLEE_SAVED_FLOAT_FOR_CSE
+#define CNT_CALLEE_SAVED_FLOAT_FOR_CSE CNT_CALLEE_SAVED_FLOAT
+#endif
+#ifndef CNT_CALLEE_TRASH_FLOAT_FOR_CSE
+#define CNT_CALLEE_TRASH_FLOAT_FOR_CSE CNT_CALLEE_TRASH_FLOAT
+#endif
+#ifndef CNT_CALLEE_ENREG_FLOAT_FOR_CSE
+#define CNT_CALLEE_ENREG_FLOAT_FOR_CSE CNT_CALLEE_ENREG_FLOAT
+#endif
+
+#ifndef CNT_CALLEE_SAVED_MASK_FOR_CSE
+#define CNT_CALLEE_SAVED_MASK_FOR_CSE CNT_CALLEE_SAVED_MASK
+#endif
+#ifndef CNT_CALLEE_TRASH_MASK_FOR_CSE
+#define CNT_CALLEE_TRASH_MASK_FOR_CSE CNT_CALLEE_TRASH_MASK
+#endif
+#ifndef CNT_CALLEE_ENREG_MASK_FOR_CSE
+#define CNT_CALLEE_ENREG_MASK_FOR_CSE CNT_CALLEE_ENREG_MASK
+#endif
+// clang-format on

--- a/src/coreclr/jit/targetwasm.h
+++ b/src/coreclr/jit/targetwasm.h
@@ -88,18 +88,27 @@
 #define REG_VAR_ORDER
 #define REG_VAR_ORDER_FLT
 
-// The defines below affect CSE heuristics, so we need to give them some 'sensible' values.
-#define CNT_CALLEE_SAVED        (8)
-#define CNT_CALLEE_TRASH        (8)
-#define CNT_CALLEE_ENREG        (CNT_CALLEE_SAVED)
+// The defines below that affect CSE heuristics are given 'average native target' values.
+#define CNT_CALLEE_SAVED          (0)
+#define CNT_CALLEE_SAVED_FOR_CSE  (8)
+#define CNT_CALLEE_TRASH          (0)
+#define CNT_CALLEE_TRASH_FOR_CSE  (8)
+#define CNT_CALLEE_ENREG          (CNT_CALLEE_SAVED)
+#define CNT_CALLEE_ENREG_FOR_CSE  (CNT_CALLEE_SAVED_FOR_CSE)
 
-#define CNT_CALLEE_SAVED_FLOAT  (10)
-#define CNT_CALLEE_TRASH_FLOAT  (10)
-#define CNT_CALLEE_ENREG_FLOAT  (CNT_CALLEE_SAVED_FLOAT)
+#define CNT_CALLEE_SAVED_FLOAT          (0)
+#define CNT_CALLEE_SAVED_FLOAT_FOR_CSE  (10)
+#define CNT_CALLEE_TRASH_FLOAT          (0)
+#define CNT_CALLEE_TRASH_FLOAT_FOR_CSE  (10)
+#define CNT_CALLEE_ENREG_FLOAT          (CNT_CALLEE_SAVED_FLOAT)
+#define CNT_CALLEE_ENREG_FLOAT_FOR_CSE  (CNT_CALLEE_SAVED_FLOAT_FOR_CSE)
 
-#define CNT_CALLEE_SAVED_MASK   (0)
-#define CNT_CALLEE_TRASH_MASK   (0)
-#define CNT_CALLEE_ENREG_MASK   (CNT_CALLEE_SAVED_MASK)
+#define CNT_CALLEE_SAVED_MASK          (0)
+#define CNT_CALLEE_SAVED_MASK_FOR_CSE  (0)
+#define CNT_CALLEE_TRASH_MASK          (0)
+#define CNT_CALLEE_TRASH_MASK_FOR_CSE  (0)
+#define CNT_CALLEE_ENREG_MASK          (CNT_CALLEE_SAVED_MASK)
+#define CNT_CALLEE_ENREG_MASK_FOR_CSE  (CNT_CALLEE_SAVED_MASK_FOR_CSE)
 
 #define CALLEE_SAVED_REG_MAXSZ    (CNT_CALLEE_SAVED * REGSIZE_BYTES)
 #define CALLEE_SAVED_FLOAT_MAXSZ  (CNT_CALLEE_SAVED_FLOAT * FPSAVE_REGSIZE_BYTES)

--- a/src/coreclr/jit/unwindwasm.cpp
+++ b/src/coreclr/jit/unwindwasm.cpp
@@ -1,0 +1,26 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "jitpch.h"
+#ifdef _MSC_VER
+#pragma hdrstop
+#endif
+
+//
+// We don't have native-code-offset-based unwind info on WASM so this the following functions are all no-ops.
+//
+void Compiler::unwindReserve()
+{
+}
+
+void Compiler::unwindReserveFunc(FuncInfoDsc* func)
+{
+}
+
+void Compiler::unwindEmit(void* pHotCode, void* pColdCode)
+{
+}
+
+void Compiler::unwindEmitFunc(FuncInfoDsc* func, void* pHotCode, void* pColdCode)
+{
+}


### PR DESCRIPTION
Scaffolding for more code generation.

Has two long-term TODOs ([there will be an issue for them](https://github.com/dotnet/runtime/issues/121865)):
1) `genPoisonFrame` (relies on `HAS_FIXED_REGISTER_SET` code).
2) Stack alignment.
