### PR TITLE
Fix the MinimumPlatformVersion for Mac Catalyst in the Mach-O writer.

### DIFF
--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/MachObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/MachObjectWriter.cs
@@ -265,7 +265,7 @@ namespace ILCompiler.ObjectWriter
 
                 case TargetOS.MacCatalyst:
                     buildVersion.Platform = PLATFORM_MACCATALYST;
-                    buildVersion.MinimumPlatformVersion = 0x0F_02_00; // 15.0.0
+                    buildVersion.MinimumPlatformVersion = 0x0F_00_00; // 15.0.0
                     break;
 
                 case TargetOS.iOS:


### PR DESCRIPTION
The constant didn't match the comment, and since the comment is correct, fix the constant.