### PR TITLE
[clr-interp] Implement cached virtual/interface dispatch

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5185,6 +5185,8 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
             // Traditional virtual call. In theory we could optimize this to using the vtable
             AddIns(tailcall ? INTOP_CALLVIRT_TAIL : INTOP_CALLVIRT);
             m_pLastNewIns->data[0] = GetDataItemIndex(callInfo.hMethod);
+            // Reserved slot for caching DispatchToken
+            m_pLastNewIns->data[1] = GetNewDataItemIndex(nullptr);
             break;
 
         case CORINFO_VIRTUALCALL_LDVIRTFTN:
@@ -5217,6 +5219,7 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
             {
                 AddIns(tailcall ? INTOP_CALLVIRT_TAIL : INTOP_CALLVIRT);
                 m_pLastNewIns->data[0] = GetDataItemIndex(callInfo.hMethod);
+                m_pLastNewIns->data[1] = GetNewDataItemIndex(nullptr);
             }
             break;
 

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5182,13 +5182,16 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
             break;
         }
         case CORINFO_VIRTUALCALL_VTABLE:
+        {
             // Traditional virtual call. In theory we could optimize this to using the vtable
             AddIns(tailcall ? INTOP_CALLVIRT_TAIL : INTOP_CALLVIRT);
             m_pLastNewIns->data[0] = GetDataItemIndex(callInfo.hMethod);
-            // Reserved slot for caching DispatchToken
+            // Reserved slots for caching DispatchToken and its hash
             m_pLastNewIns->data[1] = GetNewDataItemIndex(nullptr);
+            int32_t secondCache = GetNewDataItemIndex(nullptr);
+            assert(secondCache == (m_pLastNewIns->data[1] + 1));
             break;
-
+        }
         case CORINFO_VIRTUALCALL_LDVIRTFTN:
             if ((callInfo.sig.sigInst.methInstCount != 0) || (m_compHnd->getClassAttribs(m_compHnd->getMethodClass(callInfo.hMethod)) & CORINFO_FLG_SHAREDINST))
             {
@@ -5220,6 +5223,8 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
                 AddIns(tailcall ? INTOP_CALLVIRT_TAIL : INTOP_CALLVIRT);
                 m_pLastNewIns->data[0] = GetDataItemIndex(callInfo.hMethod);
                 m_pLastNewIns->data[1] = GetNewDataItemIndex(nullptr);
+                int32_t secondCache = GetNewDataItemIndex(nullptr);
+                assert(secondCache == (m_pLastNewIns->data[1] + 1));
             }
             break;
 

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5189,7 +5189,9 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
             // Reserved slots for caching DispatchToken and its hash
             m_pLastNewIns->data[1] = GetNewDataItemIndex(nullptr);
             int32_t secondCache = GetNewDataItemIndex(nullptr);
+#ifdef DEBUG
             assert(secondCache == (m_pLastNewIns->data[1] + 1));
+#endif
             break;
         }
         case CORINFO_VIRTUALCALL_LDVIRTFTN:
@@ -5224,7 +5226,9 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
                 m_pLastNewIns->data[0] = GetDataItemIndex(callInfo.hMethod);
                 m_pLastNewIns->data[1] = GetNewDataItemIndex(nullptr);
                 int32_t secondCache = GetNewDataItemIndex(nullptr);
+#ifdef DEBUG
                 assert(secondCache == (m_pLastNewIns->data[1] + 1));
+#endif
             }
             break;
 

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -105,6 +105,13 @@ public:
         _dataItems = dataItems;
     }
 
+    // Allocates a slot in the data items that is not shared with other opcodes
+    // Typically used for caching data at runtime.
+    int32_t GetNewDataItemIndex(void* data)
+    {
+        return _dataItems->Add(data);
+    }
+
     int32_t GetDataItemIndex(const InterpGenericLookup& lookup)
     {
         const size_t sizeOfFieldsConcatenated = sizeof(InterpGenericLookup::offsets) +
@@ -686,6 +693,10 @@ private:
     int32_t GetDataItemIndex(const InterpGenericLookup& data)
     {
         return m_genericLookupToDataItemIndex.GetDataItemIndex(data);
+    }
+    int32_t GetNewDataItemIndex(void* data)
+    {
+        return m_genericLookupToDataItemIndex.GetNewDataItemIndex(data);
     }
 
     void* GetDataItemAtIndex(int32_t index);

--- a/src/coreclr/interpreter/inc/intops.def
+++ b/src/coreclr/interpreter/inc/intops.def
@@ -379,7 +379,7 @@ OPDEF(INTOP_CALL_NULLCHECK, "call.nullcheck", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLDELEGATE, "call.delegate", 5, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLDELEGATE_TAIL, "call.delegate.tail", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLI, "calli", 6, 1, 2, InterpOpLdPtr)
-OPDEF(INTOP_CALLVIRT, "callvirt", 4, 1, 1, InterpOpMethodHandle)
+OPDEF(INTOP_CALLVIRT, "callvirt", 5, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALL_PINVOKE, "call.pinvoke", 6, 1, 1, InterpOpMethodHandle) // inlined (no marshaling wrapper) pinvokes only
 OPDEF(INTOP_NEWOBJ, "newobj", 5, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_NEWOBJ_GENERIC, "newobj.generic", 6, 1, 2, InterpOpMethodHandle)
@@ -388,7 +388,7 @@ OPDEF(INTOP_NEWOBJ_VT, "newobj.vt", 5, 1, 1, InterpOpMethodHandle)
 // Tail calls
 OPDEF(INTOP_CALL_TAIL, "call.tail", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLI_TAIL, "calli.tail", 6, 1, 2, InterpOpLdPtr)
-OPDEF(INTOP_CALLVIRT_TAIL, "callvirt.tail", 4, 1, 1, InterpOpMethodHandle)
+OPDEF(INTOP_CALLVIRT_TAIL, "callvirt.tail", 5, 1, 1, InterpOpMethodHandle)
 
 // The following helper call instructions exist in 2 variants, one for normal methods, and one for cases where a shared generic lookup is needed.
 // In the case where a shared generic lookup is needed an extra argument is passed as an svar, which is a pointer to the generic context.

--- a/src/coreclr/vm/contractimpl.h
+++ b/src/coreclr/vm/contractimpl.h
@@ -403,6 +403,10 @@ public:
         LIMITED_METHOD_CONTRACT;
         return !(m_token == INVALID_TOKEN);
     }
+
+    //------------------------------------------------------------------------
+    // Returns a hash of the token suitable for use in dispatch caches.
+    UINT16 GetHash() const;
 };  // struct DispatchToken
 
 // DispatchToken.m_token should be the only field of DispatchToken.

--- a/src/coreclr/vm/interpexec.h
+++ b/src/coreclr/vm/interpexec.h
@@ -125,4 +125,7 @@ struct UnmanagedMethodWithTransitionParam
     PCODE callTarget;
 };
 
+void InterpDispatchCache_ReclaimAll();
+void InterpDispatchCache_ClearForLoaderAllocator(LoaderAllocator* pLoaderAllocator);
+
 #endif // _INTERPEXEC_H_

--- a/src/coreclr/vm/loaderallocator.cpp
+++ b/src/coreclr/vm/loaderallocator.cpp
@@ -13,6 +13,10 @@
 #endif
 #include "comcallablewrapper.h"
 
+#ifdef FEATURE_INTERPRETER
+#include "interpexec.h"
+#endif
+
 //#define ENABLE_LOG_LOADER_ALLOCATOR_CLEANUP 1
 
 #define STUBMANAGER_RANGELIST(stubManager) (stubManager::g_pManager->GetRangeList())
@@ -638,6 +642,10 @@ void LoaderAllocator::GCLoaderAllocators(LoaderAllocator* pOriginalLoaderAllocat
 
         ExecutionManager::Unload(pDomainLoaderAllocatorDestroyIterator);
         pDomainLoaderAllocatorDestroyIterator->UninitVirtualCallStubManager();
+
+#ifdef FEATURE_INTERPRETER
+        InterpDispatchCache_ClearForLoaderAllocator(pDomainLoaderAllocatorDestroyIterator);
+#endif
 
         // TODO: Do we really want to perform this on each LoaderAllocator?
         MethodTable::ClearMethodDataCache();

--- a/src/coreclr/vm/syncclean.cpp
+++ b/src/coreclr/vm/syncclean.cpp
@@ -9,7 +9,7 @@
 #include "threadsuspend.h"
 
 #ifdef FEATURE_INTERPRETER
-void InterpDispatchCache_ReclaimAll();
+#include "interpexec.h"
 #endif
 
 VolatilePtr<Bucket> SyncClean::m_HashMap = NULL;

--- a/src/coreclr/vm/syncclean.cpp
+++ b/src/coreclr/vm/syncclean.cpp
@@ -8,6 +8,10 @@
 #include "virtualcallstub.h"
 #include "threadsuspend.h"
 
+#ifdef FEATURE_INTERPRETER
+void InterpDispatchCache_ReclaimAll();
+#endif
+
 VolatilePtr<Bucket> SyncClean::m_HashMap = NULL;
 VolatilePtr<EEHashEntry*> SyncClean::m_EEHashTable;
 
@@ -95,4 +99,9 @@ void SyncClean::CleanUp ()
 
     // Give others we want to reclaim during the GC sync point a chance to do it
     VirtualCallStubManager::ReclaimAll();
+
+#ifdef FEATURE_INTERPRETER
+    // Reclaim dead interpreter dispatch cache entries
+    InterpDispatchCache_ReclaimAll();
+#endif
 }

--- a/src/coreclr/vm/virtualcallstub.cpp
+++ b/src/coreclr/vm/virtualcallstub.cpp
@@ -3935,13 +3935,13 @@ static const UINT16 tokenHashBits[32] =
 #endif // HOST_64BIT
 };
 
-#ifdef FEATURE_VIRTUAL_STUB_DISPATCH
-/*static*/ UINT16 DispatchCache::HashToken(size_t token)
+UINT16 DispatchToken::GetHash() const
 {
     LIMITED_METHOD_CONTRACT;
 
     UINT16 hash  = 0;
     int    index = 0;
+    size_t token = m_token;
 
     // Note if you change the number of bits in CALL_STUB_CACHE_NUM_BITS
     // then we have to recompute the hash function
@@ -3958,6 +3958,13 @@ static const UINT16 tokenHashBits[32] =
     }
     _ASSERTE((hash & ~CALL_STUB_CACHE_MASK) == 0);
     return hash;
+}
+
+#ifdef FEATURE_VIRTUAL_STUB_DISPATCH
+/*static*/ UINT16 DispatchCache::HashToken(size_t token)
+{
+    WRAPPER_NO_CONTRACT;
+    return DispatchToken::From_SIZE_T(token).GetHash();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
We create a simple hashtable (InterpDispatchCache) that maps DispatchToken + target MT to target method to be called. The cache is similar to the `DispatchCache` used by VSD. It holds a single mapping per index, when a collision happens the entry will be replaced with the new one. Replaced entries are freed during GC. The expectation is that there will be few collisions given only a subset of methods are being interpreted.

This makes a microbenchmark from the suite 4x faster.