### PR TITLE
Localization: translate "on" in ExtendedPropertyDescriptor and fix Wasm build

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/Microsoft.Extensions.Configuration.Functional.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/Microsoft.Extensions.Configuration.Functional.Tests.csproj
@@ -9,11 +9,7 @@
     <Compile Include="$(LibrariesProjectRoot)Microsoft.Extensions.Configuration\tests\Common\ConfigurationProviderExtensions.cs" Link="Common\ConfigurationProviderExtensions.cs" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Content Include="testFileToReload.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+ 
 
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.FileProviders.Abstractions\src\Microsoft.Extensions.FileProviders.Abstractions.csproj" />

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtendedPropertyDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtendedPropertyDescriptor.cs
@@ -99,7 +99,7 @@ namespace System.ComponentModel
                     string? providerName = site?.Name;
                     if (providerName != null && providerName.Length > 0)
                     {
-                        name = SR.Format(SR.UsingResourceKeys() ? "{0} on {1}" : SR.MetaExtenderName, name, providerName);
+                        name = SR.Format(SR.MetaExtenderName, name, providerName);
                     }
                 }
                 return name;


### PR DESCRIPTION
This PR addresses issue #108422 by localizing the "on" string in ExtendedPropertyDescriptor.

Additionally, it fixes a build failure (NETSDK1022) in Wasm/Browser tests caused by a duplicate content inclusion of "testFileToReload.json" in the Microsoft.Extensions.Configuration functional tests.