### PR TITLE
Be careful about getExactClasses of variant types

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -2282,7 +2282,7 @@ namespace Internal.JitInterface
         private int getExactClasses(CORINFO_CLASS_STRUCT_* baseType, int maxExactClasses, CORINFO_CLASS_STRUCT_** exactClsRet)
         {
             MetadataType type = HandleToObject(baseType) as MetadataType;
-            if (type == null)
+            if (type == null || type.HasVariance)
             {
                 return -1;
             }


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/123112 started running more outerloop tests, including: https://github.com/dotnet/runtime/blob/81e28e28a7dd0c5109f8a3c0e458d3de577e78f8/src/tests/JIT/Methodical/flowgraph/dev10_bug679008/sealedCastVariance.cs#L13-L32

We were incorrectly optimizing the `a.GetType() == typeof(Action<object>)` check to `false` (type of the parameter is `Action<string>` and JIT was asking for exact classes of `Action<string>`; and there are none).

Cc @dotnet/ilc-contrib @EgorBo 