### PR TITLE
Use unordered_map in DacInstanceManager in lieu of hand-rolled hash table

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -1546,7 +1546,7 @@ DacInstanceManager::Add(DAC_INSTANCE* inst)
 #ifdef _DEBUG
     bool isInserted = (m_hash.find(inst->addr) == m_hash.end());
 #endif //_DEBUG
-    DAC_INSTANCE *(&target) = m_hash[inst->addr];
+    DAC_INSTANCE* &target = m_hash[inst->addr];
     _ASSERTE(!isInserted || target == NULL);
     if( target != NULL )
     {
@@ -2020,7 +2020,6 @@ DacInstanceManager::ClearEnumMemMarker(void)
 void
 DacInstanceManager::ClearEnumMemMarker(void)
 {
-    ULONG i;
     DAC_INSTANCE* inst;
 
     DacInstanceHashIterator end = m_hash.end();

--- a/src/coreclr/debug/daccess/dacimpl.h
+++ b/src/coreclr/debug/daccess/dacimpl.h
@@ -15,12 +15,10 @@
 
 #include <minipal/mutex.h>
 #include "gcinterface.dac.h"
+
 //---------------------------------------------------------------------------------------
 // Setting DAC_HASHTABLE tells the DAC to use the hand rolled hashtable for
 // storing code:DAC_INSTANCE .  Otherwise, the DAC uses the STL unordered_map to.
-
-#define DAC_HASHTABLE
-
 #ifndef DAC_HASHTABLE
 #pragma push_macro("return")
 #undef return
@@ -732,9 +730,8 @@ private:
     // This has the benefit of scaling to different workloads appropriately (as opposed to having a
     // fixed number of buckets).
 
-    class DacHashCompare : public std::hash_compare<TADDR>
+    struct DacInstanceHashFunc
     {
-    public:
         // Custom hash function
         // The default hash function uses a pseudo-randomizing function to get a random
         // distribution.  In our case, we'd actually like a more even distribution to get
@@ -751,29 +748,13 @@ private:
         // The default pseudo-randomizing function also requires a call to ldiv which shows up as
         // a 3%-5% perf hit in most perf-sensitive scenarios, so this should also always be
         // faster.
-        inline size_t operator()(const TADDR& keyval) const
+        std::size_t operator()(const TADDR& keyval) const noexcept
         {
-            return (unsigned)(keyval >>DAC_INSTANCE_HASH_SHIFT);
+            return (std::size_t)(keyval >>DAC_INSTANCE_HASH_SHIFT);
         }
-
-        // Explicitly bring in the two-argument comparison function from the base class (just less-than)
-        // This is necessary because once we override one form of operator() above, we don't automatically
-        // get the others by C++ inheritance rules.
-    using std::hash_compare<TADDR>::operator();
-
-#ifdef NIDUMP_CUSTOMIZED_DAC_HASH   // not set
-        //this particular number is supposed to be roughly the same amount of
-        //memory as the old code (buckets * number of entries in the old
-        //blocks.)
-        //disabled for now.  May tweak implementation later.  It turns out that
-        //having a large number of initial buckets is excellent for nidump, but it
-        // is terrible for most other scenarios due to the cost of clearing them at
-        // every Flush.  Once there is a better perf suite, we can tweak these values more.
-        static const size_t min_buckets = DAC_INSTANCE_HASH_SIZE * 256;
-#endif
-
     };
-    typedef std::unordered_map<TADDR, DAC_INSTANCE*, DacHashCompare > DacInstanceHash;
+
+    typedef std::unordered_map<TADDR, DAC_INSTANCE*, DacInstanceHashFunc> DacInstanceHash;
     typedef DacInstanceHash::value_type DacInstanceHashValue;
     typedef DacInstanceHash::iterator DacInstanceHashIterator;
     DacInstanceHash m_hash;


### PR DESCRIPTION
Replaces the hand-rolled hash table implementation in `DacInstanceManager` with preexisting `std::unordered_map` logic. This hash is more efficient for the high volume of find operations the DAC issues when verifying cached cross-process reads. During mini dump collection, `DacInstanceManager` is the central cache for all memory read from the target process. The hand-rolled hash table used a fixed bucket array that degraded quickly for Find and insertion operations. 

Measured minidump collection against a repro app with 10,000 iterations across 10 threads. The baseline was 55s while after this change we achieve collection in 5s.