### PR TITLE
[clr-interp] Fix debugger issues in interpreter

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -5088,7 +5088,7 @@ ClrDataAccess::FollowStubStep(
             methodDesc = PTR_MethodDesc(CORDB_ADDRESS_TO_TADDR(inBuffer->u.addr));
             if (methodDesc->HasNativeCode())
             {
-                *outAddr = methodDesc->GetNativeCode();
+                *outAddr = methodDesc->GetCodeForInterpreterOrJitted();
                 *outFlags = CLRDATA_FOLLOW_STUB_EXIT;
                 return S_OK;
             }
@@ -5737,7 +5737,7 @@ ClrDataAccess::RawGetMethodName(
     MethodDesc* methodDesc = NULL;
 
     {
-        EECodeInfo codeInfo(TO_TADDR(address));
+        EECodeInfo codeInfo(GetInterpreterCodeFromInterpreterPrecodeIfPresent(TO_TADDR(address)));
         if (codeInfo.IsValid())
         {
             if (displacement)
@@ -5886,7 +5886,7 @@ ClrDataAccess::GetMethodExtents(MethodDesc* methodDesc,
         // for all types of managed code.
         //
 
-        PCODE methodStart = methodDesc->GetNativeCode();
+        PCODE methodStart = methodDesc->GetCodeForInterpreterOrJitted();
         if (!methodStart)
         {
             return E_NOINTERFACE;
@@ -5940,11 +5940,11 @@ ClrDataAccess::GetMethodVarInfo(MethodDesc* methodDesc,
         {
             return E_INVALIDARG;
         }
-        nativeCodeStartAddr = PCODEToPINSTR(requestedNativeCodeVersion.GetNativeCode());
+        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromInterpreterPrecodeIfPresent(requestedNativeCodeVersion.GetNativeCode()));
     }
     else
     {
-        nativeCodeStartAddr = PCODEToPINSTR(methodDesc->GetNativeCode());
+        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromInterpreterPrecodeIfPresent(methodDesc->GetNativeCode()));
     }
 
     DebugInfoRequest request;
@@ -5999,11 +5999,11 @@ ClrDataAccess::GetMethodNativeMap(MethodDesc* methodDesc,
         {
             return E_INVALIDARG;
         }
-        nativeCodeStartAddr = PCODEToPINSTR(requestedNativeCodeVersion.GetNativeCode());
+        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromInterpreterPrecodeIfPresent(requestedNativeCodeVersion.GetNativeCode()));
     }
     else
     {
-        nativeCodeStartAddr = PCODEToPINSTR(methodDesc->GetNativeCode());
+        nativeCodeStartAddr = PCODEToPINSTR(GetInterpreterCodeFromInterpreterPrecodeIfPresent(methodDesc->GetNativeCode()));
     }
 
     DebugInfoRequest request;

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -1137,7 +1137,7 @@ void DacDbiInterfaceImpl::GetMethodRegionInfo(MethodDesc *             pMethodDe
     CONTRACTL_END;
 
     IJitManager::MethodRegionInfo methodRegionInfo = {(TADDR)NULL, 0, (TADDR)NULL, 0};
-    PCODE functionAddress = pMethodDesc->GetNativeCode();
+    PCODE functionAddress = pMethodDesc->GetCodeForInterpreterOrJitted();
 
     // get the start address of the hot region and initialize the jit manager
     pCodeInfo->m_rgCodeRegions[kHot].pAddress = CORDB_ADDRESS(PCODEToPINSTR(functionAddress));
@@ -1228,6 +1228,12 @@ void DacDbiInterfaceImpl::GetNativeCodeInfoForAddr(VMPTR_MethodDesc         vmMe
 
     IJitManager::MethodRegionInfo methodRegionInfo = {(TADDR)NULL, 0, (TADDR)NULL, 0};
     TADDR codeAddr = CORDB_ADDRESS_TO_TADDR(hotCodeStartAddr);
+
+    EX_TRY_ALLOW_DATATARGET_MISSING_MEMORY
+    {
+        codeAddr = GetInterpreterCodeFromInterpreterPrecodeIfPresent(codeAddr);
+    }
+    EX_END_CATCH_ALLOW_DATATARGET_MISSING_MEMORY;
 
 #ifdef TARGET_ARM
     // TADDR should not have the thumb code bit set.

--- a/src/coreclr/debug/daccess/enummem.cpp
+++ b/src/coreclr/debug/daccess/enummem.cpp
@@ -593,7 +593,7 @@ HRESULT ClrDataAccess::DumpManagedExcepObject(CLRDataEnumMemoryFlags flags, OBJE
             // Pulls in data to translate from token to MethodDesc
             FindLoadedMethodRefOrDef(pMD->GetMethodTable()->GetModule(), pMD->GetMemberDef());
 
-            PCODE addr = pMD->GetNativeCode();
+            PCODE addr = pMD->GetCodeForInterpreterOrJitted();
             if (addr != (PCODE)NULL)
             {
                 EECodeInfo codeInfo(addr);

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -901,7 +901,7 @@ HRESULT ClrDataAccess::GetThreadData(CLRDATA_ADDRESS threadAddr, struct DacpThre
 void CopyNativeCodeVersionToReJitData(NativeCodeVersion nativeCodeVersion, NativeCodeVersion activeCodeVersion, DacpReJitData * pReJitData)
 {
     pReJitData->rejitID = nativeCodeVersion.GetILCodeVersion().GetVersionId();
-    pReJitData->NativeCodeAddr = GetInterpreterCodeFromInterpreterPrecodeIfPresent(nativeCodeVersion.GetNativeCode ());
+    pReJitData->NativeCodeAddr = GetInterpreterCodeFromInterpreterPrecodeIfPresent(nativeCodeVersion.GetNativeCode());
 
     if (nativeCodeVersion != activeCodeVersion)
     {

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -227,7 +227,7 @@ BOOL DacValidateMD(PTR_MethodDesc pMD)
 
         if (retval && pMD->HasNativeCode() && !pMD->IsFCall())
         {
-            PCODE jitCodeAddr = pMD->GetNativeCode();
+            PCODE jitCodeAddr = pMD->GetCodeForInterpreterOrJitted();
 
             MethodDesc *pMDCheck = ExecutionManager::GetCodeMethodDesc(jitCodeAddr);
             if (pMDCheck)
@@ -901,7 +901,7 @@ HRESULT ClrDataAccess::GetThreadData(CLRDATA_ADDRESS threadAddr, struct DacpThre
 void CopyNativeCodeVersionToReJitData(NativeCodeVersion nativeCodeVersion, NativeCodeVersion activeCodeVersion, DacpReJitData * pReJitData)
 {
     pReJitData->rejitID = nativeCodeVersion.GetILCodeVersion().GetVersionId();
-    pReJitData->NativeCodeAddr = nativeCodeVersion.GetNativeCode();
+    pReJitData->NativeCodeAddr = GetInterpreterCodeFromInterpreterPrecodeIfPresent(nativeCodeVersion.GetNativeCode ());
 
     if (nativeCodeVersion != activeCodeVersion)
     {
@@ -1011,7 +1011,7 @@ HRESULT ClrDataAccess::GetMethodDescData(
         if (!requestedNativeCodeVersion.IsNull() && requestedNativeCodeVersion.GetNativeCode() != (PCODE)NULL)
         {
             methodDescData->bHasNativeCode = TRUE;
-            methodDescData->NativeCodeAddr = TO_CDADDR(PCODEToPINSTR(requestedNativeCodeVersion.GetNativeCode()));
+            methodDescData->NativeCodeAddr = TO_CDADDR(PCODEToPINSTR(GetInterpreterCodeFromInterpreterPrecodeIfPresent(requestedNativeCodeVersion.GetNativeCode())));
         }
         else
         {
@@ -1235,7 +1235,7 @@ HRESULT ClrDataAccess::GetTieredVersions(
         int count = 0;
         for (NativeCodeVersionIterator iter = nativeCodeVersions.Begin(); iter != nativeCodeVersions.End(); iter++)
         {
-            TADDR pNativeCode = PCODEToPINSTR((*iter).GetNativeCode());
+            TADDR pNativeCode = PCODEToPINSTR(GetInterpreterCodeFromInterpreterPrecodeIfPresent((*iter).GetNativeCode()));
             nativeCodeAddrs[count].NativeCodeAddr = pNativeCode;
             PTR_NativeCodeVersionNode pNode = (*iter).AsNode();
             nativeCodeAddrs[count].NativeCodeVersionNodePtr = PTR_CDADDR(pNode);

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1614,13 +1614,11 @@ public:
     PCODE GetNativeCode();
 
     // Returns either the jitted code or the interpreter code (will not return the InterpreterStub which GetNativeCode might return)
-#ifdef FEATURE_INTERPRETER
     PCODE GetCodeForInterpreterOrJitted()
     {
         WRAPPER_NO_CONTRACT;
         return GetInterpreterCodeFromInterpreterPrecodeIfPresent(GetNativeCode());
     }
-#endif
 
     // Returns GetNativeCode() if it exists, but also checks to see if there
     // is a non-default code version that is populated with a code body and returns that.

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1613,6 +1613,15 @@ public:
     // Returns the address of the native code.
     PCODE GetNativeCode();
 
+    // Returns either the jitted code or the interpreter code (will not return the InterpreterStub which GetNativeCode might return)
+#ifdef FEATURE_INTERPRETER
+    PCODE GetCodeForInterpreterOrJitted()
+    {
+        WRAPPER_NO_CONTRACT;
+        return GetInterpreterCodeFromInterpreterPrecodeIfPresent(GetNativeCode());
+    }
+#endif
+
     // Returns GetNativeCode() if it exists, but also checks to see if there
     // is a non-default code version that is populated with a code body and returns that.
     // Perf warning: takes the CodeVersionManagerLock on every call

--- a/src/coreclr/vm/precode.cpp
+++ b/src/coreclr/vm/precode.cpp
@@ -959,7 +959,7 @@ BOOL StubPrecode::IsStubPrecodeByASM(PCODE addr)
 
 #endif // !FEATURE_PORTABLE_ENTRYPOINTS
 
-PCODE GetInterpreterCodeFromInterpreterPrecodeIfPresent(PCODE codePointerMaybeInterpreterStub)
+PCODE GetInterpreterCodeFromInterpreterPrecodeIfPresent(TADDR codePointerMaybeInterpreterStub)
 {
     CONTRACTL {
         NOTHROW;

--- a/src/coreclr/vm/precode.cpp
+++ b/src/coreclr/vm/precode.cpp
@@ -959,7 +959,7 @@ BOOL StubPrecode::IsStubPrecodeByASM(PCODE addr)
 
 #endif // !FEATURE_PORTABLE_ENTRYPOINTS
 
-PCODE GetInterpreterCodeFromInterpreterPrecodeIfPresent(TADDR codePointerMaybeInterpreterStub)
+TADDR GetInterpreterCodeFromInterpreterPrecodeIfPresent(TADDR codePointerMaybeInterpreterStub)
 {
     CONTRACTL {
         NOTHROW;
@@ -967,10 +967,10 @@ PCODE GetInterpreterCodeFromInterpreterPrecodeIfPresent(TADDR codePointerMaybeIn
         SUPPORTS_DAC;
     } CONTRACTL_END;
     
-#ifdef FEATURE_INTERPRETER
-    if (codePointerMaybeInterpreterStub == NULL)
+#if defined(FEATURE_INTERPRETER) && !defined(FEATURE_PORTABLE_ENTRYPOINTS)
+    if (codePointerMaybeInterpreterStub == (TADDR)NULL)
     {
-        return NULL;
+        return (TADDR)NULL;
     }
 
     RangeSection * pRS = ExecutionManager::FindCodeRange(codePointerMaybeInterpreterStub, ExecutionManager::GetScanFlags());

--- a/src/coreclr/vm/precode.cpp
+++ b/src/coreclr/vm/precode.cpp
@@ -958,3 +958,33 @@ BOOL StubPrecode::IsStubPrecodeByASM(PCODE addr)
 }
 
 #endif // !FEATURE_PORTABLE_ENTRYPOINTS
+
+PCODE GetInterpreterCodeFromInterpreterPrecodeIfPresent(PCODE codePointerMaybeInterpreterStub)
+{
+    CONTRACTL {
+        NOTHROW;
+        GC_NOTRIGGER;
+        SUPPORTS_DAC;
+    } CONTRACTL_END;
+    
+#ifdef FEATURE_INTERPRETER
+    if (codePointerMaybeInterpreterStub == NULL)
+    {
+        return NULL;
+    }
+
+    RangeSection * pRS = ExecutionManager::FindCodeRange(codePointerMaybeInterpreterStub, ExecutionManager::GetScanFlags());
+    if (pRS != NULL && pRS->_flags & RangeSection::RANGE_SECTION_RANGELIST)
+    {
+        if (pRS->_pRangeList->GetCodeBlockKind() == STUB_CODE_BLOCK_STUBPRECODE)
+        {
+            if (dac_cast<PTR_StubPrecode>(PCODEToPINSTR(codePointerMaybeInterpreterStub))->GetType() == PRECODE_INTERPRETER)
+            {
+                codePointerMaybeInterpreterStub = (dac_cast<PTR_InterpreterPrecode>(PCODEToPINSTR(codePointerMaybeInterpreterStub)))->GetData()->ByteCodeAddr;
+            }
+        }
+    }
+#endif
+
+    return codePointerMaybeInterpreterStub;
+}

--- a/src/coreclr/vm/precode.h
+++ b/src/coreclr/vm/precode.h
@@ -864,4 +864,6 @@ extern InterleavedLoaderHeapConfig s_fixupStubPrecodeHeapConfig;
 
 #endif // FEATURE_PORTABLE_ENTRYPOINTS
 
+TADDR GetInterpreterCodeFromInterpreterPrecodeIfPresent(TADDR codePointerMaybeInterpreterStub);
+
 #endif // __PRECODE_H__

--- a/src/coreclr/vm/stubmgr.cpp
+++ b/src/coreclr/vm/stubmgr.cpp
@@ -1011,6 +1011,11 @@ BOOL PrecodeStubManager::CheckIsStub_Internal(PCODE stubStartAddress)
     else if (stubKind == STUB_CODE_BLOCK_STUBPRECODE)
     {
         Precode* pPrecode = Precode::GetPrecodeFromEntryPoint(stubStartAddress);
+        if (pPrecode == NULL)
+        {
+            return FALSE;
+        }
+
         switch (pPrecode->GetType())
         {
             case PRECODE_STUB:

--- a/src/coreclr/vm/stubmgr.cpp
+++ b/src/coreclr/vm/stubmgr.cpp
@@ -1011,10 +1011,14 @@ BOOL PrecodeStubManager::CheckIsStub_Internal(PCODE stubStartAddress)
     else if (stubKind == STUB_CODE_BLOCK_STUBPRECODE)
     {
         Precode* pPrecode = Precode::GetPrecodeFromEntryPoint(stubStartAddress);
+#ifdef DACCESS_COMPILE
+        // The DAC always treats GetPrecodeFromEntryPoint as if the speculative flag is TRUE.
+        // so it may return NULL
         if (pPrecode == NULL)
         {
             return FALSE;
         }
+#endif
 
         switch (pPrecode->GetType())
         {


### PR DESCRIPTION
Fix a set of issues found when attempting to use the debugger on interpreted code. In general we need to get the interpreter byte codes if possible when attempting to use the EECodeInfo infrastructure. These changes helped me debug issues that appeared in interpmode=2