### PR TITLE
Cleanup `NET6_0_OR_GREATER` symbol

### DIFF
--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ArtifactWriter.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/ArtifactWriter.cs
@@ -48,7 +48,7 @@ public static class ArtifactWriter
 
     private static string ComputeHash(byte[] data)
     {
-#if NET6_0_OR_GREATER
+#if NET
         var hash = SHA256.HashData(data);
         return Convert.ToBase64String(hash);
 #else


### PR DESCRIPTION
Follow-up https://github.com/dotnet/runtime/issues/109254