### PR TITLE
Rework bootstrap layout usage for AOT publish of cdac project

### DIFF
--- a/eng/targetingpacks.targets
+++ b/eng/targetingpacks.targets
@@ -16,9 +16,10 @@
     <TargetingpacksTargetsImported>true</TargetingpacksTargetsImported>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(DisableImplicitFrameworkReferences)' != 'true' and
-                            '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
-                            '$(TargetFrameworkVersion)' == 'v$(NetCoreAppCurrentVersion)'">
+  <PropertyGroup Condition="('$(DisableImplicitFrameworkReferences)' != 'true' and
+                             '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and
+                             '$(TargetFrameworkVersion)' == 'v$(NetCoreAppCurrentVersion)')
+                            or '$(UseBootstrapLayout)' == 'true'">
     <UseLocalTargetingRuntimePack Condition="'$(UseLocalTargetingRuntimePack)' == ''">true</UseLocalTargetingRuntimePack>
   </PropertyGroup>
 

--- a/src/native/managed/Directory.Build.props
+++ b/src/native/managed/Directory.Build.props
@@ -1,8 +1,9 @@
 <Project>
   <Import Project="..\..\..\Directory.Build.props" />
-  <Import Project=".\native-library.props" Condition="'$(IsSourceProject)' == 'true' and '$(Language)' == 'C#'" />
+  <PropertyGroup>
 
-  <PropertyGroup Condition="'$(UseBootstrapLayout)' == 'true'">
-    <UseLocalTargetingRuntimePack>true</UseLocalTargetingRuntimePack>
+    <UseBootstrapLayout Condition="'$(NeedsAotPublish)' == 'true' and '$(UseBootstrap)' == 'true'">true</UseBootstrapLayout>
   </PropertyGroup>
+
+  <Import Project=".\native-library.props" Condition="'$(NeedsAotPublish)' == 'true'" />
 </Project>

--- a/src/native/managed/Directory.Build.targets
+++ b/src/native/managed/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Import Project=".\native-library.targets" Condition="'$(IsSourceProject)' == 'true' and '$(Language)' == 'C#'" />
+  <Import Project=".\native-library.targets" Condition="'$(NeedsAotPublish)' == 'true'" />
   <Import Project="..\..\..\Directory.Build.targets" />
   <Import Project="$(RepositoryEngineeringDir)targetingpacks.targets" Condition="'$(UseBootstrapLayout)' == 'true'" />
   <Import Project="$(RepositoryEngineeringDir)liveILLink.targets" Condition="'$(UseBootstrapLayout)' == 'true'" />

--- a/src/native/managed/cdac/mscordaccore_universal/mscordaccore_universal.csproj
+++ b/src/native/managed/cdac/mscordaccore_universal/mscordaccore_universal.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <NeedsAotPublish>true</NeedsAotPublish>
     <AssemblyName>$(LibPrefix)$(MSBuildProjectName)</AssemblyName>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>

--- a/src/native/managed/cdac/mscordaccore_universal/mscordaccore_universal.csproj
+++ b/src/native/managed/cdac/mscordaccore_universal/mscordaccore_universal.csproj
@@ -1,7 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+<Project>
   <PropertyGroup>
     <NeedsAotPublish>true</NeedsAotPublish>
+  </PropertyGroup>
+
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <PropertyGroup>
     <AssemblyName>$(LibPrefix)$(MSBuildProjectName)</AssemblyName>
     <TargetFramework>$(NetCoreAppToolCurrent)</TargetFramework>
     <RootNamespace>Microsoft.Diagnostics.DataContractReader</RootNamespace>
@@ -33,4 +36,5 @@
     <ProjectReference Include="..\Microsoft.Diagnostics.DataContractReader.Legacy\Microsoft.Diagnostics.DataContractReader.Legacy.csproj" />
   </ItemGroup>
 
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 </Project>

--- a/src/native/managed/subproject.props
+++ b/src/native/managed/subproject.props
@@ -5,7 +5,6 @@
         <SubprojectProps Include="RuntimeConfiguration" Value="$(RuntimeConfiguration)" />
         <SubprojectProps Include="LibrariesConfiguration" Value="$(LibrariesConfiguration)" />
         <SubprojectProps Include="RuntimeIdentifier" Value="$(PortableTargetRid)" />
-        <SubprojectProps Include="UseBootstrapLayout" Value="$(UseBootstrap)" />
     </ItemGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
The cdac was setting a slew of properties that had cascading effects on the bootstrap targetting pack logic. Simplify this to only kick in when using AOT publishing in-build. 