### PR TITLE
Add vertical tab support to Regex.Escape

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -193,6 +193,9 @@ namespace System.Text.RegularExpressions
                     case '\f':
                         ch = 'f';
                         break;
+                    case '\v':
+                        ch = 'v';
+                        break;
                 }
 
                 vsb.Append('\\');
@@ -1602,7 +1605,7 @@ namespace System.Text.RegularExpressions
                 case 't':
                     return '\t';
                 case 'v':
-                    return '\u000B';
+                    return '\v';
                 case 'c':
                     return ScanControl();
                 default:
@@ -1923,7 +1926,7 @@ namespace System.Text.RegularExpressions
         private const byte Q = 4;    // quantifier          * + ? {
         private const byte S = 3;    // stopper             $ ( ) . [ \ ^ |
         private const byte Z = 2;    // # stopper           #
-        private const byte W = 1;    // whitespace          \t \n \f \r ' '
+        private const byte W = 1;    // whitespace          \t \n \v \f \r ' '
 
         /// <summary>For categorizing ASCII characters.</summary>
         private static ReadOnlySpan<byte> Category =>

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.EscapeUnescape.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.EscapeUnescape.Tests.cs
@@ -31,6 +31,12 @@ namespace System.Text.RegularExpressions.Tests
         public static void Escape_VerticalTab(string str, string expected)
         {
             Assert.Equal(expected, Regex.Escape(str));
+
+            if (expected.Length > 0)
+            {
+                const int Count = 100;
+                Assert.Equal(string.Concat(Enumerable.Repeat(expected, Count)), Regex.Escape(string.Concat(Enumerable.Repeat(str, Count))));
+            }
         }
 
         [Fact]
@@ -63,6 +69,12 @@ namespace System.Text.RegularExpressions.Tests
         public void Unescape_VerticalTab(string str, string expected)
         {
             Assert.Equal(expected, Regex.Unescape(str));
+
+            if (expected.Length > 0)
+            {
+                const int Count = 100;
+                Assert.Equal(string.Concat(Enumerable.Repeat(expected, Count)), Regex.Unescape(string.Concat(Enumerable.Repeat(str, Count))));
+            }
         }
 
         [Fact]

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.EscapeUnescape.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.EscapeUnescape.Tests.cs
@@ -25,6 +25,14 @@ namespace System.Text.RegularExpressions.Tests
             }
         }
 
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
+        [InlineData("\v", "\\v")]
+        [InlineData("\n\r\v\t\f", "\\n\\r\\v\\t\\f")]
+        public static void Escape_VerticalTab(string str, string expected)
+        {
+            Assert.Equal(expected, Regex.Escape(str));
+        }
+
         [Fact]
         public void Escape_NullString_ThrowsArgumentNullException()
         {
@@ -47,6 +55,14 @@ namespace System.Text.RegularExpressions.Tests
                 const int Count = 100;
                 Assert.Equal(string.Concat(Enumerable.Repeat(expected, Count)), Regex.Unescape(string.Concat(Enumerable.Repeat(str, Count))));
             }
+        }
+
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNetCore))]
+        [InlineData("\\v", "\v")]
+        [InlineData("\\n\\r\\v\\t\\f", "\n\r\v\t\f")]
+        public void Unescape_VerticalTab(string str, string expected)
+        {
+            Assert.Equal(expected, Regex.Unescape(str));
         }
 
         [Fact]


### PR DESCRIPTION
Add support for escaping vertical tab character (`\v`) in `Regex.Escape`.
`Regex.Unescape` already supported `\v`, but `Regex.Escape` was missing this functionality.

- Handle `\v` character (0x0B) in `RegexParser.EscapeImpl`
- Use `\v` instead of `\u000B` in `RegexParser.ScanCharEscape`
- Add test for vertical tab character in `Regex.Escape/Unescape`

Related to PR #120625