### PR TITLE
Fix typo from `unit` to `uint`

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/LengthBucketsFrozenDictionary.AlternateLookup.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/LengthBucketsFrozenDictionary.AlternateLookup.cs
@@ -49,7 +49,7 @@ namespace System.Collections.Frozen
                     }
                     else
                     {
-                        // -1 is used to indicate a null, when it's casted to unit it becomes > keys.Length
+                        // -1 is used to indicate a null, when it's casted to uint it becomes > keys.Length
                         break;
                     }
                 }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/LengthBucketsFrozenDictionary.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/LengthBucketsFrozenDictionary.cs
@@ -81,7 +81,7 @@ namespace System.Collections.Frozen
                         }
                         else
                         {
-                            // -1 is used to indicate a null, when it's casted to unit it becomes > keys.Length
+                            // -1 is used to indicate a null, when it's casted to uint it becomes > keys.Length
                             break;
                         }
                     }
@@ -100,7 +100,7 @@ namespace System.Collections.Frozen
                         }
                         else
                         {
-                            // -1 is used to indicate a null, when it's casted to unit it becomes > keys.Length
+                            // -1 is used to indicate a null, when it's casted to uint it becomes > keys.Length
                             break;
                         }
                     }

--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/LengthBucketsFrozenSet.AlternateLookup.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/String/LengthBucketsFrozenSet.AlternateLookup.cs
@@ -48,7 +48,7 @@ namespace System.Collections.Frozen
                     }
                     else
                     {
-                        // -1 is used to indicate a null, when it's casted to unit it becomes > items.Length
+                        // -1 is used to indicate a null, when it's casted to uint it becomes > items.Length
                         break;
                     }
                 }


### PR DESCRIPTION
Fix typo from `unit` to `uint` in comment.
 