### PR TITLE
[clr-interp] Fix conversion from unsigned integer to float

### DIFF
--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -825,6 +825,9 @@ private:
     // Opcode peeps
     bool    FindAndApplyPeep(OpcodePeep* Peeps[]);
 
+    bool    IsConvRUnR4Peep(const uint8_t* ip, OpcodePeepElement* peep, void** computedInfo) { return true; }
+    int     ApplyConvRUnR4Peep(const uint8_t* ip, OpcodePeepElement* peep, void* computedInfo);
+
     bool    IsStoreLoadPeep(const uint8_t* ip, OpcodePeepElement* peep, void** computedInfo);
     int     ApplyStoreLoadPeep(const uint8_t* ip, OpcodePeepElement* peep, void* computedInfo);
 

--- a/src/coreclr/interpreter/inc/intops.def
+++ b/src/coreclr/interpreter/inc/intops.def
@@ -137,8 +137,11 @@ OPDEF(INTOP_NOT_I8, "not.i8", 3, 1, 1, InterpOpNoArgs)
 OPDEF(INTOP_CKFINITE_R4, "ckfinite.r4", 3, 1, 1, InterpOpNoArgs)
 OPDEF(INTOP_CKFINITE_R8, "ckfinite.r8", 3, 1, 1, InterpOpNoArgs)
 
-OPDEF(INTOP_CONV_R_UN_I4, "conv.r.un.i4", 3, 1, 1, InterpOpNoArgs)
-OPDEF(INTOP_CONV_R_UN_I8, "conv.r.un.i8", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_R4_UN_I4, "conv.r4.un.i4", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_R4_UN_I8, "conv.r4.un.i8", 3, 1, 1, InterpOpNoArgs)
+
+OPDEF(INTOP_CONV_R8_UN_I4, "conv.r8.un.i4", 3, 1, 1, InterpOpNoArgs)
+OPDEF(INTOP_CONV_R8_UN_I8, "conv.r8.un.i8", 3, 1, 1, InterpOpNoArgs)
 
 OPDEF(INTOP_CONV_I1_I4, "conv.i1.i4", 3, 1, 1, InterpOpNoArgs)
 OPDEF(INTOP_CONV_I1_I8, "conv.i1.i8", 3, 1, 1, InterpOpNoArgs)

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1067,12 +1067,20 @@ MAIN_LOOP:
                     ip += 3;
                     break;
 
-                case INTOP_CONV_R_UN_I4:
+                case INTOP_CONV_R8_UN_I4:
                     LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], uint32_t);
                     ip += 3;
                     break;
-                case INTOP_CONV_R_UN_I8:
+                case INTOP_CONV_R8_UN_I8:
                     LOCAL_VAR(ip[1], double) = (double)LOCAL_VAR(ip[2], uint64_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_R4_UN_I4:
+                    LOCAL_VAR(ip[1], float) = (float)LOCAL_VAR(ip[2], uint32_t);
+                    ip += 3;
+                    break;
+                case INTOP_CONV_R4_UN_I8:
+                    LOCAL_VAR(ip[1], float) = (float)LOCAL_VAR(ip[2], uint64_t);
                     ip += 3;
                     break;
                 case INTOP_CONV_I1_I4:


### PR DESCRIPTION
- There isn't a single instruction for this, but the jit recognizes the conv.r.un + conv.r4 pattern as meaning convert directly from unsigned integer to float. Per ECMA it is valid to do processing at a higher intermediate precision, but RyuJit/interpreter follows tighter rules which result in less loss of precision.

Fixes Runtime_106338 test.