### PR TITLE
async read/writes to STD IN/OUT/ERR are cancelable on Windows since .NET 8

### DIFF
--- a/src/libraries/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
+++ b/src/libraries/System.Diagnostics.Process/tests/ProcessStreamReadTests.cs
@@ -344,7 +344,6 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [SkipOnPlatform(TestPlatforms.Windows, "currently on Windows these operations async-over-sync on Windows")]
         [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         public async Task ReadAsync_OutputStreams_Cancel_RespondsQuickly()
         {


### PR DESCRIPTION
.NET included 8 https://github.com/dotnet/runtime/pull/87103, the cancellation should just work now.

Context: I am researching Process API issues and found this old test to be running only on Linux.

```cmd
.\dotnet.cmd build .\src\libraries\System.Diagnostics.Process\tests\System.Diagnostics.Process.Tests.csproj /t:Test /p:xunitMethodName=System.Diagnostics.Tests.ProcessStreamReadTests.ReadAsync_OutputStreams_Cancel_RespondsQuickly
```

```log
  "D:\projects\runtime\artifacts\bin\testhost\net10.0-windows-Debug-x64\dotnet.exe" exec --runtimeconfig System.Diagnostics.Process.Tests.runtimeconfig.json --depsfile System.Diagnostics.Process.Tests.deps.json C:\Users\adsitnik\.nuget\packages\microsoft.dotnet.xunitconsolerunner\2.9.3-beta.25528.108\build\..\tools\net\xunit.console.dll System.Diagnostics.Process.Tests.dll -xml testResults.xml -nologo -method System.Diagnostics.Tests.ProcessStreamReadTests.ReadAsync_OutputStreams_Cancel_RespondsQuickly -notrait category=OuterLoop -notrait category=failing
  popd
  ===========================================================================================================
    Discovering: System.Diagnostics.Process.Tests (method display = ClassAndMethod, method display options = None)
    Discovered:  System.Diagnostics.Process.Tests (found 1 of 292 test case)
    Starting:    System.Diagnostics.Process.Tests (parallel test collections = on [24 threads], stop on fail = off)
    Finished:    System.Diagnostics.Process.Tests
  === TEST EXECUTION SUMMARY ===
     System.Diagnostics.Process.Tests  Total: 1, Errors: 0, Failed: 0, Skipped: 0, Time: 0.214s
  ----- end Tue 11/25/2025 17:01:00.26 ----- exit code 0 ----------------------------------------------------------

Build succeeded.
    0 Warning(s)
    0 Error(s)
```