### PR TITLE
[release/9.0] Ignore C4319 build warnings in libunwind

### DIFF
--- a/src/native/external/libunwind/CMakeLists.txt
+++ b/src/native/external/libunwind/CMakeLists.txt
@@ -58,6 +58,7 @@ if ("${CMAKE_GENERATOR}" MATCHES "^Visual Studio.*$")
   # Warnings in release builds
   add_compile_options(-wd4068) # ignore unknown pragma warnings (gcc pragmas)
   add_compile_options(-wd4334) # 32-bit shift implicitly converted to 64 bits
+  add_compile_options(-wd4319) # zero extending 'unsigned long' to 'size_t' of greater size
 
   # Disable warning due to incorrect format specifier in debugging printf via the Debug macro
   add_compile_options(-wd4311) # pointer truncation from 'unw_word_t *' to 'long'

--- a/src/native/external/libunwind_extras/CMakeLists.txt
+++ b/src/native/external/libunwind_extras/CMakeLists.txt
@@ -141,6 +141,7 @@ if(CLR_CMAKE_HOST_WIN32)
     # Warnings in release builds
     add_compile_options(-wd4068) # ignore unknown pragma warnings (gcc pragmas)
     add_compile_options(-wd4334) # 32-bit shift implicitly converted to 64 bits
+    add_compile_options(-wd4319) # zero extending 'unsigned long' to 'size_t' of greater size
 
     # Disable warning due to incorrect format specifier in debugging printf via the Debug macro
     add_compile_options(-wd4311) # pointer truncation from 'unw_word_t *' to 'long'


### PR DESCRIPTION
The networking team has automated stress tests periodically running on Windows and Linux.
Our builds of runtime on Windows broke around Nov 21, I suspect due to a tooling update in the `1es-windows-2022-open` image.

There's nothing special about how we're building libraries (`build.cmd clr+libs -ci -rc release -c $configuration`) and the build now always fails with a C4319 error (warning).
```
FAILED: [code=2] D:/a/_work/1/s/artifacts/obj/external/libunwind/CMakeFiles/libunwind_xdac.dir/D_/a/_work/1/s/src/native/external/libunwind/src/mi/mempool.c.obj 
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\cl.exe  /nologo -DCROSS_COMPILE -DDISABLE_CONTRACTS -DHAVE_CONFIG_H=1 -DHAVE_DL_ITERATE_PHDR=1 -DHAVE_UNW_GET_ACCESSORS -DHAVE___THREAD=0 -DHOST_64BIT -DHOST_AMD64 -DHOST_WINDOWS -DNDEBUG -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_STRING=\"\" -DTARGET_64BIT -DTARGET_AMD64 -DTARGET_LINUX -DTARGET_UNIX -DUNW_REMOTE_ONLY -DURTBLDENV_FRIENDLY=Retail -D_CRT_DECLARE_NONSTDC_NAMES -D_CRT_SECURE_NO_WARNINGS -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D_TIME_BITS=64 -D_Thread_local="" -D__amd64__ -D__linux__ -D__x86_64__ -ID:\a\_work\1\s\artifacts\obj\external\libunwind -ID:\a\_work\1\s\src\native\external\libunwind_extras -ID:\a\_work\1\s\src\native -ID:\a\_work\1\s\src\native\inc -ID:\a\_work\1\s\src\native\external\libunwind\include\tdep -ID:\a\_work\1\s\src\native\external\libunwind\include -ID:\a\_work\1\s\artifacts\obj\external\libunwind\include\tdep -ID:\a\_work\1\s\artifacts\obj\external\libunwind\include -ID:\a\_work\1\s\src\native\external\libunwind\include\remote -ID:\a\_work\1\s\src\native\external\libunwind\include\remote\win -ID:\a\_work\1\s\src\native\external\libunwind\src /DWIN32 /D_WINDOWS /O2 /Ob2 /DNDEBUG -std:c11 -MT /GL /Ox /nologo /W4 /WX /Oi /Oy- /Gm- /Zp8 /Gy /GS /fp:precise /FC /MP /Zm200 /Zc:strictStrings /Zc:wchar_t /Zc:inline /Zc:forScope /wd4065 /wd4100 /wd4127 /wd4131 /wd4189 /wd4200 /wd4201 /wd4206 /wd4239 /wd4245 /wd4291 /wd4310 /wd4324 /wd4366 /wd4456 /wd4457 /wd4458 /wd4459 /wd4463 /wd4505 /wd4702 /wd4706 /wd4733 /wd4815 /wd4838 /wd4918 /wd4960 /wd4961 /wd5105 /wd5205 /we4007 /we4013 /we4102 /we4551 /we4640 /we4806 /we4055 /we4146 /we4242 /we4244 /we4267 /we4302 /we4308 /we4509 /we4510 /we4532 /we4533 /we4610 /we4611 /we4700 /we4701 /we4703 /we4789 /we4995 /we4996 /w34092 /w34121 /w34125 /w34130 /w34132 /w34212 /w34530 /w35038 /w44177 /Zi /ZH:SHA_256 /source-charset:utf-8 /guard:cf /guard:ehcont /permissive- -wd4068 -wd4334 -wd4311 -wd4475 -wd4477 /TC /showIncludes /FoD:\a\_work\1\s\artifacts\obj\external\libunwind\CMakeFiles\libunwind_xdac.dir\D_\a\_work\1\s\src\native\external\libunwind\src\mi\mempool.c.obj /FdD:\a\_work\1\s\artifacts\obj\external\libunwind\CMakeFiles\libunwind_xdac.dir\ /FS -c D:\a\_work\1\s\src\native\external\libunwind\src\mi\mempool.c
D:\a\_work\1\s\src\native\external\libunwind\src\mi\mempool.c(96): error C2220: the following warning is treated as an error
D:\a\_work\1\s\src\native\external\libunwind\src\mi\mempool.c(96): warning C4319: '~': zero extending 'unsigned long' to 'size_t' of greater size
D:\a\_work\1\s\src\native\external\libunwind\src\mi\mempool.c(127): warning C4319: '~': zero extending 'unsigned long' to 'size_t' of greater size
```

This is only happening on Windows on the 9.0 branch. 8.0 and main aren't hitting this.

From the logs this might be due to a change from `MSVC 19.44.35220.0` to `MSVC 19.44.35221.0` in the image.

@AaronRobinsonMSFT does it make sense to suppress this warning or is there a better way to go about fixing this?