### PR TITLE
[release/8.0-staging] Update OpenSSL dependency for openSUSE and SLES

### DIFF
--- a/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-opensuse.42.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-opensuse.42.proj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <LinuxPackageDependency Include="libopenssl1_0_0;libicu;krb5" />
+    <LinuxPackageDependency Include="libopenssl3;libicu;krb5" />
   </ItemGroup>
 </Project>

--- a/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-sles.12.proj
+++ b/src/installer/pkg/sfx/installers/dotnet-runtime-deps/dotnet-runtime-deps-sles.12.proj
@@ -5,6 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <LinuxPackageDependency Include="libopenssl1_1;libicu;krb5" />
+    <LinuxPackageDependency Include="libopenssl3;libicu;krb5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/122653

`libopenssl3` is supported and installed by default on all of the supported distro releases listed at https://learn.microsoft.com/en-us/dotnet/core/install/linux-sles?tabs=dotnet8 and https://learn.microsoft.com/en-us/dotnet/core/install/linux-opensuse?tabs=dotnet8

`libopenssl3` is also supported and installed by default on openSUSE Tumbleweed release. This release does not have any other, older, version of this library.