### PR TITLE
Change Regex Cache to use a System.Threading.Lock instance directly

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Cache.cs
@@ -59,7 +59,7 @@ namespace System.Text.RegularExpressions
         private static int s_maxCacheSize = DefaultMaxCacheSize;
 
         /// <summary>Lock used to protect shared state on mutations.</summary>
-        private static object SyncObj => s_cacheDictionary;
+        private static Lock SyncObj { get; } = new();
 
         /// <summary>Gets or sets the maximum size of the cache.</summary>
         public static int MaxCacheSize


### PR DESCRIPTION
Use a System.Threading.Lock instance directly instead of going through the syncblock on the ConcurrentDictionary.
