### PR TITLE
JIT: Fix build after two conflicting changes

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -3397,8 +3397,9 @@ bool Compiler::impImportAndPushBoxForNullable(CORINFO_RESOLVED_TOKEN* pResolvedT
     // Decompose the Nullable<> arg into _hasValue and _value fields
     // and calculate the type and layout of the 'value' field
     //
+    // Boxing allows the "initclass" flag, but not volatile/unaligned flags
     GenTreeFlags indirFlags = GTF_EMPTY;
-    nullableObj             = impGetNodeAddr(nullableObj, CHECK_SPILL_ALL, &indirFlags);
+    nullableObj             = impGetNodeAddr(nullableObj, CHECK_SPILL_ALL, GTF_IND_INITCLASS, &indirFlags);
     GenTree* nullableObjClone;
     nullableObj = impCloneExpr(nullableObj, &nullableObjClone, CHECK_SPILL_ALL, nullptr DEBUGARG("nullable obj clone"));
 


### PR DESCRIPTION
#122381 changed the signature of a function that had another use introduced by #122167