### PR TITLE
Add III.1.7 "Managed pointers exposing parameters outside of the method scope" to Ecma-335-Augments.md

### DIFF
--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -1034,7 +1034,7 @@ Changes to signatures:
 Add a new paragraph "III.1.7.7 Managed pointers exposing parameters outside of the method scope" under section "III.1.7 Restrictions on CIL code sequences"
 Byrefs derived from method parameters can escape from a function only in the following ways:
 - By explicit return of a byref or byref-like type
-- By writing through a byref to a byref-like type or byref-like type containing multiple levels of byref fields. For an example: `Span<T> p` parameter cannot expose anything, while `ref Span<T> p` can.
+- By writing through a byref to a byref-like type or byref-like type containing multiple levels of byref fields. For example: `Span<T> p` parameter cannot expose anything, while `ref Span<T> p` can.
 The behavior is undefined if a any other form of escape is attempted.
  
 ## <a name="byreflike-generics"></a> ByRefLike types in generics

--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -1030,6 +1030,13 @@ Changes to signatures:
   - Managed pointers which point at the address just past the end of an object, or the address where an element just past the end of an array would be stored, are permitted but not dereferenceable.
   - Null managed pointers are permitted to be dereferenced resulting in a `NullReferenceException`.
 
+### III.1.7.7
+Add a new paragraph "III.1.7.7 Managed pointers exposing parameters outside of the method scope" under section "III.1.7 Restrictions on CIL code sequences"
+Byrefs derived from method parameters can escape from a function only in the following ways:
+- By explicit return of a byref or byref-like type
+- By writing through a byref to a byref-like type or byref-like type containing multiple levels of byref fields. For an example: `Span<T> p` parameter cannot expose anything, while `ref Span<T> p` can.
+The behavior is undefined if a any other form of escape is attempted.
+ 
 ## <a name="byreflike-generics"></a> ByRefLike types in generics
 
 ByRefLike types, defined in C# with the `ref struct` syntax, represent types that cannot escape to the managed heap and must remain on the stack. It is possible for these types to be used as generic parameters, but in order to improve utility certain affordances are required.

--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -1036,7 +1036,7 @@ Byrefs derived from method parameters can escape from a function only in the fol
 - By explicit return of a byref or byref-like type
 - By writing through a byref to a byref-like type or byref-like type containing multiple levels of byref fields. For example: `Span<T> p` parameter cannot expose anything, while `ref Span<T> p` can.
 The behavior is undefined if any other form of escape is attempted.
- 
+
 ## <a name="byreflike-generics"></a> ByRefLike types in generics
 
 ByRefLike types, defined in C# with the `ref struct` syntax, represent types that cannot escape to the managed heap and must remain on the stack. It is possible for these types to be used as generic parameters, but in order to improve utility certain affordances are required.

--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -1035,7 +1035,7 @@ Add a new paragraph "III.1.7.7 Managed pointers exposing parameters outside of t
 Byrefs derived from method parameters can escape from a function only in the following ways:
 - By explicit return of a byref or byref-like type
 - By writing through a byref to a byref-like type or byref-like type containing multiple levels of byref fields. For example: `Span<T> p` parameter cannot expose anything, while `ref Span<T> p` can.
-The behavior is undefined if a any other form of escape is attempted.
+The behavior is undefined if any other form of escape is attempted.
  
 ## <a name="byreflike-generics"></a> ByRefLike types in generics
 

--- a/docs/design/specs/Ecma-335-Augments.md
+++ b/docs/design/specs/Ecma-335-Augments.md
@@ -1032,10 +1032,13 @@ Changes to signatures:
 
 ### III.1.7.7
 Add a new paragraph "III.1.7.7 Managed pointers exposing parameters outside of the method scope" under section "III.1.7 Restrictions on CIL code sequences"
-Byrefs derived from method parameters can escape from a function only in the following ways:
+Managed pointers obtained from method parameters, and byref-like values that contain them, can be made observable outside of a function only through escape paths present in the function signature:
 - By explicit return of a byref or byref-like type
-- By writing through a byref to a byref-like type or byref-like type containing multiple levels of byref fields. For example: `Span<T> p` parameter cannot expose anything, while `ref Span<T> p` can.
-The behavior is undefined if any other form of escape is attempted.
+- By writing to storage exposed by a byref parameter, including byref-like types containing multiple levels of byref fields
+
+The same rule applies to unsafe code. Copying such a managed pointer or byref-like value through unmanaged or other raw storage is permitted, but it is undefined behavior to copy it into storage that makes it observable outside of the function through an escape path not present in the signature. Temporary copies in storage that is not observable outside of the function are permitted.
+
+For example: `void M(Span<T> p)` cannot expose `p` outside of `M`, while `void M(Span<T> p, ref Span<T> q)` can copy `p` into `q`.
 
 ## <a name="byreflike-generics"></a> ByRefLike types in generics
 


### PR DESCRIPTION
Motivation:
1) Set written rules for the JIT optimizer when it can and when it cannot optimize boxings for structs https://github.com/dotnet/runtime/issues/122099. If we don't set the rules, the optimization that the JIT does is only valid when the method over the boxed struct is inlined and JIT's escape analysis clearly sees that nothing escapes anywhere. If we conservatively make it so, it will be a noticeable performance regression over previous releases.
2) Allow JIT to perform a free inter-procedural escape analysis by only looking at call's signature, for an example:
```cs
Span<int> buffer = new int[10];
Consume(buffer); 
```
given the `void Consume(Span<int>)` signature, JIT can be sure that the buffer never escapes anywhere without looking into actual implementation. We expect this to unlock the potential of the current Escape Analysis and handle a lot more cases.

Another examples:
```cs
void Case1(ref Span<int> X)
{
    Span<int> buffer = new int[10];
    Consume(buffer, ref X); // buffer cannot be stack-allocated as it might escape through X
}

ref int Case2()
{
    Span<int> buffer = new int[10];
    return ref Consume(buffer); // buffer cannot be stack-allocated as it might escape through return ref
}

ByrefLikeType Case3()
{
    Span<int> buffer = new int[10];
    return Consume(buffer); // buffer cannot be stack-allocated as it might escape through return ByrefLikeType
}

// ByrefLikeTypeWithRefRef can not be declared today
void Case4(ByrefLikeTypeWithRefRef p)
{
    Span<int> buffer = new int[10];
    return Consume(buffer, p); // buffer cannot be stack-allocated as it might escape through p parameter
}
```

Based on the discussion with @jakobbotsch @jkotas. Let me know if the wording needs to be improved.

PS: "multiple levels of byref fields" is not something that can be represented today in C#, but we leave a room for it.

### Open questions:
- [x] If we call it UB, should we make `warning CS9085: This ref-assigns 'field' to 'p' but 'field' has a narrower escape scope than 'p'.` an error? **UPD:** given it requires unsafe and there are, possibly, valid scenarios it's fine to leave it as is.