### PR TITLE
[release/10.0] Fix internal validation pipeline

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -172,27 +172,7 @@ jobs:
     - ${{ if and(eq(parameters.isOfficialBuild, true), notin(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator')) }}:
       - template: /eng/pipelines/common/restore-internal-tools.yml
 
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - ${{ if and(ne(parameters.osGroup, 'windows'), ne(parameters.hostedOs, 'windows')) }}:
-        - task: Bash@3
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-            arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
-      - ${{ else }}:
-        - task: PowerShell@2
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
-        # Run the NuGetAuthenticate task after the internal feeds are added to the nuget.config
-        # This ensures that creds are set appropriately for all feeds in the config, and that the
-        # credential provider is installed.
-        - task: NuGetAuthenticate@1
+    - template: /eng/common/${{ parameters.templatePath }}/steps/enable-internal-sources.yml
 
     - ${{ if in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator') }}:
       - script: $(Build.SourcesDirectory)/eng/common/native/install-dependencies.sh ${{ parameters.osGroup }}

--- a/eng/pipelines/common/templates/runtimes/xplat-job.yml
+++ b/eng/pipelines/common/templates/runtimes/xplat-job.yml
@@ -109,4 +109,6 @@ jobs:
       fetchDepth: $(checkoutFetchDepth)
       fetchTags: false
 
+    - template: /eng/common/${{ parameters.templatePath }}/steps/enable-internal-sources.yml
+
     - ${{ parameters.steps }}

--- a/eng/pipelines/coreclr/templates/helix-queues-setup.yml
+++ b/eng/pipelines/coreclr/templates/helix-queues-setup.yml
@@ -34,31 +34,52 @@ jobs:
 
     # iOS Simulator/Mac Catalyst arm64
     - ${{ if in(parameters.platform, 'maccatalyst_arm64', 'iossimulator_arm64') }}:
-      - OSX.26.Arm64.Open
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - OSX.15.Arm64.Open
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - OSX.15.Arm64
 
     # iOS/tvOS Simulator x64 & MacCatalyst x64
     - ${{ if in(parameters.platform, 'iossimulator_x64', 'tvossimulator_x64', 'maccatalyst_x64') }}:
-      - OSX.15.Amd64.Open
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - OSX.15.Amd64.Open
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - OSX.15.Amd64
 
     # Android arm64
     - ${{ if in(parameters.platform, 'android_arm64') }}:
-      - Windows.11.Amd64.Android.Open
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - Windows.11.Amd64.Android.Open
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - Windows.11.Amd64.Android
 
     # Android x64
     - ${{ if in(parameters.platform, 'android_x64') }}:
-      - Ubuntu.2204.Amd64.Android.29.Open
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - Ubuntu.2204.Amd64.Android.29.Open
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - Ubuntu.2204.Amd64.Android.29
 
     # Browser wasm
     - ${{ if eq(parameters.platform, 'browser_wasm') }}:
-      - (Ubuntu.2404.Amd64)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04-helix-webassembly-amd64
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - (Ubuntu.2404.Amd64)AzureLinux.3.Amd64.Open@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04-helix-webassembly-amd64
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - (Ubuntu.2404.Amd64)AzureLinux.3.Amd64@mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-24.04-helix-webassembly-amd64
 
     # iOS devices
     - ${{ if in(parameters.platform, 'ios_arm64') }}:
-      - OSX.15.Amd64.Iphone.Open
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        - OSX.15.Amd64.Iphone.Open
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - osx.15.amd64.iphone
 
     # tvOS devices
     - ${{ if in(parameters.platform, 'tvos_arm64') }}:
-        - OSX.15.Amd64.AppleTV.Open
+      - ${{ if eq(variables['System.TeamProject'], 'public') }}:
+          - OSX.15.Amd64.AppleTV.Open
+      - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        - osx.15.amd64.appletv
 
     # Linux arm
     - ${{ if eq(parameters.platform, 'linux_arm') }}:

--- a/eng/pipelines/diagnostics/runtime-diag-job.yml
+++ b/eng/pipelines/diagnostics/runtime-diag-job.yml
@@ -142,27 +142,7 @@ jobs:
     - ${{ if and(eq(parameters.isOfficialBuild, true), notin(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator')) }}:
       - template: /eng/pipelines/common/restore-internal-tools.yml
 
-    - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-      - ${{ if and(ne(parameters.osGroup, 'windows'), ne(parameters.hostedOs, 'windows')) }}:
-        - task: Bash@3
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-            arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
-      - ${{ else }}:
-        - task: PowerShell@2
-          displayName: Setup Private Feeds Credentials
-          inputs:
-            filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-            arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-          env:
-            Token: $(dn-bot-dnceng-artifact-feeds-rw)
-        # Run the NuGetAuthenticate task after the internal feeds are added to the nuget.config
-        # This ensures that creds are set appropriately for all feeds in the config, and that the
-        # credential provider is installed.
-        - task: NuGetAuthenticate@1
+    - template: /eng/common/${{ parameters.templatePath }}/steps/enable-internal-sources.yml
 
     - ${{ if in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator') }}:
       - script: $(Build.SourcesDirectory)/eng/common/native/install-dependencies.sh ${{ parameters.osGroup }}

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -85,9 +85,11 @@ jobs:
       - OSX.15.Amd64.Open
 
     # Android
-    - ${{ if in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64') }}:
+    # Always use the Ubuntu-based Android queue for internal validation as there is no internal equivalent of
+    # the Windows.11.Amd64.Android.Open queue.
+    - ${{ if or(eq(variables['System.TeamProject'], 'internal'), in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64')) }}:
       - Ubuntu.2204.Amd64.Android.29.Open
-    - ${{ if in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64') }}:
+    - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64')) }}:
       - Windows.11.Amd64.Android.Open
 
     # iOS Simulator/Mac Catalyst arm64

--- a/eng/pipelines/libraries/run-test-job.yml
+++ b/eng/pipelines/libraries/run-test-job.yml
@@ -26,9 +26,10 @@ parameters:
   helixArtifactsName: ''
   unifiedBuildNameSuffix: ''
   unifiedBuildConfigOverride: ''
+  templatePath: 'templates'
 
 jobs:
-  - template: /eng/common/templates/job/job.yml
+  - template: /eng/common/${{ parameters.templatePath }}/job/job.yml
     parameters:
       enablePublishBuildArtifacts: true
       timeoutInMinutes: ${{ parameters.timeoutInMinutes }}
@@ -88,27 +89,7 @@ jobs:
         fetchDepth: $(checkoutFetchDepth)
         fetchTags: false
 
-      - ${{ if ne(variables['System.TeamProject'], 'public') }}:
-        - ${{ if ne(parameters.osGroup, 'windows') }}:
-          - task: Bash@3
-            displayName: Setup Private Feeds Credentials
-            inputs:
-              filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.sh
-              arguments: $(Build.SourcesDirectory)/NuGet.config $Token
-            env:
-              Token: $(dn-bot-dnceng-artifact-feeds-rw)
-        - ${{ if eq(parameters.osGroup, 'windows') }}:
-          - task: PowerShell@2
-            displayName: Setup Private Feeds Credentials
-            inputs:
-              filePath: $(Build.SourcesDirectory)/eng/common/SetupNugetSources.ps1
-              arguments: -ConfigFile $(Build.SourcesDirectory)/NuGet.config -Password $Env:Token
-            env:
-              Token: $(dn-bot-dnceng-artifact-feeds-rw)
-        # Run the NuGetAuthenticate task after the internal feeds are added to the nuget.config
-        # This ensures that creds are set appropriately for all feeds in the config, and that the
-        # credential provider is installed.
-        - task: NuGetAuthenticate@1
+      - template: /eng/common/${{ parameters.templatePath }}/steps/enable-internal-sources.yml
 
       - ${{ if in(parameters.osGroup, 'osx', 'maccatalyst', 'ios', 'iossimulator', 'tvos', 'tvossimulator') }}:
         - script: $(Build.SourcesDirectory)/eng/common/native/install-dependencies.sh ${{ parameters.osGroup }}


### PR DESCRIPTION
Fixes #123444

main PR https://github.com/dotnet/runtime/pull/123452

# Description

Fix internal validation pipeline so we can validate backflow from the VMR for internal/release/10.x.

# Customer Impact

None, infra only change

# Regression

None, infra only change

# Testing

<!-- What kind of testing has been done with the fix. -->

# Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

# Package authoring no longer needed in .NET 9

IMPORTANT: Starting with .NET 9, you no longer need to edit a NuGet package's csproj to enable building and bump the version.
Keep in mind that we still need package authoring in .NET 8 and older versions.