### PR TITLE
Add an ASCII check for edge-case non-ASCII hosts that can't be Punycode encoded

### DIFF
--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -372,8 +372,8 @@
   <data name="net_http_request_invalid_char_encoding" xml:space="preserve">
     <value>Request headers must contain only ASCII characters.</value>
   </data>
-  <data name="net_http_request_invalid_nonascii_host" xml:space="preserve">
-    <value>Request Uri's host contained non-ASCII characters that could not be Punycode encoded.</value>
+  <data name="net_http_request_invalid_host_punycode" xml:space="preserve">
+    <value>Request Uri's host could not be Punycode encoded.</value>
   </data>
   <data name="net_http_ssl_connection_failed" xml:space="preserve">
     <value>The SSL connection could not be established, see inner exception.</value>

--- a/src/libraries/System.Net.Http/src/Resources/Strings.resx
+++ b/src/libraries/System.Net.Http/src/Resources/Strings.resx
@@ -372,6 +372,9 @@
   <data name="net_http_request_invalid_char_encoding" xml:space="preserve">
     <value>Request headers must contain only ASCII characters.</value>
   </data>
+  <data name="net_http_request_invalid_nonascii_host" xml:space="preserve">
+    <value>Request Uri's host contained non-ASCII characters that could not be Punycode encoded.</value>
+  </data>
   <data name="net_http_ssl_connection_failed" xml:space="preserve">
     <value>The SSL connection could not be established, see inner exception.</value>
   </data>

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpAuthority.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpAuthority.cs
@@ -41,8 +41,9 @@ namespace System.Net.Http
             {
                 Debug.Assert(uri.HostNameType == UriHostNameType.Basic);
 
-                // This is not a DNS host and it contains non-ASCII characters that can't be Punycode encoded.
-                throw new HttpRequestException(SR.net_http_request_invalid_nonascii_host);
+                // This is not a DNS host and it contains non-ASCII characters.
+                // Uri failed to Punycode encode it, likely because one of the labels was too long for DNS.
+                throw new HttpRequestException(SR.net_http_request_invalid_host_punycode);
             }
 
             Port = port;

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpAuthority.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpAuthority.cs
@@ -3,10 +3,10 @@
 
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 
 namespace System.Net.Http
 {
-
     internal sealed class HttpAuthority : IEquatable<HttpAuthority>
     {
         // ALPN Protocol Name should also be part of an authority, but we are special-casing for HTTP/3, so this can be assumed to be "H3".
@@ -36,6 +36,15 @@ namespace System.Net.Http
                 // IPv4 address, dns or puny encoded name
                 HostValue = IdnHost = uri.IdnHost;
             }
+
+            if (!Ascii.IsValid(HostValue))
+            {
+                Debug.Assert(uri.HostNameType == UriHostNameType.Basic);
+
+                // This is not a DNS host and it contains non-ASCII characters that can't be Punycode encoded.
+                throw new HttpRequestException(SR.net_http_request_invalid_nonascii_host);
+            }
+
             Port = port;
         }
 

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs
@@ -496,7 +496,7 @@ namespace System.Net.Http
             Debug.Assert(status == OperationStatus.Done);
             Debug.Assert(bytesWritten == s.Length);
 
-            _writeBuffer.Commit(s.Length);
+            _writeBuffer.Commit(bytesWritten);
         }
 
         private void WriteString(string s, Encoding? encoding)

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/SocketsHttpHandlerTest.cs
@@ -1351,6 +1351,16 @@ namespace System.Net.Http.Functional.Tests
     public sealed class SocketsHttpHandler_HttpClientHandlerTest : HttpClientHandlerTest
     {
         public SocketsHttpHandler_HttpClientHandlerTest(ITestOutputHelper output) : base(output) { }
+
+        [Fact]
+        public async Task SendAsync_UriWithNonDnsNonAsciiHost_Throws()
+        {
+            using HttpClient client = CreateHttpClient();
+
+            HttpRequestMessage request = CreateRequest(HttpMethod.Get, new Uri($"http://hőst{new string('a', 60)}"), UseVersion);
+
+            await Assert.ThrowsAsync<HttpRequestException>(() => client.SendAsync(TestAsync, request));
+        }
     }
 
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsNotBrowser))]


### PR DESCRIPTION
This is an edge-case where some hosts that exceed DNS limits (e.g. contain long labels) can't get Punycode encoded, and their `IdnHost` may return a non-ASCII value.
This broke some assumptions in our HTTP logic where we'd hit debug asserts.