### PR TITLE
Fix FrameDataAllocator popping in InterpreterFrame::ExceptionUnwind

### DIFF
--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -1985,7 +1985,7 @@ void InterpreterFrame::ExceptionUnwind_Impl()
 
     Thread *pThread = GetThread();
     InterpThreadContext *pThreadContext = pThread->GetInterpThreadContext();
-    InterpMethodContextFrame *pInterpMethodContextFrame = m_pTopInterpMethodContextFrame;
+    InterpMethodContextFrame *pInterpMethodContextFrame = GetTopInterpMethodContextFrame();
 
     // Unwind the interpreter frames belonging to the current InterpreterFrame.
     while (pInterpMethodContextFrame != NULL)


### PR DESCRIPTION
The InterpreterFrame::ExceptionUnwind_Impl was passing a wrong topmost frame to the frameDataAllocator.PopInfo - the one read directly from the m_pTopInterpMethodContextFrame which is not always up to date. The correct way is to use the call to GetTopInterpMethodContextFrame to get it.

It was leading to the following assert in some libraries tests: assert(pCurrent == pFirst && pCurrent->pFramePos == pCurrent->pFrameStart)