### PR TITLE
Fix up hijacking on x86 (preserve async continuation register)

### DIFF
--- a/src/coreclr/nativeaot/Runtime/i386/AsmMacros.inc
+++ b/src/coreclr/nativeaot/Runtime/i386/AsmMacros.inc
@@ -130,6 +130,7 @@ PTFF_SAVE_RDI           equ 00000004h
 PTFF_SAVE_ALL_PRESERVED equ 00000007h   ;; NOTE: RBP is not included in this set!
 PTFF_SAVE_RSP           equ 00008000h
 PTFF_SAVE_RAX           equ 00000100h   ;; RAX is saved if it contains a GC ref and we're in hijack handler
+PTFF_SAVE_RCX           equ 00000200h   ;; RCX is saved if it contains a GC ref and we're in hijack handler
 PTFF_SAVE_ALL_SCRATCH   equ 00000700h
 
 ;; These must match the TrapThreadsFlags enum

--- a/src/coreclr/nativeaot/Runtime/i386/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/i386/GcProbe.asm
@@ -241,7 +241,7 @@ _RhpGcProbeHijack@0  proc public
         HijackFixupEpilog
 
 WaitForGC:
-        or          ecx, DEFAULT_PROBE_SAVE_FLAGS + PTFF_SAVE_RAX
+        or          ecx, DEFAULT_PROBE_SAVE_FLAGS + PTFF_SAVE_RAX + PTFF_SAVE_RCX
         jmp         RhpWaitForGC
 
 _RhpGcProbeHijack@0  endp
@@ -250,7 +250,7 @@ ifdef FEATURE_GC_STRESS
 _RhpGcStressHijack@0  proc public
 
         HijackFixupProlog
-        or          ecx, DEFAULT_PROBE_SAVE_FLAGS + PTFF_SAVE_RAX
+        or          ecx, DEFAULT_PROBE_SAVE_FLAGS + PTFF_SAVE_RAX + PTFF_SAVE_RCX
         jmp         RhpGcStressProbe
 
 _RhpGcStressHijack@0  endp

--- a/src/coreclr/nativeaot/Runtime/i386/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/i386/GcProbe.asm
@@ -92,6 +92,9 @@ endm
 ;;  ECX is NOT trashed if BITMASK_REG_OR_VALUE is a literal value and not a register
 ;;
 PushProbeFrame macro BITMASK_REG_OR_VALUE
+        push        eax                                 ; Save live EAX first
+        mov         eax, [ebp - 4]          ; ECX
+        xchg        [esp], eax                          ; stack={ECX}, eax=original EAX
         push        eax                     ; EAX
         lea         eax, [ebp + 8]                      ; get caller ESP
         push        eax                     ; ESP
@@ -128,6 +131,7 @@ endm
 ;;  ESI: restored
 ;;  EDI: restored
 ;;  EAX: restored
+;;  ECX: restored
 ;;
 PopProbeFrame macro
         add         esp, 4*4h
@@ -135,7 +139,9 @@ PopProbeFrame macro
         pop         esi
         pop         edi
         pop         eax     ; discard ESP
-        pop         eax
+        pop         eax     ; EAX
+        pop         edx                                 ; ECX (into EDX temporarily)
+        mov         [ebp - 4], edx                      ; write updated ECX back to HijackFixupProlog save location
 endm
 
 ;;

--- a/src/coreclr/nativeaot/Runtime/i386/GcProbe.asm
+++ b/src/coreclr/nativeaot/Runtime/i386/GcProbe.asm
@@ -139,10 +139,8 @@ PopProbeFrame macro
         pop         esi
         pop         edi
         pop         eax     ; discard ESP
-        pop         edx                                 ; EAX (into EDX temporarily)
-        mov         [ebp - 12], edx                     ; write updated EAX back to HijackFixupProlog save location
-        pop         edx                                 ; ECX (into EDX temporarily)
-        mov         [ebp - 4], edx                      ; write updated ECX back to HijackFixupProlog save location
+        pop         [ebp - 12]                          ; write updated EAX back to HijackFixupProlog save location
+        pop         [ebp - 4]                           ; write updated ECX back to HijackFixupProlog save location
 endm
 
 ;;

--- a/src/coreclr/nativeaot/Runtime/inc/rhbinder.h
+++ b/src/coreclr/nativeaot/Runtime/inc/rhbinder.h
@@ -521,7 +521,7 @@ struct PInvokeTransitionFrame
 // RBX, RSI, RDI, R12, R13, R14, R15, RAX, RSP
 #define PInvokeTransitionFrame_SaveRegs_count 9
 #elif defined(TARGET_X86)
-// RBX, RSI, RDI, RAX, RSP, RCX
+// RBX, RSI, RDI, RSP, RAX, RCX
 #define PInvokeTransitionFrame_SaveRegs_count 6
 #elif defined(TARGET_ARM)
 // R4-R10, R0, SP

--- a/src/coreclr/nativeaot/Runtime/inc/rhbinder.h
+++ b/src/coreclr/nativeaot/Runtime/inc/rhbinder.h
@@ -521,8 +521,8 @@ struct PInvokeTransitionFrame
 // RBX, RSI, RDI, R12, R13, R14, R15, RAX, RSP
 #define PInvokeTransitionFrame_SaveRegs_count 9
 #elif defined(TARGET_X86)
-// RBX, RSI, RDI, RAX, RSP
-#define PInvokeTransitionFrame_SaveRegs_count 5
+// RBX, RSI, RDI, RAX, RSP, RCX
+#define PInvokeTransitionFrame_SaveRegs_count 6
 #elif defined(TARGET_ARM)
 // R4-R10, R0, SP
 #define PInvokeTransitionFrame_SaveRegs_count 9


### PR DESCRIPTION
Flag ecx (see [async calling convention](https://github.com/dotnet/runtime/blob/main/docs/design/coreclr/botr/clr-abi.md#returning-continuation)) during GC as it might contain an async continuation.

Contributes to https://github.com/dotnet/runtime/issues/122492.