### PR TITLE
Mostly switch object writer to UTF-8

### DIFF
--- a/src/coreclr/tools/Common/Compiler/DependencyAnalysis/MethodReadOnlyDataNode.cs
+++ b/src/coreclr/tools/Common/Compiler/DependencyAnalysis/MethodReadOnlyDataNode.cs
@@ -34,7 +34,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append("__readonlydata_" + nameMangler.GetMangledMethodName(_owningMethod));
+            sb.Append("__readonlydata_"u8).Append(nameMangler.GetMangledMethodName(_owningMethod));
         }
         public int Offset => 0;
         public override bool IsShareable => true;

--- a/src/coreclr/tools/Common/Compiler/NameMangler.cs
+++ b/src/coreclr/tools/Common/Compiler/NameMangler.cs
@@ -23,7 +23,7 @@ namespace ILCompiler
         public NodeMangler NodeMangler { get; private set; }
 #endif
 
-        public abstract string CompilationUnitPrefix { get; set; }
+        public abstract Utf8String CompilationUnitPrefix { get; set; }
 
         public abstract Utf8String SanitizeName(Utf8String s);
 

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/ElfObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/ElfObjectWriter.cs
@@ -10,6 +10,7 @@ using System.Numerics;
 using System.Reflection;
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysisFramework;
+using Internal.Text;
 using Internal.TypeSystem;
 using static ILCompiler.DependencyAnalysis.RelocType;
 using static ILCompiler.ObjectWriter.EabiNative;
@@ -40,10 +41,10 @@ namespace ILCompiler.ObjectWriter
         private readonly List<ElfSectionDefinition> _sections = new();
         private readonly List<ElfSymbol> _symbols = new();
         private uint _localSymbolCount;
-        private readonly Dictionary<string, ElfSectionDefinition> _comdatNameToElfSection = new(StringComparer.Ordinal);
+        private readonly Dictionary<Utf8String, ElfSectionDefinition> _comdatNameToElfSection = new();
 
         // Symbol table
-        private readonly Dictionary<string, uint> _symbolNameToIndex = new();
+        private readonly Dictionary<Utf8String, uint> _symbolNameToIndex = new();
 
         private static readonly ObjectNodeSection ArmAttributesSection = new ObjectNodeSection(".ARM.attributes", SectionType.ReadOnly);
         private static readonly ObjectNodeSection ArmTextThunkSection = new ObjectNodeSection(".text.thunks", SectionType.Executable);
@@ -69,7 +70,7 @@ namespace ILCompiler.ObjectWriter
             _symbols.Add(new ElfSymbol {});
         }
 
-        private protected override void CreateSection(ObjectNodeSection section, string comdatName, string symbolName, int sectionIndex, Stream sectionStream)
+        private protected override void CreateSection(ObjectNodeSection section, Utf8String comdatName, Utf8String symbolName, int sectionIndex, Stream sectionStream)
         {
             string sectionName =
                 section.Name == "rdata" ? ".rodata" :
@@ -114,7 +115,7 @@ namespace ILCompiler.ObjectWriter
                 };
             }
 
-            if (comdatName is not null)
+            if (!comdatName.IsNull)
             {
                 flags |= SHF_GROUP;
                 if (!_comdatNameToElfSection.TryGetValue(comdatName, out groupSection))
@@ -154,7 +155,7 @@ namespace ILCompiler.ObjectWriter
             });
 
             // Emit section symbol into symbol table (for COMDAT the defining symbol is section symbol)
-            if (comdatName is null)
+            if (comdatName.IsNull)
             {
                 _symbolNameToIndex[sectionName] = (uint)_symbols.Count;
                 _symbols.Add(new ElfSymbol
@@ -174,7 +175,7 @@ namespace ILCompiler.ObjectWriter
                 });
             }
 
-            base.CreateSection(section, comdatName, symbolName ?? sectionName, sectionIndex, sectionStream);
+            base.CreateSection(section, comdatName, symbolName.IsNull ? sectionName : symbolName, sectionIndex, sectionStream);
         }
 
         protected internal override void UpdateSectionAlignment(int sectionIndex, int alignment)
@@ -188,7 +189,7 @@ namespace ILCompiler.ObjectWriter
             long offset,
             Span<byte> data,
             RelocType relocType,
-            string symbolName,
+            Utf8String symbolName,
             long addend)
         {
             fixed (byte *pData = data)
@@ -265,11 +266,11 @@ namespace ILCompiler.ObjectWriter
         private static string GetRiscV64SymbolNameForPcrelRelocation(int sectionIndex, long offset) => $".Lpcrel_hi{sectionIndex}_{offset:x}";
 
         private protected override void EmitSymbolTable(
-            IDictionary<string, SymbolDefinition> definedSymbols,
-            SortedSet<string> undefinedSymbols)
+            IDictionary<Utf8String, SymbolDefinition> definedSymbols,
+            SortedSet<Utf8String> undefinedSymbols)
         {
             List<ElfSymbol> sortedSymbols = new(definedSymbols.Count + undefinedSymbols.Count);
-            foreach ((string name, SymbolDefinition definition) in definedSymbols)
+            foreach ((Utf8String name, SymbolDefinition definition) in definedSymbols)
             {
                 var section = _sections[definition.SectionIndex];
                 var type =
@@ -290,7 +291,7 @@ namespace ILCompiler.ObjectWriter
             int thunkSectionIndex = useArmThunks ? GetOrCreateSection(ArmTextThunkSection).SectionIndex : 0;
             int thunkSymbolsIndex = 0;
 
-            foreach (string externSymbol in undefinedSymbols)
+            foreach (Utf8String externSymbol in undefinedSymbols)
             {
                 if (!_symbolNameToIndex.ContainsKey(externSymbol))
                 {
@@ -316,7 +317,7 @@ namespace ILCompiler.ObjectWriter
                 }
             }
 
-            sortedSymbols.Sort((symA, symB) => string.CompareOrdinal(symA.Name, symB.Name));
+            sortedSymbols.Sort((symA, symB) => Comparer<Utf8String>.Default.Compare(symA.Name, symB.Name));
             _localSymbolCount = (uint)_symbols.Count;
             _symbols.AddRange(sortedSymbols);
             uint symbolIndex = _localSymbolCount;
@@ -337,7 +338,7 @@ namespace ILCompiler.ObjectWriter
                 Span<byte> relocationEntry = stackalloc byte[8];
                 var relocationStream = new MemoryStream(8 * undefinedSymbols.Count);
                 _sections[thunkSectionWriter.SectionIndex].RelocationStream = relocationStream;
-                foreach (string externSymbol in undefinedSymbols)
+                foreach (Utf8String externSymbol in undefinedSymbols)
                 {
                     if (_symbolNameToIndex.TryGetValue($"{externSymbol}$thunk", out uint thunkSymbolIndex))
                     {
@@ -356,7 +357,7 @@ namespace ILCompiler.ObjectWriter
             }
 
             // Update group sections links
-            foreach ((string comdatName, ElfSectionDefinition groupSection) in _comdatNameToElfSection)
+            foreach ((Utf8String comdatName, ElfSectionDefinition groupSection) in _comdatNameToElfSection)
             {
                 groupSection.SectionHeader.Info = (uint)_symbolNameToIndex[comdatName];
             }
@@ -669,7 +670,7 @@ namespace ILCompiler.ObjectWriter
             // Reserve all symbol names
             foreach (var symbol in _symbols)
             {
-                if (symbol.Name is not null)
+                if (!symbol.Name.IsNull)
                 {
                     _stringTable.ReserveString(symbol.Name);
                 }
@@ -1039,7 +1040,7 @@ namespace ILCompiler.ObjectWriter
 
         private sealed class ElfSymbol
         {
-            public string Name { get; init; }
+            public Utf8String Name { get; init; }
             public ulong Value { get; init; }
             public ulong Size { get; init; }
             public ElfSectionDefinition Section { get; init; }
@@ -1062,7 +1063,7 @@ namespace ILCompiler.ObjectWriter
                     (ushort)SHN_XINDEX :
                     (Section is not null ? (ushort)Section.SectionIndex : (ushort)0u);
 
-                BinaryPrimitives.WriteUInt32LittleEndian(buffer, Name is not null ? stringTable.GetStringOffset(Name) : 0);
+                BinaryPrimitives.WriteUInt32LittleEndian(buffer, !Name.IsNull ? stringTable.GetStringOffset(Name) : 0);
                 if (typeof(TSize) == typeof(uint))
                 {
                     TSize.CreateChecked(Value).WriteLittleEndian(buffer.Slice(4));

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/OutputInfoBuilder.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/OutputInfoBuilder.cs
@@ -13,6 +13,7 @@ using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysisFramework;
 using ILCompiler.Diagnostics;
 using Internal.JitInterface;
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 
@@ -47,9 +48,9 @@ namespace ILCompiler.ObjectWriter
         /// <summary>
         /// Item name
         /// </summary>
-        public readonly string Name;
+        public readonly Utf8String Name;
 
-        public OutputItem(int sectionIndex, ulong offset, string name)
+        public OutputItem(int sectionIndex, ulong offset, Utf8String name)
         {
             SectionIndex = sectionIndex;
             Offset = offset;
@@ -93,7 +94,7 @@ namespace ILCompiler.ObjectWriter
     /// </summary>
     public sealed class OutputSymbol : OutputItem
     {
-        public OutputSymbol(int sectionIndex, ulong offset, string name)
+        public OutputSymbol(int sectionIndex, ulong offset, Utf8String name)
             : base(sectionIndex, offset, name)
         {
         }
@@ -171,7 +172,7 @@ namespace ILCompiler.ObjectWriter
 
         public bool FindSymbol(OutputItem item, out int index)
         {
-            index = _symbols.BinarySearch(new OutputSymbol(item.SectionIndex, item.Offset, name: null), OutputItem.Comparer.Instance);
+            index = _symbols.BinarySearch(new OutputSymbol(item.SectionIndex, item.Offset, name: default), OutputItem.Comparer.Instance);
             bool result = (index >= 0 && index < _symbols.Count && OutputItem.Comparer.Instance.Compare(_symbols[index], item) == 0);
             if (!result)
             {

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/PEObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/PEObjectWriter.cs
@@ -13,6 +13,7 @@ using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
 using System.Text;
 using ILCompiler.DependencyAnalysis;
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace ILCompiler.ObjectWriter
@@ -80,7 +81,7 @@ namespace ILCompiler.ObjectWriter
 
         // Base relocation (.reloc) bookkeeping
         private readonly SortedDictionary<uint, List<ushort>> _baseRelocMap = new();
-        private Dictionary<string, SymbolDefinition> _definedSymbols = [];
+        private Dictionary<Utf8String, SymbolDefinition> _definedSymbols = [];
 
         private HashSet<string> _exportedSymbolNames = new();
         private long _coffHeaderOffset;
@@ -101,10 +102,10 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        private protected override void CreateSection(ObjectNodeSection section, string comdatName, string symbolName, int sectionIndex, Stream sectionStream)
+        private protected override void CreateSection(ObjectNodeSection section, Utf8String comdatName, Utf8String symbolName, int sectionIndex, Stream sectionStream)
         {
             // COMDAT sections are not supported in PE files
-            base.CreateSection(section, comdatName: null, symbolName, sectionIndex, sectionStream);
+            base.CreateSection(section, comdatName: default, symbolName, sectionIndex, sectionStream);
 
             if (_requestedSectionAlignment != 0)
             {
@@ -339,7 +340,7 @@ namespace ILCompiler.ObjectWriter
             Reserved = 15,
         }
 
-        private protected override void EmitSymbolTable(IDictionary<string, SymbolDefinition> definedSymbols, SortedSet<string> undefinedSymbols)
+        private protected override void EmitSymbolTable(IDictionary<Utf8String, SymbolDefinition> definedSymbols, SortedSet<Utf8String> undefinedSymbols)
         {
             if (undefinedSymbols.Count > 0)
             {
@@ -347,7 +348,7 @@ namespace ILCompiler.ObjectWriter
             }
 
             // Grab the defined symbols to resolve relocs during emit.
-            _definedSymbols = new Dictionary<string, SymbolDefinition>(definedSymbols);
+            _definedSymbols = new Dictionary<Utf8String, SymbolDefinition>(definedSymbols);
         }
 
         private protected override void EmitSectionsAndLayout()

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/SectionWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/SectionWriter.cs
@@ -45,7 +45,7 @@ namespace ILCompiler.ObjectWriter
             long relativeOffset,
             Span<byte> data,
             RelocType relocType,
-            string symbolName,
+            Utf8String symbolName,
             long addend)
         {
             _objectWriter.EmitRelocation(
@@ -58,7 +58,7 @@ namespace ILCompiler.ObjectWriter
         }
 
         public readonly void EmitSymbolDefinition(
-            string symbolName,
+            Utf8String symbolName,
             long relativeOffset = 0,
             int size = 0,
             bool global = false)
@@ -73,7 +73,7 @@ namespace ILCompiler.ObjectWriter
 
         public readonly void EmitSymbolReference(
             RelocType relocType,
-            string symbolName,
+            Utf8String symbolName,
             long addend = 0)
         {
             IBufferWriter<byte> bufferWriter = _sectionData.BufferWriter;

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/StringTableBuilder.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/StringTableBuilder.cs
@@ -141,7 +141,7 @@ namespace ILCompiler.ObjectWriter
                             (input[0], input[1]) = (input[1], input[0]);
                             break;
                         }
-                        else if (c0 > c1 || c0 == (char)0)
+                        else if (c0 > c1 || c0 == 0)
                         {
                             break;
                         }
@@ -157,13 +157,10 @@ namespace ILCompiler.ObjectWriter
         private uint CreateIndex(Utf8String text)
         {
             uint offset = (uint)_stream.Position;
-            int reservedBytes = text.Length + 1;
-            byte[] buffer = ArrayPool<byte>.Shared.Rent(reservedBytes);
-            var span = new Span<byte>(buffer, 0, reservedBytes);
-            text.AsSpan().CopyTo(span);
-            span[reservedBytes - 1] = 0;
-            _stream.Write(span);
-            ArrayPool<byte>.Shared.Return(buffer);
+
+            _stream.Write(text.AsSpan());
+            _stream.WriteByte(0);
+
             _stringToOffset[text] = offset;
             return offset;
         }

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/StringTableBuilder.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/StringTableBuilder.cs
@@ -8,14 +8,15 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Linq;
+using Internal.Text;
 
 namespace ILCompiler.ObjectWriter
 {
     internal class StringTableBuilder
     {
         private readonly MemoryStream _stream = new();
-        private readonly SortedSet<string> _reservedStrings = new(StringComparer.Ordinal);
-        private Dictionary<string, uint> _stringToOffset = new(StringComparer.Ordinal);
+        private readonly SortedSet<Utf8String> _reservedStrings = new();
+        private Dictionary<Utf8String, uint> _stringToOffset = new();
 
         public void Write(Stream stream)
         {
@@ -32,9 +33,9 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        public void ReserveString(string text)
+        public void ReserveString(Utf8String text)
         {
-            if (text is object && !_stringToOffset.ContainsKey(text))
+            if (!text.IsNull && !_stringToOffset.ContainsKey(text))
             {
                 _reservedStrings.Add(text);
             }
@@ -42,21 +43,21 @@ namespace ILCompiler.ObjectWriter
 
         private void FlushReservedStrings()
         {
-            string[] reservedStrings = _reservedStrings.ToArray();
+            Utf8String[] reservedStrings = _reservedStrings.ToArray();
 
             // Pre-sort the string based on their matching suffix
             MultiKeySort(reservedStrings, 0);
 
             // Add the strings to string table
-            string lastText = null;
+            Utf8String lastText = default;
             for (int i = 0; i < reservedStrings.Length; i++)
             {
                 var text = reservedStrings[i];
                 uint index;
-                if (lastText is not null && lastText.EndsWith(text, StringComparison.Ordinal))
+                if (!lastText.IsNull && lastText.AsSpan().EndsWith(text.AsSpan()))
                 {
                     // Suffix matches the last symbol
-                    index = (uint)(_stream.Length - Encoding.UTF8.GetByteCount(text) - 1);
+                    index = (uint)(_stream.Length - text.Length - 1);
                     _stringToOffset.Add(text, index);
                 }
                 else
@@ -68,15 +69,15 @@ namespace ILCompiler.ObjectWriter
 
             _reservedStrings.Clear();
 
-            static char TailCharacter(string str, int pos)
+            static byte TailCharacter(Utf8String str, int pos)
             {
                 int index = str.Length - pos - 1;
                 if ((uint)index < str.Length)
-                    return str[index];
-                return '\0';
+                    return str.AsSpan()[index];
+                return 0;
             }
 
-            static void MultiKeySort(Span<string> input, int pos)
+            static void MultiKeySort(Span<Utf8String> input, int pos)
             {
                 if (!MultiKeySortSmallInput(input, pos))
                 {
@@ -84,14 +85,14 @@ namespace ILCompiler.ObjectWriter
                 }
             }
 
-            static void MultiKeySortLargeInput(Span<string> input, int pos)
+            static void MultiKeySortLargeInput(Span<Utf8String> input, int pos)
             {
             tailcall:
-                char pivot = TailCharacter(input[0], pos);
+                byte pivot = TailCharacter(input[0], pos);
                 int l = 0, h = input.Length;
                 for (int i = 1; i < h;)
                 {
-                    char c = TailCharacter(input[i], pos);
+                    byte c = TailCharacter(input[i], pos);
                     if (c > pivot)
                     {
                         (input[l], input[i]) = (input[i], input[l]);
@@ -123,7 +124,7 @@ namespace ILCompiler.ObjectWriter
                 }
             }
 
-            static bool MultiKeySortSmallInput(Span<string> input, int pos)
+            static bool MultiKeySortSmallInput(Span<Utf8String> input, int pos)
             {
                 if (input.Length <= 1)
                     return true;
@@ -133,8 +134,8 @@ namespace ILCompiler.ObjectWriter
                 {
                     while (true)
                     {
-                        char c0 = TailCharacter(input[0], pos);
-                        char c1 = TailCharacter(input[1], pos);
+                        byte c0 = TailCharacter(input[0], pos);
+                        byte c1 = TailCharacter(input[1], pos);
                         if (c0 < c1)
                         {
                             (input[0], input[1]) = (input[1], input[0]);
@@ -153,13 +154,13 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        private uint CreateIndex(string text)
+        private uint CreateIndex(Utf8String text)
         {
             uint offset = (uint)_stream.Position;
-            int reservedBytes = Encoding.UTF8.GetByteCount(text) + 1;
+            int reservedBytes = text.Length + 1;
             byte[] buffer = ArrayPool<byte>.Shared.Rent(reservedBytes);
             var span = new Span<byte>(buffer, 0, reservedBytes);
-            Encoding.UTF8.GetBytes(text, span);
+            text.AsSpan().CopyTo(span);
             span[reservedBytes - 1] = 0;
             _stream.Write(span);
             ArrayPool<byte>.Shared.Return(buffer);
@@ -167,7 +168,7 @@ namespace ILCompiler.ObjectWriter
             return offset;
         }
 
-        public uint GetStringOffset(string text)
+        public uint GetStringOffset(Utf8String text)
         {
             if (_reservedStrings.Count > 0)
             {

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/UnixObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/UnixObjectWriter.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Buffers.Binary;
 using ILCompiler.DependencyAnalysis;
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -19,7 +20,7 @@ namespace ILCompiler.ObjectWriter
     /// </summary>
     internal abstract partial class UnixObjectWriter : ObjectWriter
     {
-        private sealed record UnixSectionDefinition(string SymbolName, Stream SectionStream);
+        private sealed record UnixSectionDefinition(Utf8String SymbolName, Stream SectionStream);
         private readonly List<UnixSectionDefinition> _sections = new();
 
         private static readonly ObjectNodeSection LsdaSection = new ObjectNodeSection(".dotnet_eh_table", SectionType.ReadOnly);
@@ -30,12 +31,12 @@ namespace ILCompiler.ObjectWriter
         {
         }
 
-        private protected override void CreateSection(ObjectNodeSection section, string comdatName, string symbolName, int sectionIndex, Stream sectionStream)
+        private protected override void CreateSection(ObjectNodeSection section, Utf8String comdatName, Utf8String symbolName, int sectionIndex, Stream sectionStream)
         {
             if (section.Type != SectionType.Debug &&
                 section != LsdaSection &&
                 section != EhFrameSection &&
-                (comdatName is null || Equals(comdatName, symbolName)))
+                (comdatName.IsNull || Equals(comdatName, symbolName)))
             {
                 // Record code and data sections that can be referenced from debugging information
                 _sections.Add(new UnixSectionDefinition(symbolName, sectionStream));

--- a/src/coreclr/tools/Common/Internal/Text/Utf8String.cs
+++ b/src/coreclr/tools/Common/Internal/Text/Utf8String.cs
@@ -109,7 +109,7 @@ namespace Internal.Text
         {
             var result = new byte[s1.Length + s2.Length];
             s1.CopyTo(result);
-            s2.CopyTo(new Span<byte>(result).Slice(s1.Length));
+            s2.CopyTo(result.AsSpan(s1.Length));
             return new Utf8String(result);
         }
 
@@ -117,8 +117,8 @@ namespace Internal.Text
         {
             var result = new byte[s1.Length + s2.Length + s3.Length];
             s1.CopyTo(result);
-            s2.CopyTo(new Span<byte>(result).Slice(s1.Length));
-            s3.CopyTo(new Span<byte>(result).Slice(s1.Length + s2.Length));
+            s2.CopyTo(result.AsSpan(s1.Length));
+            s3.CopyTo(result.AsSpan(s1.Length + s2.Length));
             return new Utf8String(result);
         }
 
@@ -126,9 +126,9 @@ namespace Internal.Text
         {
             var result = new byte[s1.Length + s2.Length + s3.Length + s4.Length];
             s1.CopyTo(result);
-            s2.CopyTo(new Span<byte>(result).Slice(s1.Length));
-            s3.CopyTo(new Span<byte>(result).Slice(s1.Length + s2.Length));
-            s4.CopyTo(new Span<byte>(result).Slice(s1.Length + s2.Length + s3.Length));
+            s2.CopyTo(result.AsSpan(s1.Length));
+            s3.CopyTo(result.AsSpan(s1.Length + s2.Length));
+            s4.CopyTo(result.AsSpan(s1.Length + s2.Length + s3.Length));
             return new Utf8String(result);
         }
 
@@ -136,10 +136,10 @@ namespace Internal.Text
         {
             var result = new byte[s1.Length + s2.Length + s3.Length + s4.Length + s5.Length];
             s1.CopyTo(result);
-            s2.CopyTo(new Span<byte>(result).Slice(s1.Length));
-            s3.CopyTo(new Span<byte>(result).Slice(s1.Length + s2.Length));
-            s4.CopyTo(new Span<byte>(result).Slice(s1.Length + s2.Length + s3.Length));
-            s5.CopyTo(new Span<byte>(result).Slice(s1.Length + s2.Length + s3.Length + s4.Length));
+            s2.CopyTo(result.AsSpan(s1.Length));
+            s3.CopyTo(result.AsSpan(s1.Length + s2.Length));
+            s4.CopyTo(result.AsSpan(s1.Length + s2.Length + s3.Length));
+            s5.CopyTo(result.AsSpan(s1.Length + s2.Length + s3.Length + s4.Length));
             return new Utf8String(result);
         }
     }

--- a/src/coreclr/tools/Common/Internal/Text/Utf8String.cs
+++ b/src/coreclr/tools/Common/Internal/Text/Utf8String.cs
@@ -11,6 +11,8 @@ namespace Internal.Text
     {
         private readonly byte[] _value;
 
+        public bool IsNull => _value == null;
+
         public Utf8String(byte[] underlyingArray)
         {
             _value = underlyingArray;
@@ -100,6 +102,44 @@ namespace Internal.Text
                 resultSpan = resultSpan.Slice(s.Length);
             }
 
+            return new Utf8String(result);
+        }
+
+        public static Utf8String Concat(ReadOnlySpan<byte> s1, ReadOnlySpan<byte> s2)
+        {
+            var result = new byte[s1.Length + s2.Length];
+            s1.CopyTo(result);
+            s2.CopyTo(new Span<byte>(result).Slice(s1.Length));
+            return new Utf8String(result);
+        }
+
+        public static Utf8String Concat(ReadOnlySpan<byte> s1, ReadOnlySpan<byte> s2, ReadOnlySpan<byte> s3)
+        {
+            var result = new byte[s1.Length + s2.Length + s3.Length];
+            s1.CopyTo(result);
+            s2.CopyTo(new Span<byte>(result).Slice(s1.Length));
+            s3.CopyTo(new Span<byte>(result).Slice(s1.Length + s2.Length));
+            return new Utf8String(result);
+        }
+
+        public static Utf8String Concat(ReadOnlySpan<byte> s1, ReadOnlySpan<byte> s2, ReadOnlySpan<byte> s3, ReadOnlySpan<byte> s4)
+        {
+            var result = new byte[s1.Length + s2.Length + s3.Length + s4.Length];
+            s1.CopyTo(result);
+            s2.CopyTo(new Span<byte>(result).Slice(s1.Length));
+            s3.CopyTo(new Span<byte>(result).Slice(s1.Length + s2.Length));
+            s4.CopyTo(new Span<byte>(result).Slice(s1.Length + s2.Length + s3.Length));
+            return new Utf8String(result);
+        }
+
+        public static Utf8String Concat(ReadOnlySpan<byte> s1, ReadOnlySpan<byte> s2, ReadOnlySpan<byte> s3, ReadOnlySpan<byte> s4, ReadOnlySpan<byte> s5)
+        {
+            var result = new byte[s1.Length + s2.Length + s3.Length + s4.Length + s5.Length];
+            s1.CopyTo(result);
+            s2.CopyTo(new Span<byte>(result).Slice(s1.Length));
+            s3.CopyTo(new Span<byte>(result).Slice(s1.Length + s2.Length));
+            s4.CopyTo(new Span<byte>(result).Slice(s1.Length + s2.Length + s3.Length));
+            s5.CopyTo(new Span<byte>(result).Slice(s1.Length + s2.Length + s3.Length + s4.Length));
             return new Utf8String(result);
         }
     }

--- a/src/coreclr/tools/Common/TypeSystem/TypesDebugInfoWriter/TypesDebugInfoWriter.cs
+++ b/src/coreclr/tools/Common/TypeSystem/TypesDebugInfoWriter/TypesDebugInfoWriter.cs
@@ -32,7 +32,7 @@ namespace Internal.TypeSystem.TypesDebugInfo
     public struct EnumRecordTypeDescriptor
     {
         public ulong Value;
-        public string Name;
+        public Utf8String Name;
     }
 
     [StructLayout(LayoutKind.Sequential)]
@@ -57,13 +57,13 @@ namespace Internal.TypeSystem.TypesDebugInfo
     {
         public uint FieldTypeIndex;
         public ulong Offset;
-        public string Name;
+        public Utf8String Name;
     }
 
     [StructLayout(LayoutKind.Sequential)]
     public struct StaticDataFieldDescriptor
     {
-        public string StaticDataName;
+        public Utf8String StaticDataName;
         public ulong StaticOffset;
         public int IsStaticDataInObject;
     }
@@ -109,6 +109,6 @@ namespace Internal.TypeSystem.TypesDebugInfo
     {
         public uint MemberFunction;
         public uint ParentClass;
-        public string Name;
+        public Utf8String Name;
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/EETypeNode.cs
@@ -229,11 +229,6 @@ namespace ILCompiler.DependencyAnalysis
 
         public override bool StaticDependenciesAreComputed => true;
 
-        public static string GetMangledName(TypeDesc type, NameMangler nameMangler)
-        {
-            return nameMangler.NodeMangler.MethodTable(type);
-        }
-
         public virtual void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
             sb.Append(nameMangler.NodeMangler.MethodTable(_type));

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GCStaticsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GCStaticsNode.cs
@@ -39,7 +39,7 @@ namespace ILCompiler.DependencyAnalysis
         public int Offset => 0;
         public MetadataType Type => _type;
 
-        public static string GetMangledName(TypeDesc type, NameMangler nameMangler)
+        public static Utf8String GetMangledName(TypeDesc type, NameMangler nameMangler)
         {
             return nameMangler.NodeMangler.GCStatics(type);
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/MethodExceptionHandlingInfoNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/MethodExceptionHandlingInfoNode.cs
@@ -30,7 +30,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append("__ehinfo_" + nameMangler.GetMangledMethodName(_owningMethod));
+            sb.Append("__ehinfo_"u8).Append(nameMangler.GetMangledMethodName(_owningMethod));
         }
         public int Offset => 0;
         public override bool IsShareable => true;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NodeFactory.cs
@@ -273,15 +273,15 @@ namespace ILCompiler.DependencyAnalysis
                 return new FieldRvaDataNode(key);
             });
 
-            _externFunctionSymbols = new NodeCache<string, ExternFunctionSymbolNode>((string name) =>
+            _externFunctionSymbols = new NodeCache<Utf8String, ExternFunctionSymbolNode>((Utf8String name) =>
             {
                 return new ExternFunctionSymbolNode(name);
             });
-            _externIndirectFunctionSymbols = new NodeCache<string, ExternFunctionSymbolNode>((string name) =>
+            _externIndirectFunctionSymbols = new NodeCache<Utf8String, ExternFunctionSymbolNode>((Utf8String name) =>
             {
                 return new ExternFunctionSymbolNode(name, isIndirection: true);
             });
-            _externDataSymbols = new NodeCache<string, ExternDataSymbolNode>((string name) =>
+            _externDataSymbols = new NodeCache<Utf8String, ExternDataSymbolNode>((Utf8String name) =>
             {
                 return new ExternDataSymbolNode(name);
             });
@@ -972,30 +972,30 @@ namespace ILCompiler.DependencyAnalysis
             return _genericVariances.GetOrAdd(details);
         }
 
-        private NodeCache<string, ExternFunctionSymbolNode> _externFunctionSymbols;
+        private NodeCache<Utf8String, ExternFunctionSymbolNode> _externFunctionSymbols;
 
-        public ISortableSymbolNode ExternFunctionSymbol(string name)
+        public ISortableSymbolNode ExternFunctionSymbol(Utf8String name)
         {
             return _externFunctionSymbols.GetOrAdd(name);
         }
 
-        private NodeCache<string, ExternFunctionSymbolNode> _externIndirectFunctionSymbols;
+        private NodeCache<Utf8String, ExternFunctionSymbolNode> _externIndirectFunctionSymbols;
 
-        public ISortableSymbolNode ExternIndirectFunctionSymbol(string name)
+        public ISortableSymbolNode ExternIndirectFunctionSymbol(Utf8String name)
         {
             return _externIndirectFunctionSymbols.GetOrAdd(name);
         }
 
-        private NodeCache<string, ExternDataSymbolNode> _externDataSymbols;
+        private NodeCache<Utf8String, ExternDataSymbolNode> _externDataSymbols;
 
-        public ISortableSymbolNode ExternDataSymbol(string name)
+        public ISortableSymbolNode ExternDataSymbol(Utf8String name)
         {
             return _externDataSymbols.GetOrAdd(name);
         }
 
-        public ISortableSymbolNode ExternVariable(string name)
+        public ISortableSymbolNode ExternVariable(Utf8String name)
         {
-            string mangledName = NameMangler.NodeMangler.ExternVariable(name);
+            Utf8String mangledName = NameMangler.NodeMangler.ExternVariable(name);
             return _externDataSymbols.GetOrAdd(mangledName);
         }
 
@@ -1563,12 +1563,12 @@ namespace ILCompiler.DependencyAnalysis
         /// Returns alternative symbol name that object writer should produce for given symbols
         /// in addition to the regular one.
         /// </summary>
-        public string GetSymbolAlternateName(ISymbolNode node, out bool isHidden)
+        public Utf8String GetSymbolAlternateName(ISymbolNode node, out bool isHidden)
         {
             if (!NodeAliases.TryGetValue(node, out var value))
             {
                 isHidden = false;
-                return null;
+                return default;
             }
 
             isHidden = value.Hidden;
@@ -1595,7 +1595,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public ReadyToRunHeaderNode ReadyToRunHeader;
 
-        public Dictionary<ISymbolNode, (string Name, bool Hidden)> NodeAliases = new Dictionary<ISymbolNode, (string, bool)>();
+        public Dictionary<ISymbolNode, (Utf8String Name, bool Hidden)> NodeAliases = new Dictionary<ISymbolNode, (Utf8String, bool)>();
 
         protected internal TypeManagerIndirectionNode TypeManagerIndirection = new TypeManagerIndirectionNode();
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NonGCStaticsNode.cs
@@ -71,7 +71,7 @@ namespace ILCompiler.DependencyAnalysis
             }
         }
 
-        public static string GetMangledName(TypeDesc type, NameMangler nameMangler)
+        public static Utf8String GetMangledName(TypeDesc type, NameMangler nameMangler)
         {
             return nameMangler.NodeMangler.NonGCStatics(type);
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/SealedVTableNode.cs
@@ -34,7 +34,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public virtual void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            sb.Append(nameMangler.CompilationUnitPrefix + "__SealedVTable_" + nameMangler.NodeMangler.MethodTable(_type));
+            sb.Append(nameMangler.CompilationUnitPrefix).Append("__SealedVTable_"u8).Append(nameMangler.NodeMangler.MethodTable(_type));
         }
 
         int ISymbolNode.Offset => 0;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/ThreadStaticsNode.cs
@@ -37,7 +37,7 @@ namespace ILCompiler.DependencyAnalysis
             factory.ThreadStaticsRegion.AddEmbeddedObject(this);
         }
 
-        public static string GetMangledName(TypeDesc type, NameMangler nameMangler)
+        public static Utf8String GetMangledName(TypeDesc type, NameMangler nameMangler)
         {
             return nameMangler.NodeMangler.ThreadStatics(type);
         }
@@ -48,7 +48,7 @@ namespace ILCompiler.DependencyAnalysis
 
         public void AppendMangledName(NameMangler nameMangler, Utf8StringBuilder sb)
         {
-            string mangledName = _type == null ? "_inlinedThreadStatics" : GetMangledName(_type, nameMangler);
+            Utf8String mangledName = _type == null ? "_inlinedThreadStatics" : GetMangledName(_type, nameMangler);
             sb.Append(mangledName);
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/UnboxingStubNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/UnboxingStubNode.cs
@@ -41,9 +41,9 @@ namespace ILCompiler.DependencyAnalysis
             sb.Append("unbox_"u8).Append(nameMangler.GetMangledMethodName(Method));
         }
 
-        public static string GetMangledName(NameMangler nameMangler, MethodDesc method)
+        public static Utf8String GetMangledName(NameMangler nameMangler, MethodDesc method)
         {
-            return "unbox_" + nameMangler.GetMangledMethodName(method);
+            return Utf8String.Concat("unbox_"u8, nameMangler.GetMangledMethodName(method).AsSpan());
         }
 
         protected override string GetName(NodeFactory factory) => this.GetMangledName(factory.NameMangler);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/IRootingServiceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/IRootingServiceProvider.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace ILCompiler
@@ -10,7 +11,8 @@ namespace ILCompiler
     /// </summary>
     public interface IRootingServiceProvider
     {
-        void AddCompilationRoot(MethodDesc method, string reason, string exportName = null, bool exportHidden = false);
+        void AddCompilationRoot(MethodDesc method, string reason) => AddCompilationRoot(method, reason, default);
+        void AddCompilationRoot(MethodDesc method, string reason, Utf8String exportName, bool exportHidden = false);
         void AddCompilationRoot(TypeDesc type, string reason);
         void AddReflectionRoot(TypeDesc type, string reason);
         void AddReflectionRoot(MethodDesc method, string reason);
@@ -19,7 +21,7 @@ namespace ILCompiler
         void RootGCStaticBaseForType(TypeDesc type, string reason);
         void RootNonGCStaticBaseForType(TypeDesc type, string reason);
         void RootModuleMetadata(ModuleDesc module, string reason);
-        void RootReadOnlyDataBlob(byte[] data, int alignment, string reason, string exportName, bool exportHidden);
+        void RootReadOnlyDataBlob(byte[] data, int alignment, string reason, Utf8String exportName, bool exportHidden);
         void RootDelegateMarshallingData(DefType type, string reason);
         void RootStructMarshallingData(DefType type, string reason);
         void AddCompilationRoot(object o, string reason);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/NodeMangler.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/NodeMangler.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 namespace ILCompiler
@@ -14,19 +15,19 @@ namespace ILCompiler
     {
         public NameMangler NameMangler;
 
-        protected const string GenericDictionaryNamePrefix = "__GenericDict_";
+        protected static readonly Utf8String GenericDictionaryNamePrefix = new Utf8String("__GenericDict_");
 
         // Mangled name of boxed version of a type
-        public abstract string MangledBoxedTypeName(TypeDesc type);
+        public abstract Utf8String MangledBoxedTypeName(TypeDesc type);
 
-        public abstract string MethodTable(TypeDesc type);
-        public abstract string GCStatics(TypeDesc type);
-        public abstract string NonGCStatics(TypeDesc type);
-        public abstract string ThreadStatics(TypeDesc type);
-        public abstract string ThreadStaticsIndex(TypeDesc type);
-        public abstract string TypeGenericDictionary(TypeDesc type);
-        public abstract string MethodGenericDictionary(MethodDesc method);
-        public abstract string ExternMethod(string unmangledName, MethodDesc method);
-        public abstract string ExternVariable(string unmangledName);
+        public abstract Utf8String MethodTable(TypeDesc type);
+        public abstract Utf8String GCStatics(TypeDesc type);
+        public abstract Utf8String NonGCStatics(TypeDesc type);
+        public abstract Utf8String ThreadStatics(TypeDesc type);
+        public abstract Utf8String ThreadStaticsIndex(TypeDesc type);
+        public abstract Utf8String TypeGenericDictionary(TypeDesc type);
+        public abstract Utf8String MethodGenericDictionary(MethodDesc method);
+        public abstract Utf8String ExternMethod(Utf8String unmangledName, MethodDesc method);
+        public abstract Utf8String ExternVariable(Utf8String unmangledName);
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDataInterner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectDataInterner.cs
@@ -69,7 +69,7 @@ namespace ILCompiler
 
                     // Bodies that are visible from outside should not be folded because we don't know
                     // if they're address taken.
-                    if (factory.GetSymbolAlternateName(body, out _) != null)
+                    if (!factory.GetSymbolAlternateName(body, out _).IsNull)
                         continue;
 
                     var key = new MethodInternKey(body, factory);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/CodeView/CodeViewSymbolsBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/CodeView/CodeViewSymbolsBuilder.cs
@@ -112,7 +112,7 @@ namespace ILCompiler.ObjectWriter
         }
 
         public void EmitSubprogramInfo(
-            string methodName,
+            Utf8String methodName,
             int methodPCLength,
             uint methodTypeIndex,
             IEnumerable<(DebugVarInfoMetadata, uint)> debugVars,
@@ -220,7 +220,7 @@ namespace ILCompiler.ObjectWriter
 
         public void EmitLineInfo(
             CodeViewFileTableBuilder fileTableBuilder,
-            string methodName,
+            Utf8String methodName,
             int methodPCLength,
             IEnumerable<NativeSequencePoint> sequencePoints)
         {
@@ -300,7 +300,7 @@ namespace ILCompiler.ObjectWriter
             private readonly SectionWriter _sectionWriter;
             internal uint _size;
             internal readonly List<byte[]> _data = new();
-            internal readonly List<(uint, RelocType, string)> _relocations = new();
+            internal readonly List<(uint, RelocType, Utf8String)> _relocations = new();
 
             public SubsectionWriter(DebugSymbolsSubsectionType kind, SectionWriter sectionWriter)
             {
@@ -416,7 +416,7 @@ namespace ILCompiler.ObjectWriter
 
             public void EmitSymbolReference(
                 RelocType relocType,
-                string symbolName,
+                Utf8String symbolName,
                 int addend = 0)
             {
                 _subsectionWriter._relocations.Add((

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfBuilder.cs
@@ -17,9 +17,9 @@ namespace ILCompiler.ObjectWriter
 {
     internal sealed class DwarfBuilder : ITypesDebugInfoWriter
     {
-        private record struct SectionInfo(string SectionSymbolName, ulong Size);
+        private record struct SectionInfo(Utf8String SectionSymbolName, ulong Size);
         private record struct MemberFunctionTypeInfo(MemberFunctionTypeDescriptor MemberDescriptor, uint[] ArgumentTypes, bool IsStatic);
-        public delegate (string SectionSymbolName, long Address) ResolveStaticVariable(string name);
+        public delegate (Utf8String SectionSymbolName, long Address) ResolveStaticVariable(Utf8String name);
 
         private readonly NameMangler _nameMangler;
         private readonly TargetArchitecture _architecture;
@@ -201,8 +201,8 @@ namespace ILCompiler.ObjectWriter
 
                 foreach (DwarfStaticVariableInfo staticField in _staticFields)
                 {
-                    (string sectionSymbolName, long address) = resolveStaticVariable(staticField.Name);
-                    if (sectionSymbolName is not null)
+                    (Utf8String sectionSymbolName, long address) = resolveStaticVariable(staticField.Name);
+                    if (!sectionSymbolName.IsNull)
                     {
                         staticField.Dump(dwarfInfoWriter, sectionSymbolName, address);
                     }
@@ -429,8 +429,8 @@ namespace ILCompiler.ObjectWriter
         }
 
         public void EmitSubprogramInfo(
-            string methodName,
-            string sectionSymbolName,
+            Utf8String methodName,
+            Utf8String sectionSymbolName,
             long methodAddress,
             int methodPCLength,
             uint methodTypeIndex,
@@ -456,7 +456,7 @@ namespace ILCompiler.ObjectWriter
 
         public void EmitLineInfo(
             int sectionIndex,
-            string sectionSymbolName,
+            Utf8String sectionSymbolName,
             long methodAddress,
             IEnumerable<NativeSequencePoint> sequencePoints)
         {
@@ -493,7 +493,7 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        public void EmitSectionInfo(string sectionSymbolName, ulong size)
+        public void EmitSectionInfo(Utf8String sectionSymbolName, ulong size)
         {
             _sections.Add(new SectionInfo(sectionSymbolName, size));
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfEhFrame.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfEhFrame.cs
@@ -171,9 +171,9 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        private void WriteAddress(byte encoding, string symbolName, long symbolOffset = 0)
+        private void WriteAddress(byte encoding, Utf8String symbolName, long symbolOffset = 0)
         {
-            if (symbolName != null)
+            if (!symbolName.IsNull)
             {
                 RelocType relocationType = encoding switch
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfFde.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfFde.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics;
 using System.Buffers;
+using System.Diagnostics;
+
+using Internal.Text;
+
 using static ILCompiler.ObjectWriter.DwarfNative;
 
 namespace ILCompiler.ObjectWriter
@@ -12,20 +15,20 @@ namespace ILCompiler.ObjectWriter
     {
         public readonly DwarfCie Cie;
         public readonly byte[] Instructions;
-        public readonly string PcStartSymbolName;
+        public readonly Utf8String PcStartSymbolName;
         public readonly long PcStartSymbolOffset;
         public readonly ulong PcLength;
-        public readonly string LsdaSymbolName;
-        public readonly string PersonalitySymbolName;
+        public readonly Utf8String LsdaSymbolName;
+        public readonly Utf8String PersonalitySymbolName;
 
         public DwarfFde(
             DwarfCie cie,
             byte[] blobData,
-            string pcStartSymbolName,
+            Utf8String pcStartSymbolName,
             long pcStartSymbolOffset,
             ulong pcLength,
-            string lsdaSymbolName,
-            string personalitySymbolName)
+            Utf8String lsdaSymbolName,
+            Utf8String personalitySymbolName)
         {
             Cie = cie;
             Instructions = CfiCodeToInstructions(cie, blobData);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfInfo.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfInfo.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using ILCompiler.DependencyAnalysis;
 using Internal.JitInterface;
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.TypesDebugInfo;
 using static ILCompiler.ObjectWriter.DwarfNative;
@@ -194,15 +195,15 @@ namespace ILCompiler.ObjectWriter
 
     internal sealed class DwarfMemberFunction
     {
-        public string Name { get; private set; }
-        public string LinkageName { get; set; }
+        public Utf8String Name { get; private set; }
+        public Utf8String LinkageName { get; set; }
         public MemberFunctionTypeDescriptor Descriptor { get; private set; }
         public uint[] ArgumentTypes { get; private set; }
         public bool IsStatic { get; private set; }
         public long InfoOffset { get; set; }
 
         public DwarfMemberFunction(
-            string name,
+            Utf8String name,
             MemberFunctionTypeDescriptor descriptor,
             uint[] argumentTypes,
             bool isStatic)
@@ -360,7 +361,7 @@ namespace ILCompiler.ObjectWriter
 
     internal sealed class DwarfSubprogramInfo : DwarfInfo
     {
-        private readonly string _sectionSymbolName;
+        private readonly Utf8String _sectionSymbolName;
         private readonly long _methodAddress;
         private readonly int _methodSize;
         private readonly DwarfMemberFunction _memberFunction;
@@ -370,7 +371,7 @@ namespace ILCompiler.ObjectWriter
         private readonly bool _hasChildren;
 
         public DwarfSubprogramInfo(
-            string sectionSymbolName,
+            Utf8String sectionSymbolName,
             long methodAddress,
             int methodSize,
             DwarfMemberFunction memberFunction,
@@ -553,14 +554,14 @@ namespace ILCompiler.ObjectWriter
         private readonly StaticDataFieldDescriptor _descriptor;
 
         public long InfoOffset { get; set; }
-        public string Name => _descriptor.StaticDataName;
+        public Utf8String Name => _descriptor.StaticDataName;
 
         public DwarfStaticVariableInfo(StaticDataFieldDescriptor descriptor)
         {
             _descriptor = descriptor;
         }
 
-        public void Dump(DwarfInfoWriter writer, string sectionSymbolName, long address)
+        public void Dump(DwarfInfoWriter writer, Utf8String sectionSymbolName, long address)
         {
             writer.WriteStartDIE(DwarfAbbrev.VariableStatic);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfInfoWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfInfoWriter.cs
@@ -137,7 +137,7 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        public void WriteCodeReference(string sectionSymbolName, long offset = 0)
+        public void WriteCodeReference(Utf8String sectionSymbolName, long offset = 0)
         {
             Debug.Assert(offset >= 0);
             _infoSectionWriter.EmitSymbolReference(_codeRelocType, sectionSymbolName, offset);
@@ -169,7 +169,7 @@ namespace ILCompiler.ObjectWriter
             _infoSectionWriter.EmitSymbolReference(RelocType.IMAGE_REL_BASED_HIGHLOW, ".debug_loc", (int)offset);
         }
 
-        public void WriteLocationListExpression(string methodName, long startOffset, long endOffset, DwarfExpressionBuilder expressionBuilder)
+        public void WriteLocationListExpression(Utf8String methodName, long startOffset, long endOffset, DwarfExpressionBuilder expressionBuilder)
         {
             _ = expressionBuilder;
             _locSectionWriter.EmitSymbolReference(_codeRelocType, methodName, startOffset);
@@ -190,7 +190,7 @@ namespace ILCompiler.ObjectWriter
             _infoSectionWriter.EmitSymbolReference(RelocType.IMAGE_REL_BASED_HIGHLOW, ".debug_ranges", offset);
         }
 
-        public void WriteRangeListEntry(string symbolName, long startOffset, long endOffset)
+        public void WriteRangeListEntry(Utf8String symbolName, long startOffset, long endOffset)
         {
             _rangeSectionWriter.EmitSymbolReference(_codeRelocType, symbolName, startOffset);
             _rangeSectionWriter.EmitSymbolReference(_codeRelocType, symbolName, endOffset);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfLineSequenceWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/Dwarf/DwarfLineSequenceWriter.cs
@@ -4,6 +4,7 @@
 using System.Buffers;
 using System.Diagnostics;
 using ILCompiler.DependencyAnalysis;
+using Internal.Text;
 using static ILCompiler.ObjectWriter.DwarfNative;
 
 namespace ILCompiler.ObjectWriter
@@ -11,7 +12,7 @@ namespace ILCompiler.ObjectWriter
     internal sealed class DwarfLineSequenceWriter
     {
         private readonly ArrayBufferWriter<byte> _writer;
-        private readonly string _sectionName;
+        private readonly Utf8String _sectionName;
         private readonly byte _minimumInstructionLength;
         private readonly uint _maxDeltaAddressPerSpecialCode;
 
@@ -21,7 +22,7 @@ namespace ILCompiler.ObjectWriter
         private int _line = 1;
         private int _column;
 
-        public DwarfLineSequenceWriter(string sectionName, byte minimumInstructionLength)
+        public DwarfLineSequenceWriter(Utf8String sectionName, byte minimumInstructionLength)
         {
             _writer = new ArrayBufferWriter<byte>();
             _sectionName = sectionName;

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ElfObjectWriter.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ElfObjectWriter.Aot.cs
@@ -2,14 +2,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Diagnostics;
 using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Numerics;
 using System.Reflection;
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysisFramework;
+using Internal.Text;
 using Internal.TypeSystem;
 using static ILCompiler.DependencyAnalysis.RelocType;
 using static ILCompiler.ObjectWriter.EabiNative;
@@ -50,7 +51,7 @@ namespace ILCompiler.ObjectWriter
         private protected override void EmitUnwindInfo(
             SectionWriter sectionWriter,
             INodeWithCodeInfo nodeWithCodeInfo,
-            string currentSymbolName)
+            Utf8String currentSymbolName)
         {
             if (_machine is not EM_ARM)
             {
@@ -66,8 +67,8 @@ namespace ILCompiler.ObjectWriter
 
                 if (ShouldShareSymbol((ObjectNode)nodeWithCodeInfo))
                 {
-                    exidxSectionWriter = GetOrCreateSection(ArmUnwindIndexSection, currentSymbolName, $"_unwind0{currentSymbolName}");
-                    extabSectionWriter = GetOrCreateSection(ArmUnwindTableSection, currentSymbolName, $"_extab0{currentSymbolName}");
+                    exidxSectionWriter = GetOrCreateSection(ArmUnwindIndexSection, currentSymbolName, Utf8String.Concat("_unwind0"u8, currentSymbolName.AsSpan()));
+                    extabSectionWriter = GetOrCreateSection(ArmUnwindTableSection, currentSymbolName, Utf8String.Concat("_extab0"u8, currentSymbolName.AsSpan()));
                     _sections[exidxSectionWriter.SectionIndex].LinkSection = _sections[sectionWriter.SectionIndex];
                 }
                 else
@@ -90,6 +91,7 @@ namespace ILCompiler.ObjectWriter
 
                 long mainLsdaOffset = 0;
                 Span<byte> unwindWord = stackalloc byte[4];
+                Span<byte> i_str = stackalloc byte[16];
                 for (int i = 0; i < frameInfos.Length; i++)
                 {
                     FrameInfo frameInfo = frameInfos[i];
@@ -97,8 +99,8 @@ namespace ILCompiler.ObjectWriter
                     int end = frameInfo.EndOffset;
                     byte[] blob = frameInfo.BlobData;
 
-                    string framSymbolName = $"_fram{i}{currentSymbolName}";
-                    string extabSymbolName = $"_extab{i}{currentSymbolName}";
+                    Utf8String framSymbolName = _utf8StringBuilder.Clear().Append("_fram"u8).Append(FormatUtf8Int(i_str, i)).Append(currentSymbolName).ToUtf8String();
+                    Utf8String extabSymbolName = _utf8StringBuilder.Clear().Append("_extab"u8).Append(FormatUtf8Int(i_str, i)).Append(currentSymbolName).ToUtf8String();
 
                     sectionWriter.EmitSymbolDefinition(framSymbolName, start);
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.Aot.cs
@@ -9,11 +9,11 @@ using System.IO;
 using System.Linq;
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysisFramework;
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.TypesDebugInfo;
 using ObjectData = ILCompiler.DependencyAnalysis.ObjectNode.ObjectData;
 using static ILCompiler.DependencyAnalysis.RelocType;
-using Internal.Text;
 
 namespace ILCompiler.ObjectWriter
 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/ObjectWriter.Aot.cs
@@ -13,6 +13,7 @@ using Internal.TypeSystem;
 using Internal.TypeSystem.TypesDebugInfo;
 using ObjectData = ILCompiler.DependencyAnalysis.ObjectNode.ObjectData;
 using static ILCompiler.DependencyAnalysis.RelocType;
+using Internal.Text;
 
 namespace ILCompiler.ObjectWriter
 {
@@ -24,7 +25,7 @@ namespace ILCompiler.ObjectWriter
         private protected abstract void EmitUnwindInfo(
             SectionWriter sectionWriter,
             INodeWithCodeInfo nodeWithCodeInfo,
-            string currentSymbolName);
+            Utf8String currentSymbolName);
 
         private protected uint GetVarTypeIndex(bool isStateMachineMoveNextMethod, DebugVarInfoMetadata debugVar)
         {
@@ -55,19 +56,19 @@ namespace ILCompiler.ObjectWriter
 
         private protected abstract void EmitDebugFunctionInfo(
             uint methodTypeIndex,
-            string methodName,
+            Utf8String methodName,
             SymbolDefinition methodSymbol,
             INodeWithDebugInfo debugNode,
             bool hasSequencePoints);
 
         private protected virtual void EmitDebugThunkInfo(
-            string methodName,
+            Utf8String methodName,
             SymbolDefinition methodSymbol,
             INodeWithDebugInfo debugNode)
         {
         }
 
-        private protected abstract void EmitDebugSections(IDictionary<string, SymbolDefinition> definedSymbols);
+        private protected abstract void EmitDebugSections(IDictionary<Utf8String, SymbolDefinition> definedSymbols);
 
         partial void EmitDebugInfo(IReadOnlyCollection<DependencyNode> nodes, Logger logger)
         {
@@ -99,7 +100,7 @@ namespace ILCompiler.ObjectWriter
 
                 if (node is INodeWithDebugInfo debugNode and ISymbolDefinitionNode symbolDefinitionNode)
                 {
-                    string methodName = GetMangledName(symbolDefinitionNode);
+                    Utf8String methodName = GetMangledName(symbolDefinitionNode);
                     if (_definedSymbols.TryGetValue(methodName, out var methodSymbol))
                     {
                         if (node is IMethodNode methodNode)
@@ -129,7 +130,7 @@ namespace ILCompiler.ObjectWriter
 
         partial void PrepareForUnwindInfo() => CreateEhSections();
 
-        partial void EmitUnwindInfoForNode(ObjectNode node, string currentSymbolName, SectionWriter sectionWriter)
+        partial void EmitUnwindInfoForNode(ObjectNode node, Utf8String currentSymbolName, SectionWriter sectionWriter)
         {
             if (node is INodeWithCodeInfo nodeWithCodeInfo)
             {
@@ -137,7 +138,7 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        partial void HandleControlFlowForRelocation(ISymbolNode relocTarget, string relocSymbolName)
+        partial void HandleControlFlowForRelocation(ISymbolNode relocTarget, Utf8String relocSymbolName)
         {
             if (relocTarget is IMethodNode or AssemblyStubNode or AddressTakenExternFunctionSymbolNode)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/UnixObjectWriter.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/UnixObjectWriter.Aot.cs
@@ -7,11 +7,11 @@ using System.IO;
 using System.Linq;
 using System.Buffers.Binary;
 using ILCompiler.DependencyAnalysis;
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.TypesDebugInfo;
 
 using Debug = System.Diagnostics.Debug;
-using Internal.Text;
 
 namespace ILCompiler.ObjectWriter
 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/UnixObjectWriter.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/ObjectWriter/UnixObjectWriter.Aot.cs
@@ -11,6 +11,7 @@ using Internal.TypeSystem;
 using Internal.TypeSystem.TypesDebugInfo;
 
 using Debug = System.Diagnostics.Debug;
+using Internal.Text;
 
 namespace ILCompiler.ObjectWriter
 {
@@ -41,7 +42,7 @@ namespace ILCompiler.ObjectWriter
 
         private protected virtual bool UseFrameNames => false;
 
-        private protected virtual bool EmitCompactUnwinding(string startSymbolName, ulong length, string lsdaSymbolName, byte[] blob) => false;
+        private protected virtual bool EmitCompactUnwinding(Utf8String startSymbolName, ulong length, Utf8String lsdaSymbolName, byte[] blob) => false;
 
         private protected override void CreateEhSections()
         {
@@ -96,13 +97,13 @@ namespace ILCompiler.ObjectWriter
 
                 if (associatedDataNode is not null)
                 {
-                    string symbolName = GetMangledName(associatedDataNode);
+                    Utf8String symbolName = GetMangledName(associatedDataNode);
                     lsdaSectionWriter.EmitSymbolReference(RelocType.IMAGE_REL_BASED_RELPTR32, symbolName, 0);
                 }
 
                 if (ehInfo is not null)
                 {
-                    string symbolName = GetMangledName(ehInfo);
+                    Utf8String symbolName = GetMangledName(ehInfo);
                     lsdaSectionWriter.EmitSymbolReference(RelocType.IMAGE_REL_BASED_RELPTR32, symbolName, 0);
                 }
 
@@ -144,18 +145,18 @@ namespace ILCompiler.ObjectWriter
                 }
             }
 
-            private Dictionary<INodeWithCodeInfo, string[]> _lsdas = new Dictionary<INodeWithCodeInfo, string[]>(LsdaComparer.Instance);
+            private Dictionary<INodeWithCodeInfo, Utf8String[]> _lsdas = new Dictionary<INodeWithCodeInfo, Utf8String[]>(LsdaComparer.Instance);
 
             public static bool IsCacheable(INodeWithCodeInfo nodeWithCodeInfo)
                 => nodeWithCodeInfo.EHInfo == null && !MethodAssociatedDataNode.MethodHasAssociatedData((IMethodNode)nodeWithCodeInfo);
 
-            public string[] FindCachedLsda(INodeWithCodeInfo nodeWithCodeInfo)
+            public Utf8String[] FindCachedLsda(INodeWithCodeInfo nodeWithCodeInfo)
             {
                 Debug.Assert(IsCacheable(nodeWithCodeInfo));
                 return _lsdas.GetValueOrDefault(nodeWithCodeInfo);
             }
 
-            public void AddLsdaToCache(INodeWithCodeInfo nodeWithCodeInfo, string[] symbols)
+            public void AddLsdaToCache(INodeWithCodeInfo nodeWithCodeInfo, Utf8String[] symbols)
             {
                 Debug.Assert(IsCacheable(nodeWithCodeInfo));
                 _lsdas.Add(nodeWithCodeInfo, symbols);
@@ -167,7 +168,7 @@ namespace ILCompiler.ObjectWriter
         private protected override void EmitUnwindInfo(
             SectionWriter sectionWriter,
             INodeWithCodeInfo nodeWithCodeInfo,
-            string currentSymbolName)
+            Utf8String currentSymbolName)
         {
             if (nodeWithCodeInfo.FrameInfos is FrameInfo[] frameInfos &&
                 nodeWithCodeInfo is ISymbolDefinitionNode)
@@ -175,11 +176,11 @@ namespace ILCompiler.ObjectWriter
                 bool useFrameNames = UseFrameNames;
                 SectionWriter lsdaSectionWriter;
 
-                string[] newLsdaSymbols = null;
-                string[] emittedLsdaSymbols = null;
+                Utf8String[] newLsdaSymbols = null;
+                Utf8String[] emittedLsdaSymbols = null;
                 if (ShouldShareSymbol((ObjectNode)nodeWithCodeInfo))
                 {
-                    lsdaSectionWriter = GetOrCreateSection(LsdaSection, currentSymbolName, $"_lsda0{currentSymbolName}");
+                    lsdaSectionWriter = GetOrCreateSection(LsdaSection, currentSymbolName, Utf8String.Concat("_lsda0"u8, currentSymbolName.AsSpan()));
                 }
                 else
                 {
@@ -188,11 +189,12 @@ namespace ILCompiler.ObjectWriter
                     {
                         emittedLsdaSymbols = _lsdaCache.FindCachedLsda(nodeWithCodeInfo);
                         if (emittedLsdaSymbols == null)
-                            newLsdaSymbols = new string[frameInfos.Length];
+                            newLsdaSymbols = new Utf8String[frameInfos.Length];
                     }
                 }
 
                 long mainLsdaOffset = 0;
+                Span<byte> i_str = stackalloc byte[16];
                 for (int i = 0; i < frameInfos.Length; i++)
                 {
                     FrameInfo frameInfo = frameInfos[i];
@@ -201,27 +203,27 @@ namespace ILCompiler.ObjectWriter
                     int end = frameInfo.EndOffset;
                     byte[] blob = frameInfo.BlobData;
 
-                    string lsdaSymbolName;
+                    Utf8String lsdaSymbolName;
                     if (emittedLsdaSymbols != null)
                     {
                         lsdaSymbolName = emittedLsdaSymbols[i];
                     }
                     else
                     {
-                        lsdaSymbolName = $"_lsda{i}{currentSymbolName}";
+                        lsdaSymbolName = _utf8StringBuilder.Clear().Append("_lsda"u8).Append(FormatUtf8Int(i_str, i)).Append(currentSymbolName).ToUtf8String();
                         if (newLsdaSymbols != null)
                             newLsdaSymbols[i] = lsdaSymbolName;
                         lsdaSectionWriter.EmitSymbolDefinition(lsdaSymbolName);
                         EmitLsda(nodeWithCodeInfo, frameInfos, i, _lsdaSectionWriter, ref mainLsdaOffset);
                     }
 
-                    string framSymbolName = $"_fram{i}{currentSymbolName}";
+                    Utf8String framSymbolName = _utf8StringBuilder.Clear().Append("_fram"u8).Append(FormatUtf8Int(i_str, i)).Append(currentSymbolName).ToUtf8String();
                     if (useFrameNames && start != 0)
                     {
                         sectionWriter.EmitSymbolDefinition(framSymbolName, start);
                     }
 
-                    string startSymbolName = useFrameNames && start != 0 ? framSymbolName : currentSymbolName;
+                    Utf8String startSymbolName = useFrameNames && start != 0 ? framSymbolName : currentSymbolName;
                     ulong length = (ulong)(end - start);
                     if (!EmitCompactUnwinding(startSymbolName, length, lsdaSymbolName, blob))
                     {
@@ -232,7 +234,7 @@ namespace ILCompiler.ObjectWriter
                             pcStartSymbolOffset: useFrameNames ? 0 : start,
                             pcLength: (ulong)(end - start),
                             lsdaSymbolName,
-                            personalitySymbolName: null);
+                            personalitySymbolName: default);
                         _dwarfEhFrame.AddFde(fde);
                     }
                 }
@@ -244,7 +246,7 @@ namespace ILCompiler.ObjectWriter
 
         private protected override void EmitDebugFunctionInfo(
             uint methodTypeIndex,
-            string methodName,
+            Utf8String methodName,
             SymbolDefinition methodSymbol,
             INodeWithDebugInfo debugNode,
             bool hasSequencePoints)
@@ -278,7 +280,7 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
-        private protected override void EmitDebugSections(IDictionary<string, SymbolDefinition> definedSymbols)
+        private protected override void EmitDebugSections(IDictionary<Utf8String, SymbolDefinition> definedSymbols)
         {
             foreach (UnixSectionDefinition section in _sections)
             {
@@ -311,7 +313,7 @@ namespace ILCompiler.ObjectWriter
                     {
                         return (section.SymbolName, symbolDef.Value);
                     }
-                    return (null, 0);
+                    return (default, 0);
                 });
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingServiceProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/RootingServiceProvider.cs
@@ -4,6 +4,7 @@
 using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysisFramework;
 
+using Internal.Text;
 using Internal.TypeSystem;
 
 using Debug = System.Diagnostics.Debug;
@@ -23,13 +24,13 @@ namespace ILCompiler
             _rootAdder = rootAdder;
         }
 
-        public void AddCompilationRoot(MethodDesc method, string reason, string exportName = null, bool exportHidden = false)
+        public void AddCompilationRoot(MethodDesc method, string reason, Utf8String exportName, bool exportHidden = false)
         {
             MethodDesc canonMethod = method.GetCanonMethodTarget(CanonicalFormKind.Specific);
             IMethodNode methodEntryPoint = _factory.MethodEntrypoint(canonMethod);
             _rootAdder(methodEntryPoint, reason);
 
-            if (exportName != null)
+            if (!exportName.IsNull)
             {
                 exportName = _factory.NameMangler.NodeMangler.ExternMethod(exportName, method);
                 _factory.NodeAliases.Add(methodEntryPoint, (exportName, exportHidden));
@@ -140,7 +141,7 @@ namespace ILCompiler
             }
         }
 
-        public void RootReadOnlyDataBlob(byte[] data, int alignment, string reason, string exportName, bool exportHidden)
+        public void RootReadOnlyDataBlob(byte[] data, int alignment, string reason, Utf8String exportName, bool exportHidden)
         {
             var blob = _factory.ReadOnlyDataBlob("__readonlydata_" + exportName, data, alignment);
             _rootAdder(blob, reason);

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UnixNodeMangler.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UnixNodeMangler.cs
@@ -1,66 +1,71 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Internal.TypeSystem;
+using System;
 using System.Diagnostics;
 using System.Globalization;
+using Internal.Text;
+using Internal.TypeSystem;
 
 namespace ILCompiler
 {
     public sealed class UnixNodeMangler : NodeMangler
     {
         // Mangled name of boxed version of a type
-        public sealed override string MangledBoxedTypeName(TypeDesc type)
+        public sealed override Utf8String MangledBoxedTypeName(TypeDesc type)
         {
             Debug.Assert(type.IsValueType);
-            return "Boxed_" + NameMangler.GetMangledTypeName(type);
+            return Utf8String.Concat("Boxed_"u8, NameMangler.GetMangledTypeName(type).AsSpan());
         }
 
-        public sealed override string MethodTable(TypeDesc type)
+        public sealed override Utf8String MethodTable(TypeDesc type)
         {
-            string mangledJustTypeName = type.IsValueType
+            Utf8String mangledJustTypeName = type.IsValueType
                 ? MangledBoxedTypeName(type)
-                : NameMangler.GetMangledTypeName(type).ToString();
+                : NameMangler.GetMangledTypeName(type);
 
-            return "_ZTV" + mangledJustTypeName.Length.ToString(CultureInfo.InvariantCulture) + mangledJustTypeName;
+            Span<byte> typeNameLengthStr = stackalloc byte[16];
+            mangledJustTypeName.Length.TryFormat(typeNameLengthStr, out int written);
+
+            return Utf8String.Concat("_ZTV"u8, typeNameLengthStr.Slice(0, written), mangledJustTypeName.AsSpan());
         }
 
-        public sealed override string GCStatics(TypeDesc type)
+        public sealed override Utf8String GCStatics(TypeDesc type)
         {
-            return "__GCSTATICS" + NameMangler.GetMangledTypeName(type);
+            return Utf8String.Concat("__GCSTATICS"u8, NameMangler.GetMangledTypeName(type).AsSpan());
         }
 
-        public sealed override string NonGCStatics(TypeDesc type)
+        public sealed override Utf8String NonGCStatics(TypeDesc type)
         {
-            return "__NONGCSTATICS" + NameMangler.GetMangledTypeName(type);
+            return Utf8String.Concat("__NONGCSTATICS"u8, NameMangler.GetMangledTypeName(type).AsSpan());
         }
 
-        public sealed override string ThreadStatics(TypeDesc type)
+        public sealed override Utf8String ThreadStatics(TypeDesc type)
         {
-            return NameMangler.CompilationUnitPrefix + "__THREADSTATICS" + NameMangler.GetMangledTypeName(type);
+            return Utf8String.Concat(NameMangler.CompilationUnitPrefix.AsSpan(), "__THREADSTATICS"u8, NameMangler.GetMangledTypeName(type).AsSpan());
         }
 
-        public sealed override string ThreadStaticsIndex(TypeDesc type)
+        public sealed override Utf8String ThreadStaticsIndex(TypeDesc type)
         {
-            return "__TypeThreadStaticIndex" + NameMangler.GetMangledTypeName(type);
+            return Utf8String.Concat("__TypeThreadStaticIndex"u8, NameMangler.GetMangledTypeName(type).AsSpan());
         }
 
-        public sealed override string TypeGenericDictionary(TypeDesc type)
+        public sealed override Utf8String TypeGenericDictionary(TypeDesc type)
         {
-            return GenericDictionaryNamePrefix + NameMangler.GetMangledTypeName(type);
+            return Utf8String.Concat(GenericDictionaryNamePrefix, NameMangler.GetMangledTypeName(type));
         }
 
-        public sealed override string MethodGenericDictionary(MethodDesc method)
+        public sealed override Utf8String MethodGenericDictionary(MethodDesc method)
         {
-            return GenericDictionaryNamePrefix + NameMangler.GetMangledMethodName(method);
+            return Utf8String.Concat(GenericDictionaryNamePrefix, NameMangler.GetMangledMethodName(method));
         }
 
-        public sealed override string ExternMethod(string unmangledName, MethodDesc method)
+        public sealed override Utf8String ExternMethod(Utf8String unmangledName, MethodDesc method)
         {
             return unmangledName;
         }
 
-        public sealed override string ExternVariable(string unmangledName)
+        public sealed override Utf8String ExternVariable(Utf8String unmangledName)
         {
             return unmangledName;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
@@ -6,12 +6,12 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 
+using Internal.Text;
 using Internal.TypeSystem;
 using Internal.TypeSystem.Ecma;
 using Internal.TypeSystem.TypesDebugInfo;
 
 using ILCompiler.DependencyAnalysis;
-using Internal.Text;
 
 namespace ILCompiler
 {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UserDefinedTypeDescriptor.cs
@@ -11,6 +11,7 @@ using Internal.TypeSystem.Ecma;
 using Internal.TypeSystem.TypesDebugInfo;
 
 using ILCompiler.DependencyAnalysis;
+using Internal.Text;
 
 namespace ILCompiler
 {
@@ -233,7 +234,7 @@ namespace ILCompiler
 
                 descriptor.MemberFunction = GetMethodTypeIndex(method);
                 descriptor.ParentClass = GetTypeIndex(method.OwningType, true);
-                descriptor.Name = method.GetName();
+                descriptor.Name = new Utf8String(method.Name.ToArray());
 
                 typeIndex = _objectWriter.GetMemberFunctionId(descriptor);
                 _methodIdIndices.Add(method, typeIndex);
@@ -420,7 +421,7 @@ namespace ILCompiler
                 FieldDesc field = fieldsDescriptors[i];
                 EnumRecordTypeDescriptor recordTypeDescriptor;
                 recordTypeDescriptor.Value = GetEnumRecordValue(field);
-                recordTypeDescriptor.Name = field.GetName();
+                recordTypeDescriptor.Name = new Utf8String(field.Name.ToArray());
                 typeRecords[i] = recordTypeDescriptor;
             }
             uint typeIndex = _objectWriter.GetEnumTypeIndex(enumTypeDescriptor, typeRecords);
@@ -585,9 +586,9 @@ namespace ILCompiler
             List<DataFieldDescriptor> threadStaticFields = new List<DataFieldDescriptor>();
             List<StaticDataFieldDescriptor> staticsDescs = new List<StaticDataFieldDescriptor>();
 
-            string nonGcStaticDataName = NodeFactory.NameMangler.NodeMangler.NonGCStatics(type);
-            string gcStaticDataName = NodeFactory.NameMangler.NodeMangler.GCStatics(type);
-            string threadStaticDataName = NodeFactory.NameMangler.NodeMangler.ThreadStatics(type);
+            Utf8String nonGcStaticDataName = NodeFactory.NameMangler.NodeMangler.NonGCStatics(type);
+            Utf8String gcStaticDataName = NodeFactory.NameMangler.NodeMangler.GCStatics(type);
+            Utf8String threadStaticDataName = NodeFactory.NameMangler.NodeMangler.ThreadStatics(type);
             bool isNativeAOT = Abi == TargetAbi.NativeAot;
 
             bool hasNonGcStatics = NodeFactory.MetadataManager.HasNonGcStaticBase(defType);
@@ -665,7 +666,7 @@ namespace ILCompiler
                 {
                     FieldTypeIndex = fieldTypeIndex,
                     Offset = (ulong)fieldOffsetEmit,
-                    Name = fieldDesc.GetName()
+                    Name = new Utf8String(fieldDesc.Name.ToArray())
                 };
 
                 if (fieldDesc.IsStatic)
@@ -749,7 +750,7 @@ namespace ILCompiler
                 return typeIndex;
         }
 
-        private void InsertStaticFieldRegionMember(List<DataFieldDescriptor> fieldDescs, DefType defType, List<DataFieldDescriptor> staticFields, string staticFieldForm,
+        private void InsertStaticFieldRegionMember(List<DataFieldDescriptor> fieldDescs, DefType defType, List<DataFieldDescriptor> staticFields, Utf8String staticFieldForm,
                                                    bool staticDataInObject, bool isThreadStatic)
         {
             if (staticFields != null && (staticFields.Count > 0))
@@ -764,7 +765,7 @@ namespace ILCompiler
                 ClassTypeDescriptor classTypeDescriptor = new ClassTypeDescriptor
                 {
                     IsStruct = !staticDataInObject ? 1 : 0,
-                    Name = $"__type{staticFieldForm}{_objectWriter.GetMangledName(defType)}",
+                    Name = Utf8String.Concat("__type"u8, staticFieldForm.AsSpan(), _objectWriter.GetMangledName(defType).AsSpan()),
                     BaseClassId = 0
                 };
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/WindowsNodeMangler.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/WindowsNodeMangler.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using Internal.Text;
 using Internal.TypeSystem;
+using System;
 using System.Diagnostics;
 
 namespace ILCompiler
@@ -13,10 +15,10 @@ namespace ILCompiler
     {
         private TargetDetails _target;
 
-        public const string NonGCStaticMemberName = "__NONGCSTATICS";
-        public const string GCStaticMemberName = "__GCSTATICS";
-        public const string ThreadStaticMemberName = "__THREADSTATICS";
-        public const string ThreadStaticIndexName = "__THREADSTATICINDEX";
+        public static Utf8String NonGCStaticMemberName = "__NONGCSTATICS";
+        public static Utf8String GCStaticMemberName = "__GCSTATICS";
+        public static Utf8String ThreadStaticMemberName = "__THREADSTATICS";
+        public static Utf8String ThreadStaticIndexName = "__THREADSTATICINDEX";
 
         public WindowsNodeMangler(TargetDetails target)
         {
@@ -24,60 +26,64 @@ namespace ILCompiler
         }
 
         // Mangled name of boxed version of a type
-        public sealed override string MangledBoxedTypeName(TypeDesc type)
+        public sealed override Utf8String MangledBoxedTypeName(TypeDesc type)
         {
             Debug.Assert(type.IsValueType);
-            return "Boxed_" + NameMangler.GetMangledTypeName(type);
+            return Utf8String.Concat("Boxed_"u8, NameMangler.GetMangledTypeName(type).AsSpan());
         }
 
-        public sealed override string MethodTable(TypeDesc type)
+        public sealed override Utf8String MethodTable(TypeDesc type)
         {
-            string mangledJustTypeName = type.IsValueType
+            Utf8String mangledJustTypeName = type.IsValueType
                 ? MangledBoxedTypeName(type)
-                : NameMangler.GetMangledTypeName(type).ToString();
+                : NameMangler.GetMangledTypeName(type);
 
             // "??_7TypeName@@6B@" is the C++ mangling for "const TypeName::`vftable'"
             // This, along with LF_VTSHAPE debug records added by the object writer
             // is the debugger magic that allows debuggers to vcast types to their bases.
-            return "??_7" + mangledJustTypeName + "@@6B@";
+            return Utf8String.Concat("??_7"u8, mangledJustTypeName.AsSpan(), "@@6B@"u8);
         }
 
-        private string CreateStaticFieldName(TypeDesc type, string fieldName)
+        private Utf8String CreateStaticFieldName(TypeDesc type, ReadOnlySpan<byte> fieldName)
         {
-            return @$"?{fieldName}@{NameMangler.GetMangledTypeName(type)}@@";
+            return Utf8String.Concat("?"u8, fieldName, "@"u8, NameMangler.GetMangledTypeName(type).AsSpan(), "@@"u8);
         }
 
-        public sealed override string GCStatics(TypeDesc type)
+        public sealed override Utf8String GCStatics(TypeDesc type)
         {
-            return CreateStaticFieldName(type, GCStaticMemberName);
+            return CreateStaticFieldName(type, GCStaticMemberName.AsSpan());
         }
 
-        public sealed override string NonGCStatics(TypeDesc type)
+        public sealed override Utf8String NonGCStatics(TypeDesc type)
         {
-            return CreateStaticFieldName(type, NonGCStaticMemberName);
+            return CreateStaticFieldName(type, NonGCStaticMemberName.AsSpan());
         }
 
-        public sealed override string ThreadStatics(TypeDesc type)
+        public sealed override Utf8String ThreadStatics(TypeDesc type)
         {
-            return CreateStaticFieldName(type, NameMangler.CompilationUnitPrefix + ThreadStaticMemberName);
+            Utf8String name = NameMangler.CompilationUnitPrefix.Length > 0
+                ? Utf8String.Concat(NameMangler.CompilationUnitPrefix, ThreadStaticMemberName)
+                : ThreadStaticMemberName;
+
+            return CreateStaticFieldName(type, name.AsSpan());
         }
 
-        public sealed override string ThreadStaticsIndex(TypeDesc type)
+        public sealed override Utf8String ThreadStaticsIndex(TypeDesc type)
         {
-            return CreateStaticFieldName(type, ThreadStaticIndexName);
+            return CreateStaticFieldName(type, ThreadStaticIndexName.AsSpan());
         }
 
-        public sealed override string TypeGenericDictionary(TypeDesc type)
+        public sealed override Utf8String TypeGenericDictionary(TypeDesc type)
         {
-            return GenericDictionaryNamePrefix + NameMangler.GetMangledTypeName(type);
+            return Utf8String.Concat(GenericDictionaryNamePrefix, NameMangler.GetMangledTypeName(type));
         }
 
-        public sealed override string MethodGenericDictionary(MethodDesc method)
+        public sealed override Utf8String MethodGenericDictionary(MethodDesc method)
         {
-            return GenericDictionaryNamePrefix + NameMangler.GetMangledMethodName(method);
+            return Utf8String.Concat(GenericDictionaryNamePrefix, NameMangler.GetMangledMethodName(method));
         }
 
-        public sealed override string ExternMethod(string unmangledName, MethodDesc method)
+        public sealed override Utf8String ExternMethod(Utf8String unmangledName, MethodDesc method)
         {
             if (_target.Architecture != TargetArchitecture.X86)
             {
@@ -117,7 +123,7 @@ namespace ILCompiler
             };
         }
 
-        public sealed override string ExternVariable(string unmangledName)
+        public sealed override Utf8String ExternVariable(Utf8String unmangledName)
         {
             if (_target.Architecture != TargetArchitecture.X86)
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -1062,14 +1062,14 @@ namespace ILCompiler.DependencyAnalysis
             _genericCycleDetector?.DetectCycle(caller, callee);
         }
 
-        public string GetSymbolAlternateName(ISymbolNode node, out bool isHidden)
+        public Utf8String GetSymbolAlternateName(ISymbolNode node, out bool isHidden)
         {
             isHidden = false;
             if (node == Header)
             {
-                return "RTR_HEADER";
+                return new Utf8String("RTR_HEADER"u8.ToArray());
             }
-            return null;
+            return default;
         }
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/MapFileBuilder.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ObjectWriter/MapFileBuilder.cs
@@ -19,6 +19,7 @@ using ILCompiler.DependencyAnalysis;
 using ILCompiler.DependencyAnalysis.ReadyToRun;
 using ILCompiler.Diagnostics;
 using ILCompiler.ObjectWriter;
+using Internal.Text;
 
 namespace ILCompiler.PEWriter
 {
@@ -37,19 +38,19 @@ namespace ILCompiler.PEWriter
         /// </summary>
         private class NodeTypeStatistics
         {
-            public readonly string Name;
+            public readonly Utf8String Name;
 
             public int Count;
             public int Length;
 
-            public NodeTypeStatistics(string name)
+            public NodeTypeStatistics(Utf8String name)
             {
                 Name = name;
             }
 
             public void AddNode(OutputNode node)
             {
-                Debug.Assert(Name == node.Name);
+                Debug.Assert(Name.AsSpan().SequenceEqual(node.Name.AsSpan()));
                 Count++;
                 Length += node.Length;
             }
@@ -116,7 +117,7 @@ namespace ILCompiler.PEWriter
         private IEnumerable<NodeTypeStatistics> GetNodeTypeStatistics()
         {
             List<NodeTypeStatistics> nodeTypeStats = new List<NodeTypeStatistics>();
-            Dictionary<string, int> statsNameIndex = new Dictionary<string, int>();
+            Dictionary<Utf8String, int> statsNameIndex = new Dictionary<Utf8String, int>();
             foreach (OutputNode node in _outputInfoBuilder.Nodes)
             {
                 if (!statsNameIndex.TryGetValue(node.Name, out int statsIndex))

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -8,12 +8,13 @@ using System.IO;
 using System.Runtime.InteropServices;
 
 using Internal.IL;
-using Internal.TypeSystem;
 using Internal.ReadyToRunConstants;
+using Internal.Text;
+using Internal.TypeSystem;
+using Internal.TypeSystem.Ecma;
 
 using ILCompiler;
 using ILCompiler.DependencyAnalysis;
-using Internal.TypeSystem.Ecma;
 
 #if SUPPORT_JIT
 using MethodCodeNode = Internal.Runtime.JitSupport.JitMethodCodeNode;
@@ -1922,7 +1923,7 @@ namespace Internal.JitInterface
         {
             MethodDesc md = HandleToObject(method);
 
-            string externName = _compilation.PInvokeILProvider.GetDirectCallExternName(md);
+            Utf8String externName = _compilation.PInvokeILProvider.GetDirectCallExternName(md);
             externName = _compilation.NodeFactory.NameMangler.NodeMangler.ExternMethod(externName, md);
 
             pLookup = CreateConstLookupToSymbol(_compilation.NodeFactory.ExternFunctionSymbol(externName));


### PR DESCRIPTION
When compiling hello world:

`byte[]` allocations before: 564000. `string` allocations before: 302000
`byte[]` allocations after: 625000. `string` allocations after: 241000

So this is mostly a wash allocation-wise, however, not allocating string means we're also avoiding the UTF-8 -> UTF-16 -> UTF-8 conversions.

Cc @dotnet/ilc-contrib 