### PR TITLE
[Wasm RyuJIT] Add some missing types to ins_Load and ins_Store

### DIFF
--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -2101,6 +2101,9 @@ instruction CodeGenInterface::ins_Load(var_types srcType, bool aligned /*=false*
 #if defined(TARGET_WASM)
     switch (srcType)
     {
+        case TYP_REF:
+        case TYP_BYREF:
+            // TODO-WASM: 64-bit
         case TYP_INT:
             return INS_i32_load;
         case TYP_LONG:
@@ -2501,6 +2504,9 @@ instruction CodeGenInterface::ins_Store(var_types dstType, bool aligned /*=false
 #if defined(TARGET_WASM)
     switch (dstType)
     {
+        case TYP_REF:
+        case TYP_BYREF:
+            // TODO-WASM: 64-bit
         case TYP_INT:
             return INS_i32_store;
         case TYP_LONG:

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -2103,7 +2103,7 @@ instruction CodeGenInterface::ins_Load(var_types srcType, bool aligned /*=false*
     {
         case TYP_REF:
         case TYP_BYREF:
-            // TODO-WASM: 64-bit
+            return ins_Load(TYP_I_IMPL, aligned);
         case TYP_INT:
             return INS_i32_load;
         case TYP_LONG:
@@ -2506,7 +2506,7 @@ instruction CodeGenInterface::ins_Store(var_types dstType, bool aligned /*=false
     {
         case TYP_REF:
         case TYP_BYREF:
-            // TODO-WASM: 64-bit
+            return ins_Store(TYP_I_IMPL, aligned);
         case TYP_INT:
             return INS_i32_store;
         case TYP_LONG:


### PR DESCRIPTION
We get a bunch of asserts here when doing superpmi replays, from TYP_REF ending up in here.