### PR TITLE
Implement InstantiateSignature on AsyncMethodVariant/EcmaMethod

### DIFF
--- a/src/coreclr/tools/Common/Compiler/AsyncMethodVariant.cs
+++ b/src/coreclr/tools/Common/Compiler/AsyncMethodVariant.cs
@@ -58,7 +58,7 @@ namespace ILCompiler
 
         public override MethodDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation)
         {
-            throw new NotImplementedException();
+            return this;
         }
 
         public override string ToString() => $"Async variant: " + _wrappedMethod.ToString();

--- a/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Ecma/EcmaMethod.cs
@@ -599,5 +599,7 @@ namespace Internal.TypeSystem.Ecma
         public override EcmaMethod GetMethodDefinition() => this;
 
         public override EcmaMethod GetTypicalMethodDefinition() => this;
+
+        public override MethodDesc InstantiateSignature(Instantiation typeInstantiation, Instantiation methodInstantiation) => this;
     }
 }


### PR DESCRIPTION
We left this as NYI but I hit this. The correct implementation for anything that represents a definition should be `return this`. Since I was looking at this, I'm doing the same for `EcmaMethod` too since the base `MethodDesc.InstantiateSignature` does a lot of work for nothing on a definition.

Cc @dotnet/ilc-contrib 