### PR TITLE
[infra][tvOS] Use arm64 tvOS simulator instead of x64

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -33,7 +33,7 @@ jobs:
     helixQueues:
 
     # iOS Simulator/Mac Catalyst arm64
-    - ${{ if in(parameters.platform, 'maccatalyst_arm64', 'iossimulator_arm64') }}:
+    - ${{ if in(parameters.platform, 'iossimulator_arm64', 'tvossimulator_arm64', 'maccatalyst_arm64') }}:
       - OSX.15.Arm64.Open
 
     # iOS/tvOS Simulator x64 & MacCatalyst x64

--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslikesimulator.yml
@@ -24,8 +24,8 @@ jobs:
     isiOSLikeSimulatorOnlyBuild: ${{ parameters.isiOSLikeSimulatorOnlyBuild }}
     platforms:
     - iossimulator_x64
-    - tvossimulator_x64
     - iossimulator_arm64
+    - tvossimulator_arm64
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange
@@ -58,8 +58,8 @@ jobs:
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
       - iossimulator_x64
-      - tvossimulator_x64
       - iossimulator_arm64
+      - tvossimulator_arm64
     variables:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - name: _HelixSource
@@ -103,8 +103,8 @@ jobs:
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
       - iossimulator_x64
-      - tvossimulator_x64
       - iossimulator_arm64
+      - tvossimulator_arm64
     variables:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - name: _HelixSource

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -91,7 +91,7 @@ jobs:
       - Windows.11.Amd64.Android.Open
 
     # iOS Simulator/Mac Catalyst arm64
-    - ${{ if in(parameters.platform, 'maccatalyst_arm64', 'iossimulator_arm64') }}:
+    - ${{ if in(parameters.platform, 'iossimulator_arm64', 'tvossimulator_arm64', 'maccatalyst_arm64') }}:
       - OSX.15.Arm64.Open
 
     # iOS/tvOS Simulator x64 & MacCatalyst x64

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -793,7 +793,7 @@ extends:
           buildConfig: ${{ variables.debugOnPrReleaseOnRolling }}
           runtimeFlavor: mono
           platforms:
-          - tvossimulator_x64
+          - tvossimulator_arm64
           - linux_x64
           - linux_arm
           - linux_arm64


### PR DESCRIPTION
Use arm64 tvOS simulator instead of x64. We still keep coverage over x64 iOS simulators.