### PR TITLE
ignore async thunks when iterating the async continuation chain

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -5288,8 +5288,8 @@ GENERICS_TYPE_TOKEN DacDbiInterfaceImpl::ResolveExactGenericArgsToken(DWORD     
     ThrowHR(CORDBG_E_TARGET_INCONSISTENT);
 }
 
-// Check if the given method is an IL stub or an LCD method.
-IDacDbiInterface::DynamicMethodType DacDbiInterfaceImpl::IsILStubOrLCGMethod(VMPTR_MethodDesc vmMethodDesc)
+// Check if the given method is a DiagnosticHidden or an LCG method.
+IDacDbiInterface::DynamicMethodType DacDbiInterfaceImpl::IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5297,7 +5297,7 @@ IDacDbiInterface::DynamicMethodType DacDbiInterfaceImpl::IsILStubOrLCGMethod(VMP
 
     if (pMD->IsDiagnosticsHidden())
     {
-        return kILStub;
+        return kDiagnosticHidden;
     }
     else if (pMD->IsLCGMethod())
     {
@@ -7261,7 +7261,7 @@ HRESULT DacDbiInterfaceImpl::AreOptimizationsDisabled(VMPTR_Module vmModule, mdM
     {
         return E_INVALIDARG;
     }
-#ifdef FEATURE_REJIT    
+#ifdef FEATURE_REJIT
     {
         CodeVersionManager * pCodeVersionManager = pModule->GetCodeVersionManager();
         ILCodeVersion activeILVersion = pCodeVersionManager->GetActiveILCodeVersion(pModule, methodTk);
@@ -7451,12 +7451,12 @@ void DacDbiInterfaceImpl::GetAsyncLocals(
     ULONG32 cAsyncVars = 0;
 
     BOOL success = DebugInfoManager::GetAsyncDebugInfo(
-        request, 
-        DebugInfoStoreNew, 
-        nullptr, 
-        &asyncInfo, 
-        &asyncSuspensionPoints, 
-        &asyncVars, 
+        request,
+        DebugInfoStoreNew,
+        nullptr,
+        &asyncInfo,
+        &asyncSuspensionPoints,
+        &asyncVars,
         &cAsyncVars);
 
     if (!success) return;

--- a/src/coreclr/debug/daccess/dacdbiimpl.h
+++ b/src/coreclr/debug/daccess/dacdbiimpl.h
@@ -915,8 +915,8 @@ public:
                                             DebuggerREGDISPLAY * pOutDRD,
                                             BOOL fActive);
 
-    // Check if the given method is an IL stub or an LCD method.
-    DynamicMethodType IsILStubOrLCGMethod(VMPTR_MethodDesc vmMethodDesc);
+    // Check if the given method is a DiagnosticHidden or an LCG method.
+    DynamicMethodType IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc);
 
     // Return a TargetBuffer for the raw vararg signature.
     TargetBuffer GetVarArgSig(CORDB_ADDRESS   VASigCookieAddr,

--- a/src/coreclr/debug/inc/dacdbiinterface.h
+++ b/src/coreclr/debug/inc/dacdbiinterface.h
@@ -1571,25 +1571,25 @@ public:
     typedef enum
     {
         kNone,
-        kILStub,
+        kDiagnosticHidden,
         kLCGMethod,
     } DynamicMethodType;
 
     //
-    // Check whether the specified method is an IL stub or an LCG method.  This answer determines if we
+    // Check whether the specified method is a DiagnosticHidden or an LCG method.  This answer determines if we
     // need to expose the method in a V2-style stackwalk.
     //
     // Arguments:
     //    vmMethodDesc - the method to be checked
     //
     // Return Value:
-    //    Return kNone if the method is neither an IL stub or an LCG method.
-    //    Return kILStub if the method is an IL stub.
+    //    Return kNone if the method is neither a DiagnosticHidden or an LCG method.
+    //    Return kDiagnosticHidden if the method is a DiagnosticHidden method.
     //    Return kLCGMethod if the method is an LCG method.
     //
 
     virtual
-    DynamicMethodType IsILStubOrLCGMethod(VMPTR_MethodDesc vmMethodDesc) = 0;
+    DynamicMethodType IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc) = 0;
 
     //
     // Return a TargetBuffer for the raw vararg signature.


### PR DESCRIPTION
* Updates `CordbAsyncStackWalk::PopulateFrame` to ignore methods that are marked `IsDiagnosticsHidden()`. The relevant case is for async v2 -> async v1 thunks. These don't have debug info and can be skipped in the iteration. Previously this would throw an exception and fail.
* For clarity renames `IsILStubOrLCGMethod` -> `IsDiagnosticsHiddenOrLCGMethod` to accurately represent behavior. (Behavior is unchanged in PR.
* Misc whitespace fixes