### PR TITLE
Update tools in prompts to non-deprecated names that work in VSC Copilot Chat

### DIFF
--- a/.github/prompts/add-new-jit-ee-api.prompt.md
+++ b/.github/prompts/add-new-jit-ee-api.prompt.md
@@ -1,6 +1,6 @@
 ---
-mode: 'agent'
-tools: ['fetch', 'codebase', 'runCommands', 'usages', 'search', 'think']
+agent: 'agent'
+tools: ['web/fetch', 'search/codebase', 'execute/getTerminalOutput', 'execute/runInTerminal', 'read/terminalLastCommand', 'read/terminalSelection', 'search/usages', 'search', 'edit/editFiles', 'think']
 description: 'Add a new API to the JIT-VM (aka JIT-EE) interface in the codebase.'
 ---
 

--- a/.github/prompts/docs.prompt.md
+++ b/.github/prompts/docs.prompt.md
@@ -1,6 +1,6 @@
 ---
-mode: 'agent'
-tools: ['changes', 'codebase', 'editFiles', 'problems']
+agent: 'agent'
+tools: ['search/changes', 'search/codebase', 'edit/editFiles', 'read/problems']
 description: 'Ensure that C# types are documented with XML comments and follow best practices for documentation.'
 ---
 


### PR DESCRIPTION
Also added `edit/editFiles` to the JIT-EE API prompt as it required it in my local usage.