### PR TITLE
Arm64: Fix for 96441

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -4846,7 +4846,7 @@ GenTree* Lowering::LowerSelect(GenTreeConditional* select)
     {
         TryLowerCselToCSOp(select, cond);
     }
-    else if (trueVal->IsCnsIntOrI() && falseVal->IsCnsIntOrI())
+    else if (trueVal->IsCnsIntOrI() || falseVal->IsCnsIntOrI())
     {
         TryLowerCnsIntCselToCinc(select, cond);
     }

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -3524,6 +3524,10 @@ void Lowering::TryLowerCnsIntCselToCinc(GenTreeOp* select, GenTree* cond)
     }
     else
     {
+        if (!cond->OperIs(GT_CMP))
+        {
+            return;
+        }
         // Look for cases like this to convert to conditional increment
         // if (myvar==0) myvar = 1;
         // If we're comparing a local to a constant int, and reassigning that local to a value that is 1 larger

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -3454,7 +3454,8 @@ void Lowering::TryLowerCselToCSOp(GenTreeOp* select, GenTree* cond)
 
 //----------------------------------------------------------------------------------------------
 // TryLowerCnsIntCselToCinc: Try converting SELECT/SELECTCC to SELECT_INC/SELECT_INCCC.
-// Conversion is possible only if both the trueVal and falseVal are integer constants and abs(trueVal - falseVal) = 1.
+// Conversion is possible if both the trueVal and falseVal are integer constants and abs(trueVal - falseVal) = 1,
+// or if one of trueVal/falseVal is 1 greater than the value being compared against
 //
 // Arguments:
 //     select - The select node that is now SELECT or SELECTCC
@@ -3466,54 +3467,120 @@ void Lowering::TryLowerCnsIntCselToCinc(GenTreeOp* select, GenTree* cond)
 
     GenTree* trueVal  = select->gtOp1;
     GenTree* falseVal = select->gtOp2;
-    size_t   op1Val   = (size_t)trueVal->AsIntCon()->IconValue();
-    size_t   op2Val   = (size_t)falseVal->AsIntCon()->IconValue();
 
-    if ((op1Val + 1 == op2Val) || (op2Val + 1 == op1Val))
+    if (trueVal->IsCnsIntOrI() && falseVal->IsCnsIntOrI())
     {
-        const bool shouldReverseCondition = (op1Val + 1 == op2Val);
+        size_t op1Val = (size_t)trueVal->AsIntCon()->IconValue();
+        size_t op2Val = (size_t)falseVal->AsIntCon()->IconValue();
 
-        if (select->OperIs(GT_SELECT))
+        if ((op1Val + 1 == op2Val) || (op2Val + 1 == op1Val))
         {
-            if (shouldReverseCondition)
+            const bool shouldReverseCondition = (op1Val + 1 == op2Val);
+
+            if (select->OperIs(GT_SELECT))
             {
-                // Reverse the condition so that op2 will be selected
-                if (!cond->OperIsCompare())
+                if (shouldReverseCondition)
                 {
-                    // Non-compare nodes add additional GT_NOT node after reversing.
-                    // This would remove gains from this optimisation so don't proceed.
-                    return;
+                    // Reverse the condition so that op2 will be selected
+                    if (!cond->OperIsCompare())
+                    {
+                        // Non-compare nodes add additional GT_NOT node after reversing.
+                        // This would remove gains from this optimisation so don't proceed.
+                        return;
+                    }
+                    GenTree* revCond = comp->gtReverseCond(cond);
+                    assert(cond == revCond); // Ensure `gtReverseCond` did not create a new node.
                 }
-                GenTree* revCond = comp->gtReverseCond(cond);
-                assert(cond == revCond); // Ensure `gtReverseCond` did not create a new node.
-            }
-            BlockRange().Remove(select->gtOp2, true);
-            select->gtOp2 = nullptr;
-            select->SetOper(GT_SELECT_INC);
-            JITDUMP("Converted to: GT_SELECT_INC\n");
-            DISPTREERANGE(BlockRange(), select);
-            JITDUMP("\n");
-        }
-        else
-        {
-            GenTreeOpCC* selectcc   = select->AsOpCC();
-            GenCondition selectCond = selectcc->gtCondition;
-
-            if (shouldReverseCondition)
-            {
-                // Reverse the condition so that op2 will be selected
-                selectcc->gtCondition = GenCondition::Reverse(selectCond);
+                BlockRange().Remove(select->gtOp2, true);
+                select->gtOp2 = nullptr;
+                select->SetOper(GT_SELECT_INC);
+                JITDUMP("Converted to: GT_SELECT_INC\n");
+                DISPTREERANGE(BlockRange(), select);
+                JITDUMP("\n");
             }
             else
             {
-                std::swap(selectcc->gtOp1, selectcc->gtOp2);
-            }
+                GenTreeOpCC* selectcc   = select->AsOpCC();
+                GenCondition selectCond = selectcc->gtCondition;
 
-            BlockRange().Remove(selectcc->gtOp2, true);
-            selectcc->gtOp2 = nullptr;
-            selectcc->SetOper(GT_SELECT_INCCC);
+                if (shouldReverseCondition)
+                {
+                    // Reverse the condition so that op2 will be selected
+                    selectcc->gtCondition = GenCondition::Reverse(selectCond);
+                }
+                else
+                {
+                    std::swap(selectcc->gtOp1, selectcc->gtOp2);
+                }
+
+                BlockRange().Remove(selectcc->gtOp2, true);
+                selectcc->gtOp2 = nullptr;
+                selectcc->SetOper(GT_SELECT_INCCC);
+                JITDUMP("Converted to: GT_SELECT_INCCC\n");
+                DISPTREERANGE(BlockRange(), selectcc);
+                JITDUMP("\n");
+            }
+        }
+    }
+    else
+    {
+        // Look for cases like this to convert to conditional increment
+        // if (myvar==0) myvar = 1;
+        // If we're comparing a local to a constant int, and reassigning that local to a value that is 1 larger
+        if (!cond->gtGetOp1()->IsIntegralConst() && !cond->gtGetOp2()->IsIntegralConst())
+        {
+            return;
+        }
+        if (!cond->gtGetOp1()->OperIs(GT_LCL_VAR) && !cond->gtGetOp2()->OperIs(GT_LCL_VAR))
+        {
+            return;
+        }
+
+        // One of the CMP operands is a constant int
+        auto     code     = select->AsOpCC()->gtCondition.GetCode();
+        int64_t  constVal = 0;
+        unsigned lclNum   = 0;
+
+        if (cond->gtGetOp1()->IsIntegralConst())
+        {
+            constVal = cond->gtGetOp1()->AsIntCon()->IntegralValue();
+            lclNum   = cond->gtGetOp2()->AsLclVar()->GetLclNum();
+        }
+        else
+        {
+            constVal = cond->gtGetOp2()->AsIntCon()->IntegralValue();
+            lclNum   = cond->gtGetOp1()->AsLclVar()->GetLclNum();
+        }
+
+        if (code != GenCondition::EQ && code != GenCondition::NE)
+        {
+            return;
+        }
+
+        GenTree** replaceOperand = nullptr;
+        GenTree*  removeVal      = nullptr;
+        if (code == GenCondition::NE && falseVal->IsIntegralConst() &&
+            falseVal->AsIntCon()->IntegralValue() - constVal == 1)
+        {
+            removeVal = falseVal;
+            replaceOperand = &(select->gtOp2);
+        }
+        else if (code == GenCondition::EQ && trueVal->IsIntegralConst() &&
+                 trueVal->AsIntCon()->IntegralValue() - constVal == 1)
+        {
+            removeVal      = trueVal;
+            replaceOperand = &(select->gtOp1);
+        }
+        if (removeVal)
+        {
+            GenTree* newLocal = comp->gtNewLclvNode(lclNum, removeVal->TypeGet());
+            BlockRange().InsertBefore(removeVal, newLocal);
+            BlockRange().Remove(removeVal);
+            *replaceOperand = newLocal;
+            select->SetOper(GT_SELECT_INCCC);
+
             JITDUMP("Converted to: GT_SELECT_INCCC\n");
-            DISPTREERANGE(BlockRange(), selectcc);
+            DISPTREERANGE(BlockRange(), select);
             JITDUMP("\n");
         }
     }

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -3528,8 +3528,7 @@ void Lowering::TryLowerCnsIntCselToCinc(GenTreeOp* select, GenTree* cond)
         // if (myvar==0) myvar = 1;
         // If we're comparing a local to a constant int, and branch has a use of the value+1
 
-        if (!cond->OperIs(GT_CMP) ||
-            !select->OperIs(GT_SELECTCC))
+        if (!cond->OperIs(GT_CMP) || !select->OperIs(GT_SELECTCC))
         {
             return;
         }

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -3528,7 +3528,8 @@ void Lowering::TryLowerCnsIntCselToCinc(GenTreeOp* select, GenTree* cond)
         // if (myvar==0) myvar = 1;
         // If we're comparing a local to a constant int, and branch has a use of the value+1
 
-        if (!cond->OperIs(GT_CMP))
+        if (!cond->OperIs(GT_CMP) ||
+            !select->OperIs(GT_SELECTCC))
         {
             return;
         }
@@ -3539,9 +3540,9 @@ void Lowering::TryLowerCnsIntCselToCinc(GenTreeOp* select, GenTree* cond)
         }
 
         // One of the CMP operands is a constant int
-        auto     code     = select->AsOpCC()->gtCondition.GetCode();
-        int64_t  constVal = 0;
-        unsigned lclNum   = 0;
+        GenCondition::Code code     = select->AsOpCC()->gtCondition.GetCode();
+        int64_t            constVal = 0;
+        unsigned           lclNum   = 0;
 
         if (cond->gtGetOp1()->IsIntegralConst())
         {

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -3570,9 +3570,6 @@ void Lowering::TryLowerCnsIntCselToCinc(GenTreeOp* select, GenTree* cond)
             return;
         }
 
-        GenTree** replaceOperand = nullptr;
-        GenTree*  removeVal      = nullptr;
-
         // The increment needs to occur along the false path,
         // reverse condition if that's not the case
         if (code == GenCondition::EQ)


### PR DESCRIPTION
The increment of `lzcnt`  (`*`) wasn't getting transformed to a conditional increment, because an earlier phase folds the "add local, 1" into a constant based on assertion information.

```
[MethodImpl(MethodImplOptions.AggressiveInlining)]
public static int RuneLength(in byte value)
{
    var lzcnt = (uint)BitOperations.LeadingZeroCount(~((uint)value << 24));
    if (lzcnt is 0) lzcnt++; //*

    return (int)lzcnt;
}
```

Fix to allow `TryLowerCnsIntCselToCinc` to look cases similar to `if (myvar==0)myvar=1;`

fixes #96441 