### PR TITLE
[Wasm RyuJit] Fixes for some issues in codegen bringup tests

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -155,12 +155,6 @@ void CodeGen::genEmitStartBlock(BasicBlock* block)
     {
         instGen(INS_end);
         WasmInterval* interval = wasmControlFlowStack->Pop();
-
-        if (!interval->IsLoop() && !block->HasFlag(BBF_HAS_LABEL))
-        {
-            block->SetFlags(BBF_HAS_LABEL);
-            genDefineTempLabel(block);
-        }
     }
 
     // Push control flow for intervals that start here or earlier, and emit
@@ -185,10 +179,23 @@ void CodeGen::genEmitStartBlock(BasicBlock* block)
             wasmCursor++;
             wasmControlFlowStack->Push(interval);
 
-            if (interval->IsLoop() && !block->HasFlag(BBF_HAS_LABEL))
+            if (interval->IsLoop())
             {
-                block->SetFlags(BBF_HAS_LABEL);
-                genDefineTempLabel(block);
+                if (!block->HasFlag(BBF_HAS_LABEL))
+                {
+                    block->SetFlags(BBF_HAS_LABEL);
+                    genDefineTempLabel(block);
+                }
+            }
+            else
+            {
+                BasicBlock* const endBlock = compiler->fgIndexToBlockMap[interval->End()];
+
+                if (!endBlock->HasFlag(BBF_HAS_LABEL))
+                {
+                    endBlock->SetFlags(BBF_HAS_LABEL);
+                    genDefineTempLabel(endBlock);
+                }
             }
 
             if (wasmCursor >= compiler->fgWasmIntervals->size())

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5242,6 +5242,7 @@ public:
 
 #ifdef TARGET_WASM
     jitstd::vector<WasmInterval*>* fgWasmIntervals = nullptr;
+    BasicBlock** fgIndexToBlockMap = nullptr;
 #endif
 
     FlowGraphDfsTree* m_dfsTree = nullptr;

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -1407,6 +1407,10 @@ PhaseStatus Compiler::fgWasmControlFlow()
         }
     }
 
+    // Publish the index to block map for use during codegen.
+    //
+    fgIndexToBlockMap = initialLayout;
+
     JITDUMPEXEC(fgDumpWasmControlFlow());
     JITDUMPEXEC(fgDumpWasmControlFlowDot());
 

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -2492,10 +2492,13 @@ PhaseStatus Compiler::fgAddInternal()
 
     CORINFO_JUST_MY_CODE_HANDLE* pDbgHandle = nullptr;
     CORINFO_JUST_MY_CODE_HANDLE  dbgHandle  = nullptr;
+
+#if !defined(TARGET_WASM)
     if (opts.compDbgCode && !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IL_STUB))
     {
         dbgHandle = info.compCompHnd->getJustMyCodeHandle(info.compMethodHnd, &pDbgHandle);
     }
+#endif
 
     noway_assert(!dbgHandle || !pDbgHandle);
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -4526,12 +4526,12 @@ GenTree* Lowering::OptimizeConstCompare(GenTree* cmp)
 //
 GenTree* Lowering::LowerCompare(GenTree* cmp)
 {
-#ifndef TARGET_64BIT
+#if LOWER_DECOMPOSE_LONGS
     if (cmp->gtGetOp1()->TypeIs(TYP_LONG))
     {
         return DecomposeLongCompare(cmp);
     }
-#endif
+#endif // LOWER_DECOMPOSE_LONGS
 
     if (cmp->gtGetOp2()->IsIntegralConst() && !comp->opts.MinOpts())
     {

--- a/src/coreclr/jit/scopeinfo.cpp
+++ b/src/coreclr/jit/scopeinfo.cpp
@@ -1541,6 +1541,15 @@ void CodeGen::siBeginBlock(BasicBlock* block)
 //
 void CodeGen::siOpenScopesForNonTrackedVars(const BasicBlock* block, unsigned int lastBlockILEndOffset)
 {
+#if defined(TARGET_WASM)
+    // TODO-WASM: Wasm structured control flow
+    // requirements are incompatible with debug codegen's
+    // desire to keep blocks in increasing IL offset
+    // order. Figure out the proper scope manipulations.
+    //
+    return;
+#endif // defined(TARGET_WASM)
+
     unsigned int beginOffs = block->bbCodeOffs;
 
     // There aren't any tracked locals.


### PR DESCRIPTION
The strategy for marking blocks that need labels was wrong. We need to mark block ends when we encounter block starts. To do this efficiently we need to map from interval end index to block, so expose the map we built during interval building for use in codegen.

We likely don't need Just My Code debug support for Wasm, so ignore any request from the runtime to insert the checks.

Wasm structured control flow doesn't allow us to keep blocks in increasing IL offset order (in general). So disable some of the scope tracking mechanisms that expect to see this.

Fix another instance where we assumed a 32 bit target would decompose longs.