### PR TITLE
[Mono][AOT] Add missing unlock in `mono_aot_get_class_from_name` if aot table_size == 0

### DIFF
--- a/src/mono/mono/mini/aot-runtime.c
+++ b/src/mono/mono/mini/aot-runtime.c
@@ -2708,8 +2708,10 @@ mono_aot_get_class_from_name (MonoImage *image, const char *name_space, const ch
 	table_size = amodule->class_name_table [0];
 	table = amodule->class_name_table + 1;
 
-	if (table_size == 0)
+	if (table_size == 0) {
+		amodule_unlock (amodule);
 		return FALSE;
+	}
 
 	if (name_space [0] == '\0')
 		full_name = g_strdup_printf ("%s", name);


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/122096