### PR TITLE
Optimize SMTP extension parsing

### DIFF
--- a/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpConnection.Auth.cs
+++ b/src/libraries/System.Net.Mail/src/System/Net/Mail/SmtpConnection.Auth.cs
@@ -47,6 +47,12 @@ namespace System.Net.Mail
             {
                 if (extension.StartsWith(AuthExtension, StringComparison.OrdinalIgnoreCase))
                 {
+                    if (extension.Length == AuthExtension.Length)
+                    {
+                        // No auth types specified
+                        continue;
+                    }
+
                     // remove the AUTH text including the following character
                     // to ensure that split only gets the modules supported
                     ReadOnlySpan<char> authTypes = extension.AsSpan(SizeOfAuthExtension);


### PR DESCRIPTION
Optimizes the parsing of SMTP extensions, mostly just by using some APIs which likely weren't available when this was last looked at closely.

- Eliminates allocations
- Roughly twice as fast
- Roughly half the code size

Benchmarks
```
BenchmarkDotNet v0.15.6, Windows 11 (10.0.26100.7171/24H2/2024Update/HudsonValley)
13th Gen Intel Core i7-1355U 1.70GHz, 1 CPU, 12 logical and 10 physical cores
.NET SDK 10.0.100
  [Host]     : .NET 10.0.0 (10.0.0, 10.0.25.52411), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.0 (10.0.0, 10.0.25.52411), X64 RyuJIT x86-64-v3

| Method             | Mean     | Error    | StdDev   | Ratio | Code Size | Gen0   | Allocated | Alloc Ratio |
|------------------- |---------:|---------:|---------:|------:|----------:|-------:|----------:|------------:|
| ParseExtension_Old | 48.40 ns | 0.156 ns | 0.138 ns |  1.00 |   1,831 B | 0.0357 |     224 B |        1.00 |
| ParseExtension     | 17.32 ns | 0.021 ns | 0.020 ns |  0.36 |     943 B |      - |         - |        0.00 |
```

<details>
  <summary>Benchmark Code</summary>

```csharp

BenchmarkRunner.Run<BenchmarkSmtpExtensionParser>();

[SimpleJob, MemoryDiagnoser, DisassemblyDiagnoser]
public class BenchmarkSmtpExtensionParser
{
    string[] extensions = ["SMTPUTF8", "STARTTLS", "AUTH:LOGIN NTLM GSSAPI"];
    private readonly SmtpExtensionParser _parser = new SmtpExtensionParser();

    [Benchmark(Baseline = true)]
    public void ParseExtension_Old() => _parser.ParseExtensions(extensions);

    [Benchmark]
    public void ParseExtension() => _parser.ParseExtensions2(extensions);
}

public class SmtpExtensionParser
{
    private bool _serverSupportsEai;
    private bool _dsnEnabled;
#pragma warning disable CS0414      // Field is not used in test project
    private bool _serverSupportsStartTls;
#pragma warning restore CS0414
    private bool _sawNegotiate;
    private SupportedAuth _supportedAuth = SupportedAuth.None;
    // accounts for the '=' or ' ' character after AUTH
    private const int SizeOfAuthExtension = 4;

    private static readonly char[] s_authExtensionSplitters = new char[] { ' ', '=' };

    private const string AuthExtension = "auth";
    private const string AuthLogin = "login";
    private const string AuthNtlm = "ntlm";
    private const string AuthGssapi = "gssapi";

    internal void ParseExtensions(string[] extensions)
    {
        _supportedAuth = SupportedAuth.None;
        foreach (string extension in extensions)
        {
            if (string.Compare(extension, 0, AuthExtension, 0,
                SizeOfAuthExtension, StringComparison.OrdinalIgnoreCase) == 0)
            {
                // remove the AUTH text including the following character
                // to ensure that split only gets the modules supported
                string[] authTypes = extension.Remove(0, SizeOfAuthExtension).Split(s_authExtensionSplitters, StringSplitOptions.RemoveEmptyEntries);
                foreach (string authType in authTypes)
                {
                    if (string.Equals(authType, AuthLogin, StringComparison.OrdinalIgnoreCase))
                    {
                        _supportedAuth |= SupportedAuth.Login;
                    }
                    else if (string.Equals(authType, AuthNtlm, StringComparison.OrdinalIgnoreCase))
                    {
                        _supportedAuth |= SupportedAuth.NTLM;
                    }
                    else if (string.Equals(authType, AuthGssapi, StringComparison.OrdinalIgnoreCase))
                    {
                        _supportedAuth |= SupportedAuth.GSSAPI;
                    }
                }
            }
            else if (string.Compare(extension, 0, "dsn ", 0, 3, StringComparison.OrdinalIgnoreCase) == 0)
            {
                _dsnEnabled = true;
            }
            else if (string.Compare(extension, 0, "STARTTLS", 0, 8, StringComparison.OrdinalIgnoreCase) == 0)
            {
                _serverSupportsStartTls = true;
            }
            else if (string.Compare(extension, 0, "SMTPUTF8", 0, 8, StringComparison.OrdinalIgnoreCase) == 0)
            {
                _serverSupportsEai = true;
            }
        }
    }

    internal void ParseExtensions2(string[] extensions)
    {
        _supportedAuth = SupportedAuth.None;
        foreach (string extension in extensions)
        {
            if (extension.StartsWith(AuthExtension, StringComparison.OrdinalIgnoreCase))
            {
                // remove the AUTH text including the following character
                // to ensure that split only gets the modules supported
                ReadOnlySpan<char> authTypes = extension.AsSpan(SizeOfAuthExtension + 1);

                foreach (Range i in authTypes.SplitAny(s_authExtensionSplitters))
                {
                    ReadOnlySpan<char> authType = authTypes[i];
                    if (authType.Equals(AuthLogin, StringComparison.OrdinalIgnoreCase))
                    {
                        _supportedAuth |= SupportedAuth.Login;
                    }
                    else if (authType.Equals(AuthNtlm, StringComparison.OrdinalIgnoreCase))
                    {
                        _supportedAuth |= SupportedAuth.NTLM;
                    }
                    else if (authType.Equals(AuthGssapi, StringComparison.OrdinalIgnoreCase))
                    {
                        _supportedAuth |= SupportedAuth.GSSAPI;
                    }
                }
            }
            else if (extension.StartsWith("dsn ", StringComparison.OrdinalIgnoreCase))
            {
                _dsnEnabled = true;
            }
            else if (extension.StartsWith("STARTTLS", StringComparison.OrdinalIgnoreCase))
            {
                _serverSupportsStartTls = true;
            }
            else if (extension.StartsWith("SMTPUTF8", StringComparison.OrdinalIgnoreCase))
            {
                _serverSupportsEai = true;
            }
        }
    }
}
```

</details>