### PR TITLE
Do not try obtaining canonical dictionaries in `VirtualDispatchCellGenericLookupResult`

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -711,10 +711,18 @@ namespace ILCompiler.DependencyAnalysis
             if (isConcreteInstantiation || !instantiatedMethod.IsCanonicalMethod(CanonicalFormKind.Any))
             {
                 TypeSystemEntity contextOwner = context.Context;
-                GenericDictionaryNode dictionary =
-                    contextOwner is TypeDesc ?
-                    (GenericDictionaryNode)factory.TypeGenericDictionary((TypeDesc)contextOwner) :
-                    (GenericDictionaryNode)factory.MethodGenericDictionary((MethodDesc)contextOwner);
+                GenericDictionaryNode dictionary;
+
+                if (isConcreteInstantiation)
+                {
+                    dictionary = contextOwner is TypeDesc ?
+                        (GenericDictionaryNode)factory.TypeGenericDictionary((TypeDesc)contextOwner) :
+                        (GenericDictionaryNode)factory.MethodGenericDictionary((MethodDesc)contextOwner);
+                }
+                else
+                {
+                    dictionary = null;
+                }
 
                 return factory.InterfaceDispatchCell(instantiatedMethod, dictionary);
             }


### PR DESCRIPTION
We broke outerloops in #122012. Looks like the outerloop run was already broken in that PR but nobody went over the results.

```
  Process terminated. Assertion failed.
  !owningType.IsCanonicalSubtype(CanonicalFormKind.Any)
     at System.Diagnostics.DebugProvider.Fail(String, String) + 0x37
     at System.Diagnostics.Debug.Fail(String, String) + 0x49
     at ILCompiler.DependencyAnalysis.TypeGenericDictionaryNode..ctor(TypeDesc, NodeFactory) + 0x4c

...

D:\a\_work\1\s\artifacts\bin\coreclr\windows.x64.Checked\build\Microsoft.NETCore.Native.targets(332,5): error MSB3073: The command ""D:\a\_work\1\s\artifacts\bin\coreclr\windows.x64.Checked\x64\ilc\\ilc" @"D:\a\_work\1\s\artifacts\obj\Microsoft.Extensions.Logging.Tests\Release\net11.0-windows\native\Microsoft.Extensions.Logging.Tests.ilc.rsp"" exited with code 57005. [D:\a\_work\1\s\src\libraries\Microsoft.Extensions.Logging\tests\Common\Microsoft.Extensions.Logging.Tests.csproj::TargetFramework=net11.0-windows]
```

This is because we're trying to obtain generic dictionaries of something in a canonical form from here. The callsite identifier parameter is not necessary when referencing from NonConcrete methods because we're not going to build an associated generic dictionary anyway.