### PR TITLE
[RyuJit Wasm] don't home locals if none are referenced

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -115,6 +115,16 @@ void CodeGen::genHomeRegisterParams(regNumber initReg, bool* initRegStillZeroed)
 {
     JITDUMP("*************** In genHomeRegisterParams()\n");
 
+    if (GetStackPointerReg() == REG_NA)
+    {
+        // We didn't see any local or argument references, so there's nothing to spill.
+        // TODO-WASM: debug codegen would likely spill all the user args anyways.
+        //
+        JITDUMP("  No local references -- skipping parameter homing\n");
+        assert(!isFramePointerUsed());
+        return;
+    }
+
     auto spillParam = [this](unsigned lclNum, unsigned offset, unsigned paramLclNum, const ABIPassingSegment& segment) {
         assert(segment.IsPassedInRegister());
 


### PR DESCRIPTION
In such cases we won't have set up a stack pointer.