### PR TITLE
Fix MethodBase.GetCurrentMethod with runtime async

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -202,13 +202,13 @@ namespace ILCompiler
             }
             else if (intrinsicOwningType.Name.SequenceEqual("MethodBase"u8) && intrinsicOwningType.Namespace.SequenceEqual("System.Reflection"u8))
             {
-                if (callsiteMethod.IsAsyncVariant())
-                {
-                    // For async methods, we need to get the MethodBase for the thunk variant.
-                    callsiteMethod = TypeSystemContext.GetTargetOfAsyncVariantMethod(callsiteMethod);
-                }
                 if (intrinsicMethod.Signature.IsStatic && intrinsicMethod.Name.SequenceEqual("GetCurrentMethod"u8))
                 {
+                    if (callsiteMethod.IsAsyncVariant())
+                    {
+                        // For async methods, we need to get the MethodBase for the thunk variant.
+                        callsiteMethod = TypeSystemContext.GetTargetOfAsyncVariantMethod(callsiteMethod);
+                    }
                     return _methodBaseGetCurrentMethodThunks.GetHelper(callsiteMethod).InstantiateAsOpen();
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -202,6 +202,11 @@ namespace ILCompiler
             }
             else if (intrinsicOwningType.Name.SequenceEqual("MethodBase"u8) && intrinsicOwningType.Namespace.SequenceEqual("System.Reflection"u8))
             {
+                if (callsiteMethod.IsAsync)
+                {
+                    // For async methods, we need to get the MethodBase for the thunk variant.
+                    callsiteMethod = TypeSystemContext.GetTargetOfAsyncVariantMethod(callsiteMethod);
+                }
                 if (intrinsicMethod.Signature.IsStatic && intrinsicMethod.Name.SequenceEqual("GetCurrentMethod"u8))
                 {
                     return _methodBaseGetCurrentMethodThunks.GetHelper(callsiteMethod).InstantiateAsOpen();

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Compilation.cs
@@ -202,7 +202,7 @@ namespace ILCompiler
             }
             else if (intrinsicOwningType.Name.SequenceEqual("MethodBase"u8) && intrinsicOwningType.Namespace.SequenceEqual("System.Reflection"u8))
             {
-                if (callsiteMethod.IsAsync)
+                if (callsiteMethod.IsAsyncVariant())
                 {
                     // For async methods, we need to get the MethodBase for the thunk variant.
                     callsiteMethod = TypeSystemContext.GetTargetOfAsyncVariantMethod(callsiteMethod);

--- a/src/tests/async/reflection/reflection.cs
+++ b/src/tests/async/reflection/reflection.cs
@@ -247,7 +247,6 @@ public class Async2Reflection
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/122517", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
     public static void CurrentMethod()
     {
         // Note: async1 leaks implementation details here and returns "Void MoveNext()"


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/122546.

The following code can now be Native AOT compiled and run with runtime-async enabled.

```C#
class Program
{
    static async Task Main()
    {
        Console.WriteLine("Hello world");
        await MyAsyncMethod();
    }

    static async Task MyAsyncMethod()
    {
        MethodBase currentMethod = MethodBase.GetCurrentMethod();
        Console.WriteLine($"Current method: {currentMethod?.Name}");
        await Task.Delay(100);
    }
}
```