### PR TITLE
Fix off-by-one error in TypePreinit switch instruction handling

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -1272,7 +1272,7 @@ namespace ILCompiler
 
                         uint count = reader.ReadILUInt32();
                         int nextInstruction = reader.Offset + (int)(4 * count);
-                        if (target > count)
+                        if (target >= count)
                         {
                             reader.Seek(nextInstruction);
                         }

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -821,6 +821,7 @@ class TestSwitch
         public static int CaseMinus1 = Switch(-1);
         public static int Case0 = Switch(0);
         public static int Case6 = Switch(6);
+        public static int Case7 = Switch(7); // Boundary: value == case count (tests fix for https://github.com/dotnet/runtime/issues/123833)
         public static int Case100 = Switch(100);
 
         private static int Switch(int x)
@@ -845,6 +846,7 @@ class TestSwitch
         Assert.AreEqual(Switcher.CaseMinus1, 100000);
         Assert.AreEqual(Switcher.Case0, 100);
         Assert.AreEqual(Switcher.Case6, 700);
+        Assert.AreEqual(Switcher.Case7, 100000);
         Assert.AreEqual(Switcher.Case100, 100000);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #123833

The switch IL instruction interpreter in TypePreinit used `>` instead of `>=` when checking if the switch value exceeds the case count. Per ECMA-335, switch should fall through to the next instruction when `value >= count`, but the code only did this for `value > count`.

When the value exactly equals the case count, the code tried to read a non-existent jump table entry, corrupting the IL reader offset and causing an `IndexOutOfRangeException` during NativeAOT compilation.

## Changes

- **TypePreinit.cs**: Changed `target > count` to `target >= count` in the switch instruction handler
- **Preinitialization.cs**: Added test case for the boundary condition (value == case count)