### PR TITLE
Fix runtime async in multifile compilation

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LibraryRootProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/LibraryRootProvider.cs
@@ -49,7 +49,7 @@ namespace ILCompiler
 
         private static void RootMethods(TypeDesc type, string reason, IRootingServiceProvider rootProvider)
         {
-            foreach (MethodDesc method in type.GetAllMethods())
+            foreach (MethodDesc method in type.GetAllMethodsAndAsyncVariants())
             {
                 // Skip methods with no IL and uninstantiated generic methods
                 if (method.IsAbstract || method.HasInstantiation)


### PR DESCRIPTION
1. When compiling a library, compile all methods including async variants.
2. When enumerating methods on types, generate variants for every task returning method, not just virtuals.

The 2 is a bit surprising but it matches what we now do in https://github.com/dotnet/runtime/blob/d31e5990b896447bfc3dbe98cfe6ec3b169a4896/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs#L1849-L1857. We originally restricted this to methods being runtimeasync but changed it in https://github.com/dotnet/runtime/pull/121622/files#diff-132a77bcd3f74cf0e0b04fbccda246c97c91e40562d78cb01fff61cf69403573L1860.

Cc @dotnet/ilc-contrib 