### PR TITLE
[NET] Remove unnecessary Keyword property from internal log events

### DIFF
--- a/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.Associate.cs
+++ b/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.Associate.cs
@@ -29,7 +29,7 @@ namespace System.Net
         public static void Associate(object? thisOrContextObject, object first, object second, [CallerMemberName] string? memberName = null) =>
             Log.Associate(IdOf(thisOrContextObject), memberName, IdOf(first), IdOf(second));
 
-        [Event(AssociateEventId, Level = EventLevel.Informational, Keywords = Keywords.Default, Message = "[{2}]<-->[{3}]")]
+        [Event(AssociateEventId, Level = EventLevel.Informational, Message = "[{2}]<-->[{3}]")]
         private void Associate(string thisOrContextObject, string? memberName, string first, string second)
         {
             Debug.Assert(IsEnabled());

--- a/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.DumpBuffer.cs
+++ b/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.DumpBuffer.cs
@@ -34,7 +34,7 @@ namespace System.Net
         public static void DumpBuffer(object? thisOrContextObject, ReadOnlySpan<byte> buffer, [CallerMemberName] string? memberName = null) =>
             Log.DumpBuffer(IdOf(thisOrContextObject), memberName, buffer.Slice(0, Math.Min(buffer.Length, MaxDumpSize)).ToArray());
 
-        [Event(DumpArrayEventId, Level = EventLevel.Verbose, Keywords = Keywords.Debug)]
+        [Event(DumpArrayEventId, Level = EventLevel.Verbose)]
         private void DumpBuffer(string thisOrContextObject, string? memberName, byte[] buffer) =>
             WriteEvent(DumpArrayEventId, thisOrContextObject, memberName ?? MissingMember, buffer);
 

--- a/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.cs
+++ b/src/libraries/Common/src/System/Net/Logging/NetEventSource.Common.cs
@@ -38,12 +38,6 @@ namespace System.Net
         public static readonly NetEventSource Log = new NetEventSource();
 
         #region Metadata
-        public static class Keywords
-        {
-            public const EventKeywords Default = (EventKeywords)0x0001;
-            public const EventKeywords Debug = (EventKeywords)0x0002;
-        }
-
         private const string MissingMember = "(?)";
         private const string NullInstance = "(null)";
         private const string StaticMethodObject = "(static)";
@@ -74,7 +68,7 @@ namespace System.Net
         public static void Info(object? thisOrContextObject, object? message, [CallerMemberName] string? memberName = null) =>
             Log.Info(IdOf(thisOrContextObject), memberName, Format(message));
 
-        [Event(InfoEventId, Level = EventLevel.Informational, Keywords = Keywords.Default)]
+        [Event(InfoEventId, Level = EventLevel.Informational)]
         private void Info(string thisOrContextObject, string? memberName, string? message)
         {
             Debug.Assert(IsEnabled());
@@ -99,7 +93,7 @@ namespace System.Net
         public static void Error(object? thisOrContextObject, object message, [CallerMemberName] string? memberName = null) =>
             Log.ErrorMessage(IdOf(thisOrContextObject), memberName, Format(message));
 
-        [Event(ErrorEventId, Level = EventLevel.Error, Keywords = Keywords.Default)]
+        [Event(ErrorEventId, Level = EventLevel.Error)]
         private void ErrorMessage(string thisOrContextObject, string? memberName, string? message)
         {
             Debug.Assert(IsEnabled());

--- a/src/libraries/Common/src/System/Net/Security/NetEventSource.Security.Windows.cs
+++ b/src/libraries/Common/src/System/Net/Security/NetEventSource.Security.Windows.cs
@@ -20,15 +20,15 @@ namespace System.Net
         private const int OperationReturnedSomethingId = AcceptSecuritContextId + 1;
         // Make sure to update the event IDs in NetEventSource.Security.cs if you add more events here
 
-        [Event(EnumerateSecurityPackagesId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(EnumerateSecurityPackagesId, Level = EventLevel.Informational)]
         public void EnumerateSecurityPackages(string? securityPackage) =>
             WriteEvent(EnumerateSecurityPackagesId, securityPackage);
 
-        [Event(SspiPackageNotFoundId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(SspiPackageNotFoundId, Level = EventLevel.Informational)]
         public void SspiPackageNotFound(string packageName) =>
             WriteEvent(SspiPackageNotFoundId, packageName);
 
-        [Event(AcquireDefaultCredentialId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(AcquireDefaultCredentialId, Level = EventLevel.Informational)]
         public void AcquireDefaultCredential(string packageName, Interop.SspiCli.CredentialUse intent) =>
             WriteEvent(AcquireDefaultCredentialId, packageName, intent);
 
@@ -36,7 +36,7 @@ namespace System.Net
         public void AcquireCredentialsHandle(string packageName, Interop.SspiCli.CredentialUse intent, object authdata) =>
             AcquireCredentialsHandle(packageName, intent, IdOf(authdata));
 
-        [Event(AcquireCredentialsHandleId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(AcquireCredentialsHandleId, Level = EventLevel.Informational)]
         public void AcquireCredentialsHandle(string packageName, Interop.SspiCli.CredentialUse intent, string authdata) =>
             WriteEvent(AcquireCredentialsHandleId, packageName, (int)intent, authdata);
 
@@ -44,7 +44,7 @@ namespace System.Net
         public void InitializeSecurityContext(SafeFreeCredentials? credential, SafeDeleteContext? context, string? targetName, Interop.SspiCli.ContextFlags inFlags) =>
             InitializeSecurityContext(IdOf(credential), IdOf(context), targetName, inFlags);
 
-        [Event(InitializeSecurityContextId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(InitializeSecurityContextId, Level = EventLevel.Informational)]
         private void InitializeSecurityContext(string credential, string context, string? targetName, Interop.SspiCli.ContextFlags inFlags) =>
             WriteEvent(InitializeSecurityContextId, credential, context, targetName, (int)inFlags);
 
@@ -52,19 +52,19 @@ namespace System.Net
         public void AcceptSecurityContext(SafeFreeCredentials? credential, SafeDeleteContext? context, Interop.SspiCli.ContextFlags inFlags) =>
             AcceptSecurityContext(IdOf(credential), IdOf(context), inFlags);
 
-        [Event(AcceptSecuritContextId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(AcceptSecuritContextId, Level = EventLevel.Informational)]
         private void AcceptSecurityContext(string credential, string context, Interop.SspiCli.ContextFlags inFlags) =>
             WriteEvent(AcceptSecuritContextId, credential, context, (int)inFlags);
 
-        [Event(OperationReturnedSomethingId, Keywords = Keywords.Default, Level = EventLevel.Informational, Message = "{0} returned {1}.")]
+        [Event(OperationReturnedSomethingId, Level = EventLevel.Informational, Message = "{0} returned {1}.")]
         public void OperationReturnedSomething(string operation, Interop.SECURITY_STATUS errorCode) =>
             WriteEvent(OperationReturnedSomethingId, operation, errorCode);
 
-        [Event(SecurityContextInputBufferId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(SecurityContextInputBufferId, Level = EventLevel.Informational)]
         public void SecurityContextInputBuffer(string context, int inputBufferSize, int outputBufferSize, Interop.SECURITY_STATUS errorCode) =>
             WriteEvent(SecurityContextInputBufferId, context, inputBufferSize, outputBufferSize, (int)errorCode);
 
-        [Event(SecurityContextInputBuffersId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(SecurityContextInputBuffersId, Level = EventLevel.Informational)]
         public void SecurityContextInputBuffers(string context, int inputBuffersSize, int outputBufferSize, Interop.SECURITY_STATUS errorCode) =>
             WriteEvent(SecurityContextInputBuffersId, context, inputBuffersSize, outputBufferSize, (int)errorCode);
 

--- a/src/libraries/Common/tests/System/Net/EventSourceTestLogging.cs
+++ b/src/libraries/Common/tests/System/Net/EventSourceTestLogging.cs
@@ -19,19 +19,19 @@ namespace System.Net.Test.Common
             }
         }
 
-        [Event(1, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(1, Level = EventLevel.Informational)]
         public void TestMessage(string message)
         {
             WriteEvent(1, message);
         }
 
-        [Event(2, Keywords = Keywords.Debug, Level = EventLevel.Verbose)]
+        [Event(2, Level = EventLevel.Verbose)]
         public void TestVerboseMessage(string message)
         {
             WriteEvent(2, message);
         }
 
-        [Event(3, Keywords = Keywords.Debug, Level = EventLevel.Error)]
+        [Event(3, Level = EventLevel.Error)]
         public void TestAncillaryError(Exception ex)
         {
             WriteEvent(3, ex.ToString());

--- a/src/libraries/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/NetEventSource.Http.cs
@@ -25,7 +25,7 @@ namespace System.Net
             Log.UriBaseAddress(baseAddress?.ToString(), IdOf(obj));
         }
 
-        [Event(UriBaseAddressId, Keywords = Keywords.Debug, Level = EventLevel.Informational)]
+        [Event(UriBaseAddressId, Level = EventLevel.Informational)]
         private void UriBaseAddress(string? uriBaseAddress, string objName) =>
             WriteEvent(UriBaseAddressId, uriBaseAddress, objName);
 
@@ -36,19 +36,19 @@ namespace System.Net
             Log.ContentNull(IdOf(obj), GetHashCode(obj));
         }
 
-        [Event(ContentNullId, Keywords = Keywords.Debug, Level = EventLevel.Informational)]
+        [Event(ContentNullId, Level = EventLevel.Informational)]
         private void ContentNull(string objName, int objHash) =>
             WriteEvent(ContentNullId, objName, objHash);
 
-        [Event(HeadersInvalidValueId, Keywords = Keywords.Debug, Level = EventLevel.Error)]
+        [Event(HeadersInvalidValueId, Level = EventLevel.Error)]
         public void HeadersInvalidValue(string name, string rawValue) =>
             WriteEvent(HeadersInvalidValueId, name, rawValue);
 
-        [Event(HandlerMessageId, Keywords = Keywords.Debug, Level = EventLevel.Verbose)]
+        [Event(HandlerMessageId, Level = EventLevel.Verbose)]
         public void HandlerMessage(int poolId, int workerId, int requestId, string? memberName, string? message) =>
             WriteEvent(HandlerMessageId, poolId, workerId, requestId, memberName, message);
 
-        [Event(HandlerErrorId, Keywords = Keywords.Debug, Level = EventLevel.Error)]
+        [Event(HandlerErrorId, Level = EventLevel.Error)]
         public void HandlerMessageError(int poolId, int workerId, int requestId, string? memberName, string message) =>
             WriteEvent(HandlerErrorId, poolId, workerId, requestId, memberName, message);
 
@@ -59,7 +59,7 @@ namespace System.Net
             Log.AuthenticationInfo(uri?.ToString(), message);
         }
 
-        [Event(AuthenticationInfoId, Keywords = Keywords.Debug, Level = EventLevel.Verbose)]
+        [Event(AuthenticationInfoId, Level = EventLevel.Verbose)]
         public void AuthenticationInfo(string? uri, string message) =>
             WriteEvent(AuthenticationInfoId, uri, message);
 
@@ -70,7 +70,7 @@ namespace System.Net
             Log.AuthenticationError(uri?.ToString(), message);
         }
 
-        [Event(AuthenticationErrorId, Keywords = Keywords.Debug, Level = EventLevel.Error)]
+        [Event(AuthenticationErrorId, Level = EventLevel.Error)]
         public void AuthenticationError(string? uri, string message) =>
             WriteEvent(AuthenticationErrorId, uri, message);
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/NetEventSource.Security.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/NetEventSource.Security.cs
@@ -65,7 +65,7 @@ namespace System.Net
             SslStreamCtor(IdOf(sslStream), localId, remoteId);
         }
 
-        [Event(SslStreamCtorId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(SslStreamCtorId, Level = EventLevel.Informational)]
         private void SslStreamCtor(string thisOrContextObject, string? localId, string? remoteId) =>
               WriteEvent(SslStreamCtorId, thisOrContextObject, localId, remoteId);
 
@@ -73,7 +73,7 @@ namespace System.Net
         public void LocatingPrivateKey(X509Certificate x509Certificate, object instance) =>
             LocatingPrivateKey(x509Certificate.ToString(fVerbose: true), GetHashCode(instance));
 
-        [Event(LocatingPrivateKeyId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(LocatingPrivateKeyId, Level = EventLevel.Informational)]
         private void LocatingPrivateKey(string x509Certificate, int sslStreamHash) =>
             WriteEvent(LocatingPrivateKeyId, x509Certificate, sslStreamHash);
 
@@ -81,7 +81,7 @@ namespace System.Net
         public void CertIsType2(object instance) =>
             CertIsType2(GetHashCode(instance));
 
-        [Event(CertIsType2Id, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(CertIsType2Id, Level = EventLevel.Informational)]
         private void CertIsType2(int sslStreamHash) =>
             WriteEvent(CertIsType2Id, sslStreamHash);
 
@@ -89,7 +89,7 @@ namespace System.Net
         public void FoundCertInStore(bool serverMode, object instance) =>
             FoundCertInStore(serverMode ? "LocalMachine" : "CurrentUser", GetHashCode(instance));
 
-        [Event(FoundCertInStoreId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(FoundCertInStoreId, Level = EventLevel.Informational)]
         private void FoundCertInStore(string store, int sslStreamHash) =>
             WriteEvent(FoundCertInStoreId, store, sslStreamHash);
 
@@ -97,7 +97,7 @@ namespace System.Net
         public void NotFoundCertInStore(object instance) =>
             NotFoundCertInStore(GetHashCode(instance));
 
-        [Event(NotFoundCertInStoreId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(NotFoundCertInStoreId, Level = EventLevel.Informational)]
         private void NotFoundCertInStore(int sslStreamHash) =>
             WriteEvent(NotFoundCertInStoreId, sslStreamHash);
 
@@ -105,7 +105,7 @@ namespace System.Net
         public void RemoteCertificate(X509Certificate? remoteCertificate) =>
             RemoteCertificate(remoteCertificate?.ToString(fVerbose: true));
 
-        [Event(RemoteCertificateId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(RemoteCertificateId, Level = EventLevel.Informational)]
         private void RemoteCertificate(string? remoteCertificate) =>
             WriteEvent(RemoteCertificateId, remoteCertificate);
 
@@ -113,7 +113,7 @@ namespace System.Net
         public void CertificateFromDelegate(SslStream SslStream) =>
             CertificateFromDelegate(GetHashCode(SslStream));
 
-        [Event(CertificateFromDelegateId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(CertificateFromDelegateId, Level = EventLevel.Informational)]
         private void CertificateFromDelegate(int sslStreamHash) =>
             WriteEvent(CertificateFromDelegateId, sslStreamHash);
 
@@ -121,7 +121,7 @@ namespace System.Net
         public void NoDelegateNoClientCert(SslStream SslStream) =>
             NoDelegateNoClientCert(GetHashCode(SslStream));
 
-        [Event(NoDelegateNoClientCertId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(NoDelegateNoClientCertId, Level = EventLevel.Informational)]
         private void NoDelegateNoClientCert(int sslStreamHash) =>
             WriteEvent(NoDelegateNoClientCertId, sslStreamHash);
 
@@ -129,7 +129,7 @@ namespace System.Net
         public void NoDelegateButClientCert(SslStream SslStream) =>
             NoDelegateButClientCert(GetHashCode(SslStream));
 
-        [Event(NoDelegateButClientCertId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(NoDelegateButClientCertId, Level = EventLevel.Informational)]
         private void NoDelegateButClientCert(int sslStreamHash) =>
             WriteEvent(NoDelegateButClientCertId, sslStreamHash);
 
@@ -137,7 +137,7 @@ namespace System.Net
         public void AttemptingRestartUsingCert(X509Certificate? clientCertificate, SslStream SslStream) =>
             AttemptingRestartUsingCert(clientCertificate?.ToString(fVerbose: true), GetHashCode(SslStream));
 
-        [Event(AttemptingRestartUsingCertId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(AttemptingRestartUsingCertId, Level = EventLevel.Informational)]
         private void AttemptingRestartUsingCert(string? clientCertificate, int sslStreamHash) =>
             WriteEvent(AttemptingRestartUsingCertId, clientCertificate, sslStreamHash);
 
@@ -145,7 +145,7 @@ namespace System.Net
         public void NoIssuersTryAllCerts(SslStream SslStream) =>
             NoIssuersTryAllCerts(GetHashCode(SslStream));
 
-        [Event(NoIssuersTryAllCertsId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(NoIssuersTryAllCertsId, Level = EventLevel.Informational)]
         private void NoIssuersTryAllCerts(int sslStreamHash) =>
             WriteEvent(NoIssuersTryAllCertsId, sslStreamHash);
 
@@ -153,7 +153,7 @@ namespace System.Net
         public void LookForMatchingCerts(int issuersCount, SslStream SslStream) =>
             LookForMatchingCerts(issuersCount, GetHashCode(SslStream));
 
-        [Event(LookForMatchingCertsId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(LookForMatchingCertsId, Level = EventLevel.Informational)]
         private void LookForMatchingCerts(int issuersCount, int sslStreamHash) =>
             WriteEvent(LookForMatchingCertsId, issuersCount, sslStreamHash);
 
@@ -161,7 +161,7 @@ namespace System.Net
         public void SelectedCert(X509Certificate clientCertificate, SslStream SslStream) =>
             SelectedCert(clientCertificate?.ToString(fVerbose: true), GetHashCode(SslStream));
 
-        [Event(SelectedCertId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(SelectedCertId, Level = EventLevel.Informational)]
         private void SelectedCert(string? clientCertificate, int sslStreamHash) =>
             WriteEvent(SelectedCertId, clientCertificate, sslStreamHash);
 
@@ -169,7 +169,7 @@ namespace System.Net
         public void CertsAfterFiltering(int filteredCertsCount, SslStream SslStream) =>
             CertsAfterFiltering(filteredCertsCount, GetHashCode(SslStream));
 
-        [Event(CertsAfterFilteringId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(CertsAfterFilteringId, Level = EventLevel.Informational)]
         private void CertsAfterFiltering(int filteredCertsCount, int sslStreamHash) =>
             WriteEvent(CertsAfterFilteringId, filteredCertsCount, sslStreamHash);
 
@@ -177,7 +177,7 @@ namespace System.Net
         public void FindingMatchingCerts(SslStream SslStream) =>
             FindingMatchingCerts(GetHashCode(SslStream));
 
-        [Event(FindingMatchingCertsId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(FindingMatchingCertsId, Level = EventLevel.Informational)]
         private void FindingMatchingCerts(int sslStreamHash) =>
             WriteEvent(FindingMatchingCertsId, sslStreamHash);
 
@@ -185,12 +185,12 @@ namespace System.Net
         public void UsingCachedCredential(SslStream SslStream) =>
             UsingCachedCredential(GetHashCode(SslStream));
 
-        [Event(UsingCachedCredentialId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(UsingCachedCredentialId, Level = EventLevel.Informational)]
         private void UsingCachedCredential(int sslStreamHash) =>
             WriteEvent(UsingCachedCredentialId, sslStreamHash);
 
 #pragma warning disable SYSLIB0058 // Use NegotiatedCipherSuite.
-        [Event(SspiSelectedCipherSuitId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(SspiSelectedCipherSuitId, Level = EventLevel.Informational)]
         public void SspiSelectedCipherSuite(
             string process,
             SslProtocols sslProtocol,
@@ -211,7 +211,7 @@ namespace System.Net
         public void RemoteCertificateError(SslStream SslStream, string message) =>
             RemoteCertificateError(GetHashCode(SslStream), message);
 
-        [Event(RemoteCertificateErrorId, Keywords = Keywords.Default, Level = EventLevel.Verbose)]
+        [Event(RemoteCertificateErrorId, Level = EventLevel.Verbose)]
         private void RemoteCertificateError(int sslStreamHash, string message) =>
             WriteEvent(RemoteCertificateErrorId, sslStreamHash, message);
 
@@ -219,7 +219,7 @@ namespace System.Net
         public void RemoteCertDeclaredValid(SslStream SslStream) =>
             RemoteCertDeclaredValid(GetHashCode(SslStream));
 
-        [Event(RemoteVertificateValidId, Keywords = Keywords.Default, Level = EventLevel.Verbose)]
+        [Event(RemoteVertificateValidId, Level = EventLevel.Verbose)]
         private void RemoteCertDeclaredValid(int sslStreamHash) =>
             WriteEvent(RemoteVertificateValidId, sslStreamHash);
 
@@ -227,7 +227,7 @@ namespace System.Net
         public void RemoteCertHasNoErrors(SslStream SslStream) =>
             RemoteCertHasNoErrors(GetHashCode(SslStream));
 
-        [Event(RemoteCertificateSuccessId, Keywords = Keywords.Default, Level = EventLevel.Verbose)]
+        [Event(RemoteCertificateSuccessId, Level = EventLevel.Verbose)]
         private void RemoteCertHasNoErrors(int sslStreamHash) =>
             WriteEvent(RemoteCertificateSuccessId, sslStreamHash);
 
@@ -235,7 +235,7 @@ namespace System.Net
         public void RemoteCertUserDeclaredInvalid(SslStream SslStream) =>
             RemoteCertUserDeclaredInvalid(GetHashCode(SslStream));
 
-        [Event(RemoteCertificateInvalidId, Keywords = Keywords.Default, Level = EventLevel.Verbose)]
+        [Event(RemoteCertificateInvalidId, Level = EventLevel.Verbose)]
         private void RemoteCertUserDeclaredInvalid(int sslStreamHash) =>
             WriteEvent(RemoteCertificateInvalidId, sslStreamHash);
 
@@ -247,7 +247,7 @@ namespace System.Net
             SentFrame(IdOf(sslStream), info.ToString(), isComplete ? 1 : 0);
         }
 
-        [Event(SentFrameId, Keywords = Keywords.Default, Level = EventLevel.Verbose)]
+        [Event(SentFrameId, Level = EventLevel.Verbose)]
         private void SentFrame(string sslStream, string tlsFrame, int isComplete) =>
             WriteEvent(SentFrameId, sslStream, tlsFrame, isComplete);
 
@@ -263,7 +263,7 @@ namespace System.Net
             ReceivedFrame(IdOf(sslStream), info.ToString(), isComplete ? 1 : 0);
         }
 
-        [Event(ReceivedFrameId, Keywords = Keywords.Default, Level = EventLevel.Verbose)]
+        [Event(ReceivedFrameId, Level = EventLevel.Verbose)]
         private void ReceivedFrame(string sslStream, string tlsFrame, int isComplete) =>
             WriteEvent(ReceivedFrameId, sslStream, tlsFrame, isComplete);
 
@@ -271,7 +271,7 @@ namespace System.Net
         public void CertificateFromCertContext(SslStream sslStream) =>
             CertificateFromCertContext(GetHashCode(sslStream));
 
-        [Event(CertificateFromCertContextId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(CertificateFromCertContextId, Level = EventLevel.Informational)]
         public void CertificateFromCertContext(int sslStreamHash) =>
             WriteEvent(CertificateFromCertContextId, sslStreamHash);
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetEventSource.Sockets.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/NetEventSource.Sockets.cs
@@ -19,7 +19,7 @@ namespace System.Net
         public static void Accepted(Socket socket, object? remoteEp, object? localEp) =>
             Log.Accepted(IdOf(remoteEp), IdOf(localEp), GetHashCode(socket));
 
-        [Event(AcceptedId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(AcceptedId, Level = EventLevel.Informational)]
         private void Accepted(string remoteEp, string localEp, int socketHash) =>
             WriteEvent(AcceptedId, remoteEp, localEp, socketHash);
 
@@ -27,7 +27,7 @@ namespace System.Net
         public static void Connected(Socket socket, object? localEp, object? remoteEp) =>
             Log.Connected(IdOf(localEp), IdOf(remoteEp), GetHashCode(socket));
 
-        [Event(ConnectedId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(ConnectedId, Level = EventLevel.Informational)]
         private void Connected(string localEp, string remoteEp, int socketHash) =>
             WriteEvent(ConnectedId, localEp, remoteEp, socketHash);
 
@@ -35,7 +35,7 @@ namespace System.Net
         public static void ConnectedAsyncDns(Socket socket) =>
             Log.ConnectedAsyncDns(GetHashCode(socket));
 
-        [Event(ConnectedAsyncDnsId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(ConnectedAsyncDnsId, Level = EventLevel.Informational)]
         private void ConnectedAsyncDns(int socketHash) =>
             WriteEvent(ConnectedAsyncDnsId, socketHash);
 
@@ -43,7 +43,7 @@ namespace System.Net
         public static void NotLoggedFile(string filePath, Socket socket, SocketAsyncOperation completedOperation) =>
             Log.NotLoggedFile(filePath, GetHashCode(socket), completedOperation);
 
-        [Event(NotLoggedFileId, Keywords = Keywords.Default, Level = EventLevel.Informational)]
+        [Event(NotLoggedFileId, Level = EventLevel.Informational)]
         private void NotLoggedFile(string filePath, int socketHash, SocketAsyncOperation completedOperation) =>
             WriteEvent(NotLoggedFileId, filePath, socketHash, (int)completedOperation);
 

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/NetEventSource.WebSockets.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/NetEventSource.WebSockets.cs
@@ -42,11 +42,11 @@ namespace System.Net
         private const string Ping = "Ping";
         private const string Pong = "Pong";
 
-        [Event(KeepAliveSentId, Keywords = Keywords.Debug, Level = EventLevel.Informational)]
+        [Event(KeepAliveSentId, Level = EventLevel.Informational)]
         private void KeepAliveSent(string objName, string opcode, long payload) =>
             WriteEvent(KeepAliveSentId, objName, opcode, payload);
 
-        [Event(KeepAliveAckedId, Keywords = Keywords.Debug, Level = EventLevel.Informational)]
+        [Event(KeepAliveAckedId, Level = EventLevel.Informational)]
         private void KeepAliveAcked(string objName, long payload) =>
             WriteEvent(KeepAliveAckedId, objName, payload);
 
@@ -75,7 +75,7 @@ namespace System.Net
         // Debug Messages
         //
 
-        [Event(WsTraceId, Keywords = Keywords.Debug, Level = EventLevel.Verbose)]
+        [Event(WsTraceId, Level = EventLevel.Verbose)]
         private void WsTrace(string objName, string memberName, string message) =>
             WriteEvent(WsTraceId, objName, memberName, message);
 
@@ -98,11 +98,11 @@ namespace System.Net
         // Close
         //
 
-        [Event(CloseStartId, Keywords = Keywords.Debug, Level = EventLevel.Verbose)]
+        [Event(CloseStartId, Level = EventLevel.Verbose)]
         private void CloseStart(string objName, string memberName) =>
             WriteEvent(CloseStartId, objName, memberName);
 
-        [Event(CloseStopId, Keywords = Keywords.Debug, Level = EventLevel.Verbose)]
+        [Event(CloseStopId, Level = EventLevel.Verbose)]
         private void CloseStop(string objName, string memberName) =>
             WriteEvent(CloseStopId, objName, memberName);
 
@@ -124,11 +124,11 @@ namespace System.Net
         // ReceiveAsyncPrivate
         //
 
-        [Event(ReceiveStartId, Keywords = Keywords.Debug, Level = EventLevel.Informational)]
+        [Event(ReceiveStartId, Level = EventLevel.Informational)]
         private void ReceiveStart(string objName, string memberName, int bufferLength) =>
             WriteEvent(ReceiveStartId, objName, memberName, bufferLength);
 
-        [Event(ReceiveStopId, Keywords = Keywords.Debug, Level = EventLevel.Informational)]
+        [Event(ReceiveStopId, Level = EventLevel.Informational)]
         private void ReceiveStop(string objName, string memberName) =>
             WriteEvent(ReceiveStopId, objName, memberName);
 
@@ -150,11 +150,11 @@ namespace System.Net
         // SendFrameAsync
         //
 
-        [Event(SendStartId, Keywords = Keywords.Debug, Level = EventLevel.Verbose)]
+        [Event(SendStartId, Level = EventLevel.Verbose)]
         private void SendStart(string objName, string memberName, string opcode, int bufferLength) =>
             WriteEvent(SendStartId, objName, memberName, opcode, bufferLength);
 
-        [Event(SendStopId, Keywords = Keywords.Debug, Level = EventLevel.Verbose)]
+        [Event(SendStopId, Level = EventLevel.Verbose)]
         private void SendStop(string objName, string memberName) =>
             WriteEvent(SendStopId, objName, memberName);
 
@@ -176,11 +176,11 @@ namespace System.Net
         // AsyncMutex
         //
 
-        [Event(MutexEnterId, Keywords = Keywords.Debug, Level = EventLevel.Verbose)]
+        [Event(MutexEnterId, Level = EventLevel.Verbose)]
         private void MutexEnter(string objName, string memberName) =>
             WriteEvent(MutexEnterId, objName, memberName);
 
-        [Event(MutexExitId, Keywords = Keywords.Debug, Level = EventLevel.Verbose)]
+        [Event(MutexExitId, Level = EventLevel.Verbose)]
         private void MutexExit(string objName, string memberName) =>
             WriteEvent(MutexExitId, objName, memberName);
 


### PR DESCRIPTION
They were just containing the very same information as the `LogLevel` and having them specified prevents `dotnet trace` to collect the logs without masking for them in flags (see _:0xf_):
```
dotnet trace collect -p <pid> --providers Private.InternalDiagnostics.System.Net.Security:0xf,...
```

Tested manually.

cc @rzikm 