### PR TITLE
[mono] read `$DOTNET_STARTUP_HOOKS`

### DIFF
--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -8139,6 +8139,11 @@ mono_runtime_run_startup_hooks (void)
 	if (startup_hooks_env) {
 		startup_hooks_arg = mono_string_new_checked (startup_hooks_env, error);
 		g_free (startup_hooks_env);
+		if (!is_ok (error)) {
+			g_warning ("Failed to process $DOTNET_STARTUP_HOOKS environment variable");
+			mono_error_cleanup (error);
+			return;
+		}
 	} else {
 		startup_hooks_arg = mono_string_empty_internal (mono_domain_get ());
 	}

--- a/src/mono/mono/metadata/object.c
+++ b/src/mono/mono/metadata/object.c
@@ -8134,8 +8134,17 @@ mono_runtime_run_startup_hooks (void)
 	if (!method)
 		return;
 
+	gchar *startup_hooks_env = g_getenv ("DOTNET_STARTUP_HOOKS");
+	MonoString *startup_hooks_arg;
+	if (startup_hooks_env) {
+		startup_hooks_arg = mono_string_new_checked (startup_hooks_env, error);
+		g_free (startup_hooks_env);
+	} else {
+		startup_hooks_arg = mono_string_empty_internal (mono_domain_get ());
+	}
+
 	gpointer args [1];
-	args[0] = mono_string_empty_internal (mono_domain_get ());
+	args[0] = startup_hooks_arg;
 
 	mono_runtime_invoke_checked (method, NULL, args, error);
 	// runtime hooks design doc says not to catch exceptions from the hooks


### PR DESCRIPTION
Context: https://github.com/dotnet/runtime/blob/741b7157472b9a5c83a78f781ccfa8cd39707763/docs/design/features/host-startup-hook.md
Context: https://github.com/dotnet/android/pull/10755

Mono does not appear to read the `$DOTNET_STARTUP_HOOKS` env var when calling `System.StartupHookProvider.ProcessStartupHooks()` and only passes in `""`.

So, to get the same behavior as other runtimes, you would need to workaround with something like:

    <RuntimeHostConfigurationOption Include="STARTUP_HOOKS" Value="MyStartupHook" Condition=" '$(UseMonoRuntime)' == 'true' " />

Let's read the env var in Mono so that it works the same way as other runtimes.