### PR TITLE
[browser][coreCLR] detect browser features and fail fast

### DIFF
--- a/src/native/corehost/browserhost/loader/bootstrap.ts
+++ b/src/native/corehost/browserhost/loader/bootstrap.ts
@@ -3,6 +3,8 @@
 
 import type { LoaderConfig, DotnetHostBuilder } from "./types";
 
+import { exceptions, simd } from "wasm-feature-detect";
+
 import { GlobalizationMode } from "./types";
 import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_SHELL } from "./per-module";
 import { nodeFs } from "./polyfills";
@@ -13,6 +15,11 @@ const queryIndex = scriptUrlQuery.indexOf("?");
 const modulesUniqueQuery = queryIndex > 0 ? scriptUrlQuery.substring(queryIndex) : "";
 const scriptUrl = normalizeFileUrl(scriptUrlQuery);
 const scriptDirectory = normalizeDirectoryUrl(scriptUrl);
+
+export async function validateWasmFeatures(): Promise<void> {
+    dotnetAssert.check(await exceptions, "This browser/engine doesn't support WASM exception handling. Please use a modern version. See also https://aka.ms/dotnet-wasm-features");
+    dotnetAssert.check(await simd, "This browser/engine doesn't support WASM SIMD. Please use a modern version. See also https://aka.ms/dotnet-wasm-features");
+}
 
 export function locateFile(path: string, isModule = false): string {
     let res;

--- a/src/native/corehost/browserhost/loader/run.ts
+++ b/src/native/corehost/browserhost/loader/run.ts
@@ -4,7 +4,7 @@
 import type { DotnetHostBuilder, JsModuleExports, EmscriptenModuleInternal } from "./types";
 
 import { dotnetAssert, dotnetGetInternals, dotnetBrowserHostExports, Module } from "./cross-module";
-import { findResources, isNodeHosted, isShellHosted } from "./bootstrap";
+import { findResources, isNodeHosted, isShellHosted, validateWasmFeatures } from "./bootstrap";
 import { exit, runtimeState } from "./exit";
 import { createPromiseCompletionSource } from "./promise-completion-source";
 import { getIcuResourceName } from "./icu";
@@ -30,10 +30,11 @@ export async function createRuntime(downloadOnly: boolean): Promise<any> {
     const config = getLoaderConfig();
     if (!config.resources || !config.resources.coreAssembly || !config.resources.coreAssembly.length) throw new Error("Invalid config, resources is not set");
 
-
     if (typeof Module.onConfigLoaded === "function") {
         await Module.onConfigLoaded(config);
     }
+
+    await validateWasmFeatures();
 
     if (config.resources.jsModuleDiagnostics && config.resources.jsModuleDiagnostics.length > 0) {
         const diagnosticsModule = await loadJSModule(config.resources.jsModuleDiagnostics[0]);


### PR DESCRIPTION
- new `validateWasmFeatures()` which makes sure that the JS Engine supports WASM EH and SIMD