### PR TITLE
Configure HardwareIntrinsic support for Apple Mobile platforms

### DIFF
--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -31,7 +31,7 @@ namespace System.CommandLine
 
             if ((targetArchitecture == TargetArchitecture.X86) || (targetArchitecture == TargetArchitecture.X64))
             {
-                if (isReadyToRun && ((targetOS == TargetOS.OSX) || (targetOS == TargetOS.MacCatalyst)))
+                if (isReadyToRun && targetOS != TargetOS.OSX && targetOS != TargetOS.MacCatalyst)
                 {
                     // ReadyToRun can presume AVX2, BMI1, BMI2, F16C, FMA, LZCNT, and MOVBE
                     instructionSetSupportBuilder.AddSupportedInstructionSet("x86-64-v3");

--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -17,7 +17,7 @@ namespace System.CommandLine
     internal static partial class Helpers
     {
         public static InstructionSetSupport ConfigureInstructionSetSupport(string instructionSet, int maxVectorTBitWidth, bool isVectorTOptimistic, TargetArchitecture targetArchitecture, TargetOS targetOS,
-            string mustNotBeMessage, string invalidImplicationMessage, Logger logger, bool optimizingForSize, bool isReadyToRun)
+            string mustNotBeMessage, string invalidImplicationMessage, Logger logger, bool allowOptimistic, bool isReadyToRun)
         {
             InstructionSetSupportBuilder instructionSetSupportBuilder = new(targetArchitecture);
 
@@ -31,7 +31,7 @@ namespace System.CommandLine
 
             if ((targetArchitecture == TargetArchitecture.X86) || (targetArchitecture == TargetArchitecture.X64))
             {
-                if (isReadyToRun && (targetOS != TargetOS.OSX))
+                if (isReadyToRun && ((targetOS == TargetOS.OSX) || (targetOS == TargetOS.MacCatalyst)))
                 {
                     // ReadyToRun can presume AVX2, BMI1, BMI2, F16C, FMA, LZCNT, and MOVBE
                     instructionSetSupportBuilder.AddSupportedInstructionSet("x86-64-v3");
@@ -67,6 +67,11 @@ namespace System.CommandLine
                         instructionSetSupportBuilder.AddSupportedInstructionSet("armv8.2-a");
                         instructionSetSupportBuilder.AddSupportedInstructionSet("rcpc");
                     }
+                    else if (targetOS is TargetOS.iOS or TargetOS.iOSSimulator or TargetOS.tvOS or TargetOS.tvOSSimulator)
+                    {
+                        // ReadyToRun on iOS/tvOS can only presume armv8.0-a
+                        instructionSetSupportBuilder.AddSupportedInstructionSet("armv8-a");
+                    }
                     else
                     {
                         // While Unix needs a lower baseline due to things like Raspberry PI
@@ -88,9 +93,7 @@ namespace System.CommandLine
             }
 
             // Whether to allow optimistically expanding the instruction sets beyond what was specified.
-            // We seed this from optimizingForSize - if we're size-optimizing, we don't want to unnecessarily
-            // compile both branches of IsSupported checks.
-            bool allowOptimistic = !optimizingForSize;
+            // This value is provided by the caller.
 
             bool throttleAvx512 = false;
 

--- a/src/coreclr/tools/Common/InstructionSetHelpers.cs
+++ b/src/coreclr/tools/Common/InstructionSetHelpers.cs
@@ -92,9 +92,6 @@ namespace System.CommandLine
                 }
             }
 
-            // Whether to allow optimistically expanding the instruction sets beyond what was specified.
-            // This value is provided by the caller.
-
             bool throttleAvx512 = false;
 
             if (instructionSet == "native")

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -57,11 +57,12 @@ namespace ILCompiler
         public ReadyToRunCompilerContext(
             TargetDetails details,
             SharedGenericsMode genericsMode,
-            bool bubbleIncludesCorelib,
+            bool bubbleIncludesCoreModule,
             InstructionSetSupport instructionSetSupport,
             CompilerTypeSystemContext oldTypeSystemContext)
             : base(details, genericsMode)
         {
+            BubbleIncludesCoreModule = bubbleIncludesCoreModule;
             InstructionSetSupport = instructionSetSupport;
             _r2rFieldLayoutAlgorithm = new ReadyToRunMetadataFieldLayoutAlgorithm();
             _systemObjectFieldLayoutAlgorithm = new SystemObjectFieldLayoutAlgorithm(_r2rFieldLayoutAlgorithm);
@@ -94,7 +95,27 @@ namespace ILCompiler
             }
         }
 
+        public bool BubbleIncludesCoreModule { get; }
+
         public InstructionSetSupport InstructionSetSupport { get; }
+
+        public bool TargetAllowsRuntimeCodeGeneration
+        {
+            get
+            {
+                if (Target.OperatingSystem is TargetOS.iOS or TargetOS.iOSSimulator or TargetOS.MacCatalyst or TargetOS.tvOS or TargetOS.tvOSSimulator)
+                {
+                    return false;
+                }
+
+                if (Target.Architecture is TargetArchitecture.Wasm32)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+        }
 
         public override FieldLayoutAlgorithm GetLayoutAlgorithmForType(DefType type)
         {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunHardwareIntrinsicRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunHardwareIntrinsicRootProvider.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 
 using Internal.TypeSystem;
 using Internal.JitInterface;
+using System.Diagnostics;
 
 namespace ILCompiler
 {
@@ -35,6 +36,11 @@ namespace ILCompiler
                     {
                         rootProvider.AddCompilationRoot(method, rootMinimalDependencies: false, "Hardware intrinsic method fallback implementation");
                     }
+                }
+                else
+                {
+                    MethodDesc isSupportedMethod = type.GetMethod("get_IsSupported"u8, new MethodSignature(MethodSignatureFlags.Static, 0, context.GetWellKnownType(WellKnownType.Boolean), []));
+                    rootProvider.AddCompilationRoot(isSupportedMethod, rootMinimalDependencies: false, "IsSupported getter for unsupported hardware intrinsic");
                 }
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunHardwareIntrinsicRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunHardwareIntrinsicRootProvider.cs
@@ -40,7 +40,10 @@ namespace ILCompiler
                 else
                 {
                     MethodDesc isSupportedMethod = type.GetMethod("get_IsSupported"u8, new MethodSignature(MethodSignatureFlags.Static, 0, context.GetWellKnownType(WellKnownType.Boolean), []));
-                    rootProvider.AddCompilationRoot(isSupportedMethod, rootMinimalDependencies: false, "IsSupported getter for unsupported hardware intrinsic");
+                    if (isSupportedMethod is not null)
+                    {
+                        rootProvider.AddCompilationRoot(isSupportedMethod, rootMinimalDependencies: false, "IsSupported getter for unsupported hardware intrinsic");
+                    }
                 }
             }
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunHardwareIntrinsicRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunHardwareIntrinsicRootProvider.cs
@@ -3,10 +3,8 @@
 
 using System.Collections.Generic;
 
-using Internal.TypeSystem.Ecma;
 using Internal.TypeSystem;
 using Internal.JitInterface;
-using System.Reflection.Metadata;
 
 namespace ILCompiler
 {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunHardwareIntrinsicRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunHardwareIntrinsicRootProvider.cs
@@ -1,0 +1,44 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+
+using Internal.TypeSystem.Ecma;
+using Internal.TypeSystem;
+using Internal.JitInterface;
+using System.Reflection.Metadata;
+
+namespace ILCompiler
+{
+    /// <summary>
+    /// Root all methods on supported hardware intrinsic classes.
+    /// </summary>
+    public class ReadyToRunHardwareIntrinsicRootProvider(ReadyToRunCompilerContext context) : ICompilationRootProvider
+    {
+        public void AddCompilationRoots(IRootingServiceProvider rootProvider)
+        {
+            InstructionSetSupport specifiedInstructionSet = context.InstructionSetSupport;
+            TargetArchitecture targetArch = context.Target.Architecture;
+
+            // Hardware intrinsics can only live in the system module.
+            foreach (MetadataType type in context.SystemModule.GetAllTypes())
+            {
+                InstructionSet instructionSet = InstructionSetParser.LookupPlatformIntrinsicInstructionSet(targetArch, type);
+
+                if (instructionSet == InstructionSet.ILLEGAL)
+                {
+                    // Not a HardwareIntrinsics type for our platform.
+                    continue;
+                }
+
+                if (specifiedInstructionSet.IsInstructionSetSupported(instructionSet))
+                {
+                    foreach (MethodDesc method in type.GetMethods())
+                    {
+                        rootProvider.AddCompilationRoot(method, rootMinimalDependencies: false, "Hardware intrinsic method fallback implementation");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/ILCompiler.ReadyToRun.csproj
@@ -189,6 +189,7 @@
     <Compile Include="Compiler\Logger.cs" />
     <Compile Include="Compiler\ReadyToRunVisibilityRootProvider.cs" />
     <Compile Include="Compiler\ReadyToRunProfilingRootProvider.cs" />
+    <Compile Include="Compiler\ReadyToRunHardwareIntrinsicRootProvider.cs" />
     <Compile Include="ObjectWriter\MapFileBuilder.cs" />
     <Compile Include="CodeGen\ReadyToRunObjectWriter.cs" />
     <Compile Include="Compiler\CompilationModuleGroup.ReadyToRun.cs" />

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -108,7 +108,7 @@ namespace ILCompiler
             TargetOS targetOS = Get(_command.TargetOS);
             InstructionSetSupport instructionSetSupport = Helpers.ConfigureInstructionSetSupport(Get(_command.InstructionSet), Get(_command.MaxVectorTBitWidth), isVectorTOptimistic, targetArchitecture, targetOS,
                 "Unrecognized instruction set {0}", "Unsupported combination of instruction sets: {0}/{1}", logger,
-                optimizingForSize: _command.OptimizationMode == OptimizationMode.PreferSize,
+                allowOptimistic: _command.OptimizationMode != OptimizationMode.PreferSize,
                 isReadyToRun: false);
 
             string systemModuleName = Get(_command.SystemModuleName);

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -572,6 +572,16 @@ namespace ILCompiler
                             }
                         }
                     }
+
+                    if (!typeSystemContext.TargetAllowsRuntimeCodeGeneration && typeSystemContext.BubbleIncludesCoreModule)
+                    {
+                        // For some platforms, we cannot JIT.
+                        // As a result, we need to ensure that we have a fallback implementation for all hardware intrinsics
+                        // that are marked as supported.
+                        // Otherwise, the interpreter won't have an implementation it can call for any non-ReadyToRun code.
+                        compilationRoots.Add(new ReadyToRunHardwareIntrinsicRootProvider(typeSystemContext));
+                    }
+
                     // In single-file compilation mode, use the assembly's DebuggableAttribute to determine whether to optimize
                     // or produce debuggable code if an explicit optimization level was not specified on the command line
                     OptimizationMode optimizationMode = _command.OptimizationMode;


### PR DESCRIPTION
For Apple Mobile platforms, we need to slightly modify our policies for HW intrinsic support to provide the best user experience.

1. We should set the baseline ISA to the ISA supported by the oldest hardware that supports an OS version you can build a .NET app against. For iOS, this is `armv8-a` (not `armv8-a + lse` as is currently specified)
2. We do not want to support optimistic instruction sets by default. Methods with optimistic support can have their ReadyToRun code thrown out. As we cannot JIT, we'd prefer to use slightly less optimized ReadyToRun code than conditionally use better optimized ReadyToRun code or interpreted code depending on the device (with slower devices generally going down the slower interpreter path).
3. The supported hardware intrinsics methods (which all have recursive implementations that will be considered `mustExpand`) will be rooted when CoreLib is in the R2R version bubble. This ensures that the JIT's fallback implementation will be available for the interpreter to use.
4. For unsupported hardware intrinsics, the `get_IsSupported` method will be rooted so an explicit `IsSupported => false` implementation will be pregenerated. This ensures that we don't end up in a situation where any ISAs that are supported on the device but don't have any pre-jitted implementation for the given ISA are called by the interpreter.

To support newer intrinsics when targeting newer devices, the .NET Mac/iOS SDK should explicitly specify the new minimum instruction sets for the user's targeted OS version.

Fixes #122190

Contributes to #120047
Contributes to #120048