### PR TITLE
`__ComObject` doesn't support dynamic interface map (redux)

### DIFF
--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -1138,10 +1138,14 @@ public:
     {
         LIMITED_METHOD_DAC_CONTRACT;
 
-        // All ComObjects except for __ComObject
-        // have dynamic Interface maps
-        return GetNumInterfaces() > 1
-            && IsComObjectType()
+        // All ComObjects except for __ComObject have dynamic Interface maps
+        // to avoid costly QIs on required managed interfaces. The __ComObject
+        // type is inserted automatically when a COM object enters the runtime.
+        // For example, an incoming COM interface pointer or activation via a
+        // COM coclass. See ComObject::SupportsInterface() for relevant use of
+        // the dynamic interface map.
+        return IsComObjectType()
+            && GetNumInterfaces() > g_pBaseCOMObject->GetNumInterfaces()
             && !ParentEquals(g_pObjectClass);
     }
 #endif // FEATURE_COMINTEROP

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -1140,10 +1140,9 @@ public:
 
         // All ComObjects except for __ComObject
         // have dynamic Interface maps
-        return GetNumInterfaces() > 0
+        return GetNumInterfaces() > 1
             && IsComObjectType()
-            && !ParentEquals(g_pObjectClass)
-            && this != g_pBaseCOMObject;
+            && !ParentEquals(g_pObjectClass);
     }
 #endif // FEATURE_COMINTEROP
 

--- a/src/tests/Interop/COM/NETClients/MiscTypes/Program.cs
+++ b/src/tests/Interop/COM/NETClients/MiscTypes/Program.cs
@@ -214,9 +214,12 @@ namespace NetClient
 
             Console.WriteLine("-- Interfaces...");
             {
+                Assert.True(new MiscTypesTestingClass() is Server.Contract.IInterface2);
+                Assert.True(Activator.CreateInstance(typeof(MiscTypesTestingClass)) is Server.Contract.IInterface2);
+
                 var interfaceMaybe = miscTypeTesting.Marshal_Interface(new InterfaceImpl());
-                Assert.True(interfaceMaybe is Server.Contract.IInterface1);
                 Assert.True(interfaceMaybe is Server.Contract.IInterface2);
+                Assert.True(interfaceMaybe is Server.Contract.IInterface1);
             }
         }
 

--- a/src/tests/Interop/COM/NETClients/MiscTypes/Program.cs
+++ b/src/tests/Interop/COM/NETClients/MiscTypes/Program.cs
@@ -79,7 +79,7 @@ namespace NetClient
             return 100;
         }
 
-        private class InterfaceImpl : Server.Contract.IInterface2
+        private class InterfaceImpl : Server.Contract.IInterface1
         {
         }
 
@@ -214,11 +214,10 @@ namespace NetClient
 
             Console.WriteLine("-- Interfaces...");
             {
-                Assert.True(new MiscTypesTestingClass() is Server.Contract.IInterface2);
-                Assert.True(Activator.CreateInstance(typeof(MiscTypesTestingClass)) is Server.Contract.IInterface2);
+                Assert.True(new MiscTypesTestingClass() is Server.Contract.IInterface1);
+                Assert.True(Activator.CreateInstance(typeof(MiscTypesTestingClass)) is Server.Contract.IInterface1);
 
                 var interfaceMaybe = miscTypeTesting.Marshal_Interface(new InterfaceImpl());
-                Assert.True(interfaceMaybe is Server.Contract.IInterface2);
                 Assert.True(interfaceMaybe is Server.Contract.IInterface1);
             }
         }

--- a/src/tests/Interop/COM/NETServer/MiscTypesTesting.cs
+++ b/src/tests/Interop/COM/NETServer/MiscTypesTesting.cs
@@ -46,13 +46,13 @@ public class MiscTypesTesting : Server.Contract.IMiscTypesTesting
         result = value;
     }
 
-    private class InterfaceImpl : Server.Contract.IInterface2
+    private class InterfaceImpl : Server.Contract.IInterface1
     {
     }
 
-    Server.Contract.IInterface2 Server.Contract.IMiscTypesTesting.Marshal_Interface(object inst)
+    Server.Contract.IInterface1 Server.Contract.IMiscTypesTesting.Marshal_Interface(object inst)
     {
-        if (inst is not Server.Contract.IInterface2)
+        if (inst is not Server.Contract.IInterface1)
         {
             throw new InvalidCastException();
         }

--- a/src/tests/Interop/COM/NativeClients/MiscTypes/MiscTypes.cpp
+++ b/src/tests/Interop/COM/NativeClients/MiscTypes/MiscTypes.cpp
@@ -91,16 +91,15 @@ struct VariantMarshalTest
 
 class InterfaceImpl :
     public UnknownImpl,
-    public IInterface2
+    public IInterface1
 {
 public: // IInterface1
-public: // IInterface2
 public: // IUnknown
     STDMETHOD(QueryInterface)(
         /* [in] */ REFIID riid,
         /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR *__RPC_FAR *ppvObject)
     {
-        return DoQueryInterface(riid, ppvObject, static_cast<IInterface1 *>(this), static_cast<IInterface2 *>(this));
+        return DoQueryInterface(riid, ppvObject, static_cast<IInterface1 *>(this));
     }
 
     DEFINE_REF_COUNTING();
@@ -354,7 +353,7 @@ void ValidationTests()
         ComSmartPtr<InterfaceImpl> iface;
         iface.Attach(new InterfaceImpl());
 
-        ComSmartPtr<IInterface2> result;
+        ComSmartPtr<IInterface1> result;
         HRESULT hr = miscTypesTesting->Marshal_Interface(iface, &result);
         THROW_IF_FAILED(hr);
     }

--- a/src/tests/Interop/COM/NativeServer/MiscTypesTesting.h
+++ b/src/tests/Interop/COM/NativeServer/MiscTypesTesting.h
@@ -6,24 +6,22 @@
 #include <xplatform.h>
 #include "Servers.h"
 
-class MiscTypesTesting : public UnknownImpl, public IMiscTypesTesting, public IInterface2
+class MiscTypesTesting : public UnknownImpl, public IMiscTypesTesting, public IInterface1
 {
-    struct InterfaceImpl : public UnknownImpl, public IInterface2
+    struct InterfaceImpl : public UnknownImpl, public IInterface1
     {
         public: // IInterface1
-        public: // IInterface2
         public: // IUnknown
             STDMETHOD(QueryInterface)(
                 /* [in] */ REFIID riid,
                 /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR *__RPC_FAR *ppvObject)
             {
-                return DoQueryInterface(riid, ppvObject, static_cast<IInterface1 *>(this), static_cast<IInterface2 *>(this));
+                return DoQueryInterface(riid, ppvObject, static_cast<IInterface1 *>(this));
             }
 
         DEFINE_REF_COUNTING();
     };
 public: // IInterface1
-public: // IInterface2
 public: // IMiscTypesTesting
     DEF_FUNC(Marshal_Variant)(_In_ VARIANT obj, _Out_ VARIANT* result)
     {
@@ -40,18 +38,18 @@ public: // IMiscTypesTesting
         return E_NOTIMPL;
     }
 
-    DEF_FUNC(Marshal_Interface)(_In_ IUnknown* input, _Outptr_ IInterface2** value)
+    DEF_FUNC(Marshal_Interface)(_In_ IUnknown* input, _Outptr_ IInterface1** value)
     {
         HRESULT hr;
 
-        IInterface2* ifaceMaybe = nullptr;
-        hr = input->QueryInterface(__uuidof(IInterface2), (void**)&ifaceMaybe);
+        IInterface1* ifaceMaybe = nullptr;
+        hr = input->QueryInterface(__uuidof(IInterface1), (void**)&ifaceMaybe);
         if (FAILED(hr))
             return hr;
         (void)ifaceMaybe->Release();
 
         InterfaceImpl* inst = new InterfaceImpl();
-        hr = inst->QueryInterface(__uuidof(IInterface2), (void**)value);
+        hr = inst->QueryInterface(__uuidof(IInterface1), (void**)value);
         (void)inst->Release();
         return hr;
     }
@@ -61,7 +59,7 @@ public: // IUnknown
         /* [in] */ REFIID riid,
         /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR *__RPC_FAR *ppvObject)
     {
-        return DoQueryInterface(riid, ppvObject, static_cast<IMiscTypesTesting *>(this), static_cast<IInterface1 *>(this), static_cast<IInterface2 *>(this));
+        return DoQueryInterface(riid, ppvObject, static_cast<IMiscTypesTesting *>(this), static_cast<IInterface1 *>(this));
     }
 
     DEFINE_REF_COUNTING();

--- a/src/tests/Interop/COM/NativeServer/MiscTypesTesting.h
+++ b/src/tests/Interop/COM/NativeServer/MiscTypesTesting.h
@@ -6,7 +6,7 @@
 #include <xplatform.h>
 #include "Servers.h"
 
-class MiscTypesTesting : public UnknownImpl, public IMiscTypesTesting
+class MiscTypesTesting : public UnknownImpl, public IMiscTypesTesting, public IInterface2
 {
     struct InterfaceImpl : public UnknownImpl, public IInterface2
     {
@@ -22,6 +22,8 @@ class MiscTypesTesting : public UnknownImpl, public IMiscTypesTesting
 
         DEFINE_REF_COUNTING();
     };
+public: // IInterface1
+public: // IInterface2
 public: // IMiscTypesTesting
     DEF_FUNC(Marshal_Variant)(_In_ VARIANT obj, _Out_ VARIANT* result)
     {
@@ -59,7 +61,7 @@ public: // IUnknown
         /* [in] */ REFIID riid,
         /* [iid_is][out] */ _COM_Outptr_ void __RPC_FAR *__RPC_FAR *ppvObject)
     {
-        return DoQueryInterface(riid, ppvObject, static_cast<IMiscTypesTesting *>(this));
+        return DoQueryInterface(riid, ppvObject, static_cast<IMiscTypesTesting *>(this), static_cast<IInterface1 *>(this), static_cast<IInterface2 *>(this));
     }
 
     DEFINE_REF_COUNTING();

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -184,6 +184,8 @@ namespace Server.Contract
         void Pass_Through_LCID(out int lcid);
     }
 
+    // This interface must not be an explicit COM interface to trigger
+    // the dynamic interface map codepath in ComObject.
     public interface Interface0
     {
     }

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -191,14 +191,7 @@ namespace Server.Contract
     [ComVisible(true)]
     [Guid("4242A2F9-995D-4302-A722-02058CF58158")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IInterface1
-    {
-    }
-
-    [ComVisible(true)]
-    [Guid("7AC820FE-E227-4C4D-A8B0-FCA68C459B43")]
-    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IInterface2 : IInterface1, Interface0
+    public interface IInterface1 : Interface0
     {
     }
 
@@ -215,7 +208,7 @@ namespace Server.Contract
         void Marshal_ByRefVariant(ref object result, object value);
 
         [return: MarshalAs(UnmanagedType.Interface)]
-        IInterface2 Marshal_Interface([MarshalAs(UnmanagedType.Interface)] object inst);
+        IInterface1 Marshal_Interface([MarshalAs(UnmanagedType.Interface)] object inst);
     }
 
     public struct HResult

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -184,6 +184,10 @@ namespace Server.Contract
         void Pass_Through_LCID(out int lcid);
     }
 
+    public interface Interface0
+    {
+    }
+
     [ComVisible(true)]
     [Guid("4242A2F9-995D-4302-A722-02058CF58158")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
@@ -194,7 +198,7 @@ namespace Server.Contract
     [ComVisible(true)]
     [Guid("7AC820FE-E227-4C4D-A8B0-FCA68C459B43")]
     [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IInterface2 : IInterface1
+    public interface IInterface2 : IInterface1, Interface0
     {
     }
 

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
@@ -371,11 +371,6 @@ IInterface1 : IUnknown
 {
 };
 
-struct __declspec(uuid("7AC820FE-E227-4C4D-A8B0-FCA68C459B43"))
-IInterface2 : public IInterface1
-{
-};
-
 struct __declspec(uuid("7FBB8677-BDD0-4E5A-B38B-CA92A4555466"))
 IMiscTypesTesting : IUnknown
 {
@@ -393,7 +388,7 @@ IMiscTypesTesting : IUnknown
 
       virtual HRESULT STDMETHODCALLTYPE Marshal_Interface (
         /*[in]*/ IUnknown* value,
-        /*[out,ret]*/ IInterface2** iface) = 0;
+        /*[out,ret]*/ IInterface1** iface) = 0;
 };
 
 struct __declspec(uuid("592386a5-6837-444d-9de3-250815d18556"))


### PR DESCRIPTION
In https://github.com/dotnet/runtime/pull/112375 a fix was checked in with insufficient validation. An issue was reported offline that uncovered a deficiency in that fix and the validation. This PR revisits that issue, adds the needed comprehensive testing, and adds comments on the utility of the dynamic interface map.

Re fixes #112371