### PR TITLE
[clr-interp] Fix issue where a delegate directly wraps another delegate

### DIFF
--- a/src/coreclr/vm/callstubgenerator.h
+++ b/src/coreclr/vm/callstubgenerator.h
@@ -43,7 +43,6 @@ struct CallStubHeader
     {
         LIMITED_METHOD_CONTRACT;
 
-        _ASSERTE(target != 0);
         VolatileStore(&Routines[NumRoutines - 1], target);
     }
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -274,7 +274,7 @@ void InvokeDelegateInvokeMethod(MethodDesc *pMDDelegateInvoke, int8_t *pArgs, in
     CallStubHeader *stubHeaderTemplate = pMDDelegateInvoke->GetCallStub();
     if (stubHeaderTemplate == NULL)
     {
-        stubHeaderTemplate = UpdateCallStubForMethod(pMDDelegateInvoke, (PCODE)NULL);
+        stubHeaderTemplate = UpdateCallStubForMethod(pMDDelegateInvoke, (PCODE)pMDDelegateInvoke->GetMultiCallableAddrOfCode(CORINFO_ACCESS_ANY));
     }
 
     // CallStubHeaders encode their destination addresses in the Routines array, so they need to be

--- a/src/tests/JIT/Methodical/Methodical_others.csproj
+++ b/src/tests/JIT/Methodical/Methodical_others.csproj
@@ -22,6 +22,7 @@
     <Compile Include="Boxing\boxunbox\BoxPatternMatchAndSideEffects.cs" />
     <Compile Include="Boxing\misc\unusedindir.cs" />
     <Compile Include="Coverage\b433189.cs" />
+    <Compile Include="delegate\DelegateToDelegate.cs" />
     <Compile Include="delegate\GSDelegate.cs" />
     <Compile Include="delegate\VirtualDelegate.cs" />
     <Compile Include="divrem\div\negSignedMod.cs" />

--- a/src/tests/JIT/Methodical/delegate/DelegateToDelegate.cs
+++ b/src/tests/JIT/Methodical/delegate/DelegateToDelegate.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+public class DelegateToDelegate
+{
+    public delegate string OuterDelegate();
+
+    private static string InnerMethod() {
+        return "PASS";
+    }
+
+    [Fact]
+    public static int TestEntryPoint() {
+        int retVal = 100;
+
+        Func<string> innerDelegate = InnerMethod;
+
+        // The initial issue where we observed a need for this test failed if the inner delegate type was used before we attempted to 
+        innerDelegate();
+
+        var del = (OuterDelegate)Delegate.CreateDelegate(typeof(OuterDelegate), innerDelegate, typeof(Func<string>).GetMethod ("Invoke"));
+        if (del() != "PASS")
+            retVal = 1;
+        
+        return retVal;
+    }
+}


### PR DESCRIPTION
In the interpreter we use the CallStub of a delegate invoke method for both invoking the Invoke method directly as well as for handling the calling convention details for a fallback call to use the function pointer embedded in the delegate object.

In the current logic when we construct the call stub for for the `Invoke` method for the use of just doing signature handling for delegate invoke, we didn't supply it with a target pointer, we just use NULL. When actually dispatching, we copy the `CallStubHeader` to the stack and then fill in the target pointer. It turns out that this is inadequate when a delegate directly wraps a delegate. Since we share the CallStubHeader for both purposes, we end up simply dispatching to `NULL` which will cause an access violation. The fix is to always fill in the CallStubHeader completely, but still stomp the target pointer when we are doing the delegate invoke path.

Included in this change is a coreclr test case to avoid the need to have some code in the xunit testharness which hits this in the libraries test.