### PR TITLE
[wasm][coreclr] Fix DoPrestub for delegates

### DIFF
--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2372,7 +2372,7 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT, CallerGCMode callerGCMo
         {
             return pCode;
         }
-#endif // !FEATURE_PORTABLE_ENTRYPOINTS
+#endif // FEATURE_PORTABLE_ENTRYPOINTS
 
         SetCodeEntryPoint(pCode);
     }

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2367,6 +2367,13 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT, CallerGCMode callerGCMo
     {
         _ASSERTE(!MayHaveEntryPointSlotsToBackpatch()); // This path doesn't lock the MethodDescBackpatchTracker as it should only
                                                         // happen for jump-stampable or non-versionable methods
+#ifdef FEATURE_PORTABLE_ENTRYPOINTS
+        if (pMT->IsDelegate())
+        {
+            return pCode;
+        }
+#endif // !FEATURE_PORTABLE_ENTRYPOINTS
+
         SetCodeEntryPoint(pCode);
     }
     else


### PR DESCRIPTION
Return early for delegates to avoid setting the slot in `SetCodeEntryPoint` and to skip backpatch. The delegates are special case, where we have single implementation for all of them, and we don't want to break other parts, which depend on 1:1 mapping between implementation and method desc.

This fixes https://github.com/dotnet/runtime/issues/121955, which was still happening a lot in the runtime tests (cca 90 occurences in the out of process tests on wasm)

We were getting the exception, because during the access checks we got private DelegateConstruct method from the MT slot.