### PR TITLE
[browser] Fix NETSDK1022: Duplicate 'Content' items for Microsoft.Extensions.Configuration.Functional.Tests

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/Microsoft.Extensions.Configuration.Functional.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/Microsoft.Extensions.Configuration.Functional.Tests.csproj
@@ -15,7 +15,7 @@
     NETSDK1022: Duplicate 'Content' items were included. The .NET SDK includes 'Content' items from your project directory by default.
     https://github.com/dotnet/runtime/issues/123237
     -->
-    <Content Include="testFileToReload.json" Condition="!@(Content->AnyHaveMetadataValue('Identity', 'testFileToReload.json'))">
+    <Content Include="testFileToReload.json" Condition="'$(TargetsBrowser)' != 'true' ">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/Microsoft.Extensions.Configuration.Functional.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/Microsoft.Extensions.Configuration.Functional.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
+    <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/Microsoft.Extensions.Configuration.Functional.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/Microsoft.Extensions.Configuration.Functional.Tests.csproj
@@ -10,6 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- 
+    Naively adding Content would conflict with Static Web Assets on Browser target.
+    NETSDK1022: Duplicate 'Content' items were included. The .NET SDK includes 'Content' items from your project directory by default.
+    https://github.com/dotnet/runtime/issues/123237
+    -->
     <Content Include="testFileToReload.json" Condition="!@(Content->AnyHaveMetadataValue('Identity', 'testFileToReload.json'))">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/Microsoft.Extensions.Configuration.Functional.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/Microsoft.Extensions.Configuration.Functional.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <EnableDefaultItems>true</EnableDefaultItems>
-    <EnableDefaultContentItems>false</EnableDefaultContentItems>
   </PropertyGroup>
 
   <ItemGroup>
@@ -11,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="testFileToReload.json">
+    <Content Include="testFileToReload.json" Condition="!@(Content->AnyHaveMetadataValue('Identity', 'testFileToReload.json'))">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
Contributes to https://github.com/dotnet/runtime/issues/123237