### PR TITLE
[DiagnosticServer] Impove ipc message parsing resiliency

### DIFF
--- a/src/native/eventpipe/ds-profiler-protocol.c
+++ b/src/native/eventpipe/ds-profiler-protocol.c
@@ -70,7 +70,7 @@ attach_profiler_command_try_parse_payload (
 		!ds_ipc_message_try_parse_value (&buffer_cursor, &buffer_cursor_len, (uint8_t *)&instance->profiler_guid, (uint32_t)ARRAY_SIZE (instance->profiler_guid)) ||
 		!ds_ipc_message_try_parse_string_utf16_t (&buffer_cursor, &buffer_cursor_len, &instance->profiler_path) ||
 		!ds_ipc_message_try_parse_uint32_t (&buffer_cursor, &buffer_cursor_len, &instance->client_data_len) ||
-		!(buffer_cursor_len <= instance->client_data_len))
+		!(buffer_cursor_len >= instance->client_data_len))
 		ep_raise_error ();
 
 	instance->client_data = buffer_cursor;

--- a/src/native/eventpipe/ds-protocol.c
+++ b/src/native/eventpipe/ds-protocol.c
@@ -396,7 +396,10 @@ ds_ipc_message_try_parse_value (
 	EP_ASSERT (buffer != NULL);
 	EP_ASSERT (buffer_len != NULL);
 	EP_ASSERT (value != NULL);
-	EP_ASSERT ((buffer_len - value_len) <= buffer_len);
+	EP_ASSERT (*buffer_len >= value_len);
+
+	if (*buffer_len < value_len)
+		return false;
 
 	memcpy (value, *buffer, value_len);
 	*buffer = *buffer + value_len;

--- a/src/native/eventpipe/ds-protocol.c
+++ b/src/native/eventpipe/ds-protocol.c
@@ -330,8 +330,6 @@ ipc_message_try_parse_string_utf16_t_byte_array (
 
 	bool result = false;
 
-	ep_raise_error_if_nok (((uintptr_t)*buffer & 0x1u) == 0);
-
 	ep_raise_error_if_nok (ds_ipc_message_try_parse_uint32_t (buffer, buffer_len, string_byte_array_len));
 	*string_byte_array_len *= sizeof (ep_char16_t);
 

--- a/src/native/eventpipe/ds-protocol.c
+++ b/src/native/eventpipe/ds-protocol.c
@@ -330,6 +330,8 @@ ipc_message_try_parse_string_utf16_t_byte_array (
 
 	bool result = false;
 
+	ep_raise_error_if_nok (((uintptr_t)*buffer & 0x1u) == 0);
+
 	ep_raise_error_if_nok (ds_ipc_message_try_parse_uint32_t (buffer, buffer_len, string_byte_array_len));
 	*string_byte_array_len *= sizeof (ep_char16_t);
 


### PR DESCRIPTION
While investigating for a way to check whether arbitrary .NET processes support emitting userevents, the idea of probing for `DS_IPC_E_UNKNOWN_COMMAND 0x80131385` with an empty payload uncovered a problem with truncated payloads. Additionally, there were two other places to improve the resiliency of IPC protocol parsing.