### PR TITLE
Remove NetEventSource.WriteEvent and replace HexConverter.IsHexChar with public API

### DIFF
--- a/src/libraries/Common/src/System/Net/IPv6AddressHelper.Common.cs
+++ b/src/libraries/Common/src/System/Net/IPv6AddressHelper.Common.cs
@@ -136,9 +136,9 @@ namespace System.Net
             int i;
             for (i = start; i < end; ++i)
             {
-                int currentCh = IPv4AddressHelper.ToUShort(name[i]);
+                ushort currentCh = IPv4AddressHelper.ToUShort(name[i]);
 
-                if (HexConverter.IsHexChar(currentCh))
+                if (char.IsAsciiHexDigit((char)currentCh))
                 {
                     ++sequenceLength;
                     expectingNumber = false;
@@ -197,9 +197,7 @@ namespace System.Net
                                 i += 4;
                                 for (; i < end; i++)
                                 {
-                                    int ch = IPv4AddressHelper.ToUShort(name[i]);
-
-                                    if (!HexConverter.IsHexChar(ch))
+                                    if (!char.IsAsciiHexDigit((char)IPv4AddressHelper.ToUShort(name[i])))
                                     {
                                         return false;
                                     }

--- a/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.cs
+++ b/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.cs
@@ -46,7 +46,6 @@ namespace System.Net
 
         private const string MissingMember = "(?)";
         private const string NullInstance = "(null)";
-        private const string StaticMethodObject = "(static)";
         private const string NoParameters = "";
 
         private const int InfoEventId = 1;
@@ -188,39 +187,5 @@ namespace System.Net
 
         static partial void AdditionalCustomizedToString(object value, ref string? result);
         #endregion
-
-        [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern",
-                   Justification = EventSourceSuppressMessage)]
-        [NonEvent]
-        private unsafe void WriteEvent(int eventId, string? arg1, string? arg2, int arg3)
-        {
-            arg1 ??= "";
-            arg2 ??= "";
-
-            fixed (char* arg1Ptr = arg1)
-            fixed (char* arg2Ptr = arg2)
-            {
-                const int NumEventDatas = 3;
-                EventData* descrs = stackalloc EventData[NumEventDatas];
-
-                descrs[0] = new EventData
-                {
-                    DataPointer = (IntPtr)(arg1Ptr),
-                    Size = (arg1.Length + 1) * sizeof(char)
-                };
-                descrs[1] = new EventData
-                {
-                    DataPointer = (IntPtr)(arg2Ptr),
-                    Size = (arg2.Length + 1) * sizeof(char)
-                };
-                descrs[2] = new EventData
-                {
-                    DataPointer = (IntPtr)(&arg3),
-                    Size = sizeof(int)
-                };
-
-                WriteEventCore(eventId, NumEventDatas, descrs);
-            }
-        }
     }
 }


### PR DESCRIPTION
I'd be nice to get rid of HexConverter as a shared source and use public APIs.