### PR TITLE
[wasm] Fix debug build of AOT cross compiler

### DIFF
--- a/src/mono/mono.proj
+++ b/src/mono/mono.proj
@@ -803,7 +803,6 @@ JS_ENGINES = [NODE_JS]
     <PropertyGroup Condition="'$(TargetsBrowser)' == 'true' or '$(TargetsWasi)' == 'true'">
       <MonoAotAbi Condition="'$(TargetsBrowser)' == 'true'">wasm32-unknown-none</MonoAotAbi>
       <MonoAotAbi Condition="'$(TargetsWasi)' == 'true'">wasm32-unknown-wasip2</MonoAotAbi>
-      <_ForceRelease Condition="$([MSBuild]::IsOSPlatform('Windows')) and '$(TargetArchitecture)' == 'wasm' and '$(Configuration)' == 'Debug'">true</_ForceRelease>
     </PropertyGroup>
 
     <!-- Windows specific options -->


### PR DESCRIPTION
Make debug version of cross compiler to link debug C runtime

reverts https://github.com/dotnet/runtime/pull/50418
related https://github.com/dotnet/runtime/pull/113536 https://github.com/pavelsavara/runtime/commit/ee4c4d9532d698a77d3cae9211562459b48b2454#diff-96c540b134a40045501aeaaec0e57f7365c649e88e70dd70e65924704fd29585R16