### PR TITLE
Restructure workflow docs for better navigation

### DIFF
--- a/docs/workflow/README.md
+++ b/docs/workflow/README.md
@@ -1,164 +1,144 @@
 # Workflow Guide
 
-- [Introduction](#introduction)
-- [Important Concepts to Understand](#important-concepts-to-understand)
-  - [Build Configurations](#build-configurations)
-- [Building the Repo](#building-the-repo)
-  - [General Overview](#general-overview)
-  - [Get Started on your Platform and Components](#get-started-on-your-platform-and-components)
-  - [General Recommendations](#general-recommendations)
-- [Testing the Repo](#testing-the-repo)
-  - [Performance Analysis](#performance-analysis)
-- [Warnings as Errors](#warnings-as-errors)
-- [Submitting a PR](#submitting-a-pr)
-- [Triaging Errors in CI](#triaging-errors-in-ci)
+Your guide to building, testing, and contributing to dotnet/runtime.
 
-## Introduction
+## 🚀 Start Here
 
-The runtime repo can be worked with on Windows, Linux, macOS, and FreeBSD. Each platform has its own specific requirements to work properly, and not all architectures are supported for dev work. That said, the builds can target a wider range of platforms beyond the ones mentioned earlier. You can see it as there are always two platforms at play whenever you are working with builds in the runtime repo:
+| I want to... | Go to... |
+|--------------|----------|
+| **Get started** (new contributor) | [Getting Started Guide](getting-started.md) |
+| **Work on Libraries** (most common) | [Libraries Guide](components/libraries.md) |
+| **Work on CoreCLR** | [CoreCLR Guide](components/coreclr.md) |
+| **Work on Mono** | [Mono Guide](components/mono.md) |
+| **Work on Host** | [Host Guide](components/host.md) |
+| **Submit a PR** | [PR Guide](ci/pr-guide.md) |
 
-For WebAssembly-specific development workflows, see [WebAssembly Documentation](wasm-documentation.md).
+## 📚 Documentation Index
 
-- **The Build Platform:** This is the platform of the machine where you cloned the runtime repo and therefore where all your build tools are running on. The following table shows the OS and architecture combinations that we currently support, as well as links to each OS's requirements doc. If you are using WSL directly (i.e. not Docker), then follow the Linux requirements doc.
+### Setup & Environment
 
-| Chip  | Windows  | Linux    | macOS    | FreeBSD  |
-| :---: | :------: | :------: | :------: | :------: |
-| x64   | &#x2714; | &#x2714; | &#x2714; | &#x2714; |
-| x86   | &#x2714; |          |          |          |
-| Arm32 |          | &#x2714; |          |          |
-| Arm64 | &#x2714; | &#x2714; | &#x2714; |          |
-|       | [Requirements](requirements/windows-requirements.md) | [Requirements](requirements/linux-requirements.md) | [Requirements](requirements/macos-requirements.md) | [Requirements](requirements/freebsd-requirements.md)
+| Topic | Description |
+|-------|-------------|
+| [Getting Started](getting-started.md) | First-time setup and first build |
+| [Platform Requirements](platforms/README.md) | OS-specific prerequisites |
+| [Development Environments](environments/README.md) | Codespaces, Docker, IDE setup |
 
-- **The Target Platform:** This is the platform you are building the artifacts for, i.e. the platform you intend to run your builds on.
+### Building
 
-The *Build Platform* and the *Target Platform* can be either the same as or different from each other. The former scenario is straightforward, as you will likely be doing all the work on the same machine. In the latter scenario, the process is called *cross-compiling*. There are certain workflows that require you to follow this process, as it is not possible to build the repo directly on those platforms (e.g., Web Assembly (WASM), Browser, Mobiles). The full instructions on how to work with this are detailed in the building docs later on.
+| Topic | Description |
+|-------|-------------|
+| [Building Overview](building/README.md) | Build commands and configurations |
+| [Building CoreCLR](building/coreclr/README.md) | CoreCLR-specific build details |
+| [Building Libraries](building/libraries/README.md) | Libraries-specific build details |
+| [Building Mono](building/mono/README.md) | Mono-specific build details |
 
-Additionally, keep in mind that cloning the full history of this repo takes roughly 400-500 MB of network transfer, inflating to a repository that can consume somewhere between 1 to 1.5 GB. A build of the repo can take somewhere between 10 and 20 GB of space for a single OS and Platform configuration depending on the portions of the product built. This might increase over time, so consider this to be a minimum bar for working with this codebase.
+### Testing
 
-The runtime repo consists of three major components:
+| Topic | Description |
+|-------|-------------|
+| [Testing Overview](testing/README.md) | Test commands and filtering |
+| [Testing CoreCLR](testing/coreclr/testing.md) | Runtime tests |
+| [Testing Libraries](testing/libraries/testing.md) | Library unit tests |
+| [Testing Mono](testing/mono/testing.md) | Mono-specific tests |
+| [Testing Host](testing/host/testing.md) | Host activation tests |
 
-- The Runtimes (CoreCLR and Mono)
-- The Libraries
-- The Hosts and Installers
+### Debugging
 
-You can run your builds from a regular terminal, from the root of the repository. Sudo and administrator privileges are not needed for this.
+| Topic | Description |
+|-------|-------------|
+| [Debugging Overview](debugging/README.md) | Debugging tools and setup |
+| [Debugging CoreCLR](debugging/coreclr/debugging-runtime.md) | Native runtime debugging |
+| [Debugging Libraries](debugging/libraries/) | Managed code debugging |
+| [Editing and Debugging](editing-and-debugging.md) | Visual Studio setup |
 
-- For instructions on how to edit code and make changes, see [Editing and Debugging](/docs/workflow/editing-and-debugging.md).
-- For instructions on how to debug CoreCLR, see [Debugging CoreCLR](/docs/workflow/debugging/coreclr/debugging-runtime.md).
-- For instructions on using GitHub Codespaces, see [Codespaces](/docs/workflow/Codespaces.md).
+### CI & Contributing
 
-## Important Concepts to Understand
+| Topic | Description |
+|-------|-------------|
+| [CI Overview](ci/README.md) | CI system and workflows |
+| [PR Guide](ci/pr-guide.md) | Creating and managing PRs |
+| [Failure Analysis](ci/failure-analysis.md) | Investigating CI failures |
 
-The following sections describe some important terminology to keep in mind while working with runtime repo builds. For more information, and a complete list of acronyms and their meanings, check out the glossary [over here](/docs/project/glossary.md).
+### Specialized Topics
+
+| Topic | Description |
+|-------|-------------|
+| [WebAssembly](wasm-documentation.md) | WASM development guide |
+| [NativeAOT](building/coreclr/nativeaot.md) | Ahead-of-time compilation |
+| [Trimming](trimming/) | IL trimming configuration |
+
+## Quick Reference
+
+### Build Commands
+
+```bash
+# Full build (first time)
+./build.sh                    # Linux/macOS
+./build.cmd                   # Windows
+
+# Component builds
+./build.sh clr                # CoreCLR only
+./build.sh libs               # Libraries only
+./build.sh mono               # Mono only
+./build.sh clr+libs           # CoreCLR + Libraries
+
+# With configuration
+./build.sh clr+libs -rc Release -lc Debug
+```
+
+### Test Commands
+
+```bash
+# Library tests
+cd src/libraries/System.Foo/tests
+dotnet build /t:Test
+
+# CoreCLR tests
+./src/tests/build.sh generatelayoutonly
+./src/tests/run.sh
+```
 
 ### Build Configurations
 
-To work with the runtime repo, there are three supported configurations (one is *CoreCLR* exclusive) that define how your build will behave:
+| Configuration | Flag | Description |
+|---------------|------|-------------|
+| Debug | `-c Debug` | Development, full debugging (default) |
+| Release | `-c Release` | Optimized, performance testing |
+| Checked | `-c Checked` | Optimized with assertions (CoreCLR only) |
 
-- **Debug**: Non-optimized code. Asserts are enabled. This configuration runs the slowest. As its name suggests, it provides the best experience for debugging the product.
-- **Checked** *(CoreCLR runtime exclusive)*: Optimized code. Asserts are enabled.
-- **Release**: Optimized code. Asserts are disabled. Runs at the best speed, and is most suitable for performance profiling. This will impact the debugging experience however, due to compiler optimizations that make understanding what the debugger shows difficult, relative to the source code.
+### Key Subsets
 
-### Build Components
+| Subset | Description |
+|--------|-------------|
+| `clr` | CoreCLR runtime + CoreLib |
+| `mono` | Mono runtime + CoreLib |
+| `libs` | All libraries |
+| `host` | .NET host and installers |
+| `packs` | Shipping packages |
 
-- **Runtime**: The execution engine for managed code. There are two different implementations, both written in C or C++:
-  - *CoreCLR*: The comprehensive execution engine originally born from .NET Framework. Its source code lives under the [src/coreclr](/src/coreclr) subtree.
-  - *Mono*: A slimmer runtime than CoreCLR, originally born open-source to bring .NET and C# support to non-Windows platforms. Due to its lightweight nature, it is less affected in terms of speed when working with the *Debug* configuration. Its source code lives under the [src/mono](/src/mono) subtree.
+## Performance
 
-- **CoreLib** *(also known as System.Private.CoreLib)*: The lowest level managed library. It is directly related to the runtime, which means it must be built in the matching configuration (e.g. Building a *Debug* runtime means *CoreLib* must also be in *Debug*). The `clr` subset includes both, the *Runtime* and the *CoreLib* components, so you usually don't have to worry about that. There are, however, some special cases where you might need to build the components separately. The runtime agnostic code for this library can be found at [src/libraries/System.Private.CoreLib/src](/src/libraries/System.Private.CoreLib/src/README.md).
+- [Benchmarking Workflow](https://github.com/dotnet/performance/blob/master/docs/benchmarking-workflow-dotnet-runtime.md)
+- [Profiling Workflow](https://github.com/dotnet/performance/blob/master/docs/profiling-workflow-dotnet-runtime.md)
 
-- **Libraries**: The bulk of dll's providing the rest of the functionality to the runtime. The libraries can be built in their own configuration, regardless of which one the runtime is using. Their source code lives under the [src/libraries](/src/libraries) subtree.
+## Tips
 
-## Building the Repo
-
-The main script that will be in charge of most of the building you might want to do is the `build.sh`, or `build.cmd` on Windows, located at the root of the repo. This script receives as arguments the subset(s) you might want to build, as well as multiple parameters to configure your build, such as the configuration, target operating system, target architecture, and so on.
-
-**NOTE:** If you plan on using Docker to work on the runtime repo, read [this doc](/docs/workflow/using-docker.md) first. It explains how to set up, as well as the images and containers to prepare you to follow the building and testing instructions in the next sections.
-
-### General Overview
-
-Running the script (`build.sh`/`build.cmd`) with no arguments will build the whole repo in *Debug* configuration, for the OS and architecture of your machine. A typical dev workflow only one or two components at a time, so it is more efficient to just build those. This is done by means of the `-subset` flag. For example, for CoreCLR, it would be:
-
-```bash
-./build.sh -subset clr
-```
-
-The main subset values are:
-
-- `Clr`: The full CoreCLR runtime, which consists of the runtime itself and the CoreLib components.
-- `Libs`: All the libraries components, excluding their tests. This includes the libraries' native parts, refs, source assemblies, and their packages and test infrastructure.
-- `Packs`: The shared framework packs, archives, bundles, installers, and the framework pack tests.
-- `Host`: The .NET hosts, packages, hosting libraries, and their tests.
-- `Mono`: The Mono runtime and its CoreLib.
-
-Some subsets are subsequently divided into smaller pieces, giving you more flexibility as to what to build/rebuild depending on what you're working on. For a full list of all the supported subsets, run the build script, passing `help` as the argument to the `subset` flag.
-
-It is also possible to build more than one subset under the same command-line. In order to do this, you have to link them together with a `+` sign in the value you're passing to `-subset`. For example, to build both, CoreCLR and Libraries in Release configuration, the command-line would look like this:
+### Disable Warnings-as-Errors
 
 ```bash
-./build.sh -subset clr+libs -configuration Release
+export TreatWarningsAsErrors=false   # Linux/macOS
+set TreatWarningsAsErrors=false      # Windows
 ```
 
-If you require to use different configurations for different subsets, there are some specific flags you can use:
-
-- `-runtimeConfiguration (-rc)`: The CoreCLR build configuration
-- `-librariesConfiguration (-lc)`: The Libraries build configuration
-- `-hostConfiguration (-hc)`: The Host build configuration
-
-The behavior of the script is that the general configuration flag `-c` affects all subsets that have not been qualified with a more specific flag, as well as the subsets that don't have a specific flag supported, like `packs`. For example, the following command-line would build the libraries in *Release* mode and the runtime in *Debug* mode:
+### Get Help
 
 ```bash
-./build.sh -subset clr+libs -configuration Release -runtimeConfiguration Debug
+./build.sh -h                 # Build help
+./build.sh -subset help       # List all subsets
 ```
 
-In this example, the `-lc` flag was not specified, so `-c` qualifies `libs`. In the first example, only `-c` was passed, so it qualifies both, `clr` and `libs`.
+## See Also
 
-As an extra note here, if your first argument to the build script are the subsets, you can omit the `-subset` flag altogether. Additionally, several of the supported flags also include a shorthand version (e.g. `-c` for `-configuration`). Run the script with `-h` or `-help` to get an extensive overview on all the supported flags to customize your build, including their shorthand forms, as well as a wider variety of examples.
-
-**NOTE:** On non-Windows systems, the longhand versions of the flags can be passed with either single `-` or double `--` dashes.
-
-### Get Started on your Platform and Components
-
-Now that you've got the general idea on how to get started, it is important to mention that, while the procedure is very similar among platforms and subsets, each component has its own technicalities and details, as explained in their own specific docs:
-
-**Component Specifics:**
-
-- [CoreCLR](/docs/workflow/building/coreclr/README.md)
-- [Libraries](/docs/workflow/building/libraries/README.md)
-- [Mono](/docs/workflow/building/mono/README.md)
-
-**NOTE:** *NativeAOT* is part of CoreCLR, but it has its own specifics when it comes to building. We have a separate doc dedicated to it [over here](/docs/workflow/building/coreclr/nativeaot.md).
-
-### General Recommendations
-
-- If you're working with the runtimes, then the usual recommendation is to build everything in *Debug* mode. That said, if you know you won't be debugging the libraries source code but will need them (e.g. for a *Core_Root* build), then building the libraries on *Release* instead will provide a more productive experience.
-- The counterpart to the previous point: When you are working in libraries. In this case, it is recommended to build the runtime on *Release* and the libraries on *Debug*.
-- If you're working on *CoreLib*, then you probably want to try to get the job done with a *Release* runtime, and fall back to *Debug* if you need to.
-
-## Testing the Repo
-
-Building the components of the repo is just part of the experience. The runtime repo also includes vast test suites you can run to ensure your changes work properly as expected and don't inadvertently break something else. Each component has its own methodologies to run their tests, which are explained in their own specific docs:
-
-- [CoreCLR](/docs/workflow/testing/coreclr/testing.md)
-  - [NativeAOT](/docs/workflow/building/coreclr/nativeaot.md#running-tests)
-- [Libraries](/docs/workflow/testing/libraries/testing.md)
-- [Mono](/docs/workflow/testing/mono/testing.md)
-
-### Performance Analysis
-
-Fixing bugs and adding new features aren't the only things to work on in the runtime repo. We also have to ensure performance is kept as optimal as can be, and that is done through benchmarking and profiling. If you're interested in conducting these kinds of analysis, the following links will show you the usual workflow you can follow:
-
-* [Benchmarking Workflow for dotnet/runtime repository](https://github.com/dotnet/performance/blob/master/docs/benchmarking-workflow-dotnet-runtime.md)
-* [Profiling Workflow for dotnet/runtime repository](https://github.com/dotnet/performance/blob/master/docs/profiling-workflow-dotnet-runtime.md)
-
-## Warnings as Errors
-
-The repo build treats warnings as errors, including many code-style warnings. Dealing with warnings when you're in the middle of making changes can be annoying (e.g. unused variable that you plan to use later). To disable treating warnings as errors, set the `TreatWarningsAsErrors` environment variable to `false` before building. This variable will be respected by both the `build.sh`/`build.cmd` root build scripts and builds done with `dotnet build` or Visual Studio. Some people may prefer setting this environment variable globally in their machine settings.
-
-## Submitting a PR
-
-Before submitting a PR, make sure to review the [contribution guidelines](/CONTRIBUTING.md). After you get familiarized with them, please read the [PR guide](/docs/workflow/ci/pr-guide.md) to find more information about tips and conventions around creating a PR, getting it reviewed, and understanding the CI results.
-
-## Triaging Errors in CI
-
-Given the size of the runtime repository, flaky tests are expected to some degree. There are a few mechanisms we use to help with the discoverability of widely impacting issues. We also have a regular procedure that ensures issues get properly tracked and prioritized. You can find more information on [triaging failures in CI](/docs/workflow/ci/failure-analysis.md).
+- [Project Glossary](../project/glossary.md) - Terms and acronyms
+- [Contribution Guidelines](/CONTRIBUTING.md) - How to contribute
+- [GitHub Discussions](https://github.com/dotnet/runtime/discussions) - Ask questions

--- a/docs/workflow/building/README.md
+++ b/docs/workflow/building/README.md
@@ -1,0 +1,80 @@
+# Building the Runtime
+
+Guides for building the different components of dotnet/runtime.
+
+## Quick Start
+
+For most developers, start with the [Getting Started Guide](../getting-started.md).
+
+## By Component
+
+| Component | Guide | Description |
+|-----------|-------|-------------|
+| **CoreCLR** | [Building CoreCLR](coreclr/README.md) | The primary .NET runtime |
+| **Libraries** | [Building Libraries](libraries/README.md) | Base Class Library (BCL) |
+| **Mono** | [Building Mono](mono/README.md) | Mobile/WASM/embedded runtime |
+
+## Common Build Commands
+
+```bash
+# Build everything
+./build.sh
+
+# CoreCLR only
+./build.sh clr
+
+# Libraries only
+./build.sh libs
+
+# Mono only
+./build.sh mono
+
+# Combine subsets
+./build.sh clr+libs
+```
+
+## Build Configurations
+
+| Configuration | Flag | Use Case |
+|---------------|------|----------|
+| Debug | `-c Debug` | Development (default) |
+| Release | `-c Release` | Performance testing |
+| Checked | `-c Checked` | Testing with assertions (CoreCLR) |
+
+Per-component configuration:
+
+```bash
+# Release CoreCLR, Debug libraries
+./build.sh clr+libs -rc Release -lc Debug
+```
+
+## Platform-Specific Builds
+
+| Topic | Guide |
+|-------|-------|
+| Cross-compilation (CoreCLR) | [Cross-Building CoreCLR](coreclr/cross-building.md) |
+| Cross-compilation (Libraries) | [Cross-Building Libraries](libraries/cross-building.md) |
+| WebAssembly | [WebAssembly Instructions](libraries/webassembly-instructions.md) |
+| Android | [Android Build](coreclr/android.md) |
+| iOS | [iOS Build](coreclr/ios.md) |
+| FreeBSD | [FreeBSD Build](coreclr/freebsd-instructions.md) |
+| NativeAOT | [NativeAOT Build](coreclr/nativeaot.md) |
+
+## Build Help
+
+Get full help on build options:
+
+```bash
+./build.sh -h
+./build.sh -subset help
+```
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Missing prerequisites | Check [Platform Requirements](../platforms/README.md) |
+| Out of disk space | Builds need 10-20 GB |
+| Build timeout | Full builds take 30-40 minutes |
+
+Build logs are in: `artifacts/log/`

--- a/docs/workflow/ci/README.md
+++ b/docs/workflow/ci/README.md
@@ -1,0 +1,49 @@
+# CI and Pull Requests
+
+Guides for working with the dotnet/runtime CI system and contributing changes.
+
+## Contributing
+
+| Guide | Description |
+|-------|-------------|
+| [PR Guide](pr-guide.md) | How to create and manage pull requests |
+| [Contribution Guidelines](/CONTRIBUTING.md) | Repository contribution policies |
+
+## CI System
+
+| Guide | Description |
+|-------|-------------|
+| [Pipelines Overview](pipelines-overview.md) | How the CI pipelines are structured |
+| [Failure Analysis](failure-analysis.md) | How to investigate CI failures |
+| [Triaging Failures](triaging-failures.md) | Process for handling flaky tests |
+| [CoreCLR CI Health](coreclr-ci-health.md) | CoreCLR-specific CI status |
+
+## Test Management
+
+| Guide | Description |
+|-------|-------------|
+| [Disabling Tests](disabling-tests.md) | How to temporarily disable flaky tests |
+
+## Quick Reference
+
+### Before Submitting a PR
+
+1. Build locally: `./build.sh clr+libs`
+2. Run relevant tests
+3. Review [contribution guidelines](/CONTRIBUTING.md)
+4. Read the [PR guide](pr-guide.md)
+
+### When CI Fails
+
+1. Check if it's a known issue in [failure analysis](failure-analysis.md)
+2. Look at the build logs
+3. Try to reproduce locally
+4. If flaky, see [triaging failures](triaging-failures.md)
+
+### Understanding CI Results
+
+- ✅ Green check: All tests passed
+- ❌ Red X: Build or test failure
+- 🟡 Yellow dot: Running or pending
+
+Check the PR's "Checks" tab for details.

--- a/docs/workflow/components/coreclr.md
+++ b/docs/workflow/components/coreclr.md
@@ -1,0 +1,213 @@
+# CoreCLR Development Guide
+
+This guide covers everything you need to build, test, and debug CoreCLR - the primary .NET runtime.
+
+**Source location:** `src/coreclr/`
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Build CoreCLR | `./build.sh clr` |
+| Build CoreCLR + Libraries | `./build.sh clr+libs` |
+| Build Core_Root for testing | `./src/tests/build.sh generatelayoutonly` |
+| Run all CoreCLR tests | `./src/tests/run.sh` |
+
+## Building
+
+### Basic Build
+
+```bash
+./build.sh -subset clr
+```
+
+This builds:
+- The CoreCLR runtime (`libcoreclr.so`/`coreclr.dll`)
+- System.Private.CoreLib
+- The `corerun` host executable
+
+### Build Configurations
+
+| Configuration | Use Case | Flag |
+|---------------|----------|------|
+| **Debug** | Development (default) | `-c Debug` |
+| **Checked** | Testing with assertions | `-c Checked` |
+| **Release** | Performance testing | `-c Release` |
+
+**Recommendation:** Use Checked for running tests (faster than Debug, keeps assertions).
+
+### Build Outputs
+
+Binaries are placed in: `artifacts/bin/coreclr/<OS>.<Arch>.<Config>/`
+
+Key files:
+- `corerun` / `corerun.exe` - Host executable
+- `libcoreclr.so` / `coreclr.dll` - The runtime
+- `System.Private.CoreLib.dll` - Core managed library
+
+### Building for Testing
+
+To run CoreCLR tests, you need both the runtime and libraries:
+
+```bash
+# Build runtime (Checked) + libraries (Release)
+./build.sh clr+libs -rc Checked -lc Release
+```
+
+Then generate the Core_Root (test execution environment):
+
+```bash
+./src/tests/build.sh generatelayoutonly
+```
+
+Core_Root location: `artifacts/tests/coreclr/<OS>.<Arch>.<Config>/Tests/Core_Root`
+
+## Testing
+
+### Building Tests
+
+```bash
+cd src/tests
+./build.sh checked        # Builds tests for Checked runtime
+```
+
+Build specific tests:
+
+```bash
+# Single test
+./build.sh -test:JIT/Methodical/Test.csproj
+
+# Directory of tests
+./build.sh -dir:JIT/Methodical
+
+# Subtree of tests
+./build.sh -tree:JIT
+```
+
+### Running Tests
+
+Run all tests:
+
+```bash
+./src/tests/run.sh checked
+```
+
+Run a single test:
+
+```bash
+export CORE_ROOT=/path/to/Core_Root
+./artifacts/tests/coreclr/<OS>.<Arch>.<Config>/JIT/Test/Test.sh
+```
+
+### Test Priorities
+
+By default, only Priority 0 tests build. Include Priority 1:
+
+```bash
+./src/tests/build.sh -priority=1
+```
+
+### Test Results
+
+- HTML report: `artifacts/log/TestRun_<Arch>_<Config>.html`
+- Failed tests: `artifacts/log/TestRunResults_<OS>_<Arch>_<Config>.err`
+- Individual results: `artifacts/tests/coreclr/<OS>.<Arch>.<Config>/Reports/`
+
+## Debugging
+
+### Visual Studio (Windows)
+
+1. Build with the `-msbuild` flag or run:
+   ```cmd
+   build.cmd -vs CoreCLR.slnx -a x64 -c Debug
+   ```
+2. Set INSTALL as startup project
+3. Configure debugging properties:
+   - Command: `$(SolutionDir)\..\..\..\bin\coreclr\windows.$(Platform).$(Configuration)\corerun.exe`
+   - Arguments: `YourApp.dll`
+   - Working Directory: Path to Core_Root
+   - Environment: `CORE_LIBRARIES=<path to libraries>`
+
+### LLDB (Linux/macOS)
+
+```bash
+lldb -- /path/to/corerun /path/to/app.dll
+
+# In LLDB:
+process handle -s false SIGUSR1
+breakpoint set -n coreclr_execute_assembly
+process launch -s
+```
+
+For detailed debugging instructions, see [Debugging CoreCLR](debugging/coreclr/debugging-runtime.md).
+
+### Debugging with SOS
+
+SOS is the debugger extension for .NET. Install it from the [diagnostics repo](https://github.com/dotnet/diagnostics).
+
+Common commands:
+- `clrstack` - Show managed call stack
+- `dumpobj` - Dump object contents
+- `VerifyHeap` - Verify GC heap integrity
+
+### macOS Debug Symbols
+
+For better LLDB experience on macOS, generate `.dSYM` bundles:
+
+```bash
+./build.sh clr -cmakeargs "-DCLR_CMAKE_APPLE_DYSM=TRUE"
+```
+
+## Common Tasks
+
+### Rebuilding Just CoreLib
+
+```bash
+./build.sh clr.corelib+clr.nativecorelib
+```
+
+### Cross-Compilation
+
+| From | To | Supported |
+|------|-----|-----------|
+| Windows x64 | x86, Arm64 | ✓ |
+| Linux x64 | Arm32, Arm64 | ✓ |
+| macOS x64/Arm64 | Arm64/x64 | ✓ |
+
+See [Cross-Building CoreCLR](building/coreclr/cross-building.md).
+
+### Using Native Sanitizers
+
+```bash
+./build.sh clr -fsanitize address
+```
+
+### Building with Different Build Drivers
+
+```bash
+# Use MSBuild on Windows (instead of Ninja)
+./build.cmd clr -msbuild
+
+# Use Ninja on Linux/macOS (instead of Make)
+./build.sh clr -ninja
+```
+
+## Specialized Builds
+
+| Target | Documentation |
+|--------|---------------|
+| NativeAOT | [NativeAOT Guide](building/coreclr/nativeaot.md) |
+| WebAssembly | [WASM Guide](building/coreclr/wasm.md) |
+| Android | [Android Guide](building/coreclr/android.md) |
+| iOS | [iOS Guide](building/coreclr/ios.md) |
+| FreeBSD | [FreeBSD Guide](building/coreclr/freebsd-instructions.md) |
+
+## Deep Dives
+
+| Topic | Link |
+|-------|------|
+| Building details | [Building CoreCLR](building/coreclr/README.md) |
+| Testing details | [Testing CoreCLR](testing/coreclr/testing.md) |
+| Debugging details | [Debugging CoreCLR](debugging/coreclr/debugging-runtime.md) |
+| JIT debugging | [Debugging AOT Compilers](debugging/coreclr/debugging-aot-compilers.md) |
+| PAL tests (Unix) | [Testing Guide](testing/coreclr/testing.md#pal-tests-macos-and-linux-only) |

--- a/docs/workflow/components/host.md
+++ b/docs/workflow/components/host.md
@@ -1,0 +1,164 @@
+# Host Development Guide
+
+This guide covers building, testing, and debugging the .NET host components - the executables and libraries that launch and configure .NET applications.
+
+**Source location:** `src/native/corehost/`, `src/installer/`
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Build host | `./build.sh host -rc Release -lc Release` |
+| Build host + tests | `./build.sh host.tests -rc Release -lc Release` |
+| Run host tests | `./build.sh host.tests -test -rc Release -lc Release` |
+
+## What are the Host Components?
+
+The host components include:
+
+- **dotnet** - The main CLI executable
+- **apphost** - Per-app executable template
+- **hostfxr** - Framework resolution logic
+- **hostpolicy** - Runtime configuration and startup
+
+## Building
+
+### Prerequisites
+
+First, build the runtime and libraries:
+
+```bash
+./build.sh clr+libs -c Release
+```
+
+### Building the Host
+
+```bash
+./build.sh host -runtimeConfiguration Release -librariesConfiguration Release
+```
+
+Or using shorthand:
+
+```bash
+./build.sh host -rc Release -lc Release
+```
+
+### Build Outputs
+
+Host binaries are placed in: `artifacts/bin/win-x64.Release/corehost/`
+
+The Visual Studio solution is at: `artifacts/obj/win-<Arch>.<Config>/corehost/ide/corehost.slnx`
+
+Open it with:
+
+```cmd
+build.cmd -vs corehost.slnx -a x64 -c Release
+```
+
+## Testing
+
+### Building Tests
+
+Tests are included in the `host` subset by default. Build just the tests:
+
+```bash
+./build.sh host.tests -rc Release -lc Release
+```
+
+### Running All Tests
+
+```bash
+./build.sh host.tests -test -rc Release -lc Release
+```
+
+Without rebuilding:
+
+```bash
+./build.sh host.tests -test -testnobuild
+```
+
+### Running Specific Tests
+
+```bash
+dotnet test artifacts/bin/HostActivation.Tests/Debug/net11.0/HostActivation.Tests.dll \
+  --filter "category!=failing"
+```
+
+Filter to specific tests:
+
+```bash
+dotnet test artifacts/bin/HostActivation.Tests/Debug/net11.0/HostActivation.Tests.dll \
+  --filter "DependencyResolution&category!=failing"
+```
+
+### Test Context
+
+Host tests require:
+
+1. Pre-built test project output
+2. Product binaries in .NET install layout
+3. TestContextVariables.txt configuration
+
+These are created by the `host.pretest` subset (included in `host`).
+
+To update test context without running tests:
+
+```bash
+./build.sh host.pretest
+
+# Then for a specific test project:
+dotnet build src/installer/tests/HostActivation.Tests \
+  -t:SetupTestContextVariables \
+  -p:RuntimeConfiguration=Release \
+  -p:LibrariesConfiguration=Release
+```
+
+## Debugging
+
+### Visual Studio
+
+1. Open the solution:
+   ```cmd
+   build.cmd -vs Microsoft.DotNet.CoreSetup -rc Release -lc Release
+   ```
+
+2. Set your test project as startup project
+3. Debug as normal
+
+### Investigating Test Failures
+
+Test results are in: `artifacts/TestResults/`
+
+Tests launch separate processes (dotnet, apphost) and validate output. On failure, they report:
+- The file path of the launched executable
+- Command-line arguments
+- Environment variables
+
+### Preserving Test Artifacts
+
+By default, test artifacts are deleted after tests complete. To keep them:
+
+```bash
+export PRESERVE_TEST_RUNS=1
+./build.sh host.tests -test
+```
+
+This helps with debugging by preserving the exact test setup.
+
+## Common Tasks
+
+### Using apphost
+
+See [Using apphost](testing/host/using-apphost.md) for testing with custom app hosts.
+
+### Testing with Your Build
+
+See [Using Your Build with Installed SDK](testing/using-your-build-with-installed-sdk.md).
+
+## Deep Dives
+
+| Topic | Link |
+|-------|------|
+| Testing details | [Testing Host](testing/host/testing.md) |
+| Host design | [Host Components Design](../design/features/host-components.md) |
+| Using dev packages | [Dev Shipping Packages](testing/using-dev-shipping-packages.md) |

--- a/docs/workflow/components/libraries.md
+++ b/docs/workflow/components/libraries.md
@@ -1,0 +1,191 @@
+# Libraries Development Guide
+
+This guide covers everything you need to build, test, and debug the .NET libraries (the BCL - Base Class Library).
+
+**Source location:** `src/libraries/`
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Build all libraries | `./build.sh libs` |
+| Build + test one library | `cd src/libraries/System.Foo/tests && dotnet build /t:Test` |
+| Run all library tests | `./build.sh libs.tests -test` |
+
+## Building
+
+### First-Time Setup
+
+Before working on libraries, build the runtime they'll run on:
+
+```bash
+# Build CoreCLR (Release) + Libraries (Debug) - recommended setup
+./build.sh clr+libs -rc Release
+```
+
+### Building a Single Library
+
+Navigate to the library and build:
+
+```bash
+cd src/libraries/System.Collections
+dotnet build
+```
+
+Or from repo root:
+
+```bash
+./build.sh -projects src/libraries/*/System.Collections.slnx
+```
+
+### Building All Libraries
+
+```bash
+./build.sh libs
+```
+
+### Build Options
+
+| Flag | Description |
+|------|-------------|
+| `-c Release` | Build in Release mode |
+| `-arch x86` | Build for x86 architecture |
+| `-os linux` | Build for Linux |
+| `/p:RuntimeFlavor=Mono` | Build against Mono instead of CoreCLR |
+
+### Iterating on System.Private.CoreLib
+
+When you change `System.Private.CoreLib`, rebuild it and update the test host:
+
+```bash
+./build.sh clr.corelib+clr.nativecorelib+libs.pretest -rc Release
+```
+
+For Mono:
+
+```bash
+./build.sh mono.corelib+libs.pretest
+```
+
+## Testing
+
+### Testing a Single Library
+
+```bash
+cd src/libraries/System.Collections/tests
+dotnet build /t:Test
+```
+
+### Filtering Tests
+
+Run specific test class:
+
+```bash
+dotnet build /t:Test /p:XUnitOptions="-class Test.ClassUnderTests"
+```
+
+Run specific test method:
+
+```bash
+dotnet build /t:Test /p:XUnitOptions="-method Namespace.Class.Method"
+```
+
+### Running Outer Loop Tests
+
+Outer loop tests are slower but more comprehensive:
+
+```bash
+dotnet build /t:Test /p:Outerloop=true
+```
+
+### Testing All Libraries
+
+```bash
+./build.sh libs.tests -test -c Release
+```
+
+### Speeding Up Test Iteration
+
+Skip rebuild when code hasn't changed:
+
+```bash
+dotnet build /t:Test /p:testnobuild=true --no-restore
+```
+
+### Test Results
+
+Test logs are at: `artifacts/bin/System.Foo.Tests/Debug/net11.0/testResults.xml`
+
+## Debugging
+
+### Visual Studio (Windows)
+
+1. Open the library's solution file (`.slnx`)
+2. Set the test project as startup project
+3. Debug as normal
+
+**Note:** Starting with VS 2022 17.5, you may need to disable signature validation for local builds. See [Debugging CoreCLR](debugging/coreclr/debugging-runtime.md#resolving-signature-validation-errors-in-visual-studio).
+
+### VS Code
+
+See [Debugging with VS Code](debugging/libraries/debugging-vscode.md) for detailed setup.
+
+### Debugging on Unix
+
+See [Unix Debugging Instructions](debugging/libraries/unix-instructions.md).
+
+## Common Tasks
+
+### Adding a New Test
+
+Add tests to existing test files when possible. If creating a new test file:
+
+1. Add it to the appropriate test project under `tests/`
+2. Follow existing naming conventions
+3. Use `[Fact]` for simple tests, `[Theory]` for parameterized tests
+
+### Updating Reference Assemblies
+
+When adding new APIs, update the reference source:
+
+```bash
+cd src/libraries/System.Foo/ref
+dotnet build /t:GenerateReferenceSource
+```
+
+See [Updating Reference Source](../../coding-guidelines/updating-ref-source.md).
+
+### Building Packages
+
+```bash
+./build.sh libs
+dotnet pack src/libraries/System.Foo/src/ -c Release
+```
+
+### API Compatibility Errors
+
+If you see API compatibility errors and they're expected (e.g., updating preview APIs):
+
+```bash
+dotnet pack /p:ApiCompatGenerateSuppressionFile=true
+```
+
+## Platform-Specific Development
+
+### WebAssembly
+
+See [WebAssembly Libraries](building/libraries/webassembly-instructions.md).
+
+### Android/iOS
+
+See [Testing on Mobile](testing/libraries/testing-android.md) and [Testing on Apple](testing/libraries/testing-apple.md).
+
+## Deep Dives
+
+| Topic | Link |
+|-------|------|
+| Building details | [Building Libraries](building/libraries/README.md) |
+| Testing details | [Testing Libraries](testing/libraries/testing.md) |
+| Code coverage | [Code Coverage](building/libraries/code-coverage.md) |
+| Cross-building | [Cross-Building](building/libraries/cross-building.md) |
+| Project guidelines | [Project Guidelines](../../coding-guidelines/project-guidelines.md) |

--- a/docs/workflow/components/mono.md
+++ b/docs/workflow/components/mono.md
@@ -1,0 +1,220 @@
+# Mono Development Guide
+
+This guide covers everything you need to build, test, and debug the Mono runtime - optimized for mobile, WebAssembly, and embedded scenarios.
+
+**Source location:** `src/mono/`
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Build Mono + Libraries | `./build.sh mono+libs` |
+| Build Mono only | `./build.sh mono` |
+| Run library tests on Mono | `dotnet build /t:Test /p:RuntimeFlavor=mono` |
+
+## Building
+
+### First-Time Setup
+
+Build Mono with the libraries it needs:
+
+```bash
+./build.sh mono+libs
+```
+
+### Building Mono Only
+
+After the initial build, iterate on just Mono:
+
+```bash
+./build.sh mono
+```
+
+Skip package restore for faster builds:
+
+```bash
+./build.sh mono --build
+```
+
+### Build for Testing
+
+To run library tests with your Mono changes:
+
+```bash
+./build.sh mono+libs.pretest
+```
+
+### Build Outputs
+
+Binaries are placed in: `artifacts/bin/mono/<OS>.<Arch>.<Config>/`
+
+### Useful Build Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `/p:MonoEnableLLVM=true` | Build with LLVM JIT |
+| `/p:MonoLLVMDir=path` | Use custom LLVM build |
+| `/p:DisableCrossgen=true` | Skip installer build (faster) |
+| `/p:KeepNativeSymbols=true` | Keep symbols for debugging |
+
+Example with LLVM:
+
+```bash
+./build.sh mono /p:MonoEnableLLVM=true
+```
+
+## Testing
+
+### Library Tests on Desktop Mono
+
+```bash
+cd src/libraries/System.Foo/tests
+dotnet build /t:Test /p:RuntimeFlavor=mono
+```
+
+Or use the Makefile:
+
+```bash
+cd src/mono
+make run-tests-corefx-System.Runtime
+```
+
+### Runtime Tests on Desktop Mono
+
+1. Build the test host:
+   ```bash
+   ./build.sh clr.hosts -c Release
+   ```
+
+2. Build the tests:
+   ```bash
+   cd src/tests
+   ./build.sh mono release
+   ```
+
+3. Run all tests:
+   ```bash
+   ./run.sh Release
+   ```
+
+4. Run a single test:
+   ```bash
+   ./artifacts/tests/coreclr/<OS>.<Arch>.Release/JIT/Test/Test.sh \
+     -coreroot=$(pwd)/artifacts/tests/coreclr/<OS>.<Arch>.Release/Tests/Core_Root
+   ```
+
+### Debugging Tests with LLDB
+
+```bash
+./artifacts/tests/coreclr/<OS>.<Arch>.Release/JIT/Test/Test.sh \
+  -coreroot=$(pwd)/artifacts/tests/coreclr/<OS>.<Arch>.Release/Tests/Core_Root \
+  -debug=/usr/bin/lldb
+```
+
+In LLDB, add Mono symbols:
+
+```
+add-dsym <CORE_ROOT>/libcoreclr.dylib.dwarf
+```
+
+## Platform-Specific Development
+
+### WebAssembly
+
+Build for browser:
+
+```bash
+./build.sh mono+libs -os browser
+```
+
+Run tests:
+
+```bash
+./build.sh libs.tests -test -os browser
+```
+
+See [WebAssembly Documentation](wasm-documentation.md) for complete details.
+
+### Android
+
+Build:
+
+```bash
+./src/tests/build.sh mono -os android -arch arm64
+```
+
+See [Testing on Android](testing/libraries/testing-android.md).
+
+### iOS
+
+Build:
+
+```bash
+./src/tests/build.sh mono -os ios -arch arm64
+```
+
+See [Testing on Apple](testing/libraries/testing-apple.md).
+
+## Debugging
+
+### VS Code on Mono
+
+See [Debugging with VS Code on Mono](debugging/libraries/debugging-vscode.md#debugging-libraries-with-visual-studio-code-running-on-mono).
+
+### WebAssembly Debugging
+
+See [WebAssembly Debugging](debugging/mono/wasm-debugging.md).
+
+### Android Debugging
+
+See [Android Debugging](debugging/mono/android-debugging.md).
+
+## Samples
+
+Quick test samples are in `src/mono/sample/`:
+
+### Desktop Sample
+
+```bash
+cd src/mono/sample/HelloWorld
+make run
+```
+
+### WebAssembly Sample
+
+```bash
+cd src/mono/sample/wasm/browser  # or console
+make build && make run
+```
+
+### Android Sample
+
+```bash
+cd src/mono/sample/Android
+make run
+```
+
+### iOS Sample
+
+```bash
+cd src/mono/sample/iOS
+make run
+```
+
+## Building Packages
+
+```bash
+./build.sh packs -runtimeFlavor mono -c Release
+```
+
+Packages are placed in: `artifacts/packages/<Config>/Shipping/`
+
+## Deep Dives
+
+| Topic | Link |
+|-------|------|
+| Building details | [Building Mono](building/mono/README.md) |
+| Testing details | [Testing Mono](testing/mono/testing.md) |
+| WebAssembly | [WebAssembly Documentation](wasm-documentation.md) |
+| Browser internals | [Browser README](../../src/mono/browser/README.md) |
+| WASI support | [WASI README](../../src/mono/wasi/README.md) |

--- a/docs/workflow/debugging/README.md
+++ b/docs/workflow/debugging/README.md
@@ -1,0 +1,108 @@
+# Debugging the Runtime
+
+Guides for debugging the different components of dotnet/runtime.
+
+## By Component
+
+| Component | Guide | Description |
+|-----------|-------|-------------|
+| **CoreCLR** | [Debugging CoreCLR](coreclr/debugging-runtime.md) | Native runtime debugging |
+| **Libraries** | [Debugging Libraries](libraries/) | Managed code debugging |
+| **Mono** | [Debugging Mono](mono/) | Mono-specific debugging |
+
+## Quick Start by Platform
+
+### Windows
+
+**Visual Studio** is recommended for both native and managed debugging.
+
+- [Debugging CoreCLR in VS](coreclr/debugging-runtime.md#using-visual-studio)
+- [Debugging Libraries in VS](libraries/windows-instructions.md)
+
+### Linux/macOS
+
+**LLDB** for native code, **VS Code** for managed code.
+
+- [Debugging with LLDB](coreclr/debugging-runtime.md#debugging-coreclr-with-lldb)
+- [Debugging with VS Code](libraries/debugging-vscode.md)
+
+## Common Scenarios
+
+### Debugging a Library Test
+
+```bash
+# In VS Code or Visual Studio
+# 1. Open the test project
+# 2. Set breakpoint
+# 3. Debug test
+```
+
+See [Debugging Libraries](libraries/) for detailed setup.
+
+### Debugging the Runtime (Native)
+
+Windows with Visual Studio:
+```cmd
+build.cmd -vs CoreCLR.slnx -a x64 -c Debug
+```
+
+Linux/macOS with LLDB:
+```bash
+lldb -- /path/to/corerun app.dll
+```
+
+See [Debugging CoreCLR](coreclr/debugging-runtime.md).
+
+### Debugging System.Private.CoreLib
+
+See [Debugging CoreLib](libraries/debugging-corelib.md).
+
+## Specialized Debugging
+
+| Topic | Guide |
+|-------|-------|
+| AOT compilers | [Debugging AOT Compilers](coreclr/debugging-aot-compilers.md) |
+| Compiler dependency analysis | [Dependency Analysis](coreclr/debugging-compiler-dependency-analysis.md) |
+| WebAssembly | [WASM Debugging](mono/wasm-debugging.md) |
+| Android | [Android Debugging](mono/android-debugging.md) |
+
+## Tools
+
+### SOS Debugger Extension
+
+SOS provides .NET-specific debugging commands.
+
+- [Installing SOS](https://github.com/dotnet/diagnostics)
+- [SOS Commands](https://github.com/dotnet/diagnostics/blob/master/documentation/sos-debugging-extension-windows.md)
+
+Common commands:
+- `clrstack` - Managed call stack
+- `dumpobj` - Object contents
+- `VerifyHeap` - GC heap verification
+
+### PerfView
+
+For performance analysis and profiling.
+
+- [PerfView Tutorial](https://github.com/Microsoft/perfview/blob/main/documentation/Downloading.md)
+- Example usage: See [debugging libraries](libraries/perfview_example.gif)
+
+## Troubleshooting
+
+### Visual Studio Signature Validation Error (VS 2022 17.5+)
+
+When debugging local builds, you may see signature validation errors.
+
+**Quick fix:** Set environment variable before launching VS:
+```cmd
+set VSDebugger_ValidateDotnetDebugLibSignatures=0
+devenv.exe
+```
+
+See [full details](coreclr/debugging-runtime.md#resolving-signature-validation-errors-in-visual-studio).
+
+### Symbols Not Loading
+
+- Ensure you built in Debug configuration
+- On macOS, use `-DCLR_CMAKE_APPLE_DYSM=TRUE` for `.dSYM` bundles
+- Load SOS manually if needed: `plugin load /path/to/libsosplugin.so`

--- a/docs/workflow/environments/README.md
+++ b/docs/workflow/environments/README.md
@@ -1,0 +1,64 @@
+# Development Environments
+
+Alternative ways to set up your development environment for dotnet/runtime.
+
+## Cloud Development
+
+### [GitHub Codespaces](codespaces.md)
+
+Develop in a pre-configured cloud environment with no local setup required.
+
+- **Pros:** Zero setup, pre-built runtime, works from any browser
+- **Best for:** Quick contributions, trying out the repo
+- **Cost:** Free tier available, then pay-per-use
+
+## Containerized Development
+
+### [Docker](docker.md)
+
+Build in containers for consistent, reproducible environments.
+
+- **Pros:** Matches CI environment, easy cross-compilation
+- **Best for:** Cross-platform builds, reproducing CI issues
+- **Requirements:** Docker installed on your machine
+
+## Local Development
+
+### Visual Studio (Windows)
+
+Full IDE experience for Windows development.
+
+- **Pros:** Rich debugging, IntelliSense, integrated testing
+- **Best for:** Windows-focused development, native code debugging
+- **Setup:** See [Windows Requirements](../requirements/windows-requirements.md)
+
+See [Editing and Debugging](../editing-and-debugging.md) for Visual Studio solutions.
+
+### VS Code (Cross-Platform)
+
+Lightweight editor with debugging support.
+
+- **Pros:** Cross-platform, fast, extensible
+- **Best for:** Libraries development, managed code debugging
+- **Setup:** Install C# extension
+
+See [Debugging with VS Code](../debugging/libraries/debugging-vscode.md) for setup.
+
+### Command Line
+
+Build and test entirely from the terminal.
+
+- **Pros:** Scriptable, no IDE overhead
+- **Best for:** CI/CD, automation, remote development
+- **Setup:** See platform requirements for your OS
+
+## Comparison
+
+| Feature | Codespaces | Docker | VS | VS Code | CLI |
+|---------|------------|--------|-----|---------|-----|
+| No local setup | ✓ | | | | |
+| Pre-built runtime | ✓ | | | | |
+| Native debugging | | | ✓ | partial | partial |
+| Cross-compilation | ✓ | ✓ | | | |
+| Full IntelliSense | ✓ | | ✓ | ✓ | |
+| Offline work | | ✓ | ✓ | ✓ | ✓ |

--- a/docs/workflow/environments/codespaces.md
+++ b/docs/workflow/environments/codespaces.md
@@ -1,0 +1,49 @@
+# Using Codespaces
+
+* [Create a Codespace](#create-a-codespace)
+* [Updating dotnet/runtime's Codespaces Configuration](#updating-dotnetruntimes-codespaces-configuration)
+* [Testing out your Changes](#testing-out-your-changes)
+
+Codespaces allows you to develop in a Docker container running in the cloud. You can use an in-browser version of VS Code or the full VS Code application with the [GitHub Codespaces VS Code Extension](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces). This means you don't need to install any prerequisites on your current machine in order to develop in _dotnet/runtime_.
+
+## Create a Codespace
+
+The _dotnet/runtime_ repo runs a nightly GitHub Action to build the latest code in it. This allows you to immediately start developing and testing after creating a Codespace without having to build the whole repo. When the machine is created, it will have built the repo using the code as of 6 AM UTC of that morning.
+
+1. From this [repository's root](https://github.com/dotnet/runtime), Click the _<> Code_ button and then click _Codespaces_ tab.
+
+2. At the top right of the _Codespaces_ tab, select ... and click _+ New with options_
+
+![Configure and create codespace](https://docs.github.com/assets/cb-49317/images/help/codespaces/default-machine-type.png)
+
+3. Select which Dev container configuration you want to use.
+
+![Dev container configuration](./codespace-dev-container-configuration.png)
+
+* For `libraries` work, pick `.devcontainer/libraries/devcontainer.json`.
+* For `WASM` work, pick `.devcontainer/wasm/devcontainer.json`.
+
+4. Select the Machine type. For `dotnet/runtime`, it is recommended to select at least a `4-core` machine. You can also verify that a `Prebuild` is ready.
+
+![Codespace machine size](codespace-machine-size.png)
+
+_If these instructions are out of date, see <https://docs.github.com/codespaces/developing-in-codespaces/creating-a-codespace#creating-a-codespace> for instructions on how to create a new Codespace._
+
+## Updating dotnet/runtime's Codespaces Configuration
+
+The Codespaces configuration is spread across the following places:
+
+1. The [.devcontainer](/.devcontainer) folder contains subfolders for each development scenario:
+    * _Libraries_: Used by developers working in `src/libraries`.
+    * _Wasm_: Used by developers working on the _browser-wasm_ workload.
+    * _Scripts_: Contains any scripts that are executed during the creation of the codespace. This has the build command that builds the entire repo for prebuilds.
+2. Each development scenario folder contains the following files:
+    * The `devcontainer.json` file that configures the codespace and has VS Code / Environment settings.
+    * The _Dockerfile_ used to create the Docker image
+3. The GitHub Action can be configured by following the instructions at <https://docs.github.com/codespaces/prebuilding-your-codespaces/configuring-prebuilds>.
+
+To test out changes to the `.devcontainer` files, you can follow the process in the [Applying Changes to your Configuration](https://docs.github.com/codespaces/customizing-your-codespace/configuring-codespaces-for-your-project#applying-changes-to-your-configuration) docs. This allows you to rebuild the Codespace privately before creating a PR.
+
+## Testing out your Changes
+
+To test out your changes you can run the [Codespaces Prebuilds Action](https://github.com/dotnet/runtime/actions/workflows/codespaces/create_codespaces_prebuilds) in your fork against a branch with your changes.

--- a/docs/workflow/environments/docker.md
+++ b/docs/workflow/environments/docker.md
@@ -1,0 +1,76 @@
+# Using Docker for your Workflow
+
+- [Docker Basics](#docker-basics)
+- [The Official Runtime Docker Images](#the-official-runtime-docker-images)
+- [Build the Repo](#build-the-repo)
+
+This doc will cover the usage of Docker images and containers for your builds.
+
+## Docker Basics
+
+First, you have to enable and install the Docker Engine. Follow the instructions in their official site in [this link](https://docs.docker.com/get-started/get-docker) if you haven't done so.
+
+When using Docker, your machine's OS is strictly speaking not terribly important. For example, if you are on *Ubuntu 22.04*, you can use the *Ubuntu 18.04* image without any issues whatsoever. Likewise, you can run Linux images on Windows if you have WSL enabled. If you followed the instructions from the Docker official website when installing the engine, you most likely have it already up and running. If not, you can follow the instructions in [this link](https://learn.microsoft.com/windows/wsl/install) to enable it. However, note that you can't run multiple OS's on the same *Docker Daemon*, as it takes resources from the underlying kernel as needed. In other words, you can run either Linux on WSL, or Windows containers. You have to switch between them if you need both, and restart Docker.
+
+The target architecture is more important to consider when using Docker containers. The image's architecture has to match your machine's supported platforms. For instance, you can run both, x64 and Arm64 images on an *Apple Silicon Mac*, thanks to the *Rosetta* x64 emulator it provides. Likewise, you can run Linux Arm32 images on a Linux Arm64 host.
+
+Note that while Docker uses WSL to run the Linux containers on Windows, you don't have to boot up a WSL terminal to run them. Any `cmd` or `powershell` terminal with the `docker` command available will suffice to run all the commands. Docker takes care of the rest.
+
+## The Official Runtime Docker Images
+
+In the following tables, you will find the full names with tags of the images used for the official builds.
+
+**Main Docker Images**
+
+The main Docker images are the most commonly used ones, and the ones you will probably need for your builds. If you are working with more specific scenarios (e.g. Android, Risc-V), then you will find the images you need in the *Extended Docker Images* table right below this one.
+
+| Host OS           | Target OS    | Target Arch     | Image                                                                                  | crossrootfs dir      |
+| ----------------- | ------------ | --------------- | -------------------------------------------------------------------------------------- | -------------------- |
+| Azure Linux (x64) | Alpine 3.17  | x64             | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64-musl` | `/crossrootfs/x64`   |
+| Azure Linux (x64) | Ubuntu 18.04 | x64             | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64`        | `/crossrootfs/x64`   |
+| Azure Linux (x64) | Alpine 3.17  | Arm32 (armhf)   | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm-musl`   | `/crossrootfs/arm`   |
+| Azure Linux (x64) | Ubuntu 22.04 | Arm32 (armhf)   | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm`          | `/crossrootfs/arm`   |
+| Azure Linux (x64) | Alpine 3.17  | Arm64 (arm64v8) | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm64-musl` | `/crossrootfs/arm64` |
+| Azure Linux (x64) | Ubuntu 18.04 | Arm64 (arm64v8) | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-arm64`        | `/crossrootfs/arm64` |
+| Azure Linux (x64) | Ubuntu 18.04 | x86             | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-x86`          | `/crossrootfs/x86`   |
+
+**Extended Docker Images**
+
+| Host OS           | Target OS                  | Target Arch   | Image                                                                                   | crossrootfs dir        |
+| ----------------- | -------------------------- | ------------- | --------------------------------------------------------------------------------------- | ---------------------- |
+| Azure Linux (x64) | Android Bionic             | x64           | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-android-amd64` |        *N/A*           |
+| Azure Linux (x64) | Android Bionic (w/OpenSSL) | x64           | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-android-openssl`     |        *N/A*           |
+| Azure Linux (x64) | Android Bionic (w/Docker)  | x64           | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-android-docker`      |        *N/A*           |
+| Azure Linux (x64) | FreeBSD 14                 | x64           | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-freebsd-14`    | `/crossrootfs/x64`     |
+| Azure Linux (x64) | Ubuntu 18.04               | PPC64le       | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-ppc64le`       | `/crossrootfs/ppc64le` |
+| Azure Linux (x64) | Ubuntu 24.04               | RISC-V        | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-riscv64`       | `/crossrootfs/riscv64` |
+| Azure Linux (x64) | Debian sid                 | LoongArch     | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-loongarch64`   | `/crossrootfs/loongarch64` |
+| Azure Linux (x64) | Ubuntu 18.04               | S390x         | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-s390x`         | `/crossrootfs/s390x`   |
+| Azure Linux (x64) | Ubuntu 18.04 (Wasm)        | x64           | `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-webassembly-amd64`   | `/crossrootfs/x64`     |
+| Debian (x64)      | Debian 13                  | x64           | `mcr.microsoft.com/dotnet-buildtools/prereqs:debian-13-gcc15-amd64`                     |        *N/A*           |
+| Ubuntu (x64)      | Tizen 9.0                  | Arm32 (armel) | `mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-22.04-cross-armel-tizen`            | `/crossrootfs/armel`   |
+
+## Build the Repo
+
+Once you've chosen the image that suits your needs, you can issue `docker run` with the necessary arguments to use your clone of the runtime repo, and call the build scripts as you need. Down below, we have a small command-line example, explaining each of the flags you might need to use:
+
+```bash
+docker run --rm \
+  -v <RUNTIME_REPO_PATH>:/runtime \
+  -w /runtime \
+  -e ROOTFS_DIR=/crossrootfs/x64/ \
+  mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64 \
+  ./build.sh -s clr --cross -c Checked
+```
+
+Now, dissecting the command:
+
+- `--rm`: Erase the created container after it finishes running.
+- `-v <RUNTIME_REPO_PATH>:/runtime`: Mount the runtime repo clone located in `<RUNTIME_REPO_PATH>` to the container path `/runtime`.
+- `-w /runtime`: Start the container in the `/runtime` directory.
+- `-e ROOTFS_DIR=/crossrootfs/x64/` sets up the environment variable for crossbuilding.
+- `mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net11.0-cross-amd64`: The fully qualified name of the Docker image to download. In this case, we want to use an *Azure Linux* image to target the *x64* architecture.
+- `./build.sh -s clr --cross -c Checked`: The build command to run in the repo. In this case, we want to build the *Clr* subset in the *Checked* configuration with the cross compilation option.
+
+You might also want to interact with the container directly for a myriad of reasons, like running multiple builds in different paths for example. In this case, instead of passing the build script command to the `docker` command-line, pass the flag `-it`. When you do this, you will get access to a small shell within the container, which allows you to explore it, run builds manually, and so on, like you would on a regular terminal in your machine. Note that the containers' shell's built-in tools are very limited in comparison to the ones you probably have on your machine, so don't expect to be able to do full work there.
+

--- a/docs/workflow/getting-started.md
+++ b/docs/workflow/getting-started.md
@@ -1,0 +1,151 @@
+# Getting Started
+
+This guide helps you set up your development environment and make your first contribution to dotnet/runtime.
+
+## Quick Start (5 minutes to first build)
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/dotnet/runtime.git
+cd runtime
+```
+
+**Note:** The repo requires ~1.5 GB for a clone and 10-20 GB for a build.
+
+### 2. Install Prerequisites
+
+Choose your platform:
+
+| Platform | Guide |
+|----------|-------|
+| Windows | [Windows Setup](requirements/windows-requirements.md) |
+| Linux | [Linux Setup](requirements/linux-requirements.md) |
+| macOS | [macOS Setup](requirements/macos-requirements.md) |
+| FreeBSD | [FreeBSD Setup](requirements/freebsd-requirements.md) |
+
+### 3. Build the Runtime
+
+From the repository root:
+
+```bash
+# Build everything (first time, ~30-40 minutes)
+./build.sh        # Linux/macOS
+./build.cmd       # Windows
+```
+
+For faster iteration, build only what you need:
+
+```bash
+# CoreCLR runtime only
+./build.sh -subset clr
+
+# Libraries only (requires runtime built first)
+./build.sh -subset libs
+
+# Mono runtime only
+./build.sh -subset mono
+```
+
+### 4. Verify Your Build
+
+```bash
+# Set up the dotnet CLI from your build
+export PATH="$(pwd)/.dotnet:$PATH"  # Linux/macOS
+set PATH=%CD%\.dotnet;%PATH%        # Windows
+
+dotnet --version
+```
+
+## What's Next?
+
+### Choose Your Component
+
+| Component | Best For | Guide |
+|-----------|----------|-------|
+| **Libraries** | Most contributors - BCL, networking, IO, collections | [Libraries Guide](components/libraries.md) |
+| **CoreCLR** | JIT, GC, type system, interop | [CoreCLR Guide](components/coreclr.md) |
+| **Mono** | Mobile, WebAssembly, embedded | [Mono Guide](components/mono.md) |
+| **Host** | App startup, SDK integration | [Host Guide](components/host.md) |
+
+### Common Workflows
+
+- **Edit and test a library**: See [Libraries Guide](components/libraries.md)
+- **Debug the runtime**: See [Debugging Guide](debugging/README.md)
+- **Run tests**: See [Testing Guide](testing/README.md)
+- **Submit a PR**: See [PR Guide](ci/pr-guide.md)
+
+## Development Environments
+
+| Environment | Description |
+|-------------|-------------|
+| [GitHub Codespaces](environments/codespaces.md) | Cloud-based, pre-configured environment |
+| [Docker](environments/docker.md) | Containerized builds for cross-compilation |
+| [Visual Studio](editing-and-debugging.md) | Full IDE experience on Windows |
+| [VS Code](debugging/libraries/debugging-vscode.md) | Lightweight, cross-platform |
+
+## Build Configurations
+
+| Configuration | Use Case |
+|---------------|----------|
+| **Debug** | Development and debugging (default) |
+| **Release** | Performance testing |
+| **Checked** | Testing with assertions (CoreCLR only) |
+
+Specify configuration with `-c` or `-configuration`:
+
+```bash
+./build.sh -subset clr -c Release
+```
+
+Use different configurations per component:
+
+```bash
+# Release runtime, Debug libraries (common for library work)
+./build.sh -subset clr+libs -rc Release -lc Debug
+```
+
+## Troubleshooting
+
+### Build Fails Immediately
+
+- Ensure all [prerequisites](#2-install-prerequisites) are installed
+- On Windows, run from a Developer Command Prompt
+- Check available disk space (need 10-20 GB)
+
+### "testhost" or "shared framework" Errors
+
+Run a full baseline build first:
+
+```bash
+./build.sh clr+libs -rc release
+```
+
+### Need More Help?
+
+- Review [build logs](../project/glossary.md) in `artifacts/log/`
+- Check [CI failure analysis](ci/failure-analysis.md) for known issues
+- Ask in [GitHub Discussions](https://github.com/dotnet/runtime/discussions)
+
+## Key Concepts
+
+### Subsets
+
+The build is organized into subsets you can build independently:
+
+| Subset | Description |
+|--------|-------------|
+| `clr` | CoreCLR runtime + System.Private.CoreLib |
+| `mono` | Mono runtime + System.Private.CoreLib |
+| `libs` | All libraries |
+| `host` | .NET hosts and installers |
+| `packs` | Shipping packages |
+
+Combine with `+`: `./build.sh -subset clr+libs`
+
+### Build vs. Target Platform
+
+- **Build Platform**: Where you're running the build (your machine)
+- **Target Platform**: What you're building for (may be different for cross-compilation)
+
+See [Cross-Compilation](building/coreclr/cross-building.md) for building for other platforms.

--- a/docs/workflow/platforms/README.md
+++ b/docs/workflow/platforms/README.md
@@ -1,0 +1,52 @@
+# Platform Requirements
+
+Set up your development environment for building dotnet/runtime.
+
+## Supported Platforms
+
+| Platform | Architectures | Guide |
+|----------|--------------|-------|
+| **Windows** | x64, x86, Arm64 | [Windows Setup](../requirements/windows-requirements.md) |
+| **Linux** | x64, Arm32, Arm64 | [Linux Setup](../requirements/linux-requirements.md) |
+| **macOS** | x64, Arm64 | [macOS Setup](../requirements/macos-requirements.md) |
+| **FreeBSD** | x64 | [FreeBSD Setup](../requirements/freebsd-requirements.md) |
+
+## Quick Summary
+
+### Windows
+
+- Visual Studio 2022 (17.0+) with C++ workload
+- Windows SDK (10.0.20348.0+)
+- CMake 3.20+
+
+### Linux
+
+- Clang 16+ or GCC 13+
+- CMake 3.20+
+- Various dev packages (see full guide)
+
+### macOS
+
+- Xcode 14.3+ or Command Line Tools
+- CMake 3.20+
+
+## Cross-Compilation
+
+You can build for platforms different from your host machine:
+
+| Host | Can Target |
+|------|------------|
+| Windows x64 | Windows x86, Windows Arm64 |
+| Linux x64 | Linux Arm32, Linux Arm64, Alpine, Android |
+| macOS x64 | macOS Arm64 |
+| macOS Arm64 | macOS x64 |
+
+See [Using Docker](../environments/docker.md) for cross-compilation using containers.
+
+## Alternative Environments
+
+| Environment | Description |
+|-------------|-------------|
+| [GitHub Codespaces](../environments/codespaces.md) | Cloud-based, pre-configured |
+| [Docker](../environments/docker.md) | Containerized builds |
+| [WSL](../requirements/linux-requirements.md) | Linux on Windows |

--- a/docs/workflow/testing/README.md
+++ b/docs/workflow/testing/README.md
@@ -1,0 +1,97 @@
+# Testing the Runtime
+
+Guides for testing the different components of dotnet/runtime.
+
+## By Component
+
+| Component | Guide | Description |
+|-----------|-------|-------------|
+| **CoreCLR** | [Testing CoreCLR](coreclr/testing.md) | Runtime tests in `src/tests/` |
+| **Libraries** | [Testing Libraries](libraries/testing.md) | Library unit tests |
+| **Mono** | [Testing Mono](mono/testing.md) | Mono-specific testing |
+| **Host** | [Testing Host](host/testing.md) | Host activation tests |
+
+## Quick Reference
+
+### Library Tests (Most Common)
+
+```bash
+# Test a single library
+cd src/libraries/System.Foo/tests
+dotnet build /t:Test
+
+# Run all library tests
+./build.sh libs.tests -test
+```
+
+### CoreCLR Tests
+
+```bash
+# Build Core_Root first
+./src/tests/build.sh generatelayoutonly
+
+# Run all tests
+./src/tests/run.sh
+
+# Build and run specific test
+./src/tests/build.sh -test:JIT/Test/Test.csproj
+```
+
+### Mono Tests
+
+```bash
+# Library tests on Mono
+dotnet build /t:Test /p:RuntimeFlavor=mono
+```
+
+## Test Filtering
+
+### Library Tests
+
+```bash
+# By class
+dotnet build /t:Test /p:XUnitOptions="-class Namespace.TestClass"
+
+# By method
+dotnet build /t:Test /p:XUnitOptions="-method Namespace.Class.Method"
+
+# Outer loop tests
+dotnet build /t:Test /p:Outerloop=true
+```
+
+### CoreCLR Tests
+
+```bash
+# By priority (0 is default)
+./src/tests/build.sh -priority=1
+
+# By directory
+./src/tests/build.sh -dir:JIT/Methodical
+
+# By subtree
+./src/tests/build.sh -tree:JIT
+```
+
+## Platform-Specific Testing
+
+| Platform | Guide |
+|----------|-------|
+| WebAssembly | [Testing WASM](libraries/testing-wasm.md) |
+| Android | [Testing Android](libraries/testing-android.md) |
+| iOS/macOS | [Testing Apple](libraries/testing-apple.md) |
+
+## Special Topics
+
+| Topic | Guide |
+|-------|-------|
+| Filtering tests | [Test Filtering](libraries/filtering-tests.md) |
+| Using corerun | [Using corerun and Core_Root](using-corerun-and-coreroot.md) |
+| Dev packages | [Using Dev Packages](using-dev-shipping-packages.md) |
+| Installed SDK | [Using Your Build](using-your-build-with-installed-sdk.md) |
+| Visual Studio | [Testing in VS](visualstudio.md) |
+
+## Test Results
+
+- Library tests: `artifacts/bin/<Library>.Tests/*/testResults.xml`
+- CoreCLR tests: `artifacts/log/TestRun_<Arch>_<Config>.html`
+- Failures: `artifacts/log/TestRunResults_*.err`


### PR DESCRIPTION
NOTE: This is a draft to see how creative we can get with AI to help shape our docs.

- Add getting-started.md as clear entry point for new contributors
- Add components/ folder with unified guides (coreclr, libraries, mono, host)
- Add index README.md files to building/, testing/, debugging/, ci/
- Add platforms/ and environments/ folders for setup documentation
- Rewrite main README.md as concise navigation hub with task-oriented tables
- Copy Codespaces.md and using-docker.md to environments/ folder

The new structure organizes docs by user task rather than activity type, making it easier to find all build+test+debug info for a component in one place.