### PR TITLE
Remove O1K_BOUND_OPER_BND and O1K_BOUND_LOOP_BND

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1614,28 +1614,27 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     ValueNum op1VN     = relopFuncApp.m_args[0];
     ValueNum op2VN     = relopFuncApp.m_args[1];
 
-    // Comparisons involving checked bounds
-    if ((relopFunc == VNF_LE) || (relopFunc == VNF_LT) || (relopFunc == VNF_GE) || (relopFunc == VNF_GT) ||
-        (relopFunc == VNF_GT))
+    // Signed comparisons involving checked bounds
+    if ((relopFunc == VNF_LE) || (relopFunc == VNF_LT) || (relopFunc == VNF_GE) || (relopFunc == VNF_GT))
     {
         // "CheckedBnd <relop> X"
         if (vnStore->IsVNCheckedBound(op1VN))
         {
             // Move the checked bound to the right side for simplicity
-            relopFunc            = ValueNumStore::SwapRelop(relopFunc);
-            AssertionDsc   dsc   = AssertionDsc::CreateCompareCheckedBound(relopFunc, op2VN, op1VN, 0);
-            AssertionIndex index = optAddAssertion(dsc);
-            optCreateComplementaryAssertion(index);
-            return index;
+            relopFunc          = ValueNumStore::SwapRelop(relopFunc);
+            AssertionDsc   dsc = AssertionDsc::CreateCompareCheckedBound(relopFunc, op2VN, op1VN, 0);
+            AssertionIndex idx = optAddAssertion(dsc);
+            optCreateComplementaryAssertion(idx);
+            return idx;
         }
 
         // "X <relop> CheckedBnd"
         if (vnStore->IsVNCheckedBound(op2VN))
         {
-            AssertionDsc   dsc   = AssertionDsc::CreateCompareCheckedBound(relopFunc, op1VN, op2VN, 0);
-            AssertionIndex index = optAddAssertion(dsc);
-            optCreateComplementaryAssertion(index);
-            return index;
+            AssertionDsc   dsc = AssertionDsc::CreateCompareCheckedBound(relopFunc, op1VN, op2VN, 0);
+            AssertionIndex idx = optAddAssertion(dsc);
+            optCreateComplementaryAssertion(idx);
+            return idx;
         }
 
         ValueNum checkedBnd;
@@ -1645,20 +1644,20 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
         if (vnStore->IsVNCheckedBoundAddConst(op1VN, &checkedBnd, &cns))
         {
             // Move the (CheckedBnd + CNS) part to the right side for simplicity
-            relopFunc            = ValueNumStore::SwapRelop(relopFunc);
-            AssertionDsc   dsc   = AssertionDsc::CreateCompareCheckedBound(relopFunc, op2VN, checkedBnd, cns);
-            AssertionIndex index = optAddAssertion(dsc);
-            optCreateComplementaryAssertion(index);
-            return index;
+            relopFunc          = ValueNumStore::SwapRelop(relopFunc);
+            AssertionDsc   dsc = AssertionDsc::CreateCompareCheckedBound(relopFunc, op2VN, checkedBnd, cns);
+            AssertionIndex idx = optAddAssertion(dsc);
+            optCreateComplementaryAssertion(idx);
+            return idx;
         }
 
         // "X <relop> (CheckedBnd + CNS)"
         if (vnStore->IsVNCheckedBoundAddConst(op2VN, &checkedBnd, &cns))
         {
             AssertionDsc   dsc   = AssertionDsc::CreateCompareCheckedBound(relopFunc, op1VN, checkedBnd, cns);
-            AssertionIndex index = optAddAssertion(dsc);
-            optCreateComplementaryAssertion(index);
-            return index;
+            AssertionIndex idx = optAddAssertion(dsc);
+            optCreateComplementaryAssertion(idx);
+            return idx;
         }
     }
 
@@ -3932,7 +3931,7 @@ GenTree* Compiler::optAssertionPropGlobal_RelOp(ASSERT_VALARG_TP assertions,
             //
             if (curAssertion.IsRelop() && (curAssertion.GetOp1().GetVN() == op1VN) &&
                 (curAssertion.GetOp2().GetVN() == op2VN) &&
-                // O2K_CHECKED_BOUND_ADD_CNS means op2 is decomposed into op2.vn being checked bound
+                // O2K_CHECKED_BOUND_ADD_CNS means op2 is decomposed into op2.vn being checked bound 
                 // and op2.cns being the constant offset. We assemble the original relop VN if we want.
                 // For now, just skip such assertions here.
                 !curAssertion.GetOp2().KindIs(O2K_CHECKED_BOUND_ADD_CNS))

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -781,14 +781,6 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
             printf("VN " FMT_VN "", curAssertion.GetOp1().GetVN());
             break;
 
-        case O1K_BOUND_OPER_BND:
-            printf("Oper_Bnd " FMT_VN "", curAssertion.GetOp1().GetVN());
-            break;
-
-        case O1K_BOUND_LOOP_BND:
-            printf("Loop_Bnd " FMT_VN "", curAssertion.GetOp1().GetVN());
-            break;
-
         case O1K_EXACT_TYPE:
             printf("ExactType " FMT_VN "", curAssertion.GetOp1().GetVN());
             break;
@@ -872,10 +864,6 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
                     printf("MT(%s)", eeGetClassName(reinterpret_cast<CORINFO_CLASS_HANDLE>(iconVal)));
                 }
             }
-            else if (curAssertion.GetOp1().KindIs(O1K_BOUND_OPER_BND, O1K_BOUND_LOOP_BND))
-            {
-                vnStore->vnDump(this, curAssertion.GetOp2().GetVN());
-            }
             else if (curAssertion.GetOp2().IsNullConstant())
             {
                 printf("null");
@@ -910,7 +898,11 @@ void Compiler::optPrintAssertion(const AssertionDsc& curAssertion, AssertionInde
             break;
 
         case O2K_CHECKED_BOUND:
-            printf("VN " FMT_VN "", curAssertion.GetOp2().GetVN());
+            printf("Checked_Bnd " FMT_VN "", curAssertion.GetOp2().GetVN());
+            break;
+
+        case O2K_CHECKED_BOUND_BINOP:
+            printf("Checked_Bnd_BinOp " FMT_VN "", curAssertion.GetOp2().GetVN());
             break;
 
         default:
@@ -1458,8 +1450,6 @@ void Compiler::optDebugCheckAssertion(const AssertionDsc& assertion) const
         case O1K_EXACT_TYPE:
         case O1K_SUBTYPE:
         case O1K_VN:
-        case O1K_BOUND_OPER_BND:
-        case O1K_BOUND_LOOP_BND:
             assert(!optLocalAssertionProp);
             break;
         default:

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1543,7 +1543,7 @@ void Compiler::optCreateComplementaryAssertion(AssertionIndex assertionIndex)
         AssertionDsc reversed = candidateAssertion.Reverse();
         optMapComplementary(optAddAssertion(reversed), assertionIndex);
     }
-    else if (candidateAssertion.KindIs(OAK_LT, OAK_LT_UN, OAK_LE, OAK_LE_UN) &&
+    else if (candidateAssertion.KindIs(OAK_LT_UN, OAK_LE_UN) &&
              candidateAssertion.GetOp2().KindIs(O2K_CHECKED_BOUND_ADD_CNS))
     {
         // Assertions such as "X > checkedBndVN" aren't very useful.

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1645,7 +1645,7 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     {
         // Move the checked bound to the right side for simplicity
         relopFunc          = ValueNumStore::SwapRelop(relopFunc);
-        AssertionDsc   dsc = AssertionDsc::CreateCompareCheckedBound(this, relopFunc, op2VN, op1VN, 0);
+        AssertionDsc   dsc = AssertionDsc::CreateCompareCheckedBound(relopFunc, op2VN, op1VN, 0);
         AssertionIndex idx = optAddAssertion(dsc);
         optCreateComplementaryAssertion(idx);
         return idx;
@@ -1654,7 +1654,7 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     // "X <relop> CheckedBnd"
     if (!isUnsignedRelop && vnStore->IsVNCheckedBound(op2VN))
     {
-        AssertionDsc   dsc = AssertionDsc::CreateCompareCheckedBound(this, relopFunc, op1VN, op2VN, 0);
+        AssertionDsc   dsc = AssertionDsc::CreateCompareCheckedBound(relopFunc, op1VN, op2VN, 0);
         AssertionIndex idx = optAddAssertion(dsc);
         optCreateComplementaryAssertion(idx);
         return idx;
@@ -1667,7 +1667,7 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     {
         // Move the (CheckedBnd + CNS) part to the right side for simplicity
         relopFunc          = ValueNumStore::SwapRelop(relopFunc);
-        AssertionDsc   dsc = AssertionDsc::CreateCompareCheckedBound(this, relopFunc, op2VN, checkedBnd, checkedBndCns);
+        AssertionDsc   dsc = AssertionDsc::CreateCompareCheckedBound(relopFunc, op2VN, checkedBnd, checkedBndCns);
         AssertionIndex idx = optAddAssertion(dsc);
         optCreateComplementaryAssertion(idx);
         return idx;
@@ -1676,7 +1676,7 @@ AssertionInfo Compiler::optCreateJTrueBoundsAssertion(GenTree* tree)
     // "X <relop> (CheckedBnd + CNS)"
     if (!isUnsignedRelop && vnStore->IsVNCheckedBoundAddConst(op2VN, &checkedBnd, &checkedBndCns))
     {
-        AssertionDsc   dsc = AssertionDsc::CreateCompareCheckedBound(this, relopFunc, op1VN, checkedBnd, checkedBndCns);
+        AssertionDsc   dsc = AssertionDsc::CreateCompareCheckedBound(relopFunc, op1VN, checkedBnd, checkedBndCns);
         AssertionIndex idx = optAddAssertion(dsc);
         optCreateComplementaryAssertion(idx);
         return idx;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7713,8 +7713,8 @@ public:
         O2K_NEVER_NEGATIVE,        // Something that is known to be never negative, e.g., array or span length
         O2K_CHECKED_BOUND_ADD_CNS, // "checkedBndVN + cns" where op2.vn holds the "checkedBndVN"
                                    // and op2.iconVal holds the "cns".
-                                   // "Checked bound" alone doesn't mean anything (nor it implies that it's never
-                                   // negative)
+                                   // "Checked bound" alone doesn't mean anything,
+                                   // nor it implies that it's never negative.
         O2K_ZEROOBJ,
         O2K_SUBRANGE
     };
@@ -7926,13 +7926,6 @@ public:
             return m_op2;
         }
 
-        // Is it "X relop (len + cns)" form?
-        // NOTE: the cns can be zero, so this implies "X relop len" form.
-        bool IsCheckedBoundWithConst() const
-        {
-            return KindIs(OAK_GE, OAK_GT, OAK_LE, OAK_LT) && GetOp2().KindIs(O2K_CHECKED_BOUND_ADD_CNS);
-        }
-
         bool IsCopyAssertion() const
         {
             return (KindIs(OAK_EQUAL) && GetOp1().KindIs(O1K_LCLVAR) && GetOp2().KindIs(O2K_LCLVAR_COPY));
@@ -7975,7 +7968,8 @@ public:
 
         bool IsBoundsCheckNoThrow() const
         {
-            // O1K_VN (idx) u< O2K_VN (len)
+            // O1K_VN (idx) u< O2K_VN (len) where len is never negative.
+            // Effectively, it's "idx >= 0 && idx < len"
             return GetOp1().KindIs(O1K_VN) && KindIs(OAK_LT_UN) && (GetOp2().KindIs(O2K_NEVER_NEGATIVE));
         }
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8152,7 +8152,8 @@ public:
 
                 case O2K_CHECKED_BOUND_ADD_CNS:
                     return GetOp2().GetCheckedBound() == that.GetOp2().GetCheckedBound() &&
-                           GetOp2().GetCheckedBoundConstant() == that.GetOp2().GetCheckedBoundConstant();
+                           GetOp2().GetCheckedBoundConstant() == that.GetOp2().GetCheckedBoundConstant() &&
+                           GetOp2().IsCheckedBoundNeverNegative() == that.GetOp2().IsCheckedBoundNeverNegative();
 
                 case O2K_LCLVAR_COPY:
                     return GetOp2().GetLclNum() == that.GetOp2().GetLclNum();

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8354,12 +8354,10 @@ public:
 
         // Create "i <relop> (bnd + cns)" assertion
         static AssertionDsc CreateCompareCheckedBound(
-            const Compiler* comp, VNFunc relop, ValueNum op1VN, ValueNum checkedBndVN, int cns)
+            VNFunc relop, ValueNum op1VN, ValueNum checkedBndVN, int cns)
         {
             assert(op1VN != ValueNumStore::NoVN);
             assert(checkedBndVN != ValueNumStore::NoVN);
-
-            // if cns is 0 and checkedBndVN is never negative, we can convert this into CreateNoThrowArrBnd
 
             AssertionDsc dsc           = {};
             dsc.m_assertionKind        = FromVNFunc(relop);

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8360,36 +8360,21 @@ public:
 
         // Create "i < constant" or "i u< constant" assertion
         // TODO-Cleanup: Rename it as it's not necessarily a loop bound
-        static AssertionDsc CreateConstantLoopBound(const Compiler* comp, ValueNum relopVN)
+        static AssertionDsc CreateConstantBound(const Compiler* comp, VNFunc relop, ValueNum op1VN, ValueNum cnsVN)
         {
-            assert(comp->vnStore->IsVNConstantBound(relopVN) || comp->vnStore->IsVNConstantBoundUnsigned(relopVN));
+            assert(op1VN != ValueNumStore::NoVN);
 
-            VNFuncApp funcApp;
-            comp->vnStore->GetVNFunc(relopVN, &funcApp);
-
-            VNFunc   func = funcApp.m_func;
-            ValueNum op1  = funcApp.m_args[0];
-            ValueNum op2  = funcApp.m_args[1];
-
-            // if op1 is a constant, then swap the operands and the operator
-            if (comp->vnStore->IsVNInt32Constant(op1) && !comp->vnStore->IsVNInt32Constant(op2))
-            {
-                std::swap(op1, op2);
-                func = comp->vnStore->SwapRelop(func);
-            }
-            else
-            {
-                bool op2IsCns = comp->vnStore->IsVNInt32Constant(op2);
-                assert(op2IsCns);
-            }
+            ssize_t cns;
+            bool    op2IsCns = comp->vnStore->IsVNIntegralConstant(cnsVN, &cns);
+            assert(op2IsCns);
 
             AssertionDsc dsc           = {};
-            dsc.m_assertionKind        = FromVNFunc(func);
+            dsc.m_assertionKind        = FromVNFunc(relop);
             dsc.m_op1.m_kind           = O1K_VN;
-            dsc.m_op1.m_vn             = op1;
+            dsc.m_op1.m_vn             = op1VN;
             dsc.m_op2.m_kind           = O2K_CONST_INT;
-            dsc.m_op2.m_vn             = op2;
-            dsc.m_op2.m_icon.m_iconVal = comp->vnStore->CoercedConstantValue<ssize_t>(op2);
+            dsc.m_op2.m_vn             = cnsVN;
+            dsc.m_op2.m_icon.m_iconVal = cns;
             return dsc;
         }
     };

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7811,14 +7811,6 @@ public:
                 return m_icon.m_iconVal;
             }
 
-            // For "checkedBndVN + cns" form, return the "cns" part.
-            int GetCheckedBoundConstant() const
-            {
-                assert(KindIs(O2K_CHECKED_BOUND_ADD_CNS));
-                assert(FitsIn<int>(m_icon.m_iconVal));
-                return (int)m_icon.m_iconVal;
-            }
-
             IntegralRange GetIntegralRange() const
             {
                 assert(KindIs(O2K_SUBRANGE));
@@ -7834,7 +7826,24 @@ public:
 
             ValueNum GetVN() const
             {
-                assert(KindIs(O2K_CONST_INT, O2K_CONST_DOUBLE, O2K_ZEROOBJ, O2K_CHECKED_BOUND_ADD_CNS));
+                assert(KindIs(O2K_CONST_INT, O2K_CONST_DOUBLE, O2K_ZEROOBJ));
+                assert(m_vn != ValueNumStore::NoVN);
+                return m_vn;
+            }
+
+            // For "checkedBndVN + cns" form, return the "cns" part.
+            int GetCheckedBoundConstant() const
+            {
+                assert(KindIs(O2K_CHECKED_BOUND_ADD_CNS));
+                assert(FitsIn<int>(m_icon.m_iconVal));
+                return (int)m_icon.m_iconVal;
+            }
+
+            // For "checkedBndVN + cns" form, return the "checkedBndVN" part.
+            // We intentionally don't allow to use it via GetVN() to avoid confusion.
+            ValueNum GetCheckedBound() const
+            {
+                assert(KindIs(O2K_CHECKED_BOUND_ADD_CNS));
                 assert(m_vn != ValueNumStore::NoVN);
                 return m_vn;
             }
@@ -8140,7 +8149,7 @@ public:
                     return true;
 
                 case O2K_CHECKED_BOUND_ADD_CNS:
-                    return GetOp2().GetVN() == that.GetOp2().GetVN() &&
+                    return GetOp2().GetCheckedBound() == that.GetOp2().GetCheckedBound() &&
                            GetOp2().GetCheckedBoundConstant() == that.GetOp2().GetCheckedBoundConstant();
 
                 case O2K_LCLVAR_COPY:

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -939,7 +939,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             cmpOper = Compiler::AssertionDsc::ToCompareOper(curAssertion.GetKind(), &isUnsigned);
             limit   = Limit(Limit::keConstant, static_cast<int>(curAssertion.GetOp2().GetIntConstant()));
 
-            // Make sure we don't deal with negative constants for unsigned comparisons
+            // Make sure we don't deal with non-positive constants for unsigned comparisons
             assert((curAssertion.GetOp2().GetIntConstant() > 0) || !isUnsigned);
         }
         // Current assertion is of the form "i == cns" or "i != cns"
@@ -997,7 +997,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         {
             // IsBoundsCheckNoThrow is "op1VN (Idx) LT_UN op2VN (Len)"
             ValueNum indexVN = curAssertion.GetOp1().GetVN();
-            ValueNum lenVN   = curAssertion.GetOp2().GetCheckedBound();
+            ValueNum lenVN   = curAssertion.GetOp2().GetVN();
             if (normalLclVN == indexVN)
             {
                 if (canUseCheckedBounds)

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -999,7 +999,11 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         {
             // IsBoundsCheckNoThrow is "op1VN (Idx) LT_UN op2VN (Len)"
             ValueNum indexVN = curAssertion.GetOp1().GetVN();
-            ValueNum lenVN   = curAssertion.GetOp2().GetVN();
+            ValueNum lenVN   = curAssertion.GetOp2().GetCheckedBound();
+
+            assert(curAssertion.GetOp2().GetCheckedBoundConstant() == 0);
+            assert(curAssertion.GetOp2().IsCheckedBoundNeverNegative());
+
             if (normalLclVN == indexVN)
             {
                 if (canUseCheckedBounds)

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -915,11 +915,11 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             if (normalLclVN == curAssertion.GetOp1().GetVN())
             {
                 cmpOper = Compiler::AssertionDsc::ToCompareOper(curAssertion.GetKind(), &isUnsigned);
-                limit   = Limit(Limit::keBinOpArray, curAssertion.GetOp2().GetVN(),
+                limit   = Limit(Limit::keBinOpArray, curAssertion.GetOp2().GetCheckedBound(),
                                 curAssertion.GetOp2().GetCheckedBoundConstant());
             }
             // Check if it's "checkedBndVN1 <relop> (checkedBndVN2 + 0)" and normalLclVN is checkedBndVN2
-            else if ((normalLclVN == curAssertion.GetOp2().GetVN()) &&
+            else if ((normalLclVN == curAssertion.GetOp2().GetCheckedBound()) &&
                      (curAssertion.GetOp2().GetCheckedBoundConstant() == 0))
             {
                 cmpOper =
@@ -997,7 +997,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         {
             // IsBoundsCheckNoThrow is "op1VN (Idx) LT_UN op2VN (Len)"
             ValueNum indexVN = curAssertion.GetOp1().GetVN();
-            ValueNum lenVN   = curAssertion.GetOp2().GetVN();
+            ValueNum lenVN   = curAssertion.GetOp2().GetCheckedBound();
             if (normalLclVN == indexVN)
             {
                 if (canUseCheckedBounds)

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -909,14 +909,11 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         genTreeOps cmpOper    = GT_NONE;
         bool       isUnsigned = false;
 
-        ValueNum checkedBndVN;
-        int      checkedBndCns;
         // Current assertion is of the form (i < len - cns) != 0
         if (canUseCheckedBounds && curAssertion.IsCheckedBoundArithBound() &&
-            (normalLclVN == curAssertion.GetOp1().GetVN() &&
-             comp->vnStore->IsVNCheckedBoundArith(curAssertion.GetOp2().GetVN(), &checkedBndVN, &checkedBndCns)))
+            (normalLclVN == curAssertion.GetOp1().GetVN()))
         {
-            limit   = Limit(Limit::keBinOpArray, checkedBndVN, checkedBndCns);
+            limit   = Limit(Limit::keBinOpArray, curAssertion.GetOp2().GetVN(), curAssertion.GetOp2().GetCheckedBoundConstant());
             cmpOper = Compiler::AssertionDsc::ToCompareOper(curAssertion.GetKind(), &isUnsigned);
         }
         // Current assertion is of the form (i < len) != 0

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -910,7 +910,9 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         bool       isUnsigned = false;
 
         // Current assertion is of the form "i <relop> (checkedBndVN + cns)"
-        if (canUseCheckedBounds && curAssertion.IsCheckedBoundWithConst())
+        if (canUseCheckedBounds &&
+            curAssertion.KindIs(Compiler::OAK_GE, Compiler::OAK_GT, Compiler::OAK_LE, Compiler::OAK_LT) &&
+            curAssertion.GetOp2().KindIs(Compiler::O2K_CHECKED_BOUND_ADD_CNS))
         {
             if (normalLclVN == curAssertion.GetOp1().GetVN())
             {

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -936,9 +936,11 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         else if (curAssertion.IsRelop() && curAssertion.GetOp2().KindIs(Compiler::O2K_CONST_INT) &&
                  (curAssertion.GetOp1().GetVN() == normalLclVN) && FitsIn<int>(curAssertion.GetOp2().GetIntConstant()))
         {
-            isUnsigned = false;
-            cmpOper    = Compiler::AssertionDsc::ToCompareOper(curAssertion.GetKind(), &isUnsigned);
-            limit      = Limit(Limit::keConstant, static_cast<int>(curAssertion.GetOp2().GetIntConstant()));
+            cmpOper = Compiler::AssertionDsc::ToCompareOper(curAssertion.GetKind(), &isUnsigned);
+            limit   = Limit(Limit::keConstant, static_cast<int>(curAssertion.GetOp2().GetIntConstant()));
+
+            // Make sure we don't deal with negative constants for unsigned comparisons
+            assert((curAssertion.GetOp2().GetIntConstant() > 0) || !isUnsigned);
         }
         // Current assertion is of the form "i == cns" or "i != cns"
         else if (curAssertion.IsConstantInt32Assertion() && (curAssertion.GetOp1().GetVN() == normalLclVN))

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -7010,46 +7010,6 @@ bool ValueNumStore::IsVNRelop(ValueNum vn)
     }
 }
 
-bool ValueNumStore::IsVNConstantBound(ValueNum vn)
-{
-    VNFuncApp funcApp;
-    if ((vn != NoVN) && GetVNFunc(vn, &funcApp))
-    {
-        if ((funcApp.m_func == (VNFunc)GT_LE) || (funcApp.m_func == (VNFunc)GT_GE) ||
-            (funcApp.m_func == (VNFunc)GT_LT) || (funcApp.m_func == (VNFunc)GT_GT))
-        {
-            const bool op1IsConst = IsVNInt32Constant(funcApp.m_args[0]);
-            const bool op2IsConst = IsVNInt32Constant(funcApp.m_args[1]);
-
-            // Technically, we can allow both to be constants,
-            // but such relops are expected to be constant folded anyway.
-            return op1IsConst != op2IsConst;
-        }
-    }
-    return false;
-}
-
-bool ValueNumStore::IsVNConstantBoundUnsigned(ValueNum vn)
-{
-    VNFuncApp funcApp;
-    if (GetVNFunc(vn, &funcApp))
-    {
-        switch (funcApp.m_func)
-        {
-            case VNF_LT_UN:
-            case VNF_LE_UN:
-            case VNF_GE_UN:
-            case VNF_GT_UN:
-                // Technically, we can allow both to be constants,
-                // but such relops are expected to be constant folded anyway.
-                return IsVNPositiveInt32Constant(funcApp.m_args[0]) != IsVNPositiveInt32Constant(funcApp.m_args[1]);
-            default:
-                break;
-        }
-    }
-    return false;
-}
-
 //------------------------------------------------------------------------
 // IsVNPositiveInt32Constant: returns true iff vn is a known Int32 constant that is greater then 0
 //

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -1118,6 +1118,7 @@ public:
     bool IsVNUnsignedCompareCheckedBound(ValueNum vn, UnsignedCompareCheckedBoundInfo* info);
 
     // If "vn" is of the form "len + cns" return true.
+    // NOTE: it accepts "cns + len" and "len - cns" as well ("len - cns" is treated as "len + (-cns)").
     bool IsVNCheckedBoundAddConst(ValueNum vn, ValueNum* checkedBndVN, int* addCns);
 
     // Returns the flags on the current handle. GTF_ICON_SCOPE_HDL for example.

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -186,6 +186,17 @@ struct VNFuncApp
     unsigned  m_arity;
     ValueNum* m_args;
 
+    bool FuncIs(VNFunc func) const
+    {
+        return m_func == func;
+    }
+
+    template <typename... T>
+    bool FuncIs(VNFunc func, T... rest) const
+    {
+        return FuncIs(func) || FuncIs(rest...);
+    }
+
     bool Equals(const VNFuncApp& funcApp)
     {
         if (m_func != funcApp.m_func)
@@ -1102,12 +1113,6 @@ public:
 
     // If "vn" is VN(a.Length) or VN(a.GetLength(n)) then return VN(a); NoVN if VN(a) can't be determined.
     ValueNum GetArrForLenVn(ValueNum vn);
-
-    // Return true with any Relop except for == and !=  and one operand has to be a 32-bit integer constant.
-    bool IsVNConstantBound(ValueNum vn);
-
-    // If "vn" is of the form "(uint)var relop cns" for any relop except for == and !=
-    bool IsVNConstantBoundUnsigned(ValueNum vn);
 
     // If "vn" is of the form "(uint)var < (uint)len" (or equivalent) return true.
     bool IsVNUnsignedCompareCheckedBound(ValueNum vn, UnsignedCompareCheckedBoundInfo* info);

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -1112,14 +1112,8 @@ public:
     // If "vn" is of the form "(uint)var < (uint)len" (or equivalent) return true.
     bool IsVNUnsignedCompareCheckedBound(ValueNum vn, UnsignedCompareCheckedBoundInfo* info);
 
-    // If "vn" is of the form "var < len" or "len <= var" return true.
-    bool IsVNCompareCheckedBound(ValueNum vn);
-
     // If "vn" is of the form "len + cns" return true.
-    bool IsVNCheckedBoundArith(ValueNum vn, ValueNum* pCheckedBndVN = nullptr, int* addCns = nullptr);
-
-    // If "vn" is of the form "var < len +/- k" return true.
-    bool IsVNCompareCheckedBoundArith(ValueNum vn);
+    bool IsVNCheckedBoundAddConst(ValueNum vn, ValueNum* checkedBndVN, int* addCns);
 
     // Returns the flags on the current handle. GTF_ICON_SCOPE_HDL for example.
     GenTreeFlags GetHandleFlags(ValueNum vn);

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -1088,42 +1088,6 @@ public:
         }
     };
 
-    struct CompareCheckedBoundArithInfo
-    {
-        // (vnBound - 1) > vnOp
-        // (vnBound arrOper arrOp) cmpOper cmpOp
-        ValueNum vnBound;
-        unsigned arrOper;
-        ValueNum arrOp;
-        bool     arrOpLHS; // arrOp is on the left side of cmpOp expression
-        unsigned cmpOper;
-        ValueNum cmpOp;
-        CompareCheckedBoundArithInfo()
-            : vnBound(NoVN)
-            , arrOper(GT_NONE)
-            , arrOp(NoVN)
-            , arrOpLHS(false)
-            , cmpOper(GT_NONE)
-            , cmpOp(NoVN)
-        {
-        }
-#ifdef DEBUG
-        void dump(ValueNumStore* vnStore)
-        {
-            vnStore->vnDump(vnStore->m_compiler, cmpOp);
-            printf(" ");
-            printf(vnStore->VNFuncName((VNFunc)cmpOper));
-            printf(" ");
-            vnStore->vnDump(vnStore->m_compiler, vnBound);
-            if (arrOper != GT_NONE)
-            {
-                printf(vnStore->VNFuncName((VNFunc)arrOper));
-                vnStore->vnDump(vnStore->m_compiler, arrOp);
-            }
-        }
-#endif
-    };
-
     // Check if "vn" is "new [] (type handle, size)"
     bool IsVNNewArr(ValueNum vn, VNFuncApp* funcApp);
 
@@ -1151,20 +1115,11 @@ public:
     // If "vn" is of the form "var < len" or "len <= var" return true.
     bool IsVNCompareCheckedBound(ValueNum vn);
 
-    // If "vn" is checked bound, then populate the "info" fields for the boundVn, cmpOp, cmpOper.
-    void GetCompareCheckedBound(ValueNum vn, CompareCheckedBoundArithInfo* info);
-
-    // If "vn" is of the form "len +/- var" return true.
-    bool IsVNCheckedBoundArith(ValueNum vn);
-
-    // If "vn" is checked bound arith, then populate the "info" fields for arrOper, arrVn, arrOp.
-    void GetCheckedBoundArithInfo(ValueNum vn, CompareCheckedBoundArithInfo* info);
+    // If "vn" is of the form "len + cns" return true.
+    bool IsVNCheckedBoundArith(ValueNum vn, ValueNum* pCheckedBndVN = nullptr, int* addCns = nullptr);
 
     // If "vn" is of the form "var < len +/- k" return true.
     bool IsVNCompareCheckedBoundArith(ValueNum vn);
-
-    // If "vn" is checked bound arith, then populate the "info" fields for cmpOp, cmpOper.
-    void GetCompareCheckedBoundArithInfo(ValueNum vn, CompareCheckedBoundArithInfo* info);
 
     // Returns the flags on the current handle. GTF_ICON_SCOPE_HDL for example.
     GenTreeFlags GetHandleFlags(ValueNum vn);


### PR DESCRIPTION
This PR removes the remaining `O1K_BOUND_OPER_BND` and `O1K_BOUND_LOOP_BND`.

All bounds-related assertions now look like:

```
O1K_VN  -- OAK_<relop> -- O2K_CHECKED_BOUND_ADD_CNS
```
* `op1.vn` - just some variable
* `op2.vn` - the checked bound
* `op2.icon.iconValue` - the int constant added to the checked bound

Hence, it's unified for e.g. "x < len" and "x < (len - 10)". The "x < len" is effectively "x < (len + 0)".

Overall, it simplifies a lot the search for relevant assertions as we no longer need to decompose relopVNs (and its operands) into pieces every time.

Did a small cleanup along the way. It brings some improvements mostly due to "don't create useless complimentary assertions such as X > BND" check. Also, TP improvements.

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1283890&view=ms.vss-build-web.run-extensions-tab)