### PR TITLE
[release/10.0] Backport PQC Boundary Condition Test Fixes

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTests.cs
@@ -35,7 +35,7 @@ namespace System.Security.Cryptography.Tests
         }
 
         private static bool PlatformSupportsMLDsa() =>
-            PlatformDetection.IsOpenSsl3_5 || PlatformDetection.IsWindows10Version26200OrGreater;
+            PlatformDetection.IsOpenSsl3_5 || PlatformDetection.IsWindows10Version26100OrGreater;
 
         [Fact]
         public static void DisposeIsCalledOnImplementation()

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/MLDsa/MLDsaTests.cs
@@ -35,7 +35,7 @@ namespace System.Security.Cryptography.Tests
         }
 
         private static bool PlatformSupportsMLDsa() =>
-            PlatformDetection.IsOpenSsl3_5 || PlatformDetection.IsWindows10Version27858OrGreater;
+            PlatformDetection.IsOpenSsl3_5 || PlatformDetection.IsWindows10Version26200OrGreater;
 
         [Fact]
         public static void DisposeIsCalledOnImplementation()

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemImplementationTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemImplementationTests.cs
@@ -55,6 +55,6 @@ namespace System.Security.Cryptography.Tests
 
         private static bool PlatformSupportsMLKem() =>
             PlatformDetection.IsOpenSsl3_5 ||
-            PlatformDetection.IsWindows10Version26200OrGreater;
+            PlatformDetection.IsWindows10Version26100OrGreater;
     }
 }

--- a/src/libraries/Common/tests/System/Security/Cryptography/MLKemImplementationTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/MLKemImplementationTests.cs
@@ -55,6 +55,6 @@ namespace System.Security.Cryptography.Tests
 
         private static bool PlatformSupportsMLKem() =>
             PlatformDetection.IsOpenSsl3_5 ||
-            PlatformDetection.IsWindows10Version27858OrGreater;
+            PlatformDetection.IsWindows10Version26200OrGreater;
     }
 }

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -69,8 +69,8 @@ namespace System
         // Windows 11 aka 21H2
         public static bool IsWindows10Version22000OrGreater => IsWindowsVersionOrLater(10, 0, 22000);
 
-        // Windows 11 2025 Update (25H2)
-        public static bool IsWindows10Version26200OrGreater => IsWindowsVersionOrLater(10, 0, 26200);
+        // Windows 11 2024 Update (24H2)
+        public static bool IsWindows10Version26100OrGreater => IsWindowsVersionOrLater(10, 0, 26100);
 
         public static bool IsWindowsIoTCore
         {

--- a/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
+++ b/src/libraries/Common/tests/TestUtilities/System/PlatformDetection.Windows.cs
@@ -69,9 +69,8 @@ namespace System
         // Windows 11 aka 21H2
         public static bool IsWindows10Version22000OrGreater => IsWindowsVersionOrLater(10, 0, 22000);
 
-        // TODO: Update this to the first official PQC supported build when available.
-        // Windows 11 Insider Preview Build 27871 (Canary Channel)
-        public static bool IsWindows10Version27858OrGreater => IsWindowsVersionOrLater(10, 0, 27858);
+        // Windows 11 2025 Update (25H2)
+        public static bool IsWindows10Version26200OrGreater => IsWindowsVersionOrLater(10, 0, 26200);
 
         public static bool IsWindowsIoTCore
         {


### PR DESCRIPTION
Backports two pull requests to release/10.0.

* https://github.com/dotnet/runtime/pull/121972
* https://github.com/dotnet/runtime/pull/122298

cc @bartonjs 

## Customer Impact

These are test only changes. These changes react to Windows PQC being back ported to Windows 11 24H2 (Build 26100). These tests compare our feature-detection implementation vs. the Windows build. 

Issue for failing test: https://github.com/dotnet/runtime/issues/122228

- [ ] Customer reported
- [x] Found internally

## Regression

- [ ] Yes
- [x] No

## Testing

Tests that were failing are now passing in CI.

## Risk

None, test only changes.