### PR TITLE
Fix XUnitWrapperGenerator handling of SkipOnCoreClrAttribute with no runtime test modes

### DIFF
--- a/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
@@ -147,10 +147,15 @@ public sealed class ConditionalTest : ITestInfo
 
         _innerTest = innerTest;
         _condition = condition;
-   }
+    }
 
     public ConditionalTest(ITestInfo innerTest, Xunit.TestPlatforms platform)
         : this(innerTest, GetPlatformConditionFromTestPlatform(platform))
+    {
+    }
+    
+    public ConditionalTest(ITestInfo innerTest, string condition, Xunit.TestPlatforms platform)
+        :this(innerTest, $"{(condition.Length == 0 ? "true" : condition)} && ({GetPlatformConditionFromTestPlatform(platform)})")
     {
     }
 
@@ -206,6 +211,16 @@ public sealed class ConditionalTest : ITestInfo
     private static string GetPlatformConditionFromTestPlatform(Xunit.TestPlatforms platform)
     {
         List<string> platformCheckConditions = new();
+
+        if (platform == Xunit.TestPlatforms.Any)
+        {
+            return "false";
+        }
+
+        if (platform == 0)
+        {
+            return "true";
+        }
 
         if (platform.HasFlag(Xunit.TestPlatforms.Windows))
         {

--- a/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
@@ -214,12 +214,12 @@ public sealed class ConditionalTest : ITestInfo
 
         if (platform == Xunit.TestPlatforms.Any)
         {
-            return "false";
+            return "true";
         }
 
         if (platform == 0)
         {
-            return "true";
+            return "false";
         }
 
         if (platform.HasFlag(Xunit.TestPlatforms.Windows))

--- a/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/ITestInfo.cs
@@ -153,9 +153,9 @@ public sealed class ConditionalTest : ITestInfo
         : this(innerTest, GetPlatformConditionFromTestPlatform(platform))
     {
     }
-    
+
     public ConditionalTest(ITestInfo innerTest, string condition, Xunit.TestPlatforms platform)
-        :this(innerTest, $"{(condition.Length == 0 ? "true" : condition)} && ({GetPlatformConditionFromTestPlatform(platform)})")
+        : this(innerTest, $"{(condition.Length == 0 ? "true" : condition)} && ({GetPlatformConditionFromTestPlatform(platform)})")
     {
     }
 

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -876,7 +876,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
                     }
 
                     if (skippedTestModes == Xunit.RuntimeTestModes.Any
-                        && skippedConfigurations == Xunit.RuntimeConfigurations.Any
+                        && skippedConfigurations == Xunit.RuntimeConfiguration.Any
                         && skippedTestPlatforms == Xunit.TestPlatforms.Any)
                     {
                         testInfos = FilterForSkippedRuntime(testInfos, (int)Xunit.TestRuntimes.CoreCLR, options);

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -847,9 +847,9 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
                         continue;
                     }
 
-                    Xunit.TestPlatforms skippedTestPlatforms = 0;
-                    Xunit.RuntimeConfiguration skippedConfigurations = 0;
-                    Xunit.RuntimeTestModes skippedTestModes = 0;
+                    Xunit.TestPlatforms skippedTestPlatforms = Xunit.TestPlatforms.Any;
+                    Xunit.RuntimeConfiguration skippedConfigurations = Xunit.RuntimeConfiguration.Any;
+                    Xunit.RuntimeTestModes skippedTestModes = Xunit.RuntimeTestModes.Any;
 
                     for (int i = 1; i < filterAttribute.ConstructorArguments.Length; i++)
                     {
@@ -959,12 +959,6 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         else if (skippedTestModes.HasFlag(Xunit.RuntimeTestModes.GCStressC))
         {
             conditions.Add($"!{ConditionClass}.IsGCStressC");
-        }
-
-        if (conditions.Count == 0)
-        {
-            // If all configurations are skipped, just skip the test as a whole
-            return ImmutableArray<ITestInfo>.Empty;
         }
 
         return ImmutableArray.CreateRange<ITestInfo>(testInfos.Select(t => new ConditionalTest(t, string.Join(" && ", conditions))));

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -956,7 +956,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         {
             conditions.Add($"!{ConditionClass}.IsGCStressC");
         }
-        
+
         options.GlobalOptions.TryGetValue("build_property.TargetOS", out string? targetOS);
         Xunit.TestPlatforms targetPlatform = GetPlatformForTargetOS(targetOS);
 

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -956,8 +956,11 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         {
             conditions.Add($"!{ConditionClass}.IsGCStressC");
         }
+        
+        options.GlobalOptions.TryGetValue("build_property.TargetOS", out string? targetOS);
+        Xunit.TestPlatforms targetPlatform = GetPlatformForTargetOS(targetOS);
 
-        return ImmutableArray.CreateRange<ITestInfo>(testInfos.Select(t => new ConditionalTest(t, string.Join(" && ", conditions), ~skippedTestPlatforms)));
+        return ImmutableArray.CreateRange<ITestInfo>(testInfos.Select(t => new ConditionalTest(t, string.Join(" && ", conditions), targetPlatform & ~skippedTestPlatforms)));
     }
 
     private static ImmutableArray<ITestInfo> FilterForSkippedTargetFrameworkMonikers(ImmutableArray<ITestInfo> testInfos, int v)
@@ -1075,28 +1078,28 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
             // The target platform is not mentioned in the attribute, just run it as-is.
             return testInfos;
         }
+    }
 
-        static Xunit.TestPlatforms GetPlatformForTargetOS(string? targetOS)
+    private static Xunit.TestPlatforms GetPlatformForTargetOS(string? targetOS)
+    {
+        return targetOS?.ToLowerInvariant() switch
         {
-            return targetOS?.ToLowerInvariant() switch
-            {
-                "windows" => Xunit.TestPlatforms.Windows,
-                "linux" => Xunit.TestPlatforms.Linux,
-                "osx" => Xunit.TestPlatforms.OSX,
-                "illumos" => Xunit.TestPlatforms.illumos,
-                "solaris" => Xunit.TestPlatforms.Solaris,
-                "android" => Xunit.TestPlatforms.Android,
-                "ios" => Xunit.TestPlatforms.iOS,
-                "tvos" => Xunit.TestPlatforms.tvOS,
-                "maccatalyst" => Xunit.TestPlatforms.MacCatalyst,
-                "browser" => Xunit.TestPlatforms.Browser,
-                "wasi" => Xunit.TestPlatforms.Wasi,
-                "freebsd" => Xunit.TestPlatforms.FreeBSD,
-                "netbsd" => Xunit.TestPlatforms.NetBSD,
-                null or "" or "anyos" => Xunit.TestPlatforms.Any,
-                _ => 0
-            };
-        }
+            "windows" => Xunit.TestPlatforms.Windows,
+            "linux" => Xunit.TestPlatforms.Linux,
+            "osx" => Xunit.TestPlatforms.OSX,
+            "illumos" => Xunit.TestPlatforms.illumos,
+            "solaris" => Xunit.TestPlatforms.Solaris,
+            "android" => Xunit.TestPlatforms.Android,
+            "ios" => Xunit.TestPlatforms.iOS,
+            "tvos" => Xunit.TestPlatforms.tvOS,
+            "maccatalyst" => Xunit.TestPlatforms.MacCatalyst,
+            "browser" => Xunit.TestPlatforms.Browser,
+            "wasi" => Xunit.TestPlatforms.Wasi,
+            "freebsd" => Xunit.TestPlatforms.FreeBSD,
+            "netbsd" => Xunit.TestPlatforms.NetBSD,
+            null or "" or "anyos" => Xunit.TestPlatforms.Any,
+            _ => 0
+        };
     }
 
     private static ImmutableArray<ITestInfo> DecorateWithUserDefinedCondition(

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -890,7 +890,7 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
         return testInfos;
     }
 
-    private static ImmutableArray<ITestInfo> DecorateWithSkipOnCoreClrConfiguration(ImmutableArray<ITestInfo> testInfos, Xunit.RuntimeTestModes skippedTestModes, Xunit.RuntimeConfiguration skippedConfigurations, Xunit.TestPlatforms skippedTestPlatforms)
+    private static ImmutableArray<ITestInfo> DecorateWithSkipOnCoreClrConfiguration(ImmutableArray<ITestInfo> testInfos, Xunit.RuntimeTestModes skippedTestModes, Xunit.RuntimeConfiguration skippedConfigurations, Xunit.TestPlatforms skippedTestPlatforms, AnalyzerConfigOptionsProvider options)
     {
         const string ConditionClass = "TestLibrary.CoreClrConfigurationDetection";
         List<string> conditions = new();

--- a/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
+++ b/src/tests/Common/XUnitWrapperGenerator/XUnitWrapperGenerator.cs
@@ -961,6 +961,12 @@ public sealed class XUnitWrapperGenerator : IIncrementalGenerator
             conditions.Add($"!{ConditionClass}.IsGCStressC");
         }
 
+        if (conditions.Count == 0)
+        {
+            // If all configurations are skipped, just skip the test as a whole
+            return ImmutableArray<ITestInfo>.Empty;
+        }
+
         return ImmutableArray.CreateRange<ITestInfo>(testInfos.Select(t => new ConditionalTest(t, string.Join(" && ", conditions))));
     }
 


### PR DESCRIPTION
Add check to skip tests if all RuntimeTestModes are skipped

Fixes https://github.com/dotnet/runtime/issues/105964