### PR TITLE
Fix DateTime parsing when AM designator prefix PM designator

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -3744,33 +3744,36 @@ DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,   DS.ERROR,
 
             if (str.GetNext())
             {
-                string searchStr = dtfi.AMDesignator;
-                if (searchStr.Length > 0)
+                string amDesignator = dtfi.AMDesignator;
+                string pmDesignator;
+
+                if (amDesignator.Length > 0)
                 {
-                    if (str.MatchSpecifiedWord(searchStr))
+                    if (str.MatchSpecifiedWord(amDesignator))
                     {
-                        string searchStr1 = dtfi.PMDesignator;
-                        if (searchStr1.Length > searchStr.Length && searchStr1.StartsWith(searchStr, StringComparison.Ordinal) && str.MatchSpecifiedWord(searchStr1))
+                        pmDesignator = dtfi.PMDesignator;
+                        if (pmDesignator.StartsWith(amDesignator, StringComparison.Ordinal) && str.MatchSpecifiedWord(pmDesignator))
                         {
                             // AM designator is a prefix of PM designator and we have matched PM designator. Use longer match.
-                            str.Index += (searchStr1.Length - 1);
+                            str.Index += (pmDesignator.Length - 1);
                             result = TM.PM;
                             return true;
                         }
 
                         // Found an AM timemark with length > 0.
-                        str.Index += (searchStr.Length - 1);
+                        str.Index += (amDesignator.Length - 1);
                         result = TM.AM;
                         return true;
                     }
                 }
-                searchStr = dtfi.PMDesignator;
-                if (searchStr.Length > 0)
+
+                pmDesignator = dtfi.PMDesignator;
+                if (pmDesignator.Length > 0)
                 {
-                    if (str.MatchSpecifiedWord(searchStr))
+                    if (str.MatchSpecifiedWord(pmDesignator))
                     {
                         // Found a PM timemark with length > 0.
-                        str.Index += (searchStr.Length - 1);
+                        str.Index += (pmDesignator.Length - 1);
                         result = TM.PM;
                         return true;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -3750,7 +3750,7 @@ DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,   DS.ERROR,
                     if (str.MatchSpecifiedWord(searchStr))
                     {
                         string searchStr1 = dtfi.PMDesignator;
-                        if (searchStr1.Length > searchStr.Length && searchStr1.StartsWith(searchStr1, StringComparison.Ordinal) && str.MatchSpecifiedWord(searchStr1))
+                        if (searchStr1.Length > searchStr.Length && searchStr1.StartsWith(searchStr, StringComparison.Ordinal) && str.MatchSpecifiedWord(searchStr1))
                         {
                             // AM designator is a prefix of PM designator and we have matched PM designator. Use longer match.
                             str.Index += (searchStr1.Length - 1);

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/DateTimeParse.cs
@@ -3749,6 +3749,15 @@ DS.ERROR,  DS.TX_NNN,  DS.TX_NNN,  DS.TX_NNN,  DS.ERROR,   DS.ERROR,   DS.ERROR,
                 {
                     if (str.MatchSpecifiedWord(searchStr))
                     {
+                        string searchStr1 = dtfi.PMDesignator;
+                        if (searchStr1.Length > searchStr.Length && searchStr1.StartsWith(searchStr1, StringComparison.Ordinal) && str.MatchSpecifiedWord(searchStr1))
+                        {
+                            // AM designator is a prefix of PM designator and we have matched PM designator. Use longer match.
+                            str.Index += (searchStr1.Length - 1);
+                            result = TM.PM;
+                            return true;
+                        }
+
                         // Found an AM timemark with length > 0.
                         str.Index += (searchStr.Length - 1);
                         result = TM.AM;

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DateTimeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/DateTimeTests.cs
@@ -3085,5 +3085,22 @@ namespace System.Tests
                 break;
             }
         }
+
+        [Fact]
+        public void TestParsingWithAmPrefixPm()
+        {
+            var culture = new CultureInfo("en-US");
+            DateTime dt = new DateTime(2023, 4, 17, 14, 30, 0);
+
+            // AM designator is a prefix of PM designator
+            culture.DateTimeFormat.AMDesignator = "aM";
+            culture.DateTimeFormat.PMDesignator = "aMP";
+
+            string formatted = dt.ToString("hh:mm tt", culture);
+            Assert.Equal("02:30 aMP", formatted);
+
+            DateTime parsedDateTime = DateTime.ParseExact(formatted, "hh:mm tt", culture);
+            Assert.Equal(dt.TimeOfDay, parsedDateTime.TimeOfDay);
+        }
     }
 }


### PR DESCRIPTION
CLDR globalization data updates changed the `ak-GH` AM and PM designators to `AN` and `ANW`, respectively. The new values make the AM designator a prefix of the PM designator, which causes issues during date/time parsing: a value may be parsed as the AM designator even when the input contains the PM designator. The fix is to always attempt to parse the longest matching value first, and fall back to the shorter one if needed.