### PR TITLE
Fold Span.Slice(X) like bound checks

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4470,11 +4470,12 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
 
         if (peeledOffset != 0)
         {
-            Range peeledOp1Rng = Range(Limit(Limit::keUnknown));
+            Range peeledOffsetRng = Range(Limit(Limit::keConstant, peeledOffset));
+            Range peeledOp1Rng    = Range(Limit(Limit::keUnknown));
             if (RangeCheck::TryGetRangeFromAssertions(this, peeledOp1VN, assertions, &peeledOp1Rng))
             {
-                Range peeledOffsetRng = Range(Limit(Limit::keConstant, peeledOffset));
-                rng2 = RangeOps::Subtract(rng2, peeledOffsetRng); // Subtract handles overflow internally.
+                // Subtract handles overflow internally.
+                rng2 = RangeOps::Subtract(rng2, peeledOffsetRng);
 
                 RangeOps::RelationKind kind =
                     RangeOps::EvalRelop(tree->OperGet(), tree->IsUnsigned(), peeledOp1Rng, rng2);

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4474,7 +4474,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
             if (RangeCheck::TryGetRangeFromAssertions(this, peeledOp1VN, assertions, &peeledOp1Rng))
             {
                 Range peeledOffsetRng = Range(Limit(Limit::keConstant, peeledOffset));
-                rng2                  = RangeOps::Add(rng2, peeledOffsetRng); // Add handles overflow internally.
+                rng2 = RangeOps::Subtract(rng2, peeledOffsetRng); // Subtract handles overflow internally.
 
                 RangeOps::RelationKind kind =
                     RangeOps::EvalRelop(tree->OperGet(), tree->IsUnsigned(), peeledOp1Rng, rng2);

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4463,27 +4463,31 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
         }
 
         // If op1VN is actually ADD(X, CNS), we can try peeling the constant offset and adjusting op2Cns accordingly.
+        // It's a bit more complicated for unsigned comparisons, so only do it for signed ones for now.
         //
-        ValueNum peeledOp1VN  = op1VN;
-        int      peeledOffset = 0;
-        vnStore->PeelOffsetsI32(&peeledOp1VN, &peeledOffset);
-
-        if (peeledOffset != 0)
+        if (!tree->IsUnsigned())
         {
-            Range peeledOffsetRng = Range(Limit(Limit::keConstant, peeledOffset));
-            Range peeledOp1Rng    = Range(Limit(Limit::keUnknown));
-            if (RangeCheck::TryGetRangeFromAssertions(this, peeledOp1VN, assertions, &peeledOp1Rng))
-            {
-                // Subtract handles overflow internally.
-                rng2 = RangeOps::Subtract(rng2, peeledOffsetRng);
+            ValueNum peeledOp1VN  = op1VN;
+            int      peeledOffset = 0;
+            vnStore->PeelOffsetsI32(&peeledOp1VN, &peeledOffset);
 
-                RangeOps::RelationKind kind =
-                    RangeOps::EvalRelop(tree->OperGet(), tree->IsUnsigned(), peeledOp1Rng, rng2);
-                if ((kind != RangeOps::RelationKind::Unknown))
+            if (peeledOffset != 0)
+            {
+                Range peeledOffsetRng = Range(Limit(Limit::keConstant, peeledOffset));
+                Range peeledOp1Rng    = Range(Limit(Limit::keUnknown));
+                if (RangeCheck::TryGetRangeFromAssertions(this, peeledOp1VN, assertions, &peeledOp1Rng))
                 {
-                    newTree = kind == RangeOps::RelationKind::AlwaysTrue ? gtNewTrue() : gtNewFalse();
-                    newTree = gtWrapWithSideEffects(newTree, tree, GTF_ALL_EFFECT);
-                    return optAssertionProp_Update(newTree, tree, stmt);
+                    // Subtract handles overflow internally.
+                    rng2 = RangeOps::Subtract(rng2, peeledOffsetRng);
+
+                    RangeOps::RelationKind kind =
+                        RangeOps::EvalRelop(tree->OperGet(), tree->IsUnsigned(), peeledOp1Rng, rng2);
+                    if ((kind != RangeOps::RelationKind::Unknown))
+                    {
+                        newTree = kind == RangeOps::RelationKind::AlwaysTrue ? gtNewTrue() : gtNewFalse();
+                        newTree = gtWrapWithSideEffects(newTree, tree, GTF_ALL_EFFECT);
+                        return optAssertionProp_Update(newTree, tree, stmt);
+                    }
                 }
             }
         }

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -328,6 +328,24 @@ struct RangeOps
         return Limit(Limit::keUnknown);
     }
 
+    static Limit SubtractConstantLimit(const Limit& value, const Limit& cns)
+    {
+        assert(cns.IsConstant());
+
+        if (cns.GetConstant() == INT_MIN)
+        {
+            // Subtracting INT_MIN would overflow
+            return Limit(Limit::keUnknown);
+        }
+
+        Limit l = value;
+        if (l.AddConstant(-cns.GetConstant()))
+        {
+            return l;
+        }
+        return Limit(Limit::keUnknown);
+    }
+
     // Perform 'value' * 'cns'
     static Limit MultiplyConstantLimit(const Limit& value, const Limit& cns)
     {
@@ -389,6 +407,47 @@ struct RangeOps
         if (r2hi.IsConstant())
         {
             result.uLimit = AddConstantLimit(r1hi, r2hi);
+        }
+        return result;
+    }
+
+    // Given two ranges "r1" and "r2", perform an add operation on the
+    // ranges.
+    static Range Subtract(Range& r1, Range& r2)
+    {
+        Limit& r1lo = r1.LowerLimit();
+        Limit& r1hi = r1.UpperLimit();
+        Limit& r2lo = r2.LowerLimit();
+        Limit& r2hi = r2.UpperLimit();
+
+        Range result = Limit(Limit::keUnknown);
+
+        // Check lo ranges if they are dependent and not unknown.
+        if ((r1lo.IsDependent() && !r1lo.IsUnknown()) || (r2lo.IsDependent() && !r2lo.IsUnknown()))
+        {
+            result.lLimit = Limit(Limit::keDependent);
+        }
+        // Check hi ranges if they are dependent and not unknown.
+        if ((r1hi.IsDependent() && !r1hi.IsUnknown()) || (r2hi.IsDependent() && !r2hi.IsUnknown()))
+        {
+            result.uLimit = Limit(Limit::keDependent);
+        }
+
+        if (r1lo.IsConstant())
+        {
+            result.lLimit = SubtractConstantLimit(r2lo, r1lo);
+        }
+        if (r2lo.IsConstant())
+        {
+            result.lLimit = SubtractConstantLimit(r1lo, r2lo);
+        }
+        if (r1hi.IsConstant())
+        {
+            result.uLimit = SubtractConstantLimit(r2hi, r1hi);
+        }
+        if (r2hi.IsConstant())
+        {
+            result.uLimit = SubtractConstantLimit(r1hi, r2hi);
         }
         return result;
     }

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -328,6 +328,7 @@ struct RangeOps
         return Limit(Limit::keUnknown);
     }
 
+    // Perform 'value' - 'cns'
     static Limit SubtractConstantLimit(const Limit& value, const Limit& cns)
     {
         assert(cns.IsConstant());
@@ -370,9 +371,9 @@ struct RangeOps
         return Limit(Limit::keUnknown);
     }
 
-    // Given two ranges "r1" and "r2", perform an add operation on the
-    // ranges.
-    static Range Add(Range& r1, Range& r2)
+    // Given two ranges "r1" and "r2", perform a generic 'op' operation on the ranges.
+    template <typename Operation>
+    static Range ApplyRangeOp(Range& r1, Range& r2, Operation op)
     {
         Limit& r1lo = r1.LowerLimit();
         Limit& r1hi = r1.UpperLimit();
@@ -394,62 +395,43 @@ struct RangeOps
 
         if (r1lo.IsConstant())
         {
-            result.lLimit = AddConstantLimit(r2lo, r1lo);
+            result.lLimit = op(r2lo, r1lo);
         }
         if (r2lo.IsConstant())
         {
-            result.lLimit = AddConstantLimit(r1lo, r2lo);
+            result.lLimit = op(r1lo, r2lo);
         }
         if (r1hi.IsConstant())
         {
-            result.uLimit = AddConstantLimit(r2hi, r1hi);
+            result.uLimit = op(r2hi, r1hi);
         }
         if (r2hi.IsConstant())
         {
-            result.uLimit = AddConstantLimit(r1hi, r2hi);
+            result.uLimit = op(r1hi, r2hi);
         }
+
         return result;
     }
 
-    // Given two ranges "r1" and "r2", perform an add operation on the
-    // ranges.
+    static Range Add(Range& r1, Range& r2)
+    {
+        return ApplyRangeOp(r1, r2, [](Limit& a, Limit& b) {
+            return AddConstantLimit(a, b);
+        });
+    }
+
     static Range Subtract(Range& r1, Range& r2)
     {
-        Limit& r1lo = r1.LowerLimit();
-        Limit& r1hi = r1.UpperLimit();
-        Limit& r2lo = r2.LowerLimit();
-        Limit& r2hi = r2.UpperLimit();
+        return ApplyRangeOp(r1, r2, [](Limit& a, Limit& b) {
+            return SubtractConstantLimit(a, b);
+        });
+    }
 
-        Range result = Limit(Limit::keUnknown);
-
-        // Check lo ranges if they are dependent and not unknown.
-        if ((r1lo.IsDependent() && !r1lo.IsUnknown()) || (r2lo.IsDependent() && !r2lo.IsUnknown()))
-        {
-            result.lLimit = Limit(Limit::keDependent);
-        }
-        // Check hi ranges if they are dependent and not unknown.
-        if ((r1hi.IsDependent() && !r1hi.IsUnknown()) || (r2hi.IsDependent() && !r2hi.IsUnknown()))
-        {
-            result.uLimit = Limit(Limit::keDependent);
-        }
-
-        if (r1lo.IsConstant())
-        {
-            result.lLimit = SubtractConstantLimit(r2lo, r1lo);
-        }
-        if (r2lo.IsConstant())
-        {
-            result.lLimit = SubtractConstantLimit(r1lo, r2lo);
-        }
-        if (r1hi.IsConstant())
-        {
-            result.uLimit = SubtractConstantLimit(r2hi, r1hi);
-        }
-        if (r2hi.IsConstant())
-        {
-            result.uLimit = SubtractConstantLimit(r1hi, r2hi);
-        }
-        return result;
+    static Range Multiply(Range& r1, Range& r2)
+    {
+        return ApplyRangeOp(r1, r2, [](Limit& a, Limit& b) {
+            return MultiplyConstantLimit(a, b);
+        });
     }
 
     static Range ShiftRight(Range& r1, Range& r2)
@@ -486,47 +468,6 @@ struct RangeOps
             result.uLimit = ShiftRightConstantLimit(r1hi, r2hi);
         }
 
-        return result;
-    }
-
-    // Given two ranges "r1" and "r2", perform an multiply operation on the
-    // ranges.
-    static Range Multiply(Range& r1, Range& r2)
-    {
-        Limit& r1lo = r1.LowerLimit();
-        Limit& r1hi = r1.UpperLimit();
-        Limit& r2lo = r2.LowerLimit();
-        Limit& r2hi = r2.UpperLimit();
-
-        Range result = Limit(Limit::keUnknown);
-
-        // Check lo ranges if they are dependent and not unknown.
-        if ((r1lo.IsDependent() && !r1lo.IsUnknown()) || (r2lo.IsDependent() && !r2lo.IsUnknown()))
-        {
-            result.lLimit = Limit(Limit::keDependent);
-        }
-        // Check hi ranges if they are dependent and not unknown.
-        if ((r1hi.IsDependent() && !r1hi.IsUnknown()) || (r2hi.IsDependent() && !r2hi.IsUnknown()))
-        {
-            result.uLimit = Limit(Limit::keDependent);
-        }
-
-        if (r1lo.IsConstant())
-        {
-            result.lLimit = MultiplyConstantLimit(r2lo, r1lo);
-        }
-        if (r2lo.IsConstant())
-        {
-            result.lLimit = MultiplyConstantLimit(r1lo, r2lo);
-        }
-        if (r1hi.IsConstant())
-        {
-            result.uLimit = MultiplyConstantLimit(r2hi, r1hi);
-        }
-        if (r2hi.IsConstant())
-        {
-            result.uLimit = MultiplyConstantLimit(r1hi, r2hi);
-        }
         return result;
     }
 


### PR DESCRIPTION
[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1215131&view=ms.vss-build-web.run-extensions-tab).

```cs
    static Vector256<int> Test(Span<int> values)
    {
        if (values.Length < 16)
            return default;
        return Vector256.Create(values.Slice(8));
    }
```
Was:
```asm
; Method Program:Test(System.Span`1[int]):System.Runtime.Intrinsics.Vector256`1[int] (FullOpts)
       sub      rsp, 40
       mov      rax, bword ptr [rdx]
       mov      edx, dword ptr [rdx+0x08]
       cmp      edx, 16
       jl       SHORT G_M55981_IG04
       add      rax, 32
       add      edx, -8
       cmp      edx, 8
       jl       SHORT G_M55981_IG07
       vmovups  ymm0, ymmword ptr [rax]
       vmovups  ymmword ptr [rcx], ymm0
       jmp      SHORT G_M55981_IG05
G_M55981_IG04:
       vxorps   ymm0, ymm0, ymm0
       vmovups  ymmword ptr [rcx], ymm0
G_M55981_IG05:
       mov      rax, rcx
       vzeroupper 
       add      rsp, 40
       ret      
G_M55981_IG07:
       mov      ecx, 6
       call     [System.ThrowHelper:ThrowArgumentOutOfRangeException(int)]
       int3     
; Total bytes of code: 68
```
Now:
```asm
; Method Program:Test(System.Span`1[int]):System.Runtime.Intrinsics.Vector256`1[int] (FullOpts)
       mov      rax, bword ptr [rdx]
       mov      edx, dword ptr [rdx+0x08]
       cmp      edx, 16
       jl       SHORT G_M55981_IG04
       add      rax, 32
       vmovups  ymm0, ymmword ptr [rax]
       vmovups  ymmword ptr [rcx], ymm0
       jmp      SHORT G_M55981_IG05
G_M55981_IG04:
       vxorps   ymm0, ymm0, ymm0
       vmovups  ymmword ptr [rcx], ymm0
G_M55981_IG05:
       mov      rax, rcx
       vzeroupper 
       ret      
; Total bytes of code: 40
```