### PR TITLE
[RyuJit/WASM] Refactoring in preparation for parameter homing

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -589,9 +589,7 @@ protected:
     void genReserveProlog(BasicBlock* block); // currently unused
     void genReserveEpilog(BasicBlock* block);
     void genFnProlog();
-#if defined(TARGET_WASM)
-    void genWasmLocals();
-#endif
+    void genBeginFnProlog();
     void genFnEpilog(BasicBlock* block);
 
     void genReserveFuncletProlog(BasicBlock* block);
@@ -758,6 +756,8 @@ protected:
     void genSetRegToConst(regNumber targetReg, var_types targetType, simd_t* val);
     void genSetRegToConst(regNumber targetReg, var_types targetType, simdmask_t* val);
 #endif
+    void genLoadLocalIntoReg(regNumber targetReg, unsigned lclNum);
+
     void genCodeForTreeNode(GenTree* treeNode);
     void genCodeForBinary(GenTreeOp* treeNode);
     bool genIsSameLocalVar(GenTree* tree1, GenTree* tree2);

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -2545,10 +2545,10 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
     regMaskTP regMask;
 
     regMaskTP availMask = regSet.rsGetModifiedRegsMask() | RBM_INT_CALLEE_TRASH; // Set of available registers
-    availMask &= ~intRegState.rsCalleeRegArgMaskLiveIn; // Remove all of the incoming argument registers as they are
-                                                        // currently live
-    availMask &= ~genRegMask(initReg); // Remove the pre-calculated initReg as we will zero it and maybe use it for
-                                       // a large constant.
+    availMask &= ~calleeRegArgMaskLiveIn; // Remove all of the incoming argument registers as they are
+                                          // currently live
+    availMask &= ~genRegMask(initReg);    // Remove the pre-calculated initReg as we will zero it and maybe use it for
+                                          // a large constant.
 
     if (compiler->compLocallocUsed)
     {
@@ -2563,8 +2563,7 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
     regMask = genFindLowestBit(availMask);
     rZero2  = genRegNumFromMask(regMask);
     availMask &= ~regMask;
-    assert((genRegMask(rZero2) & intRegState.rsCalleeRegArgMaskLiveIn) == 0); // rZero2 is not a live incoming
-                                                                              // argument reg
+    assert((genRegMask(rZero2) & calleeRegArgMaskLiveIn) == 0); // rZero2 is not a live incoming argument reg
 
     // We pick the next lowest register number for rAddr
     noway_assert(availMask != RBM_NONE);
@@ -2594,7 +2593,7 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
     }
 
     // rAddr is not a live incoming argument reg
-    assert((genRegMask(rAddr) & intRegState.rsCalleeRegArgMaskLiveIn) == 0);
+    assert((genRegMask(rAddr) & calleeRegArgMaskLiveIn) == 0);
 
     if (arm_Valid_Imm_For_Add(untrLclLo, INS_FLAGS_DONT_CARE))
     {
@@ -2611,8 +2610,7 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
     if (useLoop)
     {
         noway_assert(uCntSlots >= 2);
-        assert((genRegMask(rCnt) & intRegState.rsCalleeRegArgMaskLiveIn) == 0); // rCnt is not a live incoming
-                                                                                // argument reg
+        assert((genRegMask(rCnt) & calleeRegArgMaskLiveIn) == 0); // rCnt is not a live incoming argument reg
         instGen_Set_Reg_To_Imm(EA_PTRSIZE, rCnt, (ssize_t)uCntSlots / 2);
     }
 

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -4333,8 +4333,7 @@ void CodeGen::genPushCalleeSavedRegisters()
     // registers have been saved. So instead of letting genAllocLclFrame use initReg as a temporary register,
     // always use REG_SCRATCH. We don't care if it trashes it, so ignore the initRegZeroed output argument.
     bool ignoreInitRegZeroed = false;
-    genAllocLclFrame(compiler->compLclFrameSize, REG_SCRATCH, &ignoreInitRegZeroed,
-                     intRegState.rsCalleeRegArgMaskLiveIn);
+    genAllocLclFrame(compiler->compLclFrameSize, REG_SCRATCH, &ignoreInitRegZeroed, calleeRegArgMaskLiveIn);
 #endif
 
     regMaskTP rsPushRegs = regSet.rsGetModifiedCalleeSavedRegsMask();

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -3007,7 +3007,7 @@ var_types CodeGen::genParamStackType(LclVarDsc* dsc, const ABIPassingSegment& se
 void CodeGen::genSpillOrAddRegisterParam(
     unsigned lclNum, unsigned offset, unsigned paramLclNum, const ABIPassingSegment& segment, RegGraph* graph)
 {
-    regMaskTP paramRegs = intRegState.rsCalleeRegArgMaskLiveIn | floatRegState.rsCalleeRegArgMaskLiveIn;
+    regMaskTP paramRegs = calleeRegArgMaskLiveIn;
 
     if (!segment.IsPassedInRegister() || ((paramRegs & genRegMask(segment.GetRegister())) == 0))
     {
@@ -3110,7 +3110,7 @@ void CodeGen::genHomeRegisterParams(regNumber initReg, bool* initRegStillZeroed)
     }
 #endif
 
-    regMaskTP paramRegs = intRegState.rsCalleeRegArgMaskLiveIn | floatRegState.rsCalleeRegArgMaskLiveIn;
+    regMaskTP paramRegs = calleeRegArgMaskLiveIn;
     if (compiler->opts.OptimizationDisabled())
     {
         // All registers are going to frame
@@ -3212,7 +3212,7 @@ void CodeGen::genHomeRegisterParams(regNumber initReg, bool* initRegStillZeroed)
 
     INDEBUG(graph.Validate());
 
-    regMaskTP busyRegs = intRegState.rsCalleeRegArgMaskLiveIn | floatRegState.rsCalleeRegArgMaskLiveIn;
+    regMaskTP busyRegs = calleeRegArgMaskLiveIn;
     while (true)
     {
         RegNode* node = graph.FindNodeToProcess();
@@ -3353,13 +3353,13 @@ void CodeGen::genHomeRegisterParams(regNumber initReg, bool* initRegStillZeroed)
 //
 regMaskTP CodeGen::genGetParameterHomingTempRegisterCandidates()
 {
-    regMaskTP regs = RBM_CALLEE_TRASH | intRegState.rsCalleeRegArgMaskLiveIn | floatRegState.rsCalleeRegArgMaskLiveIn |
-                     regSet.rsGetModifiedRegsMask();
+    regMaskTP regs = RBM_CALLEE_TRASH | calleeRegArgMaskLiveIn | regSet.rsGetModifiedRegsMask();
     // We may have reserved register that the backend needs to access stack
     // locals. We cannot place state in that register.
     regs &= ~regSet.rsMaskResvd;
     return regs;
 }
+#endif // !TARGET_WASM
 
 /*****************************************************************************
  * If any incoming stack arguments live in registers, load them.
@@ -3424,18 +3424,15 @@ void CodeGen::genEnregisterIncomingStackArgs()
             continue;
         }
 
-        /* Load the incoming parameter into the register */
-
-        /* Figure out the home offset of the incoming argument */
-
+        // Load the incoming parameter into the register.
         regNumber regNum = varDsc->GetArgInitReg();
         assert(regNum != REG_STK);
 
-        var_types regType = varDsc->GetStackSlotHomeType();
 #ifdef TARGET_LOONGARCH64
         {
-            bool FPbased;
-            int  base = compiler->lvaFrameAddress(varNum, &FPbased);
+            bool      FPbased;
+            int       base    = compiler->lvaFrameAddress(varNum, &FPbased);
+            var_types regType = varDsc->GetStackSlotHomeType();
 
             if (emitter::isValidSimm12(base))
             {
@@ -3461,13 +3458,12 @@ void CodeGen::genEnregisterIncomingStackArgs()
             }
         }
 #else  // !TARGET_LOONGARCH64
-        GetEmitter()->emitIns_R_S(ins_Load(regType), emitTypeSize(regType), regNum, varNum, 0);
+        genLoadLocalIntoReg(regNum, varNum);
 #endif // !TARGET_LOONGARCH64
 
         regSet.verifyRegUsed(regNum);
     }
 }
-#endif // !TARGET_WASM
 
 /*-------------------------------------------------------------------------
  *
@@ -3675,25 +3671,24 @@ void CodeGen::genCheckUseBlockInit()
 
 #endif // TARGET_64BIT
 
+#ifdef TARGET_ARM
     if (genUseBlockInit)
     {
-        regMaskTP maskCalleeRegArgMask = intRegState.rsCalleeRegArgMaskLiveIn;
-
-#ifdef TARGET_ARM
         //
         // On the Arm if we are using a block init to initialize, then we
         // must force spill R4/R5/R6 so that we can use them during
         // zero-initialization process.
         //
-        int forceSpillRegCount = genCountBits(maskCalleeRegArgMask & ~genPrespilledUnmappedRegs()) - 1;
+        regMaskTP maskCalleeRegArgMask = calleeRegArgMaskLiveIn & RBM_ALLINT;
+        int       forceSpillRegCount   = genCountBits(maskCalleeRegArgMask & ~genPrespilledUnmappedRegs()) - 1;
         if (forceSpillRegCount > 0)
             regSet.rsSetRegsModified(RBM_R4);
         if (forceSpillRegCount > 1)
             regSet.rsSetRegsModified(RBM_R5);
         if (forceSpillRegCount > 2)
             regSet.rsSetRegsModified(RBM_R6);
-#endif // TARGET_ARM
     }
+#endif // TARGET_ARM
 }
 
 #ifndef TARGET_WASM
@@ -3844,8 +3839,7 @@ void CodeGen::genZeroInitFrame(int untrLclHi, int untrLclLo, regNumber initReg, 
     }
     else if (genInitStkLclCnt > 0)
     {
-        assert((genRegMask(initReg) & intRegState.rsCalleeRegArgMaskLiveIn) == 0); // initReg is not a live incoming
-                                                                                   // argument reg
+        assert((genRegMask(initReg) & calleeRegArgMaskLiveIn) == 0); // initReg is not a live incoming argument reg
 
         /* Initialize any lvMustInit vars on the stack */
 
@@ -4215,6 +4209,7 @@ void CodeGen::genHomeSwiftStructStackParameters()
     }
 }
 #endif
+#endif // !TARGET_WASM
 
 //-----------------------------------------------------------------------------
 // genHomeStackPartOfSplitParameter: Home the tail (stack) portion of a split parameter next to where the head
@@ -4265,6 +4260,7 @@ void CodeGen::genHomeStackPartOfSplitParameter(regNumber initReg, bool* initRegS
 #endif // TARGET_RISCV64 || TARGET_LOONGARCH64
 }
 
+#ifndef TARGET_WASM
 /*-----------------------------------------------------------------------------
  *
  *  Save the generic context argument.
@@ -4648,7 +4644,7 @@ void CodeGen::genFinalizeFrame()
     // Parameter homing may need an additional register to handle conflicts if
     // all callee trash registers are used by parameters.
     regMaskTP homingCandidates = genGetParameterHomingTempRegisterCandidates();
-    if (((homingCandidates & ~intRegState.rsCalleeRegArgMaskLiveIn) & RBM_ALLINT) == RBM_NONE)
+    if (((homingCandidates & ~calleeRegArgMaskLiveIn) & RBM_ALLINT) == RBM_NONE)
     {
         regMaskTP extraRegMask = RBM_ALLINT & ~homingCandidates & ~regSet.rsMaskResvd;
         assert(extraRegMask != RBM_NONE);
@@ -4657,7 +4653,7 @@ void CodeGen::genFinalizeFrame()
         regSet.rsSetRegsModified(genRegMask(extraReg));
     }
 
-    if (((homingCandidates & ~floatRegState.rsCalleeRegArgMaskLiveIn) & RBM_ALLFLOAT) == RBM_NONE)
+    if (((homingCandidates & ~calleeRegArgMaskLiveIn) & RBM_ALLFLOAT) == RBM_NONE)
     {
         regMaskTP extraRegMask = RBM_ALLFLOAT & ~homingCandidates & ~regSet.rsMaskResvd;
         assert(extraRegMask != RBM_NONE);
@@ -4834,9 +4830,7 @@ void CodeGen::genFnProlog()
 
     GetEmitter()->emitBegProlog();
 
-#if !defined(TARGET_WASM)
     compiler->unwindBegProlog();
-#endif // !defined(TARGET_WASM)
 
     // Do this so we can put the prolog instruction group ahead of
     // other instruction groups
@@ -4855,7 +4849,7 @@ void CodeGen::genFnProlog()
         psiBegProlog();
     }
 
-#if !defined(TARGET_WASM)
+    genBeginFnProlog();
 
 #if defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
     // For arm64 OSR, emit a "phantom prolog" to account for the actions taken
@@ -4918,6 +4912,7 @@ void CodeGen::genFnProlog()
     regMaskTP initFltRegs = RBM_NONE; // FP registers which must be init'ed.
     regMaskTP initDblRegs = RBM_NONE;
 
+#ifndef TARGET_WASM
     unsigned   varNum;
     LclVarDsc* varDsc;
 
@@ -5090,9 +5085,9 @@ void CodeGen::genFnProlog()
     // On the ARM we will spill any incoming struct args in the first instruction in the prolog
     // Ditto for all enregistered user arguments in a varargs method.
     // These registers will be available to use for the initReg.  We just remove
-    // all of these registers from the rsCalleeRegArgMaskLiveIn.
+    // all of these registers from the calleeRegArgMaskLiveIn.
     //
-    intRegState.rsCalleeRegArgMaskLiveIn &= ~genPrespilledUnmappedRegs();
+    calleeRegArgMaskLiveIn &= ~genPrespilledUnmappedRegs();
 #endif
 
     /* Choose the register to use for zero initialization */
@@ -5103,7 +5098,7 @@ void CodeGen::genFnProlog()
     // If initReg is ever set to zero, this variable is set to true and zero initializing initReg
     // will be skipped.
     bool      initRegZeroed = false;
-    regMaskTP excludeMask   = intRegState.rsCalleeRegArgMaskLiveIn;
+    regMaskTP excludeMask   = calleeRegArgMaskLiveIn;
 #if defined(TARGET_AMD64)
     // we'd require eEVEX present to enable EGPRs in HWIntrinsics.
     if (!compiler->canUseEvexEncoding())
@@ -5323,8 +5318,7 @@ void CodeGen::genFnProlog()
 
     if (maskStackAlloc == RBM_NONE)
     {
-        genAllocLclFrame(compiler->compLclFrameSize + extraFrameSize, initReg, &initRegZeroed,
-                         intRegState.rsCalleeRegArgMaskLiveIn);
+        genAllocLclFrame(compiler->compLclFrameSize + extraFrameSize, initReg, &initRegZeroed, calleeRegArgMaskLiveIn);
     }
 #endif // !TARGET_ARM64 && !TARGET_LOONGARCH64 && !TARGET_RISCV64
 
@@ -5409,6 +5403,10 @@ void CodeGen::genFnProlog()
     }
 
 #endif // PROFILING_SUPPORTED
+#else  // TARGET_WASM
+    regNumber initReg       = REG_NA;
+    bool      initRegZeroed = false;
+#endif // TARGET_WASM
 
     // For OSR we may have a zero-length prolog. That's not supported
     // when the method must report a generics context,/ so add a nop if so.
@@ -5450,7 +5448,7 @@ void CodeGen::genFnProlog()
         // consider it to be live
         if (compiler->lvaSwiftErrorArg != BAD_VAR_NUM)
         {
-            intRegState.rsCalleeRegArgMaskLiveIn &= ~RBM_SWIFT_ERROR;
+            calleeRegArgMaskLiveIn &= ~RBM_SWIFT_ERROR;
         }
     }
 #endif
@@ -5484,7 +5482,7 @@ void CodeGen::genFnProlog()
 
         genHomeStackPartOfSplitParameter(initReg, &initRegZeroed);
 
-        if ((intRegState.rsCalleeRegArgMaskLiveIn | floatRegState.rsCalleeRegArgMaskLiveIn) != RBM_NONE)
+        if (calleeRegArgMaskLiveIn != RBM_NONE)
         {
             genHomeRegisterParams(initReg, &initRegZeroed);
         }
@@ -5493,6 +5491,7 @@ void CodeGen::genFnProlog()
         genEnregisterIncomingStackArgs();
     }
 
+#ifndef TARGET_WASM
     /* Initialize any must-init registers variables now */
 
     if (initRegs)
@@ -5540,6 +5539,7 @@ void CodeGen::genFnProlog()
 
         genZeroInitFltRegs(initFltRegs, initDblRegs, initReg);
     }
+#endif // !TARGET_WASM
 
     //-----------------------------------------------------------------------------
 
@@ -5630,15 +5630,18 @@ void CodeGen::genFnProlog()
     }
 #endif // defined(DEBUG) && defined(TARGET_XARCH)
 
-#else  // defined(TARGET_WASM)
-    genWasmLocals();
-    GetEmitter()->emitMarkPrologEnd();
-#endif // !defined(TARGET_WASM)
-
     GetEmitter()->emitEndProlog();
 }
 
 #if !defined(TARGET_WASM)
+//----------------------------------------------------------------------------------
+// genBeginFnProlog: target-specific prolog generation hook.
+//
+// Called by "genFnProlog" before emitting any instructions into the prolog.
+//
+void CodeGen::genBeginFnProlog()
+{
+}
 
 //----------------------------------------------------------------------------------
 // genEmitJumpTable: emit jump table and return its base offset
@@ -8009,6 +8012,20 @@ void CodeGen::genStackPointerCheck(bool      doStackPointerCheck,
 }
 
 #endif // defined(DEBUG) && defined(TARGET_XARCH)
+
+//------------------------------------------------------------------------
+// genLoadLocalIntoReg: set the register to "load(local on stack)".
+//
+// Arguments:
+//    targetReg - The register to load into
+//    lclNum    - The local on stack to load from
+//
+void CodeGen::genLoadLocalIntoReg(regNumber regNum, unsigned lclNum)
+{
+    LclVarDsc* varDsc  = compiler->lvaGetDesc(lclNum);
+    var_types  regType = varDsc->GetStackSlotHomeType();
+    GetEmitter()->emitIns_R_S(ins_Load(regType), emitTypeSize(regType), regNum, lclNum, 0);
+}
 #endif // !TARGET_WASM
 
 unsigned CodeGenInterface::getCurrentStackLevel() const

--- a/src/coreclr/jit/codegeninterface.h
+++ b/src/coreclr/jit/codegeninterface.h
@@ -30,15 +30,6 @@
 class CodeGenInterface;
 class emitter;
 
-// Small helper types
-
-//-------------------- Register selection ---------------------------------
-
-struct RegState
-{
-    regMaskTP rsCalleeRegArgMaskLiveIn; // mask of register arguments (live on entry to method)
-};
-
 //-------------------- CodeGenInterface ---------------------------------
 // interface to hide the full CodeGen implementation from rest of Compiler
 
@@ -153,10 +144,9 @@ public:
                                    unsigned* mulPtr,
                                    ssize_t*  cnsPtr) = 0;
 
-    GCInfo   gcInfo;
-    RegSet   regSet;
-    RegState intRegState;
-    RegState floatRegState;
+    GCInfo    gcInfo;
+    RegSet    regSet;
+    regMaskTP calleeRegArgMaskLiveIn; // Mask of register arguments live on entry to the (root) method.
 
 #if HAS_FIXED_REGISTER_SET
     NodeInternalRegisters internalRegisters;

--- a/src/coreclr/jit/codegenloongarch64.cpp
+++ b/src/coreclr/jit/codegenloongarch64.cpp
@@ -750,16 +750,15 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
 
     regMaskTP availMask = regSet.rsGetModifiedRegsMask() | RBM_INT_CALLEE_TRASH; // Set of available registers
     // see: src/jit/registerloongarch64.h
-    availMask &= ~intRegState.rsCalleeRegArgMaskLiveIn; // Remove all of the incoming argument registers as they are
-                                                        // currently live
-    availMask &= ~genRegMask(initReg); // Remove the pre-calculated initReg as we will zero it and maybe use it for
-                                       // a large constant.
+    availMask &= ~calleeRegArgMaskLiveIn; // Remove all of the incoming argument registers as they are currently live
+    availMask &= ~genRegMask(initReg);    // Remove the pre-calculated initReg as we will zero it and maybe use it for
+                                          // a large constant.
 
     rAddr           = initReg;
     *pInitRegZeroed = false;
 
     // rAddr is not a live incoming argument reg
-    assert((genRegMask(rAddr) & intRegState.rsCalleeRegArgMaskLiveIn) == 0);
+    assert((genRegMask(rAddr) & calleeRegArgMaskLiveIn) == 0);
     assert(untrLclLo % 4 == 0);
 
     if (emitter::isValidSimm12(untrLclLo))
@@ -804,8 +803,7 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
         availMask &= ~regMask;
 
         noway_assert(uCntSlots >= 2);
-        assert((genRegMask(rCnt) & intRegState.rsCalleeRegArgMaskLiveIn) == 0); // rCnt is not a live incoming
-                                                                                // argument reg
+        assert((genRegMask(rCnt) & calleeRegArgMaskLiveIn) == 0); // rCnt is not a live incoming argument reg
         instGen_Set_Reg_To_Imm(EA_PTRSIZE, rCnt, (ssize_t)uCntSlots / 2);
 
         // TODO-LOONGARCH64: maybe optimize further

--- a/src/coreclr/jit/codegenriscv64.cpp
+++ b/src/coreclr/jit/codegenriscv64.cpp
@@ -730,16 +730,15 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
 
     regMaskTP availMask = regSet.rsGetModifiedRegsMask() | RBM_INT_CALLEE_TRASH; // Set of available registers
     // see: src/jit/registerriscv64.h
-    availMask &= ~intRegState.rsCalleeRegArgMaskLiveIn; // Remove all of the incoming argument registers as they are
-                                                        // currently live
-    availMask &= ~genRegMask(initReg); // Remove the pre-calculated initReg as we will zero it and maybe use it for
-                                       // a large constant.
+    availMask &= ~calleeRegArgMaskLiveIn; // Remove all of the incoming argument registers as they are currently live
+    availMask &= ~genRegMask(initReg);    // Remove the pre-calculated initReg as we will zero it and maybe use it for
+                                          // a large constant.
 
     rAddr           = initReg;
     *pInitRegZeroed = false;
 
     // rAddr is not a live incoming argument reg
-    assert((genRegMask(rAddr) & intRegState.rsCalleeRegArgMaskLiveIn) == 0);
+    assert((genRegMask(rAddr) & calleeRegArgMaskLiveIn) == 0);
     assert(untrLclLo % 4 == 0);
 
     if (emitter::isValidSimm12(untrLclLo))
@@ -777,7 +776,7 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
         availMask &= ~regMask;
 
         // rEndAddr is not a live incoming argument reg
-        assert((genRegMask(rEndAddr) & intRegState.rsCalleeRegArgMaskLiveIn) == 0);
+        assert((genRegMask(rEndAddr) & calleeRegArgMaskLiveIn) == 0);
 
         ssize_t uLoopBytes = (uRegSlots & ~0x3) * REGSIZE_BYTES;
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -11161,7 +11161,7 @@ void CodeGen::genZeroInitFrameUsingBlockInit(int untrLclHi, int untrLclLo, regNu
     assert(blkSize >= 0);
     noway_assert((blkSize % sizeof(int)) == 0);
     // initReg is not a live incoming argument reg
-    assert((genRegMask(initReg) & intRegState.rsCalleeRegArgMaskLiveIn) == 0);
+    assert((genRegMask(initReg) & calleeRegArgMaskLiveIn) == 0);
 
 #if defined(TARGET_AMD64)
     // We will align on x64 so can use the aligned mov

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -9865,7 +9865,7 @@ public:
     bool fgIsDoingEarlyLiveness         = false;
     bool fgDidEarlyLiveness             = false;
     bool compPostImportationCleanupDone = false;
-    bool compLSRADone                   = false;
+    bool compRegAllocDone               = false;
     bool compRationalIRForm             = false;
 
     bool compGeneratingProlog       = false;

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -7049,8 +7049,7 @@ unsigned emitter::emitEndCodeGen(Compiler*         comp,
         {
             emitSyncThisObjReg = thisDsc->GetRegNum();
 
-            if (emitSyncThisObjReg == (int)REG_ARG_0 &&
-                (codeGen->intRegState.rsCalleeRegArgMaskLiveIn & genRegMask(REG_ARG_0)))
+            if (emitSyncThisObjReg == (int)REG_ARG_0 && (codeGen->calleeRegArgMaskLiveIn & genRegMask(REG_ARG_0)))
             {
                 if (emitFullGCinfo)
                 {

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -4809,7 +4809,7 @@ void Compiler::lvaUpdateArgWithInitialReg(LclVarDsc* varDsc)
 //
 void Compiler::lvaUpdateArgsWithInitialReg()
 {
-    if (!compLSRADone)
+    if (!compRegAllocDone)
     {
         return;
     }

--- a/src/coreclr/jit/lsra.cpp
+++ b/src/coreclr/jit/lsra.cpp
@@ -1412,7 +1412,7 @@ PhaseStatus LinearScan::doRegisterAllocation()
     compiler->fgDebugCheckLinks();
 #endif
 
-    compiler->compLSRADone = true;
+    compiler->compRegAllocDone = true;
 
     // If edge resolution didn't create new blocks,
     // we can reuse the current flowgraph annotations during block layout.

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -246,4 +246,5 @@ void WasmRegAlloc::PublishAllocationResults()
     }
 
     m_compiler->raMarkStkVars();
+    m_compiler->compRegAllocDone = true;
 }

--- a/src/coreclr/jit/unwindwasm.cpp
+++ b/src/coreclr/jit/unwindwasm.cpp
@@ -7,8 +7,16 @@
 #endif
 
 //
-// We don't have native-code-offset-based unwind info on WASM so this the following functions are all no-ops.
+// We don't have native-code-offset-based unwind info on WASM so the following functions are all no-ops.
 //
+void Compiler::unwindBegProlog()
+{
+}
+
+void Compiler::unwindEndProlog()
+{
+}
+
 void Compiler::unwindReserve()
 {
 }


### PR DESCRIPTION
The headline change is that we no longer have two separate fields for integer and float live-in masks.

Also `genEnregisterIncomingStackArgs` was implemented (but we don't have enregistered locals yet).

Should be no-diff.