### PR TITLE
[release/8.0-staging] Use explicit versions for MSBuild properties

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -182,10 +182,11 @@
     <NetStandardLibraryVersion>2.0.3</NetStandardLibraryVersion>
     <MicrosoftDiagnosticsToolsRuntimeClientVersion>1.0.4-preview6.19326.1</MicrosoftDiagnosticsToolsRuntimeClientVersion>
     <DNNEVersion>2.0.5</DNNEVersion>
+    <!-- Intentionally using explicit versions for all MSBuild properties - required by source-build. -->
     <MicrosoftBuildVersion>17.8.3</MicrosoftBuildVersion>
-    <MicrosoftBuildTasksCoreVersion>$(MicrosoftBuildVersion)</MicrosoftBuildTasksCoreVersion>
-    <MicrosoftBuildFrameworkVersion>$(MicrosoftBuildVersion)</MicrosoftBuildFrameworkVersion>
-    <MicrosoftBuildUtilitiesCoreVersion>$(MicrosoftBuildVersion)</MicrosoftBuildUtilitiesCoreVersion>
+    <MicrosoftBuildTasksCoreVersion>17.8.3</MicrosoftBuildTasksCoreVersion>
+    <MicrosoftBuildFrameworkVersion>17.8.3</MicrosoftBuildFrameworkVersion>
+    <MicrosoftBuildUtilitiesCoreVersion>17.8.3</MicrosoftBuildUtilitiesCoreVersion>
     <NugetFrameworksVersion>6.2.4</NugetFrameworksVersion>
     <NugetProjectModelVersion>6.2.4</NugetProjectModelVersion>
     <NugetPackagingVersion>6.2.4</NugetPackagingVersion>


### PR DESCRIPTION
This PR reapplies the change in `Versions.props` from https://github.com/dotnet/runtime/pull/121307

Somehow, that change was lost in the past month.

I am also adding a comment to ensure someone doesn't revert the intentional change to use explicit versions for all 4 MSBuild properties and use a reference to the "main" property.

## Notes

This is an infra change as this change produces no differences in the runtime build.

There are also no differences in source-build as we currently have a patch that sets these properties to explicit versions: https://github.com/dotnet/installer/blob/release/8.0.1xx/src/SourceBuild/patches/runtime/0002-Update-MSBuild-dependencies.patch

With this fix, we will be able to remove the source-build patch.