### PR TITLE
[Wasm RyuJit] Codegen labels

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -11,7 +11,8 @@
 
 void CodeGen::genMarkLabelsForCodegen()
 {
-    // We have alredy marked labels, so nothing to do here
+    // No work needed here for now.
+    // We mark labels as needed in genEmitStartBlock.
 }
 
 void CodeGen::genFnEpilog(BasicBlock* block)

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -11,8 +11,7 @@
 
 void CodeGen::genMarkLabelsForCodegen()
 {
-    // TODO-WASM: serialize fgWasmControlFlow results into codegen-level metadata/labels
-    // (or use them directly and leave this empty).
+    // We have alredy marked labels, so nothing to do here
 }
 
 void CodeGen::genFnEpilog(BasicBlock* block)
@@ -154,7 +153,13 @@ void CodeGen::genEmitStartBlock(BasicBlock* block)
     while (!wasmControlFlowStack->Empty() && (wasmControlFlowStack->Top()->End() == cursor))
     {
         instGen(INS_end);
-        wasmControlFlowStack->Pop();
+        WasmInterval* interval = wasmControlFlowStack->Pop();
+
+        if (!interval->IsLoop() && !block->HasFlag(BBF_HAS_LABEL))
+        {
+            block->SetFlags(BBF_HAS_LABEL);
+            genDefineTempLabel(block);
+        }
     }
 
     // Push control flow for intervals that start here or earlier, and emit
@@ -178,6 +183,12 @@ void CodeGen::genEmitStartBlock(BasicBlock* block)
 
             wasmCursor++;
             wasmControlFlowStack->Push(interval);
+
+            if (interval->IsLoop() && !block->HasFlag(BBF_HAS_LABEL))
+            {
+                block->SetFlags(BBF_HAS_LABEL);
+                genDefineTempLabel(block);
+            }
 
             if (wasmCursor >= compiler->fgWasmIntervals->size())
             {
@@ -349,7 +360,7 @@ void CodeGen::genTableBasedSwitch(GenTree* treeNode)
         BasicBlock* const caseTarget = desc->GetCase(caseNum)->getDestinationBlock();
         unsigned          depth      = findTargetDepth(caseTarget);
 
-        GetEmitter()->emitIns_I(INS_label, EA_4BYTE, depth);
+        GetEmitter()->emitIns_J(INS_label, EA_4BYTE, depth, caseTarget);
     }
 }
 
@@ -878,7 +889,7 @@ void CodeGen::inst_JMP(emitJumpKind jmp, BasicBlock* tgtBlock)
 {
     instruction    instr = emitter::emitJumpKindToIns(jmp);
     unsigned const depth = findTargetDepth(tgtBlock);
-    GetEmitter()->emitIns_I(instr, EA_4BYTE, depth);
+    GetEmitter()->emitIns_J(instr, EA_4BYTE, depth, tgtBlock);
 }
 
 void CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUGARG(void* code))

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -1729,6 +1729,7 @@ void* emitter::emitAllocAnyInstr(size_t sz, emitAttr opsz)
         assert(info->idFinallyCall == false);
         assert(info->idCatchRet == false);
         assert(info->idCallSig == nullptr);
+        assert(info->idTargetBlock == nullptr);
 
         info->idNum  = emitInsCount;
         info->idSize = sz;

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -892,6 +892,10 @@ protected:
         insOpts  _idInsOpt    : 3; // options for Load/Store instructions
 #endif
 
+#ifdef TARGET_WASM
+        unsigned _idJump : 1; // jump descriptor
+#endif
+
         ////////////////////////////////////////////////////////////////////////
         // Space taken up to here:
         // x86:         50 bits
@@ -900,7 +904,7 @@ protected:
         // arm64:       55 bits
         // loongarch64: 46 bits
         // risc-v:      46 bits
-        // wasm:        28 bits
+        // wasm:        29 bits
 
         //
         // How many bits have been used beyond the first 32?
@@ -918,7 +922,7 @@ protected:
 #elif defined(TARGET_AMD64)
 #define ID_EXTRA_BITFIELD_BITS (20)
 #elif defined(TARGET_WASM)
-#define ID_EXTRA_BITFIELD_BITS (-4)
+#define ID_EXTRA_BITFIELD_BITS (-3)
 #else
 #error Unsupported or unset target architecture
 #endif
@@ -1934,6 +1938,17 @@ protected:
             _idLclVar = 1;
         }
 #endif // TARGET_RISCV64
+
+#ifdef TARGET_WASM
+        bool idIsJump() const
+        {
+            return _idJump != 0;
+        }
+        void idSetIsJump()
+        {
+            _idJump = 1;
+        }
+#endif
 
         bool idIsCnsReloc() const
         {

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -637,6 +637,7 @@ protected:
         bool              idFinallyCall; // Branch instruction is a call to finally
         bool              idCatchRet;    // Instruction is for a catch 'return'
         CORINFO_SIG_INFO* idCallSig;     // Used to report native call site signatures to the EE
+        BasicBlock*       idTargetBlock; // Target block for branches
     };
 
 #ifdef TARGET_ARM
@@ -892,10 +893,6 @@ protected:
         insOpts  _idInsOpt    : 3; // options for Load/Store instructions
 #endif
 
-#ifdef TARGET_WASM
-        unsigned _idJump : 1; // jump descriptor
-#endif
-
         ////////////////////////////////////////////////////////////////////////
         // Space taken up to here:
         // x86:         50 bits
@@ -904,7 +901,7 @@ protected:
         // arm64:       55 bits
         // loongarch64: 46 bits
         // risc-v:      46 bits
-        // wasm:        29 bits
+        // wasm:        28 bits
 
         //
         // How many bits have been used beyond the first 32?
@@ -922,7 +919,7 @@ protected:
 #elif defined(TARGET_AMD64)
 #define ID_EXTRA_BITFIELD_BITS (20)
 #elif defined(TARGET_WASM)
-#define ID_EXTRA_BITFIELD_BITS (-3)
+#define ID_EXTRA_BITFIELD_BITS (-4)
 #else
 #error Unsupported or unset target architecture
 #endif
@@ -1938,17 +1935,6 @@ protected:
             _idLclVar = 1;
         }
 #endif // TARGET_RISCV64
-
-#ifdef TARGET_WASM
-        bool idIsJump() const
-        {
-            return _idJump != 0;
-        }
-        void idSetIsJump()
-        {
-            _idJump = 1;
-        }
-#endif
 
         bool idIsCnsReloc() const
         {

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -52,7 +52,7 @@ void emitter::emitIns_I(instruction ins, emitAttr attr, cnsval_ssize_t imm)
 // Arguments:
 //   ins         - instruction to emit
 //   attr        - emit attributes
-//   imm         - immediiate value (depth in control flow stack)
+//   imm         - immediate value (depth in control flow stack)
 //   targetBlock - block at that depth
 //
 void emitter::emitIns_J(instruction ins, emitAttr attr, cnsval_ssize_t imm, BasicBlock* targetBlock)
@@ -468,7 +468,6 @@ void emitter::emitDispIns(
     {
         case IF_OPCODE:
         case IF_BLOCK:
-            dispJumpTargetIfAny();
             break;
 
         case IF_LABEL:

--- a/src/coreclr/jit/emitwasm.h
+++ b/src/coreclr/jit/emitwasm.h
@@ -18,6 +18,7 @@ void emitDispInst(instruction ins);
 public:
 void emitIns(instruction ins);
 void emitIns_I(instruction ins, emitAttr attr, cnsval_ssize_t imm);
+void emitIns_J(instruction ins, emitAttr attr, cnsval_ssize_t imm, BasicBlock* tgtBlock);
 void emitIns_S(instruction ins, emitAttr attr, int varx, int offs);
 void emitIns_R(instruction ins, emitAttr attr, regNumber reg);
 


### PR DESCRIPTION
Create emitter labels for places Wasm will branch to, and display the instr group branch targets as comments when dumping out disassembly.