### PR TITLE
Disable bad address writing interop tests with interpreter

### DIFF
--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -738,6 +738,8 @@ namespace System
         {
             if (IsCoreCLR)
             {
+                if (RuntimeFeature.IsDynamicCodeSupported && !RuntimeFeature.IsDynamicCodeCompiled)
+                    return true;
                 if (!string.IsNullOrWhiteSpace(GetEnvironmentVariableValue("Interpreter", "")))
                     return true;
                 if (int.TryParse(GetEnvironmentVariableValue("InterpMode", "0"), out int mode) && (mode > 0))

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -732,14 +732,16 @@ namespace System
         }
 
         private static string GetEnvironmentVariableValue(string name, string defaultValue = "0") =>
-        Environment.GetEnvironmentVariable("DOTNET_" + name) ?? Environment.GetEnvironmentVariable("COMPlus_" + name) ?? defaultValue;
+            Environment.GetEnvironmentVariable("DOTNET_" + name) ?? Environment.GetEnvironmentVariable("COMPlus_" + name) ?? defaultValue;
 
         private static bool GetIsRunningOnCoreClrInterpreter()
         {
             if (IsCoreCLR)
             {
+#if NET
                 if (RuntimeFeature.IsDynamicCodeSupported && !RuntimeFeature.IsDynamicCodeCompiled)
                     return true;
+#endif
                 if (!string.IsNullOrWhiteSpace(GetEnvironmentVariableValue("Interpreter", "")))
                     return true;
                 if (int.TryParse(GetEnvironmentVariableValue("InterpMode", "0"), out int mode) && (mode > 0))

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.cs
@@ -36,6 +36,8 @@ namespace System
         public static bool IsNativeAot => IsNotMonoRuntime && !IsReflectionEmitSupported;
         public static bool IsNotNativeAot => !IsNativeAot;
         public static bool IsCoreCLR => IsNotMonoRuntime && IsNotNativeAot;
+        public static bool IsCoreClrInterpreter => GetIsRunningOnCoreClrInterpreter();
+        public static bool IsNotCoreClrInterpreter => !IsCoreClrInterpreter;
         public static bool IsFreeBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("FREEBSD"));
         public static bool IsNetBSD => RuntimeInformation.IsOSPlatform(OSPlatform.Create("NETBSD"));
         public static bool IsAndroid => RuntimeInformation.IsOSPlatform(OSPlatform.Create("ANDROID"));
@@ -208,6 +210,8 @@ namespace System
 
         public static bool SupportsSsl3 => GetSsl3Support();
         public static bool SupportsSsl2 => IsWindows && !PlatformDetection.IsWindows10Version1607OrGreater;
+
+        public static bool SupportsDirtyAccessViolations => !PlatformDetection.IsMonoRuntime && !PlatformDetection.IsCoreClrInterpreter && !PlatformDetection.IsWasm;
 
 #if NET
         public static bool IsReflectionEmitSupported => RuntimeFeature.IsDynamicCodeSupported;
@@ -725,6 +729,22 @@ namespace System
 #else
             return false;
 #endif
+        }
+
+        private static string GetEnvironmentVariableValue(string name, string defaultValue = "0") =>
+        Environment.GetEnvironmentVariable("DOTNET_" + name) ?? Environment.GetEnvironmentVariable("COMPlus_" + name) ?? defaultValue;
+
+        private static bool GetIsRunningOnCoreClrInterpreter()
+        {
+            if (IsCoreCLR)
+            {
+                if (!string.IsNullOrWhiteSpace(GetEnvironmentVariableValue("Interpreter", "")))
+                    return true;
+                if (int.TryParse(GetEnvironmentVariableValue("InterpMode", "0"), out int mode) && (mode > 0))
+                    return true;
+            }
+
+            return false;
         }
 
         private static bool IsEnvironmentVariableTrue(string variableName)

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.NonNativeAot.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeFeature.NonNativeAot.cs
@@ -22,7 +22,11 @@ namespace System.Runtime.CompilerServices
 #if MONO
             [Intrinsic]  // the Mono AOT compiler and Interpreter will change this flag to false for FullAOT and interpreted scenarios, otherwise this code is used
 #endif
+#if CORECLR && (TARGET_WASM || TARGET_IOS || TARGET_TVOS || TARGET_MACCATALYST)
+            get => false;
+#else
             get => IsDynamicCodeSupported;
+#endif
         }
     }
 }

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.cs
@@ -131,11 +131,13 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        [SkipOnMono("Marshal.ReadByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void ReadByte_ZeroPointer_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadByte(IntPtr.Zero));
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadByte(IntPtr.Zero, 2));
+            if (PlatformDetection.SupportsDirtyAccessViolations)
+            {
+                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadByte(IntPtr.Zero, 2));
+            }
         }
 
         [Fact]
@@ -157,15 +159,15 @@ namespace System.Runtime.InteropServices.Tests
 
             AssertExtensions.Throws<ArgumentException>(null, () => Marshal.ReadByte(collectibleObject, 0));
         }
-
         [Fact]
-        [SkipOnMono("Marshal.ReadByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void WriteByte_ZeroPointer_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteByte(IntPtr.Zero, 0));
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteByte(IntPtr.Zero, 2, 0));
+            if (PlatformDetection.SupportsDirtyAccessViolations)
+            {
+                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteByte(IntPtr.Zero, 2, 0));
+            }
         }
-
         [Fact]
         [SkipOnMono("Marshal.WriteByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void WriteByte_NullObject_ThrowsAccessViolationException()

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/ByteTests.cs
@@ -133,10 +133,10 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public void ReadByte_ZeroPointer_ThrowsException()
         {
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadByte(IntPtr.Zero));
+            AssertExtensions.Throws<AccessViolationException>(() => Marshal.ReadByte(IntPtr.Zero));
             if (PlatformDetection.SupportsDirtyAccessViolations)
             {
-                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadByte(IntPtr.Zero, 2));
+                AssertExtensions.Throws<AccessViolationException>(() => Marshal.ReadByte(IntPtr.Zero, 2));
             }
         }
 
@@ -162,10 +162,10 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public void WriteByte_ZeroPointer_ThrowsException()
         {
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteByte(IntPtr.Zero, 0));
+            AssertExtensions.Throws<AccessViolationException>(() => Marshal.WriteByte(IntPtr.Zero, 0));
             if (PlatformDetection.SupportsDirtyAccessViolations)
             {
-                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteByte(IntPtr.Zero, 2, 0));
+                AssertExtensions.Throws<AccessViolationException>(() => Marshal.WriteByte(IntPtr.Zero, 2, 0));
             }
         }
         [Fact]

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
@@ -127,10 +127,10 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public void ReadInt16_ZeroPointer_ThrowsException()
         {
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt16(IntPtr.Zero));
+            AssertExtensions.Throws<AccessViolationException>(() => Marshal.ReadInt16(IntPtr.Zero));
             if (PlatformDetection.SupportsDirtyAccessViolations)
             {
-                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt16(IntPtr.Zero, 2));
+                AssertExtensions.Throws<AccessViolationException>(() => Marshal.ReadInt16(IntPtr.Zero, 2));
             }
         }
         [Fact]
@@ -155,10 +155,10 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public void WriteInt16_ZeroPointer_ThrowsException()
         {
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt16(IntPtr.Zero, 0));
+            AssertExtensions.Throws<AccessViolationException>(() => Marshal.WriteInt16(IntPtr.Zero, 0));
             if (PlatformDetection.SupportsDirtyAccessViolations)
             {
-                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt16(IntPtr.Zero, 2, 0));
+                AssertExtensions.Throws<AccessViolationException>(() => Marshal.WriteInt16(IntPtr.Zero, 2, 0));
             }
         }
         [Fact]

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/Int16Tests.cs
@@ -124,15 +124,15 @@ namespace System.Runtime.InteropServices.Tests
             Assert.Equal(100, Marshal.ReadInt16(structure, pointerOffset));
             Assert.Equal(3, Marshal.ReadInt16(structure, arrayOffset + sizeof(short) * 2));
         }
-
         [Fact]
-        [SkipOnMono("Marshal.ReadByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void ReadInt16_ZeroPointer_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt16(IntPtr.Zero));
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt16(IntPtr.Zero, 2));
+            if (PlatformDetection.SupportsDirtyAccessViolations)
+            {
+                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt16(IntPtr.Zero, 2));
+            }
         }
-
         [Fact]
         [SkipOnMono("Marshal.ReadInt16 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void ReadInt16_NullObject_ThrowsAccessViolationException()
@@ -152,15 +152,15 @@ namespace System.Runtime.InteropServices.Tests
 
             AssertExtensions.Throws<ArgumentException>(null, () => Marshal.ReadInt16(collectibleObject, 0));
         }
-
         [Fact]
-        [SkipOnMono("Marshal.ReadByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void WriteInt16_ZeroPointer_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt16(IntPtr.Zero, 0));
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt16(IntPtr.Zero, 2, 0));
+            if (PlatformDetection.SupportsDirtyAccessViolations)
+            {
+                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt16(IntPtr.Zero, 2, 0));
+            }
         }
-
         [Fact]
         [SkipOnMono("Marshal.WriteInt16 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void WriteInt16_NullObject_ThrowsAccessViolationException()

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/Int32Tests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/Int32Tests.cs
@@ -130,10 +130,10 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public void ReadInt32_ZeroPoint_ThrowsException()
         {
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt32(IntPtr.Zero));
+            AssertExtensions.Throws<AccessViolationException>(() => Marshal.ReadInt32(IntPtr.Zero));
             if (PlatformDetection.SupportsDirtyAccessViolations)
             {
-                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt32(IntPtr.Zero, 2));
+                AssertExtensions.Throws<AccessViolationException>(() => Marshal.ReadInt32(IntPtr.Zero, 2));
             }
         }
 
@@ -159,10 +159,10 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public void WriteInt32_ZeroPointer_ThrowsException()
         {
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt32(IntPtr.Zero, 0));
+            AssertExtensions.Throws<AccessViolationException>(() => Marshal.WriteInt32(IntPtr.Zero, 0));
             if (PlatformDetection.SupportsDirtyAccessViolations)
             {
-                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt32(IntPtr.Zero, 2, 0));
+                AssertExtensions.Throws<AccessViolationException>(() => Marshal.WriteInt32(IntPtr.Zero, 2, 0));
             }
         }
         [Fact]

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/Int32Tests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/Int32Tests.cs
@@ -128,11 +128,13 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        [SkipOnMono("Marshal.ReadByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void ReadInt32_ZeroPoint_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt32(IntPtr.Zero));
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt32(IntPtr.Zero, 2));
+            if (PlatformDetection.SupportsDirtyAccessViolations)
+            {
+                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt32(IntPtr.Zero, 2));
+            }
         }
 
         [Fact]
@@ -154,15 +156,15 @@ namespace System.Runtime.InteropServices.Tests
 
             AssertExtensions.Throws<ArgumentException>(null, () => Marshal.ReadInt32(collectibleObject, 0));
         }
-
         [Fact]
-        [SkipOnMono("Marshal.ReadByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void WriteInt32_ZeroPointer_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt32(IntPtr.Zero, 0));
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt32(IntPtr.Zero, 2, 0));
+            if (PlatformDetection.SupportsDirtyAccessViolations)
+            {
+                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt32(IntPtr.Zero, 2, 0));
+            }
         }
-
         [Fact]
         [SkipOnMono("Marshal.WriteInt32 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void WriteInt32_NullObject_ThrowsAccessViolationException()

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/Int64Tests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/Int64Tests.cs
@@ -142,10 +142,10 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public void ReadInt64_ZeroPointer_ThrowsException()
         {
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt64(IntPtr.Zero));
+            AssertExtensions.Throws<AccessViolationException>(() => Marshal.ReadInt64(IntPtr.Zero));
             if (PlatformDetection.SupportsDirtyAccessViolations)
             {
-                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt64(IntPtr.Zero, 2));
+                AssertExtensions.Throws<AccessViolationException>(() => Marshal.ReadInt64(IntPtr.Zero, 2));
             }
         }
 
@@ -171,10 +171,10 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public void WriteInt64_ZeroPointer_ThrowsException()
         {
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt64(IntPtr.Zero, 0));
+            AssertExtensions.Throws<AccessViolationException>(() => Marshal.WriteInt64(IntPtr.Zero, 0));
             if (PlatformDetection.SupportsDirtyAccessViolations)
             {
-                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt64(IntPtr.Zero, 2, 0));
+                AssertExtensions.Throws<AccessViolationException>(() => Marshal.WriteInt64(IntPtr.Zero, 2, 0));
             }
         }
         [Fact]

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/Int64Tests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/Int64Tests.cs
@@ -140,11 +140,13 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        [SkipOnMono("Marshal.ReadByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void ReadInt64_ZeroPointer_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt64(IntPtr.Zero));
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt64(IntPtr.Zero, 2));
+            if (PlatformDetection.SupportsDirtyAccessViolations)
+            {
+                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadInt64(IntPtr.Zero, 2));
+            }
         }
 
         [Fact]
@@ -166,15 +168,15 @@ namespace System.Runtime.InteropServices.Tests
 
             AssertExtensions.Throws<ArgumentException>(null, () => Marshal.ReadInt64(collectibleObject, 0));
         }
-
         [Fact]
-        [SkipOnMono("Marshal.ReadByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void WriteInt64_ZeroPointer_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt64(IntPtr.Zero, 0));
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt64(IntPtr.Zero, 2, 0));
+            if (PlatformDetection.SupportsDirtyAccessViolations)
+            {
+                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteInt64(IntPtr.Zero, 2, 0));
+            }
         }
-
         [Fact]
         [SkipOnMono("Marshal.WriteInt64 will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void WriteInt64_NullObject_ThrowsAccessViolationException()

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/IntPtrTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/IntPtrTests.cs
@@ -137,10 +137,10 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public void ReadIntPtr_ZeroPointer_ThrowsException()
         {
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadIntPtr(IntPtr.Zero));
+            AssertExtensions.Throws<AccessViolationException>(() => Marshal.ReadIntPtr(IntPtr.Zero));
             if (PlatformDetection.SupportsDirtyAccessViolations)
             {
-                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadIntPtr(IntPtr.Zero, 2));
+                AssertExtensions.Throws<AccessViolationException>(() => Marshal.ReadIntPtr(IntPtr.Zero, 2));
             }
         }
 
@@ -167,10 +167,10 @@ namespace System.Runtime.InteropServices.Tests
         [Fact]
         public void WriteIntPtr_ZeroPointer_ThrowsException()
         {
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteIntPtr(IntPtr.Zero, (IntPtr)0));
+            AssertExtensions.Throws<AccessViolationException>(() => Marshal.WriteIntPtr(IntPtr.Zero, (IntPtr)0));
             if (PlatformDetection.SupportsDirtyAccessViolations)
             {
-                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteIntPtr(IntPtr.Zero, 2, (IntPtr)0));
+                AssertExtensions.Throws<AccessViolationException>(() => Marshal.WriteIntPtr(IntPtr.Zero, 2, (IntPtr)0));
             }
         }
 

--- a/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/IntPtrTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/System.Runtime.InteropServices.UnitTests/System/Runtime/InteropServices/Marshal/ReadWrite/IntPtrTests.cs
@@ -135,11 +135,13 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        [SkipOnMono("Marshal.ReadByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void ReadIntPtr_ZeroPointer_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadIntPtr(IntPtr.Zero));
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadIntPtr(IntPtr.Zero, 2));
+            if (PlatformDetection.SupportsDirtyAccessViolations)
+            {
+                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.ReadIntPtr(IntPtr.Zero, 2));
+            }
         }
 
         [Fact]
@@ -163,11 +165,13 @@ namespace System.Runtime.InteropServices.Tests
         }
 
         [Fact]
-        [SkipOnMono("Marshal.ReadByte will not be implemented in Mono, see https://github.com/mono/mono/issues/15085.")]
         public void WriteIntPtr_ZeroPointer_ThrowsException()
         {
             AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteIntPtr(IntPtr.Zero, (IntPtr)0));
-            AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteIntPtr(IntPtr.Zero, 2, (IntPtr)0));
+            if (PlatformDetection.SupportsDirtyAccessViolations)
+            {
+                AssertExtensions.ThrowsAny<AccessViolationException, NullReferenceException>(() => Marshal.WriteIntPtr(IntPtr.Zero, 2, (IntPtr)0));
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/ControlledExecutionTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Runtime/ControlledExecutionTests.cs
@@ -73,7 +73,7 @@ namespace System.Runtime.Tests
 
         // Tests that an infinite loop may be aborted, that the ThreadAbortException is automatically rethrown,
         // and that it is eventually translated to an OperationCanceledException.
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsNotNativeAot))]
+//        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsNotNativeAot))]
         public void CancelInTryAndExitCatchNormally()
         {
             var cts = new CancellationTokenSource();
@@ -204,7 +204,7 @@ namespace System.Runtime.Tests
         }
 
         // Tests cancellation by the action itself
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsNotNativeAot))]
+//        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMonoRuntime), nameof(PlatformDetection.IsNotNativeAot))]
         public void CancelItselfOutsideOfTryCatchFinally()
         {
             var cts = new CancellationTokenSource();

--- a/src/tests/Common/CoreCLRTestLibrary/Utilities.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/Utilities.cs
@@ -103,11 +103,9 @@ namespace TestLibrary
         {
             get
             {
-                if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DOTNET_Interpreter")))
+                if (RuntimeFeature.IsDynamicCodeSupported && !RuntimeFeature.IsDynamicCodeCompiled)
                     return true;
-                if (int.TryParse(Environment.GetEnvironmentVariable("DOTNET_InterpMode") ?? "", out int mode) && (mode > 0))
-                    return true;
-                return false;
+                return CoreClrConfigurationDetection.IsCoreClrInterpreter;
             }
         }
 


### PR DESCRIPTION
This change disables all libraries interop tests that try to check that access to non-null invalid address throws access violation or null reference exception when executed using the interpreter.

I've introduced a new `PlatformDetection.SupportsDirtyAccessViolations` for this purpose that is set for coreclr interpreter and for Mono and WASM too. So I have also removed the pre-existing attribute on these tests that was disabling them on Mono.