### PR TITLE
[clr-interp] Fix GitHub_9651 by allowing an I4 to be treated as a ByRef

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -586,7 +586,7 @@ void InterpCompiler::EmitBBEndVarMoves(InterpBasicBlock *pTargetBB)
                 }
 #ifdef TARGET_64BIT
                 // nint and int32 can be used interchangeably. Add implicit conversions.
-                else if (interpType == InterpTypeI4 && interpDestType == InterpTypeI8)
+                else if (interpType == InterpTypeI4 && ((interpDestType == InterpTypeI8) || (interpDestType == InterpTypeByRef)))
                 {
                     movOp = INTOP_CONV_I8_I4;
                 }


### PR DESCRIPTION
- This is part of allowing I4 and I to be interchangeable, since some forms of ByRef will devolve to be treated as an I
- This isn't a fully general purpose fix, but in cases where it is valid code it will make it work.