### PR TITLE
Fix typo `unit` -> `uint`

### DIFF
--- a/src/tests/Loader/classloader/generics/Variance/IL/vsw543506.cs
+++ b/src/tests/Loader/classloader/generics/Variance/IL/vsw543506.cs
@@ -154,7 +154,7 @@ public class Test_vsw543506
 
 
 
-		// IPos<unit> --> IPos<int>
+		// IPos<uint> --> IPos<int>
 	    	IsInstShouldFail<IPos<int>>(cui);
 
 		// IPos<IComparable> --> IPos<uint>


### PR DESCRIPTION
Follow-up: https://github.com/dotnet/runtime/pull/121884#issuecomment-3563916686