### PR TITLE
Fix assertions generated by optCreateJumpTableImpliedAssertions

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5786,7 +5786,8 @@ bool Compiler::optCreateJumpTableImpliedAssertions(BasicBlock* switchBb)
             //           default: %name.Length is >= 8 here%
             //       }
             //
-            if ((value > 0) && !vnStore->IsVNConstant(opVN))
+            // NOTE: if offset != 0, we only know that "X + offset >= maxJumpIdx", which is not very useful.
+            if ((offset == 0) && (value > 0) && !vnStore->IsVNConstant(opVN))
             {
                 AssertionDsc dsc   = {};
                 dsc.assertionKind  = OAK_NOT_EQUAL;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_122254/Runtime_122254.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_122254/Runtime_122254.cs
@@ -1,0 +1,47 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_122254
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        try
+        {
+            Test(new int[0]);
+        }
+        catch (InvalidOperationException)
+        {
+            return;
+        }
+        throw new InvalidOperationException();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Test(int[] arr)
+    {
+        int block = arr.Length;
+        switch (block)
+        {
+            case 2:
+                Console.WriteLine("2");
+                break;
+            case 3:
+                Console.WriteLine("3");
+                break;
+            case 4:
+                Console.WriteLine("4");
+                break;
+            default:
+                if (block == 0)
+                {
+                    throw new InvalidOperationException();
+                }
+                break;
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/122254

bug repro:
```c
switch (X)
{
    case 2:
        // ...
        break;
    case 3:
        // ...
        break;
    case 4:
        // ...
        break;
    default:
        // "X >= 5" assertion was created here (which is incorrect, X can be 0 or 1 as well)  
        break;
}
```