### PR TITLE
Fix return statement in X509ResourceClient instrumentation

### DIFF
--- a/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs
+++ b/src/libraries/Common/src/System/Net/Http/X509ResourceClient.cs
@@ -67,7 +67,7 @@ namespace System.Net.Http
                 await ((Task)task).ConfigureAwait(ConfigureAwaitOptions.SuppressThrowing);
                 if (task.IsCompletedSuccessfully)
                 {
-                    return task.Result;
+                    return ret = task.Result;
                 }
             }
             catch { }


### PR DESCRIPTION
The AssetDownloadStop event did not contain the downloaded payload size