### PR TITLE
Fix edge-case Uri IPv4 parsing regression

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/IPv4AddressHelper.cs
+++ b/src/libraries/System.Private.Uri/src/System/IPv4AddressHelper.cs
@@ -13,7 +13,7 @@ namespace System.Net
         // Parse and canonicalize
         internal static string ParseCanonicalName(string str, int start, int end, ref bool isLoopback)
         {
-            long result = ParseNonCanonical(str.AsSpan(start), out _, true);
+            long result = ParseNonCanonical(str.AsSpan(start, end - start), out _, true);
 
             Debug.Assert(result != Invalid, $"Failed to parse after already validated: {str}");
 

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UncTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UncTest.cs
@@ -149,5 +149,15 @@ namespace System.PrivateUri.Tests
             Assert.True(uri.IsUnc);
             Assert.Empty(uri.Host);
         }
+
+        [Fact]
+        public static void UncWithTrailingSpaces_CanBeParsed()
+        {
+            Uri uri = new Uri("//9\n");
+            Assert.True(uri.IsUnc);
+            Assert.Equal(UriHostNameType.IPv4, uri.HostNameType);
+            Assert.Equal("0.0.0.9", uri.Host);
+            Assert.Equal(@"\\0.0.0.9", uri.LocalPath);
+        }
     }
 }


### PR DESCRIPTION
Recently broken in #121225

If the Uri ends with the host (no path/query/fragment delimiter) and has trailing whitespace, we'd pass the host including the whitespace to `ParseNonCanonical` which would return `Invalid`, hitting the `Debug.Assert(result != Invalid)` below.