### PR TITLE
Reduce file existence checks when servicing directory exists

### DIFF
--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -224,8 +224,6 @@ void deps_resolver_t::setup_probe_config(
         pal::string_t ext_pkgs = m_core_servicing;
         append_path(&ext_pkgs, _X("pkgs"));
         m_probes.push_back(probe_config_t::svc(ext_pkgs));
-
-        m_needs_file_existence_checks = true;
     }
 
     // The published deps directory to be probed: either app or FX directory.
@@ -354,7 +352,12 @@ bool deps_resolver_t::probe_deps_entry(const deps_entry_t& entry, const pal::str
         }
         else
         {
-            if (entry.to_library_package_path(config.probe_dir, candidate, search_options | (config.is_servicing() ? deps_entry_t::search_options::is_servicing : 0)))
+            if (config.is_servicing())
+            {
+                search_options |= deps_entry_t::search_options::is_servicing | deps_entry_t::search_options::file_existence;
+            }
+
+            if (entry.to_library_package_path(config.probe_dir, candidate, search_options))
             {
                 trace::verbose(_X("    Probed package dir and matched '%s'"), candidate->c_str());
                 return true;


### PR DESCRIPTION
The presence of a servicing directory (even empty) would enable file existence checks for all files in the deps.json. We always look in the servicing directory first (if it exists) - and only care about the file existence there, not in the regular app directory. This change limits file existence checks to only when probing the servicing directory itself.

This reduces I/O operations during startup for applications that have a servicing directory present (and don't use additional probe paths or shared stores).

For the staticconsoletemplate startup test in dotnet/performance, running locally on Windows, if an empty servicing directory exists:

| Metric | Before | After | Delta |
|--------|------------------------|----------------------|-------------|
| Average | 69.812 ms | 58.895 ms | -10.92 ms (-15.6%) |
| Min | 69.392 ms | 58.467 ms | -10.93 ms |
| Max | 70.772 ms | 59.327 ms | -11.45 ms |
| Std Dev | 0.393 ms | 0.290 ms | -0.10 ms (26% tighter) |
| Range | 1.38 ms | 0.86 ms | 38% smaller |

@dotnet/appmodel @AaronRobinsonMSFT 