### PR TITLE
Fix detection of System.Net.Security.Native

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.Unix.cs
@@ -776,7 +776,8 @@ namespace System.Net
         {
             try
             {
-                return Interop.NetSecurityNative.IsNtlmInstalled();
+                _ = Interop.NetSecurityNative.IsNtlmInstalled();
+                return true;
             }
             catch (Exception e) when (e is EntryPointNotFoundException || e is DllNotFoundException || e is TypeInitializationException)
             {


### PR DESCRIPTION
The `CheckHasSystemNetSecurityNative` method should return `true` when the native interop is available and can call GSSAPI. It should not detect the presence of `gss-ntlmssp` on the system.

Related to https://github.com/dotnet/runtime/issues/122895#issuecomment-3722818178