### PR TITLE
Improve exception message when passing directory to ZipFile methods

### DIFF
--- a/src/libraries/System.IO.Compression.ZipFile/src/Resources/Strings.resx
+++ b/src/libraries/System.IO.Compression.ZipFile/src/Resources/Strings.resx
@@ -100,6 +100,9 @@
   <data name="UnauthorizedAccess_IODenied_Path" xml:space="preserve">
     <value>Access to the path '{0}' is denied.</value>
   </data>
+  <data name="IO_DirectoryNotAllowed" xml:space="preserve">
+    <value>The specified path '{0}' is a directory, which is not allowed in this operation.</value>
+  </data>
   <data name="ZipUnsupportedFile" xml:space="preserve">
     <value>The file type of '{0}' is not supported for zip archiving.</value>
   </data>

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs
@@ -482,11 +482,6 @@ namespace System.IO.Compression
                 // If we get UnauthorizedAccessException and the path is a directory, provide a clearer error message
                 throw new UnauthorizedAccessException(SR.Format(SR.IO_DirectoryNotAllowed, archiveFileName));
             }
-            catch (IOException) when (mode == ZipArchiveMode.Create && Directory.Exists(archiveFileName))
-            {
-                // If we get IOException in Create mode and the path is a directory, provide a clearer error message
-                throw new IOException(SR.Format(SR.IO_DirectoryNotAllowed, archiveFileName));
-            }
         }
 
         private static (string, string) GetFullPathsForDoCreateFromDirectory(string sourceDirectoryName, string destinationArchiveFileName)

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs
@@ -473,7 +473,15 @@ namespace System.IO.Compression
                 _ => throw new ArgumentOutOfRangeException(nameof(mode)),
             };
 
-            return new FileStream(archiveFileName, fileMode, access, fileShare, bufferSize: FileStreamBufferSize, useAsync);
+            try
+            {
+                return new FileStream(archiveFileName, fileMode, access, fileShare, bufferSize: FileStreamBufferSize, useAsync);
+            }
+            catch (UnauthorizedAccessException) when (Directory.Exists(archiveFileName))
+            {
+                // If we get UnauthorizedAccessException and the path is a directory, provide a clearer error message
+                throw new UnauthorizedAccessException(SR.Format(SR.IO_DirectoryNotAllowed, archiveFileName));
+            }
         }
 
         private static (string, string) GetFullPathsForDoCreateFromDirectory(string sourceDirectoryName, string destinationArchiveFileName)

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs
@@ -482,6 +482,11 @@ namespace System.IO.Compression
                 // If we get UnauthorizedAccessException and the path is a directory, provide a clearer error message
                 throw new UnauthorizedAccessException(SR.Format(SR.IO_DirectoryNotAllowed, archiveFileName));
             }
+            catch (IOException) when (mode == ZipArchiveMode.Create && Directory.Exists(archiveFileName))
+            {
+                // If we get IOException in Create mode and the path is a directory, provide a clearer error message
+                throw new IOException(SR.Format(SR.IO_DirectoryNotAllowed, archiveFileName));
+            }
         }
 
         private static (string, string) GetFullPathsForDoCreateFromDirectory(string sourceDirectoryName, string destinationArchiveFileName)

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.Create.cs
@@ -463,7 +463,8 @@ namespace System.IO.Compression
 
         private static FileStream GetFileStreamForOpen(ZipArchiveMode mode, string archiveFileName, bool useAsync)
         {
-            // Check if the path is a directory before attempting to open.
+            // Check if the path is a directory before attempting to open,
+            // to match the UnauthorizedAccessException thrown by FileStream's ctor.
             if (Directory.Exists(archiveFileName))
             {
                 throw new UnauthorizedAccessException(SR.Format(SR.IO_DirectoryNotAllowed, archiveFileName));

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
@@ -54,7 +54,6 @@ namespace System.IO.Compression.Tests
             Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
-
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
         public async Task ExtractToDirectoryUnicode(bool async)

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
@@ -44,6 +44,19 @@ namespace System.IO.Compression.Tests
 
         [Theory]
         [MemberData(nameof(Get_Booleans_Data))]
+        public async Task ExtractToDirectory_PassDirectoryAsArchiveFile_ThrowsUnauthorizedAccessException(bool async)
+        {
+            string directoryPath = GetTestFilePath();
+            Directory.CreateDirectory(directoryPath);
+
+            UnauthorizedAccessException ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+                CallZipFileExtractToDirectory(async, directoryPath, GetTestFilePath()));
+            Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
         public async Task ExtractToDirectoryUnicode(bool async)
         {
             string zipFileName = zfile("unicode.zip");

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Extract.cs
@@ -49,9 +49,8 @@ namespace System.IO.Compression.Tests
             string directoryPath = GetTestFilePath();
             Directory.CreateDirectory(directoryPath);
 
-            UnauthorizedAccessException ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
+            await Assert.ThrowsAsync<UnauthorizedAccessException>(() =>
                 CallZipFileExtractToDirectory(async, directoryPath, GetTestFilePath()));
-            Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [Theory]

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Open.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Open.cs
@@ -35,6 +35,15 @@ public class ZipFile_Open : ZipFileTestBase
     }
 
     [Fact]
+    public void Open_PassDirectory_CreateMode_ThrowsIOException()
+    {
+        string directoryPath = GetTestFilePath();
+        Directory.CreateDirectory(directoryPath);
+
+        Assert.Throws<IOException>(() => ZipFile.Open(directoryPath, ZipArchiveMode.Create));
+    }
+
+    [Fact]
     public async Task OpenAsync_PassDirectory_ThrowsUnauthorizedAccessException()
     {
         string directoryPath = GetTestFilePath();
@@ -48,6 +57,15 @@ public class ZipFile_Open : ZipFileTestBase
 
         ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() => ZipFile.OpenAsync(directoryPath, ZipArchiveMode.Update, default));
         Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task OpenAsync_PassDirectory_CreateMode_ThrowsIOException()
+    {
+        string directoryPath = GetTestFilePath();
+        Directory.CreateDirectory(directoryPath);
+
+        await Assert.ThrowsAsync<IOException>(() => ZipFile.OpenAsync(directoryPath, ZipArchiveMode.Create, default));
     }
 
     [Fact]

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Open.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Open.cs
@@ -18,7 +18,7 @@ public class ZipFile_Open : ZipFileTestBase
         return Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => CallZipFileOpen(async, "bad file", (ZipArchiveMode)(10)));
     }
 
-     [Fact]
+    [Fact]
     public void Open_PassDirectory_ThrowsUnauthorizedAccessException()
     {
         string directoryPath = GetTestFilePath();

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Open.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Open.cs
@@ -26,16 +26,8 @@ public class ZipFile_Open : ZipFileTestBase
 
         Assert.Throws<UnauthorizedAccessException>(() => ZipFile.Open(directoryPath, ZipArchiveMode.Read));
         Assert.Throws<UnauthorizedAccessException>(() => ZipFile.OpenRead(directoryPath));
+        Assert.Throws<UnauthorizedAccessException>(() => ZipFile.Open(directoryPath, ZipArchiveMode.Create));
         Assert.Throws<UnauthorizedAccessException>(() => ZipFile.Open(directoryPath, ZipArchiveMode.Update));
-    }
-
-    [Fact]
-    public void Open_PassDirectory_CreateMode_ThrowsIOException()
-    {
-        string directoryPath = GetTestFilePath();
-        Directory.CreateDirectory(directoryPath);
-
-        Assert.Throws<IOException>(() => ZipFile.Open(directoryPath, ZipArchiveMode.Create));
     }
 
     [Fact]
@@ -46,16 +38,8 @@ public class ZipFile_Open : ZipFileTestBase
 
         await Assert.ThrowsAsync<UnauthorizedAccessException>(() => ZipFile.OpenAsync(directoryPath, ZipArchiveMode.Read, default));
         await Assert.ThrowsAsync<UnauthorizedAccessException>(() => ZipFile.OpenReadAsync(directoryPath, default));
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => ZipFile.OpenAsync(directoryPath, ZipArchiveMode.Create, default));
         await Assert.ThrowsAsync<UnauthorizedAccessException>(() => ZipFile.OpenAsync(directoryPath, ZipArchiveMode.Update, default));
-    }
-
-    [Fact]
-    public async Task OpenAsync_PassDirectory_CreateMode_ThrowsIOException()
-    {
-        string directoryPath = GetTestFilePath();
-        Directory.CreateDirectory(directoryPath);
-
-        await Assert.ThrowsAsync<IOException>(() => ZipFile.OpenAsync(directoryPath, ZipArchiveMode.Create, default));
     }
 
     [Fact]

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Open.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Open.cs
@@ -24,14 +24,9 @@ public class ZipFile_Open : ZipFileTestBase
         string directoryPath = GetTestFilePath();
         Directory.CreateDirectory(directoryPath);
 
-        UnauthorizedAccessException ex = Assert.Throws<UnauthorizedAccessException>(() => ZipFile.Open(directoryPath, ZipArchiveMode.Read));
-        Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
-
-        ex = Assert.Throws<UnauthorizedAccessException>(() => ZipFile.OpenRead(directoryPath));
-        Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
-
-        ex = Assert.Throws<UnauthorizedAccessException>(() => ZipFile.Open(directoryPath, ZipArchiveMode.Update));
-        Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Throws<UnauthorizedAccessException>(() => ZipFile.Open(directoryPath, ZipArchiveMode.Read));
+        Assert.Throws<UnauthorizedAccessException>(() => ZipFile.OpenRead(directoryPath));
+        Assert.Throws<UnauthorizedAccessException>(() => ZipFile.Open(directoryPath, ZipArchiveMode.Update));
     }
 
     [Fact]
@@ -49,14 +44,9 @@ public class ZipFile_Open : ZipFileTestBase
         string directoryPath = GetTestFilePath();
         Directory.CreateDirectory(directoryPath);
 
-        UnauthorizedAccessException ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() => ZipFile.OpenAsync(directoryPath, ZipArchiveMode.Read, default));
-        Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
-
-        ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() => ZipFile.OpenReadAsync(directoryPath, default));
-        Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
-
-        ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() => ZipFile.OpenAsync(directoryPath, ZipArchiveMode.Update, default));
-        Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => ZipFile.OpenAsync(directoryPath, ZipArchiveMode.Read, default));
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => ZipFile.OpenReadAsync(directoryPath, default));
+        await Assert.ThrowsAsync<UnauthorizedAccessException>(() => ZipFile.OpenAsync(directoryPath, ZipArchiveMode.Update, default));
     }
 
     [Fact]

--- a/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Open.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/tests/ZipFile.Open.cs
@@ -18,6 +18,38 @@ public class ZipFile_Open : ZipFileTestBase
         return Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => CallZipFileOpen(async, "bad file", (ZipArchiveMode)(10)));
     }
 
+     [Fact]
+    public void Open_PassDirectory_ThrowsUnauthorizedAccessException()
+    {
+        string directoryPath = GetTestFilePath();
+        Directory.CreateDirectory(directoryPath);
+
+        UnauthorizedAccessException ex = Assert.Throws<UnauthorizedAccessException>(() => ZipFile.Open(directoryPath, ZipArchiveMode.Read));
+        Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        ex = Assert.Throws<UnauthorizedAccessException>(() => ZipFile.OpenRead(directoryPath));
+        Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        ex = Assert.Throws<UnauthorizedAccessException>(() => ZipFile.Open(directoryPath, ZipArchiveMode.Update));
+        Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task OpenAsync_PassDirectory_ThrowsUnauthorizedAccessException()
+    {
+        string directoryPath = GetTestFilePath();
+        Directory.CreateDirectory(directoryPath);
+
+        UnauthorizedAccessException ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() => ZipFile.OpenAsync(directoryPath, ZipArchiveMode.Read, default));
+        Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() => ZipFile.OpenReadAsync(directoryPath, default));
+        Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
+
+        ex = await Assert.ThrowsAsync<UnauthorizedAccessException>(() => ZipFile.OpenAsync(directoryPath, ZipArchiveMode.Update, default));
+        Assert.Contains("directory", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void InvalidFiles()
     {


### PR DESCRIPTION
Fixes an issue where passing a directory path to `ZipFile` methods resulted in an unclear `UnauthorizedAccessException` without explaining that the problem was passing a directory instead of a file.

Modified `GetFileStreamForOpen()` to catch `UnauthorizedAccessException` when `FileStream` fails to open a directory, and re-throw with a clearer error message that explicitly states the path is a directory.

Fixes #100720 