### PR TITLE
FormattedLogValues - Small optimization for index operator

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/FormattedLogValues.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/FormattedLogValues.cs
@@ -64,17 +64,21 @@ namespace Microsoft.Extensions.Logging
         {
             get
             {
-                if (index < 0 || index >= Count)
+                if (_formatter is null || _values is null)
                 {
-                    throw new IndexOutOfRangeException();
+                    if (index == 0)
+                    {
+                        return new KeyValuePair<string, object?>("{OriginalFormat}", _originalMessage);
+                    }
+                    else
+                    {
+                        throw new IndexOutOfRangeException();
+                    }
                 }
-
-                if (index == Count - 1)
+                else
                 {
-                    return new KeyValuePair<string, object?>("{OriginalFormat}", _originalMessage);
+                    return _formatter.GetValue(_values, index);
                 }
-
-                return _formatter!.GetValue(_values!, index);
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/FormattedLogValues.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/src/FormattedLogValues.cs
@@ -70,15 +70,11 @@ namespace Microsoft.Extensions.Logging
                     {
                         return new KeyValuePair<string, object?>("{OriginalFormat}", _originalMessage);
                     }
-                    else
-                    {
-                        throw new IndexOutOfRangeException();
-                    }
+
+                    throw new IndexOutOfRangeException();
                 }
-                else
-                {
-                    return _formatter.GetValue(_values, index);
-                }
+
+                return _formatter.GetValue(_values, index);
             }
         }
 


### PR DESCRIPTION
Resolves #122046 (Removed "expensive" Count-check, since also exists in `LogValuesFormatter`)

| Method                           | Mean      | Error     | StdDev    | Gen0   | Allocated |
|--------------------------------- |----------:|----------:|----------:|-------:|----------:|
| FormattedLogValues_Lookup (Before)    |  5.429 ns | 0.0971 ns | 0.0908 ns |      - |         - |
| FormattedLogValues_Lookup (After)   |  4.295 ns | 0.0159 ns | 0.0149 ns |      - |         - |

Benchmark code:
```csharp
    public class FormattedLogValuesTest
    {
        FormattedLogValues _test = new FormattedLogValues("{0} {1} {2}", new object[] { "Hello", "Cruel", "World" });

        [Benchmark]
        public void FormattedLogValues_Lookup()
        {
            var parameterCount = _test.Count;
            for (int i = 0; i < parameterCount; ++i)
            {
                var parameter = _test[i];
                if (parameter.Key is null)
                    return;
            }
        }
    }
```