### PR TITLE
JIT: Optimize async OSR resumptions

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -65,8 +65,8 @@ namespace System.Runtime.CompilerServices
         // pointer sized when present, apart from the result that has variable
         // size.
 
-        // Whether or not the continuation starts with an OSR IL offset.
-        HasOsrILOffset = 1,
+        // Whether or not the continuation starts with an OSR address.
+        HasOsrAddress = 1,
         // If this bit is set the continuation resumes inside a try block and
         // thus if an exception is being propagated, needs to be resumed.
         HasException = 2,

--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -1775,8 +1775,8 @@ enum CorInfoContinuationFlags
     // pointer sized when present, apart from the result that has variable
     // size.
 
-    // Whether or not the continuation starts with an OSR IL offset.
-    CORINFO_CONTINUATION_HAS_OSR_ILOFFSET = 1,
+    // Whether or not the continuation starts with an OSR resumption address.
+    CORINFO_CONTINUATION_HAS_OSR_ADDRESS = 1,
     // If this bit is set the continuation resumes inside a try block and
     // thus if an exception is being propagated, needs to be resumed.
     CORINFO_CONTINUATION_HAS_EXCEPTION = 2,

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1576,8 +1576,8 @@ void AsyncTransformation::FillInDataOnSuspension(GenTreeCall*              call,
         // OSR address needs to be at offset 0 because OSR and tier0 methods
         // need to agree on that.
         assert(layout.OSRAddress == 0);
-        GenTree* newContinuation       = m_comp->gtNewLclvNode(m_newContinuationVar, TYP_REF);
-        unsigned offset                = OFFSETOF__CORINFO_Continuation__data;
+        GenTree* newContinuation = m_comp->gtNewLclvNode(m_newContinuationVar, TYP_REF);
+        unsigned offset          = OFFSETOF__CORINFO_Continuation__data;
         GenTree* storeOSRAddress = StoreAtOffset(newContinuation, offset, osrAddressToStore, TYP_I_IMPL);
         LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_comp, storeOSRAddress));
     }
@@ -2422,14 +2422,14 @@ void AsyncTransformation::CreateResumptionSwitch()
         checkILOffsetBB->inheritWeightPercentage(newEntryBB, 0);
 
         FlowEdge* toOnContinuationBB = m_comp->fgAddRefPred(onContinuationBB, checkILOffsetBB);
-        FlowEdge* toJmpOSRBB     = m_comp->fgAddRefPred(jmpOSR, checkILOffsetBB);
+        FlowEdge* toJmpOSRBB         = m_comp->fgAddRefPred(jmpOSR, checkILOffsetBB);
         checkILOffsetBB->SetCond(toJmpOSRBB, toOnContinuationBB);
         toJmpOSRBB->setLikelihood(0);
         toOnContinuationBB->setLikelihood(1);
         jmpOSR->inheritWeightPercentage(checkILOffsetBB, 0);
 
         // We need to dispatch to the OSR version if the OSR address is non-zero.
-        continuationArg           = m_comp->gtNewLclvNode(m_comp->lvaAsyncContinuationArg, TYP_REF);
+        continuationArg             = m_comp->gtNewLclvNode(m_comp->lvaAsyncContinuationArg, TYP_REF);
         unsigned offsetOfOSRAddress = OFFSETOF__CORINFO_Continuation__data;
         GenTree* osrAddress         = LoadFromOffset(continuationArg, offsetOfOSRAddress, TYP_I_IMPL);
         unsigned osrAddressLclNum   = m_comp->lvaGrabTemp(false DEBUGARG("OSR address for tier0 OSR method"));
@@ -2457,7 +2457,7 @@ void AsyncTransformation::CreateResumptionSwitch()
         // ignore it, so create a BB that jumps back.
         BasicBlock* onContinuationBB   = newEntryBB->GetTrueTarget();
         BasicBlock* onNoContinuationBB = newEntryBB->GetFalseTarget();
-        BasicBlock* checkOSRAddressBB    = m_comp->fgNewBBbefore(BBJ_COND, onContinuationBB, true);
+        BasicBlock* checkOSRAddressBB  = m_comp->fgNewBBbefore(BBJ_COND, onContinuationBB, true);
 
         // Switch newEntryBB -> onContinuationBB into newEntryBB -> checkOSRAddressBB
         m_comp->fgRedirectEdge(newEntryBB->TrueEdgeRef(), checkOSRAddressBB);
@@ -2475,12 +2475,12 @@ void AsyncTransformation::CreateResumptionSwitch()
 
         JITDUMP("    Created " FMT_BB " to check for Tier-0 continuations\n", checkOSRAddressBB->bbNum);
 
-        continuationArg           = m_comp->gtNewLclvNode(m_comp->lvaAsyncContinuationArg, TYP_REF);
+        continuationArg             = m_comp->gtNewLclvNode(m_comp->lvaAsyncContinuationArg, TYP_REF);
         unsigned offsetOfOSRAddress = OFFSETOF__CORINFO_Continuation__data;
-        GenTree* osrAddress       = LoadFromOffset(continuationArg, offsetOfOSRAddress, TYP_I_IMPL);
-        GenTree* zero             = m_comp->gtNewIconNode(0, TYP_I_IMPL);
-        GenTree* eqZero           = m_comp->gtNewOperNode(GT_EQ, TYP_INT, osrAddress, zero);
-        GenTree* jtrue            = m_comp->gtNewOperNode(GT_JTRUE, TYP_VOID, eqZero);
+        GenTree* osrAddress         = LoadFromOffset(continuationArg, offsetOfOSRAddress, TYP_I_IMPL);
+        GenTree* zero               = m_comp->gtNewIconNode(0, TYP_I_IMPL);
+        GenTree* eqZero             = m_comp->gtNewOperNode(GT_EQ, TYP_INT, osrAddress, zero);
+        GenTree* jtrue              = m_comp->gtNewOperNode(GT_JTRUE, TYP_VOID, eqZero);
         LIR::AsRange(checkOSRAddressBB).InsertAtEnd(LIR::SeqTree(m_comp, jtrue));
     }
 }

--- a/src/coreclr/jit/async.h
+++ b/src/coreclr/jit/async.h
@@ -22,7 +22,7 @@ struct LiveLocalInfo
 struct ContinuationLayout
 {
     unsigned                             Size                      = 0;
-    unsigned                             OSRILOffset               = UINT_MAX;
+    unsigned                             OSRAddress                = UINT_MAX;
     unsigned                             ExceptionOffset           = UINT_MAX;
     unsigned                             ContinuationContextOffset = UINT_MAX;
     unsigned                             KeepAliveOffset           = UINT_MAX;

--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -1226,6 +1226,7 @@ protected:
     void                 genJumpTable(GenTree* tree);
     void                 genTableBasedSwitch(GenTree* tree);
     void                 genAsyncResumeInfo(GenTreeVal* tree);
+    void                 genFtnEntry(GenTree* tree);
     UNATIVE_OFFSET       genEmitAsyncResumeInfoTable(emitter::dataSection** dataSec);
     CORINFO_FIELD_HANDLE genEmitAsyncResumeInfo(unsigned stateNum);
 #if defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
@@ -1288,6 +1289,8 @@ protected:
 #ifdef SWIFT_SUPPORT
     void genSwiftErrorReturn(GenTree* treeNode);
 #endif // SWIFT_SUPPORT
+
+    void genNonLocalJmp(GenTreeUnOp* treeNode);
 
 #ifdef TARGET_XARCH
     void           genStackPointerConstantAdjustment(ssize_t spDelta, bool trackSpAdjustments);

--- a/src/coreclr/jit/codegenarm.cpp
+++ b/src/coreclr/jit/codegenarm.cpp
@@ -669,6 +669,17 @@ void CodeGen::genAsyncResumeInfo(GenTreeVal* treeNode)
 }
 
 //------------------------------------------------------------------------
+// genFtnEntry: emits address of the current function being compiled
+//
+// Parameters:
+//   treeNode - the GT_FTN_ENTRY node
+//
+void CodeGen::genFtnEntry(GenTree* treeNode)
+{
+    NYI_ARM64("FTN_ENTRY");
+}
+
+//------------------------------------------------------------------------
 // genGetInsForOper: Return instruction encoding of the operation tree.
 //
 instruction CodeGen::genGetInsForOper(genTreeOps oper, var_types type)

--- a/src/coreclr/jit/codegenarm64.cpp
+++ b/src/coreclr/jit/codegenarm64.cpp
@@ -3758,6 +3758,17 @@ void CodeGen::genAsyncResumeInfo(GenTreeVal* treeNode)
 }
 
 //------------------------------------------------------------------------
+// genFtnEntry: emits address of the current function being compiled
+//
+// Parameters:
+//   treeNode - the GT_FTN_ENTRY node
+//
+void CodeGen::genFtnEntry(GenTree* treeNode)
+{
+    NYI_ARM64("FTN_ENTRY");
+}
+
+//------------------------------------------------------------------------
 // genLockedInstructions: Generate code for a GT_XADD, GT_XAND, GT_XORR or GT_XCHG node.
 //
 // Arguments:

--- a/src/coreclr/jit/codegenarmarch.cpp
+++ b/src/coreclr/jit/codegenarmarch.cpp
@@ -518,6 +518,10 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             genAsyncResumeInfo(treeNode->AsVal());
             break;
 
+        case GT_FTN_ENTRY:
+            genFtnEntry(treeNode);
+            break;
+
         case GT_PINVOKE_PROLOG:
             noway_assert(((gcInfo.gcRegGCrefSetCur | gcInfo.gcRegByrefSetCur) &
                           ~fullIntArgRegMask(compiler->info.compCallConv)) == 0);

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -5238,6 +5238,10 @@ void CodeGen::genFnProlog()
         // allocating the local frame.
         //
         extraFrameSize = compiler->compCalleeRegsPushed * REGSIZE_BYTES;
+
+        // Simulate a call address being pushed to get expected misalignment on entry.
+        GetEmitter()->emitIns_R(INS_push, EA_PTRSIZE, REG_EAX);
+        compiler->unwindAllocStack(REGSIZE_BYTES);
     }
 #endif // TARGET_AMD64
 

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -10054,13 +10054,14 @@ void CodeGen::genOSRRecordTier0CalleeSavedRegistersAndFrame()
     // We must account for the post-callee-saves push SP movement
     // done by the Tier0 frame and by the OSR transition.
     //
-    // tier0FrameSize is the Tier0 FP-SP delta plus the fake call slot added by
-    // JIT_Patchpoint. We add one slot to account for the saved FP.
+    // tier0FrameSize is the Tier0 FP-SP delta plus the fake call slot we push in genFnProlog.
+    // We subtract the fake call slot since we will add it as unwind after the instruction itself.
+    // We then add back one slot to account for the saved FP.
     //
     // We then need to subtract off the size the Tier0 callee saves as SP
     // adjusts for those will have been modelled by the unwind pushes above.
     //
-    int const tier0FrameSize = patchpointInfo->TotalFrameSize() + REGSIZE_BYTES;
+    int const tier0FrameSize = patchpointInfo->TotalFrameSize() - REGSIZE_BYTES + REGSIZE_BYTES;
     int const tier0NetSize   = tier0FrameSize - tier0IntCalleeSaveUsedSize;
     compiler->unwindAllocStack(tier0NetSize);
 }

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -4296,8 +4296,6 @@ void CodeGen::genNonLocalJmp(GenTreeUnOp* tree)
 {
     genConsumeOperands(tree->AsOp());
     inst_TT(INS_i_jmp, EA_PTRSIZE, tree->gtGetOp1());
-    //GetEmitter()->ihnst
-    //GetEmitter()->emitIns_R(INS_i_jmp, emitTypeSize(TYP_I_IMPL), reg);
 }
 
 // emits the table and an instruction to get the address of the first element

--- a/src/coreclr/jit/codegenxarch.cpp
+++ b/src/coreclr/jit/codegenxarch.cpp
@@ -1935,6 +1935,10 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             genReturnSuspend(treeNode->AsUnOp());
             break;
 
+        case GT_NONLOCAL_JMP:
+            genNonLocalJmp(treeNode->AsUnOp());
+            break;
+
         case GT_LEA:
             // If we are here, it is the case where there is an LEA that cannot be folded into a parent instruction.
             genLeaInstruction(treeNode->AsAddrMode());
@@ -2140,6 +2144,10 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 
         case GT_ASYNC_RESUME_INFO:
             genAsyncResumeInfo(treeNode->AsVal());
+            break;
+
+        case GT_FTN_ENTRY:
+            genFtnEntry(treeNode);
             break;
 
         case GT_STORE_BLK:
@@ -4284,6 +4292,14 @@ void CodeGen::genTableBasedSwitch(GenTree* treeNode)
     GetEmitter()->emitIns_R(INS_i_jmp, emitTypeSize(TYP_I_IMPL), baseReg);
 }
 
+void CodeGen::genNonLocalJmp(GenTreeUnOp* tree)
+{
+    genConsumeOperands(tree->AsOp());
+    inst_TT(INS_i_jmp, EA_PTRSIZE, tree->gtGetOp1());
+    //GetEmitter()->ihnst
+    //GetEmitter()->emitIns_R(INS_i_jmp, emitTypeSize(TYP_I_IMPL), reg);
+}
+
 // emits the table and an instruction to get the address of the first element
 void CodeGen::genJumpTable(GenTree* treeNode)
 {
@@ -4307,6 +4323,17 @@ void CodeGen::genAsyncResumeInfo(GenTreeVal* treeNode)
     GetEmitter()->emitIns_R_C(INS_lea, emitTypeSize(TYP_I_IMPL), treeNode->GetRegNum(),
                               genEmitAsyncResumeInfo((unsigned)treeNode->gtVal1), 0);
     genProduceReg(treeNode);
+}
+
+//------------------------------------------------------------------------
+// genFtnEntry: emits address of the current function being compiled
+//
+// Parameters:
+//   treeNode - the GT_FTN_ENTRY node
+//
+void CodeGen::genFtnEntry(GenTree* treeNode)
+{
+    GetEmitter()->emitIns_R_C(INS_lea, EA_PTRSIZE, treeNode->GetRegNum(), FLD_FTN_ENTRY, 0);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -5570,8 +5570,8 @@ void Compiler::generatePatchpointInfo()
     // offset.
 
 #if defined(TARGET_AMD64)
-    // We add +TARGET_POINTER_SIZE here is to account for the slot that Jit_Patchpoint
-    // creates when it simulates calling the OSR method (the "pseudo return address" slot).
+    // We add +TARGET_POINTER_SIZE here is to account for the return address slot that the OSR method
+    // pushes on entry (the "pseudo return address" slot) to make the stack unaligned.
     // This is effectively a new slot at the bottom of the Tier0 frame.
     //
     const int totalFrameSize = codeGen->genTotalFrameSize() + TARGET_POINTER_SIZE;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -11724,6 +11724,7 @@ public:
             case GT_ASYNC_RESUME_INFO:
             case GT_LABEL:
             case GT_FTN_ADDR:
+            case GT_FTN_ENTRY:
             case GT_RET_EXPR:
             case GT_CNS_INT:
             case GT_CNS_LNG:
@@ -11797,6 +11798,7 @@ public:
             case GT_FIELD_ADDR:
             case GT_RETURN:
             case GT_RETURN_SUSPEND:
+            case GT_NONLOCAL_JMP:
             case GT_RETFILT:
             case GT_RUNTIMELOOKUP:
             case GT_ARR_ADDR:

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -4477,6 +4477,7 @@ GenTree::VisitResult GenTree::VisitOperands(TVisitor visitor)
         case GT_ASYNC_RESUME_INFO:
         case GT_LABEL:
         case GT_FTN_ADDR:
+        case GT_FTN_ENTRY:
         case GT_RET_EXPR:
         case GT_CNS_INT:
         case GT_CNS_LNG:
@@ -4551,6 +4552,7 @@ GenTree::VisitResult GenTree::VisitOperands(TVisitor visitor)
         case GT_KEEPALIVE:
         case GT_INC_SATURATE:
         case GT_RETURN_SUSPEND:
+        case GT_NONLOCAL_JMP:
             return visitor(this->AsUnOp()->gtOp1);
 
 // Variadic nodes

--- a/src/coreclr/jit/fgstmt.cpp
+++ b/src/coreclr/jit/fgstmt.cpp
@@ -540,6 +540,7 @@ inline bool OperIsControlFlow(genTreeOps oper)
         case GT_RETFILT:
         case GT_SWIFT_ERROR_RET:
         case GT_RETURN_SUSPEND:
+        case GT_NONLOCAL_JMP:
             return true;
 
         default:

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2749,9 +2749,12 @@ AGAIN:
                 }
                 return true;
 
+            case GT_ASYNC_RESUME_INFO:
+                return op1->AsVal()->gtVal1 == op2->AsVal()->gtVal1;
+
             case GT_NOP:
             case GT_LABEL:
-            case GT_ASYNC_RESUME_INFO:
+            case GT_FTN_ENTRY:
             case GT_SWIFT_ERROR:
             case GT_GCPOLL:
                 return true;
@@ -6801,6 +6804,7 @@ bool GenTree::TryGetUse(GenTree* operand, GenTree*** pUse)
         case GT_ASYNC_RESUME_INFO:
         case GT_LABEL:
         case GT_FTN_ADDR:
+        case GT_FTN_ENTRY:
         case GT_RET_EXPR:
         case GT_CNS_INT:
         case GT_CNS_LNG:
@@ -6863,6 +6867,7 @@ bool GenTree::TryGetUse(GenTree* operand, GenTree*** pUse)
         case GT_RETURN:
         case GT_RETFILT:
         case GT_RETURN_SUSPEND:
+        case GT_NONLOCAL_JMP:
         case GT_BSWAP:
         case GT_BSWAP16:
         case GT_KEEPALIVE:
@@ -7147,6 +7152,7 @@ bool GenTree::OperRequiresCallFlag(Compiler* comp) const
         case GT_KEEPALIVE:
         case GT_ASYNC_CONTINUATION:
         case GT_RETURN_SUSPEND:
+        case GT_NONLOCAL_JMP:
             return true;
 
         case GT_SWIFT_ERROR:
@@ -7490,6 +7496,7 @@ bool GenTree::OperRequiresGlobRefFlag(Compiler* comp) const
         case GT_KEEPALIVE:
         case GT_ASYNC_CONTINUATION:
         case GT_RETURN_SUSPEND:
+        case GT_NONLOCAL_JMP:
         case GT_SWIFT_ERROR:
         case GT_GCPOLL:
             return true;
@@ -7552,6 +7559,7 @@ bool GenTree::OperSupportsOrderingSideEffect() const
         case GT_CATCH_ARG:
         case GT_ASYNC_CONTINUATION:
         case GT_RETURN_SUSPEND:
+        case GT_NONLOCAL_JMP:
         case GT_SWIFT_ERROR:
             return true;
         default:
@@ -9680,6 +9688,7 @@ GenTree* Compiler::gtCloneExpr(GenTree* tree)
 
             case GT_CATCH_ARG:
             case GT_ASYNC_CONTINUATION:
+            case GT_FTN_ENTRY:
             case GT_NO_OP:
             case GT_NOP:
             case GT_LABEL:
@@ -10440,6 +10449,7 @@ GenTreeUseEdgeIterator::GenTreeUseEdgeIterator(GenTree* node)
         case GT_ASYNC_RESUME_INFO:
         case GT_LABEL:
         case GT_FTN_ADDR:
+        case GT_FTN_ENTRY:
         case GT_RET_EXPR:
         case GT_CNS_INT:
         case GT_CNS_LNG:
@@ -10505,6 +10515,7 @@ GenTreeUseEdgeIterator::GenTreeUseEdgeIterator(GenTree* node)
         case GT_INC_SATURATE:
         case GT_RETURNTRAP:
         case GT_RETURN_SUSPEND:
+        case GT_NONLOCAL_JMP:
             m_edge = &m_node->AsUnOp()->gtOp1;
             assert(*m_edge != nullptr);
             m_advance = &GenTreeUseEdgeIterator::Terminate;
@@ -12522,6 +12533,7 @@ void Compiler::gtDispLeaf(GenTree* tree, IndentStack* indentStack)
         case GT_JMPTABLE:
         case GT_SWIFT_ERROR:
         case GT_GCPOLL:
+        case GT_FTN_ENTRY:
             break;
 
         case GT_RET_EXPR:

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -39,6 +39,7 @@ GTNODE(FTN_ADDR         , GenTreeFptrVal     ,0,0,GTK_LEAF)             // Addre
 GTNODE(RET_EXPR         , GenTreeRetExpr     ,0,0,GTK_LEAF|DBK_NOTLIR)  // Place holder for the return expression from an inline candidate
 GTNODE(GCPOLL           , GenTree            ,0,0,GTK_LEAF|GTK_NOVALUE|DBK_NOTLIR)
 GTNODE(ASYNC_RESUME_INFO, GenTreeVal         ,0,0,GTK_LEAF)             // Address of async resume info for a state
+GTNODE(FTN_ENTRY        , GenTree            ,0,0,GTK_LEAF)             // Address of this function's entry point
 
 //-----------------------------------------------------------------------------
 //  Constant nodes:
@@ -103,6 +104,8 @@ GTNODE(BSWAP            , GenTreeOp          ,0,0,GTK_UNOP)               // Byt
 GTNODE(BSWAP16          , GenTreeOp          ,0,0,GTK_UNOP)               // Byte swap lower 16-bits and zero upper 16 bits
 
 GTNODE(LZCNT            , GenTreeOp          ,0,0,GTK_UNOP)               // Leading Zero Count - Only used for SIMD VN evaluation today
+
+GTNODE(NONLOCAL_JMP     , GenTreeOp          ,0,0,GTK_UNOP|GTK_NOVALUE)   // Non-local jump to specified address
 
 //-----------------------------------------------------------------------------
 //  Binary operators (2 operands):

--- a/src/coreclr/jit/jit.h
+++ b/src/coreclr/jit/jit.h
@@ -454,6 +454,7 @@ typedef double weight_t;
 #define FLD_GLOBAL_DS ((CORINFO_FIELD_HANDLE)-4)
 #define FLD_GLOBAL_FS ((CORINFO_FIELD_HANDLE)-8)
 #define FLD_GLOBAL_GS ((CORINFO_FIELD_HANDLE)-12)
+#define FLD_FTN_ENTRY ((CORINFO_FIELD_HANDLE)-16)
 
 class GlobalJitOptions
 {

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -1489,6 +1489,7 @@ void Compiler::fgComputeLifeLIR(VARSET_TP& life, BasicBlock* block, VARSET_VALAR
             case GT_JTRUE:
             case GT_RETURN:
             case GT_RETURN_SUSPEND:
+            case GT_NONLOCAL_JMP:
             case GT_SWITCH:
             case GT_RETFILT:
             case GT_START_NONGC:

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -687,6 +687,10 @@ GenTree* Lowering::LowerNode(GenTree* node)
             LowerReturnSuspend(node);
             break;
 
+        case GT_NONLOCAL_JMP:
+            ContainCheckNonLocalJmp(node->AsOp());
+            break;
+
 #if defined(FEATURE_HW_INTRINSICS) && defined(TARGET_ARM64)
         case GT_CNS_MSK:
             return LowerCnsMask(node->AsMskCon());
@@ -9743,6 +9747,9 @@ void Lowering::ContainCheckNode(GenTree* node)
             ContainCheckHWIntrinsic(node->AsHWIntrinsic());
             break;
 #endif // FEATURE_HW_INTRINSICS
+        case GT_NONLOCAL_JMP:
+            ContainCheckNonLocalJmp(node->AsUnOp());
+            break;
         default:
             break;
     }

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -109,6 +109,7 @@ private:
     void ContainCheckCallOperands(GenTreeCall* call);
     void ContainCheckIndir(GenTreeIndir* indirNode);
     void ContainCheckStoreIndir(GenTreeStoreInd* indirNode);
+    void ContainCheckNonLocalJmp(GenTreeUnOp* node);
     void ContainCheckMul(GenTreeOp* node);
     void ContainCheckShiftRotate(GenTreeOp* node);
     void ContainCheckStoreLoc(GenTreeLclVarCommon* storeLoc) const;

--- a/src/coreclr/jit/lowerarmarch.cpp
+++ b/src/coreclr/jit/lowerarmarch.cpp
@@ -2948,6 +2948,10 @@ void Lowering::ContainCheckDivOrMod(GenTreeOp* node)
     // ARM doesn't have a div instruction with an immediate operand
 }
 
+void Lowering::ContainCheckNonLocalJmp(GenTreeUnOp* node)
+{
+}
+
 //------------------------------------------------------------------------
 // ContainCheckShiftRotate: Determine whether a mul op's operands should be contained.
 //

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -227,6 +227,10 @@ void Lowering::ContainCheckCallOperands(GenTreeCall* call)
 {
 }
 
+void Lowering::ContainCheckNonLocalJmp(GenTreeUnOp* node)
+{
+}
+
 //------------------------------------------------------------------------
 // ContainCheckStoreIndir: determine whether the sources of a STOREIND node should be contained.
 //

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -7290,6 +7290,19 @@ void Lowering::ContainCheckIndir(GenTreeIndir* node)
     }
 }
 
+void Lowering::ContainCheckNonLocalJmp(GenTreeUnOp* node)
+{
+    GenTree* addr = node->gtGetOp1();
+    if (IsContainableMemoryOp(addr) && IsSafeToContainMem(node, addr))
+    {
+        MakeSrcContained(node, addr);
+    }
+    else if (IsSafeToMarkRegOptional(node, addr))
+    {
+        MakeSrcRegOptional(node, addr);
+    }
+}
+
 //------------------------------------------------------------------------
 // ContainCheckStoreIndir: determine whether the sources of a STOREIND node should be contained.
 //

--- a/src/coreclr/jit/lsraarm.cpp
+++ b/src/coreclr/jit/lsraarm.cpp
@@ -321,6 +321,11 @@ int LinearScan::BuildNode(GenTree* tree)
             assert(srcCount == 2);
             break;
 
+        case GT_NONLOCAL_JMP:
+            assert(dstCount == 0);
+            srcCount = BuildOperandUses(tree->gtGetOp1());
+            break;
+
         case GT_ADD_LO:
         case GT_ADD_HI:
         case GT_SUB_LO:

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1272,6 +1272,11 @@ int LinearScan::BuildNode(GenTree* tree)
             BuildDef(tree, RBM_ASYNC_CONTINUATION_RET.GetIntRegSet());
             break;
 
+        case GT_FTN_ENTRY:
+            srcCount = 0;
+            BuildDef(tree);
+            break;
+
         case GT_INDEX_ADDR:
             assert(dstCount == 1);
             srcCount = BuildBinaryUses(tree->AsOp());

--- a/src/coreclr/vm/jithelpers.cpp
+++ b/src/coreclr/vm/jithelpers.cpp
@@ -1696,11 +1696,6 @@ extern "C" void JIT_PatchpointWorkerWorkerWithPolicy(TransitionBlock * pTransiti
         // use that to adjust the stack, likely saving some stack space.
 
 #if defined(TARGET_AMD64)
-        // If calls push the return address, we need to simulate that here, so the OSR
-        // method sees the "expected" SP misalgnment on entry.
-        _ASSERTE(currentSP % 16 == 0);
-        currentSP -= 8;
-
 #if defined(TARGET_WINDOWS)
         DWORD64 ssp = GetSSP(pFrameContext);
         if (ssp != 0)

--- a/src/coreclr/vm/object.h
+++ b/src/coreclr/vm/object.h
@@ -2198,7 +2198,7 @@ class ContinuationObject : public Object
     {
         LIMITED_METHOD_CONTRACT;
         PTR_BYTE dataAddress = dac_cast<PTR_BYTE>((dac_cast<TADDR>(this) + OFFSETOF__CORINFO_Continuation__data));
-        if (GetFlags() & CORINFO_CONTINUATION_HAS_OSR_ILOFFSET)
+        if (GetFlags() & CORINFO_CONTINUATION_HAS_OSR_ADDRESS)
         {
             dataAddress += sizeof(void*);
         }
@@ -2219,7 +2219,7 @@ class ContinuationObject : public Object
         _ASSERTE((GetFlags() & CORINFO_CONTINUATION_HAS_EXCEPTION));
 
         PTR_BYTE dataAddress = dac_cast<PTR_BYTE>((dac_cast<TADDR>(this) + OFFSETOF__CORINFO_Continuation__data));
-        if (GetFlags() & CORINFO_CONTINUATION_HAS_OSR_ILOFFSET)
+        if (GetFlags() & CORINFO_CONTINUATION_HAS_OSR_ADDRESS)
         {
             dataAddress += sizeof(void*);
         }


### PR DESCRIPTION
Previously resumption inside OSR methods looked like a normal OSR transition going through the patchpoint helper. However, the patchpoint helper is not cheap and the overhead of this is around 10-20x.

This PR optimizes resumption inside OSR functions by executing a direct non-local jump from the tier0 code into the OSR code. This completely bypasses the patchpoint helper. To do so:
- Introduce `GT_FTN_ENTRY` which represents the entry point of the current function being compiled. Switch the OSR IL offset stored by OSR methods in the continuation to be this address instead.
- Introduce `GT_NONLOCAL_JMP`, a unary node which represents a jump to a specified address. Change the async transformation to generate this node in tier0 codegen, so that when an OSR continuation is passed, we just jump to the OSR address.
- Move the responsibility of simulating a call instruction from `JIT_Patchpoint` to the OSR function itself by simply pushing any value on the stack on entry.

Currently this only works for x64. To make this work for other targets they need to be switched to restore callee saves from the tier0 frame.
The same approach can also be used to remove the transitioning responsibility from `JIT_Patchpoint`. The idea would be that `JIT_Patchpoint` returns a function address and the tier0 codegen just executes a nonlocal jump to it.

Example:
```csharp
using System;
using System.Diagnostics;
using System.Runtime.CompilerServices;
using System.Threading.Tasks;

namespace OSRPerf;

public class Program
{
    static void Main()
    {
        NullAwaiter na = new NullAwaiter();

        Task t = Foo(10_000_000, na);
        while (!t.IsCompleted)
        {
            na.Continue();
        }
    }

    static int s_value;
    static async Task Foo(int n, NullAwaiter na)
    {
        for (int i = 0; i < n; i++)
        {
            s_value += i;
        }

        Stopwatch timer = Stopwatch.StartNew();
        for (int i = 0; i < 10_000_000; i++)
        {
            await na;
        }
        Console.WriteLine("Took {0:F1} ms", timer.Elapsed.TotalMilliseconds);
    }

    private class NullAwaiter : ICriticalNotifyCompletion
    {
        public Action Continue;

        public NullAwaiter GetAwaiter() => this;

        public bool IsCompleted => false;

        public void GetResult()
        {
        }

        public void UnsafeOnCompleted(Action continuation)
        {
            Continue = continuation;
        }

        public void OnCompleted(Action continuation)
        {
            throw new NotImplementedException();
        }
    }
}
```

Before: Took 19462.2 ms
After: Took 799.1 ms

<details>

<summary> Tier0 codegen diff</summary>

```diff
@@ -22,7 +22,7 @@
 ;  V12 tmp4         [V12    ] (  1,  1   )     ref  ->  [rbp-0x48]  do-not-enreg[X] must-init addr-exposed ld-addr-op "Async SynchronizationContext"
 ;  V13 tmp5         [V13    ] (  1,  1   )     ref  ->  [rbp-0x80]  do-not-enreg[] must-init "returned continuation"
 ;  V14 tmp6         [V14    ] (  1,  1   )     ref  ->  [rbp-0x88]  do-not-enreg[] must-init "new continuation"
-;  V15 tmp7         [V15    ] (  1,  1   )     int  ->  [rbp-0x8C]  do-not-enreg[] must-init "IL offset for tier0 OSR method"
+;  V15 tmp7         [V15    ] (  1,  1   )    long  ->  [rbp-0x90]  do-not-enreg[] must-init "OSR address for tier0 OSR method"
 ;  TEMP_01                                   byref  ->  [rbp-0x98]
 ;
 ; Lcl frame size = 192
@@ -178,7 +178,8 @@ G_M39061_IG15:
        mov      rax, gword ptr [rbp-0x88]
        mov      dword ptr [rax+0x18], 1
        mov      rax, gword ptr [rbp-0x88]
-       mov      dword ptr [rax+0x20], -1
+       xor      ecx, ecx
+       mov      qword ptr [rax+0x20], rcx
        mov      rax, gword ptr [rbp-0x88]
        lea      rcx, bword ptr [rax+0x30]
        mov      rdx, gword ptr [rbp+0x20]
@@ -223,9 +224,9 @@ G_M39061_IG15:
        mov      bword ptr [rbp-0x98], rcx
        call     [System.Runtime.CompilerServices.AsyncHelpers:CaptureExecutionContext():System.Threading.ExecutionContext]
        mov      rcx, bword ptr [rbp-0x98]
-       mov      rdx, rax
-						;; size=309 bbWeight=0 PerfScore 0.00
+						;; size=305 bbWeight=0 PerfScore 0.00
 G_M39061_IG16:
+       mov      rdx, rax
        call     CORINFO_HELP_ASSIGN_REF
        cmp      gword ptr [rbp+0x10], 0
        setne    cl
@@ -235,7 +236,7 @@ G_M39061_IG16:
        call     [System.Runtime.CompilerServices.AsyncHelpers:RestoreContextsOnSuspension(bool,System.Threading.ExecutionContext,System.Threading.SynchronizationContext)]
        mov      rax, gword ptr [rbp-0x88]
        mov      rcx, rax
-						;; size=40 bbWeight=0 PerfScore 0.00
+						;; size=43 bbWeight=0 PerfScore 0.00
 G_M39061_IG17:
        add      rsp, 192
        pop      rbp
@@ -243,10 +244,10 @@ G_M39061_IG17:
 						;; size=9 bbWeight=0 PerfScore 0.00
 G_M39061_IG18:
        mov      rax, gword ptr [rbp+0x10]
-       mov      eax, dword ptr [rax+0x20]
-       mov      dword ptr [rbp-0x8C], eax
-       cmp      dword ptr [rbp-0x8C], 0
-       jge      G_M39061_IG19
+       mov      rax, qword ptr [rax+0x20]
+       mov      qword ptr [rbp-0x90], rax
+       cmp      qword ptr [rbp-0x90], 0
+       jne      G_M39061_IG19
        mov      rax, gword ptr [rbp+0x10]
        mov      rcx, gword ptr [rax+0x28]
        call     [System.Runtime.CompilerServices.AsyncHelpers:RestoreExecutionContext(System.Threading.ExecutionContext)]
@@ -284,12 +285,11 @@ G_M39061_IG18:
        mov      eax, dword ptr [rax+0x74]
        mov      dword ptr [rbp-0x78], eax
        jmp      G_M39061_IG09
-						;; size=172 bbWeight=0 PerfScore 0.00
+						;; size=175 bbWeight=0 PerfScore 0.00
 G_M39061_IG19:
-       mov      ecx, dword ptr [rbp-0x8C]
-       call     CORINFO_HELP_PATCHPOINT_FORCED
+       jmp      qword ptr [rbp-0x90]
        int3     
-						;; size=12 bbWeight=0 PerfScore 0.00
+						;; size=7 bbWeight=0 PerfScore 0.00
 G_M39061_IG20:
        sub      rsp, 40
 						;; size=4 bbWeight=0 PerfScore 0.00
@@ -310,5 +310,5 @@ RWD00  	dq	(dynamicClass):IL_STUB_AsyncResume_Foo_Tier0(System.Object,byref):Sys
 	dq	G_M39061_IG15
 
 
-; Total bytes of code 1050, prolog size 62, PerfScore 126.37, instruction count 235, allocated bytes for code 1050 (MethodHash=01c8676a) for method OSRPerf.Program:Foo(int,OSRPerf.Program+NullAwaiter) (Instrumented Tier0)
+; Total bytes of code 1047, prolog size 62, PerfScore 126.37, instruction count 235, allocated bytes for code 1047 (MethodHash=01c8676a) for method OSRPerf.Program:Foo(int,OSRPerf.Program+NullAwaiter) (Instrumented Tier0)
 ; ============================================================
```

</details>

<details>

<summary> OSR method diff </summary>

```diff
@@ -62,6 +62,7 @@
 ; Lcl frame size = 80
 
 G_M39061_IG01:
+       push     rax
        mov      rax, qword ptr [rbp]
        push     rax
        sub      rsp, 112
@@ -78,7 +79,7 @@ G_M39061_IG01:
        mov      rax, gword ptr [rbp+0xE0]
        mov      ecx, dword ptr [rbp+0xE8]
        mov      edx, dword ptr [rbp+0x7C]
-						;; size=81 bbWeight=1 PerfScore 19.00
+						;; size=82 bbWeight=1 PerfScore 20.00
 G_M39061_IG02:
        test     rax, rax
        jne      G_M39061_IG49
@@ -343,7 +344,8 @@ G_M39061_IG47:
        lea      rcx, [reloc @RWD32]
        mov      qword ptr [r14+0x10], rcx
        mov      qword ptr [r14+0x18], 1
-       mov      dword ptr [r14+0x20], 20
+       lea      rcx, G_M39061_IG01
+       mov      qword ptr [r14+0x20], rcx
        lea      rcx, bword ptr [r14+0x30]
        mov      rdx, rbx
        call     CORINFO_HELP_ASSIGN_REF
@@ -366,7 +368,7 @@ G_M39061_IG47:
        mov      r8, gword ptr [rbp+0x88]
        call     [System.Runtime.CompilerServices.AsyncHelpers:RestoreContextsOnSuspension(bool,System.Threading.ExecutionContext,System.Threading.SynchronizationContext)]
        mov      rcx, r14
-						;; size=145 bbWeight=0 PerfScore 0.00
+						;; size=148 bbWeight=0 PerfScore 0.00
 G_M39061_IG48:
        vmovaps  xmm6, xmmword ptr [rsp+0x40]
        add      rsp, 288
@@ -378,9 +380,9 @@ G_M39061_IG48:
        ret      
 						;; size=20 bbWeight=0 PerfScore 0.00
 G_M39061_IG49:
-       cmp      dword ptr [rax+0x20], 0
+       cmp      qword ptr [rax+0x20], 0
        mov      rax, gword ptr [rbp+0xE0]
-       jl       G_M39061_IG03
+       je       G_M39061_IG03
        mov      rcx, gword ptr [rax+0x28]
        call     [System.Runtime.CompilerServices.AsyncHelpers:RestoreExecutionContext(System.Threading.ExecutionContext)]
        mov      rax, gword ptr [rbp+0xE0]
@@ -392,7 +394,7 @@ G_M39061_IG49:
        mov      qword ptr [rbp-0x40], r8
        mov      edi, dword ptr [rax+0x50]
        jmp      G_M39061_IG12
-						;; size=66 bbWeight=0 PerfScore 0.00
+						;; size=67 bbWeight=0 PerfScore 0.00
 G_M39061_IG50:
        sub      rsp, 40
        vzeroupper 
@@ -418,5 +420,5 @@ RWD32  	dq	(dynamicClass):IL_STUB_AsyncResume_Foo_Tier1OSR(System.Object,byref):
 	dq	G_M39061_IG47
```

</details>

Fix #120865