### PR TITLE
Fix another Uri debug assert

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -4371,7 +4371,7 @@ namespace System
                         // Unescape in-place
                         dest.Length = start;
                         UriHelper.Unescape(slice, ref dest);
-                        Debug.Assert(slice.Overlaps(dest.RawChars));
+                        Debug.Assert(slice.IsEmpty || slice.Overlaps(dest.RawChars));
                     }
                 }
                 else

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriRelativeResolutionTest.cs
@@ -523,6 +523,8 @@ namespace System.PrivateUri.Tests
         {
             Uri ftp = new Uri("ftp://host?a=b/..");
             Assert.Equal("ftp://host/", ftp.AbsoluteUri);
+            Assert.Equal("/", ftp.AbsolutePath);
+            Assert.Equal("/", ftp.LocalPath);
         }
 
         #endregion PathCompression


### PR DESCRIPTION
`Overlaps` special-cases empty spans as not overlapping even if the pointer appears in the middle.
In this case, the `LocalPath` test exercises the `UriFormat.Unescaped` code path.