### PR TITLE
[Wasm RyuJIT] Block stores

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2014,7 +2014,7 @@ void CodeGen::genCodeForCpObj(GenTreeBlk* cpObjNode)
 //    to use memset call due to atomicity requirements.
 //
 // Arguments:
-//    initBlkNode - the GT_STORE_BLK node
+//    blkOp - the GT_STORE_BLK node
 //
 void CodeGen::genCodeForInitBlkLoop(GenTreeBlk* blkOp)
 {

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1977,7 +1977,6 @@ void CodeGen::genCompareFloat(GenTreeOp* treeNode)
 void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
 {
     assert(blkOp->OperIs(GT_STORE_BLK));
-    assert(!blkOp->gtBlkOpGcUnsafe);
 
     bool isCopyBlk = blkOp->OperIsCopyBlkOp();
 

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1983,7 +1983,6 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
     switch (blkOp->gtBlkOpKind)
     {
         case GenTreeBlk::BlkOpKindCpObjUnroll:
-            assert(!blkOp->gtBlkOpGcUnsafe);
             genCodeForCpObj(blkOp->AsBlk());
             break;
 

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -10,6 +10,8 @@
 #include "regallocwasm.h"
 #include "fgwasm.h"
 
+static const int LINEAR_MEMORY_INDEX = 0;
+
 #ifdef TARGET_64BIT
 static const instruction INS_I_const = INS_i64_const;
 static const instruction INS_I_add   = INS_i64_add;
@@ -1995,7 +1997,7 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
             genConsumeOperands(blkOp);
             // Emit the size constant expected by the memory.copy and memory.fill opcodes
             GetEmitter()->emitIns_I(INS_i32_const, EA_4BYTE, blkOp->Size());
-            GetEmitter()->emitIns_I(isCopyBlk ? INS_memory_copy : INS_memory_fill, EA_8BYTE, /* memory index */ 0);
+            GetEmitter()->emitIns_I(isCopyBlk ? INS_memory_copy : INS_memory_fill, EA_8BYTE, LINEAR_MEMORY_INDEX);
             break;
 
         default:
@@ -2027,7 +2029,7 @@ void CodeGen::genCodeForInitBlkLoop(GenTreeBlk* blkOp)
     GetEmitter()->emitIns_I(INS_i32_const, EA_4BYTE, 0);
     // Emit the size constant expected by the memory.copy and memory.fill opcodes
     GetEmitter()->emitIns_I(INS_i32_const, EA_4BYTE, blkOp->Size());
-    GetEmitter()->emitIns_I(INS_memory_fill, EA_8BYTE, /* memory index */ 0);
+    GetEmitter()->emitIns_I(INS_memory_fill, EA_8BYTE, LINEAR_MEMORY_INDEX);
 }
 
 BasicBlock* CodeGen::genCallFinally(BasicBlock* block)

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1974,7 +1974,7 @@ void CodeGen::genCompareFloat(GenTreeOp* treeNode)
 // genCodeForStoreBlk: Produce code for a GT_STORE_BLK node.
 //
 // Arguments:
-//    tree - the node
+//    blkOp - the node
 //
 void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
 {

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1977,11 +1977,8 @@ void CodeGen::genCompareFloat(GenTreeOp* treeNode)
 void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
 {
     assert(blkOp->OperIs(GT_STORE_BLK));
+    assert(!blkOp->gtBlkOpGcUnsafe);
 
-    if (blkOp->gtBlkOpGcUnsafe)
-    {
-        GetEmitter()->emitDisableGC();
-    }
     bool isCopyBlk = blkOp->OperIsCopyBlkOp();
 
     switch (blkOp->gtBlkOpKind)
@@ -2005,11 +2002,6 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
 
         default:
             unreached();
-    }
-
-    if (blkOp->gtBlkOpGcUnsafe)
-    {
-        GetEmitter()->emitEnableGC();
     }
 }
 

--- a/src/coreclr/jit/emitfmtswasm.h
+++ b/src/coreclr/jit/emitfmtswasm.h
@@ -40,7 +40,7 @@ IF_DEF(F64,           IS_NONE, NONE) // <opcode> <f64 immediate (stored as 64-bi
 IF_DEF(MEMARG,        IS_NONE, NONE) // <opcode> <memarg> (<align> <offset>)
 IF_DEF(LOCAL_DECL,    IS_NONE, NONE) // <ULEB128 immediate> <byte>
 IF_DEF(CALL_INDIRECT, IS_NONE, NONE) // <opcode> <ULEB128 immediate> <ULEB128 immediate>
-IF_DEF(MEMCPY,        IS_NONE, NONE) // <memory index> <memory index>
+IF_DEF(MEMIDX_MEMIDX, IS_NONE, NONE) // <memory index> <memory index>
 
 #undef IF_DEF
 #endif // !DEFINE_ID_OPS

--- a/src/coreclr/jit/emitfmtswasm.h
+++ b/src/coreclr/jit/emitfmtswasm.h
@@ -40,6 +40,7 @@ IF_DEF(F64,           IS_NONE, NONE) // <opcode> <f64 immediate (stored as 64-bi
 IF_DEF(MEMARG,        IS_NONE, NONE) // <opcode> <memarg> (<align> <offset>)
 IF_DEF(LOCAL_DECL,    IS_NONE, NONE) // <ULEB128 immediate> <byte>
 IF_DEF(CALL_INDIRECT, IS_NONE, NONE) // <opcode> <ULEB128 immediate> <ULEB128 immediate>
+IF_DEF(MEMCPY,        IS_NONE, NONE) // <memory index> <memory index>
 
 #undef IF_DEF
 #endif // !DEFINE_ID_OPS

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -430,7 +430,7 @@ unsigned emitter::instrDesc::idCodeSize() const
             size += idIsCnsReloc() ? PADDED_RELOC_SIZE : SizeOfULEB128(emitGetInsSC(this));
             break;
         }
-        case IF_MEMCPY:
+        case IF_MEMIDX_MEMIDX:
         {
             size += idIsCnsReloc() ? PADDED_RELOC_SIZE : SizeOfULEB128(emitGetInsSC(this));
             size += idIsCnsReloc() ? PADDED_RELOC_SIZE : SizeOfULEB128(emitGetInsSC(this));
@@ -657,7 +657,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             dst += emitOutputByte(dst, valType);
             break;
         }
-        case IF_MEMCPY:
+        case IF_MEMIDX_MEMIDX:
         {
             dst += emitOutputOpcode(dst, ins);
             cnsval_ssize_t constant = emitGetInsSC(id);
@@ -806,7 +806,7 @@ void emitter::emitDispIns(
             dispHandleIfAny();
         }
         break;
-        case IF_MEMCPY:
+        case IF_MEMIDX_MEMIDX:
         {
             cnsval_ssize_t imm = emitGetInsSC(id);
             printf(" %llu %llu", (uint64_t)imm, (uint64_t)imm);

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -430,6 +430,12 @@ unsigned emitter::instrDesc::idCodeSize() const
             size += idIsCnsReloc() ? PADDED_RELOC_SIZE : SizeOfULEB128(emitGetInsSC(this));
             break;
         }
+        case IF_MEMCPY:
+        {
+            size += idIsCnsReloc() ? PADDED_RELOC_SIZE : SizeOfULEB128(emitGetInsSC(this));
+            size += idIsCnsReloc() ? PADDED_RELOC_SIZE : SizeOfULEB128(emitGetInsSC(this));
+            break;
+        }
         default:
             unreached();
     }
@@ -651,6 +657,14 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
             dst += emitOutputByte(dst, valType);
             break;
         }
+        case IF_MEMCPY:
+        {
+            dst += emitOutputOpcode(dst, ins);
+            cnsval_ssize_t constant = emitGetInsSC(id);
+            dst += emitOutputULEB128(dst, (uint64_t)constant);
+            dst += emitOutputULEB128(dst, (uint64_t)constant);
+            break;
+        }
         default:
             NYI_WASM("emitOutputInstr");
             break;
@@ -792,7 +806,12 @@ void emitter::emitDispIns(
             dispHandleIfAny();
         }
         break;
-
+        case IF_MEMCPY:
+        {
+            cnsval_ssize_t imm = emitGetInsSC(id);
+            printf(" %llu %llu", (uint64_t)imm, (uint64_t)imm);
+        }
+        break;
         case IF_LOCAL_DECL:
         {
             unsigned int  count   = emitGetLclVarDeclCount(id);

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -12846,6 +12846,12 @@ void Compiler::gtDispTree(GenTree*                    tree,
                         printf(" (Loop)");
                         break;
 
+#ifdef TARGET_WASM
+                    case GenTreeBlk::BlkOpKindNativeOpcode:
+                        printf(" (memory.copy|fill)");
+                        break;
+#endif
+
                     default:
                         unreached();
                 }

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -8098,6 +8098,9 @@ public:
         BlkOpKindLoop,
         BlkOpKindUnroll,
         BlkOpKindUnrollMemmove,
+#ifdef TARGET_WASM
+        BlkOpKindNativeOpcode,
+#endif
     } gtBlkOpKind;
 
     bool gtBlkOpGcUnsafe;

--- a/src/coreclr/jit/instrswasm.h
+++ b/src/coreclr/jit/instrswasm.h
@@ -228,8 +228,8 @@ INST(i64_trunc_sat_f32_u, "i64.trunc_sat_f32_u", 0, IF_OPCODE,  0x05FC)
 INST(i64_trunc_sat_f64_s, "i64.trunc_sat_f64_s", 0, IF_OPCODE,  0x06FC)
 INST(i64_trunc_sat_f64_u, "i64.trunc_sat_f64_u", 0, IF_OPCODE,  0x07FC)
 
-INST(memory_copy,         "memory.copy",         0, IF_MEMCPY,  0x0AFC)
-INST(memory_fill,         "memory.fill",         0, IF_ULEB128, 0x0BFC)
+INST(memory_copy,         "memory.copy",         0, IF_MEMIDX_MEMIDX, 0x0AFC)
+INST(memory_fill,         "memory.fill",         0, IF_ULEB128,       0x0BFC)
 
 // clang-format on
 

--- a/src/coreclr/jit/instrswasm.h
+++ b/src/coreclr/jit/instrswasm.h
@@ -228,6 +228,9 @@ INST(i64_trunc_sat_f32_u, "i64.trunc_sat_f32_u", 0, IF_OPCODE,  0x05FC)
 INST(i64_trunc_sat_f64_s, "i64.trunc_sat_f64_s", 0, IF_OPCODE,  0x06FC)
 INST(i64_trunc_sat_f64_u, "i64.trunc_sat_f64_u", 0, IF_OPCODE,  0x07FC)
 
+INST(memory_copy,         "memory.copy",         0, IF_MEMCPY,  0x0AFC)
+INST(memory_fill,         "memory.fill",         0, IF_ULEB128, 0x0BFC)
+
 // clang-format on
 
 #undef INST

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -225,7 +225,6 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         if (src->OperIs(GT_LCL_VAR))
         {
             // TODO-1stClassStructs: for now we can't work with STORE_BLOCK source in register.
-            // TODO-WASM: Is this true for wasm as well?
             const unsigned srcLclNum = src->AsLclVar()->GetLclNum();
             m_compiler->lvaSetVarDoNotEnregister(srcLclNum DEBUGARG(DoNotEnregisterReason::StoreBlkSrc));
         }

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -241,7 +241,6 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
                 return;
             }
 
-            assert(dstAddr->TypeIs(TYP_BYREF, TYP_I_IMPL));
             blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindCpObjUnroll;
         }
         else

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -496,16 +496,8 @@ void Lowering::AfterLowerBlock()
                     // rare, introduced in lowering only. All HIR-induced cases (such as from "gtSetEvalOrder") should
                     // instead be ifdef-ed out for WASM.
                     m_anyChanges = true;
-#ifdef DEBUG
-                    if (JitTls::GetCompiler()->verbose)
-                    {
-                        printf("node==");
-                        Compiler::printTreeID(node);
-                        printf(" prev==");
-                        Compiler::printTreeID(prev);
-                        printf("\n");
-                    }
-#endif
+
+                    JITDUMP("node==[%06u] prev==[%06u]\n", Compiler::dspTreeID(node), Compiler::dspTreeID(prev));
                     NYI_WASM("IR not in a stackified form");
                 }
 

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -497,11 +497,14 @@ void Lowering::AfterLowerBlock()
                     // instead be ifdef-ed out for WASM.
                     m_anyChanges = true;
 #ifdef DEBUG
-                    printf("node==");
-                    Compiler::printTreeID(node);
-                    printf(" prev==");
-                    Compiler::printTreeID(prev);
-                    printf("\n");
+                    if (JitTls::GetCompiler()->verbose)
+                    {
+                        printf("node==");
+                        Compiler::printTreeID(node);
+                        printf(" prev==");
+                        Compiler::printTreeID(prev);
+                        printf("\n");
+                    }
 #endif
                     NYI_WASM("IR not in a stackified form");
                 }

--- a/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
+++ b/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using Internal.TypeSystem;
 using ILCompiler.ObjectWriter;
@@ -148,17 +149,8 @@ namespace Internal.JitInterface
                 returnIsVoid = true;
             }
 
-            int parameterCount = signature.Length;
-
-            if (hasReturnBuffer)
-            {
-                parameterCount++; // return buffer
-            }
-
-            if (!method.IsUnmanagedCallersOnly)
-            {
-                parameterCount += 2; // sp and pe
-            }
+            // Reserve space for potential implicit this, stack pointer parameter, portable entrypoint parameter, and return buffer
+            ArrayBuilder<WasmValueType> result = new(signature.Length + 4);
 
             if (!signature.IsStatic)
             {
@@ -170,46 +162,43 @@ namespace Internal.JitInterface
                 }
                 else
                 {
-                    parameterCount += 1; // implicit this
+                    throw new NotImplementedException("Implicit this");
                 }
             }
-
-            Span<WasmValueType> wasmParameters = new WasmValueType[parameterCount];
-
-            int index = 0;
 
             if (method.IsUnmanagedCallersOnly) // reverse P/Invoke
             {
                 if (hasReturnBuffer)
                 {
-                    wasmParameters[index++] = pointerType;
+                    result.Add(pointerType);
                 }
             }
             else // managed call
             {
-                wasmParameters[0] = pointerType; // Stack pointer parameter
-
-                // Return buffer is first after this.
+                result.Add(pointerType); // Stack pointer parameter
 
                 if (hasThis)
                 {
-                    wasmParameters[index++] = pointerType;
+                    result.Add(pointerType);
                 }
 
                 if (hasReturnBuffer)
                 {
-                    wasmParameters[index++] = pointerType;
+                    result.Add(pointerType);
                 }
-
-                wasmParameters[wasmParameters.Length - 1] = pointerType; // PE entrypoint parameter
             }
 
             for (int i = explicitThis ? 1 : 0; i < signature.Length; i++)
             {
-                wasmParameters[index++] = LowerType(signature[i]);
+                result.Add(LowerType(signature[i]));
             }
 
-            WasmResultType ps = new(wasmParameters.ToArray());
+            if (!method.IsUnmanagedCallersOnly)
+            {
+                result.Add(pointerType); // PE entrypoint parameter
+            }
+
+            WasmResultType ps = new(result.ToArray());
             WasmResultType ret = returnIsVoid ? new(Array.Empty<WasmValueType>())
                 : new([LowerType(loweredReturnType)]);
 

--- a/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
+++ b/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
@@ -160,10 +160,6 @@ namespace Internal.JitInterface
                 {
                     explicitThis = true;
                 }
-                else
-                {
-                    throw new NotImplementedException("Implicit this");
-                }
             }
 
             if (method.IsUnmanagedCallersOnly) // reverse P/Invoke


### PR DESCRIPTION
This is sufficient to compile these three managed methods to wasm functions with native `memory.fill` and `memory.copy` instructions:

```csharp
    struct S {
        public int A, B, C, D;
    }

    struct S2 {
        public string A, B, C, D;
    }

    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
    static unsafe void zeroStruct (S *result) {
        *result = default;
    }

    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
    static unsafe void copyStruct (S *a, S *b) {
        *a = *b;
    }

    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
    static void zeroStructWithRefs (ref S2 result) {
        result = default;
    }
```