### PR TITLE
Add missing import for AppleBuild.InTree.targets in iOS project

### DIFF
--- a/src/mono/sample/iOS/Program.csproj
+++ b/src/mono/sample/iOS/Program.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
 
   <Import Project="$(MonoProjectRoot)\msbuild\apple\build\AppleBuild.props" />
+  <Import Project="$(MonoProjectRoot)\msbuild\apple\build\AppleBuild.InTree.targets" />
 
   <Target Name="BuildAppBundle" AfterTargets="$(BuildAppBundleAfterTargets)" DependsOnTargets="$(BuildAppBundleDependsOnTargets)"/>
   <Target Name="_SetAppleGenerateAppBundleProps" Condition="'$(TargetOS)' != 'ios' and '$(ArchiveTests)' != 'true'" BeforeTargets="_AppleGenerateAppBundle">


### PR DESCRIPTION
## Description

Targets in AppleBuild.InTree.targets were removed by mistake in https://github.com/dotnet/runtime/pull/122036. This change restores them and fixes the performance jobs.

Internal performance job: https://dev.azure.com/dnceng/internal/_build/results?buildId=2856228&view=results