### PR TITLE
JIT: Mark non-internal block as imported

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -2016,6 +2016,8 @@ BasicBlock* AsyncTransformation::RethrowExceptionOnResumption(BasicBlock*       
     if ((rethrowExceptionBB->Prev() == block) && !block->HasFlag(BBF_INTERNAL))
     {
         rethrowExceptionBB->RemoveFlags(BBF_INTERNAL);
+        // Non-internal blocks must be marked imported
+        rethrowExceptionBB->SetFlags(BBF_IMPORTED);
     }
 
     BasicBlock* storeResultBB = m_comp->fgNewBBafter(BBJ_ALWAYS, resumeBB, true);


### PR DESCRIPTION
The JIT has some debug checking that validates that non-internal blocks are always marked `BBF_IMPORTED`. We introduce such a block in the async rewrite (it should not be internal due to debug info), so make sure we uphold that invariant.

The check happens here:
https://github.com/dotnet/runtime/blob/87b69c5f69f306251524fcd4ba80ceab7cb4bba9/src/coreclr/jit/fgdiagnostic.cpp#L114-L124

Fix #122963