### PR TITLE
Fix Base64 decoding edge cases with small destinations and whitespace

### DIFF
--- a/src/libraries/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
+++ b/src/libraries/System.Memory/tests/Base64/Base64DecoderUnitTests.cs
@@ -875,5 +875,22 @@ namespace System.Buffers.Text.Tests
             Assert.Equal(4, written4);
             Assert.Equal(new byte[] { 1, 2, 3, 4 }, destination4);
         }
+
+        [Fact]
+        public void DecodingWithEmbeddedWhiteSpaceIntoSmallDestination_TrailingWhiteSpacesAreConsumed()
+        {
+            byte[] input = "        8J+N        i    f    C    f        jYk="u8.ToArray();
+
+            // The actual decoded data is 8 bytes long.
+            // If we provide a destination buffer with 6 bytes, we can decode two blocks (6 bytes) and leave 2 bytes undecoded.
+            // But even though there are 2 bytes left undecoded, we should still consume as much input as possible,
+            // such that all trailing whitespace are also consumed.
+
+            byte[] destination = new byte[6];
+            Assert.Equal(OperationStatus.DestinationTooSmall, Base64.DecodeFromUtf8(input, destination, out int consumed, out int written));
+            Assert.Equal((byte)'j', input[consumed]); // byte right after the spaces
+            Assert.Equal(destination.Length, written);
+            Assert.Equal(new byte[] { 240, 159, 141, 137, 240, 159 }, destination);
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64DecoderHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64DecoderHelper.cs
@@ -312,13 +312,7 @@ namespace System.Buffers.Text
 
                     // The DecodeFrom helper will return DestinationTooSmall if the destination is too small,
                     // regardless of whether it's actually too small once you skip whitespace characters.
-                    // As long as we're making progress, try to trim whitespace characters again and continue.
-                    if (status == OperationStatus.DestinationTooSmall && localConsumed == 0)
-                    {
-                        // If the input contains whitespace in the middle of the next Base64 block AND the destination is small,
-                        // the DecodeFrom helper may be unable to make forward progress. Fall back to block-wise decoding.
-                        return decoder.DecodeWithWhiteSpaceBlockwiseWrapper(decoder, source, bytes, ref bytesConsumed, ref bytesWritten, isFinalBlock);
-                    }
+                    // In that case we loop again and fall back to block-wise decoding if we can't make progress.
 
                     source = source.Slice(localConsumed);
                     bytes = bytes.Slice(localWritten);

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.cs
@@ -325,8 +325,10 @@ namespace System.Tests
                     Assert.False(success);
                     Assert.Equal(0, bytesWritten);
 
-                    Assert.Equal(OperationStatus.DestinationTooSmall, Base64.DecodeFromUtf8(Encoding.UTF8.GetBytes(encoded), actual, out _, out bytesWritten));
-                    Assert.Equal(actual.Length, bytesWritten);
+                    Assert.Equal(OperationStatus.DestinationTooSmall, Base64.DecodeFromUtf8(Encoding.UTF8.GetBytes(encoded), actual, out int bytesConsumed, out bytesWritten));
+                    Assert.Equal(actual.Length / 3 * 3, bytesWritten);
+                    Assert.InRange(bytesConsumed, Base64.GetMaxEncodedToUtf8Length(bytesWritten), encoded.Length - 1);
+                    Assert.NotEqual(' ', encoded[bytesConsumed]);
                 }
 
                 // Buffer larger than needed

--- a/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Extensions.Tests/System/Convert.cs
@@ -8,6 +8,8 @@ using System.Text;
 using System.Collections.Generic;
 
 using Test.Cryptography;
+using System.Buffers.Text;
+using System.Buffers;
 
 namespace System.Tests
 {
@@ -297,6 +299,8 @@ namespace System.Tests
                 bool success = Convert.TryFromBase64String(encoded, actual, out int bytesWritten);
                 Assert.False(success);
                 Assert.Equal(0, bytesWritten);
+
+                Assert.Equal(OperationStatus.InvalidData, Base64.DecodeFromUtf8(Encoding.UTF8.GetBytes(encoded), actual, out _, out _));
             }
             else
             {
@@ -307,6 +311,10 @@ namespace System.Tests
                     Assert.True(success);
                     Assert.Equal<byte>(expected, actual);
                     Assert.Equal(expected.Length, bytesWritten);
+
+                    Assert.Equal(OperationStatus.Done, Base64.DecodeFromUtf8(Encoding.UTF8.GetBytes(encoded), actual, out int bytesConsumed, out bytesWritten));
+                    Assert.Equal(encoded.Length, bytesConsumed);
+                    Assert.Equal(expected.Length, bytesWritten);
                 }
 
                 // Buffer too short
@@ -316,6 +324,9 @@ namespace System.Tests
                     bool success = Convert.TryFromBase64String(encoded, actual, out int bytesWritten);
                     Assert.False(success);
                     Assert.Equal(0, bytesWritten);
+
+                    Assert.Equal(OperationStatus.DestinationTooSmall, Base64.DecodeFromUtf8(Encoding.UTF8.GetBytes(encoded), actual, out _, out bytesWritten));
+                    Assert.Equal(actual.Length, bytesWritten);
                 }
 
                 // Buffer larger than needed
@@ -326,6 +337,10 @@ namespace System.Tests
                     Assert.True(success);
                     Assert.Equal(99, actual[expected.Length]);
                     Assert.Equal<byte>(expected, actual.Take(expected.Length));
+                    Assert.Equal(expected.Length, bytesWritten);
+
+                    Assert.Equal(OperationStatus.Done, Base64.DecodeFromUtf8(Encoding.UTF8.GetBytes(encoded), actual, out int bytesConsumed, out bytesWritten));
+                    Assert.Equal(encoded.Length, bytesConsumed);
                     Assert.Equal(expected.Length, bytesWritten);
                 }
             }


### PR DESCRIPTION
Fixes #123222
Fixes #123389
Replaces #123258

From `InvalidDataFallback` we'll call back into `DecodeFrom` to try and process more data.
But if the destination is too small and the next block of Base64 contains whitespace, it won't be able to make progress. Use the block-wise fallback in those cases.

Tests in #123151 now pass when including this change.