### PR TITLE
JIT: Skip redundant AND masking in NarrowWithSaturation codegen

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -3359,7 +3359,8 @@ public:
                                  GenTree*    op1,
                                  GenTree*    op2,
                                  var_types   simdBaseType,
-                                 unsigned    simdSize);
+                                 unsigned    simdSize,
+                                 bool        inputsAlreadyClamped = false);
 
     GenTree* gtNewSimdRoundNode(
         var_types type, GenTree* op1, var_types simdBaseType, unsigned simdSize);

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -3541,7 +3541,8 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                     op2 = gtNewSimdMinMaxNode(retType, op2, gtCloneExpr(maxCns), simdBaseType, simdSize,
                                               /* isMax */ false, /* isMagnitude */ false, /* isNumber */ false);
 
-                    retNode = gtNewSimdNarrowNode(retType, op1, op2, narrowSimdBaseType, simdSize);
+                    retNode = gtNewSimdNarrowNode(retType, op1, op2, narrowSimdBaseType, simdSize,
+                                                  /* inputsAlreadyClamped */ true);
                 }
             }
             break;

--- a/src/coreclr/jit/hwintrinsicxarch.cpp
+++ b/src/coreclr/jit/hwintrinsicxarch.cpp
@@ -3541,8 +3541,15 @@ GenTree* Compiler::impSpecialIntrinsic(NamedIntrinsic        intrinsic,
                     op2 = gtNewSimdMinMaxNode(retType, op2, gtCloneExpr(maxCns), simdBaseType, simdSize,
                                               /* isMax */ false, /* isMagnitude */ false, /* isNumber */ false);
 
-                    retNode = gtNewSimdNarrowNode(retType, op1, op2, narrowSimdBaseType, simdSize,
-                                                  /* inputsAlreadyClamped */ true);
+                    // For unsigned narrow types (TYP_UBYTE, TYP_USHORT, TYP_UINT), the clamping
+                    // already ensures the upper bits are zero, so the AND masking in
+                    // gtNewSimdNarrowNode is redundant. For signed narrow types, we still need
+                    // the AND masking to clear sign-extended bits before PackUnsignedSaturate
+                    // can correctly pack the values.
+                    bool inputsAlreadyClamped = varTypeIsUnsigned(narrowSimdBaseType);
+
+                    retNode =
+                        gtNewSimdNarrowNode(retType, op1, op2, narrowSimdBaseType, simdSize, inputsAlreadyClamped);
                 }
             }
             break;


### PR DESCRIPTION
Fixes #116526

When `NarrowWithSaturation` is used with **unsigned** narrow types (e.g., `UInt32` → `UInt16`, `UInt16` → `Byte`), we're already clamping via `Min()` internally - so the subsequent `vpand` to mask the result is redundant. This adds an `inputsAlreadyClamped` param to `gtNewSimdNarrowNode` so callers like `NarrowWithSaturation` can skip the extra AND for unsigned types.

**Note:** For **signed** narrow types (e.g., `Int32` → `Int16`), the AND masking is still required. After clamping, negative values have sign-extended upper bits that must be cleared before `PackUnsignedSaturate` can correctly pack them.

Approach suggested by @tannergooding in the issue.

**Before (unsigned narrowing):**
```asm
vpminuw  xmm1, xmm0, xmmword ptr [...]
vpand    xmm1, xmm1, xmm0
vpminuw  xmm2, xmm0, xmmword ptr [...]
vpand    xmm0, xmm2, xmm0
vpackuswb xmm0, xmm1, xmm0
```

**After (unsigned narrowing):**
```asm
vpminuw  xmm1, xmm0, xmmword ptr [...]
vpminuw  xmm0, xmm0, xmmword ptr [...]
vpackuswb xmm0, xmm1, xmm0
```

ARM64 isn't affected - it uses AdvSimd intrinsics that handle this natively.

Tested with System.Runtime.Intrinsics and System.Numerics.Vectors test suites.
