### PR TITLE
JIT: Further liveness cleanups

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -710,7 +710,7 @@ PhaseStatus AsyncTransformation::Run()
         }
 
         m_compiler->lvaComputeRefCounts(true, false);
-        m_compiler->fgLocalVarLiveness();
+        m_compiler->fgAsyncLiveness();
         INDEBUG(m_compiler->mostRecentlyActivePhase = PHASE_ASYNC);
         VarSetOps::AssignNoCopy(m_compiler, m_compiler->compCurLife, VarSetOps::MakeEmpty(m_compiler));
     }

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -4724,7 +4724,7 @@ void Compiler::compCompile(void** methodCodePtr, uint32_t* methodCodeSize, JitFl
             else
             {
                 // At least do local var liveness; lowering depends on this.
-                fgLocalVarLiveness();
+                fgSsaLiveness();
             }
 
             if (doEarlyProp)

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -10034,7 +10034,6 @@ public:
 #endif // DEBUG
 
     bool fgLocalVarLivenessDone         = false; // Note that this one is used outside of debug.
-    bool fgIsDoingEarlyLiveness         = false;
     bool fgDidEarlyLiveness             = false;
     bool compPostImportationCleanupDone = false;
     bool compRegAllocDone               = false;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -5591,15 +5591,6 @@ public:
 
     GenTreeCall* fgGetSharedCCtor(CORINFO_CLASS_HANDLE cls);
 
-    bool backendRequiresLocalVarLifetimes()
-    {
-        return !opts.MinOpts() || m_regAlloc->willEnregisterLocalVars();
-    }
-
-    void fgLocalVarLiveness();
-
-    void fgAddHandlerLiveVars(BasicBlock* block, VARSET_TP& ehHandlerLiveVars, MemoryKindSet& memoryLiveness);
-
     // Blocks: convenience methods for enabling range-based `for` iteration over the function's blocks, e.g.:
     // 1.   for (BasicBlock* const block : compiler->Blocks()) ...
     // 2.   for (BasicBlock* const block : compiler->Blocks(startBlock)) ...
@@ -6701,7 +6692,17 @@ public:
 
     bool byrefStatesMatchGcHeapStates; // True iff GcHeap and ByrefExposed memory have all the same def points.
 
+    bool backendRequiresLocalVarLifetimes()
+    {
+        return !opts.MinOpts() || m_regAlloc->willEnregisterLocalVars();
+    }
+
+    void fgSsaLiveness();
+    void fgAsyncLiveness();
+    void fgPostLowerLiveness();
     PhaseStatus fgEarlyLiveness();
+
+    void fgAddHandlerLiveVars(BasicBlock* block, VARSET_TP& ehHandlerLiveVars, MemoryKindSet& memoryLiveness);
 
     //-------------------------------------------------------------------------
     //
@@ -10032,8 +10033,7 @@ public:
 
 #endif // DEBUG
 
-    bool fgLocalVarLivenessDone = false; // Note that this one is used outside of debug.
-    bool fgLocalVarLivenessChanged;
+    bool fgLocalVarLivenessDone         = false; // Note that this one is used outside of debug.
     bool fgIsDoingEarlyLiveness         = false;
     bool fgDidEarlyLiveness             = false;
     bool compPostImportationCleanupDone = false;

--- a/src/coreclr/jit/liveness.cpp
+++ b/src/coreclr/jit/liveness.cpp
@@ -22,17 +22,18 @@ class Liveness
 {
     Compiler* m_compiler;
 
-    VARSET_TP m_curUseSet; // vars used     by block (before a def)
-    VARSET_TP m_curDefSet; // vars assigned by block (before a use)
-    MemoryKindSet m_curMemoryUse = emptyMemoryKindSet;   // True iff the current basic block uses memory.
-    MemoryKindSet m_curMemoryDef = emptyMemoryKindSet;   // True iff the current basic block modifies memory.
-    MemoryKindSet m_curMemoryHavoc = emptyMemoryKindSet; // True if  the current basic block is known to set memory to a "havoc" value.
+    VARSET_TP     m_curUseSet;                         // vars used     by block (before a def)
+    VARSET_TP     m_curDefSet;                         // vars assigned by block (before a use)
+    MemoryKindSet m_curMemoryUse = emptyMemoryKindSet; // True iff the current basic block uses memory.
+    MemoryKindSet m_curMemoryDef = emptyMemoryKindSet; // True iff the current basic block modifies memory.
+    MemoryKindSet m_curMemoryHavoc =
+        emptyMemoryKindSet; // True if  the current basic block is known to set memory to a "havoc" value.
 
-    VARSET_TP m_liveIn;
-    VARSET_TP m_liveOut;
-    VARSET_TP m_ehHandlerLiveVars;
-    MemoryKindSet  m_memoryLiveIn = emptyMemoryKindSet;
-    MemoryKindSet  m_memoryLiveOut = emptyMemoryKindSet;
+    VARSET_TP     m_liveIn;
+    VARSET_TP     m_liveOut;
+    VARSET_TP     m_ehHandlerLiveVars;
+    MemoryKindSet m_memoryLiveIn  = emptyMemoryKindSet;
+    MemoryKindSet m_memoryLiveOut = emptyMemoryKindSet;
 
     bool m_livenessChanged = false;
 
@@ -1421,8 +1422,8 @@ void Liveness<TLiveness>::InterBlockLocalVarLiveness()
 template <typename TLiveness>
 void Liveness<TLiveness>::DoLiveVarAnalysis()
 {
-    m_liveIn = VarSetOps::MakeEmpty(m_compiler);
-    m_liveOut = VarSetOps::MakeEmpty(m_compiler);
+    m_liveIn            = VarSetOps::MakeEmpty(m_compiler);
+    m_liveOut           = VarSetOps::MakeEmpty(m_compiler);
     m_ehHandlerLiveVars = VarSetOps::MakeEmpty(m_compiler);
 
     const bool keepAliveThis =
@@ -1496,7 +1497,7 @@ void Liveness<TLiveness>::DoLiveVarAnalysis()
 #endif // DEBUG
 }
 
-template<typename TLiveness>
+template <typename TLiveness>
 bool Liveness<TLiveness>::PerBlockAnalysis(BasicBlock* block, bool keepAliveThis)
 {
     /* Compute the 'liveOut' set */
@@ -2918,6 +2919,6 @@ PhaseStatus Compiler::fgEarlyLiveness()
 
     EarlyLiveness liveness(this);
     liveness.Run();
-    fgDidEarlyLiveness     = true;
+    fgDidEarlyLiveness = true;
     return PhaseStatus::MODIFIED_EVERYTHING;
 }

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -8832,7 +8832,7 @@ PhaseStatus Lowering::DoPhase()
     {
         assert(m_compiler->opts.OptimizationEnabled());
 
-        m_compiler->fgLocalVarLiveness();
+        m_compiler->fgPostLowerLiveness();
         // local var liveness can delete code, which may create empty blocks
         bool modified = m_compiler->fgUpdateFlowGraph(/* doTailDuplication */ false, /* isPhase */ false);
 
@@ -8840,7 +8840,7 @@ PhaseStatus Lowering::DoPhase()
         {
             m_compiler->fgDfsBlocksAndRemove();
             JITDUMP("had to run another liveness pass:\n");
-            m_compiler->fgLocalVarLiveness();
+            m_compiler->fgPostLowerLiveness();
         }
 
         // Recompute local var ref counts again after liveness to reflect

--- a/src/coreclr/jit/ssabuilder.cpp
+++ b/src/coreclr/jit/ssabuilder.cpp
@@ -1203,7 +1203,7 @@ void SsaBuilder::Build()
     JITDUMP("*************** In SsaBuilder::Build()\n");
 
     // Compute liveness on the graph.
-    m_compiler->fgLocalVarLiveness();
+    m_compiler->fgSsaLiveness();
     EndPhase(PHASE_BUILD_SSA_LIVENESS);
 
     m_compiler->optRemoveRedundantZeroInits();


### PR DESCRIPTION
- Give each liveness phase its own separate function
- Remove `Compiler::fgIsDoingEarlyLiveness` in favor of a new config option in `Liveness`
- Move `fgLocalVarLivenessChanged` into `Liveness`
- Rename some fields in `Liveness`
- Remove optimization level checks in liveness since we only run liveness when optimizing and have done so for a while
- Remove the `LiveVarAnalysis` class and merge it into the `Liveness` class

No diffs expected. The last change here (removing `LiveVarAnalysis`) has some TP regressions on MSVC, once again related to inlining decisions.