### PR TITLE
Add testing for native `IDispatch` custom marshaller scenario.

### DIFF
--- a/src/tests/Interop/COM/NETServer/DispatchTesting.cs
+++ b/src/tests/Interop/COM/NETServer/DispatchTesting.cs
@@ -89,4 +89,17 @@ public class DispatchTesting : Server.Contract.IDispatchTesting
     {
         return Enumerable.Range(0, 10).ToList().GetEnumerator();
     }
+
+    public object TriggerCustomMarshaler(object objIn, ref object objRef)
+    {
+        if (!Marshal.IsComObject(objIn))
+            throw new ArgumentException("objIn is not a COM object");
+
+        if (!Marshal.IsComObject(objRef))
+            throw new ArgumentException("objRef is not a COM object");
+
+        var ret = objRef;
+        objRef = objIn;
+        return ret;
+    }
 }

--- a/src/tests/Interop/COM/NativeServer/DispatchTesting.h
+++ b/src/tests/Interop/COM/NativeServer/DispatchTesting.h
@@ -250,6 +250,13 @@ public: // IDispatchTesting
             return S_FALSE; // Return a success case to indicate failure to trigger a failure.
         }
     }
+    virtual HRESULT STDMETHODCALLTYPE TriggerCustomMarshaler(
+        /*[in]*/ IUnknown* objIn,
+        /*[in,out]*/ IUnknown** objRef,
+        /*[out,retval]*/ IUnknown* pRetVal)
+    {
+        return E_NOTIMPL;
+    }
     virtual HRESULT STDMETHODCALLTYPE DoubleHVAValues (
         /*[in,out]*/ HFA_4 *input,
         /*[out,retval]*/ HFA_4 *pRetVal)

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.cs
@@ -257,6 +257,21 @@ namespace Server.Contract
         public int Value;
     }
 
+    public sealed class CustomObjectMarshaler : ICustomMarshaler
+    {
+        public static ICustomMarshaler GetInstance(string cookie) => new CustomObjectMarshaler();
+
+        public void CleanUpManagedData(object ManagedObj) => Marshal.ReleaseComObject(ManagedObj);
+
+        public void CleanUpNativeData(IntPtr pNativeData) => Marshal.Release(pNativeData);
+
+        public int GetNativeDataSize() => IntPtr.Size;
+
+        public IntPtr MarshalManagedToNative(object ManagedObj) => Marshal.GetIUnknownForObject(ManagedObj);
+
+        public object MarshalNativeToManaged(IntPtr pNativeData) => Marshal.GetObjectForIUnknown(pNativeData);
+    }
+
     [ComVisible(true)]
     [Guid("a5e04c1c-474e-46d2-bbc0-769d04e12b54")]
     [InterfaceType(ComInterfaceType.InterfaceIsIDispatch)]
@@ -281,6 +296,9 @@ namespace Server.Contract
         float Add_Float_ReturnAndUpdateByRef(float a, ref float b);
         double Add_Double_ReturnAndUpdateByRef(double a, ref double b);
         void TriggerException(IDispatchTesting_Exception excep, int errorCode);
+
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(CustomObjectMarshaler))]
+        object TriggerCustomMarshaler([MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(CustomObjectMarshaler))] object objIn, [MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef=typeof(CustomObjectMarshaler))] ref object objRef);
 
         // Special cases
         HFA_4 DoubleHVAValues(ref HFA_4 input);

--- a/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
+++ b/src/tests/Interop/COM/ServerContracts/Server.Contracts.h
@@ -443,6 +443,10 @@ IDispatchTesting : IDispatch
     virtual HRESULT STDMETHODCALLTYPE TriggerException (
         /*[in]*/ enum IDispatchTesting_Exception excep,
         /*[in]*/ int errorCode) = 0;
+    virtual HRESULT STDMETHODCALLTYPE TriggerCustomMarshaler(
+        /*[in]*/ IUnknown* objIn,
+        /*[in,out]*/ IUnknown** objRef,
+        /*[out,retval]*/ IUnknown* pRetVal) = 0;
 
     // Special cases
     virtual HRESULT STDMETHODCALLTYPE DoubleHVAValues(


### PR DESCRIPTION
Addressed test hole discovered in https://github.com/dotnet/runtime/pull/123832.