### PR TITLE
Only root supported hwintrinsic methods for interpreter-based platforms

### DIFF
--- a/src/coreclr/tools/Common/JitInterface/CorInfoInstructionSet.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoInstructionSet.cs
@@ -1020,10 +1020,10 @@ namespace Internal.JitInterface
                     break;
 
                 case TargetArchitecture.RiscV64:
-                    yield return new InstructionSetInfo("base", "RiscV64Base", InstructionSet.RiscV64_RiscV64Base, true);
-                    yield return new InstructionSetInfo("zba", "Zba", InstructionSet.RiscV64_Zba, true);
-                    yield return new InstructionSetInfo("zbb", "Zbb", InstructionSet.RiscV64_Zbb, true);
-                    yield return new InstructionSetInfo("zbs", "Zbs", InstructionSet.RiscV64_Zbs, true);
+                    yield return new InstructionSetInfo("base", "", InstructionSet.RiscV64_RiscV64Base, true);
+                    yield return new InstructionSetInfo("zba", "", InstructionSet.RiscV64_Zba, true);
+                    yield return new InstructionSetInfo("zbb", "", InstructionSet.RiscV64_Zbb, true);
+                    yield return new InstructionSetInfo("zbs", "", InstructionSet.RiscV64_Zbs, true);
                     break;
 
                 case TargetArchitecture.X64:
@@ -1335,6 +1335,9 @@ namespace Internal.JitInterface
                     break;
 
                 case TargetArchitecture.X64:
+                    platformIntrinsicNamespace = "System.Runtime.Intrinsics.X86";
+                    break;
+
                 case TargetArchitecture.X86:
                     platformIntrinsicNamespace = "System.Runtime.Intrinsics.X86";
                     break;
@@ -1413,28 +1416,16 @@ namespace Internal.JitInterface
                         else
                         { return InstructionSet.ARM64_Sve2; }
 
+                    default:
+                        return InstructionSet.ILLEGAL;
                 }
-                break;
-
                 case TargetArchitecture.RiscV64:
                 switch (typeName)
                 {
 
-                    case "RiscV64Base":
-                        { return InstructionSet.RiscV64_RiscV64Base; }
-
-                    case "Zba":
-                        { return InstructionSet.RiscV64_Zba; }
-
-                    case "Zbb":
-                        { return InstructionSet.RiscV64_Zbb; }
-
-                    case "Zbs":
-                        { return InstructionSet.RiscV64_Zbs; }
-
+                    default:
+                        return InstructionSet.ILLEGAL;
                 }
-                break;
-
                 case TargetArchitecture.X64:
                 switch (typeName)
                 {
@@ -1763,9 +1754,9 @@ namespace Internal.JitInterface
                         else
                         { return InstructionSet.X64_AVXVNNIINT; }
 
+                    default:
+                        return InstructionSet.ILLEGAL;
                 }
-                break;
-
                 case TargetArchitecture.X86:
                 switch (typeName)
                 {
@@ -1947,9 +1938,9 @@ namespace Internal.JitInterface
                         else
                         { return InstructionSet.X86_AVXVNNIINT; }
 
+                    default:
+                        return InstructionSet.ILLEGAL;
                 }
-                break;
-
             }
             return InstructionSet.ILLEGAL;
         }
@@ -1961,7 +1952,7 @@ namespace Internal.JitInterface
                 case (InstructionSet.ARM64_ArmBase, TargetArchitecture.ARM64):
                 case (InstructionSet.ARM64_ArmBase_Arm64, TargetArchitecture.ARM64):
                 {
-                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "ArmBase"u8, true);
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm"u8, "ArmBase"u8, true);
                     yield return type;
                     if (instructionSet == InstructionSet.ARM64_ArmBase_Arm64)
                     {
@@ -1973,7 +1964,7 @@ namespace Internal.JitInterface
                 case (InstructionSet.ARM64_AdvSimd, TargetArchitecture.ARM64):
                 case (InstructionSet.ARM64_AdvSimd_Arm64, TargetArchitecture.ARM64):
                 {
-                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "AdvSimd"u8, true);
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm"u8, "AdvSimd"u8, true);
                     yield return type;
                     if (instructionSet == InstructionSet.ARM64_AdvSimd_Arm64)
                     {
@@ -1985,7 +1976,7 @@ namespace Internal.JitInterface
                 case (InstructionSet.ARM64_Aes, TargetArchitecture.ARM64):
                 case (InstructionSet.ARM64_Aes_Arm64, TargetArchitecture.ARM64):
                 {
-                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Aes"u8, true);
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm"u8, "Aes"u8, true);
                     yield return type;
                     if (instructionSet == InstructionSet.ARM64_Aes_Arm64)
                     {
@@ -1997,7 +1988,7 @@ namespace Internal.JitInterface
                 case (InstructionSet.ARM64_Crc32, TargetArchitecture.ARM64):
                 case (InstructionSet.ARM64_Crc32_Arm64, TargetArchitecture.ARM64):
                 {
-                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Crc32"u8, true);
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm"u8, "Crc32"u8, true);
                     yield return type;
                     if (instructionSet == InstructionSet.ARM64_Crc32_Arm64)
                     {
@@ -2009,7 +2000,7 @@ namespace Internal.JitInterface
                 case (InstructionSet.ARM64_Dp, TargetArchitecture.ARM64):
                 case (InstructionSet.ARM64_Dp_Arm64, TargetArchitecture.ARM64):
                 {
-                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Dp"u8, true);
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm"u8, "Dp"u8, true);
                     yield return type;
                     if (instructionSet == InstructionSet.ARM64_Dp_Arm64)
                     {
@@ -2021,7 +2012,7 @@ namespace Internal.JitInterface
                 case (InstructionSet.ARM64_Rdm, TargetArchitecture.ARM64):
                 case (InstructionSet.ARM64_Rdm_Arm64, TargetArchitecture.ARM64):
                 {
-                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Rdm"u8, true);
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm"u8, "Rdm"u8, true);
                     yield return type;
                     if (instructionSet == InstructionSet.ARM64_Rdm_Arm64)
                     {
@@ -2033,7 +2024,7 @@ namespace Internal.JitInterface
                 case (InstructionSet.ARM64_Sha1, TargetArchitecture.ARM64):
                 case (InstructionSet.ARM64_Sha1_Arm64, TargetArchitecture.ARM64):
                 {
-                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Sha1"u8, true);
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm"u8, "Sha1"u8, true);
                     yield return type;
                     if (instructionSet == InstructionSet.ARM64_Sha1_Arm64)
                     {
@@ -2045,7 +2036,7 @@ namespace Internal.JitInterface
                 case (InstructionSet.ARM64_Sha256, TargetArchitecture.ARM64):
                 case (InstructionSet.ARM64_Sha256_Arm64, TargetArchitecture.ARM64):
                 {
-                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Sha256"u8, true);
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm"u8, "Sha256"u8, true);
                     yield return type;
                     if (instructionSet == InstructionSet.ARM64_Sha256_Arm64)
                     {
@@ -2057,7 +2048,7 @@ namespace Internal.JitInterface
                 case (InstructionSet.ARM64_Sve, TargetArchitecture.ARM64):
                 case (InstructionSet.ARM64_Sve_Arm64, TargetArchitecture.ARM64):
                 {
-                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Sve"u8, true);
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm"u8, "Sve"u8, true);
                     yield return type;
                     if (instructionSet == InstructionSet.ARM64_Sve_Arm64)
                     {
@@ -2069,7 +2060,7 @@ namespace Internal.JitInterface
                 case (InstructionSet.ARM64_Sve2, TargetArchitecture.ARM64):
                 case (InstructionSet.ARM64_Sve2_Arm64, TargetArchitecture.ARM64):
                 {
-                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Sve2"u8, true);
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm"u8, "Sve2"u8, true);
                     yield return type;
                     if (instructionSet == InstructionSet.ARM64_Sve2_Arm64)
                     {

--- a/src/coreclr/tools/Common/JitInterface/CorInfoInstructionSet.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoInstructionSet.cs
@@ -5,6 +5,7 @@
 // FROM /src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetDesc.txt
 // using /src/coreclr/tools/Common/JitInterface/ThunkGenerator/gen.bat
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -1954,6 +1955,998 @@ namespace Internal.JitInterface
 
             }
             return InstructionSet.ILLEGAL;
+        }
+
+        public static IEnumerable<MetadataType> LookupPlatformIntrinsicTypes(TypeSystemContext context, InstructionSet instructionSet)
+        {
+            switch ((instructionSet, context.Target.Architecture))
+            {
+                case (InstructionSet.ARM64_ArmBase, TargetArchitecture.ARM64):
+                case (InstructionSet.ARM64_ArmBase_Arm64, TargetArchitecture.ARM64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "ArmBase"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.ARM64_ArmBase_Arm64)
+                    {
+                        yield return type.GetNestedType("Arm64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.ARM64_AdvSimd, TargetArchitecture.ARM64):
+                case (InstructionSet.ARM64_AdvSimd_Arm64, TargetArchitecture.ARM64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "AdvSimd"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.ARM64_AdvSimd_Arm64)
+                    {
+                        yield return type.GetNestedType("Arm64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.ARM64_Aes, TargetArchitecture.ARM64):
+                case (InstructionSet.ARM64_Aes_Arm64, TargetArchitecture.ARM64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Aes"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.ARM64_Aes_Arm64)
+                    {
+                        yield return type.GetNestedType("Arm64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.ARM64_Crc32, TargetArchitecture.ARM64):
+                case (InstructionSet.ARM64_Crc32_Arm64, TargetArchitecture.ARM64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Crc32"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.ARM64_Crc32_Arm64)
+                    {
+                        yield return type.GetNestedType("Arm64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.ARM64_Dp, TargetArchitecture.ARM64):
+                case (InstructionSet.ARM64_Dp_Arm64, TargetArchitecture.ARM64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Dp"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.ARM64_Dp_Arm64)
+                    {
+                        yield return type.GetNestedType("Arm64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.ARM64_Rdm, TargetArchitecture.ARM64):
+                case (InstructionSet.ARM64_Rdm_Arm64, TargetArchitecture.ARM64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Rdm"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.ARM64_Rdm_Arm64)
+                    {
+                        yield return type.GetNestedType("Arm64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.ARM64_Sha1, TargetArchitecture.ARM64):
+                case (InstructionSet.ARM64_Sha1_Arm64, TargetArchitecture.ARM64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Sha1"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.ARM64_Sha1_Arm64)
+                    {
+                        yield return type.GetNestedType("Arm64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.ARM64_Sha256, TargetArchitecture.ARM64):
+                case (InstructionSet.ARM64_Sha256_Arm64, TargetArchitecture.ARM64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Sha256"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.ARM64_Sha256_Arm64)
+                    {
+                        yield return type.GetNestedType("Arm64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.ARM64_VectorT128, TargetArchitecture.ARM64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "VectorT128"u8, true);
+                    yield return type;
+                }
+                break;
+
+                case (InstructionSet.ARM64_Sve, TargetArchitecture.ARM64):
+                case (InstructionSet.ARM64_Sve_Arm64, TargetArchitecture.ARM64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Sve"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.ARM64_Sve_Arm64)
+                    {
+                        yield return type.GetNestedType("Arm64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.ARM64_Sve2, TargetArchitecture.ARM64):
+                case (InstructionSet.ARM64_Sve2_Arm64, TargetArchitecture.ARM64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "Sve2"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.ARM64_Sve2_Arm64)
+                    {
+                        yield return type.GetNestedType("Arm64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_X86Base, TargetArchitecture.X64):
+                case (InstructionSet.X64_X86Base_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "X86Base"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_X86Base_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Sse"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_X86Base_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Sse2"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_X86Base_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Sse42"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_X86Base_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Sse3"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_X86Base_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Ssse3"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_X86Base_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Sse41"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_X86Base_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Popcnt"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_X86Base_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_AVX, TargetArchitecture.X64):
+                case (InstructionSet.X64_AVX_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_AVX2, TargetArchitecture.X64):
+                case (InstructionSet.X64_AVX2_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx2"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX2_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Bmi1"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX2_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Bmi2"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX2_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "F16C"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX2_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Fma"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX2_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Lzcnt"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX2_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_AVX512, TargetArchitecture.X64):
+                case (InstructionSet.X64_AVX512_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512F"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX512_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512F"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                    if (instructionSet == InstructionSet.X64_AVX512_X64)
+                    {
+                        yield return parentType.GetNestedType("VL_X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512BW"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX512_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512BW"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                    if (instructionSet == InstructionSet.X64_AVX512_X64)
+                    {
+                        yield return parentType.GetNestedType("VL_X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512CD"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX512_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512CD"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                    if (instructionSet == InstructionSet.X64_AVX512_X64)
+                    {
+                        yield return parentType.GetNestedType("VL_X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512DQ"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX512_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512DQ"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                    if (instructionSet == InstructionSet.X64_AVX512_X64)
+                    {
+                        yield return parentType.GetNestedType("VL_X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_AVX512v2, TargetArchitecture.X64):
+                case (InstructionSet.X64_AVX512v2_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vbmi"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX512v2_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vbmi"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                    if (instructionSet == InstructionSet.X64_AVX512v2_X64)
+                    {
+                        yield return parentType.GetNestedType("VL_X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_AVX512v3, TargetArchitecture.X64):
+                case (InstructionSet.X64_AVX512v3_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Bitalg"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX512v3_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Bitalg"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                    if (instructionSet == InstructionSet.X64_AVX512v3_X64)
+                    {
+                        yield return parentType.GetNestedType("VL_X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vbmi2"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX512v3_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vbmi2"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                    if (instructionSet == InstructionSet.X64_AVX512v3_X64)
+                    {
+                        yield return parentType.GetNestedType("VL_X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vpopcntdq"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX512v3_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vpopcntdq"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                    if (instructionSet == InstructionSet.X64_AVX512v3_X64)
+                    {
+                        yield return parentType.GetNestedType("VL_X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_AVX10v1, TargetArchitecture.X64):
+                case (InstructionSet.X64_AVX10v1_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Bf16"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX10v1_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Bf16"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                    if (instructionSet == InstructionSet.X64_AVX10v1_X64)
+                    {
+                        yield return parentType.GetNestedType("VL_X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Fp16"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX10v1_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Fp16"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                    if (instructionSet == InstructionSet.X64_AVX10v1_X64)
+                    {
+                        yield return parentType.GetNestedType("VL_X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx10v1"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX10v1_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx10v1"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V512"u8);
+                    if (instructionSet == InstructionSet.X64_AVX10v1_X64)
+                    {
+                        yield return parentType.GetNestedType("V512_X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_AVX10v2, TargetArchitecture.X64):
+                case (InstructionSet.X64_AVX10v2_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx10v2"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX10v2_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx10v2"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V512"u8);
+                    if (instructionSet == InstructionSet.X64_AVX10v2_X64)
+                    {
+                        yield return parentType.GetNestedType("V512_X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_AES, TargetArchitecture.X64):
+                case (InstructionSet.X64_AES_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Aes"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AES_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Pclmulqdq"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AES_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_AES_V256, TargetArchitecture.X64):
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Aes"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V256"u8);
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Pclmulqdq"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V256"u8);
+                }
+                break;
+
+                case (InstructionSet.X64_AES_V512, TargetArchitecture.X64):
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Aes"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V512"u8);
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Pclmulqdq"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V512"u8);
+                }
+                break;
+
+                case (InstructionSet.X64_AVX512VP2INTERSECT, TargetArchitecture.X64):
+                case (InstructionSet.X64_AVX512VP2INTERSECT_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vp2intersect"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVX512VP2INTERSECT_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vp2intersect"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                    if (instructionSet == InstructionSet.X64_AVX512VP2INTERSECT_X64)
+                    {
+                        yield return parentType.GetNestedType("VL_X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_AVXIFMA, TargetArchitecture.X64):
+                case (InstructionSet.X64_AVXIFMA_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "AvxIfma"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVXIFMA_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_AVXVNNI, TargetArchitecture.X64):
+                case (InstructionSet.X64_AVXVNNI_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "AvxVnni"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_AVXVNNI_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_GFNI, TargetArchitecture.X64):
+                case (InstructionSet.X64_GFNI_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Gfni"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_GFNI_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_GFNI_V256, TargetArchitecture.X64):
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Gfni"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V256"u8);
+                }
+                break;
+
+                case (InstructionSet.X64_GFNI_V512, TargetArchitecture.X64):
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Gfni"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V512"u8);
+                }
+                break;
+
+                case (InstructionSet.X64_SHA, TargetArchitecture.X64):
+                case (InstructionSet.X64_SHA_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Sha"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_SHA_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_WAITPKG, TargetArchitecture.X64):
+                case (InstructionSet.X64_WAITPKG_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "WaitPkg"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_WAITPKG_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_X86Serialize, TargetArchitecture.X64):
+                case (InstructionSet.X64_X86Serialize_X64, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "X86Serialize"u8, true);
+                    yield return type;
+                    if (instructionSet == InstructionSet.X64_X86Serialize_X64)
+                    {
+                        yield return type.GetNestedType("X64"u8);
+                    }
+                }
+                break;
+
+                case (InstructionSet.X64_AVXVNNIINT, TargetArchitecture.X64):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "AvxVnniInt8"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "AvxVnniInt16"u8, true);
+                    yield return type;
+                }
+                break;
+
+                case (InstructionSet.X64_AVXVNNIINT_V512, TargetArchitecture.X64):
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "AvxVnniInt8"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V512"u8);
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "AvxVnniInt16"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V512"u8);
+                }
+                break;
+
+                case (InstructionSet.X86_X86Base, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "X86Base"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Sse"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Sse2"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Sse42"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Sse3"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Ssse3"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Sse41"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Popcnt"u8, true);
+                    yield return type;
+                }
+                break;
+
+                case (InstructionSet.X86_AVX, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx"u8, true);
+                    yield return type;
+                }
+                break;
+
+                case (InstructionSet.X86_AVX2, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx2"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Bmi1"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Bmi2"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "F16C"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Fma"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Lzcnt"u8, true);
+                    yield return type;
+                }
+                break;
+
+                case (InstructionSet.X86_AVX512, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512F"u8, true);
+                    yield return type;
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512F"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512BW"u8, true);
+                    yield return type;
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512BW"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512CD"u8, true);
+                    yield return type;
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512CD"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512DQ"u8, true);
+                    yield return type;
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512DQ"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                }
+                break;
+
+                case (InstructionSet.X86_AVX512v2, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vbmi"u8, true);
+                    yield return type;
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vbmi"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                }
+                break;
+
+                case (InstructionSet.X86_AVX512v3, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Bitalg"u8, true);
+                    yield return type;
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Bitalg"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vbmi2"u8, true);
+                    yield return type;
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vbmi2"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vpopcntdq"u8, true);
+                    yield return type;
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vpopcntdq"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                }
+                break;
+
+                case (InstructionSet.X86_AVX10v1, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Bf16"u8, true);
+                    yield return type;
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Bf16"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Fp16"u8, true);
+                    yield return type;
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Fp16"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx10v1"u8, true);
+                    yield return type;
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx10v1"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V512"u8);
+                }
+                break;
+
+                case (InstructionSet.X86_AVX10v2, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx10v2"u8, true);
+                    yield return type;
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx10v2"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V512"u8);
+                }
+                break;
+
+                case (InstructionSet.X86_AES, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Aes"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Pclmulqdq"u8, true);
+                    yield return type;
+                }
+                break;
+
+                case (InstructionSet.X86_AES_V256, TargetArchitecture.X86):
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Aes"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V256"u8);
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Pclmulqdq"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V256"u8);
+                }
+                break;
+
+                case (InstructionSet.X86_AES_V512, TargetArchitecture.X86):
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Aes"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V512"u8);
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Pclmulqdq"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V512"u8);
+                }
+                break;
+
+                case (InstructionSet.X86_AVX512VP2INTERSECT, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vp2intersect"u8, true);
+                    yield return type;
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Avx512Vp2intersect"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("VL"u8);
+                }
+                break;
+
+                case (InstructionSet.X86_AVXIFMA, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "AvxIfma"u8, true);
+                    yield return type;
+                }
+                break;
+
+                case (InstructionSet.X86_AVXVNNI, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "AvxVnni"u8, true);
+                    yield return type;
+                }
+                break;
+
+                case (InstructionSet.X86_GFNI, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Gfni"u8, true);
+                    yield return type;
+                }
+                break;
+
+                case (InstructionSet.X86_GFNI_V256, TargetArchitecture.X86):
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Gfni"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V256"u8);
+                }
+                break;
+
+                case (InstructionSet.X86_GFNI_V512, TargetArchitecture.X86):
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Gfni"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V512"u8);
+                }
+                break;
+
+                case (InstructionSet.X86_SHA, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "Sha"u8, true);
+                    yield return type;
+                }
+                break;
+
+                case (InstructionSet.X86_WAITPKG, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "WaitPkg"u8, true);
+                    yield return type;
+                }
+                break;
+
+                case (InstructionSet.X86_X86Serialize, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "X86Serialize"u8, true);
+                    yield return type;
+                }
+                break;
+
+                case (InstructionSet.X86_AVXVNNIINT, TargetArchitecture.X86):
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "AvxVnniInt8"u8, true);
+                    yield return type;
+                }
+                {
+                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "AvxVnniInt16"u8, true);
+                    yield return type;
+                }
+                break;
+
+                case (InstructionSet.X86_AVXVNNIINT_V512, TargetArchitecture.X86):
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "AvxVnniInt8"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V512"u8);
+                }
+                {
+                    var parentType = context.SystemModule.GetType("System.Runtime.Intrinsics.X86"u8, "AvxVnniInt16"u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType("V512"u8);
+                }
+                break;
+
+            }
         }
     }
 }

--- a/src/coreclr/tools/Common/JitInterface/CorInfoInstructionSet.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoInstructionSet.cs
@@ -1013,7 +1013,7 @@ namespace Internal.JitInterface
                     yield return new InstructionSetInfo("Vector128", "", InstructionSet.ARM64_Vector128, false);
                     yield return new InstructionSetInfo("Dczva", "", InstructionSet.ARM64_Dczva, false);
                     yield return new InstructionSetInfo("rcpc", "", InstructionSet.ARM64_Rcpc, true);
-                    yield return new InstructionSetInfo("vectort128", "VectorT128", InstructionSet.ARM64_VectorT128, true);
+                    yield return new InstructionSetInfo("vectort128", "", InstructionSet.ARM64_VectorT128, true);
                     yield return new InstructionSetInfo("rcpc2", "", InstructionSet.ARM64_Rcpc2, true);
                     yield return new InstructionSetInfo("sve", "Sve", InstructionSet.ARM64_Sve, true);
                     yield return new InstructionSetInfo("sve2", "Sve2", InstructionSet.ARM64_Sve2, true);
@@ -1400,9 +1400,6 @@ namespace Internal.JitInterface
                         { return InstructionSet.ARM64_Sha256_Arm64; }
                         else
                         { return InstructionSet.ARM64_Sha256; }
-
-                    case "VectorT128":
-                        { return InstructionSet.ARM64_VectorT128; }
 
                     case "Sve":
                         if (nestedTypeName == "Arm64")
@@ -2054,13 +2051,6 @@ namespace Internal.JitInterface
                     {
                         yield return type.GetNestedType("Arm64"u8);
                     }
-                }
-                break;
-
-                case (InstructionSet.ARM64_VectorT128, TargetArchitecture.ARM64):
-                {
-                    var type = context.SystemModule.GetType("System.Runtime.Intrinsics.Arm64"u8, "VectorT128"u8, true);
-                    yield return type;
                 }
                 break;
 

--- a/src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetDesc.txt
+++ b/src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetDesc.txt
@@ -1,6 +1,9 @@
 ; Define the set of instruction sets available on a platform
 ; Format is
 ;
+; Define an architecture
+; definearch,<architecture>,<bitness>,<64bit variant JIT name>,<64bit variant managed name>,<managed namespace>
+;
 ; Add new instruction set
 ; instructionset,<architecture>,<managed name>,<r2r name if different>,<R2R numeric value>, <jit instruction set name>, <public name>
 ;
@@ -203,7 +206,7 @@ definearch         ,X64   ,64Bit     ,X64, X64, X86
 copyinstructionsets,X86   ,X64
 
 ; Definition of Arm64 instruction sets
-definearch         ,ARM64 ,64Bit     ,Arm64, Arm64, Arm64
+definearch         ,ARM64 ,64Bit     ,Arm64, Arm64, Arm
 
 instructionset     ,ARM64 ,ArmBase               ,           ,16 ,ArmBase               ,base
 instructionset     ,ARM64 ,AdvSimd               ,           ,17 ,AdvSimd               ,neon
@@ -253,10 +256,10 @@ implication        ,ARM64 ,Sve2       ,Sve
 ; Definition of Riscv64 instruction sets
 definearch         ,RiscV64 ,64Bit     ,RiscV64, RiscV64,
 
-instructionset     ,RiscV64 ,RiscV64Base         ,        ,56 ,RiscV64Base         ,base
-instructionset     ,RiscV64 ,Zba                 ,        ,57 ,Zba                 ,zba
-instructionset     ,RiscV64 ,Zbb                 ,        ,58 ,Zbb                 ,zbb
-instructionset     ,RiscV64 ,Zbs                 ,        ,84 ,Zbs                 ,zbs
+instructionset     ,RiscV64 , ,RiscV64Base       ,56 ,RiscV64Base         ,base
+instructionset     ,RiscV64 , ,Zba               ,57 ,Zba                 ,zba
+instructionset     ,RiscV64 , ,Zbb               ,58 ,Zbb                 ,zbb
+instructionset     ,RiscV64 , ,Zbs               ,84 ,Zbs                 ,zbs
 
 implication        ,RiscV64 ,Zbb                 ,RiscV64Base
 implication        ,RiscV64 ,Zba                 ,RiscV64Base

--- a/src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetDesc.txt
+++ b/src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetDesc.txt
@@ -205,23 +205,23 @@ copyinstructionsets,X86   ,X64
 ; Definition of Arm64 instruction sets
 definearch         ,ARM64 ,64Bit     ,Arm64, Arm64, Arm64
 
-instructionset     ,ARM64 ,ArmBase               ,        ,16 ,ArmBase               ,base
-instructionset     ,ARM64 ,AdvSimd               ,        ,17 ,AdvSimd               ,neon
-instructionset     ,ARM64 ,Aes                   ,        ,9  ,Aes                   ,aes
-instructionset     ,ARM64 ,Crc32                 ,        ,18 ,Crc32                 ,crc
-instructionset     ,ARM64 ,Dp                    ,        ,23 ,Dp                    ,dotprod
-instructionset     ,ARM64 ,Rdm                   ,        ,24 ,Rdm                   ,rdma
-instructionset     ,ARM64 ,Sha1                  ,        ,19 ,Sha1                  ,sha1
-instructionset     ,ARM64 ,Sha256                ,        ,20 ,Sha256                ,sha2
-instructionset     ,ARM64 ,                      ,Atomics ,21 ,Atomics               ,lse
-instructionset     ,ARM64 ,                      ,        ,   ,Vector64              ,
-instructionset     ,ARM64 ,                      ,        ,   ,Vector128             ,
-instructionset     ,ARM64 ,                      ,        ,   ,Dczva                 ,
-instructionset     ,ARM64 ,                      ,Rcpc    ,26 ,Rcpc                  ,rcpc
-instructionset     ,ARM64 ,VectorT128            ,        ,39 ,VectorT128            ,vectort128
-instructionset     ,ARM64 ,                      ,Rcpc2   ,42 ,Rcpc2                 ,rcpc2
-instructionset     ,ARM64 ,Sve                   ,        ,43 ,Sve                   ,sve
-instructionset     ,ARM64 ,Sve2                  ,        ,59 ,Sve2                  ,sve2
+instructionset     ,ARM64 ,ArmBase               ,           ,16 ,ArmBase               ,base
+instructionset     ,ARM64 ,AdvSimd               ,           ,17 ,AdvSimd               ,neon
+instructionset     ,ARM64 ,Aes                   ,           ,9  ,Aes                   ,aes
+instructionset     ,ARM64 ,Crc32                 ,           ,18 ,Crc32                 ,crc
+instructionset     ,ARM64 ,Dp                    ,           ,23 ,Dp                    ,dotprod
+instructionset     ,ARM64 ,Rdm                   ,           ,24 ,Rdm                   ,rdma
+instructionset     ,ARM64 ,Sha1                  ,           ,19 ,Sha1                  ,sha1
+instructionset     ,ARM64 ,Sha256                ,           ,20 ,Sha256                ,sha2
+instructionset     ,ARM64 ,                      ,Atomics    ,21 ,Atomics               ,lse
+instructionset     ,ARM64 ,                      ,           ,   ,Vector64              ,
+instructionset     ,ARM64 ,                      ,           ,   ,Vector128             ,
+instructionset     ,ARM64 ,                      ,           ,   ,Dczva                 ,
+instructionset     ,ARM64 ,                      ,Rcpc       ,26 ,Rcpc                  ,rcpc
+instructionset     ,ARM64 ,                      ,VectorT128 ,39 ,VectorT128            ,vectort128
+instructionset     ,ARM64 ,                      ,Rcpc2      ,42 ,Rcpc2                 ,rcpc2
+instructionset     ,ARM64 ,Sve                   ,           ,43 ,Sve                   ,sve
+instructionset     ,ARM64 ,Sve2                  ,           ,59 ,Sve2                  ,sve2
 
 instructionset64bit,ARM64 ,ArmBase
 instructionset64bit,ARM64 ,AdvSimd

--- a/src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetDesc.txt
+++ b/src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetDesc.txt
@@ -26,7 +26,7 @@
 ; NEXT_AVAILABLE_R2R_BIT = 82
 
 ; Definition of X86 instruction sets
-definearch         ,X86   ,32Bit                ,X64, X64
+definearch         ,X86   ,32Bit                ,X64, X64, X86
 
 instructionset     ,X86   ,X86Base              ,                   ,22 ,X86Base               ,base
 instructionset     ,X86   ,Sse                  ,                   ,1  ,X86Base               ,base
@@ -198,12 +198,12 @@ implication        ,X86   ,VectorT256           ,AVX2
 implication        ,X86   ,VectorT512           ,AVX512
 
 ; Definition of X64 instruction sets
-definearch         ,X64   ,64Bit     ,X64, X64
+definearch         ,X64   ,64Bit     ,X64, X64, X86
 
 copyinstructionsets,X86   ,X64
 
 ; Definition of Arm64 instruction sets
-definearch         ,ARM64 ,64Bit     ,Arm64, Arm64
+definearch         ,ARM64 ,64Bit     ,Arm64, Arm64, Arm64
 
 instructionset     ,ARM64 ,ArmBase               ,        ,16 ,ArmBase               ,base
 instructionset     ,ARM64 ,AdvSimd               ,        ,17 ,AdvSimd               ,neon
@@ -251,7 +251,7 @@ implication        ,ARM64 ,Sve        ,AdvSimd
 implication        ,ARM64 ,Sve2       ,Sve
 
 ; Definition of Riscv64 instruction sets
-definearch         ,RiscV64 ,64Bit     ,RiscV64, RiscV64
+definearch         ,RiscV64 ,64Bit     ,RiscV64, RiscV64,
 
 instructionset     ,RiscV64 ,RiscV64Base         ,        ,56 ,RiscV64Base         ,base
 instructionset     ,RiscV64 ,Zba                 ,        ,57 ,Zba                 ,zba

--- a/src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetGenerator.cs
+++ b/src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetGenerator.cs
@@ -88,6 +88,7 @@ namespace Thunkerator
         private SortedDictionary<string, int> _r2rNamesByName = new SortedDictionary<string, int>();
         private SortedDictionary<int, string> _r2rNamesByNumber = new SortedDictionary<int, string>();
         private SortedSet<string> _architectures = new SortedSet<string>();
+        private Dictionary<string, string> _architectureManagedNamespace = new Dictionary<string, string>();
         private Dictionary<string, HashSet<string>> _architectureJitNames = new Dictionary<string, HashSet<string>>();
         private Dictionary<string, HashSet<string>> _architectureVectorInstructionSetJitNames = new Dictionary<string, HashSet<string>>();
         private HashSet<string> _64BitArchitectures = new HashSet<string>();
@@ -159,7 +160,7 @@ namespace Thunkerator
                     switch (command[0])
                     {
                         case "definearch":
-                            if (command.Length != 5)
+                            if (command.Length != 6)
                                 throw new Exception($"Incorrect number of args for definearch {command.Length}");
                             ArchitectureEncountered(command[1]);
                             if (command[2] == "64Bit")
@@ -172,6 +173,10 @@ namespace Thunkerator
                             }
                             _64BitVariantArchitectureJitNameSuffix[command[1]] = command[3];
                             _64BitVariantArchitectureManagedNameSuffix[command[1]] = command[4];
+                            if (command[5] != "")
+                            {
+                                _architectureManagedNamespace[command[1]] = $"System.Runtime.Intrinsics.{command[5]}";
+                            }
                             break;
                         case "instructionset":
                             if (command.Length != 7)
@@ -388,6 +393,7 @@ namespace Internal.ReadyToRunConstants
 // FROM /src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetDesc.txt
 // using /src/coreclr/tools/Common/JitInterface/ThunkGenerator/gen.bat
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -901,6 +907,87 @@ namespace Internal.JitInterface
             tr.Write(@"
             }
             return InstructionSet.ILLEGAL;
+        }
+
+        public static IEnumerable<MetadataType> LookupPlatformIntrinsicTypes(TypeSystemContext context, InstructionSet instructionSet)
+        {
+            switch ((instructionSet, context.Target.Architecture))
+            {");
+
+            foreach (string architecture in _architectures.Where(_architectureManagedNamespace.ContainsKey))
+            {
+                var ns = _architectureManagedNamespace[architecture];
+                var archInstructionSets = _instructionSets.Where(isa => isa.Architecture == architecture && !string.IsNullOrEmpty(isa.ManagedName)).GroupBy(isa => isa.JitName).ToArray();
+                foreach (var instructionSets in archInstructionSets)
+                {
+                    string jitName = instructionSets.Key;
+                    tr.Write($@"
+                case (InstructionSet.{architecture}_{jitName}, TargetArchitecture.{architecture}):");
+
+                    bool hasSixtyFourBitInstructionSet = _64bitVariants[architecture].Contains(jitName) && _64BitArchitectures.Contains(architecture);
+                    if (hasSixtyFourBitInstructionSet)
+                    {
+                        tr.Write($@"
+                case (InstructionSet.{architecture}_{jitName}_{ArchToInstructionSetSuffixArch(architecture)}, TargetArchitecture.{architecture}):");
+                    }
+
+                    foreach (var instructionSet in instructionSets)
+                    {
+                        string managedName = instructionSet.ManagedName;
+                        if (managedName.Contains('_'))
+                        {
+                            // This is a nested type
+                            string parentName = managedName[..managedName.IndexOf('_')];
+                            string nestedName = managedName[(managedName.IndexOf('_') + 1)..];
+                            tr.Write($@"
+                {{
+                    var parentType = context.SystemModule.GetType(""{ns}""u8, ""{parentName}""u8, true);
+                    yield return parentType;
+                    yield return parentType.GetNestedType(""{nestedName}""u8);");
+
+                            if (hasSixtyFourBitInstructionSet)
+                            {
+                                string sixtyFourBitSuffix = ArchToManagedInstructionSetSuffixArch(architecture);
+                                tr.Write($@"
+                    if (instructionSet == InstructionSet.{architecture}_{instructionSet.JitName}_{ArchToInstructionSetSuffixArch(architecture)})
+                    {{
+                        yield return parentType.GetNestedType(""{nestedName}_{sixtyFourBitSuffix}""u8);
+                    }}");
+                            }
+
+                        tr.Write($@"
+                }}");
+                        }
+                        else
+                        {
+                            tr.Write($@"
+                {{
+                    var type = context.SystemModule.GetType(""{ns}""u8, ""{managedName}""u8, true);
+                    yield return type;");
+
+                            if (hasSixtyFourBitInstructionSet)
+                            {
+                                string sixtyFourBitSuffix = ArchToManagedInstructionSetSuffixArch(architecture);
+                                tr.Write($@"
+                    if (instructionSet == InstructionSet.{architecture}_{instructionSet.JitName}_{ArchToInstructionSetSuffixArch(architecture)})
+                    {{
+                        yield return type.GetNestedType(""{sixtyFourBitSuffix}""u8);
+                    }}");
+                            }
+
+                        tr.Write($@"
+                }}");
+                        }
+                    }
+
+                    tr.Write($@"
+                break;
+");
+                }
+            }
+
+            tr.Write(@"
+            }
         }
     }
 }

--- a/src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetGenerator.cs
+++ b/src/coreclr/tools/Common/JitInterface/ThunkGenerator/InstructionSetGenerator.cs
@@ -824,20 +824,28 @@ namespace Internal.JitInterface
             string platformIntrinsicNamespace;
 
             switch (targetArch)
+            {");
+
+
+            foreach (string architecture in _architectures)
             {
-                case TargetArchitecture.ARM64:
-                    platformIntrinsicNamespace = ""System.Runtime.Intrinsics.Arm"";
-                    break;
+                if (!_architectureManagedNamespace.ContainsKey(architecture))
+                    continue;
 
-                case TargetArchitecture.X64:
-                case TargetArchitecture.X86:
-                    platformIntrinsicNamespace = ""System.Runtime.Intrinsics.X86"";
+                string ns = _architectureManagedNamespace[architecture];
+                tr.Write($@"
+                case TargetArchitecture.{architecture}:
+                    platformIntrinsicNamespace = ""{ns}"";
                     break;
+");
+            }
 
+            tr.Write(@"
                 default:
                     return InstructionSet.ILLEGAL;
             }
-
+");
+            tr.Write(@"
             if (namespaceName != platformIntrinsicNamespace)
                 return InstructionSet.ILLEGAL;
 
@@ -899,9 +907,9 @@ namespace Internal.JitInterface
 ");
                 }
                 tr.Write($@"
-                }}
-                break;
-");
+                    default:
+                        return InstructionSet.ILLEGAL;
+                }}");
             }
 
             tr.Write(@"


### PR DESCRIPTION
We don't need to root the `IsSupported` getters for unsupported intrinsic types as the interpreter already handles those as `return false;`.

Add a new helper in `InstructionSetParser` to do the "instruction set -> types that provide hardware intrinsic methods for said instruction set" mapping so we don't need to search every type in the system module now that we only need to go through the explicitly supported instruction sets.

Adjust InstructionSetDesc.txt to support specifying the managed namespace for intrinsic instruction sets so we can better filter ISAs with no managed types (ie RiscV) and avoid hard-coding namespaces in `LookupPlatformIntrinsicInstructionSet`.

