### PR TITLE
[TestOnly] Enable runtime async in Libraries partition + disable 

### DIFF
--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -588,7 +588,7 @@ OPT_CONFIG_INTEGER(JitDoIfConversion, "JitDoIfConversion", 1)                   
 OPT_CONFIG_INTEGER(JitDoOptimizeMaskConversions, "JitDoOptimizeMaskConversions", 1) // Perform optimization of mask
                                                                                     // conversions
 
-OPT_CONFIG_INTEGER(JitOptimizeAwait, "JitOptimizeAwait", 1) // Perform optimization of Await intrinsics
+OPT_CONFIG_INTEGER(JitOptimizeAwait, "JitOptimizeAwait", 0) // Perform optimization of Await intrinsics
 
 RELEASE_CONFIG_INTEGER(JitEnableOptRepeat, "JitEnableOptRepeat", 1) // If zero, do not allow JitOptRepeat
 RELEASE_CONFIG_METHODSET(JitOptRepeat, "JitOptRepeat")            // Runs optimizer multiple times on specified methods

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -99,4 +99,8 @@
     <CoverageIncludeDirectory Include="shared\Microsoft.NETCore.App\$(ProductVersion)" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <Features Condition="'$(RuntimeFlavor)' != 'mono' and '$(TestBuildMode)' != 'nativeaot' and '$(TargetArchitecture)' != 'wasm'">$(Features);runtime-async=on</Features>
+  </PropertyGroup>
+  
 </Project>

--- a/src/libraries/Directory.Build.props
+++ b/src/libraries/Directory.Build.props
@@ -101,6 +101,8 @@
 
   <PropertyGroup>
     <Features Condition="'$(RuntimeFlavor)' != 'mono' and '$(TestBuildMode)' != 'nativeaot' and '$(TargetArchitecture)' != 'wasm'">$(Features);runtime-async=on</Features>
+    <NoWarn>$(NoWarn);SYSLIB5007</NoWarn>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
   </PropertyGroup>
   
 </Project>


### PR DESCRIPTION
Re:https://github.com/dotnet/runtime/issues/122052#issuecomment-3716664417

An equivalent of running everything with `set DOTNET_JitOptimizeAwait=0`

Not for merging. 
Just checking what will fail if Await optimisation is disabled.
