### PR TITLE
[EventPipe] BufferManager Event Heap

### DIFF
--- a/src/native/eventpipe/ep-types-forward.h
+++ b/src/native/eventpipe/ep-types-forward.h
@@ -12,6 +12,8 @@ typedef struct _EventFilterDescriptor EventFilterDescriptor;
 typedef struct _EventPipeBuffer EventPipeBuffer;
 typedef struct _EventPipeBufferList EventPipeBufferList;
 typedef struct _EventPipeBufferManager EventPipeBufferManager;
+typedef struct _EventPipeBufferManagerEventHeap EventPipeBufferManagerEventHeap;
+typedef struct _EventPipeBufferManagerEventHeapNode EventPipeBufferManagerEventHeapNode;
 typedef struct _EventPipeBlock EventPipeBlock;
 typedef struct _EventPipeBlockVtable EventPipeBlockVtable;
 typedef struct _EventPipeConfiguration EventPipeConfiguration;


### PR DESCRIPTION
The implementation is currently based on the thread-lock removal in https://github.com/dotnet/runtime/pull/118415. It'll be some work to decouple, but I'd figure the event heap implementation can be mostly reviewed separately.