### PR TITLE
Remove redundant ulong casts in Span.Slice for x64 targets

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ValueListBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ValueListBuilder.cs
@@ -110,7 +110,7 @@ namespace System.Collections.Generic
 
             int pos = _pos;
             Span<T> span = _span;
-            if ((ulong)(uint)pos + (ulong)(uint)length <= (ulong)(uint)span.Length) // same guard condition as in Span<T>.Slice on 64-bit
+            if ((uint)pos <= (uint)span.Length - (uint)length) // same guard condition as in Span<T>.Slice
             {
                 _pos = pos + length;
                 return span.Slice(pos, length);

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ValueListBuilder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/ValueListBuilder.cs
@@ -110,7 +110,11 @@ namespace System.Collections.Generic
 
             int pos = _pos;
             Span<T> span = _span;
-            if ((uint)pos <= (uint)span.Length - (uint)length) // same guard condition as in Span<T>.Slice
+#if TARGET_64BIT
+            if ((ulong)(uint)pos + (ulong)(uint)length <= (ulong)(uint)span.Length) // same guard condition as in Span<T>.Slice on 64-bit
+#else
+            if ((uint)pos <= (uint)span.Length && (uint)length <= (uint)(span.Length - pos)) // same guard condition as in Span<T>.Slice
+#endif
             {
                 _pos = pos + length;
                 return span.Slice(pos, length);

--- a/src/libraries/System.Private.CoreLib/src/System/Memory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Memory.cs
@@ -93,14 +93,8 @@ namespace System
             }
             if (!typeof(T).IsValueType && array.GetType() != typeof(T[]))
                 ThrowHelper.ThrowArrayTypeMismatchException();
-#if TARGET_64BIT
-            // See comment in Span<T>.Slice for how this works.
-            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException();
-#else
             if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
-#endif
 
             _object = array;
             _index = start;
@@ -244,14 +238,8 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Memory<T> Slice(int start, int length)
         {
-#if TARGET_64BIT
-            // See comment in Span<T>.Slice for how this works.
-            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)_length)
-                ThrowHelper.ThrowArgumentOutOfRangeException();
-#else
             if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
-#endif
 
             // It is expected for _index + start to be negative if the memory is already pre-pinned.
             return new Memory<T>(_object, _index + start, length);
@@ -329,18 +317,10 @@ namespace System
 
                     int desiredLength = _length;
 
-#if TARGET_64BIT
-                    // See comment in Span<T>.Slice for how this works.
-                    if ((ulong)desiredStartIndex + (ulong)(uint)desiredLength > (ulong)(uint)lengthOfUnderlyingSpan)
-                    {
-                        ThrowHelper.ThrowArgumentOutOfRangeException();
-                    }
-#else
                     if ((uint)desiredStartIndex > (uint)lengthOfUnderlyingSpan || (uint)desiredLength > (uint)lengthOfUnderlyingSpan - (uint)desiredStartIndex)
                     {
                         ThrowHelper.ThrowArgumentOutOfRangeException();
                     }
-#endif
 
                     refToReturn = ref Unsafe.Add(ref refToReturn, desiredStartIndex);
                     lengthOfUnderlyingSpan = desiredLength;

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -198,14 +198,8 @@ namespace System
                 return default;
             }
 
-#if TARGET_64BIT
-            // See comment in Span<T>.Slice for how this works.
-            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)text.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-#else
             if ((uint)start > (uint)text.Length || (uint)length > (uint)(text.Length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-#endif
 
             return new ReadOnlySpan<char>(ref Unsafe.Add(ref text.GetRawStringData(), (nint)(uint)start /* force zero-extension */), length);
         }
@@ -280,14 +274,8 @@ namespace System
                 return default;
             }
 
-#if TARGET_64BIT
-            // See comment in Span<T>.Slice for how this works.
-            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)text.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-#else
             if ((uint)start > (uint)text.Length || (uint)length > (uint)(text.Length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-#endif
 
             return new ReadOnlyMemory<char>(text, start, length);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlyMemory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlyMemory.cs
@@ -71,14 +71,8 @@ namespace System
                 this = default;
                 return; // returns default
             }
-#if TARGET_64BIT
-            // See comment in Span<T>.Slice for how this works.
-            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException();
-#else
             if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
-#endif
 
             _object = array;
             _index = start;
@@ -173,14 +167,8 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlyMemory<T> Slice(int start, int length)
         {
-#if TARGET_64BIT
-            // See comment in Span<T>.Slice for how this works.
-            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)_length)
-                ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-#else
             if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.start);
-#endif
 
             // It is expected for _index + start to be negative if the memory is already pre-pinned.
             return new ReadOnlyMemory<T>(_object, _index + start, length);
@@ -251,18 +239,10 @@ namespace System
 
                     int desiredLength = _length;
 
-#if TARGET_64BIT
-                    // See comment in Span<T>.Slice for how this works.
-                    if ((ulong)desiredStartIndex + (ulong)(uint)desiredLength > (ulong)(uint)lengthOfUnderlyingSpan)
-                    {
-                        ThrowHelper.ThrowArgumentOutOfRangeException();
-                    }
-#else
                     if ((uint)desiredStartIndex > (uint)lengthOfUnderlyingSpan || (uint)desiredLength > (uint)lengthOfUnderlyingSpan - (uint)desiredStartIndex)
                     {
                         ThrowHelper.ThrowArgumentOutOfRangeException();
                     }
-#endif
 
                     refToReturn = ref Unsafe.Add(ref refToReturn, desiredStartIndex);
                     lengthOfUnderlyingSpan = desiredLength;

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -71,14 +71,8 @@ namespace System
                 this = default;
                 return; // returns default
             }
-#if TARGET_64BIT
-            // See comment in Span<T>.Slice for how this works.
-            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)array.Length)
-                ThrowHelper.ThrowArgumentOutOfRangeException();
-#else
             if ((uint)start > (uint)array.Length || (uint)length > (uint)(array.Length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
-#endif
 
             _reference = ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(array), (nint)(uint)start /* force zero-extension */);
             _length = length;
@@ -387,14 +381,8 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public ReadOnlySpan<T> Slice(int start, int length)
         {
-#if TARGET_64BIT
-            // See comment in Span<T>.Slice for how this works.
-            if ((ulong)(uint)start + (ulong)(uint)length > (ulong)(uint)_length)
-                ThrowHelper.ThrowArgumentOutOfRangeException();
-#else
             if ((uint)start > (uint)_length || (uint)length > (uint)(_length - start))
                 ThrowHelper.ThrowArgumentOutOfRangeException();
-#endif
 
             return new ReadOnlySpan<T>(ref Unsafe.Add(ref _reference, (nint)(uint)start /* force zero-extension */), length);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -2294,12 +2294,7 @@ namespace System
 
         public string Substring(int startIndex, int length)
         {
-#if TARGET_64BIT
-            // See comment in Span<T>.Slice for how this works.
-            if ((ulong)(uint)startIndex + (ulong)(uint)length > (ulong)(uint)Length)
-#else
             if ((uint)startIndex > (uint)Length || (uint)length > (uint)(Length - startIndex))
-#endif
             {
                 ThrowSubstringArgumentOutOfRange(startIndex, length);
             }

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -368,20 +368,11 @@ namespace System
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool TryGetSpan(int startIndex, int count, out ReadOnlySpan<char> slice)
         {
-#if TARGET_64BIT
-            // See comment in Span<T>.Slice for how this works.
-            if ((ulong)(uint)startIndex + (ulong)(uint)count > (ulong)(uint)Length)
-            {
-                slice = default;
-                return false;
-            }
-#else
             if ((uint)startIndex > (uint)Length || (uint)count > (uint)(Length - startIndex))
             {
                 slice = default;
                 return false;
             }
-#endif
 
             slice = new ReadOnlySpan<char>(ref Unsafe.Add(ref _firstChar, (nint)(uint)startIndex /* force zero-extension */), count);
             return true;


### PR DESCRIPTION
Fixes #120607.

Related:  #67044 , #119689

Remove 64-bit workarounds (ulong casts for 64-bit arithmetic) to produce JIT-friendly code that eliminates unnecessary bounds checks for Span slices. Presumably, this has become possible thanks to earlier work done in  #62864,  

Code from the issue:
```csharp
[MethodImpl(MethodImplOptions.NoInlining)]
static Span<byte> SlicePattern(Span<byte> input)
{
    if (input.Length >= 1)
        return input.Slice(1, input.Length - 1);  // Should have no bounds check
    return input;
}
```

Before changes:
```asm
G_M000_IG01:
            stp     fp, lr, [sp, #-0x10]!
            mov     fp, sp

G_M000_IG02:
            cmp     w1, #0
            bgt     G_M000_IG04

G_M000_IG03:
            ldp     fp, lr, [sp], #0x10
            ret     lr

G_M000_IG04:
            sub     w2, w1, #1          ; compute length - 1
            mov     w3, w2
            add     x3, x3, #1          ; compute 1 + (length - 1)
            cmp     x3, w1, UXTW        ; BOUNDS CHECK: compare with original length
            bhi     G_M000_IG06         ; branch to throw if out of bounds
            add     x0, x0, #1
            mov     x1, x2

G_M000_IG05:
            ldp     fp, lr, [sp], #0x10
            ret     lr

G_M000_IG06:                            ; throw path
            movz    x0, #0xD908
            movk    x0, #0x1012 LSL #16
            movk    x0, #0xEDC5 LSL #32
            ldr     x0, [x0]
            blr     x0
            brk     #0

; Total bytes of code 84
```

After changes
```asm
G_M000_IG01:
            stp     fp, lr, [sp, #-0x10]!
            mov     fp, sp

G_M000_IG02:
            cmp     w1, #0              ; if (input.Length >= 1)
            bgt     G_M000_IG04

G_M000_IG03:
            ldp     fp, lr, [sp], #0x10
            ret     lr

G_M000_IG04:
            sub     w1, w1, #1          ; new length = length - 1
            add     x0, x0, #1          ; new pointer = pointer + 1

G_M000_IG05:
            ldp     fp, lr, [sp], #0x10
            ret     lr

; Total bytes of code 40
``` 