### PR TITLE
[clr-interp] Adjust timeout on NativeRuntimeEventSourceTest

### DIFF
--- a/src/tests/tracing/runtimeeventsource/NativeRuntimeEventSourceTest.cs
+++ b/src/tests/tracing/runtimeeventsource/NativeRuntimeEventSourceTest.cs
@@ -77,7 +77,7 @@ namespace Tracing.Tests
 
                         Stopwatch sw = Stopwatch.StartNew();
 
-                        while (sw.Elapsed <= TimeSpan.FromMinutes(0.75))
+                        while (sw.Elapsed <= TimeSpan.FromSeconds(45))
                         {
                             Thread.Sleep(100);
 

--- a/src/tests/tracing/runtimeeventsource/NativeRuntimeEventSourceTest.cs
+++ b/src/tests/tracing/runtimeeventsource/NativeRuntimeEventSourceTest.cs
@@ -77,7 +77,7 @@ namespace Tracing.Tests
 
                         Stopwatch sw = Stopwatch.StartNew();
 
-                        while (sw.Elapsed <= TimeSpan.FromMinutes(1d / 12d))
+                        while (sw.Elapsed <= TimeSpan.FromMinutes(0.75))
                         {
                             Thread.Sleep(100);
 


### PR DESCRIPTION
The existing timeout of 5 seconds was too short. Make it 45 seconds.