### PR TITLE
[browser][ST] Harden Stream to never call blocking .Wait()

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Stream.cs
@@ -222,6 +222,9 @@ namespace System.IO
             }
             else
             {
+#if FEATURE_SINGLE_THREADED
+                if (OperatingSystem.IsBrowser()) throw new PlatformNotSupportedException();
+#endif
 #pragma warning disable CA1416 // Validate platform compatibility, issue: https://github.com/dotnet/runtime/issues/44543
                 semaphore.Wait();
 #pragma warning restore CA1416
@@ -496,6 +499,9 @@ namespace System.IO
             }
             else
             {
+#if FEATURE_SINGLE_THREADED
+                if (OperatingSystem.IsBrowser()) throw new PlatformNotSupportedException();
+#endif
 #pragma warning disable CA1416 // Validate platform compatibility, issue: https://github.com/dotnet/runtime/issues/44543
                 semaphore.Wait(); // synchronously wait here
 #pragma warning restore CA1416


### PR DESCRIPTION
- Blocking `.Wait()` of any type is impossible to implement in single-threaded browser. 
- It's marked with `[UnsupportedOSPlatform("browser")]`
- Eventually throws `PlatformNotSupportedException`

This is attempt to throw earlier and allow IL trimmer to throw away part of the wait subsystem.
Together with https://github.com/dotnet/runtime/pull/123329 and https://github.com/dotnet/runtime/pull/123326