### PR TITLE
SPMI: Update superpmi-collect queues from osx13 to osx15

### DIFF
--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -464,9 +464,9 @@ def main(main_args):
                 helix_queue = "azurelinux.3.amd64.open"
         elif platform_name == "osx":
             if arch == "arm64": # public osx_arm64
-                helix_queue = "osx.13.arm64.open"
+                helix_queue = "osx.14.arm64.open"
             else: # public osx_x64
-                helix_queue = "OSX.13.Amd64.Open"
+                helix_queue = "OSX.14.Amd64.Open"
     else:
         if platform_name == "windows":
             if arch == "arm64": # internal windows_arm64

--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -464,9 +464,9 @@ def main(main_args):
                 helix_queue = "azurelinux.3.amd64.open"
         elif platform_name == "osx":
             if arch == "arm64": # public osx_arm64
-                helix_queue = "osx.14.arm64.open"
+                helix_queue = "osx.15.arm64.open"
             else: # public osx_x64
-                helix_queue = "OSX.14.Amd64.Open"
+                helix_queue = "OSX.15.Amd64.Open"
     else:
         if platform_name == "windows":
             if arch == "arm64": # internal windows_arm64
@@ -482,9 +482,9 @@ def main(main_args):
                 helix_queue = "azurelinux.3.amd64"
         elif platform_name == "osx":
             if arch == "arm64": # internal osx_arm64
-                helix_queue = "OSX.13.ARM64"
+                helix_queue = "OSX.15.ARM64"
             else: # internal osx_x64
-                helix_queue = "OSX.13.Amd64"
+                helix_queue = "OSX.15.Amd64"
 
     # Copy the superpmi scripts
 

--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -464,7 +464,7 @@ def main(main_args):
                 helix_queue = "azurelinux.3.amd64.open"
         elif platform_name == "osx":
             if arch == "arm64": # public osx_arm64
-                helix_queue = "osx.15.arm64.open"
+                helix_queue = "OSX.15.Arm64.Open"
             else: # public osx_x64
                 helix_queue = "OSX.15.Amd64.Open"
     else:
@@ -482,7 +482,7 @@ def main(main_args):
                 helix_queue = "azurelinux.3.amd64"
         elif platform_name == "osx":
             if arch == "arm64": # internal osx_arm64
-                helix_queue = "OSX.15.ARM64"
+                helix_queue = "OSX.15.Arm64"
             else: # internal osx_x64
                 helix_queue = "OSX.15.Amd64"
 


### PR DESCRIPTION
osx.13.arm64 queue does not have any capacity anymore. Switch to the osx15 queue.