### PR TITLE
[Draft] Try installing Dotnet SDK on Helix Runners for SPMI Benchmark Collections

### DIFF
--- a/src/coreclr/scripts/superpmi_benchmarks.py
+++ b/src/coreclr/scripts/superpmi_benchmarks.py
@@ -142,13 +142,6 @@ def make_executable(file_name):
              (stat.S_IROTH | stat.S_IXOTH))
     run_command(["ls", "-l", file_name])
 
-def install_dotnet_sdk(python_path, performance_directory, arch):
-    """Install dotnet sdk in performance repo
-    Args:
-        performance_directory (string): Path to performance directory
-        arch (string): Architecture
-    """
-
 def build_and_run(coreclr_args, output_mch_name):
     """Build the microbenchmarks/real-world and run them under "superpmi collect"
 

--- a/src/coreclr/scripts/superpmi_benchmarks.py
+++ b/src/coreclr/scripts/superpmi_benchmarks.py
@@ -142,6 +142,26 @@ def make_executable(file_name):
              (stat.S_IROTH | stat.S_IXOTH))
     run_command(["ls", "-l", file_name])
 
+def install_dotnet_sdk(python_path, performance_directory, arch):
+    """Install dotnet sdk in performance repo
+    Args:
+        performance_directory (string): Path to performance directory
+        arch (string): Architecture
+    """
+    dotnet_script = os.path.join(performance_directory, "scripts", "dotnet.py")
+    # Install the sdk
+    # use run_command to run the command in powershell on windows to avoid ssl/tls issues
+    # TODO: this is currently broken on windows because of the default tls version on runners,
+    # PR to fix it is here (needs to be in the performance repo dotnet install script): 
+    run_command([python_path, 
+                dotnet_script,
+                "install",
+                "--architecture",
+                    arch,
+                "--channels",
+                "main",
+                "--verbose"])
+
 def build_and_run(coreclr_args, output_mch_name):
     """Build the microbenchmarks/real-world and run them under "superpmi collect"
 
@@ -179,7 +199,8 @@ def build_and_run(coreclr_args, output_mch_name):
         corerun_exe = "corerun"
         script_name = "run_benchmarks.sh"
 
-    make_executable(dotnet_exe)
+    # Install the dotnet sdk using the script within the performance repo
+    install_dotnet_sdk(python_path, performance_directory, arch)
 
     # Start with a "dotnet --info" to see what we've got.
     run_command([dotnet_exe, "--info"])

--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -396,7 +396,7 @@ def setup_benchmark(workitem_directory, arch):
     performance_directory = os.path.join(workitem_directory, "performance")
 
     run_command(
-        ["git", "clone", "--quiet", "--depth", "1", "https://github.com/adamperlin/performance", performance_directory])
+        ["git", "clone", "--quiet", "--depth", "1", "https://github.com/dotnet/performance", performance_directory])
 
     try:
         shutil.rmtree(os.path.join(performance_directory, ".git"))

--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -396,25 +396,12 @@ def setup_benchmark(workitem_directory, arch):
     performance_directory = os.path.join(workitem_directory, "performance")
 
     run_command(
-        ["git", "clone", "--quiet", "--depth", "1", "https://github.com/dotnet/performance", performance_directory])
+        ["git", "clone", "--quiet", "--depth", "1", "https://github.com/adamperlin/performance", performance_directory])
 
     try:
         shutil.rmtree(os.path.join(performance_directory, ".git"))
     except Exception as ex:
         print("Warning: failed to remove directory \"%s\": %s", os.path.join(performance_directory, ".git"), ex)
-
-    with ChangeDir(performance_directory):
-        dotnet_directory = os.path.join(performance_directory, "tools", "dotnet", arch)
-        dotnet_install_script = os.path.join(performance_directory, "scripts", "dotnet.py")
-
-        if not os.path.isfile(dotnet_install_script):
-            print("Missing " + dotnet_install_script)
-            return
-
-        run_command(
-            get_python_name() + [dotnet_install_script, "install", "--channels", "10.0", "--architecture", arch, "--install-dir",
-                                 dotnet_directory, "--verbose"])
-
 
 def get_python_name():
     """Gets the python name


### PR DESCRIPTION
Requires a patched version of dotnet/performance to set the TLS version in powershell on windows.
dotnet/performance PR here: https://github.com/dotnet/performance/pull/5088 