### PR TITLE
JIT: Zero continuation return after profiler leave callback

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -7095,6 +7095,8 @@ void CodeGen::genReturn(GenTree* treeNode)
     if (treeNode->OperIs(GT_RETURN) && compiler->compIsAsync())
     {
         instGen_Set_Reg_To_Zero(EA_PTRSIZE, REG_ASYNC_CONTINUATION_RET);
+
+        gcInfo.gcMarkRegPtrVal(REG_ASYNC_CONTINUATION_RET, TYP_REF);
     }
 
 #if defined(DEBUG) && defined(TARGET_XARCH)
@@ -7173,6 +7175,11 @@ void CodeGen::genReturnSuspend(GenTreeUnOp* treeNode)
     }
 
     genMarkReturnGCInfo();
+
+    if (compiler->compIsAsync())
+    {
+        gcInfo.gcMarkRegPtrVal(REG_ASYNC_CONTINUATION_RET, TYP_REF);
+    }
 }
 
 //------------------------------------------------------------------------
@@ -7195,11 +7202,6 @@ void CodeGen::genMarkReturnGCInfo()
             gcInfo.gcMarkRegPtrVal(retTypeDesc.GetABIReturnReg(i, compiler->info.compCallConv),
                                    retTypeDesc.GetReturnRegType(i));
         }
-    }
-
-    if (compiler->compIsAsync())
-    {
-        gcInfo.gcMarkRegPtrVal(REG_ASYNC_CONTINUATION_RET, TYP_REF);
     }
 }
 

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -7069,11 +7069,6 @@ void CodeGen::genReturn(GenTree* treeNode)
         }
     }
 
-    if (treeNode->OperIs(GT_RETURN) && compiler->compIsAsync())
-    {
-        instGen_Set_Reg_To_Zero(EA_PTRSIZE, REG_ASYNC_CONTINUATION_RET);
-    }
-
 #if EMIT_GENERATE_GCINFO
     if (treeNode->OperIs(GT_RETURN, GT_SWIFT_ERROR_RET))
     {
@@ -7096,6 +7091,11 @@ void CodeGen::genReturn(GenTree* treeNode)
         genProfilingLeaveCallback(CORINFO_HELP_PROF_FCN_LEAVE);
     }
 #endif // PROFILING_SUPPORTED
+
+    if (treeNode->OperIs(GT_RETURN) && compiler->compIsAsync())
+    {
+        instGen_Set_Reg_To_Zero(EA_PTRSIZE, REG_ASYNC_CONTINUATION_RET);
+    }
 
 #if defined(DEBUG) && defined(TARGET_XARCH)
     bool doStackPointerCheck = compiler->opts.compStackCheckOnRet;

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -7095,7 +7095,6 @@ void CodeGen::genReturn(GenTree* treeNode)
     if (treeNode->OperIs(GT_RETURN) && compiler->compIsAsync())
     {
         instGen_Set_Reg_To_Zero(EA_PTRSIZE, REG_ASYNC_CONTINUATION_RET);
-
         gcInfo.gcMarkRegPtrVal(REG_ASYNC_CONTINUATION_RET, TYP_REF);
     }
 
@@ -7162,6 +7161,7 @@ void CodeGen::genReturnSuspend(GenTreeUnOp* treeNode)
 
     regNumber reg = genConsumeReg(op);
     inst_Mov(TYP_REF, REG_ASYNC_CONTINUATION_RET, reg, /* canSkip */ true);
+    gcInfo.gcMarkRegPtrVal(REG_ASYNC_CONTINUATION_RET, TYP_REF);
 
     ReturnTypeDesc retTypeDesc = compiler->compRetTypeDesc;
     unsigned       numRetRegs  = retTypeDesc.GetReturnRegCount();
@@ -7175,11 +7175,6 @@ void CodeGen::genReturnSuspend(GenTreeUnOp* treeNode)
     }
 
     genMarkReturnGCInfo();
-
-    if (compiler->compIsAsync())
-    {
-        gcInfo.gcMarkRegPtrVal(REG_ASYNC_CONTINUATION_RET, TYP_REF);
-    }
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
#122195 introduced a runtime async test that is the first one to run in combination with other stress configurations. It revealed that when leave callbacks are emitted we do not appropriately zero the async continuation on standard returns.

Fix #122475