### PR TITLE
[wasm][coreclr] Fix unhandled exceptions

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
@@ -205,8 +205,8 @@ class AsmOffsets
     public const int OFFSETOF__PAL_LIMITED_CONTEXT__FP = 0xb8;
 #elif TARGET_WASM
     // offset to dummy field
-    public const int OFFSETOF__PAL_LIMITED_CONTEXT__IP = 0x04;
-    public const int OFFSETOF__PAL_LIMITED_CONTEXT__FP = 0x04;
+    public const int OFFSETOF__PAL_LIMITED_CONTEXT__IP = 0x10;
+    public const int OFFSETOF__PAL_LIMITED_CONTEXT__FP = 0x0c;
 #endif
 
     // Offsets / sizes that are different in 64 / 32 bit mode
@@ -280,6 +280,9 @@ class AsmOffsets
 #elif TARGET_LOONGARCH64
     static_assert(offsetof(CONTEXT, Pc) == AsmOffsets::OFFSETOF__PAL_LIMITED_CONTEXT__IP);
     static_assert(offsetof(CONTEXT, Fp) == AsmOffsets::OFFSETOF__PAL_LIMITED_CONTEXT__FP);
+#elif TARGET_WASM
+    static_assert(offsetof(CONTEXT, InterpreterIP) == AsmOffsets::OFFSETOF__PAL_LIMITED_CONTEXT__IP);
+    static_assert(offsetof(CONTEXT, InterpreterFP) == AsmOffsets::OFFSETOF__PAL_LIMITED_CONTEXT__FP);
 #endif
     static_assert(sizeof(REGDISPLAY) == AsmOffsets::SIZEOF__REGDISPLAY);
     static_assert(offsetof(REGDISPLAY, SP) == AsmOffsets::OFFSETOF__REGDISPLAY__SP);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
@@ -204,7 +204,6 @@ class AsmOffsets
     public const int OFFSETOF__PAL_LIMITED_CONTEXT__IP = 0x108;
     public const int OFFSETOF__PAL_LIMITED_CONTEXT__FP = 0xb8;
 #elif TARGET_WASM
-    // offset to dummy field
     public const int OFFSETOF__PAL_LIMITED_CONTEXT__IP = 0x10;
     public const int OFFSETOF__PAL_LIMITED_CONTEXT__FP = 0x0c;
 #endif

--- a/src/coreclr/pal/src/arch/wasm/stubs.cpp
+++ b/src/coreclr/pal/src/arch/wasm/stubs.cpp
@@ -25,10 +25,10 @@ DBG_DebugBreak()
 /* context */
 
 extern "C" void
-RtlCaptureContext(OUT PCONTEXT ContextRecord)
+RtlCaptureContext(OUT PCONTEXT pContextRecord)
 {
     // we cannot implement this function for wasm because there is no way to capture the current execution context
-    memset(ContextRecord, 0, sizeof(CONTEXT));
+    memset(pContextRecord, 0, sizeof(*pContextRecord));
 }
 
 extern "C" void

--- a/src/coreclr/pal/src/arch/wasm/stubs.cpp
+++ b/src/coreclr/pal/src/arch/wasm/stubs.cpp
@@ -27,48 +27,49 @@ DBG_DebugBreak()
 extern "C" void
 RtlCaptureContext(OUT PCONTEXT ContextRecord)
 {
-    _ASSERT("RtlCaptureContext not implemented on wasm");
+    // we cannot implement this function for wasm because there is no way to capture the current execution context
+    memset(ContextRecord, 0, sizeof(CONTEXT));
 }
 
 extern "C" void
 CONTEXT_CaptureContext(LPCONTEXT lpContext)
 {
-    _ASSERT("CONTEXT_CaptureContext not implemented on wasm");
+    _ASSERT(!"CONTEXT_CaptureContext not implemented on wasm");
 }
 
 extern "C" void ThrowExceptionFromContextInternal(CONTEXT* context, PAL_SEHException* ex)
 {
-    _ASSERT("ThrowExceptionFromContextInternal not implemented on wasm");
+    _ASSERT(!"ThrowExceptionFromContextInternal not implemented on wasm");
 }
 
 /* unwind */
 
 void ExecuteHandlerOnCustomStack(int code, siginfo_t *siginfo, void *context, size_t sp, SignalHandlerWorkerReturnPoint* returnPoint)
 {
-    _ASSERT("ExecuteHandlerOnCustomStack not implemented on wasm");
+    _ASSERT(!"ExecuteHandlerOnCustomStack not implemented on wasm");
 }
 
 extern "C" int unw_getcontext(int)
 {
-    _ASSERT("unw_getcontext not implemented on wasm");
+    _ASSERT(!"unw_getcontext not implemented on wasm");
     return 0;
 }
 
 extern "C" int unw_init_local(int, int)
 {
-    _ASSERT("unw_init_local not implemented on wasm");
+    _ASSERT(!"unw_init_local not implemented on wasm");
     return 0;
 }
 
 extern "C" int unw_step(int)
 {
-    _ASSERT("unw_step not implemented on wasm");
+    _ASSERT(!"unw_step not implemented on wasm");
     return 0;
 }
 
 extern "C" int unw_is_signal_frame(int)
 {
-    _ASSERT("unw_is_signal_frame not implemented on wasm");
+    _ASSERT(!"unw_is_signal_frame not implemented on wasm");
     return 0;
 }
 
@@ -76,6 +77,6 @@ extern "C" int unw_is_signal_frame(int)
 
 extern "C" int pthread_setschedparam(pthread_t, int, const struct sched_param *)
 {
-    _ASSERT("pthread_setschedparam not implemented on wasm");
+    _ASSERT(!"pthread_setschedparam not implemented on wasm");
     return 0;
 }

--- a/src/coreclr/pal/src/exception/seh-unwind.cpp
+++ b/src/coreclr/pal/src/exception/seh-unwind.cpp
@@ -935,14 +935,14 @@ RaiseException(IN DWORD dwExceptionCode,
 
     // Capture the context of RaiseException.
     ZeroMemory(contextRecord, sizeof(CONTEXT));
-// WASM-TODO: reconsider this
+    // WASM-TODO: reconsider this
 #ifndef TARGET_WASM
     contextRecord->ContextFlags = CONTEXT_FULL;
     CONTEXT_CaptureContext(contextRecord);
 
     // We have to unwind one level to get the actual context user code could be resumed at.
     PAL_VirtualUnwind(contextRecord, NULL);
-#endif // TARGET_WASM
+#endif // !TARGET_WASM
 
     exceptionRecord->ExceptionAddress = (void *)CONTEXTGetPC(contextRecord);
 

--- a/src/coreclr/pal/src/exception/seh-unwind.cpp
+++ b/src/coreclr/pal/src/exception/seh-unwind.cpp
@@ -942,7 +942,7 @@ RaiseException(IN DWORD dwExceptionCode,
 
     // We have to unwind one level to get the actual context user code could be resumed at.
     PAL_VirtualUnwind(contextRecord, NULL);
-#endif
+#endif // TARGET_WASM
 
     exceptionRecord->ExceptionAddress = (void *)CONTEXTGetPC(contextRecord);
 

--- a/src/coreclr/pal/src/exception/seh-unwind.cpp
+++ b/src/coreclr/pal/src/exception/seh-unwind.cpp
@@ -935,11 +935,14 @@ RaiseException(IN DWORD dwExceptionCode,
 
     // Capture the context of RaiseException.
     ZeroMemory(contextRecord, sizeof(CONTEXT));
+// WASM-TODO: reconsider this
+#ifndef TARGET_WASM
     contextRecord->ContextFlags = CONTEXT_FULL;
     CONTEXT_CaptureContext(contextRecord);
 
     // We have to unwind one level to get the actual context user code could be resumed at.
     PAL_VirtualUnwind(contextRecord, NULL);
+#endif
 
     exceptionRecord->ExceptionAddress = (void *)CONTEXTGetPC(contextRecord);
 

--- a/src/coreclr/pal/src/include/pal/context.h
+++ b/src/coreclr/pal/src/include/pal/context.h
@@ -1394,7 +1394,7 @@ inline static DWORD64 CONTEXTGetPC(LPCONTEXT pContext)
     return pContext->PSWAddr;
 #elif defined(HOST_POWERPC64)
     return pContext->Nip;
-#elif defined(HOST_WASM) // wasm has no PC
+#elif defined(HOST_WASM)
     return pContext->InterpreterIP;
 #else
     return pContext->Pc;
@@ -1411,7 +1411,7 @@ inline static void CONTEXTSetPC(LPCONTEXT pContext, DWORD64 pc)
     pContext->PSWAddr = pc;
 #elif defined(HOST_POWERPC64)
     pContext->Nip = pc;
-#elif defined(HOST_WASM) // wasm has no PC
+#elif defined(HOST_WASM)
     pContext->InterpreterIP = pc;
 #else
     pContext->Pc = pc;
@@ -1430,7 +1430,7 @@ inline static DWORD64 CONTEXTGetFP(LPCONTEXT pContext)
     return pContext->R11;
 #elif defined(HOST_POWERPC64)
     return pContext->R31;
-#elif defined(HOST_WASM) // wasm has no PC
+#elif defined(HOST_WASM)
     return pContext->InterpreterFP;
 #else
     return pContext->Fp;

--- a/src/coreclr/pal/src/include/pal/context.h
+++ b/src/coreclr/pal/src/include/pal/context.h
@@ -1395,8 +1395,7 @@ inline static DWORD64 CONTEXTGetPC(LPCONTEXT pContext)
 #elif defined(HOST_POWERPC64)
     return pContext->Nip;
 #elif defined(HOST_WASM) // wasm has no PC
-    _ASSERT(false);
-    return 0;
+    return pContext->InterpreterIP;
 #else
     return pContext->Pc;
 #endif
@@ -1413,7 +1412,7 @@ inline static void CONTEXTSetPC(LPCONTEXT pContext, DWORD64 pc)
 #elif defined(HOST_POWERPC64)
     pContext->Nip = pc;
 #elif defined(HOST_WASM) // wasm has no PC
-    _ASSERT(false);
+    pContext->InterpreterIP = pc;
 #else
     pContext->Pc = pc;
 #endif
@@ -1432,8 +1431,7 @@ inline static DWORD64 CONTEXTGetFP(LPCONTEXT pContext)
 #elif defined(HOST_POWERPC64)
     return pContext->R31;
 #elif defined(HOST_WASM) // wasm has no PC
-    _ASSERT(false);
-    return 0;
+    return pContext->InterpreterFP;
 #else
     return pContext->Fp;
 #endif

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3292,7 +3292,12 @@ void CallCatchFunclet(OBJECTREF throwable, BYTE* pHandlerIP, REGDISPLAY* pvRegDi
 #endif
         {
             STRESS_LOG2(LF_EH, LL_INFO100, "Resuming propagation of managed exception through native frames at IP=%p, SP=%p\n", GetIP(pvRegDisplay->pCurrentContext), GetSP(pvRegDisplay->pCurrentContext));
+#ifdef TARGET_WASM
+            // wasm cannot unwind frames, so we let C++ exception handling do all the work
+            PropagateExceptionThroughNativeFrames(OBJECTREFToObject(throwable));
+#else
             ExecuteFunctionBelowContext((PCODE)PropagateExceptionThroughNativeFrames, pvRegDisplay->pCurrentContext, targetSSP, (size_t)OBJECTREFToObject(throwable));
+#endif
         }
 #undef FIRST_ARG_REG
     }

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3295,9 +3295,9 @@ void CallCatchFunclet(OBJECTREF throwable, BYTE* pHandlerIP, REGDISPLAY* pvRegDi
 #ifdef TARGET_WASM
             // wasm cannot unwind frames, so we let C++ exception handling do all the work
             PropagateExceptionThroughNativeFrames(OBJECTREFToObject(throwable));
-#else
+#else // !TARGET_WASM
             ExecuteFunctionBelowContext((PCODE)PropagateExceptionThroughNativeFrames, pvRegDisplay->pCurrentContext, targetSSP, (size_t)OBJECTREFToObject(throwable));
-#endif
+#endif // TARGET_WASM
         }
 #undef FIRST_ARG_REG
     }

--- a/src/coreclr/vm/interpexec.h
+++ b/src/coreclr/vm/interpexec.h
@@ -80,7 +80,7 @@ struct ExceptionClauseArgs
 void InterpExecMethod(InterpreterFrame *pInterpreterFrame, InterpMethodContextFrame *pFrame, InterpThreadContext *pThreadContext, ExceptionClauseArgs *pExceptionClauseArgs = NULL);
 
 extern "C" void LookupMethodByName(const char* fullQualifiedTypeName, const char* methodName, MethodDesc** ppMD);
-extern "C" void ExecuteInterpretedMethodFromUnmanaged(MethodDesc* pMD, int8_t* args, size_t argSize, int8_t* ret);
+extern "C" void ExecuteInterpretedMethodFromUnmanaged(MethodDesc* pMD, int8_t* args, size_t argSize, int8_t* ret, PCODE callerIp);
 
 CallStubHeader *CreateNativeToInterpreterCallStub(InterpMethod* pInterpMethod);
 

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2067,9 +2067,9 @@ void ExecuteInterpretedMethodWithArgs(TADDR targetIp, int8_t* args, size_t argSi
         memcpy(sp, args, argSize);
     }
 
-    TransitionBlock dummy{};
-    dummy.m_ReturnAddress = (TADDR)callerIp;
-    (void)ExecuteInterpretedMethod(&dummy, (TADDR)targetIp, retBuff);
+    TransitionBlock block{};
+    block.m_ReturnAddress = (TADDR)callerIp;
+    (void)ExecuteInterpretedMethod(&block, (TADDR)targetIp, retBuff);
 }
 
 extern "C" void ExecuteInterpretedMethodFromUnmanaged(MethodDesc* pMD, int8_t* args, size_t argSize, int8_t* ret, PCODE callerIp)

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2056,7 +2056,7 @@ extern "C" void* STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBl
     return frames.interpMethodContextFrame.pRetVal;
 }
 
-void ExecuteInterpretedMethodWithArgs(TADDR targetIp, int8_t* args, size_t argSize, void* retBuff)
+void ExecuteInterpretedMethodWithArgs(TADDR targetIp, int8_t* args, size_t argSize, void* retBuff, PCODE callerIp)
 {
     // Copy arguments to the stack
     if (argSize > 0)
@@ -2068,10 +2068,11 @@ void ExecuteInterpretedMethodWithArgs(TADDR targetIp, int8_t* args, size_t argSi
     }
 
     TransitionBlock dummy{};
+    dummy.m_ReturnAddress = (TADDR)callerIp;
     (void)ExecuteInterpretedMethod(&dummy, (TADDR)targetIp, retBuff);
 }
 
-extern "C" void ExecuteInterpretedMethodFromUnmanaged(MethodDesc* pMD, int8_t* args, size_t argSize, int8_t* ret)
+extern "C" void ExecuteInterpretedMethodFromUnmanaged(MethodDesc* pMD, int8_t* args, size_t argSize, int8_t* ret, PCODE callerIp)
 {
     _ASSERTE(pMD != NULL);
 
@@ -2086,7 +2087,7 @@ extern "C" void ExecuteInterpretedMethodFromUnmanaged(MethodDesc* pMD, int8_t* a
         (void)pMD->DoPrestub(NULL /* MethodTable */, CallerGCMode::Coop);
         targetIp = pMD->GetInterpreterCode();
     }
-    (void)ExecuteInterpretedMethodWithArgs((TADDR)targetIp, args, argSize, ret);
+    (void)ExecuteInterpretedMethodWithArgs((TADDR)targetIp, args, argSize, ret, callerIp);
 }
 #endif // FEATURE_INTERPRETER
 

--- a/src/coreclr/vm/wasm/calldescrworkerwasm.cpp
+++ b/src/coreclr/vm/wasm/calldescrworkerwasm.cpp
@@ -5,7 +5,7 @@
 #include <interpexec.h>
 
 // Forward declaration
-void ExecuteInterpretedMethodWithArgs(TADDR targetIp, int8_t* args, size_t argSize, void* retBuff);
+void ExecuteInterpretedMethodWithArgs(TADDR targetIp, int8_t* args, size_t argSize, void* retBuff, PCODE callerIp);
 
 extern "C" void STDCALL CallDescrWorkerInternal(CallDescrData* pCallDescrData)
 {
@@ -26,5 +26,5 @@ extern "C" void STDCALL CallDescrWorkerInternal(CallDescrData* pCallDescrData)
         targetIp = pMethod->GetInterpreterCode();
     }
 
-    ExecuteInterpretedMethodWithArgs((TADDR)targetIp, (int8_t*)pCallDescrData->pSrc, pCallDescrData->nArgsSize, (int8_t*)pCallDescrData->returnValue);
+    ExecuteInterpretedMethodWithArgs((TADDR)targetIp, (int8_t*)pCallDescrData->pSrc, pCallDescrData->nArgsSize, (int8_t*)pCallDescrData->returnValue, (PCODE)&CallDescrWorkerInternal);
 }

--- a/src/coreclr/vm/wasm/callhelpers-reverse.cpp
+++ b/src/coreclr/vm/wasm/callhelpers-reverse.cpp
@@ -12,7 +12,7 @@ class MethodDesc;
 // WASM-TODO: The method lookup would ideally be fully qualified assembly and then methodDef token.
 // The current approach has limitations with overloaded methods.
 extern "C" void LookupMethodByName(const char* fullQualifiedTypeName, const char* methodName, MethodDesc** ppMD);
-extern "C" void ExecuteInterpretedMethodFromUnmanaged(MethodDesc* pMD, int8_t* args, size_t argSize, int8_t* ret);
+extern "C" void ExecuteInterpretedMethodFromUnmanaged(MethodDesc* pMD, int8_t* args, size_t argSize, int8_t* ret, PCODE callerIp);
 
 static MethodDesc* MD_System_Private_CoreLib_System_Threading_ThreadPool_BackgroundJobHandler_Void_RetVoid = nullptr;
 static void Call_System_Private_CoreLib_System_Threading_ThreadPool_BackgroundJobHandler()
@@ -22,7 +22,7 @@ static void Call_System_Private_CoreLib_System_Threading_ThreadPool_BackgroundJo
     {
         LookupMethodByName("System.Threading.ThreadPool, System.Private.CoreLib", "BackgroundJobHandler", &MD_System_Private_CoreLib_System_Threading_ThreadPool_BackgroundJobHandler_Void_RetVoid);
     }
-    ExecuteInterpretedMethodFromUnmanaged(MD_System_Private_CoreLib_System_Threading_ThreadPool_BackgroundJobHandler_Void_RetVoid, nullptr, 0, nullptr);
+    ExecuteInterpretedMethodFromUnmanaged(MD_System_Private_CoreLib_System_Threading_ThreadPool_BackgroundJobHandler_Void_RetVoid, nullptr, 0, nullptr, (PCODE)&Call_System_Private_CoreLib_System_Threading_ThreadPool_BackgroundJobHandler);
 }
 
 extern "C" void SystemJS_ExecuteBackgroundJobCallback()
@@ -38,7 +38,7 @@ static void Call_System_Private_CoreLib_System_Threading_TimerQueue_TimerHandler
     {
         LookupMethodByName("System.Threading.TimerQueue, System.Private.CoreLib", "TimerHandler", &MD_System_Private_CoreLib_System_Threading_TimerQueue_TimerHandler_Void_RetVoid);
     }
-    ExecuteInterpretedMethodFromUnmanaged(MD_System_Private_CoreLib_System_Threading_TimerQueue_TimerHandler_Void_RetVoid, nullptr, 0, nullptr);
+    ExecuteInterpretedMethodFromUnmanaged(MD_System_Private_CoreLib_System_Threading_TimerQueue_TimerHandler_Void_RetVoid, nullptr, 0, nullptr, (PCODE)&Call_System_Private_CoreLib_System_Threading_TimerQueue_TimerHandler);
 }
 
 extern "C" void SystemJS_ExecuteTimerCallback()

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -162,10 +162,15 @@ void FaultingExceptionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool u
 
 void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
-    PORTABILITY_ASSERT("TransitionFrame::UpdateRegDisplay_Impl is not implemented on wasm");
+    pRD->pCurrentContext->InterpreterIP = GetReturnAddress();
+    pRD->pCurrentContext->InterpreterSP = GetSP();
+
+    SyncRegDisplayToCurrentContext(pRD);
+
+    LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    TransitionFrame::UpdateRegDisplay_Impl(rip:%p, rsp:%p)\n", pRD->ControlPC, pRD->SP));
 }
 
-size_t CallDescrWorkerInternalReturnAddressOffset;
+size_t CallDescrWorkerInternalReturnAddressOffset = 0;
 
 VOID PALAPI RtlRestoreContext(IN PCONTEXT ContextRecord, IN PEXCEPTION_RECORD ExceptionRecord)
 {


### PR DESCRIPTION
Developed with Jan Vorlicek

Make sure the return address is set in transition block when going through `ExecuteInterpretedMethodWithArgs`, so that `SfiNextWorker` gets the address.

Fill missing pieces around context.

Fix few asserts and offsets.