### PR TITLE
[interp][coreclr] Fix virtual generic calls in interpreter

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -4071,7 +4071,11 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
             //  intrinsics for the recursive call. Otherwise we will just recurse infinitely and overflow stack.
             //  This expansion can produce value that is inconsistent with the value seen by JIT/R2R code that can
             //  cause user code to misbehave. This is by design. One-off method Interpretation is for internal use only.
-            bool isMustExpand = (callInfo.hMethod == m_methodHnd) || (ni == NI_System_StubHelpers_GetStubContext);
+            bool isMustExpand = (callInfo.hMethod == m_methodHnd) || (
+                    ni == NI_System_StubHelpers_GetStubContext ||
+                    ni == NI_System_StubHelpers_NextCallReturnAddress ||
+                    ni == NI_System_Runtime_CompilerServices_RuntimeHelpers_SetNextCallGenericContext ||
+                    ni == NI_System_Runtime_CompilerServices_RuntimeHelpers_SetNextCallAsyncContinuation);
             if ((InterpConfig.InterpMode() == 3) || isMustExpand)
             {
                 if (EmitNamedIntrinsicCall(ni, callInfo.kind == CORINFO_CALL, resolvedCallToken.hClass, callInfo.hMethod, callInfo.sig))


### PR DESCRIPTION
Fix regression introduced in #121799

Force intrinsic expansion for new runtime helpers in the interpreter.

Added the new methods and also
`NI_System_StubHelpers_NextCallReturnAddress`, which has also `// Unconditionally expanded intrinsic` comment.

This was happening on wasm and possibly on other platforms too, resulting in unhandled exception. Possibly only on platforms, which use generic instantiation IL stubs.

```
Unhandled exception. System.Diagnostics.UnreachableException: The program executed an instruction that was thought to be unreachable.
   at System.Runtime.CompilerServices.RuntimeHelpers.SetNextCallGenericContext(Void* value) in /Users/rodo/git/runtime-clean/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs:line 186
   at InterpreterTest.TestVirtual() in /Users/rodo/git/runtime-clean/src/tests/JIT/interpreter/Interpreter.cs:line 1960
   at InterpreterTest.RunInterpreterTests() in /Users/rodo/git/runtime-clean/src/tests/JIT/interpreter/Interpreter.cs:line 896
   at InterpreterTest.Main(String[] args) in /Users/rodo/git/runtime-clean/src/tests/JIT/interpreter/Interpreter.cs:line 731
Aborted(native code called abort())
```