### PR TITLE
Reduce unsafe code usage in HttpHeaders

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -1521,9 +1521,8 @@ namespace System.Net.Http.Headers
                 _count++;
                 entries = new HeaderEntry[InitialCapacity];
                 _headerStore = entries;
-                ref HeaderEntry firstEntry = ref MemoryMarshal.GetArrayDataReference(entries);
-                firstEntry.Key = key;
-                return ref firstEntry.Value!;
+                entries[0].Key = key;
+                return ref entries[0].Value!;
             }
             else
             {


### PR DESCRIPTION
The usage of `GetArrayDataReference` in `HttpHeaders` is unnecessary. Since the JIT can prove that accessing the 0th element of the array will not result in an IndexOutOfBoundsException (see the newarr two lines above the changed code), standard array access syntax already avoids the bounds check. There's no need for unsafe code here.

x64 before:

```asm
    L00a2: test rdi, rdi // if (store is null)
    L00a5: jne short L00f3
    L00a7: mov r14d, [rbx+0x10]
    L00ab: lea ecx, [r14+1]
    L00af: mov [rbx+0x10], ecx // count++;
    L00b2: mov rcx, 0x7ffe3ea6d520
    L00bc: mov edx, 4
    L00c1: call 0x00007ffe46666610 // newarr
    L00c6: mov rbp, rax
    L00c9: lea rcx, [rbx+8]
    L00cd: mov rdx, rbp
    L00d0: call 0x00007ffde6960010 // stfld (_headerStore)
    L00d5: add rbp, 0x10 // addrof newArr[0]
    L00d9: lea rcx, [rbp+8] // addrof firstEntry.Key
    L00dd: mov rdx, rsi
    L00e0: call 0x00007ffde6960010 // stfld (firstEntry.Key)
    L00e5: mov rax, rbp // return ref firstEntry.Value
    L00e8: add rsp, 0x20
    L00ec: pop rbx
    L00ed: pop rbp
    L00ee: pop rsi
    L00ef: pop rdi
    L00f0: pop r14
    L00f2: ret
```

x64 after:

```asm
    L009f: test rdi, rdi // if (store is null)
    L00a2: jne short L00ed
    L00a4: mov r14d, [rbx+0x10]
    L00a8: lea ecx, [r14+1]
    L00ac: mov [rbx+0x10], ecx // count++;
    L00af: mov rcx, 0x7ffe3eafd510
    L00b9: mov edx, 4
    L00be: call 0x00007ffe46666610 // newarr
    L00c3: mov rbp, rax
    L00c6: lea rcx, [rbx+8]
    L00ca: mov rdx, rbp
    L00cd: call 0x00007ffde6960010 // stfld (_headerStore)
    L00d2: lea rcx, [rbp+0x18] // addrof entries[0].Key
    L00d6: mov rdx, rsi
    L00d9: call 0x00007ffde6960010 // stfld (entries[0].Key)
    L00de: lea rax, [rbp+0x10] // return ref entries[0].Value
    L00e2: add rsp, 0x20
    L00e6: pop rbx
    L00e7: pop rbp
    L00e8: pop rsi
    L00e9: pop rdi
    L00ea: pop r14
    L00ec: ret
```