### PR TITLE
Fix incorrect Vector256->Vector512 in SpanHelpers

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -3974,7 +3974,7 @@ namespace System
                         return ComputeFirstIndex(ref searchSpace, ref current, inRangeVector);
                     }
 
-                    current = ref Unsafe.Add(ref current, Vector256<T>.Count);
+                    current = ref Unsafe.Add(ref current, Vector512<T>.Count);
                 }
                 while (Unsafe.IsAddressLessThan(ref current, ref oneVectorAwayFromEnd));
 


### PR DESCRIPTION
I think this would only manifest as a perf rather than correctness issue.