### PR TITLE
Default to ninja for faster builds (mac & linux)

### DIFF
--- a/docs/workflow/requirements/freebsd-requirements.md
+++ b/docs/workflow/requirements/freebsd-requirements.md
@@ -56,7 +56,7 @@ Install the following packages:
 * openssl (optional)
 * python39
 * libinotify
-* ninja (optional, enables building native code with ninja instead of make)
+* ninja
 
 ```sh
 sudo pkg install --yes libunwind icu libinotify lttng-ust krb5 cmake openssl ninja

--- a/docs/workflow/requirements/linux-requirements.md
+++ b/docs/workflow/requirements/linux-requirements.md
@@ -47,7 +47,7 @@ The packages you need to install are shown in the following list:
 - `lld`
 - `lldb`
 - `llvm`
-- `ninja-build` (Optional. Enables building native code using `ninja` instead of `make`)
+- `ninja-build`
 - `pigz` (Optional. Enables parallel gzip compression for tarball creation in `packs` subset)
 - `python-is-python3`
 
@@ -116,7 +116,7 @@ Install the following packages for the toolchain:
 - `lldb`
 - `llvm`
 - `lttng-ust-devel`
-- `ninja-build` (Optional. Enables building native code using `ninja` instead of `make`)
+- `ninja-build`
 - `openssl-devel`
 - `pigz` (Optional. Enables parallel gzip compression for tarball creation in `packs` subset)
 - `python`

--- a/docs/workflow/requirements/macos-requirements.md
+++ b/docs/workflow/requirements/macos-requirements.md
@@ -20,7 +20,7 @@ To build the runtime repo, you will also need to install the following dependenc
 - `icu4c`
 - `pkg-config`
 - `python3`
-- `ninja` (Used by default on macOS for faster builds. Use `--ninja false` to fall back to `make`)
+- `ninja`
 
 You can install them separately, or you can alternatively opt to install *[Homebrew](https://brew.sh/)* and use the `install-dependencies.sh` script provided by the repo, which takes care of everything for you. If you go by this route, once you have *Homebrew* up and running on your machine, run the following command from the root of the repo to download and install all the necessary dependencies at once:
 

--- a/docs/workflow/requirements/macos-requirements.md
+++ b/docs/workflow/requirements/macos-requirements.md
@@ -20,7 +20,7 @@ To build the runtime repo, you will also need to install the following dependenc
 - `icu4c`
 - `pkg-config`
 - `python3`
-- `ninja` (This one is optional. It is an alternative tool to `make` for building native code)
+- `ninja` (Used by default on macOS for faster builds. Use `--ninja false` to fall back to `make`)
 
 You can install them separately, or you can alternatively opt to install *[Homebrew](https://brew.sh/)* and use the `install-dependencies.sh` script provided by the repo, which takes care of everything for you. If you go by this route, once you have *Homebrew* up and running on your machine, run the following command from the root of the repo to download and install all the necessary dependencies at once:
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -84,7 +84,7 @@ usage()
   echo "  --gccx.y                   Optional argument to build using gcc version x.y."
   echo "  --portablebuild            Optional argument: set to false to force a non-portable build."
   echo "  --keepnativesymbols        Optional argument: set to true to keep native symbols/debuginfo in generated binaries."
-  echo "  --ninja                    Optional argument: use Ninja instead of Make (default: true if ninja is installed, use --ninja false to disable)."
+  echo "  --ninja                    Optional argument: use Ninja instead of Make (default: true, use --ninja false to disable)."
   echo "  --pgoinstrument            Optional argument: build PGO-instrumented runtime"
   echo "  --fsanitize                Optional argument: Specify native sanitizers to instrument the native build with. Supported values are: 'address'."
   echo ""
@@ -166,12 +166,8 @@ source $scriptroot/common/native/init-os-and-arch.sh
 
 hostArch=$arch
 
-# Default to using Ninja if installed for faster builds (can be overridden with --ninja false)
-if command -v ninja &> /dev/null; then
-  useNinja=true
-else
-  useNinja=false
-fi
+# Default to using Ninja for faster builds (can be overridden with --ninja false)
+useNinja=true
 
 # Check if an action is passed in
 declare -a actions=("b" "build" "r" "restore" "rebuild" "testnobuild" "sign" "publish" "clean")

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -499,20 +499,16 @@ while [[ $# -gt 0 ]]; do
 
 
       -ninja)
-      if [ -z ${2+x} ]; then
+      if [ -z ${2+x} ] || [[ "$2" == -* ]]; then
         useNinja=true
         shift 1
       else
         ninja="$(echo "$2" | tr "[:upper:]" "[:lower:]")"
         shift 2
-        if [ "$ninja" = true ]; then
-          arguments+=("/p:Ninja=true")
-          useNinja=true
-        elif [ "$ninja" = false ]; then
+        if [ "$ninja" = false ]; then
           arguments+=("/p:Ninja=false")
           useNinja=false
         else
-          arguments+=("/p:Ninja=true")
           useNinja=true
         fi
       fi

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -504,15 +504,16 @@ while [[ $# -gt 0 ]]; do
         shift 1
       else
         ninja="$(echo "$2" | tr "[:upper:]" "[:lower:]")"
+        shift 2
         if [ "$ninja" = true ]; then
+          arguments+=("/p:Ninja=true")
           useNinja=true
-          shift 2
         elif [ "$ninja" = false ]; then
+          arguments+=("/p:Ninja=false")
           useNinja=false
-          shift 2
         else
+          arguments+=("/p:Ninja=true")
           useNinja=true
-          shift 1
         fi
       fi
       ;;

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -168,11 +168,10 @@ hostArch=$arch
 
 # Default to using Ninja on macOS for faster builds (can be overridden with --ninja false)
 if [[ "$os" == "osx" ]]; then
-  useNinjaDefault=true
+  useNinja=true
 else
-  useNinjaDefault=false
+  useNinja=false
 fi
-ninjaExplicitlySet=false
 
 # Check if an action is passed in
 declare -a actions=("b" "build" "r" "restore" "rebuild" "testnobuild" "sign" "publish" "clean")
@@ -504,20 +503,19 @@ while [[ $# -gt 0 ]]; do
 
 
       -ninja)
-      ninjaExplicitlySet=true
       if [ -z ${2+x} ]; then
-        arguments+=("/p:Ninja=true")
+        useNinja=true
         shift 1
       else
         ninja="$(echo "$2" | tr "[:upper:]" "[:lower:]")"
         if [ "$ninja" = true ]; then
-          arguments+=("/p:Ninja=true")
+          useNinja=true
           shift 2
         elif [ "$ninja" = false ]; then
-          arguments+=("/p:Ninja=false")
+          useNinja=false
           shift 2
         else
-          arguments+=("/p:Ninja=true")
+          useNinja=true
           shift 1
         fi
       fi
@@ -591,8 +589,8 @@ arguments+=("-tl:false")
 # disable line wrapping so that C&P from the console works well
 arguments+=("-clp:ForceNoAlign")
 
-# Apply default ninja setting on macOS if not explicitly set by user
-if [[ "$useNinjaDefault" == true && "$ninjaExplicitlySet" != true ]]; then
+# Apply ninja setting
+if [[ "$useNinja" == true ]]; then
   arguments+=("/p:Ninja=true")
 fi
 

--- a/eng/build.sh
+++ b/eng/build.sh
@@ -84,7 +84,7 @@ usage()
   echo "  --gccx.y                   Optional argument to build using gcc version x.y."
   echo "  --portablebuild            Optional argument: set to false to force a non-portable build."
   echo "  --keepnativesymbols        Optional argument: set to true to keep native symbols/debuginfo in generated binaries."
-  echo "  --ninja                    Optional argument: use Ninja instead of Make (default: true on macOS, use --ninja false to disable)."
+  echo "  --ninja                    Optional argument: use Ninja instead of Make (default: true if ninja is installed, use --ninja false to disable)."
   echo "  --pgoinstrument            Optional argument: build PGO-instrumented runtime"
   echo "  --fsanitize                Optional argument: Specify native sanitizers to instrument the native build with. Supported values are: 'address'."
   echo ""
@@ -166,8 +166,8 @@ source $scriptroot/common/native/init-os-and-arch.sh
 
 hostArch=$arch
 
-# Default to using Ninja on macOS for faster builds (can be overridden with --ninja false)
-if [[ "$os" == "osx" ]]; then
+# Default to using Ninja if installed for faster builds (can be overridden with --ninja false)
+if command -v ninja &> /dev/null; then
   useNinja=true
 else
   useNinja=false

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -312,6 +312,7 @@ else
 fi
 
 # Default to using Ninja on macOS for faster builds
+__UseNinja=0
 if [[ "$os" == "osx" ]]; then
   __UseNinja=1
 fi

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -415,19 +415,16 @@ while :; do
             ;;
 
         ninja|-ninja)
-            if [[ -n "$2" ]]; then
+            if [[ -z "${2+x}" ]] || [[ "$2" == -* ]]; then
+              __UseNinja=1
+            else
               ninja_arg="$(echo "$2" | tr "[:upper:]" "[:lower:]")"
               if [[ "$ninja_arg" == "false" ]]; then
                 __UseNinja=0
-                shift
-              elif [[ "$ninja_arg" == "true" ]]; then
-                __UseNinja=1
-                shift
               else
                 __UseNinja=1
               fi
-            else
-              __UseNinja=1
+              shift
             fi
             ;;
 

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -271,7 +271,7 @@ usage()
     echo "        will use ROOTFS_DIR environment variable if set."
     echo "-gcc: optional argument to build using gcc in PATH."
     echo "-gccx.y: optional argument to build using gcc version x.y."
-    echo "-ninja: target ninja instead of GNU make"
+    echo "-ninja: target ninja instead of GNU make (default on macOS, use -ninja false to disable)"
     echo "-numproc: set the number of build processes."
     echo "-targetrid: optional argument that overrides the target rid name."
     echo "-portablebuild: pass -portablebuild=false to force a non-portable build."
@@ -309,6 +309,11 @@ elif (NAME=""; . /etc/os-release; test "$NAME" = "Tizen"); then
   __NumProc="$(getconf _NPROCESSORS_ONLN)"
 else
   __NumProc=1
+fi
+
+# Default to using Ninja on macOS for faster builds
+if [[ "$os" == "osx" ]]; then
+  __UseNinja=1
 fi
 
 while :; do
@@ -412,7 +417,20 @@ while :; do
             ;;
 
         ninja|-ninja)
-            __UseNinja=1
+            if [[ -n "$2" ]]; then
+              ninja_arg="$(echo "$2" | tr "[:upper:]" "[:lower:]")"
+              if [[ "$ninja_arg" == "false" ]]; then
+                __UseNinja=0
+                shift
+              elif [[ "$ninja_arg" == "true" ]]; then
+                __UseNinja=1
+                shift
+              else
+                __UseNinja=1
+              fi
+            else
+              __UseNinja=1
+            fi
             ;;
 
         numproc|-numproc)

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -271,7 +271,7 @@ usage()
     echo "        will use ROOTFS_DIR environment variable if set."
     echo "-gcc: optional argument to build using gcc in PATH."
     echo "-gccx.y: optional argument to build using gcc version x.y."
-    echo "-ninja: target ninja instead of GNU make (default on macOS, use -ninja false to disable)"
+    echo "-ninja: target ninja instead of GNU make (default: true, use -ninja false to disable)"
     echo "-numproc: set the number of build processes."
     echo "-targetrid: optional argument that overrides the target rid name."
     echo "-portablebuild: pass -portablebuild=false to force a non-portable build."
@@ -311,11 +311,8 @@ else
   __NumProc=1
 fi
 
-# Default to using Ninja on macOS for faster builds
-__UseNinja=0
-if [[ "$os" == "osx" ]]; then
-  __UseNinja=1
-fi
+# Default to using Ninja for faster builds
+__UseNinja=1
 
 while :; do
     if [[ "$#" -le 0 ]]; then

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -217,8 +217,8 @@ build_native()
         pushd "$intermediatesDir"
 
         buildTool="$SCAN_BUILD_COMMAND -o $__BinDir/scan-build-log $buildTool"
-        echo "Executing $buildTool $target -j $__NumProc"
-        "$buildTool" $target -j "$__NumProc"
+        echo "Executing $buildTool -j $__NumProc $target"
+        "$buildTool" -j "$__NumProc" $target
         exit_code="$?"
 
         popd
@@ -234,8 +234,8 @@ build_native()
             # multiple targets. Instead, directly invoke the build tool to build multiple targets in one invocation.
             pushd "$intermediatesDir"
 
-            echo "Executing $buildTool $target -j $__NumProc"
-            "$buildTool" $target -j "$__NumProc"
+            echo "Executing $buildTool -j $__NumProc $target"
+            "$buildTool" -j "$__NumProc" $target
             exit_code="$?"
 
             popd

--- a/src/coreclr/build-runtime.sh
+++ b/src/coreclr/build-runtime.sh
@@ -99,7 +99,6 @@ __SkipRestore=""
 __SourceDir="$__ProjectDir/src"
 __StaticAnalyzer=0
 __UnprocessedBuildArgs=
-__UseNinja=0
 __VerboseBuild=0
 __CMakeArgs=""
 __RequestedBuildComponents=""

--- a/src/tests/build.sh
+++ b/src/tests/build.sh
@@ -347,7 +347,6 @@ __SkipRestore=""
 __SkipRestorePackages=0
 __SourceDir="$__ProjectDir/src"
 __UnprocessedBuildArgs=()
-__UseNinja=0
 __VerboseBuild=0
 __CMakeArgs=""
 __Priority=0


### PR DESCRIPTION
Benchmarking showed ninja provides ~8.8% faster builds on macOS (avg 654s vs 718s per build). This change defaults to using ninja for both MacOS and Linux.

Changes:

- eng/build.sh: default to using ninja
- eng/native/build-commons.sh: Default -ninja on macOS, add -ninja false opt-out

Users can opt out with --ninja false (or -ninja false for native builds).

Contributes to https://github.com/dotnet/runtime/issues/54022 (https://github.com/dotnet/runtime/issues/54022)