### PR TITLE
[Tests][UserEvents] Add userevents functional runtime tests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -109,7 +109,7 @@
     <!-- Not auto-updated. -->
     <MicrosoftDiaSymReaderVersion>2.0.0</MicrosoftDiaSymReaderVersion>
     <MicrosoftDiaSymReaderNativeVersion>17.10.0-beta1.24272.1</MicrosoftDiaSymReaderNativeVersion>
-    <TraceEventVersion>3.1.16</TraceEventVersion>
+    <TraceEventVersion>3.1.28</TraceEventVersion>
     <MicrosoftDiagnosticsNetCoreClientVersion>0.2.621003</MicrosoftDiagnosticsNetCoreClientVersion>
     <NETStandardLibraryRefVersion>2.1.0</NETStandardLibraryRefVersion>
     <NetStandardLibraryVersion>2.0.3</NetStandardLibraryVersion>
@@ -124,6 +124,7 @@
     <!-- Testing -->
     <MicrosoftNETCoreCoreDisToolsVersion>1.6.0</MicrosoftNETCoreCoreDisToolsVersion>
     <MicrosoftNETTestSdkVersion>17.4.0-preview-20220707-01</MicrosoftNETTestSdkVersion>
+    <MicrosoftOneCollectRecordTraceVersion>0.1.32221</MicrosoftOneCollectRecordTraceVersion>
     <NUnitVersion>3.12.0</NUnitVersion>
     <NUnit3TestAdapterVersion>4.5.0</NUnit3TestAdapterVersion>
     <CoverletCollectorVersion>6.0.4</CoverletCollectorVersion>

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -413,10 +413,26 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <_ExtraTestExecutablesListFiles Remote="@(_ExtraTestExecutablesListFiles)" />
+      <_ExtraTestExecutablesListFiles Include="@(_MergedPayloadFiles)"
+            Condition="$([System.String]::Copy('%(Identity)').ToLower().EndsWith('helix-extra-executables.list'))" />
+      <_ExtraTestExecutables Remove="@(_ExtraTestExecutables)" />
+    </ItemGroup>
+    <ReadLinesFromFile File="%(_ExtraTestExecutablesListFiles.Identity)" Condition="'@(_ExtraTestExecutablesListFiles)' != ''">
+      <Output TaskParameter="Lines" ItemName="_ExtraTestExecutables" />
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <_ExtraTestExecutables Remove="@(_ExtraTestExecutables)" Condition="'%(Identity)' == ''" />
+    </ItemGroup>
+
+    <ItemGroup>
       <!-- We need to ensure that the test run script is marked as executable. -->
       <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' == 'true'" Include="set TEST_HARNESS_STRIPE_TO_EXECUTE=.0.1" />
       <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' != 'true'" Include="export TEST_HARNESS_STRIPE_TO_EXECUTE=.0.1" />
       <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' != 'true'" Include="chmod +x $(_MergedWrapperRunScriptRelative)" />
+
+      <!-- Tests may depend on other executables. Copying files to Helix removes execute permissions, so mark them as executable as well. -->
+      <HelixCommandLines Condition="'$(TestWrapperTargetsWindows)' != 'true' and Exists('$(TestBinDir)%(Identity)')" Include="@(_ExtraTestExecutables->'chmod +x %(Identity)')" />
 
       <HelixCommandLines Include="$(_WorkaroundForNuGetMigrations)" />
 

--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -40,6 +40,7 @@
     <RestoreProjects Include="Common\XHarnessRunnerLibrary\XHarnessRunnerLibrary.csproj" />
     <RestoreProjects Include="Common\external\external.csproj" />
     <RestoreProjects Include="Common\ilasm\ilasm.ilproj" />
+    <RestoreProjects Include="tracing\userevents\common\userevents_common.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -1535,6 +1535,9 @@
         <ExcludeList Include="$(XunitTestBinBase)/baseservices/exceptions/UnhandledExceptionHandler/NoEffectInMainThread/*">
             <Issue>Test issue. The test relies on overriding the process return code.</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)/tracing/userevents/**">
+            <Issue>Record-Trace's diagnostic port detection logic relies on memfd-based double mapping</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- Known failures for mono runtime on Windows -->

--- a/src/tests/tracing/userevents/README.md
+++ b/src/tests/tracing/userevents/README.md
@@ -1,0 +1,29 @@
+# User Events Functional Tests
+
+This directory contains **functional tests** for the .NET user_events scenario. These tests validate that .NET Runtime user events can be emitted via EventPipe and collected by [one-collect](https://github.com/microsoft/one-collect/)'s `record-trace` tool.
+
+## High-level Test Flow
+
+Each scenario uses the same pattern:
+
+1. **Scenario invokes the shared test runner**
+
+    User events scenarios can differ in their tracee logic, the events expected in the .nettrace, the record-trace script used to collect those events, and how long it takes for the tracee to emit them and for record-trace to resolve symbols and write the .nettrace. To handle this variance, UserEventsTestRunner lets each scenario pass in its scenario-specific record-trace script path, the path to its test assembly (used to spawn the tracee process), a validator that checks for the expected events from the tracee, and optional timeouts for both the tracee and record-trace to exit gracefully.
+
+2. **`UserEventsTestRunner` orchestrates tracing and validation**
+
+    Using this configuration, UserEventsTestRunner first checks whether user events are supported. It then starts record-trace with the scenario’s script and launches the tracee process so it can emit events. After the run completes, the runner stops both the tracee and record-trace, opens the resulting .nettrace with EventPipeEventSource, and applies the scenario’s validator to confirm that the expected events were recorded. Finally, it returns an exit code indicating whether the scenario passed or failed.
+
+## Layout
+
+- `common/`
+  - `UserEventsRequirements.cs` - Checks whether the environment supports user events.
+  - `UserEventsTestRunner.cs` - Shared runner that coordinates `record-trace`, the tracee process, and event validation.
+  - `userevents_common.csproj` - Common project for shared user events test logic.
+  - `NuGet.config` - Configures dotnet-diagnostics-tests nuget source which transports Microsoft.OneCollect.RecordTrace.
+- `<scenario>/`
+  - `<scenario>.cs` - The tracee workload logic used when invoked with the `tracee` argument.
+  - `<scenario>.csproj` - Project file for the scenario.
+  - `<scenario>.script` - `record-trace` script that configures how to collect the trace for the scenario.
+
+Each scenario reuses the common runner and shared `record-trace` deployable instead of duplicating binaries or orchestration logic.

--- a/src/tests/tracing/userevents/README.md
+++ b/src/tests/tracing/userevents/README.md
@@ -4,7 +4,7 @@ This directory contains **functional tests** for the .NET user_events scenario. 
 
 ## High-level Test Flow
 
-Each scenario uses the same pattern:
+Each scenario (for example, `basic`) uses the same pattern:
 
 1. **Scenario invokes the shared test runner**
 
@@ -26,4 +26,4 @@ Each scenario uses the same pattern:
   - `<scenario>.csproj` - Project file for the scenario.
   - `<scenario>.script` - `record-trace` script that configures how to collect the trace for the scenario.
 
-Each scenario reuses the common runner and shared `record-trace` deployable instead of duplicating binaries or orchestration logic.
+Each scenario reuses the common runner and shared `record-trace` deployable instead of duplicating binaries or orchestration logic. The `basic` scenario serves as a concrete example of how to add additional scenarios.

--- a/src/tests/tracing/userevents/activity/activity.cs
+++ b/src/tests/tracing/userevents/activity/activity.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Diagnostics.Tracing;
-using System.Threading;
 using System.Threading.Tasks;
 using Tracing.UserEvents.Tests.Common;
 using Microsoft.Diagnostics.Tracing;
@@ -14,8 +13,6 @@ namespace Tracing.UserEvents.Tests.Activity
     {
         public static void ActivityTracee()
         {
-            // Allow some time for tracepoints be enabled before emitting events
-            Thread.Sleep(150);
             ActivityTraceeAsync().GetAwaiter().GetResult();
         }
 
@@ -151,13 +148,12 @@ namespace Tracing.UserEvents.Tests.Activity
 
         public static int Main(string[] args)
         {
-            if (args.Length > 0 && args[0].Equals("tracee", StringComparison.OrdinalIgnoreCase))
-            {
-                ActivityTracee();
-                return 0;
-            }
-
-            return UserEventsTestRunner.Run("activity", typeof(Activity).Assembly.Location, s_traceValidator, 10000);
+            return UserEventsTestRunner.Run(
+                args,
+                "activity",
+                typeof(Activity).Assembly.Location,
+                ActivityTracee,
+                s_traceValidator);
         }
     }
 

--- a/src/tests/tracing/userevents/activity/activity.cs
+++ b/src/tests/tracing/userevents/activity/activity.cs
@@ -1,0 +1,186 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.Threading;
+using System.Threading.Tasks;
+using Tracing.UserEvents.Tests.Common;
+using Microsoft.Diagnostics.Tracing;
+
+namespace Tracing.UserEvents.Tests.Activity
+{
+    public static class Activity
+    {
+        public static void ActivityTracee()
+        {
+            // Allow some time for tracepoints be enabled before emitting events
+            Thread.Sleep(150);
+            ActivityTraceeAsync().GetAwaiter().GetResult();
+        }
+
+        private static async Task ActivityTraceeAsync()
+        {
+            Task requestA = ProcessRequest("RequestA");
+            Task requestB = ProcessRequest("RequestB");
+
+            await Task.WhenAll(requestA, requestB);
+        }
+
+        private static async Task ProcessRequest(string requestName)
+        {
+            ActivityEventSource.Log.WorkStart(requestName);
+
+            Task query1 = Query("Query1 for " + requestName);
+            Task query2 = Query("Query2 for " + requestName);
+
+            await Task.WhenAll(query1, query2);
+
+            ActivityEventSource.Log.WorkStop();
+        }
+
+        private static async Task Query(string query)
+        {
+            ActivityEventSource.Log.QueryStart(query);
+            await Task.Delay(50);
+            ActivityEventSource.Log.DebugMessage("processing " + query);
+            await Task.Delay(50);
+            ActivityEventSource.Log.QueryStop();
+        }
+
+        private static readonly Func<EventPipeEventSource, bool> s_traceValidator = source =>
+        {
+            Guid firstWorkActivityId = Guid.Empty;
+            Guid secondWorkActivityId = Guid.Empty;
+
+            Guid firstWorkQuery1ActivityId = Guid.Empty;
+            Guid firstWorkQuery2ActivityId = Guid.Empty;
+            Guid secondWorkQuery1ActivityId = Guid.Empty;
+            Guid secondWorkQuery2ActivityId = Guid.Empty;
+
+            Guid firstWorkQuery1RelatedActivityId = Guid.Empty;
+            Guid firstWorkQuery2RelatedActivityId = Guid.Empty;
+            Guid secondWorkQuery1RelatedActivityId = Guid.Empty;
+            Guid secondWorkQuery2RelatedActivityId = Guid.Empty;
+
+            source.Dynamic.All += e =>
+            {
+                if (!string.Equals(e.ProviderName, "DemoActivityIDs", StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                if (e.EventName is null)
+                {
+                    return;
+                }
+
+                if (e.EventName.Equals("Work/Start", StringComparison.OrdinalIgnoreCase))
+                {
+                    string requestName = e.PayloadByName("requestName") as string ?? string.Empty;
+
+                    if (string.Equals(requestName, "RequestA", StringComparison.Ordinal))
+                    {
+                        firstWorkActivityId = e.ActivityID;
+                    }
+                    else if (string.Equals(requestName, "RequestB", StringComparison.Ordinal))
+                    {
+                        secondWorkActivityId = e.ActivityID;
+                    }
+                }
+                else if (e.EventName.Equals("Query/Start", StringComparison.OrdinalIgnoreCase))
+                {
+                    string queryText = e.PayloadByName("query") as string ?? string.Empty;
+
+                    if (string.Equals(queryText, "Query1 for RequestA", StringComparison.Ordinal))
+                    {
+                        firstWorkQuery1ActivityId = e.ActivityID;
+                        firstWorkQuery1RelatedActivityId = e.RelatedActivityID;
+                    }
+                    else if (string.Equals(queryText, "Query2 for RequestA", StringComparison.Ordinal))
+                    {
+                        firstWorkQuery2ActivityId = e.ActivityID;
+                        firstWorkQuery2RelatedActivityId = e.RelatedActivityID;
+                    }
+                    else if (string.Equals(queryText, "Query1 for RequestB", StringComparison.Ordinal))
+                    {
+                        secondWorkQuery1ActivityId = e.ActivityID;
+                        secondWorkQuery1RelatedActivityId = e.RelatedActivityID;
+                    }
+                    else if (string.Equals(queryText, "Query2 for RequestB", StringComparison.Ordinal))
+                    {
+                        secondWorkQuery2ActivityId = e.ActivityID;
+                        secondWorkQuery2RelatedActivityId = e.RelatedActivityID;
+                    }
+                }
+            };
+
+            source.Process();
+
+            if (firstWorkActivityId == Guid.Empty || secondWorkActivityId == Guid.Empty)
+            {
+                Console.Error.WriteLine("The trace did not contain two WorkStart events with ActivityIds for RequestA and RequestB.");
+                return false;
+            }
+
+            if (firstWorkQuery1ActivityId == Guid.Empty || firstWorkQuery2ActivityId == Guid.Empty ||
+                secondWorkQuery1ActivityId == Guid.Empty || secondWorkQuery2ActivityId == Guid.Empty)
+            {
+                Console.Error.WriteLine("The trace did not contain all expected QueryStart events with ActivityIds for both requests.");
+                return false;
+            }
+
+            if (firstWorkQuery1RelatedActivityId == Guid.Empty || firstWorkQuery2RelatedActivityId == Guid.Empty ||
+                secondWorkQuery1RelatedActivityId == Guid.Empty || secondWorkQuery2RelatedActivityId == Guid.Empty)
+            {
+                Console.Error.WriteLine("The trace did not contain RelatedActivityIds on all QueryStart events.");
+                return false;
+            }
+
+            if (firstWorkQuery1RelatedActivityId != firstWorkActivityId ||
+                firstWorkQuery2RelatedActivityId != firstWorkActivityId ||
+                secondWorkQuery1RelatedActivityId != secondWorkActivityId ||
+                secondWorkQuery2RelatedActivityId != secondWorkActivityId)
+            {
+                Console.Error.WriteLine("QueryStart RelatedActivityIds did not match their corresponding WorkStart ActivityIds.");
+                return false;
+            }
+
+            return true;
+        };
+
+        public static int Main(string[] args)
+        {
+            if (args.Length > 0 && args[0].Equals("tracee", StringComparison.OrdinalIgnoreCase))
+            {
+                ActivityTracee();
+                return 0;
+            }
+
+            return UserEventsTestRunner.Run("activity", typeof(Activity).Assembly.Location, s_traceValidator, 10000);
+        }
+    }
+
+    [EventSource(Name = "DemoActivityIDs")]
+    internal sealed class ActivityEventSource : EventSource
+    {
+        public static readonly ActivityEventSource Log = new ActivityEventSource();
+
+        private ActivityEventSource() {}
+
+        [Event(1)]
+        public void WorkStart(string requestName) => WriteEvent(1, requestName);
+
+        [Event(2)]
+        public void WorkStop() => WriteEvent(2);
+
+        [Event(3)]
+        public void DebugMessage(string message) => WriteEvent(3, message);
+
+        [Event(4)]
+        public void QueryStart(string query) => WriteEvent(4, query);
+
+        [Event(5)]
+        public void QueryStop() => WriteEvent(5);
+    }
+}

--- a/src/tests/tracing/userevents/activity/activity.csproj
+++ b/src/tests/tracing/userevents/activity/activity.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<CLRTestTargetUnsupported Condition="'$(TargetOS)' != 'linux' or ('$(TargetArchitecture)' != 'x64' and '$(TargetArchitecture)' != 'arm64')">true</CLRTestTargetUnsupported>
+		<RequiresProcessIsolation>true</RequiresProcessIsolation>
+		<ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<Compile Include="$(MSBuildProjectName).cs" />
+		<ProjectReference Include="../common/userevents_common.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Content Include="activity.script">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+			<TargetPath>activity.script</TargetPath>
+		</Content>
+	</ItemGroup>
+</Project>

--- a/src/tests/tracing/userevents/activity/activity.script
+++ b/src/tests/tracing/userevents/activity/activity.script
@@ -1,0 +1,5 @@
+let DemoActivityIds_flags = new_dotnet_provider_flags();
+record_dotnet_provider("DemoActivityIDs", 0x0, 5, DemoActivityIds_flags);
+
+let System_Threading_Tasks_TplEventSource_flags = new_dotnet_provider_flags();
+record_dotnet_provider("System.Threading.Tasks.TplEventSource", 0x80, 5, System_Threading_Tasks_TplEventSource_flags);

--- a/src/tests/tracing/userevents/basic/basic.cs
+++ b/src/tests/tracing/userevents/basic/basic.cs
@@ -52,13 +52,12 @@ namespace Tracing.UserEvents.Tests.Basic
 
         public static int Main(string[] args)
         {
-            if (args.Length > 0 && args[0].Equals("tracee", StringComparison.OrdinalIgnoreCase))
-            {
-                BasicTracee();
-                return 0;
-            }
-
-            return UserEventsTestRunner.Run("basic", typeof(Basic).Assembly.Location, s_traceValidator);
+            return UserEventsTestRunner.Run(
+                args,
+                "basic",
+                typeof(Basic).Assembly.Location,
+                BasicTracee,
+                s_traceValidator);
         }
     }
 }

--- a/src/tests/tracing/userevents/basic/basic.cs
+++ b/src/tests/tracing/userevents/basic/basic.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using Tracing.UserEvents.Tests.Common;
+using Microsoft.Diagnostics.Tracing;
+
+namespace Tracing.UserEvents.Tests.Basic
+{
+    public class Basic
+    {
+        private static byte[] s_array;
+
+        public static void BasicTracee()
+        {
+            long startTimestamp = Stopwatch.GetTimestamp();
+            long targetTicks = Stopwatch.Frequency; // 1s
+
+            while (Stopwatch.GetTimestamp() - startTimestamp < targetTicks)
+            {
+                s_array = new byte[1024 * 100];
+                Thread.Sleep(100);
+            }
+        }
+
+        private readonly static Func<EventPipeEventSource, bool> s_traceValidator = source =>
+        {
+            bool allocationSampledEventFound = false;
+
+            source.Dynamic.All += (TraceEvent e) =>
+            {
+                if (e.ProviderName == "Microsoft-Windows-DotNETRuntime")
+                {
+                    // TraceEvent's ClrTraceEventParser does not know about the AllocationSampled Event, so it shows up as "Unknown(303)"
+                    if (e.EventName.StartsWith("Unknown") && e.ID == (TraceEventID)303)
+                    {
+                        allocationSampledEventFound = true;
+                    }
+                }
+            };
+
+            source.Process();
+
+            if (!allocationSampledEventFound)
+            {
+                Console.Error.WriteLine("The trace did not contain an AllocationSampled event.");
+            }
+            return allocationSampledEventFound;
+        };
+
+        public static int Main(string[] args)
+        {
+            if (args.Length > 0 && args[0].Equals("tracee", StringComparison.OrdinalIgnoreCase))
+            {
+                BasicTracee();
+                return 0;
+            }
+
+            return UserEventsTestRunner.Run("basic", typeof(Basic).Assembly.Location, s_traceValidator);
+        }
+    }
+}

--- a/src/tests/tracing/userevents/basic/basic.csproj
+++ b/src/tests/tracing/userevents/basic/basic.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestTargetUnsupported Condition="'$(TargetOS)' != 'linux' or ('$(TargetArchitecture)' != 'x64' and '$(TargetArchitecture)' != 'arm64')">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="../common/userevents_common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="basic.script">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>basic.script</TargetPath>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/src/tests/tracing/userevents/basic/basic.script
+++ b/src/tests/tracing/userevents/basic/basic.script
@@ -1,0 +1,2 @@
+let Microsoft_Windows_DotNETRuntime_flags = new_dotnet_provider_flags();
+record_dotnet_provider("Microsoft-Windows-DotNETRuntime", 0x80000000000, 4, Microsoft_Windows_DotNETRuntime_flags);

--- a/src/tests/tracing/userevents/common/NuGet.config
+++ b/src/tests/tracing/userevents/common/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="dotnet-diagnostics-tests" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-diagnostics-tests/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/tests/tracing/userevents/common/UserEventsRequirements.cs
+++ b/src/tests/tracing/userevents/common/UserEventsRequirements.cs
@@ -1,0 +1,185 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Tracing.UserEvents.Tests.Common
+{
+    internal static class UserEventsRequirements
+    {
+        private static readonly Version s_minKernelVersion = new(6, 4);
+        private const string TracefsPath = "/sys/kernel/tracing";
+        private const string UserEventsDataPath = "/sys/kernel/tracing/user_events_data";
+        private static readonly Version s_minGlibcVersion = new(2, 35);
+
+        internal static bool IsSupported()
+        {
+            if (Environment.OSVersion.Version < s_minKernelVersion)
+            {
+                Console.WriteLine($"Kernel version '{Environment.OSVersion.Version}' is less than the minimum required '{s_minKernelVersion}'");
+                return false;
+            }
+
+            return IsGlibcAtLeast(s_minGlibcVersion) &&
+                   IsTracefsMounted() &&
+                   IsUserEventsDataAvailable();
+        }
+
+        private static bool IsTracefsMounted()
+        {
+            ProcessStartInfo checkTracefsStartInfo = new();
+            checkTracefsStartInfo.FileName = "sudo";
+            checkTracefsStartInfo.Arguments = $"-n test -d {TracefsPath}";
+            checkTracefsStartInfo.UseShellExecute = false;
+            checkTracefsStartInfo.RedirectStandardOutput = true;
+            checkTracefsStartInfo.RedirectStandardError = true;
+
+            using Process checkTracefs = new() { StartInfo = checkTracefsStartInfo };
+            checkTracefs.OutputDataReceived += (_, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    Console.WriteLine($"[tracefs-check] {e.Data}");
+                }
+            };
+            checkTracefs.ErrorDataReceived += (_, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    Console.Error.WriteLine($"[tracefs-check] {e.Data}");
+                }
+            };
+
+            checkTracefs.Start();
+            checkTracefs.BeginOutputReadLine();
+            checkTracefs.BeginErrorReadLine();
+            checkTracefs.WaitForExit();
+            if (checkTracefs.ExitCode == 0)
+            {
+                return true;
+            }
+
+            Console.WriteLine($"Tracefs not mounted at '{TracefsPath}'.");
+            return false;
+        }
+
+        private static bool IsUserEventsDataAvailable()
+        {
+            ProcessStartInfo checkUserEventsDataStartInfo = new();
+            checkUserEventsDataStartInfo.FileName = "sudo";
+            checkUserEventsDataStartInfo.Arguments = $"-n test -e {UserEventsDataPath}";
+            checkUserEventsDataStartInfo.UseShellExecute = false;
+            checkUserEventsDataStartInfo.RedirectStandardOutput = true;
+            checkUserEventsDataStartInfo.RedirectStandardError = true;
+
+            using Process checkUserEventsData = new() { StartInfo = checkUserEventsDataStartInfo };
+            checkUserEventsData.OutputDataReceived += (_, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    Console.WriteLine($"[user-events-check] {e.Data}");
+                }
+            };
+            checkUserEventsData.ErrorDataReceived += (_, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    Console.Error.WriteLine($"[user-events-check] {e.Data}");
+                }
+            };
+
+            checkUserEventsData.Start();
+            checkUserEventsData.BeginOutputReadLine();
+            checkUserEventsData.BeginErrorReadLine();
+            checkUserEventsData.WaitForExit();
+            if (checkUserEventsData.ExitCode == 0)
+            {
+                return true;
+            }
+
+            Console.WriteLine($"User events data not available at '{UserEventsDataPath}'.");
+            return false;
+        }
+
+        private static bool IsGlibcAtLeast(Version minVersion)
+        {
+            ProcessStartInfo lddStartInfo = new();
+            lddStartInfo.FileName = "ldd";
+            lddStartInfo.Arguments = "--version";
+            lddStartInfo.UseShellExecute = false;
+            lddStartInfo.RedirectStandardOutput = true;
+            lddStartInfo.RedirectStandardError = true;
+
+            using Process lddProcess = new() { StartInfo = lddStartInfo };
+            string? detectedVersionLine = null;
+
+            lddProcess.OutputDataReceived += (_, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data) && detectedVersionLine is null)
+                {
+                    detectedVersionLine = e.Data;
+                }
+            };
+            lddProcess.ErrorDataReceived += (_, e) =>
+            {
+                if (!string.IsNullOrEmpty(e.Data))
+                {
+                    Console.Error.WriteLine($"[ldd] {e.Data}");
+                }
+            };
+
+            try
+            {
+                lddProcess.Start();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to start 'ldd --version': {ex.Message}");
+                return false;
+            }
+
+            lddProcess.BeginOutputReadLine();
+            lddProcess.BeginErrorReadLine();
+            lddProcess.WaitForExit();
+
+            if (lddProcess.ExitCode != 0)
+            {
+                Console.WriteLine($"'ldd --version' exited with code {lddProcess.ExitCode}.");
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(detectedVersionLine))
+            {
+                Console.WriteLine("Could not read glibc version from 'ldd --version' output.");
+                return false;
+            }
+
+            string[] tokens = detectedVersionLine.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            Version? glibcVersion = null;
+            foreach (string token in tokens)
+            {
+                if (Version.TryParse(token, out Version? parsedVersion))
+                {
+                    glibcVersion = parsedVersion;
+                    break;
+                }
+            }
+
+            if (glibcVersion is null)
+            {
+                Console.WriteLine($"Failed to parse glibc version from 'ldd --version' output line: {detectedVersionLine}");
+                return false;
+            }
+
+            if (glibcVersion < minVersion)
+            {
+                Console.WriteLine($"glibc version '{glibcVersion}' is less than required '{minVersion}'.");
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/tests/tracing/userevents/common/UserEventsRequirements.cs
+++ b/src/tests/tracing/userevents/common/UserEventsRequirements.cs
@@ -12,6 +12,7 @@ namespace Tracing.UserEvents.Tests.Common
         private static readonly Version s_minKernelVersion = new(6, 4);
         private const string TracefsPath = "/sys/kernel/tracing";
         private const string UserEventsDataPath = "/sys/kernel/tracing/user_events_data";
+        // https://github.com/microsoft/one-collect/issues/225
         private static readonly Version s_minGlibcVersion = new(2, 35);
 
         internal static bool IsSupported()

--- a/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
+++ b/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
@@ -1,0 +1,163 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Diagnostics.Tracing;
+
+namespace Tracing.UserEvents.Tests.Common
+{
+    public class UserEventsTestRunner
+    {
+        private const int SIGINT = 2;
+        private const int DefaultTraceeExitTimeoutMs = 5000;
+        private const int DefaultRecordTraceExitTimeoutMs = 20000;
+
+        [DllImport("libc", EntryPoint = "kill", SetLastError = true)]
+        private static extern int Kill(int pid, int sig);
+
+        public static int Run(
+            string scenarioName,
+            string traceeAssemblyPath,
+            Func<EventPipeEventSource, bool> traceValidator,
+            int traceeExitTimeout = DefaultTraceeExitTimeoutMs,
+            int recordTraceExitTimeout = DefaultRecordTraceExitTimeoutMs)
+        {
+            string userEventsScenarioDir = Path.GetDirectoryName(traceeAssemblyPath);
+            string recordTracePath = ResolveRecordTracePath(userEventsScenarioDir);
+            string scriptFilePath = Path.Combine(userEventsScenarioDir, $"{scenarioName}.script");
+
+            if (!UserEventsRequirements.IsSupported())
+            {
+                Console.WriteLine("Skipping test: environment does not support user events.");
+                return 100;
+            }
+            if (!File.Exists(recordTracePath))
+            {
+                Console.Error.WriteLine($"record-trace not found at `{recordTracePath}`. Test cannot run.");
+                return -1;
+            }
+            if (!File.Exists(scriptFilePath))
+            {
+                Console.Error.WriteLine($"record-trace script-file not found at `{scriptFilePath}`. Test cannot run.");
+                return -1;
+            }
+
+            string traceFilePath = Path.GetTempFileName();
+            // In the past, it's been observed that record-trace has trouble overwriting newly created temp files 
+            // in `/tmp` (e.g. mktemp or Path.GetTempFileName). It's suspected to be a permissions issue.
+            // As a workaround, deleting the temp file and allowing record-trace to create it works reliably.
+            File.Delete(traceFilePath);
+            traceFilePath = Path.ChangeExtension(traceFilePath, ".nettrace");
+
+            ProcessStartInfo recordTraceStartInfo = new();
+            recordTraceStartInfo.FileName = "sudo";
+            recordTraceStartInfo.Arguments = $"-n {recordTracePath} --script-file {scriptFilePath} --out {traceFilePath}";
+            recordTraceStartInfo.WorkingDirectory = userEventsScenarioDir;
+            recordTraceStartInfo.UseShellExecute = false;
+            recordTraceStartInfo.RedirectStandardOutput = true;
+            recordTraceStartInfo.RedirectStandardError = true;
+
+            Console.WriteLine($"Starting record-trace: {recordTraceStartInfo.FileName} {recordTraceStartInfo.Arguments}");
+            using Process recordTraceProcess = Process.Start(recordTraceStartInfo);
+            recordTraceProcess.OutputDataReceived += (_, args) =>
+            {
+                if (!string.IsNullOrEmpty(args.Data))
+                {
+                    Console.WriteLine($"[record-trace] {args.Data}");
+                }
+            };
+            recordTraceProcess.BeginOutputReadLine();
+            recordTraceProcess.ErrorDataReceived += (_, args) =>
+            {
+                if (!string.IsNullOrEmpty(args.Data))
+                {
+                    Console.Error.WriteLine($"[record-trace] {args.Data}");
+                }
+            };
+            recordTraceProcess.BeginErrorReadLine();
+            Console.WriteLine($"record-trace started with PID: {recordTraceProcess.Id}");
+
+            ProcessStartInfo traceeStartInfo = new();
+            traceeStartInfo.FileName = Process.GetCurrentProcess().MainModule!.FileName;
+            traceeStartInfo.Arguments = $"{traceeAssemblyPath} tracee";
+            traceeStartInfo.WorkingDirectory = userEventsScenarioDir;
+            traceeStartInfo.RedirectStandardOutput = true;
+            traceeStartInfo.RedirectStandardError = true;
+
+            Console.WriteLine($"Starting tracee process: {traceeStartInfo.FileName} {traceeStartInfo.Arguments}");
+            using Process traceeProcess = Process.Start(traceeStartInfo);
+            Console.WriteLine($"Tracee process started with PID: {traceeProcess.Id}");
+            traceeProcess.OutputDataReceived += (_, args) =>
+            {
+                if (!string.IsNullOrEmpty(args.Data))
+                {
+                    Console.WriteLine($"[tracee] {args.Data}");
+                }
+            };
+            traceeProcess.BeginOutputReadLine();
+            traceeProcess.ErrorDataReceived += (_, args) =>
+            {
+                if (!string.IsNullOrEmpty(args.Data))
+                {
+                    Console.Error.WriteLine($"[tracee] {args.Data}");
+                }
+            };
+            traceeProcess.BeginErrorReadLine();
+
+            Console.WriteLine($"Waiting for tracee process to exit...");
+            if (!traceeProcess.HasExited && !traceeProcess.WaitForExit(traceeExitTimeout))
+            {
+                Console.WriteLine($"Tracee process did not exit within the {traceeExitTimeout}ms timeout, killing it.");
+                traceeProcess.Kill();
+            }
+            traceeProcess.WaitForExit(); // flush async output
+
+            if (!recordTraceProcess.HasExited)
+            {
+                // Until record-trace supports duration, the only way to stop it is to send SIGINT (ctrl+c)
+                Console.WriteLine($"Stopping record-trace with SIGINT.");
+                Kill(recordTraceProcess.Id, SIGINT);
+                Console.WriteLine($"Waiting for record-trace to exit...");
+                if (!recordTraceProcess.WaitForExit(recordTraceExitTimeout))
+                {
+                    // record-trace needs to stop gracefully to generate the trace file
+                    Console.WriteLine($"record-trace did not exit within the {recordTraceExitTimeout}ms timeout, killing it.");
+                    recordTraceProcess.Kill();
+                }
+            }
+            else
+            {
+                Console.WriteLine($"record-trace unexpectedly exited without SIGINT with code {recordTraceProcess.ExitCode}.");
+            }
+            recordTraceProcess.WaitForExit(); // flush async output
+
+            if (!File.Exists(traceFilePath))
+            {
+                Console.Error.WriteLine($"Expected trace file not found at `{traceFilePath}`");
+                return -1;
+            }
+
+            using EventPipeEventSource source = new EventPipeEventSource(traceFilePath);
+            if (!traceValidator(source))
+            {
+                Console.Error.WriteLine($"Trace file `{traceFilePath}` does not contain expected events.");
+                return -1;
+            }
+
+            return 100;
+        }
+
+        private static string ResolveRecordTracePath(string userEventsScenarioDir)
+        {
+            // scenario dir: .../tracing/userevents/<scenario>/<scenario>
+            string usereventsRoot = Path.GetFullPath(Path.Combine(userEventsScenarioDir, "..", ".."));
+            // common dir: .../tracing/userevents/common/userevents_common
+            string commonDir = Path.Combine(usereventsRoot, "common", "userevents_common");
+            string recordTracePath = Path.Combine(commonDir, "record-trace");
+            return recordTracePath;
+        }
+    }
+}

--- a/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
+++ b/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
@@ -87,9 +87,14 @@ namespace Tracing.UserEvents.Tests.Common
             traceeStartInfo.RedirectStandardOutput = true;
             traceeStartInfo.RedirectStandardError = true;
 
+            // record-trace currently only searches /tmp/ for diagnostic ports https://github.com/microsoft/one-collect/issues/183
+            string diagnosticPortDir = "/tmp/";
+            traceeStartInfo.Environment["TMPDIR"] = diagnosticPortDir;
+
             Console.WriteLine($"Starting tracee process: {traceeStartInfo.FileName} {traceeStartInfo.Arguments}");
             using Process traceeProcess = Process.Start(traceeStartInfo);
-            Console.WriteLine($"Tracee process started with PID: {traceeProcess.Id}");
+            int traceePid = traceeProcess.Id;
+            Console.WriteLine($"Tracee process started with PID: {traceePid}");
             traceeProcess.OutputDataReceived += (_, args) =>
             {
                 if (!string.IsNullOrEmpty(args.Data))
@@ -114,6 +119,12 @@ namespace Tracing.UserEvents.Tests.Common
                 traceeProcess.Kill();
             }
             traceeProcess.WaitForExit(); // flush async output
+
+            // TMPDIR is configured on Helix, but the diagnostic port was created outside of helix's default temp datadisk path.
+            // The diagnostic port should be automatically cleaned up when the tracee shutsdown, but just in case of an
+            // abrupt exit, ensure cleanup to avoid leaving artifacts on helix machines.
+            // When https://github.com/microsoft/one-collect/issues/183 is fixed, this and the above TMPDIR should be removed.
+            CleanupTraceeDiagnosticPorts(diagnosticPortDir, traceePid);
 
             if (!recordTraceProcess.HasExited)
             {
@@ -144,6 +155,7 @@ namespace Tracing.UserEvents.Tests.Common
             if (!traceValidator(source))
             {
                 Console.Error.WriteLine($"Trace file `{traceFilePath}` does not contain expected events.");
+                UploadTraceFileFromHelix(traceFilePath, scenarioName);
                 return -1;
             }
 
@@ -158,6 +170,34 @@ namespace Tracing.UserEvents.Tests.Common
             string commonDir = Path.Combine(usereventsRoot, "common", "userevents_common");
             string recordTracePath = Path.Combine(commonDir, "record-trace");
             return recordTracePath;
+        }
+
+        private static void CleanupTraceeDiagnosticPorts(string diagnosticPortDir, int traceePid)
+        {
+            try
+            {
+                string[] udsFiles = Directory.GetFiles(diagnosticPortDir, $"dotnet-diagnostic-{traceePid}-*-socket");
+                foreach (string udsFile in udsFiles)
+                {
+                    Console.WriteLine($"Deleting tracee diagnostic port UDS file: {udsFile}");
+                    File.Delete(udsFile);
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failed to cleanup tracee diagnostic ports: {ex}");
+            }
+        }
+
+        private static void UploadTraceFileFromHelix(string traceFilePath, string scenarioName)
+        {
+            var helixWorkItemDirectory = Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT");
+            if (helixWorkItemDirectory != null && Directory.Exists(helixWorkItemDirectory))
+            {
+                var destPath = Path.Combine(helixWorkItemDirectory, $"{scenarioName}.nettrace");
+                Console.WriteLine($"Uploading trace file to Helix work item directory: {destPath}");
+                File.Copy(traceFilePath, destPath, overwrite: true);
+            }
         }
     }
 }

--- a/src/tests/tracing/userevents/common/userevents_common.csproj
+++ b/src/tests/tracing/userevents/common/userevents_common.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <IsTestProject>false</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.OneCollect.RecordTrace" Version="$(MicrosoftOneCollectRecordTraceVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="UserEventsTestRunner.cs" />
+    <Compile Include="UserEventsRequirements.cs" />
+  </ItemGroup>
+
+  <Target Name="CopyRecordTrace" BeforeTargets="Build" Condition="'$(TargetOS)' == 'linux' and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')">
+    <PropertyGroup>
+      <_DestDir>$(TargetDir)</_DestDir>
+      <_DestDir Condition="'$(_DestDir)' == ''">$(OutputPath)</_DestDir>
+      <_RecordTraceSource>$(NuGetPackageRoot)microsoft.onecollect.recordtrace/$(MicrosoftOneCollectRecordTraceVersion)/runtimes/linux-$(TargetArchitecture)/native/record-trace</_RecordTraceSource>
+    </PropertyGroup>
+
+    <Copy SourceFiles="$(_RecordTraceSource)" DestinationFiles="$(_DestDir)record-trace" SkipUnchangedFiles="true" />
+
+    <!-- For local testing, ensure it has execute permissions -->
+    <Exec Command="chmod +x '$(_DestDir)record-trace'" Condition="Exists('$(_DestDir)record-trace')" />
+  </Target>
+</Project>

--- a/src/tests/tracing/userevents/common/userevents_common.csproj
+++ b/src/tests/tracing/userevents/common/userevents_common.csproj
@@ -13,16 +13,29 @@
     <Compile Include="UserEventsRequirements.cs" />
   </ItemGroup>
 
-  <Target Name="CopyRecordTrace" BeforeTargets="Build" Condition="'$(TargetOS)' == 'linux' and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')">
+  <Target Name="CopyRecordTrace" BeforeTargets="Build;CopyAllNativeProjectReferenceBinaries" Condition="'$(TargetOS)' == 'linux' and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')">
     <PropertyGroup>
       <_DestDir>$(TargetDir)</_DestDir>
       <_DestDir Condition="'$(_DestDir)' == ''">$(OutputPath)</_DestDir>
       <_RecordTraceSource>$(NuGetPackageRoot)microsoft.onecollect.recordtrace/$(MicrosoftOneCollectRecordTraceVersion)/runtimes/linux-$(TargetArchitecture)/native/record-trace</_RecordTraceSource>
+      <_RecordTraceRelative Condition="$(BuildProjectRelativeDir) != ''">$(BuildProjectRelativeDir)record-trace</_RecordTraceRelative>
+      <_RecordTraceRelative Condition="'$(_RecordTraceRelative)' == ''">$([System.IO.Path]::GetRelativePath('$(TestBinDir)', '$(_DestDir)record-trace'))</_RecordTraceRelative>
     </PropertyGroup>
 
     <Copy SourceFiles="$(_RecordTraceSource)" DestinationFiles="$(_DestDir)record-trace" SkipUnchangedFiles="true" />
 
     <!-- For local testing, ensure it has execute permissions -->
     <Exec Command="chmod +x '$(_DestDir)record-trace'" Condition="Exists('$(_DestDir)record-trace')" />
+
+    <!-- For Helix builds, artifacts copied over have their permissions reset. Add the executable to a list for helix to reapply execute permissions -->
+    <WriteLinesToFile File="$(_DestDir)helix-extra-executables.list" Lines="$(_RecordTraceRelative)" Overwrite="true" />
+
+    <!-- Although this isn't a test project, userevents tests depend on record-trace, which in turn relies on helix-extra-executables.list to receive execute permissions
+         So to get the files included into Helix's _MergedPayloadFiles, we need to manually add an OutOfProcessTest marker. -->
+    <WriteLinesToFile
+      File="$(_DestDir)$(MSBuildProjectName).OutOfProcessTest"
+      Lines="OutOfProcessTest"
+      Overwrite="true"
+      WriteOnlyWhenDifferent="true" />
   </Target>
 </Project>

--- a/src/tests/tracing/userevents/custommetadata/custommetadata.cs
+++ b/src/tests/tracing/userevents/custommetadata/custommetadata.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
-using System.Threading;
 using Tracing.UserEvents.Tests.Common;
 using Microsoft.Diagnostics.Tracing;
 
@@ -14,8 +13,6 @@ namespace Tracing.UserEvents.Tests.CustomMetadata
     {
         public static void CustomMetadataTracee()
         {
-            // Allow some time for tracepoints be enabled before emitting events
-            Thread.Sleep(150);
             CustomMetadataEventSource.Log.WorkItem(1, "Item1");
         }
 
@@ -70,13 +67,12 @@ namespace Tracing.UserEvents.Tests.CustomMetadata
 
         public static int Main(string[] args)
         {
-            if (args.Length > 0 && args[0].Equals("tracee", StringComparison.OrdinalIgnoreCase))
-            {
-                CustomMetadataTracee();
-                return 0;
-            }
-
-            return UserEventsTestRunner.Run("custommetadata", typeof(CustomMetadata).Assembly.Location, s_traceValidator, 20000);
+            return UserEventsTestRunner.Run(
+                args,
+                "custommetadata",
+                typeof(CustomMetadata).Assembly.Location,
+                CustomMetadataTracee,
+                s_traceValidator);
         }
     }
 

--- a/src/tests/tracing/userevents/custommetadata/custommetadata.cs
+++ b/src/tests/tracing/userevents/custommetadata/custommetadata.cs
@@ -1,0 +1,96 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Threading;
+using Tracing.UserEvents.Tests.Common;
+using Microsoft.Diagnostics.Tracing;
+
+namespace Tracing.UserEvents.Tests.CustomMetadata
+{
+    public static class CustomMetadata
+    {
+        public static void CustomMetadataTracee()
+        {
+            // Allow some time for tracepoints be enabled before emitting events
+            Thread.Sleep(150);
+            CustomMetadataEventSource.Log.WorkItem(1, "Item1");
+        }
+
+        private static readonly Func<EventPipeEventSource, bool> s_traceValidator = source =>
+        {
+            bool anyMatching = false;
+
+            source.Dynamic.All += (TraceEvent e) =>
+            {
+                if (!string.Equals(e.ProviderName, "DemoCustomMetadata", StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                if (!string.Equals(e.EventName, "WorkItem", StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                try
+                {
+                    object? idObj = e.PayloadByName("id");
+                    object? nameObj = e.PayloadByName("name");
+                    int id = idObj is null ? -1 : Convert.ToInt32(idObj);
+                    string? name = nameObj as string;
+
+                    if (id != 1 || !string.Equals(name, "Item1", StringComparison.Ordinal))
+                    {
+                        Console.Error.WriteLine($"Unexpected payload values: id={id}, name={name}");
+                    }
+                    else
+                    {
+                        anyMatching = true;
+                        Console.WriteLine($"CustomMetadata event: Id={id}, Name={name}");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Exception while reading CustomMetadata payload: {ex}");
+                }
+            };
+
+            source.Process();
+
+            if (!anyMatching)
+            {
+                Console.Error.WriteLine("The trace did not contain the expected CustomMetadata event.");
+            }
+
+            return anyMatching;
+        };
+
+        public static int Main(string[] args)
+        {
+            if (args.Length > 0 && args[0].Equals("tracee", StringComparison.OrdinalIgnoreCase))
+            {
+                CustomMetadataTracee();
+                return 0;
+            }
+
+            return UserEventsTestRunner.Run("custommetadata", typeof(CustomMetadata).Assembly.Location, s_traceValidator, 20000);
+        }
+    }
+
+    [EventSource(Name = "DemoCustomMetadata")]
+    public sealed class CustomMetadataEventSource : EventSource
+    {
+        public static readonly CustomMetadataEventSource Log = new CustomMetadataEventSource();
+
+        private CustomMetadataEventSource() : base(EventSourceSettings.EtwSelfDescribingEventFormat) {}
+
+        [Event(1, Level = EventLevel.Informational)]
+        public void WorkItem(int id, string name)
+        {
+            WriteEvent(1, id, name);
+        }
+    }
+}

--- a/src/tests/tracing/userevents/custommetadata/custommetadata.csproj
+++ b/src/tests/tracing/userevents/custommetadata/custommetadata.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestTargetUnsupported Condition="'$(TargetOS)' != 'linux' or ('$(TargetArchitecture)' != 'x64' and '$(TargetArchitecture)' != 'arm64')">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="../common/userevents_common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="custommetadata.script">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>custommetadata.script</TargetPath>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/src/tests/tracing/userevents/custommetadata/custommetadata.script
+++ b/src/tests/tracing/userevents/custommetadata/custommetadata.script
@@ -1,0 +1,2 @@
+let DemoCustomMetadata_flags = new_dotnet_provider_flags();
+record_dotnet_provider("DemoCustomMetadata", 0x0, 5, DemoCustomMetadata_flags);

--- a/src/tests/tracing/userevents/managedevent/managedevent.cs
+++ b/src/tests/tracing/userevents/managedevent/managedevent.cs
@@ -55,13 +55,12 @@ namespace Tracing.UserEvents.Tests.ManagedEvent
 
         public static int Main(string[] args)
         {
-            if (args.Length > 0 && args[0].Equals("tracee", StringComparison.OrdinalIgnoreCase))
-            {
-                ManagedEventTracee();
-                return 0;
-            }
-
-            return UserEventsTestRunner.Run("managedevent", typeof(ManagedEvent).Assembly.Location, s_traceValidator);
+            return UserEventsTestRunner.Run(
+                args,
+                "managedevent",
+                typeof(ManagedEvent).Assembly.Location,
+                ManagedEventTracee,
+                s_traceValidator);
         }
     }
 

--- a/src/tests/tracing/userevents/managedevent/managedevent.cs
+++ b/src/tests/tracing/userevents/managedevent/managedevent.cs
@@ -1,0 +1,76 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Threading;
+using Tracing.UserEvents.Tests.Common;
+using Microsoft.Diagnostics.Tracing;
+
+namespace Tracing.UserEvents.Tests.ManagedEvent
+{
+    public class ManagedEvent
+    {
+        public static void ManagedEventTracee()
+        {
+            long startTimestamp = Stopwatch.GetTimestamp();
+            long targetTicks = Stopwatch.Frequency; // 1s
+
+            while (Stopwatch.GetTimestamp() - startTimestamp < targetTicks)
+            {
+                ManagedUserEventSource.Log.SampleEvent("SampleWork");
+                Thread.Sleep(100);
+            }
+        }
+
+        private static readonly Func<EventPipeEventSource, bool> s_traceValidator = source =>
+        {
+            bool sampleEventFound = false;
+
+            source.Dynamic.All += (TraceEvent e) =>
+            {
+                if (!string.Equals(e.ProviderName, "ManagedUserEvent", StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+
+                if (e.EventName is null)
+                {
+                    return;
+                }
+
+                sampleEventFound = true;
+            };
+
+            source.Process();
+
+            if (!sampleEventFound)
+            {
+                Console.Error.WriteLine("The trace did not contain the expected managed event.");
+            }
+
+            return sampleEventFound;
+        };
+
+        public static int Main(string[] args)
+        {
+            if (args.Length > 0 && args[0].Equals("tracee", StringComparison.OrdinalIgnoreCase))
+            {
+                ManagedEventTracee();
+                return 0;
+            }
+
+            return UserEventsTestRunner.Run("managedevent", typeof(ManagedEvent).Assembly.Location, s_traceValidator);
+        }
+    }
+
+    [EventSource(Name = "ManagedUserEvent")]
+    internal sealed class ManagedUserEventSource : EventSource
+    {
+        public static readonly ManagedUserEventSource Log = new ManagedUserEventSource();
+
+        [Event(1)]
+        public void SampleEvent(string requestName) => WriteEvent(1, requestName);
+    }
+}

--- a/src/tests/tracing/userevents/managedevent/managedevent.csproj
+++ b/src/tests/tracing/userevents/managedevent/managedevent.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestTargetUnsupported Condition="'$(TargetOS)' != 'linux' or ('$(TargetArchitecture)' != 'x64' and '$(TargetArchitecture)' != 'arm64')">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="../common/userevents_common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="managedevent.script">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>managedevent.script</TargetPath>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/src/tests/tracing/userevents/managedevent/managedevent.script
+++ b/src/tests/tracing/userevents/managedevent/managedevent.script
@@ -1,0 +1,2 @@
+let manageduserevent_flags = new_dotnet_provider_flags();
+record_dotnet_provider("ManagedUserEvent", 0x0, 5, manageduserevent_flags);

--- a/src/tests/tracing/userevents/multithread/multithread.cs
+++ b/src/tests/tracing/userevents/multithread/multithread.cs
@@ -94,13 +94,12 @@ namespace Tracing.UserEvents.Tests.MultiThread
 
         public static int Main(string[] args)
         {
-            if (args.Length > 0 && args[0].Equals("tracee", StringComparison.OrdinalIgnoreCase))
-            {
-                MultiThreadTracee();
-                return 0;
-            }
-
-            return UserEventsTestRunner.Run("multithread", typeof(MultiThread).Assembly.Location, s_traceValidator);
+            return UserEventsTestRunner.Run(
+                args,
+                "multithread",
+                typeof(MultiThread).Assembly.Location,
+                MultiThreadTracee,
+                s_traceValidator);
         }
     }
 }

--- a/src/tests/tracing/userevents/multithread/multithread.cs
+++ b/src/tests/tracing/userevents/multithread/multithread.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Threading;
+using System.Threading.Tasks;
+using Tracing.UserEvents.Tests.Common;
+using Microsoft.Diagnostics.Tracing;
+
+namespace Tracing.UserEvents.Tests.MultiThread
+{
+    [EventSource(Name = "DemoMultiThread")]
+    public sealed class MultiThreadEventSource : EventSource
+    {
+        public static readonly MultiThreadEventSource Log = new MultiThreadEventSource();
+
+        private MultiThreadEventSource() {}
+
+        [Event(1, Level = EventLevel.Informational)]
+        public void WorkerEvent(int workerId)
+        {
+            WriteEvent(1, workerId);
+        }
+    }
+
+    public static class MultiThread
+    {
+        private const int WorkerCount = 4;
+
+        public static void MultiThreadTracee()
+        {
+            Task[] tasks = new Task[WorkerCount];
+
+            for (int i = 0; i < WorkerCount; i++)
+            {
+                int workerId = i;
+                tasks[i] = Task.Run(() =>
+                {
+                    MultiThreadEventSource.Log.WorkerEvent(workerId);
+                });
+            }
+
+            Task.WaitAll(tasks);
+        }
+
+        private static readonly Func<EventPipeEventSource, bool> s_traceValidator = source =>
+        {
+            HashSet<int> seenWorkers = new HashSet<int>();
+
+            source.Dynamic.All += (TraceEvent e) =>
+            {
+                if (!string.Equals(e.ProviderName, "DemoMultiThread", StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                if (e.EventName is not "WorkerEvent")
+                {
+                    return;
+                }
+
+                int workerId = -1;
+                try
+                {
+                    workerId = (int)(e.PayloadByName("workerId") ?? -1);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine($"Exception while reading workerId payload: {ex}");
+                }
+
+                if (workerId >= 0)
+                {
+                    seenWorkers.Add(workerId);
+                }
+            };
+
+            source.Process();
+
+            for (int i = 0; i < WorkerCount; i++)
+            {
+                if (!seenWorkers.Contains(i))
+                {
+                    Console.Error.WriteLine($"Did not observe event for worker {i}.");
+                    return false;
+                }
+            }
+
+            return true;
+        };
+
+        public static int Main(string[] args)
+        {
+            if (args.Length > 0 && args[0].Equals("tracee", StringComparison.OrdinalIgnoreCase))
+            {
+                MultiThreadTracee();
+                return 0;
+            }
+
+            return UserEventsTestRunner.Run("multithread", typeof(MultiThread).Assembly.Location, s_traceValidator);
+        }
+    }
+}

--- a/src/tests/tracing/userevents/multithread/multithread.csproj
+++ b/src/tests/tracing/userevents/multithread/multithread.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <CLRTestTargetUnsupported Condition="'$(TargetOS)' != 'linux' or ('$(TargetArchitecture)' != 'x64' and '$(TargetArchitecture)' != 'arm64')">true</CLRTestTargetUnsupported>
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="../common/userevents_common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="multithread.script">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <TargetPath>multithread.script</TargetPath>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/src/tests/tracing/userevents/multithread/multithread.script
+++ b/src/tests/tracing/userevents/multithread/multithread.script
@@ -1,0 +1,2 @@
+let DemoMultiThread_flags = new_dotnet_provider_flags();
+record_dotnet_provider("DemoMultiThread", 0x0, 5, DemoMultiThread_flags);


### PR DESCRIPTION
With user_events support added in https://github.com/dotnet/runtime/pull/115265, this PR looks to test a few end-to-end user_events scenario.

## Alternative testing approaches considered

### **Existing EventPipe runtime tests**
Existing EventPipe tests under `src/tests/tracing/eventpipe` are incompatible with testing the user_events scenario due to:

1. Starting EventPipeSessions through DiagnosticClient ❌ 
DiagnosticClient does not have the support to send the IPC command to start a user_events based EventPipe session, because it requires the user_events_data file descriptor to be sent using SCM_RIGHTS (see https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md#passing_file_descriptor).

2. Using an EventPipeEventSource to validate events streamed through EventPipe ❌ 
User_events based EventPipe sessions do not stream events. Instead, events are written to configured TraceFS tracepoints, and currently only RecordTrace from https://github.com/microsoft/one-collect/ is capable of generating `.nettrace` traces from tracepoint user_events.

### **Native EventPipe Unit Tests**
There are Mono Native EventPipe tests under `src/mono/mono/eventpipe/test` that are not hooked up to CI. These unit tests are built through linking the shared EventPipe interface library against [Mono's EventPipe runtime shims](https://github.com/dotnet/runtime/tree/main/src/mono/mono/eventpipe) and using [Mono's test runner](https://github.com/dotnet/runtime/tree/main/src/mono/mono/eglib/test). To update these unit tests into the [standard runtime tests structure](https://github.com/dotnet/runtime/tree/main/src/tests), a **larger investment** is needed to either migrate EventPipe from using runtime shims to a OS Pal source shared by coreclr/nativeaot/mono (see https://github.com/dotnet/runtime/pull/118874#discussion_r2474264532) or build an EventPipe shared library specifically for the runtime test using a runtime-agnostic shim.
As existing mono unit tests don't currently test IPC commands, coupled with no existing runtime infrastructure to read events from tracepoints, there would be even more work on top of updating mono native eventpipe unit tests to even test the user_events scenario.

## End-to-End Testing Added
A low-cost approach to testing .NET Runtime's user_events functionality leverages RecordTrace from https://github.com/microsoft/one-collect/, which is already capable of starting user_events based EventPipe sessions and generating `.nettrace`s. (Note: [dotnet-trace wraps around RecordTrace](https://github.com/dotnet/diagnostics/pull/5570))
Despite adding an external dependency which allows RecordTrace failures to fail the end-to-end test, user_events was initially added with the intent to depend on RecordTrace for the end-to-end scenario, and there are no other ways to functionally test a user_events based eventpipe session.

### Approach

Each scenario uses the same pattern:

1. **Scenario invokes the shared test runner**

    User events scenarios can differ in their tracee logic, the events expected in the .nettrace, the record-trace script used to collect those events, and how long it takes for the tracee to emit them and for record-trace to resolve symbols and write the .nettrace. To handle this variance, UserEventsTestRunner lets each scenario pass in its scenario-specific record-trace script path, the path to its test assembly (used to spawn the tracee process), a validator that checks for the expected events from the tracee, and optional timeouts for both the tracee and record-trace to exit gracefully.

2. **`UserEventsTestRunner` orchestrates tracing and validation**

    Using this configuration, UserEventsTestRunner first checks whether user events are supported. It then starts record-trace with the scenario’s script and launches the tracee process so it can emit events. After the run completes, the runner stops both the tracee and record-trace, opens the resulting .nettrace with EventPipeEventSource, and applies the scenario’s validator to confirm that the expected events were recorded. Finally, it returns an exit code indicating whether the scenario passed or failed.

### Dependencies:
- Environment with a kernel 6.4+, .NET 10, glibc 2.35+
- Microsoft.OneCollect.RecordTrace (transitively resolved through a dotnet diagnostics public feed)
- Microsoft.Diagnostics.Tracing.TraceEvent 3.1.24+ (to read [NetTrace V6](https://github.com/microsoft/perfview/blob/main/src/TraceEvent/EventPipe/NetTraceFormat.md))

## Helix Nuances

UserEvents functional runtime tests differ from other runtime tests because it depends on OneCollect's Record-Trace tool to enable a userevents-based eventpipe session and to collect events. By design, Record-Trace requires elevated privileges, so these tests invoke a record-trace executable with sudo.

When tests run on Helix, test artifacts are stripped of their permissions, so the test infrastructure was modified to give record-trace execute permissions (helix-extra-executables.list). Moreover, to avoid having one copy of record-trace per scenario, which in turn requires re-adding execute permissions for each, more modifications were added to copy over a single record-trace executable that would be used by all scenarios (OutOfProcess marker).

Additionally, in Helix environments, TMPDIR is set to a helix specific temporary directory like /datadisks/disk1/work/<id>/t, and at this time, record-trace only scans /tmp/ for the runtime's diagnostic ports. So as a workaround, the tracee apps are spawned with TMPDIR set to /tmp.

Lastly, the job steps to run tests on AzDO prevents restoring individual runtime test projects. Because record-trace is currently only resolvable through the dotnet-diagnostics-tests source, userevents_common.csproj was added to the group of projects restored at the beginning of copying native test components to restore Microsoft.OneCollect.RecordTrace.
