### PR TITLE
JIT: Disallow tailcall stress in async methods

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -10552,7 +10552,8 @@ public:
         // Do not stress tailcalls in IL stubs as the runtime creates several IL
         // stubs to implement the tailcall mechanism, which would then
         // recursively create more IL stubs.
-        return !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IL_STUB) &&
+        // Tailcalls are also not allowed out of async methods, so do not stress in those either.
+        return !opts.jitFlags->IsSet(JitFlags::JIT_FLAG_IL_STUB) && !compIsAsync() &&
                (JitConfig.TailcallStress() != 0 || compStressCompile(STRESS_TAILCALL, 5));
 #else
         return false;


### PR DESCRIPTION
Explicit tailcalls are not allowed out of async methods so it does not make sense to allow turning on tailcall stress. Turning it on also impacts IR created because we we may skip creating some `GT_RETURN` nodes, which is not expected by async transformations.

Fix #122632