### PR TITLE
[clr-interp] Enable building clr-interp on Release, via build flag

### DIFF
--- a/eng/build.ps1
+++ b/eng/build.ps1
@@ -26,6 +26,7 @@ Param(
   [string[]]$fsanitize,
   [switch]$bootstrap,
   [switch]$useBoostrap,
+  [switch]$clrinterpreter,
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 
@@ -57,6 +58,7 @@ function Get-Help() {
   Write-Host "                                 '-subset' can be omitted if the subset is given as the first argument."
   Write-Host "                                 [Default: Builds the entire repo.]"
   Write-Host "  -usemonoruntime                Product a .NET runtime with Mono as the underlying runtime."
+  Write-Host "  -clrinterpreter                Enables CoreCLR interpreter for Release builds of targets where it is a Debug only feature."
   Write-Host "  -verbosity (-v)                MSBuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
   Write-Host "                                 [Default: Minimal]"
   Write-Host "  --useBootstrap                 Use the results of building the bootstrap subset to build published tools on the target machine."
@@ -335,6 +337,7 @@ foreach ($argument in $PSBoundParameters.Keys)
     "arch"                   {}
     "fsanitize"              { $arguments += " /p:EnableNativeSanitizers=$($PSBoundParameters[$argument])"}
     "useBootstrap"           { $arguments += " /p:UseBootstrap=$($PSBoundParameters[$argument])" }
+    "clrinterpreter"         { $arguments += " /p:FeatureInterpreter=true" }
     default                  { $arguments += " /p:$argument=$($PSBoundParameters[$argument])" }
   }
 }

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -46,6 +46,7 @@ usage()
   echo "                                 '--subset' can be omitted if the subset is given as the first argument."
   echo "                                  [Default: Builds the entire repo.]"
   echo "  --usemonoruntime                Product a .NET runtime with Mono as the underlying runtime."
+  echo "  --clrinterpreter                Enables CoreCLR interpreter for Release builds of targets where it is a Debug only feature."
   echo "  --verbosity (-v)                MSBuild verbosity: q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]."
   echo "                                  [Default: Minimal]"
   echo "  --use-bootstrap                 Use the results of building the bootstrap subset to build published tools on the target machine."
@@ -378,6 +379,11 @@ while [[ $# -gt 0 ]]; do
 
      -usemonoruntime)
       arguments+=("/p:PrimaryRuntimeFlavor=Mono")
+      shift 1
+      ;;
+
+     -clrinterpreter)
+      arguments+=("/p:FeatureInterpreter=true")
       shift 1
       ;;
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
@@ -135,8 +135,13 @@ class AsmOffsets
 #if TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x8;
 #if FEATURE_INTERPRETER
+#if TARGET_UNIX
     public const int SIZEOF__StackFrameIterator = 0x168;
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x160;
+#else // TARGET_UNIX
+    public const int SIZEOF__StackFrameIterator = 0x170;
+    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x168;
+#endif // TARGET_UNIX
 #else
     public const int SIZEOF__StackFrameIterator = 0x148;
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x140;

--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -51,6 +51,7 @@
       <_CoreClrBuildArg Include="-cmakeargs &quot;-DCLR_DOTNET_HOST_PATH=$(DOTNET_HOST_PATH)&quot;" />
       <_CoreClrBuildArg Condition="'$(HasCdacBuildTool)' == 'true'" Include="-cmakeargs &quot;-DCDAC_BUILD_TOOL_BINARY_PATH=$(RuntimeBinDir)cdac-build-tool\cdac-build-tool.dll&quot;" />
       <_CoreClrBuildArg Condition="'$(FeatureXplatEventSource)' == 'false'" Include="-cmakeargs &quot;-DFEATURE_EVENTSOURCE_XPLAT=0&quot;" />
+      <_CoreClrBuildArg Condition="'$(FeatureInterpreter)' == 'true'" Include="-cmakeargs &quot;-DFEATURE_INTERPRETER=1&quot;" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(CxxStandardLibrary)' != ''">

--- a/src/coreclr/vm/amd64/asmconstants.h
+++ b/src/coreclr/vm/amd64/asmconstants.h
@@ -575,7 +575,11 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__InterpMethod__pCallStub == offsetof(InterpMethod
 #define OFFSETOF__Thread__m_pInterpThreadContext 0x2a0
 #endif // _DEBUG
 #else // TARGET_UNIX
+#ifdef _DEBUG
 #define OFFSETOF__Thread__m_pInterpThreadContext 0xb60
+#else // _DEBUG
+#define OFFSETOF__Thread__m_pInterpThreadContext 0x2e8
+#endif // _DEBUG
 #endif // TARGET_UNIX
 ASMCONSTANTS_C_ASSERT(OFFSETOF__Thread__m_pInterpThreadContext == offsetof(Thread, m_pInterpThreadContext))
 


### PR DESCRIPTION
Interpreter is enabled on targets needing it: wasm/ios.
Interpreter is enabled on debug desktop build.
Interpreter is disabled on release desktop build.

This commit makes it possible to enable it on desktop release build. Ex:
```
./build.sh -subset clr -c Release --clrinterpreter
```