### PR TITLE
[RISC-V] Use srli instead of srai for 32-bit unsigned mulhi

### DIFF
--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1055,7 +1055,7 @@ void CodeGen::genCodeForMulHi(GenTreeOp* treeNode)
             emit->emitIns_R_R_I(INS_slli, EA_8BYTE, tempReg, op1->GetRegNum(), 32);
             emit->emitIns_R_R_I(INS_slli, EA_8BYTE, targetReg, op2->GetRegNum(), 32);
             emit->emitIns_R_R_R(INS_mulhu, EA_8BYTE, targetReg, tempReg, targetReg);
-            emit->emitIns_R_R_I(INS_srai, attr, targetReg, targetReg, 32);
+            emit->emitIns_R_R_I(INS_srli, attr, targetReg, targetReg, 32);
         }
         else
         {


### PR DESCRIPTION
The 32-bit unsigned mulhi implementation previously used an arithmetic right shift (`srai`) to extract the high 32 bits from the widened 64-bit product. While this happens to produce correct results because the sign-extended high bits are discarded, the instruction does not semantically match the unsigned operation.

Using `srli` better reflects the intended semantics of an unsigned high-half multiply and avoids relying on sign-extension behavior.

No functional behavior change is expected.

Part of https://github.com/dotnet/runtime/issues/84834, cc @dotnet/samsung
@namu-lee 