### PR TITLE
Add allocMem support for allocating multiple data chunks

### DIFF
--- a/src/coreclr/inc/corjit.h
+++ b/src/coreclr/inc/corjit.h
@@ -46,12 +46,10 @@ enum CorJitResult
 // to guide the memory allocation for the code, readonly data, and read-write data
 enum CorJitAllocMemFlag
 {
-    CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN = 0x00000000, // The code will use the normal alignment
-    CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN   = 0x00000001, // The code will be 16-byte aligned
-    CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN = 0x00000002, // The read-only data will be 16-byte aligned
-    CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN   = 0x00000004, // The code will be 32-byte aligned
-    CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN = 0x00000008, // The read-only data will be 32-byte aligned
-    CORJIT_ALLOCMEM_FLG_RODATA_64BYTE_ALIGN = 0x00000010, // The read-only data will be 64-byte aligned
+    CORJIT_ALLOCMEM_HOT_CODE = 1,
+    CORJIT_ALLOCMEM_COLD_CODE = 2,
+    CORJIT_ALLOCMEM_READONLY_DATA = 4,
+    CORJIT_ALLOCMEM_HAS_POINTERS_TO_CODE = 8,
 };
 
 inline CorJitAllocMemFlag operator |(CorJitAllocMemFlag a, CorJitAllocMemFlag b)
@@ -77,22 +75,29 @@ enum CheckedWriteBarrierKinds {
     CWBKind_AddrOfLocal,     // Store through the address of a local (arguably a bug that this happens at all).
 };
 
+struct AllocMemChunk
+{
+    // Alignment of the chunk. Different restrictions apply for different
+    // situations, and the value must generally be a power of two.
+    // - For the hot code chunk the maximal supported alignment is 32. 0 indicates default alignment.
+    // - For the cold code chunk the value must always be 0.
+    // - For read-only data chunks the max supported alignment is 64. An explicit alignment must always be requested.
+    uint32_t alignment;
+    uint32_t size;
+    CorJitAllocMemFlag flags;
+
+    // out
+    uint8_t* block;
+    uint8_t* blockRW;
+};
+
 struct AllocMemArgs
 {
-    // Input arguments
-    uint32_t hotCodeSize;
-    uint32_t coldCodeSize;
-    uint32_t roDataSize;
+    // Chunks to allocate. Supports one hot code chunk, one cold code chunk,
+    // and an arbitrary number of data chunks.
+    AllocMemChunk* chunks;
+    unsigned chunksCount;
     uint32_t xcptnsCount;
-    CorJitAllocMemFlag flag;
-
-    // Output arguments
-    void* hotCodeBlock;
-    void* hotCodeBlockRW;
-    void* coldCodeBlock;
-    void* coldCodeBlockRW;
-    void* roDataBlock;
-    void* roDataBlockRW;
 };
 
 #include "corjithost.h"

--- a/src/coreclr/inc/corjit.h
+++ b/src/coreclr/inc/corjit.h
@@ -77,11 +77,10 @@ enum CheckedWriteBarrierKinds {
 
 struct AllocMemChunk
 {
-    // Alignment of the chunk. Different restrictions apply for different types
-    // of chunks, and the value must generally be a power of two.
-    // - For the hot code chunk the maximal supported alignment is 32. 0 indicates default alignment.
-    // - For the cold code chunk the value must always be 0.
-    // - For read-only data chunks the max supported alignment is 64. An explicit alignment must always be requested.
+    // Alignment of the chunk. Must be a power of two with the following restrictions:
+    // - For the hot code chunk the max supported alignment is 32.
+    // - For the cold code chunk the value must always be 1.
+    // - For read-only data chunks the max supported alignment is 64.
     uint32_t alignment;
     uint32_t size;
     CorJitAllocMemFlag flags;

--- a/src/coreclr/inc/corjit.h
+++ b/src/coreclr/inc/corjit.h
@@ -77,8 +77,8 @@ enum CheckedWriteBarrierKinds {
 
 struct AllocMemChunk
 {
-    // Alignment of the chunk. Different restrictions apply for different
-    // situations, and the value must generally be a power of two.
+    // Alignment of the chunk. Different restrictions apply for different types
+    // of chunks, and the value must generally be a power of two.
     // - For the hot code chunk the maximal supported alignment is 32. 0 indicates default alignment.
     // - For the cold code chunk the value must always be 0.
     // - For read-only data chunks the max supported alignment is 64. An explicit alignment must always be requested.

--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -37,11 +37,11 @@
 
 #include <minipal/guid.h>
 
-constexpr GUID JITEEVersionIdentifier = { /* 976a4d6d-d1b2-4096-a3c9-46ddcae71196 */
-    0x976a4d6d,
-    0xd1b2,
-    0x4096,
-    {0xa3, 0xc9, 0x46, 0xdd, 0xca, 0xe7, 0x11, 0x96}
+constexpr GUID JITEEVersionIdentifier = { /* db46fd97-a8e8-4bda-9cec-d7feb061154c */
+    0xdb46fd97,
+    0xa8e8,
+    0x4bda,
+    {0x9c, 0xec, 0xd7, 0xfe, 0xb0, 0x61, 0x15, 0x4c}
   };
 
 #endif // JIT_EE_VERSIONING_GUID_H

--- a/src/coreclr/interpreter/eeinterp.cpp
+++ b/src/coreclr/interpreter/eeinterp.cpp
@@ -129,7 +129,7 @@ CorJitResult CILInterp::compileMethod(ICorJitInfo*         compHnd,
             uint8_t unwindInfo[8] = {0, 0, 0, 0, 0, 0, 0, 0};
 
             AllocMemChunk codeChunk {};
-            codeChunk.alignment = 0;
+            codeChunk.alignment = 1;
             codeChunk.size = sizeOfCode;
             codeChunk.flags = CORJIT_ALLOCMEM_HOT_CODE;
 

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -195,8 +195,6 @@ protected:
     unsigned  codeSize;
     void*     coldCodePtr;
     void*     coldCodePtrRW;
-    void*     consPtr;
-    void*     consPtrRW;
 
     // Last instr we have displayed for dspInstrs
     unsigned genCurDispOffset;

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -2131,7 +2131,7 @@ void CodeGen::genEmitMachineCode()
     codeSize =
         GetEmitter()->emitEndCodeGen(compiler, trackedStackPtrsContig, GetInterruptible(), IsFullPtrRegMapRequired(),
                                      compiler->compHndBBtabCount, &prologSize, &epilogSize, codePtr, &codePtrRW,
-                                     &coldCodePtr, &coldCodePtrRW, &consPtr, &consPtrRW DEBUGARG(&instrCount));
+                                     &coldCodePtr, &coldCodePtrRW DEBUGARG(&instrCount));
 
 #ifdef DEBUG
     assert(compiler->compCodeGenDone == false);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8532,7 +8532,11 @@ public:
 
     // ICorJitInfo wrappers
 
-    void eeAllocMem(AllocMemArgs* args, const UNATIVE_OFFSET roDataSectionAlignment);
+    void eeAllocMem(AllocMemChunk& codeChunk,
+                    AllocMemChunk* coldCodeChunk,
+                    AllocMemChunk* dataChunks,
+                    unsigned       numDataChunks,
+                    unsigned       numExceptions);
 
     void eeReserveUnwindInfo(bool isFunclet, bool isColdCode, ULONG unwindSize);
 

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -1173,23 +1173,15 @@ void Compiler::eeAllocMem(AllocMemChunk& codeChunk,
 
     for (unsigned i = 0; i < numDataChunks; i++)
     {
-        if ((dataChunks[i].flags & CORJIT_ALLOCMEM_HAS_POINTERS_TO_CODE) != 0)
-        {
-            // These are always passed to the EE as separate chunks since their relocations need special treatment
-            chunks.Push(dataChunks[i]);
-        }
-        else
-        {
-            // Increase size of the hot code chunk and store offset in data chunk
-            AllocMemChunk& codeChunk = chunks.BottomRef(0);
+        // Increase size of the hot code chunk and store offset in data chunk
+        AllocMemChunk& codeChunk = chunks.BottomRef(0);
 
-            codeChunk.size        = AlignUp(codeChunk.size, dataChunks[i].alignment);
-            dataChunks[i].block   = (uint8_t*)(uintptr_t)codeChunk.size;
-            dataChunks[i].blockRW = (uint8_t*)(uintptr_t)codeChunk.size;
-            codeChunk.size += dataChunks[i].size;
+        codeChunk.size        = AlignUp(codeChunk.size, dataChunks[i].alignment);
+        dataChunks[i].block   = (uint8_t*)(uintptr_t)codeChunk.size;
+        dataChunks[i].blockRW = (uint8_t*)(uintptr_t)codeChunk.size;
+        codeChunk.size += dataChunks[i].size;
 
-            codeChunk.alignment = max(codeChunk.alignment, dataChunks[i].alignment);
-        }
+        codeChunk.alignment = max(codeChunk.alignment, dataChunks[i].alignment);
     }
 
 #else

--- a/src/coreclr/jit/ee_il_dll.cpp
+++ b/src/coreclr/jit/ee_il_dll.cpp
@@ -1228,18 +1228,8 @@ void Compiler::eeAllocMem(AllocMemChunk& codeChunk,
     // Fix up data section pointers.
     for (unsigned i = 0; i < numDataChunks; i++)
     {
-        if ((dataChunks[i].flags & CORJIT_ALLOCMEM_HAS_POINTERS_TO_CODE) != 0)
-        {
-            // These are always passed to the EE as separate chunks since their relocations need special treatment
-            dataChunks[i].block   = chunks.BottomRef(curDataChunk).block;
-            dataChunks[i].blockRW = chunks.BottomRef(curDataChunk).blockRW;
-            curDataChunk++;
-        }
-        else
-        {
-            dataChunks[i].block   = codeChunk.block + (size_t)dataChunks[i].block;
-            dataChunks[i].blockRW = codeChunk.blockRW + (size_t)dataChunks[i].blockRW;
-        }
+        dataChunks[i].block   = codeChunk.block + (size_t)dataChunks[i].block;
+        dataChunks[i].blockRW = codeChunk.blockRW + (size_t)dataChunks[i].blockRW;
     }
 
 #else

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6732,10 +6732,10 @@ unsigned emitter::emitEndCodeGen(Compiler*             comp,
 
     assert(emitCurIG == nullptr);
 
-    emitCodeBlock  = nullptr;
-    emitDataChunks = nullptr;
+    emitCodeBlock        = nullptr;
+    emitDataChunks       = nullptr;
     emitDataChunkOffsets = nullptr;
-    emitNumDataChunks = 0;
+    emitNumDataChunks    = 0;
 
     emitOffsAdj = 0;
 
@@ -6887,13 +6887,12 @@ unsigned emitter::emitEndCodeGen(Compiler*             comp,
         numDataChunks++;
     }
 
-    emitDataChunks =
-        numDataChunks == 0 ? nullptr : new (emitComp, CMK_Codegen) AllocMemChunk[numDataChunks]{};
+    emitDataChunks       = numDataChunks == 0 ? nullptr : new (emitComp, CMK_Codegen) AllocMemChunk[numDataChunks]{};
     emitDataChunkOffsets = numDataChunks == 0 ? nullptr : new (emitComp, CMK_Codegen) unsigned[numDataChunks]{};
-    emitNumDataChunks = numDataChunks;
+    emitNumDataChunks    = numDataChunks;
 
-    AllocMemChunk* dataChunk = emitDataChunks;
-    unsigned* dataChunkOffset = emitDataChunkOffsets;
+    AllocMemChunk* dataChunk       = emitDataChunks;
+    unsigned*      dataChunkOffset = emitDataChunkOffsets;
 
     unsigned cumulativeOffset = 0;
     for (dataSection* sec = emitConsDsc.dsdList; sec != nullptr; sec = sec->dsNext, dataChunk++, dataChunkOffset++)

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -6827,7 +6827,7 @@ unsigned emitter::emitEndCodeGen(Compiler*             comp,
     // buffer.
 
     AllocMemChunk codeChunk = {};
-    codeChunk.alignment     = TARGET_POINTER_SIZE;
+    codeChunk.alignment     = 1;
     codeChunk.size          = emitTotalHotCodeSize;
     codeChunk.flags         = CORJIT_ALLOCMEM_HOT_CODE;
 
@@ -6874,7 +6874,7 @@ unsigned emitter::emitEndCodeGen(Compiler*             comp,
     AllocMemChunk coldCodeChunk = {};
     if (emitTotalColdCodeSize > 0)
     {
-        coldCodeChunk.alignment = 0;
+        coldCodeChunk.alignment = 1;
         coldCodeChunk.size      = emitTotalColdCodeSize;
         coldCodeChunk.flags     = CORJIT_ALLOCMEM_COLD_CODE;
     }

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -7510,7 +7510,7 @@ unsigned emitter::emitEndCodeGen(Compiler*             comp,
 
     if (emitConsDsc.dsdOffs != 0)
     {
-        emitOutputDataSec(&emitConsDsc, dataChunks);
+        emitOutputDataSec(&emitConsDsc, emitDataChunks);
     }
 
     /* Make sure all GC ref variables are marked as dead */

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2621,10 +2621,10 @@ public:
     bool emitIssuing;
 #endif
 
-    BYTE*  emitCodeBlock;     // Hot code block
-    BYTE*  emitColdCodeBlock; // Cold code block
-    BYTE*  emitConsBlock;     // Read-only (constant) data block
-    size_t writeableOffset;   // Offset applied to a code address to get memory location that can be written
+    BYTE*          emitCodeBlock;     // Hot code block
+    BYTE*          emitColdCodeBlock; // Cold code block
+    AllocMemChunk* emitDataChunks;
+    size_t         writeableOffset; // Offset applied to a code address to get memory location that can be written
 
     UNATIVE_OFFSET emitTotalHotCodeSize;
     UNATIVE_OFFSET emitTotalColdCodeSize;
@@ -2662,11 +2662,7 @@ public:
         }
     }
 
-    BYTE* emitDataOffsetToPtr(UNATIVE_OFFSET offset)
-    {
-        assert(offset < emitDataSize());
-        return emitConsBlock + offset;
-    }
+    BYTE* emitDataOffsetToPtr(UNATIVE_OFFSET offset);
 
     bool emitJumpCrossHotColdBoundary(size_t srcOffset, size_t dstOffset)
     {
@@ -3551,6 +3547,7 @@ public:
         };
 
         dataSection*   dsNext;
+        UNATIVE_OFFSET dsAlignment;
         UNATIVE_OFFSET dsSize;
         sectionType    dsType;
         var_types      dsDataType;
@@ -3568,13 +3565,11 @@ public:
         dataSection*   dsdList;
         dataSection*   dsdLast;
         UNATIVE_OFFSET dsdOffs;
-        UNATIVE_OFFSET alignment; // in bytes, defaults to 4
 
         dataSecDsc()
             : dsdList(nullptr)
             , dsdLast(nullptr)
             , dsdOffs(0)
-            , alignment(4)
         {
         }
     };
@@ -3583,8 +3578,8 @@ public:
 
     dataSection* emitDataSecCur;
 
-    void emitOutputDataSec(dataSecDsc* sec, BYTE* dst);
-    void emitDispDataSec(dataSecDsc* section, BYTE* dst);
+    void emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* dataChunks);
+    void emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks);
     void emitAsyncResumeTable(unsigned numEntries, UNATIVE_OFFSET* dataOffset, dataSection** dataSection);
 
     /************************************************************************/

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -2624,6 +2624,8 @@ public:
     BYTE*          emitCodeBlock;     // Hot code block
     BYTE*          emitColdCodeBlock; // Cold code block
     AllocMemChunk* emitDataChunks;
+    unsigned*      emitDataChunkOffsets;
+    unsigned       emitNumDataChunks;
     size_t         writeableOffset; // Offset applied to a code address to get memory location that can be written
 
     UNATIVE_OFFSET emitTotalHotCodeSize;

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -6219,7 +6219,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             code = emitInsCode(ins, fmt);
             code |= insEncodeRegT2_D(id->idReg1());
             imm  = emitGetInsSC(id);
-            addr = emitConsBlock + imm;
+            addr = emitDataOffsetToPtr((UNATIVE_OFFSET)imm);
             if (!id->idIsReloc())
             {
                 assert(sizeof(size_t) == sizeof(target_size_t));

--- a/src/coreclr/jit/emitloongarch64.cpp
+++ b/src/coreclr/jit/emitloongarch64.cpp
@@ -3411,7 +3411,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             if (id->idIsReloc())
             {
                 // get the addr-offset of the data.
-                imm = (ssize_t)emitConsBlock - (ssize_t)(dstRW - writeableOffset) + dataOffs;
+                imm = (ssize_t)emitDataOffsetToPtr(dataOffs) - (ssize_t)(dstRW - writeableOffset);
                 assert(imm > 0);
                 assert(!(imm & 3));
 
@@ -3453,7 +3453,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             else
             {
                 // get the addr of the data.
-                imm = (ssize_t)emitConsBlock + dataOffs;
+                imm = (ssize_t)emitDataOffsetToPtr(dataOffs);
 
                 code = emitInsCode(INS_lu12i_w);
                 if (ins == INS_bl)

--- a/src/coreclr/jit/emitpub.h
+++ b/src/coreclr/jit/emitpub.h
@@ -22,19 +22,17 @@ void emitEndFN();
 
 void emitComputeCodeSizes();
 
-unsigned emitEndCodeGen(Compiler*         comp,
-                        bool              contTrkPtrLcls,
-                        bool              fullyInt,
-                        bool              fullPtrMap,
-                        unsigned          xcptnsCount,
-                        unsigned*         prologSize,
-                        unsigned*         epilogSize,
-                        void**            codeAddr,
-                        void**            codeAddrRW,
-                        void**            coldCodeAddr,
-                        void**            coldCodeAddrRW,
-                        void**            consAddr,
-                        void** consAddrRW DEBUGARG(unsigned* instrCount));
+unsigned emitEndCodeGen(Compiler*             comp,
+                        bool                  contTrkPtrLcls,
+                        bool                  fullyInt,
+                        bool                  fullPtrMap,
+                        unsigned              xcptnsCount,
+                        unsigned*             prologSize,
+                        unsigned*             epilogSize,
+                        void**                codeAddr,
+                        void**                codeAddrRW,
+                        void**                coldCodeAddr,
+                        void** coldCodeAddrRW DEBUGARG(unsigned* instrCount));
 
 /************************************************************************/
 /*                      Method prolog and epilog                        */
@@ -79,8 +77,6 @@ const char* emitOffsetToLabel(unsigned offs);
 /************************************************************************/
 
 UNATIVE_OFFSET emitDataGenBeg(unsigned size, unsigned alignment, var_types dataType);
-
-void emitEnsureDataSectionAlignment(unsigned alignment);
 
 UNATIVE_OFFSET emitBBTableDataGenBeg(unsigned numEntries, bool relativeAddr);
 

--- a/src/coreclr/jit/emitriscv64.cpp
+++ b/src/coreclr/jit/emitriscv64.cpp
@@ -2948,7 +2948,7 @@ BYTE* emitter::emitOutputInstr_OptsRc(BYTE* dst, const instrDesc* id, instructio
     const regNumber reg1 = id->idReg1();
     assert(reg1 != REG_ZERO);
     assert(id->idCodeSize() == 2 * sizeof(code_t));
-    const ssize_t immediate = (emitConsBlock - dst) + offset;
+    const ssize_t immediate = emitDataOffsetToPtr(offset) - dst;
     assert((immediate > 0) && ((immediate & 0x01) == 0));
     assert(isValidSimm32(immediate));
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -12683,7 +12683,7 @@ void emitter::emitDispIns(
             /* Display a data section reference */
 
             assert((unsigned)offs < emitConsDsc.dsdOffs);
-            addr = emitConsBlock ? emitConsBlock + offs : nullptr;
+            addr = emitDataOffsetToPtr((UNATIVE_OFFSET)offs);
 
 #if 0
             // TODO-XArch-Cleanup: Fix or remove this code.
@@ -15057,7 +15057,7 @@ GOT_DSP:
                 // Special case: jump through a jump table
                 if (ins == INS_i_jmp)
                 {
-                    dsp += (size_t)emitConsBlock;
+                    dsp = (ssize_t)emitDataOffsetToPtr((UNATIVE_OFFSET)dsp);
                 }
 
                 dst += emitOutputLong(dst, dsp);
@@ -16065,7 +16065,7 @@ BYTE* emitter::emitOutputCV(BYTE* dst, instrDesc* id, code_t code, CnsVal* addc)
     doff = Compiler::eeGetJitDataOffs(fldh);
     if (doff >= 0)
     {
-        addr = emitConsBlock + doff;
+        addr = emitDataOffsetToPtr((UNATIVE_OFFSET)doff);
 
 #ifdef DEBUG
         int byteSize = EA_SIZE_IN_BYTES(emitGetMemOpSize(id, /*ignoreEmbeddedBroadcast*/ false));

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -3825,17 +3825,17 @@ namespace Internal.JitInterface
 
             foreach (ref AllocMemChunk chunk in chunks)
             {
-                ref int alignmentField = ref _codeAlignment;
                 if ((chunk.flags & CorJitAllocMemFlag.CORJIT_ALLOCMEM_HOT_CODE) != 0)
                 {
                     chunk.block = (byte*)GetPin(_code = new byte[chunk.size]);
                     chunk.blockRW = chunk.block;
+                    _codeAlignment = (int)chunk.alignment;
                 }
                 else if ((chunk.flags & CorJitAllocMemFlag.CORJIT_ALLOCMEM_COLD_CODE) != 0)
                 {
                     chunk.block = (byte*)GetPin(_coldCode = new byte[chunk.size]);
                     chunk.blockRW = chunk.block;
-
+                    Debug.Assert(chunk.alignment == 1);
 #if READYTORUN
                     _methodColdCodeNode = new MethodColdCodeNode(MethodBeingCompiled);
 #endif
@@ -3844,12 +3844,7 @@ namespace Internal.JitInterface
                 {
                     roDataSize = (uint)((int)roDataSize).AlignUp((int)chunk.alignment);
                     roDataSize += chunk.size;
-                    alignmentField = ref _roDataAlignment;
-                }
-
-                if (chunk.alignment != 0)
-                {
-                    alignmentField = Math.Max(alignmentField, (int)chunk.alignment);
+                    _roDataAlignment = Math.Max(_roDataAlignment, (int)chunk.alignment);
                 }
             }
 

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -328,8 +328,11 @@ namespace Internal.JitInterface
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct AllocMemChunk
     {
-        // in
-        // Alignment can be 0 for default alignment for code chunks
+        // Alignment of the chunk. Different restrictions apply for different types
+        // of chunks, and the value must generally be a power of two.
+        // - For the hot code chunk the maximal supported alignment is 32. 0 indicates default alignment.
+        // - For the cold code chunk the value must always be 0.
+        // - For read-only data chunks the max supported alignment is 64. An explicit alignment must always be requested.
         public uint alignment;
         public uint size;
         public CorJitAllocMemFlag flags;

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -326,22 +326,25 @@ namespace Internal.JitInterface
     }
 
     [StructLayout(LayoutKind.Sequential)]
+    public unsafe struct AllocMemChunk
+    {
+        // in
+        // Alignment can be 0 for default alignment for code chunks
+        public uint alignment;
+        public uint size;
+        public CorJitAllocMemFlag flags;
+
+        // out
+        public byte* block;
+        public byte* blockRW;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
     public unsafe struct AllocMemArgs
     {
-        // Input arguments
-        public uint hotCodeSize;
-        public uint coldCodeSize;
-        public uint roDataSize;
+        public AllocMemChunk* chunks;
+        public uint chunksCount;
         public uint xcptnsCount;
-        public CorJitAllocMemFlag flag;
-
-        // Output arguments
-        public void* hotCodeBlock;
-        public void* hotCodeBlockRW;
-        public void* coldCodeBlock;
-        public void* coldCodeBlockRW;
-        public void* roDataBlock;
-        public void* roDataBlockRW;
     }
 
     // Flags computed by a runtime compiler
@@ -780,12 +783,10 @@ namespace Internal.JitInterface
     // to guide the memory allocation for the code, readonly data, and read-write data
     public enum CorJitAllocMemFlag
     {
-        CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN = 0x00000000, // The code will be use the normal alignment
-        CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN = 0x00000001, // The code will be 16-byte aligned
-        CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN = 0x00000002, // The read-only data will be 16-byte aligned
-        CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN   = 0x00000004, // The code will be 32-byte aligned
-        CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN = 0x00000008, // The read-only data will be 32-byte aligned
-        CORJIT_ALLOCMEM_FLG_RODATA_64BYTE_ALIGN = 0x00000010, // The read-only data will be 64-byte aligned
+        CORJIT_ALLOCMEM_HOT_CODE = 1,
+        CORJIT_ALLOCMEM_COLD_CODE = 2,
+        CORJIT_ALLOCMEM_READONLY_DATA = 4,
+        CORJIT_ALLOCMEM_HAS_POINTERS_TO_CODE = 8,
     }
 
     public enum CorJitFuncKind

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -328,11 +328,10 @@ namespace Internal.JitInterface
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct AllocMemChunk
     {
-        // Alignment of the chunk. Different restrictions apply for different types
-        // of chunks, and the value must generally be a power of two.
-        // - For the hot code chunk the maximal supported alignment is 32. 0 indicates default alignment.
-        // - For the cold code chunk the value must always be 0.
-        // - For read-only data chunks the max supported alignment is 64. An explicit alignment must always be requested.
+        // Alignment of the chunk. Must be a power of two with the following restrictions:
+        // - For the hot code chunk the max supported alignment is 32.
+        // - For the cold code chunk the value must always be 1.
+        // - For read-only data chunks the max supported alignment is 64.
         public uint alignment;
         public uint size;
         public CorJitAllocMemFlag flags;

--- a/src/coreclr/tools/superpmi/superpmi-shared/agnostic.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/agnostic.h
@@ -768,7 +768,6 @@ struct Capture_AllocMemDetails
     ULONG              coldCodeSize;
     ULONG              roDataSize;
     ULONG              xcptnsCount;
-    CorJitAllocMemFlag flag;
     void*              hotCodeBlock;
     void*              coldCodeBlock;
     void*              roDataBlock;
@@ -792,7 +791,6 @@ struct Agnostic_AllocMemDetails
     DWORD     coldCodeSize;
     DWORD     roDataSize;
     DWORD     xcptnsCount;
-    DWORD     flag;
     DWORD     hotCodeBlock_offset;
     DWORD     coldCodeBlock_offset;
     DWORD     roDataBlock_offset;

--- a/src/coreclr/tools/superpmi/superpmi-shared/asmdumper.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/asmdumper.cpp
@@ -28,7 +28,6 @@ void ASMDumper::DumpToFile(HANDLE hFile, MethodContext* mc, CompileResult* cr)
     ULONG              coldCodeSize;
     ULONG              roDataSize;
     ULONG              xcptnsCount;
-    CorJitAllocMemFlag flag;
     unsigned char*     hotCodeBlock;
     unsigned char*     coldCodeBlock;
     unsigned char*     roDataBlock;
@@ -36,7 +35,7 @@ void ASMDumper::DumpToFile(HANDLE hFile, MethodContext* mc, CompileResult* cr)
     void*              orig_coldCodeBlock;
     void*              orig_roDataBlock;
 
-    cr->repAllocMem(&hotCodeSize, &coldCodeSize, &roDataSize, &xcptnsCount, &flag, &hotCodeBlock, &coldCodeBlock,
+    cr->repAllocMem(&hotCodeSize, &coldCodeSize, &roDataSize, &xcptnsCount, &hotCodeBlock, &coldCodeBlock,
                     &roDataBlock, &orig_hotCodeBlock, &orig_coldCodeBlock, &orig_roDataBlock);
 
     RelocContext rc;

--- a/src/coreclr/tools/superpmi/superpmi-shared/compileresult.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/compileresult.cpp
@@ -24,7 +24,6 @@ CompileResult::CompileResult()
     allocMemDets.coldCodeSize  = 0;
     allocMemDets.roDataSize    = 0;
     allocMemDets.xcptnsCount   = 0;
-    allocMemDets.flag          = (CorJitAllocMemFlag)0;
     allocMemDets.hotCodeBlock  = nullptr;
     allocMemDets.coldCodeBlock = nullptr;
     allocMemDets.roDataBlock   = nullptr;
@@ -139,20 +138,18 @@ void CompileResult::recAllocMem(ULONG              hotCodeSize,
                                 ULONG              coldCodeSize,
                                 ULONG              roDataSize,
                                 ULONG              xcptnsCount,
-                                CorJitAllocMemFlag flag,
-                                void**             hotCodeBlock,
-                                void**             coldCodeBlock,
-                                void**             roDataBlock)
+                                void*              hotCodeBlock,
+                                void*              coldCodeBlock,
+                                void*              roDataBlock)
 {
     // Grab the values, so we can scrape the real answers in the capture method
     allocMemDets.hotCodeSize   = hotCodeSize;
     allocMemDets.coldCodeSize  = coldCodeSize;
     allocMemDets.roDataSize    = roDataSize;
     allocMemDets.xcptnsCount   = xcptnsCount;
-    allocMemDets.flag          = flag;
-    allocMemDets.hotCodeBlock  = *hotCodeBlock;
-    allocMemDets.coldCodeBlock = *coldCodeBlock;
-    allocMemDets.roDataBlock   = *roDataBlock;
+    allocMemDets.hotCodeBlock  = hotCodeBlock;
+    allocMemDets.coldCodeBlock = coldCodeBlock;
+    allocMemDets.roDataBlock   = roDataBlock;
 }
 void CompileResult::recAllocMemCapture()
 {
@@ -165,7 +162,6 @@ void CompileResult::recAllocMemCapture()
     value.coldCodeSize = (DWORD)allocMemDets.coldCodeSize;
     value.roDataSize   = (DWORD)allocMemDets.roDataSize;
     value.xcptnsCount  = (DWORD)allocMemDets.xcptnsCount;
-    value.flag         = (DWORD)allocMemDets.flag;
     value.hotCodeBlock_offset =
         (DWORD)AllocMem->AddBuffer((const unsigned char*)allocMemDets.hotCodeBlock, allocMemDets.hotCodeSize);
     value.coldCodeBlock_offset =
@@ -181,10 +177,10 @@ void CompileResult::recAllocMemCapture()
 
 void CompileResult::dmpAllocMem(DWORD key, const Agnostic_AllocMemDetails& value)
 {
-    printf("AllocMem key 0, value hotCodeSize-%u coldCodeSize-%u roDataSize-%u xcptnsCount-%u flag-%08X "
+    printf("AllocMem key 0, value hotCodeSize-%u coldCodeSize-%u roDataSize-%u xcptnsCount-%u "
            "hotCodeBlock_offset-%u coldCodeBlock_offset-%u roDataBlock_offset-%u hotCodeBlock-%016" PRIX64 " "
            "coldCodeBlock-%016" PRIX64 " roDataBlock-%016" PRIX64,
-           value.hotCodeSize, value.coldCodeSize, value.roDataSize, value.xcptnsCount, value.flag,
+           value.hotCodeSize, value.coldCodeSize, value.roDataSize, value.xcptnsCount,
            value.hotCodeBlock_offset, value.coldCodeBlock_offset, value.roDataBlock_offset, value.hotCodeBlock,
            value.coldCodeBlock, value.roDataBlock);
 }
@@ -195,7 +191,6 @@ void CompileResult::repAllocMem(ULONG*              hotCodeSize,
                                 ULONG*              coldCodeSize,
                                 ULONG*              roDataSize,
                                 ULONG*              xcptnsCount,
-                                CorJitAllocMemFlag* flag,
                                 unsigned char**     hotCodeBlock,
                                 unsigned char**     coldCodeBlock,
                                 unsigned char**     roDataBlock,
@@ -211,7 +206,6 @@ void CompileResult::repAllocMem(ULONG*              hotCodeSize,
     *coldCodeSize = (ULONG)value.coldCodeSize;
     *roDataSize   = (ULONG)value.roDataSize;
     *xcptnsCount  = (ULONG)value.xcptnsCount;
-    *flag         = (CorJitAllocMemFlag)value.flag;
 
     if (*hotCodeSize > 0)
         *hotCodeBlock = AllocMem->GetBuffer(value.hotCodeBlock_offset);

--- a/src/coreclr/tools/superpmi/superpmi-shared/compileresult.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/compileresult.h
@@ -95,17 +95,15 @@ public:
                      ULONG              coldCodeSize,
                      ULONG              roDataSize,
                      ULONG              xcptnsCount,
-                     CorJitAllocMemFlag flag,
-                     void**             hotCodeBlock,
-                     void**             coldCodeBlock,
-                     void**             roDataBlock);
+                     void*              hotCodeBlock,
+                     void*              coldCodeBlock,
+                     void*              roDataBlock);
     void recAllocMemCapture();
     void dmpAllocMem(DWORD key, const Agnostic_AllocMemDetails& value);
     void repAllocMem(ULONG*              hotCodeSize,
                      ULONG*              coldCodeSize,
                      ULONG*              roDataSize,
                      ULONG*              xcptnsCount,
-                     CorJitAllocMemFlag* flag,
                      unsigned char**     hotCodeBlock,
                      unsigned char**     coldCodeBlock,
                      unsigned char**     roDataBlock,

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/icorjitinfo.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/icorjitinfo.cpp
@@ -1835,8 +1835,6 @@ void interceptor_ICJI::allocMem(AllocMemArgs *pArgs)
 {
     mc->cr->AddCall("allocMem");
     original_ICorJitInfo->allocMem(pArgs);
-    mc->cr->recAllocMem(pArgs->hotCodeSize, pArgs->coldCodeSize, pArgs->roDataSize, pArgs->xcptnsCount, pArgs->flag, &pArgs->hotCodeBlock, &pArgs->coldCodeBlock,
-                        &pArgs->roDataBlock);
 }
 
 // Reserve memory for the method/funclet's unwind information.

--- a/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/neardiffer.cpp
@@ -1264,7 +1264,6 @@ bool NearDiffer::compare(MethodContext* mc, CompileResult* cr1, CompileResult* c
     ULONG              coldCodeSize_1;
     ULONG              roDataSize_1;
     ULONG              xcptnsCount_1;
-    CorJitAllocMemFlag flag_1;
     unsigned char*     hotCodeBlock_1;
     unsigned char*     coldCodeBlock_1;
     unsigned char*     roDataBlock_1;
@@ -1276,7 +1275,6 @@ bool NearDiffer::compare(MethodContext* mc, CompileResult* cr1, CompileResult* c
     ULONG              coldCodeSize_2;
     ULONG              roDataSize_2;
     ULONG              xcptnsCount_2;
-    CorJitAllocMemFlag flag_2;
     unsigned char*     hotCodeBlock_2;
     unsigned char*     coldCodeBlock_2;
     unsigned char*     roDataBlock_2;
@@ -1284,10 +1282,10 @@ bool NearDiffer::compare(MethodContext* mc, CompileResult* cr1, CompileResult* c
     void*              orig_coldCodeBlock_2;
     void*              orig_roDataBlock_2;
 
-    cr1->repAllocMem(&hotCodeSize_1, &coldCodeSize_1, &roDataSize_1, &xcptnsCount_1, &flag_1, &hotCodeBlock_1,
+    cr1->repAllocMem(&hotCodeSize_1, &coldCodeSize_1, &roDataSize_1, &xcptnsCount_1, &hotCodeBlock_1,
                      &coldCodeBlock_1, &roDataBlock_1, &orig_hotCodeBlock_1, &orig_coldCodeBlock_1,
                      &orig_roDataBlock_1);
-    cr2->repAllocMem(&hotCodeSize_2, &coldCodeSize_2, &roDataSize_2, &xcptnsCount_2, &flag_2, &hotCodeBlock_2,
+    cr2->repAllocMem(&hotCodeSize_2, &coldCodeSize_2, &roDataSize_2, &xcptnsCount_2, &hotCodeBlock_2,
                      &coldCodeBlock_2, &roDataBlock_2, &orig_hotCodeBlock_2, &orig_coldCodeBlock_2,
                      &orig_roDataBlock_2);
 
@@ -1320,11 +1318,11 @@ bool NearDiffer::compare(MethodContext* mc, CompileResult* cr1, CompileResult* c
         }
     }
 
-    LogDebug("HCS1 %d CCS1 %d RDS1 %d xcpnt1 %d flag1 %08X, HCB %p CCB %p RDB %p ohcb %p occb %p odb %p", hotCodeSize_1,
-             coldCodeSize_1, roDataSize_1, xcptnsCount_1, flag_1, hotCodeBlock_1, coldCodeBlock_1, roDataBlock_1,
+    LogDebug("HCS1 %d CCS1 %d RDS1 %d xcpnt1 %d HCB %p CCB %p RDB %p ohcb %p occb %p odb %p", hotCodeSize_1,
+             coldCodeSize_1, roDataSize_1, xcptnsCount_1, hotCodeBlock_1, coldCodeBlock_1, roDataBlock_1,
              orig_hotCodeBlock_1, orig_coldCodeBlock_1, orig_roDataBlock_1);
-    LogDebug("HCS2 %d CCS2 %d RDS2 %d xcpnt2 %d flag2 %08X, HCB %p CCB %p RDB %p ohcb %p occb %p odb %p", hotCodeSize_2,
-             coldCodeSize_2, roDataSize_2, xcptnsCount_2, flag_2, hotCodeBlock_2, coldCodeBlock_2, roDataBlock_2,
+    LogDebug("HCS2 %d CCS2 %d RDS2 %d xcpnt2 %d HCB %p CCB %p RDB %p ohcb %p occb %p odb %p", hotCodeSize_2,
+             coldCodeSize_2, roDataSize_2, xcptnsCount_2, hotCodeBlock_2, coldCodeBlock_2, roDataBlock_2,
              orig_hotCodeBlock_2, orig_coldCodeBlock_2, orig_roDataBlock_2);
 
     RelocContext rc;

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -2859,7 +2859,7 @@ void* EECodeGenManager::AllocCodeWorker(CodeHeapRequestInfo *pInfo,
 }
 
 template<typename TCodeHeader>
-void EECodeGenManager::AllocCode(MethodDesc* pMD, size_t blockSize, size_t reserveForJumpStubs, CorJitAllocMemFlag flag, void** ppCodeHeader, void** ppCodeHeaderRW,
+void EECodeGenManager::AllocCode(MethodDesc* pMD, size_t blockSize, size_t reserveForJumpStubs, unsigned alignment, void** ppCodeHeader, void** ppCodeHeaderRW,
                                  size_t* pAllocatedSize, HeapList** ppCodeHeap
                                , BYTE** ppRealHeader
                                , UINT nUnwindInfos
@@ -2874,21 +2874,10 @@ void EECodeGenManager::AllocCode(MethodDesc* pMD, size_t blockSize, size_t reser
     // Alignment
     //
 
-    unsigned alignment = CODE_SIZE_ALIGN;
-
-    if ((flag & CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN) != 0)
-    {
-        alignment = max(alignment, 32u);
-    }
-    else if ((flag & CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) != 0)
-    {
-        alignment = max(alignment, 16u);
-    }
-
 #if defined(TARGET_X86)
     // when not optimizing for code size, 8-byte align the method entry point, so that
     // the JIT can in turn 8-byte align the loop entry headers.
-    else if ((g_pConfig->GenOptimizeType() != OPT_SIZE))
+    if ((g_pConfig->GenOptimizeType() != OPT_SIZE))
     {
         alignment = max(alignment, 8u);
     }
@@ -3017,14 +3006,14 @@ void EECodeGenManager::AllocCode(MethodDesc* pMD, size_t blockSize, size_t reser
     *ppCodeHeaderRW = pCodeHdrRW;
 }
 
-template void EECodeGenManager::AllocCode<CodeHeader>(MethodDesc* pMD, size_t blockSize, size_t reserveForJumpStubs, CorJitAllocMemFlag flag, void** ppCodeHeader, void** ppCodeHeaderRW,
+template void EECodeGenManager::AllocCode<CodeHeader>(MethodDesc* pMD, size_t blockSize, size_t reserveForJumpStubs, unsigned alignment, void** ppCodeHeader, void** ppCodeHeaderRW,
                                                       size_t* pAllocatedSize, HeapList** ppCodeHeap
                                                     , BYTE** ppRealHeader
                                                     , UINT nUnwindInfos
                                                      );
 
 #ifdef FEATURE_INTERPRETER
-template void EECodeGenManager::AllocCode<InterpreterCodeHeader>(MethodDesc* pMD, size_t blockSize, size_t reserveForJumpStubs, CorJitAllocMemFlag flag, void** ppCodeHeader, void** ppCodeHeaderRW,
+template void EECodeGenManager::AllocCode<InterpreterCodeHeader>(MethodDesc* pMD, size_t blockSize, size_t reserveForJumpStubs, unsigned alignment, void** ppCodeHeader, void** ppCodeHeaderRW,
                                                                  size_t* pAllocatedSize, HeapList** ppCodeHeap
                                                                , BYTE** ppRealHeader
                                                                , UINT nUnwindInfos

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -1948,7 +1948,7 @@ public:
     void CleanupCodeHeaps();
 
     template<typename TCodeHeader>
-    void AllocCode(MethodDesc* pMD, size_t blockSize, size_t reserveForJumpStubs, CorJitAllocMemFlag flag, void** ppCodeHeader, void** ppCodeHeaderRW,
+    void AllocCode(MethodDesc* pMD, size_t blockSize, size_t reserveForJumpStubs, unsigned alignment, void** ppCodeHeader, void** ppCodeHeaderRW,
                    size_t* pAllocatedSize, HeapList** ppCodeHeap , BYTE** ppRealHeader
                  , UINT nUnwindInfos
                   );

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -11388,12 +11388,11 @@ void CInterpreterJitInfo::allocMem(AllocMemArgs *pArgs)
 {
     JIT_TO_EE_TRANSITION();
 
-    _ASSERTE(pArgs->coldCodeSize == 0);
-    _ASSERTE(pArgs->roDataSize == 0);
+    _ASSERTE(pArgs->chunksCount == 1);
 
-    ULONG codeSize      = pArgs->hotCodeSize;
-    void **codeBlock    = &pArgs->hotCodeBlock;
-    void **codeBlockRW  = &pArgs->hotCodeBlockRW;
+    ULONG codeSize      = pArgs->chunks[0].size;
+    uint8_t **codeBlock    = &pArgs->chunks[0].block;
+    uint8_t **codeBlockRW  = &pArgs->chunks[0].blockRW;
     S_SIZE_T totalSize = S_SIZE_T(codeSize);
 
     _ASSERTE(m_CodeHeader == 0 &&
@@ -11418,10 +11417,10 @@ void CInterpreterJitInfo::allocMem(AllocMemArgs *pArgs)
             ullMethodIdentifier = (ULONGLONG)m_pMethodBeingCompiled;
         }
         FireEtwMethodJitMemoryAllocatedForCode(ullMethodIdentifier, ullModuleID,
-            pArgs->hotCodeSize, pArgs->roDataSize, totalSize.Value(), pArgs->flag, GetClrInstanceId());
+            codeSize, 0, totalSize.Value(), 0, GetClrInstanceId());
     }
 
-    m_jitManager->AllocCode<InterpreterCodeHeader>(m_pMethodBeingCompiled, totalSize.Value(), 0, pArgs->flag, &m_CodeHeader, &m_CodeHeaderRW,
+    m_jitManager->AllocCode<InterpreterCodeHeader>(m_pMethodBeingCompiled, totalSize.Value(), 0, 0, &m_CodeHeader, &m_CodeHeaderRW,
         &m_codeWriteBufferSize, &m_pCodeHeap, &m_pRealCodeHeader, 0);
 
     BYTE* current = (BYTE *)((InterpreterCodeHeader*)m_CodeHeader)->GetCodeStartAddress();
@@ -11433,11 +11432,6 @@ void CInterpreterJitInfo::allocMem(AllocMemArgs *pArgs)
     *codeBlockRW = current;
 
     current += codeSize;
-
-    pArgs->coldCodeBlock = NULL;
-    pArgs->coldCodeBlockRW = NULL;
-    pArgs->roDataBlock = NULL;
-    pArgs->roDataBlockRW = NULL;
 
     _ASSERTE((SIZE_T)(current - (BYTE *)((InterpreterCodeHeader*)m_CodeHeader)->GetCodeStartAddress()) <= totalSize.Value());
 
@@ -12689,53 +12683,28 @@ void CEEJitInfo::allocMem (AllocMemArgs *pArgs)
 
     JIT_TO_EE_TRANSITION();
 
-    _ASSERTE(pArgs->coldCodeSize == 0);
-    if (pArgs->coldCodeBlock)
-    {
-        pArgs->coldCodeBlock = NULL;
-    }
+    unsigned codeSize = 0;
+    unsigned roDataSize = 0;
+    S_SIZE_T totalSize(0);
+    unsigned alignment = CODE_SIZE_ALIGN;
 
-    ULONG codeSize      = pArgs->hotCodeSize;
-    void **codeBlock    = &pArgs->hotCodeBlock;
-    void **codeBlockRW  = &pArgs->hotCodeBlockRW;
+    for (unsigned i = 0; i < pArgs->chunksCount; i++)
+    {
+        _ASSERTE((pArgs->chunks[i].flags & CORJIT_ALLOCMEM_COLD_CODE) == 0);
+        _ASSERTE((CountBits(pArgs->chunks[i].alignment) == 1) && (pArgs->chunks[i].alignment <= 64));
 
-    S_SIZE_T totalSize = S_SIZE_T(codeSize);
-
-    size_t roDataAlignment = sizeof(void*);
-    if ((pArgs->flag & CORJIT_ALLOCMEM_FLG_RODATA_64BYTE_ALIGN)!= 0)
-    {
-        roDataAlignment = 64;
-    }
-    else if ((pArgs->flag & CORJIT_ALLOCMEM_FLG_RODATA_32BYTE_ALIGN)!= 0)
-    {
-        roDataAlignment = 32;
-    }
-    else if ((pArgs->flag & CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN)!= 0)
-    {
-        roDataAlignment = 16;
-    }
-    else if (pArgs->roDataSize >= 8)
-    {
-        roDataAlignment = 8;
-    }
-    if (pArgs->roDataSize > 0)
-    {
-        size_t codeAlignment = sizeof(void*);
-
-        if ((pArgs->flag & CORJIT_ALLOCMEM_FLG_32BYTE_ALIGN) != 0)
+        if ((pArgs->chunks[i].flags & CORJIT_ALLOCMEM_HOT_CODE) != 0)
         {
-            codeAlignment = 32;
+            codeSize += pArgs->chunks[i].size;
         }
-        else if ((pArgs->flag & CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN) != 0)
+        else
         {
-            codeAlignment = 16;
+            roDataSize += pArgs->chunks[i].size;
         }
-        totalSize.AlignUp(codeAlignment);
-        if (roDataAlignment > codeAlignment) {
-            // Add padding to align read-only data.
-            totalSize += (roDataAlignment - codeAlignment);
-        }
-        totalSize += pArgs->roDataSize;
+
+        totalSize.AlignUp(pArgs->chunks[i].alignment);
+        totalSize += pArgs->chunks[i].size;
+        alignment = max(alignment, pArgs->chunks[i].alignment);
     }
 
     totalSize.AlignUp(sizeof(DWORD));
@@ -12767,40 +12736,32 @@ void CEEJitInfo::allocMem (AllocMemArgs *pArgs)
         }
 
         FireEtwMethodJitMemoryAllocatedForCode(ullMethodIdentifier, ullModuleID,
-            pArgs->hotCodeSize + pArgs->coldCodeSize, pArgs->roDataSize, totalSize.Value(), pArgs->flag, GetClrInstanceId());
+            codeSize, roDataSize, totalSize.Value(), 0, GetClrInstanceId());
     }
 
-    m_jitManager->AllocCode<CodeHeader>(m_pMethodBeingCompiled, totalSize.Value(), GetReserveForJumpStubs(), pArgs->flag, &m_CodeHeader,
+    m_jitManager->AllocCode<CodeHeader>(m_pMethodBeingCompiled, totalSize.Value(), GetReserveForJumpStubs(), alignment, &m_CodeHeader,
         &m_CodeHeaderRW, &m_codeWriteBufferSize, &m_pCodeHeap, &m_pRealCodeHeader, m_totalUnwindInfos);
 
     m_moduleBase = m_pCodeHeap->GetModuleBase();
 
-    BYTE* current = (BYTE *)((CodeHeader*)m_CodeHeader)->GetCodeStartAddress();
+    BYTE* start = (BYTE *)((CodeHeader*)m_CodeHeader)->GetCodeStartAddress();
+    size_t offset = 0;
     size_t writeableOffset = (BYTE *)m_CodeHeaderRW - (BYTE *)m_CodeHeader;
 
-    *codeBlock = current;
-    *codeBlockRW = current + writeableOffset;
-    current += codeSize;
-
-    if (pArgs->roDataSize > 0)
+    for (unsigned i = 0; i < pArgs->chunksCount; i++)
     {
-        current = (BYTE *)ALIGN_UP(current, roDataAlignment);
-        pArgs->roDataBlock = current;
-        pArgs->roDataBlockRW = current + writeableOffset;
-        current += pArgs->roDataSize;
-    }
-    else
-    {
-        pArgs->roDataBlock = NULL;
-        pArgs->roDataBlockRW = NULL;
+        offset = AlignUp(offset, pArgs->chunks[i].alignment);
+        pArgs->chunks[i].block = start + offset;
+        pArgs->chunks[i].blockRW = start + offset + writeableOffset;
+        offset += pArgs->chunks[i].size;
     }
 
-    current = (BYTE *)ALIGN_UP(current, sizeof(DWORD));
+    offset = AlignUp(offset, sizeof(DWORD));
 
-    m_theUnwindBlock = current;
-    current += m_totalUnwindSize;
+    m_theUnwindBlock = start + offset;
+    offset += m_totalUnwindSize;
 
-    _ASSERTE((SIZE_T)(current - (BYTE *)((CodeHeader*)m_CodeHeader)->GetCodeStartAddress()) <= totalSize.Value());
+    _ASSERTE(offset <= totalSize.Value());
 
 #ifdef _DEBUG
     m_codeSize = codeSize;

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -12690,21 +12690,21 @@ void CEEJitInfo::allocMem (AllocMemArgs *pArgs)
 
     for (unsigned i = 0; i < pArgs->chunksCount; i++)
     {
-        _ASSERTE((pArgs->chunks[i].flags & CORJIT_ALLOCMEM_COLD_CODE) == 0);
-        _ASSERTE((CountBits(pArgs->chunks[i].alignment) == 1) && (pArgs->chunks[i].alignment <= 64));
+        AllocMemChunk& chunk = pArgs->chunks[i];
+        _ASSERTE((chunk.flags & CORJIT_ALLOCMEM_COLD_CODE) == 0);
 
-        if ((pArgs->chunks[i].flags & CORJIT_ALLOCMEM_HOT_CODE) != 0)
+        if ((chunk.flags & CORJIT_ALLOCMEM_HOT_CODE) != 0)
         {
-            codeSize += pArgs->chunks[i].size;
+            codeSize += chunk.size;
         }
         else
         {
-            roDataSize += pArgs->chunks[i].size;
+            roDataSize += chunk.size;
         }
 
-        totalSize.AlignUp(pArgs->chunks[i].alignment);
-        totalSize += pArgs->chunks[i].size;
-        alignment = max(alignment, pArgs->chunks[i].alignment);
+        totalSize.AlignUp(chunk.alignment);
+        totalSize += chunk.size;
+        alignment = max(alignment, chunk.alignment);
     }
 
     totalSize.AlignUp(sizeof(DWORD));
@@ -12750,10 +12750,11 @@ void CEEJitInfo::allocMem (AllocMemArgs *pArgs)
 
     for (unsigned i = 0; i < pArgs->chunksCount; i++)
     {
-        offset = AlignUp(offset, pArgs->chunks[i].alignment);
-        pArgs->chunks[i].block = start + offset;
-        pArgs->chunks[i].blockRW = start + offset + writeableOffset;
-        offset += pArgs->chunks[i].size;
+        AllocMemChunk& chunk = pArgs->chunks[i];
+        offset = AlignUp(offset, chunk.alignment);
+        chunk.block = start + offset;
+        chunk.blockRW = start + offset + writeableOffset;
+        offset += chunk.size;
     }
 
     offset = AlignUp(offset, sizeof(DWORD));

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -11390,9 +11390,10 @@ void CInterpreterJitInfo::allocMem(AllocMemArgs *pArgs)
 
     _ASSERTE(pArgs->chunksCount == 1);
 
-    ULONG codeSize      = pArgs->chunks[0].size;
-    uint8_t **codeBlock    = &pArgs->chunks[0].block;
-    uint8_t **codeBlockRW  = &pArgs->chunks[0].blockRW;
+    unsigned codeAlign    = std::max((unsigned)CODE_SIZE_ALIGN, pArgs->chunks[0].alignment);
+    ULONG codeSize        = pArgs->chunks[0].size;
+    uint8_t **codeBlock   = &pArgs->chunks[0].block;
+    uint8_t **codeBlockRW = &pArgs->chunks[0].blockRW;
     S_SIZE_T totalSize = S_SIZE_T(codeSize);
 
     _ASSERTE(m_CodeHeader == 0 &&
@@ -11420,7 +11421,7 @@ void CInterpreterJitInfo::allocMem(AllocMemArgs *pArgs)
             codeSize, 0, totalSize.Value(), 0, GetClrInstanceId());
     }
 
-    m_jitManager->AllocCode<InterpreterCodeHeader>(m_pMethodBeingCompiled, totalSize.Value(), 0, 0, &m_CodeHeader, &m_CodeHeaderRW,
+    m_jitManager->AllocCode<InterpreterCodeHeader>(m_pMethodBeingCompiled, totalSize.Value(), 0, codeAlign, &m_CodeHeader, &m_CodeHeaderRW,
         &m_codeWriteBufferSize, &m_pCodeHeap, &m_pRealCodeHeader, 0);
 
     BYTE* current = (BYTE *)((InterpreterCodeHeader*)m_CodeHeader)->GetCodeStartAddress();


### PR DESCRIPTION
Rework `allocMem` to support allocating an arbitrary number of data chunks. The motivation is to allow ilc to put async resumption info chunks into sections that support relocations to .text, but additionally will allow for sharing read only data between multiple functions.