### PR TITLE
[release/8.0][mono] Fix memory leak in mono

### DIFF
--- a/src/mono/mono/mini/driver.c
+++ b/src/mono/mono/mini/driver.c
@@ -1907,6 +1907,7 @@ switch_gc (char* argv[], const char* target_gc)
 #else
 	fprintf (stderr, "Error: --gc=<NAME> option not supported on this platform.\n");
 #endif
+	g_string_free (path, TRUE);
 }
 
 static void


### PR DESCRIPTION
Found by Linux Verification Center (linuxtesting.org) with SVACE.
Reporter: Pavel Tikhomirov ([Tihomirov-P@gaz-is.ru](mailto:Tihomirov-P@gaz-is.ru)).
Organization: Gazinformservice([resp@gaz-is.ru](mailto:resp@gaz-is.ru)).