### PR TITLE
[RyuJit/WASM] Reach the NYI in `genFnProlog`

### DIFF
--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -3183,7 +3183,7 @@ void CodeGen::genCall(GenTreeCall* call)
 #ifdef TARGET_ARM
                 if (compiler->opts.compUseSoftFP && returnType == TYP_DOUBLE)
                 {
-                    inst_RV_RV_RV(INS_vmov_i2d, call->GetRegNum(), returnReg, genRegArgNext(returnReg), EA_8BYTE);
+                    inst_RV_RV_RV(INS_vmov_i2d, call->GetRegNum(), returnReg, REG_NEXT(returnReg), EA_8BYTE);
                 }
                 else if (compiler->opts.compUseSoftFP && returnType == TYP_FLOAT)
                 {

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1357,10 +1357,6 @@ void emitter::emitBegFN(bool hasFramePtr
     ig->igPrev          = nullptr;
 #endif
 
-#ifdef DEBUG
-    emitScratchSigInfo = nullptr;
-#endif // DEBUG
-
     /* Append another group, to start generating the method body */
 
     emitNewIG();

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -10098,7 +10098,7 @@ void emitter::emitRemoveLastInstruction()
  *  emitGetInsSC: Get the instruction's constant value.
  */
 
-cnsval_ssize_t emitter::emitGetInsSC(const instrDesc* id) const
+cnsval_ssize_t emitter::emitGetInsSC(const instrDesc* id)
 {
 #ifdef TARGET_ARM // should it be TARGET_ARMARCH? Why do we need this? Note that on ARM64 we store scaled immediates
                   // for some formats

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -3623,12 +3623,6 @@ public:
                             CORINFO_SIG_INFO*     callSig,       /* IN */
                             CORINFO_METHOD_HANDLE methodHandle); /* IN */
 
-#ifdef DEBUG
-    // This is a scratch buffer used to minimize the number of sig info structs
-    // we have to allocate for recordCallSite.
-    CORINFO_SIG_INFO* emitScratchSigInfo;
-#endif // DEBUG
-
     /************************************************************************/
     /*               Logic to collect and display statistics                */
     /************************************************************************/

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -1264,12 +1264,7 @@ protected:
             _idCodeSize = sz;
         }
 #elif defined(TARGET_WASM)
-        unsigned idCodeSize() const
-        {
-            // TODO-WASM: return an accurate number here based on instruction format/opcode like ARM64 above.
-            NYI_WASM("isCodeSize");
-            return 0;
-        }
+        unsigned idCodeSize() const;
 #endif
 
         emitAttr idOpSize() const
@@ -2460,8 +2455,8 @@ protected:
     static bool          HasApxPpx(instruction ins);
 #endif // TARGET_XARCH
 
-    cnsval_ssize_t emitGetInsSC(const instrDesc* id) const;
-    unsigned       emitInsCount;
+    NOT_ARM(static) cnsval_ssize_t emitGetInsSC(const instrDesc* id);
+    unsigned emitInsCount;
 
     /************************************************************************/
     /*           A few routines used for debug display purposes             */

--- a/src/coreclr/jit/emitfmtswasm.h
+++ b/src/coreclr/jit/emitfmtswasm.h
@@ -26,7 +26,10 @@ enum ID_OPS
 //                  (unused)
 //////////////////////////////////////////////////////////////////////////////
 
-IF_DEF(NONE, IS_NONE, NONE)
+IF_DEF(NONE,    IS_NONE, NONE)
+IF_DEF(OPCODE,  IS_NONE, NONE) // <opcode>
+IF_DEF(ULEB128, IS_NONE, NONE) // <opcode> <ULEB128 immediate>
+IF_DEF(MEMARG,  IS_NONE, NONE) // <opcode> <memarg> (<align> <offset>)
 
 #undef IF_DEF
 #endif // !DEFINE_ID_OPS

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -6,22 +6,58 @@
 #pragma hdrstop
 #endif
 
+#include "codegen.h"
+
 // clang-format off
 /*static*/ const BYTE CodeGenInterface::instInfo[] =
 {
-    #define INST(id, nm, info, opcode) info,
+    #define INST(id, nm, info, fmt, opcode) info,
+    #include "instrs.h"
+};
+
+static const uint8_t insOpcodes[]
+{
+    #define INST(id, nm, info, fmt, opcode) static_cast<uint8_t>(opcode),
     #include "instrs.h"
 };
 // clang-format on
 
 void emitter::emitIns(instruction ins)
 {
-    NYI_WASM("emitIns");
+    instrDesc* id = emitNewInstrSmall(EA_8BYTE);
+    id->idIns(ins);
+    id->idInsFmt(IF_OPCODE);
+
+    dispIns(id);
+    appendToCurIG(id);
 }
 
-void emitter::emitIns_I(instruction ins, emitAttr attr, ssize_t imm)
+//------------------------------------------------------------------------
+// emitIns_I: Emit an instruction with an immediate operand.
+//
+void emitter::emitIns_I(instruction ins, emitAttr attr, target_ssize_t imm)
 {
-    NYI_WASM("emitIns_I");
+    instrDesc* id  = emitNewInstrSC(attr, imm);
+    insFormat  fmt = emitInsFormat(ins);
+
+    id->idIns(ins);
+    id->idInsFmt(fmt);
+
+    dispIns(id);
+    appendToCurIG(id);
+}
+
+//------------------------------------------------------------------------
+// emitIns_S: Emit a memory instruction with a stack-based address mode operand.
+//
+void emitter::emitIns_S(instruction ins, emitAttr attr, int varx, int offs)
+{
+    bool FPBased;
+    int  lclOffset = emitComp->lvaFrameAddress(varx, &FPBased);
+    int  offset    = lclOffset + offs;
+    noway_assert(offset >= 0); // WASM address modes are unsigned.
+
+    emitIns_I(ins, attr, offset);
 }
 
 void emitter::emitIns_R(instruction ins, emitAttr attr, regNumber reg)
@@ -55,10 +91,78 @@ bool emitter::emitInsIsStore(instruction ins)
     return false;
 }
 
+emitter::insFormat emitter::emitInsFormat(instruction ins)
+{
+    // clang-format off
+    const static insFormat insFormats[] =
+    {
+        #define INST(id, nm, info, fmt, opcode) fmt,
+        #include "instrs.h"
+    };
+    // clang-format on
+
+    assert(ins < ArrLen(insFormats));
+    assert((insFormats[ins] != IF_NONE));
+    return insFormats[ins];
+}
+
+static unsigned GetInsOpcode(instruction ins)
+{
+    assert(ins < ArrLen(insOpcodes));
+    return insOpcodes[ins];
+}
+
 size_t emitter::emitSizeOfInsDsc(instrDesc* id) const
 {
-    NYI_WASM("emitSizeOfInsDsc"); // Note this should return the size of the "id" structure itself.
-    return 0;
+    if (emitIsSmallInsDsc(id))
+        return SMALL_IDSC_SIZE;
+
+    if (id->idIsLargeCns())
+    {
+        assert(!id->idIsLargeDsp());
+        assert(!id->idIsLargeCall());
+        return sizeof(instrDescCns);
+    }
+    return sizeof(instrDesc);
+}
+
+static unsigned SizeOfULEB128(uint64_t value)
+{
+    // bits_to_encode = (data != 0) ? 64 - CLZ(x) : 1 = 64 - CLZ(data | 1)
+    // bytes = ceil(bits_to_encode / 7.0);            = (6 + bits_to_encode) / 7
+    unsigned x = 6 + 64 - (unsigned)BitOperations::LeadingZeroCount(value | 1UL);
+    // Division by 7 is done by (x * 37) >> 8 where 37 = ceil(256 / 7).
+    // This works for 0 <= x < 256 / (7 * 37 - 256), i.e. 0 <= x <= 85.
+    return (x * 37) >> 8;
+}
+
+unsigned emitter::instrDesc::idCodeSize() const
+{
+#ifdef TARGET_WASM32
+    static const unsigned PADDED_RELOC_SIZE = 5;
+#else
+#error WASM64
+#endif
+
+    // Currently, all our instructions have 1 byte opcode.
+    unsigned size = 1;
+    assert(FitsIn<uint8_t>(GetInsOpcode(idIns())));
+    switch (idInsFmt())
+    {
+        case IF_OPCODE:
+            break;
+        case IF_ULEB128:
+            // TODO-WASM: handle relocs here.
+            size += idIsCnsReloc() ? PADDED_RELOC_SIZE : SizeOfULEB128(static_cast<target_size_t>(emitGetInsSC(this)));
+            break;
+        case IF_MEMARG:
+            size += 1; // The alignment hint byte.
+            size += idIsCnsReloc() ? PADDED_RELOC_SIZE : SizeOfULEB128(static_cast<target_size_t>(emitGetInsSC(this)));
+            break;
+        default:
+            unreached();
+    }
+    return size;
 }
 
 void emitter::emitSetShortJump(instrDescJmp* id)
@@ -72,10 +176,131 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     return 0;
 }
 
+//--------------------------------------------------------------------
+// emitDispIns: Dump the given instruction to jitstdout.
+//
+// Arguments:
+//   id     - The instruction
+//   isNew  - Whether the instruction is newly generated (before encoding).
+//   doffs  - If true, always display the passed-in offset.
+//   asmfm  - Whether the instruction should be displayed in assembly format.
+//            If false some additional information may be printed for the instruction.
+//   offset - The offset of the instruction. Only displayed if doffs is true or if !isNew && !asmfm.
+//   code   - Pointer to the actual code, used for displaying the address and encoded bytes if turned on.
+//   sz     - The size of the instruction, used to display the encoded bytes.
+//   ig     - The instruction group containing the instruction.
+//
 void emitter::emitDispIns(
     instrDesc* id, bool isNew, bool doffs, bool asmfm, unsigned offset, BYTE* pCode, size_t sz, insGroup* ig)
 {
-    NYI_WASM("emitDispIns");
+#ifdef DEBUG
+    if (EMITVERBOSE)
+    {
+        unsigned idNum = id->idDebugOnlyInfo()->idNum;
+        printf("IN%04x: ", idNum);
+    }
+#endif
+
+    if (pCode == nullptr)
+    {
+        sz = 0;
+    }
+
+    if (!isNew && !asmfm && sz)
+    {
+        doffs = true;
+    }
+
+    // Display the instruction address.
+    emitDispInsAddr(pCode);
+
+    // Display the instruction offset.
+    emitDispInsOffs(offset, doffs);
+
+    BYTE* pCodeRW = nullptr;
+    if (pCode != nullptr)
+    {
+        /* Display the instruction hex code */
+        assert(((pCode >= emitCodeBlock) && (pCode < emitCodeBlock + emitTotalHotCodeSize)) ||
+               ((pCode >= emitColdCodeBlock) && (pCode < emitColdCodeBlock + emitTotalColdCodeSize)));
+
+        pCodeRW = pCode + writeableOffset;
+    }
+
+    emitDispInsHex(id, pCodeRW, sz);
+
+    printf("      ");
+
+    instruction ins = id->idIns();
+    insFormat   fmt = id->idInsFmt();
+
+    emitDispInst(ins);
+
+    // The reference for the following style of display is wasm-objdump output.
+    //
+    switch (fmt)
+    {
+        case IF_OPCODE:
+            break;
+
+        case IF_ULEB128:
+        {
+            target_size_t imm = emitGetInsSC(id);
+            printf(" %u", imm);
+        }
+        break;
+
+        case IF_MEMARG:
+        {
+            // TODO-WASM: decide what our strategy for alignment hints is and display these accordingly.
+            unsigned      log2align = 1;
+            target_size_t offset    = emitGetInsSC(id);
+            printf(" %u %u", log2align, offset);
+        }
+        break;
+
+        default:
+            unreached();
+    }
+
+    printf("\n");
+}
+
+//--------------------------------------------------------------------
+// emitDispInst: Display the instruction name.
+//
+void emitter::emitDispInst(instruction ins)
+{
+    const char* instName = codeGen->genInsName(ins);
+    printf("%s", instName);
+}
+
+//--------------------------------------------------------------------
+// emitDispInsHex: Display (optionally) the instruction encoding in hex.
+//
+void emitter::emitDispInsHex(instrDesc* id, BYTE* code, size_t sz)
+{
+    if (!emitComp->opts.disCodeBytes)
+    {
+        return;
+    }
+
+    // We do not display the instruction hex if we want diff-able disassembly
+    if (!emitComp->opts.disDiffable && (sz != 0))
+    {
+        static const int PAD_WIDTH = 28; // From wasm-objdump output.
+
+        int length = 0;
+        for (size_t i = 0; i < sz; i++)
+        {
+            length += printf(" %02X", code[i]);
+        }
+        if (length < PAD_WIDTH)
+        {
+            printf("%*c", PAD_WIDTH - length, ' ');
+        }
+        printf(" | ");
+    }
 }
 
 #if defined(DEBUG) || defined(LATE_DISASM)
@@ -89,6 +314,5 @@ emitter::insExecutionCharacteristics emitter::getInsExecutionCharacteristics(ins
 #ifdef DEBUG
 void emitter::emitInsSanityCheck(instrDesc* id)
 {
-    NYI_WASM("emitInsSanityCheck");
 }
 #endif // DEBUG

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -152,7 +152,6 @@ unsigned emitter::instrDesc::idCodeSize() const
         case IF_OPCODE:
             break;
         case IF_ULEB128:
-            // TODO-WASM: handle relocs here.
             size += idIsCnsReloc() ? PADDED_RELOC_SIZE : SizeOfULEB128(static_cast<target_size_t>(emitGetInsSC(this)));
             break;
         case IF_MEMARG:

--- a/src/coreclr/jit/emitwasm.h
+++ b/src/coreclr/jit/emitwasm.h
@@ -9,13 +9,16 @@
 void getInsSveExecutionCharacteristics(instrDesc* id, insExecutionCharacteristics& result);
 #endif // defined(DEBUG) || defined(LATE_DISASM)
 
+void emitDispInst(instruction ins);
+
 /************************************************************************/
 /*           The public entry points to output instructions             */
 /************************************************************************/
 
 public:
 void emitIns(instruction ins);
-void emitIns_I(instruction ins, emitAttr attr, ssize_t imm);
+void emitIns_I(instruction ins, emitAttr attr, target_ssize_t imm);
+void emitIns_S(instruction ins, emitAttr attr, int varx, int offs);
 void emitIns_R(instruction ins, emitAttr attr, regNumber reg);
 
 void emitIns_R_I(instruction ins, emitAttr attr, regNumber reg, ssize_t imm);
@@ -46,3 +49,5 @@ instrDesc* emitNewInstrCallInd(int              argCnt,
 
 private:
 bool emitInsIsStore(instruction ins);
+
+insFormat emitInsFormat(instruction ins);

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -86,7 +86,7 @@ const char* CodeGen::genInsName(instruction ins)
         #include "instrs.h"
 
 #elif defined(TARGET_WASM)
-        #define INST(id, nm, info, opcode) nm,
+        #define INST(id, nm, info, fmt, opcode) nm,
         #include "instrs.h"
 
 #else
@@ -2178,6 +2178,15 @@ instruction CodeGenInterface::ins_Load(var_types srcType, bool aligned /*=false*
         else
         {
             ins = INS_ld; // default ld.
+        }
+#elif defined(TARGET_WASM)
+        switch (srcType)
+        {
+            case TYP_INT:
+                ins = INS_i32_load;
+                break;
+            default:
+                NYI_WASM("ins_Load");
         }
 #else
         NYI("ins_Load");

--- a/src/coreclr/jit/instr.h
+++ b/src/coreclr/jit/instr.h
@@ -77,7 +77,7 @@ enum instruction : uint32_t
 
     INS_lea,   // Not a real instruction. It is used for load the address of stack locals
 #elif defined(TARGET_WASM)
-    #define INST(id, nm, info, opcode) INS_##id,
+    #define INST(id, nm, info, fmt, opcode) INS_##id,
     #include "instrs.h"
 
 #else

--- a/src/coreclr/jit/instrswasm.h
+++ b/src/coreclr/jit/instrswasm.h
@@ -7,6 +7,7 @@
  *          id          -- the enum name for the instruction
  *          nm          -- textual name (for assembly display)
  *          info        -- miscellaneous instruction info
+ *          fmt         -- instruction format
  *          opcode      -- encoding (modulo operands)
  *
  ******************************************************************************/

--- a/src/coreclr/jit/instrswasm.h
+++ b/src/coreclr/jit/instrswasm.h
@@ -7,7 +7,7 @@
  *          id          -- the enum name for the instruction
  *          nm          -- textual name (for assembly display)
  *          info        -- miscellaneous instruction info
- *          encode      -- encoding (modulo operands)
+ *          opcode      -- encoding (modulo operands)
  *
  ******************************************************************************/
 
@@ -22,11 +22,13 @@
 // TODO-WASM: fill out with more instructions (and everything else needed).
 //
 // clang-format off
-INST(invalid,     "INVALID",     0, BAD_CODE)
-INST(unreachable, "unreachable", 0, 0x00)
-INST(nop,         "nop",         0, 0x01)
-INST(br,          "br",          0, 0x0C)
-INST(i32_add,     "i32.add",     0, 0x6a)
+INST(invalid,     "INVALID",     0, IF_NONE,    BAD_CODE)
+INST(unreachable, "unreachable", 0, IF_OPCODE,  0x00)
+INST(nop,         "nop",         0, IF_OPCODE,  0x01)
+INST(br,          "br",          0, IF_ULEB128, 0x0C)
+INST(local_get,   "local.get",   0, IF_ULEB128, 0x20)
+INST(i32_load,    "i32.load",    0, IF_MEMARG,  0x28)
+INST(i32_add,     "i32.add",     0, IF_OPCODE,  0x6a)
 // clang-format on
 
 #undef INST

--- a/src/coreclr/jit/registeropswasm.cpp
+++ b/src/coreclr/jit/registeropswasm.cpp
@@ -81,6 +81,20 @@ unsigned UnpackWasmReg(regNumber reg, WasmValueType* pType)
     return regValue & ~WASM_REG_TYPE_MASK;
 }
 
+//------------------------------------------------------------------------
+// UnpackWasmReg: Extract the WASM local's index out of a register
+//
+// Arguments:
+//    reg   - The register number representing '(index, type)'
+//
+// Return Value:
+//    The index represented by 'reg'.
+//
+unsigned WasmRegToIndex(regNumber reg)
+{
+    return UnpackWasmReg(reg);
+}
+
 bool genIsValidReg(regNumber reg)
 {
     WasmValueType wasmType;

--- a/src/coreclr/jit/registeropswasm.h
+++ b/src/coreclr/jit/registeropswasm.h
@@ -19,4 +19,5 @@ enum class WasmValueType : unsigned
 
 regNumber MakeWasmReg(unsigned index, var_types type);
 unsigned  UnpackWasmReg(regNumber reg, WasmValueType* pType = nullptr);
+unsigned  WasmRegToIndex(regNumber reg);
 bool      genIsValidReg(regNumber reg);

--- a/src/coreclr/jit/regset.cpp
+++ b/src/coreclr/jit/regset.cpp
@@ -443,7 +443,6 @@ void RegSet::rsSpillTree(regNumber reg, GenTree* tree, unsigned regIdx /* =0 */)
         tree->SetRegSpillFlagByIdx(regFlags, regIdx);
     }
 }
-#endif // HAS_FIXED_REGISTER_SET
 
 #if defined(TARGET_X86)
 /*****************************************************************************
@@ -568,6 +567,7 @@ void RegSet::rsMarkSpill(GenTree* tree, regNumber reg)
 {
     tree->gtFlags |= GTF_SPILLED;
 }
+#endif // HAS_FIXED_REGISTER_SET
 
 /*****************************************************************************/
 
@@ -894,60 +894,6 @@ bool RegSet::tmpAllFree() const
 }
 
 #endif // DEBUG
-
-/*
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XX                                                                           XX
-XX  Register-related utility functions                                       XX
-XX                                                                           XX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-*/
-
-/*****************************************************************************
- *
- *  Given a register that is an argument register
- *   returns the next argument register
- *
- *  Note: that this method will return a non arg register
- *   when given REG_ARG_LAST
- *
- */
-
-regNumber genRegArgNext(regNumber argReg)
-{
-    assert(isValidIntArgReg(argReg, CorInfoCallConvExtension::Managed) || isValidFloatArgReg(argReg));
-
-    switch (argReg)
-    {
-
-#ifdef TARGET_AMD64
-#ifdef UNIX_AMD64_ABI
-
-        // Linux x64 ABI: REG_RDI, REG_RSI, REG_RDX, REG_RCX, REG_R8, REG_R9
-        case REG_ARG_0:       // REG_RDI
-            return REG_ARG_1; // REG_RSI
-        case REG_ARG_1:       // REG_RSI
-            return REG_ARG_2; // REG_RDX
-        case REG_ARG_2:       // REG_RDX
-            return REG_ARG_3; // REG_RCX
-        case REG_ARG_3:       // REG_RCX
-            return REG_ARG_4; // REG_R8
-
-#else // !UNIX_AMD64_ABI
-
-        // Windows x64 ABI: REG_RCX, REG_RDX, REG_R8, REG_R9
-        case REG_ARG_1:       // REG_RDX
-            return REG_ARG_2; // REG_R8
-
-#endif // !UNIX_AMD64_ABI
-#endif // TARGET_AMD64
-
-        default:
-            return REG_NEXT(argReg);
-    }
-}
 
 /*****************************************************************************
  *

--- a/src/coreclr/jit/target.h
+++ b/src/coreclr/jit/target.h
@@ -877,13 +877,6 @@ inline bool isValidIntArgReg(regNumber reg, CorInfoCallConvExtension callConv)
 }
 
 //-------------------------------------------------------------------------------------------
-// genRegArgNext:
-//     Given a register that is an integer or floating point argument register
-//     returns the next argument register
-//
-regNumber genRegArgNext(regNumber argReg);
-
-//-------------------------------------------------------------------------------------------
 // isValidFloatArgReg:
 //     Returns true if the register is a valid floating-point argument register
 //


### PR DESCRIPTION
Pulling on the thread of NYIs a bit further. We now have this for my `Problem(int a, int b) => a + b;`:
```cs
Scope info: begin block BB01, IL range [000..004)
Added IP mapping: 0x0000 STACK_EMPTY (G_M56520_IG02,ins#0,ofs#0) label
Generating:                [000004] -----------                            IL_OFFSET void   INLRT @ 0x000[E--]
Generating: N001 (  1,  1) [000000] -----+-----                    t0 =    LCL_VAR   int    V00 arg0         u:1 (last use) $80
Mapped BB01 to G_M56520_IG02
IN0001:             i32.load 1 4
Debug: Closing V00 debug range.
                                                        Live vars after [000000]: {V00 V01} -{V00} => {V01}
Generating: N002 (  1,  1) [000001] -----+-----                    t1 =    LCL_VAR   int    V01 arg1         u:1 (last use) $81
IN0002:             i32.load 1 0
Debug: Closing V01 debug range.
                                                        Live vars after [000001]: {V01} -{V01} => {}
                                                                        /--*  t0     int
                                                                        +--*  t1     int
Generating: N003 (  3,  3) [000002] -----+-----                    t2 = *  ADD       int    $100
IN0003:             i32.add
                                                                        /--*  t2     int
Generating: N004 (  4,  4) [000003] -----+-----                         *  RETURN    int    $VN.Void
```