### PR TITLE
Fix the bindhandle tests to use the correct interop description for calling CreateFile

### DIFF
--- a/src/tests/baseservices/threading/threadpool/bindhandle/bindhandle1.cs
+++ b/src/tests/baseservices/threading/threadpool/bindhandle/bindhandle1.cs
@@ -20,7 +20,7 @@ public class BindHandle1
     }
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-    public static extern IntPtr CreateFile(String FileName, uint Access, uint Share, int Atts, uint Dispo, uint Flags, int Template);
+    public static extern IntPtr CreateFile(String FileName, uint Access, uint Share, nint Atts, uint Dispo, uint Flags, nint Template);
 
 
     int RunTest()

--- a/src/tests/baseservices/threading/threadpool/bindhandle/bindhandleinvalid3.cs
+++ b/src/tests/baseservices/threading/threadpool/bindhandle/bindhandleinvalid3.cs
@@ -20,7 +20,7 @@ public class BindHandleInvalid3
     }
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-    public static extern IntPtr CreateFile(String FileName, uint Access, uint Share, int Atts, uint Dispo, uint Flags, int Template);
+    public static extern IntPtr CreateFile(String FileName, uint Access, uint Share, nint Atts, uint Dispo, uint Flags, nint Template);
 
 
     int RunTest()

--- a/src/tests/baseservices/threading/threadpool/bindhandle/bindhandleinvalid6.cs
+++ b/src/tests/baseservices/threading/threadpool/bindhandle/bindhandleinvalid6.cs
@@ -20,7 +20,7 @@ public class BindHandle1
     }
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
-    public static extern IntPtr CreateFile(String FileName, uint Access, uint Share, int Atts, uint Dispo, uint Flags, int Template);
+    public static extern IntPtr CreateFile(String FileName, uint Access, uint Share, nint Atts, uint Dispo, uint Flags, nint Template);
 
     int RunTest()
     {


### PR DESCRIPTION
- The Atts and Template parameters are actually pointers, and the existing prototypes were only passing 32bit integers