### PR TITLE
[mono] Fix function pointer type compatibility for isinst (issue #90308)

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/FunctionPointerTests.Runtime.cs
+++ b/src/libraries/System.Runtime/tests/System.Runtime.Tests/System/Type/FunctionPointerTests.Runtime.cs
@@ -12,7 +12,6 @@ namespace System.Tests.Types
     public partial class FunctionPointerTests
     {
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/90308", TestRuntimes.Mono)]
         public static unsafe void CompileTimeIdentity_Managed()
         {
             object obj = new delegate*<int>[1];
@@ -27,7 +26,6 @@ namespace System.Tests.Types
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/90308", TestRuntimes.Mono)]
         public static unsafe void CompileTimeIdentity_ManagedWithMods()
         {
             object obj = new delegate*<ref int, void>[1];
@@ -42,7 +40,6 @@ namespace System.Tests.Types
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/90308", TestRuntimes.Mono)]
         public static unsafe void CompileTimeIdentity_Unmanaged()
         {
             object obj = new delegate* unmanaged[MemberFunction]<void>[1];
@@ -59,7 +56,6 @@ namespace System.Tests.Types
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/90308", TestRuntimes.Mono)]
         public static unsafe void CompileTimeIdentity_UnmanagedIsPartOfIdentity()
         {
             object obj = new delegate* unmanaged[MemberFunction]<void>[1];

--- a/src/mono/mono/metadata/class.c
+++ b/src/mono/mono/metadata/class.c
@@ -4325,12 +4325,15 @@ mono_class_is_assignable_from_general (MonoClass *klass, MonoClass *oklass, gboo
 		}
 
 		if (m_class_get_byval_arg (klass)->type == MONO_TYPE_FNPTR) {
-			if (mono_metadata_signature_equal (m_type_data_get_method (klass_byval_arg), m_type_data_get_method (oklass_byval_arg))) {
-				*result = TRUE;
+			if (m_class_get_byval_arg (oklass)->type != MONO_TYPE_FNPTR) {
+				*result = FALSE;
 				return;
 			}
-
-			*result = FALSE;
+			/* Use type comparison with IGNORE_CMODS to treat function pointers with
+			 * different calling convention modifiers (e.g. Cdecl vs Stdcall) as equal,
+			 * while still distinguishing managed vs unmanaged calling conventions.
+			 * See https://github.com/dotnet/runtime/issues/90308 */
+			*result = mono_metadata_type_equal_full (klass_byval_arg, oklass_byval_arg, MONO_TYPE_EQ_FLAG_IGNORE_CMODS);
 			return;
 		}
 


### PR DESCRIPTION
- Add special case in JIT type-checking for function pointer array elements to fall back to runtime check instead of direct class pointer comparison
- Fix mono_class_is_assignable_from_general to use mono_metadata_type_equal_full with MONO_TYPE_EQ_FLAG_IGNORE_CMODS for proper function pointer comparison
- Remove ActiveIssue attributes from 4 CompileTimeIdentity tests that now pass