### PR TITLE
Prep filter for NtQueryDirectoryFile

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/NtDll/Interop.NtStatus.cs
+++ b/src/libraries/Common/src/Interop/Windows/NtDll/Interop.NtStatus.cs
@@ -17,6 +17,7 @@ internal static partial class Interop
         internal const uint STATUS_FILE_NOT_FOUND         = 0xC000000F;
         internal const uint STATUS_NO_MEMORY              = 0xC0000017;
         internal const uint STATUS_ACCESS_DENIED          = 0xC0000022;
+        internal const uint STATUS_OBJECT_NAME_INVALID    = 0xC0000033;
         internal const uint STATUS_OBJECT_NAME_NOT_FOUND  = 0xC0000034;
         internal const uint STATUS_QUOTA_EXCEEDED         = 0xC0000044;
         internal const uint STATUS_ACCOUNT_RESTRICTION    = 0xC000006E;

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerableFactory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerableFactory.cs
@@ -74,15 +74,9 @@ namespace System.IO.Enumeration
                         // is the directory separator and cannot be part of any path segment in Windows). The other three are the
                         // special case wildcards that we'll convert some * and ? into. They're also valid as filenames on Unix,
                         // which is not true in Windows and as such we'll escape any that occur on the input string.
-                        if (Path.DirectorySeparatorChar != '\\' && expression.AsSpan().ContainsAny(@"\""<>"))
+                        if (Path.DirectorySeparatorChar != '\\')
                         {
-                            // Backslash isn't the default separator, need to escape (e.g. Unix)
-                            expression = expression.Replace("\\", "\\\\");
-
-                            // Also need to escape the other special wild characters ('"', '<', and '>')
-                            expression = expression.Replace("\"", "\\\"");
-                            expression = expression.Replace(">", "\\>");
-                            expression = expression.Replace("<", "\\<");
+                            expression = FileSystemName.EscapeExpression(expression);
                         }
 
                         // Need to convert the expression to match Win32 behavior

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -51,15 +51,26 @@ namespace System.IO.Enumeration
         internal FileSystemEnumerator(string directory, bool isNormalized, EnumerationOptions? options, string? expression) :
             this(directory, isNormalized, options)
         {
-            // We need to ensure that the expression is prepped to be used as an NtQueryDirectoryFile filter.
-            // If the match type is simple, we need to escape the special DOS wildcard characters. If it is
-            // DOS style, the characters have already been escaped in the FileSystemEnumerableFactory.
-
-            if (expression is not null && !_options.RecurseSubdirectories)
+            if (_options.RecurseSubdirectories)
             {
-                if (expression is "." or "..")
+                // We can never filter when recursing, as we need to find all subdirectories to recurse into them.
+                expression = null;
+            }
+
+            if (expression is not null)
+            {
+                // We need to ensure that the expression is prepped to be used as an NtQueryDirectoryFile filter.
+                // If the match type is simple, we need to escape the special DOS wildcard characters. If it is
+                // DOS style, the characters have already been escaped in the FileSystemEnumerableFactory.
+
+                if (expression.Length > 255 || expression == "*")
                 {
-                    // Special directories are not valid expressions for OS-level filtering
+                    // Don't allow expressions longer than the maximum filename length. This comes back as
+                    // STATUS_INVALID_PARAMETER from NtQueryDirectoryFile. We could catch that there, but
+                    // don't want to mask other bad parameter issues.
+                    //
+                    // Also, an expression of "*" is pointless as a filter- it matches everything. "*.*"
+                    // should have been converted to "*" already in the case of MatchType.Win32.
                     expression = null;
                 }
                 else if (_options.MatchType == MatchType.Simple && expression.AsSpan().ContainsAny(@"\""<>"))
@@ -134,7 +145,7 @@ namespace System.IO.Enumeration
                 if (_isFirstGetData)
                 {
                     _isFirstGetData = false;
-                    if (!_options.RecurseSubdirectories && _expression is not null)
+                    if (_expression is not null)
                     {
                         fileNameStruct.Length = fileNameStruct.MaximumLength = (ushort)(_expression.Length * sizeof(char));
                         fileNameStruct.Buffer = (IntPtr)pBuffer;
@@ -158,14 +169,19 @@ namespace System.IO.Enumeration
 
             switch ((uint)status)
             {
-                case Interop.StatusOptions.STATUS_NO_MORE_FILES:
-                    DirectoryFinished();
-                    return false;
                 case Interop.StatusOptions.STATUS_SUCCESS:
                     Debug.Assert(statusBlock.Information.ToInt64() != 0);
                     return true;
+                case Interop.StatusOptions.STATUS_NO_MORE_FILES:
                 // FILE_NOT_FOUND can occur when there are NO files in a volume root (usually there are hidden system files).
                 case Interop.StatusOptions.STATUS_FILE_NOT_FOUND:
+                // STATUS_OBJECT_NAME_INVALID is returned when the FileName has characters the filesystem doesn't like. They
+                // never would have matched manually filtering the current directory, so we'll return no matches. It is
+                // better to let Windows tell us that we have an invalid name as opposed to guessing. We can't know which
+                // file system driver a given directory is going to be on- could even be a Unix type file system.
+                //
+                // This is also the error given back when trying to filter for "." or "..".
+                case Interop.StatusOptions.STATUS_OBJECT_NAME_INVALID:
                     DirectoryFinished();
                     return false;
                 default:

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -63,9 +63,7 @@ namespace System.IO.Enumeration
                 // If the match type is simple, we need to escape the special DOS wildcard characters. If it is
                 // DOS style, the characters have already been escaped in the FileSystemEnumerableFactory.
 
-                if (expression.Length > 255
-                    || expression == "*"
-                    || (_options.ReturnSpecialDirectories && (expression == "." || expression == "..")))
+                if (expression.Length > 255 || expression is "*" or "." or "..")
                 {
                     // Don't allow expressions longer than the maximum filename length. This comes back as
                     // STATUS_INVALID_PARAMETER from NtQueryDirectoryFile. We could catch that there, but
@@ -74,8 +72,8 @@ namespace System.IO.Enumeration
                     // Also, an expression of "*" is pointless as a filter- it matches everything. "*.*"
                     // should have been converted to "*" already in the case of MatchType.Win32.
                     //
-                    // Finally, "." and ".." are invalid filter names on their own, but we allow having them
-                    // returned when Options.ReturnSpecialDirectories is set.
+                    // Finally, "." and ".." are invalid filter names on their own, but we allow you to see
+                    // these entries if you specifically ask via EnumerationOptions.ReturnSpecialDirectories.
                     expression = null;
                 }
                 else if (_options.MatchType == MatchType.Simple)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -62,7 +62,7 @@ namespace System.IO.Enumeration
                     // Special directories are not valid expressions for OS-level filtering
                     expression = null;
                 }
-                else if (_options.MatchType == MatchType.Simple && _expression.AsSpan().ContainsAny(@"\""<>"))
+                else if (_options.MatchType == MatchType.Simple && expression.AsSpan().ContainsAny(@"\""<>"))
                 {
                     // Escape the escaping literal first
                     expression = expression.Replace("\\", "\\\\");

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemEnumerator.Windows.cs
@@ -56,8 +56,7 @@ namespace System.IO.Enumeration
                 // We can never filter when recursing, as we need to find all subdirectories to recurse into them.
                 expression = null;
             }
-
-            if (expression is not null)
+            else if (expression is not null)
             {
                 // We need to ensure that the expression is prepped to be used as an NtQueryDirectoryFile filter.
                 // If the match type is simple, we need to escape the special DOS wildcard characters. If it is

--- a/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemName.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/Enumeration/FileSystemName.cs
@@ -413,5 +413,35 @@ namespace System.IO.Enumeration
 
             return currentState == maxState;
         }
+
+        /// <summary>
+        /// Escapes the given expression so that only '*' and '?' are treated as wildcards, and
+        /// '\' isn't treated as an escape character.
+        /// </summary>
+        internal static string EscapeExpression(string expression)
+        {
+            ReadOnlySpan<char> span = expression;
+            ReadOnlySpan<char> charsToEscape = ['\\', '"', '<', '>'];
+
+            int i = span.IndexOfAny(charsToEscape);
+            if (i >= 0)
+            {
+                ValueStringBuilder vsb = new(stackalloc char[256]);
+                do
+                {
+                    vsb.Append(span.Slice(0, i));
+                    vsb.Append('\\');
+                    vsb.Append(span[i]);
+                    span = span.Slice(i + 1);
+                    i = span.IndexOfAny(charsToEscape);
+                }
+                while (i >= 0);
+
+                vsb.Append(span);
+                expression = vsb.ToString();
+            }
+
+            return expression;
+        }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Enumeration/FileSystemNameTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Enumeration/FileSystemNameTests.cs
@@ -2,12 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO.Enumeration;
+using System.Reflection;
 using Xunit;
 
 namespace System.IO.Tests
 {
     public class FileSystemNameTests
     {
+        private static readonly MethodInfo? s_escapeExpressionMethodInfo = typeof(FileSystemName).GetMethod(
+            nameof(EscapeExpression),
+            BindingFlags.NonPublic | BindingFlags.Static);
+
         [Theory,
             MemberData(nameof(SimpleMatchData)),
             MemberData(nameof(EscapedSimpleMatchData)),
@@ -148,6 +153,26 @@ namespace System.IO.Tests
         {
             string longString = new string('a', 10_000_000);
             Assert.Equal(longString, FileSystemName.TranslateWin32Expression(longString));
+        }
+
+        [Theory,
+            InlineData("", ""),
+            InlineData("abc", "abc"),
+            InlineData("*?", "*?"),
+            InlineData("\\", "\\\\"),
+            InlineData("\"", "\\\""),
+            InlineData("<", "\\<"),
+            InlineData(">", "\\>"),
+            InlineData("a\\b\"c<d>e", "a\\\\b\\\"c\\<d\\>e")]
+        public void EscapeExpression(string expression, string expected)
+        {
+            if (s_escapeExpressionMethodInfo is null)
+            {
+                return;
+            }
+
+            object? result = s_escapeExpressionMethodInfo.Invoke(null, [expression]);
+            Assert.Equal(expected, result);
         }
     }
 }

--- a/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Enumeration/FileSystemNameTests.cs
+++ b/src/libraries/System.Runtime/tests/System.IO.FileSystem.Tests/Enumeration/FileSystemNameTests.cs
@@ -2,17 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO.Enumeration;
-using System.Reflection;
 using Xunit;
 
 namespace System.IO.Tests
 {
     public class FileSystemNameTests
     {
-        private static readonly MethodInfo? s_escapeExpressionMethodInfo = typeof(FileSystemName).GetMethod(
-            nameof(EscapeExpression),
-            BindingFlags.NonPublic | BindingFlags.Static);
-
         [Theory,
             MemberData(nameof(SimpleMatchData)),
             MemberData(nameof(EscapedSimpleMatchData)),
@@ -153,26 +148,6 @@ namespace System.IO.Tests
         {
             string longString = new string('a', 10_000_000);
             Assert.Equal(longString, FileSystemName.TranslateWin32Expression(longString));
-        }
-
-        [Theory,
-            InlineData("", ""),
-            InlineData("abc", "abc"),
-            InlineData("*?", "*?"),
-            InlineData("\\", "\\\\"),
-            InlineData("\"", "\\\""),
-            InlineData("<", "\\<"),
-            InlineData(">", "\\>"),
-            InlineData("a\\b\"c<d>e", "a\\\\b\\\"c\\<d\\>e")]
-        public void EscapeExpression(string expression, string expected)
-        {
-            if (s_escapeExpressionMethodInfo is null)
-            {
-                return;
-            }
-
-            object? result = s_escapeExpressionMethodInfo.Invoke(null, [expression]);
-            Assert.Equal(expected, result);
         }
     }
 }


### PR DESCRIPTION
`NtQueryDirectoryFile` should always be able to take filters as long as they are properly escaped for how we'll do our matching. The special directories `.` and `..` get blocked, but anything outside of that should be fair game.

cc: @stephentoub