### PR TITLE
[8.0][browser][AOT] use response file for llvm-size

### DIFF
--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -183,7 +183,7 @@
       <_EmccDefaultFlagsRsp>$([MSBuild]::NormalizePath($(_WasmRuntimePackSrcDir), 'emcc-default.rsp'))</_EmccDefaultFlagsRsp>
       <_EmccDefaultLinkFlagsRsp>$([MSBuild]::NormalizePath($(_WasmRuntimePackSrcDir), 'emcc-link.rsp'))</_EmccDefaultLinkFlagsRsp>
 
-      <_EmcssLlvmsizeRsp>$(_WasmIntermediateOutputPath)emcc-llvmsize.rsp</_EmcssLlvmsizeRsp>
+      <_WasmLlvmSizeRsp>$(_WasmIntermediateOutputPath)emcc-llvmsize.rsp</_WasmLlvmSizeRsp>
 
       <WasmLinkIcalls Condition="'$(WasmLinkIcalls)' == ''">$(WasmBuildNative)</WasmLinkIcalls>
 
@@ -420,12 +420,15 @@
     <!-- for AOT builds we use llvm-size tool to collect size of the DATA segment in each object file -->
     <WriteLinesToFile 
         Condition="'$(_WasmShouldAOT)' == 'true'"
-        Lines="@(_AOTObjectFile->'&quot;%(Identity)&quot;', ' ')" 
-        File="$(_EmcssLlvmsizeRsp)" 
+        Lines="@(_AOTObjectFile->'&quot;%(Identity)&quot;')" 
+        File="$(_WasmLlvmSizeRsp)" 
         Overwrite="true" 
         WriteOnlyWhenDifferent="true" 
         />
-    <Exec Command='llvm-size$(_ExeExt) -d --format=sysv  "@$(_EmcssLlvmsizeRsp)"'
+    <ItemGroup Condition="'$(_WasmShouldAOT)' == 'true'">
+      <FileWrites Include="$(_WasmLlvmSizeRsp)" />
+    </ItemGroup>
+    <Exec Command='llvm-size$(_ExeExt) -d --format=sysv  "@$(_WasmLlvmSizeRsp)"'
           Condition="'$(_WasmShouldAOT)' == 'true'"
           IgnoreStandardErrorWarningFormat="true"
           ConsoleToMsBuild="true"

--- a/src/mono/wasm/build/WasmApp.Native.targets
+++ b/src/mono/wasm/build/WasmApp.Native.targets
@@ -182,6 +182,9 @@
       <_MonoAotCrossCompilerPath>@(MonoAotCrossCompiler->WithMetadataValue('RuntimeIdentifier','browser-wasm'))</_MonoAotCrossCompilerPath>
       <_EmccDefaultFlagsRsp>$([MSBuild]::NormalizePath($(_WasmRuntimePackSrcDir), 'emcc-default.rsp'))</_EmccDefaultFlagsRsp>
       <_EmccDefaultLinkFlagsRsp>$([MSBuild]::NormalizePath($(_WasmRuntimePackSrcDir), 'emcc-link.rsp'))</_EmccDefaultLinkFlagsRsp>
+
+      <_EmcssLlvmsizeRsp>$(_WasmIntermediateOutputPath)emcc-llvmsize.rsp</_EmcssLlvmsizeRsp>
+
       <WasmLinkIcalls Condition="'$(WasmLinkIcalls)' == ''">$(WasmBuildNative)</WasmLinkIcalls>
 
       <_WasmICallTablePath>$(_WasmIntermediateOutputPath)icall-table.h</_WasmICallTablePath>
@@ -415,7 +418,14 @@
     </ItemGroup>
 
     <!-- for AOT builds we use llvm-size tool to collect size of the DATA segment in each object file -->
-    <Exec Command="llvm-size$(_ExeExt) -d --format=sysv @(_AOTObjectFile->'&quot;%(Identity)&quot;', ' ')"
+    <WriteLinesToFile 
+        Condition="'$(_WasmShouldAOT)' == 'true'"
+        Lines="@(_AOTObjectFile->'&quot;%(Identity)&quot;', ' ')" 
+        File="$(_EmcssLlvmsizeRsp)" 
+        Overwrite="true" 
+        WriteOnlyWhenDifferent="true" 
+        />
+    <Exec Command='llvm-size$(_ExeExt) -d --format=sysv  "@$(_EmcssLlvmsizeRsp)"'
           Condition="'$(_WasmShouldAOT)' == 'true'"
           IgnoreStandardErrorWarningFormat="true"
           ConsoleToMsBuild="true"


### PR DESCRIPTION
Makes our Mono AOT SDK for Wasm/Browser run also on old versions of windows without long path support.

Backport of https://github.com/dotnet/runtime/pull/123548 to release/8.0 with modifications for Net8

## Customer Impact

- [x] Customer reported
- [ ] Found internally

Fixes https://github.com/dotnet/runtime/issues/123257

## Regression

- [ ] Yes
- [x] No

## Testing

Automated tests on CI

## Risk

