### PR TITLE
Fix interpreter threadabort in finally

### DIFF
--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -4219,8 +4219,8 @@ do                                                                      \
 
         pInterpreterFrame->SetIsFaulting(false);
 
-        Thread *pThread = GetThread();
-        if (pThread->IsAbortRequested())
+        void* abortAddress = COMPlusCheckForAbort(resumeIP);
+        if (abortAddress != NULL)
         {
             // Record the resume IP in the pFrame so that the exception handling unwinds from there
             pFrame->ip = ip;


### PR DESCRIPTION
This fixes the
System.Runtime.Tests.ControlledExecutionTests.CancelItselfFromFinally libraries test that was failing with the interpreter. The issue was that finally block was being aborted due to the fact that instead of the complex COMPlusCheckForAbort, the interpreter was only checking if abort was requested.