### PR TITLE
Add early return in TryGetLast for empty results.

### DIFF
--- a/src/libraries/System.Linq/src/System/Linq/SkipTake.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/SkipTake.SpeedOpt.cs
@@ -441,8 +441,14 @@ namespace System.Linq
             {
                 if (_source is Iterator<TSource> iterator &&
                     iterator.GetCount(onlyIfCheap: true) is int count &&
-                    count > _minIndexInclusive)
+                    count != -1)
                 {
+                    if (count <= _minIndexInclusive)
+                    {
+                        found = false;
+                        return default;
+                    }
+
                     // If there's no upper bound, or if there are fewer items in the list
                     // than the upper bound allows, just return the last element of the list.
                     // Otherwise, get the element at the upper bound.

--- a/src/libraries/System.Linq/src/System/Linq/SkipTake.SpeedOpt.cs
+++ b/src/libraries/System.Linq/src/System/Linq/SkipTake.SpeedOpt.cs
@@ -441,7 +441,7 @@ namespace System.Linq
             {
                 if (_source is Iterator<TSource> iterator &&
                     iterator.GetCount(onlyIfCheap: true) is int count &&
-                    count != -1)
+                    count >= 0)
                 {
                     if (count <= _minIndexInclusive)
                     {


### PR DESCRIPTION
### Summary

This PR adds a fast path in `IEnumerableSkipTakeIterator.TryGetLast`. When source is an Iterator and `GetCount(onlyIfCheap: true)` returns a valid count (not -1), check if count <= _minIndexInclusive. In this case, immediately return with found=false.

### Benchmark

#### 

```
| Method                    | Toolchain         | Mean     | Error    | StdDev   | Median   | Code Size | Gen0   | Allocated |
|-------------------------- |------------------ |---------:|---------:|---------:|---------:|----------:|-------:|----------:|
| LastOrDefault_PrependSkip | \main\corerun.exe | 54.05 ns | 4.295 ns | 4.774 ns | 53.12 ns |   2,616 B | 0.0180 |     152 B |
| LastOrDefault_PrependSkip | \pr\corerun.exe   | 25.75 ns | 0.948 ns | 1.014 ns | 25.67 ns |   1,777 B | 0.0181 |     152 B |
|                           |                   |          |          |          |          |           |        |           |
| LastOrDefault_AppendSkip  | \main\corerun.exe | 54.89 ns | 3.638 ns | 4.190 ns | 53.72 ns |   2,603 B | 0.0181 |     152 B |
| LastOrDefault_AppendSkip  | \pr\corerun.exe   | 25.78 ns | 1.001 ns | 1.112 ns | 25.53 ns |   1,770 B | 0.0181 |     152 B |
|                           |                   |          |          |          |          |           |        |           |
| LastOrDefault_ConcatSkip  | \main\corerun.exe | 85.73 ns | 4.710 ns | 5.424 ns | 87.06 ns |   4,306 B | 0.0255 |     216 B |
| LastOrDefault_ConcatSkip  | \pr\corerun.exe   | 41.26 ns | 2.351 ns | 2.613 ns | 40.88 ns |   2,089 B | 0.0220 |     184 B |
```

```csharp
    [MemoryDiagnoser]
    [BenchmarkCategory(Categories.Libraries, Categories.LINQ)]
    public class SkipTakeTryGetLastBenchmarks
    {
        [Benchmark]
        public int LastOrDefault_PrependSkip()
        {
            return Enumerable.Range(0, 4).Prepend(4).Skip(5).LastOrDefault();
        }

        [Benchmark]
        public int LastOrDefault_AppendSkip()
        {
            return Enumerable.Range(0, 4).Append(4).Skip(5).LastOrDefault();
        }

        [Benchmark]
        public int LastOrDefault_ConcatSkip()
        {
            return Enumerable.Range(0, 3).Concat(new []{ 3, 4 }).Skip(5).LastOrDefault();
        }
    }
```