### PR TITLE
Fix EH profiler notifications

### DIFF
--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3717,7 +3717,7 @@ NOINLINE static void NotifyFunctionEnterHelper(StackFrameIterator *pThis, Thread
 {
     MethodDesc *pMD = pThis->m_crawl.GetFunction();
 
-    if (pThis->m_crawl.IsFunclet() && (pMD == pExInfo->m_pMDToReportFunctionLeave))
+    if (pExInfo->m_reportedFunctionEnterWasForFunclet && (pMD == pExInfo->m_pMDToReportFunctionLeave))
     {
         // In case of a funclet, the pMD represents the parent of the funclet. We only want to report entering and leaving
         // the method once. So we ignore transitions from the funclet to the parent method or the funclet into another funclet
@@ -3743,6 +3743,7 @@ NOINLINE static void NotifyFunctionEnterHelper(StackFrameIterator *pThis, Thread
     }
 
     pExInfo->m_pMDToReportFunctionLeave = pMD;
+    pExInfo->m_reportedFunctionEnterWasForFunclet = pThis->m_crawl.IsFunclet();
 }
 
 static void NotifyFunctionEnter(StackFrameIterator *pThis, Thread *pThread, ExInfo *pExInfo)

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3717,6 +3717,14 @@ NOINLINE static void NotifyFunctionEnterHelper(StackFrameIterator *pThis, Thread
 {
     MethodDesc *pMD = pThis->m_crawl.GetFunction();
 
+    if (pThis->m_crawl.IsFunclet() && (pMD == pExInfo->m_pMDToReportFunctionLeave))
+    {
+        // In case of a funclet, the pMD represents the parent of the funclet. We only want to report entering and leaving
+        // the method once. So we ignore transitions from the funclet to the parent method or the funclet into another funclet
+        // of the same parent method.
+        return;
+    }
+
     if (pExInfo->m_passNumber == 1)
     {
         if (pExInfo->m_pMDToReportFunctionLeave != NULL)

--- a/src/coreclr/vm/exinfo.cpp
+++ b/src/coreclr/vm/exinfo.cpp
@@ -30,7 +30,8 @@ ExInfo::ExInfo(Thread *pThread, EXCEPTION_RECORD *pExceptionRecord, CONTEXT *pEx
     m_propagateExceptionContext(NULL),
 #endif // HOST_UNIX
     m_CurrentClause({}),
-    m_pMDToReportFunctionLeave(NULL)
+    m_pMDToReportFunctionLeave(NULL),
+    m_reportedFunctionEnterWasForFunclet(false)
 #ifdef HOST_WINDOWS
     , m_pLongJmpBuf(NULL),
     m_longJmpReturnValue(0)

--- a/src/coreclr/vm/exinfo.h
+++ b/src/coreclr/vm/exinfo.h
@@ -191,6 +191,7 @@ struct ExInfo
     EE_ILEXCEPTION_CLAUSE m_CurrentClause;
     // Method to report to the debugger / profiler when stack frame iterator leaves a frame
     MethodDesc    *m_pMDToReportFunctionLeave;
+    bool           m_reportedFunctionEnterWasForFunclet;
     // CONTEXT and REGDISPLAY used by the StackFrameIterator for stack walking
     CONTEXT        m_exContext;
     REGDISPLAY     m_regDisplay;

--- a/src/tests/profiler/exception/ExceptionTest.cs
+++ b/src/tests/profiler/exception/ExceptionTest.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Collections.Generic;
+
+namespace Profiler.Tests
+{
+    class ExceptionTest
+    {
+        static readonly Guid ExceptionProfilerGuid = new Guid("E3C1F87D-1D20-4F1C-A35E-2C2D2E2B8F5D");
+
+        public static void Foo()
+        {
+            try
+            {
+                
+            }
+            finally
+            {
+                try
+                {
+                }
+                finally
+                {
+                    throw new Exception("Thrown from finally");
+                }
+            }
+        }
+
+        public static void Bar()
+        {
+            try
+            {
+                Foo();
+            }
+            catch (Exception)
+            {
+            }            
+        }
+
+        public static int RunTest(String[] args)
+        {
+            Bar();
+            return 100;
+        }
+
+        public static int Main(string[] args)
+        {
+            if (args.Length > 0 && args[0].Equals("RunTest", StringComparison.OrdinalIgnoreCase))
+            {
+                return RunTest(args);
+            }
+
+            // Verify that the function search / unwind function enter / leave events are not generated for funclets, that means
+            // that the Foo occurs only once in the sequence.
+            const string expectedSequence = 
+                "ExceptionThrown\n"+
+                "ExceptionSearchFunctionEnter: Foo\n"+
+                "ExceptionSearchFunctionLeave\n"+
+                "ExceptionSearchFunctionEnter: Bar\n"+
+                "ExceptionSearchCatcherFound: Bar\n"+
+                "ExceptionSearchFunctionLeave\n"+
+                "ExceptionUnwindFunctionEnter: Foo\n"+
+                "ExceptionUnwindFunctionLeave\n"+
+                "ExceptionUnwindFunctionEnter: Bar\n"+
+                "ExceptionCatcherEnter: Bar\n"+
+                "ExceptionCatcherLeave\n";
+
+            return ProfilerTestRunner.Run(profileePath: System.Reflection.Assembly.GetExecutingAssembly().Location,
+                                          testName: "ExceptionTest",
+                                          profilerClsid: ExceptionProfilerGuid,
+                                          envVars: new Dictionary<string, string>
+                                          {
+                                              { "Exception_Expected_Sequence", expectedSequence },
+                                          });
+        }
+    }
+}

--- a/src/tests/profiler/exception/ExceptionTest.csproj
+++ b/src/tests/profiler/exception/ExceptionTest.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <OutputType>exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <!-- The test launches a secondary process and process launch creates
+    an infinite event loop in the SocketAsyncEngine on Linux. Since
+    runincontext loads even framework assemblies into the unloadable
+    context, locals in this loop prevent unloading -->
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+    <ProjectReference Include="../common/profiler_common.csproj" />
+    <CMakeProjectReference Include="$(MSBuildThisFileDirectory)/../native/CMakeLists.txt" />
+  </ItemGroup>
+</Project>

--- a/src/tests/profiler/native/CMakeLists.txt
+++ b/src/tests/profiler/native/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     eventpipeprofiler/eventpipereadingprofiler.cpp
     eventpipeprofiler/eventpipewritingprofiler.cpp
     eventpipeprofiler/eventpipemetadatareader.cpp
+    exceptionprofiler/exceptionprofiler.cpp
     gcallocateprofiler/gcallocateprofiler.cpp
     gcbasicprofiler/gcbasicprofiler.cpp
     gcheapenumerationprofiler/gcheapenumerationprofiler.cpp

--- a/src/tests/profiler/native/classfactory.cpp
+++ b/src/tests/profiler/native/classfactory.cpp
@@ -6,6 +6,7 @@
 #include "enumthreadsprofiler/enumthreadsprofiler.h"
 #include "eventpipeprofiler/eventpipereadingprofiler.h"
 #include "eventpipeprofiler/eventpipewritingprofiler.h"
+#include "exceptionprofiler/exceptionprofiler.h"
 #include "getappdomainstaticaddress/getappdomainstaticaddress.h"
 #include "gcallocateprofiler/gcallocateprofiler.h"
 #include "nongcheap/nongcheap.h"
@@ -95,6 +96,10 @@ HRESULT STDMETHODCALLTYPE ClassFactory::CreateInstance(IUnknown *pUnkOuter, REFI
     else if (clsid == EventPipeWritingProfiler::GetClsid())
     {
         profiler = new EventPipeWritingProfiler();
+    }
+    else if (clsid == ExceptionProfiler::GetClsid())
+    {
+        profiler = new ExceptionProfiler();
     }
     else if (clsid == MetaDataGetDispenser::GetClsid())
     {

--- a/src/tests/profiler/native/exceptionprofiler/exceptionprofiler.cpp
+++ b/src/tests/profiler/native/exceptionprofiler/exceptionprofiler.cpp
@@ -1,0 +1,167 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#include "ExceptionProfiler.h"
+
+GUID ExceptionProfiler::GetClsid()
+{
+    GUID clsid = { 0xE3C1F87D, 0x1D20, 0x4F1C,{ 0xA3, 0x5E, 0x2C, 0x2D, 0x2E, 0x2B, 0x8F, 0x5D } };
+	return clsid;
+}
+
+HRESULT ExceptionProfiler::Initialize(IUnknown* pICorProfilerInfoUnk)
+{
+    Profiler::Initialize(pICorProfilerInfoUnk);
+
+    HRESULT hr = S_OK;
+    if (FAILED(hr = pCorProfilerInfo->SetEventMask2(COR_PRF_MONITOR_EXCEPTIONS | COR_PRF_DISABLE_INLINING, 0)))
+    {
+        printf("FAIL: ICorProfilerInfo::SetEventMask2() failed hr=0x%x", hr);
+        return hr;
+    }
+
+    constexpr ULONG bufferSize = 1024;
+    ULONG envVarLen = 0;
+    WCHAR envVar[bufferSize];
+    if (FAILED(hr = pCorProfilerInfo->GetEnvironmentVariable(WCHAR("Exception_Expected_Sequence"), bufferSize, &envVarLen, envVar)))
+    {
+        return E_FAIL;
+    }
+    expectedSequence = envVar;
+
+    return S_OK;
+}
+
+HRESULT ExceptionProfiler::Shutdown()
+{
+    Profiler::Shutdown();
+
+    if (expectedSequence == actualSequence)
+    {
+        printf("PROFILER TEST PASSES\n");
+    }
+    else
+    {
+        std::wcout << L"ExceptionProfiler::Shutdown: FAIL: Expected and actual exception sequences do not match" << std::endl;
+        std::wcout << L"Expected Sequence" << std::endl << expectedSequence << std::endl;
+        std::wcout << L"Actual Sequence" << std::endl << actualSequence << std::endl;
+    }
+
+    fflush(stdout);
+    return S_OK;
+}
+
+HRESULT ExceptionProfiler::ExceptionThrown(ObjectID thrownObjectId)
+{
+    SHUTDOWNGUARD();
+
+    actualSequence += String(L"ExceptionThrown");
+    actualSequence += L"\n";
+
+    return S_OK;
+}
+HRESULT ExceptionProfiler::ExceptionSearchFunctionEnter(FunctionID functionId)
+{
+    SHUTDOWNGUARD();
+
+    actualSequence += String(L"ExceptionSearchFunctionEnter: ");
+    actualSequence += GetFunctionIDName(functionId);
+    actualSequence += L"\n";
+
+    return S_OK;
+}
+HRESULT ExceptionProfiler::ExceptionSearchFunctionLeave()
+{
+    SHUTDOWNGUARD();
+
+    actualSequence += String(L"ExceptionSearchFunctionLeave");
+    actualSequence += L"\n";
+
+    return S_OK;
+}
+HRESULT ExceptionProfiler::ExceptionSearchFilterEnter(FunctionID functionId)
+{
+    SHUTDOWNGUARD();
+
+    actualSequence += String(L"ExceptionSearchFilterEnter: ");
+    actualSequence += GetFunctionIDName(functionId);
+    actualSequence += L"\n";
+
+    return S_OK;
+}
+HRESULT ExceptionProfiler::ExceptionSearchFilterLeave()
+{
+    SHUTDOWNGUARD();
+
+    actualSequence += String(L"ExceptionSearchFilterLeave");
+    actualSequence += L"\n";
+
+    return S_OK;
+}
+HRESULT ExceptionProfiler::ExceptionSearchCatcherFound(FunctionID functionId)
+{
+    SHUTDOWNGUARD();
+
+    actualSequence += String(L"ExceptionSearchCatcherFound: ");
+    actualSequence += GetFunctionIDName(functionId);
+    actualSequence += L"\n";
+
+    return S_OK;
+}
+HRESULT ExceptionProfiler::ExceptionUnwindFunctionEnter(FunctionID functionId)
+{
+    SHUTDOWNGUARD();
+
+    actualSequence += String(L"ExceptionUnwindFunctionEnter: ");
+    actualSequence += GetFunctionIDName(functionId);
+    actualSequence += L"\n";
+
+    return S_OK;
+}
+HRESULT ExceptionProfiler::ExceptionUnwindFunctionLeave()
+{
+    SHUTDOWNGUARD();
+
+    actualSequence += String(L"ExceptionUnwindFunctionLeave");
+    actualSequence += L"\n";
+
+    return S_OK;
+}
+HRESULT ExceptionProfiler::ExceptionUnwindFinallyEnter(FunctionID functionId)
+{
+    SHUTDOWNGUARD();
+
+    actualSequence += String(L"ExceptionUnwindFinallyEnter: ");
+    actualSequence += GetFunctionIDName(functionId);
+    actualSequence += L"\n";
+
+    return S_OK;
+}
+HRESULT ExceptionProfiler::ExceptionUnwindFinallyLeave()
+{
+    SHUTDOWNGUARD();
+
+    actualSequence += String(L"ExceptionUnwindFinallyLeave");
+    actualSequence += L"\n";
+
+    return S_OK;
+}
+HRESULT ExceptionProfiler::ExceptionCatcherEnter(FunctionID functionId, ObjectID objectId)
+{
+    SHUTDOWNGUARD();
+
+    actualSequence += String(L"ExceptionCatcherEnter: ");
+    actualSequence += GetFunctionIDName(functionId);
+    actualSequence += L"\n";
+
+    return S_OK;
+}
+HRESULT ExceptionProfiler::ExceptionCatcherLeave()
+{
+    SHUTDOWNGUARD();
+
+    actualSequence += String(L"ExceptionCatcherLeave");
+    actualSequence += L"\n";
+
+    return S_OK;
+}

--- a/src/tests/profiler/native/exceptionprofiler/exceptionprofiler.cpp
+++ b/src/tests/profiler/native/exceptionprofiler/exceptionprofiler.cpp
@@ -55,8 +55,8 @@ HRESULT ExceptionProfiler::ExceptionThrown(ObjectID thrownObjectId)
 {
     SHUTDOWNGUARD();
 
-    actualSequence += String(L"ExceptionThrown");
-    actualSequence += L"\n";
+    actualSequence += String(WCHAR("ExceptionThrown"));
+    actualSequence += WCHAR("\n");
 
     return S_OK;
 }
@@ -64,9 +64,9 @@ HRESULT ExceptionProfiler::ExceptionSearchFunctionEnter(FunctionID functionId)
 {
     SHUTDOWNGUARD();
 
-    actualSequence += String(L"ExceptionSearchFunctionEnter: ");
+    actualSequence += String(WCHAR("ExceptionSearchFunctionEnter: "));
     actualSequence += GetFunctionIDName(functionId);
-    actualSequence += L"\n";
+    actualSequence += WCHAR("\n");
 
     return S_OK;
 }
@@ -74,8 +74,8 @@ HRESULT ExceptionProfiler::ExceptionSearchFunctionLeave()
 {
     SHUTDOWNGUARD();
 
-    actualSequence += String(L"ExceptionSearchFunctionLeave");
-    actualSequence += L"\n";
+    actualSequence += String(WCHAR("ExceptionSearchFunctionLeave"));
+    actualSequence += WCHAR("\n");
 
     return S_OK;
 }
@@ -83,9 +83,9 @@ HRESULT ExceptionProfiler::ExceptionSearchFilterEnter(FunctionID functionId)
 {
     SHUTDOWNGUARD();
 
-    actualSequence += String(L"ExceptionSearchFilterEnter: ");
+    actualSequence += String(WCHAR("ExceptionSearchFilterEnter: "));
     actualSequence += GetFunctionIDName(functionId);
-    actualSequence += L"\n";
+    actualSequence += WCHAR("\n");
 
     return S_OK;
 }
@@ -93,8 +93,8 @@ HRESULT ExceptionProfiler::ExceptionSearchFilterLeave()
 {
     SHUTDOWNGUARD();
 
-    actualSequence += String(L"ExceptionSearchFilterLeave");
-    actualSequence += L"\n";
+    actualSequence += String(WCHAR("ExceptionSearchFilterLeave"));
+    actualSequence += WCHAR("\n");
 
     return S_OK;
 }
@@ -102,9 +102,9 @@ HRESULT ExceptionProfiler::ExceptionSearchCatcherFound(FunctionID functionId)
 {
     SHUTDOWNGUARD();
 
-    actualSequence += String(L"ExceptionSearchCatcherFound: ");
+    actualSequence += String(WCHAR("ExceptionSearchCatcherFound: "));
     actualSequence += GetFunctionIDName(functionId);
-    actualSequence += L"\n";
+    actualSequence += WCHAR("\n");
 
     return S_OK;
 }
@@ -112,9 +112,9 @@ HRESULT ExceptionProfiler::ExceptionUnwindFunctionEnter(FunctionID functionId)
 {
     SHUTDOWNGUARD();
 
-    actualSequence += String(L"ExceptionUnwindFunctionEnter: ");
+    actualSequence += String(WCHAR("ExceptionUnwindFunctionEnter: "));
     actualSequence += GetFunctionIDName(functionId);
-    actualSequence += L"\n";
+    actualSequence += WCHAR("\n");
 
     return S_OK;
 }
@@ -122,8 +122,8 @@ HRESULT ExceptionProfiler::ExceptionUnwindFunctionLeave()
 {
     SHUTDOWNGUARD();
 
-    actualSequence += String(L"ExceptionUnwindFunctionLeave");
-    actualSequence += L"\n";
+    actualSequence += String(WCHAR("ExceptionUnwindFunctionLeave"));
+    actualSequence += WCHAR("\n");
 
     return S_OK;
 }
@@ -131,9 +131,9 @@ HRESULT ExceptionProfiler::ExceptionUnwindFinallyEnter(FunctionID functionId)
 {
     SHUTDOWNGUARD();
 
-    actualSequence += String(L"ExceptionUnwindFinallyEnter: ");
+    actualSequence += String(WCHAR("ExceptionUnwindFinallyEnter: "));
     actualSequence += GetFunctionIDName(functionId);
-    actualSequence += L"\n";
+    actualSequence += WCHAR("\n");
 
     return S_OK;
 }
@@ -141,8 +141,8 @@ HRESULT ExceptionProfiler::ExceptionUnwindFinallyLeave()
 {
     SHUTDOWNGUARD();
 
-    actualSequence += String(L"ExceptionUnwindFinallyLeave");
-    actualSequence += L"\n";
+    actualSequence += String(WCHAR("ExceptionUnwindFinallyLeave"));
+    actualSequence += WCHAR("\n");
 
     return S_OK;
 }
@@ -150,9 +150,9 @@ HRESULT ExceptionProfiler::ExceptionCatcherEnter(FunctionID functionId, ObjectID
 {
     SHUTDOWNGUARD();
 
-    actualSequence += String(L"ExceptionCatcherEnter: ");
+    actualSequence += String(WCHAR("ExceptionCatcherEnter: "));
     actualSequence += GetFunctionIDName(functionId);
-    actualSequence += L"\n";
+    actualSequence += WCHAR("\n");
 
     return S_OK;
 }
@@ -160,8 +160,8 @@ HRESULT ExceptionProfiler::ExceptionCatcherLeave()
 {
     SHUTDOWNGUARD();
 
-    actualSequence += String(L"ExceptionCatcherLeave");
-    actualSequence += L"\n";
+    actualSequence += String(WCHAR("ExceptionCatcherLeave"));
+    actualSequence += WCHAR("\n");
 
     return S_OK;
 }

--- a/src/tests/profiler/native/exceptionprofiler/exceptionprofiler.cpp
+++ b/src/tests/profiler/native/exceptionprofiler/exceptionprofiler.cpp
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-#include "ExceptionProfiler.h"
+#include "exceptionprofiler.h"
 
 GUID ExceptionProfiler::GetClsid()
 {

--- a/src/tests/profiler/native/exceptionprofiler/exceptionprofiler.h
+++ b/src/tests/profiler/native/exceptionprofiler/exceptionprofiler.h
@@ -12,8 +12,8 @@ public:
     {}
 
     static GUID GetClsid();
-    virtual HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pICorProfilerInfoUnk);
-    virtual HRESULT STDMETHODCALLTYPE Shutdown();
+    virtual HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pICorProfilerInfoUnk) override;
+    virtual HRESULT STDMETHODCALLTYPE Shutdown() override;
     virtual HRESULT STDMETHODCALLTYPE ExceptionThrown(ObjectID thrownObjectId) override;
     virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFunctionEnter(FunctionID functionId) override;
     virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFunctionLeave() override;

--- a/src/tests/profiler/native/exceptionprofiler/exceptionprofiler.h
+++ b/src/tests/profiler/native/exceptionprofiler/exceptionprofiler.h
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma once
+
+#include "../profiler.h"
+
+class ExceptionProfiler : public Profiler
+{
+public:
+    ExceptionProfiler() : Profiler()
+    {}
+
+    static GUID GetClsid();
+    virtual HRESULT STDMETHODCALLTYPE Initialize(IUnknown* pICorProfilerInfoUnk);
+    virtual HRESULT STDMETHODCALLTYPE Shutdown();
+    virtual HRESULT STDMETHODCALLTYPE ExceptionThrown(ObjectID thrownObjectId) override;
+    virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFunctionEnter(FunctionID functionId) override;
+    virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFunctionLeave() override;
+    virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFilterEnter(FunctionID functionId) override;
+    virtual HRESULT STDMETHODCALLTYPE ExceptionSearchFilterLeave() override;
+    virtual HRESULT STDMETHODCALLTYPE ExceptionSearchCatcherFound(FunctionID functionId) override;
+    virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFunctionEnter(FunctionID functionId) override;
+    virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFunctionLeave() override;
+    virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFinallyEnter(FunctionID functionId) override;
+    virtual HRESULT STDMETHODCALLTYPE ExceptionUnwindFinallyLeave() override;
+    virtual HRESULT STDMETHODCALLTYPE ExceptionCatcherEnter(FunctionID functionId, ObjectID objectId) override;
+    virtual HRESULT STDMETHODCALLTYPE ExceptionCatcherLeave() override;
+private:
+
+    String expectedSequence;
+    String actualSequence;
+};


### PR DESCRIPTION
The new EH was incorrectly notifying exception search and unwind function enter / leave in case of funclets. For each funclet, it was reporting enter and leave of the parent and then it reported it again for the parent itself.

This was different from the old EH behavior where only one enter / leave was reported for each method.

This change rectifies it.

Close #123351