### PR TITLE
Introduce OAK_*relops*

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -781,25 +781,12 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
             printf("VN " FMT_VN "", curAssertion.GetOp1().GetVN());
             break;
 
-        case O1K_ARR_BND:
-            printf("ArrBnd idx " FMT_VN " < len " FMT_VN "", curAssertion.GetOp1().GetArrBndIndex(),
-                   curAssertion.GetOp1().GetArrBndLength());
-            break;
-
         case O1K_BOUND_OPER_BND:
             printf("Oper_Bnd " FMT_VN "", curAssertion.GetOp1().GetVN());
             break;
 
         case O1K_BOUND_LOOP_BND:
             printf("Loop_Bnd " FMT_VN "", curAssertion.GetOp1().GetVN());
-            break;
-
-        case O1K_CONSTANT_LOOP_BND:
-            printf("Const_Bnd " FMT_VN "", curAssertion.GetOp1().GetVN());
-            break;
-
-        case O1K_CONSTANT_LOOP_BND_UN:
-            printf("Const_Bnd_Un " FMT_VN "", curAssertion.GetOp1().GetVN());
             break;
 
         case O1K_EXACT_TYPE:
@@ -825,13 +812,41 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
             printf(" != ");
             break;
 
+        case OAK_LT:
+            printf(" < ");
+            break;
+
+        case OAK_LT_UN:
+            printf(" u< ");
+            break;
+
+        case OAK_LE:
+            printf(" <= ");
+            break;
+
+        case OAK_LE_UN:
+            printf(" u<= ");
+            break;
+
+        case OAK_GT:
+            printf(" > ");
+            break;
+
+        case OAK_GT_UN:
+            printf(" u> ");
+            break;
+
+        case OAK_GE:
+            printf(" >= ");
+            break;
+
+        case OAK_GE_UN:
+            printf(" u>= ");
+            break;
+
         case OAK_SUBRANGE:
             printf(" in ");
             break;
-
-        case OAK_NO_THROW:
-            printf(" no-throw\n");
-            return; // No op2 to print
 
         default:
             unreached();
@@ -857,8 +872,7 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
                     printf("MT(%s)", eeGetClassName(reinterpret_cast<CORINFO_CLASS_HANDLE>(iconVal)));
                 }
             }
-            else if (curAssertion.GetOp1().KindIs(O1K_BOUND_OPER_BND, O1K_BOUND_LOOP_BND, O1K_CONSTANT_LOOP_BND,
-                                                  O1K_CONSTANT_LOOP_BND_UN))
+            else if (curAssertion.GetOp1().KindIs(O1K_BOUND_OPER_BND, O1K_BOUND_LOOP_BND))
             {
                 vnStore->vnDump(this, curAssertion.GetOp2().GetVN());
             }
@@ -893,6 +907,10 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
 
         case O2K_SUBRANGE:
             IntegralRange::Print(curAssertion.GetOp2().GetIntegralRange());
+            break;
+
+        case O2K_CHECKED_BOUND:
+            printf("VN " FMT_VN "", curAssertion.GetOp2().GetVN());
             break;
 
         default:
@@ -1437,27 +1455,15 @@ void Compiler::optDebugCheckAssertion(const AssertionDsc& assertion) const
 {
     switch (assertion.GetOp1().GetKind())
     {
-        case O1K_ARR_BND:
-            // It would be good to check that bnd.vnIdx and bnd.vnLen are valid value numbers.
-            assert(!optLocalAssertionProp);
-            assert(assertion.KindIs(OAK_NO_THROW));
-            break;
         case O1K_EXACT_TYPE:
         case O1K_SUBTYPE:
         case O1K_VN:
         case O1K_BOUND_OPER_BND:
         case O1K_BOUND_LOOP_BND:
-        case O1K_CONSTANT_LOOP_BND:
-        case O1K_CONSTANT_LOOP_BND_UN:
             assert(!optLocalAssertionProp);
             break;
         default:
             break;
-    }
-
-    if (!assertion.HasOp2())
-    {
-        return;
     }
 
     switch (assertion.GetOp2().GetKind())
@@ -1508,14 +1514,12 @@ void Compiler::optDebugCheckAssertions(AssertionIndex index)
 //
 // Arguments:
 //    assertionIndex - the index of the assertion
-//    op1 - the first assertion operand
-//    op2 - the second assertion operand
 //
 // Notes:
 //    The created complementary assertion is associated with the original
 //    assertion such that it can be found by optFindComplementary.
 //
-void Compiler::optCreateComplementaryAssertion(AssertionIndex assertionIndex, GenTree* op1, GenTree* op2)
+void Compiler::optCreateComplementaryAssertion(AssertionIndex assertionIndex)
 {
     if (assertionIndex == NO_ASSERTION_INDEX)
     {
@@ -1523,7 +1527,6 @@ void Compiler::optCreateComplementaryAssertion(AssertionIndex assertionIndex, Ge
     }
 
     const AssertionDsc& candidateAssertion = optGetAssertion(assertionIndex);
-
     if (candidateAssertion.KindIs(OAK_EQUAL))
     {
         // Don't create useless OAK_NOT_EQUAL assertions
@@ -1550,15 +1553,12 @@ void Compiler::optCreateComplementaryAssertion(AssertionIndex assertionIndex, Ge
         {
             return;
         }
-
-        AssertionDsc reversed = candidateAssertion.ReverseEquality();
+        AssertionDsc reversed = candidateAssertion.Reverse();
         optMapComplementary(optAddAssertion(reversed), assertionIndex);
     }
-    else if (candidateAssertion.KindIs(OAK_NOT_EQUAL))
+    else if (AssertionDsc::IsReversible(candidateAssertion.GetKind()))
     {
-        // All OAK_EQUAL assertions are potentially useful
-
-        AssertionDsc reversed = candidateAssertion.ReverseEquality();
+        AssertionDsc reversed = candidateAssertion.Reverse();
         optMapComplementary(optAddAssertion(reversed), assertionIndex);
     }
 }
@@ -1589,7 +1589,7 @@ AssertionIndex Compiler::optCreateJtrueAssertions(GenTree* op1, GenTree* op2, bo
     // allows for a complementary only if there is an assertion on the False path (tree->HasAssertion()).
     if (assertionIndex != NO_ASSERTION_INDEX)
     {
-        optCreateComplementaryAssertion(assertionIndex, op1, op2);
+        optCreateComplementaryAssertion(assertionIndex);
     }
     return assertionIndex;
 }
@@ -1618,7 +1618,7 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     {
         AssertionDsc   dsc   = AssertionDsc::CreateCompareCheckedBoundArith(this, relopVN, /*withArith*/ true);
         AssertionIndex index = optAddAssertion(dsc);
-        optCreateComplementaryAssertion(index, nullptr, nullptr);
+        optCreateComplementaryAssertion(index);
         return index;
     }
 
@@ -1629,7 +1629,7 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     {
         AssertionDsc   dsc   = AssertionDsc::CreateCompareCheckedBoundArith(this, relopVN, /*withArith*/ false);
         AssertionIndex index = optAddAssertion(dsc);
-        optCreateComplementaryAssertion(index, nullptr, nullptr);
+        optCreateComplementaryAssertion(index);
         return index;
     }
 
@@ -1652,24 +1652,12 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
         return index;
     }
 
-    // Cases where op1 holds the lhs of the condition op2 holds rhs.
-    // Loop condition like "i < 100"
-    // Assertion: "i < 100 != 0"
-    if (vnStore->IsVNConstantBound(relopVN))
+    // Create "X relop CNS" assertion (both signed and unsigned relops)
+    if (vnStore->IsVNConstantBound(relopVN) || vnStore->IsVNConstantBoundUnsigned(relopVN))
     {
-        AssertionDsc   dsc   = AssertionDsc::CreateConstantLoopBound(this, relopVN, /*isUnsigned*/ false);
+        AssertionDsc   dsc   = AssertionDsc::CreateConstantLoopBound(this, relopVN);
         AssertionIndex index = optAddAssertion(dsc);
-        optCreateComplementaryAssertion(index, nullptr, nullptr);
-        return index;
-    }
-
-    // Same as above but for unsigned comparisons.
-    // Assertion: "i u< 100 != 0"
-    if (vnStore->IsVNConstantBoundUnsigned(relopVN))
-    {
-        AssertionDsc   dsc   = AssertionDsc::CreateConstantLoopBound(this, relopVN, /*isUnsigned*/ true);
-        AssertionIndex index = optAddAssertion(dsc);
-        optCreateComplementaryAssertion(index, nullptr, nullptr);
+        optCreateComplementaryAssertion(index);
         return index;
     }
 
@@ -2012,7 +2000,7 @@ AssertionIndex Compiler::optFindComplementary(AssertionIndex assertIndex)
     const AssertionDsc& inputAssertion = optGetAssertion(assertIndex);
 
     // Must be an equal or not equal assertion.
-    if (!inputAssertion.KindIs(OAK_EQUAL) && !inputAssertion.KindIs(OAK_NOT_EQUAL))
+    if (!AssertionDsc::IsReversible(inputAssertion.GetKind()))
     {
         return NO_ASSERTION_INDEX;
     }
@@ -3531,7 +3519,7 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
         //   array[idx] = 42; // creates 'BoundsCheckNoThrow' assertion
         //   return idx % 8;  // idx is known to be never negative here, hence, MOD->UMOD
         //
-        if (curAssertion.IsBoundsCheckNoThrow() && (curAssertion.GetOp1().GetArrBndIndex() == treeVN))
+        if (curAssertion.IsBoundsCheckNoThrow() && (curAssertion.GetOp1().GetVN() == treeVN))
         {
             *isKnownNonNegative = true;
             continue;
@@ -3542,7 +3530,7 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
         //  array[idx] = 42;
         //  array.Length is known to be non-negative and non-zero here
         //
-        if (curAssertion.IsBoundsCheckNoThrow() && (curAssertion.GetOp1().GetArrBndLength() == treeVN))
+        if (curAssertion.IsBoundsCheckNoThrow() && (curAssertion.GetOp2().GetVN() == treeVN))
         {
             *isKnownNonNegative = true;
             *isKnownNonZero     = true;
@@ -3567,49 +3555,19 @@ void Compiler::optAssertionProp_RangeProperties(ASSERT_VALARG_TP assertions,
             }
         }
 
-        // OAK_[NOT]_EQUAL assertion with op1 being O1K_CONSTANT_LOOP_BND
-        // representing "(X relop CNS) ==/!= 0" assertion.
-        if (!curAssertion.IsConstantBound() && !curAssertion.IsConstantBoundUnsigned())
+        if (curAssertion.IsRelop() && curAssertion.GetOp2().KindIs(O2K_CONST_INT) &&
+            (curAssertion.GetOp1().GetVN() == treeVN) && curAssertion.GetOp2().GetIntConstant() >= 0)
         {
-            continue;
-        }
-
-        ValueNumStore::ConstantBoundInfo info;
-        vnStore->GetConstantBoundInfo(curAssertion.GetOp1().GetVN(), &info);
-
-        if (info.cmpOpVN != treeVN)
-        {
-            continue;
-        }
-
-        // Root assertion has to be either:
-        // (X relop CNS) == 0
-        // (X relop CNS) != 0
-        if (!curAssertion.GetOp2().KindIs(O2K_CONST_INT) || (curAssertion.GetOp2().GetIntConstant() != 0))
-        {
-            continue;
-        }
-
-        genTreeOps cmpOper = static_cast<genTreeOps>(info.cmpOper);
-
-        // Normalize "(X relop CNS) == false" to "(X reversed_relop CNS) == true"
-        if (curAssertion.KindIs(OAK_EQUAL))
-        {
-            cmpOper = GenTree::ReverseRelop(cmpOper);
-        }
-
-        if ((info.constVal >= 0))
-        {
-            if (info.isUnsigned && ((cmpOper == GT_LT) || (cmpOper == GT_LE)))
+            if (curAssertion.KindIs(OAK_LT_UN, OAK_LE_UN))
             {
                 // (uint)X <= CNS means X is [0..CNS]
                 *isKnownNonNegative = true;
             }
-            else if (!info.isUnsigned && ((cmpOper == GT_GE) || (cmpOper == GT_GT)))
+            else if (curAssertion.KindIs(OAK_GE, OAK_GT))
             {
                 // X >= CNS means X is [CNS..unknown]
                 *isKnownNonNegative = true;
-                *isKnownNonZero     = (cmpOper == GT_GT) || (info.constVal > 0);
+                *isKnownNonZero     = curAssertion.KindIs(OAK_GT) || (curAssertion.GetOp2().GetIntConstant() > 0);
             }
         }
     }
@@ -3834,42 +3792,6 @@ AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP as
 
 /*****************************************************************************
  *
- *  Given a set of "assertions" to search for, find an assertion that is either
- *  op == 0 or op != 0
- *
- */
-AssertionIndex Compiler::optGlobalAssertionIsEqualOrNotEqualZero(ASSERT_VALARG_TP assertions, GenTree* op1)
-{
-    if (BitVecOps::IsEmpty(apTraits, assertions) || !optCanPropEqual)
-    {
-        return NO_ASSERTION_INDEX;
-    }
-    BitVecOps::Iter iter(apTraits, assertions);
-    unsigned        index = 0;
-    while (iter.NextElem(&index))
-    {
-        AssertionIndex assertionIndex = GetAssertionIndex(index);
-        if (assertionIndex > optAssertionCount)
-        {
-            break;
-        }
-        const AssertionDsc& curAssertion = optGetAssertion(assertionIndex);
-        if (!curAssertion.CanPropEqualOrNotEqual())
-        {
-            continue;
-        }
-
-        if ((curAssertion.GetOp1().GetVN() == vnStore->VNConservativeNormalValue(op1->gtVNPair)) &&
-            (curAssertion.GetOp2().GetVN() == vnStore->VNZeroForType(op1->TypeGet())))
-        {
-            return assertionIndex;
-        }
-    }
-    return NO_ASSERTION_INDEX;
-}
-
-/*****************************************************************************
- *
  *  Given a tree consisting of a RelOp and a set of available assertions
  *  we try to propagate an assertion and modify the RelOp tree if we can.
  *  We pass in the root of the tree via 'stmt', for local copy prop 'stmt' will be nullptr
@@ -3962,36 +3884,59 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
         }
     }
 
-    // Look for assertions of the form (tree EQ/NE 0)
-    AssertionIndex index = optGlobalAssertionIsEqualOrNotEqualZero(assertions, tree);
-
-    if (index != NO_ASSERTION_INDEX)
+    ValueNum relopVN = optConservativeNormalVN(tree);
+    if (!BitVecOps::IsEmpty(apTraits, assertions))
     {
-        // We know that this relop is either 0 or != 0 (1)
-        const AssertionDsc& curAssertion = optGetAssertion(index);
+        ValueNum op1VN   = optConservativeNormalVN(op1);
+        ValueNum op2VN   = optConservativeNormalVN(op2);
+        ValueNum falseVN = vnStore->VNZeroForType(TYP_INT);
 
-#ifdef DEBUG
-        if (verbose)
+        BitVecOps::Iter iter(apTraits, assertions);
+        unsigned        index = 0;
+        while (iter.NextElem(&index))
         {
-            printf("\nVN relop based constant assertion prop in " FMT_BB ":\n", compCurBB->bbNum);
-            printf("Assertion index=#%02u: ", index);
-            printTreeID(tree);
-            printf(" %s 0\n", curAssertion.KindIs(OAK_EQUAL) ? "==" : "!=");
-        }
-#endif
+            const AssertionDsc& curAssertion = optGetAssertion(GetAssertionIndex(index));
 
-        newTree = curAssertion.KindIs(OAK_EQUAL) ? gtNewIconNode(0) : gtNewIconNode(1);
-        newTree = gtWrapWithSideEffects(newTree, tree, GTF_ALL_EFFECT);
-        DISPTREE(newTree);
-        return optAssertionProp_Update(newTree, tree, stmt);
+            // Look for a relop-like assertion that matches the current relop exactly.
+            // Example: currentTree is "X >= Y" and we have an assertion "X >= Y" (or its inverse "X < Y").
+            //
+            if (curAssertion.IsRelop() && (curAssertion.GetOp1().GetVN() == op1VN) &&
+                (curAssertion.GetOp2().GetVN() == op2VN))
+            {
+                bool       isUnsigned;
+                genTreeOps assertionOper = AssertionDsc::ToCompareOper(curAssertion.GetKind(), &isUnsigned);
+
+                if (tree->OperIs(assertionOper, GenTree::ReverseRelop(assertionOper)) &&
+                    (tree->IsUnsigned() == isUnsigned))
+                {
+                    newTree = gtNewIconNode(tree->OperIs(assertionOper) ? 1 : 0);
+                }
+            }
+            // Look for an equality assertion involving the entire relop and zero.
+            // Example: currentTree is "X >= Y" and we have an assertion "(X >= Y) == 0"
+            //
+            else if (curAssertion.CanPropEqualOrNotEqual() && (curAssertion.GetOp1().GetVN() == relopVN) &&
+                     (curAssertion.GetOp2().GetVN() == falseVN))
+            {
+                newTree = gtNewIconNode(curAssertion.KindIs(OAK_EQUAL) ? 0 : 1);
+            }
+
+            if (tree != newTree)
+            {
+                JITDUMP("Found matching assertion #%02u for tree %06u.", index, dspTreeID(tree));
+                newTree = gtWrapWithSideEffects(newTree, tree, GTF_ALL_EFFECT);
+                JITDUMP(". Folded into:\n");
+                DISPTREE(newTree);
+                return optAssertionProp_Update(newTree, tree, stmt);
+            }
+        }
     }
 
     // See if we can fold the relop based on range information.
     // We don't need the op1->TypeIs(TYP_INT) check, but it seems to improve the TP quite a bit.
     if (op1->TypeIs(TYP_INT))
     {
-        ValueNum relopVN    = vnStore->VNConservativeNormalValue(tree->gtVNPair);
-        Range    relopRange = RangeCheck::GetRangeFromAssertions(this, relopVN, assertions);
+        Range relopRange = RangeCheck::GetRangeFromAssertions(this, relopVN, assertions);
 
         int relopResult;
         if (relopRange.IsSingleValueConstant(&relopResult))
@@ -4039,7 +3984,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
     }
 
     // Find an equal or not equal assertion involving "op1" and "op2".
-    index = optGlobalAssertionIsEqualOrNotEqual(assertions, op1, op2);
+    AssertionIndex index = optGlobalAssertionIsEqualOrNotEqual(assertions, op1, op2);
 
     if (index == NO_ASSERTION_INDEX)
     {
@@ -4967,12 +4912,11 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
         }
 
         // Do we have a previous range check involving the same 'vnLen' upper bound?
-        if (curAssertion.GetOp1().GetArrBndLength() ==
-            vnStore->VNConservativeNormalValue(arrBndsChk->GetArrayLength()->gtVNPair))
+        if (curAssertion.GetOp2().GetVN() == vnStore->VNConservativeNormalValue(arrBndsChk->GetArrayLength()->gtVNPair))
         {
             // Do we have the exact same lower bound 'vnIdx'?
             //       a[i] followed by a[i]
-            if (curAssertion.GetOp1().GetArrBndIndex() == vnCurIdx)
+            if (curAssertion.GetOp1().GetVN() == vnCurIdx)
             {
                 return dropBoundsCheck(INDEBUG("a[i] followed by a[i]"));
             }
@@ -5012,7 +4956,7 @@ GenTree* Compiler::optAssertionProp_BndsChk(ASSERT_VALARG_TP assertions, GenTree
 
                 int index1;
                 int index2;
-                if (tryGetMaxOrMinConst(curAssertion.GetOp1().GetArrBndIndex(), /*min*/ true, &index1) &&
+                if (tryGetMaxOrMinConst(curAssertion.GetOp1().GetVN(), /*min*/ true, &index1) &&
                     tryGetMaxOrMinConst(vnCurIdx, /*max*/ false, &index2))
                 {
                     // It can always be considered as redundant with any previous higher constant value
@@ -5283,14 +5227,14 @@ bool Compiler::optCreateJumpTableImpliedAssertions(BasicBlock* switchBb)
                 {
                     // Create "X >= value" assertion (both operands are never negative)
                     ValueNum     relop = vnStore->VNForFunc(TYP_INT, VNF_GE, opVN, vnStore->VNForIntCon(value));
-                    AssertionDsc dsc   = AssertionDsc::CreateConstantLoopBound(this, relop, /*isUnsigned*/ false);
+                    AssertionDsc dsc   = AssertionDsc::CreateConstantLoopBound(this, relop);
                     newAssertIdx       = optAddAssertion(dsc);
                 }
                 else
                 {
                     // Create "X u>= value" assertion
                     ValueNum     relop = vnStore->VNForFunc(TYP_INT, VNF_GE_UN, opVN, vnStore->VNForIntCon(value));
-                    AssertionDsc dsc   = AssertionDsc::CreateConstantLoopBound(this, relop, /*isUnsigned*/ true);
+                    AssertionDsc dsc   = AssertionDsc::CreateConstantLoopBound(this, relop);
                     newAssertIdx       = optAddAssertion(dsc);
                 }
             }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -3884,6 +3884,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
         }
     }
 
+    // Check if we have an assertion that exactly matches the relop.
     ValueNum relopVN = optConservativeNormalVN(tree);
     if (!BitVecOps::IsEmpty(apTraits, assertions))
     {

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7677,21 +7677,27 @@ public:
 
     enum optAssertionKind : uint8_t
     {
+        // TODO-Cleanup: Rename these to EQ,NE for consistency.
         OAK_EQUAL,
         OAK_NOT_EQUAL,
+
+        OAK_LT,
+        OAK_LT_UN,
+        OAK_LE,
+        OAK_LE_UN,
+        OAK_GT,
+        OAK_GT_UN,
+        OAK_GE,
+        OAK_GE_UN,
         OAK_SUBRANGE,
-        OAK_NO_THROW,
     };
 
     enum optOp1Kind : uint8_t
     {
         O1K_LCLVAR,
         O1K_VN,
-        O1K_ARR_BND,
         O1K_BOUND_OPER_BND,
         O1K_BOUND_LOOP_BND,
-        O1K_CONSTANT_LOOP_BND,
-        O1K_CONSTANT_LOOP_BND_UN,
         O1K_EXACT_TYPE,
         O1K_SUBTYPE
         // NOTE: as of today, only LCLVAR is used by both Local and Global assertion prop
@@ -7704,8 +7710,9 @@ public:
         O2K_LCLVAR_COPY,
         O2K_CONST_INT,
         O2K_CONST_DOUBLE,
-        O2K_ZEROOBJ,
-        O2K_SUBRANGE
+        O2K_CHECKED_BOUND, // Array/Span length (or similar)
+        O2K_ZEROOBJ,       // zeroed struct
+        O2K_SUBRANGE       // IntegralRange
     };
 
     struct AssertionDsc
@@ -7720,11 +7727,6 @@ public:
             {
                 ValueNum m_vn;
                 unsigned m_lclNum;
-                struct
-                {
-                    ValueNum m_vnIdx;
-                    ValueNum m_vnLen;
-                } m_bnd;
             };
 
         public:
@@ -7742,11 +7744,6 @@ public:
             ValueNum GetVN() const
             {
                 // TODO-Cleanup: O1K_LCLVAR should be Local-AP only.
-                // Today it's used by both Local and Global AP.
-                assert(KindIs(O1K_LCLVAR, O1K_VN, O1K_BOUND_OPER_BND, O1K_BOUND_LOOP_BND, O1K_CONSTANT_LOOP_BND,
-                              O1K_CONSTANT_LOOP_BND_UN, O1K_EXACT_TYPE, O1K_SUBTYPE));
-                // Basically, only O1K_ARR_BND doesn't use this property (it uses m_vnIdx and m_vnLen instead).
-
                 assert(m_vn != ValueNumStore::NoVN);
                 return m_vn;
             }
@@ -7756,20 +7753,6 @@ public:
                 assert(m_lclNum != BAD_VAR_NUM);
                 assert(KindIs(O1K_LCLVAR));
                 return m_lclNum;
-            }
-
-            ValueNum GetArrBndIndex() const
-            {
-                assert(KindIs(O1K_ARR_BND));
-                assert(m_bnd.m_vnIdx != ValueNumStore::NoVN);
-                return m_bnd.m_vnIdx;
-            }
-
-            ValueNum GetArrBndLength() const
-            {
-                assert(KindIs(O1K_ARR_BND));
-                assert(m_bnd.m_vnLen != ValueNumStore::NoVN);
-                return m_bnd.m_vnLen;
             }
 
             optOp1Kind GetKind() const
@@ -7843,7 +7826,7 @@ public:
 
             ValueNum GetVN() const
             {
-                assert(KindIs(O2K_CONST_INT, O2K_CONST_DOUBLE, O2K_ZEROOBJ));
+                assert(KindIs(O2K_CONST_INT, O2K_CONST_DOUBLE, O2K_ZEROOBJ, O2K_CHECKED_BOUND));
                 assert(m_vn != ValueNumStore::NoVN);
                 return m_vn;
             }
@@ -7917,15 +7900,8 @@ public:
             return m_op1;
         }
 
-        bool HasOp2() const
-        {
-            // For OAK_NO_THROW, m_op2 is not used.
-            return !KindIs(OAK_NO_THROW);
-        }
-
         const AssertionDscOp2& GetOp2() const
         {
-            assert(HasOp2());
             return m_op2;
         }
 
@@ -7936,18 +7912,6 @@ public:
         bool IsCheckedBoundBound() const
         {
             return (CanPropEqualOrNotEqual() && GetOp1().KindIs(O1K_BOUND_LOOP_BND));
-        }
-        bool IsConstantBound() const
-        {
-            return (CanPropEqualOrNotEqual() && GetOp1().KindIs(O1K_CONSTANT_LOOP_BND));
-        }
-        bool IsConstantBoundUnsigned() const
-        {
-            return (CanPropEqualOrNotEqual() && GetOp1().KindIs(O1K_CONSTANT_LOOP_BND_UN));
-        }
-        bool IsBoundsCheckNoThrow() const
-        {
-            return (KindIs(OAK_NO_THROW) && GetOp1().KindIs(O1K_ARR_BND));
         }
 
         bool IsCopyAssertion() const
@@ -7977,7 +7941,7 @@ public:
 
         bool CanPropBndsCheck() const
         {
-            return GetOp1().KindIs(O1K_ARR_BND, O1K_VN);
+            return GetOp1().KindIs(O1K_VN);
         }
 
         bool CanPropSubRange() const
@@ -7990,26 +7954,142 @@ public:
             return false;
         }
 
-        AssertionDsc ReverseEquality() const
+        bool IsBoundsCheckNoThrow() const
         {
-            assert(CanPropEqualOrNotEqual());
+            // O1K_VN (idx) u< O2K_VN (len)
+            return GetOp1().KindIs(O1K_VN) && KindIs(OAK_LT_UN) && GetOp2().KindIs(O2K_CHECKED_BOUND);
+        }
 
+        // Convert VNFunc to optAssertionKind
+        static optAssertionKind FromVMFunc(VNFunc func)
+        {
+            switch (func)
+            {
+                case VNF_EQ:
+                    return OAK_EQUAL;
+                case VNF_NE:
+                    return OAK_NOT_EQUAL;
+                case VNF_LT:
+                    return OAK_LT;
+                case VNF_LE:
+                    return OAK_LE;
+                case VNF_GT:
+                    return OAK_GT;
+                case VNF_GE:
+                    return OAK_GE;
+                case VNF_LT_UN:
+                    return OAK_LT_UN;
+                case VNF_LE_UN:
+                    return OAK_LE_UN;
+                case VNF_GT_UN:
+                    return OAK_GT_UN;
+                case VNF_GE_UN:
+                    return OAK_GE_UN;
+                default:
+                    unreached();
+            }
+        }
+
+        // Convert optAssertionKind to genTreeOps
+        static genTreeOps ToCompareOper(optAssertionKind kind, bool* isUnsigned)
+        {
+            *isUnsigned = false;
+            switch (kind)
+            {
+                case OAK_EQUAL:
+                    return GT_EQ;
+                case OAK_NOT_EQUAL:
+                    return GT_NE;
+                case OAK_LT:
+                    return GT_LT;
+                case OAK_LE:
+                    return GT_LE;
+                case OAK_GT:
+                    return GT_GT;
+                case OAK_GE:
+                    return GT_GE;
+                case OAK_LT_UN:
+                    *isUnsigned = true;
+                    return GT_LT;
+                case OAK_LE_UN:
+                    *isUnsigned = true;
+                    return GT_LE;
+                case OAK_GT_UN:
+                    *isUnsigned = true;
+                    return GT_GT;
+                case OAK_GE_UN:
+                    *isUnsigned = true;
+                    return GT_GE;
+                default:
+                    unreached();
+            }
+        }
+
+        // Reverse the kind of the assertion
+        static optAssertionKind ReverseKind(optAssertionKind kind)
+        {
+            switch (kind)
+            {
+                case OAK_EQUAL:
+                    return OAK_NOT_EQUAL;
+                case OAK_NOT_EQUAL:
+                    return OAK_EQUAL;
+                case OAK_LT:
+                    return OAK_GE;
+                case OAK_LT_UN:
+                    return OAK_GE_UN;
+                case OAK_LE:
+                    return OAK_GT;
+                case OAK_LE_UN:
+                    return OAK_GT_UN;
+                case OAK_GT:
+                    return OAK_LE;
+                case OAK_GT_UN:
+                    return OAK_LE_UN;
+                case OAK_GE:
+                    return OAK_LT;
+                case OAK_GE_UN:
+                    return OAK_LT_UN;
+                default:
+                    unreached();
+            }
+        }
+
+        static bool IsReversible(optAssertionKind kind)
+        {
+            // Only OAK_SUBRANGE is not reversible (its reverse is not defined).
+            return kind != OAK_SUBRANGE;
+        }
+
+        AssertionDsc Reverse() const
+        {
+            assert(IsReversible(GetKind()));
             AssertionDsc copy    = *this;
-            copy.m_assertionKind = KindIs(OAK_EQUAL) ? OAK_NOT_EQUAL : OAK_EQUAL;
+            copy.m_assertionKind = ReverseKind(GetKind());
             return copy;
+        }
+
+        bool IsRelop() const
+        {
+            switch (GetKind())
+            {
+                case OAK_LT:
+                case OAK_LT_UN:
+                case OAK_LE:
+                case OAK_LE_UN:
+                case OAK_GT:
+                case OAK_GT_UN:
+                case OAK_GE:
+                case OAK_GE_UN:
+                    return true;
+                default:
+                    return false;
+            }
         }
 
         static bool ComplementaryKind(optAssertionKind kind, optAssertionKind kind2)
         {
-            if (kind == OAK_EQUAL)
-            {
-                return kind2 == OAK_NOT_EQUAL;
-            }
-            else if (kind == OAK_NOT_EQUAL)
-            {
-                return kind2 == OAK_EQUAL;
-            }
-            return false;
+            return IsReversible(kind) && ReverseKind(kind) == kind2;
         }
 
         bool HasSameOp1(const AssertionDsc& that, bool vnBased) const
@@ -8017,12 +8097,6 @@ public:
             if (!GetOp1().KindIs(that.GetOp1().GetKind()))
             {
                 return false;
-            }
-            else if (GetOp1().KindIs(O1K_ARR_BND))
-            {
-                assert(vnBased);
-                return (GetOp1().GetArrBndIndex() == that.GetOp1().GetArrBndIndex()) &&
-                       (GetOp1().GetArrBndLength() == that.GetOp1().GetArrBndLength());
             }
             else if (GetOp1().KindIs(O1K_VN))
             {
@@ -8038,7 +8112,6 @@ public:
 
         bool HasSameOp2(const AssertionDsc& that, bool vnBased) const
         {
-            assert(HasOp2());
             if (!GetOp2().KindIs(that.GetOp2().GetKind()))
             {
                 return false;
@@ -8056,6 +8129,9 @@ public:
 
                 case O2K_ZEROOBJ:
                     return true;
+
+                case O2K_CHECKED_BOUND:
+                    return GetOp2().GetVN() == that.GetOp2().GetVN();
 
                 case O2K_LCLVAR_COPY:
                     return GetOp2().GetLclNum() == that.GetOp2().GetLclNum();
@@ -8080,7 +8156,7 @@ public:
 
         bool Equals(const AssertionDsc& that, bool vnBased) const
         {
-            return KindIs(that.GetKind()) && HasSameOp1(that, vnBased) && (!HasOp2() || HasSameOp2(that, vnBased));
+            return KindIs(that.GetKind()) && HasSameOp1(that, vnBased) && HasSameOp2(that, vnBased);
         }
 
         //
@@ -8247,12 +8323,12 @@ public:
             assert(idxVN != ValueNumStore::NoVN);
             assert(lenVN != ValueNumStore::NoVN);
 
-            AssertionDsc dsc        = {};
-            dsc.m_assertionKind     = OAK_NO_THROW;
-            dsc.m_op1.m_kind        = O1K_ARR_BND;
-            dsc.m_op1.m_bnd.m_vnIdx = idxVN;
-            dsc.m_op1.m_bnd.m_vnLen = lenVN;
-            dsc.m_op2.m_kind        = O2K_INVALID;
+            AssertionDsc dsc    = {};
+            dsc.m_assertionKind = OAK_LT_UN;
+            dsc.m_op1.m_kind    = O1K_VN;
+            dsc.m_op1.m_vn      = idxVN;
+            dsc.m_op2.m_kind    = O2K_CHECKED_BOUND;
+            dsc.m_op2.m_vn      = lenVN;
             return dsc;
         }
 
@@ -8285,29 +8361,36 @@ public:
 
         // Create "i < constant" or "i u< constant" assertion
         // TODO-Cleanup: Rename it as it's not necessarily a loop bound
-        static AssertionDsc CreateConstantLoopBound(const Compiler* comp, ValueNum relopVN, bool isUnsigned)
+        static AssertionDsc CreateConstantLoopBound(const Compiler* comp, ValueNum relopVN)
         {
-            assert(relopVN != ValueNumStore::NoVN);
-            if (isUnsigned)
+            assert(comp->vnStore->IsVNConstantBound(relopVN) || comp->vnStore->IsVNConstantBoundUnsigned(relopVN));
+
+            VNFuncApp funcApp;
+            comp->vnStore->GetVNFunc(relopVN, &funcApp);
+
+            VNFunc   func = funcApp.m_func;
+            ValueNum op1  = funcApp.m_args[0];
+            ValueNum op2  = funcApp.m_args[1];
+
+            // if op1 is a constant, then swap the operands and the operator
+            if (comp->vnStore->IsVNInt32Constant(op1) && !comp->vnStore->IsVNInt32Constant(op2))
             {
-                assert(comp->vnStore->IsVNConstantBoundUnsigned(relopVN));
+                std::swap(op1, op2);
+                func = comp->vnStore->SwapRelop(func);
             }
             else
             {
-                assert(comp->vnStore->IsVNConstantBound(relopVN));
+                bool op2IsCns = comp->vnStore->IsVNInt32Constant(op2);
+                assert(op2IsCns);
             }
 
-            // We can guess the signedness of the loop bound from the VN and remove
-            // O1K_CONSTANT_LOOP_BND_UN entirely. However, it improves the TP a bit since we don't
-            // have to call GetVNFunc for each assertion during assertion matching.
-
             AssertionDsc dsc           = {};
-            dsc.m_assertionKind        = OAK_NOT_EQUAL;
-            dsc.m_op1.m_kind           = isUnsigned ? O1K_CONSTANT_LOOP_BND_UN : O1K_CONSTANT_LOOP_BND;
-            dsc.m_op1.m_vn             = relopVN;
+            dsc.m_assertionKind        = FromVMFunc(func);
+            dsc.m_op1.m_kind           = O1K_VN;
+            dsc.m_op1.m_vn             = op1;
             dsc.m_op2.m_kind           = O2K_CONST_INT;
-            dsc.m_op2.m_vn             = comp->vnStore->VNZeroForType(TYP_INT);
-            dsc.m_op2.m_icon.m_iconVal = 0;
+            dsc.m_op2.m_vn             = op2;
+            dsc.m_op2.m_icon.m_iconVal = comp->vnStore->CoercedConstantValue<ssize_t>(op2);
             return dsc;
         }
     };
@@ -8386,7 +8469,7 @@ public:
 
     bool optTryExtractSubrangeAssertion(GenTree* source, IntegralRange* pRange);
 
-    void optCreateComplementaryAssertion(AssertionIndex assertionIndex, GenTree* op1, GenTree* op2);
+    void optCreateComplementaryAssertion(AssertionIndex assertionIndex);
 
     AssertionIndex optAddAssertion(const AssertionDsc& assertion);
 
@@ -8397,7 +8480,6 @@ public:
     bool           optAssertionIsNonNull(GenTree* op, ASSERT_VALARG_TP assertions);
 
     AssertionIndex optGlobalAssertionIsEqualOrNotEqual(ASSERT_VALARG_TP assertions, GenTree* op1, GenTree* op2);
-    AssertionIndex optGlobalAssertionIsEqualOrNotEqualZero(ASSERT_VALARG_TP assertions, GenTree* op1);
     AssertionIndex optLocalAssertionIsEqualOrNotEqual(
         optOp1Kind op1Kind, unsigned lclNum, optOp2Kind op2Kind, ssize_t cnsVal, ASSERT_VALARG_TP assertions);
 

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -906,9 +906,8 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         const Compiler::AssertionDsc& curAssertion = comp->optGetAssertion(assertionIndex);
 
         Limit      limit(Limit::keUndef);
-        genTreeOps cmpOper             = GT_NONE;
-        bool       isConstantAssertion = false;
-        bool       isUnsigned          = false;
+        genTreeOps cmpOper    = GT_NONE;
+        bool       isUnsigned = false;
 
         // Current assertion is of the form (i < len - cns) != 0
         if (canUseCheckedBounds && curAssertion.IsCheckedBoundArithBound())
@@ -964,22 +963,12 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             }
         }
         // Current assertion is of the form (i < 100) != 0
-        else if (curAssertion.IsConstantBound() || curAssertion.IsConstantBoundUnsigned())
+        else if (curAssertion.IsRelop() && curAssertion.GetOp2().KindIs(Compiler::O2K_CONST_INT) &&
+                 (curAssertion.GetOp1().GetVN() == normalLclVN) && FitsIn<int>(curAssertion.GetOp2().GetIntConstant()))
         {
-            ValueNumStore::ConstantBoundInfo info;
-
-            // Get the info as "i", "<" and "100"
-            comp->vnStore->GetConstantBoundInfo(curAssertion.GetOp1().GetVN(), &info);
-
-            // If we don't have the same variable we are comparing against, bail.
-            if (normalLclVN != info.cmpOpVN)
-            {
-                continue;
-            }
-
-            limit      = Limit(Limit::keConstant, info.constVal);
-            cmpOper    = (genTreeOps)info.cmpOper;
-            isUnsigned = info.isUnsigned;
+            isUnsigned = false;
+            cmpOper    = Compiler::AssertionDsc::ToCompareOper(curAssertion.GetKind(), &isUnsigned);
+            limit      = Limit(Limit::keConstant, static_cast<int>(curAssertion.GetOp2().GetIntConstant()));
         }
         // Current assertion is of the form i == 100
         else if (curAssertion.IsConstantInt32Assertion())
@@ -1035,14 +1024,12 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
                     continue;
                 }
             }
-
-            isConstantAssertion = true;
         }
         // Current assertion asserts a bounds check does not throw
         else if (curAssertion.IsBoundsCheckNoThrow())
         {
-            ValueNum indexVN = curAssertion.GetOp1().GetArrBndIndex();
-            ValueNum lenVN   = curAssertion.GetOp1().GetArrBndLength();
+            ValueNum indexVN = curAssertion.GetOp1().GetVN();
+            ValueNum lenVN   = curAssertion.GetOp2().GetVN();
             if (normalLclVN == indexVN)
             {
                 if (canUseCheckedBounds)
@@ -1098,9 +1085,13 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
 
         assert(limit.IsBinOpArray() || limit.IsConstant());
 
+        // TODO-Cleanup: remove this once these assertions are no longer existed.
+        // All relop-related assertions should be "op1VN relop op2VN" instead of "relopVN ==/!= 0"
+        bool legacyAssertionKind =
+            curAssertion.GetOp1().KindIs(Compiler::O1K_BOUND_LOOP_BND, Compiler::O1K_BOUND_OPER_BND);
+
         // Make sure the assertion is of the form != 0 or == 0 if it isn't a constant assertion.
-        if (!isConstantAssertion && !curAssertion.KindIs(Compiler::OAK_NO_THROW) &&
-            (curAssertion.GetOp2().GetVN() != comp->vnStore->VNZeroForType(TYP_INT)))
+        if (legacyAssertionKind && (curAssertion.GetOp2().GetVN() != comp->vnStore->VNZeroForType(TYP_INT)))
         {
             continue;
         }
@@ -1149,7 +1140,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         // If we have a non-constant assertion of the form == 0 (i.e., equals false), then reverse relop.
         // The relop has to be reversed because we have: (i < length) is false which is the same
         // as (i >= length).
-        if (curAssertion.KindIs(Compiler::OAK_EQUAL) && !isConstantAssertion)
+        if (curAssertion.KindIs(Compiler::OAK_EQUAL) && legacyAssertionKind)
         {
             cmpOper = GenTree::ReverseRelop(cmpOper);
         }

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1028,6 +1028,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         // Current assertion asserts a bounds check does not throw
         else if (curAssertion.IsBoundsCheckNoThrow())
         {
+            // IsBoundsCheckNoThrow is "op1VN (Idx) LT_UN op2VN (Len)"
             ValueNum indexVN = curAssertion.GetOp1().GetVN();
             ValueNum lenVN   = curAssertion.GetOp2().GetVN();
             if (normalLclVN == indexVN)

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7050,51 +7050,6 @@ bool ValueNumStore::IsVNConstantBoundUnsigned(ValueNum vn)
     return false;
 }
 
-void ValueNumStore::GetConstantBoundInfo(ValueNum vn, ConstantBoundInfo* info)
-{
-    assert(IsVNConstantBound(vn) || IsVNConstantBoundUnsigned(vn));
-    assert(info);
-
-    VNFuncApp funcAttr;
-    GetVNFunc(vn, &funcAttr);
-
-    bool       isUnsigned = true;
-    genTreeOps op;
-    switch (funcAttr.m_func)
-    {
-        case VNF_GT_UN:
-            op = GT_GT;
-            break;
-        case VNF_GE_UN:
-            op = GT_GE;
-            break;
-        case VNF_LT_UN:
-            op = GT_LT;
-            break;
-        case VNF_LE_UN:
-            op = GT_LE;
-            break;
-        default:
-            op         = (genTreeOps)funcAttr.m_func;
-            isUnsigned = false;
-            break;
-    }
-
-    if (IsVNInt32Constant(funcAttr.m_args[1]))
-    {
-        info->cmpOper  = op;
-        info->cmpOpVN  = funcAttr.m_args[0];
-        info->constVal = GetConstantInt32(funcAttr.m_args[1]);
-    }
-    else
-    {
-        info->cmpOper  = GenTree::SwapRelop(op);
-        info->cmpOpVN  = funcAttr.m_args[1];
-        info->constVal = GetConstantInt32(funcAttr.m_args[0]);
-    }
-    info->isUnsigned = isUnsigned;
-}
-
 //------------------------------------------------------------------------
 // IsVNPositiveInt32Constant: returns true iff vn is a known Int32 constant that is greater then 0
 //

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -1124,34 +1124,6 @@ public:
 #endif
     };
 
-    struct ConstantBoundInfo
-    {
-        // 100 > vnOp
-        int      constVal;
-        unsigned cmpOper;
-        ValueNum cmpOpVN;
-        bool     isUnsigned;
-
-        ConstantBoundInfo()
-            : constVal(0)
-            , cmpOper(GT_NONE)
-            , cmpOpVN(NoVN)
-            , isUnsigned(false)
-        {
-        }
-
-#ifdef DEBUG
-        void dump(ValueNumStore* vnStore)
-        {
-            vnStore->vnDump(vnStore->m_compiler, cmpOpVN);
-            printf(" ");
-            printf(vnStore->VNFuncName((VNFunc)cmpOper));
-            printf(" ");
-            printf("%d", constVal);
-        }
-#endif
-    };
-
     // Check if "vn" is "new [] (type handle, size)"
     bool IsVNNewArr(ValueNum vn, VNFuncApp* funcApp);
 
@@ -1172,9 +1144,6 @@ public:
 
     // If "vn" is of the form "(uint)var relop cns" for any relop except for == and !=
     bool IsVNConstantBoundUnsigned(ValueNum vn);
-
-    // If "vn" is constant bound, then populate the "info" fields for constVal, cmpOp, cmpOper.
-    void GetConstantBoundInfo(ValueNum vn, ConstantBoundInfo* info);
 
     // If "vn" is of the form "(uint)var < (uint)len" (or equivalent) return true.
     bool IsVNUnsignedCompareCheckedBound(ValueNum vn, UnsignedCompareCheckedBoundInfo* info);


### PR DESCRIPTION
Today, assertions for relops are represented as `relopVN  OAK_[NOT]_EQUAL  0` - this forces most assertion consumers to call GetVNFunc over the relopVN to see if one of the operands matches thiers. This PR attempts to remove them and introduce `OAK_<relop>` so all assertions become just e.g. `op1VN  OAK_LE  op2VN`.

The plan is to remove these:
```
(removed in this PR) O1K_CONSTANT_LOOP_BND
(removed in this PR) O1K_CONSTANT_LOOP_BND_UN
(removed in this PR) O1K_ARR_BND
(will be removed in a follow up) O1K_BOUND_LOOP_BND,    // X < CHECKED_BND
(will be removed in a follow up) O1K_BOUND_OPER_BND,    // X < CHECKED_BND + Y
(removed in this PR) OAK_NO_THROW
```
Also, no longer weird `OAK_NO_THROW` without `op2`. It's now represented as a normal `op1VN (idx)  OAK_LT_UN  op2VN (len)`

I need this simplification for some of the optimizations I have in mind (and enable many existing ops for 64-bit integers and floating points). Also, it makes it easier to implement a VN-mapped hash set to quickly validate that we definitely don't have assertions for the given VN. 

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1281385&view=ms.vss-build-web.run-extensions-tab) - slight improvements in size and TP. I tried to keep the size diffs minimal for the refactoring PR, but it was not possible without ugly hacks to make them exactly zero.