### PR TITLE
Add small int return value conversion to call stubs

### DIFF
--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -1182,6 +1182,69 @@ END_PROLOGUE
         ret
 NESTED_END CallJittedMethodRetDouble, _TEXT
 
+NESTED_ENTRY CallJittedMethodRetI1, _TEXT
+        push_nonvol_reg rbp
+        set_frame rbp, 0
+        push_vol_reg r8
+        push_vol_reg rax ; align
+END_PROLOGUE
+        add r9, 20h ; argument save area + alignment
+        sub rsp, r9 ; total stack space
+        mov r11, rcx ; The routines list
+        mov r10, rdx ; interpreter stack args
+        call qword ptr [r11]
+        movsx rax, al  ; Sign extend 1 byte to 64 bit
+        mov rdx, [rbp + 48]
+        mov [rdx], rcx
+        mov r8, [rbp - 8]
+        mov qword ptr [r8], rax
+        mov rsp, rbp
+        pop rbp
+        ret
+NESTED_END CallJittedMethodRetI1, _TEXT
+
+NESTED_ENTRY CallJittedMethodRetI2, _TEXT
+        push_nonvol_reg rbp
+        set_frame rbp, 0
+        push_vol_reg r8
+        push_vol_reg rax ; align
+END_PROLOGUE
+        add r9, 20h ; argument save area + alignment
+        sub rsp, r9 ; total stack space
+        mov r11, rcx ; The routines list
+        mov r10, rdx ; interpreter stack args
+        call qword ptr [r11]
+        movsx rax, ax  ; Sign extend 2 bytes to 64 bit
+        mov rdx, [rbp + 48]
+        mov [rdx], rcx
+        mov r8, [rbp - 8]
+        mov qword ptr [r8], rax
+        mov rsp, rbp
+        pop rbp
+        ret
+NESTED_END CallJittedMethodRetI2, _TEXT
+
+NESTED_ENTRY CallJittedMethodRetI4, _TEXT
+        push_nonvol_reg rbp
+        set_frame rbp, 0
+        push_vol_reg r8
+        push_vol_reg rax ; align
+END_PROLOGUE
+        add r9, 20h ; argument save area + alignment
+        sub rsp, r9 ; total stack space
+        mov r11, rcx ; The routines list
+        mov r10, rdx ; interpreter stack args
+        call qword ptr [r11]
+        movsxd rax, eax  ; Sign extend 4 bytes to 64 bit
+        mov rdx, [rbp + 48]
+        mov [rdx], rcx
+        mov r8, [rbp - 8]
+        mov qword ptr [r8], rax
+        mov rsp, rbp
+        pop rbp
+        ret
+NESTED_END CallJittedMethodRetI4, _TEXT
+
 NESTED_ENTRY CallJittedMethodRetI8, _TEXT
         push_nonvol_reg rbp
         set_frame rbp, 0
@@ -1201,6 +1264,69 @@ END_PROLOGUE
         pop rbp
         ret
 NESTED_END CallJittedMethodRetI8, _TEXT
+
+NESTED_ENTRY CallJittedMethodRetU1, _TEXT
+        push_nonvol_reg rbp
+        set_frame rbp, 0
+        push_vol_reg r8
+        push_vol_reg rax ; align
+END_PROLOGUE
+        add r9, 20h ; argument save area + alignment
+        sub rsp, r9 ; total stack space
+        mov r11, rcx ; The routines list
+        mov r10, rdx ; interpreter stack args
+        call qword ptr [r11]
+        movzx rax, al  ; Zero extend 1 byte to 64 bit
+        mov rdx, [rbp + 48]
+        mov [rdx], rcx
+        mov r8, [rbp - 8]
+        mov qword ptr [r8], rax
+        mov rsp, rbp
+        pop rbp
+        ret
+NESTED_END CallJittedMethodRetU1, _TEXT
+
+NESTED_ENTRY CallJittedMethodRetU2, _TEXT
+        push_nonvol_reg rbp
+        set_frame rbp, 0
+        push_vol_reg r8
+        push_vol_reg rax ; align
+END_PROLOGUE
+        add r9, 20h ; argument save area + alignment
+        sub rsp, r9 ; total stack space
+        mov r11, rcx ; The routines list
+        mov r10, rdx ; interpreter stack args
+        call qword ptr [r11]
+        movzx rax, ax  ; Zero extend 2 bytes to 64 bit
+        mov rdx, [rbp + 48]
+        mov [rdx], rcx
+        mov r8, [rbp - 8]
+        mov qword ptr [r8], rax
+        mov rsp, rbp
+        pop rbp
+        ret
+NESTED_END CallJittedMethodRetU2, _TEXT
+
+NESTED_ENTRY CallJittedMethodRetU4, _TEXT
+        push_nonvol_reg rbp
+        set_frame rbp, 0
+        push_vol_reg r8
+        push_vol_reg rax ; align
+END_PROLOGUE
+        add r9, 20h ; argument save area + alignment
+        sub rsp, r9 ; total stack space
+        mov r11, rcx ; The routines list
+        mov r10, rdx ; interpreter stack args
+        call qword ptr [r11]
+        mov eax, eax  ; Zero extend 4 bytes to 64 bit (clearing upper 32 bits)
+        mov rdx, [rbp + 48]
+        mov [rdx], rcx
+        mov r8, [rbp - 8]
+        mov qword ptr [r8], rax
+        mov rsp, rbp
+        pop rbp
+        ret
+NESTED_END CallJittedMethodRetU4, _TEXT
 
 endif ; FEATURE_INTERPRETER
 

--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -1224,27 +1224,6 @@ END_PROLOGUE
         ret
 NESTED_END CallJittedMethodRetI2, _TEXT
 
-NESTED_ENTRY CallJittedMethodRetI4, _TEXT
-        push_nonvol_reg rbp
-        set_frame rbp, 0
-        push_vol_reg r8
-        push_vol_reg rax ; align
-END_PROLOGUE
-        add r9, 20h ; argument save area + alignment
-        sub rsp, r9 ; total stack space
-        mov r11, rcx ; The routines list
-        mov r10, rdx ; interpreter stack args
-        call qword ptr [r11]
-        movsxd rax, eax  ; Sign extend 4 bytes to 64 bit
-        mov rdx, [rbp + 48]
-        mov [rdx], rcx
-        mov r8, [rbp - 8]
-        mov qword ptr [r8], rax
-        mov rsp, rbp
-        pop rbp
-        ret
-NESTED_END CallJittedMethodRetI4, _TEXT
-
 NESTED_ENTRY CallJittedMethodRetI8, _TEXT
         push_nonvol_reg rbp
         set_frame rbp, 0
@@ -1306,27 +1285,6 @@ END_PROLOGUE
         pop rbp
         ret
 NESTED_END CallJittedMethodRetU2, _TEXT
-
-NESTED_ENTRY CallJittedMethodRetU4, _TEXT
-        push_nonvol_reg rbp
-        set_frame rbp, 0
-        push_vol_reg r8
-        push_vol_reg rax ; align
-END_PROLOGUE
-        add r9, 20h ; argument save area + alignment
-        sub rsp, r9 ; total stack space
-        mov r11, rcx ; The routines list
-        mov r10, rdx ; interpreter stack args
-        call qword ptr [r11]
-        mov eax, eax  ; Zero extend 4 bytes to 64 bit (clearing upper 32 bits)
-        mov rdx, [rbp + 48]
-        mov [rdx], rcx
-        mov r8, [rbp - 8]
-        mov qword ptr [r8], rax
-        mov rsp, rbp
-        pop rbp
-        ret
-NESTED_END CallJittedMethodRetU4, _TEXT
 
 endif ; FEATURE_INTERPRETER
 

--- a/src/coreclr/vm/amd64/asmhelpers.S
+++ b/src/coreclr/vm/amd64/asmhelpers.S
@@ -1808,6 +1808,69 @@ END_PROLOGUE
         ret
 NESTED_END CallJittedMethodRetDouble, _TEXT
 
+NESTED_ENTRY CallJittedMethodRetI1, _TEXT, NoHandler
+        push_nonvol_reg rbp
+        mov  rbp, rsp
+        set_cfa_register rbp, 0
+        push_register r8
+        push_register rdx
+END_PROLOGUE
+        sub rsp, rcx // total stack space
+        mov r11, rdi // The routines list
+        mov r10, rsi // interpreter stack args
+        call qword ptr [r11]
+        movsx rax, al  // Sign extend 1 byte to 64 bit
+        mov r8, [rbp - 8]
+        mov [r8], rcx
+        mov rdx, [rbp - 16]
+        mov qword ptr [rdx], rax
+        mov rsp, rbp
+        pop rbp
+        ret
+NESTED_END CallJittedMethodRetI1, _TEXT
+
+NESTED_ENTRY CallJittedMethodRetI2, _TEXT, NoHandler
+        push_nonvol_reg rbp
+        mov  rbp, rsp
+        set_cfa_register rbp, 0
+        push_register r8
+        push_register rdx
+END_PROLOGUE
+        sub rsp, rcx // total stack space
+        mov r11, rdi // The routines list
+        mov r10, rsi // interpreter stack args
+        call qword ptr [r11]
+        movsx rax, ax  // Sign extend 2 bytes to 64 bit
+        mov r8, [rbp - 8]
+        mov [r8], rcx
+        mov rdx, [rbp - 16]
+        mov qword ptr [rdx], rax
+        mov rsp, rbp
+        pop rbp
+        ret
+NESTED_END CallJittedMethodRetI2, _TEXT
+
+NESTED_ENTRY CallJittedMethodRetI4, _TEXT, NoHandler
+        push_nonvol_reg rbp
+        mov  rbp, rsp
+        set_cfa_register rbp, 0
+        push_register r8
+        push_register rdx
+END_PROLOGUE
+        sub rsp, rcx // total stack space
+        mov r11, rdi // The routines list
+        mov r10, rsi // interpreter stack args
+        call qword ptr [r11]
+        movsxd rax, eax  // Sign extend 4 bytes to 64 bit
+        mov r8, [rbp - 8]
+        mov [r8], rcx
+        mov rdx, [rbp - 16]
+        mov qword ptr [rdx], rax
+        mov rsp, rbp
+        pop rbp
+        ret
+NESTED_END CallJittedMethodRetI4, _TEXT
+
 NESTED_ENTRY CallJittedMethodRetI8, _TEXT, NoHandler
         push_nonvol_reg rbp
         mov  rbp, rsp
@@ -1827,6 +1890,69 @@ END_PROLOGUE
         pop rbp
         ret
 NESTED_END CallJittedMethodRetI8, _TEXT
+
+NESTED_ENTRY CallJittedMethodRetU1, _TEXT, NoHandler
+        push_nonvol_reg rbp
+        mov  rbp, rsp
+        set_cfa_register rbp, 0
+        push_register r8
+        push_register rdx
+END_PROLOGUE
+        sub rsp, rcx // total stack space
+        mov r11, rdi // The routines list
+        mov r10, rsi // interpreter stack args
+        call qword ptr [r11]
+        movzx rax, al  // Zero extend 1 byte to 64 bit
+        mov r8, [rbp - 8]
+        mov [r8], rcx
+        mov rdx, [rbp - 16]
+        mov qword ptr [rdx], rax
+        mov rsp, rbp
+        pop rbp
+        ret
+NESTED_END CallJittedMethodRetU1, _TEXT
+
+NESTED_ENTRY CallJittedMethodRetU2, _TEXT, NoHandler
+        push_nonvol_reg rbp
+        mov  rbp, rsp
+        set_cfa_register rbp, 0
+        push_register r8
+        push_register rdx
+END_PROLOGUE
+        sub rsp, rcx // total stack space
+        mov r11, rdi // The routines list
+        mov r10, rsi // interpreter stack args
+        call qword ptr [r11]
+        movzx rax, ax  // Zero extend 2 bytes to 64 bit
+        mov r8, [rbp - 8]
+        mov [r8], rcx
+        mov rdx, [rbp - 16]
+        mov qword ptr [rdx], rax
+        mov rsp, rbp
+        pop rbp
+        ret
+NESTED_END CallJittedMethodRetU2, _TEXT
+
+NESTED_ENTRY CallJittedMethodRetU4, _TEXT, NoHandler
+        push_nonvol_reg rbp
+        mov  rbp, rsp
+        set_cfa_register rbp, 0
+        push_register r8
+        push_register rdx
+END_PROLOGUE
+        sub rsp, rcx // total stack space
+        mov r11, rdi // The routines list
+        mov r10, rsi // interpreter stack args
+        call qword ptr [r11]
+        mov eax, eax  // Zero extend 4 bytes to 64 bit (clearing upper 32 bits)
+        mov r8, [rbp - 8]
+        mov [r8], rcx
+        mov rdx, [rbp - 16]
+        mov qword ptr [rdx], rax
+        mov rsp, rbp
+        pop rbp
+        ret
+NESTED_END CallJittedMethodRetU4, _TEXT
 
 NESTED_ENTRY CallJittedMethodRetI8I8, _TEXT, NoHandler
         push_nonvol_reg rbp

--- a/src/coreclr/vm/amd64/asmhelpers.S
+++ b/src/coreclr/vm/amd64/asmhelpers.S
@@ -1850,27 +1850,6 @@ END_PROLOGUE
         ret
 NESTED_END CallJittedMethodRetI2, _TEXT
 
-NESTED_ENTRY CallJittedMethodRetI4, _TEXT, NoHandler
-        push_nonvol_reg rbp
-        mov  rbp, rsp
-        set_cfa_register rbp, 0
-        push_register r8
-        push_register rdx
-END_PROLOGUE
-        sub rsp, rcx // total stack space
-        mov r11, rdi // The routines list
-        mov r10, rsi // interpreter stack args
-        call qword ptr [r11]
-        movsxd rax, eax  // Sign extend 4 bytes to 64 bit
-        mov r8, [rbp - 8]
-        mov [r8], rcx
-        mov rdx, [rbp - 16]
-        mov qword ptr [rdx], rax
-        mov rsp, rbp
-        pop rbp
-        ret
-NESTED_END CallJittedMethodRetI4, _TEXT
-
 NESTED_ENTRY CallJittedMethodRetI8, _TEXT, NoHandler
         push_nonvol_reg rbp
         mov  rbp, rsp
@@ -1932,27 +1911,6 @@ END_PROLOGUE
         pop rbp
         ret
 NESTED_END CallJittedMethodRetU2, _TEXT
-
-NESTED_ENTRY CallJittedMethodRetU4, _TEXT, NoHandler
-        push_nonvol_reg rbp
-        mov  rbp, rsp
-        set_cfa_register rbp, 0
-        push_register r8
-        push_register rdx
-END_PROLOGUE
-        sub rsp, rcx // total stack space
-        mov r11, rdi // The routines list
-        mov r10, rsi // interpreter stack args
-        call qword ptr [r11]
-        mov eax, eax  // Zero extend 4 bytes to 64 bit (clearing upper 32 bits)
-        mov r8, [rbp - 8]
-        mov [r8], rcx
-        mov rdx, [rbp - 16]
-        mov qword ptr [rdx], rax
-        mov rsp, rbp
-        pop rbp
-        ret
-NESTED_END CallJittedMethodRetU4, _TEXT
 
 NESTED_ENTRY CallJittedMethodRetI8I8, _TEXT, NoHandler
         push_nonvol_reg rbp

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -2407,7 +2407,8 @@ NESTED_ENTRY CallJittedMethodRetI4, _TEXT, NoHandler
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
-    sxth x0, w0
+    blr x11
+    sxtw x0, w0
     ldr x11, [fp, #40]
     cbz x11, LOCAL_LABEL(CallJittedMethodRetI4_NoSwiftError)
     str x21, [x11]

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -2344,25 +2344,20 @@ NESTED_END CallJittedMethodRetBuff, _TEXT
 // X3 - stack arguments size (properly aligned)
 // X4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetI1, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -48
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
     stp x2, x4, [fp, #16]
-    str xzr, [fp, #40]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
     sxtb x0, w0
-    ldr x11, [fp, #40]
-    cbz x11, LOCAL_LABEL(CallJittedMethodRetI1_NoSwiftError)
-    str x21, [x11]
-LOCAL_LABEL(CallJittedMethodRetI1_NoSwiftError):
     ldr x9, [fp, #24]
     str x2, [x9]
     ldr x9, [fp, #16]
     str x0, [x9]
     EPILOG_STACK_RESTORE
-    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 48
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
     EPILOG_RETURN
 NESTED_END CallJittedMethodRetI1, _TEXT
 
@@ -2372,25 +2367,20 @@ NESTED_END CallJittedMethodRetI1, _TEXT
 // X3 - stack arguments size (properly aligned)
 // X4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetI2, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -48
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
     stp x2, x4, [fp, #16]
-    str xzr, [fp, #40]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
     sxth x0, w0
-    ldr x11, [fp, #40]
-    cbz x11, LOCAL_LABEL(CallJittedMethodRetI2_NoSwiftError)
-    str x21, [x11]
-LOCAL_LABEL(CallJittedMethodRetI2_NoSwiftError):
     ldr x9, [fp, #24]
     str x2, [x9]
     ldr x9, [fp, #16]
     str x0, [x9]
     EPILOG_STACK_RESTORE
-    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 48
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
     EPILOG_RETURN
 NESTED_END CallJittedMethodRetI2, _TEXT
 
@@ -2422,25 +2412,20 @@ NESTED_END CallJittedMethodRetI8, _TEXT
 // X3 - stack arguments size (properly aligned)
 // X4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetU1, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -48
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
     stp x2, x4, [fp, #16]
-    str xzr, [fp, #40]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
     uxtb x0, w0
-    ldr x11, [fp, #40]
-    cbz x11, LOCAL_LABEL(CallJittedMethodRetU1_NoSwiftError)
-    str x21, [x11]
-LOCAL_LABEL(CallJittedMethodRetU1_NoSwiftError):
     ldr x9, [fp, #24]
     str x2, [x9]
     ldr x9, [fp, #16]
     str x0, [x9]
     EPILOG_STACK_RESTORE
-    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 48
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
     EPILOG_RETURN
 NESTED_END CallJittedMethodRetU1, _TEXT
 
@@ -2450,25 +2435,20 @@ NESTED_END CallJittedMethodRetU1, _TEXT
 // X3 - stack arguments size (properly aligned)
 // X4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetU2, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -48
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
     stp x2, x4, [fp, #16]
-    str xzr, [fp, #40]
     sub sp, sp, x3
     mov x10, x0
     mov x9, x1
     ldr x11, [x10], #8
     blr x11
     uxth x0, w0
-    ldr x11, [fp, #40]
-    cbz x11, LOCAL_LABEL(CallJittedMethodRetU2_NoSwiftError)
-    str x21, [x11]
-LOCAL_LABEL(CallJittedMethodRetU2_NoSwiftError):
     ldr x9, [fp, #24]
     str x2, [x9]
     ldr x9, [fp, #16]
     str x0, [x9]
     EPILOG_STACK_RESTORE
-    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 48
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
     EPILOG_RETURN
 NESTED_END CallJittedMethodRetU2, _TEXT
 

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -2343,6 +2343,89 @@ NESTED_END CallJittedMethodRetBuff, _TEXT
 // X2 - interpreter stack return value location
 // X3 - stack arguments size (properly aligned)
 // X4 - address of continuation return value
+NESTED_ENTRY CallJittedMethodRetI1, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -48
+    stp x2, x4, [fp, #16]
+    str xzr, [fp, #40]
+    sub sp, sp, x3
+    mov x10, x0
+    mov x9, x1
+    ldr x11, [x10], #8
+    blr x11
+    sxtb x0, w0
+    ldr x11, [fp, #40]
+    cbz x11, LOCAL_LABEL(CallJittedMethodRetI1_NoSwiftError)
+    str x21, [x11]
+LOCAL_LABEL(CallJittedMethodRetI1_NoSwiftError):
+    ldr x9, [fp, #24]
+    str x2, [x9]
+    ldr x9, [fp, #16]
+    str x0, [x9]
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 48
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRetI1, _TEXT
+
+// X0 - routines array
+// X1 - interpreter stack args location
+// X2 - interpreter stack return value location
+// X3 - stack arguments size (properly aligned)
+// X4 - address of continuation return value
+NESTED_ENTRY CallJittedMethodRetI2, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -48
+    stp x2, x4, [fp, #16]
+    str xzr, [fp, #40]
+    sub sp, sp, x3
+    mov x10, x0
+    mov x9, x1
+    ldr x11, [x10], #8
+    blr x11
+    sxth x0, w0
+    ldr x11, [fp, #40]
+    cbz x11, LOCAL_LABEL(CallJittedMethodRetI2_NoSwiftError)
+    str x21, [x11]
+LOCAL_LABEL(CallJittedMethodRetI2_NoSwiftError):
+    ldr x9, [fp, #24]
+    str x2, [x9]
+    ldr x9, [fp, #16]
+    str x0, [x9]
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 48
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRetI2, _TEXT
+
+// X0 - routines array
+// X1 - interpreter stack args location
+// X2 - interpreter stack return value location
+// X3 - stack arguments size (properly aligned)
+// X4 - address of continuation return value
+NESTED_ENTRY CallJittedMethodRetI4, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -48
+    stp x2, x4, [fp, #16]
+    str xzr, [fp, #40]
+    sub sp, sp, x3
+    mov x10, x0
+    mov x9, x1
+    ldr x11, [x10], #8
+    sxth x0, w0
+    ldr x11, [fp, #40]
+    cbz x11, LOCAL_LABEL(CallJittedMethodRetI4_NoSwiftError)
+    str x21, [x11]
+LOCAL_LABEL(CallJittedMethodRetI4_NoSwiftError):
+    ldr x9, [fp, #24]
+    str x2, [x9]
+    ldr x9, [fp, #16]
+    str x0, [x9]
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 48
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRetI4, _TEXT
+
+// X0 - routines array
+// X1 - interpreter stack args location
+// X2 - interpreter stack return value location
+// X3 - stack arguments size (properly aligned)
+// X4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetI8, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
     stp x2, x4, [fp, #16]
@@ -2359,6 +2442,90 @@ NESTED_ENTRY CallJittedMethodRetI8, _TEXT, NoHandler
     EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 32
     EPILOG_RETURN
 NESTED_END CallJittedMethodRetI8, _TEXT
+
+// X0 - routines array
+// X1 - interpreter stack args location
+// X2 - interpreter stack return value location
+// X3 - stack arguments size (properly aligned)
+// X4 - address of continuation return value
+NESTED_ENTRY CallJittedMethodRetU1, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -48
+    stp x2, x4, [fp, #16]
+    str xzr, [fp, #40]
+    sub sp, sp, x3
+    mov x10, x0
+    mov x9, x1
+    ldr x11, [x10], #8
+    blr x11
+    uxtb x0, w0
+    ldr x11, [fp, #40]
+    cbz x11, LOCAL_LABEL(CallJittedMethodRetU1_NoSwiftError)
+    str x21, [x11]
+LOCAL_LABEL(CallJittedMethodRetU1_NoSwiftError):
+    ldr x9, [fp, #24]
+    str x2, [x9]
+    ldr x9, [fp, #16]
+    str x0, [x9]
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 48
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRetU1, _TEXT
+
+// X0 - routines array
+// X1 - interpreter stack args location
+// X2 - interpreter stack return value location
+// X3 - stack arguments size (properly aligned)
+// X4 - address of continuation return value
+NESTED_ENTRY CallJittedMethodRetU2, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -48
+    stp x2, x4, [fp, #16]
+    str xzr, [fp, #40]
+    sub sp, sp, x3
+    mov x10, x0
+    mov x9, x1
+    ldr x11, [x10], #8
+    blr x11
+    uxth x0, w0
+    ldr x11, [fp, #40]
+    cbz x11, LOCAL_LABEL(CallJittedMethodRetU2_NoSwiftError)
+    str x21, [x11]
+LOCAL_LABEL(CallJittedMethodRetU2_NoSwiftError):
+    ldr x9, [fp, #24]
+    str x2, [x9]
+    ldr x9, [fp, #16]
+    str x0, [x9]
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 48
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRetU2, _TEXT
+
+// X0 - routines array
+// X1 - interpreter stack args location
+// X2 - interpreter stack return value location
+// X3 - stack arguments size (properly aligned)
+// X4 - address of continuation return value
+NESTED_ENTRY CallJittedMethodRetU4, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -48
+    stp x2, x4, [fp, #16]
+    str xzr, [fp, #40]
+    sub sp, sp, x3
+    mov x10, x0
+    mov x9, x1
+    ldr x11, [x10], #8
+    blr x11
+    uxtw x0, w0
+    ldr x11, [fp, #40]
+    cbz x11, LOCAL_LABEL(CallJittedMethodRetU4_NoSwiftError)
+    str x21, [x11]
+LOCAL_LABEL(CallJittedMethodRetU4_NoSwiftError):
+    ldr x9, [fp, #24]
+    str x2, [x9]
+    ldr x9, [fp, #16]
+    str x0, [x9]
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 48
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRetU4, _TEXT
 
 // X0 - routines array
 // X1 - interpreter stack args location

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -2399,34 +2399,6 @@ NESTED_END CallJittedMethodRetI2, _TEXT
 // X2 - interpreter stack return value location
 // X3 - stack arguments size (properly aligned)
 // X4 - address of continuation return value
-NESTED_ENTRY CallJittedMethodRetI4, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -48
-    stp x2, x4, [fp, #16]
-    str xzr, [fp, #40]
-    sub sp, sp, x3
-    mov x10, x0
-    mov x9, x1
-    ldr x11, [x10], #8
-    blr x11
-    sxtw x0, w0
-    ldr x11, [fp, #40]
-    cbz x11, LOCAL_LABEL(CallJittedMethodRetI4_NoSwiftError)
-    str x21, [x11]
-LOCAL_LABEL(CallJittedMethodRetI4_NoSwiftError):
-    ldr x9, [fp, #24]
-    str x2, [x9]
-    ldr x9, [fp, #16]
-    str x0, [x9]
-    EPILOG_STACK_RESTORE
-    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 48
-    EPILOG_RETURN
-NESTED_END CallJittedMethodRetI4, _TEXT
-
-// X0 - routines array
-// X1 - interpreter stack args location
-// X2 - interpreter stack return value location
-// X3 - stack arguments size (properly aligned)
-// X4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetI8, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -32
     stp x2, x4, [fp, #16]
@@ -2499,34 +2471,6 @@ LOCAL_LABEL(CallJittedMethodRetU2_NoSwiftError):
     EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 48
     EPILOG_RETURN
 NESTED_END CallJittedMethodRetU2, _TEXT
-
-// X0 - routines array
-// X1 - interpreter stack args location
-// X2 - interpreter stack return value location
-// X3 - stack arguments size (properly aligned)
-// X4 - address of continuation return value
-NESTED_ENTRY CallJittedMethodRetU4, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, lr, -48
-    stp x2, x4, [fp, #16]
-    str xzr, [fp, #40]
-    sub sp, sp, x3
-    mov x10, x0
-    mov x9, x1
-    ldr x11, [x10], #8
-    blr x11
-    uxtw x0, w0
-    ldr x11, [fp, #40]
-    cbz x11, LOCAL_LABEL(CallJittedMethodRetU4_NoSwiftError)
-    str x21, [x11]
-LOCAL_LABEL(CallJittedMethodRetU4_NoSwiftError):
-    ldr x9, [fp, #24]
-    str x2, [x9]
-    ldr x9, [fp, #16]
-    str x0, [x9]
-    EPILOG_STACK_RESTORE
-    EPILOG_RESTORE_REG_PAIR_INDEXED fp, lr, 48
-    EPILOG_RETURN
-NESTED_END CallJittedMethodRetU4, _TEXT
 
 // X0 - routines array
 // X1 - interpreter stack args location

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -2650,29 +2650,6 @@ CopyLoop
     ; X2 - interpreter stack return value location
     ; X3 - stack arguments size (properly aligned)
     ; X4 - address of continuation return value
-    NESTED_ENTRY CallJittedMethodRetI4
-        PROLOG_SAVE_REG_PAIR fp, lr, #-32!
-        stp x2, x4, [fp, #16]
-        sub sp, sp, x3
-        mov x10, x0
-        mov x9, x1
-        ldr x11, [x10], #8
-        blr x11
-        sxtw x0, w0
-        ldr x9, [fp, #16]
-        str x0, [x9]
-        ldr x9, [fp, #24]
-        str x2, [x9]
-        EPILOG_STACK_RESTORE
-        EPILOG_RESTORE_REG_PAIR fp, lr, #32!
-        EPILOG_RETURN
-    NESTED_END CallJittedMethodRetI4
-
-    ; X0 - routines array
-    ; X1 - interpreter stack args location
-    ; X2 - interpreter stack return value location
-    ; X3 - stack arguments size (properly aligned)
-    ; X4 - address of continuation return value
     NESTED_ENTRY CallJittedMethodRetI8
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
         stp x2, x4, [fp, #16]
@@ -2735,29 +2712,6 @@ CopyLoop
         EPILOG_RESTORE_REG_PAIR fp, lr, #32!
         EPILOG_RETURN
     NESTED_END CallJittedMethodRetU2
-
-    ; X0 - routines array
-    ; X1 - interpreter stack args location
-    ; X2 - interpreter stack return value location
-    ; X3 - stack arguments size (properly aligned)
-    ; X4 - address of continuation return value
-    NESTED_ENTRY CallJittedMethodRetU4
-        PROLOG_SAVE_REG_PAIR fp, lr, #-32!
-        stp x2, x4, [fp, #16]
-        sub sp, sp, x3
-        mov x10, x0
-        mov x9, x1
-        ldr x11, [x10], #8
-        blr x11
-        uxtw x0, w0
-        ldr x9, [fp, #16]
-        str x0, [x9]
-        ldr x9, [fp, #24]
-        str x2, [x9]
-        EPILOG_STACK_RESTORE
-        EPILOG_RESTORE_REG_PAIR fp, lr, #32!
-        EPILOG_RETURN
-    NESTED_END CallJittedMethodRetU4
 
     ; X0 - routines array
     ; X1 - interpreter stack args location

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -2604,6 +2604,75 @@ CopyLoop
     ; X2 - interpreter stack return value location
     ; X3 - stack arguments size (properly aligned)
     ; X4 - address of continuation return value
+    NESTED_ENTRY CallJittedMethodRetI1
+        PROLOG_SAVE_REG_PAIR fp, lr, #-32!
+        stp x2, x4, [fp, #16]
+        sub sp, sp, x3
+        mov x10, x0
+        mov x9, x1
+        ldr x11, [x10], #8
+        blr x11
+        sxtb x0, w0
+        ldr x9, [fp, #16]
+        str x0, [x9]
+        ldr x9, [fp, #24]
+        str x2, [x9]
+        EPILOG_STACK_RESTORE
+        EPILOG_RESTORE_REG_PAIR fp, lr, #32!
+        EPILOG_RETURN
+    NESTED_END CallJittedMethodRetI1
+
+    ; X0 - routines array
+    ; X1 - interpreter stack args location
+    ; X2 - interpreter stack return value location
+    ; X3 - stack arguments size (properly aligned)
+    ; X4 - address of continuation return value
+    NESTED_ENTRY CallJittedMethodRetI2
+        PROLOG_SAVE_REG_PAIR fp, lr, #-32!
+        stp x2, x4, [fp, #16]
+        sub sp, sp, x3
+        mov x10, x0
+        mov x9, x1
+        ldr x11, [x10], #8
+        blr x11
+        sxth x0, w0
+        ldr x9, [fp, #16]
+        str x0, [x9]
+        ldr x9, [fp, #24]
+        str x2, [x9]
+        EPILOG_STACK_RESTORE
+        EPILOG_RESTORE_REG_PAIR fp, lr, #32!
+        EPILOG_RETURN
+    NESTED_END CallJittedMethodRetI2
+
+    ; X0 - routines array
+    ; X1 - interpreter stack args location
+    ; X2 - interpreter stack return value location
+    ; X3 - stack arguments size (properly aligned)
+    ; X4 - address of continuation return value
+    NESTED_ENTRY CallJittedMethodRetI4
+        PROLOG_SAVE_REG_PAIR fp, lr, #-32!
+        stp x2, x4, [fp, #16]
+        sub sp, sp, x3
+        mov x10, x0
+        mov x9, x1
+        ldr x11, [x10], #8
+        blr x11
+        sxtw x0, w0
+        ldr x9, [fp, #16]
+        str x0, [x9]
+        ldr x9, [fp, #24]
+        str x2, [x9]
+        EPILOG_STACK_RESTORE
+        EPILOG_RESTORE_REG_PAIR fp, lr, #32!
+        EPILOG_RETURN
+    NESTED_END CallJittedMethodRetI4
+
+    ; X0 - routines array
+    ; X1 - interpreter stack args location
+    ; X2 - interpreter stack return value location
+    ; X3 - stack arguments size (properly aligned)
+    ; X4 - address of continuation return value
     NESTED_ENTRY CallJittedMethodRetI8
         PROLOG_SAVE_REG_PAIR fp, lr, #-32!
         stp x2, x4, [fp, #16]
@@ -2620,6 +2689,75 @@ CopyLoop
         EPILOG_RESTORE_REG_PAIR fp, lr, #32!
         EPILOG_RETURN
     NESTED_END CallJittedMethodRetI8
+
+    ; X0 - routines array
+    ; X1 - interpreter stack args location
+    ; X2 - interpreter stack return value location
+    ; X3 - stack arguments size (properly aligned)
+    ; X4 - address of continuation return value
+    NESTED_ENTRY CallJittedMethodRetU1
+        PROLOG_SAVE_REG_PAIR fp, lr, #-32!
+        stp x2, x4, [fp, #16]
+        sub sp, sp, x3
+        mov x10, x0
+        mov x9, x1
+        ldr x11, [x10], #8
+        blr x11
+        uxtb x0, w0
+        ldr x9, [fp, #16]
+        str x0, [x9]
+        ldr x9, [fp, #24]
+        str x2, [x9]
+        EPILOG_STACK_RESTORE
+        EPILOG_RESTORE_REG_PAIR fp, lr, #32!
+        EPILOG_RETURN
+    NESTED_END CallJittedMethodRetU1
+
+    ; X0 - routines array
+    ; X1 - interpreter stack args location
+    ; X2 - interpreter stack return value location
+    ; X3 - stack arguments size (properly aligned)
+    ; X4 - address of continuation return value
+    NESTED_ENTRY CallJittedMethodRetU2
+        PROLOG_SAVE_REG_PAIR fp, lr, #-32!
+        stp x2, x4, [fp, #16]
+        sub sp, sp, x3
+        mov x10, x0
+        mov x9, x1
+        ldr x11, [x10], #8
+        blr x11
+        uxth x0, w0
+        ldr x9, [fp, #16]
+        str x0, [x9]
+        ldr x9, [fp, #24]
+        str x2, [x9]
+        EPILOG_STACK_RESTORE
+        EPILOG_RESTORE_REG_PAIR fp, lr, #32!
+        EPILOG_RETURN
+    NESTED_END CallJittedMethodRetU2
+
+    ; X0 - routines array
+    ; X1 - interpreter stack args location
+    ; X2 - interpreter stack return value location
+    ; X3 - stack arguments size (properly aligned)
+    ; X4 - address of continuation return value
+    NESTED_ENTRY CallJittedMethodRetU4
+        PROLOG_SAVE_REG_PAIR fp, lr, #-32!
+        stp x2, x4, [fp, #16]
+        sub sp, sp, x3
+        mov x10, x0
+        mov x9, x1
+        ldr x11, [x10], #8
+        blr x11
+        uxtw x0, w0
+        ldr x9, [fp, #16]
+        str x0, [x9]
+        ldr x9, [fp, #24]
+        str x2, [x9]
+        EPILOG_STACK_RESTORE
+        EPILOG_RESTORE_REG_PAIR fp, lr, #32!
+        EPILOG_RETURN
+    NESTED_END CallJittedMethodRetU4
 
     ; X0 - routines array
     ; X1 - interpreter stack args location

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -1977,8 +1977,6 @@ extern "C" void CallJittedMethodRetI1(PCODE *routines, int8_t*pArgs, int8_t*pRet
 extern "C" void CallJittedMethodRetU1(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
 extern "C" void CallJittedMethodRetI2(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
 extern "C" void CallJittedMethodRetU2(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
-extern "C" void CallJittedMethodRetI4(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
-extern "C" void CallJittedMethodRetU4(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
 extern "C" void CallJittedMethodRetI8(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
 extern "C" void InterpreterStubRetVoid();
 extern "C" void InterpreterStubRetDouble();
@@ -2083,10 +2081,6 @@ CallStubHeader::InvokeFunctionPtr CallStubGenerator::GetInvokeFunctionPtr(CallSt
             INVOKE_FUNCTION_PTR(CallJittedMethodRetI2);
         case ReturnTypeU2:
             INVOKE_FUNCTION_PTR(CallJittedMethodRetU2);
-        case ReturnTypeI4:
-            INVOKE_FUNCTION_PTR(CallJittedMethodRetI4);
-        case ReturnTypeU4:
-            INVOKE_FUNCTION_PTR(CallJittedMethodRetU4);
 #ifdef TARGET_AMD64
 #ifdef TARGET_WINDOWS
         case ReturnTypeBuffArg1:
@@ -2184,8 +2178,6 @@ PCODE CallStubGenerator::GetInterpreterReturnTypeHandler(CallStubGenerator::Retu
         case ReturnTypeI8:
         case ReturnTypeI2:
         case ReturnTypeU2:
-        case ReturnTypeI4:
-        case ReturnTypeU4:
             RETURN_TYPE_HANDLER(InterpreterStubRetI8);
 #ifdef TARGET_AMD64
         case ReturnTypeBuffArg1:
@@ -3089,9 +3081,7 @@ CallStubGenerator::ReturnType CallStubGenerator::GetReturnType(ArgIteratorType *
             case ELEMENT_TYPE_U2:
                 return ReturnTypeU2;
             case ELEMENT_TYPE_I4:
-                return ReturnTypeI4;
             case ELEMENT_TYPE_U4:
-                return ReturnTypeU4;
             case ELEMENT_TYPE_I8:
             case ELEMENT_TYPE_U8:
             case ELEMENT_TYPE_I:

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -1972,6 +1972,13 @@ PCODE CallStubGenerator::GetFPReg32RangeRoutine(int x1, int x2)
 
 extern "C" void CallJittedMethodRetVoid(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
 extern "C" void CallJittedMethodRetDouble(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
+extern "C" void CallJittedMethodRetFloat(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
+extern "C" void CallJittedMethodRetI1(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
+extern "C" void CallJittedMethodRetU1(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
+extern "C" void CallJittedMethodRetI2(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
+extern "C" void CallJittedMethodRetU2(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
+extern "C" void CallJittedMethodRetI4(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
+extern "C" void CallJittedMethodRetU4(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
 extern "C" void CallJittedMethodRetI8(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
 extern "C" void InterpreterStubRetVoid();
 extern "C" void InterpreterStubRetDouble();
@@ -2010,7 +2017,6 @@ extern "C" void CallJittedMethodRet2I8(PCODE *routines, int8_t*pArgs, int8_t*pRe
 extern "C" void CallJittedMethodRet2Double(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
 extern "C" void CallJittedMethodRet3Double(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
 extern "C" void CallJittedMethodRet4Double(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
-extern "C" void CallJittedMethodRetFloat(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
 extern "C" void CallJittedMethodRet2Float(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
 extern "C" void CallJittedMethodRet3Float(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
 extern "C" void CallJittedMethodRet4Float(PCODE *routines, int8_t*pArgs, int8_t*pRet, int totalStackSize, PTR_PTR_Object pContinuation);
@@ -2069,6 +2075,18 @@ CallStubHeader::InvokeFunctionPtr CallStubGenerator::GetInvokeFunctionPtr(CallSt
             INVOKE_FUNCTION_PTR(CallJittedMethodRetDouble);
         case ReturnTypeI8:
             INVOKE_FUNCTION_PTR(CallJittedMethodRetI8);
+        case ReturnTypeI1:
+            INVOKE_FUNCTION_PTR(CallJittedMethodRetI1);
+        case ReturnTypeU1:
+            INVOKE_FUNCTION_PTR(CallJittedMethodRetU1);
+        case ReturnTypeI2:
+            INVOKE_FUNCTION_PTR(CallJittedMethodRetI2);
+        case ReturnTypeU2:
+            INVOKE_FUNCTION_PTR(CallJittedMethodRetU2);
+        case ReturnTypeI4:
+            INVOKE_FUNCTION_PTR(CallJittedMethodRetI4);
+        case ReturnTypeU4:
+            INVOKE_FUNCTION_PTR(CallJittedMethodRetU4);
 #ifdef TARGET_AMD64
 #ifdef TARGET_WINDOWS
         case ReturnTypeBuffArg1:
@@ -2161,7 +2179,13 @@ PCODE CallStubGenerator::GetInterpreterReturnTypeHandler(CallStubGenerator::Retu
             RETURN_TYPE_HANDLER(InterpreterStubRetVoid);
         case ReturnTypeDouble:
             RETURN_TYPE_HANDLER(InterpreterStubRetDouble);
+        case ReturnTypeI1:
+        case ReturnTypeU1:
         case ReturnTypeI8:
+        case ReturnTypeI2:
+        case ReturnTypeU2:
+        case ReturnTypeI4:
+        case ReturnTypeU4:
             RETURN_TYPE_HANDLER(InterpreterStubRetI8);
 #ifdef TARGET_AMD64
         case ReturnTypeBuffArg1:
@@ -3054,14 +3078,20 @@ CallStubGenerator::ReturnType CallStubGenerator::GetReturnType(ArgIteratorType *
 
         switch (thReturnType)
         {
-            case ELEMENT_TYPE_BOOLEAN:
-            case ELEMENT_TYPE_CHAR:
             case ELEMENT_TYPE_I1:
+                return ReturnTypeI1;
+            case ELEMENT_TYPE_BOOLEAN:
             case ELEMENT_TYPE_U1:
+                return ReturnTypeU1;
             case ELEMENT_TYPE_I2:
+                return ReturnTypeI2;
+            case ELEMENT_TYPE_CHAR:
             case ELEMENT_TYPE_U2:
+                return ReturnTypeU2;
             case ELEMENT_TYPE_I4:
+                return ReturnTypeI4;
             case ELEMENT_TYPE_U4:
+                return ReturnTypeU4;
             case ELEMENT_TYPE_I8:
             case ELEMENT_TYPE_U8:
             case ELEMENT_TYPE_I:
@@ -3078,6 +3108,9 @@ CallStubGenerator::ReturnType CallStubGenerator::GetReturnType(ArgIteratorType *
                 return ReturnTypeI8;
                 break;
             case ELEMENT_TYPE_R4:
+#ifdef TARGET_ARM64
+                return ReturnTypeFloat;
+#endif // TARGET_ARM64
             case ELEMENT_TYPE_R8:
                 return ReturnTypeDouble;
                 break;

--- a/src/coreclr/vm/callstubgenerator.h
+++ b/src/coreclr/vm/callstubgenerator.h
@@ -69,6 +69,12 @@ class CallStubGenerator
     enum ReturnType
     {
         ReturnTypeVoid,
+        ReturnTypeI1,
+        ReturnTypeU1,
+        ReturnTypeI2,
+        ReturnTypeU2,
+        ReturnTypeI4,
+        ReturnTypeU4,
         ReturnTypeI8,
         ReturnTypeDouble,
 #ifdef TARGET_AMD64

--- a/src/coreclr/vm/callstubgenerator.h
+++ b/src/coreclr/vm/callstubgenerator.h
@@ -73,8 +73,6 @@ class CallStubGenerator
         ReturnTypeU1,
         ReturnTypeI2,
         ReturnTypeU2,
-        ReturnTypeI4,
-        ReturnTypeU4,
         ReturnTypeI8,
         ReturnTypeDouble,
 #ifdef TARGET_AMD64

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -1154,6 +1154,161 @@ NESTED_END CallJittedMethodRetBuff, _TEXT
 // a2 - interpreter stack return value location
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
+NESTED_ENTRY CallJittedMethodRetI1, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    sd a2, 16(fp)
+    sd a4, 24(fp)
+    sub sp, sp, a3
+    mv t2, a0
+    mv t3, a1
+    ld t4, 0(t2)
+    addi t2, t2, 8
+    jalr t4
+    ld a4, 24(fp)
+    sd a2, 0(a4)
+    ld a2, 16(fp)
+    // Sign extend 8-bit to 64-bit
+    sext.b a0, a0
+    sd a0, 0(a2)
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, ra, 32
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRetI1, _TEXT
+
+// a0 - routines array
+// a1 - interpreter stack args location
+// a2 - interpreter stack return value location
+// a3 - stack arguments size (properly aligned)
+// a4 - address of continuation return value
+NESTED_ENTRY CallJittedMethodRetI2, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    sd a2, 16(fp)
+    sd a4, 24(fp)
+    sub sp, sp, a3
+    mv t2, a0
+    mv t3, a1
+    ld t4, 0(t2)
+    addi t2, t2, 8
+    jalr t4
+    ld a4, 24(fp)
+    sd a2, 0(a4)
+    ld a2, 16(fp)
+    // Sign extend 16-bit to 64-bit
+    sext.h a0, a0
+    sd a0, 0(a2)
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, ra, 32
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRetI2, _TEXT
+
+// a0 - routines array
+// a1 - interpreter stack args location
+// a2 - interpreter stack return value location
+// a3 - stack arguments size (properly aligned)
+// a4 - address of continuation return value
+NESTED_ENTRY CallJittedMethodRetI4, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    sd a2, 16(fp)
+    sd a4, 24(fp)
+    sub sp, sp, a3
+    mv t2, a0
+    mv t3, a1
+    ld t4, 0(t2)
+    addi t2, t2, 8
+    jalr t4
+    ld a4, 24(fp)
+    sd a2, 0(a4)
+    ld a2, 16(fp)
+    // Sign extend 32-bit to 64-bit
+    sext.w a0, a0
+    sd a0, 0(a2)
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, ra, 32
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRetI4, _TEXT
+
+// a0 - routines array
+// a1 - interpreter stack args location
+// a2 - interpreter stack return value location
+// a3 - stack arguments size (properly aligned)
+// a4 - address of continuation return value
+NESTED_ENTRY CallJittedMethodRetU1, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    sd a2, 16(fp)
+    sd a4, 24(fp)
+    sub sp, sp, a3
+    mv t2, a0
+    mv t3, a1
+    ld t4, 0(t2)
+    addi t2, t2, 8
+    jalr t4
+    ld a4, 24(fp)
+    sd a2, 0(a4)
+    ld a2, 16(fp)
+    // Zero extend 8-bit to 64-bit
+    zext.b a0, a0
+    sd a0, 0(a2)
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, ra, 32
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRetU1, _TEXT
+
+// a0 - routines array
+// a1 - interpreter stack args location
+// a2 - interpreter stack return value location
+// a3 - stack arguments size (properly aligned)
+// a4 - address of continuation return value
+NESTED_ENTRY CallJittedMethodRetU2, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    sd a2, 16(fp)
+    sd a4, 24(fp)
+    sub sp, sp, a3
+    mv t2, a0
+    mv t3, a1
+    ld t4, 0(t2)
+    addi t2, t2, 8
+    jalr t4
+    ld a4, 24(fp)
+    sd a2, 0(a4)
+    ld a2, 16(fp)
+    // Zero extend 16-bit to 64-bit
+    zext.h a0, a0
+    sd a0, 0(a2)
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, ra, 32
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRetU2, _TEXT
+
+// a0 - routines array
+// a1 - interpreter stack args location
+// a2 - interpreter stack return value location
+// a3 - stack arguments size (properly aligned)
+// a4 - address of continuation return value
+NESTED_ENTRY CallJittedMethodRetU4, _TEXT, NoHandler
+    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
+    sd a2, 16(fp)
+    sd a4, 24(fp)
+    sub sp, sp, a3
+    mv t2, a0
+    mv t3, a1
+    ld t4, 0(t2)
+    addi t2, t2, 8
+    jalr t4
+    ld a4, 24(fp)
+    sd a2, 0(a4)
+    ld a2, 16(fp)
+    // Zero extend 32-bit to 64-bit
+    zext.w a0, a0
+    sd a0, 0(a2)
+    EPILOG_STACK_RESTORE
+    EPILOG_RESTORE_REG_PAIR_INDEXED fp, ra, 32
+    EPILOG_RETURN
+NESTED_END CallJittedMethodRetU4, _TEXT
+// a0 - routines array
+// a1 - interpreter stack args location
+// a2 - interpreter stack return value location
+// a3 - stack arguments size (properly aligned)
+// a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetI8, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
     sd a2, 16(fp)

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -1206,32 +1206,6 @@ NESTED_END CallJittedMethodRetI2, _TEXT
 // a2 - interpreter stack return value location
 // a3 - stack arguments size (properly aligned)
 // a4 - address of continuation return value
-NESTED_ENTRY CallJittedMethodRetI4, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
-    sd a2, 16(fp)
-    sd a4, 24(fp)
-    sub sp, sp, a3
-    mv t2, a0
-    mv t3, a1
-    ld t4, 0(t2)
-    addi t2, t2, 8
-    jalr t4
-    ld a4, 24(fp)
-    sd a2, 0(a4)
-    ld a2, 16(fp)
-    // Sign extend 32-bit to 64-bit
-    sext.w a0, a0
-    sd a0, 0(a2)
-    EPILOG_STACK_RESTORE
-    EPILOG_RESTORE_REG_PAIR_INDEXED fp, ra, 32
-    EPILOG_RETURN
-NESTED_END CallJittedMethodRetI4, _TEXT
-
-// a0 - routines array
-// a1 - interpreter stack args location
-// a2 - interpreter stack return value location
-// a3 - stack arguments size (properly aligned)
-// a4 - address of continuation return value
 NESTED_ENTRY CallJittedMethodRetU1, _TEXT, NoHandler
     PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
     sd a2, 16(fp)
@@ -1279,31 +1253,6 @@ NESTED_ENTRY CallJittedMethodRetU2, _TEXT, NoHandler
     EPILOG_RETURN
 NESTED_END CallJittedMethodRetU2, _TEXT
 
-// a0 - routines array
-// a1 - interpreter stack args location
-// a2 - interpreter stack return value location
-// a3 - stack arguments size (properly aligned)
-// a4 - address of continuation return value
-NESTED_ENTRY CallJittedMethodRetU4, _TEXT, NoHandler
-    PROLOG_SAVE_REG_PAIR_INDEXED fp, ra, -32
-    sd a2, 16(fp)
-    sd a4, 24(fp)
-    sub sp, sp, a3
-    mv t2, a0
-    mv t3, a1
-    ld t4, 0(t2)
-    addi t2, t2, 8
-    jalr t4
-    ld a4, 24(fp)
-    sd a2, 0(a4)
-    ld a2, 16(fp)
-    // Zero extend 32-bit to 64-bit
-    zext.w a0, a0
-    sd a0, 0(a2)
-    EPILOG_STACK_RESTORE
-    EPILOG_RESTORE_REG_PAIR_INDEXED fp, ra, 32
-    EPILOG_RETURN
-NESTED_END CallJittedMethodRetU4, _TEXT
 // a0 - routines array
 // a1 - interpreter stack args location
 // a2 - interpreter stack return value location


### PR DESCRIPTION
A couple of libraries tests have uncovered an issue in handling return values from pinvokes when this value is an integer smaller than 64 bits. We were writing the value of the whole 64 bit return value register to the interpreter stack slot. It turns out that we should use only the proper number of bits of the return value and either zero or sign extend it to 64 bits depending of whether the return type is signed or unsigned.

I was considering making the change in the interpreter compiler, but in the end decided to add new flavors of CallJittedMethodXXX stubs that contain the conversions instead.