### PR TITLE
JIT: Remove tailcall "has GC safe point" assert

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3592,7 +3592,6 @@ GenTree* Lowering::LowerTailCallViaJitHelper(GenTreeCall* call, GenTree* callTar
     return result;
 }
 
-
 //------------------------------------------------------------------------
 // LowerCFGCall: Potentially lower a call to use control-flow guard. This
 // expands indirect calls into either a validate+call sequence or to a dispatch

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3639,7 +3639,7 @@ bool Lowering::IsBlockReachableWithoutGCSafePoint(BasicBlock* block)
             continue;
         }
 
-        block->VisitAllSuccs(comp, [&](BasicBlock* succ) {
+        visitBlock->VisitAllSuccs(comp, [&](BasicBlock* succ) {
             if (BitVecOps::TryAddElemD(&traits, visited, succ->bbNum))
             {
                 stack.Push(succ);

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -3515,10 +3515,10 @@ GenTree* Lowering::LowerTailCallViaJitHelper(GenTreeCall* call, GenTree* callTar
     assert(call->IsTailCallViaJitHelper());
     assert(callTarget != nullptr);
 
-    // The TailCall helper call never returns to the caller and is not GC interruptible.
-    // Therefore the block containing the tail call should be a GC safe point to avoid
-    // GC starvation. It is legal for the block to be unmarked iff the entry block is a
-    // GC safe point, as the entry block trivially dominates every reachable block.
+    // VM cannot use return address hijacking when A() and B() tail call each
+    // other in mutual recursion. Therefore, this block is reachable through
+    // a GC-safe point or the whole method is marked as fully interruptible.
+    //
     assert(comp->GetInterruptible() || comp->compCurBB->HasFlag(BBF_GC_SAFE_POINT) ||
            !IsBlockReachableWithoutGCSafePoint(comp->compCurBB));
 

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -198,7 +198,6 @@ private:
     GenTree* LowerDirectCall(GenTreeCall* call);
     GenTree* LowerNonvirtPinvokeCall(GenTreeCall* call);
     GenTree* LowerTailCallViaJitHelper(GenTreeCall* callNode, GenTree* callTarget);
-    bool     IsBlockReachableWithoutGCSafePoint(BasicBlock* block);
     void     LowerFastTailCall(GenTreeCall* callNode);
     GenTree* FirstOperand(GenTree* node);
     void     RehomeArgForFastTailCall(unsigned int lclNum,

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -198,6 +198,7 @@ private:
     GenTree* LowerDirectCall(GenTreeCall* call);
     GenTree* LowerNonvirtPinvokeCall(GenTreeCall* call);
     GenTree* LowerTailCallViaJitHelper(GenTreeCall* callNode, GenTree* callTarget);
+    bool     IsBlockReachableWithoutGCSafePoint(BasicBlock* block);
     void     LowerFastTailCall(GenTreeCall* callNode);
     GenTree* FirstOperand(GenTree* node);
     void     RehomeArgForFastTailCall(unsigned int lclNum,


### PR DESCRIPTION
`BBF_GC_SAFE_POINT` is not kept up to date so we cannot reliably assert this. The assert was already disabled for fast tailcalls for that reason, so remove it from there and from JIT helper based tailcalls as well.

Fix #122481