### PR TITLE
[Wasm Ryujit] codegen for NOT and NEG

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1131,7 +1131,7 @@ protected:
     void genCodeForLclAddr(GenTreeLclFld* lclAddrNode);
     void genCodeForIndexAddr(GenTreeIndexAddr* tree);
     void genCodeForIndir(GenTreeIndir* tree);
-    void genCodeForNegNot(GenTree* tree);
+    void genCodeForNegNot(GenTreeOp* tree);
     void genCodeForBswap(GenTree* tree);
     bool genCanOmitNormalizationForBswap16(GenTree* tree);
     void genCodeForLclVar(GenTreeLclVar* tree);

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -755,7 +755,7 @@ instruction CodeGen::genGetInsForOper(genTreeOps oper, var_types type)
 // Arguments:
 //    tree - the node
 //
-void CodeGen::genCodeForNegNot(GenTree* tree)
+void CodeGen::genCodeForNegNot(GenTreeOp* tree)
 {
     assert(tree->OperIs(GT_NEG, GT_NOT));
 

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -3303,7 +3303,7 @@ BAILOUT:
 // Arguments:
 //    tree - the node
 //
-void CodeGen::genCodeForNegNot(GenTree* tree)
+void CodeGen::genCodeForNegNot(GenTreeOp* tree)
 {
     assert(tree->OperIs(GT_NEG, GT_NOT));
 

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -198,7 +198,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 
         case GT_NOT:
         case GT_NEG:
-            genCodeForNegNot(treeNode);
+            genCodeForNegNot(treeNode->AsOp());
             break;
 
 #if defined(TARGET_ARM64)

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -1710,7 +1710,7 @@ BAILOUT:
 // Arguments:
 //    tree - the node
 //
-void CodeGen::genCodeForNegNot(GenTree* tree)
+void CodeGen::genCodeForNegNot(GenTreeOp* tree)
 {
     assert(tree->OperIs(GT_NEG, GT_NOT));
 

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -4116,7 +4116,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 
         case GT_NOT:
         case GT_NEG:
-            genCodeForNegNot(treeNode);
+            genCodeForNegNot(treeNode->AsOp());
             break;
 
         case GT_BSWAP:

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -3870,7 +3870,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 
         case GT_NOT:
         case GT_NEG:
-            genCodeForNegNot(treeNode);
+            genCodeForNegNot(treeNode->AsOp());
             break;
 
         case GT_BSWAP:

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -1646,7 +1646,7 @@ BAILOUT:
 // Arguments:
 //    tree - the node
 //
-void CodeGen::genCodeForNegNot(GenTree* tree)
+void CodeGen::genCodeForNegNot(GenTreeOp* tree)
 {
     assert(tree->OperIs(GT_NEG, GT_NOT));
 

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -700,7 +700,7 @@ void CodeGen::genCodeForNegNot(GenTree* tree)
             break;
         case PackOperAndType(GT_NEG, TYP_INT):
         case PackOperAndType(GT_NEG, TYP_LONG):
-            // We cannot easily emit i32.sub(x, 0) here since x is already on the stack.
+            // We cannot easily emit i32.sub(0, x) here since x is already on the stack.
             // So we transform these to SUB in lower.
             unreached();
             break;

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -282,6 +282,11 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             genCodeForConstant(treeNode);
             break;
 
+        case GT_NEG:
+        case GT_NOT:
+            genCodeForNegNot(treeNode);
+            break;
+
         default:
 #ifdef DEBUG
             NYIRAW(GenTree::OpName(treeNode->OperGet()));
@@ -658,6 +663,57 @@ void CodeGen::genCodeForShift(GenTree* tree)
         default:
             ins = INS_none;
             NYI_WASM("genCodeForShift");
+            break;
+    }
+
+    GetEmitter()->emitIns(ins);
+    genProduceReg(treeNode);
+}
+
+//------------------------------------------------------------------------
+// genCodeForNegNot: Generate code for a neg/not
+//
+// Arguments:
+//    tree - neg/not tree node
+//
+void CodeGen::genCodeForNegNot(GenTree* tree)
+{
+    assert(tree->OperIs(GT_NEG, GT_NOT));
+
+    GenTreeOp* treeNode = tree->AsOp();
+    genConsumeOperands(treeNode);
+
+    instruction ins;
+    switch (PackOperAndType(treeNode))
+    {
+        case PackOperAndType(GT_NOT, TYP_INT):
+            GetEmitter()->emitIns_I(INS_i32_const, emitTypeSize(treeNode), -1);
+            ins = INS_i32_xor;
+            break;
+        case PackOperAndType(GT_NOT, TYP_LONG):
+            GetEmitter()->emitIns_I(INS_i64_const, emitTypeSize(treeNode), -1);
+            ins = INS_i64_xor;
+            break;
+        case PackOperAndType(GT_NOT, TYP_FLOAT):
+        case PackOperAndType(GT_NOT, TYP_DOUBLE):
+            unreached();
+            break;
+        case PackOperAndType(GT_NEG, TYP_INT):
+        case PackOperAndType(GT_NEG, TYP_LONG):
+            // We cannot easily emit i32.sub(x, 0) here since x is already on the stack.
+            // So we transform these to SUB in lower.
+            unreached();
+            break;
+        case PackOperAndType(GT_NEG, TYP_FLOAT):
+            ins = INS_f32_neg;
+            break;
+        case PackOperAndType(GT_NEG, TYP_DOUBLE):
+            ins = INS_f64_neg;
+            break;
+
+        default:
+            ins = INS_none;
+            NYI_WASM("genCodeForNegNot");
             break;
     }
 

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -284,7 +284,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 
         case GT_NEG:
         case GT_NOT:
-            genCodeForNegNot(treeNode);
+            genCodeForNegNot(treeNode->AsOp());
             break;
 
         default:
@@ -676,22 +676,20 @@ void CodeGen::genCodeForShift(GenTree* tree)
 // Arguments:
 //    tree - neg/not tree node
 //
-void CodeGen::genCodeForNegNot(GenTree* tree)
+void CodeGen::genCodeForNegNot(GenTreeOp* tree)
 {
     assert(tree->OperIs(GT_NEG, GT_NOT));
-
-    GenTreeOp* treeNode = tree->AsOp();
-    genConsumeOperands(treeNode);
+    genConsumeOperands(tree);
 
     instruction ins;
-    switch (PackOperAndType(treeNode))
+    switch (PackOperAndType(tree))
     {
         case PackOperAndType(GT_NOT, TYP_INT):
-            GetEmitter()->emitIns_I(INS_i32_const, emitTypeSize(treeNode), -1);
+            GetEmitter()->emitIns_I(INS_i32_const, emitTypeSize(tree), -1);
             ins = INS_i32_xor;
             break;
         case PackOperAndType(GT_NOT, TYP_LONG):
-            GetEmitter()->emitIns_I(INS_i64_const, emitTypeSize(treeNode), -1);
+            GetEmitter()->emitIns_I(INS_i64_const, emitTypeSize(tree), -1);
             ins = INS_i64_xor;
             break;
         case PackOperAndType(GT_NOT, TYP_FLOAT):
@@ -712,13 +710,12 @@ void CodeGen::genCodeForNegNot(GenTree* tree)
             break;
 
         default:
-            ins = INS_none;
-            NYI_WASM("genCodeForNegNot");
+            unreached();
             break;
     }
 
     GetEmitter()->emitIns(ins);
-    genProduceReg(treeNode);
+    genProduceReg(tree);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -654,7 +654,7 @@ void CodeGen::genSetRegToConst(regNumber targetReg, var_types targetType, GenTre
 // Arguments:
 //    tree - the node
 //
-void CodeGen::genCodeForNegNot(GenTree* tree)
+void CodeGen::genCodeForNegNot(GenTreeOp* tree)
 {
     assert(tree->OperIs(GT_NEG, GT_NOT));
 
@@ -1919,7 +1919,7 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 
         case GT_NOT:
         case GT_NEG:
-            genCodeForNegNot(treeNode);
+            genCodeForNegNot(treeNode->AsOp());
             break;
 
         case GT_BSWAP:

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -9689,14 +9689,14 @@ void Lowering::ContainCheckRet(GenTreeUnOp* ret)
 {
     assert(ret->OperIs(GT_RETURN, GT_SWIFT_ERROR_RET));
 
-#if !defined(TARGET_64BIT) && !defined(TARGET_WASM)
+#if LOWER_DECOMPOSE_LONGS
     if (ret->TypeIs(TYP_LONG))
     {
         GenTree* op1 = ret->AsOp()->GetReturnValue();
         noway_assert(op1->OperIs(GT_LONG));
         MakeSrcContained(ret, op1);
     }
-#endif // !defined(TARGET_64BIT) && !defined(TARGET_WASM)
+#endif // LOWER_DECOMPOSE_LONGS
 #if FEATURE_MULTIREG_RET
     if (ret->TypeIs(TYP_STRUCT))
     {

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -466,7 +466,10 @@ GenTree* Lowering::LowerNode(GenTree* node)
             ContainCheckNeg(node->AsOp());
         }
 #endif
-        break;
+#ifdef TARGET_WASM
+            return LowerNeg(node->AsOp());
+#endif
+            break;
         case GT_NOT:
 #ifdef TARGET_ARM64
             ContainCheckNot(node->AsOp());
@@ -9686,14 +9689,14 @@ void Lowering::ContainCheckRet(GenTreeUnOp* ret)
 {
     assert(ret->OperIs(GT_RETURN, GT_SWIFT_ERROR_RET));
 
-#if !defined(TARGET_64BIT)
+#if !defined(TARGET_64BIT) && !defined(TARGET_WASM)
     if (ret->TypeIs(TYP_LONG))
     {
         GenTree* op1 = ret->AsOp()->GetReturnValue();
         noway_assert(op1->OperIs(GT_LONG));
         MakeSrcContained(ret, op1);
     }
-#endif // !defined(TARGET_64BIT)
+#endif // !defined(TARGET_64BIT) && !defined(TARGET_WASM)
 #if FEATURE_MULTIREG_RET
     if (ret->TypeIs(TYP_STRUCT))
     {

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -417,6 +417,10 @@ private:
     GenTree* TryLowerMulWithConstant(GenTreeOp* node);
 #endif // TARGET_XARCH
 
+#ifdef TARGET_WASM
+    GenTree* LowerNeg(GenTreeOp* node);
+#endif
+
     bool TryCreateAddrMode(GenTree* addr, bool isContainable, GenTree* parent);
 
     bool TryTransformStoreObjAsStoreInd(GenTreeBlk* blkNode);

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -102,6 +102,35 @@ GenTree* Lowering::LowerMul(GenTreeOp* mul)
 }
 
 //------------------------------------------------------------------------
+// LowerMul: Lower a GT_NEG node.
+//
+// Arguments:
+//    node - The node to lower
+//
+// Return Value:
+//    The next node to lower.
+//
+GenTree* Lowering::LowerNeg(GenTreeOp* node)
+{
+    if (!node->TypeIs(TYP_INT, TYP_LONG))
+    {
+        return node->gtNext;
+    }
+
+    // For ints, NEG(x) ==> SUB(0, x)
+    //
+    GenTree* x    = node->gtGetOp1();
+    GenTree* zero = comp->gtNewZeroConNode(node->TypeGet());
+    BlockRange().InsertBefore(x, zero);
+    LowerNode(zero);
+    node->ChangeOper(GT_SUB);
+    node->gtOp1 = zero;
+    node->gtOp2 = x;
+
+    return LowerNode(node);
+}
+
+//------------------------------------------------------------------------
 // Lowering::LowerJTrue: Lowers a JTRUE node.
 //
 // Arguments:

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -102,7 +102,7 @@ GenTree* Lowering::LowerMul(GenTreeOp* mul)
 }
 
 //------------------------------------------------------------------------
-// LowerMul: Lower a GT_NEG node.
+// LowerNeg: Lower a GT_NEG node.
 //
 // Arguments:
 //    node - The node to lower
@@ -117,7 +117,7 @@ GenTree* Lowering::LowerNeg(GenTreeOp* node)
         return node->gtNext;
     }
 
-    // For ints, NEG(x) ==> SUB(0, x)
+    // For integer types (TYP_INT and TYP_LONG), NEG(x) ==> SUB(0, x)
     //
     GenTree* x    = node->gtGetOp1();
     GenTree* zero = comp->gtNewZeroConNode(node->TypeGet());


### PR DESCRIPTION
Wasm has a few wrinkles here to sort through. There is no NOT or NEG for integer types in Wasm.

Also, support returning TYP_LONG directly.