### PR TITLE
Fix duplicate Uri ToString for DOS-like custom schemes

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -3260,7 +3260,6 @@ namespace System
                 // Dos/Unix paths have no host.  Other schemes cleared/set _string with host information in PrivateParseMinimal.
                 if (InFact(Flags.DosPath | Flags.UnixPath))
                 {
-                    Debug.Assert(ReferenceEquals(_string, OriginalString));
                     Debug.Assert(!InFact(Flags.HasUserInfo));
 
                     _string =
@@ -3271,6 +3270,10 @@ namespace System
                     _info.Offset.Scheme = 0;
                     _info.Offset.User = _string.Length;
                     _info.Offset.Host = _string.Length;
+                }
+                else
+                {
+                    Debug.Assert(!ReferenceEquals(_string, OriginalString));
                 }
 
                 _info.Offset.Path = _string.Length;

--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -2277,12 +2277,21 @@ namespace System
 
                 if ((cF & Flags.AuthorityFound) != 0)
                 {
-                    Debug.Assert(str[idx] is '/' or '\\' && str[idx + 1] is '/' or '\\');
+                    if (str[idx] is '/' or '\\' && str[idx + 1] is '/' or '\\')
+                    {
+                        if (str[idx] == '\\' || str[idx + 1] == '\\')
+                        {
+                            notCanonicalScheme = true;
+                        }
 
-                    if (str[idx] == '\\' || str[idx + 1] == '\\')
-                        notCanonicalScheme = true;
-
-                    idx += 2;
+                        idx += 2;
+                    }
+                    else
+                    {
+                        Debug.Assert(IsDosPath);
+                        Debug.Assert(char.IsAsciiLetter(str.AsSpan(idx).TrimStart(['/', '\\'])[0]));
+                        Debug.Assert(str.AsSpan(idx).TrimStart(['/', '\\'])[1] is ':' or '|');
+                    }
 
                     if ((cF & (Flags.UncPath | Flags.DosPath)) != 0)
                     {
@@ -3249,16 +3258,15 @@ namespace System
                 DebugAssertInCtor();
 
                 // Dos/Unix paths have no host.  Other schemes cleared/set _string with host information in PrivateParseMinimal.
-                if (IsFile && !IsUncPath)
+                if (InFact(Flags.DosPath | Flags.UnixPath))
                 {
-                    if (IsImplicitFile)
-                    {
-                        _string = string.Empty;
-                    }
-                    else
-                    {
-                        _string = _syntax.SchemeName + SchemeDelimiter;
-                    }
+                    Debug.Assert(ReferenceEquals(_string, OriginalString));
+                    Debug.Assert(!InFact(Flags.HasUserInfo));
+
+                    _string =
+                        IsImplicitFile ? string.Empty :
+                        InFact(Flags.AuthorityFound) ? _syntax.SchemeName + SchemeDelimiter :
+                        _syntax.SchemeName + ':';
 
                     _info.Offset.Scheme = 0;
                     _info.Offset.User = _string.Length;

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -821,11 +821,29 @@ namespace System.PrivateUri.Tests
             yield return new object[] { "file:///\u00FCri/", "file:///\u00FCri/", "/%C3%BCri/", "file:///%C3%BCri/", "/\u00FCri/" };
             yield return new object[] { "file:///a/b\uD83D\uDE1F/Foo.cs", "file:///a/b\uD83D\uDE1F/Foo.cs", "/a/b%F0%9F%98%9F/Foo.cs", "file:///a/b%F0%9F%98%9F/Foo.cs", "/a/b\uD83D\uDE1F/Foo.cs" };
 
+            // DOS with ':' or ':/' instead of '://'
+            yield return new object[] { "file:C:/uri/", "file:///C:/uri/", "C:/uri/", "file:///C:/uri/", "C:\\uri\\" };
+            yield return new object[] { "file:C:/\u00FCri/", "file:///C:/\u00FCri/", "C:/%C3%BCri/", "file:///C:/%C3%BCri/", "C:\\\u00FCri\\" };
+            yield return new object[] { "file:/C:/uri/", "file:///C:/uri/", "C:/uri/", "file:///C:/uri/", "C:\\uri\\" };
+            yield return new object[] { "file:/C:/\u00FCri/", "file:///C:/\u00FCri/", "C:/%C3%BCri/", "file:///C:/%C3%BCri/", "C:\\\u00FCri\\" };
+
             // DOS
+            yield return new object[] { "file://C:/uri/", "file:///C:/uri/", "C:/uri/", "file:///C:/uri/", "C:\\uri\\" };
             yield return new object[] { "file://C:/\u00FCri/", "file:///C:/\u00FCri/", "C:/%C3%BCri/", "file:///C:/%C3%BCri/", "C:\\\u00FCri\\" };
+            yield return new object[] { "file:///C:/uri/", "file:///C:/uri/", "C:/uri/", "file:///C:/uri/", "C:\\uri\\" };
             yield return new object[] { "file:///C:/\u00FCri/", "file:///C:/\u00FCri/", "C:/%C3%BCri/", "file:///C:/%C3%BCri/", "C:\\\u00FCri\\" };
             yield return new object[] { "C:/\u00FCri/", "file:///C:/\u00FCri/", "C:/%C3%BCri/", "file:///C:/%C3%BCri/", "C:\\\u00FCri\\" };
             yield return new object[] { "\tC:/\u00FCri/", "file:///C:/\u00FCri/", "C:/%C3%BCri/", "file:///C:/%C3%BCri/", "C:\\\u00FCri\\" };
+
+            // DOS in custom scheme (differs in whether ':' vs '://' is used since it doesn't have MustHaveAuthority)
+            yield return new object[] { "custom:C:/uri/", "custom:C:/uri/", "C:/uri/", "custom:C:/uri/", "C:\\uri\\" };
+            yield return new object[] { "custom:C:/\u00FCri/", "custom:C:/\u00FCri/", "C:/%C3%BCri/", "custom:C:/%C3%BCri/", "C:\\\u00FCri\\" };
+            yield return new object[] { "custom:/C:/uri/", "custom:/C:/uri/", "C:/uri/", "custom:/C:/uri/", "C:\\uri\\" };
+            yield return new object[] { "custom:/C:/\u00FCri/", "custom:/C:/\u00FCri/", "C:/%C3%BCri/", "custom:/C:/%C3%BCri/", "C:\\\u00FCri\\" };
+            yield return new object[] { "custom://C:/uri/", "custom:///C:/uri/", "C:/uri/", "custom:///C:/uri/", "C:\\uri\\" };
+            yield return new object[] { "custom://C:/\u00FCri/", "custom:///C:/\u00FCri/", "C:/%C3%BCri/", "custom:///C:/%C3%BCri/", "C:\\\u00FCri\\" };
+            yield return new object[] { "custom:///C:/uri/", "custom:///C:/uri/", "C:/uri/", "custom:///C:/uri/", "C:\\uri\\" };
+            yield return new object[] { "custom:///C:/\u00FCri/", "custom:///C:/\u00FCri/", "C:/%C3%BCri/", "custom:///C:/%C3%BCri/", "C:\\\u00FCri\\" };
 
             // UNC
             yield return new object[] { "\\\\\u00FCri/", "file://\u00FCri/", "/", "file://\u00FCri/", "\\\\\u00FCri\\" };

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -845,6 +845,9 @@ namespace System.PrivateUri.Tests
             yield return new object[] { "custom:///C:/uri/", "custom:///C:/uri/", "C:/uri/", "custom:///C:/uri/", "C:\\uri\\" };
             yield return new object[] { "custom:///C:/\u00FCri/", "custom:///C:/\u00FCri/", "C:/%C3%BCri/", "custom:///C:/%C3%BCri/", "C:\\\u00FCri\\" };
 
+            yield return new object[] { "vsmacros://C:/\u00FCri/", "vsmacros://C:/\u00FCri/", "C:/%C3%BCri/", "vsmacros://C:/%C3%BCri/", "C:\\\u00FCri\\" };
+            yield return new object[] { "vsmacros://test/\u00FCri/", "vsmacros://test/\u00FCri/", "/%C3%BCri/", "vsmacros://test/%C3%BCri/", "\\\\test\\\u00FCri\\" };
+
             // UNC
             yield return new object[] { "\\\\\u00FCri/", "file://\u00FCri/", "/", "file://\u00FCri/", "\\\\\u00FCri\\" };
             yield return new object[] { "file://\u00FCri/", "file://\u00FCri/", "/", "file://\u00FCri/", "\\\\\u00FCri\\" };


### PR DESCRIPTION
The fix in #36429 wasn't quite right because DOS-like Uris may appear with non-file schemes (e.g. `custom:C:/uri`).
This changes the condition to handle such inputs (`Dos || Unix` instead of `File && !Unc`).

The change with checking for `InFact(Flags.AuthorityFound)` is specific for custom schemes with DOS-like inputs.
It ensures that `custom:C:/uri` and `custom:C:/üri` (with non-ASCII or not) behave similarly with `ToString` and preserve whether `:` vs `://` was used.

Fixes #94572