### PR TITLE
[release/10.0] Backport Reliability fixes for the Thread Pool

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -91,19 +91,19 @@ namespace System.Net.Sockets
         //
         private readonly ConcurrentQueue<SocketIOEvent> _eventQueue = new ConcurrentQueue<SocketIOEvent>();
 
-        // The scheme works as follows:
-        // - From NotScheduled, the only transition is to Scheduled when new events are enqueued and a work item is enqueued to process them.
-        // - From Scheduled, the only transition is to Determining right before trying to dequeue an event.
-        // - From Determining, it can go to either NotScheduled when no events are present in the queue (the previous work item processed all of them)
-        //   or Scheduled if the queue is still not empty (let the current work item handle parallelization as convinient).
-        //
-        // The goal is to avoid enqueueing more work items than necessary, while still ensuring that all events are processed.
-        // Another work item isn't enqueued to the thread pool hastily while the state is Determining,
-        // instead the parallelizer takes care of that. We also ensure that only one thread can be parallelizing at any time.
         private enum EventQueueProcessingStage
         {
+            // NotScheduled: has no guarantees
             NotScheduled,
-            Determining,
+
+            // Scheduled: means a worker will check work queues and ensure that
+            // any work items inserted in work queue before setting the flag
+            // are picked up.
+            // Note: The state must be cleared by the worker thread _before_
+            //       checking. Otherwise there is a window between finding no work
+            //       and resetting the flag, when the flag is in a wrong state.
+            //       A new work item may be added right before the flag is reset
+            //       without asking for a worker, while the last worker is quitting.
             Scheduled
         }
 
@@ -231,14 +231,9 @@ namespace System.Net.Sockets
                     // The native shim is responsible for ensuring this condition.
                     Debug.Assert(numEvents > 0, $"Unexpected numEvents: {numEvents}");
 
-                    // Only enqueue a work item if the stage is NotScheduled.
-                    // Otherwise there must be a work item already queued or another thread already handling parallelization.
-                    if (handler.HandleSocketEvents(numEvents) &&
-                        Interlocked.Exchange(
-                            ref _eventQueueProcessingStage,
-                            EventQueueProcessingStage.Scheduled) == EventQueueProcessingStage.NotScheduled)
+                    if (handler.HandleSocketEvents(numEvents))
                     {
-                        ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
+                        EnsureWorkerScheduled();
                     }
                 }
             }
@@ -248,70 +243,42 @@ namespace System.Net.Sockets
             }
         }
 
-        private void UpdateEventQueueProcessingStage(bool isEventQueueEmpty)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void EnsureWorkerScheduled()
         {
-            if (!isEventQueueEmpty)
+            // Only one thread is requested at a time to mitigate Thundering Herd problem.
+            // That is the minimum - we have inserted a workitem and NotScheduled
+            // state requires asking for a worker.
+            if (Interlocked.Exchange(
+                ref _eventQueueProcessingStage,
+                EventQueueProcessingStage.Scheduled) == EventQueueProcessingStage.NotScheduled)
             {
-                // There are more events to process, set stage to Scheduled and enqueue a work item.
-                _eventQueueProcessingStage = EventQueueProcessingStage.Scheduled;
+                ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
             }
-            else
-            {
-                // The stage here would be Scheduled if an enqueuer has enqueued work and changed the stage, or Determining
-                // otherwise. If the stage is Determining, there's no more work to do. If the stage is Scheduled, the enqueuer
-                // would not have scheduled a work item to process the work, so schedule one now.
-                EventQueueProcessingStage stageBeforeUpdate =
-                    Interlocked.CompareExchange(
-                        ref _eventQueueProcessingStage,
-                        EventQueueProcessingStage.NotScheduled,
-                        EventQueueProcessingStage.Determining);
-                Debug.Assert(stageBeforeUpdate != EventQueueProcessingStage.NotScheduled);
-                if (stageBeforeUpdate == EventQueueProcessingStage.Determining)
-                {
-                    return;
-                }
-            }
-
-            ThreadPool.UnsafeQueueUserWorkItem(this, preferLocal: false);
         }
 
         void IThreadPoolWorkItem.Execute()
         {
+            _eventQueueProcessingStage = EventQueueProcessingStage.NotScheduled;
+
+            // Checking for items must happen after resetting the processing state.
+            Interlocked.MemoryBarrier();
+
             ConcurrentQueue<SocketIOEvent> eventQueue = _eventQueue;
-            SocketIOEvent ev;
-            while (true)
+            if (!eventQueue.TryDequeue(out SocketIOEvent ev))
             {
-                Debug.Assert(_eventQueueProcessingStage == EventQueueProcessingStage.Scheduled);
-
-                // The change needs to be visible to other threads that may request a worker thread before a work item is attempted
-                // to be dequeued by the current thread. In particular, if an enqueuer queues a work item and does not request a
-                // thread because it sees a Determining or Scheduled stage, and the current thread is the last thread processing
-                // work items, the current thread must either see the work item queued by the enqueuer, or it must see a stage of
-                // Scheduled, and try to dequeue again or request another thread.
-                _eventQueueProcessingStage = EventQueueProcessingStage.Determining;
-                Interlocked.MemoryBarrier();
-
-                if (eventQueue.TryDequeue(out ev))
-                {
-                    break;
-                }
-
-                // The stage here would be Scheduled if an enqueuer has enqueued work and changed the stage, or Determining
-                // otherwise. If the stage is Determining, there's no more work to do. If the stage is Scheduled, the enqueuer
-                // would not have scheduled a work item to process the work, so try to dequeue a work item again.
-                EventQueueProcessingStage stageBeforeUpdate =
-                    Interlocked.CompareExchange(
-                        ref _eventQueueProcessingStage,
-                        EventQueueProcessingStage.NotScheduled,
-                        EventQueueProcessingStage.Determining);
-                Debug.Assert(stageBeforeUpdate != EventQueueProcessingStage.NotScheduled);
-                if (stageBeforeUpdate == EventQueueProcessingStage.Determining)
-                {
-                    return;
-                }
+                return;
             }
 
-            UpdateEventQueueProcessingStage(eventQueue.IsEmpty);
+            // The batch that is currently in the queue could have asked only for one worker.
+            // We are going to process a workitem, which may take unknown time or even block.
+            // In a worst case the current workitem will indirectly depend on progress of other
+            // items and that would lead to a deadlock if noone else checks the queue.
+            // We must ensure at least one more worker is coming if the queue is not empty.
+            if (!eventQueue.IsEmpty)
+            {
+                EnsureWorkerScheduled();
+            }
 
             int startTimeMs = Environment.TickCount;
             do

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -273,7 +273,7 @@ namespace System.Net.Sockets
             // The batch that is currently in the queue could have asked only for one worker.
             // We are going to process a workitem, which may take unknown time or even block.
             // In a worst case the current workitem will indirectly depend on progress of other
-            // items and that would lead to a deadlock if noone else checks the queue.
+            // items and that would lead to a deadlock if no one else checks the queue.
             // We must ensure at least one more worker is coming if the queue is not empty.
             if (!eventQueue.IsEmpty)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -431,21 +431,19 @@ namespace System.Threading
         private readonly int[] _assignedWorkItemQueueThreadCounts =
             s_assignableWorkItemQueueCount > 0 ? new int[s_assignableWorkItemQueueCount] : Array.Empty<int>();
 
-        private object? _nextWorkItemToProcess;
-
-        // The scheme works as follows:
-        // - From NotScheduled, the only transition is to Scheduled when new items are enqueued and a thread is requested to process them.
-        // - From Scheduled, the only transition is to Determining right before trying to dequeue an item.
-        // - From Determining, it can go to either NotScheduled when no items are present in the queue (the previous thread processed all of them)
-        //   or Scheduled if the queue is still not empty (let the current thread handle parallelization as convinient).
-        //
-        // The goal is to avoid requesting more threads than necessary, while still ensuring that all items are processed.
-        // Another thread isn't requested hastily while the state is Determining,
-        // instead the parallelizer takes care of that. We also ensure that only one thread can be parallelizing at any time.
         private enum QueueProcessingStage
         {
+            // NotScheduled: has no guarantees
             NotScheduled,
-            Determining,
+
+            // Scheduled: means a worker will check work queues and ensure that
+            // any work items inserted in work queue before setting the flag
+            // are picked up.
+            // Note: The state must be cleared by the worker thread _before_
+            //       checking. Otherwise there is a window between finding no work
+            //       and resetting the flag, when the flag is in a wrong state.
+            //       A new work item may be added right before the flag is reset
+            //       without asking for a worker, while the last worker is quitting.
             Scheduled
         }
 
@@ -618,11 +616,12 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void EnsureThreadRequested()
         {
-            // Only request a thread if the stage is NotScheduled.
-            // Otherwise let the current requested thread handle parallelization.
+            // Only one thread is requested at a time to mitigate Thundering Herd problem.
+            // That is the minimum - we have inserted a workitem and NotScheduled
+            // state requires asking for a worker.
             if (Interlocked.Exchange(
-                    ref _separated.queueProcessingStage,
-                    QueueProcessingStage.Scheduled) == QueueProcessingStage.NotScheduled)
+                ref _separated.queueProcessingStage,
+                QueueProcessingStage.Scheduled) == QueueProcessingStage.NotScheduled)
             {
                 ThreadPool.RequestWorkerThread();
             }
@@ -723,40 +722,14 @@ namespace System.Threading
             // Pop each work item off the local queue and push it onto the global. This is a
             // bounded loop as no other thread is allowed to push into this thread's queue.
             ThreadPoolWorkQueue queue = ThreadPool.s_workQueue;
-            bool addedHighPriorityWorkItem = false;
-            bool ensureThreadRequest = false;
             while (tl.workStealingQueue.LocalPop() is object workItem)
             {
-                // If there's an unexpected exception here that happens to get handled, the lost work item, or missing thread
-                // request, etc., may lead to other issues. A fail-fast or try-finally here could reduce the effect of such
-                // uncommon issues to various degrees, but it's also uncommon to check for unexpected exceptions.
-                try
-                {
-                    queue.highPriorityWorkItems.Enqueue(workItem);
-                    addedHighPriorityWorkItem = true;
-                }
-                catch (OutOfMemoryException)
-                {
-                    // This is not expected to throw under normal circumstances
-                    tl.workStealingQueue.LocalPush(workItem);
-
-                    // A work item had been removed temporarily and other threads may have missed stealing it, so ensure that
-                    // there will be a thread request
-                    ensureThreadRequest = true;
-                    break;
-                }
+                queue.highPriorityWorkItems.Enqueue(workItem);
             }
 
-            if (addedHighPriorityWorkItem)
-            {
-                Volatile.Write(ref queue._mayHaveHighPriorityWorkItems, true);
-                ensureThreadRequest = true;
-            }
+            Volatile.Write(ref queue._mayHaveHighPriorityWorkItems, true);
 
-            if (ensureThreadRequest)
-            {
-                queue.EnsureThreadRequested();
-            }
+            queue.EnsureThreadRequested();
         }
 
         internal static bool LocalFindAndPop(object callback)
@@ -772,15 +745,6 @@ namespace System.Threading
             if (workItem != null)
             {
                 return workItem;
-            }
-
-            if (_nextWorkItemToProcess != null)
-            {
-                workItem = Interlocked.Exchange(ref _nextWorkItemToProcess, null);
-                if (workItem != null)
-                {
-                    return workItem;
-                }
             }
 
             // Check for high-priority work items
@@ -959,123 +923,39 @@ namespace System.Threading
                 workQueue.AssignWorkItemQueue(tl);
             }
 
-            // The change needs to be visible to other threads that may request a worker thread before a work item is attempted
-            // to be dequeued by the current thread. In particular, if an enqueuer queues a work item and does not request a
-            // thread because it sees a Determining or Scheduled stage, and the current thread is the last thread processing
-            // work items, the current thread must either see the work item queued by the enqueuer, or it must see a stage of
-            // Scheduled, and try to dequeue again or request another thread.
-            Debug.Assert(workQueue._separated.queueProcessingStage == QueueProcessingStage.Scheduled);
-            workQueue._separated.queueProcessingStage = QueueProcessingStage.Determining;
+            // Before dequeuing the first work item, acknowledge that the thread request has been satisfied
+            workQueue._separated.queueProcessingStage = QueueProcessingStage.NotScheduled;
+
+            // The state change must happen before sweeping queues for items.
             Interlocked.MemoryBarrier();
 
-            object? workItem = null;
-            if (workQueue._nextWorkItemToProcess != null)
-            {
-                workItem = Interlocked.Exchange(ref workQueue._nextWorkItemToProcess, null);
-            }
-
+            object? workItem = DequeueWithPriorityAlternation(workQueue, tl, out bool missedSteal);
             if (workItem == null)
             {
-                // Try to dequeue a work item, clean up and return if no item was found
-                while ((workItem = DequeueWithPriorityAlternation(workQueue, tl, out bool missedSteal)) == null)
+                if (s_assignableWorkItemQueueCount > 0)
                 {
-                    //
-                    // No work.
-                    // If we missed a steal, though, there may be more work in the queue.
-                    // Instead of looping around and trying again, we'll just request another thread.  Hopefully the thread
-                    // that owns the contended work-stealing queue will pick up its own workitems in the meantime,
-                    // which will be more efficient than this thread doing it anyway.
-                    //
-                    if (missedSteal)
-                    {
-                        if (s_assignableWorkItemQueueCount > 0)
-                        {
-                            workQueue.UnassignWorkItemQueue(tl);
-                        }
-
-                        Debug.Assert(workQueue._separated.queueProcessingStage != QueueProcessingStage.NotScheduled);
-                        workQueue._separated.queueProcessingStage = QueueProcessingStage.Scheduled;
-                        ThreadPool.RequestWorkerThread();
-                        return true;
-                    }
-
-                    // The stage here would be Scheduled if an enqueuer has enqueued work and changed the stage, or Determining
-                    // otherwise. If the stage is Determining, there's no more work to do. If the stage is Scheduled, the enqueuer
-                    // would not have scheduled a work item to process the work, so try to dequeue a work item again.
-                    QueueProcessingStage stageBeforeUpdate =
-                        Interlocked.CompareExchange(
-                            ref workQueue._separated.queueProcessingStage,
-                            QueueProcessingStage.NotScheduled,
-                            QueueProcessingStage.Determining);
-                    Debug.Assert(stageBeforeUpdate != QueueProcessingStage.NotScheduled);
-                    if (stageBeforeUpdate == QueueProcessingStage.Determining)
-                    {
-                        if (s_assignableWorkItemQueueCount > 0)
-                        {
-                            workQueue.UnassignWorkItemQueue(tl);
-                        }
-
-                        return true;
-                    }
-
-                    // A work item was enqueued after the stage was set to Determining earlier, and a thread was not requested
-                    // by the enqueuer. Set the stage back to Determining and try to dequeue a work item again.
-                    //
-                    // See the first similarly used memory barrier in the method for why it's necessary.
-                    workQueue._separated.queueProcessingStage = QueueProcessingStage.Determining;
-                    Interlocked.MemoryBarrier();
+                    workQueue.UnassignWorkItemQueue(tl);
                 }
+
+                // Missing a steal means there may be an item that we we were unable to get.
+                // Effectively, we failed to fullfill our promise to check the queues after
+                // clearing "Scheduled" flag.
+                // We need to make sure someone will do another pass.
+                if (missedSteal)
+                {
+                    workQueue.EnsureThreadRequested();
+                }
+
+                // Tell the VM we're returning normally, not because Hill Climbing asked us to return.
+                return true;
             }
 
-            {
-                // A work item may have been enqueued after the stage was set to Determining earlier, so the stage may be
-                // Scheduled here, and the enqueued work item may have already been dequeued above or by a different thread. Now
-                // that we're about to try dequeuing a second work item, set the stage back to Determining first so that we'll
-                // be able to detect if an enqueue races with the dequeue below.
-                //
-                // See the first similarly used memory barrier in the method for why it's necessary.
-                workQueue._separated.queueProcessingStage = QueueProcessingStage.Determining;
-                Interlocked.MemoryBarrier();
-
-                object? secondWorkItem = DequeueWithPriorityAlternation(workQueue, tl, out bool missedSteal);
-                if (secondWorkItem != null)
-                {
-                    Debug.Assert(workQueue._nextWorkItemToProcess == null);
-                    workQueue._nextWorkItemToProcess = secondWorkItem;
-                }
-
-                if (secondWorkItem != null || missedSteal)
-                {
-                    // A work item was successfully dequeued, and there may be more work items to process. Request a thread to
-                    // parallelize processing of work items, before processing more work items. Following this, it is the
-                    // responsibility of the new thread and other enqueuers to request more threads as necessary. The
-                    // parallelization may be necessary here for correctness (aside from perf) if the work item blocks for some
-                    // reason that may have a dependency on other queued work items.
-                    Debug.Assert(workQueue._separated.queueProcessingStage != QueueProcessingStage.NotScheduled);
-                    workQueue._separated.queueProcessingStage = QueueProcessingStage.Scheduled;
-                    ThreadPool.RequestWorkerThread();
-                }
-                else
-                {
-                    // The stage here would be Scheduled if an enqueuer has enqueued work and changed the stage, or Determining
-                    // otherwise. If the stage is Determining, there's no more work to do. If the stage is Scheduled, the enqueuer
-                    // would not have requested a thread, so request one now.
-                    QueueProcessingStage stageBeforeUpdate =
-                        Interlocked.CompareExchange(
-                            ref workQueue._separated.queueProcessingStage,
-                            QueueProcessingStage.NotScheduled,
-                            QueueProcessingStage.Determining);
-                    Debug.Assert(stageBeforeUpdate != QueueProcessingStage.NotScheduled);
-                    if (stageBeforeUpdate == QueueProcessingStage.Scheduled)
-                    {
-                        // A work item was enqueued after the stage was set to Determining earlier, and a thread was not
-                        // requested by the enqueuer, so request a thread now. An alternate is to retry dequeuing, as requesting
-                        // a thread can be more expensive, but retrying multiple times (though unlikely) can delay the
-                        // processing of the first work item that was already dequeued.
-                        ThreadPool.RequestWorkerThread();
-                    }
-                }
-            }
+            // The workitems that are currently in the queues could have asked only for one worker.
+            // We are going to process a workitem, which may take unknown time or even block.
+            // In a worst case the current workitem will indirectly depend on progress of other
+            // items and that would lead to a deadlock if noone else checks the queue.
+            // We must ensure at least one more worker is coming if the queue is not empty.
+            workQueue.EnsureThreadRequested();
 
             //
             // After this point, this method is no longer responsible for ensuring thread requests except for missed steals
@@ -1103,7 +983,7 @@ namespace System.Threading
             {
                 if (workItem == null)
                 {
-                    bool missedSteal = false;
+                    missedSteal = false;
                     workItem = workQueue.Dequeue(tl, ref missedSteal);
 
                     if (workItem == null)
@@ -1312,19 +1192,19 @@ namespace System.Threading
 
     internal sealed class ThreadPoolTypedWorkItemQueue : IThreadPoolWorkItem
     {
-        // The scheme works as follows:
-        // - From NotScheduled, the only transition is to Scheduled when new items are enqueued and a TP work item is enqueued to process them.
-        // - From Scheduled, the only transition is to Determining right before trying to dequeue an item.
-        // - From Determining, it can go to either NotScheduled when no items are present in the queue (the previous TP work item processed all of them)
-        //   or Scheduled if the queue is still not empty (let the current TP work item handle parallelization as convinient).
-        //
-        // The goal is to avoid enqueueing more TP work items than necessary, while still ensuring that all items are processed.
-        // Another TP work item isn't enqueued to the thread pool hastily while the state is Determining,
-        // instead the parallelizer takes care of that. We also ensure that only one thread can be parallelizing at any time.
         private enum QueueProcessingStage
         {
+            // NotScheduled: has no guarantees
             NotScheduled,
-            Determining,
+
+            // Scheduled: means a worker will check work queues and ensure that
+            // any work items inserted in work queue before setting the flag
+            // are picked up.
+            // Note: The state must be cleared by the worker thread _before_
+            //       checking. Otherwise there is a window between finding no work
+            //       and resetting the flag, when the flag is in a wrong state.
+            //       A new work item may be added right before the flag is reset
+            //       without asking for a worker, while the last worker is quitting.
             Scheduled
         }
 
@@ -1340,84 +1220,49 @@ namespace System.Threading
         }
 
         public void BatchEnqueue(IOCompletionPollerEvent workItem) => _workItems.Enqueue(workItem);
-        public void CompleteBatchEnqueue()
+        public void CompleteBatchEnqueue() => EnsureWorkerScheduled();
+
+        private void EnsureWorkerScheduled()
         {
-            // Only enqueue a work item if the stage is NotScheduled.
-            // Otherwise there must be a work item already queued or another thread already handling parallelization.
+            // Only one thread is requested at a time to mitigate Thundering Herd problem.
+            // That is the minimum - we have inserted a workitem and NotScheduled
+            // state requires asking for a worker.
             if (Interlocked.Exchange(
                 ref _queueProcessingStage,
                 QueueProcessingStage.Scheduled) == QueueProcessingStage.NotScheduled)
             {
+                // Currently where this type is used, queued work is expected to be processed
+                // at high priority. The implementation could be modified to support different
+                // priorities if necessary.
                 ThreadPool.UnsafeQueueHighPriorityWorkItemInternal(this);
             }
         }
 
-        private void UpdateQueueProcessingStage(bool isQueueEmpty)
-        {
-            if (!isQueueEmpty)
-            {
-                // There are more items to process, set stage to Scheduled and enqueue a TP work item.
-                _queueProcessingStage = QueueProcessingStage.Scheduled;
-            }
-            else
-            {
-                // The stage here would be Scheduled if an enqueuer has enqueued work and changed the stage, or Determining
-                // otherwise. If the stage is Determining, there's no more work to do. If the stage is Scheduled, the enqueuer
-                // would not have scheduled a work item to process the work, so schedule one one.
-                QueueProcessingStage stageBeforeUpdate =
-                    Interlocked.CompareExchange(
-                        ref _queueProcessingStage,
-                        QueueProcessingStage.NotScheduled,
-                        QueueProcessingStage.Determining);
-                Debug.Assert(stageBeforeUpdate != QueueProcessingStage.NotScheduled);
-                if (stageBeforeUpdate == QueueProcessingStage.Determining)
-                {
-                    return;
-                }
-            }
-
-            ThreadPool.UnsafeQueueHighPriorityWorkItemInternal(this);
-        }
-
         void IThreadPoolWorkItem.Execute()
         {
-            IOCompletionPollerEvent workItem;
-            while (true)
+            // We are asking for one worker at a time, thus the state should be Scheduled.
+            Debug.Assert(_queueProcessingStage == QueueProcessingStage.Scheduled);
+            _queueProcessingStage = QueueProcessingStage.NotScheduled;
+
+            // Checking for items must happen after resetting the processing state.
+            Interlocked.MemoryBarrier();
+
+            if (!_workItems.TryDequeue(out var workItem))
             {
-                Debug.Assert(_queueProcessingStage == QueueProcessingStage.Scheduled);
-
-                // The change needs to be visible to other threads that may request a worker thread before a work item is attempted
-                // to be dequeued by the current thread. In particular, if an enqueuer queues a work item and does not request a
-                // thread because it sees a Determining or Scheduled stage, and the current thread is the last thread processing
-                // work items, the current thread must either see the work item queued by the enqueuer, or it must see a stage of
-                // Scheduled, and try to dequeue again or request another thread.
-                _queueProcessingStage = QueueProcessingStage.Determining;
-                Interlocked.MemoryBarrier();
-
-                if (_workItems.TryDequeue(out workItem))
-                {
-                    break;
-                }
-
-                // The stage here would be Scheduled if an enqueuer has enqueued work and changed the stage, or Determining
-                // otherwise. If the stage is Determining, there's no more work to do. If the stage is Scheduled, the enqueuer
-                // would not have scheduled a work item to process the work, so try to dequeue a work item again.
-                QueueProcessingStage stageBeforeUpdate =
-                    Interlocked.CompareExchange(
-                        ref _queueProcessingStage,
-                        QueueProcessingStage.NotScheduled,
-                        QueueProcessingStage.Determining);
-                Debug.Assert(stageBeforeUpdate != QueueProcessingStage.NotScheduled);
-                if (stageBeforeUpdate == QueueProcessingStage.Determining)
-                {
-                    // Discount a work item here to avoid counting this queue processing work item
-                    ThreadInt64PersistentCounter.Decrement(
-                        ThreadPoolWorkQueueThreadLocals.threadLocals!.threadLocalCompletionCountObject!);
-                    return;
-                }
+                // Discount a work item here to avoid counting this queue processing work item
+                ThreadPoolWorkQueueThreadLocals.threadLocals!.threadLocalCompletionCountNode!.Decrement();
+                return;
             }
 
-            UpdateQueueProcessingStage(_workItems.IsEmpty);
+            // The batch that is currently in the queue could have asked only for one worker.
+            // We are going to process a workitem, which may take unknown time or even block.
+            // In a worst case the current workitem will indirectly depend on progress of other
+            // items and that would lead to a deadlock if noone else checks the queue.
+            // We must ensure at least one more worker is coming if the queue is not empty.
+            if (!_workItems.IsEmpty)
+            {
+                EnsureWorkerScheduled();
+            }
 
             ThreadPoolWorkQueueThreadLocals tl = ThreadPoolWorkQueueThreadLocals.threadLocals!;
             Debug.Assert(tl != null);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -937,8 +937,8 @@ namespace System.Threading
                     workQueue.UnassignWorkItemQueue(tl);
                 }
 
-                // Missing a steal means there may be an item that we we were unable to get.
-                // Effectively, we failed to fullfill our promise to check the queues after
+                // Missing a steal means there may be an item that we were unable to get.
+                // Effectively, we failed to fulfill our promise to check the queues after
                 // clearing "Scheduled" flag.
                 // We need to make sure someone will do another pass.
                 if (missedSteal)
@@ -953,7 +953,7 @@ namespace System.Threading
             // The workitems that are currently in the queues could have asked only for one worker.
             // We are going to process a workitem, which may take unknown time or even block.
             // In a worst case the current workitem will indirectly depend on progress of other
-            // items and that would lead to a deadlock if noone else checks the queue.
+            // items and that would lead to a deadlock if no one else checks the queue.
             // We must ensure at least one more worker is coming if the queue is not empty.
             workQueue.EnsureThreadRequested();
 
@@ -1257,7 +1257,7 @@ namespace System.Threading
             // The batch that is currently in the queue could have asked only for one worker.
             // We are going to process a workitem, which may take unknown time or even block.
             // In a worst case the current workitem will indirectly depend on progress of other
-            // items and that would lead to a deadlock if noone else checks the queue.
+            // items and that would lead to a deadlock if no one else checks the queue.
             // We must ensure at least one more worker is coming if the queue is not empty.
             if (!_workItems.IsEmpty)
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -1229,10 +1229,11 @@ namespace System.Threading
             // Checking for items must happen after resetting the processing state.
             Interlocked.MemoryBarrier();
 
+            ThreadPoolWorkQueueThreadLocals tl = ThreadPoolWorkQueueThreadLocals.threadLocals!;
             if (!_workItems.TryDequeue(out var workItem))
             {
                 // Discount a work item here to avoid counting this queue processing work item
-                ThreadPoolWorkQueueThreadLocals.threadLocals!.threadLocalCompletionCountNode!.Decrement();
+                ThreadInt64PersistentCounter.Decrement(tl.threadLocalCompletionCountObject!);
                 return;
             }
 
@@ -1246,7 +1247,6 @@ namespace System.Threading
                 EnsureWorkerScheduled();
             }
 
-            ThreadPoolWorkQueueThreadLocals tl = ThreadPoolWorkQueueThreadLocals.threadLocals!;
             Debug.Assert(tl != null);
             Thread currentThread = tl.currentThread;
             Debug.Assert(currentThread == Thread.CurrentThread);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -945,7 +945,7 @@ namespace System.Threading
             // We are going to process a workitem, which may take unknown time or even block.
             // In a worst case the current workitem will indirectly depend on progress of other
             // items and that would lead to a deadlock if no one else checks the queue.
-            // We must ensure at least one more worker is coming if the queue is not empty.
+            // We must ensure at least one more worker is coming in case the queue contains more items.
             workQueue.EnsureThreadRequested();
 
             //

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -930,7 +930,7 @@ namespace System.Threading
 
                 // Missing a steal means there may be an item that we were unable to get.
                 // Effectively, we failed to fulfill our promise to check the queues after
-                // clearing "Scheduled" flag.
+                // clearing the outstanding thread request flag.
                 // We need to make sure someone will do another pass.
                 if (missedSteal)
                 {


### PR DESCRIPTION
Fixes: #121608
Backport of https://github.com/dotnet/runtime/pull/121887

The ThreadPool in rare cases allows a scenario when an enqueued workitem is not guaranteed to be executed unless more workitems are enqueued. In some scenarios execution of a particular workitem may be necessary before more work is enqueued, thus leading to a deadlock. 
This is a subtle regression introduced by a change in enqueuer/worker handshake algorithm.

The same pattern is used in 2 other ThreadPool-like internal features in addition to the ThreadPool. 

## Customer Impact

- [ ] Customer reported
- [x] Found internally

## Regression

- [x] Yes
- [ ] No

## Testing

Standard test pass for deterministic regressions.
A targeted stress application that demonstrates the issue. 
(no fix: hangs within 1-2 minutes, with the fix: runs for 20+ min. on the same system)

## Risk
Low. This is a revert to the preexisting algorithm for the enqueuer/worker handshake. (in all 3 places)