### PR TITLE
Fix WASM debugger breakpoints not hitting after Terser 5.39+.

### DIFF
--- a/src/mono/browser/runtime/debug.ts
+++ b/src/mono/browser/runtime/debug.ts
@@ -34,9 +34,10 @@ export function mono_wasm_runtime_ready (): void {
 }
 
 export function mono_wasm_fire_debugger_agent_message_with_data_to_pause (base64String: string): void {
-    //keep this console.assert, otherwise optimization will remove the assignments
+    // Terser 5.39+ removes console.assert(true, ...) as "unnecessary".
+    // !!Date.now() is always true at runtime, but Terser can't evaluate it statically.
     // eslint-disable-next-line no-console
-    console.assert(true, `mono_wasm_fire_debugger_agent_message_with_data ${base64String}`);
+    console.assert(!!Date.now(), `mono_wasm_fire_debugger_agent_message_with_data ${base64String}`);
     // eslint-disable-next-line no-debugger
     debugger;
 }
@@ -163,9 +164,10 @@ export function mono_wasm_set_entrypoint_breakpoint (entrypoint_method_token: nu
     //keep these assignments, these values are used by BrowserDebugProxy
     _assembly_name_str = loaderHelpers.config.mainAssemblyName + ".dll";
     _entrypoint_method_token = entrypoint_method_token;
-    //keep this console.assert, otherwise optimization will remove the assignments
+    // Terser 5.39+ removes console.assert(true, ...) as "unnecessary".
+    // !!Date.now() is always true at runtime, but Terser can't evaluate it statically.
     // eslint-disable-next-line no-console
-    console.assert(true, `Adding an entrypoint breakpoint ${_assembly_name_str} at method token  ${_entrypoint_method_token}`);
+    console.assert(!!Date.now(), `Adding an entrypoint breakpoint ${_assembly_name_str} at method token  ${_entrypoint_method_token}`);
     // eslint-disable-next-line no-debugger
     debugger;
 


### PR DESCRIPTION
Terser 5.39 introduced an optimization that removes console.assert(true, ...) as "unnecessary" https://github.com/terser/terser/blob/master/CHANGELOG.md#v5390.

In runtime we are counting on the assert to keep `base64String`:
https://github.com/dotnet/runtime/blob/1af7e1a9b7d659fdb9e2bc7aa52197fd5d272ec6/src/mono/browser/runtime/debug.ts#L37

The assert removal caused the `base64String` to be optimized away, breaking the `BrowserDebugProxy's ` ability to read debugger agent info from the paused scope.

<img width="2725" height="204" alt="image" src="https://github.com/user-attachments/assets/a55233c9-fe3e-4c5e-99fb-36a5f02b7dba" />

This affects net11 debugging, net10 works correctly.

This PR replaces `true` with `!!Date.now()` which Terser cannot statically evaluate.