### PR TITLE
[Wasm RyuJit] unordered floating point compares

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -915,8 +915,6 @@ void CodeGen::genCompareFloat(GenTreeOp* treeNode)
             op          = GenTree::ReverseRelop(op);
             invertSense = true;
         }
-
-        treeNode->gtFlags &= ~GTF_RELOP_NAN_UN;
     }
     else
     {

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -895,28 +895,41 @@ void CodeGen::genCompareFloat(GenTreeOp* treeNode)
 {
     assert(treeNode->OperIsCmpCompare());
 
-    bool invertSense = false;
+    genTreeOps op          = treeNode->OperGet();
+    bool       invertSense = false;
 
     if ((treeNode->gtFlags & GTF_RELOP_NAN_UN) != 0)
     {
+        // We don't expect to see GT_EQ unordered,
+        // since CIL doesn't have this mode.
+        //
+        assert(op != GT_EQ);
+
         // Wasm float comparisons other than "fne" return false for NaNs.
         // Our unordered float compares need to return true for NaNs.
         //
         // So we can re-express say GT_GE (UN) as !GT_LT
         //
-        if (!treeNode->OperIs(GT_NE))
+        if (op != GT_NE)
         {
-            treeNode->ChangeOper(GenTree::ReverseRelop(treeNode->OperGet()));
+            op          = GenTree::ReverseRelop(op);
             invertSense = true;
         }
 
         treeNode->gtFlags &= ~GTF_RELOP_NAN_UN;
     }
+    else
+    {
+        // We don't expect to see GT_NE ordered,
+        // since CIL doesn't have this mode.
+        //
+        assert(op != GT_NE);
+    }
 
     genConsumeOperands(treeNode);
 
     instruction ins;
-    switch (PackOperAndType(treeNode->OperGet(), treeNode->gtOp1->TypeGet()))
+    switch (PackOperAndType(op, treeNode->gtOp1->TypeGet()))
     {
         case PackOperAndType(GT_EQ, TYP_FLOAT):
             ins = INS_f32_eq;


### PR DESCRIPTION
Wasm floating point comparisons (except `fne`) return false if any operand is a NaN. Handle unordered compares by reversing the comparison and branching if the result is false.