### PR TITLE
[EventPipe] Add dotnet_ipc_created mapping

### DIFF
--- a/src/native/eventpipe/configure.cmake
+++ b/src/native/eventpipe/configure.cmake
@@ -29,6 +29,11 @@ check_include_file(
 )
 
 check_include_file(
+    sys/syscall.h
+    HAVE_SYS_SYSCALL_H
+)
+
+check_include_file(
     unistd.h
     HAVE_UNISTD_H
 )
@@ -41,6 +46,17 @@ check_include_file(
 check_include_file(
     errno.h
     HAVE_ERRNO_H
+)
+
+check_include_file(
+    sys/mman.h
+    HAVE_SYS_MMAN_H
+)
+
+check_symbol_exists(
+    __NR_memfd_create
+    sys/syscall.h
+    HAVE_MEMFD_CREATE
 )
 
 if (NOT DEFINED EP_GENERATED_HEADER_PATH)

--- a/src/native/eventpipe/ds-ipc.c
+++ b/src/native/eventpipe/ds-ipc.c
@@ -345,6 +345,7 @@ ds_ipc_stream_factory_configure (ds_ipc_error_callback_func callback)
 #if HAVE_SYS_MMAN_H && HAVE_MEMFD_CREATE && HAVE_UNISTD_H
 		// Create a mapping to signal that the diagnostic server IPC is available.
 		// External tools can use this to detect when the runtime is ready to accept diagnostic commands.
+		// The mapping's lifetime is tied to the process, so tools that start after the .NET process can still detect it.
 		if (default_listen_port_ready) {
 			int fd = (int)syscall (__NR_memfd_create, "dotnet_ipc_created", (unsigned int)MFD_CLOEXEC);
 			if (fd >= 0) {

--- a/src/native/eventpipe/ds-ipc.c
+++ b/src/native/eventpipe/ds-ipc.c
@@ -358,7 +358,7 @@ ds_ipc_stream_factory_configure (ds_ipc_error_callback_func callback)
 	if (ds_ipc_stream_factory_any_listen_ports ()) {
 		int fd = (int)syscall (__NR_memfd_create, "dotnet_ipc_created", (unsigned int)MFD_CLOEXEC);
 		if (fd >= 0) {
-			mmap (NULL, 1, PROT_EXEC | PROT_READ, MAP_PRIVATE, fd, 0);
+			mmap (NULL, 1, PROT_NONE, MAP_PRIVATE, fd, 0);
 			close (fd);
 		}
 	}

--- a/src/native/eventpipe/ds-ipc.c
+++ b/src/native/eventpipe/ds-ipc.c
@@ -504,23 +504,23 @@ ds_ipc_stream_factory_resume_current_port (void)
 bool
 ds_ipc_stream_factory_any_listen_ports (void)
 {
-	bool any_listen_ports = false;
 	DN_VECTOR_PTR_FOREACH_BEGIN (DiagnosticsPort *, port, _ds_port_array) {
-		any_listen_ports |= (port->type == DS_PORT_TYPE_LISTEN);
+		if (port->type == DS_PORT_TYPE_LISTEN)
+			return true;
 	} DN_VECTOR_PTR_FOREACH_END;
 
-	return any_listen_ports;
+	return false;
 }
 
 bool
 ds_ipc_stream_factory_any_suspended_ports (void)
 {
-	bool any_suspended_ports = false;
 	DN_VECTOR_PTR_FOREACH_BEGIN (DiagnosticsPort *, port, _ds_port_array) {
-		any_suspended_ports |= !(port->suspend_mode == DS_PORT_SUSPEND_MODE_NOSUSPEND || port->has_resumed_runtime);
+		if (port->suspend_mode == DS_PORT_SUSPEND_MODE_SUSPEND && !port->has_resumed_runtime)
+			return true;
 	} DN_VECTOR_PTR_FOREACH_END;
 
-	return any_suspended_ports;
+	return false;
 }
 
 bool

--- a/src/native/eventpipe/ds-ipc.h
+++ b/src/native/eventpipe/ds-ipc.h
@@ -33,6 +33,9 @@ void
 ds_ipc_stream_factory_resume_current_port (void);
 
 bool
+ds_ipc_stream_factory_any_listen_ports (void);
+
+bool
 ds_ipc_stream_factory_any_suspended_ports (void);
 
 bool

--- a/src/native/eventpipe/ep-shared-config.h.in
+++ b/src/native/eventpipe/ep-shared-config.h.in
@@ -2,6 +2,8 @@
 #define EP_SHARED_CONFIG_H_INCLUDED
 
 #cmakedefine01 HAVE_ERRNO_H
+#cmakedefine01 HAVE_SYS_MMAN_H
+#cmakedefine01 HAVE_MEMFD_CREATE
 #cmakedefine01 HAVE_LINUX_USER_EVENTS_H
 #cmakedefine01 HAVE_SYS_IOCTL_H
 #cmakedefine01 HAVE_SYS_SOCKET_H


### PR DESCRIPTION
External tools interested in connecting to the runtime's diagnostic ports benefit from a low-overhead IO signal that a .NET process is ready to receive IPC commands, instead of trying to IO over all known temp file directories looking for diagnostic ports for each process.

Following the discussion in https://github.com/microsoft/one-collect/issues/226, this PR adds a new mapping, `dotnet_ipc_created`, that is created once a .NET process' singular listen port is successfully created.

## Testing

userevents runtime tests now work on NativeAOT with the record-trace change https://github.com/microsoft/one-collect/pull/229
```
mihw@CPC-mihw-6KMZDM:~/repo/runtime$ ./artifacts/tests/coreclr/linux.x64.Release/tracing/userevents/basic/basic/basic.sh
BEGIN EXECUTION
/home/mihw/repo/runtime/src/tests/Common/scripts/nativeaottest.sh /home/mihw/repo/runtime/artifacts/tests/coreclr/linux.x64.Release/tracing/userevents/basic/basic/ basic.dll ''
traceeAssemblyPath:
Starting record-trace: sudo -n /home/mihw/repo/runtime/artifacts/tests/coreclr/linux.x64.Release/tracing/userevents/common/userevents_common/record-trace --script-file /home/mihw/repo/runtime/artifacts/tests/coreclr/linux.x64.Release/tracing/userevents/basic/basic/native/../basic.script --out /tmp/tmpBoli5K.nettrace --log-mode console --log-filter error,one_collect::helpers::dotnet::os::linux=debug
record-trace started with PID: 1543079
[record-trace] 2026-01-29T22:55:19.967428Z DEBUG one_collect::helpers::dotnet::os::linux: Registered .NET tracepoint: name=OC_DotNet_Microsoft_Windows_DotNETRuntime_1543081_All, callstacks=false, use_names=true
Starting tracee process: /home/mihw/repo/runtime/artifacts/tests/coreclr/linux.x64.Release/tracing/userevents/basic/basic/native/basic tracee
Tracee process started with PID: 1543083
Waiting for tracee process to exit...
[record-trace] 2026-01-29T22:55:20.093460Z DEBUG one_collect::helpers::dotnet::os::linux: Opened diagnostic socket: pid=1543063, nspid=1543063
[record-trace] 2026-01-29T22:55:20.093476Z DEBUG one_collect::helpers::dotnet::os::linux: Opened diagnostic socket: pid=1543063, nspid=1543063
[record-trace] 2026-01-29T22:55:20.094446Z DEBUG one_collect::helpers::dotnet::os::linux: Opened diagnostic socket: pid=1543063, nspid=1543063
[record-trace] Recording started.  Press CTRL+C to stop.
[record-trace] 2026-01-29T22:55:20.097795Z  INFO one_collect::helpers::dotnet::os::linux: Enabled .NET events for process: pid=1543063
[record-trace] 2026-01-29T22:55:20.098955Z DEBUG one_collect::helpers::dotnet::os::linux: Opened diagnostic socket: pid=1543083, nspid=1543083
[record-trace] 2026-01-29T22:55:20.099085Z DEBUG one_collect::helpers::dotnet::os::linux: Opened diagnostic socket: pid=1543083, nspid=1543083
[record-trace] 2026-01-29T22:55:20.100017Z DEBUG one_collect::helpers::dotnet::os::linux: Opened diagnostic socket: pid=1543083, nspid=1543083
[record-trace] 2026-01-29T22:55:20.104842Z  INFO one_collect::helpers::dotnet::os::linux: Enabled .NET events for process: pid=1543083
Stopping record-trace with SIGINT.
Waiting for record-trace to exit...
[record-trace] Recording stopped.
[record-trace] Resolving symbols.
[record-trace] Finished recording trace.
[record-trace] Trace written to /tmp/tmpBoli5K.nettrace
Expected: 100
Actual: 100
END EXECUTION - PASSED
```