### PR TITLE
Use `CorSigUncompressCallingConv` to uncompress calling conventions in `PrettyPrintSignature`

### DIFF
--- a/src/coreclr/inc/formattype.cpp
+++ b/src/coreclr/inc/formattype.cpp
@@ -217,7 +217,7 @@ PCCOR_SIGNATURE PrettyPrintSignature(
     if (name != 0)
     {
         // get the calling convention out
-        unsigned callConv = CorSigUncompressData(typePtr);
+        unsigned callConv = CorSigUncompressCallingConv(typePtr);
 
         // should not be a local var sig
         _ASSERTE(!isCallConv(callConv, IMAGE_CEE_CS_CALLCONV_LOCAL_SIG));
@@ -321,7 +321,7 @@ PCCOR_SIGNATURE PrettyPrintSignature(
 #ifdef _DEBUG
         unsigned callConv =
 #endif
-            CorSigUncompressData(typePtr);
+            CorSigUncompressCallingConv(typePtr);
 #ifdef _DEBUG
         (void)callConv; //prevent "unused variable" warning from GCC
         // should be a local var sig


### PR DESCRIPTION
We were using `CorSigUncompressData` on the calling convention byte, but this is not stored as a normal compressed integer. It happened to work because compressed integers are specified by having their upper bit set, and metadata signatures never have that bit set in their calling convention. However, for some internal cases we repurpose that bit (specifically to specify that a signature has a generic context parameter).

Fix #122050