### PR TITLE
Fix interpreter delegate calls with large alignment of first arg

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -4504,7 +4504,7 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
                 else if (opcode == INTOP_CALLDELEGATE)
                 {
                     int32_t firstTargetArgOffset = INTERP_STACK_SLOT_SIZE;
-                    if (numArgs > 0)
+                    if (numArgs > 1)
                     {
                         // The first argument is the delegate obj, the second is the first target arg
                         // The offset of the first target arg relative to the start of delegate call args is equal to the alignment of the

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -4501,6 +4501,18 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
                         ((lookup.accessType == IAT_PVALUE) ? (int32_t)PInvokeCallFlags::Indirect : 0) |
                         (suppressGCTransition ? (int32_t)PInvokeCallFlags::SuppressGCTransition : 0);
                 }
+                else if (opcode == INTOP_CALLDELEGATE)
+                {
+                    int32_t firstTargetArgOffset = INTERP_STACK_SLOT_SIZE;
+                    if (numArgs > 0)
+                    {
+                        // The first argument is the delegate obj, the second is the first target arg
+                        // The offset of the first target arg relative to the start of delegate call args is equal to the alignment of the
+                        // first target arg.
+                        GetInterpTypeStackSize(m_pVars[callArgs[1]].clsHnd, m_pVars[callArgs[1]].interpType, &firstTargetArgOffset);
+                    }
+                    m_pLastNewIns->data[1] = firstTargetArgOffset;
+                }
             }
             break;
 

--- a/src/coreclr/interpreter/inc/intops.def
+++ b/src/coreclr/interpreter/inc/intops.def
@@ -370,7 +370,7 @@ OPDEF(INTOP_LDFLDA, "ldflda", 4, 1, 1, InterpOpInt)
 // Calls
 OPDEF(INTOP_CALL, "call", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALL_NULLCHECK, "call.nullcheck", 4, 1, 1, InterpOpMethodHandle)
-OPDEF(INTOP_CALLDELEGATE, "call.delegate", 4, 1, 1, InterpOpMethodHandle)
+OPDEF(INTOP_CALLDELEGATE, "call.delegate", 5, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLDELEGATE_TAIL, "call.delegate.tail", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLI, "calli", 6, 1, 2, InterpOpLdPtr)
 OPDEF(INTOP_CALLVIRT, "callvirt", 4, 1, 1, InterpOpMethodHandle)

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -2563,7 +2563,17 @@ MAIN_LOOP:
 
                     int8_t* returnValueAddress = LOCAL_VAR_ADDR(returnOffset, int8_t);
 
-                    ip += 4;
+                    // Used only for INTOP_CALLDELEGATE to allow removal of the delegate object from the argument list
+                    size_t firstTargetArgOffset = 0;
+                    if (*ip == INTOP_CALLDELEGATE)
+                    {
+                        firstTargetArgOffset = (size_t)ip[4];
+                        ip += 5;
+                    }
+                    else
+                    {
+                        ip += 4;
+                    }
 
                     DELEGATEREF* delegateObj = LOCAL_VAR_ADDR(callArgsOffset, DELEGATEREF);
                     NULL_CHECK(*delegateObj);
@@ -2624,7 +2634,7 @@ MAIN_LOOP:
                             else
                             {
                                 // Shift args down by one slot to remove the delegate obj pointer
-                                memmove(LOCAL_VAR_ADDR(callArgsOffset, int8_t), LOCAL_VAR_ADDR(callArgsOffset + INTERP_STACK_SLOT_SIZE, int8_t), pTargetMethod->argsSize);
+                                memmove(LOCAL_VAR_ADDR(callArgsOffset, int8_t), LOCAL_VAR_ADDR(callArgsOffset + firstTargetArgOffset, int8_t), pTargetMethod->argsSize);
                                 // Allocate child frame.
                                 InterpMethodContextFrame *pChildFrame = pFrame->pNext;
                                 if (!pChildFrame)


### PR DESCRIPTION
There is a problem with delegate calls when the first target arch is aligned to 16 bytes. One path to call the delegate removes the delegate obj from the argument list by moving the arguments on the interpreter stack by the size of the delegate obj slot. But in the problematic case, the stack slot of the delegate obj is followed by an unused slot that ensures the alignment of the first target argument that starts after it. Moving the arguments by the 8 bytes garbles the arguments and makes that unused slot part of the first target arg. Moreover, it also doesn't move the last 8 bytes of the last argument due to this.

This change fixes it by ensuring that we move the arguments starting at the aligned location of the first target argument.

This fixes a large number of the libraries tests.