### PR TITLE
System.IO.Ports: check device capabilities for DTR/DSR in SerialStream Constructor/dispose (Windows)

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.COMMPROP.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.COMMPROP.cs
@@ -16,6 +16,8 @@ internal static partial class Interop
         // https://msdn.microsoft.com/en-us/library/windows/desktop/aa363189.aspx
         internal struct COMMPROP
         {
+            public const int PCF_DTRDSR = 0x1;
+
             public ushort wPacketLength;
             public ushort wPacketVersion;
             public int dwServiceMask;

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -635,7 +635,8 @@ namespace System.IO.Ports
                 InitializeDCB(baudRate, parity, dataBits, stopBits, discardNull);
 
                 //if device doesnt support DTR and DTR is disabled, then dont try to set DTR
-                if (DtrEnable || ((_commProp.dwProvCapabilities & Interop.Kernel32.COMMPROP.PCF_DTRDSR) != 0)) {
+                if (DtrEnable || ((_commProp.dwProvCapabilities & Interop.Kernel32.COMMPROP.PCF_DTRDSR) != 0))
+                {
                     DtrEnable = dtrEnable;
 
                     // query and cache the initial RtsEnable value

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -721,7 +721,8 @@ namespace System.IO.Ports
                     // turn off all events and signal WaitCommEvent
                     Interop.Kernel32.SetCommMask(_handle, 0);
                     //if device supports DTR then clear
-                    if ((_commProp.dwProvCapabilities & Interop.Kernel32.COMMPROP.PCF_DTRDSR) != 0) {
+                    if ((_commProp.dwProvCapabilities & Interop.Kernel32.COMMPROP.PCF_DTRDSR) != 0)
+                    {
                         if (!Interop.Kernel32.EscapeCommFunction(_handle, Interop.Kernel32.CommFunctions.CLRDTR))
                         {
                             int hr = Marshal.GetLastPInvokeError();

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -634,7 +634,7 @@ namespace System.IO.Ports
                 // set constant properties of the DCB
                 InitializeDCB(baudRate, parity, dataBits, stopBits, discardNull);
 
-                //if device doesnt support DTR and DTR is disabled, then dont try to set DTR 
+                //if device doesnt support DTR and DTR is disabled, then dont try to set DTR
                 if (DtrEnable || ((_commProp.dwProvCapabilities & Interop.Kernel32.COMMPROP.PCF_DTRDSR) != 0)) {
                     DtrEnable = dtrEnable;
 
@@ -720,7 +720,6 @@ namespace System.IO.Ports
 
                     // turn off all events and signal WaitCommEvent
                     Interop.Kernel32.SetCommMask(_handle, 0);
-                    
                     //if device supports DTR then clear
                     if ((_commProp.dwProvCapabilities & Interop.Kernel32.COMMPROP.PCF_DTRDSR) != 0) {
                         if (!Interop.Kernel32.EscapeCommFunction(_handle, Interop.Kernel32.CommFunctions.CLRDTR))


### PR DESCRIPTION
See #121468
Fixes #27729