### PR TITLE
[LoongArch64] Align PR#108419: Verify TLS resolver code for LA64.

### DIFF
--- a/src/tests/JIT/Directed/tls/CMakeLists.txt
+++ b/src/tests/JIT/Directed/tls/CMakeLists.txt
@@ -6,3 +6,7 @@ include_directories(${INC_PLATFORM_DIR})
 add_library(usetls SHARED testtls.cpp)
 
 install (TARGETS usetls DESTINATION bin)
+
+if(CLR_CMAKE_TARGET_ARCH_LOONGARCH64)
+    add_definitions(-mtls-dialect=desc)
+endif()


### PR DESCRIPTION
* Align [PR#108419](https://github.com/dotnet/runtime/pull/108419): Verify TLS resolver code for LA64.
* Add `-mtls-dialect=desc` compile parameters for TestTLSWithLoadedDlls.sh to enble `R_LARCH_TLS_DESC6` relocation type.