### PR TITLE
[release/9.0-staging] Update MsQuic version to 2.4.16

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -230,7 +230,7 @@
     <MicrosoftNETCoreRuntimeICUTransportVersion>9.0.0-rtm.26078.1</MicrosoftNETCoreRuntimeICUTransportVersion>
     <MicrosoftNETCoreRuntimeICUTransportVersion>9.0.0-rtm.24466.4</MicrosoftNETCoreRuntimeICUTransportVersion>
     <!-- MsQuic -->
-    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.8</MicrosoftNativeQuicMsQuicSchannelVersion>
+    <MicrosoftNativeQuicMsQuicSchannelVersion>2.4.16</MicrosoftNativeQuicMsQuicSchannelVersion>
     <!-- Mono LLVM -->
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>19.1.0-alpha.1.25625.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMSdkVersion>
     <runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>19.1.0-alpha.1.25625.1</runtimelinuxarm64MicrosoftNETCoreRuntimeMonoLLVMToolsVersion>


### PR DESCRIPTION
Update MsQuic version published with dotnet/runtime on Windows

Backport of https://github.com/dotnet/runtime/pull/121198

## Customer Impact

No

## Regression

No

## Testing

Automated tests

## Risk

Low, change only in patch version and we've been running with 2.4.16 in main and .NET 10 for many months.