### PR TITLE
Install .NET 9.0 in OneFuzz deployment pipeline

### DIFF
--- a/eng/pipelines/libraries/fuzzing/deploy-to-onefuzz.yml
+++ b/eng/pipelines/libraries/fuzzing/deploy-to-onefuzz.yml
@@ -34,6 +34,11 @@ extends:
           fetchTags: false
           lfs: false
 
+        # The SharpFuzz CLI currently targets .NET 9.0
+        - powershell: |
+            winget install -e --id Microsoft.DotNet.SDK.9 --accept-package-agreements --accept-source-agreements
+          displayName: Install .NET 9.0
+
         - powershell: |
             cd $(Build.SourcesDirectory)
             ./build.cmd clr+libs -rc Checked -c Debug


### PR DESCRIPTION
Deployments broke a few days ago when the image was updated to `vs2026preview`.
The pipeline only runs on the internal mirror, I tested that this change resolves the issue there.