### PR TITLE
[Android] Add ActiveIssue to TimeZoneInfoTests.TestGetSystemTimeZones

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/TimeZoneInfoTests.cs
@@ -2808,6 +2808,7 @@ namespace System.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/90269", TestPlatforms.Android)]
         public static void TestGetSystemTimeZones()
         {
             TimeZoneInfo.ClearCachedData(); // Start clean


### PR DESCRIPTION
The TimeZoneInfoTests.TestGetSystemTimeZones is failing due to a known issue where on Android we return timezones with duplicate display names (#90269), now we're just seeing it on a more recent Android API levels. This is possibly due to an update to the TZ data.

Closes #121963

/cc @tarekgh @davidnguyen-tech 