### PR TITLE
[Wasm RyuJit] fix abi info for small arg types

### DIFF
--- a/src/coreclr/jit/targetwasm.cpp
+++ b/src/coreclr/jit/targetwasm.cpp
@@ -51,8 +51,7 @@ ABIPassingInformation WasmClassifier::Classify(Compiler*    comp,
         NYI_WASM("WasmClassifier::Classify - structs");
     }
 
-    type                  = genActualType(type);
-    regNumber         reg = MakeWasmReg(m_localIndex++, type);
+    regNumber         reg = MakeWasmReg(m_localIndex++, genActualType(type));
     ABIPassingSegment seg = ABIPassingSegment::InRegister(reg, 0, genTypeSize(type));
     return ABIPassingInformation::FromSegmentByValue(comp, seg);
 }


### PR DESCRIPTION
The "register" is stack sized, but the argument is smaller.