### PR TITLE
[release/8.0-staging] Deny unmasked frame receive for WebSocket Server

### DIFF
--- a/src/libraries/System.Net.WebSockets/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.WebSockets/src/Resources/Strings.resx
@@ -117,6 +117,9 @@
   <data name="net_Websockets_ClientReceivedMaskedFrame" xml:space="preserve">
     <value>The WebSocket server sent a masked frame.</value>
   </data>
+  <data name="net_Websockets_ServerReceivedUnmaskedFrame" xml:space="preserve">
+    <value>The WebSocket client sent an unmasked frame.</value>
+  </data>
   <data name="net_Websockets_ContinuationFromFinalFrame" xml:space="preserve">
     <value>The WebSocket received a continuation frame from a previous final message.</value>
   </data>

--- a/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
+++ b/src/libraries/System.Net.WebSockets/src/System/Net/WebSockets/ManagedWebSocket.cs
@@ -1204,6 +1204,11 @@ namespace System.Net.WebSockets
                 // Consume the mask bytes
                 ConsumeFromBuffer(4);
             }
+            else if (_isServer)
+            {
+                resultHeader = default;
+                return SR.net_Websockets_ServerReceivedUnmaskedFrame;
+            }
 
             // Do basic validation of the header
             switch (header.Opcode)

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs
@@ -184,6 +184,20 @@ namespace System.Net.WebSockets.Tests
                client.SendAsync(Memory<byte>.Empty, WebSocketMessageType.Binary, WebSocketMessageFlags.EndOfMessage, default));
         }
 
+        [Fact]
+        public async Task ReceiveAsync_ServerUnmaskedFrame_ThrowsWebSocketException()
+        {
+            byte[] frame = { 0x81, 0x05, 0x48, 0x65, 0x6C, 0x6C, 0x6F };
+            using var stream = new MemoryStream();
+            stream.Write(frame, 0, frame.Length);
+            stream.Position = 0;
+            using WebSocket websocket = WebSocket.CreateFromStream(stream, new WebSocketCreationOptions { IsServer = true });
+            WebSocketException exception = await Assert.ThrowsAsync<WebSocketException>(() =>
+                websocket.ReceiveAsync(new byte[5], CancellationToken.None));
+            Assert.Equal(SR.net_Websockets_ServerReceivedUnmaskedFrame, exception.Message);
+            Assert.Equal(WebSocketState.Aborted, websocket.State);
+        }
+
         public abstract class ExposeProtectedWebSocket : WebSocket
         {
             public static new bool IsStateTerminal(WebSocketState state) =>

--- a/src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs
+++ b/src/libraries/System.Net.WebSockets/tests/WebSocketTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -194,7 +195,7 @@ namespace System.Net.WebSockets.Tests
             using WebSocket websocket = WebSocket.CreateFromStream(stream, new WebSocketCreationOptions { IsServer = true });
             WebSocketException exception = await Assert.ThrowsAsync<WebSocketException>(() =>
                 websocket.ReceiveAsync(new byte[5], CancellationToken.None));
-            Assert.Equal(SR.net_Websockets_ServerReceivedUnmaskedFrame, exception.Message);
+            Assert.Equal("The WebSocket client sent an unmasked frame.", exception.Message);
             Assert.Equal(WebSocketState.Aborted, websocket.State);
         }
 


### PR DESCRIPTION
Backport of #123485 to release/8.0-staging

Increasing RFC compliance for WebSocket

## Customer Impact

RFC compliance

## Regression

No

## Testing

Manual verification + automated tests

## Risk

Low, the change only affects non‑compliant WebSocket clients sending unmasked frames, which is explicitly disallowed by RFC 6455. No behavior change is expected for compliant clients.