### PR TITLE
JIT: fix retyping issue in object stack allocation

### DIFF
--- a/src/coreclr/jit/objectalloc.cpp
+++ b/src/coreclr/jit/objectalloc.cpp
@@ -2649,6 +2649,14 @@ void ObjectAllocator::RewriteUses()
             }
             else if (newType == TYP_STRUCT)
             {
+                // For struct stores there is no upwards type propagation.
+                // These nodes and any ancestors will remain TYP_STRUCT.
+                //
+                if (tree->OperIs(GT_STORE_LCL_VAR, GT_STORE_LCL_FLD))
+                {
+                    return Compiler::fgWalkResult::WALK_CONTINUE;
+                }
+
                 newLayout    = lclVarDsc->GetLayout();
                 newType      = newLayout->HasGCPtr() ? TYP_BYREF : TYP_I_IMPL;
                 retypeFields = true;


### PR DESCRIPTION
In cases where we stack allocated an object referred to by local structs, and one of these struct locals was stored to under the value side of a comma, the object allocation phase would inadvertently try and retype the comma, and this retyping ended up cascading back down onto the store and retyping it as well.

To fix this, do not run ancestor type propagation for struct stores.

Closes #123718