### PR TITLE
[release/10.0] Fix regression caused by special marker type optimization (#123413)

### DIFF
--- a/src/coreclr/vm/clsload.cpp
+++ b/src/coreclr/vm/clsload.cpp
@@ -4660,6 +4660,22 @@ BOOL ClassLoader::CanAccessFamily(
 
 #endif // #ifndef DACCESS_COMPILE
 
+bool ClassLoader::EligibleForSpecialMarkerTypeUsage(Instantiation inst, MethodTable* pOwnerMT)
+{
+    LIMITED_METHOD_DAC_CONTRACT;
+
+    if (pOwnerMT == NULL)
+        return false;
+
+    if (inst.GetNumArgs() > MethodTable::MaxGenericParametersForSpecialMarkerType)
+        return false;
+
+    if (!inst.ContainsAllOneType(pOwnerMT->GetSpecialInstantiationType()))
+        return false;
+
+    return true;
+}
+
 #ifdef DACCESS_COMPILE
 
 void

--- a/src/coreclr/vm/clsload.hpp
+++ b/src/coreclr/vm/clsload.hpp
@@ -1004,6 +1004,8 @@ private:
                                              TypeHandle typeHnd,
                                              ClassLoadLevel targetLevel);
 #endif //!DACCESS_COMPILE
+public:
+    static bool EligibleForSpecialMarkerTypeUsage(Instantiation inst, MethodTable* pOwnerMT);
 
 };  // class ClassLoader
 

--- a/src/coreclr/vm/siginfo.cpp
+++ b/src/coreclr/vm/siginfo.cpp
@@ -1616,9 +1616,17 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
 
                 Instantiation genericLoadInst(thisinst, ntypars);
 
-                if (pMTInterfaceMapOwner != NULL && genericLoadInst.ContainsAllOneType(pMTInterfaceMapOwner->GetSpecialInstantiationType()))
+                if (ClassLoader::EligibleForSpecialMarkerTypeUsage(genericLoadInst, pMTInterfaceMapOwner))
                 {
                     thRet = ClassLoader::LoadTypeDefThrowing(pGenericTypeModule, tkGenericType, ClassLoader::ThrowIfNotFound, ClassLoader::PermitUninstDefOrRef, 0, level);
+                    if (thRet.AsMethodTable()->GetInstantiation()[0] == pMTInterfaceMapOwner->GetSpecialInstantiationType())
+                    {
+                        // We loaded the special marker type, but it is ALSO the exact expected type which isn't a valid combination
+                        // In this case return something else (object) to indicate that
+                        // we found an invalid situation and this function should be retried without the special marker type logic enabled.
+                        thRet = TypeHandle(g_pObjectClass);
+                        break;
+                    }
                 }
                 else
                 {
@@ -1643,7 +1651,7 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
                         // the loaded type is not the expected type we should be looking for to return a special marker type, but the normal load has
                         // found a type which claims to be a special marker type. In this case return something else (object) to indicate that
                         // we found an invalid situation and this function should be retried without the special marker type logic enabled.
-                        thRet = TypeHandle(CoreLibBinder::GetElementType(ELEMENT_TYPE_OBJECT));
+                        thRet = TypeHandle(g_pObjectClass);
                         break;
                     }
                     else if (!handlingRecursiveGenericFieldScenario)

--- a/src/coreclr/vm/typehandle.h
+++ b/src/coreclr/vm/typehandle.h
@@ -691,6 +691,7 @@ public:
 
     bool ContainsAllOneType(TypeHandle th)
     {
+        LIMITED_METHOD_DAC_CONTRACT;
         for (DWORD i = GetNumArgs(); i > 0;)
         {
             if ((*this)[--i] != th)

--- a/src/tests/Directory.Build.props
+++ b/src/tests/Directory.Build.props
@@ -128,6 +128,11 @@
     <DefineConstants>$(DefineConstants);DEBUG;TRACE;XUNIT_PERF</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup>
+     <!-- The SDK for VB.NET requires the DefineConstants variable to be , delimited instead of ; -->
+     <DefineConstants Condition="'$(MSBuildProjectExtension)' == '.vbproj'">$(DefineConstants.Replace(';',','))</DefineConstants>
+  </PropertyGroup>
+
   <!-- Setup the default output and intermediate paths -->
   <PropertyGroup>
     <SkipXunitDependencyCopying>true</SkipXunitDependencyCopying>

--- a/src/tests/Loader/classloader/regressions/GitHub_123254/GitHub_123254.vb
+++ b/src/tests/Loader/classloader/regressions/GitHub_123254/GitHub_123254.vb
@@ -1,0 +1,199 @@
+' Licensed to the .NET Foundation under one or more agreements.
+' The .NET Foundation licenses this file to you under the MIT license.
+
+Imports System
+Imports System.Collections
+Imports System.Collections.Generic
+Imports Xunit
+
+' This test needs to be written in VB, since the C# compiler has a different rule around
+' filling in the InterfaceImpl table. Notably, the C# compiler will emit into the table, all of the
+' interfaces that are transitively implemented by a class that the C# compiler is aware of, and
+' the VB compiler will only emit the interfaces as specified in the source. In practice, this isn't
+' supposed to have any meaningful impact unless the set of assemblies being used at runtime does not
+' match the set of assemblies used at compile time, but it does impact some of the runtimes internal
+' algorithms around interface resolution, notably the behavior of LoadExactInterfaceMap has an optimization
+' that avoids doing quite a lot of work.
+Public Class GitHub_123254
+
+    ' Test the scenario where the implied interface is in the interface map of a containing interface as a special marker type, and the containing interface itself is ALSO a special marker type.
+    ' The critical path is that when establishing the interface map for ILayer3_1(Of T) we find read ILayer1_1(Of T) as a special marker type member of ILayer2_1(Of T), and the ILayer2_1(Of T) itself is a special marker type.
+    <Fact>
+    Public Shared Sub Test_Method1()
+        Dim w As New TestClass1(Of Integer)
+        Dim en As IEnumerator(Of Integer) = DirectCast(w, ILayer1_1(Of Integer)).GetEnumerator()
+    End Sub
+
+    Public Class TestClass1(Of T)
+        Implements ILayer3_1(Of T)
+
+        Public ReadOnly Property Count As Integer Implements ILayer2_1(Of T).Count
+
+        Public Function GetEnumerator() As IEnumerator(Of T) Implements ILayer1_1(Of T).GetEnumerator
+            Return DirectCast(Array.Empty(Of T)(), IEnumerable(Of T)).GetEnumerator()
+        End Function
+    End Class
+
+    Public Interface ILayer3_1(Of T)
+        Inherits ILayer2_1(Of T)
+    End Interface
+
+    Public Interface ILayer2_1(Of T)
+        Inherits ILayer1_1(Of T)
+        ReadOnly Property Count As Integer
+    End Interface
+
+    Public Interface ILayer1_1(Of T)
+        Function GetEnumerator() As IEnumerator(Of T)
+    End Interface
+
+    ' Test the scenario where the implied interface is in the interface map of a containing interface as a special marker type, and the containing interface itself is NOT a special marker type.
+    ' The critical path is that when establishing the interface map for ILayer3_2(Of T) we find read ILayer1_2(Of T) as a special marker type member of ILayer2_2(Of T), and the ILayer2_2(Of T) itself is a special marker type.
+    ' Then, it will also turn out that even though we had a special marker type in the interface map we're expanding, we will need to put an exact type into the map since that's what we actually need.
+    <Fact>
+    Public Shared Sub Test_Method2()
+        Dim w As New TestClass2(Of Integer)
+        Dim en As IEnumerator(Of String) = DirectCast(w, ILayer1_2(Of String)).GetEnumerator()
+    End Sub
+
+    Public Class TestClass2(Of T)
+        Implements ILayer3_2(Of T)
+        Public ReadOnly Property Count As Integer Implements ILayer2_2(Of String).Count
+
+        Public Function GetEnumerator() As IEnumerator(Of String) Implements ILayer1_2(Of String).GetEnumerator
+            Return DirectCast(Array.Empty(Of String)(), IEnumerable(Of String)).GetEnumerator()
+        End Function
+    End Class
+
+    Public Interface ILayer3_2(Of T)
+        Inherits ILayer2_2(Of String)
+    End Interface
+
+    Public Interface ILayer2_2(Of T)
+        Inherits ILayer1_2(Of T)
+        ReadOnly Property Count As Integer
+    End Interface
+
+    Public Interface ILayer1_2(Of T)
+        Function GetEnumerator() As IEnumerator(Of T)
+    End Interface
+
+    ' Test the scenario where the implied interface is in the interface map of a containing interface as a special marker type, and the containing interface itself is NOT a special marker type.
+    ' The critical path is that when establishing the interface map for TestClass3 we find read ILayer1_3(Of T) as a special marker type member of ILayer3_3(Of TestClass, Integer), but when we place
+    ' the interface onto TestClass3 we find that we can use the special marker type even though the containing interface is not the special marker type.
+    <Fact>
+    Public Shared Sub Test_Method3()
+        Dim w As New TestClass3
+        Dim en As IEnumerator(Of TestClass3) = DirectCast(w, ILayer1_3(Of TestClass3)).GetEnumerator()
+    End Sub
+
+    Public Structure TestClass3
+        Implements ILayer3_3(Of TestClass3, Integer)
+        Public ReadOnly Property Count As Integer Implements ILayer2_3(Of TestClass3).Count
+
+        Public Function GetEnumerator() As IEnumerator(Of TestClass3) Implements ILayer1_3(Of TestClass3).GetEnumerator
+            Return DirectCast(Array.Empty(Of TestClass3)(), IEnumerable(Of TestClass3)).GetEnumerator()
+        End Function
+    End Structure
+
+    Public Interface ILayer3_3(Of T, SomethingElse)
+        Inherits ILayer2_3(Of T)
+    End Interface
+
+    Public Interface ILayer2_3(Of T)
+        Inherits ILayer1_3(Of T)
+        ReadOnly Property Count As Integer
+    End Interface
+
+    Public Interface ILayer1_3(Of T)
+        Function GetEnumerator() As IEnumerator(Of T)
+    End Interface
+
+    ' Test the scenario where the implied interface is in the interface map of a containing interface as a special marker type, and the containing interface itself is NOT a special marker type.
+    ' The critical path is that when establishing the interface map for TestClass4 we find read ILayer3_4(Of String) and then under that there are exact types ILayer2_4(Of Integer) and ILayer1_4(Of TestClass4)
+    ' Then the algorithm will decide to put a special marker type for ILayer1_4(Of T) into the map since it is the appropriate shape, and we will place the exact type ILayer2_4(Of Integer) into the map since that is the exact type needed.
+    <Fact>
+    Public Shared Sub Test_Method4()
+        Dim w As New TestClass4
+        Dim en As IEnumerator(Of TestClass4) = DirectCast(w, ILayer1_4(Of TestClass4)).GetEnumerator()
+        Dim countVal As Integer = DirectCast(w, ILayer2_4(Of Integer)).Count
+    End Sub
+
+    Public Structure TestClass4
+        Implements ILayer3_4(Of String)
+        Public ReadOnly Property Count As Integer Implements ILayer2_4(Of Integer).Count
+
+        Public Function GetEnumerator() As IEnumerator(Of TestClass4) Implements ILayer1_4(Of TestClass4).GetEnumerator
+            Return DirectCast(Array.Empty(Of TestClass4)(), IEnumerable(Of TestClass4)).GetEnumerator()
+        End Function
+    End Structure
+
+    Public Interface ILayer3_4(Of T)
+        Inherits ILayer2_4(Of Integer)
+    End Interface
+
+    Public Interface ILayer2_4(Of T)
+        Inherits ILayer1_4(Of TestClass4)
+        ReadOnly Property Count As Integer
+    End Interface
+
+    Public Interface ILayer1_4(Of T)
+        Function GetEnumerator() As IEnumerator(Of T)
+    End Interface
+
+    ' Test path for forcing the interface map out of the supporting special marker types due to a conflict with the concept of special marker types
+    ' I could only find a way to hit this path with reflection, and since reflection is imperfect on NativeAOT, just skip this test there.
+    <ConditionalFact(GetType(TestLibrary.Utilities), NameOf(TestLibrary.Utilities.IsNotNativeAot))>
+    Public Shared Sub Test_Method5()
+        ' Test indirect implementation of interface
+        Dim testClassType As Type = GetType(TestClass5(Of Integer)).GetGenericTypeDefinition().MakeGenericType(GetType(ILayer1_5(Of Integer)).GetGenericTypeDefinition().GetGenericArguments()(0))
+        Console.WriteLine("testClassType first generic argument: " & testClassType.GetGenericArguments()(0).Name)
+        For Each iface As Type In testClassType.GetInterfaces()
+            Console.WriteLine("IFace name: " & iface.Name)
+            Console.WriteLine("IFace first generic argument: " & iface.GetGenericArguments()(0).Name)
+            Assert.Equal("Z", iface.GetGenericArguments()(0).Name)
+        Next
+
+        ' Test direct implementation of interface
+        testClassType = GetType(TestClass6(Of Integer)).GetGenericTypeDefinition().MakeGenericType(GetType(ILayer1_5(Of Integer)).GetGenericTypeDefinition().GetGenericArguments()(0))
+        Console.WriteLine("testClassType first generic argument: " & testClassType.GetGenericArguments()(0).Name)
+        For Each iface As Type In testClassType.GetInterfaces()
+            Console.WriteLine("IFace name: " & iface.Name)
+            Console.WriteLine("IFace first generic argument: " & iface.GetGenericArguments()(0).Name)
+            Assert.Equal("Z", iface.GetGenericArguments()(0).Name)
+        Next
+
+        ' Test implementation via containing interface
+        testClassType = GetType(ILayer3_5(Of Integer)).GetGenericTypeDefinition().MakeGenericType(GetType(ILayer1_5(Of Integer)).GetGenericTypeDefinition().GetGenericArguments()(0))
+        Console.WriteLine("testClassType first generic argument: " & testClassType.GetGenericArguments()(0).Name)
+        For Each iface As Type In testClassType.GetInterfaces()
+            Console.WriteLine("IFace name: " & iface.Name)
+            Console.WriteLine("IFace first generic argument: " & iface.GetGenericArguments()(0).Name)
+            Assert.Equal("Z", iface.GetGenericArguments()(0).Name)
+        Next
+    End Sub
+
+    Public Structure TestClass5(Of T)
+        Implements ILayer2_5(Of T, Integer)
+        Sub GetEnumerator(argument As TestClass5(Of T)) Implements ILayer1_5(Of T).GetEnumerator
+        End Sub
+    End Structure
+
+    Public Structure TestClass6(Of U)
+        Implements ILayer1_5(Of U)
+        Sub GetEnumerator(argument As TestClass5(Of U)) Implements ILayer1_5(Of U).GetEnumerator
+        End Sub
+    End Structure
+
+    Public Interface ILayer3_5(Of R)
+        Inherits ILayer2_5(Of R, Integer)
+    End Interface
+
+    Public Interface ILayer2_5(Of V, W)
+        Inherits ILayer1_5(Of V)
+    End Interface
+
+    Public Interface ILayer1_5(Of Z)
+        Sub GetEnumerator(argument As TestClass5(Of Z))
+    End Interface
+End Class

--- a/src/tests/Loader/classloader/regressions/GitHub_123254/GitHub_123254.vb
+++ b/src/tests/Loader/classloader/regressions/GitHub_123254/GitHub_123254.vb
@@ -59,7 +59,6 @@ Public Class GitHub_123254
     Public Class TestClass2(Of T)
         Implements ILayer3_2(Of T)
         Public ReadOnly Property Count As Integer Implements ILayer2_2(Of String).Count
-
         Public Function GetEnumerator() As IEnumerator(Of String) Implements ILayer1_2(Of String).GetEnumerator
             Return DirectCast(Array.Empty(Of String)(), IEnumerable(Of String)).GetEnumerator()
         End Function

--- a/src/tests/Loader/classloader/regressions/GitHub_123254/GitHub_123254.vbproj
+++ b/src/tests/Loader/classloader/regressions/GitHub_123254/GitHub_123254.vbproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="GitHub_123254.vb" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/regressions/GitHub_123318/GitHub_123318.cs
+++ b/src/tests/Loader/classloader/regressions/GitHub_123318/GitHub_123318.cs
@@ -1,0 +1,56 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// this test verifies that loading using the special marker type will not cause problems with generics with more than 8 parameters
+
+
+using System;
+using Xunit;
+
+public class GitHub_123318
+{
+    [Fact]
+    public static void Test()
+    {
+        var i = new MyEntity<string, string, string, string, string, string, string, string, string>(); // <-- Throws System.ExecutionEngineException in System.Reflection.MethodBaseInvoker.InvokeWithOneArg(...)
+    }
+
+    public sealed class MyEntity<TItem1, TItem2, TItem3, TItem4, TItem5, TItem6, TItem7, TItem8, TItem9> : IEditableEntity<TItem1, TItem2, TItem3, TItem4, TItem5, TItem6, TItem7, TItem8, TItem9>
+    {
+        public TItem1 Item1 {get; set;}
+        public TItem2 Item2 {get; set;}
+        public TItem3 Item3 {get; set;}
+        public TItem4 Item4 {get; set;}
+        public TItem5 Item5 {get; set;}
+        public TItem6 Item6 {get; set;}
+        public TItem7 Item7 {get; set;}
+        public TItem8 Item8 {get; set;}
+        public TItem9 Item9 {get; set;}
+    }
+
+    public interface IReadonlyEntity<TItem1, TItem2, TItem3, TItem4, TItem5, TItem6, TItem7, TItem8, TItem9>
+    {
+        TItem1 Item1 {get;}
+        TItem2 Item2 {get;}
+        TItem3 Item3 {get;}
+        TItem4 Item4 {get;}
+        TItem5 Item5 {get;}
+        TItem6 Item6 {get;}
+        TItem7 Item7 {get;}
+        TItem8 Item8 {get;}
+        TItem9 Item9 {get;}
+    }
+
+    public interface IEditableEntity<TItem1, TItem2, TItem3, TItem4, TItem5, TItem6, TItem7, TItem8, TItem9> : IReadonlyEntity<TItem1, TItem2, TItem3, TItem4, TItem5, TItem6, TItem7, TItem8, TItem9>
+    {
+        new TItem1 Item1 {get;set;}
+        new TItem2 Item2 {get;set;}
+        new TItem3 Item3 {get;set;}
+        new TItem4 Item4 {get;set;}
+        new TItem5 Item5 {get;set;}
+        new TItem6 Item6 {get;set;}
+        new TItem7 Item7 {get;set;}
+        new TItem8 Item8 {get;set;}
+        new TItem9 Item9 {get;set;}
+    }
+}

--- a/src/tests/Loader/classloader/regressions/GitHub_123318/GitHub_123318.csproj
+++ b/src/tests/Loader/classloader/regressions/GitHub_123318/GitHub_123318.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="GitHub_123318.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Backport of #123413 to release/10.0

/cc @Copilot

## Customer Impact

- [x] Customer reported
- [ ] Found internally

[Select one or both of the boxes. Describe how this issue impacts customers, citing the expected and actual behaviors and scope of the issue. If customer-reported, provide the issue number.]

There are 2 fixes here
1. For issue #123254, the problem is that the implementation of the optimized path interface map logic for interfaces which can be expanded by just manually expanding the first 2 layers of interfaces was not wired up at all. It turns out that this path is almost exclusively only available to VB.NET programs due to differences in the metadata generation algorithms between the VB and C# compilers. Notably, the VB.NET compiler does not expand the full set of interfaces into the outermost type, and C# compilation does. The fix is to implement handling for all of the various combinations of type that can appear at that point. See the newly added regression test for details on how to get into those situations. All known customers hitting this issue are using VB.NET, although it is theoretically possible to encounter this problem in C# if complex binary assembly compatibility scenarios are in play. (e.g Assembly A is built against assembly B version 1 which has a significantly less complex implied interface hierarchy, but is run against assembly B version 2 which has a more complex hierarchy.) However, this is a relatively unusual scenario.
2. For issue #123318 there was an issue where if there are more than MaxGenericParametersForSpecialMarkerType but we may have attempted to use a special marker type to optimize type loading. The fix is to place the logic for determining if a type can be represented in an interface map via a special marker type into a common location, and to not forget the check against MaxGenericParametersForSpecialMarkerType. This is known to impact customers with large numbers of generic parameters on their types where all the generic parameters are the same. This issue is impacting customers using C# as well as VB.

Fixes #123254 and #123318

## Regression

- [x] Yes
- [ ] No

This regressed with the change to improve the performance of process startup. See PR #120712 . That PR had several bugs which were noticed within days of 10.0.2 releasing.

## Testing

The fix was verified by running the customer repro cases, and additional exploratory tests. New tests were added which stressed the problematic behavior. Notably, the new tests are written in VB.NET which due to an implementation detail of the VB.NET compiler has significantly different interface loading behavior compared to C#. The issue #123318 was simply an issue of insufficient boundary condition testing.

## Risk

Low compared to risk of fix remaining in the product.

This fix fixes issues in a codepath which was severely misbehaving. At worst this fix misses some special cases, but it's certainly better than it was before.

---------