### PR TITLE
[release/10.0] JIT: disable stack allocation for sites in CEA cloned regions

### DIFF
--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -56,6 +56,7 @@ ObjectAllocator::ObjectAllocator(Compiler* comp)
     , m_regionsToClone(0)
     , m_trackFields(false)
     , m_StoreAddressToIndexMap(comp->getAllocator(CMK_ObjectAllocator))
+    , m_initialMaxBlockID(comp->compBasicBlockID)
 {
     m_EscapingPointers                = BitVecOps::UninitVal();
     m_PossiblyStackPointingPointers   = BitVecOps::UninitVal();
@@ -1365,6 +1366,18 @@ bool ObjectAllocator::MorphAllocObjNodeHelper(AllocationCandidate& candidate)
     if (candidate.m_block->HasFlag(BBF_BACKWARD_JUMP))
     {
         candidate.m_onHeapReason = "[alloc in loop]";
+        return false;
+    }
+
+    // Don't stack allocate at sites that were cloned or are clones. These sites now violate
+    // the single assignment assumption used by the escape analysis.
+    //
+    // This is something we can fix by keeping track of which allocation sites are clones
+    // of other sites, and just allocating one var to cover them all.
+    //
+    if (BlockIsCloneOrWasCloned(candidate.m_block))
+    {
+        candidate.m_onHeapReason = "[allocation was cloned]";
         return false;
     }
 
@@ -3636,7 +3649,7 @@ void ObjectAllocator::RecordAppearance(unsigned lclNum, BasicBlock* block, State
 bool ObjectAllocator::CloneOverlaps(CloneInfo* info)
 {
     bool         overlaps = false;
-    BitVecTraits traits(comp->compBasicBlockID, comp);
+    BitVecTraits traits(m_initialMaxBlockID, comp);
 
     for (CloneInfo* const c : CloneMap::ValueIteration(&m_CloneMap))
     {
@@ -3666,6 +3679,56 @@ bool ObjectAllocator::CloneOverlaps(CloneInfo* info)
     }
 
     return overlaps;
+}
+
+//------------------------------------------------------------------------------
+// BlockIsCloneOrWasCloned: check if this block is a clone or was cloned as
+//    part of an conditional escape optimization
+//
+// Arguments:
+//   block -- block in question
+//
+// Returns:
+//   true if block was cloned
+//
+// Notes:
+//   Such blocks are interesting when they contain ALLCOBJs that we can prove
+//   won't escape.
+//
+bool ObjectAllocator::BlockIsCloneOrWasCloned(BasicBlock* block)
+{
+    if (block->bbID >= m_initialMaxBlockID)
+    {
+        JITDUMP("Block " FMT_BB " was cloned as part of conditional escape processing\n", block->bbNum);
+        return true;
+    }
+
+    BitVecTraits traits(m_initialMaxBlockID, comp);
+
+    for (CloneInfo* const c : CloneMap::ValueIteration(&m_CloneMap))
+    {
+        // Ignore regions that we did not clone
+        //
+        if (!c->m_willClone)
+        {
+            continue;
+        }
+
+        // We don't actually clone the alloc blocks, despite them being
+        // in the block set for the clone.
+        //
+        if (block == c->m_allocBlock)
+        {
+            continue;
+        }
+
+        if (BitVecOps::IsMember(&traits, c->m_blocks, block->bbID))
+        {
+            JITDUMP("Block " FMT_BB " was cloned as part of conditional escape processing\n", block->bbNum);
+            return true;
+        }
+    }
+    return false;
 }
 
 //------------------------------------------------------------------------------
@@ -3862,7 +3925,7 @@ bool ObjectAllocator::CheckCanClone(CloneInfo* info)
     jitstd::vector<BasicBlock*>* visited         = new (alloc) jitstd::vector<BasicBlock*>(alloc);
     jitstd::vector<BasicBlock*>* toVisitTryEntry = new (alloc) jitstd::vector<BasicBlock*>(alloc);
 
-    BitVecTraits traits(comp->compBasicBlockID, comp);
+    BitVecTraits traits(m_initialMaxBlockID, comp);
     BitVec       visitedBlocks(BitVecOps::MakeEmpty(&traits));
     toVisit.Push(allocBlock);
     BitVecOps::AddElemD(&traits, visitedBlocks, allocBlock->bbID);

--- a/src/coreclr/jit/objectalloc.h
+++ b/src/coreclr/jit/objectalloc.h
@@ -195,6 +195,9 @@ class ObjectAllocator final : public Phase
     bool           m_trackFields;
     NodeToIndexMap m_StoreAddressToIndexMap;
 
+    // Info to distinguish cloned blocks
+    unsigned m_initialMaxBlockID;
+
     //===============================================================================
     // Methods
 public:
@@ -284,6 +287,8 @@ private:
     bool ShouldClone(CloneInfo* info);
     void CloneAndSpecialize(CloneInfo* info);
     void CloneAndSpecialize();
+
+    bool BlockIsCloneOrWasCloned(BasicBlock* block);
 
     static const unsigned int s_StackAllocMaxSize = 0x2000U;
 

--- a/src/tests/JIT/opt/ObjectStackAllocation/Runtime_121736.cs
+++ b/src/tests/JIT/opt/ObjectStackAllocation/Runtime_121736.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+public class Runtime_121736
+{
+    [Fact]
+    public static void Test()
+    {
+        HashSet<Fake> pureSelectedObjects = [new Fake(TestEnum.One)];
+        try
+        {
+            for (var i = 0; i < 10_000_000; i++)
+            {
+                TestEnum txt = pureSelectedObjects.Select(x => (TestEnum)x.GetSourceItem()).First();
+            }
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e);
+            throw;
+        }
+
+        Console.WriteLine("Passed");
+    }
+}
+
+public enum TestEnum
+{
+    One
+}
+
+public class Fake
+{
+    private readonly TestEnum src;
+
+    public Fake(TestEnum t)
+    {
+        src = t;
+    }
+
+    public object GetSourceItem()
+    {
+        return src;
+    }
+}

--- a/src/tests/JIT/opt/ObjectStackAllocation/Runtime_121736.csproj
+++ b/src/tests/JIT/opt/ObjectStackAllocation/Runtime_121736.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of #121771 to release/10.0

/cc @AndyAyersMS

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Reported by customer in https://github.com/dotnet/runtime/issues/121736

## Regression

- [ ] Yes
- [x] No

An issue in a new optimization in .NET 10. 

Escape analysis assumes each stack allocation candidate node has a unique temp that has that allocation as its only assigned value. Conditional escape analysis may clone these nodes, creating a second allocation site assigning to the same temp. This breaks the 1-1 assumption noted above and can lead to silent bad codegen.

To fix this we disallow stack allocation for sites in blocks that were cloned, or their clones.

## Testing

Verified on the test case from the issue.

## Risk

Low. Disables an optimization. No diffs for this in our SPMI testing.
