### PR TITLE
Use QueryUnbiasedInterruptTime instead of GetTickCount64 to allow more responsive Windows apps when they opt-in

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.QueryUnbiasedInterruptTime.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.QueryUnbiasedInterruptTime.cs
@@ -7,8 +7,16 @@ internal static partial class Interop
 {
     internal static partial class Kernel32
     {
+        // The actual native signature is:
+        //      BOOL WINAPI QueryUnbiasedInterruptTime(
+        //          _Out_ PULONGLONG UnbiasedTime
+        //      );
+        //
+        // We take a long* (rather than a out long) to avoid the pinning overhead.
+        // We don't set last error since we don't need the extended error info.
+
         [LibraryImport(Libraries.Kernel32)]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        internal static partial bool QueryUnbiasedInterruptTime(out ulong UnbiasedTime);
+        [SuppressGCTransition]
+        internal static unsafe partial BOOL QueryUnbiasedInterruptTime(ulong* unbiasedTime);
     }
 }

--- a/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.QueryUnbiasedInterruptTime.cs
+++ b/src/libraries/Common/src/Interop/Windows/Kernel32/Interop.QueryUnbiasedInterruptTime.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
         //          _Out_ PULONGLONG UnbiasedTime
         //      );
         //
-        // We take a long* (rather than a out long) to avoid the pinning overhead.
+        // We take a ulong* (rather than a out ulong) to avoid the pinning overhead.
         // We don't set last error since we don't need the extended error info.
 
         [LibraryImport(Libraries.Kernel32)]

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs
@@ -377,6 +377,27 @@ namespace System
 
         /// <summary>Gets the number of milliseconds elapsed since the system started.</summary>
         /// <value>A 64-bit signed integer containing the amount of time in milliseconds that has passed since the last time the computer was started.</value>
-        public static long TickCount64 => (long)Interop.Kernel32.GetTickCount64();
+        public static long TickCount64
+        {
+            get
+            {
+                unsafe
+                {
+                    // GetTickCount64 uses fixed resolution of 10-16ms for backward compatibility. Use
+                    // QueryUnbiasedInterruptTime instead which becomes more accurate if the underlying system
+                    // resolution is improved. This helps responsiveness in the case an app is trying to opt
+                    // into things like multimedia scenarios and additionally does not include "bias" from time
+                    // the system is spent asleep or in hibernation.
+
+                    ulong unbiasedTime;
+
+                    Interop.BOOL result = Interop.Kernel32.QueryUnbiasedInterruptTime(&unbiasedTime);
+                    // The P/Invoke is documented to only fail if a null-ptr is passed in
+                    Debug.Assert(result != Interop.BOOL.FALSE);
+
+                    return (long)(unbiasedTime / TimeSpan.TicksPerMillisecond);
+                }
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Timer.cs
@@ -42,7 +42,7 @@ namespace System.Threading
     {
         #region Shared TimerQueue instances
         /// <summary>Mapping from a tick count to a time to use when debugging to translate tick count values.</summary>
-        internal static readonly (long TickCount, DateTime Time) s_tickCountToTimeMap = (TickCount64, DateTime.UtcNow);
+        internal static readonly (long TickCount, DateTime Time) s_tickCountToTimeMap = (Environment.TickCount64, DateTime.UtcNow);
 
         public static TimerQueue[] Instances { get; } = CreateTimerQueues();
 
@@ -126,7 +126,7 @@ namespace System.Threading
 
             if (_isTimerScheduled)
             {
-                long elapsed = TickCount64 - _currentTimerStartTicks;
+                long elapsed = Environment.TickCount64 - _currentTimerStartTicks;
                 if (elapsed >= _currentTimerDuration)
                     return true; // the timer's about to fire
 
@@ -138,7 +138,7 @@ namespace System.Threading
             if (SetTimer(actualDuration))
             {
                 _isTimerScheduled = true;
-                _currentTimerStartTicks = TickCount64;
+                _currentTimerStartTicks = Environment.TickCount64;
                 _currentTimerDuration = actualDuration;
                 return true;
             }
@@ -161,7 +161,7 @@ namespace System.Threading
 
         // The current threshold, an absolute time where any timers scheduled to go off at or
         // before this time must be queued to the short list.
-        private long _currentAbsoluteThreshold = TickCount64 + ShortTimersThresholdMilliseconds;
+        private long _currentAbsoluteThreshold = Environment.TickCount64 + ShortTimersThresholdMilliseconds;
 
         // Default threshold that separates which timers target _shortTimers vs _longTimers. The threshold
         // is chosen to balance the number of timers in the small list against the frequency with which
@@ -191,7 +191,7 @@ namespace System.Threading
                 bool haveTimerToSchedule = false;
                 uint nextTimerDuration = uint.MaxValue;
 
-                long nowTicks = TickCount64;
+                long nowTicks = Environment.TickCount64;
 
                 // Sweep through the "short" timers.  If the current tick count is greater than
                 // the current threshold, also sweep through the "long" timers.  Finally, as part
@@ -342,7 +342,7 @@ namespace System.Threading
 
         public bool UpdateTimer(TimerQueueTimer timer, uint dueTime, uint period)
         {
-            long nowTicks = TickCount64;
+            long nowTicks = Environment.TickCount64;
 
             // The timer can be put onto the short list if it's next absolute firing time
             // is <= the current absolute threshold.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Browser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Browser.cs
@@ -19,7 +19,6 @@ namespace System.Threading
     //
     internal partial class TimerQueue
     {
-        private static long TickCount64 => Environment.TickCount64;
         private static List<TimerQueue>? s_scheduledTimers;
         private static List<TimerQueue>? s_scheduledTimersToFire;
         private static long s_shortestDueTimeMs = long.MaxValue;
@@ -49,7 +48,7 @@ namespace System.Threading
                 // always only have one scheduled at a time
                 s_shortestDueTimeMs = long.MaxValue;
 
-                long currentTimeMs = TickCount64;
+                long currentTimeMs = Environment.TickCount64;
                 ReplaceNextTimer(PumpTimerQueue(currentTimeMs), currentTimeMs);
             }
             catch (Exception e)
@@ -62,7 +61,7 @@ namespace System.Threading
         private bool SetTimer(uint actualDuration)
         {
             Debug.Assert((int)actualDuration >= 0);
-            long currentTimeMs = TickCount64;
+            long currentTimeMs = Environment.TickCount64;
             if (!_isScheduled)
             {
                 s_scheduledTimers ??= new List<TimerQueue>(Instances.Length);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Portable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Portable.cs
@@ -50,7 +50,7 @@ namespace System.Threading
         private bool SetTimerPortable(uint actualDuration)
         {
             Debug.Assert((int)actualDuration >= 0);
-            long dueTimeMs = TickCount64 + (int)actualDuration;
+            long dueTimeMs = Environment.TickCount64 + (int)actualDuration;
             AutoResetEvent timerEvent = s_timerEvent;
             Lock timerEventLock = s_timerEventLock;
 
@@ -92,7 +92,7 @@ namespace System.Threading
             {
                 timerEvent.WaitOne(shortestWaitDurationMs);
 
-                long currentTimeMs = TickCount64;
+                long currentTimeMs = Environment.TickCount64;
                 shortestWaitDurationMs = int.MaxValue;
                 lock (timerEventLock)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Unix.cs
@@ -5,8 +5,6 @@ namespace System.Threading
 {
     internal sealed partial class TimerQueue
     {
-        public static long TickCount64 => Environment.TickCount64;
-
 #pragma warning disable IDE0060
         private TimerQueue(int id)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Wasi.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Wasi.cs
@@ -18,7 +18,6 @@ namespace System.Threading
     //
     internal sealed partial class TimerQueue
     {
-        private static long TickCount64 => Environment.TickCount64;
         private static List<TimerQueue>? s_scheduledTimers;
         private static List<TimerQueue>? s_scheduledTimersToFire;
         private static long s_shortestDueTimeMs = long.MaxValue;
@@ -36,7 +35,7 @@ namespace System.Threading
             {
                 s_shortestDueTimeMs = long.MaxValue;
 
-                long currentTimeMs = TickCount64;
+                long currentTimeMs = Environment.TickCount64;
                 SetNextTimer(PumpTimerQueue(currentTimeMs), currentTimeMs);
             }
             catch (Exception e)
@@ -49,7 +48,7 @@ namespace System.Threading
         private bool SetTimer(uint actualDuration)
         {
             Debug.Assert((int)actualDuration >= 0);
-            long currentTimeMs = TickCount64;
+            long currentTimeMs = Environment.TickCount64;
             if (!_isScheduled)
             {
                 s_scheduledTimers ??= new List<TimerQueue>(Instances.Length);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Windows.cs
@@ -12,8 +12,6 @@ namespace System.Threading
             _id = id;
         }
 
-        public static long TickCount64 => Environment.TickCount64;
-
         private bool SetTimer(uint actualDuration) =>
             ThreadPool.UseWindowsThreadPool ?
             SetTimerWindowsThreadPool(actualDuration) :

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/TimerQueue.Windows.cs
@@ -12,32 +12,7 @@ namespace System.Threading
             _id = id;
         }
 
-        public static long TickCount64
-        {
-            get
-            {
-                // We need to keep our notion of time synchronized with the calls to SleepEx that drive
-                // the underlying native timer.  In Win8, SleepEx does not count the time the machine spends
-                // sleeping/hibernating.  Environment.TickCount (GetTickCount) *does* count that time,
-                // so we will get out of sync with SleepEx if we use that method.
-                //
-                // So, on Win8, we use QueryUnbiasedInterruptTime instead; this does not count time spent
-                // in sleep/hibernate mode.
-                if (Environment.IsWindows8OrAbove)
-                {
-                    // Based on its documentation the QueryUnbiasedInterruptTime() function validates
-                    // the argument is non-null. In this case we are always supplying an argument,
-                    // so will skip return value validation.
-                    bool success = Interop.Kernel32.QueryUnbiasedInterruptTime(out ulong time100ns);
-                    Debug.Assert(success);
-                    return (long)(time100ns / 10_000); // convert from 100ns to milliseconds
-                }
-                else
-                {
-                    return Environment.TickCount64;
-                }
-            }
-        }
+        public static long TickCount64 => Environment.TickCount64;
 
         private bool SetTimer(uint actualDuration) =>
             ThreadPool.UseWindowsThreadPool ?


### PR DESCRIPTION
Unix systems (Linux and MacOS) were already using timers like `CLOCK_MONOTONIC_COARSE` and `CLOCK_UPTIME_RAW` and so allowed for higher responsiveness.

It was only Windows which was restricting itself to 10-16ms (typically 15.5ms) of responsiveness and which did not respect apps which set higher precision tick times. This was also then inconsistent with changes the OS itself made (in Win8+) to its various Wait APIs to no longer include sleep/hibernate time (bias) as part of their timeout checks.

Linux will fallback to `CLOCK_MONOTONIC` if `CLOCK_MONOTONIC_COARSE` isn't available. The non-coarse version is closer to `QueryUnbiasedInterruptTimePrecise` which is an "exact" rather than cached query.

MacOS doesn't try to use `CLOCK_UPTIME_RAW_APPROX` which is the "coarse" equivalent.