### PR TITLE
Mark async reflection tests relying on stack frames as NoInlining

### DIFF
--- a/src/tests/async/reflection/reflection.cs
+++ b/src/tests/async/reflection/reflection.cs
@@ -288,6 +288,7 @@ public class Async2Reflection
     [InlineData(0)]
     [InlineData(1)]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/122547", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static void FromStack(int level)
     {
         // StackFrame.GetMethod() is not supported on NativeAOT
@@ -353,6 +354,7 @@ public class Async2Reflection
     [Theory]
     [InlineData(0)]
     [InlineData(1)]
+    [MethodImpl(MethodImplOptions.NoInlining)]
     public static void FromStackDMI(int level)
     {
         if (level == 0)


### PR DESCRIPTION
`FromStack(1)` and `FromStackDMI(1)` rely on the test entry points to not be inlined into the test executor, so ensure these are NoInlining.

Fix #123279