### PR TITLE
Restore correct outerloop priority tracking and test execution

### DIFF
--- a/src/tests/Common/XUnitWrapperGenerator/OptionsHelper.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/OptionsHelper.cs
@@ -8,7 +8,7 @@ public static class OptionsHelper
 {
     private const string InMergedTestDirectoryOption = "build_property.InMergedTestDirectory";
     private const string IsMergedTestRunnerAssemblyOption = "build_property.IsMergedTestRunnerAssembly";
-    private const string PriorityOption = "build_property.Priority";
+    private const string CLRTestPriorityToBuildOption = "build_property.CLRTestPriorityToBuild";
     private const string TestBuildModeOption = "build_property.TestBuildMode";
     private const string RuntimeFlavorOption = "build_property.RuntimeFlavor";
     private const string IsOutOfProcessTestAssemblyOption = "build_metadata.AdditionalFiles.IsOutOfProcessTestAssembly";
@@ -35,7 +35,7 @@ public static class OptionsHelper
 
     internal static bool IsMergedTestRunnerAssembly(this AnalyzerConfigOptions options) => options.GetBoolOption(IsMergedTestRunnerAssemblyOption);
 
-    internal static int? Priority(this AnalyzerConfigOptions options) => options.GetIntOption(PriorityOption);
+    internal static int? CLRTestPriorityToBuild(this AnalyzerConfigOptions options) => options.GetIntOption(CLRTestPriorityToBuildOption);
 
     internal static string RuntimeFlavor(this AnalyzerConfigOptions options) => options.TryGetValue(RuntimeFlavorOption, out string? flavor) ? flavor : "CoreCLR";
 

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -769,7 +769,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
                         break;
                     }
                 case "Xunit.OuterLoopAttribute":
-                    if (options.GlobalOptions.Priority() == 0)
+                    if (options.GlobalOptions.CLRTestPriorityToBuild() == 0)
                     {
                         if (filterAttribute.AttributeConstructor!.Parameters.Length < 2)
                         {

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.props
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.props
@@ -4,7 +4,7 @@
     <CompilerVisibleProperty Include="RuntimeFlavor" />
     <CompilerVisibleProperty Include="TargetOS" />
     <CompilerVisibleProperty Include="TargetArchitecture" />
-    <CompilerVisibleProperty Include="Priority" />
+    <CompilerVisibleProperty Include="CLRTestPriorityToBuild" />
     <CompilerVisibleProperty Include="TestBuildMode" />
     <!-- Properties that influence test harness generation -->
     <CompilerVisibleProperty Include="InMergedTestDirectory" />

--- a/src/tests/JIT/Methodical/Methodical_others.csproj
+++ b/src/tests/JIT/Methodical/Methodical_others.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="flowgraph/dev10_bug679008/helper.ilproj" />
     <MergedWrapperProjectReference Remove="flowgraph/dev10_bug679008/helper.ilproj" />
     <CMakeProjectReference Include="gc_poll/CMakeLists.txt" />
+    <CMakeProjectReference Include="structs/systemvbringup/CMakeLists.txt" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Arrays\misc\IndexingSideEffects.cs" />

--- a/src/tests/JIT/Methodical/tailcall/Desktop/thread-race_r.csproj
+++ b/src/tests/JIT/Methodical/tailcall/Desktop/thread-race_r.csproj
@@ -13,5 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="thread-race.cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b423721/b423721.cs
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b423721/b423721.cs
@@ -36,7 +36,7 @@ namespace b423721
                 ret = 101;
             }
 
-            Type t = Type.GetType("Test.C1`1[[System.Int64, mscorlib, Version=0.0.0.0, Culture=neutral ]], c1, Version=0.0.0.0, Culture=neutral");
+            Type t = Type.GetType("b423721.C1`1[[System.Int64, mscorlib, Version=0.0.0.0, Culture=neutral ]], c1, Version=0.0.0.0, Culture=neutral");
             if (t == null)
             {
                 Console.WriteLine("FAIL: Could not get Type C1`1[[System.Int64, mscorlib, Version=0.0.0.0, Culture=neutral ]], c1, Version=0.0.0.0, Culture=neutral");

--- a/src/tests/JIT/Regression/Dev11/External/dev11_145295/ilpart.il
+++ b/src/tests/JIT/Regression/Dev11/External/dev11_145295/ilpart.il
@@ -86,21 +86,21 @@
             endfinally
 
         RUN_CALLOUT_3:
-            call        void [CSharpPart_145295]Test.Helpers::Callout3()
+            call        void [CSharpPart_145295]dev11_145295.Helpers::Callout3()
             endfinally
 
         RUN_CALLOUT_4:
             ldc.i4      4
             stloc       computedValue
-            call        void [CSharpPart_145295]Test.Helpers::Callout4()
+            call        void [CSharpPart_145295]dev11_145295.Helpers::Callout4()
             endfinally
 
         RUN_CALLOUT_5:
-            call        void [CSharpPart_145295]Test.Helpers::Callout5()
+            call        void [CSharpPart_145295]dev11_145295.Helpers::Callout5()
             endfinally
 
         RUN_CALLOUT_6:
-            call        void [CSharpPart_145295]Test.Helpers::Callout6()
+            call        void [CSharpPart_145295]dev11_145295.Helpers::Callout6()
             endfinally
 
         }
@@ -135,7 +135,7 @@
         .try
         {
 
-            call        void [CSharpPart_145295]Test.Helpers::Throw()
+            call        void [CSharpPart_145295]dev11_145295.Helpers::Throw()
             leave       END_OF_METHOD_BODY
 
         }
@@ -181,19 +181,19 @@
                 endfinally
 
             RUN_CALLOUT_3:
-                call        void [CSharpPart_145295]Test.Helpers::Callout3()
+                call        void [CSharpPart_145295]dev11_145295.Helpers::Callout3()
                 endfinally
 
             RUN_CALLOUT_4:
-                call        void [CSharpPart_145295]Test.Helpers::Callout4()
+                call        void [CSharpPart_145295]dev11_145295.Helpers::Callout4()
                 endfinally
 
             RUN_CALLOUT_5:
-                call        void [CSharpPart_145295]Test.Helpers::Callout5()
+                call        void [CSharpPart_145295]dev11_145295.Helpers::Callout5()
                 endfinally
 
             RUN_CALLOUT_6:
-                call        void [CSharpPart_145295]Test.Helpers::Callout6()
+                call        void [CSharpPart_145295]dev11_145295.Helpers::Callout6()
                 endfinally
 
             }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_64883/Runtime_64883.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_64883/Runtime_64883.cs
@@ -7,9 +7,9 @@
 // Reduced from 168.4 KiB to 0.2 KiB in 00:05:13
 // Hits JIT assert in Release:
 // Assertion failed '!"Write to unaliased local overlaps outstanding read"' in 'Program:Main(Fuzzlyn.ExecutionServer.IRuntime)' during 'Rationalize IR' (IL size 26)
-// 
+//
 //     File: D:\a\_work\1\s\src\coreclr\jit\lir.cpp Line: 1397
-// 
+//
 
 namespace Runtime_64883;
 
@@ -29,7 +29,7 @@ public class Runtime_64883
         // This needs an ALC because the "static access" helper is different in ALCs.
         CollectibleALC alc = new CollectibleALC();
         Assembly asm = alc.LoadFromAssemblyPath(Assembly.GetExecutingAssembly().Location);
-        MethodInfo mi = asm.GetType(nameof(Runtime_64883)).GetMethod(nameof(MainT));
+        MethodInfo mi = asm.GetType($"{nameof(Runtime_64883)}.{nameof(Runtime_64883)}").GetMethod(nameof(MainT));
         mi.Invoke(null, new object[0]);
     }
 
@@ -42,7 +42,7 @@ public class Runtime_64883
         uint vr6 = s_29;
     }
 #pragma warning restore xUnit1013
-    
+
     private class CollectibleALC : AssemblyLoadContext
     {
         public CollectibleALC() : base(true)

--- a/src/tests/JIT/jit64/opt/cse/hugeexpr1.csproj
+++ b/src/tests/JIT/jit64/opt/cse/hugeexpr1.csproj
@@ -14,5 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="hugeexpr1.cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
   </ItemGroup>
 </Project>

--- a/src/tests/JIT/superpmi/superpmicollect.csproj
+++ b/src/tests/JIT/superpmi/superpmicollect.csproj
@@ -34,7 +34,10 @@
     <_SpmiTestProjects Include="..\Performance\CodeQuality\Bytemark\Bytemark.csproj" />
     <_SpmiTestProjects Include="..\Performance\CodeQuality\Roslyn\CscBench.csproj" />
     <_SpmiTestProjects Include="..\Methodical\cctor\xassem\xprecise1_cs_do.csproj" />
-    <_SpmiTestSupportProjects Include="..\Methodical\cctor\xassem\testlib_xassem.csproj" />
+
+    <_SpmiTestProjects Update="@(_SpmiTestProjects)" TestProject="%(FileName)" />
+
+    <_SpmiTestSupportProjects Include="..\Methodical\cctor\xassem\testlib_xassem.csproj" TestProject="xprecise1_cs_do" />
 
     <ProjectReference Include="@(_SpmiTestProjects);@(_SpmiTestSupportProjects)">
       <Targets>Build</Targets>
@@ -65,7 +68,7 @@
   </ItemGroup>
 
   <Target Name="_CopySpmiTestsToOutput" DependsOnTargets="ResolveProjectReferences" BeforeTargets="AssignTargetPaths">
-    <Copy SourceFiles="@(_SpmiTest)" DestinationFolder="$([System.IO.Path]::GetDirectoryName('$(OutputPath)'))/$([System.IO.Path]::GetFileName('%(FileName)'))" SkipUnchangedFiles="True" />
+    <Copy SourceFiles="@(_SpmiTest)" DestinationFolder="$([System.IO.Path]::GetDirectoryName('$(OutputPath)'))/$([System.IO.Path]::GetFileName('%(TestProject)'))" SkipUnchangedFiles="True" />
   </Target>
 
   <!-- This target builds the executables and test running scripts for the _SpmiTestProjects


### PR DESCRIPTION
When this was originally written, we set a Priority property based on the __Priority environment variable for the generator as well as CLRTestPriorityToBuild for the overall build.

At some point, we lost this. As a result, we have been missing test coverage in our outerloops.

This restores the correct outerloop test execution behavior by unifying on CLRTestPriorityToBuild.