### PR TITLE
Don't runtime-await Delegate.Invoke methods

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1854,7 +1854,7 @@ namespace Internal.JitInterface
                     bool allowAsyncVariant = method.GetTypicalMethodDefinition().Signature.ReturnsTaskOrValueTask();
 
                     // Don't get async variant of Delegate.Invoke method; the pointed to method is not an async variant either.
-                    allowAsyncVariant &= !method.OwningType.IsDelegate;
+                    allowAsyncVariant = allowAsyncVariant && !method.OwningType.IsDelegate;
 
                     method = allowAsyncVariant
                         ? _compilation.TypeSystemContext.GetAsyncVariantMethod(method)

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1851,7 +1851,12 @@ namespace Internal.JitInterface
                     // in rare cases a method that returns Task is not actually TaskReturning (i.e. returns T).
                     // we cannot resolve to an Async variant in such case.
                     // return NULL, so that caller would re-resolve as a regular method call
-                    method = method.GetTypicalMethodDefinition().Signature.ReturnsTaskOrValueTask()
+                    bool allowAsyncVariant = method.GetTypicalMethodDefinition().Signature.ReturnsTaskOrValueTask();
+
+                    // Don't get async variant of Delegate.Invoke method; the pointed to method is not an async variant either.
+                    allowAsyncVariant &= !method.OwningType.IsDelegate;
+
+                    method = allowAsyncVariant
                         ? _compilation.TypeSystemContext.GetAsyncVariantMethod(method)
                         : null;
                 }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -477,6 +477,7 @@ namespace Internal.IL
                 // If this is the task await pattern, we're actually going to call the variant
                 // so switch our focus to the variant.
                 if (method.GetTypicalMethodDefinition().Signature.ReturnsTaskOrValueTask()
+                    && !method.OwningType.IsDelegate
                     && MatchTaskAwaitPattern())
                 {
                     runtimeDeterminedMethod = _factory.TypeSystemContext.GetAsyncVariantMethod(runtimeDeterminedMethod);

--- a/src/tests/async/delegates/delegates.cs
+++ b/src/tests/async/delegates/delegates.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2Delegates
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        var p = new Async2Delegates();
+        Assert.Equal(30, RunAsync(p.AddCompilerAsync).Result);
+        Assert.Equal(30, RunAsync(p.AddRuntimeAsync).Result);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static async Task<int> RunAsync(AddTwo del)
+    {
+        return await del(10, 20);
+    }
+
+    delegate Task<int> AddTwo(int x, int y);
+
+    [RuntimeAsyncMethodGeneration(false)]
+    async Task<int> AddCompilerAsync(int x, int y) => x + y;
+    [RuntimeAsyncMethodGeneration(true)]
+    async Task<int> AddRuntimeAsync(int x, int y) => x + y;
+}

--- a/src/tests/async/delegates/delegates.csproj
+++ b/src/tests/async/delegates/delegates.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This is doubly inefficient because:

* The method pointed to by the delegate is guaranteed not runtime-async (so we'd go through up to two thunks), and
* the variant of `Invoke` method is no longer _the_ `Delegate.Invoke` method that can be reported as `CORINFO_FLG_DELEGATE_INVOKE` to RyuJIT (needs to be invoked as a regular method instead of the efficient delegate invoke sequence).

CoreCLR does this in methodtablebuilder.cs where we consider all methods on delegates as `MethodReturnKind::NormalMethod`.

Also adding a test because it looks like we don't have one.

Cc @dotnet/ilc-contrib 