### PR TITLE
Avoid C4319 build warnings in libunwind (#122179)

### DIFF
--- a/src/native/external/libunwind-version.txt
+++ b/src/native/external/libunwind-version.txt
@@ -11,3 +11,4 @@ Revert https://github.com/libunwind/libunwind/commit/ec03043244082b8f552881ba9fb
 Apply https://github.com/libunwind/libunwind/pull/734
 Apply https://github.com/libunwind/libunwind/pull/758
 Apply https://github.com/libunwind/libunwind/pull/741
+Apply https://github.com/libunwind/libunwind/pull/931

--- a/src/native/external/libunwind/include/libunwind_i.h
+++ b/src/native/external/libunwind/include/libunwind_i.h
@@ -437,6 +437,6 @@ static inline void invalidate_edi (struct elf_dyn_info *edi)
 # define DWARF_VAL_LOC(c,v)     DWARF_NULL_LOC
 #endif
 
-#define UNW_ALIGN(x,a) (((x)+(a)-1UL)&~((a)-1UL))
+#define UNW_ALIGN(x,a) (((size_t)(x) + (size_t)(a) - 1) & ~((size_t)(a) - 1))
 
 #endif /* libunwind_i_h */


### PR DESCRIPTION
Forward port of https://github.com/dotnet/runtime/pull/122179 to fix the broken runtime build with VS 2026