### PR TITLE
[release/9.0] Avoid C4319 build warnings in libunwind

### DIFF
--- a/src/native/external/libunwind-version.txt
+++ b/src/native/external/libunwind-version.txt
@@ -10,3 +10,4 @@ Apply https://github.com/libunwind/libunwind/pull/714
 Revert https://github.com/libunwind/libunwind/commit/ec03043244082b8f552881ba9fb790aa49c85468 and follow up changes in the same file # issue: https://github.com/libunwind/libunwind/issues/715
 Apply https://github.com/libunwind/libunwind/pull/734
 Apply https://github.com/libunwind/libunwind/pull/758
+Apply https://github.com/libunwind/libunwind/pull/931

--- a/src/native/external/libunwind/include/libunwind_i.h
+++ b/src/native/external/libunwind/include/libunwind_i.h
@@ -437,6 +437,6 @@ static inline void invalidate_edi (struct elf_dyn_info *edi)
 # define DWARF_VAL_LOC(c,v)     DWARF_NULL_LOC
 #endif
 
-#define UNW_ALIGN(x,a) (((x)+(a)-1UL)&~((a)-1UL))
+#define UNW_ALIGN(x,a) (((size_t)(x) + (size_t)(a) - 1) & ~((size_t)(a) - 1))
 
 #endif /* libunwind_i_h */


### PR DESCRIPTION
Include https://github.com/libunwind/libunwind/pull/931 in the build of the libunwind dependency.

Fixes runtime build errors on `1es-windows-2022-open` that are blocking HTTP & SSL stress runs.

## Customer Impact

- [x] Found internally

Our internal HTTP and SSL stress tests are failing to build on the 8.0 branch.
An update of MSVC in the `1es-windows-2022-open` image brought updated analyzer rules that now fail the build of dotnet/runtime on Windows.
```
mempool.c(96): warning C4319: '~': zero extending 'unsigned long' to 'size_t' of greater size
```

This change adds `(size_t)` casts in the libunwind dependency, which resolves the new errors.

## Regression

- [X] Yes

Infra update.

## Testing

Regular CI is still passing + CI stress runs for HTTP and SSL now build and work again.

## Risk

Low.
This is a one-line targeted fix that only adds casts.