### PR TITLE
Look through async thunks in `RuntimeHelpers.PrepareMethod`

### DIFF
--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -1283,20 +1283,22 @@ static void PrepareMethodHelper(MethodDesc * pMD)
 
     pMD->EnsureActive();
 
-    if (pMD->IsAsyncThunkMethod())
+    if (pMD->IsWrapperStub())
     {
+        if (pMD->ShouldCallPrestub())
+            pMD->DoPrestub(NULL);
+        pMD = pMD->GetWrappedMethodDesc();
+    }
+
+    if (pMD->IsAsyncThunk())
+    {
+        if (pMD->ShouldCallPrestub())
+            pMD->DoPrestub(NULL);
         pMD = pMD->GetAsyncVariant();
     }
 
     if (pMD->ShouldCallPrestub())
         pMD->DoPrestub(NULL);
-
-    if (pMD->IsWrapperStub())
-    {
-        pMD = pMD->GetWrappedMethodDesc();
-        if (pMD->ShouldCallPrestub())
-            pMD->DoPrestub(NULL);
-    }
 }
 
 // This method triggers a given method to be jitted. CoreCLR implementation of this method triggers jiting of the given method only.

--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -1290,7 +1290,7 @@ static void PrepareMethodHelper(MethodDesc * pMD)
         pMD = pMD->GetWrappedMethodDesc();
     }
 
-    if (pMD->IsAsyncThunk())
+    if (pMD->IsAsyncThunkMethod())
     {
         if (pMD->ShouldCallPrestub())
             pMD->DoPrestub(NULL);

--- a/src/coreclr/vm/reflectioninvocation.cpp
+++ b/src/coreclr/vm/reflectioninvocation.cpp
@@ -1283,6 +1283,11 @@ static void PrepareMethodHelper(MethodDesc * pMD)
 
     pMD->EnsureActive();
 
+    if (pMD->IsAsyncThunkMethod())
+    {
+        pMD = pMD->GetAsyncVariant();
+    }
+
     if (pMD->ShouldCallPrestub())
         pMD->DoPrestub(NULL);
 


### PR DESCRIPTION
This function should JIT the method that has the user IL. For runtime async functions reflection exposes the Task-returning variant which is normally a thunk, so treat these transparently.