### PR TITLE
Run async testing on x86

### DIFF
--- a/src/tests/async/Directory.Build.targets
+++ b/src/tests/async/Directory.Build.targets
@@ -5,9 +5,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- https://github.com/dotnet/runtime/issues/121872 -->
-    <DisableProjectBuild Condition="'$(TestBuildMode)' == 'nativeaot' and '$(TargetArchitecture)' == 'x86'">true</DisableProjectBuild>
-
     <!-- https://github.com/dotnet/runtime/issues/121878 -->
     <DisableProjectBuild Condition="'$(TestBuildMode)' == 'nativeaot' and '$(TargetArchitecture)' == 'arm64'">true</DisableProjectBuild>
   </PropertyGroup>


### PR DESCRIPTION
The fix presumably merged in #121941.

Cc @dotnet/ilc-contrib 