### PR TITLE
SPMI: Fix TOC logic broken after PAL cleanup

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontextreader.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontextreader.cpp
@@ -65,7 +65,7 @@ std::string MethodContextReader::CheckForPairedFile(const std::string& fileName,
     if (suffix_offset == std::string::npos || suffix_offset == 0 || (tmp != to_lower(fileName.substr(suffix_offset))))
         return std::string();
 
-    if (test_filename_available(fileName))
+    if (!test_filename_available(fileName))
         return std::string();
 
     // next, check foo.orig.new from foo.orig


### PR DESCRIPTION
This was broken in #116096. It means that SPMI has not been using TOC files since then, resulting in significant superpmi-diffs slowdown (creating asmdiffs for the examples became very slow, taking multiple minutes).

Before:
```
Measure-Command { C:\dev\dotnet\runtime\artifacts\tests\coreclr\windows.x64.Debug\Tests\Core_Root\superpmi.exe C:\dev\dotnet\runtime\artifacts\tests\coreclr\windows.x64.Debug\Tests\Core_Root\clrjit.dll C:\dev\dotnet\spmi\mch\c10e2acf-7c94-4c61-b895-5178602e0e1e.windows.x64\libraries_tests.run.windows.x64.Release.mch -c 684683 }
...
TotalMilliseconds : 2554.6079
```

After:
```
Measure-Command { C:\dev\dotnet\runtime\artifacts\tests\coreclr\windows.x64.Debug\Tests\Core_Root\superpmi.exe C:\dev\dotnet\runtime\artifacts\tests\coreclr\windows.x64.Debug\Tests\Core_Root\clrjit.dll C:\dev\dotnet\spmi\mch\c10e2acf-7c94-4c61-b895-5178602e0e1e.windows.x64\libraries_tests.run.windows.x64.Release.mch -c 684683 }
...
TotalMilliseconds : 46.0829
```
