### PR TITLE
Run async tests on native AOT ARM64

### DIFF
--- a/src/tests/async/Directory.Build.targets
+++ b/src/tests/async/Directory.Build.targets
@@ -4,10 +4,5 @@
     <DisableProjectBuild Condition="'$(RuntimeFlavor)' == 'mono' or '$(TargetArchitecture)' == 'wasm'">true</DisableProjectBuild>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <!-- https://github.com/dotnet/runtime/issues/121871 -->
-    <DisableProjectBuild Condition="'$(TestBuildMode)' == 'nativeaot' and '$(TargetArchitecture)' == 'arm64'">true</DisableProjectBuild>
-  </PropertyGroup>
-
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.targets, $(MSBuildThisFileDirectory)..))" />
 </Project>


### PR DESCRIPTION
This is likely no longer needed since the workaround code will kick in: https://github.com/dotnet/runtime/pull/123378#issuecomment-3778014384