### PR TITLE
JIT: Keep continuation alive until generic context is loaded

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1977,7 +1977,7 @@ void AsyncTransformation::RestoreFromDataOnResumption(const ContinuationLayout& 
     {
         // Ensure that the continuation remains alive until we finished loading the generic context
         GenTree* continuation = m_comp->gtNewLclvNode(m_comp->lvaAsyncContinuationArg, TYP_REF);
-        GenTree* keepAlive    = m_comp->gtNewOperNode(GT_KEEPALIVE, TYP_VOID, continuation);
+        GenTree* keepAlive    = m_comp->gtNewKeepAliveNode(continuation);
         LIR::AsRange(resumeBB).InsertAtEnd(LIR::SeqTree(m_comp, keepAlive));
     }
 }

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1972,6 +1972,14 @@ void AsyncTransformation::RestoreFromDataOnResumption(const ContinuationLayout& 
 
         LIR::AsRange(resumeBB).InsertAtEnd(LIR::SeqTree(m_comp, store));
     }
+
+    if (layout.KeepAliveOffset != UINT_MAX)
+    {
+        // Ensure that the continuation remains alive until we finished loading the generic context
+        GenTree* continuation = m_comp->gtNewLclvNode(m_comp->lvaAsyncContinuationArg, TYP_REF);
+        GenTree* keepAlive    = m_comp->gtNewOperNode(GT_KEEPALIVE, TYP_VOID, continuation);
+        LIR::AsRange(resumeBB).InsertAtEnd(LIR::SeqTree(m_comp, keepAlive));
+    }
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
There is a theoretical problem where JIT reports the continuation as dead before having restored the generic context local that the EE side is using to keep a `LoaderAllocator` alive.

Insert an explicit `GT_KEEPALIVE` node after the state restore.

Fix #117265