### PR TITLE
Update cryptography tests for Windows 7 removal.

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherOneShotTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherOneShotTests.cs
@@ -927,271 +927,267 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                     8,
                 };
 
-                // CFB128 is not supported on Windows 7.
-                if (PlatformDetection.IsNotWindows7)
+                yield return new object[]
                 {
-                    yield return new object[]
+
+                    // plaintext
+                    new byte[]
                     {
+                        0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
+                        0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
+                    },
 
-                        // plaintext
-                        new byte[]
-                        {
-                            0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
-                            0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
-                        },
-
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x53, 0x3F, 0x49, 0x1D, 0x53, 0x29, 0x39, 0x67,
-                            0x8A, 0x06, 0x28, 0x76, 0x34, 0x9A, 0x2D, 0xE3,
-                            0x2B, 0x63, 0xD4, 0x34, 0x86, 0x05, 0x9B, 0x52,
-                            0x20, 0x46, 0x65, 0xD5, 0xBC, 0xA1, 0xED, 0x11,
-                        },
-
-                        PaddingMode.PKCS7,
-                        CipherMode.CFB,
-                        128,
-                    };
-
-                    yield return new object[]
+                    // ciphertext
+                    new byte[]
                     {
+                        0x53, 0x3F, 0x49, 0x1D, 0x53, 0x29, 0x39, 0x67,
+                        0x8A, 0x06, 0x28, 0x76, 0x34, 0x9A, 0x2D, 0xE3,
+                        0x2B, 0x63, 0xD4, 0x34, 0x86, 0x05, 0x9B, 0x52,
+                        0x20, 0x46, 0x65, 0xD5, 0xBC, 0xA1, 0xED, 0x11,
+                    },
 
-                        // plaintext
-                        new byte[]
-                        {
-                            0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
-                            0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
-                        },
+                    PaddingMode.PKCS7,
+                    CipherMode.CFB,
+                    128,
+                };
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x53, 0x3F, 0x49, 0x1D, 0x53, 0x29, 0x39, 0x67,
-                            0x8A, 0x06, 0x28, 0x76, 0x34, 0x9A, 0x2D, 0xE3,
-                        },
+                yield return new object[]
+                {
 
-                        PaddingMode.None,
-                        CipherMode.CFB,
-                        128,
-                    };
-
-                    yield return new object[]
+                    // plaintext
+                    new byte[]
                     {
+                        0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
+                        0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
+                    },
 
-                        // plaintext
-                        new byte[]
-                        {
-                            0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
-                            0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
-                        },
-
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x53, 0x3F, 0x49, 0x1D, 0x53, 0x29, 0x39, 0x67,
-                            0x8A, 0x06, 0x28, 0x76, 0x34, 0x9A, 0x2D, 0xE3,
-                        },
-
-                        PaddingMode.Zeros,
-                        CipherMode.CFB,
-                        128,
-                    };
-
-                    yield return new object[]
+                    // ciphertext
+                    new byte[]
                     {
+                        0x53, 0x3F, 0x49, 0x1D, 0x53, 0x29, 0x39, 0x67,
+                        0x8A, 0x06, 0x28, 0x76, 0x34, 0x9A, 0x2D, 0xE3,
+                    },
 
-                        // plaintext
-                        new byte[]
-                        {
-                            0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
-                            0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
-                        },
+                    PaddingMode.None,
+                    CipherMode.CFB,
+                    128,
+                };
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x53, 0x3F, 0x49, 0x1D, 0x53, 0x29, 0x39, 0x67,
-                            0x8A, 0x06, 0x28, 0x76, 0x34, 0x9A, 0x2D, 0xE3,
-                            0x3B, 0x73, 0xC4, 0x24, 0x96, 0x15, 0x8B, 0x42,
-                            0x30, 0x56, 0x75, 0xC5, 0xAC, 0xB1, 0xFD, 0x11,
-                        },
+                yield return new object[]
+                {
 
-                        PaddingMode.ANSIX923,
-                        CipherMode.CFB,
-                        128,
-                    };
-
-                    yield return new object[]
+                    // plaintext
+                    new byte[]
                     {
+                        0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
+                        0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
+                    },
 
-                        // plaintext
-                        new byte[]
-                        {
-                            0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
-                            0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
-                        },
-
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x53, 0x3F, 0x49, 0x1D, 0x53, 0x29, 0x39, 0x67,
-                            0x8A, 0x06, 0x28, 0x76, 0x34, 0x9A, 0x2D, 0xE3,
-                            0x3E, 0x5D, 0xED, 0x96, 0x51, 0x93, 0xF0, 0x12,
-                            0x95, 0x98, 0x51, 0x29, 0xB6, 0xF8, 0x84, 0x11,
-                        },
-
-                        PaddingMode.ISO10126,
-                        CipherMode.CFB,
-                        128,
-                    };
-
-                    yield return new object[]
+                    // ciphertext
+                    new byte[]
                     {
+                        0x53, 0x3F, 0x49, 0x1D, 0x53, 0x29, 0x39, 0x67,
+                        0x8A, 0x06, 0x28, 0x76, 0x34, 0x9A, 0x2D, 0xE3,
+                    },
 
-                        // plaintext
-                        new byte[]
-                        {
-                            0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
-                            0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
-                            0x59,
-                        },
+                    PaddingMode.Zeros,
+                    CipherMode.CFB,
+                    128,
+                };
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x9A, 0x07, 0x33, 0xAB, 0xA8, 0x7E, 0xF9, 0x26,
-                            0xBA, 0xC0, 0x0E, 0xAF, 0xB7, 0x12, 0x25, 0x39,
-                            0x0C, 0xD0, 0xD4, 0xF1, 0x60, 0x93, 0xD0, 0x20,
-                            0x91, 0x11, 0xD8, 0xF6, 0x27, 0xE3, 0xAF, 0x0F,
-                        },
+                yield return new object[]
+                {
 
-                        PaddingMode.PKCS7,
-                        CipherMode.CFB,
-                        128,
-                    };
-
-                    yield return new object[]
+                    // plaintext
+                    new byte[]
                     {
+                        0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
+                        0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
+                    },
 
-                        // plaintext
-                        new byte[]
-                        {
-                            0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
-                            0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
-                            0x59,
-                        },
-
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x9A, 0x07, 0x33, 0xAB, 0xA8, 0x7E, 0xF9, 0x26,
-                            0xBA, 0xC0, 0x0E, 0xAF, 0xB7, 0x12, 0x25, 0x39,
-                            0x0C, 0xDF, 0xDB, 0xFE, 0x6F, 0x9C, 0xDF, 0x2F,
-                            0x9E, 0x1E, 0xD7, 0xF9, 0x28, 0xEC, 0xA0, 0x00,
-                        },
-
-                        PaddingMode.Zeros,
-                        CipherMode.CFB,
-                        128,
-                    };
-
-                    yield return new object[]
+                    // ciphertext
+                    new byte[]
                     {
+                        0x53, 0x3F, 0x49, 0x1D, 0x53, 0x29, 0x39, 0x67,
+                        0x8A, 0x06, 0x28, 0x76, 0x34, 0x9A, 0x2D, 0xE3,
+                        0x3B, 0x73, 0xC4, 0x24, 0x96, 0x15, 0x8B, 0x42,
+                        0x30, 0x56, 0x75, 0xC5, 0xAC, 0xB1, 0xFD, 0x11,
+                    },
 
-                        // plaintext
-                        new byte[]
-                        {
-                            0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
-                            0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
-                            0x59,
-                        },
+                    PaddingMode.ANSIX923,
+                    CipherMode.CFB,
+                    128,
+                };
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x9A, 0x07, 0x33, 0xAB, 0xA8, 0x7E, 0xF9, 0x26,
-                            0xBA, 0xC0, 0x0E, 0xAF, 0xB7, 0x12, 0x25, 0x39,
-                            0x0C, 0xDF, 0xDB, 0xFE, 0x6F, 0x9C, 0xDF, 0x2F,
-                            0x9E, 0x1E, 0xD7, 0xF9, 0x28, 0xEC, 0xA0, 0x0F,
-                        },
+                yield return new object[]
+                {
 
-                        PaddingMode.ANSIX923,
-                        CipherMode.CFB,
-                        128,
-                    };
-
-                    yield return new object[]
+                    // plaintext
+                    new byte[]
                     {
+                        0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
+                        0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
+                    },
 
-                        // plaintext
-                        new byte[]
-                        {
-                            0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
-                            0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
-                            0x59,
-                        },
-
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x9A, 0x07, 0x33, 0xAB, 0xA8, 0x7E, 0xF9, 0x26,
-                            0xBA, 0xC0, 0x0E, 0xAF, 0xB7, 0x12, 0x25, 0x39,
-                            0x0C, 0x0C, 0x39, 0x31, 0x1C, 0xAA, 0x41, 0x45,
-                            0x78, 0xD0, 0x9F, 0x0F, 0x44, 0xD9, 0x37, 0x0F,
-                        },
-
-                        PaddingMode.ISO10126,
-                        CipherMode.CFB,
-                        128,
-                    };
-
-                    yield return new object[]
+                    // ciphertext
+                    new byte[]
                     {
+                        0x53, 0x3F, 0x49, 0x1D, 0x53, 0x29, 0x39, 0x67,
+                        0x8A, 0x06, 0x28, 0x76, 0x34, 0x9A, 0x2D, 0xE3,
+                        0x3E, 0x5D, 0xED, 0x96, 0x51, 0x93, 0xF0, 0x12,
+                        0x95, 0x98, 0x51, 0x29, 0xB6, 0xF8, 0x84, 0x11,
+                    },
 
-                        // plaintext
-                        Array.Empty<byte>(),
+                    PaddingMode.ISO10126,
+                    CipherMode.CFB,
+                    128,
+                };
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x13, 0x47, 0x4B, 0xA9, 0x1C, 0x31, 0xE1, 0xFE,
-                            0x23, 0x69, 0x61, 0xE6, 0x27, 0x01, 0xBE, 0xAA,
-                        },
+                yield return new object[]
+                {
 
-                        PaddingMode.PKCS7,
-                        CipherMode.CFB,
-                        128,
-                    };
-
-                    yield return new object[]
+                    // plaintext
+                    new byte[]
                     {
+                        0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
+                        0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
+                        0x59,
+                    },
 
-                        // plaintext
-                        Array.Empty<byte>(),
-
-                        // ciphertext
-                        Array.Empty<byte>(),
-
-                        PaddingMode.Zeros,
-                        CipherMode.CFB,
-                        128,
-                    };
-
-                    yield return new object[]
+                    // ciphertext
+                    new byte[]
                     {
+                        0x9A, 0x07, 0x33, 0xAB, 0xA8, 0x7E, 0xF9, 0x26,
+                        0xBA, 0xC0, 0x0E, 0xAF, 0xB7, 0x12, 0x25, 0x39,
+                        0x0C, 0xD0, 0xD4, 0xF1, 0x60, 0x93, 0xD0, 0x20,
+                        0x91, 0x11, 0xD8, 0xF6, 0x27, 0xE3, 0xAF, 0x0F,
+                    },
 
-                        // plaintext
-                        Array.Empty<byte>(),
+                    PaddingMode.PKCS7,
+                    CipherMode.CFB,
+                    128,
+                };
 
-                        // ciphertext
-                        Array.Empty<byte>(),
+                yield return new object[]
+                {
 
-                        PaddingMode.None,
-                        CipherMode.CFB,
-                        128,
-                    };
-                }
+                    // plaintext
+                    new byte[]
+                    {
+                        0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
+                        0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
+                        0x59,
+                    },
+
+                    // ciphertext
+                    new byte[]
+                    {
+                        0x9A, 0x07, 0x33, 0xAB, 0xA8, 0x7E, 0xF9, 0x26,
+                        0xBA, 0xC0, 0x0E, 0xAF, 0xB7, 0x12, 0x25, 0x39,
+                        0x0C, 0xDF, 0xDB, 0xFE, 0x6F, 0x9C, 0xDF, 0x2F,
+                        0x9E, 0x1E, 0xD7, 0xF9, 0x28, 0xEC, 0xA0, 0x00,
+                    },
+
+                    PaddingMode.Zeros,
+                    CipherMode.CFB,
+                    128,
+                };
+
+                yield return new object[]
+                {
+
+                    // plaintext
+                    new byte[]
+                    {
+                        0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
+                        0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
+                        0x59,
+                    },
+
+                    // ciphertext
+                    new byte[]
+                    {
+                        0x9A, 0x07, 0x33, 0xAB, 0xA8, 0x7E, 0xF9, 0x26,
+                        0xBA, 0xC0, 0x0E, 0xAF, 0xB7, 0x12, 0x25, 0x39,
+                        0x0C, 0xDF, 0xDB, 0xFE, 0x6F, 0x9C, 0xDF, 0x2F,
+                        0x9E, 0x1E, 0xD7, 0xF9, 0x28, 0xEC, 0xA0, 0x0F,
+                    },
+
+                    PaddingMode.ANSIX923,
+                    CipherMode.CFB,
+                    128,
+                };
+
+                yield return new object[]
+                {
+
+                    // plaintext
+                    new byte[]
+                    {
+                        0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
+                        0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
+                        0x59,
+                    },
+
+                    // ciphertext
+                    new byte[]
+                    {
+                        0x9A, 0x07, 0x33, 0xAB, 0xA8, 0x7E, 0xF9, 0x26,
+                        0xBA, 0xC0, 0x0E, 0xAF, 0xB7, 0x12, 0x25, 0x39,
+                        0x0C, 0x0C, 0x39, 0x31, 0x1C, 0xAA, 0x41, 0x45,
+                        0x78, 0xD0, 0x9F, 0x0F, 0x44, 0xD9, 0x37, 0x0F,
+                    },
+
+                    PaddingMode.ISO10126,
+                    CipherMode.CFB,
+                    128,
+                };
+
+                yield return new object[]
+                {
+
+                    // plaintext
+                    Array.Empty<byte>(),
+
+                    // ciphertext
+                    new byte[]
+                    {
+                        0x13, 0x47, 0x4B, 0xA9, 0x1C, 0x31, 0xE1, 0xFE,
+                        0x23, 0x69, 0x61, 0xE6, 0x27, 0x01, 0xBE, 0xAA,
+                    },
+
+                    PaddingMode.PKCS7,
+                    CipherMode.CFB,
+                    128,
+                };
+
+                yield return new object[]
+                {
+
+                    // plaintext
+                    Array.Empty<byte>(),
+
+                    // ciphertext
+                    Array.Empty<byte>(),
+
+                    PaddingMode.Zeros,
+                    CipherMode.CFB,
+                    128,
+                };
+
+                yield return new object[]
+                {
+
+                    // plaintext
+                    Array.Empty<byte>(),
+
+                    // ciphertext
+                    Array.Empty<byte>(),
+
+                    PaddingMode.None,
+                    CipherMode.CFB,
+                    128,
+                };
             }
         }
     }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherTests.cs
@@ -78,7 +78,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
             TestAesDecrypt(CipherMode.CBC, s_aes256Key, s_aes256CbcIv, encryptedBytes, s_multiBlockBytes);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void DecryptKnownCFB128_256()
         {
             byte[] encryptedBytes = new byte[]
@@ -122,7 +122,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
             TestAesDecrypt(CipherMode.ECB, s_aes192Key, null, encryptedBytes, s_multiBlockBytes);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void DecryptKnownCFB128_192()
         {
             byte[] encryptedBytes = new byte[]
@@ -144,7 +144,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
             TestAesDecrypt(CipherMode.CFB, s_aes192Key, s_aes256CbcIv, encryptedBytes, s_multiBlockBytes, 128);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void DecryptKnownCFB128_128()
         {
             byte[] encryptedBytes = new byte[]
@@ -372,7 +372,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 cipherBytes: new byte[] { 0x6C, 0xD0, 0x25, 0x13, 0xE8, 0xD4, 0xDC, 0x98, 0x6B, 0x4A, 0xFE, 0x08, 0x7A, 0x60, 0xBD, 0x0C });
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_8_NoPadding()
         {
             TestAesTransformDirectKey(
@@ -385,7 +385,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 8);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_128_NoPadding()
         {
             TestAesTransformDirectKey(
@@ -422,7 +422,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 cipherBytes: new byte[] { 0x19, 0x46, 0xDA, 0xBF, 0x6A, 0x03, 0xA2, 0xA2, 0xC3, 0xD0, 0xB0, 0x50, 0x80, 0xAE, 0xD6, 0xFC });
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_256_NoPadding()
         {
             TestAesTransformDirectKey(
@@ -460,7 +460,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 cipherBytes: new byte[] { 0x0E, 0xDD, 0x33, 0xD3, 0xC6, 0x21, 0xE5, 0x46, 0x45, 0x5B, 0xD8, 0xBA, 0x14, 0x18, 0xBE, 0xC8 });
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_128_NoPadding_2()
         {
             TestAesTransformDirectKey(
@@ -485,7 +485,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 cipherBytes: new byte[] { 0x3A, 0xD7, 0x8E, 0x72, 0x6C, 0x1E, 0xC0, 0x2B, 0x7E, 0xBF, 0xE9, 0x2B, 0x23, 0xD9, 0xEC, 0x34 });
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_128_NoPadding_3()
         {
             TestAesTransformDirectKey(
@@ -510,7 +510,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 cipherBytes: new byte[] { 0xDE, 0x88, 0x5D, 0xC8, 0x7F, 0x5A, 0x92, 0x59, 0x40, 0x82, 0xD0, 0x2C, 0xC1, 0xE1, 0xB4, 0x2C });
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_192_NoPadding()
         {
             TestAesTransformDirectKey(
@@ -548,7 +548,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 cipherBytes: new byte[] { 0x6C, 0xD0, 0x25, 0x13, 0xE8, 0xD4, 0xDC, 0x98, 0x6B, 0x4A, 0xFE, 0x08, 0x7A, 0x60, 0xBD, 0x0C });
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_192_NoPadding_2()
         {
             TestAesTransformDirectKey(
@@ -672,7 +672,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 feedbackSize: 8);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_128_NoPadding_4_Fails()
         {
             Assert.Throws<CryptographicException>(() =>
@@ -687,7 +687,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_128_PKCS7_4()
         {
             TestAesTransformDirectKey(
@@ -821,7 +821,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 feedbackSize: 8);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_128_NoPadding_0()
         {
             // NIST CAVP AESMMT.ZIP CFB128MMT128.rsp, [ENCRYPT] COUNT=0
@@ -835,7 +835,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 feedbackSize: 128);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_128_NoPadding_1_Extended()
         {
             // NIST CAVP AESMMT.ZIP CFB128MMT128.rsp, [ENCRYPT] COUNT=1
@@ -849,7 +849,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 feedbackSize: 128);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_192_NoPadding_0_Extended()
         {
             // NIST CAVP AESMMT.ZIP CFB128MMT192.rsp, [ENCRYPT] COUNT=0
@@ -863,7 +863,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 feedbackSize: 128);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_192_NoPadding_1_Extended()
         {
             // NIST CAVP AESMMT.ZIP CFB128MMT192.rsp, [ENCRYPT] COUNT=1
@@ -877,7 +877,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 feedbackSize: 128);
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(CipherMode.CBC, 0)]
         [InlineData(CipherMode.CFB, 128)]
         [InlineData(CipherMode.CFB, 8)]
@@ -907,7 +907,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(CipherMode.CBC, 0)]
         [InlineData(CipherMode.CFB, 128)]
         [InlineData(CipherMode.CFB, 8)]
@@ -942,7 +942,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_256_NoPadding_0_Extended()
         {
             // NIST CAVP AESMMT.ZIP CFB128MMT256.rsp, [ENCRYPT] COUNT=0
@@ -956,7 +956,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 feedbackSize: 128);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB128_256_NoPadding_1_Extended()
         {
             // NIST CAVP AESMMT.ZIP CFB128MMT256.rsp, [ENCRYPT] COUNT=1
@@ -975,12 +975,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
             get
             {
                 yield return new object[] { CipherMode.CBC };
-
-                if (!PlatformDetection.IsWindows7)
-                {
-                    // Windows 7 does not support CFB128.
-                    yield return new object[] { CipherMode.CFB };
-                }
+                yield return new object[] { CipherMode.CFB };
             }
         }
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesContractTests.cs
@@ -148,12 +148,6 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
         [InlineData(128)]
         public static void ValidCFBFeedbackSizes(int feedbackSize)
         {
-            // Windows 7 only supports CFB8.
-            if (feedbackSize != 8 && PlatformDetection.IsWindows7)
-            {
-                return;
-            }
-
             using (Aes aes = AesFactory.Create())
             {
                 aes.GenerateKey();
@@ -497,7 +491,7 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                         {
                             one = enc.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
                         }
-                       
+
                         iv = aes.IV;
                     }
                     else

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesModeTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesModeTests.cs
@@ -28,16 +28,10 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
             SupportsMode(CipherMode.CFB, feedbackSize: 8);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void SupportsCFB128()
         {
             SupportsMode(CipherMode.CFB, feedbackSize: 128);
-        }
-
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows7))]
-        public static void Windows7DoesNotSupportCFB128()
-        {
-            DoesNotSupportMode(CipherMode.CFB, feedbackSize: 128);
         }
 
         [Fact]

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESCipherOneShotTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESCipherOneShotTests.cs
@@ -579,232 +579,228 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
                     CipherMode.ECB,
                 };
 
-                // Windows 7 does not support CFB8
-                if (PlatformDetection.IsNotWindows7)
+                yield return new object[]
                 {
-                    yield return new object[]
+                    // plaintext
+                    new byte[]
                     {
-                        // plaintext
-                        new byte[]
-                        {
-                            0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
-                            0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
-                        },
+                        0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
+                        0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
+                    },
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x6F, 0xF8, 0x24, 0x52, 0x68, 0x8E, 0x53, 0x97,
-                            0x2A, 0x6B, 0x8A, 0x5E, 0xBE, 0x98, 0x84, 0x28,
-                            0x39,
-                        },
-
-                        PaddingMode.PKCS7,
-                        CipherMode.CFB,
-                        8,
-                    };
-
-                    yield return new object[]
+                    // ciphertext
+                    new byte[]
                     {
-                        // plaintext
-                        new byte[]
-                        {
-                            0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
-                            0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
-                        },
+                        0x6F, 0xF8, 0x24, 0x52, 0x68, 0x8E, 0x53, 0x97,
+                        0x2A, 0x6B, 0x8A, 0x5E, 0xBE, 0x98, 0x84, 0x28,
+                        0x39,
+                    },
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x6F, 0xF8, 0x24, 0x52, 0x68, 0x8E, 0x53, 0x97,
-                            0x2A, 0x6B, 0x8A, 0x5E, 0xBE, 0x98, 0x84, 0x28,
-                        },
+                    PaddingMode.PKCS7,
+                    CipherMode.CFB,
+                    8,
+                };
 
-                        PaddingMode.None,
-                        CipherMode.CFB,
-                        8,
-                    };
-
-                    yield return new object[]
+                yield return new object[]
+                {
+                    // plaintext
+                    new byte[]
                     {
-                        // plaintext
-                        new byte[]
-                        {
-                            0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
-                            0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
-                        },
+                        0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
+                        0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
+                    },
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x6F, 0xF8, 0x24, 0x52, 0x68, 0x8E, 0x53, 0x97,
-                            0x2A, 0x6B, 0x8A, 0x5E, 0xBE, 0x98, 0x84, 0x28,
-                        },
-
-                        PaddingMode.Zeros,
-                        CipherMode.CFB,
-                        8,
-                    };
-
-                    yield return new object[]
+                    // ciphertext
+                    new byte[]
                     {
-                        // plaintext
-                        new byte[]
-                        {
-                            0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
-                            0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
-                        },
+                        0x6F, 0xF8, 0x24, 0x52, 0x68, 0x8E, 0x53, 0x97,
+                        0x2A, 0x6B, 0x8A, 0x5E, 0xBE, 0x98, 0x84, 0x28,
+                    },
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x6F, 0xF8, 0x24, 0x52, 0x68, 0x8E, 0x53, 0x97,
-                            0x2A, 0x6B, 0x8A, 0x5E, 0xBE, 0x98, 0x84, 0x28,
-                            0x39,
-                        },
+                    PaddingMode.None,
+                    CipherMode.CFB,
+                    8,
+                };
 
-                        PaddingMode.ANSIX923,
-                        CipherMode.CFB,
-                        8,
-                    };
-
-                    yield return new object[]
+                yield return new object[]
+                {
+                    // plaintext
+                    new byte[]
                     {
-                        // plaintext
-                        new byte[]
-                        {
-                            0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
-                            0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
-                        },
+                        0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
+                        0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
+                    },
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0x6F, 0xF8, 0x24, 0x52, 0x68, 0x8E, 0x53, 0x97,
-                            0x2A, 0x6B, 0x8A, 0x5E, 0xBE, 0x98, 0x84, 0x28,
-                            0x39,
-                        },
-
-                        PaddingMode.ISO10126,
-                        CipherMode.CFB,
-                        8,
-                    };
-
-                    yield return new object[]
+                    // ciphertext
+                    new byte[]
                     {
-                        // plaintext
-                        new byte[]
-                        {
-                            0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
-                            0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
-                            0x59,
-                        },
+                        0x6F, 0xF8, 0x24, 0x52, 0x68, 0x8E, 0x53, 0x97,
+                        0x2A, 0x6B, 0x8A, 0x5E, 0xBE, 0x98, 0x84, 0x28,
+                    },
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0xA6, 0x51, 0xB4, 0xF2, 0x2B, 0xFA, 0x22, 0xF5,
-                            0x15, 0x1E, 0x5E, 0x65, 0x39, 0xFD, 0x84, 0x4F,
-                            0xE1, 0x7E,
-                        },
+                    PaddingMode.Zeros,
+                    CipherMode.CFB,
+                    8,
+                };
 
-                        PaddingMode.PKCS7,
-                        CipherMode.CFB,
-                        8,
-                    };
-
-                    yield return new object[]
+                yield return new object[]
+                {
+                    // plaintext
+                    new byte[]
                     {
-                        // plaintext
-                        new byte[]
-                        {
-                            0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
-                            0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
-                            0x59,
-                        },
+                        0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
+                        0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
+                    },
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0xA6, 0x51, 0xB4, 0xF2, 0x2B, 0xFA, 0x22, 0xF5,
-                            0x15, 0x1E, 0x5E, 0x65, 0x39, 0xFD, 0x84, 0x4F,
-                            0xE1,
-                        },
-
-                        PaddingMode.None,
-                        CipherMode.CFB,
-                        8,
-                    };
-
-                    yield return new object[]
+                    // ciphertext
+                    new byte[]
                     {
-                        // plaintext
-                        new byte[]
-                        {
-                            0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
-                            0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
-                            0x59,
-                        },
+                        0x6F, 0xF8, 0x24, 0x52, 0x68, 0x8E, 0x53, 0x97,
+                        0x2A, 0x6B, 0x8A, 0x5E, 0xBE, 0x98, 0x84, 0x28,
+                        0x39,
+                    },
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0xA6, 0x51, 0xB4, 0xF2, 0x2B, 0xFA, 0x22, 0xF5,
-                            0x15, 0x1E, 0x5E, 0x65, 0x39, 0xFD, 0x84, 0x4F,
-                            0xE1,
-                        },
+                    PaddingMode.ANSIX923,
+                    CipherMode.CFB,
+                    8,
+                };
 
-                        PaddingMode.Zeros,
-                        CipherMode.CFB,
-                        8,
-                    };
-
-                    yield return new object[]
+                yield return new object[]
+                {
+                    // plaintext
+                    new byte[]
                     {
-                        // plaintext
-                        new byte[]
-                        {
-                            0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
-                            0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
-                            0x59,
-                        },
+                        0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8, 0x89,
+                        0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83, 0x59,
+                    },
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0xA6, 0x51, 0xB4, 0xF2, 0x2B, 0xFA, 0x22, 0xF5,
-                            0x15, 0x1E, 0x5E, 0x65, 0x39, 0xFD, 0x84, 0x4F,
-                            0xE1, 0x7E,
-                        },
-
-                        PaddingMode.ANSIX923,
-                        CipherMode.CFB,
-                        8,
-                    };
-
-                    yield return new object[]
+                    // ciphertext
+                    new byte[]
                     {
-                        // plaintext
-                        new byte[]
-                        {
-                            0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
-                            0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
-                            0x59,
-                        },
+                        0x6F, 0xF8, 0x24, 0x52, 0x68, 0x8E, 0x53, 0x97,
+                        0x2A, 0x6B, 0x8A, 0x5E, 0xBE, 0x98, 0x84, 0x28,
+                        0x39,
+                    },
 
-                        // ciphertext
-                        new byte[]
-                        {
-                            0xA6, 0x51, 0xB4, 0xF2, 0x2B, 0xFA, 0x22, 0xF5,
-                            0x15, 0x1E, 0x5E, 0x65, 0x39, 0xFD, 0x84, 0x4F,
-                            0xE1, 0x7E,
-                        },
+                    PaddingMode.ISO10126,
+                    CipherMode.CFB,
+                    8,
+                };
 
-                        PaddingMode.ISO10126,
-                        CipherMode.CFB,
-                        8,
-                    };
-                }
+                yield return new object[]
+                {
+                    // plaintext
+                    new byte[]
+                    {
+                        0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
+                        0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
+                        0x59,
+                    },
+
+                    // ciphertext
+                    new byte[]
+                    {
+                        0xA6, 0x51, 0xB4, 0xF2, 0x2B, 0xFA, 0x22, 0xF5,
+                        0x15, 0x1E, 0x5E, 0x65, 0x39, 0xFD, 0x84, 0x4F,
+                        0xE1, 0x7E,
+                    },
+
+                    PaddingMode.PKCS7,
+                    CipherMode.CFB,
+                    8,
+                };
+
+                yield return new object[]
+                {
+                    // plaintext
+                    new byte[]
+                    {
+                        0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
+                        0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
+                        0x59,
+                    },
+
+                    // ciphertext
+                    new byte[]
+                    {
+                        0xA6, 0x51, 0xB4, 0xF2, 0x2B, 0xFA, 0x22, 0xF5,
+                        0x15, 0x1E, 0x5E, 0x65, 0x39, 0xFD, 0x84, 0x4F,
+                        0xE1,
+                    },
+
+                    PaddingMode.None,
+                    CipherMode.CFB,
+                    8,
+                };
+
+                yield return new object[]
+                {
+                    // plaintext
+                    new byte[]
+                    {
+                        0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
+                        0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
+                        0x59,
+                    },
+
+                    // ciphertext
+                    new byte[]
+                    {
+                        0xA6, 0x51, 0xB4, 0xF2, 0x2B, 0xFA, 0x22, 0xF5,
+                        0x15, 0x1E, 0x5E, 0x65, 0x39, 0xFD, 0x84, 0x4F,
+                        0xE1,
+                    },
+
+                    PaddingMode.Zeros,
+                    CipherMode.CFB,
+                    8,
+                };
+
+                yield return new object[]
+                {
+                    // plaintext
+                    new byte[]
+                    {
+                        0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
+                        0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
+                        0x59,
+                    },
+
+                    // ciphertext
+                    new byte[]
+                    {
+                        0xA6, 0x51, 0xB4, 0xF2, 0x2B, 0xFA, 0x22, 0xF5,
+                        0x15, 0x1E, 0x5E, 0x65, 0x39, 0xFD, 0x84, 0x4F,
+                        0xE1, 0x7E,
+                    },
+
+                    PaddingMode.ANSIX923,
+                    CipherMode.CFB,
+                    8,
+                };
+
+                yield return new object[]
+                {
+                    // plaintext
+                    new byte[]
+                    {
+                        0x99, 0x50, 0x68, 0x12, 0xA4, 0x5F, 0x08, 0xC8,
+                        0x89, 0xB9, 0x7F, 0x59, 0x80, 0x03, 0x8B, 0x83,
+                        0x59,
+                    },
+
+                    // ciphertext
+                    new byte[]
+                    {
+                        0xA6, 0x51, 0xB4, 0xF2, 0x2B, 0xFA, 0x22, 0xF5,
+                        0x15, 0x1E, 0x5E, 0x65, 0x39, 0xFD, 0x84, 0x4F,
+                        0xE1, 0x7E,
+                    },
+
+                    PaddingMode.ISO10126,
+                    CipherMode.CFB,
+                    8,
+                };
             }
         }
     }

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESCipherTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESCipherTests.cs
@@ -254,7 +254,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(PaddingMode.None)]
         [InlineData(PaddingMode.Zeros)]
         public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_0(PaddingMode paddingMode)
@@ -272,7 +272,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(PaddingMode.None)]
         [InlineData(PaddingMode.Zeros)]
         public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_1(PaddingMode paddingMode)
@@ -290,7 +290,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(PaddingMode.None)]
         [InlineData(PaddingMode.Zeros)]
         public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_2(PaddingMode paddingMode)
@@ -308,7 +308,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(CipherMode.CBC, 0)]
         [InlineData(CipherMode.CFB, 8)]
         [InlineData(CipherMode.ECB, 0)]
@@ -337,7 +337,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(CipherMode.CBC, 0)]
         [InlineData(CipherMode.CFB, 8)]
         [InlineData(CipherMode.ECB, 0)]
@@ -371,7 +371,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(PaddingMode.None)]
         [InlineData(PaddingMode.Zeros)]
         public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_3(PaddingMode paddingMode)
@@ -389,7 +389,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB8_PKCS7_3()
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=3
@@ -405,7 +405,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(PaddingMode.None)]
         [InlineData(PaddingMode.Zeros)]
         public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_4(PaddingMode paddingMode)
@@ -423,7 +423,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(PaddingMode.None)]
         [InlineData(PaddingMode.Zeros)]
         public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_5(PaddingMode paddingMode)
@@ -441,7 +441,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(PaddingMode.None)]
         [InlineData(PaddingMode.Zeros)]
         public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_6(PaddingMode paddingMode)
@@ -459,7 +459,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(PaddingMode.None)]
         [InlineData(PaddingMode.Zeros)]
         public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_7(PaddingMode paddingMode)
@@ -477,7 +477,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(PaddingMode.None)]
         [InlineData(PaddingMode.Zeros)]
         public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_8(PaddingMode paddingMode)
@@ -495,7 +495,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             );
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(PaddingMode.None)]
         [InlineData(PaddingMode.Zeros)]
         public static void VerifyKnownTransform_CFB8_NoOrZeroPadding_9(PaddingMode paddingMode)

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/DES/DESContractTests.cs
@@ -12,56 +12,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
     [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public static class DesContractTests
     {
-        // cfb not available on windows 7
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows7))]
-        [InlineData(0, true)]
-        [InlineData(1, true)]
-        [InlineData(7, true)]
-        [InlineData(9, true)]
-        [InlineData(-1, true)]
-        [InlineData(int.MaxValue, true)]
-        [InlineData(int.MinValue, true)]
-        [InlineData(8, false)]
-        [InlineData(64, false)]
-        [InlineData(256, true)]
-        [InlineData(128, true)]
-        [InlineData(127, true)]
-        public static void Windows7DoesNotSupportCFB(int feedbackSize, bool discoverableInSetter)
-        {
-            using (DES des = DESFactory.Create())
-            {
-                des.GenerateKey();
-                des.Mode = CipherMode.CFB;
-
-                if (discoverableInSetter)
-                {
-                    // there are some key sizes that are invalid for any of the modes,
-                    // so the exception is thrown in the setter
-                    Assert.ThrowsAny<CryptographicException>(() =>
-                    {
-                        des.FeedbackSize = feedbackSize;
-                    });
-                }
-                else
-                {
-                    des.FeedbackSize = feedbackSize;
-
-                    // however, for CFB only few sizes are valid. Those should throw in the
-                    // actual DES instantiation.
-
-                    Assert.ThrowsAny<CryptographicException>(() =>
-                    {
-                        return des.CreateDecryptor();
-                    });
-                    Assert.ThrowsAny<CryptographicException>(() =>
-                    {
-                        return des.CreateEncryptor();
-                    });
-                }
-            }
-        }
-
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(0, true)]
         [InlineData(1, true)]
         [InlineData(7, true)]
@@ -102,7 +53,7 @@ namespace System.Security.Cryptography.Encryption.Des.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(8)]
         public static void ValidCFBFeedbackSizes(int feedbackSize)
         {

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/RSA/ImportExport.cs
@@ -311,7 +311,7 @@ namespace System.Security.Cryptography.Rsa.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public static void ImportZeroModulus(bool includePrivateParameters)

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/Symmetric/SymmetricOneShotBase.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/Symmetric/SymmetricOneShotBase.cs
@@ -419,7 +419,7 @@ namespace System.Security.Cryptography.Tests
             Assert.Empty(missingMethods);
         }
 
-        [Fact]
+        [ConditionalFact]
         public void DecryptOneShot_Cfb8_ToleratesExtraPadding()
         {
             using (SymmetricAlgorithm alg = CreateAlgorithm())
@@ -498,7 +498,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(PaddingMode.PKCS7, 0)]
         [InlineData(PaddingMode.ANSIX923, 0)]
         [InlineData(PaddingMode.ISO10126, 0)]
@@ -553,7 +553,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(PaddingMode.PKCS7)]
         [InlineData(PaddingMode.ANSIX923)]
         [InlineData(PaddingMode.ISO10126)]

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/Symmetric/SymmetricOneShotBase.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/Symmetric/SymmetricOneShotBase.cs
@@ -419,7 +419,7 @@ namespace System.Security.Cryptography.Tests
             Assert.Empty(missingMethods);
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public void DecryptOneShot_Cfb8_ToleratesExtraPadding()
         {
             using (SymmetricAlgorithm alg = CreateAlgorithm())
@@ -498,7 +498,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(PaddingMode.PKCS7, 0)]
         [InlineData(PaddingMode.ANSIX923, 0)]
         [InlineData(PaddingMode.ISO10126, 0)]
@@ -553,7 +553,7 @@ namespace System.Security.Cryptography.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(PaddingMode.PKCS7)]
         [InlineData(PaddingMode.ANSIX923)]
         [InlineData(PaddingMode.ISO10126)]

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESCipherTests.cs
@@ -137,7 +137,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB64_PKCS7_2()
         {
             // NIST CAVS TDESMMT.ZIP TCFB8MMT2.rsp, [DECRYPT] COUNT=2
@@ -271,7 +271,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB64_NoPadding_0()
         {
             // NIST CAVS TDESMMT.ZIP TCFB64MMT2.rsp, [DECRYPT] COUNT=0
@@ -286,7 +286,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(CipherMode.CBC, 0)]
         [InlineData(CipherMode.CFB, 8)]
         [InlineData(CipherMode.CFB, 64)]
@@ -316,7 +316,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(CipherMode.CBC, 0)]
         [InlineData(CipherMode.CFB, 8)]
         [InlineData(CipherMode.CFB, 64)]
@@ -351,7 +351,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB64_NoPadding_1()
         {
             // NIST CAVS TDESMMT.ZIP TCFB64MMT2.rsp, [DECRYPT] COUNT=1
@@ -366,7 +366,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB64_NoPadding_2()
         {
             // NIST CAVS TDESMMT.ZIP TCFB64MMT2.rsp, [DECRYPT] COUNT=2
@@ -381,7 +381,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB64_NoPadding_3()
         {
             // NIST CAVS TDESMMT.ZIP TCFB64MMT2.rsp, [DECRYPT] COUNT=3
@@ -396,7 +396,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB64_NoPadding_4()
         {
             // NIST CAVS TDESMMT.ZIP TCFB64MMT2.rsp, [DECRYPT] COUNT=4
@@ -411,7 +411,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB64_NoPadding_5()
         {
             // NIST CAVS TDESMMT.ZIP TCFB64MMT2.rsp, [DECRYPT] COUNT=5
@@ -426,7 +426,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB64_NoPadding_6()
         {
             // NIST CAVS TDESMMT.ZIP TCFB64MMT2.rsp, [DECRYPT] COUNT=6
@@ -441,7 +441,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB64_NoPadding_7()
         {
             // NIST CAVS TDESMMT.ZIP TCFB64MMT2.rsp, [DECRYPT] COUNT=7
@@ -456,7 +456,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB64_NoPadding_8()
         {
             // NIST CAVS TDESMMT.ZIP TCFB64MMT2.rsp, [DECRYPT] COUNT=8
@@ -471,7 +471,7 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             );
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Fact]
         public static void VerifyKnownTransform_CFB64_NoPadding_9()
         {
             // NIST CAVS TDESMMT.ZIP TCFB64MMT2.rsp, [DECRYPT] COUNT=9

--- a/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESContractTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESContractTests.cs
@@ -10,21 +10,6 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
     [SkipOnPlatform(TestPlatforms.Browser, "Not supported on Browser")]
     public static class TripleDESContractTests
     {
-
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows7))]
-        public static void Windows7DoesNotSupportCFB64()
-        {
-            using (TripleDES tdes = TripleDESFactory.Create())
-            {
-                tdes.GenerateKey();
-                tdes.Mode = CipherMode.CFB;
-                tdes.FeedbackSize = 64;
-
-                Assert.ThrowsAny<CryptographicException>(() => tdes.CreateDecryptor());
-                Assert.ThrowsAny<CryptographicException>(() => tdes.CreateEncryptor());
-            }
-        }
-
         [Theory]
         [InlineData(0, true)]
         [InlineData(1, true)]
@@ -65,17 +50,11 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindows7))]
+        [Theory]
         [InlineData(8)]
         [InlineData(64)]
         public static void ValidCFBFeedbackSizes(int feedbackSize)
         {
-            // Windows 7 only supports CFB8.
-            if (feedbackSize != 8 && PlatformDetection.IsWindows7)
-            {
-                return;
-            }
-
             using (TripleDES tdes = TripleDESFactory.Create())
             {
                 tdes.GenerateKey();

--- a/src/libraries/System.Security.Cryptography/tests/DefaultDSAProvider.cs
+++ b/src/libraries/System.Security.Cryptography/tests/DefaultDSAProvider.cs
@@ -27,7 +27,7 @@ namespace System.Security.Cryptography.Dsa.Tests
         {
             get
             {
-                return PlatformSupport.IsDSASupported && !PlatformDetection.IsWindows7;
+                return PlatformSupport.IsDSASupported;
             }
         }
     }

--- a/src/libraries/System.Security.Cryptography/tests/RijndaelTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/RijndaelTests.cs
@@ -302,10 +302,6 @@ namespace System.Security.Cryptography.Tests
         [InlineData(null)]
         public static void CfbFeedbackSizeIsRespected(int? feedbackSize)
         {
-            // Windows 7 CFB only supports CFB8.
-            if (PlatformDetection.IsWindows7 && feedbackSize != 8)
-                return;
-
             void Test(Rijndael alg)
             {
                 alg.Mode = CipherMode.CFB;

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/X500DistinguishedNameTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/X500DistinguishedNameTests.cs
@@ -210,15 +210,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [SkipOnPlatform(TestPlatforms.Browser, "Browser doesn't support an X.509 PAL")]
         public static void TpmIdentifiers()
         {
-            // On Windows the X.500 name pretty printer is in crypt32, so it doesn't use our OidLookup.
-            // Windows 7 doesn't have the TPM OIDs mapped, so they come back as (e.g.) OID.2.23.133.2.3 still.
-            //
-            // Just skip this test there.
-            if (PlatformDetection.IsWindows7)
-            {
-                return;
-            }
-
             X500DistinguishedName dn = new X500DistinguishedName("OID.2.23.133.2.3=id:0020065,OID.2.23.133.2.2=,OID.2.23.133.2.1=id:564D5700");
             X500DistinguishedName dn2 = new X500DistinguishedName(dn.RawData);
             Assert.Equal("TPMManufacturer=id:564D5700, TPMModel=\"\", TPMVersion=id:0020065", dn2.Decode(X500DistinguishedNameFlags.None));


### PR DESCRIPTION
Some tests were conditioned to only run on Windows 7. Those tests were removed.

Other tests were conditioned to run on things other that Windows 7. These conditions were removed.

Best reviewed ignoring whitespace changes.