### PR TITLE
Support ICU v78 changes including IDN and Japanese Meiji era start date

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/JapaneseCalendar.Icu.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/JapaneseCalendar.Icu.cs
@@ -58,6 +58,14 @@ namespace System.Globalization
                     return null;
                 }
 
+                if (dt.Year == s_calendarMinValue.Year)
+                {
+                    // adjust the start date to the minimum supported date time
+                    // date 1868/9/8 is actually Meiji 1/1/1 but the actual Gregorian date is 1868/10/23. The 1868/9/8 is used before as a Gregorian era start date
+                    // for JapaneseCalendar but now we are ensuring using the correct 1868/10/23 stored in s_calendarMinValue.
+                    dt = s_calendarMinValue;
+                }
+
                 if (dt < s_calendarMinValue)
                 {
                     // only populate the Eras that are valid JapaneseCalendar date times

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/JapaneseCalendar.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/JapaneseCalendar.cs
@@ -27,12 +27,12 @@ namespace System.Globalization
     /// Calendar support range:
     ///     Calendar    Minimum     Maximum
     ///     ==========  ==========  ==========
-    ///     Gregorian   1868/09/08  9999/12/31
+    ///     Gregorian   1868/10/23  9999/12/31
     ///     Japanese    Meiji 01/01 Reiwa 7981/12/31
     /// </remarks>
     public partial class JapaneseCalendar : Calendar
     {
-        private static readonly DateTime s_calendarMinValue = new DateTime(1868, 9, 8);
+        private static readonly DateTime s_calendarMinValue = new DateTime(1868, 10, 23);
 
         public override DateTime MinSupportedDateTime => s_calendarMinValue;
 

--- a/src/libraries/System.Runtime/tests/System.Globalization.Calendars.Tests/JapaneseCalendar/JapaneseCalendarAddMonths.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Calendars.Tests/JapaneseCalendar/JapaneseCalendarAddMonths.cs
@@ -19,12 +19,12 @@ namespace System.Globalization.Tests
             yield return new object[] { new DateTime(2007, 1, 1), -1, new DateTime(2006, 12, 1) };
 
             // Boundary values
-            yield return new object[] { new DateTime(1868, 9, 8), 1, new DateTime(1868, 10, 8) };
-            yield return new object[] { new DateTime(1868, 10, 8), -1, new DateTime(1868, 9, 8) };
+            yield return new object[] { new DateTime(1868, 10, 23), 1, new DateTime(1868, 11, 23) };
+            yield return new object[] { new DateTime(1868, 11, 23), -1, new DateTime(1868, 10, 23) };
             yield return new object[] { new DateTime(9999, 11, 30), 1, new DateTime(9999, 12, 30) };
             yield return new object[] { new DateTime(9999, 12, 30), -1, new DateTime(9999, 11, 30) };
             yield return new object[] { DateTime.MaxValue, 0, DateTime.MaxValue };
-            yield return new object[] { new DateTime(1868, 9, 8), 0, new DateTime(1868, 9, 8) };
+            yield return new object[] { new DateTime(1868, 10, 23), 0, new DateTime(1868, 10, 23) };
 
             // Day is not in the month
             yield return new object[] { new DateTime(2006, 10, 31), 1, new DateTime(2006, 11, 30) };

--- a/src/libraries/System.Runtime/tests/System.Globalization.Calendars.Tests/System/Globalization/JapaneseCalendarTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Calendars.Tests/System/Globalization/JapaneseCalendarTests.cs
@@ -9,7 +9,7 @@ namespace System.Globalization.Tests
     {
         public override Calendar Calendar => new JapaneseCalendar();
 
-        public override DateTime MinSupportedDateTime => new DateTime(1868, 09, 08);
+        public override DateTime MinSupportedDateTime => new DateTime(1868, 10, 23);
 
         public override bool SkipErasTest => true;
 

--- a/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/IdnMapping/Data/Factory.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/IdnMapping/Data/Factory.cs
@@ -29,7 +29,9 @@ namespace System.Globalization.Tests
             // some exception for Windows which released ICU 72.1.0.4 which using Unicode 15.1.
 
             string fileName = null;
-            if (PlatformDetection.ICUVersion >= new Version(76, 0))
+            if (PlatformDetection.ICUVersion >= new Version(78, 0))
+                fileName = "IdnaTest_17.txt";
+            else if (PlatformDetection.ICUVersion >= new Version(76, 0))
                 fileName = "IdnaTest_16.txt";
             else if (PlatformDetection.ICUVersion >= new Version(72, 1, 0, 4))
                 fileName = "IdnaTest_15_1.txt";
@@ -70,7 +72,9 @@ namespace System.Globalization.Tests
 
         private static IConformanceIdnaTest GetConformanceIdnaTest(string line, int lineCount)
         {
-            if (PlatformDetection.ICUVersion >= new Version(76, 0))
+            if (PlatformDetection.ICUVersion >= new Version(78, 0))
+                return new Unicode_17_0_IdnaTest(line, lineCount);
+            else if (PlatformDetection.ICUVersion >= new Version(76, 0))
                 return new Unicode_16_0_IdnaTest(line, lineCount);
             else if (PlatformDetection.ICUVersion >= new Version(72, 1, 0, 4))
                 return new Unicode_15_1_IdnaTest(line, lineCount);

--- a/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/IdnMapping/Data/Unicode_17_0/IdnaTest_17.txt
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/IdnMapping/Data/Unicode_17_0/IdnaTest_17.txt
@@ -1,0 +1,6508 @@
+# IdnaTestV2.txt
+# Date: 2025-05-01, 19:36:55 GMT
+# © 2025 Unicode®, Inc.
+# Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+# For terms of use and license, see https://www.unicode.org/terms_of_use.html
+#
+# Unicode IDNA Compatible Preprocessing for UTS #46
+# Version: 17.0.0
+#
+# For documentation and usage, see https://www.unicode.org/reports/tr46
+#
+# Test cases for verifying UTS #46 conformance.
+#
+# FORMAT:
+#
+# This file is in UTF-8, where characters may be escaped using the \uXXXX or \x{XXXX}
+# convention where they could otherwise have a confusing display.
+# These characters include control codes and combining marks.
+#
+# Columns (c1, c2,...) are separated by semicolons.
+# Leading and trailing spaces and tabs in each column are ignored.
+# Comments are indicated with hash marks.
+#
+# Column 1: source -          The source string to be tested.
+#                             "" means the empty string.
+# Column 2: toUnicode -       The result of applying toUnicode to the source,
+#                             with Transitional_Processing=false.
+#                             A blank value means the same as the source value.
+#                             "" means the empty string.
+# Column 3: toUnicodeStatus - A set of status codes, each corresponding to a particular test.
+#                             A blank value means [] (no errors).
+# Column 4: toAsciiN -        The result of applying toASCII to the source,
+#                             with Transitional_Processing=false.
+#                             A blank value means the same as the toUnicode value.
+#                             "" means the empty string.
+# Column 5: toAsciiNStatus -  A set of status codes, each corresponding to a particular test.
+#                             A blank value means the same as the toUnicodeStatus value.
+#                             An explicit [] means no errors.
+# Column 6: toAsciiT -        The result of applying toASCII to the source,
+#                             with Transitional_Processing=true.
+#                             A blank value means the same as the toAsciiN value.
+#                             "" means the empty string.
+# Column 7: toAsciiTStatus -  A set of status codes, each corresponding to a particular test.
+#                             A blank value means the same as the toAsciiNStatus value.
+#                             An explicit [] means no errors.
+#
+# The line comments currently show visible characters that have been escaped.
+#
+# CONFORMANCE:
+#
+# To test for conformance to UTS #46, an implementation will perform the toUnicode, toAsciiN, and
+# toAsciiT operations on the source string, then verify the resulting strings and relevant status
+# values.
+#
+# If the implementation converts illegal code points into U+FFFD (as per
+# https://www.unicode.org/reports/tr46/#Processing) then the string comparisons need to
+# account for that by treating U+FFFD in the actual value as a wildcard when comparing to the
+# expected value in the test file.
+#
+# A status in toUnicode, toAsciiN or toAsciiT is indicated by a value in square brackets,
+# such as "[B5, B6]". In such a case, the contents is a list of status codes based on the step
+# numbers in UTS #46 and IDNA2008, with the following formats.
+#
+#   Pn for Section 4 Processing step n
+#   Vn for 4.1 Validity Criteria step n
+#   U1 for UseSTD3ASCIIRules
+#   An for 4.2 ToASCII step n
+#   Bn for Bidi (in IDNA2008)
+#   Cn for ContextJ (in IDNA2008)
+#   Xn for toUnicode issues (see below)
+#
+# Thus C1 = Appendix A.1. ZERO WIDTH NON-JOINER, and C2 = Appendix A.2. ZERO WIDTH JOINER.
+# (The CONTEXTO tests are optional for client software, and not tested here.)
+#
+# Implementations that allow values of particular input flags to be false would ignore
+# the corresponding status codes listed in the table below when testing for errors.
+#
+# VerifyDnsLength:   A4_1, A4_2
+# CheckHyphens:      V2, V3
+# CheckJoiners:      Cn
+# CheckBidi:         Bn
+# UseSTD3ASCIIRules: U1
+#
+# Implementations that cannot work with ill-formed strings would skip test cases that contain them.
+# For example, the status code A3 is set for a Punycode encoding error,
+# which may be due to an unpaired surrogate.
+#
+# Implementations may be more strict than the default settings for UTS #46.
+# In particular, an implementation conformant to IDNA2008 would skip any line in this test file that
+# contained a character in the toUnicode field that has the IDNA2008 Status value NV8 or XV8
+# in IdnaMappingTable.txt.
+# For example, it would skip a line containing ¢ (U+00A2 CENT SIGN) in the toUnicode field, 
+# because of the following line in IdnaMappingTable.txt:
+#
+# 00A1..00A7    ; valid                  ;      ; NV8    # 1.1  INVERTED EXCLAMATION MARK..SECTION SIGN
+#
+# Implementations need only record that there is an error: they need not reproduce the
+# precise status codes (after removing the ignored status values).
+#
+# Compatibility errors
+#
+# The special error code X4_2 is now returned where a toASCII error code
+# was formerly being generated in toUnicode due to an empty label:
+# A4_2 was being generated for an empty label in CheckBidi (in addition to A4_2’s normal usage).
+# ============================================================================================
+fass.de; ; ; ; ; ;  # fass.de
+faß.de; ; ; xn--fa-hia.de; ; fass.de;  # faß.de
+Faß.de; faß.de; ; xn--fa-hia.de; ; fass.de;  # faß.de
+xn--fa-hia.de; faß.de; ; xn--fa-hia.de; ; ;  # faß.de
+
+# BIDI TESTS
+
+à\u05D0; ; [B5, B6]; xn--0ca24w; ; ;  # àא
+a\u0300\u05D0; à\u05D0; [B5, B6]; xn--0ca24w; ; ;  # àא
+A\u0300\u05D0; à\u05D0; [B5, B6]; xn--0ca24w; ; ;  # àא
+À\u05D0; à\u05D0; [B5, B6]; xn--0ca24w; ; ;  # àא
+xn--0ca24w; à\u05D0; [B5, B6]; xn--0ca24w; ; ;  # àא
+0à.\u05D0; ; [B1]; xn--0-sfa.xn--4db; ; ;  # 0à.א
+0a\u0300.\u05D0; 0à.\u05D0; [B1]; xn--0-sfa.xn--4db; ; ;  # 0à.א
+0A\u0300.\u05D0; 0à.\u05D0; [B1]; xn--0-sfa.xn--4db; ; ;  # 0à.א
+0À.\u05D0; 0à.\u05D0; [B1]; xn--0-sfa.xn--4db; ; ;  # 0à.א
+xn--0-sfa.xn--4db; 0à.\u05D0; [B1]; xn--0-sfa.xn--4db; ; ;  # 0à.א
+à.\u05D0\u0308; ; ; xn--0ca.xn--ssa73l; ; ;  # à.א̈
+a\u0300.\u05D0\u0308; à.\u05D0\u0308; ; xn--0ca.xn--ssa73l; ; ;  # à.א̈
+A\u0300.\u05D0\u0308; à.\u05D0\u0308; ; xn--0ca.xn--ssa73l; ; ;  # à.א̈
+À.\u05D0\u0308; à.\u05D0\u0308; ; xn--0ca.xn--ssa73l; ; ;  # à.א̈
+xn--0ca.xn--ssa73l; à.\u05D0\u0308; ; xn--0ca.xn--ssa73l; ; ;  # à.א̈
+à.\u05D00\u0660\u05D0; ; [B4]; xn--0ca.xn--0-zhcb98c; ; ;  # à.א0٠א
+a\u0300.\u05D00\u0660\u05D0; à.\u05D00\u0660\u05D0; [B4]; xn--0ca.xn--0-zhcb98c; ; ;  # à.א0٠א
+A\u0300.\u05D00\u0660\u05D0; à.\u05D00\u0660\u05D0; [B4]; xn--0ca.xn--0-zhcb98c; ; ;  # à.א0٠א
+À.\u05D00\u0660\u05D0; à.\u05D00\u0660\u05D0; [B4]; xn--0ca.xn--0-zhcb98c; ; ;  # à.א0٠א
+xn--0ca.xn--0-zhcb98c; à.\u05D00\u0660\u05D0; [B4]; xn--0ca.xn--0-zhcb98c; ; ;  # à.א0٠א
+\u0308.\u05D0; ; [B1, V6]; xn--ssa.xn--4db; ; ;  # ̈.א
+xn--ssa.xn--4db; \u0308.\u05D0; [B1, V6]; xn--ssa.xn--4db; ; ;  # ̈.א
+à.\u05D00\u0660; ; [B4]; xn--0ca.xn--0-zhc74b; ; ;  # à.א0٠
+a\u0300.\u05D00\u0660; à.\u05D00\u0660; [B4]; xn--0ca.xn--0-zhc74b; ; ;  # à.א0٠
+A\u0300.\u05D00\u0660; à.\u05D00\u0660; [B4]; xn--0ca.xn--0-zhc74b; ; ;  # à.א0٠
+À.\u05D00\u0660; à.\u05D00\u0660; [B4]; xn--0ca.xn--0-zhc74b; ; ;  # à.א0٠
+xn--0ca.xn--0-zhc74b; à.\u05D00\u0660; [B4]; xn--0ca.xn--0-zhc74b; ; ;  # à.א0٠
+àˇ.\u05D0; ; [B6]; xn--0ca88g.xn--4db; ; ;  # àˇ.א
+a\u0300ˇ.\u05D0; àˇ.\u05D0; [B6]; xn--0ca88g.xn--4db; ; ;  # àˇ.א
+A\u0300ˇ.\u05D0; àˇ.\u05D0; [B6]; xn--0ca88g.xn--4db; ; ;  # àˇ.א
+Àˇ.\u05D0; àˇ.\u05D0; [B6]; xn--0ca88g.xn--4db; ; ;  # àˇ.א
+xn--0ca88g.xn--4db; àˇ.\u05D0; [B6]; xn--0ca88g.xn--4db; ; ;  # àˇ.א
+à\u0308.\u05D0; ; ; xn--0ca81i.xn--4db; ; ;  # à̈.א
+a\u0300\u0308.\u05D0; à\u0308.\u05D0; ; xn--0ca81i.xn--4db; ; ;  # à̈.א
+A\u0300\u0308.\u05D0; à\u0308.\u05D0; ; xn--0ca81i.xn--4db; ; ;  # à̈.א
+À\u0308.\u05D0; à\u0308.\u05D0; ; xn--0ca81i.xn--4db; ; ;  # à̈.א
+xn--0ca81i.xn--4db; à\u0308.\u05D0; ; xn--0ca81i.xn--4db; ; ;  # à̈.א
+
+# CONTEXT TESTS
+
+a\u200Cb; ; [C1]; xn--ab-j1t; ; ab; [] # ab
+A\u200CB; a\u200Cb; [C1]; xn--ab-j1t; ; ab; [] # ab
+A\u200Cb; a\u200Cb; [C1]; xn--ab-j1t; ; ab; [] # ab
+ab; ; ; ; ; ;  # ab
+xn--ab-j1t; a\u200Cb; [C1]; xn--ab-j1t; ; ;  # ab
+a\u094D\u200Cb; ; ; xn--ab-fsf604u; ; xn--ab-fsf;  # a्b
+A\u094D\u200CB; a\u094D\u200Cb; ; xn--ab-fsf604u; ; xn--ab-fsf;  # a्b
+A\u094D\u200Cb; a\u094D\u200Cb; ; xn--ab-fsf604u; ; xn--ab-fsf;  # a्b
+xn--ab-fsf; a\u094Db; ; xn--ab-fsf; ; ;  # a्b
+a\u094Db; ; ; xn--ab-fsf; ; ;  # a्b
+A\u094DB; a\u094Db; ; xn--ab-fsf; ; ;  # a्b
+A\u094Db; a\u094Db; ; xn--ab-fsf; ; ;  # a्b
+xn--ab-fsf604u; a\u094D\u200Cb; ; xn--ab-fsf604u; ; ;  # a्b
+\u0308\u200C\u0308\u0628b; ; [B1, C1, V6]; xn--b-bcba413a2w8b; ; xn--b-bcba413a; [B1, V6] # ̈̈بb
+\u0308\u200C\u0308\u0628B; \u0308\u200C\u0308\u0628b; [B1, C1, V6]; xn--b-bcba413a2w8b; ; xn--b-bcba413a; [B1, V6] # ̈̈بb
+xn--b-bcba413a; \u0308\u0308\u0628b; [B1, V6]; xn--b-bcba413a; ; ;  # ̈̈بb
+xn--b-bcba413a2w8b; \u0308\u200C\u0308\u0628b; [B1, C1, V6]; xn--b-bcba413a2w8b; ; ;  # ̈̈بb
+a\u0628\u0308\u200C\u0308; ; [B5, B6, C1]; xn--a-ccba213a5w8b; ; xn--a-ccba213a; [B5, B6] # aب̈̈
+A\u0628\u0308\u200C\u0308; a\u0628\u0308\u200C\u0308; [B5, B6, C1]; xn--a-ccba213a5w8b; ; xn--a-ccba213a; [B5, B6] # aب̈̈
+xn--a-ccba213a; a\u0628\u0308\u0308; [B5, B6]; xn--a-ccba213a; ; ;  # aب̈̈
+xn--a-ccba213a5w8b; a\u0628\u0308\u200C\u0308; [B5, B6, C1]; xn--a-ccba213a5w8b; ; ;  # aب̈̈
+a\u0628\u0308\u200C\u0308\u0628b; ; [B5]; xn--ab-uuba211bca8057b; ; xn--ab-uuba211bca;  # aب̈̈بb
+A\u0628\u0308\u200C\u0308\u0628B; a\u0628\u0308\u200C\u0308\u0628b; [B5]; xn--ab-uuba211bca8057b; ; xn--ab-uuba211bca;  # aب̈̈بb
+A\u0628\u0308\u200C\u0308\u0628b; a\u0628\u0308\u200C\u0308\u0628b; [B5]; xn--ab-uuba211bca8057b; ; xn--ab-uuba211bca;  # aب̈̈بb
+xn--ab-uuba211bca; a\u0628\u0308\u0308\u0628b; [B5]; xn--ab-uuba211bca; ; ;  # aب̈̈بb
+xn--ab-uuba211bca8057b; a\u0628\u0308\u200C\u0308\u0628b; [B5]; xn--ab-uuba211bca8057b; ; ;  # aب̈̈بb
+a\u200Db; ; [C2]; xn--ab-m1t; ; ab; [] # ab
+A\u200DB; a\u200Db; [C2]; xn--ab-m1t; ; ab; [] # ab
+A\u200Db; a\u200Db; [C2]; xn--ab-m1t; ; ab; [] # ab
+xn--ab-m1t; a\u200Db; [C2]; xn--ab-m1t; ; ;  # ab
+a\u094D\u200Db; ; ; xn--ab-fsf014u; ; xn--ab-fsf;  # a्b
+A\u094D\u200DB; a\u094D\u200Db; ; xn--ab-fsf014u; ; xn--ab-fsf;  # a्b
+A\u094D\u200Db; a\u094D\u200Db; ; xn--ab-fsf014u; ; xn--ab-fsf;  # a्b
+xn--ab-fsf014u; a\u094D\u200Db; ; xn--ab-fsf014u; ; ;  # a्b
+\u0308\u200D\u0308\u0628b; ; [B1, C2, V6]; xn--b-bcba413a7w8b; ; xn--b-bcba413a; [B1, V6] # ̈̈بb
+\u0308\u200D\u0308\u0628B; \u0308\u200D\u0308\u0628b; [B1, C2, V6]; xn--b-bcba413a7w8b; ; xn--b-bcba413a; [B1, V6] # ̈̈بb
+xn--b-bcba413a7w8b; \u0308\u200D\u0308\u0628b; [B1, C2, V6]; xn--b-bcba413a7w8b; ; ;  # ̈̈بb
+a\u0628\u0308\u200D\u0308; ; [B5, B6, C2]; xn--a-ccba213abx8b; ; xn--a-ccba213a; [B5, B6] # aب̈̈
+A\u0628\u0308\u200D\u0308; a\u0628\u0308\u200D\u0308; [B5, B6, C2]; xn--a-ccba213abx8b; ; xn--a-ccba213a; [B5, B6] # aب̈̈
+xn--a-ccba213abx8b; a\u0628\u0308\u200D\u0308; [B5, B6, C2]; xn--a-ccba213abx8b; ; ;  # aب̈̈
+a\u0628\u0308\u200D\u0308\u0628b; ; [B5, C2]; xn--ab-uuba211bca5157b; ; xn--ab-uuba211bca; [B5] # aب̈̈بb
+A\u0628\u0308\u200D\u0308\u0628B; a\u0628\u0308\u200D\u0308\u0628b; [B5, C2]; xn--ab-uuba211bca5157b; ; xn--ab-uuba211bca; [B5] # aب̈̈بb
+A\u0628\u0308\u200D\u0308\u0628b; a\u0628\u0308\u200D\u0308\u0628b; [B5, C2]; xn--ab-uuba211bca5157b; ; xn--ab-uuba211bca; [B5] # aب̈̈بb
+xn--ab-uuba211bca5157b; a\u0628\u0308\u200D\u0308\u0628b; [B5, C2]; xn--ab-uuba211bca5157b; ; ;  # aب̈̈بb
+
+# SELECTED TESTS
+
+¡; ; ; xn--7a; ; ;  # ¡
+xn--7a; ¡; ; xn--7a; ; ;  # ¡
+᧚; ; ; xn--pkf; ; ;  # ᧚
+xn--pkf; ᧚; ; xn--pkf; ; ;  # ᧚
+""; ; [X4_2]; ; [A4_1, A4_2]; ;  # 
+。; .; [X4_2]; ; [A4_1, A4_2]; ;  # .
+.; ; [X4_2]; ; [A4_1, A4_2]; ;  # .
+ꭠ; ; ; xn--3y9a; ; ;  # ꭠ
+xn--3y9a; ꭠ; ; xn--3y9a; ; ;  # ꭠ
+1234567890ä1234567890123456789012345678901234567890123456; ; ; xn--12345678901234567890123456789012345678901234567890123456-fxe; [A4_2]; ;  # 1234567890ä1234567890123456789012345678901234567890123456
+1234567890a\u03081234567890123456789012345678901234567890123456; 1234567890ä1234567890123456789012345678901234567890123456; ; xn--12345678901234567890123456789012345678901234567890123456-fxe; [A4_2]; ;  # 1234567890ä1234567890123456789012345678901234567890123456
+1234567890A\u03081234567890123456789012345678901234567890123456; 1234567890ä1234567890123456789012345678901234567890123456; ; xn--12345678901234567890123456789012345678901234567890123456-fxe; [A4_2]; ;  # 1234567890ä1234567890123456789012345678901234567890123456
+1234567890Ä1234567890123456789012345678901234567890123456; 1234567890ä1234567890123456789012345678901234567890123456; ; xn--12345678901234567890123456789012345678901234567890123456-fxe; [A4_2]; ;  # 1234567890ä1234567890123456789012345678901234567890123456
+xn--12345678901234567890123456789012345678901234567890123456-fxe; 1234567890ä1234567890123456789012345678901234567890123456; ; xn--12345678901234567890123456789012345678901234567890123456-fxe; [A4_2]; ;  # 1234567890ä1234567890123456789012345678901234567890123456
+www.eXample.cOm; www.example.com; ; ; ; ;  # www.example.com
+Bücher.de; bücher.de; ; xn--bcher-kva.de; ; ;  # bücher.de
+Bu\u0308cher.de; bücher.de; ; xn--bcher-kva.de; ; ;  # bücher.de
+bu\u0308cher.de; bücher.de; ; xn--bcher-kva.de; ; ;  # bücher.de
+bücher.de; ; ; xn--bcher-kva.de; ; ;  # bücher.de
+BÜCHER.DE; bücher.de; ; xn--bcher-kva.de; ; ;  # bücher.de
+BU\u0308CHER.DE; bücher.de; ; xn--bcher-kva.de; ; ;  # bücher.de
+xn--bcher-kva.de; bücher.de; ; xn--bcher-kva.de; ; ;  # bücher.de
+ÖBB; öbb; ; xn--bb-eka; ; ;  # öbb
+O\u0308BB; öbb; ; xn--bb-eka; ; ;  # öbb
+o\u0308bb; öbb; ; xn--bb-eka; ; ;  # öbb
+öbb; ; ; xn--bb-eka; ; ;  # öbb
+Öbb; öbb; ; xn--bb-eka; ; ;  # öbb
+O\u0308bb; öbb; ; xn--bb-eka; ; ;  # öbb
+xn--bb-eka; öbb; ; xn--bb-eka; ; ;  # öbb
+FAẞ.de; faß.de; ; xn--fa-hia.de; ; fass.de;  # faß.de
+FAẞ.DE; faß.de; ; xn--fa-hia.de; ; fass.de;  # faß.de
+βόλος.com; ; ; xn--nxasmm1c.com; ; xn--nxasmq6b.com;  # βόλος.com
+βο\u0301λος.com; βόλος.com; ; xn--nxasmm1c.com; ; xn--nxasmq6b.com;  # βόλος.com
+ΒΟ\u0301ΛΟΣ.COM; βόλοσ.com; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com
+ΒΌΛΟΣ.COM; βόλοσ.com; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com
+βόλοσ.com; ; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com
+βο\u0301λοσ.com; βόλοσ.com; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com
+Βο\u0301λοσ.com; βόλοσ.com; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com
+Βόλοσ.com; βόλοσ.com; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com
+xn--nxasmq6b.com; βόλοσ.com; ; xn--nxasmq6b.com; ; ;  # βόλοσ.com
+Βο\u0301λος.com; βόλος.com; ; xn--nxasmm1c.com; ; xn--nxasmq6b.com;  # βόλος.com
+Βόλος.com; βόλος.com; ; xn--nxasmm1c.com; ; xn--nxasmq6b.com;  # βόλος.com
+xn--nxasmm1c.com; βόλος.com; ; xn--nxasmm1c.com; ; ;  # βόλος.com
+xn--nxasmm1c; βόλος; ; xn--nxasmm1c; ; ;  # βόλος
+βόλος; ; ; xn--nxasmm1c; ; xn--nxasmq6b;  # βόλος
+βο\u0301λος; βόλος; ; xn--nxasmm1c; ; xn--nxasmq6b;  # βόλος
+ΒΟ\u0301ΛΟΣ; βόλοσ; ; xn--nxasmq6b; ; ;  # βόλοσ
+ΒΌΛΟΣ; βόλοσ; ; xn--nxasmq6b; ; ;  # βόλοσ
+βόλοσ; ; ; xn--nxasmq6b; ; ;  # βόλοσ
+βο\u0301λοσ; βόλοσ; ; xn--nxasmq6b; ; ;  # βόλοσ
+Βο\u0301λοσ; βόλοσ; ; xn--nxasmq6b; ; ;  # βόλοσ
+Βόλοσ; βόλοσ; ; xn--nxasmq6b; ; ;  # βόλοσ
+xn--nxasmq6b; βόλοσ; ; xn--nxasmq6b; ; ;  # βόλοσ
+Βόλος; βόλος; ; xn--nxasmm1c; ; xn--nxasmq6b;  # βόλος
+Βο\u0301λος; βόλος; ; xn--nxasmm1c; ; xn--nxasmq6b;  # βόλος
+www.ශ\u0DCA\u200Dර\u0DD3.com; ; ; www.xn--10cl1a0b660p.com; ; www.xn--10cl1a0b.com;  # www.ශ්රී.com
+WWW.ශ\u0DCA\u200Dර\u0DD3.COM; www.ශ\u0DCA\u200Dර\u0DD3.com; ; www.xn--10cl1a0b660p.com; ; www.xn--10cl1a0b.com;  # www.ශ්රී.com
+Www.ශ\u0DCA\u200Dර\u0DD3.com; www.ශ\u0DCA\u200Dර\u0DD3.com; ; www.xn--10cl1a0b660p.com; ; www.xn--10cl1a0b.com;  # www.ශ්රී.com
+www.xn--10cl1a0b.com; www.ශ\u0DCAර\u0DD3.com; ; www.xn--10cl1a0b.com; ; ;  # www.ශ්රී.com
+www.ශ\u0DCAර\u0DD3.com; ; ; www.xn--10cl1a0b.com; ; ;  # www.ශ්රී.com
+WWW.ශ\u0DCAර\u0DD3.COM; www.ශ\u0DCAර\u0DD3.com; ; www.xn--10cl1a0b.com; ; ;  # www.ශ්රී.com
+Www.ශ\u0DCAර\u0DD3.com; www.ශ\u0DCAර\u0DD3.com; ; www.xn--10cl1a0b.com; ; ;  # www.ශ්රී.com
+www.xn--10cl1a0b660p.com; www.ශ\u0DCA\u200Dර\u0DD3.com; ; www.xn--10cl1a0b660p.com; ; ;  # www.ශ්රී.com
+\u0646\u0627\u0645\u0647\u200C\u0627\u06CC; ; ; xn--mgba3gch31f060k; ; xn--mgba3gch31f;  # نامهای
+xn--mgba3gch31f; \u0646\u0627\u0645\u0647\u0627\u06CC; ; xn--mgba3gch31f; ; ;  # نامهای
+\u0646\u0627\u0645\u0647\u0627\u06CC; ; ; xn--mgba3gch31f; ; ;  # نامهای
+xn--mgba3gch31f060k; \u0646\u0627\u0645\u0647\u200C\u0627\u06CC; ; xn--mgba3gch31f060k; ; ;  # نامهای
+xn--mgba3gch31f060k.com; \u0646\u0627\u0645\u0647\u200C\u0627\u06CC.com; ; xn--mgba3gch31f060k.com; ; ;  # نامهای.com
+\u0646\u0627\u0645\u0647\u200C\u0627\u06CC.com; ; ; xn--mgba3gch31f060k.com; ; xn--mgba3gch31f.com;  # نامهای.com
+\u0646\u0627\u0645\u0647\u200C\u0627\u06CC.COM; \u0646\u0627\u0645\u0647\u200C\u0627\u06CC.com; ; xn--mgba3gch31f060k.com; ; xn--mgba3gch31f.com;  # نامهای.com
+xn--mgba3gch31f.com; \u0646\u0627\u0645\u0647\u0627\u06CC.com; ; xn--mgba3gch31f.com; ; ;  # نامهای.com
+\u0646\u0627\u0645\u0647\u0627\u06CC.com; ; ; xn--mgba3gch31f.com; ; ;  # نامهای.com
+\u0646\u0627\u0645\u0647\u0627\u06CC.COM; \u0646\u0627\u0645\u0647\u0627\u06CC.com; ; xn--mgba3gch31f.com; ; ;  # نامهای.com
+a.b．c。d｡; a.b.c.d.; ; ; [A4_2]; ;  # a.b.c.d.
+a.b.c。d。; a.b.c.d.; ; ; [A4_2]; ;  # a.b.c.d.
+A.B.C。D。; a.b.c.d.; ; ; [A4_2]; ;  # a.b.c.d.
+A.b.c。D。; a.b.c.d.; ; ; [A4_2]; ;  # a.b.c.d.
+a.b.c.d.; ; ; ; [A4_2]; ;  # a.b.c.d.
+A.B．C。D｡; a.b.c.d.; ; ; [A4_2]; ;  # a.b.c.d.
+A.b．c。D｡; a.b.c.d.; ; ; [A4_2]; ;  # a.b.c.d.
+U\u0308.xn--tda; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+Ü.xn--tda; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+ü.xn--tda; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+u\u0308.xn--tda; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+U\u0308.XN--TDA; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+Ü.XN--TDA; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+Ü.xn--Tda; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+U\u0308.xn--Tda; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+xn--tda.xn--tda; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+ü.ü; ; ; xn--tda.xn--tda; ; ;  # ü.ü
+u\u0308.u\u0308; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+U\u0308.U\u0308; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+Ü.Ü; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+Ü.ü; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+U\u0308.u\u0308; ü.ü; ; xn--tda.xn--tda; ; ;  # ü.ü
+xn--u-ccb; u\u0308; [V1]; xn--u-ccb; ; ;  # ü
+a⒈com; ; [V7]; xn--acom-0w1b; ; ;  # a⒈com
+a1.com; ; ; ; ; ;  # a1.com
+A⒈COM; a⒈com; [V7]; xn--acom-0w1b; ; ;  # a⒈com
+A⒈Com; a⒈com; [V7]; xn--acom-0w1b; ; ;  # a⒈com
+xn--acom-0w1b; a⒈com; [V7]; xn--acom-0w1b; ; ;  # a⒈com
+xn--a-ecp.ru; a⒈.ru; [V7]; xn--a-ecp.ru; ; ;  # a⒈.ru
+xn--0.pt; ; [P4]; ; ; ;  # xn--0.pt
+xn--a.pt; \u0080.pt; [V7]; xn--a.pt; ; ;  # .pt
+xn--a-Ä.pt; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+xn--a-A\u0308.pt; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+xn--a-a\u0308.pt; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+xn--a-ä.pt; ; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+XN--A-Ä.PT; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+XN--A-A\u0308.PT; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+Xn--A-A\u0308.pt; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+Xn--A-Ä.pt; xn--a-ä.pt; [P4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+xn--xn--a--gua.pt; xn--a-ä.pt; [V2, V4]; xn--xn--a--gua.pt; ; ;  # xn--a-ä.pt
+日本語。ＪＰ; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語。JP; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語。jp; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語。Jp; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+xn--wgv71a119e.jp; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語.jp; ; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語.JP; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語.Jp; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語。ｊｐ; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+日本語。Ｊｐ; 日本語.jp; ; xn--wgv71a119e.jp; ; ;  # 日本語.jp
+☕; ; ; xn--53h; ; ;  # ☕
+xn--53h; ☕; ; xn--53h; ; ;  # ☕
+1.aß\u200C\u200Db\u200C\u200Dcßßßßdςσßßßßßßßßeßßßßßßßßßßxßßßßßßßßßßyßßßßßßßß\u0302ßz; ; [C1, C2]; 1.xn--abcdexyz-qyacaaabaaaaaaabaaaaaaaaabaaaaaaaaabaaaaaaaa010ze2isb1140zba8cc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.aßbcßßßßdςσßßßßßßßßeßßßßßßßßßßxßßßßßßßßßßyßßßßßßßß̂ßz
+1.ASS\u200C\u200DB\u200C\u200DCSSSSSSSSDΣΣSSSSSSSSSSSSSSSSESSSSSSSSSSSSSSSSSSSSXSSSSSSSSSSSSSSSSSSSSYSSSSSSSSSSSSSSSS\u0302SSZ; 1.ass\u200C\u200Db\u200C\u200Dcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; [C1, C2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.ASS\u200C\u200DB\u200C\u200DCSSSSSSSSDΣΣSSSSSSSSSSSSSSSSESSSSSSSSSSSSSSSSSSSSXSSSSSSSSSSSSSSSSSSSSYSSSSSSSSSSSSSSSŜSSZ; 1.ass\u200C\u200Db\u200C\u200Dcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; [C1, C2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.ass\u200C\u200Db\u200C\u200Dcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; [C1, C2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.ass\u200C\u200Db\u200C\u200Dcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssyssssssssssssssss\u0302ssz; 1.ass\u200C\u200Db\u200C\u200Dcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; [C1, C2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.Ass\u200C\u200Db\u200C\u200Dcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssyssssssssssssssss\u0302ssz; 1.ass\u200C\u200Db\u200C\u200Dcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; [C1, C2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.Ass\u200C\u200Db\u200C\u200Dcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; 1.ass\u200C\u200Db\u200C\u200Dcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; [C1, C2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; ; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssyssssssssssssssss\u0302ssz; 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.ASSBCSSSSSSSSDΣΣSSSSSSSSSSSSSSSSESSSSSSSSSSSSSSSSSSSSXSSSSSSSSSSSSSSSSSSSSYSSSSSSSSSSSSSSSS\u0302SSZ; 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.ASSBCSSSSSSSSDΣΣSSSSSSSSSSSSSSSSESSSSSSSSSSSSSSSSSSSSXSSSSSSSSSSSSSSSSSSSSYSSSSSSSSSSSSSSSŜSSZ; 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.Assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.Assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssyssssssssssssssss\u0302ssz; 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; ; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; 1.ass\u200C\u200Db\u200C\u200Dcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz; [C1, C2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa69989dba9gc; [C1, C2, A4_2]; ;  # 1.assbcssssssssdσσssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssŝssz
+1.Aß\u200C\u200Db\u200C\u200Dcßßßßdςσßßßßßßßßeßßßßßßßßßßxßßßßßßßßßßyßßßßßßßß\u0302ßz; 1.aß\u200C\u200Db\u200C\u200Dcßßßßdςσßßßßßßßßeßßßßßßßßßßxßßßßßßßßßßyßßßßßßßß\u0302ßz; [C1, C2]; 1.xn--abcdexyz-qyacaaabaaaaaaabaaaaaaaaabaaaaaaaaabaaaaaaaa010ze2isb1140zba8cc; [C1, C2, A4_2]; 1.xn--assbcssssssssdssssssssssssssssessssssssssssssssssssxssssssssssssssssssssysssssssssssssssssz-pxq1419aa; [A4_2] # 1.aßbcßßßßdςσßßßßßßßßeßßßßßßßßßßxßßßßßßßßßßyßßßßßßßß̂ßz
+1.xn--abcdexyz-qyacaaabaaaaaaabaaaaaaaaabaaaaaaaaabaaaaaaaa010ze2isb1140zba8cc; 1.aß\u200C\u200Db\u200C\u200Dcßßßßdςσßßßßßßßßeßßßßßßßßßßxßßßßßßßßßßyßßßßßßßß\u0302ßz; [C1, C2]; 1.xn--abcdexyz-qyacaaabaaaaaaabaaaaaaaaabaaaaaaaaabaaaaaaaa010ze2isb1140zba8cc; [C1, C2, A4_2]; ;  # 1.aßbcßßßßdςσßßßßßßßßeßßßßßßßßßßxßßßßßßßßßßyßßßßßßßß̂ßz
+\u200Cx\u200Dn\u200C-\u200D-bß; ; [C1, C2]; xn--xn--b-pqa5796ccahd; ; xn--bss; [] # xn--bß
+\u200CX\u200DN\u200C-\u200D-BSS; \u200Cx\u200Dn\u200C-\u200D-bss; [C1, C2]; xn--xn--bss-7z6ccid; ; xn--bss; [] # xn--bss
+\u200Cx\u200Dn\u200C-\u200D-bss; ; [C1, C2]; xn--xn--bss-7z6ccid; ; xn--bss; [] # xn--bss
+\u200CX\u200Dn\u200C-\u200D-Bss; \u200Cx\u200Dn\u200C-\u200D-bss; [C1, C2]; xn--xn--bss-7z6ccid; ; xn--bss; [] # xn--bss
+xn--bss; 夙; ; xn--bss; ; ;  # 夙
+夙; ; ; xn--bss; ; ;  # 夙
+xn--xn--bss-7z6ccid; \u200Cx\u200Dn\u200C-\u200D-bss; [C1, C2]; xn--xn--bss-7z6ccid; ; ;  # xn--bss
+\u200CX\u200Dn\u200C-\u200D-Bß; \u200Cx\u200Dn\u200C-\u200D-bß; [C1, C2]; xn--xn--b-pqa5796ccahd; ; xn--bss; [] # xn--bß
+xn--xn--b-pqa5796ccahd; \u200Cx\u200Dn\u200C-\u200D-bß; [C1, C2]; xn--xn--b-pqa5796ccahd; ; ;  # xn--bß
+ˣ\u034Fℕ\u200B﹣\u00AD－\u180Cℬ\uFE00ſ\u2064𝔰󠇯ﬄ; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+x\u034FN\u200B-\u00AD-\u180CB\uFE00s\u2064s󠇯ffl; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+x\u034Fn\u200B-\u00AD-\u180Cb\uFE00s\u2064s󠇯ffl; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+X\u034FN\u200B-\u00AD-\u180CB\uFE00S\u2064S󠇯FFL; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+X\u034Fn\u200B-\u00AD-\u180CB\uFE00s\u2064s󠇯ffl; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+xn--bssffl; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+夡夞夜夙; ; ; xn--bssffl; ; ;  # 夡夞夜夙
+ˣ\u034Fℕ\u200B﹣\u00AD－\u180Cℬ\uFE00S\u2064𝔰󠇯FFL; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+x\u034FN\u200B-\u00AD-\u180CB\uFE00S\u2064s󠇯FFL; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+ˣ\u034Fℕ\u200B﹣\u00AD－\u180Cℬ\uFE00s\u2064𝔰󠇯ffl; 夡夞夜夙; ; xn--bssffl; ; ;  # 夡夞夜夙
+123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; ; ; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; ; ; ; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.
+123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; ; ; ; [A4_1]; ;  # 123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c
+123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901234.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; ; ; ; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901234.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a
+123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901234.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; ; ; ; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901234.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.
+123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901234.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; ; ; [A4_1, A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901234.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+ä1234567890123456789012345678901234567890123456789012345; ; ; xn--1234567890123456789012345678901234567890123456789012345-9te; ; ;  # ä1234567890123456789012345678901234567890123456789012345
+a\u03081234567890123456789012345678901234567890123456789012345; ä1234567890123456789012345678901234567890123456789012345; ; xn--1234567890123456789012345678901234567890123456789012345-9te; ; ;  # ä1234567890123456789012345678901234567890123456789012345
+A\u03081234567890123456789012345678901234567890123456789012345; ä1234567890123456789012345678901234567890123456789012345; ; xn--1234567890123456789012345678901234567890123456789012345-9te; ; ;  # ä1234567890123456789012345678901234567890123456789012345
+Ä1234567890123456789012345678901234567890123456789012345; ä1234567890123456789012345678901234567890123456789012345; ; xn--1234567890123456789012345678901234567890123456789012345-9te; ; ;  # ä1234567890123456789012345678901234567890123456789012345
+xn--1234567890123456789012345678901234567890123456789012345-9te; ä1234567890123456789012345678901234567890123456789012345; ; xn--1234567890123456789012345678901234567890123456789012345-9te; ; ;  # ä1234567890123456789012345678901234567890123456789012345
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+123456789012345678901234567890123456789012345678901234567890123.1234567890a\u0308123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+123456789012345678901234567890123456789012345678901234567890123.1234567890A\u0308123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890B; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890B; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; ; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.
+123456789012345678901234567890123456789012345678901234567890123.1234567890a\u0308123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.
+123456789012345678901234567890123456789012345678901234567890123.1234567890A\u0308123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890B.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890B.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.
+123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; ; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; [A4_1]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c
+123456789012345678901234567890123456789012345678901234567890123.1234567890a\u0308123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; [A4_1]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c
+123456789012345678901234567890123456789012345678901234567890123.1234567890A\u0308123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901C; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; [A4_1]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901C; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; [A4_1]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c
+123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; [A4_1]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; ; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a
+123456789012345678901234567890123456789012345678901234567890123.1234567890a\u03081234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a
+123456789012345678901234567890123456789012345678901234567890123.1234567890A\u03081234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789A; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789A; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a
+123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; ; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.
+123456789012345678901234567890123456789012345678901234567890123.1234567890a\u03081234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.
+123456789012345678901234567890123456789012345678901234567890123.1234567890A\u03081234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789A.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789A.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.
+123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.
+123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; [A4_1, A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+123456789012345678901234567890123456789012345678901234567890123.1234567890a\u03081234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; [A4_1, A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+123456789012345678901234567890123456789012345678901234567890123.1234567890A\u03081234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890B; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; [A4_1, A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890B; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; [A4_1, A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; [A4_1, A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+a.b..-q--a-.e; ; [V2, V3, X4_2]; ; [V2, V3, A4_2]; ;  # a.b..-q--a-.e
+a.b..-q--ä-.e; ; [V2, V3, X4_2]; a.b..xn---q----jra.e; [V2, V3, A4_2]; ;  # a.b..-q--ä-.e
+a.b..-q--a\u0308-.e; a.b..-q--ä-.e; [V2, V3, X4_2]; a.b..xn---q----jra.e; [V2, V3, A4_2]; ;  # a.b..-q--ä-.e
+A.B..-Q--A\u0308-.E; a.b..-q--ä-.e; [V2, V3, X4_2]; a.b..xn---q----jra.e; [V2, V3, A4_2]; ;  # a.b..-q--ä-.e
+A.B..-Q--Ä-.E; a.b..-q--ä-.e; [V2, V3, X4_2]; a.b..xn---q----jra.e; [V2, V3, A4_2]; ;  # a.b..-q--ä-.e
+A.b..-Q--Ä-.E; a.b..-q--ä-.e; [V2, V3, X4_2]; a.b..xn---q----jra.e; [V2, V3, A4_2]; ;  # a.b..-q--ä-.e
+A.b..-Q--A\u0308-.E; a.b..-q--ä-.e; [V2, V3, X4_2]; a.b..xn---q----jra.e; [V2, V3, A4_2]; ;  # a.b..-q--ä-.e
+a.b..xn---q----jra.e; a.b..-q--ä-.e; [V2, V3, X4_2]; a.b..xn---q----jra.e; [V2, V3, A4_2]; ;  # a.b..-q--ä-.e
+a..c; ; [X4_2]; ; [A4_2]; ;  # a..c
+a.-b.; ; [V3]; ; [V3, A4_2]; ;  # a.-b.
+a.b-.c; ; [V3]; ; ; ;  # a.b-.c
+a.-.c; ; [V3]; ; ; ;  # a.-.c
+a.bc--de.f; ; [V2]; ; ; ;  # a.bc--de.f
+xn--xn---epa; xn--é; [V2, V4]; xn--xn---epa; ; ;  # xn--é
+ä.\u00AD.c; ä..c; [X4_2]; xn--4ca..c; [A4_2]; ;  # ä..c
+a\u0308.\u00AD.c; ä..c; [X4_2]; xn--4ca..c; [A4_2]; ;  # ä..c
+A\u0308.\u00AD.C; ä..c; [X4_2]; xn--4ca..c; [A4_2]; ;  # ä..c
+Ä.\u00AD.C; ä..c; [X4_2]; xn--4ca..c; [A4_2]; ;  # ä..c
+xn--4ca..c; ä..c; [X4_2]; xn--4ca..c; [A4_2]; ;  # ä..c
+ä.-b.; ; [V3]; xn--4ca.-b.; [V3, A4_2]; ;  # ä.-b.
+a\u0308.-b.; ä.-b.; [V3]; xn--4ca.-b.; [V3, A4_2]; ;  # ä.-b.
+A\u0308.-B.; ä.-b.; [V3]; xn--4ca.-b.; [V3, A4_2]; ;  # ä.-b.
+Ä.-B.; ä.-b.; [V3]; xn--4ca.-b.; [V3, A4_2]; ;  # ä.-b.
+xn--4ca.-b.; ä.-b.; [V3]; xn--4ca.-b.; [V3, A4_2]; ;  # ä.-b.
+ä.b-.c; ; [V3]; xn--4ca.b-.c; ; ;  # ä.b-.c
+a\u0308.b-.c; ä.b-.c; [V3]; xn--4ca.b-.c; ; ;  # ä.b-.c
+A\u0308.B-.C; ä.b-.c; [V3]; xn--4ca.b-.c; ; ;  # ä.b-.c
+Ä.B-.C; ä.b-.c; [V3]; xn--4ca.b-.c; ; ;  # ä.b-.c
+Ä.b-.C; ä.b-.c; [V3]; xn--4ca.b-.c; ; ;  # ä.b-.c
+A\u0308.b-.C; ä.b-.c; [V3]; xn--4ca.b-.c; ; ;  # ä.b-.c
+xn--4ca.b-.c; ä.b-.c; [V3]; xn--4ca.b-.c; ; ;  # ä.b-.c
+ä.-.c; ; [V3]; xn--4ca.-.c; ; ;  # ä.-.c
+a\u0308.-.c; ä.-.c; [V3]; xn--4ca.-.c; ; ;  # ä.-.c
+A\u0308.-.C; ä.-.c; [V3]; xn--4ca.-.c; ; ;  # ä.-.c
+Ä.-.C; ä.-.c; [V3]; xn--4ca.-.c; ; ;  # ä.-.c
+xn--4ca.-.c; ä.-.c; [V3]; xn--4ca.-.c; ; ;  # ä.-.c
+ä.bc--de.f; ; [V2]; xn--4ca.bc--de.f; ; ;  # ä.bc--de.f
+a\u0308.bc--de.f; ä.bc--de.f; [V2]; xn--4ca.bc--de.f; ; ;  # ä.bc--de.f
+A\u0308.BC--DE.F; ä.bc--de.f; [V2]; xn--4ca.bc--de.f; ; ;  # ä.bc--de.f
+Ä.BC--DE.F; ä.bc--de.f; [V2]; xn--4ca.bc--de.f; ; ;  # ä.bc--de.f
+Ä.bc--De.f; ä.bc--de.f; [V2]; xn--4ca.bc--de.f; ; ;  # ä.bc--de.f
+A\u0308.bc--De.f; ä.bc--de.f; [V2]; xn--4ca.bc--de.f; ; ;  # ä.bc--de.f
+xn--4ca.bc--de.f; ä.bc--de.f; [V2]; xn--4ca.bc--de.f; ; ;  # ä.bc--de.f
+a.b.\u0308c.d; ; [V6]; a.b.xn--c-bcb.d; ; ;  # a.b.̈c.d
+A.B.\u0308C.D; a.b.\u0308c.d; [V6]; a.b.xn--c-bcb.d; ; ;  # a.b.̈c.d
+A.b.\u0308c.d; a.b.\u0308c.d; [V6]; a.b.xn--c-bcb.d; ; ;  # a.b.̈c.d
+a.b.xn--c-bcb.d; a.b.\u0308c.d; [V6]; a.b.xn--c-bcb.d; ; ;  # a.b.̈c.d
+A0; a0; ; ; ; ;  # a0
+0A; 0a; ; ; ; ;  # 0a
+0A.\u05D0; 0a.\u05D0; [B1]; 0a.xn--4db; ; ;  # 0a.א
+0a.\u05D0; ; [B1]; 0a.xn--4db; ; ;  # 0a.א
+0a.xn--4db; 0a.\u05D0; [B1]; 0a.xn--4db; ; ;  # 0a.א
+c.xn--0-eha.xn--4db; c.0ü.\u05D0; [B1]; c.xn--0-eha.xn--4db; ; ;  # c.0ü.א
+b-.\u05D0; ; [B6, V3]; b-.xn--4db; ; ;  # b-.א
+B-.\u05D0; b-.\u05D0; [B6, V3]; b-.xn--4db; ; ;  # b-.א
+b-.xn--4db; b-.\u05D0; [B6, V3]; b-.xn--4db; ; ;  # b-.א
+d.xn----dha.xn--4db; d.ü-.\u05D0; [B6, V3]; d.xn----dha.xn--4db; ; ;  # d.ü-.א
+a\u05D0; ; [B5, B6]; xn--a-0hc; ; ;  # aא
+A\u05D0; a\u05D0; [B5, B6]; xn--a-0hc; ; ;  # aא
+xn--a-0hc; a\u05D0; [B5, B6]; xn--a-0hc; ; ;  # aא
+\u05D0\u05C7; ; ; xn--vdbr; ; ;  # אׇ
+xn--vdbr; \u05D0\u05C7; ; xn--vdbr; ; ;  # אׇ
+\u05D09\u05C7; ; ; xn--9-ihcz; ; ;  # א9ׇ
+xn--9-ihcz; \u05D09\u05C7; ; xn--9-ihcz; ; ;  # א9ׇ
+\u05D0a\u05C7; ; [B2, B3]; xn--a-ihcz; ; ;  # אaׇ
+\u05D0A\u05C7; \u05D0a\u05C7; [B2, B3]; xn--a-ihcz; ; ;  # אaׇ
+xn--a-ihcz; \u05D0a\u05C7; [B2, B3]; xn--a-ihcz; ; ;  # אaׇ
+\u05D0\u05EA; ; ; xn--4db6c; ; ;  # את
+xn--4db6c; \u05D0\u05EA; ; xn--4db6c; ; ;  # את
+\u05D0\u05F3\u05EA; ; ; xn--4db6c0a; ; ;  # א׳ת
+xn--4db6c0a; \u05D0\u05F3\u05EA; ; xn--4db6c0a; ; ;  # א׳ת
+a\u05D0Tz; a\u05D0tz; [B5]; xn--atz-qpe; ; ;  # aאtz
+a\u05D0tz; ; [B5]; xn--atz-qpe; ; ;  # aאtz
+A\u05D0TZ; a\u05D0tz; [B5]; xn--atz-qpe; ; ;  # aאtz
+A\u05D0tz; a\u05D0tz; [B5]; xn--atz-qpe; ; ;  # aאtz
+xn--atz-qpe; a\u05D0tz; [B5]; xn--atz-qpe; ; ;  # aאtz
+\u05D0T\u05EA; \u05D0t\u05EA; [B2]; xn--t-zhc3f; ; ;  # אtת
+\u05D0t\u05EA; ; [B2]; xn--t-zhc3f; ; ;  # אtת
+xn--t-zhc3f; \u05D0t\u05EA; [B2]; xn--t-zhc3f; ; ;  # אtת
+\u05D07\u05EA; ; ; xn--7-zhc3f; ; ;  # א7ת
+xn--7-zhc3f; \u05D07\u05EA; ; xn--7-zhc3f; ; ;  # א7ת
+\u05D0\u0667\u05EA; ; ; xn--4db6c6t; ; ;  # א٧ת
+xn--4db6c6t; \u05D0\u0667\u05EA; ; xn--4db6c6t; ; ;  # א٧ת
+a7\u0667z; ; [B5]; xn--a7z-06e; ; ;  # a7٧z
+A7\u0667Z; a7\u0667z; [B5]; xn--a7z-06e; ; ;  # a7٧z
+A7\u0667z; a7\u0667z; [B5]; xn--a7z-06e; ; ;  # a7٧z
+xn--a7z-06e; a7\u0667z; [B5]; xn--a7z-06e; ; ;  # a7٧z
+\u05D07\u0667\u05EA; ; [B4]; xn--7-zhc3fty; ; ;  # א7٧ת
+xn--7-zhc3fty; \u05D07\u0667\u05EA; [B4]; xn--7-zhc3fty; ; ;  # א7٧ת
+ஹ\u0BCD\u200D; ; ; xn--dmc4b194h; ; xn--dmc4b;  # ஹ்
+xn--dmc4b; ஹ\u0BCD; ; xn--dmc4b; ; ;  # ஹ்
+ஹ\u0BCD; ; ; xn--dmc4b; ; ;  # ஹ்
+xn--dmc4b194h; ஹ\u0BCD\u200D; ; xn--dmc4b194h; ; ;  # ஹ்
+ஹ\u200D; ; [C2]; xn--dmc225h; ; xn--dmc; [] # ஹ
+xn--dmc; ஹ; ; xn--dmc; ; ;  # ஹ
+ஹ; ; ; xn--dmc; ; ;  # ஹ
+xn--dmc225h; ஹ\u200D; [C2]; xn--dmc225h; ; ;  # ஹ
+\u200D; ; [C2]; xn--1ug; ; ""; [A4_1, A4_2] # 
+xn--1ug; \u200D; [C2]; xn--1ug; ; ;  # 
+ஹ\u0BCD\u200C; ; ; xn--dmc4by94h; ; xn--dmc4b;  # ஹ்
+xn--dmc4by94h; ஹ\u0BCD\u200C; ; xn--dmc4by94h; ; ;  # ஹ்
+ஹ\u200C; ; [C1]; xn--dmc025h; ; xn--dmc; [] # ஹ
+xn--dmc025h; ஹ\u200C; [C1]; xn--dmc025h; ; ;  # ஹ
+\u200C; ; [C1]; xn--0ug; ; ""; [A4_1, A4_2] # 
+xn--0ug; \u200C; [C1]; xn--0ug; ; ;  # 
+\u0644\u0670\u200C\u06ED\u06EF; ; ; xn--ghb2gxqia7523a; ; xn--ghb2gxqia;  # لٰۭۯ
+xn--ghb2gxqia; \u0644\u0670\u06ED\u06EF; ; xn--ghb2gxqia; ; ;  # لٰۭۯ
+\u0644\u0670\u06ED\u06EF; ; ; xn--ghb2gxqia; ; ;  # لٰۭۯ
+xn--ghb2gxqia7523a; \u0644\u0670\u200C\u06ED\u06EF; ; xn--ghb2gxqia7523a; ; ;  # لٰۭۯ
+\u0644\u0670\u200C\u06EF; ; ; xn--ghb2g3qq34f; ; xn--ghb2g3q;  # لٰۯ
+xn--ghb2g3q; \u0644\u0670\u06EF; ; xn--ghb2g3q; ; ;  # لٰۯ
+\u0644\u0670\u06EF; ; ; xn--ghb2g3q; ; ;  # لٰۯ
+xn--ghb2g3qq34f; \u0644\u0670\u200C\u06EF; ; xn--ghb2g3qq34f; ; ;  # لٰۯ
+\u0644\u200C\u06ED\u06EF; ; ; xn--ghb25aga828w; ; xn--ghb25aga;  # لۭۯ
+xn--ghb25aga; \u0644\u06ED\u06EF; ; xn--ghb25aga; ; ;  # لۭۯ
+\u0644\u06ED\u06EF; ; ; xn--ghb25aga; ; ;  # لۭۯ
+xn--ghb25aga828w; \u0644\u200C\u06ED\u06EF; ; xn--ghb25aga828w; ; ;  # لۭۯ
+\u0644\u200C\u06EF; ; ; xn--ghb65a953d; ; xn--ghb65a;  # لۯ
+xn--ghb65a; \u0644\u06EF; ; xn--ghb65a; ; ;  # لۯ
+\u0644\u06EF; ; ; xn--ghb65a; ; ;  # لۯ
+xn--ghb65a953d; \u0644\u200C\u06EF; ; xn--ghb65a953d; ; ;  # لۯ
+\u0644\u0670\u200C\u06ED; ; [B3, C1]; xn--ghb2gxqy34f; ; xn--ghb2gxq; [] # لٰۭ
+xn--ghb2gxq; \u0644\u0670\u06ED; ; xn--ghb2gxq; ; ;  # لٰۭ
+\u0644\u0670\u06ED; ; ; xn--ghb2gxq; ; ;  # لٰۭ
+xn--ghb2gxqy34f; \u0644\u0670\u200C\u06ED; [B3, C1]; xn--ghb2gxqy34f; ; ;  # لٰۭ
+\u06EF\u200C\u06EF; ; [C1]; xn--cmba004q; ; xn--cmba; [] # ۯۯ
+xn--cmba; \u06EF\u06EF; ; xn--cmba; ; ;  # ۯۯ
+\u06EF\u06EF; ; ; xn--cmba; ; ;  # ۯۯ
+xn--cmba004q; \u06EF\u200C\u06EF; [C1]; xn--cmba004q; ; ;  # ۯۯ
+\u0644\u200C; ; [B3, C1]; xn--ghb413k; ; xn--ghb; [] # ل
+xn--ghb; \u0644; ; xn--ghb; ; ;  # ل
+\u0644; ; ; xn--ghb; ; ;  # ل
+xn--ghb413k; \u0644\u200C; [B3, C1]; xn--ghb413k; ; ;  # ل
+a。。b; a..b; [X4_2]; ; [A4_2]; ;  # a..b
+A。。B; a..b; [X4_2]; ; [A4_2]; ;  # a..b
+a..b; ; [X4_2]; ; [A4_2]; ;  # a..b
+\u200D。。\u06B9\u200C; \u200D..\u06B9\u200C; [B1, B3, C1, C2, X4_2]; xn--1ug..xn--skb080k; [B1, B3, C1, C2, A4_2]; ..xn--skb; [A4_2] # ..ڹ
+..xn--skb; ..\u06B9; [X4_2]; ..xn--skb; [A4_2]; ;  # ..ڹ
+xn--1ug..xn--skb080k; \u200D..\u06B9\u200C; [B1, B3, C1, C2, X4_2]; xn--1ug..xn--skb080k; [B1, B3, C1, C2, A4_2]; ;  # ..ڹ
+\u05D00\u0660; ; [B4]; xn--0-zhc74b; ; ;  # א0٠
+xn--0-zhc74b; \u05D00\u0660; [B4]; xn--0-zhc74b; ; ;  # א0٠
+$; ; [U1]; ; ; ;  # $
+⑷.four; (4).four; [U1]; ; ; ;  # (4).four
+(4).four; ; [U1]; ; ; ;  # (4).four
+⑷.FOUR; (4).four; [U1]; ; ; ;  # (4).four
+⑷.Four; (4).four; [U1]; ; ; ;  # (4).four
+a\uD900z; ; [V7]; ; [V7, A3]; ;  # az
+A\uD900Z; a\uD900z; [V7]; ; [V7, A3]; ;  # az
+xn--; ""; [P4, X4_2]; ; [P4, A4_1, A4_2]; ;  # 
+xn---; ; [P4]; ; ; ;  # xn---
+xn--ASCII-; ascii; [P4]; ; ; ;  # ascii
+ascii; ; ; ; ; ;  # ascii
+xn--unicode-.org; unicode.org; [P4]; ; ; ;  # unicode.org
+unicode.org; ; ; ; ; ;  # unicode.org
+陋㛼当𤎫竮䗗; 陋㛼当𤎫竮䗗; ; xn--snl253bgitxhzwu2arn60c; ; ;  # 陋㛼当𤎫竮䗗
+陋㛼当𤎫竮䗗; ; ; xn--snl253bgitxhzwu2arn60c; ; ;  # 陋㛼当𤎫竮䗗
+xn--snl253bgitxhzwu2arn60c; 陋㛼当𤎫竮䗗; ; xn--snl253bgitxhzwu2arn60c; ; ;  # 陋㛼当𤎫竮䗗
+電𡍪弳䎫窮䵗; ; ; xn--kbo60w31ob3z6t3av9z5b; ; ;  # 電𡍪弳䎫窮䵗
+xn--kbo60w31ob3z6t3av9z5b; 電𡍪弳䎫窮䵗; ; xn--kbo60w31ob3z6t3av9z5b; ; ;  # 電𡍪弳䎫窮䵗
+xn--A-1ga; aö; ; xn--a-1ga; ; ;  # aö
+aö; ; ; xn--a-1ga; ; ;  # aö
+ao\u0308; aö; ; xn--a-1ga; ; ;  # aö
+AO\u0308; aö; ; xn--a-1ga; ; ;  # aö
+AÖ; aö; ; xn--a-1ga; ; ;  # aö
+Aö; aö; ; xn--a-1ga; ; ;  # aö
+Ao\u0308; aö; ; xn--a-1ga; ; ;  # aö
+＝\u0338; ≠; ; xn--1ch; ; ;  # ≠
+≠; ; ; xn--1ch; ; ;  # ≠
+=\u0338; ≠; ; xn--1ch; ; ;  # ≠
+xn--1ch; ≠; ; xn--1ch; ; ;  # ≠
+
+# RANDOMIZED TESTS
+
+123456789012345678901234567890123456789012345678901234567890123.1234567890A\u0308123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+123456789012345678901234567890123456789012345678901234567890123.1234567890A\u0308123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b.
+123456789012345678901234567890123456789012345678901234567890123.1234567890A\u0308123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; [A4_1]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; ; 123456789012345678901234567890123456789012345678901234567890123.xn--1234567890123456789012345678901234567890123456789012345-kue.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c; [A4_1]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä123456789012345678901234567890123456789012345.123456789012345678901234567890123456789012345678901234567890123.1234567890123456789012345678901234567890123456789012345678901c
+123456789012345678901234567890123456789012345678901234567890123.1234567890A\u03081234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a
+123456789012345678901234567890123456789012345678901234567890123.1234567890A\u03081234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.; [A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.12345678901234567890123456789012345678901234567890123456789a.
+123456789012345678901234567890123456789012345678901234567890123.1234567890A\u03081234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; [A4_1, A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+123456789012345678901234567890123456789012345678901234567890123.1234567890Ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; ; 123456789012345678901234567890123456789012345678901234567890123.xn--12345678901234567890123456789012345678901234567890123456-fxe.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b; [A4_1, A4_2]; ;  # 123456789012345678901234567890123456789012345678901234567890123.1234567890ä1234567890123456789012345678901234567890123456.123456789012345678901234567890123456789012345678901234567890123.123456789012345678901234567890123456789012345678901234567890b
+c.0ü.\u05D0; ; [B1]; c.xn--0-eha.xn--4db; ; ;  # c.0ü.א
+c.0u\u0308.\u05D0; c.0ü.\u05D0; [B1]; c.xn--0-eha.xn--4db; ; ;  # c.0ü.א
+C.0U\u0308.\u05D0; c.0ü.\u05D0; [B1]; c.xn--0-eha.xn--4db; ; ;  # c.0ü.א
+C.0Ü.\u05D0; c.0ü.\u05D0; [B1]; c.xn--0-eha.xn--4db; ; ;  # c.0ü.א
+C.0ü.\u05D0; c.0ü.\u05D0; [B1]; c.xn--0-eha.xn--4db; ; ;  # c.0ü.א
+C.0u\u0308.\u05D0; c.0ü.\u05D0; [B1]; c.xn--0-eha.xn--4db; ; ;  # c.0ü.א
+⒕∝\u065F򓤦．-󠄯; ⒕∝\u065F򓤦.-; [V3, V7]; xn--7hb713lfwbi1311b.-; ; ;  # ⒕∝ٟ.-
+14.∝\u065F򓤦.-󠄯; 14.∝\u065F򓤦.-; [V3, V7]; 14.xn--7hb713l3v90n.-; ; ;  # 14.∝ٟ.-
+14.xn--7hb713l3v90n.-; 14.∝\u065F򓤦.-; [V3, V7]; 14.xn--7hb713l3v90n.-; ; ;  # 14.∝ٟ.-
+xn--7hb713lfwbi1311b.-; ⒕∝\u065F򓤦.-; [V3, V7]; xn--7hb713lfwbi1311b.-; ; ;  # ⒕∝ٟ.-
+ꡣ.\u07CF; ; ; xn--8c9a.xn--qsb; ; ;  # ꡣ.ߏ
+xn--8c9a.xn--qsb; ꡣ.\u07CF; ; xn--8c9a.xn--qsb; ; ;  # ꡣ.ߏ
+≯\u0603｡-; ≯\u0603.-; [B1, V3, V7]; xn--lfb566l.-; ; ;  # ≯.-
+>\u0338\u0603｡-; ≯\u0603.-; [B1, V3, V7]; xn--lfb566l.-; ; ;  # ≯.-
+≯\u0603。-; ≯\u0603.-; [B1, V3, V7]; xn--lfb566l.-; ; ;  # ≯.-
+>\u0338\u0603。-; ≯\u0603.-; [B1, V3, V7]; xn--lfb566l.-; ; ;  # ≯.-
+xn--lfb566l.-; ≯\u0603.-; [B1, V3, V7]; xn--lfb566l.-; ; ;  # ≯.-
+⾛𐹧⾕.\u115F󠗰ςႭ; 走𐹧谷.󠗰ςⴍ; [B1, B5, V7]; xn--6g3a1x434z.xn--3xa652s5d17u; ; xn--6g3a1x434z.xn--4xa452s5d17u;  # 走𐹧谷.ςⴍ
+走𐹧谷.\u115F󠗰ςႭ; 走𐹧谷.󠗰ςⴍ; [B1, B5, V7]; xn--6g3a1x434z.xn--3xa652s5d17u; ; xn--6g3a1x434z.xn--4xa452s5d17u;  # 走𐹧谷.ςⴍ
+走𐹧谷.\u115F󠗰ςⴍ; 走𐹧谷.󠗰ςⴍ; [B1, B5, V7]; xn--6g3a1x434z.xn--3xa652s5d17u; ; xn--6g3a1x434z.xn--4xa452s5d17u;  # 走𐹧谷.ςⴍ
+走𐹧谷.\u115F󠗰ΣႭ; 走𐹧谷.󠗰σⴍ; [B1, B5, V7]; xn--6g3a1x434z.xn--4xa452s5d17u; ; ;  # 走𐹧谷.σⴍ
+走𐹧谷.\u115F󠗰σⴍ; 走𐹧谷.󠗰σⴍ; [B1, B5, V7]; xn--6g3a1x434z.xn--4xa452s5d17u; ; ;  # 走𐹧谷.σⴍ
+走𐹧谷.\u115F󠗰Σⴍ; 走𐹧谷.󠗰σⴍ; [B1, B5, V7]; xn--6g3a1x434z.xn--4xa452s5d17u; ; ;  # 走𐹧谷.σⴍ
+xn--6g3a1x434z.xn--4xa452s5d17u; 走𐹧谷.󠗰σⴍ; [B1, B5, V7]; xn--6g3a1x434z.xn--4xa452s5d17u; ; ;  # 走𐹧谷.σⴍ
+xn--6g3a1x434z.xn--3xa652s5d17u; 走𐹧谷.󠗰ςⴍ; [B1, B5, V7]; xn--6g3a1x434z.xn--3xa652s5d17u; ; ;  # 走𐹧谷.ςⴍ
+⾛𐹧⾕.\u115F󠗰ςⴍ; 走𐹧谷.󠗰ςⴍ; [B1, B5, V7]; xn--6g3a1x434z.xn--3xa652s5d17u; ; xn--6g3a1x434z.xn--4xa452s5d17u;  # 走𐹧谷.ςⴍ
+⾛𐹧⾕.\u115F󠗰ΣႭ; 走𐹧谷.󠗰σⴍ; [B1, B5, V7]; xn--6g3a1x434z.xn--4xa452s5d17u; ; ;  # 走𐹧谷.σⴍ
+⾛𐹧⾕.\u115F󠗰σⴍ; 走𐹧谷.󠗰σⴍ; [B1, B5, V7]; xn--6g3a1x434z.xn--4xa452s5d17u; ; ;  # 走𐹧谷.σⴍ
+⾛𐹧⾕.\u115F󠗰Σⴍ; 走𐹧谷.󠗰σⴍ; [B1, B5, V7]; xn--6g3a1x434z.xn--4xa452s5d17u; ; ;  # 走𐹧谷.σⴍ
+xn--6g3a1x434z.xn--4xa180eotvh7453a; 走𐹧谷.\u115F󠗰σⴍ; [B5, V7]; xn--6g3a1x434z.xn--4xa180eotvh7453a; ; ;  # 走𐹧谷.σⴍ
+xn--6g3a1x434z.xn--4xa627dhpae6345i; 走𐹧谷.\u115F󠗰σႭ; [B5, V7]; xn--6g3a1x434z.xn--4xa627dhpae6345i; ; ;  # 走𐹧谷.σႭ
+xn--6g3a1x434z.xn--3xa380eotvh7453a; 走𐹧谷.\u115F󠗰ςⴍ; [B5, V7]; xn--6g3a1x434z.xn--3xa380eotvh7453a; ; ;  # 走𐹧谷.ςⴍ
+xn--6g3a1x434z.xn--3xa827dhpae6345i; 走𐹧谷.\u115F󠗰ςႭ; [B5, V7]; xn--6g3a1x434z.xn--3xa827dhpae6345i; ; ;  # 走𐹧谷.ςႭ
+\u200D≠ᢙ≯.솣-ᡴႠ; \u200D≠ᢙ≯.솣-ᡴⴀ; [C2]; xn--jbf929a90b0b.xn----p9j493ivi4l; ; xn--jbf911clb.xn----p9j493ivi4l; [] # ≠ᢙ≯.솣-ᡴⴀ
+\u200D=\u0338ᢙ>\u0338.솣-ᡴႠ; \u200D≠ᢙ≯.솣-ᡴⴀ; [C2]; xn--jbf929a90b0b.xn----p9j493ivi4l; ; xn--jbf911clb.xn----p9j493ivi4l; [] # ≠ᢙ≯.솣-ᡴⴀ
+\u200D=\u0338ᢙ>\u0338.솣-ᡴⴀ; \u200D≠ᢙ≯.솣-ᡴⴀ; [C2]; xn--jbf929a90b0b.xn----p9j493ivi4l; ; xn--jbf911clb.xn----p9j493ivi4l; [] # ≠ᢙ≯.솣-ᡴⴀ
+\u200D≠ᢙ≯.솣-ᡴⴀ; ; [C2]; xn--jbf929a90b0b.xn----p9j493ivi4l; ; xn--jbf911clb.xn----p9j493ivi4l; [] # ≠ᢙ≯.솣-ᡴⴀ
+xn--jbf911clb.xn----p9j493ivi4l; ≠ᢙ≯.솣-ᡴⴀ; ; xn--jbf911clb.xn----p9j493ivi4l; ; ;  # ≠ᢙ≯.솣-ᡴⴀ
+≠ᢙ≯.솣-ᡴⴀ; ; ; xn--jbf911clb.xn----p9j493ivi4l; ; ;  # ≠ᢙ≯.솣-ᡴⴀ
+=\u0338ᢙ>\u0338.솣-ᡴⴀ; ≠ᢙ≯.솣-ᡴⴀ; ; xn--jbf911clb.xn----p9j493ivi4l; ; ;  # ≠ᢙ≯.솣-ᡴⴀ
+=\u0338ᢙ>\u0338.솣-ᡴႠ; ≠ᢙ≯.솣-ᡴⴀ; ; xn--jbf911clb.xn----p9j493ivi4l; ; ;  # ≠ᢙ≯.솣-ᡴⴀ
+≠ᢙ≯.솣-ᡴႠ; ≠ᢙ≯.솣-ᡴⴀ; ; xn--jbf911clb.xn----p9j493ivi4l; ; ;  # ≠ᢙ≯.솣-ᡴⴀ
+xn--jbf929a90b0b.xn----p9j493ivi4l; \u200D≠ᢙ≯.솣-ᡴⴀ; [C2]; xn--jbf929a90b0b.xn----p9j493ivi4l; ; ;  # ≠ᢙ≯.솣-ᡴⴀ
+xn--jbf911clb.xn----6zg521d196p; ≠ᢙ≯.솣-ᡴႠ; [V7]; xn--jbf911clb.xn----6zg521d196p; ; ;  # ≠ᢙ≯.솣-ᡴႠ
+xn--jbf929a90b0b.xn----6zg521d196p; \u200D≠ᢙ≯.솣-ᡴႠ; [C2, V7]; xn--jbf929a90b0b.xn----6zg521d196p; ; ;  # ≠ᢙ≯.솣-ᡴႠ
+񯞜．𐿇\u0FA2\u077D\u0600; 񯞜.𐿇\u0FA1\u0FB7\u077D\u0600; [V7]; xn--gw68a.xn--ifb57ev2psc6027m; ; ;  # .𐿇ྡྷݽ
+񯞜．𐿇\u0FA1\u0FB7\u077D\u0600; 񯞜.𐿇\u0FA1\u0FB7\u077D\u0600; [V7]; xn--gw68a.xn--ifb57ev2psc6027m; ; ;  # .𐿇ྡྷݽ
+񯞜.𐿇\u0FA1\u0FB7\u077D\u0600; ; [V7]; xn--gw68a.xn--ifb57ev2psc6027m; ; ;  # .𐿇ྡྷݽ
+xn--gw68a.xn--ifb57ev2psc6027m; 񯞜.𐿇\u0FA1\u0FB7\u077D\u0600; [V7]; xn--gw68a.xn--ifb57ev2psc6027m; ; ;  # .𐿇ྡྷݽ
+𣳔\u0303.𑓂; ; [V6]; xn--nsa95820a.xn--wz1d; ; ;  # 𣳔̃.𑓂
+xn--nsa95820a.xn--wz1d; 𣳔\u0303.𑓂; [V6]; xn--nsa95820a.xn--wz1d; ; ;  # 𣳔̃.𑓂
+𞤀𞥅񘐱。󠄌Ⴣꡥ; 𞤢𞥅񘐱.ⴣꡥ; [B2, B3, V7]; xn--9d6hgcy3556a.xn--rlju750b; ; ;  # 𞤢𞥅.ⴣꡥ
+𞤢𞥅񘐱。󠄌ⴣꡥ; 𞤢𞥅񘐱.ⴣꡥ; [B2, B3, V7]; xn--9d6hgcy3556a.xn--rlju750b; ; ;  # 𞤢𞥅.ⴣꡥ
+xn--9d6hgcy3556a.xn--rlju750b; 𞤢𞥅񘐱.ⴣꡥ; [B2, B3, V7]; xn--9d6hgcy3556a.xn--rlju750b; ; ;  # 𞤢𞥅.ⴣꡥ
+xn--9d6hgcy3556a.xn--7nd0578e; 𞤢𞥅񘐱.Ⴣꡥ; [B2, B3, V7]; xn--9d6hgcy3556a.xn--7nd0578e; ; ;  # 𞤢𞥅.Ⴣꡥ
+𞤀𞥅񘐱。󠄌ⴣꡥ; 𞤢𞥅񘐱.ⴣꡥ; [B2, B3, V7]; xn--9d6hgcy3556a.xn--rlju750b; ; ;  # 𞤢𞥅.ⴣꡥ
+\u08E2𑁿ς𖬱。󠅡렧; \u08E2𑁿ς𖬱.렧; [B1, V7]; xn--3xa73xp48ys2xc.xn--kn2b; ; xn--4xa53xp48ys2xc.xn--kn2b;  # 𑁿ς𖬱.렧
+\u08E2𑁿ς𖬱。󠅡렧; \u08E2𑁿ς𖬱.렧; [B1, V7]; xn--3xa73xp48ys2xc.xn--kn2b; ; xn--4xa53xp48ys2xc.xn--kn2b;  # 𑁿ς𖬱.렧
+\u08E2𑁿Σ𖬱。󠅡렧; \u08E2𑁿σ𖬱.렧; [B1, V7]; xn--4xa53xp48ys2xc.xn--kn2b; ; ;  # 𑁿σ𖬱.렧
+\u08E2𑁿Σ𖬱。󠅡렧; \u08E2𑁿σ𖬱.렧; [B1, V7]; xn--4xa53xp48ys2xc.xn--kn2b; ; ;  # 𑁿σ𖬱.렧
+\u08E2𑁿σ𖬱。󠅡렧; \u08E2𑁿σ𖬱.렧; [B1, V7]; xn--4xa53xp48ys2xc.xn--kn2b; ; ;  # 𑁿σ𖬱.렧
+\u08E2𑁿σ𖬱。󠅡렧; \u08E2𑁿σ𖬱.렧; [B1, V7]; xn--4xa53xp48ys2xc.xn--kn2b; ; ;  # 𑁿σ𖬱.렧
+xn--4xa53xp48ys2xc.xn--kn2b; \u08E2𑁿σ𖬱.렧; [B1, V7]; xn--4xa53xp48ys2xc.xn--kn2b; ; ;  # 𑁿σ𖬱.렧
+xn--3xa73xp48ys2xc.xn--kn2b; \u08E2𑁿ς𖬱.렧; [B1, V7]; xn--3xa73xp48ys2xc.xn--kn2b; ; ;  # 𑁿ς𖬱.렧
+-\u200D。𞤍\u200C\u200D⒈; -\u200D.𞤯\u200C\u200D⒈; [B1, C1, C2, V3, V7]; xn----ugn.xn--0ugc555aiv51d; ; -.xn--tsh3666n; [B1, V3, V7] # -.𞤯⒈
+-\u200D。𞤍\u200C\u200D1.; -\u200D.𞤯\u200C\u200D1.; [B1, C1, C2, V3]; xn----ugn.xn--1-rgnd61297b.; [B1, C1, C2, V3, A4_2]; -.xn--1-0i8r.; [B1, V3, A4_2] # -.𞤯1.
+-\u200D。𞤯\u200C\u200D1.; -\u200D.𞤯\u200C\u200D1.; [B1, C1, C2, V3]; xn----ugn.xn--1-rgnd61297b.; [B1, C1, C2, V3, A4_2]; -.xn--1-0i8r.; [B1, V3, A4_2] # -.𞤯1.
+-.xn--1-0i8r.; -.𞤯1.; [B1, V3]; -.xn--1-0i8r.; [B1, V3, A4_2]; ;  # -.𞤯1.
+xn----ugn.xn--1-rgnd61297b.; -\u200D.𞤯\u200C\u200D1.; [B1, C1, C2, V3]; xn----ugn.xn--1-rgnd61297b.; [B1, C1, C2, V3, A4_2]; ;  # -.𞤯1.
+-\u200D。𞤯\u200C\u200D⒈; -\u200D.𞤯\u200C\u200D⒈; [B1, C1, C2, V3, V7]; xn----ugn.xn--0ugc555aiv51d; ; -.xn--tsh3666n; [B1, V3, V7] # -.𞤯⒈
+-.xn--tsh3666n; -.𞤯⒈; [B1, V3, V7]; -.xn--tsh3666n; ; ;  # -.𞤯⒈
+xn----ugn.xn--0ugc555aiv51d; -\u200D.𞤯\u200C\u200D⒈; [B1, C1, C2, V3, V7]; xn----ugn.xn--0ugc555aiv51d; ; ;  # -.𞤯⒈
+\u200C򅎭.Ⴒ𑇀; \u200C򅎭.ⴒ𑇀; [C1, V7]; xn--0ug15083f.xn--9kj2034e; ; xn--bn95b.xn--9kj2034e; [V7] # .ⴒ𑇀
+\u200C򅎭.ⴒ𑇀; ; [C1, V7]; xn--0ug15083f.xn--9kj2034e; ; xn--bn95b.xn--9kj2034e; [V7] # .ⴒ𑇀
+xn--bn95b.xn--9kj2034e; 򅎭.ⴒ𑇀; [V7]; xn--bn95b.xn--9kj2034e; ; ;  # .ⴒ𑇀
+xn--0ug15083f.xn--9kj2034e; \u200C򅎭.ⴒ𑇀; [C1, V7]; xn--0ug15083f.xn--9kj2034e; ; ;  # .ⴒ𑇀
+xn--bn95b.xn--qnd6272k; 򅎭.Ⴒ𑇀; [V7]; xn--bn95b.xn--qnd6272k; ; ;  # .Ⴒ𑇀
+xn--0ug15083f.xn--qnd6272k; \u200C򅎭.Ⴒ𑇀; [C1, V7]; xn--0ug15083f.xn--qnd6272k; ; ;  # .Ⴒ𑇀
+繱𑖿\u200D.８︒; 繱𑖿\u200D.8︒; [V7]; xn--1ug6928ac48e.xn--8-o89h; ; xn--gl0as212a.xn--8-o89h;  # 繱𑖿.8︒
+繱𑖿\u200D.8。; 繱𑖿\u200D.8.; ; xn--1ug6928ac48e.8.; [A4_2]; xn--gl0as212a.8.;  # 繱𑖿.8.
+xn--gl0as212a.i.; 繱𑖿.i.; ; xn--gl0as212a.i.; [A4_2]; ;  # 繱𑖿.i.
+繱𑖿.i.; ; ; xn--gl0as212a.i.; [A4_2]; ;  # 繱𑖿.i.
+繱𑖿.I.; 繱𑖿.i.; ; xn--gl0as212a.i.; [A4_2]; ;  # 繱𑖿.i.
+xn--1ug6928ac48e.i.; 繱𑖿\u200D.i.; ; xn--1ug6928ac48e.i.; [A4_2]; ;  # 繱𑖿.i.
+繱𑖿\u200D.i.; ; ; xn--1ug6928ac48e.i.; [A4_2]; xn--gl0as212a.i.;  # 繱𑖿.i.
+繱𑖿\u200D.I.; 繱𑖿\u200D.i.; ; xn--1ug6928ac48e.i.; [A4_2]; xn--gl0as212a.i.;  # 繱𑖿.i.
+xn--gl0as212a.xn--8-o89h; 繱𑖿.8︒; [V7]; xn--gl0as212a.xn--8-o89h; ; ;  # 繱𑖿.8︒
+xn--1ug6928ac48e.xn--8-o89h; 繱𑖿\u200D.8︒; [V7]; xn--1ug6928ac48e.xn--8-o89h; ; ;  # 繱𑖿.8︒
+󠆾．𞀈; .𞀈; [V6, X4_2]; .xn--ph4h; [V6, A4_2]; ;  # .𞀈
+󠆾.𞀈; .𞀈; [V6, X4_2]; .xn--ph4h; [V6, A4_2]; ;  # .𞀈
+.xn--ph4h; .𞀈; [V6, X4_2]; .xn--ph4h; [V6, A4_2]; ;  # .𞀈
+ß\u06EB。\u200D; ß\u06EB.\u200D; [C2]; xn--zca012a.xn--1ug; ; xn--ss-59d.; [A4_2] # ß۫.
+SS\u06EB。\u200D; ss\u06EB.\u200D; [C2]; xn--ss-59d.xn--1ug; ; xn--ss-59d.; [A4_2] # ss۫.
+ss\u06EB。\u200D; ss\u06EB.\u200D; [C2]; xn--ss-59d.xn--1ug; ; xn--ss-59d.; [A4_2] # ss۫.
+Ss\u06EB。\u200D; ss\u06EB.\u200D; [C2]; xn--ss-59d.xn--1ug; ; xn--ss-59d.; [A4_2] # ss۫.
+xn--ss-59d.; ss\u06EB.; ; xn--ss-59d.; [A4_2]; ;  # ss۫.
+ss\u06EB.; ; ; xn--ss-59d.; [A4_2]; ;  # ss۫.
+SS\u06EB.; ss\u06EB.; ; xn--ss-59d.; [A4_2]; ;  # ss۫.
+Ss\u06EB.; ss\u06EB.; ; xn--ss-59d.; [A4_2]; ;  # ss۫.
+xn--ss-59d.xn--1ug; ss\u06EB.\u200D; [C2]; xn--ss-59d.xn--1ug; ; ;  # ss۫.
+xn--zca012a.xn--1ug; ß\u06EB.\u200D; [C2]; xn--zca012a.xn--1ug; ; ;  # ß۫.
+󠐵\u200C⒈．󠎇; 󠐵\u200C⒈.󠎇; [C1, V7]; xn--0ug88o47900b.xn--tv36e; ; xn--tshz2001k.xn--tv36e; [V7] # ⒈.
+󠐵\u200C1..󠎇; ; [C1, V7, X4_2]; xn--1-rgn37671n..xn--tv36e; [C1, V7, A4_2]; xn--1-bs31m..xn--tv36e; [V7, A4_2] # 1..
+xn--1-bs31m..xn--tv36e; 󠐵1..󠎇; [V7, X4_2]; xn--1-bs31m..xn--tv36e; [V7, A4_2]; ;  # 1..
+xn--1-rgn37671n..xn--tv36e; 󠐵\u200C1..󠎇; [C1, V7, X4_2]; xn--1-rgn37671n..xn--tv36e; [C1, V7, A4_2]; ;  # 1..
+xn--tshz2001k.xn--tv36e; 󠐵⒈.󠎇; [V7]; xn--tshz2001k.xn--tv36e; ; ;  # ⒈.
+xn--0ug88o47900b.xn--tv36e; 󠐵\u200C⒈.󠎇; [C1, V7]; xn--0ug88o47900b.xn--tv36e; ; ;  # ⒈.
+󟈣\u065F\uAAB2ß。󌓧; 󟈣\u065F\uAAB2ß.󌓧; [V7]; xn--zca92z0t7n5w96j.xn--bb79d; ; xn--ss-3xd2839nncy1m.xn--bb79d;  # ٟꪲß.
+󟈣\u065F\uAAB2SS。󌓧; 󟈣\u065F\uAAB2ss.󌓧; [V7]; xn--ss-3xd2839nncy1m.xn--bb79d; ; ;  # ٟꪲss.
+󟈣\u065F\uAAB2ss。󌓧; 󟈣\u065F\uAAB2ss.󌓧; [V7]; xn--ss-3xd2839nncy1m.xn--bb79d; ; ;  # ٟꪲss.
+󟈣\u065F\uAAB2Ss。󌓧; 󟈣\u065F\uAAB2ss.󌓧; [V7]; xn--ss-3xd2839nncy1m.xn--bb79d; ; ;  # ٟꪲss.
+xn--ss-3xd2839nncy1m.xn--bb79d; 󟈣\u065F\uAAB2ss.󌓧; [V7]; xn--ss-3xd2839nncy1m.xn--bb79d; ; ;  # ٟꪲss.
+xn--zca92z0t7n5w96j.xn--bb79d; 󟈣\u065F\uAAB2ß.󌓧; [V7]; xn--zca92z0t7n5w96j.xn--bb79d; ; ;  # ٟꪲß.
+\u0774\u200C𞤿。𽘐䉜\u200D񿤼; \u0774\u200C𞤿.𽘐䉜\u200D񿤼; [C1, C2, V7]; xn--4pb607jjt73a.xn--1ug236ke314donv1a; ; xn--4pb2977v.xn--z0nt555ukbnv; [V7] # ݴ𞤿.䉜
+\u0774\u200C𞤝。𽘐䉜\u200D񿤼; \u0774\u200C𞤿.𽘐䉜\u200D񿤼; [C1, C2, V7]; xn--4pb607jjt73a.xn--1ug236ke314donv1a; ; xn--4pb2977v.xn--z0nt555ukbnv; [V7] # ݴ𞤿.䉜
+xn--4pb2977v.xn--z0nt555ukbnv; \u0774𞤿.𽘐䉜񿤼; [V7]; xn--4pb2977v.xn--z0nt555ukbnv; ; ;  # ݴ𞤿.䉜
+xn--4pb607jjt73a.xn--1ug236ke314donv1a; \u0774\u200C𞤿.𽘐䉜\u200D񿤼; [C1, C2, V7]; xn--4pb607jjt73a.xn--1ug236ke314donv1a; ; ;  # ݴ𞤿.䉜
+򔭜ςᡱ⒈.≮𑄳\u200D𐮍; ; [B1, V7]; xn--3xa407hkzinr77u.xn--1ug85gn777ahze; ; xn--4xa207hkzinr77u.xn--gdh5392g6sd;  # ςᡱ⒈.≮𑄳𐮍
+򔭜ςᡱ⒈.<\u0338𑄳\u200D𐮍; 򔭜ςᡱ⒈.≮𑄳\u200D𐮍; [B1, V7]; xn--3xa407hkzinr77u.xn--1ug85gn777ahze; ; xn--4xa207hkzinr77u.xn--gdh5392g6sd;  # ςᡱ⒈.≮𑄳𐮍
+򔭜ςᡱ1..≮𑄳\u200D𐮍; ; [B1, V7, X4_2]; xn--1-xmb999meq63t..xn--1ug85gn777ahze; [B1, V7, A4_2]; xn--1-zmb699meq63t..xn--gdh5392g6sd;  # ςᡱ1..≮𑄳𐮍
+򔭜ςᡱ1..<\u0338𑄳\u200D𐮍; 򔭜ςᡱ1..≮𑄳\u200D𐮍; [B1, V7, X4_2]; xn--1-xmb999meq63t..xn--1ug85gn777ahze; [B1, V7, A4_2]; xn--1-zmb699meq63t..xn--gdh5392g6sd;  # ςᡱ1..≮𑄳𐮍
+򔭜Σᡱ1..<\u0338𑄳\u200D𐮍; 򔭜σᡱ1..≮𑄳\u200D𐮍; [B1, V7, X4_2]; xn--1-zmb699meq63t..xn--1ug85gn777ahze; [B1, V7, A4_2]; xn--1-zmb699meq63t..xn--gdh5392g6sd;  # σᡱ1..≮𑄳𐮍
+򔭜Σᡱ1..≮𑄳\u200D𐮍; 򔭜σᡱ1..≮𑄳\u200D𐮍; [B1, V7, X4_2]; xn--1-zmb699meq63t..xn--1ug85gn777ahze; [B1, V7, A4_2]; xn--1-zmb699meq63t..xn--gdh5392g6sd;  # σᡱ1..≮𑄳𐮍
+򔭜σᡱ1..≮𑄳\u200D𐮍; ; [B1, V7, X4_2]; xn--1-zmb699meq63t..xn--1ug85gn777ahze; [B1, V7, A4_2]; xn--1-zmb699meq63t..xn--gdh5392g6sd;  # σᡱ1..≮𑄳𐮍
+򔭜σᡱ1..<\u0338𑄳\u200D𐮍; 򔭜σᡱ1..≮𑄳\u200D𐮍; [B1, V7, X4_2]; xn--1-zmb699meq63t..xn--1ug85gn777ahze; [B1, V7, A4_2]; xn--1-zmb699meq63t..xn--gdh5392g6sd;  # σᡱ1..≮𑄳𐮍
+xn--1-zmb699meq63t..xn--gdh5392g6sd; 򔭜σᡱ1..≮𑄳𐮍; [B1, V7, X4_2]; xn--1-zmb699meq63t..xn--gdh5392g6sd; [B1, V7, A4_2]; ;  # σᡱ1..≮𑄳𐮍
+xn--1-zmb699meq63t..xn--1ug85gn777ahze; 򔭜σᡱ1..≮𑄳\u200D𐮍; [B1, V7, X4_2]; xn--1-zmb699meq63t..xn--1ug85gn777ahze; [B1, V7, A4_2]; ;  # σᡱ1..≮𑄳𐮍
+xn--1-xmb999meq63t..xn--1ug85gn777ahze; 򔭜ςᡱ1..≮𑄳\u200D𐮍; [B1, V7, X4_2]; xn--1-xmb999meq63t..xn--1ug85gn777ahze; [B1, V7, A4_2]; ;  # ςᡱ1..≮𑄳𐮍
+򔭜Σᡱ⒈.<\u0338𑄳\u200D𐮍; 򔭜σᡱ⒈.≮𑄳\u200D𐮍; [B1, V7]; xn--4xa207hkzinr77u.xn--1ug85gn777ahze; ; xn--4xa207hkzinr77u.xn--gdh5392g6sd;  # σᡱ⒈.≮𑄳𐮍
+򔭜Σᡱ⒈.≮𑄳\u200D𐮍; 򔭜σᡱ⒈.≮𑄳\u200D𐮍; [B1, V7]; xn--4xa207hkzinr77u.xn--1ug85gn777ahze; ; xn--4xa207hkzinr77u.xn--gdh5392g6sd;  # σᡱ⒈.≮𑄳𐮍
+򔭜σᡱ⒈.≮𑄳\u200D𐮍; ; [B1, V7]; xn--4xa207hkzinr77u.xn--1ug85gn777ahze; ; xn--4xa207hkzinr77u.xn--gdh5392g6sd;  # σᡱ⒈.≮𑄳𐮍
+򔭜σᡱ⒈.<\u0338𑄳\u200D𐮍; 򔭜σᡱ⒈.≮𑄳\u200D𐮍; [B1, V7]; xn--4xa207hkzinr77u.xn--1ug85gn777ahze; ; xn--4xa207hkzinr77u.xn--gdh5392g6sd;  # σᡱ⒈.≮𑄳𐮍
+xn--4xa207hkzinr77u.xn--gdh5392g6sd; 򔭜σᡱ⒈.≮𑄳𐮍; [B1, V7]; xn--4xa207hkzinr77u.xn--gdh5392g6sd; ; ;  # σᡱ⒈.≮𑄳𐮍
+xn--4xa207hkzinr77u.xn--1ug85gn777ahze; 򔭜σᡱ⒈.≮𑄳\u200D𐮍; [B1, V7]; xn--4xa207hkzinr77u.xn--1ug85gn777ahze; ; ;  # σᡱ⒈.≮𑄳𐮍
+xn--3xa407hkzinr77u.xn--1ug85gn777ahze; 򔭜ςᡱ⒈.≮𑄳\u200D𐮍; [B1, V7]; xn--3xa407hkzinr77u.xn--1ug85gn777ahze; ; ;  # ςᡱ⒈.≮𑄳𐮍
+\u3164\u094DႠ\u17D0.\u180B; \u094Dⴀ\u17D0.; [V6]; xn--n3b445e53p.; [V6, A4_2]; ;  # ्ⴀ័.
+\u1160\u094DႠ\u17D0.\u180B; \u094Dⴀ\u17D0.; [V6]; xn--n3b445e53p.; [V6, A4_2]; ;  # ्ⴀ័.
+\u1160\u094Dⴀ\u17D0.\u180B; \u094Dⴀ\u17D0.; [V6]; xn--n3b445e53p.; [V6, A4_2]; ;  # ्ⴀ័.
+xn--n3b445e53p.; \u094Dⴀ\u17D0.; [V6]; xn--n3b445e53p.; [V6, A4_2]; ;  # ्ⴀ័.
+\u3164\u094Dⴀ\u17D0.\u180B; \u094Dⴀ\u17D0.; [V6]; xn--n3b445e53p.; [V6, A4_2]; ;  # ्ⴀ័.
+xn--n3b742bkqf4ty.; \u1160\u094Dⴀ\u17D0.; [V7]; xn--n3b742bkqf4ty.; [V7, A4_2]; ;  # ्ⴀ័.
+xn--n3b468aoqa89r.; \u1160\u094DႠ\u17D0.; [V7]; xn--n3b468aoqa89r.; [V7, A4_2]; ;  # ्Ⴀ័.
+xn--n3b445e53po6d.; \u3164\u094Dⴀ\u17D0.; [V7]; xn--n3b445e53po6d.; [V7, A4_2]; ;  # ्ⴀ័.
+xn--n3b468azngju2a.; \u3164\u094DႠ\u17D0.; [V7]; xn--n3b468azngju2a.; [V7, A4_2]; ;  # ्Ⴀ័.
+❣\u200D．\u09CD𑰽\u0612\uA929; ❣\u200D.\u09CD𑰽\u0612\uA929; [C2, V6]; xn--1ugy10a.xn--0fb32q3w7q2g4d; ; xn--pei.xn--0fb32q3w7q2g4d; [V6] # ❣.্𑰽ؒꤩ
+❣\u200D.\u09CD𑰽\u0612\uA929; ; [C2, V6]; xn--1ugy10a.xn--0fb32q3w7q2g4d; ; xn--pei.xn--0fb32q3w7q2g4d; [V6] # ❣.্𑰽ؒꤩ
+xn--pei.xn--0fb32q3w7q2g4d; ❣.\u09CD𑰽\u0612\uA929; [V6]; xn--pei.xn--0fb32q3w7q2g4d; ; ;  # ❣.্𑰽ؒꤩ
+xn--1ugy10a.xn--0fb32q3w7q2g4d; ❣\u200D.\u09CD𑰽\u0612\uA929; [C2, V6]; xn--1ugy10a.xn--0fb32q3w7q2g4d; ; ;  # ❣.্𑰽ؒꤩ
+≮𐳺𐹄.≯񪮸ꡅ; ; [B1, V7]; xn--gdh7943gk2a.xn--hdh1383c5e36c; ; ;  # ≮𐳺.≯ꡅ
+<\u0338𐳺𐹄.>\u0338񪮸ꡅ; ≮𐳺𐹄.≯񪮸ꡅ; [B1, V7]; xn--gdh7943gk2a.xn--hdh1383c5e36c; ; ;  # ≮𐳺.≯ꡅ
+xn--gdh7943gk2a.xn--hdh1383c5e36c; ≮𐳺𐹄.≯񪮸ꡅ; [B1, V7]; xn--gdh7943gk2a.xn--hdh1383c5e36c; ; ;  # ≮𐳺.≯ꡅ
+\u0CCC𐧅𐳏󠲺｡\u0CCDᠦ; \u0CCC𐧅𐳏󠲺.\u0CCDᠦ; [B1, V6, V7]; xn--7tc6360ky5bn2732c.xn--8tc429c; ; ;  # ೌ𐧅𐳏.್ᠦ
+\u0CCC𐧅𐳏󠲺。\u0CCDᠦ; \u0CCC𐧅𐳏󠲺.\u0CCDᠦ; [B1, V6, V7]; xn--7tc6360ky5bn2732c.xn--8tc429c; ; ;  # ೌ𐧅𐳏.್ᠦ
+\u0CCC𐧅𐲏󠲺。\u0CCDᠦ; \u0CCC𐧅𐳏󠲺.\u0CCDᠦ; [B1, V6, V7]; xn--7tc6360ky5bn2732c.xn--8tc429c; ; ;  # ೌ𐧅𐳏.್ᠦ
+xn--7tc6360ky5bn2732c.xn--8tc429c; \u0CCC𐧅𐳏󠲺.\u0CCDᠦ; [B1, V6, V7]; xn--7tc6360ky5bn2732c.xn--8tc429c; ; ;  # ೌ𐧅𐳏.್ᠦ
+\u0CCC𐧅𐲏󠲺｡\u0CCDᠦ; \u0CCC𐧅𐳏󠲺.\u0CCDᠦ; [B1, V6, V7]; xn--7tc6360ky5bn2732c.xn--8tc429c; ; ;  # ೌ𐧅𐳏.್ᠦ
+\u0349。𧡫; \u0349.𧡫; [V6]; xn--nua.xn--bc6k; ; ;  # ͉.𧡫
+xn--nua.xn--bc6k; \u0349.𧡫; [V6]; xn--nua.xn--bc6k; ; ;  # ͉.𧡫
+𑰿󠅦．\u1160; 𑰿.; [V6]; xn--ok3d.; [V6, A4_2]; ;  # 𑰿.
+𑰿󠅦.\u1160; 𑰿.; [V6]; xn--ok3d.; [V6, A4_2]; ;  # 𑰿.
+xn--ok3d.; 𑰿.; [V6]; xn--ok3d.; [V6, A4_2]; ;  # 𑰿.
+xn--ok3d.xn--psd; 𑰿.\u1160; [V6, V7]; xn--ok3d.xn--psd; ; ;  # 𑰿.
+-𞤆\u200D。󸼄𞳒; -𞤨\u200D.󸼄𞳒; [B1, B5, B6, C2, V3, V7]; xn----ugnx367r.xn--846h96596c; ; xn----ni8r.xn--846h96596c; [B1, B5, B6, V3, V7] # -𞤨.
+-𞤨\u200D。󸼄𞳒; -𞤨\u200D.󸼄𞳒; [B1, B5, B6, C2, V3, V7]; xn----ugnx367r.xn--846h96596c; ; xn----ni8r.xn--846h96596c; [B1, B5, B6, V3, V7] # -𞤨.
+xn----ni8r.xn--846h96596c; -𞤨.󸼄𞳒; [B1, B5, B6, V3, V7]; xn----ni8r.xn--846h96596c; ; ;  # -𞤨.
+xn----ugnx367r.xn--846h96596c; -𞤨\u200D.󸼄𞳒; [B1, B5, B6, C2, V3, V7]; xn----ugnx367r.xn--846h96596c; ; ;  # -𞤨.
+ꡏ󠇶≯𳾽。\u1DFD⾇滸𐹰; ꡏ󠇶≯𳾽.\u1DFD舛滸𐹰; [B1, V6, V7]; xn--hdh7483cu6twwki8e.xn--yfg0765a58l0n6k; ; ;  # ꡏ≯.᷽舛滸𐹰
+ꡏ󠇶>\u0338𳾽。\u1DFD⾇滸𐹰; ꡏ󠇶≯𳾽.\u1DFD舛滸𐹰; [B1, V6, V7]; xn--hdh7483cu6twwki8e.xn--yfg0765a58l0n6k; ; ;  # ꡏ≯.᷽舛滸𐹰
+ꡏ󠇶≯𳾽。\u1DFD舛滸𐹰; ꡏ󠇶≯𳾽.\u1DFD舛滸𐹰; [B1, V6, V7]; xn--hdh7483cu6twwki8e.xn--yfg0765a58l0n6k; ; ;  # ꡏ≯.᷽舛滸𐹰
+ꡏ󠇶>\u0338𳾽。\u1DFD舛滸𐹰; ꡏ󠇶≯𳾽.\u1DFD舛滸𐹰; [B1, V6, V7]; xn--hdh7483cu6twwki8e.xn--yfg0765a58l0n6k; ; ;  # ꡏ≯.᷽舛滸𐹰
+xn--hdh7483cu6twwki8e.xn--yfg0765a58l0n6k; ꡏ󠇶≯𳾽.\u1DFD舛滸𐹰; [B1, V6, V7]; xn--hdh7483cu6twwki8e.xn--yfg0765a58l0n6k; ; ;  # ꡏ≯.᷽舛滸𐹰
+蔏｡𑰺; 蔏.𑰺; [V6]; xn--uy1a.xn--jk3d; ; ;  # 蔏.𑰺
+蔏。𑰺; 蔏.𑰺; [V6]; xn--uy1a.xn--jk3d; ; ;  # 蔏.𑰺
+xn--uy1a.xn--jk3d; 蔏.𑰺; [V6]; xn--uy1a.xn--jk3d; ; ;  # 蔏.𑰺
+𝟿𐮋。󠄊; 9𐮋.; [B1]; xn--9-rv5i.; [B1, A4_2]; ;  # 9𐮋.
+9𐮋。󠄊; 9𐮋.; [B1]; xn--9-rv5i.; [B1, A4_2]; ;  # 9𐮋.
+xn--9-rv5i.; 9𐮋.; [B1]; xn--9-rv5i.; [B1, A4_2]; ;  # 9𐮋.
+󟇇-䟖F。\u07CB⒈\u0662; 󟇇-䟖f.\u07CB⒈\u0662; [B4, V7]; xn---f-mz8b08788k.xn--bib53ev44d; ; ;  # -䟖f.ߋ⒈٢
+󟇇-䟖F。\u07CB1.\u0662; 󟇇-䟖f.\u07CB1.\u0662; [B1, V7]; xn---f-mz8b08788k.xn--1-ybd.xn--bib; ; ;  # -䟖f.ߋ1.٢
+󟇇-䟖f。\u07CB1.\u0662; 󟇇-䟖f.\u07CB1.\u0662; [B1, V7]; xn---f-mz8b08788k.xn--1-ybd.xn--bib; ; ;  # -䟖f.ߋ1.٢
+xn---f-mz8b08788k.xn--1-ybd.xn--bib; 󟇇-䟖f.\u07CB1.\u0662; [B1, V7]; xn---f-mz8b08788k.xn--1-ybd.xn--bib; ; ;  # -䟖f.ߋ1.٢
+󟇇-䟖f。\u07CB⒈\u0662; 󟇇-䟖f.\u07CB⒈\u0662; [B4, V7]; xn---f-mz8b08788k.xn--bib53ev44d; ; ;  # -䟖f.ߋ⒈٢
+xn---f-mz8b08788k.xn--bib53ev44d; 󟇇-䟖f.\u07CB⒈\u0662; [B4, V7]; xn---f-mz8b08788k.xn--bib53ev44d; ; ;  # -䟖f.ߋ⒈٢
+\u200C｡𐹺; \u200C.𐹺; [B1, C1]; xn--0ug.xn--yo0d; ; .xn--yo0d; [B1, A4_2] # .𐹺
+\u200C。𐹺; \u200C.𐹺; [B1, C1]; xn--0ug.xn--yo0d; ; .xn--yo0d; [B1, A4_2] # .𐹺
+.xn--yo0d; .𐹺; [B1, X4_2]; .xn--yo0d; [B1, A4_2]; ;  # .𐹺
+xn--0ug.xn--yo0d; \u200C.𐹺; [B1, C1]; xn--0ug.xn--yo0d; ; ;  # .𐹺
+𐡆.≯\u200C-𞥀; ; [B1, C1]; xn--le9c.xn----rgn40iy359e; ; xn--le9c.xn----ogo9956r; [B1] # 𐡆.≯-𞥀
+𐡆.>\u0338\u200C-𞥀; 𐡆.≯\u200C-𞥀; [B1, C1]; xn--le9c.xn----rgn40iy359e; ; xn--le9c.xn----ogo9956r; [B1] # 𐡆.≯-𞥀
+𐡆.>\u0338\u200C-𞤞; 𐡆.≯\u200C-𞥀; [B1, C1]; xn--le9c.xn----rgn40iy359e; ; xn--le9c.xn----ogo9956r; [B1] # 𐡆.≯-𞥀
+𐡆.≯\u200C-𞤞; 𐡆.≯\u200C-𞥀; [B1, C1]; xn--le9c.xn----rgn40iy359e; ; xn--le9c.xn----ogo9956r; [B1] # 𐡆.≯-𞥀
+xn--le9c.xn----ogo9956r; 𐡆.≯-𞥀; [B1]; xn--le9c.xn----ogo9956r; ; ;  # 𐡆.≯-𞥀
+xn--le9c.xn----rgn40iy359e; 𐡆.≯\u200C-𞥀; [B1, C1]; xn--le9c.xn----rgn40iy359e; ; ;  # 𐡆.≯-𞥀
+󠁀-。≠\uFCD7; 󠁀-.≠\u0647\u062C; [B1, V3, V7]; xn----f411m.xn--rgb7c611j; ; ;  # -.≠هج
+󠁀-。=\u0338\uFCD7; 󠁀-.≠\u0647\u062C; [B1, V3, V7]; xn----f411m.xn--rgb7c611j; ; ;  # -.≠هج
+󠁀-。≠\u0647\u062C; 󠁀-.≠\u0647\u062C; [B1, V3, V7]; xn----f411m.xn--rgb7c611j; ; ;  # -.≠هج
+󠁀-。=\u0338\u0647\u062C; 󠁀-.≠\u0647\u062C; [B1, V3, V7]; xn----f411m.xn--rgb7c611j; ; ;  # -.≠هج
+xn----f411m.xn--rgb7c611j; 󠁀-.≠\u0647\u062C; [B1, V3, V7]; xn----f411m.xn--rgb7c611j; ; ;  # -.≠هج
+񻬹𑈵。\u200D𞨶; 񻬹𑈵.\u200D𞨶; [B1, C2, V7]; xn--8g1d12120a.xn--1ug6651p; ; xn--8g1d12120a.xn--5l6h; [V7] # 𑈵.
+xn--8g1d12120a.xn--5l6h; 񻬹𑈵.𞨶; [V7]; xn--8g1d12120a.xn--5l6h; ; ;  # 𑈵.
+xn--8g1d12120a.xn--1ug6651p; 񻬹𑈵.\u200D𞨶; [B1, C2, V7]; xn--8g1d12120a.xn--1ug6651p; ; ;  # 𑈵.
+𑋧\uA9C02｡㧉򒖄; 𑋧\uA9C02.㧉򒖄; [V6, V7]; xn--2-5z4eu89y.xn--97l02706d; ; ;  # 𑋧꧀2.㧉
+𑋧\uA9C02。㧉򒖄; 𑋧\uA9C02.㧉򒖄; [V6, V7]; xn--2-5z4eu89y.xn--97l02706d; ; ;  # 𑋧꧀2.㧉
+xn--2-5z4eu89y.xn--97l02706d; 𑋧\uA9C02.㧉򒖄; [V6, V7]; xn--2-5z4eu89y.xn--97l02706d; ; ;  # 𑋧꧀2.㧉
+\u200C𽬄𐹴𞩥。≯6; \u200C𽬄𐹴𞩥.≯6; [B1, C1, V7]; xn--0ug7105gf5wfxepq.xn--6-ogo; ; xn--so0du768aim9m.xn--6-ogo; [B1, B5, B6, V7] # 𐹴.≯6
+\u200C𽬄𐹴𞩥。>\u03386; \u200C𽬄𐹴𞩥.≯6; [B1, C1, V7]; xn--0ug7105gf5wfxepq.xn--6-ogo; ; xn--so0du768aim9m.xn--6-ogo; [B1, B5, B6, V7] # 𐹴.≯6
+xn--so0du768aim9m.xn--6-ogo; 𽬄𐹴𞩥.≯6; [B1, B5, B6, V7]; xn--so0du768aim9m.xn--6-ogo; ; ;  # 𐹴.≯6
+xn--0ug7105gf5wfxepq.xn--6-ogo; \u200C𽬄𐹴𞩥.≯6; [B1, C1, V7]; xn--0ug7105gf5wfxepq.xn--6-ogo; ; ;  # 𐹴.≯6
+𑁿．𐹦𻞵-\u200D; 𑁿.𐹦𻞵-\u200D; [B1, C2, V6, V7]; xn--q30d.xn----ugn1088hfsxv; ; xn--q30d.xn----i26i1299n; [B1, V3, V6, V7] # 𑁿.𐹦-
+𑁿.𐹦𻞵-\u200D; ; [B1, C2, V6, V7]; xn--q30d.xn----ugn1088hfsxv; ; xn--q30d.xn----i26i1299n; [B1, V3, V6, V7] # 𑁿.𐹦-
+xn--q30d.xn----i26i1299n; 𑁿.𐹦𻞵-; [B1, V3, V6, V7]; xn--q30d.xn----i26i1299n; ; ;  # 𑁿.𐹦-
+xn--q30d.xn----ugn1088hfsxv; 𑁿.𐹦𻞵-\u200D; [B1, C2, V6, V7]; xn--q30d.xn----ugn1088hfsxv; ; ;  # 𑁿.𐹦-
+⤸ς𺱀｡\uFFA0; ⤸ς𺱀.; [V7]; xn--3xa392qmp03d.; [V7, A4_2]; xn--4xa192qmp03d.;  # ⤸ς.
+⤸ς𺱀。\u1160; ⤸ς𺱀.; [V7]; xn--3xa392qmp03d.; [V7, A4_2]; xn--4xa192qmp03d.;  # ⤸ς.
+⤸Σ𺱀。\u1160; ⤸σ𺱀.; [V7]; xn--4xa192qmp03d.; [V7, A4_2]; ;  # ⤸σ.
+⤸σ𺱀。\u1160; ⤸σ𺱀.; [V7]; xn--4xa192qmp03d.; [V7, A4_2]; ;  # ⤸σ.
+xn--4xa192qmp03d.; ⤸σ𺱀.; [V7]; xn--4xa192qmp03d.; [V7, A4_2]; ;  # ⤸σ.
+xn--3xa392qmp03d.; ⤸ς𺱀.; [V7]; xn--3xa392qmp03d.; [V7, A4_2]; ;  # ⤸ς.
+⤸Σ𺱀｡\uFFA0; ⤸σ𺱀.; [V7]; xn--4xa192qmp03d.; [V7, A4_2]; ;  # ⤸σ.
+⤸σ𺱀｡\uFFA0; ⤸σ𺱀.; [V7]; xn--4xa192qmp03d.; [V7, A4_2]; ;  # ⤸σ.
+xn--4xa192qmp03d.xn--psd; ⤸σ𺱀.\u1160; [V7]; xn--4xa192qmp03d.xn--psd; ; ;  # ⤸σ.
+xn--3xa392qmp03d.xn--psd; ⤸ς𺱀.\u1160; [V7]; xn--3xa392qmp03d.xn--psd; ; ;  # ⤸ς.
+xn--4xa192qmp03d.xn--cl7c; ⤸σ𺱀.\uFFA0; [V7]; xn--4xa192qmp03d.xn--cl7c; ; ;  # ⤸σ.
+xn--3xa392qmp03d.xn--cl7c; ⤸ς𺱀.\uFFA0; [V7]; xn--3xa392qmp03d.xn--cl7c; ; ;  # ⤸ς.
+\u0765\u1035𐫔\u06D5.𐦬𑋪Ⴃ; \u0765\u1035𐫔\u06D5.𐦬𑋪ⴃ; [B2, B3]; xn--llb10as9tqp5y.xn--ukj7371e21f; ; ;  # ݥဵ𐫔ە.𐦬𑋪ⴃ
+\u0765\u1035𐫔\u06D5.𐦬𑋪ⴃ; ; [B2, B3]; xn--llb10as9tqp5y.xn--ukj7371e21f; ; ;  # ݥဵ𐫔ە.𐦬𑋪ⴃ
+xn--llb10as9tqp5y.xn--ukj7371e21f; \u0765\u1035𐫔\u06D5.𐦬𑋪ⴃ; [B2, B3]; xn--llb10as9tqp5y.xn--ukj7371e21f; ; ;  # ݥဵ𐫔ە.𐦬𑋪ⴃ
+xn--llb10as9tqp5y.xn--bnd9168j21f; \u0765\u1035𐫔\u06D5.𐦬𑋪Ⴃ; [B2, B3, V7]; xn--llb10as9tqp5y.xn--bnd9168j21f; ; ;  # ݥဵ𐫔ە.𐦬𑋪Ⴃ
+\u0661\u1B44-킼.\u1BAA\u0616\u066C≯; ; [B1, B5, B6, V6]; xn----9pc551nk39n.xn--4fb6o571degg; ; ;  # ١᭄-킼.᮪ؖ٬≯
+\u0661\u1B44-킼.\u1BAA\u0616\u066C>\u0338; \u0661\u1B44-킼.\u1BAA\u0616\u066C≯; [B1, B5, B6, V6]; xn----9pc551nk39n.xn--4fb6o571degg; ; ;  # ١᭄-킼.᮪ؖ٬≯
+xn----9pc551nk39n.xn--4fb6o571degg; \u0661\u1B44-킼.\u1BAA\u0616\u066C≯; [B1, B5, B6, V6]; xn----9pc551nk39n.xn--4fb6o571degg; ; ;  # ١᭄-킼.᮪ؖ٬≯
+-。\u06C2\u0604򅖡𑓂; -.\u06C2\u0604򅖡𑓂; [B1, B2, B3, V3, V7]; -.xn--mfb39a7208dzgs3d; ; ;  # -.ۂ𑓂
+-。\u06C1\u0654\u0604򅖡𑓂; -.\u06C2\u0604򅖡𑓂; [B1, B2, B3, V3, V7]; -.xn--mfb39a7208dzgs3d; ; ;  # -.ۂ𑓂
+-.xn--mfb39a7208dzgs3d; -.\u06C2\u0604򅖡𑓂; [B1, B2, B3, V3, V7]; -.xn--mfb39a7208dzgs3d; ; ;  # -.ۂ𑓂
+\u200D󯑖󠁐．\u05BD𙮰ꡝ𐋡; \u200D󯑖󠁐.\u05BD𙮰ꡝ𐋡; [C2, V6, V7]; xn--1ug66101lt8me.xn--ldb8734fg0qcyzzg; ; xn--b726ey18m.xn--ldb8734fg0qcyzzg; [V6, V7] # .ֽꡝ𐋡
+\u200D󯑖󠁐.\u05BD𙮰ꡝ𐋡; ; [C2, V6, V7]; xn--1ug66101lt8me.xn--ldb8734fg0qcyzzg; ; xn--b726ey18m.xn--ldb8734fg0qcyzzg; [V6, V7] # .ֽꡝ𐋡
+xn--b726ey18m.xn--ldb8734fg0qcyzzg; 󯑖󠁐.\u05BD𙮰ꡝ𐋡; [V6, V7]; xn--b726ey18m.xn--ldb8734fg0qcyzzg; ; ;  # .ֽꡝ𐋡
+xn--1ug66101lt8me.xn--ldb8734fg0qcyzzg; \u200D󯑖󠁐.\u05BD𙮰ꡝ𐋡; [C2, V6, V7]; xn--1ug66101lt8me.xn--ldb8734fg0qcyzzg; ; ;  # .ֽꡝ𐋡
+︒􃈵ς񀠇｡𐮈; ︒􃈵ς񀠇.𐮈; [B1, V7]; xn--3xa3729jwz5t7gl5f.xn--f29c; ; xn--4xa1729jwz5t7gl5f.xn--f29c;  # ︒ς.𐮈
+。􃈵ς񀠇。𐮈; .􃈵ς񀠇.𐮈; [V7, X4_2]; .xn--3xa88573c7n64d.xn--f29c; [V7, A4_2]; .xn--4xa68573c7n64d.xn--f29c;  # .ς.𐮈
+。􃈵Σ񀠇。𐮈; .􃈵σ񀠇.𐮈; [V7, X4_2]; .xn--4xa68573c7n64d.xn--f29c; [V7, A4_2]; ;  # .σ.𐮈
+。􃈵σ񀠇。𐮈; .􃈵σ񀠇.𐮈; [V7, X4_2]; .xn--4xa68573c7n64d.xn--f29c; [V7, A4_2]; ;  # .σ.𐮈
+.xn--4xa68573c7n64d.xn--f29c; .􃈵σ񀠇.𐮈; [V7, X4_2]; .xn--4xa68573c7n64d.xn--f29c; [V7, A4_2]; ;  # .σ.𐮈
+.xn--3xa88573c7n64d.xn--f29c; .􃈵ς񀠇.𐮈; [V7, X4_2]; .xn--3xa88573c7n64d.xn--f29c; [V7, A4_2]; ;  # .ς.𐮈
+︒􃈵Σ񀠇｡𐮈; ︒􃈵σ񀠇.𐮈; [B1, V7]; xn--4xa1729jwz5t7gl5f.xn--f29c; ; ;  # ︒σ.𐮈
+︒􃈵σ񀠇｡𐮈; ︒􃈵σ񀠇.𐮈; [B1, V7]; xn--4xa1729jwz5t7gl5f.xn--f29c; ; ;  # ︒σ.𐮈
+xn--4xa1729jwz5t7gl5f.xn--f29c; ︒􃈵σ񀠇.𐮈; [B1, V7]; xn--4xa1729jwz5t7gl5f.xn--f29c; ; ;  # ︒σ.𐮈
+xn--3xa3729jwz5t7gl5f.xn--f29c; ︒􃈵ς񀠇.𐮈; [B1, V7]; xn--3xa3729jwz5t7gl5f.xn--f29c; ; ;  # ︒ς.𐮈
+\u07D9．\u06EE󆾃≯󠅲; \u07D9.\u06EE󆾃≯; [B2, B3, V7]; xn--0sb.xn--bmb691l0524t; ; ;  # ߙ.ۮ≯
+\u07D9．\u06EE󆾃>\u0338󠅲; \u07D9.\u06EE󆾃≯; [B2, B3, V7]; xn--0sb.xn--bmb691l0524t; ; ;  # ߙ.ۮ≯
+\u07D9.\u06EE󆾃≯󠅲; \u07D9.\u06EE󆾃≯; [B2, B3, V7]; xn--0sb.xn--bmb691l0524t; ; ;  # ߙ.ۮ≯
+\u07D9.\u06EE󆾃>\u0338󠅲; \u07D9.\u06EE󆾃≯; [B2, B3, V7]; xn--0sb.xn--bmb691l0524t; ; ;  # ߙ.ۮ≯
+xn--0sb.xn--bmb691l0524t; \u07D9.\u06EE󆾃≯; [B2, B3, V7]; xn--0sb.xn--bmb691l0524t; ; ;  # ߙ.ۮ≯
+\u1A73󚙸.𐭍; ; [B1, V6, V7]; xn--2of22352n.xn--q09c; ; ;  # ᩳ.𐭍
+xn--2of22352n.xn--q09c; \u1A73󚙸.𐭍; [B1, V6, V7]; xn--2of22352n.xn--q09c; ; ;  # ᩳ.𐭍
+⒉󠊓≠｡Ⴟ⬣Ⴈ; ⒉󠊓≠.ⴟ⬣ⴈ; [V7]; xn--1ch07f91401d.xn--45iz7d6b; ; ;  # ⒉≠.ⴟ⬣ⴈ
+⒉󠊓=\u0338｡Ⴟ⬣Ⴈ; ⒉󠊓≠.ⴟ⬣ⴈ; [V7]; xn--1ch07f91401d.xn--45iz7d6b; ; ;  # ⒉≠.ⴟ⬣ⴈ
+2.󠊓≠。Ⴟ⬣Ⴈ; 2.󠊓≠.ⴟ⬣ⴈ; [V7]; 2.xn--1chz4101l.xn--45iz7d6b; ; ;  # 2.≠.ⴟ⬣ⴈ
+2.󠊓=\u0338。Ⴟ⬣Ⴈ; 2.󠊓≠.ⴟ⬣ⴈ; [V7]; 2.xn--1chz4101l.xn--45iz7d6b; ; ;  # 2.≠.ⴟ⬣ⴈ
+2.󠊓=\u0338。ⴟ⬣ⴈ; 2.󠊓≠.ⴟ⬣ⴈ; [V7]; 2.xn--1chz4101l.xn--45iz7d6b; ; ;  # 2.≠.ⴟ⬣ⴈ
+2.󠊓≠。ⴟ⬣ⴈ; 2.󠊓≠.ⴟ⬣ⴈ; [V7]; 2.xn--1chz4101l.xn--45iz7d6b; ; ;  # 2.≠.ⴟ⬣ⴈ
+2.xn--1chz4101l.xn--45iz7d6b; 2.󠊓≠.ⴟ⬣ⴈ; [V7]; 2.xn--1chz4101l.xn--45iz7d6b; ; ;  # 2.≠.ⴟ⬣ⴈ
+⒉󠊓=\u0338｡ⴟ⬣ⴈ; ⒉󠊓≠.ⴟ⬣ⴈ; [V7]; xn--1ch07f91401d.xn--45iz7d6b; ; ;  # ⒉≠.ⴟ⬣ⴈ
+⒉󠊓≠｡ⴟ⬣ⴈ; ⒉󠊓≠.ⴟ⬣ⴈ; [V7]; xn--1ch07f91401d.xn--45iz7d6b; ; ;  # ⒉≠.ⴟ⬣ⴈ
+xn--1ch07f91401d.xn--45iz7d6b; ⒉󠊓≠.ⴟ⬣ⴈ; [V7]; xn--1ch07f91401d.xn--45iz7d6b; ; ;  # ⒉≠.ⴟ⬣ⴈ
+2.xn--1chz4101l.xn--gnd9b297j; 2.󠊓≠.Ⴟ⬣Ⴈ; [V7]; 2.xn--1chz4101l.xn--gnd9b297j; ; ;  # 2.≠.Ⴟ⬣Ⴈ
+xn--1ch07f91401d.xn--gnd9b297j; ⒉󠊓≠.Ⴟ⬣Ⴈ; [V7]; xn--1ch07f91401d.xn--gnd9b297j; ; ;  # ⒉≠.Ⴟ⬣Ⴈ
+-󠉱\u0FB8Ⴥ。-𐹽\u0774𞣑; -󠉱\u0FB8ⴥ.-𐹽\u0774𞣑; [B1, V3, V7]; xn----xmg317tgv352a.xn----05c4213ryr0g; ; ;  # -ྸⴥ.-𐹽ݴ𞣑
+-󠉱\u0FB8ⴥ。-𐹽\u0774𞣑; -󠉱\u0FB8ⴥ.-𐹽\u0774𞣑; [B1, V3, V7]; xn----xmg317tgv352a.xn----05c4213ryr0g; ; ;  # -ྸⴥ.-𐹽ݴ𞣑
+xn----xmg317tgv352a.xn----05c4213ryr0g; -󠉱\u0FB8ⴥ.-𐹽\u0774𞣑; [B1, V3, V7]; xn----xmg317tgv352a.xn----05c4213ryr0g; ; ;  # -ྸⴥ.-𐹽ݴ𞣑
+xn----xmg12fm2555h.xn----05c4213ryr0g; -󠉱\u0FB8Ⴥ.-𐹽\u0774𞣑; [B1, V3, V7]; xn----xmg12fm2555h.xn----05c4213ryr0g; ; ;  # -ྸჅ.-𐹽ݴ𞣑
+\u0659。𑄴︒\u0627\u07DD; \u0659.𑄴︒\u0627\u07DD; [B1, V6, V7]; xn--1hb.xn--mgb09fp820c08pa; ; ;  # ٙ.𑄴︒اߝ
+\u0659。𑄴。\u0627\u07DD; \u0659.𑄴.\u0627\u07DD; [B1, V6]; xn--1hb.xn--w80d.xn--mgb09f; ; ;  # ٙ.𑄴.اߝ
+xn--1hb.xn--w80d.xn--mgb09f; \u0659.𑄴.\u0627\u07DD; [B1, V6]; xn--1hb.xn--w80d.xn--mgb09f; ; ;  # ٙ.𑄴.اߝ
+xn--1hb.xn--mgb09fp820c08pa; \u0659.𑄴︒\u0627\u07DD; [B1, V6, V7]; xn--1hb.xn--mgb09fp820c08pa; ; ;  # ٙ.𑄴︒اߝ
+Ⴙ\u0638.󠆓\u200D; ⴙ\u0638.\u200D; [B1, B5, B6, C2]; xn--3gb910r.xn--1ug; ; xn--3gb910r.; [B5, B6, A4_2] # ⴙظ.
+ⴙ\u0638.󠆓\u200D; ⴙ\u0638.\u200D; [B1, B5, B6, C2]; xn--3gb910r.xn--1ug; ; xn--3gb910r.; [B5, B6, A4_2] # ⴙظ.
+xn--3gb910r.; ⴙ\u0638.; [B5, B6]; xn--3gb910r.; [B5, B6, A4_2]; ;  # ⴙظ.
+xn--3gb910r.xn--1ug; ⴙ\u0638.\u200D; [B1, B5, B6, C2]; xn--3gb910r.xn--1ug; ; ;  # ⴙظ.
+xn--3gb194c.; Ⴙ\u0638.; [B5, B6, V7]; xn--3gb194c.; [B5, B6, V7, A4_2]; ;  # Ⴙظ.
+xn--3gb194c.xn--1ug; Ⴙ\u0638.\u200D; [B1, B5, B6, C2, V7]; xn--3gb194c.xn--1ug; ; ;  # Ⴙظ.
+󠆸｡₆０𐺧\u0756; .60𐺧\u0756; [B1, X4_2]; .xn--60-cke9470y; [B1, A4_2]; ;  # .60𐺧ݖ
+󠆸。60𐺧\u0756; .60𐺧\u0756; [B1, X4_2]; .xn--60-cke9470y; [B1, A4_2]; ;  # .60𐺧ݖ
+.xn--60-cke9470y; .60𐺧\u0756; [B1, X4_2]; .xn--60-cke9470y; [B1, A4_2]; ;  # .60𐺧ݖ
+6\u084F｡-𑈴; 6\u084F.-𑈴; [B1, V3]; xn--6-jjd.xn----6n8i; ; ;  # 6ࡏ.-𑈴
+6\u084F。-𑈴; 6\u084F.-𑈴; [B1, V3]; xn--6-jjd.xn----6n8i; ; ;  # 6ࡏ.-𑈴
+xn--6-jjd.xn----6n8i; 6\u084F.-𑈴; [B1, V3]; xn--6-jjd.xn----6n8i; ; ;  # 6ࡏ.-𑈴
+\u200D񋌿𐹰｡\u0ACDς𞰎\u08D6; \u200D񋌿𐹰.\u0ACDς𞰎\u08D6; [B1, C2, V6, V7]; xn--1ugx105gq26y.xn--3xa41xcwbfz15g; ; xn--oo0d1330n.xn--4xa21xcwbfz15g; [B1, B5, B6, V6, V7] # 𐹰.્ςࣖ
+\u200D񋌿𐹰。\u0ACDς𞰎\u08D6; \u200D񋌿𐹰.\u0ACDς𞰎\u08D6; [B1, C2, V6, V7]; xn--1ugx105gq26y.xn--3xa41xcwbfz15g; ; xn--oo0d1330n.xn--4xa21xcwbfz15g; [B1, B5, B6, V6, V7] # 𐹰.્ςࣖ
+\u200D񋌿𐹰。\u0ACDΣ𞰎\u08D6; \u200D񋌿𐹰.\u0ACDσ𞰎\u08D6; [B1, C2, V6, V7]; xn--1ugx105gq26y.xn--4xa21xcwbfz15g; ; xn--oo0d1330n.xn--4xa21xcwbfz15g; [B1, B5, B6, V6, V7] # 𐹰.્σࣖ
+\u200D񋌿𐹰。\u0ACDσ𞰎\u08D6; \u200D񋌿𐹰.\u0ACDσ𞰎\u08D6; [B1, C2, V6, V7]; xn--1ugx105gq26y.xn--4xa21xcwbfz15g; ; xn--oo0d1330n.xn--4xa21xcwbfz15g; [B1, B5, B6, V6, V7] # 𐹰.્σࣖ
+xn--oo0d1330n.xn--4xa21xcwbfz15g; 񋌿𐹰.\u0ACDσ𞰎\u08D6; [B1, B5, B6, V6, V7]; xn--oo0d1330n.xn--4xa21xcwbfz15g; ; ;  # 𐹰.્σࣖ
+xn--1ugx105gq26y.xn--4xa21xcwbfz15g; \u200D񋌿𐹰.\u0ACDσ𞰎\u08D6; [B1, C2, V6, V7]; xn--1ugx105gq26y.xn--4xa21xcwbfz15g; ; ;  # 𐹰.્σࣖ
+xn--1ugx105gq26y.xn--3xa41xcwbfz15g; \u200D񋌿𐹰.\u0ACDς𞰎\u08D6; [B1, C2, V6, V7]; xn--1ugx105gq26y.xn--3xa41xcwbfz15g; ; ;  # 𐹰.્ςࣖ
+\u200D񋌿𐹰｡\u0ACDΣ𞰎\u08D6; \u200D񋌿𐹰.\u0ACDσ𞰎\u08D6; [B1, C2, V6, V7]; xn--1ugx105gq26y.xn--4xa21xcwbfz15g; ; xn--oo0d1330n.xn--4xa21xcwbfz15g; [B1, B5, B6, V6, V7] # 𐹰.્σࣖ
+\u200D񋌿𐹰｡\u0ACDσ𞰎\u08D6; \u200D񋌿𐹰.\u0ACDσ𞰎\u08D6; [B1, C2, V6, V7]; xn--1ugx105gq26y.xn--4xa21xcwbfz15g; ; xn--oo0d1330n.xn--4xa21xcwbfz15g; [B1, B5, B6, V6, V7] # 𐹰.્σࣖ
+⒈񟄜Ⴓ⒪．\u0DCA򘘶\u088B𐹢; ⒈񟄜ⴓ(o).\u0DCA򘘶\u088B𐹢; [B1, V6, V7, U1]; xn--(o)-ge4ax01c3t74t.xn--3xb99xpx1yoes3e; ; ;  # ⒈ⴓ(o).්ࢋ𐹢
+1.񟄜Ⴓ(o).\u0DCA򘘶\u088B𐹢; 1.񟄜ⴓ(o).\u0DCA򘘶\u088B𐹢; [B1, B6, V6, V7, U1]; 1.xn--(o)-ej1bu5389e.xn--3xb99xpx1yoes3e; ; ;  # 1.ⴓ(o).්ࢋ𐹢
+1.񟄜ⴓ(o).\u0DCA򘘶\u088B𐹢; ; [B1, B6, V6, V7, U1]; 1.xn--(o)-ej1bu5389e.xn--3xb99xpx1yoes3e; ; ;  # 1.ⴓ(o).්ࢋ𐹢
+1.񟄜Ⴓ(O).\u0DCA򘘶\u088B𐹢; 1.񟄜ⴓ(o).\u0DCA򘘶\u088B𐹢; [B1, B6, V6, V7, U1]; 1.xn--(o)-ej1bu5389e.xn--3xb99xpx1yoes3e; ; ;  # 1.ⴓ(o).්ࢋ𐹢
+1.xn--(o)-ej1bu5389e.xn--3xb99xpx1yoes3e; 1.񟄜ⴓ(o).\u0DCA򘘶\u088B𐹢; [B1, B6, V6, V7, U1]; 1.xn--(o)-ej1bu5389e.xn--3xb99xpx1yoes3e; ; ;  # 1.ⴓ(o).්ࢋ𐹢
+⒈񟄜ⴓ⒪．\u0DCA򘘶\u088B𐹢; ⒈񟄜ⴓ(o).\u0DCA򘘶\u088B𐹢; [B1, V6, V7, U1]; xn--(o)-ge4ax01c3t74t.xn--3xb99xpx1yoes3e; ; ;  # ⒈ⴓ(o).්ࢋ𐹢
+xn--(o)-ge4ax01c3t74t.xn--3xb99xpx1yoes3e; ⒈񟄜ⴓ(o).\u0DCA򘘶\u088B𐹢; [B1, V6, V7, U1]; xn--(o)-ge4ax01c3t74t.xn--3xb99xpx1yoes3e; ; ;  # ⒈ⴓ(o).්ࢋ𐹢
+1.xn--(o)-7sn88849j.xn--3xb99xpx1yoes3e; 1.񟄜Ⴓ(o).\u0DCA򘘶\u088B𐹢; [B1, B6, V6, V7, U1]; 1.xn--(o)-7sn88849j.xn--3xb99xpx1yoes3e; ; ;  # 1.Ⴓ(o).්ࢋ𐹢
+xn--tsh0ds63atl31n.xn--3xb99xpx1yoes3e; ⒈񟄜ⴓ⒪.\u0DCA򘘶\u088B𐹢; [B1, V6, V7]; xn--tsh0ds63atl31n.xn--3xb99xpx1yoes3e; ; ;  # ⒈ⴓ⒪.්ࢋ𐹢
+xn--rnd762h7cx3027d.xn--3xb99xpx1yoes3e; ⒈񟄜Ⴓ⒪.\u0DCA򘘶\u088B𐹢; [B1, V6, V7]; xn--rnd762h7cx3027d.xn--3xb99xpx1yoes3e; ; ;  # ⒈Ⴓ⒪.්ࢋ𐹢
+𞤷.𐮐𞢁𐹠\u0624; ; ; xn--ve6h.xn--jgb1694kz0b2176a; ; ;  # 𞤷.𐮐𞢁𐹠ؤ
+𞤷.𐮐𞢁𐹠\u0648\u0654; 𞤷.𐮐𞢁𐹠\u0624; ; xn--ve6h.xn--jgb1694kz0b2176a; ; ;  # 𞤷.𐮐𞢁𐹠ؤ
+𞤕.𐮐𞢁𐹠\u0648\u0654; 𞤷.𐮐𞢁𐹠\u0624; ; xn--ve6h.xn--jgb1694kz0b2176a; ; ;  # 𞤷.𐮐𞢁𐹠ؤ
+𞤕.𐮐𞢁𐹠\u0624; 𞤷.𐮐𞢁𐹠\u0624; ; xn--ve6h.xn--jgb1694kz0b2176a; ; ;  # 𞤷.𐮐𞢁𐹠ؤ
+xn--ve6h.xn--jgb1694kz0b2176a; 𞤷.𐮐𞢁𐹠\u0624; ; xn--ve6h.xn--jgb1694kz0b2176a; ; ;  # 𞤷.𐮐𞢁𐹠ؤ
+𐲈-｡𑄳񢌻; 𐳈-.𑄳񢌻; [B1, B3, V3, V6, V7]; xn----ue6i.xn--v80d6662t; ; ;  # 𐳈-.𑄳
+𐲈-。𑄳񢌻; 𐳈-.𑄳񢌻; [B1, B3, V3, V6, V7]; xn----ue6i.xn--v80d6662t; ; ;  # 𐳈-.𑄳
+𐳈-。𑄳񢌻; 𐳈-.𑄳񢌻; [B1, B3, V3, V6, V7]; xn----ue6i.xn--v80d6662t; ; ;  # 𐳈-.𑄳
+xn----ue6i.xn--v80d6662t; 𐳈-.𑄳񢌻; [B1, B3, V3, V6, V7]; xn----ue6i.xn--v80d6662t; ; ;  # 𐳈-.𑄳
+𐳈-｡𑄳񢌻; 𐳈-.𑄳񢌻; [B1, B3, V3, V6, V7]; xn----ue6i.xn--v80d6662t; ; ;  # 𐳈-.𑄳
+-󠉖ꡧ．󠊂񇆃🄉; -󠉖ꡧ.󠊂񇆃8,; [V3, V7, U1]; xn----hg4ei0361g.xn--8,-k362evu488a; ; ;  # -ꡧ.8,
+-󠉖ꡧ.󠊂񇆃8,; ; [V3, V7, U1]; xn----hg4ei0361g.xn--8,-k362evu488a; ; ;  # -ꡧ.8,
+xn----hg4ei0361g.xn--8,-k362evu488a; -󠉖ꡧ.󠊂񇆃8,; [V3, V7, U1]; xn----hg4ei0361g.xn--8,-k362evu488a; ; ;  # -ꡧ.8,
+xn----hg4ei0361g.xn--207ht163h7m94c; -󠉖ꡧ.󠊂񇆃🄉; [V3, V7]; xn----hg4ei0361g.xn--207ht163h7m94c; ; ;  # -ꡧ.🄉
+󠾛󠈴臯𧔤.\u0768𝟝; 󠾛󠈴臯𧔤.\u07685; [B1, V7]; xn--zb1at733hm579ddhla.xn--5-b5c; ; ;  # 臯𧔤.ݨ5
+󠾛󠈴臯𧔤.\u07685; ; [B1, V7]; xn--zb1at733hm579ddhla.xn--5-b5c; ; ;  # 臯𧔤.ݨ5
+xn--zb1at733hm579ddhla.xn--5-b5c; 󠾛󠈴臯𧔤.\u07685; [B1, V7]; xn--zb1at733hm579ddhla.xn--5-b5c; ; ;  # 臯𧔤.ݨ5
+≮𐹣．𝨿; ≮𐹣.𝨿; [B1, V6]; xn--gdh1504g.xn--e92h; ; ;  # ≮𐹣.𝨿
+<\u0338𐹣．𝨿; ≮𐹣.𝨿; [B1, V6]; xn--gdh1504g.xn--e92h; ; ;  # ≮𐹣.𝨿
+≮𐹣.𝨿; ; [B1, V6]; xn--gdh1504g.xn--e92h; ; ;  # ≮𐹣.𝨿
+<\u0338𐹣.𝨿; ≮𐹣.𝨿; [B1, V6]; xn--gdh1504g.xn--e92h; ; ;  # ≮𐹣.𝨿
+xn--gdh1504g.xn--e92h; ≮𐹣.𝨿; [B1, V6]; xn--gdh1504g.xn--e92h; ; ;  # ≮𐹣.𝨿
+𐹯ᯛ\u0A4D｡脥; 𐹯ᯛ\u0A4D.脥; [B1]; xn--ybc101g3m1p.xn--740a; ; ;  # 𐹯ᯛ੍.脥
+𐹯ᯛ\u0A4D。脥; 𐹯ᯛ\u0A4D.脥; [B1]; xn--ybc101g3m1p.xn--740a; ; ;  # 𐹯ᯛ੍.脥
+xn--ybc101g3m1p.xn--740a; 𐹯ᯛ\u0A4D.脥; [B1]; xn--ybc101g3m1p.xn--740a; ; ;  # 𐹯ᯛ੍.脥
+\u1B44\u115F𞷿򃀍.-; \u1B44𞷿򃀍.-; [B1, B5, V3, V6, V7]; xn--1uf9538sxny9a.-; ; ;  # ᭄.-
+xn--1uf9538sxny9a.-; \u1B44𞷿򃀍.-; [B1, B5, V3, V6, V7]; xn--1uf9538sxny9a.-; ; ;  # ᭄.-
+xn--osd971cpx70btgt8b.-; \u1B44\u115F𞷿򃀍.-; [B1, B5, V3, V6, V7]; xn--osd971cpx70btgt8b.-; ; ;  # ᭄.-
+\u200C｡\u0354; \u200C.\u0354; [C1, V6]; xn--0ug.xn--yua; ; .xn--yua; [V6, A4_2] # .͔
+\u200C。\u0354; \u200C.\u0354; [C1, V6]; xn--0ug.xn--yua; ; .xn--yua; [V6, A4_2] # .͔
+.xn--yua; .\u0354; [V6, X4_2]; .xn--yua; [V6, A4_2]; ;  # .͔
+xn--0ug.xn--yua; \u200C.\u0354; [C1, V6]; xn--0ug.xn--yua; ; ;  # .͔
+𞤥󠅮．ᡄႮ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤥󠅮.ᡄႮ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤥󠅮.ᡄⴎ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤃󠅮.ᡄႮ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤃󠅮.ᡄⴎ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+xn--de6h.xn--37e857h; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤥.ᡄⴎ; ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤃.ᡄႮ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤃.ᡄⴎ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤥󠅮．ᡄⴎ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤃󠅮．ᡄႮ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤃󠅮．ᡄⴎ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+xn--de6h.xn--mnd799a; 𞤥.ᡄႮ; [V7]; xn--de6h.xn--mnd799a; ; ;  # 𞤥.ᡄႮ
+𞤥.ᡄႮ; 𞤥.ᡄⴎ; ; xn--de6h.xn--37e857h; ; ;  # 𞤥.ᡄⴎ
+𞤧𝨨Ξ．𪺏㛨❸; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+𞤧𝨨Ξ.𪺏㛨❸; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+𞤧𝨨ξ.𪺏㛨❸; ; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+𞤅𝨨Ξ.𪺏㛨❸; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+𞤅𝨨ξ.𪺏㛨❸; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+xn--zxa5691vboja.xn--bfi293ci119b; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+𞤧𝨨ξ．𪺏㛨❸; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+𞤅𝨨Ξ．𪺏㛨❸; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+𞤅𝨨ξ．𪺏㛨❸; 𞤧𝨨ξ.𪺏㛨❸; [B2, B3, B6]; xn--zxa5691vboja.xn--bfi293ci119b; ; ;  # 𞤧𝨨ξ.𪺏㛨❸
+᠆몆\u200C-｡Ⴛ𐦅︒; ᠆몆\u200C-.ⴛ𐦅︒; [B1, B5, B6, C1, V3, V7]; xn----e3j425bsk1o.xn--jlj4997dhgh; ; xn----e3j6620g.xn--jlj4997dhgh; [B1, B5, B6, V3, V7] # ᠆몆-.ⴛ𐦅︒
+᠆몆\u200C-｡Ⴛ𐦅︒; ᠆몆\u200C-.ⴛ𐦅︒; [B1, B5, B6, C1, V3, V7]; xn----e3j425bsk1o.xn--jlj4997dhgh; ; xn----e3j6620g.xn--jlj4997dhgh; [B1, B5, B6, V3, V7] # ᠆몆-.ⴛ𐦅︒
+᠆몆\u200C-。Ⴛ𐦅。; ᠆몆\u200C-.ⴛ𐦅.; [B1, B5, B6, C1, V3]; xn----e3j425bsk1o.xn--jlju661e.; [B1, B5, B6, C1, V3, A4_2]; xn----e3j6620g.xn--jlju661e.; [B1, B5, B6, V3, A4_2] # ᠆몆-.ⴛ𐦅.
+᠆몆\u200C-。Ⴛ𐦅。; ᠆몆\u200C-.ⴛ𐦅.; [B1, B5, B6, C1, V3]; xn----e3j425bsk1o.xn--jlju661e.; [B1, B5, B6, C1, V3, A4_2]; xn----e3j6620g.xn--jlju661e.; [B1, B5, B6, V3, A4_2] # ᠆몆-.ⴛ𐦅.
+᠆몆\u200C-。ⴛ𐦅。; ᠆몆\u200C-.ⴛ𐦅.; [B1, B5, B6, C1, V3]; xn----e3j425bsk1o.xn--jlju661e.; [B1, B5, B6, C1, V3, A4_2]; xn----e3j6620g.xn--jlju661e.; [B1, B5, B6, V3, A4_2] # ᠆몆-.ⴛ𐦅.
+᠆몆\u200C-。ⴛ𐦅。; ᠆몆\u200C-.ⴛ𐦅.; [B1, B5, B6, C1, V3]; xn----e3j425bsk1o.xn--jlju661e.; [B1, B5, B6, C1, V3, A4_2]; xn----e3j6620g.xn--jlju661e.; [B1, B5, B6, V3, A4_2] # ᠆몆-.ⴛ𐦅.
+xn----e3j6620g.xn--jlju661e.; ᠆몆-.ⴛ𐦅.; [B1, B5, B6, V3]; xn----e3j6620g.xn--jlju661e.; [B1, B5, B6, V3, A4_2]; ;  # ᠆몆-.ⴛ𐦅.
+xn----e3j425bsk1o.xn--jlju661e.; ᠆몆\u200C-.ⴛ𐦅.; [B1, B5, B6, C1, V3]; xn----e3j425bsk1o.xn--jlju661e.; [B1, B5, B6, C1, V3, A4_2]; ;  # ᠆몆-.ⴛ𐦅.
+᠆몆\u200C-｡ⴛ𐦅︒; ᠆몆\u200C-.ⴛ𐦅︒; [B1, B5, B6, C1, V3, V7]; xn----e3j425bsk1o.xn--jlj4997dhgh; ; xn----e3j6620g.xn--jlj4997dhgh; [B1, B5, B6, V3, V7] # ᠆몆-.ⴛ𐦅︒
+᠆몆\u200C-｡ⴛ𐦅︒; ᠆몆\u200C-.ⴛ𐦅︒; [B1, B5, B6, C1, V3, V7]; xn----e3j425bsk1o.xn--jlj4997dhgh; ; xn----e3j6620g.xn--jlj4997dhgh; [B1, B5, B6, V3, V7] # ᠆몆-.ⴛ𐦅︒
+xn----e3j6620g.xn--jlj4997dhgh; ᠆몆-.ⴛ𐦅︒; [B1, B5, B6, V3, V7]; xn----e3j6620g.xn--jlj4997dhgh; ; ;  # ᠆몆-.ⴛ𐦅︒
+xn----e3j425bsk1o.xn--jlj4997dhgh; ᠆몆\u200C-.ⴛ𐦅︒; [B1, B5, B6, C1, V3, V7]; xn----e3j425bsk1o.xn--jlj4997dhgh; ; ;  # ᠆몆-.ⴛ𐦅︒
+xn----e3j6620g.xn--znd4948j.; ᠆몆-.Ⴛ𐦅.; [B1, B5, B6, V3, V7]; xn----e3j6620g.xn--znd4948j.; [B1, B5, B6, V3, V7, A4_2]; ;  # ᠆몆-.Ⴛ𐦅.
+xn----e3j425bsk1o.xn--znd4948j.; ᠆몆\u200C-.Ⴛ𐦅.; [B1, B5, B6, C1, V3, V7]; xn----e3j425bsk1o.xn--znd4948j.; [B1, B5, B6, C1, V3, V7, A4_2]; ;  # ᠆몆-.Ⴛ𐦅.
+xn----e3j6620g.xn--znd2362jhgh; ᠆몆-.Ⴛ𐦅︒; [B1, B5, B6, V3, V7]; xn----e3j6620g.xn--znd2362jhgh; ; ;  # ᠆몆-.Ⴛ𐦅︒
+xn----e3j425bsk1o.xn--znd2362jhgh; ᠆몆\u200C-.Ⴛ𐦅︒; [B1, B5, B6, C1, V3, V7]; xn----e3j425bsk1o.xn--znd2362jhgh; ; ;  # ᠆몆-.Ⴛ𐦅︒
+󠾳.︒⥱\u200C𐹬; ; [B1, C1, V7]; xn--uf66e.xn--0ugz28axl3pqxna; ; xn--uf66e.xn--qtiz073e3ik; [B1, V7] # .︒⥱𐹬
+󠾳.。⥱\u200C𐹬; 󠾳..⥱\u200C𐹬; [B1, C1, V7, X4_2]; xn--uf66e..xn--0ugz28as66q; [B1, C1, V7, A4_2]; xn--uf66e..xn--qti2829e; [B1, V7, A4_2] # ..⥱𐹬
+xn--uf66e..xn--qti2829e; 󠾳..⥱𐹬; [B1, V7, X4_2]; xn--uf66e..xn--qti2829e; [B1, V7, A4_2]; ;  # ..⥱𐹬
+xn--uf66e..xn--0ugz28as66q; 󠾳..⥱\u200C𐹬; [B1, C1, V7, X4_2]; xn--uf66e..xn--0ugz28as66q; [B1, C1, V7, A4_2]; ;  # ..⥱𐹬
+xn--uf66e.xn--qtiz073e3ik; 󠾳.︒⥱𐹬; [B1, V7]; xn--uf66e.xn--qtiz073e3ik; ; ;  # .︒⥱𐹬
+xn--uf66e.xn--0ugz28axl3pqxna; 󠾳.︒⥱\u200C𐹬; [B1, C1, V7]; xn--uf66e.xn--0ugz28axl3pqxna; ; ;  # .︒⥱𐹬
+𐯖.𐹠Ⴑ񚇜𐫊; 𐯖.𐹠ⴑ񚇜𐫊; [B1, V7]; xn--n49c.xn--8kj8702ewicl862o; ; ;  # .𐹠ⴑ𐫊
+𐯖.𐹠ⴑ񚇜𐫊; ; [B1, V7]; xn--n49c.xn--8kj8702ewicl862o; ; ;  # .𐹠ⴑ𐫊
+xn--n49c.xn--8kj8702ewicl862o; 𐯖.𐹠ⴑ񚇜𐫊; [B1, V7]; xn--n49c.xn--8kj8702ewicl862o; ; ;  # .𐹠ⴑ𐫊
+xn--n49c.xn--pnd4619jwicl862o; 𐯖.𐹠Ⴑ񚇜𐫊; [B1, V7]; xn--n49c.xn--pnd4619jwicl862o; ; ;  # .𐹠Ⴑ𐫊
+\u0FA4񱤯．𝟭Ⴛ; \u0FA4񱤯.1ⴛ; [V6, V7]; xn--0fd40533g.xn--1-tws; ; ;  # ྤ.1ⴛ
+\u0FA4񱤯.1Ⴛ; \u0FA4񱤯.1ⴛ; [V6, V7]; xn--0fd40533g.xn--1-tws; ; ;  # ྤ.1ⴛ
+\u0FA4񱤯.1ⴛ; ; [V6, V7]; xn--0fd40533g.xn--1-tws; ; ;  # ྤ.1ⴛ
+xn--0fd40533g.xn--1-tws; \u0FA4񱤯.1ⴛ; [V6, V7]; xn--0fd40533g.xn--1-tws; ; ;  # ྤ.1ⴛ
+\u0FA4񱤯．𝟭ⴛ; \u0FA4񱤯.1ⴛ; [V6, V7]; xn--0fd40533g.xn--1-tws; ; ;  # ྤ.1ⴛ
+xn--0fd40533g.xn--1-q1g; \u0FA4񱤯.1Ⴛ; [V6, V7]; xn--0fd40533g.xn--1-q1g; ; ;  # ྤ.1Ⴛ
+-\u0826齀。릿𐸋; -\u0826齀.릿𐸋; [B1, B5, B6, V3, V7]; xn----6gd0617i.xn--7y2bm55m; ; ;  # -ࠦ齀.릿
+-\u0826齀。릿𐸋; -\u0826齀.릿𐸋; [B1, B5, B6, V3, V7]; xn----6gd0617i.xn--7y2bm55m; ; ;  # -ࠦ齀.릿
+xn----6gd0617i.xn--7y2bm55m; -\u0826齀.릿𐸋; [B1, B5, B6, V3, V7]; xn----6gd0617i.xn--7y2bm55m; ; ;  # -ࠦ齀.릿
+󠔊\u071C鹝꾗。񾵐\u200D\u200D⏃; 󠔊\u071C鹝꾗.񾵐\u200D\u200D⏃; [B1, B6, C2, V7]; xn--mnb6558e91kyq533a.xn--1uga46zs309y; ; xn--mnb6558e91kyq533a.xn--6mh27269e; [B1, B6, V7] # ܜ鹝꾗.⏃
+󠔊\u071C鹝꾗。񾵐\u200D\u200D⏃; 󠔊\u071C鹝꾗.񾵐\u200D\u200D⏃; [B1, B6, C2, V7]; xn--mnb6558e91kyq533a.xn--1uga46zs309y; ; xn--mnb6558e91kyq533a.xn--6mh27269e; [B1, B6, V7] # ܜ鹝꾗.⏃
+xn--mnb6558e91kyq533a.xn--6mh27269e; 󠔊\u071C鹝꾗.񾵐⏃; [B1, B6, V7]; xn--mnb6558e91kyq533a.xn--6mh27269e; ; ;  # ܜ鹝꾗.⏃
+xn--mnb6558e91kyq533a.xn--1uga46zs309y; 󠔊\u071C鹝꾗.񾵐\u200D\u200D⏃; [B1, B6, C2, V7]; xn--mnb6558e91kyq533a.xn--1uga46zs309y; ; ;  # ܜ鹝꾗.⏃
+≮．-\u0708--; ≮.-\u0708--; [B1, V2, V3]; xn--gdh.xn------eqf; ; ;  # ≮.-܈--
+<\u0338．-\u0708--; ≮.-\u0708--; [B1, V2, V3]; xn--gdh.xn------eqf; ; ;  # ≮.-܈--
+≮.-\u0708--; ; [B1, V2, V3]; xn--gdh.xn------eqf; ; ;  # ≮.-܈--
+<\u0338.-\u0708--; ≮.-\u0708--; [B1, V2, V3]; xn--gdh.xn------eqf; ; ;  # ≮.-܈--
+xn--gdh.xn------eqf; ≮.-\u0708--; [B1, V2, V3]; xn--gdh.xn------eqf; ; ;  # ≮.-܈--
+𐹸󠋳。\u200Dς𝟩; 𐹸󠋳.\u200Dς7; [B1, C2, V7]; xn--wo0di5177c.xn--7-xmb248s; ; xn--wo0di5177c.xn--7-zmb; [B1, V7] # 𐹸.ς7
+𐹸󠋳。\u200Dς7; 𐹸󠋳.\u200Dς7; [B1, C2, V7]; xn--wo0di5177c.xn--7-xmb248s; ; xn--wo0di5177c.xn--7-zmb; [B1, V7] # 𐹸.ς7
+𐹸󠋳。\u200DΣ7; 𐹸󠋳.\u200Dσ7; [B1, C2, V7]; xn--wo0di5177c.xn--7-zmb938s; ; xn--wo0di5177c.xn--7-zmb; [B1, V7] # 𐹸.σ7
+𐹸󠋳。\u200Dσ7; 𐹸󠋳.\u200Dσ7; [B1, C2, V7]; xn--wo0di5177c.xn--7-zmb938s; ; xn--wo0di5177c.xn--7-zmb; [B1, V7] # 𐹸.σ7
+xn--wo0di5177c.xn--7-zmb; 𐹸󠋳.σ7; [B1, V7]; xn--wo0di5177c.xn--7-zmb; ; ;  # 𐹸.σ7
+xn--wo0di5177c.xn--7-zmb938s; 𐹸󠋳.\u200Dσ7; [B1, C2, V7]; xn--wo0di5177c.xn--7-zmb938s; ; ;  # 𐹸.σ7
+xn--wo0di5177c.xn--7-xmb248s; 𐹸󠋳.\u200Dς7; [B1, C2, V7]; xn--wo0di5177c.xn--7-xmb248s; ; ;  # 𐹸.ς7
+𐹸󠋳。\u200DΣ𝟩; 𐹸󠋳.\u200Dσ7; [B1, C2, V7]; xn--wo0di5177c.xn--7-zmb938s; ; xn--wo0di5177c.xn--7-zmb; [B1, V7] # 𐹸.σ7
+𐹸󠋳。\u200Dσ𝟩; 𐹸󠋳.\u200Dσ7; [B1, C2, V7]; xn--wo0di5177c.xn--7-zmb938s; ; xn--wo0di5177c.xn--7-zmb; [B1, V7] # 𐹸.σ7
+ς򅜌８.𞭤; ς򅜌8.𞭤; [V7]; xn--8-xmb44974n.xn--su6h; ; xn--8-zmb14974n.xn--su6h;  # ς8.
+ς򅜌8.𞭤; ; [V7]; xn--8-xmb44974n.xn--su6h; ; xn--8-zmb14974n.xn--su6h;  # ς8.
+Σ򅜌8.𞭤; σ򅜌8.𞭤; [V7]; xn--8-zmb14974n.xn--su6h; ; ;  # σ8.
+σ򅜌8.𞭤; ; [V7]; xn--8-zmb14974n.xn--su6h; ; ;  # σ8.
+xn--8-zmb14974n.xn--su6h; σ򅜌8.𞭤; [V7]; xn--8-zmb14974n.xn--su6h; ; ;  # σ8.
+xn--8-xmb44974n.xn--su6h; ς򅜌8.𞭤; [V7]; xn--8-xmb44974n.xn--su6h; ; ;  # ς8.
+Σ򅜌８.𞭤; σ򅜌8.𞭤; [V7]; xn--8-zmb14974n.xn--su6h; ; ;  # σ8.
+σ򅜌８.𞭤; σ򅜌8.𞭤; [V7]; xn--8-zmb14974n.xn--su6h; ; ;  # σ8.
+\u200Cᡑ🄀\u0684．-𐫄𑲤; \u200Cᡑ🄀\u0684.-𐫄𑲤; [B1, C1, V3, V7]; xn--9ib722gvtfi563c.xn----ek5i065b; ; xn--9ib722gbw95a.xn----ek5i065b; [B1, B5, B6, V3, V7] # ᡑ🄀ڄ.-𐫄𑲤
+\u200Cᡑ0.\u0684.-𐫄𑲤; ; [B1, C1, V3]; xn--0-o7j263b.xn--9ib.xn----ek5i065b; ; xn--0-o7j.xn--9ib.xn----ek5i065b; [B1, V3] # ᡑ0.ڄ.-𐫄𑲤
+xn--0-o7j.xn--9ib.xn----ek5i065b; ᡑ0.\u0684.-𐫄𑲤; [B1, V3]; xn--0-o7j.xn--9ib.xn----ek5i065b; ; ;  # ᡑ0.ڄ.-𐫄𑲤
+xn--0-o7j263b.xn--9ib.xn----ek5i065b; \u200Cᡑ0.\u0684.-𐫄𑲤; [B1, C1, V3]; xn--0-o7j263b.xn--9ib.xn----ek5i065b; ; ;  # ᡑ0.ڄ.-𐫄𑲤
+xn--9ib722gbw95a.xn----ek5i065b; ᡑ🄀\u0684.-𐫄𑲤; [B1, B5, B6, V3, V7]; xn--9ib722gbw95a.xn----ek5i065b; ; ;  # ᡑ🄀ڄ.-𐫄𑲤
+xn--9ib722gvtfi563c.xn----ek5i065b; \u200Cᡑ🄀\u0684.-𐫄𑲤; [B1, C1, V3, V7]; xn--9ib722gvtfi563c.xn----ek5i065b; ; ;  # ᡑ🄀ڄ.-𐫄𑲤
+𖠍。𐪿넯򞵲; 𖠍.𐪿넯򞵲; [B2, B3, V7]; xn--4e9e.xn--l60bj21opd57g; ; ;  # 𖠍.넯
+𖠍。𐪿넯򞵲; 𖠍.𐪿넯򞵲; [B2, B3, V7]; xn--4e9e.xn--l60bj21opd57g; ; ;  # 𖠍.넯
+xn--4e9e.xn--l60bj21opd57g; 𖠍.𐪿넯򞵲; [B2, B3, V7]; xn--4e9e.xn--l60bj21opd57g; ; ;  # 𖠍.넯
+᠇Ⴘ。\u0603Ⴈ𝆊; ᠇ⴘ.\u0603ⴈ𝆊; [B1, V7]; xn--d6e009h.xn--lfb290rfu3z; ; ;  # ᠇ⴘ.ⴈ𝆊
+᠇ⴘ。\u0603ⴈ𝆊; ᠇ⴘ.\u0603ⴈ𝆊; [B1, V7]; xn--d6e009h.xn--lfb290rfu3z; ; ;  # ᠇ⴘ.ⴈ𝆊
+xn--d6e009h.xn--lfb290rfu3z; ᠇ⴘ.\u0603ⴈ𝆊; [B1, V7]; xn--d6e009h.xn--lfb290rfu3z; ; ;  # ᠇ⴘ.ⴈ𝆊
+xn--wnd558a.xn--lfb465c1v87a; ᠇Ⴘ.\u0603Ⴈ𝆊; [B1, V7]; xn--wnd558a.xn--lfb465c1v87a; ; ;  # ᠇Ⴘ.Ⴈ𝆊
+⒚󠋑𞤰。牣\u0667Ⴜᣥ; ⒚󠋑𞤰.牣\u0667ⴜᣥ; [B1, B5, V7]; xn--cthy466n29j3e.xn--gib285gtxo2l9d; ; ;  # ⒚𞤰.牣٧ⴜᣥ
+19.󠋑𞤰。牣\u0667Ⴜᣥ; 19.󠋑𞤰.牣\u0667ⴜᣥ; [B1, B5, V7]; 19.xn--oe6h75760c.xn--gib285gtxo2l9d; ; ;  # 19.𞤰.牣٧ⴜᣥ
+19.󠋑𞤰。牣\u0667ⴜᣥ; 19.󠋑𞤰.牣\u0667ⴜᣥ; [B1, B5, V7]; 19.xn--oe6h75760c.xn--gib285gtxo2l9d; ; ;  # 19.𞤰.牣٧ⴜᣥ
+19.󠋑𞤎。牣\u0667Ⴜᣥ; 19.󠋑𞤰.牣\u0667ⴜᣥ; [B1, B5, V7]; 19.xn--oe6h75760c.xn--gib285gtxo2l9d; ; ;  # 19.𞤰.牣٧ⴜᣥ
+19.󠋑𞤎。牣\u0667ⴜᣥ; 19.󠋑𞤰.牣\u0667ⴜᣥ; [B1, B5, V7]; 19.xn--oe6h75760c.xn--gib285gtxo2l9d; ; ;  # 19.𞤰.牣٧ⴜᣥ
+19.xn--oe6h75760c.xn--gib285gtxo2l9d; 19.󠋑𞤰.牣\u0667ⴜᣥ; [B1, B5, V7]; 19.xn--oe6h75760c.xn--gib285gtxo2l9d; ; ;  # 19.𞤰.牣٧ⴜᣥ
+⒚󠋑𞤰。牣\u0667ⴜᣥ; ⒚󠋑𞤰.牣\u0667ⴜᣥ; [B1, B5, V7]; xn--cthy466n29j3e.xn--gib285gtxo2l9d; ; ;  # ⒚𞤰.牣٧ⴜᣥ
+⒚󠋑𞤎。牣\u0667Ⴜᣥ; ⒚󠋑𞤰.牣\u0667ⴜᣥ; [B1, B5, V7]; xn--cthy466n29j3e.xn--gib285gtxo2l9d; ; ;  # ⒚𞤰.牣٧ⴜᣥ
+⒚󠋑𞤎。牣\u0667ⴜᣥ; ⒚󠋑𞤰.牣\u0667ⴜᣥ; [B1, B5, V7]; xn--cthy466n29j3e.xn--gib285gtxo2l9d; ; ;  # ⒚𞤰.牣٧ⴜᣥ
+xn--cthy466n29j3e.xn--gib285gtxo2l9d; ⒚󠋑𞤰.牣\u0667ⴜᣥ; [B1, B5, V7]; xn--cthy466n29j3e.xn--gib285gtxo2l9d; ; ;  # ⒚𞤰.牣٧ⴜᣥ
+19.xn--oe6h75760c.xn--gib404ccxgh00h; 19.󠋑𞤰.牣\u0667Ⴜᣥ; [B1, B5, V7]; 19.xn--oe6h75760c.xn--gib404ccxgh00h; ; ;  # 19.𞤰.牣٧Ⴜᣥ
+xn--cthy466n29j3e.xn--gib404ccxgh00h; ⒚󠋑𞤰.牣\u0667Ⴜᣥ; [B1, B5, V7]; xn--cthy466n29j3e.xn--gib404ccxgh00h; ; ;  # ⒚𞤰.牣٧Ⴜᣥ
+-𐋱𐰽⒈.Ⴓ; -𐋱𐰽⒈.ⴓ; [B1, V3, V7]; xn----ecp0206g90h.xn--blj; ; ;  # -𐋱𐰽⒈.ⴓ
+-𐋱𐰽1..Ⴓ; -𐋱𐰽1..ⴓ; [B1, V3, X4_2]; xn---1-895nq11a..xn--blj; [B1, V3, A4_2]; ;  # -𐋱𐰽1..ⴓ
+-𐋱𐰽1..ⴓ; ; [B1, V3, X4_2]; xn---1-895nq11a..xn--blj; [B1, V3, A4_2]; ;  # -𐋱𐰽1..ⴓ
+xn---1-895nq11a..xn--blj; -𐋱𐰽1..ⴓ; [B1, V3, X4_2]; xn---1-895nq11a..xn--blj; [B1, V3, A4_2]; ;  # -𐋱𐰽1..ⴓ
+-𐋱𐰽⒈.ⴓ; ; [B1, V3, V7]; xn----ecp0206g90h.xn--blj; ; ;  # -𐋱𐰽⒈.ⴓ
+xn----ecp0206g90h.xn--blj; -𐋱𐰽⒈.ⴓ; [B1, V3, V7]; xn----ecp0206g90h.xn--blj; ; ;  # -𐋱𐰽⒈.ⴓ
+xn---1-895nq11a..xn--rnd; -𐋱𐰽1..Ⴓ; [B1, V3, V7, X4_2]; xn---1-895nq11a..xn--rnd; [B1, V3, V7, A4_2]; ;  # -𐋱𐰽1..Ⴓ
+xn----ecp0206g90h.xn--rnd; -𐋱𐰽⒈.Ⴓ; [B1, V3, V7]; xn----ecp0206g90h.xn--rnd; ; ;  # -𐋱𐰽⒈.Ⴓ
+\u200C긃.榶-; ; [C1, V3]; xn--0ug3307c.xn----d87b; ; xn--ej0b.xn----d87b; [V3] # 긃.榶-
+\u200C긃.榶-; \u200C긃.榶-; [C1, V3]; xn--0ug3307c.xn----d87b; ; xn--ej0b.xn----d87b; [V3] # 긃.榶-
+xn--ej0b.xn----d87b; 긃.榶-; [V3]; xn--ej0b.xn----d87b; ; ;  # 긃.榶-
+xn--0ug3307c.xn----d87b; \u200C긃.榶-; [C1, V3]; xn--0ug3307c.xn----d87b; ; ;  # 긃.榶-
+뉓泓𜵽.\u09CD\u200D; ; [V6]; xn--lwwp69lqs7m.xn--b7b605i; ; xn--lwwp69lqs7m.xn--b7b;  # 뉓泓𜵽.্
+뉓泓𜵽.\u09CD\u200D; 뉓泓𜵽.\u09CD\u200D; [V6]; xn--lwwp69lqs7m.xn--b7b605i; ; xn--lwwp69lqs7m.xn--b7b;  # 뉓泓𜵽.্
+xn--lwwp69lqs7m.xn--b7b; 뉓泓𜵽.\u09CD; [V6]; xn--lwwp69lqs7m.xn--b7b; ; ;  # 뉓泓𜵽.্
+xn--lwwp69lqs7m.xn--b7b605i; 뉓泓𜵽.\u09CD\u200D; [V6]; xn--lwwp69lqs7m.xn--b7b605i; ; ;  # 뉓泓𜵽.্
+\u200D𐹴ß｡\u0EB4\u2B75񪅌; \u200D𐹴ß.\u0EB4\u2B75񪅌; [B1, C2, V6, V7]; xn--zca770nip7n.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, V6, V7] # 𐹴ß.ິ
+\u200D𐹴ß。\u0EB4\u2B75񪅌; \u200D𐹴ß.\u0EB4\u2B75񪅌; [B1, C2, V6, V7]; xn--zca770nip7n.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, V6, V7] # 𐹴ß.ິ
+\u200D𐹴SS。\u0EB4\u2B75񪅌; \u200D𐹴ss.\u0EB4\u2B75񪅌; [B1, C2, V6, V7]; xn--ss-l1t5169j.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, V6, V7] # 𐹴ss.ິ
+\u200D𐹴ss。\u0EB4\u2B75񪅌; \u200D𐹴ss.\u0EB4\u2B75񪅌; [B1, C2, V6, V7]; xn--ss-l1t5169j.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, V6, V7] # 𐹴ss.ິ
+\u200D𐹴Ss。\u0EB4\u2B75񪅌; \u200D𐹴ss.\u0EB4\u2B75񪅌; [B1, C2, V6, V7]; xn--ss-l1t5169j.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, V6, V7] # 𐹴ss.ິ
+xn--ss-ti3o.xn--57c638l8774i; 𐹴ss.\u0EB4\u2B75񪅌; [B1, V6, V7]; xn--ss-ti3o.xn--57c638l8774i; ; ;  # 𐹴ss.ິ
+xn--ss-l1t5169j.xn--57c638l8774i; \u200D𐹴ss.\u0EB4\u2B75񪅌; [B1, C2, V6, V7]; xn--ss-l1t5169j.xn--57c638l8774i; ; ;  # 𐹴ss.ິ
+xn--zca770nip7n.xn--57c638l8774i; \u200D𐹴ß.\u0EB4\u2B75񪅌; [B1, C2, V6, V7]; xn--zca770nip7n.xn--57c638l8774i; ; ;  # 𐹴ß.ິ
+\u200D𐹴SS｡\u0EB4\u2B75񪅌; \u200D𐹴ss.\u0EB4\u2B75񪅌; [B1, C2, V6, V7]; xn--ss-l1t5169j.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, V6, V7] # 𐹴ss.ິ
+\u200D𐹴ss｡\u0EB4\u2B75񪅌; \u200D𐹴ss.\u0EB4\u2B75񪅌; [B1, C2, V6, V7]; xn--ss-l1t5169j.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, V6, V7] # 𐹴ss.ິ
+\u200D𐹴Ss｡\u0EB4\u2B75񪅌; \u200D𐹴ss.\u0EB4\u2B75񪅌; [B1, C2, V6, V7]; xn--ss-l1t5169j.xn--57c638l8774i; ; xn--ss-ti3o.xn--57c638l8774i; [B1, V6, V7] # 𐹴ss.ິ
+\u1B44．\u1BAA-≮≠; \u1B44.\u1BAA-≮≠; [V6]; xn--1uf.xn----nmlz65aub; ; ;  # ᭄.᮪-≮≠
+\u1B44．\u1BAA-<\u0338=\u0338; \u1B44.\u1BAA-≮≠; [V6]; xn--1uf.xn----nmlz65aub; ; ;  # ᭄.᮪-≮≠
+\u1B44.\u1BAA-≮≠; ; [V6]; xn--1uf.xn----nmlz65aub; ; ;  # ᭄.᮪-≮≠
+\u1B44.\u1BAA-<\u0338=\u0338; \u1B44.\u1BAA-≮≠; [V6]; xn--1uf.xn----nmlz65aub; ; ;  # ᭄.᮪-≮≠
+xn--1uf.xn----nmlz65aub; \u1B44.\u1BAA-≮≠; [V6]; xn--1uf.xn----nmlz65aub; ; ;  # ᭄.᮪-≮≠
+\u1BF3Ⴑ\u115F．𑄴Ⅎ; \u1BF3ⴑ.𑄴ⅎ; [V6]; xn--1zf224e.xn--73g3065g; ; ;  # ᯳ⴑ.𑄴ⅎ
+\u1BF3Ⴑ\u115F.𑄴Ⅎ; \u1BF3ⴑ.𑄴ⅎ; [V6]; xn--1zf224e.xn--73g3065g; ; ;  # ᯳ⴑ.𑄴ⅎ
+\u1BF3ⴑ\u115F.𑄴ⅎ; \u1BF3ⴑ.𑄴ⅎ; [V6]; xn--1zf224e.xn--73g3065g; ; ;  # ᯳ⴑ.𑄴ⅎ
+\u1BF3Ⴑ\u115F.𑄴ⅎ; \u1BF3ⴑ.𑄴ⅎ; [V6]; xn--1zf224e.xn--73g3065g; ; ;  # ᯳ⴑ.𑄴ⅎ
+xn--1zf224e.xn--73g3065g; \u1BF3ⴑ.𑄴ⅎ; [V6]; xn--1zf224e.xn--73g3065g; ; ;  # ᯳ⴑ.𑄴ⅎ
+\u1BF3ⴑ\u115F．𑄴ⅎ; \u1BF3ⴑ.𑄴ⅎ; [V6]; xn--1zf224e.xn--73g3065g; ; ;  # ᯳ⴑ.𑄴ⅎ
+\u1BF3Ⴑ\u115F．𑄴ⅎ; \u1BF3ⴑ.𑄴ⅎ; [V6]; xn--1zf224e.xn--73g3065g; ; ;  # ᯳ⴑ.𑄴ⅎ
+xn--pnd26a55x.xn--73g3065g; \u1BF3Ⴑ\u115F.𑄴ⅎ; [V6, V7]; xn--pnd26a55x.xn--73g3065g; ; ;  # ᯳Ⴑ.𑄴ⅎ
+xn--osd925cvyn.xn--73g3065g; \u1BF3ⴑ\u115F.𑄴ⅎ; [V6, V7]; xn--osd925cvyn.xn--73g3065g; ; ;  # ᯳ⴑ.𑄴ⅎ
+xn--pnd26a55x.xn--f3g7465g; \u1BF3Ⴑ\u115F.𑄴Ⅎ; [V6, V7]; xn--pnd26a55x.xn--f3g7465g; ; ;  # ᯳Ⴑ.𑄴Ⅎ
+𜉆。Ⴃ𐴣𐹹똯; 𜉆.ⴃ𐴣𐹹똯; [B5, V7]; xn--187g.xn--ukjy205b8rscdeb; ; ;  # .ⴃ𐴣𐹹똯
+𜉆。Ⴃ𐴣𐹹똯; 𜉆.ⴃ𐴣𐹹똯; [B5, V7]; xn--187g.xn--ukjy205b8rscdeb; ; ;  # .ⴃ𐴣𐹹똯
+𜉆。ⴃ𐴣𐹹똯; 𜉆.ⴃ𐴣𐹹똯; [B5, V7]; xn--187g.xn--ukjy205b8rscdeb; ; ;  # .ⴃ𐴣𐹹똯
+𜉆。ⴃ𐴣𐹹똯; 𜉆.ⴃ𐴣𐹹똯; [B5, V7]; xn--187g.xn--ukjy205b8rscdeb; ; ;  # .ⴃ𐴣𐹹똯
+xn--187g.xn--ukjy205b8rscdeb; 𜉆.ⴃ𐴣𐹹똯; [B5, V7]; xn--187g.xn--ukjy205b8rscdeb; ; ;  # .ⴃ𐴣𐹹똯
+xn--187g.xn--bnd4785f8r8bdeb; 𜉆.Ⴃ𐴣𐹹똯; [B5, V7]; xn--187g.xn--bnd4785f8r8bdeb; ; ;  # .Ⴃ𐴣𐹹똯
+𐫀｡⳻󠙾󠄷\u3164; 𐫀.⳻󠙾; [B1, V7]; xn--pw9c.xn--mkjw9654i; ; ;  # 𐫀.⳻
+𐫀。⳻󠙾󠄷\u1160; 𐫀.⳻󠙾; [B1, V7]; xn--pw9c.xn--mkjw9654i; ; ;  # 𐫀.⳻
+xn--pw9c.xn--mkjw9654i; 𐫀.⳻󠙾; [B1, V7]; xn--pw9c.xn--mkjw9654i; ; ;  # 𐫀.⳻
+xn--pw9c.xn--psd742lxt32w; 𐫀.⳻󠙾\u1160; [B1, V7]; xn--pw9c.xn--psd742lxt32w; ; ;  # 𐫀.⳻
+xn--pw9c.xn--mkj83l4v899a; 𐫀.⳻󠙾\u3164; [B1, V7]; xn--pw9c.xn--mkj83l4v899a; ; ;  # 𐫀.⳻
+\u079A⾇．\u071E-𐋰; \u079A舛.\u071E-𐋰; [B2, B3]; xn--7qb6383d.xn----20c3154q; ; ;  # ޚ舛.ܞ-𐋰
+\u079A舛.\u071E-𐋰; ; [B2, B3]; xn--7qb6383d.xn----20c3154q; ; ;  # ޚ舛.ܞ-𐋰
+xn--7qb6383d.xn----20c3154q; \u079A舛.\u071E-𐋰; [B2, B3]; xn--7qb6383d.xn----20c3154q; ; ;  # ޚ舛.ܞ-𐋰
+Ⴉ猕󹛫≮．︒; ⴉ猕󹛫≮.︒; [V7]; xn--gdh892bbz0d5438s.xn--y86c; ; ;  # ⴉ猕≮.︒
+Ⴉ猕󹛫<\u0338．︒; ⴉ猕󹛫≮.︒; [V7]; xn--gdh892bbz0d5438s.xn--y86c; ; ;  # ⴉ猕≮.︒
+Ⴉ猕󹛫≮.。; ⴉ猕󹛫≮..; [V7, X4_2]; xn--gdh892bbz0d5438s..; [V7, A4_2]; ;  # ⴉ猕≮..
+Ⴉ猕󹛫<\u0338.。; ⴉ猕󹛫≮..; [V7, X4_2]; xn--gdh892bbz0d5438s..; [V7, A4_2]; ;  # ⴉ猕≮..
+ⴉ猕󹛫<\u0338.。; ⴉ猕󹛫≮..; [V7, X4_2]; xn--gdh892bbz0d5438s..; [V7, A4_2]; ;  # ⴉ猕≮..
+ⴉ猕󹛫≮.。; ⴉ猕󹛫≮..; [V7, X4_2]; xn--gdh892bbz0d5438s..; [V7, A4_2]; ;  # ⴉ猕≮..
+xn--gdh892bbz0d5438s..; ⴉ猕󹛫≮..; [V7, X4_2]; xn--gdh892bbz0d5438s..; [V7, A4_2]; ;  # ⴉ猕≮..
+ⴉ猕󹛫<\u0338．︒; ⴉ猕󹛫≮.︒; [V7]; xn--gdh892bbz0d5438s.xn--y86c; ; ;  # ⴉ猕≮.︒
+ⴉ猕󹛫≮．︒; ⴉ猕󹛫≮.︒; [V7]; xn--gdh892bbz0d5438s.xn--y86c; ; ;  # ⴉ猕≮.︒
+xn--gdh892bbz0d5438s.xn--y86c; ⴉ猕󹛫≮.︒; [V7]; xn--gdh892bbz0d5438s.xn--y86c; ; ;  # ⴉ猕≮.︒
+xn--hnd212gz32d54x5r..; Ⴉ猕󹛫≮..; [V7, X4_2]; xn--hnd212gz32d54x5r..; [V7, A4_2]; ;  # Ⴉ猕≮..
+xn--hnd212gz32d54x5r.xn--y86c; Ⴉ猕󹛫≮.︒; [V7]; xn--hnd212gz32d54x5r.xn--y86c; ; ;  # Ⴉ猕≮.︒
+🏮｡\u062B鳳\u07E2󠅉; 🏮.\u062B鳳\u07E2; [B1, B2]; xn--8m8h.xn--qgb29f6z90a; ; ;  # 🏮.ث鳳ߢ
+🏮。\u062B鳳\u07E2󠅉; 🏮.\u062B鳳\u07E2; [B1, B2]; xn--8m8h.xn--qgb29f6z90a; ; ;  # 🏮.ث鳳ߢ
+xn--8m8h.xn--qgb29f6z90a; 🏮.\u062B鳳\u07E2; [B1, B2]; xn--8m8h.xn--qgb29f6z90a; ; ;  # 🏮.ث鳳ߢ
+\u200D𐹶。ß; \u200D𐹶.ß; [B1, C2]; xn--1ug9105g.xn--zca; ; xn--uo0d.ss; [B1] # 𐹶.ß
+\u200D𐹶。SS; \u200D𐹶.ss; [B1, C2]; xn--1ug9105g.ss; ; xn--uo0d.ss; [B1] # 𐹶.ss
+\u200D𐹶。ss; \u200D𐹶.ss; [B1, C2]; xn--1ug9105g.ss; ; xn--uo0d.ss; [B1] # 𐹶.ss
+\u200D𐹶。Ss; \u200D𐹶.ss; [B1, C2]; xn--1ug9105g.ss; ; xn--uo0d.ss; [B1] # 𐹶.ss
+xn--uo0d.ss; 𐹶.ss; [B1]; xn--uo0d.ss; ; ;  # 𐹶.ss
+xn--1ug9105g.ss; \u200D𐹶.ss; [B1, C2]; xn--1ug9105g.ss; ; ;  # 𐹶.ss
+xn--1ug9105g.xn--zca; \u200D𐹶.ß; [B1, C2]; xn--1ug9105g.xn--zca; ; ;  # 𐹶.ß
+Å둄-．\u200C; å둄-.\u200C; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3, A4_2] # å둄-.
+A\u030A둄-．\u200C; å둄-.\u200C; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3, A4_2] # å둄-.
+Å둄-.\u200C; å둄-.\u200C; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3, A4_2] # å둄-.
+A\u030A둄-.\u200C; å둄-.\u200C; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3, A4_2] # å둄-.
+a\u030A둄-.\u200C; å둄-.\u200C; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3, A4_2] # å둄-.
+å둄-.\u200C; ; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3, A4_2] # å둄-.
+xn----1fa1788k.; å둄-.; [V3]; xn----1fa1788k.; [V3, A4_2]; ;  # å둄-.
+xn----1fa1788k.xn--0ug; å둄-.\u200C; [C1, V3]; xn----1fa1788k.xn--0ug; ; ;  # å둄-.
+a\u030A둄-．\u200C; å둄-.\u200C; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3, A4_2] # å둄-.
+å둄-．\u200C; å둄-.\u200C; [C1, V3]; xn----1fa1788k.xn--0ug; ; xn----1fa1788k.; [V3, A4_2] # å둄-.
+\u3099򬎑\u1DD7𞤀.򱲢-\u0953; \u3099򬎑\u1DD7𞤢.򱲢-\u0953; [B1, B6, V6, V7]; xn--veg121fwg63altj9d.xn----eyd92688s; ; ;  # ゙ᷗ𞤢.-॓
+\u3099򬎑\u1DD7𞤢.򱲢-\u0953; ; [B1, B6, V6, V7]; xn--veg121fwg63altj9d.xn----eyd92688s; ; ;  # ゙ᷗ𞤢.-॓
+xn--veg121fwg63altj9d.xn----eyd92688s; \u3099򬎑\u1DD7𞤢.򱲢-\u0953; [B1, B6, V6, V7]; xn--veg121fwg63altj9d.xn----eyd92688s; ; ;  # ゙ᷗ𞤢.-॓
+ς.ß񴱄\u06DD\u2D7F; ; [B5, B6, V7]; xn--3xa.xn--zca281az71b8x73m; ; xn--4xa.xn--ss-y8d4760biv60n;  # ς.ß⵿
+Σ.SS񴱄\u06DD\u2D7F; σ.ss񴱄\u06DD\u2D7F; [B5, B6, V7]; xn--4xa.xn--ss-y8d4760biv60n; ; ;  # σ.ss⵿
+σ.ss񴱄\u06DD\u2D7F; ; [B5, B6, V7]; xn--4xa.xn--ss-y8d4760biv60n; ; ;  # σ.ss⵿
+Σ.ss񴱄\u06DD\u2D7F; σ.ss񴱄\u06DD\u2D7F; [B5, B6, V7]; xn--4xa.xn--ss-y8d4760biv60n; ; ;  # σ.ss⵿
+xn--4xa.xn--ss-y8d4760biv60n; σ.ss񴱄\u06DD\u2D7F; [B5, B6, V7]; xn--4xa.xn--ss-y8d4760biv60n; ; ;  # σ.ss⵿
+Σ.ß񴱄\u06DD\u2D7F; σ.ß񴱄\u06DD\u2D7F; [B5, B6, V7]; xn--4xa.xn--zca281az71b8x73m; ; xn--4xa.xn--ss-y8d4760biv60n;  # σ.ß⵿
+σ.ß񴱄\u06DD\u2D7F; ; [B5, B6, V7]; xn--4xa.xn--zca281az71b8x73m; ; xn--4xa.xn--ss-y8d4760biv60n;  # σ.ß⵿
+xn--4xa.xn--zca281az71b8x73m; σ.ß񴱄\u06DD\u2D7F; [B5, B6, V7]; xn--4xa.xn--zca281az71b8x73m; ; ;  # σ.ß⵿
+xn--3xa.xn--zca281az71b8x73m; ς.ß񴱄\u06DD\u2D7F; [B5, B6, V7]; xn--3xa.xn--zca281az71b8x73m; ; ;  # ς.ß⵿
+ꡀ𞀟｡\u066B\u0599; ꡀ𞀟.\u066B\u0599; [B1]; xn--8b9a1720d.xn--kcb33b; ; ;  # ꡀ𞀟.٫֙
+ꡀ𞀟。\u066B\u0599; ꡀ𞀟.\u066B\u0599; [B1]; xn--8b9a1720d.xn--kcb33b; ; ;  # ꡀ𞀟.٫֙
+xn--8b9a1720d.xn--kcb33b; ꡀ𞀟.\u066B\u0599; [B1]; xn--8b9a1720d.xn--kcb33b; ; ;  # ꡀ𞀟.٫֙
+򈛉\u200C\u08A9｡⧅񘘡-𐭡; 򈛉\u200C\u08A9.⧅񘘡-𐭡; [B1, B5, B6, C1, V7]; xn--yyb780jll63m.xn----zir1232guu71b; ; xn--yyb56242i.xn----zir1232guu71b; [B1, B5, B6, V7] # ࢩ.⧅-𐭡
+򈛉\u200C\u08A9。⧅񘘡-𐭡; 򈛉\u200C\u08A9.⧅񘘡-𐭡; [B1, B5, B6, C1, V7]; xn--yyb780jll63m.xn----zir1232guu71b; ; xn--yyb56242i.xn----zir1232guu71b; [B1, B5, B6, V7] # ࢩ.⧅-𐭡
+xn--yyb56242i.xn----zir1232guu71b; 򈛉\u08A9.⧅񘘡-𐭡; [B1, B5, B6, V7]; xn--yyb56242i.xn----zir1232guu71b; ; ;  # ࢩ.⧅-𐭡
+xn--yyb780jll63m.xn----zir1232guu71b; 򈛉\u200C\u08A9.⧅񘘡-𐭡; [B1, B5, B6, C1, V7]; xn--yyb780jll63m.xn----zir1232guu71b; ; ;  # ࢩ.⧅-𐭡
+룱\u200D𰍨\u200C。𝨖︒; 룱\u200D𰍨\u200C.𝨖︒; [C1, C2, V6, V7]; xn--0ugb3358ili2v.xn--y86cl899a; ; xn--ct2b0738h.xn--y86cl899a; [V6, V7] # 룱𰍨.𝨖︒
+룱\u200D𰍨\u200C。𝨖︒; 룱\u200D𰍨\u200C.𝨖︒; [C1, C2, V6, V7]; xn--0ugb3358ili2v.xn--y86cl899a; ; xn--ct2b0738h.xn--y86cl899a; [V6, V7] # 룱𰍨.𝨖︒
+룱\u200D𰍨\u200C。𝨖。; 룱\u200D𰍨\u200C.𝨖.; [C1, C2, V6]; xn--0ugb3358ili2v.xn--772h.; [C1, C2, V6, A4_2]; xn--ct2b0738h.xn--772h.; [V6, A4_2] # 룱𰍨.𝨖.
+룱\u200D𰍨\u200C。𝨖。; 룱\u200D𰍨\u200C.𝨖.; [C1, C2, V6]; xn--0ugb3358ili2v.xn--772h.; [C1, C2, V6, A4_2]; xn--ct2b0738h.xn--772h.; [V6, A4_2] # 룱𰍨.𝨖.
+xn--ct2b0738h.xn--772h.; 룱𰍨.𝨖.; [V6]; xn--ct2b0738h.xn--772h.; [V6, A4_2]; ;  # 룱𰍨.𝨖.
+xn--0ugb3358ili2v.xn--772h.; 룱\u200D𰍨\u200C.𝨖.; [C1, C2, V6]; xn--0ugb3358ili2v.xn--772h.; [C1, C2, V6, A4_2]; ;  # 룱𰍨.𝨖.
+xn--ct2b0738h.xn--y86cl899a; 룱𰍨.𝨖︒; [V6, V7]; xn--ct2b0738h.xn--y86cl899a; ; ;  # 룱𰍨.𝨖︒
+xn--0ugb3358ili2v.xn--y86cl899a; 룱\u200D𰍨\u200C.𝨖︒; [C1, C2, V6, V7]; xn--0ugb3358ili2v.xn--y86cl899a; ; ;  # 룱𰍨.𝨖︒
+🄄．\u1CDC⒈ß; 3,.\u1CDC⒈ß; [V6, V7, U1]; 3,.xn--zca344lmif; ; 3,.xn--ss-k1r094b;  # 3,.᳜⒈ß
+3,.\u1CDC1.ß; ; [V6, U1]; 3,.xn--1-43l.xn--zca; ; 3,.xn--1-43l.ss;  # 3,.᳜1.ß
+3,.\u1CDC1.SS; 3,.\u1CDC1.ss; [V6, U1]; 3,.xn--1-43l.ss; ; ;  # 3,.᳜1.ss
+3,.\u1CDC1.ss; ; [V6, U1]; 3,.xn--1-43l.ss; ; ;  # 3,.᳜1.ss
+3,.\u1CDC1.Ss; 3,.\u1CDC1.ss; [V6, U1]; 3,.xn--1-43l.ss; ; ;  # 3,.᳜1.ss
+3,.xn--1-43l.ss; 3,.\u1CDC1.ss; [V6, U1]; 3,.xn--1-43l.ss; ; ;  # 3,.᳜1.ss
+3,.xn--1-43l.xn--zca; 3,.\u1CDC1.ß; [V6, U1]; 3,.xn--1-43l.xn--zca; ; ;  # 3,.᳜1.ß
+🄄．\u1CDC⒈SS; 3,.\u1CDC⒈ss; [V6, V7, U1]; 3,.xn--ss-k1r094b; ; ;  # 3,.᳜⒈ss
+🄄．\u1CDC⒈ss; 3,.\u1CDC⒈ss; [V6, V7, U1]; 3,.xn--ss-k1r094b; ; ;  # 3,.᳜⒈ss
+🄄．\u1CDC⒈Ss; 3,.\u1CDC⒈ss; [V6, V7, U1]; 3,.xn--ss-k1r094b; ; ;  # 3,.᳜⒈ss
+3,.xn--ss-k1r094b; 3,.\u1CDC⒈ss; [V6, V7, U1]; 3,.xn--ss-k1r094b; ; ;  # 3,.᳜⒈ss
+3,.xn--zca344lmif; 3,.\u1CDC⒈ß; [V6, V7, U1]; 3,.xn--zca344lmif; ; ;  # 3,.᳜⒈ß
+xn--x07h.xn--ss-k1r094b; 🄄.\u1CDC⒈ss; [V6, V7]; xn--x07h.xn--ss-k1r094b; ; ;  # 🄄.᳜⒈ss
+xn--x07h.xn--zca344lmif; 🄄.\u1CDC⒈ß; [V6, V7]; xn--x07h.xn--zca344lmif; ; ;  # 🄄.᳜⒈ß
+񇌍\u2D7F｡𞼓򡄨𑐺; 񇌍\u2D7F.𞼓򡄨𑐺; [B2, B3, V7]; xn--eoj16016a.xn--0v1d3848a3lr0d; ; ;  # ⵿.𑐺
+񇌍\u2D7F。𞼓򡄨𑐺; 񇌍\u2D7F.𞼓򡄨𑐺; [B2, B3, V7]; xn--eoj16016a.xn--0v1d3848a3lr0d; ; ;  # ⵿.𑐺
+xn--eoj16016a.xn--0v1d3848a3lr0d; 񇌍\u2D7F.𞼓򡄨𑐺; [B2, B3, V7]; xn--eoj16016a.xn--0v1d3848a3lr0d; ; ;  # ⵿.𑐺
+\u1DFD\u103A\u094D．≠\u200D㇛; \u103A\u094D\u1DFD.≠\u200D㇛; [C2, V6]; xn--n3b956a9zm.xn--1ug63gz5w; ; xn--n3b956a9zm.xn--1ch912d; [V6] # ်्᷽.≠㇛
+\u103A\u094D\u1DFD．≠\u200D㇛; \u103A\u094D\u1DFD.≠\u200D㇛; [C2, V6]; xn--n3b956a9zm.xn--1ug63gz5w; ; xn--n3b956a9zm.xn--1ch912d; [V6] # ်्᷽.≠㇛
+\u103A\u094D\u1DFD．=\u0338\u200D㇛; \u103A\u094D\u1DFD.≠\u200D㇛; [C2, V6]; xn--n3b956a9zm.xn--1ug63gz5w; ; xn--n3b956a9zm.xn--1ch912d; [V6] # ်्᷽.≠㇛
+\u103A\u094D\u1DFD.≠\u200D㇛; ; [C2, V6]; xn--n3b956a9zm.xn--1ug63gz5w; ; xn--n3b956a9zm.xn--1ch912d; [V6] # ်्᷽.≠㇛
+\u103A\u094D\u1DFD.=\u0338\u200D㇛; \u103A\u094D\u1DFD.≠\u200D㇛; [C2, V6]; xn--n3b956a9zm.xn--1ug63gz5w; ; xn--n3b956a9zm.xn--1ch912d; [V6] # ်्᷽.≠㇛
+xn--n3b956a9zm.xn--1ch912d; \u103A\u094D\u1DFD.≠㇛; [V6]; xn--n3b956a9zm.xn--1ch912d; ; ;  # ်्᷽.≠㇛
+xn--n3b956a9zm.xn--1ug63gz5w; \u103A\u094D\u1DFD.≠\u200D㇛; [C2, V6]; xn--n3b956a9zm.xn--1ug63gz5w; ; ;  # ်्᷽.≠㇛
+Ⴁ𐋨娤.\u200D\u033C\u0662𑖿; ⴁ𐋨娤.\u200D\u033C\u0662𑖿; [B1, C2]; xn--skjw75lg29h.xn--9ta62ngt6aou8t; ; xn--skjw75lg29h.xn--9ta62nrv36a; [B1, V6] # ⴁ𐋨娤.̼٢𑖿
+ⴁ𐋨娤.\u200D\u033C\u0662𑖿; ; [B1, C2]; xn--skjw75lg29h.xn--9ta62ngt6aou8t; ; xn--skjw75lg29h.xn--9ta62nrv36a; [B1, V6] # ⴁ𐋨娤.̼٢𑖿
+xn--skjw75lg29h.xn--9ta62nrv36a; ⴁ𐋨娤.\u033C\u0662𑖿; [B1, V6]; xn--skjw75lg29h.xn--9ta62nrv36a; ; ;  # ⴁ𐋨娤.̼٢𑖿
+xn--skjw75lg29h.xn--9ta62ngt6aou8t; ⴁ𐋨娤.\u200D\u033C\u0662𑖿; [B1, C2]; xn--skjw75lg29h.xn--9ta62ngt6aou8t; ; ;  # ⴁ𐋨娤.̼٢𑖿
+xn--8md2578ag21g.xn--9ta62nrv36a; Ⴁ𐋨娤.\u033C\u0662𑖿; [B1, V6, V7]; xn--8md2578ag21g.xn--9ta62nrv36a; ; ;  # Ⴁ𐋨娤.̼٢𑖿
+xn--8md2578ag21g.xn--9ta62ngt6aou8t; Ⴁ𐋨娤.\u200D\u033C\u0662𑖿; [B1, C2, V7]; xn--8md2578ag21g.xn--9ta62ngt6aou8t; ; ;  # Ⴁ𐋨娤.̼٢𑖿
+🄀Ⴄ\u0669\u0820。⒈\u0FB6ß; 🄀ⴄ\u0669\u0820.⒈\u0FB6ß; [B1, V7]; xn--iib29fp25e0219a.xn--zca117e3vp; ; xn--iib29fp25e0219a.xn--ss-1sj588o;  # 🄀ⴄ٩ࠠ.⒈ྶß
+0.Ⴄ\u0669\u0820。1.\u0FB6ß; 0.ⴄ\u0669\u0820.1.\u0FB6ß; [B1, B5, B6, V6]; 0.xn--iib29fp25e.1.xn--zca117e; ; 0.xn--iib29fp25e.1.xn--ss-1sj;  # 0.ⴄ٩ࠠ.1.ྶß
+0.ⴄ\u0669\u0820。1.\u0FB6ß; 0.ⴄ\u0669\u0820.1.\u0FB6ß; [B1, B5, B6, V6]; 0.xn--iib29fp25e.1.xn--zca117e; ; 0.xn--iib29fp25e.1.xn--ss-1sj;  # 0.ⴄ٩ࠠ.1.ྶß
+0.Ⴄ\u0669\u0820。1.\u0FB6SS; 0.ⴄ\u0669\u0820.1.\u0FB6ss; [B1, B5, B6, V6]; 0.xn--iib29fp25e.1.xn--ss-1sj; ; ;  # 0.ⴄ٩ࠠ.1.ྶss
+0.ⴄ\u0669\u0820。1.\u0FB6ss; 0.ⴄ\u0669\u0820.1.\u0FB6ss; [B1, B5, B6, V6]; 0.xn--iib29fp25e.1.xn--ss-1sj; ; ;  # 0.ⴄ٩ࠠ.1.ྶss
+0.Ⴄ\u0669\u0820。1.\u0FB6Ss; 0.ⴄ\u0669\u0820.1.\u0FB6ss; [B1, B5, B6, V6]; 0.xn--iib29fp25e.1.xn--ss-1sj; ; ;  # 0.ⴄ٩ࠠ.1.ྶss
+0.xn--iib29fp25e.1.xn--ss-1sj; 0.ⴄ\u0669\u0820.1.\u0FB6ss; [B1, B5, B6, V6]; 0.xn--iib29fp25e.1.xn--ss-1sj; ; ;  # 0.ⴄ٩ࠠ.1.ྶss
+0.xn--iib29fp25e.1.xn--zca117e; 0.ⴄ\u0669\u0820.1.\u0FB6ß; [B1, B5, B6, V6]; 0.xn--iib29fp25e.1.xn--zca117e; ; ;  # 0.ⴄ٩ࠠ.1.ྶß
+🄀ⴄ\u0669\u0820。⒈\u0FB6ß; 🄀ⴄ\u0669\u0820.⒈\u0FB6ß; [B1, V7]; xn--iib29fp25e0219a.xn--zca117e3vp; ; xn--iib29fp25e0219a.xn--ss-1sj588o;  # 🄀ⴄ٩ࠠ.⒈ྶß
+🄀Ⴄ\u0669\u0820。⒈\u0FB6SS; 🄀ⴄ\u0669\u0820.⒈\u0FB6ss; [B1, V7]; xn--iib29fp25e0219a.xn--ss-1sj588o; ; ;  # 🄀ⴄ٩ࠠ.⒈ྶss
+🄀ⴄ\u0669\u0820。⒈\u0FB6ss; 🄀ⴄ\u0669\u0820.⒈\u0FB6ss; [B1, V7]; xn--iib29fp25e0219a.xn--ss-1sj588o; ; ;  # 🄀ⴄ٩ࠠ.⒈ྶss
+🄀Ⴄ\u0669\u0820。⒈\u0FB6Ss; 🄀ⴄ\u0669\u0820.⒈\u0FB6ss; [B1, V7]; xn--iib29fp25e0219a.xn--ss-1sj588o; ; ;  # 🄀ⴄ٩ࠠ.⒈ྶss
+xn--iib29fp25e0219a.xn--ss-1sj588o; 🄀ⴄ\u0669\u0820.⒈\u0FB6ss; [B1, V7]; xn--iib29fp25e0219a.xn--ss-1sj588o; ; ;  # 🄀ⴄ٩ࠠ.⒈ྶss
+xn--iib29fp25e0219a.xn--zca117e3vp; 🄀ⴄ\u0669\u0820.⒈\u0FB6ß; [B1, V7]; xn--iib29fp25e0219a.xn--zca117e3vp; ; ;  # 🄀ⴄ٩ࠠ.⒈ྶß
+0.xn--iib29f26o.1.xn--ss-1sj; 0.Ⴄ\u0669\u0820.1.\u0FB6ss; [B1, B5, B6, V6, V7]; 0.xn--iib29f26o.1.xn--ss-1sj; ; ;  # 0.Ⴄ٩ࠠ.1.ྶss
+0.xn--iib29f26o.1.xn--zca117e; 0.Ⴄ\u0669\u0820.1.\u0FB6ß; [B1, B5, B6, V6, V7]; 0.xn--iib29f26o.1.xn--zca117e; ; ;  # 0.Ⴄ٩ࠠ.1.ྶß
+xn--iib29f26o6n43c.xn--ss-1sj588o; 🄀Ⴄ\u0669\u0820.⒈\u0FB6ss; [B1, V7]; xn--iib29f26o6n43c.xn--ss-1sj588o; ; ;  # 🄀Ⴄ٩ࠠ.⒈ྶss
+xn--iib29f26o6n43c.xn--zca117e3vp; 🄀Ⴄ\u0669\u0820.⒈\u0FB6ß; [B1, V7]; xn--iib29f26o6n43c.xn--zca117e3vp; ; ;  # 🄀Ⴄ٩ࠠ.⒈ྶß
+≠.\u200C-\u066B; ; [B1, C1]; xn--1ch.xn----vqc597q; ; xn--1ch.xn----vqc; [B1, V3] # ≠.-٫
+=\u0338.\u200C-\u066B; ≠.\u200C-\u066B; [B1, C1]; xn--1ch.xn----vqc597q; ; xn--1ch.xn----vqc; [B1, V3] # ≠.-٫
+xn--1ch.xn----vqc; ≠.-\u066B; [B1, V3]; xn--1ch.xn----vqc; ; ;  # ≠.-٫
+xn--1ch.xn----vqc597q; ≠.\u200C-\u066B; [B1, C1]; xn--1ch.xn----vqc597q; ; ;  # ≠.-٫
+\u0660۱｡󠳶𞠁\u0665; \u0660۱.󠳶𞠁\u0665; [B1, V7]; xn--8hb40a.xn--eib7967vner3e; ; ;  # ٠۱.𞠁٥
+\u0660۱。󠳶𞠁\u0665; \u0660۱.󠳶𞠁\u0665; [B1, V7]; xn--8hb40a.xn--eib7967vner3e; ; ;  # ٠۱.𞠁٥
+xn--8hb40a.xn--eib7967vner3e; \u0660۱.󠳶𞠁\u0665; [B1, V7]; xn--8hb40a.xn--eib7967vner3e; ; ;  # ٠۱.𞠁٥
+\u200C\u0663⒖。󱅉𽷛\u1BF3; \u200C\u0663⒖.󱅉𽷛\u1BF3; [B1, C1, V7]; xn--cib152kwgd.xn--1zf13512buy41d; ; xn--cib675m.xn--1zf13512buy41d; [B1, V7] # ٣⒖.᯳
+\u200C\u066315.。󱅉𽷛\u1BF3; \u200C\u066315..󱅉𽷛\u1BF3; [B1, C1, V7, X4_2]; xn--15-gyd983x..xn--1zf13512buy41d; [B1, C1, V7, A4_2]; xn--15-gyd..xn--1zf13512buy41d; [B1, V7, A4_2] # ٣15..᯳
+xn--15-gyd..xn--1zf13512buy41d; \u066315..󱅉𽷛\u1BF3; [B1, V7, X4_2]; xn--15-gyd..xn--1zf13512buy41d; [B1, V7, A4_2]; ;  # ٣15..᯳
+xn--15-gyd983x..xn--1zf13512buy41d; \u200C\u066315..󱅉𽷛\u1BF3; [B1, C1, V7, X4_2]; xn--15-gyd983x..xn--1zf13512buy41d; [B1, C1, V7, A4_2]; ;  # ٣15..᯳
+xn--cib675m.xn--1zf13512buy41d; \u0663⒖.󱅉𽷛\u1BF3; [B1, V7]; xn--cib675m.xn--1zf13512buy41d; ; ;  # ٣⒖.᯳
+xn--cib152kwgd.xn--1zf13512buy41d; \u200C\u0663⒖.󱅉𽷛\u1BF3; [B1, C1, V7]; xn--cib152kwgd.xn--1zf13512buy41d; ; ;  # ٣⒖.᯳
+\u1BF3.-逋񳦭󙙮; ; [V3, V6, V7]; xn--1zf.xn----483d46987byr50b; ; ;  # ᯳.-逋
+xn--1zf.xn----483d46987byr50b; \u1BF3.-逋񳦭󙙮; [V3, V6, V7]; xn--1zf.xn----483d46987byr50b; ; ;  # ᯳.-逋
+\u0756。\u3164\u200Dς; \u0756.\u200Dς; [B1, C2]; xn--9ob.xn--3xa995l; ; xn--9ob.xn--4xa; [] # ݖ.ς
+\u0756。\u1160\u200Dς; \u0756.\u200Dς; [B1, C2]; xn--9ob.xn--3xa995l; ; xn--9ob.xn--4xa; [] # ݖ.ς
+\u0756。\u1160\u200DΣ; \u0756.\u200Dσ; [B1, C2]; xn--9ob.xn--4xa795l; ; xn--9ob.xn--4xa; [] # ݖ.σ
+\u0756。\u1160\u200Dσ; \u0756.\u200Dσ; [B1, C2]; xn--9ob.xn--4xa795l; ; xn--9ob.xn--4xa; [] # ݖ.σ
+xn--9ob.xn--4xa; \u0756.σ; ; xn--9ob.xn--4xa; ; ;  # ݖ.σ
+\u0756.σ; ; ; xn--9ob.xn--4xa; ; ;  # ݖ.σ
+\u0756.Σ; \u0756.σ; ; xn--9ob.xn--4xa; ; ;  # ݖ.σ
+xn--9ob.xn--4xa795l; \u0756.\u200Dσ; [B1, C2]; xn--9ob.xn--4xa795l; ; ;  # ݖ.σ
+xn--9ob.xn--3xa995l; \u0756.\u200Dς; [B1, C2]; xn--9ob.xn--3xa995l; ; ;  # ݖ.ς
+\u0756。\u3164\u200DΣ; \u0756.\u200Dσ; [B1, C2]; xn--9ob.xn--4xa795l; ; xn--9ob.xn--4xa; [] # ݖ.σ
+\u0756。\u3164\u200Dσ; \u0756.\u200Dσ; [B1, C2]; xn--9ob.xn--4xa795l; ; xn--9ob.xn--4xa; [] # ݖ.σ
+xn--9ob.xn--4xa380e; \u0756.\u1160σ; [V7]; xn--9ob.xn--4xa380e; ; ;  # ݖ.σ
+xn--9ob.xn--4xa380ebol; \u0756.\u1160\u200Dσ; [C2, V7]; xn--9ob.xn--4xa380ebol; ; ;  # ݖ.σ
+xn--9ob.xn--3xa580ebol; \u0756.\u1160\u200Dς; [C2, V7]; xn--9ob.xn--3xa580ebol; ; ;  # ݖ.ς
+xn--9ob.xn--4xa574u; \u0756.\u3164σ; [V7]; xn--9ob.xn--4xa574u; ; ;  # ݖ.σ
+xn--9ob.xn--4xa795lq2l; \u0756.\u3164\u200Dσ; [C2, V7]; xn--9ob.xn--4xa795lq2l; ; ;  # ݖ.σ
+xn--9ob.xn--3xa995lq2l; \u0756.\u3164\u200Dς; [C2, V7]; xn--9ob.xn--3xa995lq2l; ; ;  # ݖ.ς
+ᡆႣ｡󞢧\u0315\u200D\u200D; ᡆⴃ.󞢧\u0315\u200D\u200D; [C2, V7]; xn--57e237h.xn--5sa649la993427a; ; xn--57e237h.xn--5sa98523p; [V7] # ᡆⴃ.̕
+ᡆႣ。󞢧\u0315\u200D\u200D; ᡆⴃ.󞢧\u0315\u200D\u200D; [C2, V7]; xn--57e237h.xn--5sa649la993427a; ; xn--57e237h.xn--5sa98523p; [V7] # ᡆⴃ.̕
+ᡆⴃ。󞢧\u0315\u200D\u200D; ᡆⴃ.󞢧\u0315\u200D\u200D; [C2, V7]; xn--57e237h.xn--5sa649la993427a; ; xn--57e237h.xn--5sa98523p; [V7] # ᡆⴃ.̕
+xn--57e237h.xn--5sa98523p; ᡆⴃ.󞢧\u0315; [V7]; xn--57e237h.xn--5sa98523p; ; ;  # ᡆⴃ.̕
+xn--57e237h.xn--5sa649la993427a; ᡆⴃ.󞢧\u0315\u200D\u200D; [C2, V7]; xn--57e237h.xn--5sa649la993427a; ; ;  # ᡆⴃ.̕
+ᡆⴃ｡󞢧\u0315\u200D\u200D; ᡆⴃ.󞢧\u0315\u200D\u200D; [C2, V7]; xn--57e237h.xn--5sa649la993427a; ; xn--57e237h.xn--5sa98523p; [V7] # ᡆⴃ.̕
+xn--bnd320b.xn--5sa98523p; ᡆႣ.󞢧\u0315; [V7]; xn--bnd320b.xn--5sa98523p; ; ;  # ᡆႣ.̕
+xn--bnd320b.xn--5sa649la993427a; ᡆႣ.󞢧\u0315\u200D\u200D; [C2, V7]; xn--bnd320b.xn--5sa649la993427a; ; ;  # ᡆႣ.̕
+㭄\u200D\u084F𑚵．ς𐮮\u200C\u200D; 㭄\u200D\u084F𑚵.ς𐮮\u200C\u200D; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--3xa895lda6932v; ; xn--ewb302xhu1l.xn--4xa0426k; [B5, B6] # 㭄ࡏ𑚵.ς𐮮
+㭄\u200D\u084F𑚵.ς𐮮\u200C\u200D; ; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--3xa895lda6932v; ; xn--ewb302xhu1l.xn--4xa0426k; [B5, B6] # 㭄ࡏ𑚵.ς𐮮
+㭄\u200D\u084F𑚵.Σ𐮮\u200C\u200D; 㭄\u200D\u084F𑚵.σ𐮮\u200C\u200D; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--4xa695lda6932v; ; xn--ewb302xhu1l.xn--4xa0426k; [B5, B6] # 㭄ࡏ𑚵.σ𐮮
+㭄\u200D\u084F𑚵.σ𐮮\u200C\u200D; ; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--4xa695lda6932v; ; xn--ewb302xhu1l.xn--4xa0426k; [B5, B6] # 㭄ࡏ𑚵.σ𐮮
+xn--ewb302xhu1l.xn--4xa0426k; 㭄\u084F𑚵.σ𐮮; [B5, B6]; xn--ewb302xhu1l.xn--4xa0426k; ; ;  # 㭄ࡏ𑚵.σ𐮮
+xn--ewb962jfitku4r.xn--4xa695lda6932v; 㭄\u200D\u084F𑚵.σ𐮮\u200C\u200D; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--4xa695lda6932v; ; ;  # 㭄ࡏ𑚵.σ𐮮
+xn--ewb962jfitku4r.xn--3xa895lda6932v; 㭄\u200D\u084F𑚵.ς𐮮\u200C\u200D; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--3xa895lda6932v; ; ;  # 㭄ࡏ𑚵.ς𐮮
+㭄\u200D\u084F𑚵．Σ𐮮\u200C\u200D; 㭄\u200D\u084F𑚵.σ𐮮\u200C\u200D; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--4xa695lda6932v; ; xn--ewb302xhu1l.xn--4xa0426k; [B5, B6] # 㭄ࡏ𑚵.σ𐮮
+㭄\u200D\u084F𑚵．σ𐮮\u200C\u200D; 㭄\u200D\u084F𑚵.σ𐮮\u200C\u200D; [B5, B6, C1, C2]; xn--ewb962jfitku4r.xn--4xa695lda6932v; ; xn--ewb302xhu1l.xn--4xa0426k; [B5, B6] # 㭄ࡏ𑚵.σ𐮮
+\u17B5。𞯸ꡀ🄋; .𞯸ꡀ🄋; [B2, B3, V7, X4_2]; .xn--8b9ar252dngd; [B2, B3, V7, A4_2]; ;  # .ꡀ🄋
+.xn--8b9ar252dngd; .𞯸ꡀ🄋; [B2, B3, V7, X4_2]; .xn--8b9ar252dngd; [B2, B3, V7, A4_2]; ;  # .ꡀ🄋
+xn--03e.xn--8b9ar252dngd; \u17B5.𞯸ꡀ🄋; [B1, B2, B3, V6, V7]; xn--03e.xn--8b9ar252dngd; ; ;  # .ꡀ🄋
+󐪺暑．⾑\u0668; 󐪺暑.襾\u0668; [B5, B6, V7]; xn--tlvq3513e.xn--hib9228d; ; ;  # 暑.襾٨
+󐪺暑.襾\u0668; ; [B5, B6, V7]; xn--tlvq3513e.xn--hib9228d; ; ;  # 暑.襾٨
+xn--tlvq3513e.xn--hib9228d; 󐪺暑.襾\u0668; [B5, B6, V7]; xn--tlvq3513e.xn--hib9228d; ; ;  # 暑.襾٨
+󠄚≯ꡢ。\u0891\u1DFF; ≯ꡢ.\u0891\u1DFF; [B1, V7]; xn--hdh7783c.xn--9xb680i; ; ;  # ≯ꡢ.᷿
+󠄚>\u0338ꡢ。\u0891\u1DFF; ≯ꡢ.\u0891\u1DFF; [B1, V7]; xn--hdh7783c.xn--9xb680i; ; ;  # ≯ꡢ.᷿
+xn--hdh7783c.xn--9xb680i; ≯ꡢ.\u0891\u1DFF; [B1, V7]; xn--hdh7783c.xn--9xb680i; ; ;  # ≯ꡢ.᷿
+\uFDC3𮁱\u0B4D𐨿.󐧤Ⴗ; \u0643\u0645\u0645𮁱\u0B4D𐨿.󐧤ⴗ; [B2, B3, V7]; xn--fhbea662czx68a2tju.xn--fljz2846h; ; ;  # كمم𮁱୍𐨿.ⴗ
+\u0643\u0645\u0645𮁱\u0B4D𐨿.󐧤Ⴗ; \u0643\u0645\u0645𮁱\u0B4D𐨿.󐧤ⴗ; [B2, B3, V7]; xn--fhbea662czx68a2tju.xn--fljz2846h; ; ;  # كمم𮁱୍𐨿.ⴗ
+\u0643\u0645\u0645𮁱\u0B4D𐨿.󐧤ⴗ; ; [B2, B3, V7]; xn--fhbea662czx68a2tju.xn--fljz2846h; ; ;  # كمم𮁱୍𐨿.ⴗ
+xn--fhbea662czx68a2tju.xn--fljz2846h; \u0643\u0645\u0645𮁱\u0B4D𐨿.󐧤ⴗ; [B2, B3, V7]; xn--fhbea662czx68a2tju.xn--fljz2846h; ; ;  # كمم𮁱୍𐨿.ⴗ
+\uFDC3𮁱\u0B4D𐨿.󐧤ⴗ; \u0643\u0645\u0645𮁱\u0B4D𐨿.󐧤ⴗ; [B2, B3, V7]; xn--fhbea662czx68a2tju.xn--fljz2846h; ; ;  # كمم𮁱୍𐨿.ⴗ
+xn--fhbea662czx68a2tju.xn--vnd55511o; \u0643\u0645\u0645𮁱\u0B4D𐨿.󐧤Ⴗ; [B2, B3, V7]; xn--fhbea662czx68a2tju.xn--vnd55511o; ; ;  # كمم𮁱୍𐨿.Ⴗ
+𞀨｡\u1B44򡛨𞎇; 𞀨.\u1B44򡛨𞎇; [V6, V7]; xn--mi4h.xn--1uf6843smg20c; ; ;  # 𞀨.᭄
+𞀨。\u1B44򡛨𞎇; 𞀨.\u1B44򡛨𞎇; [V6, V7]; xn--mi4h.xn--1uf6843smg20c; ; ;  # 𞀨.᭄
+xn--mi4h.xn--1uf6843smg20c; 𞀨.\u1B44򡛨𞎇; [V6, V7]; xn--mi4h.xn--1uf6843smg20c; ; ;  # 𞀨.᭄
+󠣼\u200C．𐺰\u200Cᡟ; 󠣼\u200C.𐺰\u200Cᡟ; [B1, B2, B3, C1, V7]; xn--0ug18531l.xn--v8e340bp21t; ; xn--q046e.xn--v8e7227j; [B1, B2, B3, V7] # .𐺰ᡟ
+󠣼\u200C.𐺰\u200Cᡟ; ; [B1, B2, B3, C1, V7]; xn--0ug18531l.xn--v8e340bp21t; ; xn--q046e.xn--v8e7227j; [B1, B2, B3, V7] # .𐺰ᡟ
+xn--q046e.xn--v8e7227j; 󠣼.𐺰ᡟ; [B1, B2, B3, V7]; xn--q046e.xn--v8e7227j; ; ;  # .𐺰ᡟ
+xn--0ug18531l.xn--v8e340bp21t; 󠣼\u200C.𐺰\u200Cᡟ; [B1, B2, B3, C1, V7]; xn--0ug18531l.xn--v8e340bp21t; ; ;  # .𐺰ᡟ
+ᢛ󨅟ß.ጧ; ; [V7]; xn--zca562jc642x.xn--p5d; ; xn--ss-7dp66033t.xn--p5d;  # ᢛß.ጧ
+ᢛ󨅟SS.ጧ; ᢛ󨅟ss.ጧ; [V7]; xn--ss-7dp66033t.xn--p5d; ; ;  # ᢛss.ጧ
+ᢛ󨅟ss.ጧ; ; [V7]; xn--ss-7dp66033t.xn--p5d; ; ;  # ᢛss.ጧ
+ᢛ󨅟Ss.ጧ; ᢛ󨅟ss.ጧ; [V7]; xn--ss-7dp66033t.xn--p5d; ; ;  # ᢛss.ጧ
+xn--ss-7dp66033t.xn--p5d; ᢛ󨅟ss.ጧ; [V7]; xn--ss-7dp66033t.xn--p5d; ; ;  # ᢛss.ጧ
+xn--zca562jc642x.xn--p5d; ᢛ󨅟ß.ጧ; [V7]; xn--zca562jc642x.xn--p5d; ; ;  # ᢛß.ጧ
+⮒\u200C.񒚗\u200C; ; [C1, V7]; xn--0ugx66b.xn--0ugz2871c; ; xn--b9i.xn--5p9y; [V7] # ⮒.
+xn--b9i.xn--5p9y; ⮒.񒚗; [V7]; xn--b9i.xn--5p9y; ; ;  # ⮒.
+xn--0ugx66b.xn--0ugz2871c; ⮒\u200C.񒚗\u200C; [C1, V7]; xn--0ugx66b.xn--0ugz2871c; ; ;  # ⮒.
+𞤂񹞁𐹯。Ⴜ; 𞤤񹞁𐹯.ⴜ; [B2, V7]; xn--no0dr648a51o3b.xn--klj; ; ;  # 𞤤𐹯.ⴜ
+𞤤񹞁𐹯。ⴜ; 𞤤񹞁𐹯.ⴜ; [B2, V7]; xn--no0dr648a51o3b.xn--klj; ; ;  # 𞤤𐹯.ⴜ
+xn--no0dr648a51o3b.xn--klj; 𞤤񹞁𐹯.ⴜ; [B2, V7]; xn--no0dr648a51o3b.xn--klj; ; ;  # 𞤤𐹯.ⴜ
+xn--no0dr648a51o3b.xn--0nd; 𞤤񹞁𐹯.Ⴜ; [B2, V7]; xn--no0dr648a51o3b.xn--0nd; ; ;  # 𞤤𐹯.Ⴜ
+𞤂񹞁𐹯。ⴜ; 𞤤񹞁𐹯.ⴜ; [B2, V7]; xn--no0dr648a51o3b.xn--klj; ; ;  # 𞤤𐹯.ⴜ
+𐹵⮣\u200C𑄰｡񷴿\uFCB7; 𐹵⮣\u200C𑄰.񷴿\u0636\u0645; [B1, B5, B6, C1, V7]; xn--0ug586bcj8p7jc.xn--1gb4a66004i; ; xn--s9i5458e7yb.xn--1gb4a66004i; [B1, B5, B6, V7] # 𐹵⮣𑄰.ضم
+𐹵⮣\u200C𑄰。񷴿\u0636\u0645; 𐹵⮣\u200C𑄰.񷴿\u0636\u0645; [B1, B5, B6, C1, V7]; xn--0ug586bcj8p7jc.xn--1gb4a66004i; ; xn--s9i5458e7yb.xn--1gb4a66004i; [B1, B5, B6, V7] # 𐹵⮣𑄰.ضم
+xn--s9i5458e7yb.xn--1gb4a66004i; 𐹵⮣𑄰.񷴿\u0636\u0645; [B1, B5, B6, V7]; xn--s9i5458e7yb.xn--1gb4a66004i; ; ;  # 𐹵⮣𑄰.ضم
+xn--0ug586bcj8p7jc.xn--1gb4a66004i; 𐹵⮣\u200C𑄰.񷴿\u0636\u0645; [B1, B5, B6, C1, V7]; xn--0ug586bcj8p7jc.xn--1gb4a66004i; ; ;  # 𐹵⮣𑄰.ضم
+Ⴒ。デß𞤵\u0C4D; ⴒ.デß𞤵\u0C4D; [B5, B6]; xn--9kj.xn--zca669cmr3a0f28a; ; xn--9kj.xn--ss-9nh3648ahh20b;  # ⴒ.デß𞤵్
+Ⴒ。テ\u3099ß𞤵\u0C4D; ⴒ.デß𞤵\u0C4D; [B5, B6]; xn--9kj.xn--zca669cmr3a0f28a; ; xn--9kj.xn--ss-9nh3648ahh20b;  # ⴒ.デß𞤵్
+ⴒ。テ\u3099ß𞤵\u0C4D; ⴒ.デß𞤵\u0C4D; [B5, B6]; xn--9kj.xn--zca669cmr3a0f28a; ; xn--9kj.xn--ss-9nh3648ahh20b;  # ⴒ.デß𞤵్
+ⴒ。デß𞤵\u0C4D; ⴒ.デß𞤵\u0C4D; [B5, B6]; xn--9kj.xn--zca669cmr3a0f28a; ; xn--9kj.xn--ss-9nh3648ahh20b;  # ⴒ.デß𞤵్
+Ⴒ。デSS𞤓\u0C4D; ⴒ.デss𞤵\u0C4D; [B5, B6]; xn--9kj.xn--ss-9nh3648ahh20b; ; ;  # ⴒ.デss𞤵్
+Ⴒ。テ\u3099SS𞤓\u0C4D; ⴒ.デss𞤵\u0C4D; [B5, B6]; xn--9kj.xn--ss-9nh3648ahh20b; ; ;  # ⴒ.デss𞤵్
+ⴒ。テ\u3099ss𞤵\u0C4D; ⴒ.デss𞤵\u0C4D; [B5, B6]; xn--9kj.xn--ss-9nh3648ahh20b; ; ;  # ⴒ.デss𞤵్
+ⴒ。デss𞤵\u0C4D; ⴒ.デss𞤵\u0C4D; [B5, B6]; xn--9kj.xn--ss-9nh3648ahh20b; ; ;  # ⴒ.デss𞤵్
+Ⴒ。デSs𞤵\u0C4D; ⴒ.デss𞤵\u0C4D; [B5, B6]; xn--9kj.xn--ss-9nh3648ahh20b; ; ;  # ⴒ.デss𞤵్
+Ⴒ。テ\u3099Ss𞤵\u0C4D; ⴒ.デss𞤵\u0C4D; [B5, B6]; xn--9kj.xn--ss-9nh3648ahh20b; ; ;  # ⴒ.デss𞤵్
+xn--9kj.xn--ss-9nh3648ahh20b; ⴒ.デss𞤵\u0C4D; [B5, B6]; xn--9kj.xn--ss-9nh3648ahh20b; ; ;  # ⴒ.デss𞤵్
+xn--9kj.xn--zca669cmr3a0f28a; ⴒ.デß𞤵\u0C4D; [B5, B6]; xn--9kj.xn--zca669cmr3a0f28a; ; ;  # ⴒ.デß𞤵్
+xn--qnd.xn--ss-9nh3648ahh20b; Ⴒ.デss𞤵\u0C4D; [B5, B6, V7]; xn--qnd.xn--ss-9nh3648ahh20b; ; ;  # Ⴒ.デss𞤵్
+xn--qnd.xn--zca669cmr3a0f28a; Ⴒ.デß𞤵\u0C4D; [B5, B6, V7]; xn--qnd.xn--zca669cmr3a0f28a; ; ;  # Ⴒ.デß𞤵్
+Ⴒ。デSS𞤵\u0C4D; ⴒ.デss𞤵\u0C4D; [B5, B6]; xn--9kj.xn--ss-9nh3648ahh20b; ; ;  # ⴒ.デss𞤵్
+Ⴒ。テ\u3099SS𞤵\u0C4D; ⴒ.デss𞤵\u0C4D; [B5, B6]; xn--9kj.xn--ss-9nh3648ahh20b; ; ;  # ⴒ.デss𞤵్
+𑁿\u0D4D．７-\u07D2; 𑁿\u0D4D.7-\u07D2; [B1, V6]; xn--wxc1283k.xn--7--yue; ; ;  # 𑁿്.7-ߒ
+𑁿\u0D4D.7-\u07D2; ; [B1, V6]; xn--wxc1283k.xn--7--yue; ; ;  # 𑁿്.7-ߒ
+xn--wxc1283k.xn--7--yue; 𑁿\u0D4D.7-\u07D2; [B1, V6]; xn--wxc1283k.xn--7--yue; ; ;  # 𑁿്.7-ߒ
+≯𑜫󠭇.\u1734񒞤𑍬ᢧ; ; [V6, V7]; xn--hdhx157g68o0g.xn--c0e65eu616c34o7a; ; ;  # ≯𑜫.᜴𑍬ᢧ
+>\u0338𑜫󠭇.\u1734񒞤𑍬ᢧ; ≯𑜫󠭇.\u1734񒞤𑍬ᢧ; [V6, V7]; xn--hdhx157g68o0g.xn--c0e65eu616c34o7a; ; ;  # ≯𑜫.᜴𑍬ᢧ
+xn--hdhx157g68o0g.xn--c0e65eu616c34o7a; ≯𑜫󠭇.\u1734񒞤𑍬ᢧ; [V6, V7]; xn--hdhx157g68o0g.xn--c0e65eu616c34o7a; ; ;  # ≯𑜫.᜴𑍬ᢧ
+\u1DDB򎐙Ⴗ쏔。\u0781; \u1DDB򎐙ⴗ쏔.\u0781; [B1, V6, V7]; xn--zegy26dw47iy6w2f.xn--iqb; ; ;  # ᷛⴗ쏔.ށ
+\u1DDB򎐙Ⴗ쏔。\u0781; \u1DDB򎐙ⴗ쏔.\u0781; [B1, V6, V7]; xn--zegy26dw47iy6w2f.xn--iqb; ; ;  # ᷛⴗ쏔.ށ
+\u1DDB򎐙ⴗ쏔。\u0781; \u1DDB򎐙ⴗ쏔.\u0781; [B1, V6, V7]; xn--zegy26dw47iy6w2f.xn--iqb; ; ;  # ᷛⴗ쏔.ށ
+\u1DDB򎐙ⴗ쏔。\u0781; \u1DDB򎐙ⴗ쏔.\u0781; [B1, V6, V7]; xn--zegy26dw47iy6w2f.xn--iqb; ; ;  # ᷛⴗ쏔.ށ
+xn--zegy26dw47iy6w2f.xn--iqb; \u1DDB򎐙ⴗ쏔.\u0781; [B1, V6, V7]; xn--zegy26dw47iy6w2f.xn--iqb; ; ;  # ᷛⴗ쏔.ށ
+xn--vnd148d733ky6n9e.xn--iqb; \u1DDB򎐙Ⴗ쏔.\u0781; [B1, V6, V7]; xn--vnd148d733ky6n9e.xn--iqb; ; ;  # ᷛႷ쏔.ށ
+ß｡𐋳Ⴌ\u0FB8; ß.𐋳ⴌ\u0FB8; ; xn--zca.xn--lgd921mvv0m; ; ss.xn--lgd921mvv0m;  # ß.𐋳ⴌྸ
+ß。𐋳Ⴌ\u0FB8; ß.𐋳ⴌ\u0FB8; ; xn--zca.xn--lgd921mvv0m; ; ss.xn--lgd921mvv0m;  # ß.𐋳ⴌྸ
+ß。𐋳ⴌ\u0FB8; ß.𐋳ⴌ\u0FB8; ; xn--zca.xn--lgd921mvv0m; ; ss.xn--lgd921mvv0m;  # ß.𐋳ⴌྸ
+SS。𐋳Ⴌ\u0FB8; ss.𐋳ⴌ\u0FB8; ; ss.xn--lgd921mvv0m; ; ;  # ss.𐋳ⴌྸ
+ss。𐋳ⴌ\u0FB8; ss.𐋳ⴌ\u0FB8; ; ss.xn--lgd921mvv0m; ; ;  # ss.𐋳ⴌྸ
+Ss。𐋳Ⴌ\u0FB8; ss.𐋳ⴌ\u0FB8; ; ss.xn--lgd921mvv0m; ; ;  # ss.𐋳ⴌྸ
+ss.xn--lgd921mvv0m; ss.𐋳ⴌ\u0FB8; ; ss.xn--lgd921mvv0m; ; ;  # ss.𐋳ⴌྸ
+ss.𐋳ⴌ\u0FB8; ; ; ss.xn--lgd921mvv0m; ; ;  # ss.𐋳ⴌྸ
+SS.𐋳Ⴌ\u0FB8; ss.𐋳ⴌ\u0FB8; ; ss.xn--lgd921mvv0m; ; ;  # ss.𐋳ⴌྸ
+Ss.𐋳Ⴌ\u0FB8; ss.𐋳ⴌ\u0FB8; ; ss.xn--lgd921mvv0m; ; ;  # ss.𐋳ⴌྸ
+xn--zca.xn--lgd921mvv0m; ß.𐋳ⴌ\u0FB8; ; xn--zca.xn--lgd921mvv0m; ; ;  # ß.𐋳ⴌྸ
+ß.𐋳ⴌ\u0FB8; ; ; xn--zca.xn--lgd921mvv0m; ; ss.xn--lgd921mvv0m;  # ß.𐋳ⴌྸ
+ß｡𐋳ⴌ\u0FB8; ß.𐋳ⴌ\u0FB8; ; xn--zca.xn--lgd921mvv0m; ; ss.xn--lgd921mvv0m;  # ß.𐋳ⴌྸ
+SS｡𐋳Ⴌ\u0FB8; ss.𐋳ⴌ\u0FB8; ; ss.xn--lgd921mvv0m; ; ;  # ss.𐋳ⴌྸ
+ss｡𐋳ⴌ\u0FB8; ss.𐋳ⴌ\u0FB8; ; ss.xn--lgd921mvv0m; ; ;  # ss.𐋳ⴌྸ
+Ss｡𐋳Ⴌ\u0FB8; ss.𐋳ⴌ\u0FB8; ; ss.xn--lgd921mvv0m; ; ;  # ss.𐋳ⴌྸ
+ss.xn--lgd10cu829c; ss.𐋳Ⴌ\u0FB8; [V7]; ss.xn--lgd10cu829c; ; ;  # ss.𐋳Ⴌྸ
+xn--zca.xn--lgd10cu829c; ß.𐋳Ⴌ\u0FB8; [V7]; xn--zca.xn--lgd10cu829c; ; ;  # ß.𐋳Ⴌྸ
+-\u069E𐶡.\u200C⾝\u09CD; -\u069E𐶡.\u200C身\u09CD; [B1, C1, V3, V7]; xn----stc7013r.xn--b7b305imj2f; ; xn----stc7013r.xn--b7b1419d; [B1, V3, V7] # -ڞ.身্
+-\u069E𐶡.\u200C身\u09CD; ; [B1, C1, V3, V7]; xn----stc7013r.xn--b7b305imj2f; ; xn----stc7013r.xn--b7b1419d; [B1, V3, V7] # -ڞ.身্
+xn----stc7013r.xn--b7b1419d; -\u069E𐶡.身\u09CD; [B1, V3, V7]; xn----stc7013r.xn--b7b1419d; ; ;  # -ڞ.身্
+xn----stc7013r.xn--b7b305imj2f; -\u069E𐶡.\u200C身\u09CD; [B1, C1, V3, V7]; xn----stc7013r.xn--b7b305imj2f; ; ;  # -ڞ.身্
+😮\u0764𑈵𞀖.💅\u200D; 😮\u0764𑈵𞀖.💅\u200D; [B1, C2]; xn--opb4277kuc7elqsa.xn--1ug5265p; ; xn--opb4277kuc7elqsa.xn--kr8h; [B1] # 😮ݤ𑈵𞀖.💅
+😮\u0764𑈵𞀖.💅\u200D; ; [B1, C2]; xn--opb4277kuc7elqsa.xn--1ug5265p; ; xn--opb4277kuc7elqsa.xn--kr8h; [B1] # 😮ݤ𑈵𞀖.💅
+xn--opb4277kuc7elqsa.xn--kr8h; 😮\u0764𑈵𞀖.💅; [B1]; xn--opb4277kuc7elqsa.xn--kr8h; ; ;  # 😮ݤ𑈵𞀖.💅
+xn--opb4277kuc7elqsa.xn--1ug5265p; 😮\u0764𑈵𞀖.💅\u200D; [B1, C2]; xn--opb4277kuc7elqsa.xn--1ug5265p; ; ;  # 😮ݤ𑈵𞀖.💅
+\u08F2\u200D꙳\u0712.ᢏ\u200C󠍄; ; [B1, B6, C1, C2, V6, V7]; xn--cnb37g904be26j.xn--89e849ax9363a; ; xn--cnb37gdy00a.xn--89e02253p; [B1, B6, V6, V7] # ࣲ꙳ܒ.ᢏ
+xn--cnb37gdy00a.xn--89e02253p; \u08F2꙳\u0712.ᢏ󠍄; [B1, B6, V6, V7]; xn--cnb37gdy00a.xn--89e02253p; ; ;  # ࣲ꙳ܒ.ᢏ
+xn--cnb37g904be26j.xn--89e849ax9363a; \u08F2\u200D꙳\u0712.ᢏ\u200C󠍄; [B1, B6, C1, C2, V6, V7]; xn--cnb37g904be26j.xn--89e849ax9363a; ; ;  # ࣲ꙳ܒ.ᢏ
+Ⴑ．\u06BF𞯓ᠲ; ⴑ.\u06BF𞯓ᠲ; [B2, B3, V7]; xn--8kj.xn--ykb840gd555a; ; ;  # ⴑ.ڿᠲ
+Ⴑ.\u06BF𞯓ᠲ; ⴑ.\u06BF𞯓ᠲ; [B2, B3, V7]; xn--8kj.xn--ykb840gd555a; ; ;  # ⴑ.ڿᠲ
+ⴑ.\u06BF𞯓ᠲ; ; [B2, B3, V7]; xn--8kj.xn--ykb840gd555a; ; ;  # ⴑ.ڿᠲ
+xn--8kj.xn--ykb840gd555a; ⴑ.\u06BF𞯓ᠲ; [B2, B3, V7]; xn--8kj.xn--ykb840gd555a; ; ;  # ⴑ.ڿᠲ
+ⴑ．\u06BF𞯓ᠲ; ⴑ.\u06BF𞯓ᠲ; [B2, B3, V7]; xn--8kj.xn--ykb840gd555a; ; ;  # ⴑ.ڿᠲ
+xn--pnd.xn--ykb840gd555a; Ⴑ.\u06BF𞯓ᠲ; [B2, B3, V7]; xn--pnd.xn--ykb840gd555a; ; ;  # Ⴑ.ڿᠲ
+\u1A5A𛦝\u0C4D。𚝬𝟵; \u1A5A𛦝\u0C4D.𚝬9; [V6, V7]; xn--lqc703ebm93a.xn--9-000p; ; ;  # ᩚ్.9
+\u1A5A𛦝\u0C4D。𚝬9; \u1A5A𛦝\u0C4D.𚝬9; [V6, V7]; xn--lqc703ebm93a.xn--9-000p; ; ;  # ᩚ్.9
+xn--lqc703ebm93a.xn--9-000p; \u1A5A𛦝\u0C4D.𚝬9; [V6, V7]; xn--lqc703ebm93a.xn--9-000p; ; ;  # ᩚ్.9
+\u200C\u06A0𿺆𝟗｡Ⴣ꒘\uFCD0񐘖; \u200C\u06A0𿺆9.ⴣ꒘\u0645\u062E񐘖; [B1, B5, C1, V7]; xn--9-vtc736qts91g.xn--tgb9bz87p833hw316c; ; xn--9-vtc42319e.xn--tgb9bz87p833hw316c; [B2, B5, V7] # ڠ9.ⴣ꒘مخ
+\u200C\u06A0𿺆9。Ⴣ꒘\u0645\u062E񐘖; \u200C\u06A0𿺆9.ⴣ꒘\u0645\u062E񐘖; [B1, B5, C1, V7]; xn--9-vtc736qts91g.xn--tgb9bz87p833hw316c; ; xn--9-vtc42319e.xn--tgb9bz87p833hw316c; [B2, B5, V7] # ڠ9.ⴣ꒘مخ
+\u200C\u06A0𿺆9。ⴣ꒘\u0645\u062E񐘖; \u200C\u06A0𿺆9.ⴣ꒘\u0645\u062E񐘖; [B1, B5, C1, V7]; xn--9-vtc736qts91g.xn--tgb9bz87p833hw316c; ; xn--9-vtc42319e.xn--tgb9bz87p833hw316c; [B2, B5, V7] # ڠ9.ⴣ꒘مخ
+xn--9-vtc42319e.xn--tgb9bz87p833hw316c; \u06A0𿺆9.ⴣ꒘\u0645\u062E񐘖; [B2, B5, V7]; xn--9-vtc42319e.xn--tgb9bz87p833hw316c; ; ;  # ڠ9.ⴣ꒘مخ
+xn--9-vtc736qts91g.xn--tgb9bz87p833hw316c; \u200C\u06A0𿺆9.ⴣ꒘\u0645\u062E񐘖; [B1, B5, C1, V7]; xn--9-vtc736qts91g.xn--tgb9bz87p833hw316c; ; ;  # ڠ9.ⴣ꒘مخ
+\u200C\u06A0𿺆𝟗｡ⴣ꒘\uFCD0񐘖; \u200C\u06A0𿺆9.ⴣ꒘\u0645\u062E񐘖; [B1, B5, C1, V7]; xn--9-vtc736qts91g.xn--tgb9bz87p833hw316c; ; xn--9-vtc42319e.xn--tgb9bz87p833hw316c; [B2, B5, V7] # ڠ9.ⴣ꒘مخ
+xn--9-vtc42319e.xn--tgb9bz61cfn8mw3t2c; \u06A0𿺆9.Ⴣ꒘\u0645\u062E񐘖; [B2, B5, V7]; xn--9-vtc42319e.xn--tgb9bz61cfn8mw3t2c; ; ;  # ڠ9.Ⴣ꒘مخ
+xn--9-vtc736qts91g.xn--tgb9bz61cfn8mw3t2c; \u200C\u06A0𿺆9.Ⴣ꒘\u0645\u062E񐘖; [B1, B5, C1, V7]; xn--9-vtc736qts91g.xn--tgb9bz61cfn8mw3t2c; ; ;  # ڠ9.Ⴣ꒘مخ
+ᡖ｡\u031F񗛨\u0B82-; ᡖ.\u031F񗛨\u0B82-; [V3, V6, V7]; xn--m8e.xn----mdb555dkk71m; ; ;  # ᡖ.̟ஂ-
+ᡖ。\u031F񗛨\u0B82-; ᡖ.\u031F񗛨\u0B82-; [V3, V6, V7]; xn--m8e.xn----mdb555dkk71m; ; ;  # ᡖ.̟ஂ-
+xn--m8e.xn----mdb555dkk71m; ᡖ.\u031F񗛨\u0B82-; [V3, V6, V7]; xn--m8e.xn----mdb555dkk71m; ; ;  # ᡖ.̟ஂ-
+𞠠浘。絧𞀀; 𞠠浘.絧𞀀; [B2, B3]; xn--e0wp491f.xn--ud0a3573e; ; ;  # 𞠠浘.絧𞀀
+xn--e0wp491f.xn--ud0a3573e; 𞠠浘.絧𞀀; [B2, B3]; xn--e0wp491f.xn--ud0a3573e; ; ;  # 𞠠浘.絧𞀀
+\u0596Ⴋ．𝟳≯︒\uFE0A; \u0596ⴋ.7≯︒; [V6, V7]; xn--hcb613r.xn--7-pgoy530h; ; ;  # ֖ⴋ.7≯︒
+\u0596Ⴋ．𝟳>\u0338︒\uFE0A; \u0596ⴋ.7≯︒; [V6, V7]; xn--hcb613r.xn--7-pgoy530h; ; ;  # ֖ⴋ.7≯︒
+\u0596Ⴋ.7≯。\uFE0A; \u0596ⴋ.7≯.; [V6]; xn--hcb613r.xn--7-pgo.; [V6, A4_2]; ;  # ֖ⴋ.7≯.
+\u0596Ⴋ.7>\u0338。\uFE0A; \u0596ⴋ.7≯.; [V6]; xn--hcb613r.xn--7-pgo.; [V6, A4_2]; ;  # ֖ⴋ.7≯.
+\u0596ⴋ.7>\u0338。\uFE0A; \u0596ⴋ.7≯.; [V6]; xn--hcb613r.xn--7-pgo.; [V6, A4_2]; ;  # ֖ⴋ.7≯.
+\u0596ⴋ.7≯。\uFE0A; \u0596ⴋ.7≯.; [V6]; xn--hcb613r.xn--7-pgo.; [V6, A4_2]; ;  # ֖ⴋ.7≯.
+xn--hcb613r.xn--7-pgo.; \u0596ⴋ.7≯.; [V6]; xn--hcb613r.xn--7-pgo.; [V6, A4_2]; ;  # ֖ⴋ.7≯.
+\u0596ⴋ．𝟳>\u0338︒\uFE0A; \u0596ⴋ.7≯︒; [V6, V7]; xn--hcb613r.xn--7-pgoy530h; ; ;  # ֖ⴋ.7≯︒
+\u0596ⴋ．𝟳≯︒\uFE0A; \u0596ⴋ.7≯︒; [V6, V7]; xn--hcb613r.xn--7-pgoy530h; ; ;  # ֖ⴋ.7≯︒
+xn--hcb613r.xn--7-pgoy530h; \u0596ⴋ.7≯︒; [V6, V7]; xn--hcb613r.xn--7-pgoy530h; ; ;  # ֖ⴋ.7≯︒
+xn--hcb887c.xn--7-pgo.; \u0596Ⴋ.7≯.; [V6, V7]; xn--hcb887c.xn--7-pgo.; [V6, V7, A4_2]; ;  # ֖Ⴋ.7≯.
+xn--hcb887c.xn--7-pgoy530h; \u0596Ⴋ.7≯︒; [V6, V7]; xn--hcb887c.xn--7-pgoy530h; ; ;  # ֖Ⴋ.7≯︒
+\u200DF𑓂。󠺨︒\u077E𐹢; \u200Df𑓂.󠺨︒\u077E𐹢; [B1, C2, V7]; xn--f-tgn9761i.xn--fqb1637j8hky9452a; ; xn--f-kq9i.xn--fqb1637j8hky9452a; [B1, V7] # f𑓂.︒ݾ𐹢
+\u200DF𑓂。󠺨。\u077E𐹢; \u200Df𑓂.󠺨.\u077E𐹢; [B1, C2, V7]; xn--f-tgn9761i.xn--7656e.xn--fqb4175k; ; xn--f-kq9i.xn--7656e.xn--fqb4175k; [B1, V7] # f𑓂..ݾ𐹢
+\u200Df𑓂。󠺨。\u077E𐹢; \u200Df𑓂.󠺨.\u077E𐹢; [B1, C2, V7]; xn--f-tgn9761i.xn--7656e.xn--fqb4175k; ; xn--f-kq9i.xn--7656e.xn--fqb4175k; [B1, V7] # f𑓂..ݾ𐹢
+xn--f-kq9i.xn--7656e.xn--fqb4175k; f𑓂.󠺨.\u077E𐹢; [B1, V7]; xn--f-kq9i.xn--7656e.xn--fqb4175k; ; ;  # f𑓂..ݾ𐹢
+xn--f-tgn9761i.xn--7656e.xn--fqb4175k; \u200Df𑓂.󠺨.\u077E𐹢; [B1, C2, V7]; xn--f-tgn9761i.xn--7656e.xn--fqb4175k; ; ;  # f𑓂..ݾ𐹢
+\u200Df𑓂。󠺨︒\u077E𐹢; \u200Df𑓂.󠺨︒\u077E𐹢; [B1, C2, V7]; xn--f-tgn9761i.xn--fqb1637j8hky9452a; ; xn--f-kq9i.xn--fqb1637j8hky9452a; [B1, V7] # f𑓂.︒ݾ𐹢
+xn--f-kq9i.xn--fqb1637j8hky9452a; f𑓂.󠺨︒\u077E𐹢; [B1, V7]; xn--f-kq9i.xn--fqb1637j8hky9452a; ; ;  # f𑓂.︒ݾ𐹢
+xn--f-tgn9761i.xn--fqb1637j8hky9452a; \u200Df𑓂.󠺨︒\u077E𐹢; [B1, C2, V7]; xn--f-tgn9761i.xn--fqb1637j8hky9452a; ; ;  # f𑓂.︒ݾ𐹢
+\u0845🄇𐼗︒｡𐹻𑜫; \u08456,𐼗︒.𐹻𑜫; [B1, B3, V7, U1]; xn--6,-r4e6182wo1ra.xn--zo0di2m; ; ;  # ࡅ6,𐼗︒.𐹻𑜫
+\u08456,𐼗。。𐹻𑜫; \u08456,𐼗..𐹻𑜫; [B1, U1, X4_2]; xn--6,-r4e4420y..xn--zo0di2m; [B1, U1, A4_2]; ;  # ࡅ6,𐼗..𐹻𑜫
+xn--6,-r4e4420y..xn--zo0di2m; \u08456,𐼗..𐹻𑜫; [B1, U1, X4_2]; xn--6,-r4e4420y..xn--zo0di2m; [B1, U1, A4_2]; ;  # ࡅ6,𐼗..𐹻𑜫
+xn--6,-r4e6182wo1ra.xn--zo0di2m; \u08456,𐼗︒.𐹻𑜫; [B1, B3, V7, U1]; xn--6,-r4e6182wo1ra.xn--zo0di2m; ; ;  # ࡅ6,𐼗︒.𐹻𑜫
+xn--3vb4696jpxkjh7s.xn--zo0di2m; \u0845🄇𐼗︒.𐹻𑜫; [B1, B3, V7]; xn--3vb4696jpxkjh7s.xn--zo0di2m; ; ;  # ࡅ🄇𐼗︒.𐹻𑜫
+𐹈.\u1DC0𑈱𐦭; ; [B1, V6, V7]; xn--jn0d.xn--7dg0871h3lf; ; ;  # .᷀𑈱𐦭
+xn--jn0d.xn--7dg0871h3lf; 𐹈.\u1DC0𑈱𐦭; [B1, V6, V7]; xn--jn0d.xn--7dg0871h3lf; ; ;  # .᷀𑈱𐦭
+Ⴂ䠺。𞤃񅏎󙮦\u0693; ⴂ䠺.𞤥񅏎󙮦\u0693; [B2, V7]; xn--tkj638f.xn--pjb9818vg4xno967d; ; ;  # ⴂ䠺.𞤥ړ
+ⴂ䠺。𞤥񅏎󙮦\u0693; ⴂ䠺.𞤥񅏎󙮦\u0693; [B2, V7]; xn--tkj638f.xn--pjb9818vg4xno967d; ; ;  # ⴂ䠺.𞤥ړ
+xn--tkj638f.xn--pjb9818vg4xno967d; ⴂ䠺.𞤥񅏎󙮦\u0693; [B2, V7]; xn--tkj638f.xn--pjb9818vg4xno967d; ; ;  # ⴂ䠺.𞤥ړ
+xn--9md875z.xn--pjb9818vg4xno967d; Ⴂ䠺.𞤥񅏎󙮦\u0693; [B2, V7]; xn--9md875z.xn--pjb9818vg4xno967d; ; ;  # Ⴂ䠺.𞤥ړ
+ⴂ䠺。𞤃񅏎󙮦\u0693; ⴂ䠺.𞤥񅏎󙮦\u0693; [B2, V7]; xn--tkj638f.xn--pjb9818vg4xno967d; ; ;  # ⴂ䠺.𞤥ړ
+🄇伐︒.𜙚\uA8C4; 6,伐︒.𜙚\uA8C4; [V7, U1]; xn--6,-7i3cj157d.xn--0f9ao925c; ; ;  # 6,伐︒.꣄
+6,伐。.𜙚\uA8C4; 6,伐..𜙚\uA8C4; [V7, U1, X4_2]; xn--6,-7i3c..xn--0f9ao925c; [V7, U1, A4_2]; ;  # 6,伐..꣄
+xn--6,-7i3c..xn--0f9ao925c; 6,伐..𜙚\uA8C4; [V7, U1, X4_2]; xn--6,-7i3c..xn--0f9ao925c; [V7, U1, A4_2]; ;  # 6,伐..꣄
+xn--6,-7i3cj157d.xn--0f9ao925c; 6,伐︒.𜙚\uA8C4; [V7, U1]; xn--6,-7i3cj157d.xn--0f9ao925c; ; ;  # 6,伐︒.꣄
+xn--woqs083bel0g.xn--0f9ao925c; 🄇伐︒.𜙚\uA8C4; [V7]; xn--woqs083bel0g.xn--0f9ao925c; ; ;  # 🄇伐︒.꣄
+\u200D𐹠\uABED\uFFFB。\u200D𐫓Ⴚ𑂹; \u200D𐹠\uABED\uFFFB.\u200D𐫓ⴚ𑂹; [B1, C2, V7]; xn--1ugz126coy7bdbm.xn--1ug062chv7ov6e; ; xn--429az70n29i.xn--ilj7702eqyd; [B1, B2, B3, V7] # 𐹠꯭.𐫓ⴚ𑂹
+\u200D𐹠\uABED\uFFFB。\u200D𐫓ⴚ𑂹; \u200D𐹠\uABED\uFFFB.\u200D𐫓ⴚ𑂹; [B1, C2, V7]; xn--1ugz126coy7bdbm.xn--1ug062chv7ov6e; ; xn--429az70n29i.xn--ilj7702eqyd; [B1, B2, B3, V7] # 𐹠꯭.𐫓ⴚ𑂹
+xn--429az70n29i.xn--ilj7702eqyd; 𐹠\uABED\uFFFB.𐫓ⴚ𑂹; [B1, B2, B3, V7]; xn--429az70n29i.xn--ilj7702eqyd; ; ;  # 𐹠꯭.𐫓ⴚ𑂹
+xn--1ugz126coy7bdbm.xn--1ug062chv7ov6e; \u200D𐹠\uABED\uFFFB.\u200D𐫓ⴚ𑂹; [B1, C2, V7]; xn--1ugz126coy7bdbm.xn--1ug062chv7ov6e; ; ;  # 𐹠꯭.𐫓ⴚ𑂹
+xn--429az70n29i.xn--ynd3619jqyd; 𐹠\uABED\uFFFB.𐫓Ⴚ𑂹; [B1, B2, B3, V7]; xn--429az70n29i.xn--ynd3619jqyd; ; ;  # 𐹠꯭.𐫓Ⴚ𑂹
+xn--1ugz126coy7bdbm.xn--ynd959evs1pv6e; \u200D𐹠\uABED\uFFFB.\u200D𐫓Ⴚ𑂹; [B1, C2, V7]; xn--1ugz126coy7bdbm.xn--ynd959evs1pv6e; ; ;  # 𐹠꯭.𐫓Ⴚ𑂹
+󠆠．񷐴󌟈; .񷐴󌟈; [V7, X4_2]; .xn--rx21bhv12i; [V7, A4_2]; ;  # .
+󠆠.񷐴󌟈; .񷐴󌟈; [V7, X4_2]; .xn--rx21bhv12i; [V7, A4_2]; ;  # .
+.xn--rx21bhv12i; .񷐴󌟈; [V7, X4_2]; .xn--rx21bhv12i; [V7, A4_2]; ;  # .
+𐫃\u200CႦ.≠𞷙; 𐫃\u200Cⴆ.≠𞷙; [B1, B2, B3, C1, V7]; xn--0ug132csv7o.xn--1ch2802p; ; xn--xkjz802e.xn--1ch2802p; [B1, B2, B3, V7] # 𐫃ⴆ.≠
+𐫃\u200CႦ.=\u0338𞷙; 𐫃\u200Cⴆ.≠𞷙; [B1, B2, B3, C1, V7]; xn--0ug132csv7o.xn--1ch2802p; ; xn--xkjz802e.xn--1ch2802p; [B1, B2, B3, V7] # 𐫃ⴆ.≠
+𐫃\u200Cⴆ.=\u0338𞷙; 𐫃\u200Cⴆ.≠𞷙; [B1, B2, B3, C1, V7]; xn--0ug132csv7o.xn--1ch2802p; ; xn--xkjz802e.xn--1ch2802p; [B1, B2, B3, V7] # 𐫃ⴆ.≠
+𐫃\u200Cⴆ.≠𞷙; ; [B1, B2, B3, C1, V7]; xn--0ug132csv7o.xn--1ch2802p; ; xn--xkjz802e.xn--1ch2802p; [B1, B2, B3, V7] # 𐫃ⴆ.≠
+xn--xkjz802e.xn--1ch2802p; 𐫃ⴆ.≠𞷙; [B1, B2, B3, V7]; xn--xkjz802e.xn--1ch2802p; ; ;  # 𐫃ⴆ.≠
+xn--0ug132csv7o.xn--1ch2802p; 𐫃\u200Cⴆ.≠𞷙; [B1, B2, B3, C1, V7]; xn--0ug132csv7o.xn--1ch2802p; ; ;  # 𐫃ⴆ.≠
+xn--end1719j.xn--1ch2802p; 𐫃Ⴆ.≠𞷙; [B1, B2, B3, V7]; xn--end1719j.xn--1ch2802p; ; ;  # 𐫃Ⴆ.≠
+xn--end799ekr1p.xn--1ch2802p; 𐫃\u200CႦ.≠𞷙; [B1, B2, B3, C1, V7]; xn--end799ekr1p.xn--1ch2802p; ; ;  # 𐫃Ⴆ.≠
+󠁲𙩢𝟥ꘌ．\u0841; 󠁲𙩢3ꘌ.\u0841; [B1, V7]; xn--3-0g3es485d8i15h.xn--zvb; ; ;  # 3ꘌ.ࡁ
+󠁲𙩢3ꘌ.\u0841; ; [B1, V7]; xn--3-0g3es485d8i15h.xn--zvb; ; ;  # 3ꘌ.ࡁ
+xn--3-0g3es485d8i15h.xn--zvb; 󠁲𙩢3ꘌ.\u0841; [B1, V7]; xn--3-0g3es485d8i15h.xn--zvb; ; ;  # 3ꘌ.ࡁ
+-.\u1886󡲣-; ; [V3, V6, V7]; -.xn----pbkx6497q; ; ;  # -.ᢆ-
+-.xn----pbkx6497q; -.\u1886󡲣-; [V3, V6, V7]; -.xn----pbkx6497q; ; ;  # -.ᢆ-
+󲚗\u200C｡\u200C𞰆ς; 󲚗\u200C.\u200C𞰆ς; [B1, B6, C1, V7]; xn--0ug76062m.xn--3xa795lhn92a; ; xn--qp42f.xn--4xa3011w; [B2, B3, V7] # .ς
+󲚗\u200C。\u200C𞰆ς; 󲚗\u200C.\u200C𞰆ς; [B1, B6, C1, V7]; xn--0ug76062m.xn--3xa795lhn92a; ; xn--qp42f.xn--4xa3011w; [B2, B3, V7] # .ς
+󲚗\u200C。\u200C𞰆Σ; 󲚗\u200C.\u200C𞰆σ; [B1, B6, C1, V7]; xn--0ug76062m.xn--4xa595lhn92a; ; xn--qp42f.xn--4xa3011w; [B2, B3, V7] # .σ
+󲚗\u200C。\u200C𞰆σ; 󲚗\u200C.\u200C𞰆σ; [B1, B6, C1, V7]; xn--0ug76062m.xn--4xa595lhn92a; ; xn--qp42f.xn--4xa3011w; [B2, B3, V7] # .σ
+xn--qp42f.xn--4xa3011w; 󲚗.𞰆σ; [B2, B3, V7]; xn--qp42f.xn--4xa3011w; ; ;  # .σ
+xn--0ug76062m.xn--4xa595lhn92a; 󲚗\u200C.\u200C𞰆σ; [B1, B6, C1, V7]; xn--0ug76062m.xn--4xa595lhn92a; ; ;  # .σ
+xn--0ug76062m.xn--3xa795lhn92a; 󲚗\u200C.\u200C𞰆ς; [B1, B6, C1, V7]; xn--0ug76062m.xn--3xa795lhn92a; ; ;  # .ς
+󲚗\u200C｡\u200C𞰆Σ; 󲚗\u200C.\u200C𞰆σ; [B1, B6, C1, V7]; xn--0ug76062m.xn--4xa595lhn92a; ; xn--qp42f.xn--4xa3011w; [B2, B3, V7] # .σ
+󲚗\u200C｡\u200C𞰆σ; 󲚗\u200C.\u200C𞰆σ; [B1, B6, C1, V7]; xn--0ug76062m.xn--4xa595lhn92a; ; xn--qp42f.xn--4xa3011w; [B2, B3, V7] # .σ
+堕𑓂\u1B02。𐮇𞤽\u200C-; 堕𑓂\u1B02.𐮇𞤽\u200C-; [B3, C1, V3]; xn--5sf345zdk8h.xn----rgnt157hwl9g; ; xn--5sf345zdk8h.xn----iv5iw606c; [B3, V3] # 堕𑓂ᬂ.𐮇𞤽-
+堕𑓂\u1B02。𐮇𞤛\u200C-; 堕𑓂\u1B02.𐮇𞤽\u200C-; [B3, C1, V3]; xn--5sf345zdk8h.xn----rgnt157hwl9g; ; xn--5sf345zdk8h.xn----iv5iw606c; [B3, V3] # 堕𑓂ᬂ.𐮇𞤽-
+xn--5sf345zdk8h.xn----iv5iw606c; 堕𑓂\u1B02.𐮇𞤽-; [B3, V3]; xn--5sf345zdk8h.xn----iv5iw606c; ; ;  # 堕𑓂ᬂ.𐮇𞤽-
+xn--5sf345zdk8h.xn----rgnt157hwl9g; 堕𑓂\u1B02.𐮇𞤽\u200C-; [B3, C1, V3]; xn--5sf345zdk8h.xn----rgnt157hwl9g; ; ;  # 堕𑓂ᬂ.𐮇𞤽-
+𐹶𑁆ᡕ𞤢｡ᡥς\u062Aς; 𐹶𑁆ᡕ𞤢.ᡥς\u062Aς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xaa16plx4a; ; xn--l8e1317j1ebz456b.xn--4xaa85plx4a;  # 𐹶𑁆ᡕ𞤢.ᡥςتς
+𐹶𑁆ᡕ𞤢。ᡥς\u062Aς; 𐹶𑁆ᡕ𞤢.ᡥς\u062Aς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xaa16plx4a; ; xn--l8e1317j1ebz456b.xn--4xaa85plx4a;  # 𐹶𑁆ᡕ𞤢.ᡥςتς
+𐹶𑁆ᡕ𞤀。ᡥΣ\u062AΣ; 𐹶𑁆ᡕ𞤢.ᡥσ\u062Aσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+𐹶𑁆ᡕ𞤢。ᡥσ\u062Aσ; 𐹶𑁆ᡕ𞤢.ᡥσ\u062Aσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+xn--l8e1317j1ebz456b.xn--4xaa85plx4a; 𐹶𑁆ᡕ𞤢.ᡥσ\u062Aσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+xn--l8e1317j1ebz456b.xn--3xaa16plx4a; 𐹶𑁆ᡕ𞤢.ᡥς\u062Aς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xaa16plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥςتς
+𐹶𑁆ᡕ𞤀｡ᡥΣ\u062AΣ; 𐹶𑁆ᡕ𞤢.ᡥσ\u062Aσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+𐹶𑁆ᡕ𞤢｡ᡥσ\u062Aσ; 𐹶𑁆ᡕ𞤢.ᡥσ\u062Aσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+𐹶𑁆ᡕ𞤢。ᡥΣ\u062AΣ; 𐹶𑁆ᡕ𞤢.ᡥσ\u062Aσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+𐹶𑁆ᡕ𞤢。ᡥΣ\u062Aσ; 𐹶𑁆ᡕ𞤢.ᡥσ\u062Aσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+𐹶𑁆ᡕ𞤢。ᡥΣ\u062Aς; 𐹶𑁆ᡕ𞤢.ᡥσ\u062Aς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xab95plx4a; ; xn--l8e1317j1ebz456b.xn--4xaa85plx4a;  # 𐹶𑁆ᡕ𞤢.ᡥσتς
+𐹶𑁆ᡕ𞤢。ᡥσ\u062Aς; 𐹶𑁆ᡕ𞤢.ᡥσ\u062Aς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xab95plx4a; ; xn--l8e1317j1ebz456b.xn--4xaa85plx4a;  # 𐹶𑁆ᡕ𞤢.ᡥσتς
+xn--l8e1317j1ebz456b.xn--3xab95plx4a; 𐹶𑁆ᡕ𞤢.ᡥσ\u062Aς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xab95plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتς
+𐹶𑁆ᡕ𞤢｡ᡥΣ\u062AΣ; 𐹶𑁆ᡕ𞤢.ᡥσ\u062Aσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+𐹶𑁆ᡕ𞤢｡ᡥΣ\u062Aσ; 𐹶𑁆ᡕ𞤢.ᡥσ\u062Aσ; [B1, B5]; xn--l8e1317j1ebz456b.xn--4xaa85plx4a; ; ;  # 𐹶𑁆ᡕ𞤢.ᡥσتσ
+𐹶𑁆ᡕ𞤢｡ᡥΣ\u062Aς; 𐹶𑁆ᡕ𞤢.ᡥσ\u062Aς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xab95plx4a; ; xn--l8e1317j1ebz456b.xn--4xaa85plx4a;  # 𐹶𑁆ᡕ𞤢.ᡥσتς
+𐹶𑁆ᡕ𞤢｡ᡥσ\u062Aς; 𐹶𑁆ᡕ𞤢.ᡥσ\u062Aς; [B1, B5]; xn--l8e1317j1ebz456b.xn--3xab95plx4a; ; xn--l8e1317j1ebz456b.xn--4xaa85plx4a;  # 𐹶𑁆ᡕ𞤢.ᡥσتς
+󏒰．-𝟻ß; 󏒰.-5ß; [V3, V7]; xn--t960e.xn---5-hia; ; xn--t960e.-5ss;  # .-5ß
+󏒰.-5ß; ; [V3, V7]; xn--t960e.xn---5-hia; ; xn--t960e.-5ss;  # .-5ß
+󏒰.-5SS; 󏒰.-5ss; [V3, V7]; xn--t960e.-5ss; ; ;  # .-5ss
+󏒰.-5ss; ; [V3, V7]; xn--t960e.-5ss; ; ;  # .-5ss
+xn--t960e.-5ss; 󏒰.-5ss; [V3, V7]; xn--t960e.-5ss; ; ;  # .-5ss
+xn--t960e.xn---5-hia; 󏒰.-5ß; [V3, V7]; xn--t960e.xn---5-hia; ; ;  # .-5ß
+󏒰．-𝟻SS; 󏒰.-5ss; [V3, V7]; xn--t960e.-5ss; ; ;  # .-5ss
+󏒰．-𝟻ss; 󏒰.-5ss; [V3, V7]; xn--t960e.-5ss; ; ;  # .-5ss
+󏒰．-𝟻Ss; 󏒰.-5ss; [V3, V7]; xn--t960e.-5ss; ; ;  # .-5ss
+󏒰.-5Ss; 󏒰.-5ss; [V3, V7]; xn--t960e.-5ss; ; ;  # .-5ss
+\u200D𐨿.🤒Ⴥ򑮶; \u200D𐨿.🤒ⴥ򑮶; [C2, V7]; xn--1ug9533g.xn--tljz038l0gz4b; ; xn--0s9c.xn--tljz038l0gz4b; [V6, V7] # 𐨿.🤒ⴥ
+\u200D𐨿.🤒ⴥ򑮶; ; [C2, V7]; xn--1ug9533g.xn--tljz038l0gz4b; ; xn--0s9c.xn--tljz038l0gz4b; [V6, V7] # 𐨿.🤒ⴥ
+xn--0s9c.xn--tljz038l0gz4b; 𐨿.🤒ⴥ򑮶; [V6, V7]; xn--0s9c.xn--tljz038l0gz4b; ; ;  # 𐨿.🤒ⴥ
+xn--1ug9533g.xn--tljz038l0gz4b; \u200D𐨿.🤒ⴥ򑮶; [C2, V7]; xn--1ug9533g.xn--tljz038l0gz4b; ; ;  # 𐨿.🤒ⴥ
+xn--0s9c.xn--9nd3211w0gz4b; 𐨿.🤒Ⴥ򑮶; [V6, V7]; xn--0s9c.xn--9nd3211w0gz4b; ; ;  # 𐨿.🤒Ⴥ
+xn--1ug9533g.xn--9nd3211w0gz4b; \u200D𐨿.🤒Ⴥ򑮶; [C2, V7]; xn--1ug9533g.xn--9nd3211w0gz4b; ; ;  # 𐨿.🤒Ⴥ
+𵋅。ß𬵩\u200D; 𵋅.ß𬵩\u200D; [C2, V7]; xn--ey1p.xn--zca870nz438b; ; xn--ey1p.xn--ss-eq36b; [V7] # .ß𬵩
+𵋅。SS𬵩\u200D; 𵋅.ss𬵩\u200D; [C2, V7]; xn--ey1p.xn--ss-n1tx0508a; ; xn--ey1p.xn--ss-eq36b; [V7] # .ss𬵩
+𵋅。ss𬵩\u200D; 𵋅.ss𬵩\u200D; [C2, V7]; xn--ey1p.xn--ss-n1tx0508a; ; xn--ey1p.xn--ss-eq36b; [V7] # .ss𬵩
+𵋅。Ss𬵩\u200D; 𵋅.ss𬵩\u200D; [C2, V7]; xn--ey1p.xn--ss-n1tx0508a; ; xn--ey1p.xn--ss-eq36b; [V7] # .ss𬵩
+xn--ey1p.xn--ss-eq36b; 𵋅.ss𬵩; [V7]; xn--ey1p.xn--ss-eq36b; ; ;  # .ss𬵩
+xn--ey1p.xn--ss-n1tx0508a; 𵋅.ss𬵩\u200D; [C2, V7]; xn--ey1p.xn--ss-n1tx0508a; ; ;  # .ss𬵩
+xn--ey1p.xn--zca870nz438b; 𵋅.ß𬵩\u200D; [C2, V7]; xn--ey1p.xn--zca870nz438b; ; ;  # .ß𬵩
+\u200C𭉝。\u07F1\u0301𞹻; \u200C𭉝.\u07F1\u0301\u063A; [B1, C1, V6]; xn--0ugy003y.xn--lsa46nuub; ; xn--634m.xn--lsa46nuub; [B1, V6] # 𭉝.߱́غ
+\u200C𭉝。\u07F1\u0301\u063A; \u200C𭉝.\u07F1\u0301\u063A; [B1, C1, V6]; xn--0ugy003y.xn--lsa46nuub; ; xn--634m.xn--lsa46nuub; [B1, V6] # 𭉝.߱́غ
+xn--634m.xn--lsa46nuub; 𭉝.\u07F1\u0301\u063A; [B1, V6]; xn--634m.xn--lsa46nuub; ; ;  # 𭉝.߱́غ
+xn--0ugy003y.xn--lsa46nuub; \u200C𭉝.\u07F1\u0301\u063A; [B1, C1, V6]; xn--0ugy003y.xn--lsa46nuub; ; ;  # 𭉝.߱́غ
+𞼌\u200C𑈶。𐹡; 𞼌\u200C𑈶.𐹡; [B1, B3, C1, V7]; xn--0ug7946gzpxf.xn--8n0d; ; xn--9g1d1288a.xn--8n0d; [B1, V7] # 𑈶.𐹡
+xn--9g1d1288a.xn--8n0d; 𞼌𑈶.𐹡; [B1, V7]; xn--9g1d1288a.xn--8n0d; ; ;  # 𑈶.𐹡
+xn--0ug7946gzpxf.xn--8n0d; 𞼌\u200C𑈶.𐹡; [B1, B3, C1, V7]; xn--0ug7946gzpxf.xn--8n0d; ; ;  # 𑈶.𐹡
+󠅯򇽭\u200C🜭｡𑖿\u1ABBς≠; 򇽭\u200C🜭.𑖿\u1ABBς≠; [C1, V6, V7]; xn--0ug3766p5nm1b.xn--3xa578i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [V6, V7] # 🜭.𑖿᪻ς≠
+󠅯򇽭\u200C🜭｡𑖿\u1ABBς=\u0338; 򇽭\u200C🜭.𑖿\u1ABBς≠; [C1, V6, V7]; xn--0ug3766p5nm1b.xn--3xa578i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [V6, V7] # 🜭.𑖿᪻ς≠
+󠅯򇽭\u200C🜭。𑖿\u1ABBς≠; 򇽭\u200C🜭.𑖿\u1ABBς≠; [C1, V6, V7]; xn--0ug3766p5nm1b.xn--3xa578i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [V6, V7] # 🜭.𑖿᪻ς≠
+󠅯򇽭\u200C🜭。𑖿\u1ABBς=\u0338; 򇽭\u200C🜭.𑖿\u1ABBς≠; [C1, V6, V7]; xn--0ug3766p5nm1b.xn--3xa578i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [V6, V7] # 🜭.𑖿᪻ς≠
+󠅯򇽭\u200C🜭。𑖿\u1ABBΣ=\u0338; 򇽭\u200C🜭.𑖿\u1ABBσ≠; [C1, V6, V7]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [V6, V7] # 🜭.𑖿᪻σ≠
+󠅯򇽭\u200C🜭。𑖿\u1ABBΣ≠; 򇽭\u200C🜭.𑖿\u1ABBσ≠; [C1, V6, V7]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [V6, V7] # 🜭.𑖿᪻σ≠
+󠅯򇽭\u200C🜭。𑖿\u1ABBσ≠; 򇽭\u200C🜭.𑖿\u1ABBσ≠; [C1, V6, V7]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [V6, V7] # 🜭.𑖿᪻σ≠
+󠅯򇽭\u200C🜭。𑖿\u1ABBσ=\u0338; 򇽭\u200C🜭.𑖿\u1ABBσ≠; [C1, V6, V7]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [V6, V7] # 🜭.𑖿᪻σ≠
+xn--zb9h5968x.xn--4xa378i1mfjw7y; 򇽭🜭.𑖿\u1ABBσ≠; [V6, V7]; xn--zb9h5968x.xn--4xa378i1mfjw7y; ; ;  # 🜭.𑖿᪻σ≠
+xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; 򇽭\u200C🜭.𑖿\u1ABBσ≠; [C1, V6, V7]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; ;  # 🜭.𑖿᪻σ≠
+xn--0ug3766p5nm1b.xn--3xa578i1mfjw7y; 򇽭\u200C🜭.𑖿\u1ABBς≠; [C1, V6, V7]; xn--0ug3766p5nm1b.xn--3xa578i1mfjw7y; ; ;  # 🜭.𑖿᪻ς≠
+󠅯򇽭\u200C🜭｡𑖿\u1ABBΣ=\u0338; 򇽭\u200C🜭.𑖿\u1ABBσ≠; [C1, V6, V7]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [V6, V7] # 🜭.𑖿᪻σ≠
+󠅯򇽭\u200C🜭｡𑖿\u1ABBΣ≠; 򇽭\u200C🜭.𑖿\u1ABBσ≠; [C1, V6, V7]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [V6, V7] # 🜭.𑖿᪻σ≠
+󠅯򇽭\u200C🜭｡𑖿\u1ABBσ≠; 򇽭\u200C🜭.𑖿\u1ABBσ≠; [C1, V6, V7]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [V6, V7] # 🜭.𑖿᪻σ≠
+󠅯򇽭\u200C🜭｡𑖿\u1ABBσ=\u0338; 򇽭\u200C🜭.𑖿\u1ABBσ≠; [C1, V6, V7]; xn--0ug3766p5nm1b.xn--4xa378i1mfjw7y; ; xn--zb9h5968x.xn--4xa378i1mfjw7y; [V6, V7] # 🜭.𑖿᪻σ≠
+⒋｡⒈\u200D򳴢; ⒋.⒈\u200D򳴢; [C2, V7]; xn--wsh.xn--1ug58o74922a; ; xn--wsh.xn--tsh07994h; [V7] # ⒋.⒈
+4.。1.\u200D򳴢; 4..1.\u200D򳴢; [C2, V7, X4_2]; 4..1.xn--1ug64613i; [C2, V7, A4_2]; 4..1.xn--sf51d; [V7, A4_2] # 4..1.
+4..1.xn--sf51d; 4..1.򳴢; [V7, X4_2]; 4..1.xn--sf51d; [V7, A4_2]; ;  # 4..1.
+4..1.xn--1ug64613i; 4..1.\u200D򳴢; [C2, V7, X4_2]; 4..1.xn--1ug64613i; [C2, V7, A4_2]; ;  # 4..1.
+xn--wsh.xn--tsh07994h; ⒋.⒈򳴢; [V7]; xn--wsh.xn--tsh07994h; ; ;  # ⒋.⒈
+xn--wsh.xn--1ug58o74922a; ⒋.⒈\u200D򳴢; [C2, V7]; xn--wsh.xn--1ug58o74922a; ; ;  # ⒋.⒈
+\u0644ß｡𐇽\u1A60򾅢𞤾; \u0644ß.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--zca57y.xn--jof2298hn83fln78f; ; xn--ss-svd.xn--jof2298hn83fln78f;  # لß.᩠𐇽𞤾
+\u0644ß｡\u1A60𐇽򾅢𞤾; \u0644ß.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--zca57y.xn--jof2298hn83fln78f; ; xn--ss-svd.xn--jof2298hn83fln78f;  # لß.᩠𐇽𞤾
+\u0644ß。\u1A60𐇽򾅢𞤾; \u0644ß.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--zca57y.xn--jof2298hn83fln78f; ; xn--ss-svd.xn--jof2298hn83fln78f;  # لß.᩠𐇽𞤾
+\u0644SS。\u1A60𐇽򾅢𞤜; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+\u0644ss。\u1A60𐇽򾅢𞤾; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+\u0644ss。\u1A60𐇽򾅢𞤜; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+xn--ss-svd.xn--jof2298hn83fln78f; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+\u0644ß。\u1A60𐇽򾅢𞤜; \u0644ß.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--zca57y.xn--jof2298hn83fln78f; ; xn--ss-svd.xn--jof2298hn83fln78f;  # لß.᩠𐇽𞤾
+xn--zca57y.xn--jof2298hn83fln78f; \u0644ß.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--zca57y.xn--jof2298hn83fln78f; ; ;  # لß.᩠𐇽𞤾
+\u0644SS｡\u1A60𐇽򾅢𞤜; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+\u0644ss｡\u1A60𐇽򾅢𞤾; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+\u0644ss｡\u1A60𐇽򾅢𞤜; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+\u0644ß｡\u1A60𐇽򾅢𞤜; \u0644ß.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--zca57y.xn--jof2298hn83fln78f; ; xn--ss-svd.xn--jof2298hn83fln78f;  # لß.᩠𐇽𞤾
+\u0644SS｡𐇽\u1A60򾅢𞤜; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+\u0644ss｡𐇽\u1A60򾅢𞤾; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+\u0644ss｡𐇽\u1A60򾅢𞤜; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+\u0644ß｡𐇽\u1A60򾅢𞤜; \u0644ß.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--zca57y.xn--jof2298hn83fln78f; ; xn--ss-svd.xn--jof2298hn83fln78f;  # لß.᩠𐇽𞤾
+\u0644SS。\u1A60𐇽򾅢𞤾; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+\u0644Ss。\u1A60𐇽򾅢𞤾; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+\u0644SS｡\u1A60𐇽򾅢𞤾; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+\u0644Ss｡\u1A60𐇽򾅢𞤾; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+\u0644SS｡𐇽\u1A60򾅢𞤾; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+\u0644Ss｡𐇽\u1A60򾅢𞤾; \u0644ss.\u1A60𐇽򾅢𞤾; [B1, B2, B3, V6, V7]; xn--ss-svd.xn--jof2298hn83fln78f; ; ;  # لss.᩠𐇽𞤾
+𐹽𑄳񼜲.\u1DDF\u17B8\uA806𑜫; ; [B1, V6, V7]; xn--1o0di0c0652w.xn--33e362arr1l153d; ; ;  # 𐹽𑄳.ᷟី꠆𑜫
+xn--1o0di0c0652w.xn--33e362arr1l153d; 𐹽𑄳񼜲.\u1DDF\u17B8\uA806𑜫; [B1, V6, V7]; xn--1o0di0c0652w.xn--33e362arr1l153d; ; ;  # 𐹽𑄳.ᷟី꠆𑜫
+Ⴓ𑜫\u200D򗭓．\u06A7𑰶; ⴓ𑜫\u200D򗭓.\u06A7𑰶; [V7]; xn--1ugy52cym7p7xu5e.xn--9jb4223l; ; xn--blj6306ey091d.xn--9jb4223l;  # ⴓ𑜫.ڧ𑰶
+Ⴓ𑜫\u200D򗭓.\u06A7𑰶; ⴓ𑜫\u200D򗭓.\u06A7𑰶; [V7]; xn--1ugy52cym7p7xu5e.xn--9jb4223l; ; xn--blj6306ey091d.xn--9jb4223l;  # ⴓ𑜫.ڧ𑰶
+ⴓ𑜫\u200D򗭓.\u06A7𑰶; ; [V7]; xn--1ugy52cym7p7xu5e.xn--9jb4223l; ; xn--blj6306ey091d.xn--9jb4223l;  # ⴓ𑜫.ڧ𑰶
+xn--blj6306ey091d.xn--9jb4223l; ⴓ𑜫򗭓.\u06A7𑰶; [V7]; xn--blj6306ey091d.xn--9jb4223l; ; ;  # ⴓ𑜫.ڧ𑰶
+xn--1ugy52cym7p7xu5e.xn--9jb4223l; ⴓ𑜫\u200D򗭓.\u06A7𑰶; [V7]; xn--1ugy52cym7p7xu5e.xn--9jb4223l; ; ;  # ⴓ𑜫.ڧ𑰶
+ⴓ𑜫\u200D򗭓．\u06A7𑰶; ⴓ𑜫\u200D򗭓.\u06A7𑰶; [V7]; xn--1ugy52cym7p7xu5e.xn--9jb4223l; ; xn--blj6306ey091d.xn--9jb4223l;  # ⴓ𑜫.ڧ𑰶
+xn--rnd8945ky009c.xn--9jb4223l; Ⴓ𑜫򗭓.\u06A7𑰶; [V7]; xn--rnd8945ky009c.xn--9jb4223l; ; ;  # Ⴓ𑜫.ڧ𑰶
+xn--rnd479ep20q7x12e.xn--9jb4223l; Ⴓ𑜫\u200D򗭓.\u06A7𑰶; [V7]; xn--rnd479ep20q7x12e.xn--9jb4223l; ; ;  # Ⴓ𑜫.ڧ𑰶
+𐨿.🄆—; 𐨿.5,—; [V6, U1]; xn--0s9c.xn--5,-81t; ; ;  # 𐨿.5,—
+𐨿.5,—; ; [V6, U1]; xn--0s9c.xn--5,-81t; ; ;  # 𐨿.5,—
+xn--0s9c.xn--5,-81t; 𐨿.5,—; [V6, U1]; xn--0s9c.xn--5,-81t; ; ;  # 𐨿.5,—
+xn--0s9c.xn--8ug8324p; 𐨿.🄆—; [V6, V7]; xn--0s9c.xn--8ug8324p; ; ;  # 𐨿.🄆—
+򔊱񁦮۸。󠾭-; 򔊱񁦮۸.󠾭-; [V3, V7]; xn--lmb18944c0g2z.xn----2k81m; ; ;  # ۸.-
+xn--lmb18944c0g2z.xn----2k81m; 򔊱񁦮۸.󠾭-; [V3, V7]; xn--lmb18944c0g2z.xn----2k81m; ; ;  # ۸.-
+𼗸\u07CD𐹮。\u06DDᡎᠴ; 𼗸\u07CD𐹮.\u06DDᡎᠴ; [B1, B5, B6, V7]; xn--osb0855kcc2r.xn--tlb299fhc; ; ;  # ߍ𐹮.ᡎᠴ
+xn--osb0855kcc2r.xn--tlb299fhc; 𼗸\u07CD𐹮.\u06DDᡎᠴ; [B1, B5, B6, V7]; xn--osb0855kcc2r.xn--tlb299fhc; ; ;  # ߍ𐹮.ᡎᠴ
+\u200DᠮႾ🄂.🚗\u0841𮹌\u200C; \u200Dᠮⴞ1,.🚗\u0841𮹌\u200C; [B1, C1, C2, U1]; xn--1,-v3o161c53q.xn--zvb692j9664aic1g; ; xn--1,-v3o625k.xn--zvb3124wpkpf; [B1, B6, U1] # ᠮⴞ1,.🚗ࡁ𮹌
+\u200DᠮႾ1,.🚗\u0841𮹌\u200C; \u200Dᠮⴞ1,.🚗\u0841𮹌\u200C; [B1, C1, C2, U1]; xn--1,-v3o161c53q.xn--zvb692j9664aic1g; ; xn--1,-v3o625k.xn--zvb3124wpkpf; [B1, B6, U1] # ᠮⴞ1,.🚗ࡁ𮹌
+\u200Dᠮⴞ1,.🚗\u0841𮹌\u200C; ; [B1, C1, C2, U1]; xn--1,-v3o161c53q.xn--zvb692j9664aic1g; ; xn--1,-v3o625k.xn--zvb3124wpkpf; [B1, B6, U1] # ᠮⴞ1,.🚗ࡁ𮹌
+xn--1,-v3o625k.xn--zvb3124wpkpf; ᠮⴞ1,.🚗\u0841𮹌; [B1, B6, U1]; xn--1,-v3o625k.xn--zvb3124wpkpf; ; ;  # ᠮⴞ1,.🚗ࡁ𮹌
+xn--1,-v3o161c53q.xn--zvb692j9664aic1g; \u200Dᠮⴞ1,.🚗\u0841𮹌\u200C; [B1, C1, C2, U1]; xn--1,-v3o161c53q.xn--zvb692j9664aic1g; ; ;  # ᠮⴞ1,.🚗ࡁ𮹌
+\u200Dᠮⴞ🄂.🚗\u0841𮹌\u200C; \u200Dᠮⴞ1,.🚗\u0841𮹌\u200C; [B1, C1, C2, U1]; xn--1,-v3o161c53q.xn--zvb692j9664aic1g; ; xn--1,-v3o625k.xn--zvb3124wpkpf; [B1, B6, U1] # ᠮⴞ1,.🚗ࡁ𮹌
+xn--1,-ogkx89c.xn--zvb3124wpkpf; ᠮႾ1,.🚗\u0841𮹌; [B1, B6, V7, U1]; xn--1,-ogkx89c.xn--zvb3124wpkpf; ; ;  # ᠮႾ1,.🚗ࡁ𮹌
+xn--1,-ogkx89c39j.xn--zvb692j9664aic1g; \u200DᠮႾ1,.🚗\u0841𮹌\u200C; [B1, C1, C2, V7, U1]; xn--1,-ogkx89c39j.xn--zvb692j9664aic1g; ; ;  # ᠮႾ1,.🚗ࡁ𮹌
+xn--h7e438h1p44a.xn--zvb3124wpkpf; ᠮⴞ🄂.🚗\u0841𮹌; [B1, V7]; xn--h7e438h1p44a.xn--zvb3124wpkpf; ; ;  # ᠮⴞ🄂.🚗ࡁ𮹌
+xn--h7e341b0wlbv45b.xn--zvb692j9664aic1g; \u200Dᠮⴞ🄂.🚗\u0841𮹌\u200C; [B1, C1, C2, V7]; xn--h7e341b0wlbv45b.xn--zvb692j9664aic1g; ; ;  # ᠮⴞ🄂.🚗ࡁ𮹌
+xn--2nd129ai554b.xn--zvb3124wpkpf; ᠮႾ🄂.🚗\u0841𮹌; [B1, V7]; xn--2nd129ai554b.xn--zvb3124wpkpf; ; ;  # ᠮႾ🄂.🚗ࡁ𮹌
+xn--2nd129ay2gnw71c.xn--zvb692j9664aic1g; \u200DᠮႾ🄂.🚗\u0841𮹌\u200C; [B1, C1, C2, V7]; xn--2nd129ay2gnw71c.xn--zvb692j9664aic1g; ; ;  # ᠮႾ🄂.🚗ࡁ𮹌
+\u0601\u0697．𑚶񼡷⾆; \u0601\u0697.𑚶񼡷舌; [B1, V6, V7]; xn--jfb41a.xn--tc1ap851axo39c; ; ;  # ڗ.𑚶舌
+\u0601\u0697.𑚶񼡷舌; ; [B1, V6, V7]; xn--jfb41a.xn--tc1ap851axo39c; ; ;  # ڗ.𑚶舌
+xn--jfb41a.xn--tc1ap851axo39c; \u0601\u0697.𑚶񼡷舌; [B1, V6, V7]; xn--jfb41a.xn--tc1ap851axo39c; ; ;  # ڗ.𑚶舌
+🞅󠳡󜍙.񲖷; ; [V7]; xn--ie9hi1349bqdlb.xn--oj69a; ; ;  # 🞅.
+xn--ie9hi1349bqdlb.xn--oj69a; 🞅󠳡󜍙.񲖷; [V7]; xn--ie9hi1349bqdlb.xn--oj69a; ; ;  # 🞅.
+\u20E7񯡎-򫣝.4Ⴄ\u200C; \u20E7񯡎-򫣝.4ⴄ\u200C; [C1, V6, V7]; xn----9snu5320fi76w.xn--4-sgn589c; ; xn----9snu5320fi76w.xn--4-ivs; [V6, V7] # ⃧-.4ⴄ
+\u20E7񯡎-򫣝.4ⴄ\u200C; ; [C1, V6, V7]; xn----9snu5320fi76w.xn--4-sgn589c; ; xn----9snu5320fi76w.xn--4-ivs; [V6, V7] # ⃧-.4ⴄ
+xn----9snu5320fi76w.xn--4-ivs; \u20E7񯡎-򫣝.4ⴄ; [V6, V7]; xn----9snu5320fi76w.xn--4-ivs; ; ;  # ⃧-.4ⴄ
+xn----9snu5320fi76w.xn--4-sgn589c; \u20E7񯡎-򫣝.4ⴄ\u200C; [C1, V6, V7]; xn----9snu5320fi76w.xn--4-sgn589c; ; ;  # ⃧-.4ⴄ
+xn----9snu5320fi76w.xn--4-f0g; \u20E7񯡎-򫣝.4Ⴄ; [V6, V7]; xn----9snu5320fi76w.xn--4-f0g; ; ;  # ⃧-.4Ⴄ
+xn----9snu5320fi76w.xn--4-f0g649i; \u20E7񯡎-򫣝.4Ⴄ\u200C; [C1, V6, V7]; xn----9snu5320fi76w.xn--4-f0g649i; ; ;  # ⃧-.4Ⴄ
+ᚭ｡𝌠ß𖫱; ᚭ.𝌠ß𖫱; ; xn--hwe.xn--zca4946pblnc; ; xn--hwe.xn--ss-ci1ub261a;  # ᚭ.𝌠ß𖫱
+ᚭ。𝌠ß𖫱; ᚭ.𝌠ß𖫱; ; xn--hwe.xn--zca4946pblnc; ; xn--hwe.xn--ss-ci1ub261a;  # ᚭ.𝌠ß𖫱
+ᚭ。𝌠SS𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+ᚭ。𝌠ss𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+ᚭ。𝌠Ss𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+xn--hwe.xn--ss-ci1ub261a; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+ᚭ.𝌠ss𖫱; ; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+ᚭ.𝌠SS𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+ᚭ.𝌠Ss𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+xn--hwe.xn--zca4946pblnc; ᚭ.𝌠ß𖫱; ; xn--hwe.xn--zca4946pblnc; ; ;  # ᚭ.𝌠ß𖫱
+ᚭ.𝌠ß𖫱; ; ; xn--hwe.xn--zca4946pblnc; ; xn--hwe.xn--ss-ci1ub261a;  # ᚭ.𝌠ß𖫱
+ᚭ｡𝌠SS𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+ᚭ｡𝌠ss𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+ᚭ｡𝌠Ss𖫱; ᚭ.𝌠ss𖫱; ; xn--hwe.xn--ss-ci1ub261a; ; ;  # ᚭ.𝌠ss𖫱
+₁｡𞤫ꡪ; 1.𞤫ꡪ; [B1, B2, B3]; 1.xn--gd9al691d; ; ;  # 1.𞤫ꡪ
+1。𞤫ꡪ; 1.𞤫ꡪ; [B1, B2, B3]; 1.xn--gd9al691d; ; ;  # 1.𞤫ꡪ
+1。𞤉ꡪ; 1.𞤫ꡪ; [B1, B2, B3]; 1.xn--gd9al691d; ; ;  # 1.𞤫ꡪ
+1.xn--gd9al691d; 1.𞤫ꡪ; [B1, B2, B3]; 1.xn--gd9al691d; ; ;  # 1.𞤫ꡪ
+₁｡𞤉ꡪ; 1.𞤫ꡪ; [B1, B2, B3]; 1.xn--gd9al691d; ; ;  # 1.𞤫ꡪ
+𯻼\u200C.𞶞򻙤񥘇; ; [B2, B3, B6, C1, V7]; xn--0ug27500a.xn--2b7hs861pl540a; ; xn--kg4n.xn--2b7hs861pl540a; [B2, B3, V7] # .
+xn--kg4n.xn--2b7hs861pl540a; 𯻼.𞶞򻙤񥘇; [B2, B3, V7]; xn--kg4n.xn--2b7hs861pl540a; ; ;  # .
+xn--0ug27500a.xn--2b7hs861pl540a; 𯻼\u200C.𞶞򻙤񥘇; [B2, B3, B6, C1, V7]; xn--0ug27500a.xn--2b7hs861pl540a; ; ;  # .
+𑑄≯｡𑜤; 𑑄≯.𑜤; [V6]; xn--hdh5636g.xn--ci2d; ; ;  # 𑑄≯.𑜤
+𑑄>\u0338｡𑜤; 𑑄≯.𑜤; [V6]; xn--hdh5636g.xn--ci2d; ; ;  # 𑑄≯.𑜤
+𑑄≯。𑜤; 𑑄≯.𑜤; [V6]; xn--hdh5636g.xn--ci2d; ; ;  # 𑑄≯.𑜤
+𑑄>\u0338。𑜤; 𑑄≯.𑜤; [V6]; xn--hdh5636g.xn--ci2d; ; ;  # 𑑄≯.𑜤
+xn--hdh5636g.xn--ci2d; 𑑄≯.𑜤; [V6]; xn--hdh5636g.xn--ci2d; ; ;  # 𑑄≯.𑜤
+Ⴋ≮𱲆。\u200D\u07A7𐋣; ⴋ≮𱲆.\u200D\u07A7𐋣; [C2]; xn--gdhz03bxt42d.xn--lrb506jqr4n; ; xn--gdhz03bxt42d.xn--lrb6479j; [V6] # ⴋ≮𱲆.ާ𐋣
+Ⴋ<\u0338𱲆。\u200D\u07A7𐋣; ⴋ≮𱲆.\u200D\u07A7𐋣; [C2]; xn--gdhz03bxt42d.xn--lrb506jqr4n; ; xn--gdhz03bxt42d.xn--lrb6479j; [V6] # ⴋ≮𱲆.ާ𐋣
+ⴋ<\u0338𱲆。\u200D\u07A7𐋣; ⴋ≮𱲆.\u200D\u07A7𐋣; [C2]; xn--gdhz03bxt42d.xn--lrb506jqr4n; ; xn--gdhz03bxt42d.xn--lrb6479j; [V6] # ⴋ≮𱲆.ާ𐋣
+ⴋ≮𱲆。\u200D\u07A7𐋣; ⴋ≮𱲆.\u200D\u07A7𐋣; [C2]; xn--gdhz03bxt42d.xn--lrb506jqr4n; ; xn--gdhz03bxt42d.xn--lrb6479j; [V6] # ⴋ≮𱲆.ާ𐋣
+xn--gdhz03bxt42d.xn--lrb6479j; ⴋ≮𱲆.\u07A7𐋣; [V6]; xn--gdhz03bxt42d.xn--lrb6479j; ; ;  # ⴋ≮𱲆.ާ𐋣
+xn--gdhz03bxt42d.xn--lrb506jqr4n; ⴋ≮𱲆.\u200D\u07A7𐋣; [C2]; xn--gdhz03bxt42d.xn--lrb506jqr4n; ; ;  # ⴋ≮𱲆.ާ𐋣
+xn--jnd802gsm17c.xn--lrb6479j; Ⴋ≮𱲆.\u07A7𐋣; [V6, V7]; xn--jnd802gsm17c.xn--lrb6479j; ; ;  # Ⴋ≮𱲆.ާ𐋣
+xn--jnd802gsm17c.xn--lrb506jqr4n; Ⴋ≮𱲆.\u200D\u07A7𐋣; [C2, V7]; xn--jnd802gsm17c.xn--lrb506jqr4n; ; ;  # Ⴋ≮𱲆.ާ𐋣
+\u17D2.򆽒≯; ; [V6, V7]; xn--u4e.xn--hdhx0084f; ; ;  # ្.≯
+\u17D2.򆽒>\u0338; \u17D2.򆽒≯; [V6, V7]; xn--u4e.xn--hdhx0084f; ; ;  # ្.≯
+xn--u4e.xn--hdhx0084f; \u17D2.򆽒≯; [V6, V7]; xn--u4e.xn--hdhx0084f; ; ;  # ្.≯
+񏁇\u1734．𐨺É⬓𑄴; 񏁇\u1734.𐨺é⬓𑄴; [V6, V7]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+񏁇\u1734．𐨺E\u0301⬓𑄴; 񏁇\u1734.𐨺é⬓𑄴; [V6, V7]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+񏁇\u1734.𐨺É⬓𑄴; 񏁇\u1734.𐨺é⬓𑄴; [V6, V7]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+񏁇\u1734.𐨺E\u0301⬓𑄴; 񏁇\u1734.𐨺é⬓𑄴; [V6, V7]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+񏁇\u1734.𐨺e\u0301⬓𑄴; 񏁇\u1734.𐨺é⬓𑄴; [V6, V7]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+񏁇\u1734.𐨺é⬓𑄴; ; [V6, V7]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+xn--c0e34564d.xn--9ca207st53lg3f; 񏁇\u1734.𐨺é⬓𑄴; [V6, V7]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+񏁇\u1734．𐨺e\u0301⬓𑄴; 񏁇\u1734.𐨺é⬓𑄴; [V6, V7]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+񏁇\u1734．𐨺é⬓𑄴; 񏁇\u1734.𐨺é⬓𑄴; [V6, V7]; xn--c0e34564d.xn--9ca207st53lg3f; ; ;  # ᜴.𐨺é⬓𑄴
+ᢇ\u200D\uA8C4｡︒𞤺; ᢇ\u200D\uA8C4.︒𞤺; [B1, B6, C2, V7]; xn--09e669a6x8j.xn--y86cv562b; ; xn--09e4694e.xn--y86cv562b; [B1, V7] # ᢇ꣄.︒𞤺
+ᢇ\u200D\uA8C4。。𞤺; ᢇ\u200D\uA8C4..𞤺; [B6, C2, X4_2]; xn--09e669a6x8j..xn--ye6h; [B6, C2, A4_2]; xn--09e4694e..xn--ye6h; [A4_2] # ᢇ꣄..𞤺
+ᢇ\u200D\uA8C4。。𞤘; ᢇ\u200D\uA8C4..𞤺; [B6, C2, X4_2]; xn--09e669a6x8j..xn--ye6h; [B6, C2, A4_2]; xn--09e4694e..xn--ye6h; [A4_2] # ᢇ꣄..𞤺
+xn--09e4694e..xn--ye6h; ᢇ\uA8C4..𞤺; [X4_2]; xn--09e4694e..xn--ye6h; [A4_2]; ;  # ᢇ꣄..𞤺
+xn--09e669a6x8j..xn--ye6h; ᢇ\u200D\uA8C4..𞤺; [B6, C2, X4_2]; xn--09e669a6x8j..xn--ye6h; [B6, C2, A4_2]; ;  # ᢇ꣄..𞤺
+ᢇ\u200D\uA8C4｡︒𞤘; ᢇ\u200D\uA8C4.︒𞤺; [B1, B6, C2, V7]; xn--09e669a6x8j.xn--y86cv562b; ; xn--09e4694e.xn--y86cv562b; [B1, V7] # ᢇ꣄.︒𞤺
+xn--09e4694e.xn--y86cv562b; ᢇ\uA8C4.︒𞤺; [B1, V7]; xn--09e4694e.xn--y86cv562b; ; ;  # ᢇ꣄.︒𞤺
+xn--09e669a6x8j.xn--y86cv562b; ᢇ\u200D\uA8C4.︒𞤺; [B1, B6, C2, V7]; xn--09e669a6x8j.xn--y86cv562b; ; ;  # ᢇ꣄.︒𞤺
+𞩬򖙱\u1714\u200C｡\u0631\u07AA≮; 𞩬򖙱\u1714\u200C.\u0631\u07AA≮; [B2, B3, V7]; xn--fze607b9651bjwl7c.xn--wgb86el10d; ; xn--fze3930v7hz6b.xn--wgb86el10d;  # ᜔.رު≮
+𞩬򖙱\u1714\u200C｡\u0631\u07AA<\u0338; 𞩬򖙱\u1714\u200C.\u0631\u07AA≮; [B2, B3, V7]; xn--fze607b9651bjwl7c.xn--wgb86el10d; ; xn--fze3930v7hz6b.xn--wgb86el10d;  # ᜔.رު≮
+𞩬򖙱\u1714\u200C。\u0631\u07AA≮; 𞩬򖙱\u1714\u200C.\u0631\u07AA≮; [B2, B3, V7]; xn--fze607b9651bjwl7c.xn--wgb86el10d; ; xn--fze3930v7hz6b.xn--wgb86el10d;  # ᜔.رު≮
+𞩬򖙱\u1714\u200C。\u0631\u07AA<\u0338; 𞩬򖙱\u1714\u200C.\u0631\u07AA≮; [B2, B3, V7]; xn--fze607b9651bjwl7c.xn--wgb86el10d; ; xn--fze3930v7hz6b.xn--wgb86el10d;  # ᜔.رު≮
+xn--fze3930v7hz6b.xn--wgb86el10d; 𞩬򖙱\u1714.\u0631\u07AA≮; [B2, B3, V7]; xn--fze3930v7hz6b.xn--wgb86el10d; ; ;  # ᜔.رު≮
+xn--fze607b9651bjwl7c.xn--wgb86el10d; 𞩬򖙱\u1714\u200C.\u0631\u07AA≮; [B2, B3, V7]; xn--fze607b9651bjwl7c.xn--wgb86el10d; ; ;  # ᜔.رު≮
+Ⴣ．\u0653ᢤ; ⴣ.\u0653ᢤ; [V6]; xn--rlj.xn--vhb294g; ; ;  # ⴣ.ٓᢤ
+Ⴣ.\u0653ᢤ; ⴣ.\u0653ᢤ; [V6]; xn--rlj.xn--vhb294g; ; ;  # ⴣ.ٓᢤ
+ⴣ.\u0653ᢤ; ; [V6]; xn--rlj.xn--vhb294g; ; ;  # ⴣ.ٓᢤ
+xn--rlj.xn--vhb294g; ⴣ.\u0653ᢤ; [V6]; xn--rlj.xn--vhb294g; ; ;  # ⴣ.ٓᢤ
+ⴣ．\u0653ᢤ; ⴣ.\u0653ᢤ; [V6]; xn--rlj.xn--vhb294g; ; ;  # ⴣ.ٓᢤ
+xn--7nd.xn--vhb294g; Ⴣ.\u0653ᢤ; [V6, V7]; xn--7nd.xn--vhb294g; ; ;  # Ⴣ.ٓᢤ
+󠄈\u0813．싉򄆻Ⴤ򂡐; \u0813.싉򄆻ⴤ򂡐; [V7]; xn--oub.xn--sljz109bpe25dviva; ; ;  # ࠓ.싉ⴤ
+󠄈\u0813．싉򄆻Ⴤ򂡐; \u0813.싉򄆻ⴤ򂡐; [V7]; xn--oub.xn--sljz109bpe25dviva; ; ;  # ࠓ.싉ⴤ
+󠄈\u0813.싉򄆻Ⴤ򂡐; \u0813.싉򄆻ⴤ򂡐; [V7]; xn--oub.xn--sljz109bpe25dviva; ; ;  # ࠓ.싉ⴤ
+󠄈\u0813.싉򄆻Ⴤ򂡐; \u0813.싉򄆻ⴤ򂡐; [V7]; xn--oub.xn--sljz109bpe25dviva; ; ;  # ࠓ.싉ⴤ
+󠄈\u0813.싉򄆻ⴤ򂡐; \u0813.싉򄆻ⴤ򂡐; [V7]; xn--oub.xn--sljz109bpe25dviva; ; ;  # ࠓ.싉ⴤ
+󠄈\u0813.싉򄆻ⴤ򂡐; \u0813.싉򄆻ⴤ򂡐; [V7]; xn--oub.xn--sljz109bpe25dviva; ; ;  # ࠓ.싉ⴤ
+xn--oub.xn--sljz109bpe25dviva; \u0813.싉򄆻ⴤ򂡐; [V7]; xn--oub.xn--sljz109bpe25dviva; ; ;  # ࠓ.싉ⴤ
+󠄈\u0813．싉򄆻ⴤ򂡐; \u0813.싉򄆻ⴤ򂡐; [V7]; xn--oub.xn--sljz109bpe25dviva; ; ;  # ࠓ.싉ⴤ
+󠄈\u0813．싉򄆻ⴤ򂡐; \u0813.싉򄆻ⴤ򂡐; [V7]; xn--oub.xn--sljz109bpe25dviva; ; ;  # ࠓ.싉ⴤ
+xn--oub.xn--8nd9522gpe69cviva; \u0813.싉򄆻Ⴤ򂡐; [V7]; xn--oub.xn--8nd9522gpe69cviva; ; ;  # ࠓ.싉Ⴤ
+\uAA2C𑲫≮．⤂; \uAA2C𑲫≮.⤂; [V6]; xn--gdh1854cn19c.xn--kqi; ; ;  # ꨬ𑲫≮.⤂
+\uAA2C𑲫<\u0338．⤂; \uAA2C𑲫≮.⤂; [V6]; xn--gdh1854cn19c.xn--kqi; ; ;  # ꨬ𑲫≮.⤂
+\uAA2C𑲫≮.⤂; ; [V6]; xn--gdh1854cn19c.xn--kqi; ; ;  # ꨬ𑲫≮.⤂
+\uAA2C𑲫<\u0338.⤂; \uAA2C𑲫≮.⤂; [V6]; xn--gdh1854cn19c.xn--kqi; ; ;  # ꨬ𑲫≮.⤂
+xn--gdh1854cn19c.xn--kqi; \uAA2C𑲫≮.⤂; [V6]; xn--gdh1854cn19c.xn--kqi; ; ;  # ꨬ𑲫≮.⤂
+\u0604𐩔≮Ⴢ．Ⴃ; \u0604𐩔≮ⴢ.ⴃ; [B1, V7]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+\u0604𐩔<\u0338Ⴢ．Ⴃ; \u0604𐩔≮ⴢ.ⴃ; [B1, V7]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+\u0604𐩔≮Ⴢ.Ⴃ; \u0604𐩔≮ⴢ.ⴃ; [B1, V7]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+\u0604𐩔<\u0338Ⴢ.Ⴃ; \u0604𐩔≮ⴢ.ⴃ; [B1, V7]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+\u0604𐩔<\u0338ⴢ.ⴃ; \u0604𐩔≮ⴢ.ⴃ; [B1, V7]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+\u0604𐩔≮ⴢ.ⴃ; ; [B1, V7]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+\u0604𐩔≮Ⴢ.ⴃ; \u0604𐩔≮ⴢ.ⴃ; [B1, V7]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+\u0604𐩔<\u0338Ⴢ.ⴃ; \u0604𐩔≮ⴢ.ⴃ; [B1, V7]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+xn--mfb266l4khr54u.xn--ukj; \u0604𐩔≮ⴢ.ⴃ; [B1, V7]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+\u0604𐩔<\u0338ⴢ．ⴃ; \u0604𐩔≮ⴢ.ⴃ; [B1, V7]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+\u0604𐩔≮ⴢ．ⴃ; \u0604𐩔≮ⴢ.ⴃ; [B1, V7]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+\u0604𐩔≮Ⴢ．ⴃ; \u0604𐩔≮ⴢ.ⴃ; [B1, V7]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+\u0604𐩔<\u0338Ⴢ．ⴃ; \u0604𐩔≮ⴢ.ⴃ; [B1, V7]; xn--mfb266l4khr54u.xn--ukj; ; ;  # 𐩔≮ⴢ.ⴃ
+xn--mfb416c0jox02t.xn--ukj; \u0604𐩔≮Ⴢ.ⴃ; [B1, V7]; xn--mfb416c0jox02t.xn--ukj; ; ;  # 𐩔≮Ⴢ.ⴃ
+xn--mfb416c0jox02t.xn--bnd; \u0604𐩔≮Ⴢ.Ⴃ; [B1, V7]; xn--mfb416c0jox02t.xn--bnd; ; ;  # 𐩔≮Ⴢ.Ⴃ
+𑁅。-; 𑁅.-; [V3, V6]; xn--210d.-; ; ;  # 𑁅.-
+xn--210d.-; 𑁅.-; [V3, V6]; xn--210d.-; ; ;  # 𑁅.-
+\u0DCA򕸽󠧱｡饈≠\u0664; \u0DCA򕸽󠧱.饈≠\u0664; [B1, B5, B6, V6, V7]; xn--h1c25913jfwov.xn--dib144ler5f; ; ;  # ්.饈≠٤
+\u0DCA򕸽󠧱｡饈=\u0338\u0664; \u0DCA򕸽󠧱.饈≠\u0664; [B1, B5, B6, V6, V7]; xn--h1c25913jfwov.xn--dib144ler5f; ; ;  # ්.饈≠٤
+\u0DCA򕸽󠧱。饈≠\u0664; \u0DCA򕸽󠧱.饈≠\u0664; [B1, B5, B6, V6, V7]; xn--h1c25913jfwov.xn--dib144ler5f; ; ;  # ්.饈≠٤
+\u0DCA򕸽󠧱。饈=\u0338\u0664; \u0DCA򕸽󠧱.饈≠\u0664; [B1, B5, B6, V6, V7]; xn--h1c25913jfwov.xn--dib144ler5f; ; ;  # ්.饈≠٤
+xn--h1c25913jfwov.xn--dib144ler5f; \u0DCA򕸽󠧱.饈≠\u0664; [B1, B5, B6, V6, V7]; xn--h1c25913jfwov.xn--dib144ler5f; ; ;  # ්.饈≠٤
+𞥃ᠠ⁷｡≯邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+𞥃ᠠ⁷｡>\u0338邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+𞥃ᠠ7。≯邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+𞥃ᠠ7。>\u0338邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+𞤡ᠠ7。>\u0338邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+𞤡ᠠ7。≯邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+xn--7-v4j2826w.xn--4-ogoy01bou3i; 𞥃ᠠ7.≯邅⬻4; [B1, B2]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+𞤡ᠠ⁷｡>\u0338邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+𞤡ᠠ⁷｡≯邅⬻4; 𞥃ᠠ7.≯邅⬻4; [B1, B2]; xn--7-v4j2826w.xn--4-ogoy01bou3i; ; ;  # 𞥃ᠠ7.≯邅⬻4
+򠿯ᡳ-𑐻.𐹴𐋫\u0605󑎳; ; [B1, B6, V7]; xn----m9j3429kxmy7e.xn--nfb7950kdihrp812a; ; ;  # ᡳ-𑐻.𐹴𐋫
+xn----m9j3429kxmy7e.xn--nfb7950kdihrp812a; 򠿯ᡳ-𑐻.𐹴𐋫\u0605󑎳; [B1, B6, V7]; xn----m9j3429kxmy7e.xn--nfb7950kdihrp812a; ; ;  # ᡳ-𑐻.𐹴𐋫
+򠶆\u0845\u0A51.넨-󶧈; ; [B5, B6, V7]; xn--3vb26hb6834b.xn----i37ez0957g; ; ;  # ࡅੑ.넨-
+򠶆\u0845\u0A51.넨-󶧈; 򠶆\u0845\u0A51.넨-󶧈; [B5, B6, V7]; xn--3vb26hb6834b.xn----i37ez0957g; ; ;  # ࡅੑ.넨-
+xn--3vb26hb6834b.xn----i37ez0957g; 򠶆\u0845\u0A51.넨-󶧈; [B5, B6, V7]; xn--3vb26hb6834b.xn----i37ez0957g; ; ;  # ࡅੑ.넨-
+ꡦᡑ\u200D⒈。𐋣-; ꡦᡑ\u200D⒈.𐋣-; [C2, V3, V7]; xn--h8e470bl0d838o.xn----381i; ; xn--h8e863drj7h.xn----381i; [V3, V7] # ꡦᡑ⒈.𐋣-
+ꡦᡑ\u200D1.。𐋣-; ꡦᡑ\u200D1..𐋣-; [C2, V3, X4_2]; xn--1-o7j663bdl7m..xn----381i; [C2, V3, A4_2]; xn--1-o7j0610f..xn----381i; [V3, A4_2] # ꡦᡑ1..𐋣-
+xn--1-o7j0610f..xn----381i; ꡦᡑ1..𐋣-; [V3, X4_2]; xn--1-o7j0610f..xn----381i; [V3, A4_2]; ;  # ꡦᡑ1..𐋣-
+xn--1-o7j663bdl7m..xn----381i; ꡦᡑ\u200D1..𐋣-; [C2, V3, X4_2]; xn--1-o7j663bdl7m..xn----381i; [C2, V3, A4_2]; ;  # ꡦᡑ1..𐋣-
+xn--h8e863drj7h.xn----381i; ꡦᡑ⒈.𐋣-; [V3, V7]; xn--h8e863drj7h.xn----381i; ; ;  # ꡦᡑ⒈.𐋣-
+xn--h8e470bl0d838o.xn----381i; ꡦᡑ\u200D⒈.𐋣-; [C2, V3, V7]; xn--h8e470bl0d838o.xn----381i; ; ;  # ꡦᡑ⒈.𐋣-
+Ⴌ。􍼠\uFB69; ⴌ.􍼠\u0679; [B5, B6, V7]; xn--3kj.xn--yib19191t; ; ;  # ⴌ.ٹ
+Ⴌ。􍼠\u0679; ⴌ.􍼠\u0679; [B5, B6, V7]; xn--3kj.xn--yib19191t; ; ;  # ⴌ.ٹ
+ⴌ。􍼠\u0679; ⴌ.􍼠\u0679; [B5, B6, V7]; xn--3kj.xn--yib19191t; ; ;  # ⴌ.ٹ
+xn--3kj.xn--yib19191t; ⴌ.􍼠\u0679; [B5, B6, V7]; xn--3kj.xn--yib19191t; ; ;  # ⴌ.ٹ
+ⴌ。􍼠\uFB69; ⴌ.􍼠\u0679; [B5, B6, V7]; xn--3kj.xn--yib19191t; ; ;  # ⴌ.ٹ
+xn--knd.xn--yib19191t; Ⴌ.􍼠\u0679; [B5, B6, V7]; xn--knd.xn--yib19191t; ; ;  # Ⴌ.ٹ
+𐮁𐭱.\u0F84\u135E-ᳺ; ; [B1, V6]; xn--r19c5a.xn----xjg270ag3m; ; ;  # 𐮁𐭱.྄፞-ᳺ
+xn--r19c5a.xn----xjg270ag3m; 𐮁𐭱.\u0F84\u135E-ᳺ; [B1, V6]; xn--r19c5a.xn----xjg270ag3m; ; ;  # 𐮁𐭱.྄፞-ᳺ
+⒈䰹\u200D-。웈; ⒈䰹\u200D-.웈; [C2, V3, V7]; xn----tgnx5rjr6c.xn--kp5b; ; xn----dcp160o.xn--kp5b; [V3, V7] # ⒈䰹-.웈
+⒈䰹\u200D-。웈; ⒈䰹\u200D-.웈; [C2, V3, V7]; xn----tgnx5rjr6c.xn--kp5b; ; xn----dcp160o.xn--kp5b; [V3, V7] # ⒈䰹-.웈
+1.䰹\u200D-。웈; 1.䰹\u200D-.웈; [C2, V3]; 1.xn----tgnz80r.xn--kp5b; ; 1.xn----zw5a.xn--kp5b; [V3] # 1.䰹-.웈
+1.䰹\u200D-。웈; 1.䰹\u200D-.웈; [C2, V3]; 1.xn----tgnz80r.xn--kp5b; ; 1.xn----zw5a.xn--kp5b; [V3] # 1.䰹-.웈
+1.xn----zw5a.xn--kp5b; 1.䰹-.웈; [V3]; 1.xn----zw5a.xn--kp5b; ; ;  # 1.䰹-.웈
+1.xn----tgnz80r.xn--kp5b; 1.䰹\u200D-.웈; [C2, V3]; 1.xn----tgnz80r.xn--kp5b; ; ;  # 1.䰹-.웈
+xn----dcp160o.xn--kp5b; ⒈䰹-.웈; [V3, V7]; xn----dcp160o.xn--kp5b; ; ;  # ⒈䰹-.웈
+xn----tgnx5rjr6c.xn--kp5b; ⒈䰹\u200D-.웈; [C2, V3, V7]; xn----tgnx5rjr6c.xn--kp5b; ; ;  # ⒈䰹-.웈
+て。\u200C󠳽\u07F3; て.\u200C󠳽\u07F3; [C1, V7]; xn--m9j.xn--rtb154j9l73w; ; xn--m9j.xn--rtb10784p; [V7] # て.߳
+xn--m9j.xn--rtb10784p; て.󠳽\u07F3; [V7]; xn--m9j.xn--rtb10784p; ; ;  # て.߳
+xn--m9j.xn--rtb154j9l73w; て.\u200C󠳽\u07F3; [C1, V7]; xn--m9j.xn--rtb154j9l73w; ; ;  # て.߳
+ς｡\uA9C0\u06E7; ς.\uA9C0\u06E7; [V6]; xn--3xa.xn--3lb1944f; ; xn--4xa.xn--3lb1944f;  # ς.꧀ۧ
+ς。\uA9C0\u06E7; ς.\uA9C0\u06E7; [V6]; xn--3xa.xn--3lb1944f; ; xn--4xa.xn--3lb1944f;  # ς.꧀ۧ
+Σ。\uA9C0\u06E7; σ.\uA9C0\u06E7; [V6]; xn--4xa.xn--3lb1944f; ; ;  # σ.꧀ۧ
+σ。\uA9C0\u06E7; σ.\uA9C0\u06E7; [V6]; xn--4xa.xn--3lb1944f; ; ;  # σ.꧀ۧ
+xn--4xa.xn--3lb1944f; σ.\uA9C0\u06E7; [V6]; xn--4xa.xn--3lb1944f; ; ;  # σ.꧀ۧ
+xn--3xa.xn--3lb1944f; ς.\uA9C0\u06E7; [V6]; xn--3xa.xn--3lb1944f; ; ;  # ς.꧀ۧ
+Σ｡\uA9C0\u06E7; σ.\uA9C0\u06E7; [V6]; xn--4xa.xn--3lb1944f; ; ;  # σ.꧀ۧ
+σ｡\uA9C0\u06E7; σ.\uA9C0\u06E7; [V6]; xn--4xa.xn--3lb1944f; ; ;  # σ.꧀ۧ
+\u0BCD󥫅򌉑.ႢႵ; \u0BCD󥫅򌉑.ⴂⴕ; [V6, V7]; xn--xmc83135idcxza.xn--tkjwb; ; ;  # ்.ⴂⴕ
+\u0BCD󥫅򌉑.ⴂⴕ; ; [V6, V7]; xn--xmc83135idcxza.xn--tkjwb; ; ;  # ்.ⴂⴕ
+\u0BCD󥫅򌉑.Ⴂⴕ; \u0BCD󥫅򌉑.ⴂⴕ; [V6, V7]; xn--xmc83135idcxza.xn--tkjwb; ; ;  # ்.ⴂⴕ
+xn--xmc83135idcxza.xn--tkjwb; \u0BCD󥫅򌉑.ⴂⴕ; [V6, V7]; xn--xmc83135idcxza.xn--tkjwb; ; ;  # ்.ⴂⴕ
+xn--xmc83135idcxza.xn--9md086l; \u0BCD󥫅򌉑.Ⴂⴕ; [V6, V7]; xn--xmc83135idcxza.xn--9md086l; ; ;  # ்.Ⴂⴕ
+xn--xmc83135idcxza.xn--9md2b; \u0BCD󥫅򌉑.ႢႵ; [V6, V7]; xn--xmc83135idcxza.xn--9md2b; ; ;  # ்.ႢႵ
+\u1C32🄈⾛\u05A6．\u200D򯥤\u07FD; \u1C327,走\u05A6.\u200D򯥤\u07FD; [C2, V6, V7, U1]; xn--7,-bid991urn3k.xn--1tb334j1197q; ; xn--7,-bid991urn3k.xn--1tb13454l; [V6, V7, U1] # ᰲ7,走֦.߽
+\u1C327,走\u05A6.\u200D򯥤\u07FD; ; [C2, V6, V7, U1]; xn--7,-bid991urn3k.xn--1tb334j1197q; ; xn--7,-bid991urn3k.xn--1tb13454l; [V6, V7, U1] # ᰲ7,走֦.߽
+xn--7,-bid991urn3k.xn--1tb13454l; \u1C327,走\u05A6.򯥤\u07FD; [V6, V7, U1]; xn--7,-bid991urn3k.xn--1tb13454l; ; ;  # ᰲ7,走֦.߽
+xn--7,-bid991urn3k.xn--1tb334j1197q; \u1C327,走\u05A6.\u200D򯥤\u07FD; [C2, V6, V7, U1]; xn--7,-bid991urn3k.xn--1tb334j1197q; ; ;  # ᰲ7,走֦.߽
+xn--xcb756i493fwi5o.xn--1tb13454l; \u1C32🄈走\u05A6.򯥤\u07FD; [V6, V7]; xn--xcb756i493fwi5o.xn--1tb13454l; ; ;  # ᰲ🄈走֦.߽
+xn--xcb756i493fwi5o.xn--1tb334j1197q; \u1C32🄈走\u05A6.\u200D򯥤\u07FD; [C2, V6, V7]; xn--xcb756i493fwi5o.xn--1tb334j1197q; ; ;  # ᰲ🄈走֦.߽
+ᢗ｡Ӏ񝄻; ᢗ.ӏ񝄻; [V7]; xn--hbf.xn--s5a83117e; ; ;  # ᢗ.ӏ
+ᢗ。Ӏ񝄻; ᢗ.ӏ񝄻; [V7]; xn--hbf.xn--s5a83117e; ; ;  # ᢗ.ӏ
+ᢗ。ӏ񝄻; ᢗ.ӏ񝄻; [V7]; xn--hbf.xn--s5a83117e; ; ;  # ᢗ.ӏ
+xn--hbf.xn--s5a83117e; ᢗ.ӏ񝄻; [V7]; xn--hbf.xn--s5a83117e; ; ;  # ᢗ.ӏ
+ᢗ｡ӏ񝄻; ᢗ.ӏ񝄻; [V7]; xn--hbf.xn--s5a83117e; ; ;  # ᢗ.ӏ
+xn--hbf.xn--d5a86117e; ᢗ.Ӏ񝄻; [V7]; xn--hbf.xn--d5a86117e; ; ;  # ᢗ.Ӏ
+\u0668-。񠏇🝆ᄾ; \u0668-.񠏇🝆ᄾ; [B1, V3, V7]; xn----oqc.xn--qrd1699v327w; ; ;  # ٨-.🝆ᄾ
+xn----oqc.xn--qrd1699v327w; \u0668-.񠏇🝆ᄾ; [B1, V3, V7]; xn----oqc.xn--qrd1699v327w; ; ;  # ٨-.🝆ᄾ
+-𐋷𖾑。󠆬; -𐋷𖾑.; [V3]; xn----991iq40y.; [V3, A4_2]; ;  # -𐋷𖾑.
+xn----991iq40y.; -𐋷𖾑.; [V3]; xn----991iq40y.; [V3, A4_2]; ;  # -𐋷𖾑.
+\u200C𐹳🐴멈.\uABED񐡼; ; [B1, C1, V6, V7]; xn--0ug6681d406b7bwk.xn--429a8682s; ; xn--422b325mqb6i.xn--429a8682s; [B1, V6, V7] # 𐹳🐴멈.꯭
+\u200C𐹳🐴멈.\uABED񐡼; \u200C𐹳🐴멈.\uABED񐡼; [B1, C1, V6, V7]; xn--0ug6681d406b7bwk.xn--429a8682s; ; xn--422b325mqb6i.xn--429a8682s; [B1, V6, V7] # 𐹳🐴멈.꯭
+xn--422b325mqb6i.xn--429a8682s; 𐹳🐴멈.\uABED񐡼; [B1, V6, V7]; xn--422b325mqb6i.xn--429a8682s; ; ;  # 𐹳🐴멈.꯭
+xn--0ug6681d406b7bwk.xn--429a8682s; \u200C𐹳🐴멈.\uABED񐡼; [B1, C1, V6, V7]; xn--0ug6681d406b7bwk.xn--429a8682s; ; ;  # 𐹳🐴멈.꯭
+≮.\u0769\u0603; ; [B1, V7]; xn--gdh.xn--lfb92e; ; ;  # ≮.ݩ
+<\u0338.\u0769\u0603; ≮.\u0769\u0603; [B1, V7]; xn--gdh.xn--lfb92e; ; ;  # ≮.ݩ
+xn--gdh.xn--lfb92e; ≮.\u0769\u0603; [B1, V7]; xn--gdh.xn--lfb92e; ; ;  # ≮.ݩ
+𐶭⾆｡\u200C𑚶򟱃𞰘; 𐶭舌.\u200C𑚶򟱃𞰘; [B1, B2, B3, C1, V7]; xn--tc1ao37z.xn--0ugx728gi1nfwqz2e; ; xn--tc1ao37z.xn--6e2dw557azds2d; [B2, B3, B5, B6, V6, V7] # 舌.𑚶
+𐶭舌。\u200C𑚶򟱃𞰘; 𐶭舌.\u200C𑚶򟱃𞰘; [B1, B2, B3, C1, V7]; xn--tc1ao37z.xn--0ugx728gi1nfwqz2e; ; xn--tc1ao37z.xn--6e2dw557azds2d; [B2, B3, B5, B6, V6, V7] # 舌.𑚶
+xn--tc1ao37z.xn--6e2dw557azds2d; 𐶭舌.𑚶򟱃𞰘; [B2, B3, B5, B6, V6, V7]; xn--tc1ao37z.xn--6e2dw557azds2d; ; ;  # 舌.𑚶
+xn--tc1ao37z.xn--0ugx728gi1nfwqz2e; 𐶭舌.\u200C𑚶򟱃𞰘; [B1, B2, B3, C1, V7]; xn--tc1ao37z.xn--0ugx728gi1nfwqz2e; ; ;  # 舌.𑚶
+\u200CჀ-.𝟷ς𞴺ς; \u200Cⴠ-.1ς𞴺ς; [B1, C1, V3]; xn----rgn530d.xn--1-ymba92321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, V3] # ⴠ-.1ς𞴺ς
+\u200CჀ-.1ς𞴺ς; \u200Cⴠ-.1ς𞴺ς; [B1, C1, V3]; xn----rgn530d.xn--1-ymba92321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, V3] # ⴠ-.1ς𞴺ς
+\u200Cⴠ-.1ς𞴺ς; ; [B1, C1, V3]; xn----rgn530d.xn--1-ymba92321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, V3] # ⴠ-.1ς𞴺ς
+\u200CჀ-.1Σ𞴺Σ; \u200Cⴠ-.1σ𞴺σ; [B1, C1, V3]; xn----rgn530d.xn--1-0mba52321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, V3] # ⴠ-.1σ𞴺σ
+\u200Cⴠ-.1σ𞴺σ; ; [B1, C1, V3]; xn----rgn530d.xn--1-0mba52321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, V3] # ⴠ-.1σ𞴺σ
+\u200CჀ-.1σ𞴺Σ; \u200Cⴠ-.1σ𞴺σ; [B1, C1, V3]; xn----rgn530d.xn--1-0mba52321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, V3] # ⴠ-.1σ𞴺σ
+xn----2ws.xn--1-0mba52321c; ⴠ-.1σ𞴺σ; [B1, B6, V3]; xn----2ws.xn--1-0mba52321c; ; ;  # ⴠ-.1σ𞴺σ
+xn----rgn530d.xn--1-0mba52321c; \u200Cⴠ-.1σ𞴺σ; [B1, C1, V3]; xn----rgn530d.xn--1-0mba52321c; ; ;  # ⴠ-.1σ𞴺σ
+\u200CჀ-.1ς𞴺Σ; \u200Cⴠ-.1ς𞴺σ; [B1, C1, V3]; xn----rgn530d.xn--1-ymbd52321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, V3] # ⴠ-.1ς𞴺σ
+\u200Cⴠ-.1ς𞴺σ; ; [B1, C1, V3]; xn----rgn530d.xn--1-ymbd52321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, V3] # ⴠ-.1ς𞴺σ
+xn----rgn530d.xn--1-ymbd52321c; \u200Cⴠ-.1ς𞴺σ; [B1, C1, V3]; xn----rgn530d.xn--1-ymbd52321c; ; ;  # ⴠ-.1ς𞴺σ
+xn----rgn530d.xn--1-ymba92321c; \u200Cⴠ-.1ς𞴺ς; [B1, C1, V3]; xn----rgn530d.xn--1-ymba92321c; ; ;  # ⴠ-.1ς𞴺ς
+\u200Cⴠ-.𝟷ς𞴺ς; \u200Cⴠ-.1ς𞴺ς; [B1, C1, V3]; xn----rgn530d.xn--1-ymba92321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, V3] # ⴠ-.1ς𞴺ς
+\u200CჀ-.𝟷Σ𞴺Σ; \u200Cⴠ-.1σ𞴺σ; [B1, C1, V3]; xn----rgn530d.xn--1-0mba52321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, V3] # ⴠ-.1σ𞴺σ
+\u200Cⴠ-.𝟷σ𞴺σ; \u200Cⴠ-.1σ𞴺σ; [B1, C1, V3]; xn----rgn530d.xn--1-0mba52321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, V3] # ⴠ-.1σ𞴺σ
+\u200CჀ-.𝟷σ𞴺Σ; \u200Cⴠ-.1σ𞴺σ; [B1, C1, V3]; xn----rgn530d.xn--1-0mba52321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, V3] # ⴠ-.1σ𞴺σ
+\u200CჀ-.𝟷ς𞴺Σ; \u200Cⴠ-.1ς𞴺σ; [B1, C1, V3]; xn----rgn530d.xn--1-ymbd52321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, V3] # ⴠ-.1ς𞴺σ
+\u200Cⴠ-.𝟷ς𞴺σ; \u200Cⴠ-.1ς𞴺σ; [B1, C1, V3]; xn----rgn530d.xn--1-ymbd52321c; ; xn----2ws.xn--1-0mba52321c; [B1, B6, V3] # ⴠ-.1ς𞴺σ
+xn----z1g.xn--1-0mba52321c; Ⴠ-.1σ𞴺σ; [B1, B6, V3, V7]; xn----z1g.xn--1-0mba52321c; ; ;  # Ⴠ-.1σ𞴺σ
+xn----z1g168i.xn--1-0mba52321c; \u200CჀ-.1σ𞴺σ; [B1, C1, V3, V7]; xn----z1g168i.xn--1-0mba52321c; ; ;  # Ⴠ-.1σ𞴺σ
+xn----z1g168i.xn--1-ymbd52321c; \u200CჀ-.1ς𞴺σ; [B1, C1, V3, V7]; xn----z1g168i.xn--1-ymbd52321c; ; ;  # Ⴠ-.1ς𞴺σ
+xn----z1g168i.xn--1-ymba92321c; \u200CჀ-.1ς𞴺ς; [B1, C1, V3, V7]; xn----z1g168i.xn--1-ymba92321c; ; ;  # Ⴠ-.1ς𞴺ς
+𑲘󠄒𓑡｡𝟪Ⴜ; 𑲘𓑡.8ⴜ; [V6]; xn--7m3d291b.xn--8-vws; ; ;  # 𑲘𓑡.8ⴜ
+𑲘󠄒𓑡。8Ⴜ; 𑲘𓑡.8ⴜ; [V6]; xn--7m3d291b.xn--8-vws; ; ;  # 𑲘𓑡.8ⴜ
+𑲘󠄒𓑡。8ⴜ; 𑲘𓑡.8ⴜ; [V6]; xn--7m3d291b.xn--8-vws; ; ;  # 𑲘𓑡.8ⴜ
+xn--7m3d291b.xn--8-vws; 𑲘𓑡.8ⴜ; [V6]; xn--7m3d291b.xn--8-vws; ; ;  # 𑲘𓑡.8ⴜ
+𑲘󠄒𓑡｡𝟪ⴜ; 𑲘𓑡.8ⴜ; [V6]; xn--7m3d291b.xn--8-vws; ; ;  # 𑲘𓑡.8ⴜ
+xn--7m3d291b.xn--8-s1g; 𑲘𓑡.8Ⴜ; [V6, V7]; xn--7m3d291b.xn--8-s1g; ; ;  # 𑲘𓑡.8Ⴜ
+䪏\u06AB\u07E0\u0941｡뭕ᢝ\u17B9; 䪏\u06AB\u07E0\u0941.뭕ᢝ\u17B9; [B5, B6]; xn--ekb23dj4at01n.xn--43e96bh910b; ; ;  # 䪏ګߠु.뭕ᢝឹ
+䪏\u06AB\u07E0\u0941｡뭕ᢝ\u17B9; 䪏\u06AB\u07E0\u0941.뭕ᢝ\u17B9; [B5, B6]; xn--ekb23dj4at01n.xn--43e96bh910b; ; ;  # 䪏ګߠु.뭕ᢝឹ
+䪏\u06AB\u07E0\u0941。뭕ᢝ\u17B9; 䪏\u06AB\u07E0\u0941.뭕ᢝ\u17B9; [B5, B6]; xn--ekb23dj4at01n.xn--43e96bh910b; ; ;  # 䪏ګߠु.뭕ᢝឹ
+䪏\u06AB\u07E0\u0941。뭕ᢝ\u17B9; 䪏\u06AB\u07E0\u0941.뭕ᢝ\u17B9; [B5, B6]; xn--ekb23dj4at01n.xn--43e96bh910b; ; ;  # 䪏ګߠु.뭕ᢝឹ
+xn--ekb23dj4at01n.xn--43e96bh910b; 䪏\u06AB\u07E0\u0941.뭕ᢝ\u17B9; [B5, B6]; xn--ekb23dj4at01n.xn--43e96bh910b; ; ;  # 䪏ګߠु.뭕ᢝឹ
+\u1BAB｡🂉󠁰; \u1BAB.🂉󠁰; [V6, V7]; xn--zxf.xn--fx7ho0250c; ; ;  # ᮫.🂉
+\u1BAB。🂉󠁰; \u1BAB.🂉󠁰; [V6, V7]; xn--zxf.xn--fx7ho0250c; ; ;  # ᮫.🂉
+xn--zxf.xn--fx7ho0250c; \u1BAB.🂉󠁰; [V6, V7]; xn--zxf.xn--fx7ho0250c; ; ;  # ᮫.🂉
+󩎃\u0AC4。ς\u200D𐹮𑈵; 󩎃\u0AC4.ς\u200D𐹮𑈵; [B5, C2, V7]; xn--dfc53161q.xn--3xa006lzo7nsfd; ; xn--dfc53161q.xn--4xa8467k5mc; [B5, V7] # ૄ.ς𐹮𑈵
+󩎃\u0AC4。Σ\u200D𐹮𑈵; 󩎃\u0AC4.σ\u200D𐹮𑈵; [B5, C2, V7]; xn--dfc53161q.xn--4xa895lzo7nsfd; ; xn--dfc53161q.xn--4xa8467k5mc; [B5, V7] # ૄ.σ𐹮𑈵
+󩎃\u0AC4。σ\u200D𐹮𑈵; 󩎃\u0AC4.σ\u200D𐹮𑈵; [B5, C2, V7]; xn--dfc53161q.xn--4xa895lzo7nsfd; ; xn--dfc53161q.xn--4xa8467k5mc; [B5, V7] # ૄ.σ𐹮𑈵
+xn--dfc53161q.xn--4xa8467k5mc; 󩎃\u0AC4.σ𐹮𑈵; [B5, V7]; xn--dfc53161q.xn--4xa8467k5mc; ; ;  # ૄ.σ𐹮𑈵
+xn--dfc53161q.xn--4xa895lzo7nsfd; 󩎃\u0AC4.σ\u200D𐹮𑈵; [B5, C2, V7]; xn--dfc53161q.xn--4xa895lzo7nsfd; ; ;  # ૄ.σ𐹮𑈵
+xn--dfc53161q.xn--3xa006lzo7nsfd; 󩎃\u0AC4.ς\u200D𐹮𑈵; [B5, C2, V7]; xn--dfc53161q.xn--3xa006lzo7nsfd; ; ;  # ૄ.ς𐹮𑈵
+𐫀ᡂ𑜫．𑘿; 𐫀ᡂ𑜫.𑘿; [B1, B2, B3, V6]; xn--17e9625js1h.xn--sb2d; ; ;  # 𐫀ᡂ𑜫.𑘿
+𐫀ᡂ𑜫.𑘿; ; [B1, B2, B3, V6]; xn--17e9625js1h.xn--sb2d; ; ;  # 𐫀ᡂ𑜫.𑘿
+xn--17e9625js1h.xn--sb2d; 𐫀ᡂ𑜫.𑘿; [B1, B2, B3, V6]; xn--17e9625js1h.xn--sb2d; ; ;  # 𐫀ᡂ𑜫.𑘿
+󬚶󸋖򖩰-。\u200C; 󬚶󸋖򖩰-.\u200C; [C1, V3, V7]; xn----7i12hu122k9ire.xn--0ug; ; xn----7i12hu122k9ire.; [V3, V7, A4_2] # -.
+xn----7i12hu122k9ire.; 󬚶󸋖򖩰-.; [V3, V7]; xn----7i12hu122k9ire.; [V3, V7, A4_2]; ;  # -.
+xn----7i12hu122k9ire.xn--0ug; 󬚶󸋖򖩰-.\u200C; [C1, V3, V7]; xn----7i12hu122k9ire.xn--0ug; ; ;  # -.
+𐹣．\u07C2; 𐹣.\u07C2; [B1]; xn--bo0d.xn--dsb; ; ;  # 𐹣.߂
+𐹣.\u07C2; ; [B1]; xn--bo0d.xn--dsb; ; ;  # 𐹣.߂
+xn--bo0d.xn--dsb; 𐹣.\u07C2; [B1]; xn--bo0d.xn--dsb; ; ;  # 𐹣.߂
+-\u07E1｡Ↄ; -\u07E1.ↄ; [B1, V3]; xn----8cd.xn--r5g; ; ;  # -ߡ.ↄ
+-\u07E1。Ↄ; -\u07E1.ↄ; [B1, V3]; xn----8cd.xn--r5g; ; ;  # -ߡ.ↄ
+-\u07E1。ↄ; -\u07E1.ↄ; [B1, V3]; xn----8cd.xn--r5g; ; ;  # -ߡ.ↄ
+xn----8cd.xn--r5g; -\u07E1.ↄ; [B1, V3]; xn----8cd.xn--r5g; ; ;  # -ߡ.ↄ
+-\u07E1｡ↄ; -\u07E1.ↄ; [B1, V3]; xn----8cd.xn--r5g; ; ;  # -ߡ.ↄ
+xn----8cd.xn--q5g; -\u07E1.Ↄ; [B1, V3, V7]; xn----8cd.xn--q5g; ; ;  # -ߡ.Ↄ
+\u200D-︒󠄄。ß哑\u200C𐵿; \u200D-︒.ß哑\u200C𐵿; [B1, B5, B6, C1, C2, V7]; xn----tgnt341h.xn--zca670n5f0binyk; ; xn----o89h.xn--ss-h46c5711e; [B1, B5, B6, V3, V7] # -︒.ß哑𐵿
+\u200D-。󠄄。ß哑\u200C𐵿; \u200D-..ß哑\u200C𐵿; [B1, B5, B6, C1, C2, V3, X4_2]; xn----tgn..xn--zca670n5f0binyk; [B1, B5, B6, C1, C2, V3, A4_2]; -..xn--ss-h46c5711e; [B1, B5, B6, V3, A4_2] # -..ß哑𐵿
+\u200D-。󠄄。SS哑\u200C𐵟; \u200D-..ss哑\u200C𐵿; [B1, B5, B6, C1, C2, V3, X4_2]; xn----tgn..xn--ss-k1ts75zb8ym; [B1, B5, B6, C1, C2, V3, A4_2]; -..xn--ss-h46c5711e; [B1, B5, B6, V3, A4_2] # -..ss哑𐵿
+\u200D-。󠄄。ss哑\u200C𐵿; \u200D-..ss哑\u200C𐵿; [B1, B5, B6, C1, C2, V3, X4_2]; xn----tgn..xn--ss-k1ts75zb8ym; [B1, B5, B6, C1, C2, V3, A4_2]; -..xn--ss-h46c5711e; [B1, B5, B6, V3, A4_2] # -..ss哑𐵿
+\u200D-。󠄄。Ss哑\u200C𐵟; \u200D-..ss哑\u200C𐵿; [B1, B5, B6, C1, C2, V3, X4_2]; xn----tgn..xn--ss-k1ts75zb8ym; [B1, B5, B6, C1, C2, V3, A4_2]; -..xn--ss-h46c5711e; [B1, B5, B6, V3, A4_2] # -..ss哑𐵿
+-..xn--ss-h46c5711e; -..ss哑𐵿; [B1, B5, B6, V3, X4_2]; -..xn--ss-h46c5711e; [B1, B5, B6, V3, A4_2]; ;  # -..ss哑𐵿
+xn----tgn..xn--ss-k1ts75zb8ym; \u200D-..ss哑\u200C𐵿; [B1, B5, B6, C1, C2, V3, X4_2]; xn----tgn..xn--ss-k1ts75zb8ym; [B1, B5, B6, C1, C2, V3, A4_2]; ;  # -..ss哑𐵿
+xn----tgn..xn--zca670n5f0binyk; \u200D-..ß哑\u200C𐵿; [B1, B5, B6, C1, C2, V3, X4_2]; xn----tgn..xn--zca670n5f0binyk; [B1, B5, B6, C1, C2, V3, A4_2]; ;  # -..ß哑𐵿
+\u200D-︒󠄄。SS哑\u200C𐵟; \u200D-︒.ss哑\u200C𐵿; [B1, B5, B6, C1, C2, V7]; xn----tgnt341h.xn--ss-k1ts75zb8ym; ; xn----o89h.xn--ss-h46c5711e; [B1, B5, B6, V3, V7] # -︒.ss哑𐵿
+\u200D-︒󠄄。ss哑\u200C𐵿; \u200D-︒.ss哑\u200C𐵿; [B1, B5, B6, C1, C2, V7]; xn----tgnt341h.xn--ss-k1ts75zb8ym; ; xn----o89h.xn--ss-h46c5711e; [B1, B5, B6, V3, V7] # -︒.ss哑𐵿
+\u200D-︒󠄄。Ss哑\u200C𐵟; \u200D-︒.ss哑\u200C𐵿; [B1, B5, B6, C1, C2, V7]; xn----tgnt341h.xn--ss-k1ts75zb8ym; ; xn----o89h.xn--ss-h46c5711e; [B1, B5, B6, V3, V7] # -︒.ss哑𐵿
+xn----o89h.xn--ss-h46c5711e; -︒.ss哑𐵿; [B1, B5, B6, V3, V7]; xn----o89h.xn--ss-h46c5711e; ; ;  # -︒.ss哑𐵿
+xn----tgnt341h.xn--ss-k1ts75zb8ym; \u200D-︒.ss哑\u200C𐵿; [B1, B5, B6, C1, C2, V7]; xn----tgnt341h.xn--ss-k1ts75zb8ym; ; ;  # -︒.ss哑𐵿
+xn----tgnt341h.xn--zca670n5f0binyk; \u200D-︒.ß哑\u200C𐵿; [B1, B5, B6, C1, C2, V7]; xn----tgnt341h.xn--zca670n5f0binyk; ; ;  # -︒.ß哑𐵿
+\u200D-。󠄄。SS哑\u200C𐵿; \u200D-..ss哑\u200C𐵿; [B1, B5, B6, C1, C2, V3, X4_2]; xn----tgn..xn--ss-k1ts75zb8ym; [B1, B5, B6, C1, C2, V3, A4_2]; -..xn--ss-h46c5711e; [B1, B5, B6, V3, A4_2] # -..ss哑𐵿
+\u200D-。󠄄。Ss哑\u200C𐵿; \u200D-..ss哑\u200C𐵿; [B1, B5, B6, C1, C2, V3, X4_2]; xn----tgn..xn--ss-k1ts75zb8ym; [B1, B5, B6, C1, C2, V3, A4_2]; -..xn--ss-h46c5711e; [B1, B5, B6, V3, A4_2] # -..ss哑𐵿
+\u200D-︒󠄄。SS哑\u200C𐵿; \u200D-︒.ss哑\u200C𐵿; [B1, B5, B6, C1, C2, V7]; xn----tgnt341h.xn--ss-k1ts75zb8ym; ; xn----o89h.xn--ss-h46c5711e; [B1, B5, B6, V3, V7] # -︒.ss哑𐵿
+\u200D-︒󠄄。Ss哑\u200C𐵿; \u200D-︒.ss哑\u200C𐵿; [B1, B5, B6, C1, C2, V7]; xn----tgnt341h.xn--ss-k1ts75zb8ym; ; xn----o89h.xn--ss-h46c5711e; [B1, B5, B6, V3, V7] # -︒.ss哑𐵿
+︒．\uFE2F𑑂; ︒.𑑂\uFE2F; [V6, V7]; xn--y86c.xn--s96cu30b; ; ;  # ︒.𑑂︯
+︒．𑑂\uFE2F; ︒.𑑂\uFE2F; [V6, V7]; xn--y86c.xn--s96cu30b; ; ;  # ︒.𑑂︯
+。.𑑂\uFE2F; ..𑑂\uFE2F; [V6, X4_2]; ..xn--s96cu30b; [V6, A4_2]; ;  # ..𑑂︯
+..xn--s96cu30b; ..𑑂\uFE2F; [V6, X4_2]; ..xn--s96cu30b; [V6, A4_2]; ;  # ..𑑂︯
+xn--y86c.xn--s96cu30b; ︒.𑑂\uFE2F; [V6, V7]; xn--y86c.xn--s96cu30b; ; ;  # ︒.𑑂︯
+\uA92C。\u200D; \uA92C.\u200D; [C2, V6]; xn--zi9a.xn--1ug; ; xn--zi9a.; [V6, A4_2] # ꤬.
+xn--zi9a.; \uA92C.; [V6]; xn--zi9a.; [V6, A4_2]; ;  # ꤬.
+xn--zi9a.xn--1ug; \uA92C.\u200D; [C2, V6]; xn--zi9a.xn--1ug; ; ;  # ꤬.
+\u200D󠸡｡\uFCD7; \u200D󠸡.\u0647\u062C; [B1, C2, V7]; xn--1ug80651l.xn--rgb7c; ; xn--d356e.xn--rgb7c; [B1, V7] # .هج
+\u200D󠸡。\u0647\u062C; \u200D󠸡.\u0647\u062C; [B1, C2, V7]; xn--1ug80651l.xn--rgb7c; ; xn--d356e.xn--rgb7c; [B1, V7] # .هج
+xn--d356e.xn--rgb7c; 󠸡.\u0647\u062C; [B1, V7]; xn--d356e.xn--rgb7c; ; ;  # .هج
+xn--1ug80651l.xn--rgb7c; \u200D󠸡.\u0647\u062C; [B1, C2, V7]; xn--1ug80651l.xn--rgb7c; ; ;  # .هج
+-Ⴄ𝟢\u0663．𑍴ς; -ⴄ0\u0663.𑍴ς; [B1, V3, V6]; xn---0-iyd8660b.xn--3xa1220l; ; xn---0-iyd8660b.xn--4xa9120l;  # -ⴄ0٣.𑍴ς
+-Ⴄ0\u0663.𑍴ς; -ⴄ0\u0663.𑍴ς; [B1, V3, V6]; xn---0-iyd8660b.xn--3xa1220l; ; xn---0-iyd8660b.xn--4xa9120l;  # -ⴄ0٣.𑍴ς
+-ⴄ0\u0663.𑍴ς; ; [B1, V3, V6]; xn---0-iyd8660b.xn--3xa1220l; ; xn---0-iyd8660b.xn--4xa9120l;  # -ⴄ0٣.𑍴ς
+-Ⴄ0\u0663.𑍴Σ; -ⴄ0\u0663.𑍴σ; [B1, V3, V6]; xn---0-iyd8660b.xn--4xa9120l; ; ;  # -ⴄ0٣.𑍴σ
+-ⴄ0\u0663.𑍴σ; ; [B1, V3, V6]; xn---0-iyd8660b.xn--4xa9120l; ; ;  # -ⴄ0٣.𑍴σ
+xn---0-iyd8660b.xn--4xa9120l; -ⴄ0\u0663.𑍴σ; [B1, V3, V6]; xn---0-iyd8660b.xn--4xa9120l; ; ;  # -ⴄ0٣.𑍴σ
+xn---0-iyd8660b.xn--3xa1220l; -ⴄ0\u0663.𑍴ς; [B1, V3, V6]; xn---0-iyd8660b.xn--3xa1220l; ; ;  # -ⴄ0٣.𑍴ς
+-ⴄ𝟢\u0663．𑍴ς; -ⴄ0\u0663.𑍴ς; [B1, V3, V6]; xn---0-iyd8660b.xn--3xa1220l; ; xn---0-iyd8660b.xn--4xa9120l;  # -ⴄ0٣.𑍴ς
+-Ⴄ𝟢\u0663．𑍴Σ; -ⴄ0\u0663.𑍴σ; [B1, V3, V6]; xn---0-iyd8660b.xn--4xa9120l; ; ;  # -ⴄ0٣.𑍴σ
+-ⴄ𝟢\u0663．𑍴σ; -ⴄ0\u0663.𑍴σ; [B1, V3, V6]; xn---0-iyd8660b.xn--4xa9120l; ; ;  # -ⴄ0٣.𑍴σ
+xn---0-iyd216h.xn--4xa9120l; -Ⴄ0\u0663.𑍴σ; [B1, V3, V6, V7]; xn---0-iyd216h.xn--4xa9120l; ; ;  # -Ⴄ0٣.𑍴σ
+xn---0-iyd216h.xn--3xa1220l; -Ⴄ0\u0663.𑍴ς; [B1, V3, V6, V7]; xn---0-iyd216h.xn--3xa1220l; ; ;  # -Ⴄ0٣.𑍴ς
+󦈄。-; 󦈄.-; [V3, V7]; xn--xm38e.-; ; ;  # .-
+xn--xm38e.-; 󦈄.-; [V3, V7]; xn--xm38e.-; ; ;  # .-
+⋠𐋮．򶈮\u0F18ß≯; ⋠𐋮.򶈮\u0F18ß≯; [V7]; xn--pgh4639f.xn--zca593eo6oc013y; ; xn--pgh4639f.xn--ss-ifj426nle504a;  # ⋠𐋮.༘ß≯
+≼\u0338𐋮．򶈮\u0F18ß>\u0338; ⋠𐋮.򶈮\u0F18ß≯; [V7]; xn--pgh4639f.xn--zca593eo6oc013y; ; xn--pgh4639f.xn--ss-ifj426nle504a;  # ⋠𐋮.༘ß≯
+⋠𐋮.򶈮\u0F18ß≯; ; [V7]; xn--pgh4639f.xn--zca593eo6oc013y; ; xn--pgh4639f.xn--ss-ifj426nle504a;  # ⋠𐋮.༘ß≯
+≼\u0338𐋮.򶈮\u0F18ß>\u0338; ⋠𐋮.򶈮\u0F18ß≯; [V7]; xn--pgh4639f.xn--zca593eo6oc013y; ; xn--pgh4639f.xn--ss-ifj426nle504a;  # ⋠𐋮.༘ß≯
+≼\u0338𐋮.򶈮\u0F18SS>\u0338; ⋠𐋮.򶈮\u0F18ss≯; [V7]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮.򶈮\u0F18SS≯; ⋠𐋮.򶈮\u0F18ss≯; [V7]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮.򶈮\u0F18ss≯; ; [V7]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+≼\u0338𐋮.򶈮\u0F18ss>\u0338; ⋠𐋮.򶈮\u0F18ss≯; [V7]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+≼\u0338𐋮.򶈮\u0F18Ss>\u0338; ⋠𐋮.򶈮\u0F18ss≯; [V7]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮.򶈮\u0F18Ss≯; ⋠𐋮.򶈮\u0F18ss≯; [V7]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+xn--pgh4639f.xn--ss-ifj426nle504a; ⋠𐋮.򶈮\u0F18ss≯; [V7]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+xn--pgh4639f.xn--zca593eo6oc013y; ⋠𐋮.򶈮\u0F18ß≯; [V7]; xn--pgh4639f.xn--zca593eo6oc013y; ; ;  # ⋠𐋮.༘ß≯
+≼\u0338𐋮．򶈮\u0F18SS>\u0338; ⋠𐋮.򶈮\u0F18ss≯; [V7]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮．򶈮\u0F18SS≯; ⋠𐋮.򶈮\u0F18ss≯; [V7]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮．򶈮\u0F18ss≯; ⋠𐋮.򶈮\u0F18ss≯; [V7]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+≼\u0338𐋮．򶈮\u0F18ss>\u0338; ⋠𐋮.򶈮\u0F18ss≯; [V7]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+≼\u0338𐋮．򶈮\u0F18Ss>\u0338; ⋠𐋮.򶈮\u0F18ss≯; [V7]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+⋠𐋮．򶈮\u0F18Ss≯; ⋠𐋮.򶈮\u0F18ss≯; [V7]; xn--pgh4639f.xn--ss-ifj426nle504a; ; ;  # ⋠𐋮.༘ss≯
+1𐋸\u0664｡󠢮\uFBA4񷝊; 1𐋸\u0664.󠢮\u06C0񷝊; [B1, V7]; xn--1-hqc3905q.xn--zkb83268gqee4a; ; ;  # 1𐋸٤.ۀ
+1𐋸\u0664。󠢮\u06C0񷝊; 1𐋸\u0664.󠢮\u06C0񷝊; [B1, V7]; xn--1-hqc3905q.xn--zkb83268gqee4a; ; ;  # 1𐋸٤.ۀ
+1𐋸\u0664。󠢮\u06D5\u0654񷝊; 1𐋸\u0664.󠢮\u06C0񷝊; [B1, V7]; xn--1-hqc3905q.xn--zkb83268gqee4a; ; ;  # 1𐋸٤.ۀ
+xn--1-hqc3905q.xn--zkb83268gqee4a; 1𐋸\u0664.󠢮\u06C0񷝊; [B1, V7]; xn--1-hqc3905q.xn--zkb83268gqee4a; ; ;  # 1𐋸٤.ۀ
+儭-｡𐹴Ⴢ񥳠\u200C; 儭-.𐹴ⴢ񥳠\u200C; [B1, B6, C1, V3, V7]; xn----gz7a.xn--0ug472cfq0pus98b; ; xn----gz7a.xn--qlj9223eywx0b; [B1, B6, V3, V7] # 儭-.𐹴ⴢ
+儭-。𐹴Ⴢ񥳠\u200C; 儭-.𐹴ⴢ񥳠\u200C; [B1, B6, C1, V3, V7]; xn----gz7a.xn--0ug472cfq0pus98b; ; xn----gz7a.xn--qlj9223eywx0b; [B1, B6, V3, V7] # 儭-.𐹴ⴢ
+儭-。𐹴ⴢ񥳠\u200C; 儭-.𐹴ⴢ񥳠\u200C; [B1, B6, C1, V3, V7]; xn----gz7a.xn--0ug472cfq0pus98b; ; xn----gz7a.xn--qlj9223eywx0b; [B1, B6, V3, V7] # 儭-.𐹴ⴢ
+xn----gz7a.xn--qlj9223eywx0b; 儭-.𐹴ⴢ񥳠; [B1, B6, V3, V7]; xn----gz7a.xn--qlj9223eywx0b; ; ;  # 儭-.𐹴ⴢ
+xn----gz7a.xn--0ug472cfq0pus98b; 儭-.𐹴ⴢ񥳠\u200C; [B1, B6, C1, V3, V7]; xn----gz7a.xn--0ug472cfq0pus98b; ; ;  # 儭-.𐹴ⴢ
+儭-｡𐹴ⴢ񥳠\u200C; 儭-.𐹴ⴢ񥳠\u200C; [B1, B6, C1, V3, V7]; xn----gz7a.xn--0ug472cfq0pus98b; ; xn----gz7a.xn--qlj9223eywx0b; [B1, B6, V3, V7] # 儭-.𐹴ⴢ
+xn----gz7a.xn--6nd5001kyw98a; 儭-.𐹴Ⴢ񥳠; [B1, B6, V3, V7]; xn----gz7a.xn--6nd5001kyw98a; ; ;  # 儭-.𐹴Ⴢ
+xn----gz7a.xn--6nd249ejl4pusr7b; 儭-.𐹴Ⴢ񥳠\u200C; [B1, B6, C1, V3, V7]; xn----gz7a.xn--6nd249ejl4pusr7b; ; ;  # 儭-.𐹴Ⴢ
+𝟺𐋷\u06B9．𞤭򿍡; 4𐋷\u06B9.𞤭򿍡; [B1, B2, B3, V7]; xn--4-cvc5384q.xn--le6hi7322b; ; ;  # 4𐋷ڹ.𞤭
+4𐋷\u06B9.𞤭򿍡; ; [B1, B2, B3, V7]; xn--4-cvc5384q.xn--le6hi7322b; ; ;  # 4𐋷ڹ.𞤭
+4𐋷\u06B9.𞤋򿍡; 4𐋷\u06B9.𞤭򿍡; [B1, B2, B3, V7]; xn--4-cvc5384q.xn--le6hi7322b; ; ;  # 4𐋷ڹ.𞤭
+xn--4-cvc5384q.xn--le6hi7322b; 4𐋷\u06B9.𞤭򿍡; [B1, B2, B3, V7]; xn--4-cvc5384q.xn--le6hi7322b; ; ;  # 4𐋷ڹ.𞤭
+𝟺𐋷\u06B9．𞤋򿍡; 4𐋷\u06B9.𞤭򿍡; [B1, B2, B3, V7]; xn--4-cvc5384q.xn--le6hi7322b; ; ;  # 4𐋷ڹ.𞤭
+≯-ꡋ𑲣.⒈𐹭; ; [B1, V7]; xn----ogox061d5i8d.xn--tsh0666f; ; ;  # ≯-ꡋ𑲣.⒈𐹭
+>\u0338-ꡋ𑲣.⒈𐹭; ≯-ꡋ𑲣.⒈𐹭; [B1, V7]; xn----ogox061d5i8d.xn--tsh0666f; ; ;  # ≯-ꡋ𑲣.⒈𐹭
+≯-ꡋ𑲣.1.𐹭; ; [B1]; xn----ogox061d5i8d.1.xn--lo0d; ; ;  # ≯-ꡋ𑲣.1.𐹭
+>\u0338-ꡋ𑲣.1.𐹭; ≯-ꡋ𑲣.1.𐹭; [B1]; xn----ogox061d5i8d.1.xn--lo0d; ; ;  # ≯-ꡋ𑲣.1.𐹭
+xn----ogox061d5i8d.1.xn--lo0d; ≯-ꡋ𑲣.1.𐹭; [B1]; xn----ogox061d5i8d.1.xn--lo0d; ; ;  # ≯-ꡋ𑲣.1.𐹭
+xn----ogox061d5i8d.xn--tsh0666f; ≯-ꡋ𑲣.⒈𐹭; [B1, V7]; xn----ogox061d5i8d.xn--tsh0666f; ; ;  # ≯-ꡋ𑲣.⒈𐹭
+\u0330．󰜱蚀; \u0330.󰜱蚀; [V6, V7]; xn--xta.xn--e91aw9417e; ; ;  # ̰.蚀
+\u0330.󰜱蚀; ; [V6, V7]; xn--xta.xn--e91aw9417e; ; ;  # ̰.蚀
+xn--xta.xn--e91aw9417e; \u0330.󰜱蚀; [V6, V7]; xn--xta.xn--e91aw9417e; ; ;  # ̰.蚀
+\uFB39Ⴘ.𞡼𑇀ß\u20D7; \u05D9\u05BCⴘ.𞡼𑇀ß\u20D7; [B2, B3]; xn--kdb1d278n.xn--zca284nhg9nrrxg; ; xn--kdb1d278n.xn--ss-yju5690ken9h;  # יּⴘ.𞡼𑇀ß⃗
+\u05D9\u05BCႸ.𞡼𑇀ß\u20D7; \u05D9\u05BCⴘ.𞡼𑇀ß\u20D7; [B2, B3]; xn--kdb1d278n.xn--zca284nhg9nrrxg; ; xn--kdb1d278n.xn--ss-yju5690ken9h;  # יּⴘ.𞡼𑇀ß⃗
+\u05D9\u05BCⴘ.𞡼𑇀ß\u20D7; ; [B2, B3]; xn--kdb1d278n.xn--zca284nhg9nrrxg; ; xn--kdb1d278n.xn--ss-yju5690ken9h;  # יּⴘ.𞡼𑇀ß⃗
+\u05D9\u05BCႸ.𞡼𑇀SS\u20D7; \u05D9\u05BCⴘ.𞡼𑇀ss\u20D7; [B2, B3]; xn--kdb1d278n.xn--ss-yju5690ken9h; ; ;  # יּⴘ.𞡼𑇀ss⃗
+\u05D9\u05BCⴘ.𞡼𑇀ss\u20D7; ; [B2, B3]; xn--kdb1d278n.xn--ss-yju5690ken9h; ; ;  # יּⴘ.𞡼𑇀ss⃗
+xn--kdb1d278n.xn--ss-yju5690ken9h; \u05D9\u05BCⴘ.𞡼𑇀ss\u20D7; [B2, B3]; xn--kdb1d278n.xn--ss-yju5690ken9h; ; ;  # יּⴘ.𞡼𑇀ss⃗
+xn--kdb1d278n.xn--zca284nhg9nrrxg; \u05D9\u05BCⴘ.𞡼𑇀ß\u20D7; [B2, B3]; xn--kdb1d278n.xn--zca284nhg9nrrxg; ; ;  # יּⴘ.𞡼𑇀ß⃗
+\uFB39ⴘ.𞡼𑇀ß\u20D7; \u05D9\u05BCⴘ.𞡼𑇀ß\u20D7; [B2, B3]; xn--kdb1d278n.xn--zca284nhg9nrrxg; ; xn--kdb1d278n.xn--ss-yju5690ken9h;  # יּⴘ.𞡼𑇀ß⃗
+\uFB39Ⴘ.𞡼𑇀SS\u20D7; \u05D9\u05BCⴘ.𞡼𑇀ss\u20D7; [B2, B3]; xn--kdb1d278n.xn--ss-yju5690ken9h; ; ;  # יּⴘ.𞡼𑇀ss⃗
+\uFB39ⴘ.𞡼𑇀ss\u20D7; \u05D9\u05BCⴘ.𞡼𑇀ss\u20D7; [B2, B3]; xn--kdb1d278n.xn--ss-yju5690ken9h; ; ;  # יּⴘ.𞡼𑇀ss⃗
+xn--kdb1d867b.xn--ss-yju5690ken9h; \u05D9\u05BCႸ.𞡼𑇀ss\u20D7; [B2, B3, V7]; xn--kdb1d867b.xn--ss-yju5690ken9h; ; ;  # יּႸ.𞡼𑇀ss⃗
+xn--kdb1d867b.xn--zca284nhg9nrrxg; \u05D9\u05BCႸ.𞡼𑇀ß\u20D7; [B2, B3, V7]; xn--kdb1d867b.xn--zca284nhg9nrrxg; ; ;  # יּႸ.𞡼𑇀ß⃗
+\u05D9\u05BCႸ.𞡼𑇀ss\u20D7; \u05D9\u05BCⴘ.𞡼𑇀ss\u20D7; [B2, B3]; xn--kdb1d278n.xn--ss-yju5690ken9h; ; ;  # יּⴘ.𞡼𑇀ss⃗
+\uFB39Ⴘ.𞡼𑇀ss\u20D7; \u05D9\u05BCⴘ.𞡼𑇀ss\u20D7; [B2, B3]; xn--kdb1d278n.xn--ss-yju5690ken9h; ; ;  # יּⴘ.𞡼𑇀ss⃗
+\u1BA3𐹰򁱓｡凬; \u1BA3𐹰򁱓.凬; [B1, V6, V7]; xn--rxfz314ilg20c.xn--t9q; ; ;  # ᮣ𐹰.凬
+\u1BA3𐹰򁱓。凬; \u1BA3𐹰򁱓.凬; [B1, V6, V7]; xn--rxfz314ilg20c.xn--t9q; ; ;  # ᮣ𐹰.凬
+xn--rxfz314ilg20c.xn--t9q; \u1BA3𐹰򁱓.凬; [B1, V6, V7]; xn--rxfz314ilg20c.xn--t9q; ; ;  # ᮣ𐹰.凬
+🢟🄈\u200Dꡎ｡\u0F84; 🢟7,\u200Dꡎ.\u0F84; [C2, V6, U1]; xn--7,-n1t0654eqo3o.xn--3ed; ; xn--7,-gh9hg322i.xn--3ed; [V6, U1] # 🢟7,ꡎ.྄
+🢟7,\u200Dꡎ。\u0F84; 🢟7,\u200Dꡎ.\u0F84; [C2, V6, U1]; xn--7,-n1t0654eqo3o.xn--3ed; ; xn--7,-gh9hg322i.xn--3ed; [V6, U1] # 🢟7,ꡎ.྄
+xn--7,-gh9hg322i.xn--3ed; 🢟7,ꡎ.\u0F84; [V6, U1]; xn--7,-gh9hg322i.xn--3ed; ; ;  # 🢟7,ꡎ.྄
+xn--7,-n1t0654eqo3o.xn--3ed; 🢟7,\u200Dꡎ.\u0F84; [C2, V6, U1]; xn--7,-n1t0654eqo3o.xn--3ed; ; ;  # 🢟7,ꡎ.྄
+xn--nc9aq743ds0e.xn--3ed; 🢟🄈ꡎ.\u0F84; [V6, V7]; xn--nc9aq743ds0e.xn--3ed; ; ;  # 🢟🄈ꡎ.྄
+xn--1ug4874cfd0kbmg.xn--3ed; 🢟🄈\u200Dꡎ.\u0F84; [C2, V6, V7]; xn--1ug4874cfd0kbmg.xn--3ed; ; ;  # 🢟🄈ꡎ.྄
+ꡔ。\u1039ᢇ; ꡔ.\u1039ᢇ; [V6]; xn--tc9a.xn--9jd663b; ; ;  # ꡔ.္ᢇ
+xn--tc9a.xn--9jd663b; ꡔ.\u1039ᢇ; [V6]; xn--tc9a.xn--9jd663b; ; ;  # ꡔ.္ᢇ
+\u20EB≮.𝨖; ; [V6]; xn--e1g71d.xn--772h; ; ;  # ⃫≮.𝨖
+\u20EB<\u0338.𝨖; \u20EB≮.𝨖; [V6]; xn--e1g71d.xn--772h; ; ;  # ⃫≮.𝨖
+xn--e1g71d.xn--772h; \u20EB≮.𝨖; [V6]; xn--e1g71d.xn--772h; ; ;  # ⃫≮.𝨖
+Ⴢ≯褦．ᠪ\u07EAႾ\u0767; ⴢ≯褦.ᠪ\u07EAⴞ\u0767; [B5, B6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+Ⴢ>\u0338褦．ᠪ\u07EAႾ\u0767; ⴢ≯褦.ᠪ\u07EAⴞ\u0767; [B5, B6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+Ⴢ≯褦.ᠪ\u07EAႾ\u0767; ⴢ≯褦.ᠪ\u07EAⴞ\u0767; [B5, B6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+Ⴢ>\u0338褦.ᠪ\u07EAႾ\u0767; ⴢ≯褦.ᠪ\u07EAⴞ\u0767; [B5, B6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+ⴢ>\u0338褦.ᠪ\u07EAⴞ\u0767; ⴢ≯褦.ᠪ\u07EAⴞ\u0767; [B5, B6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+ⴢ≯褦.ᠪ\u07EAⴞ\u0767; ; [B5, B6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+Ⴢ≯褦.ᠪ\u07EAⴞ\u0767; ⴢ≯褦.ᠪ\u07EAⴞ\u0767; [B5, B6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+Ⴢ>\u0338褦.ᠪ\u07EAⴞ\u0767; ⴢ≯褦.ᠪ\u07EAⴞ\u0767; [B5, B6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+xn--hdh433bev8e.xn--rpb5x392bcyt; ⴢ≯褦.ᠪ\u07EAⴞ\u0767; [B5, B6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+ⴢ>\u0338褦．ᠪ\u07EAⴞ\u0767; ⴢ≯褦.ᠪ\u07EAⴞ\u0767; [B5, B6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+ⴢ≯褦．ᠪ\u07EAⴞ\u0767; ⴢ≯褦.ᠪ\u07EAⴞ\u0767; [B5, B6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+Ⴢ≯褦．ᠪ\u07EAⴞ\u0767; ⴢ≯褦.ᠪ\u07EAⴞ\u0767; [B5, B6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+Ⴢ>\u0338褦．ᠪ\u07EAⴞ\u0767; ⴢ≯褦.ᠪ\u07EAⴞ\u0767; [B5, B6]; xn--hdh433bev8e.xn--rpb5x392bcyt; ; ;  # ⴢ≯褦.ᠪߪⴞݧ
+xn--6nd461g478e.xn--rpb5x392bcyt; Ⴢ≯褦.ᠪ\u07EAⴞ\u0767; [B5, B6, V7]; xn--6nd461g478e.xn--rpb5x392bcyt; ; ;  # Ⴢ≯褦.ᠪߪⴞݧ
+xn--6nd461g478e.xn--rpb5x49td2h; Ⴢ≯褦.ᠪ\u07EAႾ\u0767; [B5, B6, V7]; xn--6nd461g478e.xn--rpb5x49td2h; ; ;  # Ⴢ≯褦.ᠪߪႾݧ
+򊉆󠆒\u200C\uA953。𞤙\u067Bꡘ; 򊉆\u200C\uA953.𞤻\u067Bꡘ; [B2, B3, C1, V7]; xn--0ug8815chtz0e.xn--0ib8893fegvj; ; xn--3j9al6189a.xn--0ib8893fegvj; [B2, B3, V7] # ꥓.𞤻ٻꡘ
+򊉆󠆒\u200C\uA953。𞤻\u067Bꡘ; 򊉆\u200C\uA953.𞤻\u067Bꡘ; [B2, B3, C1, V7]; xn--0ug8815chtz0e.xn--0ib8893fegvj; ; xn--3j9al6189a.xn--0ib8893fegvj; [B2, B3, V7] # ꥓.𞤻ٻꡘ
+xn--3j9al6189a.xn--0ib8893fegvj; 򊉆\uA953.𞤻\u067Bꡘ; [B2, B3, V7]; xn--3j9al6189a.xn--0ib8893fegvj; ; ;  # ꥓.𞤻ٻꡘ
+xn--0ug8815chtz0e.xn--0ib8893fegvj; 򊉆\u200C\uA953.𞤻\u067Bꡘ; [B2, B3, C1, V7]; xn--0ug8815chtz0e.xn--0ib8893fegvj; ; ;  # ꥓.𞤻ٻꡘ
+\u200C.≯; ; [C1]; xn--0ug.xn--hdh; ; .xn--hdh; [A4_2] # .≯
+\u200C.>\u0338; \u200C.≯; [C1]; xn--0ug.xn--hdh; ; .xn--hdh; [A4_2] # .≯
+.xn--hdh; .≯; [X4_2]; .xn--hdh; [A4_2]; ;  # .≯
+xn--0ug.xn--hdh; \u200C.≯; [C1]; xn--0ug.xn--hdh; ; ;  # .≯
+𰅧񣩠-．\uABED-悜; 𰅧񣩠-.\uABED-悜; [V3, V6, V7]; xn----7m53aj640l.xn----8f4br83t; ; ;  # 𰅧-.꯭-悜
+𰅧񣩠-.\uABED-悜; ; [V3, V6, V7]; xn----7m53aj640l.xn----8f4br83t; ; ;  # 𰅧-.꯭-悜
+xn----7m53aj640l.xn----8f4br83t; 𰅧񣩠-.\uABED-悜; [V3, V6, V7]; xn----7m53aj640l.xn----8f4br83t; ; ;  # 𰅧-.꯭-悜
+ᡉ𶓧⬞ᢜ.-\u200D𞣑\u202E; ; [C2, V3, V7]; xn--87e0ol04cdl39e.xn----ugn5e3763s; ; xn--87e0ol04cdl39e.xn----qinu247r; [V3, V7] # ᡉ⬞ᢜ.-𞣑
+xn--87e0ol04cdl39e.xn----qinu247r; ᡉ𶓧⬞ᢜ.-𞣑\u202E; [V3, V7]; xn--87e0ol04cdl39e.xn----qinu247r; ; ;  # ᡉ⬞ᢜ.-𞣑
+xn--87e0ol04cdl39e.xn----ugn5e3763s; ᡉ𶓧⬞ᢜ.-\u200D𞣑\u202E; [C2, V3, V7]; xn--87e0ol04cdl39e.xn----ugn5e3763s; ; ;  # ᡉ⬞ᢜ.-𞣑
+⒐\u200C衃Ⴝ.\u0682Ⴔ; ⒐\u200C衃ⴝ.\u0682ⴔ; [B1, B2, B3, C1, V7]; xn--0ugx0px1izu2h.xn--7ib268q; ; xn--1shy52abz3f.xn--7ib268q; [B1, B2, B3, V7] # ⒐衃ⴝ.ڂⴔ
+9.\u200C衃Ⴝ.\u0682Ⴔ; 9.\u200C衃ⴝ.\u0682ⴔ; [B1, B2, B3, C1]; 9.xn--0ug862cbm5e.xn--7ib268q; ; 9.xn--llj1920a.xn--7ib268q; [B1, B2, B3] # 9.衃ⴝ.ڂⴔ
+9.\u200C衃ⴝ.\u0682ⴔ; ; [B1, B2, B3, C1]; 9.xn--0ug862cbm5e.xn--7ib268q; ; 9.xn--llj1920a.xn--7ib268q; [B1, B2, B3] # 9.衃ⴝ.ڂⴔ
+9.\u200C衃Ⴝ.\u0682ⴔ; 9.\u200C衃ⴝ.\u0682ⴔ; [B1, B2, B3, C1]; 9.xn--0ug862cbm5e.xn--7ib268q; ; 9.xn--llj1920a.xn--7ib268q; [B1, B2, B3] # 9.衃ⴝ.ڂⴔ
+9.xn--llj1920a.xn--7ib268q; 9.衃ⴝ.\u0682ⴔ; [B1, B2, B3]; 9.xn--llj1920a.xn--7ib268q; ; ;  # 9.衃ⴝ.ڂⴔ
+9.xn--0ug862cbm5e.xn--7ib268q; 9.\u200C衃ⴝ.\u0682ⴔ; [B1, B2, B3, C1]; 9.xn--0ug862cbm5e.xn--7ib268q; ; ;  # 9.衃ⴝ.ڂⴔ
+⒐\u200C衃ⴝ.\u0682ⴔ; ; [B1, B2, B3, C1, V7]; xn--0ugx0px1izu2h.xn--7ib268q; ; xn--1shy52abz3f.xn--7ib268q; [B1, B2, B3, V7] # ⒐衃ⴝ.ڂⴔ
+⒐\u200C衃Ⴝ.\u0682ⴔ; ⒐\u200C衃ⴝ.\u0682ⴔ; [B1, B2, B3, C1, V7]; xn--0ugx0px1izu2h.xn--7ib268q; ; xn--1shy52abz3f.xn--7ib268q; [B1, B2, B3, V7] # ⒐衃ⴝ.ڂⴔ
+xn--1shy52abz3f.xn--7ib268q; ⒐衃ⴝ.\u0682ⴔ; [B1, B2, B3, V7]; xn--1shy52abz3f.xn--7ib268q; ; ;  # ⒐衃ⴝ.ڂⴔ
+xn--0ugx0px1izu2h.xn--7ib268q; ⒐\u200C衃ⴝ.\u0682ⴔ; [B1, B2, B3, C1, V7]; xn--0ugx0px1izu2h.xn--7ib268q; ; ;  # ⒐衃ⴝ.ڂⴔ
+9.xn--1nd9032d.xn--7ib268q; 9.衃Ⴝ.\u0682ⴔ; [B1, B2, B3, V7]; 9.xn--1nd9032d.xn--7ib268q; ; ;  # 9.衃Ⴝ.ڂⴔ
+9.xn--1nd159e1y2f.xn--7ib268q; 9.\u200C衃Ⴝ.\u0682ⴔ; [B1, B2, B3, C1, V7]; 9.xn--1nd159e1y2f.xn--7ib268q; ; ;  # 9.衃Ⴝ.ڂⴔ
+9.xn--1nd9032d.xn--7ib433c; 9.衃Ⴝ.\u0682Ⴔ; [B1, B2, B3, V7]; 9.xn--1nd9032d.xn--7ib433c; ; ;  # 9.衃Ⴝ.ڂႴ
+9.xn--1nd159e1y2f.xn--7ib433c; 9.\u200C衃Ⴝ.\u0682Ⴔ; [B1, B2, B3, C1, V7]; 9.xn--1nd159e1y2f.xn--7ib433c; ; ;  # 9.衃Ⴝ.ڂႴ
+xn--1nd362hy16e.xn--7ib268q; ⒐衃Ⴝ.\u0682ⴔ; [B1, B2, B3, V7]; xn--1nd362hy16e.xn--7ib268q; ; ;  # ⒐衃Ⴝ.ڂⴔ
+xn--1nd159ecmd785k.xn--7ib268q; ⒐\u200C衃Ⴝ.\u0682ⴔ; [B1, B2, B3, C1, V7]; xn--1nd159ecmd785k.xn--7ib268q; ; ;  # ⒐衃Ⴝ.ڂⴔ
+xn--1nd362hy16e.xn--7ib433c; ⒐衃Ⴝ.\u0682Ⴔ; [B1, B2, B3, V7]; xn--1nd362hy16e.xn--7ib433c; ; ;  # ⒐衃Ⴝ.ڂႴ
+xn--1nd159ecmd785k.xn--7ib433c; ⒐\u200C衃Ⴝ.\u0682Ⴔ; [B1, B2, B3, C1, V7]; xn--1nd159ecmd785k.xn--7ib433c; ; ;  # ⒐衃Ⴝ.ڂႴ
+\u07E1\u200C。--⸬; \u07E1\u200C.--⸬; [B1, B3, C1, V3]; xn--8sb884j.xn-----iw2a; ; xn--8sb.xn-----iw2a; [B1, V3] # ߡ.--⸬
+xn--8sb.xn-----iw2a; \u07E1.--⸬; [B1, V3]; xn--8sb.xn-----iw2a; ; ;  # ߡ.--⸬
+xn--8sb884j.xn-----iw2a; \u07E1\u200C.--⸬; [B1, B3, C1, V3]; xn--8sb884j.xn-----iw2a; ; ;  # ߡ.--⸬
+𞥓．\u0718; 𞥓.\u0718; ; xn--of6h.xn--inb; ; ;  # 𞥓.ܘ
+𞥓.\u0718; ; ; xn--of6h.xn--inb; ; ;  # 𞥓.ܘ
+xn--of6h.xn--inb; 𞥓.\u0718; ; xn--of6h.xn--inb; ; ;  # 𞥓.ܘ
+󠄽-．-\u0DCA; -.-\u0DCA; [V3]; -.xn----ptf; ; ;  # -.-්
+󠄽-.-\u0DCA; -.-\u0DCA; [V3]; -.xn----ptf; ; ;  # -.-්
+-.xn----ptf; -.-\u0DCA; [V3]; -.xn----ptf; ; ;  # -.-්
+󠇝\u075B-.\u1927; \u075B-.\u1927; [B1, B3, V3, V6]; xn----k4c.xn--lff; ; ;  # ݛ-.ᤧ
+xn----k4c.xn--lff; \u075B-.\u1927; [B1, B3, V3, V6]; xn----k4c.xn--lff; ; ;  # ݛ-.ᤧ
+𞤴󠆹⦉𐹺.\uA806⒌󘤸; 𞤴⦉𐹺.\uA806⒌󘤸; [B1, V6, V7]; xn--fuix729epewf.xn--xsh5029b6e77i; ; ;  # 𞤴⦉𐹺.꠆⒌
+𞤴󠆹⦉𐹺.\uA8065.󘤸; 𞤴⦉𐹺.\uA8065.󘤸; [B1, V6, V7]; xn--fuix729epewf.xn--5-w93e.xn--7b83e; ; ;  # 𞤴⦉𐹺.꠆5.
+𞤒󠆹⦉𐹺.\uA8065.󘤸; 𞤴⦉𐹺.\uA8065.󘤸; [B1, V6, V7]; xn--fuix729epewf.xn--5-w93e.xn--7b83e; ; ;  # 𞤴⦉𐹺.꠆5.
+xn--fuix729epewf.xn--5-w93e.xn--7b83e; 𞤴⦉𐹺.\uA8065.󘤸; [B1, V6, V7]; xn--fuix729epewf.xn--5-w93e.xn--7b83e; ; ;  # 𞤴⦉𐹺.꠆5.
+𞤒󠆹⦉𐹺.\uA806⒌󘤸; 𞤴⦉𐹺.\uA806⒌󘤸; [B1, V6, V7]; xn--fuix729epewf.xn--xsh5029b6e77i; ; ;  # 𞤴⦉𐹺.꠆⒌
+xn--fuix729epewf.xn--xsh5029b6e77i; 𞤴⦉𐹺.\uA806⒌󘤸; [B1, V6, V7]; xn--fuix729epewf.xn--xsh5029b6e77i; ; ;  # 𞤴⦉𐹺.꠆⒌
+󠄸₀。𑖿\u200C𐦂\u200D; 0.𑖿\u200C𐦂\u200D; [B1, C2, V6]; 0.xn--0ugc8040p9hk; ; 0.xn--mn9cz2s; [B1, V6] # 0.𑖿𐦂
+󠄸0。𑖿\u200C𐦂\u200D; 0.𑖿\u200C𐦂\u200D; [B1, C2, V6]; 0.xn--0ugc8040p9hk; ; 0.xn--mn9cz2s; [B1, V6] # 0.𑖿𐦂
+0.xn--mn9cz2s; 0.𑖿𐦂; [B1, V6]; 0.xn--mn9cz2s; ; ;  # 0.𑖿𐦂
+0.xn--0ugc8040p9hk; 0.𑖿\u200C𐦂\u200D; [B1, C2, V6]; 0.xn--0ugc8040p9hk; ; ;  # 0.𑖿𐦂
+Ⴚ𐋸󠄄。𝟝ퟶ\u103A; ⴚ𐋸.5ퟶ\u103A; ; xn--ilj2659d.xn--5-dug9054m; ; ;  # ⴚ𐋸.5ퟶ်
+Ⴚ𐋸󠄄。5ퟶ\u103A; ⴚ𐋸.5ퟶ\u103A; ; xn--ilj2659d.xn--5-dug9054m; ; ;  # ⴚ𐋸.5ퟶ်
+ⴚ𐋸󠄄。5ퟶ\u103A; ⴚ𐋸.5ퟶ\u103A; ; xn--ilj2659d.xn--5-dug9054m; ; ;  # ⴚ𐋸.5ퟶ်
+xn--ilj2659d.xn--5-dug9054m; ⴚ𐋸.5ퟶ\u103A; ; xn--ilj2659d.xn--5-dug9054m; ; ;  # ⴚ𐋸.5ퟶ်
+ⴚ𐋸.5ퟶ\u103A; ; ; xn--ilj2659d.xn--5-dug9054m; ; ;  # ⴚ𐋸.5ퟶ်
+Ⴚ𐋸.5ퟶ\u103A; ⴚ𐋸.5ퟶ\u103A; ; xn--ilj2659d.xn--5-dug9054m; ; ;  # ⴚ𐋸.5ퟶ်
+ⴚ𐋸󠄄。𝟝ퟶ\u103A; ⴚ𐋸.5ퟶ\u103A; ; xn--ilj2659d.xn--5-dug9054m; ; ;  # ⴚ𐋸.5ퟶ်
+xn--ynd2415j.xn--5-dug9054m; Ⴚ𐋸.5ퟶ\u103A; [V7]; xn--ynd2415j.xn--5-dug9054m; ; ;  # Ⴚ𐋸.5ퟶ်
+\u200D-ᠹ﹪.\u1DE1\u1922; \u200D-ᠹ%.\u1DE1\u1922; [C2, V6, U1]; xn---%-u4oy48b.xn--gff52t; ; xn---%-u4o.xn--gff52t; [V3, V6, U1] # -ᠹ%.ᷡᤢ
+\u200D-ᠹ%.\u1DE1\u1922; ; [C2, V6, U1]; xn---%-u4oy48b.xn--gff52t; ; xn---%-u4o.xn--gff52t; [V3, V6, U1] # -ᠹ%.ᷡᤢ
+xn---%-u4o.xn--gff52t; -ᠹ%.\u1DE1\u1922; [V3, V6, U1]; xn---%-u4o.xn--gff52t; ; ;  # -ᠹ%.ᷡᤢ
+xn---%-u4oy48b.xn--gff52t; \u200D-ᠹ%.\u1DE1\u1922; [C2, V6, U1]; xn---%-u4oy48b.xn--gff52t; ; ;  # -ᠹ%.ᷡᤢ
+xn----c6jx047j.xn--gff52t; -ᠹ﹪.\u1DE1\u1922; [V3, V6, V7]; xn----c6jx047j.xn--gff52t; ; ;  # -ᠹ﹪.ᷡᤢ
+xn----c6j614b1z4v.xn--gff52t; \u200D-ᠹ﹪.\u1DE1\u1922; [C2, V6, V7]; xn----c6j614b1z4v.xn--gff52t; ; ;  # -ᠹ﹪.ᷡᤢ
+≠.ᠿ; ; ; xn--1ch.xn--y7e; ; ;  # ≠.ᠿ
+=\u0338.ᠿ; ≠.ᠿ; ; xn--1ch.xn--y7e; ; ;  # ≠.ᠿ
+xn--1ch.xn--y7e; ≠.ᠿ; ; xn--1ch.xn--y7e; ; ;  # ≠.ᠿ
+\u0723\u05A3｡㌪; \u0723\u05A3.ハイツ; ; xn--ucb18e.xn--eck4c5a; ; ;  # ܣ֣.ハイツ
+\u0723\u05A3。ハイツ; \u0723\u05A3.ハイツ; ; xn--ucb18e.xn--eck4c5a; ; ;  # ܣ֣.ハイツ
+xn--ucb18e.xn--eck4c5a; \u0723\u05A3.ハイツ; ; xn--ucb18e.xn--eck4c5a; ; ;  # ܣ֣.ハイツ
+\u0723\u05A3.ハイツ; ; ; xn--ucb18e.xn--eck4c5a; ; ;  # ܣ֣.ハイツ
+𞷥󠆀≮.\u2D7F-; 𞷥≮.\u2D7F-; [B1, B3, V3, V6, V7]; xn--gdhx802p.xn----i2s; ; ;  # ≮.⵿-
+𞷥󠆀<\u0338.\u2D7F-; 𞷥≮.\u2D7F-; [B1, B3, V3, V6, V7]; xn--gdhx802p.xn----i2s; ; ;  # ≮.⵿-
+xn--gdhx802p.xn----i2s; 𞷥≮.\u2D7F-; [B1, B3, V3, V6, V7]; xn--gdhx802p.xn----i2s; ; ;  # ≮.⵿-
+₆榎򦖎\u0D4D｡𞤅\u06ED\uFC5A󠮨; 6榎򦖎\u0D4D.𞤧\u06ED\u064A\u064A󠮨; [B1, B3, V7]; xn--6-kmf4691ejv41j.xn--mhba10ch545mn8v8h; ; ;  # 6榎്.𞤧ۭيي
+6榎򦖎\u0D4D。𞤅\u06ED\u064A\u064A󠮨; 6榎򦖎\u0D4D.𞤧\u06ED\u064A\u064A󠮨; [B1, B3, V7]; xn--6-kmf4691ejv41j.xn--mhba10ch545mn8v8h; ; ;  # 6榎്.𞤧ۭيي
+6榎򦖎\u0D4D。𞤧\u06ED\u064A\u064A󠮨; 6榎򦖎\u0D4D.𞤧\u06ED\u064A\u064A󠮨; [B1, B3, V7]; xn--6-kmf4691ejv41j.xn--mhba10ch545mn8v8h; ; ;  # 6榎്.𞤧ۭيي
+xn--6-kmf4691ejv41j.xn--mhba10ch545mn8v8h; 6榎򦖎\u0D4D.𞤧\u06ED\u064A\u064A󠮨; [B1, B3, V7]; xn--6-kmf4691ejv41j.xn--mhba10ch545mn8v8h; ; ;  # 6榎്.𞤧ۭيي
+₆榎򦖎\u0D4D｡𞤧\u06ED\uFC5A󠮨; 6榎򦖎\u0D4D.𞤧\u06ED\u064A\u064A󠮨; [B1, B3, V7]; xn--6-kmf4691ejv41j.xn--mhba10ch545mn8v8h; ; ;  # 6榎്.𞤧ۭيي
+𣩫．򌑲; 𣩫.򌑲; [V7]; xn--td3j.xn--4628b; ; ;  # 𣩫.
+𣩫.򌑲; ; [V7]; xn--td3j.xn--4628b; ; ;  # 𣩫.
+xn--td3j.xn--4628b; 𣩫.򌑲; [V7]; xn--td3j.xn--4628b; ; ;  # 𣩫.
+\u200D︒｡\u06B9\u200C; \u200D︒.\u06B9\u200C; [B1, B3, C1, C2, V7]; xn--1ug2658f.xn--skb080k; ; xn--y86c.xn--skb; [B1, V7] # ︒.ڹ
+xn--y86c.xn--skb; ︒.\u06B9; [B1, V7]; xn--y86c.xn--skb; ; ;  # ︒.ڹ
+xn--1ug2658f.xn--skb080k; \u200D︒.\u06B9\u200C; [B1, B3, C1, C2, V7]; xn--1ug2658f.xn--skb080k; ; ;  # ︒.ڹ
+xn--skb; \u06B9; ; xn--skb; ; ;  # ڹ
+\u06B9; ; ; xn--skb; ; ;  # ڹ
+𐹦\u200C𐹶。\u206D; 𐹦\u200C𐹶.; [B1, C1]; xn--0ug4994goba.; [B1, C1, A4_2]; xn--eo0d6a.; [B1, A4_2] # 𐹦𐹶.
+xn--eo0d6a.; 𐹦𐹶.; [B1]; xn--eo0d6a.; [B1, A4_2]; ;  # 𐹦𐹶.
+xn--0ug4994goba.; 𐹦\u200C𐹶.; [B1, C1]; xn--0ug4994goba.; [B1, C1, A4_2]; ;  # 𐹦𐹶.
+xn--eo0d6a.xn--sxg; 𐹦𐹶.\u206D; [B1, V7]; xn--eo0d6a.xn--sxg; ; ;  # 𐹦𐹶.
+xn--0ug4994goba.xn--sxg; 𐹦\u200C𐹶.\u206D; [B1, C1, V7]; xn--0ug4994goba.xn--sxg; ; ;  # 𐹦𐹶.
+\u0C4D𝨾\u05A9𝟭。-𑜨; \u0C4D𝨾\u05A91.-𑜨; [V3, V6]; xn--1-rfc312cdp45c.xn----nq0j; ; ;  # ్𝨾֩1.-𑜨
+\u0C4D𝨾\u05A91。-𑜨; \u0C4D𝨾\u05A91.-𑜨; [V3, V6]; xn--1-rfc312cdp45c.xn----nq0j; ; ;  # ్𝨾֩1.-𑜨
+xn--1-rfc312cdp45c.xn----nq0j; \u0C4D𝨾\u05A91.-𑜨; [V3, V6]; xn--1-rfc312cdp45c.xn----nq0j; ; ;  # ్𝨾֩1.-𑜨
+򣿈。뙏; 򣿈.뙏; [V7]; xn--ph26c.xn--281b; ; ;  # .뙏
+򣿈。뙏; 򣿈.뙏; [V7]; xn--ph26c.xn--281b; ; ;  # .뙏
+xn--ph26c.xn--281b; 򣿈.뙏; [V7]; xn--ph26c.xn--281b; ; ;  # .뙏
+񕨚󠄌󑽀ᡀ.\u08B6; 񕨚󑽀ᡀ.\u08B6; [V7]; xn--z7e98100evc01b.xn--czb; ; ;  # ᡀ.ࢶ
+xn--z7e98100evc01b.xn--czb; 񕨚󑽀ᡀ.\u08B6; [V7]; xn--z7e98100evc01b.xn--czb; ; ;  # ᡀ.ࢶ
+\u200D｡񅁛; \u200D.񅁛; [C2, V7]; xn--1ug.xn--6x4u; ; .xn--6x4u; [V7, A4_2] # .
+\u200D。񅁛; \u200D.񅁛; [C2, V7]; xn--1ug.xn--6x4u; ; .xn--6x4u; [V7, A4_2] # .
+.xn--6x4u; .񅁛; [V7, X4_2]; .xn--6x4u; [V7, A4_2]; ;  # .
+xn--1ug.xn--6x4u; \u200D.񅁛; [C2, V7]; xn--1ug.xn--6x4u; ; ;  # .
+\u084B皥．-; \u084B皥.-; [B1, B2, B3, V3]; xn--9vb4167c.-; ; ;  # ࡋ皥.-
+\u084B皥.-; ; [B1, B2, B3, V3]; xn--9vb4167c.-; ; ;  # ࡋ皥.-
+xn--9vb4167c.-; \u084B皥.-; [B1, B2, B3, V3]; xn--9vb4167c.-; ; ;  # ࡋ皥.-
+𐣸\u0315𐮇．⒈ꡦ; 𐣸\u0315𐮇.⒈ꡦ; [B1, V7]; xn--5sa9915kgvb.xn--tshw539b; ; ;  # ̕𐮇.⒈ꡦ
+𐣸\u0315𐮇.1.ꡦ; ; [B1, V7]; xn--5sa9915kgvb.1.xn--cd9a; ; ;  # ̕𐮇.1.ꡦ
+xn--5sa9915kgvb.1.xn--cd9a; 𐣸\u0315𐮇.1.ꡦ; [B1, V7]; xn--5sa9915kgvb.1.xn--cd9a; ; ;  # ̕𐮇.1.ꡦ
+xn--5sa9915kgvb.xn--tshw539b; 𐣸\u0315𐮇.⒈ꡦ; [B1, V7]; xn--5sa9915kgvb.xn--tshw539b; ; ;  # ̕𐮇.⒈ꡦ
+Ⴛ\u200C\u05A2\u200D。\uFFA0ā𐹦; ⴛ\u200C\u05A2\u200D.ā𐹦; [B5, B6, C1, C2]; xn--tcb736kea974k.xn--yda4409k; ; xn--tcb323r.xn--yda4409k; [B5, B6] # ⴛ֢.ā𐹦
+Ⴛ\u200C\u05A2\u200D。\uFFA0a\u0304𐹦; ⴛ\u200C\u05A2\u200D.ā𐹦; [B5, B6, C1, C2]; xn--tcb736kea974k.xn--yda4409k; ; xn--tcb323r.xn--yda4409k; [B5, B6] # ⴛ֢.ā𐹦
+Ⴛ\u200C\u05A2\u200D。\u1160ā𐹦; ⴛ\u200C\u05A2\u200D.ā𐹦; [B5, B6, C1, C2]; xn--tcb736kea974k.xn--yda4409k; ; xn--tcb323r.xn--yda4409k; [B5, B6] # ⴛ֢.ā𐹦
+Ⴛ\u200C\u05A2\u200D。\u1160a\u0304𐹦; ⴛ\u200C\u05A2\u200D.ā𐹦; [B5, B6, C1, C2]; xn--tcb736kea974k.xn--yda4409k; ; xn--tcb323r.xn--yda4409k; [B5, B6] # ⴛ֢.ā𐹦
+ⴛ\u200C\u05A2\u200D。\u1160a\u0304𐹦; ⴛ\u200C\u05A2\u200D.ā𐹦; [B5, B6, C1, C2]; xn--tcb736kea974k.xn--yda4409k; ; xn--tcb323r.xn--yda4409k; [B5, B6] # ⴛ֢.ā𐹦
+ⴛ\u200C\u05A2\u200D。\u1160ā𐹦; ⴛ\u200C\u05A2\u200D.ā𐹦; [B5, B6, C1, C2]; xn--tcb736kea974k.xn--yda4409k; ; xn--tcb323r.xn--yda4409k; [B5, B6] # ⴛ֢.ā𐹦
+Ⴛ\u200C\u05A2\u200D。\u1160Ā𐹦; ⴛ\u200C\u05A2\u200D.ā𐹦; [B5, B6, C1, C2]; xn--tcb736kea974k.xn--yda4409k; ; xn--tcb323r.xn--yda4409k; [B5, B6] # ⴛ֢.ā𐹦
+Ⴛ\u200C\u05A2\u200D。\u1160A\u0304𐹦; ⴛ\u200C\u05A2\u200D.ā𐹦; [B5, B6, C1, C2]; xn--tcb736kea974k.xn--yda4409k; ; xn--tcb323r.xn--yda4409k; [B5, B6] # ⴛ֢.ā𐹦
+xn--tcb323r.xn--yda4409k; ⴛ\u05A2.ā𐹦; [B5, B6]; xn--tcb323r.xn--yda4409k; ; ;  # ⴛ֢.ā𐹦
+xn--tcb736kea974k.xn--yda4409k; ⴛ\u200C\u05A2\u200D.ā𐹦; [B5, B6, C1, C2]; xn--tcb736kea974k.xn--yda4409k; ; ;  # ⴛ֢.ā𐹦
+ⴛ\u200C\u05A2\u200D。\uFFA0a\u0304𐹦; ⴛ\u200C\u05A2\u200D.ā𐹦; [B5, B6, C1, C2]; xn--tcb736kea974k.xn--yda4409k; ; xn--tcb323r.xn--yda4409k; [B5, B6] # ⴛ֢.ā𐹦
+ⴛ\u200C\u05A2\u200D。\uFFA0ā𐹦; ⴛ\u200C\u05A2\u200D.ā𐹦; [B5, B6, C1, C2]; xn--tcb736kea974k.xn--yda4409k; ; xn--tcb323r.xn--yda4409k; [B5, B6] # ⴛ֢.ā𐹦
+Ⴛ\u200C\u05A2\u200D。\uFFA0Ā𐹦; ⴛ\u200C\u05A2\u200D.ā𐹦; [B5, B6, C1, C2]; xn--tcb736kea974k.xn--yda4409k; ; xn--tcb323r.xn--yda4409k; [B5, B6] # ⴛ֢.ā𐹦
+Ⴛ\u200C\u05A2\u200D。\uFFA0A\u0304𐹦; ⴛ\u200C\u05A2\u200D.ā𐹦; [B5, B6, C1, C2]; xn--tcb736kea974k.xn--yda4409k; ; xn--tcb323r.xn--yda4409k; [B5, B6] # ⴛ֢.ā𐹦
+xn--tcb597c.xn--yda594fdn5q; Ⴛ\u05A2.\u1160ā𐹦; [B5, B6, V7]; xn--tcb597c.xn--yda594fdn5q; ; ;  # Ⴛ֢.ā𐹦
+xn--tcb597cdmmfa.xn--yda594fdn5q; Ⴛ\u200C\u05A2\u200D.\u1160ā𐹦; [B5, B6, C1, C2, V7]; xn--tcb597cdmmfa.xn--yda594fdn5q; ; ;  # Ⴛ֢.ā𐹦
+xn--tcb323r.xn--yda594fdn5q; ⴛ\u05A2.\u1160ā𐹦; [B5, B6, V7]; xn--tcb323r.xn--yda594fdn5q; ; ;  # ⴛ֢.ā𐹦
+xn--tcb736kea974k.xn--yda594fdn5q; ⴛ\u200C\u05A2\u200D.\u1160ā𐹦; [B5, B6, C1, C2, V7]; xn--tcb736kea974k.xn--yda594fdn5q; ; ;  # ⴛ֢.ā𐹦
+xn--tcb597c.xn--yda9741khjj; Ⴛ\u05A2.\uFFA0ā𐹦; [B5, B6, V7]; xn--tcb597c.xn--yda9741khjj; ; ;  # Ⴛ֢.ā𐹦
+xn--tcb597cdmmfa.xn--yda9741khjj; Ⴛ\u200C\u05A2\u200D.\uFFA0ā𐹦; [B5, B6, C1, C2, V7]; xn--tcb597cdmmfa.xn--yda9741khjj; ; ;  # Ⴛ֢.ā𐹦
+xn--tcb323r.xn--yda9741khjj; ⴛ\u05A2.\uFFA0ā𐹦; [B5, B6, V7]; xn--tcb323r.xn--yda9741khjj; ; ;  # ⴛ֢.ā𐹦
+xn--tcb736kea974k.xn--yda9741khjj; ⴛ\u200C\u05A2\u200D.\uFFA0ā𐹦; [B5, B6, C1, C2, V7]; xn--tcb736kea974k.xn--yda9741khjj; ; ;  # ⴛ֢.ā𐹦
+\uFFF9\u200C｡曳⾑𐋰≯; \uFFF9\u200C.曳襾𐋰≯; [C1, V7]; xn--0ug2139f.xn--hdh501y8wvfs5h; ; xn--vn7c.xn--hdh501y8wvfs5h; [V7] # .曳襾𐋰≯
+\uFFF9\u200C｡曳⾑𐋰>\u0338; \uFFF9\u200C.曳襾𐋰≯; [C1, V7]; xn--0ug2139f.xn--hdh501y8wvfs5h; ; xn--vn7c.xn--hdh501y8wvfs5h; [V7] # .曳襾𐋰≯
+\uFFF9\u200C。曳襾𐋰≯; \uFFF9\u200C.曳襾𐋰≯; [C1, V7]; xn--0ug2139f.xn--hdh501y8wvfs5h; ; xn--vn7c.xn--hdh501y8wvfs5h; [V7] # .曳襾𐋰≯
+\uFFF9\u200C。曳襾𐋰>\u0338; \uFFF9\u200C.曳襾𐋰≯; [C1, V7]; xn--0ug2139f.xn--hdh501y8wvfs5h; ; xn--vn7c.xn--hdh501y8wvfs5h; [V7] # .曳襾𐋰≯
+xn--vn7c.xn--hdh501y8wvfs5h; \uFFF9.曳襾𐋰≯; [V7]; xn--vn7c.xn--hdh501y8wvfs5h; ; ;  # .曳襾𐋰≯
+xn--0ug2139f.xn--hdh501y8wvfs5h; \uFFF9\u200C.曳襾𐋰≯; [C1, V7]; xn--0ug2139f.xn--hdh501y8wvfs5h; ; ;  # .曳襾𐋰≯
+≯⒈。ß; ≯⒈.ß; [V7]; xn--hdh84f.xn--zca; ; xn--hdh84f.ss;  # ≯⒈.ß
+>\u0338⒈。ß; ≯⒈.ß; [V7]; xn--hdh84f.xn--zca; ; xn--hdh84f.ss;  # ≯⒈.ß
+≯1.。ß; ≯1..ß; [X4_2]; xn--1-ogo..xn--zca; [A4_2]; xn--1-ogo..ss;  # ≯1..ß
+>\u03381.。ß; ≯1..ß; [X4_2]; xn--1-ogo..xn--zca; [A4_2]; xn--1-ogo..ss;  # ≯1..ß
+>\u03381.。SS; ≯1..ss; [X4_2]; xn--1-ogo..ss; [A4_2]; ;  # ≯1..ss
+≯1.。SS; ≯1..ss; [X4_2]; xn--1-ogo..ss; [A4_2]; ;  # ≯1..ss
+≯1.。ss; ≯1..ss; [X4_2]; xn--1-ogo..ss; [A4_2]; ;  # ≯1..ss
+>\u03381.。ss; ≯1..ss; [X4_2]; xn--1-ogo..ss; [A4_2]; ;  # ≯1..ss
+>\u03381.。Ss; ≯1..ss; [X4_2]; xn--1-ogo..ss; [A4_2]; ;  # ≯1..ss
+≯1.。Ss; ≯1..ss; [X4_2]; xn--1-ogo..ss; [A4_2]; ;  # ≯1..ss
+xn--1-ogo..ss; ≯1..ss; [X4_2]; xn--1-ogo..ss; [A4_2]; ;  # ≯1..ss
+xn--1-ogo..xn--zca; ≯1..ß; [X4_2]; xn--1-ogo..xn--zca; [A4_2]; ;  # ≯1..ß
+>\u0338⒈。SS; ≯⒈.ss; [V7]; xn--hdh84f.ss; ; ;  # ≯⒈.ss
+≯⒈。SS; ≯⒈.ss; [V7]; xn--hdh84f.ss; ; ;  # ≯⒈.ss
+≯⒈。ss; ≯⒈.ss; [V7]; xn--hdh84f.ss; ; ;  # ≯⒈.ss
+>\u0338⒈。ss; ≯⒈.ss; [V7]; xn--hdh84f.ss; ; ;  # ≯⒈.ss
+>\u0338⒈。Ss; ≯⒈.ss; [V7]; xn--hdh84f.ss; ; ;  # ≯⒈.ss
+≯⒈。Ss; ≯⒈.ss; [V7]; xn--hdh84f.ss; ; ;  # ≯⒈.ss
+xn--hdh84f.ss; ≯⒈.ss; [V7]; xn--hdh84f.ss; ; ;  # ≯⒈.ss
+xn--hdh84f.xn--zca; ≯⒈.ß; [V7]; xn--hdh84f.xn--zca; ; ;  # ≯⒈.ß
+\u0667\u200D\uFB96｡\u07DA-₆Ⴙ; \u0667\u200D\u06B3.\u07DA-6ⴙ; [B1, B2, B3, C2]; xn--gib6m343e.xn---6-lve6529a; ; xn--gib6m.xn---6-lve6529a; [B1, B2, B3] # ٧ڳ.ߚ-6ⴙ
+\u0667\u200D\u06B3。\u07DA-6Ⴙ; \u0667\u200D\u06B3.\u07DA-6ⴙ; [B1, B2, B3, C2]; xn--gib6m343e.xn---6-lve6529a; ; xn--gib6m.xn---6-lve6529a; [B1, B2, B3] # ٧ڳ.ߚ-6ⴙ
+\u0667\u200D\u06B3。\u07DA-6ⴙ; \u0667\u200D\u06B3.\u07DA-6ⴙ; [B1, B2, B3, C2]; xn--gib6m343e.xn---6-lve6529a; ; xn--gib6m.xn---6-lve6529a; [B1, B2, B3] # ٧ڳ.ߚ-6ⴙ
+xn--gib6m.xn---6-lve6529a; \u0667\u06B3.\u07DA-6ⴙ; [B1, B2, B3]; xn--gib6m.xn---6-lve6529a; ; ;  # ٧ڳ.ߚ-6ⴙ
+xn--gib6m343e.xn---6-lve6529a; \u0667\u200D\u06B3.\u07DA-6ⴙ; [B1, B2, B3, C2]; xn--gib6m343e.xn---6-lve6529a; ; ;  # ٧ڳ.ߚ-6ⴙ
+\u0667\u200D\uFB96｡\u07DA-₆ⴙ; \u0667\u200D\u06B3.\u07DA-6ⴙ; [B1, B2, B3, C2]; xn--gib6m343e.xn---6-lve6529a; ; xn--gib6m.xn---6-lve6529a; [B1, B2, B3] # ٧ڳ.ߚ-6ⴙ
+xn--gib6m.xn---6-lve002g; \u0667\u06B3.\u07DA-6Ⴙ; [B1, B2, B3, V7]; xn--gib6m.xn---6-lve002g; ; ;  # ٧ڳ.ߚ-6Ⴙ
+xn--gib6m343e.xn---6-lve002g; \u0667\u200D\u06B3.\u07DA-6Ⴙ; [B1, B2, B3, C2, V7]; xn--gib6m343e.xn---6-lve002g; ; ;  # ٧ڳ.ߚ-6Ⴙ
+\u200C｡≠; \u200C.≠; [C1]; xn--0ug.xn--1ch; ; .xn--1ch; [A4_2] # .≠
+\u200C｡=\u0338; \u200C.≠; [C1]; xn--0ug.xn--1ch; ; .xn--1ch; [A4_2] # .≠
+\u200C。≠; \u200C.≠; [C1]; xn--0ug.xn--1ch; ; .xn--1ch; [A4_2] # .≠
+\u200C。=\u0338; \u200C.≠; [C1]; xn--0ug.xn--1ch; ; .xn--1ch; [A4_2] # .≠
+.xn--1ch; .≠; [X4_2]; .xn--1ch; [A4_2]; ;  # .≠
+xn--0ug.xn--1ch; \u200C.≠; [C1]; xn--0ug.xn--1ch; ; ;  # .≠
+𑖿𝨔.ᡟ𑖿\u1B42\u200C; ; [C1, V6]; xn--461dw464a.xn--v8e29ldzfo952a; ; xn--461dw464a.xn--v8e29loy65a; [V6] # 𑖿𝨔.ᡟ𑖿ᭂ
+xn--461dw464a.xn--v8e29loy65a; 𑖿𝨔.ᡟ𑖿\u1B42; [V6]; xn--461dw464a.xn--v8e29loy65a; ; ;  # 𑖿𝨔.ᡟ𑖿ᭂ
+xn--461dw464a.xn--v8e29ldzfo952a; 𑖿𝨔.ᡟ𑖿\u1B42\u200C; [C1, V6]; xn--461dw464a.xn--v8e29ldzfo952a; ; ;  # 𑖿𝨔.ᡟ𑖿ᭂ
+򔣳\u200D򑝱.𖬴Ↄ≠-; 򔣳\u200D򑝱.𖬴ↄ≠-; [C2, V3, V6, V7]; xn--1ug15151gkb5a.xn----81n51bt713h; ; xn--6j00chy9a.xn----81n51bt713h; [V3, V6, V7] # .𖬴ↄ≠-
+򔣳\u200D򑝱.𖬴Ↄ=\u0338-; 򔣳\u200D򑝱.𖬴ↄ≠-; [C2, V3, V6, V7]; xn--1ug15151gkb5a.xn----81n51bt713h; ; xn--6j00chy9a.xn----81n51bt713h; [V3, V6, V7] # .𖬴ↄ≠-
+򔣳\u200D򑝱.𖬴ↄ=\u0338-; 򔣳\u200D򑝱.𖬴ↄ≠-; [C2, V3, V6, V7]; xn--1ug15151gkb5a.xn----81n51bt713h; ; xn--6j00chy9a.xn----81n51bt713h; [V3, V6, V7] # .𖬴ↄ≠-
+򔣳\u200D򑝱.𖬴ↄ≠-; ; [C2, V3, V6, V7]; xn--1ug15151gkb5a.xn----81n51bt713h; ; xn--6j00chy9a.xn----81n51bt713h; [V3, V6, V7] # .𖬴ↄ≠-
+xn--6j00chy9a.xn----81n51bt713h; 򔣳򑝱.𖬴ↄ≠-; [V3, V6, V7]; xn--6j00chy9a.xn----81n51bt713h; ; ;  # .𖬴ↄ≠-
+xn--1ug15151gkb5a.xn----81n51bt713h; 򔣳\u200D򑝱.𖬴ↄ≠-; [C2, V3, V6, V7]; xn--1ug15151gkb5a.xn----81n51bt713h; ; ;  # .𖬴ↄ≠-
+xn--6j00chy9a.xn----61n81bt713h; 򔣳򑝱.𖬴Ↄ≠-; [V3, V6, V7]; xn--6j00chy9a.xn----61n81bt713h; ; ;  # .𖬴Ↄ≠-
+xn--1ug15151gkb5a.xn----61n81bt713h; 򔣳\u200D򑝱.𖬴Ↄ≠-; [C2, V3, V6, V7]; xn--1ug15151gkb5a.xn----61n81bt713h; ; ;  # .𖬴Ↄ≠-
+\u07E2ς\u200D𝟳。蔑򛖢; \u07E2ς\u200D7.蔑򛖢; [B2, C2, V7]; xn--7-xmb182aez5a.xn--wy1ao4929b; ; xn--7-zmb872a.xn--wy1ao4929b; [B2, V7] # ߢς7.蔑
+\u07E2ς\u200D7。蔑򛖢; \u07E2ς\u200D7.蔑򛖢; [B2, C2, V7]; xn--7-xmb182aez5a.xn--wy1ao4929b; ; xn--7-zmb872a.xn--wy1ao4929b; [B2, V7] # ߢς7.蔑
+\u07E2Σ\u200D7。蔑򛖢; \u07E2σ\u200D7.蔑򛖢; [B2, C2, V7]; xn--7-zmb872aez5a.xn--wy1ao4929b; ; xn--7-zmb872a.xn--wy1ao4929b; [B2, V7] # ߢσ7.蔑
+\u07E2σ\u200D7。蔑򛖢; \u07E2σ\u200D7.蔑򛖢; [B2, C2, V7]; xn--7-zmb872aez5a.xn--wy1ao4929b; ; xn--7-zmb872a.xn--wy1ao4929b; [B2, V7] # ߢσ7.蔑
+xn--7-zmb872a.xn--wy1ao4929b; \u07E2σ7.蔑򛖢; [B2, V7]; xn--7-zmb872a.xn--wy1ao4929b; ; ;  # ߢσ7.蔑
+xn--7-zmb872aez5a.xn--wy1ao4929b; \u07E2σ\u200D7.蔑򛖢; [B2, C2, V7]; xn--7-zmb872aez5a.xn--wy1ao4929b; ; ;  # ߢσ7.蔑
+xn--7-xmb182aez5a.xn--wy1ao4929b; \u07E2ς\u200D7.蔑򛖢; [B2, C2, V7]; xn--7-xmb182aez5a.xn--wy1ao4929b; ; ;  # ߢς7.蔑
+\u07E2Σ\u200D𝟳。蔑򛖢; \u07E2σ\u200D7.蔑򛖢; [B2, C2, V7]; xn--7-zmb872aez5a.xn--wy1ao4929b; ; xn--7-zmb872a.xn--wy1ao4929b; [B2, V7] # ߢσ7.蔑
+\u07E2σ\u200D𝟳。蔑򛖢; \u07E2σ\u200D7.蔑򛖢; [B2, C2, V7]; xn--7-zmb872aez5a.xn--wy1ao4929b; ; xn--7-zmb872a.xn--wy1ao4929b; [B2, V7] # ߢσ7.蔑
+𐹰.\u0600; ; [B1, V7]; xn--oo0d.xn--ifb; ; ;  # 𐹰.
+xn--oo0d.xn--ifb; 𐹰.\u0600; [B1, V7]; xn--oo0d.xn--ifb; ; ;  # 𐹰.
+-\u08A8.𱠖; ; [B1, V3]; xn----mod.xn--5o9n; ; ;  # -ࢨ.𱠖
+xn----mod.xn--5o9n; -\u08A8.𱠖; [B1, V3]; xn----mod.xn--5o9n; ; ;  # -ࢨ.𱠖
+≯𞱸󠇀。誆⒈; ≯𞱸.誆⒈; [B1, V7]; xn--hdh7151p.xn--tsh1248a; ; ;  # ≯𞱸.誆⒈
+>\u0338𞱸󠇀。誆⒈; ≯𞱸.誆⒈; [B1, V7]; xn--hdh7151p.xn--tsh1248a; ; ;  # ≯𞱸.誆⒈
+≯𞱸󠇀。誆1.; ≯𞱸.誆1.; [B1]; xn--hdh7151p.xn--1-dy1d.; [B1, A4_2]; ;  # ≯𞱸.誆1.
+>\u0338𞱸󠇀。誆1.; ≯𞱸.誆1.; [B1]; xn--hdh7151p.xn--1-dy1d.; [B1, A4_2]; ;  # ≯𞱸.誆1.
+xn--hdh7151p.xn--1-dy1d.; ≯𞱸.誆1.; [B1]; xn--hdh7151p.xn--1-dy1d.; [B1, A4_2]; ;  # ≯𞱸.誆1.
+xn--hdh7151p.xn--tsh1248a; ≯𞱸.誆⒈; [B1, V7]; xn--hdh7151p.xn--tsh1248a; ; ;  # ≯𞱸.誆⒈
+\u0616𞥙䐊\u0650．︒\u0645↺\u069C; \u0616𞥙䐊\u0650.︒\u0645↺\u069C; [B1, V6, V7]; xn--4fb0j490qjg4x.xn--hhb8o948euo5r; ; ;  # ؖ𞥙䐊ِ.︒م↺ڜ
+\u0616𞥙䐊\u0650.。\u0645↺\u069C; \u0616𞥙䐊\u0650..\u0645↺\u069C; [B1, V6, X4_2]; xn--4fb0j490qjg4x..xn--hhb8o948e; [B1, V6, A4_2]; ;  # ؖ𞥙䐊ِ..م↺ڜ
+xn--4fb0j490qjg4x..xn--hhb8o948e; \u0616𞥙䐊\u0650..\u0645↺\u069C; [B1, V6, X4_2]; xn--4fb0j490qjg4x..xn--hhb8o948e; [B1, V6, A4_2]; ;  # ؖ𞥙䐊ِ..م↺ڜ
+xn--4fb0j490qjg4x.xn--hhb8o948euo5r; \u0616𞥙䐊\u0650.︒\u0645↺\u069C; [B1, V6, V7]; xn--4fb0j490qjg4x.xn--hhb8o948euo5r; ; ;  # ؖ𞥙䐊ِ.︒م↺ڜ
+퀬-?񶳒.\u200C\u0AC5󩸤۴; ; [C1, V7, U1]; xn---?-6g4k75207c.xn--hmb76q48y18505a; ; xn---?-6g4k75207c.xn--hmb76q74166b; [V6, V7, U1] # 퀬-?.ૅ۴
+퀬-?񶳒.\u200C\u0AC5󩸤۴; 퀬-?񶳒.\u200C\u0AC5󩸤۴; [C1, V7, U1]; xn---?-6g4k75207c.xn--hmb76q48y18505a; ; xn---?-6g4k75207c.xn--hmb76q74166b; [V6, V7, U1] # 퀬-?.ૅ۴
+xn---?-6g4k75207c.xn--hmb76q74166b; 퀬-?񶳒.\u0AC5󩸤۴; [V6, V7, U1]; xn---?-6g4k75207c.xn--hmb76q74166b; ; ;  # 퀬-?.ૅ۴
+xn---?-6g4k75207c.xn--hmb76q48y18505a; 퀬-?񶳒.\u200C\u0AC5󩸤۴; [C1, V7, U1]; xn---?-6g4k75207c.xn--hmb76q48y18505a; ; ;  # 퀬-?.ૅ۴
+퀬-?񶳒.xn--hmb76q74166b; 퀬-?񶳒.\u0AC5󩸤۴; [V6, V7, U1]; xn---?-6g4k75207c.xn--hmb76q74166b; ; ;  # 퀬-?.ૅ۴
+퀬-?񶳒.xn--hmb76q74166b; 퀬-?񶳒.\u0AC5󩸤۴; [V6, V7, U1]; xn---?-6g4k75207c.xn--hmb76q74166b; ; ;  # 퀬-?.ૅ۴
+퀬-?񶳒.XN--HMB76Q74166B; 퀬-?񶳒.\u0AC5󩸤۴; [V6, V7, U1]; xn---?-6g4k75207c.xn--hmb76q74166b; ; ;  # 퀬-?.ૅ۴
+퀬-?񶳒.XN--HMB76Q74166B; 퀬-?񶳒.\u0AC5󩸤۴; [V6, V7, U1]; xn---?-6g4k75207c.xn--hmb76q74166b; ; ;  # 퀬-?.ૅ۴
+퀬-?񶳒.Xn--Hmb76q74166b; 퀬-?񶳒.\u0AC5󩸤۴; [V6, V7, U1]; xn---?-6g4k75207c.xn--hmb76q74166b; ; ;  # 퀬-?.ૅ۴
+퀬-?񶳒.Xn--Hmb76q74166b; 퀬-?񶳒.\u0AC5󩸤۴; [V6, V7, U1]; xn---?-6g4k75207c.xn--hmb76q74166b; ; ;  # 퀬-?.ૅ۴
+퀬-?񶳒.xn--hmb76q48y18505a; 퀬-?񶳒.\u200C\u0AC5󩸤۴; [C1, V7, U1]; xn---?-6g4k75207c.xn--hmb76q48y18505a; ; ;  # 퀬-?.ૅ۴
+퀬-?񶳒.xn--hmb76q48y18505a; 퀬-?񶳒.\u200C\u0AC5󩸤۴; [C1, V7, U1]; xn---?-6g4k75207c.xn--hmb76q48y18505a; ; ;  # 퀬-?.ૅ۴
+퀬-?񶳒.XN--HMB76Q48Y18505A; 퀬-?񶳒.\u200C\u0AC5󩸤۴; [C1, V7, U1]; xn---?-6g4k75207c.xn--hmb76q48y18505a; ; ;  # 퀬-?.ૅ۴
+퀬-?񶳒.XN--HMB76Q48Y18505A; 퀬-?񶳒.\u200C\u0AC5󩸤۴; [C1, V7, U1]; xn---?-6g4k75207c.xn--hmb76q48y18505a; ; ;  # 퀬-?.ૅ۴
+퀬-?񶳒.Xn--Hmb76q48y18505a; 퀬-?񶳒.\u200C\u0AC5󩸤۴; [C1, V7, U1]; xn---?-6g4k75207c.xn--hmb76q48y18505a; ; ;  # 퀬-?.ૅ۴
+퀬-?񶳒.Xn--Hmb76q48y18505a; 퀬-?񶳒.\u200C\u0AC5󩸤۴; [C1, V7, U1]; xn---?-6g4k75207c.xn--hmb76q48y18505a; ; ;  # 퀬-?.ૅ۴
+Ⴌ.𐹾︒𑁿𞾄; ⴌ.𐹾︒𑁿𞾄; [B1, V7]; xn--3kj.xn--y86c030a9ob6374b; ; ;  # ⴌ.𐹾︒𑁿
+Ⴌ.𐹾。𑁿𞾄; ⴌ.𐹾.𑁿𞾄; [B1, V6, V7]; xn--3kj.xn--2o0d.xn--q30dg029a; ; ;  # ⴌ.𐹾.𑁿
+ⴌ.𐹾。𑁿𞾄; ⴌ.𐹾.𑁿𞾄; [B1, V6, V7]; xn--3kj.xn--2o0d.xn--q30dg029a; ; ;  # ⴌ.𐹾.𑁿
+xn--3kj.xn--2o0d.xn--q30dg029a; ⴌ.𐹾.𑁿𞾄; [B1, V6, V7]; xn--3kj.xn--2o0d.xn--q30dg029a; ; ;  # ⴌ.𐹾.𑁿
+ⴌ.𐹾︒𑁿𞾄; ; [B1, V7]; xn--3kj.xn--y86c030a9ob6374b; ; ;  # ⴌ.𐹾︒𑁿
+xn--3kj.xn--y86c030a9ob6374b; ⴌ.𐹾︒𑁿𞾄; [B1, V7]; xn--3kj.xn--y86c030a9ob6374b; ; ;  # ⴌ.𐹾︒𑁿
+xn--knd.xn--2o0d.xn--q30dg029a; Ⴌ.𐹾.𑁿𞾄; [B1, V6, V7]; xn--knd.xn--2o0d.xn--q30dg029a; ; ;  # Ⴌ.𐹾.𑁿
+xn--knd.xn--y86c030a9ob6374b; Ⴌ.𐹾︒𑁿𞾄; [B1, V7]; xn--knd.xn--y86c030a9ob6374b; ; ;  # Ⴌ.𐹾︒𑁿
+񧞿╏。𞩕󠁾; 񧞿╏.𞩕󠁾; [B3, B6, V7]; xn--iyh90030d.xn--1m6hs0260c; ; ;  # ╏.
+xn--iyh90030d.xn--1m6hs0260c; 񧞿╏.𞩕󠁾; [B3, B6, V7]; xn--iyh90030d.xn--1m6hs0260c; ; ;  # ╏.
+\u200D┮󠇐．\u0C00\u0C4D\u1734\u200D; \u200D┮.\u0C00\u0C4D\u1734\u200D; [C2, V6]; xn--1ug04r.xn--eoc8m432a40i; ; xn--kxh.xn--eoc8m432a; [V6] # ┮.ఀ్᜴
+\u200D┮󠇐.\u0C00\u0C4D\u1734\u200D; \u200D┮.\u0C00\u0C4D\u1734\u200D; [C2, V6]; xn--1ug04r.xn--eoc8m432a40i; ; xn--kxh.xn--eoc8m432a; [V6] # ┮.ఀ్᜴
+xn--kxh.xn--eoc8m432a; ┮.\u0C00\u0C4D\u1734; [V6]; xn--kxh.xn--eoc8m432a; ; ;  # ┮.ఀ్᜴
+xn--1ug04r.xn--eoc8m432a40i; \u200D┮.\u0C00\u0C4D\u1734\u200D; [C2, V6]; xn--1ug04r.xn--eoc8m432a40i; ; ;  # ┮.ఀ్᜴
+򹚪｡🄂; 򹚪.1,; [V7, U1]; xn--n433d.1,; ; ;  # .1,
+򹚪。1,; 򹚪.1,; [V7, U1]; xn--n433d.1,; ; ;  # .1,
+xn--n433d.1,; 򹚪.1,; [V7, U1]; xn--n433d.1,; ; ;  # .1,
+xn--n433d.xn--v07h; 򹚪.🄂; [V7]; xn--n433d.xn--v07h; ; ;  # .🄂
+𑍨刍.🛦; ; [V6]; xn--rbry728b.xn--y88h; ; ;  # 𑍨刍.🛦
+xn--rbry728b.xn--y88h; 𑍨刍.🛦; [V6]; xn--rbry728b.xn--y88h; ; ;  # 𑍨刍.🛦
+󠌏3｡\u1BF1𝟒; 󠌏3.\u1BF14; [V6, V7]; xn--3-ib31m.xn--4-pql; ; ;  # 3.ᯱ4
+󠌏3。\u1BF14; 󠌏3.\u1BF14; [V6, V7]; xn--3-ib31m.xn--4-pql; ; ;  # 3.ᯱ4
+xn--3-ib31m.xn--4-pql; 󠌏3.\u1BF14; [V6, V7]; xn--3-ib31m.xn--4-pql; ; ;  # 3.ᯱ4
+\u0687６Ⴔ辘.\uFD22\u0687\u200C; \u06876ⴔ辘.\u0635\u064A\u0687\u200C; [B2, B3, C1]; xn--6-gsc2270akm6f.xn--0gb6bxkx18g; ; xn--6-gsc2270akm6f.xn--0gb6bxk; [B2, B3] # ڇ6ⴔ辘.صيڇ
+\u06876Ⴔ辘.\u0635\u064A\u0687\u200C; \u06876ⴔ辘.\u0635\u064A\u0687\u200C; [B2, B3, C1]; xn--6-gsc2270akm6f.xn--0gb6bxkx18g; ; xn--6-gsc2270akm6f.xn--0gb6bxk; [B2, B3] # ڇ6ⴔ辘.صيڇ
+\u06876ⴔ辘.\u0635\u064A\u0687\u200C; ; [B2, B3, C1]; xn--6-gsc2270akm6f.xn--0gb6bxkx18g; ; xn--6-gsc2270akm6f.xn--0gb6bxk; [B2, B3] # ڇ6ⴔ辘.صيڇ
+xn--6-gsc2270akm6f.xn--0gb6bxk; \u06876ⴔ辘.\u0635\u064A\u0687; [B2, B3]; xn--6-gsc2270akm6f.xn--0gb6bxk; ; ;  # ڇ6ⴔ辘.صيڇ
+xn--6-gsc2270akm6f.xn--0gb6bxkx18g; \u06876ⴔ辘.\u0635\u064A\u0687\u200C; [B2, B3, C1]; xn--6-gsc2270akm6f.xn--0gb6bxkx18g; ; ;  # ڇ6ⴔ辘.صيڇ
+\u0687６ⴔ辘.\uFD22\u0687\u200C; \u06876ⴔ辘.\u0635\u064A\u0687\u200C; [B2, B3, C1]; xn--6-gsc2270akm6f.xn--0gb6bxkx18g; ; xn--6-gsc2270akm6f.xn--0gb6bxk; [B2, B3] # ڇ6ⴔ辘.صيڇ
+xn--6-gsc039eqq6k.xn--0gb6bxk; \u06876Ⴔ辘.\u0635\u064A\u0687; [B2, B3, V7]; xn--6-gsc039eqq6k.xn--0gb6bxk; ; ;  # ڇ6Ⴔ辘.صيڇ
+xn--6-gsc039eqq6k.xn--0gb6bxkx18g; \u06876Ⴔ辘.\u0635\u064A\u0687\u200C; [B2, B3, C1, V7]; xn--6-gsc039eqq6k.xn--0gb6bxkx18g; ; ;  # ڇ6Ⴔ辘.صيڇ
+󠄍.𐮭𞰬򻫞۹; .𐮭𞰬򻫞۹; [B2, V7, X4_2]; .xn--mmb3954kd0uf1zx7f; [B2, V7, A4_2]; ;  # .𐮭۹
+.xn--mmb3954kd0uf1zx7f; .𐮭𞰬򻫞۹; [B2, V7, X4_2]; .xn--mmb3954kd0uf1zx7f; [B2, V7, A4_2]; ;  # .𐮭۹
+\uA87D≯．򻲀򒳄; \uA87D≯.򻲀򒳄; [V7]; xn--hdh8193c.xn--5z40cp629b; ; ;  # ≯.
+\uA87D>\u0338．򻲀򒳄; \uA87D≯.򻲀򒳄; [V7]; xn--hdh8193c.xn--5z40cp629b; ; ;  # ≯.
+\uA87D≯.򻲀򒳄; ; [V7]; xn--hdh8193c.xn--5z40cp629b; ; ;  # ≯.
+\uA87D>\u0338.򻲀򒳄; \uA87D≯.򻲀򒳄; [V7]; xn--hdh8193c.xn--5z40cp629b; ; ;  # ≯.
+xn--hdh8193c.xn--5z40cp629b; \uA87D≯.򻲀򒳄; [V7]; xn--hdh8193c.xn--5z40cp629b; ; ;  # ≯.
+ςო\u067B.ς\u0714; ; [B5, B6]; xn--3xa80l26n.xn--3xa41o; ; xn--4xa60l26n.xn--4xa21o;  # ςოٻ.ςܔ
+ΣᲝ\u067B.Σ\u0714; σო\u067B.σ\u0714; [B5, B6]; xn--4xa60l26n.xn--4xa21o; ; ;  # σოٻ.σܔ
+σო\u067B.σ\u0714; ; [B5, B6]; xn--4xa60l26n.xn--4xa21o; ; ;  # σოٻ.σܔ
+Σო\u067B.σ\u0714; σო\u067B.σ\u0714; [B5, B6]; xn--4xa60l26n.xn--4xa21o; ; ;  # σოٻ.σܔ
+xn--4xa60l26n.xn--4xa21o; σო\u067B.σ\u0714; [B5, B6]; xn--4xa60l26n.xn--4xa21o; ; ;  # σოٻ.σܔ
+Σო\u067B.ς\u0714; σო\u067B.ς\u0714; [B5, B6]; xn--4xa60l26n.xn--3xa41o; ; xn--4xa60l26n.xn--4xa21o;  # σოٻ.ςܔ
+σო\u067B.ς\u0714; ; [B5, B6]; xn--4xa60l26n.xn--3xa41o; ; xn--4xa60l26n.xn--4xa21o;  # σოٻ.ςܔ
+xn--4xa60l26n.xn--3xa41o; σო\u067B.ς\u0714; [B5, B6]; xn--4xa60l26n.xn--3xa41o; ; ;  # σოٻ.ςܔ
+xn--3xa80l26n.xn--3xa41o; ςო\u067B.ς\u0714; [B5, B6]; xn--3xa80l26n.xn--3xa41o; ; ;  # ςოٻ.ςܔ
+Σო\u067B.Σ\u0714; σო\u067B.σ\u0714; [B5, B6]; xn--4xa60l26n.xn--4xa21o; ; ;  # σოٻ.σܔ
+򄖚\u0748𠄯\u075F｡󠛩; 򄖚\u0748𠄯\u075F.󠛩; [B1, B5, B6, V7]; xn--vob0c4369twfv8b.xn--kl46e; ; ;  # ݈𠄯ݟ.
+򄖚\u0748𠄯\u075F。󠛩; 򄖚\u0748𠄯\u075F.󠛩; [B1, B5, B6, V7]; xn--vob0c4369twfv8b.xn--kl46e; ; ;  # ݈𠄯ݟ.
+xn--vob0c4369twfv8b.xn--kl46e; 򄖚\u0748𠄯\u075F.󠛩; [B1, B5, B6, V7]; xn--vob0c4369twfv8b.xn--kl46e; ; ;  # ݈𠄯ݟ.
+󠳛．\u200D䤫≠Ⴞ; 󠳛.\u200D䤫≠ⴞ; [C2, V7]; xn--1t56e.xn--1ug73gzzpwi3a; ; xn--1t56e.xn--1ch153bqvw; [V7] # .䤫≠ⴞ
+󠳛．\u200D䤫=\u0338Ⴞ; 󠳛.\u200D䤫≠ⴞ; [C2, V7]; xn--1t56e.xn--1ug73gzzpwi3a; ; xn--1t56e.xn--1ch153bqvw; [V7] # .䤫≠ⴞ
+󠳛.\u200D䤫≠Ⴞ; 󠳛.\u200D䤫≠ⴞ; [C2, V7]; xn--1t56e.xn--1ug73gzzpwi3a; ; xn--1t56e.xn--1ch153bqvw; [V7] # .䤫≠ⴞ
+󠳛.\u200D䤫=\u0338Ⴞ; 󠳛.\u200D䤫≠ⴞ; [C2, V7]; xn--1t56e.xn--1ug73gzzpwi3a; ; xn--1t56e.xn--1ch153bqvw; [V7] # .䤫≠ⴞ
+󠳛.\u200D䤫=\u0338ⴞ; 󠳛.\u200D䤫≠ⴞ; [C2, V7]; xn--1t56e.xn--1ug73gzzpwi3a; ; xn--1t56e.xn--1ch153bqvw; [V7] # .䤫≠ⴞ
+󠳛.\u200D䤫≠ⴞ; ; [C2, V7]; xn--1t56e.xn--1ug73gzzpwi3a; ; xn--1t56e.xn--1ch153bqvw; [V7] # .䤫≠ⴞ
+xn--1t56e.xn--1ch153bqvw; 󠳛.䤫≠ⴞ; [V7]; xn--1t56e.xn--1ch153bqvw; ; ;  # .䤫≠ⴞ
+xn--1t56e.xn--1ug73gzzpwi3a; 󠳛.\u200D䤫≠ⴞ; [C2, V7]; xn--1t56e.xn--1ug73gzzpwi3a; ; ;  # .䤫≠ⴞ
+󠳛．\u200D䤫=\u0338ⴞ; 󠳛.\u200D䤫≠ⴞ; [C2, V7]; xn--1t56e.xn--1ug73gzzpwi3a; ; xn--1t56e.xn--1ch153bqvw; [V7] # .䤫≠ⴞ
+󠳛．\u200D䤫≠ⴞ; 󠳛.\u200D䤫≠ⴞ; [C2, V7]; xn--1t56e.xn--1ug73gzzpwi3a; ; xn--1t56e.xn--1ch153bqvw; [V7] # .䤫≠ⴞ
+xn--1t56e.xn--2nd141ghl2a; 󠳛.䤫≠Ⴞ; [V7]; xn--1t56e.xn--2nd141ghl2a; ; ;  # .䤫≠Ⴞ
+xn--1t56e.xn--2nd159e9vb743e; 󠳛.\u200D䤫≠Ⴞ; [C2, V7]; xn--1t56e.xn--2nd159e9vb743e; ; ;  # .䤫≠Ⴞ
+𐽘𑈵．𐹣🕥; 𐽘𑈵.𐹣🕥; [B1, B2, B3]; xn--bv0d02c.xn--bo0dq650b; ; ;  # 𐽘𑈵.𐹣🕥
+𐽘𑈵.𐹣🕥; ; [B1, B2, B3]; xn--bv0d02c.xn--bo0dq650b; ; ;  # 𐽘𑈵.𐹣🕥
+xn--bv0d02c.xn--bo0dq650b; 𐽘𑈵.𐹣🕥; [B1, B2, B3]; xn--bv0d02c.xn--bo0dq650b; ; ;  # 𐽘𑈵.𐹣🕥
+⒊⒈𑁄。9; ⒊⒈𑁄.9; [V7]; xn--tshd3512p.9; ; ;  # ⒊⒈𑁄.9
+3.1.𑁄。9; 3.1.𑁄.9; [V6]; 3.1.xn--110d.9; ; ;  # 3.1.𑁄.9
+3.1.xn--110d.j; 3.1.𑁄.j; [V6]; 3.1.xn--110d.j; ; ;  # 3.1.𑁄.j
+xn--tshd3512p.j; ⒊⒈𑁄.j; [V7]; xn--tshd3512p.j; ; ;  # ⒊⒈𑁄.j
+-\u200C\u2DF1≮．𐹱򭏴4₉; -\u200C\u2DF1≮.𐹱򭏴49; [B1, C1, V3, V7]; xn----sgn20i14s.xn--49-ki3om2611f; ; xn----ngo823c.xn--49-ki3om2611f; [B1, V3, V7] # -ⷱ≮.𐹱49
+-\u200C\u2DF1<\u0338．𐹱򭏴4₉; -\u200C\u2DF1≮.𐹱򭏴49; [B1, C1, V3, V7]; xn----sgn20i14s.xn--49-ki3om2611f; ; xn----ngo823c.xn--49-ki3om2611f; [B1, V3, V7] # -ⷱ≮.𐹱49
+-\u200C\u2DF1≮.𐹱򭏴49; ; [B1, C1, V3, V7]; xn----sgn20i14s.xn--49-ki3om2611f; ; xn----ngo823c.xn--49-ki3om2611f; [B1, V3, V7] # -ⷱ≮.𐹱49
+-\u200C\u2DF1<\u0338.𐹱򭏴49; -\u200C\u2DF1≮.𐹱򭏴49; [B1, C1, V3, V7]; xn----sgn20i14s.xn--49-ki3om2611f; ; xn----ngo823c.xn--49-ki3om2611f; [B1, V3, V7] # -ⷱ≮.𐹱49
+xn----ngo823c.xn--49-ki3om2611f; -\u2DF1≮.𐹱򭏴49; [B1, V3, V7]; xn----ngo823c.xn--49-ki3om2611f; ; ;  # -ⷱ≮.𐹱49
+xn----sgn20i14s.xn--49-ki3om2611f; -\u200C\u2DF1≮.𐹱򭏴49; [B1, C1, V3, V7]; xn----sgn20i14s.xn--49-ki3om2611f; ; ;  # -ⷱ≮.𐹱49
+-≯딾｡\u0847; -≯딾.\u0847; [B1, V3]; xn----pgow547d.xn--5vb; ; ;  # -≯딾.ࡇ
+->\u0338딾｡\u0847; -≯딾.\u0847; [B1, V3]; xn----pgow547d.xn--5vb; ; ;  # -≯딾.ࡇ
+-≯딾。\u0847; -≯딾.\u0847; [B1, V3]; xn----pgow547d.xn--5vb; ; ;  # -≯딾.ࡇ
+->\u0338딾。\u0847; -≯딾.\u0847; [B1, V3]; xn----pgow547d.xn--5vb; ; ;  # -≯딾.ࡇ
+xn----pgow547d.xn--5vb; -≯딾.\u0847; [B1, V3]; xn----pgow547d.xn--5vb; ; ;  # -≯딾.ࡇ
+𑙢⒈𐹠-｡󠗐\u200C; 𑙢⒈𐹠-.󠗐\u200C; [B1, C1, V3, V7]; xn----dcpy090hiyg.xn--0ug23321l; ; xn----dcpy090hiyg.xn--jd46e; [B1, V3, V7] # 𑙢⒈𐹠-.
+𑙢1.𐹠-。󠗐\u200C; 𑙢1.𐹠-.󠗐\u200C; [B1, C1, V3, V7]; xn--1-bf0j.xn----516i.xn--0ug23321l; ; xn--1-bf0j.xn----516i.xn--jd46e; [B1, V3, V7] # 𑙢1.𐹠-.
+xn--1-bf0j.xn----516i.xn--jd46e; 𑙢1.𐹠-.󠗐; [B1, V3, V7]; xn--1-bf0j.xn----516i.xn--jd46e; ; ;  # 𑙢1.𐹠-.
+xn--1-bf0j.xn----516i.xn--0ug23321l; 𑙢1.𐹠-.󠗐\u200C; [B1, C1, V3, V7]; xn--1-bf0j.xn----516i.xn--0ug23321l; ; ;  # 𑙢1.𐹠-.
+xn----dcpy090hiyg.xn--jd46e; 𑙢⒈𐹠-.󠗐; [B1, V3, V7]; xn----dcpy090hiyg.xn--jd46e; ; ;  # 𑙢⒈𐹠-.
+xn----dcpy090hiyg.xn--0ug23321l; 𑙢⒈𐹠-.󠗐\u200C; [B1, C1, V3, V7]; xn----dcpy090hiyg.xn--0ug23321l; ; ;  # 𑙢⒈𐹠-.
+\u034A．𐨎; \u034A.𐨎; [V6]; xn--oua.xn--mr9c; ; ;  # ͊.𐨎
+\u034A.𐨎; ; [V6]; xn--oua.xn--mr9c; ; ;  # ͊.𐨎
+xn--oua.xn--mr9c; \u034A.𐨎; [V6]; xn--oua.xn--mr9c; ; ;  # ͊.𐨎
+훉≮｡\u0E34; 훉≮.\u0E34; [V6]; xn--gdh2512e.xn--i4c; ; ;  # 훉≮.ิ
+훉<\u0338｡\u0E34; 훉≮.\u0E34; [V6]; xn--gdh2512e.xn--i4c; ; ;  # 훉≮.ิ
+훉≮。\u0E34; 훉≮.\u0E34; [V6]; xn--gdh2512e.xn--i4c; ; ;  # 훉≮.ิ
+훉<\u0338。\u0E34; 훉≮.\u0E34; [V6]; xn--gdh2512e.xn--i4c; ; ;  # 훉≮.ิ
+xn--gdh2512e.xn--i4c; 훉≮.\u0E34; [V6]; xn--gdh2512e.xn--i4c; ; ;  # 훉≮.ิ
+\u2DF7򞣉🃘．𴈇𝟸\u0659𞤯; \u2DF7򞣉🃘.𴈇2\u0659𞤯; [B1, B5, B6, V6, V7]; xn--trj8045le6s9b.xn--2-upc23918acjsj; ; ;  # ⷷ🃘.2ٙ𞤯
+\u2DF7򞣉🃘.𴈇2\u0659𞤯; ; [B1, B5, B6, V6, V7]; xn--trj8045le6s9b.xn--2-upc23918acjsj; ; ;  # ⷷ🃘.2ٙ𞤯
+\u2DF7򞣉🃘.𴈇2\u0659𞤍; \u2DF7򞣉🃘.𴈇2\u0659𞤯; [B1, B5, B6, V6, V7]; xn--trj8045le6s9b.xn--2-upc23918acjsj; ; ;  # ⷷ🃘.2ٙ𞤯
+xn--trj8045le6s9b.xn--2-upc23918acjsj; \u2DF7򞣉🃘.𴈇2\u0659𞤯; [B1, B5, B6, V6, V7]; xn--trj8045le6s9b.xn--2-upc23918acjsj; ; ;  # ⷷ🃘.2ٙ𞤯
+\u2DF7򞣉🃘．𴈇𝟸\u0659𞤍; \u2DF7򞣉🃘.𴈇2\u0659𞤯; [B1, B5, B6, V6, V7]; xn--trj8045le6s9b.xn--2-upc23918acjsj; ; ;  # ⷷ🃘.2ٙ𞤯
+󗇩ßᢞ\u200C。\u0660𞷻\uFCD4-; 󗇩ßᢞ\u200C.\u0660𞷻\u0646\u062E-; [B1, B6, C1, V3, V7]; xn--zca272jbif10059a.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, V3, V7] # ßᢞ.٠نخ-
+󗇩ßᢞ\u200C。\u0660𞷻\u0646\u062E-; 󗇩ßᢞ\u200C.\u0660𞷻\u0646\u062E-; [B1, B6, C1, V3, V7]; xn--zca272jbif10059a.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, V3, V7] # ßᢞ.٠نخ-
+󗇩SSᢞ\u200C。\u0660𞷻\u0646\u062E-; 󗇩ssᢞ\u200C.\u0660𞷻\u0646\u062E-; [B1, B6, C1, V3, V7]; xn--ss-jep006bqt765b.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, V3, V7] # ssᢞ.٠نخ-
+󗇩ssᢞ\u200C。\u0660𞷻\u0646\u062E-; 󗇩ssᢞ\u200C.\u0660𞷻\u0646\u062E-; [B1, B6, C1, V3, V7]; xn--ss-jep006bqt765b.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, V3, V7] # ssᢞ.٠نخ-
+󗇩Ssᢞ\u200C。\u0660𞷻\u0646\u062E-; 󗇩ssᢞ\u200C.\u0660𞷻\u0646\u062E-; [B1, B6, C1, V3, V7]; xn--ss-jep006bqt765b.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, V3, V7] # ssᢞ.٠نخ-
+xn--ss-jepz4596r.xn----dnc5e1er384z; 󗇩ssᢞ.\u0660𞷻\u0646\u062E-; [B1, V3, V7]; xn--ss-jepz4596r.xn----dnc5e1er384z; ; ;  # ssᢞ.٠نخ-
+xn--ss-jep006bqt765b.xn----dnc5e1er384z; 󗇩ssᢞ\u200C.\u0660𞷻\u0646\u062E-; [B1, B6, C1, V3, V7]; xn--ss-jep006bqt765b.xn----dnc5e1er384z; ; ;  # ssᢞ.٠نخ-
+xn--zca272jbif10059a.xn----dnc5e1er384z; 󗇩ßᢞ\u200C.\u0660𞷻\u0646\u062E-; [B1, B6, C1, V3, V7]; xn--zca272jbif10059a.xn----dnc5e1er384z; ; ;  # ßᢞ.٠نخ-
+󗇩SSᢞ\u200C。\u0660𞷻\uFCD4-; 󗇩ssᢞ\u200C.\u0660𞷻\u0646\u062E-; [B1, B6, C1, V3, V7]; xn--ss-jep006bqt765b.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, V3, V7] # ssᢞ.٠نخ-
+󗇩ssᢞ\u200C。\u0660𞷻\uFCD4-; 󗇩ssᢞ\u200C.\u0660𞷻\u0646\u062E-; [B1, B6, C1, V3, V7]; xn--ss-jep006bqt765b.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, V3, V7] # ssᢞ.٠نخ-
+󗇩Ssᢞ\u200C。\u0660𞷻\uFCD4-; 󗇩ssᢞ\u200C.\u0660𞷻\u0646\u062E-; [B1, B6, C1, V3, V7]; xn--ss-jep006bqt765b.xn----dnc5e1er384z; ; xn--ss-jepz4596r.xn----dnc5e1er384z; [B1, V3, V7] # ssᢞ.٠نخ-
+ꡆ。Ↄ\u0FB5놮-; ꡆ.ↄ\u0FB5놮-; [V3]; xn--fc9a.xn----qmg097k469k; ; ;  # ꡆ.ↄྵ놮-
+ꡆ。Ↄ\u0FB5놮-; ꡆ.ↄ\u0FB5놮-; [V3]; xn--fc9a.xn----qmg097k469k; ; ;  # ꡆ.ↄྵ놮-
+ꡆ。ↄ\u0FB5놮-; ꡆ.ↄ\u0FB5놮-; [V3]; xn--fc9a.xn----qmg097k469k; ; ;  # ꡆ.ↄྵ놮-
+ꡆ。ↄ\u0FB5놮-; ꡆ.ↄ\u0FB5놮-; [V3]; xn--fc9a.xn----qmg097k469k; ; ;  # ꡆ.ↄྵ놮-
+xn--fc9a.xn----qmg097k469k; ꡆ.ↄ\u0FB5놮-; [V3]; xn--fc9a.xn----qmg097k469k; ; ;  # ꡆ.ↄྵ놮-
+xn--fc9a.xn----qmg787k869k; ꡆ.Ↄ\u0FB5놮-; [V3, V7]; xn--fc9a.xn----qmg787k869k; ; ;  # ꡆ.Ↄྵ놮-
+\uFDAD\u200D.񥰌\u06A9; \u0644\u0645\u064A\u200D.񥰌\u06A9; [B3, B5, B6, C2, V7]; xn--ghbcp494x.xn--ckb36214f; ; xn--ghbcp.xn--ckb36214f; [B5, B6, V7] # لمي.ک
+\u0644\u0645\u064A\u200D.񥰌\u06A9; ; [B3, B5, B6, C2, V7]; xn--ghbcp494x.xn--ckb36214f; ; xn--ghbcp.xn--ckb36214f; [B5, B6, V7] # لمي.ک
+xn--ghbcp.xn--ckb36214f; \u0644\u0645\u064A.񥰌\u06A9; [B5, B6, V7]; xn--ghbcp.xn--ckb36214f; ; ;  # لمي.ک
+xn--ghbcp494x.xn--ckb36214f; \u0644\u0645\u064A\u200D.񥰌\u06A9; [B3, B5, B6, C2, V7]; xn--ghbcp494x.xn--ckb36214f; ; ;  # لمي.ک
+Ⴜ\u1C2F𐳒≯。\u06E0\u1732\u0FBA; ⴜ\u1C2F𐳒≯.\u06E0\u1732\u0FBA; [B1, B5, B6, V6]; xn--r1f68xh1jgv7u.xn--wlb646b4ng; ; ;  # ⴜᰯ𐳒≯.۠ᜲྺ
+Ⴜ\u1C2F𐳒>\u0338。\u06E0\u1732\u0FBA; ⴜ\u1C2F𐳒≯.\u06E0\u1732\u0FBA; [B1, B5, B6, V6]; xn--r1f68xh1jgv7u.xn--wlb646b4ng; ; ;  # ⴜᰯ𐳒≯.۠ᜲྺ
+ⴜ\u1C2F𐳒>\u0338。\u06E0\u1732\u0FBA; ⴜ\u1C2F𐳒≯.\u06E0\u1732\u0FBA; [B1, B5, B6, V6]; xn--r1f68xh1jgv7u.xn--wlb646b4ng; ; ;  # ⴜᰯ𐳒≯.۠ᜲྺ
+ⴜ\u1C2F𐳒≯。\u06E0\u1732\u0FBA; ⴜ\u1C2F𐳒≯.\u06E0\u1732\u0FBA; [B1, B5, B6, V6]; xn--r1f68xh1jgv7u.xn--wlb646b4ng; ; ;  # ⴜᰯ𐳒≯.۠ᜲྺ
+Ⴜ\u1C2F𐲒≯。\u06E0\u1732\u0FBA; ⴜ\u1C2F𐳒≯.\u06E0\u1732\u0FBA; [B1, B5, B6, V6]; xn--r1f68xh1jgv7u.xn--wlb646b4ng; ; ;  # ⴜᰯ𐳒≯.۠ᜲྺ
+Ⴜ\u1C2F𐲒>\u0338。\u06E0\u1732\u0FBA; ⴜ\u1C2F𐳒≯.\u06E0\u1732\u0FBA; [B1, B5, B6, V6]; xn--r1f68xh1jgv7u.xn--wlb646b4ng; ; ;  # ⴜᰯ𐳒≯.۠ᜲྺ
+xn--r1f68xh1jgv7u.xn--wlb646b4ng; ⴜ\u1C2F𐳒≯.\u06E0\u1732\u0FBA; [B1, B5, B6, V6]; xn--r1f68xh1jgv7u.xn--wlb646b4ng; ; ;  # ⴜᰯ𐳒≯.۠ᜲྺ
+xn--0nd679cf3eq67y.xn--wlb646b4ng; Ⴜ\u1C2F𐳒≯.\u06E0\u1732\u0FBA; [B1, B5, B6, V6, V7]; xn--0nd679cf3eq67y.xn--wlb646b4ng; ; ;  # Ⴜᰯ𐳒≯.۠ᜲྺ
+𐋵。\uFCEC; 𐋵.\u0643\u0645; [B1]; xn--p97c.xn--fhbe; ; ;  # 𐋵.كم
+𐋵。\u0643\u0645; 𐋵.\u0643\u0645; [B1]; xn--p97c.xn--fhbe; ; ;  # 𐋵.كم
+xn--p97c.xn--fhbe; 𐋵.\u0643\u0645; [B1]; xn--p97c.xn--fhbe; ; ;  # 𐋵.كم
+𐋵.\u0643\u0645; ; [B1]; xn--p97c.xn--fhbe; ; ;  # 𐋵.كم
+≮𝅶．񱲁\uAAEC⹈󰥭; ≮.񱲁\uAAEC⹈󰥭; [V7]; xn--gdh.xn--4tjx101bsg00ds9pyc; ; ;  # ≮.ꫬ⹈
+<\u0338𝅶．񱲁\uAAEC⹈󰥭; ≮.񱲁\uAAEC⹈󰥭; [V7]; xn--gdh.xn--4tjx101bsg00ds9pyc; ; ;  # ≮.ꫬ⹈
+≮𝅶.񱲁\uAAEC⹈󰥭; ≮.񱲁\uAAEC⹈󰥭; [V7]; xn--gdh.xn--4tjx101bsg00ds9pyc; ; ;  # ≮.ꫬ⹈
+<\u0338𝅶.񱲁\uAAEC⹈󰥭; ≮.񱲁\uAAEC⹈󰥭; [V7]; xn--gdh.xn--4tjx101bsg00ds9pyc; ; ;  # ≮.ꫬ⹈
+xn--gdh.xn--4tjx101bsg00ds9pyc; ≮.񱲁\uAAEC⹈󰥭; [V7]; xn--gdh.xn--4tjx101bsg00ds9pyc; ; ;  # ≮.ꫬ⹈
+xn--gdh0880o.xn--4tjx101bsg00ds9pyc; ≮𝅶.񱲁\uAAEC⹈󰥭; [V7]; xn--gdh0880o.xn--4tjx101bsg00ds9pyc; ; ;  # ≮.ꫬ⹈
+\u2DF0\u0358ᢕ．\u0361𐹷󠴍; \u2DF0\u0358ᢕ.\u0361𐹷󠴍; [B1, V6, V7]; xn--2ua889htsp.xn--cva2687k2tv0g; ; ;  # ⷰ͘ᢕ.͡𐹷
+\u2DF0\u0358ᢕ.\u0361𐹷󠴍; ; [B1, V6, V7]; xn--2ua889htsp.xn--cva2687k2tv0g; ; ;  # ⷰ͘ᢕ.͡𐹷
+xn--2ua889htsp.xn--cva2687k2tv0g; \u2DF0\u0358ᢕ.\u0361𐹷󠴍; [B1, V6, V7]; xn--2ua889htsp.xn--cva2687k2tv0g; ; ;  # ⷰ͘ᢕ.͡𐹷
+\uFD79ᡐ\u200C\u06AD．𑋪\u05C7; \u063A\u0645\u0645ᡐ\u200C\u06AD.𑋪\u05C7; [B1, B2, V6]; xn--5gbwa03bg24eptk.xn--vdb1198k; ; xn--5gbwa03bg24e.xn--vdb1198k;  # غممᡐڭ.𑋪ׇ
+\u063A\u0645\u0645ᡐ\u200C\u06AD.𑋪\u05C7; ; [B1, B2, V6]; xn--5gbwa03bg24eptk.xn--vdb1198k; ; xn--5gbwa03bg24e.xn--vdb1198k;  # غممᡐڭ.𑋪ׇ
+xn--5gbwa03bg24e.xn--vdb1198k; \u063A\u0645\u0645ᡐ\u06AD.𑋪\u05C7; [B1, B2, V6]; xn--5gbwa03bg24e.xn--vdb1198k; ; ;  # غممᡐڭ.𑋪ׇ
+xn--5gbwa03bg24eptk.xn--vdb1198k; \u063A\u0645\u0645ᡐ\u200C\u06AD.𑋪\u05C7; [B1, B2, V6]; xn--5gbwa03bg24eptk.xn--vdb1198k; ; ;  # غممᡐڭ.𑋪ׇ
+𑑂｡\u200D󥞀🞕򥁔; 𑑂.\u200D󥞀🞕򥁔; [C2, V6, V7]; xn--8v1d.xn--1ug1386plvx1cd8vya; ; xn--8v1d.xn--ye9h41035a2qqs; [V6, V7] # 𑑂.🞕
+𑑂。\u200D󥞀🞕򥁔; 𑑂.\u200D󥞀🞕򥁔; [C2, V6, V7]; xn--8v1d.xn--1ug1386plvx1cd8vya; ; xn--8v1d.xn--ye9h41035a2qqs; [V6, V7] # 𑑂.🞕
+xn--8v1d.xn--ye9h41035a2qqs; 𑑂.󥞀🞕򥁔; [V6, V7]; xn--8v1d.xn--ye9h41035a2qqs; ; ;  # 𑑂.🞕
+xn--8v1d.xn--1ug1386plvx1cd8vya; 𑑂.\u200D󥞀🞕򥁔; [C2, V6, V7]; xn--8v1d.xn--1ug1386plvx1cd8vya; ; ;  # 𑑂.🞕
+-\u05E9。⒚; -\u05E9.⒚; [B1, V3, V7]; xn----gjc.xn--cth; ; ;  # -ש.⒚
+-\u05E9。19.; -\u05E9.19.; [B1, V3]; xn----gjc.19.; [B1, V3, A4_2]; ;  # -ש.19.
+xn----gjc.1j.; -\u05E9.1j.; [B1, V3]; xn----gjc.1j.; [B1, V3, A4_2]; ;  # -ש.1j.
+xn----gjc.xn--cth; -\u05E9.⒚; [B1, V3, V7]; xn----gjc.xn--cth; ; ;  # -ש.⒚
+􊾻\u0845\u200C｡ᢎ\u200D; 􊾻\u0845\u200C.ᢎ\u200D; [B5, B6, C1, C2, V7]; xn--3vb882jz4411a.xn--79e259a; ; xn--3vb50049s.xn--79e; [B5, B6, V7] # ࡅ.ᢎ
+􊾻\u0845\u200C。ᢎ\u200D; 􊾻\u0845\u200C.ᢎ\u200D; [B5, B6, C1, C2, V7]; xn--3vb882jz4411a.xn--79e259a; ; xn--3vb50049s.xn--79e; [B5, B6, V7] # ࡅ.ᢎ
+xn--3vb50049s.xn--79e; 􊾻\u0845.ᢎ; [B5, B6, V7]; xn--3vb50049s.xn--79e; ; ;  # ࡅ.ᢎ
+xn--3vb882jz4411a.xn--79e259a; 􊾻\u0845\u200C.ᢎ\u200D; [B5, B6, C1, C2, V7]; xn--3vb882jz4411a.xn--79e259a; ; ;  # ࡅ.ᢎ
+ß\u09C1\u1DED。\u06208₅; ß\u09C1\u1DED.\u062085; ; xn--zca266bwrr.xn--85-psd; ; xn--ss-e2f077r.xn--85-psd;  # ßুᷭ.ؠ85
+ß\u09C1\u1DED。\u062085; ß\u09C1\u1DED.\u062085; ; xn--zca266bwrr.xn--85-psd; ; xn--ss-e2f077r.xn--85-psd;  # ßুᷭ.ؠ85
+SS\u09C1\u1DED。\u062085; ss\u09C1\u1DED.\u062085; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+ss\u09C1\u1DED。\u062085; ss\u09C1\u1DED.\u062085; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+Ss\u09C1\u1DED。\u062085; ss\u09C1\u1DED.\u062085; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+xn--ss-e2f077r.xn--85-psd; ss\u09C1\u1DED.\u062085; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+ss\u09C1\u1DED.\u062085; ; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+SS\u09C1\u1DED.\u062085; ss\u09C1\u1DED.\u062085; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+Ss\u09C1\u1DED.\u062085; ss\u09C1\u1DED.\u062085; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+xn--zca266bwrr.xn--85-psd; ß\u09C1\u1DED.\u062085; ; xn--zca266bwrr.xn--85-psd; ; ;  # ßুᷭ.ؠ85
+ß\u09C1\u1DED.\u062085; ; ; xn--zca266bwrr.xn--85-psd; ; xn--ss-e2f077r.xn--85-psd;  # ßুᷭ.ؠ85
+SS\u09C1\u1DED。\u06208₅; ss\u09C1\u1DED.\u062085; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+ss\u09C1\u1DED。\u06208₅; ss\u09C1\u1DED.\u062085; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+Ss\u09C1\u1DED。\u06208₅; ss\u09C1\u1DED.\u062085; ; xn--ss-e2f077r.xn--85-psd; ; ;  # ssুᷭ.ؠ85
+\u0ACD\u0484魅𝟣．₃𐹥ß; \u0ACD\u0484魅1.3𐹥ß; [B1, V6]; xn--1-0xb049b102o.xn--3-qfa7018r; ; xn--1-0xb049b102o.xn--3ss-nv9t;  # ્҄魅1.3𐹥ß
+\u0ACD\u0484魅1.3𐹥ß; ; [B1, V6]; xn--1-0xb049b102o.xn--3-qfa7018r; ; xn--1-0xb049b102o.xn--3ss-nv9t;  # ્҄魅1.3𐹥ß
+\u0ACD\u0484魅1.3𐹥SS; \u0ACD\u0484魅1.3𐹥ss; [B1, V6]; xn--1-0xb049b102o.xn--3ss-nv9t; ; ;  # ્҄魅1.3𐹥ss
+\u0ACD\u0484魅1.3𐹥ss; ; [B1, V6]; xn--1-0xb049b102o.xn--3ss-nv9t; ; ;  # ્҄魅1.3𐹥ss
+\u0ACD\u0484魅1.3𐹥Ss; \u0ACD\u0484魅1.3𐹥ss; [B1, V6]; xn--1-0xb049b102o.xn--3ss-nv9t; ; ;  # ્҄魅1.3𐹥ss
+xn--1-0xb049b102o.xn--3ss-nv9t; \u0ACD\u0484魅1.3𐹥ss; [B1, V6]; xn--1-0xb049b102o.xn--3ss-nv9t; ; ;  # ્҄魅1.3𐹥ss
+xn--1-0xb049b102o.xn--3-qfa7018r; \u0ACD\u0484魅1.3𐹥ß; [B1, V6]; xn--1-0xb049b102o.xn--3-qfa7018r; ; ;  # ્҄魅1.3𐹥ß
+\u0ACD\u0484魅𝟣．₃𐹥SS; \u0ACD\u0484魅1.3𐹥ss; [B1, V6]; xn--1-0xb049b102o.xn--3ss-nv9t; ; ;  # ્҄魅1.3𐹥ss
+\u0ACD\u0484魅𝟣．₃𐹥ss; \u0ACD\u0484魅1.3𐹥ss; [B1, V6]; xn--1-0xb049b102o.xn--3ss-nv9t; ; ;  # ્҄魅1.3𐹥ss
+\u0ACD\u0484魅𝟣．₃𐹥Ss; \u0ACD\u0484魅1.3𐹥ss; [B1, V6]; xn--1-0xb049b102o.xn--3ss-nv9t; ; ;  # ્҄魅1.3𐹥ss
+\u072B｡𑓂⒈𑜫󠿻; \u072B.𑓂⒈𑜫󠿻; [B1, V6, V7]; xn--1nb.xn--tsh7798f6rbrt828c; ; ;  # ܫ.𑓂⒈𑜫
+\u072B。𑓂1.𑜫󠿻; \u072B.𑓂1.𑜫󠿻; [B1, V6, V7]; xn--1nb.xn--1-jq9i.xn--ji2dg9877c; ; ;  # ܫ.𑓂1.𑜫
+xn--1nb.xn--1-jq9i.xn--ji2dg9877c; \u072B.𑓂1.𑜫󠿻; [B1, V6, V7]; xn--1nb.xn--1-jq9i.xn--ji2dg9877c; ; ;  # ܫ.𑓂1.𑜫
+xn--1nb.xn--tsh7798f6rbrt828c; \u072B.𑓂⒈𑜫󠿻; [B1, V6, V7]; xn--1nb.xn--tsh7798f6rbrt828c; ; ;  # ܫ.𑓂⒈𑜫
+\uFE0Dછ。嵨; છ.嵨; ; xn--6dc.xn--tot; ; ;  # છ.嵨
+xn--6dc.xn--tot; છ.嵨; ; xn--6dc.xn--tot; ; ;  # છ.嵨
+છ.嵨; ; ; xn--6dc.xn--tot; ; ;  # છ.嵨
+Ⴔ≠Ⴀ.𐹥𐹰; ⴔ≠ⴀ.𐹥𐹰; [B1]; xn--1ch603bxb.xn--do0dwa; ; ;  # ⴔ≠ⴀ.𐹥𐹰
+Ⴔ=\u0338Ⴀ.𐹥𐹰; ⴔ≠ⴀ.𐹥𐹰; [B1]; xn--1ch603bxb.xn--do0dwa; ; ;  # ⴔ≠ⴀ.𐹥𐹰
+ⴔ=\u0338ⴀ.𐹥𐹰; ⴔ≠ⴀ.𐹥𐹰; [B1]; xn--1ch603bxb.xn--do0dwa; ; ;  # ⴔ≠ⴀ.𐹥𐹰
+ⴔ≠ⴀ.𐹥𐹰; ; [B1]; xn--1ch603bxb.xn--do0dwa; ; ;  # ⴔ≠ⴀ.𐹥𐹰
+xn--1ch603bxb.xn--do0dwa; ⴔ≠ⴀ.𐹥𐹰; [B1]; xn--1ch603bxb.xn--do0dwa; ; ;  # ⴔ≠ⴀ.𐹥𐹰
+xn--7md3b171g.xn--do0dwa; Ⴔ≠Ⴀ.𐹥𐹰; [B1, V7]; xn--7md3b171g.xn--do0dwa; ; ;  # Ⴔ≠Ⴀ.𐹥𐹰
+-\u200C⒙𐫥｡𝨵; -\u200C⒙𐫥.𝨵; [C1, V3, V6, V7]; xn----sgn18r3191a.xn--382h; ; xn----ddps939g.xn--382h; [V3, V6, V7] # -⒙𐫥.𝨵
+-\u200C18.𐫥。𝨵; -\u200C18.𐫥.𝨵; [C1, V3, V6]; xn---18-9m0a.xn--rx9c.xn--382h; ; -18.xn--rx9c.xn--382h; [V3, V6] # -18.𐫥.𝨵
+-18.xn--rx9c.xn--382h; -18.𐫥.𝨵; [V3, V6]; -18.xn--rx9c.xn--382h; ; ;  # -18.𐫥.𝨵
+xn---18-9m0a.xn--rx9c.xn--382h; -\u200C18.𐫥.𝨵; [C1, V3, V6]; xn---18-9m0a.xn--rx9c.xn--382h; ; ;  # -18.𐫥.𝨵
+xn----ddps939g.xn--382h; -⒙𐫥.𝨵; [V3, V6, V7]; xn----ddps939g.xn--382h; ; ;  # -⒙𐫥.𝨵
+xn----sgn18r3191a.xn--382h; -\u200C⒙𐫥.𝨵; [C1, V3, V6, V7]; xn----sgn18r3191a.xn--382h; ; ;  # -⒙𐫥.𝨵
+︒.ʌᠣ-𐹽; ; [B1, B5, B6, V7]; xn--y86c.xn----73a596nuh9t; ; ;  # ︒.ʌᠣ-𐹽
+。.ʌᠣ-𐹽; ..ʌᠣ-𐹽; [B5, B6, X4_2]; ..xn----73a596nuh9t; [B5, B6, A4_2]; ;  # ..ʌᠣ-𐹽
+。.Ʌᠣ-𐹽; ..ʌᠣ-𐹽; [B5, B6, X4_2]; ..xn----73a596nuh9t; [B5, B6, A4_2]; ;  # ..ʌᠣ-𐹽
+..xn----73a596nuh9t; ..ʌᠣ-𐹽; [B5, B6, X4_2]; ..xn----73a596nuh9t; [B5, B6, A4_2]; ;  # ..ʌᠣ-𐹽
+︒.Ʌᠣ-𐹽; ︒.ʌᠣ-𐹽; [B1, B5, B6, V7]; xn--y86c.xn----73a596nuh9t; ; ;  # ︒.ʌᠣ-𐹽
+xn--y86c.xn----73a596nuh9t; ︒.ʌᠣ-𐹽; [B1, B5, B6, V7]; xn--y86c.xn----73a596nuh9t; ; ;  # ︒.ʌᠣ-𐹽
+\uFE05︒。𦀾\u1CE0; ︒.𦀾\u1CE0; [V7]; xn--y86c.xn--t6f5138v; ; ;  # ︒.𦀾᳠
+\uFE05。。𦀾\u1CE0; ..𦀾\u1CE0; [X4_2]; ..xn--t6f5138v; [A4_2]; ;  # ..𦀾᳠
+..xn--t6f5138v; ..𦀾\u1CE0; [X4_2]; ..xn--t6f5138v; [A4_2]; ;  # ..𦀾᳠
+xn--y86c.xn--t6f5138v; ︒.𦀾\u1CE0; [V7]; xn--y86c.xn--t6f5138v; ; ;  # ︒.𦀾᳠
+xn--t6f5138v; 𦀾\u1CE0; ; xn--t6f5138v; ; ;  # 𦀾᳠
+𦀾\u1CE0; ; ; xn--t6f5138v; ; ;  # 𦀾᳠
+𞮑ß􏞞。ᡁ; 𞮑ß􏞞.ᡁ; [B2, B3, V7]; xn--zca9432wb989f.xn--07e; ; xn--ss-o412ac6305g.xn--07e;  # ß.ᡁ
+𞮑SS􏞞。ᡁ; 𞮑ss􏞞.ᡁ; [B2, B3, V7]; xn--ss-o412ac6305g.xn--07e; ; ;  # ss.ᡁ
+𞮑ss􏞞。ᡁ; 𞮑ss􏞞.ᡁ; [B2, B3, V7]; xn--ss-o412ac6305g.xn--07e; ; ;  # ss.ᡁ
+𞮑Ss􏞞。ᡁ; 𞮑ss􏞞.ᡁ; [B2, B3, V7]; xn--ss-o412ac6305g.xn--07e; ; ;  # ss.ᡁ
+xn--ss-o412ac6305g.xn--07e; 𞮑ss􏞞.ᡁ; [B2, B3, V7]; xn--ss-o412ac6305g.xn--07e; ; ;  # ss.ᡁ
+xn--zca9432wb989f.xn--07e; 𞮑ß􏞞.ᡁ; [B2, B3, V7]; xn--zca9432wb989f.xn--07e; ; ;  # ß.ᡁ
+\uA953\u200D\u062C\u066C。𱆎󻡟\u200C󠅆; \uA953\u200D\u062C\u066C.𱆎󻡟\u200C; [B5, B6, C1, V6, V7]; xn--rgb2k500fhq9j.xn--0ug78870a5sp9d; ; xn--rgb2k6711c.xn--ec8nj3948b; [B5, B6, V6, V7] # ꥓ج٬.𱆎
+xn--rgb2k6711c.xn--ec8nj3948b; \uA953\u062C\u066C.𱆎󻡟; [B5, B6, V6, V7]; xn--rgb2k6711c.xn--ec8nj3948b; ; ;  # ꥓ج٬.𱆎
+xn--rgb2k500fhq9j.xn--0ug78870a5sp9d; \uA953\u200D\u062C\u066C.𱆎󻡟\u200C; [B5, B6, C1, V6, V7]; xn--rgb2k500fhq9j.xn--0ug78870a5sp9d; ; ;  # ꥓ج٬.𱆎
+󠕏．-ß\u200C≠; 󠕏.-ß\u200C≠; [C1, V3, V7]; xn--u836e.xn----qfa750ve7b; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ß≠
+󠕏．-ß\u200C=\u0338; 󠕏.-ß\u200C≠; [C1, V3, V7]; xn--u836e.xn----qfa750ve7b; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ß≠
+󠕏.-ß\u200C≠; ; [C1, V3, V7]; xn--u836e.xn----qfa750ve7b; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ß≠
+󠕏.-ß\u200C=\u0338; 󠕏.-ß\u200C≠; [C1, V3, V7]; xn--u836e.xn----qfa750ve7b; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ß≠
+󠕏.-SS\u200C=\u0338; 󠕏.-ss\u200C≠; [C1, V3, V7]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ss≠
+󠕏.-SS\u200C≠; 󠕏.-ss\u200C≠; [C1, V3, V7]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ss≠
+󠕏.-ss\u200C≠; ; [C1, V3, V7]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ss≠
+󠕏.-ss\u200C=\u0338; 󠕏.-ss\u200C≠; [C1, V3, V7]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ss≠
+󠕏.-Ss\u200C=\u0338; 󠕏.-ss\u200C≠; [C1, V3, V7]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ss≠
+󠕏.-Ss\u200C≠; 󠕏.-ss\u200C≠; [C1, V3, V7]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ss≠
+xn--u836e.xn---ss-gl2a; 󠕏.-ss≠; [V3, V7]; xn--u836e.xn---ss-gl2a; ; ;  # .-ss≠
+xn--u836e.xn---ss-cn0at5l; 󠕏.-ss\u200C≠; [C1, V3, V7]; xn--u836e.xn---ss-cn0at5l; ; ;  # .-ss≠
+xn--u836e.xn----qfa750ve7b; 󠕏.-ß\u200C≠; [C1, V3, V7]; xn--u836e.xn----qfa750ve7b; ; ;  # .-ß≠
+󠕏．-SS\u200C=\u0338; 󠕏.-ss\u200C≠; [C1, V3, V7]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ss≠
+󠕏．-SS\u200C≠; 󠕏.-ss\u200C≠; [C1, V3, V7]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ss≠
+󠕏．-ss\u200C≠; 󠕏.-ss\u200C≠; [C1, V3, V7]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ss≠
+󠕏．-ss\u200C=\u0338; 󠕏.-ss\u200C≠; [C1, V3, V7]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ss≠
+󠕏．-Ss\u200C=\u0338; 󠕏.-ss\u200C≠; [C1, V3, V7]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ss≠
+󠕏．-Ss\u200C≠; 󠕏.-ss\u200C≠; [C1, V3, V7]; xn--u836e.xn---ss-cn0at5l; ; xn--u836e.xn---ss-gl2a; [V3, V7] # .-ss≠
+ᡙ\u200C｡≯𐋲≠; ᡙ\u200C.≯𐋲≠; [C1]; xn--p8e650b.xn--1ch3a7084l; ; xn--p8e.xn--1ch3a7084l; [] # ᡙ.≯𐋲≠
+ᡙ\u200C｡>\u0338𐋲=\u0338; ᡙ\u200C.≯𐋲≠; [C1]; xn--p8e650b.xn--1ch3a7084l; ; xn--p8e.xn--1ch3a7084l; [] # ᡙ.≯𐋲≠
+ᡙ\u200C。≯𐋲≠; ᡙ\u200C.≯𐋲≠; [C1]; xn--p8e650b.xn--1ch3a7084l; ; xn--p8e.xn--1ch3a7084l; [] # ᡙ.≯𐋲≠
+ᡙ\u200C。>\u0338𐋲=\u0338; ᡙ\u200C.≯𐋲≠; [C1]; xn--p8e650b.xn--1ch3a7084l; ; xn--p8e.xn--1ch3a7084l; [] # ᡙ.≯𐋲≠
+xn--p8e.xn--1ch3a7084l; ᡙ.≯𐋲≠; ; xn--p8e.xn--1ch3a7084l; ; ;  # ᡙ.≯𐋲≠
+ᡙ.≯𐋲≠; ; ; xn--p8e.xn--1ch3a7084l; ; ;  # ᡙ.≯𐋲≠
+ᡙ.>\u0338𐋲=\u0338; ᡙ.≯𐋲≠; ; xn--p8e.xn--1ch3a7084l; ; ;  # ᡙ.≯𐋲≠
+xn--p8e650b.xn--1ch3a7084l; ᡙ\u200C.≯𐋲≠; [C1]; xn--p8e650b.xn--1ch3a7084l; ; ;  # ᡙ.≯𐋲≠
+𐹧𞲄󠁭񆼩。\u034E🄀; 𐹧𞲄󠁭񆼩.\u034E🄀; [B1, V6, V7]; xn--fo0dw409aq58qrn69d.xn--sua6883w; ; ;  # 𐹧𞲄.͎🄀
+𐹧𞲄󠁭񆼩。\u034E0.; 𐹧𞲄󠁭񆼩.\u034E0.; [B1, V6, V7]; xn--fo0dw409aq58qrn69d.xn--0-bgb.; [B1, V6, V7, A4_2]; ;  # 𐹧𞲄.͎0.
+xn--fo0dw409aq58qrn69d.xn--0-bgb.; 𐹧𞲄󠁭񆼩.\u034E0.; [B1, V6, V7]; xn--fo0dw409aq58qrn69d.xn--0-bgb.; [B1, V6, V7, A4_2]; ;  # 𐹧𞲄.͎0.
+xn--fo0dw409aq58qrn69d.xn--sua6883w; 𐹧𞲄󠁭񆼩.\u034E🄀; [B1, V6, V7]; xn--fo0dw409aq58qrn69d.xn--sua6883w; ; ;  # 𐹧𞲄.͎🄀
+Ⴄ．\u200D\u0721󻣋ς; ⴄ.\u200D\u0721󻣋ς; [B1, C2, V7]; xn--vkj.xn--3xa93o3t5ajq467a; ; xn--vkj.xn--4xa73ob5892c; [B2, B3, V7] # ⴄ.ܡς
+Ⴄ.\u200D\u0721󻣋ς; ⴄ.\u200D\u0721󻣋ς; [B1, C2, V7]; xn--vkj.xn--3xa93o3t5ajq467a; ; xn--vkj.xn--4xa73ob5892c; [B2, B3, V7] # ⴄ.ܡς
+ⴄ.\u200D\u0721󻣋ς; ; [B1, C2, V7]; xn--vkj.xn--3xa93o3t5ajq467a; ; xn--vkj.xn--4xa73ob5892c; [B2, B3, V7] # ⴄ.ܡς
+Ⴄ.\u200D\u0721󻣋Σ; ⴄ.\u200D\u0721󻣋σ; [B1, C2, V7]; xn--vkj.xn--4xa73o3t5ajq467a; ; xn--vkj.xn--4xa73ob5892c; [B2, B3, V7] # ⴄ.ܡσ
+ⴄ.\u200D\u0721󻣋σ; ; [B1, C2, V7]; xn--vkj.xn--4xa73o3t5ajq467a; ; xn--vkj.xn--4xa73ob5892c; [B2, B3, V7] # ⴄ.ܡσ
+xn--vkj.xn--4xa73ob5892c; ⴄ.\u0721󻣋σ; [B2, B3, V7]; xn--vkj.xn--4xa73ob5892c; ; ;  # ⴄ.ܡσ
+xn--vkj.xn--4xa73o3t5ajq467a; ⴄ.\u200D\u0721󻣋σ; [B1, C2, V7]; xn--vkj.xn--4xa73o3t5ajq467a; ; ;  # ⴄ.ܡσ
+xn--vkj.xn--3xa93o3t5ajq467a; ⴄ.\u200D\u0721󻣋ς; [B1, C2, V7]; xn--vkj.xn--3xa93o3t5ajq467a; ; ;  # ⴄ.ܡς
+ⴄ．\u200D\u0721󻣋ς; ⴄ.\u200D\u0721󻣋ς; [B1, C2, V7]; xn--vkj.xn--3xa93o3t5ajq467a; ; xn--vkj.xn--4xa73ob5892c; [B2, B3, V7] # ⴄ.ܡς
+Ⴄ．\u200D\u0721󻣋Σ; ⴄ.\u200D\u0721󻣋σ; [B1, C2, V7]; xn--vkj.xn--4xa73o3t5ajq467a; ; xn--vkj.xn--4xa73ob5892c; [B2, B3, V7] # ⴄ.ܡσ
+ⴄ．\u200D\u0721󻣋σ; ⴄ.\u200D\u0721󻣋σ; [B1, C2, V7]; xn--vkj.xn--4xa73o3t5ajq467a; ; xn--vkj.xn--4xa73ob5892c; [B2, B3, V7] # ⴄ.ܡσ
+xn--cnd.xn--4xa73ob5892c; Ⴄ.\u0721󻣋σ; [B2, B3, V7]; xn--cnd.xn--4xa73ob5892c; ; ;  # Ⴄ.ܡσ
+xn--cnd.xn--4xa73o3t5ajq467a; Ⴄ.\u200D\u0721󻣋σ; [B1, C2, V7]; xn--cnd.xn--4xa73o3t5ajq467a; ; ;  # Ⴄ.ܡσ
+xn--cnd.xn--3xa93o3t5ajq467a; Ⴄ.\u200D\u0721󻣋ς; [B1, C2, V7]; xn--cnd.xn--3xa93o3t5ajq467a; ; ;  # Ⴄ.ܡς
+򮵛\u0613.Ⴕ; 򮵛\u0613.ⴕ; [V7]; xn--1fb94204l.xn--dlj; ; ;  # ؓ.ⴕ
+򮵛\u0613.ⴕ; ; [V7]; xn--1fb94204l.xn--dlj; ; ;  # ؓ.ⴕ
+xn--1fb94204l.xn--dlj; 򮵛\u0613.ⴕ; [V7]; xn--1fb94204l.xn--dlj; ; ;  # ؓ.ⴕ
+xn--1fb94204l.xn--tnd; 򮵛\u0613.Ⴕ; [V7]; xn--1fb94204l.xn--tnd; ; ;  # ؓ.Ⴕ
+≯\u1DF3𞤥。\u200C\uA8C4󠪉\u200D; ≯\u1DF3𞤥.\u200C\uA8C4󠪉\u200D; [B1, C1, C2, V7]; xn--ofg13qyr21c.xn--0ugc0116hix29k; ; xn--ofg13qyr21c.xn--0f9au6706d; [B1, V6, V7] # ≯ᷳ𞤥.꣄
+>\u0338\u1DF3𞤥。\u200C\uA8C4󠪉\u200D; ≯\u1DF3𞤥.\u200C\uA8C4󠪉\u200D; [B1, C1, C2, V7]; xn--ofg13qyr21c.xn--0ugc0116hix29k; ; xn--ofg13qyr21c.xn--0f9au6706d; [B1, V6, V7] # ≯ᷳ𞤥.꣄
+>\u0338\u1DF3𞤃。\u200C\uA8C4󠪉\u200D; ≯\u1DF3𞤥.\u200C\uA8C4󠪉\u200D; [B1, C1, C2, V7]; xn--ofg13qyr21c.xn--0ugc0116hix29k; ; xn--ofg13qyr21c.xn--0f9au6706d; [B1, V6, V7] # ≯ᷳ𞤥.꣄
+≯\u1DF3𞤃。\u200C\uA8C4󠪉\u200D; ≯\u1DF3𞤥.\u200C\uA8C4󠪉\u200D; [B1, C1, C2, V7]; xn--ofg13qyr21c.xn--0ugc0116hix29k; ; xn--ofg13qyr21c.xn--0f9au6706d; [B1, V6, V7] # ≯ᷳ𞤥.꣄
+xn--ofg13qyr21c.xn--0f9au6706d; ≯\u1DF3𞤥.\uA8C4󠪉; [B1, V6, V7]; xn--ofg13qyr21c.xn--0f9au6706d; ; ;  # ≯ᷳ𞤥.꣄
+xn--ofg13qyr21c.xn--0ugc0116hix29k; ≯\u1DF3𞤥.\u200C\uA8C4󠪉\u200D; [B1, C1, C2, V7]; xn--ofg13qyr21c.xn--0ugc0116hix29k; ; ;  # ≯ᷳ𞤥.꣄
+\u200C󠄷｡򒑁; \u200C.򒑁; [C1, V7]; xn--0ug.xn--w720c; ; .xn--w720c; [V7, A4_2] # .
+\u200C󠄷。򒑁; \u200C.򒑁; [C1, V7]; xn--0ug.xn--w720c; ; .xn--w720c; [V7, A4_2] # .
+.xn--w720c; .򒑁; [V7, X4_2]; .xn--w720c; [V7, A4_2]; ;  # .
+xn--0ug.xn--w720c; \u200C.򒑁; [C1, V7]; xn--0ug.xn--w720c; ; ;  # .
+⒈\u0DD6焅.󗡙\u200Dꡟ; ; [C2, V7]; xn--t1c337io97c.xn--1ugz184c9lw7i; ; xn--t1c337io97c.xn--4c9a21133d; [V7] # ⒈ූ焅.ꡟ
+1.\u0DD6焅.󗡙\u200Dꡟ; ; [C2, V6, V7]; 1.xn--t1c6981c.xn--1ugz184c9lw7i; ; 1.xn--t1c6981c.xn--4c9a21133d; [V6, V7] # 1.ූ焅.ꡟ
+1.xn--t1c6981c.xn--4c9a21133d; 1.\u0DD6焅.󗡙ꡟ; [V6, V7]; 1.xn--t1c6981c.xn--4c9a21133d; ; ;  # 1.ූ焅.ꡟ
+1.xn--t1c6981c.xn--1ugz184c9lw7i; 1.\u0DD6焅.󗡙\u200Dꡟ; [C2, V6, V7]; 1.xn--t1c6981c.xn--1ugz184c9lw7i; ; ;  # 1.ූ焅.ꡟ
+xn--t1c337io97c.xn--4c9a21133d; ⒈\u0DD6焅.󗡙ꡟ; [V7]; xn--t1c337io97c.xn--4c9a21133d; ; ;  # ⒈ූ焅.ꡟ
+xn--t1c337io97c.xn--1ugz184c9lw7i; ⒈\u0DD6焅.󗡙\u200Dꡟ; [C2, V7]; xn--t1c337io97c.xn--1ugz184c9lw7i; ; ;  # ⒈ූ焅.ꡟ
+\u1DCDς≮.ς𝪦𞤕0; \u1DCDς≮.ς𝪦𞤷0; [B1, B5, V6]; xn--3xa744kvid.xn--0-xmb85727aggma; ; xn--4xa544kvid.xn--0-zmb55727aggma;  # ᷍ς≮.ς𝪦𞤷0
+\u1DCDς<\u0338.ς𝪦𞤕0; \u1DCDς≮.ς𝪦𞤷0; [B1, B5, V6]; xn--3xa744kvid.xn--0-xmb85727aggma; ; xn--4xa544kvid.xn--0-zmb55727aggma;  # ᷍ς≮.ς𝪦𞤷0
+\u1DCDς<\u0338.ς𝪦𞤷0; \u1DCDς≮.ς𝪦𞤷0; [B1, B5, V6]; xn--3xa744kvid.xn--0-xmb85727aggma; ; xn--4xa544kvid.xn--0-zmb55727aggma;  # ᷍ς≮.ς𝪦𞤷0
+\u1DCDς≮.ς𝪦𞤷0; ; [B1, B5, V6]; xn--3xa744kvid.xn--0-xmb85727aggma; ; xn--4xa544kvid.xn--0-zmb55727aggma;  # ᷍ς≮.ς𝪦𞤷0
+\u1DCDΣ≮.Σ𝪦𞤕0; \u1DCDσ≮.σ𝪦𞤷0; [B1, B5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+\u1DCDΣ<\u0338.Σ𝪦𞤕0; \u1DCDσ≮.σ𝪦𞤷0; [B1, B5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+\u1DCDσ<\u0338.σ𝪦𞤷0; \u1DCDσ≮.σ𝪦𞤷0; [B1, B5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+\u1DCDσ≮.σ𝪦𞤷0; ; [B1, B5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+\u1DCDΣ≮.Σ𝪦𞤷0; \u1DCDσ≮.σ𝪦𞤷0; [B1, B5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+\u1DCDΣ<\u0338.Σ𝪦𞤷0; \u1DCDσ≮.σ𝪦𞤷0; [B1, B5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+xn--4xa544kvid.xn--0-zmb55727aggma; \u1DCDσ≮.σ𝪦𞤷0; [B1, B5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+xn--3xa744kvid.xn--0-xmb85727aggma; \u1DCDς≮.ς𝪦𞤷0; [B1, B5, V6]; xn--3xa744kvid.xn--0-xmb85727aggma; ; ;  # ᷍ς≮.ς𝪦𞤷0
+\u1DCDσ≮.σ𝪦𞤕0; \u1DCDσ≮.σ𝪦𞤷0; [B1, B5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+\u1DCDσ<\u0338.σ𝪦𞤕0; \u1DCDσ≮.σ𝪦𞤷0; [B1, B5, V6]; xn--4xa544kvid.xn--0-zmb55727aggma; ; ;  # ᷍σ≮.σ𝪦𞤷0
+򢦾ß\u05B9𐫙.\u05AD\u08A1; ; [B1, B5, B6, V6, V7]; xn--zca89v339zj118e.xn--4cb62m; ; xn--ss-xjd6058xlz50g.xn--4cb62m;  # ßֹ𐫙.֭ࢡ
+򢦾SS\u05B9𐫙.\u05AD\u08A1; 򢦾ss\u05B9𐫙.\u05AD\u08A1; [B1, B5, B6, V6, V7]; xn--ss-xjd6058xlz50g.xn--4cb62m; ; ;  # ssֹ𐫙.֭ࢡ
+򢦾ss\u05B9𐫙.\u05AD\u08A1; ; [B1, B5, B6, V6, V7]; xn--ss-xjd6058xlz50g.xn--4cb62m; ; ;  # ssֹ𐫙.֭ࢡ
+򢦾Ss\u05B9𐫙.\u05AD\u08A1; 򢦾ss\u05B9𐫙.\u05AD\u08A1; [B1, B5, B6, V6, V7]; xn--ss-xjd6058xlz50g.xn--4cb62m; ; ;  # ssֹ𐫙.֭ࢡ
+xn--ss-xjd6058xlz50g.xn--4cb62m; 򢦾ss\u05B9𐫙.\u05AD\u08A1; [B1, B5, B6, V6, V7]; xn--ss-xjd6058xlz50g.xn--4cb62m; ; ;  # ssֹ𐫙.֭ࢡ
+xn--zca89v339zj118e.xn--4cb62m; 򢦾ß\u05B9𐫙.\u05AD\u08A1; [B1, B5, B6, V6, V7]; xn--zca89v339zj118e.xn--4cb62m; ; ;  # ßֹ𐫙.֭ࢡ
+-𞣄｡⒈; -𞣄.⒈; [B1, V3, V7]; xn----xc8r.xn--tsh; ; ;  # -𞣄.⒈
+-𞣄。1.; -𞣄.1.; [B1, V3]; xn----xc8r.1.; [B1, V3, A4_2]; ;  # -𞣄.1.
+xn----xc8r.b.; -𞣄.b.; [B1, V3]; xn----xc8r.b.; [B1, V3, A4_2]; ;  # -𞣄.b.
+xn----xc8r.xn--tsh; -𞣄.⒈; [B1, V3, V7]; xn----xc8r.xn--tsh; ; ;  # -𞣄.⒈
+񈠢𐫖𝟡。\u063E𑘿; 񈠢𐫖9.\u063E𑘿; [B5, V7]; xn--9-el5iv442t.xn--9gb0830l; ; ;  # 𐫖9.ؾ𑘿
+񈠢𐫖9。\u063E𑘿; 񈠢𐫖9.\u063E𑘿; [B5, V7]; xn--9-el5iv442t.xn--9gb0830l; ; ;  # 𐫖9.ؾ𑘿
+xn--9-el5iv442t.xn--9gb0830l; 񈠢𐫖9.\u063E𑘿; [B5, V7]; xn--9-el5iv442t.xn--9gb0830l; ; ;  # 𐫖9.ؾ𑘿
+\u0668\uFC8C\u0668\u1A5D.\u200D; \u0668\u0646\u0645\u0668\u1A5D.\u200D; [B1, C2]; xn--hhbb5hc956w.xn--1ug; ; xn--hhbb5hc956w.; [B1, A4_2] # ٨نم٨ᩝ.
+\u0668\u0646\u0645\u0668\u1A5D.\u200D; ; [B1, C2]; xn--hhbb5hc956w.xn--1ug; ; xn--hhbb5hc956w.; [B1, A4_2] # ٨نم٨ᩝ.
+xn--hhbb5hc956w.; \u0668\u0646\u0645\u0668\u1A5D.; [B1]; xn--hhbb5hc956w.; [B1, A4_2]; ;  # ٨نم٨ᩝ.
+xn--hhbb5hc956w.xn--1ug; \u0668\u0646\u0645\u0668\u1A5D.\u200D; [B1, C2]; xn--hhbb5hc956w.xn--1ug; ; ;  # ٨نم٨ᩝ.
+𝟘．Ⴇ󀳑\uFD50񫃱; 0.ⴇ󀳑\u062A\u062C\u0645񫃱; [B1, B5, V7]; 0.xn--pgbe9ez79qd207lvff8b; ; ;  # 0.ⴇتجم
+0.Ⴇ󀳑\u062A\u062C\u0645񫃱; 0.ⴇ󀳑\u062A\u062C\u0645񫃱; [B1, B5, V7]; 0.xn--pgbe9ez79qd207lvff8b; ; ;  # 0.ⴇتجم
+0.ⴇ󀳑\u062A\u062C\u0645񫃱; ; [B1, B5, V7]; 0.xn--pgbe9ez79qd207lvff8b; ; ;  # 0.ⴇتجم
+0.xn--pgbe9ez79qd207lvff8b; 0.ⴇ󀳑\u062A\u062C\u0645񫃱; [B1, B5, V7]; 0.xn--pgbe9ez79qd207lvff8b; ; ;  # 0.ⴇتجم
+𝟘．ⴇ󀳑\uFD50񫃱; 0.ⴇ󀳑\u062A\u062C\u0645񫃱; [B1, B5, V7]; 0.xn--pgbe9ez79qd207lvff8b; ; ;  # 0.ⴇتجم
+0.xn--pgbe9e344c2725svff8b; 0.Ⴇ󀳑\u062A\u062C\u0645񫃱; [B1, B5, V7]; 0.xn--pgbe9e344c2725svff8b; ; ;  # 0.Ⴇتجم
+𑇀▍.⁞ᠰ; ; [V6]; xn--9zh3057f.xn--j7e103b; ; ;  # 𑇀▍.⁞ᠰ
+xn--9zh3057f.xn--j7e103b; 𑇀▍.⁞ᠰ; [V6]; xn--9zh3057f.xn--j7e103b; ; ;  # 𑇀▍.⁞ᠰ
+\u200D-\u067A.򏯩; ; [B1, C2, V7]; xn----qrc357q.xn--ts49b; ; xn----qrc.xn--ts49b; [B1, V3, V7] # -ٺ.
+xn----qrc.xn--ts49b; -\u067A.򏯩; [B1, V3, V7]; xn----qrc.xn--ts49b; ; ;  # -ٺ.
+xn----qrc357q.xn--ts49b; \u200D-\u067A.򏯩; [B1, C2, V7]; xn----qrc357q.xn--ts49b; ; ;  # -ٺ.
+ᠢ𐮂𐫘寐｡\u200C≯✳; ᠢ𐮂𐫘寐.\u200C≯✳; [B1, B5, C1]; xn--46e6675axzzhota.xn--0ug06gu8f; ; xn--46e6675axzzhota.xn--hdh99p; [B1, B5] # ᠢ𐮂𐫘寐.≯✳
+ᠢ𐮂𐫘寐｡\u200C>\u0338✳; ᠢ𐮂𐫘寐.\u200C≯✳; [B1, B5, C1]; xn--46e6675axzzhota.xn--0ug06gu8f; ; xn--46e6675axzzhota.xn--hdh99p; [B1, B5] # ᠢ𐮂𐫘寐.≯✳
+ᠢ𐮂𐫘寐。\u200C≯✳; ᠢ𐮂𐫘寐.\u200C≯✳; [B1, B5, C1]; xn--46e6675axzzhota.xn--0ug06gu8f; ; xn--46e6675axzzhota.xn--hdh99p; [B1, B5] # ᠢ𐮂𐫘寐.≯✳
+ᠢ𐮂𐫘寐。\u200C>\u0338✳; ᠢ𐮂𐫘寐.\u200C≯✳; [B1, B5, C1]; xn--46e6675axzzhota.xn--0ug06gu8f; ; xn--46e6675axzzhota.xn--hdh99p; [B1, B5] # ᠢ𐮂𐫘寐.≯✳
+xn--46e6675axzzhota.xn--hdh99p; ᠢ𐮂𐫘寐.≯✳; [B1, B5]; xn--46e6675axzzhota.xn--hdh99p; ; ;  # ᠢ𐮂𐫘寐.≯✳
+xn--46e6675axzzhota.xn--0ug06gu8f; ᠢ𐮂𐫘寐.\u200C≯✳; [B1, B5, C1]; xn--46e6675axzzhota.xn--0ug06gu8f; ; ;  # ᠢ𐮂𐫘寐.≯✳
+\u200D｡󸲜ႺႴ𞨇; \u200D.󸲜ⴚⴔ𞨇; [B1, B5, B6, C2, V7]; xn--1ug.xn--cljl81825an3r4h; ; .xn--cljl81825an3r4h; [B5, B6, V7, A4_2] # .ⴚⴔ
+\u200D。󸲜ႺႴ𞨇; \u200D.󸲜ⴚⴔ𞨇; [B1, B5, B6, C2, V7]; xn--1ug.xn--cljl81825an3r4h; ; .xn--cljl81825an3r4h; [B5, B6, V7, A4_2] # .ⴚⴔ
+\u200D。󸲜ⴚⴔ𞨇; \u200D.󸲜ⴚⴔ𞨇; [B1, B5, B6, C2, V7]; xn--1ug.xn--cljl81825an3r4h; ; .xn--cljl81825an3r4h; [B5, B6, V7, A4_2] # .ⴚⴔ
+\u200D。󸲜Ⴚⴔ𞨇; \u200D.󸲜ⴚⴔ𞨇; [B1, B5, B6, C2, V7]; xn--1ug.xn--cljl81825an3r4h; ; .xn--cljl81825an3r4h; [B5, B6, V7, A4_2] # .ⴚⴔ
+.xn--cljl81825an3r4h; .󸲜ⴚⴔ𞨇; [B5, B6, V7, X4_2]; .xn--cljl81825an3r4h; [B5, B6, V7, A4_2]; ;  # .ⴚⴔ
+xn--1ug.xn--cljl81825an3r4h; \u200D.󸲜ⴚⴔ𞨇; [B1, B5, B6, C2, V7]; xn--1ug.xn--cljl81825an3r4h; ; ;  # .ⴚⴔ
+\u200D｡󸲜ⴚⴔ𞨇; \u200D.󸲜ⴚⴔ𞨇; [B1, B5, B6, C2, V7]; xn--1ug.xn--cljl81825an3r4h; ; .xn--cljl81825an3r4h; [B5, B6, V7, A4_2] # .ⴚⴔ
+\u200D｡󸲜Ⴚⴔ𞨇; \u200D.󸲜ⴚⴔ𞨇; [B1, B5, B6, C2, V7]; xn--1ug.xn--cljl81825an3r4h; ; .xn--cljl81825an3r4h; [B5, B6, V7, A4_2] # .ⴚⴔ
+.xn--ynd036lq981an3r4h; .󸲜Ⴚⴔ𞨇; [B5, B6, V7, X4_2]; .xn--ynd036lq981an3r4h; [B5, B6, V7, A4_2]; ;  # .Ⴚⴔ
+xn--1ug.xn--ynd036lq981an3r4h; \u200D.󸲜Ⴚⴔ𞨇; [B1, B5, B6, C2, V7]; xn--1ug.xn--ynd036lq981an3r4h; ; ;  # .Ⴚⴔ
+.xn--sndl01647an3h1h; .󸲜ႺႴ𞨇; [B5, B6, V7, X4_2]; .xn--sndl01647an3h1h; [B5, B6, V7, A4_2]; ;  # .ႺႴ
+xn--1ug.xn--sndl01647an3h1h; \u200D.󸲜ႺႴ𞨇; [B1, B5, B6, C2, V7]; xn--1ug.xn--sndl01647an3h1h; ; ;  # .ႺႴ
+-3.\u200Dヌᢕ; ; [C2, V3]; -3.xn--fbf739aq5o; ; -3.xn--fbf115j; [V3] # -3.ヌᢕ
+-3.xn--fbf115j; -3.ヌᢕ; [V3]; -3.xn--fbf115j; ; ;  # -3.ヌᢕ
+-3.xn--fbf739aq5o; -3.\u200Dヌᢕ; [C2, V3]; -3.xn--fbf739aq5o; ; ;  # -3.ヌᢕ
+🂃\u0666ß\u200D。󠠂򭰍𞩒-; 🂃\u0666ß\u200D.󠠂򭰍𞩒-; [B1, C2, V3, V7]; xn--zca34z68yzu83b.xn----nz8rh7531csznt; ; xn--ss-pyd98921c.xn----nz8rh7531csznt; [B1, V3, V7] # 🂃٦ß.-
+🂃\u0666SS\u200D。󠠂򭰍𞩒-; 🂃\u0666ss\u200D.󠠂򭰍𞩒-; [B1, C2, V3, V7]; xn--ss-pyd483x5k99b.xn----nz8rh7531csznt; ; xn--ss-pyd98921c.xn----nz8rh7531csznt; [B1, V3, V7] # 🂃٦ss.-
+🂃\u0666ss\u200D。󠠂򭰍𞩒-; 🂃\u0666ss\u200D.󠠂򭰍𞩒-; [B1, C2, V3, V7]; xn--ss-pyd483x5k99b.xn----nz8rh7531csznt; ; xn--ss-pyd98921c.xn----nz8rh7531csznt; [B1, V3, V7] # 🂃٦ss.-
+xn--ss-pyd98921c.xn----nz8rh7531csznt; 🂃\u0666ss.󠠂򭰍𞩒-; [B1, V3, V7]; xn--ss-pyd98921c.xn----nz8rh7531csznt; ; ;  # 🂃٦ss.-
+xn--ss-pyd483x5k99b.xn----nz8rh7531csznt; 🂃\u0666ss\u200D.󠠂򭰍𞩒-; [B1, C2, V3, V7]; xn--ss-pyd483x5k99b.xn----nz8rh7531csznt; ; ;  # 🂃٦ss.-
+xn--zca34z68yzu83b.xn----nz8rh7531csznt; 🂃\u0666ß\u200D.󠠂򭰍𞩒-; [B1, C2, V3, V7]; xn--zca34z68yzu83b.xn----nz8rh7531csznt; ; ;  # 🂃٦ß.-
+🂃\u0666Ss\u200D。󠠂򭰍𞩒-; 🂃\u0666ss\u200D.󠠂򭰍𞩒-; [B1, C2, V3, V7]; xn--ss-pyd483x5k99b.xn----nz8rh7531csznt; ; xn--ss-pyd98921c.xn----nz8rh7531csznt; [B1, V3, V7] # 🂃٦ss.-
+ꇟ-𐾺\u069F。򰀺\u200C; ꇟ-𐾺\u069F.򰀺\u200C; [B5, B6, C1, V7]; xn----utc4430jd3zd.xn--0ugx6670i; ; xn----utc4430jd3zd.xn--bp20d; [B5, B6, V7] # ꇟ-𐾺ڟ.
+xn----utc4430jd3zd.xn--bp20d; ꇟ-𐾺\u069F.򰀺; [B5, B6, V7]; xn----utc4430jd3zd.xn--bp20d; ; ;  # ꇟ-𐾺ڟ.
+xn----utc4430jd3zd.xn--0ugx6670i; ꇟ-𐾺\u069F.򰀺\u200C; [B5, B6, C1, V7]; xn----utc4430jd3zd.xn--0ugx6670i; ; ;  # ꇟ-𐾺ڟ.
+\u0665.\u0484𐨗𝩋𴤃; ; [B1, V6, V7]; xn--eib.xn--n3a0405kus8eft5l; ; ;  # ٥.҄𐨗𝩋
+xn--eib.xn--n3a0405kus8eft5l; \u0665.\u0484𐨗𝩋𴤃; [B1, V6, V7]; xn--eib.xn--n3a0405kus8eft5l; ; ;  # ٥.҄𐨗𝩋
+-.񱼓\u0649𐨿; ; [B1, B5, B6, V3, V7]; -.xn--lhb4124khbq4b; ; ;  # -.ى𐨿
+-.xn--lhb4124khbq4b; -.񱼓\u0649𐨿; [B1, B5, B6, V3, V7]; -.xn--lhb4124khbq4b; ; ;  # -.ى𐨿
+󾬨ς.𞶙녫ß; ; [B2, B3, V7]; xn--3xa96659r.xn--zca5051g4h4i; ; xn--4xa76659r.xn--ss-d64i8755h;  # ς.녫ß
+󾬨ς.𞶙녫ß; 󾬨ς.𞶙녫ß; [B2, B3, V7]; xn--3xa96659r.xn--zca5051g4h4i; ; xn--4xa76659r.xn--ss-d64i8755h;  # ς.녫ß
+󾬨Σ.𞶙녫SS; 󾬨σ.𞶙녫ss; [B2, B3, V7]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨Σ.𞶙녫SS; 󾬨σ.𞶙녫ss; [B2, B3, V7]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨σ.𞶙녫ss; ; [B2, B3, V7]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨σ.𞶙녫ss; 󾬨σ.𞶙녫ss; [B2, B3, V7]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨Σ.𞶙녫ss; 󾬨σ.𞶙녫ss; [B2, B3, V7]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨Σ.𞶙녫ss; 󾬨σ.𞶙녫ss; [B2, B3, V7]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨Σ.𞶙녫Ss; 󾬨σ.𞶙녫ss; [B2, B3, V7]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨Σ.𞶙녫Ss; 󾬨σ.𞶙녫ss; [B2, B3, V7]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+xn--4xa76659r.xn--ss-d64i8755h; 󾬨σ.𞶙녫ss; [B2, B3, V7]; xn--4xa76659r.xn--ss-d64i8755h; ; ;  # σ.녫ss
+󾬨Σ.𞶙녫ß; 󾬨σ.𞶙녫ß; [B2, B3, V7]; xn--4xa76659r.xn--zca5051g4h4i; ; xn--4xa76659r.xn--ss-d64i8755h;  # σ.녫ß
+󾬨Σ.𞶙녫ß; 󾬨σ.𞶙녫ß; [B2, B3, V7]; xn--4xa76659r.xn--zca5051g4h4i; ; xn--4xa76659r.xn--ss-d64i8755h;  # σ.녫ß
+󾬨σ.𞶙녫ß; ; [B2, B3, V7]; xn--4xa76659r.xn--zca5051g4h4i; ; xn--4xa76659r.xn--ss-d64i8755h;  # σ.녫ß
+󾬨σ.𞶙녫ß; 󾬨σ.𞶙녫ß; [B2, B3, V7]; xn--4xa76659r.xn--zca5051g4h4i; ; xn--4xa76659r.xn--ss-d64i8755h;  # σ.녫ß
+xn--4xa76659r.xn--zca5051g4h4i; 󾬨σ.𞶙녫ß; [B2, B3, V7]; xn--4xa76659r.xn--zca5051g4h4i; ; ;  # σ.녫ß
+xn--3xa96659r.xn--zca5051g4h4i; 󾬨ς.𞶙녫ß; [B2, B3, V7]; xn--3xa96659r.xn--zca5051g4h4i; ; ;  # ς.녫ß
+Ⅎ\u17D2\u200D｡≠\u200D\u200C; ⅎ\u17D2\u200D.≠\u200D\u200C; [C1, C2]; xn--u4e823bq1a.xn--0ugb89o; ; xn--u4e969b.xn--1ch; [] # ⅎ្.≠
+Ⅎ\u17D2\u200D｡=\u0338\u200D\u200C; ⅎ\u17D2\u200D.≠\u200D\u200C; [C1, C2]; xn--u4e823bq1a.xn--0ugb89o; ; xn--u4e969b.xn--1ch; [] # ⅎ្.≠
+Ⅎ\u17D2\u200D。≠\u200D\u200C; ⅎ\u17D2\u200D.≠\u200D\u200C; [C1, C2]; xn--u4e823bq1a.xn--0ugb89o; ; xn--u4e969b.xn--1ch; [] # ⅎ្.≠
+Ⅎ\u17D2\u200D。=\u0338\u200D\u200C; ⅎ\u17D2\u200D.≠\u200D\u200C; [C1, C2]; xn--u4e823bq1a.xn--0ugb89o; ; xn--u4e969b.xn--1ch; [] # ⅎ្.≠
+ⅎ\u17D2\u200D。=\u0338\u200D\u200C; ⅎ\u17D2\u200D.≠\u200D\u200C; [C1, C2]; xn--u4e823bq1a.xn--0ugb89o; ; xn--u4e969b.xn--1ch; [] # ⅎ្.≠
+ⅎ\u17D2\u200D。≠\u200D\u200C; ⅎ\u17D2\u200D.≠\u200D\u200C; [C1, C2]; xn--u4e823bq1a.xn--0ugb89o; ; xn--u4e969b.xn--1ch; [] # ⅎ្.≠
+xn--u4e969b.xn--1ch; ⅎ\u17D2.≠; ; xn--u4e969b.xn--1ch; ; ;  # ⅎ្.≠
+ⅎ\u17D2.≠; ; ; xn--u4e969b.xn--1ch; ; ;  # ⅎ្.≠
+ⅎ\u17D2.=\u0338; ⅎ\u17D2.≠; ; xn--u4e969b.xn--1ch; ; ;  # ⅎ្.≠
+Ⅎ\u17D2.=\u0338; ⅎ\u17D2.≠; ; xn--u4e969b.xn--1ch; ; ;  # ⅎ្.≠
+Ⅎ\u17D2.≠; ⅎ\u17D2.≠; ; xn--u4e969b.xn--1ch; ; ;  # ⅎ្.≠
+xn--u4e823bq1a.xn--0ugb89o; ⅎ\u17D2\u200D.≠\u200D\u200C; [C1, C2]; xn--u4e823bq1a.xn--0ugb89o; ; ;  # ⅎ្.≠
+ⅎ\u17D2\u200D｡=\u0338\u200D\u200C; ⅎ\u17D2\u200D.≠\u200D\u200C; [C1, C2]; xn--u4e823bq1a.xn--0ugb89o; ; xn--u4e969b.xn--1ch; [] # ⅎ្.≠
+ⅎ\u17D2\u200D｡≠\u200D\u200C; ⅎ\u17D2\u200D.≠\u200D\u200C; [C1, C2]; xn--u4e823bq1a.xn--0ugb89o; ; xn--u4e969b.xn--1ch; [] # ⅎ្.≠
+xn--u4e319b.xn--1ch; Ⅎ\u17D2.≠; [V7]; xn--u4e319b.xn--1ch; ; ;  # Ⅎ្.≠
+xn--u4e823bcza.xn--0ugb89o; Ⅎ\u17D2\u200D.≠\u200D\u200C; [C1, C2, V7]; xn--u4e823bcza.xn--0ugb89o; ; ;  # Ⅎ្.≠
+𐋺\uAAF6\uA953󧦉．\u200C\u1714\u068F; 𐋺\uAAF6\uA953󧦉.\u200C\u1714\u068F; [B1, C1, V7]; xn--3j9a14ak27osbz2o.xn--ljb175f1wg; ; xn--3j9a14ak27osbz2o.xn--ljb175f; [B1, V6, V7] # 𐋺꫶꥓.᜔ڏ
+𐋺\uAAF6\uA953󧦉.\u200C\u1714\u068F; ; [B1, C1, V7]; xn--3j9a14ak27osbz2o.xn--ljb175f1wg; ; xn--3j9a14ak27osbz2o.xn--ljb175f; [B1, V6, V7] # 𐋺꫶꥓.᜔ڏ
+xn--3j9a14ak27osbz2o.xn--ljb175f; 𐋺\uAAF6\uA953󧦉.\u1714\u068F; [B1, V6, V7]; xn--3j9a14ak27osbz2o.xn--ljb175f; ; ;  # 𐋺꫶꥓.᜔ڏ
+xn--3j9a14ak27osbz2o.xn--ljb175f1wg; 𐋺\uAAF6\uA953󧦉.\u200C\u1714\u068F; [B1, C1, V7]; xn--3j9a14ak27osbz2o.xn--ljb175f1wg; ; ;  # 𐋺꫶꥓.᜔ڏ
+񺔯\u0FA8．≯; 񺔯\u0FA8.≯; [V7]; xn--4fd57150h.xn--hdh; ; ;  # ྨ.≯
+񺔯\u0FA8．>\u0338; 񺔯\u0FA8.≯; [V7]; xn--4fd57150h.xn--hdh; ; ;  # ྨ.≯
+񺔯\u0FA8.≯; ; [V7]; xn--4fd57150h.xn--hdh; ; ;  # ྨ.≯
+񺔯\u0FA8.>\u0338; 񺔯\u0FA8.≯; [V7]; xn--4fd57150h.xn--hdh; ; ;  # ྨ.≯
+xn--4fd57150h.xn--hdh; 񺔯\u0FA8.≯; [V7]; xn--4fd57150h.xn--hdh; ; ;  # ྨ.≯
+\u200D𞡄Ⴓ．𐇽; \u200D𞡄ⴓ.𐇽; [B1, C2, V6]; xn--1ugz52c4i16a.xn--m27c; ; xn--blj7492l.xn--m27c; [B1, B2, B3, V6] # 𞡄ⴓ.𐇽
+\u200D𞡄Ⴓ.𐇽; \u200D𞡄ⴓ.𐇽; [B1, C2, V6]; xn--1ugz52c4i16a.xn--m27c; ; xn--blj7492l.xn--m27c; [B1, B2, B3, V6] # 𞡄ⴓ.𐇽
+\u200D𞡄ⴓ.𐇽; ; [B1, C2, V6]; xn--1ugz52c4i16a.xn--m27c; ; xn--blj7492l.xn--m27c; [B1, B2, B3, V6] # 𞡄ⴓ.𐇽
+xn--blj7492l.xn--m27c; 𞡄ⴓ.𐇽; [B1, B2, B3, V6]; xn--blj7492l.xn--m27c; ; ;  # 𞡄ⴓ.𐇽
+xn--1ugz52c4i16a.xn--m27c; \u200D𞡄ⴓ.𐇽; [B1, C2, V6]; xn--1ugz52c4i16a.xn--m27c; ; ;  # 𞡄ⴓ.𐇽
+\u200D𞡄ⴓ．𐇽; \u200D𞡄ⴓ.𐇽; [B1, C2, V6]; xn--1ugz52c4i16a.xn--m27c; ; xn--blj7492l.xn--m27c; [B1, B2, B3, V6] # 𞡄ⴓ.𐇽
+xn--rnd5552v.xn--m27c; 𞡄Ⴓ.𐇽; [B1, B2, B3, V6, V7]; xn--rnd5552v.xn--m27c; ; ;  # 𞡄Ⴓ.𐇽
+xn--rnd379ex885a.xn--m27c; \u200D𞡄Ⴓ.𐇽; [B1, C2, V6, V7]; xn--rnd379ex885a.xn--m27c; ; ;  # 𞡄Ⴓ.𐇽
+𐪒ß\uA8EA．ᡤ; 𐪒ß\uA8EA.ᡤ; [B2, B3]; xn--zca2517f2hvc.xn--08e; ; xn--ss-tu9hw933a.xn--08e;  # 𐪒ß꣪.ᡤ
+𐪒ß\uA8EA.ᡤ; ; [B2, B3]; xn--zca2517f2hvc.xn--08e; ; xn--ss-tu9hw933a.xn--08e;  # 𐪒ß꣪.ᡤ
+𐪒SS\uA8EA.ᡤ; 𐪒ss\uA8EA.ᡤ; [B2, B3]; xn--ss-tu9hw933a.xn--08e; ; ;  # 𐪒ss꣪.ᡤ
+𐪒ss\uA8EA.ᡤ; ; [B2, B3]; xn--ss-tu9hw933a.xn--08e; ; ;  # 𐪒ss꣪.ᡤ
+xn--ss-tu9hw933a.xn--08e; 𐪒ss\uA8EA.ᡤ; [B2, B3]; xn--ss-tu9hw933a.xn--08e; ; ;  # 𐪒ss꣪.ᡤ
+xn--zca2517f2hvc.xn--08e; 𐪒ß\uA8EA.ᡤ; [B2, B3]; xn--zca2517f2hvc.xn--08e; ; ;  # 𐪒ß꣪.ᡤ
+𐪒SS\uA8EA．ᡤ; 𐪒ss\uA8EA.ᡤ; [B2, B3]; xn--ss-tu9hw933a.xn--08e; ; ;  # 𐪒ss꣪.ᡤ
+𐪒ss\uA8EA．ᡤ; 𐪒ss\uA8EA.ᡤ; [B2, B3]; xn--ss-tu9hw933a.xn--08e; ; ;  # 𐪒ss꣪.ᡤ
+𐪒Ss\uA8EA.ᡤ; 𐪒ss\uA8EA.ᡤ; [B2, B3]; xn--ss-tu9hw933a.xn--08e; ; ;  # 𐪒ss꣪.ᡤ
+𐪒Ss\uA8EA．ᡤ; 𐪒ss\uA8EA.ᡤ; [B2, B3]; xn--ss-tu9hw933a.xn--08e; ; ;  # 𐪒ss꣪.ᡤ
+𐨿󠆌鸮𑚶.ς; 𐨿鸮𑚶.ς; [V6]; xn--l76a726rt2h.xn--3xa; ; xn--l76a726rt2h.xn--4xa;  # 𐨿鸮𑚶.ς
+𐨿󠆌鸮𑚶.Σ; 𐨿鸮𑚶.σ; [V6]; xn--l76a726rt2h.xn--4xa; ; ;  # 𐨿鸮𑚶.σ
+𐨿󠆌鸮𑚶.σ; 𐨿鸮𑚶.σ; [V6]; xn--l76a726rt2h.xn--4xa; ; ;  # 𐨿鸮𑚶.σ
+xn--l76a726rt2h.xn--4xa; 𐨿鸮𑚶.σ; [V6]; xn--l76a726rt2h.xn--4xa; ; ;  # 𐨿鸮𑚶.σ
+xn--l76a726rt2h.xn--3xa; 𐨿鸮𑚶.ς; [V6]; xn--l76a726rt2h.xn--3xa; ; ;  # 𐨿鸮𑚶.ς
+⒗𞤬。-𑚶; ⒗𞤬.-𑚶; [B1, V3, V7]; xn--8shw466n.xn----4j0j; ; ;  # ⒗𞤬.-𑚶
+16.𞤬。-𑚶; 16.𞤬.-𑚶; [B1, V3]; 16.xn--ke6h.xn----4j0j; ; ;  # 16.𞤬.-𑚶
+16.𞤊。-𑚶; 16.𞤬.-𑚶; [B1, V3]; 16.xn--ke6h.xn----4j0j; ; ;  # 16.𞤬.-𑚶
+16.xn--ke6h.xn----4j0j; 16.𞤬.-𑚶; [B1, V3]; 16.xn--ke6h.xn----4j0j; ; ;  # 16.𞤬.-𑚶
+⒗𞤊。-𑚶; ⒗𞤬.-𑚶; [B1, V3, V7]; xn--8shw466n.xn----4j0j; ; ;  # ⒗𞤬.-𑚶
+xn--8shw466n.xn----4j0j; ⒗𞤬.-𑚶; [B1, V3, V7]; xn--8shw466n.xn----4j0j; ; ;  # ⒗𞤬.-𑚶
+\u08B3𞤿⾫｡𐹣\u068F⒈; \u08B3𞤿隹.𐹣\u068F⒈; [B1, B2, B3, V7]; xn--8yb0383efiwk.xn--ljb064mol4n; ; ;  # ࢳ𞤿隹.𐹣ڏ⒈
+\u08B3𞤿隹。𐹣\u068F1.; \u08B3𞤿隹.𐹣\u068F1.; [B1, B2, B3]; xn--8yb0383efiwk.xn--1-wsc3373r.; [B1, B2, B3, A4_2]; ;  # ࢳ𞤿隹.𐹣ڏ1.
+\u08B3𞤝隹。𐹣\u068F1.; \u08B3𞤿隹.𐹣\u068F1.; [B1, B2, B3]; xn--8yb0383efiwk.xn--1-wsc3373r.; [B1, B2, B3, A4_2]; ;  # ࢳ𞤿隹.𐹣ڏ1.
+xn--8yb0383efiwk.xn--1-wsc3373r.; \u08B3𞤿隹.𐹣\u068F1.; [B1, B2, B3]; xn--8yb0383efiwk.xn--1-wsc3373r.; [B1, B2, B3, A4_2]; ;  # ࢳ𞤿隹.𐹣ڏ1.
+\u08B3𞤝⾫｡𐹣\u068F⒈; \u08B3𞤿隹.𐹣\u068F⒈; [B1, B2, B3, V7]; xn--8yb0383efiwk.xn--ljb064mol4n; ; ;  # ࢳ𞤿隹.𐹣ڏ⒈
+xn--8yb0383efiwk.xn--ljb064mol4n; \u08B3𞤿隹.𐹣\u068F⒈; [B1, B2, B3, V7]; xn--8yb0383efiwk.xn--ljb064mol4n; ; ;  # ࢳ𞤿隹.𐹣ڏ⒈
+\u2433𚎛𝟧\u0661.ᡢ8\u0F72\u0600; \u2433𚎛5\u0661.ᡢ8\u0F72\u0600; [B5, B6, V7]; xn--5-bqc410un435a.xn--8-rkc763epjj; ; ;  # 5١.ᡢ8ི
+\u2433𚎛5\u0661.ᡢ8\u0F72\u0600; ; [B5, B6, V7]; xn--5-bqc410un435a.xn--8-rkc763epjj; ; ;  # 5١.ᡢ8ི
+xn--5-bqc410un435a.xn--8-rkc763epjj; \u2433𚎛5\u0661.ᡢ8\u0F72\u0600; [B5, B6, V7]; xn--5-bqc410un435a.xn--8-rkc763epjj; ; ;  # 5١.ᡢ8ི
+𐹠.🄀⒒-󨰈; ; [B1, V7]; xn--7n0d.xn----xcp9757q1s13g; ; ;  # 𐹠.🄀⒒-
+𐹠.0.11.-󨰈; ; [B1, V3, V7]; xn--7n0d.0.11.xn----8j07m; ; ;  # 𐹠.0.11.-
+xn--7n0d.0.11.xn----8j07m; 𐹠.0.11.-󨰈; [B1, V3, V7]; xn--7n0d.0.11.xn----8j07m; ; ;  # 𐹠.0.11.-
+xn--7n0d.xn----xcp9757q1s13g; 𐹠.🄀⒒-󨰈; [B1, V7]; xn--7n0d.xn----xcp9757q1s13g; ; ;  # 𐹠.🄀⒒-
+ς-。\u200C𝟭-; ς-.\u200C1-; [C1, V3]; xn----xmb.xn--1--i1t; ; xn----zmb.1-; [V3] # ς-.1-
+ς-。\u200C1-; ς-.\u200C1-; [C1, V3]; xn----xmb.xn--1--i1t; ; xn----zmb.1-; [V3] # ς-.1-
+Σ-。\u200C1-; σ-.\u200C1-; [C1, V3]; xn----zmb.xn--1--i1t; ; xn----zmb.1-; [V3] # σ-.1-
+σ-。\u200C1-; σ-.\u200C1-; [C1, V3]; xn----zmb.xn--1--i1t; ; xn----zmb.1-; [V3] # σ-.1-
+xn----zmb.1-; σ-.1-; [V3]; xn----zmb.1-; ; ;  # σ-.1-
+xn----zmb.xn--1--i1t; σ-.\u200C1-; [C1, V3]; xn----zmb.xn--1--i1t; ; ;  # σ-.1-
+xn----xmb.xn--1--i1t; ς-.\u200C1-; [C1, V3]; xn----xmb.xn--1--i1t; ; ;  # ς-.1-
+Σ-。\u200C𝟭-; σ-.\u200C1-; [C1, V3]; xn----zmb.xn--1--i1t; ; xn----zmb.1-; [V3] # σ-.1-
+σ-。\u200C𝟭-; σ-.\u200C1-; [C1, V3]; xn----zmb.xn--1--i1t; ; xn----zmb.1-; [V3] # σ-.1-
+\u1734-\u0CE2．󠄩Ⴄ; \u1734-\u0CE2.ⴄ; [V6]; xn----ggf830f.xn--vkj; ; ;  # ᜴-ೢ.ⴄ
+\u1734-\u0CE2.󠄩Ⴄ; \u1734-\u0CE2.ⴄ; [V6]; xn----ggf830f.xn--vkj; ; ;  # ᜴-ೢ.ⴄ
+\u1734-\u0CE2.󠄩ⴄ; \u1734-\u0CE2.ⴄ; [V6]; xn----ggf830f.xn--vkj; ; ;  # ᜴-ೢ.ⴄ
+xn----ggf830f.xn--vkj; \u1734-\u0CE2.ⴄ; [V6]; xn----ggf830f.xn--vkj; ; ;  # ᜴-ೢ.ⴄ
+\u1734-\u0CE2．󠄩ⴄ; \u1734-\u0CE2.ⴄ; [V6]; xn----ggf830f.xn--vkj; ; ;  # ᜴-ೢ.ⴄ
+xn----ggf830f.xn--cnd; \u1734-\u0CE2.Ⴄ; [V6, V7]; xn----ggf830f.xn--cnd; ; ;  # ᜴-ೢ.Ⴄ
+򭈗♋\u06BB𐦥｡\u0954⒈; 򭈗♋\u06BB𐦥.\u0954⒈; [B1, B5, B6, V6, V7]; xn--ukb372n129m3rs7f.xn--u3b240l; ; ;  # ♋ڻ𐦥.॔⒈
+򭈗♋\u06BB𐦥。\u09541.; 򭈗♋\u06BB𐦥.\u09541.; [B1, B5, B6, V6, V7]; xn--ukb372n129m3rs7f.xn--1-fyd.; [B1, B5, B6, V6, V7, A4_2]; ;  # ♋ڻ𐦥.॔1.
+xn--ukb372n129m3rs7f.xn--1-fyd.; 򭈗♋\u06BB𐦥.\u09541.; [B1, B5, B6, V6, V7]; xn--ukb372n129m3rs7f.xn--1-fyd.; [B1, B5, B6, V6, V7, A4_2]; ;  # ♋ڻ𐦥.॔1.
+xn--ukb372n129m3rs7f.xn--u3b240l; 򭈗♋\u06BB𐦥.\u0954⒈; [B1, B5, B6, V6, V7]; xn--ukb372n129m3rs7f.xn--u3b240l; ; ;  # ♋ڻ𐦥.॔⒈
+\u05A4．\u06C1\u1AB3\u200C; \u05A4.\u06C1\u1AB3\u200C; [B1, B3, C1, V6]; xn--vcb.xn--0kb623hm1d; ; xn--vcb.xn--0kb623h; [B1, V6] # ֤.ہ᪳
+\u05A4.\u06C1\u1AB3\u200C; ; [B1, B3, C1, V6]; xn--vcb.xn--0kb623hm1d; ; xn--vcb.xn--0kb623h; [B1, V6] # ֤.ہ᪳
+xn--vcb.xn--0kb623h; \u05A4.\u06C1\u1AB3; [B1, V6]; xn--vcb.xn--0kb623h; ; ;  # ֤.ہ᪳
+xn--vcb.xn--0kb623hm1d; \u05A4.\u06C1\u1AB3\u200C; [B1, B3, C1, V6]; xn--vcb.xn--0kb623hm1d; ; ;  # ֤.ہ᪳
+񢭏\u0846≮\u0ACD．𞦊; 񢭏\u0846≮\u0ACD.𞦊; [B5, B6, V7]; xn--4vb80kq29ayo62l.xn--8g6h; ; ;  # ࡆ≮્.
+񢭏\u0846<\u0338\u0ACD．𞦊; 񢭏\u0846≮\u0ACD.𞦊; [B5, B6, V7]; xn--4vb80kq29ayo62l.xn--8g6h; ; ;  # ࡆ≮્.
+񢭏\u0846≮\u0ACD.𞦊; ; [B5, B6, V7]; xn--4vb80kq29ayo62l.xn--8g6h; ; ;  # ࡆ≮્.
+񢭏\u0846<\u0338\u0ACD.𞦊; 񢭏\u0846≮\u0ACD.𞦊; [B5, B6, V7]; xn--4vb80kq29ayo62l.xn--8g6h; ; ;  # ࡆ≮્.
+xn--4vb80kq29ayo62l.xn--8g6h; 񢭏\u0846≮\u0ACD.𞦊; [B5, B6, V7]; xn--4vb80kq29ayo62l.xn--8g6h; ; ;  # ࡆ≮્.
+\u200D。𞀘⒈ꡍ擉; \u200D.𞀘⒈ꡍ擉; [C2, V6, V7]; xn--1ug.xn--tsh026uql4bew9p; ; .xn--tsh026uql4bew9p; [V6, V7, A4_2] # .𞀘⒈ꡍ擉
+\u200D。𞀘1.ꡍ擉; \u200D.𞀘1.ꡍ擉; [C2, V6]; xn--1ug.xn--1-1p4r.xn--s7uv61m; ; .xn--1-1p4r.xn--s7uv61m; [V6, A4_2] # .𞀘1.ꡍ擉
+.xn--1-1p4r.xn--s7uv61m; .𞀘1.ꡍ擉; [V6, X4_2]; .xn--1-1p4r.xn--s7uv61m; [V6, A4_2]; ;  # .𞀘1.ꡍ擉
+xn--1ug.xn--1-1p4r.xn--s7uv61m; \u200D.𞀘1.ꡍ擉; [C2, V6]; xn--1ug.xn--1-1p4r.xn--s7uv61m; ; ;  # .𞀘1.ꡍ擉
+.xn--tsh026uql4bew9p; .𞀘⒈ꡍ擉; [V6, V7, X4_2]; .xn--tsh026uql4bew9p; [V6, V7, A4_2]; ;  # .𞀘⒈ꡍ擉
+xn--1ug.xn--tsh026uql4bew9p; \u200D.𞀘⒈ꡍ擉; [C2, V6, V7]; xn--1ug.xn--tsh026uql4bew9p; ; ;  # .𞀘⒈ꡍ擉
+₈\u07CB．\uFB64≠; 8\u07CB.\u067F≠; [B1, B3]; xn--8-zbd.xn--4ib883l; ; ;  # 8ߋ.ٿ≠
+₈\u07CB．\uFB64=\u0338; 8\u07CB.\u067F≠; [B1, B3]; xn--8-zbd.xn--4ib883l; ; ;  # 8ߋ.ٿ≠
+8\u07CB.\u067F≠; ; [B1, B3]; xn--8-zbd.xn--4ib883l; ; ;  # 8ߋ.ٿ≠
+8\u07CB.\u067F=\u0338; 8\u07CB.\u067F≠; [B1, B3]; xn--8-zbd.xn--4ib883l; ; ;  # 8ߋ.ٿ≠
+xn--8-zbd.xn--4ib883l; 8\u07CB.\u067F≠; [B1, B3]; xn--8-zbd.xn--4ib883l; ; ;  # 8ߋ.ٿ≠
+ᢡ\u07DE򹐣.⒒\u0642𑍦; ; [B1, B5, V7]; xn--5sb596fi873t.xn--ehb336mvy7n; ; ;  # ᢡߞ.⒒ق𑍦
+ᢡ\u07DE򹐣.11.\u0642𑍦; ; [B1, B5, V7]; xn--5sb596fi873t.11.xn--ehb4198k; ; ;  # ᢡߞ.11.ق𑍦
+xn--5sb596fi873t.11.xn--ehb4198k; ᢡ\u07DE򹐣.11.\u0642𑍦; [B1, B5, V7]; xn--5sb596fi873t.11.xn--ehb4198k; ; ;  # ᢡߞ.11.ق𑍦
+xn--5sb596fi873t.xn--ehb336mvy7n; ᢡ\u07DE򹐣.⒒\u0642𑍦; [B1, B5, V7]; xn--5sb596fi873t.xn--ehb336mvy7n; ; ;  # ᢡߞ.⒒ق𑍦
+\u0E48-𐹺𝟜.\u0363\u06E1⒏; \u0E48-𐹺4.\u0363\u06E1⒏; [B1, V6, V7]; xn---4-owiz479s.xn--eva20pjv9a; ; ;  # ่-𐹺4.ͣۡ⒏
+\u0E48-𐹺4.\u0363\u06E18.; ; [B1, V6]; xn---4-owiz479s.xn--8-ihb69x.; [B1, V6, A4_2]; ;  # ่-𐹺4.ͣۡ8.
+xn---4-owiz479s.xn--8-ihb69x.; \u0E48-𐹺4.\u0363\u06E18.; [B1, V6]; xn---4-owiz479s.xn--8-ihb69x.; [B1, V6, A4_2]; ;  # ่-𐹺4.ͣۡ8.
+xn---4-owiz479s.xn--eva20pjv9a; \u0E48-𐹺4.\u0363\u06E1⒏; [B1, V6, V7]; xn---4-owiz479s.xn--eva20pjv9a; ; ;  # ่-𐹺4.ͣۡ⒏
+⫐｡Ⴠ-󃐢; ⫐.ⴠ-󃐢; [V7]; xn--r3i.xn----2wst7439i; ; ;  # ⫐.ⴠ-
+⫐。Ⴠ-󃐢; ⫐.ⴠ-󃐢; [V7]; xn--r3i.xn----2wst7439i; ; ;  # ⫐.ⴠ-
+⫐。ⴠ-󃐢; ⫐.ⴠ-󃐢; [V7]; xn--r3i.xn----2wst7439i; ; ;  # ⫐.ⴠ-
+xn--r3i.xn----2wst7439i; ⫐.ⴠ-󃐢; [V7]; xn--r3i.xn----2wst7439i; ; ;  # ⫐.ⴠ-
+⫐｡ⴠ-󃐢; ⫐.ⴠ-󃐢; [V7]; xn--r3i.xn----2wst7439i; ; ;  # ⫐.ⴠ-
+xn--r3i.xn----z1g58579u; ⫐.Ⴠ-󃐢; [V7]; xn--r3i.xn----z1g58579u; ; ;  # ⫐.Ⴠ-
+𑑂◊．⦟∠; 𑑂◊.⦟∠; [V6]; xn--01h3338f.xn--79g270a; ; ;  # 𑑂◊.⦟∠
+𑑂◊.⦟∠; ; [V6]; xn--01h3338f.xn--79g270a; ; ;  # 𑑂◊.⦟∠
+xn--01h3338f.xn--79g270a; 𑑂◊.⦟∠; [V6]; xn--01h3338f.xn--79g270a; ; ;  # 𑑂◊.⦟∠
+𿌰-\u0662。󋸛ꡂ; 𿌰-\u0662.󋸛ꡂ; [B5, B6, V7]; xn----dqc20828e.xn--bc9an2879c; ; ;  # -٢.ꡂ
+xn----dqc20828e.xn--bc9an2879c; 𿌰-\u0662.󋸛ꡂ; [B5, B6, V7]; xn----dqc20828e.xn--bc9an2879c; ; ;  # -٢.ꡂ
+\u0678。󠏬\u0741𞪭𐹪; \u064A\u0674.󠏬\u0741𞪭𐹪; [B1, V7]; xn--mhb8f.xn--oob2585kfdsfsbo7h; ; ;  # يٴ.݁𐹪
+\u064A\u0674。󠏬\u0741𞪭𐹪; \u064A\u0674.󠏬\u0741𞪭𐹪; [B1, V7]; xn--mhb8f.xn--oob2585kfdsfsbo7h; ; ;  # يٴ.݁𐹪
+xn--mhb8f.xn--oob2585kfdsfsbo7h; \u064A\u0674.󠏬\u0741𞪭𐹪; [B1, V7]; xn--mhb8f.xn--oob2585kfdsfsbo7h; ; ;  # يٴ.݁𐹪
+𐫆ꌄ｡\u200Dᣬ; 𐫆ꌄ.\u200Dᣬ; [B1, B2, B3, C2]; xn--y77ao18q.xn--wdf367a; ; xn--y77ao18q.xn--wdf; [B2, B3] # 𐫆ꌄ.ᣬ
+𐫆ꌄ。\u200Dᣬ; 𐫆ꌄ.\u200Dᣬ; [B1, B2, B3, C2]; xn--y77ao18q.xn--wdf367a; ; xn--y77ao18q.xn--wdf; [B2, B3] # 𐫆ꌄ.ᣬ
+xn--y77ao18q.xn--wdf; 𐫆ꌄ.ᣬ; [B2, B3]; xn--y77ao18q.xn--wdf; ; ;  # 𐫆ꌄ.ᣬ
+xn--y77ao18q.xn--wdf367a; 𐫆ꌄ.\u200Dᣬ; [B1, B2, B3, C2]; xn--y77ao18q.xn--wdf367a; ; ;  # 𐫆ꌄ.ᣬ
+₀\u0662。󅪞≯-; 0\u0662.󅪞≯-; [B1, B6, V3, V7]; xn--0-dqc.xn----ogov3342l; ; ;  # 0٢.≯-
+₀\u0662。󅪞>\u0338-; 0\u0662.󅪞≯-; [B1, B6, V3, V7]; xn--0-dqc.xn----ogov3342l; ; ;  # 0٢.≯-
+0\u0662。󅪞≯-; 0\u0662.󅪞≯-; [B1, B6, V3, V7]; xn--0-dqc.xn----ogov3342l; ; ;  # 0٢.≯-
+0\u0662。󅪞>\u0338-; 0\u0662.󅪞≯-; [B1, B6, V3, V7]; xn--0-dqc.xn----ogov3342l; ; ;  # 0٢.≯-
+xn--0-dqc.xn----ogov3342l; 0\u0662.󅪞≯-; [B1, B6, V3, V7]; xn--0-dqc.xn----ogov3342l; ; ;  # 0٢.≯-
+\u031C𐹫-𞯃.𐋤\u0845; ; [B1, V6, V7]; xn----gdb7046r692g.xn--3vb1349j; ; ;  # ̜𐹫-.𐋤ࡅ
+xn----gdb7046r692g.xn--3vb1349j; \u031C𐹫-𞯃.𐋤\u0845; [B1, V6, V7]; xn----gdb7046r692g.xn--3vb1349j; ; ;  # ̜𐹫-.𐋤ࡅ
+≠｡𝩑𐹩Ⴡ\u0594; ≠.𝩑𐹩ⴡ\u0594; [B1, V6]; xn--1ch.xn--fcb363rk03mypug; ; ;  # ≠.𝩑𐹩ⴡ֔
+=\u0338｡𝩑𐹩Ⴡ\u0594; ≠.𝩑𐹩ⴡ\u0594; [B1, V6]; xn--1ch.xn--fcb363rk03mypug; ; ;  # ≠.𝩑𐹩ⴡ֔
+≠。𝩑𐹩Ⴡ\u0594; ≠.𝩑𐹩ⴡ\u0594; [B1, V6]; xn--1ch.xn--fcb363rk03mypug; ; ;  # ≠.𝩑𐹩ⴡ֔
+=\u0338。𝩑𐹩Ⴡ\u0594; ≠.𝩑𐹩ⴡ\u0594; [B1, V6]; xn--1ch.xn--fcb363rk03mypug; ; ;  # ≠.𝩑𐹩ⴡ֔
+=\u0338。𝩑𐹩ⴡ\u0594; ≠.𝩑𐹩ⴡ\u0594; [B1, V6]; xn--1ch.xn--fcb363rk03mypug; ; ;  # ≠.𝩑𐹩ⴡ֔
+≠。𝩑𐹩ⴡ\u0594; ≠.𝩑𐹩ⴡ\u0594; [B1, V6]; xn--1ch.xn--fcb363rk03mypug; ; ;  # ≠.𝩑𐹩ⴡ֔
+xn--1ch.xn--fcb363rk03mypug; ≠.𝩑𐹩ⴡ\u0594; [B1, V6]; xn--1ch.xn--fcb363rk03mypug; ; ;  # ≠.𝩑𐹩ⴡ֔
+=\u0338｡𝩑𐹩ⴡ\u0594; ≠.𝩑𐹩ⴡ\u0594; [B1, V6]; xn--1ch.xn--fcb363rk03mypug; ; ;  # ≠.𝩑𐹩ⴡ֔
+≠｡𝩑𐹩ⴡ\u0594; ≠.𝩑𐹩ⴡ\u0594; [B1, V6]; xn--1ch.xn--fcb363rk03mypug; ; ;  # ≠.𝩑𐹩ⴡ֔
+xn--1ch.xn--fcb538c649rypog; ≠.𝩑𐹩Ⴡ\u0594; [B1, V6, V7]; xn--1ch.xn--fcb538c649rypog; ; ;  # ≠.𝩑𐹩Ⴡ֔
+𖫳≠.Ⴀ𐮀; 𖫳≠.ⴀ𐮀; [B1, B5, B6, V6]; xn--1ch9250k.xn--rkj6232e; ; ;  # 𖫳≠.ⴀ𐮀
+𖫳=\u0338.Ⴀ𐮀; 𖫳≠.ⴀ𐮀; [B1, B5, B6, V6]; xn--1ch9250k.xn--rkj6232e; ; ;  # 𖫳≠.ⴀ𐮀
+𖫳=\u0338.ⴀ𐮀; 𖫳≠.ⴀ𐮀; [B1, B5, B6, V6]; xn--1ch9250k.xn--rkj6232e; ; ;  # 𖫳≠.ⴀ𐮀
+𖫳≠.ⴀ𐮀; ; [B1, B5, B6, V6]; xn--1ch9250k.xn--rkj6232e; ; ;  # 𖫳≠.ⴀ𐮀
+xn--1ch9250k.xn--rkj6232e; 𖫳≠.ⴀ𐮀; [B1, B5, B6, V6]; xn--1ch9250k.xn--rkj6232e; ; ;  # 𖫳≠.ⴀ𐮀
+xn--1ch9250k.xn--7md2659j; 𖫳≠.Ⴀ𐮀; [B1, B5, B6, V6, V7]; xn--1ch9250k.xn--7md2659j; ; ;  # 𖫳≠.Ⴀ𐮀
+󠅾\u0736\u0726．ᢚ閪\u08E2𝩟; \u0736\u0726.ᢚ閪\u08E2𝩟; [B1, B5, B6, V6, V7]; xn--wnb5a.xn--l0b161fis8gbp5m; ; ;  # ܶܦ.ᢚ閪𝩟
+󠅾\u0736\u0726.ᢚ閪\u08E2𝩟; \u0736\u0726.ᢚ閪\u08E2𝩟; [B1, B5, B6, V6, V7]; xn--wnb5a.xn--l0b161fis8gbp5m; ; ;  # ܶܦ.ᢚ閪𝩟
+xn--wnb5a.xn--l0b161fis8gbp5m; \u0736\u0726.ᢚ閪\u08E2𝩟; [B1, B5, B6, V6, V7]; xn--wnb5a.xn--l0b161fis8gbp5m; ; ;  # ܶܦ.ᢚ閪𝩟
+\u200D󠇜\u06CB\uA8E9｡\u20DD\u0FB0-ᛟ; \u200D\u06CB\uA8E9.\u20DD\u0FB0-ᛟ; [B1, C2, V6]; xn--blb540ke10h.xn----gmg236cj6k; ; xn--blb8114f.xn----gmg236cj6k; [B1, V6] # ۋ꣩.⃝ྰ-ᛟ
+\u200D󠇜\u06CB\uA8E9。\u20DD\u0FB0-ᛟ; \u200D\u06CB\uA8E9.\u20DD\u0FB0-ᛟ; [B1, C2, V6]; xn--blb540ke10h.xn----gmg236cj6k; ; xn--blb8114f.xn----gmg236cj6k; [B1, V6] # ۋ꣩.⃝ྰ-ᛟ
+xn--blb8114f.xn----gmg236cj6k; \u06CB\uA8E9.\u20DD\u0FB0-ᛟ; [B1, V6]; xn--blb8114f.xn----gmg236cj6k; ; ;  # ۋ꣩.⃝ྰ-ᛟ
+xn--blb540ke10h.xn----gmg236cj6k; \u200D\u06CB\uA8E9.\u20DD\u0FB0-ᛟ; [B1, C2, V6]; xn--blb540ke10h.xn----gmg236cj6k; ; ;  # ۋ꣩.⃝ྰ-ᛟ
+헁󘖙\u0E3A󚍚。\u06BA𝟜; 헁󘖙\u0E3A󚍚.\u06BA4; [V7]; xn--o4c1723h8g85gt4ya.xn--4-dvc; ; ;  # 헁ฺ.ں4
+헁󘖙\u0E3A󚍚。\u06BA𝟜; 헁󘖙\u0E3A󚍚.\u06BA4; [V7]; xn--o4c1723h8g85gt4ya.xn--4-dvc; ; ;  # 헁ฺ.ں4
+헁󘖙\u0E3A󚍚。\u06BA4; 헁󘖙\u0E3A󚍚.\u06BA4; [V7]; xn--o4c1723h8g85gt4ya.xn--4-dvc; ; ;  # 헁ฺ.ں4
+헁󘖙\u0E3A󚍚。\u06BA4; 헁󘖙\u0E3A󚍚.\u06BA4; [V7]; xn--o4c1723h8g85gt4ya.xn--4-dvc; ; ;  # 헁ฺ.ں4
+xn--o4c1723h8g85gt4ya.xn--4-dvc; 헁󘖙\u0E3A󚍚.\u06BA4; [V7]; xn--o4c1723h8g85gt4ya.xn--4-dvc; ; ;  # 헁ฺ.ں4
+𐹭｡󃱂\u200CႾ; 𐹭.󃱂\u200Cⴞ; [B1, C1, V7]; xn--lo0d.xn--0ugx72cwi33v; ; xn--lo0d.xn--mljx1099g; [B1, V7] # 𐹭.ⴞ
+𐹭。󃱂\u200CႾ; 𐹭.󃱂\u200Cⴞ; [B1, C1, V7]; xn--lo0d.xn--0ugx72cwi33v; ; xn--lo0d.xn--mljx1099g; [B1, V7] # 𐹭.ⴞ
+𐹭。󃱂\u200Cⴞ; 𐹭.󃱂\u200Cⴞ; [B1, C1, V7]; xn--lo0d.xn--0ugx72cwi33v; ; xn--lo0d.xn--mljx1099g; [B1, V7] # 𐹭.ⴞ
+xn--lo0d.xn--mljx1099g; 𐹭.󃱂ⴞ; [B1, V7]; xn--lo0d.xn--mljx1099g; ; ;  # 𐹭.ⴞ
+xn--lo0d.xn--0ugx72cwi33v; 𐹭.󃱂\u200Cⴞ; [B1, C1, V7]; xn--lo0d.xn--0ugx72cwi33v; ; ;  # 𐹭.ⴞ
+𐹭｡󃱂\u200Cⴞ; 𐹭.󃱂\u200Cⴞ; [B1, C1, V7]; xn--lo0d.xn--0ugx72cwi33v; ; xn--lo0d.xn--mljx1099g; [B1, V7] # 𐹭.ⴞ
+xn--lo0d.xn--2nd75260n; 𐹭.󃱂Ⴞ; [B1, V7]; xn--lo0d.xn--2nd75260n; ; ;  # 𐹭.Ⴞ
+xn--lo0d.xn--2nd949eqw95u; 𐹭.󃱂\u200CႾ; [B1, C1, V7]; xn--lo0d.xn--2nd949eqw95u; ; ;  # 𐹭.Ⴞ
+\uA953.\u033D𑂽馋; ; [V6, V7]; xn--3j9a.xn--bua0708eqzrd; ; ;  # ꥓.̽馋
+xn--3j9a.xn--bua0708eqzrd; \uA953.\u033D𑂽馋; [V6, V7]; xn--3j9a.xn--bua0708eqzrd; ; ;  # ꥓.̽馋
+󈫝򪛸\u200D｡䜖; 󈫝򪛸\u200D.䜖; [C2, V7]; xn--1ug30527h9mxi.xn--k0o; ; xn--g138cxw05a.xn--k0o; [V7] # .䜖
+󈫝򪛸\u200D。䜖; 󈫝򪛸\u200D.䜖; [C2, V7]; xn--1ug30527h9mxi.xn--k0o; ; xn--g138cxw05a.xn--k0o; [V7] # .䜖
+xn--g138cxw05a.xn--k0o; 󈫝򪛸.䜖; [V7]; xn--g138cxw05a.xn--k0o; ; ;  # .䜖
+xn--1ug30527h9mxi.xn--k0o; 󈫝򪛸\u200D.䜖; [C2, V7]; xn--1ug30527h9mxi.xn--k0o; ; ;  # .䜖
+ᡯ⚉姶🄉．۷\u200D🎪\u200D; ᡯ⚉姶8,.۷\u200D🎪\u200D; [C2, U1]; xn--8,-g9oy26fzu4d.xn--kmb859ja94998b; ; xn--8,-g9oy26fzu4d.xn--kmb6733w; [U1] # ᡯ⚉姶8,.۷🎪
+ᡯ⚉姶8,.۷\u200D🎪\u200D; ; [C2, U1]; xn--8,-g9oy26fzu4d.xn--kmb859ja94998b; ; xn--8,-g9oy26fzu4d.xn--kmb6733w; [U1] # ᡯ⚉姶8,.۷🎪
+xn--8,-g9oy26fzu4d.xn--kmb6733w; ᡯ⚉姶8,.۷🎪; [U1]; xn--8,-g9oy26fzu4d.xn--kmb6733w; ; ;  # ᡯ⚉姶8,.۷🎪
+xn--8,-g9oy26fzu4d.xn--kmb859ja94998b; ᡯ⚉姶8,.۷\u200D🎪\u200D; [C2, U1]; xn--8,-g9oy26fzu4d.xn--kmb859ja94998b; ; ;  # ᡯ⚉姶8,.۷🎪
+xn--c9e433epi4b3j20a.xn--kmb6733w; ᡯ⚉姶🄉.۷🎪; [V7]; xn--c9e433epi4b3j20a.xn--kmb6733w; ; ;  # ᡯ⚉姶🄉.۷🎪
+xn--c9e433epi4b3j20a.xn--kmb859ja94998b; ᡯ⚉姶🄉.۷\u200D🎪\u200D; [C2, V7]; xn--c9e433epi4b3j20a.xn--kmb859ja94998b; ; ;  # ᡯ⚉姶🄉.۷🎪
+𞽀.𐹸🚖\u0E3A; ; [B1, V7]; xn--0n7h.xn--o4c9032klszf; ; ;  # .𐹸🚖ฺ
+xn--0n7h.xn--o4c9032klszf; 𞽀.𐹸🚖\u0E3A; [B1, V7]; xn--0n7h.xn--o4c9032klszf; ; ;  # .𐹸🚖ฺ
+Ⴔᠵ｡𐹧\u0747۹; ⴔᠵ.𐹧\u0747۹; [B1]; xn--o7e997h.xn--mmb9ml895e; ; ;  # ⴔᠵ.𐹧݇۹
+Ⴔᠵ。𐹧\u0747۹; ⴔᠵ.𐹧\u0747۹; [B1]; xn--o7e997h.xn--mmb9ml895e; ; ;  # ⴔᠵ.𐹧݇۹
+ⴔᠵ。𐹧\u0747۹; ⴔᠵ.𐹧\u0747۹; [B1]; xn--o7e997h.xn--mmb9ml895e; ; ;  # ⴔᠵ.𐹧݇۹
+xn--o7e997h.xn--mmb9ml895e; ⴔᠵ.𐹧\u0747۹; [B1]; xn--o7e997h.xn--mmb9ml895e; ; ;  # ⴔᠵ.𐹧݇۹
+ⴔᠵ｡𐹧\u0747۹; ⴔᠵ.𐹧\u0747۹; [B1]; xn--o7e997h.xn--mmb9ml895e; ; ;  # ⴔᠵ.𐹧݇۹
+xn--snd659a.xn--mmb9ml895e; Ⴔᠵ.𐹧\u0747۹; [B1, V7]; xn--snd659a.xn--mmb9ml895e; ; ;  # Ⴔᠵ.𐹧݇۹
+\u135Fᡈ\u200C．︒-𖾐-; \u135Fᡈ\u200C.︒-𖾐-; [C1, V3, V6, V7]; xn--b7d82wo4h.xn-----c82nz547a; ; xn--b7d82w.xn-----c82nz547a; [V3, V6, V7] # ፟ᡈ.︒-𖾐-
+\u135Fᡈ\u200C.。-𖾐-; \u135Fᡈ\u200C..-𖾐-; [C1, V3, V6, X4_2]; xn--b7d82wo4h..xn-----pe4u; [C1, V3, V6, A4_2]; xn--b7d82w..xn-----pe4u; [V3, V6, A4_2] # ፟ᡈ..-𖾐-
+xn--b7d82w..xn-----pe4u; \u135Fᡈ..-𖾐-; [V3, V6, X4_2]; xn--b7d82w..xn-----pe4u; [V3, V6, A4_2]; ;  # ፟ᡈ..-𖾐-
+xn--b7d82wo4h..xn-----pe4u; \u135Fᡈ\u200C..-𖾐-; [C1, V3, V6, X4_2]; xn--b7d82wo4h..xn-----pe4u; [C1, V3, V6, A4_2]; ;  # ፟ᡈ..-𖾐-
+xn--b7d82w.xn-----c82nz547a; \u135Fᡈ.︒-𖾐-; [V3, V6, V7]; xn--b7d82w.xn-----c82nz547a; ; ;  # ፟ᡈ.︒-𖾐-
+xn--b7d82wo4h.xn-----c82nz547a; \u135Fᡈ\u200C.︒-𖾐-; [C1, V3, V6, V7]; xn--b7d82wo4h.xn-----c82nz547a; ; ;  # ፟ᡈ.︒-𖾐-
+⒈\u0601⒖\u200C.\u1DF0\u07DB; ; [B1, C1, V6, V7]; xn--jfb844kmfdwb.xn--2sb914i; ; xn--jfb347mib.xn--2sb914i; [B1, V6, V7] # ⒈⒖.ᷰߛ
+1.\u060115.\u200C.\u1DF0\u07DB; ; [B1, C1, V6, V7]; 1.xn--15-1pd.xn--0ug.xn--2sb914i; ; 1.xn--15-1pd..xn--2sb914i; [B1, V6, V7, A4_2] # 1.15..ᷰߛ
+1.xn--15-1pd..xn--2sb914i; 1.\u060115..\u1DF0\u07DB; [B1, V6, V7, X4_2]; 1.xn--15-1pd..xn--2sb914i; [B1, V6, V7, A4_2]; ;  # 1.15..ᷰߛ
+1.xn--15-1pd.xn--0ug.xn--2sb914i; 1.\u060115.\u200C.\u1DF0\u07DB; [B1, C1, V6, V7]; 1.xn--15-1pd.xn--0ug.xn--2sb914i; ; ;  # 1.15..ᷰߛ
+xn--jfb347mib.xn--2sb914i; ⒈\u0601⒖.\u1DF0\u07DB; [B1, V6, V7]; xn--jfb347mib.xn--2sb914i; ; ;  # ⒈⒖.ᷰߛ
+xn--jfb844kmfdwb.xn--2sb914i; ⒈\u0601⒖\u200C.\u1DF0\u07DB; [B1, C1, V6, V7]; xn--jfb844kmfdwb.xn--2sb914i; ; ;  # ⒈⒖.ᷰߛ
+𝩜。-\u0B4DႫ; 𝩜.-\u0B4Dⴋ; [V3, V6]; xn--792h.xn----bse820x; ; ;  # 𝩜.-୍ⴋ
+𝩜。-\u0B4Dⴋ; 𝩜.-\u0B4Dⴋ; [V3, V6]; xn--792h.xn----bse820x; ; ;  # 𝩜.-୍ⴋ
+xn--792h.xn----bse820x; 𝩜.-\u0B4Dⴋ; [V3, V6]; xn--792h.xn----bse820x; ; ;  # 𝩜.-୍ⴋ
+xn--792h.xn----bse632b; 𝩜.-\u0B4DႫ; [V3, V6, V7]; xn--792h.xn----bse632b; ; ;  # 𝩜.-୍Ⴋ
+ßჀ.\u0620刯Ⴝ; ßⴠ.\u0620刯ⴝ; [B2, B3]; xn--zca277t.xn--fgb670rovy; ; xn--ss-j81a.xn--fgb670rovy;  # ßⴠ.ؠ刯ⴝ
+ßⴠ.\u0620刯ⴝ; ; [B2, B3]; xn--zca277t.xn--fgb670rovy; ; xn--ss-j81a.xn--fgb670rovy;  # ßⴠ.ؠ刯ⴝ
+SSჀ.\u0620刯Ⴝ; ssⴠ.\u0620刯ⴝ; [B2, B3]; xn--ss-j81a.xn--fgb670rovy; ; ;  # ssⴠ.ؠ刯ⴝ
+ssⴠ.\u0620刯ⴝ; ; [B2, B3]; xn--ss-j81a.xn--fgb670rovy; ; ;  # ssⴠ.ؠ刯ⴝ
+Ssⴠ.\u0620刯Ⴝ; ssⴠ.\u0620刯ⴝ; [B2, B3]; xn--ss-j81a.xn--fgb670rovy; ; ;  # ssⴠ.ؠ刯ⴝ
+xn--ss-j81a.xn--fgb670rovy; ssⴠ.\u0620刯ⴝ; [B2, B3]; xn--ss-j81a.xn--fgb670rovy; ; ;  # ssⴠ.ؠ刯ⴝ
+xn--zca277t.xn--fgb670rovy; ßⴠ.\u0620刯ⴝ; [B2, B3]; xn--zca277t.xn--fgb670rovy; ; ;  # ßⴠ.ؠ刯ⴝ
+xn--ss-j81a.xn--fgb845cb66c; ssⴠ.\u0620刯Ⴝ; [B2, B3, V7]; xn--ss-j81a.xn--fgb845cb66c; ; ;  # ssⴠ.ؠ刯Ⴝ
+xn--ss-wgk.xn--fgb845cb66c; ssჀ.\u0620刯Ⴝ; [B2, B3, V7]; xn--ss-wgk.xn--fgb845cb66c; ; ;  # ssჀ.ؠ刯Ⴝ
+xn--zca442f.xn--fgb845cb66c; ßჀ.\u0620刯Ⴝ; [B2, B3, V7]; xn--zca442f.xn--fgb845cb66c; ; ;  # ßჀ.ؠ刯Ⴝ
+\u1BAAႣℲ｡ᠳ툻\u0673; \u1BAAⴃⅎ.ᠳ툻\u0673; [B5, B6, V6]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+\u1BAAႣℲ｡ᠳ툻\u0673; \u1BAAⴃⅎ.ᠳ툻\u0673; [B5, B6, V6]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+\u1BAAႣℲ。ᠳ툻\u0673; \u1BAAⴃⅎ.ᠳ툻\u0673; [B5, B6, V6]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+\u1BAAႣℲ。ᠳ툻\u0673; \u1BAAⴃⅎ.ᠳ툻\u0673; [B5, B6, V6]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+\u1BAAⴃⅎ。ᠳ툻\u0673; \u1BAAⴃⅎ.ᠳ툻\u0673; [B5, B6, V6]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+\u1BAAⴃⅎ。ᠳ툻\u0673; \u1BAAⴃⅎ.ᠳ툻\u0673; [B5, B6, V6]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+\u1BAAႣⅎ。ᠳ툻\u0673; \u1BAAⴃⅎ.ᠳ툻\u0673; [B5, B6, V6]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+\u1BAAႣⅎ。ᠳ툻\u0673; \u1BAAⴃⅎ.ᠳ툻\u0673; [B5, B6, V6]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+xn--yxf24x4ol.xn--sib102gc69k; \u1BAAⴃⅎ.ᠳ툻\u0673; [B5, B6, V6]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+\u1BAAⴃⅎ｡ᠳ툻\u0673; \u1BAAⴃⅎ.ᠳ툻\u0673; [B5, B6, V6]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+\u1BAAⴃⅎ｡ᠳ툻\u0673; \u1BAAⴃⅎ.ᠳ툻\u0673; [B5, B6, V6]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+\u1BAAႣⅎ｡ᠳ툻\u0673; \u1BAAⴃⅎ.ᠳ툻\u0673; [B5, B6, V6]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+\u1BAAႣⅎ｡ᠳ툻\u0673; \u1BAAⴃⅎ.ᠳ툻\u0673; [B5, B6, V6]; xn--yxf24x4ol.xn--sib102gc69k; ; ;  # ᮪ⴃⅎ.ᠳ툻ٳ
+xn--bnd957c2pe.xn--sib102gc69k; \u1BAAႣⅎ.ᠳ툻\u0673; [B5, B6, V6, V7]; xn--bnd957c2pe.xn--sib102gc69k; ; ;  # ᮪Ⴃⅎ.ᠳ툻ٳ
+xn--bnd957cone.xn--sib102gc69k; \u1BAAႣℲ.ᠳ툻\u0673; [B5, B6, V6, V7]; xn--bnd957cone.xn--sib102gc69k; ; ;  # ᮪ႣℲ.ᠳ툻ٳ
+\u06EC.\u08A2𐹫\u067C; ; [B1, V6]; xn--8lb.xn--1ib31ily45b; ; ;  # ۬.ࢢ𐹫ټ
+xn--8lb.xn--1ib31ily45b; \u06EC.\u08A2𐹫\u067C; [B1, V6]; xn--8lb.xn--1ib31ily45b; ; ;  # ۬.ࢢ𐹫ټ
+\u06B6\u06DF。₇\uA806; \u06B6\u06DF.7\uA806; [B1]; xn--pkb6f.xn--7-x93e; ; ;  # ڶ۟.7꠆
+\u06B6\u06DF。7\uA806; \u06B6\u06DF.7\uA806; [B1]; xn--pkb6f.xn--7-x93e; ; ;  # ڶ۟.7꠆
+xn--pkb6f.xn--7-x93e; \u06B6\u06DF.7\uA806; [B1]; xn--pkb6f.xn--7-x93e; ; ;  # ڶ۟.7꠆
+\u06B6\u06DF.7\uA806; ; [B1]; xn--pkb6f.xn--7-x93e; ; ;  # ڶ۟.7꠆
+Ⴣ𐹻.\u200C𝪣≮󠩉; ⴣ𐹻.\u200C𝪣≮󠩉; [B1, B5, B6, C1, V7]; xn--rlj6323e.xn--0ugy6gn120eb103g; ; xn--rlj6323e.xn--gdh4944ob3x3e; [B1, B5, B6, V6, V7] # ⴣ𐹻.𝪣≮
+Ⴣ𐹻.\u200C𝪣<\u0338󠩉; ⴣ𐹻.\u200C𝪣≮󠩉; [B1, B5, B6, C1, V7]; xn--rlj6323e.xn--0ugy6gn120eb103g; ; xn--rlj6323e.xn--gdh4944ob3x3e; [B1, B5, B6, V6, V7] # ⴣ𐹻.𝪣≮
+ⴣ𐹻.\u200C𝪣<\u0338󠩉; ⴣ𐹻.\u200C𝪣≮󠩉; [B1, B5, B6, C1, V7]; xn--rlj6323e.xn--0ugy6gn120eb103g; ; xn--rlj6323e.xn--gdh4944ob3x3e; [B1, B5, B6, V6, V7] # ⴣ𐹻.𝪣≮
+ⴣ𐹻.\u200C𝪣≮󠩉; ; [B1, B5, B6, C1, V7]; xn--rlj6323e.xn--0ugy6gn120eb103g; ; xn--rlj6323e.xn--gdh4944ob3x3e; [B1, B5, B6, V6, V7] # ⴣ𐹻.𝪣≮
+xn--rlj6323e.xn--gdh4944ob3x3e; ⴣ𐹻.𝪣≮󠩉; [B1, B5, B6, V6, V7]; xn--rlj6323e.xn--gdh4944ob3x3e; ; ;  # ⴣ𐹻.𝪣≮
+xn--rlj6323e.xn--0ugy6gn120eb103g; ⴣ𐹻.\u200C𝪣≮󠩉; [B1, B5, B6, C1, V7]; xn--rlj6323e.xn--0ugy6gn120eb103g; ; ;  # ⴣ𐹻.𝪣≮
+xn--7nd8101k.xn--gdh4944ob3x3e; Ⴣ𐹻.𝪣≮󠩉; [B1, B5, B6, V6, V7]; xn--7nd8101k.xn--gdh4944ob3x3e; ; ;  # Ⴣ𐹻.𝪣≮
+xn--7nd8101k.xn--0ugy6gn120eb103g; Ⴣ𐹻.\u200C𝪣≮󠩉; [B1, B5, B6, C1, V7]; xn--7nd8101k.xn--0ugy6gn120eb103g; ; ;  # Ⴣ𐹻.𝪣≮
+𝟵隁⯮．\u180D\u200C; 9隁⯮.\u200C; [C1]; xn--9-mfs8024b.xn--0ug; ; xn--9-mfs8024b.; [A4_2] # 9隁⯮.
+9隁⯮.\u180D\u200C; 9隁⯮.\u200C; [C1]; xn--9-mfs8024b.xn--0ug; ; xn--9-mfs8024b.; [A4_2] # 9隁⯮.
+xn--9-mfs8024b.; 9隁⯮.; ; xn--9-mfs8024b.; [A4_2]; ;  # 9隁⯮.
+9隁⯮.; ; ; xn--9-mfs8024b.; [A4_2]; ;  # 9隁⯮.
+xn--9-mfs8024b.xn--0ug; 9隁⯮.\u200C; [C1]; xn--9-mfs8024b.xn--0ug; ; ;  # 9隁⯮.
+⒏𐹧｡Ⴣ\u0F84彦; ⒏𐹧.ⴣ\u0F84彦; [B1, V7]; xn--0sh2466f.xn--3ed972m6o8a; ; ;  # ⒏𐹧.ⴣ྄彦
+8.𐹧。Ⴣ\u0F84彦; 8.𐹧.ⴣ\u0F84彦; [B1]; 8.xn--fo0d.xn--3ed972m6o8a; ; ;  # 8.𐹧.ⴣ྄彦
+8.𐹧。ⴣ\u0F84彦; 8.𐹧.ⴣ\u0F84彦; [B1]; 8.xn--fo0d.xn--3ed972m6o8a; ; ;  # 8.𐹧.ⴣ྄彦
+8.xn--fo0d.xn--3ed972m6o8a; 8.𐹧.ⴣ\u0F84彦; [B1]; 8.xn--fo0d.xn--3ed972m6o8a; ; ;  # 8.𐹧.ⴣ྄彦
+⒏𐹧｡ⴣ\u0F84彦; ⒏𐹧.ⴣ\u0F84彦; [B1, V7]; xn--0sh2466f.xn--3ed972m6o8a; ; ;  # ⒏𐹧.ⴣ྄彦
+xn--0sh2466f.xn--3ed972m6o8a; ⒏𐹧.ⴣ\u0F84彦; [B1, V7]; xn--0sh2466f.xn--3ed972m6o8a; ; ;  # ⒏𐹧.ⴣ྄彦
+8.xn--fo0d.xn--3ed15dt93o; 8.𐹧.Ⴣ\u0F84彦; [B1, V7]; 8.xn--fo0d.xn--3ed15dt93o; ; ;  # 8.𐹧.Ⴣ྄彦
+xn--0sh2466f.xn--3ed15dt93o; ⒏𐹧.Ⴣ\u0F84彦; [B1, V7]; xn--0sh2466f.xn--3ed15dt93o; ; ;  # ⒏𐹧.Ⴣ྄彦
+-问񬰔⒛。\u0604-񜗉橬; -问񬰔⒛.\u0604-񜗉橬; [B1, V3, V7]; xn----hdpu849bhis3e.xn----ykc7228efm46d; ; ;  # -问⒛.-橬
+-问񬰔20.。\u0604-񜗉橬; -问񬰔20..\u0604-񜗉橬; [B1, V3, V7, X4_2]; xn---20-658jx1776d..xn----ykc7228efm46d; [B1, V3, V7, A4_2]; ;  # -问20..-橬
+xn---20-658jx1776d..xn----ykc7228efm46d; -问񬰔20..\u0604-񜗉橬; [B1, V3, V7, X4_2]; xn---20-658jx1776d..xn----ykc7228efm46d; [B1, V3, V7, A4_2]; ;  # -问20..-橬
+xn----hdpu849bhis3e.xn----ykc7228efm46d; -问񬰔⒛.\u0604-񜗉橬; [B1, V3, V7]; xn----hdpu849bhis3e.xn----ykc7228efm46d; ; ;  # -问⒛.-橬
+\u1BACႬ\u200C\u0325。𝟸; \u1BACⴌ\u200C\u0325.2; [C1, V6]; xn--mta176j97cl2q.2; ; xn--mta176jjjm.2; [V6] # ᮬⴌ̥.2
+\u1BACႬ\u200C\u0325。2; \u1BACⴌ\u200C\u0325.2; [C1, V6]; xn--mta176j97cl2q.2; ; xn--mta176jjjm.2; [V6] # ᮬⴌ̥.2
+\u1BACⴌ\u200C\u0325。2; \u1BACⴌ\u200C\u0325.2; [C1, V6]; xn--mta176j97cl2q.2; ; xn--mta176jjjm.2; [V6] # ᮬⴌ̥.2
+xn--mta176jjjm.c; \u1BACⴌ\u0325.c; [V6]; xn--mta176jjjm.c; ; ;  # ᮬⴌ̥.c
+xn--mta176j97cl2q.c; \u1BACⴌ\u200C\u0325.c; [C1, V6]; xn--mta176j97cl2q.c; ; ;  # ᮬⴌ̥.c
+\u1BACⴌ\u200C\u0325。𝟸; \u1BACⴌ\u200C\u0325.2; [C1, V6]; xn--mta176j97cl2q.2; ; xn--mta176jjjm.2; [V6] # ᮬⴌ̥.2
+xn--mta930emri.c; \u1BACႬ\u0325.c; [V6, V7]; xn--mta930emri.c; ; ;  # ᮬႬ̥.c
+xn--mta930emribme.c; \u1BACႬ\u200C\u0325.c; [C1, V6, V7]; xn--mta930emribme.c; ; ;  # ᮬႬ̥.c
+?。\uA806\u0669󠒩; ?.\uA806\u0669󠒩; [B1, V6, V7, U1]; ?.xn--iib9583fusy0i; ; ;  # ?.꠆٩
+?.xn--iib9583fusy0i; ?.\uA806\u0669󠒩; [B1, V6, V7, U1]; ?.xn--iib9583fusy0i; ; ;  # ?.꠆٩
+󠄁\u035F⾶｡₇︒눇≮; \u035F飛.7︒눇≮; [V6, V7]; xn--9ua0567e.xn--7-ngou006d1ttc; ; ;  # ͟飛.7︒눇≮
+󠄁\u035F⾶｡₇︒눇<\u0338; \u035F飛.7︒눇≮; [V6, V7]; xn--9ua0567e.xn--7-ngou006d1ttc; ; ;  # ͟飛.7︒눇≮
+󠄁\u035F飛。7。눇≮; \u035F飛.7.눇≮; [V6]; xn--9ua0567e.7.xn--gdh6767c; ; ;  # ͟飛.7.눇≮
+󠄁\u035F飛。7。눇<\u0338; \u035F飛.7.눇≮; [V6]; xn--9ua0567e.7.xn--gdh6767c; ; ;  # ͟飛.7.눇≮
+xn--9ua0567e.7.xn--gdh6767c; \u035F飛.7.눇≮; [V6]; xn--9ua0567e.7.xn--gdh6767c; ; ;  # ͟飛.7.눇≮
+xn--9ua0567e.xn--7-ngou006d1ttc; \u035F飛.7︒눇≮; [V6, V7]; xn--9ua0567e.xn--7-ngou006d1ttc; ; ;  # ͟飛.7︒눇≮
+\u200C\uFE09𐹴\u200D．\u200C⿃; \u200C𐹴\u200D.\u200C鳥; [B1, C1, C2]; xn--0ugc6024p.xn--0ug1920c; ; xn--so0d.xn--6x6a; [B1] # 𐹴.鳥
+\u200C\uFE09𐹴\u200D.\u200C鳥; \u200C𐹴\u200D.\u200C鳥; [B1, C1, C2]; xn--0ugc6024p.xn--0ug1920c; ; xn--so0d.xn--6x6a; [B1] # 𐹴.鳥
+xn--so0d.xn--6x6a; 𐹴.鳥; [B1]; xn--so0d.xn--6x6a; ; ;  # 𐹴.鳥
+xn--0ugc6024p.xn--0ug1920c; \u200C𐹴\u200D.\u200C鳥; [B1, C1, C2]; xn--0ugc6024p.xn--0ug1920c; ; ;  # 𐹴.鳥
+🍮．\u200D󠗒𐦁𝨝; 🍮.\u200D󠗒𐦁𝨝; [B1, C2, V7]; xn--lj8h.xn--1ug6603gr1pfwq37h; ; xn--lj8h.xn--ln9ci476aqmr2g; [B1, V7] # 🍮.𐦁𝨝
+🍮.\u200D󠗒𐦁𝨝; ; [B1, C2, V7]; xn--lj8h.xn--1ug6603gr1pfwq37h; ; xn--lj8h.xn--ln9ci476aqmr2g; [B1, V7] # 🍮.𐦁𝨝
+xn--lj8h.xn--ln9ci476aqmr2g; 🍮.󠗒𐦁𝨝; [B1, V7]; xn--lj8h.xn--ln9ci476aqmr2g; ; ;  # 🍮.𐦁𝨝
+xn--lj8h.xn--1ug6603gr1pfwq37h; 🍮.\u200D󠗒𐦁𝨝; [B1, C2, V7]; xn--lj8h.xn--1ug6603gr1pfwq37h; ; ;  # 🍮.𐦁𝨝
+\u067D\u0943.𞤓\u200D; \u067D\u0943.𞤵\u200D; [B3, C2]; xn--2ib43l.xn--1ugy711p; ; xn--2ib43l.xn--te6h; [] # ٽृ.𞤵
+\u067D\u0943.𞤵\u200D; ; [B3, C2]; xn--2ib43l.xn--1ugy711p; ; xn--2ib43l.xn--te6h; [] # ٽृ.𞤵
+xn--2ib43l.xn--te6h; \u067D\u0943.𞤵; ; xn--2ib43l.xn--te6h; ; ;  # ٽृ.𞤵
+\u067D\u0943.𞤵; ; ; xn--2ib43l.xn--te6h; ; ;  # ٽृ.𞤵
+\u067D\u0943.𞤓; \u067D\u0943.𞤵; ; xn--2ib43l.xn--te6h; ; ;  # ٽृ.𞤵
+xn--2ib43l.xn--1ugy711p; \u067D\u0943.𞤵\u200D; [B3, C2]; xn--2ib43l.xn--1ugy711p; ; ;  # ٽृ.𞤵
+\u0664\u0A4D-．󥜽\u1039񦦐; \u0664\u0A4D-.󥜽\u1039񦦐; [B1, V3, V7]; xn----gqc711a.xn--9jd88234f3qm0b; ; ;  # ٤੍-.္
+\u0664\u0A4D-.󥜽\u1039񦦐; ; [B1, V3, V7]; xn----gqc711a.xn--9jd88234f3qm0b; ; ;  # ٤੍-.္
+xn----gqc711a.xn--9jd88234f3qm0b; \u0664\u0A4D-.󥜽\u1039񦦐; [B1, V3, V7]; xn----gqc711a.xn--9jd88234f3qm0b; ; ;  # ٤੍-.္
+4\u103A-𐹸｡\uAA29\u200C𐹴≮; 4\u103A-𐹸.\uAA29\u200C𐹴≮; [B1, C1, V6]; xn--4--e4j7831r.xn--0ugy6gjy5sl3ud; ; xn--4--e4j7831r.xn--gdh8754cz40c; [B1, V6] # 4်-𐹸.ꨩ𐹴≮
+4\u103A-𐹸｡\uAA29\u200C𐹴<\u0338; 4\u103A-𐹸.\uAA29\u200C𐹴≮; [B1, C1, V6]; xn--4--e4j7831r.xn--0ugy6gjy5sl3ud; ; xn--4--e4j7831r.xn--gdh8754cz40c; [B1, V6] # 4်-𐹸.ꨩ𐹴≮
+4\u103A-𐹸。\uAA29\u200C𐹴≮; 4\u103A-𐹸.\uAA29\u200C𐹴≮; [B1, C1, V6]; xn--4--e4j7831r.xn--0ugy6gjy5sl3ud; ; xn--4--e4j7831r.xn--gdh8754cz40c; [B1, V6] # 4်-𐹸.ꨩ𐹴≮
+4\u103A-𐹸。\uAA29\u200C𐹴<\u0338; 4\u103A-𐹸.\uAA29\u200C𐹴≮; [B1, C1, V6]; xn--4--e4j7831r.xn--0ugy6gjy5sl3ud; ; xn--4--e4j7831r.xn--gdh8754cz40c; [B1, V6] # 4်-𐹸.ꨩ𐹴≮
+xn--4--e4j7831r.xn--gdh8754cz40c; 4\u103A-𐹸.\uAA29𐹴≮; [B1, V6]; xn--4--e4j7831r.xn--gdh8754cz40c; ; ;  # 4်-𐹸.ꨩ𐹴≮
+xn--4--e4j7831r.xn--0ugy6gjy5sl3ud; 4\u103A-𐹸.\uAA29\u200C𐹴≮; [B1, C1, V6]; xn--4--e4j7831r.xn--0ugy6gjy5sl3ud; ; ;  # 4်-𐹸.ꨩ𐹴≮
+\u200C。\uFFA0\u0F84\u0F96; \u200C.\u0F84\u0F96; [C1, V6]; xn--0ug.xn--3ed0b; ; .xn--3ed0b; [V6, A4_2] # .྄ྖ
+\u200C。\u1160\u0F84\u0F96; \u200C.\u0F84\u0F96; [C1, V6]; xn--0ug.xn--3ed0b; ; .xn--3ed0b; [V6, A4_2] # .྄ྖ
+.xn--3ed0b; .\u0F84\u0F96; [V6, X4_2]; .xn--3ed0b; [V6, A4_2]; ;  # .྄ྖ
+xn--0ug.xn--3ed0b; \u200C.\u0F84\u0F96; [C1, V6]; xn--0ug.xn--3ed0b; ; ;  # .྄ྖ
+.xn--3ed0b20h; .\u1160\u0F84\u0F96; [V7, X4_2]; .xn--3ed0b20h; [V7, A4_2]; ;  # .྄ྖ
+xn--0ug.xn--3ed0b20h; \u200C.\u1160\u0F84\u0F96; [C1, V7]; xn--0ug.xn--3ed0b20h; ; ;  # .྄ྖ
+.xn--3ed0by082k; .\uFFA0\u0F84\u0F96; [V7, X4_2]; .xn--3ed0by082k; [V7, A4_2]; ;  # .྄ྖ
+xn--0ug.xn--3ed0by082k; \u200C.\uFFA0\u0F84\u0F96; [C1, V7]; xn--0ug.xn--3ed0by082k; ; ;  # .྄ྖ
+≯򍘅．\u200D𐅼򲇛; ≯򍘅.\u200D𐅼򲇛; [C2, V7]; xn--hdh84488f.xn--1ug8099fbjp4e; ; xn--hdh84488f.xn--xy7cw2886b; [V7] # ≯.𐅼
+>\u0338򍘅．\u200D𐅼򲇛; ≯򍘅.\u200D𐅼򲇛; [C2, V7]; xn--hdh84488f.xn--1ug8099fbjp4e; ; xn--hdh84488f.xn--xy7cw2886b; [V7] # ≯.𐅼
+≯򍘅.\u200D𐅼򲇛; ; [C2, V7]; xn--hdh84488f.xn--1ug8099fbjp4e; ; xn--hdh84488f.xn--xy7cw2886b; [V7] # ≯.𐅼
+>\u0338򍘅.\u200D𐅼򲇛; ≯򍘅.\u200D𐅼򲇛; [C2, V7]; xn--hdh84488f.xn--1ug8099fbjp4e; ; xn--hdh84488f.xn--xy7cw2886b; [V7] # ≯.𐅼
+xn--hdh84488f.xn--xy7cw2886b; ≯򍘅.𐅼򲇛; [V7]; xn--hdh84488f.xn--xy7cw2886b; ; ;  # ≯.𐅼
+xn--hdh84488f.xn--1ug8099fbjp4e; ≯򍘅.\u200D𐅼򲇛; [C2, V7]; xn--hdh84488f.xn--1ug8099fbjp4e; ; ;  # ≯.𐅼
+\u0641ß𐰯｡𝟕𐫫; \u0641ß𐰯.7𐫫; [B1, B2]; xn--zca96ys96y.xn--7-mm5i; ; xn--ss-jvd2339x.xn--7-mm5i;  # فß𐰯.7𐫫
+\u0641ß𐰯。7𐫫; \u0641ß𐰯.7𐫫; [B1, B2]; xn--zca96ys96y.xn--7-mm5i; ; xn--ss-jvd2339x.xn--7-mm5i;  # فß𐰯.7𐫫
+\u0641SS𐰯。7𐫫; \u0641ss𐰯.7𐫫; [B1, B2]; xn--ss-jvd2339x.xn--7-mm5i; ; ;  # فss𐰯.7𐫫
+\u0641ss𐰯。7𐫫; \u0641ss𐰯.7𐫫; [B1, B2]; xn--ss-jvd2339x.xn--7-mm5i; ; ;  # فss𐰯.7𐫫
+xn--ss-jvd2339x.xn--7-mm5i; \u0641ss𐰯.7𐫫; [B1, B2]; xn--ss-jvd2339x.xn--7-mm5i; ; ;  # فss𐰯.7𐫫
+xn--zca96ys96y.xn--7-mm5i; \u0641ß𐰯.7𐫫; [B1, B2]; xn--zca96ys96y.xn--7-mm5i; ; ;  # فß𐰯.7𐫫
+\u0641SS𐰯｡𝟕𐫫; \u0641ss𐰯.7𐫫; [B1, B2]; xn--ss-jvd2339x.xn--7-mm5i; ; ;  # فss𐰯.7𐫫
+\u0641ss𐰯｡𝟕𐫫; \u0641ss𐰯.7𐫫; [B1, B2]; xn--ss-jvd2339x.xn--7-mm5i; ; ;  # فss𐰯.7𐫫
+\u0641Ss𐰯。7𐫫; \u0641ss𐰯.7𐫫; [B1, B2]; xn--ss-jvd2339x.xn--7-mm5i; ; ;  # فss𐰯.7𐫫
+\u0641Ss𐰯｡𝟕𐫫; \u0641ss𐰯.7𐫫; [B1, B2]; xn--ss-jvd2339x.xn--7-mm5i; ; ;  # فss𐰯.7𐫫
+ß\u07AC\u07A7\u08B1。𐭁􅮙𐹲; ß\u07AC\u07A7\u08B1.𐭁􅮙𐹲; [B2, B5, B6, V7]; xn--zca685aoa95h.xn--e09co8cr9861c; ; xn--ss-9qet02k.xn--e09co8cr9861c;  # ßެާࢱ.𐭁𐹲
+SS\u07AC\u07A7\u08B1。𐭁􅮙𐹲; ss\u07AC\u07A7\u08B1.𐭁􅮙𐹲; [B2, B5, B6, V7]; xn--ss-9qet02k.xn--e09co8cr9861c; ; ;  # ssެާࢱ.𐭁𐹲
+ss\u07AC\u07A7\u08B1。𐭁􅮙𐹲; ss\u07AC\u07A7\u08B1.𐭁􅮙𐹲; [B2, B5, B6, V7]; xn--ss-9qet02k.xn--e09co8cr9861c; ; ;  # ssެާࢱ.𐭁𐹲
+Ss\u07AC\u07A7\u08B1。𐭁􅮙𐹲; ss\u07AC\u07A7\u08B1.𐭁􅮙𐹲; [B2, B5, B6, V7]; xn--ss-9qet02k.xn--e09co8cr9861c; ; ;  # ssެާࢱ.𐭁𐹲
+xn--ss-9qet02k.xn--e09co8cr9861c; ss\u07AC\u07A7\u08B1.𐭁􅮙𐹲; [B2, B5, B6, V7]; xn--ss-9qet02k.xn--e09co8cr9861c; ; ;  # ssެާࢱ.𐭁𐹲
+xn--zca685aoa95h.xn--e09co8cr9861c; ß\u07AC\u07A7\u08B1.𐭁􅮙𐹲; [B2, B5, B6, V7]; xn--zca685aoa95h.xn--e09co8cr9861c; ; ;  # ßެާࢱ.𐭁𐹲
+-｡󠉗⒌𞯛; -.󠉗⒌𞯛; [B1, V3, V7]; -.xn--xsh6367n1bi3e; ; ;  # -.⒌
+-。󠉗5.𞯛; -.󠉗5.𞯛; [B1, V3, V7]; -.xn--5-zz21m.xn--6x6h; ; ;  # -.5.
+-.xn--5-zz21m.xn--6x6h; -.󠉗5.𞯛; [B1, V3, V7]; -.xn--5-zz21m.xn--6x6h; ; ;  # -.5.
+-.xn--xsh6367n1bi3e; -.󠉗⒌𞯛; [B1, V3, V7]; -.xn--xsh6367n1bi3e; ; ;  # -.⒌
+𼎏ς．-≮\uFCAB; 𼎏ς.-≮\u062E\u062C; [B1, V3, V7]; xn--3xa13520c.xn----9mcf1400a; ; xn--4xa92520c.xn----9mcf1400a;  # ς.-≮خج
+𼎏ς．-<\u0338\uFCAB; 𼎏ς.-≮\u062E\u062C; [B1, V3, V7]; xn--3xa13520c.xn----9mcf1400a; ; xn--4xa92520c.xn----9mcf1400a;  # ς.-≮خج
+𼎏ς.-≮\u062E\u062C; ; [B1, V3, V7]; xn--3xa13520c.xn----9mcf1400a; ; xn--4xa92520c.xn----9mcf1400a;  # ς.-≮خج
+𼎏ς.-<\u0338\u062E\u062C; 𼎏ς.-≮\u062E\u062C; [B1, V3, V7]; xn--3xa13520c.xn----9mcf1400a; ; xn--4xa92520c.xn----9mcf1400a;  # ς.-≮خج
+𼎏Σ.-<\u0338\u062E\u062C; 𼎏σ.-≮\u062E\u062C; [B1, V3, V7]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+𼎏Σ.-≮\u062E\u062C; 𼎏σ.-≮\u062E\u062C; [B1, V3, V7]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+𼎏σ.-≮\u062E\u062C; ; [B1, V3, V7]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+𼎏σ.-<\u0338\u062E\u062C; 𼎏σ.-≮\u062E\u062C; [B1, V3, V7]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+xn--4xa92520c.xn----9mcf1400a; 𼎏σ.-≮\u062E\u062C; [B1, V3, V7]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+xn--3xa13520c.xn----9mcf1400a; 𼎏ς.-≮\u062E\u062C; [B1, V3, V7]; xn--3xa13520c.xn----9mcf1400a; ; ;  # ς.-≮خج
+𼎏Σ．-<\u0338\uFCAB; 𼎏σ.-≮\u062E\u062C; [B1, V3, V7]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+𼎏Σ．-≮\uFCAB; 𼎏σ.-≮\u062E\u062C; [B1, V3, V7]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+𼎏σ．-≮\uFCAB; 𼎏σ.-≮\u062E\u062C; [B1, V3, V7]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+𼎏σ．-<\u0338\uFCAB; 𼎏σ.-≮\u062E\u062C; [B1, V3, V7]; xn--4xa92520c.xn----9mcf1400a; ; ;  # σ.-≮خج
+ꡗ\u08B8\u0719．񔤔󠛙\u0C4D\uFC3E; ꡗ\u08B8\u0719.񔤔󠛙\u0C4D\u0643\u064A; [B5, B6, V7]; xn--jnb34fs003a.xn--fhbo927bk128mpi24d; ; ;  # ꡗࢸܙ.్كي
+ꡗ\u08B8\u0719.񔤔󠛙\u0C4D\u0643\u064A; ; [B5, B6, V7]; xn--jnb34fs003a.xn--fhbo927bk128mpi24d; ; ;  # ꡗࢸܙ.్كي
+xn--jnb34fs003a.xn--fhbo927bk128mpi24d; ꡗ\u08B8\u0719.񔤔󠛙\u0C4D\u0643\u064A; [B5, B6, V7]; xn--jnb34fs003a.xn--fhbo927bk128mpi24d; ; ;  # ꡗࢸܙ.్كي
+𐠰\u08B7𞤌𐫭。𐋦\u17CD𝩃; 𐠰\u08B7𞤮𐫭.𐋦\u17CD𝩃; [B1]; xn--dzb5191kezbrw47a.xn--p4e3841jz9tf; ; ;  # 𐠰ࢷ𞤮𐫭.𐋦៍𝩃
+𐠰\u08B7𞤮𐫭。𐋦\u17CD𝩃; 𐠰\u08B7𞤮𐫭.𐋦\u17CD𝩃; [B1]; xn--dzb5191kezbrw47a.xn--p4e3841jz9tf; ; ;  # 𐠰ࢷ𞤮𐫭.𐋦៍𝩃
+xn--dzb5191kezbrw47a.xn--p4e3841jz9tf; 𐠰\u08B7𞤮𐫭.𐋦\u17CD𝩃; [B1]; xn--dzb5191kezbrw47a.xn--p4e3841jz9tf; ; ;  # 𐠰ࢷ𞤮𐫭.𐋦៍𝩃
+𐠰\u08B7𞤮𐫭.𐋦\u17CD𝩃; ; [B1]; xn--dzb5191kezbrw47a.xn--p4e3841jz9tf; ; ;  # 𐠰ࢷ𞤮𐫭.𐋦៍𝩃
+𐠰\u08B7𞤌𐫭.𐋦\u17CD𝩃; 𐠰\u08B7𞤮𐫭.𐋦\u17CD𝩃; [B1]; xn--dzb5191kezbrw47a.xn--p4e3841jz9tf; ; ;  # 𐠰ࢷ𞤮𐫭.𐋦៍𝩃
+₂㘷--。\u06D3\u200C𐫆𑖿; 2㘷--.\u06D3\u200C𐫆𑖿; [B1, C1, V2, V3]; xn--2---u58b.xn--jlb820ku99nbgj; ; xn--2---u58b.xn--jlb8024k14g; [B1, V2, V3] # 2㘷--.ۓ𐫆𑖿
+₂㘷--。\u06D2\u0654\u200C𐫆𑖿; 2㘷--.\u06D3\u200C𐫆𑖿; [B1, C1, V2, V3]; xn--2---u58b.xn--jlb820ku99nbgj; ; xn--2---u58b.xn--jlb8024k14g; [B1, V2, V3] # 2㘷--.ۓ𐫆𑖿
+2㘷--。\u06D3\u200C𐫆𑖿; 2㘷--.\u06D3\u200C𐫆𑖿; [B1, C1, V2, V3]; xn--2---u58b.xn--jlb820ku99nbgj; ; xn--2---u58b.xn--jlb8024k14g; [B1, V2, V3] # 2㘷--.ۓ𐫆𑖿
+2㘷--。\u06D2\u0654\u200C𐫆𑖿; 2㘷--.\u06D3\u200C𐫆𑖿; [B1, C1, V2, V3]; xn--2---u58b.xn--jlb820ku99nbgj; ; xn--2---u58b.xn--jlb8024k14g; [B1, V2, V3] # 2㘷--.ۓ𐫆𑖿
+xn--2---u58b.xn--jlb8024k14g; 2㘷--.\u06D3𐫆𑖿; [B1, V2, V3]; xn--2---u58b.xn--jlb8024k14g; ; ;  # 2㘷--.ۓ𐫆𑖿
+xn--2---u58b.xn--jlb820ku99nbgj; 2㘷--.\u06D3\u200C𐫆𑖿; [B1, C1, V2, V3]; xn--2---u58b.xn--jlb820ku99nbgj; ; ;  # 2㘷--.ۓ𐫆𑖿
+-𘊻．ᡮ\u062D-; -𘊻.ᡮ\u062D-; [B1, B5, B6, V3]; xn----bp5n.xn----bnc231l; ; ;  # -𘊻.ᡮح-
+-𘊻.ᡮ\u062D-; ; [B1, B5, B6, V3]; xn----bp5n.xn----bnc231l; ; ;  # -𘊻.ᡮح-
+xn----bp5n.xn----bnc231l; -𘊻.ᡮ\u062D-; [B1, B5, B6, V3]; xn----bp5n.xn----bnc231l; ; ;  # -𘊻.ᡮح-
+\u200C-ß｡ᢣ𐹭\u063F; \u200C-ß.ᢣ𐹭\u063F; [B1, B5, B6, C1]; xn----qfa550v.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ß.ᢣ𐹭ؿ
+\u200C-ß。ᢣ𐹭\u063F; \u200C-ß.ᢣ𐹭\u063F; [B1, B5, B6, C1]; xn----qfa550v.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ß.ᢣ𐹭ؿ
+\u200C-SS。ᢣ𐹭\u063F; \u200C-ss.ᢣ𐹭\u063F; [B1, B5, B6, C1]; xn---ss-8m0a.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ss.ᢣ𐹭ؿ
+\u200C-ss。ᢣ𐹭\u063F; \u200C-ss.ᢣ𐹭\u063F; [B1, B5, B6, C1]; xn---ss-8m0a.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ss.ᢣ𐹭ؿ
+\u200C-Ss。ᢣ𐹭\u063F; \u200C-ss.ᢣ𐹭\u063F; [B1, B5, B6, C1]; xn---ss-8m0a.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ss.ᢣ𐹭ؿ
+-ss.xn--bhb925glx3p; -ss.ᢣ𐹭\u063F; [B1, B5, B6, V3]; -ss.xn--bhb925glx3p; ; ;  # -ss.ᢣ𐹭ؿ
+xn---ss-8m0a.xn--bhb925glx3p; \u200C-ss.ᢣ𐹭\u063F; [B1, B5, B6, C1]; xn---ss-8m0a.xn--bhb925glx3p; ; ;  # -ss.ᢣ𐹭ؿ
+xn----qfa550v.xn--bhb925glx3p; \u200C-ß.ᢣ𐹭\u063F; [B1, B5, B6, C1]; xn----qfa550v.xn--bhb925glx3p; ; ;  # -ß.ᢣ𐹭ؿ
+\u200C-SS｡ᢣ𐹭\u063F; \u200C-ss.ᢣ𐹭\u063F; [B1, B5, B6, C1]; xn---ss-8m0a.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ss.ᢣ𐹭ؿ
+\u200C-ss｡ᢣ𐹭\u063F; \u200C-ss.ᢣ𐹭\u063F; [B1, B5, B6, C1]; xn---ss-8m0a.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ss.ᢣ𐹭ؿ
+\u200C-Ss｡ᢣ𐹭\u063F; \u200C-ss.ᢣ𐹭\u063F; [B1, B5, B6, C1]; xn---ss-8m0a.xn--bhb925glx3p; ; -ss.xn--bhb925glx3p; [B1, B5, B6, V3] # -ss.ᢣ𐹭ؿ
+꧐Ӏ\u1BAA\u08F6．눵; ꧐ӏ\u1BAA\u08F6.눵; ; xn--s5a04sn4u297k.xn--2e1b; ; ;  # ꧐ӏ᮪ࣶ.눵
+꧐Ӏ\u1BAA\u08F6．눵; ꧐ӏ\u1BAA\u08F6.눵; ; xn--s5a04sn4u297k.xn--2e1b; ; ;  # ꧐ӏ᮪ࣶ.눵
+꧐Ӏ\u1BAA\u08F6.눵; ꧐ӏ\u1BAA\u08F6.눵; ; xn--s5a04sn4u297k.xn--2e1b; ; ;  # ꧐ӏ᮪ࣶ.눵
+꧐Ӏ\u1BAA\u08F6.눵; ꧐ӏ\u1BAA\u08F6.눵; ; xn--s5a04sn4u297k.xn--2e1b; ; ;  # ꧐ӏ᮪ࣶ.눵
+꧐ӏ\u1BAA\u08F6.눵; ꧐ӏ\u1BAA\u08F6.눵; ; xn--s5a04sn4u297k.xn--2e1b; ; ;  # ꧐ӏ᮪ࣶ.눵
+꧐ӏ\u1BAA\u08F6.눵; ; ; xn--s5a04sn4u297k.xn--2e1b; ; ;  # ꧐ӏ᮪ࣶ.눵
+xn--s5a04sn4u297k.xn--2e1b; ꧐ӏ\u1BAA\u08F6.눵; ; xn--s5a04sn4u297k.xn--2e1b; ; ;  # ꧐ӏ᮪ࣶ.눵
+꧐ӏ\u1BAA\u08F6．눵; ꧐ӏ\u1BAA\u08F6.눵; ; xn--s5a04sn4u297k.xn--2e1b; ; ;  # ꧐ӏ᮪ࣶ.눵
+꧐ӏ\u1BAA\u08F6．눵; ꧐ӏ\u1BAA\u08F6.눵; ; xn--s5a04sn4u297k.xn--2e1b; ; ;  # ꧐ӏ᮪ࣶ.눵
+xn--d5a07sn4u297k.xn--2e1b; ꧐Ӏ\u1BAA\u08F6.눵; [V7]; xn--d5a07sn4u297k.xn--2e1b; ; ;  # ꧐Ӏ᮪ࣶ.눵
+\uA8EA｡𖄿𑆾󠇗; \uA8EA.𖄿𑆾; [V6, V7]; xn--3g9a.xn--ud1dz07k; ; ;  # ꣪.𑆾
+\uA8EA。𖄿𑆾󠇗; \uA8EA.𖄿𑆾; [V6, V7]; xn--3g9a.xn--ud1dz07k; ; ;  # ꣪.𑆾
+xn--3g9a.xn--ud1dz07k; \uA8EA.𖄿𑆾; [V6, V7]; xn--3g9a.xn--ud1dz07k; ; ;  # ꣪.𑆾
+󇓓𑚳。񐷿≯⾇; 󇓓𑚳.񐷿≯舛; [V7]; xn--3e2d79770c.xn--hdh0088abyy1c; ; ;  # 𑚳.≯舛
+󇓓𑚳。񐷿>\u0338⾇; 󇓓𑚳.񐷿≯舛; [V7]; xn--3e2d79770c.xn--hdh0088abyy1c; ; ;  # 𑚳.≯舛
+󇓓𑚳。񐷿≯舛; 󇓓𑚳.񐷿≯舛; [V7]; xn--3e2d79770c.xn--hdh0088abyy1c; ; ;  # 𑚳.≯舛
+󇓓𑚳。񐷿>\u0338舛; 󇓓𑚳.񐷿≯舛; [V7]; xn--3e2d79770c.xn--hdh0088abyy1c; ; ;  # 𑚳.≯舛
+xn--3e2d79770c.xn--hdh0088abyy1c; 󇓓𑚳.񐷿≯舛; [V7]; xn--3e2d79770c.xn--hdh0088abyy1c; ; ;  # 𑚳.≯舛
+𐫇\u0661\u200C．\u200D\u200C; 𐫇\u0661\u200C.\u200D\u200C; [B1, B3, C1, C2]; xn--9hb652kv99n.xn--0ugb; ; xn--9hb7344k.; [A4_2] # 𐫇١.
+𐫇\u0661\u200C.\u200D\u200C; ; [B1, B3, C1, C2]; xn--9hb652kv99n.xn--0ugb; ; xn--9hb7344k.; [A4_2] # 𐫇١.
+xn--9hb7344k.; 𐫇\u0661.; ; xn--9hb7344k.; [A4_2]; ;  # 𐫇١.
+𐫇\u0661.; ; ; xn--9hb7344k.; [A4_2]; ;  # 𐫇١.
+xn--9hb652kv99n.xn--0ugb; 𐫇\u0661\u200C.\u200D\u200C; [B1, B3, C1, C2]; xn--9hb652kv99n.xn--0ugb; ; ;  # 𐫇١.
+񡅈砪≯ᢑ｡≯𝩚򓴔\u200C; 񡅈砪≯ᢑ.≯𝩚򓴔\u200C; [C1, V7]; xn--bbf561cf95e57y3e.xn--0ugz6gc910ejro8c; ; xn--bbf561cf95e57y3e.xn--hdh0834o7mj6b; [V7] # 砪≯ᢑ.≯𝩚
+񡅈砪>\u0338ᢑ｡>\u0338𝩚򓴔\u200C; 񡅈砪≯ᢑ.≯𝩚򓴔\u200C; [C1, V7]; xn--bbf561cf95e57y3e.xn--0ugz6gc910ejro8c; ; xn--bbf561cf95e57y3e.xn--hdh0834o7mj6b; [V7] # 砪≯ᢑ.≯𝩚
+񡅈砪≯ᢑ。≯𝩚򓴔\u200C; 񡅈砪≯ᢑ.≯𝩚򓴔\u200C; [C1, V7]; xn--bbf561cf95e57y3e.xn--0ugz6gc910ejro8c; ; xn--bbf561cf95e57y3e.xn--hdh0834o7mj6b; [V7] # 砪≯ᢑ.≯𝩚
+񡅈砪>\u0338ᢑ。>\u0338𝩚򓴔\u200C; 񡅈砪≯ᢑ.≯𝩚򓴔\u200C; [C1, V7]; xn--bbf561cf95e57y3e.xn--0ugz6gc910ejro8c; ; xn--bbf561cf95e57y3e.xn--hdh0834o7mj6b; [V7] # 砪≯ᢑ.≯𝩚
+xn--bbf561cf95e57y3e.xn--hdh0834o7mj6b; 񡅈砪≯ᢑ.≯𝩚򓴔; [V7]; xn--bbf561cf95e57y3e.xn--hdh0834o7mj6b; ; ;  # 砪≯ᢑ.≯𝩚
+xn--bbf561cf95e57y3e.xn--0ugz6gc910ejro8c; 񡅈砪≯ᢑ.≯𝩚򓴔\u200C; [C1, V7]; xn--bbf561cf95e57y3e.xn--0ugz6gc910ejro8c; ; ;  # 砪≯ᢑ.≯𝩚
+Ⴥ.𑄳㊸; ⴥ.𑄳43; [V6]; xn--tlj.xn--43-274o; ; ;  # ⴥ.𑄳43
+Ⴥ.𑄳43; ⴥ.𑄳43; [V6]; xn--tlj.xn--43-274o; ; ;  # ⴥ.𑄳43
+ⴥ.𑄳43; ; [V6]; xn--tlj.xn--43-274o; ; ;  # ⴥ.𑄳43
+xn--tlj.xn--43-274o; ⴥ.𑄳43; [V6]; xn--tlj.xn--43-274o; ; ;  # ⴥ.𑄳43
+ⴥ.𑄳㊸; ⴥ.𑄳43; [V6]; xn--tlj.xn--43-274o; ; ;  # ⴥ.𑄳43
+xn--9nd.xn--43-274o; Ⴥ.𑄳43; [V6, V7]; xn--9nd.xn--43-274o; ; ;  # Ⴥ.𑄳43
+𝟎\u0663。Ⴒᡇ\u08F2𐹠; 0\u0663.ⴒᡇ\u08F2𐹠; [B1, B5, B6]; xn--0-fqc.xn--10b369eivp359r; ; ;  # 0٣.ⴒᡇࣲ𐹠
+0\u0663。Ⴒᡇ\u08F2𐹠; 0\u0663.ⴒᡇ\u08F2𐹠; [B1, B5, B6]; xn--0-fqc.xn--10b369eivp359r; ; ;  # 0٣.ⴒᡇࣲ𐹠
+0\u0663。ⴒᡇ\u08F2𐹠; 0\u0663.ⴒᡇ\u08F2𐹠; [B1, B5, B6]; xn--0-fqc.xn--10b369eivp359r; ; ;  # 0٣.ⴒᡇࣲ𐹠
+xn--0-fqc.xn--10b369eivp359r; 0\u0663.ⴒᡇ\u08F2𐹠; [B1, B5, B6]; xn--0-fqc.xn--10b369eivp359r; ; ;  # 0٣.ⴒᡇࣲ𐹠
+𝟎\u0663。ⴒᡇ\u08F2𐹠; 0\u0663.ⴒᡇ\u08F2𐹠; [B1, B5, B6]; xn--0-fqc.xn--10b369eivp359r; ; ;  # 0٣.ⴒᡇࣲ𐹠
+xn--0-fqc.xn--10b180bnwgfy0z; 0\u0663.Ⴒᡇ\u08F2𐹠; [B1, B5, B6, V7]; xn--0-fqc.xn--10b180bnwgfy0z; ; ;  # 0٣.Ⴒᡇࣲ𐹠
+񗪨󠄉\uFFA0\u0FB7.񸞰\uA953; 񗪨\u0FB7.񸞰\uA953; [V7]; xn--kgd72212e.xn--3j9au7544a; ; ;  # ྷ.꥓
+񗪨󠄉\u1160\u0FB7.񸞰\uA953; 񗪨\u0FB7.񸞰\uA953; [V7]; xn--kgd72212e.xn--3j9au7544a; ; ;  # ྷ.꥓
+xn--kgd72212e.xn--3j9au7544a; 񗪨\u0FB7.񸞰\uA953; [V7]; xn--kgd72212e.xn--3j9au7544a; ; ;  # ྷ.꥓
+xn--kgd36f9z57y.xn--3j9au7544a; 񗪨\u1160\u0FB7.񸞰\uA953; [V7]; xn--kgd36f9z57y.xn--3j9au7544a; ; ;  # ྷ.꥓
+xn--kgd7493jee34a.xn--3j9au7544a; 񗪨\uFFA0\u0FB7.񸞰\uA953; [V7]; xn--kgd7493jee34a.xn--3j9au7544a; ; ;  # ྷ.꥓
+\u0618.۳\u200C\uA953; ; [C1, V6]; xn--6fb.xn--gmb469jjf1h; ; xn--6fb.xn--gmb0524f; [V6] # ؘ.۳꥓
+xn--6fb.xn--gmb0524f; \u0618.۳\uA953; [V6]; xn--6fb.xn--gmb0524f; ; ;  # ؘ.۳꥓
+xn--6fb.xn--gmb469jjf1h; \u0618.۳\u200C\uA953; [C1, V6]; xn--6fb.xn--gmb469jjf1h; ; ;  # ؘ.۳꥓
+ᡌ．︒ᢑ; ᡌ.︒ᢑ; [V7]; xn--c8e.xn--bbf9168i; ; ;  # ᡌ.︒ᢑ
+ᡌ.。ᢑ; ᡌ..ᢑ; [X4_2]; xn--c8e..xn--bbf; [A4_2]; ;  # ᡌ..ᢑ
+xn--c8e..xn--bbf; ᡌ..ᢑ; [X4_2]; xn--c8e..xn--bbf; [A4_2]; ;  # ᡌ..ᢑ
+xn--c8e.xn--bbf9168i; ᡌ.︒ᢑ; [V7]; xn--c8e.xn--bbf9168i; ; ;  # ᡌ.︒ᢑ
+𑋪\u1073｡𞽧; 𑋪\u1073.𞽧; [B1, V6, V7]; xn--xld7443k.xn--4o7h; ; ;  # 𑋪ၳ.
+𑋪\u1073。𞽧; 𑋪\u1073.𞽧; [B1, V6, V7]; xn--xld7443k.xn--4o7h; ; ;  # 𑋪ၳ.
+xn--xld7443k.xn--4o7h; 𑋪\u1073.𞽧; [B1, V6, V7]; xn--xld7443k.xn--4o7h; ; ;  # 𑋪ၳ.
+𞷏。ᠢ򓘆; 𞷏.ᠢ򓘆; [V7]; xn--hd7h.xn--46e66060j; ; ;  # .ᠢ
+xn--hd7h.xn--46e66060j; 𞷏.ᠢ򓘆; [V7]; xn--hd7h.xn--46e66060j; ; ;  # .ᠢ
+𑄳㴼．\u200C𐹡\u20EB񫺦; 𑄳㴼.\u200C𐹡\u20EB񫺦; [B1, C1, V6, V7]; xn--iym9428c.xn--0ug46a7218cllv0c; ; xn--iym9428c.xn--e1g3464g08p3b; [B1, V6, V7] # 𑄳㴼.𐹡⃫
+𑄳㴼.\u200C𐹡\u20EB񫺦; ; [B1, C1, V6, V7]; xn--iym9428c.xn--0ug46a7218cllv0c; ; xn--iym9428c.xn--e1g3464g08p3b; [B1, V6, V7] # 𑄳㴼.𐹡⃫
+xn--iym9428c.xn--e1g3464g08p3b; 𑄳㴼.𐹡\u20EB񫺦; [B1, V6, V7]; xn--iym9428c.xn--e1g3464g08p3b; ; ;  # 𑄳㴼.𐹡⃫
+xn--iym9428c.xn--0ug46a7218cllv0c; 𑄳㴼.\u200C𐹡\u20EB񫺦; [B1, C1, V6, V7]; xn--iym9428c.xn--0ug46a7218cllv0c; ; ;  # 𑄳㴼.𐹡⃫
+񠻟𐹳𑈯｡\u031D; 񠻟𐹳𑈯.\u031D; [B1, B5, B6, V6, V7]; xn--ro0dw7dey96m.xn--eta; ; ;  # 𐹳𑈯.̝
+񠻟𐹳𑈯。\u031D; 񠻟𐹳𑈯.\u031D; [B1, B5, B6, V6, V7]; xn--ro0dw7dey96m.xn--eta; ; ;  # 𐹳𑈯.̝
+xn--ro0dw7dey96m.xn--eta; 񠻟𐹳𑈯.\u031D; [B1, B5, B6, V6, V7]; xn--ro0dw7dey96m.xn--eta; ; ;  # 𐹳𑈯.̝
+ᢊ뾜󠱴𑚶。\u089D𐹥; ᢊ뾜󠱴𑚶.\u089D𐹥; [B1, V6, V7]; xn--39e4566fjv8bwmt6n.xn--myb6415k; ; ;  # ᢊ뾜𑚶.࢝𐹥
+ᢊ뾜󠱴𑚶。\u089D𐹥; ᢊ뾜󠱴𑚶.\u089D𐹥; [B1, V6, V7]; xn--39e4566fjv8bwmt6n.xn--myb6415k; ; ;  # ᢊ뾜𑚶.࢝𐹥
+xn--39e4566fjv8bwmt6n.xn--myb6415k; ᢊ뾜󠱴𑚶.\u089D𐹥; [B1, V6, V7]; xn--39e4566fjv8bwmt6n.xn--myb6415k; ; ;  # ᢊ뾜𑚶.࢝𐹥
+𐹥≠｡𐋲󠧠\u200C; 𐹥≠.𐋲󠧠\u200C; [B1, C1, V7]; xn--1ch6704g.xn--0ug3840g51u4g; ; xn--1ch6704g.xn--m97cw2999c; [B1, V7] # 𐹥≠.𐋲
+𐹥=\u0338｡𐋲󠧠\u200C; 𐹥≠.𐋲󠧠\u200C; [B1, C1, V7]; xn--1ch6704g.xn--0ug3840g51u4g; ; xn--1ch6704g.xn--m97cw2999c; [B1, V7] # 𐹥≠.𐋲
+𐹥≠。𐋲󠧠\u200C; 𐹥≠.𐋲󠧠\u200C; [B1, C1, V7]; xn--1ch6704g.xn--0ug3840g51u4g; ; xn--1ch6704g.xn--m97cw2999c; [B1, V7] # 𐹥≠.𐋲
+𐹥=\u0338。𐋲󠧠\u200C; 𐹥≠.𐋲󠧠\u200C; [B1, C1, V7]; xn--1ch6704g.xn--0ug3840g51u4g; ; xn--1ch6704g.xn--m97cw2999c; [B1, V7] # 𐹥≠.𐋲
+xn--1ch6704g.xn--m97cw2999c; 𐹥≠.𐋲󠧠; [B1, V7]; xn--1ch6704g.xn--m97cw2999c; ; ;  # 𐹥≠.𐋲
+xn--1ch6704g.xn--0ug3840g51u4g; 𐹥≠.𐋲󠧠\u200C; [B1, C1, V7]; xn--1ch6704g.xn--0ug3840g51u4g; ; ;  # 𐹥≠.𐋲
+\u115F񙯠\u094D．\u200D\uA953𐪤; 񙯠\u094D.\u200D\uA953𐪤; [B1, C2, V7]; xn--n3b91514e.xn--1ug6815co9wc; ; xn--n3b91514e.xn--3j9al95p; [B5, B6, V6, V7] # ्.꥓
+\u115F񙯠\u094D.\u200D\uA953𐪤; 񙯠\u094D.\u200D\uA953𐪤; [B1, C2, V7]; xn--n3b91514e.xn--1ug6815co9wc; ; xn--n3b91514e.xn--3j9al95p; [B5, B6, V6, V7] # ्.꥓
+xn--n3b91514e.xn--3j9al95p; 񙯠\u094D.\uA953𐪤; [B5, B6, V6, V7]; xn--n3b91514e.xn--3j9al95p; ; ;  # ्.꥓
+xn--n3b91514e.xn--1ug6815co9wc; 񙯠\u094D.\u200D\uA953𐪤; [B1, C2, V7]; xn--n3b91514e.xn--1ug6815co9wc; ; ;  # ्.꥓
+xn--n3b542bb085j.xn--3j9al95p; \u115F񙯠\u094D.\uA953𐪤; [B5, B6, V6, V7]; xn--n3b542bb085j.xn--3j9al95p; ; ;  # ्.꥓
+xn--n3b542bb085j.xn--1ug6815co9wc; \u115F񙯠\u094D.\u200D\uA953𐪤; [B1, C2, V7]; xn--n3b542bb085j.xn--1ug6815co9wc; ; ;  # ्.꥓
+򌋔󠆎󠆗𑲕。≮; 򌋔𑲕.≮; [V7]; xn--4m3dv4354a.xn--gdh; ; ;  # 𑲕.≮
+򌋔󠆎󠆗𑲕。<\u0338; 򌋔𑲕.≮; [V7]; xn--4m3dv4354a.xn--gdh; ; ;  # 𑲕.≮
+xn--4m3dv4354a.xn--gdh; 򌋔𑲕.≮; [V7]; xn--4m3dv4354a.xn--gdh; ; ;  # 𑲕.≮
+󠆦.\u08E3暀≠; .\u08E3暀≠; [V6, X4_2]; .xn--m0b461k3g2c; [V6, A4_2]; ;  # .ࣣ暀≠
+󠆦.\u08E3暀=\u0338; .\u08E3暀≠; [V6, X4_2]; .xn--m0b461k3g2c; [V6, A4_2]; ;  # .ࣣ暀≠
+.xn--m0b461k3g2c; .\u08E3暀≠; [V6, X4_2]; .xn--m0b461k3g2c; [V6, A4_2]; ;  # .ࣣ暀≠
+𐡤\uABED｡\uFD30򜖅\u1DF0; 𐡤\uABED.\u0634\u0645򜖅\u1DF0; [B2, B3, V7]; xn--429ak76o.xn--zgb8a701kox37t; ; ;  # 𐡤꯭.شمᷰ
+𐡤\uABED。\u0634\u0645򜖅\u1DF0; 𐡤\uABED.\u0634\u0645򜖅\u1DF0; [B2, B3, V7]; xn--429ak76o.xn--zgb8a701kox37t; ; ;  # 𐡤꯭.شمᷰ
+xn--429ak76o.xn--zgb8a701kox37t; 𐡤\uABED.\u0634\u0645򜖅\u1DF0; [B2, B3, V7]; xn--429ak76o.xn--zgb8a701kox37t; ; ;  # 𐡤꯭.شمᷰ
+𝉃\u200D⒈｡Ⴌ𞱓; 𝉃\u200D⒈.ⴌ𞱓; [B1, B5, B6, C2, V6, V7]; xn--1ug68oq348b.xn--3kj4524l; ; xn--tshz828m.xn--3kj4524l; [B1, B5, B6, V6, V7] # 𝉃⒈.ⴌ
+𝉃\u200D1.。Ⴌ𞱓; 𝉃\u200D1..ⴌ𞱓; [B1, B5, B6, C2, V6, V7, X4_2]; xn--1-tgn9827q..xn--3kj4524l; [B1, B5, B6, C2, V6, V7, A4_2]; xn--1-px8q..xn--3kj4524l; [B1, B5, B6, V6, V7, A4_2] # 𝉃1..ⴌ
+𝉃\u200D1.。ⴌ𞱓; 𝉃\u200D1..ⴌ𞱓; [B1, B5, B6, C2, V6, V7, X4_2]; xn--1-tgn9827q..xn--3kj4524l; [B1, B5, B6, C2, V6, V7, A4_2]; xn--1-px8q..xn--3kj4524l; [B1, B5, B6, V6, V7, A4_2] # 𝉃1..ⴌ
+xn--1-px8q..xn--3kj4524l; 𝉃1..ⴌ𞱓; [B1, B5, B6, V6, V7, X4_2]; xn--1-px8q..xn--3kj4524l; [B1, B5, B6, V6, V7, A4_2]; ;  # 𝉃1..ⴌ
+xn--1-tgn9827q..xn--3kj4524l; 𝉃\u200D1..ⴌ𞱓; [B1, B5, B6, C2, V6, V7, X4_2]; xn--1-tgn9827q..xn--3kj4524l; [B1, B5, B6, C2, V6, V7, A4_2]; ;  # 𝉃1..ⴌ
+𝉃\u200D⒈｡ⴌ𞱓; 𝉃\u200D⒈.ⴌ𞱓; [B1, B5, B6, C2, V6, V7]; xn--1ug68oq348b.xn--3kj4524l; ; xn--tshz828m.xn--3kj4524l; [B1, B5, B6, V6, V7] # 𝉃⒈.ⴌ
+xn--tshz828m.xn--3kj4524l; 𝉃⒈.ⴌ𞱓; [B1, B5, B6, V6, V7]; xn--tshz828m.xn--3kj4524l; ; ;  # 𝉃⒈.ⴌ
+xn--1ug68oq348b.xn--3kj4524l; 𝉃\u200D⒈.ⴌ𞱓; [B1, B5, B6, C2, V6, V7]; xn--1ug68oq348b.xn--3kj4524l; ; ;  # 𝉃⒈.ⴌ
+xn--1-px8q..xn--knd8464v; 𝉃1..Ⴌ𞱓; [B1, B5, B6, V6, V7, X4_2]; xn--1-px8q..xn--knd8464v; [B1, B5, B6, V6, V7, A4_2]; ;  # 𝉃1..Ⴌ
+xn--1-tgn9827q..xn--knd8464v; 𝉃\u200D1..Ⴌ𞱓; [B1, B5, B6, C2, V6, V7, X4_2]; xn--1-tgn9827q..xn--knd8464v; [B1, B5, B6, C2, V6, V7, A4_2]; ;  # 𝉃1..Ⴌ
+xn--tshz828m.xn--knd8464v; 𝉃⒈.Ⴌ𞱓; [B1, B5, B6, V6, V7]; xn--tshz828m.xn--knd8464v; ; ;  # 𝉃⒈.Ⴌ
+xn--1ug68oq348b.xn--knd8464v; 𝉃\u200D⒈.Ⴌ𞱓; [B1, B5, B6, C2, V6, V7]; xn--1ug68oq348b.xn--knd8464v; ; ;  # 𝉃⒈.Ⴌ
+󠣙\u0A4D𱫘𞤸.ς񵯞􈰔; ; [B1, V7]; xn--ybc0236vjvxgt5q0g.xn--3xa03737giye6b; ; xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b;  # ੍𱫘𞤸.ς
+󠣙\u0A4D𱫘𞤖.Σ񵯞􈰔; 󠣙\u0A4D𱫘𞤸.σ񵯞􈰔; [B1, V7]; xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b; ; ;  # ੍𱫘𞤸.σ
+󠣙\u0A4D𱫘𞤸.σ񵯞􈰔; ; [B1, V7]; xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b; ; ;  # ੍𱫘𞤸.σ
+󠣙\u0A4D𱫘𞤖.σ񵯞􈰔; 󠣙\u0A4D𱫘𞤸.σ񵯞􈰔; [B1, V7]; xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b; ; ;  # ੍𱫘𞤸.σ
+xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b; 󠣙\u0A4D𱫘𞤸.σ񵯞􈰔; [B1, V7]; xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b; ; ;  # ੍𱫘𞤸.σ
+󠣙\u0A4D𱫘𞤖.ς񵯞􈰔; 󠣙\u0A4D𱫘𞤸.ς񵯞􈰔; [B1, V7]; xn--ybc0236vjvxgt5q0g.xn--3xa03737giye6b; ; xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b;  # ੍𱫘𞤸.ς
+xn--ybc0236vjvxgt5q0g.xn--3xa03737giye6b; 󠣙\u0A4D𱫘𞤸.ς񵯞􈰔; [B1, V7]; xn--ybc0236vjvxgt5q0g.xn--3xa03737giye6b; ; ;  # ੍𱫘𞤸.ς
+󠣙\u0A4D𱫘𞤸.Σ񵯞􈰔; 󠣙\u0A4D𱫘𞤸.σ񵯞􈰔; [B1, V7]; xn--ybc0236vjvxgt5q0g.xn--4xa82737giye6b; ; ;  # ੍𱫘𞤸.σ
+\u07D3。\u200C𐫀򞭱; \u07D3.\u200C𐫀򞭱; [B1, C1, V7]; xn--usb.xn--0ug9553gm3v5d; ; xn--usb.xn--pw9ci1099a; [B2, B3, V7] # ߓ.𐫀
+xn--usb.xn--pw9ci1099a; \u07D3.𐫀򞭱; [B2, B3, V7]; xn--usb.xn--pw9ci1099a; ; ;  # ߓ.𐫀
+xn--usb.xn--0ug9553gm3v5d; \u07D3.\u200C𐫀򞭱; [B1, C1, V7]; xn--usb.xn--0ug9553gm3v5d; ; ;  # ߓ.𐫀
+\u1C2E𞀝.\u05A6ꡟ𞤕󠆖; \u1C2E𞀝.\u05A6ꡟ𞤷; [B1, V6]; xn--q1f4493q.xn--xcb8244fifvj; ; ;  # ᰮ𞀝.֦ꡟ𞤷
+\u1C2E𞀝.\u05A6ꡟ𞤷󠆖; \u1C2E𞀝.\u05A6ꡟ𞤷; [B1, V6]; xn--q1f4493q.xn--xcb8244fifvj; ; ;  # ᰮ𞀝.֦ꡟ𞤷
+xn--q1f4493q.xn--xcb8244fifvj; \u1C2E𞀝.\u05A6ꡟ𞤷; [B1, V6]; xn--q1f4493q.xn--xcb8244fifvj; ; ;  # ᰮ𞀝.֦ꡟ𞤷
+䂹󾖅𐋦．\u200D; 䂹󾖅𐋦.\u200D; [C2, V7]; xn--0on3543c5981i.xn--1ug; ; xn--0on3543c5981i.; [V7, A4_2] # 䂹𐋦.
+䂹󾖅𐋦.\u200D; ; [C2, V7]; xn--0on3543c5981i.xn--1ug; ; xn--0on3543c5981i.; [V7, A4_2] # 䂹𐋦.
+xn--0on3543c5981i.; 䂹󾖅𐋦.; [V7]; xn--0on3543c5981i.; [V7, A4_2]; ;  # 䂹𐋦.
+xn--0on3543c5981i.xn--1ug; 䂹󾖅𐋦.\u200D; [C2, V7]; xn--0on3543c5981i.xn--1ug; ; ;  # 䂹𐋦.
+\uA9C0\u200C𐹲\u200C｡\u0767🄉; \uA9C0\u200C𐹲\u200C.\u07678,; [B3, B5, B6, C1, V6, U1]; xn--0uga8686hdgvd.xn--8,-qle; ; xn--7m9an32q.xn--8,-qle; [B3, B5, B6, V6, U1] # ꧀𐹲.ݧ8,
+\uA9C0\u200C𐹲\u200C。\u07678,; \uA9C0\u200C𐹲\u200C.\u07678,; [B3, B5, B6, C1, V6, U1]; xn--0uga8686hdgvd.xn--8,-qle; ; xn--7m9an32q.xn--8,-qle; [B3, B5, B6, V6, U1] # ꧀𐹲.ݧ8,
+xn--7m9an32q.xn--8,-qle; \uA9C0𐹲.\u07678,; [B3, B5, B6, V6, U1]; xn--7m9an32q.xn--8,-qle; ; ;  # ꧀𐹲.ݧ8,
+xn--0uga8686hdgvd.xn--8,-qle; \uA9C0\u200C𐹲\u200C.\u07678,; [B3, B5, B6, C1, V6, U1]; xn--0uga8686hdgvd.xn--8,-qle; ; ;  # ꧀𐹲.ݧ8,
+xn--7m9an32q.xn--rpb6081w; \uA9C0𐹲.\u0767🄉; [B5, B6, V6, V7]; xn--7m9an32q.xn--rpb6081w; ; ;  # ꧀𐹲.ݧ🄉
+xn--0uga8686hdgvd.xn--rpb6081w; \uA9C0\u200C𐹲\u200C.\u0767🄉; [B5, B6, C1, V6, V7]; xn--0uga8686hdgvd.xn--rpb6081w; ; ;  # ꧀𐹲.ݧ🄉
+︒｡Ⴃ≯; ︒.ⴃ≯; [V7]; xn--y86c.xn--hdh782b; ; ;  # ︒.ⴃ≯
+︒｡Ⴃ>\u0338; ︒.ⴃ≯; [V7]; xn--y86c.xn--hdh782b; ; ;  # ︒.ⴃ≯
+。。Ⴃ≯; ..ⴃ≯; [X4_2]; ..xn--hdh782b; [A4_2]; ;  # ..ⴃ≯
+。。Ⴃ>\u0338; ..ⴃ≯; [X4_2]; ..xn--hdh782b; [A4_2]; ;  # ..ⴃ≯
+。。ⴃ>\u0338; ..ⴃ≯; [X4_2]; ..xn--hdh782b; [A4_2]; ;  # ..ⴃ≯
+。。ⴃ≯; ..ⴃ≯; [X4_2]; ..xn--hdh782b; [A4_2]; ;  # ..ⴃ≯
+..xn--hdh782b; ..ⴃ≯; [X4_2]; ..xn--hdh782b; [A4_2]; ;  # ..ⴃ≯
+︒｡ⴃ>\u0338; ︒.ⴃ≯; [V7]; xn--y86c.xn--hdh782b; ; ;  # ︒.ⴃ≯
+︒｡ⴃ≯; ︒.ⴃ≯; [V7]; xn--y86c.xn--hdh782b; ; ;  # ︒.ⴃ≯
+xn--y86c.xn--hdh782b; ︒.ⴃ≯; [V7]; xn--y86c.xn--hdh782b; ; ;  # ︒.ⴃ≯
+..xn--bnd622g; ..Ⴃ≯; [V7, X4_2]; ..xn--bnd622g; [V7, A4_2]; ;  # ..Ⴃ≯
+xn--y86c.xn--bnd622g; ︒.Ⴃ≯; [V7]; xn--y86c.xn--bnd622g; ; ;  # ︒.Ⴃ≯
+𐹮｡󠢼\u200D; 𐹮.󠢼\u200D; [B1, C2, V7]; xn--mo0d.xn--1ug18431l; ; xn--mo0d.xn--wy46e; [B1, V7] # 𐹮.
+𐹮。󠢼\u200D; 𐹮.󠢼\u200D; [B1, C2, V7]; xn--mo0d.xn--1ug18431l; ; xn--mo0d.xn--wy46e; [B1, V7] # 𐹮.
+xn--mo0d.xn--wy46e; 𐹮.󠢼; [B1, V7]; xn--mo0d.xn--wy46e; ; ;  # 𐹮.
+xn--mo0d.xn--1ug18431l; 𐹮.󠢼\u200D; [B1, C2, V7]; xn--mo0d.xn--1ug18431l; ; ;  # 𐹮.
+Ⴞ𐹨｡︒\u077D\u200DႯ; ⴞ𐹨.︒\u077D\u200Dⴏ; [B1, B5, B6, C2, V7]; xn--mlju223e.xn--eqb096jpgj9y7r; ; xn--mlju223e.xn--eqb053qjk7l; [B1, B5, B6, V7] # ⴞ𐹨.︒ݽⴏ
+Ⴞ𐹨。。\u077D\u200DႯ; ⴞ𐹨..\u077D\u200Dⴏ; [B2, B3, B5, B6, C2, X4_2]; xn--mlju223e..xn--eqb096jpgj; [B2, B3, B5, B6, C2, A4_2]; xn--mlju223e..xn--eqb053q; [B2, B3, B5, B6, A4_2] # ⴞ𐹨..ݽⴏ
+ⴞ𐹨。。\u077D\u200Dⴏ; ⴞ𐹨..\u077D\u200Dⴏ; [B2, B3, B5, B6, C2, X4_2]; xn--mlju223e..xn--eqb096jpgj; [B2, B3, B5, B6, C2, A4_2]; xn--mlju223e..xn--eqb053q; [B2, B3, B5, B6, A4_2] # ⴞ𐹨..ݽⴏ
+Ⴞ𐹨。。\u077D\u200Dⴏ; ⴞ𐹨..\u077D\u200Dⴏ; [B2, B3, B5, B6, C2, X4_2]; xn--mlju223e..xn--eqb096jpgj; [B2, B3, B5, B6, C2, A4_2]; xn--mlju223e..xn--eqb053q; [B2, B3, B5, B6, A4_2] # ⴞ𐹨..ݽⴏ
+xn--mlju223e..xn--eqb053q; ⴞ𐹨..\u077Dⴏ; [B2, B3, B5, B6, X4_2]; xn--mlju223e..xn--eqb053q; [B2, B3, B5, B6, A4_2]; ;  # ⴞ𐹨..ݽⴏ
+xn--mlju223e..xn--eqb096jpgj; ⴞ𐹨..\u077D\u200Dⴏ; [B2, B3, B5, B6, C2, X4_2]; xn--mlju223e..xn--eqb096jpgj; [B2, B3, B5, B6, C2, A4_2]; ;  # ⴞ𐹨..ݽⴏ
+ⴞ𐹨｡︒\u077D\u200Dⴏ; ⴞ𐹨.︒\u077D\u200Dⴏ; [B1, B5, B6, C2, V7]; xn--mlju223e.xn--eqb096jpgj9y7r; ; xn--mlju223e.xn--eqb053qjk7l; [B1, B5, B6, V7] # ⴞ𐹨.︒ݽⴏ
+Ⴞ𐹨｡︒\u077D\u200Dⴏ; ⴞ𐹨.︒\u077D\u200Dⴏ; [B1, B5, B6, C2, V7]; xn--mlju223e.xn--eqb096jpgj9y7r; ; xn--mlju223e.xn--eqb053qjk7l; [B1, B5, B6, V7] # ⴞ𐹨.︒ݽⴏ
+xn--mlju223e.xn--eqb053qjk7l; ⴞ𐹨.︒\u077Dⴏ; [B1, B5, B6, V7]; xn--mlju223e.xn--eqb053qjk7l; ; ;  # ⴞ𐹨.︒ݽⴏ
+xn--mlju223e.xn--eqb096jpgj9y7r; ⴞ𐹨.︒\u077D\u200Dⴏ; [B1, B5, B6, C2, V7]; xn--mlju223e.xn--eqb096jpgj9y7r; ; ;  # ⴞ𐹨.︒ݽⴏ
+xn--2nd0990k..xn--eqb053q; Ⴞ𐹨..\u077Dⴏ; [B2, B3, B5, B6, V7, X4_2]; xn--2nd0990k..xn--eqb053q; [B2, B3, B5, B6, V7, A4_2]; ;  # Ⴞ𐹨..ݽⴏ
+xn--2nd0990k..xn--eqb096jpgj; Ⴞ𐹨..\u077D\u200Dⴏ; [B2, B3, B5, B6, C2, V7, X4_2]; xn--2nd0990k..xn--eqb096jpgj; [B2, B3, B5, B6, C2, V7, A4_2]; ;  # Ⴞ𐹨..ݽⴏ
+xn--2nd0990k..xn--eqb228b; Ⴞ𐹨..\u077DႯ; [B2, B3, B5, B6, V7, X4_2]; xn--2nd0990k..xn--eqb228b; [B2, B3, B5, B6, V7, A4_2]; ;  # Ⴞ𐹨..ݽႯ
+xn--2nd0990k..xn--eqb228bgzm; Ⴞ𐹨..\u077D\u200DႯ; [B2, B3, B5, B6, C2, V7, X4_2]; xn--2nd0990k..xn--eqb228bgzm; [B2, B3, B5, B6, C2, V7, A4_2]; ;  # Ⴞ𐹨..ݽႯ
+xn--2nd0990k.xn--eqb053qjk7l; Ⴞ𐹨.︒\u077Dⴏ; [B1, B5, B6, V7]; xn--2nd0990k.xn--eqb053qjk7l; ; ;  # Ⴞ𐹨.︒ݽⴏ
+xn--2nd0990k.xn--eqb096jpgj9y7r; Ⴞ𐹨.︒\u077D\u200Dⴏ; [B1, B5, B6, C2, V7]; xn--2nd0990k.xn--eqb096jpgj9y7r; ; ;  # Ⴞ𐹨.︒ݽⴏ
+xn--2nd0990k.xn--eqb228b583r; Ⴞ𐹨.︒\u077DႯ; [B1, B5, B6, V7]; xn--2nd0990k.xn--eqb228b583r; ; ;  # Ⴞ𐹨.︒ݽႯ
+xn--2nd0990k.xn--eqb228bgzmvp0t; Ⴞ𐹨.︒\u077D\u200DႯ; [B1, B5, B6, C2, V7]; xn--2nd0990k.xn--eqb228bgzmvp0t; ; ;  # Ⴞ𐹨.︒ݽႯ
+\u200CႦ𝟹。-\u20D2-\u07D1; \u200Cⴆ3.-\u20D2-\u07D1; [B1, C1, V3]; xn--3-rgnv99c.xn-----vue617w; ; xn--3-lvs.xn-----vue617w; [B1, V3] # ⴆ3.-⃒-ߑ
+\u200CႦ3。-\u20D2-\u07D1; \u200Cⴆ3.-\u20D2-\u07D1; [B1, C1, V3]; xn--3-rgnv99c.xn-----vue617w; ; xn--3-lvs.xn-----vue617w; [B1, V3] # ⴆ3.-⃒-ߑ
+\u200Cⴆ3。-\u20D2-\u07D1; \u200Cⴆ3.-\u20D2-\u07D1; [B1, C1, V3]; xn--3-rgnv99c.xn-----vue617w; ; xn--3-lvs.xn-----vue617w; [B1, V3] # ⴆ3.-⃒-ߑ
+xn--3-lvs.xn-----vue617w; ⴆ3.-\u20D2-\u07D1; [B1, V3]; xn--3-lvs.xn-----vue617w; ; ;  # ⴆ3.-⃒-ߑ
+xn--3-rgnv99c.xn-----vue617w; \u200Cⴆ3.-\u20D2-\u07D1; [B1, C1, V3]; xn--3-rgnv99c.xn-----vue617w; ; ;  # ⴆ3.-⃒-ߑ
+\u200Cⴆ𝟹。-\u20D2-\u07D1; \u200Cⴆ3.-\u20D2-\u07D1; [B1, C1, V3]; xn--3-rgnv99c.xn-----vue617w; ; xn--3-lvs.xn-----vue617w; [B1, V3] # ⴆ3.-⃒-ߑ
+xn--3-i0g.xn-----vue617w; Ⴆ3.-\u20D2-\u07D1; [B1, V3, V7]; xn--3-i0g.xn-----vue617w; ; ;  # Ⴆ3.-⃒-ߑ
+xn--3-i0g939i.xn-----vue617w; \u200CႦ3.-\u20D2-\u07D1; [B1, C1, V3, V7]; xn--3-i0g939i.xn-----vue617w; ; ;  # Ⴆ3.-⃒-ߑ
+箃Ⴡ-󠁝｡≠-🤖; 箃ⴡ-󠁝.≠-🤖; [V7]; xn----4wsr321ay823p.xn----tfot873s; ; ;  # 箃ⴡ-.≠-🤖
+箃Ⴡ-󠁝｡=\u0338-🤖; 箃ⴡ-󠁝.≠-🤖; [V7]; xn----4wsr321ay823p.xn----tfot873s; ; ;  # 箃ⴡ-.≠-🤖
+箃Ⴡ-󠁝。≠-🤖; 箃ⴡ-󠁝.≠-🤖; [V7]; xn----4wsr321ay823p.xn----tfot873s; ; ;  # 箃ⴡ-.≠-🤖
+箃Ⴡ-󠁝。=\u0338-🤖; 箃ⴡ-󠁝.≠-🤖; [V7]; xn----4wsr321ay823p.xn----tfot873s; ; ;  # 箃ⴡ-.≠-🤖
+箃ⴡ-󠁝。=\u0338-🤖; 箃ⴡ-󠁝.≠-🤖; [V7]; xn----4wsr321ay823p.xn----tfot873s; ; ;  # 箃ⴡ-.≠-🤖
+箃ⴡ-󠁝。≠-🤖; 箃ⴡ-󠁝.≠-🤖; [V7]; xn----4wsr321ay823p.xn----tfot873s; ; ;  # 箃ⴡ-.≠-🤖
+xn----4wsr321ay823p.xn----tfot873s; 箃ⴡ-󠁝.≠-🤖; [V7]; xn----4wsr321ay823p.xn----tfot873s; ; ;  # 箃ⴡ-.≠-🤖
+箃ⴡ-󠁝｡=\u0338-🤖; 箃ⴡ-󠁝.≠-🤖; [V7]; xn----4wsr321ay823p.xn----tfot873s; ; ;  # 箃ⴡ-.≠-🤖
+箃ⴡ-󠁝｡≠-🤖; 箃ⴡ-󠁝.≠-🤖; [V7]; xn----4wsr321ay823p.xn----tfot873s; ; ;  # 箃ⴡ-.≠-🤖
+xn----11g3013fy8x5m.xn----tfot873s; 箃Ⴡ-󠁝.≠-🤖; [V7]; xn----11g3013fy8x5m.xn----tfot873s; ; ;  # 箃Ⴡ-.≠-🤖
+\u07E5.\u06B5; ; ; xn--dtb.xn--okb; ; ;  # ߥ.ڵ
+xn--dtb.xn--okb; \u07E5.\u06B5; ; xn--dtb.xn--okb; ; ;  # ߥ.ڵ
+\u200C\u200D.𞤿; ; [B1, C1, C2]; xn--0ugc.xn--3e6h; ; .xn--3e6h; [A4_2] # .𞤿
+\u200C\u200D.𞤝; \u200C\u200D.𞤿; [B1, C1, C2]; xn--0ugc.xn--3e6h; ; .xn--3e6h; [A4_2] # .𞤿
+.xn--3e6h; .𞤿; [X4_2]; .xn--3e6h; [A4_2]; ;  # .𞤿
+xn--0ugc.xn--3e6h; \u200C\u200D.𞤿; [B1, C1, C2]; xn--0ugc.xn--3e6h; ; ;  # .𞤿
+xn--3e6h; 𞤿; ; xn--3e6h; ; ;  # 𞤿
+𞤿; ; ; xn--3e6h; ; ;  # 𞤿
+𞤝; 𞤿; ; xn--3e6h; ; ;  # 𞤿
+🜑𐹧\u0639.ς𑍍蜹; ; [B1]; xn--4gb3736kk4zf.xn--3xa4248dy27d; ; xn--4gb3736kk4zf.xn--4xa2248dy27d;  # 🜑𐹧ع.ς𑍍蜹
+🜑𐹧\u0639.Σ𑍍蜹; 🜑𐹧\u0639.σ𑍍蜹; [B1]; xn--4gb3736kk4zf.xn--4xa2248dy27d; ; ;  # 🜑𐹧ع.σ𑍍蜹
+🜑𐹧\u0639.σ𑍍蜹; ; [B1]; xn--4gb3736kk4zf.xn--4xa2248dy27d; ; ;  # 🜑𐹧ع.σ𑍍蜹
+xn--4gb3736kk4zf.xn--4xa2248dy27d; 🜑𐹧\u0639.σ𑍍蜹; [B1]; xn--4gb3736kk4zf.xn--4xa2248dy27d; ; ;  # 🜑𐹧ع.σ𑍍蜹
+xn--4gb3736kk4zf.xn--3xa4248dy27d; 🜑𐹧\u0639.ς𑍍蜹; [B1]; xn--4gb3736kk4zf.xn--3xa4248dy27d; ; ;  # 🜑𐹧ع.ς𑍍蜹
+򫠐ス􆟤\u0669．󚃟; 򫠐ス􆟤\u0669.󚃟; [B5, B6, V7]; xn--iib777sp230oo708a.xn--7824e; ; ;  # ス٩.
+򫠐ス􆟤\u0669.󚃟; ; [B5, B6, V7]; xn--iib777sp230oo708a.xn--7824e; ; ;  # ス٩.
+xn--iib777sp230oo708a.xn--7824e; 򫠐ス􆟤\u0669.󚃟; [B5, B6, V7]; xn--iib777sp230oo708a.xn--7824e; ; ;  # ス٩.
+𝪣򕡝．\u059A?\u06C2; 𝪣򕡝.\u059A?\u06C2; [B1, V6, V7, U1]; xn--8c3hu7971a.xn--?-wec30g; ; ;  # 𝪣.֚?ۂ
+𝪣򕡝．\u059A?\u06C1\u0654; 𝪣򕡝.\u059A?\u06C2; [B1, V6, V7, U1]; xn--8c3hu7971a.xn--?-wec30g; ; ;  # 𝪣.֚?ۂ
+𝪣򕡝.\u059A?\u06C2; ; [B1, V6, V7, U1]; xn--8c3hu7971a.xn--?-wec30g; ; ;  # 𝪣.֚?ۂ
+𝪣򕡝.\u059A?\u06C1\u0654; 𝪣򕡝.\u059A?\u06C2; [B1, V6, V7, U1]; xn--8c3hu7971a.xn--?-wec30g; ; ;  # 𝪣.֚?ۂ
+xn--8c3hu7971a.xn--?-wec30g; 𝪣򕡝.\u059A?\u06C2; [B1, V6, V7, U1]; xn--8c3hu7971a.xn--?-wec30g; ; ;  # 𝪣.֚?ۂ
+xn--8c3hu7971a.\u059A?\u06C2; 𝪣򕡝.\u059A?\u06C2; [B1, V6, V7, U1]; xn--8c3hu7971a.xn--?-wec30g; ; ;  # 𝪣.֚?ۂ
+xn--8c3hu7971a.\u059A?\u06C1\u0654; 𝪣򕡝.\u059A?\u06C2; [B1, V6, V7, U1]; xn--8c3hu7971a.xn--?-wec30g; ; ;  # 𝪣.֚?ۂ
+XN--8C3HU7971A.\u059A?\u06C1\u0654; 𝪣򕡝.\u059A?\u06C2; [B1, V6, V7, U1]; xn--8c3hu7971a.xn--?-wec30g; ; ;  # 𝪣.֚?ۂ
+XN--8C3HU7971A.\u059A?\u06C2; 𝪣򕡝.\u059A?\u06C2; [B1, V6, V7, U1]; xn--8c3hu7971a.xn--?-wec30g; ; ;  # 𝪣.֚?ۂ
+Xn--8c3hu7971a.\u059A?\u06C2; 𝪣򕡝.\u059A?\u06C2; [B1, V6, V7, U1]; xn--8c3hu7971a.xn--?-wec30g; ; ;  # 𝪣.֚?ۂ
+Xn--8c3hu7971a.\u059A?\u06C1\u0654; 𝪣򕡝.\u059A?\u06C2; [B1, V6, V7, U1]; xn--8c3hu7971a.xn--?-wec30g; ; ;  # 𝪣.֚?ۂ
+\u0660򪓵\u200C。\u0757; \u0660򪓵\u200C.\u0757; [B1, C1, V7]; xn--8hb852ke991q.xn--bpb; ; xn--8hb82030l.xn--bpb; [B1, V7] # ٠.ݗ
+xn--8hb82030l.xn--bpb; \u0660򪓵.\u0757; [B1, V7]; xn--8hb82030l.xn--bpb; ; ;  # ٠.ݗ
+xn--8hb852ke991q.xn--bpb; \u0660򪓵\u200C.\u0757; [B1, C1, V7]; xn--8hb852ke991q.xn--bpb; ; ;  # ٠.ݗ
+\u103A\u200D\u200C。-\u200C; \u103A\u200D\u200C.-\u200C; [C1, V3, V6]; xn--bkd412fca.xn----sgn; ; xn--bkd.-; [V3, V6] # ်.-
+xn--bkd.-; \u103A.-; [V3, V6]; xn--bkd.-; ; ;  # ်.-
+xn--bkd412fca.xn----sgn; \u103A\u200D\u200C.-\u200C; [C1, V3, V6]; xn--bkd412fca.xn----sgn; ; ;  # ်.-
+︒｡\u1B44ᡉ; ︒.\u1B44ᡉ; [V6, V7]; xn--y86c.xn--87e93m; ; ;  # ︒.᭄ᡉ
+。。\u1B44ᡉ; ..\u1B44ᡉ; [V6, X4_2]; ..xn--87e93m; [V6, A4_2]; ;  # ..᭄ᡉ
+..xn--87e93m; ..\u1B44ᡉ; [V6, X4_2]; ..xn--87e93m; [V6, A4_2]; ;  # ..᭄ᡉ
+xn--y86c.xn--87e93m; ︒.\u1B44ᡉ; [V6, V7]; xn--y86c.xn--87e93m; ; ;  # ︒.᭄ᡉ
+\u0758ß。ጫᢊ\u0768𝟐; \u0758ß.ጫᢊ\u07682; [B2, B3, B5]; xn--zca724a.xn--2-b5c641gfmf; ; xn--ss-gke.xn--2-b5c641gfmf;  # ݘß.ጫᢊݨ2
+\u0758ß。ጫᢊ\u07682; \u0758ß.ጫᢊ\u07682; [B2, B3, B5]; xn--zca724a.xn--2-b5c641gfmf; ; xn--ss-gke.xn--2-b5c641gfmf;  # ݘß.ጫᢊݨ2
+\u0758SS。ጫᢊ\u07682; \u0758ss.ጫᢊ\u07682; [B2, B3, B5]; xn--ss-gke.xn--2-b5c641gfmf; ; ;  # ݘss.ጫᢊݨ2
+\u0758ss。ጫᢊ\u07682; \u0758ss.ጫᢊ\u07682; [B2, B3, B5]; xn--ss-gke.xn--2-b5c641gfmf; ; ;  # ݘss.ጫᢊݨ2
+xn--ss-gke.xn--2-b5c641gfmf; \u0758ss.ጫᢊ\u07682; [B2, B3, B5]; xn--ss-gke.xn--2-b5c641gfmf; ; ;  # ݘss.ጫᢊݨ2
+xn--zca724a.xn--2-b5c641gfmf; \u0758ß.ጫᢊ\u07682; [B2, B3, B5]; xn--zca724a.xn--2-b5c641gfmf; ; ;  # ݘß.ጫᢊݨ2
+\u0758SS。ጫᢊ\u0768𝟐; \u0758ss.ጫᢊ\u07682; [B2, B3, B5]; xn--ss-gke.xn--2-b5c641gfmf; ; ;  # ݘss.ጫᢊݨ2
+\u0758ss。ጫᢊ\u0768𝟐; \u0758ss.ጫᢊ\u07682; [B2, B3, B5]; xn--ss-gke.xn--2-b5c641gfmf; ; ;  # ݘss.ጫᢊݨ2
+\u0758Ss。ጫᢊ\u07682; \u0758ss.ጫᢊ\u07682; [B2, B3, B5]; xn--ss-gke.xn--2-b5c641gfmf; ; ;  # ݘss.ጫᢊݨ2
+\u0758Ss。ጫᢊ\u0768𝟐; \u0758ss.ጫᢊ\u07682; [B2, B3, B5]; xn--ss-gke.xn--2-b5c641gfmf; ; ;  # ݘss.ጫᢊݨ2
+\u07C3𞶇ᚲ.\u0902\u0353𝟚\u09CD; \u07C3𞶇ᚲ.\u0902\u03532\u09CD; [B1, B2, B3, V6, V7]; xn--esb067enh07a.xn--2-lgb874bjxa; ; ;  # ߃ᚲ.ं͓2্
+\u07C3𞶇ᚲ.\u0902\u03532\u09CD; ; [B1, B2, B3, V6, V7]; xn--esb067enh07a.xn--2-lgb874bjxa; ; ;  # ߃ᚲ.ं͓2্
+xn--esb067enh07a.xn--2-lgb874bjxa; \u07C3𞶇ᚲ.\u0902\u03532\u09CD; [B1, B2, B3, V6, V7]; xn--esb067enh07a.xn--2-lgb874bjxa; ; ;  # ߃ᚲ.ं͓2্
+-\u1BAB︒\u200D.񒶈񥹓; ; [C2, V3, V7]; xn----qmlv7tw180a.xn--x50zy803a; ; xn----qml1407i.xn--x50zy803a; [V3, V7] # -᮫︒.
+-\u1BAB。\u200D.񒶈񥹓; -\u1BAB.\u200D.񒶈񥹓; [C2, V3, V7]; xn----qml.xn--1ug.xn--x50zy803a; ; xn----qml..xn--x50zy803a; [V3, V7, A4_2] # -᮫..
+xn----qml..xn--x50zy803a; -\u1BAB..񒶈񥹓; [V3, V7, X4_2]; xn----qml..xn--x50zy803a; [V3, V7, A4_2]; ;  # -᮫..
+xn----qml.xn--1ug.xn--x50zy803a; -\u1BAB.\u200D.񒶈񥹓; [C2, V3, V7]; xn----qml.xn--1ug.xn--x50zy803a; ; ;  # -᮫..
+xn----qml1407i.xn--x50zy803a; -\u1BAB︒.񒶈񥹓; [V3, V7]; xn----qml1407i.xn--x50zy803a; ; ;  # -᮫︒.
+xn----qmlv7tw180a.xn--x50zy803a; -\u1BAB︒\u200D.񒶈񥹓; [C2, V3, V7]; xn----qmlv7tw180a.xn--x50zy803a; ; ;  # -᮫︒.
+󠦮.≯𞀆; ; [V7]; xn--t546e.xn--hdh5166o; ; ;  # .≯𞀆
+󠦮.>\u0338𞀆; 󠦮.≯𞀆; [V7]; xn--t546e.xn--hdh5166o; ; ;  # .≯𞀆
+xn--t546e.xn--hdh5166o; 󠦮.≯𞀆; [V7]; xn--t546e.xn--hdh5166o; ; ;  # .≯𞀆
+-𑄳󠊗𐹩。𞮱; -𑄳󠊗𐹩.𞮱; [B1, V3, V7]; xn----p26i72em2894c.xn--zw6h; ; ;  # -𑄳𐹩.
+xn----p26i72em2894c.xn--zw6h; -𑄳󠊗𐹩.𞮱; [B1, V3, V7]; xn----p26i72em2894c.xn--zw6h; ; ;  # -𑄳𐹩.
+\u06B9．ᡳ\u115F; \u06B9.ᡳ; ; xn--skb.xn--g9e; ; ;  # ڹ.ᡳ
+\u06B9.ᡳ\u115F; \u06B9.ᡳ; ; xn--skb.xn--g9e; ; ;  # ڹ.ᡳ
+xn--skb.xn--g9e; \u06B9.ᡳ; ; xn--skb.xn--g9e; ; ;  # ڹ.ᡳ
+\u06B9.ᡳ; ; ; xn--skb.xn--g9e; ; ;  # ڹ.ᡳ
+xn--skb.xn--osd737a; \u06B9.ᡳ\u115F; [V7]; xn--skb.xn--osd737a; ; ;  # ڹ.ᡳ
+㨛𘱎.︒𝟕\u0D01; 㨛𘱎.︒7\u0D01; [V7]; xn--mbm8237g.xn--7-7hf1526p; ; ;  # 㨛𘱎.︒7ഁ
+㨛𘱎.。7\u0D01; 㨛𘱎..7\u0D01; [X4_2]; xn--mbm8237g..xn--7-7hf; [A4_2]; ;  # 㨛𘱎..7ഁ
+xn--mbm8237g..xn--7-7hf; 㨛𘱎..7\u0D01; [X4_2]; xn--mbm8237g..xn--7-7hf; [A4_2]; ;  # 㨛𘱎..7ഁ
+xn--mbm8237g.xn--7-7hf1526p; 㨛𘱎.︒7\u0D01; [V7]; xn--mbm8237g.xn--7-7hf1526p; ; ;  # 㨛𘱎.︒7ഁ
+\u06DD𻱧-｡𞷁\u2064𞤣≮; \u06DD𻱧-.𞷁𞤣≮; [B1, B3, V3, V7]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+\u06DD𻱧-｡𞷁\u2064𞤣<\u0338; \u06DD𻱧-.𞷁𞤣≮; [B1, B3, V3, V7]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+\u06DD𻱧-。𞷁\u2064𞤣≮; \u06DD𻱧-.𞷁𞤣≮; [B1, B3, V3, V7]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+\u06DD𻱧-。𞷁\u2064𞤣<\u0338; \u06DD𻱧-.𞷁𞤣≮; [B1, B3, V3, V7]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+\u06DD𻱧-。𞷁\u2064𞤁<\u0338; \u06DD𻱧-.𞷁𞤣≮; [B1, B3, V3, V7]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+\u06DD𻱧-。𞷁\u2064𞤁≮; \u06DD𻱧-.𞷁𞤣≮; [B1, B3, V3, V7]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+xn----dxc06304e.xn--gdh5020pk5c; \u06DD𻱧-.𞷁𞤣≮; [B1, B3, V3, V7]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+\u06DD𻱧-｡𞷁\u2064𞤁<\u0338; \u06DD𻱧-.𞷁𞤣≮; [B1, B3, V3, V7]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+\u06DD𻱧-｡𞷁\u2064𞤁≮; \u06DD𻱧-.𞷁𞤣≮; [B1, B3, V3, V7]; xn----dxc06304e.xn--gdh5020pk5c; ; ;  # -.𞤣≮
+ß\u200C\uAAF6ᢥ．⊶ჁႶ; ß\u200C\uAAF6ᢥ.⊶ⴡⴖ; [C1]; xn--zca682johfi89m.xn--ifh802b6a; ; xn--ss-4epx629f.xn--ifh802b6a; [] # ß꫶ᢥ.⊶ⴡⴖ
+ß\u200C\uAAF6ᢥ.⊶ჁႶ; ß\u200C\uAAF6ᢥ.⊶ⴡⴖ; [C1]; xn--zca682johfi89m.xn--ifh802b6a; ; xn--ss-4epx629f.xn--ifh802b6a; [] # ß꫶ᢥ.⊶ⴡⴖ
+ß\u200C\uAAF6ᢥ.⊶ⴡⴖ; ; [C1]; xn--zca682johfi89m.xn--ifh802b6a; ; xn--ss-4epx629f.xn--ifh802b6a; [] # ß꫶ᢥ.⊶ⴡⴖ
+SS\u200C\uAAF6ᢥ.⊶ჁႶ; ss\u200C\uAAF6ᢥ.⊶ⴡⴖ; [C1]; xn--ss-4ep585bkm5p.xn--ifh802b6a; ; xn--ss-4epx629f.xn--ifh802b6a; [] # ss꫶ᢥ.⊶ⴡⴖ
+ss\u200C\uAAF6ᢥ.⊶ⴡⴖ; ; [C1]; xn--ss-4ep585bkm5p.xn--ifh802b6a; ; xn--ss-4epx629f.xn--ifh802b6a; [] # ss꫶ᢥ.⊶ⴡⴖ
+Ss\u200C\uAAF6ᢥ.⊶Ⴡⴖ; ss\u200C\uAAF6ᢥ.⊶ⴡⴖ; [C1]; xn--ss-4ep585bkm5p.xn--ifh802b6a; ; xn--ss-4epx629f.xn--ifh802b6a; [] # ss꫶ᢥ.⊶ⴡⴖ
+xn--ss-4epx629f.xn--ifh802b6a; ss\uAAF6ᢥ.⊶ⴡⴖ; ; xn--ss-4epx629f.xn--ifh802b6a; ; ;  # ss꫶ᢥ.⊶ⴡⴖ
+ss\uAAF6ᢥ.⊶ⴡⴖ; ; ; xn--ss-4epx629f.xn--ifh802b6a; ; ;  # ss꫶ᢥ.⊶ⴡⴖ
+SS\uAAF6ᢥ.⊶ჁႶ; ss\uAAF6ᢥ.⊶ⴡⴖ; ; xn--ss-4epx629f.xn--ifh802b6a; ; ;  # ss꫶ᢥ.⊶ⴡⴖ
+Ss\uAAF6ᢥ.⊶Ⴡⴖ; ss\uAAF6ᢥ.⊶ⴡⴖ; ; xn--ss-4epx629f.xn--ifh802b6a; ; ;  # ss꫶ᢥ.⊶ⴡⴖ
+xn--ss-4ep585bkm5p.xn--ifh802b6a; ss\u200C\uAAF6ᢥ.⊶ⴡⴖ; [C1]; xn--ss-4ep585bkm5p.xn--ifh802b6a; ; ;  # ss꫶ᢥ.⊶ⴡⴖ
+xn--zca682johfi89m.xn--ifh802b6a; ß\u200C\uAAF6ᢥ.⊶ⴡⴖ; [C1]; xn--zca682johfi89m.xn--ifh802b6a; ; ;  # ß꫶ᢥ.⊶ⴡⴖ
+ß\u200C\uAAF6ᢥ．⊶ⴡⴖ; ß\u200C\uAAF6ᢥ.⊶ⴡⴖ; [C1]; xn--zca682johfi89m.xn--ifh802b6a; ; xn--ss-4epx629f.xn--ifh802b6a; [] # ß꫶ᢥ.⊶ⴡⴖ
+SS\u200C\uAAF6ᢥ．⊶ჁႶ; ss\u200C\uAAF6ᢥ.⊶ⴡⴖ; [C1]; xn--ss-4ep585bkm5p.xn--ifh802b6a; ; xn--ss-4epx629f.xn--ifh802b6a; [] # ss꫶ᢥ.⊶ⴡⴖ
+ss\u200C\uAAF6ᢥ．⊶ⴡⴖ; ss\u200C\uAAF6ᢥ.⊶ⴡⴖ; [C1]; xn--ss-4ep585bkm5p.xn--ifh802b6a; ; xn--ss-4epx629f.xn--ifh802b6a; [] # ss꫶ᢥ.⊶ⴡⴖ
+Ss\u200C\uAAF6ᢥ．⊶Ⴡⴖ; ss\u200C\uAAF6ᢥ.⊶ⴡⴖ; [C1]; xn--ss-4ep585bkm5p.xn--ifh802b6a; ; xn--ss-4epx629f.xn--ifh802b6a; [] # ss꫶ᢥ.⊶ⴡⴖ
+xn--ss-4epx629f.xn--5nd703gyrh; ss\uAAF6ᢥ.⊶Ⴡⴖ; [V7]; xn--ss-4epx629f.xn--5nd703gyrh; ; ;  # ss꫶ᢥ.⊶Ⴡⴖ
+xn--ss-4ep585bkm5p.xn--5nd703gyrh; ss\u200C\uAAF6ᢥ.⊶Ⴡⴖ; [C1, V7]; xn--ss-4ep585bkm5p.xn--5nd703gyrh; ; ;  # ss꫶ᢥ.⊶Ⴡⴖ
+xn--ss-4epx629f.xn--undv409k; ss\uAAF6ᢥ.⊶ჁႶ; [V7]; xn--ss-4epx629f.xn--undv409k; ; ;  # ss꫶ᢥ.⊶ჁႶ
+xn--ss-4ep585bkm5p.xn--undv409k; ss\u200C\uAAF6ᢥ.⊶ჁႶ; [C1, V7]; xn--ss-4ep585bkm5p.xn--undv409k; ; ;  # ss꫶ᢥ.⊶ჁႶ
+xn--zca682johfi89m.xn--undv409k; ß\u200C\uAAF6ᢥ.⊶ჁႶ; [C1, V7]; xn--zca682johfi89m.xn--undv409k; ; ;  # ß꫶ᢥ.⊶ჁႶ
+\u200D。ς󠁉; \u200D.ς󠁉; [C2, V7]; xn--1ug.xn--3xa44344p; ; .xn--4xa24344p; [V7, A4_2] # .ς
+\u200D。Σ󠁉; \u200D.σ󠁉; [C2, V7]; xn--1ug.xn--4xa24344p; ; .xn--4xa24344p; [V7, A4_2] # .σ
+\u200D。σ󠁉; \u200D.σ󠁉; [C2, V7]; xn--1ug.xn--4xa24344p; ; .xn--4xa24344p; [V7, A4_2] # .σ
+.xn--4xa24344p; .σ󠁉; [V7, X4_2]; .xn--4xa24344p; [V7, A4_2]; ;  # .σ
+xn--1ug.xn--4xa24344p; \u200D.σ󠁉; [C2, V7]; xn--1ug.xn--4xa24344p; ; ;  # .σ
+xn--1ug.xn--3xa44344p; \u200D.ς󠁉; [C2, V7]; xn--1ug.xn--3xa44344p; ; ;  # .ς
+𞵑ß.\u0751\u200D𞤛-; 𞵑ß.\u0751\u200D𞤽-; [B2, B3, C2, V3, V7]; xn--zca5423w.xn----z3c011q9513b; ; xn--ss-2722a.xn----z3c03218a; [B2, B3, V3, V7] # ß.ݑ𞤽-
+𞵑ß.\u0751\u200D𞤽-; ; [B2, B3, C2, V3, V7]; xn--zca5423w.xn----z3c011q9513b; ; xn--ss-2722a.xn----z3c03218a; [B2, B3, V3, V7] # ß.ݑ𞤽-
+𞵑SS.\u0751\u200D𞤛-; 𞵑ss.\u0751\u200D𞤽-; [B2, B3, C2, V3, V7]; xn--ss-2722a.xn----z3c011q9513b; ; xn--ss-2722a.xn----z3c03218a; [B2, B3, V3, V7] # ss.ݑ𞤽-
+𞵑ss.\u0751\u200D𞤽-; ; [B2, B3, C2, V3, V7]; xn--ss-2722a.xn----z3c011q9513b; ; xn--ss-2722a.xn----z3c03218a; [B2, B3, V3, V7] # ss.ݑ𞤽-
+𞵑Ss.\u0751\u200D𞤽-; 𞵑ss.\u0751\u200D𞤽-; [B2, B3, C2, V3, V7]; xn--ss-2722a.xn----z3c011q9513b; ; xn--ss-2722a.xn----z3c03218a; [B2, B3, V3, V7] # ss.ݑ𞤽-
+xn--ss-2722a.xn----z3c03218a; 𞵑ss.\u0751𞤽-; [B2, B3, V3, V7]; xn--ss-2722a.xn----z3c03218a; ; ;  # ss.ݑ𞤽-
+xn--ss-2722a.xn----z3c011q9513b; 𞵑ss.\u0751\u200D𞤽-; [B2, B3, C2, V3, V7]; xn--ss-2722a.xn----z3c011q9513b; ; ;  # ss.ݑ𞤽-
+xn--zca5423w.xn----z3c011q9513b; 𞵑ß.\u0751\u200D𞤽-; [B2, B3, C2, V3, V7]; xn--zca5423w.xn----z3c011q9513b; ; ;  # ß.ݑ𞤽-
+𞵑ss.\u0751\u200D𞤛-; 𞵑ss.\u0751\u200D𞤽-; [B2, B3, C2, V3, V7]; xn--ss-2722a.xn----z3c011q9513b; ; xn--ss-2722a.xn----z3c03218a; [B2, B3, V3, V7] # ss.ݑ𞤽-
+𞵑Ss.\u0751\u200D𞤛-; 𞵑ss.\u0751\u200D𞤽-; [B2, B3, C2, V3, V7]; xn--ss-2722a.xn----z3c011q9513b; ; xn--ss-2722a.xn----z3c03218a; [B2, B3, V3, V7] # ss.ݑ𞤽-
+𑘽\u200D𞤧．𐹧󡦪-; 𑘽\u200D𞤧.𐹧󡦪-; [B1, C2, V3, V6, V7]; xn--1ugz808gdimf.xn----k26iq1483f; ; xn--qb2ds317a.xn----k26iq1483f; [B1, V3, V6, V7] # 𑘽𞤧.𐹧-
+𑘽\u200D𞤧.𐹧󡦪-; ; [B1, C2, V3, V6, V7]; xn--1ugz808gdimf.xn----k26iq1483f; ; xn--qb2ds317a.xn----k26iq1483f; [B1, V3, V6, V7] # 𑘽𞤧.𐹧-
+𑘽\u200D𞤅.𐹧󡦪-; 𑘽\u200D𞤧.𐹧󡦪-; [B1, C2, V3, V6, V7]; xn--1ugz808gdimf.xn----k26iq1483f; ; xn--qb2ds317a.xn----k26iq1483f; [B1, V3, V6, V7] # 𑘽𞤧.𐹧-
+xn--qb2ds317a.xn----k26iq1483f; 𑘽𞤧.𐹧󡦪-; [B1, V3, V6, V7]; xn--qb2ds317a.xn----k26iq1483f; ; ;  # 𑘽𞤧.𐹧-
+xn--1ugz808gdimf.xn----k26iq1483f; 𑘽\u200D𞤧.𐹧󡦪-; [B1, C2, V3, V6, V7]; xn--1ugz808gdimf.xn----k26iq1483f; ; ;  # 𑘽𞤧.𐹧-
+𑘽\u200D𞤅．𐹧󡦪-; 𑘽\u200D𞤧.𐹧󡦪-; [B1, C2, V3, V6, V7]; xn--1ugz808gdimf.xn----k26iq1483f; ; xn--qb2ds317a.xn----k26iq1483f; [B1, V3, V6, V7] # 𑘽𞤧.𐹧-
+⒒򨘙򳳠𑓀.-󞡊; ; [V3, V7]; xn--3shy698frsu9dt1me.xn----x310m; ; ;  # ⒒𑓀.-
+11.򨘙򳳠𑓀.-󞡊; ; [V3, V7]; 11.xn--uz1d59632bxujd.xn----x310m; ; ;  # 11.𑓀.-
+11.xn--uz1d59632bxujd.xn----x310m; 11.򨘙򳳠𑓀.-󞡊; [V3, V7]; 11.xn--uz1d59632bxujd.xn----x310m; ; ;  # 11.𑓀.-
+xn--3shy698frsu9dt1me.xn----x310m; ⒒򨘙򳳠𑓀.-󞡊; [V3, V7]; xn--3shy698frsu9dt1me.xn----x310m; ; ;  # ⒒𑓀.-
+-｡\u200D; -.\u200D; [C2, V3]; -.xn--1ug; ; -.; [V3, A4_2] # -.
+-。\u200D; -.\u200D; [C2, V3]; -.xn--1ug; ; -.; [V3, A4_2] # -.
+-.; ; [V3]; ; [V3, A4_2]; ;  # -.
+-.xn--1ug; -.\u200D; [C2, V3]; -.xn--1ug; ; ;  # -.
+≮ᡬ．ς¹-?; ≮ᡬ.ς1-?; [U1]; xn--88e732c.xn--1-?-lzc; ; xn--88e732c.xn--1-?-pzc;  # ≮ᡬ.ς1-?
+<\u0338ᡬ．ς¹-?; ≮ᡬ.ς1-?; [U1]; xn--88e732c.xn--1-?-lzc; ; xn--88e732c.xn--1-?-pzc;  # ≮ᡬ.ς1-?
+≮ᡬ.ς1-?; ; [U1]; xn--88e732c.xn--1-?-lzc; ; xn--88e732c.xn--1-?-pzc;  # ≮ᡬ.ς1-?
+<\u0338ᡬ.ς1-?; ≮ᡬ.ς1-?; [U1]; xn--88e732c.xn--1-?-lzc; ; xn--88e732c.xn--1-?-pzc;  # ≮ᡬ.ς1-?
+<\u0338ᡬ.Σ1-?; ≮ᡬ.σ1-?; [U1]; xn--88e732c.xn--1-?-pzc; ; ;  # ≮ᡬ.σ1-?
+≮ᡬ.Σ1-?; ≮ᡬ.σ1-?; [U1]; xn--88e732c.xn--1-?-pzc; ; ;  # ≮ᡬ.σ1-?
+≮ᡬ.σ1-?; ; [U1]; xn--88e732c.xn--1-?-pzc; ; ;  # ≮ᡬ.σ1-?
+<\u0338ᡬ.σ1-?; ≮ᡬ.σ1-?; [U1]; xn--88e732c.xn--1-?-pzc; ; ;  # ≮ᡬ.σ1-?
+xn--88e732c.xn--1-?-pzc; ≮ᡬ.σ1-?; [U1]; xn--88e732c.xn--1-?-pzc; ; ;  # ≮ᡬ.σ1-?
+xn--88e732c.xn--1-?-lzc; ≮ᡬ.ς1-?; [U1]; xn--88e732c.xn--1-?-lzc; ; ;  # ≮ᡬ.ς1-?
+<\u0338ᡬ．Σ¹-?; ≮ᡬ.σ1-?; [U1]; xn--88e732c.xn--1-?-pzc; ; ;  # ≮ᡬ.σ1-?
+≮ᡬ．Σ¹-?; ≮ᡬ.σ1-?; [U1]; xn--88e732c.xn--1-?-pzc; ; ;  # ≮ᡬ.σ1-?
+≮ᡬ．σ¹-?; ≮ᡬ.σ1-?; [U1]; xn--88e732c.xn--1-?-pzc; ; ;  # ≮ᡬ.σ1-?
+<\u0338ᡬ．σ¹-?; ≮ᡬ.σ1-?; [U1]; xn--88e732c.xn--1-?-pzc; ; ;  # ≮ᡬ.σ1-?
+xn--88e732c.σ1-?; ≮ᡬ.σ1-?; [U1]; xn--88e732c.xn--1-?-pzc; ; ;  # ≮ᡬ.σ1-?
+XN--88E732C.Σ1-?; ≮ᡬ.σ1-?; [U1]; xn--88e732c.xn--1-?-pzc; ; ;  # ≮ᡬ.σ1-?
+xn--88e732c.ς1-?; ≮ᡬ.ς1-?; [U1]; xn--88e732c.xn--1-?-lzc; ; xn--88e732c.xn--1-?-pzc;  # ≮ᡬ.ς1-?
+Xn--88e732c.ς1-?; ≮ᡬ.ς1-?; [U1]; xn--88e732c.xn--1-?-lzc; ; xn--88e732c.xn--1-?-pzc;  # ≮ᡬ.ς1-?
+Xn--88e732c.σ1-?; ≮ᡬ.σ1-?; [U1]; xn--88e732c.xn--1-?-pzc; ; ;  # ≮ᡬ.σ1-?
+ቬ򔠼񁗶｡𐨬𝟠; ቬ򔠼񁗶.𐨬8; [V7]; xn--d0d41273c887z.xn--8-ob5i; ; ;  # ቬ.𐨬8
+ቬ򔠼񁗶。𐨬8; ቬ򔠼񁗶.𐨬8; [V7]; xn--d0d41273c887z.xn--8-ob5i; ; ;  # ቬ.𐨬8
+xn--d0d41273c887z.xn--8-ob5i; ቬ򔠼񁗶.𐨬8; [V7]; xn--d0d41273c887z.xn--8-ob5i; ; ;  # ቬ.𐨬8
+𐱲。蔫\u0766; 𐱲.蔫\u0766; [B5, B6, V7]; xn--389c.xn--qpb7055d; ; ;  # .蔫ݦ
+xn--389c.xn--qpb7055d; 𐱲.蔫\u0766; [B5, B6, V7]; xn--389c.xn--qpb7055d; ; ;  # .蔫ݦ
+򒲧₃｡ꡚ𛇑󠄳\u0647; 򒲧3.ꡚ𛇑\u0647; [B5, B6, V7]; xn--3-ep59g.xn--jhb5904fcp0h; ; ;  # 3.ꡚ𛇑ه
+򒲧3。ꡚ𛇑󠄳\u0647; 򒲧3.ꡚ𛇑\u0647; [B5, B6, V7]; xn--3-ep59g.xn--jhb5904fcp0h; ; ;  # 3.ꡚ𛇑ه
+xn--3-ep59g.xn--jhb5904fcp0h; 򒲧3.ꡚ𛇑\u0647; [B5, B6, V7]; xn--3-ep59g.xn--jhb5904fcp0h; ; ;  # 3.ꡚ𛇑ه
+蓸\u0642≠.ß; ; [B5, B6]; xn--ehb015lnt1e.xn--zca; ; xn--ehb015lnt1e.ss;  # 蓸ق≠.ß
+蓸\u0642=\u0338.ß; 蓸\u0642≠.ß; [B5, B6]; xn--ehb015lnt1e.xn--zca; ; xn--ehb015lnt1e.ss;  # 蓸ق≠.ß
+蓸\u0642=\u0338.SS; 蓸\u0642≠.ss; [B5, B6]; xn--ehb015lnt1e.ss; ; ;  # 蓸ق≠.ss
+蓸\u0642≠.SS; 蓸\u0642≠.ss; [B5, B6]; xn--ehb015lnt1e.ss; ; ;  # 蓸ق≠.ss
+蓸\u0642≠.ss; ; [B5, B6]; xn--ehb015lnt1e.ss; ; ;  # 蓸ق≠.ss
+蓸\u0642=\u0338.ss; 蓸\u0642≠.ss; [B5, B6]; xn--ehb015lnt1e.ss; ; ;  # 蓸ق≠.ss
+蓸\u0642=\u0338.Ss; 蓸\u0642≠.ss; [B5, B6]; xn--ehb015lnt1e.ss; ; ;  # 蓸ق≠.ss
+蓸\u0642≠.Ss; 蓸\u0642≠.ss; [B5, B6]; xn--ehb015lnt1e.ss; ; ;  # 蓸ق≠.ss
+xn--ehb015lnt1e.ss; 蓸\u0642≠.ss; [B5, B6]; xn--ehb015lnt1e.ss; ; ;  # 蓸ق≠.ss
+xn--ehb015lnt1e.xn--zca; 蓸\u0642≠.ß; [B5, B6]; xn--ehb015lnt1e.xn--zca; ; ;  # 蓸ق≠.ß
+\u084E\u067A\u0DD3⒊.𐹹𞱩󠃪\u200C; ; [B1, C1, V7]; xn--zib94gfziuq1a.xn--0ug3205g7eyf3c96h; ; xn--zib94gfziuq1a.xn--xo0dw109an237f; [B1, V7] # ࡎٺී⒊.𐹹
+\u084E\u067A\u0DD33..𐹹𞱩󠃪\u200C; ; [B1, C1, V7, X4_2]; xn--3-prc71ls9j..xn--0ug3205g7eyf3c96h; [B1, C1, V7, A4_2]; xn--3-prc71ls9j..xn--xo0dw109an237f; [B1, V7, A4_2] # ࡎٺී3..𐹹
+xn--3-prc71ls9j..xn--xo0dw109an237f; \u084E\u067A\u0DD33..𐹹𞱩󠃪; [B1, V7, X4_2]; xn--3-prc71ls9j..xn--xo0dw109an237f; [B1, V7, A4_2]; ;  # ࡎٺී3..𐹹
+xn--3-prc71ls9j..xn--0ug3205g7eyf3c96h; \u084E\u067A\u0DD33..𐹹𞱩󠃪\u200C; [B1, C1, V7, X4_2]; xn--3-prc71ls9j..xn--0ug3205g7eyf3c96h; [B1, C1, V7, A4_2]; ;  # ࡎٺී3..𐹹
+xn--zib94gfziuq1a.xn--xo0dw109an237f; \u084E\u067A\u0DD3⒊.𐹹𞱩󠃪; [B1, V7]; xn--zib94gfziuq1a.xn--xo0dw109an237f; ; ;  # ࡎٺී⒊.𐹹
+xn--zib94gfziuq1a.xn--0ug3205g7eyf3c96h; \u084E\u067A\u0DD3⒊.𐹹𞱩󠃪\u200C; [B1, C1, V7]; xn--zib94gfziuq1a.xn--0ug3205g7eyf3c96h; ; ;  # ࡎٺී⒊.𐹹
+ς\u200D-.Ⴣ𦟙; ς\u200D-.ⴣ𦟙; [C2, V3]; xn----xmb348s.xn--rlj2573p; ; xn----zmb.xn--rlj2573p; [V3] # ς-.ⴣ𦟙
+ς\u200D-.ⴣ𦟙; ; [C2, V3]; xn----xmb348s.xn--rlj2573p; ; xn----zmb.xn--rlj2573p; [V3] # ς-.ⴣ𦟙
+Σ\u200D-.Ⴣ𦟙; σ\u200D-.ⴣ𦟙; [C2, V3]; xn----zmb048s.xn--rlj2573p; ; xn----zmb.xn--rlj2573p; [V3] # σ-.ⴣ𦟙
+σ\u200D-.ⴣ𦟙; ; [C2, V3]; xn----zmb048s.xn--rlj2573p; ; xn----zmb.xn--rlj2573p; [V3] # σ-.ⴣ𦟙
+xn----zmb.xn--rlj2573p; σ-.ⴣ𦟙; [V3]; xn----zmb.xn--rlj2573p; ; ;  # σ-.ⴣ𦟙
+xn----zmb048s.xn--rlj2573p; σ\u200D-.ⴣ𦟙; [C2, V3]; xn----zmb048s.xn--rlj2573p; ; ;  # σ-.ⴣ𦟙
+xn----xmb348s.xn--rlj2573p; ς\u200D-.ⴣ𦟙; [C2, V3]; xn----xmb348s.xn--rlj2573p; ; ;  # ς-.ⴣ𦟙
+xn----zmb.xn--7nd64871a; σ-.Ⴣ𦟙; [V3, V7]; xn----zmb.xn--7nd64871a; ; ;  # σ-.Ⴣ𦟙
+xn----zmb048s.xn--7nd64871a; σ\u200D-.Ⴣ𦟙; [C2, V3, V7]; xn----zmb048s.xn--7nd64871a; ; ;  # σ-.Ⴣ𦟙
+xn----xmb348s.xn--7nd64871a; ς\u200D-.Ⴣ𦟙; [C2, V3, V7]; xn----xmb348s.xn--7nd64871a; ; ;  # ς-.Ⴣ𦟙
+≠。🞳𝟲; ≠.🞳6; ; xn--1ch.xn--6-dl4s; ; ;  # ≠.🞳6
+=\u0338。🞳𝟲; ≠.🞳6; ; xn--1ch.xn--6-dl4s; ; ;  # ≠.🞳6
+≠。🞳6; ≠.🞳6; ; xn--1ch.xn--6-dl4s; ; ;  # ≠.🞳6
+=\u0338。🞳6; ≠.🞳6; ; xn--1ch.xn--6-dl4s; ; ;  # ≠.🞳6
+xn--1ch.xn--6-dl4s; ≠.🞳6; ; xn--1ch.xn--6-dl4s; ; ;  # ≠.🞳6
+≠.🞳6; ; ; xn--1ch.xn--6-dl4s; ; ;  # ≠.🞳6
+=\u0338.🞳6; ≠.🞳6; ; xn--1ch.xn--6-dl4s; ; ;  # ≠.🞳6
+󅬽.蠔; ; [V7]; xn--g747d.xn--xl2a; ; ;  # .蠔
+xn--g747d.xn--xl2a; 󅬽.蠔; [V7]; xn--g747d.xn--xl2a; ; ;  # .蠔
+\u08E6\u200D．뼽; \u08E6\u200D.뼽; [C2, V6]; xn--p0b869i.xn--e43b; ; xn--p0b.xn--e43b; [V6] # ࣦ.뼽
+\u08E6\u200D．뼽; \u08E6\u200D.뼽; [C2, V6]; xn--p0b869i.xn--e43b; ; xn--p0b.xn--e43b; [V6] # ࣦ.뼽
+\u08E6\u200D.뼽; ; [C2, V6]; xn--p0b869i.xn--e43b; ; xn--p0b.xn--e43b; [V6] # ࣦ.뼽
+\u08E6\u200D.뼽; \u08E6\u200D.뼽; [C2, V6]; xn--p0b869i.xn--e43b; ; xn--p0b.xn--e43b; [V6] # ࣦ.뼽
+xn--p0b.xn--e43b; \u08E6.뼽; [V6]; xn--p0b.xn--e43b; ; ;  # ࣦ.뼽
+xn--p0b869i.xn--e43b; \u08E6\u200D.뼽; [C2, V6]; xn--p0b869i.xn--e43b; ; ;  # ࣦ.뼽
+₇\u0BCD􃂷\u06D2。👖\u0675-𞪑; 7\u0BCD􃂷\u06D2.👖\u0627\u0674-𞪑; [B1, V7]; xn--7-rwc839aj3073c.xn----ymc5uv818oghka; ; ;  # 7்ے.👖اٴ-
+7\u0BCD􃂷\u06D2。👖\u0627\u0674-𞪑; 7\u0BCD􃂷\u06D2.👖\u0627\u0674-𞪑; [B1, V7]; xn--7-rwc839aj3073c.xn----ymc5uv818oghka; ; ;  # 7்ے.👖اٴ-
+xn--7-rwc839aj3073c.xn----ymc5uv818oghka; 7\u0BCD􃂷\u06D2.👖\u0627\u0674-𞪑; [B1, V7]; xn--7-rwc839aj3073c.xn----ymc5uv818oghka; ; ;  # 7்ے.👖اٴ-
+-｡\u077B; -.\u077B; [B1, V3]; -.xn--cqb; ; ;  # -.ݻ
+-。\u077B; -.\u077B; [B1, V3]; -.xn--cqb; ; ;  # -.ݻ
+-.xn--cqb; -.\u077B; [B1, V3]; -.xn--cqb; ; ;  # -.ݻ
+𑇌𵛓｡-⒈ꡏ\u072B; 𑇌𵛓.-⒈ꡏ\u072B; [B1, V3, V6, V7]; xn--8d1dg030h.xn----u1c466tp10j; ; ;  # 𑇌.-⒈ꡏܫ
+𑇌𵛓。-1.ꡏ\u072B; 𑇌𵛓.-1.ꡏ\u072B; [B1, B5, B6, V3, V6, V7]; xn--8d1dg030h.-1.xn--1nb7163f; ; ;  # 𑇌.-1.ꡏܫ
+xn--8d1dg030h.-1.xn--1nb7163f; 𑇌𵛓.-1.ꡏ\u072B; [B1, B5, B6, V3, V6, V7]; xn--8d1dg030h.-1.xn--1nb7163f; ; ;  # 𑇌.-1.ꡏܫ
+xn--8d1dg030h.xn----u1c466tp10j; 𑇌𵛓.-⒈ꡏ\u072B; [B1, V3, V6, V7]; xn--8d1dg030h.xn----u1c466tp10j; ; ;  # 𑇌.-⒈ꡏܫ
+璛\u1734\u06AF.-; ; [B1, B5, B6, V3]; xn--ikb175frt4e.-; ; ;  # 璛᜴گ.-
+xn--ikb175frt4e.-; 璛\u1734\u06AF.-; [B1, B5, B6, V3]; xn--ikb175frt4e.-; ; ;  # 璛᜴گ.-
+󠆰\u08A1\u0A4D샕．𐹲휁; \u08A1\u0A4D샕.𐹲휁; [B1, B2, B3]; xn--qyb07fj857a.xn--728bv72h; ; ;  # ࢡ੍샕.𐹲휁
+󠆰\u08A1\u0A4D샕．𐹲휁; \u08A1\u0A4D샕.𐹲휁; [B1, B2, B3]; xn--qyb07fj857a.xn--728bv72h; ; ;  # ࢡ੍샕.𐹲휁
+󠆰\u08A1\u0A4D샕.𐹲휁; \u08A1\u0A4D샕.𐹲휁; [B1, B2, B3]; xn--qyb07fj857a.xn--728bv72h; ; ;  # ࢡ੍샕.𐹲휁
+󠆰\u08A1\u0A4D샕.𐹲휁; \u08A1\u0A4D샕.𐹲휁; [B1, B2, B3]; xn--qyb07fj857a.xn--728bv72h; ; ;  # ࢡ੍샕.𐹲휁
+xn--qyb07fj857a.xn--728bv72h; \u08A1\u0A4D샕.𐹲휁; [B1, B2, B3]; xn--qyb07fj857a.xn--728bv72h; ; ;  # ࢡ੍샕.𐹲휁
+񍨽．񋸕; 񍨽.񋸕; [V7]; xn--pr3x.xn--rv7w; ; ;  # .
+񍨽.񋸕; ; [V7]; xn--pr3x.xn--rv7w; ; ;  # .
+xn--pr3x.xn--rv7w; 񍨽.񋸕; [V7]; xn--pr3x.xn--rv7w; ; ;  # .
+\u067D𞥕｡𑑂𞤶Ⴍ-; \u067D𞥕.𑑂𞤶ⴍ-; [B1, V3, V6]; xn--2ib0338v.xn----zvs0199fo91g; ; ;  # ٽ𞥕.𑑂𞤶ⴍ-
+\u067D𞥕。𑑂𞤶Ⴍ-; \u067D𞥕.𑑂𞤶ⴍ-; [B1, V3, V6]; xn--2ib0338v.xn----zvs0199fo91g; ; ;  # ٽ𞥕.𑑂𞤶ⴍ-
+\u067D𞥕。𑑂𞤶ⴍ-; \u067D𞥕.𑑂𞤶ⴍ-; [B1, V3, V6]; xn--2ib0338v.xn----zvs0199fo91g; ; ;  # ٽ𞥕.𑑂𞤶ⴍ-
+\u067D𞥕。𑑂𞤔Ⴍ-; \u067D𞥕.𑑂𞤶ⴍ-; [B1, V3, V6]; xn--2ib0338v.xn----zvs0199fo91g; ; ;  # ٽ𞥕.𑑂𞤶ⴍ-
+\u067D𞥕。𑑂𞤔ⴍ-; \u067D𞥕.𑑂𞤶ⴍ-; [B1, V3, V6]; xn--2ib0338v.xn----zvs0199fo91g; ; ;  # ٽ𞥕.𑑂𞤶ⴍ-
+xn--2ib0338v.xn----zvs0199fo91g; \u067D𞥕.𑑂𞤶ⴍ-; [B1, V3, V6]; xn--2ib0338v.xn----zvs0199fo91g; ; ;  # ٽ𞥕.𑑂𞤶ⴍ-
+\u067D𞥕｡𑑂𞤶ⴍ-; \u067D𞥕.𑑂𞤶ⴍ-; [B1, V3, V6]; xn--2ib0338v.xn----zvs0199fo91g; ; ;  # ٽ𞥕.𑑂𞤶ⴍ-
+\u067D𞥕｡𑑂𞤔Ⴍ-; \u067D𞥕.𑑂𞤶ⴍ-; [B1, V3, V6]; xn--2ib0338v.xn----zvs0199fo91g; ; ;  # ٽ𞥕.𑑂𞤶ⴍ-
+\u067D𞥕｡𑑂𞤔ⴍ-; \u067D𞥕.𑑂𞤶ⴍ-; [B1, V3, V6]; xn--2ib0338v.xn----zvs0199fo91g; ; ;  # ٽ𞥕.𑑂𞤶ⴍ-
+xn--2ib0338v.xn----w0g2740ro9vg; \u067D𞥕.𑑂𞤶Ⴍ-; [B1, V3, V6, V7]; xn--2ib0338v.xn----w0g2740ro9vg; ; ;  # ٽ𞥕.𑑂𞤶Ⴍ-
+𐯀𐸉𞧏。񢚧₄Ⴋ񂹫; 𐯀𐸉𞧏.񢚧4ⴋ񂹫; [V7]; xn--039c42bq865a.xn--4-wvs27840bnrzm; ; ;  # .4ⴋ
+𐯀𐸉𞧏。񢚧4Ⴋ񂹫; 𐯀𐸉𞧏.񢚧4ⴋ񂹫; [V7]; xn--039c42bq865a.xn--4-wvs27840bnrzm; ; ;  # .4ⴋ
+𐯀𐸉𞧏。񢚧4ⴋ񂹫; 𐯀𐸉𞧏.񢚧4ⴋ񂹫; [V7]; xn--039c42bq865a.xn--4-wvs27840bnrzm; ; ;  # .4ⴋ
+xn--039c42bq865a.xn--4-wvs27840bnrzm; 𐯀𐸉𞧏.񢚧4ⴋ񂹫; [V7]; xn--039c42bq865a.xn--4-wvs27840bnrzm; ; ;  # .4ⴋ
+𐯀𐸉𞧏。񢚧₄ⴋ񂹫; 𐯀𐸉𞧏.񢚧4ⴋ񂹫; [V7]; xn--039c42bq865a.xn--4-wvs27840bnrzm; ; ;  # .4ⴋ
+xn--039c42bq865a.xn--4-t0g49302fnrzm; 𐯀𐸉𞧏.񢚧4Ⴋ񂹫; [V7]; xn--039c42bq865a.xn--4-t0g49302fnrzm; ; ;  # .4Ⴋ
+4\u06BD︒󠑥.≠; ; [B1, V7]; xn--4-kvc5601q2h50i.xn--1ch; ; ;  # 4ڽ︒.≠
+4\u06BD︒󠑥.=\u0338; 4\u06BD︒󠑥.≠; [B1, V7]; xn--4-kvc5601q2h50i.xn--1ch; ; ;  # 4ڽ︒.≠
+4\u06BD。󠑥.≠; 4\u06BD.󠑥.≠; [B1, V7]; xn--4-kvc.xn--5136e.xn--1ch; ; ;  # 4ڽ..≠
+4\u06BD。󠑥.=\u0338; 4\u06BD.󠑥.≠; [B1, V7]; xn--4-kvc.xn--5136e.xn--1ch; ; ;  # 4ڽ..≠
+xn--4-kvc.xn--5136e.xn--1ch; 4\u06BD.󠑥.≠; [B1, V7]; xn--4-kvc.xn--5136e.xn--1ch; ; ;  # 4ڽ..≠
+xn--4-kvc5601q2h50i.xn--1ch; 4\u06BD︒󠑥.≠; [B1, V7]; xn--4-kvc5601q2h50i.xn--1ch; ; ;  # 4ڽ︒.≠
+𝟓。\u06D7; 5.\u06D7; [V6]; 5.xn--nlb; ; ;  # 5.ۗ
+5。\u06D7; 5.\u06D7; [V6]; 5.xn--nlb; ; ;  # 5.ۗ
+5.xn--nlb; 5.\u06D7; [V6]; 5.xn--nlb; ; ;  # 5.ۗ
+\u200C򺸩.⾕; \u200C򺸩.谷; [C1, V7]; xn--0ug26167i.xn--6g3a; ; xn--i183d.xn--6g3a; [V7] # .谷
+\u200C򺸩.谷; ; [C1, V7]; xn--0ug26167i.xn--6g3a; ; xn--i183d.xn--6g3a; [V7] # .谷
+xn--i183d.xn--6g3a; 򺸩.谷; [V7]; xn--i183d.xn--6g3a; ; ;  # .谷
+xn--0ug26167i.xn--6g3a; \u200C򺸩.谷; [C1, V7]; xn--0ug26167i.xn--6g3a; ; ;  # .谷
+︒󎰇\u200D.-\u073C\u200C; ; [C1, C2, V3, V7]; xn--1ug1658ftw26f.xn----t2c071q; ; xn--y86c71305c.xn----t2c; [V3, V7] # ︒.-ܼ
+。󎰇\u200D.-\u073C\u200C; .󎰇\u200D.-\u073C\u200C; [C1, C2, V3, V7, X4_2]; .xn--1ug05310k.xn----t2c071q; [C1, C2, V3, V7, A4_2]; .xn--hh50e.xn----t2c; [V3, V7, A4_2] # ..-ܼ
+.xn--hh50e.xn----t2c; .󎰇.-\u073C; [V3, V7, X4_2]; .xn--hh50e.xn----t2c; [V3, V7, A4_2]; ;  # ..-ܼ
+.xn--1ug05310k.xn----t2c071q; .󎰇\u200D.-\u073C\u200C; [C1, C2, V3, V7, X4_2]; .xn--1ug05310k.xn----t2c071q; [C1, C2, V3, V7, A4_2]; ;  # ..-ܼ
+xn--y86c71305c.xn----t2c; ︒󎰇.-\u073C; [V3, V7]; xn--y86c71305c.xn----t2c; ; ;  # ︒.-ܼ
+xn--1ug1658ftw26f.xn----t2c071q; ︒󎰇\u200D.-\u073C\u200C; [C1, C2, V3, V7]; xn--1ug1658ftw26f.xn----t2c071q; ; ;  # ︒.-ܼ
+≯𞤟。ᡨ; ≯𞥁.ᡨ; [B1]; xn--hdhz520p.xn--48e; ; ;  # ≯𞥁.ᡨ
+>\u0338𞤟。ᡨ; ≯𞥁.ᡨ; [B1]; xn--hdhz520p.xn--48e; ; ;  # ≯𞥁.ᡨ
+>\u0338𞥁。ᡨ; ≯𞥁.ᡨ; [B1]; xn--hdhz520p.xn--48e; ; ;  # ≯𞥁.ᡨ
+≯𞥁。ᡨ; ≯𞥁.ᡨ; [B1]; xn--hdhz520p.xn--48e; ; ;  # ≯𞥁.ᡨ
+xn--hdhz520p.xn--48e; ≯𞥁.ᡨ; [B1]; xn--hdhz520p.xn--48e; ; ;  # ≯𞥁.ᡨ
+\u0F74𫫰𝨄。\u0713𐹦; \u0F74𫫰𝨄.\u0713𐹦; [B1, V6]; xn--ned8985uo92e.xn--dnb6395k; ; ;  # ུ𫫰𝨄.ܓ𐹦
+xn--ned8985uo92e.xn--dnb6395k; \u0F74𫫰𝨄.\u0713𐹦; [B1, V6]; xn--ned8985uo92e.xn--dnb6395k; ; ;  # ུ𫫰𝨄.ܓ𐹦
+\u033C\u07DB⁷𝟹｡𝟬; \u033C\u07DB73.0; [B1, V6]; xn--73-9yb648b.0; ; ;  # ̼ߛ73.0
+\u033C\u07DB73。0; \u033C\u07DB73.0; [B1, V6]; xn--73-9yb648b.0; ; ;  # ̼ߛ73.0
+xn--73-9yb648b.a; \u033C\u07DB73.a; [B1, V6]; xn--73-9yb648b.a; ; ;  # ̼ߛ73.a
+\u200D．𝟗; \u200D.9; [C2]; xn--1ug.9; ; .9; [A4_2] # .9
+\u200D.j; ; [C2]; xn--1ug.j; ; .j; [A4_2] # .j
+\u200D.J; \u200D.j; [C2]; xn--1ug.j; ; .j; [A4_2] # .j
+.j; ; [X4_2]; ; [A4_2]; ;  # .j
+xn--1ug.j; \u200D.j; [C2]; xn--1ug.j; ; ;  # .j
+j; ; ; ; ; ;  # j
+\u0779ᡭ𪕈。\u06B6\u08D9; \u0779ᡭ𪕈.\u06B6\u08D9; [B2, B3]; xn--9pb497fs270c.xn--pkb80i; ; ;  # ݹᡭ𪕈.ڶࣙ
+xn--9pb497fs270c.xn--pkb80i; \u0779ᡭ𪕈.\u06B6\u08D9; [B2, B3]; xn--9pb497fs270c.xn--pkb80i; ; ;  # ݹᡭ𪕈.ڶࣙ
+\u0726５\u07E2겙。\u1CF4𐷚; \u07265\u07E2겙.\u1CF4𐷚; [B1, B2, B3, V6, V7]; xn--5-j1c97c2483c.xn--e7f2093h; ; ;  # ܦ5ߢ겙.᳴
+\u0726５\u07E2겙。\u1CF4𐷚; \u07265\u07E2겙.\u1CF4𐷚; [B1, B2, B3, V6, V7]; xn--5-j1c97c2483c.xn--e7f2093h; ; ;  # ܦ5ߢ겙.᳴
+\u07265\u07E2겙。\u1CF4𐷚; \u07265\u07E2겙.\u1CF4𐷚; [B1, B2, B3, V6, V7]; xn--5-j1c97c2483c.xn--e7f2093h; ; ;  # ܦ5ߢ겙.᳴
+\u07265\u07E2겙。\u1CF4𐷚; \u07265\u07E2겙.\u1CF4𐷚; [B1, B2, B3, V6, V7]; xn--5-j1c97c2483c.xn--e7f2093h; ; ;  # ܦ5ߢ겙.᳴
+xn--5-j1c97c2483c.xn--e7f2093h; \u07265\u07E2겙.\u1CF4𐷚; [B1, B2, B3, V6, V7]; xn--5-j1c97c2483c.xn--e7f2093h; ; ;  # ܦ5ߢ겙.᳴
+Ⴍ𿣍ꡨ\u05AE。Ⴞ\u200C\u200C; ⴍ𿣍ꡨ\u05AE.ⴞ\u200C\u200C; [C1, V7]; xn--5cb172r175fug38a.xn--0uga051h; ; xn--5cb172r175fug38a.xn--mlj; [V7] # ⴍꡨ֮.ⴞ
+ⴍ𿣍ꡨ\u05AE。ⴞ\u200C\u200C; ⴍ𿣍ꡨ\u05AE.ⴞ\u200C\u200C; [C1, V7]; xn--5cb172r175fug38a.xn--0uga051h; ; xn--5cb172r175fug38a.xn--mlj; [V7] # ⴍꡨ֮.ⴞ
+xn--5cb172r175fug38a.xn--mlj; ⴍ𿣍ꡨ\u05AE.ⴞ; [V7]; xn--5cb172r175fug38a.xn--mlj; ; ;  # ⴍꡨ֮.ⴞ
+xn--5cb172r175fug38a.xn--0uga051h; ⴍ𿣍ꡨ\u05AE.ⴞ\u200C\u200C; [C1, V7]; xn--5cb172r175fug38a.xn--0uga051h; ; ;  # ⴍꡨ֮.ⴞ
+xn--5cb347co96jug15a.xn--2nd; Ⴍ𿣍ꡨ\u05AE.Ⴞ; [V7]; xn--5cb347co96jug15a.xn--2nd; ; ;  # Ⴍꡨ֮.Ⴞ
+xn--5cb347co96jug15a.xn--2nd059ea; Ⴍ𿣍ꡨ\u05AE.Ⴞ\u200C\u200C; [C1, V7]; xn--5cb347co96jug15a.xn--2nd059ea; ; ;  # Ⴍꡨ֮.Ⴞ
+𐋰。󑓱; 𐋰.󑓱; [V7]; xn--k97c.xn--q031e; ; ;  # 𐋰.
+xn--k97c.xn--q031e; 𐋰.󑓱; [V7]; xn--k97c.xn--q031e; ; ;  # 𐋰.
+󡎦\u17B4\u0B4D.𐹾; 󡎦\u0B4D.𐹾; [B1, V7]; xn--9ic59305p.xn--2o0d; ; ;  # ୍.𐹾
+xn--9ic59305p.xn--2o0d; 󡎦\u0B4D.𐹾; [B1, V7]; xn--9ic59305p.xn--2o0d; ; ;  # ୍.𐹾
+xn--9ic364dho91z.xn--2o0d; 󡎦\u17B4\u0B4D.𐹾; [B1, V7]; xn--9ic364dho91z.xn--2o0d; ; ;  # ୍.𐹾
+\u08DFႫ𶿸귤．򠅼𝟢휪\u0AE3; \u08DFⴋ𶿸귤.򠅼0휪\u0AE3; [V6, V7]; xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ; ;  # ࣟⴋ귤.0휪ૣ
+\u08DFႫ𶿸귤．򠅼𝟢휪\u0AE3; \u08DFⴋ𶿸귤.򠅼0휪\u0AE3; [V6, V7]; xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ; ;  # ࣟⴋ귤.0휪ૣ
+\u08DFႫ𶿸귤.򠅼0휪\u0AE3; \u08DFⴋ𶿸귤.򠅼0휪\u0AE3; [V6, V7]; xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ; ;  # ࣟⴋ귤.0휪ૣ
+\u08DFႫ𶿸귤.򠅼0휪\u0AE3; \u08DFⴋ𶿸귤.򠅼0휪\u0AE3; [V6, V7]; xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ; ;  # ࣟⴋ귤.0휪ૣ
+\u08DFⴋ𶿸귤.򠅼0휪\u0AE3; \u08DFⴋ𶿸귤.򠅼0휪\u0AE3; [V6, V7]; xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ; ;  # ࣟⴋ귤.0휪ૣ
+\u08DFⴋ𶿸귤.򠅼0휪\u0AE3; ; [V6, V7]; xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ; ;  # ࣟⴋ귤.0휪ૣ
+xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; \u08DFⴋ𶿸귤.򠅼0휪\u0AE3; [V6, V7]; xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ; ;  # ࣟⴋ귤.0휪ૣ
+\u08DFⴋ𶿸귤．򠅼𝟢휪\u0AE3; \u08DFⴋ𶿸귤.򠅼0휪\u0AE3; [V6, V7]; xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ; ;  # ࣟⴋ귤.0휪ૣ
+\u08DFⴋ𶿸귤．򠅼𝟢휪\u0AE3; \u08DFⴋ𶿸귤.򠅼0휪\u0AE3; [V6, V7]; xn--i0b436pkl2g2h42a.xn--0-8le8997mulr5f; ; ;  # ࣟⴋ귤.0휪ૣ
+xn--i0b601b6r7l2hs0a.xn--0-8le8997mulr5f; \u08DFႫ𶿸귤.򠅼0휪\u0AE3; [V6, V7]; xn--i0b601b6r7l2hs0a.xn--0-8le8997mulr5f; ; ;  # ࣟႫ귤.0휪ૣ
+\u0784．𞡝\u0601; \u0784.𞡝\u0601; [V7]; xn--lqb.xn--jfb1808v; ; ;  # ބ.𞡝
+\u0784.𞡝\u0601; ; [V7]; xn--lqb.xn--jfb1808v; ; ;  # ބ.𞡝
+xn--lqb.xn--jfb1808v; \u0784.𞡝\u0601; [V7]; xn--lqb.xn--jfb1808v; ; ;  # ބ.𞡝
+\u0ACD₃.8\uA8C4\u200D🃤; \u0ACD3.8\uA8C4\u200D🃤; [V6]; xn--3-yke.xn--8-ugnv982dbkwm; ; xn--3-yke.xn--8-sl4et308f;  # ્3.8꣄🃤
+\u0ACD3.8\uA8C4\u200D🃤; ; [V6]; xn--3-yke.xn--8-ugnv982dbkwm; ; xn--3-yke.xn--8-sl4et308f;  # ્3.8꣄🃤
+xn--3-yke.xn--8-sl4et308f; \u0ACD3.8\uA8C4🃤; [V6]; xn--3-yke.xn--8-sl4et308f; ; ;  # ્3.8꣄🃤
+xn--3-yke.xn--8-ugnv982dbkwm; \u0ACD3.8\uA8C4\u200D🃤; [V6]; xn--3-yke.xn--8-ugnv982dbkwm; ; ;  # ્3.8꣄🃤
+℻⩷𝆆。𞤠󠆁\u180C; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+FAX⩷𝆆。𞤠󠆁\u180C; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+fax⩷𝆆。𞥂󠆁\u180C; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+Fax⩷𝆆。𞤠󠆁\u180C; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+xn--fax-4c9a1676t.xn--6e6h; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+℻⩷𝆆。𞥂󠆁\u180C; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+FAX⩷𝆆。𞥂󠆁\u180C; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+fax⩷𝆆。𞤠󠆁\u180C; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+fax⩷𝆆.𞥂; ; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+FAX⩷𝆆.𞤠; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+Fax⩷𝆆.𞤠; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+FAX⩷𝆆.𞥂; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+Fax⩷𝆆.𞥂; fax⩷𝆆.𞥂; [B6]; xn--fax-4c9a1676t.xn--6e6h; ; ;  # fax⩷𝆆.𞥂
+ꡕ≠\u105E󮿱｡𐵧󠄫\uFFA0; ꡕ≠\u105E󮿱.𐵧; [V7]; xn--cld333gn31h0158l.xn--3g0d; ; ;  # ꡕ≠ၞ.
+ꡕ=\u0338\u105E󮿱｡𐵧󠄫\uFFA0; ꡕ≠\u105E󮿱.𐵧; [V7]; xn--cld333gn31h0158l.xn--3g0d; ; ;  # ꡕ≠ၞ.
+ꡕ≠\u105E󮿱。𐵧󠄫\u1160; ꡕ≠\u105E󮿱.𐵧; [V7]; xn--cld333gn31h0158l.xn--3g0d; ; ;  # ꡕ≠ၞ.
+ꡕ=\u0338\u105E󮿱。𐵧󠄫\u1160; ꡕ≠\u105E󮿱.𐵧; [V7]; xn--cld333gn31h0158l.xn--3g0d; ; ;  # ꡕ≠ၞ.
+xn--cld333gn31h0158l.xn--3g0d; ꡕ≠\u105E󮿱.𐵧; [V7]; xn--cld333gn31h0158l.xn--3g0d; ; ;  # ꡕ≠ၞ.
+xn--cld333gn31h0158l.xn--psd1510k; ꡕ≠\u105E󮿱.𐵧\u1160; [B2, B3, V7]; xn--cld333gn31h0158l.xn--psd1510k; ; ;  # ꡕ≠ၞ.
+xn--cld333gn31h0158l.xn--cl7c96v; ꡕ≠\u105E󮿱.𐵧\uFFA0; [B2, B3, V7]; xn--cld333gn31h0158l.xn--cl7c96v; ; ;  # ꡕ≠ၞ.
+鱊。\u200C; 鱊.\u200C; [C1]; xn--rt6a.xn--0ug; ; xn--rt6a.; [A4_2] # 鱊.
+xn--rt6a.; 鱊.; ; xn--rt6a.; [A4_2]; ;  # 鱊.
+鱊.; ; ; xn--rt6a.; [A4_2]; ;  # 鱊.
+xn--rt6a.xn--0ug; 鱊.\u200C; [C1]; xn--rt6a.xn--0ug; ; ;  # 鱊.
+8𐹣．𑍨; 8𐹣.𑍨; [B1, V6]; xn--8-d26i.xn--0p1d; ; ;  # 8𐹣.𑍨
+8𐹣.𑍨; ; [B1, V6]; xn--8-d26i.xn--0p1d; ; ;  # 8𐹣.𑍨
+xn--8-d26i.xn--0p1d; 8𐹣.𑍨; [B1, V6]; xn--8-d26i.xn--0p1d; ; ;  # 8𐹣.𑍨
+⏹𐧀．𐫯; ⏹𐧀.𐫯; [B1]; xn--qoh9161g.xn--1x9c; ; ;  # ⏹𐧀.𐫯
+⏹𐧀.𐫯; ; [B1]; xn--qoh9161g.xn--1x9c; ; ;  # ⏹𐧀.𐫯
+xn--qoh9161g.xn--1x9c; ⏹𐧀.𐫯; [B1]; xn--qoh9161g.xn--1x9c; ; ;  # ⏹𐧀.𐫯
+𞤺\u07CC4．\u200D; 𞤺\u07CC4.\u200D; [B1, C2]; xn--4-0bd15808a.xn--1ug; ; xn--4-0bd15808a.; [A4_2] # 𞤺ߌ4.
+𞤺\u07CC4.\u200D; ; [B1, C2]; xn--4-0bd15808a.xn--1ug; ; xn--4-0bd15808a.; [A4_2] # 𞤺ߌ4.
+𞤘\u07CC4.\u200D; 𞤺\u07CC4.\u200D; [B1, C2]; xn--4-0bd15808a.xn--1ug; ; xn--4-0bd15808a.; [A4_2] # 𞤺ߌ4.
+xn--4-0bd15808a.; 𞤺\u07CC4.; ; xn--4-0bd15808a.; [A4_2]; ;  # 𞤺ߌ4.
+𞤺\u07CC4.; ; ; xn--4-0bd15808a.; [A4_2]; ;  # 𞤺ߌ4.
+𞤘\u07CC4.; 𞤺\u07CC4.; ; xn--4-0bd15808a.; [A4_2]; ;  # 𞤺ߌ4.
+xn--4-0bd15808a.xn--1ug; 𞤺\u07CC4.\u200D; [B1, C2]; xn--4-0bd15808a.xn--1ug; ; ;  # 𞤺ߌ4.
+𞤘\u07CC4．\u200D; 𞤺\u07CC4.\u200D; [B1, C2]; xn--4-0bd15808a.xn--1ug; ; xn--4-0bd15808a.; [A4_2] # 𞤺ߌ4.
+⒗\u0981\u20EF-.\u08E2•; ; [B1, V3, V7]; xn----z0d801p6kd.xn--l0b810j; ; ;  # ⒗ঁ⃯-.•
+16.\u0981\u20EF-.\u08E2•; ; [B1, V3, V6, V7]; 16.xn----z0d801p.xn--l0b810j; ; ;  # 16.ঁ⃯-.•
+16.xn----z0d801p.xn--l0b810j; 16.\u0981\u20EF-.\u08E2•; [B1, V3, V6, V7]; 16.xn----z0d801p.xn--l0b810j; ; ;  # 16.ঁ⃯-.•
+xn----z0d801p6kd.xn--l0b810j; ⒗\u0981\u20EF-.\u08E2•; [B1, V3, V7]; xn----z0d801p6kd.xn--l0b810j; ; ;  # ⒗ঁ⃯-.•
+-｡䏛; -.䏛; [V3]; -.xn--xco; ; ;  # -.䏛
+-。䏛; -.䏛; [V3]; -.xn--xco; ; ;  # -.䏛
+-.xn--xco; -.䏛; [V3]; -.xn--xco; ; ;  # -.䏛
+\u200C񒃠．\u200D; \u200C񒃠.\u200D; [C1, C2, V7]; xn--0ugz7551c.xn--1ug; ; xn--dj8y.; [V7, A4_2] # .
+\u200C񒃠.\u200D; ; [C1, C2, V7]; xn--0ugz7551c.xn--1ug; ; xn--dj8y.; [V7, A4_2] # .
+xn--dj8y.; 񒃠.; [V7]; xn--dj8y.; [V7, A4_2]; ;  # .
+xn--0ugz7551c.xn--1ug; \u200C񒃠.\u200D; [C1, C2, V7]; xn--0ugz7551c.xn--1ug; ; ;  # .
+⒈⓰󥣇｡𐹠\u200D򗷦Ⴕ; ⒈⓰󥣇.𐹠\u200D򗷦ⴕ; [B1, C2, V7]; xn--tsh0nz9380h.xn--1ug352csp0psg45e; ; xn--tsh0nz9380h.xn--dljv223ee5t2d; [B1, V7] # ⒈⓰.𐹠ⴕ
+1.⓰󥣇。𐹠\u200D򗷦Ⴕ; 1.⓰󥣇.𐹠\u200D򗷦ⴕ; [B1, C2, V7]; 1.xn--svh00804k.xn--1ug352csp0psg45e; ; 1.xn--svh00804k.xn--dljv223ee5t2d; [B1, V7] # 1.⓰.𐹠ⴕ
+1.⓰󥣇。𐹠\u200D򗷦ⴕ; 1.⓰󥣇.𐹠\u200D򗷦ⴕ; [B1, C2, V7]; 1.xn--svh00804k.xn--1ug352csp0psg45e; ; 1.xn--svh00804k.xn--dljv223ee5t2d; [B1, V7] # 1.⓰.𐹠ⴕ
+1.xn--svh00804k.xn--dljv223ee5t2d; 1.⓰󥣇.𐹠򗷦ⴕ; [B1, V7]; 1.xn--svh00804k.xn--dljv223ee5t2d; ; ;  # 1.⓰.𐹠ⴕ
+1.xn--svh00804k.xn--1ug352csp0psg45e; 1.⓰󥣇.𐹠\u200D򗷦ⴕ; [B1, C2, V7]; 1.xn--svh00804k.xn--1ug352csp0psg45e; ; ;  # 1.⓰.𐹠ⴕ
+⒈⓰󥣇｡𐹠\u200D򗷦ⴕ; ⒈⓰󥣇.𐹠\u200D򗷦ⴕ; [B1, C2, V7]; xn--tsh0nz9380h.xn--1ug352csp0psg45e; ; xn--tsh0nz9380h.xn--dljv223ee5t2d; [B1, V7] # ⒈⓰.𐹠ⴕ
+xn--tsh0nz9380h.xn--dljv223ee5t2d; ⒈⓰󥣇.𐹠򗷦ⴕ; [B1, V7]; xn--tsh0nz9380h.xn--dljv223ee5t2d; ; ;  # ⒈⓰.𐹠ⴕ
+xn--tsh0nz9380h.xn--1ug352csp0psg45e; ⒈⓰󥣇.𐹠\u200D򗷦ⴕ; [B1, C2, V7]; xn--tsh0nz9380h.xn--1ug352csp0psg45e; ; ;  # ⒈⓰.𐹠ⴕ
+1.xn--svh00804k.xn--tnd1990ke579c; 1.⓰󥣇.𐹠򗷦Ⴕ; [B1, V7]; 1.xn--svh00804k.xn--tnd1990ke579c; ; ;  # 1.⓰.𐹠Ⴕ
+1.xn--svh00804k.xn--tnd969erj4psgl3e; 1.⓰󥣇.𐹠\u200D򗷦Ⴕ; [B1, C2, V7]; 1.xn--svh00804k.xn--tnd969erj4psgl3e; ; ;  # 1.⓰.𐹠Ⴕ
+xn--tsh0nz9380h.xn--tnd1990ke579c; ⒈⓰󥣇.𐹠򗷦Ⴕ; [B1, V7]; xn--tsh0nz9380h.xn--tnd1990ke579c; ; ;  # ⒈⓰.𐹠Ⴕ
+xn--tsh0nz9380h.xn--tnd969erj4psgl3e; ⒈⓰󥣇.𐹠\u200D򗷦Ⴕ; [B1, C2, V7]; xn--tsh0nz9380h.xn--tnd969erj4psgl3e; ; ;  # ⒈⓰.𐹠Ⴕ
+𞠊ᠮ-ß｡\u1CD0効\u0601𷣭; 𞠊ᠮ-ß.\u1CD0効\u0601𷣭; [B1, B2, B3, V6, V7]; xn----qfa310pg973b.xn--jfb197i791bi6x4c; ; xn---ss-21t18904a.xn--jfb197i791bi6x4c;  # 𞠊ᠮ-ß.᳐効
+𞠊ᠮ-ß。\u1CD0効\u0601𷣭; 𞠊ᠮ-ß.\u1CD0効\u0601𷣭; [B1, B2, B3, V6, V7]; xn----qfa310pg973b.xn--jfb197i791bi6x4c; ; xn---ss-21t18904a.xn--jfb197i791bi6x4c;  # 𞠊ᠮ-ß.᳐効
+𞠊ᠮ-SS。\u1CD0効\u0601𷣭; 𞠊ᠮ-ss.\u1CD0効\u0601𷣭; [B1, B2, B3, V6, V7]; xn---ss-21t18904a.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ss.᳐効
+𞠊ᠮ-ss。\u1CD0効\u0601𷣭; 𞠊ᠮ-ss.\u1CD0効\u0601𷣭; [B1, B2, B3, V6, V7]; xn---ss-21t18904a.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ss.᳐効
+𞠊ᠮ-Ss。\u1CD0効\u0601𷣭; 𞠊ᠮ-ss.\u1CD0効\u0601𷣭; [B1, B2, B3, V6, V7]; xn---ss-21t18904a.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ss.᳐効
+xn---ss-21t18904a.xn--jfb197i791bi6x4c; 𞠊ᠮ-ss.\u1CD0効\u0601𷣭; [B1, B2, B3, V6, V7]; xn---ss-21t18904a.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ss.᳐効
+xn----qfa310pg973b.xn--jfb197i791bi6x4c; 𞠊ᠮ-ß.\u1CD0効\u0601𷣭; [B1, B2, B3, V6, V7]; xn----qfa310pg973b.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ß.᳐効
+𞠊ᠮ-SS｡\u1CD0効\u0601𷣭; 𞠊ᠮ-ss.\u1CD0効\u0601𷣭; [B1, B2, B3, V6, V7]; xn---ss-21t18904a.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ss.᳐効
+𞠊ᠮ-ss｡\u1CD0効\u0601𷣭; 𞠊ᠮ-ss.\u1CD0効\u0601𷣭; [B1, B2, B3, V6, V7]; xn---ss-21t18904a.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ss.᳐効
+𞠊ᠮ-Ss｡\u1CD0効\u0601𷣭; 𞠊ᠮ-ss.\u1CD0効\u0601𷣭; [B1, B2, B3, V6, V7]; xn---ss-21t18904a.xn--jfb197i791bi6x4c; ; ;  # 𞠊ᠮ-ss.᳐効
+𑇀.󠨱; ; [V6, V7]; xn--wd1d.xn--k946e; ; ;  # 𑇀.
+xn--wd1d.xn--k946e; 𑇀.󠨱; [V6, V7]; xn--wd1d.xn--k946e; ; ;  # 𑇀.
+␒3\uFB88｡𝟘𐨿𐹆; ␒3\u0688.0𐨿𐹆; [B1, V7]; xn--3-jsc897t.xn--0-sc5iy3h; ; ;  # ␒3ڈ.0𐨿
+␒3\u0688。0𐨿𐹆; ␒3\u0688.0𐨿𐹆; [B1, V7]; xn--3-jsc897t.xn--0-sc5iy3h; ; ;  # ␒3ڈ.0𐨿
+xn--3-jsc897t.xn--0-sc5iy3h; ␒3\u0688.0𐨿𐹆; [B1, V7]; xn--3-jsc897t.xn--0-sc5iy3h; ; ;  # ␒3ڈ.0𐨿
+\u076B６\u0A81\u08A6。\u1DE3; \u076B6\u0A81\u08A6.\u1DE3; [B1, V6]; xn--6-h5c06gj6c.xn--7eg; ; ;  # ݫ6ઁࢦ.ᷣ
+\u076B6\u0A81\u08A6。\u1DE3; \u076B6\u0A81\u08A6.\u1DE3; [B1, V6]; xn--6-h5c06gj6c.xn--7eg; ; ;  # ݫ6ઁࢦ.ᷣ
+xn--6-h5c06gj6c.xn--7eg; \u076B6\u0A81\u08A6.\u1DE3; [B1, V6]; xn--6-h5c06gj6c.xn--7eg; ; ;  # ݫ6ઁࢦ.ᷣ
+\u0605-𽤞Ⴂ。򅤶\u200D; \u0605-𽤞ⴂ.򅤶\u200D; [B1, B6, C2, V7]; xn----0kc8501a5399e.xn--1ugy3204f; ; xn----0kc8501a5399e.xn--ss06b; [B1, V7] # -ⴂ.
+\u0605-𽤞ⴂ。򅤶\u200D; \u0605-𽤞ⴂ.򅤶\u200D; [B1, B6, C2, V7]; xn----0kc8501a5399e.xn--1ugy3204f; ; xn----0kc8501a5399e.xn--ss06b; [B1, V7] # -ⴂ.
+xn----0kc8501a5399e.xn--ss06b; \u0605-𽤞ⴂ.򅤶; [B1, V7]; xn----0kc8501a5399e.xn--ss06b; ; ;  # -ⴂ.
+xn----0kc8501a5399e.xn--1ugy3204f; \u0605-𽤞ⴂ.򅤶\u200D; [B1, B6, C2, V7]; xn----0kc8501a5399e.xn--1ugy3204f; ; ;  # -ⴂ.
+xn----0kc662fc152h.xn--ss06b; \u0605-𽤞Ⴂ.򅤶; [B1, V7]; xn----0kc662fc152h.xn--ss06b; ; ;  # -Ⴂ.
+xn----0kc662fc152h.xn--1ugy3204f; \u0605-𽤞Ⴂ.򅤶\u200D; [B1, B6, C2, V7]; xn----0kc662fc152h.xn--1ugy3204f; ; ;  # -Ⴂ.
+⾆．ꡈ５≯ß; 舌.ꡈ5≯ß; ; xn--tc1a.xn--5-qfa988w745i; ; xn--tc1a.xn--5ss-3m2a5009e;  # 舌.ꡈ5≯ß
+⾆．ꡈ５>\u0338ß; 舌.ꡈ5≯ß; ; xn--tc1a.xn--5-qfa988w745i; ; xn--tc1a.xn--5ss-3m2a5009e;  # 舌.ꡈ5≯ß
+舌.ꡈ5≯ß; ; ; xn--tc1a.xn--5-qfa988w745i; ; xn--tc1a.xn--5ss-3m2a5009e;  # 舌.ꡈ5≯ß
+舌.ꡈ5>\u0338ß; 舌.ꡈ5≯ß; ; xn--tc1a.xn--5-qfa988w745i; ; xn--tc1a.xn--5ss-3m2a5009e;  # 舌.ꡈ5≯ß
+舌.ꡈ5>\u0338SS; 舌.ꡈ5≯ss; ; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+舌.ꡈ5≯SS; 舌.ꡈ5≯ss; ; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+舌.ꡈ5≯ss; ; ; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+舌.ꡈ5>\u0338ss; 舌.ꡈ5≯ss; ; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+舌.ꡈ5>\u0338Ss; 舌.ꡈ5≯ss; ; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+舌.ꡈ5≯Ss; 舌.ꡈ5≯ss; ; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+xn--tc1a.xn--5ss-3m2a5009e; 舌.ꡈ5≯ss; ; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+xn--tc1a.xn--5-qfa988w745i; 舌.ꡈ5≯ß; ; xn--tc1a.xn--5-qfa988w745i; ; ;  # 舌.ꡈ5≯ß
+⾆．ꡈ５>\u0338SS; 舌.ꡈ5≯ss; ; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+⾆．ꡈ５≯SS; 舌.ꡈ5≯ss; ; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+⾆．ꡈ５≯ss; 舌.ꡈ5≯ss; ; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+⾆．ꡈ５>\u0338ss; 舌.ꡈ5≯ss; ; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+⾆．ꡈ５>\u0338Ss; 舌.ꡈ5≯ss; ; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+⾆．ꡈ５≯Ss; 舌.ꡈ5≯ss; ; xn--tc1a.xn--5ss-3m2a5009e; ; ;  # 舌.ꡈ5≯ss
+\u0ACD8\u200D．򾂈\u075C; \u0ACD8\u200D.򾂈\u075C; [B1, B5, B6, C2, V6, V7]; xn--8-yke534n.xn--gpb79046m; ; xn--8-yke.xn--gpb79046m; [B1, B5, B6, V6, V7] # ્8.ݜ
+\u0ACD8\u200D.򾂈\u075C; ; [B1, B5, B6, C2, V6, V7]; xn--8-yke534n.xn--gpb79046m; ; xn--8-yke.xn--gpb79046m; [B1, B5, B6, V6, V7] # ્8.ݜ
+xn--8-yke.xn--gpb79046m; \u0ACD8.򾂈\u075C; [B1, B5, B6, V6, V7]; xn--8-yke.xn--gpb79046m; ; ;  # ્8.ݜ
+xn--8-yke534n.xn--gpb79046m; \u0ACD8\u200D.򾂈\u075C; [B1, B5, B6, C2, V6, V7]; xn--8-yke534n.xn--gpb79046m; ; ;  # ્8.ݜ
+򸷆\u0A70≮򹓙．񞎧⁷󠯙\u06B6; 򸷆\u0A70≮򹓙.񞎧7󠯙\u06B6; [B5, B6, V7]; xn--ycc893jqh38rb6fa.xn--7-5uc53836ixt41c; ; ;  # ੰ≮.7ڶ
+򸷆\u0A70<\u0338򹓙．񞎧⁷󠯙\u06B6; 򸷆\u0A70≮򹓙.񞎧7󠯙\u06B6; [B5, B6, V7]; xn--ycc893jqh38rb6fa.xn--7-5uc53836ixt41c; ; ;  # ੰ≮.7ڶ
+򸷆\u0A70≮򹓙.񞎧7󠯙\u06B6; ; [B5, B6, V7]; xn--ycc893jqh38rb6fa.xn--7-5uc53836ixt41c; ; ;  # ੰ≮.7ڶ
+򸷆\u0A70<\u0338򹓙.񞎧7󠯙\u06B6; 򸷆\u0A70≮򹓙.񞎧7󠯙\u06B6; [B5, B6, V7]; xn--ycc893jqh38rb6fa.xn--7-5uc53836ixt41c; ; ;  # ੰ≮.7ڶ
+xn--ycc893jqh38rb6fa.xn--7-5uc53836ixt41c; 򸷆\u0A70≮򹓙.񞎧7󠯙\u06B6; [B5, B6, V7]; xn--ycc893jqh38rb6fa.xn--7-5uc53836ixt41c; ; ;  # ੰ≮.7ڶ
+𞤪.ς; ; ; xn--ie6h.xn--3xa; ; xn--ie6h.xn--4xa;  # 𞤪.ς
+𞤈.Σ; 𞤪.σ; ; xn--ie6h.xn--4xa; ; ;  # 𞤪.σ
+𞤪.σ; ; ; xn--ie6h.xn--4xa; ; ;  # 𞤪.σ
+𞤈.σ; 𞤪.σ; ; xn--ie6h.xn--4xa; ; ;  # 𞤪.σ
+xn--ie6h.xn--4xa; 𞤪.σ; ; xn--ie6h.xn--4xa; ; ;  # 𞤪.σ
+𞤈.ς; 𞤪.ς; ; xn--ie6h.xn--3xa; ; xn--ie6h.xn--4xa;  # 𞤪.ς
+xn--ie6h.xn--3xa; 𞤪.ς; ; xn--ie6h.xn--3xa; ; ;  # 𞤪.ς
+𞤪.Σ; 𞤪.σ; ; xn--ie6h.xn--4xa; ; ;  # 𞤪.σ
+\u200CႺ｡ς; \u200Cⴚ.ς; [C1]; xn--0ug262c.xn--3xa; ; xn--ilj.xn--4xa; [] # ⴚ.ς
+\u200CႺ。ς; \u200Cⴚ.ς; [C1]; xn--0ug262c.xn--3xa; ; xn--ilj.xn--4xa; [] # ⴚ.ς
+\u200Cⴚ。ς; \u200Cⴚ.ς; [C1]; xn--0ug262c.xn--3xa; ; xn--ilj.xn--4xa; [] # ⴚ.ς
+\u200CႺ。Σ; \u200Cⴚ.σ; [C1]; xn--0ug262c.xn--4xa; ; xn--ilj.xn--4xa; [] # ⴚ.σ
+\u200Cⴚ。σ; \u200Cⴚ.σ; [C1]; xn--0ug262c.xn--4xa; ; xn--ilj.xn--4xa; [] # ⴚ.σ
+xn--ilj.xn--4xa; ⴚ.σ; ; xn--ilj.xn--4xa; ; ;  # ⴚ.σ
+ⴚ.σ; ; ; xn--ilj.xn--4xa; ; ;  # ⴚ.σ
+Ⴚ.Σ; ⴚ.σ; ; xn--ilj.xn--4xa; ; ;  # ⴚ.σ
+ⴚ.ς; ; ; xn--ilj.xn--3xa; ; xn--ilj.xn--4xa;  # ⴚ.ς
+Ⴚ.ς; ⴚ.ς; ; xn--ilj.xn--3xa; ; xn--ilj.xn--4xa;  # ⴚ.ς
+xn--ilj.xn--3xa; ⴚ.ς; ; xn--ilj.xn--3xa; ; ;  # ⴚ.ς
+Ⴚ.σ; ⴚ.σ; ; xn--ilj.xn--4xa; ; ;  # ⴚ.σ
+xn--0ug262c.xn--4xa; \u200Cⴚ.σ; [C1]; xn--0ug262c.xn--4xa; ; ;  # ⴚ.σ
+xn--0ug262c.xn--3xa; \u200Cⴚ.ς; [C1]; xn--0ug262c.xn--3xa; ; ;  # ⴚ.ς
+\u200Cⴚ｡ς; \u200Cⴚ.ς; [C1]; xn--0ug262c.xn--3xa; ; xn--ilj.xn--4xa; [] # ⴚ.ς
+\u200CႺ｡Σ; \u200Cⴚ.σ; [C1]; xn--0ug262c.xn--4xa; ; xn--ilj.xn--4xa; [] # ⴚ.σ
+\u200Cⴚ｡σ; \u200Cⴚ.σ; [C1]; xn--0ug262c.xn--4xa; ; xn--ilj.xn--4xa; [] # ⴚ.σ
+xn--ynd.xn--4xa; Ⴚ.σ; [V7]; xn--ynd.xn--4xa; ; ;  # Ⴚ.σ
+xn--ynd.xn--3xa; Ⴚ.ς; [V7]; xn--ynd.xn--3xa; ; ;  # Ⴚ.ς
+xn--ynd759e.xn--4xa; \u200CႺ.σ; [C1, V7]; xn--ynd759e.xn--4xa; ; ;  # Ⴚ.σ
+xn--ynd759e.xn--3xa; \u200CႺ.ς; [C1, V7]; xn--ynd759e.xn--3xa; ; ;  # Ⴚ.ς
+𞤃．𐹦; 𞤥.𐹦; [B1]; xn--de6h.xn--eo0d; ; ;  # 𞤥.𐹦
+𞤃.𐹦; 𞤥.𐹦; [B1]; xn--de6h.xn--eo0d; ; ;  # 𞤥.𐹦
+𞤥.𐹦; ; [B1]; xn--de6h.xn--eo0d; ; ;  # 𞤥.𐹦
+xn--de6h.xn--eo0d; 𞤥.𐹦; [B1]; xn--de6h.xn--eo0d; ; ;  # 𞤥.𐹦
+𞤥．𐹦; 𞤥.𐹦; [B1]; xn--de6h.xn--eo0d; ; ;  # 𞤥.𐹦
+\u200D⾕。\u200C\u0310\uA953ꡎ; \u200D谷.\u200C\uA953\u0310ꡎ; [C1, C2]; xn--1ug0273b.xn--0sa359l6n7g13a; ; xn--6g3a.xn--0sa8175flwa; [V6] # 谷.꥓̐ꡎ
+\u200D⾕。\u200C\uA953\u0310ꡎ; \u200D谷.\u200C\uA953\u0310ꡎ; [C1, C2]; xn--1ug0273b.xn--0sa359l6n7g13a; ; xn--6g3a.xn--0sa8175flwa; [V6] # 谷.꥓̐ꡎ
+\u200D谷。\u200C\uA953\u0310ꡎ; \u200D谷.\u200C\uA953\u0310ꡎ; [C1, C2]; xn--1ug0273b.xn--0sa359l6n7g13a; ; xn--6g3a.xn--0sa8175flwa; [V6] # 谷.꥓̐ꡎ
+xn--6g3a.xn--0sa8175flwa; 谷.\uA953\u0310ꡎ; [V6]; xn--6g3a.xn--0sa8175flwa; ; ;  # 谷.꥓̐ꡎ
+xn--1ug0273b.xn--0sa359l6n7g13a; \u200D谷.\u200C\uA953\u0310ꡎ; [C1, C2]; xn--1ug0273b.xn--0sa359l6n7g13a; ; ;  # 谷.꥓̐ꡎ
+\u06AA-뉔．𞤐\u200C; \u06AA-뉔.𞤲\u200C; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+\u06AA-뉔．𞤐\u200C; \u06AA-뉔.𞤲\u200C; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+\u06AA-뉔.𞤐\u200C; \u06AA-뉔.𞤲\u200C; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+\u06AA-뉔.𞤐\u200C; \u06AA-뉔.𞤲\u200C; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+\u06AA-뉔.𞤲\u200C; \u06AA-뉔.𞤲\u200C; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+\u06AA-뉔.𞤲\u200C; ; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+xn----guc3592k.xn--qe6h; \u06AA-뉔.𞤲; [B2, B3]; xn----guc3592k.xn--qe6h; ; ;  # ڪ-뉔.𞤲
+xn----guc3592k.xn--0ug7611p; \u06AA-뉔.𞤲\u200C; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; ;  # ڪ-뉔.𞤲
+\u06AA-뉔．𞤲\u200C; \u06AA-뉔.𞤲\u200C; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+\u06AA-뉔．𞤲\u200C; \u06AA-뉔.𞤲\u200C; [B2, B3, C1]; xn----guc3592k.xn--0ug7611p; ; xn----guc3592k.xn--qe6h; [B2, B3] # ڪ-뉔.𞤲
+񔲵５ᦛς.\uA8C4\u077B\u1CD2\u0738; 񔲵5ᦛς.\uA8C4\u077B\u0738\u1CD2; [B1, V6, V7]; xn--5-ymb298ng603j.xn--fob7kk44dl41k; ; xn--5-0mb988ng603j.xn--fob7kk44dl41k;  # 5ᦛς.꣄ݻܸ᳒
+񔲵５ᦛς.\uA8C4\u077B\u0738\u1CD2; 񔲵5ᦛς.\uA8C4\u077B\u0738\u1CD2; [B1, V6, V7]; xn--5-ymb298ng603j.xn--fob7kk44dl41k; ; xn--5-0mb988ng603j.xn--fob7kk44dl41k;  # 5ᦛς.꣄ݻܸ᳒
+񔲵5ᦛς.\uA8C4\u077B\u0738\u1CD2; ; [B1, V6, V7]; xn--5-ymb298ng603j.xn--fob7kk44dl41k; ; xn--5-0mb988ng603j.xn--fob7kk44dl41k;  # 5ᦛς.꣄ݻܸ᳒
+񔲵5ᦛΣ.\uA8C4\u077B\u0738\u1CD2; 񔲵5ᦛσ.\uA8C4\u077B\u0738\u1CD2; [B1, V6, V7]; xn--5-0mb988ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛσ.꣄ݻܸ᳒
+񔲵5ᦛσ.\uA8C4\u077B\u0738\u1CD2; ; [B1, V6, V7]; xn--5-0mb988ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛσ.꣄ݻܸ᳒
+xn--5-0mb988ng603j.xn--fob7kk44dl41k; 񔲵5ᦛσ.\uA8C4\u077B\u0738\u1CD2; [B1, V6, V7]; xn--5-0mb988ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛσ.꣄ݻܸ᳒
+xn--5-ymb298ng603j.xn--fob7kk44dl41k; 񔲵5ᦛς.\uA8C4\u077B\u0738\u1CD2; [B1, V6, V7]; xn--5-ymb298ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛς.꣄ݻܸ᳒
+񔲵５ᦛΣ.\uA8C4\u077B\u0738\u1CD2; 񔲵5ᦛσ.\uA8C4\u077B\u0738\u1CD2; [B1, V6, V7]; xn--5-0mb988ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛσ.꣄ݻܸ᳒
+񔲵５ᦛσ.\uA8C4\u077B\u0738\u1CD2; 񔲵5ᦛσ.\uA8C4\u077B\u0738\u1CD2; [B1, V6, V7]; xn--5-0mb988ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛσ.꣄ݻܸ᳒
+񔲵５ᦛΣ.\uA8C4\u077B\u1CD2\u0738; 񔲵5ᦛσ.\uA8C4\u077B\u0738\u1CD2; [B1, V6, V7]; xn--5-0mb988ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛσ.꣄ݻܸ᳒
+񔲵５ᦛσ.\uA8C4\u077B\u1CD2\u0738; 񔲵5ᦛσ.\uA8C4\u077B\u0738\u1CD2; [B1, V6, V7]; xn--5-0mb988ng603j.xn--fob7kk44dl41k; ; ;  # 5ᦛσ.꣄ݻܸ᳒
+淽。ᠾ; 淽.ᠾ; ; xn--34w.xn--x7e; ; ;  # 淽.ᠾ
+xn--34w.xn--x7e; 淽.ᠾ; ; xn--34w.xn--x7e; ; ;  # 淽.ᠾ
+淽.ᠾ; ; ; xn--34w.xn--x7e; ; ;  # 淽.ᠾ
+𐹴𑘷。-; 𐹴𑘷.-; [B1, V3]; xn--so0do6k.-; ; ;  # 𐹴𑘷.-
+xn--so0do6k.-; 𐹴𑘷.-; [B1, V3]; xn--so0do6k.-; ; ;  # 𐹴𑘷.-
+򬨩Ⴓ❓｡𑄨; 򬨩ⴓ❓.𑄨; [V6, V7]; xn--8di78qvw32y.xn--k80d; ; ;  # ⴓ❓.𑄨
+򬨩Ⴓ❓。𑄨; 򬨩ⴓ❓.𑄨; [V6, V7]; xn--8di78qvw32y.xn--k80d; ; ;  # ⴓ❓.𑄨
+򬨩ⴓ❓。𑄨; 򬨩ⴓ❓.𑄨; [V6, V7]; xn--8di78qvw32y.xn--k80d; ; ;  # ⴓ❓.𑄨
+xn--8di78qvw32y.xn--k80d; 򬨩ⴓ❓.𑄨; [V6, V7]; xn--8di78qvw32y.xn--k80d; ; ;  # ⴓ❓.𑄨
+򬨩ⴓ❓｡𑄨; 򬨩ⴓ❓.𑄨; [V6, V7]; xn--8di78qvw32y.xn--k80d; ; ;  # ⴓ❓.𑄨
+xn--rnd896i0j14q.xn--k80d; 򬨩Ⴓ❓.𑄨; [V6, V7]; xn--rnd896i0j14q.xn--k80d; ; ;  # Ⴓ❓.𑄨
+\u200C𐹡𞤌Ⴇ｡ßႣ; \u200C𐹡𞤮ⴇ.ßⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--zca417t; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ßⴃ
+\u200C𐹡𞤌Ⴇ。ßႣ; \u200C𐹡𞤮ⴇ.ßⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--zca417t; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ßⴃ
+\u200C𐹡𞤮ⴇ。ßⴃ; \u200C𐹡𞤮ⴇ.ßⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--zca417t; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ßⴃ
+\u200C𐹡𞤌Ⴇ。SSႣ; \u200C𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+\u200C𐹡𞤮ⴇ。ssⴃ; \u200C𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+\u200C𐹡𞤌ⴇ。Ssⴃ; \u200C𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+xn--ykj9323eegwf.xn--ss-151a; 𐹡𞤮ⴇ.ssⴃ; [B1]; xn--ykj9323eegwf.xn--ss-151a; ; ;  # 𐹡𞤮ⴇ.ssⴃ
+xn--0ug332c3q0pr56g.xn--ss-151a; \u200C𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; ;  # 𐹡𞤮ⴇ.ssⴃ
+xn--0ug332c3q0pr56g.xn--zca417t; \u200C𐹡𞤮ⴇ.ßⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--zca417t; ; ;  # 𐹡𞤮ⴇ.ßⴃ
+\u200C𐹡𞤮ⴇ｡ßⴃ; \u200C𐹡𞤮ⴇ.ßⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--zca417t; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ßⴃ
+\u200C𐹡𞤌Ⴇ｡SSႣ; \u200C𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+\u200C𐹡𞤮ⴇ｡ssⴃ; \u200C𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+\u200C𐹡𞤌ⴇ｡Ssⴃ; \u200C𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+xn--fnd1201kegrf.xn--ss-fek; 𐹡𞤮Ⴇ.ssႣ; [B1, V7]; xn--fnd1201kegrf.xn--ss-fek; ; ;  # 𐹡𞤮Ⴇ.ssႣ
+xn--fnd599eyj4pr50g.xn--ss-fek; \u200C𐹡𞤮Ⴇ.ssႣ; [B1, C1, V7]; xn--fnd599eyj4pr50g.xn--ss-fek; ; ;  # 𐹡𞤮Ⴇ.ssႣ
+xn--fnd599eyj4pr50g.xn--zca681f; \u200C𐹡𞤮Ⴇ.ßႣ; [B1, C1, V7]; xn--fnd599eyj4pr50g.xn--zca681f; ; ;  # 𐹡𞤮Ⴇ.ßႣ
+\u200C𐹡𞤌ⴇ。ßⴃ; \u200C𐹡𞤮ⴇ.ßⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--zca417t; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ßⴃ
+\u200C𐹡𞤌ⴇ。ssⴃ; \u200C𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+\u200C𐹡𞤌Ⴇ。Ssⴃ; \u200C𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+xn--fnd1201kegrf.xn--ss-151a; 𐹡𞤮Ⴇ.ssⴃ; [B1, V7]; xn--fnd1201kegrf.xn--ss-151a; ; ;  # 𐹡𞤮Ⴇ.ssⴃ
+xn--fnd599eyj4pr50g.xn--ss-151a; \u200C𐹡𞤮Ⴇ.ssⴃ; [B1, C1, V7]; xn--fnd599eyj4pr50g.xn--ss-151a; ; ;  # 𐹡𞤮Ⴇ.ssⴃ
+\u200C𐹡𞤌ⴇ｡ßⴃ; \u200C𐹡𞤮ⴇ.ßⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--zca417t; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ßⴃ
+\u200C𐹡𞤌ⴇ｡ssⴃ; \u200C𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+\u200C𐹡𞤌Ⴇ｡Ssⴃ; \u200C𐹡𞤮ⴇ.ssⴃ; [B1, C1]; xn--0ug332c3q0pr56g.xn--ss-151a; ; xn--ykj9323eegwf.xn--ss-151a; [B1] # 𐹡𞤮ⴇ.ssⴃ
+\u17FF｡𞬳; \u17FF.𞬳; [V7]; xn--45e.xn--et6h; ; ;  # .
+\u17FF。𞬳; \u17FF.𞬳; [V7]; xn--45e.xn--et6h; ; ;  # .
+xn--45e.xn--et6h; \u17FF.𞬳; [V7]; xn--45e.xn--et6h; ; ;  # .
+\u0652\u200D｡\u0CCD𑚳; \u0652\u200D.\u0CCD𑚳; [C2, V6]; xn--uhb882k.xn--8tc4527k; ; xn--uhb.xn--8tc4527k; [V6] # ْ.್𑚳
+\u0652\u200D。\u0CCD𑚳; \u0652\u200D.\u0CCD𑚳; [C2, V6]; xn--uhb882k.xn--8tc4527k; ; xn--uhb.xn--8tc4527k; [V6] # ْ.್𑚳
+xn--uhb.xn--8tc4527k; \u0652.\u0CCD𑚳; [V6]; xn--uhb.xn--8tc4527k; ; ;  # ْ.್𑚳
+xn--uhb882k.xn--8tc4527k; \u0652\u200D.\u0CCD𑚳; [C2, V6]; xn--uhb882k.xn--8tc4527k; ; ;  # ْ.್𑚳
+-≠ᠻ．\u076D𞥃≮󟷺; -≠ᠻ.\u076D𞥃≮󟷺; [B1, B2, B3, V3, V7]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+-=\u0338ᠻ．\u076D𞥃<\u0338󟷺; -≠ᠻ.\u076D𞥃≮󟷺; [B1, B2, B3, V3, V7]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+-≠ᠻ.\u076D𞥃≮󟷺; ; [B1, B2, B3, V3, V7]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+-=\u0338ᠻ.\u076D𞥃<\u0338󟷺; -≠ᠻ.\u076D𞥃≮󟷺; [B1, B2, B3, V3, V7]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+-=\u0338ᠻ.\u076D𞤡<\u0338󟷺; -≠ᠻ.\u076D𞥃≮󟷺; [B1, B2, B3, V3, V7]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+-≠ᠻ.\u076D𞤡≮󟷺; -≠ᠻ.\u076D𞥃≮󟷺; [B1, B2, B3, V3, V7]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+xn----g6j886c.xn--xpb049kk353abj99f; -≠ᠻ.\u076D𞥃≮󟷺; [B1, B2, B3, V3, V7]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+-=\u0338ᠻ．\u076D𞤡<\u0338󟷺; -≠ᠻ.\u076D𞥃≮󟷺; [B1, B2, B3, V3, V7]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+-≠ᠻ．\u076D𞤡≮󟷺; -≠ᠻ.\u076D𞥃≮󟷺; [B1, B2, B3, V3, V7]; xn----g6j886c.xn--xpb049kk353abj99f; ; ;  # -≠ᠻ.ݭ𞥃≮
+󠰆≯\u07B5𐻪．򊥕≮𑁆\u084C; 󠰆≯\u07B5𐻪.򊥕≮𑁆\u084C; [B1, B5, B6, V7]; xn--zrb797kdm1oes34i.xn--bwb394k8k2o25n6d; ; ;  # ≯.≮𑁆ࡌ
+󠰆>\u0338\u07B5𐻪．򊥕<\u0338𑁆\u084C; 󠰆≯\u07B5𐻪.򊥕≮𑁆\u084C; [B1, B5, B6, V7]; xn--zrb797kdm1oes34i.xn--bwb394k8k2o25n6d; ; ;  # ≯.≮𑁆ࡌ
+󠰆≯\u07B5𐻪.򊥕≮𑁆\u084C; ; [B1, B5, B6, V7]; xn--zrb797kdm1oes34i.xn--bwb394k8k2o25n6d; ; ;  # ≯.≮𑁆ࡌ
+󠰆>\u0338\u07B5𐻪.򊥕<\u0338𑁆\u084C; 󠰆≯\u07B5𐻪.򊥕≮𑁆\u084C; [B1, B5, B6, V7]; xn--zrb797kdm1oes34i.xn--bwb394k8k2o25n6d; ; ;  # ≯.≮𑁆ࡌ
+xn--zrb797kdm1oes34i.xn--bwb394k8k2o25n6d; 󠰆≯\u07B5𐻪.򊥕≮𑁆\u084C; [B1, B5, B6, V7]; xn--zrb797kdm1oes34i.xn--bwb394k8k2o25n6d; ; ;  # ≯.≮𑁆ࡌ
+≠󦋂.\u0600\u0BCD-\u06B9; ; [B1, V7]; xn--1ch22084l.xn----qkc07co6n; ; ;  # ≠.்-ڹ
+=\u0338󦋂.\u0600\u0BCD-\u06B9; ≠󦋂.\u0600\u0BCD-\u06B9; [B1, V7]; xn--1ch22084l.xn----qkc07co6n; ; ;  # ≠.்-ڹ
+xn--1ch22084l.xn----qkc07co6n; ≠󦋂.\u0600\u0BCD-\u06B9; [B1, V7]; xn--1ch22084l.xn----qkc07co6n; ; ;  # ≠.்-ڹ
+\u17DD󠁣≠｡𐹼𐋤; \u17DD󠁣≠.𐹼𐋤; [B1, V6, V7]; xn--54e694cn389z.xn--787ct8r; ; ;  # ៝≠.𐹼𐋤
+\u17DD󠁣=\u0338｡𐹼𐋤; \u17DD󠁣≠.𐹼𐋤; [B1, V6, V7]; xn--54e694cn389z.xn--787ct8r; ; ;  # ៝≠.𐹼𐋤
+\u17DD󠁣≠。𐹼𐋤; \u17DD󠁣≠.𐹼𐋤; [B1, V6, V7]; xn--54e694cn389z.xn--787ct8r; ; ;  # ៝≠.𐹼𐋤
+\u17DD󠁣=\u0338。𐹼𐋤; \u17DD󠁣≠.𐹼𐋤; [B1, V6, V7]; xn--54e694cn389z.xn--787ct8r; ; ;  # ៝≠.𐹼𐋤
+xn--54e694cn389z.xn--787ct8r; \u17DD󠁣≠.𐹼𐋤; [B1, V6, V7]; xn--54e694cn389z.xn--787ct8r; ; ;  # ៝≠.𐹼𐋤
+ß𰀻񆬗｡𝩨🕮ß; ß𰀻񆬗.𝩨🕮ß; [V6, V7]; xn--zca20040bgrkh.xn--zca3653v86qa; ; xn--ss-jl59biy67d.xn--ss-4d11aw87d;  # ß𰀻.𝩨🕮ß
+ß𰀻񆬗。𝩨🕮ß; ß𰀻񆬗.𝩨🕮ß; [V6, V7]; xn--zca20040bgrkh.xn--zca3653v86qa; ; xn--ss-jl59biy67d.xn--ss-4d11aw87d;  # ß𰀻.𝩨🕮ß
+SS𰀻񆬗。𝩨🕮SS; ss𰀻񆬗.𝩨🕮ss; [V6, V7]; xn--ss-jl59biy67d.xn--ss-4d11aw87d; ; ;  # ss𰀻.𝩨🕮ss
+ss𰀻񆬗。𝩨🕮ss; ss𰀻񆬗.𝩨🕮ss; [V6, V7]; xn--ss-jl59biy67d.xn--ss-4d11aw87d; ; ;  # ss𰀻.𝩨🕮ss
+Ss𰀻񆬗。𝩨🕮Ss; ss𰀻񆬗.𝩨🕮ss; [V6, V7]; xn--ss-jl59biy67d.xn--ss-4d11aw87d; ; ;  # ss𰀻.𝩨🕮ss
+xn--ss-jl59biy67d.xn--ss-4d11aw87d; ss𰀻񆬗.𝩨🕮ss; [V6, V7]; xn--ss-jl59biy67d.xn--ss-4d11aw87d; ; ;  # ss𰀻.𝩨🕮ss
+xn--zca20040bgrkh.xn--zca3653v86qa; ß𰀻񆬗.𝩨🕮ß; [V6, V7]; xn--zca20040bgrkh.xn--zca3653v86qa; ; ;  # ß𰀻.𝩨🕮ß
+SS𰀻񆬗｡𝩨🕮SS; ss𰀻񆬗.𝩨🕮ss; [V6, V7]; xn--ss-jl59biy67d.xn--ss-4d11aw87d; ; ;  # ss𰀻.𝩨🕮ss
+ss𰀻񆬗｡𝩨🕮ss; ss𰀻񆬗.𝩨🕮ss; [V6, V7]; xn--ss-jl59biy67d.xn--ss-4d11aw87d; ; ;  # ss𰀻.𝩨🕮ss
+Ss𰀻񆬗｡𝩨🕮Ss; ss𰀻񆬗.𝩨🕮ss; [V6, V7]; xn--ss-jl59biy67d.xn--ss-4d11aw87d; ; ;  # ss𰀻.𝩨🕮ss
+\u200D。\u200C; \u200D.\u200C; [C1, C2]; xn--1ug.xn--0ug; ; .; [A4_1, A4_2] # .
+xn--1ug.xn--0ug; \u200D.\u200C; [C1, C2]; xn--1ug.xn--0ug; ; ;  # .
+\u0483𐭞\u200D.\u17B9𞯌򟩚; ; [B1, C2, V6, V7]; xn--m3a412lrr0o.xn--43e8670vmd79b; ; xn--m3a6965k.xn--43e8670vmd79b; [B1, V6, V7] # ҃𐭞.ឹ
+xn--m3a6965k.xn--43e8670vmd79b; \u0483𐭞.\u17B9𞯌򟩚; [B1, V6, V7]; xn--m3a6965k.xn--43e8670vmd79b; ; ;  # ҃𐭞.ឹ
+xn--m3a412lrr0o.xn--43e8670vmd79b; \u0483𐭞\u200D.\u17B9𞯌򟩚; [B1, C2, V6, V7]; xn--m3a412lrr0o.xn--43e8670vmd79b; ; ;  # ҃𐭞.ឹ
+\u200C𐠨\u200C临。ꡢ򄷞ⶏ𐹣; \u200C𐠨\u200C临.ꡢ򄷞ⶏ𐹣; [B1, B5, B6, C1, V7]; xn--0uga2656aop9k.xn--uojv340bk71c99u9f; ; xn--miq9646b.xn--uojv340bk71c99u9f; [B2, B3, B5, B6, V7] # 𐠨临.ꡢⶏ𐹣
+xn--miq9646b.xn--uojv340bk71c99u9f; 𐠨临.ꡢ򄷞ⶏ𐹣; [B2, B3, B5, B6, V7]; xn--miq9646b.xn--uojv340bk71c99u9f; ; ;  # 𐠨临.ꡢⶏ𐹣
+xn--0uga2656aop9k.xn--uojv340bk71c99u9f; \u200C𐠨\u200C临.ꡢ򄷞ⶏ𐹣; [B1, B5, B6, C1, V7]; xn--0uga2656aop9k.xn--uojv340bk71c99u9f; ; ;  # 𐠨临.ꡢⶏ𐹣
+󠑘．󠄮; 󠑘.; [V7]; xn--s136e.; [V7, A4_2]; ;  # .
+󠑘.󠄮; 󠑘.; [V7]; xn--s136e.; [V7, A4_2]; ;  # .
+xn--s136e.; 󠑘.; [V7]; xn--s136e.; [V7, A4_2]; ;  # .
+𐫄\u0D4D．\uAAF6; 𐫄\u0D4D.\uAAF6; [B1, V6]; xn--wxc7880k.xn--2v9a; ; ;  # 𐫄്.꫶
+𐫄\u0D4D.\uAAF6; ; [B1, V6]; xn--wxc7880k.xn--2v9a; ; ;  # 𐫄്.꫶
+xn--wxc7880k.xn--2v9a; 𐫄\u0D4D.\uAAF6; [B1, V6]; xn--wxc7880k.xn--2v9a; ; ;  # 𐫄്.꫶
+\uA9B7󝵙멹。⒛󠨇; \uA9B7󝵙멹.⒛󠨇; [V6, V7]; xn--ym9av13acp85w.xn--dth22121k; ; ;  # ꦷ멹.⒛
+\uA9B7󝵙멹。⒛󠨇; \uA9B7󝵙멹.⒛󠨇; [V6, V7]; xn--ym9av13acp85w.xn--dth22121k; ; ;  # ꦷ멹.⒛
+\uA9B7󝵙멹。20.󠨇; \uA9B7󝵙멹.20.󠨇; [V6, V7]; xn--ym9av13acp85w.20.xn--d846e; ; ;  # ꦷ멹.20.
+\uA9B7󝵙멹。20.󠨇; \uA9B7󝵙멹.20.󠨇; [V6, V7]; xn--ym9av13acp85w.20.xn--d846e; ; ;  # ꦷ멹.20.
+xn--ym9av13acp85w.20.xn--d846e; \uA9B7󝵙멹.20.󠨇; [V6, V7]; xn--ym9av13acp85w.20.xn--d846e; ; ;  # ꦷ멹.20.
+xn--ym9av13acp85w.xn--dth22121k; \uA9B7󝵙멹.⒛󠨇; [V6, V7]; xn--ym9av13acp85w.xn--dth22121k; ; ;  # ꦷ멹.⒛
+Ⴅ󲬹릖󠶚.\u0777𐹳⒊; ⴅ󲬹릖󠶚.\u0777𐹳⒊; [B4, B6, V7]; xn--wkj8016bne45io02g.xn--7pb000mwm4n; ; ;  # ⴅ릖.ݷ𐹳⒊
+Ⴅ󲬹릖󠶚.\u0777𐹳⒊; ⴅ󲬹릖󠶚.\u0777𐹳⒊; [B4, B6, V7]; xn--wkj8016bne45io02g.xn--7pb000mwm4n; ; ;  # ⴅ릖.ݷ𐹳⒊
+Ⴅ󲬹릖󠶚.\u0777𐹳3.; ⴅ󲬹릖󠶚.\u0777𐹳3.; [B4, B6, V7]; xn--wkj8016bne45io02g.xn--3-55c6803r.; [B4, B6, V7, A4_2]; ;  # ⴅ릖.ݷ𐹳3.
+Ⴅ󲬹릖󠶚.\u0777𐹳3.; ⴅ󲬹릖󠶚.\u0777𐹳3.; [B4, B6, V7]; xn--wkj8016bne45io02g.xn--3-55c6803r.; [B4, B6, V7, A4_2]; ;  # ⴅ릖.ݷ𐹳3.
+ⴅ󲬹릖󠶚.\u0777𐹳3.; ⴅ󲬹릖󠶚.\u0777𐹳3.; [B4, B6, V7]; xn--wkj8016bne45io02g.xn--3-55c6803r.; [B4, B6, V7, A4_2]; ;  # ⴅ릖.ݷ𐹳3.
+ⴅ󲬹릖󠶚.\u0777𐹳3.; ; [B4, B6, V7]; xn--wkj8016bne45io02g.xn--3-55c6803r.; [B4, B6, V7, A4_2]; ;  # ⴅ릖.ݷ𐹳3.
+xn--wkj8016bne45io02g.xn--3-55c6803r.; ⴅ󲬹릖󠶚.\u0777𐹳3.; [B4, B6, V7]; xn--wkj8016bne45io02g.xn--3-55c6803r.; [B4, B6, V7, A4_2]; ;  # ⴅ릖.ݷ𐹳3.
+ⴅ󲬹릖󠶚.\u0777𐹳⒊; ⴅ󲬹릖󠶚.\u0777𐹳⒊; [B4, B6, V7]; xn--wkj8016bne45io02g.xn--7pb000mwm4n; ; ;  # ⴅ릖.ݷ𐹳⒊
+ⴅ󲬹릖󠶚.\u0777𐹳⒊; ; [B4, B6, V7]; xn--wkj8016bne45io02g.xn--7pb000mwm4n; ; ;  # ⴅ릖.ݷ𐹳⒊
+xn--wkj8016bne45io02g.xn--7pb000mwm4n; ⴅ󲬹릖󠶚.\u0777𐹳⒊; [B4, B6, V7]; xn--wkj8016bne45io02g.xn--7pb000mwm4n; ; ;  # ⴅ릖.ݷ𐹳⒊
+xn--dnd2167fnet0io02g.xn--3-55c6803r.; Ⴅ󲬹릖󠶚.\u0777𐹳3.; [B4, B6, V7]; xn--dnd2167fnet0io02g.xn--3-55c6803r.; [B4, B6, V7, A4_2]; ;  # Ⴅ릖.ݷ𐹳3.
+xn--dnd2167fnet0io02g.xn--7pb000mwm4n; Ⴅ󲬹릖󠶚.\u0777𐹳⒊; [B4, B6, V7]; xn--dnd2167fnet0io02g.xn--7pb000mwm4n; ; ;  # Ⴅ릖.ݷ𐹳⒊
+\u200C｡︒; \u200C.︒; [C1, V7]; xn--0ug.xn--y86c; ; .xn--y86c; [V7, A4_2] # .︒
+\u200C。。; \u200C..; [C1, X4_2]; xn--0ug..; [C1, A4_2]; ..; [A4_2] # ..
+..; ; [X4_2]; ; [A4_2]; ;  # ..
+xn--0ug..; \u200C..; [C1, X4_2]; xn--0ug..; [C1, A4_2]; ;  # ..
+.xn--y86c; .︒; [V7, X4_2]; .xn--y86c; [V7, A4_2]; ;  # .︒
+xn--0ug.xn--y86c; \u200C.︒; [C1, V7]; xn--0ug.xn--y86c; ; ;  # .︒
+≯\u076D．₄; ≯\u076D.4; [B1]; xn--xpb149k.4; ; ;  # ≯ݭ.4
+>\u0338\u076D．₄; ≯\u076D.4; [B1]; xn--xpb149k.4; ; ;  # ≯ݭ.4
+≯\u076D.e; ; [B1]; xn--xpb149k.e; ; ;  # ≯ݭ.e
+>\u0338\u076D.e; ≯\u076D.e; [B1]; xn--xpb149k.e; ; ;  # ≯ݭ.e
+>\u0338\u076D.E; ≯\u076D.e; [B1]; xn--xpb149k.e; ; ;  # ≯ݭ.e
+≯\u076D.E; ≯\u076D.e; [B1]; xn--xpb149k.e; ; ;  # ≯ݭ.e
+xn--xpb149k.e; ≯\u076D.e; [B1]; xn--xpb149k.e; ; ;  # ≯ݭ.e
+ᡲ-𝟹.ß-\u200C-; ᡲ-3.ß-\u200C-; [C1, V3]; xn---3-p9o.xn-----fia9303a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ß--
+ᡲ-3.ß-\u200C-; ; [C1, V3]; xn---3-p9o.xn-----fia9303a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ß--
+ᡲ-3.SS-\u200C-; ᡲ-3.ss-\u200C-; [C1, V3]; xn---3-p9o.xn--ss---276a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ss--
+ᡲ-3.ss-\u200C-; ; [C1, V3]; xn---3-p9o.xn--ss---276a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ss--
+ᡲ-3.Ss-\u200C-; ᡲ-3.ss-\u200C-; [C1, V3]; xn---3-p9o.xn--ss---276a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ss--
+xn---3-p9o.ss--; ᡲ-3.ss--; [V2, V3]; xn---3-p9o.ss--; ; ;  # ᡲ-3.ss--
+xn---3-p9o.xn--ss---276a; ᡲ-3.ss-\u200C-; [C1, V3]; xn---3-p9o.xn--ss---276a; ; ;  # ᡲ-3.ss--
+xn---3-p9o.xn-----fia9303a; ᡲ-3.ß-\u200C-; [C1, V3]; xn---3-p9o.xn-----fia9303a; ; ;  # ᡲ-3.ß--
+ᡲ-𝟹.SS-\u200C-; ᡲ-3.ss-\u200C-; [C1, V3]; xn---3-p9o.xn--ss---276a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ss--
+ᡲ-𝟹.ss-\u200C-; ᡲ-3.ss-\u200C-; [C1, V3]; xn---3-p9o.xn--ss---276a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ss--
+ᡲ-𝟹.Ss-\u200C-; ᡲ-3.ss-\u200C-; [C1, V3]; xn---3-p9o.xn--ss---276a; ; xn---3-p9o.ss--; [V2, V3] # ᡲ-3.ss--
+\uFD08𝟦\u0647󎊯｡Ӏ; \u0636\u064A4\u0647󎊯.ӏ; [B2, B3, V7]; xn--4-tnc6ck183523b.xn--s5a; ; ;  # ضي4ه.ӏ
+\u0636\u064A4\u0647󎊯。Ӏ; \u0636\u064A4\u0647󎊯.ӏ; [B2, B3, V7]; xn--4-tnc6ck183523b.xn--s5a; ; ;  # ضي4ه.ӏ
+\u0636\u064A4\u0647󎊯。ӏ; \u0636\u064A4\u0647󎊯.ӏ; [B2, B3, V7]; xn--4-tnc6ck183523b.xn--s5a; ; ;  # ضي4ه.ӏ
+xn--4-tnc6ck183523b.xn--s5a; \u0636\u064A4\u0647󎊯.ӏ; [B2, B3, V7]; xn--4-tnc6ck183523b.xn--s5a; ; ;  # ضي4ه.ӏ
+\uFD08𝟦\u0647󎊯｡ӏ; \u0636\u064A4\u0647󎊯.ӏ; [B2, B3, V7]; xn--4-tnc6ck183523b.xn--s5a; ; ;  # ضي4ه.ӏ
+xn--4-tnc6ck183523b.xn--d5a; \u0636\u064A4\u0647󎊯.Ӏ; [B2, B3, V7]; xn--4-tnc6ck183523b.xn--d5a; ; ;  # ضي4ه.Ӏ
+-.\u0602\u0622𑆾🐹; ; [B1, V3, V7]; -.xn--kfb8dy983hgl7g; ; ;  # -.آ𑆾🐹
+-.\u0602\u0627\u0653𑆾🐹; -.\u0602\u0622𑆾🐹; [B1, V3, V7]; -.xn--kfb8dy983hgl7g; ; ;  # -.آ𑆾🐹
+-.xn--kfb8dy983hgl7g; -.\u0602\u0622𑆾🐹; [B1, V3, V7]; -.xn--kfb8dy983hgl7g; ; ;  # -.آ𑆾🐹
+󙶜ᢘ。\u1A7F⺢; 󙶜ᢘ.\u1A7F⺢; [V6, V7]; xn--ibf35138o.xn--fpfz94g; ; ;  # ᢘ.᩿⺢
+xn--ibf35138o.xn--fpfz94g; 󙶜ᢘ.\u1A7F⺢; [V6, V7]; xn--ibf35138o.xn--fpfz94g; ; ;  # ᢘ.᩿⺢
+≠ႷᠤႫ｡?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+=\u0338ႷᠤႫ｡?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+≠ႷᠤႫ。?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+=\u0338ႷᠤႫ。?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+=\u0338ⴗᠤⴋ。?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+≠ⴗᠤⴋ。?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+≠Ⴗᠤⴋ。?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+=\u0338Ⴗᠤⴋ。?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+xn--66e353ce0ilb.xn--?-7fb34t0u7s; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+=\u0338ⴗᠤⴋ｡?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+≠ⴗᠤⴋ｡?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+≠Ⴗᠤⴋ｡?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+=\u0338Ⴗᠤⴋ｡?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+xn--vnd619as6ig6k.xn--?-7fb34t0u7s; ≠Ⴗᠤⴋ.?\u034C\u0633觴; [B1, V7, U1]; xn--vnd619as6ig6k.xn--?-7fb34t0u7s; ; ;  # ≠Ⴗᠤⴋ.?͌س觴
+xn--jndx718cnnl.xn--?-7fb34t0u7s; ≠ႷᠤႫ.?\u034C\u0633觴; [B1, V7, U1]; xn--jndx718cnnl.xn--?-7fb34t0u7s; ; ;  # ≠ႷᠤႫ.?͌س觴
+xn--vnd619as6ig6k.?\u034C\u0633觴; ≠Ⴗᠤⴋ.?\u034C\u0633觴; [B1, V7, U1]; xn--vnd619as6ig6k.xn--?-7fb34t0u7s; ; ;  # ≠Ⴗᠤⴋ.?͌س觴
+XN--VND619AS6IG6K.?\u034C\u0633觴; ≠Ⴗᠤⴋ.?\u034C\u0633觴; [B1, V7, U1]; xn--vnd619as6ig6k.xn--?-7fb34t0u7s; ; ;  # ≠Ⴗᠤⴋ.?͌س觴
+Xn--Vnd619as6ig6k.?\u034C\u0633觴; ≠Ⴗᠤⴋ.?\u034C\u0633觴; [B1, V7, U1]; xn--vnd619as6ig6k.xn--?-7fb34t0u7s; ; ;  # ≠Ⴗᠤⴋ.?͌س觴
+xn--66e353ce0ilb.?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+XN--66E353CE0ILB.?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+Xn--66e353ce0ilb.?\u034C\u0633觴; ≠ⴗᠤⴋ.?\u034C\u0633觴; [B1, U1]; xn--66e353ce0ilb.xn--?-7fb34t0u7s; ; ;  # ≠ⴗᠤⴋ.?͌س觴
+xn--jndx718cnnl.?\u034C\u0633觴; ≠ႷᠤႫ.?\u034C\u0633觴; [B1, V7, U1]; xn--jndx718cnnl.xn--?-7fb34t0u7s; ; ;  # ≠ႷᠤႫ.?͌س觴
+XN--JNDX718CNNL.?\u034C\u0633觴; ≠ႷᠤႫ.?\u034C\u0633觴; [B1, V7, U1]; xn--jndx718cnnl.xn--?-7fb34t0u7s; ; ;  # ≠ႷᠤႫ.?͌س觴
+Xn--Jndx718cnnl.?\u034C\u0633觴; ≠ႷᠤႫ.?\u034C\u0633觴; [B1, V7, U1]; xn--jndx718cnnl.xn--?-7fb34t0u7s; ; ;  # ≠ႷᠤႫ.?͌س觴
+\u0667.𐥨; ; [B1, V7]; xn--gib.xn--vm9c; ; ;  # ٧.
+xn--gib.xn--vm9c; \u0667.𐥨; [B1, V7]; xn--gib.xn--vm9c; ; ;  # ٧.
+\uA9C0𝟯｡\u200D񼑥𐹪\u1BF3; \uA9C03.\u200D񼑥𐹪\u1BF3; [B1, C2, V6, V7]; xn--3-5z4e.xn--1zf96ony8ygd68c; ; xn--3-5z4e.xn--1zfz754hncv8b; [B5, V6, V7] # ꧀3.𐹪᯳
+\uA9C03。\u200D񼑥𐹪\u1BF3; \uA9C03.\u200D񼑥𐹪\u1BF3; [B1, C2, V6, V7]; xn--3-5z4e.xn--1zf96ony8ygd68c; ; xn--3-5z4e.xn--1zfz754hncv8b; [B5, V6, V7] # ꧀3.𐹪᯳
+xn--3-5z4e.xn--1zfz754hncv8b; \uA9C03.񼑥𐹪\u1BF3; [B5, V6, V7]; xn--3-5z4e.xn--1zfz754hncv8b; ; ;  # ꧀3.𐹪᯳
+xn--3-5z4e.xn--1zf96ony8ygd68c; \uA9C03.\u200D񼑥𐹪\u1BF3; [B1, C2, V6, V7]; xn--3-5z4e.xn--1zf96ony8ygd68c; ; ;  # ꧀3.𐹪᯳
+򣕄4񠖽.≯\u0664𑀾󠸌; ; [B1, V7]; xn--4-fg85dl688i.xn--dib174li86ntdy0i; ; ;  # 4.≯٤𑀾
+򣕄4񠖽.>\u0338\u0664𑀾󠸌; 򣕄4񠖽.≯\u0664𑀾󠸌; [B1, V7]; xn--4-fg85dl688i.xn--dib174li86ntdy0i; ; ;  # 4.≯٤𑀾
+xn--4-fg85dl688i.xn--dib174li86ntdy0i; 򣕄4񠖽.≯\u0664𑀾󠸌; [B1, V7]; xn--4-fg85dl688i.xn--dib174li86ntdy0i; ; ;  # 4.≯٤𑀾
+򗆧𝟯。⒈\u1A76𝟚򠘌; 򗆧3.⒈\u1A762򠘌; [V7]; xn--3-rj42h.xn--2-13k746cq465x; ; ;  # 3.⒈᩶2
+򗆧3。1.\u1A762򠘌; 򗆧3.1.\u1A762򠘌; [V6, V7]; xn--3-rj42h.1.xn--2-13k96240l; ; ;  # 3.1.᩶2
+xn--3-rj42h.1.xn--2-13k96240l; 򗆧3.1.\u1A762򠘌; [V6, V7]; xn--3-rj42h.1.xn--2-13k96240l; ; ;  # 3.1.᩶2
+xn--3-rj42h.xn--2-13k746cq465x; 򗆧3.⒈\u1A762򠘌; [V7]; xn--3-rj42h.xn--2-13k746cq465x; ; ;  # 3.⒈᩶2
+\u200D₅⒈。≯𝟴\u200D; \u200D5⒈.≯8\u200D; [C2, V7]; xn--5-tgnz5r.xn--8-ugn00i; ; xn--5-ecp.xn--8-ogo; [V7] # 5⒈.≯8
+\u200D₅⒈。>\u0338𝟴\u200D; \u200D5⒈.≯8\u200D; [C2, V7]; xn--5-tgnz5r.xn--8-ugn00i; ; xn--5-ecp.xn--8-ogo; [V7] # 5⒈.≯8
+\u200D51.。≯8\u200D; \u200D51..≯8\u200D; [C2, X4_2]; xn--51-l1t..xn--8-ugn00i; [C2, A4_2]; 51..xn--8-ogo; [A4_2] # 51..≯8
+\u200D51.。>\u03388\u200D; \u200D51..≯8\u200D; [C2, X4_2]; xn--51-l1t..xn--8-ugn00i; [C2, A4_2]; 51..xn--8-ogo; [A4_2] # 51..≯8
+51..xn--8-ogo; 51..≯8; [X4_2]; 51..xn--8-ogo; [A4_2]; ;  # 51..≯8
+xn--51-l1t..xn--8-ugn00i; \u200D51..≯8\u200D; [C2, X4_2]; xn--51-l1t..xn--8-ugn00i; [C2, A4_2]; ;  # 51..≯8
+xn--5-ecp.xn--8-ogo; 5⒈.≯8; [V7]; xn--5-ecp.xn--8-ogo; ; ;  # 5⒈.≯8
+xn--5-tgnz5r.xn--8-ugn00i; \u200D5⒈.≯8\u200D; [C2, V7]; xn--5-tgnz5r.xn--8-ugn00i; ; ;  # 5⒈.≯8
+ꡰ\u0697\u1086．򪘙\u072F≠\u200C; ꡰ\u0697\u1086.򪘙\u072F≠\u200C; [B5, B6, C1, V7]; xn--tjb002cn51k.xn--5nb448jcubcz547b; ; xn--tjb002cn51k.xn--5nb630lbj91q; [B5, B6, V7] # ꡰڗႆ.ܯ≠
+ꡰ\u0697\u1086．򪘙\u072F=\u0338\u200C; ꡰ\u0697\u1086.򪘙\u072F≠\u200C; [B5, B6, C1, V7]; xn--tjb002cn51k.xn--5nb448jcubcz547b; ; xn--tjb002cn51k.xn--5nb630lbj91q; [B5, B6, V7] # ꡰڗႆ.ܯ≠
+ꡰ\u0697\u1086.򪘙\u072F≠\u200C; ; [B5, B6, C1, V7]; xn--tjb002cn51k.xn--5nb448jcubcz547b; ; xn--tjb002cn51k.xn--5nb630lbj91q; [B5, B6, V7] # ꡰڗႆ.ܯ≠
+ꡰ\u0697\u1086.򪘙\u072F=\u0338\u200C; ꡰ\u0697\u1086.򪘙\u072F≠\u200C; [B5, B6, C1, V7]; xn--tjb002cn51k.xn--5nb448jcubcz547b; ; xn--tjb002cn51k.xn--5nb630lbj91q; [B5, B6, V7] # ꡰڗႆ.ܯ≠
+xn--tjb002cn51k.xn--5nb630lbj91q; ꡰ\u0697\u1086.򪘙\u072F≠; [B5, B6, V7]; xn--tjb002cn51k.xn--5nb630lbj91q; ; ;  # ꡰڗႆ.ܯ≠
+xn--tjb002cn51k.xn--5nb448jcubcz547b; ꡰ\u0697\u1086.򪘙\u072F≠\u200C; [B5, B6, C1, V7]; xn--tjb002cn51k.xn--5nb448jcubcz547b; ; ;  # ꡰڗႆ.ܯ≠
+𑄱｡򪌿𐹵; 𑄱.򪌿𐹵; [B1, B5, B6, V6, V7]; xn--t80d.xn--to0d14792b; ; ;  # 𑄱.𐹵
+𑄱。򪌿𐹵; 𑄱.򪌿𐹵; [B1, B5, B6, V6, V7]; xn--t80d.xn--to0d14792b; ; ;  # 𑄱.𐹵
+xn--t80d.xn--to0d14792b; 𑄱.򪌿𐹵; [B1, B5, B6, V6, V7]; xn--t80d.xn--to0d14792b; ; ;  # 𑄱.𐹵
+𝟥\u0600。\u073D; 3\u0600.\u073D; [B1, V6, V7]; xn--3-rkc.xn--kob; ; ;  # 3.ܽ
+3\u0600。\u073D; 3\u0600.\u073D; [B1, V6, V7]; xn--3-rkc.xn--kob; ; ;  # 3.ܽ
+xn--3-rkc.xn--kob; 3\u0600.\u073D; [B1, V6, V7]; xn--3-rkc.xn--kob; ; ;  # 3.ܽ
+\u0637𐹣\u0666.\u076D긷; ; [B2, B3]; xn--2gb8gu829f.xn--xpb0156f; ; ;  # ط𐹣٦.ݭ긷
+\u0637𐹣\u0666.\u076D긷; \u0637𐹣\u0666.\u076D긷; [B2, B3]; xn--2gb8gu829f.xn--xpb0156f; ; ;  # ط𐹣٦.ݭ긷
+xn--2gb8gu829f.xn--xpb0156f; \u0637𐹣\u0666.\u076D긷; [B2, B3]; xn--2gb8gu829f.xn--xpb0156f; ; ;  # ط𐹣٦.ݭ긷
+︒Ↄ\u2DE7򾀃．Ⴗ𐣞; ︒ↄ\u2DE7򾀃.ⴗ𐣞; [B1, B5, B6, V7]; xn--r5gy00c056n0226g.xn--flj4541e; ; ;  # ︒ↄⷧ.ⴗ
+。Ↄ\u2DE7򾀃.Ⴗ𐣞; .ↄ\u2DE7򾀃.ⴗ𐣞; [B5, B6, V7, X4_2]; .xn--r5gy00cll06u.xn--flj4541e; [B5, B6, V7, A4_2]; ;  # .ↄⷧ.ⴗ
+。ↄ\u2DE7򾀃.ⴗ𐣞; .ↄ\u2DE7򾀃.ⴗ𐣞; [B5, B6, V7, X4_2]; .xn--r5gy00cll06u.xn--flj4541e; [B5, B6, V7, A4_2]; ;  # .ↄⷧ.ⴗ
+.xn--r5gy00cll06u.xn--flj4541e; .ↄ\u2DE7򾀃.ⴗ𐣞; [B5, B6, V7, X4_2]; .xn--r5gy00cll06u.xn--flj4541e; [B5, B6, V7, A4_2]; ;  # .ↄⷧ.ⴗ
+︒ↄ\u2DE7򾀃．ⴗ𐣞; ︒ↄ\u2DE7򾀃.ⴗ𐣞; [B1, B5, B6, V7]; xn--r5gy00c056n0226g.xn--flj4541e; ; ;  # ︒ↄⷧ.ⴗ
+xn--r5gy00c056n0226g.xn--flj4541e; ︒ↄ\u2DE7򾀃.ⴗ𐣞; [B1, B5, B6, V7]; xn--r5gy00c056n0226g.xn--flj4541e; ; ;  # ︒ↄⷧ.ⴗ
+.xn--q5g000cll06u.xn--vnd8618j; .Ↄ\u2DE7򾀃.Ⴗ𐣞; [B5, B6, V7, X4_2]; .xn--q5g000cll06u.xn--vnd8618j; [B5, B6, V7, A4_2]; ;  # .Ↄⷧ.Ⴗ
+xn--q5g000c056n0226g.xn--vnd8618j; ︒Ↄ\u2DE7򾀃.Ⴗ𐣞; [B1, B5, B6, V7]; xn--q5g000c056n0226g.xn--vnd8618j; ; ;  # ︒Ↄⷧ.Ⴗ
+\u0600.\u05B1; ; [B1, V6, V7]; xn--ifb.xn--8cb; ; ;  # .ֱ
+xn--ifb.xn--8cb; \u0600.\u05B1; [B1, V6, V7]; xn--ifb.xn--8cb; ; ;  # .ֱ
+ς≯｡𐹽; ς≯.𐹽; [B1, B6]; xn--3xa028m.xn--1o0d; ; xn--4xa818m.xn--1o0d;  # ς≯.𐹽
+ς>\u0338｡𐹽; ς≯.𐹽; [B1, B6]; xn--3xa028m.xn--1o0d; ; xn--4xa818m.xn--1o0d;  # ς≯.𐹽
+ς≯。𐹽; ς≯.𐹽; [B1, B6]; xn--3xa028m.xn--1o0d; ; xn--4xa818m.xn--1o0d;  # ς≯.𐹽
+ς>\u0338。𐹽; ς≯.𐹽; [B1, B6]; xn--3xa028m.xn--1o0d; ; xn--4xa818m.xn--1o0d;  # ς≯.𐹽
+Σ>\u0338。𐹽; σ≯.𐹽; [B1, B6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+Σ≯。𐹽; σ≯.𐹽; [B1, B6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+σ≯。𐹽; σ≯.𐹽; [B1, B6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+σ>\u0338。𐹽; σ≯.𐹽; [B1, B6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+xn--4xa818m.xn--1o0d; σ≯.𐹽; [B1, B6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+xn--3xa028m.xn--1o0d; ς≯.𐹽; [B1, B6]; xn--3xa028m.xn--1o0d; ; ;  # ς≯.𐹽
+Σ>\u0338｡𐹽; σ≯.𐹽; [B1, B6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+Σ≯｡𐹽; σ≯.𐹽; [B1, B6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+σ≯｡𐹽; σ≯.𐹽; [B1, B6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+σ>\u0338｡𐹽; σ≯.𐹽; [B1, B6]; xn--4xa818m.xn--1o0d; ; ;  # σ≯.𐹽
+\u17D2\u200D\u075F。𐹶; \u17D2\u200D\u075F.𐹶; [B1, V6]; xn--jpb535fv9f.xn--uo0d; ; xn--jpb535f.xn--uo0d;  # ្ݟ.𐹶
+xn--jpb535f.xn--uo0d; \u17D2\u075F.𐹶; [B1, V6]; xn--jpb535f.xn--uo0d; ; ;  # ្ݟ.𐹶
+xn--jpb535fv9f.xn--uo0d; \u17D2\u200D\u075F.𐹶; [B1, V6]; xn--jpb535fv9f.xn--uo0d; ; ;  # ្ݟ.𐹶
+𾷂\u0A42Ⴊ񂂟.≮; 𾷂\u0A42ⴊ񂂟.≮; [V7]; xn--nbc229o4y27dgskb.xn--gdh; ; ;  # ੂⴊ.≮
+𾷂\u0A42Ⴊ񂂟.<\u0338; 𾷂\u0A42ⴊ񂂟.≮; [V7]; xn--nbc229o4y27dgskb.xn--gdh; ; ;  # ੂⴊ.≮
+𾷂\u0A42ⴊ񂂟.<\u0338; 𾷂\u0A42ⴊ񂂟.≮; [V7]; xn--nbc229o4y27dgskb.xn--gdh; ; ;  # ੂⴊ.≮
+𾷂\u0A42ⴊ񂂟.≮; ; [V7]; xn--nbc229o4y27dgskb.xn--gdh; ; ;  # ੂⴊ.≮
+xn--nbc229o4y27dgskb.xn--gdh; 𾷂\u0A42ⴊ񂂟.≮; [V7]; xn--nbc229o4y27dgskb.xn--gdh; ; ;  # ੂⴊ.≮
+xn--nbc493aro75ggskb.xn--gdh; 𾷂\u0A42Ⴊ񂂟.≮; [V7]; xn--nbc493aro75ggskb.xn--gdh; ; ;  # ੂႪ.≮
+ꡠ．۲; ꡠ.۲; ; xn--5c9a.xn--fmb; ; ;  # ꡠ.۲
+ꡠ.۲; ; ; xn--5c9a.xn--fmb; ; ;  # ꡠ.۲
+xn--5c9a.xn--fmb; ꡠ.۲; ; xn--5c9a.xn--fmb; ; ;  # ꡠ.۲
+𐹣񄷄｡ꡬ🄄; 𐹣񄷄.ꡬ3,; [B1, B6, V7, U1]; xn--bo0d0203l.xn--3,-yj9h; ; ;  # 𐹣.ꡬ3,
+𐹣񄷄。ꡬ3,; 𐹣񄷄.ꡬ3,; [B1, B6, V7, U1]; xn--bo0d0203l.xn--3,-yj9h; ; ;  # 𐹣.ꡬ3,
+xn--bo0d0203l.xn--3,-yj9h; 𐹣񄷄.ꡬ3,; [B1, B6, V7, U1]; xn--bo0d0203l.xn--3,-yj9h; ; ;  # 𐹣.ꡬ3,
+xn--bo0d0203l.xn--id9a4443d; 𐹣񄷄.ꡬ🄄; [B1, V7]; xn--bo0d0203l.xn--id9a4443d; ; ;  # 𐹣.ꡬ🄄
+-\u0C4D𞾀𑲓｡\u200D\u0D4D; -\u0C4D𞾀𑲓.\u200D\u0D4D; [B1, C2, V3, V7]; xn----x6e0220sclug.xn--wxc317g; ; xn----x6e0220sclug.xn--wxc; [B1, V3, V6, V7] # -్𑲓.്
+-\u0C4D𞾀𑲓。\u200D\u0D4D; -\u0C4D𞾀𑲓.\u200D\u0D4D; [B1, C2, V3, V7]; xn----x6e0220sclug.xn--wxc317g; ; xn----x6e0220sclug.xn--wxc; [B1, V3, V6, V7] # -్𑲓.്
+xn----x6e0220sclug.xn--wxc; -\u0C4D𞾀𑲓.\u0D4D; [B1, V3, V6, V7]; xn----x6e0220sclug.xn--wxc; ; ;  # -్𑲓.്
+xn----x6e0220sclug.xn--wxc317g; -\u0C4D𞾀𑲓.\u200D\u0D4D; [B1, C2, V3, V7]; xn----x6e0220sclug.xn--wxc317g; ; ;  # -్𑲓.്
+\uA67D\u200C霣🄆｡\u200C𑁂\u1B01; \uA67D\u200C霣5,.\u200C𑁂\u1B01; [C1, V6, U1]; xn--5,-i1tz135dnbqa.xn--4sf36u6u4w; ; xn--5,-op8g373c.xn--4sf0725i; [V6, U1] # ꙽霣5,.𑁂ᬁ
+\uA67D\u200C霣🄆｡\u200C𑁂\u1B01; \uA67D\u200C霣5,.\u200C𑁂\u1B01; [C1, V6, U1]; xn--5,-i1tz135dnbqa.xn--4sf36u6u4w; ; xn--5,-op8g373c.xn--4sf0725i; [V6, U1] # ꙽霣5,.𑁂ᬁ
+\uA67D\u200C霣5,。\u200C𑁂\u1B01; \uA67D\u200C霣5,.\u200C𑁂\u1B01; [C1, V6, U1]; xn--5,-i1tz135dnbqa.xn--4sf36u6u4w; ; xn--5,-op8g373c.xn--4sf0725i; [V6, U1] # ꙽霣5,.𑁂ᬁ
+xn--5,-op8g373c.xn--4sf0725i; \uA67D霣5,.𑁂\u1B01; [V6, U1]; xn--5,-op8g373c.xn--4sf0725i; ; ;  # ꙽霣5,.𑁂ᬁ
+xn--5,-i1tz135dnbqa.xn--4sf36u6u4w; \uA67D\u200C霣5,.\u200C𑁂\u1B01; [C1, V6, U1]; xn--5,-i1tz135dnbqa.xn--4sf36u6u4w; ; ;  # ꙽霣5,.𑁂ᬁ
+xn--2q5a751a653w.xn--4sf0725i; \uA67D霣🄆.𑁂\u1B01; [V6, V7]; xn--2q5a751a653w.xn--4sf0725i; ; ;  # ꙽霣🄆.𑁂ᬁ
+xn--0ug4208b2vjuk63a.xn--4sf36u6u4w; \uA67D\u200C霣🄆.\u200C𑁂\u1B01; [C1, V6, V7]; xn--0ug4208b2vjuk63a.xn--4sf36u6u4w; ; ;  # ꙽霣🄆.𑁂ᬁ
+兎｡ᠼ󠴜𑚶𑰿; 兎.ᠼ󠴜𑚶𑰿; [V7]; xn--b5q.xn--v7e6041kqqd4m251b; ; ;  # 兎.ᠼ𑚶𑰿
+兎。ᠼ󠴜𑚶𑰿; 兎.ᠼ󠴜𑚶𑰿; [V7]; xn--b5q.xn--v7e6041kqqd4m251b; ; ;  # 兎.ᠼ𑚶𑰿
+xn--b5q.xn--v7e6041kqqd4m251b; 兎.ᠼ󠴜𑚶𑰿; [V7]; xn--b5q.xn--v7e6041kqqd4m251b; ; ;  # 兎.ᠼ𑚶𑰿
+𝟙｡\u200D𝟸\u200D⁷; 1.\u200D2\u200D7; [C2]; 1.xn--27-l1tb; ; 1.27; [] # 1.27
+1。\u200D2\u200D7; 1.\u200D2\u200D7; [C2]; 1.xn--27-l1tb; ; 1.27; [] # 1.27
+1.2h; ; ; ; ; ;  # 1.2h
+1.xn--27-l1tb; 1.\u200D2\u200D7; [C2]; 1.xn--27-l1tb; ; ;  # 1.27
+ᡨ-｡󠻋𝟷; ᡨ-.󠻋1; [V3, V7]; xn----z8j.xn--1-5671m; ; ;  # ᡨ-.1
+ᡨ-。󠻋1; ᡨ-.󠻋1; [V3, V7]; xn----z8j.xn--1-5671m; ; ;  # ᡨ-.1
+xn----z8j.xn--1-5671m; ᡨ-.󠻋1; [V3, V7]; xn----z8j.xn--1-5671m; ; ;  # ᡨ-.1
+𑰻񵀐𐫚．\u0668⁹; 𑰻񵀐𐫚.\u06689; [B1, V6, V7]; xn--gx9cr01aul57i.xn--9-oqc; ; ;  # 𑰻𐫚.٨9
+𑰻񵀐𐫚.\u06689; ; [B1, V6, V7]; xn--gx9cr01aul57i.xn--9-oqc; ; ;  # 𑰻𐫚.٨9
+xn--gx9cr01aul57i.xn--9-oqc; 𑰻񵀐𐫚.\u06689; [B1, V6, V7]; xn--gx9cr01aul57i.xn--9-oqc; ; ;  # 𑰻𐫚.٨9
+Ⴜ򈷭\u0F80⾇。Ⴏ♀\u200C\u200C; ⴜ򈷭\u0F80舛.ⴏ♀\u200C\u200C; [C1, V7]; xn--zed372mdj2do3v4h.xn--0uga678bgyh; ; xn--zed372mdj2do3v4h.xn--e5h11w; [V7] # ⴜྀ舛.ⴏ♀
+Ⴜ򈷭\u0F80舛。Ⴏ♀\u200C\u200C; ⴜ򈷭\u0F80舛.ⴏ♀\u200C\u200C; [C1, V7]; xn--zed372mdj2do3v4h.xn--0uga678bgyh; ; xn--zed372mdj2do3v4h.xn--e5h11w; [V7] # ⴜྀ舛.ⴏ♀
+ⴜ򈷭\u0F80舛。ⴏ♀\u200C\u200C; ⴜ򈷭\u0F80舛.ⴏ♀\u200C\u200C; [C1, V7]; xn--zed372mdj2do3v4h.xn--0uga678bgyh; ; xn--zed372mdj2do3v4h.xn--e5h11w; [V7] # ⴜྀ舛.ⴏ♀
+xn--zed372mdj2do3v4h.xn--e5h11w; ⴜ򈷭\u0F80舛.ⴏ♀; [V7]; xn--zed372mdj2do3v4h.xn--e5h11w; ; ;  # ⴜྀ舛.ⴏ♀
+xn--zed372mdj2do3v4h.xn--0uga678bgyh; ⴜ򈷭\u0F80舛.ⴏ♀\u200C\u200C; [C1, V7]; xn--zed372mdj2do3v4h.xn--0uga678bgyh; ; ;  # ⴜྀ舛.ⴏ♀
+ⴜ򈷭\u0F80⾇。ⴏ♀\u200C\u200C; ⴜ򈷭\u0F80舛.ⴏ♀\u200C\u200C; [C1, V7]; xn--zed372mdj2do3v4h.xn--0uga678bgyh; ; xn--zed372mdj2do3v4h.xn--e5h11w; [V7] # ⴜྀ舛.ⴏ♀
+xn--zed54dz10wo343g.xn--nnd651i; Ⴜ򈷭\u0F80舛.Ⴏ♀; [V7]; xn--zed54dz10wo343g.xn--nnd651i; ; ;  # Ⴜྀ舛.Ⴏ♀
+xn--zed54dz10wo343g.xn--nnd089ea464d; Ⴜ򈷭\u0F80舛.Ⴏ♀\u200C\u200C; [C1, V7]; xn--zed54dz10wo343g.xn--nnd089ea464d; ; ;  # Ⴜྀ舛.Ⴏ♀
+𑁆𝟰.\u200D; 𑁆4.\u200D; [C2, V6]; xn--4-xu7i.xn--1ug; ; xn--4-xu7i.; [V6, A4_2] # 𑁆4.
+𑁆4.\u200D; ; [C2, V6]; xn--4-xu7i.xn--1ug; ; xn--4-xu7i.; [V6, A4_2] # 𑁆4.
+xn--4-xu7i.; 𑁆4.; [V6]; xn--4-xu7i.; [V6, A4_2]; ;  # 𑁆4.
+xn--4-xu7i.xn--1ug; 𑁆4.\u200D; [C2, V6]; xn--4-xu7i.xn--1ug; ; ;  # 𑁆4.
+񮴘Ⴞ癀｡𑘿\u200D\u200C붼; 񮴘ⴞ癀.𑘿\u200D\u200C붼; [C1, V6, V7]; xn--mlju35u7qx2f.xn--0ugb6122js83c; ; xn--mlju35u7qx2f.xn--et3bn23n; [V6, V7] # ⴞ癀.𑘿붼
+񮴘Ⴞ癀｡𑘿\u200D\u200C붼; 񮴘ⴞ癀.𑘿\u200D\u200C붼; [C1, V6, V7]; xn--mlju35u7qx2f.xn--0ugb6122js83c; ; xn--mlju35u7qx2f.xn--et3bn23n; [V6, V7] # ⴞ癀.𑘿붼
+񮴘Ⴞ癀。𑘿\u200D\u200C붼; 񮴘ⴞ癀.𑘿\u200D\u200C붼; [C1, V6, V7]; xn--mlju35u7qx2f.xn--0ugb6122js83c; ; xn--mlju35u7qx2f.xn--et3bn23n; [V6, V7] # ⴞ癀.𑘿붼
+񮴘Ⴞ癀。𑘿\u200D\u200C붼; 񮴘ⴞ癀.𑘿\u200D\u200C붼; [C1, V6, V7]; xn--mlju35u7qx2f.xn--0ugb6122js83c; ; xn--mlju35u7qx2f.xn--et3bn23n; [V6, V7] # ⴞ癀.𑘿붼
+񮴘ⴞ癀。𑘿\u200D\u200C붼; 񮴘ⴞ癀.𑘿\u200D\u200C붼; [C1, V6, V7]; xn--mlju35u7qx2f.xn--0ugb6122js83c; ; xn--mlju35u7qx2f.xn--et3bn23n; [V6, V7] # ⴞ癀.𑘿붼
+񮴘ⴞ癀。𑘿\u200D\u200C붼; 񮴘ⴞ癀.𑘿\u200D\u200C붼; [C1, V6, V7]; xn--mlju35u7qx2f.xn--0ugb6122js83c; ; xn--mlju35u7qx2f.xn--et3bn23n; [V6, V7] # ⴞ癀.𑘿붼
+xn--mlju35u7qx2f.xn--et3bn23n; 񮴘ⴞ癀.𑘿붼; [V6, V7]; xn--mlju35u7qx2f.xn--et3bn23n; ; ;  # ⴞ癀.𑘿붼
+xn--mlju35u7qx2f.xn--0ugb6122js83c; 񮴘ⴞ癀.𑘿\u200D\u200C붼; [C1, V6, V7]; xn--mlju35u7qx2f.xn--0ugb6122js83c; ; ;  # ⴞ癀.𑘿붼
+񮴘ⴞ癀｡𑘿\u200D\u200C붼; 񮴘ⴞ癀.𑘿\u200D\u200C붼; [C1, V6, V7]; xn--mlju35u7qx2f.xn--0ugb6122js83c; ; xn--mlju35u7qx2f.xn--et3bn23n; [V6, V7] # ⴞ癀.𑘿붼
+񮴘ⴞ癀｡𑘿\u200D\u200C붼; 񮴘ⴞ癀.𑘿\u200D\u200C붼; [C1, V6, V7]; xn--mlju35u7qx2f.xn--0ugb6122js83c; ; xn--mlju35u7qx2f.xn--et3bn23n; [V6, V7] # ⴞ癀.𑘿붼
+xn--2nd6803c7q37d.xn--et3bn23n; 񮴘Ⴞ癀.𑘿붼; [V6, V7]; xn--2nd6803c7q37d.xn--et3bn23n; ; ;  # Ⴞ癀.𑘿붼
+xn--2nd6803c7q37d.xn--0ugb6122js83c; 񮴘Ⴞ癀.𑘿\u200D\u200C붼; [C1, V6, V7]; xn--2nd6803c7q37d.xn--0ugb6122js83c; ; ;  # Ⴞ癀.𑘿붼
+󚀅-\u0BCD。\u06B9; 󚀅-\u0BCD.\u06B9; [B6, V7]; xn----mze84808x.xn--skb; ; ;  # -்.ڹ
+xn----mze84808x.xn--skb; 󚀅-\u0BCD.\u06B9; [B6, V7]; xn----mze84808x.xn--skb; ; ;  # -்.ڹ
+ᡃ𝟧≯ᠣ．氁񨏱ꁫ; ᡃ5≯ᠣ.氁񨏱ꁫ; [V7]; xn--5-24jyf768b.xn--lqw213ime95g; ; ;  # ᡃ5≯ᠣ.氁ꁫ
+ᡃ𝟧>\u0338ᠣ．氁񨏱ꁫ; ᡃ5≯ᠣ.氁񨏱ꁫ; [V7]; xn--5-24jyf768b.xn--lqw213ime95g; ; ;  # ᡃ5≯ᠣ.氁ꁫ
+ᡃ5≯ᠣ.氁񨏱ꁫ; ; [V7]; xn--5-24jyf768b.xn--lqw213ime95g; ; ;  # ᡃ5≯ᠣ.氁ꁫ
+ᡃ5>\u0338ᠣ.氁񨏱ꁫ; ᡃ5≯ᠣ.氁񨏱ꁫ; [V7]; xn--5-24jyf768b.xn--lqw213ime95g; ; ;  # ᡃ5≯ᠣ.氁ꁫ
+xn--5-24jyf768b.xn--lqw213ime95g; ᡃ5≯ᠣ.氁񨏱ꁫ; [V7]; xn--5-24jyf768b.xn--lqw213ime95g; ; ;  # ᡃ5≯ᠣ.氁ꁫ
+𐹬𝩇．\u0F76; 𐹬𝩇.\u0FB2\u0F80; [B1, V6]; xn--ko0d8295a.xn--zed3h; ; ;  # 𐹬𝩇.ྲྀ
+𐹬𝩇．\u0FB2\u0F80; 𐹬𝩇.\u0FB2\u0F80; [B1, V6]; xn--ko0d8295a.xn--zed3h; ; ;  # 𐹬𝩇.ྲྀ
+𐹬𝩇.\u0FB2\u0F80; ; [B1, V6]; xn--ko0d8295a.xn--zed3h; ; ;  # 𐹬𝩇.ྲྀ
+xn--ko0d8295a.xn--zed3h; 𐹬𝩇.\u0FB2\u0F80; [B1, V6]; xn--ko0d8295a.xn--zed3h; ; ;  # 𐹬𝩇.ྲྀ
+-𑈶⒏．⒎𰛢󠎭; -𑈶⒏.⒎𰛢󠎭; [V3, V7]; xn----scp6252h.xn--zshy411yzpx2d; ; ;  # -𑈶⒏.⒎𰛢
+-𑈶8..7.𰛢󠎭; ; [V3, V7, X4_2]; xn---8-bv5o..7.xn--c35nf1622b; [V3, V7, A4_2]; ;  # -𑈶8..7.𰛢
+xn---8-bv5o..7.xn--c35nf1622b; -𑈶8..7.𰛢󠎭; [V3, V7, X4_2]; xn---8-bv5o..7.xn--c35nf1622b; [V3, V7, A4_2]; ;  # -𑈶8..7.𰛢
+xn----scp6252h.xn--zshy411yzpx2d; -𑈶⒏.⒎𰛢󠎭; [V3, V7]; xn----scp6252h.xn--zshy411yzpx2d; ; ;  # -𑈶⒏.⒎𰛢
+\u200CႡ畝\u200D．≮; \u200Cⴁ畝\u200D.≮; [C1, C2]; xn--0ugc160hb36e.xn--gdh; ; xn--skjy82u.xn--gdh; [] # ⴁ畝.≮
+\u200CႡ畝\u200D．<\u0338; \u200Cⴁ畝\u200D.≮; [C1, C2]; xn--0ugc160hb36e.xn--gdh; ; xn--skjy82u.xn--gdh; [] # ⴁ畝.≮
+\u200CႡ畝\u200D.≮; \u200Cⴁ畝\u200D.≮; [C1, C2]; xn--0ugc160hb36e.xn--gdh; ; xn--skjy82u.xn--gdh; [] # ⴁ畝.≮
+\u200CႡ畝\u200D.<\u0338; \u200Cⴁ畝\u200D.≮; [C1, C2]; xn--0ugc160hb36e.xn--gdh; ; xn--skjy82u.xn--gdh; [] # ⴁ畝.≮
+\u200Cⴁ畝\u200D.<\u0338; \u200Cⴁ畝\u200D.≮; [C1, C2]; xn--0ugc160hb36e.xn--gdh; ; xn--skjy82u.xn--gdh; [] # ⴁ畝.≮
+\u200Cⴁ畝\u200D.≮; ; [C1, C2]; xn--0ugc160hb36e.xn--gdh; ; xn--skjy82u.xn--gdh; [] # ⴁ畝.≮
+xn--skjy82u.xn--gdh; ⴁ畝.≮; ; xn--skjy82u.xn--gdh; ; ;  # ⴁ畝.≮
+ⴁ畝.≮; ; ; xn--skjy82u.xn--gdh; ; ;  # ⴁ畝.≮
+ⴁ畝.<\u0338; ⴁ畝.≮; ; xn--skjy82u.xn--gdh; ; ;  # ⴁ畝.≮
+Ⴁ畝.<\u0338; ⴁ畝.≮; ; xn--skjy82u.xn--gdh; ; ;  # ⴁ畝.≮
+Ⴁ畝.≮; ⴁ畝.≮; ; xn--skjy82u.xn--gdh; ; ;  # ⴁ畝.≮
+xn--0ugc160hb36e.xn--gdh; \u200Cⴁ畝\u200D.≮; [C1, C2]; xn--0ugc160hb36e.xn--gdh; ; ;  # ⴁ畝.≮
+\u200Cⴁ畝\u200D．<\u0338; \u200Cⴁ畝\u200D.≮; [C1, C2]; xn--0ugc160hb36e.xn--gdh; ; xn--skjy82u.xn--gdh; [] # ⴁ畝.≮
+\u200Cⴁ畝\u200D．≮; \u200Cⴁ畝\u200D.≮; [C1, C2]; xn--0ugc160hb36e.xn--gdh; ; xn--skjy82u.xn--gdh; [] # ⴁ畝.≮
+xn--8md0962c.xn--gdh; Ⴁ畝.≮; [V7]; xn--8md0962c.xn--gdh; ; ;  # Ⴁ畝.≮
+xn--8md700fea3748f.xn--gdh; \u200CႡ畝\u200D.≮; [C1, C2, V7]; xn--8md700fea3748f.xn--gdh; ; ;  # Ⴁ畝.≮
+歷｡𐹻≯󳛽\u200D; 歷.𐹻≯󳛽\u200D; [B1, C2, V7]; xn--nmw.xn--1ugx6gs128a1134j; ; xn--nmw.xn--hdh7804gdms2h; [B1, V7] # 歷.𐹻≯
+歷｡𐹻>\u0338󳛽\u200D; 歷.𐹻≯󳛽\u200D; [B1, C2, V7]; xn--nmw.xn--1ugx6gs128a1134j; ; xn--nmw.xn--hdh7804gdms2h; [B1, V7] # 歷.𐹻≯
+歷。𐹻≯󳛽\u200D; 歷.𐹻≯󳛽\u200D; [B1, C2, V7]; xn--nmw.xn--1ugx6gs128a1134j; ; xn--nmw.xn--hdh7804gdms2h; [B1, V7] # 歷.𐹻≯
+歷。𐹻>\u0338󳛽\u200D; 歷.𐹻≯󳛽\u200D; [B1, C2, V7]; xn--nmw.xn--1ugx6gs128a1134j; ; xn--nmw.xn--hdh7804gdms2h; [B1, V7] # 歷.𐹻≯
+xn--nmw.xn--hdh7804gdms2h; 歷.𐹻≯󳛽; [B1, V7]; xn--nmw.xn--hdh7804gdms2h; ; ;  # 歷.𐹻≯
+xn--nmw.xn--1ugx6gs128a1134j; 歷.𐹻≯󳛽\u200D; [B1, C2, V7]; xn--nmw.xn--1ugx6gs128a1134j; ; ;  # 歷.𐹻≯
+\u0ECB\u200D．鎁󠰑; \u0ECB\u200D.鎁󠰑; [C2, V6, V7]; xn--t8c059f.xn--iz4a43209d; ; xn--t8c.xn--iz4a43209d; [V6, V7] # ໋.鎁
+\u0ECB\u200D.鎁󠰑; ; [C2, V6, V7]; xn--t8c059f.xn--iz4a43209d; ; xn--t8c.xn--iz4a43209d; [V6, V7] # ໋.鎁
+xn--t8c.xn--iz4a43209d; \u0ECB.鎁󠰑; [V6, V7]; xn--t8c.xn--iz4a43209d; ; ;  # ໋.鎁
+xn--t8c059f.xn--iz4a43209d; \u0ECB\u200D.鎁󠰑; [C2, V6, V7]; xn--t8c059f.xn--iz4a43209d; ; ;  # ໋.鎁
+\u200D\u200C𞤀｡𱘅𐶃; \u200D\u200C𞤢.𱘅𐶃; [B1, B5, B6, C1, C2]; xn--0ugb45126a.xn--wh0dj799f; ; xn--9d6h.xn--wh0dj799f; [B5, B6] # 𞤢.𱘅𐶃
+\u200D\u200C𞤀。𱘅𐶃; \u200D\u200C𞤢.𱘅𐶃; [B1, B5, B6, C1, C2]; xn--0ugb45126a.xn--wh0dj799f; ; xn--9d6h.xn--wh0dj799f; [B5, B6] # 𞤢.𱘅𐶃
+\u200D\u200C𞤢。𱘅𐶃; \u200D\u200C𞤢.𱘅𐶃; [B1, B5, B6, C1, C2]; xn--0ugb45126a.xn--wh0dj799f; ; xn--9d6h.xn--wh0dj799f; [B5, B6] # 𞤢.𱘅𐶃
+\u200D\u200C𞤀。𱘅𐵣; \u200D\u200C𞤢.𱘅𐶃; [B1, B5, B6, C1, C2]; xn--0ugb45126a.xn--wh0dj799f; ; xn--9d6h.xn--wh0dj799f; [B5, B6] # 𞤢.𱘅𐶃
+xn--9d6h.xn--wh0dj799f; 𞤢.𱘅𐶃; [B5, B6]; xn--9d6h.xn--wh0dj799f; ; ;  # 𞤢.𱘅𐶃
+xn--0ugb45126a.xn--wh0dj799f; \u200D\u200C𞤢.𱘅𐶃; [B1, B5, B6, C1, C2]; xn--0ugb45126a.xn--wh0dj799f; ; ;  # 𞤢.𱘅𐶃
+\u200D\u200C𞤢｡𱘅𐶃; \u200D\u200C𞤢.𱘅𐶃; [B1, B5, B6, C1, C2]; xn--0ugb45126a.xn--wh0dj799f; ; xn--9d6h.xn--wh0dj799f; [B5, B6] # 𞤢.𱘅𐶃
+\u200D\u200C𞤀｡𱘅𐵣; \u200D\u200C𞤢.𱘅𐶃; [B1, B5, B6, C1, C2]; xn--0ugb45126a.xn--wh0dj799f; ; xn--9d6h.xn--wh0dj799f; [B5, B6] # 𞤢.𱘅𐶃
+\u0628≠𝟫-.ς⒍𐹦≠; \u0628≠9-.ς⒍𐹦≠; [B3, B5, B6, V3, V7]; xn--9--etd0100a.xn--3xa097mzpbzz04b; ; xn--9--etd0100a.xn--4xa887mzpbzz04b;  # ب≠9-.ς⒍𐹦≠
+\u0628=\u0338𝟫-.ς⒍𐹦=\u0338; \u0628≠9-.ς⒍𐹦≠; [B3, B5, B6, V3, V7]; xn--9--etd0100a.xn--3xa097mzpbzz04b; ; xn--9--etd0100a.xn--4xa887mzpbzz04b;  # ب≠9-.ς⒍𐹦≠
+\u0628≠9-.ς6.𐹦≠; ; [B1, B3, V3]; xn--9--etd0100a.xn--6-xmb.xn--1ch8704g; ; xn--9--etd0100a.xn--6-zmb.xn--1ch8704g;  # ب≠9-.ς6.𐹦≠
+\u0628=\u03389-.ς6.𐹦=\u0338; \u0628≠9-.ς6.𐹦≠; [B1, B3, V3]; xn--9--etd0100a.xn--6-xmb.xn--1ch8704g; ; xn--9--etd0100a.xn--6-zmb.xn--1ch8704g;  # ب≠9-.ς6.𐹦≠
+\u0628=\u03389-.Σ6.𐹦=\u0338; \u0628≠9-.σ6.𐹦≠; [B1, B3, V3]; xn--9--etd0100a.xn--6-zmb.xn--1ch8704g; ; ;  # ب≠9-.σ6.𐹦≠
+\u0628≠9-.Σ6.𐹦≠; \u0628≠9-.σ6.𐹦≠; [B1, B3, V3]; xn--9--etd0100a.xn--6-zmb.xn--1ch8704g; ; ;  # ب≠9-.σ6.𐹦≠
+\u0628≠9-.σ6.𐹦≠; ; [B1, B3, V3]; xn--9--etd0100a.xn--6-zmb.xn--1ch8704g; ; ;  # ب≠9-.σ6.𐹦≠
+\u0628=\u03389-.σ6.𐹦=\u0338; \u0628≠9-.σ6.𐹦≠; [B1, B3, V3]; xn--9--etd0100a.xn--6-zmb.xn--1ch8704g; ; ;  # ب≠9-.σ6.𐹦≠
+xn--9--etd0100a.xn--6-zmb.xn--1ch8704g; \u0628≠9-.σ6.𐹦≠; [B1, B3, V3]; xn--9--etd0100a.xn--6-zmb.xn--1ch8704g; ; ;  # ب≠9-.σ6.𐹦≠
+xn--9--etd0100a.xn--6-xmb.xn--1ch8704g; \u0628≠9-.ς6.𐹦≠; [B1, B3, V3]; xn--9--etd0100a.xn--6-xmb.xn--1ch8704g; ; ;  # ب≠9-.ς6.𐹦≠
+\u0628=\u0338𝟫-.Σ⒍𐹦=\u0338; \u0628≠9-.σ⒍𐹦≠; [B3, B5, B6, V3, V7]; xn--9--etd0100a.xn--4xa887mzpbzz04b; ; ;  # ب≠9-.σ⒍𐹦≠
+\u0628≠𝟫-.Σ⒍𐹦≠; \u0628≠9-.σ⒍𐹦≠; [B3, B5, B6, V3, V7]; xn--9--etd0100a.xn--4xa887mzpbzz04b; ; ;  # ب≠9-.σ⒍𐹦≠
+\u0628≠𝟫-.σ⒍𐹦≠; \u0628≠9-.σ⒍𐹦≠; [B3, B5, B6, V3, V7]; xn--9--etd0100a.xn--4xa887mzpbzz04b; ; ;  # ب≠9-.σ⒍𐹦≠
+\u0628=\u0338𝟫-.σ⒍𐹦=\u0338; \u0628≠9-.σ⒍𐹦≠; [B3, B5, B6, V3, V7]; xn--9--etd0100a.xn--4xa887mzpbzz04b; ; ;  # ب≠9-.σ⒍𐹦≠
+xn--9--etd0100a.xn--4xa887mzpbzz04b; \u0628≠9-.σ⒍𐹦≠; [B3, B5, B6, V3, V7]; xn--9--etd0100a.xn--4xa887mzpbzz04b; ; ;  # ب≠9-.σ⒍𐹦≠
+xn--9--etd0100a.xn--3xa097mzpbzz04b; \u0628≠9-.ς⒍𐹦≠; [B3, B5, B6, V3, V7]; xn--9--etd0100a.xn--3xa097mzpbzz04b; ; ;  # ب≠9-.ς⒍𐹦≠
+򉛴.-ᡢ\u0592𝨠; ; [V3, V7]; xn--ep37b.xn----hec165lho83b; ; ;  # .-ᡢ֒𝨠
+xn--ep37b.xn----hec165lho83b; 򉛴.-ᡢ\u0592𝨠; [V3, V7]; xn--ep37b.xn----hec165lho83b; ; ;  # .-ᡢ֒𝨠
+\u06CB⒈ß󠄽。񷋍-; \u06CB⒈ß.񷋍-; [B2, B3, B6, V3, V7]; xn--zca541ato3a.xn----q001f; ; xn--ss-d7d6651a.xn----q001f;  # ۋ⒈ß.-
+\u06CB1.ß󠄽。񷋍-; \u06CB1.ß.񷋍-; [B6, V3, V7]; xn--1-cwc.xn--zca.xn----q001f; ; xn--1-cwc.ss.xn----q001f;  # ۋ1.ß.-
+\u06CB1.SS󠄽。񷋍-; \u06CB1.ss.񷋍-; [B6, V3, V7]; xn--1-cwc.ss.xn----q001f; ; ;  # ۋ1.ss.-
+\u06CB1.ss󠄽。񷋍-; \u06CB1.ss.񷋍-; [B6, V3, V7]; xn--1-cwc.ss.xn----q001f; ; ;  # ۋ1.ss.-
+\u06CB1.Ss󠄽。񷋍-; \u06CB1.ss.񷋍-; [B6, V3, V7]; xn--1-cwc.ss.xn----q001f; ; ;  # ۋ1.ss.-
+xn--1-cwc.ss.xn----q001f; \u06CB1.ss.񷋍-; [B6, V3, V7]; xn--1-cwc.ss.xn----q001f; ; ;  # ۋ1.ss.-
+xn--1-cwc.xn--zca.xn----q001f; \u06CB1.ß.񷋍-; [B6, V3, V7]; xn--1-cwc.xn--zca.xn----q001f; ; ;  # ۋ1.ß.-
+\u06CB⒈SS󠄽。񷋍-; \u06CB⒈ss.񷋍-; [B2, B3, B6, V3, V7]; xn--ss-d7d6651a.xn----q001f; ; ;  # ۋ⒈ss.-
+\u06CB⒈ss󠄽。񷋍-; \u06CB⒈ss.񷋍-; [B2, B3, B6, V3, V7]; xn--ss-d7d6651a.xn----q001f; ; ;  # ۋ⒈ss.-
+\u06CB⒈Ss󠄽。񷋍-; \u06CB⒈ss.񷋍-; [B2, B3, B6, V3, V7]; xn--ss-d7d6651a.xn----q001f; ; ;  # ۋ⒈ss.-
+xn--ss-d7d6651a.xn----q001f; \u06CB⒈ss.񷋍-; [B2, B3, B6, V3, V7]; xn--ss-d7d6651a.xn----q001f; ; ;  # ۋ⒈ss.-
+xn--zca541ato3a.xn----q001f; \u06CB⒈ß.񷋍-; [B2, B3, B6, V3, V7]; xn--zca541ato3a.xn----q001f; ; ;  # ۋ⒈ß.-
+𿀫．\u1BAAςႦ\u200D; 𿀫.\u1BAAςⴆ\u200D; [C2, V6, V7]; xn--nu4s.xn--3xa353jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [V6, V7] # .᮪ςⴆ
+𿀫.\u1BAAςႦ\u200D; 𿀫.\u1BAAςⴆ\u200D; [C2, V6, V7]; xn--nu4s.xn--3xa353jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [V6, V7] # .᮪ςⴆ
+𿀫.\u1BAAςⴆ\u200D; ; [C2, V6, V7]; xn--nu4s.xn--3xa353jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [V6, V7] # .᮪ςⴆ
+𿀫.\u1BAAΣႦ\u200D; 𿀫.\u1BAAσⴆ\u200D; [C2, V6, V7]; xn--nu4s.xn--4xa153jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [V6, V7] # .᮪σⴆ
+𿀫.\u1BAAσⴆ\u200D; ; [C2, V6, V7]; xn--nu4s.xn--4xa153jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [V6, V7] # .᮪σⴆ
+𿀫.\u1BAAΣⴆ\u200D; 𿀫.\u1BAAσⴆ\u200D; [C2, V6, V7]; xn--nu4s.xn--4xa153jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [V6, V7] # .᮪σⴆ
+xn--nu4s.xn--4xa153j7im; 𿀫.\u1BAAσⴆ; [V6, V7]; xn--nu4s.xn--4xa153j7im; ; ;  # .᮪σⴆ
+xn--nu4s.xn--4xa153jk8cs1q; 𿀫.\u1BAAσⴆ\u200D; [C2, V6, V7]; xn--nu4s.xn--4xa153jk8cs1q; ; ;  # .᮪σⴆ
+xn--nu4s.xn--3xa353jk8cs1q; 𿀫.\u1BAAςⴆ\u200D; [C2, V6, V7]; xn--nu4s.xn--3xa353jk8cs1q; ; ;  # .᮪ςⴆ
+𿀫．\u1BAAςⴆ\u200D; 𿀫.\u1BAAςⴆ\u200D; [C2, V6, V7]; xn--nu4s.xn--3xa353jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [V6, V7] # .᮪ςⴆ
+𿀫．\u1BAAΣႦ\u200D; 𿀫.\u1BAAσⴆ\u200D; [C2, V6, V7]; xn--nu4s.xn--4xa153jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [V6, V7] # .᮪σⴆ
+𿀫．\u1BAAσⴆ\u200D; 𿀫.\u1BAAσⴆ\u200D; [C2, V6, V7]; xn--nu4s.xn--4xa153jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [V6, V7] # .᮪σⴆ
+𿀫．\u1BAAΣⴆ\u200D; 𿀫.\u1BAAσⴆ\u200D; [C2, V6, V7]; xn--nu4s.xn--4xa153jk8cs1q; ; xn--nu4s.xn--4xa153j7im; [V6, V7] # .᮪σⴆ
+xn--nu4s.xn--4xa217dxri; 𿀫.\u1BAAσႦ; [V6, V7]; xn--nu4s.xn--4xa217dxri; ; ;  # .᮪σႦ
+xn--nu4s.xn--4xa217dxriome; 𿀫.\u1BAAσႦ\u200D; [C2, V6, V7]; xn--nu4s.xn--4xa217dxriome; ; ;  # .᮪σႦ
+xn--nu4s.xn--3xa417dxriome; 𿀫.\u1BAAςႦ\u200D; [C2, V6, V7]; xn--nu4s.xn--3xa417dxriome; ; ;  # .᮪ςႦ
+⾆\u08E2.𝈴; 舌\u08E2.𝈴; [B1, B5, B6, V7]; xn--l0b9413d.xn--kl1h; ; ;  # 舌.𝈴
+舌\u08E2.𝈴; ; [B1, B5, B6, V7]; xn--l0b9413d.xn--kl1h; ; ;  # 舌.𝈴
+xn--l0b9413d.xn--kl1h; 舌\u08E2.𝈴; [B1, B5, B6, V7]; xn--l0b9413d.xn--kl1h; ; ;  # 舌.𝈴
+⫞𐹶𖫴。⭠⒈; ⫞𐹶𖫴.⭠⒈; [B1, V7]; xn--53ix188et88b.xn--tsh52w; ; ;  # ⫞𐹶𖫴.⭠⒈
+⫞𐹶𖫴。⭠1.; ⫞𐹶𖫴.⭠1.; [B1]; xn--53ix188et88b.xn--1-h6r.; [B1, A4_2]; ;  # ⫞𐹶𖫴.⭠1.
+xn--53ix188et88b.xn--1-h6r.; ⫞𐹶𖫴.⭠1.; [B1]; xn--53ix188et88b.xn--1-h6r.; [B1, A4_2]; ;  # ⫞𐹶𖫴.⭠1.
+xn--53ix188et88b.xn--tsh52w; ⫞𐹶𖫴.⭠⒈; [B1, V7]; xn--53ix188et88b.xn--tsh52w; ; ;  # ⫞𐹶𖫴.⭠⒈
+⒈\u200C\uAAEC︒．\u0ACD; ⒈\u200C\uAAEC︒.\u0ACD; [C1, V6, V7]; xn--0ug78o720myr1c.xn--mfc; ; xn--tsh0720cse8b.xn--mfc; [V6, V7] # ⒈ꫬ︒.્
+1.\u200C\uAAEC。.\u0ACD; 1.\u200C\uAAEC..\u0ACD; [C1, V6, X4_2]; 1.xn--0ug7185c..xn--mfc; [C1, V6, A4_2]; 1.xn--sv9a..xn--mfc; [V6, A4_2] # 1.ꫬ..્
+1.xn--sv9a..xn--mfc; 1.\uAAEC..\u0ACD; [V6, X4_2]; 1.xn--sv9a..xn--mfc; [V6, A4_2]; ;  # 1.ꫬ..્
+1.xn--0ug7185c..xn--mfc; 1.\u200C\uAAEC..\u0ACD; [C1, V6, X4_2]; 1.xn--0ug7185c..xn--mfc; [C1, V6, A4_2]; ;  # 1.ꫬ..્
+xn--tsh0720cse8b.xn--mfc; ⒈\uAAEC︒.\u0ACD; [V6, V7]; xn--tsh0720cse8b.xn--mfc; ; ;  # ⒈ꫬ︒.્
+xn--0ug78o720myr1c.xn--mfc; ⒈\u200C\uAAEC︒.\u0ACD; [C1, V6, V7]; xn--0ug78o720myr1c.xn--mfc; ; ;  # ⒈ꫬ︒.્
+\u0C46。䰀\u0668𞭅󠅼; \u0C46.䰀\u0668𞭅; [B1, B5, B6, V6, V7]; xn--eqc.xn--hib5476aim6t; ; ;  # ె.䰀٨
+xn--eqc.xn--hib5476aim6t; \u0C46.䰀\u0668𞭅; [B1, B5, B6, V6, V7]; xn--eqc.xn--hib5476aim6t; ; ;  # ె.䰀٨
+ß\u200D.\u1BF2񄾼; ; [C2, V6, V7]; xn--zca870n.xn--0zf22107b; ; ss.xn--0zf22107b; [V6, V7] # ß.᯲
+SS\u200D.\u1BF2񄾼; ss\u200D.\u1BF2񄾼; [C2, V6, V7]; xn--ss-n1t.xn--0zf22107b; ; ss.xn--0zf22107b; [V6, V7] # ss.᯲
+ss\u200D.\u1BF2񄾼; ; [C2, V6, V7]; xn--ss-n1t.xn--0zf22107b; ; ss.xn--0zf22107b; [V6, V7] # ss.᯲
+Ss\u200D.\u1BF2񄾼; ss\u200D.\u1BF2񄾼; [C2, V6, V7]; xn--ss-n1t.xn--0zf22107b; ; ss.xn--0zf22107b; [V6, V7] # ss.᯲
+ss.xn--0zf22107b; ss.\u1BF2񄾼; [V6, V7]; ss.xn--0zf22107b; ; ;  # ss.᯲
+xn--ss-n1t.xn--0zf22107b; ss\u200D.\u1BF2񄾼; [C2, V6, V7]; xn--ss-n1t.xn--0zf22107b; ; ;  # ss.᯲
+xn--zca870n.xn--0zf22107b; ß\u200D.\u1BF2񄾼; [C2, V6, V7]; xn--zca870n.xn--0zf22107b; ; ;  # ß.᯲
+𑓂\u200C≮.≮; ; [V6]; xn--0ugy6glz29a.xn--gdh; ; xn--gdhz656g.xn--gdh;  # 𑓂≮.≮
+𑓂\u200C<\u0338.<\u0338; 𑓂\u200C≮.≮; [V6]; xn--0ugy6glz29a.xn--gdh; ; xn--gdhz656g.xn--gdh;  # 𑓂≮.≮
+xn--gdhz656g.xn--gdh; 𑓂≮.≮; [V6]; xn--gdhz656g.xn--gdh; ; ;  # 𑓂≮.≮
+xn--0ugy6glz29a.xn--gdh; 𑓂\u200C≮.≮; [V6]; xn--0ugy6glz29a.xn--gdh; ; ;  # 𑓂≮.≮
+🕼．\uFFA0; 🕼.; ; xn--my8h.; [A4_2]; ;  # 🕼.
+🕼.\u1160; 🕼.; ; xn--my8h.; [A4_2]; ;  # 🕼.
+xn--my8h.; 🕼.; ; xn--my8h.; [A4_2]; ;  # 🕼.
+🕼.; ; ; xn--my8h.; [A4_2]; ;  # 🕼.
+xn--my8h.xn--psd; 🕼.\u1160; [V7]; xn--my8h.xn--psd; ; ;  # 🕼.
+xn--my8h.xn--cl7c; 🕼.\uFFA0; [V7]; xn--my8h.xn--cl7c; ; ;  # 🕼.
+ᡔ\uFD82。񷘎; ᡔ\u0644\u062D\u0649.񷘎; [B5, B6, V7]; xn--sgb9bq785p.xn--bc31b; ; ;  # ᡔلحى.
+ᡔ\u0644\u062D\u0649。񷘎; ᡔ\u0644\u062D\u0649.񷘎; [B5, B6, V7]; xn--sgb9bq785p.xn--bc31b; ; ;  # ᡔلحى.
+xn--sgb9bq785p.xn--bc31b; ᡔ\u0644\u062D\u0649.񷘎; [B5, B6, V7]; xn--sgb9bq785p.xn--bc31b; ; ;  # ᡔلحى.
+爕򳙑．𝟰気; 爕򳙑.4気; [V7]; xn--1zxq3199c.xn--4-678b; ; ;  # 爕.4気
+爕򳙑.4気; ; [V7]; xn--1zxq3199c.xn--4-678b; ; ;  # 爕.4気
+xn--1zxq3199c.xn--4-678b; 爕򳙑.4気; [V7]; xn--1zxq3199c.xn--4-678b; ; ;  # 爕.4気
+⒋𑍍Ⴝ-．𞬪\u0DCA\u05B5; ⒋𑍍ⴝ-.𞬪\u0DCA\u05B5; [B1, V3, V7]; xn----jcp487avl3w.xn--ddb152b7y23b; ; ;  # ⒋𑍍ⴝ-.්ֵ
+4.𑍍Ⴝ-.𞬪\u0DCA\u05B5; 4.𑍍ⴝ-.𞬪\u0DCA\u05B5; [B1, B6, V3, V6, V7]; 4.xn----wwsx259f.xn--ddb152b7y23b; ; ;  # 4.𑍍ⴝ-.්ֵ
+4.𑍍ⴝ-.𞬪\u0DCA\u05B5; ; [B1, B6, V3, V6, V7]; 4.xn----wwsx259f.xn--ddb152b7y23b; ; ;  # 4.𑍍ⴝ-.්ֵ
+4.xn----wwsx259f.xn--ddb152b7y23b; 4.𑍍ⴝ-.𞬪\u0DCA\u05B5; [B1, B6, V3, V6, V7]; 4.xn----wwsx259f.xn--ddb152b7y23b; ; ;  # 4.𑍍ⴝ-.්ֵ
+⒋𑍍ⴝ-．𞬪\u0DCA\u05B5; ⒋𑍍ⴝ-.𞬪\u0DCA\u05B5; [B1, V3, V7]; xn----jcp487avl3w.xn--ddb152b7y23b; ; ;  # ⒋𑍍ⴝ-.්ֵ
+xn----jcp487avl3w.xn--ddb152b7y23b; ⒋𑍍ⴝ-.𞬪\u0DCA\u05B5; [B1, V3, V7]; xn----jcp487avl3w.xn--ddb152b7y23b; ; ;  # ⒋𑍍ⴝ-.්ֵ
+4.xn----t1g9869q.xn--ddb152b7y23b; 4.𑍍Ⴝ-.𞬪\u0DCA\u05B5; [B1, B6, V3, V6, V7]; 4.xn----t1g9869q.xn--ddb152b7y23b; ; ;  # 4.𑍍Ⴝ-.්ֵ
+xn----t1g323mnk9t.xn--ddb152b7y23b; ⒋𑍍Ⴝ-.𞬪\u0DCA\u05B5; [B1, V3, V7]; xn----t1g323mnk9t.xn--ddb152b7y23b; ; ;  # ⒋𑍍Ⴝ-.්ֵ
+󞝃。򑆃񉢗--; 󞝃.򑆃񉢗--; [V2, V3, V7]; xn--2y75e.xn-----1l15eer88n; ; ;  # .--
+xn--2y75e.xn-----1l15eer88n; 󞝃.򑆃񉢗--; [V2, V3, V7]; xn--2y75e.xn-----1l15eer88n; ; ;  # .--
+\u200D\u07DF｡\u200C\uABED; \u200D\u07DF.\u200C\uABED; [B1, C1, C2]; xn--6sb394j.xn--0ug1126c; ; xn--6sb.xn--429a; [B1, V6] # ߟ.꯭
+\u200D\u07DF。\u200C\uABED; \u200D\u07DF.\u200C\uABED; [B1, C1, C2]; xn--6sb394j.xn--0ug1126c; ; xn--6sb.xn--429a; [B1, V6] # ߟ.꯭
+xn--6sb.xn--429a; \u07DF.\uABED; [B1, V6]; xn--6sb.xn--429a; ; ;  # ߟ.꯭
+xn--6sb394j.xn--0ug1126c; \u200D\u07DF.\u200C\uABED; [B1, C1, C2]; xn--6sb394j.xn--0ug1126c; ; ;  # ߟ.꯭
+𞮽\u07FF\u084E｡ᢍ򝹁𐫘; 𞮽\u07FF\u084E.ᢍ򝹁𐫘; [B5, B6, V7]; xn--3tb2nz468k.xn--69e8615j5rn5d; ; ;  # ߿ࡎ.ᢍ𐫘
+𞮽\u07FF\u084E。ᢍ򝹁𐫘; 𞮽\u07FF\u084E.ᢍ򝹁𐫘; [B5, B6, V7]; xn--3tb2nz468k.xn--69e8615j5rn5d; ; ;  # ߿ࡎ.ᢍ𐫘
+xn--3tb2nz468k.xn--69e8615j5rn5d; 𞮽\u07FF\u084E.ᢍ򝹁𐫘; [B5, B6, V7]; xn--3tb2nz468k.xn--69e8615j5rn5d; ; ;  # ߿ࡎ.ᢍ𐫘
+\u06ED𞺌𑄚\u1714.ꡞ\u08B7; \u06ED\u0645𑄚\u1714.ꡞ\u08B7; [B1, B5, B6, V6]; xn--hhb94ag41b739u.xn--dzb5582f; ; ;  # ۭم𑄚᜔.ꡞࢷ
+\u06ED\u0645𑄚\u1714.ꡞ\u08B7; ; [B1, B5, B6, V6]; xn--hhb94ag41b739u.xn--dzb5582f; ; ;  # ۭم𑄚᜔.ꡞࢷ
+xn--hhb94ag41b739u.xn--dzb5582f; \u06ED\u0645𑄚\u1714.ꡞ\u08B7; [B1, B5, B6, V6]; xn--hhb94ag41b739u.xn--dzb5582f; ; ;  # ۭم𑄚᜔.ꡞࢷ
+񻂵킃𑘶\u07DC｡ς\u063Cς; 񻂵킃𑘶\u07DC.ς\u063Cς; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--3xaa51q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.ςؼς
+񻂵킃𑘶\u07DC｡ς\u063Cς; 񻂵킃𑘶\u07DC.ς\u063Cς; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--3xaa51q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.ςؼς
+񻂵킃𑘶\u07DC。ς\u063Cς; 񻂵킃𑘶\u07DC.ς\u063Cς; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--3xaa51q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.ςؼς
+񻂵킃𑘶\u07DC。ς\u063Cς; 񻂵킃𑘶\u07DC.ς\u063Cς; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--3xaa51q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.ςؼς
+񻂵킃𑘶\u07DC。Σ\u063CΣ; 񻂵킃𑘶\u07DC.σ\u063Cσ; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶\u07DC。Σ\u063CΣ; 񻂵킃𑘶\u07DC.σ\u063Cσ; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶\u07DC。σ\u063Cσ; 񻂵킃𑘶\u07DC.σ\u063Cσ; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶\u07DC。σ\u063Cσ; 񻂵킃𑘶\u07DC.σ\u063Cσ; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶\u07DC。Σ\u063Cσ; 񻂵킃𑘶\u07DC.σ\u063Cσ; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶\u07DC。Σ\u063Cσ; 񻂵킃𑘶\u07DC.σ\u063Cσ; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+xn--3sb7483hoyvbbe76g.xn--4xaa21q; 񻂵킃𑘶\u07DC.σ\u063Cσ; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶\u07DC。Σ\u063Cς; 񻂵킃𑘶\u07DC.σ\u063Cς; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+񻂵킃𑘶\u07DC。Σ\u063Cς; 񻂵킃𑘶\u07DC.σ\u063Cς; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+񻂵킃𑘶\u07DC。σ\u063Cς; 񻂵킃𑘶\u07DC.σ\u063Cς; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+񻂵킃𑘶\u07DC。σ\u063Cς; 񻂵킃𑘶\u07DC.σ\u063Cς; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+xn--3sb7483hoyvbbe76g.xn--3xab31q; 񻂵킃𑘶\u07DC.σ\u063Cς; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; ;  # 킃𑘶ߜ.σؼς
+xn--3sb7483hoyvbbe76g.xn--3xaa51q; 񻂵킃𑘶\u07DC.ς\u063Cς; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--3xaa51q; ; ;  # 킃𑘶ߜ.ςؼς
+񻂵킃𑘶\u07DC｡Σ\u063CΣ; 񻂵킃𑘶\u07DC.σ\u063Cσ; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶\u07DC｡Σ\u063CΣ; 񻂵킃𑘶\u07DC.σ\u063Cσ; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶\u07DC｡σ\u063Cσ; 񻂵킃𑘶\u07DC.σ\u063Cσ; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶\u07DC｡σ\u063Cσ; 񻂵킃𑘶\u07DC.σ\u063Cσ; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶\u07DC｡Σ\u063Cσ; 񻂵킃𑘶\u07DC.σ\u063Cσ; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶\u07DC｡Σ\u063Cσ; 񻂵킃𑘶\u07DC.σ\u063Cσ; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--4xaa21q; ; ;  # 킃𑘶ߜ.σؼσ
+񻂵킃𑘶\u07DC｡Σ\u063Cς; 񻂵킃𑘶\u07DC.σ\u063Cς; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+񻂵킃𑘶\u07DC｡Σ\u063Cς; 񻂵킃𑘶\u07DC.σ\u063Cς; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+񻂵킃𑘶\u07DC｡σ\u063Cς; 񻂵킃𑘶\u07DC.σ\u063Cς; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+񻂵킃𑘶\u07DC｡σ\u063Cς; 񻂵킃𑘶\u07DC.σ\u063Cς; [B5, B6, V7]; xn--3sb7483hoyvbbe76g.xn--3xab31q; ; xn--3sb7483hoyvbbe76g.xn--4xaa21q;  # 킃𑘶ߜ.σؼς
+蔰。󠁹\u08DD-𑈵; 蔰.󠁹\u08DD-𑈵; [V7]; xn--sz1a.xn----mrd9984r3dl0i; ; ;  # 蔰.ࣝ-𑈵
+xn--sz1a.xn----mrd9984r3dl0i; 蔰.󠁹\u08DD-𑈵; [V7]; xn--sz1a.xn----mrd9984r3dl0i; ; ;  # 蔰.ࣝ-𑈵
+ςჅ。\u075A; ςⴥ.\u075A; ; xn--3xa403s.xn--epb; ; xn--4xa203s.xn--epb;  # ςⴥ.ݚ
+ςⴥ。\u075A; ςⴥ.\u075A; ; xn--3xa403s.xn--epb; ; xn--4xa203s.xn--epb;  # ςⴥ.ݚ
+ΣჅ。\u075A; σⴥ.\u075A; ; xn--4xa203s.xn--epb; ; ;  # σⴥ.ݚ
+σⴥ。\u075A; σⴥ.\u075A; ; xn--4xa203s.xn--epb; ; ;  # σⴥ.ݚ
+Σⴥ。\u075A; σⴥ.\u075A; ; xn--4xa203s.xn--epb; ; ;  # σⴥ.ݚ
+xn--4xa203s.xn--epb; σⴥ.\u075A; ; xn--4xa203s.xn--epb; ; ;  # σⴥ.ݚ
+σⴥ.\u075A; ; ; xn--4xa203s.xn--epb; ; ;  # σⴥ.ݚ
+ΣჅ.\u075A; σⴥ.\u075A; ; xn--4xa203s.xn--epb; ; ;  # σⴥ.ݚ
+Σⴥ.\u075A; σⴥ.\u075A; ; xn--4xa203s.xn--epb; ; ;  # σⴥ.ݚ
+xn--3xa403s.xn--epb; ςⴥ.\u075A; ; xn--3xa403s.xn--epb; ; ;  # ςⴥ.ݚ
+ςⴥ.\u075A; ; ; xn--3xa403s.xn--epb; ; xn--4xa203s.xn--epb;  # ςⴥ.ݚ
+xn--4xa477d.xn--epb; σჅ.\u075A; [V7]; xn--4xa477d.xn--epb; ; ;  # σჅ.ݚ
+xn--3xa677d.xn--epb; ςჅ.\u075A; [V7]; xn--3xa677d.xn--epb; ; ;  # ςჅ.ݚ
+\u0C4DႩ𞰓．\u1B72; \u0C4Dⴉ𞰓.\u1B72; [B1, V6, V7]; xn--lqc478nlr02a.xn--dwf; ; ;  # ్ⴉ.᭲
+\u0C4DႩ𞰓.\u1B72; \u0C4Dⴉ𞰓.\u1B72; [B1, V6, V7]; xn--lqc478nlr02a.xn--dwf; ; ;  # ్ⴉ.᭲
+\u0C4Dⴉ𞰓.\u1B72; ; [B1, V6, V7]; xn--lqc478nlr02a.xn--dwf; ; ;  # ్ⴉ.᭲
+xn--lqc478nlr02a.xn--dwf; \u0C4Dⴉ𞰓.\u1B72; [B1, V6, V7]; xn--lqc478nlr02a.xn--dwf; ; ;  # ్ⴉ.᭲
+\u0C4Dⴉ𞰓．\u1B72; \u0C4Dⴉ𞰓.\u1B72; [B1, V6, V7]; xn--lqc478nlr02a.xn--dwf; ; ;  # ్ⴉ.᭲
+xn--lqc64t7t26c.xn--dwf; \u0C4DႩ𞰓.\u1B72; [B1, V6, V7]; xn--lqc64t7t26c.xn--dwf; ; ;  # ్Ⴉ.᭲
+⮷≮񎈴󠄟。𐠄; ⮷≮񎈴.𐠄; [B1, V7]; xn--gdh877a3513h.xn--pc9c; ; ;  # ⮷≮.𐠄
+⮷<\u0338񎈴󠄟。𐠄; ⮷≮񎈴.𐠄; [B1, V7]; xn--gdh877a3513h.xn--pc9c; ; ;  # ⮷≮.𐠄
+xn--gdh877a3513h.xn--pc9c; ⮷≮񎈴.𐠄; [B1, V7]; xn--gdh877a3513h.xn--pc9c; ; ;  # ⮷≮.𐠄
+\u06BC｡\u200Dẏ\u200Cᡤ; \u06BC.\u200Dẏ\u200Cᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+\u06BC｡\u200Dy\u0307\u200Cᡤ; \u06BC.\u200Dẏ\u200Cᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+\u06BC。\u200Dẏ\u200Cᡤ; \u06BC.\u200Dẏ\u200Cᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+\u06BC。\u200Dy\u0307\u200Cᡤ; \u06BC.\u200Dẏ\u200Cᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+\u06BC。\u200DY\u0307\u200Cᡤ; \u06BC.\u200Dẏ\u200Cᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+\u06BC。\u200DẎ\u200Cᡤ; \u06BC.\u200Dẏ\u200Cᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+xn--vkb.xn--08e172a; \u06BC.ẏᡤ; ; xn--vkb.xn--08e172a; ; ;  # ڼ.ẏᡤ
+\u06BC.ẏᡤ; ; ; xn--vkb.xn--08e172a; ; ;  # ڼ.ẏᡤ
+\u06BC.y\u0307ᡤ; \u06BC.ẏᡤ; ; xn--vkb.xn--08e172a; ; ;  # ڼ.ẏᡤ
+\u06BC.Y\u0307ᡤ; \u06BC.ẏᡤ; ; xn--vkb.xn--08e172a; ; ;  # ڼ.ẏᡤ
+\u06BC.Ẏᡤ; \u06BC.ẏᡤ; ; xn--vkb.xn--08e172a; ; ;  # ڼ.ẏᡤ
+xn--vkb.xn--08e172ax6aca; \u06BC.\u200Dẏ\u200Cᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; ;  # ڼ.ẏᡤ
+\u06BC｡\u200DY\u0307\u200Cᡤ; \u06BC.\u200Dẏ\u200Cᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+\u06BC｡\u200DẎ\u200Cᡤ; \u06BC.\u200Dẏ\u200Cᡤ; [B1, C1, C2]; xn--vkb.xn--08e172ax6aca; ; xn--vkb.xn--08e172a; [] # ڼ.ẏᡤ
+𐹹𑲛。񑂐\u0DCA; 𐹹𑲛.񑂐\u0DCA; [B1, V7]; xn--xo0dg5v.xn--h1c39876d; ; ;  # 𐹹𑲛.්
+xn--xo0dg5v.xn--h1c39876d; 𐹹𑲛.񑂐\u0DCA; [B1, V7]; xn--xo0dg5v.xn--h1c39876d; ; ;  # 𐹹𑲛.්
+-≠𑈵｡嵕\uFEF1۴\uA953; -≠𑈵.嵕\u064A۴\uA953; [B1, B5, V3]; xn----ufo4749h.xn--mhb45a235sns3c; ; ;  # -≠𑈵.嵕ي۴꥓
+-=\u0338𑈵｡嵕\uFEF1۴\uA953; -≠𑈵.嵕\u064A۴\uA953; [B1, B5, V3]; xn----ufo4749h.xn--mhb45a235sns3c; ; ;  # -≠𑈵.嵕ي۴꥓
+-≠𑈵。嵕\u064A۴\uA953; -≠𑈵.嵕\u064A۴\uA953; [B1, B5, V3]; xn----ufo4749h.xn--mhb45a235sns3c; ; ;  # -≠𑈵.嵕ي۴꥓
+-=\u0338𑈵。嵕\u064A۴\uA953; -≠𑈵.嵕\u064A۴\uA953; [B1, B5, V3]; xn----ufo4749h.xn--mhb45a235sns3c; ; ;  # -≠𑈵.嵕ي۴꥓
+xn----ufo4749h.xn--mhb45a235sns3c; -≠𑈵.嵕\u064A۴\uA953; [B1, B5, V3]; xn----ufo4749h.xn--mhb45a235sns3c; ; ;  # -≠𑈵.嵕ي۴꥓
+\u200C񍸰𐹶\u076E．\u06C1\u200D≯\u200D; \u200C񍸰𐹶\u076E.\u06C1\u200D≯\u200D; [B1, B3, C1, C2, V7]; xn--ypb717jrx2o7v94a.xn--0kb660ka35v; ; xn--ypb5875khz9y.xn--0kb682l; [B3, B5, B6, V7] # 𐹶ݮ.ہ≯
+\u200C񍸰𐹶\u076E．\u06C1\u200D>\u0338\u200D; \u200C񍸰𐹶\u076E.\u06C1\u200D≯\u200D; [B1, B3, C1, C2, V7]; xn--ypb717jrx2o7v94a.xn--0kb660ka35v; ; xn--ypb5875khz9y.xn--0kb682l; [B3, B5, B6, V7] # 𐹶ݮ.ہ≯
+\u200C񍸰𐹶\u076E.\u06C1\u200D≯\u200D; ; [B1, B3, C1, C2, V7]; xn--ypb717jrx2o7v94a.xn--0kb660ka35v; ; xn--ypb5875khz9y.xn--0kb682l; [B3, B5, B6, V7] # 𐹶ݮ.ہ≯
+\u200C񍸰𐹶\u076E.\u06C1\u200D>\u0338\u200D; \u200C񍸰𐹶\u076E.\u06C1\u200D≯\u200D; [B1, B3, C1, C2, V7]; xn--ypb717jrx2o7v94a.xn--0kb660ka35v; ; xn--ypb5875khz9y.xn--0kb682l; [B3, B5, B6, V7] # 𐹶ݮ.ہ≯
+xn--ypb5875khz9y.xn--0kb682l; 񍸰𐹶\u076E.\u06C1≯; [B3, B5, B6, V7]; xn--ypb5875khz9y.xn--0kb682l; ; ;  # 𐹶ݮ.ہ≯
+xn--ypb717jrx2o7v94a.xn--0kb660ka35v; \u200C񍸰𐹶\u076E.\u06C1\u200D≯\u200D; [B1, B3, C1, C2, V7]; xn--ypb717jrx2o7v94a.xn--0kb660ka35v; ; ;  # 𐹶ݮ.ہ≯
+≮．\u17B5\u0855𐫔; ≮.\u0855𐫔; [B1]; xn--gdh.xn--kwb4643k; ; ;  # ≮.ࡕ𐫔
+<\u0338．\u17B5\u0855𐫔; ≮.\u0855𐫔; [B1]; xn--gdh.xn--kwb4643k; ; ;  # ≮.ࡕ𐫔
+≮.\u17B5\u0855𐫔; ≮.\u0855𐫔; [B1]; xn--gdh.xn--kwb4643k; ; ;  # ≮.ࡕ𐫔
+<\u0338.\u17B5\u0855𐫔; ≮.\u0855𐫔; [B1]; xn--gdh.xn--kwb4643k; ; ;  # ≮.ࡕ𐫔
+xn--gdh.xn--kwb4643k; ≮.\u0855𐫔; [B1]; xn--gdh.xn--kwb4643k; ; ;  # ≮.ࡕ𐫔
+xn--gdh.xn--kwb589e217p; ≮.\u17B5\u0855𐫔; [B1, V6, V7]; xn--gdh.xn--kwb589e217p; ; ;  # ≮.ࡕ𐫔
+𐩗\u200D｡ႩႵ; 𐩗\u200D.ⴉⴕ; [B3, C2]; xn--1ug4933g.xn--0kjya; ; xn--pt9c.xn--0kjya; [] # 𐩗.ⴉⴕ
+𐩗\u200D。ႩႵ; 𐩗\u200D.ⴉⴕ; [B3, C2]; xn--1ug4933g.xn--0kjya; ; xn--pt9c.xn--0kjya; [] # 𐩗.ⴉⴕ
+𐩗\u200D。ⴉⴕ; 𐩗\u200D.ⴉⴕ; [B3, C2]; xn--1ug4933g.xn--0kjya; ; xn--pt9c.xn--0kjya; [] # 𐩗.ⴉⴕ
+𐩗\u200D。Ⴉⴕ; 𐩗\u200D.ⴉⴕ; [B3, C2]; xn--1ug4933g.xn--0kjya; ; xn--pt9c.xn--0kjya; [] # 𐩗.ⴉⴕ
+xn--pt9c.xn--0kjya; 𐩗.ⴉⴕ; ; xn--pt9c.xn--0kjya; ; ;  # 𐩗.ⴉⴕ
+𐩗.ⴉⴕ; ; ; xn--pt9c.xn--0kjya; ; ;  # 𐩗.ⴉⴕ
+𐩗.ႩႵ; 𐩗.ⴉⴕ; ; xn--pt9c.xn--0kjya; ; ;  # 𐩗.ⴉⴕ
+𐩗.Ⴉⴕ; 𐩗.ⴉⴕ; ; xn--pt9c.xn--0kjya; ; ;  # 𐩗.ⴉⴕ
+xn--1ug4933g.xn--0kjya; 𐩗\u200D.ⴉⴕ; [B3, C2]; xn--1ug4933g.xn--0kjya; ; ;  # 𐩗.ⴉⴕ
+𐩗\u200D｡ⴉⴕ; 𐩗\u200D.ⴉⴕ; [B3, C2]; xn--1ug4933g.xn--0kjya; ; xn--pt9c.xn--0kjya; [] # 𐩗.ⴉⴕ
+𐩗\u200D｡Ⴉⴕ; 𐩗\u200D.ⴉⴕ; [B3, C2]; xn--1ug4933g.xn--0kjya; ; xn--pt9c.xn--0kjya; [] # 𐩗.ⴉⴕ
+xn--pt9c.xn--hnd666l; 𐩗.Ⴉⴕ; [V7]; xn--pt9c.xn--hnd666l; ; ;  # 𐩗.Ⴉⴕ
+xn--1ug4933g.xn--hnd666l; 𐩗\u200D.Ⴉⴕ; [B3, C2, V7]; xn--1ug4933g.xn--hnd666l; ; ;  # 𐩗.Ⴉⴕ
+xn--pt9c.xn--hndy; 𐩗.ႩႵ; [V7]; xn--pt9c.xn--hndy; ; ;  # 𐩗.ႩႵ
+xn--1ug4933g.xn--hndy; 𐩗\u200D.ႩႵ; [B3, C2, V7]; xn--1ug4933g.xn--hndy; ; ;  # 𐩗.ႩႵ
+\u200C\u200Cㄤ．\u032E󕨑\u09C2; \u200C\u200Cㄤ.\u032E󕨑\u09C2; [C1, V6, V7]; xn--0uga242k.xn--vta284a9o563a; ; xn--1fk.xn--vta284a9o563a; [V6, V7] # ㄤ.̮ূ
+\u200C\u200Cㄤ.\u032E󕨑\u09C2; ; [C1, V6, V7]; xn--0uga242k.xn--vta284a9o563a; ; xn--1fk.xn--vta284a9o563a; [V6, V7] # ㄤ.̮ূ
+xn--1fk.xn--vta284a9o563a; ㄤ.\u032E󕨑\u09C2; [V6, V7]; xn--1fk.xn--vta284a9o563a; ; ;  # ㄤ.̮ূ
+xn--0uga242k.xn--vta284a9o563a; \u200C\u200Cㄤ.\u032E󕨑\u09C2; [C1, V6, V7]; xn--0uga242k.xn--vta284a9o563a; ; ;  # ㄤ.̮ূ
+𐋻｡-\u200C𐫄Ⴗ; 𐋻.-\u200C𐫄ⴗ; [B1, C1, V3]; xn--v97c.xn----sgnv20du99s; ; xn--v97c.xn----lws0526f; [B1, V3] # 𐋻.-𐫄ⴗ
+𐋻。-\u200C𐫄Ⴗ; 𐋻.-\u200C𐫄ⴗ; [B1, C1, V3]; xn--v97c.xn----sgnv20du99s; ; xn--v97c.xn----lws0526f; [B1, V3] # 𐋻.-𐫄ⴗ
+𐋻。-\u200C𐫄ⴗ; 𐋻.-\u200C𐫄ⴗ; [B1, C1, V3]; xn--v97c.xn----sgnv20du99s; ; xn--v97c.xn----lws0526f; [B1, V3] # 𐋻.-𐫄ⴗ
+xn--v97c.xn----lws0526f; 𐋻.-𐫄ⴗ; [B1, V3]; xn--v97c.xn----lws0526f; ; ;  # 𐋻.-𐫄ⴗ
+xn--v97c.xn----sgnv20du99s; 𐋻.-\u200C𐫄ⴗ; [B1, C1, V3]; xn--v97c.xn----sgnv20du99s; ; ;  # 𐋻.-𐫄ⴗ
+𐋻｡-\u200C𐫄ⴗ; 𐋻.-\u200C𐫄ⴗ; [B1, C1, V3]; xn--v97c.xn----sgnv20du99s; ; xn--v97c.xn----lws0526f; [B1, V3] # 𐋻.-𐫄ⴗ
+xn--v97c.xn----i1g2513q; 𐋻.-𐫄Ⴗ; [B1, V3, V7]; xn--v97c.xn----i1g2513q; ; ;  # 𐋻.-𐫄Ⴗ
+xn--v97c.xn----i1g888ih12u; 𐋻.-\u200C𐫄Ⴗ; [B1, C1, V3, V7]; xn--v97c.xn----i1g888ih12u; ; ;  # 𐋻.-𐫄Ⴗ
+🙑𐷺．≠\u200C; 🙑𐷺.≠\u200C; [B1, C1, V7]; xn--bl0dh970b.xn--0ug83g; ; xn--bl0dh970b.xn--1ch; [B1, V7] # 🙑.≠
+🙑𐷺．=\u0338\u200C; 🙑𐷺.≠\u200C; [B1, C1, V7]; xn--bl0dh970b.xn--0ug83g; ; xn--bl0dh970b.xn--1ch; [B1, V7] # 🙑.≠
+🙑𐷺.≠\u200C; ; [B1, C1, V7]; xn--bl0dh970b.xn--0ug83g; ; xn--bl0dh970b.xn--1ch; [B1, V7] # 🙑.≠
+🙑𐷺.=\u0338\u200C; 🙑𐷺.≠\u200C; [B1, C1, V7]; xn--bl0dh970b.xn--0ug83g; ; xn--bl0dh970b.xn--1ch; [B1, V7] # 🙑.≠
+xn--bl0dh970b.xn--1ch; 🙑𐷺.≠; [B1, V7]; xn--bl0dh970b.xn--1ch; ; ;  # 🙑.≠
+xn--bl0dh970b.xn--0ug83g; 🙑𐷺.≠\u200C; [B1, C1, V7]; xn--bl0dh970b.xn--0ug83g; ; ;  # 🙑.≠
+\u064C\u1CD2｡𞮞\u2D7F⧎; \u064C\u1CD2.𞮞\u2D7F⧎; [B1, B3, V6, V7]; xn--ohb646i.xn--ewi38jf765c; ; ;  # ٌ᳒.⵿⧎
+\u064C\u1CD2。𞮞\u2D7F⧎; \u064C\u1CD2.𞮞\u2D7F⧎; [B1, B3, V6, V7]; xn--ohb646i.xn--ewi38jf765c; ; ;  # ٌ᳒.⵿⧎
+xn--ohb646i.xn--ewi38jf765c; \u064C\u1CD2.𞮞\u2D7F⧎; [B1, B3, V6, V7]; xn--ohb646i.xn--ewi38jf765c; ; ;  # ٌ᳒.⵿⧎
+Ⴔ𝨨₃󠁦．𝟳𑂹\u0B82; ⴔ𝨨3󠁦.7𑂹\u0B82; [V7]; xn--3-ews6985n35s3g.xn--7-cve6271r; ; ;  # ⴔ𝨨3.7𑂹ஂ
+Ⴔ𝨨3󠁦.7𑂹\u0B82; ⴔ𝨨3󠁦.7𑂹\u0B82; [V7]; xn--3-ews6985n35s3g.xn--7-cve6271r; ; ;  # ⴔ𝨨3.7𑂹ஂ
+ⴔ𝨨3󠁦.7𑂹\u0B82; ; [V7]; xn--3-ews6985n35s3g.xn--7-cve6271r; ; ;  # ⴔ𝨨3.7𑂹ஂ
+xn--3-ews6985n35s3g.xn--7-cve6271r; ⴔ𝨨3󠁦.7𑂹\u0B82; [V7]; xn--3-ews6985n35s3g.xn--7-cve6271r; ; ;  # ⴔ𝨨3.7𑂹ஂ
+ⴔ𝨨₃󠁦．𝟳𑂹\u0B82; ⴔ𝨨3󠁦.7𑂹\u0B82; [V7]; xn--3-ews6985n35s3g.xn--7-cve6271r; ; ;  # ⴔ𝨨3.7𑂹ஂ
+xn--3-b1g83426a35t0g.xn--7-cve6271r; Ⴔ𝨨3󠁦.7𑂹\u0B82; [V7]; xn--3-b1g83426a35t0g.xn--7-cve6271r; ; ;  # Ⴔ𝨨3.7𑂹ஂ
+䏈\u200C。\u200C⒈񱢕; 䏈\u200C.\u200C⒈񱢕; [C1, V7]; xn--0ug491l.xn--0ug88oot66q; ; xn--eco.xn--tsh21126d; [V7] # 䏈.⒈
+䏈\u200C。\u200C1.񱢕; 䏈\u200C.\u200C1.񱢕; [C1, V7]; xn--0ug491l.xn--1-rgn.xn--ms39a; ; xn--eco.1.xn--ms39a; [V7] # 䏈.1.
+xn--eco.1.xn--ms39a; 䏈.1.񱢕; [V7]; xn--eco.1.xn--ms39a; ; ;  # 䏈.1.
+xn--0ug491l.xn--1-rgn.xn--ms39a; 䏈\u200C.\u200C1.񱢕; [C1, V7]; xn--0ug491l.xn--1-rgn.xn--ms39a; ; ;  # 䏈.1.
+xn--eco.xn--tsh21126d; 䏈.⒈񱢕; [V7]; xn--eco.xn--tsh21126d; ; ;  # 䏈.⒈
+xn--0ug491l.xn--0ug88oot66q; 䏈\u200C.\u200C⒈񱢕; [C1, V7]; xn--0ug491l.xn--0ug88oot66q; ; ;  # 䏈.⒈
+１\uAAF6ß𑲥｡\u1DD8; 1\uAAF6ß𑲥.\u1DD8; [V6]; xn--1-qfa2471kdb0d.xn--weg; ; xn--1ss-ir6ln166b.xn--weg;  # 1꫶ß𑲥.ᷘ
+1\uAAF6ß𑲥。\u1DD8; 1\uAAF6ß𑲥.\u1DD8; [V6]; xn--1-qfa2471kdb0d.xn--weg; ; xn--1ss-ir6ln166b.xn--weg;  # 1꫶ß𑲥.ᷘ
+1\uAAF6SS𑲥。\u1DD8; 1\uAAF6ss𑲥.\u1DD8; [V6]; xn--1ss-ir6ln166b.xn--weg; ; ;  # 1꫶ss𑲥.ᷘ
+1\uAAF6ss𑲥。\u1DD8; 1\uAAF6ss𑲥.\u1DD8; [V6]; xn--1ss-ir6ln166b.xn--weg; ; ;  # 1꫶ss𑲥.ᷘ
+xn--1ss-ir6ln166b.xn--weg; 1\uAAF6ss𑲥.\u1DD8; [V6]; xn--1ss-ir6ln166b.xn--weg; ; ;  # 1꫶ss𑲥.ᷘ
+xn--1-qfa2471kdb0d.xn--weg; 1\uAAF6ß𑲥.\u1DD8; [V6]; xn--1-qfa2471kdb0d.xn--weg; ; ;  # 1꫶ß𑲥.ᷘ
+１\uAAF6SS𑲥｡\u1DD8; 1\uAAF6ss𑲥.\u1DD8; [V6]; xn--1ss-ir6ln166b.xn--weg; ; ;  # 1꫶ss𑲥.ᷘ
+１\uAAF6ss𑲥｡\u1DD8; 1\uAAF6ss𑲥.\u1DD8; [V6]; xn--1ss-ir6ln166b.xn--weg; ; ;  # 1꫶ss𑲥.ᷘ
+1\uAAF6Ss𑲥。\u1DD8; 1\uAAF6ss𑲥.\u1DD8; [V6]; xn--1ss-ir6ln166b.xn--weg; ; ;  # 1꫶ss𑲥.ᷘ
+１\uAAF6Ss𑲥｡\u1DD8; 1\uAAF6ss𑲥.\u1DD8; [V6]; xn--1ss-ir6ln166b.xn--weg; ; ;  # 1꫶ss𑲥.ᷘ
+\u200D񫶩𞪯\u0CCD｡\u077C⒈; \u200D񫶩𞪯\u0CCD.\u077C⒈; [B1, C2, V7]; xn--8tc969gzn94a4lm8a.xn--dqb689l; ; xn--8tc9875v5is1a.xn--dqb689l; [B5, B6, V7] # ್.ݼ⒈
+\u200D񫶩𞪯\u0CCD。\u077C1.; \u200D񫶩𞪯\u0CCD.\u077C1.; [B1, C2, V7]; xn--8tc969gzn94a4lm8a.xn--1-g6c.; [B1, C2, V7, A4_2]; xn--8tc9875v5is1a.xn--1-g6c.; [B5, B6, V7, A4_2] # ್.ݼ1.
+xn--8tc9875v5is1a.xn--1-g6c.; 񫶩𞪯\u0CCD.\u077C1.; [B5, B6, V7]; xn--8tc9875v5is1a.xn--1-g6c.; [B5, B6, V7, A4_2]; ;  # ್.ݼ1.
+xn--8tc969gzn94a4lm8a.xn--1-g6c.; \u200D񫶩𞪯\u0CCD.\u077C1.; [B1, C2, V7]; xn--8tc969gzn94a4lm8a.xn--1-g6c.; [B1, C2, V7, A4_2]; ;  # ್.ݼ1.
+xn--8tc9875v5is1a.xn--dqb689l; 񫶩𞪯\u0CCD.\u077C⒈; [B5, B6, V7]; xn--8tc9875v5is1a.xn--dqb689l; ; ;  # ್.ݼ⒈
+xn--8tc969gzn94a4lm8a.xn--dqb689l; \u200D񫶩𞪯\u0CCD.\u077C⒈; [B1, C2, V7]; xn--8tc969gzn94a4lm8a.xn--dqb689l; ; ;  # ್.ݼ⒈
+\u1AB6．𞤳򓢖򻉒\u07D7; \u1AB6.𞤳򓢖򻉒\u07D7; [B1, B2, V6, V7]; xn--zqf.xn--ysb9657vuiz5bj0ep; ; ;  # ᪶.𞤳ߗ
+\u1AB6.𞤳򓢖򻉒\u07D7; ; [B1, B2, V6, V7]; xn--zqf.xn--ysb9657vuiz5bj0ep; ; ;  # ᪶.𞤳ߗ
+\u1AB6.𞤑򓢖򻉒\u07D7; \u1AB6.𞤳򓢖򻉒\u07D7; [B1, B2, V6, V7]; xn--zqf.xn--ysb9657vuiz5bj0ep; ; ;  # ᪶.𞤳ߗ
+xn--zqf.xn--ysb9657vuiz5bj0ep; \u1AB6.𞤳򓢖򻉒\u07D7; [B1, B2, V6, V7]; xn--zqf.xn--ysb9657vuiz5bj0ep; ; ;  # ᪶.𞤳ߗ
+\u1AB6．𞤑򓢖򻉒\u07D7; \u1AB6.𞤳򓢖򻉒\u07D7; [B1, B2, V6, V7]; xn--zqf.xn--ysb9657vuiz5bj0ep; ; ;  # ᪶.𞤳ߗ
+\u0842𞩚⒈．󠬌８򏳏\u0770; \u0842𞩚⒈.󠬌8򏳏\u0770; [B1, V7]; xn--0vb095ldg52a.xn--8-s5c22427ox454a; ; ;  # ࡂ⒈.8ݰ
+\u0842𞩚1..󠬌8򏳏\u0770; ; [B1, V7, X4_2]; xn--1-rid26318a..xn--8-s5c22427ox454a; [B1, V7, A4_2]; ;  # ࡂ1..8ݰ
+xn--1-rid26318a..xn--8-s5c22427ox454a; \u0842𞩚1..󠬌8򏳏\u0770; [B1, V7, X4_2]; xn--1-rid26318a..xn--8-s5c22427ox454a; [B1, V7, A4_2]; ;  # ࡂ1..8ݰ
+xn--0vb095ldg52a.xn--8-s5c22427ox454a; \u0842𞩚⒈.󠬌8򏳏\u0770; [B1, V7]; xn--0vb095ldg52a.xn--8-s5c22427ox454a; ; ;  # ࡂ⒈.8ݰ
+\u0361𐫫\u0369ᡷ。-󠰛鞰; \u0361𐫫\u0369ᡷ.-󠰛鞰; [B1, V3, V6, V7]; xn--cvaq482npv5t.xn----yg7dt1332g; ; ;  # ͡𐫫ͩᡷ.-鞰
+xn--cvaq482npv5t.xn----yg7dt1332g; \u0361𐫫\u0369ᡷ.-󠰛鞰; [B1, V3, V6, V7]; xn--cvaq482npv5t.xn----yg7dt1332g; ; ;  # ͡𐫫ͩᡷ.-鞰
+-.\u0ACD剘ß𐫃; ; [B1, V3, V6]; -.xn--zca791c493duf8i; ; -.xn--ss-bqg4734erywk;  # -.્剘ß𐫃
+-.\u0ACD剘SS𐫃; -.\u0ACD剘ss𐫃; [B1, V3, V6]; -.xn--ss-bqg4734erywk; ; ;  # -.્剘ss𐫃
+-.\u0ACD剘ss𐫃; ; [B1, V3, V6]; -.xn--ss-bqg4734erywk; ; ;  # -.્剘ss𐫃
+-.\u0ACD剘Ss𐫃; -.\u0ACD剘ss𐫃; [B1, V3, V6]; -.xn--ss-bqg4734erywk; ; ;  # -.્剘ss𐫃
+-.xn--ss-bqg4734erywk; -.\u0ACD剘ss𐫃; [B1, V3, V6]; -.xn--ss-bqg4734erywk; ; ;  # -.્剘ss𐫃
+-.xn--zca791c493duf8i; -.\u0ACD剘ß𐫃; [B1, V3, V6]; -.xn--zca791c493duf8i; ; ;  # -.્剘ß𐫃
+\u08FB𞵸｡-; \u08FB𞵸.-; [B1, V3, V6, V7]; xn--b1b2719v.-; ; ;  # ࣻ.-
+\u08FB𞵸。-; \u08FB𞵸.-; [B1, V3, V6, V7]; xn--b1b2719v.-; ; ;  # ࣻ.-
+xn--b1b2719v.-; \u08FB𞵸.-; [B1, V3, V6, V7]; xn--b1b2719v.-; ; ;  # ࣻ.-
+⒈󠈻𐹲｡≠\u0603𐹽; ⒈󠈻𐹲.≠\u0603𐹽; [B1, V7]; xn--tshw766f1153g.xn--lfb536lb35n; ; ;  # ⒈𐹲.≠𐹽
+⒈󠈻𐹲｡=\u0338\u0603𐹽; ⒈󠈻𐹲.≠\u0603𐹽; [B1, V7]; xn--tshw766f1153g.xn--lfb536lb35n; ; ;  # ⒈𐹲.≠𐹽
+1.󠈻𐹲。≠\u0603𐹽; 1.󠈻𐹲.≠\u0603𐹽; [B1, V7]; 1.xn--qo0dl3077c.xn--lfb536lb35n; ; ;  # 1.𐹲.≠𐹽
+1.󠈻𐹲。=\u0338\u0603𐹽; 1.󠈻𐹲.≠\u0603𐹽; [B1, V7]; 1.xn--qo0dl3077c.xn--lfb536lb35n; ; ;  # 1.𐹲.≠𐹽
+1.xn--qo0dl3077c.xn--lfb536lb35n; 1.󠈻𐹲.≠\u0603𐹽; [B1, V7]; 1.xn--qo0dl3077c.xn--lfb536lb35n; ; ;  # 1.𐹲.≠𐹽
+xn--tshw766f1153g.xn--lfb536lb35n; ⒈󠈻𐹲.≠\u0603𐹽; [B1, V7]; xn--tshw766f1153g.xn--lfb536lb35n; ; ;  # ⒈𐹲.≠𐹽
+𐹢󠈚Ⴎ\u200C.㖾𐹡; 𐹢󠈚ⴎ\u200C.㖾𐹡; [B1, B5, B6, C1, V7]; xn--0ug342clq0pqxv4i.xn--pelu572d; ; xn--5kjx323em053g.xn--pelu572d; [B1, B5, B6, V7] # 𐹢ⴎ.㖾𐹡
+𐹢󠈚ⴎ\u200C.㖾𐹡; ; [B1, B5, B6, C1, V7]; xn--0ug342clq0pqxv4i.xn--pelu572d; ; xn--5kjx323em053g.xn--pelu572d; [B1, B5, B6, V7] # 𐹢ⴎ.㖾𐹡
+xn--5kjx323em053g.xn--pelu572d; 𐹢󠈚ⴎ.㖾𐹡; [B1, B5, B6, V7]; xn--5kjx323em053g.xn--pelu572d; ; ;  # 𐹢ⴎ.㖾𐹡
+xn--0ug342clq0pqxv4i.xn--pelu572d; 𐹢󠈚ⴎ\u200C.㖾𐹡; [B1, B5, B6, C1, V7]; xn--0ug342clq0pqxv4i.xn--pelu572d; ; ;  # 𐹢ⴎ.㖾𐹡
+xn--mnd9001km0o0g.xn--pelu572d; 𐹢󠈚Ⴎ.㖾𐹡; [B1, B5, B6, V7]; xn--mnd9001km0o0g.xn--pelu572d; ; ;  # 𐹢Ⴎ.㖾𐹡
+xn--mnd289ezj4pqxp0i.xn--pelu572d; 𐹢󠈚Ⴎ\u200C.㖾𐹡; [B1, B5, B6, C1, V7]; xn--mnd289ezj4pqxp0i.xn--pelu572d; ; ;  # 𐹢Ⴎ.㖾𐹡
+򩼗．\u07C7ᡖႳႧ; 򩼗.\u07C7ᡖⴓⴇ; [B2, B3, V7]; xn--te28c.xn--isb295fbtpmb; ; ;  # .߇ᡖⴓⴇ
+򩼗.\u07C7ᡖႳႧ; 򩼗.\u07C7ᡖⴓⴇ; [B2, B3, V7]; xn--te28c.xn--isb295fbtpmb; ; ;  # .߇ᡖⴓⴇ
+򩼗.\u07C7ᡖⴓⴇ; ; [B2, B3, V7]; xn--te28c.xn--isb295fbtpmb; ; ;  # .߇ᡖⴓⴇ
+xn--te28c.xn--isb295fbtpmb; 򩼗.\u07C7ᡖⴓⴇ; [B2, B3, V7]; xn--te28c.xn--isb295fbtpmb; ; ;  # .߇ᡖⴓⴇ
+򩼗．\u07C7ᡖⴓⴇ; 򩼗.\u07C7ᡖⴓⴇ; [B2, B3, V7]; xn--te28c.xn--isb295fbtpmb; ; ;  # .߇ᡖⴓⴇ
+xn--te28c.xn--isb856b9a631d; 򩼗.\u07C7ᡖႳႧ; [B2, B3, V7]; xn--te28c.xn--isb856b9a631d; ; ;  # .߇ᡖႳႧ
+򩼗.\u07C7ᡖႳⴇ; 򩼗.\u07C7ᡖⴓⴇ; [B2, B3, V7]; xn--te28c.xn--isb295fbtpmb; ; ;  # .߇ᡖⴓⴇ
+xn--te28c.xn--isb286btrgo7w; 򩼗.\u07C7ᡖႳⴇ; [B2, B3, V7]; xn--te28c.xn--isb286btrgo7w; ; ;  # .߇ᡖႳⴇ
+򩼗．\u07C7ᡖႳⴇ; 򩼗.\u07C7ᡖⴓⴇ; [B2, B3, V7]; xn--te28c.xn--isb295fbtpmb; ; ;  # .߇ᡖⴓⴇ
+\u200D􅍉.\u06B3\u0775; ; [B1, C2, V7]; xn--1ug39444n.xn--mkb20b; ; xn--3j78f.xn--mkb20b; [V7] # .ڳݵ
+xn--3j78f.xn--mkb20b; 􅍉.\u06B3\u0775; [V7]; xn--3j78f.xn--mkb20b; ; ;  # .ڳݵ
+xn--1ug39444n.xn--mkb20b; \u200D􅍉.\u06B3\u0775; [B1, C2, V7]; xn--1ug39444n.xn--mkb20b; ; ;  # .ڳݵ
+𲤱⒛⾳．ꡦ⒈; 𲤱⒛音.ꡦ⒈; [V7]; xn--dth6033bzbvx.xn--tsh9439b; ; ;  # 𲤱⒛音.ꡦ⒈
+𲤱20.音.ꡦ1.; ; ; xn--20-9802c.xn--0w5a.xn--1-eg4e.; [A4_2]; ;  # 𲤱20.音.ꡦ1.
+xn--20-9802c.xn--0w5a.xn--1-eg4e.; 𲤱20.音.ꡦ1.; ; xn--20-9802c.xn--0w5a.xn--1-eg4e.; [A4_2]; ;  # 𲤱20.音.ꡦ1.
+xn--dth6033bzbvx.xn--tsh9439b; 𲤱⒛音.ꡦ⒈; [V7]; xn--dth6033bzbvx.xn--tsh9439b; ; ;  # 𲤱⒛音.ꡦ⒈
+\u07DC８񳦓-｡򞲙𑁿𐩥\u09CD; \u07DC8񳦓-.򞲙𑁿𐩥\u09CD; [B2, B3, B5, B6, V3, V7]; xn--8--rve13079p.xn--b7b9842k42df776x; ; ;  # ߜ8-.𑁿𐩥্
+\u07DC8񳦓-。򞲙𑁿𐩥\u09CD; \u07DC8񳦓-.򞲙𑁿𐩥\u09CD; [B2, B3, B5, B6, V3, V7]; xn--8--rve13079p.xn--b7b9842k42df776x; ; ;  # ߜ8-.𑁿𐩥্
+xn--8--rve13079p.xn--b7b9842k42df776x; \u07DC8񳦓-.򞲙𑁿𐩥\u09CD; [B2, B3, B5, B6, V3, V7]; xn--8--rve13079p.xn--b7b9842k42df776x; ; ;  # ߜ8-.𑁿𐩥্
+Ⴕ。۰≮ß\u0745; ⴕ.۰≮ß\u0745; ; xn--dlj.xn--zca912alh227g; ; xn--dlj.xn--ss-jbe65aw27i;  # ⴕ.۰≮ß݅
+Ⴕ。۰<\u0338ß\u0745; ⴕ.۰≮ß\u0745; ; xn--dlj.xn--zca912alh227g; ; xn--dlj.xn--ss-jbe65aw27i;  # ⴕ.۰≮ß݅
+ⴕ。۰<\u0338ß\u0745; ⴕ.۰≮ß\u0745; ; xn--dlj.xn--zca912alh227g; ; xn--dlj.xn--ss-jbe65aw27i;  # ⴕ.۰≮ß݅
+ⴕ。۰≮ß\u0745; ⴕ.۰≮ß\u0745; ; xn--dlj.xn--zca912alh227g; ; xn--dlj.xn--ss-jbe65aw27i;  # ⴕ.۰≮ß݅
+Ⴕ。۰≮SS\u0745; ⴕ.۰≮ss\u0745; ; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+Ⴕ。۰<\u0338SS\u0745; ⴕ.۰≮ss\u0745; ; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+ⴕ。۰<\u0338ss\u0745; ⴕ.۰≮ss\u0745; ; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+ⴕ。۰≮ss\u0745; ⴕ.۰≮ss\u0745; ; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+Ⴕ。۰≮Ss\u0745; ⴕ.۰≮ss\u0745; ; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+Ⴕ。۰<\u0338Ss\u0745; ⴕ.۰≮ss\u0745; ; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+xn--dlj.xn--ss-jbe65aw27i; ⴕ.۰≮ss\u0745; ; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+ⴕ.۰≮ss\u0745; ; ; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+ⴕ.۰<\u0338ss\u0745; ⴕ.۰≮ss\u0745; ; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+Ⴕ.۰<\u0338SS\u0745; ⴕ.۰≮ss\u0745; ; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+Ⴕ.۰≮SS\u0745; ⴕ.۰≮ss\u0745; ; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+Ⴕ.۰≮Ss\u0745; ⴕ.۰≮ss\u0745; ; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+Ⴕ.۰<\u0338Ss\u0745; ⴕ.۰≮ss\u0745; ; xn--dlj.xn--ss-jbe65aw27i; ; ;  # ⴕ.۰≮ss݅
+xn--dlj.xn--zca912alh227g; ⴕ.۰≮ß\u0745; ; xn--dlj.xn--zca912alh227g; ; ;  # ⴕ.۰≮ß݅
+ⴕ.۰≮ß\u0745; ; ; xn--dlj.xn--zca912alh227g; ; xn--dlj.xn--ss-jbe65aw27i;  # ⴕ.۰≮ß݅
+ⴕ.۰<\u0338ß\u0745; ⴕ.۰≮ß\u0745; ; xn--dlj.xn--zca912alh227g; ; xn--dlj.xn--ss-jbe65aw27i;  # ⴕ.۰≮ß݅
+xn--tnd.xn--ss-jbe65aw27i; Ⴕ.۰≮ss\u0745; [V7]; xn--tnd.xn--ss-jbe65aw27i; ; ;  # Ⴕ.۰≮ss݅
+xn--tnd.xn--zca912alh227g; Ⴕ.۰≮ß\u0745; [V7]; xn--tnd.xn--zca912alh227g; ; ;  # Ⴕ.۰≮ß݅
+\u07E9-.𝨗꒱\u1B72; ; [B1, B3, V3, V6]; xn----odd.xn--dwf8994dc8wj; ; ;  # ߩ-.𝨗꒱᭲
+xn----odd.xn--dwf8994dc8wj; \u07E9-.𝨗꒱\u1B72; [B1, B3, V3, V6]; xn----odd.xn--dwf8994dc8wj; ; ;  # ߩ-.𝨗꒱᭲
+𞼸\u200C.≯䕵⫧; ; [B1, B3, C1, V7]; xn--0ugx453p.xn--hdh754ax6w; ; xn--sn7h.xn--hdh754ax6w; [B1, V7] # .≯䕵⫧
+𞼸\u200C.>\u0338䕵⫧; 𞼸\u200C.≯䕵⫧; [B1, B3, C1, V7]; xn--0ugx453p.xn--hdh754ax6w; ; xn--sn7h.xn--hdh754ax6w; [B1, V7] # .≯䕵⫧
+xn--sn7h.xn--hdh754ax6w; 𞼸.≯䕵⫧; [B1, V7]; xn--sn7h.xn--hdh754ax6w; ; ;  # .≯䕵⫧
+xn--0ugx453p.xn--hdh754ax6w; 𞼸\u200C.≯䕵⫧; [B1, B3, C1, V7]; xn--0ugx453p.xn--hdh754ax6w; ; ;  # .≯䕵⫧
+𐨅ß\uFC57.\u06AC۳︒; 𐨅ß\u064A\u062E.\u06AC۳︒; [B1, B3, V6, V7]; xn--zca23yncs877j.xn--fkb6lp314e; ; xn--ss-ytd5i7765l.xn--fkb6lp314e;  # 𐨅ßيخ.ڬ۳︒
+𐨅ß\u064A\u062E.\u06AC۳。; 𐨅ß\u064A\u062E.\u06AC۳.; [B1, V6]; xn--zca23yncs877j.xn--fkb6l.; [B1, V6, A4_2]; xn--ss-ytd5i7765l.xn--fkb6l.;  # 𐨅ßيخ.ڬ۳.
+𐨅SS\u064A\u062E.\u06AC۳。; 𐨅ss\u064A\u062E.\u06AC۳.; [B1, V6]; xn--ss-ytd5i7765l.xn--fkb6l.; [B1, V6, A4_2]; ;  # 𐨅ssيخ.ڬ۳.
+𐨅ss\u064A\u062E.\u06AC۳。; 𐨅ss\u064A\u062E.\u06AC۳.; [B1, V6]; xn--ss-ytd5i7765l.xn--fkb6l.; [B1, V6, A4_2]; ;  # 𐨅ssيخ.ڬ۳.
+𐨅Ss\u064A\u062E.\u06AC۳。; 𐨅ss\u064A\u062E.\u06AC۳.; [B1, V6]; xn--ss-ytd5i7765l.xn--fkb6l.; [B1, V6, A4_2]; ;  # 𐨅ssيخ.ڬ۳.
+xn--ss-ytd5i7765l.xn--fkb6l.; 𐨅ss\u064A\u062E.\u06AC۳.; [B1, V6]; xn--ss-ytd5i7765l.xn--fkb6l.; [B1, V6, A4_2]; ;  # 𐨅ssيخ.ڬ۳.
+xn--zca23yncs877j.xn--fkb6l.; 𐨅ß\u064A\u062E.\u06AC۳.; [B1, V6]; xn--zca23yncs877j.xn--fkb6l.; [B1, V6, A4_2]; ;  # 𐨅ßيخ.ڬ۳.
+𐨅SS\uFC57.\u06AC۳︒; 𐨅ss\u064A\u062E.\u06AC۳︒; [B1, B3, V6, V7]; xn--ss-ytd5i7765l.xn--fkb6lp314e; ; ;  # 𐨅ssيخ.ڬ۳︒
+𐨅ss\uFC57.\u06AC۳︒; 𐨅ss\u064A\u062E.\u06AC۳︒; [B1, B3, V6, V7]; xn--ss-ytd5i7765l.xn--fkb6lp314e; ; ;  # 𐨅ssيخ.ڬ۳︒
+𐨅Ss\uFC57.\u06AC۳︒; 𐨅ss\u064A\u062E.\u06AC۳︒; [B1, B3, V6, V7]; xn--ss-ytd5i7765l.xn--fkb6lp314e; ; ;  # 𐨅ssيخ.ڬ۳︒
+xn--ss-ytd5i7765l.xn--fkb6lp314e; 𐨅ss\u064A\u062E.\u06AC۳︒; [B1, B3, V6, V7]; xn--ss-ytd5i7765l.xn--fkb6lp314e; ; ;  # 𐨅ssيخ.ڬ۳︒
+xn--zca23yncs877j.xn--fkb6lp314e; 𐨅ß\u064A\u062E.\u06AC۳︒; [B1, B3, V6, V7]; xn--zca23yncs877j.xn--fkb6lp314e; ; ;  # 𐨅ßيخ.ڬ۳︒
+-≮🡒\u1CED.񏿾Ⴁ\u0714; -≮🡒\u1CED.񏿾ⴁ\u0714; [B1, V3, V7]; xn----44l04zxt68c.xn--enb135qf106f; ; ;  # -≮🡒᳭.ⴁܔ
+-<\u0338🡒\u1CED.񏿾Ⴁ\u0714; -≮🡒\u1CED.񏿾ⴁ\u0714; [B1, V3, V7]; xn----44l04zxt68c.xn--enb135qf106f; ; ;  # -≮🡒᳭.ⴁܔ
+-<\u0338🡒\u1CED.񏿾ⴁ\u0714; -≮🡒\u1CED.񏿾ⴁ\u0714; [B1, V3, V7]; xn----44l04zxt68c.xn--enb135qf106f; ; ;  # -≮🡒᳭.ⴁܔ
+-≮🡒\u1CED.񏿾ⴁ\u0714; ; [B1, V3, V7]; xn----44l04zxt68c.xn--enb135qf106f; ; ;  # -≮🡒᳭.ⴁܔ
+xn----44l04zxt68c.xn--enb135qf106f; -≮🡒\u1CED.񏿾ⴁ\u0714; [B1, V3, V7]; xn----44l04zxt68c.xn--enb135qf106f; ; ;  # -≮🡒᳭.ⴁܔ
+xn----44l04zxt68c.xn--enb300c1597h; -≮🡒\u1CED.񏿾Ⴁ\u0714; [B1, V3, V7]; xn----44l04zxt68c.xn--enb300c1597h; ; ;  # -≮🡒᳭.Ⴁܔ
+𞤨｡ꡏ\u200D\u200C; 𞤨.ꡏ\u200D\u200C; [B6, C1, C2]; xn--ge6h.xn--0ugb9575h; ; xn--ge6h.xn--oc9a; [] # 𞤨.ꡏ
+𞤨。ꡏ\u200D\u200C; 𞤨.ꡏ\u200D\u200C; [B6, C1, C2]; xn--ge6h.xn--0ugb9575h; ; xn--ge6h.xn--oc9a; [] # 𞤨.ꡏ
+𞤆。ꡏ\u200D\u200C; 𞤨.ꡏ\u200D\u200C; [B6, C1, C2]; xn--ge6h.xn--0ugb9575h; ; xn--ge6h.xn--oc9a; [] # 𞤨.ꡏ
+xn--ge6h.xn--oc9a; 𞤨.ꡏ; ; xn--ge6h.xn--oc9a; ; ;  # 𞤨.ꡏ
+𞤨.ꡏ; ; ; xn--ge6h.xn--oc9a; ; ;  # 𞤨.ꡏ
+𞤆.ꡏ; 𞤨.ꡏ; ; xn--ge6h.xn--oc9a; ; ;  # 𞤨.ꡏ
+xn--ge6h.xn--0ugb9575h; 𞤨.ꡏ\u200D\u200C; [B6, C1, C2]; xn--ge6h.xn--0ugb9575h; ; ;  # 𞤨.ꡏ
+𞤆｡ꡏ\u200D\u200C; 𞤨.ꡏ\u200D\u200C; [B6, C1, C2]; xn--ge6h.xn--0ugb9575h; ; xn--ge6h.xn--oc9a; [] # 𞤨.ꡏ
+󠅹𑂶．ᢌ𑂹\u0669; 𑂶.ᢌ𑂹\u0669; [B1, B5, B6, V6]; xn--b50d.xn--iib993gyp5p; ; ;  # 𑂶.ᢌ𑂹٩
+󠅹𑂶.ᢌ𑂹\u0669; 𑂶.ᢌ𑂹\u0669; [B1, B5, B6, V6]; xn--b50d.xn--iib993gyp5p; ; ;  # 𑂶.ᢌ𑂹٩
+xn--b50d.xn--iib993gyp5p; 𑂶.ᢌ𑂹\u0669; [B1, B5, B6, V6]; xn--b50d.xn--iib993gyp5p; ; ;  # 𑂶.ᢌ𑂹٩
+Ⅎ󠅺񝵒。≯⾑; ⅎ񝵒.≯襾; [V7]; xn--73g39298c.xn--hdhz171b; ; ;  # ⅎ.≯襾
+Ⅎ󠅺񝵒。>\u0338⾑; ⅎ񝵒.≯襾; [V7]; xn--73g39298c.xn--hdhz171b; ; ;  # ⅎ.≯襾
+Ⅎ󠅺񝵒。≯襾; ⅎ񝵒.≯襾; [V7]; xn--73g39298c.xn--hdhz171b; ; ;  # ⅎ.≯襾
+Ⅎ󠅺񝵒。>\u0338襾; ⅎ񝵒.≯襾; [V7]; xn--73g39298c.xn--hdhz171b; ; ;  # ⅎ.≯襾
+ⅎ󠅺񝵒。>\u0338襾; ⅎ񝵒.≯襾; [V7]; xn--73g39298c.xn--hdhz171b; ; ;  # ⅎ.≯襾
+ⅎ󠅺񝵒。≯襾; ⅎ񝵒.≯襾; [V7]; xn--73g39298c.xn--hdhz171b; ; ;  # ⅎ.≯襾
+xn--73g39298c.xn--hdhz171b; ⅎ񝵒.≯襾; [V7]; xn--73g39298c.xn--hdhz171b; ; ;  # ⅎ.≯襾
+ⅎ󠅺񝵒。>\u0338⾑; ⅎ񝵒.≯襾; [V7]; xn--73g39298c.xn--hdhz171b; ; ;  # ⅎ.≯襾
+ⅎ󠅺񝵒。≯⾑; ⅎ񝵒.≯襾; [V7]; xn--73g39298c.xn--hdhz171b; ; ;  # ⅎ.≯襾
+xn--f3g73398c.xn--hdhz171b; Ⅎ񝵒.≯襾; [V7]; xn--f3g73398c.xn--hdhz171b; ; ;  # Ⅎ.≯襾
+ς\u200D\u0DD4\u0660｡-; ς\u200D\u0DD4\u0660.-; [B1, B5, B6, C2, V3]; xn--3xa45ks2jenu.-; ; xn--4xa25ks2j.-; [B1, B5, B6, V3] # ςු٠.-
+ς\u200D\u0DD4\u0660。-; ς\u200D\u0DD4\u0660.-; [B1, B5, B6, C2, V3]; xn--3xa45ks2jenu.-; ; xn--4xa25ks2j.-; [B1, B5, B6, V3] # ςු٠.-
+Σ\u200D\u0DD4\u0660。-; σ\u200D\u0DD4\u0660.-; [B1, B5, B6, C2, V3]; xn--4xa25ks2jenu.-; ; xn--4xa25ks2j.-; [B1, B5, B6, V3] # σු٠.-
+σ\u200D\u0DD4\u0660。-; σ\u200D\u0DD4\u0660.-; [B1, B5, B6, C2, V3]; xn--4xa25ks2jenu.-; ; xn--4xa25ks2j.-; [B1, B5, B6, V3] # σු٠.-
+xn--4xa25ks2j.-; σ\u0DD4\u0660.-; [B1, B5, B6, V3]; xn--4xa25ks2j.-; ; ;  # σු٠.-
+xn--4xa25ks2jenu.-; σ\u200D\u0DD4\u0660.-; [B1, B5, B6, C2, V3]; xn--4xa25ks2jenu.-; ; ;  # σු٠.-
+xn--3xa45ks2jenu.-; ς\u200D\u0DD4\u0660.-; [B1, B5, B6, C2, V3]; xn--3xa45ks2jenu.-; ; ;  # ςු٠.-
+Σ\u200D\u0DD4\u0660｡-; σ\u200D\u0DD4\u0660.-; [B1, B5, B6, C2, V3]; xn--4xa25ks2jenu.-; ; xn--4xa25ks2j.-; [B1, B5, B6, V3] # σු٠.-
+σ\u200D\u0DD4\u0660｡-; σ\u200D\u0DD4\u0660.-; [B1, B5, B6, C2, V3]; xn--4xa25ks2jenu.-; ; xn--4xa25ks2j.-; [B1, B5, B6, V3] # σු٠.-
+\u200C.ßႩ-; \u200C.ßⴉ-; [C1, V3]; xn--0ug.xn----pfa2305a; ; .xn--ss--bi1b; [V3, A4_2] # .ßⴉ-
+\u200C.ßⴉ-; ; [C1, V3]; xn--0ug.xn----pfa2305a; ; .xn--ss--bi1b; [V3, A4_2] # .ßⴉ-
+\u200C.SSႩ-; \u200C.ssⴉ-; [C1, V3]; xn--0ug.xn--ss--bi1b; ; .xn--ss--bi1b; [V3, A4_2] # .ssⴉ-
+\u200C.ssⴉ-; ; [C1, V3]; xn--0ug.xn--ss--bi1b; ; .xn--ss--bi1b; [V3, A4_2] # .ssⴉ-
+\u200C.Ssⴉ-; \u200C.ssⴉ-; [C1, V3]; xn--0ug.xn--ss--bi1b; ; .xn--ss--bi1b; [V3, A4_2] # .ssⴉ-
+.xn--ss--bi1b; .ssⴉ-; [V3, X4_2]; .xn--ss--bi1b; [V3, A4_2]; ;  # .ssⴉ-
+xn--0ug.xn--ss--bi1b; \u200C.ssⴉ-; [C1, V3]; xn--0ug.xn--ss--bi1b; ; ;  # .ssⴉ-
+xn--0ug.xn----pfa2305a; \u200C.ßⴉ-; [C1, V3]; xn--0ug.xn----pfa2305a; ; ;  # .ßⴉ-
+.xn--ss--4rn; .ssႩ-; [V3, V7, X4_2]; .xn--ss--4rn; [V3, V7, A4_2]; ;  # .ssႩ-
+xn--0ug.xn--ss--4rn; \u200C.ssႩ-; [C1, V3, V7]; xn--0ug.xn--ss--4rn; ; ;  # .ssႩ-
+xn--0ug.xn----pfa042j; \u200C.ßႩ-; [C1, V3, V7]; xn--0ug.xn----pfa042j; ; ;  # .ßႩ-
+󍭲𐫍㓱。⾑; 󍭲𐫍㓱.襾; [B5, V7]; xn--u7kt691dlj09f.xn--9v2a; ; ;  # 𐫍㓱.襾
+󍭲𐫍㓱。襾; 󍭲𐫍㓱.襾; [B5, V7]; xn--u7kt691dlj09f.xn--9v2a; ; ;  # 𐫍㓱.襾
+xn--u7kt691dlj09f.xn--9v2a; 󍭲𐫍㓱.襾; [B5, V7]; xn--u7kt691dlj09f.xn--9v2a; ; ;  # 𐫍㓱.襾
+\u06A0𐮋𐹰≮。≯󠦗\u200D; \u06A0𐮋𐹰≮.≯󠦗\u200D; [B1, B3, C2, V7]; xn--2jb053lf13nyoc.xn--1ugx6gc8096c; ; xn--2jb053lf13nyoc.xn--hdh08821l; [B1, B3, V7] # ڠ𐮋𐹰≮.≯
+\u06A0𐮋𐹰<\u0338。>\u0338󠦗\u200D; \u06A0𐮋𐹰≮.≯󠦗\u200D; [B1, B3, C2, V7]; xn--2jb053lf13nyoc.xn--1ugx6gc8096c; ; xn--2jb053lf13nyoc.xn--hdh08821l; [B1, B3, V7] # ڠ𐮋𐹰≮.≯
+xn--2jb053lf13nyoc.xn--hdh08821l; \u06A0𐮋𐹰≮.≯󠦗; [B1, B3, V7]; xn--2jb053lf13nyoc.xn--hdh08821l; ; ;  # ڠ𐮋𐹰≮.≯
+xn--2jb053lf13nyoc.xn--1ugx6gc8096c; \u06A0𐮋𐹰≮.≯󠦗\u200D; [B1, B3, C2, V7]; xn--2jb053lf13nyoc.xn--1ugx6gc8096c; ; ;  # ڠ𐮋𐹰≮.≯
+𝟞｡񃰶\u0777\u08B0⩋; 6.񃰶\u0777\u08B0⩋; [B1, B5, B6, V7]; 6.xn--7pb04do15eq748f; ; ;  # 6.ݷࢰ⩋
+6。񃰶\u0777\u08B0⩋; 6.񃰶\u0777\u08B0⩋; [B1, B5, B6, V7]; 6.xn--7pb04do15eq748f; ; ;  # 6.ݷࢰ⩋
+6.xn--7pb04do15eq748f; 6.񃰶\u0777\u08B0⩋; [B1, B5, B6, V7]; 6.xn--7pb04do15eq748f; ; ;  # 6.ݷࢰ⩋
+-\uFCFD。𑇀𑍴; -\u0634\u0649.𑇀𑍴; [B1, V3, V6]; xn----qnc7d.xn--wd1d62a; ; ;  # -شى.𑇀𑍴
+-\uFCFD。𑇀𑍴; -\u0634\u0649.𑇀𑍴; [B1, V3, V6]; xn----qnc7d.xn--wd1d62a; ; ;  # -شى.𑇀𑍴
+-\u0634\u0649。𑇀𑍴; -\u0634\u0649.𑇀𑍴; [B1, V3, V6]; xn----qnc7d.xn--wd1d62a; ; ;  # -شى.𑇀𑍴
+xn----qnc7d.xn--wd1d62a; -\u0634\u0649.𑇀𑍴; [B1, V3, V6]; xn----qnc7d.xn--wd1d62a; ; ;  # -شى.𑇀𑍴
+\u200C󠊶𝟏.\u0D43򪥐𐹬󊓶; \u200C󠊶1.\u0D43򪥐𐹬󊓶; [B1, C1, V6, V7]; xn--1-rgnu0071n.xn--mxc0872kcu37dnmem; ; xn--1-f521m.xn--mxc0872kcu37dnmem; [B1, V6, V7] # 1.ൃ𐹬
+\u200C󠊶1.\u0D43򪥐𐹬󊓶; ; [B1, C1, V6, V7]; xn--1-rgnu0071n.xn--mxc0872kcu37dnmem; ; xn--1-f521m.xn--mxc0872kcu37dnmem; [B1, V6, V7] # 1.ൃ𐹬
+xn--1-f521m.xn--mxc0872kcu37dnmem; 󠊶1.\u0D43򪥐𐹬󊓶; [B1, V6, V7]; xn--1-f521m.xn--mxc0872kcu37dnmem; ; ;  # 1.ൃ𐹬
+xn--1-rgnu0071n.xn--mxc0872kcu37dnmem; \u200C󠊶1.\u0D43򪥐𐹬󊓶; [B1, C1, V6, V7]; xn--1-rgnu0071n.xn--mxc0872kcu37dnmem; ; ;  # 1.ൃ𐹬
+齙--𝟰.ß; 齙--4.ß; ; xn----4-p16k.xn--zca; ; xn----4-p16k.ss;  # 齙--4.ß
+齙--4.ß; ; ; xn----4-p16k.xn--zca; ; xn----4-p16k.ss;  # 齙--4.ß
+齙--4.SS; 齙--4.ss; ; xn----4-p16k.ss; ; ;  # 齙--4.ss
+齙--4.ss; ; ; xn----4-p16k.ss; ; ;  # 齙--4.ss
+齙--4.Ss; 齙--4.ss; ; xn----4-p16k.ss; ; ;  # 齙--4.ss
+xn----4-p16k.ss; 齙--4.ss; ; xn----4-p16k.ss; ; ;  # 齙--4.ss
+xn----4-p16k.xn--zca; 齙--4.ß; ; xn----4-p16k.xn--zca; ; ;  # 齙--4.ß
+齙--𝟰.SS; 齙--4.ss; ; xn----4-p16k.ss; ; ;  # 齙--4.ss
+齙--𝟰.ss; 齙--4.ss; ; xn----4-p16k.ss; ; ;  # 齙--4.ss
+齙--𝟰.Ss; 齙--4.ss; ; xn----4-p16k.ss; ; ;  # 齙--4.ss
+\u1BF2.𐹢𞀖\u200C; ; [B1, C1, V6]; xn--0zf.xn--0ug9894grqqf; ; xn--0zf.xn--9n0d2296a; [B1, V6] # ᯲.𐹢𞀖
+xn--0zf.xn--9n0d2296a; \u1BF2.𐹢𞀖; [B1, V6]; xn--0zf.xn--9n0d2296a; ; ;  # ᯲.𐹢𞀖
+xn--0zf.xn--0ug9894grqqf; \u1BF2.𐹢𞀖\u200C; [B1, C1, V6]; xn--0zf.xn--0ug9894grqqf; ; ;  # ᯲.𐹢𞀖
+󃲙󠋘｡?-\u200D; 󃲙󠋘.?-\u200D; [C2, V7, U1]; xn--ct86d8w51a.xn--?--n1t; ; xn--ct86d8w51a.?-; [V3, V7, U1] # .?-
+󃲙󠋘。?-\u200D; 󃲙󠋘.?-\u200D; [C2, V7, U1]; xn--ct86d8w51a.xn--?--n1t; ; xn--ct86d8w51a.?-; [V3, V7, U1] # .?-
+xn--ct86d8w51a.?-; 󃲙󠋘.?-; [V3, V7, U1]; xn--ct86d8w51a.?-; ; ;  # .?-
+xn--ct86d8w51a.xn--?--n1t; 󃲙󠋘.?-\u200D; [C2, V7, U1]; xn--ct86d8w51a.xn--?--n1t; ; ;  # .?-
+xn--ct86d8w51a.?-\u200D; 󃲙󠋘.?-\u200D; [C2, V7, U1]; xn--ct86d8w51a.xn--?--n1t; ; xn--ct86d8w51a.?-; [V3, V7, U1] # .?-
+XN--CT86D8W51A.?-\u200D; 󃲙󠋘.?-\u200D; [C2, V7, U1]; xn--ct86d8w51a.xn--?--n1t; ; xn--ct86d8w51a.?-; [V3, V7, U1] # .?-
+Xn--Ct86d8w51a.?-\u200D; 󃲙󠋘.?-\u200D; [C2, V7, U1]; xn--ct86d8w51a.xn--?--n1t; ; xn--ct86d8w51a.?-; [V3, V7, U1] # .?-
+\u1A60．𞵷-𝪩悎; \u1A60.𞵷-𝪩悎; [B1, B2, B3, V6, V7]; xn--jof.xn----gf4bq282iezpa; ; ;  # ᩠.-𝪩悎
+\u1A60.𞵷-𝪩悎; ; [B1, B2, B3, V6, V7]; xn--jof.xn----gf4bq282iezpa; ; ;  # ᩠.-𝪩悎
+xn--jof.xn----gf4bq282iezpa; \u1A60.𞵷-𝪩悎; [B1, B2, B3, V6, V7]; xn--jof.xn----gf4bq282iezpa; ; ;  # ᩠.-𝪩悎
+𛜯󠊛．𞤳񏥾; 𛜯󠊛.𞤳񏥾; [B2, B3, B6, V7]; xn--xx5gy2741c.xn--re6hw266j; ; ;  # .𞤳
+𛜯󠊛.𞤳񏥾; ; [B2, B3, B6, V7]; xn--xx5gy2741c.xn--re6hw266j; ; ;  # .𞤳
+𛜯󠊛.𞤑񏥾; 𛜯󠊛.𞤳񏥾; [B2, B3, B6, V7]; xn--xx5gy2741c.xn--re6hw266j; ; ;  # .𞤳
+xn--xx5gy2741c.xn--re6hw266j; 𛜯󠊛.𞤳񏥾; [B2, B3, B6, V7]; xn--xx5gy2741c.xn--re6hw266j; ; ;  # .𞤳
+𛜯󠊛．𞤑񏥾; 𛜯󠊛.𞤳񏥾; [B2, B3, B6, V7]; xn--xx5gy2741c.xn--re6hw266j; ; ;  # .𞤳
+\u071C𐫒\u062E.𐋲; ; [B1]; xn--tgb98b8643d.xn--m97c; ; ;  # ܜ𐫒خ.𐋲
+xn--tgb98b8643d.xn--m97c; \u071C𐫒\u062E.𐋲; [B1]; xn--tgb98b8643d.xn--m97c; ; ;  # ܜ𐫒خ.𐋲
+𐼑𞤓\u0637\u08E2.?; 𐼑𞤵\u0637\u08E2.?; [B1, V7, U1]; xn--2gb08k9w69agm0g.?; ; ;  # 𐼑𞤵ط.?
+𐼑𞤵\u0637\u08E2.?; ; [B1, V7, U1]; xn--2gb08k9w69agm0g.?; ; ;  # 𐼑𞤵ط.?
+xn--2gb08k9w69agm0g.?; 𐼑𞤵\u0637\u08E2.?; [B1, V7, U1]; xn--2gb08k9w69agm0g.?; ; ;  # 𐼑𞤵ط.?
+Ↄ。\u0A4D\u1CD4𞷣; ↄ.\u1CD4\u0A4D𞷣; [B1, V6, V7]; xn--r5g.xn--ybc995g0835a; ; ;  # ↄ.᳔੍
+Ↄ。\u1CD4\u0A4D𞷣; ↄ.\u1CD4\u0A4D𞷣; [B1, V6, V7]; xn--r5g.xn--ybc995g0835a; ; ;  # ↄ.᳔੍
+ↄ。\u1CD4\u0A4D𞷣; ↄ.\u1CD4\u0A4D𞷣; [B1, V6, V7]; xn--r5g.xn--ybc995g0835a; ; ;  # ↄ.᳔੍
+xn--r5g.xn--ybc995g0835a; ↄ.\u1CD4\u0A4D𞷣; [B1, V6, V7]; xn--r5g.xn--ybc995g0835a; ; ;  # ↄ.᳔੍
+ↄ。\u0A4D\u1CD4𞷣; ↄ.\u1CD4\u0A4D𞷣; [B1, V6, V7]; xn--r5g.xn--ybc995g0835a; ; ;  # ↄ.᳔੍
+xn--q5g.xn--ybc995g0835a; Ↄ.\u1CD4\u0A4D𞷣; [B1, V6, V7]; xn--q5g.xn--ybc995g0835a; ; ;  # Ↄ.᳔੍
+󠪢-。򛂏≮𑜫; 󠪢-.򛂏≮𑜫; [V3, V7]; xn----bh61m.xn--gdhz157g0em1d; ; ;  # -.≮𑜫
+󠪢-。򛂏<\u0338𑜫; 󠪢-.򛂏≮𑜫; [V3, V7]; xn----bh61m.xn--gdhz157g0em1d; ; ;  # -.≮𑜫
+xn----bh61m.xn--gdhz157g0em1d; 󠪢-.򛂏≮𑜫; [V3, V7]; xn----bh61m.xn--gdhz157g0em1d; ; ;  # -.≮𑜫
+\u200C󠉹\u200D。򌿧≮Ⴉ; \u200C󠉹\u200D.򌿧≮ⴉ; [C1, C2, V7]; xn--0ugc90904y.xn--gdh992byu01p; ; xn--3n36e.xn--gdh992byu01p; [V7] # .≮ⴉ
+\u200C󠉹\u200D。򌿧<\u0338Ⴉ; \u200C󠉹\u200D.򌿧≮ⴉ; [C1, C2, V7]; xn--0ugc90904y.xn--gdh992byu01p; ; xn--3n36e.xn--gdh992byu01p; [V7] # .≮ⴉ
+\u200C󠉹\u200D。򌿧<\u0338ⴉ; \u200C󠉹\u200D.򌿧≮ⴉ; [C1, C2, V7]; xn--0ugc90904y.xn--gdh992byu01p; ; xn--3n36e.xn--gdh992byu01p; [V7] # .≮ⴉ
+\u200C󠉹\u200D。򌿧≮ⴉ; \u200C󠉹\u200D.򌿧≮ⴉ; [C1, C2, V7]; xn--0ugc90904y.xn--gdh992byu01p; ; xn--3n36e.xn--gdh992byu01p; [V7] # .≮ⴉ
+xn--3n36e.xn--gdh992byu01p; 󠉹.򌿧≮ⴉ; [V7]; xn--3n36e.xn--gdh992byu01p; ; ;  # .≮ⴉ
+xn--0ugc90904y.xn--gdh992byu01p; \u200C󠉹\u200D.򌿧≮ⴉ; [C1, C2, V7]; xn--0ugc90904y.xn--gdh992byu01p; ; ;  # .≮ⴉ
+xn--3n36e.xn--hnd112gpz83n; 󠉹.򌿧≮Ⴉ; [V7]; xn--3n36e.xn--hnd112gpz83n; ; ;  # .≮Ⴉ
+xn--0ugc90904y.xn--hnd112gpz83n; \u200C󠉹\u200D.򌿧≮Ⴉ; [C1, C2, V7]; xn--0ugc90904y.xn--hnd112gpz83n; ; ;  # .≮Ⴉ
+𐹯-𑄴\u08BC。︒䖐⾆; 𐹯-𑄴\u08BC.︒䖐舌; [B1, V7]; xn----rpd7902rclc.xn--fpo216mn07e; ; ;  # 𐹯-𑄴ࢼ.︒䖐舌
+𐹯-𑄴\u08BC。。䖐舌; 𐹯-𑄴\u08BC..䖐舌; [B1, X4_2]; xn----rpd7902rclc..xn--fpo216m; [B1, A4_2]; ;  # 𐹯-𑄴ࢼ..䖐舌
+xn----rpd7902rclc..xn--fpo216m; 𐹯-𑄴\u08BC..䖐舌; [B1, X4_2]; xn----rpd7902rclc..xn--fpo216m; [B1, A4_2]; ;  # 𐹯-𑄴ࢼ..䖐舌
+xn----rpd7902rclc.xn--fpo216mn07e; 𐹯-𑄴\u08BC.︒䖐舌; [B1, V7]; xn----rpd7902rclc.xn--fpo216mn07e; ; ;  # 𐹯-𑄴ࢼ.︒䖐舌
+𝪞Ⴐ｡쪡; 𝪞ⴐ.쪡; [V6]; xn--7kj1858k.xn--pi6b; ; ;  # 𝪞ⴐ.쪡
+𝪞Ⴐ｡쪡; 𝪞ⴐ.쪡; [V6]; xn--7kj1858k.xn--pi6b; ; ;  # 𝪞ⴐ.쪡
+𝪞Ⴐ。쪡; 𝪞ⴐ.쪡; [V6]; xn--7kj1858k.xn--pi6b; ; ;  # 𝪞ⴐ.쪡
+𝪞Ⴐ。쪡; 𝪞ⴐ.쪡; [V6]; xn--7kj1858k.xn--pi6b; ; ;  # 𝪞ⴐ.쪡
+𝪞ⴐ。쪡; 𝪞ⴐ.쪡; [V6]; xn--7kj1858k.xn--pi6b; ; ;  # 𝪞ⴐ.쪡
+𝪞ⴐ。쪡; 𝪞ⴐ.쪡; [V6]; xn--7kj1858k.xn--pi6b; ; ;  # 𝪞ⴐ.쪡
+xn--7kj1858k.xn--pi6b; 𝪞ⴐ.쪡; [V6]; xn--7kj1858k.xn--pi6b; ; ;  # 𝪞ⴐ.쪡
+𝪞ⴐ｡쪡; 𝪞ⴐ.쪡; [V6]; xn--7kj1858k.xn--pi6b; ; ;  # 𝪞ⴐ.쪡
+𝪞ⴐ｡쪡; 𝪞ⴐ.쪡; [V6]; xn--7kj1858k.xn--pi6b; ; ;  # 𝪞ⴐ.쪡
+xn--ond3755u.xn--pi6b; 𝪞Ⴐ.쪡; [V6, V7]; xn--ond3755u.xn--pi6b; ; ;  # 𝪞Ⴐ.쪡
+\u0E3A쩁𐹬.􋉳; ; [B1, V6, V7]; xn--o4c4837g2zvb.xn--5f70g; ; ;  # ฺ쩁𐹬.
+\u0E3A쩁𐹬.􋉳; \u0E3A쩁𐹬.􋉳; [B1, V6, V7]; xn--o4c4837g2zvb.xn--5f70g; ; ;  # ฺ쩁𐹬.
+xn--o4c4837g2zvb.xn--5f70g; \u0E3A쩁𐹬.􋉳; [B1, V6, V7]; xn--o4c4837g2zvb.xn--5f70g; ; ;  # ฺ쩁𐹬.
+ᡅ０\u200C｡⎢󤨄; ᡅ0\u200C.⎢󤨄; [C1, V7]; xn--0-z6jy93b.xn--8lh28773l; ; xn--0-z6j.xn--8lh28773l; [V7] # ᡅ0.⎢
+ᡅ0\u200C。⎢󤨄; ᡅ0\u200C.⎢󤨄; [C1, V7]; xn--0-z6jy93b.xn--8lh28773l; ; xn--0-z6j.xn--8lh28773l; [V7] # ᡅ0.⎢
+xn--0-z6j.xn--8lh28773l; ᡅ0.⎢󤨄; [V7]; xn--0-z6j.xn--8lh28773l; ; ;  # ᡅ0.⎢
+xn--0-z6jy93b.xn--8lh28773l; ᡅ0\u200C.⎢󤨄; [C1, V7]; xn--0-z6jy93b.xn--8lh28773l; ; ;  # ᡅ0.⎢
+𲮚９ꍩ\u17D3．\u200Dß; 𲮚9ꍩ\u17D3.\u200Dß; [C2]; xn--9-i0j5967eg3qz.xn--zca770n; ; xn--9-i0j5967eg3qz.ss; [] # 𲮚9ꍩ៓.ß
+𲮚9ꍩ\u17D3.\u200Dß; ; [C2]; xn--9-i0j5967eg3qz.xn--zca770n; ; xn--9-i0j5967eg3qz.ss; [] # 𲮚9ꍩ៓.ß
+𲮚9ꍩ\u17D3.\u200DSS; 𲮚9ꍩ\u17D3.\u200Dss; [C2]; xn--9-i0j5967eg3qz.xn--ss-l1t; ; xn--9-i0j5967eg3qz.ss; [] # 𲮚9ꍩ៓.ss
+𲮚9ꍩ\u17D3.\u200Dss; ; [C2]; xn--9-i0j5967eg3qz.xn--ss-l1t; ; xn--9-i0j5967eg3qz.ss; [] # 𲮚9ꍩ៓.ss
+xn--9-i0j5967eg3qz.ss; 𲮚9ꍩ\u17D3.ss; ; xn--9-i0j5967eg3qz.ss; ; ;  # 𲮚9ꍩ៓.ss
+𲮚9ꍩ\u17D3.ss; ; ; xn--9-i0j5967eg3qz.ss; ; ;  # 𲮚9ꍩ៓.ss
+𲮚9ꍩ\u17D3.SS; 𲮚9ꍩ\u17D3.ss; ; xn--9-i0j5967eg3qz.ss; ; ;  # 𲮚9ꍩ៓.ss
+xn--9-i0j5967eg3qz.xn--ss-l1t; 𲮚9ꍩ\u17D3.\u200Dss; [C2]; xn--9-i0j5967eg3qz.xn--ss-l1t; ; ;  # 𲮚9ꍩ៓.ss
+xn--9-i0j5967eg3qz.xn--zca770n; 𲮚9ꍩ\u17D3.\u200Dß; [C2]; xn--9-i0j5967eg3qz.xn--zca770n; ; ;  # 𲮚9ꍩ៓.ß
+𲮚９ꍩ\u17D3．\u200DSS; 𲮚9ꍩ\u17D3.\u200Dss; [C2]; xn--9-i0j5967eg3qz.xn--ss-l1t; ; xn--9-i0j5967eg3qz.ss; [] # 𲮚9ꍩ៓.ss
+𲮚９ꍩ\u17D3．\u200Dss; 𲮚9ꍩ\u17D3.\u200Dss; [C2]; xn--9-i0j5967eg3qz.xn--ss-l1t; ; xn--9-i0j5967eg3qz.ss; [] # 𲮚9ꍩ៓.ss
+𲮚9ꍩ\u17D3.\u200DSs; 𲮚9ꍩ\u17D3.\u200Dss; [C2]; xn--9-i0j5967eg3qz.xn--ss-l1t; ; xn--9-i0j5967eg3qz.ss; [] # 𲮚9ꍩ៓.ss
+𲮚９ꍩ\u17D3．\u200DSs; 𲮚9ꍩ\u17D3.\u200Dss; [C2]; xn--9-i0j5967eg3qz.xn--ss-l1t; ; xn--9-i0j5967eg3qz.ss; [] # 𲮚9ꍩ៓.ss
+ꗷ𑆀.\u075D𐩒; ; ; xn--ju8a625r.xn--hpb0073k; ; ;  # ꗷ𑆀.ݝ𐩒
+xn--ju8a625r.xn--hpb0073k; ꗷ𑆀.\u075D𐩒; ; xn--ju8a625r.xn--hpb0073k; ; ;  # ꗷ𑆀.ݝ𐩒
+⒐≯-。︒򩑣-񞛠; ⒐≯-.︒򩑣-񞛠; [V3, V7]; xn----ogot9g.xn----n89hl0522az9u2a; ; ;  # ⒐≯-.︒-
+⒐>\u0338-。︒򩑣-񞛠; ⒐≯-.︒򩑣-񞛠; [V3, V7]; xn----ogot9g.xn----n89hl0522az9u2a; ; ;  # ⒐≯-.︒-
+9.≯-。。򩑣-񞛠; 9.≯-..򩑣-񞛠; [V3, V7, X4_2]; 9.xn----ogo..xn----xj54d1s69k; [V3, V7, A4_2]; ;  # 9.≯-..-
+9.>\u0338-。。򩑣-񞛠; 9.≯-..򩑣-񞛠; [V3, V7, X4_2]; 9.xn----ogo..xn----xj54d1s69k; [V3, V7, A4_2]; ;  # 9.≯-..-
+9.xn----ogo..xn----xj54d1s69k; 9.≯-..򩑣-񞛠; [V3, V7, X4_2]; 9.xn----ogo..xn----xj54d1s69k; [V3, V7, A4_2]; ;  # 9.≯-..-
+xn----ogot9g.xn----n89hl0522az9u2a; ⒐≯-.︒򩑣-񞛠; [V3, V7]; xn----ogot9g.xn----n89hl0522az9u2a; ; ;  # ⒐≯-.︒-
+򈪚\u0CE3Ⴡ󠢏．\u061D; 򈪚\u0CE3ⴡ󠢏.\u061D; [B6, V7]; xn--vuc226n8n28lmju7a.xn--cgb; ; ;  # ೣⴡ.؝
+򈪚\u0CE3Ⴡ󠢏.\u061D; 򈪚\u0CE3ⴡ󠢏.\u061D; [B6, V7]; xn--vuc226n8n28lmju7a.xn--cgb; ; ;  # ೣⴡ.؝
+򈪚\u0CE3ⴡ󠢏.\u061D; ; [B6, V7]; xn--vuc226n8n28lmju7a.xn--cgb; ; ;  # ೣⴡ.؝
+xn--vuc226n8n28lmju7a.xn--cgb; 򈪚\u0CE3ⴡ󠢏.\u061D; [B6, V7]; xn--vuc226n8n28lmju7a.xn--cgb; ; ;  # ೣⴡ.؝
+򈪚\u0CE3ⴡ󠢏．\u061D; 򈪚\u0CE3ⴡ󠢏.\u061D; [B6, V7]; xn--vuc226n8n28lmju7a.xn--cgb; ; ;  # ೣⴡ.؝
+xn--vuc49qvu85xmju7a.xn--cgb; 򈪚\u0CE3Ⴡ󠢏.\u061D; [B6, V7]; xn--vuc49qvu85xmju7a.xn--cgb; ; ;  # ೣჁ.؝
+\u1DEB。𐋩\u0638-𐫮; \u1DEB.𐋩\u0638-𐫮; [B1, V6]; xn--gfg.xn----xnc0815qyyg; ; ;  # ᷫ.𐋩ظ-𐫮
+xn--gfg.xn----xnc0815qyyg; \u1DEB.𐋩\u0638-𐫮; [B1, V6]; xn--gfg.xn----xnc0815qyyg; ; ;  # ᷫ.𐋩ظ-𐫮
+싇。⾇𐳋Ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。⾇𐳋Ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。舛𐳋Ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。舛𐳋Ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。舛𐳋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。舛𐳋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。舛𐲋Ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。舛𐲋Ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。舛𐲋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。舛𐲋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+xn--9u4b.xn--llj123yh74e; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。⾇𐳋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。⾇𐳋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。⾇𐲋Ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。⾇𐲋Ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。⾇𐲋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+싇。⾇𐲋ⴝ; 싇.舛𐳋ⴝ; [B5]; xn--9u4b.xn--llj123yh74e; ; ;  # 싇.舛𐳋ⴝ
+xn--9u4b.xn--1nd7519ch79d; 싇.舛𐳋Ⴝ; [B5, V7]; xn--9u4b.xn--1nd7519ch79d; ; ;  # 싇.舛𐳋Ⴝ
+𐹠ς。\u200C\u06BFჀ; 𐹠ς.\u200C\u06BFⴠ; [B1, C1]; xn--3xa1267k.xn--ykb760k9hj; ; xn--4xa9167k.xn--ykb467q; [B1, B2, B3] # 𐹠ς.ڿⴠ
+𐹠ς。\u200C\u06BFⴠ; 𐹠ς.\u200C\u06BFⴠ; [B1, C1]; xn--3xa1267k.xn--ykb760k9hj; ; xn--4xa9167k.xn--ykb467q; [B1, B2, B3] # 𐹠ς.ڿⴠ
+𐹠Σ。\u200C\u06BFჀ; 𐹠σ.\u200C\u06BFⴠ; [B1, C1]; xn--4xa9167k.xn--ykb760k9hj; ; xn--4xa9167k.xn--ykb467q; [B1, B2, B3] # 𐹠σ.ڿⴠ
+𐹠σ。\u200C\u06BFⴠ; 𐹠σ.\u200C\u06BFⴠ; [B1, C1]; xn--4xa9167k.xn--ykb760k9hj; ; xn--4xa9167k.xn--ykb467q; [B1, B2, B3] # 𐹠σ.ڿⴠ
+𐹠Σ。\u200C\u06BFⴠ; 𐹠σ.\u200C\u06BFⴠ; [B1, C1]; xn--4xa9167k.xn--ykb760k9hj; ; xn--4xa9167k.xn--ykb467q; [B1, B2, B3] # 𐹠σ.ڿⴠ
+xn--4xa9167k.xn--ykb467q; 𐹠σ.\u06BFⴠ; [B1, B2, B3]; xn--4xa9167k.xn--ykb467q; ; ;  # 𐹠σ.ڿⴠ
+xn--4xa9167k.xn--ykb760k9hj; 𐹠σ.\u200C\u06BFⴠ; [B1, C1]; xn--4xa9167k.xn--ykb760k9hj; ; ;  # 𐹠σ.ڿⴠ
+xn--3xa1267k.xn--ykb760k9hj; 𐹠ς.\u200C\u06BFⴠ; [B1, C1]; xn--3xa1267k.xn--ykb760k9hj; ; ;  # 𐹠ς.ڿⴠ
+xn--4xa9167k.xn--ykb632c; 𐹠σ.\u06BFჀ; [B1, B2, B3, V7]; xn--4xa9167k.xn--ykb632c; ; ;  # 𐹠σ.ڿჀ
+xn--4xa9167k.xn--ykb632cvxm; 𐹠σ.\u200C\u06BFჀ; [B1, C1, V7]; xn--4xa9167k.xn--ykb632cvxm; ; ;  # 𐹠σ.ڿჀ
+xn--3xa1267k.xn--ykb632cvxm; 𐹠ς.\u200C\u06BFჀ; [B1, C1, V7]; xn--3xa1267k.xn--ykb632cvxm; ; ;  # 𐹠ς.ڿჀ
+򇒐\u200C\u0604.\u069A-ß; ; [B2, B3, B5, B6, C1, V7]; xn--mfb144kqo32m.xn----qfa315b; ; xn--mfb98261i.xn---ss-sdf; [B2, B3, B5, B6, V7] # .ښ-ß
+򇒐\u200C\u0604.\u069A-SS; 򇒐\u200C\u0604.\u069A-ss; [B2, B3, B5, B6, C1, V7]; xn--mfb144kqo32m.xn---ss-sdf; ; xn--mfb98261i.xn---ss-sdf; [B2, B3, B5, B6, V7] # .ښ-ss
+򇒐\u200C\u0604.\u069A-ss; ; [B2, B3, B5, B6, C1, V7]; xn--mfb144kqo32m.xn---ss-sdf; ; xn--mfb98261i.xn---ss-sdf; [B2, B3, B5, B6, V7] # .ښ-ss
+򇒐\u200C\u0604.\u069A-Ss; 򇒐\u200C\u0604.\u069A-ss; [B2, B3, B5, B6, C1, V7]; xn--mfb144kqo32m.xn---ss-sdf; ; xn--mfb98261i.xn---ss-sdf; [B2, B3, B5, B6, V7] # .ښ-ss
+xn--mfb98261i.xn---ss-sdf; 򇒐\u0604.\u069A-ss; [B2, B3, B5, B6, V7]; xn--mfb98261i.xn---ss-sdf; ; ;  # .ښ-ss
+xn--mfb144kqo32m.xn---ss-sdf; 򇒐\u200C\u0604.\u069A-ss; [B2, B3, B5, B6, C1, V7]; xn--mfb144kqo32m.xn---ss-sdf; ; ;  # .ښ-ss
+xn--mfb144kqo32m.xn----qfa315b; 򇒐\u200C\u0604.\u069A-ß; [B2, B3, B5, B6, C1, V7]; xn--mfb144kqo32m.xn----qfa315b; ; ;  # .ښ-ß
+\u200C\u200D\u17B5\u067A.-\uFBB0󅄞𐸚; \u200C\u200D\u067A.-\u06D3󅄞𐸚; [B1, C1, C2, V3, V7]; xn--zib502kda.xn----twc1133r17r6g; ; xn--zib.xn----twc1133r17r6g; [B1, V3, V7] # ٺ.-ۓ
+\u200C\u200D\u17B5\u067A.-\u06D3󅄞𐸚; \u200C\u200D\u067A.-\u06D3󅄞𐸚; [B1, C1, C2, V3, V7]; xn--zib502kda.xn----twc1133r17r6g; ; xn--zib.xn----twc1133r17r6g; [B1, V3, V7] # ٺ.-ۓ
+\u200C\u200D\u17B5\u067A.-\u06D2\u0654󅄞𐸚; \u200C\u200D\u067A.-\u06D3󅄞𐸚; [B1, C1, C2, V3, V7]; xn--zib502kda.xn----twc1133r17r6g; ; xn--zib.xn----twc1133r17r6g; [B1, V3, V7] # ٺ.-ۓ
+xn--zib.xn----twc1133r17r6g; \u067A.-\u06D3󅄞𐸚; [B1, V3, V7]; xn--zib.xn----twc1133r17r6g; ; ;  # ٺ.-ۓ
+xn--zib502kda.xn----twc1133r17r6g; \u200C\u200D\u067A.-\u06D3󅄞𐸚; [B1, C1, C2, V3, V7]; xn--zib502kda.xn----twc1133r17r6g; ; ;  # ٺ.-ۓ
+xn--zib539f.xn----twc1133r17r6g; \u17B5\u067A.-\u06D3󅄞𐸚; [B1, V3, V6, V7]; xn--zib539f.xn----twc1133r17r6g; ; ;  # ٺ.-ۓ
+xn--zib539f8igea.xn----twc1133r17r6g; \u200C\u200D\u17B5\u067A.-\u06D3󅄞𐸚; [B1, C1, C2, V3, V7]; xn--zib539f8igea.xn----twc1133r17r6g; ; ;  # ٺ.-ۓ
+򡶱｡𐮬≠; 򡶱.𐮬≠; [B3, V7]; xn--dd55c.xn--1ch3003g; ; ;  # .𐮬≠
+򡶱｡𐮬=\u0338; 򡶱.𐮬≠; [B3, V7]; xn--dd55c.xn--1ch3003g; ; ;  # .𐮬≠
+򡶱。𐮬≠; 򡶱.𐮬≠; [B3, V7]; xn--dd55c.xn--1ch3003g; ; ;  # .𐮬≠
+򡶱。𐮬=\u0338; 򡶱.𐮬≠; [B3, V7]; xn--dd55c.xn--1ch3003g; ; ;  # .𐮬≠
+xn--dd55c.xn--1ch3003g; 򡶱.𐮬≠; [B3, V7]; xn--dd55c.xn--1ch3003g; ; ;  # .𐮬≠
+\u0FB2𞶅｡𐹮𐹷덝۵; \u0FB2𞶅.𐹮𐹷덝۵; [B1, V6, V7]; xn--fgd0675v.xn--imb5839fidpcbba; ; ;  # ྲ.𐹮𐹷덝۵
+\u0FB2𞶅｡𐹮𐹷덝۵; \u0FB2𞶅.𐹮𐹷덝۵; [B1, V6, V7]; xn--fgd0675v.xn--imb5839fidpcbba; ; ;  # ྲ.𐹮𐹷덝۵
+\u0FB2𞶅。𐹮𐹷덝۵; \u0FB2𞶅.𐹮𐹷덝۵; [B1, V6, V7]; xn--fgd0675v.xn--imb5839fidpcbba; ; ;  # ྲ.𐹮𐹷덝۵
+\u0FB2𞶅。𐹮𐹷덝۵; \u0FB2𞶅.𐹮𐹷덝۵; [B1, V6, V7]; xn--fgd0675v.xn--imb5839fidpcbba; ; ;  # ྲ.𐹮𐹷덝۵
+xn--fgd0675v.xn--imb5839fidpcbba; \u0FB2𞶅.𐹮𐹷덝۵; [B1, V6, V7]; xn--fgd0675v.xn--imb5839fidpcbba; ; ;  # ྲ.𐹮𐹷덝۵
+Ⴏ󠅋-．\u200DႩ; ⴏ-.\u200Dⴉ; [C2, V3]; xn----3vs.xn--1ug532c; ; xn----3vs.xn--0kj; [V3] # ⴏ-.ⴉ
+Ⴏ󠅋-.\u200DႩ; ⴏ-.\u200Dⴉ; [C2, V3]; xn----3vs.xn--1ug532c; ; xn----3vs.xn--0kj; [V3] # ⴏ-.ⴉ
+ⴏ󠅋-.\u200Dⴉ; ⴏ-.\u200Dⴉ; [C2, V3]; xn----3vs.xn--1ug532c; ; xn----3vs.xn--0kj; [V3] # ⴏ-.ⴉ
+xn----3vs.xn--0kj; ⴏ-.ⴉ; [V3]; xn----3vs.xn--0kj; ; ;  # ⴏ-.ⴉ
+xn----3vs.xn--1ug532c; ⴏ-.\u200Dⴉ; [C2, V3]; xn----3vs.xn--1ug532c; ; ;  # ⴏ-.ⴉ
+ⴏ󠅋-．\u200Dⴉ; ⴏ-.\u200Dⴉ; [C2, V3]; xn----3vs.xn--1ug532c; ; xn----3vs.xn--0kj; [V3] # ⴏ-.ⴉ
+xn----00g.xn--hnd; Ⴏ-.Ⴉ; [V3, V7]; xn----00g.xn--hnd; ; ;  # Ⴏ-.Ⴉ
+xn----00g.xn--hnd399e; Ⴏ-.\u200DႩ; [C2, V3, V7]; xn----00g.xn--hnd399e; ; ;  # Ⴏ-.Ⴉ
+⇧𐨏󠾈󯶅。\u0600󠈵󠆉; ⇧𐨏󠾈󯶅.\u0600󠈵; [B1, V7]; xn--l8g5552g64t4g46xf.xn--ifb08144p; ; ;  # ⇧𐨏.
+xn--l8g5552g64t4g46xf.xn--ifb08144p; ⇧𐨏󠾈󯶅.\u0600󠈵; [B1, V7]; xn--l8g5552g64t4g46xf.xn--ifb08144p; ; ;  # ⇧𐨏.
+≠𐮂.↑🄇⒈; ≠𐮂.↑6,⒈; [B1, V7, U1]; xn--1chy492g.xn--6,-uzus5m; ; ;  # ≠𐮂.↑6,⒈
+=\u0338𐮂.↑🄇⒈; ≠𐮂.↑6,⒈; [B1, V7, U1]; xn--1chy492g.xn--6,-uzus5m; ; ;  # ≠𐮂.↑6,⒈
+≠𐮂.↑6,1.; ; [B1, U1]; xn--1chy492g.xn--6,1-pw1a.; [B1, U1, A4_2]; ;  # ≠𐮂.↑6,1.
+=\u0338𐮂.↑6,1.; ≠𐮂.↑6,1.; [B1, U1]; xn--1chy492g.xn--6,1-pw1a.; [B1, U1, A4_2]; ;  # ≠𐮂.↑6,1.
+xn--1chy492g.xn--6,1-pw1a.; ≠𐮂.↑6,1.; [B1, U1]; xn--1chy492g.xn--6,1-pw1a.; [B1, U1, A4_2]; ;  # ≠𐮂.↑6,1.
+xn--1chy492g.xn--6,-uzus5m; ≠𐮂.↑6,⒈; [B1, V7, U1]; xn--1chy492g.xn--6,-uzus5m; ; ;  # ≠𐮂.↑6,⒈
+xn--1chy492g.xn--45gx9iuy44d; ≠𐮂.↑🄇⒈; [B1, V7]; xn--1chy492g.xn--45gx9iuy44d; ; ;  # ≠𐮂.↑🄇⒈
+𝩏󠲉ß.ᢤ򄦌\u200C𐹫; ; [B1, B5, B6, C1, V6, V7]; xn--zca3153vupz3e.xn--ubf609atw1tynn3d; ; xn--ss-zb11ap1427e.xn--ubf2596jbt61c; [B1, B5, B6, V6, V7] # 𝩏ß.ᢤ𐹫
+𝩏󠲉SS.ᢤ򄦌\u200C𐹫; 𝩏󠲉ss.ᢤ򄦌\u200C𐹫; [B1, B5, B6, C1, V6, V7]; xn--ss-zb11ap1427e.xn--ubf609atw1tynn3d; ; xn--ss-zb11ap1427e.xn--ubf2596jbt61c; [B1, B5, B6, V6, V7] # 𝩏ss.ᢤ𐹫
+𝩏󠲉ss.ᢤ򄦌\u200C𐹫; ; [B1, B5, B6, C1, V6, V7]; xn--ss-zb11ap1427e.xn--ubf609atw1tynn3d; ; xn--ss-zb11ap1427e.xn--ubf2596jbt61c; [B1, B5, B6, V6, V7] # 𝩏ss.ᢤ𐹫
+𝩏󠲉Ss.ᢤ򄦌\u200C𐹫; 𝩏󠲉ss.ᢤ򄦌\u200C𐹫; [B1, B5, B6, C1, V6, V7]; xn--ss-zb11ap1427e.xn--ubf609atw1tynn3d; ; xn--ss-zb11ap1427e.xn--ubf2596jbt61c; [B1, B5, B6, V6, V7] # 𝩏ss.ᢤ𐹫
+xn--ss-zb11ap1427e.xn--ubf2596jbt61c; 𝩏󠲉ss.ᢤ򄦌𐹫; [B1, B5, B6, V6, V7]; xn--ss-zb11ap1427e.xn--ubf2596jbt61c; ; ;  # 𝩏ss.ᢤ𐹫
+xn--ss-zb11ap1427e.xn--ubf609atw1tynn3d; 𝩏󠲉ss.ᢤ򄦌\u200C𐹫; [B1, B5, B6, C1, V6, V7]; xn--ss-zb11ap1427e.xn--ubf609atw1tynn3d; ; ;  # 𝩏ss.ᢤ𐹫
+xn--zca3153vupz3e.xn--ubf609atw1tynn3d; 𝩏󠲉ß.ᢤ򄦌\u200C𐹫; [B1, B5, B6, C1, V6, V7]; xn--zca3153vupz3e.xn--ubf609atw1tynn3d; ; ;  # 𝩏ß.ᢤ𐹫
+ß𐵳񗘁Ⴇ｡\uA67A; ß𐵳񗘁ⴇ.\uA67A; [B1, B5, V6, V7]; xn--zca227tpy4lkns1b.xn--9x8a; ; xn--ss-e61ar955h4hs7b.xn--9x8a;  # ß𐵳ⴇ.ꙺ
+ß𐵳񗘁Ⴇ。\uA67A; ß𐵳񗘁ⴇ.\uA67A; [B1, B5, V6, V7]; xn--zca227tpy4lkns1b.xn--9x8a; ; xn--ss-e61ar955h4hs7b.xn--9x8a;  # ß𐵳ⴇ.ꙺ
+ß𐵳񗘁ⴇ。\uA67A; ß𐵳񗘁ⴇ.\uA67A; [B1, B5, V6, V7]; xn--zca227tpy4lkns1b.xn--9x8a; ; xn--ss-e61ar955h4hs7b.xn--9x8a;  # ß𐵳ⴇ.ꙺ
+SS𐵓񗘁Ⴇ。\uA67A; ss𐵳񗘁ⴇ.\uA67A; [B1, B5, V6, V7]; xn--ss-e61ar955h4hs7b.xn--9x8a; ; ;  # ss𐵳ⴇ.ꙺ
+ss𐵳񗘁ⴇ。\uA67A; ss𐵳񗘁ⴇ.\uA67A; [B1, B5, V6, V7]; xn--ss-e61ar955h4hs7b.xn--9x8a; ; ;  # ss𐵳ⴇ.ꙺ
+Ss𐵳񗘁Ⴇ。\uA67A; ss𐵳񗘁ⴇ.\uA67A; [B1, B5, V6, V7]; xn--ss-e61ar955h4hs7b.xn--9x8a; ; ;  # ss𐵳ⴇ.ꙺ
+xn--ss-e61ar955h4hs7b.xn--9x8a; ss𐵳񗘁ⴇ.\uA67A; [B1, B5, V6, V7]; xn--ss-e61ar955h4hs7b.xn--9x8a; ; ;  # ss𐵳ⴇ.ꙺ
+xn--zca227tpy4lkns1b.xn--9x8a; ß𐵳񗘁ⴇ.\uA67A; [B1, B5, V6, V7]; xn--zca227tpy4lkns1b.xn--9x8a; ; ;  # ß𐵳ⴇ.ꙺ
+ß𐵳񗘁ⴇ｡\uA67A; ß𐵳񗘁ⴇ.\uA67A; [B1, B5, V6, V7]; xn--zca227tpy4lkns1b.xn--9x8a; ; xn--ss-e61ar955h4hs7b.xn--9x8a;  # ß𐵳ⴇ.ꙺ
+SS𐵓񗘁Ⴇ｡\uA67A; ss𐵳񗘁ⴇ.\uA67A; [B1, B5, V6, V7]; xn--ss-e61ar955h4hs7b.xn--9x8a; ; ;  # ss𐵳ⴇ.ꙺ
+ss𐵳񗘁ⴇ｡\uA67A; ss𐵳񗘁ⴇ.\uA67A; [B1, B5, V6, V7]; xn--ss-e61ar955h4hs7b.xn--9x8a; ; ;  # ss𐵳ⴇ.ꙺ
+Ss𐵳񗘁Ⴇ｡\uA67A; ss𐵳񗘁ⴇ.\uA67A; [B1, B5, V6, V7]; xn--ss-e61ar955h4hs7b.xn--9x8a; ; ;  # ss𐵳ⴇ.ꙺ
+SS𐵳񗘁Ⴇ。\uA67A; ss𐵳񗘁ⴇ.\uA67A; [B1, B5, V6, V7]; xn--ss-e61ar955h4hs7b.xn--9x8a; ; ;  # ss𐵳ⴇ.ꙺ
+xn--ss-rek7420r4hs7b.xn--9x8a; ss𐵳񗘁Ⴇ.\uA67A; [B1, B5, V6, V7]; xn--ss-rek7420r4hs7b.xn--9x8a; ; ;  # ss𐵳Ⴇ.ꙺ
+xn--zca491fci5qkn79a.xn--9x8a; ß𐵳񗘁Ⴇ.\uA67A; [B1, B5, V6, V7]; xn--zca491fci5qkn79a.xn--9x8a; ; ;  # ß𐵳Ⴇ.ꙺ
+SS𐵳񗘁Ⴇ｡\uA67A; ss𐵳񗘁ⴇ.\uA67A; [B1, B5, V6, V7]; xn--ss-e61ar955h4hs7b.xn--9x8a; ; ;  # ss𐵳ⴇ.ꙺ
+\u1714。󠆣-𑋪; \u1714.-𑋪; [V3, V6]; xn--fze.xn----ly8i; ; ;  # ᜔.-𑋪
+xn--fze.xn----ly8i; \u1714.-𑋪; [V3, V6]; xn--fze.xn----ly8i; ; ;  # ᜔.-𑋪
+\uABE8-．򨏜\u05BDß; \uABE8-.򨏜\u05BDß; [V3, V6, V7]; xn----pw5e.xn--zca50wfv060a; ; xn----pw5e.xn--ss-7jd10716y;  # ꯨ-.ֽß
+\uABE8-.򨏜\u05BDß; ; [V3, V6, V7]; xn----pw5e.xn--zca50wfv060a; ; xn----pw5e.xn--ss-7jd10716y;  # ꯨ-.ֽß
+\uABE8-.򨏜\u05BDSS; \uABE8-.򨏜\u05BDss; [V3, V6, V7]; xn----pw5e.xn--ss-7jd10716y; ; ;  # ꯨ-.ֽss
+\uABE8-.򨏜\u05BDss; ; [V3, V6, V7]; xn----pw5e.xn--ss-7jd10716y; ; ;  # ꯨ-.ֽss
+\uABE8-.򨏜\u05BDSs; \uABE8-.򨏜\u05BDss; [V3, V6, V7]; xn----pw5e.xn--ss-7jd10716y; ; ;  # ꯨ-.ֽss
+xn----pw5e.xn--ss-7jd10716y; \uABE8-.򨏜\u05BDss; [V3, V6, V7]; xn----pw5e.xn--ss-7jd10716y; ; ;  # ꯨ-.ֽss
+xn----pw5e.xn--zca50wfv060a; \uABE8-.򨏜\u05BDß; [V3, V6, V7]; xn----pw5e.xn--zca50wfv060a; ; ;  # ꯨ-.ֽß
+\uABE8-．򨏜\u05BDSS; \uABE8-.򨏜\u05BDss; [V3, V6, V7]; xn----pw5e.xn--ss-7jd10716y; ; ;  # ꯨ-.ֽss
+\uABE8-．򨏜\u05BDss; \uABE8-.򨏜\u05BDss; [V3, V6, V7]; xn----pw5e.xn--ss-7jd10716y; ; ;  # ꯨ-.ֽss
+\uABE8-．򨏜\u05BDSs; \uABE8-.򨏜\u05BDss; [V3, V6, V7]; xn----pw5e.xn--ss-7jd10716y; ; ;  # ꯨ-.ֽss
+ᡓ-≮。\u066B󠅱ᡄ; ᡓ-≮.\u066Bᡄ; [B1, B6]; xn----s7j866c.xn--kib252g; ; ;  # ᡓ-≮.٫ᡄ
+ᡓ-<\u0338。\u066B󠅱ᡄ; ᡓ-≮.\u066Bᡄ; [B1, B6]; xn----s7j866c.xn--kib252g; ; ;  # ᡓ-≮.٫ᡄ
+xn----s7j866c.xn--kib252g; ᡓ-≮.\u066Bᡄ; [B1, B6]; xn----s7j866c.xn--kib252g; ; ;  # ᡓ-≮.٫ᡄ
+𝟥♮𑜫\u08ED．\u17D2𑜫8󠆏; 3♮𑜫\u08ED.\u17D2𑜫8; [V6]; xn--3-ksd277tlo7s.xn--8-f0jx021l; ; ;  # 3♮𑜫࣭.្𑜫8
+3♮𑜫\u08ED.\u17D2𑜫8󠆏; 3♮𑜫\u08ED.\u17D2𑜫8; [V6]; xn--3-ksd277tlo7s.xn--8-f0jx021l; ; ;  # 3♮𑜫࣭.្𑜫8
+xn--3-ksd277tlo7s.xn--8-f0jx021l; 3♮𑜫\u08ED.\u17D2𑜫8; [V6]; xn--3-ksd277tlo7s.xn--8-f0jx021l; ; ;  # 3♮𑜫࣭.្𑜫8
+-｡򕌀\u200D❡; -.򕌀\u200D❡; [C2, V3, V7]; -.xn--1ug800aq795s; ; -.xn--nei54421f; [V3, V7] # -.❡
+-。򕌀\u200D❡; -.򕌀\u200D❡; [C2, V3, V7]; -.xn--1ug800aq795s; ; -.xn--nei54421f; [V3, V7] # -.❡
+-.xn--nei54421f; -.򕌀❡; [V3, V7]; -.xn--nei54421f; ; ;  # -.❡
+-.xn--1ug800aq795s; -.򕌀\u200D❡; [C2, V3, V7]; -.xn--1ug800aq795s; ; ;  # -.❡
+𝟓☱𝟐򥰵｡𝪮񐡳; 5☱2򥰵.𝪮񐡳; [V6, V7]; xn--52-dwx47758j.xn--kd3hk431k; ; ;  # 5☱2.𝪮
+5☱2򥰵。𝪮񐡳; 5☱2򥰵.𝪮񐡳; [V6, V7]; xn--52-dwx47758j.xn--kd3hk431k; ; ;  # 5☱2.𝪮
+xn--52-dwx47758j.xn--kd3hk431k; 5☱2򥰵.𝪮񐡳; [V6, V7]; xn--52-dwx47758j.xn--kd3hk431k; ; ;  # 5☱2.𝪮
+-.-├򖦣; ; [V3, V7]; -.xn----ukp70432h; ; ;  # -.-├
+-.xn----ukp70432h; -.-├򖦣; [V3, V7]; -.xn----ukp70432h; ; ;  # -.-├
+\u05A5\u076D｡\u200D󠀘; \u05A5\u076D.\u200D󠀘; [B1, C2, V6, V7]; xn--wcb62g.xn--1ugy8001l; ; xn--wcb62g.xn--p526e; [B1, V6, V7] # ֥ݭ.
+\u05A5\u076D。\u200D󠀘; \u05A5\u076D.\u200D󠀘; [B1, C2, V6, V7]; xn--wcb62g.xn--1ugy8001l; ; xn--wcb62g.xn--p526e; [B1, V6, V7] # ֥ݭ.
+xn--wcb62g.xn--p526e; \u05A5\u076D.󠀘; [B1, V6, V7]; xn--wcb62g.xn--p526e; ; ;  # ֥ݭ.
+xn--wcb62g.xn--1ugy8001l; \u05A5\u076D.\u200D󠀘; [B1, C2, V6, V7]; xn--wcb62g.xn--1ugy8001l; ; ;  # ֥ݭ.
+쥥󔏉Ⴎ．\u200C⒈⒈𐫒; 쥥󔏉ⴎ.\u200C⒈⒈𐫒; [B1, C1, V7]; xn--5kj3511ccyw3h.xn--0ug88oa0396u; ; xn--5kj3511ccyw3h.xn--tsha6797o; [B1, V7] # 쥥ⴎ.⒈⒈𐫒
+쥥󔏉Ⴎ．\u200C⒈⒈𐫒; 쥥󔏉ⴎ.\u200C⒈⒈𐫒; [B1, C1, V7]; xn--5kj3511ccyw3h.xn--0ug88oa0396u; ; xn--5kj3511ccyw3h.xn--tsha6797o; [B1, V7] # 쥥ⴎ.⒈⒈𐫒
+쥥󔏉Ⴎ.\u200C1.1.𐫒; 쥥󔏉ⴎ.\u200C1.1.𐫒; [B1, C1, V7]; xn--5kj3511ccyw3h.xn--1-rgn.1.xn--7w9c; ; xn--5kj3511ccyw3h.1.1.xn--7w9c; [B1, V7] # 쥥ⴎ.1.1.𐫒
+쥥󔏉Ⴎ.\u200C1.1.𐫒; 쥥󔏉ⴎ.\u200C1.1.𐫒; [B1, C1, V7]; xn--5kj3511ccyw3h.xn--1-rgn.1.xn--7w9c; ; xn--5kj3511ccyw3h.1.1.xn--7w9c; [B1, V7] # 쥥ⴎ.1.1.𐫒
+쥥󔏉ⴎ.\u200C1.1.𐫒; 쥥󔏉ⴎ.\u200C1.1.𐫒; [B1, C1, V7]; xn--5kj3511ccyw3h.xn--1-rgn.1.xn--7w9c; ; xn--5kj3511ccyw3h.1.1.xn--7w9c; [B1, V7] # 쥥ⴎ.1.1.𐫒
+쥥󔏉ⴎ.\u200C1.1.𐫒; ; [B1, C1, V7]; xn--5kj3511ccyw3h.xn--1-rgn.1.xn--7w9c; ; xn--5kj3511ccyw3h.1.1.xn--7w9c; [B1, V7] # 쥥ⴎ.1.1.𐫒
+xn--5kj3511ccyw3h.1.1.xn--7w9c; 쥥󔏉ⴎ.1.1.𐫒; [B1, V7]; xn--5kj3511ccyw3h.1.1.xn--7w9c; ; ;  # 쥥ⴎ.1.1.𐫒
+xn--5kj3511ccyw3h.xn--1-rgn.1.xn--7w9c; 쥥󔏉ⴎ.\u200C1.1.𐫒; [B1, C1, V7]; xn--5kj3511ccyw3h.xn--1-rgn.1.xn--7w9c; ; ;  # 쥥ⴎ.1.1.𐫒
+쥥󔏉ⴎ．\u200C⒈⒈𐫒; 쥥󔏉ⴎ.\u200C⒈⒈𐫒; [B1, C1, V7]; xn--5kj3511ccyw3h.xn--0ug88oa0396u; ; xn--5kj3511ccyw3h.xn--tsha6797o; [B1, V7] # 쥥ⴎ.⒈⒈𐫒
+쥥󔏉ⴎ．\u200C⒈⒈𐫒; 쥥󔏉ⴎ.\u200C⒈⒈𐫒; [B1, C1, V7]; xn--5kj3511ccyw3h.xn--0ug88oa0396u; ; xn--5kj3511ccyw3h.xn--tsha6797o; [B1, V7] # 쥥ⴎ.⒈⒈𐫒
+xn--5kj3511ccyw3h.xn--tsha6797o; 쥥󔏉ⴎ.⒈⒈𐫒; [B1, V7]; xn--5kj3511ccyw3h.xn--tsha6797o; ; ;  # 쥥ⴎ.⒈⒈𐫒
+xn--5kj3511ccyw3h.xn--0ug88oa0396u; 쥥󔏉ⴎ.\u200C⒈⒈𐫒; [B1, C1, V7]; xn--5kj3511ccyw3h.xn--0ug88oa0396u; ; ;  # 쥥ⴎ.⒈⒈𐫒
+xn--mnd7865gcy28g.1.1.xn--7w9c; 쥥󔏉Ⴎ.1.1.𐫒; [B1, V7]; xn--mnd7865gcy28g.1.1.xn--7w9c; ; ;  # 쥥Ⴎ.1.1.𐫒
+xn--mnd7865gcy28g.xn--1-rgn.1.xn--7w9c; 쥥󔏉Ⴎ.\u200C1.1.𐫒; [B1, C1, V7]; xn--mnd7865gcy28g.xn--1-rgn.1.xn--7w9c; ; ;  # 쥥Ⴎ.1.1.𐫒
+xn--mnd7865gcy28g.xn--tsha6797o; 쥥󔏉Ⴎ.⒈⒈𐫒; [B1, V7]; xn--mnd7865gcy28g.xn--tsha6797o; ; ;  # 쥥Ⴎ.⒈⒈𐫒
+xn--mnd7865gcy28g.xn--0ug88oa0396u; 쥥󔏉Ⴎ.\u200C⒈⒈𐫒; [B1, C1, V7]; xn--mnd7865gcy28g.xn--0ug88oa0396u; ; ;  # 쥥Ⴎ.⒈⒈𐫒
+\u0827𝟶\u06A0-。𑄳; \u08270\u06A0-.𑄳; [B1, V3, V6]; xn--0--p3d67m.xn--v80d; ; ;  # ࠧ0ڠ-.𑄳
+\u08270\u06A0-。𑄳; \u08270\u06A0-.𑄳; [B1, V3, V6]; xn--0--p3d67m.xn--v80d; ; ;  # ࠧ0ڠ-.𑄳
+xn--0--p3d67m.xn--v80d; \u08270\u06A0-.𑄳; [B1, V3, V6]; xn--0--p3d67m.xn--v80d; ; ;  # ࠧ0ڠ-.𑄳
+ς．\uFDC1🞛⒈; ς.\u0641\u0645\u064A🞛⒈; [V7]; xn--3xa.xn--dhbip2802atb20c; ; xn--4xa.xn--dhbip2802atb20c;  # ς.فمي🞛⒈
+ς.\u0641\u0645\u064A🞛1.; ; ; xn--3xa.xn--1-gocmu97674d.; [A4_2]; xn--4xa.xn--1-gocmu97674d.;  # ς.فمي🞛1.
+Σ.\u0641\u0645\u064A🞛1.; σ.\u0641\u0645\u064A🞛1.; ; xn--4xa.xn--1-gocmu97674d.; [A4_2]; ;  # σ.فمي🞛1.
+σ.\u0641\u0645\u064A🞛1.; ; ; xn--4xa.xn--1-gocmu97674d.; [A4_2]; ;  # σ.فمي🞛1.
+xn--4xa.xn--1-gocmu97674d.; σ.\u0641\u0645\u064A🞛1.; ; xn--4xa.xn--1-gocmu97674d.; [A4_2]; ;  # σ.فمي🞛1.
+xn--3xa.xn--1-gocmu97674d.; ς.\u0641\u0645\u064A🞛1.; ; xn--3xa.xn--1-gocmu97674d.; [A4_2]; ;  # ς.فمي🞛1.
+Σ．\uFDC1🞛⒈; σ.\u0641\u0645\u064A🞛⒈; [V7]; xn--4xa.xn--dhbip2802atb20c; ; ;  # σ.فمي🞛⒈
+σ．\uFDC1🞛⒈; σ.\u0641\u0645\u064A🞛⒈; [V7]; xn--4xa.xn--dhbip2802atb20c; ; ;  # σ.فمي🞛⒈
+xn--4xa.xn--dhbip2802atb20c; σ.\u0641\u0645\u064A🞛⒈; [V7]; xn--4xa.xn--dhbip2802atb20c; ; ;  # σ.فمي🞛⒈
+xn--3xa.xn--dhbip2802atb20c; ς.\u0641\u0645\u064A🞛⒈; [V7]; xn--3xa.xn--dhbip2802atb20c; ; ;  # ς.فمي🞛⒈
+🗩-｡𐹻󐞆񥉮; 🗩-.𐹻󐞆񥉮; [B1, V3, V7]; xn----6t3s.xn--zo0d4811u6ru6a; ; ;  # 🗩-.𐹻
+🗩-。𐹻󐞆񥉮; 🗩-.𐹻󐞆񥉮; [B1, V3, V7]; xn----6t3s.xn--zo0d4811u6ru6a; ; ;  # 🗩-.𐹻
+xn----6t3s.xn--zo0d4811u6ru6a; 🗩-.𐹻󐞆񥉮; [B1, V3, V7]; xn----6t3s.xn--zo0d4811u6ru6a; ; ;  # 🗩-.𐹻
+𐡜-🔪｡𝟻\u200C𐿀; 𐡜-🔪.5\u200C𐿀; [B1, B3, C1]; xn----5j4iv089c.xn--5-sgn7149h; ; xn----5j4iv089c.xn--5-bn7i; [B1, B3] # 𐡜-🔪.5𐿀
+𐡜-🔪。5\u200C𐿀; 𐡜-🔪.5\u200C𐿀; [B1, B3, C1]; xn----5j4iv089c.xn--5-sgn7149h; ; xn----5j4iv089c.xn--5-bn7i; [B1, B3] # 𐡜-🔪.5𐿀
+xn----5j4iv089c.xn--5-bn7i; 𐡜-🔪.5𐿀; [B1, B3]; xn----5j4iv089c.xn--5-bn7i; ; ;  # 𐡜-🔪.5𐿀
+xn----5j4iv089c.xn--5-sgn7149h; 𐡜-🔪.5\u200C𐿀; [B1, B3, C1]; xn----5j4iv089c.xn--5-sgn7149h; ; ;  # 𐡜-🔪.5𐿀
+𐹣늿\u200Dß．\u07CF0\u05BC; 𐹣늿\u200Dß.\u07CF0\u05BC; [B1, C2]; xn--zca770n5s4hev6c.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ß.ߏ0ּ
+𐹣늿\u200Dß．\u07CF0\u05BC; 𐹣늿\u200Dß.\u07CF0\u05BC; [B1, C2]; xn--zca770n5s4hev6c.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ß.ߏ0ּ
+𐹣늿\u200Dß.\u07CF0\u05BC; ; [B1, C2]; xn--zca770n5s4hev6c.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ß.ߏ0ּ
+𐹣늿\u200Dß.\u07CF0\u05BC; 𐹣늿\u200Dß.\u07CF0\u05BC; [B1, C2]; xn--zca770n5s4hev6c.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ß.ߏ0ּ
+𐹣늿\u200DSS.\u07CF0\u05BC; 𐹣늿\u200Dss.\u07CF0\u05BC; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿\u200DSS.\u07CF0\u05BC; 𐹣늿\u200Dss.\u07CF0\u05BC; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿\u200Dss.\u07CF0\u05BC; ; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿\u200Dss.\u07CF0\u05BC; 𐹣늿\u200Dss.\u07CF0\u05BC; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+xn--ss-i05i7041a.xn--0-vgc50n; 𐹣늿ss.\u07CF0\u05BC; [B1]; xn--ss-i05i7041a.xn--0-vgc50n; ; ;  # 𐹣늿ss.ߏ0ּ
+xn--ss-l1tu910fo0xd.xn--0-vgc50n; 𐹣늿\u200Dss.\u07CF0\u05BC; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; ;  # 𐹣늿ss.ߏ0ּ
+𐹣늿\u200DSs.\u07CF0\u05BC; 𐹣늿\u200Dss.\u07CF0\u05BC; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿\u200DSs.\u07CF0\u05BC; 𐹣늿\u200Dss.\u07CF0\u05BC; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+xn--zca770n5s4hev6c.xn--0-vgc50n; 𐹣늿\u200Dß.\u07CF0\u05BC; [B1, C2]; xn--zca770n5s4hev6c.xn--0-vgc50n; ; ;  # 𐹣늿ß.ߏ0ּ
+𐹣늿\u200DSS．\u07CF0\u05BC; 𐹣늿\u200Dss.\u07CF0\u05BC; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿\u200DSS．\u07CF0\u05BC; 𐹣늿\u200Dss.\u07CF0\u05BC; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿\u200Dss．\u07CF0\u05BC; 𐹣늿\u200Dss.\u07CF0\u05BC; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿\u200Dss．\u07CF0\u05BC; 𐹣늿\u200Dss.\u07CF0\u05BC; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿\u200DSs．\u07CF0\u05BC; 𐹣늿\u200Dss.\u07CF0\u05BC; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+𐹣늿\u200DSs．\u07CF0\u05BC; 𐹣늿\u200Dss.\u07CF0\u05BC; [B1, C2]; xn--ss-l1tu910fo0xd.xn--0-vgc50n; ; xn--ss-i05i7041a.xn--0-vgc50n; [B1] # 𐹣늿ss.ߏ0ּ
+9󠇥．󪴴ᢓ; 9.󪴴ᢓ; [V7]; 9.xn--dbf91222q; ; ;  # 9.ᢓ
+9󠇥.󪴴ᢓ; 9.󪴴ᢓ; [V7]; 9.xn--dbf91222q; ; ;  # 9.ᢓ
+9.xn--dbf91222q; 9.󪴴ᢓ; [V7]; 9.xn--dbf91222q; ; ;  # 9.ᢓ
+\u200C\uFFA0.𐫭🠗ß⽟; \u200C.𐫭🠗ß玉; [B1, B2, B3, C1]; xn--0ug.xn--zca2289c550e0iwi; ; .xn--ss-je6eq954cp25j; [B2, B3, A4_2] # .𐫭🠗ß玉
+\u200C\u1160.𐫭🠗ß玉; \u200C.𐫭🠗ß玉; [B1, B2, B3, C1]; xn--0ug.xn--zca2289c550e0iwi; ; .xn--ss-je6eq954cp25j; [B2, B3, A4_2] # .𐫭🠗ß玉
+\u200C\u1160.𐫭🠗SS玉; \u200C.𐫭🠗ss玉; [B1, B2, B3, C1]; xn--0ug.xn--ss-je6eq954cp25j; ; .xn--ss-je6eq954cp25j; [B2, B3, A4_2] # .𐫭🠗ss玉
+\u200C\u1160.𐫭🠗ss玉; \u200C.𐫭🠗ss玉; [B1, B2, B3, C1]; xn--0ug.xn--ss-je6eq954cp25j; ; .xn--ss-je6eq954cp25j; [B2, B3, A4_2] # .𐫭🠗ss玉
+\u200C\u1160.𐫭🠗Ss玉; \u200C.𐫭🠗ss玉; [B1, B2, B3, C1]; xn--0ug.xn--ss-je6eq954cp25j; ; .xn--ss-je6eq954cp25j; [B2, B3, A4_2] # .𐫭🠗ss玉
+.xn--ss-je6eq954cp25j; .𐫭🠗ss玉; [B2, B3, X4_2]; .xn--ss-je6eq954cp25j; [B2, B3, A4_2]; ;  # .𐫭🠗ss玉
+xn--0ug.xn--ss-je6eq954cp25j; \u200C.𐫭🠗ss玉; [B1, B2, B3, C1]; xn--0ug.xn--ss-je6eq954cp25j; ; ;  # .𐫭🠗ss玉
+xn--0ug.xn--zca2289c550e0iwi; \u200C.𐫭🠗ß玉; [B1, B2, B3, C1]; xn--0ug.xn--zca2289c550e0iwi; ; ;  # .𐫭🠗ß玉
+\u200C\uFFA0.𐫭🠗SS⽟; \u200C.𐫭🠗ss玉; [B1, B2, B3, C1]; xn--0ug.xn--ss-je6eq954cp25j; ; .xn--ss-je6eq954cp25j; [B2, B3, A4_2] # .𐫭🠗ss玉
+\u200C\uFFA0.𐫭🠗ss⽟; \u200C.𐫭🠗ss玉; [B1, B2, B3, C1]; xn--0ug.xn--ss-je6eq954cp25j; ; .xn--ss-je6eq954cp25j; [B2, B3, A4_2] # .𐫭🠗ss玉
+\u200C\uFFA0.𐫭🠗Ss⽟; \u200C.𐫭🠗ss玉; [B1, B2, B3, C1]; xn--0ug.xn--ss-je6eq954cp25j; ; .xn--ss-je6eq954cp25j; [B2, B3, A4_2] # .𐫭🠗ss玉
+xn--psd.xn--ss-je6eq954cp25j; \u1160.𐫭🠗ss玉; [B2, B3, V7]; xn--psd.xn--ss-je6eq954cp25j; ; ;  # .𐫭🠗ss玉
+xn--psd526e.xn--ss-je6eq954cp25j; \u200C\u1160.𐫭🠗ss玉; [B1, B2, B3, C1, V7]; xn--psd526e.xn--ss-je6eq954cp25j; ; ;  # .𐫭🠗ss玉
+xn--psd526e.xn--zca2289c550e0iwi; \u200C\u1160.𐫭🠗ß玉; [B1, B2, B3, C1, V7]; xn--psd526e.xn--zca2289c550e0iwi; ; ;  # .𐫭🠗ß玉
+xn--cl7c.xn--ss-je6eq954cp25j; \uFFA0.𐫭🠗ss玉; [B2, B3, V7]; xn--cl7c.xn--ss-je6eq954cp25j; ; ;  # .𐫭🠗ss玉
+xn--0ug7719f.xn--ss-je6eq954cp25j; \u200C\uFFA0.𐫭🠗ss玉; [B1, B2, B3, C1, V7]; xn--0ug7719f.xn--ss-je6eq954cp25j; ; ;  # .𐫭🠗ss玉
+xn--0ug7719f.xn--zca2289c550e0iwi; \u200C\uFFA0.𐫭🠗ß玉; [B1, B2, B3, C1, V7]; xn--0ug7719f.xn--zca2289c550e0iwi; ; ;  # .𐫭🠗ß玉
+︒Ⴖ\u0366．\u200C; ︒ⴖ\u0366.\u200C; [C1, V7]; xn--hva754sy94k.xn--0ug; ; xn--hva754sy94k.; [V7, A4_2] # ︒ⴖͦ.
+。Ⴖ\u0366.\u200C; .ⴖ\u0366.\u200C; [C1, X4_2]; .xn--hva754s.xn--0ug; [C1, A4_2]; .xn--hva754s.; [A4_2] # .ⴖͦ.
+。ⴖ\u0366.\u200C; .ⴖ\u0366.\u200C; [C1, X4_2]; .xn--hva754s.xn--0ug; [C1, A4_2]; .xn--hva754s.; [A4_2] # .ⴖͦ.
+.xn--hva754s.; .ⴖ\u0366.; [X4_2]; .xn--hva754s.; [A4_2]; ;  # .ⴖͦ.
+.xn--hva754s.xn--0ug; .ⴖ\u0366.\u200C; [C1, X4_2]; .xn--hva754s.xn--0ug; [C1, A4_2]; ;  # .ⴖͦ.
+︒ⴖ\u0366．\u200C; ︒ⴖ\u0366.\u200C; [C1, V7]; xn--hva754sy94k.xn--0ug; ; xn--hva754sy94k.; [V7, A4_2] # ︒ⴖͦ.
+xn--hva754sy94k.; ︒ⴖ\u0366.; [V7]; xn--hva754sy94k.; [V7, A4_2]; ;  # ︒ⴖͦ.
+xn--hva754sy94k.xn--0ug; ︒ⴖ\u0366.\u200C; [C1, V7]; xn--hva754sy94k.xn--0ug; ; ;  # ︒ⴖͦ.
+.xn--hva929d.; .Ⴖ\u0366.; [V7, X4_2]; .xn--hva929d.; [V7, A4_2]; ;  # .Ⴖͦ.
+.xn--hva929d.xn--0ug; .Ⴖ\u0366.\u200C; [C1, V7, X4_2]; .xn--hva929d.xn--0ug; [C1, V7, A4_2]; ;  # .Ⴖͦ.
+xn--hva929dl29p.; ︒Ⴖ\u0366.; [V7]; xn--hva929dl29p.; [V7, A4_2]; ;  # ︒Ⴖͦ.
+xn--hva929dl29p.xn--0ug; ︒Ⴖ\u0366.\u200C; [C1, V7]; xn--hva929dl29p.xn--0ug; ; ;  # ︒Ⴖͦ.
+xn--hva754s.; ⴖ\u0366.; ; xn--hva754s.; [A4_2]; ;  # ⴖͦ.
+ⴖ\u0366.; ; ; xn--hva754s.; [A4_2]; ;  # ⴖͦ.
+Ⴖ\u0366.; ⴖ\u0366.; ; xn--hva754s.; [A4_2]; ;  # ⴖͦ.
+xn--hva929d.; Ⴖ\u0366.; [V7]; xn--hva929d.; [V7, A4_2]; ;  # Ⴖͦ.
+\u08BB．\u200CႣ𞀒; \u08BB.\u200Cⴃ𞀒; [B1, C1]; xn--hzb.xn--0ug822cp045a; ; xn--hzb.xn--ukj4430l; [] # ࢻ.ⴃ𞀒
+\u08BB.\u200CႣ𞀒; \u08BB.\u200Cⴃ𞀒; [B1, C1]; xn--hzb.xn--0ug822cp045a; ; xn--hzb.xn--ukj4430l; [] # ࢻ.ⴃ𞀒
+\u08BB.\u200Cⴃ𞀒; ; [B1, C1]; xn--hzb.xn--0ug822cp045a; ; xn--hzb.xn--ukj4430l; [] # ࢻ.ⴃ𞀒
+xn--hzb.xn--ukj4430l; \u08BB.ⴃ𞀒; ; xn--hzb.xn--ukj4430l; ; ;  # ࢻ.ⴃ𞀒
+\u08BB.ⴃ𞀒; ; ; xn--hzb.xn--ukj4430l; ; ;  # ࢻ.ⴃ𞀒
+\u08BB.Ⴃ𞀒; \u08BB.ⴃ𞀒; ; xn--hzb.xn--ukj4430l; ; ;  # ࢻ.ⴃ𞀒
+xn--hzb.xn--0ug822cp045a; \u08BB.\u200Cⴃ𞀒; [B1, C1]; xn--hzb.xn--0ug822cp045a; ; ;  # ࢻ.ⴃ𞀒
+\u08BB．\u200Cⴃ𞀒; \u08BB.\u200Cⴃ𞀒; [B1, C1]; xn--hzb.xn--0ug822cp045a; ; xn--hzb.xn--ukj4430l; [] # ࢻ.ⴃ𞀒
+xn--hzb.xn--bnd2938u; \u08BB.Ⴃ𞀒; [V7]; xn--hzb.xn--bnd2938u; ; ;  # ࢻ.Ⴃ𞀒
+xn--hzb.xn--bnd300f7225a; \u08BB.\u200CႣ𞀒; [B1, C1, V7]; xn--hzb.xn--bnd300f7225a; ; ;  # ࢻ.Ⴃ𞀒
+\u200D\u200C。２䫷󠧷; \u200D\u200C.2䫷󠧷; [C1, C2, V7]; xn--0ugb.xn--2-me5ay1273i; ; .xn--2-me5ay1273i; [V7, A4_2] # .2䫷
+\u200D\u200C。2䫷󠧷; \u200D\u200C.2䫷󠧷; [C1, C2, V7]; xn--0ugb.xn--2-me5ay1273i; ; .xn--2-me5ay1273i; [V7, A4_2] # .2䫷
+.xn--2-me5ay1273i; .2䫷󠧷; [V7, X4_2]; .xn--2-me5ay1273i; [V7, A4_2]; ;  # .2䫷
+xn--0ugb.xn--2-me5ay1273i; \u200D\u200C.2䫷󠧷; [C1, C2, V7]; xn--0ugb.xn--2-me5ay1273i; ; ;  # .2䫷
+-𞀤󜠐。򈬖; -𞀤󜠐.򈬖; [V3, V7]; xn----rq4re4997d.xn--l707b; ; ;  # -𞀤.
+xn----rq4re4997d.xn--l707b; -𞀤󜠐.򈬖; [V3, V7]; xn----rq4re4997d.xn--l707b; ; ;  # -𞀤.
+󳛂︒\u200C㟀．\u0624⒈; 󳛂︒\u200C㟀.\u0624⒈; [C1, V7]; xn--0ug754gxl4ldlt0k.xn--jgb476m; ; xn--etlt457ccrq7h.xn--jgb476m; [V7] # ︒㟀.ؤ⒈
+󳛂︒\u200C㟀．\u0648\u0654⒈; 󳛂︒\u200C㟀.\u0624⒈; [C1, V7]; xn--0ug754gxl4ldlt0k.xn--jgb476m; ; xn--etlt457ccrq7h.xn--jgb476m; [V7] # ︒㟀.ؤ⒈
+󳛂。\u200C㟀.\u06241.; 󳛂.\u200C㟀.\u06241.; [B1, C1, V7]; xn--z272f.xn--0ug754g.xn--1-smc.; [B1, C1, V7, A4_2]; xn--z272f.xn--etl.xn--1-smc.; [V7, A4_2] # .㟀.ؤ1.
+󳛂。\u200C㟀.\u0648\u06541.; 󳛂.\u200C㟀.\u06241.; [B1, C1, V7]; xn--z272f.xn--0ug754g.xn--1-smc.; [B1, C1, V7, A4_2]; xn--z272f.xn--etl.xn--1-smc.; [V7, A4_2] # .㟀.ؤ1.
+xn--z272f.xn--etl.xn--1-smc.; 󳛂.㟀.\u06241.; [V7]; xn--z272f.xn--etl.xn--1-smc.; [V7, A4_2]; ;  # .㟀.ؤ1.
+xn--z272f.xn--0ug754g.xn--1-smc.; 󳛂.\u200C㟀.\u06241.; [B1, C1, V7]; xn--z272f.xn--0ug754g.xn--1-smc.; [B1, C1, V7, A4_2]; ;  # .㟀.ؤ1.
+xn--etlt457ccrq7h.xn--jgb476m; 󳛂︒㟀.\u0624⒈; [V7]; xn--etlt457ccrq7h.xn--jgb476m; ; ;  # ︒㟀.ؤ⒈
+xn--0ug754gxl4ldlt0k.xn--jgb476m; 󳛂︒\u200C㟀.\u0624⒈; [C1, V7]; xn--0ug754gxl4ldlt0k.xn--jgb476m; ; ;  # ︒㟀.ؤ⒈
+𑲜\u07CA𝅼。-\u200D; 𑲜\u07CA𝅼.-\u200D; [B1, C2, V3, V6]; xn--lsb5482l7nre.xn----ugn; ; xn--lsb5482l7nre.-; [B1, V3, V6] # 𑲜ߊ𝅼.-
+xn--lsb5482l7nre.-; 𑲜\u07CA𝅼.-; [B1, V3, V6]; xn--lsb5482l7nre.-; ; ;  # 𑲜ߊ𝅼.-
+xn--lsb5482l7nre.xn----ugn; 𑲜\u07CA𝅼.-\u200D; [B1, C2, V3, V6]; xn--lsb5482l7nre.xn----ugn; ; ;  # 𑲜ߊ𝅼.-
+\u200C．Ⴉ≠𐫶; \u200C.ⴉ≠𐫶; [B1, B5, B6, C1]; xn--0ug.xn--1chx23bzj4p; ; .xn--1chx23bzj4p; [B5, B6, A4_2] # .ⴉ≠𐫶
+\u200C．Ⴉ=\u0338𐫶; \u200C.ⴉ≠𐫶; [B1, B5, B6, C1]; xn--0ug.xn--1chx23bzj4p; ; .xn--1chx23bzj4p; [B5, B6, A4_2] # .ⴉ≠𐫶
+\u200C.Ⴉ≠𐫶; \u200C.ⴉ≠𐫶; [B1, B5, B6, C1]; xn--0ug.xn--1chx23bzj4p; ; .xn--1chx23bzj4p; [B5, B6, A4_2] # .ⴉ≠𐫶
+\u200C.Ⴉ=\u0338𐫶; \u200C.ⴉ≠𐫶; [B1, B5, B6, C1]; xn--0ug.xn--1chx23bzj4p; ; .xn--1chx23bzj4p; [B5, B6, A4_2] # .ⴉ≠𐫶
+\u200C.ⴉ=\u0338𐫶; \u200C.ⴉ≠𐫶; [B1, B5, B6, C1]; xn--0ug.xn--1chx23bzj4p; ; .xn--1chx23bzj4p; [B5, B6, A4_2] # .ⴉ≠𐫶
+\u200C.ⴉ≠𐫶; ; [B1, B5, B6, C1]; xn--0ug.xn--1chx23bzj4p; ; .xn--1chx23bzj4p; [B5, B6, A4_2] # .ⴉ≠𐫶
+.xn--1chx23bzj4p; .ⴉ≠𐫶; [B5, B6, X4_2]; .xn--1chx23bzj4p; [B5, B6, A4_2]; ;  # .ⴉ≠𐫶
+xn--0ug.xn--1chx23bzj4p; \u200C.ⴉ≠𐫶; [B1, B5, B6, C1]; xn--0ug.xn--1chx23bzj4p; ; ;  # .ⴉ≠𐫶
+\u200C．ⴉ=\u0338𐫶; \u200C.ⴉ≠𐫶; [B1, B5, B6, C1]; xn--0ug.xn--1chx23bzj4p; ; .xn--1chx23bzj4p; [B5, B6, A4_2] # .ⴉ≠𐫶
+\u200C．ⴉ≠𐫶; \u200C.ⴉ≠𐫶; [B1, B5, B6, C1]; xn--0ug.xn--1chx23bzj4p; ; .xn--1chx23bzj4p; [B5, B6, A4_2] # .ⴉ≠𐫶
+.xn--hnd481gv73o; .Ⴉ≠𐫶; [B5, B6, V7, X4_2]; .xn--hnd481gv73o; [B5, B6, V7, A4_2]; ;  # .Ⴉ≠𐫶
+xn--0ug.xn--hnd481gv73o; \u200C.Ⴉ≠𐫶; [B1, B5, B6, C1, V7]; xn--0ug.xn--hnd481gv73o; ; ;  # .Ⴉ≠𐫶
+\u0750。≯ς; \u0750.≯ς; [B1]; xn--3ob.xn--3xa918m; ; xn--3ob.xn--4xa718m;  # ݐ.≯ς
+\u0750。>\u0338ς; \u0750.≯ς; [B1]; xn--3ob.xn--3xa918m; ; xn--3ob.xn--4xa718m;  # ݐ.≯ς
+\u0750。>\u0338Σ; \u0750.≯σ; [B1]; xn--3ob.xn--4xa718m; ; ;  # ݐ.≯σ
+\u0750。≯Σ; \u0750.≯σ; [B1]; xn--3ob.xn--4xa718m; ; ;  # ݐ.≯σ
+\u0750。≯σ; \u0750.≯σ; [B1]; xn--3ob.xn--4xa718m; ; ;  # ݐ.≯σ
+\u0750。>\u0338σ; \u0750.≯σ; [B1]; xn--3ob.xn--4xa718m; ; ;  # ݐ.≯σ
+xn--3ob.xn--4xa718m; \u0750.≯σ; [B1]; xn--3ob.xn--4xa718m; ; ;  # ݐ.≯σ
+xn--3ob.xn--3xa918m; \u0750.≯ς; [B1]; xn--3ob.xn--3xa918m; ; ;  # ݐ.≯ς
+\u07FC𐸆.𓖏︒񊨩Ⴐ; \u07FC𐸆.𓖏︒񊨩ⴐ; [V7]; xn--0tb8725k.xn--7kj9008dt18a7py9c; ; ;  # .𓖏︒ⴐ
+\u07FC𐸆.𓖏。񊨩Ⴐ; \u07FC𐸆.𓖏.񊨩ⴐ; [V7]; xn--0tb8725k.xn--tu8d.xn--7kj73887a; ; ;  # .𓖏.ⴐ
+\u07FC𐸆.𓖏。񊨩ⴐ; \u07FC𐸆.𓖏.񊨩ⴐ; [V7]; xn--0tb8725k.xn--tu8d.xn--7kj73887a; ; ;  # .𓖏.ⴐ
+xn--0tb8725k.xn--tu8d.xn--7kj73887a; \u07FC𐸆.𓖏.񊨩ⴐ; [V7]; xn--0tb8725k.xn--tu8d.xn--7kj73887a; ; ;  # .𓖏.ⴐ
+\u07FC𐸆.𓖏︒񊨩ⴐ; ; [V7]; xn--0tb8725k.xn--7kj9008dt18a7py9c; ; ;  # .𓖏︒ⴐ
+xn--0tb8725k.xn--7kj9008dt18a7py9c; \u07FC𐸆.𓖏︒񊨩ⴐ; [V7]; xn--0tb8725k.xn--7kj9008dt18a7py9c; ; ;  # .𓖏︒ⴐ
+xn--0tb8725k.xn--tu8d.xn--ond97931d; \u07FC𐸆.𓖏.񊨩Ⴐ; [V7]; xn--0tb8725k.xn--tu8d.xn--ond97931d; ; ;  # .𓖏.Ⴐ
+xn--0tb8725k.xn--ond3562jt18a7py9c; \u07FC𐸆.𓖏︒񊨩Ⴐ; [V7]; xn--0tb8725k.xn--ond3562jt18a7py9c; ; ;  # .𓖏︒Ⴐ
+Ⴥ⚭󠖫⋃｡𑌼; ⴥ⚭󠖫⋃.𑌼; [V6, V7]; xn--vfh16m67gx1162b.xn--ro1d; ; ;  # ⴥ⚭⋃.𑌼
+Ⴥ⚭󠖫⋃。𑌼; ⴥ⚭󠖫⋃.𑌼; [V6, V7]; xn--vfh16m67gx1162b.xn--ro1d; ; ;  # ⴥ⚭⋃.𑌼
+ⴥ⚭󠖫⋃。𑌼; ⴥ⚭󠖫⋃.𑌼; [V6, V7]; xn--vfh16m67gx1162b.xn--ro1d; ; ;  # ⴥ⚭⋃.𑌼
+xn--vfh16m67gx1162b.xn--ro1d; ⴥ⚭󠖫⋃.𑌼; [V6, V7]; xn--vfh16m67gx1162b.xn--ro1d; ; ;  # ⴥ⚭⋃.𑌼
+ⴥ⚭󠖫⋃｡𑌼; ⴥ⚭󠖫⋃.𑌼; [V6, V7]; xn--vfh16m67gx1162b.xn--ro1d; ; ;  # ⴥ⚭⋃.𑌼
+xn--9nd623g4zc5z060c.xn--ro1d; Ⴥ⚭󠖫⋃.𑌼; [V6, V7]; xn--9nd623g4zc5z060c.xn--ro1d; ; ;  # Ⴥ⚭⋃.𑌼
+🄈。󠷳\u0844; 7,.󠷳\u0844; [B1, V7, U1]; 7,.xn--2vb13094p; ; ;  # 7,.ࡄ
+7,。󠷳\u0844; 7,.󠷳\u0844; [B1, V7, U1]; 7,.xn--2vb13094p; ; ;  # 7,.ࡄ
+7,.xn--2vb13094p; 7,.󠷳\u0844; [B1, V7, U1]; 7,.xn--2vb13094p; ; ;  # 7,.ࡄ
+xn--107h.xn--2vb13094p; 🄈.󠷳\u0844; [B1, V7]; xn--107h.xn--2vb13094p; ; ;  # 🄈.ࡄ
+≮\u0846。섖쮖ß; ≮\u0846.섖쮖ß; [B1]; xn--4vb505k.xn--zca7259goug; ; xn--4vb505k.xn--ss-5z4j006a;  # ≮ࡆ.섖쮖ß
+<\u0338\u0846。섖쮖ß; ≮\u0846.섖쮖ß; [B1]; xn--4vb505k.xn--zca7259goug; ; xn--4vb505k.xn--ss-5z4j006a;  # ≮ࡆ.섖쮖ß
+<\u0338\u0846。섖쮖SS; ≮\u0846.섖쮖ss; [B1]; xn--4vb505k.xn--ss-5z4j006a; ; ;  # ≮ࡆ.섖쮖ss
+≮\u0846。섖쮖SS; ≮\u0846.섖쮖ss; [B1]; xn--4vb505k.xn--ss-5z4j006a; ; ;  # ≮ࡆ.섖쮖ss
+≮\u0846。섖쮖ss; ≮\u0846.섖쮖ss; [B1]; xn--4vb505k.xn--ss-5z4j006a; ; ;  # ≮ࡆ.섖쮖ss
+<\u0338\u0846。섖쮖ss; ≮\u0846.섖쮖ss; [B1]; xn--4vb505k.xn--ss-5z4j006a; ; ;  # ≮ࡆ.섖쮖ss
+xn--4vb505k.xn--ss-5z4j006a; ≮\u0846.섖쮖ss; [B1]; xn--4vb505k.xn--ss-5z4j006a; ; ;  # ≮ࡆ.섖쮖ss
+≮\u0846。섖쮖Ss; ≮\u0846.섖쮖ss; [B1]; xn--4vb505k.xn--ss-5z4j006a; ; ;  # ≮ࡆ.섖쮖ss
+<\u0338\u0846。섖쮖Ss; ≮\u0846.섖쮖ss; [B1]; xn--4vb505k.xn--ss-5z4j006a; ; ;  # ≮ࡆ.섖쮖ss
+xn--4vb505k.xn--zca7259goug; ≮\u0846.섖쮖ß; [B1]; xn--4vb505k.xn--zca7259goug; ; ;  # ≮ࡆ.섖쮖ß
+󠆓⛏-。ꡒ; ⛏-.ꡒ; [V3]; xn----o9p.xn--rc9a; ; ;  # ⛏-.ꡒ
+xn----o9p.xn--rc9a; ⛏-.ꡒ; [V3]; xn----o9p.xn--rc9a; ; ;  # ⛏-.ꡒ
+\u07BB𐹳\u0626𑁆。\u08A7\u06B0\u200Cᢒ; \u07BB𐹳\u0626𑁆.\u08A7\u06B0\u200Cᢒ; [B2, B3, V7]; xn--lgb32f2753cosb.xn--jkb91hlz1azih; ; xn--lgb32f2753cosb.xn--jkb91hlz1a;  # 𐹳ئ𑁆.ࢧڰᢒ
+\u07BB𐹳\u064A𑁆\u0654。\u08A7\u06B0\u200Cᢒ; \u07BB𐹳\u0626𑁆.\u08A7\u06B0\u200Cᢒ; [B2, B3, V7]; xn--lgb32f2753cosb.xn--jkb91hlz1azih; ; xn--lgb32f2753cosb.xn--jkb91hlz1a;  # 𐹳ئ𑁆.ࢧڰᢒ
+xn--lgb32f2753cosb.xn--jkb91hlz1a; \u07BB𐹳\u0626𑁆.\u08A7\u06B0ᢒ; [B2, B3, V7]; xn--lgb32f2753cosb.xn--jkb91hlz1a; ; ;  # 𐹳ئ𑁆.ࢧڰᢒ
+xn--lgb32f2753cosb.xn--jkb91hlz1azih; \u07BB𐹳\u0626𑁆.\u08A7\u06B0\u200Cᢒ; [B2, B3, V7]; xn--lgb32f2753cosb.xn--jkb91hlz1azih; ; ;  # 𐹳ئ𑁆.ࢧڰᢒ
+\u0816.𐨕𚚕; ; [B1, B2, B3, V6, V7]; xn--rub.xn--tr9c248x; ; ;  # ࠖ.𐨕
+xn--rub.xn--tr9c248x; \u0816.𐨕𚚕; [B1, B2, B3, V6, V7]; xn--rub.xn--tr9c248x; ; ;  # ࠖ.𐨕
+--。𽊆\u0767𐽋𞠬; --.𽊆\u0767𐽋𞠬; [B1, B5, B6, V3, V7]; --.xn--rpb6226k77pfh58p; ; ;  # --.ݧ𐽋𞠬
+--.xn--rpb6226k77pfh58p; --.𽊆\u0767𐽋𞠬; [B1, B5, B6, V3, V7]; --.xn--rpb6226k77pfh58p; ; ;  # --.ݧ𐽋𞠬
+򛭦𐋥𹸐.≯\u08B0\u08A6󔛣; ; [B1, V7]; xn--887c2298i5mv6a.xn--vybt688qm8981a; ; ;  # 𐋥.≯ࢰࢦ
+򛭦𐋥𹸐.>\u0338\u08B0\u08A6󔛣; 򛭦𐋥𹸐.≯\u08B0\u08A6󔛣; [B1, V7]; xn--887c2298i5mv6a.xn--vybt688qm8981a; ; ;  # 𐋥.≯ࢰࢦ
+xn--887c2298i5mv6a.xn--vybt688qm8981a; 򛭦𐋥𹸐.≯\u08B0\u08A6󔛣; [B1, V7]; xn--887c2298i5mv6a.xn--vybt688qm8981a; ; ;  # 𐋥.≯ࢰࢦ
+䔛󠇒򤸞𐹧．-䤷; 䔛򤸞𐹧.-䤷; [B1, B5, B6, V3, V7]; xn--2loy662coo60e.xn----0n4a; ; ;  # 䔛𐹧.-䤷
+䔛󠇒򤸞𐹧.-䤷; 䔛򤸞𐹧.-䤷; [B1, B5, B6, V3, V7]; xn--2loy662coo60e.xn----0n4a; ; ;  # 䔛𐹧.-䤷
+xn--2loy662coo60e.xn----0n4a; 䔛򤸞𐹧.-䤷; [B1, B5, B6, V3, V7]; xn--2loy662coo60e.xn----0n4a; ; ;  # 䔛𐹧.-䤷
+𐹩．\u200D-; 𐹩.\u200D-; [B1, C2, V3]; xn--ho0d.xn----tgn; ; xn--ho0d.-; [B1, V3] # 𐹩.-
+𐹩.\u200D-; ; [B1, C2, V3]; xn--ho0d.xn----tgn; ; xn--ho0d.-; [B1, V3] # 𐹩.-
+xn--ho0d.-; 𐹩.-; [B1, V3]; xn--ho0d.-; ; ;  # 𐹩.-
+xn--ho0d.xn----tgn; 𐹩.\u200D-; [B1, C2, V3]; xn--ho0d.xn----tgn; ; ;  # 𐹩.-
+񂈦帷｡≯萺\u1DC8-; 񂈦帷.≯萺\u1DC8-; [V3, V7]; xn--qutw175s.xn----mimu6tf67j; ; ;  # 帷.≯萺᷈-
+񂈦帷｡>\u0338萺\u1DC8-; 񂈦帷.≯萺\u1DC8-; [V3, V7]; xn--qutw175s.xn----mimu6tf67j; ; ;  # 帷.≯萺᷈-
+񂈦帷。≯萺\u1DC8-; 񂈦帷.≯萺\u1DC8-; [V3, V7]; xn--qutw175s.xn----mimu6tf67j; ; ;  # 帷.≯萺᷈-
+񂈦帷。>\u0338萺\u1DC8-; 񂈦帷.≯萺\u1DC8-; [V3, V7]; xn--qutw175s.xn----mimu6tf67j; ; ;  # 帷.≯萺᷈-
+xn--qutw175s.xn----mimu6tf67j; 񂈦帷.≯萺\u1DC8-; [V3, V7]; xn--qutw175s.xn----mimu6tf67j; ; ;  # 帷.≯萺᷈-
+\u200D攌\uABED。ᢖ-Ⴘ; \u200D攌\uABED.ᢖ-ⴘ; [C2]; xn--1ug592ykp6b.xn----mck373i; ; xn--p9ut19m.xn----mck373i; [] # 攌꯭.ᢖ-ⴘ
+\u200D攌\uABED。ᢖ-ⴘ; \u200D攌\uABED.ᢖ-ⴘ; [C2]; xn--1ug592ykp6b.xn----mck373i; ; xn--p9ut19m.xn----mck373i; [] # 攌꯭.ᢖ-ⴘ
+xn--p9ut19m.xn----mck373i; 攌\uABED.ᢖ-ⴘ; ; xn--p9ut19m.xn----mck373i; ; ;  # 攌꯭.ᢖ-ⴘ
+攌\uABED.ᢖ-ⴘ; ; ; xn--p9ut19m.xn----mck373i; ; ;  # 攌꯭.ᢖ-ⴘ
+攌\uABED.ᢖ-Ⴘ; 攌\uABED.ᢖ-ⴘ; ; xn--p9ut19m.xn----mck373i; ; ;  # 攌꯭.ᢖ-ⴘ
+xn--1ug592ykp6b.xn----mck373i; \u200D攌\uABED.ᢖ-ⴘ; [C2]; xn--1ug592ykp6b.xn----mck373i; ; ;  # 攌꯭.ᢖ-ⴘ
+xn--p9ut19m.xn----k1g451d; 攌\uABED.ᢖ-Ⴘ; [V7]; xn--p9ut19m.xn----k1g451d; ; ;  # 攌꯭.ᢖ-Ⴘ
+xn--1ug592ykp6b.xn----k1g451d; \u200D攌\uABED.ᢖ-Ⴘ; [C2, V7]; xn--1ug592ykp6b.xn----k1g451d; ; ;  # 攌꯭.ᢖ-Ⴘ
+\u200Cꖨ．⒗３툒۳; \u200Cꖨ.⒗3툒۳; [C1, V7]; xn--0ug2473c.xn--3-nyc678tu07m; ; xn--9r8a.xn--3-nyc678tu07m; [V7] # ꖨ.⒗3툒۳
+\u200Cꖨ．⒗３툒۳; \u200Cꖨ.⒗3툒۳; [C1, V7]; xn--0ug2473c.xn--3-nyc678tu07m; ; xn--9r8a.xn--3-nyc678tu07m; [V7] # ꖨ.⒗3툒۳
+\u200Cꖨ.16.3툒۳; ; [C1]; xn--0ug2473c.16.xn--3-nyc0117m; ; xn--9r8a.16.xn--3-nyc0117m; [] # ꖨ.16.3툒۳
+\u200Cꖨ.16.3툒۳; \u200Cꖨ.16.3툒۳; [C1]; xn--0ug2473c.16.xn--3-nyc0117m; ; xn--9r8a.16.xn--3-nyc0117m; [] # ꖨ.16.3툒۳
+xn--9r8a.16.xn--3-nyc0117m; ꖨ.16.3툒۳; ; xn--9r8a.16.xn--3-nyc0117m; ; ;  # ꖨ.16.3툒۳
+ꖨ.16.3툒۳; ; ; xn--9r8a.16.xn--3-nyc0117m; ; ;  # ꖨ.16.3툒۳
+ꖨ.16.3툒۳; ꖨ.16.3툒۳; ; xn--9r8a.16.xn--3-nyc0117m; ; ;  # ꖨ.16.3툒۳
+xn--0ug2473c.16.xn--3-nyc0117m; \u200Cꖨ.16.3툒۳; [C1]; xn--0ug2473c.16.xn--3-nyc0117m; ; ;  # ꖨ.16.3툒۳
+xn--9r8a.xn--3-nyc678tu07m; ꖨ.⒗3툒۳; [V7]; xn--9r8a.xn--3-nyc678tu07m; ; ;  # ꖨ.⒗3툒۳
+xn--0ug2473c.xn--3-nyc678tu07m; \u200Cꖨ.⒗3툒۳; [C1, V7]; xn--0ug2473c.xn--3-nyc678tu07m; ; ;  # ꖨ.⒗3툒۳
+⒈걾6.𐱁\u06D0; ; [B1, V7]; xn--6-dcps419c.xn--glb1794k; ; ;  # ⒈걾6.𐱁ې
+⒈걾6.𐱁\u06D0; ⒈걾6.𐱁\u06D0; [B1, V7]; xn--6-dcps419c.xn--glb1794k; ; ;  # ⒈걾6.𐱁ې
+1.걾6.𐱁\u06D0; ; [B1]; 1.xn--6-945e.xn--glb1794k; ; ;  # 1.걾6.𐱁ې
+1.걾6.𐱁\u06D0; 1.걾6.𐱁\u06D0; [B1]; 1.xn--6-945e.xn--glb1794k; ; ;  # 1.걾6.𐱁ې
+1.xn--6-945e.xn--glb1794k; 1.걾6.𐱁\u06D0; [B1]; 1.xn--6-945e.xn--glb1794k; ; ;  # 1.걾6.𐱁ې
+xn--6-dcps419c.xn--glb1794k; ⒈걾6.𐱁\u06D0; [B1, V7]; xn--6-dcps419c.xn--glb1794k; ; ;  # ⒈걾6.𐱁ې
+𐲞𝟶≮≮.󠀧\u0639; 𐳞0≮≮.󠀧\u0639; [B1, B3, V7]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+𐲞𝟶<\u0338<\u0338.󠀧\u0639; 𐳞0≮≮.󠀧\u0639; [B1, B3, V7]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+𐲞0≮≮.󠀧\u0639; 𐳞0≮≮.󠀧\u0639; [B1, B3, V7]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+𐲞0<\u0338<\u0338.󠀧\u0639; 𐳞0≮≮.󠀧\u0639; [B1, B3, V7]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+𐳞0<\u0338<\u0338.󠀧\u0639; 𐳞0≮≮.󠀧\u0639; [B1, B3, V7]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+𐳞0≮≮.󠀧\u0639; ; [B1, B3, V7]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+xn--0-ngoa5711v.xn--4gb31034p; 𐳞0≮≮.󠀧\u0639; [B1, B3, V7]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+𐳞𝟶<\u0338<\u0338.󠀧\u0639; 𐳞0≮≮.󠀧\u0639; [B1, B3, V7]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+𐳞𝟶≮≮.󠀧\u0639; 𐳞0≮≮.󠀧\u0639; [B1, B3, V7]; xn--0-ngoa5711v.xn--4gb31034p; ; ;  # 𐳞0≮≮.ع
+\u0AE3.𐹺\u115F; \u0AE3.𐹺; [B1, V6]; xn--8fc.xn--yo0d; ; ;  # ૣ.𐹺
+xn--8fc.xn--yo0d; \u0AE3.𐹺; [B1, V6]; xn--8fc.xn--yo0d; ; ;  # ૣ.𐹺
+xn--8fc.xn--osd3070k; \u0AE3.𐹺\u115F; [B1, V6, V7]; xn--8fc.xn--osd3070k; ; ;  # ૣ.𐹺
+𝟏𝨙⸖.\u200D; 1𝨙⸖.\u200D; [C2]; xn--1-5bt6845n.xn--1ug; ; xn--1-5bt6845n.; [A4_2] # 1𝨙⸖.
+1𝨙⸖.\u200D; ; [C2]; xn--1-5bt6845n.xn--1ug; ; xn--1-5bt6845n.; [A4_2] # 1𝨙⸖.
+xn--1-5bt6845n.; 1𝨙⸖.; ; xn--1-5bt6845n.; [A4_2]; ;  # 1𝨙⸖.
+1𝨙⸖.; ; ; xn--1-5bt6845n.; [A4_2]; ;  # 1𝨙⸖.
+xn--1-5bt6845n.xn--1ug; 1𝨙⸖.\u200D; [C2]; xn--1-5bt6845n.xn--1ug; ; ;  # 1𝨙⸖.
+𞤐≠\u0726\u1A60｡-\u200C\u07D5; 𞤲≠\u0726\u1A60.-\u200C\u07D5; [B1, C1, V3]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, V3] # 𞤲≠ܦ᩠.-ߕ
+𞤐=\u0338\u0726\u1A60｡-\u200C\u07D5; 𞤲≠\u0726\u1A60.-\u200C\u07D5; [B1, C1, V3]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, V3] # 𞤲≠ܦ᩠.-ߕ
+𞤐≠\u0726\u1A60。-\u200C\u07D5; 𞤲≠\u0726\u1A60.-\u200C\u07D5; [B1, C1, V3]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, V3] # 𞤲≠ܦ᩠.-ߕ
+𞤐=\u0338\u0726\u1A60。-\u200C\u07D5; 𞤲≠\u0726\u1A60.-\u200C\u07D5; [B1, C1, V3]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, V3] # 𞤲≠ܦ᩠.-ߕ
+𞤲=\u0338\u0726\u1A60。-\u200C\u07D5; 𞤲≠\u0726\u1A60.-\u200C\u07D5; [B1, C1, V3]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, V3] # 𞤲≠ܦ᩠.-ߕ
+𞤲≠\u0726\u1A60。-\u200C\u07D5; 𞤲≠\u0726\u1A60.-\u200C\u07D5; [B1, C1, V3]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, V3] # 𞤲≠ܦ᩠.-ߕ
+xn--wnb859grzfzw60c.xn----kcd; 𞤲≠\u0726\u1A60.-\u07D5; [B1, V3]; xn--wnb859grzfzw60c.xn----kcd; ; ;  # 𞤲≠ܦ᩠.-ߕ
+xn--wnb859grzfzw60c.xn----kcd017p; 𞤲≠\u0726\u1A60.-\u200C\u07D5; [B1, C1, V3]; xn--wnb859grzfzw60c.xn----kcd017p; ; ;  # 𞤲≠ܦ᩠.-ߕ
+𞤲=\u0338\u0726\u1A60｡-\u200C\u07D5; 𞤲≠\u0726\u1A60.-\u200C\u07D5; [B1, C1, V3]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, V3] # 𞤲≠ܦ᩠.-ߕ
+𞤲≠\u0726\u1A60｡-\u200C\u07D5; 𞤲≠\u0726\u1A60.-\u200C\u07D5; [B1, C1, V3]; xn--wnb859grzfzw60c.xn----kcd017p; ; xn--wnb859grzfzw60c.xn----kcd; [B1, V3] # 𞤲≠ܦ᩠.-ߕ
+𐹰\u0368-ꡧ｡\u0675; 𐹰\u0368-ꡧ.\u0627\u0674; [B1]; xn----shb2387jgkqd.xn--mgb8m; ; ;  # 𐹰ͨ-ꡧ.اٴ
+𐹰\u0368-ꡧ。\u0627\u0674; 𐹰\u0368-ꡧ.\u0627\u0674; [B1]; xn----shb2387jgkqd.xn--mgb8m; ; ;  # 𐹰ͨ-ꡧ.اٴ
+xn----shb2387jgkqd.xn--mgb8m; 𐹰\u0368-ꡧ.\u0627\u0674; [B1]; xn----shb2387jgkqd.xn--mgb8m; ; ;  # 𐹰ͨ-ꡧ.اٴ
+F󠅟｡򏗅♚; f.򏗅♚; [V7]; f.xn--45hz6953f; ; ;  # f.♚
+F󠅟。򏗅♚; f.򏗅♚; [V7]; f.xn--45hz6953f; ; ;  # f.♚
+f󠅟。򏗅♚; f.򏗅♚; [V7]; f.xn--45hz6953f; ; ;  # f.♚
+f.xn--45hz6953f; f.򏗅♚; [V7]; f.xn--45hz6953f; ; ;  # f.♚
+f󠅟｡򏗅♚; f.򏗅♚; [V7]; f.xn--45hz6953f; ; ;  # f.♚
+\u0B4D𑄴\u1DE9。𝟮Ⴘ𞀨񃥇; \u0B4D𑄴\u1DE9.2ⴘ𞀨񃥇; [V6, V7]; xn--9ic246gs21p.xn--2-nws2918ndrjr; ; ;  # ୍𑄴ᷩ.2ⴘ𞀨
+\u0B4D𑄴\u1DE9。2Ⴘ𞀨񃥇; \u0B4D𑄴\u1DE9.2ⴘ𞀨񃥇; [V6, V7]; xn--9ic246gs21p.xn--2-nws2918ndrjr; ; ;  # ୍𑄴ᷩ.2ⴘ𞀨
+\u0B4D𑄴\u1DE9。2ⴘ𞀨񃥇; \u0B4D𑄴\u1DE9.2ⴘ𞀨񃥇; [V6, V7]; xn--9ic246gs21p.xn--2-nws2918ndrjr; ; ;  # ୍𑄴ᷩ.2ⴘ𞀨
+xn--9ic246gs21p.xn--2-nws2918ndrjr; \u0B4D𑄴\u1DE9.2ⴘ𞀨񃥇; [V6, V7]; xn--9ic246gs21p.xn--2-nws2918ndrjr; ; ;  # ୍𑄴ᷩ.2ⴘ𞀨
+\u0B4D𑄴\u1DE9。𝟮ⴘ𞀨񃥇; \u0B4D𑄴\u1DE9.2ⴘ𞀨񃥇; [V6, V7]; xn--9ic246gs21p.xn--2-nws2918ndrjr; ; ;  # ୍𑄴ᷩ.2ⴘ𞀨
+xn--9ic246gs21p.xn--2-k1g43076adrwq; \u0B4D𑄴\u1DE9.2Ⴘ𞀨񃥇; [V6, V7]; xn--9ic246gs21p.xn--2-k1g43076adrwq; ; ;  # ୍𑄴ᷩ.2Ⴘ𞀨
+򓠭\u200C\u200C⒈。勉𑁅; 򓠭\u200C\u200C⒈.勉𑁅; [C1, V7]; xn--0uga855aez302a.xn--4grs325b; ; xn--tsh11906f.xn--4grs325b; [V7] # ⒈.勉𑁅
+򓠭\u200C\u200C1.。勉𑁅; 򓠭\u200C\u200C1..勉𑁅; [C1, V7, X4_2]; xn--1-rgna61159u..xn--4grs325b; [C1, V7, A4_2]; xn--1-yi00h..xn--4grs325b; [V7, A4_2] # 1..勉𑁅
+xn--1-yi00h..xn--4grs325b; 򓠭1..勉𑁅; [V7, X4_2]; xn--1-yi00h..xn--4grs325b; [V7, A4_2]; ;  # 1..勉𑁅
+xn--1-rgna61159u..xn--4grs325b; 򓠭\u200C\u200C1..勉𑁅; [C1, V7, X4_2]; xn--1-rgna61159u..xn--4grs325b; [C1, V7, A4_2]; ;  # 1..勉𑁅
+xn--tsh11906f.xn--4grs325b; 򓠭⒈.勉𑁅; [V7]; xn--tsh11906f.xn--4grs325b; ; ;  # ⒈.勉𑁅
+xn--0uga855aez302a.xn--4grs325b; 򓠭\u200C\u200C⒈.勉𑁅; [C1, V7]; xn--0uga855aez302a.xn--4grs325b; ; ;  # ⒈.勉𑁅
+ᡃ.玿񫈜󕞐; ; [V7]; xn--27e.xn--7cy81125a0yq4a; ; ;  # ᡃ.玿
+xn--27e.xn--7cy81125a0yq4a; ᡃ.玿񫈜󕞐; [V7]; xn--27e.xn--7cy81125a0yq4a; ; ;  # ᡃ.玿
+\u200C\u200C｡⒈≯𝟵; \u200C\u200C.⒈≯9; [C1, V7]; xn--0uga.xn--9-ogo37g; ; .xn--9-ogo37g; [V7, A4_2] # .⒈≯9
+\u200C\u200C｡⒈>\u0338𝟵; \u200C\u200C.⒈≯9; [C1, V7]; xn--0uga.xn--9-ogo37g; ; .xn--9-ogo37g; [V7, A4_2] # .⒈≯9
+\u200C\u200C。1.≯9; \u200C\u200C.1.≯9; [C1]; xn--0uga.1.xn--9-ogo; ; .1.xn--9-ogo; [A4_2] # .1.≯9
+\u200C\u200C。1.>\u03389; \u200C\u200C.1.≯9; [C1]; xn--0uga.1.xn--9-ogo; ; .1.xn--9-ogo; [A4_2] # .1.≯9
+.1.xn--9-ogo; .1.≯9; [X4_2]; .1.xn--9-ogo; [A4_2]; ;  # .1.≯9
+xn--0uga.1.xn--9-ogo; \u200C\u200C.1.≯9; [C1]; xn--0uga.1.xn--9-ogo; ; ;  # .1.≯9
+.xn--9-ogo37g; .⒈≯9; [V7, X4_2]; .xn--9-ogo37g; [V7, A4_2]; ;  # .⒈≯9
+xn--0uga.xn--9-ogo37g; \u200C\u200C.⒈≯9; [C1, V7]; xn--0uga.xn--9-ogo37g; ; ;  # .⒈≯9
+\u115F\u1DE0򐀁.𺻆≯𐮁; \u1DE0򐀁.𺻆≯𐮁; [B1, B5, B6, V6, V7]; xn--4eg41418g.xn--hdh5192gkm6r; ; ;  # ᷠ.≯𐮁
+\u115F\u1DE0򐀁.𺻆>\u0338𐮁; \u1DE0򐀁.𺻆≯𐮁; [B1, B5, B6, V6, V7]; xn--4eg41418g.xn--hdh5192gkm6r; ; ;  # ᷠ.≯𐮁
+xn--4eg41418g.xn--hdh5192gkm6r; \u1DE0򐀁.𺻆≯𐮁; [B1, B5, B6, V6, V7]; xn--4eg41418g.xn--hdh5192gkm6r; ; ;  # ᷠ.≯𐮁
+xn--osd615d5659o.xn--hdh5192gkm6r; \u115F\u1DE0򐀁.𺻆≯𐮁; [B5, B6, V7]; xn--osd615d5659o.xn--hdh5192gkm6r; ; ;  # ᷠ.≯𐮁
+󠄫𝩤\u200D\u063E.𝩩-\u081E󑼩; 𝩤\u200D\u063E.𝩩-\u081E󑼩; [B1, C2, V6, V7]; xn--9gb723kg862a.xn----qgd52296avol4f; ; xn--9gb5080v.xn----qgd52296avol4f; [B1, V6, V7] # 𝩤ؾ.𝩩-ࠞ
+xn--9gb5080v.xn----qgd52296avol4f; 𝩤\u063E.𝩩-\u081E󑼩; [B1, V6, V7]; xn--9gb5080v.xn----qgd52296avol4f; ; ;  # 𝩤ؾ.𝩩-ࠞ
+xn--9gb723kg862a.xn----qgd52296avol4f; 𝩤\u200D\u063E.𝩩-\u081E󑼩; [B1, C2, V6, V7]; xn--9gb723kg862a.xn----qgd52296avol4f; ; ;  # 𝩤ؾ.𝩩-ࠞ
+\u20DA．𑘿-; \u20DA.𑘿-; [V3, V6]; xn--w0g.xn----bd0j; ; ;  # ⃚.𑘿-
+\u20DA.𑘿-; ; [V3, V6]; xn--w0g.xn----bd0j; ; ;  # ⃚.𑘿-
+xn--w0g.xn----bd0j; \u20DA.𑘿-; [V3, V6]; xn--w0g.xn----bd0j; ; ;  # ⃚.𑘿-
+䮸ß.󠵟󠭎紙\u08A8; ; [B1, V7]; xn--zca5349a.xn--xyb1370div70kpzba; ; xn--ss-sf1c.xn--xyb1370div70kpzba;  # 䮸ß.紙ࢨ
+䮸SS.󠵟󠭎紙\u08A8; 䮸ss.󠵟󠭎紙\u08A8; [B1, V7]; xn--ss-sf1c.xn--xyb1370div70kpzba; ; ;  # 䮸ss.紙ࢨ
+䮸ss.󠵟󠭎紙\u08A8; ; [B1, V7]; xn--ss-sf1c.xn--xyb1370div70kpzba; ; ;  # 䮸ss.紙ࢨ
+䮸Ss.󠵟󠭎紙\u08A8; 䮸ss.󠵟󠭎紙\u08A8; [B1, V7]; xn--ss-sf1c.xn--xyb1370div70kpzba; ; ;  # 䮸ss.紙ࢨ
+xn--ss-sf1c.xn--xyb1370div70kpzba; 䮸ss.󠵟󠭎紙\u08A8; [B1, V7]; xn--ss-sf1c.xn--xyb1370div70kpzba; ; ;  # 䮸ss.紙ࢨ
+xn--zca5349a.xn--xyb1370div70kpzba; 䮸ß.󠵟󠭎紙\u08A8; [B1, V7]; xn--zca5349a.xn--xyb1370div70kpzba; ; ;  # 䮸ß.紙ࢨ
+-Ⴞ.-𝩨⅔𐦕; -ⴞ.-𝩨2⁄3𐦕; [B1, V3]; xn----zws.xn---23-pt0a0433lk3jj; ; ;  # -ⴞ.-𝩨2⁄3𐦕
+-Ⴞ.-𝩨2⁄3𐦕; -ⴞ.-𝩨2⁄3𐦕; [B1, V3]; xn----zws.xn---23-pt0a0433lk3jj; ; ;  # -ⴞ.-𝩨2⁄3𐦕
+-ⴞ.-𝩨2⁄3𐦕; ; [B1, V3]; xn----zws.xn---23-pt0a0433lk3jj; ; ;  # -ⴞ.-𝩨2⁄3𐦕
+xn----zws.xn---23-pt0a0433lk3jj; -ⴞ.-𝩨2⁄3𐦕; [B1, V3]; xn----zws.xn---23-pt0a0433lk3jj; ; ;  # -ⴞ.-𝩨2⁄3𐦕
+-ⴞ.-𝩨⅔𐦕; -ⴞ.-𝩨2⁄3𐦕; [B1, V3]; xn----zws.xn---23-pt0a0433lk3jj; ; ;  # -ⴞ.-𝩨2⁄3𐦕
+xn----w1g.xn---23-pt0a0433lk3jj; -Ⴞ.-𝩨2⁄3𐦕; [B1, V3, V7]; xn----w1g.xn---23-pt0a0433lk3jj; ; ;  # -Ⴞ.-𝩨2⁄3𐦕
+󧈯𐹯\u0AC2｡򖢨𐮁񇼖ᡂ; 󧈯𐹯\u0AC2.򖢨𐮁񇼖ᡂ; [B5, B6, V7]; xn--bfc7604kv8m3g.xn--17e5565jl7zw4h16a; ; ;  # 𐹯ૂ.𐮁ᡂ
+󧈯𐹯\u0AC2。򖢨𐮁񇼖ᡂ; 󧈯𐹯\u0AC2.򖢨𐮁񇼖ᡂ; [B5, B6, V7]; xn--bfc7604kv8m3g.xn--17e5565jl7zw4h16a; ; ;  # 𐹯ૂ.𐮁ᡂ
+xn--bfc7604kv8m3g.xn--17e5565jl7zw4h16a; 󧈯𐹯\u0AC2.򖢨𐮁񇼖ᡂ; [B5, B6, V7]; xn--bfc7604kv8m3g.xn--17e5565jl7zw4h16a; ; ;  # 𐹯ૂ.𐮁ᡂ
+\u1082-\u200D\uA8EA．ꡊ\u200D񼸳; \u1082-\u200D\uA8EA.ꡊ\u200D񼸳; [C2, V6, V7]; xn----gyg250jio7k.xn--1ug8774cri56d; ; xn----gyg3618i.xn--jc9ao4185a; [V6, V7] # ႂ-꣪.ꡊ
+\u1082-\u200D\uA8EA.ꡊ\u200D񼸳; ; [C2, V6, V7]; xn----gyg250jio7k.xn--1ug8774cri56d; ; xn----gyg3618i.xn--jc9ao4185a; [V6, V7] # ႂ-꣪.ꡊ
+xn----gyg3618i.xn--jc9ao4185a; \u1082-\uA8EA.ꡊ񼸳; [V6, V7]; xn----gyg3618i.xn--jc9ao4185a; ; ;  # ႂ-꣪.ꡊ
+xn----gyg250jio7k.xn--1ug8774cri56d; \u1082-\u200D\uA8EA.ꡊ\u200D񼸳; [C2, V6, V7]; xn----gyg250jio7k.xn--1ug8774cri56d; ; ;  # ႂ-꣪.ꡊ
+۱。≠\u0668; ۱.≠\u0668; [B1]; xn--emb.xn--hib334l; ; ;  # ۱.≠٨
+۱。=\u0338\u0668; ۱.≠\u0668; [B1]; xn--emb.xn--hib334l; ; ;  # ۱.≠٨
+xn--emb.xn--hib334l; ۱.≠\u0668; [B1]; xn--emb.xn--hib334l; ; ;  # ۱.≠٨
+𑈵廊.𐠍; ; [V6]; xn--xytw701b.xn--yc9c; ; ;  # 𑈵廊.𐠍
+xn--xytw701b.xn--yc9c; 𑈵廊.𐠍; [V6]; xn--xytw701b.xn--yc9c; ; ;  # 𑈵廊.𐠍
+\u200D\u0356-．-Ⴐ\u0661; \u200D\u0356-.-ⴐ\u0661; [B1, C2, V3]; xn----rgb661t.xn----bqc2280a; ; xn----rgb.xn----bqc2280a; [B1, V3, V6] # ͖-.-ⴐ١
+\u200D\u0356-.-Ⴐ\u0661; \u200D\u0356-.-ⴐ\u0661; [B1, C2, V3]; xn----rgb661t.xn----bqc2280a; ; xn----rgb.xn----bqc2280a; [B1, V3, V6] # ͖-.-ⴐ١
+\u200D\u0356-.-ⴐ\u0661; ; [B1, C2, V3]; xn----rgb661t.xn----bqc2280a; ; xn----rgb.xn----bqc2280a; [B1, V3, V6] # ͖-.-ⴐ١
+xn----rgb.xn----bqc2280a; \u0356-.-ⴐ\u0661; [B1, V3, V6]; xn----rgb.xn----bqc2280a; ; ;  # ͖-.-ⴐ١
+xn----rgb661t.xn----bqc2280a; \u200D\u0356-.-ⴐ\u0661; [B1, C2, V3]; xn----rgb661t.xn----bqc2280a; ; ;  # ͖-.-ⴐ١
+\u200D\u0356-．-ⴐ\u0661; \u200D\u0356-.-ⴐ\u0661; [B1, C2, V3]; xn----rgb661t.xn----bqc2280a; ; xn----rgb.xn----bqc2280a; [B1, V3, V6] # ͖-.-ⴐ١
+xn----rgb.xn----bqc030f; \u0356-.-Ⴐ\u0661; [B1, V3, V6, V7]; xn----rgb.xn----bqc030f; ; ;  # ͖-.-Ⴐ١
+xn----rgb661t.xn----bqc030f; \u200D\u0356-.-Ⴐ\u0661; [B1, C2, V3, V7]; xn----rgb661t.xn----bqc030f; ; ;  # ͖-.-Ⴐ١
+\u063A\u0661挏󾯐.-; ; [B1, B2, B3, V3, V7]; xn--5gb2f4205aqi47p.-; ; ;  # غ١挏.-
+xn--5gb2f4205aqi47p.-; \u063A\u0661挏󾯐.-; [B1, B2, B3, V3, V7]; xn--5gb2f4205aqi47p.-; ; ;  # غ١挏.-
+\u06EF｡𐹧𞤽; \u06EF.𐹧𞤽; [B1]; xn--cmb.xn--fo0dy848a; ; ;  # ۯ.𐹧𞤽
+\u06EF。𐹧𞤽; \u06EF.𐹧𞤽; [B1]; xn--cmb.xn--fo0dy848a; ; ;  # ۯ.𐹧𞤽
+\u06EF。𐹧𞤛; \u06EF.𐹧𞤽; [B1]; xn--cmb.xn--fo0dy848a; ; ;  # ۯ.𐹧𞤽
+xn--cmb.xn--fo0dy848a; \u06EF.𐹧𞤽; [B1]; xn--cmb.xn--fo0dy848a; ; ;  # ۯ.𐹧𞤽
+\u06EF｡𐹧𞤛; \u06EF.𐹧𞤽; [B1]; xn--cmb.xn--fo0dy848a; ; ;  # ۯ.𐹧𞤽
+Ⴞ𶛀𛗻．ᢗ릫; ⴞ𶛀𛗻.ᢗ릫; [V7]; xn--mlj0486jgl2j.xn--hbf6853f; ; ;  # ⴞ.ᢗ릫
+Ⴞ𶛀𛗻．ᢗ릫; ⴞ𶛀𛗻.ᢗ릫; [V7]; xn--mlj0486jgl2j.xn--hbf6853f; ; ;  # ⴞ.ᢗ릫
+Ⴞ𶛀𛗻.ᢗ릫; ⴞ𶛀𛗻.ᢗ릫; [V7]; xn--mlj0486jgl2j.xn--hbf6853f; ; ;  # ⴞ.ᢗ릫
+Ⴞ𶛀𛗻.ᢗ릫; ⴞ𶛀𛗻.ᢗ릫; [V7]; xn--mlj0486jgl2j.xn--hbf6853f; ; ;  # ⴞ.ᢗ릫
+ⴞ𶛀𛗻.ᢗ릫; ⴞ𶛀𛗻.ᢗ릫; [V7]; xn--mlj0486jgl2j.xn--hbf6853f; ; ;  # ⴞ.ᢗ릫
+ⴞ𶛀𛗻.ᢗ릫; ; [V7]; xn--mlj0486jgl2j.xn--hbf6853f; ; ;  # ⴞ.ᢗ릫
+xn--mlj0486jgl2j.xn--hbf6853f; ⴞ𶛀𛗻.ᢗ릫; [V7]; xn--mlj0486jgl2j.xn--hbf6853f; ; ;  # ⴞ.ᢗ릫
+ⴞ𶛀𛗻．ᢗ릫; ⴞ𶛀𛗻.ᢗ릫; [V7]; xn--mlj0486jgl2j.xn--hbf6853f; ; ;  # ⴞ.ᢗ릫
+ⴞ𶛀𛗻．ᢗ릫; ⴞ𶛀𛗻.ᢗ릫; [V7]; xn--mlj0486jgl2j.xn--hbf6853f; ; ;  # ⴞ.ᢗ릫
+xn--2nd8876sgl2j.xn--hbf6853f; Ⴞ𶛀𛗻.ᢗ릫; [V7]; xn--2nd8876sgl2j.xn--hbf6853f; ; ;  # Ⴞ.ᢗ릫
+󠎃󗭞\u06B7𐹷｡≯\u200C\u1DFE; 󠎃󗭞\u06B7𐹷.≯\u200C\u1DFE; [B1, C1, V7]; xn--qkb4516kbi06fg2id.xn--zfg59fm0c; ; xn--qkb4516kbi06fg2id.xn--zfg31q; [B1, V7] # ڷ𐹷.≯᷾
+󠎃󗭞\u06B7𐹷｡>\u0338\u200C\u1DFE; 󠎃󗭞\u06B7𐹷.≯\u200C\u1DFE; [B1, C1, V7]; xn--qkb4516kbi06fg2id.xn--zfg59fm0c; ; xn--qkb4516kbi06fg2id.xn--zfg31q; [B1, V7] # ڷ𐹷.≯᷾
+󠎃󗭞\u06B7𐹷。≯\u200C\u1DFE; 󠎃󗭞\u06B7𐹷.≯\u200C\u1DFE; [B1, C1, V7]; xn--qkb4516kbi06fg2id.xn--zfg59fm0c; ; xn--qkb4516kbi06fg2id.xn--zfg31q; [B1, V7] # ڷ𐹷.≯᷾
+󠎃󗭞\u06B7𐹷。>\u0338\u200C\u1DFE; 󠎃󗭞\u06B7𐹷.≯\u200C\u1DFE; [B1, C1, V7]; xn--qkb4516kbi06fg2id.xn--zfg59fm0c; ; xn--qkb4516kbi06fg2id.xn--zfg31q; [B1, V7] # ڷ𐹷.≯᷾
+xn--qkb4516kbi06fg2id.xn--zfg31q; 󠎃󗭞\u06B7𐹷.≯\u1DFE; [B1, V7]; xn--qkb4516kbi06fg2id.xn--zfg31q; ; ;  # ڷ𐹷.≯᷾
+xn--qkb4516kbi06fg2id.xn--zfg59fm0c; 󠎃󗭞\u06B7𐹷.≯\u200C\u1DFE; [B1, C1, V7]; xn--qkb4516kbi06fg2id.xn--zfg59fm0c; ; ;  # ڷ𐹷.≯᷾
+ᛎ󠅍󠐕\u200D｡𐹾𐹪𐻝-; ᛎ󠐕\u200D.𐹾𐹪𐻝-; [B1, B6, C2, V3, V7]; xn--fxe848bq3411a.xn----q26i2bvu; ; xn--fxe63563p.xn----q26i2bvu; [B1, B6, V3, V7] # ᛎ.𐹾𐹪-
+ᛎ󠅍󠐕\u200D。𐹾𐹪𐻝-; ᛎ󠐕\u200D.𐹾𐹪𐻝-; [B1, B6, C2, V3, V7]; xn--fxe848bq3411a.xn----q26i2bvu; ; xn--fxe63563p.xn----q26i2bvu; [B1, B6, V3, V7] # ᛎ.𐹾𐹪-
+xn--fxe63563p.xn----q26i2bvu; ᛎ󠐕.𐹾𐹪𐻝-; [B1, B6, V3, V7]; xn--fxe63563p.xn----q26i2bvu; ; ;  # ᛎ.𐹾𐹪-
+xn--fxe848bq3411a.xn----q26i2bvu; ᛎ󠐕\u200D.𐹾𐹪𐻝-; [B1, B6, C2, V3, V7]; xn--fxe848bq3411a.xn----q26i2bvu; ; ;  # ᛎ.𐹾𐹪-
+𐹶.𐫂; ; [B1]; xn--uo0d.xn--rw9c; ; ;  # 𐹶.𐫂
+xn--uo0d.xn--rw9c; 𐹶.𐫂; [B1]; xn--uo0d.xn--rw9c; ; ;  # 𐹶.𐫂
+ß\u200D\u103A｡⒈; ß\u200D\u103A.⒈; [C2, V7]; xn--zca679eh2l.xn--tsh; ; xn--ss-f4j.xn--tsh; [V7] # ß်.⒈
+ß\u200D\u103A。1.; ß\u200D\u103A.1.; [C2]; xn--zca679eh2l.1.; [C2, A4_2]; xn--ss-f4j.1.; [A4_2] # ß်.1.
+SS\u200D\u103A。1.; ss\u200D\u103A.1.; [C2]; xn--ss-f4j585j.1.; [C2, A4_2]; xn--ss-f4j.1.; [A4_2] # ss်.1.
+ss\u200D\u103A。1.; ss\u200D\u103A.1.; [C2]; xn--ss-f4j585j.1.; [C2, A4_2]; xn--ss-f4j.1.; [A4_2] # ss်.1.
+Ss\u200D\u103A。1.; ss\u200D\u103A.1.; [C2]; xn--ss-f4j585j.1.; [C2, A4_2]; xn--ss-f4j.1.; [A4_2] # ss်.1.
+xn--ss-f4j.b.; ss\u103A.b.; ; xn--ss-f4j.b.; [A4_2]; ;  # ss်.b.
+ss\u103A.b.; ; ; xn--ss-f4j.b.; [A4_2]; ;  # ss်.b.
+SS\u103A.B.; ss\u103A.b.; ; xn--ss-f4j.b.; [A4_2]; ;  # ss်.b.
+Ss\u103A.b.; ss\u103A.b.; ; xn--ss-f4j.b.; [A4_2]; ;  # ss်.b.
+xn--ss-f4j585j.b.; ss\u200D\u103A.b.; [C2]; xn--ss-f4j585j.b.; [C2, A4_2]; ;  # ss်.b.
+xn--zca679eh2l.b.; ß\u200D\u103A.b.; [C2]; xn--zca679eh2l.b.; [C2, A4_2]; ;  # ß်.b.
+SS\u200D\u103A｡⒈; ss\u200D\u103A.⒈; [C2, V7]; xn--ss-f4j585j.xn--tsh; ; xn--ss-f4j.xn--tsh; [V7] # ss်.⒈
+ss\u200D\u103A｡⒈; ss\u200D\u103A.⒈; [C2, V7]; xn--ss-f4j585j.xn--tsh; ; xn--ss-f4j.xn--tsh; [V7] # ss်.⒈
+Ss\u200D\u103A｡⒈; ss\u200D\u103A.⒈; [C2, V7]; xn--ss-f4j585j.xn--tsh; ; xn--ss-f4j.xn--tsh; [V7] # ss်.⒈
+xn--ss-f4j.xn--tsh; ss\u103A.⒈; [V7]; xn--ss-f4j.xn--tsh; ; ;  # ss်.⒈
+xn--ss-f4j585j.xn--tsh; ss\u200D\u103A.⒈; [C2, V7]; xn--ss-f4j585j.xn--tsh; ; ;  # ss်.⒈
+xn--zca679eh2l.xn--tsh; ß\u200D\u103A.⒈; [C2, V7]; xn--zca679eh2l.xn--tsh; ; ;  # ß်.⒈
+SS\u103A.b.; ss\u103A.b.; ; xn--ss-f4j.b.; [A4_2]; ;  # ss်.b.
+\u0B4D\u200C𙶵𞻘。\u200D; \u0B4D\u200C𙶵𞻘.\u200D; [B1, C2, V6, V7]; xn--9ic637hz82z32jc.xn--1ug; ; xn--9ic6417rn4xb.; [B1, V6, V7, A4_2] # ୍.
+xn--9ic6417rn4xb.; \u0B4D𙶵𞻘.; [B1, V6, V7]; xn--9ic6417rn4xb.; [B1, V6, V7, A4_2]; ;  # ୍.
+xn--9ic637hz82z32jc.xn--1ug; \u0B4D\u200C𙶵𞻘.\u200D; [B1, C2, V6, V7]; xn--9ic637hz82z32jc.xn--1ug; ; ;  # ୍.
+𐮅｡\u06BC🁕; 𐮅.\u06BC🁕; [B3]; xn--c29c.xn--vkb8871w; ; ;  # 𐮅.ڼ🁕
+𐮅。\u06BC🁕; 𐮅.\u06BC🁕; [B3]; xn--c29c.xn--vkb8871w; ; ;  # 𐮅.ڼ🁕
+xn--c29c.xn--vkb8871w; 𐮅.\u06BC🁕; [B3]; xn--c29c.xn--vkb8871w; ; ;  # 𐮅.ڼ🁕
+\u0620\u17D2。𐫔󠀧\u200C𑈵; \u0620\u17D2.𐫔󠀧\u200C𑈵; [B2, B3, C1, V7]; xn--fgb471g.xn--0ug9853g7verp838a; ; xn--fgb471g.xn--9w9c29jw3931a; [B2, B3, V7] # ؠ្.𐫔𑈵
+xn--fgb471g.xn--9w9c29jw3931a; \u0620\u17D2.𐫔󠀧𑈵; [B2, B3, V7]; xn--fgb471g.xn--9w9c29jw3931a; ; ;  # ؠ្.𐫔𑈵
+xn--fgb471g.xn--0ug9853g7verp838a; \u0620\u17D2.𐫔󠀧\u200C𑈵; [B2, B3, C1, V7]; xn--fgb471g.xn--0ug9853g7verp838a; ; ;  # ؠ្.𐫔𑈵
+񋉕.𞣕𞤊; 񋉕.𞣕𞤬; [B1, V6, V7]; xn--tf5w.xn--2b6hof; ; ;  # .𞣕𞤬
+񋉕.𞣕𞤬; ; [B1, V6, V7]; xn--tf5w.xn--2b6hof; ; ;  # .𞣕𞤬
+xn--tf5w.xn--2b6hof; 񋉕.𞣕𞤬; [B1, V6, V7]; xn--tf5w.xn--2b6hof; ; ;  # .𞣕𞤬
+\u06CC𐨿．ß\u0F84𑍬; \u06CC𐨿.ß\u0F84𑍬; ; xn--clb2593k.xn--zca216edt0r; ; xn--clb2593k.xn--ss-toj6092t;  # ی𐨿.ß྄𑍬
+\u06CC𐨿.ß\u0F84𑍬; ; ; xn--clb2593k.xn--zca216edt0r; ; xn--clb2593k.xn--ss-toj6092t;  # ی𐨿.ß྄𑍬
+\u06CC𐨿.SS\u0F84𑍬; \u06CC𐨿.ss\u0F84𑍬; ; xn--clb2593k.xn--ss-toj6092t; ; ;  # ی𐨿.ss྄𑍬
+\u06CC𐨿.ss\u0F84𑍬; ; ; xn--clb2593k.xn--ss-toj6092t; ; ;  # ی𐨿.ss྄𑍬
+xn--clb2593k.xn--ss-toj6092t; \u06CC𐨿.ss\u0F84𑍬; ; xn--clb2593k.xn--ss-toj6092t; ; ;  # ی𐨿.ss྄𑍬
+xn--clb2593k.xn--zca216edt0r; \u06CC𐨿.ß\u0F84𑍬; ; xn--clb2593k.xn--zca216edt0r; ; ;  # ی𐨿.ß྄𑍬
+\u06CC𐨿．SS\u0F84𑍬; \u06CC𐨿.ss\u0F84𑍬; ; xn--clb2593k.xn--ss-toj6092t; ; ;  # ی𐨿.ss྄𑍬
+\u06CC𐨿．ss\u0F84𑍬; \u06CC𐨿.ss\u0F84𑍬; ; xn--clb2593k.xn--ss-toj6092t; ; ;  # ی𐨿.ss྄𑍬
+\u06CC𐨿.Ss\u0F84𑍬; \u06CC𐨿.ss\u0F84𑍬; ; xn--clb2593k.xn--ss-toj6092t; ; ;  # ی𐨿.ss྄𑍬
+\u06CC𐨿．Ss\u0F84𑍬; \u06CC𐨿.ss\u0F84𑍬; ; xn--clb2593k.xn--ss-toj6092t; ; ;  # ی𐨿.ss྄𑍬
+𝟠≮\u200C｡󠅱\u17B4; 8≮\u200C.; [C1]; xn--8-sgn10i.; [C1, A4_2]; xn--8-ngo.; [A4_2] # 8≮.
+𝟠<\u0338\u200C｡󠅱\u17B4; 8≮\u200C.; [C1]; xn--8-sgn10i.; [C1, A4_2]; xn--8-ngo.; [A4_2] # 8≮.
+8≮\u200C。󠅱\u17B4; 8≮\u200C.; [C1]; xn--8-sgn10i.; [C1, A4_2]; xn--8-ngo.; [A4_2] # 8≮.
+8<\u0338\u200C。󠅱\u17B4; 8≮\u200C.; [C1]; xn--8-sgn10i.; [C1, A4_2]; xn--8-ngo.; [A4_2] # 8≮.
+xn--8-ngo.; 8≮.; ; xn--8-ngo.; [A4_2]; ;  # 8≮.
+8≮.; ; ; xn--8-ngo.; [A4_2]; ;  # 8≮.
+8<\u0338.; 8≮.; ; xn--8-ngo.; [A4_2]; ;  # 8≮.
+xn--8-sgn10i.; 8≮\u200C.; [C1]; xn--8-sgn10i.; [C1, A4_2]; ;  # 8≮.
+xn--8-ngo.xn--z3e; 8≮.\u17B4; [V6, V7]; xn--8-ngo.xn--z3e; ; ;  # 8≮.
+xn--8-sgn10i.xn--z3e; 8≮\u200C.\u17B4; [C1, V6, V7]; xn--8-sgn10i.xn--z3e; ; ;  # 8≮.
+ᢕ≯︒񄂯．Ⴀ; ᢕ≯︒񄂯.ⴀ; [V7]; xn--fbf851cq98poxw1a.xn--rkj; ; ;  # ᢕ≯︒.ⴀ
+ᢕ>\u0338︒񄂯．Ⴀ; ᢕ≯︒񄂯.ⴀ; [V7]; xn--fbf851cq98poxw1a.xn--rkj; ; ;  # ᢕ≯︒.ⴀ
+ᢕ≯。񄂯.Ⴀ; ᢕ≯.񄂯.ⴀ; [V7]; xn--fbf851c.xn--ko1u.xn--rkj; ; ;  # ᢕ≯..ⴀ
+ᢕ>\u0338。񄂯.Ⴀ; ᢕ≯.񄂯.ⴀ; [V7]; xn--fbf851c.xn--ko1u.xn--rkj; ; ;  # ᢕ≯..ⴀ
+ᢕ>\u0338。񄂯.ⴀ; ᢕ≯.񄂯.ⴀ; [V7]; xn--fbf851c.xn--ko1u.xn--rkj; ; ;  # ᢕ≯..ⴀ
+ᢕ≯。񄂯.ⴀ; ᢕ≯.񄂯.ⴀ; [V7]; xn--fbf851c.xn--ko1u.xn--rkj; ; ;  # ᢕ≯..ⴀ
+xn--fbf851c.xn--ko1u.xn--rkj; ᢕ≯.񄂯.ⴀ; [V7]; xn--fbf851c.xn--ko1u.xn--rkj; ; ;  # ᢕ≯..ⴀ
+ᢕ>\u0338︒񄂯．ⴀ; ᢕ≯︒񄂯.ⴀ; [V7]; xn--fbf851cq98poxw1a.xn--rkj; ; ;  # ᢕ≯︒.ⴀ
+ᢕ≯︒񄂯．ⴀ; ᢕ≯︒񄂯.ⴀ; [V7]; xn--fbf851cq98poxw1a.xn--rkj; ; ;  # ᢕ≯︒.ⴀ
+xn--fbf851cq98poxw1a.xn--rkj; ᢕ≯︒񄂯.ⴀ; [V7]; xn--fbf851cq98poxw1a.xn--rkj; ; ;  # ᢕ≯︒.ⴀ
+xn--fbf851c.xn--ko1u.xn--7md; ᢕ≯.񄂯.Ⴀ; [V7]; xn--fbf851c.xn--ko1u.xn--7md; ; ;  # ᢕ≯..Ⴀ
+xn--fbf851cq98poxw1a.xn--7md; ᢕ≯︒񄂯.Ⴀ; [V7]; xn--fbf851cq98poxw1a.xn--7md; ; ;  # ᢕ≯︒.Ⴀ
+\u0F9F．-\u082A; \u0F9F.-\u082A; [V3, V6]; xn--vfd.xn----fhd; ; ;  # ྟ.-ࠪ
+\u0F9F.-\u082A; ; [V3, V6]; xn--vfd.xn----fhd; ; ;  # ྟ.-ࠪ
+xn--vfd.xn----fhd; \u0F9F.-\u082A; [V3, V6]; xn--vfd.xn----fhd; ; ;  # ྟ.-ࠪ
+ᵬ󠆠．핒⒒⒈􈄦; ᵬ.핒⒒⒈􈄦; [V7]; xn--tbg.xn--tsht7586kyts9l; ; ;  # ᵬ.핒⒒⒈
+ᵬ󠆠．핒⒒⒈􈄦; ᵬ.핒⒒⒈􈄦; [V7]; xn--tbg.xn--tsht7586kyts9l; ; ;  # ᵬ.핒⒒⒈
+ᵬ󠆠.핒11.1.􈄦; ᵬ.핒11.1.􈄦; [V7]; xn--tbg.xn--11-5o7k.1.xn--k469f; ; ;  # ᵬ.핒11.1.
+ᵬ󠆠.핒11.1.􈄦; ᵬ.핒11.1.􈄦; [V7]; xn--tbg.xn--11-5o7k.1.xn--k469f; ; ;  # ᵬ.핒11.1.
+xn--tbg.xn--11-5o7k.1.xn--k469f; ᵬ.핒11.1.􈄦; [V7]; xn--tbg.xn--11-5o7k.1.xn--k469f; ; ;  # ᵬ.핒11.1.
+xn--tbg.xn--tsht7586kyts9l; ᵬ.핒⒒⒈􈄦; [V7]; xn--tbg.xn--tsht7586kyts9l; ; ;  # ᵬ.핒⒒⒈
+ς𑓂𐋢．\u0668; ς𑓂𐋢.\u0668; [B1]; xn--3xa8371khhl.xn--hib; ; xn--4xa6371khhl.xn--hib;  # ς𑓂𐋢.٨
+ς𑓂𐋢.\u0668; ; [B1]; xn--3xa8371khhl.xn--hib; ; xn--4xa6371khhl.xn--hib;  # ς𑓂𐋢.٨
+Σ𑓂𐋢.\u0668; σ𑓂𐋢.\u0668; [B1]; xn--4xa6371khhl.xn--hib; ; ;  # σ𑓂𐋢.٨
+σ𑓂𐋢.\u0668; ; [B1]; xn--4xa6371khhl.xn--hib; ; ;  # σ𑓂𐋢.٨
+xn--4xa6371khhl.xn--hib; σ𑓂𐋢.\u0668; [B1]; xn--4xa6371khhl.xn--hib; ; ;  # σ𑓂𐋢.٨
+xn--3xa8371khhl.xn--hib; ς𑓂𐋢.\u0668; [B1]; xn--3xa8371khhl.xn--hib; ; ;  # ς𑓂𐋢.٨
+Σ𑓂𐋢．\u0668; σ𑓂𐋢.\u0668; [B1]; xn--4xa6371khhl.xn--hib; ; ;  # σ𑓂𐋢.٨
+σ𑓂𐋢．\u0668; σ𑓂𐋢.\u0668; [B1]; xn--4xa6371khhl.xn--hib; ; ;  # σ𑓂𐋢.٨
+\uA953\u200C𐋻\u200D.\u2DF8𞿄𐹲; ; [B1, B6, C2, V6, V7]; xn--0ugc8356he76c.xn--urju692efj0f; ; xn--3j9a531o.xn--urju692efj0f; [B1, V6, V7] # ꥓𐋻.ⷸ𐹲
+xn--3j9a531o.xn--urju692efj0f; \uA953𐋻.\u2DF8𞿄𐹲; [B1, V6, V7]; xn--3j9a531o.xn--urju692efj0f; ; ;  # ꥓𐋻.ⷸ𐹲
+xn--0ugc8356he76c.xn--urju692efj0f; \uA953\u200C𐋻\u200D.\u2DF8𞿄𐹲; [B1, B6, C2, V6, V7]; xn--0ugc8356he76c.xn--urju692efj0f; ; ;  # ꥓𐋻.ⷸ𐹲
+⊼。񪧖\u0695; ⊼.񪧖\u0695; [B1, B5, B6, V7]; xn--ofh.xn--rjb13118f; ; ;  # ⊼.ڕ
+xn--ofh.xn--rjb13118f; ⊼.񪧖\u0695; [B1, B5, B6, V7]; xn--ofh.xn--rjb13118f; ; ;  # ⊼.ڕ
+𐯬񖋔。󜳥; 𐯬񖋔.󜳥; [B2, B3, V7]; xn--949co370q.xn--7g25e; ; ;  # .
+xn--949co370q.xn--7g25e; 𐯬񖋔.󜳥; [B2, B3, V7]; xn--949co370q.xn--7g25e; ; ;  # .
+\u0601𑍧\u07DD。ς򬍘🀞\u17B5; \u0601𑍧\u07DD.ς򬍘🀞; [B1, B6, V7]; xn--jfb66gt010c.xn--3xa2023w4nq4c; ; xn--jfb66gt010c.xn--4xa0023w4nq4c;  # 𑍧ߝ.ς🀞
+\u0601𑍧\u07DD。Σ򬍘🀞\u17B5; \u0601𑍧\u07DD.σ򬍘🀞; [B1, B6, V7]; xn--jfb66gt010c.xn--4xa0023w4nq4c; ; ;  # 𑍧ߝ.σ🀞
+\u0601𑍧\u07DD。σ򬍘🀞\u17B5; \u0601𑍧\u07DD.σ򬍘🀞; [B1, B6, V7]; xn--jfb66gt010c.xn--4xa0023w4nq4c; ; ;  # 𑍧ߝ.σ🀞
+xn--jfb66gt010c.xn--4xa0023w4nq4c; \u0601𑍧\u07DD.σ򬍘🀞; [B1, B6, V7]; xn--jfb66gt010c.xn--4xa0023w4nq4c; ; ;  # 𑍧ߝ.σ🀞
+xn--jfb66gt010c.xn--3xa2023w4nq4c; \u0601𑍧\u07DD.ς򬍘🀞; [B1, B6, V7]; xn--jfb66gt010c.xn--3xa2023w4nq4c; ; ;  # 𑍧ߝ.ς🀞
+xn--jfb66gt010c.xn--4xa623h9p95ars26d; \u0601𑍧\u07DD.σ򬍘🀞\u17B5; [B1, B6, V7]; xn--jfb66gt010c.xn--4xa623h9p95ars26d; ; ;  # 𑍧ߝ.σ🀞
+xn--jfb66gt010c.xn--3xa823h9p95ars26d; \u0601𑍧\u07DD.ς򬍘🀞\u17B5; [B1, B6, V7]; xn--jfb66gt010c.xn--3xa823h9p95ars26d; ; ;  # 𑍧ߝ.ς🀞
+-𐳲\u0646󠺐。\uABED𝟥; -𐳲\u0646󠺐.\uABED3; [B1, V3, V6, V7]; xn----roc5482rek10i.xn--3-zw5e; ; ;  # -𐳲ن.꯭3
+-𐳲\u0646󠺐。\uABED3; -𐳲\u0646󠺐.\uABED3; [B1, V3, V6, V7]; xn----roc5482rek10i.xn--3-zw5e; ; ;  # -𐳲ن.꯭3
+-𐲲\u0646󠺐。\uABED3; -𐳲\u0646󠺐.\uABED3; [B1, V3, V6, V7]; xn----roc5482rek10i.xn--3-zw5e; ; ;  # -𐳲ن.꯭3
+xn----roc5482rek10i.xn--3-zw5e; -𐳲\u0646󠺐.\uABED3; [B1, V3, V6, V7]; xn----roc5482rek10i.xn--3-zw5e; ; ;  # -𐳲ن.꯭3
+-𐲲\u0646󠺐。\uABED𝟥; -𐳲\u0646󠺐.\uABED3; [B1, V3, V6, V7]; xn----roc5482rek10i.xn--3-zw5e; ; ;  # -𐳲ن.꯭3
+\u200C󠴦｡񲨕≮𐦜; \u200C󠴦.񲨕≮𐦜; [B1, B5, B6, C1, V7]; xn--0ug22251l.xn--gdhz712gzlr6b; ; xn--6v56e.xn--gdhz712gzlr6b; [B1, B5, B6, V7] # .≮𐦜
+\u200C󠴦｡񲨕<\u0338𐦜; \u200C󠴦.񲨕≮𐦜; [B1, B5, B6, C1, V7]; xn--0ug22251l.xn--gdhz712gzlr6b; ; xn--6v56e.xn--gdhz712gzlr6b; [B1, B5, B6, V7] # .≮𐦜
+\u200C󠴦。񲨕≮𐦜; \u200C󠴦.񲨕≮𐦜; [B1, B5, B6, C1, V7]; xn--0ug22251l.xn--gdhz712gzlr6b; ; xn--6v56e.xn--gdhz712gzlr6b; [B1, B5, B6, V7] # .≮𐦜
+\u200C󠴦。񲨕<\u0338𐦜; \u200C󠴦.񲨕≮𐦜; [B1, B5, B6, C1, V7]; xn--0ug22251l.xn--gdhz712gzlr6b; ; xn--6v56e.xn--gdhz712gzlr6b; [B1, B5, B6, V7] # .≮𐦜
+xn--6v56e.xn--gdhz712gzlr6b; 󠴦.񲨕≮𐦜; [B1, B5, B6, V7]; xn--6v56e.xn--gdhz712gzlr6b; ; ;  # .≮𐦜
+xn--0ug22251l.xn--gdhz712gzlr6b; \u200C󠴦.񲨕≮𐦜; [B1, B5, B6, C1, V7]; xn--0ug22251l.xn--gdhz712gzlr6b; ; ;  # .≮𐦜
+⒈✌򟬟．𝟡񠱣; ⒈✌򟬟.9񠱣; [V7]; xn--tsh24g49550b.xn--9-o706d; ; ;  # ⒈✌.9
+1.✌򟬟.9񠱣; ; [V7]; 1.xn--7bi44996f.xn--9-o706d; ; ;  # 1.✌.9
+1.xn--7bi44996f.xn--9-o706d; 1.✌򟬟.9񠱣; [V7]; 1.xn--7bi44996f.xn--9-o706d; ; ;  # 1.✌.9
+xn--tsh24g49550b.xn--9-o706d; ⒈✌򟬟.9񠱣; [V7]; xn--tsh24g49550b.xn--9-o706d; ; ;  # ⒈✌.9
+𑆾𞤬𐮆.\u0666\u1DD4; ; [B1, V6]; xn--d29c79hf98r.xn--fib011j; ; ;  # 𑆾𞤬𐮆.٦ᷔ
+𑆾𞤊𐮆.\u0666\u1DD4; 𑆾𞤬𐮆.\u0666\u1DD4; [B1, V6]; xn--d29c79hf98r.xn--fib011j; ; ;  # 𑆾𞤬𐮆.٦ᷔ
+xn--d29c79hf98r.xn--fib011j; 𑆾𞤬𐮆.\u0666\u1DD4; [B1, V6]; xn--d29c79hf98r.xn--fib011j; ; ;  # 𑆾𞤬𐮆.٦ᷔ
+ς．\uA9C0\uA8C4; ς.\uA9C0\uA8C4; [V6]; xn--3xa.xn--0f9ars; ; xn--4xa.xn--0f9ars;  # ς.꧀꣄
+ς.\uA9C0\uA8C4; ; [V6]; xn--3xa.xn--0f9ars; ; xn--4xa.xn--0f9ars;  # ς.꧀꣄
+Σ.\uA9C0\uA8C4; σ.\uA9C0\uA8C4; [V6]; xn--4xa.xn--0f9ars; ; ;  # σ.꧀꣄
+σ.\uA9C0\uA8C4; ; [V6]; xn--4xa.xn--0f9ars; ; ;  # σ.꧀꣄
+xn--4xa.xn--0f9ars; σ.\uA9C0\uA8C4; [V6]; xn--4xa.xn--0f9ars; ; ;  # σ.꧀꣄
+xn--3xa.xn--0f9ars; ς.\uA9C0\uA8C4; [V6]; xn--3xa.xn--0f9ars; ; ;  # ς.꧀꣄
+Σ．\uA9C0\uA8C4; σ.\uA9C0\uA8C4; [V6]; xn--4xa.xn--0f9ars; ; ;  # σ.꧀꣄
+σ．\uA9C0\uA8C4; σ.\uA9C0\uA8C4; [V6]; xn--4xa.xn--0f9ars; ; ;  # σ.꧀꣄
+𑰶\u200C≯𐳐．\u085B; 𑰶\u200C≯𐳐.\u085B; [B1, C1, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, V6] # 𑰶≯𐳐.࡛
+𑰶\u200C>\u0338𐳐．\u085B; 𑰶\u200C≯𐳐.\u085B; [B1, C1, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, V6] # 𑰶≯𐳐.࡛
+𑰶\u200C≯𐳐.\u085B; ; [B1, C1, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, V6] # 𑰶≯𐳐.࡛
+𑰶\u200C>\u0338𐳐.\u085B; 𑰶\u200C≯𐳐.\u085B; [B1, C1, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, V6] # 𑰶≯𐳐.࡛
+𑰶\u200C>\u0338𐲐.\u085B; 𑰶\u200C≯𐳐.\u085B; [B1, C1, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, V6] # 𑰶≯𐳐.࡛
+𑰶\u200C≯𐲐.\u085B; 𑰶\u200C≯𐳐.\u085B; [B1, C1, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, V6] # 𑰶≯𐳐.࡛
+xn--hdhz343g3wj.xn--qwb; 𑰶≯𐳐.\u085B; [B1, V6]; xn--hdhz343g3wj.xn--qwb; ; ;  # 𑰶≯𐳐.࡛
+xn--0ug06g7697ap4ma.xn--qwb; 𑰶\u200C≯𐳐.\u085B; [B1, C1, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; ;  # 𑰶≯𐳐.࡛
+𑰶\u200C>\u0338𐲐．\u085B; 𑰶\u200C≯𐳐.\u085B; [B1, C1, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, V6] # 𑰶≯𐳐.࡛
+𑰶\u200C≯𐲐．\u085B; 𑰶\u200C≯𐳐.\u085B; [B1, C1, V6]; xn--0ug06g7697ap4ma.xn--qwb; ; xn--hdhz343g3wj.xn--qwb; [B1, V6] # 𑰶≯𐳐.࡛
+羚｡≯; 羚.≯; ; xn--xt0a.xn--hdh; ; ;  # 羚.≯
+羚｡>\u0338; 羚.≯; ; xn--xt0a.xn--hdh; ; ;  # 羚.≯
+羚。≯; 羚.≯; ; xn--xt0a.xn--hdh; ; ;  # 羚.≯
+羚。>\u0338; 羚.≯; ; xn--xt0a.xn--hdh; ; ;  # 羚.≯
+xn--xt0a.xn--hdh; 羚.≯; ; xn--xt0a.xn--hdh; ; ;  # 羚.≯
+羚.≯; ; ; xn--xt0a.xn--hdh; ; ;  # 羚.≯
+羚.>\u0338; 羚.≯; ; xn--xt0a.xn--hdh; ; ;  # 羚.≯
+𑓂\u1759．\u08A8; 𑓂\u1759.\u08A8; [B1, V6, V7]; xn--e1e9580k.xn--xyb; ; ;  # 𑓂.ࢨ
+𑓂\u1759.\u08A8; ; [B1, V6, V7]; xn--e1e9580k.xn--xyb; ; ;  # 𑓂.ࢨ
+xn--e1e9580k.xn--xyb; 𑓂\u1759.\u08A8; [B1, V6, V7]; xn--e1e9580k.xn--xyb; ; ;  # 𑓂.ࢨ
+󨣿󠇀\u200D｡\u0663ҠჀ𝟑; 󨣿\u200D.\u0663ҡⴠ3; [B1, B6, C2, V7]; xn--1ug89936l.xn--3-ozb36ko13f; ; xn--1r19e.xn--3-ozb36ko13f; [B1, V7] # .٣ҡⴠ3
+󨣿󠇀\u200D。\u0663ҠჀ3; 󨣿\u200D.\u0663ҡⴠ3; [B1, B6, C2, V7]; xn--1ug89936l.xn--3-ozb36ko13f; ; xn--1r19e.xn--3-ozb36ko13f; [B1, V7] # .٣ҡⴠ3
+󨣿󠇀\u200D。\u0663ҡⴠ3; 󨣿\u200D.\u0663ҡⴠ3; [B1, B6, C2, V7]; xn--1ug89936l.xn--3-ozb36ko13f; ; xn--1r19e.xn--3-ozb36ko13f; [B1, V7] # .٣ҡⴠ3
+xn--1r19e.xn--3-ozb36ko13f; 󨣿.\u0663ҡⴠ3; [B1, V7]; xn--1r19e.xn--3-ozb36ko13f; ; ;  # .٣ҡⴠ3
+xn--1ug89936l.xn--3-ozb36ko13f; 󨣿\u200D.\u0663ҡⴠ3; [B1, B6, C2, V7]; xn--1ug89936l.xn--3-ozb36ko13f; ; ;  # .٣ҡⴠ3
+󨣿󠇀\u200D｡\u0663ҡⴠ𝟑; 󨣿\u200D.\u0663ҡⴠ3; [B1, B6, C2, V7]; xn--1ug89936l.xn--3-ozb36ko13f; ; xn--1r19e.xn--3-ozb36ko13f; [B1, V7] # .٣ҡⴠ3
+xn--1r19e.xn--3-ozb36kixu; 󨣿.\u0663ҡჀ3; [B1, V7]; xn--1r19e.xn--3-ozb36kixu; ; ;  # .٣ҡჀ3
+xn--1ug89936l.xn--3-ozb36kixu; 󨣿\u200D.\u0663ҡჀ3; [B1, B6, C2, V7]; xn--1ug89936l.xn--3-ozb36kixu; ; ;  # .٣ҡჀ3
+󨣿󠇀\u200D。\u0663Ҡⴠ3; 󨣿\u200D.\u0663ҡⴠ3; [B1, B6, C2, V7]; xn--1ug89936l.xn--3-ozb36ko13f; ; xn--1r19e.xn--3-ozb36ko13f; [B1, V7] # .٣ҡⴠ3
+󨣿󠇀\u200D｡\u0663Ҡⴠ𝟑; 󨣿\u200D.\u0663ҡⴠ3; [B1, B6, C2, V7]; xn--1ug89936l.xn--3-ozb36ko13f; ; xn--1r19e.xn--3-ozb36ko13f; [B1, V7] # .٣ҡⴠ3
+ᡷ。𐹢\u08E0; ᡷ.𐹢\u08E0; [B1]; xn--k9e.xn--j0b5005k; ; ;  # ᡷ.𐹢࣠
+xn--k9e.xn--j0b5005k; ᡷ.𐹢\u08E0; [B1]; xn--k9e.xn--j0b5005k; ; ;  # ᡷ.𐹢࣠
+򕮇\u1BF3｡\u0666񗜼\u17D2ß; 򕮇\u1BF3.\u0666񗜼\u17D2ß; [B1, V7]; xn--1zf58212h.xn--zca34zk4qx711k; ; xn--1zf58212h.xn--ss-pyd459o3258m;  # ᯳.٦្ß
+򕮇\u1BF3。\u0666񗜼\u17D2ß; 򕮇\u1BF3.\u0666񗜼\u17D2ß; [B1, V7]; xn--1zf58212h.xn--zca34zk4qx711k; ; xn--1zf58212h.xn--ss-pyd459o3258m;  # ᯳.٦្ß
+򕮇\u1BF3。\u0666񗜼\u17D2SS; 򕮇\u1BF3.\u0666񗜼\u17D2ss; [B1, V7]; xn--1zf58212h.xn--ss-pyd459o3258m; ; ;  # ᯳.٦្ss
+򕮇\u1BF3。\u0666񗜼\u17D2ss; 򕮇\u1BF3.\u0666񗜼\u17D2ss; [B1, V7]; xn--1zf58212h.xn--ss-pyd459o3258m; ; ;  # ᯳.٦្ss
+򕮇\u1BF3。\u0666񗜼\u17D2Ss; 򕮇\u1BF3.\u0666񗜼\u17D2ss; [B1, V7]; xn--1zf58212h.xn--ss-pyd459o3258m; ; ;  # ᯳.٦្ss
+xn--1zf58212h.xn--ss-pyd459o3258m; 򕮇\u1BF3.\u0666񗜼\u17D2ss; [B1, V7]; xn--1zf58212h.xn--ss-pyd459o3258m; ; ;  # ᯳.٦្ss
+xn--1zf58212h.xn--zca34zk4qx711k; 򕮇\u1BF3.\u0666񗜼\u17D2ß; [B1, V7]; xn--1zf58212h.xn--zca34zk4qx711k; ; ;  # ᯳.٦្ß
+򕮇\u1BF3｡\u0666񗜼\u17D2SS; 򕮇\u1BF3.\u0666񗜼\u17D2ss; [B1, V7]; xn--1zf58212h.xn--ss-pyd459o3258m; ; ;  # ᯳.٦្ss
+򕮇\u1BF3｡\u0666񗜼\u17D2ss; 򕮇\u1BF3.\u0666񗜼\u17D2ss; [B1, V7]; xn--1zf58212h.xn--ss-pyd459o3258m; ; ;  # ᯳.٦្ss
+򕮇\u1BF3｡\u0666񗜼\u17D2Ss; 򕮇\u1BF3.\u0666񗜼\u17D2ss; [B1, V7]; xn--1zf58212h.xn--ss-pyd459o3258m; ; ;  # ᯳.٦្ss
+\u0664򤽎𑲛.󠔢︒≠; ; [B1, V7]; xn--dib0653l2i02d.xn--1ch7467f14u4g; ; ;  # ٤𑲛.︒≠
+\u0664򤽎𑲛.󠔢︒=\u0338; \u0664򤽎𑲛.󠔢︒≠; [B1, V7]; xn--dib0653l2i02d.xn--1ch7467f14u4g; ; ;  # ٤𑲛.︒≠
+\u0664򤽎𑲛.󠔢。≠; \u0664򤽎𑲛.󠔢.≠; [B1, V7]; xn--dib0653l2i02d.xn--k736e.xn--1ch; ; ;  # ٤𑲛..≠
+\u0664򤽎𑲛.󠔢。=\u0338; \u0664򤽎𑲛.󠔢.≠; [B1, V7]; xn--dib0653l2i02d.xn--k736e.xn--1ch; ; ;  # ٤𑲛..≠
+xn--dib0653l2i02d.xn--k736e.xn--1ch; \u0664򤽎𑲛.󠔢.≠; [B1, V7]; xn--dib0653l2i02d.xn--k736e.xn--1ch; ; ;  # ٤𑲛..≠
+xn--dib0653l2i02d.xn--1ch7467f14u4g; \u0664򤽎𑲛.󠔢︒≠; [B1, V7]; xn--dib0653l2i02d.xn--1ch7467f14u4g; ; ;  # ٤𑲛.︒≠
+➆񷧕ỗ⒈．򑬒񡘮\u085B𝟫; ➆񷧕ỗ⒈.򑬒񡘮\u085B9; [V7]; xn--6lg26tvvc6v99z.xn--9-6jd87310jtcqs; ; ;  # ➆ỗ⒈.࡛9
+➆񷧕o\u0302\u0303⒈．򑬒񡘮\u085B𝟫; ➆񷧕ỗ⒈.򑬒񡘮\u085B9; [V7]; xn--6lg26tvvc6v99z.xn--9-6jd87310jtcqs; ; ;  # ➆ỗ⒈.࡛9
+➆񷧕ỗ1..򑬒񡘮\u085B9; ; [V7, X4_2]; xn--1-3xm292b6044r..xn--9-6jd87310jtcqs; [V7, A4_2]; ;  # ➆ỗ1..࡛9
+➆񷧕o\u0302\u03031..򑬒񡘮\u085B9; ➆񷧕ỗ1..򑬒񡘮\u085B9; [V7, X4_2]; xn--1-3xm292b6044r..xn--9-6jd87310jtcqs; [V7, A4_2]; ;  # ➆ỗ1..࡛9
+➆񷧕O\u0302\u03031..򑬒񡘮\u085B9; ➆񷧕ỗ1..򑬒񡘮\u085B9; [V7, X4_2]; xn--1-3xm292b6044r..xn--9-6jd87310jtcqs; [V7, A4_2]; ;  # ➆ỗ1..࡛9
+➆񷧕Ỗ1..򑬒񡘮\u085B9; ➆񷧕ỗ1..򑬒񡘮\u085B9; [V7, X4_2]; xn--1-3xm292b6044r..xn--9-6jd87310jtcqs; [V7, A4_2]; ;  # ➆ỗ1..࡛9
+xn--1-3xm292b6044r..xn--9-6jd87310jtcqs; ➆񷧕ỗ1..򑬒񡘮\u085B9; [V7, X4_2]; xn--1-3xm292b6044r..xn--9-6jd87310jtcqs; [V7, A4_2]; ;  # ➆ỗ1..࡛9
+➆񷧕O\u0302\u0303⒈．򑬒񡘮\u085B𝟫; ➆񷧕ỗ⒈.򑬒񡘮\u085B9; [V7]; xn--6lg26tvvc6v99z.xn--9-6jd87310jtcqs; ; ;  # ➆ỗ⒈.࡛9
+➆񷧕Ỗ⒈．򑬒񡘮\u085B𝟫; ➆񷧕ỗ⒈.򑬒񡘮\u085B9; [V7]; xn--6lg26tvvc6v99z.xn--9-6jd87310jtcqs; ; ;  # ➆ỗ⒈.࡛9
+xn--6lg26tvvc6v99z.xn--9-6jd87310jtcqs; ➆񷧕ỗ⒈.򑬒񡘮\u085B9; [V7]; xn--6lg26tvvc6v99z.xn--9-6jd87310jtcqs; ; ;  # ➆ỗ⒈.࡛9
+\u200D｡𞤘; \u200D.𞤺; [B1, C2]; xn--1ug.xn--ye6h; ; .xn--ye6h; [A4_2] # .𞤺
+\u200D。𞤘; \u200D.𞤺; [B1, C2]; xn--1ug.xn--ye6h; ; .xn--ye6h; [A4_2] # .𞤺
+\u200D。𞤺; \u200D.𞤺; [B1, C2]; xn--1ug.xn--ye6h; ; .xn--ye6h; [A4_2] # .𞤺
+.xn--ye6h; .𞤺; [X4_2]; .xn--ye6h; [A4_2]; ;  # .𞤺
+xn--1ug.xn--ye6h; \u200D.𞤺; [B1, C2]; xn--1ug.xn--ye6h; ; ;  # .𞤺
+\u200D｡𞤺; \u200D.𞤺; [B1, C2]; xn--1ug.xn--ye6h; ; .xn--ye6h; [A4_2] # .𞤺
+xn--ye6h; 𞤺; ; xn--ye6h; ; ;  # 𞤺
+𞤺; ; ; xn--ye6h; ; ;  # 𞤺
+𞤘; 𞤺; ; xn--ye6h; ; ;  # 𞤺
+\u0829\u0724.ᢣ; ; [B1, V6]; xn--unb53c.xn--tbf; ; ;  # ࠩܤ.ᢣ
+xn--unb53c.xn--tbf; \u0829\u0724.ᢣ; [B1, V6]; xn--unb53c.xn--tbf; ; ;  # ࠩܤ.ᢣ
+\u073C\u200C-。𓐾ß; \u073C\u200C-.𓐾ß; [C1, V3, V6, V7]; xn----s2c071q.xn--zca7848m; ; xn----s2c.xn--ss-066q; [V3, V6, V7] # ܼ-.ß
+\u073C\u200C-。𓐾SS; \u073C\u200C-.𓐾ss; [C1, V3, V6, V7]; xn----s2c071q.xn--ss-066q; ; xn----s2c.xn--ss-066q; [V3, V6, V7] # ܼ-.ss
+\u073C\u200C-。𓐾ss; \u073C\u200C-.𓐾ss; [C1, V3, V6, V7]; xn----s2c071q.xn--ss-066q; ; xn----s2c.xn--ss-066q; [V3, V6, V7] # ܼ-.ss
+\u073C\u200C-。𓐾Ss; \u073C\u200C-.𓐾ss; [C1, V3, V6, V7]; xn----s2c071q.xn--ss-066q; ; xn----s2c.xn--ss-066q; [V3, V6, V7] # ܼ-.ss
+xn----s2c.xn--ss-066q; \u073C-.𓐾ss; [V3, V6, V7]; xn----s2c.xn--ss-066q; ; ;  # ܼ-.ss
+xn----s2c071q.xn--ss-066q; \u073C\u200C-.𓐾ss; [C1, V3, V6, V7]; xn----s2c071q.xn--ss-066q; ; ;  # ܼ-.ss
+xn----s2c071q.xn--zca7848m; \u073C\u200C-.𓐾ß; [C1, V3, V6, V7]; xn----s2c071q.xn--zca7848m; ; ;  # ܼ-.ß
+\u200Cς🃡⒗.\u0CC6仧\u0756; ; [B1, B5, B6, C1, V6, V7]; xn--3xa795lz9czy52d.xn--9ob79ycx2e; ; xn--4xa229nbu92a.xn--9ob79ycx2e; [B5, B6, V6, V7] # ς🃡⒗.ೆ仧ݖ
+\u200Cς🃡16..\u0CC6仧\u0756; ; [B1, B5, B6, C1, V6, X4_2]; xn--16-rbc1800avy99b..xn--9ob79ycx2e; [B1, B5, B6, C1, V6, A4_2]; xn--16-ubc66061c..xn--9ob79ycx2e; [B5, B6, V6, A4_2] # ς🃡16..ೆ仧ݖ
+\u200CΣ🃡16..\u0CC6仧\u0756; \u200Cσ🃡16..\u0CC6仧\u0756; [B1, B5, B6, C1, V6, X4_2]; xn--16-ubc7700avy99b..xn--9ob79ycx2e; [B1, B5, B6, C1, V6, A4_2]; xn--16-ubc66061c..xn--9ob79ycx2e; [B5, B6, V6, A4_2] # σ🃡16..ೆ仧ݖ
+\u200Cσ🃡16..\u0CC6仧\u0756; ; [B1, B5, B6, C1, V6, X4_2]; xn--16-ubc7700avy99b..xn--9ob79ycx2e; [B1, B5, B6, C1, V6, A4_2]; xn--16-ubc66061c..xn--9ob79ycx2e; [B5, B6, V6, A4_2] # σ🃡16..ೆ仧ݖ
+xn--16-ubc66061c..xn--9ob79ycx2e; σ🃡16..\u0CC6仧\u0756; [B5, B6, V6, X4_2]; xn--16-ubc66061c..xn--9ob79ycx2e; [B5, B6, V6, A4_2]; ;  # σ🃡16..ೆ仧ݖ
+xn--16-ubc7700avy99b..xn--9ob79ycx2e; \u200Cσ🃡16..\u0CC6仧\u0756; [B1, B5, B6, C1, V6, X4_2]; xn--16-ubc7700avy99b..xn--9ob79ycx2e; [B1, B5, B6, C1, V6, A4_2]; ;  # σ🃡16..ೆ仧ݖ
+xn--16-rbc1800avy99b..xn--9ob79ycx2e; \u200Cς🃡16..\u0CC6仧\u0756; [B1, B5, B6, C1, V6, X4_2]; xn--16-rbc1800avy99b..xn--9ob79ycx2e; [B1, B5, B6, C1, V6, A4_2]; ;  # ς🃡16..ೆ仧ݖ
+\u200CΣ🃡⒗.\u0CC6仧\u0756; \u200Cσ🃡⒗.\u0CC6仧\u0756; [B1, B5, B6, C1, V6, V7]; xn--4xa595lz9czy52d.xn--9ob79ycx2e; ; xn--4xa229nbu92a.xn--9ob79ycx2e; [B5, B6, V6, V7] # σ🃡⒗.ೆ仧ݖ
+\u200Cσ🃡⒗.\u0CC6仧\u0756; ; [B1, B5, B6, C1, V6, V7]; xn--4xa595lz9czy52d.xn--9ob79ycx2e; ; xn--4xa229nbu92a.xn--9ob79ycx2e; [B5, B6, V6, V7] # σ🃡⒗.ೆ仧ݖ
+xn--4xa229nbu92a.xn--9ob79ycx2e; σ🃡⒗.\u0CC6仧\u0756; [B5, B6, V6, V7]; xn--4xa229nbu92a.xn--9ob79ycx2e; ; ;  # σ🃡⒗.ೆ仧ݖ
+xn--4xa595lz9czy52d.xn--9ob79ycx2e; \u200Cσ🃡⒗.\u0CC6仧\u0756; [B1, B5, B6, C1, V6, V7]; xn--4xa595lz9czy52d.xn--9ob79ycx2e; ; ;  # σ🃡⒗.ೆ仧ݖ
+xn--3xa795lz9czy52d.xn--9ob79ycx2e; \u200Cς🃡⒗.\u0CC6仧\u0756; [B1, B5, B6, C1, V6, V7]; xn--3xa795lz9czy52d.xn--9ob79ycx2e; ; ;  # ς🃡⒗.ೆ仧ݖ
+-.𞸚; -.\u0638; [B1, V3]; -.xn--3gb; ; ;  # -.ظ
+-.\u0638; ; [B1, V3]; -.xn--3gb; ; ;  # -.ظ
+-.xn--3gb; -.\u0638; [B1, V3]; -.xn--3gb; ; ;  # -.ظ
+򏛓\u0683.\u0F7E\u0634; ; [B1, B5, B6, V6, V7]; xn--8ib92728i.xn--zgb968b; ; ;  # ڃ.ཾش
+xn--8ib92728i.xn--zgb968b; 򏛓\u0683.\u0F7E\u0634; [B1, B5, B6, V6, V7]; xn--8ib92728i.xn--zgb968b; ; ;  # ڃ.ཾش
+\u0FE6\u0843񽶬.𐮏; ; [B5, V7]; xn--1vb320b5m04p.xn--m29c; ; ;  # ࡃ.𐮏
+xn--1vb320b5m04p.xn--m29c; \u0FE6\u0843񽶬.𐮏; [B5, V7]; xn--1vb320b5m04p.xn--m29c; ; ;  # ࡃ.𐮏
+2񎨠\u07CBß。ᠽ; 2񎨠\u07CBß.ᠽ; [B1, V7]; xn--2-qfa924cez02l.xn--w7e; ; xn--2ss-odg83511n.xn--w7e;  # 2ߋß.ᠽ
+2񎨠\u07CBSS。ᠽ; 2񎨠\u07CBss.ᠽ; [B1, V7]; xn--2ss-odg83511n.xn--w7e; ; ;  # 2ߋss.ᠽ
+2񎨠\u07CBss。ᠽ; 2񎨠\u07CBss.ᠽ; [B1, V7]; xn--2ss-odg83511n.xn--w7e; ; ;  # 2ߋss.ᠽ
+xn--2ss-odg83511n.xn--w7e; 2񎨠\u07CBss.ᠽ; [B1, V7]; xn--2ss-odg83511n.xn--w7e; ; ;  # 2ߋss.ᠽ
+xn--2-qfa924cez02l.xn--w7e; 2񎨠\u07CBß.ᠽ; [B1, V7]; xn--2-qfa924cez02l.xn--w7e; ; ;  # 2ߋß.ᠽ
+2񎨠\u07CBSs。ᠽ; 2񎨠\u07CBss.ᠽ; [B1, V7]; xn--2ss-odg83511n.xn--w7e; ; ;  # 2ߋss.ᠽ
+㸳\u07CA≮．\u06CEß-\u200D; 㸳\u07CA≮.\u06CEß-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn----pfa076bys4a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێß-
+㸳\u07CA<\u0338．\u06CEß-\u200D; 㸳\u07CA≮.\u06CEß-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn----pfa076bys4a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێß-
+㸳\u07CA≮.\u06CEß-\u200D; ; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn----pfa076bys4a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێß-
+㸳\u07CA<\u0338.\u06CEß-\u200D; 㸳\u07CA≮.\u06CEß-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn----pfa076bys4a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێß-
+㸳\u07CA<\u0338.\u06CESS-\u200D; 㸳\u07CA≮.\u06CEss-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێss-
+㸳\u07CA≮.\u06CESS-\u200D; 㸳\u07CA≮.\u06CEss-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێss-
+㸳\u07CA≮.\u06CEss-\u200D; ; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێss-
+㸳\u07CA<\u0338.\u06CEss-\u200D; 㸳\u07CA≮.\u06CEss-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێss-
+xn--lsb457kkut.xn--ss--qjf; 㸳\u07CA≮.\u06CEss-; [B2, B3, B5, B6, V3]; xn--lsb457kkut.xn--ss--qjf; ; ;  # 㸳ߊ≮.ێss-
+xn--lsb457kkut.xn--ss--qjf2343a; 㸳\u07CA≮.\u06CEss-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn--ss--qjf2343a; ; ;  # 㸳ߊ≮.ێss-
+xn--lsb457kkut.xn----pfa076bys4a; 㸳\u07CA≮.\u06CEß-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn----pfa076bys4a; ; ;  # 㸳ߊ≮.ێß-
+㸳\u07CA<\u0338．\u06CESS-\u200D; 㸳\u07CA≮.\u06CEss-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێss-
+㸳\u07CA≮．\u06CESS-\u200D; 㸳\u07CA≮.\u06CEss-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێss-
+㸳\u07CA≮．\u06CEss-\u200D; 㸳\u07CA≮.\u06CEss-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێss-
+㸳\u07CA<\u0338．\u06CEss-\u200D; 㸳\u07CA≮.\u06CEss-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێss-
+㸳\u07CA<\u0338.\u06CESs-\u200D; 㸳\u07CA≮.\u06CEss-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێss-
+㸳\u07CA≮.\u06CESs-\u200D; 㸳\u07CA≮.\u06CEss-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێss-
+㸳\u07CA<\u0338．\u06CESs-\u200D; 㸳\u07CA≮.\u06CEss-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێss-
+㸳\u07CA≮．\u06CESs-\u200D; 㸳\u07CA≮.\u06CEss-\u200D; [B2, B3, B5, B6, C2]; xn--lsb457kkut.xn--ss--qjf2343a; ; xn--lsb457kkut.xn--ss--qjf; [B2, B3, B5, B6, V3] # 㸳ߊ≮.ێss-
+-򷝬\u135E𑜧.\u1DEB-︒; ; [V3, V6, V7]; xn----b5h1837n2ok9f.xn----mkmw278h; ; ;  # -፞𑜧.ᷫ-︒
+-򷝬\u135E𑜧.\u1DEB-。; -򷝬\u135E𑜧.\u1DEB-.; [V3, V6, V7]; xn----b5h1837n2ok9f.xn----mkm.; [V3, V6, V7, A4_2]; ;  # -፞𑜧.ᷫ-.
+xn----b5h1837n2ok9f.xn----mkm.; -򷝬\u135E𑜧.\u1DEB-.; [V3, V6, V7]; xn----b5h1837n2ok9f.xn----mkm.; [V3, V6, V7, A4_2]; ;  # -፞𑜧.ᷫ-.
+xn----b5h1837n2ok9f.xn----mkmw278h; -򷝬\u135E𑜧.\u1DEB-︒; [V3, V6, V7]; xn----b5h1837n2ok9f.xn----mkmw278h; ; ;  # -፞𑜧.ᷫ-︒
+︒.򚠡\u1A59; ; [V7]; xn--y86c.xn--cof61594i; ; ;  # ︒.ᩙ
+。.򚠡\u1A59; ..򚠡\u1A59; [V7, X4_2]; ..xn--cof61594i; [V7, A4_2]; ;  # ..ᩙ
+..xn--cof61594i; ..򚠡\u1A59; [V7, X4_2]; ..xn--cof61594i; [V7, A4_2]; ;  # ..ᩙ
+xn--y86c.xn--cof61594i; ︒.򚠡\u1A59; [V7]; xn--y86c.xn--cof61594i; ; ;  # ︒.ᩙ
+\u0323\u2DE1。\u200C⓾\u200C\u06B9; \u0323\u2DE1.\u200C⓾\u200C\u06B9; [B1, C1, V6]; xn--kta899s.xn--skb970ka771c; ; xn--kta899s.xn--skb116m; [B1, V6] # ̣ⷡ.⓾ڹ
+xn--kta899s.xn--skb116m; \u0323\u2DE1.⓾\u06B9; [B1, V6]; xn--kta899s.xn--skb116m; ; ;  # ̣ⷡ.⓾ڹ
+xn--kta899s.xn--skb970ka771c; \u0323\u2DE1.\u200C⓾\u200C\u06B9; [B1, C1, V6]; xn--kta899s.xn--skb970ka771c; ; ;  # ̣ⷡ.⓾ڹ
+𞠶ᠴ\u06DD｡\u1074𞤵󠅦; 𞠶ᠴ\u06DD.\u1074𞤵; [B1, B2, V6, V7]; xn--tlb199fwl35a.xn--yld4613v; ; ;  # 𞠶ᠴ.ၴ𞤵
+𞠶ᠴ\u06DD。\u1074𞤵󠅦; 𞠶ᠴ\u06DD.\u1074𞤵; [B1, B2, V6, V7]; xn--tlb199fwl35a.xn--yld4613v; ; ;  # 𞠶ᠴ.ၴ𞤵
+𞠶ᠴ\u06DD。\u1074𞤓󠅦; 𞠶ᠴ\u06DD.\u1074𞤵; [B1, B2, V6, V7]; xn--tlb199fwl35a.xn--yld4613v; ; ;  # 𞠶ᠴ.ၴ𞤵
+xn--tlb199fwl35a.xn--yld4613v; 𞠶ᠴ\u06DD.\u1074𞤵; [B1, B2, V6, V7]; xn--tlb199fwl35a.xn--yld4613v; ; ;  # 𞠶ᠴ.ၴ𞤵
+𞠶ᠴ\u06DD｡\u1074𞤓󠅦; 𞠶ᠴ\u06DD.\u1074𞤵; [B1, B2, V6, V7]; xn--tlb199fwl35a.xn--yld4613v; ; ;  # 𞠶ᠴ.ၴ𞤵
+𑰺.-򑟏; ; [V3, V6, V7]; xn--jk3d.xn----iz68g; ; ;  # 𑰺.-
+xn--jk3d.xn----iz68g; 𑰺.-򑟏; [V3, V6, V7]; xn--jk3d.xn----iz68g; ; ;  # 𑰺.-
+󠻩．赏; 󠻩.赏; [V7]; xn--2856e.xn--6o3a; ; ;  # .赏
+󠻩.赏; ; [V7]; xn--2856e.xn--6o3a; ; ;  # .赏
+xn--2856e.xn--6o3a; 󠻩.赏; [V7]; xn--2856e.xn--6o3a; ; ;  # .赏
+\u06B0ᠡ｡Ⴁ; \u06B0ᠡ.ⴁ; [B2, B3]; xn--jkb440g.xn--skj; ; ;  # ڰᠡ.ⴁ
+\u06B0ᠡ。Ⴁ; \u06B0ᠡ.ⴁ; [B2, B3]; xn--jkb440g.xn--skj; ; ;  # ڰᠡ.ⴁ
+\u06B0ᠡ。ⴁ; \u06B0ᠡ.ⴁ; [B2, B3]; xn--jkb440g.xn--skj; ; ;  # ڰᠡ.ⴁ
+xn--jkb440g.xn--skj; \u06B0ᠡ.ⴁ; [B2, B3]; xn--jkb440g.xn--skj; ; ;  # ڰᠡ.ⴁ
+\u06B0ᠡ｡ⴁ; \u06B0ᠡ.ⴁ; [B2, B3]; xn--jkb440g.xn--skj; ; ;  # ڰᠡ.ⴁ
+xn--jkb440g.xn--8md; \u06B0ᠡ.Ⴁ; [B2, B3, V7]; xn--jkb440g.xn--8md; ; ;  # ڰᠡ.Ⴁ
+\u20DEႪ\u06BBς｡-; \u20DEⴊ\u06BBς.-; [B1, V3, V6]; xn--3xa53mr38aeel.-; ; xn--4xa33mr38aeel.-;  # ⃞ⴊڻς.-
+\u20DEႪ\u06BBς。-; \u20DEⴊ\u06BBς.-; [B1, V3, V6]; xn--3xa53mr38aeel.-; ; xn--4xa33mr38aeel.-;  # ⃞ⴊڻς.-
+\u20DEⴊ\u06BBς。-; \u20DEⴊ\u06BBς.-; [B1, V3, V6]; xn--3xa53mr38aeel.-; ; xn--4xa33mr38aeel.-;  # ⃞ⴊڻς.-
+\u20DEႪ\u06BBΣ。-; \u20DEⴊ\u06BBσ.-; [B1, V3, V6]; xn--4xa33mr38aeel.-; ; ;  # ⃞ⴊڻσ.-
+\u20DEⴊ\u06BBσ。-; \u20DEⴊ\u06BBσ.-; [B1, V3, V6]; xn--4xa33mr38aeel.-; ; ;  # ⃞ⴊڻσ.-
+\u20DEႪ\u06BBσ。-; \u20DEⴊ\u06BBσ.-; [B1, V3, V6]; xn--4xa33mr38aeel.-; ; ;  # ⃞ⴊڻσ.-
+xn--4xa33mr38aeel.-; \u20DEⴊ\u06BBσ.-; [B1, V3, V6]; xn--4xa33mr38aeel.-; ; ;  # ⃞ⴊڻσ.-
+xn--3xa53mr38aeel.-; \u20DEⴊ\u06BBς.-; [B1, V3, V6]; xn--3xa53mr38aeel.-; ; ;  # ⃞ⴊڻς.-
+\u20DEⴊ\u06BBς｡-; \u20DEⴊ\u06BBς.-; [B1, V3, V6]; xn--3xa53mr38aeel.-; ; xn--4xa33mr38aeel.-;  # ⃞ⴊڻς.-
+\u20DEႪ\u06BBΣ｡-; \u20DEⴊ\u06BBσ.-; [B1, V3, V6]; xn--4xa33mr38aeel.-; ; ;  # ⃞ⴊڻσ.-
+\u20DEⴊ\u06BBσ｡-; \u20DEⴊ\u06BBσ.-; [B1, V3, V6]; xn--4xa33mr38aeel.-; ; ;  # ⃞ⴊڻσ.-
+\u20DEႪ\u06BBσ｡-; \u20DEⴊ\u06BBσ.-; [B1, V3, V6]; xn--4xa33mr38aeel.-; ; ;  # ⃞ⴊڻσ.-
+xn--4xa33m7zmb0q.-; \u20DEႪ\u06BBσ.-; [B1, V3, V6, V7]; xn--4xa33m7zmb0q.-; ; ;  # ⃞Ⴊڻσ.-
+xn--3xa53m7zmb0q.-; \u20DEႪ\u06BBς.-; [B1, V3, V6, V7]; xn--3xa53m7zmb0q.-; ; ;  # ⃞Ⴊڻς.-
+Ⴍ．񍇦\u200C; ⴍ.񍇦\u200C; [C1, V7]; xn--4kj.xn--0ug56448b; ; xn--4kj.xn--p01x; [V7] # ⴍ.
+Ⴍ.񍇦\u200C; ⴍ.񍇦\u200C; [C1, V7]; xn--4kj.xn--0ug56448b; ; xn--4kj.xn--p01x; [V7] # ⴍ.
+ⴍ.񍇦\u200C; ; [C1, V7]; xn--4kj.xn--0ug56448b; ; xn--4kj.xn--p01x; [V7] # ⴍ.
+xn--4kj.xn--p01x; ⴍ.񍇦; [V7]; xn--4kj.xn--p01x; ; ;  # ⴍ.
+xn--4kj.xn--0ug56448b; ⴍ.񍇦\u200C; [C1, V7]; xn--4kj.xn--0ug56448b; ; ;  # ⴍ.
+ⴍ．񍇦\u200C; ⴍ.񍇦\u200C; [C1, V7]; xn--4kj.xn--0ug56448b; ; xn--4kj.xn--p01x; [V7] # ⴍ.
+xn--lnd.xn--p01x; Ⴍ.񍇦; [V7]; xn--lnd.xn--p01x; ; ;  # Ⴍ.
+xn--lnd.xn--0ug56448b; Ⴍ.񍇦\u200C; [C1, V7]; xn--lnd.xn--0ug56448b; ; ;  # Ⴍ.
+򉟂󠵣.𐫫\u1A60󴺖\u1B44; ; [B2, B3, B6, V7]; xn--9u37blu98h.xn--jof13bt568cork1j; ; ;  # .𐫫᩠᭄
+xn--9u37blu98h.xn--jof13bt568cork1j; 򉟂󠵣.𐫫\u1A60󴺖\u1B44; [B2, B3, B6, V7]; xn--9u37blu98h.xn--jof13bt568cork1j; ; ;  # .𐫫᩠᭄
+≯❊ᠯ｡𐹱⺨; ≯❊ᠯ.𐹱⺨; [B1]; xn--i7e163ct2d.xn--vwj7372e; ; ;  # ≯❊ᠯ.𐹱⺨
+>\u0338❊ᠯ｡𐹱⺨; ≯❊ᠯ.𐹱⺨; [B1]; xn--i7e163ct2d.xn--vwj7372e; ; ;  # ≯❊ᠯ.𐹱⺨
+≯❊ᠯ。𐹱⺨; ≯❊ᠯ.𐹱⺨; [B1]; xn--i7e163ct2d.xn--vwj7372e; ; ;  # ≯❊ᠯ.𐹱⺨
+>\u0338❊ᠯ。𐹱⺨; ≯❊ᠯ.𐹱⺨; [B1]; xn--i7e163ct2d.xn--vwj7372e; ; ;  # ≯❊ᠯ.𐹱⺨
+xn--i7e163ct2d.xn--vwj7372e; ≯❊ᠯ.𐹱⺨; [B1]; xn--i7e163ct2d.xn--vwj7372e; ; ;  # ≯❊ᠯ.𐹱⺨
+􁕜𐹧𞭁𐹩。Ⴈ𐫮Ⴏ; 􁕜𐹧𞭁𐹩.ⴈ𐫮ⴏ; [B5, B6, V7]; xn--fo0de1270ope54j.xn--zkjo0151o; ; ;  # 𐹧𐹩.ⴈ𐫮ⴏ
+􁕜𐹧𞭁𐹩。ⴈ𐫮ⴏ; 􁕜𐹧𞭁𐹩.ⴈ𐫮ⴏ; [B5, B6, V7]; xn--fo0de1270ope54j.xn--zkjo0151o; ; ;  # 𐹧𐹩.ⴈ𐫮ⴏ
+xn--fo0de1270ope54j.xn--zkjo0151o; 􁕜𐹧𞭁𐹩.ⴈ𐫮ⴏ; [B5, B6, V7]; xn--fo0de1270ope54j.xn--zkjo0151o; ; ;  # 𐹧𐹩.ⴈ𐫮ⴏ
+xn--fo0de1270ope54j.xn--gndo2033q; 􁕜𐹧𞭁𐹩.Ⴈ𐫮Ⴏ; [B5, B6, V7]; xn--fo0de1270ope54j.xn--gndo2033q; ; ;  # 𐹧𐹩.Ⴈ𐫮Ⴏ
+𞠂。\uA926; 𞠂.\uA926; [B1, V6]; xn--145h.xn--ti9a; ; ;  # 𞠂.ꤦ
+xn--145h.xn--ti9a; 𞠂.\uA926; [B1, V6]; xn--145h.xn--ti9a; ; ;  # 𞠂.ꤦ
+𝟔𐹫．\u0733\u1037９ꡇ; 6𐹫.\u1037\u07339ꡇ; [B1, V6]; xn--6-t26i.xn--9-91c730e8u8n; ; ;  # 6𐹫.့ܳ9ꡇ
+𝟔𐹫．\u1037\u0733９ꡇ; 6𐹫.\u1037\u07339ꡇ; [B1, V6]; xn--6-t26i.xn--9-91c730e8u8n; ; ;  # 6𐹫.့ܳ9ꡇ
+6𐹫.\u1037\u07339ꡇ; ; [B1, V6]; xn--6-t26i.xn--9-91c730e8u8n; ; ;  # 6𐹫.့ܳ9ꡇ
+xn--6-t26i.xn--9-91c730e8u8n; 6𐹫.\u1037\u07339ꡇ; [B1, V6]; xn--6-t26i.xn--9-91c730e8u8n; ; ;  # 6𐹫.့ܳ9ꡇ
+\u0724\u0603𞲶．\u06D8; \u0724\u0603𞲶.\u06D8; [B1, V6, V7]; xn--lfb19ct414i.xn--olb; ; ;  # ܤ.ۘ
+\u0724\u0603𞲶.\u06D8; ; [B1, V6, V7]; xn--lfb19ct414i.xn--olb; ; ;  # ܤ.ۘ
+xn--lfb19ct414i.xn--olb; \u0724\u0603𞲶.\u06D8; [B1, V6, V7]; xn--lfb19ct414i.xn--olb; ; ;  # ܤ.ۘ
+✆񱔩ꡋ．\u0632\u200D𞣴; ✆񱔩ꡋ.\u0632\u200D𞣴; [B1, C2, V7]; xn--1biv525bcix0d.xn--xgb253k0m73a; ; xn--1biv525bcix0d.xn--xgb6828v; [B1, V7] # ✆ꡋ.ز
+✆񱔩ꡋ.\u0632\u200D𞣴; ; [B1, C2, V7]; xn--1biv525bcix0d.xn--xgb253k0m73a; ; xn--1biv525bcix0d.xn--xgb6828v; [B1, V7] # ✆ꡋ.ز
+xn--1biv525bcix0d.xn--xgb6828v; ✆񱔩ꡋ.\u0632𞣴; [B1, V7]; xn--1biv525bcix0d.xn--xgb6828v; ; ;  # ✆ꡋ.ز
+xn--1biv525bcix0d.xn--xgb253k0m73a; ✆񱔩ꡋ.\u0632\u200D𞣴; [B1, C2, V7]; xn--1biv525bcix0d.xn--xgb253k0m73a; ; ;  # ✆ꡋ.ز
+\u0845񃾰𞸍-．≠򃁟𑋪; \u0845񃾰\u0646-.≠򃁟𑋪; [B1, B2, B3, V3, V7]; xn----qoc64my971s.xn--1ch7585g76o3c; ; ;  # ࡅن-.≠𑋪
+\u0845񃾰𞸍-．=\u0338򃁟𑋪; \u0845񃾰\u0646-.≠򃁟𑋪; [B1, B2, B3, V3, V7]; xn----qoc64my971s.xn--1ch7585g76o3c; ; ;  # ࡅن-.≠𑋪
+\u0845񃾰\u0646-.≠򃁟𑋪; ; [B1, B2, B3, V3, V7]; xn----qoc64my971s.xn--1ch7585g76o3c; ; ;  # ࡅن-.≠𑋪
+\u0845񃾰\u0646-.=\u0338򃁟𑋪; \u0845񃾰\u0646-.≠򃁟𑋪; [B1, B2, B3, V3, V7]; xn----qoc64my971s.xn--1ch7585g76o3c; ; ;  # ࡅن-.≠𑋪
+xn----qoc64my971s.xn--1ch7585g76o3c; \u0845񃾰\u0646-.≠򃁟𑋪; [B1, B2, B3, V3, V7]; xn----qoc64my971s.xn--1ch7585g76o3c; ; ;  # ࡅن-.≠𑋪
+𝟛．笠; 3.笠; ; 3.xn--6vz; ; ;  # 3.笠
+𝟛．笠; 3.笠; ; 3.xn--6vz; ; ;  # 3.笠
+3.笠; ; ; 3.xn--6vz; ; ;  # 3.笠
+3.xn--6vz; 3.笠; ; 3.xn--6vz; ; ;  # 3.笠
+-\u200D.Ⴞ𐋷; -\u200D.ⴞ𐋷; [C2, V3]; xn----ugn.xn--mlj8559d; ; -.xn--mlj8559d; [V3] # -.ⴞ𐋷
+-\u200D.ⴞ𐋷; ; [C2, V3]; xn----ugn.xn--mlj8559d; ; -.xn--mlj8559d; [V3] # -.ⴞ𐋷
+-.xn--mlj8559d; -.ⴞ𐋷; [V3]; -.xn--mlj8559d; ; ;  # -.ⴞ𐋷
+xn----ugn.xn--mlj8559d; -\u200D.ⴞ𐋷; [C2, V3]; xn----ugn.xn--mlj8559d; ; ;  # -.ⴞ𐋷
+-.xn--2nd2315j; -.Ⴞ𐋷; [V3, V7]; -.xn--2nd2315j; ; ;  # -.Ⴞ𐋷
+xn----ugn.xn--2nd2315j; -\u200D.Ⴞ𐋷; [C2, V3, V7]; xn----ugn.xn--2nd2315j; ; ;  # -.Ⴞ𐋷
+\u200Dςß\u0731．\u0BCD; \u200Dςß\u0731.\u0BCD; [C2, V6]; xn--zca19ln1di19a.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V6] # ςßܱ.்
+\u200Dςß\u0731.\u0BCD; ; [C2, V6]; xn--zca19ln1di19a.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V6] # ςßܱ.்
+\u200DΣSS\u0731.\u0BCD; \u200Dσss\u0731.\u0BCD; [C2, V6]; xn--ss-ubc826ab34b.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V6] # σssܱ.்
+\u200Dσss\u0731.\u0BCD; ; [C2, V6]; xn--ss-ubc826ab34b.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V6] # σssܱ.்
+\u200DΣss\u0731.\u0BCD; \u200Dσss\u0731.\u0BCD; [C2, V6]; xn--ss-ubc826ab34b.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V6] # σssܱ.்
+xn--ss-ubc826a.xn--xmc; σss\u0731.\u0BCD; [V6]; xn--ss-ubc826a.xn--xmc; ; ;  # σssܱ.்
+xn--ss-ubc826ab34b.xn--xmc; \u200Dσss\u0731.\u0BCD; [C2, V6]; xn--ss-ubc826ab34b.xn--xmc; ; ;  # σssܱ.்
+\u200DΣß\u0731.\u0BCD; \u200Dσß\u0731.\u0BCD; [C2, V6]; xn--zca39lk1di19a.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V6] # σßܱ.்
+\u200Dσß\u0731.\u0BCD; ; [C2, V6]; xn--zca39lk1di19a.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V6] # σßܱ.்
+xn--zca39lk1di19a.xn--xmc; \u200Dσß\u0731.\u0BCD; [C2, V6]; xn--zca39lk1di19a.xn--xmc; ; ;  # σßܱ.்
+xn--zca19ln1di19a.xn--xmc; \u200Dςß\u0731.\u0BCD; [C2, V6]; xn--zca19ln1di19a.xn--xmc; ; ;  # ςßܱ.்
+\u200DΣSS\u0731．\u0BCD; \u200Dσss\u0731.\u0BCD; [C2, V6]; xn--ss-ubc826ab34b.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V6] # σssܱ.்
+\u200Dσss\u0731．\u0BCD; \u200Dσss\u0731.\u0BCD; [C2, V6]; xn--ss-ubc826ab34b.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V6] # σssܱ.்
+\u200DΣss\u0731．\u0BCD; \u200Dσss\u0731.\u0BCD; [C2, V6]; xn--ss-ubc826ab34b.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V6] # σssܱ.்
+\u200DΣß\u0731．\u0BCD; \u200Dσß\u0731.\u0BCD; [C2, V6]; xn--zca39lk1di19a.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V6] # σßܱ.்
+\u200Dσß\u0731．\u0BCD; \u200Dσß\u0731.\u0BCD; [C2, V6]; xn--zca39lk1di19a.xn--xmc; ; xn--ss-ubc826a.xn--xmc; [V6] # σßܱ.்
+≠．\u200D; ≠.\u200D; [C2]; xn--1ch.xn--1ug; ; xn--1ch.; [A4_2] # ≠.
+=\u0338．\u200D; ≠.\u200D; [C2]; xn--1ch.xn--1ug; ; xn--1ch.; [A4_2] # ≠.
+≠.\u200D; ; [C2]; xn--1ch.xn--1ug; ; xn--1ch.; [A4_2] # ≠.
+=\u0338.\u200D; ≠.\u200D; [C2]; xn--1ch.xn--1ug; ; xn--1ch.; [A4_2] # ≠.
+xn--1ch.; ≠.; ; xn--1ch.; [A4_2]; ;  # ≠.
+≠.; ; ; xn--1ch.; [A4_2]; ;  # ≠.
+=\u0338.; ≠.; ; xn--1ch.; [A4_2]; ;  # ≠.
+xn--1ch.xn--1ug; ≠.\u200D; [C2]; xn--1ch.xn--1ug; ; ;  # ≠.
+\uFC01｡\u0C81ᠼ▗򒁋; \u0626\u062D.\u0C81ᠼ▗򒁋; [B1, V6, V7]; xn--lgbo.xn--2rc021dcxkrx55t; ; ;  # ئح.ಁᠼ▗
+\u0626\u062D。\u0C81ᠼ▗򒁋; \u0626\u062D.\u0C81ᠼ▗򒁋; [B1, V6, V7]; xn--lgbo.xn--2rc021dcxkrx55t; ; ;  # ئح.ಁᠼ▗
+\u064A\u0654\u062D。\u0C81ᠼ▗򒁋; \u0626\u062D.\u0C81ᠼ▗򒁋; [B1, V6, V7]; xn--lgbo.xn--2rc021dcxkrx55t; ; ;  # ئح.ಁᠼ▗
+xn--lgbo.xn--2rc021dcxkrx55t; \u0626\u062D.\u0C81ᠼ▗򒁋; [B1, V6, V7]; xn--lgbo.xn--2rc021dcxkrx55t; ; ;  # ئح.ಁᠼ▗
+󧋵\u09CDς．ς𐨿; 󧋵\u09CDς.ς𐨿; [V7]; xn--3xa702av8297a.xn--3xa8055k; ; xn--4xa502av8297a.xn--4xa6055k;  # ্ς.ς𐨿
+󧋵\u09CDς.ς𐨿; ; [V7]; xn--3xa702av8297a.xn--3xa8055k; ; xn--4xa502av8297a.xn--4xa6055k;  # ্ς.ς𐨿
+󧋵\u09CDΣ.Σ𐨿; 󧋵\u09CDσ.σ𐨿; [V7]; xn--4xa502av8297a.xn--4xa6055k; ; ;  # ্σ.σ𐨿
+󧋵\u09CDσ.ς𐨿; ; [V7]; xn--4xa502av8297a.xn--3xa8055k; ; xn--4xa502av8297a.xn--4xa6055k;  # ্σ.ς𐨿
+󧋵\u09CDσ.σ𐨿; ; [V7]; xn--4xa502av8297a.xn--4xa6055k; ; ;  # ্σ.σ𐨿
+󧋵\u09CDΣ.σ𐨿; 󧋵\u09CDσ.σ𐨿; [V7]; xn--4xa502av8297a.xn--4xa6055k; ; ;  # ্σ.σ𐨿
+xn--4xa502av8297a.xn--4xa6055k; 󧋵\u09CDσ.σ𐨿; [V7]; xn--4xa502av8297a.xn--4xa6055k; ; ;  # ্σ.σ𐨿
+󧋵\u09CDΣ.ς𐨿; 󧋵\u09CDσ.ς𐨿; [V7]; xn--4xa502av8297a.xn--3xa8055k; ; xn--4xa502av8297a.xn--4xa6055k;  # ্σ.ς𐨿
+xn--4xa502av8297a.xn--3xa8055k; 󧋵\u09CDσ.ς𐨿; [V7]; xn--4xa502av8297a.xn--3xa8055k; ; ;  # ্σ.ς𐨿
+xn--3xa702av8297a.xn--3xa8055k; 󧋵\u09CDς.ς𐨿; [V7]; xn--3xa702av8297a.xn--3xa8055k; ; ;  # ্ς.ς𐨿
+󧋵\u09CDΣ．Σ𐨿; 󧋵\u09CDσ.σ𐨿; [V7]; xn--4xa502av8297a.xn--4xa6055k; ; ;  # ্σ.σ𐨿
+󧋵\u09CDσ．ς𐨿; 󧋵\u09CDσ.ς𐨿; [V7]; xn--4xa502av8297a.xn--3xa8055k; ; xn--4xa502av8297a.xn--4xa6055k;  # ্σ.ς𐨿
+󧋵\u09CDσ．σ𐨿; 󧋵\u09CDσ.σ𐨿; [V7]; xn--4xa502av8297a.xn--4xa6055k; ; ;  # ্σ.σ𐨿
+󧋵\u09CDΣ．σ𐨿; 󧋵\u09CDσ.σ𐨿; [V7]; xn--4xa502av8297a.xn--4xa6055k; ; ;  # ্σ.σ𐨿
+󧋵\u09CDΣ．ς𐨿; 󧋵\u09CDσ.ς𐨿; [V7]; xn--4xa502av8297a.xn--3xa8055k; ; xn--4xa502av8297a.xn--4xa6055k;  # ্σ.ς𐨿
+𐫓\u07D8牅\u08F8｡𞦤\u1A17򱍰Ⴙ; 𐫓\u07D8牅\u08F8.𞦤\u1A17򱍰ⴙ; [B2, B3, V7]; xn--zsb09cu46vjs6f.xn--gmf469fr883am5r1e; ; ;  # 𐫓ߘ牅ࣸ.ᨗⴙ
+𐫓\u07D8牅\u08F8。𞦤\u1A17򱍰Ⴙ; 𐫓\u07D8牅\u08F8.𞦤\u1A17򱍰ⴙ; [B2, B3, V7]; xn--zsb09cu46vjs6f.xn--gmf469fr883am5r1e; ; ;  # 𐫓ߘ牅ࣸ.ᨗⴙ
+𐫓\u07D8牅\u08F8。𞦤\u1A17򱍰ⴙ; 𐫓\u07D8牅\u08F8.𞦤\u1A17򱍰ⴙ; [B2, B3, V7]; xn--zsb09cu46vjs6f.xn--gmf469fr883am5r1e; ; ;  # 𐫓ߘ牅ࣸ.ᨗⴙ
+xn--zsb09cu46vjs6f.xn--gmf469fr883am5r1e; 𐫓\u07D8牅\u08F8.𞦤\u1A17򱍰ⴙ; [B2, B3, V7]; xn--zsb09cu46vjs6f.xn--gmf469fr883am5r1e; ; ;  # 𐫓ߘ牅ࣸ.ᨗⴙ
+𐫓\u07D8牅\u08F8｡𞦤\u1A17򱍰ⴙ; 𐫓\u07D8牅\u08F8.𞦤\u1A17򱍰ⴙ; [B2, B3, V7]; xn--zsb09cu46vjs6f.xn--gmf469fr883am5r1e; ; ;  # 𐫓ߘ牅ࣸ.ᨗⴙ
+xn--zsb09cu46vjs6f.xn--xnd909bv540bm5k9d; 𐫓\u07D8牅\u08F8.𞦤\u1A17򱍰Ⴙ; [B2, B3, V7]; xn--zsb09cu46vjs6f.xn--xnd909bv540bm5k9d; ; ;  # 𐫓ߘ牅ࣸ.ᨗႹ
+񣤒｡륧; 񣤒.륧; [V7]; xn--s264a.xn--pw2b; ; ;  # .륧
+񣤒｡륧; 񣤒.륧; [V7]; xn--s264a.xn--pw2b; ; ;  # .륧
+񣤒。륧; 񣤒.륧; [V7]; xn--s264a.xn--pw2b; ; ;  # .륧
+񣤒。륧; 񣤒.륧; [V7]; xn--s264a.xn--pw2b; ; ;  # .륧
+xn--s264a.xn--pw2b; 񣤒.륧; [V7]; xn--s264a.xn--pw2b; ; ;  # .륧
+𐹷\u200D。󉵢; 𐹷\u200D.󉵢; [B1, C2, V7]; xn--1ugx205g.xn--8088d; ; xn--vo0d.xn--8088d; [B1, V7] # 𐹷.
+xn--vo0d.xn--8088d; 𐹷.󉵢; [B1, V7]; xn--vo0d.xn--8088d; ; ;  # 𐹷.
+xn--1ugx205g.xn--8088d; 𐹷\u200D.󉵢; [B1, C2, V7]; xn--1ugx205g.xn--8088d; ; ;  # 𐹷.
+Ⴘ\u06C2𑲭｡-; ⴘ\u06C2𑲭.-; [B1, B5, B6, V3]; xn--1kb147qfk3n.-; ; ;  # ⴘۂ𑲭.-
+Ⴘ\u06C1\u0654𑲭｡-; ⴘ\u06C2𑲭.-; [B1, B5, B6, V3]; xn--1kb147qfk3n.-; ; ;  # ⴘۂ𑲭.-
+Ⴘ\u06C2𑲭。-; ⴘ\u06C2𑲭.-; [B1, B5, B6, V3]; xn--1kb147qfk3n.-; ; ;  # ⴘۂ𑲭.-
+Ⴘ\u06C1\u0654𑲭。-; ⴘ\u06C2𑲭.-; [B1, B5, B6, V3]; xn--1kb147qfk3n.-; ; ;  # ⴘۂ𑲭.-
+ⴘ\u06C1\u0654𑲭。-; ⴘ\u06C2𑲭.-; [B1, B5, B6, V3]; xn--1kb147qfk3n.-; ; ;  # ⴘۂ𑲭.-
+ⴘ\u06C2𑲭。-; ⴘ\u06C2𑲭.-; [B1, B5, B6, V3]; xn--1kb147qfk3n.-; ; ;  # ⴘۂ𑲭.-
+xn--1kb147qfk3n.-; ⴘ\u06C2𑲭.-; [B1, B5, B6, V3]; xn--1kb147qfk3n.-; ; ;  # ⴘۂ𑲭.-
+ⴘ\u06C1\u0654𑲭｡-; ⴘ\u06C2𑲭.-; [B1, B5, B6, V3]; xn--1kb147qfk3n.-; ; ;  # ⴘۂ𑲭.-
+ⴘ\u06C2𑲭｡-; ⴘ\u06C2𑲭.-; [B1, B5, B6, V3]; xn--1kb147qfk3n.-; ; ;  # ⴘۂ𑲭.-
+xn--1kb312c139t.-; Ⴘ\u06C2𑲭.-; [B1, B5, B6, V3, V7]; xn--1kb312c139t.-; ; ;  # Ⴘۂ𑲭.-
+\uA806\u067B₆ᡐ。🛇\uFCDD; \uA806\u067B6ᡐ.🛇\u064A\u0645; [B1, V6]; xn--6-rrc018krt9k.xn--hhbj61429a; ; ;  # ꠆ٻ6ᡐ.🛇يم
+\uA806\u067B6ᡐ。🛇\u064A\u0645; \uA806\u067B6ᡐ.🛇\u064A\u0645; [B1, V6]; xn--6-rrc018krt9k.xn--hhbj61429a; ; ;  # ꠆ٻ6ᡐ.🛇يم
+xn--6-rrc018krt9k.xn--hhbj61429a; \uA806\u067B6ᡐ.🛇\u064A\u0645; [B1, V6]; xn--6-rrc018krt9k.xn--hhbj61429a; ; ;  # ꠆ٻ6ᡐ.🛇يم
+򸍂.㇄ᡟ𐫂\u0622; ; [B1, V7]; xn--p292d.xn--hgb154ghrsvm2r; ; ;  # .㇄ᡟ𐫂آ
+򸍂.㇄ᡟ𐫂\u0627\u0653; 򸍂.㇄ᡟ𐫂\u0622; [B1, V7]; xn--p292d.xn--hgb154ghrsvm2r; ; ;  # .㇄ᡟ𐫂آ
+xn--p292d.xn--hgb154ghrsvm2r; 򸍂.㇄ᡟ𐫂\u0622; [B1, V7]; xn--p292d.xn--hgb154ghrsvm2r; ; ;  # .㇄ᡟ𐫂آ
+\u07DF򵚌。-\u07E9; \u07DF򵚌.-\u07E9; [B1, B2, B3, V3, V7]; xn--6sb88139l.xn----pdd; ; ;  # ߟ.-ߩ
+xn--6sb88139l.xn----pdd; \u07DF򵚌.-\u07E9; [B1, B2, B3, V3, V7]; xn--6sb88139l.xn----pdd; ; ;  # ߟ.-ߩ
+ς\u0643⾑．\u200Cᢟ\u200C⒈; ς\u0643襾.\u200Cᢟ\u200C⒈; [B1, B5, C1, V7]; xn--3xa69jux8r.xn--pbf519aba607b; ; xn--4xa49jux8r.xn--pbf212d; [B5, V7] # ςك襾.ᢟ⒈
+ς\u0643襾.\u200Cᢟ\u200C1.; ; [B1, B5, C1]; xn--3xa69jux8r.xn--1-4ck691bba.; [B1, B5, C1, A4_2]; xn--4xa49jux8r.xn--1-4ck.; [B5, A4_2] # ςك襾.ᢟ1.
+Σ\u0643襾.\u200Cᢟ\u200C1.; σ\u0643襾.\u200Cᢟ\u200C1.; [B1, B5, C1]; xn--4xa49jux8r.xn--1-4ck691bba.; [B1, B5, C1, A4_2]; xn--4xa49jux8r.xn--1-4ck.; [B5, A4_2] # σك襾.ᢟ1.
+σ\u0643襾.\u200Cᢟ\u200C1.; ; [B1, B5, C1]; xn--4xa49jux8r.xn--1-4ck691bba.; [B1, B5, C1, A4_2]; xn--4xa49jux8r.xn--1-4ck.; [B5, A4_2] # σك襾.ᢟ1.
+xn--4xa49jux8r.xn--1-4ck.; σ\u0643襾.ᢟ1.; [B5]; xn--4xa49jux8r.xn--1-4ck.; [B5, A4_2]; ;  # σك襾.ᢟ1.
+xn--4xa49jux8r.xn--1-4ck691bba.; σ\u0643襾.\u200Cᢟ\u200C1.; [B1, B5, C1]; xn--4xa49jux8r.xn--1-4ck691bba.; [B1, B5, C1, A4_2]; ;  # σك襾.ᢟ1.
+xn--3xa69jux8r.xn--1-4ck691bba.; ς\u0643襾.\u200Cᢟ\u200C1.; [B1, B5, C1]; xn--3xa69jux8r.xn--1-4ck691bba.; [B1, B5, C1, A4_2]; ;  # ςك襾.ᢟ1.
+Σ\u0643⾑．\u200Cᢟ\u200C⒈; σ\u0643襾.\u200Cᢟ\u200C⒈; [B1, B5, C1, V7]; xn--4xa49jux8r.xn--pbf519aba607b; ; xn--4xa49jux8r.xn--pbf212d; [B5, V7] # σك襾.ᢟ⒈
+σ\u0643⾑．\u200Cᢟ\u200C⒈; σ\u0643襾.\u200Cᢟ\u200C⒈; [B1, B5, C1, V7]; xn--4xa49jux8r.xn--pbf519aba607b; ; xn--4xa49jux8r.xn--pbf212d; [B5, V7] # σك襾.ᢟ⒈
+xn--4xa49jux8r.xn--pbf212d; σ\u0643襾.ᢟ⒈; [B5, V7]; xn--4xa49jux8r.xn--pbf212d; ; ;  # σك襾.ᢟ⒈
+xn--4xa49jux8r.xn--pbf519aba607b; σ\u0643襾.\u200Cᢟ\u200C⒈; [B1, B5, C1, V7]; xn--4xa49jux8r.xn--pbf519aba607b; ; ;  # σك襾.ᢟ⒈
+xn--3xa69jux8r.xn--pbf519aba607b; ς\u0643襾.\u200Cᢟ\u200C⒈; [B1, B5, C1, V7]; xn--3xa69jux8r.xn--pbf519aba607b; ; ;  # ςك襾.ᢟ⒈
+ᡆ𑓝．𞵆; ᡆ𑓝.𞵆; [V7]; xn--57e0440k.xn--k86h; ; ;  # ᡆ.
+ᡆ𑓝.𞵆; ; [V7]; xn--57e0440k.xn--k86h; ; ;  # ᡆ.
+xn--57e0440k.xn--k86h; ᡆ𑓝.𞵆; [V7]; xn--57e0440k.xn--k86h; ; ;  # ᡆ.
+\u0A4D𦍓\u1DEE｡\u200C\u08BD񝹲; \u0A4D𦍓\u1DEE.\u200C\u08BD񝹲; [B1, C1, V6, V7]; xn--ybc461hph93b.xn--jzb740j1y45h; ; xn--ybc461hph93b.xn--jzb29857e; [B1, B2, B3, V6, V7] # ੍𦍓ᷮ.ࢽ
+\u0A4D𦍓\u1DEE。\u200C\u08BD񝹲; \u0A4D𦍓\u1DEE.\u200C\u08BD񝹲; [B1, C1, V6, V7]; xn--ybc461hph93b.xn--jzb740j1y45h; ; xn--ybc461hph93b.xn--jzb29857e; [B1, B2, B3, V6, V7] # ੍𦍓ᷮ.ࢽ
+xn--ybc461hph93b.xn--jzb29857e; \u0A4D𦍓\u1DEE.\u08BD񝹲; [B1, B2, B3, V6, V7]; xn--ybc461hph93b.xn--jzb29857e; ; ;  # ੍𦍓ᷮ.ࢽ
+xn--ybc461hph93b.xn--jzb740j1y45h; \u0A4D𦍓\u1DEE.\u200C\u08BD񝹲; [B1, C1, V6, V7]; xn--ybc461hph93b.xn--jzb740j1y45h; ; ;  # ੍𦍓ᷮ.ࢽ
+\u062E\u0748񅪪-．\u200C먿; \u062E\u0748񅪪-.\u200C먿; [B1, B2, B3, C1, V3, V7]; xn----dnc06f42153a.xn--0ug1581d; ; xn----dnc06f42153a.xn--v22b; [B2, B3, V3, V7] # خ݈-.먿
+\u062E\u0748񅪪-．\u200C먿; \u062E\u0748񅪪-.\u200C먿; [B1, B2, B3, C1, V3, V7]; xn----dnc06f42153a.xn--0ug1581d; ; xn----dnc06f42153a.xn--v22b; [B2, B3, V3, V7] # خ݈-.먿
+\u062E\u0748񅪪-.\u200C먿; ; [B1, B2, B3, C1, V3, V7]; xn----dnc06f42153a.xn--0ug1581d; ; xn----dnc06f42153a.xn--v22b; [B2, B3, V3, V7] # خ݈-.먿
+\u062E\u0748񅪪-.\u200C먿; \u062E\u0748񅪪-.\u200C먿; [B1, B2, B3, C1, V3, V7]; xn----dnc06f42153a.xn--0ug1581d; ; xn----dnc06f42153a.xn--v22b; [B2, B3, V3, V7] # خ݈-.먿
+xn----dnc06f42153a.xn--v22b; \u062E\u0748񅪪-.먿; [B2, B3, V3, V7]; xn----dnc06f42153a.xn--v22b; ; ;  # خ݈-.먿
+xn----dnc06f42153a.xn--0ug1581d; \u062E\u0748񅪪-.\u200C먿; [B1, B2, B3, C1, V3, V7]; xn----dnc06f42153a.xn--0ug1581d; ; ;  # خ݈-.먿
+􋿦｡ᠽ; 􋿦.ᠽ; [V7]; xn--j890g.xn--w7e; ; ;  # .ᠽ
+􋿦。ᠽ; 􋿦.ᠽ; [V7]; xn--j890g.xn--w7e; ; ;  # .ᠽ
+xn--j890g.xn--w7e; 􋿦.ᠽ; [V7]; xn--j890g.xn--w7e; ; ;  # .ᠽ
+嬃𝍌．\u200D\u0B44; 嬃𝍌.\u200D\u0B44; [C2]; xn--b6s0078f.xn--0ic557h; ; xn--b6s0078f.xn--0ic; [V6] # 嬃𝍌.ୄ
+嬃𝍌.\u200D\u0B44; ; [C2]; xn--b6s0078f.xn--0ic557h; ; xn--b6s0078f.xn--0ic; [V6] # 嬃𝍌.ୄ
+xn--b6s0078f.xn--0ic; 嬃𝍌.\u0B44; [V6]; xn--b6s0078f.xn--0ic; ; ;  # 嬃𝍌.ୄ
+xn--b6s0078f.xn--0ic557h; 嬃𝍌.\u200D\u0B44; [C2]; xn--b6s0078f.xn--0ic557h; ; ;  # 嬃𝍌.ୄ
+\u0602𝌪≯．𚋲򵁨; \u0602𝌪≯.𚋲򵁨; [B1, V7]; xn--kfb866llx01a.xn--wp1gm3570b; ; ;  # 𝌪≯.
+\u0602𝌪>\u0338．𚋲򵁨; \u0602𝌪≯.𚋲򵁨; [B1, V7]; xn--kfb866llx01a.xn--wp1gm3570b; ; ;  # 𝌪≯.
+\u0602𝌪≯.𚋲򵁨; ; [B1, V7]; xn--kfb866llx01a.xn--wp1gm3570b; ; ;  # 𝌪≯.
+\u0602𝌪>\u0338.𚋲򵁨; \u0602𝌪≯.𚋲򵁨; [B1, V7]; xn--kfb866llx01a.xn--wp1gm3570b; ; ;  # 𝌪≯.
+xn--kfb866llx01a.xn--wp1gm3570b; \u0602𝌪≯.𚋲򵁨; [B1, V7]; xn--kfb866llx01a.xn--wp1gm3570b; ; ;  # 𝌪≯.
+򫾥\u08B7\u17CC\uA9C0.𞼠; ; [B5, V7]; xn--dzb638ewm4i1iy1h.xn--3m7h; ; ;  # ࢷ៌꧀.
+xn--dzb638ewm4i1iy1h.xn--3m7h; 򫾥\u08B7\u17CC\uA9C0.𞼠; [B5, V7]; xn--dzb638ewm4i1iy1h.xn--3m7h; ; ;  # ࢷ៌꧀.
+\u200C.񟛤; ; [C1, V7]; xn--0ug.xn--q823a; ; .xn--q823a; [V7, A4_2] # .
+.xn--q823a; .񟛤; [V7, X4_2]; .xn--q823a; [V7, A4_2]; ;  # .
+xn--0ug.xn--q823a; \u200C.񟛤; [C1, V7]; xn--0ug.xn--q823a; ; ;  # .
+򺛕Ⴃ䠅．𐸑; 򺛕ⴃ䠅.𐸑; [V7]; xn--ukju77frl47r.xn--yl0d; ; ;  # ⴃ䠅.
+򺛕Ⴃ䠅.𐸑; 򺛕ⴃ䠅.𐸑; [V7]; xn--ukju77frl47r.xn--yl0d; ; ;  # ⴃ䠅.
+򺛕ⴃ䠅.𐸑; ; [V7]; xn--ukju77frl47r.xn--yl0d; ; ;  # ⴃ䠅.
+xn--ukju77frl47r.xn--yl0d; 򺛕ⴃ䠅.𐸑; [V7]; xn--ukju77frl47r.xn--yl0d; ; ;  # ⴃ䠅.
+򺛕ⴃ䠅．𐸑; 򺛕ⴃ䠅.𐸑; [V7]; xn--ukju77frl47r.xn--yl0d; ; ;  # ⴃ䠅.
+xn--bnd074zr557n.xn--yl0d; 򺛕Ⴃ䠅.𐸑; [V7]; xn--bnd074zr557n.xn--yl0d; ; ;  # Ⴃ䠅.
+\u1BF1𐹳𐹵𞤚｡𝟨Ⴅ; \u1BF1𐹳𐹵𞤼.6ⴅ; [B1, V6]; xn--zzfy954hga2415t.xn--6-kvs; ; ;  # ᯱ𐹳𐹵𞤼.6ⴅ
+\u1BF1𐹳𐹵𞤚。6Ⴅ; \u1BF1𐹳𐹵𞤼.6ⴅ; [B1, V6]; xn--zzfy954hga2415t.xn--6-kvs; ; ;  # ᯱ𐹳𐹵𞤼.6ⴅ
+\u1BF1𐹳𐹵𞤼。6ⴅ; \u1BF1𐹳𐹵𞤼.6ⴅ; [B1, V6]; xn--zzfy954hga2415t.xn--6-kvs; ; ;  # ᯱ𐹳𐹵𞤼.6ⴅ
+\u1BF1𐹳𐹵𞤚。6ⴅ; \u1BF1𐹳𐹵𞤼.6ⴅ; [B1, V6]; xn--zzfy954hga2415t.xn--6-kvs; ; ;  # ᯱ𐹳𐹵𞤼.6ⴅ
+xn--zzfy954hga2415t.xn--6-kvs; \u1BF1𐹳𐹵𞤼.6ⴅ; [B1, V6]; xn--zzfy954hga2415t.xn--6-kvs; ; ;  # ᯱ𐹳𐹵𞤼.6ⴅ
+\u1BF1𐹳𐹵𞤼｡𝟨ⴅ; \u1BF1𐹳𐹵𞤼.6ⴅ; [B1, V6]; xn--zzfy954hga2415t.xn--6-kvs; ; ;  # ᯱ𐹳𐹵𞤼.6ⴅ
+\u1BF1𐹳𐹵𞤚｡𝟨ⴅ; \u1BF1𐹳𐹵𞤼.6ⴅ; [B1, V6]; xn--zzfy954hga2415t.xn--6-kvs; ; ;  # ᯱ𐹳𐹵𞤼.6ⴅ
+xn--zzfy954hga2415t.xn--6-h0g; \u1BF1𐹳𐹵𞤼.6Ⴅ; [B1, V6, V7]; xn--zzfy954hga2415t.xn--6-h0g; ; ;  # ᯱ𐹳𐹵𞤼.6Ⴅ
+-｡︒; -.︒; [V3, V7]; -.xn--y86c; ; ;  # -.︒
+-。。; -..; [V3, X4_2]; ; [V3, A4_2]; ;  # -..
+-..; ; [V3, X4_2]; ; [V3, A4_2]; ;  # -..
+-.xn--y86c; -.︒; [V3, V7]; -.xn--y86c; ; ;  # -.︒
+\u07DBჀ｡-⁵--; \u07DBⴠ.-5--; [B1, B2, B3, V2, V3]; xn--2sb691q.-5--; ; ;  # ߛⴠ.-5--
+\u07DBჀ。-5--; \u07DBⴠ.-5--; [B1, B2, B3, V2, V3]; xn--2sb691q.-5--; ; ;  # ߛⴠ.-5--
+\u07DBⴠ。-5--; \u07DBⴠ.-5--; [B1, B2, B3, V2, V3]; xn--2sb691q.-5--; ; ;  # ߛⴠ.-5--
+xn--2sb691q.-5--; \u07DBⴠ.-5--; [B1, B2, B3, V2, V3]; xn--2sb691q.-5--; ; ;  # ߛⴠ.-5--
+\u07DBⴠ｡-⁵--; \u07DBⴠ.-5--; [B1, B2, B3, V2, V3]; xn--2sb691q.-5--; ; ;  # ߛⴠ.-5--
+xn--2sb866b.-5--; \u07DBჀ.-5--; [B1, B2, B3, V2, V3, V7]; xn--2sb866b.-5--; ; ;  # ߛჀ.-5--
+≯?󠑕｡𐹷𐹻≯𐷒; ≯?󠑕.𐹷𐹻≯𐷒; [B1, V7, U1]; xn--?-ogo25661n.xn--hdh8283gdoaqa; ; ;  # ≯?.𐹷𐹻≯
+>\u0338?󠑕｡𐹷𐹻>\u0338𐷒; ≯?󠑕.𐹷𐹻≯𐷒; [B1, V7, U1]; xn--?-ogo25661n.xn--hdh8283gdoaqa; ; ;  # ≯?.𐹷𐹻≯
+≯?󠑕。𐹷𐹻≯𐷒; ≯?󠑕.𐹷𐹻≯𐷒; [B1, V7, U1]; xn--?-ogo25661n.xn--hdh8283gdoaqa; ; ;  # ≯?.𐹷𐹻≯
+>\u0338?󠑕。𐹷𐹻>\u0338𐷒; ≯?󠑕.𐹷𐹻≯𐷒; [B1, V7, U1]; xn--?-ogo25661n.xn--hdh8283gdoaqa; ; ;  # ≯?.𐹷𐹻≯
+xn--?-ogo25661n.xn--hdh8283gdoaqa; ≯?󠑕.𐹷𐹻≯𐷒; [B1, V7, U1]; xn--?-ogo25661n.xn--hdh8283gdoaqa; ; ;  # ≯?.𐹷𐹻≯
+≯?󠑕.xn--hdh8283gdoaqa; ≯?󠑕.𐹷𐹻≯𐷒; [B1, V7, U1]; xn--?-ogo25661n.xn--hdh8283gdoaqa; ; ;  # ≯?.𐹷𐹻≯
+>\u0338?󠑕.xn--hdh8283gdoaqa; ≯?󠑕.𐹷𐹻≯𐷒; [B1, V7, U1]; xn--?-ogo25661n.xn--hdh8283gdoaqa; ; ;  # ≯?.𐹷𐹻≯
+>\u0338?󠑕.XN--HDH8283GDOAQA; ≯?󠑕.𐹷𐹻≯𐷒; [B1, V7, U1]; xn--?-ogo25661n.xn--hdh8283gdoaqa; ; ;  # ≯?.𐹷𐹻≯
+≯?󠑕.XN--HDH8283GDOAQA; ≯?󠑕.𐹷𐹻≯𐷒; [B1, V7, U1]; xn--?-ogo25661n.xn--hdh8283gdoaqa; ; ;  # ≯?.𐹷𐹻≯
+≯?󠑕.Xn--Hdh8283gdoaqa; ≯?󠑕.𐹷𐹻≯𐷒; [B1, V7, U1]; xn--?-ogo25661n.xn--hdh8283gdoaqa; ; ;  # ≯?.𐹷𐹻≯
+>\u0338?󠑕.Xn--Hdh8283gdoaqa; ≯?󠑕.𐹷𐹻≯𐷒; [B1, V7, U1]; xn--?-ogo25661n.xn--hdh8283gdoaqa; ; ;  # ≯?.𐹷𐹻≯
+㍔\u08E6\u077C\u200D。\u0346򁳊𝅶\u0604; ルーブル\u08E6\u077C\u200D.\u0346򁳊\u0604; [B1, B5, B6, C2, V6, V7]; xn--dqb73ec22c9kp8cb1j.xn--kua81lx7141a; ; xn--dqb73el09fncab4h.xn--kua81lx7141a; [B1, B5, B6, V6, V7] # ルーブルࣦݼ.͆
+ルーブル\u08E6\u077C\u200D。\u0346򁳊𝅶\u0604; ルーブル\u08E6\u077C\u200D.\u0346򁳊\u0604; [B1, B5, B6, C2, V6, V7]; xn--dqb73ec22c9kp8cb1j.xn--kua81lx7141a; ; xn--dqb73el09fncab4h.xn--kua81lx7141a; [B1, B5, B6, V6, V7] # ルーブルࣦݼ.͆
+ルーフ\u3099ル\u08E6\u077C\u200D。\u0346򁳊𝅶\u0604; ルーブル\u08E6\u077C\u200D.\u0346򁳊\u0604; [B1, B5, B6, C2, V6, V7]; xn--dqb73ec22c9kp8cb1j.xn--kua81lx7141a; ; xn--dqb73el09fncab4h.xn--kua81lx7141a; [B1, B5, B6, V6, V7] # ルーブルࣦݼ.͆
+xn--dqb73el09fncab4h.xn--kua81lx7141a; ルーブル\u08E6\u077C.\u0346򁳊\u0604; [B1, B5, B6, V6, V7]; xn--dqb73el09fncab4h.xn--kua81lx7141a; ; ;  # ルーブルࣦݼ.͆
+xn--dqb73ec22c9kp8cb1j.xn--kua81lx7141a; ルーブル\u08E6\u077C\u200D.\u0346򁳊\u0604; [B1, B5, B6, C2, V6, V7]; xn--dqb73ec22c9kp8cb1j.xn--kua81lx7141a; ; ;  # ルーブルࣦݼ.͆
+xn--dqb73el09fncab4h.xn--kua81ls548d3608b; ルーブル\u08E6\u077C.\u0346򁳊𝅶\u0604; [B1, B5, B6, V6, V7]; xn--dqb73el09fncab4h.xn--kua81ls548d3608b; ; ;  # ルーブルࣦݼ.͆
+xn--dqb73ec22c9kp8cb1j.xn--kua81ls548d3608b; ルーブル\u08E6\u077C\u200D.\u0346򁳊𝅶\u0604; [B1, B5, B6, C2, V6, V7]; xn--dqb73ec22c9kp8cb1j.xn--kua81ls548d3608b; ; ;  # ルーブルࣦݼ.͆
+\u200D.F; \u200D.f; [C2]; xn--1ug.f; ; .f; [A4_2] # .f
+\u200D.f; ; [C2]; xn--1ug.f; ; .f; [A4_2] # .f
+.f; ; [X4_2]; ; [A4_2]; ;  # .f
+xn--1ug.f; \u200D.f; [C2]; xn--1ug.f; ; ;  # .f
+f; ; ; ; ; ;  # f
+\u200D㨲｡ß; \u200D㨲.ß; [C2]; xn--1ug914h.xn--zca; ; xn--9bm.ss; [] # 㨲.ß
+\u200D㨲。ß; \u200D㨲.ß; [C2]; xn--1ug914h.xn--zca; ; xn--9bm.ss; [] # 㨲.ß
+\u200D㨲。SS; \u200D㨲.ss; [C2]; xn--1ug914h.ss; ; xn--9bm.ss; [] # 㨲.ss
+\u200D㨲。ss; \u200D㨲.ss; [C2]; xn--1ug914h.ss; ; xn--9bm.ss; [] # 㨲.ss
+\u200D㨲。Ss; \u200D㨲.ss; [C2]; xn--1ug914h.ss; ; xn--9bm.ss; [] # 㨲.ss
+xn--9bm.ss; 㨲.ss; ; xn--9bm.ss; ; ;  # 㨲.ss
+㨲.ss; ; ; xn--9bm.ss; ; ;  # 㨲.ss
+㨲.SS; 㨲.ss; ; xn--9bm.ss; ; ;  # 㨲.ss
+㨲.Ss; 㨲.ss; ; xn--9bm.ss; ; ;  # 㨲.ss
+xn--1ug914h.ss; \u200D㨲.ss; [C2]; xn--1ug914h.ss; ; ;  # 㨲.ss
+xn--1ug914h.xn--zca; \u200D㨲.ß; [C2]; xn--1ug914h.xn--zca; ; ;  # 㨲.ß
+\u200D㨲｡SS; \u200D㨲.ss; [C2]; xn--1ug914h.ss; ; xn--9bm.ss; [] # 㨲.ss
+\u200D㨲｡ss; \u200D㨲.ss; [C2]; xn--1ug914h.ss; ; xn--9bm.ss; [] # 㨲.ss
+\u200D㨲｡Ss; \u200D㨲.ss; [C2]; xn--1ug914h.ss; ; xn--9bm.ss; [] # 㨲.ss
+\u0605\u067E｡\u08A8; \u0605\u067E.\u08A8; [B1, V7]; xn--nfb6v.xn--xyb; ; ;  # پ.ࢨ
+\u0605\u067E。\u08A8; \u0605\u067E.\u08A8; [B1, V7]; xn--nfb6v.xn--xyb; ; ;  # پ.ࢨ
+xn--nfb6v.xn--xyb; \u0605\u067E.\u08A8; [B1, V7]; xn--nfb6v.xn--xyb; ; ;  # پ.ࢨ
+⾑\u0753𞤁。𐹵\u0682; 襾\u0753𞤣.𐹵\u0682; [B1, B5, B6]; xn--6ob9577deqwl.xn--7ib5526k; ; ;  # 襾ݓ𞤣.𐹵ڂ
+襾\u0753𞤁。𐹵\u0682; 襾\u0753𞤣.𐹵\u0682; [B1, B5, B6]; xn--6ob9577deqwl.xn--7ib5526k; ; ;  # 襾ݓ𞤣.𐹵ڂ
+襾\u0753𞤣。𐹵\u0682; 襾\u0753𞤣.𐹵\u0682; [B1, B5, B6]; xn--6ob9577deqwl.xn--7ib5526k; ; ;  # 襾ݓ𞤣.𐹵ڂ
+xn--6ob9577deqwl.xn--7ib5526k; 襾\u0753𞤣.𐹵\u0682; [B1, B5, B6]; xn--6ob9577deqwl.xn--7ib5526k; ; ;  # 襾ݓ𞤣.𐹵ڂ
+⾑\u0753𞤣。𐹵\u0682; 襾\u0753𞤣.𐹵\u0682; [B1, B5, B6]; xn--6ob9577deqwl.xn--7ib5526k; ; ;  # 襾ݓ𞤣.𐹵ڂ
+񦴻ς-\u20EB｡\u0754-ꡛ; 񦴻ς-\u20EB.\u0754-ꡛ; [B2, B3, B6, V7]; xn----xmb015tuo34l.xn----53c4874j; ; xn----zmb705tuo34l.xn----53c4874j;  # ς-⃫.ݔ-ꡛ
+񦴻ς-\u20EB。\u0754-ꡛ; 񦴻ς-\u20EB.\u0754-ꡛ; [B2, B3, B6, V7]; xn----xmb015tuo34l.xn----53c4874j; ; xn----zmb705tuo34l.xn----53c4874j;  # ς-⃫.ݔ-ꡛ
+񦴻Σ-\u20EB。\u0754-ꡛ; 񦴻σ-\u20EB.\u0754-ꡛ; [B2, B3, B6, V7]; xn----zmb705tuo34l.xn----53c4874j; ; ;  # σ-⃫.ݔ-ꡛ
+񦴻σ-\u20EB。\u0754-ꡛ; 񦴻σ-\u20EB.\u0754-ꡛ; [B2, B3, B6, V7]; xn----zmb705tuo34l.xn----53c4874j; ; ;  # σ-⃫.ݔ-ꡛ
+xn----zmb705tuo34l.xn----53c4874j; 񦴻σ-\u20EB.\u0754-ꡛ; [B2, B3, B6, V7]; xn----zmb705tuo34l.xn----53c4874j; ; ;  # σ-⃫.ݔ-ꡛ
+xn----xmb015tuo34l.xn----53c4874j; 񦴻ς-\u20EB.\u0754-ꡛ; [B2, B3, B6, V7]; xn----xmb015tuo34l.xn----53c4874j; ; ;  # ς-⃫.ݔ-ꡛ
+񦴻Σ-\u20EB｡\u0754-ꡛ; 񦴻σ-\u20EB.\u0754-ꡛ; [B2, B3, B6, V7]; xn----zmb705tuo34l.xn----53c4874j; ; ;  # σ-⃫.ݔ-ꡛ
+񦴻σ-\u20EB｡\u0754-ꡛ; 񦴻σ-\u20EB.\u0754-ꡛ; [B2, B3, B6, V7]; xn----zmb705tuo34l.xn----53c4874j; ; ;  # σ-⃫.ݔ-ꡛ
+\u200D．􀸨; \u200D.􀸨; [C2, V7]; xn--1ug.xn--h327f; ; .xn--h327f; [V7, A4_2] # .
+\u200D.􀸨; ; [C2, V7]; xn--1ug.xn--h327f; ; .xn--h327f; [V7, A4_2] # .
+.xn--h327f; .􀸨; [V7, X4_2]; .xn--h327f; [V7, A4_2]; ;  # .
+xn--1ug.xn--h327f; \u200D.􀸨; [C2, V7]; xn--1ug.xn--h327f; ; ;  # .
+񣭻񌥁｡≠𝟲; 񣭻񌥁.≠6; [V7]; xn--h79w4z99a.xn--6-tfo; ; ;  # .≠6
+񣭻񌥁｡=\u0338𝟲; 񣭻񌥁.≠6; [V7]; xn--h79w4z99a.xn--6-tfo; ; ;  # .≠6
+񣭻񌥁。≠6; 񣭻񌥁.≠6; [V7]; xn--h79w4z99a.xn--6-tfo; ; ;  # .≠6
+񣭻񌥁。=\u03386; 񣭻񌥁.≠6; [V7]; xn--h79w4z99a.xn--6-tfo; ; ;  # .≠6
+xn--h79w4z99a.xn--6-tfo; 񣭻񌥁.≠6; [V7]; xn--h79w4z99a.xn--6-tfo; ; ;  # .≠6
+󠅊ᡭ\u200D.𐥡; ᡭ\u200D.𐥡; [B6, C2, V7]; xn--98e810b.xn--om9c; ; xn--98e.xn--om9c; [V7] # ᡭ.
+xn--98e.xn--om9c; ᡭ.𐥡; [V7]; xn--98e.xn--om9c; ; ;  # ᡭ.
+xn--98e810b.xn--om9c; ᡭ\u200D.𐥡; [B6, C2, V7]; xn--98e810b.xn--om9c; ; ;  # ᡭ.
+\u0C40\u0855𐥛𑄴．󭰵; \u0C40\u0855𐥛𑄴.󭰵; [B1, V6, V7]; xn--kwb91r5112avtg.xn--o580f; ; ;  # ీࡕ𑄴.
+\u0C40\u0855𐥛𑄴.󭰵; ; [B1, V6, V7]; xn--kwb91r5112avtg.xn--o580f; ; ;  # ీࡕ𑄴.
+xn--kwb91r5112avtg.xn--o580f; \u0C40\u0855𐥛𑄴.󭰵; [B1, V6, V7]; xn--kwb91r5112avtg.xn--o580f; ; ;  # ీࡕ𑄴.
+𞤮。𑇊\u200C≯\u1CE6; 𞤮.𑇊\u200C≯\u1CE6; [B1, C1, V6]; xn--me6h.xn--z6f16kn9b2642b; ; xn--me6h.xn--z6fz8ueq2v; [B1, V6] # 𞤮.𑇊≯᳦
+𞤮。𑇊\u200C>\u0338\u1CE6; 𞤮.𑇊\u200C≯\u1CE6; [B1, C1, V6]; xn--me6h.xn--z6f16kn9b2642b; ; xn--me6h.xn--z6fz8ueq2v; [B1, V6] # 𞤮.𑇊≯᳦
+𞤌。𑇊\u200C>\u0338\u1CE6; 𞤮.𑇊\u200C≯\u1CE6; [B1, C1, V6]; xn--me6h.xn--z6f16kn9b2642b; ; xn--me6h.xn--z6fz8ueq2v; [B1, V6] # 𞤮.𑇊≯᳦
+𞤌。𑇊\u200C≯\u1CE6; 𞤮.𑇊\u200C≯\u1CE6; [B1, C1, V6]; xn--me6h.xn--z6f16kn9b2642b; ; xn--me6h.xn--z6fz8ueq2v; [B1, V6] # 𞤮.𑇊≯᳦
+xn--me6h.xn--z6fz8ueq2v; 𞤮.𑇊≯\u1CE6; [B1, V6]; xn--me6h.xn--z6fz8ueq2v; ; ;  # 𞤮.𑇊≯᳦
+xn--me6h.xn--z6f16kn9b2642b; 𞤮.𑇊\u200C≯\u1CE6; [B1, C1, V6]; xn--me6h.xn--z6f16kn9b2642b; ; ;  # 𞤮.𑇊≯᳦
+󠄀𝟕.𞤌񛗓Ⴉ; 7.𞤮񛗓ⴉ; [B1, B2, B3, V7]; 7.xn--0kjz523lv1vv; ; ;  # 7.𞤮ⴉ
+󠄀7.𞤌񛗓Ⴉ; 7.𞤮񛗓ⴉ; [B1, B2, B3, V7]; 7.xn--0kjz523lv1vv; ; ;  # 7.𞤮ⴉ
+󠄀7.𞤮񛗓ⴉ; 7.𞤮񛗓ⴉ; [B1, B2, B3, V7]; 7.xn--0kjz523lv1vv; ; ;  # 7.𞤮ⴉ
+7.xn--0kjz523lv1vv; 7.𞤮񛗓ⴉ; [B1, B2, B3, V7]; 7.xn--0kjz523lv1vv; ; ;  # 7.𞤮ⴉ
+󠄀𝟕.𞤮񛗓ⴉ; 7.𞤮񛗓ⴉ; [B1, B2, B3, V7]; 7.xn--0kjz523lv1vv; ; ;  # 7.𞤮ⴉ
+7.xn--hnd3403vv1vv; 7.𞤮񛗓Ⴉ; [B1, B2, B3, V7]; 7.xn--hnd3403vv1vv; ; ;  # 7.𞤮Ⴉ
+󠄀7.𞤌񛗓ⴉ; 7.𞤮񛗓ⴉ; [B1, B2, B3, V7]; 7.xn--0kjz523lv1vv; ; ;  # 7.𞤮ⴉ
+󠄀𝟕.𞤌񛗓ⴉ; 7.𞤮񛗓ⴉ; [B1, B2, B3, V7]; 7.xn--0kjz523lv1vv; ; ;  # 7.𞤮ⴉ
+閃9𝩍。Ↄ\u0669\u08B1\u0B4D; 閃9𝩍.ↄ\u0669\u08B1\u0B4D; [B5, B6]; xn--9-3j6dk517f.xn--iib28ij3c4t9a; ; ;  # 閃9𝩍.ↄ٩ࢱ୍
+閃9𝩍。ↄ\u0669\u08B1\u0B4D; 閃9𝩍.ↄ\u0669\u08B1\u0B4D; [B5, B6]; xn--9-3j6dk517f.xn--iib28ij3c4t9a; ; ;  # 閃9𝩍.ↄ٩ࢱ୍
+xn--9-3j6dk517f.xn--iib28ij3c4t9a; 閃9𝩍.ↄ\u0669\u08B1\u0B4D; [B5, B6]; xn--9-3j6dk517f.xn--iib28ij3c4t9a; ; ;  # 閃9𝩍.ↄ٩ࢱ୍
+xn--9-3j6dk517f.xn--iib28ij3c0t9a; 閃9𝩍.Ↄ\u0669\u08B1\u0B4D; [B5, B6, V7]; xn--9-3j6dk517f.xn--iib28ij3c0t9a; ; ;  # 閃9𝩍.Ↄ٩ࢱ୍
+\uAAF6ᢏ\u0E3A２.𐋢\u0745\u0F9F︒; \uAAF6ᢏ\u0E3A2.𐋢\u0745\u0F9F︒; [V6, V7]; xn--2-2zf840fk16m.xn--sob093bj62sz9d; ; ;  # ꫶ᢏฺ2.𐋢݅ྟ︒
+\uAAF6ᢏ\u0E3A2.𐋢\u0745\u0F9F。; \uAAF6ᢏ\u0E3A2.𐋢\u0745\u0F9F.; [V6]; xn--2-2zf840fk16m.xn--sob093b2m7s.; [V6, A4_2]; ;  # ꫶ᢏฺ2.𐋢݅ྟ.
+xn--2-2zf840fk16m.xn--sob093b2m7s.; \uAAF6ᢏ\u0E3A2.𐋢\u0745\u0F9F.; [V6]; xn--2-2zf840fk16m.xn--sob093b2m7s.; [V6, A4_2]; ;  # ꫶ᢏฺ2.𐋢݅ྟ.
+xn--2-2zf840fk16m.xn--sob093bj62sz9d; \uAAF6ᢏ\u0E3A2.𐋢\u0745\u0F9F︒; [V6, V7]; xn--2-2zf840fk16m.xn--sob093bj62sz9d; ; ;  # ꫶ᢏฺ2.𐋢݅ྟ︒
+󅴧｡≠-󠙄⾛; 󅴧.≠-󠙄走; [V7]; xn--gm57d.xn----tfo4949b3664m; ; ;  # .≠-走
+󅴧｡=\u0338-󠙄⾛; 󅴧.≠-󠙄走; [V7]; xn--gm57d.xn----tfo4949b3664m; ; ;  # .≠-走
+󅴧。≠-󠙄走; 󅴧.≠-󠙄走; [V7]; xn--gm57d.xn----tfo4949b3664m; ; ;  # .≠-走
+󅴧。=\u0338-󠙄走; 󅴧.≠-󠙄走; [V7]; xn--gm57d.xn----tfo4949b3664m; ; ;  # .≠-走
+xn--gm57d.xn----tfo4949b3664m; 󅴧.≠-󠙄走; [V7]; xn--gm57d.xn----tfo4949b3664m; ; ;  # .≠-走
+\u076E\u0604Ⴊ。-≠\u1160; \u076E\u0604ⴊ.-≠; [B1, B2, B3, V3, V7]; xn--mfb73ek93f.xn----ufo; ; ;  # ݮⴊ.-≠
+\u076E\u0604Ⴊ。-=\u0338\u1160; \u076E\u0604ⴊ.-≠; [B1, B2, B3, V3, V7]; xn--mfb73ek93f.xn----ufo; ; ;  # ݮⴊ.-≠
+\u076E\u0604ⴊ。-=\u0338\u1160; \u076E\u0604ⴊ.-≠; [B1, B2, B3, V3, V7]; xn--mfb73ek93f.xn----ufo; ; ;  # ݮⴊ.-≠
+\u076E\u0604ⴊ。-≠\u1160; \u076E\u0604ⴊ.-≠; [B1, B2, B3, V3, V7]; xn--mfb73ek93f.xn----ufo; ; ;  # ݮⴊ.-≠
+xn--mfb73ek93f.xn----ufo; \u076E\u0604ⴊ.-≠; [B1, B2, B3, V3, V7]; xn--mfb73ek93f.xn----ufo; ; ;  # ݮⴊ.-≠
+xn--mfb73ek93f.xn----5bh589i; \u076E\u0604ⴊ.-≠\u1160; [B1, B2, B3, V3, V7]; xn--mfb73ek93f.xn----5bh589i; ; ;  # ݮⴊ.-≠
+xn--mfb73ex6r.xn----5bh589i; \u076E\u0604Ⴊ.-≠\u1160; [B1, B2, B3, V3, V7]; xn--mfb73ex6r.xn----5bh589i; ; ;  # ݮႪ.-≠
+\uFB4F𐹧𝟒≯｡\u200C; \u05D0\u05DC𐹧4≯.\u200C; [B1, B3, B4, C1]; xn--4-zhc0by36txt0w.xn--0ug; ; xn--4-zhc0by36txt0w.; [B3, B4, A4_2] # אל𐹧4≯.
+\uFB4F𐹧𝟒>\u0338｡\u200C; \u05D0\u05DC𐹧4≯.\u200C; [B1, B3, B4, C1]; xn--4-zhc0by36txt0w.xn--0ug; ; xn--4-zhc0by36txt0w.; [B3, B4, A4_2] # אל𐹧4≯.
+\u05D0\u05DC𐹧4≯。\u200C; \u05D0\u05DC𐹧4≯.\u200C; [B1, B3, B4, C1]; xn--4-zhc0by36txt0w.xn--0ug; ; xn--4-zhc0by36txt0w.; [B3, B4, A4_2] # אל𐹧4≯.
+\u05D0\u05DC𐹧4>\u0338。\u200C; \u05D0\u05DC𐹧4≯.\u200C; [B1, B3, B4, C1]; xn--4-zhc0by36txt0w.xn--0ug; ; xn--4-zhc0by36txt0w.; [B3, B4, A4_2] # אל𐹧4≯.
+xn--4-zhc0by36txt0w.; \u05D0\u05DC𐹧4≯.; [B3, B4]; xn--4-zhc0by36txt0w.; [B3, B4, A4_2]; ;  # אל𐹧4≯.
+xn--4-zhc0by36txt0w.xn--0ug; \u05D0\u05DC𐹧4≯.\u200C; [B1, B3, B4, C1]; xn--4-zhc0by36txt0w.xn--0ug; ; ;  # אל𐹧4≯.
+𝟎。甯; 0.甯; ; 0.xn--qny; ; ;  # 0.甯
+0。甯; 0.甯; ; 0.xn--qny; ; ;  # 0.甯
+0.xn--qny; 0.甯; ; 0.xn--qny; ; ;  # 0.甯
+0.甯; ; ; 0.xn--qny; ; ;  # 0.甯
+-⾆．\uAAF6; -舌.\uAAF6; [V3, V6]; xn----ef8c.xn--2v9a; ; ;  # -舌.꫶
+-舌.\uAAF6; ; [V3, V6]; xn----ef8c.xn--2v9a; ; ;  # -舌.꫶
+xn----ef8c.xn--2v9a; -舌.\uAAF6; [V3, V6]; xn----ef8c.xn--2v9a; ; ;  # -舌.꫶
+-｡ᢘ; -.ᢘ; [V3]; -.xn--ibf; ; ;  # -.ᢘ
+-。ᢘ; -.ᢘ; [V3]; -.xn--ibf; ; ;  # -.ᢘ
+-.xn--ibf; -.ᢘ; [V3]; -.xn--ibf; ; ;  # -.ᢘ
+🂴Ⴋ.≮; 🂴ⴋ.≮; ; xn--2kj7565l.xn--gdh; ; ;  # 🂴ⴋ.≮
+🂴Ⴋ.<\u0338; 🂴ⴋ.≮; ; xn--2kj7565l.xn--gdh; ; ;  # 🂴ⴋ.≮
+🂴ⴋ.<\u0338; 🂴ⴋ.≮; ; xn--2kj7565l.xn--gdh; ; ;  # 🂴ⴋ.≮
+🂴ⴋ.≮; ; ; xn--2kj7565l.xn--gdh; ; ;  # 🂴ⴋ.≮
+xn--2kj7565l.xn--gdh; 🂴ⴋ.≮; ; xn--2kj7565l.xn--gdh; ; ;  # 🂴ⴋ.≮
+xn--jnd1986v.xn--gdh; 🂴Ⴋ.≮; [V7]; xn--jnd1986v.xn--gdh; ; ;  # 🂴Ⴋ.≮
+璼𝨭｡\u200C󠇟; 璼𝨭.\u200C; [C1]; xn--gky8837e.xn--0ug; ; xn--gky8837e.; [A4_2] # 璼𝨭.
+璼𝨭。\u200C󠇟; 璼𝨭.\u200C; [C1]; xn--gky8837e.xn--0ug; ; xn--gky8837e.; [A4_2] # 璼𝨭.
+xn--gky8837e.; 璼𝨭.; ; xn--gky8837e.; [A4_2]; ;  # 璼𝨭.
+璼𝨭.; ; ; xn--gky8837e.; [A4_2]; ;  # 璼𝨭.
+xn--gky8837e.xn--0ug; 璼𝨭.\u200C; [C1]; xn--gky8837e.xn--0ug; ; ;  # 璼𝨭.
+\u06698񂍽｡-5🞥; \u06698񂍽.-5🞥; [B1, V3, V7]; xn--8-qqc97891f.xn---5-rp92a; ; ;  # ٩8.-5🞥
+\u06698񂍽。-5🞥; \u06698񂍽.-5🞥; [B1, V3, V7]; xn--8-qqc97891f.xn---5-rp92a; ; ;  # ٩8.-5🞥
+xn--8-qqc97891f.xn---5-rp92a; \u06698񂍽.-5🞥; [B1, V3, V7]; xn--8-qqc97891f.xn---5-rp92a; ; ;  # ٩8.-5🞥
+\u200C.\u200C; ; [C1]; xn--0ug.xn--0ug; ; .; [A4_1, A4_2] # .
+xn--0ug.xn--0ug; \u200C.\u200C; [C1]; xn--0ug.xn--0ug; ; ;  # .
+\u200D튛.\u0716; ; [B1, C2]; xn--1ug4441e.xn--gnb; ; xn--157b.xn--gnb; [] # 튛.ܖ
+\u200D튛.\u0716; \u200D튛.\u0716; [B1, C2]; xn--1ug4441e.xn--gnb; ; xn--157b.xn--gnb; [] # 튛.ܖ
+xn--157b.xn--gnb; 튛.\u0716; ; xn--157b.xn--gnb; ; ;  # 튛.ܖ
+튛.\u0716; ; ; xn--157b.xn--gnb; ; ;  # 튛.ܖ
+튛.\u0716; 튛.\u0716; ; xn--157b.xn--gnb; ; ;  # 튛.ܖ
+xn--1ug4441e.xn--gnb; \u200D튛.\u0716; [B1, C2]; xn--1ug4441e.xn--gnb; ; ;  # 튛.ܖ
+ᡋ𐹰𞽳.\u0779ⴞ; ; [B2, B3, B5, B6, V7]; xn--b8e0417jocvf.xn--9pb883q; ; ;  # ᡋ𐹰.ݹⴞ
+ᡋ𐹰𞽳.\u0779Ⴞ; ᡋ𐹰𞽳.\u0779ⴞ; [B2, B3, B5, B6, V7]; xn--b8e0417jocvf.xn--9pb883q; ; ;  # ᡋ𐹰.ݹⴞ
+xn--b8e0417jocvf.xn--9pb883q; ᡋ𐹰𞽳.\u0779ⴞ; [B2, B3, B5, B6, V7]; xn--b8e0417jocvf.xn--9pb883q; ; ;  # ᡋ𐹰.ݹⴞ
+xn--b8e0417jocvf.xn--9pb068b; ᡋ𐹰𞽳.\u0779Ⴞ; [B2, B3, B5, B6, V7]; xn--b8e0417jocvf.xn--9pb068b; ; ;  # ᡋ𐹰.ݹႾ
+𐷃\u0662𝅻𝟧．𐹮𐹬Ⴇ; 𐷃\u0662𝅻5.𐹮𐹬ⴇ; [B1, B4, V7]; xn--5-cqc8833rhv7f.xn--ykjz523efa; ; ;  # ٢𝅻5.𐹮𐹬ⴇ
+𐷃\u0662𝅻5.𐹮𐹬Ⴇ; 𐷃\u0662𝅻5.𐹮𐹬ⴇ; [B1, B4, V7]; xn--5-cqc8833rhv7f.xn--ykjz523efa; ; ;  # ٢𝅻5.𐹮𐹬ⴇ
+𐷃\u0662𝅻5.𐹮𐹬ⴇ; ; [B1, B4, V7]; xn--5-cqc8833rhv7f.xn--ykjz523efa; ; ;  # ٢𝅻5.𐹮𐹬ⴇ
+xn--5-cqc8833rhv7f.xn--ykjz523efa; 𐷃\u0662𝅻5.𐹮𐹬ⴇ; [B1, B4, V7]; xn--5-cqc8833rhv7f.xn--ykjz523efa; ; ;  # ٢𝅻5.𐹮𐹬ⴇ
+𐷃\u0662𝅻𝟧．𐹮𐹬ⴇ; 𐷃\u0662𝅻5.𐹮𐹬ⴇ; [B1, B4, V7]; xn--5-cqc8833rhv7f.xn--ykjz523efa; ; ;  # ٢𝅻5.𐹮𐹬ⴇ
+xn--5-cqc8833rhv7f.xn--fnd3401kfa; 𐷃\u0662𝅻5.𐹮𐹬Ⴇ; [B1, B4, V7]; xn--5-cqc8833rhv7f.xn--fnd3401kfa; ; ;  # ٢𝅻5.𐹮𐹬Ⴇ
+Ⴗ．\u05C2𑄴\uA9B7񘃨; ⴗ.𑄴\u05C2\uA9B7񘃨; [V6, V7]; xn--flj.xn--qdb0605f14ycrms3c; ; ;  # ⴗ.𑄴ׂꦷ
+Ⴗ．𑄴\u05C2\uA9B7񘃨; ⴗ.𑄴\u05C2\uA9B7񘃨; [V6, V7]; xn--flj.xn--qdb0605f14ycrms3c; ; ;  # ⴗ.𑄴ׂꦷ
+Ⴗ.𑄴\u05C2\uA9B7񘃨; ⴗ.𑄴\u05C2\uA9B7񘃨; [V6, V7]; xn--flj.xn--qdb0605f14ycrms3c; ; ;  # ⴗ.𑄴ׂꦷ
+ⴗ.𑄴\u05C2\uA9B7񘃨; ; [V6, V7]; xn--flj.xn--qdb0605f14ycrms3c; ; ;  # ⴗ.𑄴ׂꦷ
+xn--flj.xn--qdb0605f14ycrms3c; ⴗ.𑄴\u05C2\uA9B7񘃨; [V6, V7]; xn--flj.xn--qdb0605f14ycrms3c; ; ;  # ⴗ.𑄴ׂꦷ
+ⴗ．𑄴\u05C2\uA9B7񘃨; ⴗ.𑄴\u05C2\uA9B7񘃨; [V6, V7]; xn--flj.xn--qdb0605f14ycrms3c; ; ;  # ⴗ.𑄴ׂꦷ
+ⴗ．\u05C2𑄴\uA9B7񘃨; ⴗ.𑄴\u05C2\uA9B7񘃨; [V6, V7]; xn--flj.xn--qdb0605f14ycrms3c; ; ;  # ⴗ.𑄴ׂꦷ
+xn--vnd.xn--qdb0605f14ycrms3c; Ⴗ.𑄴\u05C2\uA9B7񘃨; [V6, V7]; xn--vnd.xn--qdb0605f14ycrms3c; ; ;  # Ⴗ.𑄴ׂꦷ
+𝟾𾤘．򇕛\u066C; 8𾤘.򇕛\u066C; [B1, B5, B6, V7]; xn--8-kh23b.xn--lib78461i; ; ;  # 8.٬
+8𾤘.򇕛\u066C; ; [B1, B5, B6, V7]; xn--8-kh23b.xn--lib78461i; ; ;  # 8.٬
+xn--8-kh23b.xn--lib78461i; 8𾤘.򇕛\u066C; [B1, B5, B6, V7]; xn--8-kh23b.xn--lib78461i; ; ;  # 8.٬
+⒈酫︒。\u08D6; ⒈酫︒.\u08D6; [V6, V7]; xn--tsh4490bfe8c.xn--8zb; ; ;  # ⒈酫︒.ࣖ
+1.酫。。\u08D6; 1.酫..\u08D6; [V6, X4_2]; 1.xn--8j4a..xn--8zb; [V6, A4_2]; ;  # 1.酫..ࣖ
+1.xn--8j4a..xn--8zb; 1.酫..\u08D6; [V6, X4_2]; 1.xn--8j4a..xn--8zb; [V6, A4_2]; ;  # 1.酫..ࣖ
+xn--tsh4490bfe8c.xn--8zb; ⒈酫︒.\u08D6; [V6, V7]; xn--tsh4490bfe8c.xn--8zb; ; ;  # ⒈酫︒.ࣖ
+\u2DE3\u200C≮\u1A6B.\u200C\u0E3A; ; [C1, V6]; xn--uof63xk4bf3s.xn--o4c732g; ; xn--uof548an0j.xn--o4c; [V6] # ⷣ≮ᩫ.ฺ
+\u2DE3\u200C<\u0338\u1A6B.\u200C\u0E3A; \u2DE3\u200C≮\u1A6B.\u200C\u0E3A; [C1, V6]; xn--uof63xk4bf3s.xn--o4c732g; ; xn--uof548an0j.xn--o4c; [V6] # ⷣ≮ᩫ.ฺ
+xn--uof548an0j.xn--o4c; \u2DE3≮\u1A6B.\u0E3A; [V6]; xn--uof548an0j.xn--o4c; ; ;  # ⷣ≮ᩫ.ฺ
+xn--uof63xk4bf3s.xn--o4c732g; \u2DE3\u200C≮\u1A6B.\u200C\u0E3A; [C1, V6]; xn--uof63xk4bf3s.xn--o4c732g; ; ;  # ⷣ≮ᩫ.ฺ
+𞪂。ႷႽ¹\u200D; 𞪂.ⴗⴝ1\u200D; [B6, C2, V7]; xn--co6h.xn--1-ugn710dya; ; xn--co6h.xn--1-kwssa; [V7] # .ⴗⴝ1
+𞪂。ႷႽ1\u200D; 𞪂.ⴗⴝ1\u200D; [B6, C2, V7]; xn--co6h.xn--1-ugn710dya; ; xn--co6h.xn--1-kwssa; [V7] # .ⴗⴝ1
+𞪂。ⴗⴝ1\u200D; 𞪂.ⴗⴝ1\u200D; [B6, C2, V7]; xn--co6h.xn--1-ugn710dya; ; xn--co6h.xn--1-kwssa; [V7] # .ⴗⴝ1
+𞪂。Ⴗⴝ1\u200D; 𞪂.ⴗⴝ1\u200D; [B6, C2, V7]; xn--co6h.xn--1-ugn710dya; ; xn--co6h.xn--1-kwssa; [V7] # .ⴗⴝ1
+xn--co6h.xn--1-kwssa; 𞪂.ⴗⴝ1; [V7]; xn--co6h.xn--1-kwssa; ; ;  # .ⴗⴝ1
+xn--co6h.xn--1-ugn710dya; 𞪂.ⴗⴝ1\u200D; [B6, C2, V7]; xn--co6h.xn--1-ugn710dya; ; ;  # .ⴗⴝ1
+𞪂。ⴗⴝ¹\u200D; 𞪂.ⴗⴝ1\u200D; [B6, C2, V7]; xn--co6h.xn--1-ugn710dya; ; xn--co6h.xn--1-kwssa; [V7] # .ⴗⴝ1
+𞪂。Ⴗⴝ¹\u200D; 𞪂.ⴗⴝ1\u200D; [B6, C2, V7]; xn--co6h.xn--1-ugn710dya; ; xn--co6h.xn--1-kwssa; [V7] # .ⴗⴝ1
+xn--co6h.xn--1-h1g429s; 𞪂.Ⴗⴝ1; [V7]; xn--co6h.xn--1-h1g429s; ; ;  # .Ⴗⴝ1
+xn--co6h.xn--1-h1g398iewm; 𞪂.Ⴗⴝ1\u200D; [B6, C2, V7]; xn--co6h.xn--1-h1g398iewm; ; ;  # .Ⴗⴝ1
+xn--co6h.xn--1-h1gs; 𞪂.ႷႽ1; [V7]; xn--co6h.xn--1-h1gs; ; ;  # .ႷႽ1
+xn--co6h.xn--1-h1gs597m; 𞪂.ႷႽ1\u200D; [B6, C2, V7]; xn--co6h.xn--1-h1gs597m; ; ;  # .ႷႽ1
+𑄴𑄳2.𞳿󠀳-; ; [B1, B3, V3, V6, V7]; xn--2-h87ic.xn----s39r33498d; ; ;  # 𑄴𑄳2.-
+xn--2-h87ic.xn----s39r33498d; 𑄴𑄳2.𞳿󠀳-; [B1, B3, V3, V6, V7]; xn--2-h87ic.xn----s39r33498d; ; ;  # 𑄴𑄳2.-
+󠕲󟶶\u0665｡񀁁𑄳𞤃\u0710; 󠕲󟶶\u0665.񀁁𑄳𞤥\u0710; [B1, B5, B6, V7]; xn--eib57614py3ea.xn--9mb5737kqnpfzkwr; ; ;  # ٥.𑄳𞤥ܐ
+󠕲󟶶\u0665。񀁁𑄳𞤃\u0710; 󠕲󟶶\u0665.񀁁𑄳𞤥\u0710; [B1, B5, B6, V7]; xn--eib57614py3ea.xn--9mb5737kqnpfzkwr; ; ;  # ٥.𑄳𞤥ܐ
+󠕲󟶶\u0665。񀁁𑄳𞤥\u0710; 󠕲󟶶\u0665.񀁁𑄳𞤥\u0710; [B1, B5, B6, V7]; xn--eib57614py3ea.xn--9mb5737kqnpfzkwr; ; ;  # ٥.𑄳𞤥ܐ
+xn--eib57614py3ea.xn--9mb5737kqnpfzkwr; 󠕲󟶶\u0665.񀁁𑄳𞤥\u0710; [B1, B5, B6, V7]; xn--eib57614py3ea.xn--9mb5737kqnpfzkwr; ; ;  # ٥.𑄳𞤥ܐ
+󠕲󟶶\u0665｡񀁁𑄳𞤥\u0710; 󠕲󟶶\u0665.񀁁𑄳𞤥\u0710; [B1, B5, B6, V7]; xn--eib57614py3ea.xn--9mb5737kqnpfzkwr; ; ;  # ٥.𑄳𞤥ܐ
+\u0720򲠽𐹢\u17BB｡ςᢈ🝭\u200C; \u0720򲠽𐹢\u17BB.ςᢈ🝭\u200C; [B2, B6, C1, V7]; xn--qnb616fis0qzt36f.xn--3xa057h6ofgl44c; ; xn--qnb616fis0qzt36f.xn--4xa847hli46a; [B2, B6, V7] # ܠ𐹢ុ.ςᢈ🝭
+\u0720򲠽𐹢\u17BB。ςᢈ🝭\u200C; \u0720򲠽𐹢\u17BB.ςᢈ🝭\u200C; [B2, B6, C1, V7]; xn--qnb616fis0qzt36f.xn--3xa057h6ofgl44c; ; xn--qnb616fis0qzt36f.xn--4xa847hli46a; [B2, B6, V7] # ܠ𐹢ុ.ςᢈ🝭
+\u0720򲠽𐹢\u17BB。Σᢈ🝭\u200C; \u0720򲠽𐹢\u17BB.σᢈ🝭\u200C; [B2, B6, C1, V7]; xn--qnb616fis0qzt36f.xn--4xa847h6ofgl44c; ; xn--qnb616fis0qzt36f.xn--4xa847hli46a; [B2, B6, V7] # ܠ𐹢ុ.σᢈ🝭
+\u0720򲠽𐹢\u17BB。σᢈ🝭\u200C; \u0720򲠽𐹢\u17BB.σᢈ🝭\u200C; [B2, B6, C1, V7]; xn--qnb616fis0qzt36f.xn--4xa847h6ofgl44c; ; xn--qnb616fis0qzt36f.xn--4xa847hli46a; [B2, B6, V7] # ܠ𐹢ុ.σᢈ🝭
+xn--qnb616fis0qzt36f.xn--4xa847hli46a; \u0720򲠽𐹢\u17BB.σᢈ🝭; [B2, B6, V7]; xn--qnb616fis0qzt36f.xn--4xa847hli46a; ; ;  # ܠ𐹢ុ.σᢈ🝭
+xn--qnb616fis0qzt36f.xn--4xa847h6ofgl44c; \u0720򲠽𐹢\u17BB.σᢈ🝭\u200C; [B2, B6, C1, V7]; xn--qnb616fis0qzt36f.xn--4xa847h6ofgl44c; ; ;  # ܠ𐹢ុ.σᢈ🝭
+xn--qnb616fis0qzt36f.xn--3xa057h6ofgl44c; \u0720򲠽𐹢\u17BB.ςᢈ🝭\u200C; [B2, B6, C1, V7]; xn--qnb616fis0qzt36f.xn--3xa057h6ofgl44c; ; ;  # ܠ𐹢ុ.ςᢈ🝭
+\u0720򲠽𐹢\u17BB｡Σᢈ🝭\u200C; \u0720򲠽𐹢\u17BB.σᢈ🝭\u200C; [B2, B6, C1, V7]; xn--qnb616fis0qzt36f.xn--4xa847h6ofgl44c; ; xn--qnb616fis0qzt36f.xn--4xa847hli46a; [B2, B6, V7] # ܠ𐹢ុ.σᢈ🝭
+\u0720򲠽𐹢\u17BB｡σᢈ🝭\u200C; \u0720򲠽𐹢\u17BB.σᢈ🝭\u200C; [B2, B6, C1, V7]; xn--qnb616fis0qzt36f.xn--4xa847h6ofgl44c; ; xn--qnb616fis0qzt36f.xn--4xa847hli46a; [B2, B6, V7] # ܠ𐹢ុ.σᢈ🝭
+\u200D--≮。𐹧; \u200D--≮.𐹧; [B1, C2]; xn-----l1tz1k.xn--fo0d; ; xn-----ujv.xn--fo0d; [B1, V3] # --≮.𐹧
+\u200D--<\u0338。𐹧; \u200D--≮.𐹧; [B1, C2]; xn-----l1tz1k.xn--fo0d; ; xn-----ujv.xn--fo0d; [B1, V3] # --≮.𐹧
+xn-----ujv.xn--fo0d; --≮.𐹧; [B1, V3]; xn-----ujv.xn--fo0d; ; ;  # --≮.𐹧
+xn-----l1tz1k.xn--fo0d; \u200D--≮.𐹧; [B1, C2]; xn-----l1tz1k.xn--fo0d; ; ;  # --≮.𐹧
+\uA806。𻚏\u0FB0⒕; \uA806.𻚏\u0FB0⒕; [V6, V7]; xn--l98a.xn--dgd218hhp28d; ; ;  # ꠆.ྰ⒕
+\uA806。𻚏\u0FB014.; \uA806.𻚏\u0FB014.; [V6, V7]; xn--l98a.xn--14-jsj57880f.; [V6, V7, A4_2]; ;  # ꠆.ྰ14.
+xn--l98a.xn--14-jsj57880f.; \uA806.𻚏\u0FB014.; [V6, V7]; xn--l98a.xn--14-jsj57880f.; [V6, V7, A4_2]; ;  # ꠆.ྰ14.
+xn--l98a.xn--dgd218hhp28d; \uA806.𻚏\u0FB0⒕; [V6, V7]; xn--l98a.xn--dgd218hhp28d; ; ;  # ꠆.ྰ⒕
+򮉂\u06BC．𑆺\u0669; 򮉂\u06BC.𑆺\u0669; [B1, B5, B6, V6, V7]; xn--vkb92243l.xn--iib9797k; ; ;  # ڼ.𑆺٩
+򮉂\u06BC.𑆺\u0669; ; [B1, B5, B6, V6, V7]; xn--vkb92243l.xn--iib9797k; ; ;  # ڼ.𑆺٩
+xn--vkb92243l.xn--iib9797k; 򮉂\u06BC.𑆺\u0669; [B1, B5, B6, V6, V7]; xn--vkb92243l.xn--iib9797k; ; ;  # ڼ.𑆺٩
+󠁎\u06D0-。𞤴; 󠁎\u06D0-.𞤴; [B1, V3, V7]; xn----mwc72685y.xn--se6h; ; ;  # ې-.𞤴
+󠁎\u06D0-。𞤒; 󠁎\u06D0-.𞤴; [B1, V3, V7]; xn----mwc72685y.xn--se6h; ; ;  # ې-.𞤴
+xn----mwc72685y.xn--se6h; 󠁎\u06D0-.𞤴; [B1, V3, V7]; xn----mwc72685y.xn--se6h; ; ;  # ې-.𞤴
+𝟠4󠇗𝈻．\u200D𐋵⛧\u200D; 84𝈻.\u200D𐋵⛧\u200D; [C2]; xn--84-s850a.xn--1uga573cfq1w; ; xn--84-s850a.xn--59h6326e; [] # 84𝈻.𐋵⛧
+84󠇗𝈻.\u200D𐋵⛧\u200D; 84𝈻.\u200D𐋵⛧\u200D; [C2]; xn--84-s850a.xn--1uga573cfq1w; ; xn--84-s850a.xn--59h6326e; [] # 84𝈻.𐋵⛧
+xn--84-s850a.xn--59h6326e; 84𝈻.𐋵⛧; ; xn--84-s850a.xn--59h6326e; ; ;  # 84𝈻.𐋵⛧
+84𝈻.𐋵⛧; ; ; xn--84-s850a.xn--59h6326e; ; ;  # 84𝈻.𐋵⛧
+xn--84-s850a.xn--1uga573cfq1w; 84𝈻.\u200D𐋵⛧\u200D; [C2]; xn--84-s850a.xn--1uga573cfq1w; ; ;  # 84𝈻.𐋵⛧
+-\u0601｡ᡪ; -\u0601.ᡪ; [B1, V3, V7]; xn----tkc.xn--68e; ; ;  # -.ᡪ
+-\u0601。ᡪ; -\u0601.ᡪ; [B1, V3, V7]; xn----tkc.xn--68e; ; ;  # -.ᡪ
+xn----tkc.xn--68e; -\u0601.ᡪ; [B1, V3, V7]; xn----tkc.xn--68e; ; ;  # -.ᡪ
+≮𝟕．謖ß≯; ≮7.謖ß≯; ; xn--7-mgo.xn--zca892oly5e; ; xn--7-mgo.xn--ss-xjvv174c;  # ≮7.謖ß≯
+<\u0338𝟕．謖ß>\u0338; ≮7.謖ß≯; ; xn--7-mgo.xn--zca892oly5e; ; xn--7-mgo.xn--ss-xjvv174c;  # ≮7.謖ß≯
+≮7.謖ß≯; ; ; xn--7-mgo.xn--zca892oly5e; ; xn--7-mgo.xn--ss-xjvv174c;  # ≮7.謖ß≯
+<\u03387.謖ß>\u0338; ≮7.謖ß≯; ; xn--7-mgo.xn--zca892oly5e; ; xn--7-mgo.xn--ss-xjvv174c;  # ≮7.謖ß≯
+<\u03387.謖SS>\u0338; ≮7.謖ss≯; ; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮7.謖SS≯; ≮7.謖ss≯; ; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮7.謖ss≯; ; ; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+<\u03387.謖ss>\u0338; ≮7.謖ss≯; ; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+<\u03387.謖Ss>\u0338; ≮7.謖ss≯; ; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮7.謖Ss≯; ≮7.謖ss≯; ; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+xn--7-mgo.xn--ss-xjvv174c; ≮7.謖ss≯; ; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+xn--7-mgo.xn--zca892oly5e; ≮7.謖ß≯; ; xn--7-mgo.xn--zca892oly5e; ; ;  # ≮7.謖ß≯
+<\u0338𝟕．謖SS>\u0338; ≮7.謖ss≯; ; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮𝟕．謖SS≯; ≮7.謖ss≯; ; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮𝟕．謖ss≯; ≮7.謖ss≯; ; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+<\u0338𝟕．謖ss>\u0338; ≮7.謖ss≯; ; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+<\u0338𝟕．謖Ss>\u0338; ≮7.謖ss≯; ; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+≮𝟕．謖Ss≯; ≮7.謖ss≯; ; xn--7-mgo.xn--ss-xjvv174c; ; ;  # ≮7.謖ss≯
+朶Ⴉ𞪡.𝨽\u0825📻-; 朶ⴉ𞪡.𝨽\u0825📻-; [B1, B5, B6, V3, V6, V7]; xn--0kjz47pd57t.xn----3gd37096apmwa; ; ;  # 朶ⴉ.𝨽ࠥ📻-
+朶ⴉ𞪡.𝨽\u0825📻-; ; [B1, B5, B6, V3, V6, V7]; xn--0kjz47pd57t.xn----3gd37096apmwa; ; ;  # 朶ⴉ.𝨽ࠥ📻-
+xn--0kjz47pd57t.xn----3gd37096apmwa; 朶ⴉ𞪡.𝨽\u0825📻-; [B1, B5, B6, V3, V6, V7]; xn--0kjz47pd57t.xn----3gd37096apmwa; ; ;  # 朶ⴉ.𝨽ࠥ📻-
+xn--hnd7245bd56p.xn----3gd37096apmwa; 朶Ⴉ𞪡.𝨽\u0825📻-; [B1, B5, B6, V3, V6, V7]; xn--hnd7245bd56p.xn----3gd37096apmwa; ; ;  # 朶Ⴉ.𝨽ࠥ📻-
+𐤎。󑿰\u200C≮\u200D; 𐤎.󑿰\u200C≮\u200D; [B6, C1, C2, V7]; xn--bk9c.xn--0ugc04p2u638c; ; xn--bk9c.xn--gdhx6802k; [B6, V7] # 𐤎.≮
+𐤎。󑿰\u200C<\u0338\u200D; 𐤎.󑿰\u200C≮\u200D; [B6, C1, C2, V7]; xn--bk9c.xn--0ugc04p2u638c; ; xn--bk9c.xn--gdhx6802k; [B6, V7] # 𐤎.≮
+xn--bk9c.xn--gdhx6802k; 𐤎.󑿰≮; [B6, V7]; xn--bk9c.xn--gdhx6802k; ; ;  # 𐤎.≮
+xn--bk9c.xn--0ugc04p2u638c; 𐤎.󑿰\u200C≮\u200D; [B6, C1, C2, V7]; xn--bk9c.xn--0ugc04p2u638c; ; ;  # 𐤎.≮
+񭜎⒈｡\u200C𝟤; 񭜎⒈.\u200C2; [C1, V7]; xn--tsh94183d.xn--2-rgn; ; xn--tsh94183d.2; [V7] # ⒈.2
+񭜎1.。\u200C2; 񭜎1..\u200C2; [C1, V7, X4_2]; xn--1-ex54e..xn--2-rgn; [C1, V7, A4_2]; xn--1-ex54e..2; [V7, A4_2] # 1..2
+xn--1-ex54e..c; 񭜎1..c; [V7, X4_2]; xn--1-ex54e..c; [V7, A4_2]; ;  # 1..c
+xn--1-ex54e..xn--2-rgn; 񭜎1..\u200C2; [C1, V7, X4_2]; xn--1-ex54e..xn--2-rgn; [C1, V7, A4_2]; ;  # 1..2
+xn--tsh94183d.c; 񭜎⒈.c; [V7]; xn--tsh94183d.c; ; ;  # ⒈.c
+xn--tsh94183d.xn--2-rgn; 񭜎⒈.\u200C2; [C1, V7]; xn--tsh94183d.xn--2-rgn; ; ;  # ⒈.2
+󠟊𐹤\u200D．𐹳󙄵𐹶; 󠟊𐹤\u200D.𐹳󙄵𐹶; [B1, C2, V7]; xn--1ugy994g7k93g.xn--ro0dga22807v; ; xn--co0d98977c.xn--ro0dga22807v; [B1, V7] # 𐹤.𐹳𐹶
+󠟊𐹤\u200D.𐹳󙄵𐹶; ; [B1, C2, V7]; xn--1ugy994g7k93g.xn--ro0dga22807v; ; xn--co0d98977c.xn--ro0dga22807v; [B1, V7] # 𐹤.𐹳𐹶
+xn--co0d98977c.xn--ro0dga22807v; 󠟊𐹤.𐹳󙄵𐹶; [B1, V7]; xn--co0d98977c.xn--ro0dga22807v; ; ;  # 𐹤.𐹳𐹶
+xn--1ugy994g7k93g.xn--ro0dga22807v; 󠟊𐹤\u200D.𐹳󙄵𐹶; [B1, C2, V7]; xn--1ugy994g7k93g.xn--ro0dga22807v; ; ;  # 𐹤.𐹳𐹶
+𞤴𐹻𑓂𐭝．\u094D\uFE07􉛯; 𞤴𐹻𑓂𐭝.\u094D􉛯; [B1, V6, V7]; xn--609c96c09grp2w.xn--n3b28708s; ; ;  # 𞤴𐹻𑓂𐭝.्
+𞤴𐹻𑓂𐭝.\u094D\uFE07􉛯; 𞤴𐹻𑓂𐭝.\u094D􉛯; [B1, V6, V7]; xn--609c96c09grp2w.xn--n3b28708s; ; ;  # 𞤴𐹻𑓂𐭝.्
+𞤒𐹻𑓂𐭝.\u094D\uFE07􉛯; 𞤴𐹻𑓂𐭝.\u094D􉛯; [B1, V6, V7]; xn--609c96c09grp2w.xn--n3b28708s; ; ;  # 𞤴𐹻𑓂𐭝.्
+xn--609c96c09grp2w.xn--n3b28708s; 𞤴𐹻𑓂𐭝.\u094D􉛯; [B1, V6, V7]; xn--609c96c09grp2w.xn--n3b28708s; ; ;  # 𞤴𐹻𑓂𐭝.्
+𞤒𐹻𑓂𐭝．\u094D\uFE07􉛯; 𞤴𐹻𑓂𐭝.\u094D􉛯; [B1, V6, V7]; xn--609c96c09grp2w.xn--n3b28708s; ; ;  # 𞤴𐹻𑓂𐭝.्
+\u0668｡𐹠𐹽񗮶; \u0668.𐹠𐹽񗮶; [B1, V7]; xn--hib.xn--7n0d2bu9196b; ; ;  # ٨.𐹠𐹽
+\u0668。𐹠𐹽񗮶; \u0668.𐹠𐹽񗮶; [B1, V7]; xn--hib.xn--7n0d2bu9196b; ; ;  # ٨.𐹠𐹽
+xn--hib.xn--7n0d2bu9196b; \u0668.𐹠𐹽񗮶; [B1, V7]; xn--hib.xn--7n0d2bu9196b; ; ;  # ٨.𐹠𐹽
+\u1160񍀜.8򶾵\u069C; 񍀜.8򶾵\u069C; [B1, V7]; xn--mn1x.xn--8-otc61545t; ; ;  # .8ڜ
+xn--mn1x.xn--8-otc61545t; 񍀜.8򶾵\u069C; [B1, V7]; xn--mn1x.xn--8-otc61545t; ; ;  # .8ڜ
+xn--psd85033d.xn--8-otc61545t; \u1160񍀜.8򶾵\u069C; [B1, V7]; xn--psd85033d.xn--8-otc61545t; ; ;  # .8ڜ
+\u200D\u200C󠆪｡ß𑓃; \u200D\u200C.ß𑓃; [C1, C2]; xn--0ugb.xn--zca0732l; ; .xn--ss-bh7o; [A4_2] # .ß𑓃
+\u200D\u200C󠆪。ß𑓃; \u200D\u200C.ß𑓃; [C1, C2]; xn--0ugb.xn--zca0732l; ; .xn--ss-bh7o; [A4_2] # .ß𑓃
+\u200D\u200C󠆪。SS𑓃; \u200D\u200C.ss𑓃; [C1, C2]; xn--0ugb.xn--ss-bh7o; ; .xn--ss-bh7o; [A4_2] # .ss𑓃
+\u200D\u200C󠆪。ss𑓃; \u200D\u200C.ss𑓃; [C1, C2]; xn--0ugb.xn--ss-bh7o; ; .xn--ss-bh7o; [A4_2] # .ss𑓃
+\u200D\u200C󠆪。Ss𑓃; \u200D\u200C.ss𑓃; [C1, C2]; xn--0ugb.xn--ss-bh7o; ; .xn--ss-bh7o; [A4_2] # .ss𑓃
+.xn--ss-bh7o; .ss𑓃; [X4_2]; .xn--ss-bh7o; [A4_2]; ;  # .ss𑓃
+xn--0ugb.xn--ss-bh7o; \u200D\u200C.ss𑓃; [C1, C2]; xn--0ugb.xn--ss-bh7o; ; ;  # .ss𑓃
+xn--0ugb.xn--zca0732l; \u200D\u200C.ß𑓃; [C1, C2]; xn--0ugb.xn--zca0732l; ; ;  # .ß𑓃
+\u200D\u200C󠆪｡SS𑓃; \u200D\u200C.ss𑓃; [C1, C2]; xn--0ugb.xn--ss-bh7o; ; .xn--ss-bh7o; [A4_2] # .ss𑓃
+\u200D\u200C󠆪｡ss𑓃; \u200D\u200C.ss𑓃; [C1, C2]; xn--0ugb.xn--ss-bh7o; ; .xn--ss-bh7o; [A4_2] # .ss𑓃
+\u200D\u200C󠆪｡Ss𑓃; \u200D\u200C.ss𑓃; [C1, C2]; xn--0ugb.xn--ss-bh7o; ; .xn--ss-bh7o; [A4_2] # .ss𑓃
+xn--ss-bh7o; ss𑓃; ; xn--ss-bh7o; ; ;  # ss𑓃
+ss𑓃; ; ; xn--ss-bh7o; ; ;  # ss𑓃
+SS𑓃; ss𑓃; ; xn--ss-bh7o; ; ;  # ss𑓃
+Ss𑓃; ss𑓃; ; xn--ss-bh7o; ; ;  # ss𑓃
+︒\u200Cヶ䒩.ꡪ; ; [C1, V7]; xn--0ug287dj0or48o.xn--gd9a; ; xn--qekw60dns9k.xn--gd9a; [V7] # ︒ヶ䒩.ꡪ
+。\u200Cヶ䒩.ꡪ; .\u200Cヶ䒩.ꡪ; [C1, X4_2]; .xn--0ug287dj0o.xn--gd9a; [C1, A4_2]; .xn--qekw60d.xn--gd9a; [A4_2] # .ヶ䒩.ꡪ
+.xn--qekw60d.xn--gd9a; .ヶ䒩.ꡪ; [X4_2]; .xn--qekw60d.xn--gd9a; [A4_2]; ;  # .ヶ䒩.ꡪ
+.xn--0ug287dj0o.xn--gd9a; .\u200Cヶ䒩.ꡪ; [C1, X4_2]; .xn--0ug287dj0o.xn--gd9a; [C1, A4_2]; ;  # .ヶ䒩.ꡪ
+xn--qekw60dns9k.xn--gd9a; ︒ヶ䒩.ꡪ; [V7]; xn--qekw60dns9k.xn--gd9a; ; ;  # ︒ヶ䒩.ꡪ
+xn--0ug287dj0or48o.xn--gd9a; ︒\u200Cヶ䒩.ꡪ; [C1, V7]; xn--0ug287dj0or48o.xn--gd9a; ; ;  # ︒ヶ䒩.ꡪ
+xn--qekw60d.xn--gd9a; ヶ䒩.ꡪ; ; xn--qekw60d.xn--gd9a; ; ;  # ヶ䒩.ꡪ
+ヶ䒩.ꡪ; ; ; xn--qekw60d.xn--gd9a; ; ;  # ヶ䒩.ꡪ
+\u200C⒈𤮍.󢓋\u1A60; ; [C1, V7]; xn--0ug88o7471d.xn--jof45148n; ; xn--tshw462r.xn--jof45148n; [V7] # ⒈𤮍.᩠
+\u200C1.𤮍.󢓋\u1A60; ; [C1, V7]; xn--1-rgn.xn--4x6j.xn--jof45148n; ; 1.xn--4x6j.xn--jof45148n; [V7] # 1.𤮍.᩠
+1.xn--4x6j.xn--jof45148n; 1.𤮍.󢓋\u1A60; [V7]; 1.xn--4x6j.xn--jof45148n; ; ;  # 1.𤮍.᩠
+xn--1-rgn.xn--4x6j.xn--jof45148n; \u200C1.𤮍.󢓋\u1A60; [C1, V7]; xn--1-rgn.xn--4x6j.xn--jof45148n; ; ;  # 1.𤮍.᩠
+xn--tshw462r.xn--jof45148n; ⒈𤮍.󢓋\u1A60; [V7]; xn--tshw462r.xn--jof45148n; ; ;  # ⒈𤮍.᩠
+xn--0ug88o7471d.xn--jof45148n; \u200C⒈𤮍.󢓋\u1A60; [C1, V7]; xn--0ug88o7471d.xn--jof45148n; ; ;  # ⒈𤮍.᩠
+⒈\u200C𐫓󠀺。\u1A60񤰵\u200D; ⒈\u200C𐫓󠀺.\u1A60񤰵\u200D; [B1, C1, C2, V6, V7]; xn--0ug78ol75wzcx4i.xn--jof95xex98m; ; xn--tsh4435fk263g.xn--jofz5294e; [B1, V6, V7] # ⒈𐫓.᩠
+1.\u200C𐫓󠀺。\u1A60񤰵\u200D; 1.\u200C𐫓󠀺.\u1A60񤰵\u200D; [B1, C1, C2, V6, V7]; 1.xn--0ug8853gk263g.xn--jof95xex98m; ; 1.xn--8w9c40377c.xn--jofz5294e; [B1, B3, V6, V7] # 1.𐫓.᩠
+1.xn--8w9c40377c.xn--jofz5294e; 1.𐫓󠀺.\u1A60񤰵; [B1, B3, V6, V7]; 1.xn--8w9c40377c.xn--jofz5294e; ; ;  # 1.𐫓.᩠
+1.xn--0ug8853gk263g.xn--jof95xex98m; 1.\u200C𐫓󠀺.\u1A60񤰵\u200D; [B1, C1, C2, V6, V7]; 1.xn--0ug8853gk263g.xn--jof95xex98m; ; ;  # 1.𐫓.᩠
+xn--tsh4435fk263g.xn--jofz5294e; ⒈𐫓󠀺.\u1A60񤰵; [B1, V6, V7]; xn--tsh4435fk263g.xn--jofz5294e; ; ;  # ⒈𐫓.᩠
+xn--0ug78ol75wzcx4i.xn--jof95xex98m; ⒈\u200C𐫓󠀺.\u1A60񤰵\u200D; [B1, C1, C2, V6, V7]; xn--0ug78ol75wzcx4i.xn--jof95xex98m; ; ;  # ⒈𐫓.᩠
+𝅵｡𝟫𞀈䬺⒈; .9𞀈䬺⒈; [V7, X4_2]; .xn--9-ecp936non25a; [V7, A4_2]; ;  # .9𞀈䬺⒈
+𝅵。9𞀈䬺1.; .9𞀈䬺1.; [X4_2]; .xn--91-030c1650n.; [A4_2]; ;  # .9𞀈䬺1.
+.xn--91-030c1650n.; .9𞀈䬺1.; [X4_2]; .xn--91-030c1650n.; [A4_2]; ;  # .9𞀈䬺1.
+.xn--9-ecp936non25a; .9𞀈䬺⒈; [V7, X4_2]; .xn--9-ecp936non25a; [V7, A4_2]; ;  # .9𞀈䬺⒈
+xn--3f1h.xn--91-030c1650n.; 𝅵.9𞀈䬺1.; [V7]; xn--3f1h.xn--91-030c1650n.; [V7, A4_2]; ;  # .9𞀈䬺1.
+xn--3f1h.xn--9-ecp936non25a; 𝅵.9𞀈䬺⒈; [V7]; xn--3f1h.xn--9-ecp936non25a; ; ;  # .9𞀈䬺⒈
+򡼺≯。盚\u0635; 򡼺≯.盚\u0635; [B5, B6, V7]; xn--hdh30181h.xn--0gb7878c; ; ;  # ≯.盚ص
+򡼺>\u0338。盚\u0635; 򡼺≯.盚\u0635; [B5, B6, V7]; xn--hdh30181h.xn--0gb7878c; ; ;  # ≯.盚ص
+xn--hdh30181h.xn--0gb7878c; 򡼺≯.盚\u0635; [B5, B6, V7]; xn--hdh30181h.xn--0gb7878c; ; ;  # ≯.盚ص
+-񿰭\u05B4。-󠁊𐢸≯; -񿰭\u05B4.-󠁊𐢸≯; [B1, V3, V7]; xn----fgc06667m.xn----pgoy615he5y4i; ; ;  # -ִ.-≯
+-񿰭\u05B4。-󠁊𐢸>\u0338; -񿰭\u05B4.-󠁊𐢸≯; [B1, V3, V7]; xn----fgc06667m.xn----pgoy615he5y4i; ; ;  # -ִ.-≯
+xn----fgc06667m.xn----pgoy615he5y4i; -񿰭\u05B4.-󠁊𐢸≯; [B1, V3, V7]; xn----fgc06667m.xn----pgoy615he5y4i; ; ;  # -ִ.-≯
+󿭓\u1B44\u200C\u0A4D．𐭛񳋔; 󿭓\u1B44\u200C\u0A4D.𐭛񳋔; [B2, B3, B6, V7]; xn--ybc997f6rd2n772c.xn--409c6100y; ; xn--ybc997fb5881a.xn--409c6100y; [B2, B3, V7] # ᭄੍.𐭛
+󿭓\u1B44\u200C\u0A4D.𐭛񳋔; ; [B2, B3, B6, V7]; xn--ybc997f6rd2n772c.xn--409c6100y; ; xn--ybc997fb5881a.xn--409c6100y; [B2, B3, V7] # ᭄੍.𐭛
+xn--ybc997fb5881a.xn--409c6100y; 󿭓\u1B44\u0A4D.𐭛񳋔; [B2, B3, V7]; xn--ybc997fb5881a.xn--409c6100y; ; ;  # ᭄੍.𐭛
+xn--ybc997f6rd2n772c.xn--409c6100y; 󿭓\u1B44\u200C\u0A4D.𐭛񳋔; [B2, B3, B6, V7]; xn--ybc997f6rd2n772c.xn--409c6100y; ; ;  # ᭄੍.𐭛
+⾇.\u067D𞤴\u06BB\u200D; 舛.\u067D𞤴\u06BB\u200D; [B3, C2]; xn--8c1a.xn--2ib8jv19e6413b; ; xn--8c1a.xn--2ib8jn539l; [] # 舛.ٽ𞤴ڻ
+舛.\u067D𞤴\u06BB\u200D; ; [B3, C2]; xn--8c1a.xn--2ib8jv19e6413b; ; xn--8c1a.xn--2ib8jn539l; [] # 舛.ٽ𞤴ڻ
+舛.\u067D𞤒\u06BB\u200D; 舛.\u067D𞤴\u06BB\u200D; [B3, C2]; xn--8c1a.xn--2ib8jv19e6413b; ; xn--8c1a.xn--2ib8jn539l; [] # 舛.ٽ𞤴ڻ
+xn--8c1a.xn--2ib8jn539l; 舛.\u067D𞤴\u06BB; ; xn--8c1a.xn--2ib8jn539l; ; ;  # 舛.ٽ𞤴ڻ
+舛.\u067D𞤴\u06BB; ; ; xn--8c1a.xn--2ib8jn539l; ; ;  # 舛.ٽ𞤴ڻ
+舛.\u067D𞤒\u06BB; 舛.\u067D𞤴\u06BB; ; xn--8c1a.xn--2ib8jn539l; ; ;  # 舛.ٽ𞤴ڻ
+xn--8c1a.xn--2ib8jv19e6413b; 舛.\u067D𞤴\u06BB\u200D; [B3, C2]; xn--8c1a.xn--2ib8jv19e6413b; ; ;  # 舛.ٽ𞤴ڻ
+⾇.\u067D𞤒\u06BB\u200D; 舛.\u067D𞤴\u06BB\u200D; [B3, C2]; xn--8c1a.xn--2ib8jv19e6413b; ; xn--8c1a.xn--2ib8jn539l; [] # 舛.ٽ𞤴ڻ
+4򭆥。\u0767≯; 4򭆥.\u0767≯; [B1, B3, V7]; xn--4-xn17i.xn--rpb459k; ; ;  # 4.ݧ≯
+4򭆥。\u0767>\u0338; 4򭆥.\u0767≯; [B1, B3, V7]; xn--4-xn17i.xn--rpb459k; ; ;  # 4.ݧ≯
+xn--4-xn17i.xn--rpb459k; 4򭆥.\u0767≯; [B1, B3, V7]; xn--4-xn17i.xn--rpb459k; ; ;  # 4.ݧ≯
+𲔏𞫨񺿂硲．\u06AD; 𲔏𞫨񺿂硲.\u06AD; [B5, V7]; xn--lcz1610fn78gk609a.xn--gkb; ; ;  # 𲔏硲.ڭ
+𲔏𞫨񺿂硲.\u06AD; ; [B5, V7]; xn--lcz1610fn78gk609a.xn--gkb; ; ;  # 𲔏硲.ڭ
+xn--lcz1610fn78gk609a.xn--gkb; 𲔏𞫨񺿂硲.\u06AD; [B5, V7]; xn--lcz1610fn78gk609a.xn--gkb; ; ;  # 𲔏硲.ڭ
+\u200C.\uFE08\u0666Ⴆ℮; \u200C.\u0666ⴆ℮; [B1, C1]; xn--0ug.xn--fib628k4li; ; .xn--fib628k4li; [B1, A4_2] # .٦ⴆ℮
+\u200C.\uFE08\u0666ⴆ℮; \u200C.\u0666ⴆ℮; [B1, C1]; xn--0ug.xn--fib628k4li; ; .xn--fib628k4li; [B1, A4_2] # .٦ⴆ℮
+.xn--fib628k4li; .\u0666ⴆ℮; [B1, X4_2]; .xn--fib628k4li; [B1, A4_2]; ;  # .٦ⴆ℮
+xn--0ug.xn--fib628k4li; \u200C.\u0666ⴆ℮; [B1, C1]; xn--0ug.xn--fib628k4li; ; ;  # .٦ⴆ℮
+.xn--fib263c0yn; .\u0666Ⴆ℮; [B1, V7, X4_2]; .xn--fib263c0yn; [B1, V7, A4_2]; ;  # .٦Ⴆ℮
+xn--0ug.xn--fib263c0yn; \u200C.\u0666Ⴆ℮; [B1, C1, V7]; xn--0ug.xn--fib263c0yn; ; ;  # .٦Ⴆ℮
+\u06A3．\u0D4D\u200DϞ; \u06A3.\u0D4D\u200Dϟ; [B1, V6]; xn--5jb.xn--xya149bpvp; ; xn--5jb.xn--xya149b;  # ڣ.്ϟ
+\u06A3.\u0D4D\u200DϞ; \u06A3.\u0D4D\u200Dϟ; [B1, V6]; xn--5jb.xn--xya149bpvp; ; xn--5jb.xn--xya149b;  # ڣ.്ϟ
+\u06A3.\u0D4D\u200Dϟ; ; [B1, V6]; xn--5jb.xn--xya149bpvp; ; xn--5jb.xn--xya149b;  # ڣ.്ϟ
+xn--5jb.xn--xya149b; \u06A3.\u0D4Dϟ; [B1, V6]; xn--5jb.xn--xya149b; ; ;  # ڣ.്ϟ
+xn--5jb.xn--xya149bpvp; \u06A3.\u0D4D\u200Dϟ; [B1, V6]; xn--5jb.xn--xya149bpvp; ; ;  # ڣ.്ϟ
+\u06A3．\u0D4D\u200Dϟ; \u06A3.\u0D4D\u200Dϟ; [B1, V6]; xn--5jb.xn--xya149bpvp; ; xn--5jb.xn--xya149b;  # ڣ.്ϟ
+\u200C𞸇𑘿。\u0623𐮂-腍; \u200C\u062D𑘿.\u0623𐮂-腍; [B1, B2, B3, C1]; xn--sgb953kmi8o.xn----qmc5075grs9e; ; xn--sgb4140l.xn----qmc5075grs9e; [B2, B3] # ح𑘿.أ𐮂-腍
+\u200C𞸇𑘿。\u0627\u0654𐮂-腍; \u200C\u062D𑘿.\u0623𐮂-腍; [B1, B2, B3, C1]; xn--sgb953kmi8o.xn----qmc5075grs9e; ; xn--sgb4140l.xn----qmc5075grs9e; [B2, B3] # ح𑘿.أ𐮂-腍
+\u200C\u062D𑘿。\u0623𐮂-腍; \u200C\u062D𑘿.\u0623𐮂-腍; [B1, B2, B3, C1]; xn--sgb953kmi8o.xn----qmc5075grs9e; ; xn--sgb4140l.xn----qmc5075grs9e; [B2, B3] # ح𑘿.أ𐮂-腍
+\u200C\u062D𑘿。\u0627\u0654𐮂-腍; \u200C\u062D𑘿.\u0623𐮂-腍; [B1, B2, B3, C1]; xn--sgb953kmi8o.xn----qmc5075grs9e; ; xn--sgb4140l.xn----qmc5075grs9e; [B2, B3] # ح𑘿.أ𐮂-腍
+xn--sgb4140l.xn----qmc5075grs9e; \u062D𑘿.\u0623𐮂-腍; [B2, B3]; xn--sgb4140l.xn----qmc5075grs9e; ; ;  # ح𑘿.أ𐮂-腍
+xn--sgb953kmi8o.xn----qmc5075grs9e; \u200C\u062D𑘿.\u0623𐮂-腍; [B1, B2, B3, C1]; xn--sgb953kmi8o.xn----qmc5075grs9e; ; ;  # ح𑘿.أ𐮂-腍
+-򭷙\u066B纛｡𝟛񭤇🄅; -򭷙\u066B纛.3񭤇4,; [B1, V3, V7, U1]; xn----vqc8143g0tt4i.xn--34,-8787l; ; ;  # -٫纛.34,
+-򭷙\u066B纛。3񭤇4,; -򭷙\u066B纛.3񭤇4,; [B1, V3, V7, U1]; xn----vqc8143g0tt4i.xn--34,-8787l; ; ;  # -٫纛.34,
+xn----vqc8143g0tt4i.xn--34,-8787l; -򭷙\u066B纛.3񭤇4,; [B1, V3, V7, U1]; xn----vqc8143g0tt4i.xn--34,-8787l; ; ;  # -٫纛.34,
+xn----vqc8143g0tt4i.xn--3-os1sn476y; -򭷙\u066B纛.3񭤇🄅; [B1, V3, V7]; xn----vqc8143g0tt4i.xn--3-os1sn476y; ; ;  # -٫纛.3🄅
+🔔．Ⴂ\u07CC\u0BCD𐋮; 🔔.ⴂ\u07CC\u0BCD𐋮; [B1, B5]; xn--nv8h.xn--nsb46rvz1b222p; ; ;  # 🔔.ⴂߌ்𐋮
+🔔.Ⴂ\u07CC\u0BCD𐋮; 🔔.ⴂ\u07CC\u0BCD𐋮; [B1, B5]; xn--nv8h.xn--nsb46rvz1b222p; ; ;  # 🔔.ⴂߌ்𐋮
+🔔.ⴂ\u07CC\u0BCD𐋮; ; [B1, B5]; xn--nv8h.xn--nsb46rvz1b222p; ; ;  # 🔔.ⴂߌ்𐋮
+xn--nv8h.xn--nsb46rvz1b222p; 🔔.ⴂ\u07CC\u0BCD𐋮; [B1, B5]; xn--nv8h.xn--nsb46rvz1b222p; ; ;  # 🔔.ⴂߌ்𐋮
+🔔．ⴂ\u07CC\u0BCD𐋮; 🔔.ⴂ\u07CC\u0BCD𐋮; [B1, B5]; xn--nv8h.xn--nsb46rvz1b222p; ; ;  # 🔔.ⴂߌ்𐋮
+xn--nv8h.xn--nsb46r83e8112a; 🔔.Ⴂ\u07CC\u0BCD𐋮; [B1, B5, V7]; xn--nv8h.xn--nsb46r83e8112a; ; ;  # 🔔.Ⴂߌ்𐋮
+軥\u06B3.-𖬵; ; [B1, B5, B6, V3]; xn--mkb5480e.xn----6u5m; ; ;  # 軥ڳ.-𖬵
+xn--mkb5480e.xn----6u5m; 軥\u06B3.-𖬵; [B1, B5, B6, V3]; xn--mkb5480e.xn----6u5m; ; ;  # 軥ڳ.-𖬵
+𐹤\u07CA\u06B6.𐨂-; ; [B1, V3, V6]; xn--pkb56cn614d.xn----974i; ; ;  # 𐹤ߊڶ.𐨂-
+xn--pkb56cn614d.xn----974i; 𐹤\u07CA\u06B6.𐨂-; [B1, V3, V6]; xn--pkb56cn614d.xn----974i; ; ;  # 𐹤ߊڶ.𐨂-
+-󠅱0｡\u17CF\u1DFD톇십; -0.\u17CF\u1DFD톇십; [V3, V6]; -0.xn--r4e872ah77nghm; ; ;  # -0.៏᷽톇십
+-󠅱0｡\u17CF\u1DFD톇십; -0.\u17CF\u1DFD톇십; [V3, V6]; -0.xn--r4e872ah77nghm; ; ;  # -0.៏᷽톇십
+-󠅱0。\u17CF\u1DFD톇십; -0.\u17CF\u1DFD톇십; [V3, V6]; -0.xn--r4e872ah77nghm; ; ;  # -0.៏᷽톇십
+-󠅱0。\u17CF\u1DFD톇십; -0.\u17CF\u1DFD톇십; [V3, V6]; -0.xn--r4e872ah77nghm; ; ;  # -0.៏᷽톇십
+-0.xn--r4e872ah77nghm; -0.\u17CF\u1DFD톇십; [V3, V6]; -0.xn--r4e872ah77nghm; ; ;  # -0.៏᷽톇십
+ꡰ︒--｡\u17CC靈𐹢񘳮; ꡰ︒--.\u17CC靈𐹢񘳮; [B1, B6, V2, V3, V6, V7]; xn-----bk9hu24z.xn--o4e6836dpxudz0v1c; ; ;  # ꡰ︒--.៌靈𐹢
+ꡰ。--。\u17CC靈𐹢񘳮; ꡰ.--.\u17CC靈𐹢񘳮; [B1, V3, V6, V7]; xn--md9a.--.xn--o4e6836dpxudz0v1c; ; ;  # ꡰ.--.៌靈𐹢
+xn--md9a.--.xn--o4e6836dpxudz0v1c; ꡰ.--.\u17CC靈𐹢񘳮; [B1, V3, V6, V7]; xn--md9a.--.xn--o4e6836dpxudz0v1c; ; ;  # ꡰ.--.៌靈𐹢
+xn-----bk9hu24z.xn--o4e6836dpxudz0v1c; ꡰ︒--.\u17CC靈𐹢񘳮; [B1, B6, V2, V3, V6, V7]; xn-----bk9hu24z.xn--o4e6836dpxudz0v1c; ; ;  # ꡰ︒--.៌靈𐹢
+\u115FႿႵრ｡\u0B4D; ⴟⴕრ.\u0B4D; [V6]; xn--1od555l3a.xn--9ic; ; ;  # ⴟⴕრ.୍
+\u115FႿႵრ。\u0B4D; ⴟⴕრ.\u0B4D; [V6]; xn--1od555l3a.xn--9ic; ; ;  # ⴟⴕრ.୍
+\u115Fⴟⴕრ。\u0B4D; ⴟⴕრ.\u0B4D; [V6]; xn--1od555l3a.xn--9ic; ; ;  # ⴟⴕრ.୍
+\u115FႿႵᲠ。\u0B4D; ⴟⴕრ.\u0B4D; [V6]; xn--1od555l3a.xn--9ic; ; ;  # ⴟⴕრ.୍
+xn--1od555l3a.xn--9ic; ⴟⴕრ.\u0B4D; [V6]; xn--1od555l3a.xn--9ic; ; ;  # ⴟⴕრ.୍
+\u115Fⴟⴕრ｡\u0B4D; ⴟⴕრ.\u0B4D; [V6]; xn--1od555l3a.xn--9ic; ; ;  # ⴟⴕრ.୍
+\u115FႿႵᲠ｡\u0B4D; ⴟⴕრ.\u0B4D; [V6]; xn--1od555l3a.xn--9ic; ; ;  # ⴟⴕრ.୍
+xn--tndt4hvw.xn--9ic; \u115FႿႵრ.\u0B4D; [V6, V7]; xn--tndt4hvw.xn--9ic; ; ;  # ႿႵრ.୍
+xn--1od7wz74eeb.xn--9ic; \u115Fⴟⴕრ.\u0B4D; [V6, V7]; xn--1od7wz74eeb.xn--9ic; ; ;  # ⴟⴕრ.୍
+\u115FႿⴕრ。\u0B4D; ⴟⴕრ.\u0B4D; [V6]; xn--1od555l3a.xn--9ic; ; ;  # ⴟⴕრ.୍
+xn--3nd0etsm92g.xn--9ic; \u115FႿⴕრ.\u0B4D; [V6, V7]; xn--3nd0etsm92g.xn--9ic; ; ;  # Ⴟⴕრ.୍
+\u115FႿⴕრ｡\u0B4D; ⴟⴕრ.\u0B4D; [V6]; xn--1od555l3a.xn--9ic; ; ;  # ⴟⴕრ.୍
+🄃𐹠.\u0664󠅇; 2,𐹠.\u0664; [B1, U1]; xn--2,-5g3o.xn--dib; ; ;  # 2,𐹠.٤
+2,𐹠.\u0664󠅇; 2,𐹠.\u0664; [B1, U1]; xn--2,-5g3o.xn--dib; ; ;  # 2,𐹠.٤
+xn--2,-5g3o.xn--dib; 2,𐹠.\u0664; [B1, U1]; xn--2,-5g3o.xn--dib; ; ;  # 2,𐹠.٤
+xn--7n0d1189a.xn--dib; 🄃𐹠.\u0664; [B1, V7]; xn--7n0d1189a.xn--dib; ; ;  # 🄃𐹠.٤
+򻲼\u200C\uFC5B．\u07D2\u0848\u1BF3; 򻲼\u200C\u0630\u0670.\u07D2\u0848\u1BF3; [B2, B3, B5, B6, C1, V7]; xn--vgb2kq00fl213y.xn--tsb0vz43c; ; xn--vgb2kp1223g.xn--tsb0vz43c; [B2, B3, B5, B6, V7] # ذٰ.ߒࡈ᯳
+򻲼\u200C\u0630\u0670.\u07D2\u0848\u1BF3; ; [B2, B3, B5, B6, C1, V7]; xn--vgb2kq00fl213y.xn--tsb0vz43c; ; xn--vgb2kp1223g.xn--tsb0vz43c; [B2, B3, B5, B6, V7] # ذٰ.ߒࡈ᯳
+xn--vgb2kp1223g.xn--tsb0vz43c; 򻲼\u0630\u0670.\u07D2\u0848\u1BF3; [B2, B3, B5, B6, V7]; xn--vgb2kp1223g.xn--tsb0vz43c; ; ;  # ذٰ.ߒࡈ᯳
+xn--vgb2kq00fl213y.xn--tsb0vz43c; 򻲼\u200C\u0630\u0670.\u07D2\u0848\u1BF3; [B2, B3, B5, B6, C1, V7]; xn--vgb2kq00fl213y.xn--tsb0vz43c; ; ;  # ذٰ.ߒࡈ᯳
+\u200D\u200D𞵪\u200C。ᡘ𑲭\u17B5; \u200D\u200D𞵪\u200C.ᡘ𑲭; [B1, C1, C2, V7]; xn--0ugba05538b.xn--o8e4044k; ; xn--l96h.xn--o8e4044k; [V7] # .ᡘ𑲭
+xn--l96h.xn--o8e4044k; 𞵪.ᡘ𑲭; [V7]; xn--l96h.xn--o8e4044k; ; ;  # .ᡘ𑲭
+xn--0ugba05538b.xn--o8e4044k; \u200D\u200D𞵪\u200C.ᡘ𑲭; [B1, C1, C2, V7]; xn--0ugba05538b.xn--o8e4044k; ; ;  # .ᡘ𑲭
+xn--l96h.xn--03e93aq365d; 𞵪.ᡘ𑲭\u17B5; [V7]; xn--l96h.xn--03e93aq365d; ; ;  # .ᡘ𑲭
+xn--0ugba05538b.xn--03e93aq365d; \u200D\u200D𞵪\u200C.ᡘ𑲭\u17B5; [B1, C1, C2, V7]; xn--0ugba05538b.xn--03e93aq365d; ; ;  # .ᡘ𑲭
+𞷻。⚄񗑇𑁿; 𞷻.⚄񗑇𑁿; [B1, V7]; xn--qe7h.xn--c7h2966f7so4a; ; ;  # .⚄𑁿
+xn--qe7h.xn--c7h2966f7so4a; 𞷻.⚄񗑇𑁿; [B1, V7]; xn--qe7h.xn--c7h2966f7so4a; ; ;  # .⚄𑁿
+\uA8C4≠．𞠨\u0667; \uA8C4≠.𞠨\u0667; [B1, V6]; xn--1chy504c.xn--gib1777v; ; ;  # ꣄≠.𞠨٧
+\uA8C4=\u0338．𞠨\u0667; \uA8C4≠.𞠨\u0667; [B1, V6]; xn--1chy504c.xn--gib1777v; ; ;  # ꣄≠.𞠨٧
+\uA8C4≠.𞠨\u0667; ; [B1, V6]; xn--1chy504c.xn--gib1777v; ; ;  # ꣄≠.𞠨٧
+\uA8C4=\u0338.𞠨\u0667; \uA8C4≠.𞠨\u0667; [B1, V6]; xn--1chy504c.xn--gib1777v; ; ;  # ꣄≠.𞠨٧
+xn--1chy504c.xn--gib1777v; \uA8C4≠.𞠨\u0667; [B1, V6]; xn--1chy504c.xn--gib1777v; ; ;  # ꣄≠.𞠨٧
+𝟛𝆪\uA8C4｡\uA8EA-; 3\uA8C4𝆪.\uA8EA-; [V3, V6]; xn--3-sl4eu679e.xn----xn4e; ; ;  # 3꣄𝆪.꣪-
+𝟛\uA8C4𝆪｡\uA8EA-; 3\uA8C4𝆪.\uA8EA-; [V3, V6]; xn--3-sl4eu679e.xn----xn4e; ; ;  # 3꣄𝆪.꣪-
+3\uA8C4𝆪。\uA8EA-; 3\uA8C4𝆪.\uA8EA-; [V3, V6]; xn--3-sl4eu679e.xn----xn4e; ; ;  # 3꣄𝆪.꣪-
+xn--3-sl4eu679e.xn----xn4e; 3\uA8C4𝆪.\uA8EA-; [V3, V6]; xn--3-sl4eu679e.xn----xn4e; ; ;  # 3꣄𝆪.꣪-
+\u075F\u1BA2\u103AႧ.e; \u075F\u1BA2\u103Aⴇ.e; [B2, B3]; xn--jpb846bjzj7pr.e; ; ;  # ݟᮢ်ⴇ.e
+\u075F\u1BA2\u103Aⴇ.e; ; [B2, B3]; xn--jpb846bjzj7pr.e; ; ;  # ݟᮢ်ⴇ.e
+\u075F\u1BA2\u103AႧ.E; \u075F\u1BA2\u103Aⴇ.e; [B2, B3]; xn--jpb846bjzj7pr.e; ; ;  # ݟᮢ်ⴇ.e
+xn--jpb846bjzj7pr.e; \u075F\u1BA2\u103Aⴇ.e; [B2, B3]; xn--jpb846bjzj7pr.e; ; ;  # ݟᮢ်ⴇ.e
+xn--jpb846bmjw88a.e; \u075F\u1BA2\u103AႧ.e; [B2, B3, V7]; xn--jpb846bmjw88a.e; ; ;  # ݟᮢ်Ⴇ.e
+ᄹ｡\u0ECA򠯤󠄞; ᄹ.\u0ECA򠯤; [V6, V7]; xn--lrd.xn--s8c05302k; ; ;  # ᄹ.໊
+ᄹ。\u0ECA򠯤󠄞; ᄹ.\u0ECA򠯤; [V6, V7]; xn--lrd.xn--s8c05302k; ; ;  # ᄹ.໊
+xn--lrd.xn--s8c05302k; ᄹ.\u0ECA򠯤; [V6, V7]; xn--lrd.xn--s8c05302k; ; ;  # ᄹ.໊
+Ⴆ򻢩．󠆡\uFE09𞤍; ⴆ򻢩.𞤯; [V7]; xn--xkjw3965g.xn--ne6h; ; ;  # ⴆ.𞤯
+Ⴆ򻢩.󠆡\uFE09𞤍; ⴆ򻢩.𞤯; [V7]; xn--xkjw3965g.xn--ne6h; ; ;  # ⴆ.𞤯
+ⴆ򻢩.󠆡\uFE09𞤯; ⴆ򻢩.𞤯; [V7]; xn--xkjw3965g.xn--ne6h; ; ;  # ⴆ.𞤯
+xn--xkjw3965g.xn--ne6h; ⴆ򻢩.𞤯; [V7]; xn--xkjw3965g.xn--ne6h; ; ;  # ⴆ.𞤯
+ⴆ򻢩．󠆡\uFE09𞤯; ⴆ򻢩.𞤯; [V7]; xn--xkjw3965g.xn--ne6h; ; ;  # ⴆ.𞤯
+xn--end82983m.xn--ne6h; Ⴆ򻢩.𞤯; [V7]; xn--end82983m.xn--ne6h; ; ;  # Ⴆ.𞤯
+ⴆ򻢩.󠆡\uFE09𞤍; ⴆ򻢩.𞤯; [V7]; xn--xkjw3965g.xn--ne6h; ; ;  # ⴆ.𞤯
+ⴆ򻢩．󠆡\uFE09𞤍; ⴆ򻢩.𞤯; [V7]; xn--xkjw3965g.xn--ne6h; ; ;  # ⴆ.𞤯
+ß\u080B︒\u067B．帼F∬\u200C; ß\u080B︒\u067B.帼f∫∫\u200C; [B5, B6, C1, V7]; xn--zca68zj8ac956c.xn--f-sgn48ga6997e; ; xn--ss-k0d31nu121d.xn--f-tcoa9162d; [B5, B6, V7] # ßࠋ︒ٻ.帼f∫∫
+ß\u080B。\u067B.帼F∫∫\u200C; ß\u080B.\u067B.帼f∫∫\u200C; [B5, B6, C1]; xn--zca687a.xn--0ib.xn--f-sgn48ga6997e; ; xn--ss-uze.xn--0ib.xn--f-tcoa9162d; [B5, B6] # ßࠋ.ٻ.帼f∫∫
+ß\u080B。\u067B.帼f∫∫\u200C; ß\u080B.\u067B.帼f∫∫\u200C; [B5, B6, C1]; xn--zca687a.xn--0ib.xn--f-sgn48ga6997e; ; xn--ss-uze.xn--0ib.xn--f-tcoa9162d; [B5, B6] # ßࠋ.ٻ.帼f∫∫
+SS\u080B。\u067B.帼F∫∫\u200C; ss\u080B.\u067B.帼f∫∫\u200C; [B5, B6, C1]; xn--ss-uze.xn--0ib.xn--f-sgn48ga6997e; ; xn--ss-uze.xn--0ib.xn--f-tcoa9162d; [B5, B6] # ssࠋ.ٻ.帼f∫∫
+ss\u080B。\u067B.帼f∫∫\u200C; ss\u080B.\u067B.帼f∫∫\u200C; [B5, B6, C1]; xn--ss-uze.xn--0ib.xn--f-sgn48ga6997e; ; xn--ss-uze.xn--0ib.xn--f-tcoa9162d; [B5, B6] # ssࠋ.ٻ.帼f∫∫
+Ss\u080B。\u067B.帼F∫∫\u200C; ss\u080B.\u067B.帼f∫∫\u200C; [B5, B6, C1]; xn--ss-uze.xn--0ib.xn--f-sgn48ga6997e; ; xn--ss-uze.xn--0ib.xn--f-tcoa9162d; [B5, B6] # ssࠋ.ٻ.帼f∫∫
+xn--ss-uze.xn--0ib.xn--f-tcoa9162d; ss\u080B.\u067B.帼f∫∫; [B5, B6]; xn--ss-uze.xn--0ib.xn--f-tcoa9162d; ; ;  # ssࠋ.ٻ.帼f∫∫
+xn--ss-uze.xn--0ib.xn--f-sgn48ga6997e; ss\u080B.\u067B.帼f∫∫\u200C; [B5, B6, C1]; xn--ss-uze.xn--0ib.xn--f-sgn48ga6997e; ; ;  # ssࠋ.ٻ.帼f∫∫
+xn--zca687a.xn--0ib.xn--f-sgn48ga6997e; ß\u080B.\u067B.帼f∫∫\u200C; [B5, B6, C1]; xn--zca687a.xn--0ib.xn--f-sgn48ga6997e; ; ;  # ßࠋ.ٻ.帼f∫∫
+ß\u080B︒\u067B．帼f∬\u200C; ß\u080B︒\u067B.帼f∫∫\u200C; [B5, B6, C1, V7]; xn--zca68zj8ac956c.xn--f-sgn48ga6997e; ; xn--ss-k0d31nu121d.xn--f-tcoa9162d; [B5, B6, V7] # ßࠋ︒ٻ.帼f∫∫
+SS\u080B︒\u067B．帼F∬\u200C; ss\u080B︒\u067B.帼f∫∫\u200C; [B5, B6, C1, V7]; xn--ss-k0d31nu121d.xn--f-sgn48ga6997e; ; xn--ss-k0d31nu121d.xn--f-tcoa9162d; [B5, B6, V7] # ssࠋ︒ٻ.帼f∫∫
+ss\u080B︒\u067B．帼f∬\u200C; ss\u080B︒\u067B.帼f∫∫\u200C; [B5, B6, C1, V7]; xn--ss-k0d31nu121d.xn--f-sgn48ga6997e; ; xn--ss-k0d31nu121d.xn--f-tcoa9162d; [B5, B6, V7] # ssࠋ︒ٻ.帼f∫∫
+Ss\u080B︒\u067B．帼F∬\u200C; ss\u080B︒\u067B.帼f∫∫\u200C; [B5, B6, C1, V7]; xn--ss-k0d31nu121d.xn--f-sgn48ga6997e; ; xn--ss-k0d31nu121d.xn--f-tcoa9162d; [B5, B6, V7] # ssࠋ︒ٻ.帼f∫∫
+xn--ss-k0d31nu121d.xn--f-tcoa9162d; ss\u080B︒\u067B.帼f∫∫; [B5, B6, V7]; xn--ss-k0d31nu121d.xn--f-tcoa9162d; ; ;  # ssࠋ︒ٻ.帼f∫∫
+xn--ss-k0d31nu121d.xn--f-sgn48ga6997e; ss\u080B︒\u067B.帼f∫∫\u200C; [B5, B6, C1, V7]; xn--ss-k0d31nu121d.xn--f-sgn48ga6997e; ; ;  # ssࠋ︒ٻ.帼f∫∫
+xn--zca68zj8ac956c.xn--f-sgn48ga6997e; ß\u080B︒\u067B.帼f∫∫\u200C; [B5, B6, C1, V7]; xn--zca68zj8ac956c.xn--f-sgn48ga6997e; ; ;  # ßࠋ︒ٻ.帼f∫∫
+󘪗｡𐹴𞨌\u200D; 󘪗.𐹴𞨌\u200D; [B1, C2, V7]; xn--8l83e.xn--1ug4105gsxwf; ; xn--8l83e.xn--so0dw168a; [B1, V7] # .𐹴
+󘪗。𐹴𞨌\u200D; 󘪗.𐹴𞨌\u200D; [B1, C2, V7]; xn--8l83e.xn--1ug4105gsxwf; ; xn--8l83e.xn--so0dw168a; [B1, V7] # .𐹴
+xn--8l83e.xn--so0dw168a; 󘪗.𐹴𞨌; [B1, V7]; xn--8l83e.xn--so0dw168a; ; ;  # .𐹴
+xn--8l83e.xn--1ug4105gsxwf; 󘪗.𐹴𞨌\u200D; [B1, C2, V7]; xn--8l83e.xn--1ug4105gsxwf; ; ;  # .𐹴
+񗛨.򅟢𝟨\uA8C4; 񗛨.򅟢6\uA8C4; [V7]; xn--mi60a.xn--6-sl4es8023c; ; ;  # .6꣄
+񗛨.򅟢6\uA8C4; ; [V7]; xn--mi60a.xn--6-sl4es8023c; ; ;  # .6꣄
+xn--mi60a.xn--6-sl4es8023c; 񗛨.򅟢6\uA8C4; [V7]; xn--mi60a.xn--6-sl4es8023c; ; ;  # .6꣄
+\u1AB2\uFD8E。-۹ႱႨ; \u1AB2\u0645\u062E\u062C.-۹ⴑⴈ; [B1, V3, V6]; xn--rgbd2e831i.xn----zyc3430a9a; ; ;  # ᪲مخج.-۹ⴑⴈ
+\u1AB2\u0645\u062E\u062C。-۹ႱႨ; \u1AB2\u0645\u062E\u062C.-۹ⴑⴈ; [B1, V3, V6]; xn--rgbd2e831i.xn----zyc3430a9a; ; ;  # ᪲مخج.-۹ⴑⴈ
+\u1AB2\u0645\u062E\u062C。-۹ⴑⴈ; \u1AB2\u0645\u062E\u062C.-۹ⴑⴈ; [B1, V3, V6]; xn--rgbd2e831i.xn----zyc3430a9a; ; ;  # ᪲مخج.-۹ⴑⴈ
+xn--rgbd2e831i.xn----zyc3430a9a; \u1AB2\u0645\u062E\u062C.-۹ⴑⴈ; [B1, V3, V6]; xn--rgbd2e831i.xn----zyc3430a9a; ; ;  # ᪲مخج.-۹ⴑⴈ
+\u1AB2\uFD8E。-۹ⴑⴈ; \u1AB2\u0645\u062E\u062C.-۹ⴑⴈ; [B1, V3, V6]; xn--rgbd2e831i.xn----zyc3430a9a; ; ;  # ᪲مخج.-۹ⴑⴈ
+xn--rgbd2e831i.xn----zyc155e9a; \u1AB2\u0645\u062E\u062C.-۹ႱႨ; [B1, V3, V6, V7]; xn--rgbd2e831i.xn----zyc155e9a; ; ;  # ᪲مخج.-۹ႱႨ
+\u1AB2\u0645\u062E\u062C。-۹Ⴑⴈ; \u1AB2\u0645\u062E\u062C.-۹ⴑⴈ; [B1, V3, V6]; xn--rgbd2e831i.xn----zyc3430a9a; ; ;  # ᪲مخج.-۹ⴑⴈ
+xn--rgbd2e831i.xn----zyc875efr3a; \u1AB2\u0645\u062E\u062C.-۹Ⴑⴈ; [B1, V3, V6, V7]; xn--rgbd2e831i.xn----zyc875efr3a; ; ;  # ᪲مخج.-۹Ⴑⴈ
+\u1AB2\uFD8E。-۹Ⴑⴈ; \u1AB2\u0645\u062E\u062C.-۹ⴑⴈ; [B1, V3, V6]; xn--rgbd2e831i.xn----zyc3430a9a; ; ;  # ᪲مخج.-۹ⴑⴈ
+𞤤．-\u08A3︒; 𞤤.-\u08A3︒; [B1, V3, V7]; xn--ce6h.xn----cod7069p; ; ;  # 𞤤.-ࢣ︒
+𞤤.-\u08A3。; 𞤤.-\u08A3.; [B1, V3]; xn--ce6h.xn----cod.; [B1, V3, A4_2]; ;  # 𞤤.-ࢣ.
+𞤂.-\u08A3。; 𞤤.-\u08A3.; [B1, V3]; xn--ce6h.xn----cod.; [B1, V3, A4_2]; ;  # 𞤤.-ࢣ.
+xn--ce6h.xn----cod.; 𞤤.-\u08A3.; [B1, V3]; xn--ce6h.xn----cod.; [B1, V3, A4_2]; ;  # 𞤤.-ࢣ.
+𞤂．-\u08A3︒; 𞤤.-\u08A3︒; [B1, V3, V7]; xn--ce6h.xn----cod7069p; ; ;  # 𞤤.-ࢣ︒
+xn--ce6h.xn----cod7069p; 𞤤.-\u08A3︒; [B1, V3, V7]; xn--ce6h.xn----cod7069p; ; ;  # 𞤤.-ࢣ︒
+\u200C𐺨.\u0859--; ; [B1, C1, V3, V6]; xn--0ug7905g.xn-----h6e; ; xn--9p0d.xn-----h6e; [B1, V3, V6] # 𐺨.࡙--
+xn--9p0d.xn-----h6e; 𐺨.\u0859--; [B1, V3, V6]; xn--9p0d.xn-----h6e; ; ;  # 𐺨.࡙--
+xn--0ug7905g.xn-----h6e; \u200C𐺨.\u0859--; [B1, C1, V3, V6]; xn--0ug7905g.xn-----h6e; ; ;  # 𐺨.࡙--
+𐋸󮘋Ⴢ.Ⴁ; 𐋸󮘋ⴢ.ⴁ; [V7]; xn--qlj1559dr224h.xn--skj; ; ;  # 𐋸ⴢ.ⴁ
+𐋸󮘋ⴢ.ⴁ; ; [V7]; xn--qlj1559dr224h.xn--skj; ; ;  # 𐋸ⴢ.ⴁ
+𐋸󮘋Ⴢ.ⴁ; 𐋸󮘋ⴢ.ⴁ; [V7]; xn--qlj1559dr224h.xn--skj; ; ;  # 𐋸ⴢ.ⴁ
+xn--qlj1559dr224h.xn--skj; 𐋸󮘋ⴢ.ⴁ; [V7]; xn--qlj1559dr224h.xn--skj; ; ;  # 𐋸ⴢ.ⴁ
+xn--6nd5215jr2u0h.xn--skj; 𐋸󮘋Ⴢ.ⴁ; [V7]; xn--6nd5215jr2u0h.xn--skj; ; ;  # 𐋸Ⴢ.ⴁ
+xn--6nd5215jr2u0h.xn--8md; 𐋸󮘋Ⴢ.Ⴁ; [V7]; xn--6nd5215jr2u0h.xn--8md; ; ;  # 𐋸Ⴢ.Ⴁ
+񗑿\uA806₄򩞆｡𲩧󠒹ς; 񗑿\uA8064򩞆.𲩧󠒹ς; [V7]; xn--4-w93ej7463a9io5a.xn--3xa51142bk3f0d; ; xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d;  # ꠆4.𲩧ς
+񗑿\uA8064򩞆。𲩧󠒹ς; 񗑿\uA8064򩞆.𲩧󠒹ς; [V7]; xn--4-w93ej7463a9io5a.xn--3xa51142bk3f0d; ; xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d;  # ꠆4.𲩧ς
+񗑿\uA8064򩞆。𲩧󠒹Σ; 񗑿\uA8064򩞆.𲩧󠒹σ; [V7]; xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d; ; ;  # ꠆4.𲩧σ
+񗑿\uA8064򩞆。𲩧󠒹σ; 񗑿\uA8064򩞆.𲩧󠒹σ; [V7]; xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d; ; ;  # ꠆4.𲩧σ
+xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d; 񗑿\uA8064򩞆.𲩧󠒹σ; [V7]; xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d; ; ;  # ꠆4.𲩧σ
+xn--4-w93ej7463a9io5a.xn--3xa51142bk3f0d; 񗑿\uA8064򩞆.𲩧󠒹ς; [V7]; xn--4-w93ej7463a9io5a.xn--3xa51142bk3f0d; ; ;  # ꠆4.𲩧ς
+񗑿\uA806₄򩞆｡𲩧󠒹Σ; 񗑿\uA8064򩞆.𲩧󠒹σ; [V7]; xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d; ; ;  # ꠆4.𲩧σ
+񗑿\uA806₄򩞆｡𲩧󠒹σ; 񗑿\uA8064򩞆.𲩧󠒹σ; [V7]; xn--4-w93ej7463a9io5a.xn--4xa31142bk3f0d; ; ;  # ꠆4.𲩧σ
+󠆀\u0723。\u1DF4\u0775; \u0723.\u1DF4\u0775; [B1, V6]; xn--tnb.xn--5pb136i; ; ;  # ܣ.ᷴݵ
+xn--tnb.xn--5pb136i; \u0723.\u1DF4\u0775; [B1, V6]; xn--tnb.xn--5pb136i; ; ;  # ܣ.ᷴݵ
+𐹱\u0842𝪨｡𬼖Ⴑ\u200D; 𐹱\u0842𝪨.𬼖ⴑ\u200D; [B1, B6, C2]; xn--0vb1535kdb6e.xn--1ug742c5714c; ; xn--0vb1535kdb6e.xn--8kjz186s; [B1] # 𐹱ࡂ𝪨.𬼖ⴑ
+𐹱\u0842𝪨。𬼖Ⴑ\u200D; 𐹱\u0842𝪨.𬼖ⴑ\u200D; [B1, B6, C2]; xn--0vb1535kdb6e.xn--1ug742c5714c; ; xn--0vb1535kdb6e.xn--8kjz186s; [B1] # 𐹱ࡂ𝪨.𬼖ⴑ
+𐹱\u0842𝪨。𬼖ⴑ\u200D; 𐹱\u0842𝪨.𬼖ⴑ\u200D; [B1, B6, C2]; xn--0vb1535kdb6e.xn--1ug742c5714c; ; xn--0vb1535kdb6e.xn--8kjz186s; [B1] # 𐹱ࡂ𝪨.𬼖ⴑ
+xn--0vb1535kdb6e.xn--8kjz186s; 𐹱\u0842𝪨.𬼖ⴑ; [B1]; xn--0vb1535kdb6e.xn--8kjz186s; ; ;  # 𐹱ࡂ𝪨.𬼖ⴑ
+xn--0vb1535kdb6e.xn--1ug742c5714c; 𐹱\u0842𝪨.𬼖ⴑ\u200D; [B1, B6, C2]; xn--0vb1535kdb6e.xn--1ug742c5714c; ; ;  # 𐹱ࡂ𝪨.𬼖ⴑ
+𐹱\u0842𝪨｡𬼖ⴑ\u200D; 𐹱\u0842𝪨.𬼖ⴑ\u200D; [B1, B6, C2]; xn--0vb1535kdb6e.xn--1ug742c5714c; ; xn--0vb1535kdb6e.xn--8kjz186s; [B1] # 𐹱ࡂ𝪨.𬼖ⴑ
+xn--0vb1535kdb6e.xn--pnd93707a; 𐹱\u0842𝪨.𬼖Ⴑ; [B1, V7]; xn--0vb1535kdb6e.xn--pnd93707a; ; ;  # 𐹱ࡂ𝪨.𬼖Ⴑ
+xn--0vb1535kdb6e.xn--pnd879eqy33c; 𐹱\u0842𝪨.𬼖Ⴑ\u200D; [B1, B6, C2, V7]; xn--0vb1535kdb6e.xn--pnd879eqy33c; ; ;  # 𐹱ࡂ𝪨.𬼖Ⴑ
+\u1714𐭪󠙘\u200D｡-𐹴; \u1714𐭪󠙘\u200D.-𐹴; [B1, C2, V3, V6, V7]; xn--fze807bso0spy14i.xn----c36i; ; xn--fze4126jujt0g.xn----c36i; [B1, V3, V6, V7] # ᜔𐭪.-𐹴
+\u1714𐭪󠙘\u200D。-𐹴; \u1714𐭪󠙘\u200D.-𐹴; [B1, C2, V3, V6, V7]; xn--fze807bso0spy14i.xn----c36i; ; xn--fze4126jujt0g.xn----c36i; [B1, V3, V6, V7] # ᜔𐭪.-𐹴
+xn--fze4126jujt0g.xn----c36i; \u1714𐭪󠙘.-𐹴; [B1, V3, V6, V7]; xn--fze4126jujt0g.xn----c36i; ; ;  # ᜔𐭪.-𐹴
+xn--fze807bso0spy14i.xn----c36i; \u1714𐭪󠙘\u200D.-𐹴; [B1, C2, V3, V6, V7]; xn--fze807bso0spy14i.xn----c36i; ; ;  # ᜔𐭪.-𐹴
+𾢬｡\u0729︒쯙𝟧; 𾢬.\u0729︒쯙5; [B2, V7]; xn--t92s.xn--5-p1c0712mm8rb; ; ;  # .ܩ︒쯙5
+𾢬｡\u0729︒쯙𝟧; 𾢬.\u0729︒쯙5; [B2, V7]; xn--t92s.xn--5-p1c0712mm8rb; ; ;  # .ܩ︒쯙5
+𾢬。\u0729。쯙5; 𾢬.\u0729.쯙5; [V7]; xn--t92s.xn--znb.xn--5-y88f; ; ;  # .ܩ.쯙5
+𾢬。\u0729。쯙5; 𾢬.\u0729.쯙5; [V7]; xn--t92s.xn--znb.xn--5-y88f; ; ;  # .ܩ.쯙5
+xn--t92s.xn--znb.xn--5-y88f; 𾢬.\u0729.쯙5; [V7]; xn--t92s.xn--znb.xn--5-y88f; ; ;  # .ܩ.쯙5
+xn--t92s.xn--5-p1c0712mm8rb; 𾢬.\u0729︒쯙5; [B2, V7]; xn--t92s.xn--5-p1c0712mm8rb; ; ;  # .ܩ︒쯙5
+𞤟-。\u0762≮뻐; 𞥁-.\u0762≮뻐; [B2, B3, V3]; xn----1j8r.xn--mpb269krv4i; ; ;  # 𞥁-.ݢ≮뻐
+𞤟-。\u0762<\u0338뻐; 𞥁-.\u0762≮뻐; [B2, B3, V3]; xn----1j8r.xn--mpb269krv4i; ; ;  # 𞥁-.ݢ≮뻐
+𞥁-。\u0762<\u0338뻐; 𞥁-.\u0762≮뻐; [B2, B3, V3]; xn----1j8r.xn--mpb269krv4i; ; ;  # 𞥁-.ݢ≮뻐
+𞥁-。\u0762≮뻐; 𞥁-.\u0762≮뻐; [B2, B3, V3]; xn----1j8r.xn--mpb269krv4i; ; ;  # 𞥁-.ݢ≮뻐
+xn----1j8r.xn--mpb269krv4i; 𞥁-.\u0762≮뻐; [B2, B3, V3]; xn----1j8r.xn--mpb269krv4i; ; ;  # 𞥁-.ݢ≮뻐
+𞥩-򊫠．\u08B4≠; 𞥩-򊫠.\u08B4≠; [B2, B3, V7]; xn----cm8rp3609a.xn--9yb852k; ; ;  # -.ࢴ≠
+𞥩-򊫠．\u08B4=\u0338; 𞥩-򊫠.\u08B4≠; [B2, B3, V7]; xn----cm8rp3609a.xn--9yb852k; ; ;  # -.ࢴ≠
+𞥩-򊫠.\u08B4≠; ; [B2, B3, V7]; xn----cm8rp3609a.xn--9yb852k; ; ;  # -.ࢴ≠
+𞥩-򊫠.\u08B4=\u0338; 𞥩-򊫠.\u08B4≠; [B2, B3, V7]; xn----cm8rp3609a.xn--9yb852k; ; ;  # -.ࢴ≠
+xn----cm8rp3609a.xn--9yb852k; 𞥩-򊫠.\u08B4≠; [B2, B3, V7]; xn----cm8rp3609a.xn--9yb852k; ; ;  # -.ࢴ≠
+-񅂏ςႼ．\u0661; -񅂏ςⴜ.\u0661; [B1, V3, V7]; xn----ymb2782aov12f.xn--9hb; ; xn----0mb9682aov12f.xn--9hb;  # -ςⴜ.١
+-񅂏ςႼ.\u0661; -񅂏ςⴜ.\u0661; [B1, V3, V7]; xn----ymb2782aov12f.xn--9hb; ; xn----0mb9682aov12f.xn--9hb;  # -ςⴜ.١
+-񅂏ςⴜ.\u0661; ; [B1, V3, V7]; xn----ymb2782aov12f.xn--9hb; ; xn----0mb9682aov12f.xn--9hb;  # -ςⴜ.١
+-񅂏ΣႼ.\u0661; -񅂏σⴜ.\u0661; [B1, V3, V7]; xn----0mb9682aov12f.xn--9hb; ; ;  # -σⴜ.١
+-񅂏σⴜ.\u0661; ; [B1, V3, V7]; xn----0mb9682aov12f.xn--9hb; ; ;  # -σⴜ.١
+-񅂏Σⴜ.\u0661; -񅂏σⴜ.\u0661; [B1, V3, V7]; xn----0mb9682aov12f.xn--9hb; ; ;  # -σⴜ.١
+xn----0mb9682aov12f.xn--9hb; -񅂏σⴜ.\u0661; [B1, V3, V7]; xn----0mb9682aov12f.xn--9hb; ; ;  # -σⴜ.١
+xn----ymb2782aov12f.xn--9hb; -񅂏ςⴜ.\u0661; [B1, V3, V7]; xn----ymb2782aov12f.xn--9hb; ; ;  # -ςⴜ.١
+-񅂏ςⴜ．\u0661; -񅂏ςⴜ.\u0661; [B1, V3, V7]; xn----ymb2782aov12f.xn--9hb; ; xn----0mb9682aov12f.xn--9hb;  # -ςⴜ.١
+-񅂏ΣႼ．\u0661; -񅂏σⴜ.\u0661; [B1, V3, V7]; xn----0mb9682aov12f.xn--9hb; ; ;  # -σⴜ.١
+-񅂏σⴜ．\u0661; -񅂏σⴜ.\u0661; [B1, V3, V7]; xn----0mb9682aov12f.xn--9hb; ; ;  # -σⴜ.١
+-񅂏Σⴜ．\u0661; -񅂏σⴜ.\u0661; [B1, V3, V7]; xn----0mb9682aov12f.xn--9hb; ; ;  # -σⴜ.١
+xn----0mb770hun11i.xn--9hb; -񅂏σႼ.\u0661; [B1, V3, V7]; xn----0mb770hun11i.xn--9hb; ; ;  # -σႼ.١
+xn----ymb080hun11i.xn--9hb; -񅂏ςႼ.\u0661; [B1, V3, V7]; xn----ymb080hun11i.xn--9hb; ; ;  # -ςႼ.١
+\u17CA.\u200D𝟮𑀿; \u17CA.\u200D2𑀿; [C2, V6]; xn--m4e.xn--2-tgnv469h; ; xn--m4e.xn--2-ku7i; [V6] # ៊.2𑀿
+\u17CA.\u200D2𑀿; ; [C2, V6]; xn--m4e.xn--2-tgnv469h; ; xn--m4e.xn--2-ku7i; [V6] # ៊.2𑀿
+xn--m4e.xn--2-ku7i; \u17CA.2𑀿; [V6]; xn--m4e.xn--2-ku7i; ; ;  # ៊.2𑀿
+xn--m4e.xn--2-tgnv469h; \u17CA.\u200D2𑀿; [C2, V6]; xn--m4e.xn--2-tgnv469h; ; ;  # ៊.2𑀿
+≯𝟖｡\u1A60𐫓򟇑; ≯8.\u1A60𐫓򟇑; [B1, V6, V7]; xn--8-ogo.xn--jof5303iv1z5d; ; ;  # ≯8.᩠𐫓
+>\u0338𝟖｡\u1A60𐫓򟇑; ≯8.\u1A60𐫓򟇑; [B1, V6, V7]; xn--8-ogo.xn--jof5303iv1z5d; ; ;  # ≯8.᩠𐫓
+≯8。\u1A60𐫓򟇑; ≯8.\u1A60𐫓򟇑; [B1, V6, V7]; xn--8-ogo.xn--jof5303iv1z5d; ; ;  # ≯8.᩠𐫓
+>\u03388。\u1A60𐫓򟇑; ≯8.\u1A60𐫓򟇑; [B1, V6, V7]; xn--8-ogo.xn--jof5303iv1z5d; ; ;  # ≯8.᩠𐫓
+xn--8-ogo.xn--jof5303iv1z5d; ≯8.\u1A60𐫓򟇑; [B1, V6, V7]; xn--8-ogo.xn--jof5303iv1z5d; ; ;  # ≯8.᩠𐫓
+𑲫Ↄ\u0664｡\u200C; 𑲫ↄ\u0664.\u200C; [B1, C1, V6]; xn--dib100l8x1p.xn--0ug; ; xn--dib100l8x1p.; [B1, V6, A4_2] # 𑲫ↄ٤.
+𑲫Ↄ\u0664。\u200C; 𑲫ↄ\u0664.\u200C; [B1, C1, V6]; xn--dib100l8x1p.xn--0ug; ; xn--dib100l8x1p.; [B1, V6, A4_2] # 𑲫ↄ٤.
+𑲫ↄ\u0664。\u200C; 𑲫ↄ\u0664.\u200C; [B1, C1, V6]; xn--dib100l8x1p.xn--0ug; ; xn--dib100l8x1p.; [B1, V6, A4_2] # 𑲫ↄ٤.
+xn--dib100l8x1p.; 𑲫ↄ\u0664.; [B1, V6]; xn--dib100l8x1p.; [B1, V6, A4_2]; ;  # 𑲫ↄ٤.
+xn--dib100l8x1p.xn--0ug; 𑲫ↄ\u0664.\u200C; [B1, C1, V6]; xn--dib100l8x1p.xn--0ug; ; ;  # 𑲫ↄ٤.
+𑲫ↄ\u0664｡\u200C; 𑲫ↄ\u0664.\u200C; [B1, C1, V6]; xn--dib100l8x1p.xn--0ug; ; xn--dib100l8x1p.; [B1, V6, A4_2] # 𑲫ↄ٤.
+xn--dib999kcy1p.; 𑲫Ↄ\u0664.; [B1, V6, V7]; xn--dib999kcy1p.; [B1, V6, V7, A4_2]; ;  # 𑲫Ↄ٤.
+xn--dib999kcy1p.xn--0ug; 𑲫Ↄ\u0664.\u200C; [B1, C1, V6, V7]; xn--dib999kcy1p.xn--0ug; ; ;  # 𑲫Ↄ٤.
+\u0C00𝟵\u200D\uFC9D.\u200D\u0750⒈; \u0C009\u200D\u0628\u062D.\u200D\u0750⒈; [B1, C2, V6, V7]; xn--9-1mcp570dl51a.xn--3ob977jmfd; ; xn--9-1mcp570d.xn--3ob470m; [B1, V6, V7] # ఀ9بح.ݐ⒈
+\u0C009\u200D\u0628\u062D.\u200D\u07501.; ; [B1, C2, V6]; xn--9-1mcp570dl51a.xn--1-x3c211q.; [B1, C2, V6, A4_2]; xn--9-1mcp570d.xn--1-x3c.; [B1, V6, A4_2] # ఀ9بح.ݐ1.
+xn--9-1mcp570d.xn--1-x3c.; \u0C009\u0628\u062D.\u07501.; [B1, V6]; xn--9-1mcp570d.xn--1-x3c.; [B1, V6, A4_2]; ;  # ఀ9بح.ݐ1.
+xn--9-1mcp570dl51a.xn--1-x3c211q.; \u0C009\u200D\u0628\u062D.\u200D\u07501.; [B1, C2, V6]; xn--9-1mcp570dl51a.xn--1-x3c211q.; [B1, C2, V6, A4_2]; ;  # ఀ9بح.ݐ1.
+xn--9-1mcp570d.xn--3ob470m; \u0C009\u0628\u062D.\u0750⒈; [B1, V6, V7]; xn--9-1mcp570d.xn--3ob470m; ; ;  # ఀ9بح.ݐ⒈
+xn--9-1mcp570dl51a.xn--3ob977jmfd; \u0C009\u200D\u0628\u062D.\u200D\u0750⒈; [B1, C2, V6, V7]; xn--9-1mcp570dl51a.xn--3ob977jmfd; ; ;  # ఀ9بح.ݐ⒈
+\uAAF6。嬶ß葽; \uAAF6.嬶ß葽; [V6]; xn--2v9a.xn--zca7637b14za; ; xn--2v9a.xn--ss-q40dp97m;  # ꫶.嬶ß葽
+\uAAF6。嬶SS葽; \uAAF6.嬶ss葽; [V6]; xn--2v9a.xn--ss-q40dp97m; ; ;  # ꫶.嬶ss葽
+\uAAF6。嬶ss葽; \uAAF6.嬶ss葽; [V6]; xn--2v9a.xn--ss-q40dp97m; ; ;  # ꫶.嬶ss葽
+\uAAF6。嬶Ss葽; \uAAF6.嬶ss葽; [V6]; xn--2v9a.xn--ss-q40dp97m; ; ;  # ꫶.嬶ss葽
+xn--2v9a.xn--ss-q40dp97m; \uAAF6.嬶ss葽; [V6]; xn--2v9a.xn--ss-q40dp97m; ; ;  # ꫶.嬶ss葽
+xn--2v9a.xn--zca7637b14za; \uAAF6.嬶ß葽; [V6]; xn--2v9a.xn--zca7637b14za; ; ;  # ꫶.嬶ß葽
+𑚶⒈。񞻡𐹺; 𑚶⒈.񞻡𐹺; [B5, B6, V6, V7]; xn--tshz969f.xn--yo0d5914s; ; ;  # 𑚶⒈.𐹺
+𑚶1.。񞻡𐹺; 𑚶1..񞻡𐹺; [B5, B6, V6, V7, X4_2]; xn--1-3j0j..xn--yo0d5914s; [B5, B6, V6, V7, A4_2]; ;  # 𑚶1..𐹺
+xn--1-3j0j..xn--yo0d5914s; 𑚶1..񞻡𐹺; [B5, B6, V6, V7, X4_2]; xn--1-3j0j..xn--yo0d5914s; [B5, B6, V6, V7, A4_2]; ;  # 𑚶1..𐹺
+xn--tshz969f.xn--yo0d5914s; 𑚶⒈.񞻡𐹺; [B5, B6, V6, V7]; xn--tshz969f.xn--yo0d5914s; ; ;  # 𑚶⒈.𐹺
+𑜤︒≮．񚕽\u05D8𞾩; 𑜤︒≮.񚕽\u05D8𞾩; [B1, B5, B6, V6, V7]; xn--gdh5267fdzpa.xn--deb0091w5q9u; ; ;  # 𑜤︒≮.ט
+𑜤︒<\u0338．񚕽\u05D8𞾩; 𑜤︒≮.񚕽\u05D8𞾩; [B1, B5, B6, V6, V7]; xn--gdh5267fdzpa.xn--deb0091w5q9u; ; ;  # 𑜤︒≮.ט
+𑜤。≮.񚕽\u05D8𞾩; 𑜤.≮.񚕽\u05D8𞾩; [B1, B5, B6, V6, V7]; xn--ci2d.xn--gdh.xn--deb0091w5q9u; ; ;  # 𑜤.≮.ט
+𑜤。<\u0338.񚕽\u05D8𞾩; 𑜤.≮.񚕽\u05D8𞾩; [B1, B5, B6, V6, V7]; xn--ci2d.xn--gdh.xn--deb0091w5q9u; ; ;  # 𑜤.≮.ט
+xn--ci2d.xn--gdh.xn--deb0091w5q9u; 𑜤.≮.񚕽\u05D8𞾩; [B1, B5, B6, V6, V7]; xn--ci2d.xn--gdh.xn--deb0091w5q9u; ; ;  # 𑜤.≮.ט
+xn--gdh5267fdzpa.xn--deb0091w5q9u; 𑜤︒≮.񚕽\u05D8𞾩; [B1, B5, B6, V6, V7]; xn--gdh5267fdzpa.xn--deb0091w5q9u; ; ;  # 𑜤︒≮.ט
+󠆋\u0603񏦤.⇁ς򏋈򺇥; \u0603񏦤.⇁ς򏋈򺇥; [B1, V7]; xn--lfb04106d.xn--3xa174mxv16m8moq; ; xn--lfb04106d.xn--4xa964mxv16m8moq;  # .⇁ς
+󠆋\u0603񏦤.⇁Σ򏋈򺇥; \u0603񏦤.⇁σ򏋈򺇥; [B1, V7]; xn--lfb04106d.xn--4xa964mxv16m8moq; ; ;  # .⇁σ
+󠆋\u0603񏦤.⇁σ򏋈򺇥; \u0603񏦤.⇁σ򏋈򺇥; [B1, V7]; xn--lfb04106d.xn--4xa964mxv16m8moq; ; ;  # .⇁σ
+xn--lfb04106d.xn--4xa964mxv16m8moq; \u0603񏦤.⇁σ򏋈򺇥; [B1, V7]; xn--lfb04106d.xn--4xa964mxv16m8moq; ; ;  # .⇁σ
+xn--lfb04106d.xn--3xa174mxv16m8moq; \u0603񏦤.⇁ς򏋈򺇥; [B1, V7]; xn--lfb04106d.xn--3xa174mxv16m8moq; ; ;  # .⇁ς
+ς𑐽𵢈𑜫｡𞬩\u200C𐫄; ς𑐽𵢈𑜫.𞬩\u200C𐫄; [C1, V7]; xn--3xa4260lk3b8z15g.xn--0ug4653g2xzf; ; xn--4xa2260lk3b8z15g.xn--tw9ct349a; [V7] # ς𑐽𑜫.𐫄
+ς𑐽𵢈𑜫。𞬩\u200C𐫄; ς𑐽𵢈𑜫.𞬩\u200C𐫄; [C1, V7]; xn--3xa4260lk3b8z15g.xn--0ug4653g2xzf; ; xn--4xa2260lk3b8z15g.xn--tw9ct349a; [V7] # ς𑐽𑜫.𐫄
+Σ𑐽𵢈𑜫。𞬩\u200C𐫄; σ𑐽𵢈𑜫.𞬩\u200C𐫄; [C1, V7]; xn--4xa2260lk3b8z15g.xn--0ug4653g2xzf; ; xn--4xa2260lk3b8z15g.xn--tw9ct349a; [V7] # σ𑐽𑜫.𐫄
+σ𑐽𵢈𑜫。𞬩\u200C𐫄; σ𑐽𵢈𑜫.𞬩\u200C𐫄; [C1, V7]; xn--4xa2260lk3b8z15g.xn--0ug4653g2xzf; ; xn--4xa2260lk3b8z15g.xn--tw9ct349a; [V7] # σ𑐽𑜫.𐫄
+xn--4xa2260lk3b8z15g.xn--tw9ct349a; σ𑐽𵢈𑜫.𞬩𐫄; [V7]; xn--4xa2260lk3b8z15g.xn--tw9ct349a; ; ;  # σ𑐽𑜫.𐫄
+xn--4xa2260lk3b8z15g.xn--0ug4653g2xzf; σ𑐽𵢈𑜫.𞬩\u200C𐫄; [C1, V7]; xn--4xa2260lk3b8z15g.xn--0ug4653g2xzf; ; ;  # σ𑐽𑜫.𐫄
+xn--3xa4260lk3b8z15g.xn--0ug4653g2xzf; ς𑐽𵢈𑜫.𞬩\u200C𐫄; [C1, V7]; xn--3xa4260lk3b8z15g.xn--0ug4653g2xzf; ; ;  # ς𑐽𑜫.𐫄
+Σ𑐽𵢈𑜫｡𞬩\u200C𐫄; σ𑐽𵢈𑜫.𞬩\u200C𐫄; [C1, V7]; xn--4xa2260lk3b8z15g.xn--0ug4653g2xzf; ; xn--4xa2260lk3b8z15g.xn--tw9ct349a; [V7] # σ𑐽𑜫.𐫄
+σ𑐽𵢈𑜫｡𞬩\u200C𐫄; σ𑐽𵢈𑜫.𞬩\u200C𐫄; [C1, V7]; xn--4xa2260lk3b8z15g.xn--0ug4653g2xzf; ; xn--4xa2260lk3b8z15g.xn--tw9ct349a; [V7] # σ𑐽𑜫.𐫄
+-򵏽｡-\uFC4C\u075B; -򵏽.-\u0646\u062D\u075B; [B1, V3, V7]; xn----o452j.xn----cnc8e38c; ; ;  # -.-نحݛ
+-򵏽。-\u0646\u062D\u075B; -򵏽.-\u0646\u062D\u075B; [B1, V3, V7]; xn----o452j.xn----cnc8e38c; ; ;  # -.-نحݛ
+xn----o452j.xn----cnc8e38c; -򵏽.-\u0646\u062D\u075B; [B1, V3, V7]; xn----o452j.xn----cnc8e38c; ; ;  # -.-نحݛ
+⺢򇺅𝟤｡\u200D🚷; ⺢򇺅2.\u200D🚷; [C2, V7]; xn--2-4jtr4282f.xn--1ugz946p; ; xn--2-4jtr4282f.xn--m78h; [V7] # ⺢2.🚷
+⺢򇺅2。\u200D🚷; ⺢򇺅2.\u200D🚷; [C2, V7]; xn--2-4jtr4282f.xn--1ugz946p; ; xn--2-4jtr4282f.xn--m78h; [V7] # ⺢2.🚷
+xn--2-4jtr4282f.xn--m78h; ⺢򇺅2.🚷; [V7]; xn--2-4jtr4282f.xn--m78h; ; ;  # ⺢2.🚷
+xn--2-4jtr4282f.xn--1ugz946p; ⺢򇺅2.\u200D🚷; [C2, V7]; xn--2-4jtr4282f.xn--1ugz946p; ; ;  # ⺢2.🚷
+\u0CF8\u200D\u2DFE𐹲｡򤐶; \u0CF8\u200D\u2DFE𐹲.򤐶; [B5, B6, C2, V7]; xn--hvc488g69j402t.xn--3e36c; ; xn--hvc220of37m.xn--3e36c; [B5, B6, V7] # ⷾ𐹲.
+\u0CF8\u200D\u2DFE𐹲。򤐶; \u0CF8\u200D\u2DFE𐹲.򤐶; [B5, B6, C2, V7]; xn--hvc488g69j402t.xn--3e36c; ; xn--hvc220of37m.xn--3e36c; [B5, B6, V7] # ⷾ𐹲.
+xn--hvc220of37m.xn--3e36c; \u0CF8\u2DFE𐹲.򤐶; [B5, B6, V7]; xn--hvc220of37m.xn--3e36c; ; ;  # ⷾ𐹲.
+xn--hvc488g69j402t.xn--3e36c; \u0CF8\u200D\u2DFE𐹲.򤐶; [B5, B6, C2, V7]; xn--hvc488g69j402t.xn--3e36c; ; ;  # ⷾ𐹲.
+𐹢．Ⴍ₉⁸; 𐹢.ⴍ98; [B1]; xn--9n0d.xn--98-u61a; ; ;  # 𐹢.ⴍ98
+𐹢.Ⴍ98; 𐹢.ⴍ98; [B1]; xn--9n0d.xn--98-u61a; ; ;  # 𐹢.ⴍ98
+𐹢.ⴍ98; ; [B1]; xn--9n0d.xn--98-u61a; ; ;  # 𐹢.ⴍ98
+xn--9n0d.xn--98-u61a; 𐹢.ⴍ98; [B1]; xn--9n0d.xn--98-u61a; ; ;  # 𐹢.ⴍ98
+𐹢．ⴍ₉⁸; 𐹢.ⴍ98; [B1]; xn--9n0d.xn--98-u61a; ; ;  # 𐹢.ⴍ98
+xn--9n0d.xn--98-7ek; 𐹢.Ⴍ98; [B1, V7]; xn--9n0d.xn--98-7ek; ; ;  # 𐹢.Ⴍ98
+\u200C\u034F｡ß\u08E2⒚≯; \u200C.ß\u08E2⒚≯; [B1, B5, B6, C1, V7]; xn--0ug.xn--zca612bx9vo5b; ; .xn--ss-9if872xjjc; [B5, B6, V7, A4_2] # .ß⒚≯
+\u200C\u034F｡ß\u08E2⒚>\u0338; \u200C.ß\u08E2⒚≯; [B1, B5, B6, C1, V7]; xn--0ug.xn--zca612bx9vo5b; ; .xn--ss-9if872xjjc; [B5, B6, V7, A4_2] # .ß⒚≯
+\u200C\u034F。ß\u08E219.≯; \u200C.ß\u08E219.≯; [B1, B5, C1, V7]; xn--0ug.xn--19-fia813f.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, V7, A4_2] # .ß19.≯
+\u200C\u034F。ß\u08E219.>\u0338; \u200C.ß\u08E219.≯; [B1, B5, C1, V7]; xn--0ug.xn--19-fia813f.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, V7, A4_2] # .ß19.≯
+\u200C\u034F。SS\u08E219.>\u0338; \u200C.ss\u08E219.≯; [B1, B5, C1, V7]; xn--0ug.xn--ss19-w0i.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, V7, A4_2] # .ss19.≯
+\u200C\u034F。SS\u08E219.≯; \u200C.ss\u08E219.≯; [B1, B5, C1, V7]; xn--0ug.xn--ss19-w0i.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, V7, A4_2] # .ss19.≯
+\u200C\u034F。ss\u08E219.≯; \u200C.ss\u08E219.≯; [B1, B5, C1, V7]; xn--0ug.xn--ss19-w0i.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, V7, A4_2] # .ss19.≯
+\u200C\u034F。ss\u08E219.>\u0338; \u200C.ss\u08E219.≯; [B1, B5, C1, V7]; xn--0ug.xn--ss19-w0i.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, V7, A4_2] # .ss19.≯
+\u200C\u034F。Ss\u08E219.>\u0338; \u200C.ss\u08E219.≯; [B1, B5, C1, V7]; xn--0ug.xn--ss19-w0i.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, V7, A4_2] # .ss19.≯
+\u200C\u034F。Ss\u08E219.≯; \u200C.ss\u08E219.≯; [B1, B5, C1, V7]; xn--0ug.xn--ss19-w0i.xn--hdh; ; .xn--ss19-w0i.xn--hdh; [B1, B5, V7, A4_2] # .ss19.≯
+.xn--ss19-w0i.xn--hdh; .ss\u08E219.≯; [B1, B5, V7, X4_2]; .xn--ss19-w0i.xn--hdh; [B1, B5, V7, A4_2]; ;  # .ss19.≯
+xn--0ug.xn--ss19-w0i.xn--hdh; \u200C.ss\u08E219.≯; [B1, B5, C1, V7]; xn--0ug.xn--ss19-w0i.xn--hdh; ; ;  # .ss19.≯
+xn--0ug.xn--19-fia813f.xn--hdh; \u200C.ß\u08E219.≯; [B1, B5, C1, V7]; xn--0ug.xn--19-fia813f.xn--hdh; ; ;  # .ß19.≯
+\u200C\u034F｡SS\u08E2⒚>\u0338; \u200C.ss\u08E2⒚≯; [B1, B5, B6, C1, V7]; xn--0ug.xn--ss-9if872xjjc; ; .xn--ss-9if872xjjc; [B5, B6, V7, A4_2] # .ss⒚≯
+\u200C\u034F｡SS\u08E2⒚≯; \u200C.ss\u08E2⒚≯; [B1, B5, B6, C1, V7]; xn--0ug.xn--ss-9if872xjjc; ; .xn--ss-9if872xjjc; [B5, B6, V7, A4_2] # .ss⒚≯
+\u200C\u034F｡ss\u08E2⒚≯; \u200C.ss\u08E2⒚≯; [B1, B5, B6, C1, V7]; xn--0ug.xn--ss-9if872xjjc; ; .xn--ss-9if872xjjc; [B5, B6, V7, A4_2] # .ss⒚≯
+\u200C\u034F｡ss\u08E2⒚>\u0338; \u200C.ss\u08E2⒚≯; [B1, B5, B6, C1, V7]; xn--0ug.xn--ss-9if872xjjc; ; .xn--ss-9if872xjjc; [B5, B6, V7, A4_2] # .ss⒚≯
+\u200C\u034F｡Ss\u08E2⒚>\u0338; \u200C.ss\u08E2⒚≯; [B1, B5, B6, C1, V7]; xn--0ug.xn--ss-9if872xjjc; ; .xn--ss-9if872xjjc; [B5, B6, V7, A4_2] # .ss⒚≯
+\u200C\u034F｡Ss\u08E2⒚≯; \u200C.ss\u08E2⒚≯; [B1, B5, B6, C1, V7]; xn--0ug.xn--ss-9if872xjjc; ; .xn--ss-9if872xjjc; [B5, B6, V7, A4_2] # .ss⒚≯
+.xn--ss-9if872xjjc; .ss\u08E2⒚≯; [B5, B6, V7, X4_2]; .xn--ss-9if872xjjc; [B5, B6, V7, A4_2]; ;  # .ss⒚≯
+xn--0ug.xn--ss-9if872xjjc; \u200C.ss\u08E2⒚≯; [B1, B5, B6, C1, V7]; xn--0ug.xn--ss-9if872xjjc; ; ;  # .ss⒚≯
+xn--0ug.xn--zca612bx9vo5b; \u200C.ß\u08E2⒚≯; [B1, B5, B6, C1, V7]; xn--0ug.xn--zca612bx9vo5b; ; ;  # .ß⒚≯
+\u200C𞥍ᡌ．𣃔; \u200C𞥍ᡌ.𣃔; [B1, C1, V7]; xn--c8e180bqz13b.xn--od1j; ; xn--c8e5919u.xn--od1j; [B2, B3, V7] # ᡌ.𣃔
+\u200C𞥍ᡌ.𣃔; ; [B1, C1, V7]; xn--c8e180bqz13b.xn--od1j; ; xn--c8e5919u.xn--od1j; [B2, B3, V7] # ᡌ.𣃔
+xn--c8e5919u.xn--od1j; 𞥍ᡌ.𣃔; [B2, B3, V7]; xn--c8e5919u.xn--od1j; ; ;  # ᡌ.𣃔
+xn--c8e180bqz13b.xn--od1j; \u200C𞥍ᡌ.𣃔; [B1, C1, V7]; xn--c8e180bqz13b.xn--od1j; ; ;  # ᡌ.𣃔
+\u07D0򜬝-񡢬。\u0FA0Ⴛ𞷏𝆬; \u07D0򜬝-񡢬.\u0FA0ⴛ𞷏𝆬; [B1, B2, B3, V6, V7]; xn----8bd11730jefvw.xn--wfd802mpm20agsxa; ; ;  # ߐ-.ྠⴛ𝆬
+\u07D0򜬝-񡢬。\u0FA0ⴛ𞷏𝆬; \u07D0򜬝-񡢬.\u0FA0ⴛ𞷏𝆬; [B1, B2, B3, V6, V7]; xn----8bd11730jefvw.xn--wfd802mpm20agsxa; ; ;  # ߐ-.ྠⴛ𝆬
+xn----8bd11730jefvw.xn--wfd802mpm20agsxa; \u07D0򜬝-񡢬.\u0FA0ⴛ𞷏𝆬; [B1, B2, B3, V6, V7]; xn----8bd11730jefvw.xn--wfd802mpm20agsxa; ; ;  # ߐ-.ྠⴛ𝆬
+xn----8bd11730jefvw.xn--wfd08cd265hgsxa; \u07D0򜬝-񡢬.\u0FA0Ⴛ𞷏𝆬; [B1, B2, B3, V6, V7]; xn----8bd11730jefvw.xn--wfd08cd265hgsxa; ; ;  # ߐ-.ྠႻ𝆬
+𝨥。⫟𑈾; 𝨥.⫟𑈾; [V6]; xn--n82h.xn--63iw010f; ; ;  # 𝨥.⫟𑈾
+xn--n82h.xn--63iw010f; 𝨥.⫟𑈾; [V6]; xn--n82h.xn--63iw010f; ; ;  # 𝨥.⫟𑈾
+⾛\u0753.Ⴕ𞠬\u0604\u200D; 走\u0753.ⴕ𞠬\u0604\u200D; [B5, B6, C2, V7]; xn--6ob9779d.xn--mfb444k5gjt754b; ; xn--6ob9779d.xn--mfb511rxu80a; [B5, B6, V7] # 走ݓ.ⴕ𞠬
+走\u0753.Ⴕ𞠬\u0604\u200D; 走\u0753.ⴕ𞠬\u0604\u200D; [B5, B6, C2, V7]; xn--6ob9779d.xn--mfb444k5gjt754b; ; xn--6ob9779d.xn--mfb511rxu80a; [B5, B6, V7] # 走ݓ.ⴕ𞠬
+走\u0753.ⴕ𞠬\u0604\u200D; ; [B5, B6, C2, V7]; xn--6ob9779d.xn--mfb444k5gjt754b; ; xn--6ob9779d.xn--mfb511rxu80a; [B5, B6, V7] # 走ݓ.ⴕ𞠬
+xn--6ob9779d.xn--mfb511rxu80a; 走\u0753.ⴕ𞠬\u0604; [B5, B6, V7]; xn--6ob9779d.xn--mfb511rxu80a; ; ;  # 走ݓ.ⴕ𞠬
+xn--6ob9779d.xn--mfb444k5gjt754b; 走\u0753.ⴕ𞠬\u0604\u200D; [B5, B6, C2, V7]; xn--6ob9779d.xn--mfb444k5gjt754b; ; ;  # 走ݓ.ⴕ𞠬
+⾛\u0753.ⴕ𞠬\u0604\u200D; 走\u0753.ⴕ𞠬\u0604\u200D; [B5, B6, C2, V7]; xn--6ob9779d.xn--mfb444k5gjt754b; ; xn--6ob9779d.xn--mfb511rxu80a; [B5, B6, V7] # 走ݓ.ⴕ𞠬
+xn--6ob9779d.xn--mfb785ck569a; 走\u0753.Ⴕ𞠬\u0604; [B5, B6, V7]; xn--6ob9779d.xn--mfb785ck569a; ; ;  # 走ݓ.Ⴕ𞠬
+xn--6ob9779d.xn--mfb785czmm0y85b; 走\u0753.Ⴕ𞠬\u0604\u200D; [B5, B6, C2, V7]; xn--6ob9779d.xn--mfb785czmm0y85b; ; ;  # 走ݓ.Ⴕ𞠬
+-ᢗ\u200C🄄.𑜢; -ᢗ\u200C3,.𑜢; [C1, V3, V6, U1]; xn---3,-3eu051c.xn--9h2d; ; xn---3,-3eu.xn--9h2d; [V3, V6, U1] # -ᢗ3,.𑜢
+-ᢗ\u200C3,.𑜢; ; [C1, V3, V6, U1]; xn---3,-3eu051c.xn--9h2d; ; xn---3,-3eu.xn--9h2d; [V3, V6, U1] # -ᢗ3,.𑜢
+xn---3,-3eu.xn--9h2d; -ᢗ3,.𑜢; [V3, V6, U1]; xn---3,-3eu.xn--9h2d; ; ;  # -ᢗ3,.𑜢
+xn---3,-3eu051c.xn--9h2d; -ᢗ\u200C3,.𑜢; [C1, V3, V6, U1]; xn---3,-3eu051c.xn--9h2d; ; ;  # -ᢗ3,.𑜢
+xn----pck1820x.xn--9h2d; -ᢗ🄄.𑜢; [V3, V6, V7]; xn----pck1820x.xn--9h2d; ; ;  # -ᢗ🄄.𑜢
+xn----pck312bx563c.xn--9h2d; -ᢗ\u200C🄄.𑜢; [C1, V3, V6, V7]; xn----pck312bx563c.xn--9h2d; ; ;  # -ᢗ🄄.𑜢
+≠𐸁𹏁\u200C.Ⴚ򳄠; ≠𐸁𹏁\u200C.ⴚ򳄠; [B1, C1, V7]; xn--0ug83gn618a21ov.xn--ilj23531g; ; xn--1ch2293gv3nr.xn--ilj23531g; [B1, V7] # ≠.ⴚ
+=\u0338𐸁𹏁\u200C.Ⴚ򳄠; ≠𐸁𹏁\u200C.ⴚ򳄠; [B1, C1, V7]; xn--0ug83gn618a21ov.xn--ilj23531g; ; xn--1ch2293gv3nr.xn--ilj23531g; [B1, V7] # ≠.ⴚ
+=\u0338𐸁𹏁\u200C.ⴚ򳄠; ≠𐸁𹏁\u200C.ⴚ򳄠; [B1, C1, V7]; xn--0ug83gn618a21ov.xn--ilj23531g; ; xn--1ch2293gv3nr.xn--ilj23531g; [B1, V7] # ≠.ⴚ
+≠𐸁𹏁\u200C.ⴚ򳄠; ; [B1, C1, V7]; xn--0ug83gn618a21ov.xn--ilj23531g; ; xn--1ch2293gv3nr.xn--ilj23531g; [B1, V7] # ≠.ⴚ
+xn--1ch2293gv3nr.xn--ilj23531g; ≠𐸁𹏁.ⴚ򳄠; [B1, V7]; xn--1ch2293gv3nr.xn--ilj23531g; ; ;  # ≠.ⴚ
+xn--0ug83gn618a21ov.xn--ilj23531g; ≠𐸁𹏁\u200C.ⴚ򳄠; [B1, C1, V7]; xn--0ug83gn618a21ov.xn--ilj23531g; ; ;  # ≠.ⴚ
+xn--1ch2293gv3nr.xn--ynd49496l; ≠𐸁𹏁.Ⴚ򳄠; [B1, V7]; xn--1ch2293gv3nr.xn--ynd49496l; ; ;  # ≠.Ⴚ
+xn--0ug83gn618a21ov.xn--ynd49496l; ≠𐸁𹏁\u200C.Ⴚ򳄠; [B1, C1, V7]; xn--0ug83gn618a21ov.xn--ynd49496l; ; ;  # ≠.Ⴚ
+\u0669｡󠇀𑇊; \u0669.𑇊; [B1, V6]; xn--iib.xn--6d1d; ; ;  # ٩.𑇊
+\u0669。󠇀𑇊; \u0669.𑇊; [B1, V6]; xn--iib.xn--6d1d; ; ;  # ٩.𑇊
+xn--iib.xn--6d1d; \u0669.𑇊; [B1, V6]; xn--iib.xn--6d1d; ; ;  # ٩.𑇊
+\u1086𞶀≯⒍。-; \u1086𞶀≯⒍.-; [B1, V3, V6, V7]; xn--hmd482gqqb8730g.-; ; ;  # ႆ≯⒍.-
+\u1086𞶀>\u0338⒍。-; \u1086𞶀≯⒍.-; [B1, V3, V6, V7]; xn--hmd482gqqb8730g.-; ; ;  # ႆ≯⒍.-
+\u1086𞶀≯6.。-; \u1086𞶀≯6..-; [B1, V3, V6, V7, X4_2]; xn--6-oyg968k7h74b..-; [B1, V3, V6, V7, A4_2]; ;  # ႆ≯6..-
+\u1086𞶀>\u03386.。-; \u1086𞶀≯6..-; [B1, V3, V6, V7, X4_2]; xn--6-oyg968k7h74b..-; [B1, V3, V6, V7, A4_2]; ;  # ႆ≯6..-
+xn--6-oyg968k7h74b..-; \u1086𞶀≯6..-; [B1, V3, V6, V7, X4_2]; xn--6-oyg968k7h74b..-; [B1, V3, V6, V7, A4_2]; ;  # ႆ≯6..-
+xn--hmd482gqqb8730g.-; \u1086𞶀≯⒍.-; [B1, V3, V6, V7]; xn--hmd482gqqb8730g.-; ; ;  # ႆ≯⒍.-
+\u17B4.쮇-; .쮇-; [V3, X4_2]; .xn----938f; [V3, A4_2]; ;  # .쮇-
+\u17B4.쮇-; .쮇-; [V3, X4_2]; .xn----938f; [V3, A4_2]; ;  # .쮇-
+.xn----938f; .쮇-; [V3, X4_2]; .xn----938f; [V3, A4_2]; ;  # .쮇-
+xn--z3e.xn----938f; \u17B4.쮇-; [V3, V6, V7]; xn--z3e.xn----938f; ; ;  # .쮇-
+\u200C𑓂。⒈-􀪛; \u200C𑓂.⒈-􀪛; [C1, V7]; xn--0ugy057g.xn----dcp29674o; ; xn--wz1d.xn----dcp29674o; [V6, V7] # 𑓂.⒈-
+\u200C𑓂。1.-􀪛; \u200C𑓂.1.-􀪛; [C1, V3, V7]; xn--0ugy057g.1.xn----rg03o; ; xn--wz1d.1.xn----rg03o; [V3, V6, V7] # 𑓂.1.-
+xn--wz1d.1.xn----rg03o; 𑓂.1.-􀪛; [V3, V6, V7]; xn--wz1d.1.xn----rg03o; ; ;  # 𑓂.1.-
+xn--0ugy057g.1.xn----rg03o; \u200C𑓂.1.-􀪛; [C1, V3, V7]; xn--0ugy057g.1.xn----rg03o; ; ;  # 𑓂.1.-
+xn--wz1d.xn----dcp29674o; 𑓂.⒈-􀪛; [V6, V7]; xn--wz1d.xn----dcp29674o; ; ;  # 𑓂.⒈-
+xn--0ugy057g.xn----dcp29674o; \u200C𑓂.⒈-􀪛; [C1, V7]; xn--0ugy057g.xn----dcp29674o; ; ;  # 𑓂.⒈-
+⒈\uFEAE\u200C。\u20E9🖞\u200C𖬴; ⒈\u0631\u200C.\u20E9🖞\u200C𖬴; [B1, C1, V6, V7]; xn--wgb253kmfd.xn--0ugz6a8040fty5d; ; xn--wgb746m.xn--c1g6021kg18c; [B1, V6, V7] # ⒈ر.⃩🖞𖬴
+1.\u0631\u200C。\u20E9🖞\u200C𖬴; 1.\u0631\u200C.\u20E9🖞\u200C𖬴; [B1, B3, C1, V6]; 1.xn--wgb253k.xn--0ugz6a8040fty5d; ; 1.xn--wgb.xn--c1g6021kg18c; [B1, V6] # 1.ر.⃩🖞𖬴
+1.xn--wgb.xn--c1g6021kg18c; 1.\u0631.\u20E9🖞𖬴; [B1, V6]; 1.xn--wgb.xn--c1g6021kg18c; ; ;  # 1.ر.⃩🖞𖬴
+1.xn--wgb253k.xn--0ugz6a8040fty5d; 1.\u0631\u200C.\u20E9🖞\u200C𖬴; [B1, B3, C1, V6]; 1.xn--wgb253k.xn--0ugz6a8040fty5d; ; ;  # 1.ر.⃩🖞𖬴
+xn--wgb746m.xn--c1g6021kg18c; ⒈\u0631.\u20E9🖞𖬴; [B1, V6, V7]; xn--wgb746m.xn--c1g6021kg18c; ; ;  # ⒈ر.⃩🖞𖬴
+xn--wgb253kmfd.xn--0ugz6a8040fty5d; ⒈\u0631\u200C.\u20E9🖞\u200C𖬴; [B1, C1, V6, V7]; xn--wgb253kmfd.xn--0ugz6a8040fty5d; ; ;  # ⒈ر.⃩🖞𖬴
+󌭇｡𝟐\u1BA8\u07D4; 󌭇.2\u1BA8\u07D4; [B1, V7]; xn--xm89d.xn--2-icd143m; ; ;  # .2ᮨߔ
+󌭇。2\u1BA8\u07D4; 󌭇.2\u1BA8\u07D4; [B1, V7]; xn--xm89d.xn--2-icd143m; ; ;  # .2ᮨߔ
+xn--xm89d.xn--2-icd143m; 󌭇.2\u1BA8\u07D4; [B1, V7]; xn--xm89d.xn--2-icd143m; ; ;  # .2ᮨߔ
+\uFD8F򫳺.ς\u200D𐹷; \u0645\u062E\u0645򫳺.ς\u200D𐹷; [B2, B3, B5, B6, C2, V7]; xn--tgb9bb64691z.xn--3xa006lrp7n; ; xn--tgb9bb64691z.xn--4xa6667k; [B2, B3, B5, B6, V7] # مخم.ς𐹷
+\u0645\u062E\u0645򫳺.ς\u200D𐹷; ; [B2, B3, B5, B6, C2, V7]; xn--tgb9bb64691z.xn--3xa006lrp7n; ; xn--tgb9bb64691z.xn--4xa6667k; [B2, B3, B5, B6, V7] # مخم.ς𐹷
+\u0645\u062E\u0645򫳺.Σ\u200D𐹷; \u0645\u062E\u0645򫳺.σ\u200D𐹷; [B2, B3, B5, B6, C2, V7]; xn--tgb9bb64691z.xn--4xa895lrp7n; ; xn--tgb9bb64691z.xn--4xa6667k; [B2, B3, B5, B6, V7] # مخم.σ𐹷
+\u0645\u062E\u0645򫳺.σ\u200D𐹷; ; [B2, B3, B5, B6, C2, V7]; xn--tgb9bb64691z.xn--4xa895lrp7n; ; xn--tgb9bb64691z.xn--4xa6667k; [B2, B3, B5, B6, V7] # مخم.σ𐹷
+xn--tgb9bb64691z.xn--4xa6667k; \u0645\u062E\u0645򫳺.σ𐹷; [B2, B3, B5, B6, V7]; xn--tgb9bb64691z.xn--4xa6667k; ; ;  # مخم.σ𐹷
+xn--tgb9bb64691z.xn--4xa895lrp7n; \u0645\u062E\u0645򫳺.σ\u200D𐹷; [B2, B3, B5, B6, C2, V7]; xn--tgb9bb64691z.xn--4xa895lrp7n; ; ;  # مخم.σ𐹷
+xn--tgb9bb64691z.xn--3xa006lrp7n; \u0645\u062E\u0645򫳺.ς\u200D𐹷; [B2, B3, B5, B6, C2, V7]; xn--tgb9bb64691z.xn--3xa006lrp7n; ; ;  # مخم.ς𐹷
+\uFD8F򫳺.Σ\u200D𐹷; \u0645\u062E\u0645򫳺.σ\u200D𐹷; [B2, B3, B5, B6, C2, V7]; xn--tgb9bb64691z.xn--4xa895lrp7n; ; xn--tgb9bb64691z.xn--4xa6667k; [B2, B3, B5, B6, V7] # مخم.σ𐹷
+\uFD8F򫳺.σ\u200D𐹷; \u0645\u062E\u0645򫳺.σ\u200D𐹷; [B2, B3, B5, B6, C2, V7]; xn--tgb9bb64691z.xn--4xa895lrp7n; ; xn--tgb9bb64691z.xn--4xa6667k; [B2, B3, B5, B6, V7] # مخم.σ𐹷
+⒎\u06C1\u0605｡\uAAF6۵𐇽; ⒎\u06C1\u0605.\uAAF6۵𐇽; [B1, V6, V7]; xn--nfb98ai25e.xn--imb3805fxt8b; ; ;  # ⒎ہ.꫶۵𐇽
+7.\u06C1\u0605。\uAAF6۵𐇽; 7.\u06C1\u0605.\uAAF6۵𐇽; [B1, V6, V7]; 7.xn--nfb98a.xn--imb3805fxt8b; ; ;  # 7.ہ.꫶۵𐇽
+7.xn--nfb98a.xn--imb3805fxt8b; 7.\u06C1\u0605.\uAAF6۵𐇽; [B1, V6, V7]; 7.xn--nfb98a.xn--imb3805fxt8b; ; ;  # 7.ہ.꫶۵𐇽
+xn--nfb98ai25e.xn--imb3805fxt8b; ⒎\u06C1\u0605.\uAAF6۵𐇽; [B1, V6, V7]; xn--nfb98ai25e.xn--imb3805fxt8b; ; ;  # ⒎ہ.꫶۵𐇽
+-ᡥ᠆󍲭。\u0605\u1A5D𐹡; -ᡥ᠆󍲭.\u0605\u1A5D𐹡; [B1, V3, V7]; xn----f3j6s87156i.xn--nfb035hoo2p; ; ;  # -ᡥ᠆.ᩝ𐹡
+xn----f3j6s87156i.xn--nfb035hoo2p; -ᡥ᠆󍲭.\u0605\u1A5D𐹡; [B1, V3, V7]; xn----f3j6s87156i.xn--nfb035hoo2p; ; ;  # -ᡥ᠆.ᩝ𐹡
+\u200D.\u06BD\u0663\u0596; ; [B1, C2]; xn--1ug.xn--hcb32bni; ; .xn--hcb32bni; [A4_2] # .ڽ٣֖
+.xn--hcb32bni; .\u06BD\u0663\u0596; [X4_2]; .xn--hcb32bni; [A4_2]; ;  # .ڽ٣֖
+xn--1ug.xn--hcb32bni; \u200D.\u06BD\u0663\u0596; [B1, C2]; xn--1ug.xn--hcb32bni; ; ;  # .ڽ٣֖
+xn--hcb32bni; \u06BD\u0663\u0596; ; xn--hcb32bni; ; ;  # ڽ٣֖
+\u06BD\u0663\u0596; ; ; xn--hcb32bni; ; ;  # ڽ٣֖
+㒧۱.Ⴚ\u0678\u200D; 㒧۱.ⴚ\u064A\u0674\u200D; [B5, B6, C2]; xn--emb715u.xn--mhb8f960g03l; ; xn--emb715u.xn--mhb8fy26k; [B5, B6] # 㒧۱.ⴚيٴ
+㒧۱.Ⴚ\u064A\u0674\u200D; 㒧۱.ⴚ\u064A\u0674\u200D; [B5, B6, C2]; xn--emb715u.xn--mhb8f960g03l; ; xn--emb715u.xn--mhb8fy26k; [B5, B6] # 㒧۱.ⴚيٴ
+㒧۱.ⴚ\u064A\u0674\u200D; ; [B5, B6, C2]; xn--emb715u.xn--mhb8f960g03l; ; xn--emb715u.xn--mhb8fy26k; [B5, B6] # 㒧۱.ⴚيٴ
+xn--emb715u.xn--mhb8fy26k; 㒧۱.ⴚ\u064A\u0674; [B5, B6]; xn--emb715u.xn--mhb8fy26k; ; ;  # 㒧۱.ⴚيٴ
+xn--emb715u.xn--mhb8f960g03l; 㒧۱.ⴚ\u064A\u0674\u200D; [B5, B6, C2]; xn--emb715u.xn--mhb8f960g03l; ; ;  # 㒧۱.ⴚيٴ
+㒧۱.ⴚ\u0678\u200D; 㒧۱.ⴚ\u064A\u0674\u200D; [B5, B6, C2]; xn--emb715u.xn--mhb8f960g03l; ; xn--emb715u.xn--mhb8fy26k; [B5, B6] # 㒧۱.ⴚيٴ
+xn--emb715u.xn--mhb8f817a; 㒧۱.Ⴚ\u064A\u0674; [B5, B6, V7]; xn--emb715u.xn--mhb8f817a; ; ;  # 㒧۱.Ⴚيٴ
+xn--emb715u.xn--mhb8f817ao2p; 㒧۱.Ⴚ\u064A\u0674\u200D; [B5, B6, C2, V7]; xn--emb715u.xn--mhb8f817ao2p; ; ;  # 㒧۱.Ⴚيٴ
+\u0F94ꡋ-．-𖬴; \u0F94ꡋ-.-𖬴; [V3, V6]; xn----ukg9938i.xn----4u5m; ; ;  # ྔꡋ-.-𖬴
+\u0F94ꡋ-.-𖬴; ; [V3, V6]; xn----ukg9938i.xn----4u5m; ; ;  # ྔꡋ-.-𖬴
+xn----ukg9938i.xn----4u5m; \u0F94ꡋ-.-𖬴; [V3, V6]; xn----ukg9938i.xn----4u5m; ; ;  # ྔꡋ-.-𖬴
+񿒳-⋢\u200C．标-; 񿒳-⋢\u200C.标-; [C1, V3, V7]; xn----sgn90kn5663a.xn----qj7b; ; xn----9mo67451g.xn----qj7b; [V3, V7] # -⋢.标-
+񿒳-⊑\u0338\u200C．标-; 񿒳-⋢\u200C.标-; [C1, V3, V7]; xn----sgn90kn5663a.xn----qj7b; ; xn----9mo67451g.xn----qj7b; [V3, V7] # -⋢.标-
+񿒳-⋢\u200C.标-; ; [C1, V3, V7]; xn----sgn90kn5663a.xn----qj7b; ; xn----9mo67451g.xn----qj7b; [V3, V7] # -⋢.标-
+񿒳-⊑\u0338\u200C.标-; 񿒳-⋢\u200C.标-; [C1, V3, V7]; xn----sgn90kn5663a.xn----qj7b; ; xn----9mo67451g.xn----qj7b; [V3, V7] # -⋢.标-
+xn----9mo67451g.xn----qj7b; 񿒳-⋢.标-; [V3, V7]; xn----9mo67451g.xn----qj7b; ; ;  # -⋢.标-
+xn----sgn90kn5663a.xn----qj7b; 񿒳-⋢\u200C.标-; [C1, V3, V7]; xn----sgn90kn5663a.xn----qj7b; ; ;  # -⋢.标-
+\u0671．ς\u07DC; \u0671.ς\u07DC; [B5, B6]; xn--qib.xn--3xa41s; ; xn--qib.xn--4xa21s;  # ٱ.ςߜ
+\u0671.ς\u07DC; ; [B5, B6]; xn--qib.xn--3xa41s; ; xn--qib.xn--4xa21s;  # ٱ.ςߜ
+\u0671.Σ\u07DC; \u0671.σ\u07DC; [B5, B6]; xn--qib.xn--4xa21s; ; ;  # ٱ.σߜ
+\u0671.σ\u07DC; ; [B5, B6]; xn--qib.xn--4xa21s; ; ;  # ٱ.σߜ
+xn--qib.xn--4xa21s; \u0671.σ\u07DC; [B5, B6]; xn--qib.xn--4xa21s; ; ;  # ٱ.σߜ
+xn--qib.xn--3xa41s; \u0671.ς\u07DC; [B5, B6]; xn--qib.xn--3xa41s; ; ;  # ٱ.ςߜ
+\u0671．Σ\u07DC; \u0671.σ\u07DC; [B5, B6]; xn--qib.xn--4xa21s; ; ;  # ٱ.σߜ
+\u0671．σ\u07DC; \u0671.σ\u07DC; [B5, B6]; xn--qib.xn--4xa21s; ; ;  # ٱ.σߜ
+񼈶\u0605．\u08C1\u200D𑑂𱼱; 񼈶\u0605.\u08C1\u200D𑑂𱼱; [B2, B3, B5, B6, C2, V7]; xn--nfb17942h.xn--nzb240jv06otevq; ; xn--nfb17942h.xn--nzb6708kx3pn; [B2, B3, B5, B6, V7] # .ࣁ𑑂𱼱
+񼈶\u0605.\u08C1\u200D𑑂𱼱; ; [B2, B3, B5, B6, C2, V7]; xn--nfb17942h.xn--nzb240jv06otevq; ; xn--nfb17942h.xn--nzb6708kx3pn; [B2, B3, B5, B6, V7] # .ࣁ𑑂𱼱
+xn--nfb17942h.xn--nzb6708kx3pn; 񼈶\u0605.\u08C1𑑂𱼱; [B2, B3, B5, B6, V7]; xn--nfb17942h.xn--nzb6708kx3pn; ; ;  # .ࣁ𑑂𱼱
+xn--nfb17942h.xn--nzb240jv06otevq; 񼈶\u0605.\u08C1\u200D𑑂𱼱; [B2, B3, B5, B6, C2, V7]; xn--nfb17942h.xn--nzb240jv06otevq; ; ;  # .ࣁ𑑂𱼱
+𐹾𐋩𞵜｡\u1BF2; 𐹾𐋩𞵜.\u1BF2; [B1, V6, V7]; xn--d97cn8rn44p.xn--0zf; ; ;  # 𐹾𐋩.᯲
+𐹾𐋩𞵜。\u1BF2; 𐹾𐋩𞵜.\u1BF2; [B1, V6, V7]; xn--d97cn8rn44p.xn--0zf; ; ;  # 𐹾𐋩.᯲
+xn--d97cn8rn44p.xn--0zf; 𐹾𐋩𞵜.\u1BF2; [B1, V6, V7]; xn--d97cn8rn44p.xn--0zf; ; ;  # 𐹾𐋩.᯲
+6\u1160\u1C33󠸧.򟜊锰\u072Cς; 6\u1C33󠸧.򟜊锰\u072Cς; [B1, B5, V7]; xn--6-iuly4983p.xn--3xa16ohw6pk078g; ; xn--6-iuly4983p.xn--4xa95ohw6pk078g;  # 6ᰳ.锰ܬς
+6\u1160\u1C33󠸧.򟜊锰\u072CΣ; 6\u1C33󠸧.򟜊锰\u072Cσ; [B1, B5, V7]; xn--6-iuly4983p.xn--4xa95ohw6pk078g; ; ;  # 6ᰳ.锰ܬσ
+6\u1160\u1C33󠸧.򟜊锰\u072Cσ; 6\u1C33󠸧.򟜊锰\u072Cσ; [B1, B5, V7]; xn--6-iuly4983p.xn--4xa95ohw6pk078g; ; ;  # 6ᰳ.锰ܬσ
+xn--6-iuly4983p.xn--4xa95ohw6pk078g; 6\u1C33󠸧.򟜊锰\u072Cσ; [B1, B5, V7]; xn--6-iuly4983p.xn--4xa95ohw6pk078g; ; ;  # 6ᰳ.锰ܬσ
+xn--6-iuly4983p.xn--3xa16ohw6pk078g; 6\u1C33󠸧.򟜊锰\u072Cς; [B1, B5, V7]; xn--6-iuly4983p.xn--3xa16ohw6pk078g; ; ;  # 6ᰳ.锰ܬς
+xn--6-5bh476ewr517a.xn--4xa95ohw6pk078g; 6\u1160\u1C33󠸧.򟜊锰\u072Cσ; [B1, B5, V7]; xn--6-5bh476ewr517a.xn--4xa95ohw6pk078g; ; ;  # 6ᰳ.锰ܬσ
+xn--6-5bh476ewr517a.xn--3xa16ohw6pk078g; 6\u1160\u1C33󠸧.򟜊锰\u072Cς; [B1, B5, V7]; xn--6-5bh476ewr517a.xn--3xa16ohw6pk078g; ; ;  # 6ᰳ.锰ܬς
+\u06B3\uFE04񅎦𝟽｡𐹽; \u06B3񅎦7.𐹽; [B1, B2, V7]; xn--7-yuc34665f.xn--1o0d; ; ;  # ڳ7.𐹽
+\u06B3\uFE04񅎦7。𐹽; \u06B3񅎦7.𐹽; [B1, B2, V7]; xn--7-yuc34665f.xn--1o0d; ; ;  # ڳ7.𐹽
+xn--7-yuc34665f.xn--1o0d; \u06B3񅎦7.𐹽; [B1, B2, V7]; xn--7-yuc34665f.xn--1o0d; ; ;  # ڳ7.𐹽
+𞮧．\u200C⫞; 𞮧.\u200C⫞; [B1, C1, V7]; xn--pw6h.xn--0ug283b; ; xn--pw6h.xn--53i; [B1, V7] # .⫞
+𞮧.\u200C⫞; ; [B1, C1, V7]; xn--pw6h.xn--0ug283b; ; xn--pw6h.xn--53i; [B1, V7] # .⫞
+xn--pw6h.xn--53i; 𞮧.⫞; [B1, V7]; xn--pw6h.xn--53i; ; ;  # .⫞
+xn--pw6h.xn--0ug283b; 𞮧.\u200C⫞; [B1, C1, V7]; xn--pw6h.xn--0ug283b; ; ;  # .⫞
+-񕉴.\u06E0ᢚ-; ; [V3, V6, V7]; xn----qi38c.xn----jxc827k; ; ;  # -.۠ᢚ-
+xn----qi38c.xn----jxc827k; -񕉴.\u06E0ᢚ-; [V3, V6, V7]; xn----qi38c.xn----jxc827k; ; ;  # -.۠ᢚ-
+⌁\u200D𑄴．\u200C𝟩\u066C; ⌁\u200D𑄴.\u200C7\u066C; [B1, C1, C2]; xn--1ug38i2093a.xn--7-xqc297q; ; xn--nhh5394g.xn--7-xqc; [B1] # ⌁𑄴.7٬
+⌁\u200D𑄴.\u200C7\u066C; ; [B1, C1, C2]; xn--1ug38i2093a.xn--7-xqc297q; ; xn--nhh5394g.xn--7-xqc; [B1] # ⌁𑄴.7٬
+xn--nhh5394g.xn--7-xqc; ⌁𑄴.7\u066C; [B1]; xn--nhh5394g.xn--7-xqc; ; ;  # ⌁𑄴.7٬
+xn--1ug38i2093a.xn--7-xqc297q; ⌁\u200D𑄴.\u200C7\u066C; [B1, C1, C2]; xn--1ug38i2093a.xn--7-xqc297q; ; ;  # ⌁𑄴.7٬
+︒\uFD05\u0E37\uFEFC。岓\u1BF2󠾃ᡂ; ︒\u0635\u0649\u0E37\u0644\u0627.岓\u1BF2󠾃ᡂ; [B1, V7]; xn--mgb1a7bt462hf267a.xn--17e10qe61f9r71s; ; ;  # ︒صىืلا.岓᯲ᡂ
+。\u0635\u0649\u0E37\u0644\u0627。岓\u1BF2󠾃ᡂ; .\u0635\u0649\u0E37\u0644\u0627.岓\u1BF2󠾃ᡂ; [V7, X4_2]; .xn--mgb1a7bt462h.xn--17e10qe61f9r71s; [V7, A4_2]; ;  # .صىืلا.岓᯲ᡂ
+.xn--mgb1a7bt462h.xn--17e10qe61f9r71s; .\u0635\u0649\u0E37\u0644\u0627.岓\u1BF2󠾃ᡂ; [V7, X4_2]; .xn--mgb1a7bt462h.xn--17e10qe61f9r71s; [V7, A4_2]; ;  # .صىืلا.岓᯲ᡂ
+xn--mgb1a7bt462hf267a.xn--17e10qe61f9r71s; ︒\u0635\u0649\u0E37\u0644\u0627.岓\u1BF2󠾃ᡂ; [B1, V7]; xn--mgb1a7bt462hf267a.xn--17e10qe61f9r71s; ; ;  # ︒صىืلا.岓᯲ᡂ
+𐹨。8𑁆; 𐹨.8𑁆; [B1]; xn--go0d.xn--8-yu7i; ; ;  # 𐹨.8𑁆
+xn--go0d.xn--8-yu7i; 𐹨.8𑁆; [B1]; xn--go0d.xn--8-yu7i; ; ;  # 𐹨.8𑁆
+𞀕\u0D43．ꡚ\u08FA𐹰\u0D44; 𞀕\u0D43.ꡚ\u08FA𐹰\u0D44; [B1, B5, B6, V6]; xn--mxc5210v.xn--90b01t8u2p1ltd; ; ;  # 𞀕ൃ.ꡚࣺ𐹰ൄ
+𞀕\u0D43.ꡚ\u08FA𐹰\u0D44; ; [B1, B5, B6, V6]; xn--mxc5210v.xn--90b01t8u2p1ltd; ; ;  # 𞀕ൃ.ꡚࣺ𐹰ൄ
+xn--mxc5210v.xn--90b01t8u2p1ltd; 𞀕\u0D43.ꡚ\u08FA𐹰\u0D44; [B1, B5, B6, V6]; xn--mxc5210v.xn--90b01t8u2p1ltd; ; ;  # 𞀕ൃ.ꡚࣺ𐹰ൄ
+󆩏𐦹\u0303｡󠍅; 󆩏𐦹\u0303.󠍅; [B1, B5, B6, V7]; xn--nsa1265kp9z9e.xn--xt36e; ; ;  # ̃.
+󆩏𐦹\u0303。󠍅; 󆩏𐦹\u0303.󠍅; [B1, B5, B6, V7]; xn--nsa1265kp9z9e.xn--xt36e; ; ;  # ̃.
+xn--nsa1265kp9z9e.xn--xt36e; 󆩏𐦹\u0303.󠍅; [B1, B5, B6, V7]; xn--nsa1265kp9z9e.xn--xt36e; ; ;  # ̃.
+ᢌ．-\u085A; ᢌ.-\u085A; [V3]; xn--59e.xn----5jd; ; ;  # ᢌ.-࡚
+ᢌ.-\u085A; ; [V3]; xn--59e.xn----5jd; ; ;  # ᢌ.-࡚
+xn--59e.xn----5jd; ᢌ.-\u085A; [V3]; xn--59e.xn----5jd; ; ;  # ᢌ.-࡚
+𥛛𑘶｡𐹬𐲸\u0BCD; 𥛛𑘶.𐹬𐲸\u0BCD; [B1, V7]; xn--jb2dj685c.xn--xmc5562kmcb; ; ;  # 𥛛𑘶.𐹬்
+𥛛𑘶。𐹬𐲸\u0BCD; 𥛛𑘶.𐹬𐲸\u0BCD; [B1, V7]; xn--jb2dj685c.xn--xmc5562kmcb; ; ;  # 𥛛𑘶.𐹬்
+xn--jb2dj685c.xn--xmc5562kmcb; 𥛛𑘶.𐹬𐲸\u0BCD; [B1, V7]; xn--jb2dj685c.xn--xmc5562kmcb; ; ;  # 𥛛𑘶.𐹬்
+Ⴐ\u077F．\u200C; ⴐ\u077F.\u200C; [B1, B5, B6, C1]; xn--gqb743q.xn--0ug; ; xn--gqb743q.; [B5, B6, A4_2] # ⴐݿ.
+Ⴐ\u077F.\u200C; ⴐ\u077F.\u200C; [B1, B5, B6, C1]; xn--gqb743q.xn--0ug; ; xn--gqb743q.; [B5, B6, A4_2] # ⴐݿ.
+ⴐ\u077F.\u200C; ; [B1, B5, B6, C1]; xn--gqb743q.xn--0ug; ; xn--gqb743q.; [B5, B6, A4_2] # ⴐݿ.
+xn--gqb743q.; ⴐ\u077F.; [B5, B6]; xn--gqb743q.; [B5, B6, A4_2]; ;  # ⴐݿ.
+xn--gqb743q.xn--0ug; ⴐ\u077F.\u200C; [B1, B5, B6, C1]; xn--gqb743q.xn--0ug; ; ;  # ⴐݿ.
+ⴐ\u077F．\u200C; ⴐ\u077F.\u200C; [B1, B5, B6, C1]; xn--gqb743q.xn--0ug; ; xn--gqb743q.; [B5, B6, A4_2] # ⴐݿ.
+xn--gqb918b.; Ⴐ\u077F.; [B5, B6, V7]; xn--gqb918b.; [B5, B6, V7, A4_2]; ;  # Ⴐݿ.
+xn--gqb918b.xn--0ug; Ⴐ\u077F.\u200C; [B1, B5, B6, C1, V7]; xn--gqb918b.xn--0ug; ; ;  # Ⴐݿ.
+🄅𑲞-⒈。\u200Dᠩ\u06A5; 4,𑲞-⒈.\u200Dᠩ\u06A5; [B1, C2, V7, U1]; xn--4,--je4aw745l.xn--7jb180gexf; ; xn--4,--je4aw745l.xn--7jb180g; [B1, B5, B6, V7, U1] # 4,𑲞-⒈.ᠩڥ
+4,𑲞-1.。\u200Dᠩ\u06A5; 4,𑲞-1..\u200Dᠩ\u06A5; [B1, C2, U1, X4_2]; xn--4,-1-w401a..xn--7jb180gexf; [B1, C2, U1, A4_2]; xn--4,-1-w401a..xn--7jb180g; [B1, B5, B6, U1, A4_2] # 4,𑲞-1..ᠩڥ
+xn--4,-1-w401a..xn--7jb180g; 4,𑲞-1..ᠩ\u06A5; [B1, B5, B6, U1, X4_2]; xn--4,-1-w401a..xn--7jb180g; [B1, B5, B6, U1, A4_2]; ;  # 4,𑲞-1..ᠩڥ
+xn--4,-1-w401a..xn--7jb180gexf; 4,𑲞-1..\u200Dᠩ\u06A5; [B1, C2, U1, X4_2]; xn--4,-1-w401a..xn--7jb180gexf; [B1, C2, U1, A4_2]; ;  # 4,𑲞-1..ᠩڥ
+xn--4,--je4aw745l.xn--7jb180g; 4,𑲞-⒈.ᠩ\u06A5; [B1, B5, B6, V7, U1]; xn--4,--je4aw745l.xn--7jb180g; ; ;  # 4,𑲞-⒈.ᠩڥ
+xn--4,--je4aw745l.xn--7jb180gexf; 4,𑲞-⒈.\u200Dᠩ\u06A5; [B1, C2, V7, U1]; xn--4,--je4aw745l.xn--7jb180gexf; ; ;  # 4,𑲞-⒈.ᠩڥ
+xn----ecp8796hjtvg.xn--7jb180g; 🄅𑲞-⒈.ᠩ\u06A5; [B1, B5, B6, V7]; xn----ecp8796hjtvg.xn--7jb180g; ; ;  # 🄅𑲞-⒈.ᠩڥ
+xn----ecp8796hjtvg.xn--7jb180gexf; 🄅𑲞-⒈.\u200Dᠩ\u06A5; [B1, C2, V7]; xn----ecp8796hjtvg.xn--7jb180gexf; ; ;  # 🄅𑲞-⒈.ᠩڥ
+񗀤。𞤪򮿋; 񗀤.𞤪򮿋; [B2, B3, V7]; xn--4240a.xn--ie6h83808a; ; ;  # .𞤪
+񗀤。𞤈򮿋; 񗀤.𞤪򮿋; [B2, B3, V7]; xn--4240a.xn--ie6h83808a; ; ;  # .𞤪
+xn--4240a.xn--ie6h83808a; 񗀤.𞤪򮿋; [B2, B3, V7]; xn--4240a.xn--ie6h83808a; ; ;  # .𞤪
+\u05C1۲｡𐮊\u066C𝨊鄨; \u05C1۲.𐮊\u066C𝨊鄨; [B1, B2, B3, V6]; xn--pdb42d.xn--lib6412enztdwv6h; ; ;  # ׁ۲.𐮊٬𝨊鄨
+\u05C1۲。𐮊\u066C𝨊鄨; \u05C1۲.𐮊\u066C𝨊鄨; [B1, B2, B3, V6]; xn--pdb42d.xn--lib6412enztdwv6h; ; ;  # ׁ۲.𐮊٬𝨊鄨
+xn--pdb42d.xn--lib6412enztdwv6h; \u05C1۲.𐮊\u066C𝨊鄨; [B1, B2, B3, V6]; xn--pdb42d.xn--lib6412enztdwv6h; ; ;  # ׁ۲.𐮊٬𝨊鄨
+𞭳-ꡁ。\u1A69\u0BCD-; 𞭳-ꡁ.\u1A69\u0BCD-; [B1, B2, B3, V3, V6, V7]; xn----be4e4276f.xn----lze333i; ; ;  # -ꡁ.ᩩ்-
+xn----be4e4276f.xn----lze333i; 𞭳-ꡁ.\u1A69\u0BCD-; [B1, B2, B3, V3, V6, V7]; xn----be4e4276f.xn----lze333i; ; ;  # -ꡁ.ᩩ்-
+\u1039-𚮭🞢．ß; \u1039-𚮭🞢.ß; [V6, V7]; xn----9tg11172akr8b.xn--zca; ; xn----9tg11172akr8b.ss;  # ္-🞢.ß
+\u1039-𚮭🞢.ß; ; [V6, V7]; xn----9tg11172akr8b.xn--zca; ; xn----9tg11172akr8b.ss;  # ္-🞢.ß
+\u1039-𚮭🞢.SS; \u1039-𚮭🞢.ss; [V6, V7]; xn----9tg11172akr8b.ss; ; ;  # ္-🞢.ss
+\u1039-𚮭🞢.ss; ; [V6, V7]; xn----9tg11172akr8b.ss; ; ;  # ္-🞢.ss
+\u1039-𚮭🞢.Ss; \u1039-𚮭🞢.ss; [V6, V7]; xn----9tg11172akr8b.ss; ; ;  # ္-🞢.ss
+xn----9tg11172akr8b.ss; \u1039-𚮭🞢.ss; [V6, V7]; xn----9tg11172akr8b.ss; ; ;  # ္-🞢.ss
+xn----9tg11172akr8b.xn--zca; \u1039-𚮭🞢.ß; [V6, V7]; xn----9tg11172akr8b.xn--zca; ; ;  # ္-🞢.ß
+\u1039-𚮭🞢．SS; \u1039-𚮭🞢.ss; [V6, V7]; xn----9tg11172akr8b.ss; ; ;  # ္-🞢.ss
+\u1039-𚮭🞢．ss; \u1039-𚮭🞢.ss; [V6, V7]; xn----9tg11172akr8b.ss; ; ;  # ္-🞢.ss
+\u1039-𚮭🞢．Ss; \u1039-𚮭🞢.ss; [V6, V7]; xn----9tg11172akr8b.ss; ; ;  # ္-🞢.ss
+\uFCF2-\u200C｡Ⴟ\u200C␣; \u0640\u064E\u0651-\u200C.ⴟ\u200C␣; [B3, B6, C1]; xn----eoc6bm0504a.xn--0ug13nd0j; ; xn----eoc6bm.xn--xph904a; [B3, B6, V3] # ـَّ-.ⴟ␣
+\u0640\u064E\u0651-\u200C。Ⴟ\u200C␣; \u0640\u064E\u0651-\u200C.ⴟ\u200C␣; [B3, B6, C1]; xn----eoc6bm0504a.xn--0ug13nd0j; ; xn----eoc6bm.xn--xph904a; [B3, B6, V3] # ـَّ-.ⴟ␣
+\u0640\u064E\u0651-\u200C。ⴟ\u200C␣; \u0640\u064E\u0651-\u200C.ⴟ\u200C␣; [B3, B6, C1]; xn----eoc6bm0504a.xn--0ug13nd0j; ; xn----eoc6bm.xn--xph904a; [B3, B6, V3] # ـَّ-.ⴟ␣
+xn----eoc6bm.xn--xph904a; \u0640\u064E\u0651-.ⴟ␣; [B3, B6, V3]; xn----eoc6bm.xn--xph904a; ; ;  # ـَّ-.ⴟ␣
+xn----eoc6bm0504a.xn--0ug13nd0j; \u0640\u064E\u0651-\u200C.ⴟ\u200C␣; [B3, B6, C1]; xn----eoc6bm0504a.xn--0ug13nd0j; ; ;  # ـَّ-.ⴟ␣
+\uFCF2-\u200C｡ⴟ\u200C␣; \u0640\u064E\u0651-\u200C.ⴟ\u200C␣; [B3, B6, C1]; xn----eoc6bm0504a.xn--0ug13nd0j; ; xn----eoc6bm.xn--xph904a; [B3, B6, V3] # ـَّ-.ⴟ␣
+xn----eoc6bm.xn--3nd240h; \u0640\u064E\u0651-.Ⴟ␣; [B3, B6, V3, V7]; xn----eoc6bm.xn--3nd240h; ; ;  # ـَّ-.Ⴟ␣
+xn----eoc6bm0504a.xn--3nd849e05c; \u0640\u064E\u0651-\u200C.Ⴟ\u200C␣; [B3, B6, C1, V7]; xn----eoc6bm0504a.xn--3nd849e05c; ; ;  # ـَّ-.Ⴟ␣
+\u0D4D-\u200D\u200C｡񥞧₅≠; \u0D4D-\u200D\u200C.񥞧5≠; [C1, C2, V6, V7]; xn----jmf215lda.xn--5-ufo50192e; ; xn----jmf.xn--5-ufo50192e; [V3, V6, V7] # ്-.5≠
+\u0D4D-\u200D\u200C｡񥞧₅=\u0338; \u0D4D-\u200D\u200C.񥞧5≠; [C1, C2, V6, V7]; xn----jmf215lda.xn--5-ufo50192e; ; xn----jmf.xn--5-ufo50192e; [V3, V6, V7] # ്-.5≠
+\u0D4D-\u200D\u200C。񥞧5≠; \u0D4D-\u200D\u200C.񥞧5≠; [C1, C2, V6, V7]; xn----jmf215lda.xn--5-ufo50192e; ; xn----jmf.xn--5-ufo50192e; [V3, V6, V7] # ്-.5≠
+\u0D4D-\u200D\u200C。񥞧5=\u0338; \u0D4D-\u200D\u200C.񥞧5≠; [C1, C2, V6, V7]; xn----jmf215lda.xn--5-ufo50192e; ; xn----jmf.xn--5-ufo50192e; [V3, V6, V7] # ്-.5≠
+xn----jmf.xn--5-ufo50192e; \u0D4D-.񥞧5≠; [V3, V6, V7]; xn----jmf.xn--5-ufo50192e; ; ;  # ്-.5≠
+xn----jmf215lda.xn--5-ufo50192e; \u0D4D-\u200D\u200C.񥞧5≠; [C1, C2, V6, V7]; xn----jmf215lda.xn--5-ufo50192e; ; ;  # ്-.5≠
+锣。\u0A4D󠘻󠚆; 锣.\u0A4D󠘻󠚆; [V6, V7]; xn--gc5a.xn--ybc83044ppga; ; ;  # 锣.੍
+xn--gc5a.xn--ybc83044ppga; 锣.\u0A4D󠘻󠚆; [V6, V7]; xn--gc5a.xn--ybc83044ppga; ; ;  # 锣.੍
+\u063D𑈾．\u0649\u200D\uA92B; \u063D𑈾.\u0649\u200D\uA92B; [B3, C2]; xn--8gb2338k.xn--lhb603k060h; ; xn--8gb2338k.xn--lhb0154f; [] # ؽ𑈾.ى꤫
+\u063D𑈾.\u0649\u200D\uA92B; ; [B3, C2]; xn--8gb2338k.xn--lhb603k060h; ; xn--8gb2338k.xn--lhb0154f; [] # ؽ𑈾.ى꤫
+xn--8gb2338k.xn--lhb0154f; \u063D𑈾.\u0649\uA92B; ; xn--8gb2338k.xn--lhb0154f; ; ;  # ؽ𑈾.ى꤫
+\u063D𑈾.\u0649\uA92B; ; ; xn--8gb2338k.xn--lhb0154f; ; ;  # ؽ𑈾.ى꤫
+xn--8gb2338k.xn--lhb603k060h; \u063D𑈾.\u0649\u200D\uA92B; [B3, C2]; xn--8gb2338k.xn--lhb603k060h; ; ;  # ؽ𑈾.ى꤫
+\u0666⁴Ⴅ．\u08BD\u200C; \u06664ⴅ.\u08BD\u200C; [B1, B3, C1]; xn--4-kqc6770a.xn--jzb840j; ; xn--4-kqc6770a.xn--jzb; [B1] # ٦4ⴅ.ࢽ
+\u06664Ⴅ.\u08BD\u200C; \u06664ⴅ.\u08BD\u200C; [B1, B3, C1]; xn--4-kqc6770a.xn--jzb840j; ; xn--4-kqc6770a.xn--jzb; [B1] # ٦4ⴅ.ࢽ
+\u06664ⴅ.\u08BD\u200C; ; [B1, B3, C1]; xn--4-kqc6770a.xn--jzb840j; ; xn--4-kqc6770a.xn--jzb; [B1] # ٦4ⴅ.ࢽ
+xn--4-kqc6770a.xn--jzb; \u06664ⴅ.\u08BD; [B1]; xn--4-kqc6770a.xn--jzb; ; ;  # ٦4ⴅ.ࢽ
+xn--4-kqc6770a.xn--jzb840j; \u06664ⴅ.\u08BD\u200C; [B1, B3, C1]; xn--4-kqc6770a.xn--jzb840j; ; ;  # ٦4ⴅ.ࢽ
+\u0666⁴ⴅ．\u08BD\u200C; \u06664ⴅ.\u08BD\u200C; [B1, B3, C1]; xn--4-kqc6770a.xn--jzb840j; ; xn--4-kqc6770a.xn--jzb; [B1] # ٦4ⴅ.ࢽ
+xn--4-kqc489e.xn--jzb; \u06664Ⴅ.\u08BD; [B1, V7]; xn--4-kqc489e.xn--jzb; ; ;  # ٦4Ⴅ.ࢽ
+xn--4-kqc489e.xn--jzb840j; \u06664Ⴅ.\u08BD\u200C; [B1, B3, C1, V7]; xn--4-kqc489e.xn--jzb840j; ; ;  # ٦4Ⴅ.ࢽ
+ჁႱ6\u0318。ß\u1B03; ⴡⴑ6\u0318.ß\u1B03; ; xn--6-8cb7433a2ba.xn--zca894k; ; xn--6-8cb7433a2ba.xn--ss-2vq;  # ⴡⴑ6̘.ßᬃ
+ⴡⴑ6\u0318。ß\u1B03; ⴡⴑ6\u0318.ß\u1B03; ; xn--6-8cb7433a2ba.xn--zca894k; ; xn--6-8cb7433a2ba.xn--ss-2vq;  # ⴡⴑ6̘.ßᬃ
+ჁႱ6\u0318。SS\u1B03; ⴡⴑ6\u0318.ss\u1B03; ; xn--6-8cb7433a2ba.xn--ss-2vq; ; ;  # ⴡⴑ6̘.ssᬃ
+ⴡⴑ6\u0318。ss\u1B03; ⴡⴑ6\u0318.ss\u1B03; ; xn--6-8cb7433a2ba.xn--ss-2vq; ; ;  # ⴡⴑ6̘.ssᬃ
+Ⴡⴑ6\u0318。Ss\u1B03; ⴡⴑ6\u0318.ss\u1B03; ; xn--6-8cb7433a2ba.xn--ss-2vq; ; ;  # ⴡⴑ6̘.ssᬃ
+xn--6-8cb7433a2ba.xn--ss-2vq; ⴡⴑ6\u0318.ss\u1B03; ; xn--6-8cb7433a2ba.xn--ss-2vq; ; ;  # ⴡⴑ6̘.ssᬃ
+ⴡⴑ6\u0318.ss\u1B03; ; ; xn--6-8cb7433a2ba.xn--ss-2vq; ; ;  # ⴡⴑ6̘.ssᬃ
+ჁႱ6\u0318.SS\u1B03; ⴡⴑ6\u0318.ss\u1B03; ; xn--6-8cb7433a2ba.xn--ss-2vq; ; ;  # ⴡⴑ6̘.ssᬃ
+Ⴡⴑ6\u0318.Ss\u1B03; ⴡⴑ6\u0318.ss\u1B03; ; xn--6-8cb7433a2ba.xn--ss-2vq; ; ;  # ⴡⴑ6̘.ssᬃ
+xn--6-8cb7433a2ba.xn--zca894k; ⴡⴑ6\u0318.ß\u1B03; ; xn--6-8cb7433a2ba.xn--zca894k; ; ;  # ⴡⴑ6̘.ßᬃ
+ⴡⴑ6\u0318.ß\u1B03; ; ; xn--6-8cb7433a2ba.xn--zca894k; ; xn--6-8cb7433a2ba.xn--ss-2vq;  # ⴡⴑ6̘.ßᬃ
+xn--6-8cb306hms1a.xn--ss-2vq; Ⴡⴑ6\u0318.ss\u1B03; [V7]; xn--6-8cb306hms1a.xn--ss-2vq; ; ;  # Ⴡⴑ6̘.ssᬃ
+xn--6-8cb555h2b.xn--ss-2vq; ჁႱ6\u0318.ss\u1B03; [V7]; xn--6-8cb555h2b.xn--ss-2vq; ; ;  # ჁႱ6̘.ssᬃ
+xn--6-8cb555h2b.xn--zca894k; ჁႱ6\u0318.ß\u1B03; [V7]; xn--6-8cb555h2b.xn--zca894k; ; ;  # ჁႱ6̘.ßᬃ
+򋡐｡≯𑋪; 򋡐.≯𑋪; [V7]; xn--eo08b.xn--hdh3385g; ; ;  # .≯𑋪
+򋡐｡>\u0338𑋪; 򋡐.≯𑋪; [V7]; xn--eo08b.xn--hdh3385g; ; ;  # .≯𑋪
+򋡐。≯𑋪; 򋡐.≯𑋪; [V7]; xn--eo08b.xn--hdh3385g; ; ;  # .≯𑋪
+򋡐。>\u0338𑋪; 򋡐.≯𑋪; [V7]; xn--eo08b.xn--hdh3385g; ; ;  # .≯𑋪
+xn--eo08b.xn--hdh3385g; 򋡐.≯𑋪; [V7]; xn--eo08b.xn--hdh3385g; ; ;  # .≯𑋪
+\u065A۲。\u200C-\u1BF3\u08E2; \u065A۲.\u200C-\u1BF3\u08E2; [B1, C1, V6, V7]; xn--2hb81a.xn----xrd657l30d; ; xn--2hb81a.xn----xrd657l; [B1, V3, V6, V7] # ٚ۲.-᯳
+xn--2hb81a.xn----xrd657l; \u065A۲.-\u1BF3\u08E2; [B1, V3, V6, V7]; xn--2hb81a.xn----xrd657l; ; ;  # ٚ۲.-᯳
+xn--2hb81a.xn----xrd657l30d; \u065A۲.\u200C-\u1BF3\u08E2; [B1, C1, V6, V7]; xn--2hb81a.xn----xrd657l30d; ; ;  # ٚ۲.-᯳
+󠄏𖬴󠲽｡\uFFA0; 𖬴󠲽.; [V6, V7]; xn--619ep9154c.; [V6, V7, A4_2]; ;  # 𖬴.
+󠄏𖬴󠲽。\u1160; 𖬴󠲽.; [V6, V7]; xn--619ep9154c.; [V6, V7, A4_2]; ;  # 𖬴.
+xn--619ep9154c.; 𖬴󠲽.; [V6, V7]; xn--619ep9154c.; [V6, V7, A4_2]; ;  # 𖬴.
+xn--619ep9154c.xn--psd; 𖬴󠲽.\u1160; [V6, V7]; xn--619ep9154c.xn--psd; ; ;  # 𖬴.
+xn--619ep9154c.xn--cl7c; 𖬴󠲽.\uFFA0; [V6, V7]; xn--619ep9154c.xn--cl7c; ; ;  # 𖬴.
+ß⒈\u0760\uD7AE．􉖲󠅄\u0605򉔯; ß⒈\u0760\uD7AE.􉖲\u0605򉔯; [B5, V7]; xn--zca444a0s1ao12n.xn--nfb09923ifkyyb; ; xn--ss-6ke9690a0g1q.xn--nfb09923ifkyyb;  # ß⒈ݠ.
+ß1.\u0760\uD7AE.􉖲󠅄\u0605򉔯; ß1.\u0760\uD7AE.􉖲\u0605򉔯; [B2, B3, B5, V7]; xn--1-pfa.xn--kpb6677h.xn--nfb09923ifkyyb; ; ss1.xn--kpb6677h.xn--nfb09923ifkyyb;  # ß1.ݠ.
+SS1.\u0760\uD7AE.􉖲󠅄\u0605򉔯; ss1.\u0760\uD7AE.􉖲\u0605򉔯; [B2, B3, B5, V7]; ss1.xn--kpb6677h.xn--nfb09923ifkyyb; ; ;  # ss1.ݠ.
+ss1.\u0760\uD7AE.􉖲󠅄\u0605򉔯; ss1.\u0760\uD7AE.􉖲\u0605򉔯; [B2, B3, B5, V7]; ss1.xn--kpb6677h.xn--nfb09923ifkyyb; ; ;  # ss1.ݠ.
+Ss1.\u0760\uD7AE.􉖲󠅄\u0605򉔯; ss1.\u0760\uD7AE.􉖲\u0605򉔯; [B2, B3, B5, V7]; ss1.xn--kpb6677h.xn--nfb09923ifkyyb; ; ;  # ss1.ݠ.
+ss1.xn--kpb6677h.xn--nfb09923ifkyyb; ss1.\u0760\uD7AE.􉖲\u0605򉔯; [B2, B3, B5, V7]; ss1.xn--kpb6677h.xn--nfb09923ifkyyb; ; ;  # ss1.ݠ.
+xn--1-pfa.xn--kpb6677h.xn--nfb09923ifkyyb; ß1.\u0760\uD7AE.􉖲\u0605򉔯; [B2, B3, B5, V7]; xn--1-pfa.xn--kpb6677h.xn--nfb09923ifkyyb; ; ;  # ß1.ݠ.
+SS⒈\u0760\uD7AE．􉖲󠅄\u0605򉔯; ss⒈\u0760\uD7AE.􉖲\u0605򉔯; [B5, V7]; xn--ss-6ke9690a0g1q.xn--nfb09923ifkyyb; ; ;  # ss⒈ݠ.
+ss⒈\u0760\uD7AE．􉖲󠅄\u0605򉔯; ss⒈\u0760\uD7AE.􉖲\u0605򉔯; [B5, V7]; xn--ss-6ke9690a0g1q.xn--nfb09923ifkyyb; ; ;  # ss⒈ݠ.
+Ss⒈\u0760\uD7AE．􉖲󠅄\u0605򉔯; ss⒈\u0760\uD7AE.􉖲\u0605򉔯; [B5, V7]; xn--ss-6ke9690a0g1q.xn--nfb09923ifkyyb; ; ;  # ss⒈ݠ.
+xn--ss-6ke9690a0g1q.xn--nfb09923ifkyyb; ss⒈\u0760\uD7AE.􉖲\u0605򉔯; [B5, V7]; xn--ss-6ke9690a0g1q.xn--nfb09923ifkyyb; ; ;  # ss⒈ݠ.
+xn--zca444a0s1ao12n.xn--nfb09923ifkyyb; ß⒈\u0760\uD7AE.􉖲\u0605򉔯; [B5, V7]; xn--zca444a0s1ao12n.xn--nfb09923ifkyyb; ; ;  # ß⒈ݠ.
+󠭔.𐋱₂; 󠭔.𐋱2; [V7]; xn--vi56e.xn--2-w91i; ; ;  # .𐋱2
+󠭔.𐋱2; ; [V7]; xn--vi56e.xn--2-w91i; ; ;  # .𐋱2
+xn--vi56e.xn--2-w91i; 󠭔.𐋱2; [V7]; xn--vi56e.xn--2-w91i; ; ;  # .𐋱2
+\u0716\u0947。-ß\u06A5\u200C; \u0716\u0947.-ß\u06A5\u200C; [B1, C1, V3]; xn--gnb63i.xn----qfa845bhx4a; ; xn--gnb63i.xn---ss-4ef; [B1, V3] # ܖे.-ßڥ
+\u0716\u0947。-SS\u06A5\u200C; \u0716\u0947.-ss\u06A5\u200C; [B1, C1, V3]; xn--gnb63i.xn---ss-4ef9263a; ; xn--gnb63i.xn---ss-4ef; [B1, V3] # ܖे.-ssڥ
+\u0716\u0947。-ss\u06A5\u200C; \u0716\u0947.-ss\u06A5\u200C; [B1, C1, V3]; xn--gnb63i.xn---ss-4ef9263a; ; xn--gnb63i.xn---ss-4ef; [B1, V3] # ܖे.-ssڥ
+\u0716\u0947。-Ss\u06A5\u200C; \u0716\u0947.-ss\u06A5\u200C; [B1, C1, V3]; xn--gnb63i.xn---ss-4ef9263a; ; xn--gnb63i.xn---ss-4ef; [B1, V3] # ܖे.-ssڥ
+xn--gnb63i.xn---ss-4ef; \u0716\u0947.-ss\u06A5; [B1, V3]; xn--gnb63i.xn---ss-4ef; ; ;  # ܖे.-ssڥ
+xn--gnb63i.xn---ss-4ef9263a; \u0716\u0947.-ss\u06A5\u200C; [B1, C1, V3]; xn--gnb63i.xn---ss-4ef9263a; ; ;  # ܖे.-ssڥ
+xn--gnb63i.xn----qfa845bhx4a; \u0716\u0947.-ß\u06A5\u200C; [B1, C1, V3]; xn--gnb63i.xn----qfa845bhx4a; ; ;  # ܖे.-ßڥ
+\u1BA9\u200D\u062A񡚈．\u1CD5䷉Ⴡ; \u1BA9\u200D\u062A񡚈.\u1CD5䷉ⴡ; [B1, C2, V6, V7]; xn--pgb911imgdrw34r.xn--i6f270etuy; ; xn--pgb911izv33i.xn--i6f270etuy; [B1, V6, V7] # ᮩت.᳕䷉ⴡ
+\u1BA9\u200D\u062A񡚈.\u1CD5䷉Ⴡ; \u1BA9\u200D\u062A񡚈.\u1CD5䷉ⴡ; [B1, C2, V6, V7]; xn--pgb911imgdrw34r.xn--i6f270etuy; ; xn--pgb911izv33i.xn--i6f270etuy; [B1, V6, V7] # ᮩت.᳕䷉ⴡ
+\u1BA9\u200D\u062A񡚈.\u1CD5䷉ⴡ; ; [B1, C2, V6, V7]; xn--pgb911imgdrw34r.xn--i6f270etuy; ; xn--pgb911izv33i.xn--i6f270etuy; [B1, V6, V7] # ᮩت.᳕䷉ⴡ
+xn--pgb911izv33i.xn--i6f270etuy; \u1BA9\u062A񡚈.\u1CD5䷉ⴡ; [B1, V6, V7]; xn--pgb911izv33i.xn--i6f270etuy; ; ;  # ᮩت.᳕䷉ⴡ
+xn--pgb911imgdrw34r.xn--i6f270etuy; \u1BA9\u200D\u062A񡚈.\u1CD5䷉ⴡ; [B1, C2, V6, V7]; xn--pgb911imgdrw34r.xn--i6f270etuy; ; ;  # ᮩت.᳕䷉ⴡ
+\u1BA9\u200D\u062A񡚈．\u1CD5䷉ⴡ; \u1BA9\u200D\u062A񡚈.\u1CD5䷉ⴡ; [B1, C2, V6, V7]; xn--pgb911imgdrw34r.xn--i6f270etuy; ; xn--pgb911izv33i.xn--i6f270etuy; [B1, V6, V7] # ᮩت.᳕䷉ⴡ
+xn--pgb911izv33i.xn--5nd792dgv3b; \u1BA9\u062A񡚈.\u1CD5䷉Ⴡ; [B1, V6, V7]; xn--pgb911izv33i.xn--5nd792dgv3b; ; ;  # ᮩت.᳕䷉Ⴡ
+xn--pgb911imgdrw34r.xn--5nd792dgv3b; \u1BA9\u200D\u062A񡚈.\u1CD5䷉Ⴡ; [B1, C2, V6, V7]; xn--pgb911imgdrw34r.xn--5nd792dgv3b; ; ;  # ᮩت.᳕䷉Ⴡ
+\u2DBF.ß\u200D; ; [C2, V7]; xn--7pj.xn--zca870n; ; xn--7pj.ss; [V7] # .ß
+\u2DBF.SS\u200D; \u2DBF.ss\u200D; [C2, V7]; xn--7pj.xn--ss-n1t; ; xn--7pj.ss; [V7] # .ss
+\u2DBF.ss\u200D; ; [C2, V7]; xn--7pj.xn--ss-n1t; ; xn--7pj.ss; [V7] # .ss
+\u2DBF.Ss\u200D; \u2DBF.ss\u200D; [C2, V7]; xn--7pj.xn--ss-n1t; ; xn--7pj.ss; [V7] # .ss
+xn--7pj.ss; \u2DBF.ss; [V7]; xn--7pj.ss; ; ;  # .ss
+xn--7pj.xn--ss-n1t; \u2DBF.ss\u200D; [C2, V7]; xn--7pj.xn--ss-n1t; ; ;  # .ss
+xn--7pj.xn--zca870n; \u2DBF.ß\u200D; [C2, V7]; xn--7pj.xn--zca870n; ; ;  # .ß
+\u1BF3︒.\u062A≯ꡂ; ; [B2, B3, B6, V6, V7]; xn--1zf8957g.xn--pgb885lry5g; ; ;  # ᯳︒.ت≯ꡂ
+\u1BF3︒.\u062A>\u0338ꡂ; \u1BF3︒.\u062A≯ꡂ; [B2, B3, B6, V6, V7]; xn--1zf8957g.xn--pgb885lry5g; ; ;  # ᯳︒.ت≯ꡂ
+\u1BF3。.\u062A≯ꡂ; \u1BF3..\u062A≯ꡂ; [B2, B3, V6, X4_2]; xn--1zf..xn--pgb885lry5g; [B2, B3, V6, A4_2]; ;  # ᯳..ت≯ꡂ
+\u1BF3。.\u062A>\u0338ꡂ; \u1BF3..\u062A≯ꡂ; [B2, B3, V6, X4_2]; xn--1zf..xn--pgb885lry5g; [B2, B3, V6, A4_2]; ;  # ᯳..ت≯ꡂ
+xn--1zf..xn--pgb885lry5g; \u1BF3..\u062A≯ꡂ; [B2, B3, V6, X4_2]; xn--1zf..xn--pgb885lry5g; [B2, B3, V6, A4_2]; ;  # ᯳..ت≯ꡂ
+xn--1zf8957g.xn--pgb885lry5g; \u1BF3︒.\u062A≯ꡂ; [B2, B3, B6, V6, V7]; xn--1zf8957g.xn--pgb885lry5g; ; ;  # ᯳︒.ت≯ꡂ
+≮≠񏻃｡-𫠆\u06B7𐹪; ≮≠񏻃.-𫠆\u06B7𐹪; [B1, V3, V7]; xn--1ch1a29470f.xn----7uc5363rc1rn; ; ;  # ≮≠.-𫠆ڷ𐹪
+<\u0338=\u0338񏻃｡-𫠆\u06B7𐹪; ≮≠񏻃.-𫠆\u06B7𐹪; [B1, V3, V7]; xn--1ch1a29470f.xn----7uc5363rc1rn; ; ;  # ≮≠.-𫠆ڷ𐹪
+≮≠񏻃。-𫠆\u06B7𐹪; ≮≠񏻃.-𫠆\u06B7𐹪; [B1, V3, V7]; xn--1ch1a29470f.xn----7uc5363rc1rn; ; ;  # ≮≠.-𫠆ڷ𐹪
+<\u0338=\u0338񏻃。-𫠆\u06B7𐹪; ≮≠񏻃.-𫠆\u06B7𐹪; [B1, V3, V7]; xn--1ch1a29470f.xn----7uc5363rc1rn; ; ;  # ≮≠.-𫠆ڷ𐹪
+xn--1ch1a29470f.xn----7uc5363rc1rn; ≮≠񏻃.-𫠆\u06B7𐹪; [B1, V3, V7]; xn--1ch1a29470f.xn----7uc5363rc1rn; ; ;  # ≮≠.-𫠆ڷ𐹪
+𐹡\u0777。ꡂ; 𐹡\u0777.ꡂ; [B1]; xn--7pb5275k.xn--bc9a; ; ;  # 𐹡ݷ.ꡂ
+xn--7pb5275k.xn--bc9a; 𐹡\u0777.ꡂ; [B1]; xn--7pb5275k.xn--bc9a; ; ;  # 𐹡ݷ.ꡂ
+Ⴉ𝆅񔻅\u0619.ß𐧦𐹳\u0775; ⴉ𝆅񔻅\u0619.ß𐧦𐹳\u0775; [B5, B6, V7]; xn--7fb940rwt3z7xvz.xn--zca684a699vf2d; ; xn--7fb940rwt3z7xvz.xn--ss-zme7575xp0e;  # ⴉؙ𝆅.ß𐧦𐹳ݵ
+ⴉ𝆅񔻅\u0619.ß𐧦𐹳\u0775; ; [B5, B6, V7]; xn--7fb940rwt3z7xvz.xn--zca684a699vf2d; ; xn--7fb940rwt3z7xvz.xn--ss-zme7575xp0e;  # ⴉؙ𝆅.ß𐧦𐹳ݵ
+Ⴉ𝆅񔻅\u0619.SS𐧦𐹳\u0775; ⴉ𝆅񔻅\u0619.ss𐧦𐹳\u0775; [B5, B6, V7]; xn--7fb940rwt3z7xvz.xn--ss-zme7575xp0e; ; ;  # ⴉؙ𝆅.ss𐧦𐹳ݵ
+ⴉ𝆅񔻅\u0619.ss𐧦𐹳\u0775; ; [B5, B6, V7]; xn--7fb940rwt3z7xvz.xn--ss-zme7575xp0e; ; ;  # ⴉؙ𝆅.ss𐧦𐹳ݵ
+Ⴉ𝆅񔻅\u0619.Ss𐧦𐹳\u0775; ⴉ𝆅񔻅\u0619.ss𐧦𐹳\u0775; [B5, B6, V7]; xn--7fb940rwt3z7xvz.xn--ss-zme7575xp0e; ; ;  # ⴉؙ𝆅.ss𐧦𐹳ݵ
+xn--7fb940rwt3z7xvz.xn--ss-zme7575xp0e; ⴉ𝆅񔻅\u0619.ss𐧦𐹳\u0775; [B5, B6, V7]; xn--7fb940rwt3z7xvz.xn--ss-zme7575xp0e; ; ;  # ⴉؙ𝆅.ss𐧦𐹳ݵ
+xn--7fb940rwt3z7xvz.xn--zca684a699vf2d; ⴉ𝆅񔻅\u0619.ß𐧦𐹳\u0775; [B5, B6, V7]; xn--7fb940rwt3z7xvz.xn--zca684a699vf2d; ; ;  # ⴉؙ𝆅.ß𐧦𐹳ݵ
+xn--7fb125cjv87a7xvz.xn--ss-zme7575xp0e; Ⴉ𝆅񔻅\u0619.ss𐧦𐹳\u0775; [B5, B6, V7]; xn--7fb125cjv87a7xvz.xn--ss-zme7575xp0e; ; ;  # Ⴉؙ𝆅.ss𐧦𐹳ݵ
+xn--7fb125cjv87a7xvz.xn--zca684a699vf2d; Ⴉ𝆅񔻅\u0619.ß𐧦𐹳\u0775; [B5, B6, V7]; xn--7fb125cjv87a7xvz.xn--zca684a699vf2d; ; ;  # Ⴉؙ𝆅.ß𐧦𐹳ݵ
+\u200D\u0643𐧾↙.񊽡; ; [B1, C2, V7]; xn--fhb713k87ag053c.xn--7s4w; ; xn--fhb011lnp8n.xn--7s4w; [B3, V7] # ك𐧾↙.
+xn--fhb011lnp8n.xn--7s4w; \u0643𐧾↙.񊽡; [B3, V7]; xn--fhb011lnp8n.xn--7s4w; ; ;  # ك𐧾↙.
+xn--fhb713k87ag053c.xn--7s4w; \u200D\u0643𐧾↙.񊽡; [B1, C2, V7]; xn--fhb713k87ag053c.xn--7s4w; ; ;  # ك𐧾↙.
+梉。\u200C; 梉.\u200C; [C1]; xn--7zv.xn--0ug; ; xn--7zv.; [A4_2] # 梉.
+xn--7zv.; 梉.; ; xn--7zv.; [A4_2]; ;  # 梉.
+梉.; ; ; xn--7zv.; [A4_2]; ;  # 梉.
+xn--7zv.xn--0ug; 梉.\u200C; [C1]; xn--7zv.xn--0ug; ; ;  # 梉.
+ꡣ-≠.\u200D𞤗𐅢Ↄ; ꡣ-≠.\u200D𞤹𐅢ↄ; [B1, B6, C2]; xn----ufo9661d.xn--1ug99cj620c71sh; ; xn----ufo9661d.xn--r5gy929fhm4f; [B2, B3, B6] # ꡣ-≠.𞤹𐅢ↄ
+ꡣ-=\u0338.\u200D𞤗𐅢Ↄ; ꡣ-≠.\u200D𞤹𐅢ↄ; [B1, B6, C2]; xn----ufo9661d.xn--1ug99cj620c71sh; ; xn----ufo9661d.xn--r5gy929fhm4f; [B2, B3, B6] # ꡣ-≠.𞤹𐅢ↄ
+ꡣ-=\u0338.\u200D𞤹𐅢ↄ; ꡣ-≠.\u200D𞤹𐅢ↄ; [B1, B6, C2]; xn----ufo9661d.xn--1ug99cj620c71sh; ; xn----ufo9661d.xn--r5gy929fhm4f; [B2, B3, B6] # ꡣ-≠.𞤹𐅢ↄ
+ꡣ-≠.\u200D𞤹𐅢ↄ; ; [B1, B6, C2]; xn----ufo9661d.xn--1ug99cj620c71sh; ; xn----ufo9661d.xn--r5gy929fhm4f; [B2, B3, B6] # ꡣ-≠.𞤹𐅢ↄ
+ꡣ-≠.\u200D𞤗𐅢ↄ; ꡣ-≠.\u200D𞤹𐅢ↄ; [B1, B6, C2]; xn----ufo9661d.xn--1ug99cj620c71sh; ; xn----ufo9661d.xn--r5gy929fhm4f; [B2, B3, B6] # ꡣ-≠.𞤹𐅢ↄ
+ꡣ-=\u0338.\u200D𞤗𐅢ↄ; ꡣ-≠.\u200D𞤹𐅢ↄ; [B1, B6, C2]; xn----ufo9661d.xn--1ug99cj620c71sh; ; xn----ufo9661d.xn--r5gy929fhm4f; [B2, B3, B6] # ꡣ-≠.𞤹𐅢ↄ
+xn----ufo9661d.xn--r5gy929fhm4f; ꡣ-≠.𞤹𐅢ↄ; [B2, B3, B6]; xn----ufo9661d.xn--r5gy929fhm4f; ; ;  # ꡣ-≠.𞤹𐅢ↄ
+xn----ufo9661d.xn--1ug99cj620c71sh; ꡣ-≠.\u200D𞤹𐅢ↄ; [B1, B6, C2]; xn----ufo9661d.xn--1ug99cj620c71sh; ; ;  # ꡣ-≠.𞤹𐅢ↄ
+xn----ufo9661d.xn--q5g0929fhm4f; ꡣ-≠.𞤹𐅢Ↄ; [B2, B3, B6, V7]; xn----ufo9661d.xn--q5g0929fhm4f; ; ;  # ꡣ-≠.𞤹𐅢Ↄ
+xn----ufo9661d.xn--1ug79cm620c71sh; ꡣ-≠.\u200D𞤹𐅢Ↄ; [B1, B6, C2, V7]; xn----ufo9661d.xn--1ug79cm620c71sh; ; ;  # ꡣ-≠.𞤹𐅢Ↄ
+ς⒐𝆫⸵｡𐱢🄊𝟳; ς⒐𝆫⸵.𐱢9,7; [B6, V7, U1]; xn--3xa019nwtghi25b.xn--9,7-r67t; ; xn--4xa809nwtghi25b.xn--9,7-r67t;  # ς⒐𝆫⸵.9,7
+ς9.𝆫⸵。𐱢9,7; ς9.𝆫⸵.𐱢9,7; [B1, V6, V7, U1]; xn--9-xmb.xn--ltj1535k.xn--9,7-r67t; ; xn--9-zmb.xn--ltj1535k.xn--9,7-r67t;  # ς9.𝆫⸵.9,7
+Σ9.𝆫⸵。𐱢9,7; σ9.𝆫⸵.𐱢9,7; [B1, V6, V7, U1]; xn--9-zmb.xn--ltj1535k.xn--9,7-r67t; ; ;  # σ9.𝆫⸵.9,7
+σ9.𝆫⸵。𐱢9,7; σ9.𝆫⸵.𐱢9,7; [B1, V6, V7, U1]; xn--9-zmb.xn--ltj1535k.xn--9,7-r67t; ; ;  # σ9.𝆫⸵.9,7
+xn--9-zmb.xn--ltj1535k.xn--9,7-r67t; σ9.𝆫⸵.𐱢9,7; [B1, V6, V7, U1]; xn--9-zmb.xn--ltj1535k.xn--9,7-r67t; ; ;  # σ9.𝆫⸵.9,7
+xn--9-xmb.xn--ltj1535k.xn--9,7-r67t; ς9.𝆫⸵.𐱢9,7; [B1, V6, V7, U1]; xn--9-xmb.xn--ltj1535k.xn--9,7-r67t; ; ;  # ς9.𝆫⸵.9,7
+Σ⒐𝆫⸵｡𐱢🄊𝟳; σ⒐𝆫⸵.𐱢9,7; [B6, V7, U1]; xn--4xa809nwtghi25b.xn--9,7-r67t; ; ;  # σ⒐𝆫⸵.9,7
+σ⒐𝆫⸵｡𐱢🄊𝟳; σ⒐𝆫⸵.𐱢9,7; [B6, V7, U1]; xn--4xa809nwtghi25b.xn--9,7-r67t; ; ;  # σ⒐𝆫⸵.9,7
+xn--4xa809nwtghi25b.xn--9,7-r67t; σ⒐𝆫⸵.𐱢9,7; [B6, V7, U1]; xn--4xa809nwtghi25b.xn--9,7-r67t; ; ;  # σ⒐𝆫⸵.9,7
+xn--3xa019nwtghi25b.xn--9,7-r67t; ς⒐𝆫⸵.𐱢9,7; [B6, V7, U1]; xn--3xa019nwtghi25b.xn--9,7-r67t; ; ;  # ς⒐𝆫⸵.9,7
+xn--4xa809nwtghi25b.xn--7-075iy877c; σ⒐𝆫⸵.𐱢🄊7; [B6, V7]; xn--4xa809nwtghi25b.xn--7-075iy877c; ; ;  # σ⒐𝆫⸵.🄊7
+xn--3xa019nwtghi25b.xn--7-075iy877c; ς⒐𝆫⸵.𐱢🄊7; [B6, V7]; xn--3xa019nwtghi25b.xn--7-075iy877c; ; ;  # ς⒐𝆫⸵.🄊7
+\u0853．\u200Cß; \u0853.\u200Cß; [B1, C1]; xn--iwb.xn--zca570n; ; xn--iwb.ss; [] # ࡓ.ß
+\u0853.\u200Cß; ; [B1, C1]; xn--iwb.xn--zca570n; ; xn--iwb.ss; [] # ࡓ.ß
+\u0853.\u200CSS; \u0853.\u200Css; [B1, C1]; xn--iwb.xn--ss-i1t; ; xn--iwb.ss; [] # ࡓ.ss
+\u0853.\u200Css; ; [B1, C1]; xn--iwb.xn--ss-i1t; ; xn--iwb.ss; [] # ࡓ.ss
+xn--iwb.ss; \u0853.ss; ; xn--iwb.ss; ; ;  # ࡓ.ss
+\u0853.ss; ; ; xn--iwb.ss; ; ;  # ࡓ.ss
+\u0853.SS; \u0853.ss; ; xn--iwb.ss; ; ;  # ࡓ.ss
+xn--iwb.xn--ss-i1t; \u0853.\u200Css; [B1, C1]; xn--iwb.xn--ss-i1t; ; ;  # ࡓ.ss
+xn--iwb.xn--zca570n; \u0853.\u200Cß; [B1, C1]; xn--iwb.xn--zca570n; ; ;  # ࡓ.ß
+\u0853．\u200CSS; \u0853.\u200Css; [B1, C1]; xn--iwb.xn--ss-i1t; ; xn--iwb.ss; [] # ࡓ.ss
+\u0853．\u200Css; \u0853.\u200Css; [B1, C1]; xn--iwb.xn--ss-i1t; ; xn--iwb.ss; [] # ࡓ.ss
+\u0853.\u200CSs; \u0853.\u200Css; [B1, C1]; xn--iwb.xn--ss-i1t; ; xn--iwb.ss; [] # ࡓ.ss
+\u0853．\u200CSs; \u0853.\u200Css; [B1, C1]; xn--iwb.xn--ss-i1t; ; xn--iwb.ss; [] # ࡓ.ss
+񯶣-.\u200D\u074E\uA94D󠻨; ; [B1, B6, C2, V3, V7]; xn----s116e.xn--1ob387jy90hq459k; ; xn----s116e.xn--1ob6504fmf40i; [B3, B6, V3, V7] # -.ݎꥍ
+xn----s116e.xn--1ob6504fmf40i; 񯶣-.\u074E\uA94D󠻨; [B3, B6, V3, V7]; xn----s116e.xn--1ob6504fmf40i; ; ;  # -.ݎꥍ
+xn----s116e.xn--1ob387jy90hq459k; 񯶣-.\u200D\u074E\uA94D󠻨; [B1, B6, C2, V3, V7]; xn----s116e.xn--1ob387jy90hq459k; ; ;  # -.ݎꥍ
+䃚蟥-。-񽒘⒈; 䃚蟥-.-񽒘⒈; [V3, V7]; xn----n50a258u.xn----ecp33805f; ; ;  # 䃚蟥-.-⒈
+䃚蟥-。-񽒘1.; 䃚蟥-.-񽒘1.; [V3, V7]; xn----n50a258u.xn---1-up07j.; [V3, V7, A4_2]; ;  # 䃚蟥-.-1.
+xn----n50a258u.xn---1-up07j.; 䃚蟥-.-񽒘1.; [V3, V7]; xn----n50a258u.xn---1-up07j.; [V3, V7, A4_2]; ;  # 䃚蟥-.-1.
+xn----n50a258u.xn----ecp33805f; 䃚蟥-.-񽒘⒈; [V3, V7]; xn----n50a258u.xn----ecp33805f; ; ;  # 䃚蟥-.-⒈
+𐹸䚵-ꡡ。⺇; 𐹸䚵-ꡡ.⺇; [B1]; xn----bm3an932a1l5d.xn--xvj; ; ;  # 𐹸䚵-ꡡ.⺇
+xn----bm3an932a1l5d.xn--xvj; 𐹸䚵-ꡡ.⺇; [B1]; xn----bm3an932a1l5d.xn--xvj; ; ;  # 𐹸䚵-ꡡ.⺇
+𑄳。\u1ADC𐹻; 𑄳.\u1ADC𐹻; [B1, V6]; xn--v80d.xn--2rf1154i; ; ;  # 𑄳.᫜𐹻
+xn--v80d.xn--2rf1154i; 𑄳.\u1ADC𐹻; [B1, V6]; xn--v80d.xn--2rf1154i; ; ;  # 𑄳.᫜𐹻
+≮𐹻.⒎𑂵\u06BA\u0602; ; [B1, V7]; xn--gdhx904g.xn--kfb18a325efm3s; ; ;  # ≮𐹻.⒎𑂵ں
+<\u0338𐹻.⒎𑂵\u06BA\u0602; ≮𐹻.⒎𑂵\u06BA\u0602; [B1, V7]; xn--gdhx904g.xn--kfb18a325efm3s; ; ;  # ≮𐹻.⒎𑂵ں
+≮𐹻.7.𑂵\u06BA\u0602; ; [B1, V6, V7]; xn--gdhx904g.7.xn--kfb18an307d; ; ;  # ≮𐹻.7.𑂵ں
+<\u0338𐹻.7.𑂵\u06BA\u0602; ≮𐹻.7.𑂵\u06BA\u0602; [B1, V6, V7]; xn--gdhx904g.7.xn--kfb18an307d; ; ;  # ≮𐹻.7.𑂵ں
+xn--gdhx904g.7.xn--kfb18an307d; ≮𐹻.7.𑂵\u06BA\u0602; [B1, V6, V7]; xn--gdhx904g.7.xn--kfb18an307d; ; ;  # ≮𐹻.7.𑂵ں
+xn--gdhx904g.xn--kfb18a325efm3s; ≮𐹻.⒎𑂵\u06BA\u0602; [B1, V7]; xn--gdhx904g.xn--kfb18a325efm3s; ; ;  # ≮𐹻.⒎𑂵ں
+ᢔ≠􋉂.\u200D𐋢; ; [C2, V7]; xn--ebf031cf7196a.xn--1ug9540g; ; xn--ebf031cf7196a.xn--587c; [V7] # ᢔ≠.𐋢
+ᢔ=\u0338􋉂.\u200D𐋢; ᢔ≠􋉂.\u200D𐋢; [C2, V7]; xn--ebf031cf7196a.xn--1ug9540g; ; xn--ebf031cf7196a.xn--587c; [V7] # ᢔ≠.𐋢
+xn--ebf031cf7196a.xn--587c; ᢔ≠􋉂.𐋢; [V7]; xn--ebf031cf7196a.xn--587c; ; ;  # ᢔ≠.𐋢
+xn--ebf031cf7196a.xn--1ug9540g; ᢔ≠􋉂.\u200D𐋢; [C2, V7]; xn--ebf031cf7196a.xn--1ug9540g; ; ;  # ᢔ≠.𐋢
+𐩁≮񣊛≯．\u066C𞵕⳿; 𐩁≮񣊛≯.\u066C𞵕⳿; [B1, B2, B3, V7]; xn--gdhc0519o0y27b.xn--lib468q0d21a; ; ;  # 𐩁≮≯.٬⳿
+𐩁<\u0338񣊛>\u0338．\u066C𞵕⳿; 𐩁≮񣊛≯.\u066C𞵕⳿; [B1, B2, B3, V7]; xn--gdhc0519o0y27b.xn--lib468q0d21a; ; ;  # 𐩁≮≯.٬⳿
+𐩁≮񣊛≯.\u066C𞵕⳿; ; [B1, B2, B3, V7]; xn--gdhc0519o0y27b.xn--lib468q0d21a; ; ;  # 𐩁≮≯.٬⳿
+𐩁<\u0338񣊛>\u0338.\u066C𞵕⳿; 𐩁≮񣊛≯.\u066C𞵕⳿; [B1, B2, B3, V7]; xn--gdhc0519o0y27b.xn--lib468q0d21a; ; ;  # 𐩁≮≯.٬⳿
+xn--gdhc0519o0y27b.xn--lib468q0d21a; 𐩁≮񣊛≯.\u066C𞵕⳿; [B1, B2, B3, V7]; xn--gdhc0519o0y27b.xn--lib468q0d21a; ; ;  # 𐩁≮≯.٬⳿
+-｡⺐; -.⺐; [V3]; -.xn--6vj; ; ;  # -.⺐
+-。⺐; -.⺐; [V3]; -.xn--6vj; ; ;  # -.⺐
+-.xn--6vj; -.⺐; [V3]; -.xn--6vj; ; ;  # -.⺐
+󠰩𑲬．\u065C; 󠰩𑲬.\u065C; [V6, V7]; xn--sn3d59267c.xn--4hb; ; ;  # 𑲬.ٜ
+󠰩𑲬.\u065C; ; [V6, V7]; xn--sn3d59267c.xn--4hb; ; ;  # 𑲬.ٜ
+xn--sn3d59267c.xn--4hb; 󠰩𑲬.\u065C; [V6, V7]; xn--sn3d59267c.xn--4hb; ; ;  # 𑲬.ٜ
+𐍺.񚇃\u200C; ; [C1, V6, V7]; xn--ie8c.xn--0ug03366c; ; xn--ie8c.xn--2g51a; [V6, V7] # 𐍺.
+xn--ie8c.xn--2g51a; 𐍺.񚇃; [V6, V7]; xn--ie8c.xn--2g51a; ; ;  # 𐍺.
+xn--ie8c.xn--0ug03366c; 𐍺.񚇃\u200C; [C1, V6, V7]; xn--ie8c.xn--0ug03366c; ; ;  # 𐍺.
+\u063D\u06E3.𐨎; ; [B1, V6]; xn--8gb64a.xn--mr9c; ; ;  # ؽۣ.𐨎
+xn--8gb64a.xn--mr9c; \u063D\u06E3.𐨎; [B1, V6]; xn--8gb64a.xn--mr9c; ; ;  # ؽۣ.𐨎
+漦Ⴙς.񡻀𐴄; 漦ⴙς.񡻀𐴄; [B5, B6, V7]; xn--3xa972sl47b.xn--9d0d3162t; ; xn--4xa772sl47b.xn--9d0d3162t;  # 漦ⴙς.𐴄
+漦ⴙς.񡻀𐴄; ; [B5, B6, V7]; xn--3xa972sl47b.xn--9d0d3162t; ; xn--4xa772sl47b.xn--9d0d3162t;  # 漦ⴙς.𐴄
+漦ႹΣ.񡻀𐴄; 漦ⴙσ.񡻀𐴄; [B5, B6, V7]; xn--4xa772sl47b.xn--9d0d3162t; ; ;  # 漦ⴙσ.𐴄
+漦ⴙσ.񡻀𐴄; ; [B5, B6, V7]; xn--4xa772sl47b.xn--9d0d3162t; ; ;  # 漦ⴙσ.𐴄
+漦Ⴙσ.񡻀𐴄; 漦ⴙσ.񡻀𐴄; [B5, B6, V7]; xn--4xa772sl47b.xn--9d0d3162t; ; ;  # 漦ⴙσ.𐴄
+xn--4xa772sl47b.xn--9d0d3162t; 漦ⴙσ.񡻀𐴄; [B5, B6, V7]; xn--4xa772sl47b.xn--9d0d3162t; ; ;  # 漦ⴙσ.𐴄
+xn--3xa972sl47b.xn--9d0d3162t; 漦ⴙς.񡻀𐴄; [B5, B6, V7]; xn--3xa972sl47b.xn--9d0d3162t; ; ;  # 漦ⴙς.𐴄
+xn--4xa947d717e.xn--9d0d3162t; 漦Ⴙσ.񡻀𐴄; [B5, B6, V7]; xn--4xa947d717e.xn--9d0d3162t; ; ;  # 漦Ⴙσ.𐴄
+xn--3xa157d717e.xn--9d0d3162t; 漦Ⴙς.񡻀𐴄; [B5, B6, V7]; xn--3xa157d717e.xn--9d0d3162t; ; ;  # 漦Ⴙς.𐴄
+𐹫踧\u0CCD򫚇.󜀃⒈𝨤; ; [B1, V7]; xn--8tc1437dro0d6q06h.xn--tsh2611ncu71e; ; ;  # 𐹫踧್.⒈𝨤
+𐹫踧\u0CCD򫚇.󜀃1.𝨤; ; [B1, V6, V7]; xn--8tc1437dro0d6q06h.xn--1-p948l.xn--m82h; ; ;  # 𐹫踧್.1.𝨤
+xn--8tc1437dro0d6q06h.xn--1-p948l.xn--m82h; 𐹫踧\u0CCD򫚇.󜀃1.𝨤; [B1, V6, V7]; xn--8tc1437dro0d6q06h.xn--1-p948l.xn--m82h; ; ;  # 𐹫踧್.1.𝨤
+xn--8tc1437dro0d6q06h.xn--tsh2611ncu71e; 𐹫踧\u0CCD򫚇.󜀃⒈𝨤; [B1, V7]; xn--8tc1437dro0d6q06h.xn--tsh2611ncu71e; ; ;  # 𐹫踧್.⒈𝨤
+\u200D≮．󠟪𹫏-; \u200D≮.󠟪𹫏-; [C2, V3, V7]; xn--1ug95g.xn----cr99a1w710b; ; xn--gdh.xn----cr99a1w710b; [V3, V7] # ≮.-
+\u200D<\u0338．󠟪𹫏-; \u200D≮.󠟪𹫏-; [C2, V3, V7]; xn--1ug95g.xn----cr99a1w710b; ; xn--gdh.xn----cr99a1w710b; [V3, V7] # ≮.-
+\u200D≮.󠟪𹫏-; ; [C2, V3, V7]; xn--1ug95g.xn----cr99a1w710b; ; xn--gdh.xn----cr99a1w710b; [V3, V7] # ≮.-
+\u200D<\u0338.󠟪𹫏-; \u200D≮.󠟪𹫏-; [C2, V3, V7]; xn--1ug95g.xn----cr99a1w710b; ; xn--gdh.xn----cr99a1w710b; [V3, V7] # ≮.-
+xn--gdh.xn----cr99a1w710b; ≮.󠟪𹫏-; [V3, V7]; xn--gdh.xn----cr99a1w710b; ; ;  # ≮.-
+xn--1ug95g.xn----cr99a1w710b; \u200D≮.󠟪𹫏-; [C2, V3, V7]; xn--1ug95g.xn----cr99a1w710b; ; ;  # ≮.-
+\u200D\u200D襔。Ⴜ5ꡮ񵝏; \u200D\u200D襔.ⴜ5ꡮ񵝏; [C2, V7]; xn--1uga7691f.xn--5-uws5848bpf44e; ; xn--2u2a.xn--5-uws5848bpf44e; [V7] # 襔.ⴜ5ꡮ
+\u200D\u200D襔。ⴜ5ꡮ񵝏; \u200D\u200D襔.ⴜ5ꡮ񵝏; [C2, V7]; xn--1uga7691f.xn--5-uws5848bpf44e; ; xn--2u2a.xn--5-uws5848bpf44e; [V7] # 襔.ⴜ5ꡮ
+xn--2u2a.xn--5-uws5848bpf44e; 襔.ⴜ5ꡮ񵝏; [V7]; xn--2u2a.xn--5-uws5848bpf44e; ; ;  # 襔.ⴜ5ꡮ
+xn--1uga7691f.xn--5-uws5848bpf44e; \u200D\u200D襔.ⴜ5ꡮ񵝏; [C2, V7]; xn--1uga7691f.xn--5-uws5848bpf44e; ; ;  # 襔.ⴜ5ꡮ
+xn--2u2a.xn--5-r1g7167ipfw8d; 襔.Ⴜ5ꡮ񵝏; [V7]; xn--2u2a.xn--5-r1g7167ipfw8d; ; ;  # 襔.Ⴜ5ꡮ
+xn--1uga7691f.xn--5-r1g7167ipfw8d; \u200D\u200D襔.Ⴜ5ꡮ񵝏; [C2, V7]; xn--1uga7691f.xn--5-r1g7167ipfw8d; ; ;  # 襔.Ⴜ5ꡮ
+𐫜𑌼\u200D．婀; 𐫜𑌼\u200D.婀; [B3, C2]; xn--1ugx063g1if.xn--q0s; ; xn--ix9c26l.xn--q0s; [] # 𐫜𑌼.婀
+𐫜𑌼\u200D.婀; ; [B3, C2]; xn--1ugx063g1if.xn--q0s; ; xn--ix9c26l.xn--q0s; [] # 𐫜𑌼.婀
+xn--ix9c26l.xn--q0s; 𐫜𑌼.婀; ; xn--ix9c26l.xn--q0s; ; ;  # 𐫜𑌼.婀
+𐫜𑌼.婀; ; ; xn--ix9c26l.xn--q0s; ; ;  # 𐫜𑌼.婀
+xn--1ugx063g1if.xn--q0s; 𐫜𑌼\u200D.婀; [B3, C2]; xn--1ugx063g1if.xn--q0s; ; ;  # 𐫜𑌼.婀
+󠅽︒︒𐹯｡⬳\u1A78; ︒︒𐹯.⬳\u1A78; [B1, V7]; xn--y86ca186j.xn--7of309e; ; ;  # ︒︒𐹯.⬳᩸
+󠅽。。𐹯。⬳\u1A78; ..𐹯.⬳\u1A78; [B1, X4_2]; ..xn--no0d.xn--7of309e; [B1, A4_2]; ;  # ..𐹯.⬳᩸
+..xn--no0d.xn--7of309e; ..𐹯.⬳\u1A78; [B1, X4_2]; ..xn--no0d.xn--7of309e; [B1, A4_2]; ;  # ..𐹯.⬳᩸
+xn--y86ca186j.xn--7of309e; ︒︒𐹯.⬳\u1A78; [B1, V7]; xn--y86ca186j.xn--7of309e; ; ;  # ︒︒𐹯.⬳᩸
+𝟖ß．󠄐-?Ⴏ; 8ß.-?ⴏ; [V3, U1]; xn--8-qfa.xn---?-261a; ; 8ss.xn---?-261a;  # 8ß.-?ⴏ
+8ß.󠄐-?Ⴏ; 8ß.-?ⴏ; [V3, U1]; xn--8-qfa.xn---?-261a; ; 8ss.xn---?-261a;  # 8ß.-?ⴏ
+8ß.󠄐-?ⴏ; 8ß.-?ⴏ; [V3, U1]; xn--8-qfa.xn---?-261a; ; 8ss.xn---?-261a;  # 8ß.-?ⴏ
+8SS.󠄐-?Ⴏ; 8ss.-?ⴏ; [V3, U1]; 8ss.xn---?-261a; ; ;  # 8ss.-?ⴏ
+8ss.󠄐-?ⴏ; 8ss.-?ⴏ; [V3, U1]; 8ss.xn---?-261a; ; ;  # 8ss.-?ⴏ
+8ss.󠄐-?Ⴏ; 8ss.-?ⴏ; [V3, U1]; 8ss.xn---?-261a; ; ;  # 8ss.-?ⴏ
+8ss.xn---?-261a; 8ss.-?ⴏ; [V3, U1]; 8ss.xn---?-261a; ; ;  # 8ss.-?ⴏ
+xn--8-qfa.xn---?-261a; 8ß.-?ⴏ; [V3, U1]; xn--8-qfa.xn---?-261a; ; ;  # 8ß.-?ⴏ
+𝟖ß．󠄐-?ⴏ; 8ß.-?ⴏ; [V3, U1]; xn--8-qfa.xn---?-261a; ; 8ss.xn---?-261a;  # 8ß.-?ⴏ
+𝟖SS．󠄐-?Ⴏ; 8ss.-?ⴏ; [V3, U1]; 8ss.xn---?-261a; ; ;  # 8ss.-?ⴏ
+𝟖ss．󠄐-?ⴏ; 8ss.-?ⴏ; [V3, U1]; 8ss.xn---?-261a; ; ;  # 8ss.-?ⴏ
+𝟖ss．󠄐-?Ⴏ; 8ss.-?ⴏ; [V3, U1]; 8ss.xn---?-261a; ; ;  # 8ss.-?ⴏ
+8ss.xn---?-gfk; 8ss.-?Ⴏ; [V3, V7, U1]; 8ss.xn---?-gfk; ; ;  # 8ss.-?Ⴏ
+xn--8-qfa.xn---?-gfk; 8ß.-?Ⴏ; [V3, V7, U1]; xn--8-qfa.xn---?-gfk; ; ;  # 8ß.-?Ⴏ
+8ss.-?Ⴏ; 8ss.-?ⴏ; [V3, U1]; 8ss.xn---?-261a; ; ;  # 8ss.-?ⴏ
+8ss.-?ⴏ; ; [V3, U1]; 8ss.xn---?-261a; ; ;  # 8ss.-?ⴏ
+8SS.-?Ⴏ; 8ss.-?ⴏ; [V3, U1]; 8ss.xn---?-261a; ; ;  # 8ss.-?ⴏ
+xn--8-qfa.-?ⴏ; 8ß.-?ⴏ; [V3, U1]; xn--8-qfa.xn---?-261a; ; ;  # 8ß.-?ⴏ
+XN--8-QFA.-?Ⴏ; 8ß.-?ⴏ; [V3, U1]; xn--8-qfa.xn---?-261a; ; ;  # 8ß.-?ⴏ
+Xn--8-Qfa.-?Ⴏ; 8ß.-?ⴏ; [V3, U1]; xn--8-qfa.xn---?-261a; ; ;  # 8ß.-?ⴏ
+xn--8-qfa.-?Ⴏ; 8ß.-?ⴏ; [V3, U1]; xn--8-qfa.xn---?-261a; ; ;  # 8ß.-?ⴏ
+𝟖Ss．󠄐-?Ⴏ; 8ss.-?ⴏ; [V3, U1]; 8ss.xn---?-261a; ; ;  # 8ss.-?ⴏ
+8Ss.󠄐-?Ⴏ; 8ss.-?ⴏ; [V3, U1]; 8ss.xn---?-261a; ; ;  # 8ss.-?ⴏ
+-\u200D󠋟.\u200C𐹣Ⴅ; -\u200D󠋟.\u200C𐹣ⴅ; [B1, C1, C2, V3, V7]; xn----ugnv7071n.xn--0ugz32cgr0p; ; xn----s721m.xn--wkj1423e; [B1, V3, V7] # -.𐹣ⴅ
+-\u200D󠋟.\u200C𐹣ⴅ; ; [B1, C1, C2, V3, V7]; xn----ugnv7071n.xn--0ugz32cgr0p; ; xn----s721m.xn--wkj1423e; [B1, V3, V7] # -.𐹣ⴅ
+xn----s721m.xn--wkj1423e; -󠋟.𐹣ⴅ; [B1, V3, V7]; xn----s721m.xn--wkj1423e; ; ;  # -.𐹣ⴅ
+xn----ugnv7071n.xn--0ugz32cgr0p; -\u200D󠋟.\u200C𐹣ⴅ; [B1, C1, C2, V3, V7]; xn----ugnv7071n.xn--0ugz32cgr0p; ; ;  # -.𐹣ⴅ
+xn----s721m.xn--dnd9201k; -󠋟.𐹣Ⴅ; [B1, V3, V7]; xn----s721m.xn--dnd9201k; ; ;  # -.𐹣Ⴅ
+xn----ugnv7071n.xn--dnd999e4j4p; -\u200D󠋟.\u200C𐹣Ⴅ; [B1, C1, C2, V3, V7]; xn----ugnv7071n.xn--dnd999e4j4p; ; ;  # -.𐹣Ⴅ
+\uA9B9\u200D큷𻶡｡₂; \uA9B9\u200D큷𻶡.2; [C2, V6, V7]; xn--1ug1435cfkyaoi04d.2; ; xn--0m9as84e2e21c.2; [V6, V7] # ꦹ큷.2
+\uA9B9\u200D큷𻶡｡₂; \uA9B9\u200D큷𻶡.2; [C2, V6, V7]; xn--1ug1435cfkyaoi04d.2; ; xn--0m9as84e2e21c.2; [V6, V7] # ꦹ큷.2
+\uA9B9\u200D큷𻶡。2; \uA9B9\u200D큷𻶡.2; [C2, V6, V7]; xn--1ug1435cfkyaoi04d.2; ; xn--0m9as84e2e21c.2; [V6, V7] # ꦹ큷.2
+\uA9B9\u200D큷𻶡。2; \uA9B9\u200D큷𻶡.2; [C2, V6, V7]; xn--1ug1435cfkyaoi04d.2; ; xn--0m9as84e2e21c.2; [V6, V7] # ꦹ큷.2
+xn--0m9as84e2e21c.c; \uA9B9큷𻶡.c; [V6, V7]; xn--0m9as84e2e21c.c; ; ;  # ꦹ큷.c
+xn--1ug1435cfkyaoi04d.c; \uA9B9\u200D큷𻶡.c; [C2, V6, V7]; xn--1ug1435cfkyaoi04d.c; ; ;  # ꦹ큷.c
+?.🄄𞯘; ?.3,𞯘; [B1, V7, U1]; ?.xn--3,-tb22a; ; ;  # ?.3,
+?.3,𞯘; ; [B1, V7, U1]; ?.xn--3,-tb22a; ; ;  # ?.3,
+?.xn--3,-tb22a; ?.3,𞯘; [B1, V7, U1]; ?.xn--3,-tb22a; ; ;  # ?.3,
+?.xn--3x6hx6f; ?.🄄𞯘; [B1, V7, U1]; ?.xn--3x6hx6f; ; ;  # ?.🄄
+𝨖𐩙。\u06DD󀡶\uA8C5⒈; 𝨖𐩙.\u06DD󀡶\uA8C5⒈; [B1, V6, V7]; xn--rt9cl956a.xn--tlb403mxv4g06s9i; ; ;  # 𝨖.ꣅ⒈
+𝨖𐩙。\u06DD󀡶\uA8C51.; 𝨖𐩙.\u06DD󀡶\uA8C51.; [B1, V6, V7]; xn--rt9cl956a.xn--1-dxc8545j0693i.; [B1, V6, V7, A4_2]; ;  # 𝨖.ꣅ1.
+xn--rt9cl956a.xn--1-dxc8545j0693i.; 𝨖𐩙.\u06DD󀡶\uA8C51.; [B1, V6, V7]; xn--rt9cl956a.xn--1-dxc8545j0693i.; [B1, V6, V7, A4_2]; ;  # 𝨖.ꣅ1.
+xn--rt9cl956a.xn--tlb403mxv4g06s9i; 𝨖𐩙.\u06DD󀡶\uA8C5⒈; [B1, V6, V7]; xn--rt9cl956a.xn--tlb403mxv4g06s9i; ; ;  # 𝨖.ꣅ⒈
+򒈣\u05E1\u06B8。Ⴈ\u200D; 򒈣\u05E1\u06B8.ⴈ\u200D; [B5, B6, C2, V7]; xn--meb44b57607c.xn--1ug232c; ; xn--meb44b57607c.xn--zkj; [B5, B6, V7] # סڸ.ⴈ
+򒈣\u05E1\u06B8。ⴈ\u200D; 򒈣\u05E1\u06B8.ⴈ\u200D; [B5, B6, C2, V7]; xn--meb44b57607c.xn--1ug232c; ; xn--meb44b57607c.xn--zkj; [B5, B6, V7] # סڸ.ⴈ
+xn--meb44b57607c.xn--zkj; 򒈣\u05E1\u06B8.ⴈ; [B5, B6, V7]; xn--meb44b57607c.xn--zkj; ; ;  # סڸ.ⴈ
+xn--meb44b57607c.xn--1ug232c; 򒈣\u05E1\u06B8.ⴈ\u200D; [B5, B6, C2, V7]; xn--meb44b57607c.xn--1ug232c; ; ;  # סڸ.ⴈ
+xn--meb44b57607c.xn--gnd; 򒈣\u05E1\u06B8.Ⴈ; [B5, B6, V7]; xn--meb44b57607c.xn--gnd; ; ;  # סڸ.Ⴈ
+xn--meb44b57607c.xn--gnd699e; 򒈣\u05E1\u06B8.Ⴈ\u200D; [B5, B6, C2, V7]; xn--meb44b57607c.xn--gnd699e; ; ;  # סڸ.Ⴈ
+󀚶𝨱\u07E6⒈．𑗝髯\u200C; 󀚶𝨱\u07E6⒈.𑗝髯\u200C; [B1, B5, C1, V6, V7]; xn--etb477lq931a1f58e.xn--0ugx259bocxd; ; xn--etb477lq931a1f58e.xn--uj6at43v; [B1, B5, V6, V7] # 𝨱ߦ⒈.𑗝髯
+󀚶𝨱\u07E61..𑗝髯\u200C; ; [B1, B5, C1, V6, V7, X4_2]; xn--1-idd62296a1fr6e..xn--0ugx259bocxd; [B1, B5, C1, V6, V7, A4_2]; xn--1-idd62296a1fr6e..xn--uj6at43v; [B1, B5, V6, V7, A4_2] # 𝨱ߦ1..𑗝髯
+xn--1-idd62296a1fr6e..xn--uj6at43v; 󀚶𝨱\u07E61..𑗝髯; [B1, B5, V6, V7, X4_2]; xn--1-idd62296a1fr6e..xn--uj6at43v; [B1, B5, V6, V7, A4_2]; ;  # 𝨱ߦ1..𑗝髯
+xn--1-idd62296a1fr6e..xn--0ugx259bocxd; 󀚶𝨱\u07E61..𑗝髯\u200C; [B1, B5, C1, V6, V7, X4_2]; xn--1-idd62296a1fr6e..xn--0ugx259bocxd; [B1, B5, C1, V6, V7, A4_2]; ;  # 𝨱ߦ1..𑗝髯
+xn--etb477lq931a1f58e.xn--uj6at43v; 󀚶𝨱\u07E6⒈.𑗝髯; [B1, B5, V6, V7]; xn--etb477lq931a1f58e.xn--uj6at43v; ; ;  # 𝨱ߦ⒈.𑗝髯
+xn--etb477lq931a1f58e.xn--0ugx259bocxd; 󀚶𝨱\u07E6⒈.𑗝髯\u200C; [B1, B5, C1, V6, V7]; xn--etb477lq931a1f58e.xn--0ugx259bocxd; ; ;  # 𝨱ߦ⒈.𑗝髯
+𐫀．\u0689𑌀; 𐫀.\u0689𑌀; ; xn--pw9c.xn--fjb8658k; ; ;  # 𐫀.ډ𑌀
+𐫀.\u0689𑌀; ; ; xn--pw9c.xn--fjb8658k; ; ;  # 𐫀.ډ𑌀
+xn--pw9c.xn--fjb8658k; 𐫀.\u0689𑌀; ; xn--pw9c.xn--fjb8658k; ; ;  # 𐫀.ډ𑌀
+𑋪．𐳝; 𑋪.𐳝; [B1, V6]; xn--fm1d.xn--5c0d; ; ;  # 𑋪.𐳝
+𑋪.𐳝; ; [B1, V6]; xn--fm1d.xn--5c0d; ; ;  # 𑋪.𐳝
+𑋪.𐲝; 𑋪.𐳝; [B1, V6]; xn--fm1d.xn--5c0d; ; ;  # 𑋪.𐳝
+xn--fm1d.xn--5c0d; 𑋪.𐳝; [B1, V6]; xn--fm1d.xn--5c0d; ; ;  # 𑋪.𐳝
+𑋪．𐲝; 𑋪.𐳝; [B1, V6]; xn--fm1d.xn--5c0d; ; ;  # 𑋪.𐳝
+≠膣。\u0F83; ≠膣.\u0F83; [V6]; xn--1chy468a.xn--2ed; ; ;  # ≠膣.ྃ
+=\u0338膣。\u0F83; ≠膣.\u0F83; [V6]; xn--1chy468a.xn--2ed; ; ;  # ≠膣.ྃ
+xn--1chy468a.xn--2ed; ≠膣.\u0F83; [V6]; xn--1chy468a.xn--2ed; ; ;  # ≠膣.ྃ
+񰀎-\u077D｡ß; 񰀎-\u077D.ß; [B5, B6, V7]; xn----j6c95618k.xn--zca; ; xn----j6c95618k.ss;  # -ݽ.ß
+񰀎-\u077D。ß; 񰀎-\u077D.ß; [B5, B6, V7]; xn----j6c95618k.xn--zca; ; xn----j6c95618k.ss;  # -ݽ.ß
+񰀎-\u077D。SS; 񰀎-\u077D.ss; [B5, B6, V7]; xn----j6c95618k.ss; ; ;  # -ݽ.ss
+񰀎-\u077D。ss; 񰀎-\u077D.ss; [B5, B6, V7]; xn----j6c95618k.ss; ; ;  # -ݽ.ss
+񰀎-\u077D。Ss; 񰀎-\u077D.ss; [B5, B6, V7]; xn----j6c95618k.ss; ; ;  # -ݽ.ss
+xn----j6c95618k.ss; 񰀎-\u077D.ss; [B5, B6, V7]; xn----j6c95618k.ss; ; ;  # -ݽ.ss
+xn----j6c95618k.xn--zca; 񰀎-\u077D.ß; [B5, B6, V7]; xn----j6c95618k.xn--zca; ; ;  # -ݽ.ß
+񰀎-\u077D｡SS; 񰀎-\u077D.ss; [B5, B6, V7]; xn----j6c95618k.ss; ; ;  # -ݽ.ss
+񰀎-\u077D｡ss; 񰀎-\u077D.ss; [B5, B6, V7]; xn----j6c95618k.ss; ; ;  # -ݽ.ss
+񰀎-\u077D｡Ss; 񰀎-\u077D.ss; [B5, B6, V7]; xn----j6c95618k.ss; ; ;  # -ݽ.ss
+ς𐹠ᡚ𑄳．⾭𐹽𽐖𐫜; ς𐹠ᡚ𑄳.靑𐹽𽐖𐫜; [B5, B6, V7]; xn--3xa856hp23pxmc.xn--es5a888tvjc2u15h; ; xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h;  # ς𐹠ᡚ𑄳.靑𐹽𐫜
+ς𐹠ᡚ𑄳.靑𐹽𽐖𐫜; ; [B5, B6, V7]; xn--3xa856hp23pxmc.xn--es5a888tvjc2u15h; ; xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h;  # ς𐹠ᡚ𑄳.靑𐹽𐫜
+Σ𐹠ᡚ𑄳.靑𐹽𽐖𐫜; σ𐹠ᡚ𑄳.靑𐹽𽐖𐫜; [B5, B6, V7]; xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h; ; ;  # σ𐹠ᡚ𑄳.靑𐹽𐫜
+σ𐹠ᡚ𑄳.靑𐹽𽐖𐫜; ; [B5, B6, V7]; xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h; ; ;  # σ𐹠ᡚ𑄳.靑𐹽𐫜
+xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h; σ𐹠ᡚ𑄳.靑𐹽𽐖𐫜; [B5, B6, V7]; xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h; ; ;  # σ𐹠ᡚ𑄳.靑𐹽𐫜
+xn--3xa856hp23pxmc.xn--es5a888tvjc2u15h; ς𐹠ᡚ𑄳.靑𐹽𽐖𐫜; [B5, B6, V7]; xn--3xa856hp23pxmc.xn--es5a888tvjc2u15h; ; ;  # ς𐹠ᡚ𑄳.靑𐹽𐫜
+Σ𐹠ᡚ𑄳．⾭𐹽𽐖𐫜; σ𐹠ᡚ𑄳.靑𐹽𽐖𐫜; [B5, B6, V7]; xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h; ; ;  # σ𐹠ᡚ𑄳.靑𐹽𐫜
+σ𐹠ᡚ𑄳．⾭𐹽𽐖𐫜; σ𐹠ᡚ𑄳.靑𐹽𽐖𐫜; [B5, B6, V7]; xn--4xa656hp23pxmc.xn--es5a888tvjc2u15h; ; ;  # σ𐹠ᡚ𑄳.靑𐹽𐫜
+𐋷。\u200D; 𐋷.\u200D; [C2]; xn--r97c.xn--1ug; ; xn--r97c.; [A4_2] # 𐋷.
+xn--r97c.; 𐋷.; ; xn--r97c.; [A4_2]; ;  # 𐋷.
+𐋷.; ; ; xn--r97c.; [A4_2]; ;  # 𐋷.
+xn--r97c.xn--1ug; 𐋷.\u200D; [C2]; xn--r97c.xn--1ug; ; ;  # 𐋷.
+𑰳𑈯。⥪; 𑰳𑈯.⥪; [V6]; xn--2g1d14o.xn--jti; ; ;  # 𑰳𑈯.⥪
+xn--2g1d14o.xn--jti; 𑰳𑈯.⥪; [V6]; xn--2g1d14o.xn--jti; ; ;  # 𑰳𑈯.⥪
+𑆀䁴񤧣．Ⴕ𝟜\u200C\u0348; 𑆀䁴񤧣.ⴕ4\u200C\u0348; [C1, V6, V7]; xn--1mnx647cg3x1b.xn--4-zfb502tlsl; ; xn--1mnx647cg3x1b.xn--4-zfb5123a; [V6, V7] # 𑆀䁴.ⴕ4͈
+𑆀䁴񤧣.Ⴕ4\u200C\u0348; 𑆀䁴񤧣.ⴕ4\u200C\u0348; [C1, V6, V7]; xn--1mnx647cg3x1b.xn--4-zfb502tlsl; ; xn--1mnx647cg3x1b.xn--4-zfb5123a; [V6, V7] # 𑆀䁴.ⴕ4͈
+𑆀䁴񤧣.ⴕ4\u200C\u0348; ; [C1, V6, V7]; xn--1mnx647cg3x1b.xn--4-zfb502tlsl; ; xn--1mnx647cg3x1b.xn--4-zfb5123a; [V6, V7] # 𑆀䁴.ⴕ4͈
+xn--1mnx647cg3x1b.xn--4-zfb5123a; 𑆀䁴񤧣.ⴕ4\u0348; [V6, V7]; xn--1mnx647cg3x1b.xn--4-zfb5123a; ; ;  # 𑆀䁴.ⴕ4͈
+xn--1mnx647cg3x1b.xn--4-zfb502tlsl; 𑆀䁴񤧣.ⴕ4\u200C\u0348; [C1, V6, V7]; xn--1mnx647cg3x1b.xn--4-zfb502tlsl; ; ;  # 𑆀䁴.ⴕ4͈
+𑆀䁴񤧣．ⴕ𝟜\u200C\u0348; 𑆀䁴񤧣.ⴕ4\u200C\u0348; [C1, V6, V7]; xn--1mnx647cg3x1b.xn--4-zfb502tlsl; ; xn--1mnx647cg3x1b.xn--4-zfb5123a; [V6, V7] # 𑆀䁴.ⴕ4͈
+xn--1mnx647cg3x1b.xn--4-zfb324h; 𑆀䁴񤧣.Ⴕ4\u0348; [V6, V7]; xn--1mnx647cg3x1b.xn--4-zfb324h; ; ;  # 𑆀䁴.Ⴕ4͈
+xn--1mnx647cg3x1b.xn--4-zfb324h32o; 𑆀䁴񤧣.Ⴕ4\u200C\u0348; [C1, V6, V7]; xn--1mnx647cg3x1b.xn--4-zfb324h32o; ; ;  # 𑆀䁴.Ⴕ4͈
+憡?\u200CႴ.𐋮\u200D≠; 憡?\u200Cⴔ.𐋮\u200D≠; [C1, C2, U1]; xn--?-sgn310doh5c.xn--1ug73gl146a; ; xn--?-fwsr13r.xn--1chz659f; [U1] # 憡?ⴔ.𐋮≠
+憡?\u200CႴ.𐋮\u200D=\u0338; 憡?\u200Cⴔ.𐋮\u200D≠; [C1, C2, U1]; xn--?-sgn310doh5c.xn--1ug73gl146a; ; xn--?-fwsr13r.xn--1chz659f; [U1] # 憡?ⴔ.𐋮≠
+憡?\u200Cⴔ.𐋮\u200D=\u0338; 憡?\u200Cⴔ.𐋮\u200D≠; [C1, C2, U1]; xn--?-sgn310doh5c.xn--1ug73gl146a; ; xn--?-fwsr13r.xn--1chz659f; [U1] # 憡?ⴔ.𐋮≠
+憡?\u200Cⴔ.𐋮\u200D≠; ; [C1, C2, U1]; xn--?-sgn310doh5c.xn--1ug73gl146a; ; xn--?-fwsr13r.xn--1chz659f; [U1] # 憡?ⴔ.𐋮≠
+xn--?-fwsr13r.xn--1chz659f; 憡?ⴔ.𐋮≠; [U1]; xn--?-fwsr13r.xn--1chz659f; ; ;  # 憡?ⴔ.𐋮≠
+xn--?-sgn310doh5c.xn--1ug73gl146a; 憡?\u200Cⴔ.𐋮\u200D≠; [C1, C2, U1]; xn--?-sgn310doh5c.xn--1ug73gl146a; ; ;  # 憡?ⴔ.𐋮≠
+xn--?-c1g3623d.xn--1chz659f; 憡?Ⴔ.𐋮≠; [V7, U1]; xn--?-c1g3623d.xn--1chz659f; ; ;  # 憡?Ⴔ.𐋮≠
+xn--?-c1g798iy27d.xn--1ug73gl146a; 憡?\u200CႴ.𐋮\u200D≠; [C1, C2, V7, U1]; xn--?-c1g798iy27d.xn--1ug73gl146a; ; ;  # 憡?Ⴔ.𐋮≠
+憡?ⴔ.xn--1chz659f; 憡?ⴔ.𐋮≠; [U1]; xn--?-fwsr13r.xn--1chz659f; ; ;  # 憡?ⴔ.𐋮≠
+憡?Ⴔ.XN--1CHZ659F; 憡?ⴔ.𐋮≠; [U1]; xn--?-fwsr13r.xn--1chz659f; ; ;  # 憡?ⴔ.𐋮≠
+憡?Ⴔ.xn--1chz659f; 憡?ⴔ.𐋮≠; [U1]; xn--?-fwsr13r.xn--1chz659f; ; ;  # 憡?ⴔ.𐋮≠
+憡?\u200Cⴔ.xn--1ug73gl146a; 憡?\u200Cⴔ.𐋮\u200D≠; [C1, C2, U1]; xn--?-sgn310doh5c.xn--1ug73gl146a; ; xn--?-fwsr13r.xn--1ug73gl146a; [C2, U1] # 憡?ⴔ.𐋮≠
+憡?\u200CႴ.XN--1UG73GL146A; 憡?\u200Cⴔ.𐋮\u200D≠; [C1, C2, U1]; xn--?-sgn310doh5c.xn--1ug73gl146a; ; xn--?-fwsr13r.xn--1ug73gl146a; [C2, U1] # 憡?ⴔ.𐋮≠
+憡?\u200CႴ.xn--1ug73gl146a; 憡?\u200Cⴔ.𐋮\u200D≠; [C1, C2, U1]; xn--?-sgn310doh5c.xn--1ug73gl146a; ; xn--?-fwsr13r.xn--1ug73gl146a; [C2, U1] # 憡?ⴔ.𐋮≠
+xn--?-fwsr13r.xn--1ug73gl146a; 憡?ⴔ.𐋮\u200D≠; [C2, U1]; xn--?-fwsr13r.xn--1ug73gl146a; ; ;  # 憡?ⴔ.𐋮≠
+xn--?-c1g3623d.xn--1ug73gl146a; 憡?Ⴔ.𐋮\u200D≠; [C2, V7, U1]; xn--?-c1g3623d.xn--1ug73gl146a; ; ;  # 憡?Ⴔ.𐋮≠
+憡?Ⴔ.xn--1ug73gl146a; 憡?ⴔ.𐋮\u200D≠; [C2, U1]; xn--?-fwsr13r.xn--1ug73gl146a; ; ;  # 憡?ⴔ.𐋮≠
+憡?ⴔ.xn--1ug73gl146a; 憡?ⴔ.𐋮\u200D≠; [C2, U1]; xn--?-fwsr13r.xn--1ug73gl146a; ; ;  # 憡?ⴔ.𐋮≠
+憡?Ⴔ.XN--1UG73GL146A; 憡?ⴔ.𐋮\u200D≠; [C2, U1]; xn--?-fwsr13r.xn--1ug73gl146a; ; ;  # 憡?ⴔ.𐋮≠

--- a/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/IdnMapping/Data/Unicode_17_0/ReadMe.txt
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/IdnMapping/Data/Unicode_17_0/ReadMe.txt
@@ -1,0 +1,14 @@
+# Unicode IDNA Mapping and Test Data
+# Date: 2025-08-15
+# © 2025 Unicode®, Inc.
+# Unicode and the Unicode Logo are registered trademarks of Unicode, Inc. in the U.S. and other countries.
+# For terms of use and license, see https://www.unicode.org/terms_of_use.html
+
+This directory contains final data files for version 17.0.0 of
+UTS #46, Unicode IDNA Compatibility Processing.
+
+It also contains the data file Idna2008.txt listing the 
+IDNA2008_Category Property for the same version.
+The listing matches the "IDNA Derived Property" as defined in RFC 5892.
+
+https://www.unicode.org/reports/tr46/

--- a/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/IdnMapping/Data/Unicode_17_0/Unicode_17_0_IdnaTest.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/IdnMapping/Data/Unicode_17_0/Unicode_17_0_IdnaTest.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Xunit;
+
+namespace System.Globalization.Tests
+{
+    /// <summary>
+    /// Class to read data obtained from http://www.unicode.org/Public/idna.  For more information read the information
+    /// contained in Data\Unicode_16_0\IdnaTest_16.txt
+    ///
+    /// The structure of the data set is a semicolon delimited list with the following columns:
+    ///
+    /// Column 1: source -          The source string to be tested
+    /// Column 2: toUnicode -       The result of applying toUnicode to the source,
+    ///                             with Transitional_Processing=false.
+    ///                             A blank value means the same as the source value.
+    /// Column 3: toUnicodeStatus - A set of status codes, each corresponding to a particular test.
+    ///                             A blank value means [] (no errors).
+    /// Column 4: toAsciiN -        The result of applying toASCII to the source,
+    ///                             with Transitional_Processing=false.
+    ///                             A blank value means the same as the toUnicode value.
+    /// Column 5: toAsciiNStatus -  A set of status codes, each corresponding to a particular test.
+    ///                             A blank value means the same as the toUnicodeStatus value.
+    ///                             An explicit [] means no errors.
+    /// Column 6: toAsciiT -        The result of applying toASCII to the source,
+    ///                             with Transitional_Processing=true.
+    ///                             A blank value means the same as the toAsciiN value.
+    /// Column 7: toAsciiTStatus -  A set of status codes, each corresponding to a particular test.
+    ///                             A blank value means the same as the toAsciiNStatus value.
+    ///                             An explicit [] means no errors.
+    ///
+    /// If the value of toUnicode or toAsciiN is the same as source, the column will be blank.
+    /// </summary>
+    public class Unicode_17_0_IdnaTest : Unicode_IdnaTest
+    {
+        public Unicode_17_0_IdnaTest(string line, int lineNumber)
+        {
+            var split = line.Split(';');
+
+            Type = PlatformDetection.IsNlsGlobalization ? IdnType.Transitional : IdnType.Nontransitional;
+
+            Source = EscapedToLiteralString(split[0], lineNumber);
+
+            UnicodeResult = new ConformanceIdnaUnicodeTestResult(EscapedToLiteralString(split[1], lineNumber), Source, EscapedToLiteralString(split[2], lineNumber), string.Empty, Source);
+            ASCIIResult = new ConformanceIdnaTestResult(EscapedToLiteralString(split[3], lineNumber), UnicodeResult.Value, EscapedToLiteralString(split[4], lineNumber), UnicodeResult.StatusValue, Source);
+
+            // NLS uses transitional IDN processing.
+            if (Type == IdnType.Transitional)
+            {
+                ASCIIResult = new ConformanceIdnaTestResult(EscapedToLiteralString(split[5], lineNumber), ASCIIResult.Value, EscapedToLiteralString(split[6], lineNumber), ASCIIResult.StatusValue);
+            }
+
+            LineNumber = lineNumber;
+        }
+    }
+}

--- a/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/NlsTests/System.Globalization.Extensions.Nls.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/NlsTests/System.Globalization.Extensions.Nls.Tests.csproj
@@ -23,6 +23,8 @@
              Link="IdnMapping\Data\Unicode_15_1\Unicode_15_1_IdnaTest.cs" />
     <Compile Include="..\IdnMapping\Data\Unicode_16_0\Unicode_16_0_IdnaTest.cs"
              Link="IdnMapping\Data\Unicode_16_0\Unicode_16_0_IdnaTest.cs" />
+    <Compile Include="..\IdnMapping\Data\Unicode_17_0\Unicode_17_0_IdnaTest.cs"
+             Link="IdnMapping\Data\Unicode_17_0\Unicode_17_0_IdnaTest.cs" />
     <Compile Include="..\IdnMapping\IdnMappingIdnaConformanceTests.cs"
              Link="IdnMapping\IdnMappingIdnaConformanceTests.cs" />
     <Compile Include="..\IdnMapping\Data\Factory.cs"
@@ -57,6 +59,7 @@
     <EmbeddedResource Include="..\IdnMapping\Data\Unicode_15_0\IdnaTest_15_0.txt" />
     <EmbeddedResource Include="..\IdnMapping\Data\Unicode_15_1\IdnaTest_15_1.txt" />
     <EmbeddedResource Include="..\IdnMapping\Data\Unicode_16_0\IdnaTest_16.txt" />
+    <EmbeddedResource Include="..\IdnMapping\Data\Unicode_17_0\IdnaTest_17.txt" />
     <EmbeddedResource Include="..\Normalization\Data\win8.txt">
       <LogicalName>NormalizationDataWin8</LogicalName>
     </EmbeddedResource>

--- a/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/System.Globalization.Extensions.Tests.csproj
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Extensions.Tests/System.Globalization.Extensions.Tests.csproj
@@ -13,6 +13,7 @@
     <Compile Include="IdnMapping\Data\Unicode_15_0\Unicode_15_0_IdnaTest.cs" />
     <Compile Include="IdnMapping\Data\Unicode_15_1\Unicode_15_1_IdnaTest.cs" />
     <Compile Include="IdnMapping\Data\Unicode_16_0\Unicode_16_0_IdnaTest.cs" />
+    <Compile Include="IdnMapping\Data\Unicode_17_0\Unicode_17_0_IdnaTest.cs" />
     <Compile Include="IdnMapping\IdnMappingIdnaConformanceTests.cs" />
     <Compile Include="IdnMapping\Data\Factory.cs" />
     <Compile Include="IdnMapping\Data\ConformanceIdnaTestResult.cs" />
@@ -34,6 +35,7 @@
     <EmbeddedResource Include="IdnMapping\Data\Unicode_15_0\IdnaTest_15_0.txt" />
     <EmbeddedResource Include="IdnMapping\Data\Unicode_15_1\IdnaTest_15_1.txt" />
     <EmbeddedResource Include="IdnMapping\Data\Unicode_16_0\IdnaTest_16.txt" />
+    <EmbeddedResource Include="IdnMapping\Data\Unicode_17_0\IdnaTest_17.txt" />
     <EmbeddedResource Include="Normalization\Data\win8.txt">
       <LogicalName>NormalizationDataWin8</LogicalName>
     </EmbeddedResource>


### PR DESCRIPTION
ICU has released version 78, which includes changes to IDN handling that caused some of our tests to fail when using the updated library.

This release also introduces a breaking change: the start date of the Japanese Meiji era has been updated from `1868-09-08` to `1868-10-23`. Additional details are available in the relevant [CLDR issue](https://unicode-org.atlassian.net/browse/CLDR-11375) and [CLDR pull request](https://github.com/unicode-org/cldr/pull/4610). The updated date is also confirmed in the historical reference on the [Meiji era](https://wikipedia.org/wiki/Meiji_era).
