### PR TITLE
Interpreter - disable libraries tests using marshalled calli

### DIFF
--- a/src/libraries/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
@@ -108,6 +108,7 @@ namespace System.Reflection.Emit.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/2383", TestRuntimes.Mono)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/118965", typeof(CoreClrConfigurationDetection), nameof(CoreClrConfigurationDetection.IsCoreClrInterpreter))]
         public void TestEmitCalliNonBlittable()
         {
             string input = "Test string!", result = "!gnirts tseT";
@@ -142,6 +143,7 @@ namespace System.Reflection.Emit.Tests
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/118965", typeof(CoreClrConfigurationDetection), nameof(CoreClrConfigurationDetection.IsCoreClrInterpreter))]
         public void TestDynamicMethodEmitCalliNonBlittable()
         {
             string input = "Test string!", result = "!gnirts tseT";

--- a/src/libraries/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
+++ b/src/libraries/System.Reflection.Emit.ILGeneration/tests/ILGenerator/Emit4Tests.cs
@@ -108,7 +108,7 @@ namespace System.Reflection.Emit.Tests
 
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/2383", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/118965", typeof(CoreClrConfigurationDetection), nameof(CoreClrConfigurationDetection.IsCoreClrInterpreter))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/118965", typeof(PlatformDetection), nameof(PlatformDetection.IsCoreClrInterpreter))]
         public void TestEmitCalliNonBlittable()
         {
             string input = "Test string!", result = "!gnirts tseT";
@@ -143,7 +143,7 @@ namespace System.Reflection.Emit.Tests
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/118965", typeof(CoreClrConfigurationDetection), nameof(CoreClrConfigurationDetection.IsCoreClrInterpreter))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/118965", typeof(PlatformDetection), nameof(PlatformDetection.IsCoreClrInterpreter))]
         public void TestDynamicMethodEmitCalliNonBlittable()
         {
             string input = "Test string!", result = "!gnirts tseT";

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -1918,9 +1918,10 @@ public class MyType
         private static string StringReverse(string a) => string.Join("", a.Reverse());
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/118965", typeof(CoreClrConfigurationDetection), nameof(CoreClrConfigurationDetection.IsCoreClrInterpreter))]
         public void EmitCalliNonBlittable()
         {
-                string input = "Test string!", result = "!gnirts tseT";
+            string input = "Test string!", result = "!gnirts tseT";
             using (TempFile file = TempFile.Create())
             {
                 PersistedAssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyBuilder(new AssemblyName("EmitCalliNonBlittable"));

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -1918,7 +1918,7 @@ public class MyType
         private static string StringReverse(string a) => string.Join("", a.Reverse());
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/118965", typeof(CoreClrConfigurationDetection), nameof(CoreClrConfigurationDetection.IsCoreClrInterpreter))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/118965", typeof(PlatformDetection), nameof(PlatformDetection.IsCoreClrInterpreter))]
         public void EmitCalliNonBlittable()
         {
             string input = "Test string!", result = "!gnirts tseT";


### PR DESCRIPTION
Marshalled calli is not supported with the interpreter