### PR TITLE
[browser] Set WasmGenerateAppBundle=false for browser-wasm to skip run args override

### DIFF
--- a/src/mono/wasm/build/WasmApp.Common.targets
+++ b/src/mono/wasm/build/WasmApp.Common.targets
@@ -174,6 +174,7 @@
     <EnableDefaultWasmAssembliesToBundle Condition="'$(EnableDefaultWasmAssembliesToBundle)' == ''">true</EnableDefaultWasmAssembliesToBundle>
     <!-- VS uses DeployOnBuild, and sdk sets _IsPublishing -->
     <WasmBuildOnlyAfterPublish Condition="'$(WasmBuildOnlyAfterPublish)' == '' and ('$(DeployOnBuild)' == 'true' or '$(_IsPublishing)' == 'true')">true</WasmBuildOnlyAfterPublish>
+    <WasmGenerateAppBundle Condition="'$(WasmGenerateAppBundle)' == '' and '$(RuntimeIdentifier)' == 'browser-wasm'">false</WasmGenerateAppBundle>
     <WasmGenerateAppBundle Condition="'$(WasmGenerateAppBundle)' == '' and ('$(OutputType)' != 'Library' or '$(_IsLibraryMode)' == 'true')">true</WasmGenerateAppBundle>
     <WasmGenerateAppBundle Condition="'$(WasmGenerateAppBundle)' == ''">false</WasmGenerateAppBundle>
 


### PR DESCRIPTION
Regression from https://github.com/dotnet/runtime/pull/120330
Mitigates https://github.com/dotnet/runtime/issues/122255

In the previous I have removed logic for "Generate Wasm AppBundle" from browser specific targets and removed setting the `WasmGenerateAppBundle=false`, because it should not do anything for browser. In the common targets we have a logic to compute run arguments, working dir and command. If `WasmGenerateAppBundle=true` this logic kicks in.