### PR TITLE
Fix dataflow analysis of lambdas in async methods

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/CompilerGeneratedState.cs
@@ -737,6 +737,10 @@ namespace ILCompiler.Dataflow
             if (sourceMember == null)
                 return false;
 
+            Debug.Assert(sourceMember is not MethodDesc sourceMethod || sourceMethod.IsTypicalMethodDefinition);
+            if (sourceMember is AsyncMethodVariant asyncVariant)
+                sourceMember = asyncVariant.Target;
+
             TypeSystemEntity member = sourceMember;
             MethodDesc? userMethodCandidate;
             while (TryGetOwningMethodForCompilerGeneratedMember(member, out userMethodCandidate))

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/RuntimeAsyncMethods.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/RuntimeAsyncMethods.cs
@@ -30,7 +30,6 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             await RuntimeAsyncWithLocalAll();
             await RuntimeAsyncWithLambda();
             await RuntimeAsyncWithAwaitedLocalMethod();
-            await RuntimeAsyncWithAwaitedLocalMethodSuppressed();
         }
 
         static async Task BasicRuntimeAsyncMethod()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/RuntimeAsyncMethods.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/RuntimeAsyncMethods.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
@@ -28,6 +29,8 @@ namespace Mono.Linker.Tests.Cases.DataFlow
             await RuntimeAsyncWithCorrectParameter(null);
             await RuntimeAsyncWithLocalAll();
             await RuntimeAsyncWithLambda();
+            await RuntimeAsyncWithAwaitedLocalMethod();
+            await RuntimeAsyncWithAwaitedLocalMethodSuppressed();
         }
 
         static async Task BasicRuntimeAsyncMethod()
@@ -115,6 +118,17 @@ namespace Mono.Linker.Tests.Cases.DataFlow
         static async Task RuntimeAsyncWithLambda()
         {
             await Task.Run([ExpectedWarning("IL2026", nameof(TypeWithRucMethod.RucMethod))] () => typeof(TypeWithRucMethod).GetMethods());
+        }
+
+        static async Task RuntimeAsyncWithAwaitedLocalMethod()
+        {
+            await GetTheMethods();
+
+            [ExpectedWarning("IL2026", nameof(TypeWithRucMethod.RucMethod))]
+            static async Task<MethodInfo[]> GetTheMethods()
+            {
+                return typeof(TypeWithRucMethod).GetMethods();
+            }
         }
     }
 }


### PR DESCRIPTION
To the same tune as #122450. This is a bug farm, as expected, but likely still better than trying to teach the code that is shared with ILLink and Roslyn analyzer about async variants.

Cc @dotnet/ilc-contrib 