### PR TITLE
[release/10.0] Fix source map URLs for .NET 10 VMR builds

### DIFF
--- a/src/mono/browser/runtime/rollup.config.js
+++ b/src/mono/browser/runtime/rollup.config.js
@@ -131,7 +131,7 @@ function sourcemapPathTransform (relativeSourcePath, sourcemapPath) {
             res = `file:///${sourcePath.replace(/\\/g, "/")}`;
         } else {
             relativeSourcePath = relativeSourcePath.substring(12);
-            res = `https://raw.githubusercontent.com/dotnet/runtime/${gitHash}/${relativeSourcePath}`;
+            res = `https://raw.githubusercontent.com/dotnet/dotnet/${gitHash}/src/runtime/${relativeSourcePath}`;
         }
         locationCache[relativeSourcePath] = res;
     }


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/121923

## Customer Impact

- [x] Customer reported: https://github.com/dotnet/runtime/issues/121804
- [ ] Found internally

.NET 10 builds from the VMR (dotnet/dotnet) instead of dotnet/runtime. Source maps generated during CI builds were pointing to the old repository, causing 404 errors when browser debuggers attempted to load TypeScript sources.

## Regression

- [X] Yes
- [ ] No

This regressed when the official runtime build moved to happen in the VMR.

## Testing

Local testing to make sure the correct URL is produced.

## Risk

Low. This only affects debugging scenarios.