### PR TITLE
Remove managed implementation from SP800-108 on Windows

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
+++ b/src/libraries/System.Security.Cryptography/src/System.Security.Cryptography.csproj
@@ -1930,8 +1930,6 @@
              Link="Common\System\Security\Cryptography\SlhDsaImplementation.Windows.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\SP800108HmacCounterKdfImplementationCng.cs"
              Link="Common\System\Security\Cryptography\SP800108HmacCounterKdfImplementationCng.cs" />
-    <Compile Include="$(CommonPath)System\Security\Cryptography\SP800108HmacCounterKdfImplementationManaged.cs"
-             Link="Common\System\Security\Cryptography\SP800108HmacCounterKdfImplementationManaged.cs" />
     <Compile Include="$(CommonPath)System\Security\Cryptography\X509Certificates\CertificateHelpers.Windows.cs"
              Link="Common\System\Security\Cryptography\X509Certificates\CertificateHelpers.Windows.cs" />
     <Compile Include="Microsoft\Win32\SafeHandles\NCryptSafeHandles.cs" />
@@ -2014,7 +2012,6 @@
     <Compile Include="System\Security\Cryptography\SlhDsaOpenSsl.NotSupported.cs" />
     <Compile Include="System\Security\Cryptography\SP800108HmacCounterKdf.Windows.cs" />
     <Compile Include="System\Security\Cryptography\SP800108HmacCounterKdfImplementationCng.cs" />
-    <Compile Include="System\Security\Cryptography\SP800108HmacCounterKdfImplementationManaged.cs" />
     <Compile Include="System\Security\Cryptography\TripleDESCng.Windows.cs" />
     <Compile Include="System\Security\Cryptography\TripleDESCryptoServiceProvider.Wrap.cs" />
     <Compile Include="System\Security\Cryptography\TripleDesImplementation.Windows.cs" />

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SP800108HmacCounterKdf.Windows.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SP800108HmacCounterKdf.Windows.cs
@@ -10,20 +10,11 @@ namespace System.Security.Cryptography
 {
     public sealed partial class SP800108HmacCounterKdf : IDisposable
     {
-        private static readonly bool s_isWindows8OrGreater = OperatingSystem.IsWindowsVersionAtLeast(6, 2);
-
         private static partial SP800108HmacCounterKdfImplementationBase CreateImplementation(
             ReadOnlySpan<byte> key,
             HashAlgorithmName hashAlgorithm)
         {
-            if (s_isWindows8OrGreater)
-            {
-                return new SP800108HmacCounterKdfImplementationCng(key, hashAlgorithm);
-            }
-            else
-            {
-                return new SP800108HmacCounterKdfImplementationManaged(key, hashAlgorithm);
-            }
+            return new SP800108HmacCounterKdfImplementationCng(key, hashAlgorithm);
         }
 
         private static partial byte[] DeriveBytesCore(
@@ -34,16 +25,7 @@ namespace System.Security.Cryptography
             int derivedKeyLengthInBytes)
         {
             byte[] result = new byte[derivedKeyLengthInBytes];
-
-            if (s_isWindows8OrGreater)
-            {
-                SP800108HmacCounterKdfImplementationCng.DeriveBytesOneShot(key, hashAlgorithm, label, context, result);
-            }
-            else
-            {
-                SP800108HmacCounterKdfImplementationManaged.DeriveBytesOneShot(key, hashAlgorithm, label, context, result);
-            }
-
+            SP800108HmacCounterKdfImplementationCng.DeriveBytesOneShot(key, hashAlgorithm, label, context, result);
             return result;
         }
 
@@ -54,14 +36,7 @@ namespace System.Security.Cryptography
             ReadOnlySpan<byte> context,
             Span<byte> destination)
         {
-            if (s_isWindows8OrGreater)
-            {
-                SP800108HmacCounterKdfImplementationCng.DeriveBytesOneShot(key, hashAlgorithm, label, context, destination);
-            }
-            else
-            {
-                SP800108HmacCounterKdfImplementationManaged.DeriveBytesOneShot(key, hashAlgorithm, label, context, destination);
-            }
+            SP800108HmacCounterKdfImplementationCng.DeriveBytesOneShot(key, hashAlgorithm, label, context, destination);
         }
 
         private static partial void DeriveBytesCore(
@@ -71,14 +46,7 @@ namespace System.Security.Cryptography
             ReadOnlySpan<char> context,
             Span<byte> destination)
         {
-            if (s_isWindows8OrGreater)
-            {
-                SP800108HmacCounterKdfImplementationCng.DeriveBytesOneShot(key, hashAlgorithm, label, context, destination);
-            }
-            else
-            {
-                SP800108HmacCounterKdfImplementationManaged.DeriveBytesOneShot(key, hashAlgorithm, label, context, destination);
-            }
+            SP800108HmacCounterKdfImplementationCng.DeriveBytesOneShot(key, hashAlgorithm, label, context, destination);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SP800108HmacCounterKdfImplementationCng.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SP800108HmacCounterKdfImplementationCng.cs
@@ -19,7 +19,7 @@ namespace System.Security.Cryptography
             if (key.Length > hashAlgorithmBlockSize)
             {
                 Span<byte> buffer = stackalloc byte[512 / 8]; // Largest supported digest is SHA512.
-                symmetricKeyMaterialLength = HashOneShot(hashAlgorithm, key, buffer);
+                symmetricKeyMaterialLength = CryptographicOperations.HashData(hashAlgorithm, key, buffer);
                 clearSpan = buffer.Slice(0, symmetricKeyMaterialLength);
                 symmetricKeyMaterial = clearSpan;
             }
@@ -48,33 +48,6 @@ namespace System.Security.Cryptography
             }
 
             _hashAlgorithm = hashAlgorithm;
-        }
-
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA5350", Justification = "Weak algorithms are used as instructed by the caller")]
-        private static int HashOneShot(HashAlgorithmName hashAlgorithm, ReadOnlySpan<byte> data, Span<byte> destination)
-        {
-            Debug.Assert(hashAlgorithm.Name is not null);
-
-            switch (hashAlgorithm.Name)
-            {
-                case HashAlgorithmNames.SHA1:
-                    return SHA1.HashData(data, destination);
-                case HashAlgorithmNames.SHA256:
-                    return SHA256.HashData(data, destination);
-                case HashAlgorithmNames.SHA384:
-                    return SHA384.HashData(data, destination);
-                case HashAlgorithmNames.SHA512:
-                    return SHA512.HashData(data, destination);
-                case HashAlgorithmNames.SHA3_256:
-                    return SHA3_256.IsSupported ? SHA3_256.HashData(data, destination) : throw new PlatformNotSupportedException();
-                case HashAlgorithmNames.SHA3_384:
-                    return SHA3_384.IsSupported ? SHA3_384.HashData(data, destination) : throw new PlatformNotSupportedException();
-                case HashAlgorithmNames.SHA3_512:
-                    return SHA3_512.IsSupported ? SHA3_512.HashData(data, destination) : throw new PlatformNotSupportedException();
-                default:
-                    Debug.Fail($"Unexpected hash algorithm '{hashAlgorithm.Name}'");
-                    throw new CryptographicException();
-            }
         }
     }
 }


### PR DESCRIPTION
It was only used for Windows 7.

While we are doing some cleanup, let's get rid of a hand-rolled one-shot implementation we don't need anymore. This will be more efficient for NativeAOT.

Contributes to https://github.com/dotnet/runtime/issues/71075.