### PR TITLE
Fix constrained call local exposure blocking escape analysis

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -6508,7 +6508,7 @@ GenTree* Compiler::impTransformThis(GenTree*                thisPtr,
             assert(genActualType(obj->gtType) == TYP_I_IMPL || obj->TypeIs(TYP_BYREF));
             CorInfoType constraintTyp = info.compCompHnd->asCorInfoType(pConstrainedResolvedToken->hClass);
 
-            obj = gtNewIndir(JITtype2varType(constraintTyp), obj);
+            obj = gtNewLoadValueNode(JITtype2varType(constraintTyp), nullptr, obj);
             return obj;
         }
 


### PR DESCRIPTION
Constrained calls on ref types currently emit trees like
```cs
--C-G------                         *  CALLV vt-ind int    System.Object:Equals(System.Object):bool:this
n---G------ this                    +--*  IND       ref
-----------                         |  \--*  LCL_ADDR  long   V06 tmp5         [+0]
----------- arg1                    \--*  LCL_VAR   ref    V04 tmp3
```
which blocks escape analysis due to the LCL_ADDR marking the local as escaped.
Using the helper to get this here instead:
```cs
--C-G------                         *  CALLV vt-ind int    System.Object:Equals(System.Object):bool:this
----------- this                    +--*  LCL_VAR   ref    V06 tmp5
----------- arg1                    \--*  LCL_VAR   ref    V04 tmp3
```
solves the issue.