### PR TITLE
[RuntimeAsync] Stop emitting modreqs into signatures of async variants.

### DIFF
--- a/src/coreclr/vm/asyncthunks.cpp
+++ b/src/coreclr/vm/asyncthunks.cpp
@@ -360,46 +360,6 @@ SigPointer MethodDesc::GetAsyncThunkResultTypeSig()
     return SigPointer(returnTypeSig, (DWORD)(returnTypeSigEnd - returnTypeSig));
 }
 
-bool MethodDesc::IsValueTaskAsyncThunk()
-{
-    _ASSERTE(IsAsyncThunkMethod());
-    PCCOR_SIGNATURE pSigRaw;
-    DWORD cSig;
-    if (FAILED(GetMDImport()->GetSigOfMethodDef(GetMemberDef(), &cSig, &pSigRaw)))
-    {
-        _ASSERTE(!"Loaded MethodDesc should not fail to get signature");
-        pSigRaw = NULL;
-        cSig = 0;
-    }
-
-    SigPointer pSig(pSigRaw, cSig);
-    uint32_t callConvInfo;
-    IfFailThrow(pSig.GetCallingConvInfo(&callConvInfo));
-
-    if ((callConvInfo & IMAGE_CEE_CS_CALLCONV_GENERIC) != 0)
-    {
-        // GenParamCount
-        IfFailThrow(pSig.GetData(NULL));
-    }
-
-    // ParamCount
-    IfFailThrow(pSig.GetData(NULL));
-
-    // ReturnType comes now. Skip the modifiers.
-    IfFailThrow(pSig.SkipCustomModifiers());
-
-    // here we should have something Task, ValueTask, Task<retType> or ValueTask<retType>
-    BYTE bElementType;
-    IfFailThrow(pSig.GetByte(&bElementType));
-
-    // skip ELEMENT_TYPE_GENERICINST
-    if (bElementType == ELEMENT_TYPE_GENERICINST)
-        IfFailThrow(pSig.GetByte(&bElementType));
-
-    _ASSERTE(bElementType == ELEMENT_TYPE_VALUETYPE || bElementType == ELEMENT_TYPE_CLASS);
-    return bElementType == ELEMENT_TYPE_VALUETYPE;
-}
-
 // Given a method Foo<T>, return a MethodSpec token for Foo<T> instantiated
 // with the result type from the current async method's return type. For
 // example, if "this" represents Task<List<T>> Foo<T>(), and "md" is
@@ -580,7 +540,7 @@ void MethodDesc::EmitAsyncMethodThunk(MethodDesc* pTaskReturningVariant, MetaSig
     }
 
     TypeHandle thLogicalRetType = msig.GetRetTypeHandleThrowing();
-    if (IsValueTaskAsyncThunk())
+    if (IsAsyncVariantForValueTaskReturningMethod())
     {
         MethodTable* pMTValueTask;
         int isCompletedToken;

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -89,14 +89,9 @@ enum class AsyncMethodFlags
     // the IL body belongs to one of the variants and another variant is a synthetic thunk.
     //
     // The signature of the Async variant is derived from the Task-returning signature by replacing
-    // Task return type with modreq'd element type:
-    //   Example: "Task<int> Foo();"  ===> "modreq(Task`) int Foo();"
-    //   Example: "ValueTask Bar();"  ===> "modreq(ValueTask) void Bar();"
-    //
-    // The reason for this encoding is that:
-    //   - it uses parts of original signature, as-is, thus does not need to look for or construct anything
-    //   - it "unwraps" the element type.
-    //   - it is reversible. Thus nonconflicting signatures will map to nonconflicting ones.
+    // Task return type with "element" type:
+    //   Example: "Task<int> Foo();"  ===> "int Foo();"
+    //   Example: "ValueTask Bar();"  ===> "void Bar();"
     //
     // It is possible to get from one variant to another via GetAsyncOtherVariant.
     //

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -72,8 +72,10 @@ enum class AsyncMethodFlags
     ReturnsTaskOrValueTask     = 2,
     // An AsyncCall representation of a ReturnsTaskOrValueTask method.
     IsAsyncVariant             = 4,
+    // Whether the ReturnsTaskOrValueTask counterpart is returning Task or ValueTask
+    IsAsyncVariantForValueTask = 8,
     // Method has synthetic body, which forwards to the other variant.
-    Thunk                      = 8,
+    Thunk                      = 16,
     // The rest of the methods that are not in any of the above groups.
     // Such methods are not interesting to the Runtime Async feature.
     // Note: Generic T-returning methods are classified as "None", even if T could be a Task.
@@ -1971,6 +1973,18 @@ public:
 
         AsyncMethodFlags asyncFlags = GetAddrOfAsyncMethodData()->flags;
         return hasAsyncFlags(asyncFlags, AsyncMethodFlags::IsAsyncVariant);
+    }
+
+    // Is this an Async variant method for a method that
+    // returns ValueTask or ValueTask<T> ?
+    inline bool IsAsyncVariantForValueTaskReturningMethod() const
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        if (!HasAsyncMethodData())
+            return false;
+
+        AsyncMethodFlags asyncFlags = GetAddrOfAsyncMethodData()->flags;
+        return hasAsyncFlags(asyncFlags, AsyncMethodFlags::IsAsyncVariantForValueTask);
     }
 
     // Is this a small(ish) synthetic Task/async adapter to an async/Task implementation?

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -2184,7 +2184,6 @@ private:
     void EmitTaskReturningThunk(MethodDesc* pAsyncCallVariant, MetaSig& thunkMsig, ILStubLinker* pSL);
     void EmitAsyncMethodThunk(MethodDesc* pTaskReturningVariant, MetaSig& msig, ILStubLinker* pSL);
     SigPointer GetAsyncThunkResultTypeSig();
-    bool IsValueTaskAsyncThunk();
     int GetTokenForGenericMethodCallWithAsyncReturnType(ILCodeStream* pCode, MethodDesc* md);
     int GetTokenForGenericTypeMethodCallWithAsyncReturnType(ILCodeStream* pCode, MethodDesc* md);
 public:

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -3391,9 +3391,16 @@ MethodTableBuilder::EnumerateClassMethods()
                 if (!IsMiAsync(dwImplFlags))
                     asyncFlags |= AsyncMethodFlags::Thunk;
 
+                // Here we construct the signature of async call variant given its task-returning counterpart.
+                // It is basicaly just removing the Task/ValueTask part of the return type and keeping
+                // the token for T or inserting void instead.
+                // The rest of the signature stays exactly the same.
                 ULONG tokenLen = 0;
                 if (returnKind == MethodReturnKind::NonGenericTaskReturningMethod)
                 {
+                    // from ". . . Task . . . Method(args);"        we construct
+                    //      ". . . void . . . Method(args);"
+
                     taskTokenOffsetFromAsyncDetailsOffset = 1;
                     tokenLen = CorSigUncompressedDataSize(&pMemberSignature[offsetOfAsyncDetails + taskTokenOffsetFromAsyncDetailsOffset]);
 
@@ -3404,6 +3411,9 @@ MethodTableBuilder::EnumerateClassMethods()
                 }
                 else if (returnKind == MethodReturnKind::GenericTaskReturningMethod)
                 {
+                    // from ". . . Task<tk> . . . Method(args);"    we construct
+                    //      ". . .      tk  . . . Method(args);"
+
                     taskTokenOffsetFromAsyncDetailsOffset = 2;
                     tokenLen = CorSigUncompressedDataSize(&pMemberSignature[offsetOfAsyncDetails + taskTokenOffsetFromAsyncDetailsOffset]);
 

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -3414,7 +3414,7 @@ MethodTableBuilder::EnumerateClassMethods()
                     asyncFlags |= AsyncMethodFlags::Thunk;
 
                 // Here we construct the signature of async call variant given its task-returning counterpart.
-                // It is basicaly just removing the Task/ValueTask part of the return type and keeping
+                // It is basically just removing the Task/ValueTask part of the return type and keeping
                 // the token for T or inserting void instead.
                 // The rest of the signature stays exactly the same.
                 ULONG tokenLen = 0;
@@ -3460,8 +3460,6 @@ MethodTableBuilder::EnumerateClassMethods()
                 // copy bytes after the original async prefix
                 _ASSERTE((cMemberSignature - originalRemainingSigOffset) == (cAsyncThunkMemberSignature - newRemainingSigOffset));
                 memcpy(pNewMemberSignature + newRemainingSigOffset, pMemberSignature + originalRemainingSigOffset, cMemberSignature - originalRemainingSigOffset);
-
-                BYTE elemTypeClassOrValuetype = returnsValueTask ? (BYTE)ELEMENT_TYPE_VALUETYPE : (BYTE)ELEMENT_TYPE_CLASS;
 
                 if (returnKind == MethodReturnKind::NonGenericTaskReturningMethod)
                 {

--- a/src/coreclr/vm/methodtablebuilder.h
+++ b/src/coreclr/vm/methodtablebuilder.h
@@ -653,13 +653,20 @@ private:
     };  // class bmtTypeHandle
 
     // --------------------------------------------------------------------------------------------
-    // MethodSignature encapsulates the name and metadata signature of a method, as well as
-    // the scope (Module*) and substitution for the signature. It is intended to facilitate
-    // passing around this tuple of information as well as providing efficient comparison
-    // operations when looking for types.
+    // MethodSignature encapsulates the name and metadata signature of a method, as well as the
+    // scope (Module*) substitution and optional async promise type (Task vs. ValueTask).
+    // It is intended to facilitate passing around this tuple of information as well as providing
+    // efficient comparison operations.
     //
     // Meant to be passed around by reference or by value. Please make sure this is declared
     // on the stack or properly deleted after use.
+
+    enum AsyncVariantKind
+    {
+        None      = 0,  // this is not a signature of an async variant method
+        Task      = 1,  // this is a signature of an async variant for a Task[<T>] returning method
+        ValueTask = 2   // this is a signature of an async variant for a ValueTask[<T>] returning method
+    };
 
     class MethodSignature
     {
@@ -673,6 +680,7 @@ private:
             const Substitution * pSubst)
             : m_pModule(pModule),
               m_tok(tok),
+              m_asyncVariantKind(None),
               m_szName(NULL),
               m_pSig(NULL),
               m_cSig(0),
@@ -693,10 +701,12 @@ private:
         MethodSignature(
             Module *             pModule,
             mdToken              tok,
+            bool                 isValueTaskVariant,
             Signature            sig,
             const Substitution * pSubst)
             : m_pModule(pModule),
               m_tok(tok),
+              m_asyncVariantKind(isValueTaskVariant ? AsyncVariantKind::ValueTask : AsyncVariantKind::Task),
               m_szName(NULL),
               m_pSig(sig.GetRawSig()),
               m_cSig(sig.GetRawSigLen()),
@@ -723,6 +733,7 @@ private:
             const Substitution * pSubst = NULL)
             : m_pModule(pModule),
               m_tok(mdTokenNil),
+              m_asyncVariantKind(None),
               m_szName(szName),
               m_pSig(pSig),
               m_cSig(cSig),
@@ -743,6 +754,7 @@ private:
             const MethodSignature & s)
             : m_pModule(s.m_pModule),
               m_tok(s.m_tok),
+              m_asyncVariantKind(s.m_asyncVariantKind),
               m_szName(s.m_szName),
               m_pSig(s.m_pSig),
               m_cSig(s.m_cSig),
@@ -809,6 +821,13 @@ private:
             const MethodSignature & sig2);
 
         //-----------------------------------------------------------------------------------------
+        // Returns true if the signatures have the same async variant kinds.
+        static bool
+        SameAsyncVariantKind(
+            const MethodSignature& sig1,
+            const MethodSignature& sig2);
+
+        //-----------------------------------------------------------------------------------------
         // Returns true if the metadata signatures (PCCOR_SIGNATURE) are equivalent. (Type equivalence permitted)
         static bool
         SignaturesEquivalent(
@@ -860,6 +879,7 @@ private:
         //-----------------------------------------------------------------------------------------
         Module *                m_pModule;
         mdToken                 m_tok;
+        AsyncVariantKind        m_asyncVariantKind;
         mutable LPCUTF8         m_szName;   // mutable because it is lazily evaluated.
         mutable PCCOR_SIGNATURE m_pSig;     // mutable because it is lazily evaluated.
         mutable size_t          m_cSig;     // mutable because it is lazily evaluated.


### PR DESCRIPTION
Re discussion in: https://github.com/dotnet/runtime/issues/122672#issuecomment-3692064969

The `modreq`s were a somewhat convenient remnant from the experiment, but otherwise unnecessary.

The convenient part was that async variants for `Task<int> M()` and `ValueTask<int> M()` with `modreq`s would have distinct signatures, which also would not match regular non-async methods, since we used open type in the `modreq`. (it might be possible to declare such signature in IL, but I am not sure if we would load it). 

Anyways, at this point `modreq`s are not strictly required, so with this change they will not be emitted.

That leaves the issue with signature ambiguities. 

The issue arises in various places where we match method overrides with their virtual bases, match implementing methods with interfaces, and so on. Method equality/equivalence in these areas is based on matching `MethodSignature` instances. They are roughly `{Name, Signature}` tuples with some support for generic substitution and efficient compares using memoized string hashes. 
Once we drop the `modreq`s from the signature of async variants, `{Name, Signature}` becomes potentially ambiguous, since we lose the information on:
- whether the signature is for an async variant or not 
(variants should not match with ordinary methods for overriding/implementing purposes)
- whether the variant is for a Task or ValueTask - returning methods. 
(`Task<int> M()` and `ValueTask<int> M()` can add `int M()` async variants into the same declared/lookup scope. They would need to be distinct when overriding/implementing)

To deal with the ambiguities, we keep that information by adding `AsyncVariantKind` to the `MethodSignature` as in:
```c
    enum AsyncVariantKind
    {
        None      = 0,  // this is not a signature of an async variant method
        Task      = 1,  // this is a signature of an async variant for a Task[<T>] returning method
        ValueTask = 2   // this is a signature of an async variant for a ValueTask[<T>] returning method
    };
``` 
  
The matching kind is a prerequisite for two `MethodSignature`s to be considered `Equivalent` or `ExactlyEqual` for the purpose of overriding, hiding, implementing.
