### PR TITLE
Temporarily disable ios_arm64 platform builds

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
@@ -23,7 +23,8 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
+      # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+      # - ios_arm64
       - tvos_arm64
     variables:
       # map dependencies variables to local variables
@@ -64,7 +65,8 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
+      # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+      # - ios_arm64
       - tvos_arm64
     variables:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
@@ -108,7 +110,8 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
+      # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+      # - ios_arm64
       - tvos_arm64
     variables:
       # map dependencies variables to local variables
@@ -141,7 +144,8 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
+      # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+      # - ios_arm64
       - tvos_arm64
     variables:
       - name: timeoutPerTestInMinutes
@@ -179,7 +183,8 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
+      # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+      # - ios_arm64
       - tvos_arm64
     variables:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
@@ -222,7 +227,8 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
+      # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+      # - ios_arm64
       - tvos_arm64
     variables:
       # map dependencies variables to local variables

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1046,7 +1046,8 @@ extends:
           buildConfig: Release
           runtimeFlavor: mono
           platforms:
-            - ios_arm64
+            # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+            # - ios_arm64
             - tvos_arm64
           variables:
             # map dependencies variables to local variables
@@ -1092,7 +1093,8 @@ extends:
           buildConfig: Release
           runtimeFlavor: coreclr
           platforms:
-            - ios_arm64
+            # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+            # - ios_arm64
             - tvos_arm64
           variables:
             # map dependencies variables to local variables
@@ -1137,7 +1139,8 @@ extends:
           buildConfig: Release
           runtimeFlavor: coreclr
           platforms:
-            - ios_arm64
+            # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+            # - ios_arm64
             - tvos_arm64
           variables:
             # map dependencies variables to local variables


### PR DESCRIPTION
## Description

App installation fails on a subset of devices in the pool. tvOS devices function as expected, indicating a potential issue with device connectivity. This will be followed up with the engineering team.

Contributes to https://github.com/dotnet/runtime/issues/123796 https://github.com/dotnet/runtime/issues/122874