### PR TITLE
Make all fields in AssertionDscOp1 and AssertionDscOp2 private

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -757,32 +757,31 @@ void Compiler::optAssertionInit(bool isLocalProp)
 #ifdef DEBUG
 void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionIndex assertionIndex /* = 0 */)
 {
-    if (curAssertion.op1.kind == O1K_EXACT_TYPE)
+    if (curAssertion.op1.KindIs(O1K_EXACT_TYPE))
     {
         printf("Type     ");
     }
-    else if (curAssertion.op1.kind == O1K_ARR_BND)
+    else if (curAssertion.op1.KindIs(O1K_ARR_BND))
     {
         printf("ArrBnds  ");
     }
-    else if (curAssertion.op1.kind == O1K_VN)
+    else if (curAssertion.op1.KindIs(O1K_VN))
     {
         printf("Vn  ");
     }
-    else if (curAssertion.op1.kind == O1K_SUBTYPE)
+    else if (curAssertion.op1.KindIs(O1K_SUBTYPE))
     {
         printf("Subtype  ");
     }
-    else if (curAssertion.op2.kind == O2K_LCLVAR_COPY)
+    else if (curAssertion.op2.KindIs(O2K_LCLVAR_COPY))
     {
         printf("Copy     ");
     }
-    else if ((curAssertion.op2.kind == O2K_CONST_INT) || (curAssertion.op2.kind == O2K_CONST_DOUBLE) ||
-             (curAssertion.op2.kind == O2K_ZEROOBJ))
+    else if (curAssertion.op2.KindIs(O2K_CONST_INT, O2K_CONST_DOUBLE, O2K_ZEROOBJ))
     {
         printf("Constant ");
     }
-    else if (curAssertion.op2.kind == O2K_SUBRANGE)
+    else if (curAssertion.op2.KindIs(O2K_SUBRANGE))
     {
         printf("Subrange ");
     }
@@ -794,64 +793,64 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
 
     if (!optLocalAssertionProp)
     {
-        printf("(" FMT_VN "," FMT_VN ") ", curAssertion.op1.vn, curAssertion.op2.vn);
+        printf("(" FMT_VN "," FMT_VN ") ", curAssertion.op1.GetVN(), curAssertion.op2.GetVN());
     }
 
-    if (curAssertion.op1.kind == O1K_LCLVAR)
+    if (curAssertion.op1.KindIs(O1K_LCLVAR))
     {
         if (!optLocalAssertionProp)
         {
             printf("LCLVAR");
-            vnStore->vnDump(this, curAssertion.op1.vn);
+            vnStore->vnDump(this, curAssertion.op1.GetVN());
         }
         else
         {
-            printf("V%02u", curAssertion.op1.lclNum);
+            printf("V%02u", curAssertion.op1.GetLclNum());
         }
     }
-    else if (curAssertion.op1.kind == O1K_EXACT_TYPE)
+    else if (curAssertion.op1.KindIs(O1K_EXACT_TYPE))
     {
         printf("Exact_Type");
-        vnStore->vnDump(this, curAssertion.op1.vn);
+        vnStore->vnDump(this, curAssertion.op1.GetVN());
     }
-    else if (curAssertion.op1.kind == O1K_SUBTYPE)
+    else if (curAssertion.op1.KindIs(O1K_SUBTYPE))
     {
         printf("Sub_Type");
-        vnStore->vnDump(this, curAssertion.op1.vn);
+        vnStore->vnDump(this, curAssertion.op1.GetVN());
     }
-    else if (curAssertion.op1.kind == O1K_ARR_BND)
+    else if (curAssertion.op1.KindIs(O1K_ARR_BND))
     {
-        printf("[idx: " FMT_VN, curAssertion.op1.bnd.vnIdx);
-        vnStore->vnDump(this, curAssertion.op1.bnd.vnIdx);
-        printf("; len: " FMT_VN, curAssertion.op1.bnd.vnLen);
-        vnStore->vnDump(this, curAssertion.op1.bnd.vnLen);
+        printf("[idx: " FMT_VN, curAssertion.op1.GetArrBnd().vnIdx);
+        vnStore->vnDump(this, curAssertion.op1.GetArrBnd().vnIdx);
+        printf("; len: " FMT_VN, curAssertion.op1.GetArrBnd().vnLen);
+        vnStore->vnDump(this, curAssertion.op1.GetArrBnd().vnLen);
         printf("]");
     }
-    else if (curAssertion.op1.kind == O1K_VN)
+    else if (curAssertion.op1.KindIs(O1K_VN))
     {
-        printf("[vn: " FMT_VN, curAssertion.op1.vn);
-        vnStore->vnDump(this, curAssertion.op1.vn);
+        printf("[vn: " FMT_VN, curAssertion.op1.GetVN());
+        vnStore->vnDump(this, curAssertion.op1.GetVN());
         printf("]");
     }
-    else if (curAssertion.op1.kind == O1K_BOUND_OPER_BND)
+    else if (curAssertion.op1.KindIs(O1K_BOUND_OPER_BND))
     {
         printf("Oper_Bnd");
-        vnStore->vnDump(this, curAssertion.op1.vn);
+        vnStore->vnDump(this, curAssertion.op1.GetVN());
     }
-    else if (curAssertion.op1.kind == O1K_BOUND_LOOP_BND)
+    else if (curAssertion.op1.KindIs(O1K_BOUND_LOOP_BND))
     {
         printf("Loop_Bnd");
-        vnStore->vnDump(this, curAssertion.op1.vn);
+        vnStore->vnDump(this, curAssertion.op1.GetVN());
     }
-    else if (curAssertion.op1.kind == O1K_CONSTANT_LOOP_BND)
+    else if (curAssertion.op1.KindIs(O1K_CONSTANT_LOOP_BND))
     {
         printf("Const_Loop_Bnd");
-        vnStore->vnDump(this, curAssertion.op1.vn);
+        vnStore->vnDump(this, curAssertion.op1.GetVN());
     }
-    else if (curAssertion.op1.kind == O1K_CONSTANT_LOOP_BND_UN)
+    else if (curAssertion.op1.KindIs(O1K_CONSTANT_LOOP_BND_UN))
     {
         printf("Const_Loop_Bnd_Un");
-        vnStore->vnDump(this, curAssertion.op1.vn);
+        vnStore->vnDump(this, curAssertion.op1.GetVN());
     }
     else
     {
@@ -864,7 +863,7 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
     }
     else if (curAssertion.assertionKind == OAK_EQUAL)
     {
-        if (curAssertion.op1.kind == O1K_LCLVAR)
+        if (curAssertion.op1.KindIs(O1K_LCLVAR))
         {
             printf(" == ");
         }
@@ -879,7 +878,7 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
     }
     else if (curAssertion.assertionKind == OAK_NOT_EQUAL)
     {
-        if (curAssertion.op1.kind == O1K_LCLVAR)
+        if (curAssertion.op1.KindIs(O1K_LCLVAR))
         {
             printf(" != ");
         }
@@ -893,16 +892,16 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
         printf(" ?assertionKind? ");
     }
 
-    if (curAssertion.op1.kind != O1K_ARR_BND)
+    if (!curAssertion.op1.KindIs(O1K_ARR_BND))
     {
-        switch (curAssertion.op2.kind)
+        switch (curAssertion.op2.GetKind())
         {
             case O2K_LCLVAR_COPY:
                 printf("V%02u", curAssertion.op2.lclNum);
                 break;
 
             case O2K_CONST_INT:
-                if (curAssertion.op1.kind == O1K_EXACT_TYPE)
+                if (curAssertion.op1.KindIs(O1K_EXACT_TYPE))
                 {
                     ssize_t iconVal = curAssertion.op2.u1.iconVal;
                     if (IsAot())
@@ -922,7 +921,7 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
                     // knowledge that the constant was ever a handle, as the expression creating the original value
                     // was not (and can't be) assigned a handle flag.
                 }
-                else if (curAssertion.op1.kind == O1K_SUBTYPE)
+                else if (curAssertion.op1.KindIs(O1K_SUBTYPE))
                 {
                     ssize_t iconVal = curAssertion.op2.u1.iconVal;
                     if (IsAot())
@@ -935,18 +934,16 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
                     }
                     assert(curAssertion.op2.HasIconFlag());
                 }
-                else if ((curAssertion.op1.kind == O1K_BOUND_OPER_BND) ||
-                         (curAssertion.op1.kind == O1K_BOUND_LOOP_BND) ||
-                         (curAssertion.op1.kind == O1K_CONSTANT_LOOP_BND) ||
-                         (curAssertion.op1.kind == O1K_CONSTANT_LOOP_BND_UN))
+                else if (curAssertion.op1.KindIs(O1K_BOUND_OPER_BND, O1K_BOUND_LOOP_BND, O1K_CONSTANT_LOOP_BND,
+                                                 O1K_CONSTANT_LOOP_BND_UN))
                 {
                     assert(!optLocalAssertionProp);
-                    vnStore->vnDump(this, curAssertion.op2.vn);
+                    vnStore->vnDump(this, curAssertion.op2.GetVN());
                 }
                 else
                 {
-                    var_types op1Type = !optLocalAssertionProp ? vnStore->TypeOfVN(curAssertion.op1.vn)
-                                                               : lvaGetRealType(curAssertion.op1.lclNum);
+                    var_types op1Type = !optLocalAssertionProp ? vnStore->TypeOfVN(curAssertion.op1.GetVN())
+                                                               : lvaGetRealType(curAssertion.op1.GetLclNum());
                     if (op1Type == TYP_REF)
                     {
                         if (curAssertion.op2.u1.iconVal == 0)
@@ -1248,8 +1245,8 @@ AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, bool equ
                 if (op1->TypeIs(TYP_STRUCT))
                 {
                     assert(iconVal == 0);
-                    AssertionDsc dsc = AssertionDsc::CreateConstLclVarAssertion(this, lclNum, op1VN, 0, op2VN, equals);
-                    dsc.op2.kind     = O2K_ZEROOBJ;
+                    AssertionDsc dsc =
+                        AssertionDsc::CreateConstLclVarAssertion(this, lclNum, op1VN, O2K_ZEROOBJ, op2VN, equals);
                     return optAddAssertion(dsc);
                 }
 
@@ -1459,9 +1456,9 @@ AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
     //
     if (optLocalAssertionProp)
     {
-        assert(newAssertion.op1.kind == O1K_LCLVAR);
+        assert(newAssertion.op1.KindIs(O1K_LCLVAR));
 
-        unsigned        lclNum = newAssertion.op1.lclNum;
+        unsigned        lclNum = newAssertion.op1.GetLclNum();
         BitVecOps::Iter iter(apTraits, GetAssertionDep(lclNum));
         unsigned        bvIndex = 0;
         while (iter.NextElem(&bvIndex))
@@ -1520,12 +1517,12 @@ AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
     // Assertion mask bits are [index + 1].
     if (optLocalAssertionProp)
     {
-        assert(newAssertion.op1.kind == O1K_LCLVAR);
+        assert(newAssertion.op1.KindIs(O1K_LCLVAR));
 
         // Mark the variables this index depends on
-        unsigned lclNum = newAssertion.op1.lclNum;
+        unsigned lclNum = newAssertion.op1.GetLclNum();
         BitVecOps::AddElemD(apTraits, GetAssertionDep(lclNum), optAssertionCount - 1);
-        if (newAssertion.op2.kind == O2K_LCLVAR_COPY)
+        if (newAssertion.op2.KindIs(O2K_LCLVAR_COPY))
         {
             lclNum = newAssertion.op2.lclNum;
             BitVecOps::AddElemD(apTraits, GetAssertionDep(lclNum), optAssertionCount - 1);
@@ -1542,11 +1539,11 @@ AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
 void Compiler::optDebugCheckAssertion(const AssertionDsc& assertion) const
 {
     assert(assertion.assertionKind < OAK_COUNT);
-    assert(assertion.op1.kind < O1K_COUNT);
-    assert(assertion.op2.kind < O2K_COUNT);
+    assert(assertion.op1.GetKind() < O1K_COUNT);
+    assert(assertion.op2.GetKind() < O2K_COUNT);
     // It would be good to check that op1.vn and op2.vn are valid value numbers.
 
-    switch (assertion.op1.kind)
+    switch (assertion.op1.GetKind())
     {
         case O1K_ARR_BND:
             // It would be good to check that bnd.vnIdx and bnd.vnLen are valid value numbers.
@@ -1565,7 +1562,7 @@ void Compiler::optDebugCheckAssertion(const AssertionDsc& assertion) const
         default:
             break;
     }
-    switch (assertion.op2.kind)
+    switch (assertion.op2.GetKind())
     {
         case O2K_SUBRANGE:
         case O2K_LCLVAR_COPY:
@@ -1634,24 +1631,24 @@ void Compiler::optCreateComplementaryAssertion(AssertionIndex assertionIndex, Ge
     {
         // Don't create useless OAK_NOT_EQUAL assertions
 
-        if ((candidateAssertion.op1.kind == O1K_LCLVAR) || (candidateAssertion.op1.kind == O1K_VN))
+        if (candidateAssertion.op1.KindIs(O1K_LCLVAR, O1K_VN))
         {
             // "LCLVAR != CNS" is not a useful assertion (unless CNS is 0/1)
-            if (((candidateAssertion.op2.kind == O2K_CONST_INT)) && (candidateAssertion.op2.u1.iconVal != 0) &&
+            if (candidateAssertion.op2.KindIs(O2K_CONST_INT) && (candidateAssertion.op2.u1.iconVal != 0) &&
                 (candidateAssertion.op2.u1.iconVal != 1))
             {
                 return;
             }
 
             // "LCLVAR != LCLVAR_COPY"
-            if (candidateAssertion.op2.kind == O2K_LCLVAR_COPY)
+            if (candidateAssertion.op2.KindIs(O2K_LCLVAR_COPY))
             {
                 return;
             }
         }
 
         // "Object is not Class" is also not a useful assertion (at least for now)
-        if ((candidateAssertion.op1.kind == O1K_EXACT_TYPE) || (candidateAssertion.op1.kind == O1K_SUBTYPE))
+        if (candidateAssertion.op1.KindIs(O1K_EXACT_TYPE, O1K_SUBTYPE))
         {
             return;
         }
@@ -2172,7 +2169,7 @@ AssertionIndex Compiler::optAssertionIsSubrange(GenTree* tree, IntegralRange ran
         const AssertionDsc&  curAssertion = optGetAssertion(index);
         if (curAssertion.CanPropSubRange())
         {
-            if (curAssertion.op1.lclNum != tree->AsLclVarCommon()->GetLclNum())
+            if (curAssertion.op1.GetLclNum() != tree->AsLclVarCommon()->GetLclNum())
             {
                 continue;
             }
@@ -2204,8 +2201,7 @@ AssertionIndex Compiler::optAssertionIsSubtype(GenTree* tree, GenTree* methodTab
     {
         AssertionIndex const index        = GetAssertionIndex(bvIndex);
         const AssertionDsc&  curAssertion = optGetAssertion(index);
-        if ((curAssertion.assertionKind != OAK_EQUAL) ||
-            ((curAssertion.op1.kind != O1K_SUBTYPE) && (curAssertion.op1.kind != O1K_EXACT_TYPE)))
+        if ((curAssertion.assertionKind != OAK_EQUAL) || !curAssertion.op1.KindIs(O1K_SUBTYPE, O1K_EXACT_TYPE))
         {
             // TODO-CQ: We might benefit from OAK_NOT_EQUAL assertion as well, e.g.:
             // if (obj is not MyClass) // obj is known to be never of MyClass class
@@ -2216,8 +2212,8 @@ AssertionIndex Compiler::optAssertionIsSubtype(GenTree* tree, GenTree* methodTab
             continue;
         }
 
-        if ((curAssertion.op1.vn != vnStore->VNConservativeNormalValue(tree->gtVNPair) ||
-             (curAssertion.op2.kind != O2K_CONST_INT)))
+        if ((curAssertion.op1.GetVN() != vnStore->VNConservativeNormalValue(tree->gtVNPair) ||
+             !curAssertion.op2.KindIs(O2K_CONST_INT)))
         {
             continue;
         }
@@ -3000,7 +2996,7 @@ GenTree* Compiler::optConstantAssertionProp(const AssertionDsc&  curAssertion,
 
     // Update 'newTree' with the new value from our table
     // Typically newTree == tree and we are updating the node in place
-    switch (curAssertion.op2.kind)
+    switch (curAssertion.op2.GetKind())
     {
         case O2K_CONST_DOUBLE:
             // There could be a positive zero and a negative zero, so don't propagate zeroes.
@@ -3059,11 +3055,11 @@ GenTree* Compiler::optConstantAssertionProp(const AssertionDsc&  curAssertion,
 
     if (!optLocalAssertionProp)
     {
-        assert(newTree->OperIsConst());                     // We should have a simple Constant node for newTree
-        assert(vnStore->IsVNConstant(curAssertion.op2.vn)); // The value number stored for op2 should be a valid
-                                                            // VN representing the constant
-        newTree->gtVNPair.SetBoth(curAssertion.op2.vn);     // Set the ValueNumPair to the constant VN from op2
-                                                            // of the assertion
+        assert(newTree->OperIsConst());                          // We should have a simple Constant node for newTree
+        assert(vnStore->IsVNConstant(curAssertion.op2.GetVN())); // The value number stored for op2 should be a valid
+                                                                 // VN representing the constant
+        newTree->gtVNPair.SetBoth(curAssertion.op2.GetVN());     // Set the ValueNumPair to the constant VN from op2
+                                                                 // of the assertion
     }
 
 #ifdef DEBUG
@@ -3224,25 +3220,25 @@ GenTree* Compiler::optCopyAssertionProp(const AssertionDsc&  curAssertion,
     const AssertionDsc::AssertionDscOp1& op1 = curAssertion.op1;
     const AssertionDsc::AssertionDscOp2& op2 = curAssertion.op2;
 
-    noway_assert(op1.lclNum != op2.lclNum);
+    noway_assert(op1.GetLclNum() != op2.lclNum);
 
     const unsigned lclNum = tree->GetLclNum();
 
     // Make sure one of the lclNum of the assertion matches with that of the tree.
-    if (op1.lclNum != lclNum && op2.lclNum != lclNum)
+    if (op1.GetLclNum() != lclNum && op2.lclNum != lclNum)
     {
         return nullptr;
     }
 
     // Extract the matching lclNum and ssaNum, as well as the field sequence.
     unsigned copyLclNum;
-    if (op1.lclNum == lclNum)
+    if (op1.GetLclNum() == lclNum)
     {
         copyLclNum = op2.lclNum;
     }
     else
     {
-        copyLclNum = op1.lclNum;
+        copyLclNum = op1.GetLclNum();
     }
 
     LclVarDsc* const copyVarDsc = lvaGetDesc(copyLclNum);
@@ -3255,7 +3251,7 @@ GenTree* Compiler::optCopyAssertionProp(const AssertionDsc&  curAssertion,
     }
 
     // Make sure we can perform this copy prop.
-    if (optCopyProp_LclVarScore(lclVarDsc, copyVarDsc, curAssertion.op1.lclNum == lclNum) <= 0)
+    if (optCopyProp_LclVarScore(lclVarDsc, copyVarDsc, curAssertion.op1.GetLclNum() == lclNum) <= 0)
     {
         return nullptr;
     }
@@ -3357,7 +3353,7 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTreeL
         }
 
         // Copy prop.
-        if (curAssertion.op2.kind == O2K_LCLVAR_COPY)
+        if (curAssertion.op2.KindIs(O2K_LCLVAR_COPY))
         {
             // Cannot do copy prop during global assertion prop because of no knowledge
             // of kill sets. We will still make a == b copy assertions during the global phase to allow
@@ -3392,7 +3388,7 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTreeL
         if (optLocalAssertionProp)
         {
             // Check lclNum in Local Assertion Prop
-            if (curAssertion.op1.lclNum == lclNum)
+            if (curAssertion.op1.GetLclNum() == lclNum)
             {
                 return optConstantAssertionProp(curAssertion, tree, stmt DEBUGARG(assertionIndex));
             }
@@ -3400,7 +3396,7 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTreeL
         else
         {
             // Check VN in Global Assertion Prop
-            if (curAssertion.op1.vn == vnStore->VNConservativeNormalValue(tree->gtVNPair))
+            if (curAssertion.op1.GetVN() == vnStore->VNConservativeNormalValue(tree->gtVNPair))
             {
                 return optConstantAssertionProp(curAssertion, tree, stmt DEBUGARG(assertionIndex));
             }
@@ -3458,7 +3454,7 @@ GenTree* Compiler::optAssertionProp_LclFld(ASSERT_VALARG_TP assertions, GenTreeL
         // See if the variable is equal to another variable.
         //
         const AssertionDsc& curAssertion = optGetAssertion(assertionIndex);
-        if (curAssertion.CanPropLclVar() && (curAssertion.op2.kind == O2K_LCLVAR_COPY))
+        if (curAssertion.CanPropLclVar() && curAssertion.op2.KindIs(O2K_LCLVAR_COPY))
         {
             GenTree* const newTree = optCopyAssertionProp(curAssertion, tree, stmt DEBUGARG(assertionIndex));
             if (newTree != nullptr)
@@ -3635,7 +3631,7 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
         //   array[idx] = 42; // creates 'BoundsCheckNoThrow' assertion
         //   return idx % 8;  // idx is known to be never negative here, hence, MOD->UMOD
         //
-        if (curAssertion.IsBoundsCheckNoThrow() && (curAssertion.op1.bnd.vnIdx == treeVN))
+        if (curAssertion.IsBoundsCheckNoThrow() && (curAssertion.op1.GetArrBnd().vnIdx == treeVN))
         {
             *isKnownNonNegative = true;
             continue;
@@ -3646,7 +3642,7 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
         //  array[idx] = 42;
         //  array.Length is known to be non-negative and non-zero here
         //
-        if (curAssertion.IsBoundsCheckNoThrow() && (curAssertion.op1.bnd.vnLen == treeVN))
+        if (curAssertion.IsBoundsCheckNoThrow() && (curAssertion.op1.GetArrBnd().vnLen == treeVN))
         {
             *isKnownNonNegative = true;
             *isKnownNonZero     = true;
@@ -3654,7 +3650,7 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
         }
 
         // First, analyze possible X ==/!= CNS assertions.
-        if (curAssertion.IsConstantInt32Assertion() && (curAssertion.op1.vn == treeVN))
+        if (curAssertion.IsConstantInt32Assertion() && (curAssertion.op1.GetVN() == treeVN))
         {
             if ((curAssertion.assertionKind == OAK_NOT_EQUAL) && (curAssertion.op2.u1.iconVal == 0))
             {
@@ -3679,7 +3675,7 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
         }
 
         ValueNumStore::ConstantBoundInfo info;
-        vnStore->GetConstantBoundInfo(curAssertion.op1.vn, &info);
+        vnStore->GetConstantBoundInfo(curAssertion.op1.GetVN(), &info);
 
         if (info.cmpOpVN != treeVN)
         {
@@ -3689,7 +3685,7 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
         // Root assertion has to be either:
         // (X relop CNS) == 0
         // (X relop CNS) != 0
-        if ((curAssertion.op2.kind != O2K_CONST_INT) || (curAssertion.op2.u1.iconVal != 0))
+        if (!curAssertion.op2.KindIs(O2K_CONST_INT) || (curAssertion.op2.u1.iconVal != 0))
         {
             continue;
         }
@@ -3852,8 +3848,8 @@ AssertionIndex Compiler::optLocalAssertionIsEqualOrNotEqual(
             continue;
         }
 
-        if ((curAssertion.op1.kind == op1Kind) && (curAssertion.op1.lclNum == lclNum) &&
-            (curAssertion.op2.kind == op2Kind))
+        if (curAssertion.op1.KindIs(op1Kind) && (curAssertion.op1.GetLclNum() == lclNum) &&
+            curAssertion.op2.KindIs(op2Kind))
         {
             bool constantIsEqual  = (curAssertion.op2.u1.iconVal == cnsVal);
             bool assertionIsEqual = (curAssertion.assertionKind == OAK_EQUAL);
@@ -3906,8 +3902,8 @@ AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP as
             continue;
         }
 
-        if ((curAssertion.op1.vn == vnStore->VNConservativeNormalValue(op1->gtVNPair)) &&
-            (curAssertion.op2.vn == vnStore->VNConservativeNormalValue(op2->gtVNPair)))
+        if ((curAssertion.op1.GetVN() == vnStore->VNConservativeNormalValue(op1->gtVNPair)) &&
+            (curAssertion.op2.GetVN() == vnStore->VNConservativeNormalValue(op2->gtVNPair)))
         {
             return assertionIndex;
         }
@@ -3918,12 +3914,12 @@ AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP as
         //   op2:       'MyType' class handle
         //   Assertion: 'myObj's type is exactly MyType
         //
-        if ((curAssertion.assertionKind == OAK_EQUAL) && (curAssertion.op1.kind == O1K_EXACT_TYPE) &&
-            (curAssertion.op2.vn == vnStore->VNConservativeNormalValue(op2->gtVNPair)) && op1->TypeIs(TYP_I_IMPL))
+        if ((curAssertion.assertionKind == OAK_EQUAL) && curAssertion.op1.KindIs(O1K_EXACT_TYPE) &&
+            (curAssertion.op2.GetVN() == vnStore->VNConservativeNormalValue(op2->gtVNPair)) && op1->TypeIs(TYP_I_IMPL))
         {
             VNFuncApp funcApp;
             if (vnStore->GetVNFunc(vnStore->VNConservativeNormalValue(op1->gtVNPair), &funcApp) &&
-                (funcApp.m_func == VNF_InvariantNonNullLoad) && (curAssertion.op1.vn == funcApp.m_args[0]))
+                (funcApp.m_func == VNF_InvariantNonNullLoad) && (curAssertion.op1.GetVN() == funcApp.m_args[0]))
             {
                 return assertionIndex;
             }
@@ -3959,8 +3955,8 @@ AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqualZero(ASSERT_VALARG_T
             continue;
         }
 
-        if ((curAssertion.op1.vn == vnStore->VNConservativeNormalValue(op1->gtVNPair)) &&
-            (curAssertion.op2.vn == vnStore->VNZeroForType(op1->TypeGet())))
+        if ((curAssertion.op1.GetVN() == vnStore->VNConservativeNormalValue(op1->gtVNPair)) &&
+            (curAssertion.op2.GetVN() == vnStore->VNZeroForType(op1->TypeGet())))
         {
             return assertionIndex;
         }
@@ -4646,7 +4642,8 @@ bool Compiler::optAssertionIsNonNull(GenTree* op, ASSERT_VALARG_TP assertions)
         {
             AssertionIndex      assertionIndex = GetAssertionIndex(index);
             const AssertionDsc& curAssertion   = optGetAssertion(assertionIndex);
-            if (curAssertion.CanPropNonNull() && ((curAssertion.op1.vn == vn) || (curAssertion.op1.vn == vnBase)))
+            if (curAssertion.CanPropNonNull() &&
+                ((curAssertion.op1.GetVN() == vn) || (curAssertion.op1.GetVN() == vnBase)))
             {
                 return true;
             }
@@ -4669,9 +4666,9 @@ bool Compiler::optAssertionIsNonNull(GenTree* op, ASSERT_VALARG_TP assertions)
             const AssertionDsc& curAssertion   = optGetAssertion(assertionIndex);
 
             if ((curAssertion.assertionKind == OAK_NOT_EQUAL) && // kind
-                (curAssertion.op1.kind == O1K_LCLVAR) &&         // op1
-                (curAssertion.op2.kind == O2K_CONST_INT) &&      // op2
-                (curAssertion.op1.lclNum == lclNum) && (curAssertion.op2.u1.iconVal == 0))
+                curAssertion.op1.KindIs(O1K_LCLVAR) &&           // op1
+                curAssertion.op2.KindIs(O2K_CONST_INT) &&        // op2
+                (curAssertion.op1.GetLclNum() == lclNum) && (curAssertion.op2.u1.iconVal == 0))
             {
                 return true;
             }
@@ -4705,7 +4702,7 @@ bool Compiler::optAssertionVNIsNonNull(ValueNum vn, ASSERT_VALARG_TP assertions)
         while (iter.NextElem(&index))
         {
             const AssertionDsc& curAssertion = optGetAssertion(GetAssertionIndex(index));
-            if (curAssertion.CanPropNonNull() && curAssertion.op1.vn == vn)
+            if (curAssertion.CanPropNonNull() && curAssertion.op1.GetVN() == vn)
             {
                 return true;
             }
@@ -5066,11 +5063,12 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
         }
 
         // Do we have a previous range check involving the same 'vnLen' upper bound?
-        if (curAssertion.op1.bnd.vnLen == vnStore->VNConservativeNormalValue(arrBndsChk->GetArrayLength()->gtVNPair))
+        if (curAssertion.op1.GetArrBnd().vnLen ==
+            vnStore->VNConservativeNormalValue(arrBndsChk->GetArrayLength()->gtVNPair))
         {
             // Do we have the exact same lower bound 'vnIdx'?
             //       a[i] followed by a[i]
-            if (curAssertion.op1.bnd.vnIdx == vnCurIdx)
+            if (curAssertion.op1.GetArrBnd().vnIdx == vnCurIdx)
             {
                 return dropBoundsCheck(INDEBUG("a[i] followed by a[i]"));
             }
@@ -5110,7 +5108,7 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
 
                 int index1;
                 int index2;
-                if (tryGetMaxOrMinConst(curAssertion.op1.bnd.vnIdx, /*min*/ true, &index1) &&
+                if (tryGetMaxOrMinConst(curAssertion.op1.GetArrBnd().vnIdx, /*min*/ true, &index1) &&
                     tryGetMaxOrMinConst(vnCurIdx, /*max*/ false, &index2))
                 {
                     // It can always be considered as redundant with any previous higher constant value

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -757,31 +757,31 @@ void Compiler::optAssertionInit(bool isLocalProp)
 #ifdef DEBUG
 void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionIndex assertionIndex /* = 0 */)
 {
-    if (curAssertion.op1.KindIs(O1K_EXACT_TYPE))
+    if (curAssertion.GetOp1().KindIs(O1K_EXACT_TYPE))
     {
         printf("Type     ");
     }
-    else if (curAssertion.op1.KindIs(O1K_ARR_BND))
+    else if (curAssertion.GetOp1().KindIs(O1K_ARR_BND))
     {
         printf("ArrBnds  ");
     }
-    else if (curAssertion.op1.KindIs(O1K_VN))
+    else if (curAssertion.GetOp1().KindIs(O1K_VN))
     {
         printf("Vn  ");
     }
-    else if (curAssertion.op1.KindIs(O1K_SUBTYPE))
+    else if (curAssertion.GetOp1().KindIs(O1K_SUBTYPE))
     {
         printf("Subtype  ");
     }
-    else if (curAssertion.op2.KindIs(O2K_LCLVAR_COPY))
+    else if (curAssertion.GetOp2().KindIs(O2K_LCLVAR_COPY))
     {
         printf("Copy     ");
     }
-    else if (curAssertion.op2.KindIs(O2K_CONST_INT, O2K_CONST_DOUBLE, O2K_ZEROOBJ))
+    else if (curAssertion.GetOp2().KindIs(O2K_CONST_INT, O2K_CONST_DOUBLE, O2K_ZEROOBJ))
     {
         printf("Constant ");
     }
-    else if (curAssertion.op2.KindIs(O2K_SUBRANGE))
+    else if (curAssertion.GetOp2().KindIs(O2K_SUBRANGE))
     {
         printf("Subrange ");
     }
@@ -793,77 +793,77 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
 
     if (!optLocalAssertionProp)
     {
-        printf("(" FMT_VN "," FMT_VN ") ", curAssertion.op1.GetVN(), curAssertion.op2.GetVN());
+        printf("(" FMT_VN "," FMT_VN ") ", curAssertion.GetOp1().GetVN(), curAssertion.GetOp2().GetVN());
     }
 
-    if (curAssertion.op1.KindIs(O1K_LCLVAR))
+    if (curAssertion.GetOp1().KindIs(O1K_LCLVAR))
     {
         if (!optLocalAssertionProp)
         {
             printf("LCLVAR");
-            vnStore->vnDump(this, curAssertion.op1.GetVN());
+            vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
         }
         else
         {
-            printf("V%02u", curAssertion.op1.GetLclNum());
+            printf("V%02u", curAssertion.GetOp1().GetLclNum());
         }
     }
-    else if (curAssertion.op1.KindIs(O1K_EXACT_TYPE))
+    else if (curAssertion.GetOp1().KindIs(O1K_EXACT_TYPE))
     {
         printf("Exact_Type");
-        vnStore->vnDump(this, curAssertion.op1.GetVN());
+        vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
     }
-    else if (curAssertion.op1.KindIs(O1K_SUBTYPE))
+    else if (curAssertion.GetOp1().KindIs(O1K_SUBTYPE))
     {
         printf("Sub_Type");
-        vnStore->vnDump(this, curAssertion.op1.GetVN());
+        vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
     }
-    else if (curAssertion.op1.KindIs(O1K_ARR_BND))
+    else if (curAssertion.GetOp1().KindIs(O1K_ARR_BND))
     {
-        printf("[idx: " FMT_VN, curAssertion.op1.GetArrBndIndex());
-        vnStore->vnDump(this, curAssertion.op1.GetArrBndIndex());
-        printf("; len: " FMT_VN, curAssertion.op1.GetArrBndLength());
-        vnStore->vnDump(this, curAssertion.op1.GetArrBndLength());
+        printf("[idx: " FMT_VN, curAssertion.GetOp1().GetArrBndIndex());
+        vnStore->vnDump(this, curAssertion.GetOp1().GetArrBndIndex());
+        printf("; len: " FMT_VN, curAssertion.GetOp1().GetArrBndLength());
+        vnStore->vnDump(this, curAssertion.GetOp1().GetArrBndLength());
         printf("]");
     }
-    else if (curAssertion.op1.KindIs(O1K_VN))
+    else if (curAssertion.GetOp1().KindIs(O1K_VN))
     {
-        printf("[vn: " FMT_VN, curAssertion.op1.GetVN());
-        vnStore->vnDump(this, curAssertion.op1.GetVN());
+        printf("[vn: " FMT_VN, curAssertion.GetOp1().GetVN());
+        vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
         printf("]");
     }
-    else if (curAssertion.op1.KindIs(O1K_BOUND_OPER_BND))
+    else if (curAssertion.GetOp1().KindIs(O1K_BOUND_OPER_BND))
     {
         printf("Oper_Bnd");
-        vnStore->vnDump(this, curAssertion.op1.GetVN());
+        vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
     }
-    else if (curAssertion.op1.KindIs(O1K_BOUND_LOOP_BND))
+    else if (curAssertion.GetOp1().KindIs(O1K_BOUND_LOOP_BND))
     {
         printf("Loop_Bnd");
-        vnStore->vnDump(this, curAssertion.op1.GetVN());
+        vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
     }
-    else if (curAssertion.op1.KindIs(O1K_CONSTANT_LOOP_BND))
+    else if (curAssertion.GetOp1().KindIs(O1K_CONSTANT_LOOP_BND))
     {
         printf("Const_Loop_Bnd");
-        vnStore->vnDump(this, curAssertion.op1.GetVN());
+        vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
     }
-    else if (curAssertion.op1.KindIs(O1K_CONSTANT_LOOP_BND_UN))
+    else if (curAssertion.GetOp1().KindIs(O1K_CONSTANT_LOOP_BND_UN))
     {
         printf("Const_Loop_Bnd_Un");
-        vnStore->vnDump(this, curAssertion.op1.GetVN());
+        vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
     }
     else
     {
         printf("?op1.kind?");
     }
 
-    if (curAssertion.assertionKind == OAK_SUBRANGE)
+    if (curAssertion.KindIs(OAK_SUBRANGE))
     {
         printf(" in ");
     }
-    else if (curAssertion.assertionKind == OAK_EQUAL)
+    else if (curAssertion.KindIs(OAK_EQUAL))
     {
-        if (curAssertion.op1.KindIs(O1K_LCLVAR))
+        if (curAssertion.GetOp1().KindIs(O1K_LCLVAR))
         {
             printf(" == ");
         }
@@ -872,13 +872,13 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
             printf(" is ");
         }
     }
-    else if (curAssertion.assertionKind == OAK_NO_THROW)
+    else if (curAssertion.KindIs(OAK_NO_THROW))
     {
         printf(" in range ");
     }
-    else if (curAssertion.assertionKind == OAK_NOT_EQUAL)
+    else if (curAssertion.KindIs(OAK_NOT_EQUAL))
     {
-        if (curAssertion.op1.KindIs(O1K_LCLVAR))
+        if (curAssertion.GetOp1().KindIs(O1K_LCLVAR))
         {
             printf(" != ");
         }
@@ -892,18 +892,18 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
         printf(" ?assertionKind? ");
     }
 
-    if (!curAssertion.op1.KindIs(O1K_ARR_BND))
+    if (!curAssertion.GetOp1().KindIs(O1K_ARR_BND))
     {
-        switch (curAssertion.op2.GetKind())
+        switch (curAssertion.GetOp2().GetKind())
         {
             case O2K_LCLVAR_COPY:
-                printf("V%02u", curAssertion.op2.GetLclNum());
+                printf("V%02u", curAssertion.GetOp2().GetLclNum());
                 break;
 
             case O2K_CONST_INT:
-                if (curAssertion.op1.KindIs(O1K_EXACT_TYPE))
+                if (curAssertion.GetOp1().KindIs(O1K_EXACT_TYPE))
                 {
-                    ssize_t iconVal = curAssertion.op2.GetIntConstant();
+                    ssize_t iconVal = curAssertion.GetOp2().GetIntConstant();
                     if (IsAot())
                     {
                         printf("Exact Type MT(0x%p)", dspPtr(iconVal));
@@ -915,15 +915,15 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
                     }
 
                     // We might want to assert:
-                    //      assert(curAssertion.op2.HasIconFlag());
+                    //      assert(curAssertion.GetOp2().HasIconFlag());
                     // However, if we run CSE with shared constant mode, we may end up with an expression instead
                     // of the original handle value. If we then use JitOptRepeat to re-build value numbers, we lose
                     // knowledge that the constant was ever a handle, as the expression creating the original value
                     // was not (and can't be) assigned a handle flag.
                 }
-                else if (curAssertion.op1.KindIs(O1K_SUBTYPE))
+                else if (curAssertion.GetOp1().KindIs(O1K_SUBTYPE))
                 {
-                    ssize_t iconVal = curAssertion.op2.GetIntConstant();
+                    ssize_t iconVal = curAssertion.GetOp2().GetIntConstant();
                     if (IsAot())
                     {
                         printf("MT(0x%p)", dspPtr(iconVal));
@@ -932,51 +932,51 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
                     {
                         printf("MT(0x%p %s)", dspPtr(iconVal), eeGetClassName((CORINFO_CLASS_HANDLE)iconVal));
                     }
-                    assert(curAssertion.op2.HasIconFlag());
+                    assert(curAssertion.GetOp2().HasIconFlag());
                 }
-                else if (curAssertion.op1.KindIs(O1K_BOUND_OPER_BND, O1K_BOUND_LOOP_BND, O1K_CONSTANT_LOOP_BND,
-                                                 O1K_CONSTANT_LOOP_BND_UN))
+                else if (curAssertion.GetOp1().KindIs(O1K_BOUND_OPER_BND, O1K_BOUND_LOOP_BND, O1K_CONSTANT_LOOP_BND,
+                                                      O1K_CONSTANT_LOOP_BND_UN))
                 {
                     assert(!optLocalAssertionProp);
-                    vnStore->vnDump(this, curAssertion.op2.GetVN());
+                    vnStore->vnDump(this, curAssertion.GetOp2().GetVN());
                 }
                 else
                 {
-                    var_types op1Type = !optLocalAssertionProp ? vnStore->TypeOfVN(curAssertion.op1.GetVN())
-                                                               : lvaGetRealType(curAssertion.op1.GetLclNum());
+                    var_types op1Type = !optLocalAssertionProp ? vnStore->TypeOfVN(curAssertion.GetOp1().GetVN())
+                                                               : lvaGetRealType(curAssertion.GetOp1().GetLclNum());
                     if (op1Type == TYP_REF)
                     {
-                        if (curAssertion.op2.GetIntConstant() == 0)
+                        if (curAssertion.GetOp2().GetIntConstant() == 0)
                         {
                             printf("null");
                         }
                         else
                         {
-                            printf("[%08p]", dspPtr(curAssertion.op2.GetIntConstant()));
+                            printf("[%08p]", dspPtr(curAssertion.GetOp2().GetIntConstant()));
                         }
                     }
                     else
                     {
-                        if (curAssertion.op2.HasIconFlag())
+                        if (curAssertion.GetOp2().HasIconFlag())
                         {
-                            printf("[%08p]", dspPtr(curAssertion.op2.GetIntConstant()));
+                            printf("[%08p]", dspPtr(curAssertion.GetOp2().GetIntConstant()));
                         }
                         else
                         {
-                            printf("%d", curAssertion.op2.GetIntConstant());
+                            printf("%d", curAssertion.GetOp2().GetIntConstant());
                         }
                     }
                 }
                 break;
 
             case O2K_CONST_DOUBLE:
-                if (FloatingPointUtils::isNegativeZero(curAssertion.op2.GetDoubleConstant()))
+                if (FloatingPointUtils::isNegativeZero(curAssertion.GetOp2().GetDoubleConstant()))
                 {
                     printf("-0.00000");
                 }
                 else
                 {
-                    printf("%#lg", curAssertion.op2.GetDoubleConstant());
+                    printf("%#lg", curAssertion.GetOp2().GetDoubleConstant());
                 }
                 break;
 
@@ -985,7 +985,7 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
                 break;
 
             case O2K_SUBRANGE:
-                IntegralRange::Print(curAssertion.op2.GetIntegralRange());
+                IntegralRange::Print(curAssertion.GetOp2().GetIntegralRange());
                 break;
 
             default:
@@ -1269,10 +1269,8 @@ AssertionIndex Compiler::optCreateAssertion(GenTree* op1, GenTree* op2, bool equ
                 }
 
                 AssertionDsc dsc =
-                    AssertionDsc::CreateConstLclVarAssertion(this, lclNum, op1VN, iconVal, op2VN, equals);
-
-                // Attach the handle flag with FieldSeq if any.
-                dsc.op2.SetIconFlag(op2->GetIconHandleFlag(), op2->AsIntCon()->gtFieldSeq);
+                    AssertionDsc::CreateConstLclVarAssertion(this, lclNum, op1VN, iconVal, op2VN, equals,
+                                                             op2->GetIconHandleFlag(), op2->AsIntCon()->gtFieldSeq);
                 return optAddAssertion(dsc);
             }
 
@@ -1446,8 +1444,6 @@ bool Compiler::optIsTreeKnownIntValue(bool vnBased, GenTree* tree, ssize_t* pCon
  */
 AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
 {
-    noway_assert(newAssertion.assertionKind != OAK_INVALID);
-
     // See if we already have this assertion in the table.
     //
     // For local assertion prop we can speed things up by checking the dep vector.
@@ -1456,9 +1452,9 @@ AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
     //
     if (optLocalAssertionProp)
     {
-        assert(newAssertion.op1.KindIs(O1K_LCLVAR));
+        assert(newAssertion.GetOp1().KindIs(O1K_LCLVAR));
 
-        unsigned        lclNum = newAssertion.op1.GetLclNum();
+        unsigned        lclNum = newAssertion.GetOp1().GetLclNum();
         BitVecOps::Iter iter(apTraits, GetAssertionDep(lclNum));
         unsigned        bvIndex = 0;
         while (iter.NextElem(&bvIndex))
@@ -1517,14 +1513,14 @@ AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
     // Assertion mask bits are [index + 1].
     if (optLocalAssertionProp)
     {
-        assert(newAssertion.op1.KindIs(O1K_LCLVAR));
+        assert(newAssertion.GetOp1().KindIs(O1K_LCLVAR));
 
         // Mark the variables this index depends on
-        unsigned lclNum = newAssertion.op1.GetLclNum();
+        unsigned lclNum = newAssertion.GetOp1().GetLclNum();
         BitVecOps::AddElemD(apTraits, GetAssertionDep(lclNum), optAssertionCount - 1);
-        if (newAssertion.op2.KindIs(O2K_LCLVAR_COPY))
+        if (newAssertion.GetOp2().KindIs(O2K_LCLVAR_COPY))
         {
-            lclNum = newAssertion.op2.GetLclNum();
+            lclNum = newAssertion.GetOp2().GetLclNum();
             BitVecOps::AddElemD(apTraits, GetAssertionDep(lclNum), optAssertionCount - 1);
         }
     }
@@ -1538,17 +1534,12 @@ AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
 #ifdef DEBUG
 void Compiler::optDebugCheckAssertion(const AssertionDsc& assertion) const
 {
-    assert(assertion.assertionKind < OAK_COUNT);
-    assert(assertion.op1.GetKind() < O1K_COUNT);
-    assert(assertion.op2.GetKind() < O2K_COUNT);
-    // It would be good to check that op1.vn and op2.vn are valid value numbers.
-
-    switch (assertion.op1.GetKind())
+    switch (assertion.GetOp1().GetKind())
     {
         case O1K_ARR_BND:
             // It would be good to check that bnd.vnIdx and bnd.vnLen are valid value numbers.
             assert(!optLocalAssertionProp);
-            assert(assertion.assertionKind == OAK_NO_THROW);
+            assert(assertion.KindIs(OAK_NO_THROW));
             break;
         case O1K_EXACT_TYPE:
         case O1K_SUBTYPE:
@@ -1562,7 +1553,13 @@ void Compiler::optDebugCheckAssertion(const AssertionDsc& assertion) const
         default:
             break;
     }
-    switch (assertion.op2.GetKind())
+
+    if (!assertion.HasOp2())
+    {
+        return;
+    }
+
+    switch (assertion.GetOp2().GetKind())
     {
         case O2K_SUBRANGE:
         case O2K_LCLVAR_COPY:
@@ -1571,16 +1568,16 @@ void Compiler::optDebugCheckAssertion(const AssertionDsc& assertion) const
 
         case O2K_ZEROOBJ:
             // We only make these assertion for stores (not control flow).
-            assert(assertion.assertionKind == OAK_EQUAL);
+            assert(assertion.KindIs(OAK_EQUAL));
             // We use "optLocalAssertionIsEqualOrNotEqual" to find these.
             break;
 
         case O2K_CONST_DOUBLE:
-            assert(!FloatingPointUtils::isNaN(assertion.op2.GetDoubleConstant()));
+            assert(!FloatingPointUtils::isNaN(assertion.GetOp2().GetDoubleConstant()));
             break;
 
         default:
-            // for all other 'assertion.op2.kind' values we don't check anything
+            // for all other 'assertion.GetOp2().GetKind()' values we don't check anything
             break;
     }
 }
@@ -1626,28 +1623,29 @@ void Compiler::optCreateComplementaryAssertion(AssertionIndex assertionIndex, Ge
 
     const AssertionDsc& candidateAssertion = optGetAssertion(assertionIndex);
 
-    if (candidateAssertion.assertionKind == OAK_EQUAL)
+    if (candidateAssertion.KindIs(OAK_EQUAL))
     {
         // Don't create useless OAK_NOT_EQUAL assertions
 
-        if (candidateAssertion.op1.KindIs(O1K_LCLVAR, O1K_VN))
+        if (candidateAssertion.GetOp1().KindIs(O1K_LCLVAR, O1K_VN))
         {
             // "LCLVAR != CNS" is not a useful assertion (unless CNS is 0/1)
-            if (candidateAssertion.op2.KindIs(O2K_CONST_INT) && (candidateAssertion.op2.GetIntConstant() != 0) &&
-                (candidateAssertion.op2.GetIntConstant() != 1))
+            if (candidateAssertion.GetOp2().KindIs(O2K_CONST_INT) &&
+                (candidateAssertion.GetOp2().GetIntConstant() != 0) &&
+                (candidateAssertion.GetOp2().GetIntConstant() != 1))
             {
                 return;
             }
 
             // "LCLVAR != LCLVAR_COPY"
-            if (candidateAssertion.op2.KindIs(O2K_LCLVAR_COPY))
+            if (candidateAssertion.GetOp2().KindIs(O2K_LCLVAR_COPY))
             {
                 return;
             }
         }
 
         // "Object is not Class" is also not a useful assertion (at least for now)
-        if (candidateAssertion.op1.KindIs(O1K_EXACT_TYPE, O1K_SUBTYPE))
+        if (candidateAssertion.GetOp1().KindIs(O1K_EXACT_TYPE, O1K_SUBTYPE))
         {
             return;
         }
@@ -1655,7 +1653,7 @@ void Compiler::optCreateComplementaryAssertion(AssertionIndex assertionIndex, Ge
         AssertionDsc reversed = candidateAssertion.ReverseEquality();
         optMapComplementary(optAddAssertion(reversed), assertionIndex);
     }
-    else if (candidateAssertion.assertionKind == OAK_NOT_EQUAL)
+    else if (candidateAssertion.KindIs(OAK_NOT_EQUAL))
     {
         // All OAK_EQUAL assertions are potentially useful
 
@@ -2113,7 +2111,7 @@ AssertionIndex Compiler::optFindComplementary(AssertionIndex assertIndex)
     const AssertionDsc& inputAssertion = optGetAssertion(assertIndex);
 
     // Must be an equal or not equal assertion.
-    if (inputAssertion.assertionKind != OAK_EQUAL && inputAssertion.assertionKind != OAK_NOT_EQUAL)
+    if (!inputAssertion.KindIs(OAK_EQUAL) && !inputAssertion.KindIs(OAK_NOT_EQUAL))
     {
         return NO_ASSERTION_INDEX;
     }
@@ -2168,12 +2166,12 @@ AssertionIndex Compiler::optAssertionIsSubrange(GenTree* tree, IntegralRange ran
         const AssertionDsc&  curAssertion = optGetAssertion(index);
         if (curAssertion.CanPropSubRange())
         {
-            if (curAssertion.op1.GetLclNum() != tree->AsLclVarCommon()->GetLclNum())
+            if (curAssertion.GetOp1().GetLclNum() != tree->AsLclVarCommon()->GetLclNum())
             {
                 continue;
             }
 
-            if (range.Contains(curAssertion.op2.GetIntegralRange()))
+            if (range.Contains(curAssertion.GetOp2().GetIntegralRange()))
             {
                 return index;
             }
@@ -2200,7 +2198,7 @@ AssertionIndex Compiler::optAssertionIsSubtype(GenTree* tree, GenTree* methodTab
     {
         AssertionIndex const index        = GetAssertionIndex(bvIndex);
         const AssertionDsc&  curAssertion = optGetAssertion(index);
-        if ((curAssertion.assertionKind != OAK_EQUAL) || !curAssertion.op1.KindIs(O1K_SUBTYPE, O1K_EXACT_TYPE))
+        if (!curAssertion.KindIs(OAK_EQUAL) || !curAssertion.GetOp1().KindIs(O1K_SUBTYPE, O1K_EXACT_TYPE))
         {
             // TODO-CQ: We might benefit from OAK_NOT_EQUAL assertion as well, e.g.:
             // if (obj is not MyClass) // obj is known to be never of MyClass class
@@ -2211,8 +2209,8 @@ AssertionIndex Compiler::optAssertionIsSubtype(GenTree* tree, GenTree* methodTab
             continue;
         }
 
-        if ((curAssertion.op1.GetVN() != vnStore->VNConservativeNormalValue(tree->gtVNPair) ||
-             !curAssertion.op2.KindIs(O2K_CONST_INT)))
+        if ((curAssertion.GetOp1().GetVN() != vnStore->VNConservativeNormalValue(tree->gtVNPair) ||
+             !curAssertion.GetOp2().KindIs(O2K_CONST_INT)))
         {
             continue;
         }
@@ -2224,7 +2222,7 @@ AssertionIndex Compiler::optAssertionIsSubtype(GenTree* tree, GenTree* methodTab
             continue;
         }
 
-        if (curAssertion.op2.GetIntConstant() == methodTableVal)
+        if (curAssertion.GetOp2().GetIntConstant() == methodTableVal)
         {
             // TODO-CQ: if they don't match, we might still be able to prove that the result is foldable via
             // compareTypesForCast.
@@ -2995,23 +2993,23 @@ GenTree* Compiler::optConstantAssertionProp(const AssertionDsc&  curAssertion,
 
     // Update 'newTree' with the new value from our table
     // Typically newTree == tree and we are updating the node in place
-    switch (curAssertion.op2.GetKind())
+    switch (curAssertion.GetOp2().GetKind())
     {
         case O2K_CONST_DOUBLE:
             // There could be a positive zero and a negative zero, so don't propagate zeroes.
-            if (curAssertion.op2.GetDoubleConstant() == 0.0)
+            if (curAssertion.GetOp2().GetDoubleConstant() == 0.0)
             {
                 return nullptr;
             }
-            newTree->BashToConst(curAssertion.op2.GetDoubleConstant(), tree->TypeGet());
+            newTree->BashToConst(curAssertion.GetOp2().GetDoubleConstant(), tree->TypeGet());
             break;
 
         case O2K_CONST_INT:
 
             // Don't propagate non-nulll non-static handles if we need to report relocs.
-            if (opts.compReloc && curAssertion.op2.HasIconFlag() && (curAssertion.op2.GetIntConstant() != 0))
+            if (opts.compReloc && curAssertion.GetOp2().HasIconFlag() && (curAssertion.GetOp2().GetIntConstant() != 0))
             {
-                if (curAssertion.op2.GetIconFlag() != GTF_ICON_STATIC_HDL)
+                if (curAssertion.GetOp2().GetIconFlag() != GTF_ICON_STATIC_HDL)
                 {
                     return nullptr;
                 }
@@ -3023,11 +3021,12 @@ GenTree* Compiler::optConstantAssertionProp(const AssertionDsc&  curAssertion,
             // here).
             assert(tree->TypeGet() == lvaGetDesc(lclNum)->TypeGet());
 
-            if (curAssertion.op2.HasIconFlag())
+            if (curAssertion.GetOp2().HasIconFlag())
             {
                 // Here we have to allocate a new 'large' node to replace the old one
-                newTree = gtNewIconHandleNode(curAssertion.op2.GetIntConstant(), curAssertion.op2.GetIconFlag(),
-                                              curAssertion.op2.GetIconFieldSeq());
+                newTree =
+                    gtNewIconHandleNode(curAssertion.GetOp2().GetIntConstant(), curAssertion.GetOp2().GetIconFlag(),
+                                        curAssertion.GetOp2().GetIconFieldSeq());
 
                 // Make sure we don't retype const gc handles to TYP_I_IMPL
                 // Although, it's possible for e.g. GTF_ICON_STATIC_HDL
@@ -3044,7 +3043,7 @@ GenTree* Compiler::optConstantAssertionProp(const AssertionDsc&  curAssertion,
             else
             {
                 assert(varTypeIsIntegralOrI(tree));
-                newTree->BashToConst(curAssertion.op2.GetIntConstant(), genActualType(tree));
+                newTree->BashToConst(curAssertion.GetOp2().GetIntConstant(), genActualType(tree));
             }
             break;
 
@@ -3054,11 +3053,11 @@ GenTree* Compiler::optConstantAssertionProp(const AssertionDsc&  curAssertion,
 
     if (!optLocalAssertionProp)
     {
-        assert(newTree->OperIsConst());                          // We should have a simple Constant node for newTree
-        assert(vnStore->IsVNConstant(curAssertion.op2.GetVN())); // The value number stored for op2 should be a valid
-                                                                 // VN representing the constant
-        newTree->gtVNPair.SetBoth(curAssertion.op2.GetVN());     // Set the ValueNumPair to the constant VN from op2
-                                                                 // of the assertion
+        assert(newTree->OperIsConst()); // We should have a simple Constant node for newTree
+        assert(vnStore->IsVNConstant(curAssertion.GetOp2().GetVN())); // The value number stored for op2 should be a
+                                                                      // valid VN representing the constant
+        newTree->gtVNPair.SetBoth(curAssertion.GetOp2().GetVN()); // Set the ValueNumPair to the constant VN from op2
+                                                                  // of the assertion
     }
 
 #ifdef DEBUG
@@ -3216,8 +3215,8 @@ GenTree* Compiler::optCopyAssertionProp(const AssertionDsc&  curAssertion,
 {
     assert(optLocalAssertionProp);
 
-    const AssertionDsc::AssertionDscOp1& op1 = curAssertion.op1;
-    const AssertionDsc::AssertionDscOp2& op2 = curAssertion.op2;
+    const AssertionDsc::AssertionDscOp1& op1 = curAssertion.GetOp1();
+    const AssertionDsc::AssertionDscOp2& op2 = curAssertion.GetOp2();
 
     noway_assert(op1.GetLclNum() != op2.GetLclNum());
 
@@ -3250,7 +3249,7 @@ GenTree* Compiler::optCopyAssertionProp(const AssertionDsc&  curAssertion,
     }
 
     // Make sure we can perform this copy prop.
-    if (optCopyProp_LclVarScore(lclVarDsc, copyVarDsc, curAssertion.op1.GetLclNum() == lclNum) <= 0)
+    if (optCopyProp_LclVarScore(lclVarDsc, copyVarDsc, curAssertion.GetOp1().GetLclNum() == lclNum) <= 0)
     {
         return nullptr;
     }
@@ -3352,7 +3351,7 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTreeL
         }
 
         // Copy prop.
-        if (curAssertion.op2.KindIs(O2K_LCLVAR_COPY))
+        if (curAssertion.GetOp2().KindIs(O2K_LCLVAR_COPY))
         {
             // Cannot do copy prop during global assertion prop because of no knowledge
             // of kill sets. We will still make a == b copy assertions during the global phase to allow
@@ -3387,7 +3386,7 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTreeL
         if (optLocalAssertionProp)
         {
             // Check lclNum in Local Assertion Prop
-            if (curAssertion.op1.GetLclNum() == lclNum)
+            if (curAssertion.GetOp1().GetLclNum() == lclNum)
             {
                 return optConstantAssertionProp(curAssertion, tree, stmt DEBUGARG(assertionIndex));
             }
@@ -3395,7 +3394,7 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTreeL
         else
         {
             // Check VN in Global Assertion Prop
-            if (curAssertion.op1.GetVN() == vnStore->VNConservativeNormalValue(tree->gtVNPair))
+            if (curAssertion.GetOp1().GetVN() == vnStore->VNConservativeNormalValue(tree->gtVNPair))
             {
                 return optConstantAssertionProp(curAssertion, tree, stmt DEBUGARG(assertionIndex));
             }
@@ -3453,7 +3452,7 @@ GenTree* Compiler::optAssertionProp_LclFld(ASSERT_VALARG_TP assertions, GenTreeL
         // See if the variable is equal to another variable.
         //
         const AssertionDsc& curAssertion = optGetAssertion(assertionIndex);
-        if (curAssertion.CanPropLclVar() && curAssertion.op2.KindIs(O2K_LCLVAR_COPY))
+        if (curAssertion.CanPropLclVar() && curAssertion.GetOp2().KindIs(O2K_LCLVAR_COPY))
         {
             GenTree* const newTree = optCopyAssertionProp(curAssertion, tree, stmt DEBUGARG(assertionIndex));
             if (newTree != nullptr)
@@ -3518,8 +3517,8 @@ GenTree* Compiler::optAssertionProp_LocalStore(ASSERT_VALARG_TP assertions, GenT
     if (dstIndex != NO_ASSERTION_INDEX)
     {
         const AssertionDsc& dstAssertion = optGetAssertion(dstIndex);
-        if ((dstAssertion.assertionKind == OAK_EQUAL) &&
-            (dstAssertion.op2.KindIs(O2K_ZEROOBJ) || (dstAssertion.op2.GetIntConstant() == 0)))
+        if (dstAssertion.KindIs(OAK_EQUAL) &&
+            (dstAssertion.GetOp2().KindIs(O2K_ZEROOBJ) || (dstAssertion.GetOp2().GetIntConstant() == 0)))
         {
             // Destination is zero. Is value a literal zero? If so we don't need the store.
             //
@@ -3631,7 +3630,7 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
         //   array[idx] = 42; // creates 'BoundsCheckNoThrow' assertion
         //   return idx % 8;  // idx is known to be never negative here, hence, MOD->UMOD
         //
-        if (curAssertion.IsBoundsCheckNoThrow() && (curAssertion.op1.GetArrBndIndex() == treeVN))
+        if (curAssertion.IsBoundsCheckNoThrow() && (curAssertion.GetOp1().GetArrBndIndex() == treeVN))
         {
             *isKnownNonNegative = true;
             continue;
@@ -3642,7 +3641,7 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
         //  array[idx] = 42;
         //  array.Length is known to be non-negative and non-zero here
         //
-        if (curAssertion.IsBoundsCheckNoThrow() && (curAssertion.op1.GetArrBndLength() == treeVN))
+        if (curAssertion.IsBoundsCheckNoThrow() && (curAssertion.GetOp1().GetArrBndLength() == treeVN))
         {
             *isKnownNonNegative = true;
             *isKnownNonZero     = true;
@@ -3650,20 +3649,20 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
         }
 
         // First, analyze possible X ==/!= CNS assertions.
-        if (curAssertion.IsConstantInt32Assertion() && (curAssertion.op1.GetVN() == treeVN))
+        if (curAssertion.IsConstantInt32Assertion() && (curAssertion.GetOp1().GetVN() == treeVN))
         {
-            if ((curAssertion.assertionKind == OAK_NOT_EQUAL) && (curAssertion.op2.GetIntConstant() == 0))
+            if (curAssertion.KindIs(OAK_NOT_EQUAL) && (curAssertion.GetOp2().GetIntConstant() == 0))
             {
                 // X != 0 --> definitely non-zero
                 // We can't say anything about X's non-negativity
                 *isKnownNonZero = true;
             }
-            else if (curAssertion.assertionKind != OAK_NOT_EQUAL)
+            else if (!curAssertion.KindIs(OAK_NOT_EQUAL))
             {
                 // X == CNS --> definitely non-negative if CNS >= 0
                 // and definitely non-zero if CNS != 0
-                *isKnownNonNegative = curAssertion.op2.GetIntConstant() >= 0;
-                *isKnownNonZero     = curAssertion.op2.GetIntConstant() != 0;
+                *isKnownNonNegative = curAssertion.GetOp2().GetIntConstant() >= 0;
+                *isKnownNonZero     = curAssertion.GetOp2().GetIntConstant() != 0;
             }
         }
 
@@ -3675,7 +3674,7 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
         }
 
         ValueNumStore::ConstantBoundInfo info;
-        vnStore->GetConstantBoundInfo(curAssertion.op1.GetVN(), &info);
+        vnStore->GetConstantBoundInfo(curAssertion.GetOp1().GetVN(), &info);
 
         if (info.cmpOpVN != treeVN)
         {
@@ -3685,7 +3684,7 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
         // Root assertion has to be either:
         // (X relop CNS) == 0
         // (X relop CNS) != 0
-        if (!curAssertion.op2.KindIs(O2K_CONST_INT) || (curAssertion.op2.GetIntConstant() != 0))
+        if (!curAssertion.GetOp2().KindIs(O2K_CONST_INT) || (curAssertion.GetOp2().GetIntConstant() != 0))
         {
             continue;
         }
@@ -3693,7 +3692,7 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
         genTreeOps cmpOper = static_cast<genTreeOps>(info.cmpOper);
 
         // Normalize "(X relop CNS) == false" to "(X reversed_relop CNS) == true"
-        if (curAssertion.assertionKind == OAK_EQUAL)
+        if (curAssertion.KindIs(OAK_EQUAL))
         {
             cmpOper = GenTree::ReverseRelop(cmpOper);
         }
@@ -3848,14 +3847,14 @@ AssertionIndex Compiler::optLocalAssertionIsEqualOrNotEqual(
             continue;
         }
 
-        if (curAssertion.op1.KindIs(op1Kind) && (curAssertion.op1.GetLclNum() == lclNum) &&
-            curAssertion.op2.KindIs(op2Kind))
+        if (curAssertion.GetOp1().KindIs(op1Kind) && (curAssertion.GetOp1().GetLclNum() == lclNum) &&
+            curAssertion.GetOp2().KindIs(op2Kind))
         {
             // Check constant value. If both are ZEROOBJ then they are equal, otherwise compare integer constant values.
-            // op2.GetIntConstant() is not available for O2K_ZEROOBJ (implies zero value).
+            // GetOp2().GetIntConstant() is not available for O2K_ZEROOBJ (implies zero value).
             bool constantIsEqual =
-                curAssertion.op2.KindIs(O2K_ZEROOBJ) || (curAssertion.op2.GetIntConstant() == cnsVal);
-            bool assertionIsEqual = (curAssertion.assertionKind == OAK_EQUAL);
+                curAssertion.GetOp2().KindIs(O2K_ZEROOBJ) || (curAssertion.GetOp2().GetIntConstant() == cnsVal);
+            bool assertionIsEqual = curAssertion.KindIs(OAK_EQUAL);
 
             if (constantIsEqual || assertionIsEqual)
             {
@@ -3905,8 +3904,8 @@ AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP as
             continue;
         }
 
-        if ((curAssertion.op1.GetVN() == vnStore->VNConservativeNormalValue(op1->gtVNPair)) &&
-            (curAssertion.op2.GetVN() == vnStore->VNConservativeNormalValue(op2->gtVNPair)))
+        if ((curAssertion.GetOp1().GetVN() == vnStore->VNConservativeNormalValue(op1->gtVNPair)) &&
+            (curAssertion.GetOp2().GetVN() == vnStore->VNConservativeNormalValue(op2->gtVNPair)))
         {
             return assertionIndex;
         }
@@ -3917,12 +3916,13 @@ AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP as
         //   op2:       'MyType' class handle
         //   Assertion: 'myObj's type is exactly MyType
         //
-        if ((curAssertion.assertionKind == OAK_EQUAL) && curAssertion.op1.KindIs(O1K_EXACT_TYPE) &&
-            (curAssertion.op2.GetVN() == vnStore->VNConservativeNormalValue(op2->gtVNPair)) && op1->TypeIs(TYP_I_IMPL))
+        if (curAssertion.KindIs(OAK_EQUAL) && curAssertion.GetOp1().KindIs(O1K_EXACT_TYPE) &&
+            (curAssertion.GetOp2().GetVN() == vnStore->VNConservativeNormalValue(op2->gtVNPair)) &&
+            op1->TypeIs(TYP_I_IMPL))
         {
             VNFuncApp funcApp;
             if (vnStore->GetVNFunc(vnStore->VNConservativeNormalValue(op1->gtVNPair), &funcApp) &&
-                (funcApp.m_func == VNF_InvariantNonNullLoad) && (curAssertion.op1.GetVN() == funcApp.m_args[0]))
+                (funcApp.m_func == VNF_InvariantNonNullLoad) && (curAssertion.GetOp1().GetVN() == funcApp.m_args[0]))
             {
                 return assertionIndex;
             }
@@ -3958,8 +3958,8 @@ AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqualZero(ASSERT_VALARG_T
             continue;
         }
 
-        if ((curAssertion.op1.GetVN() == vnStore->VNConservativeNormalValue(op1->gtVNPair)) &&
-            (curAssertion.op2.GetVN() == vnStore->VNZeroForType(op1->TypeGet())))
+        if ((curAssertion.GetOp1().GetVN() == vnStore->VNConservativeNormalValue(op1->gtVNPair)) &&
+            (curAssertion.GetOp2().GetVN() == vnStore->VNZeroForType(op1->TypeGet())))
         {
             return assertionIndex;
         }
@@ -4075,11 +4075,11 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
             printf("\nVN relop based constant assertion prop in " FMT_BB ":\n", compCurBB->bbNum);
             printf("Assertion index=#%02u: ", index);
             printTreeID(tree);
-            printf(" %s 0\n", (curAssertion.assertionKind == OAK_EQUAL) ? "==" : "!=");
+            printf(" %s 0\n", curAssertion.KindIs(OAK_EQUAL) ? "==" : "!=");
         }
 #endif
 
-        newTree = curAssertion.assertionKind == OAK_EQUAL ? gtNewIconNode(0) : gtNewIconNode(1);
+        newTree = curAssertion.KindIs(OAK_EQUAL) ? gtNewIconNode(0) : gtNewIconNode(1);
         newTree = gtWrapWithSideEffects(newTree, tree, GTF_ALL_EFFECT);
         DISPTREE(newTree);
         return optAssertionProp_Update(newTree, tree, stmt);
@@ -4146,7 +4146,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
     }
 
     const AssertionDsc& curAssertion         = optGetAssertion(index);
-    bool                assertionKindIsEqual = (curAssertion.assertionKind == OAK_EQUAL);
+    bool                assertionKindIsEqual = curAssertion.KindIs(OAK_EQUAL);
 
     // Allow or not to reverse condition for OAK_NOT_EQUAL assertions.
     bool allowReverse = true;
@@ -4280,7 +4280,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
             printf("\nVN relop based copy assertion prop in " FMT_BB ":\n", compCurBB->bbNum);
             printf("Assertion index=#%02u: V%02d.%02d %s V%02d.%02d\n", index, op1->AsLclVar()->GetLclNum(),
                    op1->AsLclVar()->GetSsaNum(),
-                   (curAssertion.assertionKind == OAK_EQUAL) ? "==" : "!=", op2->AsLclVar()->GetLclNum(),
+                   curAssertion.KindIs(OAK_EQUAL) ? "==" : "!=", op2->AsLclVar()->GetLclNum(),
                    op2->AsLclVar()->GetSsaNum());
             gtDispTree(tree, nullptr, nullptr, true);
         }
@@ -4311,7 +4311,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
     }
 
     // Finally reverse the condition, if we have a not equal assertion.
-    if (allowReverse && curAssertion.assertionKind == OAK_NOT_EQUAL)
+    if (allowReverse && curAssertion.KindIs(OAK_NOT_EQUAL))
     {
         gtReverseCond(tree);
     }
@@ -4383,18 +4383,18 @@ GenTree* Compiler::optAssertionPropLocal_RelOp(ASSERT_VALARG_TP assertions, GenT
 
     const AssertionDsc& curAssertion = optGetAssertion(index);
 
-    bool assertionKindIsEqual = (curAssertion.assertionKind == OAK_EQUAL);
+    bool assertionKindIsEqual = curAssertion.KindIs(OAK_EQUAL);
     bool constantIsEqual      = false;
 
     if (genTypeSize(cmpType) == TARGET_POINTER_SIZE)
     {
-        constantIsEqual = (curAssertion.op2.GetIntConstant() == cnsVal);
+        constantIsEqual = (curAssertion.GetOp2().GetIntConstant() == cnsVal);
     }
 #ifdef TARGET_64BIT
     else if (genTypeSize(cmpType) == sizeof(INT32))
     {
         // Compare the low 32-bits only
-        constantIsEqual = (((INT32)curAssertion.op2.GetIntConstant()) == ((INT32)cnsVal));
+        constantIsEqual = (((INT32)curAssertion.GetOp2().GetIntConstant()) == ((INT32)cnsVal));
     }
 #endif
     else
@@ -4646,7 +4646,7 @@ bool Compiler::optAssertionIsNonNull(GenTree* op, ASSERT_VALARG_TP assertions)
             AssertionIndex      assertionIndex = GetAssertionIndex(index);
             const AssertionDsc& curAssertion   = optGetAssertion(assertionIndex);
             if (curAssertion.CanPropNonNull() &&
-                ((curAssertion.op1.GetVN() == vn) || (curAssertion.op1.GetVN() == vnBase)))
+                ((curAssertion.GetOp1().GetVN() == vn) || (curAssertion.GetOp1().GetVN() == vnBase)))
             {
                 return true;
             }
@@ -4668,10 +4668,10 @@ bool Compiler::optAssertionIsNonNull(GenTree* op, ASSERT_VALARG_TP assertions)
             AssertionIndex      assertionIndex = GetAssertionIndex(index);
             const AssertionDsc& curAssertion   = optGetAssertion(assertionIndex);
 
-            if ((curAssertion.assertionKind == OAK_NOT_EQUAL) && // kind
-                curAssertion.op1.KindIs(O1K_LCLVAR) &&           // op1
-                curAssertion.op2.KindIs(O2K_CONST_INT) &&        // op2
-                (curAssertion.op1.GetLclNum() == lclNum) && (curAssertion.op2.GetIntConstant() == 0))
+            if (curAssertion.KindIs(OAK_NOT_EQUAL) &&          // kind
+                curAssertion.GetOp1().KindIs(O1K_LCLVAR) &&    // op1
+                curAssertion.GetOp2().KindIs(O2K_CONST_INT) && // op2
+                (curAssertion.GetOp1().GetLclNum() == lclNum) && (curAssertion.GetOp2().GetIntConstant() == 0))
             {
                 return true;
             }
@@ -4705,7 +4705,7 @@ bool Compiler::optAssertionVNIsNonNull(ValueNum vn, ASSERT_VALARG_TP assertions)
         while (iter.NextElem(&index))
         {
             const AssertionDsc& curAssertion = optGetAssertion(GetAssertionIndex(index));
-            if (curAssertion.CanPropNonNull() && curAssertion.op1.GetVN() == vn)
+            if (curAssertion.CanPropNonNull() && curAssertion.GetOp1().GetVN() == vn)
             {
                 return true;
             }
@@ -5066,12 +5066,12 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
         }
 
         // Do we have a previous range check involving the same 'vnLen' upper bound?
-        if (curAssertion.op1.GetArrBndLength() ==
+        if (curAssertion.GetOp1().GetArrBndLength() ==
             vnStore->VNConservativeNormalValue(arrBndsChk->GetArrayLength()->gtVNPair))
         {
             // Do we have the exact same lower bound 'vnIdx'?
             //       a[i] followed by a[i]
-            if (curAssertion.op1.GetArrBndIndex() == vnCurIdx)
+            if (curAssertion.GetOp1().GetArrBndIndex() == vnCurIdx)
             {
                 return dropBoundsCheck(INDEBUG("a[i] followed by a[i]"));
             }
@@ -5111,7 +5111,7 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
 
                 int index1;
                 int index2;
-                if (tryGetMaxOrMinConst(curAssertion.op1.GetArrBndIndex(), /*min*/ true, &index1) &&
+                if (tryGetMaxOrMinConst(curAssertion.GetOp1().GetArrBndIndex(), /*min*/ true, &index1) &&
                     tryGetMaxOrMinConst(vnCurIdx, /*max*/ false, &index2))
                 {
                     // It can always be considered as redundant with any previous higher constant value

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -932,7 +932,6 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
                     {
                         printf("MT(0x%p %s)", dspPtr(iconVal), eeGetClassName((CORINFO_CLASS_HANDLE)iconVal));
                     }
-                    assert(curAssertion.GetOp2().HasIconFlag());
                 }
                 else if (curAssertion.GetOp1().KindIs(O1K_BOUND_OPER_BND, O1K_BOUND_LOOP_BND, O1K_CONSTANT_LOOP_BND,
                                                       O1K_CONSTANT_LOOP_BND_UN))

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -767,54 +767,47 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
     switch (curAssertion.GetOp1().GetKind())
     {
         case O1K_LCLVAR:
-            printf("V%02u", curAssertion.GetOp1().GetLclNum());
-            if (!optLocalAssertionProp)
+            if (optLocalAssertionProp)
             {
-                printf(" ");
-                vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
+                printf("lclvar V%02u", curAssertion.GetOp1().GetLclNum());
+            }
+            else
+            {
+                printf("lclvar " FMT_VN "", curAssertion.GetOp1().GetVN());
             }
             break;
 
         case O1K_VN:
-            vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
+            printf("VN " FMT_VN "", curAssertion.GetOp1().GetVN());
             break;
 
         case O1K_ARR_BND:
-            printf("[idx:");
-            vnStore->vnDump(this, curAssertion.GetOp1().GetArrBndIndex());
-            printf(", len:");
-            vnStore->vnDump(this, curAssertion.GetOp1().GetArrBndLength());
-            printf("]");
+            printf("ArrBnd idx " FMT_VN " < len " FMT_VN "", curAssertion.GetOp1().GetArrBndIndex(),
+                   curAssertion.GetOp1().GetArrBndLength());
             break;
 
         case O1K_BOUND_OPER_BND:
-            printf("Oper_Bnd ");
-            vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
+            printf("Oper_Bnd " FMT_VN "", curAssertion.GetOp1().GetVN());
             break;
 
         case O1K_BOUND_LOOP_BND:
-            printf("Loop_Bnd ");
-            vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
+            printf("Loop_Bnd " FMT_VN "", curAssertion.GetOp1().GetVN());
             break;
 
         case O1K_CONSTANT_LOOP_BND:
-            printf("Const_Bnd ");
-            vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
+            printf("Const_Bnd " FMT_VN "", curAssertion.GetOp1().GetVN());
             break;
 
         case O1K_CONSTANT_LOOP_BND_UN:
-            printf("Const_Bnd_Un ");
-            vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
+            printf("Const_Bnd_Un " FMT_VN "", curAssertion.GetOp1().GetVN());
             break;
 
         case O1K_EXACT_TYPE:
-            printf("ExactType ");
-            vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
+            printf("ExactType " FMT_VN "", curAssertion.GetOp1().GetVN());
             break;
 
         case O1K_SUBTYPE:
-            printf("SubType ");
-            vnStore->vnDump(this, curAssertion.GetOp1().GetVN());
+            printf("SubType " FMT_VN "", curAssertion.GetOp1().GetVN());
             break;
 
         default:
@@ -848,7 +841,7 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
     switch (curAssertion.GetOp2().GetKind())
     {
         case O2K_LCLVAR_COPY:
-            printf("V%02u", curAssertion.GetOp2().GetLclNum());
+            printf("lclvar V%02u", curAssertion.GetOp2().GetLclNum());
             break;
 
         case O2K_CONST_INT:

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7775,22 +7775,22 @@ public:
             friend struct AssertionDsc; // For AssertionDsc::Create* factory methods
 
         private:
-            optOp1Kind kind;
+            optOp1Kind m_kind;
             union
             {
-                ValueNum vn;
-                unsigned lclNum;
+                ValueNum m_vn;
+                unsigned m_lclNum;
                 struct
                 {
-                    ValueNum vnIdx;
-                    ValueNum vnLen;
-                } bnd;
+                    ValueNum m_vnIdx;
+                    ValueNum m_vnLen;
+                } m_bnd;
             };
 
         public:
-            bool KindIs(optOp1Kind k) const
+            bool KindIs(optOp1Kind kind) const
             {
-                return kind == k;
+                return m_kind == kind;
             }
 
             template <typename... T>
@@ -7805,36 +7805,36 @@ public:
                 // Today it's used by both Local and Global AP.
                 assert(KindIs(O1K_LCLVAR, O1K_VN, O1K_BOUND_OPER_BND, O1K_BOUND_LOOP_BND, O1K_CONSTANT_LOOP_BND,
                               O1K_CONSTANT_LOOP_BND_UN, O1K_EXACT_TYPE, O1K_SUBTYPE));
-                // Basically, only O1K_ARR_BND doesn't use this property (it uses vnIdx and vnLen instead).
+                // Basically, only O1K_ARR_BND doesn't use this property (it uses m_vnIdx and m_vnLen instead).
 
-                assert(vn != ValueNumStore::NoVN);
-                return vn;
+                assert(m_vn != ValueNumStore::NoVN);
+                return m_vn;
             }
 
             unsigned GetLclNum() const
             {
-                assert(lclNum != BAD_VAR_NUM);
+                assert(m_lclNum != BAD_VAR_NUM);
                 assert(KindIs(O1K_LCLVAR));
-                return lclNum;
+                return m_lclNum;
             }
 
             ValueNum GetArrBndIndex() const
             {
                 assert(KindIs(O1K_ARR_BND));
-                assert(bnd.vnIdx != ValueNumStore::NoVN);
-                return bnd.vnIdx;
+                assert(m_bnd.m_vnIdx != ValueNumStore::NoVN);
+                return m_bnd.m_vnIdx;
             }
 
             ValueNum GetArrBndLength() const
             {
                 assert(KindIs(O1K_ARR_BND));
-                assert(bnd.vnLen != ValueNumStore::NoVN);
-                return bnd.vnLen;
+                assert(m_bnd.m_vnLen != ValueNumStore::NoVN);
+                return m_bnd.m_vnLen;
             }
 
             optOp1Kind GetKind() const
             {
-                return kind;
+                return m_kind;
             }
         };
 
@@ -7843,25 +7843,25 @@ public:
             friend struct AssertionDsc; // For AssertionDsc::Create* factory methods
 
         private:
-            optOp2Kind kind;
+            optOp2Kind m_kind;
             uint16_t   m_encodedIconFlags; // encoded icon gtFlags
-            ValueNum   vn;
+            ValueNum   m_vn;
             union
             {
-                unsigned      lclNum;
-                double        dconVal;
-                IntegralRange u2;
+                unsigned      m_lclNum;
+                double        m_dconVal;
+                IntegralRange m_range;
                 struct
                 {
-                    ssize_t   iconVal;
-                    FieldSeq* fieldSeq;
-                } u1;
+                    ssize_t   m_iconVal;
+                    FieldSeq* m_fieldSeq;
+                } m_icon;
             };
         public:
 
-            bool KindIs(optOp2Kind k) const
+            bool KindIs(optOp2Kind kind) const
             {
-                return kind == k;
+                return m_kind == kind;
             }
 
             template <typename... T>
@@ -7873,44 +7873,44 @@ public:
             unsigned GetLclNum() const
             {
                 assert(KindIs(O2K_LCLVAR_COPY));
-                return lclNum;
+                return m_lclNum;
             }
 
             double GetDoubleConstant() const
             {
                 assert(KindIs(O2K_CONST_DOUBLE));
-                return dconVal;
+                return m_dconVal;
             }
 
             ssize_t GetIntConstant() const
             {
                 assert(KindIs(O2K_CONST_INT));
-                return u1.iconVal;
+                return m_icon.m_iconVal;
             }
 
             IntegralRange GetIntegralRange() const
             {
                 assert(KindIs(O2K_SUBRANGE));
-                return u2;
+                return m_range;
             }
 
             bool IsNullConstant() const
             {
                 // Even for local prop we use ValueNumStore::VNForNull as a hint of nullness.
-                // Otherwise, we'd have to validate op1.lclNum's real type every time.
-                return KindIs(O2K_CONST_INT) && (vn == ValueNumStore::VNForNull());
+                // Otherwise, we'd have to validate op1.m_lclNum's real type every time.
+                return KindIs(O2K_CONST_INT) && (m_vn == ValueNumStore::VNForNull());
             }
 
             ValueNum GetVN() const
             {
                 assert(KindIs(O2K_CONST_INT, O2K_CONST_DOUBLE, O2K_ZEROOBJ));
-                assert(vn != ValueNumStore::NoVN);
-                return vn;
+                assert(m_vn != ValueNumStore::NoVN);
+                return m_vn;
             }
 
             optOp2Kind GetKind() const
             {
-                return kind;
+                return m_kind;
             }
 
             bool HasIconFlag() const
@@ -7940,25 +7940,30 @@ public:
                 const uint16_t iconMaskTzc = 24;
                 assert((flags & ~GTF_ICON_HDL_MASK) == 0);
                 m_encodedIconFlags = flags >> iconMaskTzc;
-                u1.fieldSeq        = fieldSeq;
+                m_icon.m_fieldSeq  = fieldSeq;
             }
 
             FieldSeq* GetIconFieldSeq() const
             {
                 assert(KindIs(O2K_CONST_INT));
-                return u1.fieldSeq;
+                return m_icon.m_fieldSeq;
             }
         };
 
     private:
-        optAssertionKind assertionKind;
-        AssertionDscOp1  op1;
-        AssertionDscOp2  op2;
+        optAssertionKind m_assertionKind;
+        AssertionDscOp1  m_op1;
+        AssertionDscOp2  m_op2;
     public:
 
-        bool KindIs(optAssertionKind k) const
+        optAssertionKind GetKind() const
         {
-            return assertionKind == k;
+            return m_assertionKind;
+        }
+
+        bool KindIs(optAssertionKind kind) const
+        {
+            return m_assertionKind == kind;
         }
 
         template <typename... T>
@@ -7969,86 +7974,93 @@ public:
 
         const AssertionDscOp1& GetOp1() const
         {
-            return op1;
+            return m_op1;
         }
 
         bool HasOp2() const
         {
-            // For OAK_NO_THROW, op2 is not used.
+            // For OAK_NO_THROW, m_op2 is not used.
             return !KindIs(OAK_NO_THROW);
         }
 
         const AssertionDscOp2& GetOp2() const
         {
             assert(HasOp2());
-            return op2;
+            return m_op2;
+        }
+
+        AssertionDscOp2& GetOp2()
+        {
+            return m_op2;
         }
 
         bool IsCheckedBoundArithBound() const
         {
-            return ((assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL) && op1.KindIs(O1K_BOUND_OPER_BND));
+            return (CanPropEqualOrNotEqual() && m_op1.KindIs(O1K_BOUND_OPER_BND));
         }
         bool IsCheckedBoundBound() const
         {
-            return ((assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL) && op1.KindIs(O1K_BOUND_LOOP_BND));
+            return (CanPropEqualOrNotEqual() && m_op1.KindIs(O1K_BOUND_LOOP_BND));
         }
         bool IsConstantBound() const
         {
-            return ((assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL) &&
-                    op1.KindIs(O1K_CONSTANT_LOOP_BND));
+            return (CanPropEqualOrNotEqual() && m_op1.KindIs(O1K_CONSTANT_LOOP_BND));
         }
         bool IsConstantBoundUnsigned() const
         {
-            return ((assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL) &&
-                    op1.KindIs(O1K_CONSTANT_LOOP_BND_UN));
+            return (CanPropEqualOrNotEqual() && m_op1.KindIs(O1K_CONSTANT_LOOP_BND_UN));
         }
         bool IsBoundsCheckNoThrow() const
         {
-            return ((assertionKind == OAK_NO_THROW) && op1.KindIs(O1K_ARR_BND));
+            return (KindIs(OAK_NO_THROW) && m_op1.KindIs(O1K_ARR_BND));
         }
 
         bool IsCopyAssertion() const
         {
-            return ((assertionKind == OAK_EQUAL) && op1.KindIs(O1K_LCLVAR) && op2.KindIs(O2K_LCLVAR_COPY));
+            return (KindIs(OAK_EQUAL) && m_op1.KindIs(O1K_LCLVAR) && m_op2.KindIs(O2K_LCLVAR_COPY));
         }
 
         bool IsConstantInt32Assertion() const
         {
-            return ((assertionKind == OAK_EQUAL) || (assertionKind == OAK_NOT_EQUAL)) && op2.KindIs(O2K_CONST_INT) &&
-                   op1.KindIs(O1K_LCLVAR, O1K_VN);
+            return CanPropEqualOrNotEqual() && m_op2.KindIs(O2K_CONST_INT) && m_op1.KindIs(O1K_LCLVAR, O1K_VN);
         }
 
         bool CanPropLclVar() const
         {
-            return assertionKind == OAK_EQUAL && op1.KindIs(O1K_LCLVAR);
+            return KindIs(OAK_EQUAL) && m_op1.KindIs(O1K_LCLVAR);
         }
 
         bool CanPropEqualOrNotEqual() const
         {
-            return assertionKind == OAK_EQUAL || assertionKind == OAK_NOT_EQUAL;
+            return KindIs(OAK_EQUAL, OAK_NOT_EQUAL);
         }
 
         bool CanPropNonNull() const
         {
-            return assertionKind == OAK_NOT_EQUAL && op1.KindIs(O1K_LCLVAR, O1K_VN) && op2.IsNullConstant();
+            return KindIs(OAK_NOT_EQUAL) && m_op1.KindIs(O1K_LCLVAR, O1K_VN) && m_op2.IsNullConstant();
         }
 
         bool CanPropBndsCheck() const
         {
-            return op1.KindIs(O1K_ARR_BND, O1K_VN);
+            return m_op1.KindIs(O1K_ARR_BND, O1K_VN);
         }
 
         bool CanPropSubRange() const
         {
-            return assertionKind == OAK_SUBRANGE && op1.KindIs(O1K_LCLVAR);
+            if (KindIs(OAK_SUBRANGE))
+            {
+                assert(m_op1.KindIs(O1K_LCLVAR));
+                return true;
+            }
+            return false;
         }
 
         AssertionDsc ReverseEquality() const
         {
-            assert((assertionKind == OAK_EQUAL) || (assertionKind == OAK_NOT_EQUAL));
+            assert(CanPropEqualOrNotEqual());
 
-            AssertionDsc copy  = *this;
-            copy.assertionKind = assertionKind == OAK_EQUAL ? OAK_NOT_EQUAL : OAK_EQUAL;
+            AssertionDsc copy    = *this;
+            copy.m_assertionKind = KindIs(OAK_EQUAL) ? OAK_NOT_EQUAL : OAK_EQUAL;
             return copy;
         }
 
@@ -8067,58 +8079,58 @@ public:
 
         bool HasSameOp1(const AssertionDsc& that, bool vnBased) const
         {
-            if (op1.GetKind() != that.op1.GetKind())
+            if (!m_op1.KindIs(that.m_op1.GetKind()))
             {
                 return false;
             }
-            else if (op1.KindIs(O1K_ARR_BND))
+            else if (m_op1.KindIs(O1K_ARR_BND))
             {
                 assert(vnBased);
-                return (op1.GetArrBndIndex() == that.op1.GetArrBndIndex()) &&
-                       (op1.GetArrBndLength() == that.op1.GetArrBndLength());
+                return (m_op1.GetArrBndIndex() == that.m_op1.GetArrBndIndex()) &&
+                       (m_op1.GetArrBndLength() == that.m_op1.GetArrBndLength());
             }
-            else if (op1.KindIs(O1K_VN))
+            else if (m_op1.KindIs(O1K_VN))
             {
                 assert(vnBased);
-                return (op1.GetVN() == that.op1.GetVN());
+                return (m_op1.GetVN() == that.m_op1.GetVN());
             }
             else
             {
-                return ((vnBased && (op1.GetVN() == that.op1.GetVN())) ||
-                        (!vnBased && (op1.GetLclNum() == that.op1.GetLclNum())));
+                return ((vnBased && (m_op1.GetVN() == that.m_op1.GetVN())) ||
+                        (!vnBased && (m_op1.GetLclNum() == that.m_op1.GetLclNum())));
             }
         }
 
         bool HasSameOp2(const AssertionDsc& that, bool vnBased) const
         {
             assert(HasOp2());
-            if (op2.GetKind() != that.op2.GetKind())
+            if (!m_op2.KindIs(that.m_op2.GetKind()))
             {
                 return false;
             }
 
-            switch (op2.GetKind())
+            switch (m_op2.GetKind())
             {
                 case O2K_CONST_INT:
-                    return ((op2.GetIntConstant() == that.op2.GetIntConstant()) &&
-                            (op2.GetIconFlag() == that.op2.GetIconFlag()));
+                    return ((m_op2.GetIntConstant() == that.m_op2.GetIntConstant()) &&
+                            (m_op2.GetIconFlag() == that.m_op2.GetIconFlag()));
 
                 case O2K_CONST_DOUBLE:
                     // exact match because of positive and negative zero.
-                    return (memcmp(&op2.dconVal, &that.op2.dconVal, sizeof(double)) == 0);
+                    return (memcmp(&m_op2.m_dconVal, &that.m_op2.m_dconVal, sizeof(double)) == 0);
 
                 case O2K_ZEROOBJ:
                     return true;
 
                 case O2K_LCLVAR_COPY:
-                    return op2.GetLclNum() == that.op2.GetLclNum();
+                    return m_op2.GetLclNum() == that.m_op2.GetLclNum();
 
                 case O2K_SUBRANGE:
-                    return op2.GetIntegralRange().Equals(that.op2.GetIntegralRange());
+                    return m_op2.GetIntegralRange().Equals(that.m_op2.GetIntegralRange());
 
                 case O2K_INVALID:
                 default:
-                    assert(!"Unexpected value for op2.kind in AssertionDsc.");
+                    assert(!"Unexpected value for m_op2.m_kind in AssertionDsc.");
                     break;
             }
 
@@ -8127,13 +8139,13 @@ public:
 
         bool Complementary(const AssertionDsc& that, bool vnBased) const
         {
-            return ComplementaryKind(assertionKind, that.assertionKind) && HasSameOp1(that, vnBased) &&
+            return ComplementaryKind(m_assertionKind, that.m_assertionKind) && HasSameOp1(that, vnBased) &&
                    HasSameOp2(that, vnBased);
         }
 
         bool Equals(const AssertionDsc& that, bool vnBased) const
         {
-            if (assertionKind != that.assertionKind)
+            if (!KindIs(that.GetKind()))
             {
                 return false;
             }
@@ -8148,8 +8160,8 @@ public:
                 return HasSameOp2(that, vnBased);
             }
 
-            // OAK_NO_THROW is the only kind of assertion where op2 is unused.
-            assert(op2.KindIs(O2K_INVALID));
+            // OAK_NO_THROW is the only kind of assertion where m_op2 is unused.
+            assert(m_op2.KindIs(O2K_INVALID));
             return true;
         }
 
@@ -8168,56 +8180,56 @@ public:
                                                        GenTreeFlags    iconFlags = GTF_EMPTY,
                                                        FieldSeq*       fldSeq    = nullptr)
         {
-            AssertionDsc dsc  = {};
-            dsc.assertionKind = equals ? OAK_EQUAL : OAK_NOT_EQUAL;
-            dsc.op1.kind      = O1K_LCLVAR;
+            AssertionDsc dsc    = {};
+            dsc.m_assertionKind = equals ? OAK_EQUAL : OAK_NOT_EQUAL;
+            dsc.m_op1.m_kind    = O1K_LCLVAR;
 
             if (comp->optLocalAssertionProp)
             {
                 assert(lclNum != BAD_VAR_NUM);
 
-                dsc.op1.lclNum = lclNum;
+                dsc.m_op1.m_lclNum = lclNum;
 
                 // We use ValueNumStore::VNForNull() as a hint of nullness. This allows us to avoid looking up the
                 // real type of the local variable to confirm we deal with a pointer-sized local (not its small-int
                 // part with the same lclnum).
                 if (cnsVN == ValueNumStore::VNForNull())
                 {
-                    dsc.op2.vn = ValueNumStore::VNForNull();
+                    dsc.m_op2.m_vn = ValueNumStore::VNForNull();
                 }
                 else
                 {
-                    dsc.op2.vn = ValueNumStore::NoVN;
+                    dsc.m_op2.m_vn = ValueNumStore::NoVN;
                 }
             }
             else
             {
                 assert(vn != ValueNumStore::NoVN);
                 assert(cnsVN != ValueNumStore::NoVN);
-                dsc.op1.vn = vn;
-                dsc.op2.vn = cnsVN;
+                dsc.m_op1.m_vn = vn;
+                dsc.m_op2.m_vn = cnsVN;
             }
 
             if constexpr (std::is_same_v<T, int> || std::is_same_v<T, ssize_t>)
             {
-                dsc.op2.kind       = O2K_CONST_INT;
-                dsc.op2.u1.iconVal = static_cast<ssize_t>(cns);
-                dsc.op2.SetIconFlag(iconFlags, fldSeq);
+                dsc.m_op2.m_kind           = O2K_CONST_INT;
+                dsc.m_op2.m_icon.m_iconVal = static_cast<ssize_t>(cns);
+                dsc.m_op2.SetIconFlag(iconFlags, fldSeq);
             }
             else if constexpr (std::is_same_v<T, double>)
             {
-                dsc.op2.kind    = O2K_CONST_DOUBLE;
-                dsc.op2.dconVal = static_cast<double>(cns);
+                dsc.m_op2.m_kind    = O2K_CONST_DOUBLE;
+                dsc.m_op2.m_dconVal = static_cast<double>(cns);
                 assert(iconFlags == GTF_EMPTY); // no flags expected for double constants
                 assert(fldSeq == nullptr);      // no fieldSeq expected for double constants
             }
             else if constexpr (std::is_same_v<T, optOp2Kind>)
             {
-                dsc.op2.kind       = static_cast<optOp2Kind>(cns);
-                dsc.op2.u1.iconVal = 0;
-                assert(dsc.op2.kind == O2K_ZEROOBJ); // only O2K_ZEROOBJ is expected here for now.
-                assert(iconFlags == GTF_EMPTY);      // no flags expected for ZEROOBJ
-                assert(fldSeq == nullptr);           // no fieldSeq expected for ZEROOBJ
+                dsc.m_op2.m_kind           = static_cast<optOp2Kind>(cns);
+                dsc.m_op2.m_icon.m_iconVal = 0;
+                assert(dsc.m_op2.m_kind == O2K_ZEROOBJ); // only O2K_ZEROOBJ is expected here for now.
+                assert(iconFlags == GTF_EMPTY);          // no flags expected for ZEROOBJ
+                assert(fldSeq == nullptr);               // no fieldSeq expected for ZEROOBJ
             }
             else
             {
@@ -8249,12 +8261,12 @@ public:
             assert(lclNum1 != BAD_VAR_NUM);
             assert(lclNum2 != BAD_VAR_NUM);
 
-            AssertionDsc dsc  = {};
-            dsc.assertionKind = equals ? OAK_EQUAL : OAK_NOT_EQUAL;
-            dsc.op1.kind      = O1K_LCLVAR;
-            dsc.op1.lclNum    = lclNum1;
-            dsc.op2.lclNum    = lclNum2;
-            dsc.op2.kind      = O2K_LCLVAR_COPY;
+            AssertionDsc dsc    = {};
+            dsc.m_assertionKind = equals ? OAK_EQUAL : OAK_NOT_EQUAL;
+            dsc.m_op1.m_kind    = O1K_LCLVAR;
+            dsc.m_op1.m_lclNum  = lclNum1;
+            dsc.m_op2.m_lclNum  = lclNum2;
+            dsc.m_op2.m_kind    = O2K_LCLVAR_COPY;
 
             return dsc;
         }
@@ -8265,12 +8277,12 @@ public:
             assert(comp->optLocalAssertionProp);
             assert(lclNum != BAD_VAR_NUM);
 
-            AssertionDsc dsc  = {};
-            dsc.assertionKind = OAK_SUBRANGE;
-            dsc.op1.kind      = O1K_LCLVAR;
-            dsc.op1.lclNum    = lclNum;
-            dsc.op2.kind      = O2K_SUBRANGE;
-            dsc.op2.u2        = range;
+            AssertionDsc dsc    = {};
+            dsc.m_assertionKind = OAK_SUBRANGE;
+            dsc.m_op1.m_kind    = O1K_LCLVAR;
+            dsc.m_op1.m_lclNum  = lclNum;
+            dsc.m_op2.m_kind    = O2K_SUBRANGE;
+            dsc.m_op2.m_range   = range;
             return dsc;
         }
 
@@ -8286,13 +8298,13 @@ public:
             assert(!comp->vnStore->IsVNHandle(op2VN));
             assert(!comp->optLocalAssertionProp);
 
-            AssertionDsc dsc   = {};
-            dsc.assertionKind  = equals ? OAK_EQUAL : OAK_NOT_EQUAL;
-            dsc.op1.vn         = op1VN;
-            dsc.op2.vn         = op2VN;
-            dsc.op1.kind       = O1K_VN;
-            dsc.op2.kind       = O2K_CONST_INT;
-            dsc.op2.u1.iconVal = comp->vnStore->ConstantValue<int>(op2VN);
+            AssertionDsc dsc           = {};
+            dsc.m_assertionKind        = equals ? OAK_EQUAL : OAK_NOT_EQUAL;
+            dsc.m_op1.m_vn             = op1VN;
+            dsc.m_op2.m_vn             = op2VN;
+            dsc.m_op1.m_kind           = O1K_VN;
+            dsc.m_op2.m_kind           = O2K_CONST_INT;
+            dsc.m_op2.m_icon.m_iconVal = comp->vnStore->ConstantValue<int>(op2VN);
             return dsc;
         }
 
@@ -8301,13 +8313,13 @@ public:
         {
             assert((objVN != ValueNumStore::NoVN) && comp->vnStore->IsVNTypeHandle(typeHndVN));
 
-            AssertionDsc dsc   = {};
-            dsc.op1.kind       = exact ? O1K_EXACT_TYPE : O1K_SUBTYPE;
-            dsc.op1.vn         = objVN;
-            dsc.op2.kind       = O2K_CONST_INT;
-            dsc.op2.u1.iconVal = comp->vnStore->CoercedConstantValue<ssize_t>(typeHndVN);
-            dsc.op2.vn         = typeHndVN;
-            dsc.assertionKind  = OAK_EQUAL;
+            AssertionDsc dsc           = {};
+            dsc.m_op1.m_kind           = exact ? O1K_EXACT_TYPE : O1K_SUBTYPE;
+            dsc.m_op1.m_vn             = objVN;
+            dsc.m_op2.m_kind           = O2K_CONST_INT;
+            dsc.m_op2.m_icon.m_iconVal = comp->vnStore->CoercedConstantValue<ssize_t>(typeHndVN);
+            dsc.m_op2.m_vn             = typeHndVN;
+            dsc.m_assertionKind        = OAK_EQUAL;
             return dsc;
         }
 
@@ -8317,12 +8329,12 @@ public:
             assert(idxVN != ValueNumStore::NoVN);
             assert(lenVN != ValueNumStore::NoVN);
 
-            AssertionDsc dsc  = {};
-            dsc.assertionKind = OAK_NO_THROW;
-            dsc.op1.kind      = O1K_ARR_BND;
-            dsc.op1.bnd.vnIdx = idxVN;
-            dsc.op1.bnd.vnLen = lenVN;
-            dsc.op2.kind      = O2K_INVALID;
+            AssertionDsc dsc        = {};
+            dsc.m_assertionKind     = OAK_NO_THROW;
+            dsc.m_op1.m_kind        = O1K_ARR_BND;
+            dsc.m_op1.m_bnd.m_vnIdx = idxVN;
+            dsc.m_op1.m_bnd.m_vnLen = lenVN;
+            dsc.m_op2.m_kind        = O2K_INVALID;
             return dsc;
         }
 
@@ -8340,16 +8352,16 @@ public:
                 assert(comp->vnStore->IsVNCompareCheckedBound(relopVN));
             }
 
-            AssertionDsc dsc  = {};
-            dsc.assertionKind = OAK_NOT_EQUAL;
+            AssertionDsc dsc    = {};
+            dsc.m_assertionKind = OAK_NOT_EQUAL;
             // TODO-Cleanup: Rename O1K_BOUND_OPER_BND and O1K_BOUND_LOOP_BND to something more meaningful
             // Also, consider removing O1K_BOUND_LOOP_BND entirely and use O1K_BOUND_OPER_BND for both cases.
             // O1K_BOUND_LOOP_BND is basically "i < bnd +/- 0 != 0". Unless it regresses TP.
-            dsc.op1.kind       = withArith ? O1K_BOUND_OPER_BND : O1K_BOUND_LOOP_BND;
-            dsc.op1.vn         = relopVN;
-            dsc.op2.kind       = O2K_CONST_INT;
-            dsc.op2.vn         = comp->vnStore->VNZeroForType(TYP_INT);
-            dsc.op2.u1.iconVal = 0;
+            dsc.m_op1.m_kind           = withArith ? O1K_BOUND_OPER_BND : O1K_BOUND_LOOP_BND;
+            dsc.m_op1.m_vn             = relopVN;
+            dsc.m_op2.m_kind           = O2K_CONST_INT;
+            dsc.m_op2.m_vn             = comp->vnStore->VNZeroForType(TYP_INT);
+            dsc.m_op2.m_icon.m_iconVal = 0;
             return dsc;
         }
 
@@ -8371,13 +8383,13 @@ public:
             // O1K_CONSTANT_LOOP_BND_UN entirely. However, it improves the TP a bit since we don't
             // have to call GetVNFunc for each assertion during assertion matching.
 
-            AssertionDsc dsc   = {};
-            dsc.assertionKind  = OAK_NOT_EQUAL;
-            dsc.op1.kind       = isUnsigned ? O1K_CONSTANT_LOOP_BND_UN : O1K_CONSTANT_LOOP_BND;
-            dsc.op1.vn         = relopVN;
-            dsc.op2.kind       = O2K_CONST_INT;
-            dsc.op2.vn         = comp->vnStore->VNZeroForType(TYP_INT);
-            dsc.op2.u1.iconVal = 0;
+            AssertionDsc dsc           = {};
+            dsc.m_assertionKind        = OAK_NOT_EQUAL;
+            dsc.m_op1.m_kind           = isUnsigned ? O1K_CONSTANT_LOOP_BND_UN : O1K_CONSTANT_LOOP_BND;
+            dsc.m_op1.m_vn             = relopVN;
+            dsc.m_op2.m_kind           = O2K_CONST_INT;
+            dsc.m_op2.m_vn             = comp->vnStore->VNZeroForType(TYP_INT);
+            dsc.m_op2.m_icon.m_iconVal = 0;
             return dsc;
         }
     };

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7989,45 +7989,40 @@ public:
             return m_op2;
         }
 
-        AssertionDscOp2& GetOp2()
-        {
-            return m_op2;
-        }
-
         bool IsCheckedBoundArithBound() const
         {
-            return (CanPropEqualOrNotEqual() && m_op1.KindIs(O1K_BOUND_OPER_BND));
+            return (CanPropEqualOrNotEqual() && GetOp1().KindIs(O1K_BOUND_OPER_BND));
         }
         bool IsCheckedBoundBound() const
         {
-            return (CanPropEqualOrNotEqual() && m_op1.KindIs(O1K_BOUND_LOOP_BND));
+            return (CanPropEqualOrNotEqual() && GetOp1().KindIs(O1K_BOUND_LOOP_BND));
         }
         bool IsConstantBound() const
         {
-            return (CanPropEqualOrNotEqual() && m_op1.KindIs(O1K_CONSTANT_LOOP_BND));
+            return (CanPropEqualOrNotEqual() && GetOp1().KindIs(O1K_CONSTANT_LOOP_BND));
         }
         bool IsConstantBoundUnsigned() const
         {
-            return (CanPropEqualOrNotEqual() && m_op1.KindIs(O1K_CONSTANT_LOOP_BND_UN));
+            return (CanPropEqualOrNotEqual() && GetOp1().KindIs(O1K_CONSTANT_LOOP_BND_UN));
         }
         bool IsBoundsCheckNoThrow() const
         {
-            return (KindIs(OAK_NO_THROW) && m_op1.KindIs(O1K_ARR_BND));
+            return (KindIs(OAK_NO_THROW) && GetOp1().KindIs(O1K_ARR_BND));
         }
 
         bool IsCopyAssertion() const
         {
-            return (KindIs(OAK_EQUAL) && m_op1.KindIs(O1K_LCLVAR) && m_op2.KindIs(O2K_LCLVAR_COPY));
+            return (KindIs(OAK_EQUAL) && GetOp1().KindIs(O1K_LCLVAR) && GetOp2().KindIs(O2K_LCLVAR_COPY));
         }
 
         bool IsConstantInt32Assertion() const
         {
-            return CanPropEqualOrNotEqual() && m_op2.KindIs(O2K_CONST_INT) && m_op1.KindIs(O1K_LCLVAR, O1K_VN);
+            return CanPropEqualOrNotEqual() && GetOp2().KindIs(O2K_CONST_INT) && GetOp1().KindIs(O1K_LCLVAR, O1K_VN);
         }
 
         bool CanPropLclVar() const
         {
-            return KindIs(OAK_EQUAL) && m_op1.KindIs(O1K_LCLVAR);
+            return KindIs(OAK_EQUAL) && GetOp1().KindIs(O1K_LCLVAR);
         }
 
         bool CanPropEqualOrNotEqual() const
@@ -8037,19 +8032,19 @@ public:
 
         bool CanPropNonNull() const
         {
-            return KindIs(OAK_NOT_EQUAL) && m_op1.KindIs(O1K_LCLVAR, O1K_VN) && m_op2.IsNullConstant();
+            return KindIs(OAK_NOT_EQUAL) && GetOp1().KindIs(O1K_LCLVAR, O1K_VN) && GetOp2().IsNullConstant();
         }
 
         bool CanPropBndsCheck() const
         {
-            return m_op1.KindIs(O1K_ARR_BND, O1K_VN);
+            return GetOp1().KindIs(O1K_ARR_BND, O1K_VN);
         }
 
         bool CanPropSubRange() const
         {
             if (KindIs(OAK_SUBRANGE))
             {
-                assert(m_op1.KindIs(O1K_LCLVAR));
+                assert(GetOp1().KindIs(O1K_LCLVAR));
                 return true;
             }
             return false;
@@ -8079,58 +8074,58 @@ public:
 
         bool HasSameOp1(const AssertionDsc& that, bool vnBased) const
         {
-            if (!m_op1.KindIs(that.m_op1.GetKind()))
+            if (!GetOp1().KindIs(that.GetOp1().GetKind()))
             {
                 return false;
             }
-            else if (m_op1.KindIs(O1K_ARR_BND))
+            else if (GetOp1().KindIs(O1K_ARR_BND))
             {
                 assert(vnBased);
-                return (m_op1.GetArrBndIndex() == that.m_op1.GetArrBndIndex()) &&
-                       (m_op1.GetArrBndLength() == that.m_op1.GetArrBndLength());
+                return (GetOp1().GetArrBndIndex() == that.GetOp1().GetArrBndIndex()) &&
+                       (GetOp1().GetArrBndLength() == that.GetOp1().GetArrBndLength());
             }
-            else if (m_op1.KindIs(O1K_VN))
+            else if (GetOp1().KindIs(O1K_VN))
             {
                 assert(vnBased);
-                return (m_op1.GetVN() == that.m_op1.GetVN());
+                return (GetOp1().GetVN() == that.GetOp1().GetVN());
             }
             else
             {
-                return ((vnBased && (m_op1.GetVN() == that.m_op1.GetVN())) ||
-                        (!vnBased && (m_op1.GetLclNum() == that.m_op1.GetLclNum())));
+                return ((vnBased && (GetOp1().GetVN() == that.GetOp1().GetVN())) ||
+                        (!vnBased && (GetOp1().GetLclNum() == that.GetOp1().GetLclNum())));
             }
         }
 
         bool HasSameOp2(const AssertionDsc& that, bool vnBased) const
         {
             assert(HasOp2());
-            if (!m_op2.KindIs(that.m_op2.GetKind()))
+            if (!GetOp2().KindIs(that.GetOp2().GetKind()))
             {
                 return false;
             }
 
-            switch (m_op2.GetKind())
+            switch (GetOp2().GetKind())
             {
                 case O2K_CONST_INT:
-                    return ((m_op2.GetIntConstant() == that.m_op2.GetIntConstant()) &&
-                            (m_op2.GetIconFlag() == that.m_op2.GetIconFlag()));
+                    return ((GetOp2().GetIntConstant() == that.GetOp2().GetIntConstant()) &&
+                            (GetOp2().GetIconFlag() == that.GetOp2().GetIconFlag()));
 
                 case O2K_CONST_DOUBLE:
                     // exact match because of positive and negative zero.
-                    return (memcmp(&m_op2.m_dconVal, &that.m_op2.m_dconVal, sizeof(double)) == 0);
+                    return (memcmp(&GetOp2().m_dconVal, &that.GetOp2().m_dconVal, sizeof(double)) == 0);
 
                 case O2K_ZEROOBJ:
                     return true;
 
                 case O2K_LCLVAR_COPY:
-                    return m_op2.GetLclNum() == that.m_op2.GetLclNum();
+                    return GetOp2().GetLclNum() == that.GetOp2().GetLclNum();
 
                 case O2K_SUBRANGE:
-                    return m_op2.GetIntegralRange().Equals(that.m_op2.GetIntegralRange());
+                    return GetOp2().GetIntegralRange().Equals(that.GetOp2().GetIntegralRange());
 
                 case O2K_INVALID:
                 default:
-                    assert(!"Unexpected value for m_op2.m_kind in AssertionDsc.");
+                    assert(!"Unexpected value for GetOp2().m_kind in AssertionDsc.");
                     break;
             }
 
@@ -8139,7 +8134,7 @@ public:
 
         bool Complementary(const AssertionDsc& that, bool vnBased) const
         {
-            return ComplementaryKind(m_assertionKind, that.m_assertionKind) && HasSameOp1(that, vnBased) &&
+            return ComplementaryKind(GetKind(), that.GetKind()) && HasSameOp1(that, vnBased) &&
                    HasSameOp2(that, vnBased);
         }
 
@@ -8161,7 +8156,7 @@ public:
             }
 
             // OAK_NO_THROW is the only kind of assertion where m_op2 is unused.
-            assert(m_op2.KindIs(O2K_INVALID));
+            assert(GetOp2().KindIs(O2K_INVALID));
             return true;
         }
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8140,24 +8140,7 @@ public:
 
         bool Equals(const AssertionDsc& that, bool vnBased) const
         {
-            if (!KindIs(that.GetKind()))
-            {
-                return false;
-            }
-
-            if (!HasSameOp1(that, vnBased))
-            {
-                return false;
-            }
-
-            if (HasOp2())
-            {
-                return HasSameOp2(that, vnBased);
-            }
-
-            // OAK_NO_THROW is the only kind of assertion where m_op2 is unused.
-            assert(GetOp2().KindIs(O2K_INVALID));
-            return true;
+            return KindIs(that.GetKind()) && HasSameOp1(that, vnBased) && (!HasOp2() || HasSameOp2(that, vnBased));
         }
 
         //

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7775,6 +7775,12 @@ public:
 
     struct AssertionDsc
     {
+        struct ArrBnd
+        {
+            ValueNum vnIdx;
+            ValueNum vnLen;
+        };
+
         struct AssertionDscOp1
         {
             friend struct AssertionDsc;
@@ -7785,11 +7791,7 @@ public:
             union
             {
                 unsigned lclNum;
-                struct ArrBnd
-                {
-                    ValueNum vnIdx;
-                    ValueNum vnLen;
-                } bnd;
+                ArrBnd   bnd;
             };
 
         public:

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7772,7 +7772,7 @@ public:
     {
         struct AssertionDscOp1
         {
-            friend struct AssertionDsc;
+            friend struct AssertionDsc; // For AssertionDsc::Create* factory methods
 
         private:
             optOp1Kind kind;
@@ -7840,11 +7840,11 @@ public:
 
         struct AssertionDscOp2
         {
-            friend struct AssertionDsc;
+            friend struct AssertionDsc; // For AssertionDsc::Create* factory methods
 
         private:
             optOp2Kind kind;
-            uint16_t   m_encodedIconFlags; // encoded icon gtFlags, don't use directly
+            uint16_t   m_encodedIconFlags; // encoded icon gtFlags
             ValueNum   vn;
             union
             {
@@ -7923,11 +7923,12 @@ public:
             GenTreeFlags GetIconFlag() const
             {
                 assert(KindIs(O2K_CONST_INT));
+
                 // number of trailing zeros in GTF_ICON_HDL_MASK
                 const uint16_t iconMaskTzc = 24;
                 static_assert((0xFF000000 == GTF_ICON_HDL_MASK) && (GTF_ICON_HDL_MASK >> iconMaskTzc) == 0xFF);
 
-                GenTreeFlags flags = (GenTreeFlags)(m_encodedIconFlags << iconMaskTzc);
+                GenTreeFlags flags = static_cast<GenTreeFlags>(m_encodedIconFlags << iconMaskTzc);
                 assert((flags & ~GTF_ICON_HDL_MASK) == 0);
                 return flags;
             }
@@ -7935,6 +7936,7 @@ public:
             void SetIconFlag(GenTreeFlags flags, FieldSeq* fieldSeq = nullptr)
             {
                 assert(KindIs(O2K_CONST_INT));
+
                 const uint16_t iconMaskTzc = 24;
                 assert((flags & ~GTF_ICON_HDL_MASK) == 0);
                 m_encodedIconFlags = flags >> iconMaskTzc;

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3802,7 +3802,7 @@ inline void Compiler::optAssertionReset()
             //
             //  op2.lclNum no longer depends upon this assertion
             //
-            lclNum = curAssertion.op2.lclNum;
+            lclNum = curAssertion.op2.GetLclNum();
             BitVecOps::RemoveElemD(apTraits, GetAssertionDep(lclNum, /*mustExist*/ true), index - 1);
         }
     }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3788,21 +3788,19 @@ inline void Compiler::optAssertionReset()
         AssertionIndex      index        = optAssertionCount;
         const AssertionDsc& curAssertion = optGetAssertion(index);
         optAssertionCount--;
-        unsigned lclNum = curAssertion.op1.GetLclNum();
+        unsigned lclNum = curAssertion.GetOp1().GetLclNum();
         assert(lclNum < lvaCount);
         BitVecOps::RemoveElemD(apTraits, GetAssertionDep(lclNum, /*mustExist*/ true), index - 1);
 
         //
         // Find the Copy assertions
         //
-        if ((curAssertion.assertionKind == OAK_EQUAL) && curAssertion.op2.KindIs(O2K_LCLVAR_COPY))
+        if (curAssertion.IsCopyAssertion())
         {
-            assert(curAssertion.op1.KindIs(O1K_LCLVAR));
-
             //
             //  op2.lclNum no longer depends upon this assertion
             //
-            lclNum = curAssertion.op2.GetLclNum();
+            lclNum = curAssertion.GetOp2().GetLclNum();
             BitVecOps::RemoveElemD(apTraits, GetAssertionDep(lclNum, /*mustExist*/ true), index - 1);
         }
     }

--- a/src/coreclr/jit/compiler.hpp
+++ b/src/coreclr/jit/compiler.hpp
@@ -3788,16 +3788,16 @@ inline void Compiler::optAssertionReset()
         AssertionIndex      index        = optAssertionCount;
         const AssertionDsc& curAssertion = optGetAssertion(index);
         optAssertionCount--;
-        unsigned lclNum = curAssertion.op1.lclNum;
+        unsigned lclNum = curAssertion.op1.GetLclNum();
         assert(lclNum < lvaCount);
         BitVecOps::RemoveElemD(apTraits, GetAssertionDep(lclNum, /*mustExist*/ true), index - 1);
 
         //
         // Find the Copy assertions
         //
-        if ((curAssertion.assertionKind == OAK_EQUAL) && (curAssertion.op2.kind == O2K_LCLVAR_COPY))
+        if ((curAssertion.assertionKind == OAK_EQUAL) && curAssertion.op2.KindIs(O2K_LCLVAR_COPY))
         {
-            assert(curAssertion.op1.kind == O1K_LCLVAR);
+            assert(curAssertion.op1.KindIs(O1K_LCLVAR));
 
             //
             //  op2.lclNum no longer depends upon this assertion

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12620,7 +12620,7 @@ void Compiler::fgKillDependentAssertionsSingle(unsigned lclNum DEBUGARG(GenTree*
             {
                 const AssertionDsc& curAssertion = optGetAssertion(index);
                 noway_assert((curAssertion.op1.GetLclNum() == lclNum) ||
-                             (curAssertion.op2.KindIs(O2K_LCLVAR_COPY) && (curAssertion.op2.lclNum == lclNum)));
+                             (curAssertion.op2.KindIs(O2K_LCLVAR_COPY) && (curAssertion.op2.GetLclNum() == lclNum)));
                 if (verbose)
                 {
                     printf("\nThe store ");
@@ -12747,7 +12747,7 @@ void Compiler::fgAssertionGen(GenTree* tree)
 
             if (varTypeIsIntegral(lclDsc->TypeGet()))
             {
-                ssize_t iconVal = assertion.op2.u1.iconVal;
+                ssize_t iconVal = assertion.op2.GetIntConstant();
                 if ((iconVal == 0) || (iconVal == 1))
                 {
                     auto         range          = IntegralRange(SymbolicIntegerValue::Zero, SymbolicIntegerValue::One);

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12619,13 +12619,14 @@ void Compiler::fgKillDependentAssertionsSingle(unsigned lclNum DEBUGARG(GenTree*
             if (BitVecOps::IsMember(apTraits, killed, index - 1))
             {
                 const AssertionDsc& curAssertion = optGetAssertion(index);
-                noway_assert((curAssertion.op1.GetLclNum() == lclNum) ||
-                             (curAssertion.op2.KindIs(O2K_LCLVAR_COPY) && (curAssertion.op2.GetLclNum() == lclNum)));
+                noway_assert(
+                    (curAssertion.GetOp1().GetLclNum() == lclNum) ||
+                    (curAssertion.GetOp2().KindIs(O2K_LCLVAR_COPY) && (curAssertion.GetOp2().GetLclNum() == lclNum)));
                 if (verbose)
                 {
                     printf("\nThe store ");
                     printTreeID(tree);
-                    printf(" using V%02u removes: ", curAssertion.op1.GetLclNum());
+                    printf(" using V%02u removes: ", curAssertion.GetOp1().GetLclNum());
                     optPrintAssertion(curAssertion, index);
                 }
             }
@@ -12740,19 +12741,20 @@ void Compiler::fgAssertionGen(GenTree* tree)
     //
     auto addImpliedAssertions = [=](AssertionIndex index, ASSERT_TP& assertions) {
         const AssertionDsc& assertion = optGetAssertion(index);
-        if ((assertion.assertionKind == OAK_EQUAL) && assertion.op1.KindIs(O1K_LCLVAR) &&
-            assertion.op2.KindIs(O2K_CONST_INT))
+        if (assertion.KindIs(OAK_EQUAL) && assertion.GetOp1().KindIs(O1K_LCLVAR) &&
+            assertion.GetOp2().KindIs(O2K_CONST_INT))
         {
-            LclVarDsc* const lclDsc = lvaGetDesc(assertion.op1.GetLclNum());
+            LclVarDsc* const lclDsc = lvaGetDesc(assertion.GetOp1().GetLclNum());
 
             if (varTypeIsIntegral(lclDsc->TypeGet()))
             {
-                ssize_t iconVal = assertion.op2.GetIntConstant();
+                ssize_t iconVal = assertion.GetOp2().GetIntConstant();
                 if ((iconVal == 0) || (iconVal == 1))
                 {
-                    auto         range          = IntegralRange(SymbolicIntegerValue::Zero, SymbolicIntegerValue::One);
-                    AssertionDsc extraAssertion = AssertionDsc::CreateSubrange(this, assertion.op1.GetLclNum(), range);
-                    AssertionIndex extraIndex   = optAddAssertion(extraAssertion);
+                    auto         range = IntegralRange(SymbolicIntegerValue::Zero, SymbolicIntegerValue::One);
+                    AssertionDsc extraAssertion =
+                        AssertionDsc::CreateSubrange(this, assertion.GetOp1().GetLclNum(), range);
+                    AssertionIndex extraIndex = optAddAssertion(extraAssertion);
                     if (extraIndex != NO_ASSERTION_INDEX)
                     {
                         unsigned const bvIndex = extraIndex - 1;

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -12619,13 +12619,13 @@ void Compiler::fgKillDependentAssertionsSingle(unsigned lclNum DEBUGARG(GenTree*
             if (BitVecOps::IsMember(apTraits, killed, index - 1))
             {
                 const AssertionDsc& curAssertion = optGetAssertion(index);
-                noway_assert((curAssertion.op1.lclNum == lclNum) ||
-                             ((curAssertion.op2.kind == O2K_LCLVAR_COPY) && (curAssertion.op2.lclNum == lclNum)));
+                noway_assert((curAssertion.op1.GetLclNum() == lclNum) ||
+                             (curAssertion.op2.KindIs(O2K_LCLVAR_COPY) && (curAssertion.op2.lclNum == lclNum)));
                 if (verbose)
                 {
                     printf("\nThe store ");
                     printTreeID(tree);
-                    printf(" using V%02u removes: ", curAssertion.op1.lclNum);
+                    printf(" using V%02u removes: ", curAssertion.op1.GetLclNum());
                     optPrintAssertion(curAssertion, index);
                 }
             }
@@ -12740,19 +12740,19 @@ void Compiler::fgAssertionGen(GenTree* tree)
     //
     auto addImpliedAssertions = [=](AssertionIndex index, ASSERT_TP& assertions) {
         const AssertionDsc& assertion = optGetAssertion(index);
-        if ((assertion.assertionKind == OAK_EQUAL) && (assertion.op1.kind == O1K_LCLVAR) &&
-            (assertion.op2.kind == O2K_CONST_INT))
+        if ((assertion.assertionKind == OAK_EQUAL) && assertion.op1.KindIs(O1K_LCLVAR) &&
+            assertion.op2.KindIs(O2K_CONST_INT))
         {
-            LclVarDsc* const lclDsc = lvaGetDesc(assertion.op1.lclNum);
+            LclVarDsc* const lclDsc = lvaGetDesc(assertion.op1.GetLclNum());
 
             if (varTypeIsIntegral(lclDsc->TypeGet()))
             {
                 ssize_t iconVal = assertion.op2.u1.iconVal;
                 if ((iconVal == 0) || (iconVal == 1))
                 {
-                    auto           range = IntegralRange(SymbolicIntegerValue::Zero, SymbolicIntegerValue::One);
-                    AssertionDsc   extraAssertion = AssertionDsc::CreateSubrange(this, assertion.op1.lclNum, range);
-                    AssertionIndex extraIndex     = optAddAssertion(extraAssertion);
+                    auto         range          = IntegralRange(SymbolicIntegerValue::Zero, SymbolicIntegerValue::One);
+                    AssertionDsc extraAssertion = AssertionDsc::CreateSubrange(this, assertion.op1.GetLclNum(), range);
+                    AssertionIndex extraIndex   = optAddAssertion(extraAssertion);
                     if (extraIndex != NO_ASSERTION_INDEX)
                     {
                         unsigned const bvIndex = extraIndex - 1;

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -916,7 +916,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             ValueNumStore::CompareCheckedBoundArithInfo info;
 
             // Get i, len, cns and < as "info."
-            comp->vnStore->GetCompareCheckedBoundArithInfo(curAssertion.op1.GetVN(), &info);
+            comp->vnStore->GetCompareCheckedBoundArithInfo(curAssertion.GetOp1().GetVN(), &info);
 
             // If we don't have the same variable we are comparing against, bail.
             if (normalLclVN != info.cmpOp)
@@ -945,7 +945,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             ValueNumStore::CompareCheckedBoundArithInfo info;
 
             // Get the info as "i", "<" and "len"
-            comp->vnStore->GetCompareCheckedBound(curAssertion.op1.GetVN(), &info);
+            comp->vnStore->GetCompareCheckedBound(curAssertion.GetOp1().GetVN(), &info);
 
             // If we don't have the same variable we are comparing against, bail.
             if (normalLclVN == info.cmpOp)
@@ -969,7 +969,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             ValueNumStore::ConstantBoundInfo info;
 
             // Get the info as "i", "<" and "100"
-            comp->vnStore->GetConstantBoundInfo(curAssertion.op1.GetVN(), &info);
+            comp->vnStore->GetConstantBoundInfo(curAssertion.GetOp1().GetVN(), &info);
 
             // If we don't have the same variable we are comparing against, bail.
             if (normalLclVN != info.cmpOpVN)
@@ -984,35 +984,35 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         // Current assertion is of the form i == 100
         else if (curAssertion.IsConstantInt32Assertion())
         {
-            if (curAssertion.op1.GetVN() != normalLclVN)
+            if (curAssertion.GetOp1().GetVN() != normalLclVN)
             {
                 continue;
             }
 
             // Ignore GC values/NULL caught by IsConstantInt32Assertion assertion (may happen on 32bit)
-            if (varTypeIsGC(comp->vnStore->TypeOfVN(curAssertion.op2.GetVN())))
+            if (varTypeIsGC(comp->vnStore->TypeOfVN(curAssertion.GetOp2().GetVN())))
             {
                 continue;
             }
 
-            int cnstLimit = (int)curAssertion.op2.GetIntConstant();
-            assert(cnstLimit == comp->vnStore->CoercedConstantValue<int>(curAssertion.op2.GetVN()));
+            int cnstLimit = (int)curAssertion.GetOp2().GetIntConstant();
+            assert(cnstLimit == comp->vnStore->CoercedConstantValue<int>(curAssertion.GetOp2().GetVN()));
 
-            if ((cnstLimit == 0) && (curAssertion.assertionKind == Compiler::OAK_NOT_EQUAL) && canUseCheckedBounds &&
-                comp->vnStore->IsVNCheckedBound(curAssertion.op1.GetVN()))
+            if ((cnstLimit == 0) && curAssertion.KindIs(Compiler::OAK_NOT_EQUAL) && canUseCheckedBounds &&
+                comp->vnStore->IsVNCheckedBound(curAssertion.GetOp1().GetVN()))
             {
                 // we have arr.Len != 0, so the length must be atleast one
                 limit   = Limit(Limit::keConstant, 1);
                 cmpOper = GT_GE;
             }
-            else if (curAssertion.assertionKind == Compiler::OAK_EQUAL)
+            else if (curAssertion.KindIs(Compiler::OAK_EQUAL))
             {
                 limit   = Limit(Limit::keConstant, cnstLimit);
                 cmpOper = GT_EQ;
             }
             else
             {
-                assert(curAssertion.assertionKind == Compiler::OAK_NOT_EQUAL);
+                assert(curAssertion.KindIs(Compiler::OAK_NOT_EQUAL));
 
                 // We have an assertion of the form "X != constLimit".
                 // For example, if the assertion is "X != 100" and the current range for X is [100, X],
@@ -1041,8 +1041,8 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         // Current assertion asserts a bounds check does not throw
         else if (curAssertion.IsBoundsCheckNoThrow())
         {
-            ValueNum indexVN = curAssertion.op1.GetArrBndIndex();
-            ValueNum lenVN   = curAssertion.op1.GetArrBndLength();
+            ValueNum indexVN = curAssertion.GetOp1().GetArrBndIndex();
+            ValueNum lenVN   = curAssertion.GetOp1().GetArrBndLength();
             if (normalLclVN == indexVN)
             {
                 if (canUseCheckedBounds)
@@ -1099,8 +1099,8 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         assert(limit.IsBinOpArray() || limit.IsConstant());
 
         // Make sure the assertion is of the form != 0 or == 0 if it isn't a constant assertion.
-        if (!isConstantAssertion && (curAssertion.assertionKind != Compiler::OAK_NO_THROW) &&
-            (curAssertion.op2.GetVN() != comp->vnStore->VNZeroForType(TYP_INT)))
+        if (!isConstantAssertion && !curAssertion.KindIs(Compiler::OAK_NO_THROW) &&
+            (curAssertion.GetOp2().GetVN() != comp->vnStore->VNZeroForType(TYP_INT)))
         {
             continue;
         }
@@ -1149,7 +1149,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         // If we have a non-constant assertion of the form == 0 (i.e., equals false), then reverse relop.
         // The relop has to be reversed because we have: (i < length) is false which is the same
         // as (i >= length).
-        if ((curAssertion.assertionKind == Compiler::OAK_EQUAL) && !isConstantAssertion)
+        if (curAssertion.KindIs(Compiler::OAK_EQUAL) && !isConstantAssertion)
         {
             cmpOper = GenTree::ReverseRelop(cmpOper);
         }

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -995,7 +995,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
                 continue;
             }
 
-            int cnstLimit = (int)curAssertion.op2.u1.iconVal;
+            int cnstLimit = (int)curAssertion.op2.GetIntConstant();
             assert(cnstLimit == comp->vnStore->CoercedConstantValue<int>(curAssertion.op2.GetVN()));
 
             if ((cnstLimit == 0) && (curAssertion.assertionKind == Compiler::OAK_NOT_EQUAL) && canUseCheckedBounds &&
@@ -1041,8 +1041,8 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         // Current assertion asserts a bounds check does not throw
         else if (curAssertion.IsBoundsCheckNoThrow())
         {
-            ValueNum indexVN = curAssertion.op1.GetArrBnd().vnIdx;
-            ValueNum lenVN   = curAssertion.op1.GetArrBnd().vnLen;
+            ValueNum indexVN = curAssertion.op1.GetArrBndIndex();
+            ValueNum lenVN   = curAssertion.op1.GetArrBndLength();
             if (normalLclVN == indexVN)
             {
                 if (canUseCheckedBounds)

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -916,7 +916,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             ValueNumStore::CompareCheckedBoundArithInfo info;
 
             // Get i, len, cns and < as "info."
-            comp->vnStore->GetCompareCheckedBoundArithInfo(curAssertion.op1.vn, &info);
+            comp->vnStore->GetCompareCheckedBoundArithInfo(curAssertion.op1.GetVN(), &info);
 
             // If we don't have the same variable we are comparing against, bail.
             if (normalLclVN != info.cmpOp)
@@ -945,7 +945,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             ValueNumStore::CompareCheckedBoundArithInfo info;
 
             // Get the info as "i", "<" and "len"
-            comp->vnStore->GetCompareCheckedBound(curAssertion.op1.vn, &info);
+            comp->vnStore->GetCompareCheckedBound(curAssertion.op1.GetVN(), &info);
 
             // If we don't have the same variable we are comparing against, bail.
             if (normalLclVN == info.cmpOp)
@@ -969,7 +969,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             ValueNumStore::ConstantBoundInfo info;
 
             // Get the info as "i", "<" and "100"
-            comp->vnStore->GetConstantBoundInfo(curAssertion.op1.vn, &info);
+            comp->vnStore->GetConstantBoundInfo(curAssertion.op1.GetVN(), &info);
 
             // If we don't have the same variable we are comparing against, bail.
             if (normalLclVN != info.cmpOpVN)
@@ -984,22 +984,22 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         // Current assertion is of the form i == 100
         else if (curAssertion.IsConstantInt32Assertion())
         {
-            if (curAssertion.op1.vn != normalLclVN)
+            if (curAssertion.op1.GetVN() != normalLclVN)
             {
                 continue;
             }
 
             // Ignore GC values/NULL caught by IsConstantInt32Assertion assertion (may happen on 32bit)
-            if (varTypeIsGC(comp->vnStore->TypeOfVN(curAssertion.op2.vn)))
+            if (varTypeIsGC(comp->vnStore->TypeOfVN(curAssertion.op2.GetVN())))
             {
                 continue;
             }
 
             int cnstLimit = (int)curAssertion.op2.u1.iconVal;
-            assert(cnstLimit == comp->vnStore->CoercedConstantValue<int>(curAssertion.op2.vn));
+            assert(cnstLimit == comp->vnStore->CoercedConstantValue<int>(curAssertion.op2.GetVN()));
 
             if ((cnstLimit == 0) && (curAssertion.assertionKind == Compiler::OAK_NOT_EQUAL) && canUseCheckedBounds &&
-                comp->vnStore->IsVNCheckedBound(curAssertion.op1.vn))
+                comp->vnStore->IsVNCheckedBound(curAssertion.op1.GetVN()))
             {
                 // we have arr.Len != 0, so the length must be atleast one
                 limit   = Limit(Limit::keConstant, 1);
@@ -1041,8 +1041,8 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         // Current assertion asserts a bounds check does not throw
         else if (curAssertion.IsBoundsCheckNoThrow())
         {
-            ValueNum indexVN = curAssertion.op1.bnd.vnIdx;
-            ValueNum lenVN   = curAssertion.op1.bnd.vnLen;
+            ValueNum indexVN = curAssertion.op1.GetArrBnd().vnIdx;
+            ValueNum lenVN   = curAssertion.op1.GetArrBnd().vnLen;
             if (normalLclVN == indexVN)
             {
                 if (canUseCheckedBounds)
@@ -1100,7 +1100,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
 
         // Make sure the assertion is of the form != 0 or == 0 if it isn't a constant assertion.
         if (!isConstantAssertion && (curAssertion.assertionKind != Compiler::OAK_NO_THROW) &&
-            (curAssertion.op2.vn != comp->vnStore->VNZeroForType(TYP_INT)))
+            (curAssertion.op2.GetVN() != comp->vnStore->VNZeroForType(TYP_INT)))
         {
             continue;
         }


### PR DESCRIPTION
[No diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1278933&view=ms.vss-build-web.run-extensions-tab). 

This PR effectively makes all fields in `AssertionDsc`, `AssertionDscOp1` and `AssertionDscOp2` private and exposes them via public getters with tons of asserts to validate that we use them in the correct context, I suspect I probably fixed a potential bug along the way.

Now all assertions are 100% never mutated outside of their Factory methods (and ReverseEquality one). As a side effect, I slightly compacted `AssertionDscOp1` with a union, now `AssertionDsc` is 40 bytes (on 64bit). I think it's possible to shrink it down to 32 bytes.

Also, renamed the fields to match our guidelines (m_)

Also, slightly improved JitDump for assertions.
