### PR TITLE
Make ZipArchiveEntry.CompressionMethod public

### DIFF
--- a/src/libraries/System.IO.Compression/ref/System.IO.Compression.cs
+++ b/src/libraries/System.IO.Compression/ref/System.IO.Compression.cs
@@ -136,7 +136,7 @@ namespace System.IO.Compression
         Create = 1,
         Update = 2,
     }
-    public enum ZipCompressionMethod : short
+    public enum ZipCompressionMethod
     {
         Stored = 0,
         Deflate = 8,

--- a/src/libraries/System.IO.Compression/ref/System.IO.Compression.cs
+++ b/src/libraries/System.IO.Compression/ref/System.IO.Compression.cs
@@ -116,6 +116,7 @@ namespace System.IO.Compression
         [System.Diagnostics.CodeAnalysis.AllowNullAttribute]
         public string Comment { get { throw null; } set { } }
         public long CompressedLength { get { throw null; } }
+        public System.IO.Compression.ZipCompressionMethod CompressionMethod { get { throw null; } }
         [System.CLSCompliantAttribute(false)]
         public uint Crc32 { get { throw null; } }
         public int ExternalAttributes { get { throw null; } set { } }
@@ -134,6 +135,12 @@ namespace System.IO.Compression
         Read = 0,
         Create = 1,
         Update = 2,
+    }
+    public enum ZipCompressionMethod : short
+    {
+        Stored = 0,
+        Deflate = 8,
+        Deflate64 = 9,
     }
     public sealed partial class ZLibCompressionOptions
     {

--- a/src/libraries/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/libraries/System.IO.Compression/src/System.IO.Compression.csproj
@@ -54,6 +54,7 @@
     <Compile Include="System\IO\Compression\PositionPreservingWriteOnlyStreamWrapper.cs" />
     <Compile Include="System\IO\Compression\ZLibCompressionOptions.cs" />
     <Compile Include="System\IO\Compression\ZLibStream.cs" />
+    <Compile Include="System\IO\Compression\ZipCompressionMethod.cs" />
     <Compile Include="$(CommonPath)System\Obsoletions.cs"
              Link="Common\System\Obsoletions.cs" />
   </ItemGroup>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/DeflateManagedStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/DeflateManagedStream.cs
@@ -20,16 +20,16 @@ namespace System.IO.Compression
         private int _asyncOperations;
 
         // A specific constructor to allow decompression of Deflate64
-        internal DeflateManagedStream(Stream stream, ZipArchiveEntry.CompressionMethodValues method, long uncompressedSize = -1)
+        internal DeflateManagedStream(Stream stream, ZipCompressionMethod method, long uncompressedSize = -1)
         {
             ArgumentNullException.ThrowIfNull(stream);
 
             if (!stream.CanRead)
                 throw new ArgumentException(SR.NotSupported_UnreadableStream, nameof(stream));
 
-            Debug.Assert(method == ZipArchiveEntry.CompressionMethodValues.Deflate64);
+            Debug.Assert(method == ZipCompressionMethod.Deflate64);
 
-            _inflater = new InflaterManaged(method == ZipArchiveEntry.CompressionMethodValues.Deflate64, uncompressedSize);
+            _inflater = new InflaterManaged(method == ZipCompressionMethod.Deflate64, uncompressedSize);
 
             _stream = stream;
             _buffer = new byte[DefaultBufferSize];

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -89,9 +89,9 @@ public partial class ZipArchiveEntry
             }
 
             // if they start modifying it and the compression method is not "store", we should make sure it will get deflated
-            if (CompressionMethod != CompressionMethodValues.Stored)
+            if (StoredCompressionMethodInternal != ZipCompressionMethod.Stored)
             {
-                CompressionMethod = CompressionMethodValues.Deflate;
+                StoredCompressionMethodInternal = ZipCompressionMethod.Deflate;
             }
         }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Async.cs
@@ -89,9 +89,9 @@ public partial class ZipArchiveEntry
             }
 
             // if they start modifying it and the compression method is not "store", we should make sure it will get deflated
-            if (StoredCompressionMethodInternal != ZipCompressionMethod.Stored)
+            if (CompressionMethod != ZipCompressionMethod.Stored)
             {
-                StoredCompressionMethodInternal = ZipCompressionMethod.Deflate;
+                CompressionMethod = ZipCompressionMethod.Deflate;
             }
         }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -24,7 +24,7 @@ namespace System.IO.Compression
         private ZipVersionNeededValues _versionToExtract;
         private BitFlagValues _generalPurposeBitFlag;
         private readonly bool _isEncrypted;
-        private CompressionMethodValues _storedCompressionMethod;
+        private ZipCompressionMethod _storedCompressionMethod;
         private DateTimeOffset _lastModified;
         private long _compressedSize;
         private long _uncompressedSize;
@@ -66,7 +66,7 @@ namespace System.IO.Compression
             _versionToExtract = (ZipVersionNeededValues)cd.VersionNeededToExtract;
             _generalPurposeBitFlag = (BitFlagValues)cd.GeneralPurposeBitFlag;
             _isEncrypted = (_generalPurposeBitFlag & BitFlagValues.IsEncrypted) != 0;
-            CompressionMethod = (CompressionMethodValues)cd.CompressionMethod;
+            StoredCompressionMethodInternal = (ZipCompressionMethod)cd.CompressionMethod;
             _lastModified = new DateTimeOffset(ZipHelper.DosTimeToDateTime(cd.LastModified));
             _compressedSize = cd.CompressedSize;
             _uncompressedSize = cd.UncompressedSize;
@@ -94,7 +94,7 @@ namespace System.IO.Compression
 
             _fileComment = cd.FileComment;
 
-            _compressionLevel = MapCompressionLevel(_generalPurposeBitFlag, CompressionMethod);
+            _compressionLevel = MapCompressionLevel(_generalPurposeBitFlag, StoredCompressionMethodInternal);
         }
 
         // Initializes a ZipArchiveEntry instance for a new archive entry with a specified compression level.
@@ -104,9 +104,9 @@ namespace System.IO.Compression
             _compressionLevel = compressionLevel;
             if (_compressionLevel == CompressionLevel.NoCompression)
             {
-                CompressionMethod = CompressionMethodValues.Stored;
+                StoredCompressionMethodInternal = ZipCompressionMethod.Stored;
             }
-            _generalPurposeBitFlag = MapDeflateCompressionOption(_generalPurposeBitFlag, _compressionLevel, CompressionMethod);
+            _generalPurposeBitFlag = MapDeflateCompressionOption(_generalPurposeBitFlag, _compressionLevel, StoredCompressionMethodInternal);
         }
 
         // Initializes a ZipArchiveEntry instance for a new archive entry.
@@ -121,8 +121,8 @@ namespace System.IO.Compression
             _versionMadeBySpecification = ZipVersionNeededValues.Default;
             _versionToExtract = ZipVersionNeededValues.Default; // this must happen before following two assignment
             _compressionLevel = CompressionLevel.Optimal;
-            CompressionMethod = CompressionMethodValues.Deflate;
-            _generalPurposeBitFlag = MapDeflateCompressionOption(0, _compressionLevel, CompressionMethod);
+            StoredCompressionMethodInternal = ZipCompressionMethod.Deflate;
+            _generalPurposeBitFlag = MapDeflateCompressionOption(0, _compressionLevel, StoredCompressionMethodInternal);
             _lastModified = DateTimeOffset.Now;
 
             _compressedSize = 0; // we don't know these yet
@@ -172,6 +172,15 @@ namespace System.IO.Compression
         /// Gets a value that indicates whether the entry is encrypted.
         /// </summary>
         public bool IsEncrypted => _isEncrypted;
+
+        /// <summary>
+        /// Gets the compression method used to compress the entry.
+        /// </summary>
+        /// <remarks>
+        /// Returns the compression method as stored in the zip archive header. The value corresponds to the
+        /// compression method values described in the ZIP File Format Specification (APPNOTE.TXT section 4.4.5).
+        /// </remarks>
+        public ZipCompressionMethod CompressionMethod => _storedCompressionMethod;
 
         /// <summary>
         /// The compressed size of the entry. If the archive that the entry belongs to is in Create mode, attempts to get this property will always throw an exception. If the archive that the entry belongs to is in update mode, this property will only be valid if the entry has not been opened.
@@ -363,6 +372,51 @@ namespace System.IO.Compression
         }
 
         /// <summary>
+        /// Opens the entry with the specified access mode. This allows for more granular control over the returned stream's capabilities.
+        /// </summary>
+        /// <param name="access">The desired file access mode for the returned stream.</param>
+        /// <returns>A Stream that represents the contents of the entry with the specified access capabilities.</returns>
+        /// <exception cref="ArgumentException">The requested access is not compatible with the archive's open mode.</exception>
+        /// <exception cref="IOException">The entry is already currently open for writing. -or- The entry has been deleted from the archive. -or- The archive that this entry belongs to was opened in ZipArchiveMode.Create, and this entry has already been written to once.</exception>
+        /// <exception cref="InvalidDataException">The entry is missing from the archive or is corrupt and cannot be read. -or- The entry has been compressed using a compression method that is not supported.</exception>
+        /// <exception cref="ObjectDisposedException">The ZipArchive that this entry belongs to has been disposed.</exception>
+        public Stream Open(FileAccess access)
+        {
+            ThrowIfInvalidArchive();
+
+            // Validate that the requested access is compatible with the archive's mode
+            switch (_archive.Mode)
+            {
+                case ZipArchiveMode.Read:
+                    if (access != FileAccess.Read)
+                        throw new ArgumentException(SR.CannotBeWrittenInReadMode, nameof(access));
+                    return OpenInReadMode(checkOpenable: true);
+
+                case ZipArchiveMode.Create:
+                    if (access == FileAccess.Read)
+                        throw new ArgumentException(SR.CannotBeReadInCreateMode, nameof(access));
+                    return OpenInWriteMode();
+
+                case ZipArchiveMode.Update:
+                    switch (access)
+                    {
+                        case FileAccess.Read:
+                            return OpenInReadMode(checkOpenable: true);
+                        case FileAccess.Write:
+                            return OpenInWriteMode();
+                        case FileAccess.ReadWrite:
+                            return OpenInUpdateMode();
+                        default:
+                            throw new ArgumentException(SR.InvalidFileAccess, nameof(access));
+                    }
+
+                default:
+                    Debug.Assert(_archive.Mode == ZipArchiveMode.Update);
+                    return OpenInUpdateMode();
+            }
+        }
+
+        /// <summary>
         /// Returns the FullName of the entry.
         /// </summary>
         /// <returns>FullName of the entry</returns>
@@ -439,23 +493,23 @@ namespace System.IO.Compression
                 }
 
                 // if they start modifying it and the compression method is not "store", we should make sure it will get deflated
-                if (CompressionMethod != CompressionMethodValues.Stored)
+                if (StoredCompressionMethodInternal != ZipCompressionMethod.Stored)
                 {
-                    CompressionMethod = CompressionMethodValues.Deflate;
+                    StoredCompressionMethodInternal = ZipCompressionMethod.Deflate;
                 }
             }
 
             return _storedUncompressedData;
         }
 
-        private CompressionMethodValues CompressionMethod
+        private ZipCompressionMethod StoredCompressionMethodInternal
         {
             get { return _storedCompressionMethod; }
             set
             {
-                if (value == CompressionMethodValues.Deflate)
+                if (value == ZipCompressionMethod.Deflate)
                     VersionToExtractAtLeast(ZipVersionNeededValues.Deflate);
-                else if (value == CompressionMethodValues.Deflate64)
+                else if (value == ZipCompressionMethod.Deflate64)
                     VersionToExtractAtLeast(ZipVersionNeededValues.Deflate64);
                 _storedCompressionMethod = value;
             }
@@ -714,20 +768,20 @@ namespace System.IO.Compression
             // changed to Stored.
             //
             // Note: Deflate64 is not supported on all platforms
-            Debug.Assert(CompressionMethod == CompressionMethodValues.Deflate
-                || CompressionMethod == CompressionMethodValues.Stored);
+            Debug.Assert(StoredCompressionMethodInternal == ZipCompressionMethod.Deflate
+                || StoredCompressionMethodInternal == ZipCompressionMethod.Stored);
             Func<Stream> compressorStreamFactory;
 
             bool isIntermediateStream = true;
 
-            switch (CompressionMethod)
+            switch (StoredCompressionMethodInternal)
             {
-                case CompressionMethodValues.Stored:
+                case ZipCompressionMethod.Stored:
                     compressorStreamFactory = () => backingStream;
                     isIntermediateStream = false;
                     break;
-                case CompressionMethodValues.Deflate:
-                case CompressionMethodValues.Deflate64:
+                case ZipCompressionMethod.Deflate:
+                case ZipCompressionMethod.Deflate64:
                 default:
                     compressorStreamFactory = () => new DeflateStream(backingStream, _compressionLevel, leaveBackingStreamOpen);
                     break;
@@ -754,19 +808,19 @@ namespace System.IO.Compression
         private Stream GetDataDecompressor(Stream compressedStreamToRead)
         {
             Stream? uncompressedStream;
-            switch (CompressionMethod)
+            switch (StoredCompressionMethodInternal)
             {
-                case CompressionMethodValues.Deflate:
+                case ZipCompressionMethod.Deflate:
                     uncompressedStream = new DeflateStream(compressedStreamToRead, CompressionMode.Decompress, _uncompressedSize);
                     break;
-                case CompressionMethodValues.Deflate64:
-                    uncompressedStream = new DeflateManagedStream(compressedStreamToRead, CompressionMethodValues.Deflate64, _uncompressedSize);
+                case ZipCompressionMethod.Deflate64:
+                    uncompressedStream = new DeflateManagedStream(compressedStreamToRead, ZipCompressionMethod.Deflate64, _uncompressedSize);
                     break;
-                case CompressionMethodValues.Stored:
+                case ZipCompressionMethod.Stored:
                 default:
                     // we can assume that only deflate/deflate64/stored are allowed because we assume that
                     // IsOpenable is checked before this function is called
-                    Debug.Assert(CompressionMethod == CompressionMethodValues.Stored);
+                    Debug.Assert(StoredCompressionMethodInternal == ZipCompressionMethod.Stored);
 
                     uncompressedStream = compressedStreamToRead;
                     break;
@@ -867,15 +921,11 @@ namespace System.IO.Compression
             message = null;
             if (needToUncompress)
             {
-                if (CompressionMethod != CompressionMethodValues.Stored &&
-                    CompressionMethod != CompressionMethodValues.Deflate &&
-                    CompressionMethod != CompressionMethodValues.Deflate64)
+                if (StoredCompressionMethodInternal != ZipCompressionMethod.Stored &&
+                    StoredCompressionMethodInternal != ZipCompressionMethod.Deflate &&
+                    StoredCompressionMethodInternal != ZipCompressionMethod.Deflate64)
                 {
-                    message = CompressionMethod switch
-                    {
-                        CompressionMethodValues.BZip2 or CompressionMethodValues.LZMA => SR.Format(SR.UnsupportedCompressionMethod, CompressionMethod.ToString()),
-                        _ => SR.UnsupportedCompression,
-                    };
+                    message = SR.UnsupportedCompression;
                     return false;
                 }
             }
@@ -923,11 +973,11 @@ namespace System.IO.Compression
 
         private bool AreSizesTooLarge => _compressedSize > uint.MaxValue || _uncompressedSize > uint.MaxValue;
 
-        private static CompressionLevel MapCompressionLevel(BitFlagValues generalPurposeBitFlag, CompressionMethodValues compressionMethod)
+        private static CompressionLevel MapCompressionLevel(BitFlagValues generalPurposeBitFlag, ZipCompressionMethod compressionMethod)
         {
             // Information about the Deflate compression option is stored in bits 1 and 2 of the general purpose bit flags.
             // If the compression method is not Deflate, the Deflate compression option is invalid - default to NoCompression.
-            if (compressionMethod == CompressionMethodValues.Deflate || compressionMethod == CompressionMethodValues.Deflate64)
+            if (compressionMethod == ZipCompressionMethod.Deflate || compressionMethod == ZipCompressionMethod.Deflate64)
             {
                 return ((int)generalPurposeBitFlag & 0x6) switch
                 {
@@ -944,12 +994,12 @@ namespace System.IO.Compression
             }
         }
 
-        private static BitFlagValues MapDeflateCompressionOption(BitFlagValues generalPurposeBitFlag, CompressionLevel compressionLevel, CompressionMethodValues compressionMethod)
+        private static BitFlagValues MapDeflateCompressionOption(BitFlagValues generalPurposeBitFlag, CompressionLevel compressionLevel, ZipCompressionMethod compressionMethod)
         {
             ushort deflateCompressionOptions = (ushort)(
                 // The Deflate compression level is only valid if the compression method is actually Deflate (or Deflate64). If it's not, the
                 // value of the two bits is undefined and they should be zeroed out.
-                compressionMethod == CompressionMethodValues.Deflate || compressionMethod == CompressionMethodValues.Deflate64
+                compressionMethod == ZipCompressionMethod.Deflate || compressionMethod == ZipCompressionMethod.Deflate64
                     ? compressionLevel switch
                     {
                         CompressionLevel.Optimal => 0,
@@ -982,7 +1032,7 @@ namespace System.IO.Compression
             // if we already know that we have an empty file don't worry about anything, just do a straight shot of the header
             if (isEmptyFile)
             {
-                CompressionMethod = CompressionMethodValues.Stored;
+                StoredCompressionMethodInternal = ZipCompressionMethod.Stored;
                 compressedSizeTruncated = 0;
                 uncompressedSizeTruncated = 0;
                 Debug.Assert(_uncompressedSize == 0);
@@ -1625,15 +1675,6 @@ namespace System.IO.Compression
             IsEncrypted = 0x1,
             DataDescriptor = 0x8,
             UnicodeFileNameAndComment = 0x800
-        }
-
-        internal enum CompressionMethodValues : ushort
-        {
-            Stored = 0x0,
-            Deflate = 0x8,
-            Deflate64 = 0x9,
-            BZip2 = 0xC,
-            LZMA = 0xE
         }
 
         internal sealed class LocalHeaderOffsetComparer : Comparer<ZipArchiveEntry>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -372,51 +372,6 @@ namespace System.IO.Compression
         }
 
         /// <summary>
-        /// Opens the entry with the specified access mode. This allows for more granular control over the returned stream's capabilities.
-        /// </summary>
-        /// <param name="access">The desired file access mode for the returned stream.</param>
-        /// <returns>A Stream that represents the contents of the entry with the specified access capabilities.</returns>
-        /// <exception cref="ArgumentException">The requested access is not compatible with the archive's open mode.</exception>
-        /// <exception cref="IOException">The entry is already currently open for writing. -or- The entry has been deleted from the archive. -or- The archive that this entry belongs to was opened in ZipArchiveMode.Create, and this entry has already been written to once.</exception>
-        /// <exception cref="InvalidDataException">The entry is missing from the archive or is corrupt and cannot be read. -or- The entry has been compressed using a compression method that is not supported.</exception>
-        /// <exception cref="ObjectDisposedException">The ZipArchive that this entry belongs to has been disposed.</exception>
-        public Stream Open(FileAccess access)
-        {
-            ThrowIfInvalidArchive();
-
-            // Validate that the requested access is compatible with the archive's mode
-            switch (_archive.Mode)
-            {
-                case ZipArchiveMode.Read:
-                    if (access != FileAccess.Read)
-                        throw new ArgumentException(SR.CannotBeWrittenInReadMode, nameof(access));
-                    return OpenInReadMode(checkOpenable: true);
-
-                case ZipArchiveMode.Create:
-                    if (access == FileAccess.Read)
-                        throw new ArgumentException(SR.CannotBeReadInCreateMode, nameof(access));
-                    return OpenInWriteMode();
-
-                case ZipArchiveMode.Update:
-                    switch (access)
-                    {
-                        case FileAccess.Read:
-                            return OpenInReadMode(checkOpenable: true);
-                        case FileAccess.Write:
-                            return OpenInWriteMode();
-                        case FileAccess.ReadWrite:
-                            return OpenInUpdateMode();
-                        default:
-                            throw new ArgumentException(SR.InvalidFileAccess, nameof(access));
-                    }
-
-                default:
-                    Debug.Assert(_archive.Mode == ZipArchiveMode.Update);
-                    return OpenInUpdateMode();
-            }
-        }
-
-        /// <summary>
         /// Returns the FullName of the entry.
         /// </summary>
         /// <returns>FullName of the entry</returns>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -176,10 +176,6 @@ namespace System.IO.Compression
         /// <summary>
         /// Gets the compression method used to compress the entry.
         /// </summary>
-        /// <remarks>
-        /// Returns the compression method as stored in the zip archive header. The value corresponds to the
-        /// compression method values described in the ZIP File Format Specification (APPNOTE.TXT section 4.4.5).
-        /// </remarks>
         public ZipCompressionMethod CompressionMethod => _storedCompressionMethod;
 
         /// <summary>

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCompressionMethod.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCompressionMethod.cs
@@ -9,7 +9,7 @@ namespace System.IO.Compression
     /// <remarks>
     /// The values correspond to the compression method values described in the ZIP File Format Specification (APPNOTE.TXT section 4.4.5).
     /// </remarks>
-    public enum ZipCompressionMethod : short
+    public enum ZipCompressionMethod
     {
         /// <summary>
         /// The entry is stored (no compression).

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCompressionMethod.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipCompressionMethod.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System.IO.Compression
+{
+    /// <summary>
+    /// Specifies the compression method used to compress an entry in a zip archive.
+    /// </summary>
+    /// <remarks>
+    /// The values correspond to the compression method values described in the ZIP File Format Specification (APPNOTE.TXT section 4.4.5).
+    /// </remarks>
+    public enum ZipCompressionMethod : short
+    {
+        /// <summary>
+        /// The entry is stored (no compression).
+        /// </summary>
+        Stored = 0x0,
+
+        /// <summary>
+        /// The entry is compressed using the Deflate algorithm.
+        /// </summary>
+        Deflate = 0x8,
+
+        /// <summary>
+        /// The entry is compressed using the Deflate64 algorithm.
+        /// </summary>
+        Deflate64 = 0x9,
+    }
+}

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -878,5 +878,16 @@ namespace System.IO.Compression.Tests
             Assert.Equal(ZipCompressionMethod.Stored, readEntry.CompressionMethod);
             await DisposeZipArchive(async, readArchive);
         }
+
+        [Theory]
+        [MemberData(nameof(Get_Booleans_Data))]
+        public static async Task CompressionMethod_Deflate64_ReturnsDeflate64(bool async)
+        {
+            MemoryStream ms = await StreamHelpers.CreateTempCopyStream(compat("deflate64.zip"));
+            ZipArchive readArchive = await CreateZipArchive(async, ms, ZipArchiveMode.Read);
+            ZipArchiveEntry readEntry = readArchive.Entries[0];
+            Assert.Equal(ZipCompressionMethod.Deflate64, readEntry.CompressionMethod);
+            await DisposeZipArchive(async, readArchive);
+        }
     }
 }

--- a/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
+++ b/src/libraries/System.IO.Compression/tests/ZipArchive/zip_ReadTests.cs
@@ -595,10 +595,9 @@ namespace System.IO.Compression.Tests
                 // Check the entry's compression method to determine seekability
                 // SubReadStream should be seekable when the underlying stream is seekable and the entry is stored (uncompressed)
                 // If the entry is compressed (Deflate, Deflate64, etc.), it will be wrapped in a compression stream which is not seekable
-                ushort compressionMethod = (ushort)compressionMethodField.GetValue(e);
-                const ushort StoredCompressionMethod = 0x0; // CompressionMethodValues.Stored
+                ZipCompressionMethod compressionMethod = (ZipCompressionMethod)compressionMethodField.GetValue(e);
                 
-                if (compressionMethod == StoredCompressionMethod)
+                if (compressionMethod == ZipCompressionMethod.Stored)
                 {
                     // Entry is stored (uncompressed), should be seekable
                     Assert.True(s.CanSeek, $"SubReadStream should be seekable for stored (uncompressed) entry '{e.FullName}' with compression method {compressionMethod} when underlying stream is seekable");


### PR DESCRIPTION
This PR exposes the compression method of ZIP archive entries through a new public `ZipCompressionMethod` enum and a public `CompressionMethod` property on `ZipArchiveEntry`.

- Only supported compression methods are included.
- Enum values (0, 8, 9) correspond to the compression method values defined in the ZIP File Format Specification (APPNOTE.TXT section 4.4.5).
- Error handling for unsupported compression methods now uses a single generic message `SR.UnsupportedCompression` instead of method-specific messages for BZip2/LZMA.

Fixes #95909