### PR TITLE
Mark new userevents tests as native AOT incompatible

### DIFF
--- a/src/tests/tracing/userevents/Directory.Build.props
+++ b/src/tests/tracing/userevents/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <NativeAotIncompatible>true</NativeAotIncompatible>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
These are all crashing:

```
11:31:58.741 Running test: tracing/userevents/custommetadata/custommetadata/custommetadata.cmd
Unhandled exception. System.ArgumentNullException: Value cannot be null. (Parameter 'path1')
   at System.ArgumentNullException.Throw(String)
   at System.IO.Path.Combine(String, String, String)
   at Tracing.UserEvents.Tests.Common.UserEventsTestRunner.ResolveRecordTracePath(String)
   at Tracing.UserEvents.Tests.Common.UserEventsTestRunner.RunOrchestrator(String, String, Func`2, Int32, Int32)
   at Tracing.UserEvents.Tests.CustomMetadata.CustomMetadata.Main(String[] args)
```