### PR TITLE
[Wasm RyuJIT] Add missing TYP_REF check

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -443,7 +443,7 @@ void CodeGen::genTableBasedSwitch(GenTree* treeNode)
 //
 static constexpr uint32_t PackOperAndType(genTreeOps oper, var_types type)
 {
-    if (type == TYP_BYREF)
+    if ((type == TYP_BYREF) || (type == TYP_REF))
     {
         type = TYP_I_IMPL;
     }


### PR DESCRIPTION
This fixes a bit over a hundred superPMI failures.

Should we centralize this somewhere else? This feels like it's probably a decent place for it.