### PR TITLE
Fix Windows PQC version boundary

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTests.cs
@@ -35,7 +35,7 @@ namespace System.Security.Cryptography.Tests
         }
 
         private static bool PlatformSupportsMLDsa() =>
-            PlatformDetection.IsOpenSsl3_5 || PlatformDetection.IsWindows10Version26200OrGreater;
+            PlatformDetection.IsOpenSsl3_5 || PlatformDetection.IsWindows10Version26100OrGreater;
 
         [Fact]
         public static void DisposeIsCalledOnImplementation()

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemImplementationTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemImplementationTests.cs
@@ -55,6 +55,6 @@ namespace System.Security.Cryptography.Tests
 
         private static bool PlatformSupportsMLKem() =>
             PlatformDetection.IsOpenSsl3_5 ||
-            PlatformDetection.IsWindows10Version26200OrGreater;
+            PlatformDetection.IsWindows10Version26100OrGreater;
     }
 }

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -69,8 +69,8 @@ namespace System
         // Windows 11 aka 21H2
         public static bool IsWindows10Version22000OrGreater => IsWindowsVersionOrLater(10, 0, 22000);
 
-        // Windows 11 2025 Update (25H2)
-        public static bool IsWindows10Version26200OrGreater => IsWindowsVersionOrLater(10, 0, 26200);
+        // Windows 11 2024 Update (24H2)
+        public static bool IsWindows10Version26100OrGreater => IsWindowsVersionOrLater(10, 0, 26100);
 
         public static bool IsWindowsIoTCore
         {


### PR DESCRIPTION
PQC was backported to 24H2, and CI picked that up in Windows update, so our version boundary test is failing. This adjusts the test to the correct version boundary.

Contributes to #122228