### PR TITLE
Fix dataflow analysis of lambdas in async methods

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/FlowAnnotations.cs
@@ -36,6 +36,8 @@ namespace ILLink.Shared.TrimAnalysis
 
         public FlowAnnotations(Logger logger, ILProvider ilProvider, CompilerGeneratedState compilerGeneratedState)
         {
+            ilProvider = new AsyncMaskingILProvider(ilProvider);
+
             _hashtable = new TypeAnnotationsHashtable(logger, ilProvider, compilerGeneratedState);
             _logger = logger;
             ILProvider = ilProvider;
@@ -299,7 +301,7 @@ namespace ILLink.Shared.TrimAnalysis
             private readonly CompilerGeneratedState _compilerGeneratedState;
 
             public TypeAnnotationsHashtable(Logger logger, ILProvider ilProvider, CompilerGeneratedState compilerGeneratedState) =>
-                (_logger, _ilProvider, _compilerGeneratedState) = (logger, new AsyncMaskingILProvider(ilProvider), compilerGeneratedState);
+                (_logger, _ilProvider, _compilerGeneratedState) = (logger, ilProvider, compilerGeneratedState);
 
             private static DynamicallyAccessedMemberTypes GetMemberTypesForDynamicallyAccessedMembersAttribute(MetadataReader reader, CustomAttributeHandleCollection customAttributeHandles)
             {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/MethodBodyScanner.cs
@@ -55,7 +55,7 @@ namespace ILCompiler.Dataflow
         protected MethodBodyScanner(FlowAnnotations annotations)
         {
             _annotations = annotations;
-            InterproceduralStateLattice = new InterproceduralStateLattice(new AsyncMaskingILProvider(annotations.ILProvider), default, default);
+            InterproceduralStateLattice = new InterproceduralStateLattice(annotations.ILProvider, default, default);
         }
 
         protected virtual void WarnAboutInvalidILInMethod(MethodIL method, int ilOffset)

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/RuntimeAsyncMethods.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/RuntimeAsyncMethods.cs
@@ -14,6 +14,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
     [SkipKeptItemsValidation]
     [SetupCompileArgument("/features:runtime-async=on")]
     [SetupCompileArgument("/nowarn:SYSLIB5007")]
+    [ExpectedNoWarnings]
     public class RuntimeAsyncMethods
     {
         public static async Task Main()
@@ -26,6 +27,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             await RuntimeAsyncReturningAnnotatedType();
             await RuntimeAsyncWithCorrectParameter(null);
             await RuntimeAsyncWithLocalAll();
+            await RuntimeAsyncWithLambda();
         }
 
         static async Task BasicRuntimeAsyncMethod()
@@ -102,6 +104,17 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             Type t = GetWithAllMembers();
             await Task.Delay(1);
             t.RequiresAll();
+        }
+
+        class TypeWithRucMethod
+        {
+            [RequiresUnreferencedCode("RUC")]
+            public static void RucMethod() { }
+        }
+
+        static async Task RuntimeAsyncWithLambda()
+        {
+            await Task.Run([ExpectedWarning("IL2026", nameof(TypeWithRucMethod.RucMethod))] () => typeof(TypeWithRucMethod).GetMethods());
         }
     }
 }


### PR DESCRIPTION
When we enter ILLinker part of the ILC codebase, we need to switch to the mode where async variants don't exist and async methods have mismatched bodies. There was a spot where we didn't do the switch here:

https://github.com/dotnet/runtime/blob/d31e5990b896447bfc3dbe98cfe6ec3b169a4896/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/UsageBasedMetadataManager.cs#L939-L949

The fix is to do the switch early in `FlowAnnotations` so that the `ILProvider` `FlowAnnotations` use (and other parts take advantage of) is already ILLinkerified.

Fixes the situation shown in the regression test (we were analyzing the IL of the async variant of `RuntimeAsyncWithLambda` and missed analyzing the lambda completely).

Cc @dotnet/ilc-contrib 