### PR TITLE
[ThreadPool] Scalability Experiments follow up. Part1 

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -2839,6 +2839,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadPoolBoundHandle.Windows.cs" Condition="'$(TargetsWindows)' == 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadPoolBoundHandleOverlapped.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\ThreadPoolCallbackWrapper.cs" Condition="'$(FeatureNativeAot)' != 'true'" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Threading\Backoff.cs" />
   </ItemGroup>
   <ItemGroup Condition="('$(TargetsBrowser)' == 'true' or '$(TargetsWasi)' == 'true') and '$(FeatureWasmManagedThreads)' != 'true'">
     <Compile Include="$(MSBuildThisFileDirectory)System\Threading\PreAllocatedOverlapped.Browser.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Backoff.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Backoff.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+namespace System.Threading
+{
+    internal static class Backoff
+    {
+        // We will use exponential backoff in rare cases when we need to change state atomically and cannot
+        // make progress due to concurrent state changes by other threads.
+        // While we cannot know the ideal amount of wait needed before making a successful attempt,
+        // the exponential backoff will generally be not more than 2X worse than the perfect guess and
+        // will do a lot less attempts than an simple retry. On multiprocessor machine fruitless attempts
+        // will cause unnecessary sharing of the contended state which may make modifying the state more expensive.
+        // To protect against degenerate cases we will cap the per-iteration wait to a few thousand spinwaits.
+        private const uint MaxExponentialBackoffBits = 14;
+
+        internal static unsafe void Exponential(uint attempt)
+        {
+            attempt = Math.Min(attempt, MaxExponentialBackoffBits);
+            // We will backoff for some random number of spins that roughly grows as attempt^2
+            // No need for much randomness here, randomness is "good to have", we could do without it,
+            // so we will just cheaply hash in the stack location.
+            uint rand = (uint)&attempt * 2654435769u;
+            // Set the highmost bit to ensure minimum number of spins is exponentialy increasing.
+            // It basically guarantees that we spin at least 0, 1, 2, 4, 8, 16, times, and so on
+            rand |= (1u << 31);
+            uint spins = rand >> (byte)(32 - attempt);
+            Thread.SpinWait((int)spins);
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Backoff.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Backoff.cs
@@ -13,7 +13,7 @@ namespace System.Threading
         // make progress due to concurrent state changes by other threads.
         // While we cannot know the ideal amount of wait needed before making a successful attempt,
         // the exponential backoff will generally be not more than 2X worse than the perfect guess and
-        // will do a lot less attempts than an simple retry. On multiprocessor machine fruitless attempts
+        // will do a lot less attempts than a simple retry. On multiprocessor machine fruitless attempts
         // will cause unnecessary sharing of the contended state which may make modifying the state more expensive.
         // To protect against degenerate cases we will cap the per-iteration wait to a few thousand spinwaits.
         private const uint MaxExponentialBackoffBits = 14;
@@ -25,7 +25,7 @@ namespace System.Threading
             // No need for much randomness here, randomness is "good to have", we could do without it,
             // so we will just cheaply hash in the stack location.
             uint rand = (uint)&attempt * 2654435769u;
-            // Set the highmost bit to ensure minimum number of spins is exponentialy increasing.
+            // Set the highmost bit to ensure minimum number of spins is exponentially increasing.
             // It basically guarantees that we spin at least 0, 1, 2, 4, 8, 16, times, and so on
             rand |= (1u << 31);
             uint spins = rand >> (byte)(32 - attempt);

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.cs
@@ -19,8 +19,6 @@ namespace System.Threading
         private readonly int _spinCount;
         private readonly Action _onWait;
 
-        private const int SpinSleep0Threshold = 10;
-
         public LowLevelLifoSemaphore(int initialSignalCount, int maximumSignalCount, int spinCount, Action onWait)
         {
             Debug.Assert(initialSignalCount >= 0);
@@ -95,10 +93,10 @@ namespace System.Threading
             }
 
             bool isSingleProcessor = Environment.IsSingleProcessor;
-            int spinIndex = isSingleProcessor ? SpinSleep0Threshold : 0;
+            int spinIndex = isSingleProcessor ? spinCount : 0;
             while (spinIndex < spinCount)
             {
-                LowLevelSpinWaiter.Wait(spinIndex, SpinSleep0Threshold, isSingleProcessor);
+                LowLevelSpinWaiter.Wait(spinIndex, int.MaxValue, isSingleProcessor);
                 spinIndex++;
 
                 // Try to acquire the semaphore and unregister as a spinner

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.cs
@@ -61,9 +61,9 @@ namespace System.Threading
         private bool WaitSlow(int timeoutMs)
         {
             // Now spin briefly with exponential backoff.
-            // We use random exponential backoff is because:
+            // We use random exponential backoff because:
             // - we do not know how soon a signal appears, but with exponential backoff we will not be more than 2x off the ideal guess
-            // - it gives mild preference to the most recent spinners. We want LIFO here so that hot threads keep running.
+            // - it gives mild preference to the most recent spinners. We want LIFO here so that hot(er) threads keep running.
             // - it is possible that spinning workers prevent non-pool threads from submitting more work to the pool,
             //   so we want some workers to sleep earlier than others.
             uint spinCount = Environment.IsSingleProcessor ? 0 : _spinCount;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.cs
@@ -19,15 +19,13 @@ namespace System.Threading
         private readonly int _spinCount;
         private readonly Action _onWait;
 
-        public LowLevelLifoSemaphore(int initialSignalCount, int maximumSignalCount, int spinCount, Action onWait)
+        public LowLevelLifoSemaphore(int maximumSignalCount, int spinCount, Action onWait)
         {
-            Debug.Assert(initialSignalCount >= 0);
-            Debug.Assert(initialSignalCount <= maximumSignalCount);
             Debug.Assert(maximumSignalCount > 0);
+            Debug.Assert(maximumSignalCount <= short.MaxValue);
             Debug.Assert(spinCount >= 0);
 
             _separated = default;
-            _separated._counts.SignalCount = (uint)initialSignalCount;
             _maximumSignalCount = maximumSignalCount;
             _spinCount = spinCount;
             _onWait = onWait;
@@ -43,83 +41,60 @@ namespace System.Threading
             Thread.AssureBlockingPossible();
 #endif
 
-            int spinCount = Environment.IsSingleProcessor ? _spinCount : 0;
-
-            // Try to acquire the semaphore or
-            // a) register as a spinner if spinCount > 0 and timeoutMs > 0
-            // b) register as a waiter if there's already too many spinners or spinCount == 0 and timeoutMs > 0
-            // c) bail out if timeoutMs == 0 and return false
+            // Try one-shot acquire first
             Counts counts = _separated._counts;
-            while (true)
+            if (counts.SignalCount != 0)
             {
-                Debug.Assert(counts.SignalCount <= _maximumSignalCount);
                 Counts newCounts = counts;
-                if (counts.SignalCount != 0)
-                {
-                    newCounts.DecrementSignalCount();
-                }
-                else if (timeoutMs != 0)
-                {
-                    if (spinCount > 0 && newCounts.SpinnerCount < byte.MaxValue)
-                    {
-                        newCounts.IncrementSpinnerCount();
-                    }
-                    else
-                    {
-                        // Maximum number of spinners reached, register as a waiter instead
-                        newCounts.IncrementWaiterCount();
-                    }
-                }
-
+                newCounts.DecrementSignalCount();
                 Counts countsBeforeUpdate = _separated._counts.InterlockedCompareExchange(newCounts, counts);
                 if (countsBeforeUpdate == counts)
                 {
-                    if (counts.SignalCount != 0)
-                    {
-                        return true;
-                    }
-                    if (newCounts.WaiterCount != counts.WaiterCount)
-                    {
-                        return WaitForSignal(timeoutMs);
-                    }
-                    if (timeoutMs == 0)
-                    {
-                        return false;
-                    }
-                    break;
+                    // we've consumed a signal
+                    return true;
                 }
-
-                counts = countsBeforeUpdate;
             }
 
+            return WaitSlow(timeoutMs);
+        }
+
+        private bool WaitSlow(int timeoutMs)
+        {
+            // Now spin briefly with exponential backoff.
+            // We use random exponential backoff is because:
+            // - we do not know how soon a signal appears, but with exponential backoff we will not be more than 2x off the ideal guess
+            // - it gives mild preference to the most recent spinners. We want LIFO here so that hot threads keep running.
+            // - it is possible that spinning workers prevent non-pool threads from creating more work for the pool,
+            //   so we want some workers to sleep early.
+
+            int spinCount = Environment.IsSingleProcessor ? 0 : _spinCount;
             for (int spinIndex = 0; spinIndex < spinCount; spinIndex++)
             {
-                LowLevelSpinWaiter.Wait(spinIndex, int.MaxValue, isSingleProcessor: false);
+                Thread.SpinWait(1 << Math.Min(spinIndex, 10));
 
-                // Try to acquire the semaphore and unregister as a spinner
-                counts = _separated._counts;
-                while (counts.SignalCount > 0)
+                Counts counts = _separated._counts;
+                if (counts.SignalCount != 0)
                 {
                     Counts newCounts = counts;
                     newCounts.DecrementSignalCount();
-                    newCounts.DecrementSpinnerCount();
-
                     Counts countsBeforeUpdate = _separated._counts.InterlockedCompareExchange(newCounts, counts);
                     if (countsBeforeUpdate == counts)
                     {
+                        // we've consumed a signal
                         return true;
                     }
-
-                    counts = countsBeforeUpdate;
                 }
             }
 
-            // Unregister as spinner, and acquire the semaphore or register as a waiter
-            counts = _separated._counts;
+            // Now we will try registering as a waiter and wait.
+            // If signaled before that, we have to acquire as this can be the last thread that could take that signal.
+            // The difference with spinning above is that we are not waiting for a signal. We should immediately succeed
+            // unless a lot of threads are trying to update the counts.
+            int collisionCount = 0;
             while (true)
             {
+                Counts counts = _separated._counts;
                 Counts newCounts = counts;
-                newCounts.DecrementSpinnerCount();
                 if (counts.SignalCount != 0)
                 {
                     newCounts.DecrementSignalCount();
@@ -135,7 +110,8 @@ namespace System.Threading
                     return counts.SignalCount != 0 || WaitForSignal(timeoutMs);
                 }
 
-                counts = countsBeforeUpdate;
+                Thread.SpinWait(1 << Math.Min(collisionCount, 10));
+                collisionCount++;
             }
         }
 
@@ -157,22 +133,20 @@ namespace System.Threading
                 }
                 int endWaitTicks = timeoutMs != -1 ? Environment.TickCount : 0;
 
-                // Unregister the waiter if this thread will not be waiting anymore, and try to acquire the semaphore
-                Counts counts = _separated._counts;
+                int collisionCount = 0;
                 while (true)
                 {
-                    Debug.Assert(counts.WaiterCount != 0);
+                    Counts counts = _separated._counts;
                     Counts newCounts = counts;
-                    if (counts.SignalCount != 0)
+
+                    Debug.Assert(counts.WaiterCount != 0);
+                    Debug.Assert(counts.CountOfWaitersSignaledToWake != 0);
+
+                    newCounts.DecrementCountOfWaitersSignaledToWake();
+                    if (newCounts.SignalCount != 0)
                     {
                         newCounts.DecrementSignalCount();
                         newCounts.DecrementWaiterCount();
-                    }
-
-                    // This waiter has woken up and this needs to be reflected in the count of waiters signaled to wake
-                    if (counts.CountOfWaitersSignaledToWake != 0)
-                    {
-                        newCounts.DecrementCountOfWaitersSignaledToWake();
                     }
 
                     Counts countsBeforeUpdate = _separated._counts.InterlockedCompareExchange(newCounts, counts);
@@ -180,56 +154,51 @@ namespace System.Threading
                     {
                         if (counts.SignalCount != 0)
                         {
+                            // success
                             return true;
                         }
+
+                        // we've consumed a wake, but there was no signal, we will wait again.
                         break;
                     }
 
-                    counts = countsBeforeUpdate;
-                    if (timeoutMs != -1) {
-                        int waitMs = endWaitTicks - startWaitTicks;
-                        if (waitMs >= 0 && waitMs < timeoutMs)
-                            timeoutMs -= waitMs;
-                        else
-                            timeoutMs = 0;
-                    }
+                    // collision, try again.
+                    Thread.SpinWait(1 << Math.Min(collisionCount, 10));
+                    collisionCount++;
+                }
+
+                // we will wait again, reduce timeout
+                if (timeoutMs != -1)
+                {
+                    int waitMs = endWaitTicks - startWaitTicks;
+                    if (waitMs >= 0 && waitMs < timeoutMs)
+                        timeoutMs -= waitMs;
+                    else
+                        timeoutMs = 0;
                 }
             }
         }
 
         public void Signal()
         {
-            int countOfWaitersToWake;
-            Counts counts = _separated._counts;
+            // Increment signal count. This enables one-shot acquire.
+            Counts counts = _separated._counts.InterlockedIncrementSignalCount();
+
+            // Now check if waiters need to be woken
+            int collisionCount = 0;
             while (true)
             {
-                Counts newCounts = counts;
-
-                // Increase the signal count. The addition doesn't overflow because of the limit on the max signal count in constructor.
-                newCounts.AddSignalCount(1);
-
-                // Determine how many waiters to wake, taking into account how many spinners and waiters there are and how many waiters
-                // have previously been signaled to wake but have not yet woken
-                countOfWaitersToWake =
-                    (int)Math.Min(newCounts.SignalCount, (uint)counts.WaiterCount + counts.SpinnerCount) -
-                    counts.SpinnerCount -
-                    counts.CountOfWaitersSignaledToWake;
-                if (countOfWaitersToWake > 0)
+                // Determine how many waiters to wake.
+                // The number of wakes should not be more than the signal count, not more than waiter count and discount any pending wakes.
+                int countOfWaitersToWake = (int)Math.Min(counts.SignalCount, counts.WaiterCount) - counts.CountOfWaitersSignaledToWake;
+                if (countOfWaitersToWake <= 0)
                 {
-                    // Ideally, limiting to a maximum of releaseCount would not be necessary and could be an assert instead, but since
-                    // WaitForSignal() does not have enough information to tell whether a woken thread was signaled, and due to the cap
-                    // below, it's possible for countOfWaitersSignaledToWake to be less than the number of threads that have actually
-                    // been signaled to wake.
-                    if (countOfWaitersToWake > 1)
-                    {
-                        countOfWaitersToWake = 1;
-                    }
-
-                    // Cap countOfWaitersSignaledToWake to its max value. It's ok to ignore some woken threads in this count, it just
-                    // means some more threads will be woken next time. Typically, it won't reach the max anyway.
-                    newCounts.AddUpToMaxCountOfWaitersSignaledToWake((uint)countOfWaitersToWake);
+                    // No waiters to wake. This is the most common case.
+                    return;
                 }
 
+                Counts newCounts = counts;
+                newCounts.AddCountOfWaitersSignaledToWake((uint)countOfWaitersToWake);
                 Counts countsBeforeUpdate = _separated._counts.InterlockedCompareExchange(newCounts, counts);
                 if (countsBeforeUpdate == counts)
                 {
@@ -239,44 +208,39 @@ namespace System.Threading
                     return;
                 }
 
-                counts = countsBeforeUpdate;
+                // collision, try again.
+                Thread.SpinWait(1 << Math.Min(collisionCount, 10));
+                collisionCount++;
+
+                counts = _separated._counts;
             }
         }
 
         private struct Counts : IEquatable<Counts>
         {
             private const byte SignalCountShift = 0;
-            private const byte WaiterCountShift = 32;
-            private const byte SpinnerCountShift = 48;
-            private const byte CountOfWaitersSignaledToWakeShift = 56;
+            private const byte WaiterCountShift = 16;
+            private const byte CountOfWaitersSignaledToWakeShift = 32;
 
             private ulong _data;
 
             private Counts(ulong data) => _data = data;
 
-            private uint GetUInt32Value(byte shift) => (uint)(_data >> shift);
-            private void SetUInt32Value(uint value, byte shift) =>
-                _data = (_data & ~((ulong)uint.MaxValue << shift)) | ((ulong)value << shift);
             private ushort GetUInt16Value(byte shift) => (ushort)(_data >> shift);
             private void SetUInt16Value(ushort value, byte shift) =>
                 _data = (_data & ~((ulong)ushort.MaxValue << shift)) | ((ulong)value << shift);
-            private byte GetByteValue(byte shift) => (byte)(_data >> shift);
-            private void SetByteValue(byte value, byte shift) =>
-                _data = (_data & ~((ulong)byte.MaxValue << shift)) | ((ulong)value << shift);
 
-            public uint SignalCount
+            public ushort SignalCount
             {
-                get => GetUInt32Value(SignalCountShift);
-                set => SetUInt32Value(value, SignalCountShift);
+                get => GetUInt16Value(SignalCountShift);
             }
 
-            public void AddSignalCount(uint value)
+            public Counts InterlockedIncrementSignalCount()
             {
-                Debug.Assert(value <= uint.MaxValue - SignalCount);
-                _data += (ulong)value << SignalCountShift;
+                var countsAfterUpdate = new Counts(Interlocked.Add(ref _data, 1ul << SignalCountShift));
+                Debug.Assert(countsAfterUpdate.SignalCount != ushort.MaxValue); // underflow check
+                return countsAfterUpdate;
             }
-
-            public void IncrementSignalCount() => AddSignalCount(1);
 
             public void DecrementSignalCount()
             {
@@ -287,13 +251,6 @@ namespace System.Threading
             public ushort WaiterCount
             {
                 get => GetUInt16Value(WaiterCountShift);
-                set => SetUInt16Value(value, WaiterCountShift);
-            }
-
-            public void IncrementWaiterCount()
-            {
-                Debug.Assert(WaiterCount < ushort.MaxValue);
-                _data += (ulong)1 << WaiterCountShift;
             }
 
             public void DecrementWaiterCount()
@@ -302,44 +259,28 @@ namespace System.Threading
                 _data -= (ulong)1 << WaiterCountShift;
             }
 
+            public void IncrementWaiterCount()
+            {
+                _data += (ulong)1 << WaiterCountShift;
+                Debug.Assert(WaiterCount != 0);
+            }
+
             public void InterlockedDecrementWaiterCount()
             {
                 var countsAfterUpdate = new Counts(Interlocked.Add(ref _data, unchecked((ulong)-1) << WaiterCountShift));
-                Debug.Assert(countsAfterUpdate.WaiterCount != ushort.MaxValue); // underflow check
+                Debug.Assert(countsAfterUpdate.WaiterCount != ushort.MaxValue); // overflow check
             }
 
-            public byte SpinnerCount
+            public ushort CountOfWaitersSignaledToWake
             {
-                get => GetByteValue(SpinnerCountShift);
-                set => SetByteValue(value, SpinnerCountShift);
+                get => GetUInt16Value(CountOfWaitersSignaledToWakeShift);
             }
 
-            public void IncrementSpinnerCount()
+            public void AddCountOfWaitersSignaledToWake(uint value)
             {
-                Debug.Assert(SpinnerCount < byte.MaxValue);
-                _data += (ulong)1 << SpinnerCountShift;
-            }
-
-            public void DecrementSpinnerCount()
-            {
-                Debug.Assert(SpinnerCount != 0);
-                _data -= (ulong)1 << SpinnerCountShift;
-            }
-
-            public byte CountOfWaitersSignaledToWake
-            {
-                get => GetByteValue(CountOfWaitersSignaledToWakeShift);
-                set => SetByteValue(value, CountOfWaitersSignaledToWakeShift);
-            }
-
-            public void AddUpToMaxCountOfWaitersSignaledToWake(uint value)
-            {
-                uint availableCount = (uint)(byte.MaxValue - CountOfWaitersSignaledToWake);
-                if (value > availableCount)
-                {
-                    value = availableCount;
-                }
                 _data += (ulong)value << CountOfWaitersSignaledToWakeShift;
+                var countsAfterUpdate = new Counts(_data);
+                Debug.Assert(countsAfterUpdate.CountOfWaitersSignaledToWake != ushort.MaxValue); // overflow check
             }
 
             public void DecrementCountOfWaitersSignaledToWake()

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelLifoSemaphore.cs
@@ -234,7 +234,7 @@ namespace System.Threading
             public Counts InterlockedIncrementSignalCount()
             {
                 var countsAfterUpdate = new Counts(Interlocked.Add(ref _data, 1ul << SignalCountShift));
-                Debug.Assert(countsAfterUpdate.SignalCount != ushort.MaxValue); // underflow check
+                Debug.Assert(countsAfterUpdate.SignalCount != ushort.MaxValue); // overflow check
                 return countsAfterUpdate;
             }
 
@@ -264,7 +264,7 @@ namespace System.Threading
             public void InterlockedDecrementWaiterCount()
             {
                 var countsAfterUpdate = new Counts(Interlocked.Add(ref _data, unchecked((ulong)-1) << WaiterCountShift));
-                Debug.Assert(countsAfterUpdate.WaiterCount != ushort.MaxValue); // overflow check
+                Debug.Assert(countsAfterUpdate.WaiterCount != ushort.MaxValue); // underflow check
             }
 
             public ushort CountOfWaitersSignaledToWake

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.Blocking.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.Blocking.cs
@@ -230,7 +230,8 @@ namespace System.Threading
                 HillClimbing.ThreadPoolHillClimber.ForceChange(
                     newNumThreadsGoal,
                     HillClimbing.StateOrTransition.CooperativeBlocking);
-                if (counts.NumProcessingWork >= numThreadsGoal && _separated.numRequestedWorkers > 0)
+
+                if (counts.NumProcessingWork >= numThreadsGoal && _separated._hasOutstandingThreadRequest != 0)
                 {
                     addWorker = true;
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.GateThread.cs
@@ -132,7 +132,7 @@ namespace System.Threading
 
                         if (!disableStarvationDetection &&
                             threadPoolInstance._pendingBlockingAdjustment == PendingBlockingAdjustment.None &&
-                            threadPoolInstance._separated.numRequestedWorkers > 0 &&
+                            threadPoolInstance._separated._hasOutstandingThreadRequest != 0 &&
                             SufficientDelaySinceLastDequeue(threadPoolInstance))
                         {
                             bool addWorker = false;
@@ -187,7 +187,7 @@ namespace System.Threading
                             }
                         }
 
-                        if (threadPoolInstance._separated.numRequestedWorkers <= 0 &&
+                        if (threadPoolInstance._separated._hasOutstandingThreadRequest == 0 &&
                             threadPoolInstance._pendingBlockingAdjustment == PendingBlockingAdjustment.None &&
                             Interlocked.Decrement(ref threadPoolInstance._separated.gateThreadRunningState) <= GetRunningStateForNumRuns(0))
                         {
@@ -208,7 +208,7 @@ namespace System.Threading
             // in deciding "too long"
             private static bool SufficientDelaySinceLastDequeue(PortableThreadPool threadPoolInstance)
             {
-                uint delay = (uint)(Environment.TickCount - threadPoolInstance._separated.lastDequeueTime);
+                uint delay = (uint)(Environment.TickCount - threadPoolInstance._separated.lastDispatchTime);
                 uint minimumDelay;
                 if (threadPoolInstance._cpuUtilization < CpuUtilizationLow)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.ThreadCounts.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.ThreadCounts.cs
@@ -60,7 +60,7 @@ namespace System.Threading
             }
 
             /// <summary>
-            /// Tries to increases the number of threads processing work items by one.
+            /// Tries to increase the number of threads processing work items by one.
             /// If at or above goal, returns false and sets overflow flag instead.
             /// NOTE: only if "true" is returned the NumProcessingWork is incremented.
             /// </summary>
@@ -82,7 +82,7 @@ namespace System.Threading
             }
 
             /// <summary>
-            /// Tries to reduces the number of threads processing work items by one.
+            /// Tries to reduce the number of threads processing work items by one.
             /// If in an overflow state, clears the overflow flag and returns false.
             /// NOTE: only if "true" is returned the NumProcessingWork is decremented.
             /// </summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.ThreadCounts.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.ThreadCounts.cs
@@ -44,13 +44,12 @@ namespace System.Threading
                 }
             }
 
-            // Returns "true" if TryIncrementProcessingWork could not
-            // increment NumProcessingWork due to the limit.
+            // Returns "true" if adding NumProcessingWork has reached the limit.
             // NOTE: it is possible to have overflow and NumProcessingWork under the limit
             // at the same time if the limit has been changed afterwards. That is ok.
-            // While changes in NumProcessingWork need to be matched with semaphore Waits/Releases,
+            // While changes in NumProcessingWork need to be matched with semaphore Wait/Signal,
             // the redundantly set overflow is mostly harmless and should self-correct when
-            // a worker that sees no work calls TryDecrementProcessingWork, possibly at cost of
+            // a worker that sees no work calls TryDecrementProcessingWork, possibly at a cost of
             // redundant check for work.
             public bool IsOverflow
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.ThreadCounts.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.ThreadCounts.cs
@@ -45,6 +45,17 @@ namespace System.Threading
             }
 
             /// <summary>
+            /// Reduces the number of threads processing work items by one.
+            /// </summary>
+            public void DecrementProcessingWork()
+            {
+                // This should never underflow
+                Debug.Assert(NumProcessingWork > 0);
+                Interlocked.Decrement(ref _data);
+                Debug.Assert(NumProcessingWork >= 0);
+            }
+
+            /// <summary>
             /// Number of thread pool threads that currently exist.
             /// </summary>
             public short NumExistingThreads

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.ThreadCounts.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.ThreadCounts.cs
@@ -45,13 +45,13 @@ namespace System.Threading
             }
 
             // Returns "true" if adding NumProcessingWork has reached the limit.
-            // NOTE: it is possible to have overflow and NumProcessingWork under the limit
-            // at the same time if the limit has been changed afterwards. That is ok.
+            // Note: it is possible to be in Saturated state while NumProcessingWork is under
+            // the limit if the limit has been changed after the state was set. That is ok.
             // While changes in NumProcessingWork need to be matched with semaphore Wait/Signal,
-            // the redundantly set overflow is mostly harmless and should self-correct when
+            // the redundantly set Saturated is mostly harmless and should self-correct when
             // a worker that sees no work calls TryDecrementProcessingWork, possibly at a cost of
             // redundant check for work.
-            public bool IsOverflow
+            public bool IsSaturated
             {
                 get
                 {
@@ -61,8 +61,8 @@ namespace System.Threading
 
             /// <summary>
             /// Tries to increase the number of threads processing work items by one.
-            /// If at or above goal, returns false and sets overflow flag instead.
-            /// NOTE: only if "true" is returned the NumProcessingWork is incremented.
+            /// If at or above goal, returns false and sets Saturated flag instead.
+            /// Note: only if "true" is returned the NumProcessingWork is incremented.
             /// </summary>
             public bool TryIncrementProcessingWork()
             {
@@ -83,13 +83,13 @@ namespace System.Threading
 
             /// <summary>
             /// Tries to reduce the number of threads processing work items by one.
-            /// If in an overflow state, clears the overflow flag and returns false.
-            /// NOTE: only if "true" is returned the NumProcessingWork is decremented.
+            /// If in a Saturated state, clears the Saturated state and returns false.
+            /// Note: only if "true" is returned the NumProcessingWork is decremented.
             /// </summary>
             public bool TryDecrementProcessingWork()
             {
                 Debug.Assert(NumProcessingWork > 0);
-                if (IsOverflow)
+                if (IsSaturated)
                 {
                     _data &= ~(1ul << 63);
                     return false;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -113,10 +113,9 @@ namespace System.Threading
 
                 while (true)
                 {
-                    bool spinWait = true;
-                    while (semaphore.Wait(timeoutMs, spinWait))
+                    while (semaphore.Wait(timeoutMs, true))
                     {
-                        WorkerDoWork(threadPoolInstance, ref spinWait);
+                        WorkerDoWork(threadPoolInstance);
                     }
 
                     // We've timed out waiting on the semaphore. Time to exit.
@@ -128,38 +127,28 @@ namespace System.Threading
                 }
             }
 
-            private static void WorkerDoWork(PortableThreadPool threadPoolInstance, ref bool spinWait)
+            private static void WorkerDoWork(PortableThreadPool threadPoolInstance)
             {
-                bool alreadyRemovedWorkingWorker = false;
 
-                // We allow the requests to be "stolen" by threads who are done dispatching,
-                // thus it is not guaranteed at this point that there is a request.
-                while (threadPoolInstance._separated._hasOutstandingThreadRequest != 0 &&
-                        Interlocked.Exchange(ref threadPoolInstance._separated._hasOutstandingThreadRequest, 0) != 0)
+                do
                 {
-                    // We took the request, now we must Dispatch some work items.
-                    threadPoolInstance.NotifyDispatchProgress(Environment.TickCount);
-                    if (!ThreadPoolWorkQueue.Dispatch())
+                    // We generally avoid spurious wakes as they are wasteful, so nearly 100% we should see a request.
+                    // However, we allow external wakes when thread goals change, which can result in "stolen" requests,
+                    // thus sometimes there is no active request and we need to check.
+                    if (Interlocked.Exchange(ref threadPoolInstance._separated._hasOutstandingThreadRequest, 0) != 0)
                     {
-                        // ShouldStopProcessingWorkNow() caused the thread to stop processing work, and it would have
-                        // already removed this working worker in the counts. This typically happens when hill climbing
-                        // decreases the worker thread count goal.
-                        alreadyRemovedWorkingWorker = true;
-                        break;
+                        // We took the request, now we must Dispatch some work items.
+                        threadPoolInstance.NotifyDispatchProgress(Environment.TickCount);
+                        if (!ThreadPoolWorkQueue.Dispatch())
+                        {
+                            // We are above goal and would have already removed this working worker in the counts.
+                            return;
+                        }
                     }
-                }
 
-                // Don't spin-wait on the semaphore next time if the thread was actively stopped from processing work,
-                // as it's unlikely that the worker thread count goal would be increased again so soon afterwards that
-                // the semaphore would be released within the spin-wait window
-                spinWait = !alreadyRemovedWorkingWorker;
-
-                if (!alreadyRemovedWorkingWorker)
-                {
-                    // If we woke up but couldn't find a request, or ran out of work items to process, we need to update
-                    // the number of working workers to reflect that we are done working for now
-                    RemoveWorkingWorker(threadPoolInstance);
-                }
+                    // We could not find more work in the queue.
+                    // if there is uncleared overflow we will be back again after clearing.
+                } while (!RemoveWorkingWorker(threadPoolInstance));
             }
 
             // returns true if the worker is shutting down
@@ -225,58 +214,49 @@ namespace System.Threading
             /// <summary>
             /// Reduce the number of working workers by one, but maybe add back a worker (possibily this thread) if a thread request comes in while we are marking this thread as not working.
             /// </summary>
-            private static void RemoveWorkingWorker(PortableThreadPool threadPoolInstance)
+            private static bool RemoveWorkingWorker(PortableThreadPool threadPoolInstance)
             {
-                threadPoolInstance._separated.counts.DecrementProcessingWork();
-
-                // It's possible that a thread request was not actionable due to being at max active threads.
-                // Now we may be able to add a thread and if we can we must add.
-                // Otherwise, if all workers happen to quit at once, there will be noone left running while
-                // there is a request.
-
-                // NOTE: The request check must happen after the active count was updated,
-                // which the interlocked decrement guarantees.
-
-                if (threadPoolInstance._separated._hasOutstandingThreadRequest != 0)
+                while (true)
                 {
-                    MaybeAddWorkingWorker(threadPoolInstance);
+                    ThreadCounts oldCounts = threadPoolInstance._separated.counts;
+                    ThreadCounts newCounts = oldCounts;
+                    bool decremented = newCounts.TryDecrementProcessingWork();
+                    if (threadPoolInstance._separated.counts.InterlockedCompareExchange(newCounts, oldCounts) == oldCounts)
+                    {
+                        return decremented;
+                    }
+
+                    // TODO: VS expowait, many threads could be exiting at once
                 }
             }
 
             internal static void MaybeAddWorkingWorker(PortableThreadPool threadPoolInstance)
             {
-                ThreadCounts counts = threadPoolInstance._separated.counts;
-                short numExistingThreads, numProcessingWork, newNumExistingThreads, newNumProcessingWork;
+                ThreadCounts oldCounts, newCounts;
+                bool incremented;
                 while (true)
                 {
-                    numProcessingWork = counts.NumProcessingWork;
-                    if (numProcessingWork >= counts.NumThreadsGoal)
-                    {
-                        return;
-                    }
-
-                    newNumProcessingWork = (short)(numProcessingWork + 1);
-                    numExistingThreads = counts.NumExistingThreads;
-                    newNumExistingThreads = Math.Max(numExistingThreads, newNumProcessingWork);
-
-                    ThreadCounts newCounts = counts;
-                    newCounts.NumProcessingWork = newNumProcessingWork;
-                    newCounts.NumExistingThreads = newNumExistingThreads;
-
-                    ThreadCounts oldCounts = threadPoolInstance._separated.counts.InterlockedCompareExchange(newCounts, counts);
-
-                    if (oldCounts == counts)
+                    oldCounts = threadPoolInstance._separated.counts;
+                    newCounts = oldCounts;
+                    incremented = newCounts.TryIncrementProcessingWork();
+                    newCounts.NumExistingThreads = Math.Max(newCounts.NumProcessingWork, newCounts.NumExistingThreads);
+                    if (threadPoolInstance._separated.counts.InterlockedCompareExchange(newCounts, oldCounts) == oldCounts)
                     {
                         break;
                     }
 
-                    counts = oldCounts;
+                    // TODO: VS expowait? the add is rarely concurrent, perhaps not
                 }
 
-                Debug.Assert(newNumProcessingWork - numProcessingWork == 1);
+                if (!incremented)
+                {
+                    return;
+                }
+
+                Debug.Assert(newCounts.NumProcessingWork - oldCounts.NumProcessingWork == 1);
                 s_semaphore.Release(1);
 
-                int toCreate = newNumExistingThreads - numExistingThreads;
+                int toCreate = newCounts.NumExistingThreads - oldCounts.NumExistingThreads;
                 Debug.Assert(toCreate == 0 || toCreate == 1);
                 if (toCreate != 0)
                 {
@@ -298,10 +278,7 @@ namespace System.Threading
                     // When there are more threads processing work than the thread count goal, it may have been decided
                     // to decrease the number of threads. Stop processing if the counts can be updated. We may have more
                     // threads existing than the thread count goal and that is ok, the cold ones will eventually time out if
-                    // the thread count goal is not increased again. This logic is a bit different from the original CoreCLR
-                    // code from which this implementation was ported, which turns a processing thread into a retired thread
-                    // and checks for pending requests like RemoveWorkingWorker. In this implementation there are
-                    // no retired threads, so only the count of threads processing work is considered.
+                    // the thread count goal is not increased again.
                     if (counts.NumProcessingWork <= counts.NumThreadsGoal)
                     {
                         return false;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -16,7 +16,11 @@ namespace System.Threading
         {
             private static readonly short ThreadsToKeepAlive = DetermineThreadsToKeepAlive();
 
-            private const int SemaphoreSpinCountDefault = 10;
+            // Spinning in the threadpool semaphore is not always useful.
+            // For example the new workitems may be produced by non-pool threads and could only arrive if pool threads start blocking.
+            // We will limit spinning to roughly 512-1024 spinwaits, each taking 35-50ns. That should be under 50 usec total.
+            // For reference the wakeup latency of a futex/event with threads queued up is reported to be in 5-50 usec range. (year 2025)
+            private const int SemaphoreSpinCountDefault = 9;
 
             // This value represents an assumption of how much uncommitted stack space a worker thread may use in the future.
             // Used in calculations to estimate when to throttle the rate of thread injection to reduce the possibility of
@@ -43,7 +47,6 @@ namespace System.Threading
             /// </summary>
             private static readonly LowLevelLifoSemaphore s_semaphore =
                 new LowLevelLifoSemaphore(
-                    0,
                     MaxPossibleThreadCount,
                     AppContextConfigHelper.GetInt32ComPlusOrDotNetConfig(
                         "System.Threading.ThreadPool.UnfairSemaphoreSpinLimit",

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -16,7 +16,7 @@ namespace System.Threading
         {
             private static readonly short ThreadsToKeepAlive = DetermineThreadsToKeepAlive();
 
-            private const int SemaphoreSpinCountDefault = 70;
+            private const int SemaphoreSpinCountDefault = 10;
 
             // This value represents an assumption of how much uncommitted stack space a worker thread may use in the future.
             // Used in calculations to estimate when to throttle the rate of thread injection to reduce the possibility of

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.WorkerThread.cs
@@ -240,7 +240,7 @@ namespace System.Threading
 
             /// In a state of overflow does nothing.
             /// Otherwise increments the active worker count and signals the semaphore.
-            /// Incrementing the count may turn on the overflow state if the active thread limit is reached.
+            /// Incrementing the count turns on the overflow state if the active thread limit is reached.
             internal static void MaybeAddWorkingWorker(PortableThreadPool threadPoolInstance)
             {
                 ThreadCounts oldCounts, newCounts;
@@ -257,7 +257,7 @@ namespace System.Threading
                         break;
                     }
 
-                    // This is less contentious than Remove as reasons to add threads are more complex and typically staged.
+                    // This is less contentious than Remove as reasons to add threads are more complex to avoid adding too many too fast.
                     // We can still see some amount of failed interlocked operations here when a burst of work is scheduled.
                     Backoff.Exponential(collisionCount++);
                 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.cs
@@ -87,8 +87,10 @@ namespace System.Threading
             [FieldOffset(Internal.PaddingHelpers.CACHE_LINE_SIZE * 1)]
             public ThreadCounts counts; // SOS's ThreadPool command depends on this name
 
+            // Periodically updated heartbeat timestamp to indicate that we are making progress.
+            // Used in starvation detection.
             [FieldOffset(Internal.PaddingHelpers.CACHE_LINE_SIZE * 2)]
-            public int lastDequeueTime;
+            public int lastDispatchTime;
 
             [FieldOffset(Internal.PaddingHelpers.CACHE_LINE_SIZE * 3)]
             public int priorCompletionCount;
@@ -97,8 +99,20 @@ namespace System.Threading
             [FieldOffset(Internal.PaddingHelpers.CACHE_LINE_SIZE * 3 + sizeof(int) * 2)]
             public int nextCompletedWorkRequestsTime;
 
+            // This flag is used for communication between item enqueuing and workers that process the items.
+            // There are two states of this flag:
+            // 0: has no guarantees
+            // 1: means a worker will check work queues and ensure that
+            //    any work items inserted in work queue before setting the flag
+            //    are picked up.
+            //    Note: The state must be cleared by the worker thread _before_
+            //       checking. Otherwise there is a window between finding no work
+            //       and resetting the flag, when the flag is in a wrong state.
+            //       A new work item may be added right before the flag is reset
+            //       without asking for a worker, while the last worker is quitting.
             [FieldOffset(Internal.PaddingHelpers.CACHE_LINE_SIZE * 4)]
-            public volatile int numRequestedWorkers;
+            public int _hasOutstandingThreadRequest;
+
             [FieldOffset(Internal.PaddingHelpers.CACHE_LINE_SIZE * 4 + sizeof(int))]
             public int gateThreadRunningState;
         }
@@ -209,7 +223,7 @@ namespace System.Threading
                 else if (_separated.counts.NumThreadsGoal < newMinThreads)
                 {
                     _separated.counts.InterlockedSetNumThreadsGoal(newMinThreads);
-                    if (_separated.numRequestedWorkers > 0)
+                    if (_separated._hasOutstandingThreadRequest != 0)
                     {
                         addWorker = true;
                     }
@@ -330,26 +344,30 @@ namespace System.Threading
             return threadLocalCompletionCountNode;
         }
 
-        private void NotifyWorkItemProgress(ThreadInt64PersistentCounter.ThreadLocalNode threadLocalCompletionCountNode, int currentTimeMs)
+        private static void NotifyWorkItemProgress(ThreadInt64PersistentCounter.ThreadLocalNode threadLocalCompletionCountNode)
         {
             threadLocalCompletionCountNode.Increment();
-            _separated.lastDequeueTime = currentTimeMs;
+        }
 
+        internal void NotifyWorkItemProgress()
+        {
+            NotifyWorkItemProgress(GetOrCreateThreadLocalCompletionCountNode());
+        }
+
+        internal bool NotifyWorkItemComplete(ThreadInt64PersistentCounter.ThreadLocalNode threadLocalCompletionCountNode, int currentTimeMs)
+        {
+            NotifyWorkItemProgress(threadLocalCompletionCountNode);
             if (ShouldAdjustMaxWorkersActive(currentTimeMs))
             {
                 AdjustMaxWorkersActive();
             }
+
+            return !WorkerThread.ShouldStopProcessingWorkNow(this);
         }
 
-        internal void NotifyWorkItemProgress() =>
-            NotifyWorkItemProgress(GetOrCreateThreadLocalCompletionCountNode(), Environment.TickCount);
-
-        internal bool NotifyWorkItemComplete(ThreadInt64PersistentCounter.ThreadLocalNode? threadLocalCompletionCountNode, int currentTimeMs)
+        internal void NotifyDispatchProgress(int currentTickCount)
         {
-            Debug.Assert(threadLocalCompletionCountNode != null);
-
-            NotifyWorkItemProgress(threadLocalCompletionCountNode, currentTimeMs);
-            return !WorkerThread.ShouldStopProcessingWorkNow(this);
+            _separated.lastDispatchTime = currentTickCount;
         }
 
         //
@@ -459,13 +477,15 @@ namespace System.Threading
             return _pendingBlockingAdjustment == PendingBlockingAdjustment.None;
         }
 
-        internal void RequestWorker()
+        internal void EnsureWorkerRequested()
         {
-            // The order of operations here is important. MaybeAddWorkingWorker() and EnsureRunning() use speculative checks to
-            // do their work and the memory barrier from the interlocked operation is necessary in this case for correctness.
-            Interlocked.Increment(ref _separated.numRequestedWorkers);
-            WorkerThread.MaybeAddWorkingWorker(this);
-            GateThread.EnsureRunning(this);
+            // Only one worker is requested at a time to mitigate Thundering Herd problem.
+            if (_separated._hasOutstandingThreadRequest == 0 &&
+                Interlocked.Exchange(ref _separated._hasOutstandingThreadRequest, 1) == 0)
+            {
+                WorkerThread.MaybeAddWorkingWorker(this);
+                GateThread.EnsureRunning(this);
+            }
         }
 
         private bool OnGen2GCCallback()

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Threads.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.Threads.cs
@@ -8,6 +8,7 @@ namespace System.Threading
         // Indicates that the threadpool should yield the thread from the dispatch loop to the
         // runtime periodically.  We use this to return back to the JS event loop so that the JS
         // event queue can be drained
-        internal static bool YieldFromDispatchLoop => true;
+#pragma warning disable IDE0060 // Remove unused parameter
+        internal static bool YieldFromDispatchLoop(int currentTickCount) => true;
+#pragma warning restore IDE0060    }
     }
-}

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Browser.cs
@@ -35,7 +35,9 @@ namespace System.Threading
     {
         // Indicates whether the thread pool should yield the thread from the dispatch loop to the runtime periodically so that
         // the runtime may use the thread for processing other work
-        internal static bool YieldFromDispatchLoop => true;
+#pragma warning disable IDE0060 // Remove unused parameter
+        internal static bool YieldFromDispatchLoop(int currentTickCount) => true;
+#pragma warning restore IDE0060
 
         private const bool IsWorkerTrackingEnabledInConfig = false;
 
@@ -78,7 +80,7 @@ namespace System.Threading
         public static long CompletedWorkItemCount => 0;
 
         [DynamicDependency("BackgroundJobHandler")] // https://github.com/dotnet/runtime/issues/101434
-        internal static unsafe void RequestWorkerThread()
+        internal static unsafe void EnsureWorkerRequested()
         {
             if (_callbackQueued)
                 return;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Unix.cs
@@ -19,7 +19,11 @@ namespace System.Threading
 #if !(TARGET_BROWSER && FEATURE_WASM_MANAGED_THREADS)
         // Indicates whether the thread pool should yield the thread from the dispatch loop to the runtime periodically so that
         // the runtime may use the thread for processing other work.
-        internal static bool YieldFromDispatchLoop => false;
+        internal static bool YieldFromDispatchLoop(int currentTickCount)
+        {
+            PortableThreadPool.ThreadPoolInstance.NotifyDispatchProgress(currentTickCount);
+            return false;
+        }
 #endif
 
         internal static ThreadInt64PersistentCounter.ThreadLocalNode GetOrCreateThreadLocalCompletionCountNode() =>
@@ -67,9 +71,9 @@ namespace System.Threading
         /// <summary>
         /// This method is called to request a new thread pool worker to handle pending work.
         /// </summary>
-        internal static unsafe void RequestWorkerThread()
+        internal static unsafe void EnsureWorkerRequested()
         {
-            PortableThreadPool.ThreadPoolInstance.RequestWorker();
+            PortableThreadPool.ThreadPoolInstance.EnsureWorkerRequested();
         }
 
         internal static void ReportThreadStatus(bool isWorking)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Wasi.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Wasi.cs
@@ -35,7 +35,9 @@ namespace System.Threading
     {
         // Indicates whether the thread pool should yield the thread from the dispatch loop to the runtime periodically so that
         // the runtime may use the thread for processing other work
-        internal static bool YieldFromDispatchLoop => true;
+#pragma warning disable IDE0060 // Remove unused parameter
+        internal static bool YieldFromDispatchLoop(int currentTickCount) => true;
+#pragma warning restore IDE0060
 
         private const bool IsWorkerTrackingEnabledInConfig = false;
 
@@ -75,7 +77,7 @@ namespace System.Threading
 
         public static long CompletedWorkItemCount => 0;
 
-        internal static unsafe void RequestWorkerThread()
+        internal static unsafe void EnsureWorkerRequested()
         {
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.Windows.cs
@@ -30,11 +30,19 @@ namespace System.Threading
 
         // Indicates whether the thread pool should yield the thread from the dispatch loop to the runtime periodically so that
         // the runtime may use the thread for processing other work.
-        //
-        // Windows thread pool threads need to yield back to the thread pool periodically, otherwise those threads may be
-        // considered to be doing long-running work and change thread pool heuristics, such as slowing or halting thread
-        // injection.
-        internal static bool YieldFromDispatchLoop => UseWindowsThreadPool;
+        internal static bool YieldFromDispatchLoop(int currentTickCount)
+        {
+            if (UseWindowsThreadPool)
+            {
+                // Windows thread pool threads need to yield back to the thread pool periodically, otherwise those threads may be
+                // considered to be doing long-running work and change thread pool heuristics, such as slowing or halting thread
+                // injection.
+                return true;
+            }
+
+            PortableThreadPool.ThreadPoolInstance.NotifyDispatchProgress(currentTickCount);
+            return false;
+        }
 
         [CLSCompliant(false)]
         [SupportedOSPlatform("windows")]
@@ -155,17 +163,24 @@ namespace System.Threading
         }
 
         /// <summary>
-        /// This method is called to request a new thread pool worker to handle pending work.
+        /// This method is called to notify the thread pool about pending work.
+        /// It will start with an ordinary read to check if a request is already pending as we
+        /// optimize for a case when queues already have items and this flag is already set.
+        /// Make sure that the presence of the item that is being added to the queue is visible
+        /// before calling this.
+        /// Typically this is not a problem when enqueing uses an interlocked update of the queue
+        /// index to establish the presence of the new item. More care may be needed when an item
+        /// is inserted via ordinary or volatile writes.
         /// </summary>
-        internal static void RequestWorkerThread()
+        internal static void EnsureWorkerRequested()
         {
             if (ThreadPool.UseWindowsThreadPool)
             {
-                WindowsThreadPool.RequestWorkerThread();
+                WindowsThreadPool.EnsureWorkerRequested();
             }
             else
             {
-                PortableThreadPool.ThreadPoolInstance.RequestWorker();
+                PortableThreadPool.ThreadPoolInstance.EnsureWorkerRequested();
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -127,7 +127,11 @@ namespace System.Threading
                 // When there are at least 2 elements' worth of space, we can take the fast path.
                 if (tail < m_headIndex + m_mask)
                 {
-                    Volatile.Write(ref m_array[tail & m_mask], obj);
+                    m_array[tail & m_mask] = obj;
+                    // The following write makes the slot to "appear" in the queue.
+                    // It must happen after the write of the item, and it does, since m_tailIndex is volatile.
+                    // NOTE: we also must be sure this write is not delayed past our check for a
+                    // pending thread request.
                     m_tailIndex = tail + 1;
                 }
                 else
@@ -156,7 +160,11 @@ namespace System.Threading
                             m_mask = (m_mask << 1) | 1;
                         }
 
-                        Volatile.Write(ref m_array[tail & m_mask], obj);
+                        m_array[tail & m_mask] = obj;
+                        // The following write makes the slot to "appear" in the queue.
+                        // It must happen after the write of the item, and it does, since m_tailIndex is volatile.
+                        // NOTE: we also must be sure this write is not delayed past our check for a
+                        // pending thread request.
                         m_tailIndex = tail + 1;
                     }
                     finally
@@ -165,6 +173,10 @@ namespace System.Threading
                             m_foreignLock.Exit(useMemoryBarrier: false);
                     }
                 }
+
+                // Our caller will check for a thread request now (with an ordinary read),
+                // make sure the check happens after the new slot appears in the queue.
+                Interlocked.MemoryBarrier();
             }
 
             [MethodImpl(MethodImplOptions.NoInlining)]
@@ -410,7 +422,6 @@ namespace System.Threading
 
         private bool _loggingEnabled;
         private bool _dispatchNormalPriorityWorkFirst;
-        private bool _mayHaveHighPriorityWorkItems;
 
         // SOS's ThreadPool command depends on the following names
         internal readonly WorkQueue workItems = new WorkQueue();
@@ -430,29 +441,6 @@ namespace System.Threading
         private readonly LowLevelLock _queueAssignmentLock = new();
         private readonly int[] _assignedWorkItemQueueThreadCounts =
             s_assignableWorkItemQueueCount > 0 ? new int[s_assignableWorkItemQueueCount] : Array.Empty<int>();
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct CacheLineSeparated
-        {
-            private readonly Internal.PaddingFor32 pad1;
-
-            // This flag is used for communication between item enqueuing and workers that process the items.
-            // There are two states of this flag:
-            // 0: has no guarantees
-            // 1: means a worker will check work queues and ensure that
-            //    any work items inserted in work queue before setting the flag
-            //    are picked up.
-            //    Note: The state must be cleared by the worker thread _before_
-            //       checking. Otherwise there is a window between finding no work
-            //       and resetting the flag, when the flag is in a wrong state.
-            //       A new work item may be added right before the flag is reset
-            //       without asking for a worker, while the last worker is quitting.
-            public int _hasOutstandingThreadRequest;
-
-            private readonly Internal.PaddingFor32 pad2;
-        }
-
-        private CacheLineSeparated _separated;
 
         public ThreadPoolWorkQueue()
         {
@@ -572,7 +560,7 @@ namespace System.Threading
 
             if (movedWorkItem)
             {
-                EnsureThreadRequested();
+                ThreadPool.EnsureWorkerRequested();
             }
         }
 
@@ -608,16 +596,6 @@ namespace System.Threading
             _loggingEnabled = FrameworkEventSource.Log.IsEnabled(EventLevel.Verbose, FrameworkEventSource.Keywords.ThreadPool | FrameworkEventSource.Keywords.ThreadTransfer);
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void EnsureThreadRequested()
-        {
-            // Only one worker is requested at a time to mitigate Thundering Herd problem.
-            if (Interlocked.Exchange(ref _separated._hasOutstandingThreadRequest, 1) == 0)
-            {
-                ThreadPool.RequestWorkerThread();
-            }
-        }
-
         public void Enqueue(object callback, bool forceGlobal)
         {
             Debug.Assert((callback is IThreadPoolWorkItem) ^ (callback is Task));
@@ -648,7 +626,7 @@ namespace System.Threading
                 }
             }
 
-            EnsureThreadRequested();
+            ThreadPool.EnsureWorkerRequested();
         }
 
 #if CORECLR
@@ -696,10 +674,7 @@ namespace System.Threading
 
             highPriorityWorkItems.Enqueue(workItem);
 
-            // If the change below is seen by another thread, ensure that the enqueued work item will also be visible
-            Volatile.Write(ref _mayHaveHighPriorityWorkItems, true);
-
-            EnsureThreadRequested();
+            ThreadPool.EnsureWorkerRequested();
         }
 
         internal static void TransferAllLocalWorkItemsToHighPriorityGlobalQueue()
@@ -713,39 +688,32 @@ namespace System.Threading
             // Pop each work item off the local queue and push it onto the global. This is a
             // bounded loop as no other thread is allowed to push into this thread's queue.
             ThreadPoolWorkQueue queue = ThreadPool.s_workQueue;
-            bool addedHighPriorityWorkItem = false;
-            bool ensureThreadRequest = false;
+            bool ensureWorkerRequest = false;
             while (tl.workStealingQueue.LocalPop() is object workItem)
             {
+                // A work item had been removed temporarily and other threads may have missed stealing it, so ensure that
+                // there will be a thread request
+                ensureWorkerRequest = true;
+
                 // If there's an unexpected exception here that happens to get handled, the lost work item, or missing thread
                 // request, etc., may lead to other issues. A fail-fast or try-finally here could reduce the effect of such
                 // uncommon issues to various degrees, but it's also uncommon to check for unexpected exceptions.
                 try
                 {
                     queue.highPriorityWorkItems.Enqueue(workItem);
-                    addedHighPriorityWorkItem = true;
                 }
                 catch (OutOfMemoryException)
                 {
                     // This is not expected to throw under normal circumstances
                     tl.workStealingQueue.LocalPush(workItem);
 
-                    // A work item had been removed temporarily and other threads may have missed stealing it, so ensure that
-                    // there will be a thread request
-                    ensureThreadRequest = true;
                     break;
                 }
             }
 
-            if (addedHighPriorityWorkItem)
+            if (ensureWorkerRequest)
             {
-                Volatile.Write(ref queue._mayHaveHighPriorityWorkItems, true);
-                ensureThreadRequest = true;
-            }
-
-            if (ensureThreadRequest)
-            {
-                queue.EnsureThreadRequested();
+                ThreadPool.EnsureWorkerRequested();
             }
         }
 
@@ -774,9 +742,11 @@ namespace System.Threading
 
                 tl.isProcessingHighPriorityWorkItems = false;
             }
-            else if (
-                _mayHaveHighPriorityWorkItems &&
-                Interlocked.CompareExchange(ref _mayHaveHighPriorityWorkItems, false, true) &&
+#if FEATURE_SINGLE_THREADED
+            else if (highPriorityWorkItems.Count == 0 &&
+#else
+            else if (!highPriorityWorkItems.IsEmpty &&
+#endif
                 TryStartProcessingHighPriorityWorkItemsAndDequeue(tl, out workItem))
             {
                 return workItem;
@@ -855,7 +825,6 @@ namespace System.Threading
             }
 
             tl.isProcessingHighPriorityWorkItems = true;
-            _mayHaveHighPriorityWorkItems = true;
             return true;
         }
 
@@ -934,33 +903,15 @@ namespace System.Threading
         {
             ThreadPoolWorkQueue workQueue = ThreadPool.s_workQueue;
             ThreadPoolWorkQueueThreadLocals tl = workQueue.GetOrCreateThreadLocals();
-
-            if (s_assignableWorkItemQueueCount > 0)
-            {
-                workQueue.AssignWorkItemQueue(tl);
-            }
-
-            // Before dequeuing the first work item, acknowledge that the thread request has been satisfied
-            workQueue._separated._hasOutstandingThreadRequest = 0;
-
-            // The state change must happen before sweeping queues for items.
-            Interlocked.MemoryBarrier();
-
             object? workItem = DequeueWithPriorityAlternation(workQueue, tl, out bool missedSteal);
             if (workItem == null)
             {
-                if (s_assignableWorkItemQueueCount > 0)
-                {
-                    workQueue.UnassignWorkItemQueue(tl);
-                }
-
                 // Missing a steal means there may be an item that we were unable to get.
-                // Effectively, we failed to fulfill our promise to check the queues after
-                // clearing "Scheduled" flag.
+                // Effectively, we failed to fulfill our promise to check the queues for work.
                 // We need to make sure someone will do another pass.
                 if (missedSteal)
                 {
-                    workQueue.EnsureThreadRequested();
+                    ThreadPool.EnsureWorkerRequested();
                 }
 
                 // Tell the VM we're returning normally, not because Hill Climbing asked us to return.
@@ -972,11 +923,17 @@ namespace System.Threading
             // In a worst case the current workitem will indirectly depend on progress of other
             // items and that would lead to a deadlock if no one else checks the queue.
             // We must ensure at least one more worker is coming if the queue is not empty.
-            workQueue.EnsureThreadRequested();
+            ThreadPool.EnsureWorkerRequested();
 
             //
             // After this point, this method is no longer responsible for ensuring thread requests except for missed steals
             //
+
+            if (s_assignableWorkItemQueueCount > 0)
+            {
+                // NOTE: this takes locks and may block and spend unknown time blocked.
+                workQueue.AssignWorkItemQueue(tl);
+            }
 
             // Has the desire for logging changed since the last time we entered?
             workQueue.RefreshLoggingEnabled();
@@ -1019,7 +976,7 @@ namespace System.Threading
                         //
                         if (missedSteal)
                         {
-                            workQueue.EnsureThreadRequested();
+                            ThreadPool.EnsureWorkerRequested();
                         }
 
                         return true;
@@ -1089,7 +1046,7 @@ namespace System.Threading
 
                 // The quantum expired, do any necessary periodic activities
 
-                if (ThreadPool.YieldFromDispatchLoop)
+                if (ThreadPool.YieldFromDispatchLoop(currentTickCount))
                 {
                     // The runtime-specific thread pool implementation requires the Dispatch loop to return to the VM
                     // periodically to let it perform its own work

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -931,7 +931,6 @@ namespace System.Threading
 
             if (s_assignableWorkItemQueueCount > 0)
             {
-                // NOTE: this takes locks and may block and spend unknown time blocked.
                 workQueue.AssignWorkItemQueue(tl);
             }
 


### PR DESCRIPTION
This is a follow up on recommendations from Scalability Experiments done some time ago. 

The Scalability Experiments resulted in many suggestions. In this part we look at overheads of submitting and executing a workitem to the threadpool from the thread scheduling point of view. In particular - this PR tries to minimize changes to the workqueue to scope the changes. 
The workqueue related recommendations will be addressed separately. 

The threadpool parts are very interconnected though, and sometimes removing one bottleneck results in another one to show up, so some workqueue changes had to be done, just to avoid regressions.

There are also a few "low hanging fruit" fixes for per-workitem overheads like unnecessary fences or too frequent modifications of shared state. 
Hopefully this will negate some of the regressions from https://github.com/dotnet/runtime/pull/121887  (as was reported in https://github.com/dotnet/runtime/issues/122186)


In this change:
- fewer operations per work item where possible. 
  such as fewer/weaker fences where possible, reporting heartbeat once per dispatch quantum vs. per each workitem, etc..

- avoid spurious wakes of worker threads. (except, unavoidably, when thread goal is changed - by HillClimb and such). 
  only one thread is requested at a time. requesting another thread is conditioned on evidence of work present in the queue (basically the minimum required for correctness). 
  as a result a thread that becomes active typically finds work.
  in particular this avoids a cascade of spurious wakes when pool is running out of workitems.

- stop tracking spinners count in LIFO semaphore. 
  we can keep track of spinners, but informational value of knowing the extremely transient count is close to zero, so we should not. 

- no Sleep in LIFO semaphore.
  using spin-Sleep is questionable in a synchronization feature that can block and ask OS to wake a thread deterministically.

- shortening spinning in the LIFO semaphore to a more affordable value. 
  since the LIFO semaphore can perform a blocking wait until condition it wants to see happens, once spinning gets into the range of wait/wake latency, it makes no sense to spin for much longer.
  it is also not uncommon that the work is introduced by non-pool threads, thus the pool threads may have to block just to allow for more work to be scheduled.

