### PR TITLE
[NO-REVIEW] Use Zstandard for compressing singlefile assemblies

### DIFF
--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -8,7 +8,8 @@ include_directories(${CLR_SRC_NATIVE_DIR})
 include_directories(${RUNTIME_DIR})
 
 # needed when zLib compression is used
-include_directories(${CLR_SRC_NATIVE_DIR}/libs/System.IO.Compression.Native)
+include_directories(${CLR_SRC_NATIVE_DIR}/external/zstd/lib)
+# include_directories(${CLR_SRC_NATIVE_DIR}/libs/System.IO.Compression.Native)
 include_directories(${CLR_SRC_NATIVE_DIR}/libs/Common)
 
 add_definitions(-DUNICODE)

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -108,17 +108,25 @@ namespace Microsoft.NET.HostModel.Bundle
                 long fileLength = file.Length;
                 file.Position = 0;
 
-                // We use DeflateStream here.
-                // It uses GZip algorithm, but with a trivial header that does not contain file info.
+#if NET
+                using (ZstandardStream compressionStream = new ZstandardStream(bundle, CompressionLevel.SmallestSize, leaveOpen: true))
+                {
+                    compressionStream.SetSourceLength(fileLength);
+                    file.CopyTo(compressionStream);
+                }
+#else
                 CompressionLevel smallestSize = (CompressionLevel)3;
-                using (DeflateStream compressionStream = new DeflateStream(bundle, Enum.IsDefined(typeof(CompressionLevel), smallestSize) ? smallestSize : CompressionLevel.Optimal, leaveOpen: true))
+                CompressionLevel compressionLevel = Enum.IsDefined(typeof(CompressionLevel), smallestSize) ? smallestSize : CompressionLevel.Optimal;
+                using (DeflateStream compressionStream = new DeflateStream(bundle, compressionLevel, leaveOpen: true))
                 {
                     file.CopyTo(compressionStream);
                 }
+#endif
 
                 long compressedSize = bundle.Position - startOffset;
                 if (compressedSize < fileLength * 0.75)
                 {
+                    System.Console.WriteLine($"Compressed {file.Name} from {fileLength} bytes to {compressedSize} bytes");
                     return (startOffset, compressedSize);
                 }
 

--- a/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
+++ b/src/installer/managed/Microsoft.NET.HostModel/Bundle/Bundler.cs
@@ -126,7 +126,6 @@ namespace Microsoft.NET.HostModel.Bundle
                 long compressedSize = bundle.Position - startOffset;
                 if (compressedSize < fileLength * 0.75)
                 {
-                    System.Console.WriteLine($"Compressed {file.Name} from {fileLength} bytes to {compressedSize} bytes");
                     return (startOffset, compressedSize);
                 }
 

--- a/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
+++ b/src/installer/managed/Microsoft.NET.HostModel/Microsoft.NET.HostModel.csproj
@@ -37,6 +37,13 @@
     <Compile Include="$(CoreClrProjectRoot)tools\Common\MachO\**\*.cs" Link="MachO\%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
+    <Reference Include="System.IO.Compression.Zstandard">
+      <HintPath>$(MicrosoftNetCoreAppRefPackRefDir)System.IO.Compression.Zstandard.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
   <Import Project="$(RepositoryEngineeringDir)PackageDownloadAndReference.targets" />
 
 </Project>

--- a/src/native/corehost/bundle/extractor.h
+++ b/src/native/corehost/bundle/extractor.h
@@ -7,6 +7,10 @@
 #include "reader.h"
 #include "manifest.h"
 
+#if defined(NATIVE_LIBS_EMBEDDED)
+#include <zstd.h>
+#endif
+
 namespace bundle
 {
     class extractor_t
@@ -22,6 +26,16 @@ namespace bundle
             m_bundle_id = bundle_id;
             m_bundle_path = bundle_path;
         }
+
+#if defined(NATIVE_LIBS_EMBEDDED)
+        ~extractor_t()
+        {
+            if (m_dctx != nullptr)
+            {
+                ZSTD_freeDCtx(m_dctx);
+            }
+        }
+#endif
 
         pal::string_t& extract(reader_t& reader);
 
@@ -45,6 +59,9 @@ namespace bundle
         pal::string_t m_extraction_dir;
         pal::string_t m_working_extraction_dir;
         const manifest_t& m_manifest;
+#if defined(NATIVE_LIBS_EMBEDDED)
+        ZSTD_DCtx* m_dctx = nullptr;
+#endif
     };
 }
 


### PR DESCRIPTION
This is an experiment that replaces DEFLATE with Zstandard in single-file published applications for compression of bundled managed assemblies.

Edit: This has been quite complicated to figure out how to test, documenting the steps below for future reference.

- `build.cmd -s Clr+Libs+Packs -c Release
- extract "artifacts\packages\Release\Shipping\dotnet-runtime-11.0.0-dev-win-x64.zip" somewhere
- copy sdk folder from local .dotnet to the folder above
- replace all sdk\**\11.0.100-alpha.1.26064.118\Microsoft.NET.HostModel.dll with the dll from artifacts\bin\Microsoft.NET.HostModel\Release\net11.0\Microsoft.NET.HostModel.dll
    - This file contains the Bundler which does the compression during publish process.
- follow steps to dogfood locally built packages and singlefilehost:
    - https://github.com/dotnet/runtime/blob/99e94ce55d79ea7d702f4d1e0c5fc70f2677670f/c:/source/dotnet/runtime/docs/workflow/testing/host/using-apphost.md
    - https://github.com/dotnet/runtime/blob/6936d807ab02592e582c999fcfa39bff39c632b6/c:/source/dotnet/runtime/docs/workflow/testing/using-dev-shipping-packages.md
<details>

<summary>Resulting csproj file:</summary>

```csproj
<Project Sdk="Microsoft.NET.Sdk.Web">

  <PropertyGroup>
    <OutputType>Exe</OutputType>
    <TargetFramework>net11.0</TargetFramework>
    <RootNamespace>test_app</RootNamespace>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>

    <!-- Compression is opt-in -->
    <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>

    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
    <PublishSingleFile>true</PublishSingleFile>
    <SingleFileHostSourcePath>C:\source\dotnet\runtime\artifacts\bin\win-x64.Release\corehost\singlefilehost.exe</SingleFileHostSourcePath>
  </PropertyGroup>

<ItemGroup>
  <FrameworkReference Update="Microsoft.NETCore.App" RuntimeFrameworkVersion="11.0.0-dev" />
</ItemGroup>

</Project>
```
</details>

<details>
<summary>NuGet.config</summary>

```xml
<?xml version="1.0" encoding="utf-8"?>
<configuration>
  <config>
    <!-- use local nuget cache which you can delete between builds -->
    <add key="globalPackagesFolder" value="C:\source\repros\2026-02-02-zstd-bundling\test-app\nuget_cache" />
  </config>

  <packageSources>
    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
    <clear />
    <!-- <add key="nuget" value="https://api.nuget.org/v3/index.json" /> -->
    <add key="dotnet11" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet11/nuget/v3/index.json" />
    <add key="local runtime" value="D:\dotnet\runtime\artifacts\packages\Release\Shipping" />
  </packageSources>
</configuration>

```

</details>

- If changes to the singlefilehost are made (e.g. peimagelayout.cpp), entire Clr subset
- If you make changes to the bundler (Microsoft.NET.HostModel.dll) delete the bin/obj folders of the test application to force repacking.

The testing application was a simple ASP.NET hello world with the weather API, with immediate exit after startup

```cs
if (args.Length == 0)
{
    return;
}
```

## Startup speed impact

I temporarily put extra logs in the apphost to verify that we decompress at least some images, and there seem to have been about 20 of them. Startup times themselves had quite a multimodal distribution (probably due to filesystem caching), the times below show the lowest modality:

| hyperfine --warmup 10 --runs 10| Min|Max|Mean | Std dev|
|----|--:|--:|---:|---|
| Compression disabled | 69.5 ms | 94.8 ms | 79.9ms | 7.0 ms|
|Deflate|119.8 ms | 124.9 ms | 122.0 ms | 1.4 ms|
|Zstd (SmallestSize)| 118.0 ms | 121.8 ms| 120.4 ms| 1.2 ms|

I would expect similar diffs on higher modalities, there was no difference across different compression level options that I could measure, so I did not include more lines in the table above

## Build time and binary size impact:

For measuring build times and actual binary sizes I measured the execution of `dotnet publish ...` after deleting `bin` and `obj` folders (keeping the nuget_cache intact).

| Method| Mean | Std dev| Min| Max| Binary size| Size diff|
|----|--:|--:|---:|---|--:|--:|
| `Compression disabled` | 3.740 s| 0.106s | 3.600 s | 3.886 s | 102,889,121 B| 106.90% |
| `Zstandard (Quality=1)`  | 4.515  s| 0.123 s |  4.418 s |  4.671 s| 54,271,488 B | 9.14%
| `Zstandard (Quality=2)`  | 4.553  s| 0.200 s |  4.293 s |  4.848 s| 52,390,638 B | 5.35%
| `Zstandard (Quality=3)`  | 4.746  s| 0.089 s |  4.645 s |  4.880 s| 50,995,793 B | 2.55%
| `Zstandard (Quality=4)`  | 4.998  s| 0.271 s |  4.698 s |  5.410 s| 50,819,706 B | 2.2%
| `Zstandard (Quality=5)`  | 5.196  s| 0.283 s |  4.837 s |  5.563 s| 50,122,524 B | 0.79%
| `Deflate`                | *6.888 s* | *0.087 s* |  *6.776 s* | *7.035 s* | *49,728,027 B*| -
| `Zstandard (Quality=6)`  | 5.348  s| 0.118 s |  5.186 s |  5.451 s| 49,516,508 B | -0.43%
| `Zstandard (Quality=7)`  | 5.788  s| 0.326 s |  5.453 s |  6.307 s| 49,299,101 B | -0.86%
| `Zstandard (Quality=8)`  | 5.862  s| 0.105 s |  5.681 s |  5.946 s| 49,209,491 B | -1.04%
| `Zstandard (Quality=9)`  | 6.282  s| 0.280 s |  5.837 s |  6.583 s| 49,184,329 B | -1.09%
| `Zstandard (Quality=10)` | 6.614  s| 0.194 s |  6.287 s |  6.808 s| 49,121,708 B | -1.22%
| `Zstandard (Quality=11)` | 6.797  s| 0.320 s |  6.397 s |  7.201 s| 49,086,309 B | -1.29%
| `Zstandard (Quality=12)` | 7.071  s| 0.359 s |  6.812 s |  7.673 s| 49,081,407 B | -1.3%
| `Zstandard (Quality=13)` | 10.724 s| 4.174 s |  8.620 s | 18.187 s| 48,843,435 B | -1.78%
| `Zstandard (Quality=14)` | 9.556  s| 0.292 s |  9.128 s |  9.808 s| 48,512,643 B | -2.44%
| `Zstandard (Quality=15)` | 9.842  s| 0.219 s |  9.562 s | 10.161 s| 48,498,631 B | -2.47%
| `Zstandard (Quality=16)` | 14.723 s| 0.795 s | 14.228 s | 16.137 s| 47,187,005 B | -5.11%
| `Zstandard (Quality=17)` | 14.984 s| 0.126 s | 14.870 s | 15.179 s| 46,609,240 B | -6.27%
| `Zstandard (Quality=18)` | 19.173 s| 0.246 s | 18.945 s | 19.542 s| 45,003,552 B | -9.5%
| `Zstandard (Quality=19)` | 23.365 s| 1.071 s | 22.347 s | 24.968 s| 44,972,958 B | -9.56%
| `Zstandard (Quality=20)` | 23.067 s| 0.679 s | 22.050 s | 23.826 s| 44,964,647 B | -9.58%
| `Zstandard (Quality=21)` | 21.588 s| 1.638 s | 19.780 s | 23.580 s| 44,964,082 B | -9.58%
| `Zstandard (Quality=22)` | 24.276 s| 0.587 s | 23.616 s | 25.139 s| 44,963,834 B | -9.58%

Looks like for Quality values between 5 and 11, we start getting small gains in both startup time and binary size, but they seem rather small, we can squeeze some more gains by training a dictionary on the usual dll files (runtime+aspnet?), but this shaves only about additional 1MB at most, so is likely not worth the extra logistics around embedding the decompression dictionary in the singlefile exe