### PR TITLE
[release/10.0] Add cache setting to asset definition, use "force-cache" for fingerprinted assets

### DIFF
--- a/eng/testing/scenarios/BuildWasmAppsJobsList.txt
+++ b/eng/testing/scenarios/BuildWasmAppsJobsList.txt
@@ -15,6 +15,7 @@ Wasm.Build.Tests.Blazor.NativeTests
 Wasm.Build.Tests.Blazor.NoopNativeRebuildTest
 Wasm.Build.Tests.Blazor.WorkloadRequiredTests
 Wasm.Build.Tests.Blazor.EventPipeDiagnosticsTests
+Wasm.Build.Tests.Blazor.AssetCachingTests
 Wasm.Build.Tests.BuildPublishTests
 Wasm.Build.Tests.ConfigSrcTests
 Wasm.Build.Tests.DllImportTests

--- a/src/mono/browser/runtime/dotnet.d.ts
+++ b/src/mono/browser/runtime/dotnet.d.ts
@@ -290,16 +290,19 @@ type Asset = {
 type WasmAsset = Asset & {
     name: string;
     hash?: string | null | "";
+    cache?: RequestCache;
 };
 type AssemblyAsset = Asset & {
     virtualPath: string;
     name: string;
     hash?: string | null | "";
+    cache?: RequestCache;
 };
 type PdbAsset = Asset & {
     virtualPath: string;
     name: string;
     hash?: string | null | "";
+    cache?: RequestCache;
 };
 type JsAsset = Asset & {
     /**
@@ -311,16 +314,19 @@ type JsAsset = Asset & {
 };
 type SymbolsAsset = Asset & {
     name: string;
+    cache?: RequestCache;
 };
 type VfsAsset = Asset & {
     virtualPath: string;
     name: string;
     hash?: string | null | "";
+    cache?: RequestCache;
 };
 type IcuAsset = Asset & {
     virtualPath: string;
     name: string;
     hash?: string | null | "";
+    cache?: RequestCache;
 };
 /**
  * A "key" is name of the file, a "value" is optional hash for integrity check.

--- a/src/mono/browser/runtime/loader/assets.ts
+++ b/src/mono/browser/runtime/loader/assets.ts
@@ -672,10 +672,15 @@ function fetchResource (asset: AssetEntryInternal): Promise<Response> {
     }
 
     const fetchOptions: RequestInit = {};
-    if (!loaderHelpers.config.disableNoCacheFetch) {
-        // FIXME: "no-cache" is how blazor works in Net7, but this prevents caching on HTTP level
-        // if we would like to get rid of our own cache and only use HTTP cache, we need to remove this
-        // https://github.com/dotnet/runtime/issues/74815
+
+    // If the user explicitly set `disableNoCacheFetch`, we respect it.
+    // Otherwise, we configure caching depending on if the asset is fingerprinted or not.
+    // Fingerprinted assets do not need to be validated for staleness.
+    // Therefore, we do not want to use the "no-cache" header with them.
+    // https://github.com/dotnet/runtime/issues/74815
+    const assetIsFingerprinted = asset.virtualPath != undefined && asset.virtualPath !== asset.name;
+
+    if (!loaderHelpers.config.disableNoCacheFetch && !assetIsFingerprinted) {
         fetchOptions.cache = "no-cache";
     }
     if (asset.useCredentials) {

--- a/src/mono/browser/runtime/loader/assets.ts
+++ b/src/mono/browser/runtime/loader/assets.ts
@@ -674,11 +674,10 @@ function fetchResource (asset: AssetEntryInternal): Promise<Response> {
     const fetchOptions: RequestInit = {};
 
     if (asset.cache) {
-        // Internal no-cache setting overrides other configuration.
+        // If the asset definition specifies a cache mode, use it.
         fetchOptions.cache = asset.cache;
     } else if (!loaderHelpers.config.disableNoCacheFetch) {
-        // We use no-cache if specified internally.
-        // For backwards compatibility other assets also get no-cache setting unless disabled by the user.
+        // Otherwise, for backwards compatibility use "no-cache" setting unless disabled by the user.
         // https://github.com/dotnet/runtime/issues/74815
         fetchOptions.cache = "no-cache";
     }

--- a/src/mono/browser/runtime/loader/assets.ts
+++ b/src/mono/browser/runtime/loader/assets.ts
@@ -658,7 +658,7 @@ function download_resource (asset: AssetEntryInternal): LoadingResource {
     }
 }
 
-function fetchResource(asset: AssetEntryInternal): Promise<Response> {
+function fetchResource (asset: AssetEntryInternal): Promise<Response> {
     // Allow developers to override how the resource is loaded
     let url = asset.resolvedUrl!;
     if (loaderHelpers.loadBootResource) {

--- a/src/mono/browser/runtime/loader/assets.ts
+++ b/src/mono/browser/runtime/loader/assets.ts
@@ -658,7 +658,7 @@ function download_resource (asset: AssetEntryInternal): LoadingResource {
     }
 }
 
-function fetchResource (asset: AssetEntryInternal): Promise<Response> {
+function fetchResource(asset: AssetEntryInternal): Promise<Response> {
     // Allow developers to override how the resource is loaded
     let url = asset.resolvedUrl!;
     if (loaderHelpers.loadBootResource) {
@@ -673,14 +673,12 @@ function fetchResource (asset: AssetEntryInternal): Promise<Response> {
 
     const fetchOptions: RequestInit = {};
 
-    if (asset.noCache === true) {
-        // Internal no-cache setting overrides other configuration.
-        fetchOptions.cache = "no-cache";
-    } else if (isAssetFingerprinted(asset)) {
+    if (isAssetFingerprinted(asset)) {
         // Fingerprinted assets are by definition never stale (newer version would have a different name).
         fetchOptions.cache = "force-cache";
-    } else if (!loaderHelpers.config.disableNoCacheFetch) {
-        // For backwards compatibility other assets get no-cache setting unless disabled by the user.
+    } else if (asset.noCache === true || !loaderHelpers.config.disableNoCacheFetch) {
+        // We use no-cache if specified internally.
+        // For backwards compatibility other assets also get no-cache setting unless disabled by the user.
         // https://github.com/dotnet/runtime/issues/74815
         fetchOptions.cache = "no-cache";
     }

--- a/src/mono/browser/runtime/loader/assets.ts
+++ b/src/mono/browser/runtime/loader/assets.ts
@@ -676,13 +676,15 @@ function fetchResource (asset: AssetEntryInternal): Promise<Response> {
     // If the user explicitly set `disableNoCacheFetch`, we respect it.
     // Otherwise, we configure caching depending on if the asset is fingerprinted or not.
     // Fingerprinted assets do not need to be validated for staleness.
-    // Therefore, we do not want to use the "no-cache" header with them.
     // https://github.com/dotnet/runtime/issues/74815
     const assetIsFingerprinted = asset.virtualPath != undefined && asset.virtualPath !== asset.name;
 
     if (!loaderHelpers.config.disableNoCacheFetch && !assetIsFingerprinted) {
         fetchOptions.cache = "no-cache";
+    } else if (assetIsFingerprinted) {
+        fetchOptions.cache = "force-cache";
     }
+
     if (asset.useCredentials) {
         // Include credentials so the server can allow download / provide user specific file
         fetchOptions.credentials = "include";

--- a/src/mono/browser/runtime/loader/assets.ts
+++ b/src/mono/browser/runtime/loader/assets.ts
@@ -673,16 +673,16 @@ function fetchResource (asset: AssetEntryInternal): Promise<Response> {
 
     const fetchOptions: RequestInit = {};
 
-    // If the user explicitly set `disableNoCacheFetch`, we respect it.
-    // Otherwise, we configure caching depending on if the asset is fingerprinted or not.
-    // Fingerprinted assets do not need to be validated for staleness.
-    // https://github.com/dotnet/runtime/issues/74815
-    const assetIsFingerprinted = asset.virtualPath != undefined && asset.virtualPath !== asset.name;
-
-    if (!loaderHelpers.config.disableNoCacheFetch && !assetIsFingerprinted) {
+    if (asset.noCache === true) {
+        // Internal no-cache setting overrides other configuration.
         fetchOptions.cache = "no-cache";
-    } else if (assetIsFingerprinted) {
+    } else if (isAssetFingerprinted(asset)) {
+        // Fingerprinted assets are by definition never stale (newer version would have a different name).
         fetchOptions.cache = "force-cache";
+    } else if (!loaderHelpers.config.disableNoCacheFetch) {
+        // For backwards compatibility other assets get no-cache setting unless disabled by the user.
+        // https://github.com/dotnet/runtime/issues/74815
+        fetchOptions.cache = "no-cache";
     }
 
     if (asset.useCredentials) {
@@ -697,6 +697,24 @@ function fetchResource (asset: AssetEntryInternal): Promise<Response> {
     }
 
     return loaderHelpers.fetch_like(url, fetchOptions);
+}
+
+function isAssetFingerprinted (asset: AssetEntryInternal): boolean {
+    if (asset.virtualPath != undefined) {
+        return asset.virtualPath !== asset.name;
+    } else {
+        // Special assets such as dotnet.native.wasm can be missing virtualPath
+        // even when they are fingerprinted.
+        // In such cases we look at some core assembly that we know will have its
+        // virtualPath set and different from its name when fingerprinting is enabled.
+        const coreAssembly = loaderHelpers.config.resources?.coreAssembly?.[0];
+
+        if (coreAssembly && coreAssembly.virtualPath != undefined) {
+            return coreAssembly.virtualPath !== coreAssembly.name;
+        }
+    }
+
+    return false;
 }
 
 const monoToBlazorAssetTypeMap: { [key: string]: WebAssemblyBootResourceType | undefined } = {

--- a/src/mono/browser/runtime/loader/assets.ts
+++ b/src/mono/browser/runtime/loader/assets.ts
@@ -399,7 +399,7 @@ export function prepareAssets () {
                     name: configUrl,
                     behavior: "vfs",
                     // TODO what should be the virtualPath ?
-                    noCache: true,
+                    cache: "no-cache",
                     useCredentials: true
                 });
             }
@@ -673,10 +673,10 @@ function fetchResource(asset: AssetEntryInternal): Promise<Response> {
 
     const fetchOptions: RequestInit = {};
 
-    if (isAssetFingerprinted(asset)) {
-        // Fingerprinted assets are by definition never stale (newer version would have a different name).
-        fetchOptions.cache = "force-cache";
-    } else if (asset.noCache === true || !loaderHelpers.config.disableNoCacheFetch) {
+    if (asset.cache) {
+        // Internal no-cache setting overrides other configuration.
+        fetchOptions.cache = asset.cache;
+    } else if (!loaderHelpers.config.disableNoCacheFetch) {
         // We use no-cache if specified internally.
         // For backwards compatibility other assets also get no-cache setting unless disabled by the user.
         // https://github.com/dotnet/runtime/issues/74815
@@ -695,24 +695,6 @@ function fetchResource(asset: AssetEntryInternal): Promise<Response> {
     }
 
     return loaderHelpers.fetch_like(url, fetchOptions);
-}
-
-function isAssetFingerprinted (asset: AssetEntryInternal): boolean {
-    if (asset.virtualPath != undefined) {
-        return asset.virtualPath !== asset.name;
-    } else {
-        // Special assets such as dotnet.native.wasm can be missing virtualPath
-        // even when they are fingerprinted.
-        // In such cases we look at some core assembly that we know will have its
-        // virtualPath set and different from its name when fingerprinting is enabled.
-        const coreAssembly = loaderHelpers.config.resources?.coreAssembly?.[0];
-
-        if (coreAssembly && coreAssembly.virtualPath != undefined) {
-            return coreAssembly.virtualPath !== coreAssembly.name;
-        }
-    }
-
-    return false;
 }
 
 const monoToBlazorAssetTypeMap: { [key: string]: WebAssemblyBootResourceType | undefined } = {

--- a/src/mono/browser/runtime/types/index.ts
+++ b/src/mono/browser/runtime/types/index.ts
@@ -251,18 +251,21 @@ export type Asset = {
 export type WasmAsset = Asset & {
     name: string;
     hash?: string | null | "";
+    cache?: RequestCache;
 }
 
 export type AssemblyAsset = Asset & {
     virtualPath: string;
     name: string; // actually URL
     hash?: string | null | "";
+    cache?: RequestCache;
 }
 
 export type PdbAsset = Asset & {
     virtualPath: string;
     name: string; // actually URL
     hash?: string | null | "";
+    cache?: RequestCache;
 }
 
 export type JsAsset = Asset & {
@@ -277,18 +280,21 @@ export type JsAsset = Asset & {
 
 export type SymbolsAsset = Asset & {
     name: string; // actually URL
+    cache?: RequestCache;
 }
 
 export type VfsAsset = Asset & {
     virtualPath: string;
     name: string; // actually URL
     hash?: string | null | "";
+    cache?: RequestCache;
 }
 
 export type IcuAsset = Asset & {
     virtualPath: string;
     name: string; // actually URL
     hash?: string | null | "";
+    cache?: RequestCache;
 }
 
 /**

--- a/src/mono/browser/runtime/types/internal.ts
+++ b/src/mono/browser/runtime/types/internal.ts
@@ -109,7 +109,7 @@ export type RunArguments = {
 export interface AssetEntryInternal extends AssetEntry {
     // this could have multiple values in time, because of re-try download logic
     pendingDownloadInternal?: LoadingResource
-    noCache?: boolean
+    cache?: RequestCache
     useCredentials?: boolean
     isCore?: boolean
 }

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
@@ -17,7 +17,7 @@ namespace Wasm.Build.Tests.Blazor;
 public class AssetCachingTests : BlazorWasmTestBase
 {
     public AssetCachingTests(ITestOutputHelper output, SharedBuildPerTestClassFixture buildContext)
-        : base(output, buildContext)
+        : base(output, buildContext, PreviousTargetFramework)
     {
     }
 

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
@@ -43,7 +43,7 @@ public class AssetCachingTests : BlazorWasmTestBase
             {
                 await WaitForCounterInteractivity(page);
 
-                // Check server request logs after first load.
+                // Check server request logs after the first load.
                 Assert.NotEmpty(wasmRequestRecorder.ResponseCodes);
                 Assert.All(wasmRequestRecorder.ResponseCodes, r => Assert.Equal(200, r.ResponseCode));
 

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
@@ -95,6 +95,8 @@ public class AssetCachingTests : BlazorWasmTestBase
                 await Task.Delay(100);
             }
         }
+
+        throw new TimeoutException("Test component not interactive");
     }
 }
 
@@ -111,9 +113,9 @@ partial class WasmRequestRecorder
 
         if (match.Success)
         {
-           	var name = match.Groups["name"].Value;
-           	var code = int.Parse(match.Groups["code"].Value);
-           	ResponseCodes.Add((name, code));
+            var name = match.Groups["name"].Value;
+            var code = int.Parse(match.Groups["code"].Value);
+            ResponseCodes.Add((name, code));
         }
     }
 }

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
@@ -26,6 +27,7 @@ public class AssetCachingTests : BlazorWasmTestBase
     }
 
     [Fact]
+    [Trait("Category", "no-fingerprinting")]
     public async Task BlazorApp_BasedOnFingerprinting_LoadsWasmAssetsFromCache()
     {
         ProjectInfo info = CopyTestAsset(
@@ -37,42 +39,72 @@ public class AssetCachingTests : BlazorWasmTestBase
         BlazorPublish(info, Configuration.Release);
 
         var startUrl = string.Empty;
+        var wasmRequestRecorder = new WasmRequestRecorder();
+
         var runOptions = new BlazorRunOptions(Configuration.Release)
         {
+            OnServerMessage = (msg) => wasmRequestRecorder.RecordIfWasmRequestFinished(msg),
             ExecuteAfterLoaded = async (_, page) => startUrl = page.Url,
             Test = async (page) =>
             {
+                await WaitForCounterInteractivity(page);
+
                 // Check resources after first load.
                 // Empty DeliveryType indicates that the resource was not cached.
                 var resourcesAfterFirstLoad = await GetWasmResourceEntries(page);
+                Assert.NotEmpty(resourcesAfterFirstLoad);
                 Assert.All(resourcesAfterFirstLoad, r => Assert.Equal(string.Empty, r.DeliveryType));
+
+                Assert.NotEmpty(wasmRequestRecorder.ResponseCodes);
+                Assert.All(wasmRequestRecorder.ResponseCodes, r => Assert.Equal(200, r.StatusCode));
+
+                // We start recording server logs for Wasm asset requests.
+                wasmRequestRecorder.ResponseCodes.Clear();
 
                 // Perform browser navigation to cause resource reload.
                 // We use the initial base URL because the test server is not configured for SPA routing.
                 await page.GotoAsync(startUrl);
+                await WaitForCounterInteractivity(page);
 
                 // Check resources after second load.
-                // ResponseStatus 200 indicates loading from cache without validation request.
                 var resourcesAfterSecondLoad = await GetWasmResourceEntries(page);
 
+                // The performance API intentionally reports response status 200 even for assets
+                // retrieved from cache after validation (when browser would show status 304).
+                // Therefore, we check for 200 even with fingerprinting disabled.
+                Assert.NotEmpty(resourcesAfterSecondLoad);
+                Assert.All(resourcesAfterSecondLoad, r => {
+                    Assert.Equal("cache", r.DeliveryType);
+                    Assert.Equal(200, r.ResponseStatus);
+                });
+
+                // Check server logs.
                 if (EnvironmentVariables.UseFingerprinting)
                 {
-                    Assert.All(resourcesAfterSecondLoad, r => {
-                        Assert.Equal("cache", r.DeliveryType);
-                        Assert.Equal(200, r.ResponseStatus);
-                    });
+                    // With fingerprinting we should not see any requests for Wasm assets on second load.
+                    Assert.Empty(wasmRequestRecorder.ResponseCodes);
                 }
                 else
                 {
-                    Assert.All(resourcesAfterSecondLoad, r => {
-                        Assert.Equal("cache", r.DeliveryType);
-                        Assert.Equal(304, r.ResponseStatus);
-                    });
+                    // Without fingerprinting we should see requests for Wasm assets on second load with response status 304.
+                    Assert.NotEmpty(wasmRequestRecorder.ResponseCodes);
+                    Assert.All(wasmRequestRecorder.ResponseCodes, r => Assert.Equal(304, r.StatusCode));
                 }
             }
         };
 
-        await RunForPublishWithWebServer(runOptions);
+        await RunForPublishWithDotnetServe(runOptions);
+    }
+
+    private static async Task WaitForCounterInteractivity(IPage page)
+    {
+        await page.Locator("text=Counter").ClickAsync();
+        var txt = await page.Locator("p[role='status']").InnerHTMLAsync();
+        Assert.Equal("Current count: 0", txt);
+
+        await page.Locator("text=\"Click me\"").ClickAsync();
+        txt = await page.Locator("p[role='status']").InnerHTMLAsync();
+        Assert.Equal("Current count: 1", txt);
     }
 
     /// <summary>
@@ -96,5 +128,25 @@ public class AssetCachingTests : BlazorWasmTestBase
 
         [JsonPropertyName("responseStatus")]
         public required int ResponseStatus { get; init; }
+    }
+}
+
+partial class WasmRequestRecorder
+{
+    public List<(string Name, int StatusCode)> ResponseCodes { get; } = new();
+
+    [GeneratedRegex(@"Request finished HTTP/\d\.\d GET http://[^/]+/(?<name>[^\s]+\.wasm)\s+-\s+(?<code>\d+)")]
+    private static partial Regex LogRegex();
+
+    public void RecordIfWasmRequestFinished(string message)
+    {
+		var match = LogRegex().Match(message);
+
+		if (match.Success)
+		{
+			var name = match.Groups["name"].Value;
+			var code = int.Parse(match.Groups["code"].Value);
+			ResponseCodes.Add((name, code));
+		}
     }
 }

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
@@ -28,7 +28,8 @@ public class AssetCachingTests : BlazorWasmTestBase
             Configuration.Release,
             aot: false,
             TestAsset.BlazorWebWasm,
-            "AssetCachingTest"
+            "AssetCachingTest",
+            appendUnicodeToPath: false
         );
 
         (string projectDir, string output) = BlazorPublish(project, Configuration.Release, new PublishOptions(AssertAppBundle: false));

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
@@ -4,9 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
@@ -84,12 +81,20 @@ public class AssetCachingTests : BlazorWasmTestBase
 
     private static async Task WaitForCounterInteractivity(IPage page)
     {
-        var txt = await page.Locator("p[role='status']").InnerHTMLAsync();
-        Assert.Equal("Current count: 0", txt);
-
-        await page.Locator("text=\"Click me\"").ClickAsync();
-        txt = await page.Locator("p[role='status']").InnerHTMLAsync();
-        Assert.Equal("Current count: 1", txt);
+        await Assertions.Expect(page.GetByRole(AriaRole.Status)).ToContainTextAsync("Current count: 0");
+        for (int i = 0; i < 10; i++)
+        {
+            try
+            {
+                await page.GetByText("Click me").ClickAsync();
+                await Assertions.Expect(page.GetByRole(AriaRole.Status)).ToContainTextAsync("Current count: 1");
+                return;
+            }
+            catch (PlaywrightException)
+            {
+                await Task.Delay(100);
+            }
+        }
     }
 }
 

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
@@ -17,7 +17,7 @@ namespace Wasm.Build.Tests.Blazor;
 public class AssetCachingTests : BlazorWasmTestBase
 {
     public AssetCachingTests(ITestOutputHelper output, SharedBuildPerTestClassFixture buildContext)
-        : base(output, buildContext, PreviousTargetFramework)
+        : base(output, buildContext)
     {
     }
 

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
@@ -74,9 +74,9 @@ public class AssetCachingTests : BlazorWasmTestBase
 
         var buildPaths = GetBuildPaths(Configuration.Release, forPublish: true, projectDir: projectDir);
         var publishedAppPath = Path.Combine(buildPaths.BinDir, "publish");
-        var publishedAppDllPath = Path.Combine(publishedAppPath, project.ProjectName + ".dll");
+        var publishedAppDllFileName = $"{project.ProjectName}.dll";
         using ToolCommand cmd = new DotNetCommand(s_buildEnv, _testOutput).WithWorkingDirectory(publishedAppPath);
-        var result = await BrowserRun(cmd, $"exec \"{publishedAppDllPath}\"", runOptions);
+        var result = await BrowserRun(cmd, $"exec {publishedAppDllFileName}", runOptions);
     }
 
     private static async Task WaitForCounterInteractivity(IPage page)

--- a/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Blazor/AssetCachingTests.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+using Microsoft.Playwright;
+
+#nullable enable
+
+namespace Wasm.Build.Tests.Blazor;
+
+public class AssetCachingTests : BlazorWasmTestBase
+{
+    public AssetCachingTests(ITestOutputHelper output, SharedBuildPerTestClassFixture buildContext)
+        : base(output, buildContext)
+    {
+        _enablePerTestCleanup = true;
+    }
+
+    [Fact]
+    public async Task BlazorApp_BasedOnFingerprinting_LoadsWasmAssetsFromCache()
+    {
+        ProjectInfo info = CopyTestAsset(
+            Configuration.Release,
+            aot: false,
+            TestAsset.BlazorBasicTestApp,
+            "blazor_publish");
+
+        BlazorPublish(info, Configuration.Release);
+
+        var startUrl = string.Empty;
+        var runOptions = new BlazorRunOptions(Configuration.Release)
+        {
+            ExecuteAfterLoaded = async (_, page) => startUrl = page.Url,
+            Test = async (page) =>
+            {
+                // Check resources after first load.
+                // Empty DeliveryType indicates that the resource was not cached.
+                var resourcesAfterFirstLoad = await GetWasmResourceEntries(page);
+                Assert.All(resourcesAfterFirstLoad, r => Assert.Equal(string.Empty, r.DeliveryType));
+
+                // Perform browser navigation to cause resource reload.
+                // We use the initial base URL because the test server is not configured for SPA routing.
+                await page.GotoAsync(startUrl);
+
+                // Check resources after second load.
+                // ResponseStatus 200 indicates loading from cache without validation request.
+                var resourcesAfterSecondLoad = await GetWasmResourceEntries(page);
+
+                if (EnvironmentVariables.UseFingerprinting)
+                {
+                    Assert.All(resourcesAfterSecondLoad, r => {
+                        Assert.Equal("cache", r.DeliveryType);
+                        Assert.Equal(200, r.ResponseStatus);
+                    });
+                }
+                else
+                {
+                    Assert.All(resourcesAfterSecondLoad, r => {
+                        Assert.Equal("cache", r.DeliveryType);
+                        Assert.Equal(304, r.ResponseStatus);
+                    });
+                }
+            }
+        };
+
+        await RunForPublishWithWebServer(runOptions);
+    }
+
+    /// <summary>
+    /// Retrieves information about how were the page's current resources loaded using the Performance API.
+    /// </summary>
+    private static async Task<List<ResourceEntry>> GetWasmResourceEntries(IPage page)
+    {
+        var jsonData = await page.EvaluateAsync<string>("JSON.stringify(window.performance.getEntriesByType('resource'))");
+        var entries = JsonSerializer.Deserialize<List<ResourceEntry>>(jsonData) ?? [];
+
+        return entries.Where(e => e.Name.EndsWith(".wasm", StringComparison.OrdinalIgnoreCase)).ToList();
+    }
+
+    private class ResourceEntry
+    {
+        [JsonPropertyName("name")]
+        public required string Name { get; init; }
+
+        [JsonPropertyName("deliveryType")]
+        public required string DeliveryType { get; init; }
+
+        [JsonPropertyName("responseStatus")]
+        public required int ResponseStatus { get; init; }
+    }
+}

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserStructures/RunOptions.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserStructures/RunOptions.cs
@@ -31,4 +31,4 @@ public abstract record RunOptions
     Func<RunOptions, IPage, Task>? ExecuteAfterLoaded = null
 );
 
-public enum RunHost { DotnetRun, WebServer };
+public enum RunHost { DotnetRun, WebServer, DotnetServe };

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserStructures/RunOptions.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserStructures/RunOptions.cs
@@ -16,7 +16,7 @@ public abstract record RunOptions
     bool AOT = false,
     RunHost Host = RunHost.DotnetRun,
     bool DetectRuntimeFailures = true,
-    
+
     Dictionary<string, string>? ServerEnvironment = null,
     NameValueCollection? BrowserQueryString = null,
     Action<string, string>? OnConsoleMessage = null,
@@ -31,4 +31,4 @@ public abstract record RunOptions
     Func<RunOptions, IPage, Task>? ExecuteAfterLoaded = null
 );
 
-public enum RunHost { DotnetRun, WebServer, DotnetServe };
+public enum RunHost { DotnetRun, WebServer };

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserStructures/TestAsset.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserStructures/TestAsset.cs
@@ -5,4 +5,5 @@ public class TestAsset
     public static readonly TestAsset WasmBasicTestApp = new() { Name = "WasmBasicTestApp", RunnableProjectSubPath = "App" };
     public static readonly TestAsset BlazorBasicTestApp = new() { Name = "BlazorBasicTestApp", RunnableProjectSubPath = "App" };
     public static readonly TestAsset LibraryModeTestApp = new() { Name = "LibraryMode" };
+    public static readonly TestAsset BlazorWebWasm = new() { Name = "BlazorWebWasm", RunnableProjectSubPath = "BlazorWebWasm" };
 }

--- a/src/mono/wasm/Wasm.Build.Tests/Common/ToolCommand.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Common/ToolCommand.cs
@@ -89,7 +89,18 @@ namespace Wasm.Build.Tests
             var resolvedCommand = _command;
             string fullArgs = GetFullArgs(args);
             _testOutput.WriteLine($"[{_label}] Executing (Captured Output) - {resolvedCommand} {fullArgs} - {WorkingDirectoryInfo()}");
-            return Task.Run(async () => await ExecuteAsyncInternal(resolvedCommand, fullArgs)).Result;
+            return Task.Run(async () =>
+            {
+                try
+                {
+                    return await ExecuteAsyncInternal(resolvedCommand, fullArgs);
+                }
+                catch (Exception ex)
+                {
+                    _testOutput.WriteLine($"[{_label}] Exception during execution: {ex}");
+                    throw;
+                }
+            }).Result;
         }
 
         public virtual void Dispose()

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
@@ -362,7 +362,7 @@ public class WasmTemplateTestsBase : BuildTestBase
         List<string> testOutput = new();
         List<string> consoleOutput = new();
         List<string> serverOutput = new();
-        var runner = new BrowserRunner(_testOutput);
+        await using var runner = new BrowserRunner(_testOutput);
         var page = await runner.RunAsync(
             cmd,
             runArgs,

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
@@ -306,6 +306,9 @@ public class WasmTemplateTestsBase : BuildTestBase
     public virtual async Task<RunResult> RunForPublishWithWebServer(RunOptions runOptions)
         => await BrowserRun(runOptions with { Host = RunHost.WebServer });
 
+    public virtual async Task<RunResult> RunForPublishWithDotnetServe(RunOptions runOptions)
+        => await BrowserRun(runOptions with { Host = RunHost.DotnetServe });
+
     private async Task<RunResult> BrowserRun(RunOptions runOptions)
     {
         if (EnvironmentVariables.UseJavascriptBundler)
@@ -324,6 +327,13 @@ public class WasmTemplateTestsBase : BuildTestBase
                             Path.GetFullPath(Path.Combine(GetBinFrameworkDir(runOptions.Configuration, forPublish: true), "..")) :
                             runOptions.CustomBundleDir,
                          runOptions),
+
+            RunHost.DotnetServe =>
+                    await BrowserRunTest($"serve",
+                        string.IsNullOrEmpty(runOptions.CustomBundleDir) ?
+                            Path.GetFullPath(Path.Combine(GetBinFrameworkDir(runOptions.Configuration, forPublish: true), "..")) :
+                            runOptions.CustomBundleDir,
+                        runOptions),
 
             _ => throw new NotImplementedException(runOptions.Host.ToString())
         };

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
@@ -306,9 +306,6 @@ public class WasmTemplateTestsBase : BuildTestBase
     public virtual async Task<RunResult> RunForPublishWithWebServer(RunOptions runOptions)
         => await BrowserRun(runOptions with { Host = RunHost.WebServer });
 
-    public virtual async Task<RunResult> RunForPublishWithDotnetServe(RunOptions runOptions)
-        => await BrowserRun(runOptions with { Host = RunHost.DotnetServe });
-
     private async Task<RunResult> BrowserRun(RunOptions runOptions)
     {
         if (EnvironmentVariables.UseJavascriptBundler)
@@ -327,13 +324,6 @@ public class WasmTemplateTestsBase : BuildTestBase
                             Path.GetFullPath(Path.Combine(GetBinFrameworkDir(runOptions.Configuration, forPublish: true), "..")) :
                             runOptions.CustomBundleDir,
                          runOptions),
-
-            RunHost.DotnetServe =>
-                    await BrowserRunTest($"serve",
-                        string.IsNullOrEmpty(runOptions.CustomBundleDir) ?
-                            Path.GetFullPath(Path.Combine(GetBinFrameworkDir(runOptions.Configuration, forPublish: true), "..")) :
-                            runOptions.CustomBundleDir,
-                        runOptions),
 
             _ => throw new NotImplementedException(runOptions.Host.ToString())
         };

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
@@ -352,6 +352,11 @@ public class WasmTemplateTestsBase : BuildTestBase
         using RunCommand runCommand = new RunCommand(s_buildEnv, _testOutput);
         ToolCommand cmd = runCommand.WithWorkingDirectory(workingDirectory);
 
+        return await BrowserRun(cmd, runArgs, runOptions);
+    }
+
+    protected async Task<RunResult> BrowserRun(ToolCommand cmd, string runArgs, RunOptions runOptions)
+    {
         var query = runOptions.BrowserQueryString ?? new NameValueCollection();
         if (runOptions.AOT)
         {
@@ -367,18 +372,18 @@ public class WasmTemplateTestsBase : BuildTestBase
         List<string> testOutput = new();
         List<string> consoleOutput = new();
         List<string> serverOutput = new();
-        await using var runner = new BrowserRunner(_testOutput);
+        var runner = new BrowserRunner(_testOutput);
         var page = await runner.RunAsync(
-            cmd,
-            runArgs,
-            locale: runOptions.Locale,
-            onConsoleMessage: OnConsoleMessage,
-            onServerMessage: OnServerMessage,
-            onError: OnErrorMessage,
-            modifyBrowserUrl: browserUrl => new Uri(new Uri(browserUrl), runOptions.BrowserPath + queryString).ToString());
+                    cmd,
+                    runArgs,
+                    locale: runOptions.Locale,
+                    onConsoleMessage: OnConsoleMessage,
+                    onServerMessage: OnServerMessage,
+                    onError: OnErrorMessage,
+                    modifyBrowserUrl: browserUrl => new Uri(new Uri(browserUrl), runOptions.BrowserPath + queryString).ToString());
 
         _testOutput.WriteLine("Waiting for page to load");
-        await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded, new () { Timeout = 1 * 60 * 1000 });
+        await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded, new() { Timeout = 1 * 60 * 1000 });
 
         if (runOptions.ExecuteAfterLoaded is not null)
         {
@@ -439,8 +444,8 @@ public class WasmTemplateTestsBase : BuildTestBase
     public string GetObjDir(Configuration config, string? framework = null, string? projectDir = null) =>
         _provider.GetObjDir(config, framework ?? DefaultTargetFramework, projectDir);
 
-    public BuildPaths GetBuildPaths(Configuration config, bool forPublish) =>
-        _provider.GetBuildPaths(config, forPublish);
+    public BuildPaths GetBuildPaths(Configuration config, bool forPublish, string? projectDir = null) =>
+        _provider.GetBuildPaths(config, forPublish, projectDir);
 
     public IDictionary<string, (string fullPath, bool unchanged)> GetFilesTable(string projectName, bool isAOT, BuildPaths paths, bool unchanged) =>
         _provider.GetFilesTable(projectName, isAOT, paths, unchanged);

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
@@ -362,7 +362,7 @@ public class WasmTemplateTestsBase : BuildTestBase
         List<string> testOutput = new();
         List<string> consoleOutput = new();
         List<string> serverOutput = new();
-        await using var runner = new BrowserRunner(_testOutput);
+        var runner = new BrowserRunner(_testOutput);
         var page = await runner.RunAsync(
             cmd,
             runArgs,

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
@@ -364,13 +364,13 @@ public class WasmTemplateTestsBase : BuildTestBase
         List<string> serverOutput = new();
         var runner = new BrowserRunner(_testOutput);
         var page = await runner.RunAsync(
-                    cmd,
-                    runArgs,
-                    locale: runOptions.Locale,
-                    onConsoleMessage: OnConsoleMessage,
-                    onServerMessage: OnServerMessage,
-                    onError: OnErrorMessage,
-                    modifyBrowserUrl: browserUrl => new Uri(new Uri(browserUrl), runOptions.BrowserPath + queryString).ToString());
+            cmd,
+            runArgs,
+            locale: runOptions.Locale,
+            onConsoleMessage: OnConsoleMessage,
+            onServerMessage: OnServerMessage,
+            onError: OnErrorMessage,
+            modifyBrowserUrl: browserUrl => new Uri(new Uri(browserUrl), runOptions.BrowserPath + queryString).ToString());
 
         _testOutput.WriteLine("Waiting for page to load");
         await page.WaitForLoadStateAsync(LoadState.DOMContentLoaded, new() { Timeout = 1 * 60 * 1000 });

--- a/src/mono/wasm/Wasm.Build.Tests/WasmSdkBasedProjectProvider.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/WasmSdkBasedProjectProvider.cs
@@ -186,12 +186,13 @@ public class WasmSdkBasedProjectProvider : ProjectProviderBase
         AssertBundle(config, buildOptions, isUsingWorkloads, isNativeBuild, wasmFingerprintDotnetJs);
     }
 
-    public BuildPaths GetBuildPaths(Configuration configuration, bool forPublish)
+    public BuildPaths GetBuildPaths(Configuration configuration, bool forPublish, string? projectDir = null)
     {
-        Assert.NotNull(ProjectDir);
+        projectDir ??= ProjectDir!;
+        Assert.NotNull(projectDir);
         string configStr = configuration.ToString();
-        string objDir = Path.Combine(ProjectDir, "obj", configStr, _defaultTargetFramework);
-        string binDir = Path.Combine(ProjectDir, "bin", configStr, _defaultTargetFramework);
+        string objDir = Path.Combine(projectDir, "obj", configStr, _defaultTargetFramework);
+        string binDir = Path.Combine(projectDir, "bin", configStr, _defaultTargetFramework);
         string binFrameworkDir = GetBinFrameworkDir(configuration, forPublish, _defaultTargetFramework);
 
         string objWasmDir = Path.Combine(objDir, "wasm", forPublish ? "for-publish" : "for-build");

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm.Client/BlazorWebWasm.Client.csproj
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm.Client/BlazorWebWasm.Client.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
+    <StaticWebAssetProjectMode>Default</StaticWebAssetProjectMode>
+    <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm.Client/Pages/Counter.razor
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm.Client/Pages/Counter.razor
@@ -1,0 +1,24 @@
+﻿@page "/counter"
+@rendermode InteractiveWebAssembly
+
+<PageTitle>Counter</PageTitle>
+
+<h1>Counter</h1>
+
+<p role="status">Current count: @currentCount</p>
+
+<button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
+
+@code {
+    private int currentCount = 0;
+
+    private void IncrementCount()
+    {
+        currentCount++;
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        Console.WriteLine("Counter.OnAfterRender");
+    }
+}

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm.Client/Program.cs
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm.Client/Program.cs
@@ -1,0 +1,5 @@
+using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+
+var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+await builder.Build().RunAsync();

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm.Client/_Imports.razor
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm.Client/_Imports.razor
@@ -1,0 +1,9 @@
+﻿@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using BlazorWebWasm.Client

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm.sln
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm.sln
@@ -1,0 +1,50 @@
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.0.0
+MinimumVisualStudioVersion = 16.0.0.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorWebWasm", "BlazorWebWasm\BlazorWebWasm.csproj", "{79840C4C-980C-460C-AFDD-2663C233ED42}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorWebWasm.Client", "BlazorWebWasm.Client\BlazorWebWasm.Client.csproj", "{CA65DE89-E642-4F21-8383-42B2899C8502}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CA65DE89-E642-4F21-8383-42B2899C8502}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA65DE89-E642-4F21-8383-42B2899C8502}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA65DE89-E642-4F21-8383-42B2899C8502}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CA65DE89-E642-4F21-8383-42B2899C8502}.Debug|x64.Build.0 = Debug|Any CPU
+		{CA65DE89-E642-4F21-8383-42B2899C8502}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CA65DE89-E642-4F21-8383-42B2899C8502}.Debug|x86.Build.0 = Debug|Any CPU
+		{CA65DE89-E642-4F21-8383-42B2899C8502}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA65DE89-E642-4F21-8383-42B2899C8502}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CA65DE89-E642-4F21-8383-42B2899C8502}.Release|x64.ActiveCfg = Release|Any CPU
+		{CA65DE89-E642-4F21-8383-42B2899C8502}.Release|x64.Build.0 = Release|Any CPU
+		{CA65DE89-E642-4F21-8383-42B2899C8502}.Release|x86.ActiveCfg = Release|Any CPU
+		{CA65DE89-E642-4F21-8383-42B2899C8502}.Release|x86.Build.0 = Release|Any CPU
+		{79840C4C-980C-460C-AFDD-2663C233ED42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79840C4C-980C-460C-AFDD-2663C233ED42}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79840C4C-980C-460C-AFDD-2663C233ED42}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{79840C4C-980C-460C-AFDD-2663C233ED42}.Debug|x64.Build.0 = Debug|Any CPU
+		{79840C4C-980C-460C-AFDD-2663C233ED42}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{79840C4C-980C-460C-AFDD-2663C233ED42}.Debug|x86.Build.0 = Debug|Any CPU
+		{79840C4C-980C-460C-AFDD-2663C233ED42}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79840C4C-980C-460C-AFDD-2663C233ED42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79840C4C-980C-460C-AFDD-2663C233ED42}.Release|x64.ActiveCfg = Release|Any CPU
+		{79840C4C-980C-460C-AFDD-2663C233ED42}.Release|x64.Build.0 = Release|Any CPU
+		{79840C4C-980C-460C-AFDD-2663C233ED42}.Release|x86.ActiveCfg = Release|Any CPU
+		{79840C4C-980C-460C-AFDD-2663C233ED42}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {60995319-A9DF-4E04-BC6E-828A27372E72}
+	EndGlobalSection
+EndGlobal

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/BlazorWebWasm.csproj
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/BlazorWebWasm.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <BlazorDisableThrowNavigationException>true</BlazorDisableThrowNavigationException>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BlazorWebWasm.Client\BlazorWebWasm.Client.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="10.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/App.razor
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/App.razor
@@ -1,0 +1,22 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <ResourcePreloader />
+    <link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]" />
+    <link rel="stylesheet" href="@Assets["app.css"]" />
+    <link rel="stylesheet" href="@Assets["BlazorWebWasm.styles.css"]" />
+    <ImportMap />
+    <link rel="icon" type="image/png" href="favicon.png" />
+    <HeadOutlet />
+</head>
+
+<body>
+    <Routes />
+    <script src="@Assets["_framework/blazor.web.js"]"></script>
+</body>
+
+</html>

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/Layout/MainLayout.razor
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/Layout/MainLayout.razor
@@ -1,0 +1,23 @@
+﻿@inherits LayoutComponentBase
+
+<div class="page">
+    <div class="sidebar">
+        <NavMenu />
+    </div>
+
+    <main>
+        <div class="top-row px-4">
+            <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
+        </div>
+
+        <article class="content px-4">
+            @Body
+        </article>
+    </main>
+</div>
+
+<div id="blazor-error-ui" data-nosnippet>
+    An unhandled error has occurred.
+    <a href="." class="reload">Reload</a>
+    <span class="dismiss">🗙</span>
+</div>

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/Layout/NavMenu.razor
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/Layout/NavMenu.razor
@@ -1,0 +1,30 @@
+﻿<div class="top-row ps-3 navbar navbar-dark">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="">BlazorWebWasm</a>
+    </div>
+</div>
+
+<input type="checkbox" title="Navigation menu" class="navbar-toggler" />
+
+<div class="nav-scrollable" onclick="document.querySelector('.navbar-toggler').click()">
+    <nav class="nav flex-column">
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
+                <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> Home
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="counter">
+                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Counter
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="weather">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
+            </NavLink>
+        </div>
+    </nav>
+</div>
+

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/Pages/Error.razor
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/Pages/Error.razor
@@ -1,0 +1,36 @@
+﻿@page "/Error"
+@using System.Diagnostics
+
+<PageTitle>Error</PageTitle>
+
+<h1 class="text-danger">Error.</h1>
+<h2 class="text-danger">An error occurred while processing your request.</h2>
+
+@if (ShowRequestId)
+{
+    <p>
+        <strong>Request ID:</strong> <code>@RequestId</code>
+    </p>
+}
+
+<h3>Development Mode</h3>
+<p>
+    Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
+</p>
+<p>
+    <strong>The Development environment shouldn't be enabled for deployed applications.</strong>
+    It can result in displaying sensitive information from exceptions to end users.
+    For local debugging, enable the <strong>Development</strong> environment by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>
+    and restarting the app.
+</p>
+
+@code{
+    [CascadingParameter]
+    private HttpContext? HttpContext { get; set; }
+
+    private string? RequestId { get; set; }
+    private bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+
+    protected override void OnInitialized() =>
+        RequestId = Activity.Current?.Id ?? HttpContext?.TraceIdentifier;
+}

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/Pages/Home.razor
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/Pages/Home.razor
@@ -1,0 +1,7 @@
+﻿@page "/"
+
+<PageTitle>Home</PageTitle>
+
+<h1>Hello, world!</h1>
+
+Welcome to your new app.

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/Pages/NotFound.razor
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/Pages/NotFound.razor
@@ -1,0 +1,5 @@
+﻿@page "/not-found"
+@layout MainLayout
+
+<h3>Not Found</h3>
+<p>Sorry, the content you are looking for does not exist.</p>

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/Routes.razor
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/Routes.razor
@@ -1,0 +1,6 @@
+﻿<Router AppAssembly="typeof(Program).Assembly" AdditionalAssemblies="new[] { typeof(Client._Imports).Assembly }" NotFoundPage="typeof(Pages.NotFound)">
+    <Found Context="routeData">
+        <RouteView RouteData="routeData" DefaultLayout="typeof(Layout.MainLayout)" />
+        <FocusOnNavigate RouteData="routeData" Selector="h1" />
+    </Found>
+</Router>

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/_Imports.razor
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Components/_Imports.razor
@@ -1,0 +1,12 @@
+﻿@using System.Net.Http
+@using System.Net.Http.Json
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Microsoft.AspNetCore.Components.Web.Virtualization
+@using Microsoft.JSInterop
+@using BlazorWebWasm
+@using BlazorWebWasm.Client
+@using BlazorWebWasm.Components
+@using BlazorWebWasm.Components.Layout

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Program.cs
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Program.cs
@@ -4,11 +4,6 @@ using Microsoft.AspNetCore.HttpLogging;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// builder.Services.AddHttpLogging(logging =>
-// {
-//     logging.LoggingFields = HttpLoggingFields.RequestPath;
-// });
-
 // Add services to the container.
 builder.Services.AddRazorComponents()
     .AddInteractiveWebAssemblyComponents();
@@ -28,7 +23,6 @@ else
 }
 app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages: true);
 app.UseHttpsRedirection();
-// app.UseHttpLogging();
 
 app.UseAntiforgery();
 

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Program.cs
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/Program.cs
@@ -1,0 +1,40 @@
+using BlazorWebWasm.Client.Pages;
+using BlazorWebWasm.Components;
+using Microsoft.AspNetCore.HttpLogging;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// builder.Services.AddHttpLogging(logging =>
+// {
+//     logging.LoggingFields = HttpLoggingFields.RequestPath;
+// });
+
+// Add services to the container.
+builder.Services.AddRazorComponents()
+    .AddInteractiveWebAssemblyComponents();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.UseWebAssemblyDebugging();
+}
+else
+{
+    app.UseExceptionHandler("/Error", createScopeForErrors: true);
+    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
+    app.UseHsts();
+}
+app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages: true);
+app.UseHttpsRedirection();
+// app.UseHttpLogging();
+
+app.UseAntiforgery();
+
+app.MapStaticAssets();
+app.MapRazorComponents<App>()
+    .AddInteractiveWebAssemblyRenderMode()
+    .AddAdditionalAssemblies(typeof(BlazorWebWasm.Client._Imports).Assembly);
+
+app.Run();

--- a/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/appsettings.json
+++ b/src/mono/wasm/testassets/BlazorWebWasm/BlazorWebWasm/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.Hosting.Diagnostics": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
@@ -345,6 +345,6 @@ namespace Microsoft.NET.Sdk.WebAssembly
             return string.Join(Environment.NewLine, imports);
         }
 
-        private static string? GetCacheControl(string endpoint, ResourcesData resources) => resources.fingerprinting?[endpoint] != null ? "force-cache" : null;
+        private static string? GetCacheControl(string endpoint, ResourcesData resources) => resources.fingerprinting?.ContainsKey(endpoint) ?? false ? "force-cache" : null;
     }
 }

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonBuilderHelper.cs
@@ -224,7 +224,8 @@ namespace Microsoft.NET.Sdk.WebAssembly
                 var asset = new WasmAsset()
                 {
                     name = a.Key,
-                    integrity = a.Value
+                    integrity = a.Value,
+                    cache = GetCacheControl(a.Key, resources)
                 };
 
                 if (bundlerFriendly)
@@ -239,6 +240,7 @@ namespace Microsoft.NET.Sdk.WebAssembly
             assets.wasmSymbols = resources.wasmSymbols?.Select(a => new SymbolsAsset()
             {
                 name = a.Key,
+                cache = GetCacheControl(a.Key, resources)
             }).ToList();
 
             assets.icu = MapGeneralAssets(resources.icu);
@@ -284,7 +286,8 @@ namespace Microsoft.NET.Sdk.WebAssembly
                 {
                     virtualPath = resources.fingerprinting?[a.Key] ?? a.Key,
                     name = a.Key,
-                    integrity = a.Value
+                    integrity = a.Value,
+                    cache = GetCacheControl(a.Key, resources)
                 };
 
                 if (bundlerFriendly)
@@ -318,11 +321,13 @@ namespace Microsoft.NET.Sdk.WebAssembly
 
             List<VfsAsset>? MapVfsAssets(Dictionary<string, Dictionary<string, string>>? assets) => assets?.Select(a =>
             {
+                string assetName = a.Value.Keys.First();
                 var asset = new VfsAsset()
                 {
                     virtualPath = a.Key,
-                    name = a.Value.Keys.First(),
-                    integrity = a.Value.Values.First()
+                    name = assetName,
+                    integrity = a.Value.Values.First(),
+                    cache = GetCacheControl(assetName, resources)
                 };
 
                 if (bundlerFriendly)
@@ -339,5 +344,7 @@ namespace Microsoft.NET.Sdk.WebAssembly
 
             return string.Join(Environment.NewLine, imports);
         }
+
+        private static string? GetCacheControl(string endpoint, ResourcesData resources) => resources.fingerprinting?[endpoint] != null ? "force-cache" : null;
     }
 }

--- a/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonData.cs
+++ b/src/tasks/Microsoft.NET.Sdk.WebAssembly.Pack.Tasks/BootJsonData.cs
@@ -351,6 +351,7 @@ public class JsAsset
 public class SymbolsAsset
 {
     public string name { get; set; }
+    public string cache { get; set; }
 }
 
 [DataContract]
@@ -359,6 +360,7 @@ public class WasmAsset
     public string name { get; set; }
     public string integrity { get; set; }
     public string resolvedUrl { get; set; }
+    public string cache { get; set; }
 }
 
 [DataContract]
@@ -368,6 +370,7 @@ public class GeneralAsset
     public string name { get; set; }
     public string integrity { get; set; }
     public string resolvedUrl { get; set; }
+    public string cache { get; set; }
 }
 
 [DataContract]
@@ -377,6 +380,7 @@ public class VfsAsset
     public string name { get; set; }
     public string integrity { get; set; }
     public string resolvedUrl { get; set; }
+    public string cache { get; set; }
 }
 
 public enum GlobalizationMode : int


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/122101 to release/10.0 to fix https://github.com/dotnet/aspnetcore/issues/64009

## Customer Impact

- [x] Customer reported
- [ ] Found internally

The issue significantly effects startup time of every WebAssembly based application. 

## Regression

- [x] Yes
- [ ] No

Caused by https://github.com/dotnet/runtime/pull/114901

## Testing

Manual testing of Blazor WebAssembly standalone, Blazor Web with WebAssembly & Auto interactivity, with Chromium-based, Firefox and Safari.
Automated test.

## Risk

Low. We are changing both built-time generator and runtime part reading the values. Thanks to fingerprinting there isn't a room for some staleness of one part. The change is scoped and in case it won't work in some scenario, the workaround is still possible.