### PR TITLE
[Wasm RyuJit] Slightly smaller code for switches

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -328,13 +328,10 @@ void CodeGen::genTableBasedSwitch(GenTree* treeNode)
     BBswtDesc* const desc      = block->GetSwitchTargets();
     unsigned const   caseCount = desc->GetCaseCount();
 
+    // We don't expect degenerate or default-less switches
+    //
+    assert(caseCount > 0);
     assert(desc->HasDefaultCase());
-
-    if (caseCount == 0)
-    {
-        assert(desc->GetDefaultCase()->getDestinationBlock() == block->Next());
-        return;
-    }
 
     GetEmitter()->emitIns_I(INS_br_table, EA_4BYTE, caseCount);
 

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -328,12 +328,11 @@ void CodeGen::genTableBasedSwitch(GenTree* treeNode)
     BBswtDesc* const desc      = block->GetSwitchTargets();
     unsigned const   caseCount = desc->GetCaseCount();
 
-    // TODO-WASM: update lowering not to peel off the default
-    //
-    assert(!desc->HasDefaultCase());
+    assert(desc->HasDefaultCase());
 
     if (caseCount == 0)
     {
+        assert(desc->GetDefaultCase()->getDestinationBlock() == block->Next());
         return;
     }
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1657,7 +1657,11 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
         blockRange = &LIR::AsRange(block);
         switchTree = blockRange->LastNode();
 
+#ifdef TARGET_WASM
+        assert(switchTree->OperIs(GT_SWITCH));
+#else
         assert(switchTree->OperIs(GT_SWITCH_TABLE));
+#endif
     }
     else
     {

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -1144,7 +1144,6 @@ PhaseStatus Compiler::fgWasmControlFlow()
             }
 
             // Branch to next needs no block, unless this is a switch
-            // (eventually when we leave the default on the switch we can remove this).
             //
             if ((succNum == (cursor + 1)) && !block->KindIs(BBJ_SWITCH))
             {
@@ -1623,13 +1622,10 @@ void Compiler::fgDumpWasmControlFlow()
                 BBswtDesc* const desc      = block->GetSwitchTargets();
                 unsigned const   caseCount = desc->GetCaseCount();
 
-                // BR_TABLE supports a default case, so we need to ensure
-                // that wasm lower does not remove it.
+                // BR_TABLE supports a default case.
+                // Wasm lower should not remove it.
                 //
-                // For now, we expect non-wasm lower has made the default case check explicit
-                // and so our BR_TABLE emission is deficient.
-                //
-                assert(!desc->HasDefaultCase());
+                assert(desc->HasDefaultCase());
 
                 if (caseCount == 0)
                 {

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -891,6 +891,12 @@ GenTree* Lowering::LowerSwitch(GenTree* node)
 
     noway_assert(jumpCnt >= 2);
 
+#ifdef TARGET_WASM
+    // Wasm's br_table maps exactly to GT_SWITCH
+    //
+    return node->gtNext;
+#endif // TARGET_WASM
+
     // Spill the argument to the switch node into a local so that it can be used later.
     LIR::Use use(switchBBRange, &(node->AsOp()->gtOp1), node);
     ReplaceWithLclVar(use);


### PR DESCRIPTION
Wasm switches (`br_table`) have a default case, so take advantage of this and stop peeling off the default case in lower.