### PR TITLE
Fix scenarios involving GVM on reflection-blocked methods

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/NativeLayoutVertexNode.cs
@@ -1382,6 +1382,11 @@ namespace ILCompiler.DependencyAnalysis
 
             factory.MetadataManager.GetDependenciesDueToLdToken(ref result, factory, _method.GetCanonMethodTarget(CanonicalFormKind.Specific));
 
+            if (_method.IsVirtual && _method.HasInstantiation && !_method.IsGenericMethodDefinition && !_method.OwningType.IsGenericDefinition)
+            {
+                result.Add(factory.GVMDependencies(_method.GetCanonMethodTarget(CanonicalFormKind.Specific)), "Potential dynamic GVM call");
+            }
+
             result.Add(factory.NativeLayout.MethodEntry(_method), "wrappednode");
 
             return result;

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Generics.cs
@@ -5,6 +5,7 @@ using System;
 using System.Reflection;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using System.Diagnostics.CodeAnalysis;
 
 [UnconditionalSuppressMessage("Trimming", "IL2055", Justification = "MakeGenericType - Intentional")]
@@ -30,6 +31,7 @@ class Generics
         TestInstantiatingUnboxingStubs.Run();
         TestNameManglingCollisionRegression.Run();
         TestSimpleGVMScenarios.Run();
+        TestAsyncGVMScenarios.Run();
         TestGvmDelegates.Run();
         TestGvmDependencies.Run();
         TestGvmLookups.Run();
@@ -1537,6 +1539,23 @@ class Generics
             if (s_NumErrors != 0)
                 throw new Exception();
         }
+    }
+
+    class TestAsyncGVMScenarios
+    {
+        public static void Run()
+        {
+            RunAsync().Wait();
+        }
+
+        static async Task RunAsync()
+        {
+            await new TestAsyncGVMScenarios().AsyncGvm1<object>();
+        }
+
+        public virtual async Task AsyncGvm1<T>() => await AsyncGvm2<T>();
+
+        public virtual async Task AsyncGvm2<T>() => await Task.CompletedTask;
     }
 
     class TestGvmDelegates

--- a/src/tests/nativeaot/SmokeTests/UnitTests/UnitTests.csproj
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/UnitTests.csproj
@@ -15,7 +15,8 @@
   </PropertyGroup>
 
   <!-- Enable runtime async; delete this block once it's on by default -->
-  <PropertyGroup>
+  <!-- Conditioned to x64 only due to https://github.com/dotnet/runtime/issues/121871 -->
+  <PropertyGroup Condition="'$(TargetArchitecture)' == 'x64'">
     <Features>$(Features);runtime-async=on</Features>
   </PropertyGroup>
 

--- a/src/tests/nativeaot/SmokeTests/UnitTests/UnitTests.csproj
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/UnitTests.csproj
@@ -13,6 +13,12 @@
 
     <IlcOrderFile>order.txt</IlcOrderFile>
   </PropertyGroup>
+
+  <!-- Enable runtime async; delete this block once it's on by default -->
+  <PropertyGroup>
+    <Features>$(Features);runtime-async=on</Features>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Include="BasicThreading.cs" />
     <Compile Include="Delegates.cs" />


### PR DESCRIPTION
GVM dispatch didn't work when calling an async GVM from a dynamic context (e.g. we are in a GVM and trying to call another GVM).

"A generic virtual method was called" is synonymous with "we need a `RuntimeMethodHandle` of a GVM" in the compiler since the GVM dispatch sequence uses the `RuntimeMethodHandle` to identify the GVM slot.

Whenever we generate a `RuntimeMethodHandle` (either the static one, or the one in native layout used when runtime type loading) we need to consider it a GVM call. We were correctly considering it in the static case (https://github.com/dotnet/runtime/blob/bed0cadfbf6a7067e24e302549829a45475cd224/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/RuntimeMethodHandleNode.cs#L57), however we missed the dynamic case (native layout information for `RuntimeMethodHandle` I'm updating here).

We were getting away with this because the line above the one I'm updating (`factory.MetadataManager.GetDependenciesDueToLdToken`) would drop a `ReflectedMethodNode` into the graph that also means "GVM method is called". However we will not get a `ReflectedMethodNode` for something that is reflection-blocked, such as async variants. So we need to explicitly spell out the dependency so that this works for runtime async.

Cc @dotnet/ilc-contrib 