### PR TITLE
[Wasm Ryujit] Flow cannot fall through into a throw helper

### DIFF
--- a/src/coreclr/jit/block.h
+++ b/src/coreclr/jit/block.h
@@ -445,6 +445,7 @@ enum BasicBlockFlags : uint64_t
     BBF_HAS_NEWARR                     = MAKE_BBFLAG(34), // BB contains 'new' of an array type.
     BBF_MAY_HAVE_BOUNDS_CHECKS         = MAKE_BBFLAG(35), // BB *likely* has a bounds check (after rangecheck phase).
     BBF_ASYNC_RESUMPTION               = MAKE_BBFLAG(36), // Block is a resumption block in an async method
+    BBF_THROW_HELPER                   = MAKE_BBFLAG(37), // Block is a call to a throw helper
 
     // The following are sets of flags.
 
@@ -455,7 +456,7 @@ enum BasicBlockFlags : uint64_t
 
     // Flags a block should not have had before it is split.
 
-    BBF_SPLIT_NONEXIST = BBF_RETLESS_CALL | BBF_COLD,
+    BBF_SPLIT_NONEXIST = BBF_RETLESS_CALL | BBF_COLD | BBF_THROW_HELPER,
 
     // Flags lost by the top block when a block is split.
     // Note, this is a conservative guess.

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -1174,9 +1174,10 @@ PhaseStatus Compiler::fgWasmControlFlow()
                 continue;
             }
 
-            // Branch to next needs no block, unless this is a switch
+            // Branch to next needs no block, unless this is a switch or next is a throw helper.
+            // We may need to branch to a throw helper mid-block, so can't always fall through.
             //
-            if ((succNum == (cursor + 1)) && !block->KindIs(BBJ_SWITCH))
+            if ((succNum == (cursor + 1)) && !block->KindIs(BBJ_SWITCH) && !(succ->HasFlag(BBF_THROW_HELPER)))
             {
                 continue;
             }

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3461,6 +3461,7 @@ void Compiler::fgCreateThrowHelperBlock(AddCodeDsc* add)
 {
     if (add->acdDstBlk != nullptr)
     {
+        assert(add->acdDstBlk->HasFlag(BBF_THROW_HELPER));
         return;
     }
 
@@ -3484,6 +3485,8 @@ void Compiler::fgCreateThrowHelperBlock(AddCodeDsc* add)
     BasicBlock* const newBlk      = fgNewBBinRegion(jumpKinds[add->acdKind], add->acdTryIndex, add->acdHndIndex,
                                                     /* nearBlk */ nullptr, putInFilter,
                                                     /* runRarely */ true, /* insertAtEnd */ true);
+
+    newBlk->SetFlags(BBF_THROW_HELPER);
 
     // Update the descriptor so future lookups can find the block
     //
@@ -3668,6 +3671,11 @@ Compiler::AddCodeDsc* Compiler::fgGetExcptnTarget(SpecialCodeKind kind, BasicBlo
         {
             fgCreateThrowHelperBlock(add);
         }
+    }
+
+    if (add->acdDstBlk != nullptr)
+    {
+        assert(add->acdDstBlk->HasFlag(BBF_THROW_HELPER));
     }
 
     return add;


### PR DESCRIPTION
Make sure we emit proper Wasm `block/end` for throw helpers, since we may branch to them mid-block, so can't fall through even if the helper is the next block.

Also make it clearer which blocks are throw helpers, instead of trying to guess by parsing block contents and such.