### PR TITLE
Replace a couple of Hashtables in CoreLib with ConcurrentDictionary

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/CurrentSystemTimeZone.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/CurrentSystemTimeZone.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Globalization;
 

--- a/src/libraries/System.Private.CoreLib/src/System/CurrentSystemTimeZone.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/CurrentSystemTimeZone.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Globalization;
 
 namespace System
@@ -156,27 +157,11 @@ namespace System
             }
         }
 
-        private DaylightTime GetCachedDaylightChanges(int year)
-        {
-            object objYear = (object)year;
-
-            if (!m_CachedDaylightChanges.Contains(objYear))
-            {
-                DaylightTime currentDaylightChanges = CreateDaylightChanges(year);
-                lock (m_CachedDaylightChanges)
-                {
-                    if (!m_CachedDaylightChanges.Contains(objYear))
-                    {
-                        m_CachedDaylightChanges.Add(objYear, currentDaylightChanges);
-                    }
-                }
-            }
-
-            return (DaylightTime)m_CachedDaylightChanges[objYear]!;
-        }
+        private DaylightTime GetCachedDaylightChanges(int year) =>
+            m_CachedDaylightChanges.GetOrAdd(year, CreateDaylightChanges);
 
         // The per-year information is cached in this instance value. As a result it can
         // be cleaned up by CultureInfo.ClearCachedData, which will clear the instance of this object
-        private readonly Hashtable m_CachedDaylightChanges = new Hashtable();
+        private readonly ConcurrentDictionary<int, DaylightTime> m_CachedDaylightChanges = [];
     } // class CurrentSystemTimeZone
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
@@ -15,7 +16,7 @@ namespace System.Text
     //
     internal static partial class EncodingTable
     {
-        private static readonly Hashtable s_nameToCodePage = Hashtable.Synchronized(new Hashtable(StringComparer.OrdinalIgnoreCase));
+        private static readonly ConcurrentDictionary<string, int> s_nameToCodePage = new(StringComparer.OrdinalIgnoreCase);
         private static CodePageDataItem?[]? s_codePageToCodePageData;
 
         /*=================================GetCodePageFromName==========================
@@ -32,18 +33,7 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(name);
 
-            object? codePageObj = s_nameToCodePage[name];
-
-            if (codePageObj != null)
-            {
-                return (int)codePageObj;
-            }
-
-            int codePage = InternalGetCodePageFromName(name);
-
-            s_nameToCodePage[name] = codePage;
-
-            return codePage;
+            return s_nameToCodePage.GetOrAdd(name, InternalGetCodePageFromName);
         }
 
         // Find the data item by binary searching the table.

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingTable.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;


### PR DESCRIPTION
Avoids boxing keys/values, makes things more strongly typed, and reduces some ceremony.