### PR TITLE
Make System.Double/Single.ConvertToInteger intrinsic

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3139,6 +3139,8 @@ bool InterpCompiler::EmitNamedIntrinsicCall(NamedIntrinsic ni, bool nonVirtualCa
             m_pLastNewIns->SetDVar(m_pStackPointer[-1].var);
             return true;
 
+        case NI_PRIMITIVE_ConvertToInteger:
+            FALLTHROUGH;
         case NI_PRIMITIVE_ConvertToIntegerNative:
         {
             CHECK_STACK(1);

--- a/src/coreclr/interpreter/intrinsics.cpp
+++ b/src/coreclr/interpreter/intrinsics.cpp
@@ -25,7 +25,9 @@ NamedIntrinsic GetNamedIntrinsic(COMP_HANDLE compHnd, CORINFO_METHOD_HANDLE comp
     {
         if (!strcmp(className, "Double") || !strcmp(className, "Single"))
         {
-            if (!strcmp(methodName, "ConvertToIntegerNative"))
+            if (!strcmp(methodName, "ConvertToInteger"))
+                return NI_PRIMITIVE_ConvertToInteger;
+            else if (!strcmp(methodName, "ConvertToIntegerNative"))
                 return NI_PRIMITIVE_ConvertToIntegerNative;
             else if (!strcmp(methodName, "MultiplyAddEstimate"))
                 return NI_System_Math_MultiplyAddEstimate;


### PR DESCRIPTION
There are two libraries tests that fail because the implementation of the System.Double/Single.ConvertToInteger in S.P.C. doesn't match the intrinsic implementation that JIT uses and behaves differently w.r.t. small primitive types (short, sbyte).

The intrinsic reuses the ConvertToIntegerNative one, JIT also shares the implementation for some targets.