### PR TITLE
[clr-interp] Add support for explicit this calli to a valuetype method

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -4139,14 +4139,14 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
     bool isMarshaledPInvoke = isPInvoke && m_compHnd->pInvokeMarshalingRequired(callInfo.hMethod, &callInfo.sig);
 
     // Process sVars
-    int numArgsFromStack = callInfo.sig.numArgs + (newObj ? 0 : callInfo.sig.hasThis());
+    int numArgsFromStack = callInfo.sig.numArgs + (newObj ? 0 : callInfo.sig.hasImplicitThis());
     int newObjThisArgLocation = newObj && !doCallInsteadOfNew ? 0 : INT_MAX;
     int numArgs = numArgsFromStack + (newObjThisArgLocation == 0);
 
     int extraParamArgLocation = INT_MAX;
     if (callInfo.sig.hasTypeArg())
     {
-        extraParamArgLocation = callInfo.sig.hasThis() ? 1 : 0;
+        extraParamArgLocation = callInfo.sig.hasImplicitThis() ? 1 : 0;
         numArgs++;
     }
 
@@ -4179,7 +4179,7 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
         else
         {
             int iCurrentStackArg = iLogicalArg - numArgsFromStack;
-            if (iLogicalArg != 0 || !callInfo.sig.hasThis() || newObj)
+            if (iLogicalArg != 0 || !callInfo.sig.hasImplicitThis() || newObj)
             {
                 CORINFO_CLASS_HANDLE classHandle;
 
@@ -5889,6 +5889,10 @@ void InterpCompiler::GenerateCode(CORINFO_METHOD_INFO* methodInfo)
     CORINFO_RESOLVED_TOKEN constrainedToken;
     CORINFO_CALL_INFO callInfo;
     const uint8_t *codeEnd;
+    if (m_methodInfo->args.hasExplicitThis())
+    {
+        BADCODE("Explicit this is only supported for calls");
+    }
     int numArgs = m_methodInfo->args.hasThis() + m_methodInfo->args.numArgs;
     bool emittedBBlocks, linkBBlocks, needsRetryEmit;
     m_pILCode = methodInfo->ILCode;

--- a/src/coreclr/interpreter/naming.cpp
+++ b/src/coreclr/interpreter/naming.cpp
@@ -266,7 +266,7 @@ void AppendMethodName(COMP_HANDLE comp,
 
         // Does it have a 'this' pointer? Don't count explicit this, which has
         // the this pointer type as the first element of the arg type list
-        if (includeThisSpecifier && sig->hasThis() && !sig->hasExplicitThis())
+        if (includeThisSpecifier && sig->hasImplicitThis())
         {
             printer->Append(":this", 5);
         }


### PR DESCRIPTION
- Fixes GitHub_35384
- Only required using the correct helper routines. The rest of the implementation fell out from there