### PR TITLE
Add AggressiveInlining to EnsureInitializedCore method to allow delegates stack alloc

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/LazyInitializer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/LazyInitializer.cs
@@ -110,13 +110,14 @@ namespace System.Threading
         /// <param name="target">The variable that need to be initialized</param>
         /// <param name="valueFactory">The delegate that will be executed to initialize the target</param>
         /// <returns>The initialized variable</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static T EnsureInitializedCore<T>([NotNull] ref T? target, Func<T> valueFactory) where T : class
         {
-            T value = valueFactory() ?? throw new InvalidOperationException(SR.Lazy_StaticInit_InvalidOperation);
+            T value = valueFactory() ?? Throw();
             Interlocked.CompareExchange(ref target, value, null!);
             Debug.Assert(target != null);
             return target;
+
+            static T Throw() => throw new InvalidOperationException(SR.Lazy_StaticInit_InvalidOperation);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/LazyInitializer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/LazyInitializer.cs
@@ -112,12 +112,18 @@ namespace System.Threading
         /// <returns>The initialized variable</returns>
         private static T EnsureInitializedCore<T>([NotNull] ref T? target, Func<T> valueFactory) where T : class
         {
-            T value = valueFactory() ?? Throw();
+            T? value = valueFactory();
+            if (value is null)
+            {
+                Throw();
+            }
+
             Interlocked.CompareExchange(ref target, value, null!);
             Debug.Assert(target != null);
             return target;
 
-            static T Throw() => throw new InvalidOperationException(SR.Lazy_StaticInit_InvalidOperation);
+            [DoesNotReturn]
+            static void Throw() => throw new InvalidOperationException(SR.Lazy_StaticInit_InvalidOperation);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/LazyInitializer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/LazyInitializer.cs
@@ -9,6 +9,7 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace System.Threading
 {
@@ -109,6 +110,7 @@ namespace System.Threading
         /// <param name="target">The variable that need to be initialized</param>
         /// <param name="valueFactory">The delegate that will be executed to initialize the target</param>
         /// <returns>The initialized variable</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static T EnsureInitializedCore<T>([NotNull] ref T? target, Func<T> valueFactory) where T : class
         {
             T value = valueFactory() ?? throw new InvalidOperationException(SR.Lazy_StaticInit_InvalidOperation);


### PR DESCRIPTION
Currently stack allocation (and overall de-abstraction) works only when JIT can has a full understanding of the code. And due to lack of cross-prodcedural analysis it means that for the optimization to work the operations should be inlined.

The same is true for `LazyInitializer.EnsureInitialized` that takes a delegate. Currently, because `EnsureInitializedCore` quite big and can't be inlined by default, JIT can't stack allocate the delegate passed to the method.

The following benchmark shows the impact of this change:

```csharp
[MemoryDiagnoser]
[ShortRunJob(RuntimeMoniker.Net90)]
[ShortRunJob(RuntimeMoniker.Net10_0)]
[CategoriesColumn]
[HideColumns(Column.Job, Column.Error, Column.Median, Column.RatioSD, Column.Ratio, Column.AllocRatio, Column.StdDev, Column.Gen0)]

public class BenchmarkingDelegates
{
    private string _cachedValue;

    [Benchmark]
    public string EnsureInitialized_Old()
    {
        string defaultValue = "defaultValue";
        return LazyInitializer.EnsureInitialized(ref _cachedValue, () => defaultValue);
    }

   
    [Benchmark]
    public string EnsureInitialized_New()
    {
        string defaultValue = "defaultValue";
        return MyLazyInitializer.EnsureInitialized(ref _cachedValue, () => defaultValue);
    }
```

The output:

```csharp
| Method                | Runtime   | Mean     | Allocated |
|---------------------- |---------- |---------:|----------:|
| EnsureInitialized_Old | .NET 10.0 | 5.374 ns |      88 B |
| EnsureInitialized_New | .NET 10.0 | 1.951 ns |      24 B |
| EnsureInitialized_Old | .NET 9.0  | 6.194 ns |      88 B |
| EnsureInitialized_New | .NET 9.0  | 6.041 ns |      88 B |
```

The `MyLazyInitializer` is the copy of the existing one with `AggressiveInlining` flag set.