### PR TITLE
[browser] Add explicit runtime flavor to perf pipeline

### DIFF
--- a/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
@@ -6,6 +6,7 @@ steps:
       ./dotnet.sh build -p:TargetOS=browser -p:TargetArchitecture=wasm /nr:false /p:TreatWarningsAsErrors=true
       /p:Configuration=${{ parameters.configForBuild }}
       /p:ContinuousIntegrationBuild=true
+      /p:RuntimeFlavor=Mono
       /t:InstallWorkloadUsingArtifacts
       /bl:$(Build.SourcesDirectory)/artifacts/log/${{ parameters.configForBuild }}/InstallWorkloadUsingArtifacts.binlog
       $(Build.SourcesDirectory)/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj


### PR DESCRIPTION
Fix regression from https://github.com/dotnet/runtime/pull/122495. I have updated runtime.yml pipeline, but missed performance.
 https://github.com/dotnet/runtime/blob/5671ed30359acb2368a88c6f46fde7633536470b/eng/pipelines/common/templates/browser-wasm-build-tests.yml#L115