### PR TITLE
Reenable tests for interpreter

### DIFF
--- a/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
+++ b/src/tests/JIT/Directed/Convert/out_of_range_fp_to_int_conversions.cs
@@ -319,7 +319,6 @@ namespace FPBehaviorApp
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
         public static int TestEntryPoint()
         {
             Program.ManagedConversionRule = FPtoIntegerConversionType.CONVERT_SATURATING;

--- a/src/tests/JIT/Performance/CodeQuality/SIMD/ConsoleMandel/ConsoleMandel.cs
+++ b/src/tests/JIT/Performance/CodeQuality/SIMD/ConsoleMandel/ConsoleMandel.cs
@@ -65,7 +65,6 @@ namespace SIMD
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
         public static int TestEntryPoint()
         {
             Bench(0, -1);

--- a/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b609988/Desktop/b609988_Desktop.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b609988/Desktop/b609988_Desktop.il
@@ -1230,11 +1230,6 @@
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
     )
-    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ActiveIssueAttribute::.ctor(string, class [mscorlib]System.Type, string[]) = {
-      string('https://github.com/dotnet/runtime/issues/120904')
-      type([TestLibrary]TestLibrary.Utilities)
-      string[1] ('IsCoreClrInterpreter')
-    }
     .entrypoint
     .maxstack  1
     IL_0000:  call       void Program::Test1()

--- a/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b609988/b609988.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/v2.1/b609988/b609988.il
@@ -1229,11 +1229,6 @@
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
     )
-    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ActiveIssueAttribute::.ctor(string, class [mscorlib]System.Type, string[]) = {
-      string('https://github.com/dotnet/runtime/issues/120904')
-      type([TestLibrary]TestLibrary.Utilities)
-      string[1] ('IsCoreClrInterpreter')
-    }
     .entrypoint
     .maxstack  1
     IL_0000:  call       void Program::Test1()

--- a/src/tests/JIT/Regression/JitBlue/GitHub_19438/GitHub_19438.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_19438/GitHub_19438.cs
@@ -65,7 +65,6 @@ namespace GitHub_19438
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
         public static void TestEntryPoint()
         {
             const int iterationCount = 10;

--- a/src/tests/JIT/SIMD/Sums.cs
+++ b/src/tests/JIT/SIMD/Sums.cs
@@ -40,7 +40,6 @@ namespace VectorMathTests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
         public static void TestEntryPoint()
         {
             System.Diagnostics.Stopwatch clock = new System.Diagnostics.Stopwatch();

--- a/src/tests/JIT/jit64/opt/rngchk/RngchkStress3.cs
+++ b/src/tests/JIT/jit64/opt/rngchk/RngchkStress3.cs
@@ -13,6 +13,7 @@ namespace SimpleArray_01
     public class Class1
     {
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
         public static int TestEntryPoint()
         {
             int retVal = 100;

--- a/src/tests/JIT/jit64/opt/rngchk/RngchkStress3.cs
+++ b/src/tests/JIT/jit64/opt/rngchk/RngchkStress3.cs
@@ -13,7 +13,6 @@ namespace SimpleArray_01
     public class Class1
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
         public static int TestEntryPoint()
         {
             int retVal = 100;

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread01.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread01.cs
@@ -55,7 +55,7 @@ public class Test_thread01
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread01.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread01.cs
@@ -55,8 +55,7 @@ public class Test_thread01
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread02.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread02.cs
@@ -55,8 +55,7 @@ public class Test_thread02
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread02.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread02.cs
@@ -55,7 +55,7 @@ public class Test_thread02
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread03.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread03.cs
@@ -57,7 +57,7 @@ public class Test_thread03
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread03.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread03.cs
@@ -57,8 +57,7 @@ public class Test_thread03
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread04.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread04.cs
@@ -57,7 +57,7 @@ public class Test_thread04
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread04.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread04.cs
@@ -57,8 +57,7 @@ public class Test_thread04
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread05.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread05.cs
@@ -57,7 +57,7 @@ public class Test_thread05
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread05.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread05.cs
@@ -57,8 +57,7 @@ public class Test_thread05
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread06.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread06.cs
@@ -57,8 +57,7 @@ public class Test_thread06
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread06.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread06.cs
@@ -57,7 +57,7 @@ public class Test_thread06
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread07.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread07.cs
@@ -55,8 +55,7 @@ public class Test_thread07
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread07.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread07.cs
@@ -55,7 +55,7 @@ public class Test_thread07
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread08.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread08.cs
@@ -57,8 +57,7 @@ public class Test_thread08
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread08.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread08.cs
@@ -57,7 +57,7 @@ public class Test_thread08
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread09.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread09.cs
@@ -57,8 +57,7 @@ public class Test_thread09
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread09.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread09.cs
@@ -57,7 +57,7 @@ public class Test_thread09
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread10.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread10.cs
@@ -65,8 +65,7 @@ public class Test_thread10
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread10.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread10.cs
@@ -65,7 +65,7 @@ public class Test_thread10
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread11.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread11.cs
@@ -65,7 +65,7 @@ public class Test_thread11
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread11.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread11.cs
@@ -65,8 +65,7 @@ public class Test_thread11
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread12.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread12.cs
@@ -65,8 +65,7 @@ public class Test_thread12
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread12.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread12.cs
@@ -65,7 +65,7 @@ public class Test_thread12
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread13.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread13.cs
@@ -212,7 +212,7 @@ public class Test_thread13
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 	
 		GenInt.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread13.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread13.cs
@@ -212,8 +212,7 @@ public class Test_thread13
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 	
 		GenInt.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread14.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread14.cs
@@ -212,7 +212,7 @@ public class Test_thread14
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 	
 		GenInt.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread14.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread14.cs
@@ -212,8 +212,7 @@ public class Test_thread14
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 	
 		GenInt.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread15.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread15.cs
@@ -212,7 +212,7 @@ public class Test_thread15
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 	
 		GenInt.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread15.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread15.cs
@@ -212,8 +212,7 @@ public class Test_thread15
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 	
 		GenInt.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread16.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread16.cs
@@ -62,7 +62,7 @@ public class Test_thread16
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread16.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread16.cs
@@ -62,8 +62,7 @@ public class Test_thread16
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread17.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread17.cs
@@ -62,7 +62,7 @@ public class Test_thread17
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread17.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread17.cs
@@ -62,8 +62,7 @@ public class Test_thread17
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread18.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread18.cs
@@ -62,8 +62,7 @@ public class Test_thread18
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread18.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread18.cs
@@ -62,7 +62,7 @@ public class Test_thread18
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread19.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread19.cs
@@ -66,8 +66,7 @@ public class Test_thread19
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread19.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread19.cs
@@ -66,7 +66,7 @@ public class Test_thread19
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread20.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread20.cs
@@ -66,8 +66,7 @@ public class Test_thread20
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread20.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread20.cs
@@ -66,7 +66,7 @@ public class Test_thread20
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread21.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread21.cs
@@ -66,7 +66,7 @@ public class Test_thread21
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread21.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread21.cs
@@ -66,8 +66,7 @@ public class Test_thread21
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread22.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread22.cs
@@ -222,8 +222,7 @@ public class Test_thread22
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 	
 		GenInt.ThreadPoolTest<int>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread22.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread22.cs
@@ -222,7 +222,7 @@ public class Test_thread22
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 	
 		GenInt.ThreadPoolTest<int>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread23.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread23.cs
@@ -220,8 +220,7 @@ public class Test_thread23
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 	
 		GenInt.ThreadPoolTest<int>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread23.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread23.cs
@@ -220,7 +220,7 @@ public class Test_thread23
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 	
 		GenInt.ThreadPoolTest<int>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread24.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread24.cs
@@ -218,7 +218,7 @@ public class Test_thread24
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 	
 		GenInt.ThreadPoolTest<int>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread24.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread24.cs
@@ -218,8 +218,7 @@ public class Test_thread24
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 	
 		GenInt.ThreadPoolTest<int>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread25.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread25.cs
@@ -55,7 +55,7 @@ public class Test_thread25
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread25.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread25.cs
@@ -55,8 +55,7 @@ public class Test_thread25
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread26.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread26.cs
@@ -57,7 +57,7 @@ public class Test_thread26
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread26.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread26.cs
@@ -57,8 +57,7 @@ public class Test_thread26
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest();
 		Gen<double>.ThreadPoolTest();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread27.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread27.cs
@@ -57,7 +57,7 @@ public class Test_thread27
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread27.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread27.cs
@@ -57,8 +57,7 @@ public class Test_thread27
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread28.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread28.cs
@@ -57,7 +57,7 @@ public class Test_thread28
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread28.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread28.cs
@@ -57,8 +57,7 @@ public class Test_thread28
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen<int>.ThreadPoolTest<object>();
 		Gen<double>.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread29.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread29.cs
@@ -55,7 +55,7 @@ public class Test_thread29
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread29.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread29.cs
@@ -55,8 +55,7 @@ public class Test_thread29
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread30.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread30.cs
@@ -55,7 +55,7 @@ public class Test_thread30
 	}
 	
 	[Fact]
-    public static int TestEntryPoint()
+	public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();

--- a/src/tests/baseservices/threading/generics/WaitCallback/thread30.cs
+++ b/src/tests/baseservices/threading/generics/WaitCallback/thread30.cs
@@ -55,8 +55,7 @@ public class Test_thread30
 	}
 	
 	[Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120904", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
-	public static int TestEntryPoint()
+    public static int TestEntryPoint()
 	{
 		Gen.ThreadPoolTest<object>();
 		Gen.ThreadPoolTest<string>();


### PR DESCRIPTION
This change reenables tests that were formerly causing crashes or hangs of whole coreclr test suites and now work fine.