### PR TITLE
Fix interpreting baud rate bitmask as decimal value

### DIFF
--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -1308,7 +1308,7 @@ namespace System.IO.Ports
         private static int ConvertMaxBaudBitMaskToBaudRate(int baudBitMask)
         {
             const uint BAUD_USER = 0x10000000;
-            if (baudBitMask == 0 || baudBitMask == BAUD_USER)
+            if (baudBitMask <= 0 || baudBitMask == BAUD_USER)
             {
                 return 0;
             }

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -72,7 +72,7 @@ namespace System.IO.Ports
         {
             set
             {
-                int maxBaud = ConvertBaudBitMaskToBaudRate((uint)_commProp.dwMaxBaud);
+                int maxBaud = ConvertMaxBaudBitMaskToBaudRate(_commProp.dwMaxBaud);
                 if (value <= 0 || (value > maxBaud && maxBaud > 0))
                 {
                     // if no upper bound on baud rate imposed by serial driver, note that argument must be positive
@@ -625,7 +625,7 @@ namespace System.IO.Ports
                         throw Win32Marshal.GetExceptionForWin32Error(errorCode, string.Empty);
                 }
 
-                int maxBaud = ConvertBaudBitMaskToBaudRate((uint)_commProp.dwMaxBaud);
+                int maxBaud = ConvertMaxBaudBitMaskToBaudRate(_commProp.dwMaxBaud);
                 if (maxBaud != 0 && baudRate > maxBaud)
                     throw new ArgumentOutOfRangeException(nameof(baudRate), SR.Format(SR.Max_Baud, maxBaud));
 
@@ -1560,6 +1560,7 @@ namespace System.IO.Ports
 
             asyncResult._userCallback?.Invoke(asyncResult);
         }
+
 
         // ----SECTION: internal classes --------*
 

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -1329,9 +1329,9 @@ namespace System.IO.Ports
 
             int index = BitOperations.LeadingZeroCount((uint)baudBitMask);
 
+            // bit which has not defined macro
             if (index >= bauds.Length)
             {
-                // throw new Exception("??? Unsupported baudrate bitmask");
                 return 0;
             }
 

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -1329,7 +1329,7 @@ namespace System.IO.Ports
             // i-th value corespond to (1 << i) bitmask
             ReadOnlySpan<int> bauds = [75, 110, 135, 150, 300, 600, 1200, 1800, 2400, 4800, 7200, 9600, 14400, 19200, 38400, 56000, 128000, 115200, 57600];
 
-            int index = BitOperations.LeadingZeroCount((uint)baudBitMask);
+            int index = BitOperations.TrailingZeroCount((uint)baudBitMask);
 
             // bit which has not defined macro. Rather enforce no limitation and give a try rather
             // then restricting usage of such device.

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -1537,7 +1537,8 @@ namespace System.IO.Ports
 
             if (BitOperations.PopCount(baudBitMask) != 1)
             {
-                throw new ArgumentException("??? Not a valid baud bitmask");
+                //throw new ArgumentException("??? Not a valid baud bitmask");
+                return (int)baudBitMask;
             }
 
             // https://learn.microsoft.com/windows/win32/api/winbase/ns-winbase-commprop
@@ -1548,7 +1549,8 @@ namespace System.IO.Ports
 
             if (index >= bauds.Length)
             {
-                throw new Exception("??? Unsupported baudrate bitmask");
+                // throw new Exception("??? Unsupported baudrate bitmask");
+                return 0;
             }
 
             return bauds[index];

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -1314,7 +1314,7 @@ namespace System.IO.Ports
             }
 
             // Windows passes value obtained from driver. According to docs, it should be single
-            // bit coresponding to supported max baudrate (bits up to baud 128K are defined) or
+            // bit corresponding to supported max baudrate (bits up to baud 128K are defined) or
             // BAUD_USER if device support arbitrary baudrate. But some device drivers (for example,
             // Silicon Labs USB to UART convertors) provides maximum baudrate value as decimal
             // value instead. Because no common baudrate is power of 2, we assume that when we get
@@ -1326,13 +1326,13 @@ namespace System.IO.Ports
             }
 
             // https://learn.microsoft.com/windows/win32/api/winbase/ns-winbase-commprop
-            // i-th value corespond to (1 << i) bitmask
+            // i-th value correspond to (1 << i) bitmask
             ReadOnlySpan<int> bauds = [75, 110, 135, 150, 300, 600, 1200, 1800, 2400, 4800, 7200, 9600, 14400, 19200, 38400, 56000, 128000, 115200, 57600];
 
             int index = BitOperations.TrailingZeroCount((uint)baudBitMask);
 
-            // bit which has not defined macro. Rather enforce no limitation and give a try rather
-            // then restricting usage of such device.
+            // Bit for which no macro is defined. Rather than restricting usage of such a device,
+            // enforce no limitation and give it a try.
             if (index >= bauds.Length)
             {
                 return 0;

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -1317,7 +1317,9 @@ namespace System.IO.Ports
             // bit coresponding to supported max baudrate (bits up to baud 128K are defined) or
             // BAUD_USER if device support arbitrary baudrate. But some device drivers (for example,
             // Silicon Labs USB to UART convertors) provides maximum baudrate value as decimal
-            // value instead.
+            // value instead. Because no common baudrate is power of 2, we assume that when we get
+            // single bit (power of two) it is bitmask, and if we get more bits set it is baudrate
+            // encoded as decimal.
             if (BitOperations.PopCount((uint)baudBitMask) != 1)
             {
                 return baudBitMask;
@@ -1329,7 +1331,8 @@ namespace System.IO.Ports
 
             int index = BitOperations.LeadingZeroCount((uint)baudBitMask);
 
-            // bit which has not defined macro
+            // bit which has not defined macro. Rather enforce no limitation and give a try rather
+            // then restricting usage of such device.
             if (index >= bauds.Length)
             {
                 return 0;

--- a/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
+++ b/src/libraries/System.IO.Ports/src/System/IO/Ports/SerialStream.Windows.cs
@@ -1527,6 +1527,7 @@ namespace System.IO.Ports
             asyncResult._userCallback?.Invoke(asyncResult);
         }
 
+
         private static int ConvertBaudBitMaskToBaudRate(uint baudBitMask)
         {
             const uint BAUD_USER = 0x10000000;
@@ -1535,6 +1536,10 @@ namespace System.IO.Ports
                 return 0;
             }
 
+            // Windows passes value obtained from driver. According to docs, it should be single
+            // bit coresponding to supported max baudrate (bits up to baud 128K are dfined) or
+            // BAUD_USER if device support almost arbitrary baudrate. But some device drivers
+            // provide maximum baudrate value in decimal instead.
             if (BitOperations.PopCount(baudBitMask) != 1)
             {
                 //throw new ArgumentException("??? Not a valid baud bitmask");


### PR DESCRIPTION
Intended to fix [!119105](https://github.com/dotnet/runtime/issues/119105).