### PR TITLE
Switch from macOS-13 to macOS-latest image

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -174,7 +174,7 @@ jobs:
 
         # OSX Public Build Pool (we don't have on-prem OSX BuildPool).
         ${{ if and(in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator'), eq(variables['System.TeamProject'], 'public')) }}:
-          vmImage: 'macos-13'
+          vmImage: 'macOS-latest'
 
         # Official build OSX pool
         ${{ if and(in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator'), ne(variables['System.TeamProject'], 'public')) }}:

--- a/eng/pipelines/performance/templates/perf-bdn-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-bdn-build-jobs.yml
@@ -23,7 +23,7 @@ jobs:
         nameSuffix: PerfBDNApp
         isOfficialBuild: false
         pool:
-          vmImage: 'macos-13'
+          vmImage: 'macOS-latest'
         postBuildSteps:
           - template: /eng/pipelines/performance/templates/build-perf-bdn-app.yml
             parameters:


### PR DESCRIPTION
macOS-13 image is being depracated, switch to macOS-latest (macOS-15 currently), see https://aka.ms/azdo-macOS.

Or we can switch to macOS-14 if we want to test on the oldest support macOS version...