### PR TITLE
Fix SVE2 API for Odd/Even methods

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve2.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve2.PlatformNotSupported.cs
@@ -3129,37 +3129,37 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint16_t svshllb[_n_s16](svint8_t op1, uint64_t imm2)
         ///   SSHLLB Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<short> ShiftLeftLogicalWideningEven(Vector<sbyte> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
+        public static Vector<short> ShiftLeftLogicalWideningEven(Vector<sbyte> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t svshllb[_n_s32](svint16_t op1, uint64_t imm2)
         ///   SSHLLB Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<int> ShiftLeftLogicalWideningEven(Vector<short> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
+        public static Vector<int> ShiftLeftLogicalWideningEven(Vector<short> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t svshllb[_n_s64](svint32_t op1, uint64_t imm2)
         ///   SSHLLB Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<long> ShiftLeftLogicalWideningEven(Vector<int> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
+        public static Vector<long> ShiftLeftLogicalWideningEven(Vector<int> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint16_t svshllb[_n_u16](svuint8_t op1, uint64_t imm2)
         ///   USHLLB Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<ushort> ShiftLeftLogicalWideningEven(Vector<byte> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
+        public static Vector<ushort> ShiftLeftLogicalWideningEven(Vector<byte> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint32_t svshllb[_n_u32](svuint16_t op1, uint64_t imm2)
         ///   USHLLB Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<uint> ShiftLeftLogicalWideningEven(Vector<ushort> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
+        public static Vector<uint> ShiftLeftLogicalWideningEven(Vector<ushort> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint64_t svshllb[_n_u64](svuint32_t op1, uint64_t imm2)
         ///   USHLLB Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<ulong> ShiftLeftLogicalWideningEven(Vector<uint> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
+        public static Vector<ulong> ShiftLeftLogicalWideningEven(Vector<uint> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
 
 
         // Shift left long (top)
@@ -3168,37 +3168,37 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint16_t svshllt[_n_s16](svint8_t op1, uint64_t imm2)
         ///   SSHLLT Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<short> ShiftLeftLogicalWideningOdd(Vector<sbyte> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
+        public static Vector<short> ShiftLeftLogicalWideningOdd(Vector<sbyte> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t svshllt[_n_s32](svint16_t op1, uint64_t imm2)
         ///   SSHLLT Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<int> ShiftLeftLogicalWideningOdd(Vector<short> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
+        public static Vector<int> ShiftLeftLogicalWideningOdd(Vector<short> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t svshllt[_n_s64](svint32_t op1, uint64_t imm2)
         ///   SSHLLT Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<long> ShiftLeftLogicalWideningOdd(Vector<int> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
+        public static Vector<long> ShiftLeftLogicalWideningOdd(Vector<int> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint16_t svshllt[_n_u16](svuint8_t op1, uint64_t imm2)
         ///   USHLLT Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<ushort> ShiftLeftLogicalWideningOdd(Vector<byte> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
+        public static Vector<ushort> ShiftLeftLogicalWideningOdd(Vector<byte> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint32_t svshllt[_n_u32](svuint16_t op1, uint64_t imm2)
         ///   USHLLT Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<uint> ShiftLeftLogicalWideningOdd(Vector<ushort> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
+        public static Vector<uint> ShiftLeftLogicalWideningOdd(Vector<ushort> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint64_t svshllt[_n_u64](svuint32_t op1, uint64_t imm2)
         ///   USHLLT Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<ulong> ShiftLeftLogicalWideningOdd(Vector<uint> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
+        public static Vector<ulong> ShiftLeftLogicalWideningOdd(Vector<uint> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
 
 
         // Rounding shift left

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve2.PlatformNotSupported.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve2.PlatformNotSupported.cs
@@ -276,13 +276,13 @@ namespace System.Runtime.Intrinsics.Arm
         /// svuint32_t svadclb[_u32](svuint32_t op1, svuint32_t op2, svuint32_t op3)
         ///   ADCLB Ztied1.S, Zop2.S, Zop3.S
         /// </summary>
-        public static unsafe Vector<uint> AddCarryWideningEven(Vector<uint> op1, Vector<uint> op2, Vector<uint> op3) { throw new PlatformNotSupportedException(); }
+        public static unsafe Vector<uint> AddCarryWideningEven(Vector<uint> left, Vector<uint> right, Vector<uint> carry) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint64_t svadclb[_u64](svuint64_t op1, svuint64_t op2, svuint64_t op3)
         ///   ADCLB Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<ulong> AddCarryWideningEven(Vector<ulong> op1, Vector<ulong> op2, Vector<ulong> op3) { throw new PlatformNotSupportedException(); }
+        public static unsafe Vector<ulong> AddCarryWideningEven(Vector<ulong> left, Vector<ulong> right, Vector<ulong> carry) { throw new PlatformNotSupportedException(); }
 
         // Add with carry long (top)
 
@@ -290,13 +290,13 @@ namespace System.Runtime.Intrinsics.Arm
         /// svuint32_t svadclt[_u32](svuint32_t op1, svuint32_t op2, svuint32_t op3)
         ///   ADCLT Ztied1.S, Zop2.S, Zop3.S
         /// </summary>
-        public static unsafe Vector<uint> AddCarryWideningOdd(Vector<uint> op1, Vector<uint> op2, Vector<uint> op3) { throw new PlatformNotSupportedException(); }
+        public static unsafe Vector<uint> AddCarryWideningOdd(Vector<uint> left, Vector<uint> right, Vector<uint> carry) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint64_t svadclt[_u64](svuint64_t op1, svuint64_t op2, svuint64_t op3)
         ///   ADCLT Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<ulong> AddCarryWideningOdd(Vector<ulong> op1, Vector<ulong> op2, Vector<ulong> op3) { throw new PlatformNotSupportedException(); }
+        public static unsafe Vector<ulong> AddCarryWideningOdd(Vector<ulong> left, Vector<ulong> right, Vector<ulong> carry) { throw new PlatformNotSupportedException(); }
 
         // Add narrow high part (bottom)
 
@@ -905,19 +905,19 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint16_t svaddlbt[_s16](svint8_t op1, svint8_t op2)
         ///   SADDLBT Zresult.H, Zop1.B, Zop2.B
         /// </summary>
-        public static Vector<short> AddWideningEvenOdd(Vector<sbyte> left, Vector<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<short> AddWideningEvenOdd(Vector<sbyte> leftEven, Vector<sbyte> rightOdd) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t svaddlbt[_s32](svint16_t op1, svint16_t op2)
         ///   SADDLBT Zresult.S, Zop1.H, Zop2.H
         /// </summary>
-        public static Vector<int> AddWideningEvenOdd(Vector<short> left, Vector<short> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<int> AddWideningEvenOdd(Vector<short> leftEven, Vector<short> rightOdd) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t svaddlbt[_s64](svint32_t op1, svint32_t op2)
         ///   SADDLBT Zresult.D, Zop1.S, Zop2.S
         /// </summary>
-        public static Vector<long> AddWideningEvenOdd(Vector<int> left, Vector<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<long> AddWideningEvenOdd(Vector<int> leftEven, Vector<int> rightOdd) { throw new PlatformNotSupportedException(); }
 
         // Add wide (top)
 
@@ -1485,97 +1485,97 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint8_t sveorbt[_s8](svint8_t odd, svint8_t op1, svint8_t op2)
         ///   EORBT Zd.B, Zn.B, Zm.B
         /// </summary>
-        public static Vector<byte> InterleavingXorEvenOdd(Vector<byte> odd, Vector<byte> left, Vector<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<byte> InterleavingXorEvenOdd(Vector<byte> odd, Vector<byte> leftEven, Vector<byte> rightOdd) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint16_t sveorbt[_s16](svint16_t odd, svint16_t op1, svint16_t op2)
         ///   EORBT Zd.H, Zn.H, Zm.H
         /// </summary>
-        public static Vector<short> InterleavingXorEvenOdd(Vector<short> odd, Vector<short> left, Vector<short> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<short> InterleavingXorEvenOdd(Vector<short> odd, Vector<short> leftEven, Vector<short> rightOdd) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t sveorbt[_s32](svint32_t odd, svint32_t op1, svint32_t op2)
         ///   EORBT Zd.S, Zn.S, Zm.S
         /// </summary>
-        public static Vector<int> InterleavingXorEvenOdd(Vector<int> odd, Vector<int> left, Vector<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<int> InterleavingXorEvenOdd(Vector<int> odd, Vector<int> leftEven, Vector<int> rightOdd) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t sveorbt[_s64](svint64_t odd, svint64_t op1, svint64_t op2)
         ///   EORBT Zd.D, Zn.D, Zm.D
         /// </summary>
-        public static Vector<long> InterleavingXorEvenOdd(Vector<long> odd, Vector<long> left, Vector<long> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<long> InterleavingXorEvenOdd(Vector<long> odd, Vector<long> leftEven, Vector<long> rightOdd) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint8_t sveorbt[_s8](svint8_t odd, svint8_t op1, svint8_t op2)
         ///   EORBT Zd.B, Zn.B, Zm.B
         /// </summary>
-        public static Vector<sbyte> InterleavingXorEvenOdd(Vector<sbyte> odd, Vector<sbyte> left, Vector<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<sbyte> InterleavingXorEvenOdd(Vector<sbyte> odd, Vector<sbyte> leftEven, Vector<sbyte> rightOdd) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint16_t sveorbt[_s16](svint16_t odd, svint16_t op1, svint16_t op2)
         ///   EORBT Zd.H, Zn.H, Zm.H
         /// </summary>
-        public static Vector<ushort> InterleavingXorEvenOdd(Vector<ushort> odd, Vector<ushort> left, Vector<ushort> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<ushort> InterleavingXorEvenOdd(Vector<ushort> odd, Vector<ushort> leftEven, Vector<ushort> rightOdd) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t sveorbt[_s32](svint32_t odd, svint32_t op1, svint32_t op2)
         ///   EORBT Zd.S, Zn.S, Zm.S
         /// </summary>
-        public static Vector<uint> InterleavingXorEvenOdd(Vector<uint> odd, Vector<uint> left, Vector<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<uint> InterleavingXorEvenOdd(Vector<uint> odd, Vector<uint> leftEven, Vector<uint> rightOdd) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t sveorbt[_s64](svint64_t odd, svint64_t op1, svint64_t op2)
         ///   EORBT Zd.D, Zn.D, Zm.D
         /// </summary>
-        public static Vector<ulong> InterleavingXorEvenOdd(Vector<ulong> odd, Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<ulong> InterleavingXorEvenOdd(Vector<ulong> odd, Vector<ulong> leftEven, Vector<ulong> rightOdd) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint8_t sveortb[_s8](svint8_t even, svint8_t op1, svint8_t op2)
         ///   EORTB Zd.B, Zn.B, Zm.B
         /// </summary>
-        public static Vector<byte> InterleavingXorOddEven(Vector<byte> even, Vector<byte> left, Vector<byte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<byte> InterleavingXorOddEven(Vector<byte> even, Vector<byte> leftOdd, Vector<byte> rightEven) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint16_t sveortb[_s16](svint16_t even, svint16_t op1, svint16_t op2)
         ///   EORTB Zd.H, Zn.H, Zm.H
         /// </summary>
-        public static Vector<short> InterleavingXorOddEven(Vector<short> even, Vector<short> left, Vector<short> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<short> InterleavingXorOddEven(Vector<short> even, Vector<short> leftOdd, Vector<short> rightEven) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t sveortb[_s32](svint32_t even, svint32_t op1, svint32_t op2)
         ///   EORTB Zd.S, Zn.S, Zm.S
         /// </summary>
-        public static Vector<int> InterleavingXorOddEven(Vector<int> even, Vector<int> left, Vector<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<int> InterleavingXorOddEven(Vector<int> even, Vector<int> leftOdd, Vector<int> rightEven) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t sveortb[_s64](svint64_t even, svint64_t op1, svint64_t op2)
         ///   EORTB Zd.D, Zn.D, Zm.D
         /// </summary>
-        public static Vector<long> InterleavingXorOddEven(Vector<long> even, Vector<long> left, Vector<long> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<long> InterleavingXorOddEven(Vector<long> even, Vector<long> leftOdd, Vector<long> rightEven) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint8_t sveortb[_s8](svint8_t even, svint8_t op1, svint8_t op2)
         ///   EORTB Zd.B, Zn.B, Zm.B
         /// </summary>
-        public static Vector<sbyte> InterleavingXorOddEven(Vector<sbyte> even, Vector<sbyte> left, Vector<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<sbyte> InterleavingXorOddEven(Vector<sbyte> even, Vector<sbyte> leftOdd, Vector<sbyte> rightEven) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint16_t sveortb[_s16](svint16_t even, svint16_t op1, svint16_t op2)
         ///   EORTB Zd.H, Zn.H, Zm.H
         /// </summary>
-        public static Vector<ushort> InterleavingXorOddEven(Vector<ushort> even, Vector<ushort> left, Vector<ushort> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<ushort> InterleavingXorOddEven(Vector<ushort> even, Vector<ushort> leftOdd, Vector<ushort> rightEven) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t sveortb[_s32](svint32_t even, svint32_t op1, svint32_t op2)
         ///   EORTB Zd.S, Zn.S, Zm.S
         /// </summary>
-        public static Vector<uint> InterleavingXorOddEven(Vector<uint> even, Vector<uint> left, Vector<uint> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<uint> InterleavingXorOddEven(Vector<uint> even, Vector<uint> leftOdd, Vector<uint> rightEven) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t sveortb[_s64](svint64_t even, svint64_t op1, svint64_t op2)
         ///   EORTB Zd.D, Zn.D, Zm.D
         /// </summary>
-        public static Vector<ulong> InterleavingXorOddEven(Vector<ulong> even, Vector<ulong> left, Vector<ulong> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<ulong> InterleavingXorOddEven(Vector<ulong> even, Vector<ulong> leftOdd, Vector<ulong> rightEven) { throw new PlatformNotSupportedException(); }
 
         // Base 2 logarithm as integer
 
@@ -3129,37 +3129,37 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint16_t svshllb[_n_s16](svint8_t op1, uint64_t imm2)
         ///   SSHLLB Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<short> ShiftLeftLogicalWideningEven(Vector<sbyte> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
+        public static Vector<short> ShiftLeftLogicalWideningEven(Vector<sbyte> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t svshllb[_n_s32](svint16_t op1, uint64_t imm2)
         ///   SSHLLB Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<int> ShiftLeftLogicalWideningEven(Vector<short> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
+        public static Vector<int> ShiftLeftLogicalWideningEven(Vector<short> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t svshllb[_n_s64](svint32_t op1, uint64_t imm2)
         ///   SSHLLB Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<long> ShiftLeftLogicalWideningEven(Vector<int> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
+        public static Vector<long> ShiftLeftLogicalWideningEven(Vector<int> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint16_t svshllb[_n_u16](svuint8_t op1, uint64_t imm2)
         ///   USHLLB Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<ushort> ShiftLeftLogicalWideningEven(Vector<byte> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
+        public static Vector<ushort> ShiftLeftLogicalWideningEven(Vector<byte> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint32_t svshllb[_n_u32](svuint16_t op1, uint64_t imm2)
         ///   USHLLB Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<uint> ShiftLeftLogicalWideningEven(Vector<ushort> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
+        public static Vector<uint> ShiftLeftLogicalWideningEven(Vector<ushort> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint64_t svshllb[_n_u64](svuint32_t op1, uint64_t imm2)
         ///   USHLLB Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<ulong> ShiftLeftLogicalWideningEven(Vector<uint> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
+        public static Vector<ulong> ShiftLeftLogicalWideningEven(Vector<uint> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
 
 
         // Shift left long (top)
@@ -3168,37 +3168,37 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint16_t svshllt[_n_s16](svint8_t op1, uint64_t imm2)
         ///   SSHLLT Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<short> ShiftLeftLogicalWideningOdd(Vector<sbyte> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
+        public static Vector<short> ShiftLeftLogicalWideningOdd(Vector<sbyte> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t svshllt[_n_s32](svint16_t op1, uint64_t imm2)
         ///   SSHLLT Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<int> ShiftLeftLogicalWideningOdd(Vector<short> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
+        public static Vector<int> ShiftLeftLogicalWideningOdd(Vector<short> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t svshllt[_n_s64](svint32_t op1, uint64_t imm2)
         ///   SSHLLT Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<long> ShiftLeftLogicalWideningOdd(Vector<int> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
+        public static Vector<long> ShiftLeftLogicalWideningOdd(Vector<int> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint16_t svshllt[_n_u16](svuint8_t op1, uint64_t imm2)
         ///   USHLLT Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<ushort> ShiftLeftLogicalWideningOdd(Vector<byte> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
+        public static Vector<ushort> ShiftLeftLogicalWideningOdd(Vector<byte> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint32_t svshllt[_n_u32](svuint16_t op1, uint64_t imm2)
         ///   USHLLT Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<uint> ShiftLeftLogicalWideningOdd(Vector<ushort> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
+        public static Vector<uint> ShiftLeftLogicalWideningOdd(Vector<ushort> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint64_t svshllt[_n_u64](svuint32_t op1, uint64_t imm2)
         ///   USHLLT Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<ulong> ShiftLeftLogicalWideningOdd(Vector<uint> value, [ConstantExpected] byte count) { throw new PlatformNotSupportedException(); }
+        public static Vector<ulong> ShiftLeftLogicalWideningOdd(Vector<uint> value, [ConstantExpected] byte shiftAmount) { throw new PlatformNotSupportedException(); }
 
 
         // Rounding shift left
@@ -3840,13 +3840,13 @@ namespace System.Runtime.Intrinsics.Arm
         /// svuint32_t svsbclb[_u32](svuint32_t op1, svuint32_t op2, svuint32_t op3)
         ///   SBCLB Ztied1.S, Zop2.S, Zop3.S
         /// </summary>
-        public static Vector<uint> SubtractBorrowWideningEven(Vector<uint> op1, Vector<uint> op2, Vector<uint> op3) { throw new PlatformNotSupportedException(); }
+        public static Vector<uint> SubtractBorrowWideningEven(Vector<uint> left, Vector<uint> right, Vector<uint> borrow) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint64_t svsbclb[_u64](svuint64_t op1, svuint64_t op2, svuint64_t op3)
         ///   SBCLB Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static Vector<ulong> SubtractBorrowWideningEven(Vector<ulong> op1, Vector<ulong> op2, Vector<ulong> op3) { throw new PlatformNotSupportedException(); }
+        public static Vector<ulong> SubtractBorrowWideningEven(Vector<ulong> left, Vector<ulong> right, Vector<ulong> borrow) { throw new PlatformNotSupportedException(); }
 
 
         // Subtract with borrow long (top)
@@ -3855,13 +3855,13 @@ namespace System.Runtime.Intrinsics.Arm
         /// svuint32_t svsbclt[_u32](svuint32_t op1, svuint32_t op2, svuint32_t op3)
         ///   SBCLT Ztied1.S, Zop2.S, Zop3.S
         /// </summary>
-        public static Vector<uint> SubtractBorrowWideningOdd(Vector<uint> op1, Vector<uint> op2, Vector<uint> op3) { throw new PlatformNotSupportedException(); }
+        public static Vector<uint> SubtractBorrowWideningOdd(Vector<uint> left, Vector<uint> right, Vector<uint> borrow) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svuint64_t svsbclt[_u64](svuint64_t op1, svuint64_t op2, svuint64_t op3)
         ///   SBCLT Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static Vector<ulong> SubtractBorrowWideningOdd(Vector<ulong> op1, Vector<ulong> op2, Vector<ulong> op3) { throw new PlatformNotSupportedException(); }
+        public static Vector<ulong> SubtractBorrowWideningOdd(Vector<ulong> left, Vector<ulong> right, Vector<ulong> borrow) { throw new PlatformNotSupportedException(); }
 
 
         // Subtract narrow high part (bottom)
@@ -4195,19 +4195,19 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint16_t svsublbt[_s16](svint8_t op1, svint8_t op2)
         ///   SSUBLBT Zresult.H, Zop1.B, Zop2.B
         /// </summary>
-        public static Vector<short> SubtractWideningEvenOdd(Vector<sbyte> left, Vector<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<short> SubtractWideningEvenOdd(Vector<sbyte> leftEven, Vector<sbyte> rightOdd) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t svsublbt[_s32](svint16_t op1, svint16_t op2)
         ///   SSUBLBT Zresult.S, Zop1.H, Zop2.H
         /// </summary>
-        public static Vector<int> SubtractWideningEvenOdd(Vector<short> left, Vector<short> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<int> SubtractWideningEvenOdd(Vector<short> leftEven, Vector<short> rightOdd) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t svsublbt[_s64](svint32_t op1, svint32_t op2)
         ///   SSUBLBT Zresult.D, Zop1.S, Zop2.S
         /// </summary>
-        public static Vector<long> SubtractWideningEvenOdd(Vector<int> left, Vector<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<long> SubtractWideningEvenOdd(Vector<int> leftEven, Vector<int> rightOdd) { throw new PlatformNotSupportedException(); }
 
 
         // Subtract wide (top)
@@ -4294,19 +4294,19 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint16_t svsubltb[_s16](svint8_t op1, svint8_t op2)
         ///   SSUBLTB Zresult.H, Zop1.B, Zop2.B
         /// </summary>
-        public static Vector<short> SubtractWideningOddEven(Vector<sbyte> left, Vector<sbyte> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<short> SubtractWideningOddEven(Vector<sbyte> leftOdd, Vector<sbyte> rightEven) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint32_t svsubltb[_s32](svint16_t op1, svint16_t op2)
         ///   SSUBLTB Zresult.S, Zop1.H, Zop2.H
         /// </summary>
-        public static Vector<int> SubtractWideningOddEven(Vector<short> left, Vector<short> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<int> SubtractWideningOddEven(Vector<short> leftOdd, Vector<short> rightEven) { throw new PlatformNotSupportedException(); }
 
         /// <summary>
         /// svint64_t svsubltb[_s64](svint32_t op1, svint32_t op2)
         ///   SSUBLTB Zresult.D, Zop1.S, Zop2.S
         /// </summary>
-        public static Vector<long> SubtractWideningOddEven(Vector<int> left, Vector<int> right) { throw new PlatformNotSupportedException(); }
+        public static Vector<long> SubtractWideningOddEven(Vector<int> leftOdd, Vector<int> rightEven) { throw new PlatformNotSupportedException(); }
 
 
         // Bit vector table lookups

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve2.cs
@@ -3153,37 +3153,37 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint16_t svshllb[_n_s16](svint8_t op1, uint64_t imm2)
         ///   SSHLLB Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<short> ShiftLeftLogicalWideningEven(Vector<sbyte> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningEven(value, shiftAmount);
+        public static Vector<short> ShiftLeftLogicalWideningEven(Vector<sbyte> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningEven(value, count);
 
         /// <summary>
         /// svint32_t svshllb[_n_s32](svint16_t op1, uint64_t imm2)
         ///   SSHLLB Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<int> ShiftLeftLogicalWideningEven(Vector<short> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningEven(value, shiftAmount);
+        public static Vector<int> ShiftLeftLogicalWideningEven(Vector<short> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningEven(value, count);
 
         /// <summary>
         /// svint64_t svshllb[_n_s64](svint32_t op1, uint64_t imm2)
         ///   SSHLLB Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<long> ShiftLeftLogicalWideningEven(Vector<int> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningEven(value, shiftAmount);
+        public static Vector<long> ShiftLeftLogicalWideningEven(Vector<int> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningEven(value, count);
 
         /// <summary>
         /// svuint16_t svshllb[_n_u16](svuint8_t op1, uint64_t imm2)
         ///   USHLLB Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<ushort> ShiftLeftLogicalWideningEven(Vector<byte> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningEven(value, shiftAmount);
+        public static Vector<ushort> ShiftLeftLogicalWideningEven(Vector<byte> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningEven(value, count);
 
         /// <summary>
         /// svuint32_t svshllb[_n_u32](svuint16_t op1, uint64_t imm2)
         ///   USHLLB Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<uint> ShiftLeftLogicalWideningEven(Vector<ushort> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningEven(value, shiftAmount);
+        public static Vector<uint> ShiftLeftLogicalWideningEven(Vector<ushort> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningEven(value, count);
 
         /// <summary>
         /// svuint64_t svshllb[_n_u64](svuint32_t op1, uint64_t imm2)
         ///   USHLLB Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<ulong> ShiftLeftLogicalWideningEven(Vector<uint> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningEven(value, shiftAmount);
+        public static Vector<ulong> ShiftLeftLogicalWideningEven(Vector<uint> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningEven(value, count);
 
 
         // Shift left long (top)
@@ -3192,37 +3192,37 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint16_t svshllt[_n_s16](svint8_t op1, uint64_t imm2)
         ///   SSHLLT Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<short> ShiftLeftLogicalWideningOdd(Vector<sbyte> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningOdd(value, shiftAmount);
+        public static Vector<short> ShiftLeftLogicalWideningOdd(Vector<sbyte> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningOdd(value, count);
 
         /// <summary>
         /// svint32_t svshllt[_n_s32](svint16_t op1, uint64_t imm2)
         ///   SSHLLT Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<int> ShiftLeftLogicalWideningOdd(Vector<short> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningOdd(value, shiftAmount);
+        public static Vector<int> ShiftLeftLogicalWideningOdd(Vector<short> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningOdd(value, count);
 
         /// <summary>
         /// svint64_t svshllt[_n_s64](svint32_t op1, uint64_t imm2)
         ///   SSHLLT Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<long> ShiftLeftLogicalWideningOdd(Vector<int> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningOdd(value, shiftAmount);
+        public static Vector<long> ShiftLeftLogicalWideningOdd(Vector<int> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningOdd(value, count);
 
         /// <summary>
         /// svuint16_t svshllt[_n_u16](svuint8_t op1, uint64_t imm2)
         ///   USHLLT Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<ushort> ShiftLeftLogicalWideningOdd(Vector<byte> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningOdd(value, shiftAmount);
+        public static Vector<ushort> ShiftLeftLogicalWideningOdd(Vector<byte> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningOdd(value, count);
 
         /// <summary>
         /// svuint32_t svshllt[_n_u32](svuint16_t op1, uint64_t imm2)
         ///   USHLLT Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<uint> ShiftLeftLogicalWideningOdd(Vector<ushort> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningOdd(value, shiftAmount);
+        public static Vector<uint> ShiftLeftLogicalWideningOdd(Vector<ushort> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningOdd(value, count);
 
         /// <summary>
         /// svuint64_t svshllt[_n_u64](svuint32_t op1, uint64_t imm2)
         ///   USHLLT Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<ulong> ShiftLeftLogicalWideningOdd(Vector<uint> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningOdd(value, shiftAmount);
+        public static Vector<ulong> ShiftLeftLogicalWideningOdd(Vector<uint> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningOdd(value, count);
 
 
         // Rounding shift left

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Arm/Sve2.cs
@@ -276,13 +276,13 @@ namespace System.Runtime.Intrinsics.Arm
         /// svuint32_t svadclb[_u32](svuint32_t op1, svuint32_t op2, svuint32_t op3)
         ///   ADCLB Ztied1.S, Zop2.S, Zop3.S
         /// </summary>
-        public static unsafe Vector<uint> AddCarryWideningEven(Vector<uint> op1, Vector<uint> op2, Vector<uint> op3) => AddCarryWideningEven(op1, op2, op3);
+        public static unsafe Vector<uint> AddCarryWideningEven(Vector<uint> left, Vector<uint> right, Vector<uint> carry) => AddCarryWideningEven(left, right, carry);
 
         /// <summary>
         /// svuint64_t svadclb[_u64](svuint64_t op1, svuint64_t op2, svuint64_t op3)
         ///   ADCLB Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<ulong> AddCarryWideningEven(Vector<ulong> op1, Vector<ulong> op2, Vector<ulong> op3) => AddCarryWideningEven(op1, op2, op3);
+        public static unsafe Vector<ulong> AddCarryWideningEven(Vector<ulong> left, Vector<ulong> right, Vector<ulong> carry) => AddCarryWideningEven(left, right, carry);
 
         // Add with carry long (top)
 
@@ -290,13 +290,13 @@ namespace System.Runtime.Intrinsics.Arm
         /// svuint32_t svadclt[_u32](svuint32_t op1, svuint32_t op2, svuint32_t op3)
         ///   ADCLT Ztied1.S, Zop2.S, Zop3.S
         /// </summary>
-        public static unsafe Vector<uint> AddCarryWideningOdd(Vector<uint> op1, Vector<uint> op2, Vector<uint> op3) => AddCarryWideningOdd(op1, op2, op3);
+        public static unsafe Vector<uint> AddCarryWideningOdd(Vector<uint> left, Vector<uint> right, Vector<uint> carry) => AddCarryWideningOdd(left, right, carry);
 
         /// <summary>
         /// svuint64_t svadclt[_u64](svuint64_t op1, svuint64_t op2, svuint64_t op3)
         ///   ADCLT Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static unsafe Vector<ulong> AddCarryWideningOdd(Vector<ulong> op1, Vector<ulong> op2, Vector<ulong> op3) => AddCarryWideningOdd(op1, op2, op3);
+        public static unsafe Vector<ulong> AddCarryWideningOdd(Vector<ulong> left, Vector<ulong> right, Vector<ulong> carry) => AddCarryWideningOdd(left, right, carry);
 
         // Add narrow high part (bottom)
 
@@ -905,19 +905,19 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint16_t svaddlbt[_s16](svint8_t op1, svint8_t op2)
         ///   SADDLBT Zresult.H, Zop1.B, Zop2.B
         /// </summary>
-        public static Vector<short> AddWideningEvenOdd(Vector<sbyte> left, Vector<sbyte> right) => AddWideningEvenOdd(left, right);
+        public static Vector<short> AddWideningEvenOdd(Vector<sbyte> leftEven, Vector<sbyte> rightOdd) => AddWideningEvenOdd(leftEven, rightOdd);
 
         /// <summary>
         /// svint32_t svaddlbt[_s32](svint16_t op1, svint16_t op2)
         ///   SADDLBT Zresult.S, Zop1.H, Zop2.H
         /// </summary>
-        public static Vector<int> AddWideningEvenOdd(Vector<short> left, Vector<short> right) => AddWideningEvenOdd(left, right);
+        public static Vector<int> AddWideningEvenOdd(Vector<short> leftEven, Vector<short> rightOdd) => AddWideningEvenOdd(leftEven, rightOdd);
 
         /// <summary>
         /// svint64_t svaddlbt[_s64](svint32_t op1, svint32_t op2)
         ///   SADDLBT Zresult.D, Zop1.S, Zop2.S
         /// </summary>
-        public static Vector<long> AddWideningEvenOdd(Vector<int> left, Vector<int> right) => AddWideningEvenOdd(left, right);
+        public static Vector<long> AddWideningEvenOdd(Vector<int> leftEven, Vector<int> rightOdd) => AddWideningEvenOdd(leftEven, rightOdd);
 
         // Add wide (top)
 
@@ -1485,97 +1485,97 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint8_t sveorbt[_s8](svint8_t odd, svint8_t op1, svint8_t op2)
         ///   EORBT Zd.B, Zn.B, Zm.B
         /// </summary>
-        public static Vector<byte> InterleavingXorEvenOdd(Vector<byte> odd, Vector<byte> left, Vector<byte> right) => InterleavingXorEvenOdd(odd, left, right);
+        public static Vector<byte> InterleavingXorEvenOdd(Vector<byte> odd, Vector<byte> leftEven, Vector<byte> rightOdd) => InterleavingXorEvenOdd(odd, leftEven, rightOdd);
 
         /// <summary>
         /// svint16_t sveorbt[_s16](svint16_t odd, svint16_t op1, svint16_t op2)
         ///   EORBT Zd.H, Zn.H, Zm.H
         /// </summary>
-        public static Vector<short> InterleavingXorEvenOdd(Vector<short> odd, Vector<short> left, Vector<short> right) => InterleavingXorEvenOdd(odd, left, right);
+        public static Vector<short> InterleavingXorEvenOdd(Vector<short> odd, Vector<short> leftEven, Vector<short> rightOdd) => InterleavingXorEvenOdd(odd, leftEven, rightOdd);
 
         /// <summary>
         /// svint32_t sveorbt[_s32](svint32_t odd, svint32_t op1, svint32_t op2)
         ///   EORBT Zd.S, Zn.S, Zm.S
         /// </summary>
-        public static Vector<int> InterleavingXorEvenOdd(Vector<int> odd, Vector<int> left, Vector<int> right) => InterleavingXorEvenOdd(odd, left, right);
+        public static Vector<int> InterleavingXorEvenOdd(Vector<int> odd, Vector<int> leftEven, Vector<int> rightOdd) => InterleavingXorEvenOdd(odd, leftEven, rightOdd);
 
         /// <summary>
         /// svint64_t sveorbt[_s64](svint64_t odd, svint64_t op1, svint64_t op2)
         ///   EORBT Zd.D, Zn.D, Zm.D
         /// </summary>
-        public static Vector<long> InterleavingXorEvenOdd(Vector<long> odd, Vector<long> left, Vector<long> right) => InterleavingXorEvenOdd(odd, left, right);
+        public static Vector<long> InterleavingXorEvenOdd(Vector<long> odd, Vector<long> leftEven, Vector<long> rightOdd) => InterleavingXorEvenOdd(odd, leftEven, rightOdd);
 
         /// <summary>
         /// svint8_t sveorbt[_s8](svint8_t odd, svint8_t op1, svint8_t op2)
         ///   EORBT Zd.B, Zn.B, Zm.B
         /// </summary>
-        public static Vector<sbyte> InterleavingXorEvenOdd(Vector<sbyte> odd, Vector<sbyte> left, Vector<sbyte> right) => InterleavingXorEvenOdd(odd, left, right);
+        public static Vector<sbyte> InterleavingXorEvenOdd(Vector<sbyte> odd, Vector<sbyte> leftEven, Vector<sbyte> rightOdd) => InterleavingXorEvenOdd(odd, leftEven, rightOdd);
 
         /// <summary>
         /// svint16_t sveorbt[_s16](svint16_t odd, svint16_t op1, svint16_t op2)
         ///   EORBT Zd.H, Zn.H, Zm.H
         /// </summary>
-        public static Vector<ushort> InterleavingXorEvenOdd(Vector<ushort> odd, Vector<ushort> left, Vector<ushort> right) => InterleavingXorEvenOdd(odd, left, right);
+        public static Vector<ushort> InterleavingXorEvenOdd(Vector<ushort> odd, Vector<ushort> leftEven, Vector<ushort> rightOdd) => InterleavingXorEvenOdd(odd, leftEven, rightOdd);
 
         /// <summary>
         /// svint32_t sveorbt[_s32](svint32_t odd, svint32_t op1, svint32_t op2)
         ///   EORBT Zd.S, Zn.S, Zm.S
         /// </summary>
-        public static Vector<uint> InterleavingXorEvenOdd(Vector<uint> odd, Vector<uint> left, Vector<uint> right) => InterleavingXorEvenOdd(odd, left, right);
+        public static Vector<uint> InterleavingXorEvenOdd(Vector<uint> odd, Vector<uint> leftEven, Vector<uint> rightOdd) => InterleavingXorEvenOdd(odd, leftEven, rightOdd);
 
         /// <summary>
         /// svint64_t sveorbt[_s64](svint64_t odd, svint64_t op1, svint64_t op2)
         ///   EORBT Zd.D, Zn.D, Zm.D
         /// </summary>
-        public static Vector<ulong> InterleavingXorEvenOdd(Vector<ulong> odd, Vector<ulong> left, Vector<ulong> right) => InterleavingXorEvenOdd(odd, left, right);
+        public static Vector<ulong> InterleavingXorEvenOdd(Vector<ulong> odd, Vector<ulong> leftEven, Vector<ulong> rightOdd) => InterleavingXorEvenOdd(odd, leftEven, rightOdd);
 
         /// <summary>
         /// svint8_t sveortb[_s8](svint8_t even, svint8_t op1, svint8_t op2)
         ///   EORTB Zd.B, Zn.B, Zm.B
         /// </summary>
-        public static Vector<byte> InterleavingXorOddEven(Vector<byte> even, Vector<byte> left, Vector<byte> right) => InterleavingXorOddEven(even, left, right);
+        public static Vector<byte> InterleavingXorOddEven(Vector<byte> even, Vector<byte> leftOdd, Vector<byte> rightEven) => InterleavingXorOddEven(even, leftOdd, rightEven);
 
         /// <summary>
         /// svint16_t sveortb[_s16](svint16_t even, svint16_t op1, svint16_t op2)
         ///   EORTB Zd.H, Zn.H, Zm.H
         /// </summary>
-        public static Vector<short> InterleavingXorOddEven(Vector<short> even, Vector<short> left, Vector<short> right) => InterleavingXorOddEven(even, left, right);
+        public static Vector<short> InterleavingXorOddEven(Vector<short> even, Vector<short> leftOdd, Vector<short> rightEven) => InterleavingXorOddEven(even, leftOdd, rightEven);
 
         /// <summary>
         /// svint32_t sveortb[_s32](svint32_t even, svint32_t op1, svint32_t op2)
         ///   EORTB Zd.S, Zn.S, Zm.S
         /// </summary>
-        public static Vector<int> InterleavingXorOddEven(Vector<int> even, Vector<int> left, Vector<int> right) => InterleavingXorOddEven(even, left, right);
+        public static Vector<int> InterleavingXorOddEven(Vector<int> even, Vector<int> leftOdd, Vector<int> rightEven) => InterleavingXorOddEven(even, leftOdd, rightEven);
 
         /// <summary>
         /// svint64_t sveortb[_s64](svint64_t even, svint64_t op1, svint64_t op2)
         ///   EORTB Zd.D, Zn.D, Zm.D
         /// </summary>
-        public static Vector<long> InterleavingXorOddEven(Vector<long> even, Vector<long> left, Vector<long> right) => InterleavingXorOddEven(even, left, right);
+        public static Vector<long> InterleavingXorOddEven(Vector<long> even, Vector<long> leftOdd, Vector<long> rightEven) => InterleavingXorOddEven(even, leftOdd, rightEven);
 
         /// <summary>
         /// svint8_t sveortb[_s8](svint8_t even, svint8_t op1, svint8_t op2)
         ///   EORTB Zd.B, Zn.B, Zm.B
         /// </summary>
-        public static Vector<sbyte> InterleavingXorOddEven(Vector<sbyte> even, Vector<sbyte> left, Vector<sbyte> right) => InterleavingXorOddEven(even, left, right);
+        public static Vector<sbyte> InterleavingXorOddEven(Vector<sbyte> even, Vector<sbyte> leftOdd, Vector<sbyte> rightEven) => InterleavingXorOddEven(even, leftOdd, rightEven);
 
         /// <summary>
         /// svint16_t sveortb[_s16](svint16_t even, svint16_t op1, svint16_t op2)
         ///   EORTB Zd.H, Zn.H, Zm.H
         /// </summary>
-        public static Vector<ushort> InterleavingXorOddEven(Vector<ushort> even, Vector<ushort> left, Vector<ushort> right) => InterleavingXorOddEven(even, left, right);
+        public static Vector<ushort> InterleavingXorOddEven(Vector<ushort> even, Vector<ushort> leftOdd, Vector<ushort> rightEven) => InterleavingXorOddEven(even, leftOdd, rightEven);
 
         /// <summary>
         /// svint32_t sveortb[_s32](svint32_t even, svint32_t op1, svint32_t op2)
         ///   EORTB Zd.S, Zn.S, Zm.S
         /// </summary>
-        public static Vector<uint> InterleavingXorOddEven(Vector<uint> even, Vector<uint> left, Vector<uint> right) => InterleavingXorOddEven(even, left, right);
+        public static Vector<uint> InterleavingXorOddEven(Vector<uint> even, Vector<uint> leftOdd, Vector<uint> rightEven) => InterleavingXorOddEven(even, leftOdd, rightEven);
 
         /// <summary>
         /// svint64_t sveortb[_s64](svint64_t even, svint64_t op1, svint64_t op2)
         ///   EORTB Zd.D, Zn.D, Zm.D
         /// </summary>
-        public static Vector<ulong> InterleavingXorOddEven(Vector<ulong> even, Vector<ulong> left, Vector<ulong> right) => InterleavingXorOddEven(even, left, right);
+        public static Vector<ulong> InterleavingXorOddEven(Vector<ulong> even, Vector<ulong> leftOdd, Vector<ulong> rightEven) => InterleavingXorOddEven(even, leftOdd, rightEven);
 
         // Base 2 logarithm as integer
 
@@ -3153,37 +3153,37 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint16_t svshllb[_n_s16](svint8_t op1, uint64_t imm2)
         ///   SSHLLB Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<short> ShiftLeftLogicalWideningEven(Vector<sbyte> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningEven(value, count);
+        public static Vector<short> ShiftLeftLogicalWideningEven(Vector<sbyte> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningEven(value, shiftAmount);
 
         /// <summary>
         /// svint32_t svshllb[_n_s32](svint16_t op1, uint64_t imm2)
         ///   SSHLLB Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<int> ShiftLeftLogicalWideningEven(Vector<short> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningEven(value, count);
+        public static Vector<int> ShiftLeftLogicalWideningEven(Vector<short> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningEven(value, shiftAmount);
 
         /// <summary>
         /// svint64_t svshllb[_n_s64](svint32_t op1, uint64_t imm2)
         ///   SSHLLB Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<long> ShiftLeftLogicalWideningEven(Vector<int> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningEven(value, count);
+        public static Vector<long> ShiftLeftLogicalWideningEven(Vector<int> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningEven(value, shiftAmount);
 
         /// <summary>
         /// svuint16_t svshllb[_n_u16](svuint8_t op1, uint64_t imm2)
         ///   USHLLB Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<ushort> ShiftLeftLogicalWideningEven(Vector<byte> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningEven(value, count);
+        public static Vector<ushort> ShiftLeftLogicalWideningEven(Vector<byte> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningEven(value, shiftAmount);
 
         /// <summary>
         /// svuint32_t svshllb[_n_u32](svuint16_t op1, uint64_t imm2)
         ///   USHLLB Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<uint> ShiftLeftLogicalWideningEven(Vector<ushort> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningEven(value, count);
+        public static Vector<uint> ShiftLeftLogicalWideningEven(Vector<ushort> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningEven(value, shiftAmount);
 
         /// <summary>
         /// svuint64_t svshllb[_n_u64](svuint32_t op1, uint64_t imm2)
         ///   USHLLB Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<ulong> ShiftLeftLogicalWideningEven(Vector<uint> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningEven(value, count);
+        public static Vector<ulong> ShiftLeftLogicalWideningEven(Vector<uint> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningEven(value, shiftAmount);
 
 
         // Shift left long (top)
@@ -3192,37 +3192,37 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint16_t svshllt[_n_s16](svint8_t op1, uint64_t imm2)
         ///   SSHLLT Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<short> ShiftLeftLogicalWideningOdd(Vector<sbyte> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningOdd(value, count);
+        public static Vector<short> ShiftLeftLogicalWideningOdd(Vector<sbyte> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningOdd(value, shiftAmount);
 
         /// <summary>
         /// svint32_t svshllt[_n_s32](svint16_t op1, uint64_t imm2)
         ///   SSHLLT Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<int> ShiftLeftLogicalWideningOdd(Vector<short> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningOdd(value, count);
+        public static Vector<int> ShiftLeftLogicalWideningOdd(Vector<short> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningOdd(value, shiftAmount);
 
         /// <summary>
         /// svint64_t svshllt[_n_s64](svint32_t op1, uint64_t imm2)
         ///   SSHLLT Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<long> ShiftLeftLogicalWideningOdd(Vector<int> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningOdd(value, count);
+        public static Vector<long> ShiftLeftLogicalWideningOdd(Vector<int> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningOdd(value, shiftAmount);
 
         /// <summary>
         /// svuint16_t svshllt[_n_u16](svuint8_t op1, uint64_t imm2)
         ///   USHLLT Zresult.H, Zop1.B, #imm2
         /// </summary>
-        public static Vector<ushort> ShiftLeftLogicalWideningOdd(Vector<byte> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningOdd(value, count);
+        public static Vector<ushort> ShiftLeftLogicalWideningOdd(Vector<byte> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningOdd(value, shiftAmount);
 
         /// <summary>
         /// svuint32_t svshllt[_n_u32](svuint16_t op1, uint64_t imm2)
         ///   USHLLT Zresult.S, Zop1.H, #imm2
         /// </summary>
-        public static Vector<uint> ShiftLeftLogicalWideningOdd(Vector<ushort> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningOdd(value, count);
+        public static Vector<uint> ShiftLeftLogicalWideningOdd(Vector<ushort> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningOdd(value, shiftAmount);
 
         /// <summary>
         /// svuint64_t svshllt[_n_u64](svuint32_t op1, uint64_t imm2)
         ///   USHLLT Zresult.D, Zop1.S, #imm2
         /// </summary>
-        public static Vector<ulong> ShiftLeftLogicalWideningOdd(Vector<uint> value, [ConstantExpected] byte count) => ShiftLeftLogicalWideningOdd(value, count);
+        public static Vector<ulong> ShiftLeftLogicalWideningOdd(Vector<uint> value, [ConstantExpected] byte shiftAmount) => ShiftLeftLogicalWideningOdd(value, shiftAmount);
 
 
         // Rounding shift left
@@ -3864,13 +3864,13 @@ namespace System.Runtime.Intrinsics.Arm
         /// svuint32_t svsbclb[_u32](svuint32_t op1, svuint32_t op2, svuint32_t op3)
         ///   SBCLB Ztied1.S, Zop2.S, Zop3.S
         /// </summary>
-        public static Vector<uint> SubtractBorrowWideningEven(Vector<uint> op1, Vector<uint> op2, Vector<uint> op3) => SubtractBorrowWideningEven(op1, op2, op3);
+        public static Vector<uint> SubtractBorrowWideningEven(Vector<uint> left, Vector<uint> right, Vector<uint> borrow) => SubtractBorrowWideningEven(left, right, borrow);
 
         /// <summary>
         /// svuint64_t svsbclb[_u64](svuint64_t op1, svuint64_t op2, svuint64_t op3)
         ///   SBCLB Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static Vector<ulong> SubtractBorrowWideningEven(Vector<ulong> op1, Vector<ulong> op2, Vector<ulong> op3) => SubtractBorrowWideningEven(op1, op2, op3);
+        public static Vector<ulong> SubtractBorrowWideningEven(Vector<ulong> left, Vector<ulong> right, Vector<ulong> borrow) => SubtractBorrowWideningEven(left, right, borrow);
 
 
         // Subtract with borrow long (top)
@@ -3879,13 +3879,13 @@ namespace System.Runtime.Intrinsics.Arm
         /// svuint32_t svsbclt[_u32](svuint32_t op1, svuint32_t op2, svuint32_t op3)
         ///   SBCLT Ztied1.S, Zop2.S, Zop3.S
         /// </summary>
-        public static Vector<uint> SubtractBorrowWideningOdd(Vector<uint> op1, Vector<uint> op2, Vector<uint> op3) => SubtractBorrowWideningOdd(op1, op2, op3);
+        public static Vector<uint> SubtractBorrowWideningOdd(Vector<uint> left, Vector<uint> right, Vector<uint> borrow) => SubtractBorrowWideningOdd(left, right, borrow);
 
         /// <summary>
         /// svuint64_t svsbclt[_u64](svuint64_t op1, svuint64_t op2, svuint64_t op3)
         ///   SBCLT Ztied1.D, Zop2.D, Zop3.D
         /// </summary>
-        public static Vector<ulong> SubtractBorrowWideningOdd(Vector<ulong> op1, Vector<ulong> op2, Vector<ulong> op3) => SubtractBorrowWideningOdd(op1, op2, op3);
+        public static Vector<ulong> SubtractBorrowWideningOdd(Vector<ulong> left, Vector<ulong> right, Vector<ulong> borrow) => SubtractBorrowWideningOdd(left, right, borrow);
 
 
         // Subtract narrow high part (bottom)
@@ -4219,19 +4219,19 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint16_t svsublbt[_s16](svint8_t op1, svint8_t op2)
         ///   SSUBLBT Zresult.H, Zop1.B, Zop2.B
         /// </summary>
-        public static Vector<short> SubtractWideningEvenOdd(Vector<sbyte> left, Vector<sbyte> right) => SubtractWideningEvenOdd(left, right);
+        public static Vector<short> SubtractWideningEvenOdd(Vector<sbyte> leftEven, Vector<sbyte> rightOdd) => SubtractWideningEvenOdd(leftEven, rightOdd);
 
         /// <summary>
         /// svint32_t svsublbt[_s32](svint16_t op1, svint16_t op2)
         ///   SSUBLBT Zresult.S, Zop1.H, Zop2.H
         /// </summary>
-        public static Vector<int> SubtractWideningEvenOdd(Vector<short> left, Vector<short> right) => SubtractWideningEvenOdd(left, right);
+        public static Vector<int> SubtractWideningEvenOdd(Vector<short> leftEven, Vector<short> rightOdd) => SubtractWideningEvenOdd(leftEven, rightOdd);
 
         /// <summary>
         /// svint64_t svsublbt[_s64](svint32_t op1, svint32_t op2)
         ///   SSUBLBT Zresult.D, Zop1.S, Zop2.S
         /// </summary>
-        public static Vector<long> SubtractWideningEvenOdd(Vector<int> left, Vector<int> right) => SubtractWideningEvenOdd(left, right);
+        public static Vector<long> SubtractWideningEvenOdd(Vector<int> leftEven, Vector<int> rightOdd) => SubtractWideningEvenOdd(leftEven, rightOdd);
 
 
         // Subtract wide (top)
@@ -4318,19 +4318,19 @@ namespace System.Runtime.Intrinsics.Arm
         /// svint16_t svsubltb[_s16](svint8_t op1, svint8_t op2)
         ///   SSUBLTB Zresult.H, Zop1.B, Zop2.B
         /// </summary>
-        public static Vector<short> SubtractWideningOddEven(Vector<sbyte> left, Vector<sbyte> right) => SubtractWideningOddEven(left, right);
+        public static Vector<short> SubtractWideningOddEven(Vector<sbyte> leftOdd, Vector<sbyte> rightEven) => SubtractWideningOddEven(leftOdd, rightEven);
 
         /// <summary>
         /// svint32_t svsubltb[_s32](svint16_t op1, svint16_t op2)
         ///   SSUBLTB Zresult.S, Zop1.H, Zop2.H
         /// </summary>
-        public static Vector<int> SubtractWideningOddEven(Vector<short> left, Vector<short> right) => SubtractWideningOddEven(left, right);
+        public static Vector<int> SubtractWideningOddEven(Vector<short> leftOdd, Vector<short> rightEven) => SubtractWideningOddEven(leftOdd, rightEven);
 
         /// <summary>
         /// svint64_t svsubltb[_s64](svint32_t op1, svint32_t op2)
         ///   SSUBLTB Zresult.D, Zop1.S, Zop2.S
         /// </summary>
-        public static Vector<long> SubtractWideningOddEven(Vector<int> left, Vector<int> right) => SubtractWideningOddEven(left, right);
+        public static Vector<long> SubtractWideningOddEven(Vector<int> leftOdd, Vector<int> rightEven) => SubtractWideningOddEven(leftOdd, rightEven);
 
 
         // Bit vector table lookups

--- a/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
+++ b/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
@@ -6216,10 +6216,10 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Numerics.Vector<uint> AbsoluteDifferenceWideningOdd(System.Numerics.Vector<ushort> left, System.Numerics.Vector<ushort> right) { throw null; }
         public static System.Numerics.Vector<ulong> AbsoluteDifferenceWideningOdd(System.Numerics.Vector<uint> left, System.Numerics.Vector<uint> right) { throw null; }
 
-        public static System.Numerics.Vector<uint> AddCarryWideningEven(System.Numerics.Vector<uint> op1, System.Numerics.Vector<uint> op2, System.Numerics.Vector<uint> op3) { throw null; }
-        public static System.Numerics.Vector<ulong> AddCarryWideningEven(System.Numerics.Vector<ulong> op1, System.Numerics.Vector<ulong> op2, System.Numerics.Vector<ulong> op3) { throw null; }
-        public static System.Numerics.Vector<uint> AddCarryWideningOdd(System.Numerics.Vector<uint> op1, System.Numerics.Vector<uint> op2, System.Numerics.Vector<uint> op3) { throw null; }
-        public static System.Numerics.Vector<ulong> AddCarryWideningOdd(System.Numerics.Vector<ulong> op1, System.Numerics.Vector<ulong> op2, System.Numerics.Vector<ulong> op3) { throw null; }
+        public static System.Numerics.Vector<uint> AddCarryWideningEven(System.Numerics.Vector<uint> left, System.Numerics.Vector<uint> right, System.Numerics.Vector<uint> carry) { throw null; }
+        public static System.Numerics.Vector<ulong> AddCarryWideningEven(System.Numerics.Vector<ulong> left, System.Numerics.Vector<ulong> right, System.Numerics.Vector<ulong> carry) { throw null; }
+        public static System.Numerics.Vector<uint> AddCarryWideningOdd(System.Numerics.Vector<uint> left, System.Numerics.Vector<uint> right, System.Numerics.Vector<uint> carry) { throw null; }
+        public static System.Numerics.Vector<ulong> AddCarryWideningOdd(System.Numerics.Vector<ulong> left, System.Numerics.Vector<ulong> right, System.Numerics.Vector<ulong> carry) { throw null; }
 
         public static System.Numerics.Vector<byte> AddHighNarrowingEven(System.Numerics.Vector<ushort> left, System.Numerics.Vector<ushort> right) { throw null; }
         public static System.Numerics.Vector<short> AddHighNarrowingEven(System.Numerics.Vector<int> left, System.Numerics.Vector<int> right) { throw null; }
@@ -6305,9 +6305,9 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Numerics.Vector<ushort> AddWideningEven(System.Numerics.Vector<byte> left, System.Numerics.Vector<byte> right) { throw null; }
         public static System.Numerics.Vector<uint> AddWideningEven(System.Numerics.Vector<ushort> left, System.Numerics.Vector<ushort> right) { throw null; }
         public static System.Numerics.Vector<ulong> AddWideningEven(System.Numerics.Vector<uint> left, System.Numerics.Vector<uint> right) { throw null; }
-        public static System.Numerics.Vector<short> AddWideningEvenOdd(System.Numerics.Vector<sbyte> left, System.Numerics.Vector<sbyte> right) { throw null; }
-        public static System.Numerics.Vector<int> AddWideningEvenOdd(System.Numerics.Vector<short> left, System.Numerics.Vector<short> right) { throw null; }
-        public static System.Numerics.Vector<long> AddWideningEvenOdd(System.Numerics.Vector<int> left, System.Numerics.Vector<int> right) { throw null; }
+        public static System.Numerics.Vector<short> AddWideningEvenOdd(System.Numerics.Vector<sbyte> leftEven, System.Numerics.Vector<sbyte> rightOdd) { throw null; }
+        public static System.Numerics.Vector<int> AddWideningEvenOdd(System.Numerics.Vector<short> leftEven, System.Numerics.Vector<short> rightOdd) { throw null; }
+        public static System.Numerics.Vector<long> AddWideningEvenOdd(System.Numerics.Vector<int> leftEven, System.Numerics.Vector<int> rightOdd) { throw null; }
         public static System.Numerics.Vector<short> AddWideningOdd(System.Numerics.Vector<short> left, System.Numerics.Vector<sbyte> right) { throw null; }
         public static System.Numerics.Vector<int> AddWideningOdd(System.Numerics.Vector<int> left, System.Numerics.Vector<short> right) { throw null; }
         public static System.Numerics.Vector<long> AddWideningOdd(System.Numerics.Vector<long> left, System.Numerics.Vector<int> right) { throw null; }
@@ -6384,22 +6384,22 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Numerics.Vector<ushort> FusedSubtractHalving(System.Numerics.Vector<ushort> left, System.Numerics.Vector<ushort> right) { throw null; }
         public static System.Numerics.Vector<uint> FusedSubtractHalving(System.Numerics.Vector<uint> left, System.Numerics.Vector<uint> right) { throw null; }
         public static System.Numerics.Vector<ulong> FusedSubtractHalving(System.Numerics.Vector<ulong> left, System.Numerics.Vector<ulong> right) { throw null; }
-        public static System.Numerics.Vector<byte> InterleavingXorEvenOdd(System.Numerics.Vector<byte> odd, System.Numerics.Vector<byte> left, System.Numerics.Vector<byte> right) { throw null; }
-        public static System.Numerics.Vector<short> InterleavingXorEvenOdd(System.Numerics.Vector<short> odd, System.Numerics.Vector<short> left, System.Numerics.Vector<short> right) { throw null; }
-        public static System.Numerics.Vector<int> InterleavingXorEvenOdd(System.Numerics.Vector<int> odd, System.Numerics.Vector<int> left, System.Numerics.Vector<int> right) { throw null; }
-        public static System.Numerics.Vector<long> InterleavingXorEvenOdd(System.Numerics.Vector<long> odd, System.Numerics.Vector<long> left, System.Numerics.Vector<long> right) { throw null; }
-        public static System.Numerics.Vector<sbyte> InterleavingXorEvenOdd(System.Numerics.Vector<sbyte> odd, System.Numerics.Vector<sbyte> left, System.Numerics.Vector<sbyte> right) { throw null; }
-        public static System.Numerics.Vector<ushort> InterleavingXorEvenOdd(System.Numerics.Vector<ushort> odd, System.Numerics.Vector<ushort> left, System.Numerics.Vector<ushort> right) { throw null; }
-        public static System.Numerics.Vector<uint> InterleavingXorEvenOdd(System.Numerics.Vector<uint> odd, System.Numerics.Vector<uint> left, System.Numerics.Vector<uint> right) { throw null; }
-        public static System.Numerics.Vector<ulong> InterleavingXorEvenOdd(System.Numerics.Vector<ulong> odd, System.Numerics.Vector<ulong> left, System.Numerics.Vector<ulong> right) { throw null; }
-        public static System.Numerics.Vector<byte> InterleavingXorOddEven(System.Numerics.Vector<byte> even, System.Numerics.Vector<byte> left, System.Numerics.Vector<byte> right) { throw null; }
-        public static System.Numerics.Vector<short> InterleavingXorOddEven(System.Numerics.Vector<short> even, System.Numerics.Vector<short> left, System.Numerics.Vector<short> right) { throw null; }
-        public static System.Numerics.Vector<int> InterleavingXorOddEven(System.Numerics.Vector<int> even, System.Numerics.Vector<int> left, System.Numerics.Vector<int> right) { throw null; }
-        public static System.Numerics.Vector<long> InterleavingXorOddEven(System.Numerics.Vector<long> even, System.Numerics.Vector<long> left, System.Numerics.Vector<long> right) { throw null; }
-        public static System.Numerics.Vector<sbyte> InterleavingXorOddEven(System.Numerics.Vector<sbyte> even, System.Numerics.Vector<sbyte> left, System.Numerics.Vector<sbyte> right) { throw null; }
-        public static System.Numerics.Vector<ushort> InterleavingXorOddEven(System.Numerics.Vector<ushort> even, System.Numerics.Vector<ushort> left, System.Numerics.Vector<ushort> right) { throw null; }
-        public static System.Numerics.Vector<uint> InterleavingXorOddEven(System.Numerics.Vector<uint> even, System.Numerics.Vector<uint> left, System.Numerics.Vector<uint> right) { throw null; }
-        public static System.Numerics.Vector<ulong> InterleavingXorOddEven(System.Numerics.Vector<ulong> even, System.Numerics.Vector<ulong> left, System.Numerics.Vector<ulong> right) { throw null; }
+        public static System.Numerics.Vector<byte> InterleavingXorEvenOdd(System.Numerics.Vector<byte> odd, System.Numerics.Vector<byte> leftEven, System.Numerics.Vector<byte> rightOdd) { throw null; }
+        public static System.Numerics.Vector<short> InterleavingXorEvenOdd(System.Numerics.Vector<short> odd, System.Numerics.Vector<short> leftEven, System.Numerics.Vector<short> rightOdd) { throw null; }
+        public static System.Numerics.Vector<int> InterleavingXorEvenOdd(System.Numerics.Vector<int> odd, System.Numerics.Vector<int> leftEven, System.Numerics.Vector<int> rightOdd) { throw null; }
+        public static System.Numerics.Vector<long> InterleavingXorEvenOdd(System.Numerics.Vector<long> odd, System.Numerics.Vector<long> leftEven, System.Numerics.Vector<long> rightOdd) { throw null; }
+        public static System.Numerics.Vector<sbyte> InterleavingXorEvenOdd(System.Numerics.Vector<sbyte> odd, System.Numerics.Vector<sbyte> leftEven, System.Numerics.Vector<sbyte> rightOdd) { throw null; }
+        public static System.Numerics.Vector<ushort> InterleavingXorEvenOdd(System.Numerics.Vector<ushort> odd, System.Numerics.Vector<ushort> leftEven, System.Numerics.Vector<ushort> rightOdd) { throw null; }
+        public static System.Numerics.Vector<uint> InterleavingXorEvenOdd(System.Numerics.Vector<uint> odd, System.Numerics.Vector<uint> leftEven, System.Numerics.Vector<uint> rightOdd) { throw null; }
+        public static System.Numerics.Vector<ulong> InterleavingXorEvenOdd(System.Numerics.Vector<ulong> odd, System.Numerics.Vector<ulong> leftEven, System.Numerics.Vector<ulong> rightOdd) { throw null; }
+        public static System.Numerics.Vector<byte> InterleavingXorOddEven(System.Numerics.Vector<byte> even, System.Numerics.Vector<byte> leftOdd, System.Numerics.Vector<byte> rightEven) { throw null; }
+        public static System.Numerics.Vector<short> InterleavingXorOddEven(System.Numerics.Vector<short> even, System.Numerics.Vector<short> leftOdd, System.Numerics.Vector<short> rightEven) { throw null; }
+        public static System.Numerics.Vector<int> InterleavingXorOddEven(System.Numerics.Vector<int> even, System.Numerics.Vector<int> leftOdd, System.Numerics.Vector<int> rightEven) { throw null; }
+        public static System.Numerics.Vector<long> InterleavingXorOddEven(System.Numerics.Vector<long> even, System.Numerics.Vector<long> leftOdd, System.Numerics.Vector<long> rightEven) { throw null; }
+        public static System.Numerics.Vector<sbyte> InterleavingXorOddEven(System.Numerics.Vector<sbyte> even, System.Numerics.Vector<sbyte> leftOdd, System.Numerics.Vector<sbyte> rightEven) { throw null; }
+        public static System.Numerics.Vector<ushort> InterleavingXorOddEven(System.Numerics.Vector<ushort> even, System.Numerics.Vector<ushort> leftOdd, System.Numerics.Vector<ushort> rightEven) { throw null; }
+        public static System.Numerics.Vector<uint> InterleavingXorOddEven(System.Numerics.Vector<uint> even, System.Numerics.Vector<uint> leftOdd, System.Numerics.Vector<uint> rightEven) { throw null; }
+        public static System.Numerics.Vector<ulong> InterleavingXorOddEven(System.Numerics.Vector<ulong> even, System.Numerics.Vector<ulong> leftOdd, System.Numerics.Vector<ulong> rightEven) { throw null; }
         public static System.Numerics.Vector<int> Log2(System.Numerics.Vector<float> value) { throw null; }
         public static System.Numerics.Vector<long> Log2(System.Numerics.Vector<double> value) { throw null; }
         public static System.Numerics.Vector<double> MaxNumberPairwise(System.Numerics.Vector<double> left, System.Numerics.Vector<double> right) { throw null; }
@@ -6626,18 +6626,18 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Numerics.Vector<ushort> ShiftLeftLogicalSaturateUnsigned(System.Numerics.Vector<short> value, [ConstantExpected] byte count) { throw null; }
         public static System.Numerics.Vector<uint> ShiftLeftLogicalSaturateUnsigned(System.Numerics.Vector<int> value, [ConstantExpected] byte count) { throw null; }
         public static System.Numerics.Vector<ulong> ShiftLeftLogicalSaturateUnsigned(System.Numerics.Vector<long> value, [ConstantExpected] byte count) { throw null; }
-        public static System.Numerics.Vector<short> ShiftLeftLogicalWideningEven(System.Numerics.Vector<sbyte> value, [ConstantExpected] byte count) { throw null; }
-        public static System.Numerics.Vector<int> ShiftLeftLogicalWideningEven(System.Numerics.Vector<short> value, [ConstantExpected] byte count) { throw null; }
-        public static System.Numerics.Vector<long> ShiftLeftLogicalWideningEven(System.Numerics.Vector<int> value, [ConstantExpected] byte count) { throw null; }
-        public static System.Numerics.Vector<ushort> ShiftLeftLogicalWideningEven(System.Numerics.Vector<byte> value, [ConstantExpected] byte count) { throw null; }
-        public static System.Numerics.Vector<uint> ShiftLeftLogicalWideningEven(System.Numerics.Vector<ushort> value, [ConstantExpected] byte count) { throw null; }
-        public static System.Numerics.Vector<ulong> ShiftLeftLogicalWideningEven(System.Numerics.Vector<uint> value, [ConstantExpected] byte count) { throw null; }
-        public static System.Numerics.Vector<short> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<sbyte> value, [ConstantExpected] byte count) { throw null; }
-        public static System.Numerics.Vector<int> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<short> value, [ConstantExpected] byte count) { throw null; }
-        public static System.Numerics.Vector<long> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<int> value, [ConstantExpected] byte count) { throw null; }
-        public static System.Numerics.Vector<ushort> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<byte> value, [ConstantExpected] byte count) { throw null; }
-        public static System.Numerics.Vector<uint> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<ushort> value, [ConstantExpected] byte count) { throw null; }
-        public static System.Numerics.Vector<ulong> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<uint> value, [ConstantExpected] byte count) { throw null; }
+        public static System.Numerics.Vector<short> ShiftLeftLogicalWideningEven(System.Numerics.Vector<sbyte> value, [ConstantExpected] byte shiftAmount) { throw null; }
+        public static System.Numerics.Vector<int> ShiftLeftLogicalWideningEven(System.Numerics.Vector<short> value, [ConstantExpected] byte shiftAmount) { throw null; }
+        public static System.Numerics.Vector<long> ShiftLeftLogicalWideningEven(System.Numerics.Vector<int> value, [ConstantExpected] byte shiftAmount) { throw null; }
+        public static System.Numerics.Vector<ushort> ShiftLeftLogicalWideningEven(System.Numerics.Vector<byte> value, [ConstantExpected] byte shiftAmount) { throw null; }
+        public static System.Numerics.Vector<uint> ShiftLeftLogicalWideningEven(System.Numerics.Vector<ushort> value, [ConstantExpected] byte shiftAmount) { throw null; }
+        public static System.Numerics.Vector<ulong> ShiftLeftLogicalWideningEven(System.Numerics.Vector<uint> value, [ConstantExpected] byte shiftAmount) { throw null; }
+        public static System.Numerics.Vector<short> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<sbyte> value, [ConstantExpected] byte shiftAmount) { throw null; }
+        public static System.Numerics.Vector<int> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<short> value, [ConstantExpected] byte shiftAmount) { throw null; }
+        public static System.Numerics.Vector<long> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<int> value, [ConstantExpected] byte shiftAmount) { throw null; }
+        public static System.Numerics.Vector<ushort> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<byte> value, [ConstantExpected] byte shiftAmount) { throw null; }
+        public static System.Numerics.Vector<uint> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<ushort> value, [ConstantExpected] byte shiftAmount) { throw null; }
+        public static System.Numerics.Vector<ulong> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<uint> value, [ConstantExpected] byte shiftAmount) { throw null; }
         public static System.Numerics.Vector<byte> ShiftLogicalRounded(System.Numerics.Vector<byte> value, System.Numerics.Vector<sbyte> count) { throw null; }
         public static System.Numerics.Vector<ushort> ShiftLogicalRounded(System.Numerics.Vector<ushort> value, System.Numerics.Vector<short> count) { throw null; }
         public static System.Numerics.Vector<uint> ShiftLogicalRounded(System.Numerics.Vector<uint> value, System.Numerics.Vector<int> count) { throw null; }
@@ -6732,10 +6732,10 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Numerics.Vector<byte> ShiftRightLogicalRoundedNarrowingSaturateOdd(System.Numerics.Vector<byte> even, System.Numerics.Vector<ushort> value, [ConstantExpected] byte count) { throw null; }
         public static System.Numerics.Vector<ushort> ShiftRightLogicalRoundedNarrowingSaturateOdd(System.Numerics.Vector<ushort> even, System.Numerics.Vector<uint> value, [ConstantExpected] byte count) { throw null; }
         public static System.Numerics.Vector<uint> ShiftRightLogicalRoundedNarrowingSaturateOdd(System.Numerics.Vector<uint> even, System.Numerics.Vector<ulong> value, [ConstantExpected] byte count) { throw null; }
-        public static System.Numerics.Vector<uint> SubtractBorrowWideningEven(System.Numerics.Vector<uint> op1, System.Numerics.Vector<uint> op2, System.Numerics.Vector<uint> op3) { throw null; }
-        public static System.Numerics.Vector<ulong> SubtractBorrowWideningEven(System.Numerics.Vector<ulong> op1, System.Numerics.Vector<ulong> op2, System.Numerics.Vector<ulong> op3) { throw null; }
-        public static System.Numerics.Vector<uint> SubtractBorrowWideningOdd(System.Numerics.Vector<uint> op1, System.Numerics.Vector<uint> op2, System.Numerics.Vector<uint> op3) { throw null; }
-        public static System.Numerics.Vector<ulong> SubtractBorrowWideningOdd(System.Numerics.Vector<ulong> op1, System.Numerics.Vector<ulong> op2, System.Numerics.Vector<ulong> op3) { throw null; }
+        public static System.Numerics.Vector<uint> SubtractBorrowWideningEven(System.Numerics.Vector<uint> left, System.Numerics.Vector<uint> right, System.Numerics.Vector<uint> borrow) { throw null; }
+        public static System.Numerics.Vector<ulong> SubtractBorrowWideningEven(System.Numerics.Vector<ulong> left, System.Numerics.Vector<ulong> right, System.Numerics.Vector<ulong> borrow) { throw null; }
+        public static System.Numerics.Vector<uint> SubtractBorrowWideningOdd(System.Numerics.Vector<uint> left, System.Numerics.Vector<uint> right, System.Numerics.Vector<uint> borrow) { throw null; }
+        public static System.Numerics.Vector<ulong> SubtractBorrowWideningOdd(System.Numerics.Vector<ulong> left, System.Numerics.Vector<ulong> right, System.Numerics.Vector<ulong> borrow) { throw null; }
         public static System.Numerics.Vector<sbyte> SubtractHighNarrowingEven(System.Numerics.Vector<short> left, System.Numerics.Vector<short> right) { throw null; }
         public static System.Numerics.Vector<short> SubtractHighNarrowingEven(System.Numerics.Vector<int> left, System.Numerics.Vector<int> right) { throw null; }
         public static System.Numerics.Vector<int> SubtractHighNarrowingEven(System.Numerics.Vector<long> left, System.Numerics.Vector<long> right) { throw null; }
@@ -6780,9 +6780,9 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Numerics.Vector<ushort> SubtractWideningEven(System.Numerics.Vector<byte> left, System.Numerics.Vector<byte> right) { throw null; }
         public static System.Numerics.Vector<uint> SubtractWideningEven(System.Numerics.Vector<ushort> left, System.Numerics.Vector<ushort> right) { throw null; }
         public static System.Numerics.Vector<ulong> SubtractWideningEven(System.Numerics.Vector<uint> left, System.Numerics.Vector<uint> right) { throw null; }
-        public static System.Numerics.Vector<short> SubtractWideningEvenOdd(System.Numerics.Vector<sbyte> left, System.Numerics.Vector<sbyte> right) { throw null; }
-        public static System.Numerics.Vector<int> SubtractWideningEvenOdd(System.Numerics.Vector<short> left, System.Numerics.Vector<short> right) { throw null; }
-        public static System.Numerics.Vector<long> SubtractWideningEvenOdd(System.Numerics.Vector<int> left, System.Numerics.Vector<int> right) { throw null; }
+        public static System.Numerics.Vector<short> SubtractWideningEvenOdd(System.Numerics.Vector<sbyte> leftEven, System.Numerics.Vector<sbyte> rightOdd) { throw null; }
+        public static System.Numerics.Vector<int> SubtractWideningEvenOdd(System.Numerics.Vector<short> leftEven, System.Numerics.Vector<short> rightOdd) { throw null; }
+        public static System.Numerics.Vector<long> SubtractWideningEvenOdd(System.Numerics.Vector<int> leftEven, System.Numerics.Vector<int> rightOdd) { throw null; }
         public static System.Numerics.Vector<short> SubtractWideningOdd(System.Numerics.Vector<short> left, System.Numerics.Vector<sbyte> right) { throw null; }
         public static System.Numerics.Vector<int> SubtractWideningOdd(System.Numerics.Vector<int> left, System.Numerics.Vector<short> right) { throw null; }
         public static System.Numerics.Vector<long> SubtractWideningOdd(System.Numerics.Vector<long> left, System.Numerics.Vector<int> right) { throw null; }
@@ -6795,9 +6795,9 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Numerics.Vector<ushort> SubtractWideningOdd(System.Numerics.Vector<byte> left, System.Numerics.Vector<byte> right) { throw null; }
         public static System.Numerics.Vector<uint> SubtractWideningOdd(System.Numerics.Vector<ushort> left, System.Numerics.Vector<ushort> right) { throw null; }
         public static System.Numerics.Vector<ulong> SubtractWideningOdd(System.Numerics.Vector<uint> left, System.Numerics.Vector<uint> right) { throw null; }
-        public static System.Numerics.Vector<short> SubtractWideningOddEven(System.Numerics.Vector<sbyte> left, System.Numerics.Vector<sbyte> right) { throw null; }
-        public static System.Numerics.Vector<int> SubtractWideningOddEven(System.Numerics.Vector<short> left, System.Numerics.Vector<short> right) { throw null; }
-        public static System.Numerics.Vector<long> SubtractWideningOddEven(System.Numerics.Vector<int> left, System.Numerics.Vector<int> right) { throw null; }
+        public static System.Numerics.Vector<short> SubtractWideningOddEven(System.Numerics.Vector<sbyte> leftOdd, System.Numerics.Vector<sbyte> rightEven) { throw null; }
+        public static System.Numerics.Vector<int> SubtractWideningOddEven(System.Numerics.Vector<short> leftOdd, System.Numerics.Vector<short> rightEven) { throw null; }
+        public static System.Numerics.Vector<long> SubtractWideningOddEven(System.Numerics.Vector<int> leftOdd, System.Numerics.Vector<int> rightEven) { throw null; }
         public static System.Numerics.Vector<byte> VectorTableLookup((System.Numerics.Vector<byte> data1, System.Numerics.Vector<byte> data2) table, System.Numerics.Vector<byte> indices) { throw null; }
         public static  System.Numerics.Vector<ushort> VectorTableLookup((System.Numerics.Vector<ushort> data1, System.Numerics.Vector<ushort> data2) table, System.Numerics.Vector<ushort> indices) { throw null; }
         public static  System.Numerics.Vector<uint> VectorTableLookup((System.Numerics.Vector<uint> data1, System.Numerics.Vector<uint> data2) table, System.Numerics.Vector<uint> indices) { throw null; }

--- a/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
+++ b/src/libraries/System.Runtime.Intrinsics/ref/System.Runtime.Intrinsics.cs
@@ -6626,18 +6626,18 @@ namespace System.Runtime.Intrinsics.Arm
         public static System.Numerics.Vector<ushort> ShiftLeftLogicalSaturateUnsigned(System.Numerics.Vector<short> value, [ConstantExpected] byte count) { throw null; }
         public static System.Numerics.Vector<uint> ShiftLeftLogicalSaturateUnsigned(System.Numerics.Vector<int> value, [ConstantExpected] byte count) { throw null; }
         public static System.Numerics.Vector<ulong> ShiftLeftLogicalSaturateUnsigned(System.Numerics.Vector<long> value, [ConstantExpected] byte count) { throw null; }
-        public static System.Numerics.Vector<short> ShiftLeftLogicalWideningEven(System.Numerics.Vector<sbyte> value, [ConstantExpected] byte shiftAmount) { throw null; }
-        public static System.Numerics.Vector<int> ShiftLeftLogicalWideningEven(System.Numerics.Vector<short> value, [ConstantExpected] byte shiftAmount) { throw null; }
-        public static System.Numerics.Vector<long> ShiftLeftLogicalWideningEven(System.Numerics.Vector<int> value, [ConstantExpected] byte shiftAmount) { throw null; }
-        public static System.Numerics.Vector<ushort> ShiftLeftLogicalWideningEven(System.Numerics.Vector<byte> value, [ConstantExpected] byte shiftAmount) { throw null; }
-        public static System.Numerics.Vector<uint> ShiftLeftLogicalWideningEven(System.Numerics.Vector<ushort> value, [ConstantExpected] byte shiftAmount) { throw null; }
-        public static System.Numerics.Vector<ulong> ShiftLeftLogicalWideningEven(System.Numerics.Vector<uint> value, [ConstantExpected] byte shiftAmount) { throw null; }
-        public static System.Numerics.Vector<short> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<sbyte> value, [ConstantExpected] byte shiftAmount) { throw null; }
-        public static System.Numerics.Vector<int> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<short> value, [ConstantExpected] byte shiftAmount) { throw null; }
-        public static System.Numerics.Vector<long> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<int> value, [ConstantExpected] byte shiftAmount) { throw null; }
-        public static System.Numerics.Vector<ushort> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<byte> value, [ConstantExpected] byte shiftAmount) { throw null; }
-        public static System.Numerics.Vector<uint> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<ushort> value, [ConstantExpected] byte shiftAmount) { throw null; }
-        public static System.Numerics.Vector<ulong> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<uint> value, [ConstantExpected] byte shiftAmount) { throw null; }
+        public static System.Numerics.Vector<short> ShiftLeftLogicalWideningEven(System.Numerics.Vector<sbyte> value, [ConstantExpected] byte count) { throw null; }
+        public static System.Numerics.Vector<int> ShiftLeftLogicalWideningEven(System.Numerics.Vector<short> value, [ConstantExpected] byte count) { throw null; }
+        public static System.Numerics.Vector<long> ShiftLeftLogicalWideningEven(System.Numerics.Vector<int> value, [ConstantExpected] byte count) { throw null; }
+        public static System.Numerics.Vector<ushort> ShiftLeftLogicalWideningEven(System.Numerics.Vector<byte> value, [ConstantExpected] byte count) { throw null; }
+        public static System.Numerics.Vector<uint> ShiftLeftLogicalWideningEven(System.Numerics.Vector<ushort> value, [ConstantExpected] byte count) { throw null; }
+        public static System.Numerics.Vector<ulong> ShiftLeftLogicalWideningEven(System.Numerics.Vector<uint> value, [ConstantExpected] byte count) { throw null; }
+        public static System.Numerics.Vector<short> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<sbyte> value, [ConstantExpected] byte count) { throw null; }
+        public static System.Numerics.Vector<int> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<short> value, [ConstantExpected] byte count) { throw null; }
+        public static System.Numerics.Vector<long> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<int> value, [ConstantExpected] byte count) { throw null; }
+        public static System.Numerics.Vector<ushort> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<byte> value, [ConstantExpected] byte count) { throw null; }
+        public static System.Numerics.Vector<uint> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<ushort> value, [ConstantExpected] byte count) { throw null; }
+        public static System.Numerics.Vector<ulong> ShiftLeftLogicalWideningOdd(System.Numerics.Vector<uint> value, [ConstantExpected] byte count) { throw null; }
         public static System.Numerics.Vector<byte> ShiftLogicalRounded(System.Numerics.Vector<byte> value, System.Numerics.Vector<sbyte> count) { throw null; }
         public static System.Numerics.Vector<ushort> ShiftLogicalRounded(System.Numerics.Vector<ushort> value, System.Numerics.Vector<short> count) { throw null; }
         public static System.Numerics.Vector<uint> ShiftLogicalRounded(System.Numerics.Vector<uint> value, System.Numerics.Vector<int> count) { throw null; }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/121961.

Rename argument names for the following methods:
- `AddCarryWideningEven`/`AddCarryWideningOdd`: `op1, op2, op3` => `left, right, carry`.
- `SubtractBorrowWideningEven`/`SubtractBorrowWideningOdd`: `op1, op2, op3` => `left, right, borrow`.
- `ShiftLeftLogicalWideningEven`/`ShiftLeftLogicalWideningOdd`: `value, count` => `value, shiftAmount`.
- `AddWideningEvenOdd`: `left, right` => `leftEven, rightOdd`.
- `SubtractWideningEvenOdd`: `left, right` => `leftEven, rightOdd`.
- `SubtractWideningOddEven`: `left, right` => `leftOdd, rightEven`.
- `InterleavingXorEvenOdd`: `odd, left, right` => `odd, leftEven, rightOdd`.
- `InterleavingXorOddEven`: `even, left, right` => `even, leftOdd, rightEven`.

@dotnet/arm64-contrib @a74nh