### PR TITLE
[Mono]: Fix stackwalk callbacks calling mono_jit_info_get_method in async signal safe mode.

### DIFF
--- a/src/mono/mono/metadata/threads.c
+++ b/src/mono/mono/metadata/threads.c
@@ -3043,7 +3043,7 @@ dump_thread (MonoInternalThread *thread, ThreadDumpUserData *ud, FILE* output_fi
 		MonoStackFrameInfo *frame = &ud->frames [i];
 		MonoMethod *method = NULL;
 
-		if (frame->type == FRAME_TYPE_MANAGED)
+		if (frame->type == FRAME_TYPE_MANAGED && frame->ji && !frame->ji->async)
 			method = mono_jit_info_get_method (frame->ji);
 
 		if (method) {

--- a/src/mono/mono/mini/mini-exceptions.c
+++ b/src/mono/mono/mini/mini-exceptions.c
@@ -598,7 +598,7 @@ mono_find_jit_info (MonoJitTlsData *jit_tls, MonoJitInfo *res, MonoJitInfo *prev
 	if (ji == (gpointer)-1)
 		return ji;
 
-	if (ji && !ji->is_trampoline)
+	if (ji && !ji->is_trampoline && !ji->async)
 		method = jinfo_get_method (ji);
 
 	if (managed2 || (method && method->wrapper_type)) {
@@ -2909,7 +2909,7 @@ print_stack_frame_signal_safe (StackFrameInfo *frame, MonoContext *ctx, gpointer
 {
 	MonoMethod *method = NULL;
 
-	if (frame->ji && frame->type != FRAME_TYPE_TRAMPOLINE)
+	if (frame->ji && frame->type != FRAME_TYPE_TRAMPOLINE && !frame->ji->async)
 		method = jinfo_get_method (frame->ji);
 
 	if (method) {


### PR DESCRIPTION
As part of https://github.com/dotnet/runtime/commit/d34ef7e2d3f41f85d35d23ec484f7af566fd0d2f a number of additional stack walking scenarios that could run as async signal safe (called from signal handlers), was flag as being async signal safe, prevents loading of full MonoJitInfo for AOT methods due to risk of deadlocks under async signal safe mode.

An AOT methods MonoJitInfo loaded when a thread runs in async signal safe mode can't be passed to mono_jit_info_get_method or it will trigger the following assert:

Assertion jit-info.c:918 (!ji->async)

There are some issues reporting this assert for .net10, like:

https://github.com/dotnet/runtime/issues/122797

After looking over the changes done in https://github.com/dotnet/runtime/commit/d34ef7e2d3f41f85d35d23ec484f7af566fd0d2f it appears that two scenarios, get_thread_dump and mono_handle_native_crash could hit scenarios where it would call mono_jit_info_get_method using MonoJitInfo loaded under async signal safe mode.

This PR fixes both these scenarios making sure they correctly check the async state of MonoJitInfo before calling mono_jit_info_get_method.

For more details, https://github.com/dotnet/runtime/issues/122797#issuecomment-3767758131.