### PR TITLE
[browser] provide dummy icon and template icon

### DIFF
--- a/src/coreclr/hosts/corerun/wasm/corerun.html
+++ b/src/coreclr/hosts/corerun/wasm/corerun.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>corerun-wasm</title>
+    <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
 </head>
 <body>
     <h1>corerun-wasm</h1>

--- a/src/coreclr/pal/tests/palsuite/wasm/index.html
+++ b/src/coreclr/pal/tests/palsuite/wasm/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <title>PAL Tests WASM</title>
+    <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
 </head>
 <body>
     <h1>PAL Tests WASM</h1>

--- a/src/mono/browser/test-index.html
+++ b/src/mono/browser/test-index.html
@@ -1,2 +1,1 @@
-<!DOCTYPE html>
-<html><body><script type='module' src='test-main.js'></script></body></html>
+<!DOCTYPE html><html><head><link rel="icon" href="data:image/png;base64,iVBORw0KGgo="></head><body><script type='module' src='test-main.js'></script></body></html>

--- a/src/mono/sample/mbr/browser/wwwroot/index.html
+++ b/src/mono/sample/mbr/browser/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>Hot Reload Sample</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type='module' src="./main.js"></script>

--- a/src/mono/sample/wasm/browser-advanced/wwwroot/index.html
+++ b/src/mono/sample/wasm/browser-advanced/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>Wasm Browser Advanced Sample</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval';" />

--- a/src/mono/sample/wasm/browser-bench/wwwroot/appstart-frame.html
+++ b/src/mono/sample/wasm/browser-bench/wwwroot/appstart-frame.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>App task</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type="module" src="./frame-main.js"></script>

--- a/src/mono/sample/wasm/browser-bench/wwwroot/index.html
+++ b/src/mono/sample/wasm/browser-bench/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>Benchmark Sample</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="style.css">

--- a/src/mono/sample/wasm/browser-eventpipe/wwwroot/index.html
+++ b/src/mono/sample/wasm/browser-eventpipe/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>Sample EventPipe profile session</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type='module' src="./main.js"></script>
@@ -13,11 +14,11 @@
 <body>
   <h3 id="header">Wasm Browser EventPipe profiling Sample</h3>
   <div>
-    <br/>
-    <br/>
+    <br />
+    <br />
     <button id="hello-button">Say Hi</button>
-    <br/>
-    <br/>
+    <br />
+    <br />
   </div>
   Answer to the Ultimate Question is : <span id="out"></span>
 </body>

--- a/src/mono/sample/wasm/browser-logprofile/wwwroot/index.html
+++ b/src/mono/sample/wasm/browser-logprofile/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>Log Profiler Sample</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type='module' src="./main.js"></script>

--- a/src/mono/sample/wasm/browser-profile/wwwroot/index.html
+++ b/src/mono/sample/wasm/browser-profile/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>Profiler Sample</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type='module' src="./main.js"></script>

--- a/src/mono/sample/wasm/browser-shutdown/wwwroot/index.html
+++ b/src/mono/sample/wasm/browser-shutdown/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>Wasm Browser Shutdown Sample</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type='module' src="./main.js"></script>

--- a/src/mono/sample/wasm/browser-threads/wwwroot/index.html
+++ b/src/mono/sample/wasm/browser-threads/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
     <title>Wasm Browser Sample</title>
+    <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <script type='module' src="./main.js"></script>

--- a/src/mono/sample/wasm/browser/wwwroot/index.html
+++ b/src/mono/sample/wasm/browser/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>Wasm Browser Sample</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type='module' src="./main.js"></script>

--- a/src/mono/sample/wasm/simple-raytracer/wwwroot/index.html
+++ b/src/mono/sample/wasm/simple-raytracer/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>Simple wasm raytracer</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="modulepreload" href="./main.js" />

--- a/src/mono/wasm/templates/templates/browser/wwwroot/index.html
+++ b/src/mono/wasm/templates/templates/browser/wwwroot/index.html
@@ -5,7 +5,7 @@
 
 <head>
   <title>browser.0</title>
-  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAFo9M/3AAAACXBIWXMAAA7DAAAOwwHHb6hkAAAAaklEQVR4nGII1L7yH4QZQAQIIEQ2L36DkELG5AqAwIqpr4jUglMByAhsAMUEZEC6FTRWgOwoGBtGwxXAgh9DwZXTX1CCEqsJtPXFEDMABL5+/vM/xuI6Rmihq8NpAEgzyBCyDBj4MCAHAwAAAP//THMASwAAAAZJREFUAwASD4VoQrM2IwAAAABJRU5ErkJggg==">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="preload" id="webassembly" />

--- a/src/mono/wasm/templates/templates/browser/wwwroot/index.html
+++ b/src/mono/wasm/templates/templates/browser/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>browser.0</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="preload" id="webassembly" />

--- a/src/mono/wasm/testassets/LibraryMode/wwwroot/index.html
+++ b/src/mono/wasm/testassets/LibraryMode/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>tmp</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type="importmap"></script>

--- a/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/index.html
+++ b/src/mono/wasm/testassets/WasmBasicTestApp/App/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>WasmBasicTestApp</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="preload" id="webassembly" />

--- a/src/mono/wasm/testassets/WasmBrowserRunMainOnly/wwwroot/index.html
+++ b/src/mono/wasm/testassets/WasmBrowserRunMainOnly/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>WasmBrowserRunMainOnly</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="preload" id="webassembly" />

--- a/src/mono/wasm/testassets/WasmOnAspNetCore/BlazorClient/wwwroot/index.html
+++ b/src/mono/wasm/testassets/WasmOnAspNetCore/BlazorClient/wwwroot/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>BlazorHosted</title>
+    <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
     <base href="/blazorclient/" />
     <script type="importmap"></script>
 </head>

--- a/src/mono/wasm/testassets/WasmOnAspNetCore/WasmBrowserClient/wwwroot/index.html
+++ b/src/mono/wasm/testassets/WasmOnAspNetCore/WasmBrowserClient/wwwroot/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>WasmBrowser</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type="importmap"></script>

--- a/src/native/corehost/browserhost/sample/index.html
+++ b/src/native/corehost/browserhost/sample/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>Wasm Browser Sample</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type='module' src="./main.mjs"></script>

--- a/src/tests/Common/wasm-test-runner/index.html
+++ b/src/tests/Common/wasm-test-runner/index.html
@@ -1,1 +1,1 @@
-<!DOCTYPE html><html><body><script type='module' src='test-main.js'></script></body></html>
+<!DOCTYPE html><html><head><link rel="icon" href="data:image/png;base64,iVBORw0KGgo="></head><body><script type='module' src='test-main.js'></script></body></html>

--- a/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/index.html
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/HotReload/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>Wasm HotReload Test</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type='module' src="./main.js"></script>

--- a/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/index.html
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/RuntimeConfig/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>Runtime config test</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type='module' src="./main.js"></script>

--- a/src/tests/FunctionalTests/WebAssembly/Browser/StartupHook/index.html
+++ b/src/tests/FunctionalTests/WebAssembly/Browser/StartupHook/index.html
@@ -5,6 +5,7 @@
 
 <head>
   <title>Runtime config test</title>
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgo=">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type='module' src="./main.js"></script>


### PR DESCRIPTION
- get rid of 404 error for icon file - which appears in our test logs
- the icon is actually just minimal PNG magic, not valid icon.
- Credits: https://stackoverflow.com/a/13416784
- For the default WASM template it's real dotnet icon
