### PR TITLE
Add pipeline to validate source-build stage1+2 builds from within runtime

### DIFF
--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -117,13 +117,3 @@ extends:
               or(
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
-
-      #
-      # Build Portable SourceBuild
-      #
-      - template: /eng/common/templates/jobs/source-build.yml
-        parameters:
-          platforms:
-          - name: Linux_x64
-            targetRID: linux-x64
-            container: SourceBuild_linux_x64

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -1,6 +1,6 @@
-# The purpose of this pipeline is to exercise various developer workflows in the repo.
-# Primarily, it is meant to cover local (non-cross) build scenarios and
-# source-build scenarios that commonly cause build breaks.
+# This pipeline is used for running the VMR verification of the PR changes in repo-level PRs.
+# If there are changes in flight that intentionally create cross-repo breaking changes in the VMR ingestion,
+# this pipeline is expected to fail until the conflicts are resolved in the VMR.
 
 trigger: none
 
@@ -18,6 +18,11 @@ pr:
     - .devcontainer/*
     - .github/*
     - docs/*
+    # Don't trigger VMR builds for changes to Mono.
+    # Mono-based stage 2 source-build is not blocking for the VMR and is only done as a basic validation
+    # for our partners. Interesting Mono-based stage 2 source-build legs are for architectures that are not
+    # supported on CoreCLR, like S390X, which we don't build ourselves.
+    - src/mono/*
     - eng/pipelines/coreclr/*.*
     - eng/pipelines/libraries/*.*
     - eng/pipelines/installer/*.*
@@ -25,95 +30,25 @@ pr:
     - THIRD-PARTY-NOTICES.TXT
 
 variables:
-  - template: /eng/pipelines/common/variables.yml
+- template: /eng/common/templates/variables/pool-providers.yml@self
 
-extends:
-  template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
+- name: skipComponentGovernanceDetection  # we run CG on internal builds only
+  value: true
+
+- name: Codeql.Enabled  # we run CodeQL on internal builds only
+  value: false
+
+resources:
+  repositories:
+  - repository: vmr
+    type: github
+    name: dotnet/dotnet
+    endpoint: dotnet
+
+stages:
+- template: /eng/pipelines/templates/stages/vmr-build.yml@vmr
   parameters:
-    isOfficialBuild: false
-    stages:
-    - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-      - stage: EvaluatePaths
-        displayName: Evaluate Paths
-        jobs:
-          - template: /eng/pipelines/common/evaluate-default-paths.yml
+    isBuiltFromVmr: false
+    scope: lite
+    verifications: [ "source-build-stage1", "source-build-stage2" ]
 
-    - stage: Build
-      jobs:
-
-      #
-      # Build with Release config and runtimeConfiguration with MSBuild generator
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: release
-          platforms:
-          - windows_x86
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: MSBuild_CMake
-            buildArgs: -c Release -msbuild
-            timeoutInMinutes: 120
-            condition:
-              or(
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build with RuntimeFlavor only. This exercise code paths where only RuntimeFlavor is
-      # specified. Catches cases where we depend on Configuration also being specified
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: debug
-          platforms:
-          - linux_x64_dev_innerloop
-          jobParameters:
-            testGroup: innerloop
-            nameSuffix: RuntimeFlavor_Mono
-            buildArgs: /p:RuntimeFlavor=Mono
-            timeoutInMinutes: 120
-            condition:
-              or(
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build Libraries (all TFMs) and create packages on a non Windows operating system.
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: debug
-          platforms:
-          - linux_x64_dev_innerloop
-          jobParameters:
-            nameSuffix: Libraries_WithPackages
-            buildArgs: -subset libs -pack
-            timeoutInMinutes: 120
-            condition:
-              or(
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-
-      #
-      # Build native assets on Alpine. This exercises more modern musl libc changes that have a tendendy to break source-build.
-      # We don't add this as a source-build job as the repo source-build infrastructure isn't set up to run on alpine effectively.
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          buildConfig: debug
-          platforms:
-          - linux_musl_x64_dev_innerloop
-          jobParameters:
-            nameSuffix: Musl_Validation
-            buildArgs: -subset clr.native+libs.native+host.native -c $(_BuildConfig)
-            timeoutInMinutes: 120
-            condition:
-              or(
-                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -1,6 +1,6 @@
-# This pipeline is used for running the VMR verification of the PR changes in repo-level PRs.
-# If there are changes in flight that intentionally create cross-repo breaking changes in the VMR ingestion,
-# this pipeline is expected to fail until the conflicts are resolved in the VMR.
+# The purpose of this pipeline is to exercise various developer workflows in the repo.
+# Primarily, it is meant to cover local (non-cross) build scenarios and
+# source-build scenarios that commonly cause build breaks.
 
 trigger: none
 
@@ -18,11 +18,6 @@ pr:
     - .devcontainer/*
     - .github/*
     - docs/*
-    # Don't trigger VMR builds for changes to Mono.
-    # Mono-based stage 2 source-build is not blocking for the VMR and is only done as a basic validation
-    # for our partners. Interesting Mono-based stage 2 source-build legs are for architectures that are not
-    # supported on CoreCLR, like S390X, which we don't build ourselves.
-    - src/mono/*
     - eng/pipelines/coreclr/*.*
     - eng/pipelines/libraries/*.*
     - eng/pipelines/installer/*.*
@@ -30,25 +25,95 @@ pr:
     - THIRD-PARTY-NOTICES.TXT
 
 variables:
-- template: /eng/common/templates/variables/pool-providers.yml@self
+  - template: /eng/pipelines/common/variables.yml
 
-- name: skipComponentGovernanceDetection  # we run CG on internal builds only
-  value: true
-
-- name: Codeql.Enabled  # we run CodeQL on internal builds only
-  value: false
-
-resources:
-  repositories:
-  - repository: vmr
-    type: github
-    name: dotnet/dotnet
-    endpoint: dotnet
-
-stages:
-- template: /eng/pipelines/templates/stages/vmr-build.yml@vmr
+extends:
+  template:  /eng/pipelines/common/templates/pipeline-with-resources.yml
   parameters:
-    isBuiltFromVmr: false
-    scope: lite
-    verifications: [ "source-build-stage1", "source-build-stage2" ]
+    isOfficialBuild: false
+    stages:
+    - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      - stage: EvaluatePaths
+        displayName: Evaluate Paths
+        jobs:
+          - template: /eng/pipelines/common/evaluate-default-paths.yml
 
+    - stage: Build
+      jobs:
+
+      #
+      # Build with Release config and runtimeConfiguration with MSBuild generator
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: release
+          platforms:
+          - windows_x86
+          jobParameters:
+            testGroup: innerloop
+            nameSuffix: MSBuild_CMake
+            buildArgs: -c Release -msbuild
+            timeoutInMinutes: 120
+            condition:
+              or(
+                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_coreclr.containsChange'], true),
+                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
+
+      #
+      # Build with RuntimeFlavor only. This exercise code paths where only RuntimeFlavor is
+      # specified. Catches cases where we depend on Configuration also being specified
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: debug
+          platforms:
+          - linux_x64_dev_innerloop
+          jobParameters:
+            testGroup: innerloop
+            nameSuffix: RuntimeFlavor_Mono
+            buildArgs: /p:RuntimeFlavor=Mono
+            timeoutInMinutes: 120
+            condition:
+              or(
+                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_wasm.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
+
+      #
+      # Build Libraries (all TFMs) and create packages on a non Windows operating system.
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: debug
+          platforms:
+          - linux_x64_dev_innerloop
+          jobParameters:
+            nameSuffix: Libraries_WithPackages
+            buildArgs: -subset libs -pack
+            timeoutInMinutes: 120
+            condition:
+              or(
+                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+                eq(variables['isRollingBuild'], true))
+
+      #
+      # Build native assets on Alpine. This exercises more modern musl libc changes that have a tendendy to break source-build.
+      # We don't add this as a source-build job as the repo source-build infrastructure isn't set up to run on alpine effectively.
+      #
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/global-build-job.yml
+          buildConfig: debug
+          platforms:
+          - linux_musl_x64_dev_innerloop
+          jobParameters:
+            nameSuffix: Musl_Validation
+            buildArgs: -subset clr.native+libs.native+host.native -c $(_BuildConfig)
+            timeoutInMinutes: 120
+            condition:
+              or(
+                eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
+                eq(variables['isRollingBuild'], true))

--- a/eng/pipelines/global-build.yml
+++ b/eng/pipelines/global-build.yml
@@ -117,3 +117,13 @@ extends:
               or(
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_non_mono_and_wasm.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
+
+      #
+      # Build Repo SourceBuild
+      #
+      - template: /eng/common/templates/jobs/source-build.yml
+        parameters:
+          platforms:
+          - name: Linux_x64
+            targetRID: linux-x64
+            container: SourceBuild_linux_x64

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1855,29 +1855,3 @@ extends:
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
                 eq(stageDependencies.EvaluatePaths.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
-
-    - stage: SourceBuild
-      displayName: Source Build Validation
-      dependsOn: []
-      condition: eq(variables['isRollingBuild'], true)
-      jobs:
-        #
-        # Sourcebuild legs
-        # We have 3 important legs for source-build:
-        # - Centos.9 (ensures that known non-portable RID is working)
-        # - Linux-x64 portable (used for dependency flow and downstream PR verification)
-        # - Banana.24 - Non-existent RID to ensure we don't break RIDs we don't know about.
-        #
-        # Running all of these everywhere is wasteful. Run Banana.24 and CentOS.9 in rolling CI,
-        # Run Linux-x64 in PR.
-        - template: /eng/common/templates/jobs/source-build.yml
-          parameters:
-            platforms:
-              - name: CentOS9
-                targetRID: centos.9-x64
-                portableBuild: false
-                container: SourceBuild_centos_x64
-              - name: NonexistentRID
-                targetRID: banana.24-x64
-                portableBuild: false
-                container: SourceBuild_centos_x64

--- a/eng/pipelines/vmr-build-pr.yml
+++ b/eng/pipelines/vmr-build-pr.yml
@@ -18,7 +18,7 @@ pr:
     - docs/*
     # Don't trigger VMR builds for changes to Mono.
     # Mono-based stage 2 source-build is not blocking for the VMR and is only done as a basic validation
-    # for our partners. Interesting Mono-based stage 2 source-build is for architectures that are not
+    # for our partners. Interesting Mono-based stage 2 source-build legs are for architectures that are not
     # supported on CoreCLR, like S390X, which we don't build ourselves.
     - src/mono/*
     - eng/pipelines/coreclr/*.*

--- a/eng/pipelines/vmr-build-pr.yml
+++ b/eng/pipelines/vmr-build-pr.yml
@@ -1,4 +1,6 @@
 # This pipeline is used for running the VMR verification of the PR changes in repo-level PRs.
+# If there are changes in flight that intentionally create cross-repo breaking changes in the VMR ingestion,
+# this pipeline is expected to fail until the conflicts are resolved in the VMR.
 
 trigger: none
 

--- a/eng/pipelines/vmr-build-pr.yml
+++ b/eng/pipelines/vmr-build-pr.yml
@@ -1,0 +1,48 @@
+# This pipeline is used for running the VMR verification of the PR changes in repo-level PRs.
+
+trigger: none
+
+pr:
+  branches:
+    include:
+    - main
+    - release/*.*
+  paths:
+    include:
+    - '*'
+    - eng/pipelines/global-build.yml
+    exclude:
+    - '**.md'
+    - .devcontainer/*
+    - .github/*
+    - docs/*
+    - src/mono/* # Repo PR VMR validation does not cover source-build stage2 with Mono, so don't trigger on Mono-only changes to avoid unnecessary builds
+    - eng/pipelines/coreclr/*.*
+    - eng/pipelines/libraries/*.*
+    - eng/pipelines/installer/*.*
+    - PATENTS.TXT
+    - THIRD-PARTY-NOTICES.TXT
+
+variables:
+- template: /eng/common/templates/variables/pool-providers.yml@self
+
+- name: skipComponentGovernanceDetection  # we run CG on internal builds only
+  value: true
+
+- name: Codeql.Enabled  # we run CodeQL on internal builds only
+  value: false
+
+resources:
+  repositories:
+  - repository: vmr
+    type: github
+    name: dotnet/dotnet
+    endpoint: dotnet
+
+stages:
+- template: /eng/pipelines/templates/stages/vmr-build.yml@vmr
+  parameters:
+    isBuiltFromVmr: false
+    scope: lite
+    verifications: [ "source-build-stage1", "source-build-stage2" ]
+

--- a/eng/pipelines/vmr-build-pr.yml
+++ b/eng/pipelines/vmr-build-pr.yml
@@ -16,7 +16,11 @@ pr:
     - .devcontainer/*
     - .github/*
     - docs/*
-    - src/mono/* # Repo PR VMR validation does not cover source-build stage2 with Mono, so don't trigger on Mono-only changes to avoid unnecessary builds
+    # Don't trigger VMR builds for changes to Mono.
+    # Mono-based stage 2 source-build is not blocking for the VMR and is only done as a basic validation
+    # for our partners. Interesting Mono-based stage 2 source-build is for architectures that are not
+    # supported on CoreCLR, like S390X, which we don't build ourselves.
+    - src/mono/*
     - eng/pipelines/coreclr/*.*
     - eng/pipelines/libraries/*.*
     - eng/pipelines/installer/*.*

--- a/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
@@ -791,7 +791,7 @@ namespace System.IO
                 }
             }
 
-            bool acquired = SharedMemoryHelpers.TryAcquireFileLock(fd, nonBlocking: true, exclusive: true);
+            bool acquired = SharedMemoryHelpers.TryAcquireFileLock(fd, nonBlocking: false, exclusive: true);
             Debug.Assert(acquired);
             return new AutoReleaseFileLock(fd);
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
@@ -791,7 +791,7 @@ namespace System.IO
                 }
             }
 
-            bool acquired = SharedMemoryHelpers.TryAcquireFileLock(fd, nonBlocking: false, exclusive: true);
+            bool acquired = SharedMemoryHelpers.TryAcquireFileLock(fd, nonBlocking: true, exclusive: true);
             Debug.Assert(acquired);
             return new AutoReleaseFileLock(fd);
 


### PR DESCRIPTION
Fixes #122998

This creates a separate pipeline for such validation as we don't want to block builds on failures as sometimes a failure is expected. As a result, I don't think we want to add this to Build Analysis. If we want to handle these sorts of expected failures via Build Analysis, I can merge this into the global-build.yml pipeline.

Remove the old source-build jobs as the VMR validation supercedes such validation.