### PR TITLE
[ilasm] Treat errors in -ERR mode as warnings

### DIFF
--- a/src/coreclr/ilasm/grammar_after.cpp
+++ b/src/coreclr/ilasm/grammar_after.cpp
@@ -1792,7 +1792,7 @@ void AsmParse::error(const char* fmt, ...)
     va_start(args, fmt);
 
     if((penv) && (penv->in)) psz+=sprintf_s(psz, (dwUniBuf >> 1), "%s(%d) : ", penv->in->name(), penv->curLine);
-    psz+=sprintf_s(psz, (dwUniBuf >> 1), "error : ");
+    psz+=sprintf_s(psz, (dwUniBuf >> 1), assem->OnErrGo ? "warning : " : "error : ");
     _vsnprintf_s(psz, (dwUniBuf >> 1),(dwUniBuf >> 1)-strlen(sz)-1, fmt, args);
     PrintANSILine(pF,sz);
 }


### PR DESCRIPTION
The undocumented -ERR mode is meant to ignore errors and allow produce invalid binaries for test purposes. Print the errors as warnings in this mode so that they do not fail the build.