### PR TITLE
[LoongArch64] Fix the failed for Fp32x2StructFunc in the profiler test slowpatheltleave.sh catched on 2K3000.

### DIFF
--- a/src/coreclr/vm/loongarch64/profiler.cpp
+++ b/src/coreclr/vm/loongarch64/profiler.cpp
@@ -293,11 +293,18 @@ LPVOID ProfileArgIterator::GetReturnBufferAddr(void)
         return (LPVOID)pData->argumentRegisters.a[0];
     }
 
-    FpStruct::Flags fpReturnSize = FpStruct::Flags(m_argIterator.GetFPReturnSize());
-
-    if (fpReturnSize != 0)
+    FpStructInRegistersInfo info = {(FpStruct::Flags)m_argIterator.GetFPReturnSize()};
+    if (info.flags != FpStruct::UseIntCallConv)
     {
-        if (fpReturnSize & (FpStruct::OnlyOne | FpStruct::BothFloat))
+        if ((info.flags & FpStruct::BothFloat) && ((info.flags & 0xF0) == 0xA0))
+        {
+            // For struct{single, single} case using the tail 16 bytes for return structure.
+            UINT32* dst = (UINT32*)&pData->buffer[sizeof(pData->buffer) - 16];
+            *dst = *(const UINT32*)&pData->floatArgumentRegisters.f[0];
+            *(dst + 1) = *(const UINT32*)(&pData->floatArgumentRegisters.f[1]);
+            return dst;
+        }
+        else if ((info.flags & FpStruct::OnlyOne) || (info.flags & FpStruct::BothFloat))
         {
             return &pData->floatArgumentRegisters.f[0];
         }
@@ -310,14 +317,14 @@ LPVOID ProfileArgIterator::GetReturnBufferAddr(void)
 
             // using the tail 16 bytes for return structure.
             UINT64* dst = (UINT64*)&pData->buffer[sizeof(pData->buffer) - 16];
-            if (fpReturnSize & FpStruct::FloatInt)
+            if (info.flags & FpStruct::FloatInt)
             {
                 *(double*)dst = pData->floatArgumentRegisters.f[0];
                 *(dst + 1) = pData->argumentRegisters.a[0];
             }
             else
             {
-                _ASSERTE(fpReturnSize & FpStruct::IntFloat);
+                _ASSERTE(info.flags & FpStruct::IntFloat);
                 *dst = pData->argumentRegisters.a[0];
                 *(double*)(dst + 1) = pData->floatArgumentRegisters.f[0];
             }


### PR DESCRIPTION
like [PR#122714](https://github.com/dotnet/runtime/pull/122714), use `pData->buffer` to return `struct{single, single}` in `ProfileArgIterator::GetReturnBufferAddr()`.