### PR TITLE
Do not ship EventSourceGenerator

### DIFF
--- a/src/libraries/NetCoreAppLibrary.props
+++ b/src/libraries/NetCoreAppLibrary.props
@@ -181,7 +181,6 @@
     <!-- List .NETCoreApp shared framework generator project names below. -->
     <NetCoreAppLibraryGenerator>
       ComInterfaceGenerator;
-      EventSourceGenerator;
       LibraryImportGenerator;
       JSImportGenerator;
       Microsoft.Interop.SourceGeneration;


### PR DESCRIPTION
#121180 said this was internal, so we shouldn't include it in the ref pack.