### PR TITLE
Display method variants in R2RDump

### DIFF
--- a/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
@@ -54,7 +54,6 @@ namespace Internal.ReadyToRunConstants
         READYTORUN_METHOD_SIG_OwnerType = 0x40,
         READYTORUN_METHOD_SIG_UpdateContext = 0x80,
         READYTORUN_METHOD_SIG_AsyncVariant = 0x100,
-        READYTORUN_METHOD_SIG_ResumptionStub = 0x200,
     }
 
     [Flags]

--- a/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
@@ -54,6 +54,7 @@ namespace Internal.ReadyToRunConstants
         READYTORUN_METHOD_SIG_OwnerType = 0x40,
         READYTORUN_METHOD_SIG_UpdateContext = 0x80,
         READYTORUN_METHOD_SIG_AsyncVariant = 0x100,
+        READYTORUN_METHOD_SIG_ResumptionStub = 0x200,
     }
 
     [Flags]

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PgoInfoKey.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PgoInfoKey.cs
@@ -33,7 +33,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         public string SignatureString { get; }
 
-        public PgoInfoKey(IAssemblyMetadata componentReader, string owningType, EntityHandle methodHandle, string[] instanceArgs)
+        public PgoInfoKey(IAssemblyMetadata componentReader, string owningType, EntityHandle methodHandle, string[] instanceArgs, string[] modifiers)
         {
             ComponentReader = componentReader;
             EntityHandle owningTypeHandle;
@@ -76,6 +76,14 @@ namespace ILCompiler.Reflection.ReadyToRun
             }
 
             StringBuilder sb = new StringBuilder();
+            if (modifiers != null)
+            {
+                foreach (var modifier in modifiers)
+                {
+                    sb.Append(modifier);
+                    sb.Append(" ");
+                }
+            }
             sb.Append(Signature.ReturnType);
             sb.Append(" ");
             sb.Append(DeclaringType);
@@ -130,7 +138,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         public static PgoInfoKey FromReadyToRunMethod(ReadyToRunMethod method)
         {
-            var key = new PgoInfoKey(method.ComponentReader, method.DeclaringType, method.MethodHandle, method.InstanceArgs);
+            var key = new PgoInfoKey(method.ComponentReader, method.DeclaringType, method.MethodHandle, method.InstanceArgs, method.Modifiers);
             Debug.Assert(key.SignatureString == method.SignatureString);
             return key;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PgoInfoKey.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/PgoInfoKey.cs
@@ -33,7 +33,7 @@ namespace ILCompiler.Reflection.ReadyToRun
         /// </summary>
         public string SignatureString { get; }
 
-        public PgoInfoKey(IAssemblyMetadata componentReader, string owningType, EntityHandle methodHandle, string[] instanceArgs, string[] modifiers)
+        public PgoInfoKey(IAssemblyMetadata componentReader, string owningType, EntityHandle methodHandle, string[] instanceArgs, string[] signaturePrefixes)
         {
             ComponentReader = componentReader;
             EntityHandle owningTypeHandle;
@@ -76,11 +76,11 @@ namespace ILCompiler.Reflection.ReadyToRun
             }
 
             StringBuilder sb = new StringBuilder();
-            if (modifiers != null)
+            if (signaturePrefixes != null)
             {
-                foreach (var modifier in modifiers)
+                foreach (var prefix in signaturePrefixes)
                 {
-                    sb.Append(modifier);
+                    sb.Append(prefix);
                     sb.Append(" ");
                 }
             }
@@ -138,7 +138,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         public static PgoInfoKey FromReadyToRunMethod(ReadyToRunMethod method)
         {
-            var key = new PgoInfoKey(method.ComponentReader, method.DeclaringType, method.MethodHandle, method.InstanceArgs, method.Modifiers);
+            var key = new PgoInfoKey(method.ComponentReader, method.DeclaringType, method.MethodHandle, method.InstanceArgs, method.SignaturePrefixes);
             Debug.Assert(key.SignatureString == method.SignatureString);
             return key;
         }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
@@ -367,6 +367,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         public int RuntimeFunctionCount { get; set; }
         public int ColdRuntimeFunctionCount { get; set; }
+        public string[] Modifiers { get; }
 
         /// <summary>
         /// Extracts the method signature from the metadata by rid
@@ -379,6 +380,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             string owningType,
             string constrainedType,
             string[] instanceArgs,
+            string[] modifiers,
             int? fixupOffset)
         {
             InstanceArgs = (string[])instanceArgs?.Clone();
@@ -441,6 +443,15 @@ namespace ILCompiler.Reflection.ReadyToRun
             }
 
             StringBuilder sb = new StringBuilder();
+            if (modifiers != null)
+            {
+                Modifiers = modifiers;
+                foreach (var modifier in modifiers)
+                {
+                    sb.Append(modifier);
+                    sb.Append(" ");
+                }
+            }
             sb.Append(Signature.ReturnType);
             sb.Append(" ");
             sb.Append(DeclaringType);

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
@@ -367,7 +367,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
         public int RuntimeFunctionCount { get; set; }
         public int ColdRuntimeFunctionCount { get; set; }
-        public string[] Modifiers { get; }
+        public string[] SignaturePrefixes { get; }
 
         /// <summary>
         /// Extracts the method signature from the metadata by rid
@@ -380,7 +380,7 @@ namespace ILCompiler.Reflection.ReadyToRun
             string owningType,
             string constrainedType,
             string[] instanceArgs,
-            string[] modifiers,
+            string[] signaturePrefixes,
             int? fixupOffset)
         {
             InstanceArgs = (string[])instanceArgs?.Clone();
@@ -443,12 +443,12 @@ namespace ILCompiler.Reflection.ReadyToRun
             }
 
             StringBuilder sb = new StringBuilder();
-            if (modifiers != null)
+            if (signaturePrefixes != null)
             {
-                Modifiers = modifiers;
-                foreach (var modifier in modifiers)
+                SignaturePrefixes = signaturePrefixes;
+                foreach (var prefix in signaturePrefixes)
                 {
-                    sb.Append(modifier);
+                    sb.Append(prefix);
                     sb.Append(" ");
                 }
             }

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunMethod.cs
@@ -443,10 +443,10 @@ namespace ILCompiler.Reflection.ReadyToRun
             }
 
             StringBuilder sb = new StringBuilder();
-            if (signaturePrefixes != null)
+            if (signaturePrefixes is not null)
             {
-                SignaturePrefixes = signaturePrefixes;
-                foreach (var prefix in signaturePrefixes)
+                SignaturePrefixes = (string[])signaturePrefixes.Clone();
+                foreach (var prefix in SignaturePrefixes)
                 {
                     sb.Append(prefix);
                     sb.Append(" ");

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -1017,15 +1017,15 @@ namespace ILCompiler.Reflection.ReadyToRun
                 List<string> signaturePrefixes = [];
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_AsyncVariant) != 0)
                 {
-                    signaturePrefixes.Add("[Async]");
+                    signaturePrefixes.Add("[ASYNC]");
                 }
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
                 {
-                    throw new NotImplementedException("Crossgen2 should not emit code for Instantiating stubs.");
+                    signaturePrefixes.Add("[INST]");
                 }
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UnboxingStub) != 0)
                 {
-                    throw new NotImplementedException("Crossgen2 should not emit code for Unboxing stubs.");
+                    signaturePrefixes.Add("[UNBOX]");
                 }
 
                 int runtimeFunctionId;
@@ -1152,15 +1152,15 @@ namespace ILCompiler.Reflection.ReadyToRun
                 List<string> signaturePrefixes = [];
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_AsyncVariant) != 0)
                 {
-                    signaturePrefixes.Add("[Async]");
+                    signaturePrefixes.Add("[ASYNC]");
                 }
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
                 {
-                    throw new NotImplementedException("Crossgen2 should not emit code for Instantiating stubs.");
+                    signaturePrefixes.Add("[INST]");
                 }
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UnboxingStub) != 0)
                 {
-                    throw new NotImplementedException("Crossgen2 should not emit code for Unboxing stubs.");
+                    signaturePrefixes.Add("[UNBOX]");
                 }
 
                 GetPgoOffsetAndVersion(decoder.Offset, out int pgoFormatVersion, out int pgoOffset);

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -860,7 +860,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     int runtimeFunctionId;
                     int? fixupOffset;
                     GetRuntimeFunctionIndexFromOffset(offset, out runtimeFunctionId, out fixupOffset);
-                    ReadyToRunMethod method = new ReadyToRunMethod(this, componentReader, methodHandle, runtimeFunctionId, owningType: null, constrainedType: null, instanceArgs: null, fixupOffset: fixupOffset);
+                    ReadyToRunMethod method = new ReadyToRunMethod(this, componentReader, methodHandle, runtimeFunctionId, owningType: null, constrainedType: null, instanceArgs: null, modifiers: [], fixupOffset: fixupOffset);
 
                     if (method.EntryPointRuntimeFunctionId < 0 || method.EntryPointRuntimeFunctionId >= isEntryPoint.Length)
                     {
@@ -1014,6 +1014,20 @@ namespace ILCompiler.Reflection.ReadyToRun
                     constrainedType = decoder.ReadTypeSignatureNoEmit();
                 }
 
+                List<string> modifiers = [];
+                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_AsyncVariant) != 0)
+                {
+                    modifiers.Add("[Async]");
+                }
+                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_ResumptionStub) != 0)
+                {
+                    modifiers.Add("[Resume]");
+                }
+                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
+                {
+                    throw new NotImplementedException("Crossgen2 should not emit code for Instantiating stubs.");
+                }
+
                 int runtimeFunctionId;
                 int? fixupOffset;
                 GetRuntimeFunctionIndexFromOffset((int)decoder.Offset, out runtimeFunctionId, out fixupOffset);
@@ -1025,6 +1039,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     owningType,
                     constrainedType,
                     methodTypeArgs,
+                    modifiers.ToArray(),
                     fixupOffset);
                 if (method.EntryPointRuntimeFunctionId >= 0 && method.EntryPointRuntimeFunctionId < isEntryPoint.Length)
                 {
@@ -1134,9 +1149,23 @@ namespace ILCompiler.Reflection.ReadyToRun
                     constrainedType = decoder.ReadTypeSignatureNoEmit();
                 }
 
+                List<string> modifiers = [];
+                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_AsyncVariant) != 0)
+                {
+                    modifiers.Add("[Async]");
+                }
+                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_ResumptionStub) != 0)
+                {
+                    modifiers.Add("[Resume]");
+                }
+                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
+                {
+                    throw new NotImplementedException("Crossgen2 should not emit code for Instantiating stubs.");
+                }
+
                 GetPgoOffsetAndVersion(decoder.Offset, out int pgoFormatVersion, out int pgoOffset);
 
-                PgoInfoKey key = new PgoInfoKey(mdReader, owningType, methodHandle, methodTypeArgs);
+                PgoInfoKey key = new PgoInfoKey(mdReader, owningType, methodHandle, methodTypeArgs, modifiers.ToArray());
                 PgoInfo info = new PgoInfo(key, this, pgoFormatVersion, Image, pgoOffset);
 
                 // Since we do non-assembly qualified name based matching for generic instantiations, we can have conflicts.

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -1019,10 +1019,6 @@ namespace ILCompiler.Reflection.ReadyToRun
                 {
                     signaturePrefixes.Add("[Async]");
                 }
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_ResumptionStub) != 0)
-                {
-                    signaturePrefixes.Add("[Resume]");
-                }
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
                 {
                     throw new NotImplementedException("Crossgen2 should not emit code for Instantiating stubs.");
@@ -1153,10 +1149,6 @@ namespace ILCompiler.Reflection.ReadyToRun
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_AsyncVariant) != 0)
                 {
                     signaturePrefixes.Add("[Async]");
-                }
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_ResumptionStub) != 0)
-                {
-                    signaturePrefixes.Add("[Resume]");
                 }
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
                 {

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -860,7 +860,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     int runtimeFunctionId;
                     int? fixupOffset;
                     GetRuntimeFunctionIndexFromOffset(offset, out runtimeFunctionId, out fixupOffset);
-                    ReadyToRunMethod method = new ReadyToRunMethod(this, componentReader, methodHandle, runtimeFunctionId, owningType: null, constrainedType: null, instanceArgs: null, modifiers: [], fixupOffset: fixupOffset);
+                    ReadyToRunMethod method = new ReadyToRunMethod(this, componentReader, methodHandle, runtimeFunctionId, owningType: null, constrainedType: null, instanceArgs: null, signaturePrefixes: [], fixupOffset: fixupOffset);
 
                     if (method.EntryPointRuntimeFunctionId < 0 || method.EntryPointRuntimeFunctionId >= isEntryPoint.Length)
                     {
@@ -1014,14 +1014,14 @@ namespace ILCompiler.Reflection.ReadyToRun
                     constrainedType = decoder.ReadTypeSignatureNoEmit();
                 }
 
-                List<string> modifiers = [];
+                List<string> signaturePrefixes = [];
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_AsyncVariant) != 0)
                 {
-                    modifiers.Add("[Async]");
+                    signaturePrefixes.Add("[Async]");
                 }
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_ResumptionStub) != 0)
                 {
-                    modifiers.Add("[Resume]");
+                    signaturePrefixes.Add("[Resume]");
                 }
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
                 {
@@ -1039,7 +1039,7 @@ namespace ILCompiler.Reflection.ReadyToRun
                     owningType,
                     constrainedType,
                     methodTypeArgs,
-                    modifiers.ToArray(),
+                    signaturePrefixes.ToArray(),
                     fixupOffset);
                 if (method.EntryPointRuntimeFunctionId >= 0 && method.EntryPointRuntimeFunctionId < isEntryPoint.Length)
                 {
@@ -1149,14 +1149,14 @@ namespace ILCompiler.Reflection.ReadyToRun
                     constrainedType = decoder.ReadTypeSignatureNoEmit();
                 }
 
-                List<string> modifiers = [];
+                List<string> signaturePrefixes = [];
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_AsyncVariant) != 0)
                 {
-                    modifiers.Add("[Async]");
+                    signaturePrefixes.Add("[Async]");
                 }
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_ResumptionStub) != 0)
                 {
-                    modifiers.Add("[Resume]");
+                    signaturePrefixes.Add("[Resume]");
                 }
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
                 {
@@ -1165,7 +1165,7 @@ namespace ILCompiler.Reflection.ReadyToRun
 
                 GetPgoOffsetAndVersion(decoder.Offset, out int pgoFormatVersion, out int pgoOffset);
 
-                PgoInfoKey key = new PgoInfoKey(mdReader, owningType, methodHandle, methodTypeArgs, modifiers.ToArray());
+                PgoInfoKey key = new PgoInfoKey(mdReader, owningType, methodHandle, methodTypeArgs, signaturePrefixes.ToArray());
                 PgoInfo info = new PgoInfo(key, this, pgoFormatVersion, Image, pgoOffset);
 
                 // Since we do non-assembly qualified name based matching for generic instantiations, we can have conflicts.

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -933,6 +933,92 @@ namespace ILCompiler.Reflection.ReadyToRun
             }
         }
 
+        private record struct DecodedMethodSignature(
+            string OwningType,
+            EntityHandle MethodHandle,
+            string[] MethodTypeArgs,
+            string ConstrainedType,
+            string[] SignaturePrefixes);
+
+        private DecodedMethodSignature DecodeMethodSignature(ref IAssemblyMetadata mdReader, ref SignatureDecoder decoder)
+        {
+            int startOffset = decoder.Offset;
+            uint methodFlags = decoder.ReadUInt();
+
+            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UpdateContext) != 0)
+            {
+                int moduleIndex = (int)decoder.ReadUInt();
+                mdReader = OpenReferenceAssembly(moduleIndex);
+
+                SignatureFormattingOptions dummyOptions = new SignatureFormattingOptions();
+                decoder = new SignatureDecoder(_assemblyResolver, dummyOptions, mdReader.MetadataReader, this, startOffset);
+
+                decoder.ReadUInt(); // Skip past methodFlags
+                decoder.ReadUInt(); // And moduleIndex
+            }
+
+            string owningType = null;
+            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_OwnerType) != 0)
+            {
+                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UpdateContext) == 0)
+                {
+                    mdReader = decoder.GetMetadataReaderFromModuleOverride() ?? mdReader;
+                    if ((_composite) && mdReader == null)
+                    {
+                        // The only types that don't have module overrides on them in composite images are primitive types within the system module
+                        mdReader = GetSystemModuleMetadataReader();
+                    }
+                }
+                owningType = decoder.ReadTypeSignatureNoEmit();
+            }
+            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_SlotInsteadOfToken) != 0)
+            {
+                throw new NotImplementedException();
+            }
+            EntityHandle methodHandle;
+            int rid = (int)decoder.ReadUInt();
+            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MemberRefToken) != 0)
+            {
+                methodHandle = MetadataTokens.MemberReferenceHandle(rid);
+            }
+            else
+            {
+                methodHandle = MetadataTokens.MethodDefinitionHandle(rid);
+            }
+            string[] methodTypeArgs = null;
+            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MethodInstantiation) != 0)
+            {
+                uint typeArgCount = decoder.ReadUInt();
+                methodTypeArgs = new string[typeArgCount];
+                for (int typeArgIndex = 0; typeArgIndex < typeArgCount; typeArgIndex++)
+                {
+                    methodTypeArgs[typeArgIndex] = decoder.ReadTypeSignatureNoEmit();
+                }
+            }
+
+            string constrainedType = null;
+            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_Constrained) != 0)
+            {
+                constrainedType = decoder.ReadTypeSignatureNoEmit();
+            }
+
+            List<string> signaturePrefixes = [];
+            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UnboxingStub) != 0)
+            {
+                signaturePrefixes.Add("[UNBOX]");
+            }
+            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
+            {
+                signaturePrefixes.Add("[INST]");
+            }
+            if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_AsyncVariant) != 0)
+            {
+                signaturePrefixes.Add("[ASYNC]");
+            }
+
+            return new DecodedMethodSignature(owningType, methodHandle, methodTypeArgs, constrainedType, signaturePrefixes.ToArray());
+        }
+
         /// <summary>
         /// Initialize generic method instances with argument types and runtime function indices from InstanceMethodEntrypoints
         /// </summary>
@@ -950,83 +1036,10 @@ namespace ILCompiler.Reflection.ReadyToRun
             while (!curParser.IsNull())
             {
                 IAssemblyMetadata mdReader = GetGlobalMetadata();
-                bool updateMDReaderFromOwnerType = true;
                 SignatureFormattingOptions dummyOptions = new SignatureFormattingOptions();
                 SignatureDecoder decoder = new SignatureDecoder(_assemblyResolver, dummyOptions, mdReader?.MetadataReader, this, (int)curParser.Offset);
 
-                string owningType = null;
-
-                uint methodFlags = decoder.ReadUInt();
-
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UpdateContext) != 0)
-                {
-                    int moduleIndex = (int)decoder.ReadUInt();
-                    mdReader = OpenReferenceAssembly(moduleIndex);
-
-                    decoder = new SignatureDecoder(_assemblyResolver, dummyOptions, mdReader.MetadataReader, this, (int)curParser.Offset);
-
-                    decoder.ReadUInt(); // Skip past methodFlags
-                    decoder.ReadUInt(); // And moduleIndex
-                    updateMDReaderFromOwnerType = false;
-                }
-
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_OwnerType) != 0)
-                {
-                    if (updateMDReaderFromOwnerType)
-                    {
-                        mdReader = decoder.GetMetadataReaderFromModuleOverride() ?? mdReader;
-                        if ((_composite) && mdReader == null)
-                        {
-                            // The only types that don't have module overrides on them in composite images are primitive types within the system module
-                            mdReader = GetSystemModuleMetadataReader();
-                        }
-                    }
-                    owningType = decoder.ReadTypeSignatureNoEmit();
-                }
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_SlotInsteadOfToken) != 0)
-                {
-                    throw new NotImplementedException();
-                }
-                EntityHandle methodHandle;
-                int rid = (int)decoder.ReadUInt();
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MemberRefToken) != 0)
-                {
-                    methodHandle = MetadataTokens.MemberReferenceHandle(rid);
-                }
-                else
-                {
-                    methodHandle = MetadataTokens.MethodDefinitionHandle(rid);
-                }
-                string[] methodTypeArgs = null;
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MethodInstantiation) != 0)
-                {
-                    uint typeArgCount = decoder.ReadUInt();
-                    methodTypeArgs = new string[typeArgCount];
-                    for (int typeArgIndex = 0; typeArgIndex < typeArgCount; typeArgIndex++)
-                    {
-                        methodTypeArgs[typeArgIndex] = decoder.ReadTypeSignatureNoEmit();
-                    }
-                }
-
-                string constrainedType = null;
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_Constrained) != 0)
-                {
-                    constrainedType = decoder.ReadTypeSignatureNoEmit();
-                }
-
-                List<string> signaturePrefixes = [];
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UnboxingStub) != 0)
-                {
-                    signaturePrefixes.Add("[UNBOX]");
-                }
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
-                {
-                    signaturePrefixes.Add("[INST]");
-                }
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_AsyncVariant) != 0)
-                {
-                    signaturePrefixes.Add("[ASYNC]");
-                }
+                var sig = DecodeMethodSignature(ref mdReader, ref decoder);
 
                 int runtimeFunctionId;
                 int? fixupOffset;
@@ -1034,12 +1047,12 @@ namespace ILCompiler.Reflection.ReadyToRun
                 ReadyToRunMethod method = new ReadyToRunMethod(
                     this,
                     mdReader,
-                    methodHandle,
+                    sig.MethodHandle,
                     runtimeFunctionId,
-                    owningType,
-                    constrainedType,
-                    methodTypeArgs,
-                    signaturePrefixes.ToArray(),
+                    sig.OwningType,
+                    sig.ConstrainedType,
+                    sig.MethodTypeArgs,
+                    sig.SignaturePrefixes,
                     fixupOffset);
                 if (method.EntryPointRuntimeFunctionId >= 0 && method.EntryPointRuntimeFunctionId < isEntryPoint.Length)
                 {
@@ -1105,67 +1118,11 @@ namespace ILCompiler.Reflection.ReadyToRun
                 SignatureFormattingOptions dummyOptions = new SignatureFormattingOptions();
                 SignatureDecoder decoder = new SignatureDecoder(_assemblyResolver, dummyOptions, mdReader?.MetadataReader, this, (int)curParser.Offset);
 
-                string owningType = null;
-
-                uint methodFlags = decoder.ReadUInt();
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_OwnerType) != 0)
-                {
-                    mdReader = decoder.GetMetadataReaderFromModuleOverride() ?? mdReader;
-                    if ((_composite) && mdReader == null)
-                    {
-                        // The only types that don't have module overrides on them in composite images are primitive types within the system module
-                        mdReader = GetSystemModuleMetadataReader();
-                    }
-                    owningType = decoder.ReadTypeSignatureNoEmit();
-                }
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_SlotInsteadOfToken) != 0)
-                {
-                    throw new NotImplementedException();
-                }
-                EntityHandle methodHandle;
-                int rid = (int)decoder.ReadUInt();
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MemberRefToken) != 0)
-                {
-                    methodHandle = MetadataTokens.MemberReferenceHandle(rid);
-                }
-                else
-                {
-                    methodHandle = MetadataTokens.MethodDefinitionHandle(rid);
-                }
-                string[] methodTypeArgs = null;
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_MethodInstantiation) != 0)
-                {
-                    uint typeArgCount = decoder.ReadUInt();
-                    methodTypeArgs = new string[typeArgCount];
-                    for (int typeArgIndex = 0; typeArgIndex < typeArgCount; typeArgIndex++)
-                    {
-                        methodTypeArgs[typeArgIndex] = decoder.ReadTypeSignatureNoEmit();
-                    }
-                }
-
-                string constrainedType = null;
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_Constrained) != 0)
-                {
-                    constrainedType = decoder.ReadTypeSignatureNoEmit();
-                }
-
-                List<string> signaturePrefixes = [];
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UnboxingStub) != 0)
-                {
-                    signaturePrefixes.Add("[UNBOX]");
-                }
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
-                {
-                    signaturePrefixes.Add("[INST]");
-                }
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_AsyncVariant) != 0)
-                {
-                    signaturePrefixes.Add("[ASYNC]");
-                }
+                var sig = DecodeMethodSignature(ref mdReader, ref decoder);
 
                 GetPgoOffsetAndVersion(decoder.Offset, out int pgoFormatVersion, out int pgoOffset);
 
-                PgoInfoKey key = new PgoInfoKey(mdReader, owningType, methodHandle, methodTypeArgs, signaturePrefixes.ToArray());
+                PgoInfoKey key = new PgoInfoKey(mdReader, sig.OwningType, sig.MethodHandle, sig.MethodTypeArgs, sig.SignaturePrefixes);
                 PgoInfo info = new PgoInfo(key, this, pgoFormatVersion, Image, pgoOffset);
 
                 // Since we do non-assembly qualified name based matching for generic instantiations, we can have conflicts.

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -1023,6 +1023,10 @@ namespace ILCompiler.Reflection.ReadyToRun
                 {
                     throw new NotImplementedException("Crossgen2 should not emit code for Instantiating stubs.");
                 }
+                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UnboxingStub) != 0)
+                {
+                    throw new NotImplementedException("Crossgen2 should not emit code for Unboxing stubs.");
+                }
 
                 int runtimeFunctionId;
                 int? fixupOffset;
@@ -1153,6 +1157,10 @@ namespace ILCompiler.Reflection.ReadyToRun
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
                 {
                     throw new NotImplementedException("Crossgen2 should not emit code for Instantiating stubs.");
+                }
+                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UnboxingStub) != 0)
+                {
+                    throw new NotImplementedException("Crossgen2 should not emit code for Unboxing stubs.");
                 }
 
                 GetPgoOffsetAndVersion(decoder.Offset, out int pgoFormatVersion, out int pgoOffset);

--- a/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Reflection.ReadyToRun/ReadyToRunReader.cs
@@ -1015,17 +1015,17 @@ namespace ILCompiler.Reflection.ReadyToRun
                 }
 
                 List<string> signaturePrefixes = [];
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_AsyncVariant) != 0)
+                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UnboxingStub) != 0)
                 {
-                    signaturePrefixes.Add("[ASYNC]");
+                    signaturePrefixes.Add("[UNBOX]");
                 }
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
                 {
                     signaturePrefixes.Add("[INST]");
                 }
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UnboxingStub) != 0)
+                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_AsyncVariant) != 0)
                 {
-                    signaturePrefixes.Add("[UNBOX]");
+                    signaturePrefixes.Add("[ASYNC]");
                 }
 
                 int runtimeFunctionId;
@@ -1150,17 +1150,17 @@ namespace ILCompiler.Reflection.ReadyToRun
                 }
 
                 List<string> signaturePrefixes = [];
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_AsyncVariant) != 0)
+                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UnboxingStub) != 0)
                 {
-                    signaturePrefixes.Add("[ASYNC]");
+                    signaturePrefixes.Add("[UNBOX]");
                 }
                 if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_InstantiatingStub) != 0)
                 {
                     signaturePrefixes.Add("[INST]");
                 }
-                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_UnboxingStub) != 0)
+                if ((methodFlags & (uint)ReadyToRunMethodSigFlags.READYTORUN_METHOD_SIG_AsyncVariant) != 0)
                 {
-                    signaturePrefixes.Add("[UNBOX]");
+                    signaturePrefixes.Add("[ASYNC]");
                 }
 
                 GetPgoOffsetAndVersion(decoder.Offset, out int pgoFormatVersion, out int pgoOffset);


### PR DESCRIPTION
Adds signature prefixes to method signatures in R2RDump to differentiate task-returning, async, and (not yet implemented) async resumption stubs in the method entrypoint table dump.