### PR TITLE
Remove optimization from valuetask-source-stub project

### DIFF
--- a/src/tests/async/valuetask-source/valuetask-source-stub.csproj
+++ b/src/tests/async/valuetask-source/valuetask-source-stub.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.IL">
-  <PropertyGroup>
-    <Optimize>True</Optimize>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>


### PR DESCRIPTION
This was added around the same time as I was making a pass to remove Optimize=true.

Cc @vsadov @jakobbotsch 