### PR TITLE
Skip crypto tests requiring elevation when not elevated

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/X509CertificateLoaderPkcs12Tests.WindowsAttributes.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/X509CertificateLoaderPkcs12Tests.WindowsAttributes.cs
@@ -2,19 +2,25 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
+using Microsoft.DotNet.XUnitExtensions;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests
 {
     public abstract partial class X509CertificateLoaderPkcs12Tests
     {
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
         public void VerifyPreserveKeyName(bool preserveName, bool machineKey)
         {
+            if (machineKey && !PlatformDetection.IsPrivilegedProcess)
+            {
+                throw new SkipTestException("Test requires administrator privileges.");
+            }
+
             Pkcs12LoaderLimits loaderLimits = new Pkcs12LoaderLimits
             {
                 PreserveKeyName = preserveName,
@@ -51,13 +57,18 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
         public void VerifyPreserveAlias(bool preserveAlias, bool machineKey)
         {
+            if (machineKey && !PlatformDetection.IsPrivilegedProcess)
+            {
+                throw new SkipTestException("Test requires administrator privileges.");
+            }
+
             Pkcs12LoaderLimits loaderLimits = new Pkcs12LoaderLimits
             {
                 PreserveCertificateAlias = preserveAlias,
@@ -95,7 +106,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(true, true, true)]
         [InlineData(true, true, false)]
         [InlineData(true, false, true)]
@@ -106,6 +117,11 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [InlineData(false, false, false)]
         public void VerifyPreserveProvider(bool preserveProvider, bool preserveName, bool machineKey)
         {
+            if (machineKey && !PlatformDetection.IsPrivilegedProcess)
+            {
+                throw new SkipTestException("Test requires administrator privileges.");
+            }
+
             // This test forces a key creation with CAPI, and verifies that
             // PreserveStorageProvider keeps the key in CAPI.  Additionally,
             // it shows that PreserveKeyName and PreserveStorageProvider are independent.
@@ -158,11 +174,16 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [InlineData(false)]
         [InlineData(true)]
         public void VerifyNamesWithDuplicateAttributes(bool noLimits)
         {
+            if (!PlatformDetection.IsPrivilegedProcess)
+            {
+                throw new SkipTestException("Test requires administrator privileges.");
+            }
+
             // This test mainly shows that when duplicate attributes are present contents
             // processed by our filter and processed directly by PFXImportCertStore come up
             // with the same answer.


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/123632