### PR TITLE
Ensure consistency between ThreadState.Stopped APIs that check if a thread is dead

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -63,7 +63,10 @@ namespace System.Threading
         // but those types of changes may race with the reset anyway, so this field doesn't need to be synchronized.
         private bool _mayNeedResetForThreadPool;
 
-        // Set in unmanaged and read in managed code.
+        // This is set in two places:
+        // For threads started with Thread.Start: Set in managed code as the thread is exiting.
+        // For external threads that attach to the runtime: Set in unmanaged code as part of thread detach.
+        // This is only read in managed code.
         private bool _isDead;
         private bool _isThreadPool;
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -567,8 +567,8 @@ namespace System.Threading
         {
             // Consider this managed thread as dead.
             // The unmanaged thread is still alive, but will die soon, after cleaning up some state.
-            // We do this before OnThreadExiting and SetJoinHandle so that any threads
-            // waiting on this thread to end will correctly see that it is stopped
+            // We set _isDead = true before calling _waitInfo?.OnThreadExiting() and SetJoinHandle()
+            // so that any threads waiting on this thread to end will correctly see that it is stopped
             // when we set the join handle.
             _isDead = true;
 #if TARGET_UNIX || TARGET_BROWSER || TARGET_WASI

--- a/src/coreclr/vm/comsynchronizable.cpp
+++ b/src/coreclr/vm/comsynchronizable.cpp
@@ -394,14 +394,8 @@ extern "C" INT32 QCALLTYPE ThreadNative_GetThreadState(QCall::ThreadHandle threa
     // grab a snapshot
     Thread::ThreadState state = thread->GetSnapshotState();
 
-    // If the thread is dead, just report that its dead.
-    // It's possible that the thread may still be in the final bits of shutting down,
-    // but for the purposes of the managed API surface, it should be reported
-    // as stopped.
     if (state & Thread::TS_Dead)
-    {
-        return ThreadNative::ThreadStopped;
-    }
+        res |= ThreadNative::ThreadStopped;
 
     if (state & Thread::TS_Background)
         res |= ThreadNative::ThreadBackground;
@@ -444,18 +438,6 @@ extern "C" void QCALLTYPE ThreadNative_ClearWaitSleepJoinState(QCall::ThreadHand
     // Clear the state bits.
     thread->ResetThreadState(Thread::TS_Interruptible);
     thread->ResetThreadStateNC(Thread::TSNC_DebuggerSleepWaitJoin);
-}
-
-extern "C" void QCALLTYPE ThreadNative_ReportDead(QCall::ThreadHandle thread)
-{
-    CONTRACTL
-    {
-        QCALL_CHECK_NO_GC_TRANSITION;
-        PRECONDITION(thread != NULL);
-    }
-    CONTRACTL_END;
-
-    thread->SetThreadState(Thread::TS_ReportDead);
 }
 
 #ifdef FEATURE_COMINTEROP_APARTMENT_SUPPORT

--- a/src/coreclr/vm/comsynchronizable.h
+++ b/src/coreclr/vm/comsynchronizable.h
@@ -58,7 +58,6 @@ extern "C" void QCALLTYPE ThreadNative_Initialize(QCall::ObjectHandleOnStack t);
 extern "C" INT32 QCALLTYPE ThreadNative_GetThreadState(QCall::ThreadHandle thread);
 extern "C" void QCALLTYPE ThreadNative_SetWaitSleepJoinState(QCall::ThreadHandle thread);
 extern "C" void QCALLTYPE ThreadNative_ClearWaitSleepJoinState(QCall::ThreadHandle thread);
-extern "C" void QCALLTYPE ThreadNative_ReportDead(QCall::ThreadHandle thread);
 extern "C" INT32 QCALLTYPE ThreadNative_ReentrantWaitAny(BOOL alertable, INT32 timeout, INT32 count, HANDLE *handles);
 #ifdef TARGET_WINDOWS
 extern "C" void QCALLTYPE ThreadNative_Interrupt(QCall::ThreadHandle thread);

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -296,7 +296,6 @@ static const Entry s_QCall[] =
     DllImportEntry(ThreadNative_GetThreadState)
     DllImportEntry(ThreadNative_SetWaitSleepJoinState)
     DllImportEntry(ThreadNative_ClearWaitSleepJoinState)
-    DllImportEntry(ThreadNative_ReportDead)
     DllImportEntry(ThreadNative_ReentrantWaitAny)
 #ifdef FEATURE_COMINTEROP_APARTMENT_SUPPORT
     DllImportEntry(ThreadNative_GetApartmentState)


### PR DESCRIPTION
When a managed thread dies, set _isDead, and make _isDead short-circuit thread state fetching instead of setting the ReportDead state before we do unmanaged thread cleanup.

Fixes #122520 