### PR TITLE
Fix array size overflow in objectalloc.cpp

### DIFF
--- a/src/coreclr/jit/layout.h
+++ b/src/coreclr/jit/layout.h
@@ -44,6 +44,10 @@ public:
     void CopyNameFrom(ClassLayout* layout, const char* prefix);
 #endif
 
+    static bool               IsArrayTooLarge(Compiler*            compiler,
+                                              CORINFO_CLASS_HANDLE arrayHandle,
+                                              unsigned             length,
+                                              unsigned             maxByteSize);
     static ClassLayoutBuilder BuildArray(Compiler* compiler, CORINFO_CLASS_HANDLE arrayType, unsigned length);
 };
 

--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -1107,6 +1107,13 @@ bool ObjectAllocator::CanAllocateLclVarOnStack(unsigned int         lclNum,
             return false;
         }
 
+        // Bail out if the array is definitely too large - we don't want to even start building its layout.
+        if (ClassLayoutBuilder::IsArrayTooLarge(comp, clsHnd, (unsigned)length, m_StackAllocMaxSize))
+        {
+            *reason = "[array is too large]";
+            return false;
+        }
+
         ClassLayout* const layout = comp->typGetArrayLayout(clsHnd, (unsigned)length);
         classSize                 = layout->GetSize();
     }


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/123361

The CI probably won't be happy to run the test repro