### PR TITLE
Add `[IgnoreILFailure]` support to ILLink test framework.

### DIFF
--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/TestFrameworkTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/TestFrameworkTests.g.cs
@@ -76,6 +76,12 @@ namespace ILLink.RoslynAnalyzer.Tests
         }
 
         [Fact]
+        public Task ILVerificationErrorsCanBeIgnored()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
         public Task ILVerificationWorks()
         {
             return RunTest(allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/IgnoreILFailureAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/IgnoreILFailureAttribute.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+[AttributeUsage (AttributeTargets.Class, AllowMultiple = true)]
+public class IgnoreILFailureAttribute : BaseExpectedLinkedBehaviorAttribute
+{
+    public IgnoreILFailureAttribute (string messageContains)
+    {
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/ILVerificationErrorsCanBeIgnored.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/ILVerificationErrorsCanBeIgnored.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.TestFramework;
+
+[DisableILVerifyDiffing] // Needed to produce an il failure
+[IgnoreILFailure("Mono.Linker.Tests.Cases.TestFramework.Dependencies.AssemblyWithInvalidIL.GiveMeAValue() - ReturnMissing: Return value missing on the stack. -  Offset IL_0000")]
+[SetupLinkerArgument("--skip-unresolved", "true")] // needed due to the mscorlib shim
+[Define("IL_ASSEMBLY_AVAILABLE")]
+[SetupCompileBefore("ILAssembly.dll", new[] { "Dependencies/AssemblyWithInvalidIL.il" })]
+[KeptMemberInAssembly("ILAssembly.dll", "Mono.Linker.Tests.Cases.TestFramework.Dependencies.AssemblyWithInvalidIL", "GiveMeAValue()")]
+public class ILVerificationErrorsCanBeIgnored
+{
+    public static void Main()
+    {
+#if IL_ASSEMBLY_AVAILABLE
+            System.Console.WriteLine(new Mono.Linker.Tests.Cases.TestFramework.Dependencies.AssemblyWithInvalidIL().GiveMeAValue());
+#endif
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ILVerification/ILVerifierResult.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/ILVerification/ILVerifierResult.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Text;
 using ILVerify;
 
 namespace Mono.Linker.Tests.TestCasesRunner.ILVerification;
 
+[DebuggerDisplay("{GetErrorMessage()}")]
 public class ILVerifierResult
 {
     public readonly VerificationResult Result;


### PR DESCRIPTION
At Unity we have a few tests where we are modifying IL in System.Private.CoreLib and it throws off the diff'ing due to shifted offsets.  The only solution today is to disable il verification for all of the assembly.  This is not ideal as it means we could let other bugs slip in in the future.  This PR adds a way to filter out a given il verification error so that you don't have to disable il verification for the whole assembly.  It's a fairly crude mechanism but I think it should be good enough for the limited number of places we want to use it.

Also while I'm here, I added `DebuggerDisplay` to `ILVerifierResult`.  It's helpful when trying to debug il verification related issues