### PR TITLE
[browser] Run Wasm.Build.Tests with in-tree artifacts

### DIFF
--- a/src/mono/browser/build/WasmApp.InTree.props
+++ b/src/mono/browser/build/WasmApp.InTree.props
@@ -1,8 +1,6 @@
 <Project>
   <!-- This depends on the root Directory.Build.props imported this file -->
   <PropertyGroup>
-    <UsingMicrosoftNETSdkWebAssembly>true</UsingMicrosoftNETSdkWebAssembly>
-
     <WasmCommonTargetsPath Condition="Exists('$(MSBuildThisFileDirectory)WasmApp.Common.props')">$(MSBuildThisFileDirectory)</WasmCommonTargetsPath>
     <WasmCommonTargetsPath Condition="'$(WasmCommonTargetsPath)' == ''">$([MSBuild]::NormalizeDirectory($(MonoProjectRoot), 'wasm', 'build'))</WasmCommonTargetsPath>
 
@@ -11,7 +9,7 @@
     <_WebAssemblySdkToolsDirectory Condition="'$(_WebAssemblySdkToolsDirectory)' == ''">$(ArtifactsBinDir)\Microsoft.NET.Sdk.WebAssembly.Pack.Tasks\$(RuntimeConfiguration)\</_WebAssemblySdkToolsDirectory>
   </PropertyGroup>
 
-  <Import Sdk="Microsoft.NET.Sdk.WebAssembly" Project="Sdk.props" Condition="'$(UsingNativeAOT)' != 'true' and '$(UsingMicrosoftNETSdkWebAssembly)' == 'true'" />
+  <Import Sdk="Microsoft.NET.Sdk.WebAssembly" Project="Sdk.props" Condition="'$(UsingNativeAOT)' != 'true' and '$(UsingMicrosoftNETSdkWebAssembly)' != 'true'" />
   <Import Project="$(MSBuildThisFileDirectory)BrowserWasmApp.props" Condition="'$(UsingNativeAOT)' != 'true'" />
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsOutputTypeLibrary)' == 'true'">

--- a/src/mono/browser/build/WasmApp.InTree.targets
+++ b/src/mono/browser/build/WasmApp.InTree.targets
@@ -3,7 +3,7 @@
   <UsingTask TaskName="MonoAOTCompiler" AssemblyFile="$(MonoAOTCompilerTasksAssemblyPath)" TaskFactory="TaskHostFactory" />
   <UsingTask TaskName="ILStrip" AssemblyFile="$(MonoTargetsTasksAssemblyPath)" TaskFactory="TaskHostFactory" />
 
-  <Import Sdk="Microsoft.NET.Sdk.WebAssembly" Project="Sdk.targets" Condition="'$(UsingNativeAOT)' != 'true' and '$(UsingMicrosoftNETSdkWebAssembly)' == 'true'" />
+  <Import Sdk="Microsoft.NET.Sdk.WebAssembly" Project="Sdk.targets" Condition="'$(UsingNativeAOT)' != 'true' and '$(UsingMicrosoftNETSdkWebAssembly)' != 'true'" />
 
   <!-- TODO: this breaks runtime tests on Helix due to the file not being there for some reason. Once this is fixed we can remove the UpdateRuntimePack target here -->
   <Import Project="$(RepositoryEngineeringDir)targetingpacks.targets" Condition="'$(TargetingpacksTargetsImported)' != 'true' and '$(ImportTargetingPacksTargetsInWasmAppTargets)' == 'true'"/>

--- a/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BuildTestBase.cs
@@ -244,17 +244,20 @@ namespace Wasm.Build.Tests
             if (UseWBTOverridePackTargets)
                 File.Copy(BuildEnvironment.WasmOverridePacksTargetsPath, Path.Combine(dir, Path.GetFileName(BuildEnvironment.WasmOverridePacksTargetsPath)), overwrite: true);
 
-            string targetNuGetConfigPath = Path.Combine(dir, "nuget.config");
-            if (addNuGetSourceForLocalPackages)
+            if (!EnvironmentVariables.UseInTree)
             {
-                File.WriteAllText(targetNuGetConfigPath,
-                                    GetNuGetConfigWithLocalPackagesPath(
-                                                GetNuGetConfigPath(),
-                                                s_buildEnv.BuiltNuGetsPath));
-            }
-            else
-            {
-                File.Copy(GetNuGetConfigPath(), targetNuGetConfigPath);
+                string targetNuGetConfigPath = Path.Combine(dir, "nuget.config");
+                if (addNuGetSourceForLocalPackages)
+                {
+                    File.WriteAllText(targetNuGetConfigPath,
+                                        GetNuGetConfigWithLocalPackagesPath(
+                                                    GetNuGetConfigPath(),
+                                                    s_buildEnv.BuiltNuGetsPath));
+                }
+                else
+                {
+                    File.Copy(GetNuGetConfigPath(), targetNuGetConfigPath);
+                }
             }
         }
 

--- a/src/mono/wasm/Wasm.Build.Tests/Common/EnvironmentVariables.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Common/EnvironmentVariables.cs
@@ -27,5 +27,6 @@ namespace Wasm.Build.Tests
         internal static readonly string? SdkDirName                = Environment.GetEnvironmentVariable("SDK_DIR_NAME");
         internal static readonly string? WasiSdkPath               = Environment.GetEnvironmentVariable("WASI_SDK_PATH");
         internal static readonly bool WorkloadsTestPreviousVersions = Environment.GetEnvironmentVariable("WORKLOADS_TEST_PREVIOUS_VERSIONS") is "true";
+        internal static readonly bool UseInTree = Environment.GetEnvironmentVariable("TEST_USING_IN_TREE") == "true";
     }
 }

--- a/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/Templates/WasmTemplateTestsBase.cs
@@ -124,8 +124,27 @@ public class WasmTemplateTestsBase : BuildTestBase
             """;
         }
 
+        if (EnvironmentVariables.UseInTree)
+        {
+            s_buildEnv.EnvVars["WBTImportInTree"] = "true";
+        }
+
         UpdateProjectFile(projectFilePath, runAnalyzers, extraProperties, extraItems, insertAtEnd);
         return new ProjectInfo(asset.Name, projectFilePath, logPath, nugetDir);
+    }
+
+    protected void CopyTestOutputToProject(TestAsset targetAsset)
+    {
+        TestAsset sourceAsset = TestAsset.WasmBasicTestApp;
+        var testOutputFilePath = Path.Combine(BuildEnvironment.TestAssetsPath, sourceAsset.Name, sourceAsset.RunnableProjectSubPath, "Common", "TestOutput.cs");
+
+        var destinationFilePath = _projectDir;
+        if (!string.IsNullOrEmpty(targetAsset.RunnableProjectSubPath))
+            destinationFilePath = Path.Combine(destinationFilePath, targetAsset.RunnableProjectSubPath);
+
+        destinationFilePath = Path.Combine(destinationFilePath, "TestOutput.cs");
+
+        File.Copy(testOutputFilePath, destinationFilePath, overwrite: true);
     }
 
     private void UpdateProjectFile(string projectFilePath, bool runAnalyzers, string extraProperties, string extraItems, string insertAtEnd)
@@ -328,7 +347,7 @@ public class WasmTemplateTestsBase : BuildTestBase
             RunHost.WebServer =>
                     await BrowserRunTest($"{s_xharnessRunnerCommand} wasm webserver --app=. --web-server-use-default-files",
                         string.IsNullOrEmpty(runOptions.CustomBundleDir) ?
-                            Path.GetFullPath(Path.Combine(GetBinFrameworkDir(runOptions.Configuration, forPublish: true), "..")) :
+                            Path.GetFullPath(Path.Combine(GetBinFrameworkDir(runOptions.Configuration, forPublish: true, _provider.DefaultTargetFramework), "..")) :
                             runOptions.CustomBundleDir,
                          runOptions),
 

--- a/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
+++ b/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
@@ -11,7 +11,7 @@
     <!-- This project should not build against the live built .NETCoreApp targeting pack as it contributes to the build itself. -->
     <UseLocalTargetingRuntimePack>false</UseLocalTargetingRuntimePack>
 
-    <TestUsingWorkloads Condition="'$(TestUsingWorkloads)' == ''">true</TestUsingWorkloads>
+    <TestUsingWorkloads Condition="'$(TestUsingWorkloads)' == '' and '$(TestUsingInTree)' == ''">true</TestUsingWorkloads>
     <!-- these are imported in this project instead -->
     <SkipWorkloadsTestingTargetsImport>false</SkipWorkloadsTestingTargetsImport>
     <InstallWorkloadForTesting>true</InstallWorkloadForTesting>
@@ -109,6 +109,9 @@
       <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export TEST_USING_WORKLOADS=$(TestUsingWorkloads)" />
       <RunScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set TEST_USING_WORKLOADS=$(TestUsingWorkloads)" />
 
+      <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export TEST_USING_IN_TREE=$(TestUsingInTree)" />
+      <RunScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set TEST_USING_IN_TREE=$(TestUsingInTree)" />
+
       <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export SDK_DIR_NAME=$(_SdkPathForLocalTesting)" />
       <RunScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set SDK_DIR_NAME=$(_SdkPathForLocalTesting)" />
 
@@ -135,6 +138,10 @@
 
       <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export BUILT_NUGETS_PATH=$(LibrariesShippingPackagesDir)/" />
       <RunScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set BUILT_NUGETS_PATH=$(LibrariesShippingPackagesDir)" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TestUsingInTree)' == 'true'">
+      <RunScriptCommands Condition="'$(OS)' != 'Windows_NT'" Include="export SDK_FOR_WORKLOAD_TESTING_PATH=$(NetCoreRoot)" />
+      <RunScriptCommands Condition="'$(OS)' == 'Windows_NT'" Include="set SDK_FOR_WORKLOAD_TESTING_PATH=$(NetCoreRoot)" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/mono/wasm/Wasm.Build.Tests/data/Local.Directory.Build.props
+++ b/src/mono/wasm/Wasm.Build.Tests/data/Local.Directory.Build.props
@@ -1,1 +1,11 @@
-<Project />
+<Project>
+  
+  <Import Project="..\..\..\..\..\..\..\..\Directory.Build.props" Condition="'$(WBTImportInTree)' == 'true'" />
+  
+  <PropertyGroup Condition="'$(WBTImportInTree)' == 'true'">
+    <OutputPath>bin\$(Configuration)</OutputPath>
+  </PropertyGroup>
+
+  <Import Project="$(BrowserProjectRoot)build\WasmApp.InTree.props" Condition="'$(WBTImportInTree)' == 'true'" />
+
+</Project>

--- a/src/mono/wasm/Wasm.Build.Tests/data/Local.Directory.Build.targets
+++ b/src/mono/wasm/Wasm.Build.Tests/data/Local.Directory.Build.targets
@@ -1,5 +1,12 @@
 <Project>
+
   <Target Name="PrintRuntimePackPath" BeforeTargets="Build">
     <Message Text="** MicrosoftNetCoreAppRuntimePackDir : '@(ResolvedRuntimePack -> '%(PackageDirectory)')'" Importance="High" Condition="@(ResolvedRuntimePack->Count()) > 0" />
   </Target>
+
+  <ImportGroup Condition="'$(WBTImportInTree)' == 'true'">
+    <Import Project="..\..\..\..\..\..\..\..\Directory.Build.targets" />
+    <Import Project="$(BrowserProjectRoot)build\WasmApp.InTree.targets" />
+  </ImportGroup>
+
 </Project>

--- a/src/mono/wasm/Wasm.Build.Tests/data/RunScriptTemplate.cmd
+++ b/src/mono/wasm/Wasm.Build.Tests/data/RunScriptTemplate.cmd
@@ -67,12 +67,14 @@ if [%WASM_BUNDLER_FRIENDLY_BOOT_CONFIG%] == [true] (
    set USE_JAVASCRIPT_BUNDLER_FOR_TESTS=false
 )
 
-if [%HELIX_CORRELATION_PAYLOAD%] NEQ [] (
-    robocopy /mt /np /nfl /NDL /nc /e %BASE_DIR%\%SDK_DIR_NAME% %EXECUTION_DIR%\%SDK_DIR_NAME%
-    set _SDK_DIR=%EXECUTION_DIR%\%SDK_DIR_NAME%
-) else (
-    set _SDK_DIR=%BASE_DIR%\%SDK_DIR_NAME%
-)
+if [%SDK_FOR_WORKLOAD_TESTING_PATH%] == [] (
+    if [%HELIX_CORRELATION_PAYLOAD%] NEQ [] (
+        robocopy /mt /np /nfl /NDL /nc /e %BASE_DIR%\%SDK_DIR_NAME% %EXECUTION_DIR%\%SDK_DIR_NAME%
+        set _SDK_DIR=%EXECUTION_DIR%\%SDK_DIR_NAME%
+    ) else (
+        set _SDK_DIR=%BASE_DIR%\%SDK_DIR_NAME%
+    )
 
-set "SDK_FOR_WORKLOAD_TESTING_PATH=%_SDK_DIR%"
+    set "SDK_FOR_WORKLOAD_TESTING_PATH=%_SDK_DIR%"
+)
 EXIT /b 0

--- a/src/mono/wasm/Wasm.Build.Tests/data/RunScriptTemplate.sh
+++ b/src/mono/wasm/Wasm.Build.Tests/data/RunScriptTemplate.sh
@@ -51,15 +51,17 @@ function set_env_vars()
         export USE_JAVASCRIPT_BUNDLER_FOR_TESTS=false
     fi
 
-    local _SDK_DIR=
-    if [[ -n "$HELIX_WORKITEM_UPLOAD_ROOT" ]]; then
-        cp -r $BASE_DIR/$SDK_DIR_NAME $EXECUTION_DIR
-        _SDK_DIR=$EXECUTION_DIR/$SDK_DIR_NAME
-    else
-        _SDK_DIR=$BASE_DIR/$SDK_DIR_NAME
-    fi
+    if [ "x$SDK_FOR_WORKLOAD_TESTING_PATH" = "x" ]; then
+        local _SDK_DIR=
+        if [[ -n "$HELIX_WORKITEM_UPLOAD_ROOT" ]]; then
+            cp -r $BASE_DIR/$SDK_DIR_NAME $EXECUTION_DIR
+            _SDK_DIR=$EXECUTION_DIR/$SDK_DIR_NAME
+        else
+            _SDK_DIR=$BASE_DIR/$SDK_DIR_NAME
+        fi
 
-    export SDK_FOR_WORKLOAD_TESTING_PATH=$_SDK_DIR
+        export SDK_FOR_WORKLOAD_TESTING_PATH=$_SDK_DIR
+    fi
 }
 
 export TEST_LOG_PATH=${XHARNESS_OUT}/logs


### PR DESCRIPTION
With `TestUsingInTree=true` Wasm.Build.Tests will use `$REPO_ROOT/.dotnet` to execute tests and will import locally built artifacts through `WasmApp.InTree.(props|targets)`.


Example usage
```
.\dotnet.cmd build -p:TargetOS=browser -p:TargetArchitecture=wasm -c Debug -t:Test .\src\mono\wasm\Wasm.Build.Tests\ -bl -p:InstallWorkloadForTesting=false -p:TestUsingInTree=true
```