### PR TITLE
Remove System.ServiceModel.Primitives dependency

### DIFF
--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -7,8 +7,6 @@ This file should be imported by eng/Versions.props
   <PropertyGroup>
     <!-- dotnet/icu dependencies -->
     <MicrosoftNETCoreRuntimeICUTransportPackageVersion>11.0.0-alpha.1.26063.1</MicrosoftNETCoreRuntimeICUTransportPackageVersion>
-    <!-- dotnet/wcf dependencies -->
-    <SystemServiceModelPrimitivesPackageVersion>4.9.0-rc2.21473.1</SystemServiceModelPrimitivesPackageVersion>
     <!-- dotnet/llvm-project dependencies -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeJITToolsPackageVersion>19.1.0-alpha.1.25625.2</runtimelinuxarm64MicrosoftNETCoreRuntimeJITToolsPackageVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMLibclangPackageVersion>19.1.0-alpha.1.25625.2</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMLibclangPackageVersion>
@@ -123,8 +121,6 @@ This file should be imported by eng/Versions.props
   <PropertyGroup>
     <!-- dotnet/icu dependencies -->
     <MicrosoftNETCoreRuntimeICUTransportVersion>$(MicrosoftNETCoreRuntimeICUTransportPackageVersion)</MicrosoftNETCoreRuntimeICUTransportVersion>
-    <!-- dotnet/wcf dependencies -->
-    <SystemServiceModelPrimitivesVersion>$(SystemServiceModelPrimitivesPackageVersion)</SystemServiceModelPrimitivesVersion>
     <!-- dotnet/llvm-project dependencies -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeJITToolsVersion>$(runtimelinuxarm64MicrosoftNETCoreRuntimeJITToolsPackageVersion)</runtimelinuxarm64MicrosoftNETCoreRuntimeJITToolsVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMLibclangVersion>$(runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMLibclangPackageVersion)</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMLibclangVersion>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -5,10 +5,6 @@
       <Uri>https://github.com/dotnet/icu</Uri>
       <Sha>b12b32d4177efa391c10895fc2ef3b7a21fb1d4d</Sha>
     </Dependency>
-    <Dependency Name="System.ServiceModel.Primitives" Version="4.9.0-rc2.21473.1">
-      <Uri>https://github.com/dotnet/wcf</Uri>
-      <Sha>7f504aabb1988e9a093c1e74d8040bd52feb2f01</Sha>
-    </Dependency>
     <Dependency Name="runtime.linux-arm64.Microsoft.NETCore.Runtime.JIT.Tools" Version="19.1.0-alpha.1.25625.2">
       <Uri>https://github.com/dotnet/llvm-project</Uri>
       <Sha>90a3b767fd10543cbaed7308406e0059dec0ffb7</Sha>


### PR DESCRIPTION
This was needed for Windows compat pack at some point but is not needed anymore.