### PR TITLE
Fix IPAddress & Uri octal parsing inconsistencies

### DIFF
--- a/src/libraries/Common/src/System/Net/IPv4AddressHelper.Common.cs
+++ b/src/libraries/Common/src/System/Net/IPv4AddressHelper.Common.cs
@@ -161,7 +161,7 @@ namespace System.Net
                 if (parsedCharacter < IPv4AddressHelper.Decimal)
                 {
                     if (!haveNumber && parsedCharacter == 0 &&
-                        (uint)(start + 1) < (uint)name.Length && char.IsBetween((char)ToUShort(name[start + 1]), '0', '9'))
+                        (uint)(start + 1) < (uint)name.Length && char.IsAsciiDigit((char)ToUShort(name[start + 1])))
                     {
                         // Octal is not allowed in canonical format.
                         return false;

--- a/src/libraries/Common/src/System/Net/IPv4AddressHelper.Common.cs
+++ b/src/libraries/Common/src/System/Net/IPv4AddressHelper.Common.cs
@@ -133,7 +133,6 @@ namespace System.Net
             int dots = 0;
             long number = 0;
             bool haveNumber = false;
-            bool firstCharIsZero = false;
             int start = 0;
 
             while (start < name.Length)
@@ -161,16 +160,11 @@ namespace System.Net
 
                 if (parsedCharacter < IPv4AddressHelper.Decimal)
                 {
-                    // A number starting with zero should be interpreted in base 8 / octal
-                    if (!haveNumber && parsedCharacter == 0)
+                    if (!haveNumber && parsedCharacter == 0 &&
+                        (uint)(start + 1) < (uint)name.Length && char.IsBetween((char)ToUShort(name[start + 1]), '0', '9'))
                     {
-                        if ((start + 1 < name.Length) && name[start + 1] == TChar.CreateTruncating('0'))
-                        {
-                            // 00 is not allowed as a prefix.
-                            return false;
-                        }
-
-                        firstCharIsZero = true;
+                        // Octal is not allowed in canonical format.
+                        return false;
                     }
 
                     haveNumber = true;
@@ -184,15 +178,14 @@ namespace System.Net
                 {
                     // If the current character is not an integer, it may be the IPv4 component separator ('.')
 
-                    if (!haveNumber || (number > 0 && firstCharIsZero))
+                    if (!haveNumber)
                     {
-                        // 0 is not allowed to prefix a number.
                         return false;
                     }
+
                     ++dots;
                     haveNumber = false;
                     number = 0;
-                    firstCharIsZero = false;
                 }
                 else
                 {

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPAddressParsing.cs
@@ -264,6 +264,8 @@ namespace System.Net.Primitives.Functional.Tests
             new object[] { "12.+1.1.4" }, // plus sign in section
             new object[] { "12.1.-1.5" }, // minus sign in section
             new object[] { "12.1.abc.5" }, // text in section
+            new object[] { "0.0.0.089" }, // octal with digits over 7
+            new object[] { "0.0.08.0" }, // octal with digits over 7
         };
 
         public static readonly object[][] InvalidIpv4AddressesStandalone = // but valid as part of IPv6 addresses
@@ -438,7 +440,6 @@ namespace System.Net.Primitives.Functional.Tests
             new object[] { "::FFFF:0:192.168.0.1", "::ffff:0:192.168.0.1" }, // SIIT
             new object[] { "::5EFE:192.168.0.1", "::5efe:192.168.0.1" }, // ISATAP
             new object[] { "1::5EFE:192.168.0.1", "1::5efe:192.168.0.1" }, // ISATAP
-            new object[] { "::192.168.0.010", "::192.168.0.10" }, // Embedded IPv4 octal, read as decimal
         };
 
         [Theory]
@@ -569,6 +570,9 @@ namespace System.Net.Primitives.Functional.Tests
             yield return new object[] { "FFFFF::" }; // invalid value
             yield return new object[] { ":%12" }; // colon scope
             yield return new object[] { "[2001:0db8:85a3:08d3:1319:8a2e:0370:7344]:443/" }; // errneous ending slash after ignored port
+
+            yield return new object[] { "::192.168.01.10" }; // Embedded IPv4 with octal
+            yield return new object[] { "::192.168.0.010" }; // Embedded IPv4 with octal
 
             yield return new object[] { "e3fff:ffff:ffff:ffff:ffff:ffff:ffff:abcd" }; // 1st number too long
             yield return new object[] { "3fff:effff:ffff:ffff:ffff:ffff:ffff:abcd" }; // 2nd number too long

--- a/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPEndPointParsing.cs
+++ b/src/libraries/System.Net.Primitives/tests/FunctionalTests/IPEndPointParsing.cs
@@ -301,7 +301,6 @@ namespace System.Net.Primitives.Functional.Tests
             new object[] { "::FFFF:0:192.168.0.1", "::ffff:0:192.168.0.1" }, // SIIT
             new object[] { "::5EFE:192.168.0.1", "::5efe:192.168.0.1" }, // ISATAP
             new object[] { "1::5EFE:192.168.0.1", "1::5efe:192.168.0.1" }, // ISATAP
-            new object[] { "::192.168.0.010", "::192.168.0.10" }, // Embedded IPv4 octal, read as decimal
         };
 
         public static readonly object[][] ValidIpv4Andv6AddressesWithAndWithoutPort =

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriIpHostTest.cs
@@ -219,6 +219,11 @@ namespace System.PrivateUri.Tests
             {
                 Assert.NotEqual(UriHostNameType.IPv4, testUri.HostNameType);
             }
+
+            if (Uri.TryCreate($"custom://{badIpv4String}/", UriKind.Absolute, out testUri))
+            {
+                Assert.NotEqual(UriHostNameType.IPv4, testUri.HostNameType);
+            }
         }
 
         #endregion Helpers
@@ -314,7 +319,6 @@ namespace System.PrivateUri.Tests
         [InlineData("::FFFF:0:192.168.0.1", "::ffff:0:192.168.0.1")] // SIIT
         [InlineData("::5EFE:192.168.0.1", "::5efe:192.168.0.1")] // ISATAP
         [InlineData("1::5EFE:192.168.0.1", "1::5efe:192.168.0.1")] // ISATAP
-        [InlineData("::192.168.0.010", "::192.168.0.10")] // Embedded IPv4 octal, read as decimal
         public void UriIPv6Host_EmbeddedIPv4_Success(string address, string expected)
         {
             ParseIPv6Address(address, expected);
@@ -461,6 +465,7 @@ namespace System.PrivateUri.Tests
 
             // TryCreate
             Assert.False(Uri.TryCreate($"http://[{badIpv6String}]/", UriKind.Absolute, out _), badIpv6String);
+            Assert.False(Uri.TryCreate($"custom://[{badIpv6String}]/", UriKind.Absolute, out _), badIpv6String);
         }
 
         #endregion Helpers


### PR DESCRIPTION
Our IPv4 logic has two validation modes:
- the default that handles things like hex/octal segments, or fewer than 4 segments
- a stricter "Canonical" mode which requires 4 segments and disallows hex/octal

The stricter mode is used for IPv4 addresses embedded in IPv6, and by Uri when dealing with an unknown scheme.
E.g. `"http://123/"` is treated as `0.0.0.123`, but `"custom://123/"` is treated as a non-IPv4 host and we just use `123`.

The current "stricter" logic has broken logic around octal where we'll allow it in the last segment (we were only validating it when encountering a dot, but not at the end).
E.g. `1.1.1.01` was considered valid, but `1.1.01.1` was not.

That error further meant that while we allowed octal in the last segment, we weren't validating that the digit is in range, so an input like `1.1.1.08` would be valid in the strict mode, but not in the non-strict one.
This violated the expectation that anything valid under the strict mode is also valid under the non-strict mode.

As a result, an input such as `custom://1.1.1.08/` is parsed as `custom://255.255.255.255/` (and triggers a debug assert).

This PR fixes the strict validation to also forbid octal in the last segmnet.