### PR TITLE
[infra][iOS] Fully build smoke tests on azdo build images

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
@@ -119,7 +119,7 @@ jobs:
         value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
     jobParameters:
       testGroup: innerloop
-      nameSuffix: AllSubsets_NativeAOT
+      nameSuffix: AllSubsets_NativeAOT_Smoke
       buildArgs: --cross -s clr.alljits+clr.tools+clr.nativeaotruntime+clr.nativeaotlibs+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=- /p:BuildTestsOnHelix=true /p:UseNativeAOTRuntime=true /p:RunAOTCompilation=false /p:ContinuousIntegrationBuild=true
       timeoutInMinutes: 180
       # extra steps, run tests
@@ -190,7 +190,7 @@ jobs:
         value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'] ]
     jobParameters:
       testGroup: innerloop
-      nameSuffix: AllSubsets_CoreCLR
+      nameSuffix: AllSubsets_CoreCLR_Smoke
       buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=false /p:UseMonoRuntime=false /p:MonoForceInterpreter=false /p:BuildTestsOnHelix=false /p:UseNativeAOTRuntime=false /p:RunSmokeTestsOnly=true
       timeoutInMinutes: 120
       # extra steps, run tests

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
@@ -157,7 +157,7 @@ jobs:
         value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'] ]
     jobParameters:
       testGroup: innerloop
-      nameSuffix: AllSubsets_CoreCLR
+      nameSuffix: AllSubsets_CoreCLR_Smoke
       buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=false /p:UseMonoRuntime=false /p:MonoForceInterpreter=false /p:RunSmokeTestsOnly=true
       timeoutInMinutes: 120
       # extra steps, run tests

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-maccatalyst.yml
@@ -226,7 +226,7 @@ jobs:
         value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'] ]
     jobParameters:
       testGroup: innerloop
-      nameSuffix: AllSubsets_CoreCLR
+      nameSuffix: AllSubsets_CoreCLR_Smoke
       buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=false /p:UseMonoRuntime=false /p:MonoForceInterpreter=false /p:BuildTestsOnHelix=false /p:UseNativeAOTRuntime=false /p:RunSmokeTestsOnly=true
       timeoutInMinutes: 120
       # extra steps, run tests

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1041,6 +1041,7 @@ extends:
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
             # extra steps, run tests
+            # TODO: Re-enable build on helix https://github.com/dotnet/runtime/issues/121967
             postBuildSteps:
               - template: /eng/pipelines/libraries/helix.yml
                 parameters:

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1031,7 +1031,7 @@ extends:
           jobParameters:
             testGroup: innerloop
             nameSuffix: AllSubsets_Mono_Smoke
-            buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true /p:RunSmokeTestsOnly=true /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=false /p:EnableAggressiveTrimming=true
+            buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true /p:RunSmokeTestsOnly=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=false /p:EnableAggressiveTrimming=true
             timeoutInMinutes: 120
             condition: >-
               or(
@@ -1046,7 +1046,6 @@ extends:
                 parameters:
                   creator: dotnet-bot
                   testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-                  extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
                   condition: >-
                     or(
                     eq(variables['librariesContainsChange'], true),

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -944,7 +944,7 @@ extends:
               value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
           jobParameters:
             testGroup: innerloop
-            nameSuffix: AllSubsets_Mono
+            nameSuffix: AllSubsets_Mono_Smoke
             buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:EnableAdditionalTimezoneChecks=true
             timeoutInMinutes: 120
             condition: >-
@@ -986,7 +986,7 @@ extends:
               value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
           jobParameters:
             testGroup: innerloop
-            nameSuffix: AllSubsets_CoreCLR
+            nameSuffix: AllSubsets_CoreCLR_Smoke
             buildArgs: -s clr.runtime+clr.alljits+clr.corelib+clr.nativecorelib+clr.tools+clr.packages+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true
             timeoutInMinutes: 180
             condition: >-
@@ -1030,7 +1030,7 @@ extends:
               value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'] ]
           jobParameters:
             testGroup: innerloop
-            nameSuffix: AllSubsets_Mono
+            nameSuffix: AllSubsets_Mono_Smoke
             buildArgs: -s mono+libs+libs.tests+host+packs -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=true /p:RunSmokeTestsOnly=true /p:BuildTestsOnHelix=true /p:EnableAdditionalTimezoneChecks=true /p:UsePortableRuntimePack=false /p:EnableAggressiveTrimming=true
             timeoutInMinutes: 120
             condition: >-
@@ -1041,19 +1041,18 @@ extends:
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
             # extra steps, run tests
-            # Disable tests on ios/tvos - mono - https://github.com/dotnet/runtime/issues/121967
-            # postBuildSteps:
-            #   - template: /eng/pipelines/libraries/helix.yml
-            #     parameters:
-            #       creator: dotnet-bot
-            #       testRunNamePrefixSuffix: Mono_$(_BuildConfig)
-            #       extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
-            #       condition: >-
-            #         or(
-            #         eq(variables['librariesContainsChange'], true),
-            #         eq(variables['monoContainsChange'], true),
-            #         eq(variables['illinkContainsChange'], true),
-            #         eq(variables['isRollingBuild'], true))
+            postBuildSteps:
+              - template: /eng/pipelines/libraries/helix.yml
+                parameters:
+                  creator: dotnet-bot
+                  testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+                  extraHelixArguments: /p:NeedsToBuildAppsOnHelix=true
+                  condition: >-
+                    or(
+                    eq(variables['librariesContainsChange'], true),
+                    eq(variables['monoContainsChange'], true),
+                    eq(variables['illinkContainsChange'], true),
+                    eq(variables['isRollingBuild'], true))
 
       #
       # Build the whole product using CoreCLR and run functional tests
@@ -1076,7 +1075,7 @@ extends:
               value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_tools_illink.containsChange'] ]
           jobParameters:
             testGroup: innerloop
-            nameSuffix: AllSubsets_CoreCLR
+            nameSuffix: AllSubsets_CoreCLR_Smoke
             buildArgs: -s clr+clr.runtime+libs+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:DevTeamProvisioning=- /p:RunAOTCompilation=false /p:UseMonoRuntime=false /p:MonoForceInterpreter=false /p:BuildTestsOnHelix=false /p:UseNativeAOTRuntime=false /p:RunSmokeTestsOnly=true
             timeoutInMinutes: 120
             condition: >-
@@ -1119,7 +1118,7 @@ extends:
               value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'] ]
           jobParameters:
             testGroup: innerloop
-            nameSuffix: AllSubsets_NativeAOT
+            nameSuffix: AllSubsets_NativeAOT_Smoke
             buildArgs: --cross -s clr.alljits+clr.tools+clr.nativeaotruntime+clr.nativeaotlibs+libs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=- /p:BuildTestsOnHelix=true /p:UseNativeAOTRuntime=true /p:RunAOTCompilation=false /p:ContinuousIntegrationBuild=true
             timeoutInMinutes: 180
             condition: >-
@@ -1162,7 +1161,7 @@ extends:
               value: $[ stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
           jobParameters:
             testGroup: innerloop
-            nameSuffix: AllSubsets_Mono
+            nameSuffix: AllSubsets_Mono_Smoke
             buildArgs: -s mono+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true /p:RunSmokeTestsOnly=true /p:DevTeamProvisioning=adhoc /p:RunAOTCompilation=true /p:MonoForceInterpreter=true
             timeoutInMinutes: 180
             condition: >-

--- a/src/libraries/sendtohelix-mobile.targets
+++ b/src/libraries/sendtohelix-mobile.targets
@@ -109,6 +109,7 @@
         <!-- The sample's C# Main method returns 42 so it should be considered by xharness as a success -->
         <ExpectedExitCode>42</ExpectedExitCode>
         <TestTarget>$(AppleTestTarget)</TestTarget>
+        <CustomCommands>$(_XHarnessAppleCustomCommand)</CustomCommands>
       </XHarnessAppBundleToTest>
 
       <!-- To save on overall size, we compress each app after building. -->
@@ -120,6 +121,7 @@
         <!-- The sample's C# Main method returns 42 so it should be considered by xharness as a success -->
         <ExpectedExitCode>42</ExpectedExitCode>
         <TestTarget>$(AppleTestTarget)</TestTarget>
+        <CustomCommands>$(_XHarnessAppleCustomCommand)</CustomCommands>
       </XHarnessAppBundleToTest>
     </ItemGroup>
 

--- a/src/libraries/sendtohelix-mobile.targets
+++ b/src/libraries/sendtohelix-mobile.targets
@@ -86,7 +86,7 @@
 
     <ItemGroup Condition="'$(TargetsAppleMobile)' == 'true'">
       <!-- Create work items for test apps -->
-      <XHarnessAppBundleToTest
+      <XHarnessAppBundleToTest Condition="Exists('$(TestArchiveTestsRoot)')"
         Include="$([System.IO.Directory]::GetDirectories('$(TestArchiveTestsRoot)', '*.app', System.IO.SearchOption.AllDirectories))">
         <TestTarget>$(AppleTestTarget)</TestTarget>
         <TestTimeout>$(_workItemTimeout)</TestTimeout>
@@ -94,9 +94,9 @@
       </XHarnessAppBundleToTest>
 
       <!-- To save on overall size, we compress each app after building. -->
-      <XHarnessAppBundleToTest
+      <XHarnessAppBundleToTest Condition="Exists('$(TestArchiveTestsRoot)$(OSPlatformConfig)')"
         Include="$([System.IO.Directory]::GetFiles('$(TestArchiveTestsRoot)$(OSPlatformConfig)', '*.zip', System.IO.SearchOption.TopDirectoryOnly))"
-        Exclude="$([System.IO.Directory]::GetFiles('$(TestArchiveRoot)', 'xharness-app-payload*', System.IO.SearchOption.AllDirectories))">
+        Exclude="$([System.IO.Directory]::GetFiles('$(TestArchiveTestsRoot)', 'xharness-app-payload*', System.IO.SearchOption.AllDirectories))">
         <TestTarget>$(AppleTestTarget)</TestTarget>
         <TestTimeout>$(_workItemTimeout)</TestTimeout>
         <CustomCommands>$(_XHarnessAppleCustomCommand)</CustomCommands>

--- a/src/mono/msbuild/apple/build/AppleBuild.targets
+++ b/src/mono/msbuild/apple/build/AppleBuild.targets
@@ -298,8 +298,8 @@
       <ExtraAppLinkerArgs Include="@(_CommonLinkerArgs)" />
       <!-- Disable linker optimization to prevent AOT PLT resolution failures on macOS 14+. This is only visible in CI and isn't reproducible locally.
            Tracking issue: https://github.com/dotnet/runtime/issues/117159 -->
-      <ExtraAppLinkerArgs Include="-Xlinker" />
-      <ExtraAppLinkerArgs Include="-O0" />
+      <ExtraAppLinkerArgs Condition="'$(UseMonoRuntime)' == 'true' and '$(UseNativeAOTRuntime)' != 'true'" Include="-Xlinker" />
+      <ExtraAppLinkerArgs Condition="'$(UseMonoRuntime)' == 'true' and '$(UseNativeAOTRuntime)' != 'true'" Include="-O0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(_IsLibraryMode)' == 'true' and '$(UseNativeAOTRuntime)' != 'true'">

--- a/src/mono/msbuild/apple/build/AppleBuild.targets
+++ b/src/mono/msbuild/apple/build/AppleBuild.targets
@@ -296,6 +296,10 @@
 
     <ItemGroup>
       <ExtraAppLinkerArgs Include="@(_CommonLinkerArgs)" />
+      <!-- Disable linker optimization to prevent AOT PLT resolution failures on macOS 14+. This is only visible in CI and isn't reproducible locally.
+           Tracking issue: https://github.com/dotnet/runtime/issues/117159 -->
+      <ExtraAppLinkerArgs Include="-Xlinker" />
+      <ExtraAppLinkerArgs Include="-O0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(_IsLibraryMode)' == 'true' and '$(UseNativeAOTRuntime)' != 'true'">

--- a/src/tests/FunctionalTests/iOS/Device/Directory.Build.props
+++ b/src/tests/FunctionalTests/iOS/Device/Directory.Build.props
@@ -4,7 +4,8 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsTestProject Condition="'$(IsTestProject)' == ''">true</IsTestProject>
+    <IsFunctionalTest>true</IsFunctionalTest>
   </PropertyGroup>
 
-  <Import Project="..\..\..\..\libraries\Directory.Build.props" />
+  <Import Project="..\..\Directory.Build.props" />
 </Project>

--- a/src/tests/FunctionalTests/iOS/Device/Directory.Build.props
+++ b/src/tests/FunctionalTests/iOS/Device/Directory.Build.props
@@ -4,7 +4,6 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsTestProject Condition="'$(IsTestProject)' == ''">true</IsTestProject>
-    <IsFunctionalTest>true</IsFunctionalTest>
   </PropertyGroup>
 
   <Import Project="..\..\Directory.Build.props" />

--- a/src/tests/FunctionalTests/iOS/Device/Directory.Build.targets
+++ b/src/tests/FunctionalTests/iOS/Device/Directory.Build.targets
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="..\..\..\..\libraries\Directory.Build.targets" />
+  <Import Project="..\..\Directory.Build.targets" />
 </Project>

--- a/src/tests/FunctionalTests/tvOS/Device/AOT/Directory.Build.props
+++ b/src/tests/FunctionalTests/tvOS/Device/AOT/Directory.Build.props
@@ -6,5 +6,5 @@
     <IsTestProject Condition="'$(IsTestProject)' == ''">true</IsTestProject>
   </PropertyGroup>
 
-  <Import Project="..\..\..\..\..\libraries\Directory.Build.props" />
+  <Import Project="..\..\..\Directory.Build.props" />
 </Project>

--- a/src/tests/FunctionalTests/tvOS/Device/AOT/Directory.Build.targets
+++ b/src/tests/FunctionalTests/tvOS/Device/AOT/Directory.Build.targets
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="..\..\..\..\..\libraries\Directory.Build.targets" />
+  <Import Project="..\..\..\Directory.Build.targets" />
 </Project>


### PR DESCRIPTION
Build Mono smoke tests on Azdo build images to work around an issue where helix machines have lower XCode than Azdo images, causing Mono linking errors: https://github.com/dotnet/runtime/pull/120589#issuecomment-3571310821

Changes:
- Correct `Directory.Build.*` imports for functional tests
- Tweak `src/libraries/sendtohelix-mobile.targets` to handle cases where only `runonly` tests are prepared for sending to helix.
- Rename mobile jobs running only smoke tests

