### PR TITLE
Revert "Fix unix x64 interpreter helpers CFI unwind info"

### DIFF
--- a/src/coreclr/vm/amd64/asmhelpers.S
+++ b/src/coreclr/vm/amd64/asmhelpers.S
@@ -1735,7 +1735,6 @@ LEAF_END Load_XMM7, _TEXT
 NESTED_ENTRY CallJittedMethodRetVoid, _TEXT, NoHandler
         push_nonvol_reg rbp
         mov  rbp, rsp
-        set_cfa_register rbp, 0
         push_register r8
         push_register rax // align
 END_PROLOGUE
@@ -1753,7 +1752,6 @@ NESTED_END CallJittedMethodRetVoid, _TEXT
 NESTED_ENTRY CallJittedMethodRetBuffRDI, _TEXT, NoHandler
         push_nonvol_reg rbp
         mov  rbp, rsp
-        set_cfa_register rbp, 0
         push_register r8
         push_register rax // align
 END_PROLOGUE
@@ -1772,7 +1770,6 @@ NESTED_END CallJittedMethodRetBuffRDI, _TEXT
 NESTED_ENTRY CallJittedMethodRetBuffRSI, _TEXT, NoHandler
         push_nonvol_reg rbp
         mov  rbp, rsp
-        set_cfa_register rbp, 0
         push_register r8
         push_register rax // align
 END_PROLOGUE
@@ -1791,7 +1788,6 @@ NESTED_END CallJittedMethodRetBuffRSI, _TEXT
 NESTED_ENTRY CallJittedMethodRetDouble, _TEXT, NoHandler
         push_nonvol_reg rbp
         mov  rbp, rsp
-        set_cfa_register rbp, 0
         push_register r8
         push_register rdx
 END_PROLOGUE
@@ -1811,7 +1807,6 @@ NESTED_END CallJittedMethodRetDouble, _TEXT
 NESTED_ENTRY CallJittedMethodRetI8, _TEXT, NoHandler
         push_nonvol_reg rbp
         mov  rbp, rsp
-        set_cfa_register rbp, 0
         push_register r8
         push_register rdx
 END_PROLOGUE
@@ -1831,7 +1826,6 @@ NESTED_END CallJittedMethodRetI8, _TEXT
 NESTED_ENTRY CallJittedMethodRetI8I8, _TEXT, NoHandler
         push_nonvol_reg rbp
         mov  rbp, rsp
-        set_cfa_register rbp, 0
         push_register r8
         push_register rdx
 END_PROLOGUE
@@ -1852,7 +1846,6 @@ NESTED_END CallJittedMethodRetI8I8, _TEXT
 NESTED_ENTRY CallJittedMethodRetI8Double, _TEXT, NoHandler
         push_nonvol_reg rbp
         mov  rbp, rsp
-        set_cfa_register rbp, 0
         push_register r8
         push_register rdx
 END_PROLOGUE
@@ -1873,7 +1866,6 @@ NESTED_END CallJittedMethodRetI8Double, _TEXT
 NESTED_ENTRY CallJittedMethodRetDoubleI8, _TEXT, NoHandler
         push_nonvol_reg rbp
         mov  rbp, rsp
-        set_cfa_register rbp, 0
         push_register r8
         push_register rdx
 END_PROLOGUE
@@ -1894,7 +1886,6 @@ NESTED_END CallJittedMethodRetDoubleI8, _TEXT
 NESTED_ENTRY CallJittedMethodRetDoubleDouble, _TEXT, NoHandler
         push_nonvol_reg rbp
         mov  rbp, rsp
-        set_cfa_register rbp, 0
         push_register r8
         push_register rdx
 END_PROLOGUE


### PR DESCRIPTION
Reverts dotnet/runtime#122427

It looks like this PR broke gcstress