### PR TITLE
Fix MemoryStreamTests.MemoryStream_CapacityBoundaryChecks

### DIFF
--- a/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.Tests/MemoryStream/MemoryStreamTests.cs
@@ -160,9 +160,9 @@ namespace System.IO.Tests
                 ms.Capacity = MaxSupportedLength;
                 Assert.Equal(MaxSupportedLength, ms.Capacity);
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => ms.Capacity = MaxSupportedLength + 1);
+                Assert.Throws<OutOfMemoryException>(() => ms.Capacity = MaxSupportedLength + 1);
 
-                Assert.Throws<ArgumentOutOfRangeException>(() => ms.Capacity = int.MaxValue);
+                Assert.Throws<OutOfMemoryException>(() => ms.Capacity = int.MaxValue);
             }
         }
 


### PR DESCRIPTION
The test verifies the exception it gets when setting the capacity to a larger than valid value. It was expecting ArgumentOutOfRangeException, but the actual exception runtime generates is OutOfMemoryException.

The test is marked by the SkipOnCI attribute, so I guess that's why we are not seeing it failing there.