### PR TITLE
Baseline tests to fix native AOT outerloops

### DIFF
--- a/src/tests/Common/CoreCLRTestLibrary/Utilities.cs
+++ b/src/tests/Common/CoreCLRTestLibrary/Utilities.cs
@@ -92,6 +92,7 @@ namespace TestLibrary
 
         // return whether or not the OS is a 64 bit OS
         public static bool Is64 => (IntPtr.Size == 8);
+        public static bool Is32 => (IntPtr.Size == 4);
 
         public static bool IsMonoRuntime => Type.GetType("Mono.RuntimeStructs") != null;
         public static bool IsNotMonoRuntime => !IsMonoRuntime;

--- a/src/tests/Interop/StringMarshalling/UTF8/UTF8Test.cs
+++ b/src/tests/Interop/StringMarshalling/UTF8/UTF8Test.cs
@@ -255,14 +255,17 @@ public class Test
         for (int i = 0; i < utf8Strings.Length - 1; i++)
             UTF8StringTests.TestStringPassByRef(utf8Strings[i], i);
 
+        // https://github.com/dotnet/runtime/issues/123529
+        if (!TestLibrary.Utilities.IsNativeAot)
+        {
+            // Test StringBuilder as [In,Out] parameter
+            for (int i = 0; i < utf8Strings.Length - 1; i++)
+                UTF8StringBuilderTests.TestInOutStringBuilderParameter(utf8Strings[i], i);
 
-        // Test StringBuilder as [In,Out] parameter
-        for (int i = 0; i < utf8Strings.Length - 1; i++)
-            UTF8StringBuilderTests.TestInOutStringBuilderParameter(utf8Strings[i], i);
-
-        // Test StringBuilder as [Out] parameter
-        for (int i = 0; i < utf8Strings.Length - 1; i++)
-            UTF8StringBuilderTests.TestOutStringBuilderParameter(utf8Strings[i], i);
+            // Test StringBuilder as [Out] parameter
+            for (int i = 0; i < utf8Strings.Length - 1; i++)
+                UTF8StringBuilderTests.TestOutStringBuilderParameter(utf8Strings[i], i);
+        }
 
         // utf8 string as struct fields
         UTF8StructMarshalling.TestUTF8StructMarshalling(utf8Strings);
@@ -270,9 +273,13 @@ public class Test
         // delegate
         UTF8DelegateMarshalling.TestUTF8DelegateMarshalling();
 
-        // Test StringBuilder as [Out] parameter
-        for (int i = 0; i < utf8Strings.Length - 1; i++)
-            UTF8StringBuilderTests.TestReturnStringBuilder(utf8Strings[i], i);
+        // https://github.com/dotnet/runtime/issues/123529
+        if (!TestLibrary.Utilities.IsNativeAot)
+        {
+            // Test StringBuilder as [Out] parameter
+            for (int i = 0; i < utf8Strings.Length - 1; i++)
+                UTF8StringBuilderTests.TestReturnStringBuilder(utf8Strings[i], i);
+        }
 
         // String.Empty tests
         UTF8StringTests.EmptyStringTest();

--- a/src/tests/JIT/Methodical/jitinterface/bug603649.cs
+++ b/src/tests/JIT/Methodical/jitinterface/bug603649.cs
@@ -11,6 +11,7 @@ public class foo
     private static object s_o = typeof(string);
     [Fact]
     [OuterLoop]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/122013", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot), nameof(TestLibrary.Utilities.Is32))]
     public static int TestEntryPoint()
     {
         bool f = typeof(string) == s_o as Type;

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/Repro.cs
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b399444/Repro.cs
@@ -12,6 +12,8 @@ namespace Tests
     {
         [OuterLoop]
         [Fact]
+        // This needs a CoreCLR TypeLoadException emulator
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/69919", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot))]
         public static int TestEntryPoint()
         {
             if ((TestManyFields() == 100)


### PR DESCRIPTION
These were all enabled in #123112
