### PR TITLE
Fix EC-DSA / EC-DH PEM key loading with PKCS#8 key load attributes

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -1987,7 +1987,7 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     // keyAgreement is mandatory for id-ecPublicKey certificates
                     // when used with ECDH.
-                    return (ext.KeyUsages & X509KeyUsageFlags.KeyAgreement) != 0;
+                    return ((ext.KeyUsages & X509KeyUsageFlags.KeyAgreement) != 0);
                 }
             }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -2040,6 +2040,7 @@ namespace System.Security.Cryptography.X509Certificates
                         epki.EncryptedData.Span,
                         decryptedBuffer);
 
+                    decryptBufferClearSize = decryptedBytes;
                     X509Certificate2? loaded = ExtractKeyFromECPrivateKeyInfo(certificate, decryptedBuffer.AsMemory(0, decryptedBytes));
 
                     if (loaded is null)
@@ -2080,7 +2081,7 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     // EC PRIVATE KEYs do not have a key usage, so usage is determined by the certificate.
 
-                    // If we can load it is EC-DH, we should prefer that over EC-DH. ECC keys that are "both" prefer
+                    // If we can load it is EC-DH, we should prefer that over EC-DSA. ECC keys that are "both" prefer
                     // to be imported as EC-DH. Importing it as EC-DSA would restrict it to EC-DSA, even if the key
                     // and certificate are valid for EC-DH. Other platforms don't have such restrictions.
                     if (IsECDiffieHellman(certificate))
@@ -2150,7 +2151,7 @@ namespace System.Security.Cryptography.X509Certificates
             X509Certificate2 certificate,
             ReadOnlyMemory<byte> privateKeyInfo)
         {
-            // We are not going to perform any validate on the PrivateKeyInfo here. We just need a hint
+            // We are not going to perform any validation on the PrivateKeyInfo here. We just need a hint
             // what algorithm to use. The actual algorithm will do whatever validation on the key as needed.
             PrivateKeyInfoAsn privateKeyInfoAsn = PrivateKeyInfoAsn.Decode(privateKeyInfo, AsnEncodingRules.BER);
 
@@ -2170,7 +2171,6 @@ namespace System.Security.Cryptography.X509Certificates
             // it will work for EC-DSA, too) or as EC-DH explicitly.
             if ((usages is null || (usages & ~EcdsaKeyUsageFlags) != 0) && IsECDiffieHellman(certificate))
             {
-                // TODO: We need to handle both. What happens if the key has both keyAggreement and digitalSignature?
                 using (ECDiffieHellman ecdh = ECDiffieHellman.Create())
                 {
                     ecdh.ImportPkcs8PrivateKey(privateKeyInfo.Span, out int pkcs8Read);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509KeyUsageExtension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509KeyUsageExtension.cs
@@ -61,7 +61,7 @@ namespace System.Security.Cryptography.X509Certificates
         }
 
 
-        private static void DecodeX509KeyUsageExtension(byte[] encoded, out X509KeyUsageFlags keyUsages)
+        internal static void DecodeX509KeyUsageExtension(ReadOnlySpan<byte> encoded, out X509KeyUsageFlags keyUsages)
         {
             KeyUsageFlagsAsn keyUsagesAsn;
 

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509Certificate2PemTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509Certificate2PemTests.cs
@@ -824,6 +824,36 @@ MII
                 X509Certificate2.CreateFromPem(certContents));
         }
 
+        [Fact]
+        public static void CreateFromPem_CanImportECCAnyPublicKeyWithSigningKeyUsage()
+        {
+            const string PrivateKeyWithSigningKeyUsage =
+                """
+                -----BEGIN PRIVATE KEY-----
+                MIGiAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQghew4zS1/h2J+PJLX
+                SY2U8qo0pBbNaFXm5f3GzsTCIxigCgYIKoZIzj0DAQehRANCAAT83cB14Y8zLLxo
+                bliw/JsBoy7oyKD0zVMgRbieDBZEn/5UpHv2Xv6W0dE3mEG6goF3s8GT+pf4JUT2
+                EfthzGhnoA0wCwYDVR0PMQQDAgCA
+                -----END PRIVATE KEY-----
+                """;
+
+            const string AnyKeyUsageCertificate =
+                """
+                -----BEGIN CERTIFICATE-----
+                MIIBITCBx6ADAgECAgkA1dyp2OqNXw0wCgYIKoZIzj0EAwIwFjEUMBIGA1UEAxML
+                ZXhhbXBsZS5jb20wHhcNMjYwMTA2MTg1ODUxWhcNMjcwMTA2MTg1ODUxWjAWMRQw
+                EgYDVQQDEwtleGFtcGxlLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABPzd
+                wHXhjzMsvGhuWLD8mwGjLujIoPTNUyBFuJ4MFkSf/lSke/Ze/pbR0TeYQbqCgXez
+                wZP6l/glRPYR+2HMaGcwCgYIKoZIzj0EAwIDSQAwRgIhAPxduNwHwIafwVcfegnp
+                ocZs707jXBeVg1oxCZz5HwMeAiEAoFbL7kOyha8n0g2kkVaXNa0lWD62FZ1Jl+m9
+                bFYUxF4=
+                -----END CERTIFICATE-----
+                """;
+
+            using X509Certificate2 cert = X509Certificate2.CreateFromPem(AnyKeyUsageCertificate, PrivateKeyWithSigningKeyUsage);
+            AssertKeysMatch(PrivateKeyWithSigningKeyUsage, cert.GetECDsaPrivateKey);
+        }
+
         private static void AssertKeysMatch<T>(string keyPem, Func<T> keyLoader, string password = null) where T : IDisposable
         {
             IDisposable key = keyLoader();
@@ -890,7 +920,8 @@ MII
                         Assert.True(dsaPem.VerifyData(data, dsaSignature, HashAlgorithmName.SHA1));
                         break;
                     case (ECDiffieHellman ecdh, ECDiffieHellman ecdhPem):
-                        ECCurve curve = ecdh.KeySize switch {
+                        ECCurve curve = ecdh.KeySize switch
+                        {
                             256 => ECCurve.NamedCurves.nistP256,
                             384 => ECCurve.NamedCurves.nistP384,
                             521 => ECCurve.NamedCurves.nistP521,

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509Certificate2PemTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509Certificate2PemTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Security.Cryptography.Pkcs;
 using System.Security.Cryptography.SLHDsa.Tests;
 using System.Security.Cryptography.Tests;
 using Test.Cryptography;
@@ -824,16 +825,19 @@ MII
                 X509Certificate2.CreateFromPem(certContents));
         }
 
-        [Fact]
-        public static void CreateFromPem_CanImportECCAnyPublicKeyWithSigningKeyUsage()
+        [Theory]
+        [InlineData(X509KeyUsageFlags.CrlSign)]
+        [InlineData(X509KeyUsageFlags.KeyCertSign)]
+        [InlineData(X509KeyUsageFlags.DigitalSignature)]
+        public static void CreateFromPem_CanImportECCAnyPublicKeyWithSigningKeyUsage(X509KeyUsageFlags flags)
         {
-            const string PrivateKeyWithSigningKeyUsage =
+            const string PrivateKey =
                 """
                 -----BEGIN PRIVATE KEY-----
-                MIGiAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQghew4zS1/h2J+PJLX
+                MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQghew4zS1/h2J+PJLX
                 SY2U8qo0pBbNaFXm5f3GzsTCIxigCgYIKoZIzj0DAQehRANCAAT83cB14Y8zLLxo
                 bliw/JsBoy7oyKD0zVMgRbieDBZEn/5UpHv2Xv6W0dE3mEG6goF3s8GT+pf4JUT2
-                EfthzGhnoA0wCwYDVR0PMQQDAgCA
+                EfthzGhn
                 -----END PRIVATE KEY-----
                 """;
 
@@ -850,21 +854,61 @@ MII
                 -----END CERTIFICATE-----
                 """;
 
-            using X509Certificate2 cert = X509Certificate2.CreateFromPem(AnyKeyUsageCertificate, PrivateKeyWithSigningKeyUsage);
-            AssertKeysMatch(PrivateKeyWithSigningKeyUsage, cert.GetECDsaPrivateKey);
+            string privateKeyWithSigningKeyUsage = AddKeyUsageAttributeToPkcs8Key(PrivateKey, flags);
+            using X509Certificate2 cert = X509Certificate2.CreateFromPem(AnyKeyUsageCertificate, privateKeyWithSigningKeyUsage);
+            AssertKeysMatch(privateKeyWithSigningKeyUsage, cert.GetECDsaPrivateKey);
         }
 
-        [Fact]
-        public static void CreateFromEncryptedPem_CanImportECCAnyPublicKeyWithSigningKeyUsage()
+        [Theory]
+        [InlineData(X509KeyUsageFlags.CrlSign | X509KeyUsageFlags.KeyAgreement)]
+        [InlineData(X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.KeyAgreement)]
+        [InlineData(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyAgreement)]
+        public static void CreateFromPem_CanImportECCAnyPublicKeyWithMixedKeyUsage(X509KeyUsageFlags flags)
         {
-            const string PrivateKeyWithSigningKeyUsage =
+            const string PrivateKey =
+                """
+                -----BEGIN PRIVATE KEY-----
+                MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQghew4zS1/h2J+PJLX
+                SY2U8qo0pBbNaFXm5f3GzsTCIxigCgYIKoZIzj0DAQehRANCAAT83cB14Y8zLLxo
+                bliw/JsBoy7oyKD0zVMgRbieDBZEn/5UpHv2Xv6W0dE3mEG6goF3s8GT+pf4JUT2
+                EfthzGhn
+                -----END PRIVATE KEY-----
+                """;
+
+            const string AnyKeyUsageCertificate =
+                """
+                -----BEGIN CERTIFICATE-----
+                MIIBITCBx6ADAgECAgkA1dyp2OqNXw0wCgYIKoZIzj0EAwIwFjEUMBIGA1UEAxML
+                ZXhhbXBsZS5jb20wHhcNMjYwMTA2MTg1ODUxWhcNMjcwMTA2MTg1ODUxWjAWMRQw
+                EgYDVQQDEwtleGFtcGxlLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABPzd
+                wHXhjzMsvGhuWLD8mwGjLujIoPTNUyBFuJ4MFkSf/lSke/Ze/pbR0TeYQbqCgXez
+                wZP6l/glRPYR+2HMaGcwCgYIKoZIzj0EAwIDSQAwRgIhAPxduNwHwIafwVcfegnp
+                ocZs707jXBeVg1oxCZz5HwMeAiEAoFbL7kOyha8n0g2kkVaXNa0lWD62FZ1Jl+m9
+                bFYUxF4=
+                -----END CERTIFICATE-----
+                """;
+
+            string privateKeyWithSigningKeyUsage = AddKeyUsageAttributeToPkcs8Key(PrivateKey, flags);
+            using X509Certificate2 cert = X509Certificate2.CreateFromPem(AnyKeyUsageCertificate, privateKeyWithSigningKeyUsage);
+            AssertKeysMatch(privateKeyWithSigningKeyUsage, cert.GetECDsaPrivateKey);
+            AssertKeysMatch(privateKeyWithSigningKeyUsage, cert.GetECDiffieHellmanPrivateKey);
+        }
+
+        [Theory]
+        [InlineData(X509KeyUsageFlags.CrlSign)]
+        [InlineData(X509KeyUsageFlags.KeyCertSign)]
+        [InlineData(X509KeyUsageFlags.DigitalSignature)]
+        public static void CreateFromEncryptedPem_CanImportECCAnyPublicKeyWithSigningKeyUsage(X509KeyUsageFlags flags)
+        {
+            const string Password = "PLACEHOLDER";
+            const string PrivateKey =
                 """
                 -----BEGIN ENCRYPTED PRIVATE KEY-----
-                MIHIMBsGCiqGSIb3DQEMAQMwDQQIAcfnWs/6zc4CAQEEgajAD5o82qPGlBdrlKds
-                sbRD8IZLyPdXf6zqx7nJi23AzJ9scmFcFLlPEUclVAxiAOc2Z0XX4Ibq1B5KG+nZ
-                b/MzxqTUVn4pCf6C8i8Cm/YEndgbA3+220K+btUB8jW0UKudCa48EagHkscJag6M
-                RrvFmAK4JBlv/QHRx/TGxwsCYmnTmJKzZ7KrObid5cXdm8kqqxvfgjigDy7lNdzU
-                YoHsCUjWhEjdmbA=
+                MIHAMCMGCiqGSIb3DQEMAQMwFQQQ2yoyxTdfjrkU0Qyc3IYVywIBAQSBmPQJanYv
+                mAH35aWV39G4/yDdbSZHZbPsmoEq3waW+yB7a0LykybjfJlMhGYJks3gZN6N21NR
+                XpnByhtPBTXzrzjxnLv/DAwZIpNuYOOkTmRKDpVsjBsHUF3Gw2b5h0YU2I4cUl2p
+                BXh95HPB2tUNrDiHd3Zya6OnGG+fg7Ya35XIyWTJ1ODnhkVc2SVkXk7Lgku3I3gq
+                CJuz
                 -----END ENCRYPTED PRIVATE KEY-----
                 """;
 
@@ -881,12 +925,126 @@ MII
                 -----END CERTIFICATE-----
                 """;
 
+            string privateKeyWithSigningKeyUsage = AddKeyUsageAttributeToPkcs8Key(PrivateKey, flags, Password);
             using X509Certificate2 cert = X509Certificate2.CreateFromEncryptedPem(
                 AnyKeyUsageCertificate,
-                PrivateKeyWithSigningKeyUsage,
-                "PLACEHOLDER");
+                privateKeyWithSigningKeyUsage,
+                Password);
 
-            AssertKeysMatch(PrivateKeyWithSigningKeyUsage, cert.GetECDsaPrivateKey, "PLACEHOLDER");
+            AssertKeysMatch(privateKeyWithSigningKeyUsage, cert.GetECDsaPrivateKey, Password);
+        }
+
+        [Theory]
+        [InlineData(X509KeyUsageFlags.CrlSign | X509KeyUsageFlags.KeyAgreement)]
+        [InlineData(X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.KeyAgreement)]
+        [InlineData(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyAgreement)]
+        public static void CreateFromEncryptedPem_CanImportECCAnyPublicKeyWithMixedKeyUsage(X509KeyUsageFlags flags)
+        {
+            const string Password = "PLACEHOLDER";
+            const string PrivateKey =
+                """
+                -----BEGIN ENCRYPTED PRIVATE KEY-----
+                MIHAMCMGCiqGSIb3DQEMAQMwFQQQ2yoyxTdfjrkU0Qyc3IYVywIBAQSBmPQJanYv
+                mAH35aWV39G4/yDdbSZHZbPsmoEq3waW+yB7a0LykybjfJlMhGYJks3gZN6N21NR
+                XpnByhtPBTXzrzjxnLv/DAwZIpNuYOOkTmRKDpVsjBsHUF3Gw2b5h0YU2I4cUl2p
+                BXh95HPB2tUNrDiHd3Zya6OnGG+fg7Ya35XIyWTJ1ODnhkVc2SVkXk7Lgku3I3gq
+                CJuz
+                -----END ENCRYPTED PRIVATE KEY-----
+                """;
+
+            const string AnyKeyUsageCertificate =
+                """
+                -----BEGIN CERTIFICATE-----
+                MIIBHzCBxqADAgECAghjN3R7a8h36TAKBggqhkjOPQQDAjAWMRQwEgYDVQQDEwtl
+                eGFtcGxlLmNvbTAeFw0yNjAxMDcxODExMzFaFw0yNzAxMDcxODExMzFaMBYxFDAS
+                BgNVBAMTC2V4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeybq
+                p51w8CAD3rKIi/cKx6JKTR9Z7dGzt53gPpCS6fpqDJMC4revxduxoZ60MhZWFESL
+                rq3coMOQVWjZAAz8rjAKBggqhkjOPQQDAgNIADBFAiBm07dRWT23lsfefred+Kzh
+                ZO9CxVEnV0nBQPkJH8GlrAIhAMnIN8RgUmGeXHNdq4yBoLlEaQcVzMquERBkZ0AG
+                dmo9
+                -----END CERTIFICATE-----
+                """;
+
+            string privateKeyWithSigningKeyUsage = AddKeyUsageAttributeToPkcs8Key(PrivateKey, flags, Password);
+            using X509Certificate2 cert = X509Certificate2.CreateFromEncryptedPem(
+                AnyKeyUsageCertificate,
+                privateKeyWithSigningKeyUsage,
+                Password);
+
+            AssertKeysMatch(privateKeyWithSigningKeyUsage, cert.GetECDsaPrivateKey, Password);
+            AssertKeysMatch(privateKeyWithSigningKeyUsage, cert.GetECDiffieHellmanPrivateKey, Password);
+        }
+
+        [Fact]
+        public static void CreateFromPem_CanImportECCAnyPublicKeyWithKeyAgreementUsage()
+        {
+            const string PrivateKey =
+                """
+                -----BEGIN PRIVATE KEY-----
+                MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQghew4zS1/h2J+PJLX
+                SY2U8qo0pBbNaFXm5f3GzsTCIxigCgYIKoZIzj0DAQehRANCAAT83cB14Y8zLLxo
+                bliw/JsBoy7oyKD0zVMgRbieDBZEn/5UpHv2Xv6W0dE3mEG6goF3s8GT+pf4JUT2
+                EfthzGhn
+                -----END PRIVATE KEY-----
+                """;
+
+            const string AnyKeyUsageCertificate =
+                """
+                -----BEGIN CERTIFICATE-----
+                MIIBITCBx6ADAgECAgkA1dyp2OqNXw0wCgYIKoZIzj0EAwIwFjEUMBIGA1UEAxML
+                ZXhhbXBsZS5jb20wHhcNMjYwMTA2MTg1ODUxWhcNMjcwMTA2MTg1ODUxWjAWMRQw
+                EgYDVQQDEwtleGFtcGxlLmNvbTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABPzd
+                wHXhjzMsvGhuWLD8mwGjLujIoPTNUyBFuJ4MFkSf/lSke/Ze/pbR0TeYQbqCgXez
+                wZP6l/glRPYR+2HMaGcwCgYIKoZIzj0EAwIDSQAwRgIhAPxduNwHwIafwVcfegnp
+                ocZs707jXBeVg1oxCZz5HwMeAiEAoFbL7kOyha8n0g2kkVaXNa0lWD62FZ1Jl+m9
+                bFYUxF4=
+                -----END CERTIFICATE-----
+                """;
+
+            string privateKeyWithAgreementKeyUsage = AddKeyUsageAttributeToPkcs8Key(PrivateKey, X509KeyUsageFlags.KeyAgreement);
+            using X509Certificate2 cert = X509Certificate2.CreateFromPem(AnyKeyUsageCertificate, privateKeyWithAgreementKeyUsage);
+            AssertKeysMatch(privateKeyWithAgreementKeyUsage, cert.GetECDiffieHellmanPrivateKey);
+        }
+
+        [Fact]
+        public static void CreateFromEncryptedPem_CanImportECCAnyPublicKeyWithKeyAgreementKeyUsage()
+        {
+            const string Password = "PLACEHOLDER";
+            const string PrivateKey =
+                """
+                -----BEGIN ENCRYPTED PRIVATE KEY-----
+                MIHAMCMGCiqGSIb3DQEMAQMwFQQQ2yoyxTdfjrkU0Qyc3IYVywIBAQSBmPQJanYv
+                mAH35aWV39G4/yDdbSZHZbPsmoEq3waW+yB7a0LykybjfJlMhGYJks3gZN6N21NR
+                XpnByhtPBTXzrzjxnLv/DAwZIpNuYOOkTmRKDpVsjBsHUF3Gw2b5h0YU2I4cUl2p
+                BXh95HPB2tUNrDiHd3Zya6OnGG+fg7Ya35XIyWTJ1ODnhkVc2SVkXk7Lgku3I3gq
+                CJuz
+                -----END ENCRYPTED PRIVATE KEY-----
+                """;
+
+            const string AnyKeyUsageCertificate =
+                """
+                -----BEGIN CERTIFICATE-----
+                MIIBHzCBxqADAgECAghjN3R7a8h36TAKBggqhkjOPQQDAjAWMRQwEgYDVQQDEwtl
+                eGFtcGxlLmNvbTAeFw0yNjAxMDcxODExMzFaFw0yNzAxMDcxODExMzFaMBYxFDAS
+                BgNVBAMTC2V4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeybq
+                p51w8CAD3rKIi/cKx6JKTR9Z7dGzt53gPpCS6fpqDJMC4revxduxoZ60MhZWFESL
+                rq3coMOQVWjZAAz8rjAKBggqhkjOPQQDAgNIADBFAiBm07dRWT23lsfefred+Kzh
+                ZO9CxVEnV0nBQPkJH8GlrAIhAMnIN8RgUmGeXHNdq4yBoLlEaQcVzMquERBkZ0AG
+                dmo9
+                -----END CERTIFICATE-----
+                """;
+
+            string privateKeyWithAgreementKeyUsage = AddKeyUsageAttributeToPkcs8Key(
+                PrivateKey,
+                X509KeyUsageFlags.KeyAgreement,
+                Password);
+
+            using X509Certificate2 cert = X509Certificate2.CreateFromEncryptedPem(
+                AnyKeyUsageCertificate,
+                privateKeyWithAgreementKeyUsage,
+                Password);
+
+            AssertKeysMatch(privateKeyWithAgreementKeyUsage, cert.GetECDiffieHellmanPrivateKey, Password);
         }
 
         private static void AssertKeysMatch<T>(string keyPem, Func<T> keyLoader, string password = null) where T : IDisposable
@@ -991,6 +1149,34 @@ MII
                         throw new CryptographicException("Unknown key algorithm");
                 }
             }
+        }
+
+        private static string AddKeyUsageAttributeToPkcs8Key(
+            ReadOnlySpan<char> keyPem,
+            X509KeyUsageFlags flags,
+            string password = null)
+        {
+            X509KeyUsageExtension ext = new(flags, false);
+
+            PemFields fields = PemEncoding.Find(keyPem);
+            byte[] data = Convert.FromBase64String(keyPem[fields.Base64Data].ToString());
+
+            if (keyPem[fields.Label].SequenceEqual("PRIVATE KEY"))
+            {
+                Pkcs8PrivateKeyInfo info = Pkcs8PrivateKeyInfo.Decode(data, out _, skipCopy: true);
+                info.Attributes.Add(new AsnEncodedData(ext.Oid, ext.RawData));
+                return PemEncoding.WriteString("PRIVATE KEY", info.Encode());
+            }
+
+            if (keyPem[fields.Label].SequenceEqual("ENCRYPTED PRIVATE KEY"))
+            {
+                Pkcs8PrivateKeyInfo info = Pkcs8PrivateKeyInfo.DecryptAndDecode(password, data, out _);
+                info.Attributes.Add(new AsnEncodedData(ext.Oid, ext.RawData));
+                PbeParameters parameters = new(PbeEncryptionAlgorithm.TripleDes3KeyPkcs12, HashAlgorithmName.SHA1, 1);
+                return PemEncoding.WriteString("ENCRYPTED PRIVATE KEY", info.Encrypt(password, parameters));
+            }
+
+            throw new InvalidOperationException("PEM-encoded PKCS#8 does not contain an understood PEM label.");
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509Certificate2PemTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/X509Certificate2PemTests.cs
@@ -854,6 +854,41 @@ MII
             AssertKeysMatch(PrivateKeyWithSigningKeyUsage, cert.GetECDsaPrivateKey);
         }
 
+        [Fact]
+        public static void CreateFromEncryptedPem_CanImportECCAnyPublicKeyWithSigningKeyUsage()
+        {
+            const string PrivateKeyWithSigningKeyUsage =
+                """
+                -----BEGIN ENCRYPTED PRIVATE KEY-----
+                MIHIMBsGCiqGSIb3DQEMAQMwDQQIAcfnWs/6zc4CAQEEgajAD5o82qPGlBdrlKds
+                sbRD8IZLyPdXf6zqx7nJi23AzJ9scmFcFLlPEUclVAxiAOc2Z0XX4Ibq1B5KG+nZ
+                b/MzxqTUVn4pCf6C8i8Cm/YEndgbA3+220K+btUB8jW0UKudCa48EagHkscJag6M
+                RrvFmAK4JBlv/QHRx/TGxwsCYmnTmJKzZ7KrObid5cXdm8kqqxvfgjigDy7lNdzU
+                YoHsCUjWhEjdmbA=
+                -----END ENCRYPTED PRIVATE KEY-----
+                """;
+
+            const string AnyKeyUsageCertificate =
+                """
+                -----BEGIN CERTIFICATE-----
+                MIIBHzCBxqADAgECAghjN3R7a8h36TAKBggqhkjOPQQDAjAWMRQwEgYDVQQDEwtl
+                eGFtcGxlLmNvbTAeFw0yNjAxMDcxODExMzFaFw0yNzAxMDcxODExMzFaMBYxFDAS
+                BgNVBAMTC2V4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeybq
+                p51w8CAD3rKIi/cKx6JKTR9Z7dGzt53gPpCS6fpqDJMC4revxduxoZ60MhZWFESL
+                rq3coMOQVWjZAAz8rjAKBggqhkjOPQQDAgNIADBFAiBm07dRWT23lsfefred+Kzh
+                ZO9CxVEnV0nBQPkJH8GlrAIhAMnIN8RgUmGeXHNdq4yBoLlEaQcVzMquERBkZ0AG
+                dmo9
+                -----END CERTIFICATE-----
+                """;
+
+            using X509Certificate2 cert = X509Certificate2.CreateFromEncryptedPem(
+                AnyKeyUsageCertificate,
+                PrivateKeyWithSigningKeyUsage,
+                "PLACEHOLDER");
+
+            AssertKeysMatch(PrivateKeyWithSigningKeyUsage, cert.GetECDsaPrivateKey, "PLACEHOLDER");
+        }
+
         private static void AssertKeysMatch<T>(string keyPem, Func<T> keyLoader, string password = null) where T : IDisposable
         {
             IDisposable key = keyLoader();


### PR DESCRIPTION
Fixes #122925.

In .NET 10, we changed the order in which X509Certificate2.ImportFrom{Encrypted}Pem` attempts to load ECC keys. Previously, it would attempt to load a key as EC-DSA if the usage permitted it, and only load it as EC-DH if the certificate's key usage was amenable to EC-DSA key usage.

In https://github.com/dotnet/runtime/issues/115232, it was reported that loading it as EC-DSA first caused it to be unusable for EC-DH, since ECC keys can be both. Windows CNG prefers loading as EC-DH if an ECC key can be both.

However that did not account for another place that contained key usages: a PKCS#8 private key. CNG likes to attach key usages on to an exported PKCS#8 key, particularly a `digitalSignature` usages for EC-DSA keys.

When we flipped the order to try EC-DH imports first, the _certificate_ does not have a key usage extension, but the PKCS#8 private key does. So it would attempt to load the PKCS#8 private key, which is restricted to EC-DSA, as EC-DH because the certificate says it has any valid usage.

This change changes the private key loader for PKCS#8 PEM, both the PrivateKeyInfo and EncryptedPrivateKeyInfo variant, to pay attention to the keyUsage attribute of the key being imported.

This unfortunately means we need to write custom logic for loading ECC keys, including cracking open the EncryptedPrivateKeyInfo to be able to read the attribute. Since we already have the decoded `{Encrypted}PrivateKeyInfo`, we load it using BER loaders for the algorithm instead of deferring to the algorithm's PEM loader. Otherwise we would pay the penalty of decoding the PEM PKCS#8 twice, and in the case of `EncryptedPrivateKeyInfo`, mean doing PBES work twice, which we don't want to do.