### PR TITLE
Use `VoidTaskResult` for void returns in runtime async

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -267,17 +267,6 @@ namespace System.Runtime.CompilerServices
             AsyncSuspend(sentinelContinuation);
         }
 
-        private interface IRuntimeAsyncTaskOps<T>
-        {
-            static abstract Action GetContinuationAction(T task);
-            static abstract Continuation MoveContinuationState(T task);
-            static abstract void SetContinuationState(T task, Continuation value);
-            static abstract bool SetCompleted(T task);
-            static abstract void PostToSyncContext(T task, SynchronizationContext syncCtx);
-            static abstract void ValueTaskSourceOnCompleted(T task, IValueTaskSourceNotifier vtsNotifier, ValueTaskSourceOnCompletedFlags configFlags);
-            static abstract ref byte GetResultStorage(T task);
-        }
-
         // Represents execution of a chain of suspended and resuming runtime
         // async functions.
         private sealed class RuntimeAsyncTask<T> : Task<T>, ITaskCompletionAction
@@ -288,195 +277,48 @@ namespace System.Runtime.CompilerServices
                 // Ensure that state object isn't published out for others to see.
                 Debug.Assert((m_stateFlags & (int)InternalTaskOptions.PromiseTask) != 0, "Expected state flags to already be configured.");
                 Debug.Assert(m_stateObject is null, "Expected to be able to use the state object field for Continuation.");
-                m_action = MoveNext;
+                m_action = DispatchContinuations;
                 m_stateFlags |= (int)InternalTaskOptions.HiddenState;
             }
 
             internal override void ExecuteFromThreadPool(Thread threadPoolThread)
             {
-                MoveNext();
-            }
-
-            private void MoveNext()
-            {
-                RuntimeAsyncTaskCore.DispatchContinuations<RuntimeAsyncTask<T>, Ops>(this);
-            }
-
-            public void HandleSuspended()
-            {
-                RuntimeAsyncTaskCore.HandleSuspended<RuntimeAsyncTask<T>, Ops>(this);
+                DispatchContinuations();
             }
 
             void ITaskCompletionAction.Invoke(Task completingTask)
             {
-                MoveNext();
+                DispatchContinuations();
             }
 
             bool ITaskCompletionAction.InvokeMayRunArbitraryCode => true;
 
-            private static readonly SendOrPostCallback s_postCallback = static state =>
+            private Action GetContinuationAction() => (Action)m_action!;
+
+            public Continuation MoveContinuationState()
             {
-                Debug.Assert(state is RuntimeAsyncTask<T>);
-                ((RuntimeAsyncTask<T>)state).MoveNext();
-            };
-
-            public static readonly Action<object?> s_runContinuationAction = static state =>
-            {
-                Debug.Assert(state is RuntimeAsyncTask<T>);
-                ((RuntimeAsyncTask<T>)state).MoveNext();
-            };
-
-            private struct Ops : IRuntimeAsyncTaskOps<RuntimeAsyncTask<T>>
-            {
-                public static Action GetContinuationAction(RuntimeAsyncTask<T> task) => (Action)task.m_action!;
-                public static Continuation MoveContinuationState(RuntimeAsyncTask<T> task)
-                {
-                    Continuation continuation = (Continuation)task.m_stateObject!;
-                    task.m_stateObject = null;
-                    return continuation;
-                }
-
-                public static void SetContinuationState(RuntimeAsyncTask<T> task, Continuation value)
-                {
-                    Debug.Assert(task.m_stateObject == null);
-                    task.m_stateObject = value;
-                }
-
-                public static bool SetCompleted(RuntimeAsyncTask<T> task)
-                {
-                    return task.TrySetResult(task.m_result);
-                }
-
-                public static void PostToSyncContext(RuntimeAsyncTask<T> task, SynchronizationContext syncContext)
-                {
-                    syncContext.Post(s_postCallback, task);
-                }
-
-                public static void ValueTaskSourceOnCompleted(RuntimeAsyncTask<T> task, IValueTaskSourceNotifier vtsNotifier, ValueTaskSourceOnCompletedFlags configFlags)
-                {
-                    vtsNotifier.OnCompleted(s_runContinuationAction, task, configFlags);
-                }
-
-                public static ref byte GetResultStorage(RuntimeAsyncTask<T> task) => ref Unsafe.As<T?, byte>(ref task.m_result);
-            }
-        }
-
-        // Represents execution of a chain of suspended and resuming runtime
-        // async functions.
-        private sealed class RuntimeAsyncTask : Task, ITaskCompletionAction
-        {
-            public RuntimeAsyncTask()
-            {
-                // We use the base Task's state object field to store the Continuation while posting the task around.
-                // Ensure that state object isn't published out for others to see.
-                Debug.Assert((m_stateFlags & (int)InternalTaskOptions.PromiseTask) != 0, "Expected state flags to already be configured.");
-                Debug.Assert(m_stateObject is null, "Expected to be able to use the state object field for Continuation.");
-                m_action = MoveNext;
-                m_stateFlags |= (int)InternalTaskOptions.HiddenState;
+                Continuation continuation = (Continuation)m_stateObject!;
+                m_stateObject = null;
+                return continuation;
             }
 
-            internal override void ExecuteFromThreadPool(Thread threadPoolThread)
+            public void SetContinuationState(Continuation value)
             {
-                MoveNext();
+                Debug.Assert(m_stateObject == null);
+                m_stateObject = value;
             }
 
-            private void MoveNext()
-            {
-                RuntimeAsyncTaskCore.DispatchContinuations<RuntimeAsyncTask, Ops>(this);
-            }
+            public ref byte GetResultStorage() => ref Unsafe.As<T?, byte>(ref m_result);
 
-            public void HandleSuspended()
-            {
-                RuntimeAsyncTaskCore.HandleSuspended<RuntimeAsyncTask, Ops>(this);
-            }
-
-            void ITaskCompletionAction.Invoke(Task completingTask)
-            {
-                MoveNext();
-            }
-
-            bool ITaskCompletionAction.InvokeMayRunArbitraryCode => true;
-
-            private static readonly SendOrPostCallback s_postCallback = static state =>
-            {
-                Debug.Assert(state is RuntimeAsyncTask);
-                ((RuntimeAsyncTask)state).MoveNext();
-            };
-
-            public static readonly Action<object?> s_runContinuationAction = static state =>
-            {
-                Debug.Assert(state is RuntimeAsyncTask);
-                ((RuntimeAsyncTask)state).MoveNext();
-            };
-
-            private struct Ops : IRuntimeAsyncTaskOps<RuntimeAsyncTask>
-            {
-                public static Action GetContinuationAction(RuntimeAsyncTask task) => (Action)task.m_action!;
-                public static Continuation MoveContinuationState(RuntimeAsyncTask task)
-                {
-                    Continuation continuation = (Continuation)task.m_stateObject!;
-                    task.m_stateObject = null;
-                    return continuation;
-                }
-
-                public static void SetContinuationState(RuntimeAsyncTask task, Continuation value)
-                {
-                    Debug.Assert(task.m_stateObject == null);
-                    task.m_stateObject = value;
-                }
-
-                public static bool SetCompleted(RuntimeAsyncTask task)
-                {
-                    return task.TrySetResult();
-                }
-
-                public static void PostToSyncContext(RuntimeAsyncTask task, SynchronizationContext syncContext)
-                {
-                    syncContext.Post(s_postCallback, task);
-                }
-
-                public static void ValueTaskSourceOnCompleted(RuntimeAsyncTask task, IValueTaskSourceNotifier vtsNotifier, ValueTaskSourceOnCompletedFlags configFlags)
-                {
-                    vtsNotifier.OnCompleted(s_runContinuationAction, task, configFlags);
-                }
-
-                public static ref byte GetResultStorage(RuntimeAsyncTask task) => ref Unsafe.NullRef<byte>();
-            }
-        }
-
-        private static class RuntimeAsyncTaskCore
-        {
-            [StructLayout(LayoutKind.Explicit)]
-            private unsafe ref struct DispatcherInfo
-            {
-                // Dispatcher info for next dispatcher present on stack, or
-                // null if none.
-                [FieldOffset(0)]
-                public DispatcherInfo* Next;
-
-                // Next continuation the dispatcher will process.
-#if TARGET_64BIT
-                [FieldOffset(8)]
-#else
-                [FieldOffset(4)]
-#endif
-                public Continuation? NextContinuation;
-            }
-
-            // Information about current task dispatching, to be used for async
-            // stackwalking.
-            [ThreadStatic]
-            private static unsafe DispatcherInfo* t_dispatcherInfo;
-
-            public static unsafe void DispatchContinuations<T, TOps>(T task) where T : Task, ITaskCompletionAction where TOps : IRuntimeAsyncTaskOps<T>
+            private unsafe void DispatchContinuations()
             {
                 ExecutionAndSyncBlockStore contexts = default;
                 contexts.Push();
 
-                DispatcherInfo dispatcherInfo;
-                dispatcherInfo.Next = t_dispatcherInfo;
-                dispatcherInfo.NextContinuation = TOps.MoveContinuationState(task);
-                t_dispatcherInfo = &dispatcherInfo;
+                RuntimeAsyncTaskCore.DispatcherInfo dispatcherInfo;
+                dispatcherInfo.Next = RuntimeAsyncTaskCore.t_dispatcherInfo;
+                dispatcherInfo.NextContinuation = MoveContinuationState();
+                RuntimeAsyncTaskCore.t_dispatcherInfo = &dispatcherInfo;
 
                 while (true)
                 {
@@ -487,15 +329,15 @@ namespace System.Runtime.CompilerServices
                         Continuation? nextContinuation = curContinuation.Next;
                         dispatcherInfo.NextContinuation = nextContinuation;
 
-                        ref byte resultLoc = ref nextContinuation != null ? ref nextContinuation.GetResultStorageOrNull() : ref TOps.GetResultStorage(task);
+                        ref byte resultLoc = ref nextContinuation != null ? ref nextContinuation.GetResultStorageOrNull() : ref GetResultStorage();
                         Continuation? newContinuation = curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
 
                         if (newContinuation != null)
                         {
                             newContinuation.Next = nextContinuation;
-                            HandleSuspended<T, TOps>(task);
+                            HandleSuspended();
                             contexts.Pop();
-                            t_dispatcherInfo = dispatcherInfo.Next;
+                            RuntimeAsyncTaskCore.t_dispatcherInfo = dispatcherInfo.Next;
                             return;
                         }
                     }
@@ -506,12 +348,12 @@ namespace System.Runtime.CompilerServices
                         {
                             // Tail of AsyncTaskMethodBuilderT.SetException
                             bool successfullySet = ex is OperationCanceledException oce ?
-                                task.TrySetCanceled(oce.CancellationToken, oce) :
-                                task.TrySetException(ex);
+                                TrySetCanceled(oce.CancellationToken, oce) :
+                                TrySetException(ex);
 
                             contexts.Pop();
 
-                            t_dispatcherInfo = dispatcherInfo.Next;
+                            RuntimeAsyncTaskCore.t_dispatcherInfo = dispatcherInfo.Next;
 
                             if (!successfullySet)
                             {
@@ -527,11 +369,11 @@ namespace System.Runtime.CompilerServices
 
                     if (dispatcherInfo.NextContinuation == null)
                     {
-                        bool successfullySet = TOps.SetCompleted(task);
+                        bool successfullySet = TrySetResult(m_result);
 
                         contexts.Pop();
 
-                        t_dispatcherInfo = dispatcherInfo.Next;
+                        RuntimeAsyncTaskCore.t_dispatcherInfo = dispatcherInfo.Next;
 
                         if (!successfullySet)
                         {
@@ -541,10 +383,10 @@ namespace System.Runtime.CompilerServices
                         return;
                     }
 
-                    if (QueueContinuationFollowUpActionIfNecessary<T, TOps>(task, dispatcherInfo.NextContinuation))
+                    if (QueueContinuationFollowUpActionIfNecessary(dispatcherInfo.NextContinuation))
                     {
                         contexts.Pop();
-                        t_dispatcherInfo = dispatcherInfo.Next;
+                        RuntimeAsyncTaskCore.t_dispatcherInfo = dispatcherInfo.Next;
                         return;
                     }
                 }
@@ -561,7 +403,7 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
-            public static void HandleSuspended<T, TOps>(T task) where T : Task, ITaskCompletionAction where TOps : IRuntimeAsyncTaskOps<T>
+            public void HandleSuspended()
             {
                 ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
 
@@ -592,22 +434,22 @@ namespace System.Runtime.CompilerServices
 
                 Debug.Assert((headContinuation.Flags & continueFlags) == 0);
 
-                TOps.SetContinuationState(task, headContinuation);
+                SetContinuationState(headContinuation);
 
                 try
                 {
                     if (critNotifier != null)
                     {
-                        critNotifier.UnsafeOnCompleted(TOps.GetContinuationAction(task));
+                        critNotifier.UnsafeOnCompleted(GetContinuationAction());
                     }
                     else if (taskNotifier != null)
                     {
                         // Runtime async callable wrapper for task returning
                         // method. This implements the context transparent
                         // forwarding and makes these wrappers minimal cost.
-                        if (!taskNotifier.TryAddCompletionAction(task))
+                        if (!taskNotifier.TryAddCompletionAction(this))
                         {
-                            ThreadPool.UnsafeQueueUserWorkItemInternal(task, preferLocal: true);
+                            ThreadPool.UnsafeQueueUserWorkItemInternal(this, preferLocal: true);
                         }
                     }
                     else if (vtsNotifier != null)
@@ -645,12 +487,12 @@ namespace System.Runtime.CompilerServices
 
                         // Clear continuation flags, so that continuation runs transparently
                         nextUserContinuation.Flags &= ~continueFlags;
-                        TOps.ValueTaskSourceOnCompleted(task, vtsNotifier, configFlags);
+                        vtsNotifier.OnCompleted(s_runContinuationAction, this, configFlags);
                     }
                     else
                     {
                         Debug.Assert(notifier != null);
-                        notifier.OnCompleted(TOps.GetContinuationAction(task));
+                        notifier.OnCompleted(GetContinuationAction());
                     }
                 }
                 catch (Exception ex)
@@ -659,7 +501,7 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
-            private static bool QueueContinuationFollowUpActionIfNecessary<T, TOps>(T task, Continuation continuation) where T : Task where TOps : IRuntimeAsyncTaskOps<T>
+            private bool QueueContinuationFollowUpActionIfNecessary(Continuation continuation)
             {
                 if ((continuation.Flags & ContinuationFlags.ContinueOnThreadPool) != 0)
                 {
@@ -674,8 +516,8 @@ namespace System.Runtime.CompilerServices
                         }
                     }
 
-                    TOps.SetContinuationState(task, continuation);
-                    ThreadPool.UnsafeQueueUserWorkItemInternal(task, preferLocal: true);
+                    SetContinuationState(continuation);
+                    ThreadPool.UnsafeQueueUserWorkItemInternal(this, preferLocal: true);
                     return true;
                 }
 
@@ -691,11 +533,11 @@ namespace System.Runtime.CompilerServices
                         return false;
                     }
 
-                    TOps.SetContinuationState(task, continuation);
+                    SetContinuationState(continuation);
 
                     try
                     {
-                        TOps.PostToSyncContext(task, continuationSyncCtx);
+                        continuationSyncCtx.Post(s_postCallback, this);
                     }
                     catch (Exception ex)
                     {
@@ -711,9 +553,9 @@ namespace System.Runtime.CompilerServices
                     Debug.Assert(continuationContext is TaskScheduler { });
                     TaskScheduler sched = (TaskScheduler)continuationContext;
 
-                    TOps.SetContinuationState(task, continuation);
+                    SetContinuationState(continuation);
                     // TODO: We do not need TaskSchedulerAwaitTaskContinuation here, just need to refactor its Run method...
-                    var taskSchedCont = new TaskSchedulerAwaitTaskContinuation(sched, TOps.GetContinuationAction(task), flowExecutionContext: false);
+                    var taskSchedCont = new TaskSchedulerAwaitTaskContinuation(sched, GetContinuationAction(), flowExecutionContext: false);
                     taskSchedCont.Run(Task.CompletedTask, canInlineContinuationTask: true);
 
                     return true;
@@ -721,6 +563,43 @@ namespace System.Runtime.CompilerServices
 
                 return false;
             }
+
+            private static readonly SendOrPostCallback s_postCallback = static state =>
+            {
+                Debug.Assert(state is RuntimeAsyncTask<T>);
+                ((RuntimeAsyncTask<T>)state).DispatchContinuations();
+            };
+
+            public static readonly Action<object?> s_runContinuationAction = static state =>
+            {
+                Debug.Assert(state is RuntimeAsyncTask<T>);
+                ((RuntimeAsyncTask<T>)state).DispatchContinuations();
+            };
+        }
+
+        internal static class RuntimeAsyncTaskCore
+        {
+            [StructLayout(LayoutKind.Explicit)]
+            internal unsafe ref struct DispatcherInfo
+            {
+                // Dispatcher info for next dispatcher present on stack, or
+                // null if none.
+                [FieldOffset(0)]
+                public DispatcherInfo* Next;
+
+                // Next continuation the dispatcher will process.
+#if TARGET_64BIT
+                [FieldOffset(8)]
+#else
+                [FieldOffset(4)]
+#endif
+                public Continuation? NextContinuation;
+            }
+
+            // Information about current task dispatching, to be used for async
+            // stackwalking.
+            [ThreadStatic]
+            internal static unsafe DispatcherInfo* t_dispatcherInfo;
         }
 
         // Change return type to RuntimeAsyncTask<T?> -- no benefit since this is used for Task returning thunks only
@@ -736,7 +615,7 @@ namespace System.Runtime.CompilerServices
 
         private static Task FinalizeTaskReturningThunk()
         {
-            RuntimeAsyncTask result = new();
+            RuntimeAsyncTask<VoidTaskResult> result = new();
             result.HandleSuspended();
             return result;
         }


### PR DESCRIPTION
Removes some abstraction and unifies behavior with async 1 at the cost of these rarely created tasks being slightly larger for void methods.

Fix #122235