### PR TITLE
Adding C#, F#, VB to StringSyntaxAttribute

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/StringSyntaxAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/StringSyntaxAttribute.cs
@@ -38,6 +38,9 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>The syntax identifier for strings containing composite formats for string formatting.</summary>
         public const string CompositeFormat = nameof(CompositeFormat);
 
+        /// <summary>The syntax identifier for strings containing CSharp code.</summary>
+        public const string CSharp = "C#";
+
         /// <summary>The syntax identifier for strings containing date format specifiers.</summary>
         public const string DateOnlyFormat = nameof(DateOnlyFormat);
 
@@ -46,6 +49,9 @@ namespace System.Diagnostics.CodeAnalysis
 
         /// <summary>The syntax identifier for strings containing <see cref="Enum"/> format specifiers.</summary>
         public const string EnumFormat = nameof(EnumFormat);
+
+        /// <summary>The syntax identifier for strings containing FSharp code.</summary>
+        public const string FSharp = "F#";
 
         /// <summary>The syntax identifier for strings containing <see cref="Guid"/> format specifiers.</summary>
         public const string GuidFormat = nameof(GuidFormat);
@@ -68,16 +74,10 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>The syntax identifier for strings containing URIs.</summary>
         public const string Uri = nameof(Uri);
 
-        /// <summary>The syntax identifier for strings containing XML.</summary>
-        public const string Xml = nameof(Xml);
-
-        /// <summary>The syntax identifier for strings containing CSharp code.</summary>
-        public const string CSharp = "C#";
-
-        /// <summary>The syntax identifier for strings containing FSharp code.</summary>
-        public const string FSharp = "F#";
-
         /// <summary>The syntax identifier for strings containing VisualBasic code.</summary>
         public const string VisualBasic = "VB.NET";
+
+        /// <summary>The syntax identifier for strings containing XML.</summary>
+        public const string Xml = nameof(Xml);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/StringSyntaxAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/StringSyntaxAttribute.cs
@@ -70,5 +70,14 @@ namespace System.Diagnostics.CodeAnalysis
 
         /// <summary>The syntax identifier for strings containing XML.</summary>
         public const string Xml = nameof(Xml);
+
+        /// <summary>The syntax identifier for strings containing CSharp code.</summary>
+        public const string CSharp = "C#";
+
+        /// <summary>The syntax identifier for strings containing FSharp code.</summary>
+        public const string FSharp = "F#";
+
+        /// <summary>The syntax identifier for strings containing VisualBasic code.</summary>
+        public const string VisualBasic = "VB.NET";
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/StringSyntaxAttribute.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/StringSyntaxAttribute.cs
@@ -38,7 +38,7 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>The syntax identifier for strings containing composite formats for string formatting.</summary>
         public const string CompositeFormat = nameof(CompositeFormat);
 
-        /// <summary>The syntax identifier for strings containing CSharp code.</summary>
+        /// <summary>The syntax identifier for strings containing C# code.</summary>
         public const string CSharp = "C#";
 
         /// <summary>The syntax identifier for strings containing date format specifiers.</summary>
@@ -50,7 +50,7 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>The syntax identifier for strings containing <see cref="Enum"/> format specifiers.</summary>
         public const string EnumFormat = nameof(EnumFormat);
 
-        /// <summary>The syntax identifier for strings containing FSharp code.</summary>
+        /// <summary>The syntax identifier for strings containing F# code.</summary>
         public const string FSharp = "F#";
 
         /// <summary>The syntax identifier for strings containing <see cref="Guid"/> format specifiers.</summary>
@@ -74,8 +74,8 @@ namespace System.Diagnostics.CodeAnalysis
         /// <summary>The syntax identifier for strings containing URIs.</summary>
         public const string Uri = nameof(Uri);
 
-        /// <summary>The syntax identifier for strings containing VisualBasic code.</summary>
-        public const string VisualBasic = "VB.NET";
+        /// <summary>The syntax identifier for strings containing Visual Basic code.</summary>
+        public const string VisualBasic = "Visual Basic";
 
         /// <summary>The syntax identifier for strings containing XML.</summary>
         public const string Xml = nameof(Xml);

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9096,9 +9096,11 @@ namespace System.Diagnostics.CodeAnalysis
     public sealed partial class StringSyntaxAttribute : System.Attribute
     {
         public const string CompositeFormat = "CompositeFormat";
+        public const string CSharp = "C#";
         public const string DateOnlyFormat = "DateOnlyFormat";
         public const string DateTimeFormat = "DateTimeFormat";
         public const string EnumFormat = "EnumFormat";
+        public const string FSharp = "F#";
         public const string GuidFormat = "GuidFormat";
         public const string Json = "Json";
         public const string NumericFormat = "NumericFormat";
@@ -9106,10 +9108,8 @@ namespace System.Diagnostics.CodeAnalysis
         public const string TimeOnlyFormat = "TimeOnlyFormat";
         public const string TimeSpanFormat = "TimeSpanFormat";
         public const string Uri = "Uri";
-        public const string Xml = "Xml";
-        public const string CSharp = "C#";
-        public const string FSharp = "F#";
         public const string VisualBasic = "VB.NET";
+        public const string Xml = "Xml";
         public StringSyntaxAttribute(string syntax) { }
         public StringSyntaxAttribute(string syntax, params object?[] arguments) { }
         public object?[] Arguments { get { throw null; } }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9108,7 +9108,7 @@ namespace System.Diagnostics.CodeAnalysis
         public const string TimeOnlyFormat = "TimeOnlyFormat";
         public const string TimeSpanFormat = "TimeSpanFormat";
         public const string Uri = "Uri";
-        public const string VisualBasic = "VB.NET";
+        public const string VisualBasic = "Visual Basic";
         public const string Xml = "Xml";
         public StringSyntaxAttribute(string syntax) { }
         public StringSyntaxAttribute(string syntax, params object?[] arguments) { }

--- a/src/libraries/System.Runtime/ref/System.Runtime.cs
+++ b/src/libraries/System.Runtime/ref/System.Runtime.cs
@@ -9107,6 +9107,9 @@ namespace System.Diagnostics.CodeAnalysis
         public const string TimeSpanFormat = "TimeSpanFormat";
         public const string Uri = "Uri";
         public const string Xml = "Xml";
+        public const string CSharp = "C#";
+        public const string FSharp = "F#";
+        public const string VisualBasic = "VB.NET";
         public StringSyntaxAttribute(string syntax) { }
         public StringSyntaxAttribute(string syntax, params object?[] arguments) { }
         public object?[] Arguments { get { throw null; } }

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Diagnostics/CodeAnalysis/StringSyntaxAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Diagnostics/CodeAnalysis/StringSyntaxAttributeTests.cs
@@ -8,11 +8,11 @@ namespace System.Diagnostics.CodeAnalysis.Tests
     public sealed class StringSyntaxAttributeTests
     {
         [Theory]
+        [InlineData(StringSyntaxAttribute.CSharp)]
         [InlineData(StringSyntaxAttribute.DateTimeFormat)]
+        [InlineData(StringSyntaxAttribute.FSharp)]
         [InlineData(StringSyntaxAttribute.Json)]
         [InlineData(StringSyntaxAttribute.Regex)]
-        [InlineData(StringSyntaxAttribute.CSharp)]
-        [InlineData(StringSyntaxAttribute.FSharp)]
         [InlineData(StringSyntaxAttribute.VisualBasic)]
         public void Ctor_Roundtrips(string syntax)
         {

--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Diagnostics/CodeAnalysis/StringSyntaxAttributeTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Diagnostics/CodeAnalysis/StringSyntaxAttributeTests.cs
@@ -11,6 +11,9 @@ namespace System.Diagnostics.CodeAnalysis.Tests
         [InlineData(StringSyntaxAttribute.DateTimeFormat)]
         [InlineData(StringSyntaxAttribute.Json)]
         [InlineData(StringSyntaxAttribute.Regex)]
+        [InlineData(StringSyntaxAttribute.CSharp)]
+        [InlineData(StringSyntaxAttribute.FSharp)]
+        [InlineData(StringSyntaxAttribute.VisualBasic)]
         public void Ctor_Roundtrips(string syntax)
         {
             var attribute = new StringSyntaxAttribute(syntax);


### PR DESCRIPTION
Adding 3 constants that represent C#, F#, and Visual Basic to the StringSyntaxAttribute

Fix #122604