### PR TITLE
skip timeout ping tests if test targets are unreachable

### DIFF
--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -803,15 +803,20 @@ namespace System.Net.NetworkInformation.Tests
                 reply = await sendPing(sender, TestSettings.UnreachableAddress3);
             }
 
+            if (reply.Status == IPStatus.DestinationNetworkUnreachable)
+            {
+                throw new SkipTestException("Unable to verify timeouts. Skipping test.");
+            }
+
             Assert.Equal(IPStatus.TimedOut, reply.Status);
         }
 
-        [Fact]
+        [ConditionalFact]
         [OuterLoop]
         public Task Ping_TimedOut_Sync_Success()
             => Ping_TimedOut_Core((sender, address) => Task.Run(() => sender.Send(address)));
 
-        [Fact]
+        [ConditionalFact]
         [OuterLoop]
         public Task Ping_TimedOut_EAP_Success()
             => Ping_TimedOut_Core(async (sender, address) =>
@@ -841,7 +846,7 @@ namespace System.Net.NetworkInformation.Tests
                 return reply;
             });
 
-        [Fact]
+        [ConditionalFact]
         [OuterLoop]
         public Task Ping_TimedOut_TAP_Success()
             => Ping_TimedOut_Core((sender, address) => sender.SendPingAsync(address));


### PR DESCRIPTION
fixes #115358
