### PR TITLE
JIT: Look harder for async calls in ASYNC_CONTINUATION lowering

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -5925,9 +5925,8 @@ GenTree* Lowering::LowerAsyncContinuation(GenTree* asyncCont)
         node = node->gtPrev;
         noway_assert((node != nullptr) && "Ran out of nodes while looking for call before async continuation");
 
-        if (node->IsCall())
+        if (node->IsCall() && node->AsCall()->IsAsync())
         {
-            assert(node->AsCall()->IsAsync());
             BlockRange().Remove(asyncCont);
             BlockRange().InsertAfter(node, asyncCont);
             break;


### PR DESCRIPTION
When the `AsyncHelpers.AsyncCallContinuation` intrinsic is used explicitly the introduced `ASYNC_CONTINUATION` node needs to appear right after the async call in linear order. That would usually be the case, but in some cases we can have a `stloc` for the call result that turns into an intervening helper call.

Fix by trying harder to locate the previous async call and allow skipping over other non-async calls. Hopefully that doesn't lead to any hard to diagnose issues.

Fix #122582