### PR TITLE
Add GetKeyedOrDefault extension to IServiceProvider

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderKeyedServiceExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderKeyedServiceExtensions.cs
@@ -32,6 +32,20 @@ namespace Microsoft.Extensions.DependencyInjection
         }
 
         /// <summary>
+        /// Get service of type <typeparamref name="T"/> from the <see cref="IServiceProvider"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of service object to get.</typeparam>
+        /// <param name="provider">The <see cref="IServiceProvider"/> to retrieve the service object from.</param>
+        /// <param name="serviceKey">An object that specifies the key of service object to get.</param>
+        /// <returns>A service object of type <typeparamref name="T"/> or the default value of <typeparamref name="T"/> if there is no such service.</returns>
+        public static T GetKeyedOrDefault<T>(this IServiceProvider provider, object? serviceKey) where T : class
+        {
+            ArgumentNullException.ThrowIfNull(provider);
+
+            return provider.GetKeyedService<T>(serviceKey) ?? provider.GetRequiredService<T>();
+        }
+
+        /// <summary>
         /// Get service of type <paramref name="serviceType"/> from the <see cref="IServiceProvider"/>.
         /// </summary>
         /// <param name="provider">The <see cref="IServiceProvider"/> to retrieve the service object from.</param>

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderKeyedServiceExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ServiceProviderKeyedServiceExtensions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="provider">The <see cref="IServiceProvider"/> to retrieve the service object from.</param>
         /// <param name="serviceKey">An object that specifies the key of service object to get.</param>
         /// <returns>A service object of type <typeparamref name="T"/> or the default value of <typeparamref name="T"/> if there is no such service.</returns>
-        public static T GetKeyedOrDefault<T>(this IServiceProvider provider, object? serviceKey) where T : class
+        public static T GetKeyedOrDefaultService<T>(this IServiceProvider provider, object? serviceKey) where T : class
         {
             ArgumentNullException.ThrowIfNull(provider);
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
@@ -1235,10 +1235,10 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             var provider = CreateServiceProvider(serviceCollection);
 
             // Key exists, should return keyed service
-            Assert.Same(service1, provider.GetKeyedOrDefault<IService>("service1"));
+            Assert.Same(service1, provider.GetKeyedOrDefaultService<IService>("service1"));
 
             // Key does not exist, should return default (non-keyed) service
-            Assert.Same(defaultService, provider.GetKeyedOrDefault<IService>("notFoundKey"));
+            Assert.Same(defaultService, provider.GetKeyedOrDefaultService<IService>("notFoundKey"));
         }
 
         [Fact]
@@ -1248,7 +1248,7 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             var provider = CreateServiceProvider(serviceCollection);
 
             // Both keyed and default services are missing, should throw
-            Assert.Throws<InvalidOperationException>(() => provider.GetKeyedOrDefault<IService>("service1"));
+            Assert.Throws<InvalidOperationException>(() => provider.GetKeyedOrDefaultService<IService>("service1"));
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Specification.Tests/src/KeyedDependencyInjectionSpecificationTests.cs
@@ -1222,5 +1222,33 @@ namespace Microsoft.Extensions.DependencyInjection.Specification
             }
         }
 #endif
+
+        [Fact]
+        public void ResolveKeyedOrDefault()
+        {
+            var defaultService = new Service();
+            var service1 = new Service();
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton<IService>(defaultService);
+            serviceCollection.AddKeyedSingleton<IService>("service1", service1);
+
+            var provider = CreateServiceProvider(serviceCollection);
+
+            // Key exists, should return keyed service
+            Assert.Same(service1, provider.GetKeyedOrDefault<IService>("service1"));
+
+            // Key does not exist, should return default (non-keyed) service
+            Assert.Same(defaultService, provider.GetKeyedOrDefault<IService>("notFoundKey"));
+        }
+
+        [Fact]
+        public void ResolveKeyedOrDefault_Throws_WhenBothMissing()
+        {
+            var serviceCollection = new ServiceCollection();
+            var provider = CreateServiceProvider(serviceCollection);
+
+            // Both keyed and default services are missing, should throw
+            Assert.Throws<InvalidOperationException>(() => provider.GetKeyedOrDefault<IService>("service1"));
+        }
     }
 }


### PR DESCRIPTION
This PR adds the `GetKeyedOrDefault<T>` extension method to `IServiceProvider`.
This method attempts to retrieve a keyed service and falls back to `GetRequiredService<T>` if the keyed service is not found.
This is useful for scenarios where a default implementation should be used if a specific keyed implementation is not available.

Changes:
- Added `GetKeyedOrDefault<T>` to `ServiceProviderKeyedServiceExtensions.cs`
- Added unit tests in `KeyedDependencyInjectionSpecificationTests.cs`