### PR TITLE
[browser] Map integrity from boot config to asset hash

### DIFF
--- a/src/mono/browser/runtime/dotnet.d.ts
+++ b/src/mono/browser/runtime/dotnet.d.ts
@@ -289,17 +289,17 @@ type Asset = {
 };
 type WasmAsset = Asset & {
     name: string;
-    hash?: string | null | "";
+    integrity?: string | null | "";
 };
 type AssemblyAsset = Asset & {
     virtualPath: string;
     name: string;
-    hash?: string | null | "";
+    integrity?: string | null | "";
 };
 type PdbAsset = Asset & {
     virtualPath: string;
     name: string;
-    hash?: string | null | "";
+    integrity?: string | null | "";
 };
 type JsAsset = Asset & {
     /**
@@ -315,12 +315,12 @@ type SymbolsAsset = Asset & {
 type VfsAsset = Asset & {
     virtualPath: string;
     name: string;
-    hash?: string | null | "";
+    integrity?: string | null | "";
 };
 type IcuAsset = Asset & {
     virtualPath: string;
     name: string;
-    hash?: string | null | "";
+    integrity?: string | null | "";
 };
 /**
  * A "key" is name of the file, a "value" is optional hash for integrity check.

--- a/src/mono/browser/runtime/loader/assets.ts
+++ b/src/mono/browser/runtime/loader/assets.ts
@@ -100,6 +100,9 @@ function convert_single_asset (assetsCollection: AssetEntryInternal[], resource:
 
     const assetEntry = resource[0] as AssetEntryInternal;
     assetEntry.behavior = behavior;
+    if ((assetEntry as any).integrity) {
+        assetEntry.hash = (assetEntry as any).integrity;
+    }
 
     set_single_asset(assetEntry);
 

--- a/src/mono/browser/runtime/loader/assets.ts
+++ b/src/mono/browser/runtime/loader/assets.ts
@@ -309,6 +309,10 @@ export function prepareAssets () {
         const addAsset = (asset: Asset, behavior: AssetBehaviors, isCore: boolean) => {
             const assetEntry = asset as AssetEntryInternal;
             assetEntry.behavior = behavior;
+            if ((asset as any).integrity) {
+                assetEntry.hash = (asset as any).integrity;
+            }
+
             if (isCore) {
                 assetEntry.isCore = true;
                 coreAssetsToLoad.push(assetEntry);

--- a/src/mono/browser/runtime/types/index.ts
+++ b/src/mono/browser/runtime/types/index.ts
@@ -250,19 +250,19 @@ export type Asset = {
 
 export type WasmAsset = Asset & {
     name: string;
-    hash?: string | null | "";
+    integrity?: string | null | "";
 }
 
 export type AssemblyAsset = Asset & {
     virtualPath: string;
     name: string; // actually URL
-    hash?: string | null | "";
+    integrity?: string | null | "";
 }
 
 export type PdbAsset = Asset & {
     virtualPath: string;
     name: string; // actually URL
-    hash?: string | null | "";
+    integrity?: string | null | "";
 }
 
 export type JsAsset = Asset & {
@@ -282,13 +282,13 @@ export type SymbolsAsset = Asset & {
 export type VfsAsset = Asset & {
     virtualPath: string;
     name: string; // actually URL
-    hash?: string | null | "";
+    integrity?: string | null | "";
 }
 
 export type IcuAsset = Asset & {
     virtualPath: string;
     name: string; // actually URL
-    hash?: string | null | "";
+    integrity?: string | null | "";
 }
 
 /**

--- a/src/mono/wasm/Wasm.Build.Tests/ModuleConfigTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/ModuleConfigTests.cs
@@ -118,7 +118,7 @@ public class ModuleConfigTests : WasmTemplateTestsBase
             TestScenario: "AssetIntegrity"
         ));
         Assert.False(
-            result.TestOutput.Any(m => !m.Contains(".js") && m.Contains("has integrity 'undefined'")),
+            result.TestOutput.Any(m => (!m.Contains(".js") || !m.Contains(".json")) && m.Contains("has integrity ''")),
             "There are assets without integrity hash"
         );
     }

--- a/src/mono/wasm/Wasm.Build.Tests/ModuleConfigTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/ModuleConfigTests.cs
@@ -118,7 +118,7 @@ public class ModuleConfigTests : WasmTemplateTestsBase
             TestScenario: "AssetIntegrity"
         ));
         Assert.False(
-            result.TestOutput.Any(m => (!m.Contains(".js") || !m.Contains(".json")) && m.Contains("has integrity ''")),
+            result.TestOutput.Any(m => !m.Contains(".js") && !m.Contains(".json") && m.Contains("has integrity ''")),
             "There are assets without integrity hash"
         );
     }

--- a/src/mono/wasm/Wasm.Build.Tests/ModuleConfigTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/ModuleConfigTests.cs
@@ -105,4 +105,21 @@ public class ModuleConfigTests : WasmTemplateTestsBase
             m => Assert.Equal("Managed code has run", m)
         );
     }
+
+    [Fact, TestCategory("bundler-friendly")]
+    public async Task AssetIntegrity()
+    {
+        Configuration config = Configuration.Debug;
+        ProjectInfo info = CopyTestAsset(config, false, TestAsset.WasmBasicTestApp, $"AssetIntegrity");
+        PublishProject(info, config);
+
+        var result = await RunForPublishWithWebServer(new BrowserRunOptions(
+            Configuration: config,
+            TestScenario: "AssetIntegrity"
+        ));
+        Assert.False(
+            result.TestOutput.Any(m => !m.Contains(".js") && m.Contains("has integrity 'undefined'")),
+            "There are assets without integrity hash"
+        );
+    }
 }

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
@@ -96,10 +96,10 @@ switch (testCase) {
         });
         break;
     case "AssetIntegrity":
-            dotnet.withResourceLoader((type, name, defaultUri, integrity, behavior) => {
-                testOutput(`Asset '${name}' has integrity '${integrity}'`);
-                return defaultUri;
-            });
+        dotnet.withResourceLoader((type, name, defaultUri, integrity, behavior) => {
+            testOutput(`Asset '${name}' has integrity '${integrity}'`);
+            return defaultUri;
+        });
         break;
     case "OutErrOverrideWorks":
         dotnet.withModuleConfig({

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
@@ -100,6 +100,7 @@ switch (testCase) {
                 testOutput(`Asset '${name}' has integrity '${integrity}'`);
                 return defaultUri;
             });
+        break;
     case "OutErrOverrideWorks":
         dotnet.withModuleConfig({
             out: (message) => {

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/main.js
@@ -95,6 +95,11 @@ switch (testCase) {
             }
         });
         break;
+    case "AssetIntegrity":
+            dotnet.withResourceLoader((type, name, defaultUri, integrity, behavior) => {
+                testOutput(`Asset '${name}' has integrity '${integrity}'`);
+                return defaultUri;
+            });
     case "OutErrOverrideWorks":
         dotnet.withModuleConfig({
             out: (message) => {
@@ -238,6 +243,7 @@ try {
             exit(0);
             break;
         case "DownloadResourceProgressTest":
+        case "AssetIntegrity":
             exit(0);
             break;
         case "OutErrOverrideWorks":


### PR DESCRIPTION
Assets generated by boot config generator contains field `integrity`, but internal assets structure contains field `hash`. This PR copies the value from `integrity` to `hash` to minimize the diff. It is a regression from boot config structure change from https://github.com/dotnet/runtime/pull/116300.

Fixes https://github.com/dotnet/runtime/issues/121876