### PR TITLE
[browser] Add DiagnosticPorts to DOTNET_DiagnosticPorts environment variable

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -142,7 +142,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       $(GenerateBuildWasmBootJsonDependsOn);
       GenerateBuildRuntimeConfigurationFiles;
       ResolveWasmOutputs;
+      _AddWasmDiagnosticPortsEnvironmentVariable;
     </GenerateBuildWasmBootJsonDependsOn>
+    <GeneratePublishWasmBootJsonDependsOn>
+      $(GeneratePublishWasmBootJsonDependsOn);
+      _AddWasmDiagnosticPortsEnvironmentVariable;
+    </GeneratePublishWasmBootJsonDependsOn>
   </PropertyGroup>
 
   <Target Name="_WasmNativeForBuild" DependsOnTargets="_GatherWasmFilesToBuild;WasmBuildApp" Condition="'$(UsingBrowserRuntimeWorkload)' == 'true'" />
@@ -383,6 +388,12 @@ Copyright (c) .NET Foundation. All rights reserved.
       <StaticWebAsset Include="@(_WasmBuildBootConfigStaticWebAsset)" />
       <StaticWebAssetEndpoint Include="@(WasmStaticWebAssetEndpoint)" />
       <StaticWebAssetEndpoint Include="@(_WasmBuildBootConfigStaticWebAssetEndpoint)" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_AddWasmDiagnosticPortsEnvironmentVariable">
+    <ItemGroup>
+      <WasmEnvironmentVariable Include="DOTNET_DiagnosticPorts" Value="$(DiagnosticPorts)" Condition="'$(DiagnosticPorts)' != ''"/>
     </ItemGroup>
   </Target>
 

--- a/src/mono/sample/wasm/Directory.Build.targets
+++ b/src/mono/sample/wasm/Directory.Build.targets
@@ -35,6 +35,7 @@
     <NestedBuildProperty Include="WasmEmitSymbolMap" />
     <NestedBuildProperty Include="WasmEnableThreads" />
     <NestedBuildProperty Include="EnableDiagnostics" />
+    <NestedBuildProperty Include="DiagnosticPorts" />
     <NestedBuildProperty Include="WasmPerformanceInstrumentation" />
   </ItemGroup>
 


### PR DESCRIPTION
We had this implemention in WasmAppBuilder. This PR promotes it to WasmSDK