### PR TITLE
[release/10.0] Update MicrosoftCodeAnalysisVersion_LatestVS

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,7 +69,7 @@
       Source-build builds the product with the most recent previously source-built release. Thankfully, these two requirements line up nicely
       such that any version that satisfies the VS version requirement will also satisfy the .NET SDK version requirement because of how we ship.
     -->
-    <MicrosoftCodeAnalysisVersion_LatestVS>5.0.0-2.25612.105</MicrosoftCodeAnalysisVersion_LatestVS>
+    <MicrosoftCodeAnalysisVersion_LatestVS>5.0.0</MicrosoftCodeAnalysisVersion_LatestVS>
     <!-- Some of the analyzer dependencies used by ILLink project -->
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.5-beta1.23270.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,7 +69,7 @@
       Source-build builds the product with the most recent previously source-built release. Thankfully, these two requirements line up nicely
       such that any version that satisfies the VS version requirement will also satisfy the .NET SDK version requirement because of how we ship.
     -->
-    <MicrosoftCodeAnalysisVersion_LatestVS>4.14.0</MicrosoftCodeAnalysisVersion_LatestVS>
+    <MicrosoftCodeAnalysisVersion_LatestVS>5.0.0-2.26070.104</MicrosoftCodeAnalysisVersion_LatestVS>
     <!-- Some of the analyzer dependencies used by ILLink project -->
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.5-beta1.23270.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,7 +69,7 @@
       Source-build builds the product with the most recent previously source-built release. Thankfully, these two requirements line up nicely
       such that any version that satisfies the VS version requirement will also satisfy the .NET SDK version requirement because of how we ship.
     -->
-    <MicrosoftCodeAnalysisVersion_LatestVS>5.0.0-2.25523.111</MicrosoftCodeAnalysisVersion_LatestVS>
+    <MicrosoftCodeAnalysisVersion_LatestVS>5.0.0-2.25612.105</MicrosoftCodeAnalysisVersion_LatestVS>
     <!-- Some of the analyzer dependencies used by ILLink project -->
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.5-beta1.23270.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -69,7 +69,7 @@
       Source-build builds the product with the most recent previously source-built release. Thankfully, these two requirements line up nicely
       such that any version that satisfies the VS version requirement will also satisfy the .NET SDK version requirement because of how we ship.
     -->
-    <MicrosoftCodeAnalysisVersion_LatestVS>5.0.0-2.26070.104</MicrosoftCodeAnalysisVersion_LatestVS>
+    <MicrosoftCodeAnalysisVersion_LatestVS>5.0.0-2.25523.111</MicrosoftCodeAnalysisVersion_LatestVS>
     <!-- Some of the analyzer dependencies used by ILLink project -->
     <MicrosoftCodeAnalysisBannedApiAnalyzersVersion>3.3.5-beta1.23270.2</MicrosoftCodeAnalysisBannedApiAnalyzersVersion>
   </PropertyGroup>

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.Windows.cs
@@ -449,10 +449,12 @@ namespace System.Security.Cryptography
                     keyBytes.Length != expectedKeySize ||
                     !parameterSet.SequenceEqual(expectedParameterSet))
                 {
+#pragma warning disable IDE0071
                     Debug.Fail(
                         $"{nameof(blobType)}: {blobType}, " +
-                        $"{nameof(parameterSet)}: {parameterSet}, " +
+                        $"{nameof(parameterSet)}: {parameterSet.ToString()}, " +
                         $"{nameof(keyBytes)}.Length: {keyBytes.Length} / {expectedKeySize}");
+#pragma warning restore IDE0071
 
                     throw new CryptographicException();
                 }

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.Windows.cs
@@ -451,7 +451,7 @@ namespace System.Security.Cryptography
                 {
                     Debug.Fail(
                         $"{nameof(blobType)}: {blobType}, " +
-                        $"{nameof(parameterSet)}: {parameterSet.ToString()}, " +
+                        $"{nameof(parameterSet)}: {parameterSet}, " +
                         $"{nameof(keyBytes)}.Length: {keyBytes.Length} / {expectedKeySize}");
 
                     throw new CryptographicException();

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
@@ -238,7 +238,7 @@ namespace System.Security.Cryptography
                 {
                     Debug.Fail(
                         $"{nameof(blobType)}: {blobType}, " +
-                        $"{nameof(parameterSet)}: {parameterSet.ToString()}, " +
+                        $"{nameof(parameterSet)}: {parameterSet}, " +
                         $"{nameof(keyBytes)}.Length: {keyBytes.Length} / {expectedKeySize}");
 
                     throw new CryptographicException();

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaImplementation.Windows.cs
@@ -236,10 +236,12 @@ namespace System.Security.Cryptography
                     keyBytes.Length != expectedKeySize ||
                     !parameterSet.SequenceEqual(expectedParameterSet))
                 {
+#pragma warning disable IDE0071
                     Debug.Fail(
                         $"{nameof(blobType)}: {blobType}, " +
-                        $"{nameof(parameterSet)}: {parameterSet}, " +
+                        $"{nameof(parameterSet)}: {parameterSet.ToString()}, " +
                         $"{nameof(keyBytes)}.Length: {keyBytes.Length} / {expectedKeySize}");
+#pragma warning restore IDE0071
 
                     throw new CryptographicException();
                 }

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeNameParser.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeNameParser.cs
@@ -61,7 +61,9 @@ namespace System.Reflection.Metadata
                 return null;
             }
 
+#pragma warning disable IDE0071
             Debug.Assert(parsedName.GetNodeCount() == recursiveDepth, $"Node count mismatch for '{typeName.ToString()}'");
+#pragma warning restore IDE0071
 
             return parsedName;
         }


### PR DESCRIPTION
To match what is referenced in the 10.0.1xx SDK:
https://github.com/dotnet/sdk/blob/0b3258423a96e6b0e0582a31f09e10ce4478fc06/eng/Version.Details.xml#L95

Fixes https://github.com/dotnet/runtime/issues/123503

## Customer Impact

- [] Customer reported
- [x] Found internally

When using a .NET 11 SDK to build a net10.0 project with trimming enabled, the trim analyzer crashes on extension properties:

```
CSC : error AD0001: Analyzer 'ILLink.RoslynAnalyzer.DynamicallyAccessedMembersAnalyzer' threw an exception of type 'System.MissingMethodException' with message 'Method not found: 'Microsoft.CodeAnalysis.IParameterSymbol Microsoft.CodeAnalysis.ITypeSymbol.get_ExtensionParameter()'.'.
```

## Regression

- [x] Yes
- [ ] No

This regressed with the removal of a preview Roslyn API in .NET 11: https://github.com/dotnet/dotnet/pull/2822.

These APIs were marked `[Obsolete]` in .NET 10 but this did not cause build failures because:
- In the MS product build, analyzers reference an older Microsoft.CodeAnalysis (for compatibility with VS), where the API did not have `[Obsolete]`.
- In the source build (which referenced a current at the time version of Microsoft.CodeAnalysis), the obsoletion was not a source breaking change (the API was reintroduced on INamedTypeSymbol).

## Testing

The fix was verified on a repro app referencing a local build of the analyzer with the updated Microsoft.CodeAnalysis version. Existing test coverage in this repo also validates the behavior when binding to INamedTypeSymbol.ExtensionParameter.

## Risk

Low - the new version matches what is shipped with the 10.0.1xx SDK, so with this change we are ensuring that we build against a version compatible with that used at runtime.

---------