### PR TITLE
[clr-interp] Fix linux x64 Interop test suite, and in general improve SysV struct classification

### DIFF
--- a/src/coreclr/vm/amd64/profiler.cpp
+++ b/src/coreclr/vm/amd64/profiler.cpp
@@ -195,12 +195,12 @@ LPVOID ProfileArgIterator::CopyStructFromRegisters()
     int fieldBytes = th.AsMethodTable()->GetNumInstanceFieldBytes();
     INDEBUG(int remainingBytes = fieldBytes;)
 
-    _ASSERTE(argLocDesc->m_numEightBytesOfStructInRegs > 0);
+    _ASSERTE(argLocDesc->m_eightByteInfo.GetNumEightBytes() > 0);
 
-    for (int i = 0; i < argLocDesc->m_numEightBytesOfStructInRegs; i++)
+    for (int i = 0; i < argLocDesc->m_eightByteInfo.GetNumEightBytes(); i++)
     {
-        int eightByteSize = argLocDesc->m_eightByteSizes[i];
-        SystemVClassificationType eightByteClassification = argLocDesc->m_eightByteClassifications[i];
+        int eightByteSize = argLocDesc->m_eightByteInfo.GetEightByteSize(i);
+        SystemVClassificationType eightByteClassification = argLocDesc->m_eightByteInfo.GetEightByteClassification(i);
 
         _ASSERTE(remainingBytes >= eightByteSize);
 
@@ -466,7 +466,7 @@ LPVOID ProfileArgIterator::GetReturnBufferAddr(void)
         EEClass* eeClass = pMT->GetClass();
         UINT fpReturnSize = m_argIterator.GetFPReturnSize();
 
-        if (eeClass->GetNumberEightBytes() == 1)
+        if (eeClass->GetEightByteRegistersInfo().GetNumEightBytes() == 1)
         {
             if (fpReturnSize != 0)
             {

--- a/src/coreclr/vm/amd64/profiler.cpp
+++ b/src/coreclr/vm/amd64/profiler.cpp
@@ -195,13 +195,12 @@ LPVOID ProfileArgIterator::CopyStructFromRegisters()
     int fieldBytes = th.AsMethodTable()->GetNumInstanceFieldBytes();
     INDEBUG(int remainingBytes = fieldBytes;)
 
-    EEClass* eeClass = argLocDesc->m_eeClass;
-    _ASSERTE(eeClass != NULL);
+    _ASSERTE(argLocDesc->m_numEightBytesOfStructInRegs > 0);
 
-    for (int i = 0; i < eeClass->GetNumberEightBytes(); i++)
+    for (int i = 0; i < argLocDesc->m_numEightBytesOfStructInRegs; i++)
     {
-        int eightByteSize = eeClass->GetEightByteSize(i);
-        SystemVClassificationType eightByteClassification = eeClass->GetEightByteClassification(i);
+        int eightByteSize = argLocDesc->m_eightByteSizes[i];
+        SystemVClassificationType eightByteClassification = argLocDesc->m_eightByteClassifications[i];
 
         _ASSERTE(remainingBytes >= eightByteSize);
 

--- a/src/coreclr/vm/argdestination.h
+++ b/src/coreclr/vm/argdestination.h
@@ -254,14 +254,13 @@ public:
         BYTE* floatRegDest = (BYTE*)GetStructFloatRegDestinationAddress();
         INDEBUG(int remainingBytes = fieldBytes;)
 
-        EEClass* eeClass = m_argLocDescForStructInRegs->m_eeClass;
-        _ASSERTE(eeClass != NULL);
+        _ASSERTE(m_argLocDescForStructInRegs->m_numEightBytesOfStructInRegs != 0);
 
         // We start at the first eightByte that the destOffset didn't skip completely.
-        for (int i = destOffset / 8; i < eeClass->GetNumberEightBytes(); i++)
+        for (int i = destOffset / 8; i < m_argLocDescForStructInRegs->m_numEightBytesOfStructInRegs; i++)
         {
-            int eightByteSize = eeClass->GetEightByteSize(i);
-            SystemVClassificationType eightByteClassification = eeClass->GetEightByteClassification(i);
+            int eightByteSize = m_argLocDescForStructInRegs->m_eightByteSizes[i];
+            SystemVClassificationType eightByteClassification = m_argLocDescForStructInRegs->m_eightByteClassifications[i];
 
             // Adjust the size of the first eightByte by the destOffset
             eightByteSize -= (destOffset & 7);
@@ -325,13 +324,12 @@ public:
         TADDR genRegDest = dac_cast<TADDR>(GetStructGenRegDestinationAddress());
         INDEBUG(int remainingBytes = fieldBytes;)
 
-        EEClass* eeClass = m_argLocDescForStructInRegs->m_eeClass;
-        _ASSERTE(eeClass != NULL);
+        _ASSERTE(m_argLocDescForStructInRegs->m_numEightBytesOfStructInRegs != 0);
 
-        for (int i = 0; i < eeClass->GetNumberEightBytes(); i++)
+        for (int i = 0; i < m_argLocDescForStructInRegs->m_numEightBytesOfStructInRegs; i++)
         {
-            int eightByteSize = eeClass->GetEightByteSize(i);
-            SystemVClassificationType eightByteClassification = eeClass->GetEightByteClassification(i);
+            int eightByteSize = m_argLocDescForStructInRegs->m_eightByteSizes[i];
+            SystemVClassificationType eightByteClassification = m_argLocDescForStructInRegs->m_eightByteClassifications[i];
 
             _ASSERTE(remainingBytes >= eightByteSize);
 

--- a/src/coreclr/vm/argdestination.h
+++ b/src/coreclr/vm/argdestination.h
@@ -254,13 +254,13 @@ public:
         BYTE* floatRegDest = (BYTE*)GetStructFloatRegDestinationAddress();
         INDEBUG(int remainingBytes = fieldBytes;)
 
-        _ASSERTE(m_argLocDescForStructInRegs->m_numEightBytesOfStructInRegs != 0);
+        _ASSERTE(m_argLocDescForStructInRegs->m_eightByteInfo.GetNumEightBytes() != 0);
 
         // We start at the first eightByte that the destOffset didn't skip completely.
-        for (int i = destOffset / 8; i < m_argLocDescForStructInRegs->m_numEightBytesOfStructInRegs; i++)
+        for (int i = destOffset / 8; i < m_argLocDescForStructInRegs->m_eightByteInfo.GetNumEightBytes(); i++)
         {
-            int eightByteSize = m_argLocDescForStructInRegs->m_eightByteSizes[i];
-            SystemVClassificationType eightByteClassification = m_argLocDescForStructInRegs->m_eightByteClassifications[i];
+            int eightByteSize = m_argLocDescForStructInRegs->m_eightByteInfo.GetEightByteSize(i);
+            SystemVClassificationType eightByteClassification = m_argLocDescForStructInRegs->m_eightByteInfo.GetEightByteClassification(i);
 
             // Adjust the size of the first eightByte by the destOffset
             eightByteSize -= (destOffset & 7);
@@ -324,12 +324,12 @@ public:
         TADDR genRegDest = dac_cast<TADDR>(GetStructGenRegDestinationAddress());
         INDEBUG(int remainingBytes = fieldBytes;)
 
-        _ASSERTE(m_argLocDescForStructInRegs->m_numEightBytesOfStructInRegs != 0);
+        _ASSERTE(m_argLocDescForStructInRegs->m_eightByteInfo.GetNumEightBytes() != 0);
 
-        for (int i = 0; i < m_argLocDescForStructInRegs->m_numEightBytesOfStructInRegs; i++)
+        for (int i = 0; i < m_argLocDescForStructInRegs->m_eightByteInfo.GetNumEightBytes(); i++)
         {
-            int eightByteSize = m_argLocDescForStructInRegs->m_eightByteSizes[i];
-            SystemVClassificationType eightByteClassification = m_argLocDescForStructInRegs->m_eightByteClassifications[i];
+            int eightByteSize = m_argLocDescForStructInRegs->m_eightByteInfo.GetEightByteSize(i);
+            SystemVClassificationType eightByteClassification = m_argLocDescForStructInRegs->m_eightByteInfo.GetEightByteClassification(i);
 
             _ASSERTE(remainingBytes >= eightByteSize);
 

--- a/src/coreclr/vm/callingconvention.h
+++ b/src/coreclr/vm/callingconvention.h
@@ -1415,7 +1415,9 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
                 m_argLocDescForStructInRegs.m_cFloatReg = cFPRegs;
                 m_argLocDescForStructInRegs.m_idxGenReg = m_idxGenReg;
                 m_argLocDescForStructInRegs.m_idxFloatReg = m_idxFPReg;
+#ifdef DEBUG
                 m_argLocDescForStructInRegs.m_thStructInRegs = m_argTypeHandle;
+#endif
                 m_argLocDescForStructInRegs.m_eightByteInfo = eightByteInfo;
 
                 m_hasArgLocDescForStructInRegs = true;

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -2754,11 +2754,11 @@ void CallStubGenerator::ComputeCallStubWorker(bool hasUnmanagedCallConv, CorInfo
         ArgLocDesc* argLocDescForStructInRegs = argIt.GetArgLocDescForStructInRegs();
         if (argLocDescForStructInRegs != NULL)
         {
-            int numEightBytes = argLocDescForStructInRegs->m_numEightBytesOfStructInRegs;
+            int numEightBytes = argLocDescForStructInRegs->m_eightByteInfo.GetNumEightBytes();
             for (int i = 0; i < numEightBytes; i++)
             {
                 ArgLocDesc argLocDescEightByte = {};
-                SystemVClassificationType eightByteType = argLocDescForStructInRegs->m_eightByteClassifications[i];
+                SystemVClassificationType eightByteType = argLocDescForStructInRegs->m_eightByteInfo.GetEightByteClassification(i);
                 switch (eightByteType)
                 {
                     case SystemVClassificationTypeInteger:

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -2489,9 +2489,6 @@ bool isNativePrimitiveStructType(MethodTable* pMT)
 
 void CallStubGenerator::ComputeCallStub(MetaSig &sig, PCODE *pRoutines, MethodDesc *pMD)
 {
-    bool rewriteMetaSigFromExplicitThisToHasThis = false;
-    bool unmanagedThisCallConv = false;
-
     bool hasUnmanagedCallConv = false;
     CorInfoCallConvExtension unmanagedCallConv = CorInfoCallConvExtension::C;
 
@@ -2525,12 +2522,40 @@ void CallStubGenerator::ComputeCallStub(MetaSig &sig, PCODE *pRoutines, MethodDe
                 unmanagedCallConv = CorInfoCallConvExtension::Thiscall;
                 hasUnmanagedCallConv = true;
                 break;
+            case IMAGE_CEE_UNMANAGED_CALLCONV_C:
+                unmanagedCallConv = CorInfoCallConvExtension::C;
+                hasUnmanagedCallConv = true;
+                break;
+            case IMAGE_CEE_UNMANAGED_CALLCONV_STDCALL:
+                unmanagedCallConv = CorInfoCallConvExtension::Stdcall;
+                hasUnmanagedCallConv = true;
+                break;
+            case IMAGE_CEE_UNMANAGED_CALLCONV_FASTCALL:
+                unmanagedCallConv = CorInfoCallConvExtension::Fastcall;
+                hasUnmanagedCallConv = true;
+                break;
             case IMAGE_CEE_CS_CALLCONV_UNMANAGED:
                 unmanagedCallConv = GetUnmanagedCallConvExtension(&sig);
                 hasUnmanagedCallConv = true;
                 break;
         }
     }
+
+    if (hasUnmanagedCallConv)
+    {
+        ComputeCallStubWorker<PInvokeArgIterator>(hasUnmanagedCallConv, unmanagedCallConv, sig, pRoutines, pMD);
+    }
+    else
+    {
+        ComputeCallStubWorker<ArgIterator>(hasUnmanagedCallConv, unmanagedCallConv, sig, pRoutines, pMD);
+    }
+}
+
+template<typename ArgIteratorType>
+void CallStubGenerator::ComputeCallStubWorker(bool hasUnmanagedCallConv, CorInfoCallConvExtension unmanagedCallConv, MetaSig &sig, PCODE *pRoutines, MethodDesc *pMD)
+{
+    bool unmanagedThisCallConv = false;
+    bool rewriteMetaSigFromExplicitThisToHasThis = false;
 
     if (hasUnmanagedCallConv)
     {
@@ -2628,7 +2653,7 @@ void CallStubGenerator::ComputeCallStub(MetaSig &sig, PCODE *pRoutines, MethodDe
         sig = newSig;
     }
 
-    ArgIterator argIt(&sig);
+    ArgIteratorType argIt(&sig);
     int32_t interpreterStackOffset = 0;
 
     m_currentRoutineType = RoutineType::None;
@@ -2666,7 +2691,7 @@ void CallStubGenerator::ComputeCallStub(MetaSig &sig, PCODE *pRoutines, MethodDe
         // In the Interpreter calling convention the argument after the "this" pointer is the parameter type
         ArgLocDesc paramArgLocDesc;
         argIt.GetParamTypeLoc(&paramArgLocDesc);
-        ProcessArgument(NULL, paramArgLocDesc, pRoutines);
+        ProcessArgument<ArgIteratorType>(NULL, paramArgLocDesc, pRoutines);
         interpreterStackOffset += INTERP_STACK_SLOT_SIZE;
     }
 
@@ -2678,7 +2703,7 @@ void CallStubGenerator::ComputeCallStub(MetaSig &sig, PCODE *pRoutines, MethodDe
         // In the Interpreter calling convention the argument after the param type is the async continuation
         ArgLocDesc asyncContinuationLocDesc;
         argIt.GetAsyncContinuationLoc(&asyncContinuationLocDesc);
-        ProcessArgument(NULL, asyncContinuationLocDesc, pRoutines);
+        ProcessArgument<ArgIteratorType>(NULL, asyncContinuationLocDesc, pRoutines);
         interpreterStackOffset += INTERP_STACK_SLOT_SIZE;
     }
 
@@ -2726,19 +2751,14 @@ void CallStubGenerator::ComputeCallStub(MetaSig &sig, PCODE *pRoutines, MethodDe
         interpreterStackOffset += interpStackSlotSize;
 
 #ifdef UNIX_AMD64_ABI
-        if (argIt.GetArgLocDescForStructInRegs() != NULL)
+        ArgLocDesc* argLocDescForStructInRegs = argIt.GetArgLocDescForStructInRegs();
+        if (argLocDescForStructInRegs != NULL)
         {
-            TypeHandle argTypeHandle;
-            CorElementType corType = argIt.GetArgType(&argTypeHandle);
-            _ASSERTE(corType == ELEMENT_TYPE_VALUETYPE);
-
-            MethodTable *pMT = argTypeHandle.AsMethodTable();
-            EEClass *pEEClass = pMT->GetClass();
-            int numEightBytes = pEEClass->GetNumberEightBytes();
+            int numEightBytes = argLocDescForStructInRegs->m_numEightBytesOfStructInRegs;
             for (int i = 0; i < numEightBytes; i++)
             {
                 ArgLocDesc argLocDescEightByte = {};
-                SystemVClassificationType eightByteType = pEEClass->GetEightByteClassification(i);
+                SystemVClassificationType eightByteType = argLocDescForStructInRegs->m_eightByteClassifications[i];
                 switch (eightByteType)
                 {
                     case SystemVClassificationTypeInteger:
@@ -2806,7 +2826,8 @@ void CallStubGenerator::ComputeCallStub(MetaSig &sig, PCODE *pRoutines, MethodDe
 
 // Process the argument described by argLocDesc. This function is called for each argument in the method signature.
 // It updates the ranges of registers and emits entries into the routines array at discontinuities.
-void CallStubGenerator::ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocDesc, PCODE *pRoutines)
+template<typename ArgIteratorType>
+void CallStubGenerator::ProcessArgument(ArgIteratorType *pArgIt, ArgLocDesc& argLocDesc, PCODE *pRoutines)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -3008,7 +3029,8 @@ void CallStubGenerator::ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocD
     m_currentRoutineType = argType;
 }
 
-CallStubGenerator::ReturnType CallStubGenerator::GetReturnType(ArgIterator *pArgIt)
+template<typename ArgIteratorType>
+CallStubGenerator::ReturnType CallStubGenerator::GetReturnType(ArgIteratorType *pArgIt)
 {
     if (pArgIt->HasRetBuffArg())
     {

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -3090,8 +3090,9 @@ CallStubGenerator::ReturnType CallStubGenerator::GetReturnType(ArgIteratorType *
                 // POD structs smaller than 64 bits are returned in rax
                 return ReturnTypeI8;
 #else // TARGET_WINDOWS
-                if (thReturnValueType.AsMethodTable()->IsRegPassedStruct())
+                if (!pArgIt->HasRetBuffArg())
                 {
+                    _ASSERTE(thReturnValueType.IsNativeValueType() ||  thReturnValueType.AsMethodTable()->IsRegPassedStruct());
                     UINT fpReturnSize = pArgIt->GetFPReturnSize();
                     if (fpReturnSize == 0)
                     {

--- a/src/coreclr/vm/callstubgenerator.h
+++ b/src/coreclr/vm/callstubgenerator.h
@@ -159,12 +159,14 @@ class CallStubGenerator
     PCODE GetFPReg32RangeRoutine(int x1, int x2);
 #endif    
     PCODE GetGPRegRangeRoutine(int r1, int r2);
-    ReturnType GetReturnType(ArgIterator *pArgIt);
+    template<typename ArgIteratorType>
+    ReturnType GetReturnType(ArgIteratorType *pArgIt);
     CallStubHeader::InvokeFunctionPtr GetInvokeFunctionPtr(ReturnType returnType);
     PCODE GetInterpreterReturnTypeHandler(ReturnType returnType);
 
     // Process the argument described by argLocDesc. This function is called for each argument in the method signature.
-    void ProcessArgument(ArgIterator *pArgIt, ArgLocDesc& argLocDesc, PCODE *pRoutines);
+    template<typename ArgIteratorType>
+    void ProcessArgument(ArgIteratorType *pArgIt, ArgLocDesc& argLocDesc, PCODE *pRoutines);
 public:
     // Generate the call stub for the given method.
     CallStubHeader *GenerateCallStub(MethodDesc *pMD, AllocMemTracker *pamTracker, bool interpreterToNative);
@@ -180,6 +182,8 @@ private:
         return sizeof(CallStubHeader) + ((numArgs + 1) * 3 + 1) * sizeof(PCODE);
     }
     void ComputeCallStub(MetaSig &sig, PCODE *pRoutines, MethodDesc *pMD);
+    template<typename ArgIteratorType>
+    void ComputeCallStubWorker(bool hasUnmanagedCallConv, CorInfoCallConvExtension unmanagedCallConv, MetaSig &sig, PCODE *pRoutines, MethodDesc *pMD);
 
     void TerminateCurrentRoutineIfNotOfNewType(RoutineType type, PCODE *pRoutines);
 };

--- a/src/coreclr/vm/class.h
+++ b/src/coreclr/vm/class.h
@@ -641,11 +641,11 @@ class EEClassOptionalFields
 
 #if defined(UNIX_AMD64_ABI)
     // Number of eightBytes in the following arrays
-    int m_numberEightBytes;
+    uint8_t m_numberEightBytes;
     // Classification of the eightBytes
     SystemVClassificationType m_eightByteClassifications[CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS];
     // Size of data the eightBytes
-    unsigned int m_eightByteSizes[CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS];
+    uint8_t m_eightByteSizes[CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS];
 #endif // UNIX_AMD64_ABI
 
     // Required alignment for this fields of this type (only set in auto-layout structures when different from pointer alignment)
@@ -1422,7 +1422,7 @@ public:
 
 #if defined(UNIX_AMD64_ABI)
     // Get number of eightbytes used by a struct passed in registers.
-    inline int GetNumberEightBytes()
+    inline uint8_t GetNumberEightBytes()
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(HasOptionalFields());
@@ -1438,7 +1438,7 @@ public:
     }
 
     // Get size of the data in the eightbyte with the specified index.
-    inline unsigned int GetEightByteSize(int index)
+    inline uint8_t GetEightByteSize(int index)
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(HasOptionalFields());
@@ -1446,7 +1446,7 @@ public:
     }
 
     // Set the eightByte classification
-    inline void SetEightByteClassification(int eightByteCount, SystemVClassificationType *eightByteClassifications, unsigned int *eightByteSizes)
+    inline void SetEightByteClassification(uint8_t eightByteCount, SystemVClassificationType *eightByteClassifications, uint8_t *eightByteSizes)
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(HasOptionalFields());

--- a/src/coreclr/vm/class.h
+++ b/src/coreclr/vm/class.h
@@ -640,12 +640,8 @@ class EEClassOptionalFields
     //
 
 #if defined(UNIX_AMD64_ABI)
-    // Number of eightBytes in the following arrays
-    uint8_t m_numberEightBytes;
-    // Classification of the eightBytes
-    SystemVClassificationType m_eightByteClassifications[CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS];
-    // Size of data the eightBytes
-    uint8_t m_eightByteSizes[CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS];
+    // Information about the eightByte classifications for structs passed in registers
+    SystemVEightByteRegistersInfo m_eightByteRegistersInfo;
 #endif // UNIX_AMD64_ABI
 
     // Required alignment for this fields of this type (only set in auto-layout structures when different from pointer alignment)
@@ -1421,41 +1417,19 @@ public:
 
 
 #if defined(UNIX_AMD64_ABI)
-    // Get number of eightbytes used by a struct passed in registers.
-    inline uint8_t GetNumberEightBytes()
+    inline SystemVEightByteRegistersInfo GetEightByteRegistersInfo()
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(HasOptionalFields());
-        return GetOptionalFields()->m_numberEightBytes;
-    }
-
-    // Get eightbyte classification for the eightbyte with the specified index.
-    inline SystemVClassificationType GetEightByteClassification(int index)
-    {
-        LIMITED_METHOD_CONTRACT;
-        _ASSERTE(HasOptionalFields());
-        return GetOptionalFields()->m_eightByteClassifications[index];
-    }
-
-    // Get size of the data in the eightbyte with the specified index.
-    inline uint8_t GetEightByteSize(int index)
-    {
-        LIMITED_METHOD_CONTRACT;
-        _ASSERTE(HasOptionalFields());
-        return GetOptionalFields()->m_eightByteSizes[index];
+        return GetOptionalFields()->m_eightByteRegistersInfo;
     }
 
     // Set the eightByte classification
-    inline void SetEightByteClassification(uint8_t eightByteCount, SystemVClassificationType *eightByteClassifications, uint8_t *eightByteSizes)
+    inline void SetEightByteClassification(SystemVEightByteRegistersInfo eightByteInfo)
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(HasOptionalFields());
-        GetOptionalFields()->m_numberEightBytes = eightByteCount;
-        for (int i = 0; i < eightByteCount; i++)
-        {
-            GetOptionalFields()->m_eightByteClassifications[i] = eightByteClassifications[i];
-            GetOptionalFields()->m_eightByteSizes[i] = eightByteSizes[i];
-        }
+        GetOptionalFields()->m_eightByteRegistersInfo = eightByteInfo;
     }
 #endif // UNIX_AMD64_ABI
 

--- a/src/coreclr/vm/class.inl
+++ b/src/coreclr/vm/class.inl
@@ -29,7 +29,7 @@ inline void EEClassOptionalFields::Init()
 #endif // FEATURE_COMINTEROP_UNMANAGED_ACTIVATION
 #endif // FEATURE_COMINTEROP
 #if defined(UNIX_AMD64_ABI)
-    m_numberEightBytes = 0;
+    m_eightByteRegistersInfo.InitEmpty();
 #endif // UNIX_AMD64_ABI
 }
 #endif // !DACCESS_COMPILE

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -82,12 +82,12 @@ class ShuffleIterator
     // Get next shuffle offset for struct passed in registers. There has to be at least one offset left.
     UINT16 GetNextOfsInStruct()
     {
-        _ASSERTE(m_argLocDesc->m_numEightBytesOfStructInRegs > 0);
+        _ASSERTE(m_argLocDesc->m_eightByteInfo.GetNumEightBytes() > 0);
 
-        if (m_currentEightByte < m_argLocDesc->m_numEightBytesOfStructInRegs)
+        if (m_currentEightByte < m_argLocDesc->m_eightByteInfo.GetNumEightBytes())
         {
-            SystemVClassificationType eightByte = m_argLocDesc->m_eightByteClassifications[m_currentEightByte];
-            unsigned int eightByteSize = m_argLocDesc->m_eightByteSizes[m_currentEightByte];
+            SystemVClassificationType eightByte = m_argLocDesc->m_eightByteInfo.GetEightByteClassification(m_currentEightByte);
+            unsigned int eightByteSize = m_argLocDesc->m_eightByteInfo.GetEightByteSize(m_currentEightByte);
 
             m_currentEightByte++;
 
@@ -158,7 +158,7 @@ public:
 #if defined(UNIX_AMD64_ABI)
 
         // Check if the argLocDesc is for a struct in registers
-        if (m_argLocDesc->m_numEightBytesOfStructInRegs != 0)
+        if (m_argLocDesc->m_eightByteInfo.GetNumEightBytes() != 0)
         {
             index = GetNextOfsInStruct();
             _ASSERT((index & ShuffleEntry::REGMASK) != 0);

--- a/src/coreclr/vm/comdelegate.cpp
+++ b/src/coreclr/vm/comdelegate.cpp
@@ -82,13 +82,12 @@ class ShuffleIterator
     // Get next shuffle offset for struct passed in registers. There has to be at least one offset left.
     UINT16 GetNextOfsInStruct()
     {
-        EEClass* eeClass = m_argLocDesc->m_eeClass;
-        _ASSERTE(eeClass != NULL);
+        _ASSERTE(m_argLocDesc->m_numEightBytesOfStructInRegs > 0);
 
-        if (m_currentEightByte < eeClass->GetNumberEightBytes())
+        if (m_currentEightByte < m_argLocDesc->m_numEightBytesOfStructInRegs)
         {
-            SystemVClassificationType eightByte = eeClass->GetEightByteClassification(m_currentEightByte);
-            unsigned int eightByteSize = eeClass->GetEightByteSize(m_currentEightByte);
+            SystemVClassificationType eightByte = m_argLocDesc->m_eightByteClassifications[m_currentEightByte];
+            unsigned int eightByteSize = m_argLocDesc->m_eightByteSizes[m_currentEightByte];
 
             m_currentEightByte++;
 
@@ -159,8 +158,7 @@ public:
 #if defined(UNIX_AMD64_ABI)
 
         // Check if the argLocDesc is for a struct in registers
-        EEClass* eeClass = m_argLocDesc->m_eeClass;
-        if (m_argLocDesc->m_eeClass != 0)
+        if (m_argLocDesc->m_numEightBytesOfStructInRegs != 0)
         {
             index = GetNextOfsInStruct();
             _ASSERT((index & ShuffleEntry::REGMASK) != 0);

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -2383,6 +2383,26 @@ unsigned CEEInfo::getClassGClayoutStatic(TypeHandle VMClsHnd, BYTE* gcPtrs)
     return result;
 }
 
+SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR SystemVRegDescriptorFromSystemVEightByteRegistersInfo(const SystemVEightByteRegistersInfo& info)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR desc = {};
+
+    desc.passedInRegisters = true;
+    desc.eightByteCount = info.GetNumEightBytes();
+    _ASSERTE(desc.eightByteCount <= CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS);
+    _ASSERTE(desc.eightByteCount > 0);
+    for (unsigned int i = 0; i < info.GetNumEightBytes(); i++)
+    {
+        desc.eightByteClassifications[i] = info.GetEightByteClassification(i);
+        desc.eightByteSizes[i] = (uint8_t)info.GetEightByteSize(i);
+        desc.eightByteOffsets[i] = i * SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES;
+    }
+
+    return desc;
+}
+
 // returns the enregister info for a struct based on type of fields, alignment, etc.
 bool CEEInfo::getSystemVAmd64PassStructInRegisterDescriptor(
                                                 /*IN*/  CORINFO_CLASS_HANDLE structHnd,
@@ -2440,30 +2460,42 @@ bool CEEInfo::getSystemVAmd64PassStructInRegisterDescriptor(
         SystemVStructRegisterPassingHelper helper((unsigned int)th.GetSize());
         if (th.GetSize() <= CLR_SYSTEMV_MAX_STRUCT_BYTES_TO_PASS_IN_REGISTERS)
         {
-            canPassInRegisters = methodTablePtr->ClassifyEightBytes(&helper, 0, 0, useNativeLayout);
+            canPassInRegisters = methodTablePtr->ClassifyEightBytes(&helper, useNativeLayout);
         }
 #endif // !defined(UNIX_AMD64_ABI)
 
         if (canPassInRegisters)
         {
 #if defined(UNIX_AMD64_ABI)
-            SystemVStructRegisterPassingHelper helper((unsigned int)th.GetSize());
-            bool result = methodTablePtr->ClassifyEightBytes(&helper, 0, 0, useNativeLayout);
-
-            // The answer must be true at this point.
-            _ASSERTE(result);
+            if (!useNativeLayout)
+            {
+                // For managed layout structs, we have already computed
+                // and cached the classification in the MethodTable.
+                SystemVEightByteRegistersInfo eightByteInfo = methodTablePtr->GetClass()->GetEightByteRegistersInfo();
+                *structPassInRegDescPtr = SystemVRegDescriptorFromSystemVEightByteRegistersInfo(eightByteInfo);
+            }
+            else
+#endif // UNIX_AMD64_ABI
+            {
+#if defined(UNIX_AMD64_ABI)
+                SystemVStructRegisterPassingHelper helper((unsigned int)th.GetSize());
+                bool result = methodTablePtr->ClassifyEightBytes(&helper, useNativeLayout);
+                
+                // The answer must be true at this point.
+                _ASSERTE(result);
 #endif // UNIX_AMD64_ABI
 
-            structPassInRegDescPtr->passedInRegisters = true;
+                structPassInRegDescPtr->passedInRegisters = true;
 
-            structPassInRegDescPtr->eightByteCount = (uint8_t)helper.eightByteCount;
-            _ASSERTE(structPassInRegDescPtr->eightByteCount <= CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS);
+                structPassInRegDescPtr->eightByteCount = (uint8_t)helper.eightByteCount;
+                _ASSERTE(structPassInRegDescPtr->eightByteCount <= CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS);
 
-            for (unsigned int i = 0; i < CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS; i++)
-            {
-                structPassInRegDescPtr->eightByteClassifications[i] = helper.eightByteClassifications[i];
-                structPassInRegDescPtr->eightByteSizes[i] = (uint8_t)helper.eightByteSizes[i];
-                structPassInRegDescPtr->eightByteOffsets[i] = (uint8_t)helper.eightByteOffsets[i];
+                for (unsigned int i = 0; i < CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS; i++)
+                {
+                    structPassInRegDescPtr->eightByteClassifications[i] = helper.eightByteClassifications[i];
+                    structPassInRegDescPtr->eightByteSizes[i] = (uint8_t)helper.eightByteSizes[i];
+                    structPassInRegDescPtr->eightByteOffsets[i] = (uint8_t)helper.eightByteOffsets[i];
+                }
             }
         }
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -2398,7 +2398,7 @@ SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR SystemVRegDescriptorFromSyst
     {
         desc.eightByteClassifications[i] = info.GetEightByteClassification(i);
         desc.eightByteSizes[i] = (uint8_t)info.GetEightByteSize(i);
-        desc.eightByteOffsets[i] = i * SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES;
+        desc.eightByteOffsets[i] = (uint8_t)i * SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES;
     }
 
     return desc;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -2383,6 +2383,7 @@ unsigned CEEInfo::getClassGClayoutStatic(TypeHandle VMClsHnd, BYTE* gcPtrs)
     return result;
 }
 
+#if defined(UNIX_AMD64_ABI_ITF)
 SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR SystemVRegDescriptorFromSystemVEightByteRegistersInfo(const SystemVEightByteRegistersInfo& info)
 {
     LIMITED_METHOD_CONTRACT;
@@ -2402,6 +2403,7 @@ SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR SystemVRegDescriptorFromSyst
 
     return desc;
 }
+#endif // defined(UNIX_AMD64_ABI_ITF)
 
 // returns the enregister info for a struct based on type of fields, alignment, etc.
 bool CEEInfo::getSystemVAmd64PassStructInRegisterDescriptor(

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -2717,7 +2717,7 @@ void  MethodTable::AssignClassifiedEightByteTypes(SystemVStructRegisterPassingHe
 
         for (unsigned int currentEightByte = 0; currentEightByte < usedEightBytes; currentEightByte++)
         {
-            unsigned int eightByteSize = accumulatedSizeForEightBytes < (SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES * (currentEightByte + 1))
+            uint8_t eightByteSize = accumulatedSizeForEightBytes < (SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES * (currentEightByte + 1))
                 ? accumulatedSizeForEightBytes % SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES
                 :   SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES;
 
@@ -2726,7 +2726,8 @@ void  MethodTable::AssignClassifiedEightByteTypes(SystemVStructRegisterPassingHe
             helperPtr->eightByteOffsets[currentEightByte] = currentEightByte * SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES;
         }
 
-        helperPtr->eightByteCount = usedEightBytes;
+        _ASSERTE(usedEightBytes <= 255);
+        helperPtr->eightByteCount = (uint8_t)usedEightBytes;
 
         _ASSERTE(helperPtr->eightByteCount <= CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS);
 

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -2045,16 +2045,16 @@ const char* GetSystemVClassificationTypeName(SystemVClassificationType t)
 #endif // _DEBUG && LOGGING
 
 // Returns 'true' if the struct is passed in registers, 'false' otherwise.
-bool MethodTable::ClassifyEightBytes(SystemVStructRegisterPassingHelper *helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct, bool useNativeLayout, MethodTable** pByValueClassCache)
+bool MethodTable::ClassifyEightBytes(SystemVStructRegisterPassingHelper *helperPtr, bool useNativeLayout, MethodTable** pByValueClassCache)
 {
     if (useNativeLayout)
     {
         _ASSERTE(pByValueClassCache == NULL);
-        return ClassifyEightBytesWithNativeLayout(helperPtr, nestingLevel, startOffsetOfStruct, GetNativeLayoutInfo());
+        return ClassifyEightBytesWithNativeLayout(helperPtr, 0, 0, GetNativeLayoutInfo());
     }
     else
     {
-        return ClassifyEightBytesWithManagedLayout(helperPtr, nestingLevel, startOffsetOfStruct, useNativeLayout, pByValueClassCache);
+        return ClassifyEightBytesWithManagedLayout(helperPtr, 0, 0, useNativeLayout, pByValueClassCache);
     }
 }
 

--- a/src/coreclr/vm/methodtable.cpp
+++ b/src/coreclr/vm/methodtable.cpp
@@ -2045,7 +2045,7 @@ const char* GetSystemVClassificationTypeName(SystemVClassificationType t)
 #endif // _DEBUG && LOGGING
 
 // Returns 'true' if the struct is passed in registers, 'false' otherwise.
-bool MethodTable::ClassifyEightBytes(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct, bool useNativeLayout, MethodTable** pByValueClassCache)
+bool MethodTable::ClassifyEightBytes(SystemVStructRegisterPassingHelper *helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct, bool useNativeLayout, MethodTable** pByValueClassCache)
 {
     if (useNativeLayout)
     {
@@ -2117,7 +2117,7 @@ static MethodTable* ByValueClassCacheLookup(MethodTable** pByValueClassCache, un
 }
 
 // Returns 'true' if the struct is passed in registers, 'false' otherwise.
-bool MethodTable::ClassifyEightBytesWithManagedLayout(SystemVStructRegisterPassingHelperPtr helperPtr,
+bool MethodTable::ClassifyEightBytesWithManagedLayout(SystemVStructRegisterPassingHelper *helperPtr,
                                                      unsigned int nestingLevel,
                                                      unsigned int startOffsetOfStruct,
                                                      bool useNativeLayout,
@@ -2326,7 +2326,7 @@ bool MethodTable::ClassifyEightBytesWithManagedLayout(SystemVStructRegisterPassi
 }
 
 // Returns 'true' if the struct is passed in registers, 'false' otherwise.
-bool MethodTable::ClassifyEightBytesWithNativeLayout(SystemVStructRegisterPassingHelperPtr helperPtr,
+bool MethodTable::ClassifyEightBytesWithNativeLayout(SystemVStructRegisterPassingHelper *helperPtr,
                                                     unsigned int nestingLevel,
                                                     unsigned int startOffsetOfStruct,
                                                     EEClassNativeLayoutInfo const* pNativeLayoutInfo)
@@ -2575,7 +2575,7 @@ bool MethodTable::ClassifyEightBytesWithNativeLayout(SystemVStructRegisterPassin
 }
 
 // Assigns the classification types to the array with eightbyte types.
-void  MethodTable::AssignClassifiedEightByteTypes(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel) const
+void  MethodTable::AssignClassifiedEightByteTypes(SystemVStructRegisterPassingHelper *helperPtr, unsigned int nestingLevel) const
 {
     static const size_t CLR_SYSTEMV_MAX_BYTES_TO_PASS_IN_REGISTERS = CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS * SYSTEMV_EIGHT_BYTE_SIZE_IN_BYTES;
     static_assert(CLR_SYSTEMV_MAX_BYTES_TO_PASS_IN_REGISTERS == SYSTEMV_MAX_NUM_FIELDS_IN_REGISTER_PASSED_STRUCT);

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -801,9 +801,9 @@ struct SystemVStructRegisterPassingHelper
     unsigned int                    structSize;
 
     // These fields are the output; these are what is computed by the classification algorithm.
-    unsigned int                    eightByteCount;
+    uint8_t                         eightByteCount;
     SystemVClassificationType       eightByteClassifications[CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS];
-    unsigned int                    eightByteSizes[CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS];
+    uint8_t                         eightByteSizes[CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS];
     unsigned int                    eightByteOffsets[CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS];
 
     // Helper members to track state.
@@ -1136,8 +1136,8 @@ public:
 
 #if defined(UNIX_AMD64_ABI_ITF)
     // Builds the internal data structures and classifies struct eightbytes for Amd System V calling convention.
-    bool ClassifyEightBytes(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct, bool isNativeStruct, MethodTable** pByValueClassCache = NULL);
-    bool ClassifyEightBytesWithNativeLayout(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct, EEClassNativeLayoutInfo const* nativeLayoutInfo);
+    bool ClassifyEightBytes(SystemVStructRegisterPassingHelper *helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct, bool isNativeStruct, MethodTable** pByValueClassCache = NULL);
+    bool ClassifyEightBytesWithNativeLayout(SystemVStructRegisterPassingHelper *helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct, EEClassNativeLayoutInfo const* nativeLayoutInfo);
 #endif // defined(UNIX_AMD64_ABI_ITF)
 
 #if !defined(DACCESS_COMPILE)
@@ -1212,9 +1212,9 @@ public:
 private:
 
 #if defined(UNIX_AMD64_ABI_ITF)
-    void AssignClassifiedEightByteTypes(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel) const;
+    void AssignClassifiedEightByteTypes(SystemVStructRegisterPassingHelper *helperPtr, unsigned int nestingLevel) const;
     // Builds the internal data structures and classifies struct eightbytes for Amd System V calling convention.
-    bool ClassifyEightBytesWithManagedLayout(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct, bool isNativeStruct, MethodTable** pByValueClassCache);
+    bool ClassifyEightBytesWithManagedLayout(SystemVStructRegisterPassingHelper *helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct, bool isNativeStruct, MethodTable** pByValueClassCache);
 #endif // defined(UNIX_AMD64_ABI_ITF)
 
     // called from CheckRunClassInitThrowing().  The type wasn't marked as

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -875,6 +875,53 @@ struct FpStructInRegistersInfo
 };
 #endif // defined(TARGET_RISCV64) || defined(TARGET_LOONGARCH64)
 
+#ifdef UNIX_AMD64_ABI_ITF
+struct SystemVEightByteRegistersInfo
+{
+private:
+    uint8_t NumEightBytes; // Number of eightbytes used by the struct passed in registers
+    SystemVClassificationType EightByteClassifications[CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS];
+    uint8_t EightByteSizes[CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS];
+public:
+
+    SystemVEightByteRegistersInfo()
+    {
+        InitEmpty();
+    }
+
+    SystemVEightByteRegistersInfo(const SystemVStructRegisterPassingHelper& helper)
+    {
+        NumEightBytes = helper.eightByteCount;
+        _ASSERTE(NumEightBytes <= CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS);
+        for (unsigned i = 0; i < NumEightBytes; i++)
+        {
+            EightByteClassifications[i] = helper.eightByteClassifications[i];
+            EightByteSizes[i] = helper.eightByteSizes[i];
+        }
+    }
+
+    void InitEmpty()
+    {
+        NumEightBytes = 0;
+    }
+
+    uint8_t GetNumEightBytes() const
+    {
+        return NumEightBytes;
+    }
+    SystemVClassificationType GetEightByteClassification(unsigned index) const
+    {
+        _ASSERTE(index < NumEightBytes);
+        return EightByteClassifications[index];
+    }
+    uint8_t GetEightByteSize(unsigned index) const
+    {
+        _ASSERTE(index < NumEightBytes);
+        return EightByteSizes[index];
+    }
+};
+#endif
+
 //===============================================================================================
 //
 // GC data appears before the beginning of the MethodTable
@@ -1136,7 +1183,7 @@ public:
 
 #if defined(UNIX_AMD64_ABI_ITF)
     // Builds the internal data structures and classifies struct eightbytes for Amd System V calling convention.
-    bool ClassifyEightBytes(SystemVStructRegisterPassingHelper *helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct, bool isNativeStruct, MethodTable** pByValueClassCache = NULL);
+    bool ClassifyEightBytes(SystemVStructRegisterPassingHelper *helperPtr, bool isNativeStruct, MethodTable** pByValueClassCache = NULL);
     bool ClassifyEightBytesWithNativeLayout(SystemVStructRegisterPassingHelper *helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct, EEClassNativeLayoutInfo const* nativeLayoutInfo);
 #endif // defined(UNIX_AMD64_ABI_ITF)
 

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -8873,7 +8873,7 @@ void MethodTableBuilder::SystemVAmd64CheckForPassStructInRegister(MethodTable** 
     const bool useNativeLayout = false;
     // Iterate through the fields and make sure they meet requirements to pass in registers
     SystemVStructRegisterPassingHelper helper((unsigned int)totalStructSize);
-    if (GetHalfBakedMethodTable()->ClassifyEightBytes(&helper, 0, 0, useNativeLayout, pByValueClassCache))
+    if (GetHalfBakedMethodTable()->ClassifyEightBytes(&helper, useNativeLayout, pByValueClassCache))
     {
         LOG((LF_JIT, LL_EVERYTHING, "**** SystemVAmd64CheckForPassStructInRegister: struct %s is enregisterable\n",
                this->GetDebugClassName()));
@@ -8897,7 +8897,7 @@ void MethodTableBuilder::StoreEightByteClassification(SystemVStructRegisterPassi
     LoaderAllocator* pAllocator = MethodTableBuilder::GetLoaderAllocator();
     AllocMemTracker* pamTracker = MethodTableBuilder::GetMemTracker();
     EnsureOptionalFieldsAreAllocated(eeClass, pamTracker, pAllocator->GetLowFrequencyHeap());
-    eeClass->SetEightByteClassification(helper->eightByteCount, helper->eightByteClassifications, helper->eightByteSizes);
+    eeClass->SetEightByteClassification(SystemVEightByteRegistersInfo(*helper));
 }
 
 #endif // UNIX_AMD64_ABI

--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -231,19 +231,9 @@ protected:
     }
 
 #if defined(UNIX_AMD64_ABI)
-    FORCEINLINE uint8_t GetNumberEightBytes(TypeHandle th)
+    FORCEINLINE SystemVEightByteRegistersInfo GetEightByteRegistersInfo(TypeHandle th)
     {
-        return th.AsMethodTable()->GetClass()->GetNumberEightBytes();
-    }
-
-    FORCEINLINE SystemVClassificationType GetEightByteClassification(TypeHandle th, int index)
-    {
-        return th.AsMethodTable()->GetClass()->GetEightByteClassification(index);
-    }
-
-    FORCEINLINE uint8_t GetEightByteSize(TypeHandle th, int index)
-    {
-        return th.AsMethodTable()->GetClass()->GetEightByteSize(index);
+        return th.AsMethodTable()->GetClass()->GetEightByteRegistersInfo();
     }
 #endif // defined(UNIX_AMD64_ABI)
 

--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -225,10 +225,27 @@ protected:
         LIMITED_METHOD_CONTRACT;
     }
 
-    FORCEINLINE BOOL IsRegPassedStruct(MethodTable* pMT)
+    FORCEINLINE BOOL IsRegPassedStruct(TypeHandle th)
     {
-        return pMT->IsRegPassedStruct();
+        return th.AsMethodTable()->IsRegPassedStruct();
     }
+
+#if defined(UNIX_AMD64_ABI)
+    FORCEINLINE uint8_t GetNumberEightBytes(TypeHandle th)
+    {
+        return th.AsMethodTable()->GetClass()->GetNumberEightBytes();
+    }
+
+    FORCEINLINE SystemVClassificationType GetEightByteClassification(TypeHandle th, int index)
+    {
+        return th.AsMethodTable()->GetClass()->GetEightByteClassification(index);
+    }
+
+    FORCEINLINE uint8_t GetEightByteSize(TypeHandle th, int index)
+    {
+        return th.AsMethodTable()->GetClass()->GetEightByteSize(index);
+    }
+#endif // defined(UNIX_AMD64_ABI)
 
 public:
     BOOL HasThis()


### PR DESCRIPTION
1. SystemV struct classification did not work correctly for interpreter managed to native and native to managed transitions.
- Notably, the ArgIterator did not perform the correct calculations for cases where there is a marshalled structure being used.
- Fixed by using the PInvokeArgIterator, and updating the PInvokeArgIterator to correctly handle SysV details.
2. SystemV struct classification had a number of inefficiencies that I found.
- The JIT did not take advantage of the cached classification for structures, instead recomputing it every time
- The cached classification data was stored using individual fields which were unnecessarily large. I created a smaller size-optimized structure to hold the relevant data. (This changes the size of EEClassOptionalFields from 40 bytes to 24 bytes on Unix AMD64 platforms)