### PR TITLE
Fix typo in ifdef for Rune

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Rune.cs
@@ -1554,7 +1554,7 @@ namespace System.Text
                 return this.CompareTo(other);
             }
 
-#if SYSTEM_PRIVATE_CORLIB
+#if SYSTEM_PRIVATE_CORELIB
             throw new ArgumentException(SR.Arg_MustBeRune);
 #else
             throw new ArgumentException();


### PR DESCRIPTION
`Rune` had a typo, `SYSTEM_PRIVATE_CORLIB` instead of `SYSTEM_PRIVATE_CORELIB`. This led to the very minor issue that the ArgumentException would not use the expected exception message.

We don't typically unit test the text of exception messages, but if we want to do something we can.