### PR TITLE
Remove now obsolete POPFRAMES

### DIFF
--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -2102,6 +2102,8 @@ public:
     // SKIPFUNCLETS includes functionless frames but excludes all funclets and everything between funclets and their parent methods
     #define SKIPFUNCLETS                    0x0002
 
+    // UNUSED                               0x0004
+    
     #define QUICKUNWIND                     0x0008 // do not restore all registers during unwind
 
     #define HANDLESKIPPEDFRAMES             0x0010 // temporary to handle skipped frames for appdomain unload

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -2102,8 +2102,6 @@ public:
     // SKIPFUNCLETS includes functionless frames but excludes all funclets and everything between funclets and their parent methods
     #define SKIPFUNCLETS                    0x0002
 
-    #define POPFRAMES                       0x0004
-
     #define QUICKUNWIND                     0x0008 // do not restore all registers during unwind
 
     #define HANDLESKIPPEDFRAMES             0x0010 // temporary to handle skipped frames for appdomain unload


### PR DESCRIPTION
After the change that removed `FEATURE_EH_FUNCLETS`, the `POPFRAMES` stackwalk option is no longer used. Also all code under `STACKWALKER_MAY_POP_FRAMES` ifdef can be removed.