### PR TITLE
Handle QueueUserAPC2 failure during thread suspension

### DIFF
--- a/src/coreclr/nativeaot/Runtime/windows/PalMinWin.cpp
+++ b/src/coreclr/nativeaot/Runtime/windows/PalMinWin.cpp
@@ -774,9 +774,6 @@ void PalHijack(Thread* pThreadToHijack)
         DWORD lastError = GetLastError();
         if (lastError != ERROR_INVALID_PARAMETER && lastError != ERROR_NOT_SUPPORTED)
         {
-            // An unexpected failure has happened. It is a concern.
-            ASSERT_UNCONDITIONALLY("Failed to queue an APC for unusual reason.");
-
             // maybe it will work next time.
             return;
         }

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -5949,8 +5949,11 @@ bool Thread::InjectActivation(ActivationReason reason)
             hThread,
             (ULONG_PTR)reason,
             SpecialUserModeApcWithContextFlags);
-    _ASSERTE(success);
-    return true;
+    if (!success)
+    {
+        m_hasPendingActivation = false;
+    }
+    return success;
 #elif defined(TARGET_UNIX)
     _ASSERTE((reason == ActivationReason::SuspendForGC) || (reason == ActivationReason::ThreadAbort) || (reason == ActivationReason::SuspendForDebugger));
 


### PR DESCRIPTION
QueueUserAPC2 can fail when the machine is under stress. Handle the failure gracefully.

Fixes #122763