### PR TITLE
Introduce factory methods to create assertions

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1349,7 +1349,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, bool equ
             }
 
             // Try and see if we can make a subrange assertion.
-            if (equals && varTypeIsIntegral(op2))
+            if (optLocalAssertionProp && equals && varTypeIsIntegral(op2))
             {
                 IntegralRange nodeRange = IntegralRange::ForNode(op2, this);
                 IntegralRange typeRange = IntegralRange::ForType(genActualType(op2));

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2211,14 +2211,17 @@ AssertionIndex Compiler::optFindComplementary(AssertionIndex assertIndex)
         return index;
     }
 
-    for (AssertionIndex index = 1; index <= optAssertionCount; ++index)
+    if (!optLocalAssertionProp) // Seems to be not profitable for Local-AP
     {
-        // Make sure assertion kinds are complementary and op1, op2 kinds match.
-        const AssertionDsc& curAssertion = optGetAssertion(index);
-        if (curAssertion.Complementary(inputAssertion, !optLocalAssertionProp))
+        for (AssertionIndex index = 1; index <= optAssertionCount; ++index)
         {
-            optMapComplementary(assertIndex, index);
-            return index;
+            // Make sure assertion kinds are complementary and op1, op2 kinds match.
+            const AssertionDsc& curAssertion = optGetAssertion(index);
+            if (curAssertion.Complementary(inputAssertion, !optLocalAssertionProp))
+            {
+                optMapComplementary(assertIndex, index);
+                return index;
+            }
         }
     }
     return NO_ASSERTION_INDEX;

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1124,12 +1124,10 @@ ssize_t Compiler::optCastConstantSmall(ssize_t iconVal, var_types smallType)
 // optCreateAssertion: Create an (op1 assertionKind op2) assertion.
 //
 // Arguments:
-//    op1 - the first assertion operand
-//    op2 - the second assertion operand
-//    assertionKind - the assertion kind
-//    helperCallArgs - when true this indicates that the assertion operands
-//                     are the arguments of a type cast helper call such as
-//                     CORINFO_HELP_ISINSTANCEOFCLASS
+//    op1    - the first assertion operand
+//    op2    - the second assertion operand
+//    equals - the assertion kind (equals / not equals)
+
 // Return Value:
 //    The new assertion index or NO_ASSERTION_INDEX if a new assertion
 //    was not created.
@@ -1785,9 +1783,9 @@ void Compiler::optCreateComplementaryAssertion(AssertionIndex assertionIndex, Ge
 // optCreateJtrueAssertions: Create assertions about a JTRUE's relop operands.
 //
 // Arguments:
-//    op1 - the first assertion operand
-//    op2 - the second assertion operand
-//    assertionKind - the assertion kind
+//    op1    - the first assertion operand
+//    op2    - the second assertion operand
+//    equals - the assertion kind (equals / not equals)
 //
 // Return Value:
 //    The new assertion index or NO_ASSERTION_INDEX if a new assertion

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -752,34 +752,34 @@ void Compiler::optAssertionInit(bool isLocalProp)
 }
 
 #ifdef DEBUG
-void Compiler::optPrintAssertion(AssertionDsc* curAssertion, AssertionIndex assertionIndex /* = 0 */)
+void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionIndex assertionIndex /* = 0 */)
 {
-    if (curAssertion->op1.kind == O1K_EXACT_TYPE)
+    if (curAssertion.op1.kind == O1K_EXACT_TYPE)
     {
         printf("Type     ");
     }
-    else if (curAssertion->op1.kind == O1K_ARR_BND)
+    else if (curAssertion.op1.kind == O1K_ARR_BND)
     {
         printf("ArrBnds  ");
     }
-    else if (curAssertion->op1.kind == O1K_VN)
+    else if (curAssertion.op1.kind == O1K_VN)
     {
         printf("Vn  ");
     }
-    else if (curAssertion->op1.kind == O1K_SUBTYPE)
+    else if (curAssertion.op1.kind == O1K_SUBTYPE)
     {
         printf("Subtype  ");
     }
-    else if (curAssertion->op2.kind == O2K_LCLVAR_COPY)
+    else if (curAssertion.op2.kind == O2K_LCLVAR_COPY)
     {
         printf("Copy     ");
     }
-    else if ((curAssertion->op2.kind == O2K_CONST_INT) || (curAssertion->op2.kind == O2K_CONST_DOUBLE) ||
-             (curAssertion->op2.kind == O2K_ZEROOBJ))
+    else if ((curAssertion.op2.kind == O2K_CONST_INT) || (curAssertion.op2.kind == O2K_CONST_DOUBLE) ||
+             (curAssertion.op2.kind == O2K_ZEROOBJ))
     {
         printf("Constant ");
     }
-    else if (curAssertion->op2.kind == O2K_SUBRANGE)
+    else if (curAssertion.op2.kind == O2K_SUBRANGE)
     {
         printf("Subrange ");
     }
@@ -791,77 +791,77 @@ void Compiler::optPrintAssertion(AssertionDsc* curAssertion, AssertionIndex asse
 
     if (!optLocalAssertionProp)
     {
-        printf("(" FMT_VN "," FMT_VN ") ", curAssertion->op1.vn, curAssertion->op2.vn);
+        printf("(" FMT_VN "," FMT_VN ") ", curAssertion.op1.vn, curAssertion.op2.vn);
     }
 
-    if (curAssertion->op1.kind == O1K_LCLVAR)
+    if (curAssertion.op1.kind == O1K_LCLVAR)
     {
         if (!optLocalAssertionProp)
         {
             printf("LCLVAR");
-            vnStore->vnDump(this, curAssertion->op1.vn);
+            vnStore->vnDump(this, curAssertion.op1.vn);
         }
         else
         {
-            printf("V%02u", curAssertion->op1.lclNum);
+            printf("V%02u", curAssertion.op1.lclNum);
         }
     }
-    else if (curAssertion->op1.kind == O1K_EXACT_TYPE)
+    else if (curAssertion.op1.kind == O1K_EXACT_TYPE)
     {
         printf("Exact_Type");
-        vnStore->vnDump(this, curAssertion->op1.vn);
+        vnStore->vnDump(this, curAssertion.op1.vn);
     }
-    else if (curAssertion->op1.kind == O1K_SUBTYPE)
+    else if (curAssertion.op1.kind == O1K_SUBTYPE)
     {
         printf("Sub_Type");
-        vnStore->vnDump(this, curAssertion->op1.vn);
+        vnStore->vnDump(this, curAssertion.op1.vn);
     }
-    else if (curAssertion->op1.kind == O1K_ARR_BND)
+    else if (curAssertion.op1.kind == O1K_ARR_BND)
     {
-        printf("[idx: " FMT_VN, curAssertion->op1.bnd.vnIdx);
-        vnStore->vnDump(this, curAssertion->op1.bnd.vnIdx);
-        printf("; len: " FMT_VN, curAssertion->op1.bnd.vnLen);
-        vnStore->vnDump(this, curAssertion->op1.bnd.vnLen);
+        printf("[idx: " FMT_VN, curAssertion.op1.bnd.vnIdx);
+        vnStore->vnDump(this, curAssertion.op1.bnd.vnIdx);
+        printf("; len: " FMT_VN, curAssertion.op1.bnd.vnLen);
+        vnStore->vnDump(this, curAssertion.op1.bnd.vnLen);
         printf("]");
     }
-    else if (curAssertion->op1.kind == O1K_VN)
+    else if (curAssertion.op1.kind == O1K_VN)
     {
-        printf("[vn: " FMT_VN, curAssertion->op1.vn);
-        vnStore->vnDump(this, curAssertion->op1.vn);
+        printf("[vn: " FMT_VN, curAssertion.op1.vn);
+        vnStore->vnDump(this, curAssertion.op1.vn);
         printf("]");
     }
-    else if (curAssertion->op1.kind == O1K_BOUND_OPER_BND)
+    else if (curAssertion.op1.kind == O1K_BOUND_OPER_BND)
     {
         printf("Oper_Bnd");
-        vnStore->vnDump(this, curAssertion->op1.vn);
+        vnStore->vnDump(this, curAssertion.op1.vn);
     }
-    else if (curAssertion->op1.kind == O1K_BOUND_LOOP_BND)
+    else if (curAssertion.op1.kind == O1K_BOUND_LOOP_BND)
     {
         printf("Loop_Bnd");
-        vnStore->vnDump(this, curAssertion->op1.vn);
+        vnStore->vnDump(this, curAssertion.op1.vn);
     }
-    else if (curAssertion->op1.kind == O1K_CONSTANT_LOOP_BND)
+    else if (curAssertion.op1.kind == O1K_CONSTANT_LOOP_BND)
     {
         printf("Const_Loop_Bnd");
-        vnStore->vnDump(this, curAssertion->op1.vn);
+        vnStore->vnDump(this, curAssertion.op1.vn);
     }
-    else if (curAssertion->op1.kind == O1K_CONSTANT_LOOP_BND_UN)
+    else if (curAssertion.op1.kind == O1K_CONSTANT_LOOP_BND_UN)
     {
         printf("Const_Loop_Bnd_Un");
-        vnStore->vnDump(this, curAssertion->op1.vn);
+        vnStore->vnDump(this, curAssertion.op1.vn);
     }
     else
     {
         printf("?op1.kind?");
     }
 
-    if (curAssertion->assertionKind == OAK_SUBRANGE)
+    if (curAssertion.assertionKind == OAK_SUBRANGE)
     {
         printf(" in ");
     }
-    else if (curAssertion->assertionKind == OAK_EQUAL)
+    else if (curAssertion.assertionKind == OAK_EQUAL)
     {
-        if (curAssertion->op1.kind == O1K_LCLVAR)
+        if (curAssertion.op1.kind == O1K_LCLVAR)
         {
             printf(" == ");
         }
@@ -870,13 +870,13 @@ void Compiler::optPrintAssertion(AssertionDsc* curAssertion, AssertionIndex asse
             printf(" is ");
         }
     }
-    else if (curAssertion->assertionKind == OAK_NO_THROW)
+    else if (curAssertion.assertionKind == OAK_NO_THROW)
     {
         printf(" in range ");
     }
-    else if (curAssertion->assertionKind == OAK_NOT_EQUAL)
+    else if (curAssertion.assertionKind == OAK_NOT_EQUAL)
     {
-        if (curAssertion->op1.kind == O1K_LCLVAR)
+        if (curAssertion.op1.kind == O1K_LCLVAR)
         {
             printf(" != ");
         }
@@ -890,18 +890,18 @@ void Compiler::optPrintAssertion(AssertionDsc* curAssertion, AssertionIndex asse
         printf(" ?assertionKind? ");
     }
 
-    if (curAssertion->op1.kind != O1K_ARR_BND)
+    if (curAssertion.op1.kind != O1K_ARR_BND)
     {
-        switch (curAssertion->op2.kind)
+        switch (curAssertion.op2.kind)
         {
             case O2K_LCLVAR_COPY:
-                printf("V%02u", curAssertion->op2.lclNum);
+                printf("V%02u", curAssertion.op2.lclNum);
                 break;
 
             case O2K_CONST_INT:
-                if (curAssertion->op1.kind == O1K_EXACT_TYPE)
+                if (curAssertion.op1.kind == O1K_EXACT_TYPE)
                 {
-                    ssize_t iconVal = curAssertion->op2.u1.iconVal;
+                    ssize_t iconVal = curAssertion.op2.u1.iconVal;
                     if (IsAot())
                     {
                         printf("Exact Type MT(0x%p)", dspPtr(iconVal));
@@ -913,15 +913,15 @@ void Compiler::optPrintAssertion(AssertionDsc* curAssertion, AssertionIndex asse
                     }
 
                     // We might want to assert:
-                    //      assert(curAssertion->op2.HasIconFlag());
+                    //      assert(curAssertion.op2.HasIconFlag());
                     // However, if we run CSE with shared constant mode, we may end up with an expression instead
                     // of the original handle value. If we then use JitOptRepeat to re-build value numbers, we lose
                     // knowledge that the constant was ever a handle, as the expression creating the original value
                     // was not (and can't be) assigned a handle flag.
                 }
-                else if (curAssertion->op1.kind == O1K_SUBTYPE)
+                else if (curAssertion.op1.kind == O1K_SUBTYPE)
                 {
-                    ssize_t iconVal = curAssertion->op2.u1.iconVal;
+                    ssize_t iconVal = curAssertion.op2.u1.iconVal;
                     if (IsAot())
                     {
                         printf("MT(0x%p)", dspPtr(iconVal));
@@ -930,53 +930,53 @@ void Compiler::optPrintAssertion(AssertionDsc* curAssertion, AssertionIndex asse
                     {
                         printf("MT(0x%p %s)", dspPtr(iconVal), eeGetClassName((CORINFO_CLASS_HANDLE)iconVal));
                     }
-                    assert(curAssertion->op2.HasIconFlag());
+                    assert(curAssertion.op2.HasIconFlag());
                 }
-                else if ((curAssertion->op1.kind == O1K_BOUND_OPER_BND) ||
-                         (curAssertion->op1.kind == O1K_BOUND_LOOP_BND) ||
-                         (curAssertion->op1.kind == O1K_CONSTANT_LOOP_BND) ||
-                         (curAssertion->op1.kind == O1K_CONSTANT_LOOP_BND_UN))
+                else if ((curAssertion.op1.kind == O1K_BOUND_OPER_BND) ||
+                         (curAssertion.op1.kind == O1K_BOUND_LOOP_BND) ||
+                         (curAssertion.op1.kind == O1K_CONSTANT_LOOP_BND) ||
+                         (curAssertion.op1.kind == O1K_CONSTANT_LOOP_BND_UN))
                 {
                     assert(!optLocalAssertionProp);
-                    vnStore->vnDump(this, curAssertion->op2.vn);
+                    vnStore->vnDump(this, curAssertion.op2.vn);
                 }
                 else
                 {
-                    var_types op1Type = !optLocalAssertionProp ? vnStore->TypeOfVN(curAssertion->op1.vn)
-                                                               : lvaGetRealType(curAssertion->op1.lclNum);
+                    var_types op1Type = !optLocalAssertionProp ? vnStore->TypeOfVN(curAssertion.op1.vn)
+                                                               : lvaGetRealType(curAssertion.op1.lclNum);
                     if (op1Type == TYP_REF)
                     {
-                        if (curAssertion->op2.u1.iconVal == 0)
+                        if (curAssertion.op2.u1.iconVal == 0)
                         {
                             printf("null");
                         }
                         else
                         {
-                            printf("[%08p]", dspPtr(curAssertion->op2.u1.iconVal));
+                            printf("[%08p]", dspPtr(curAssertion.op2.u1.iconVal));
                         }
                     }
                     else
                     {
-                        if (curAssertion->op2.HasIconFlag())
+                        if (curAssertion.op2.HasIconFlag())
                         {
-                            printf("[%08p]", dspPtr(curAssertion->op2.u1.iconVal));
+                            printf("[%08p]", dspPtr(curAssertion.op2.u1.iconVal));
                         }
                         else
                         {
-                            printf("%d", curAssertion->op2.u1.iconVal);
+                            printf("%d", curAssertion.op2.u1.iconVal);
                         }
                     }
                 }
                 break;
 
             case O2K_CONST_DOUBLE:
-                if (FloatingPointUtils::isNegativeZero(curAssertion->op2.dconVal))
+                if (FloatingPointUtils::isNegativeZero(curAssertion.op2.dconVal))
                 {
                     printf("-0.00000");
                 }
                 else
                 {
-                    printf("%#lg", curAssertion->op2.dconVal);
+                    printf("%#lg", curAssertion.op2.dconVal);
                 }
                 break;
 
@@ -985,7 +985,7 @@ void Compiler::optPrintAssertion(AssertionDsc* curAssertion, AssertionIndex asse
                 break;
 
             case O2K_SUBRANGE:
-                IntegralRange::Print(curAssertion->op2.u2);
+                IntegralRange::Print(curAssertion.op2.u2);
                 break;
 
             default:
@@ -1064,14 +1064,14 @@ void Compiler::optDumpAssertionIndices(ASSERT_TP assertions, const char* footer 
  * is NO_ASSERTION_INDEX and "optAssertionCount" is the last valid index.
  *
  */
-Compiler::AssertionDsc* Compiler::optGetAssertion(AssertionIndex assertIndex)
+Compiler::AssertionDsc* Compiler::optGetAssertion(AssertionIndex assertIndex) const
 {
     assert(NO_ASSERTION_INDEX == 0);
     assert(assertIndex != NO_ASSERTION_INDEX);
     assert(assertIndex <= optAssertionCount);
     AssertionDsc* assertion = &optAssertionTabPrivate[assertIndex - 1];
 #ifdef DEBUG
-    optDebugCheckAssertion(assertion);
+    optDebugCheckAssertion(*assertion);
 #endif
 
     return assertion;
@@ -1172,7 +1172,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, bool equ
             if (optLocalAssertionProp)
             {
                 AssertionDsc assertion = AssertionDsc::CreateLclNonNullAssertion(this, op1->AsLclVar()->GetLclNum());
-                return optAddAssertion(&assertion);
+                return optAddAssertion(assertion);
             }
 
             ValueNum op1VN = optConservativeNormalVN(op1);
@@ -1181,7 +1181,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, bool equ
                 return NO_ASSERTION_INDEX;
             }
             AssertionDsc assertion = AssertionDsc::CreateVNNonNullAssertion(this, op1VN);
-            return optAddAssertion(&assertion);
+            return optAddAssertion(assertion);
         }
     }
     //
@@ -1227,7 +1227,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, bool equ
                     AssertionDsc dsc =
                         AssertionDsc::CreateConstantLclvarAssertion(this, lclNum, op1VN, op2->AsDblCon()->DconValue(),
                                                                     op2VN, equals);
-                    return optAddAssertion(&dsc);
+                    return optAddAssertion(dsc);
                 }
 
                 case GT_CNS_INT:
@@ -1244,7 +1244,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, bool equ
                         AssertionDsc dsc =
                             AssertionDsc::CreateConstantLclvarAssertion(this, lclNum, op1VN, 0, op2VN, equals);
                         dsc.op2.kind = O2K_ZEROOBJ;
-                        return optAddAssertion(&dsc);
+                        return optAddAssertion(dsc);
                     }
 
                     ssize_t iconVal = op2->AsIntCon()->IconValue();
@@ -1269,7 +1269,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, bool equ
                     AssertionDsc dsc =
                         AssertionDsc::CreateConstantLclvarAssertion(this, lclNum, op1VN, iconVal, op2VN, equals);
                     dsc.op2.SetIconFlag(op2->GetIconHandleFlag(), op2->AsIntCon()->gtFieldSeq);
-                    return optAddAssertion(&dsc);
+                    return optAddAssertion(dsc);
                 }
 
                 case GT_LCL_VAR:
@@ -1325,7 +1325,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, bool equ
 
                     // Ok everything has been set and the assertion looks good
                     AssertionDsc assertion = AssertionDsc::CreateLclvarCopy(this, lclNum, lclNum2, equals);
-                    return optAddAssertion(&assertion);
+                    return optAddAssertion(assertion);
                 }
 
                 case GT_CALL:
@@ -1336,7 +1336,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, bool equ
                         if (call->IsHelperCall() && s_helperCallProperties.NonNullReturn(call->GetHelperNum()))
                         {
                             AssertionDsc assertion = AssertionDsc::CreateLclNonNullAssertion(this, lclNum);
-                            return optAddAssertion(&assertion);
+                            return optAddAssertion(assertion);
                         }
                     }
                     break;
@@ -1356,7 +1356,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, bool equ
                 if (!typeRange.Equals(nodeRange))
                 {
                     AssertionDsc assertion = AssertionDsc::CreateSubrange(this, lclNum, nodeRange);
-                    return optAddAssertion(&assertion);
+                    return optAddAssertion(assertion);
                 }
             }
         }
@@ -1375,7 +1375,7 @@ AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, bool equ
                 !vnStore->IsVNHandle(op2VN))
             {
                 AssertionDsc assertion = AssertionDsc::CreateInt32ConstantVNAssertion(this, op1VN, op2VN, equals);
-                return optAddAssertion(&assertion);
+                return optAddAssertion(assertion);
             }
         }
     }
@@ -1437,7 +1437,7 @@ bool Compiler::optIsTreeKnownIntValue(bool vnBased, GenTree* tree, ssize_t* pCon
  * Print the assertions related to a VN for all VNs.
  *
  */
-void Compiler::optPrintVnAssertionMapping()
+void Compiler::optPrintVnAssertionMapping() const
 {
     printf("\nVN Assertion Mapping\n");
     printf("---------------------\n");
@@ -1454,7 +1454,7 @@ void Compiler::optPrintVnAssertionMapping()
  * about that VN. Given "assertions" about a "vn" add it to the previously
  * mapped assertions about that "vn."
  */
-void Compiler::optAddVnAssertionMapping(ValueNum vn, AssertionIndex index)
+void Compiler::optAddVnAssertionMapping(ValueNum vn, AssertionIndex index) const
 {
     ASSERT_TP* cur = optValueNumToAsserts->LookupPointer(vn);
     if (cur == nullptr)
@@ -1471,7 +1471,7 @@ void Compiler::optAddVnAssertionMapping(ValueNum vn, AssertionIndex index)
  * Statically if we know that this assertion's VN involves a NaN don't bother
  * wasting an assertion table slot.
  */
-bool Compiler::optAssertionVnInvolvesNan(AssertionDsc* assertion)
+bool Compiler::optAssertionVnInvolvesNan(const AssertionDsc& assertion) const
 {
     if (optLocalAssertionProp)
     {
@@ -1479,7 +1479,7 @@ bool Compiler::optAssertionVnInvolvesNan(AssertionDsc* assertion)
     }
 
     static const int SZ      = 2;
-    ValueNum         vns[SZ] = {assertion->op1.vn, assertion->op2.vn};
+    ValueNum         vns[SZ] = {assertion.op1.vn, assertion.op2.vn};
     for (int i = 0; i < SZ; ++i)
     {
         if (vnStore->IsVNConstant(vns[i]))
@@ -1505,9 +1505,9 @@ bool Compiler::optAssertionVnInvolvesNan(AssertionDsc* assertion)
  *  we use to refer to this element.
  *  If we need to add to the table and the table is full return the value zero
  */
-AssertionIndex Compiler::optAddAssertion(AssertionDsc* newAssertion)
+AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
 {
-    noway_assert(newAssertion->assertionKind != OAK_INVALID);
+    noway_assert(newAssertion.assertionKind != OAK_INVALID);
 
     // Even though the propagation step takes care of NaN, just a check
     // to make sure there is no slot involving a NaN.
@@ -1520,7 +1520,7 @@ AssertionIndex Compiler::optAddAssertion(AssertionDsc* newAssertion)
     if (!optLocalAssertionProp)
     {
         // Ignore VN-based assertions with NoVN
-        switch (newAssertion->op1.kind)
+        switch (newAssertion.op1.kind)
         {
             case O1K_LCLVAR:
             case O1K_VN:
@@ -1530,14 +1530,14 @@ AssertionIndex Compiler::optAddAssertion(AssertionDsc* newAssertion)
             case O1K_CONSTANT_LOOP_BND_UN:
             case O1K_EXACT_TYPE:
             case O1K_SUBTYPE:
-                if (newAssertion->op1.vn == ValueNumStore::NoVN)
+                if (newAssertion.op1.vn == ValueNumStore::NoVN)
                 {
                     return NO_ASSERTION_INDEX;
                 }
                 break;
             case O1K_ARR_BND:
-                if ((newAssertion->op1.bnd.vnIdx == ValueNumStore::NoVN) ||
-                    (newAssertion->op1.bnd.vnLen == ValueNumStore::NoVN))
+                if ((newAssertion.op1.bnd.vnIdx == ValueNumStore::NoVN) ||
+                    (newAssertion.op1.bnd.vnLen == ValueNumStore::NoVN))
                 {
                     return NO_ASSERTION_INDEX;
                 }
@@ -1556,9 +1556,9 @@ AssertionIndex Compiler::optAddAssertion(AssertionDsc* newAssertion)
     //
     if (optLocalAssertionProp)
     {
-        assert(newAssertion->op1.kind == O1K_LCLVAR);
+        assert(newAssertion.op1.kind == O1K_LCLVAR);
 
-        unsigned        lclNum = newAssertion->op1.lclNum;
+        unsigned        lclNum = newAssertion.op1.lclNum;
         BitVecOps::Iter iter(apTraits, GetAssertionDep(lclNum));
         unsigned        bvIndex = 0;
         while (iter.NextElem(&bvIndex))
@@ -1594,7 +1594,7 @@ AssertionIndex Compiler::optAddAssertion(AssertionDsc* newAssertion)
         return NO_ASSERTION_INDEX;
     }
 
-    optAssertionTabPrivate[optAssertionCount] = *newAssertion;
+    optAssertionTabPrivate[optAssertionCount] = newAssertion;
     optAssertionCount++;
 
 #ifdef DEBUG
@@ -1608,33 +1608,33 @@ AssertionIndex Compiler::optAddAssertion(AssertionDsc* newAssertion)
 #endif // DEBUG
 
     // Track the short-circuit criteria
-    optCanPropLclVar |= newAssertion->CanPropLclVar();
-    optCanPropEqual |= newAssertion->CanPropEqualOrNotEqual();
-    optCanPropNonNull |= newAssertion->CanPropNonNull();
-    optCanPropSubRange |= newAssertion->CanPropSubRange();
-    optCanPropBndsChk |= newAssertion->CanPropBndsCheck();
+    optCanPropLclVar |= newAssertion.CanPropLclVar();
+    optCanPropEqual |= newAssertion.CanPropEqualOrNotEqual();
+    optCanPropNonNull |= newAssertion.CanPropNonNull();
+    optCanPropSubRange |= newAssertion.CanPropSubRange();
+    optCanPropBndsChk |= newAssertion.CanPropBndsCheck();
 
     // Assertion mask bits are [index + 1].
     if (optLocalAssertionProp)
     {
-        assert(newAssertion->op1.kind == O1K_LCLVAR);
+        assert(newAssertion.op1.kind == O1K_LCLVAR);
 
         // Mark the variables this index depends on
-        unsigned lclNum = newAssertion->op1.lclNum;
+        unsigned lclNum = newAssertion.op1.lclNum;
         BitVecOps::AddElemD(apTraits, GetAssertionDep(lclNum), optAssertionCount - 1);
-        if (newAssertion->op2.kind == O2K_LCLVAR_COPY)
+        if (newAssertion.op2.kind == O2K_LCLVAR_COPY)
         {
-            lclNum = newAssertion->op2.lclNum;
+            lclNum = newAssertion.op2.lclNum;
             BitVecOps::AddElemD(apTraits, GetAssertionDep(lclNum), optAssertionCount - 1);
         }
     }
     else
     // If global assertion prop, then add it to the dependents map.
     {
-        optAddVnAssertionMapping(newAssertion->op1.vn, optAssertionCount);
-        if (newAssertion->op2.kind == O2K_LCLVAR_COPY)
+        optAddVnAssertionMapping(newAssertion.op1.vn, optAssertionCount);
+        if (newAssertion.op2.kind == O2K_LCLVAR_COPY)
         {
-            optAddVnAssertionMapping(newAssertion->op2.vn, optAssertionCount);
+            optAddVnAssertionMapping(newAssertion.op2.vn, optAssertionCount);
         }
     }
 
@@ -1645,19 +1645,19 @@ AssertionIndex Compiler::optAddAssertion(AssertionDsc* newAssertion)
 }
 
 #ifdef DEBUG
-void Compiler::optDebugCheckAssertion(AssertionDsc* assertion)
+void Compiler::optDebugCheckAssertion(const AssertionDsc& assertion) const
 {
-    assert(assertion->assertionKind < OAK_COUNT);
-    assert(assertion->op1.kind < O1K_COUNT);
-    assert(assertion->op2.kind < O2K_COUNT);
+    assert(assertion.assertionKind < OAK_COUNT);
+    assert(assertion.op1.kind < O1K_COUNT);
+    assert(assertion.op2.kind < O2K_COUNT);
     // It would be good to check that op1.vn and op2.vn are valid value numbers.
 
-    switch (assertion->op1.kind)
+    switch (assertion.op1.kind)
     {
         case O1K_ARR_BND:
             // It would be good to check that bnd.vnIdx and bnd.vnLen are valid value numbers.
             assert(!optLocalAssertionProp);
-            assert(assertion->assertionKind == OAK_NO_THROW);
+            assert(assertion.assertionKind == OAK_NO_THROW);
             break;
         case O1K_EXACT_TYPE:
         case O1K_SUBTYPE:
@@ -1671,7 +1671,7 @@ void Compiler::optDebugCheckAssertion(AssertionDsc* assertion)
         default:
             break;
     }
-    switch (assertion->op2.kind)
+    switch (assertion.op2.kind)
     {
         case O2K_SUBRANGE:
         case O2K_LCLVAR_COPY:
@@ -1681,14 +1681,14 @@ void Compiler::optDebugCheckAssertion(AssertionDsc* assertion)
         case O2K_ZEROOBJ:
         {
             // We only make these assertion for stores (not control flow).
-            assert(assertion->assertionKind == OAK_EQUAL);
+            assert(assertion.assertionKind == OAK_EQUAL);
             // We use "optLocalAssertionIsEqualOrNotEqual" to find these.
-            assert(assertion->op2.u1.iconVal == 0);
+            assert(assertion.op2.u1.iconVal == 0);
         }
         break;
 
         default:
-            // for all other 'assertion->op2.kind' values we don't check anything
+            // for all other 'assertion.op2.kind' values we don't check anything
             break;
     }
 }
@@ -1707,7 +1707,7 @@ void Compiler::optDebugCheckAssertions(AssertionIndex index)
     for (AssertionIndex ind = start; ind <= end; ++ind)
     {
         AssertionDsc* assertion = optGetAssertion(ind);
-        optDebugCheckAssertion(assertion);
+        optDebugCheckAssertion(*assertion);
     }
 }
 #endif
@@ -1739,7 +1739,7 @@ void Compiler::optCreateComplementaryAssertion(AssertionIndex assertionIndex, Ge
     {
         AssertionDsc dsc = candidateAssertion;
         dsc.ReverseEquality();
-        optAddAssertion(&dsc);
+        optAddAssertion(dsc);
         return;
     }
 
@@ -1834,7 +1834,7 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     if (vnStore->IsVNCompareCheckedBoundArith(relopVN))
     {
         AssertionDsc   dsc   = AssertionDsc::CreateCompareCheckedBoundArith(this, relopVN, /*withArith*/ true);
-        AssertionIndex index = optAddAssertion(&dsc);
+        AssertionIndex index = optAddAssertion(dsc);
         optCreateComplementaryAssertion(index, nullptr, nullptr);
         return index;
     }
@@ -1844,7 +1844,7 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     else if (vnStore->IsVNCompareCheckedBound(relopVN))
     {
         AssertionDsc   dsc   = AssertionDsc::CreateCompareCheckedBoundArith(this, relopVN, /*withArith*/ false);
-        AssertionIndex index = optAddAssertion(&dsc);
+        AssertionIndex index = optAddAssertion(dsc);
         optCreateComplementaryAssertion(index, nullptr, nullptr);
         return index;
     }
@@ -1856,7 +1856,7 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
         ValueNum lenVN = vnStore->VNNormalValue(unsignedCompareBnd.vnBound);
 
         AssertionDsc   dsc   = AssertionDsc::CreateNoThrowArrBnd(this, idxVN, lenVN);
-        AssertionIndex index = optAddAssertion(&dsc);
+        AssertionIndex index = optAddAssertion(dsc);
         if (unsignedCompareBnd.cmpOper == VNF_GE_UN)
         {
             // By default JTRUE generated assertions hold on the "jump" edge. We have i >= bnd but we're really
@@ -1871,14 +1871,14 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     else if (vnStore->IsVNConstantBound(relopVN))
     {
         AssertionDsc   dsc   = AssertionDsc::CreateConstantLoopBound(this, relopVN, /*isUnsigned*/ false);
-        AssertionIndex index = optAddAssertion(&dsc);
+        AssertionIndex index = optAddAssertion(dsc);
         optCreateComplementaryAssertion(index, nullptr, nullptr);
         return index;
     }
     else if (vnStore->IsVNConstantBoundUnsigned(relopVN))
     {
         AssertionDsc   dsc   = AssertionDsc::CreateConstantLoopBound(this, relopVN, /*isUnsigned*/ true);
-        AssertionIndex index = optAddAssertion(&dsc);
+        AssertionIndex index = optAddAssertion(dsc);
         optCreateComplementaryAssertion(index, nullptr, nullptr);
         return index;
     }
@@ -1948,7 +1948,7 @@ AssertionInfo Compiler::optAssertionGenJtrue(GenTree* tree)
         if ((objVN != ValueNumStore::NoVN) && vnStore->IsVNTypeHandle(typeHndVN))
         {
             AssertionDsc   dsc   = AssertionDsc::CreateSubtype(this, objVN, typeHndVN, /*exact*/ true);
-            AssertionIndex index = optAddAssertion(&dsc);
+            AssertionIndex index = optAddAssertion(dsc);
 
             // We don't need to create a complementary assertion here. We're only interested
             // in the assertion that the object is of a certain type. The opposite assertion
@@ -2060,7 +2060,7 @@ AssertionInfo Compiler::optAssertionGenJtrue(GenTree* tree)
         if ((objVN != ValueNumStore::NoVN) && vnStore->IsVNTypeHandle(typeHndVN))
         {
             AssertionDsc   dsc   = AssertionDsc::CreateSubtype(this, objVN, typeHndVN, /*exact*/ false);
-            AssertionIndex index = optAddAssertion(&dsc);
+            AssertionIndex index = optAddAssertion(dsc);
 
             // We don't need to create a complementary assertion here. We're only interested
             // in the assertion that the object is of a certain type. The opposite assertion
@@ -2149,8 +2149,7 @@ void Compiler::optAssertionGen(GenTree* tree)
                 }
                 else
                 {
-                    AssertionDsc assertion = AssertionDsc::CreateNoThrowArrBnd(this, idxVN, lenVN);
-                    assertionInfo          = optAddAssertion(&assertion);
+                    assertionInfo = optAddAssertion(AssertionDsc::CreateNoThrowArrBnd(this, idxVN, lenVN));
                 }
             }
             break;
@@ -2239,7 +2238,7 @@ AssertionIndex Compiler::optFindComplementary(AssertionIndex assertIndex)
     {
         // Make sure assertion kinds are complementary and op1, op2 kinds match.
         AssertionDsc* curAssertion = optGetAssertion(index);
-        if (curAssertion->Complementary(inputAssertion, !optLocalAssertionProp))
+        if (curAssertion->Complementary(*inputAssertion, !optLocalAssertionProp))
         {
             optMapComplementary(assertIndex, index);
             return index;
@@ -3091,7 +3090,7 @@ bool Compiler::optIsProfitableToSubstitute(GenTree* dest, BasicBlock* destBlock,
 // Notes:
 //    stmt may be nullptr during local assertion prop
 //
-GenTree* Compiler::optConstantAssertionProp(AssertionDsc*        curAssertion,
+GenTree* Compiler::optConstantAssertionProp(const AssertionDsc&  curAssertion,
                                             GenTreeLclVarCommon* tree,
                                             Statement* stmt      DEBUGARG(AssertionIndex index))
 {
@@ -3111,23 +3110,23 @@ GenTree* Compiler::optConstantAssertionProp(AssertionDsc*        curAssertion,
 
     // Update 'newTree' with the new value from our table
     // Typically newTree == tree and we are updating the node in place
-    switch (curAssertion->op2.kind)
+    switch (curAssertion.op2.kind)
     {
         case O2K_CONST_DOUBLE:
             // There could be a positive zero and a negative zero, so don't propagate zeroes.
-            if (curAssertion->op2.dconVal == 0.0)
+            if (curAssertion.op2.dconVal == 0.0)
             {
                 return nullptr;
             }
-            newTree->BashToConst(curAssertion->op2.dconVal, tree->TypeGet());
+            newTree->BashToConst(curAssertion.op2.dconVal, tree->TypeGet());
             break;
 
         case O2K_CONST_INT:
 
             // Don't propagate non-nulll non-static handles if we need to report relocs.
-            if (opts.compReloc && curAssertion->op2.HasIconFlag() && (curAssertion->op2.u1.iconVal != 0))
+            if (opts.compReloc && curAssertion.op2.HasIconFlag() && (curAssertion.op2.u1.iconVal != 0))
             {
-                if (curAssertion->op2.GetIconFlag() != GTF_ICON_STATIC_HDL)
+                if (curAssertion.op2.GetIconFlag() != GTF_ICON_STATIC_HDL)
                 {
                     return nullptr;
                 }
@@ -3139,11 +3138,11 @@ GenTree* Compiler::optConstantAssertionProp(AssertionDsc*        curAssertion,
             // here).
             assert(tree->TypeGet() == lvaGetDesc(lclNum)->TypeGet());
 
-            if (curAssertion->op2.HasIconFlag())
+            if (curAssertion.op2.HasIconFlag())
             {
                 // Here we have to allocate a new 'large' node to replace the old one
-                newTree = gtNewIconHandleNode(curAssertion->op2.u1.iconVal, curAssertion->op2.GetIconFlag(),
-                                              curAssertion->op2.u1.fieldSeq);
+                newTree = gtNewIconHandleNode(curAssertion.op2.u1.iconVal, curAssertion.op2.GetIconFlag(),
+                                              curAssertion.op2.u1.fieldSeq);
 
                 // Make sure we don't retype const gc handles to TYP_I_IMPL
                 // Although, it's possible for e.g. GTF_ICON_STATIC_HDL
@@ -3160,7 +3159,7 @@ GenTree* Compiler::optConstantAssertionProp(AssertionDsc*        curAssertion,
             else
             {
                 assert(varTypeIsIntegralOrI(tree));
-                newTree->BashToConst(curAssertion->op2.u1.iconVal, genActualType(tree));
+                newTree->BashToConst(curAssertion.op2.u1.iconVal, genActualType(tree));
             }
             break;
 
@@ -3170,11 +3169,11 @@ GenTree* Compiler::optConstantAssertionProp(AssertionDsc*        curAssertion,
 
     if (!optLocalAssertionProp)
     {
-        assert(newTree->OperIsConst());                      // We should have a simple Constant node for newTree
-        assert(vnStore->IsVNConstant(curAssertion->op2.vn)); // The value number stored for op2 should be a valid
-                                                             // VN representing the constant
-        newTree->gtVNPair.SetBoth(curAssertion->op2.vn);     // Set the ValueNumPair to the constant VN from op2
-                                                             // of the assertion
+        assert(newTree->OperIsConst());                     // We should have a simple Constant node for newTree
+        assert(vnStore->IsVNConstant(curAssertion.op2.vn)); // The value number stored for op2 should be a valid
+                                                            // VN representing the constant
+        newTree->gtVNPair.SetBoth(curAssertion.op2.vn);     // Set the ValueNumPair to the constant VN from op2
+                                                            // of the assertion
     }
 
 #ifdef DEBUG
@@ -3240,7 +3239,7 @@ bool Compiler::optZeroObjAssertionProp(GenTree* tree, ASSERT_VALARG_TP assertion
 
     AssertionDsc* assertion = optGetAssertion(assertionIndex);
     JITDUMP("\nAssertion prop in " FMT_BB ":\n", compCurBB->bbNum);
-    JITDUMPEXEC(optPrintAssertion(assertion, assertionIndex));
+    JITDUMPEXEC(optPrintAssertion(*assertion, assertionIndex));
     DISPNODE(tree);
 
     tree->BashToZeroConst(TYP_INT);
@@ -3326,14 +3325,14 @@ bool Compiler::optAssertionProp_LclVarTypeCheck(GenTree* tree, LclVarDsc* lclVar
 // Notes:
 //    stmt may be nullptr during local assertion prop
 //
-GenTree* Compiler::optCopyAssertionProp(AssertionDsc*        curAssertion,
+GenTree* Compiler::optCopyAssertionProp(const AssertionDsc&  curAssertion,
                                         GenTreeLclVarCommon* tree,
                                         Statement* stmt      DEBUGARG(AssertionIndex index))
 {
     assert(optLocalAssertionProp);
 
-    const AssertionDsc::AssertionDscOp1& op1 = curAssertion->op1;
-    const AssertionDsc::AssertionDscOp2& op2 = curAssertion->op2;
+    const AssertionDsc::AssertionDscOp1& op1 = curAssertion.op1;
+    const AssertionDsc::AssertionDscOp2& op2 = curAssertion.op2;
 
     noway_assert(op1.lclNum != op2.lclNum);
 
@@ -3366,7 +3365,7 @@ GenTree* Compiler::optCopyAssertionProp(AssertionDsc*        curAssertion,
     }
 
     // Make sure we can perform this copy prop.
-    if (optCopyProp_LclVarScore(lclVarDsc, copyVarDsc, curAssertion->op1.lclNum == lclNum) <= 0)
+    if (optCopyProp_LclVarScore(lclVarDsc, copyVarDsc, curAssertion.op1.lclNum == lclNum) <= 0)
     {
         return nullptr;
     }
@@ -3477,7 +3476,7 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTreeL
             if (optLocalAssertionProp)
             {
                 // Perform copy assertion prop.
-                GenTree* newTree = optCopyAssertionProp(curAssertion, tree, stmt DEBUGARG(assertionIndex));
+                GenTree* newTree = optCopyAssertionProp(*curAssertion, tree, stmt DEBUGARG(assertionIndex));
                 if (newTree != nullptr)
                 {
                     return newTree;
@@ -3505,7 +3504,7 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTreeL
             // Check lclNum in Local Assertion Prop
             if (curAssertion->op1.lclNum == lclNum)
             {
-                return optConstantAssertionProp(curAssertion, tree, stmt DEBUGARG(assertionIndex));
+                return optConstantAssertionProp(*curAssertion, tree, stmt DEBUGARG(assertionIndex));
             }
         }
         else
@@ -3513,7 +3512,7 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTreeL
             // Check VN in Global Assertion Prop
             if (curAssertion->op1.vn == vnStore->VNConservativeNormalValue(tree->gtVNPair))
             {
-                return optConstantAssertionProp(curAssertion, tree, stmt DEBUGARG(assertionIndex));
+                return optConstantAssertionProp(*curAssertion, tree, stmt DEBUGARG(assertionIndex));
             }
         }
     }
@@ -3571,7 +3570,7 @@ GenTree* Compiler::optAssertionProp_LclFld(ASSERT_VALARG_TP assertions, GenTreeL
         AssertionDsc* const curAssertion = optGetAssertion(assertionIndex);
         if (curAssertion->CanPropLclVar() && (curAssertion->op2.kind == O2K_LCLVAR_COPY))
         {
-            GenTree* const newTree = optCopyAssertionProp(curAssertion, tree, stmt DEBUGARG(assertionIndex));
+            GenTree* const newTree = optCopyAssertionProp(*curAssertion, tree, stmt DEBUGARG(assertionIndex));
             if (newTree != nullptr)
             {
                 return newTree;
@@ -3648,7 +3647,7 @@ GenTree* Compiler::optAssertionProp_LocalStore(ASSERT_VALARG_TP assertions, GenT
             {
                 JITDUMP("[%06u] is assigning a constant zero to a struct field or gc local that is already zero\n",
                         dspTreeID(store));
-                JITDUMPEXEC(optPrintAssertion(dstAssertion));
+                JITDUMPEXEC(optPrintAssertion(*dstAssertion));
 
                 store->gtBashToNOP();
                 return optAssertionProp_Update(store, store, stmt);
@@ -5416,7 +5415,7 @@ void Compiler::optImpliedAssertions(AssertionIndex assertionIndex, ASSERT_TP& ac
     if ((curAssertion->assertionKind == OAK_EQUAL) && (curAssertion->op1.kind == O1K_LCLVAR) &&
         (curAssertion->op2.kind == O2K_CONST_INT))
     {
-        optImpliedByConstAssertion(curAssertion, activeAssertions);
+        optImpliedByConstAssertion(*curAssertion, activeAssertions);
     }
 }
 
@@ -5513,14 +5512,14 @@ bool Compiler::optCreateJumpTableImpliedAssertions(BasicBlock* switchBb)
                     // Create "X >= value" assertion (both operands are never negative)
                     ValueNum     relop = vnStore->VNForFunc(TYP_INT, VNF_GE, opVN, vnStore->VNForIntCon(value));
                     AssertionDsc dsc   = AssertionDsc::CreateConstantLoopBound(this, relop, /*isUnsigned*/ false);
-                    newAssertIdx       = optAddAssertion(&dsc);
+                    newAssertIdx       = optAddAssertion(dsc);
                 }
                 else
                 {
                     // Create "X u>= value" assertion
                     ValueNum     relop = vnStore->VNForFunc(TYP_INT, VNF_GE_UN, opVN, vnStore->VNForIntCon(value));
                     AssertionDsc dsc   = AssertionDsc::CreateConstantLoopBound(this, relop, /*isUnsigned*/ true);
-                    newAssertIdx       = optAddAssertion(&dsc);
+                    newAssertIdx       = optAddAssertion(dsc);
                 }
             }
             else
@@ -5532,10 +5531,9 @@ bool Compiler::optCreateJumpTableImpliedAssertions(BasicBlock* switchBb)
         {
             // Create "VN == value" assertion.
             // TODO-Cleanup: Should use O1K_VN instead of O1K_LCLVAR
-            ValueNum     valueVN = vnStore->VNForIntCon(value);
-            AssertionDsc dsc =
-                AssertionDsc::CreateConstantLclvarAssertion(this, BAD_VAR_NUM, opVN, value, valueVN, true);
-            newAssertIdx = optAddAssertion(&dsc);
+            ValueNum valueVN = vnStore->VNForIntCon(value);
+            newAssertIdx     = optAddAssertion(
+                AssertionDsc::CreateConstantLclvarAssertion(this, BAD_VAR_NUM, opVN, value, valueVN, true));
         }
 
         if (newAssertIdx.HasAssertion())
@@ -5668,15 +5666,15 @@ ASSERT_VALRET_TP Compiler::optGetEdgeAssertions(const BasicBlock* block, const B
  *   that are also true
  */
 
-void Compiler::optImpliedByConstAssertion(AssertionDsc* constAssertion, ASSERT_TP& result)
+void Compiler::optImpliedByConstAssertion(const AssertionDsc& constAssertion, ASSERT_TP& result)
 {
-    noway_assert(constAssertion->assertionKind == OAK_EQUAL);
-    noway_assert(constAssertion->op1.kind == O1K_LCLVAR);
-    noway_assert(constAssertion->op2.kind == O2K_CONST_INT);
+    noway_assert(constAssertion.assertionKind == OAK_EQUAL);
+    noway_assert(constAssertion.op1.kind == O1K_LCLVAR);
+    noway_assert(constAssertion.op2.kind == O2K_CONST_INT);
 
-    ssize_t iconVal = constAssertion->op2.u1.iconVal;
+    ssize_t iconVal = constAssertion.op2.u1.iconVal;
 
-    const ASSERT_TP chkAssertions = optGetVnMappedAssertions(constAssertion->op1.vn);
+    const ASSERT_TP chkAssertions = optGetVnMappedAssertions(constAssertion.op1.vn);
     if (chkAssertions == nullptr || BitVecOps::IsEmpty(apTraits, chkAssertions))
     {
         return;
@@ -5694,13 +5692,13 @@ void Compiler::optImpliedByConstAssertion(AssertionDsc* constAssertion, ASSERT_T
         }
         // The impAssertion must be different from the const assertion.
         AssertionDsc* impAssertion = optGetAssertion(chkAssertionIndex);
-        if (impAssertion == constAssertion)
+        if (impAssertion->Equals(constAssertion, !optLocalAssertionProp))
         {
             continue;
         }
 
         // The impAssertion must be an assertion about the same local var.
-        if (impAssertion->op1.vn != constAssertion->op1.vn)
+        if (impAssertion->op1.vn != constAssertion.op1.vn)
         {
             continue;
         }
@@ -5732,7 +5730,7 @@ void Compiler::optImpliedByConstAssertion(AssertionDsc* constAssertion, ASSERT_T
             {
                 AssertionDsc* firstAssertion = optGetAssertion(1);
                 printf("Compiler::optImpliedByConstAssertion: const assertion #%02d implies assertion #%02d\n",
-                       (constAssertion - firstAssertion) + 1, (impAssertion - firstAssertion) + 1);
+                       (&constAssertion - firstAssertion) + 1, (impAssertion - firstAssertion) + 1);
             }
 #endif
         }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8051,7 +8051,7 @@ public:
             }
             else
             {
-                static_assert("Unexpected type for cns");
+                static_assert(!std::is_same_v<T, T>, "Unexpected type for cns");
             }
             return dsc;
         }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7986,8 +7986,7 @@ public:
 
         bool Equals(const AssertionDsc& that, bool vnBased) const
         {
-            // op1.kind check is implied by HasSameOp1, but it improves performance to do it first.
-            if (op1.kind != that.op1.kind || assertionKind != that.assertionKind)
+            if (assertionKind != that.assertionKind)
             {
                 return false;
             }

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7895,6 +7895,12 @@ public:
             return assertionKind == OAK_SUBRANGE && op1.kind == O1K_LCLVAR;
         }
 
+        void ReverseEquality()
+        {
+            assert((assertionKind == OAK_EQUAL) || (assertionKind == OAK_NOT_EQUAL));
+            assertionKind = assertionKind == OAK_EQUAL ? OAK_NOT_EQUAL : OAK_EQUAL;
+        }
+
         static bool SameKind(AssertionDsc* a1, AssertionDsc* a2)
         {
             return a1->assertionKind == a2->assertionKind && a1->op1.kind == a2->op1.kind &&
@@ -8097,9 +8103,42 @@ public:
             return dsc;
         }
 
-        static AssertionDsc CreateNonNullAssertion(Compiler* comp, unsigned lclNum, ValueNum vn)
+        static AssertionDsc CreateNonNullAssertion(Compiler* comp, unsigned lclNum, ValueNum vn = ValueNumStore::NoVN)
         {
             return CreateConstantLclvarAssertion(comp, lclNum, vn, 0, ValueNumStore::VNForNull(), false);
+        }
+
+        static AssertionDsc CreateLclvarCopy(Compiler* comp, unsigned lclNum1, unsigned lclNum2, bool equals)
+        {
+            assert(comp->optLocalAssertionProp);
+            assert(lclNum1 != BAD_VAR_NUM);
+            assert(lclNum2 != BAD_VAR_NUM);
+
+            AssertionDsc dsc  = {};
+            dsc.assertionKind = equals ? OAK_EQUAL : OAK_NOT_EQUAL;
+            dsc.op1.kind      = O1K_LCLVAR;
+            dsc.op1.vn        = ValueNumStore::NoVN;
+            dsc.op1.lclNum    = lclNum1;
+            dsc.op2.vn        = ValueNumStore::NoVN;
+            dsc.op2.lclNum    = lclNum2;
+            dsc.op2.kind      = O2K_LCLVAR_COPY;
+            return dsc;
+        }
+
+        static AssertionDsc CreateSubrange(Compiler* comp, unsigned lclNum, const IntegralRange& range)
+        {
+            assert(comp->optLocalAssertionProp);
+            assert(lclNum != BAD_VAR_NUM);
+
+            AssertionDsc dsc  = {};
+            dsc.assertionKind = OAK_SUBRANGE;
+            dsc.op1.kind      = O1K_LCLVAR;
+            dsc.op1.vn        = ValueNumStore::NoVN;
+            dsc.op1.lclNum    = lclNum;
+            dsc.op2.vn        = ValueNumStore::NoVN;
+            dsc.op2.kind      = O2K_SUBRANGE;
+            dsc.op2.u2        = range;
+            return dsc;
         }
 
         static AssertionDsc CreateInt32ConstantVNAssertion(Compiler* comp, ValueNum op1VN, ValueNum op2VN, bool equals)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8022,12 +8022,15 @@ public:
             if (comp->optLocalAssertionProp)
             {
                 assert(lclNum != BAD_VAR_NUM);
+
+                // TODO-Cleanup: We need to introduce getters for op1.vn and op2.vn that validate that we don't use
+                // these outside of their intended context (only certain kinds of assertions and only in global-AP).
                 dsc.op1.vn     = ValueNumStore::NoVN;
                 dsc.op2.vn     = ValueNumStore::NoVN;
                 dsc.op1.lclNum = lclNum;
 
                 // TODO-Quirk: Somewhere in local-AP we check op2.vn for being ValueNumStore::VNForNull
-                // while we shouldn't. Remove it.
+                // while we shouldn't. It is left here for zero-diff with previous behavior.
                 if (cnsVN == ValueNumStore::VNForNull())
                 {
                     dsc.op2.vn = ValueNumStore::VNForNull();
@@ -8037,7 +8040,7 @@ public:
             {
                 assert(vn != ValueNumStore::NoVN);
                 assert(cnsVN != ValueNumStore::NoVN);
-                dsc.op1.lclNum = BAD_VAR_NUM;
+                dsc.op1.lclNum = BAD_VAR_NUM; // same as above
                 dsc.op1.vn     = vn;
                 dsc.op2.vn     = cnsVN;
             }
@@ -8090,6 +8093,10 @@ public:
             dsc.op2.vn        = ValueNumStore::NoVN;
             dsc.op2.lclNum    = lclNum2;
             dsc.op2.kind      = O2K_LCLVAR_COPY;
+
+            // TODO-Cleanup: We need to introduce getters for op1.vn and op2.vn that validate that we don't use these
+            // outside of their intended context (only certain kinds of assertions and only in global-AP).
+
             return dsc;
         }
 
@@ -8102,9 +8109,7 @@ public:
             AssertionDsc dsc  = {};
             dsc.assertionKind = OAK_SUBRANGE;
             dsc.op1.kind      = O1K_LCLVAR;
-            dsc.op1.vn        = ValueNumStore::NoVN;
             dsc.op1.lclNum    = lclNum;
-            dsc.op2.vn        = ValueNumStore::NoVN;
             dsc.op2.kind      = O2K_SUBRANGE;
             dsc.op2.u2        = range;
             return dsc;
@@ -8124,7 +8129,6 @@ public:
 
             AssertionDsc dsc   = {};
             dsc.assertionKind  = equals ? OAK_EQUAL : OAK_NOT_EQUAL;
-            dsc.op1.lclNum     = BAD_VAR_NUM;
             dsc.op1.vn         = op1VN;
             dsc.op2.vn         = op2VN;
             dsc.op1.kind       = O1K_VN;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8258,12 +8258,11 @@ public:
     ValueNumToAssertsMap*                                                          optValueNumToAsserts;
 
     // Assertion prop helpers.
-    ASSERT_TP&    GetAssertionDep(unsigned lclNum);
-    AssertionDsc* optGetAssertion(AssertionIndex assertIndex) const;
-    void          optAssertionInit(bool isLocalProp);
-    void          optAssertionTraitsInit(AssertionIndex assertionCount);
-    void          optAssertionReset(AssertionIndex limit);
-    void          optAssertionRemove(AssertionIndex index);
+    ASSERT_TP&          GetAssertionDep(unsigned lclNum);
+    const AssertionDsc& optGetAssertion(AssertionIndex assertIndex) const;
+    void                optAssertionInit(bool isLocalProp);
+    void                optAssertionTraitsInit(AssertionIndex assertionCount);
+    void                optAssertionReset(AssertionIndex limit);
 
     // Assertion prop data flow functions.
     PhaseStatus optAssertionPropMain();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7898,10 +7898,13 @@ public:
             return assertionKind == OAK_SUBRANGE && op1.kind == O1K_LCLVAR;
         }
 
-        void ReverseEquality()
+        AssertionDsc ReverseEquality() const
         {
             assert((assertionKind == OAK_EQUAL) || (assertionKind == OAK_NOT_EQUAL));
-            assertionKind = assertionKind == OAK_EQUAL ? OAK_NOT_EQUAL : OAK_EQUAL;
+
+            AssertionDsc copy  = *this;
+            copy.assertionKind = assertionKind == OAK_EQUAL ? OAK_NOT_EQUAL : OAK_EQUAL;
+            return copy;
         }
 
         static bool ComplementaryKind(optAssertionKind kind, optAssertionKind kind2)
@@ -8263,11 +8266,11 @@ public:
     ValueNumToAssertsMap*                                                          optValueNumToAsserts;
 
     // Assertion prop helpers.
-    ASSERT_TP&          GetAssertionDep(unsigned lclNum);
+    ASSERT_TP&          GetAssertionDep(unsigned lclNum, bool mustExist = false);
     const AssertionDsc& optGetAssertion(AssertionIndex assertIndex) const;
     void                optAssertionInit(bool isLocalProp);
     void                optAssertionTraitsInit(AssertionIndex assertionCount);
-    void                optAssertionReset(AssertionIndex limit);
+    void                optAssertionReset();
 
     // Assertion prop data flow functions.
     PhaseStatus optAssertionPropMain();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7812,12 +7812,12 @@ public:
                 IntegralRange u2;
             };
 
-            bool HasIconFlag()
+            bool HasIconFlag() const
             {
                 assert(m_encodedIconFlags <= 0xFF);
                 return m_encodedIconFlags != 0;
             }
-            GenTreeFlags GetIconFlag()
+            GenTreeFlags GetIconFlag() const
             {
                 // number of trailing zeros in GTF_ICON_HDL_MASK
                 const uint16_t iconMaskTzc = 24;
@@ -7836,61 +7836,61 @@ public:
             }
         } op2;
 
-        bool IsCheckedBoundArithBound()
+        bool IsCheckedBoundArithBound() const
         {
             return ((assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL) && op1.kind == O1K_BOUND_OPER_BND);
         }
-        bool IsCheckedBoundBound()
+        bool IsCheckedBoundBound() const
         {
             return ((assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL) && op1.kind == O1K_BOUND_LOOP_BND);
         }
-        bool IsConstantBound()
+        bool IsConstantBound() const
         {
             return ((assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL) &&
                     (op1.kind == O1K_CONSTANT_LOOP_BND));
         }
-        bool IsConstantBoundUnsigned()
+        bool IsConstantBoundUnsigned() const
         {
             return ((assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL) &&
                     (op1.kind == O1K_CONSTANT_LOOP_BND_UN));
         }
-        bool IsBoundsCheckNoThrow()
+        bool IsBoundsCheckNoThrow() const
         {
             return ((assertionKind == OAK_NO_THROW) && (op1.kind == O1K_ARR_BND));
         }
 
-        bool IsCopyAssertion()
+        bool IsCopyAssertion() const
         {
             return ((assertionKind == OAK_EQUAL) && (op1.kind == O1K_LCLVAR) && (op2.kind == O2K_LCLVAR_COPY));
         }
 
-        bool IsConstantInt32Assertion()
+        bool IsConstantInt32Assertion() const
         {
             return ((assertionKind == OAK_EQUAL) || (assertionKind == OAK_NOT_EQUAL)) && (op2.kind == O2K_CONST_INT) &&
                    ((op1.kind == O1K_LCLVAR) || (op1.kind == O1K_VN));
         }
 
-        bool CanPropLclVar()
+        bool CanPropLclVar() const
         {
             return assertionKind == OAK_EQUAL && op1.kind == O1K_LCLVAR;
         }
 
-        bool CanPropEqualOrNotEqual()
+        bool CanPropEqualOrNotEqual() const
         {
             return assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL;
         }
 
-        bool CanPropNonNull()
+        bool CanPropNonNull() const
         {
             return assertionKind == OAK_NOT_EQUAL && op2.vn == ValueNumStore::VNForNull();
         }
 
-        bool CanPropBndsCheck()
+        bool CanPropBndsCheck() const
         {
             return (op1.kind == O1K_ARR_BND) || (op1.kind == O1K_VN);
         }
 
-        bool CanPropSubRange()
+        bool CanPropSubRange() const
         {
             return assertionKind == OAK_SUBRANGE && op1.kind == O1K_LCLVAR;
         }
@@ -7901,10 +7901,9 @@ public:
             assertionKind = assertionKind == OAK_EQUAL ? OAK_NOT_EQUAL : OAK_EQUAL;
         }
 
-        static bool SameKind(AssertionDsc* a1, AssertionDsc* a2)
+        static bool SameKind(const AssertionDsc& a1, const AssertionDsc& a2)
         {
-            return a1->assertionKind == a2->assertionKind && a1->op1.kind == a2->op1.kind &&
-                   a1->op2.kind == a2->op2.kind;
+            return a1.assertionKind == a2.assertionKind && a1.op1.kind == a2.op1.kind && a1.op2.kind == a2.op2.kind;
         }
 
         static bool ComplementaryKind(optAssertionKind kind, optAssertionKind kind2)
@@ -7920,31 +7919,31 @@ public:
             return false;
         }
 
-        bool HasSameOp1(AssertionDsc* that, bool vnBased)
+        bool HasSameOp1(const AssertionDsc& that, bool vnBased) const
         {
-            if (op1.kind != that->op1.kind)
+            if (op1.kind != that.op1.kind)
             {
                 return false;
             }
             else if (op1.kind == O1K_ARR_BND)
             {
                 assert(vnBased);
-                return (op1.bnd.vnIdx == that->op1.bnd.vnIdx) && (op1.bnd.vnLen == that->op1.bnd.vnLen);
+                return (op1.bnd.vnIdx == that.op1.bnd.vnIdx) && (op1.bnd.vnLen == that.op1.bnd.vnLen);
             }
             else if (op1.kind == O1K_VN)
             {
                 assert(vnBased);
-                return (op1.vn == that->op1.vn);
+                return (op1.vn == that.op1.vn);
             }
             else
             {
-                return ((vnBased && (op1.vn == that->op1.vn)) || (!vnBased && (op1.lclNum == that->op1.lclNum)));
+                return ((vnBased && (op1.vn == that.op1.vn)) || (!vnBased && (op1.lclNum == that.op1.lclNum)));
             }
         }
 
-        bool HasSameOp2(AssertionDsc* that, bool vnBased)
+        bool HasSameOp2(const AssertionDsc& that, bool vnBased) const
         {
-            if (op2.kind != that->op2.kind)
+            if (op2.kind != that.op2.kind)
             {
                 return false;
             }
@@ -7952,20 +7951,20 @@ public:
             switch (op2.kind)
             {
                 case O2K_CONST_INT:
-                    return ((op2.u1.iconVal == that->op2.u1.iconVal) && (op2.GetIconFlag() == that->op2.GetIconFlag()));
+                    return ((op2.u1.iconVal == that.op2.u1.iconVal) && (op2.GetIconFlag() == that.op2.GetIconFlag()));
 
                 case O2K_CONST_DOUBLE:
                     // exact match because of positive and negative zero.
-                    return (memcmp(&op2.dconVal, &that->op2.dconVal, sizeof(double)) == 0);
+                    return (memcmp(&op2.dconVal, &that.op2.dconVal, sizeof(double)) == 0);
 
                 case O2K_ZEROOBJ:
                     return true;
 
                 case O2K_LCLVAR_COPY:
-                    return op2.lclNum == that->op2.lclNum;
+                    return op2.lclNum == that.op2.lclNum;
 
                 case O2K_SUBRANGE:
-                    return op2.u2.Equals(that->op2.u2);
+                    return op2.u2.Equals(that.op2.u2);
 
                 case O2K_INVALID:
                     // we will return false
@@ -7979,15 +7978,15 @@ public:
             return false;
         }
 
-        bool Complementary(AssertionDsc* that, bool vnBased)
+        bool Complementary(const AssertionDsc& that, bool vnBased) const
         {
-            return ComplementaryKind(assertionKind, that->assertionKind) && HasSameOp1(that, vnBased) &&
+            return ComplementaryKind(assertionKind, that.assertionKind) && HasSameOp1(that, vnBased) &&
                    HasSameOp2(that, vnBased);
         }
 
-        bool Equals(AssertionDsc* that, bool vnBased)
+        bool Equals(const AssertionDsc& that, bool vnBased) const
         {
-            if (assertionKind != that->assertionKind)
+            if (assertionKind != that.assertionKind)
             {
                 return false;
             }
@@ -8260,7 +8259,7 @@ public:
 
     // Assertion prop helpers.
     ASSERT_TP&    GetAssertionDep(unsigned lclNum);
-    AssertionDsc* optGetAssertion(AssertionIndex assertIndex);
+    AssertionDsc* optGetAssertion(AssertionIndex assertIndex) const;
     void          optAssertionInit(bool isLocalProp);
     void          optAssertionTraitsInit(AssertionIndex assertionCount);
     void          optAssertionReset(AssertionIndex limit);
@@ -8293,11 +8292,11 @@ public:
 
     void optCreateComplementaryAssertion(AssertionIndex assertionIndex, GenTree* op1, GenTree* op2);
 
-    bool           optAssertionVnInvolvesNan(AssertionDsc* assertion);
-    AssertionIndex optAddAssertion(AssertionDsc* assertion);
-    void           optAddVnAssertionMapping(ValueNum vn, AssertionIndex index);
+    bool           optAssertionVnInvolvesNan(const AssertionDsc& assertion) const;
+    AssertionIndex optAddAssertion(const AssertionDsc& assertion);
+    void           optAddVnAssertionMapping(ValueNum vn, AssertionIndex index) const;
 #ifdef DEBUG
-    void optPrintVnAssertionMapping();
+    void optPrintVnAssertionMapping() const;
 #endif
     ASSERT_TP optGetVnMappedAssertions(ValueNum vn);
 
@@ -8314,10 +8313,10 @@ public:
 
     // Assertion prop for lcl var functions.
     bool     optAssertionProp_LclVarTypeCheck(GenTree* tree, LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc);
-    GenTree* optCopyAssertionProp(AssertionDsc*        curAssertion,
+    GenTree* optCopyAssertionProp(const AssertionDsc&  curAssertion,
                                   GenTreeLclVarCommon* tree,
                                   Statement* stmt      DEBUGARG(AssertionIndex index));
-    GenTree* optConstantAssertionProp(AssertionDsc*        curAssertion,
+    GenTree* optConstantAssertionProp(const AssertionDsc&  curAssertion,
                                       GenTreeLclVarCommon* tree,
                                       Statement* stmt      DEBUGARG(AssertionIndex index));
     bool     optIsProfitableToSubstitute(GenTree* dest, BasicBlock* destBlock, GenTree* destParent, GenTree* value);
@@ -8367,13 +8366,13 @@ public:
     void optImpliedAssertions(AssertionIndex assertionIndex, ASSERT_TP& activeAssertions);
     void optImpliedByTypeOfAssertions(ASSERT_TP& activeAssertions);
     bool optCreateJumpTableImpliedAssertions(BasicBlock* switchBb);
-    void optImpliedByConstAssertion(AssertionDsc* curAssertion, ASSERT_TP& result);
+    void optImpliedByConstAssertion(const AssertionDsc& curAssertion, ASSERT_TP& result);
 
 #ifdef DEBUG
-    void optPrintAssertion(AssertionDsc* newAssertion, AssertionIndex assertionIndex = 0);
+    void optPrintAssertion(const AssertionDsc& newAssertion, AssertionIndex assertionIndex = 0);
     void optPrintAssertionIndex(AssertionIndex index);
     void optPrintAssertionIndices(ASSERT_TP assertions);
-    void optDebugCheckAssertion(AssertionDsc* assertion);
+    void optDebugCheckAssertion(const AssertionDsc& assertion) const;
     void optDebugCheckAssertions(AssertionIndex AssertionIndex);
 #endif
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8109,7 +8109,7 @@ public:
         static AssertionDsc CreateInt32ConstantVNAssertion(Compiler* comp, ValueNum op1VN, ValueNum op2VN, bool equals)
         {
             assert(op1VN != ValueNumStore::NoVN);
-            assert(op1VN != ValueNumStore::NoVN);
+            assert(op2VN != ValueNumStore::NoVN);
             assert(comp->vnStore->IsVNInt32Constant(op2VN));
             assert(!comp->vnStore->IsVNHandle(op2VN));
             assert(!comp->optLocalAssertionProp);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8042,7 +8042,6 @@ public:
                 dsc.op2.vn     = cnsVN;
             }
 
-            dsc.op2.SetIconFlag(GTF_EMPTY);
             if constexpr (std::is_same_v<T, int> || std::is_same_v<T, ssize_t>)
             {
                 dsc.op2.kind       = O2K_CONST_INT;
@@ -8112,7 +8111,10 @@ public:
         }
 
         // Create "VN ==/!= int32_constant" assertion
-        static AssertionDsc CreateInt32ConstantVNAssertion(const Compiler* comp, ValueNum op1VN, ValueNum op2VN, bool equals)
+        static AssertionDsc CreateInt32ConstantVNAssertion(const Compiler* comp,
+                                                           ValueNum        op1VN,
+                                                           ValueNum        op2VN,
+                                                           bool            equals)
         {
             assert(op1VN != ValueNumStore::NoVN);
             assert(op2VN != ValueNumStore::NoVN);
@@ -8128,7 +8130,6 @@ public:
             dsc.op1.kind       = O1K_VN;
             dsc.op2.kind       = O2K_CONST_INT;
             dsc.op2.u1.iconVal = comp->vnStore->ConstantValue<int>(op2VN);
-            dsc.op2.SetIconFlag(GTF_EMPTY);
             return dsc;
         }
 
@@ -8187,7 +8188,6 @@ public:
             dsc.op2.kind       = O2K_CONST_INT;
             dsc.op2.vn         = comp->vnStore->VNZeroForType(TYP_INT);
             dsc.op2.u1.iconVal = 0;
-            dsc.op2.SetIconFlag(GTF_EMPTY);
             return dsc;
         }
 
@@ -8216,7 +8216,6 @@ public:
             dsc.op2.kind       = O2K_CONST_INT;
             dsc.op2.vn         = comp->vnStore->VNZeroForType(TYP_INT);
             dsc.op2.u1.iconVal = 0;
-            dsc.op2.SetIconFlag(GTF_EMPTY);
             return dsc;
         }
     };

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3834,103 +3834,45 @@ inline void Compiler::optAssertionReset(AssertionIndex limit)
 
     while (optAssertionCount > limit)
     {
-        AssertionIndex index        = optAssertionCount;
-        AssertionDsc*  curAssertion = optGetAssertion(index);
+        AssertionIndex      index        = optAssertionCount;
+        const AssertionDsc& curAssertion = optGetAssertion(index);
         optAssertionCount--;
-        unsigned lclNum = curAssertion->op1.lclNum;
+        unsigned lclNum = curAssertion.op1.lclNum;
         assert(lclNum < lvaCount);
         BitVecOps::RemoveElemD(apTraits, GetAssertionDep(lclNum), index - 1);
 
         //
         // Find the Copy assertions
         //
-        if ((curAssertion->assertionKind == OAK_EQUAL) && (curAssertion->op1.kind == O1K_LCLVAR) &&
-            (curAssertion->op2.kind == O2K_LCLVAR_COPY))
+        if ((curAssertion.assertionKind == OAK_EQUAL) && (curAssertion.op1.kind == O1K_LCLVAR) &&
+            (curAssertion.op2.kind == O2K_LCLVAR_COPY))
         {
             //
             //  op2.lclNum no longer depends upon this assertion
             //
-            lclNum = curAssertion->op2.lclNum;
+            lclNum = curAssertion.op2.lclNum;
             BitVecOps::RemoveElemD(apTraits, GetAssertionDep(lclNum), index - 1);
         }
     }
     while (optAssertionCount < limit)
     {
-        AssertionIndex index        = ++optAssertionCount;
-        AssertionDsc*  curAssertion = optGetAssertion(index);
-        unsigned       lclNum       = curAssertion->op1.lclNum;
+        AssertionIndex      index        = ++optAssertionCount;
+        const AssertionDsc& curAssertion = optGetAssertion(index);
+        unsigned            lclNum       = curAssertion.op1.lclNum;
         BitVecOps::AddElemD(apTraits, GetAssertionDep(lclNum), index - 1);
 
         //
         // Check for Copy assertions
         //
-        if ((curAssertion->assertionKind == OAK_EQUAL) && (curAssertion->op1.kind == O1K_LCLVAR) &&
-            (curAssertion->op2.kind == O2K_LCLVAR_COPY))
+        if ((curAssertion.assertionKind == OAK_EQUAL) && (curAssertion.op1.kind == O1K_LCLVAR) &&
+            (curAssertion.op2.kind == O2K_LCLVAR_COPY))
         {
             //
             //  op2.lclNum now depends upon this assertion
             //
-            lclNum = curAssertion->op2.lclNum;
+            lclNum = curAssertion.op2.lclNum;
             BitVecOps::AddElemD(apTraits, GetAssertionDep(lclNum), index - 1);
         }
-    }
-}
-
-/*****************************************************************************
- *
- *  The following removes the i-th entry in the assertions table
- *  used only during local assertion prop
- */
-
-inline void Compiler::optAssertionRemove(AssertionIndex index)
-{
-    assert(index > 0);
-    assert(index <= optAssertionCount);
-    assert(optAssertionCount <= optMaxAssertionCount);
-
-    AssertionDsc* curAssertion = optGetAssertion(index);
-
-    //  Two cases to consider if (index == optAssertionCount) then the last
-    //  entry in the table is to be removed and that happens automatically when
-    //  optAssertionCount is decremented and we can just clear the optAssertionDep bits
-    //  The other case is when index < optAssertionCount and here we overwrite the
-    //  index-th entry in the table with the data found at the end of the table
-    //  Since we are reordering the rable the optAssertionDep bits need to be recreated
-    //  using optAssertionReset(0) and optAssertionReset(newAssertionCount) will
-    //  correctly update the optAssertionDep bits
-    //
-    if (index == optAssertionCount)
-    {
-        unsigned lclNum = curAssertion->op1.lclNum;
-        BitVecOps::RemoveElemD(apTraits, GetAssertionDep(lclNum), index - 1);
-
-        //
-        // Check for Copy assertions
-        //
-        if ((curAssertion->assertionKind == OAK_EQUAL) && (curAssertion->op1.kind == O1K_LCLVAR) &&
-            (curAssertion->op2.kind == O2K_LCLVAR_COPY))
-        {
-            //
-            //  op2.lclNum no longer depends upon this assertion
-            //
-            lclNum = curAssertion->op2.lclNum;
-            BitVecOps::RemoveElemD(apTraits, GetAssertionDep(lclNum), index - 1);
-        }
-
-        optAssertionCount--;
-    }
-    else
-    {
-        AssertionDsc*  lastAssertion     = optGetAssertion(optAssertionCount);
-        AssertionIndex newAssertionCount = optAssertionCount - 1;
-
-        optAssertionReset(0); // This make optAssertionCount equal 0
-
-        memcpy(curAssertion,  // the entry to be removed
-               lastAssertion, // last entry in the table
-               sizeof(AssertionDsc));
-
-        optAssertionReset(newAssertionCount);
     }
 }
 

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12667,7 +12667,7 @@ void Compiler::fgKillDependentAssertionsSingle(unsigned lclNum DEBUGARG(GenTree*
                     printf("\nThe store ");
                     printTreeID(tree);
                     printf(" using V%02u removes: ", curAssertion->op1.lclNum);
-                    optPrintAssertion(curAssertion, index);
+                    optPrintAssertion(*curAssertion, index);
                 }
             }
 
@@ -12760,7 +12760,7 @@ void Compiler::fgAssertionGen(GenTree* tree)
                     printf("GenTreeNode creates %sassertion:\n", condition);
                     gtDispTree(tree, nullptr, nullptr, true);
                     printf("In " FMT_BB " New Local ", compCurBB->bbNum);
-                    optPrintAssertion(optGetAssertion(apIndex), apIndex);
+                    optPrintAssertion(*optGetAssertion(apIndex), apIndex);
                 }
                 else
                 {
@@ -12791,11 +12791,9 @@ void Compiler::fgAssertionGen(GenTree* tree)
                 ssize_t iconVal = assertion->op2.u1.iconVal;
                 if ((iconVal == 0) || (iconVal == 1))
                 {
-                    AssertionDsc extraAssertion =
-                        AssertionDsc::CreateSubrange(this, assertion->op1.lclNum,
-                                                     IntegralRange(SymbolicIntegerValue::Zero,
-                                                                   SymbolicIntegerValue::One));
-                    AssertionIndex extraIndex = optAddAssertion(&extraAssertion);
+                    auto           range = IntegralRange(SymbolicIntegerValue::Zero, SymbolicIntegerValue::One);
+                    AssertionDsc   extraAssertion = AssertionDsc::CreateSubrange(this, assertion->op1.lclNum, range);
+                    AssertionIndex extraIndex     = optAddAssertion(extraAssertion);
                     if (extraIndex != NO_ASSERTION_INDEX)
                     {
                         unsigned const bvIndex = extraIndex - 1;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12659,15 +12659,15 @@ void Compiler::fgKillDependentAssertionsSingle(unsigned lclNum DEBUGARG(GenTree*
         {
             if (BitVecOps::IsMember(apTraits, killed, index - 1))
             {
-                AssertionDsc* curAssertion = optGetAssertion(index);
-                noway_assert((curAssertion->op1.lclNum == lclNum) ||
-                             ((curAssertion->op2.kind == O2K_LCLVAR_COPY) && (curAssertion->op2.lclNum == lclNum)));
+                const AssertionDsc& curAssertion = optGetAssertion(index);
+                noway_assert((curAssertion.op1.lclNum == lclNum) ||
+                             ((curAssertion.op2.kind == O2K_LCLVAR_COPY) && (curAssertion.op2.lclNum == lclNum)));
                 if (verbose)
                 {
                     printf("\nThe store ");
                     printTreeID(tree);
-                    printf(" using V%02u removes: ", curAssertion->op1.lclNum);
-                    optPrintAssertion(*curAssertion, index);
+                    printf(" using V%02u removes: ", curAssertion.op1.lclNum);
+                    optPrintAssertion(curAssertion, index);
                 }
             }
 
@@ -12760,7 +12760,7 @@ void Compiler::fgAssertionGen(GenTree* tree)
                     printf("GenTreeNode creates %sassertion:\n", condition);
                     gtDispTree(tree, nullptr, nullptr, true);
                     printf("In " FMT_BB " New Local ", compCurBB->bbNum);
-                    optPrintAssertion(*optGetAssertion(apIndex), apIndex);
+                    optPrintAssertion(optGetAssertion(apIndex), apIndex);
                 }
                 else
                 {
@@ -12780,19 +12780,19 @@ void Compiler::fgAssertionGen(GenTree* tree)
     // assertion for that local, in case this local is used as a bool.
     //
     auto addImpliedAssertions = [=](AssertionIndex index, ASSERT_TP& assertions) {
-        AssertionDsc* const assertion = optGetAssertion(index);
-        if ((assertion->assertionKind == OAK_EQUAL) && (assertion->op1.kind == O1K_LCLVAR) &&
-            (assertion->op2.kind == O2K_CONST_INT))
+        const AssertionDsc& assertion = optGetAssertion(index);
+        if ((assertion.assertionKind == OAK_EQUAL) && (assertion.op1.kind == O1K_LCLVAR) &&
+            (assertion.op2.kind == O2K_CONST_INT))
         {
-            LclVarDsc* const lclDsc = lvaGetDesc(assertion->op1.lclNum);
+            LclVarDsc* const lclDsc = lvaGetDesc(assertion.op1.lclNum);
 
             if (varTypeIsIntegral(lclDsc->TypeGet()))
             {
-                ssize_t iconVal = assertion->op2.u1.iconVal;
+                ssize_t iconVal = assertion.op2.u1.iconVal;
                 if ((iconVal == 0) || (iconVal == 1))
                 {
                     auto           range = IntegralRange(SymbolicIntegerValue::Zero, SymbolicIntegerValue::One);
-                    AssertionDsc   extraAssertion = AssertionDsc::CreateSubrange(this, assertion->op1.lclNum, range);
+                    AssertionDsc   extraAssertion = AssertionDsc::CreateSubrange(this, assertion.op1.lclNum, range);
                     AssertionIndex extraIndex     = optAddAssertion(extraAssertion);
                     if (extraIndex != NO_ASSERTION_INDEX)
                     {

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -13599,7 +13599,7 @@ void Compiler::fgMorphBlock(BasicBlock* block, MorphUnreachableInfo* unreachable
         {
             // Each block starts with an empty table, and no available assertions
             //
-            optAssertionReset(0);
+            optAssertionReset();
             BitVecOps::ClearD(apTraits, apLocal);
             BitVecOps::ClearD(apTraits, apLocalPostorder);
         }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12791,13 +12791,11 @@ void Compiler::fgAssertionGen(GenTree* tree)
                 ssize_t iconVal = assertion->op2.u1.iconVal;
                 if ((iconVal == 0) || (iconVal == 1))
                 {
-                    AssertionDsc extraAssertion = {OAK_SUBRANGE};
-                    extraAssertion.op1.kind     = O1K_LCLVAR;
-                    extraAssertion.op1.lclNum   = assertion->op1.lclNum;
-                    extraAssertion.op2.kind     = O2K_SUBRANGE;
-                    extraAssertion.op2.u2       = IntegralRange(SymbolicIntegerValue::Zero, SymbolicIntegerValue::One);
-
-                    AssertionIndex extraIndex = optFinalizeCreatingAssertion(&extraAssertion);
+                    AssertionDsc extraAssertion =
+                        AssertionDsc::CreateSubrange(this, assertion->op1.lclNum,
+                                                     IntegralRange(SymbolicIntegerValue::Zero,
+                                                                   SymbolicIntegerValue::One));
+                    AssertionIndex extraIndex = optAddAssertion(&extraAssertion);
                     if (extraIndex != NO_ASSERTION_INDEX)
                     {
                         unsigned const bvIndex = extraIndex - 1;

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -903,7 +903,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
     {
         AssertionIndex assertionIndex = GetAssertionIndex(index);
 
-        Compiler::AssertionDsc* curAssertion = comp->optGetAssertion(assertionIndex);
+        const Compiler::AssertionDsc& curAssertion = comp->optGetAssertion(assertionIndex);
 
         Limit      limit(Limit::keUndef);
         genTreeOps cmpOper             = GT_NONE;
@@ -911,12 +911,12 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         bool       isUnsigned          = false;
 
         // Current assertion is of the form (i < len - cns) != 0
-        if (canUseCheckedBounds && curAssertion->IsCheckedBoundArithBound())
+        if (canUseCheckedBounds && curAssertion.IsCheckedBoundArithBound())
         {
             ValueNumStore::CompareCheckedBoundArithInfo info;
 
             // Get i, len, cns and < as "info."
-            comp->vnStore->GetCompareCheckedBoundArithInfo(curAssertion->op1.vn, &info);
+            comp->vnStore->GetCompareCheckedBoundArithInfo(curAssertion.op1.vn, &info);
 
             // If we don't have the same variable we are comparing against, bail.
             if (normalLclVN != info.cmpOp)
@@ -940,12 +940,12 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             cmpOper  = (genTreeOps)info.cmpOper;
         }
         // Current assertion is of the form (i < len) != 0
-        else if (canUseCheckedBounds && curAssertion->IsCheckedBoundBound())
+        else if (canUseCheckedBounds && curAssertion.IsCheckedBoundBound())
         {
             ValueNumStore::CompareCheckedBoundArithInfo info;
 
             // Get the info as "i", "<" and "len"
-            comp->vnStore->GetCompareCheckedBound(curAssertion->op1.vn, &info);
+            comp->vnStore->GetCompareCheckedBound(curAssertion.op1.vn, &info);
 
             // If we don't have the same variable we are comparing against, bail.
             if (normalLclVN == info.cmpOp)
@@ -964,12 +964,12 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             }
         }
         // Current assertion is of the form (i < 100) != 0
-        else if (curAssertion->IsConstantBound() || curAssertion->IsConstantBoundUnsigned())
+        else if (curAssertion.IsConstantBound() || curAssertion.IsConstantBoundUnsigned())
         {
             ValueNumStore::ConstantBoundInfo info;
 
             // Get the info as "i", "<" and "100"
-            comp->vnStore->GetConstantBoundInfo(curAssertion->op1.vn, &info);
+            comp->vnStore->GetConstantBoundInfo(curAssertion.op1.vn, &info);
 
             // If we don't have the same variable we are comparing against, bail.
             if (normalLclVN != info.cmpOpVN)
@@ -982,37 +982,37 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             isUnsigned = info.isUnsigned;
         }
         // Current assertion is of the form i == 100
-        else if (curAssertion->IsConstantInt32Assertion())
+        else if (curAssertion.IsConstantInt32Assertion())
         {
-            if (curAssertion->op1.vn != normalLclVN)
+            if (curAssertion.op1.vn != normalLclVN)
             {
                 continue;
             }
 
             // Ignore GC values/NULL caught by IsConstantInt32Assertion assertion (may happen on 32bit)
-            if (varTypeIsGC(comp->vnStore->TypeOfVN(curAssertion->op2.vn)))
+            if (varTypeIsGC(comp->vnStore->TypeOfVN(curAssertion.op2.vn)))
             {
                 continue;
             }
 
-            int cnstLimit = (int)curAssertion->op2.u1.iconVal;
-            assert(cnstLimit == comp->vnStore->CoercedConstantValue<int>(curAssertion->op2.vn));
+            int cnstLimit = (int)curAssertion.op2.u1.iconVal;
+            assert(cnstLimit == comp->vnStore->CoercedConstantValue<int>(curAssertion.op2.vn));
 
-            if ((cnstLimit == 0) && (curAssertion->assertionKind == Compiler::OAK_NOT_EQUAL) && canUseCheckedBounds &&
-                comp->vnStore->IsVNCheckedBound(curAssertion->op1.vn))
+            if ((cnstLimit == 0) && (curAssertion.assertionKind == Compiler::OAK_NOT_EQUAL) && canUseCheckedBounds &&
+                comp->vnStore->IsVNCheckedBound(curAssertion.op1.vn))
             {
                 // we have arr.Len != 0, so the length must be atleast one
                 limit   = Limit(Limit::keConstant, 1);
                 cmpOper = GT_GE;
             }
-            else if (curAssertion->assertionKind == Compiler::OAK_EQUAL)
+            else if (curAssertion.assertionKind == Compiler::OAK_EQUAL)
             {
                 limit   = Limit(Limit::keConstant, cnstLimit);
                 cmpOper = GT_EQ;
             }
             else
             {
-                assert(curAssertion->assertionKind == Compiler::OAK_NOT_EQUAL);
+                assert(curAssertion.assertionKind == Compiler::OAK_NOT_EQUAL);
 
                 // We have an assertion of the form "X != constLimit".
                 // For example, if the assertion is "X != 100" and the current range for X is [100, X],
@@ -1039,10 +1039,10 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             isConstantAssertion = true;
         }
         // Current assertion asserts a bounds check does not throw
-        else if (curAssertion->IsBoundsCheckNoThrow())
+        else if (curAssertion.IsBoundsCheckNoThrow())
         {
-            ValueNum indexVN = curAssertion->op1.bnd.vnIdx;
-            ValueNum lenVN   = curAssertion->op1.bnd.vnLen;
+            ValueNum indexVN = curAssertion.op1.bnd.vnIdx;
+            ValueNum lenVN   = curAssertion.op1.bnd.vnLen;
             if (normalLclVN == indexVN)
             {
                 if (canUseCheckedBounds)
@@ -1099,15 +1099,15 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         assert(limit.IsBinOpArray() || limit.IsConstant());
 
         // Make sure the assertion is of the form != 0 or == 0 if it isn't a constant assertion.
-        if (!isConstantAssertion && (curAssertion->assertionKind != Compiler::OAK_NO_THROW) &&
-            (curAssertion->op2.vn != comp->vnStore->VNZeroForType(TYP_INT)))
+        if (!isConstantAssertion && (curAssertion.assertionKind != Compiler::OAK_NO_THROW) &&
+            (curAssertion.op2.vn != comp->vnStore->VNZeroForType(TYP_INT)))
         {
             continue;
         }
 #ifdef DEBUG
         if (comp->verbose)
         {
-            comp->optPrintAssertion(*curAssertion, assertionIndex);
+            comp->optPrintAssertion(curAssertion, assertionIndex);
         }
 #endif
 
@@ -1149,7 +1149,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         // If we have a non-constant assertion of the form == 0 (i.e., equals false), then reverse relop.
         // The relop has to be reversed because we have: (i < length) is false which is the same
         // as (i >= length).
-        if ((curAssertion->assertionKind == Compiler::OAK_EQUAL) && !isConstantAssertion)
+        if ((curAssertion.assertionKind == Compiler::OAK_EQUAL) && !isConstantAssertion)
         {
             cmpOper = GenTree::ReverseRelop(cmpOper);
         }

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1107,7 +1107,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
 #ifdef DEBUG
         if (comp->verbose)
         {
-            comp->optPrintAssertion(curAssertion, assertionIndex);
+            comp->optPrintAssertion(*curAssertion, assertionIndex);
         }
 #endif
 


### PR DESCRIPTION
Zero-diff clean up change.

1) All assertions are now created with `AssertionDsc::Create*` factory methods. The plan is to remove `optCreateAssertion` entirely. This gives a more precise control on which fields are relevant and which are not.
2) Replaced `AssertionDsc*` with `const AssertionDsc&` everywhere, marked many related functions as `const`. This makes code more memory safe (no unexpected mutations) and actually improves TP a bit.
3) Added lots of new debug asserts to validate assumptions
4) Removed a few unused functions

Ideas for a follow up:
1) Hide op1.* and op2.* fields under getters so they have additional debug asserts (because of unions), e.g. don't ever use op1.vn or op2.vn in local AP.
2) Use `memcmp` for AssertionDsc::Equals (if we pack it)?

[No diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1275150&view=ms.vss-build-web.run-extensions-tab)