### PR TITLE
Fix parsing inconsistencies between Uri ctors and TryCreate factories

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -145,6 +145,8 @@ namespace System
         [Conditional("DEBUG")]
         private void DebugSetLeftCtor()
         {
+            DebugAssertInCtor();
+
             _flags |= Flags.Debug_LeftConstructor;
 
             AssertInvariants();
@@ -424,7 +426,6 @@ namespace System
             ArgumentNullException.ThrowIfNull(uriString);
 
             CreateThis(uriString, false, UriKind.Absolute);
-            DebugSetLeftCtor();
         }
 
         //
@@ -438,7 +439,6 @@ namespace System
             ArgumentNullException.ThrowIfNull(uriString);
 
             CreateThis(uriString, dontEscape, UriKind.Absolute);
-            DebugSetLeftCtor();
         }
 
         //
@@ -456,7 +456,6 @@ namespace System
                 throw new ArgumentOutOfRangeException(nameof(baseUri));
 
             CreateUri(baseUri, relativeUri, dontEscape);
-            DebugSetLeftCtor();
         }
 
         //
@@ -467,7 +466,6 @@ namespace System
             ArgumentNullException.ThrowIfNull(uriString);
 
             CreateThis(uriString, false, uriKind);
-            DebugSetLeftCtor();
         }
 
         /// <summary>
@@ -480,7 +478,6 @@ namespace System
             ArgumentNullException.ThrowIfNull(uriString);
 
             CreateThis(uriString, false, UriKind.Absolute, in creationOptions);
-            DebugSetLeftCtor();
         }
 
         //
@@ -498,7 +495,6 @@ namespace System
                 throw new ArgumentOutOfRangeException(nameof(baseUri));
 
             CreateUri(baseUri, relativeUri, false);
-            DebugSetLeftCtor();
         }
 
         //
@@ -515,7 +511,6 @@ namespace System
             if (uriString!.Length != 0)
             {
                 CreateThis(uriString, false, UriKind.Absolute);
-                DebugSetLeftCtor();
                 return;
             }
 
@@ -524,7 +519,6 @@ namespace System
                 throw new ArgumentException(SR.Format(SR.InvalidNullArgument, "RelativeUri"), nameof(serializationInfo));
 
             CreateThis(uriString, false, UriKind.Relative);
-            DebugSetLeftCtor();
         }
 
         //
@@ -617,7 +611,6 @@ namespace System
                     if (!ReferenceEquals(this, resolvedRelativeUri))
                         CreateThisFromUri(resolvedRelativeUri);
 
-                    DebugSetLeftCtor();
                     return;
                 }
             }
@@ -634,7 +627,6 @@ namespace System
             _syntax = null!;
             _originalUnicodeString = null!;
             CreateThis(newUriString, dontEscape, UriKind.Absolute);
-            DebugSetLeftCtor();
         }
 
         //

--- a/src/libraries/System.Private.Uri/src/System/UriExt.cs
+++ b/src/libraries/System.Private.Uri/src/System/UriExt.cs
@@ -13,7 +13,7 @@ namespace System
 {
     public partial class Uri
     {
-        /// <summary>Helper called by all constructos to construct the Uri.</summary>
+        /// <summary>Helper called by all constructors to construct the Uri.</summary>
         [MemberNotNull(nameof(_string))]
         private void CreateThis(string? uri, bool dontEscape, UriKind uriKind, in UriCreationOptions creationOptions = default)
         {
@@ -150,6 +150,7 @@ namespace System
             }
 
             // We have a valid absolute Uri.
+            DebugSetLeftCtor();
             return null;
 
         SwitchToRelativeUri:
@@ -165,6 +166,7 @@ namespace System
                 _string = vsb.ToString();
             }
 
+            DebugSetLeftCtor();
             return null;
         }
 
@@ -221,7 +223,6 @@ namespace System
         public static bool TryCreate([NotNullWhen(true), StringSyntax(StringSyntaxAttribute.Uri, "uriKind")] string? uriString, UriKind uriKind, [NotNullWhen(true)] out Uri? result)
         {
             result = CreateHelper(uriString, false, uriKind);
-            result?.DebugSetLeftCtor();
             return result is not null;
         }
 
@@ -235,7 +236,6 @@ namespace System
         public static bool TryCreate([NotNullWhen(true), StringSyntax(StringSyntaxAttribute.Uri)] string? uriString, in UriCreationOptions creationOptions, [NotNullWhen(true)] out Uri? result)
         {
             result = CreateHelper(uriString, false, UriKind.Absolute, in creationOptions);
-            result?.DebugSetLeftCtor();
             return result is not null;
         }
 
@@ -284,7 +284,6 @@ namespace System
             result ??= CreateHelper(newUriString!, dontEscape, UriKind.Absolute);
             Debug.Assert(result is null || result.IsAbsoluteUri);
 
-            result?.DebugSetLeftCtor();
             return result is not null;
         }
 
@@ -890,6 +889,7 @@ namespace System
         private void CreateThisFromUri(Uri otherUri)
         {
             DebugAssertInCtor();
+            Debug.Assert((otherUri._flags & Flags.Debug_LeftConstructor) != 0);
 
             _flags = otherUri._flags;
 

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriTests.cs
@@ -924,8 +924,14 @@ namespace System.PrivateUri.Tests
                 (() => new Uri(new Uri(@"http://www.contoso.com/"), "catalog/shownew.htm?date=today"), "http://www.contoso.com/catalog/shownew.htm?date=today"),
                 (() => new Uri("http://test/a/b/c/d/../../e/f"), "http://test/a/b/e/f"),
                 (() => { var uri = new Uri("http://test/a/b/c/d/../../e/f"); uri.ToString(); return uri; }, "http://test/a/b/e/f"),
-                (() => new Uri("pa%41th", UriKind.Relative), "paAth"),
+                (() => new Uri("p%41th", UriKind.Relative), "pAth"),
                 (() => new Uri("pa\uFFFFth", UriKind.Relative), "pa%EF%BF%BFth"),
+                (() => new Uri("C:\\path", UriKind.Relative), "C:\\path"),
+                (() => new Uri("C:\\p%41th", UriKind.Relative), "C:\\pAth"),
+                (() => new Uri("http:\\host/path", UriKind.Relative), "http:\\host/path"),
+                (() => new Uri("http:\\host/p%41th", UriKind.Relative), "http:\\host/pAth"),
+                (() => new Uri("//host/path", UriKind.RelativeOrAbsolute), "//host/path"),
+                (() => new Uri("//host/p%41th", UriKind.RelativeOrAbsolute), "//host/pAth"),
             ];
 
             foreach ((Func<Uri> factory, string expected) in testData)


### PR DESCRIPTION
This is the "future change" I was referring to in https://github.com/dotnet/runtime/pull/122001 and https://github.com/dotnet/runtime/pull/122002.

`Uri` ctors and `TryCreate` factories used almost the same logic, but the duplication introduced a slight difference in how the fallback to relative Uris was handled.
When using `TryCreate`, we would skip the iri normalization. E.g. compare
```c#
var uri1 = new Uri("p%41th", UriKind.Relative);
Uri.TryCreate("p%41th", UriKind.Relative, out Uri uri2);
Console.WriteLine(uri1); // pAth
Console.WriteLine(uri2); // p%41th
```
01abba3c0c90b59460afcf053c40d6415002f8e1 avoids the code duplication and makes the behavior between the two the same.

---

The other inconsistency was around how the fallback to relative Uris worked for various cases where we decide we can't create an Absolute one.
If we were falling back from an implicit file path, or an invalid absolute Uri with a valid scheme, we would skip iri normalization.

d50ad4f106e3459c2dc1af58f377748ffadfd7fb uses the same logic for all such cases.

---

The distinction doesn't matter much in practice if you end up combining the Uri with a base, they'll get normalized the same. We could also choose to make the break in the other direction if we wanted to - not do iri normalization for relative uris at all.

It only matters if you interrogate the relative Uri directly. Marking as breaking-change regardless so that we remember to call it out in docs.