### PR TITLE
Add PrivateAssets to PackageReference in Microsoft.NET.Sdk.IL

### DIFF
--- a/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/Microsoft.NET.Sdk.IL.proj
+++ b/src/coreclr/.nuget/Microsoft.NET.Sdk.IL/Microsoft.NET.Sdk.IL.proj
@@ -1,4 +1,5 @@
 <Project Sdk="Microsoft.Build.NoTargets">
+
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <EnablePackageValidation>false</EnablePackageValidation>
@@ -8,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Templating" Version="$(MicrosoftDotNetBuildTasksTemplatingVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
@@ -24,7 +25,6 @@
   <Target Name="ReplaceTemplateParametersInILTargetsTemplate"
           Inputs="$(MSBuildThisFileFullPath);$(ILTargetsTemplateFile)"
           Outputs="$(ILTargetsOutputFile)">
-
     <GenerateFileFromTemplate TemplateFile="$(ILTargetsTemplateFile)"
                               OutputPath="$(ILTargetsOutputFile)"
                               Properties="IlAsmVersion=$(Version)" />


### PR DESCRIPTION
Fixes https://github.com/dotnet/dotnet/issues/4638

This probably impacts P1 as the package dependency won't be resolvable.