### PR TITLE
Add AddRef to callee that caches interface ptr

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/NativeMarshallingAttributeTests.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/LibraryImportGenerator.Tests/NativeMarshallingAttributeTests.cs
@@ -17,7 +17,6 @@ namespace LibraryImportGenerator.IntegrationTests
     public class NativeMarshallingAttributeTests
     {
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsCoreCLR))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/122447")]
         public void GetSameComInterfaceTwiceReturnsUniqueInstances()
         {
             // When using NativeMarshalling with UniqueComInterfaceMarshaller,

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaceGenerator/UniqueMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaceGenerator/UniqueMarshalling.cs
@@ -23,6 +23,8 @@ namespace NativeExports.ComInterfaceGenerator
                 s_cachedPtr = (void*)ptr;
             }
 
+            // AddRef before returning - caller will Release
+            Marshal.AddRef((nint)s_cachedPtr);
             return s_cachedPtr;
         }
     }

--- a/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaceGenerator/UniqueMarshalling.cs
+++ b/src/libraries/System.Runtime.InteropServices/tests/TestAssets/NativeExports/ComInterfaceGenerator/UniqueMarshalling.cs
@@ -10,6 +10,8 @@ namespace NativeExports.ComInterfaceGenerator
     public static unsafe class UniqueMarshalling
     {
         private static void* s_cachedPtr = null;
+        // To handle the final release of the cached pointer
+        private static ComObject s_cachedObject = null;
 
         // Call from another assembly to get a ptr to make an RCW
         [UnmanagedCallersOnly(EntryPoint = "new_unique_marshalling")]
@@ -20,6 +22,7 @@ namespace NativeExports.ComInterfaceGenerator
                 StrategyBasedComWrappers wrappers = new();
                 var myObject = new SharedTypes.ComInterfaces.UniqueMarshalling();
                 nint ptr = wrappers.GetOrCreateComInterfaceForObject(myObject, CreateComInterfaceFlags.None);
+                s_cachedObject = (ComObject)wrappers.GetOrCreateObjectForComInstance(ptr, CreateObjectFlags.None);
                 s_cachedPtr = (void*)ptr;
             }
 


### PR DESCRIPTION
Callee was missing an AddRef when returning the cached interface pointer. Tests no longer fail on Linux with this change locally.

Fixes https://github.com/dotnet/runtime/issues/122447