### PR TITLE
Fix authenticated proxy for dotnet restore

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/GlobalHttpSettings.cs
@@ -98,6 +98,13 @@ namespace System.Net.Http
             }
 #endif
 
+            // When enabled, send Basic proxy auth proactively on the first request without waiting
+            // for a 407 challenge. Useful for proxies that don't send 407 responses.
+            public static bool ProxyPreAuthenticate { get; } = RuntimeSettingParser.QueryRuntimeSettingSwitch(
+                "System.Net.Http.SocketsHttpHandler.ProxyPreAuthenticate",
+                "DOTNET_SYSTEM_NET_HTTP_SOCKETSHTTPHANDLER_PROXYPREAUTHENTICATE",
+                false);
+
             public static int MaxConnectionsPerServer { get; } = GetMaxConnectionsPerServer();
 
             private static int GetMaxConnectionsPerServer()

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
@@ -212,29 +212,44 @@ namespace System.Net.Http
 
         private static async ValueTask<HttpResponseMessage> SendWithAuthAsync(HttpRequestMessage request, Uri authUri, bool async, ICredentials credentials, bool preAuthenticate, bool isProxyAuth, bool doRequestAuth, HttpConnectionPool pool, CancellationToken cancellationToken)
         {
-            // If preauth is enabled and this isn't proxy auth, try to get a basic credential from the
-            // preauth credentials cache, and if successful, set an auth header for it onto the request.
+            // If preauth is enabled, try to set a Basic auth header proactively on the first request.
             // Currently we only support preauth for Basic.
             NetworkCredential? preAuthCredential = null;
             Uri? preAuthCredentialUri = null;
             if (preAuthenticate)
             {
-                Debug.Assert(pool.PreAuthCredentials != null);
-                (Uri uriPrefix, NetworkCredential credential)? preAuthCredentialPair;
-                lock (pool.PreAuthCredentials)
+                if (isProxyAuth)
                 {
-                    // Just look for basic credentials.  If in the future we support preauth
-                    // for other schemes, this will need to search in order of precedence.
-                    Debug.Assert(pool.PreAuthCredentials.GetCredential(authUri, NegotiateScheme) == null);
-                    Debug.Assert(pool.PreAuthCredentials.GetCredential(authUri, NtlmScheme) == null);
-                    Debug.Assert(pool.PreAuthCredentials.GetCredential(authUri, DigestScheme) == null);
-                    preAuthCredentialPair = pool.PreAuthCredentials.GetCredential(authUri, BasicScheme);
+                    // For proxy pre-authentication, get Basic credentials directly from the
+                    // supplied proxy credentials. This is needed for proxies that don't send 407
+                    // challenges but instead drop or reject unauthenticated connections.
+                    NetworkCredential? credential = credentials.GetCredential(authUri, BasicScheme);
+                    if (credential != null && credential != CredentialCache.DefaultNetworkCredentials)
+                    {
+                        preAuthCredential = credential;
+                        SetBasicAuthToken(request, credential, isProxyAuth: true);
+                    }
                 }
-
-                if (preAuthCredentialPair != null)
+                else
                 {
-                    (preAuthCredentialUri, preAuthCredential) = preAuthCredentialPair.Value;
-                    SetBasicAuthToken(request, preAuthCredential, isProxyAuth);
+                    // For request pre-authentication, look up credentials from the preauth cache.
+                    Debug.Assert(pool.PreAuthCredentials != null);
+                    (Uri uriPrefix, NetworkCredential credential)? preAuthCredentialPair;
+                    lock (pool.PreAuthCredentials)
+                    {
+                        // Just look for basic credentials.  If in the future we support preauth
+                        // for other schemes, this will need to search in order of precedence.
+                        Debug.Assert(pool.PreAuthCredentials.GetCredential(authUri, NegotiateScheme) == null);
+                        Debug.Assert(pool.PreAuthCredentials.GetCredential(authUri, NtlmScheme) == null);
+                        Debug.Assert(pool.PreAuthCredentials.GetCredential(authUri, DigestScheme) == null);
+                        preAuthCredentialPair = pool.PreAuthCredentials.GetCredential(authUri, BasicScheme);
+                    }
+
+                    if (preAuthCredentialPair != null)
+                    {
+                        (preAuthCredentialUri, preAuthCredential) = preAuthCredentialPair.Value;
+                        SetBasicAuthToken(request, preAuthCredential, isProxyAuth);
+                    }
                 }
             }
 
@@ -299,7 +314,7 @@ namespace System.Net.Http
                         SetBasicAuthToken(request, challenge.Credential, isProxyAuth);
                         response = await InnerSendAsync(request, async, isProxyAuth, doRequestAuth, pool, cancellationToken).ConfigureAwait(false);
 
-                        if (preAuthenticate)
+                        if (preAuthenticate && !isProxyAuth)
                         {
                             switch (response.StatusCode)
                             {
@@ -359,19 +374,7 @@ namespace System.Net.Http
 
         public static ValueTask<HttpResponseMessage> SendWithProxyAuthAsync(HttpRequestMessage request, Uri proxyUri, bool async, ICredentials proxyCredentials, bool doRequestAuth, HttpConnectionPool pool, CancellationToken cancellationToken)
         {
-            // When enabled via AppContext switch or environment variable, send Basic auth proactively
-            // on the first request. This is needed for proxies that don't send 407 challenges but instead
-            // drop or reject unauthenticated connections (e.g., some HTTPS CONNECT tunnel proxies).
-            if (GlobalHttpSettings.SocketsHttpHandler.ProxyPreAuthenticate)
-            {
-                NetworkCredential? credential = proxyCredentials.GetCredential(proxyUri, BasicScheme);
-                if (credential != null && credential != CredentialCache.DefaultNetworkCredentials)
-                {
-                    SetBasicAuthToken(request, credential, isProxyAuth: true);
-                }
-            }
-
-            return SendWithAuthAsync(request, proxyUri, async, proxyCredentials, preAuthenticate: false, isProxyAuth: true, doRequestAuth, pool, cancellationToken);
+            return SendWithAuthAsync(request, proxyUri, async, proxyCredentials, preAuthenticate: GlobalHttpSettings.SocketsHttpHandler.ProxyPreAuthenticate, isProxyAuth: true, doRequestAuth, pool, cancellationToken);
         }
 
         public static ValueTask<HttpResponseMessage> SendWithRequestAuthAsync(HttpRequestMessage request, bool async, ICredentials credentials, bool preAuthenticate, HttpConnectionPool pool, CancellationToken cancellationToken)

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.cs
@@ -17,38 +17,6 @@ namespace System.Net.Http
         private const string NtlmScheme = "NTLM";
         private const string NegotiateScheme = "Negotiate";
 
-        private const string EnableProactiveProxyAuthCtxSwitch = "System.Net.Http.EnableProactiveProxyAuth";
-        private const string EnableProactiveProxyAuthEnvironmentVariable = "DOTNET_SYSTEM_NET_HTTP_ENABLEPROACTIVEPROXYAUTH";
-
-        private static volatile int s_enableProactiveProxyAuth = -1;
-
-        private static bool EnableProactiveProxyAuth
-        {
-            get
-            {
-                int enableProactiveProxyAuth = s_enableProactiveProxyAuth;
-                if (enableProactiveProxyAuth != -1)
-                {
-                    return enableProactiveProxyAuth != 0;
-                }
-
-                // First check for the AppContext switch, giving it priority over the environment variable.
-                if (AppContext.TryGetSwitch(EnableProactiveProxyAuthCtxSwitch, out bool value))
-                {
-                    s_enableProactiveProxyAuth = value ? 1 : 0;
-                }
-                else
-                {
-                    // AppContext switch wasn't used. Check the environment variable.
-                    s_enableProactiveProxyAuth =
-                        Environment.GetEnvironmentVariable(EnableProactiveProxyAuthEnvironmentVariable) is string envVar &&
-                        (envVar == "1" || envVar.Equals("true", StringComparison.OrdinalIgnoreCase)) ? 1 : 0;
-                }
-
-                return s_enableProactiveProxyAuth != 0;
-            }
-        }
-
         private enum AuthenticationType
         {
             Basic,
@@ -394,7 +362,7 @@ namespace System.Net.Http
             // When enabled via AppContext switch or environment variable, send Basic auth proactively
             // on the first request. This is needed for proxies that don't send 407 challenges but instead
             // drop or reject unauthenticated connections (e.g., some HTTPS CONNECT tunnel proxies).
-            if (EnableProactiveProxyAuth)
+            if (GlobalHttpSettings.SocketsHttpHandler.ProxyPreAuthenticate)
             {
                 NetworkCredential? credential = proxyCredentials.GetCredential(proxyUri, BasicScheme);
                 if (credential != null && credential != CredentialCache.DefaultNetworkCredentials)

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ProactiveProxyAuth.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.ProactiveProxyAuth.cs
@@ -1,0 +1,156 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Test.Common;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public abstract class ProactiveProxyAuthTest : HttpClientHandlerTestBase
+    {
+        public ProactiveProxyAuthTest(ITestOutputHelper helper) : base(helper) { }
+
+        /// <summary>
+        /// Tests that when proxy credentials are provided, the Proxy-Authorization header
+        /// is sent proactively on the first request without waiting for a 407 challenge.
+        /// This is important for proxies that don't send 407 responses but instead
+        /// drop or reject unauthenticated connections.
+        /// </summary>
+        [Fact]
+        public async Task ProxyAuth_CredentialsProvided_SentProactivelyOnFirstRequest()
+        {
+            const string username = "testuser";
+            const string password = "testpassword";
+
+            // Create a proxy server that does NOT require authentication (AuthenticationSchemes.None)
+            // This allows us to verify that credentials are sent proactively even without a 407 challenge
+            using LoopbackProxyServer proxyServer = LoopbackProxyServer.Create();
+
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using HttpClientHandler handler = CreateHttpClientHandler();
+                    handler.Proxy = new WebProxy(proxyServer.Uri)
+                    {
+                        Credentials = new NetworkCredential(username, password)
+                    };
+
+                    using HttpClient client = CreateHttpClient(handler);
+
+                    // Make a request - credentials should be sent proactively
+                    HttpRequestMessage request = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true);
+                    using HttpResponseMessage response = await client.SendAsync(TestAsync, request);
+
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                    // Verify that the proxy received the Proxy-Authorization header on the first request
+                    Assert.Single(proxyServer.Requests);
+                    var proxyRequest = proxyServer.Requests[0];
+                    Assert.Equal("Basic", proxyRequest.AuthorizationHeaderValueScheme);
+                    Assert.NotNull(proxyRequest.AuthorizationHeaderValueToken);
+
+                    // Verify the credentials are correct (Base64 encoded "testuser:testpassword")
+                    string expectedToken = Convert.ToBase64String(
+                        System.Text.Encoding.UTF8.GetBytes($"{username}:{password}"));
+                    Assert.Equal(expectedToken, proxyRequest.AuthorizationHeaderValueToken);
+                },
+                async server =>
+                {
+                    await server.HandleRequestAsync(content: "Success");
+                });
+        }
+
+        /// <summary>
+        /// Tests that proactive proxy auth works for HTTPS CONNECT tunnels.
+        /// </summary>
+        [Fact]
+        public async Task ProxyAuth_HttpsConnect_CredentialsSentProactively()
+        {
+            const string username = "tunneluser";
+            const string password = "tunnelpass";
+
+            using LoopbackProxyServer proxyServer = LoopbackProxyServer.Create();
+
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using HttpClientHandler handler = CreateHttpClientHandler(allowAllCertificates: true);
+                    handler.Proxy = new WebProxy(proxyServer.Uri)
+                    {
+                        Credentials = new NetworkCredential(username, password)
+                    };
+
+                    using HttpClient client = CreateHttpClient(handler);
+
+                    HttpRequestMessage request = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true);
+                    using HttpResponseMessage response = await client.SendAsync(TestAsync, request);
+
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                    // For HTTPS, the proxy receives a CONNECT request
+                    Assert.True(proxyServer.Requests.Count >= 1);
+                    var connectRequest = proxyServer.Requests[0];
+
+                    // Verify CONNECT request has proactive auth
+                    Assert.Equal("Basic", connectRequest.AuthorizationHeaderValueScheme);
+                    Assert.NotNull(connectRequest.AuthorizationHeaderValueToken);
+                },
+                async server =>
+                {
+                    await server.HandleRequestAsync(content: "Secure Success");
+                },
+                options: new GenericLoopbackOptions { UseSsl = true });
+        }
+
+        /// <summary>
+        /// Tests that DefaultNetworkCredentials are NOT sent proactively
+        /// (they are only for NTLM/Negotiate which require challenge-response).
+        /// </summary>
+        [Fact]
+        public async Task ProxyAuth_DefaultCredentials_NotSentProactively()
+        {
+            using LoopbackProxyServer proxyServer = LoopbackProxyServer.Create();
+
+            await LoopbackServerFactory.CreateClientAndServerAsync(
+                async uri =>
+                {
+                    using HttpClientHandler handler = CreateHttpClientHandler();
+                    handler.Proxy = new WebProxy(proxyServer.Uri)
+                    {
+                        Credentials = CredentialCache.DefaultNetworkCredentials
+                    };
+
+                    using HttpClient client = CreateHttpClient(handler);
+
+                    HttpRequestMessage request = CreateRequest(HttpMethod.Get, uri, UseVersion, exactVersion: true);
+                    using HttpResponseMessage response = await client.SendAsync(TestAsync, request);
+
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                    // DefaultNetworkCredentials should NOT result in proactive Basic auth
+                    Assert.Single(proxyServer.Requests);
+                    var proxyRequest = proxyServer.Requests[0];
+                    Assert.Null(proxyRequest.AuthorizationHeaderValueScheme);
+                },
+                async server =>
+                {
+                    await server.HandleRequestAsync(content: "Success");
+                });
+        }
+    }
+
+    public sealed class ProactiveProxyAuthTest_Http11 : ProactiveProxyAuthTest
+    {
+        public ProactiveProxyAuthTest_Http11(ITestOutputHelper helper) : base(helper) { }
+        protected override Version UseVersion => HttpVersion.Version11;
+    }
+
+    [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.SupportsAlpn))]
+    public sealed class ProactiveProxyAuthTest_Http2 : ProactiveProxyAuthTest
+    {
+        public ProactiveProxyAuthTest_Http2(ITestOutputHelper helper) : base(helper) { }
+        protected override Version UseVersion => HttpVersion.Version20;
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/runtime/issues/123363

Many proxies require the Proxy-Authorization header on the first request rather than sending a 407 Proxy Authentication Required response. This is especially common for:

1. Proxies that drop/ignore unauthenticated connections
2. HTTPS CONNECT tunnels where connection reuse isn't possible
3. Environment variable proxies (HTTP_PROXY/HTTPS_PROXY) with embedded credentials (http://user:password@proxy:port)

This change modifies SendWithProxyAuthAsync to proactively send Basic authentication when credentials are available from the ICredentials provider, rather than waiting for a 407 challenge that may never come.

The reactive authentication flow is still preserved for cases where the proxy does send a 407 response with different auth scheme requirements (Digest, NTLM, Negotiate).