### PR TITLE
JIT: Skip GC info for trivial async calls for x86

### DIFF
--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -10373,8 +10373,9 @@ void emitter::emitStackPopLargeStk(BYTE* addr, bool isCall, unsigned char callIn
 
 #ifdef JIT32_GCENCODER
     // x86 does not report GC refs/byrefs in return registers at call sites
-    gcrefRegs &= ~(1u << (REG_INTRET - REG_INT_FIRST));
-    byrefRegs &= ~(1u << (REG_INTRET - REG_INT_FIRST));
+    unsigned returnRegs = (RBM_INTRET | RBM_LNGRET | RBM_ASYNC_CONTINUATION_RET).GetIntRegSet() >> REG_INT_FIRST;
+    gcrefRegs &= ~returnRegs;
+    byrefRegs &= ~returnRegs;
 
     // For the general encoder, we always have to record calls, so we don't take this early return.    /* Are there any
     // args to pop at this call site?

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -10372,10 +10372,10 @@ void emitter::emitStackPopLargeStk(BYTE* addr, bool isCall, unsigned char callIn
     assert(regMaskTP::FromIntRegSet(SingleTypeRegSet(byrefRegs << REG_INT_FIRST)) == emitThisByrefRegs);
 
 #ifdef JIT32_GCENCODER
-    // x86 does not report GC refs/byrefs in return registers at call sites
-    unsigned returnRegs = (RBM_INTRET | RBM_LNGRET | RBM_ASYNC_CONTINUATION_RET).GetIntRegSet() >> REG_INT_FIRST;
-    gcrefRegs &= ~returnRegs;
-    byrefRegs &= ~returnRegs;
+    // x86 only reports GC refs/byrefs in callee saves at call sites -- no return registers.
+    unsigned reportedRegs = (RBM_INT_CALLEE_SAVED | RBM_EBP).GetIntRegSet() >> REG_INT_FIRST;
+    gcrefRegs &= reportedRegs;
+    byrefRegs &= reportedRegs;
 
     // For the general encoder, we always have to record calls, so we don't take this early return.    /* Are there any
     // args to pop at this call site?


### PR DESCRIPTION
For x86 we only report GC pointers live in callee save registers, and we also avoid reporting any trivial call.
There is compensating code upstream of the GC reporting that returns for trivial calls, but this code did not account for the GC ref returned for async continuations. Thus it was possible that we made it into the GC encoder with a trivial call and then hit an assert.

Fix #121872