### PR TITLE
Add private `RuntimeMethodHandle.GetParallelMethodWithUserIL`

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeHandles.cs
@@ -1334,6 +1334,9 @@ namespace System
             return result;
         }
 
+        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "RuntimeMethodHandle_GetParallelMethodWithUserIL")]
+        private static partial RuntimeMethodHandleInternal GetParallelMethodWithUserIL(RuntimeMethodHandleInternal method);
+
         [MethodImpl(MethodImplOptions.InternalCall)]
         internal static extern bool IsConstructor(RuntimeMethodHandleInternal method);
 

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -176,6 +176,7 @@ static const Entry s_QCall[] =
     DllImportEntry(RuntimeMethodHandle_Destroy)
     DllImportEntry(RuntimeMethodHandle_GetStubIfNeededSlow)
     DllImportEntry(RuntimeMethodHandle_GetMethodBody)
+    DllImportEntry(RuntimeMethodHandle_GetParallelMethodWithUserIL)
     DllImportEntry(RuntimeModule_GetScopeName)
     DllImportEntry(RuntimeModule_GetFullyQualifiedName)
     DllImportEntry(RuntimeModule_GetTypes)

--- a/src/coreclr/vm/runtimehandles.cpp
+++ b/src/coreclr/vm/runtimehandles.cpp
@@ -2137,6 +2137,32 @@ extern "C" void QCALLTYPE RuntimeMethodHandle_GetMethodBody(MethodDesc* pMethod,
     END_QCALL;
 }
 
+extern "C" MethodDesc* QCALLTYPE RuntimeMethodHandle_GetParallelMethodWithUserIL(MethodDesc* pMethod)
+{
+    QCALL_CONTRACT;
+
+    _ASSERTE(pMethod != NULL);
+
+    MethodDesc* pResult = NULL;
+
+    BEGIN_QCALL;
+
+    GCX_COOP();
+
+    if (pMethod->IsAsyncThunkMethod())
+    {
+        pResult = pMethod->GetAsyncVariant();
+    }
+    else
+    {
+        pResult = pMethod;
+    }
+
+    END_QCALL;
+
+    return pResult;
+}
+
 FCIMPL1(FC_BOOL_RET, RuntimeMethodHandle::IsConstructor, MethodDesc *pMethod)
 {
     CONTRACTL {

--- a/src/coreclr/vm/runtimehandles.h
+++ b/src/coreclr/vm/runtimehandles.h
@@ -246,6 +246,7 @@ extern "C" void QCALLTYPE RuntimeMethodHandle_StripMethodInstantiation(MethodDes
 extern "C" void QCALLTYPE RuntimeMethodHandle_Destroy(MethodDesc * pMethod);
 extern "C" MethodDesc* QCALLTYPE RuntimeMethodHandle_GetStubIfNeededSlow(MethodDesc* pMethod, QCall::TypeHandle declaringTypeHandle, QCall::ObjectHandleOnStack methodInstantiation);
 extern "C" void QCALLTYPE RuntimeMethodHandle_GetMethodBody(MethodDesc* pMethod, QCall::TypeHandle pDeclaringType, QCall::ObjectHandleOnStack result);
+extern "C" MethodDesc* QCALLTYPE RuntimeMethodHandle_GetParallelMethodWithUserIL(MethodDesc* pMethod);
 
 class RuntimeFieldHandle
 {


### PR DESCRIPTION
The JIT team has tooling that wants to be able to invoke the JIT on methods obtained through reflection (PMI and Disasmo). But since reflection always returns the Task-returning version of runtime async methods we can never JIT the actual runtime async versions. Add a function that allows obtaining the non-thunk version of async methods to make sure we JIT the actual method we are interested in.

The function is private, but we expect to call it through reflection in those tools.

@jkotas what are your thoughts on this? Alternatively `PrepareMethod` could prepare both the thunk and the runtime async method, similar to how unboxing and instantiating stubs are handled.

cc @EgorBo