### PR TITLE
Disable generic recursion test on native AOT

### DIFF
--- a/src/tests/JIT/Methodical/inlining/bug505642/test.cs
+++ b/src/tests/JIT/Methodical/inlining/bug505642/test.cs
@@ -28,7 +28,7 @@ public struct Tuple<T0, T1>
 
 public static class M
 {
-    [Fact]
+    [ConditionalFact(typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNotNativeAot))]
     [OuterLoop]
     public static int TestEntryPoint()
     {


### PR DESCRIPTION
Test started running with https://github.com/dotnet/runtime/pull/123112

This is past our cutoff so the method body gets compiled to `TypeLoadException`. We have generic recursion coverage in native AOT tests.

Cc @dotnet/ilc-contrib