### PR TITLE
[release/10.0] Add support for `Visual Studio 2026` CMake generator for `gen-buildsys.cmd`

### DIFF
--- a/eng/native/gen-buildsys.cmd
+++ b/eng/native/gen-buildsys.cmd
@@ -26,6 +26,7 @@ if /i "%__Ninja%" == "1" (
     set __CmakeGenerator=Ninja
 ) else (
     if /i NOT "%__Arch%" == "wasm" (
+        if /i "%__VSVersion%" == "18.0" (set __CmakeGenerator=%__CmakeGenerator% 18 2026)
         if /i "%__VSVersion%" == "17.0" (set __CmakeGenerator=%__CmakeGenerator% 17 2022)
 
         if /i "%__Arch%" == "x64" (set __ExtraCmakeParams=%__ExtraCmakeParams% -A x64)


### PR DESCRIPTION
Backport of #120580 to release/10.0

## Customer Impact

- [x] Customer reported
- [ ] Found internally

The repo cmake msbuild generator is missing support for VS 2026 in release/10.0 branch. It makes it hard to work with the repo C/C++ code in VS 2026.

## Regression

- [ ] Yes
- [x] No

## Testing

Verified that gen-buildsys.cmd selects the Visual Studio 18 2026 generator when %_VSVersion% is 18.0.

## Risk

Low. No impact to skipping binaries.

----

Adds support for the `Visual Studio 18 2026` CMake generator in `eng/native/gen-buildsys.cmd`.

- Handles `%_VSVersion% == "18.0"` similarly to the existing Visual Studio 2022 case.
- Does not change behavior for other Visual Studio versions.

Testing:
- Verified that `gen-buildsys.cmd` selects the `Visual Studio 18 2026` generator when `%_VSVersion%` is `18.0`.
