### PR TITLE
Fix file descriptor leak

### DIFF
--- a/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
+++ b/src/native/libs/System.Security.Cryptography.Native/pal_x509.c
@@ -454,6 +454,7 @@ static DIR* OpenUserStore(const char* storePath, char** pathTmp, size_t* pathTmp
     char* tmp = (char*)calloc(allocSize, sizeof(char));
     if (!tmp)
     {
+        closedir(trustDir);
         *pathTmp = NULL;
         *nextFileWrite = NULL;
         return NULL;


### PR DESCRIPTION
The storePath file is opened in the line `DIR* trustDir = opendir(storePath);` and should be closed when the function returns on case of out of memory.

Signed-off-by: Aleksandr Dovydenkov asd@altlinux.org.
Found by Linux Verification Center (linuxtesting.org) with SVACE.