### PR TITLE
Fix `LoadFromStream` to stop checking/loading from `APP_PATHS`

### DIFF
--- a/src/coreclr/binder/customassemblybinder.cpp
+++ b/src/coreclr/binder/customassemblybinder.cpp
@@ -102,7 +102,6 @@ Exit:;
 }
 
 HRESULT CustomAssemblyBinder::BindUsingPEImage( /* in */ PEImage *pPEImage,
-                                                /* in */ bool excludeAppPaths,
                                                 /* [retval][out] */ BINDER_SPACE::Assembly **ppAssembly)
 {
     HRESULT hr = S_OK;
@@ -129,7 +128,7 @@ HRESULT CustomAssemblyBinder::BindUsingPEImage( /* in */ PEImage *pPEImage,
             IF_FAIL_GO(HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND));
         }
 
-        hr = AssemblyBinderCommon::BindUsingPEImage(this, pAssemblyName, pPEImage, excludeAppPaths, &pCoreCLRFoundAssembly);
+        hr = AssemblyBinderCommon::BindUsingPEImage(this, pAssemblyName, pPEImage, &pCoreCLRFoundAssembly);
         if (hr == S_OK)
         {
             _ASSERTE(pCoreCLRFoundAssembly != NULL);
@@ -230,7 +229,7 @@ void CustomAssemblyBinder::PrepareForLoadContextRelease(INT_PTR ptrManagedStrong
     // native LoaderAllocators of two collectible contexts in case the AssemblyLoadContext.Unload was called on the current
     // context before returning from its AssemblyLoadContext.Load override or the context's Resolving event.
     // But we need to release the LoaderAllocator so that it doesn't prevent completion of the final phase of unloading in
-    // some cases. It is safe to do as the AssemblyLoaderAllocator is guaranteed to be alive at least until the 
+    // some cases. It is safe to do as the AssemblyLoaderAllocator is guaranteed to be alive at least until the
     // CustomAssemblyBinder::ReleaseLoadContext is called, where we NULL this pointer.
     m_pAssemblyLoaderAllocator->Release();
 
@@ -258,7 +257,7 @@ void CustomAssemblyBinder::ReleaseLoadContext()
     DestroyHandle(handle);
     SetAssemblyLoadContext((INT_PTR)NULL);
 
-    // The AssemblyLoaderAllocator is in a process of shutdown and should not be used 
+    // The AssemblyLoaderAllocator is in a process of shutdown and should not be used
     // after this point.
     m_pAssemblyLoaderAllocator = NULL;
 }

--- a/src/coreclr/binder/defaultassemblybinder.cpp
+++ b/src/coreclr/binder/defaultassemblybinder.cpp
@@ -111,7 +111,6 @@ Exit:;
 
 #if !defined(DACCESS_COMPILE)
 HRESULT DefaultAssemblyBinder::BindUsingPEImage( /* in */ PEImage *pPEImage,
-                                                 /* in */ bool excludeAppPaths,
                                                  /* [retval][out] */ BINDER_SPACE::Assembly **ppAssembly)
 {
     HRESULT hr = S_OK;
@@ -158,7 +157,7 @@ HRESULT DefaultAssemblyBinder::BindUsingPEImage( /* in */ PEImage *pPEImage,
             }
         }
 
-        hr = AssemblyBinderCommon::BindUsingPEImage(this, pAssemblyName, pPEImage, excludeAppPaths, &pCoreCLRFoundAssembly);
+        hr = AssemblyBinderCommon::BindUsingPEImage(this, pAssemblyName, pPEImage, &pCoreCLRFoundAssembly);
         if (hr == S_OK)
         {
             _ASSERTE(pCoreCLRFoundAssembly != NULL);

--- a/src/coreclr/binder/inc/assemblybindercommon.hpp
+++ b/src/coreclr/binder/inc/assemblybindercommon.hpp
@@ -56,7 +56,6 @@ namespace BINDER_SPACE
         static HRESULT BindUsingPEImage(/* in */  AssemblyBinder     *pBinder,
                                         /* in */  BINDER_SPACE::AssemblyName *pAssemblyName,
                                         /* in */  PEImage            *pPEImage,
-                                        /* in */  bool              excludeAppPaths,
                                         /* [retval] [out] */  Assembly **ppAssembly);
 #endif // !defined(DACCESS_COMPILE)
 

--- a/src/coreclr/binder/inc/customassemblybinder.h
+++ b/src/coreclr/binder/inc/customassemblybinder.h
@@ -18,7 +18,6 @@ class CustomAssemblyBinder final : public AssemblyBinder
 public:
 
     HRESULT BindUsingPEImage(PEImage* pPEImage,
-        bool excludeAppPaths,
         BINDER_SPACE::Assembly** ppAssembly) override;
 
     HRESULT BindUsingAssemblyName(BINDER_SPACE::AssemblyName* pAssemblyName,

--- a/src/coreclr/binder/inc/defaultassemblybinder.h
+++ b/src/coreclr/binder/inc/defaultassemblybinder.h
@@ -16,7 +16,6 @@ class DefaultAssemblyBinder final : public AssemblyBinder
 public:
 
     HRESULT BindUsingPEImage(PEImage* pPEImage,
-        bool excludeAppPaths,
         BINDER_SPACE::Assembly** ppAssembly) override;
 
     HRESULT BindUsingAssemblyName(BINDER_SPACE::AssemblyName* pAssemblyName,

--- a/src/coreclr/vm/assemblybinder.h
+++ b/src/coreclr/vm/assemblybinder.h
@@ -19,7 +19,7 @@ class AssemblyBinder
 public:
 
     HRESULT BindAssemblyByName(AssemblyNameData* pAssemblyNameData, BINDER_SPACE::Assembly** ppAssembly);
-    virtual HRESULT BindUsingPEImage(PEImage* pPEImage, bool excludeAppPaths, BINDER_SPACE::Assembly** ppAssembly) = 0;
+    virtual HRESULT BindUsingPEImage(PEImage* pPEImage, BINDER_SPACE::Assembly** ppAssembly) = 0;
     virtual HRESULT BindUsingAssemblyName(BINDER_SPACE::AssemblyName* pAssemblyName, BINDER_SPACE::Assembly** ppAssembly) = 0;
 
     /// <summary>
@@ -89,7 +89,7 @@ private:
         {
         }
 
-        SimpleNameToExpectedMVIDAndRequiringAssembly(LPCUTF8 simpleName, GUID mvid, bool compositeComponent, LPCUTF8 AssemblyRequirementName) : 
+        SimpleNameToExpectedMVIDAndRequiringAssembly(LPCUTF8 simpleName, GUID mvid, bool compositeComponent, LPCUTF8 AssemblyRequirementName) :
             SimpleName(simpleName),
             Mvid(mvid),
             AssemblyRequirementName(AssemblyRequirementName),

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -250,9 +250,7 @@ extern "C" void QCALLTYPE AssemblyNative_LoadFromStream(INT_PTR ptrNativeAssembl
         ThrowHR(COR_E_BADIMAGEFORMAT, BFA_IJW_IN_COLLECTIBLE_ALC);
     }
 
-    // Pass the stream based assembly as IL in an attempt to bind and load it
-    // excludeAppPaths is implicitly true for streams since the user is explicitly providing
-    // a stream that should take precedence over disk-based assemblies
+    // Pass the stream-based assembly as IL in an attempt to bind and load it
     Assembly* pLoadedAssembly = AssemblyNative::LoadFromPEImage(pBinder, pILImage);
     {
         GCX_COOP();

--- a/src/coreclr/vm/assemblynative.cpp
+++ b/src/coreclr/vm/assemblynative.cpp
@@ -120,7 +120,7 @@ extern "C" void QCALLTYPE AssemblyNative_InternalLoad(NativeAssemblyNameParts* p
 }
 
 /* static */
-Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinder, PEImage *pImage, bool excludeAppPaths)
+Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinder, PEImage *pImage)
 {
     CONTRACT(Assembly*)
     {
@@ -146,7 +146,7 @@ Assembly* AssemblyNative::LoadFromPEImage(AssemblyBinder* pBinder, PEImage *pIma
 
     HRESULT hr = S_OK;
     PTR_AppDomain pCurDomain = GetAppDomain();
-    hr = pBinder->BindUsingPEImage(pImage, excludeAppPaths, &pAssembly);
+    hr = pBinder->BindUsingPEImage(pImage, &pAssembly);
 
     if (hr != S_OK)
     {
@@ -251,6 +251,8 @@ extern "C" void QCALLTYPE AssemblyNative_LoadFromStream(INT_PTR ptrNativeAssembl
     }
 
     // Pass the stream based assembly as IL in an attempt to bind and load it
+    // excludeAppPaths is implicitly true for streams since the user is explicitly providing
+    // a stream that should take precedence over disk-based assemblies
     Assembly* pLoadedAssembly = AssemblyNative::LoadFromPEImage(pBinder, pILImage);
     {
         GCX_COOP();

--- a/src/coreclr/vm/assemblynative.hpp
+++ b/src/coreclr/vm/assemblynative.hpp
@@ -21,7 +21,7 @@ class AssemblyNative
 {
 public:
 
-    static Assembly* LoadFromPEImage(AssemblyBinder* pBinder, PEImage *pImage, bool excludeAppPaths = false);
+    static Assembly* LoadFromPEImage(AssemblyBinder* pBinder, PEImage *pImage);
 
     // static FCALLs
     static FCDECL0(FC_BOOL_RET, IsTracingEnabled);

--- a/src/coreclr/vm/assemblyspec.cpp
+++ b/src/coreclr/vm/assemblyspec.cpp
@@ -436,7 +436,7 @@ Assembly *AssemblySpec::LoadAssembly(LPCWSTR pFilePath)
     if (!pILImage->CheckILFormat())
         THROW_BAD_FORMAT(BFA_BAD_IL, pILImage.GetValue());
 
-    RETURN AssemblyNative::LoadFromPEImage(AppDomain::GetCurrentDomain()->GetDefaultBinder(), pILImage, true /* excludeAppPaths */);
+    RETURN AssemblyNative::LoadFromPEImage(AppDomain::GetCurrentDomain()->GetDefaultBinder(), pILImage);
 }
 
 HRESULT AssemblySpec::CheckFriendAssemblyName()

--- a/src/tests/Loader/binding/AppPaths/AppPaths.cs
+++ b/src/tests/Loader/binding/AppPaths/AppPaths.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.Loader;
+using Xunit;
+
+public class AppPaths
+{
+    private const string AssemblyToLoad = "AssemblyToLoad";
+
+    [Fact]
+    public static void DefaultALC()
+    {
+        LoadFromStream(AssemblyLoadContext.Default);
+    }
+
+    [Fact]
+    public static void CustomALC()
+    {
+        AssemblyLoadContext alc = new("alc");
+        LoadFromStream(alc);
+    }
+
+    private static void LoadFromStream(AssemblyLoadContext alc)
+    {
+        // corerun should add the app directory as the APP_PATHS property
+        Assert.Equal(AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar), ((string)AppContext.GetData("APP_PATHS")).TrimEnd(Path.DirectorySeparatorChar), StringComparer.OrdinalIgnoreCase);
+        string assemblyPath = Path.Combine(AppContext.BaseDirectory, $"{AssemblyToLoad}.dll");
+        byte[] assemblyBytes = File.ReadAllBytes(assemblyPath);
+        MemoryStream stream = new(assemblyBytes);
+
+        Assembly assembly = alc.LoadFromStream(stream);
+        Assert.NotNull(assembly);
+        Assert.Equal(AssemblyToLoad, assembly.GetName().Name);
+        Assert.True(string.IsNullOrEmpty(assembly.Location),
+            $"Assembly should be loaded from stream and have an empty Location. Actual: '{assembly.Location}'");
+    }
+}

--- a/src/tests/Loader/binding/AppPaths/AppPaths.csproj
+++ b/src/tests/Loader/binding/AppPaths/AppPaths.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="AppPaths.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- <ProjectReference Include="$(TestLibraryProjectPath)" /> -->
+    <ProjectReference Include="AssemblyToLoad.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/binding/AppPaths/AssemblyToLoad.cs
+++ b/src/tests/Loader/binding/AppPaths/AssemblyToLoad.cs
@@ -1,0 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace AssemblyToLoad
+{
+}

--- a/src/tests/Loader/binding/AppPaths/AssemblyToLoad.csproj
+++ b/src/tests/Loader/binding/AppPaths/AssemblyToLoad.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="AssemblyToLoad.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
`AssemblyLoadContext.LoadFromStream` for the default ALC was loading assemblies from `APP_PATHS` if they exist instead of the provided stream. `BindUsingPEImage` was going through a regular full bind instead of just checking if the assembly was already loaded. This change updates to just check if the assembly is already in the context instead.

Fixes: #122304

cc @dotnet/appmodel @AaronRobinsonMSFT 