### PR TITLE
[clr-interp] ckfinite throws wrong exception.

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -674,14 +674,14 @@ template <typename TResult, typename TSource> void ConvOvfHelper(int8_t *stack, 
 static float CkfiniteHelper(float value)
 {
     if (!std::isfinite(value))
-        COMPlusThrow(kArithmeticException);
+        COMPlusThrow(kOverflowException);
     return value;
 }
 
 static double CkfiniteHelper(double value)
 {
     if (!std::isfinite(value))
-        COMPlusThrow(kArithmeticException);
+        COMPlusThrow(kOverflowException);
     return value;
 }
 


### PR DESCRIPTION
It turns out that RyuJit throws OverflowException here, not ArithmeticException. This isn't against the ECMA spec since OverflowException derives from ArithmeticException, so lets just follow Ryujit's lead.