### PR TITLE
[infa][iOS] Disable jobs to improve availability of iOS and tvOS device queues

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
@@ -23,7 +23,7 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      # - ios_arm64 TODO: Enable when Helix queue is available https://github.com/dotnet/dnceng/issues/6440
+      # - ios_arm64 TODO: Enable when Helix queue upgrade is finished https://github.com/dotnet/runtime/issues/122452
       - tvos_arm64
     variables:
       # map dependencies variables to local variables
@@ -64,7 +64,7 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      #- ios_arm64 TODO: Enable when Helix queue is available https://github.com/dotnet/dnceng/issues/6440
+      # - ios_arm64 TODO: Enable when Helix queue upgrade is finished https://github.com/dotnet/runtime/issues/122452
       - tvos_arm64
     variables:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
@@ -109,7 +109,7 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
+      # - ios_arm64 TODO: Enable when Helix queue upgrade is finished https://github.com/dotnet/runtime/issues/122452
       - tvos_arm64
     variables:
       # map dependencies variables to local variables

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1022,7 +1022,7 @@ extends:
           runtimeFlavor: mono
           platforms:
             - ios_arm64
-            - tvos_arm64
+          # - tvos_arm64 TODO: Enable when Helix queue upgrade is finished https://github.com/dotnet/runtime/issues/122452
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange
@@ -1112,7 +1112,7 @@ extends:
           runtimeFlavor: coreclr
           platforms:
             - ios_arm64
-            - tvos_arm64
+          # - tvos_arm64 TODO: Enable when Helix queue upgrade is finished https://github.com/dotnet/runtime/issues/122452
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1022,7 +1022,7 @@ extends:
           runtimeFlavor: mono
           platforms:
             - ios_arm64
-          # - tvos_arm64 TODO: Enable when Helix queue upgrade is finished https://github.com/dotnet/runtime/issues/122452
+            # - tvos_arm64 TODO: Enable when Helix queue upgrade is finished https://github.com/dotnet/runtime/issues/122452
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1112,7 +1112,7 @@ extends:
           runtimeFlavor: coreclr
           platforms:
             - ios_arm64
-          # - tvos_arm64 TODO: Enable when Helix queue upgrade is finished https://github.com/dotnet/runtime/issues/122452
+            # - tvos_arm64 TODO: Enable when Helix queue upgrade is finished https://github.com/dotnet/runtime/issues/122452
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange


### PR DESCRIPTION
Due to ongoing update of iOS and tvOS device queue, we have limited testing capacity. Disabling tvOS jobs from `runtime` pipeline and iOS jobs from `runtime-extra-platforms` pipeline. This should reduce the strain on the queues, reduce the run time of `runtime` pipeline which runs on every PR, while still providing full coverage over rolling-builds of `runtime-extra-platforms` (together with `runtime` pipeline). Work tracked in https://github.com/dotnet/runtime/issues/122452.