### PR TITLE
Fix condition checks for Crossgen2 in AppleBuild.props

### DIFF
--- a/src/mono/msbuild/apple/build/AppleBuild.props
+++ b/src/mono/msbuild/apple/build/AppleBuild.props
@@ -21,9 +21,9 @@
   <!-- Tracking issue: https://github.com/dotnet/runtime/issues/119006
        ReadyToRun settings for CoreCLR on Apple platforms.
        This can be removed once we upstream Mach-O support in the targets to the SDK -->
-  <Import Project="$(Crossgen2SdkOverridePropsPath)" Condition="'$(PublishReadyToRun)' == 'true' and '$(UseMonoRuntime)' != 'true' and '$(Crossgen2SdkOverridePropsPath)' != ''" />
+  <Import Project="$(Crossgen2SdkOverridePropsPath)" Condition="'$(PublishReadyToRun)' == 'true' and '$(UseMonoRuntime)' != 'true' and '$(Crossgen2SdkOverridePropsPath)' != '' and Exists('$(Crossgen2SdkOverridePropsPath)')" />
   <PropertyGroup Condition="'$(PublishReadyToRun)' == 'true' and '$(UseMonoRuntime)' != 'true'">
-    <AfterMicrosoftNETSdkTargets Condition="'$(Crossgen2SdkOverrideTargetsPath)' != ''">$(AfterMicrosoftNETSdkTargets);$(Crossgen2SdkOverrideTargetsPath)</AfterMicrosoftNETSdkTargets>
+    <AfterMicrosoftNETSdkTargets Condition="'$(Crossgen2SdkOverrideTargetsPath)' != '' and Exists('$(Crossgen2SdkOverrideTargetsPath)')">$(AfterMicrosoftNETSdkTargets);$(Crossgen2SdkOverrideTargetsPath)</AfterMicrosoftNETSdkTargets>
     <AfterMicrosoftNETSdkTargets>$(AfterMicrosoftNETSdkTargets);$(MonoProjectRoot)\msbuild\apple\build\AppleBuild.ReadyToRun.targets</AfterMicrosoftNETSdkTargets>
   </PropertyGroup>
 


### PR DESCRIPTION
## Description

This PR fixes condition checks for Crossgen2 in AppleBuild.props.

```
The imported project "/__w/1/s/artifacts/bin/Crossgen2Tasks/Checked/net10.0/Microsoft.NET.CrossGen.props" was not found.
```