### PR TITLE
Use unoptimized array sort helper on iOS

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.CoreCLR.cs
@@ -23,7 +23,7 @@ namespace System.Collections.Generic
         {
             IArraySortHelper<T> defaultArraySortHelper;
 
-            if (typeof(IComparable<T>).IsAssignableFrom(typeof(T)))
+            if (RuntimeFeature.IsDynamicCodeCompiled && typeof(IComparable<T>).IsAssignableFrom(typeof(T)))
             {
                 defaultArraySortHelper = (IArraySortHelper<T>)RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(GenericArraySortHelper<string>), (RuntimeType)typeof(T));
             }
@@ -56,7 +56,7 @@ namespace System.Collections.Generic
         {
             IArraySortHelper<TKey, TValue> defaultArraySortHelper;
 
-            if (typeof(IComparable<TKey>).IsAssignableFrom(typeof(TKey)))
+            if (RuntimeFeature.IsDynamicCodeCompiled && typeof(IComparable<TKey>).IsAssignableFrom(typeof(TKey)))
             {
                 defaultArraySortHelper = (IArraySortHelper<TKey, TValue>)RuntimeTypeHandle.CreateInstanceForAnotherGenericParameter((RuntimeType)typeof(GenericArraySortHelper<string, string>), (RuntimeType)typeof(TKey), (RuntimeType)typeof(TValue));
             }


### PR DESCRIPTION
The GenericArraySortHelper<> type was inflated in reflection like fashion which made R2R unable to compile its methods. This means that all methods of this type were interpreted. This commit makes List<int>.Sort() 60x faster when running with CompositeR2R + JIT disabled.

If IsDynamicCodeCompiled is false then the expectation is that we would want to rely as much as possible on AOT code so we want to avoid patterns that are not AOT friendly. This follows the same approach that nativeaot takes in https://github.com/dotnet/runtime/blob/main/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Collections/Generic/ArraySortHelper.NativeAot.cs.