### PR TITLE
Add support for iOS sample app to publish and run with R2R on coreclr

### DIFF
--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -579,11 +579,7 @@ RETAIL_CONFIG_DWORD_INFO(INTERNAL_CreateDumpDiagnostics, W("CreateDumpDiagnostic
 /// R2R
 ///
 RETAIL_CONFIG_STRING_INFO(INTERNAL_NativeImageSearchPaths, W("NativeImageSearchPaths"), "Extra search paths for native composite R2R images")
-#if defined(TARGET_IOS) || defined(TARGET_TVOS) || defined(TARGET_MACCATALYST)
-RETAIL_CONFIG_DWORD_INFO(EXTERNAL_ReadyToRun, W("ReadyToRun"), 0, "Enable/disable use of ReadyToRun native code") // Off by default for Apple mobile
-#else
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_ReadyToRun, W("ReadyToRun"), 1, "Enable/disable use of ReadyToRun native code") // On by default for CoreCLR
-#endif // defined(TARGET_IOS) || defined(TARGET_TVOS) || defined(TARGET_MACCATALYST)
 RETAIL_CONFIG_STRING_INFO(EXTERNAL_ReadyToRunExcludeList, W("ReadyToRunExcludeList"), "List of assemblies that cannot use Ready to Run images")
 RETAIL_CONFIG_STRING_INFO(EXTERNAL_ReadyToRunLogFile, W("ReadyToRunLogFile"), "Name of file to log success/failure of using Ready to Run images")
 

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -666,6 +666,9 @@ RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_PreferredVectorBitWidth,      W("PreferredV
 #if defined(TARGET_LOONGARCH64)
 //TODO: should implement LoongArch64's features.
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableHWIntrinsic,            W("EnableHWIntrinsic"),         0, "Allows Base+ hardware intrinsics to be disabled")
+#elif defined(TARGET_IOS) || defined(TARGET_TVOS) || defined(TARGET_MACCATALYST)
+// Always disabled on Apple mobile
+RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableHWIntrinsic,            W("EnableHWIntrinsic"),         0, "Allows Base+ hardware intrinsics to be disabled")
 #else
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableHWIntrinsic,            W("EnableHWIntrinsic"),         1, "Allows Base+ hardware intrinsics to be disabled")
 #endif // defined(TARGET_LOONGARCH64)

--- a/src/coreclr/inc/clrconfigvalues.h
+++ b/src/coreclr/inc/clrconfigvalues.h
@@ -666,9 +666,6 @@ RETAIL_CONFIG_DWORD_INFO_EX(EXTERNAL_PreferredVectorBitWidth,      W("PreferredV
 #if defined(TARGET_LOONGARCH64)
 //TODO: should implement LoongArch64's features.
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableHWIntrinsic,            W("EnableHWIntrinsic"),         0, "Allows Base+ hardware intrinsics to be disabled")
-#elif defined(TARGET_IOS) || defined(TARGET_TVOS) || defined(TARGET_MACCATALYST)
-// Always disabled on Apple mobile
-RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableHWIntrinsic,            W("EnableHWIntrinsic"),         0, "Allows Base+ hardware intrinsics to be disabled")
 #else
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_EnableHWIntrinsic,            W("EnableHWIntrinsic"),         1, "Allows Base+ hardware intrinsics to be disabled")
 #endif // defined(TARGET_LOONGARCH64)

--- a/src/coreclr/interpreter/eeinterp.cpp
+++ b/src/coreclr/interpreter/eeinterp.cpp
@@ -85,8 +85,8 @@ CorJitResult CILInterp::compileMethod(ICorJitInfo*         compHnd,
                 break;
         }
 
-#ifdef TARGET_WASM
-        // interpret everything on wasm
+#if defined(TARGET_WASM) || defined(TARGET_IOS) || defined(TARGET_TVOS) || defined(TARGET_MACCATALYST)
+        // interpret everything on wasm and Apple mobile platforms
         doInterpret = true;
 #else
         // NOTE: We do this check even if doInterpret==true in order to populate g_interpModule

--- a/src/coreclr/interpreter/eeinterp.cpp
+++ b/src/coreclr/interpreter/eeinterp.cpp
@@ -85,8 +85,8 @@ CorJitResult CILInterp::compileMethod(ICorJitInfo*         compHnd,
                 break;
         }
 
-#if defined(TARGET_WASM) || defined(TARGET_IOS) || defined(TARGET_TVOS) || defined(TARGET_MACCATALYST)
-        // interpret everything on wasm and Apple mobile platforms
+#if !defined(FEATURE_JIT)
+        // interpret everything when we do not have a JIT
         doInterpret = true;
 #else
         // NOTE: We do this check even if doInterpret==true in order to populate g_interpModule

--- a/src/mono/msbuild/apple/build/AppleBuild.InTree.targets
+++ b/src/mono/msbuild/apple/build/AppleBuild.InTree.targets
@@ -33,4 +33,19 @@
     </ItemGroup>
     <Message Text="Used runtime pack: %(ResolvedRuntimePack.PackageDirectory)" Importance="high" />
   </Target>
+
+  <!-- Override the ResolveReadyToRunCompilers target to use the in-build crossgen2.
+       This needs to be imported after SDK targets, so any project requiring this should set AfterMicrosoftNETSdkTargets -->
+  <Target Name="ResolveReadyToRunCompilers" Condition="'$(PublishReadyToRun)' == true" DependsOnTargets="ResolveRuntimeFilesFromLocalBuild">
+    <PropertyGroup>
+      <Crossgen2Path>$([MSBuild]::NormalizePath('$(Crossgen2InBuildDir)', 'crossgen2$(ExeSuffix)'))</Crossgen2Path>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <Crossgen2Tool Include="$(Crossgen2Path)"
+                     TargetArch="$(TargetArchitecture)"
+                     TargetOS="$(TargetOS)"
+                     PerfmapFormatVersion="$(PublishReadyToRunPerfmapFormatVersion)"/>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/mono/msbuild/apple/build/AppleBuild.targets
+++ b/src/mono/msbuild/apple/build/AppleBuild.targets
@@ -257,7 +257,7 @@
       <_MonoLLVMPath Condition="'$(_MonoLLVMPath)' == '' and '$(MonoEnableLLVM)' == 'true'">$([System.IO.Path]::GetDirectoryName("$(_CompilerBinaryPath)"))</_MonoLLVMPath>
     </PropertyGroup>
 
-    <MonoAOTCompiler Condition="'$(RunAOTCompilation)' == 'true'"
+    <MonoAOTCompiler Condition="'$(RunAOTCompilation)' == 'true' and '$(UseMonoRuntime)' != 'false'"
         AotModulesTablePath="$(_AotModuleTablePath)"
         AotModulesTableLanguage="ObjC"
         Assemblies="@(_AotInputAssemblies)"

--- a/src/mono/sample/iOS/Makefile
+++ b/src/mono/sample/iOS/Makefile
@@ -11,6 +11,7 @@ APP_SANDBOX?=false
 STRIP_DEBUG_SYMBOLS?=false # only used when measuring SOD via build-appbundle make target
 USE_MONO_RUNTIME?=true
 AOT?=true
+R2R?=false
 
 #If DIAGNOSTIC_PORTS is enabled, @(RuntimeComponents) must also include 'diagnostics_tracing'.
 #If @(RuntimeComponents) includes 'diagnostics_tracing', DIAGNOSTIC_PORTS is optional.
@@ -44,6 +45,7 @@ build-appbundle: clean appbuilder
 	/p:DeployAndRun=false \
 	/p:RunAOTCompilation=$(AOT) \
 	/p:UseMonoRuntime=$(USE_MONO_RUNTIME) \
+	/p:PublishReadyToRun=$(R2R) \
 	/bl
 
 run: clean appbuilder

--- a/src/mono/sample/iOS/Program.csproj
+++ b/src/mono/sample/iOS/Program.csproj
@@ -35,14 +35,6 @@
     <RuntimeComponents Condition="'$(DiagnosticPorts)' != ''" Include="diagnostics_tracing" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(UseMonoRuntime)' != 'true'">
-    <EnvironmentVariables Include="DOTNET_Interpreter=%2A%21%2A" />
-    <EnvironmentVariables Condition="'$(PublishReadyToRun)' == 'true'" Include="DOTNET_InterpMode=1" />
-    <EnvironmentVariables Condition="'$(PublishReadyToRun)' == 'true'" Include="DOTNET_ReadyToRun=1" />
-    <EnvironmentVariables Condition="'$(PublishReadyToRun)' != 'true'" Include="DOTNET_InterpMode=3" />
-    <EnvironmentVariables Condition="'$(PublishReadyToRun)' != 'true'" Include="DOTNET_ReadyToRun=0" />
-  </ItemGroup>
-
   <!-- Use the repo's CrossGen props/targets.
        This can be removed once we upstream Mach-O support in the targets to the SDK -->
   <Import Project="$(Crossgen2SdkOverridePropsPath)" Condition="'$(PublishReadyToRun)' == 'true' and '$(Crossgen2SdkOverridePropsPath)' != ''" />

--- a/src/mono/sample/iOS/Program.csproj
+++ b/src/mono/sample/iOS/Program.csproj
@@ -26,15 +26,32 @@
     <BuildAppBundleDependsOnTargets Condition="'$(ArchiveTests)' == 'true'">Publish</BuildAppBundleDependsOnTargets>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(PublishReadyToRun)' == 'true' and '$(UseMonoRuntime)' != 'true'">
+    <PublishReadyToRunComposite>true</PublishReadyToRunComposite>
+    <PublishReadyToRunContainerFormat>macho</PublishReadyToRunContainerFormat>
+  </PropertyGroup>
+
   <ItemGroup>
     <RuntimeComponents Condition="'$(DiagnosticPorts)' != ''" Include="diagnostics_tracing" />
-    <EnvironmentVariables Condition="'$(UseMonoRuntime)' != 'true'" Include="DOTNET_Interpreter=%2A%21%2A" />
-    <EnvironmentVariables Condition="'$(UseMonoRuntime)' != 'true'" Include="DOTNET_InterpMode=3" />
-    <EnvironmentVariables Condition="'$(UseMonoRuntime)' != 'true'" Include="DOTNET_ReadyToRun=0" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(UseMonoRuntime)' != 'true'">
+    <EnvironmentVariables Include="DOTNET_Interpreter=%2A%21%2A" />
+    <EnvironmentVariables Condition="'$(PublishReadyToRun)' == 'true'" Include="DOTNET_InterpMode=1" />
+    <EnvironmentVariables Condition="'$(PublishReadyToRun)' == 'true'" Include="DOTNET_ReadyToRun=1" />
+    <EnvironmentVariables Condition="'$(PublishReadyToRun)' != 'true'" Include="DOTNET_InterpMode=3" />
+    <EnvironmentVariables Condition="'$(PublishReadyToRun)' != 'true'" Include="DOTNET_ReadyToRun=0" />
+  </ItemGroup>
+
+  <!-- Use the repo's CrossGen props/targets.
+       This can be removed once we upstream Mach-O support in the targets to the SDK -->
+  <Import Project="$(Crossgen2SdkOverridePropsPath)" Condition="'$(PublishReadyToRun)' == 'true' and '$(Crossgen2SdkOverridePropsPath)' != ''" />
   <Import Project="$(MonoProjectRoot)\msbuild\apple\build\AppleBuild.props" />
-  <Import Project="$(MonoProjectRoot)\msbuild\apple\build\AppleBuild.InTree.targets" />
+  <PropertyGroup>
+    <!-- Import after SDK targets in order to override R2R-related targets in the SDK -->
+    <AfterMicrosoftNETSdkTargets Condition="'$(PublishReadyToRun)' == 'true' and '$(Crossgen2SdkOverrideTargetsPath)' != ''">$(Crossgen2SdkOverrideTargetsPath)</AfterMicrosoftNETSdkTargets>
+    <AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(MonoProjectRoot)\msbuild\apple\build\AppleBuild.InTree.targets</AfterMicrosoftNETSdkTargets>
+  </PropertyGroup>
 
   <Target Name="BuildAppBundle" AfterTargets="$(BuildAppBundleAfterTargets)" DependsOnTargets="$(BuildAppBundleDependsOnTargets)"/>
   <Target Name="_SetAppleGenerateAppBundleProps" Condition="'$(TargetOS)' != 'ios' and '$(ArchiveTests)' != 'true'" BeforeTargets="_AppleGenerateAppBundle">

--- a/src/tasks/AppleAppBuilder/AppleAppBuilder.csproj
+++ b/src/tasks/AppleAppBuilder/AppleAppBuilder.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Templates\*.*" />
     <EmbeddedResource Include="$(CoreClrProjectRoot)hosts\inc\coreclrhost.h" Link="Templates\coreclrhost.h" />
+    <EmbeddedResource Include="$(SharedNativeRoot)corehost\host_runtime_contract.h" Link="Templates\host_runtime_contract.h" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AppleAppBuilder.cs" />

--- a/src/tasks/AppleAppBuilder/Templates/CMakeLists.txt.template
+++ b/src/tasks/AppleAppBuilder/Templates/CMakeLists.txt.template
@@ -79,6 +79,12 @@ add_custom_command(
         if ls -1 $CODESIGNING_FOLDER_PATH/*.dylib 2>/dev/null | grep -q .\; then
           codesign --force --sign \"$SIGN_IDENTITY\" --timestamp $CODESIGNING_FOLDER_PATH/*.dylib\;
         fi\;
+        if ls -1 $CODESIGNING_FOLDER_PATH/Contents/Resources/*.r2r.dylib 2>/dev/null | grep -q .\; then
+          codesign --force --sign \"$SIGN_IDENTITY\" --timestamp $CODESIGNING_FOLDER_PATH/Contents/Resources/*.r2r.dylib\;
+        fi\;
+        if ls -1 $CODESIGNING_FOLDER_PATH/*.r2r.dylib 2>/dev/null | grep -q .\; then
+          codesign --force --sign \"$SIGN_IDENTITY\" --timestamp $CODESIGNING_FOLDER_PATH/*.r2r.dylib\;
+        fi\;
       fi\;
     fi
 )

--- a/src/tasks/AppleAppBuilder/Templates/runtime-coreclr.m
+++ b/src/tasks/AppleAppBuilder/Templates/runtime-coreclr.m
@@ -109,6 +109,8 @@ size_t get_image_size(void* base_address)
 
         return image_size;
     }
+
+    return 0;
 }
 
 bool get_native_code_data(const struct host_runtime_contract_native_code_context* context, struct host_runtime_contract_native_code_data* data)
@@ -128,7 +130,6 @@ bool get_native_code_data(const struct host_runtime_contract_native_code_context
     if (written <= 0 || (size_t)written >= sizeof(r2r_path) - dir_len)
         return false;
 
-    // TODO: store and dlclose the handles after the app runs
     void* handle = dlopen(r2r_path, RTLD_LAZY | RTLD_LOCAL);
     if (handle == NULL)
         return false;
@@ -191,6 +192,7 @@ mono_ios_runtime_init (void)
 #endif
     assert (res > 0);
 
+    // Contract lasts the lifetime of the app. The app exists before the end of this function.
     struct host_runtime_contract host_contract = {
         .size = sizeof(struct host_runtime_contract),
         .pinvoke_override = &pinvoke_override,

--- a/src/tasks/AppleAppBuilder/Templates/runtime-coreclr.m
+++ b/src/tasks/AppleAppBuilder/Templates/runtime-coreclr.m
@@ -3,6 +3,7 @@
 
 #import <Foundation/Foundation.h>
 #include "coreclrhost.h"
+#include "host_runtime_contract.h"
 #include <TargetConditionals.h>
 #import <os/log.h>
 #include <sys/stat.h>
@@ -68,7 +69,7 @@ compute_trusted_platform_assemblies ()
     return strdup([joined UTF8String]);
 }
 
-void*
+const void*
 pinvoke_override (const char *libraryName, const char *entrypointName)
 {
     if (!strcmp (libraryName, "__Internal"))
@@ -77,6 +78,80 @@ pinvoke_override (const char *libraryName, const char *entrypointName)
     }
 
     return NULL;
+}
+
+#include <mach-o/dyld.h>
+#include <mach-o/loader.h>
+size_t get_image_size(void* base_address)
+{
+    uint32_t image_count = _dyld_image_count();
+    for (uint32_t i = 0; i < image_count; ++i)
+    {
+        const struct mach_header_64* header = (const struct mach_header_64*)_dyld_get_image_header(i);
+        if ((const void*)header != base_address)
+            continue;
+
+        const struct load_command* cmd = (const struct load_command*)((const char*)header + sizeof(struct mach_header_64));
+
+        size_t image_size = 0;
+        for (uint32_t j = 0; j < header->ncmds; ++j)
+        {
+            if (cmd->cmd == LC_SEGMENT_64)
+            {
+                const struct segment_command_64* seg = (const struct segment_command_64*)cmd;
+                size_t end_addr = (size_t)(seg->vmaddr + seg->vmsize);
+                if (end_addr > image_size)
+                    image_size = end_addr;
+            }
+
+            cmd = (const struct load_command*)((const char*)cmd + cmd->cmdsize);
+        }
+
+        return image_size;
+    }
+}
+
+bool get_native_code_data(const struct host_runtime_contract_native_code_context* context, struct host_runtime_contract_native_code_data* data)
+{
+    if (!context || !data || !context->assembly_path || !context->owner_composite_name)
+        return false;
+
+    // Look for the owner composite R2R image in the same directory as the assembly
+    char r2r_path[PATH_MAX];
+    const char *last_slash = strrchr(context->assembly_path, '/');
+    size_t dir_len = last_slash ? (size_t)(last_slash - context->assembly_path) : 0;
+    if (dir_len >= sizeof(r2r_path) - 1)
+        return false;
+
+    strncpy(r2r_path, context->assembly_path, dir_len);
+    int written = snprintf(r2r_path + dir_len, sizeof(r2r_path) - dir_len, "/%s", context->owner_composite_name);
+    if (written <= 0 || (size_t)written >= sizeof(r2r_path) - dir_len)
+        return false;
+
+    // TODO: store and dlclose the handles after the app runs
+    void* handle = dlopen(r2r_path, RTLD_LAZY | RTLD_LOCAL);
+    if (handle == NULL)
+        return false;
+
+    void* r2r_header = dlsym(handle, "RTR_HEADER");
+    if (r2r_header == NULL)
+    {
+        dlclose(handle);
+        return false;
+    }
+
+    Dl_info info;
+    if (dladdr(r2r_header, &info) == 0)
+    {
+        dlclose(handle);
+        return false;
+    }
+
+    data->size = sizeof(struct host_runtime_contract_native_code_data);
+    data->r2r_header_ptr = r2r_header;
+    data->image_size = get_image_size(info.dli_fbase);
+    data->image_base = info.dli_fbase;
+    return true;
 }
 
 void
@@ -116,15 +191,21 @@ mono_ios_runtime_init (void)
 #endif
     assert (res > 0);
 
-    char pinvoke_override_addr [16];
-    sprintf (pinvoke_override_addr, "%p", &pinvoke_override);
+    struct host_runtime_contract host_contract = {
+        .size = sizeof(struct host_runtime_contract),
+        .pinvoke_override = &pinvoke_override,
+        .get_native_code_data = &get_native_code_data
+    };
+
+    char contract_str[19]; // 0x + 16 hex digits + '\0'
+    snprintf(contract_str, 19, "0x%zx", (size_t)(&host_contract));
 
     // TODO: set TRUSTED_PLATFORM_ASSEMBLIES, APP_PATHS and NATIVE_DLL_SEARCH_DIRECTORIES
     const char *appctx_keys [] = {
         "RUNTIME_IDENTIFIER",
         "APP_CONTEXT_BASE_DIRECTORY",
         "TRUSTED_PLATFORM_ASSEMBLIES",
-        "PINVOKE_OVERRIDE",
+        "HOST_RUNTIME_CONTRACT",
 #if !defined(INVARIANT_GLOBALIZATION)
         "ICU_DAT_FILE_PATH"
 #endif
@@ -133,7 +214,7 @@ mono_ios_runtime_init (void)
         APPLE_RUNTIME_IDENTIFIER,
         bundle,
         compute_trusted_platform_assemblies(),
-        pinvoke_override_addr,
+        contract_str,
 #if !defined(INVARIANT_GLOBALIZATION)
         icu_dat_path
 #endif

--- a/src/tasks/AppleAppBuilder/Templates/runtime-coreclr.m
+++ b/src/tasks/AppleAppBuilder/Templates/runtime-coreclr.m
@@ -16,10 +16,6 @@
 
 #define APPLE_RUNTIME_IDENTIFIER "//%APPLE_RUNTIME_IDENTIFIER%"
 
-#define MAX_LOADED_NATIVE_CODE_COUNT 64 // Arbitrarily 'large enough' number
-static void* loaded_native_code_handles[MAX_LOADED_NATIVE_CODE_COUNT];
-static int loaded_native_code_handle_count = 0;
-
 const char *
 get_bundle_path (void)
 {
@@ -132,13 +128,10 @@ bool get_native_code_data(const struct host_runtime_contract_native_code_context
     if (written <= 0 || (size_t)written >= sizeof(r2r_path) - dir_len)
         return false;
 
-    assert(loaded_native_code_handle_count < MAX_LOADED_NATIVE_CODE_COUNT);
+    // TODO: store and dlclose the handles after the app runs
     void* handle = dlopen(r2r_path, RTLD_LAZY | RTLD_LOCAL);
     if (handle == NULL)
         return false;
-
-    loaded_native_code_handles[loaded_native_code_handle_count] = handle;
-    loaded_native_code_handle_count++;
 
     void* r2r_header = dlsym(handle, "RTR_HEADER");
     if (r2r_header == NULL)
@@ -247,14 +240,6 @@ mono_ios_runtime_init (void)
     os_log_info (OS_LOG_DEFAULT, EXIT_CODE_TAG ": %d", res);
 
     free_managed_args (&managed_argv, argi);
-
-    // Close all loaded handles after the app runs
-    for (int i = 0; i < loaded_native_code_handle_count; ++i)
-    {
-        if (loaded_native_code_handles[i] != NULL) {
-            dlclose(loaded_native_code_handles[i]);
-        }
-    }
 
     exit (res);
 }

--- a/src/tasks/AppleAppBuilder/Xcode.cs
+++ b/src/tasks/AppleAppBuilder/Xcode.cs
@@ -618,6 +618,8 @@ internal sealed class Xcode
             {
                 File.WriteAllText(Path.Combine(binDir, "coreclrhost.h"),
                     Utils.GetEmbeddedResource("coreclrhost.h"));
+                File.WriteAllText(Path.Combine(binDir, "host_runtime_contract.h"),
+                    Utils.GetEmbeddedResource("host_runtime_contract.h"));
 
                 // NOTE: Library mode is not supported yet
                 File.WriteAllText(Path.Combine(binDir, "runtime.m"),

--- a/src/tests/FunctionalTests/iOS/Simulator/CoreCLR.Interpreter/iOS.Simulator.CoreCLR.Interpreter.Test.csproj
+++ b/src/tests/FunctionalTests/iOS/Simulator/CoreCLR.Interpreter/iOS.Simulator.CoreCLR.Interpreter.Test.csproj
@@ -13,6 +13,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <EnvironmentVariables Include="DOTNET_InterpMode=3" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="Program.cs" />
   </ItemGroup>
 </Project>

--- a/src/tests/FunctionalTests/iOS/Simulator/CoreCLR.Interpreter/iOS.Simulator.CoreCLR.Interpreter.Test.csproj
+++ b/src/tests/FunctionalTests/iOS/Simulator/CoreCLR.Interpreter/iOS.Simulator.CoreCLR.Interpreter.Test.csproj
@@ -13,10 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <EnvironmentVariables Include="DOTNET_InterpMode=3" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Include="Program.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Runtime:
- Stop disabling R2R by default on Apple mobile
- Update runtime to interpret everything on Apple moblie

iOS sample app:
- Update AppleAppBuilder host template to use `host_runtime_contract`
- Use in-build crossgen2 and in-repo targets when publishing iOS app
- Make AppleAppBuilder sign `*.r2r.dylib`