### PR TITLE
[release/8.0-staging] Update MsQuicSchannelVersion to 2.4.16

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -232,7 +232,7 @@
     <!-- ICU -->
     <MicrosoftNETCoreRuntimeICUTransportVersion>8.0.0-rtm.25625.2</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- MsQuic -->
-    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.8</MicrosoftNativeQuicMsQuicSchannelVersion>
+    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.16</MicrosoftNativeQuicMsQuicSchannelVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>16.0.5-alpha.1.25311.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>16.0.5-alpha.1.25311.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>


### PR DESCRIPTION
Update MsQuic version published with dotnet/runtime on Windows.

Backport of https://github.com/dotnet/runtime/pull/121198

## Customer Impact

No

## Regression

No

## Testing

Automated tests

## Risk

Low, change only in patch version and we've been running with 2.4.16 in main and .NET 10 for many months.