### PR TITLE
[mono][debugger] Protecting against changing the protocol version

### DIFF
--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -7185,6 +7185,11 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		break;
 	}
 	case CMD_VM_SET_PROTOCOL_VERSION: {
+		if (protocol_version_set)
+		{
+			PRINT_DEBUG_MSG (1, "[dbg] Trying to reset the protocol version, ignoring it\n");
+			break;
+		}
 		major_version = decode_int (p, &p, end);
 		minor_version = decode_int (p, &p, end);
 		if (p < end)

--- a/src/mono/mono/component/debugger-agent.c
+++ b/src/mono/mono/component/debugger-agent.c
@@ -7185,8 +7185,7 @@ vm_commands (int command, int id, guint8 *p, guint8 *end, Buffer *buf)
 		break;
 	}
 	case CMD_VM_SET_PROTOCOL_VERSION: {
-		if (protocol_version_set)
-		{
+		if (protocol_version_set) {
 			PRINT_DEBUG_MSG (1, "[dbg] Trying to reset the protocol version, ignoring it\n");
 			break;
 		}


### PR DESCRIPTION
This PR adds protection against changing the debugger protocol version after it has been initially set. The change prevents a client from resetting the protocol version through multiple CMD_VM_SET_PROTOCOL_VERSION commands.

Key Changes
- Added an early return check in the CMD_VM_SET_PROTOCOL_VERSION command handler to ignore subsequent attempts to set the protocol version
- Logs a debug message when a reset attempt is detected