### PR TITLE
Simplify InitializeUri and remove some unreachable branches

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -700,41 +700,32 @@ namespace System
             }
         }
 
-        private static UriFormatException? GetException(ParsingError err)
+        private static UriFormatException GetException(ParsingError err)
         {
-            switch (err)
+            Debug.Assert(err != ParsingError.None);
+
+            string message = err switch
             {
-                case ParsingError.None:
-                    return null;
                 // Could be OK for Relative Uri
-                case ParsingError.BadFormat:
-                    return new UriFormatException(SR.net_uri_BadFormat);
-                case ParsingError.BadScheme:
-                    return new UriFormatException(SR.net_uri_BadScheme);
-                case ParsingError.BadAuthority:
-                    return new UriFormatException(SR.net_uri_BadAuthority);
-                case ParsingError.EmptyUriString:
-                    return new UriFormatException(SR.net_uri_EmptyUri);
+                ParsingError.BadFormat => SR.net_uri_BadFormat,
+                ParsingError.BadScheme => SR.net_uri_BadScheme,
+                ParsingError.BadAuthority => SR.net_uri_BadAuthority,
+                ParsingError.EmptyUriString => SR.net_uri_EmptyUri,
+
                 // Fatal
-                case ParsingError.SchemeLimit:
-                    return new UriFormatException(SR.net_uri_SchemeLimit);
-                case ParsingError.MustRootedPath:
-                    return new UriFormatException(SR.net_uri_MustRootedPath);
+                ParsingError.SchemeLimit => SR.net_uri_SchemeLimit,
+                ParsingError.MustRootedPath => SR.net_uri_MustRootedPath,
+
                 // Derived class controllable
-                case ParsingError.BadHostName:
-                    return new UriFormatException(SR.net_uri_BadHostName);
-                case ParsingError.NonEmptyHost: //unix-only
-                    return new UriFormatException(SR.net_uri_BadFormat);
-                case ParsingError.BadPort:
-                    return new UriFormatException(SR.net_uri_BadPort);
-                case ParsingError.BadAuthorityTerminator:
-                    return new UriFormatException(SR.net_uri_BadAuthorityTerminator);
-                case ParsingError.CannotCreateRelative:
-                    return new UriFormatException(SR.net_uri_CannotCreateRelative);
-                default:
-                    break;
-            }
-            return new UriFormatException(SR.net_uri_BadFormat);
+                ParsingError.BadHostName => SR.net_uri_BadHostName,
+                ParsingError.BadPort => SR.net_uri_BadPort,
+                ParsingError.BadAuthorityTerminator => SR.net_uri_BadAuthorityTerminator,
+                ParsingError.CannotCreateRelative => SR.net_uri_CannotCreateRelative,
+
+                _ => throw new UnreachableException()
+            };
+
+            return new UriFormatException(message);
         }
 
         public string AbsolutePath

--- a/src/libraries/System.Private.Uri/src/System/UriEnumTypes.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriEnumTypes.cs
@@ -73,7 +73,6 @@ namespace System
 
         // derived class controlled
         BadHostName,
-        NonEmptyHost, // unix only
         BadPort,
         BadAuthorityTerminator,
 

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -71,12 +71,10 @@ namespace System
                     }
                     return null;
                 }
-                else
-                {
-                    // This is a fatal error based solely on scheme name parsing
-                    _string = null!; // make it be invalid Uri
-                    return GetException(err);
-                }
+
+                // This is a fatal error based solely on scheme name parsing
+                _string = null!; // make it be invalid Uri
+                return GetException(err);
             }
 
             Debug.Assert(_syntax is not null);
@@ -116,10 +114,8 @@ namespace System
                         _flags &= Flags.UserEscaped; // the only flag that makes sense for a relative uri
                         return null;
                     }
-                    else
-                    {
-                        return GetException(err);
-                    }
+
+                    return GetException(err);
                 }
 
                 if (uriKind == UriKind.Relative)

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -123,23 +123,11 @@ namespace System
                         return GetException(err);
                     }
                 }
-                else if (uriKind == UriKind.Relative)
+
+                if (uriKind == UriKind.Relative)
                 {
                     // Here we know that we can create an absolute Uri, but the user has requested only a relative one
                     return GetException(ParsingError.CannotCreateRelative);
-                }
-
-                if (hasUnicode)
-                {
-                    // In this scenario we need to parse the whole string
-                    try
-                    {
-                        EnsureParseRemaining();
-                    }
-                    catch (UriFormatException ex)
-                    {
-                        return ex;
-                    }
                 }
             }
             else
@@ -170,18 +158,18 @@ namespace System
                     // relative one
                     return GetException(ParsingError.CannotCreateRelative);
                 }
+            }
 
-                if (hasUnicode)
+            if (hasUnicode)
+            {
+                // In this scenario we need to parse the whole string
+                try
                 {
-                    // In this scenario we need to parse the whole string
-                    try
-                    {
-                        EnsureParseRemaining();
-                    }
-                    catch (UriFormatException ex)
-                    {
-                        return ex;
-                    }
+                    EnsureParseRemaining();
+                }
+                catch (UriFormatException ex)
+                {
+                    return ex;
                 }
             }
 

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -61,32 +61,27 @@ namespace System
             {
                 if (IsImplicitFile)
                 {
+                    if (uriKind == UriKind.Relative)
+                    {
+                        _syntax = null!; // make it be relative Uri
+                        _flags &= Flags.UserEscaped; // the only flag that makes sense for a relative uri
+                        e = null;
+                        return;
+                    }
+
                     // V1 compat
                     // A relative Uri wins over implicit UNC path unless the UNC path is of the form "\\something" and
                     // uriKind != Absolute
                     // A relative Uri wins over implicit Unix path unless uriKind == Absolute
-                    if (NotAny(Flags.DosPath) &&
-                        uriKind != UriKind.Absolute &&
-                       ((uriKind == UriKind.Relative || (_string.Length >= 2 && (_string[0] != '\\' || _string[1] != '\\')))
-                    || (!OperatingSystem.IsWindows() && InFact(Flags.UnixPath))))
+                    if (NotAny(Flags.DosPath) && uriKind == UriKind.RelativeOrAbsolute &&
+                       ((_string.Length >= 2 && (_string[0] != '\\' || _string[1] != '\\'))
+                        || (!OperatingSystem.IsWindows() && InFact(Flags.UnixPath))))
                     {
                         _syntax = null!; //make it be relative Uri
                         _flags &= Flags.UserEscaped; // the only flag that makes sense for a relative uri
                         e = null;
                         return;
                         // Otherwise an absolute file Uri wins when it's of the form "\\something"
-                    }
-                    //
-                    // V1 compat issue
-                    // We should support relative Uris of the form c:\bla or c:/bla
-                    //
-                    else if (uriKind == UriKind.Relative && InFact(Flags.DosPath))
-                    {
-                        _syntax = null!; //make it be relative Uri
-                        _flags &= Flags.UserEscaped; // the only flag that makes sense for a relative uri
-                        e = null;
-                        return;
-                        // Otherwise an absolute file Uri wins when it's of the form "c:\something"
                     }
                 }
             }

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -140,7 +140,7 @@ namespace System
                     return e;
                 }
 
-                if (err != ParsingError.None || InFact(Flags.ErrorOrParsingRecursion))
+                if (InFact(Flags.ErrorOrParsingRecursion))
                 {
                     // User parser took over on an invalid Uri
                     // we use = here to clear all parsing flags for a uri that we think is invalid.


### PR DESCRIPTION
The current initialization logic is written in a way that makes it hard to read, and hides inconsistencise / unreachable logic.

This PR only shuffles things around & removes some unreachable branches **without changing the behavior**.
The aim is to make future changes that do change behavior actually reviewable.

Some context:
- we use `_syntax` to represent the Uri scheme. It's always `null` for relative Uris and set for absolute ones
- before we call into the `InitializeUri` we try to parse the scheme. This populates both `ParsingError err` and `_syntax`. These two are mutually exclusive - if `err` is set it means that `_syntax == null` and vice-versa.

I've split this up into smaller commits:
- https://github.com/dotnet/runtime/commit/a6523bbb5acc72b31fc782ee17690474a7e41f56?w=1
  - This recognizes the assertion I made above about the error and syntax being mutually exclusive.
  - It moves the logic for `err != ParsingError.None` up to the top, allowing us to drop the extra nesting of the `if (_syntax != null)` branch below it (it'll always be true).
  - It also removes two dead branches that were checking if `err != ParsingError.None` when we know it can't be
- https://github.com/dotnet/runtime/commit/c73795e1a2d83ebd8d705f5ba35f325dca688238
  - This simplifies our logic that decides whether an implicit file should be trated as absolute or relative.
  - We were effectively checking `NotAny(Flags.DosPath) && uriKind == UriKind.Relative` in one place and `InFact(Flags.DosPath) && uriKind == UriKind.Relative` in another, while doing the same thing in both cases. I simplified that condition to just check for `UriKind.Relative`.
  - After you handle the `Relative` case, the `uriKind != UriKind.Absolute` check becomes `== UriKind.RelativeOrAbsolute`, which makes it clearer what we're doing
- https://github.com/dotnet/runtime/commit/fdcd584e28a1f76d9e969053b72bb313f316709c
  - Changes the `UriFormatException` to the return value instead of an `out` param
- https://github.com/dotnet/runtime/commit/7400e9a98c7397f2ea88592d9edeb42c73dfc655
  - Takes a block of code that's duplicated at the end of both the `if` and `else` and moves it after the branch
- https://github.com/dotnet/runtime/commit/393f78f7cb5347779d8841797e622060e992821f
  - Inverts one conditon to drop some nesting
- https://github.com/dotnet/runtime/commit/2f968672967808c1a1e0935fffb12920df4aa465
  - Simple change of the switch block to the switch expression + removes an unused enum value