### PR TITLE
Fix edge-case Uri debug assert failure

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -4337,8 +4337,10 @@ namespace System
                 // It will also convert back slashes if needed
                 Compress(ref dest, offset, _syntax);
 
-                if (dest[start] == '\\')
+                if (dest.Length > start && dest[start] == '\\')
+                {
                     dest[start] = '/';
+                }
 
                 // Escape path if requested and found as not fully escaped
                 if (formatAs == UriFormat.UriEscaped && NotAny(Flags.UserEscaped) && InFact(Flags.E_PathNotCanonical))

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
@@ -518,6 +518,13 @@ namespace System.PrivateUri.Tests
             Assert.Equal(expectedResult, resolved.ToString());
         }
 
+        [Fact]
+        public void Uri_Ftp_WholePathCanBeRemoved()
+        {
+            Uri ftp = new Uri("ftp://host?a=b/..");
+            Assert.Equal("ftp://host/", ftp.AbsoluteUri);
+        }
+
         #endregion PathCompression
 
         #region MakeRelativeToUri


### PR DESCRIPTION
If `Compress` removes the entire path, and that path was otherwise missing a leading slash, we can get into the case where `dest.Length == start` after the `Compress` call.
This triggers a debug assert in the `ValueStringBuilder`'s `this[]` accessor since we're reading past the length, but it's actually harmless in practice in this case since the underlying buffer will always have at least 1 available character after `start` on this path (note the `dest.Length - offset > 0` condition before compression).