### PR TITLE
[Startup] Bump PerfMap ahead of DiagnosticServer

### DIFF
--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -708,7 +708,6 @@ void EEStartupHelper()
 
 #ifdef FEATURE_PERFMAP
         PerfMap::Initialize();
-        InitThreadManagerPerfMapData();
 #endif
 
 #ifdef FEATURE_PERFTRACING
@@ -733,6 +732,10 @@ void EEStartupHelper()
 
 #ifdef LOGGING
         InitializeLogging();
+#endif
+
+#ifdef FEATURE_PERFMAP
+        InitThreadManagerPerfMapData();
 #endif
 
 #ifdef FEATURE_PGO

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -706,6 +706,11 @@ void EEStartupHelper()
         }
 #endif
 
+#ifdef FEATURE_PERFMAP
+        PerfMap::Initialize();
+        InitThreadManagerPerfMapData();
+#endif
+
 #ifdef FEATURE_PERFTRACING
         DiagnosticServerAdapter::Initialize();
         DiagnosticServerAdapter::PauseForDiagnosticsMonitor();
@@ -728,11 +733,6 @@ void EEStartupHelper()
 
 #ifdef LOGGING
         InitializeLogging();
-#endif
-
-#ifdef FEATURE_PERFMAP
-        PerfMap::Initialize();
-        InitThreadManagerPerfMapData();
 #endif
 
 #ifdef FEATURE_PGO


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/122472

From some inspection, it looks like `PerfMap::Initialize` does not depend on the methods right above it.
```
#ifdef FEATURE_PERFTRACING
        DiagnosticServerAdapter::Initialize();
        DiagnosticServerAdapter::PauseForDiagnosticsMonitor();
#endif // FEATURE_PERFTRACING

#ifdef FEATURE_GDBJIT
        // Initialize gdbjit
        NotifyGdb::Initialize();
#endif // FEATURE_GDBJIT

#ifdef FEATURE_EVENT_TRACE
        // Initialize event tracing early so we can trace CLR startup time events.
        InitializeEventTracing();

        // Fire the EE startup ETW event
        ETWFireEvent(EEStartupStart_V1);
#endif // FEATURE_EVENT_TRACE

        InitGSCookie();

#ifdef LOGGING
        InitializeLogging()
#endif
```
`PerfMap::Initialize` depends on `SString::Startup()` which occurs earlier in startup and some PAL/OS services.

Instead of adding more logic to handle a racing DiagnosticServer IPC [`EnablePerfMap` command](https://github.com/dotnet/diagnostics/blob/main/documentation/design-docs/ipc-protocol.md#enableperfmap) and `PerfMap::Initialize` (e.g. lazy-init/queued commands), bump the PerfMap initialization ahead of the DiagnosticServer initialization. The DiagnosticServer also doesn't depend on PerfMap being initialized afterwards, and PerfMap's `CrstStatic` and `PerfMap::Enable(type, sendExisting)` suggests that the IPC enable perfmap command should occur after `PerfMap::Initialize`.

This way, DiagnosticServer is still early in startup, and its `PerfMap::Enable` will not crash the runtime.
As for the IPC command to set environment variables, it is unlikely that it was used to `DOTNET_PerfMapEnabled` because that would either not have applied early enough or have crashed the runtime like in the issue. Instead, the `EnablePerfMap`/`DisablePerfMap` commands should be used to toggle PerfMap status.