### PR TITLE
[RyuJit/WASM] Add jitinterface as wasmjit dependency

### DIFF
--- a/src/coreclr/tools/aot/jitinterface/CMakeLists.txt
+++ b/src/coreclr/tools/aot/jitinterface/CMakeLists.txt
@@ -20,4 +20,5 @@ add_library_clr(jitinterface_${ARCH_HOST_NAME}
 target_link_libraries(jitinterface_${ARCH_HOST_NAME} PRIVATE minipal)
 
 install_clr(TARGETS jitinterface_${ARCH_HOST_NAME} DESTINATIONS . COMPONENT jit)
+install_clr(TARGETS jitinterface_${ARCH_HOST_NAME} DESTINATIONS . COMPONENT wasmjit)
 install_clr(TARGETS jitinterface_${ARCH_HOST_NAME} DESTINATIONS . COMPONENT alljits)


### PR DESCRIPTION
This automatically rebuilds jitinterface with `./build clr.wasmjit` if needed, like with the other jit subsets.
