### PR TITLE
Don't ping codegen team for codegen label

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -366,7 +366,7 @@ configuration:
         - mentionUsers:
             mentionees:
             - JulieLeeMSFT
-            - dotnet/jit-contrib
+            - jakobbotsch
             replyTemplate: >-
               Tagging subscribers to this area: ${mentionees}
 


### PR DESCRIPTION
Revert the change done in https://github.com/dotnet/runtime/pull/122357

`area-CodeGen-coreclr` label is by far [the most popular label](https://github.com/dotnet/runtime/labels?sort=count-desc) in dotnet/runtime. This creates a huge mailbox mess and we're more likely to miss direct pings. We usually iterate all issues with that label anyway.