### PR TITLE
Avoid executing unnecessary tasks when computing properties for NativeAOT.

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -120,7 +120,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <Exec Command="&quot;$(Xcrun)&quot; --sdk $(_AppleSdkName) --show-sdk-path" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(SysRoot)' == '' and '$(_IsiOSLikePlatform)' == 'true'" ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="SysRoot" />
     </Exec>
-    <Error Condition="!Exists('$(SysRoot)') and '$(_IsiOSLikePlatform)' == 'true' and '$(_SkipiOSLikePlatformValidation)' != 'true'"
+    <Error Condition="'$(_SkipiOSLikePlatformValidation)' != 'true' and '$(_IsiOSLikePlatform)' == 'true' and !Exists('$(SysRoot)')"
       Text="Apple SDK was not found in: '$(SysRoot)'" />
 
     <!--

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -111,7 +111,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_WhereXcrun>0</_WhereXcrun>
     </PropertyGroup>
 
-    <Exec Command="command -v &quot;$(Xcrun)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_IsiOSLikePlatform)' == 'true'">
+    <Exec Command="command -v &quot;$(Xcrun)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_IsiOSLikePlatform)' == 'true' And '$(SysRoot)' == ''">
       <Output TaskParameter="ExitCode" PropertyName="_WhereXcrun" />
     </Exec>
     <Error Condition="'$(_WhereXcrun)' != '0' and '$(_IsiOSLikePlatform)' == 'true'"
@@ -120,7 +120,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <Exec Command="&quot;$(Xcrun)&quot; --sdk $(_AppleSdkName) --show-sdk-path" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(SysRoot)' == '' and '$(_IsiOSLikePlatform)' == 'true'" ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="SysRoot" />
     </Exec>
-    <Error Condition="!Exists('$(SysRoot)') and '$(_IsiOSLikePlatform)' == 'true'"
+    <Error Condition="!Exists('$(SysRoot)') and '$(_IsiOSLikePlatform)' == 'true' and '$(_SkipiOSLikePlatformValidation)' != 'true'"
       Text="Apple SDK was not found in: '$(SysRoot)'" />
 
     <!--
@@ -273,7 +273,7 @@ The .NET Foundation licenses this file to you under the MIT license.
       <LinkerArg Include="-Wl,-z,max-page-size=16384" Condition=" '$(_linuxLibcFlavor)' == 'bionic' and '$(NativeLib)' == 'Shared' and ('$(_targetArchitecture)' == 'x64' or '$(_targetArchitecture)' == 'arm64')" />
     </ItemGroup>
 
-    <Exec Command="clang --version" Condition="'$(_IsApplePlatform)' == 'true'" IgnoreExitCode="true" StandardOutputImportance="Low" ConsoleToMSBuild="true">
+    <Exec Command="clang --version" Condition="'$(_IsApplePlatform)' == 'true' and '$(UseLdClassicXCodeLinker)' == ''" IgnoreExitCode="true" StandardOutputImportance="Low" ConsoleToMSBuild="true">
       <Output TaskParameter="ExitCode" PropertyName="_XcodeVersionStringExitCode" />
       <Output TaskParameter="ConsoleOutput" PropertyName="_XcodeVersionString" />
     </Exec>
@@ -291,15 +291,15 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_CommandProbe Condition="$([MSBuild]::IsOSPlatform('Windows'))">where /Q</_CommandProbe>
     </PropertyGroup>
 
-    <Exec Command="$(_CommandProbe) &quot;$(CppLinker)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low">
+    <Exec Command="$(_CommandProbe) &quot;$(CppLinker)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(NativeLib)' != 'Static'">
       <Output TaskParameter="ExitCode" PropertyName="_WhereLinker" />
     </Exec>
 
-    <Exec Command="$(_CommandProbe) &quot;$(CppCompilerAndLinkerAlternative)&quot;" Condition="'$(CppCompilerAndLinkerAlternative)' != '' and '$(_WhereLinker)' != '0'" IgnoreExitCode="true" StandardOutputImportance="Low">
+    <Exec Command="$(_CommandProbe) &quot;$(CppCompilerAndLinkerAlternative)&quot;" Condition="'$(CppCompilerAndLinkerAlternative)' != '' and '$(_WhereLinker)' != '0' and '$(NativeLib)' != 'Static'" IgnoreExitCode="true" StandardOutputImportance="Low">
       <Output TaskParameter="ExitCode" PropertyName="_WhereLinkerAlt" />
     </Exec>
 
-    <PropertyGroup Condition="'$(CppCompilerAndLinkerAlternative)' != '' and '$(_WhereLinker)' != '0' and '$(_WhereLinkerAlt)' == '0'">
+    <PropertyGroup Condition="'$(CppCompilerAndLinkerAlternative)' != '' and '$(_WhereLinker)' != '0' and '$(_WhereLinkerAlt)' == '0' and '$(NativeLib)' != 'Static'">
       <CppCompilerAndLinker>$(CppCompilerAndLinkerAlternative)</CppCompilerAndLinker>
       <CppLinker>$(CppCompilerAndLinker)</CppLinker>
       <_WhereLinker>0</_WhereLinker>
@@ -312,13 +312,13 @@ The .NET Foundation licenses this file to you under the MIT license.
       <ObjCopyNameAlternative Condition="$(CppCompilerAndLinker.Contains('clang'))">objcopy</ObjCopyNameAlternative>
     </PropertyGroup>
 
-    <Error Condition="'$(_WhereLinker)' != '0' and '$(_IsApplePlatform)' == 'true'" Text="Platform linker ('$(CppLinker)') not found in PATH. Ensure you have all the required prerequisites documented at https://aka.ms/nativeaot-prerequisites." />
-    <Error Condition="'$(_WhereLinker)' != '0' and '$(CppCompilerAndLinkerAlternative)' != ''"
+    <Error Condition="'$(_WhereLinker)' != '0' and '$(_IsApplePlatform)' == 'true' and '$(NativeLib)' != 'Static'" Text="Platform linker ('$(CppLinker)') not found in PATH. Ensure you have all the required prerequisites documented at https://aka.ms/nativeaot-prerequisites." />
+    <Error Condition="'$(_WhereLinker)' != '0' and '$(CppCompilerAndLinkerAlternative)' != '' and '$(NativeLib)' != 'Static'"
       Text="Platform linker ('$(CppLinker)' or '$(CppCompilerAndLinkerAlternative)') not found in PATH. Ensure you have all the required prerequisites documented at https://aka.ms/nativeaot-prerequisites." />
-    <Error Condition="'$(_WhereLinker)' != '0' and '$(CppCompilerAndLinkerAlternative)' == '' and '$(_IsApplePlatform)' != 'true'"
+    <Error Condition="'$(_WhereLinker)' != '0' and '$(CppCompilerAndLinkerAlternative)' == '' and '$(_IsApplePlatform)' != 'true' and '$(NativeLib)' != 'Static'"
       Text="Requested linker ('$(CppLinker)') not found in PATH." />
 
-    <Exec Command="&quot;$(CppLinker)&quot; -fuse-ld=lld -Wl,--version" Condition="'$(LinkerFlavor)' == 'lld'" StandardOutputImportance="Low" ConsoleToMSBuild="true">
+    <Exec Command="&quot;$(CppLinker)&quot; -fuse-ld=lld -Wl,--version" Condition="'$(LinkerFlavor)' == 'lld' and '$(NativeLib)' != 'Static'" StandardOutputImportance="Low" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="_LinkerVersionString" />
     </Exec>
 

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -111,16 +111,20 @@ The .NET Foundation licenses this file to you under the MIT license.
       <_WhereXcrun>0</_WhereXcrun>
     </PropertyGroup>
 
-    <Exec Command="command -v &quot;$(Xcrun)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_IsiOSLikePlatform)' == 'true' And '$(SysRoot)' == ''">
+    <PropertyGroup>
+      <_HasDefaultSysRoot Condition="'$(SysRoot)' != ''">true</_HasDefaultSysRoot>
+    </PropertyGroup>
+
+    <Exec Command="command -v &quot;$(Xcrun)&quot;" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_IsiOSLikePlatform)' == 'true' And '$(_HasDefaultSysRoot)' != 'true'">
       <Output TaskParameter="ExitCode" PropertyName="_WhereXcrun" />
     </Exec>
     <Error Condition="'$(_WhereXcrun)' != '0' and '$(_IsiOSLikePlatform)' == 'true'"
       Text="'$(Xcrun)' not found in PATH. Make sure '$(Xcrun)' is available in PATH." />
 
-    <Exec Command="&quot;$(Xcrun)&quot; --sdk $(_AppleSdkName) --show-sdk-path" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(SysRoot)' == '' and '$(_IsiOSLikePlatform)' == 'true'" ConsoleToMsBuild="true">
+    <Exec Command="&quot;$(Xcrun)&quot; --sdk $(_AppleSdkName) --show-sdk-path" IgnoreExitCode="true" StandardOutputImportance="Low" Condition="'$(_HasDefaultSysRoot)' != 'true' and '$(_IsiOSLikePlatform)' == 'true'" ConsoleToMsBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="SysRoot" />
     </Exec>
-    <Error Condition="'$(_SkipiOSLikePlatformValidation)' != 'true' and '$(_IsiOSLikePlatform)' == 'true' and !Exists('$(SysRoot)')"
+    <Error Condition="'$(_HasDefaultSysRoot)' != 'true' and '$(_IsiOSLikePlatform)' == 'true' and !Exists('$(SysRoot)')"
       Text="Apple SDK was not found in: '$(SysRoot)'" />
 
     <!--


### PR DESCRIPTION
For background: when building iOS projects on Windows, we run 'dotnet build' on the Windows machine, and then run tasks that need to run on the Mac remotely from the Windows machine using our own remoting logic. This has a few requirements/consequences:

* Any task that must run remotely must be aware of this fact. Our own tasks can be made aware, external (to the iOS SDK) tasks can't be.
* The build will fail in confusing ways if a task is executed on Windows when it shouldn't be.

For instance: without this change, building an iOS project on Windows with NativeAOT enabled, will fail because the build fails to run 'xcrun' (which obviously doesn't exist on Windows):

> Microsoft.NETCore.Native.Unix.targets(115): error: 'xcrun' not found in PATH. Make sure 'xcrun' is available in PATH.

The fix is to avoid running any tasks on Windows:

* The 'SetupOSSpecificProps' target runs 'xcrun' to compute the 'SysRoot' property, so avoid running 'xcrun' if 'SysRoot' is already set (which the iOS SDK will do; we already have this value computed).
* Add an escape hatch for validating that 'SysRoot' exists (it won't exist on Windows), by setting '_SkipiOSLikePlatformValidation=true'.
* Don't get the Xcode version if we don't need it (it's only used to decide if the classic linker should be used, but if 'UseLdClassicXCodeLinker' is already set, then we don't need to know the Xcode version because a decision has already been made).
* Don't try to find or validate the presence of a native linker if a native linker isn't needed (when 'NativeLib=Static').

As a side effect this will also make our build on macOS faster, because unnecessary tasks won't be executed.

Contributes towards https://github.com/dotnet/macios/issues/21808.