### PR TITLE
JIT: Make async insertion of "rethrow BB" deterministic to fix debug info

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -2006,14 +2006,13 @@ BasicBlock* AsyncTransformation::RethrowExceptionOnResumption(BasicBlock*       
 {
     JITDUMP("  We need to rethrow an exception\n");
 
-    BasicBlock* rethrowExceptionBB =
-        m_comp->fgNewBBinRegion(BBJ_THROW, block, /* runRarely */ true, /* insertAtEnd */ true);
+    BasicBlock* rethrowExceptionBB = m_comp->fgNewBBafter(BBJ_THROW, block, /* extendRegion */ true);
+
     JITDUMP("  Created " FMT_BB " to rethrow exception on resumption\n", rethrowExceptionBB->bbNum);
 
-    // If this ends up placed after 'block' then ensure it does not break
-    // debugging. We split 'block' at the call, so a BBF_INTERNAL block after
-    // it would result in broken debug info.
-    if ((rethrowExceptionBB->Prev() == block) && !block->HasFlag(BBF_INTERNAL))
+    // We split 'block' at the call, so a BBF_INTERNAL block after it would
+    // result in broken debug info if the block came from IL.
+    if (!block->HasFlag(BBF_INTERNAL))
     {
         rethrowExceptionBB->RemoveFlags(BBF_INTERNAL);
         // Non-internal blocks must be marked imported


### PR DESCRIPTION
When an async resumption needs to rethrow an exception we use `fgNewBBinRegion` to create a basic block where the rethrow happens. This results in an internal basic block being created, and to ensure that basic block does not break debug info for surrounding code there is some compensating code that makes the block IL-imported.

It turns out this compensating code is not enough. The code assumes that `fgNewBBinRegion` inserts after a specific basic block, but for a few reasons (related to old fall-through behavior) that may not be the case. If we end up inserting the block elsewhere we still have the potential of breaking debug info.

Fix the issue by always inserting the rethrow BB after the async call that we rethrow for. The compensation code can be simplified slightly as well once we do that.

Fix #123316