### PR TITLE
Remove support for running illink on runtime tests while testing

### DIFF
--- a/docs/workflow/ci/triaging-failures.md
+++ b/docs/workflow/ci/triaging-failures.md
@@ -60,12 +60,6 @@ set RunningIlasmRoundTrip=1
 ```
 triggers an ildasm/ilasm round-trip test (that is, the test assembly is disassembled, then re-assembled, then run).
 
-And,
-```
-set DoLink=1
-```
-triggers ILLink testing.
-
 ## Product and test assets
 
 To reproduce and/or debug a test failure, you'll need the product and test assets. You can either build these using the normal build processes,

--- a/src/tests/Common/CLRTest.Execute.Bash.targets
+++ b/src/tests/Common/CLRTest.Execute.Bash.targets
@@ -274,94 +274,6 @@ fi
         <Description>Run the tests using the test watcher.</Description>
       </BashCLRTestExecutionScriptArgument>
     </ItemGroup>
-
-      <PropertyGroup>
-          <ReflectionRootsXml>$(AssemblyName).reflect.xml</ReflectionRootsXml>
-          <BashLinkerTestLaunchCmds>
-              <![CDATA[
-# Linker commands
-
-LinkBin=__Link
-Assemblies="-a System.Private.CoreLib"
-ReflectionRoots=
-
-shopt -s nullglob
-
-if [ ! -z "$DoLink" ];
-then
-  if [ ! -x "$ILLINK" ];
-  then
-    echo "Illink executable [$ILLINK] Invalid"
-    exit 1
-  fi
-
-  # Clean up old Linked binaries, if any
-  rm -rf $LinkBin
-
-  # Remove Native images, since the goal is to run from Linked binaries
-  rm -f *.ni.*
-
-  # Use hints for reflection roots, if provided in $(ReflectionRootsXml)
-  if [ -f $(ReflectionRootsXml) ];
-  then
-    ReflectionRoots="-x $(ReflectionRootsXml)"
-  fi
-
-  # Include all .exe files in this directory as entry points (some tests had multiple .exe file modules)
-  for bin in *.exe *.dll;
-  do
-    Assemblies="$Assemblies -a ${bin%.*}"
-  done
-
-  # Run dotnet-linker
-  # Run the Linker such that all assemblies except System.Private.Corlib.dll are linked
-  # Debug symbol generation needs some fixes, and is currently omitted.
-  # Once this is fixed, add -b true option.
-  echo "$ILLINK -out $LinkBin -d $CORE_ROOT -c link -l none -t $Assemblies $ReflectionRoots"
-  $ILLINK -out $LinkBin -d $CORE_ROOT -c link -l none -t $Assemblies $ReflectionRoots
-  ERRORLEVEL=$?
-  if [  $ERRORLEVEL -ne 0 ]
-  then
-    echo ILLINK FAILED $ERRORLEVEL
-    if [ -z "$KeepLinkedBinaries" ];
-    then
-      rm -rf $LinkBin
-    fi
-    exit 1
-  fi
-
-  # Copy CORECLR native binaries and the test watcher to $LinkBin,
-  # so that we can run the test based on that directory
-  cp $CORE_ROOT/*.so $LinkBin/
-  cp $CORE_ROOT/corerun $LinkBin/
-  cp $CORE_ROOT/watchdog $LinkBin/
-
-  # Copy some files that may be arguments
-  for f in *.txt;
-  do
-    [ -e "$f" ] && cp $f $LinkBin
-  done
-
-  ExePath=$LinkBin/$(InputAssemblyName)
-  export CORE_ROOT=$PWD/$LinkBin
-fi
-]]>
-          </BashLinkerTestLaunchCmds>
-          <BashLinkerTestCleanupCmds>
-              <![CDATA[
-# Clean up the LinkBin directories after test execution.
-# Otherwise, RunTests may run out of disk space.
-
-if [ ! -z "$DoLink" ];
-then
-  if [ -z "$KeepLinkedBinaries" ];
-  then
-    rm -rf $LinkBin
-  fi
-fi
-]]>
-          </BashLinkerTestCleanupCmds>
-      </PropertyGroup>
       <PropertyGroup>
       <CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"$CORE_ROOT/corerun" $(CoreRunArgs)  ${__DotEnvArg}</CLRTestRunFile>
       <WatcherRunFile>"$CORE_ROOT/watchdog" $_WatcherTimeoutMins</WatcherRunFile>
@@ -386,8 +298,6 @@ $__Command msbuild $CORE_ROOT/wasm-test-runner/WasmTestRunner.proj /p:NetCoreApp
 
       <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' != 'browser' And '$(TargetOS)' != 'android'">
     <![CDATA[
-$(BashLinkerTestLaunchCmds)
-
 _DebuggerArgsSeparator=
 if [[ "$_DebuggerFullPath" == *lldb* ]];
 then
@@ -425,8 +335,6 @@ CLRTestExitCode=$?
 if [ ! -z ${RunCrossGen2+x} ]%3B then
   ReleaseLock
 fi
-
-$(BashLinkerTestCleanupCmds)
       ]]></BashCLRTestLaunchCmds>
       <BashCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And '$(TargetOS)' == 'browser'">
       <![CDATA[

--- a/src/tests/Common/CLRTest.Execute.Batch.targets
+++ b/src/tests/Common/CLRTest.Execute.Batch.targets
@@ -254,75 +254,6 @@ Exit /b 0
     </ItemGroup>
 
       <PropertyGroup>
-          <ReflectionRootsXml>$(AssemblyName).reflect.xml</ReflectionRootsXml>
-          <BatchLinkerTestLaunchCmds><![CDATA[
-REM Linker commands
-
-set LinkBin=__Link
-set Assemblies=-a System.Private.CoreLib
-
-IF defined DoLink (
-    IF NOT EXIST !ILLINK! (
-      ECHO ILLink executable [%ILLINK%] Invalid
-      popd
-      Exit /b 1
-    )
-
-    REM Clean up old Linked binaries, if any
-    IF EXIST %LinkBin% rmdir /s /q %LinkBin%
-
-    REM Remove Native images, since the goal is to run from Linked binaries
-    del /q /f *.ni.* 2> nul
-
-    REM Use hints for reflection roots, if provided in $(ReflectionRootsXml)
-    IF EXIST $(ReflectionRootsXml) set ReflectionRoots=-x $(ReflectionRootsXml)
-
-    REM Include all .exe files in this directory as entry points (some tests had multiple .exe file modules)
-    FOR /F "delims=" %%E IN ('dir /b *.exe *.dll') DO SET Assemblies=!Assemblies! -a %%~nE
-
-    REM Run dotnet-linker
-    REM Run the Linker such that all assemblies except System.Private.Corlib.dll are linked
-    REM Debug symbol generation needs some fixes, and is currently omitted.
-    REM Once this is fixed, add -b true option.
-    ECHO %ILLINK% -out %LinkBin% -d %CORE_ROOT% -c link -l none -t !Assemblies! !ReflectionRoots!
-    %ILLINK% -out %LinkBin% -d %CORE_ROOT% -c link -l none -t !Assemblies! !ReflectionRoots!
-    IF NOT "!ERRORLEVEL!"=="0" (
-      ECHO ILLINK FAILED !ERRORLEVEL!
-      IF NOT defined KeepLinkedBinaries (
-          IF EXIST %LinkBin% rmdir /s /q %LinkBin%
-      )
-      popd
-      Exit /b 1
-    )
-
-    REM Copy CORECLR native binaries and the test watcher to %LinkBin%, so that we can run the test based on that directory
-    copy %CORE_ROOT%\clrjit.dll %LinkBin% > nul 2> nul
-    copy %CORE_ROOT%\coreclr.dll %LinkBin% > nul 2> nul
-    copy %CORE_ROOT%\CoreRun.exe %LinkBin% > nul 2> nul
-    copy %CORE_ROOT%\watchdog.exe %LinkBin% > nul 2> nul
-
-    REM Copy some files that may be arguments
-    copy *.txt %LinkBin% > nul 2> nul
-
-    set ExePath=%LinkBin%\$(InputAssemblyName)
-    set CORE_ROOT=%scriptPath%\%LinkBin%
-)
-]]>
-          </BatchLinkerTestLaunchCmds>
-          <BatchLinkerTestCleanupCmds>
-              <![CDATA[
-REM Clean up the LinkBin directories after test execution.
-REM Otherwise, RunTests may run out of disk space.
-
-if defined DoLink (
-    if not defined KeepLinkedBinaries (
-        IF EXIST %LinkBin% rmdir /s /q %LinkBin%
-    )
-)
-]]>
-          </BatchLinkerTestCleanupCmds>
-      </PropertyGroup>
-      <PropertyGroup>
       <CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"%CORE_ROOT%\corerun.exe" $(CoreRunArgs) %__DotEnvArg%</CLRTestRunFile>
       <WatcherRunFile>"%CORE_ROOT%\watchdog.exe" %_WatcherTimeoutMins%</WatcherRunFile>
 
@@ -333,7 +264,6 @@ COPY /y %CORE_ROOT%\CoreShim.dll .
       ]]></BatchCopyCoreShimLocalCmds>
       <BatchCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And $(TargetOS) != 'android'">
     <![CDATA[
-$(BatchLinkerTestLaunchCmds)
 $(BatchCopyCoreShimLocalCmds)
 
 IF NOT "%CLRCustomTestLauncher%"=="" (
@@ -360,7 +290,6 @@ set CLRTestExitCode=!ERRORLEVEL!
 if defined RunCrossGen2 (
   call :ReleaseLock
 )
-$(BatchLinkerTestCleanupCmds)
       ]]></BatchCLRTestLaunchCmds>
       <BatchCLRTestLaunchCmds Condition="'$(CLRTestKind)' == 'BuildAndRun' And $(TargetOS) == 'android'">
     <![CDATA[

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -58,7 +58,7 @@ export RunningIlasmRoundTrip=
       <IlasmRoundTripBashScript Condition="'$(CLRTestKind)' == 'BuildAndRun'"><![CDATA[
 # IlasmRoundTrip Script
 
-if [ -z "$RunningIlasmRoundTrip" ];
+if [ -n "$RunningIlasmRoundTrip" ];
 then
   python3 $(AssemblyName)_ilasmroundtrip.py
   ERRORLEVEL=$?

--- a/src/tests/Common/CLRTest.Jit.targets
+++ b/src/tests/Common/CLRTest.Jit.targets
@@ -13,7 +13,7 @@ This file contains the logic for generating command scripts for special GC tests
 WARNING:   When setting properties based on their current state (for example:
            <Foo Condition="'$(Foo)'==''>Bar</Foo>).  Be very careful.  Another script generation
            target might be trying to do the same thing.  It's better to avoid this by instead setting a new property.
-           
+
            Additionally, be careful with itemgroups.  Include will propagate outside of the target too!
 
 ***********************************************************************************************
@@ -57,10 +57,8 @@ export RunningIlasmRoundTrip=
 
       <IlasmRoundTripBashScript Condition="'$(CLRTestKind)' == 'BuildAndRun'"><![CDATA[
 # IlasmRoundTrip Script
-# Disable Ilasm round-tripping for Linker tests.
-# Todo: Ilasm round-trip on linked binaries.
 
-if [ -z "$DoLink" -a ! -z "$RunningIlasmRoundTrip" ];
+if [ -z "$RunningIlasmRoundTrip" ];
 then
   python3 $(AssemblyName)_ilasmroundtrip.py
   ERRORLEVEL=$?
@@ -95,13 +93,11 @@ REM IlasmRoundTrip Script
 REM Disable Ilasm round-tripping for Linker tests.
 REM Todo: Ilasm round-trip on linked binaries.
 
-IF NOT DEFINED DoLink (
-  IF DEFINED RunningIlasmRoundTrip (
-    python $(AssemblyName)_ilasmroundtrip.py
-    IF NOT "!ERRORLEVEL!"=="0" (
-      ECHO ILASM ROUND-TRIP - FAILED !ERRORLEVEL!
-      Exit /b 1
-    )
+IF DEFINED RunningIlasmRoundTrip (
+  python $(AssemblyName)_ilasmroundtrip.py
+  IF NOT "!ERRORLEVEL!"=="0" (
+    ECHO ILASM ROUND-TRIP - FAILED !ERRORLEVEL!
+    Exit /b 1
   )
 )
 ]]>
@@ -225,7 +221,7 @@ IF NOT "%DOTNET_JitDisasm%" == "" (
   ***********************************************************************************************
   SuperPMI collection of CoreCLR tests
   ***********************************************************************************************
-  
+
   You shouldn't have to escape characters in a CDATA block, but it appears that you do actually need
   to escape semicolons with %3B here.
   -->
@@ -462,4 +458,4 @@ print("")
       Include="DOTNET_GCStress" Value="$(RunWithGcStress)" />
   </ItemGroup>
 
-</Project> 
+</Project>

--- a/src/tests/Common/scripts/bringup_runtest.sh
+++ b/src/tests/Common/scripts/bringup_runtest.sh
@@ -1086,10 +1086,6 @@ do
         --jitforcerelocs)
             export DOTNET_ForceRelocs=1
             ;;
-        --link=*)
-            export ILLINK=${i#*=}
-            export DoLink=true
-            ;;
         --tieredcompilation)
             export DOTNET_TieredCompilation=1
             ;;

--- a/src/tests/CoreMangLib/system/delegate/miscellaneous/ClosedStatic.reflect.xml
+++ b/src/tests/CoreMangLib/system/delegate/miscellaneous/ClosedStatic.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="ClosedStatic">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/JIT/Regression/Dev11/External/dev11_13748/ReflectOnField.reflect.xml
+++ b/src/tests/JIT/Regression/Dev11/External/dev11_13748/ReflectOnField.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="reflectOnField">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/MethodImpl/self_override1.reflect.xml
+++ b/src/tests/Loader/classloader/MethodImpl/self_override1.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="self_override1">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/MethodImpl/self_override2.reflect.xml
+++ b/src/tests/Loader/classloader/MethodImpl/self_override2.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="self_override2">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/MethodImpl/self_override3.reflect.xml
+++ b/src/tests/Loader/classloader/MethodImpl/self_override3.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="self_override3">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Instantiation/Negative/abstract02.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Instantiation/Negative/abstract02.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="abstract02">
-        <type fullname="GenBase" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Instantiation/Negative/abstract03.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Instantiation/Negative/abstract03.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="abstract03">
-        <type fullname="GenBase" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Instantiation/Negative/abstract04.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Instantiation/Negative/abstract04.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="abstract04">
-        <type fullname="GenBase" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Variance/IL/CastClass001.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Variance/IL/CastClass001.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="CastClass001">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Variance/IL/CastClass004.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Variance/IL/CastClass004.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="CastClass004">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Variance/IL/IsInst001.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Variance/IL/IsInst001.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="IsInst001">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Variance/IL/IsInst002.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Variance/IL/IsInst002.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="IsInst002">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Variance/IL/IsInst003.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Variance/IL/IsInst003.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="IsInst003">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Variance/IL/IsInst004.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Variance/IL/IsInst004.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="IsInst004">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Variance/IL/IsInst005.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Variance/IL/IsInst005.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="IsInst005">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Variance/IL/IsInst006.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Variance/IL/IsInst006.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="IsInst006">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Variance/IL/Unbox001.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Variance/IL/Unbox001.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="Unbox001">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Variance/IL/Unbox002.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Variance/IL/Unbox002.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="Unbox002">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Variance/IL/Unbox003.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Variance/IL/Unbox003.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="Unbox003">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Variance/IL/Unbox004.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Variance/IL/Unbox004.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="Unbox004">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Variance/IL/Unbox005.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Variance/IL/Unbox005.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="Unbox005">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/generics/Variance/IL/Unbox006.reflect.xml
+++ b/src/tests/Loader/classloader/generics/Variance/IL/Unbox006.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="Unbox006">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/regressions/14610/TestObjectGetTypeVirtual.reflect.xml
+++ b/src/tests/Loader/classloader/regressions/14610/TestObjectGetTypeVirtual.reflect.xml
@@ -1,5 +1,0 @@
-<linker>
-    <assembly fullname="TestObjectGetTypeVirtual">
-        <type fullname="*" required="true" />
-    </assembly>
-</linker>

--- a/src/tests/Loader/classloader/regressions/dev11_95728/dev11_95728.reflect.xml
+++ b/src/tests/Loader/classloader/regressions/dev11_95728/dev11_95728.reflect.xml
@@ -1,9 +1,0 @@
-<linker>
-    <assembly fullname="dev11_95728">
-        <type fullname="*" required="true" />
-    </assembly>
-    <assembly fullname="System.Linq.Expressions">
-     <!-- - Called by System.Linq.Expressions.Expression:CreateLambda --> 
-     <type fullname="System.Linq.Expressions.Expression`1" required="true" /> 
-    </assembly>
-</linker>

--- a/src/tests/issues.targets
+++ b/src/tests/issues.targets
@@ -367,20 +367,6 @@
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(TargetsOSX)' == 'true' and '$(TargetArchitecture)' == 'arm64' and '$(RuntimeFlavor)' == 'coreclr' ">
     </ItemGroup>
 
-    <!-- Failures while testing via ILLINK -->
-    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(RunTestsViaIllink)' == 'true'">
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/superpmi/superpmicollect/*">
-            <!-- Linker runs reset CORE_ROOT to the linked directory based on superpmicollect.exe.
-                 The test runs other benchmarks to collect superpmi data.
-                 These tests cannot run from the binaries generated wrt superpmicollect.exe -->
-            <Issue>By Test Infrastructure design</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)/JIT/Directed/RVAInit/nested/*">
-            <!-- Data referred from static field is dropped -->
-            <Issue>Bug</Issue>
-        </ExcludeList>
-    </ItemGroup>
-
     <!-- Crossgen2 specific -->
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and ('$(TestBuildMode)' == 'crossgen2' or '$(TestBuildMode)' == 'crossgen') and '$(RuntimeFlavor)' == 'coreclr'">
         <ExcludeList Include="$(XunitTestBinBase)/Interop/IJW/NativeVarargs/NativeVarargsTest/*">

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -65,7 +65,6 @@ if /i "%1" == "runcrossgen2tests"                       (set RunCrossGen2=1&shif
 REM This test feature is currently intentionally undocumented
 if /i "%1" == "runlargeversionbubblecrossgen2tests"     (set RunCrossGen2=1&set CrossgenLargeVersionBubble=1&shift&goto Arg_Loop)
 if /i "%1" == "synthesizepgo"                           (set CrossGen2SynthesizePgo=1&shift&goto Arg_Loop)
-if /i "%1" == "link"                                    (set DoLink=true&set ILLINK=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "gcname"                                  (set DOTNET_GCName=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "gcstresslevel"                           (set DOTNET_GCStress=%2&set __TestTimeout=1800000&shift&shift&goto Arg_Loop)
 if /i "%1" == "gcsimulator"                             (set __GCSimulatorTests=1&shift&goto Arg_Loop)
@@ -113,10 +112,6 @@ set __RuntestPyArgs=-arch %__BuildArch% -build_type %__BuildType%
 
 if defined LogsDirArg (
     set __RuntestPyArgs=%__RuntestPyArgs% -logs_dir %LogsDirArg%
-)
-
-if defined DoLink (
-    set __RuntestPyArgs=%__RuntestPyArgs% --il_link
 )
 
 if defined __LongGCTests (

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -571,9 +571,6 @@ def call_msbuild(args):
                 "/p:Configuration=%s" % args.build_type,
                 "/p:__LogsDir=%s" % args.logs_dir]
 
-    if args.il_link:
-        command += ["/p:RunTestsViaIllink=true"]
-
     if args.limited_core_dumps:
         command += ["/p:LimitedCoreDumps=true"]
 
@@ -1100,7 +1097,7 @@ def find_test_from_name(host_os, test_location, test_name):
                 dir_contents[re.sub("[%s]" % string.punctuation, "_", item)] = item
 
             file_name_cache[test_path_dir] = dir_contents
-        
+
         return dir_contents
 
     def match_filename(test_path):
@@ -1286,7 +1283,7 @@ def parse_test_results_xml_file(args, item, item_name, tests, assemblies):
                     # This doesn't do anything in the merged model.
                     type = type.split("._")[0]
                     test_name = type + "::" + method
-                    
+
                     # The "name" is something like:
                     # 1. Merged model: "JIT\Regression\CLR-x86-JIT\V1.2-M02\b00719\b00719\b00719.dll" or
                     # "_CompareVectorWithZero_r::CompareVectorWithZero.TestVector64Equality()"

--- a/src/tests/run.sh
+++ b/src/tests/run.sh
@@ -134,10 +134,6 @@ do
         --jitforcerelocs)
             export DOTNET_ForceRelocs=1
             ;;
-        --link=*)
-            export ILLINK=${i#*=}
-            export DoLink=true
-            ;;
         --ilasmroundtrip)
             ((ilasmroundtrip = 1))
             ;;


### PR DESCRIPTION
We have not been running this mode for years. The test infra also dates back to before we had reflection analysis, so we aren't even testing the most complicated portion of the linker.

This testing is better validated through our NativeAOT testing, which runs its trimming implementation, as well as our test legs that run the trimmer on the libraries tests.