### PR TITLE
JIT: Use GT_NULLCHECK for all unused indirections on XARC

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6823,7 +6823,7 @@ void Lowering::InsertPInvokeMethodEpilog(BasicBlock* returnBB DEBUGARG(GenTree* 
     if (comp->opts.ShouldUsePInvokeHelpers())
     {
         return;
-    }
+    } 
 
     JITDUMP("======= Inserting PInvoke method epilog\n");
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -11525,7 +11525,7 @@ void Lowering::TransformUnusedIndirection(GenTreeIndir* ind, Compiler* comp, Bas
     // So, to summarize:
     // - On ARM64, always use GT_NULLCHECK for a dead indirection.
     // - On ARM, always use GT_IND.
-    // - On XARCH, use GT_IND if we have a contained address, and GT_NULLCHECK otherwise.
+    // - On XARCH, always use GT_NULLCHECK.
     // In all cases we try to preserve the original type and never make it wider to avoid AVEs.
     // For structs we conservatively lower it to BYTE. For 8-byte primitives we lower it to TYP_INT
     // on XARCH as an optimization.
@@ -11539,7 +11539,7 @@ void Lowering::TransformUnusedIndirection(GenTreeIndir* ind, Compiler* comp, Bas
 #elif defined(TARGET_ARM)
     bool useNullCheck = false;
 #else  // TARGET_XARCH
-    bool useNullCheck = !ind->Addr()->isContained();
+    bool useNullCheck = true;
     ind->ClearDontExtend();
 #endif // !TARGET_XARCH
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -11545,6 +11545,11 @@ void Lowering::TransformUnusedIndirection(GenTreeIndir* ind, Compiler* comp, Bas
 
     if (useNullCheck && !ind->OperIs(GT_NULLCHECK))
     {
+        if (ind->Addr()->isContained())
+        {
+            ind->Addr()->clearContained();
+        }
+        
         comp->gtChangeOperToNullCheck(ind);
         ind->ClearUnusedValue();
     }


### PR DESCRIPTION
This PR optimizes unused indirections on XARCH by transforming them into null checks regardless of whether the address is contained. This matches the behavior on ARM64 and improves codegen by avoiding unnecessary register allocations.

Fixes #123302