### PR TITLE
[NativeAOT] Source to native mapping fix for out-of-order code

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/DependencyAnalysis/MethodCodeNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/Compiler/DependencyAnalysis/MethodCodeNode.cs
@@ -260,9 +260,10 @@ namespace ILCompiler.DependencyAnalysis
             if (_debugLocInfos == null)
                 yield break;
 
-            var sequencePoints = new (string Document, int LineNumber)[_debugLocInfos.Length * 4 /* chosen empirically */];
+            var sequencePoints = new (string Document, int LineNumber, bool IsBackedSequencePoint)[_debugLocInfos.Length * 4 /* chosen empirically */];
             try
             {
+                int maxOffset = 0;
                 foreach (var sequencePoint in _debugInfo.GetSequencePoints())
                 {
                     int offset = sequencePoint.Offset;
@@ -271,8 +272,19 @@ namespace ILCompiler.DependencyAnalysis
                         int newLength = Math.Max(2 * sequencePoints.Length, sequencePoint.Offset + 1);
                         Array.Resize(ref sequencePoints, newLength);
                     }
-                    sequencePoints[offset] = (sequencePoint.Document, sequencePoint.LineNumber);
+                    sequencePoints[offset] = (sequencePoint.Document, sequencePoint.LineNumber, true);
+                    maxOffset = Math.Max(maxOffset, offset);
                 }
+
+                for (int i = 1; i <= maxOffset; i++)
+                {
+                    if (sequencePoints[i].Document == null && sequencePoints[i - 1].Document != null)
+                    {
+                        sequencePoints[i] = (sequencePoints[i - 1].Document, sequencePoints[i - 1].LineNumber, false);
+                    }
+                }
+
+
             }
             catch (BadImageFormatException)
             {
@@ -283,6 +295,7 @@ namespace ILCompiler.DependencyAnalysis
             }
 
             int previousNativeOffset = -1;
+            int previousIlOffset = -1;
             foreach (var nativeMapping in _debugLocInfos)
             {
                 if (nativeMapping.NativeOffset == previousNativeOffset)
@@ -291,13 +304,15 @@ namespace ILCompiler.DependencyAnalysis
                 if (nativeMapping.ILOffset < sequencePoints.Length)
                 {
                     var sequencePoint = sequencePoints[nativeMapping.ILOffset];
-                    if (sequencePoint.Document != null)
+                    if ((sequencePoint.IsBackedSequencePoint || nativeMapping.ILOffset < previousIlOffset) &&
+                        sequencePoint.Document != null)
                     {
                         yield return new NativeSequencePoint(
                             nativeMapping.NativeOffset,
                             sequencePoint.Document,
                             sequencePoint.LineNumber);
                         previousNativeOffset = nativeMapping.NativeOffset;
+                        previousIlOffset = nativeMapping.ILOffset;
                     }
                 }
             }


### PR DESCRIPTION
Sometimes code is placed at a higher native offset than the code at IL offsets adjacent to it. Our debugger algorithm deals with this by, during traversal of mappings, [setting the IL offset back](https://github.com/dotnet/runtime/blob/6afecd4adc64210e5b46767d02a6495af1a08c46/src/coreclr/vm/debugdebugger.cpp#L1321) if one is encountered that is lower than the current IL offset in the traversal. Native AOT does not have this mechanism, which leads to such code being misattributed to higher-than-actual source lines.

This change reproduces this mechanism in NativeAOT by inserting a native sequence point whenever the IL offset drops below the previous offset.

Repro issue (line attribution of DoWork):

```csharp
using System.Runtime.CompilerServices;

static class Program
{
#line 53
	[MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
	public async static Task Main()
	{
		await DoWork(0);
	}
	[MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
	public async static Task BackgroundWorker1()
	{
		// await Task.Delay(10000);
		// await Task.Yield();
		throw new InvalidOperationException("BackgroundWorker1 exception.");
	}
	[MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
	public async static Task BackgroundWorker2()
	{
		await Task.Delay(10);
		Console.WriteLine("BackgroundWorker2 completed.");
	}
	[MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
	public async static Task BackgroundWorker3()
	{
		await Task.Delay(10);
		Console.WriteLine("BackgroundWorker3 completed.");
	}
	
	[MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
	static async Task DoWork(int i)
	{
		Task worker1 = BackgroundWorker1();
		Task worker2 = BackgroundWorker2();
		Task worker3 = BackgroundWorker3();
		await Task.WhenAll(worker1, worker2, worker3);
		Console.WriteLine("All background workers completed.");
	}
}
```
Config: Windows x64 Debug, .NET 11.0.100-alpha.1.25618.104, runtime-async on
<table>
  <tr>
    <th>NativeOffset</th>
    <td>0</td>
    <td>106</td>
    <td>107</td>
    <td>107</td>
    <td>116</td>
    <td>124</td>
    <td>124</td>
    <td>133</td>
    <td>141</td>
    <td>141</td>
    <td>150</td>
    <td>158</td>
    <td>169</td>
    <td>183</td>
    <td>192</td>
    <td>205</td>
    <td>222</td>
    <td>231</td>
    <td>244</td>
    <td>261</td>
    <td>270</td>
    <td>283</td>
    <td>307</td>
    <td>312</td>
    <td>357</td>
    <td>379</td>
    <td>380</td>
    <td>387</td>
    <td>392</td>
    <td>393</td>
    <td>420</td>
    <td>431</td>
    <td>867</td>
    <td>878</td>
    <td>1067</td>
    <td>1096</td>
  </tr>
  <tr>
    <th>ILOffset</th>
    <td>0</td>
    <td>0</td>
    <td>1</td>
    <td>1</td>
    <td>6</td>
    <td>7</td>
    <td>7</td>
    <td>12</td>
    <td>13</td>
    <td>13</td>
    <td>18</td>
    <td>19</td>
    <td>27</td>
    <td>30</td>
    <td>35</td>
    <td>37</td>
    <td>40</td>
    <td>45</td>
    <td>47</td>
    <td>50</td>
    <td>55</td>
    <td>57</td>
    <td>60</td>
    <td>65</td>
    <td>70</td>
    <td>75</td>
    <td>76</td>
    <td>81</td>
    <td>86</td>
    <td>87</td>
    <td>87</td>
    <td>70</td>
    <td>87</td>
    <td>70</td>
    <td>0</td>
    <td>87</td>
  </tr>
</table>

<table>
  <tr>
    <th>ILOffset</th>
    <td>0</td>
    <td>1</td>
    <td>7</td>
    <td>13</td>
    <td>19</td>
    <td>76</td>
  </tr>
  <tr>
    <th>LineNumber</th>
    <td>80</td>
    <td>81</td>
    <td>82</td>
    <td>83</td>
    <td>84</td>
    <td>85</td>
  </tr>
</table>

Before:
<table>
  <tr>
    <th>NativeOffset</th>
    <td>0</td>
    <td>106</td>
    <td>107</td>
    <td>124</td>
    <td>141</td>
    <td>158</td>
    <td>380</td>
    <td>1067</td>
  </tr>
  <tr>
    <th>LineNumber</th>
    <td>80</td>
    <td>80</td>
    <td>81</td>
    <td>82</td>
    <td>83</td>
    <td>84</td>
    <td>85</td>
    <td>80</td>
  </tr>
</table>
Notice in particular that code after native offset 431, the suspension code for DoWork, is mistakenly attributed to line 85 (Console.WriteLine).

After:
<table>
  <tr>
    <th>NativeOffset</th>
    <td>0</td>
    <td>106</td>
    <td>107</td>
    <td>124</td>
    <td>141</td>
    <td>158</td>
    <td>380</td>
    <td>431</td>
    <td>878</td>
    <td>1067</td>
  </tr>
  <tr>
    <th>LineNumber</th>
    <td>80</td>
    <td>80</td>
    <td>81</td>
    <td>82</td>
    <td>83</td>
    <td>84</td>
    <td>85</td>
    <td>84</td>
    <td>84</td>
    <td>80</td>
  </tr>
</table>
Here we see that 380-431 is attributed to Console.WriteLine, while the suspension code that follows is correctly attributed to the previous line of await.

[aot.txt](https://github.com/user-attachments/files/24697543/aot.txt)