### PR TITLE
[clr-interp] Fix a grab bag of issues, mostly around the profiler

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1814,7 +1814,7 @@ InterpMethod* InterpCompiler::CompileMethod()
 
     if (m_corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_PROF_ENTERLEAVE))
     {
-        BADCODE("Interpreter does not support profiling enter/leave hooks\n");
+        NO_WAY("Interpreter does not support profiling enter/leave hooks\n");
     }
 
     m_isSynchronized = m_compHnd->getMethodAttribs(m_methodHnd) & CORINFO_FLG_SYNCH;

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3989,7 +3989,7 @@ void InterpCompiler::EmitCalli(bool isTailCall, void* calliCookie, int callIFunc
         if (m_compHnd->pInvokeMarshalingRequired(NULL, callSiteSig))
         {
             // If we remove this restriction, we should handle the track transitions scenario by forcing a 
-            // p/invoke marshaling calli stub even when needed.
+            // p/invoke marshaling calli stub even when not needed.
             BADCODE("PInvoke marshalling for calli is not supported in interpreted code");
         }
         m_compHnd->getUnmanagedCallConv(nullptr, callSiteSig, &suppressGCTransition);

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1719,13 +1719,11 @@ InterpMethod* InterpCompiler::CreateInterpMethod()
         pDataItems[i] = m_dataItems.Get(i);
 
     bool initLocals = (m_methodInfo->options & CORINFO_OPT_INIT_LOCALS) != 0;
-    CORJIT_FLAGS corJitFlags;
-    DWORD jitFlagsSize = m_compHnd->getJitFlags(&corJitFlags, sizeof(corJitFlags));
-    assert(jitFlagsSize == sizeof(corJitFlags));
 
-    bool unmanagedCallersOnly = corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_REVERSE_PINVOKE);
+    bool unmanagedCallersOnly = m_corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_REVERSE_PINVOKE);
+    bool publishSecretStubParam = m_corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_SECRET_PARAM);
 
-    InterpMethod *pMethod = new InterpMethod(m_methodHnd, m_ILLocalsOffset, m_totalVarsStackSize, pDataItems, initLocals, unmanagedCallersOnly);
+    InterpMethod *pMethod = new InterpMethod(m_methodHnd, m_ILLocalsOffset, m_totalVarsStackSize, pDataItems, initLocals, unmanagedCallersOnly, publishSecretStubParam);
 
     return pMethod;
 }
@@ -1784,6 +1782,8 @@ InterpCompiler::InterpCompiler(COMP_HANDLE compHnd,
     m_compHnd = compHnd;
     m_methodInfo = methodInfo;
     m_classHnd   = compHnd->getMethodClass(m_methodHnd);
+    DWORD jitFlagsSize = m_compHnd->getJitFlags(&m_corJitFlags, sizeof(m_corJitFlags));
+    assert(jitFlagsSize == sizeof(m_corJitFlags));
 
 #ifdef DEBUG
     m_methodName = ::PrintMethodName(compHnd, m_classHnd, m_methodHnd, &m_methodInfo->args,
@@ -1811,6 +1811,11 @@ InterpMethod* InterpCompiler::CompileMethod()
         InterpreterCompilerBreak();
     }
 #endif
+
+    if (m_corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_PROF_ENTERLEAVE))
+    {
+        BADCODE("Interpreter does not support profiling enter/leave hooks\n");
+    }
 
     m_isSynchronized = m_compHnd->getMethodAttribs(m_methodHnd) & CORINFO_FLG_SYNCH;
     if (m_isSynchronized)
@@ -3983,6 +3988,8 @@ void InterpCompiler::EmitCalli(bool isTailCall, void* calliCookie, int callIFunc
     {
         if (m_compHnd->pInvokeMarshalingRequired(NULL, callSiteSig))
         {
+            // If we remove this restriction, we should handle the track transitions scenario by forcing a 
+            // p/invoke marshaling calli stub even when needed.
             BADCODE("PInvoke marshalling for calli is not supported in interpreted code");
         }
         m_compHnd->getUnmanagedCallConv(nullptr, callSiteSig, &suppressGCTransition);
@@ -4442,6 +4449,16 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
 
     bool isPInvoke = callInfo.methodFlags & CORINFO_FLG_PINVOKE;
     bool isMarshaledPInvoke = isPInvoke && m_compHnd->pInvokeMarshalingRequired(callInfo.hMethod, &callInfo.sig);
+
+    if (isPInvoke && m_corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_PROF_NO_PINVOKE_INLINE))
+    {
+        // If the method is a pinvoke il stub, we can inline pinvokes
+        if (!(m_compHnd->getMethodAttribs(m_methodInfo->ftn) & CORINFO_FLG_PINVOKE))
+        {
+            // Otherwise, we have to treat it as a marshaled pinvoke
+            isMarshaledPInvoke = true;
+        }
+    }
 
     // Process sVars
     int numArgsFromStack = callInfo.sig.numArgs + (newObj ? 0 : callInfo.sig.hasImplicitThis());
@@ -6556,11 +6573,7 @@ int InterpCompiler::ApplyTypeEqualityCheckPeep(const uint8_t* ip, OpcodePeepElem
 
 bool InterpCompiler::IsStoreLoadPeep(const uint8_t* ip, OpcodePeepElement* pattern, void** ppComputedInfo)
 {
-    CORJIT_FLAGS corJitFlags;
-    DWORD jitFlagsSize = m_compHnd->getJitFlags(&corJitFlags, sizeof(corJitFlags));
-    assert(jitFlagsSize == sizeof(corJitFlags));
-
-    if (corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE))
+    if (m_corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_DEBUG_CODE))
     {
         return false; // Don't optimize in debug code, this can remove needed sequence points
     }
@@ -7231,11 +7244,7 @@ void InterpCompiler::GenerateCode(CORINFO_METHOD_INFO* methodInfo)
         m_pLastNewIns->SetSVar(m_continuationArgIndex);
     }
 
-    CORJIT_FLAGS corJitFlags;
-    DWORD jitFlagsSize = m_compHnd->getJitFlags(&corJitFlags, sizeof(corJitFlags));
-    assert(jitFlagsSize == sizeof(corJitFlags));
-
-    if (corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_SECRET_PARAM))
+    if (m_corJitFlags.IsSet(CORJIT_FLAGS::CORJIT_FLAG_PUBLISH_SECRET_PARAM))
     {
         m_hiddenArgumentVar = CreateVarExplicit(InterpTypeI, NULL, sizeof(void *));
         AddIns(INTOP_STORESTUBCONTEXT);

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -552,6 +552,7 @@ private:
     CORINFO_MODULE_HANDLE m_compScopeHnd;
     COMP_HANDLE m_compHnd;
     CORINFO_METHOD_INFO* m_methodInfo;
+    CORJIT_FLAGS m_corJitFlags;
 
     void DeclarePointerIsClass(CORINFO_CLASS_HANDLE clsHnd)
     {

--- a/src/coreclr/interpreter/inc/interpretershared.h
+++ b/src/coreclr/interpreter/inc/interpretershared.h
@@ -45,11 +45,12 @@ struct InterpMethod
     CallStubHeader *pCallStub;
     bool initLocals;
     bool unmanagedCallersOnly;
+    bool publishSecretStubParam;
 
 #ifdef INTERPRETER_COMPILER_INTERNAL
     InterpMethod(
         CORINFO_METHOD_HANDLE methodHnd, int32_t argsSize, int32_t allocaSize,
-        void** pDataItems, bool initLocals, bool unmanagedCallersOnly
+        void** pDataItems, bool initLocals, bool unmanagedCallersOnly, bool publishSecretStubParam
     )
     {
 #if DEBUG
@@ -61,6 +62,7 @@ struct InterpMethod
         this->pDataItems = pDataItems;
         this->initLocals = initLocals;
         this->unmanagedCallersOnly = unmanagedCallersOnly;
+        this->publishSecretStubParam = publishSecretStubParam;
         pCallStub = NULL;
     }
 #endif

--- a/src/coreclr/vm/dllimportcallback.cpp
+++ b/src/coreclr/vm/dllimportcallback.cpp
@@ -198,6 +198,14 @@ VOID CallbackOnCollectedDelegate(UMEntryThunkData* pEntryThunkData)
 #if defined(FEATURE_INTERPRETER)
 PLATFORM_THREAD_LOCAL UMEntryThunkData * t_MostRecentUMEntryThunkData;
 
+UMEntryThunkData* GetMostRecentUMEntryThunkDataNonDestructive()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    UMEntryThunkData* result = t_MostRecentUMEntryThunkData;
+    return result;
+}
+
 UMEntryThunkData* GetMostRecentUMEntryThunkData()
 {
     LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/vm/dllimportcallback.h
+++ b/src/coreclr/vm/dllimportcallback.h
@@ -425,6 +425,7 @@ extern "C" PCODE TheUMEntryPrestubWorker(UMEntryThunkData * pUMEntryThunk);
 
 #if defined(FEATURE_INTERPRETER)
 UMEntryThunkData* GetMostRecentUMEntryThunkData();
+UMEntryThunkData* GetMostRecentUMEntryThunkDataNonDestructive();
 #endif // FEATURE_INTERPRETER
 #endif // !FEATURE_PORTABLE_ENTRYPOINTS
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -136,7 +136,19 @@ void InvokeUnmanagedCalliWithTransition(PCODE ftn, void *cookie, int8_t *stack, 
     inlinedCallFrame.Push();
     {
         GCX_PREEMP();
+#ifdef PROFILING_SUPPORTED
+        if (CORProfilerTrackTransitions() && !pFrame->startIp->Method->methodHnd->IsILStub())
+        {
+            ProfilerManagedToUnmanagedTransitionMD(pFrame->startIp->Method->methodHnd, COR_PRF_TRANSITION_CALL);
+        }
+#endif
         InvokeUnmanagedCalli(ftn, cookie, pArgs, pRet);
+#ifdef PROFILING_SUPPORTED
+        if (CORProfilerTrackTransitions() && !pFrame->startIp->Method->methodHnd->IsILStub())
+        {
+            ProfilerUnmanagedToManagedTransitionMD(pFrame->startIp->Method->methodHnd, COR_PRF_TRANSITION_CALL);
+        }
+#endif
     }
     inlinedCallFrame.Pop();
 }

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -2270,7 +2270,7 @@ EXCEPTION_HANDLER_DECL(FastNExportExceptHandler);
 #endif
 
 #ifdef DEBUGGING_SUPPORTED
-static void DebuggerTraceCall(void* returnAddr, void* thunkDataMaybe)
+void DebuggerTraceCall(void* returnAddr, void* thunkDataMaybe)
 {
     _ASSERTE(CORDebuggerTraceCall());
     _ASSERTE(returnAddr != NULL);

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1933,6 +1933,10 @@ static InterpThreadContext* GetInterpThreadContext()
     return threadContext;
 }
 
+#ifdef DEBUGGING_SUPPORTED
+void DebuggerTraceCall(void* returnAddr, void* thunkDataMaybe);
+#endif
+
 extern "C" void* STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBlock, TADDR byteCodeAddr, void* retBuff)
 {
     // Argument registers are in the TransitionBlock
@@ -1941,6 +1945,12 @@ extern "C" void* STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBl
     int8_t *sp = threadContext->pStackPointer;
 
     InterpByteCodeStart* pInterpreterCode = dac_cast<PTR_InterpByteCodeStart>(byteCodeAddr);
+#if (defined(PROFILING_SUPPORTED) || defined(DEBUGGER_SUPPORTED)) && !defined(FEATURE_PORTABLE_ENTRYPOINTS)
+    void* thunkDataMaybe = nullptr;
+#endif
+#if defined(PROFILING_SUPPORTED)
+    MethodDesc* methodDescToReportAsTransition = nullptr;
+#endif
 
     if (pInterpreterCode->Method->unmanagedCallersOnly)
     {
@@ -1951,47 +1961,86 @@ extern "C" void* STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBl
         // Verify the current thread isn't in COOP mode.
         if (thread->PreemptiveGCDisabled())
             ReversePInvokeBadTransition();
-    }
 
-    GCX_MAYBE_COOP(pInterpreterCode->Method->unmanagedCallersOnly);
-
-    // This construct ensures that the InterpreterFrame is always stored at a higher address than the
-    // InterpMethodContextFrame. This is important for the stack walking code.
-    struct Frames
-    {
-        InterpMethodContextFrame interpMethodContextFrame = {0};
-        InterpreterFrame interpreterFrame;
-
-        Frames(TransitionBlock* pTransitionBlock)
-        : interpreterFrame(pTransitionBlock, &interpMethodContextFrame)
+#ifdef PROFILING_SUPPORTED
+        if (CORProfilerTrackTransitions())
         {
+            methodDescToReportAsTransition = pInterpreterCode->Method->methodHnd;
+#ifndef FEATURE_PORTABLE_ENTRYPOINTS
+            void* thunkDataMaybe = nullptr;
+            if (pInterpreterCode->Method->publishSecretStubParam)
+                thunkDataMaybe = GetMostRecentUMEntryThunkDataNonDestructive();
+            if (thunkDataMaybe != NULL)
+            {
+                methodDescToReportAsTransition = ((UMEntryThunkData*)thunkDataMaybe)->GetMethod();
+            }
+#endif // FEATURE_PORTABLE_ENTRYPOINTS
+            ProfilerUnmanagedToManagedTransitionMD(methodDescToReportAsTransition, COR_PRF_TRANSITION_CALL);
         }
+#endif
+#ifdef DEBUGGING_SUPPORTED
+        if (g_TrapReturningThreads && CORDebuggerTraceCall())
+        {
+            void* thunkDataMaybe = nullptr;
+            if (pInterpreterCode->Method->publishSecretStubParam)
+                thunkDataMaybe = GetMostRecentUMEntryThunkDataNonDestructive();
+
+            DebuggerTraceCall((void*)pInterpreterCode->GetByteCodes(), thunkDataMaybe);
+        }
+#endif // DEBUGGING_SUPPORTED
     }
-    frames(pTransitionBlock);
 
-    frames.interpMethodContextFrame.startIp = dac_cast<PTR_InterpByteCodeStart>(byteCodeAddr);
-    frames.interpMethodContextFrame.pStack = sp;
-    frames.interpMethodContextFrame.pRetVal = (retBuff != NULL) ? (int8_t*)retBuff : sp;
+    void* retVal;
+    {
+        GCX_MAYBE_COOP(pInterpreterCode->Method->unmanagedCallersOnly);
 
-    InterpExecMethod(&frames.interpreterFrame, &frames.interpMethodContextFrame, threadContext);
+        // This construct ensures that the InterpreterFrame is always stored at a higher address than the
+        // InterpMethodContextFrame. This is important for the stack walking code.
+        struct Frames
+        {
+            InterpMethodContextFrame interpMethodContextFrame = {0};
+            InterpreterFrame interpreterFrame;
 
-    ArgumentRegisters *pArgumentRegisters = (ArgumentRegisters*)(((uint8_t*)pTransitionBlock) + TransitionBlock::GetOffsetOfArgumentRegisters());
+            Frames(TransitionBlock* pTransitionBlock)
+            : interpreterFrame(pTransitionBlock, &interpMethodContextFrame)
+            {
+            }
+        }
+        frames(pTransitionBlock);
 
-#if defined(TARGET_AMD64)
-    pArgumentRegisters->RCX = (INT_PTR)*frames.interpreterFrame.GetContinuationPtr();
-#elif defined(TARGET_ARM64)
-    pArgumentRegisters->x[2] = (INT64)*frames.interpreterFrame.GetContinuationPtr();
-#elif defined(TARGET_RISCV64)
-    pArgumentRegisters->a[2] = (INT64)*frames.interpreterFrame.GetContinuationPtr();
-#elif defined(TARGET_WASM)
-    // We do not yet have an ABI for WebAssembly native code to handle here.
-#else
-    #error Unsupported architecture
+        frames.interpMethodContextFrame.startIp = dac_cast<PTR_InterpByteCodeStart>(byteCodeAddr);
+        frames.interpMethodContextFrame.pStack = sp;
+        frames.interpMethodContextFrame.pRetVal = (retBuff != NULL) ? (int8_t*)retBuff : sp;
+
+        InterpExecMethod(&frames.interpreterFrame, &frames.interpMethodContextFrame, threadContext);
+
+        ArgumentRegisters *pArgumentRegisters = (ArgumentRegisters*)(((uint8_t*)pTransitionBlock) + TransitionBlock::GetOffsetOfArgumentRegisters());
+
+    #if defined(TARGET_AMD64)
+        pArgumentRegisters->RCX = (INT_PTR)*frames.interpreterFrame.GetContinuationPtr();
+    #elif defined(TARGET_ARM64)
+        pArgumentRegisters->x[2] = (INT64)*frames.interpreterFrame.GetContinuationPtr();
+    #elif defined(TARGET_RISCV64)
+        pArgumentRegisters->a[2] = (INT64)*frames.interpreterFrame.GetContinuationPtr();
+    #elif defined(TARGET_WASM)
+        // We do not yet have an ABI for WebAssembly native code to handle here.
+    #else
+        #error Unsupported architecture
+    #endif
+
+        frames.interpreterFrame.Pop();
+
+        retVal = frames.interpMethodContextFrame.pRetVal;
+    }
+
+#ifdef PROFILING_SUPPORTED
+    if ((methodDescToReportAsTransition != NULL) && CORProfilerTrackTransitions())
+    {
+        ProfilerManagedToUnmanagedTransitionMD(methodDescToReportAsTransition, COR_PRF_TRANSITION_RETURN);
+    }
 #endif
 
-    frames.interpreterFrame.Pop();
-
-    return frames.interpMethodContextFrame.pRetVal;
+    return retVal;
 }
 
 void ExecuteInterpretedMethodWithArgs(TADDR targetIp, int8_t* args, size_t argSize, void* retBuff, PCODE callerIp)

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1979,9 +1979,10 @@ extern "C" void* STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBl
         if (g_TrapReturningThreads && CORDebuggerTraceCall())
         {
             void* thunkDataMaybe = nullptr;
+#ifndef FEATURE_PORTABLE_ENTRYPOINTS
             if (pInterpreterCode->Method->publishSecretStubParam)
                 thunkDataMaybe = GetMostRecentUMEntryThunkDataNonDestructive();
-
+#endif // FEATURE_PORTABLE_ENTRYPOINTS
             DebuggerTraceCall((void*)pInterpreterCode->GetByteCodes(), thunkDataMaybe);
         }
 #endif // DEBUGGING_SUPPORTED

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -1945,9 +1945,6 @@ extern "C" void* STDCALL ExecuteInterpretedMethod(TransitionBlock* pTransitionBl
     int8_t *sp = threadContext->pStackPointer;
 
     InterpByteCodeStart* pInterpreterCode = dac_cast<PTR_InterpByteCodeStart>(byteCodeAddr);
-#if (defined(PROFILING_SUPPORTED) || defined(DEBUGGER_SUPPORTED)) && !defined(FEATURE_PORTABLE_ENTRYPOINTS)
-    void* thunkDataMaybe = nullptr;
-#endif
 #if defined(PROFILING_SUPPORTED)
     MethodDesc* methodDescToReportAsTransition = nullptr;
 #endif

--- a/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/PlatformDetection.cs
@@ -23,6 +23,9 @@ namespace TestLibrary
                                                 ? isEnabled
                                                 : true);
 
+        public static bool IsICorProfilerEnabled => !Utilities.IsNativeAot && !IsMonoRuntime;
+        public static bool IsICorProfilerEnterLeaveHooksEnabled => IsICorProfilerEnabled && !Utilities.IsCoreClrInterpreter;
+
         public static bool IsRareEnumsSupported => !Utilities.IsNativeAot;
 
         public static bool IsCollectibleAssembliesSupported => !Utilities.IsNativeAot;

--- a/src/tests/profiler/dynamicoptimization/DynamicOptimization.cs
+++ b/src/tests/profiler/dynamicoptimization/DynamicOptimization.cs
@@ -80,7 +80,7 @@ namespace Profiler.Tests
             RuntimeHelpers.PrepareMethod(GetMainMethod(beforeDisableInlining).MethodHandle);
             var actual = GetInlineCount();
             Console.WriteLine($"After jitting first case, inline count is: {actual}");
-            var expected = initialInlineCount + 1;
+            var expected = TestLibrary.Utilities.IsCoreClrInterpreter ? 0 : initialInlineCount + 1;
             if (expected != actual)
             {
                 throw new Exception($"Expected {expected}, got {actual}");
@@ -97,7 +97,9 @@ namespace Profiler.Tests
             RuntimeHelpers.PrepareMethod(GetMainMethod(afterReenableInlining).MethodHandle);
             actual = GetInlineCount();
             Console.WriteLine($"After jitting third case, inline count is: {actual}");
-            expected++;
+            if (!TestLibrary.Utilities.IsCoreClrInterpreter)
+                expected++;
+
             if (expected != actual)
             {
                 throw new Exception($"Expected {expected}, got {GetInlineCount()}");

--- a/src/tests/profiler/elt/slowpatheltenter.cs
+++ b/src/tests/profiler/elt/slowpatheltenter.cs
@@ -21,6 +21,11 @@ namespace SlowPathELTTests
 
         public static int Main(string[] args)
         {
+            if (!TestLibrary.PlatformDetection.IsICorProfilerEnterLeaveHooksEnabled)
+            {
+                return 100;
+            }
+
             if (args.Length > 0 && args[0].Equals("RunTest", StringComparison.OrdinalIgnoreCase))
             {
                 return SlowPathELTHelpers.RunTest();

--- a/src/tests/profiler/elt/slowpatheltleave.cs
+++ b/src/tests/profiler/elt/slowpatheltleave.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
+using TestLibrary;
 
 namespace SlowPathELTTests
 {
@@ -21,6 +22,11 @@ namespace SlowPathELTTests
 
         public static int Main(string[] args)
         {
+            if (!PlatformDetection.IsICorProfilerEnterLeaveHooksEnabled)
+            {
+                return 100;
+            }
+
             if (args.Length > 0 && args[0].Equals("RunTest", StringComparison.OrdinalIgnoreCase))
             {
                 return SlowPathELTHelpers.RunTest();

--- a/src/tests/profiler/unittest/inlining.cs
+++ b/src/tests/profiler/unittest/inlining.cs
@@ -52,6 +52,11 @@ namespace Profiler.Tests
 
         public static int Main(string[] args)
         {
+            if (!TestLibrary.PlatformDetection.IsICorProfilerEnterLeaveHooksEnabled)
+            {
+                return 100;
+            }
+
             if (args.Length > 0 && args[0].Equals("RunTest", StringComparison.OrdinalIgnoreCase))
             {
                 return RunTest(args);

--- a/src/tests/readytorun/r2rdump/FrameworkTests/R2RDumpTests.csproj
+++ b/src/tests/readytorun/r2rdump/FrameworkTests/R2RDumpTests.csproj
@@ -6,6 +6,7 @@
     <!-- The test is lengthy as it scans the entire System.Private.CoreLib so that it times out in GC stress runs. -->
     <!-- The purpose of the test is functional testing of the R2R reader, not runtime stress testing. -->
     <GCStressIncompatible>true</GCStressIncompatible>
+    <InterpreterIncompatible>true</InterpreterIncompatible> <!-- The test passes, but takes an inordinate amount of time -->
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="R2RDumpTester.cs" />


### PR DESCRIPTION
- Add support for tracking transitions via the profiler/debugger internal apis
  - Notably this involves calls to ProfilerManagedToUnmanagedTransitionMD/ProfilerUnmanagedToManagedTransitionMD for the profiler
  - And DebuggerTraceCall for the debugger on reverse p/invoke
- Disabling the enter/leave hooks in the ICorProfiler api
  - We now detect attempts to generate these in the interpreter compiler, and will fail the compile
  - Adding a PlatformDetection flag for disabling the tests which depend on this
  - And adjust several tests to use this flag
- Adjusting profiler test testing the ability of the profiler to control inlining by disabling that portion of that profiler test as the interpreter can't do that
- Finally disabling the R2RDumpTests test when the interpreter is enabled. It works, but its really slow, so lets not wait for it to finish in any of our test passes

This should fix JIT/profiler/elt/slowpatheltenter, JIT/profiler/elt/slowpatheltleave, JIT/profiler/unittest/inlining, JIT/profiler/transitions/transitions, profiler/dynamicoptimization/DynamicOptimization and readytorun/r2rdump/FrameworkTests/R2RDumpTests.