### PR TITLE
Add a script to generate code coverage reports after fuzzing

### DIFF
--- a/src/libraries/Fuzzing/.gitignore
+++ b/src/libraries/Fuzzing/.gitignore
@@ -1,7 +1,8 @@
 TempNugetCache
 publish
 deployment
-inputs
 crash-*
 timeout-*
-inputs-*
+*inputs*
+*corpus*
+*coverage-report*

--- a/src/libraries/Fuzzing/DotnetFuzzing/Program.cs
+++ b/src/libraries/Fuzzing/DotnetFuzzing/Program.cs
@@ -64,6 +64,15 @@ public static class Program
             return;
         }
 
+        if (args.ElementAtOrDefault(1) == "--get-instrumented-assemblies")
+        {
+            foreach ((string assembly, string? prefixes) in GetInstrumentationTargets(fuzzer))
+            {
+                Console.WriteLine($"{assembly} {prefixes}");
+            }
+            return;
+        }
+
         RunFuzzer(fuzzer, inputFiles: args.Length > 1 ? args[1] : null);
     }
 

--- a/src/libraries/Fuzzing/DotnetFuzzing/collect-coverage.ps1
+++ b/src/libraries/Fuzzing/DotnetFuzzing/collect-coverage.ps1
@@ -1,4 +1,4 @@
-# Usage: .\collect-coverage.ps1 JsonDocument .\json-inputs\
+# Usage: .\collect-coverage.ps1 JsonDocumentFuzzer .\json-inputs\
 param(
     [Parameter(Mandatory=$true, Position=0)]
     [string]$FuzzerName,

--- a/src/libraries/Fuzzing/DotnetFuzzing/collect-coverage.ps1
+++ b/src/libraries/Fuzzing/DotnetFuzzing/collect-coverage.ps1
@@ -53,7 +53,7 @@ if (-not $reportGeneratorInstalled) {
 
 # Build the project
 Write-Host "Building the project..." -ForegroundColor Cyan
-& $dotnetPath build
+& $dotnetPath build $PSScriptRoot
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Build failed"
     exit 1

--- a/src/libraries/Fuzzing/DotnetFuzzing/collect-coverage.ps1
+++ b/src/libraries/Fuzzing/DotnetFuzzing/collect-coverage.ps1
@@ -1,0 +1,255 @@
+# Usage: .\collect-coverage.ps1 JsonDocument .\json-inputs\
+param(
+    [Parameter(Mandatory=$true, Position=0)]
+    [string]$FuzzerName,
+
+    [Parameter(Mandatory=$true, Position=1)]
+    [string]$InputPath,
+
+    [Parameter(Mandatory=$false)]
+    [string]$OutputDir = "./coverage-report"
+)
+
+$ErrorActionPreference = "Stop"
+
+# Use the local dotnet installation from the repository root
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\..\..\.."))
+$dotnetPath = Join-Path $repoRoot ".dotnet\dotnet.exe"
+
+if (-not (Test-Path $dotnetPath)) {
+    Write-Error "Local dotnet installation not found at $dotnetPath"
+    exit 1
+}
+
+Write-Host "Using dotnet: $dotnetPath" -ForegroundColor Cyan
+
+# Check and install required dotnet tools
+Write-Host "Checking for required global tools..." -ForegroundColor Cyan
+$installedTools = & $dotnetPath tool list -g
+
+$coverletInstalled = $installedTools | Select-String "coverlet.console"
+if (-not $coverletInstalled) {
+    Write-Host "  Installing coverlet.console..." -ForegroundColor Yellow
+    & $dotnetPath tool install --global coverlet.console
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to install coverlet.console"
+        exit 1
+    }
+} else {
+    Write-Host "  coverlet.console: installed" -ForegroundColor Gray
+}
+
+$reportGeneratorInstalled = $installedTools | Select-String "dotnet-reportgenerator-globaltool"
+if (-not $reportGeneratorInstalled) {
+    Write-Host "  Installing dotnet-reportgenerator-globaltool..." -ForegroundColor Yellow
+    & $dotnetPath tool install -g dotnet-reportgenerator-globaltool
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to install reportgenerator."
+        exit 1
+    }
+} else {
+    Write-Host "  dotnet-reportgenerator-globaltool: installed" -ForegroundColor Gray
+}
+
+# Build the project
+Write-Host "Building the project..." -ForegroundColor Cyan
+& $dotnetPath build
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Build failed"
+    exit 1
+}
+
+# Get the path to the test assembly
+$projectDir = $PSScriptRoot
+$artifactsPath = Join-Path $repoRoot "artifacts\bin\DotnetFuzzing"
+$assemblyPath = (Get-ChildItem -Path $artifactsPath -Recurse -Filter "DotnetFuzzing.dll" | Select-Object -First 1).FullName
+
+if (-not $assemblyPath) {
+    Write-Error "Could not find DotnetFuzzing.dll in $artifactsPath"
+    exit 1
+}
+
+Write-Host "Found assembly: $assemblyPath" -ForegroundColor Green
+
+# Get the list of instrumented assemblies
+Write-Host "Getting instrumented assemblies for $FuzzerName..." -ForegroundColor Cyan
+$instrumentedAssemblies = & $dotnetPath run --no-build -- $FuzzerName --get-instrumented-assemblies
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to get instrumented assemblies"
+    exit 1
+}
+
+$instrumentedAssembliesArray = $instrumentedAssemblies | Where-Object { $_ -ne "" }
+
+if ($instrumentedAssembliesArray.Count -eq 0) {
+    Write-Error "No instrumented assemblies found for $FuzzerName"
+    exit 1
+}
+
+Write-Host "Instrumented assemblies:" -ForegroundColor Green
+
+# Parse assembly and type prefix information
+# Format: "AssemblyName.dll [prefix1 prefix2 ...]"
+$instrumentationTargets = @()
+foreach ($line in $instrumentedAssembliesArray) {
+    $parts = $line -split ' ', 2
+    $dllName = $parts[0]
+    $prefixes = if ($parts.Length -gt 1) { $parts[1].Trim() } else { "" }
+
+    $instrumentationTargets += @{
+        DllName = $dllName
+        Prefixes = $prefixes
+    }
+
+    if ($prefixes) {
+        Write-Host "  - $dllName (types: $prefixes)" -ForegroundColor Gray
+    } else {
+        Write-Host "  - $dllName" -ForegroundColor Gray
+    }
+}
+
+# Copy PDB files for instrumented assemblies to the DotnetFuzzing output directory
+# so coverlet can find them alongside the DLLs
+Write-Host "Copying PDB files for instrumented assemblies..." -ForegroundColor Cyan
+
+# Find the runtime directory (contains library assemblies)
+$runtimeBaseDir = Join-Path $repoRoot "artifacts\bin\runtime"
+$runtimeDir = Get-ChildItem -Path $runtimeBaseDir -Directory -Filter "net*" -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty FullName
+
+if (-not $runtimeDir) {
+    Write-Error "Runtime directory not found in $runtimeBaseDir"
+    exit 1
+}
+
+Write-Host "  Using runtime directory: $runtimeDir" -ForegroundColor Gray
+
+# Find the CoreCLR IL directory (contains System.Private.CoreLib)
+$coreClrBaseDir = Join-Path $repoRoot "artifacts\bin\coreclr"
+$coreClrDir = $null
+if (Test-Path $coreClrBaseDir) {
+    $coreClrDir = Get-ChildItem -Path $coreClrBaseDir -Directory -Recurse -Filter "IL" -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -match "windows\.x64\.(Debug|Checked|Release)" } |
+        Select-Object -First 1 -ExpandProperty FullName
+}
+
+if (-not $coreClrDir) {
+    Write-Error "CoreCLR IL directory not found in $coreClrBaseDir"
+    exit 1
+}
+
+Write-Host "  Using CoreCLR directory: $coreClrDir" -ForegroundColor Gray
+
+$assemblyDir = Split-Path $assemblyPath -Parent
+
+foreach ($target in $instrumentationTargets) {
+    $pdbName = [System.IO.Path]::ChangeExtension($target.DllName, ".pdb")
+    $destPdb = Join-Path $assemblyDir $pdbName
+
+    # Try runtime directory first
+    $sourcePdb = Join-Path $runtimeDir $pdbName
+
+    # For System.Private.CoreLib, check the coreclr IL directory
+    if (-not (Test-Path $sourcePdb) -and $pdbName -eq "System.Private.CoreLib.pdb") {
+        $sourcePdb = Join-Path $coreClrDir $pdbName
+    }
+
+    if (Test-Path $sourcePdb) {
+        Copy-Item -Path $sourcePdb -Destination $destPdb -Force
+        Write-Host "  Copied $pdbName" -ForegroundColor Gray
+    } else {
+        Write-Warning "PDB not found: $sourcePdb"
+    }
+}
+
+# Create output directory
+New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+
+# Build include filters for coverlet
+# Format: [AssemblyName]Type.Prefix* for specific prefixes, or [AssemblyName]* for all types
+$includeFilters = @()
+foreach ($target in $instrumentationTargets) {
+    $assemblyName = [System.IO.Path]::GetFileNameWithoutExtension($target.DllName)
+
+    if ($target.Prefixes) {
+        # If type prefixes are specified, create filters for each prefix
+        $prefixList = $target.Prefixes -split ' '
+        foreach ($prefix in $prefixList) {
+            if ($prefix) {
+                $includeFilters += "[${assemblyName}]${prefix}*"
+            }
+        }
+    } else {
+        # No prefixes specified, include all types from the assembly
+        $includeFilters += "[${assemblyName}]*"
+    }
+}
+
+# Build coverlet arguments
+$coverletArgs = @(
+    $assemblyPath,
+    "--target", $dotnetPath,
+    "--targetargs", "run --no-build -- $FuzzerName $InputPath",
+    "--output", "$OutputDir/",
+    "--format", "opencover",
+    "--use-source-link",
+    "--does-not-return-attribute", "DoesNotReturn"
+)
+
+# Exclude files based on runtime repository defaults
+# From src/libraries/Directory.Build.props
+$librariesRoot = Join-Path $repoRoot "src\libraries"
+$excludeByFile = @(
+    [System.IO.Path]::Combine($librariesRoot, "Common", "src", "System", "SR.*"),
+    [System.IO.Path]::Combine($librariesRoot, "Common", "src", "System", "NotImplemented.cs")
+)
+
+# Also exclude source-generated files
+$excludeByFile += [System.IO.Path]::Combine($repoRoot, "artifacts", "obj", "**", "*.g.cs")
+
+foreach ($filePattern in $excludeByFile) {
+    $coverletArgs += "--exclude-by-file"
+    $coverletArgs += $filePattern
+}
+
+# Add include filters
+foreach ($filter in $includeFilters) {
+    $coverletArgs += "--include"
+    $coverletArgs += $filter
+}
+
+# Run coverlet
+Write-Host ""
+Write-Host "Collecting coverage..." -ForegroundColor Cyan
+Write-Host "Running: coverlet $($coverletArgs -join ' ')" -ForegroundColor Gray
+Write-Host ""
+& coverlet @coverletArgs
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Coverage collection failed with exit code $LASTEXITCODE"
+    exit $LASTEXITCODE
+}
+
+Write-Host ""
+Write-Host "Coverage report generated in: $OutputDir" -ForegroundColor Green
+
+# Find the generated OpenCover XML file
+$coverageFile = Get-ChildItem -Path $OutputDir -Filter "*.opencover.xml" | Select-Object -First 1
+if ($coverageFile) {
+    Write-Host "  - OpenCover report: $($coverageFile.FullName)" -ForegroundColor Gray
+}
+
+# Generate HTML report using ReportGenerator
+Write-Host ""
+Write-Host "Generating HTML report..." -ForegroundColor Cyan
+
+if ($coverageFile) {
+    $htmlOutputDir = Join-Path $OutputDir "html"
+    & reportgenerator "-reports:$($coverageFile.FullName)" "-targetdir:$htmlOutputDir" "-reporttypes:Html"
+
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host ""
+        Write-Host "HTML report generated: $htmlOutputDir\index.html" -ForegroundColor Green
+    } else {
+        Write-Warning "Failed to generate HTML report"
+    }
+}

--- a/src/libraries/Fuzzing/DotnetFuzzing/collect-coverage.ps1
+++ b/src/libraries/Fuzzing/DotnetFuzzing/collect-coverage.ps1
@@ -128,7 +128,7 @@ $coreClrBaseDir = Join-Path $repoRoot "artifacts\bin\coreclr"
 $coreClrDir = $null
 if (Test-Path $coreClrBaseDir) {
     $coreClrDir = Get-ChildItem -Path $coreClrBaseDir -Directory -Recurse -Filter "IL" -ErrorAction SilentlyContinue |
-        Where-Object { $_.FullName -match "windows\.x64\.(Debug|Checked|Release)" } |
+        Where-Object { $_.FullName -match "windows\.[^.]+\.(Debug|Checked|Release)" } |
         Select-Object -First 1 -ExpandProperty FullName
 }
 

--- a/src/libraries/Fuzzing/DotnetFuzzing/collect-coverage.ps1
+++ b/src/libraries/Fuzzing/DotnetFuzzing/collect-coverage.ps1
@@ -60,7 +60,6 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # Get the path to the test assembly
-$projectDir = $PSScriptRoot
 $artifactsPath = Join-Path $repoRoot "artifacts\bin\DotnetFuzzing"
 $assemblyPath = (Get-ChildItem -Path $artifactsPath -Recurse -Filter "DotnetFuzzing.dll" | Select-Object -First 1).FullName
 
@@ -73,7 +72,7 @@ Write-Host "Found assembly: $assemblyPath" -ForegroundColor Green
 
 # Get the list of instrumented assemblies
 Write-Host "Getting instrumented assemblies for $FuzzerName..." -ForegroundColor Cyan
-$instrumentedAssemblies = & $dotnetPath run --no-build -- $FuzzerName --get-instrumented-assemblies
+$instrumentedAssemblies = & $dotnetPath run --project $PSScriptRoot --no-build -- $FuzzerName --get-instrumented-assemblies
 if ($LASTEXITCODE -ne 0) {
     Write-Error "Failed to get instrumented assemblies"
     exit 1
@@ -188,7 +187,7 @@ foreach ($target in $instrumentationTargets) {
 $coverletArgs = @(
     $assemblyPath,
     "--target", $dotnetPath,
-    "--targetargs", "run --no-build -- $FuzzerName $InputPath",
+    "--targetargs", "run --project $PSScriptRoot --no-build -- $FuzzerName $InputPath",
     "--output", "$OutputDir/",
     "--format", "opencover",
     "--use-source-link",

--- a/src/libraries/Fuzzing/DotnetFuzzing/run.bat
+++ b/src/libraries/Fuzzing/DotnetFuzzing/run.bat
@@ -1,1 +1,16 @@
-%~dp0..\..\..\..\artifacts\bin\DotnetFuzzing\Debug\net11.0\win-x64\DotnetFuzzing.exe prepare-onefuzz deployment
+@echo off
+setlocal
+
+set "searchRoot=%~dp0..\..\..\..\artifacts\bin\DotnetFuzzing"
+for %%I in ("%searchRoot%") do set "searchRoot=%%~fI"
+
+for /f "delims=" %%F in ('dir /s /b "%searchRoot%\DotnetFuzzing.exe" 2^>nul') do (
+    set "exePath=%%~fF"
+    goto :found
+)
+
+echo DotnetFuzzing.exe not found under "%searchRoot%"
+exit /b 1
+
+:found
+"%exePath%" prepare-onefuzz deployment

--- a/src/libraries/Fuzzing/README.md
+++ b/src/libraries/Fuzzing/README.md
@@ -61,6 +61,22 @@ For example, here is how you can run the fuzzer against a `header-inputs` corpus
 deployment/HttpHeadersFuzzer/local-run.bat header-inputs -timeout=30 -max_total_time=600 -jobs=5
 ```
 
+### Generating coverage reports
+
+After letting the fuzzer run for a while, you can use the generated inputs to test code coverage.
+
+```cmd
+mkdir header-inputs
+deployment/HttpHeadersFuzzer/local-run.bat header-inputs
+
+.\collect-coverage.ps1 HttpHeadersFuzzer header-inputs
+```
+
+The HTML report can be opened from
+```cmd
+.\coverage-report\html\index.html
+```
+
 ## Creating a new fuzzing target
 
 To create a new fuzzing target, you need to create a new class that implements the `IFuzzer` interface.
@@ -101,4 +117,4 @@ cd src/libraries/Fuzzing/DotnetFuzzing
 dotnet run HttpHeadersFuzzer inputs
 ```
 
-This can be useful when debugging a crash, or running the fuzzer over existing inputs to collect code coverage.
+This can be useful when debugging a crash.


### PR DESCRIPTION
Running the fuzzer will generate lots of test inputs. We already had logic for running a fuzzer over all inputs in a directory
```cmd
dotnet run HttpHeadersFuzzer inputs
```

But getting a code coverage report from that involves a bunch of annoying manual steps in crafting the right commands.
The `collect-coverage.ps1` script automates them so that you can just run
```cmd
.\collect-coverage.ps1 HttpHeadersFuzzer inputs
```

The powershell is mostly LLM written.