### PR TITLE
[clr-interp] Windows Arm64 InterpreterStub fix

### DIFF
--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -1099,8 +1099,8 @@ JIT_PollGCRarePath
         PROLOG_WITH_TRANSITION_BLOCK
 
         INLINE_GETTHREAD x20, x19
-        cbz x20, NoManagedThreadOrCallStub
         mov x19, METHODDESC_REGISTER ; x19 contains IR bytecode address
+        cbz x20, NoManagedThreadOrCallStub
 
         ldr x11, [x20, #OFFSETOF__Thread__m_pInterpThreadContext]
         cbnz x11, HaveInterpThreadContext


### PR DESCRIPTION
- If the ThreadContext is not set up, make sure to set x19 to have the IR bytecode address before jumping to GetInterpThreadContextWithPossiblyMissingThreadOrCallStub.