### PR TITLE
Stop checking for and writing out breadcrumbs for Microsoft.NET.DotNetHostPolicy

### DIFF
--- a/src/installer/tests/TestUtils/DotNetBuilder.cs
+++ b/src/installer/tests/TestUtils/DotNetBuilder.cs
@@ -140,9 +140,7 @@ namespace Microsoft.DotNet.CoreSetup.Test
                         // ./shared/Microsoft.NETCore.App/<version>/coreclr.dll - this is a mock, will not actually run CoreClr
                         .WithAsset((new NetCoreAppBuilder.RuntimeFileBuilder($"runtimes/{currentRid}/native/{Binaries.CoreClr.FileName}"))
                             .CopyFromFile(Binaries.CoreClr.MockPath)
-                            .WithLocalPath(Binaries.CoreClr.FileName))))
-                .WithPackage($"runtime.{currentRid}.Microsoft.NETCore.DotNetHostPolicy", version, p => p
-                    .WithNativeLibraryGroup(null, g => g
+                            .WithLocalPath(Binaries.CoreClr.FileName))
                         // ./shared/Microsoft.NETCore.App/<version>/hostpolicy.dll - this is the real component and will load CoreClr library
                         .WithAsset((new NetCoreAppBuilder.RuntimeFileBuilder($"runtimes/{currentRid}/native/{Binaries.HostPolicy.FileName}"))
                             .CopyFromFile(Binaries.HostPolicy.FilePath)

--- a/src/native/corehost/CMakeLists.txt
+++ b/src/native/corehost/CMakeLists.txt
@@ -27,9 +27,6 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${CLR_ARTIFACTS_OBJ_DIR}) # Generated version files
 
 if (NOT ${CLR_SINGLE_FILE_HOST_ONLY})
-    if("${CLI_CMAKE_PKG_RID}" STREQUAL "")
-        message(FATAL_ERROR "A minimum supported package rid is not specified (ex: win7-x86 or ubuntu.14.04-x64, osx.10.12-x64, rhel.7-x64)")
-    endif()
     if("${CLI_CMAKE_COMMIT_HASH}" STREQUAL "")
         message(FATAL_ERROR "Commit hash needs to be specified to build the host")
     endif()

--- a/src/native/corehost/apphost/static/hostpolicy_resolver.cpp
+++ b/src/native/corehost/apphost/static/hostpolicy_resolver.cpp
@@ -42,7 +42,6 @@ bool hostpolicy_resolver::try_get_dir(
     const fx_definition_vector_t& fx_definitions,
     const pal::string_t& app_candidate,
     const pal::string_t& specified_deps_file,
-    const std::vector<pal::string_t>& probe_realpaths,
     pal::string_t* impl_dir)
 {
     // static apphost is not supposed to be used in a framework-dependent app

--- a/src/native/corehost/build.cmd
+++ b/src/native/corehost/build.cmd
@@ -93,22 +93,13 @@ if exist "%__IntermediatesDir%" rd /s /q "%__IntermediatesDir%"
 :CreateIntermediates
 if not exist "%__IntermediatesDir%" md "%__IntermediatesDir%"
 
-if /i "%__BuildArch%" == "x64"     (set cm_BaseRid=win7)
-if /i "%__BuildArch%" == "x86"     (set cm_BaseRid=win7)
-if /i "%__BuildArch%" == "arm64"   (set cm_BaseRid=win10)
-if /i "%__BuildArch%" == "wasm"   (set cm_BaseRid=browser)
-:: Form the base RID to be used if we are doing a portable build
-if /i "%__PortableBuild%" == "1"   (set cm_BaseRid=win)
-set cm_BaseRid=%cm_BaseRid%-%__BuildArch%
-echo "Computed RID for native build is %cm_BaseRid%"
-
 :: When the host runs on an unknown rid, it falls back to the output rid
 :: Strip the architecture
 for /f "delims=-" %%i in ("%__TargetRid%") do set __HostFallbackOS=%%i
 :: The "win" host build is Windows 10 compatible
 if "%__HostFallbackOS%" == "win"       (set __HostFallbackOS=win10)
 
-set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCLI_CMAKE_PKG_RID=%cm_BaseRid%" "-DCLI_CMAKE_FALLBACK_OS=%__HostFallbackOS%" "-DCLI_CMAKE_COMMIT_HASH=%__CommitSha%"
+set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCLI_CMAKE_FALLBACK_OS=%__HostFallbackOS%" "-DCLI_CMAKE_COMMIT_HASH=%__CommitSha%"
 set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCLR_CMAKE_TARGET_ARCH=%__BuildArch%" "-DCLR_CMAKE_TARGET_OS=%__TargetOS%"
 set __ExtraCmakeParams=%__ExtraCmakeParams% "-DCLI_CMAKE_RESOURCE_DIR=%__ResourcesDir%" "-DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE%"
 

--- a/src/native/corehost/build.sh
+++ b/src/native/corehost/build.sh
@@ -59,7 +59,7 @@ __IntermediatesDir="$__RootBinDir/obj/$__TargetRid.$__BuildType"
 
 export __BinDir __IntermediatesDir __RuntimeFlavor
 
-__CMakeArgs="-DCLI_CMAKE_PKG_RID=\"$__TargetRid\" -DCLI_CMAKE_FALLBACK_OS=\"$__HostFallbackOS\" -DCLI_CMAKE_COMMIT_HASH=\"$__commit_hash\" $__CMakeArgs"
+__CMakeArgs="-DCLI_CMAKE_FALLBACK_OS=\"$__HostFallbackOS\" -DCLI_CMAKE_COMMIT_HASH=\"$__commit_hash\" $__CMakeArgs"
 
 if [[ "$__TargetOS" != osx ]]; then
     __CMakeArgs="-DFEATURE_DISTRO_AGNOSTIC_SSL=$__PortableBuild $__CMakeArgs"

--- a/src/native/corehost/configure.h.in
+++ b/src/native/corehost/configure.h.in
@@ -7,12 +7,8 @@
 // When hosting components are all statically linked,
 // the versioning information is irrelevant and may only come up in tracing.
 // so we will use "static"
-#define HOST_POLICY_PKG_NAME "static"
-#define HOST_POLICY_PKG_REL_DIR "static"
 #define REPO_COMMIT_HASH "static"
 #else
-#define HOST_POLICY_PKG_NAME "runtime.@CLI_CMAKE_PKG_RID@.Microsoft.NETCore.DotNetHostPolicy"
-#define HOST_POLICY_PKG_REL_DIR "runtime.@CLI_CMAKE_PKG_RID@/native"
 #define REPO_COMMIT_HASH "@CLI_CMAKE_COMMIT_HASH@"
 #endif
 

--- a/src/native/corehost/fxr/fx_muxer.cpp
+++ b/src/native/corehost/fxr/fx_muxer.cpp
@@ -491,7 +491,7 @@ namespace
         trace::verbose(_X("Executing as a %s app as per config file [%s]"),
             (is_framework_dependent ? _X("framework-dependent") : _X("self-contained")), app_config.get_path().c_str());
 
-        if (!hostpolicy_resolver::try_get_dir(mode, host_info.dotnet_root, fx_definitions, app_candidate, deps_file, probe_fullpaths, &hostpolicy_dir))
+        if (!hostpolicy_resolver::try_get_dir(mode, host_info.dotnet_root, fx_definitions, app_candidate, deps_file, &hostpolicy_dir))
         {
             return StatusCode::CoreHostLibMissingFailure;
         }
@@ -629,7 +629,7 @@ namespace
         trace::verbose(_X("Libhost loading occurring for a framework-dependent component per config file [%s]"), app_config.get_path().c_str());
 
         const pal::string_t deps_file;
-        if (!hostpolicy_resolver::try_get_dir(mode, host_info.dotnet_root, fx_definitions, host_info.app_path, deps_file, probe_fullpaths, &hostpolicy_dir))
+        if (!hostpolicy_resolver::try_get_dir(mode, host_info.dotnet_root, fx_definitions, host_info.app_path, deps_file, &hostpolicy_dir))
         {
             return StatusCode::CoreHostLibMissingFailure;
         }

--- a/src/native/corehost/fxr/hostpolicy_resolver.h
+++ b/src/native/corehost/fxr/hostpolicy_resolver.h
@@ -37,7 +37,6 @@ namespace hostpolicy_resolver
         const fx_definition_vector_t& fx_definitions,
         const pal::string_t& app_candidate,
         const pal::string_t& specified_deps_file,
-        const std::vector<pal::string_t>& probe_realpaths,
         pal::string_t* impl_dir);
 };
 

--- a/src/native/corehost/fxr/standalone/hostpolicy_resolver.cpp
+++ b/src/native/corehost/fxr/standalone/hostpolicy_resolver.cpp
@@ -18,151 +18,6 @@ namespace
     pal::dll_t g_hostpolicy;
     hostpolicy_contract_t g_hostpolicy_contract;
     pal::string_t g_hostpolicy_dir;
-
-    /**
-    * Resolve the hostpolicy version from deps.
-    *  - Scan the deps file's libraries section and find the hostpolicy version in the file.
-    */
-    pal::string_t resolve_hostpolicy_version_from_deps(const pal::string_t& deps_json)
-    {
-        trace::verbose(_X("--- Resolving %s version from deps json [%s]"), LIBHOSTPOLICY_NAME, deps_json.c_str());
-
-        json_parser_t json;
-        if (!json.parse_file(deps_json))
-        {
-            return {};
-        }
-
-        // Look up the root package instead of the "runtime" package because we can't do a full rid resolution.
-        // i.e., look for "Microsoft.NETCore.DotNetHostPolicy/" followed by version.
-        const pal::char_t prefix[] = _X("Microsoft.NETCore.DotNetHostPolicy/");
-        for (const auto& library : json.document()[_X("libraries")].GetObject())
-        {
-            pal::string_t lib_name{library.name.GetString()};
-            if (utils::starts_with(lib_name, prefix, false))
-            {
-                // Extract the version information that occurs after '/'
-                pal::string_t version = lib_name.substr(utils::strlen(prefix));
-                trace::verbose(_X("Resolved version %s from dependency manifest file [%s]"), version.c_str(), deps_json.c_str());
-                return version;
-            }
-        }
-
-        return {};
-    }
-
-    /**
-    * Given a directory and a version, find if the package relative
-    *     dir under the given directory contains hostpolicy.dll
-    */
-    bool to_hostpolicy_package_dir(const pal::string_t& dir, const pal::string_t& version, pal::string_t* candidate)
-    {
-        assert(!version.empty());
-
-        candidate->clear();
-
-        // Ensure the relative dir contains platform directory separators.
-        pal::string_t rel_dir = _STRINGIFY(HOST_POLICY_PKG_REL_DIR);
-        if (DIR_SEPARATOR != '/')
-        {
-            replace_char(&rel_dir, '/', DIR_SEPARATOR);
-        }
-
-        // Construct the path to directory containing hostpolicy.
-        pal::string_t path = dir;
-        append_path(&path, _STRINGIFY(HOST_POLICY_PKG_NAME)); // package name
-        append_path(&path, version.c_str());                  // package version
-        append_path(&path, rel_dir.c_str());                  // relative dir containing hostpolicy library
-
-                                                            // Check if "path" contains the required library.
-        if (!file_exists_in_dir(path, LIBHOSTPOLICY_NAME, nullptr))
-        {
-            trace::verbose(_X("Did not find %s in directory %s"), LIBHOSTPOLICY_NAME, path.c_str());
-            return false;
-        }
-
-        // "path" contains the directory containing hostpolicy library.
-        *candidate = path;
-
-        trace::verbose(_X("Found %s in directory %s"), LIBHOSTPOLICY_NAME, path.c_str());
-        return true;
-    }
-
-    /**
-    * Given a nuget version, detect if a serviced hostpolicy is available at
-    *   platform servicing location.
-    */
-    bool hostpolicy_exists_in_svc(const pal::string_t& version, pal::string_t* resolved_dir)
-    {
-        if (version.empty())
-        {
-            return false;
-        }
-
-        pal::string_t svc_dir;
-        pal::get_default_servicing_directory(&svc_dir);
-        append_path(&svc_dir, _X("pkgs"));
-        return to_hostpolicy_package_dir(svc_dir, version, resolved_dir);
-    }
-
-    /**
-    * Given a version and probing paths, find if package layout
-    *    directory containing hostpolicy exists.
-    */
-    bool resolve_hostpolicy_dir_from_probe_paths(const pal::string_t& version, const std::vector<pal::string_t>& probe_fullpaths, pal::string_t* candidate)
-    {
-        if (probe_fullpaths.empty() || version.empty())
-        {
-            return false;
-        }
-
-        // Check if the package relative directory containing hostpolicy exists.
-        for (const auto& probe_path : probe_fullpaths)
-        {
-            trace::verbose(_X("Considering %s to probe for %s"), probe_path.c_str(), LIBHOSTPOLICY_NAME);
-            if (to_hostpolicy_package_dir(probe_path, version, candidate))
-            {
-                return true;
-            }
-        }
-
-        // Print detailed message about the file not found in the probe paths.
-        trace::error(_X("Could not find required library %s in %d probing paths:"),
-            LIBHOSTPOLICY_NAME, probe_fullpaths.size());
-        for (const auto& path : probe_fullpaths)
-        {
-            trace::error(_X("  %s"), path.c_str());
-        }
-        return false;
-    }
-
-    /**
-    * Return name of deps file for app.
-    */
-    pal::string_t get_deps_file(
-        bool is_framework_dependent,
-        const pal::string_t& app_candidate,
-        const pal::string_t& specified_deps_file,
-        const fx_definition_vector_t& fx_definitions
-    )
-    {
-        if (is_framework_dependent)
-        {
-            // The hostpolicy is resolved from the root framework's name and location.
-            pal::string_t deps_file = get_root_framework(fx_definitions).get_dir();
-            if (!deps_file.empty() && deps_file.back() != DIR_SEPARATOR)
-            {
-                deps_file.push_back(DIR_SEPARATOR);
-            }
-
-            return deps_file + get_root_framework(fx_definitions).get_name() + _X(".deps.json");
-        }
-        else
-        {
-            // Self-contained app's hostpolicy is from specified deps or from app deps.
-            return !specified_deps_file.empty() ? specified_deps_file : get_deps_from_app_binary(get_directory(app_candidate), app_candidate);
-        }
-    }
 }
 
 int hostpolicy_resolver::load(
@@ -241,27 +96,6 @@ bool hostpolicy_resolver::try_get_dir(
 {
     bool is_framework_dependent = get_app(fx_definitions).get_runtime_config().get_is_framework_dependent();
 
-    // Obtain deps file for the given configuration.
-    pal::string_t resolved_deps = get_deps_file(is_framework_dependent, app_candidate, specified_deps_file, fx_definitions);
-
-    // Resolve hostpolicy version out of the deps file.
-    pal::string_t version;
-    if (pal::file_exists(resolved_deps))
-    {
-        version = resolve_hostpolicy_version_from_deps(resolved_deps);
-        if (trace::is_enabled() && version.empty())
-        {
-            trace::warning(_X("Dependency manifest %s does not contain an entry for %s"),
-                resolved_deps.c_str(), _STRINGIFY(HOST_POLICY_PKG_NAME));
-        }
-
-        // Check if the given version of the hostpolicy exists in servicing.
-        if (hostpolicy_exists_in_svc(version, impl_dir))
-        {
-            return true;
-        }
-    }
-
     // Get the expected directory that would contain hostpolicy.
     pal::string_t expected;
     if (is_framework_dependent)
@@ -295,16 +129,6 @@ bool hostpolicy_resolver::try_get_dir(
     if (file_exists_in_dir(expected, LIBHOSTPOLICY_NAME, nullptr))
     {
         impl_dir->assign(expected);
-        return true;
-    }
-
-    trace::verbose(_X("The %s was not found in [%s]"), LIBHOSTPOLICY_NAME, expected.c_str());
-
-    // Start probing for hostpolicy in the specified probe paths.
-    pal::string_t candidate;
-    if (resolve_hostpolicy_dir_from_probe_paths(version, probe_fullpaths, &candidate))
-    {
-        impl_dir->assign(candidate);
         return true;
     }
 

--- a/src/native/corehost/fxr/standalone/hostpolicy_resolver.cpp
+++ b/src/native/corehost/fxr/standalone/hostpolicy_resolver.cpp
@@ -91,7 +91,6 @@ bool hostpolicy_resolver::try_get_dir(
     const fx_definition_vector_t& fx_definitions,
     const pal::string_t& app_candidate,
     const pal::string_t& specified_deps_file,
-    const std::vector<pal::string_t>& probe_fullpaths,
     pal::string_t* impl_dir)
 {
     bool is_framework_dependent = get_app(fx_definitions).get_runtime_config().get_is_framework_dependent();

--- a/src/native/corehost/hostpolicy/hostpolicy_context.cpp
+++ b/src/native/corehost/hostpolicy/hostpolicy_context.cpp
@@ -192,29 +192,11 @@ int hostpolicy_context_t::initialize(const hostpolicy_init_t &hostpolicy_init, c
         return StatusCode::ResolverInitFailure;
     }
 
+    // Resolve probe paths and setup breadcrumbs if enabled
     probe_paths_t probe_paths;
-
-    // Setup breadcrumbs.
-    if (breadcrumbs_enabled)
+    if (!resolver.resolve_probe_paths(&probe_paths, breadcrumbs_enabled ? &breadcrumbs : nullptr))
     {
-        pal::string_t policy_name = _STRINGIFY(HOST_POLICY_PKG_NAME);
-        pal::string_t policy_version = _STRINGIFY(HOST_VERSION);
-
-        // Always insert the hostpolicy that the code is running on.
-        breadcrumbs.insert(policy_name);
-        breadcrumbs.insert(policy_name + _X(",") + policy_version);
-
-        if (!resolver.resolve_probe_paths(&probe_paths, &breadcrumbs))
-        {
-            return StatusCode::ResolverResolveFailure;
-        }
-    }
-    else
-    {
-        if (!resolver.resolve_probe_paths(&probe_paths, nullptr))
-        {
-            return StatusCode::ResolverResolveFailure;
-        }
+        return StatusCode::ResolverResolveFailure;
     }
 
     clr_path = probe_paths.coreclr;


### PR DESCRIPTION
This package hasn't been the way we construct .NET apps since before 3.0. We currently check for it in the deps.json on startup and write it out as a breadcrumb file for every app - we should be able to stop doing this and avoid some unnecessary file I/O and allocations (~80 heap allocs for framework-dependent, ~160 allocs, a thread, folder existence check, and file write for self-contained hello world console apps).

cc @dotnet/appmodel @AaronRobinsonMSFT 