### PR TITLE
Fix Double/Single.ConvertToIntegerNative for non-primitive types in interpreter

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3144,7 +3144,9 @@ bool InterpCompiler::EmitNamedIntrinsicCall(NamedIntrinsic ni, bool nonVirtualCa
             if (g_stackTypeFromInterpType[targetType] != StackTypeI4 &&
                 g_stackTypeFromInterpType[targetType] != StackTypeI8)
             {
-                goto FAIL_TO_EXPAND_INTRINSIC;
+                // The intrinsic is must expand only when the target type is primitive. For other types (e.g. int128),
+                // use the compiled method.
+                return false;
             }
 
             InterpOpcode convOp;


### PR DESCRIPTION
The current interpreter logic handles the
System.Double/Single.ConvertToIntegerNative always as must expand and fails with NO_WAY if the integer type is not primitive. However, that makes it incorrectly fail e.g. when the integer type is Int128.

This change fixes it by using the compiled version of the function for non-primitive types.
It fixes the following libraries tests:
*  System.Tests.DoubleTests_GenericMath.ConvertToIntegerNativeTest
*  System.Tests.SingleTests_GenericMath.ConvertToIntegerNativeTest