### PR TITLE
[release/9.0] Bump macos helix queues

### DIFF
--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -54,11 +54,11 @@ jobs:
 
     # iOS devices
     - ${{ if in(parameters.platform, 'ios_arm64') }}:
-      - OSX.13.Amd64.Iphone.Open
+      - OSX.15.Amd64.Iphone.Open
 
     # tvOS devices
     - ${{ if in(parameters.platform, 'tvos_arm64') }}:
-        - OSX.13.Amd64.AppleTV.Open
+        - OSX.15.Amd64.AppleTV.Open
 
     # Linux arm
     - ${{ if eq(parameters.platform, 'linux_arm') }}:
@@ -105,16 +105,16 @@ jobs:
     # OSX arm64
     - ${{ if eq(parameters.platform, 'osx_arm64') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - OSX.13.ARM64.Open
+        - OSX.15.ARM64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - OSX.13.ARM64
+        - OSX.15.ARM64
 
     # OSX x64
     - ${{ if eq(parameters.platform, 'osx_x64') }}:
       - ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        - OSX.13.Amd64.Open
+        - OSX.15.Amd64.Open
       - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        - OSX.13.Amd64
+        - OSX.15.Amd64
 
     # windows x64
     - ${{ if eq(parameters.platform, 'windows_x64') }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -73,11 +73,11 @@ jobs:
 
     # OSX arm64
     - ${{ if eq(parameters.platform, 'osx_arm64') }}:
-      - OSX.13.ARM64.Open
+      - OSX.15.ARM64.Open
 
     # OSX x64
     - ${{ if eq(parameters.platform, 'osx_x64') }}:
-      - OSX.13.Amd64.Open
+      - OSX.15.Amd64.Open
 
     # Android
     - ${{ if in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64') }}:
@@ -95,11 +95,11 @@ jobs:
 
     # iOS devices
     - ${{ if in(parameters.platform, 'ios_arm64') }}:
-      - OSX.13.Amd64.Iphone.Open
+      - OSX.15.Amd64.Iphone.Open
 
     # tvOS devices
     - ${{ if in(parameters.platform, 'tvos_arm64') }}:
-      - OSX.13.Amd64.AppleTV.Open
+      - OSX.15.Amd64.AppleTV.Open
 
     # windows x64
     - ${{ if eq(parameters.platform, 'windows_x64') }}:

--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -465,7 +465,7 @@ def main(main_args):
         else:
             helix_queue = "Ubuntu.2204.Amd64"
     elif platform_name == "osx":
-        helix_queue = "OSX.13.ARM64" if arch == "arm64" else "OSX.13.Amd64"
+        helix_queue = "OSX.15.ARM64" if arch == "arm64" else "OSX.15.Amd64"
 
     # Copy the superpmi scripts
 


### PR DESCRIPTION
Unfortunately, these were missed and the 13 queues no longer exist.