### PR TITLE
Reduce the amount of string copying and comparing when resolving assets on startup

### DIFF
--- a/src/native/corehost/hostpolicy/deps_entry.h
+++ b/src/native/corehost/hostpolicy/deps_entry.h
@@ -12,7 +12,7 @@
 
 struct deps_asset_t
 {
-    deps_asset_t() : deps_asset_t(_X(""), _X(""), version_t(), version_t(), _X("")) { }
+    deps_asset_t() : deps_asset_t(_X(""), _X(""), version_t::empty(), version_t::empty(), _X("")) { }
 
     deps_asset_t(const pal::string_t& name, const pal::string_t& relative_path, const version_t& assembly_version, const version_t& file_version)
         : deps_asset_t(name, relative_path, assembly_version, file_version, _X("")) { }

--- a/src/native/corehost/hostpolicy/deps_format.cpp
+++ b/src/native/corehost/hostpolicy/deps_format.cpp
@@ -404,7 +404,8 @@ void deps_json_t::process_runtime_targets(const json_parser_t::value_t& json, co
                     continue;
                 }
 
-                version_t assembly_version, file_version;
+                version_t assembly_version = version_t::empty();
+                version_t file_version = version_t::empty();
 
                 pal::string_t assembly_version_str = get_optional_property(file.value, _X("assemblyVersion"));
                 if (!assembly_version_str.empty())
@@ -466,7 +467,8 @@ void deps_json_t::process_targets(const json_parser_t::value_t& json, const pal:
             asset_files.reserve(files.MemberCount());
             for (const auto& file : files)
             {
-                version_t assembly_version, file_version;
+                version_t assembly_version = version_t::empty();
+                version_t file_version = version_t::empty();
 
                 pal::string_t assembly_version_str = get_optional_property(file.value, _X("assemblyVersion"));
                 if (assembly_version_str.length() > 0)

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -4,6 +4,7 @@
 #include <set>
 #include <functional>
 #include <cassert>
+#include <utility>
 
 #include <trace.h>
 #include "deps_entry.h"

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -549,8 +549,8 @@ bool deps_resolver_t::resolve_tpa_list(
     // application, then add them to the mix as well.
     for (const auto& additional_deps : m_additional_deps)
     {
-        auto additional_deps_entries = additional_deps->get_entries(deps_entry_t::asset_types::runtime);
-        for (auto entry : additional_deps_entries)
+        const auto& additional_deps_entries = additional_deps->get_entries(deps_entry_t::asset_types::runtime);
+        for (const auto& entry : additional_deps_entries)
         {
             if (!process_entry(m_app_dir, entry, 0))
             {
@@ -665,7 +665,7 @@ void deps_resolver_t::resolve_additional_deps(const pal::char_t* additional_deps
                 std::vector<pal::string_t> deps_dirs;
                 pal::readdir_onlydirectories(additional_deps_path_fx, &deps_dirs);
 
-                for (pal::string_t dir : deps_dirs)
+                for (const pal::string_t& dir : deps_dirs)
                 {
                     fx_ver_t ver;
                     if (fx_ver_t::parse(dir, &ver))
@@ -693,7 +693,7 @@ void deps_resolver_t::resolve_additional_deps(const pal::char_t* additional_deps
                     // The resulting list will be empty if 'additional_deps_path_fx' is not a valid directory path
                     std::vector<pal::string_t> list;
                     pal::readdir(additional_deps_path_fx, _X("*.deps.json"), &list);
-                    for (pal::string_t json_file : list)
+                    for (const pal::string_t& json_file : list)
                     {
                         pal::string_t json_full_path = additional_deps_path_fx;
                         append_path(&json_full_path, json_file.c_str());

--- a/src/native/corehost/hostpolicy/deps_resolver.h
+++ b/src/native/corehost/hostpolicy/deps_resolver.h
@@ -4,6 +4,7 @@
 #ifndef DEPS_RESOLVER_H
 #define DEPS_RESOLVER_H
 
+#include <utility>
 #include <vector>
 
 #include "pal.h"
@@ -51,6 +52,8 @@ struct deps_resolved_asset_t
     pal::string_t resolved_path;
 
 private:
+    // Asset from a deps.json that was resolved to this path. This should outlive any deps_resolved_asset_t.
+    // If null, this entry is not from a deps.json (for example, there is no deps.json) and has no version information.
     const deps_asset_t* m_asset;
 };
 

--- a/src/native/corehost/hostpolicy/deps_resolver.h
+++ b/src/native/corehost/hostpolicy/deps_resolver.h
@@ -24,6 +24,14 @@ struct probe_paths_t
     pal::string_t coreclr;
 };
 
+enum class probe_result_t
+{
+    not_found,
+    bundled,
+    serviced,
+    found
+};
+
 struct deps_resolved_asset_t
 {
     deps_resolved_asset_t(const deps_asset_t& asset, const pal::string_t& resolved_path)
@@ -218,12 +226,11 @@ private:
         std::unordered_set<pal::string_t>* breadcrumb);
 
     // Probe entry in probe configurations and deps dir.
-    bool probe_deps_entry(
+    probe_result_t probe_deps_entry(
         const deps_entry_t& entry,
         const pal::string_t& deps_dir,
         int fx_level,
-        pal::string_t* candidate,
-        bool &found_in_bundle);
+        pal::string_t* candidate);
 
 private:
     const fx_definition_vector_t& m_fx_definitions;

--- a/src/native/corehost/hostpolicy/deps_resolver.h
+++ b/src/native/corehost/hostpolicy/deps_resolver.h
@@ -34,12 +34,24 @@ enum class probe_result_t
 
 struct deps_resolved_asset_t
 {
-    deps_resolved_asset_t(const deps_asset_t& asset, const pal::string_t& resolved_path)
-        : asset(asset)
-        , resolved_path(resolved_path) { }
+    deps_resolved_asset_t(const deps_asset_t* asset, pal::string_t&& resolved_path)
+        : resolved_path(std::move(resolved_path))
+        , m_asset(asset) { }
 
-    deps_asset_t asset;
+    const version_t& assembly_version() const
+    {
+        return m_asset != nullptr ? m_asset->assembly_version : version_t::empty();
+    }
+
+    const version_t& file_version() const
+    {
+        return m_asset != nullptr ? m_asset->file_version : version_t::empty();
+    }
+
     pal::string_t resolved_path;
+
+private:
+    const deps_asset_t* m_asset;
 };
 
 typedef std::unordered_map<pal::string_t, deps_resolved_asset_t> name_to_resolved_asset_map_t;

--- a/src/native/corehost/hostpolicy/version.cpp
+++ b/src/native/corehost/hostpolicy/version.cpp
@@ -11,7 +11,12 @@
 // -- if version_t is an empty value (-1 for all segments) then as_str() returns an empty string
 // -- Different terminology; fx_ver_t(major, minor, patch, build) vs version_t(major, minor, build, revision)
 
-version_t::version_t() : version_t(-1, -1, -1, -1) { }
+/*static*/
+const version_t& version_t::empty()
+{
+    static const version_t s_empty(-1, -1, -1, -1);
+    return s_empty;
+}
 
 version_t::version_t(int major, int minor, int build, int revision)
     : m_major(major)

--- a/src/native/corehost/hostpolicy/version.h
+++ b/src/native/corehost/hostpolicy/version.h
@@ -9,7 +9,6 @@
 
 struct version_t
 {
-    version_t();
     version_t(int major, int minor, int build, int revision);
 
     int get_major() const { return m_major; }
@@ -27,6 +26,8 @@ struct version_t
     bool operator >=(const version_t& b) const;
 
     static bool parse(const pal::string_t& ver, version_t* ver_out);
+
+    static const version_t& empty();
 
 private:
     int m_major;


### PR DESCRIPTION
- Avoid string comparison against servicing directory name for every asset (assembly, native, or resources)
- Avoid copying every `deps_asset_t` asset when building the TPA list

This removes ~1000 allocations for startup of an empty console app (linear based on the number of assemblies the app depends on).

Local runs of staticconsoletemplate on Windows indicated a difference that was within measurement noise range, but it was consistent across 10 runs of 10 iterations each - combined summary:

| Metric | Baseline | Feature | Delta |
|--------|----------|---------|-------|
| Average | 55.77 ms | 55.48 ms | -0.29 ms (-0.5%) |
| Min | 53.28 ms | 53.14 ms | — |
| Max | 57.29 ms | 56.24 ms | — |
| StdDev | 0.50 ms | 0.35 ms | — |
| Rounds Won | 0 | 10 | — |

cc @dotnet/appmodel @AaronRobinsonMSFT 