### PR TITLE
JIT: SpanHelpers.Fill may escape its last argument

### DIFF
--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -2203,10 +2203,18 @@ void ObjectAllocator::AnalyzeParentStack(ArrayStack<GenTree*>* parentStack, unsi
                     switch (comp->lookupNamedIntrinsic(call->gtCallMethHnd))
                     {
                         case NI_System_SpanHelpers_ClearWithoutReferences:
-                        case NI_System_SpanHelpers_Fill:
                         case NI_System_SpanHelpers_Memmove:
                         case NI_System_SpanHelpers_SequenceEqual:
                             canLclVarEscapeViaParentStack = false;
+                            break;
+
+                        case NI_System_SpanHelpers_Fill:
+                            // For Fill only the first (byref span) arg does not escape
+                            //
+                            if (tree == call->gtArgs.GetUserArgByIndex(0)->GetNode())
+                            {
+                                canLclVarEscapeViaParentStack = false;
+                            }
                             break;
 
                         default:

--- a/src/tests/JIT/opt/ObjectStackAllocation/Runtime_122879.cs
+++ b/src/tests/JIT/opt/ObjectStackAllocation/Runtime_122879.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Poco(string value)
+{
+    public string Value { get; } = value;
+}
+
+public class Runtime_122879
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void StackTrasher()
+    {
+        Guid heavy = Guid.NewGuid();
+        heavy.ToString();
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveOptimization | MethodImplOptions.NoInlining)]
+    static Poco[] Creator() => CreateArray(new Poco("Passed"), 2);
+
+    static T[] CreateArray<T>(T value, int count)
+    {
+        var output = new T[count];
+        output.AsSpan().Fill(value);
+        return output;
+    }
+
+    [Fact]
+    public static void Test()
+    {
+        var result = Creator();
+        StackTrasher(); // Removing this line makes it work as expected
+        Console.WriteLine(result[0].Value);
+    }
+}

--- a/src/tests/JIT/opt/ObjectStackAllocation/Runtime_122879.csproj
+++ b/src/tests/JIT/opt/ObjectStackAllocation/Runtime_122879.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes #122879.