### PR TITLE
Optimize more bound checks around logical operators

### DIFF
--- a/src/coreclr/jit/clrjit.natvis
+++ b/src/coreclr/jit/clrjit.natvis
@@ -271,4 +271,14 @@ Documentation for VS debugger format specifiers: https://learn.microsoft.com/vis
     </Expand>
   </Type>
 
+  <!-- RangeCheck -->
+
+  <Type Name="Limit">
+    <DisplayString Condition="type == Limit::LimitType::keConstant">const: {cns}</DisplayString>
+  </Type>
+
+  <Type Name="Range">
+    <DisplayString Condition="lLimit.type == Limit::LimitType::keConstant &amp;&amp; uLimit.type == Limit::LimitType::keConstant">const range: [{lLimit.cns}..{uLimit.cns}]</DisplayString>
+  </Type>
+
 </AutoVisualizer>

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1170,7 +1170,7 @@ void RangeCheck::MergeAssertion(BasicBlock* block, GenTree* op, Range* pRange DE
 // Compute the range for a binary operation.
 Range RangeCheck::ComputeRangeForBinOp(BasicBlock* block, GenTreeOp* binop, bool monIncreasing DEBUGARG(int indent))
 {
-    assert(binop->OperIs(GT_ADD, GT_OR, GT_XOR, GT_AND, GT_RSH, GT_LSH, GT_UMOD, GT_MUL));
+    assert(binop->OperIs(GT_ADD, GT_OR, GT_XOR, GT_AND, GT_RSH, GT_RSZ, GT_LSH, GT_UMOD, GT_MUL));
 
     // For XOR we only care about Log2 pattern for now
     if (binop->OperIs(GT_XOR))
@@ -1238,7 +1238,10 @@ Range RangeCheck::ComputeRangeForBinOp(BasicBlock* block, GenTreeOp* binop, bool
             r = RangeOps::Multiply(op1Range, op2Range);
             break;
         case GT_RSH:
-            r = RangeOps::ShiftRight(op1Range, op2Range);
+            r = RangeOps::ShiftRight(op1Range, op2Range, /*logical*/ false);
+            break;
+        case GT_RSZ:
+            r = RangeOps::ShiftRight(op1Range, op2Range, /*logical*/ true);
             break;
         case GT_LSH:
             r = RangeOps::ShiftLeft(op1Range, op2Range);
@@ -1670,7 +1673,7 @@ Range RangeCheck::ComputeRange(BasicBlock* block, GenTree* expr, bool monIncreas
         MergeAssertion(block, expr, &range DEBUGARG(indent + 1));
     }
     // compute the range for binary operation
-    else if (expr->OperIs(GT_XOR, GT_OR, GT_ADD, GT_AND, GT_RSH, GT_LSH, GT_UMOD, GT_MUL))
+    else if (expr->OperIs(GT_XOR, GT_OR, GT_ADD, GT_AND, GT_RSH, GT_RSZ, GT_LSH, GT_UMOD, GT_MUL))
     {
         range = ComputeRangeForBinOp(block, expr->AsOp(), monIncreasing DEBUGARG(indent + 1));
     }

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -488,16 +488,6 @@ struct RangeOps
 
         Range result = Limit(Limit::keUnknown);
 
-        // AND is a commutative operation, put the constant (if any) on the right.
-        if (r1lo.IsConstant())
-        {
-            std::swap(r1lo, r2lo);
-        }
-        if (r1hi.IsConstant())
-        {
-            std::swap(r1hi, r2hi);
-        }
-
         // Lower bound
         if (r2lo.IsConstant() && r1lo.IsConstant())
         {

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -535,6 +535,8 @@ struct RangeOps
 
         Range result = Limit(Limit::keUnknown);
 
+        // For OR we can only make progress when both sides are constant and non-negative
+        //
         if (r1lo.IsConstant() && r2lo.IsConstant() && (r1lo.GetConstant() >= 0) && (r2lo.GetConstant() >= 0))
         {
             result.lLimit = Limit(Limit::keConstant, r1lo.GetConstant() | r2lo.GetConstant());
@@ -548,14 +550,14 @@ struct RangeOps
 
     static Range UnsignedMod(Range& r1, Range& r2)
     {
-        Limit& r1lo = r1.LowerLimit();
         Limit& r2lo = r2.LowerLimit();
-
-        Limit& r1hi = r1.UpperLimit();
         Limit& r2hi = r2.UpperLimit();
 
         Range result = Limit(Limit::keUnknown);
 
+        // For X UMOD Y we only handle the case when Y is a fixed non-negative constant.
+        // Example: X % 5 -> [0..4]
+        //
         if (r2lo.IsConstant() && r2lo.Equals(r2hi))
         {
             int op2Cns = r2lo.GetConstant();


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/122150
Example:
```cs
int Test(byte inData)
{
    ReadOnlySpan<byte> base64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="u8;
    return base64[((inData & 0x03) << 4) | ((inData & 0xf0) >> 4)];
}
```
Was:
```asm
; Method Program:Test(byte):int:this (FullOpts)
       sub      rsp, 40
       movzx    rax, dl
       mov      ecx, eax
       and      ecx, 3
       shl      ecx, 4
       and      eax, 240
       sar      eax, 4
       or       eax, ecx
       cmp      eax, 65
       jae      SHORT G_M54716_IG04
       mov      rcx, 0x196B4CC2D88      ; static handle
       movzx    rax, byte  ptr [rcx+rax]
       add      rsp, 40
       ret      
G_M54716_IG04:
       call     CORINFO_HELP_RNGCHKFAIL
       int3     
; Total bytes of code: 55
```
Now:
```asm
; Method Program:Test(byte):int:this (FullOpts)
       movzx    rax, dl
       mov      ecx, eax
       and      ecx, 3
       shl      ecx, 4
       and      eax, 240
       sar      eax, 4
       or       eax, ecx
       mov      rcx, 0x171D74A2D88      ; static handle
       movzx    rax, byte  ptr [rcx+rax]
       ret      
; Total bytes of code: 36
```
As the result, was able to optimize bound checks in Convert.ConvertToBase64Array
