### PR TITLE
Avoid unnecessary array allocations in ZipArchive

### DIFF
--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateManaged/InflaterManaged.cs
@@ -615,10 +615,8 @@ namespace System.IO.Compression
                                     throw new InvalidDataException();
                                 }
 
-                                for (int j = 0; j < repeatCount; j++)
-                                {
-                                    _codeList[_loopCounter++] = previousCode;
-                                }
+                                _codeList.AsSpan(_loopCounter, repeatCount).Fill(previousCode);
+                                _loopCounter += repeatCount;
                             }
                             else if (_lengthCode == 17)
                             {
@@ -635,10 +633,8 @@ namespace System.IO.Compression
                                     throw new InvalidDataException();
                                 }
 
-                                for (int j = 0; j < repeatCount; j++)
-                                {
-                                    _codeList[_loopCounter++] = 0;
-                                }
+                                _codeList.AsSpan(_loopCounter, repeatCount).Clear();
+                                _loopCounter += repeatCount;
                             }
                             else
                             {
@@ -656,10 +652,8 @@ namespace System.IO.Compression
                                     throw new InvalidDataException();
                                 }
 
-                                for (int j = 0; j < repeatCount; j++)
-                                {
-                                    _codeList[_loopCounter++] = 0;
-                                }
+                                _codeList.AsSpan(_loopCounter, repeatCount).Clear();
+                                _loopCounter += repeatCount;
                             }
                         }
                         _state = InflaterState.ReadingTreeCodesBefore; // we want to read the next code.

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.Async.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
@@ -199,9 +200,12 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
     {
         cancellationToken.ThrowIfCancellationRequested();
 
+        byte[] arrayPoolArray = ArrayPool<byte>.Shared.Rent(ReadCentralDirectoryReadBufferSize);
         try
         {
-            ReadCentralDirectoryInitialize(out byte[] fileBuffer, out long numberOfEntries, out bool saveExtraFieldsAndComments, out bool continueReadingCentralDirectory, out int bytesRead, out int currPosition, out int bytesConsumed);
+            Memory<byte> fileBuffer = arrayPoolArray;
+
+            ReadCentralDirectoryInitialize(out long numberOfEntries, out bool saveExtraFieldsAndComments, out bool continueReadingCentralDirectory, out int bytesRead, out int currPosition, out int bytesConsumed);
 
             // read the central directory
             while (continueReadingCentralDirectory)
@@ -209,13 +213,13 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
                 // the buffer read must always be large enough to fit the constant section size of at least one header
                 int currBytesRead = await _archiveStream.ReadAtLeastAsync(fileBuffer, ZipCentralDirectoryFileHeader.BlockConstantSectionSize, throwOnEndOfStream: false, cancellationToken).ConfigureAwait(false);
 
-                byte[] sizedFileBuffer = fileBuffer[0..currBytesRead];
+                ReadOnlyMemory<byte> sizedFileBuffer = fileBuffer[0..currBytesRead];
                 continueReadingCentralDirectory = currBytesRead >= ZipCentralDirectoryFileHeader.BlockConstantSectionSize;
 
                 while (currPosition + ZipCentralDirectoryFileHeader.BlockConstantSectionSize <= currBytesRead)
                 {
                     (bool result, bytesConsumed, ZipCentralDirectoryFileHeader? currentHeader) =
-                        await ZipCentralDirectoryFileHeader.TryReadBlockAsync(sizedFileBuffer.AsMemory(currPosition), _archiveStream, saveExtraFieldsAndComments, cancellationToken).ConfigureAwait(false);
+                        await ZipCentralDirectoryFileHeader.TryReadBlockAsync(sizedFileBuffer.Slice(currPosition), _archiveStream, saveExtraFieldsAndComments, cancellationToken).ConfigureAwait(false);
 
                     if (!ReadCentralDirectoryEndOfInnerLoopWork(result, currentHeader, bytesConsumed, ref continueReadingCentralDirectory, ref numberOfEntries, ref currPosition, ref bytesRead))
                     {
@@ -223,7 +227,7 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
                     }
                 }
 
-                ReadCentralDirectoryEndOfOuterLoopWork(ref currPosition, sizedFileBuffer);
+                ReadCentralDirectoryEndOfOuterLoopWork(ref currPosition, sizedFileBuffer.Span);
             }
 
             ReadCentralDirectoryPostOuterLoopWork(numberOfEntries);
@@ -231,6 +235,10 @@ public partial class ZipArchive : IDisposable, IAsyncDisposable
         catch (EndOfStreamException ex)
         {
             throw new InvalidDataException(SR.Format(SR.CentralDirectoryInvalid, ex));
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(arrayPoolArray);
         }
     }
 

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/ZipArchive.cs
@@ -4,6 +4,7 @@
 
 // Zip Spec here: http://www.pkware.com/documents/casestudies/APPNOTE.TXT
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -15,6 +16,8 @@ namespace System.IO.Compression
 {
     public partial class ZipArchive : IDisposable, IAsyncDisposable
     {
+        private const int ReadCentralDirectoryReadBufferSize = 4096;
+
         private readonly Stream _archiveStream;
         private ZipArchiveEntry? _archiveStreamOwner;
         private readonly ZipArchiveMode _mode;
@@ -475,12 +478,8 @@ namespace System.IO.Compression
             }
         }
 
-        private void ReadCentralDirectoryInitialize(out byte[] fileBuffer, out long numberOfEntries, out bool saveExtraFieldsAndComments, out bool continueReadingCentralDirectory, out int bytesRead, out int currPosition, out int bytesConsumed)
+        private void ReadCentralDirectoryInitialize(out long numberOfEntries, out bool saveExtraFieldsAndComments, out bool continueReadingCentralDirectory, out int bytesRead, out int currPosition, out int bytesConsumed)
         {
-            const int ReadCentralDirectoryReadBufferSize = 4096;
-
-            fileBuffer = new byte[ReadCentralDirectoryReadBufferSize];
-
             // assume ReadEndOfCentralDirectory has been called and has populated _centralDirectoryStart
 
             _archiveStream.Seek(_centralDirectoryStart, SeekOrigin.Begin);
@@ -550,19 +549,20 @@ namespace System.IO.Compression
 
         private void ReadCentralDirectory()
         {
+            byte[] arrayPoolArray = ArrayPool<byte>.Shared.Rent(ReadCentralDirectoryReadBufferSize);
             try
             {
-                ReadCentralDirectoryInitialize(out byte[] fileBuffer, out long numberOfEntries, out bool saveExtraFieldsAndComments, out bool continueReadingCentralDirectory, out int bytesRead, out int currPosition, out int bytesConsumed);
+                Span<byte> fileBuffer = arrayPoolArray.AsSpan();
 
-                Span<byte> fileBufferSpan = fileBuffer.AsSpan();
+                ReadCentralDirectoryInitialize(out long numberOfEntries, out bool saveExtraFieldsAndComments, out bool continueReadingCentralDirectory, out int bytesRead, out int currPosition, out int bytesConsumed);
 
                 // read the central directory
                 while (continueReadingCentralDirectory)
                 {
                     // the buffer read must always be large enough to fit the constant section size of at least one header
-                    int currBytesRead = _archiveStream.ReadAtLeast(fileBufferSpan, ZipCentralDirectoryFileHeader.BlockConstantSectionSize, throwOnEndOfStream: false);
+                    int currBytesRead = _archiveStream.ReadAtLeast(fileBuffer, ZipCentralDirectoryFileHeader.BlockConstantSectionSize, throwOnEndOfStream: false);
 
-                    ReadOnlySpan<byte> sizedFileBuffer = fileBufferSpan.Slice(0, currBytesRead);
+                    ReadOnlySpan<byte> sizedFileBuffer = fileBuffer.Slice(0, currBytesRead);
                     continueReadingCentralDirectory = currBytesRead >= ZipCentralDirectoryFileHeader.BlockConstantSectionSize;
 
                     while (currPosition + ZipCentralDirectoryFileHeader.BlockConstantSectionSize <= currBytesRead)
@@ -584,6 +584,10 @@ namespace System.IO.Compression
             catch (EndOfStreamException ex)
             {
                 throw new InvalidDataException(SR.Format(SR.CentralDirectoryInvalid, ex));
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(arrayPoolArray);
             }
         }
 


### PR DESCRIPTION
And simplify a few open-coded loops into span operations.