### PR TITLE
Skip empty sections when calculating a R2R PE file layout

### DIFF
--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/PEObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/PEObjectWriter.cs
@@ -447,13 +447,12 @@ namespace ILCompiler.ObjectWriter
                 CoffSectionHeader h = s.Header;
 
                 // Skip calculating the layout for empty sections.
-                // Empty sections remain in _sections for index stability but are assigned zero VA/size
-                // to avoid wasting virtual address space and inflating the final PE file size.
                 if (s.Stream.Length == 0 && !h.SectionCharacteristics.HasFlag(SectionCharacteristics.ContainsUninitializedData))
                 {
                     if (recordFinalLayout)
                     {
-                        // Ensure that we match the section indexes in _sections, even though we omit them in EmitObjectFile.
+                        // Although we omit the empty sections in EmitObjectFile, we add them to _sections in order to match indexes.
+                        // We assign zero VA/size to avoid wasting virtual address space and inflating the final PE file size.
                         _outputSectionLayout.Add(new OutputSection(h.Name, 0, 0, 0));
                     }
 
@@ -516,8 +515,6 @@ namespace ILCompiler.ObjectWriter
                 if (recordFinalLayout)
                 {
                     // Use the stream length so we don't include any space that's appended just for alignment purposes.
-                    // To ensure that we match the section indexes in _sections, we don't skip empty sections here
-                    // even though we omit them in EmitObjectFile.
                     _outputSectionLayout.Add(new OutputSection(h.Name, h.VirtualAddress, h.PointerToRawData, (uint)s.Stream.Length));
                 }
                 firstSection = false;


### PR DESCRIPTION
This PR updates `PEObjectWriter`.

The changes are independent from https://github.com/dotnet/runtime/pull/122511

## Problem

R2R PE files were bloated with empty space between sections.

## Cause

Although we didn't directly emit empty sections into the R2R PE file, we still allocated a 64 kB padding for each empty section on non-Windows platforms:
- In the `LayoutSections` method, the `virtualAddress` counter was incremented to include a 64 kB padding for all sections, including the empty ones
- This caused `sizeOfImage` to include unnecessary 64 kB padding for each empty section on non-Windows platforms.

## Solution

- Modified `LayoutSections` to skip VA allocation in PE file layout for empty sections - after this change, we don't add 64 kB padding before the empty sections anymore.

## Results

Observed assembly: `System.Web.dll`

Original assembly size: 16 kB

After compiling to Composite R2R on Linux & Mac:

dotnet/runtime version | `System.Web.dll` R2R Image Size
-- | --
release/10.0 | 4 kB
main | 918 kB
main with this PR applied | 600 kB (~35% decrease)
https://github.com/dotnet/runtime/pull/122511 branch | 262 kB
https://github.com/dotnet/runtime/pull/122511 branch with this PR applied | 70 kB (~73% decrease)



