### PR TITLE
[RyuJit/WASM] Establish SP & FP and home register arguments

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2929,6 +2929,7 @@ public:
     }
 #endif
 };
+#endif // !TARGET_WASM
 
 // -----------------------------------------------------------------------------
 // genParamStackType: Get the type that a part of a parameter passed in a
@@ -2998,6 +2999,7 @@ var_types CodeGen::genParamStackType(LclVarDsc* dsc, const ABIPassingSegment& se
     }
 }
 
+#ifndef TARGET_WASM
 // -----------------------------------------------------------------------------
 // genSpillOrAddRegisterParam: Handle a register parameter either by homing it
 // to stack immediately, or by adding it to the register graph.

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5214,6 +5214,11 @@ void CodeGen::genFnProlog()
         compiler->unwindPushMaskInt(regSet.rsMaskPreSpillRegs(true));
     }
 #endif // TARGET_ARM
+#else  // TARGET_WASM
+    regNumber initReg       = REG_NA;
+    bool      initRegZeroed = false;
+    bool      isOSRx64Root  = false;
+#endif // TARGET_WASM
 
     unsigned extraFrameSize = 0;
 
@@ -5378,6 +5383,7 @@ void CodeGen::genFnProlog()
     }
 #endif // TARGET_ARM
 
+#ifndef TARGET_WASM // TODO-WASM: temporary; un-undefine as needed.
     //
     // Zero out the frame as needed
     //
@@ -5395,23 +5401,17 @@ void CodeGen::genFnProlog()
 #endif // JIT32_GCENCODER
 
     // Set up the GS security cookie
-
     genSetGSSecurityCookie(initReg, &initRegZeroed);
 
 #ifdef PROFILING_SUPPORTED
-
     // Insert a function entry callback for profiling, if requested.
     // OSR methods aren't called, so don't have enter hooks.
     if (!compiler->opts.IsOSR())
     {
         genProfilingEnterCallback(initReg, &initRegZeroed);
     }
-
 #endif // PROFILING_SUPPORTED
-#else  // TARGET_WASM
-    regNumber initReg       = REG_NA;
-    bool      initRegZeroed = false;
-#endif // TARGET_WASM
+#endif // !TARGET_WASM
 
     // For OSR we may have a zero-length prolog. That's not supported
     // when the method must report a generics context,/ so add a nop if so.


### PR DESCRIPTION
I've decided to do a bespoke function for WASM, mainly due to the awkwardness of porting the register mask code that would be of questionable value. Instead, we place an allocation constraint on the RA.

With these changes, we are very close to getting a functional "add(x, y)". The only remaining part is the SP arg, being worked on in https://github.com/dotnet/runtime/pull/123262.

This is not a fully sound implementation since we have a limit on the number of instructions in the prolog (and here we're generating a potentially unbounded number of instruction). I've put a point about this into #121865. It seems this single-IG restriction ought to be fixable...