### PR TITLE
Allow type loading when merging array types

### DIFF
--- a/src/coreclr/vm/typehandle.cpp
+++ b/src/coreclr/vm/typehandle.cpp
@@ -971,17 +971,8 @@ TypeHandle TypeHandle::MergeArrayTypeHandlesToCommonParent(TypeHandle ta, TypeHa
         return TypeHandle(g_pArrayClass);
     }
 
-
-    {
-        // This should just result in resolving an already loaded type.
-        ENABLE_FORBID_GC_LOADER_USE_IN_THIS_SCOPE();
-        // == FailIfNotLoadedOrNotRestored
-        TypeHandle result = ClassLoader::LoadArrayTypeThrowing(tMergeElem, mergeKind, rank, ClassLoader::DontLoadTypes);
-        _ASSERTE(!result.IsNull());
-
-        // <TODO> should be able to assert IsRestored here </TODO>
-        return result;
-    }
+    TypeHandle result = ClassLoader::LoadArrayTypeThrowing(tMergeElem, mergeKind, rank);
+    return result;
 }
 
 #endif // #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/typehandle.cpp
+++ b/src/coreclr/vm/typehandle.cpp
@@ -971,8 +971,7 @@ TypeHandle TypeHandle::MergeArrayTypeHandlesToCommonParent(TypeHandle ta, TypeHa
         return TypeHandle(g_pArrayClass);
     }
 
-    TypeHandle result = ClassLoader::LoadArrayTypeThrowing(tMergeElem, mergeKind, rank);
-    return result;
+    return ClassLoader::LoadArrayTypeThrowing(tMergeElem, mergeKind, rank);
 }
 
 #endif // #ifndef DACCESS_COMPILE

--- a/src/tests/JIT/Regression/JitBlue/Runtime_120903/Runtime_120903.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_120903/Runtime_120903.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+
+namespace Runtime_120903;
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+class B {}
+class D1: B {}
+class D2: B {}
+
+public class Runtime_120903
+{
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static int Merge(object[] b)
+    {
+        D1[] d1 = Unsafe.As<D1[]>(b);
+        return d1.Length;
+    }
+
+    [Fact]
+    public static void Problem()
+    {
+        D2[] d2 = new D2[10];
+        Console.WriteLine(Merge(d2));
+    }   
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_120903/Runtime_120903.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_120903/Runtime_120903.cs
@@ -26,5 +26,5 @@ public class Runtime_120903
     {
         D2[] d2 = new D2[10];
         Console.WriteLine(Merge(d2));
-    }   
+    }
 }

--- a/src/tests/JIT/Regression/Regression_ro_1.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_1.csproj
@@ -75,6 +75,7 @@
     <Compile Include="JitBlue\Runtime_120414\Runtime_120414.cs" />
     <Compile Include="JitBlue\Runtime_120522\Runtime_120522.cs" />
     <Compile Include="JitBlue\Runtime_121711\Runtime_121711.cs" />
+    <Compile Include="JitBlue\Runtime_120903\Runtime_120903.cs" />
     <Compile Include="JitBlue\Runtime_31615\Runtime_31615.cs" />
     <Compile Include="JitBlue\Runtime_33884\Runtime_33884.cs" />
     <Compile Include="JitBlue\Runtime_38920\Runtime_38920.cs" />

--- a/src/tests/JIT/Regression/Regression_ro_1.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_1.csproj
@@ -74,8 +74,8 @@
     <Compile Include="JitBlue\Runtime_120270\Runtime_120270.cs" />
     <Compile Include="JitBlue\Runtime_120414\Runtime_120414.cs" />
     <Compile Include="JitBlue\Runtime_120522\Runtime_120522.cs" />
-    <Compile Include="JitBlue\Runtime_121711\Runtime_121711.cs" />
     <Compile Include="JitBlue\Runtime_120903\Runtime_120903.cs" />
+    <Compile Include="JitBlue\Runtime_121711\Runtime_121711.cs" />
     <Compile Include="JitBlue\Runtime_31615\Runtime_31615.cs" />
     <Compile Include="JitBlue\Runtime_33884\Runtime_33884.cs" />
     <Compile Include="JitBlue\Runtime_38920\Runtime_38920.cs" />


### PR DESCRIPTION
If the runtime is merging two array types, the merged type may be one that is not yet loaded. Allow the runtime to load the type.

Fixes #120903.