### PR TITLE
JIT: Always use CallInfo method handle for devirtualization

### DIFF
--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -586,9 +586,8 @@ private:
 
         if (tree->OperIs(GT_CALL))
         {
-            GenTreeCall*          call          = tree->AsCall();
-            CORINFO_METHOD_HANDLE method        = NO_METHOD_HANDLE;
-            bool                  tryLateDevirt = call->IsDevirtualizationCandidate(m_compiler, &method);
+            GenTreeCall*          call   = tree->AsCall();
+            bool tryLateDevirt = call->IsDevirtualizationCandidate(m_compiler);
 
 #ifdef DEBUG
             tryLateDevirt = tryLateDevirt && (JitConfig.JitEnableLateDevirtualization() == 1);
@@ -604,13 +603,12 @@ private:
                 }
 #endif // DEBUG
 
+                CORINFO_METHOD_HANDLE  method                 = call->gtLateDevirtualizationInfo->methodHnd;
                 CORINFO_CONTEXT_HANDLE context                = call->gtLateDevirtualizationInfo->exactContextHnd;
                 InlineContext*         inlinersContext        = call->gtLateDevirtualizationInfo->inlinersContext;
                 unsigned               methodFlags            = 0;
                 const bool             isLateDevirtualization = true;
                 const bool             explicitTailCall       = call->IsTailPrefixedCall();
-
-                assert(method != NO_METHOD_HANDLE);
 
                 CORINFO_CONTEXT_HANDLE contextInput = context;
                 context                             = nullptr;

--- a/src/coreclr/jit/fginline.cpp
+++ b/src/coreclr/jit/fginline.cpp
@@ -586,8 +586,8 @@ private:
 
         if (tree->OperIs(GT_CALL))
         {
-            GenTreeCall*          call   = tree->AsCall();
-            bool tryLateDevirt = call->IsDevirtualizationCandidate(m_compiler);
+            GenTreeCall* call          = tree->AsCall();
+            bool         tryLateDevirt = call->IsDevirtualizationCandidate(m_compiler);
 
 #ifdef DEBUG
             tryLateDevirt = tryLateDevirt && (JitConfig.JitEnableLateDevirtualization() == 1);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2370,49 +2370,13 @@ int GenTreeCall::GetNonStandardAddedArgCount(Compiler* compiler) const
 //
 // Arguments:
 //     compiler    - [In]  the compiler instance so that we can call eeFindHelper
-//     pMethHandle - [Out] the method handle if the call is a devirtualization candidate
 //
 // Return Value:
 //     Returns true if this GT_CALL node is a devirtualization candidate.
 //
-bool GenTreeCall::IsDevirtualizationCandidate(Compiler* compiler, CORINFO_METHOD_HANDLE* pMethHandle) const
+bool GenTreeCall::IsDevirtualizationCandidate(Compiler* compiler) const
 {
-    CORINFO_METHOD_HANDLE methHandleToDevirt = NO_METHOD_HANDLE;
-    bool                  isDevirtCandidate  = false;
-
-    if (IsVirtual() && gtCallType == CT_USER_FUNC)
-    {
-        methHandleToDevirt = gtCallMethHnd;
-        isDevirtCandidate  = true;
-    }
-    else if (IsGenericVirtual(compiler) && (JitConfig.JitEnableGenericVirtualDevirtualization() != 0))
-    {
-        GenTree* runtimeMethHndNode =
-            gtCallAddr->AsCall()->gtArgs.FindWellKnownArg(WellKnownArg::RuntimeMethodHandle)->GetNode();
-        assert(runtimeMethHndNode != nullptr);
-        switch (runtimeMethHndNode->OperGet())
-        {
-            case GT_RUNTIMELOOKUP:
-                methHandleToDevirt = runtimeMethHndNode->AsRuntimeLookup()->GetMethodHandle();
-                isDevirtCandidate  = true;
-                break;
-            case GT_CNS_INT:
-                methHandleToDevirt = CORINFO_METHOD_HANDLE(runtimeMethHndNode->AsIntCon()->gtCompileTimeHandle);
-                isDevirtCandidate  = true;
-                break;
-            default:
-                // Unable to get method handle for devirtualization.
-                // This can happen if the method handle is not an RUNTIMELOOKUP or CNS_INT for generic virtuals,
-                break;
-        }
-    }
-
-    if (pMethHandle)
-    {
-        *pMethHandle = methHandleToDevirt;
-    }
-
-    return isDevirtCandidate;
+    return IsVirtual() || IsGenericVirtual(compiler);
 }
 
 //-------------------------------------------------------------------------

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2376,7 +2376,7 @@ int GenTreeCall::GetNonStandardAddedArgCount(Compiler* compiler) const
 //
 bool GenTreeCall::IsDevirtualizationCandidate(Compiler* compiler) const
 {
-    return IsVirtual() || IsGenericVirtual(compiler);
+    return IsVirtual() || (IsGenericVirtual(compiler) && (JitConfig.JitEnableGenericVirtualDevirtualization() != 0));
 }
 
 //-------------------------------------------------------------------------

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -5273,7 +5273,7 @@ struct GenTreeCall final : public GenTree
                                               gtCallAddr->IsHelperCall(compiler, CORINFO_HELP_GVMLOOKUP_FOR_SLOT)));
     }
 
-    bool IsDevirtualizationCandidate(Compiler* compiler, CORINFO_METHOD_HANDLE* pMethHandle = nullptr) const;
+    bool IsDevirtualizationCandidate(Compiler* compiler) const;
 
     bool IsInlineCandidate() const
     {

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -1292,6 +1292,7 @@ DONE:
             JITDUMP("\nSaving generic context %p and inline context %p for call [%06u]\n", dspPtr(exactContextHnd),
                     dspPtr(compInlineContext), dspTreeID(call->AsCall()));
             LateDevirtualizationInfo* const info       = new (this, CMK_Inlining) LateDevirtualizationInfo;
+            info->methodHnd                            = callInfo->hMethod;
             info->exactContextHnd                      = exactContextHnd;
             info->inlinersContext                      = compInlineContext;
             call->AsCall()->gtLateDevirtualizationInfo = info;

--- a/src/coreclr/jit/inline.h
+++ b/src/coreclr/jit/inline.h
@@ -634,6 +634,7 @@ struct InlineCandidateInfo : public HandleHistogramProfileCandidateInfo
 //
 struct LateDevirtualizationInfo
 {
+    CORINFO_METHOD_HANDLE  methodHnd;
     CORINFO_CONTEXT_HANDLE exactContextHnd;
     InlineContext*         inlinersContext;
 };


### PR DESCRIPTION
We already have the method handle in CallInfo, so we don't need to rely on the GenTree to extract the method handle for devirtualization.

Previously in #122023 we changed the JIT to only devirtualize a call when we can get the method handle from the GenTree, which was unnecessarily conservative especially when we already have the method handle in CallInfo.

Fixes #123391