### PR TITLE
[release/10.0] Fix missing release semantics in VolatilePtr

### DIFF
--- a/src/coreclr/gc/env/volatile.h
+++ b/src/coreclr/gc/env/volatile.h
@@ -470,6 +470,16 @@ public:
     }
 
     //
+    // Bring the base class operator= into scope.
+    //
+    using Volatile<P>::operator=;
+
+    //
+    // Copy assignment operator.
+    //
+    inline VolatilePtr<T,P>& operator=(const VolatilePtr<T,P>& other) {this->Store(other.Load()); return *this;}
+
+    //
     // Cast to the pointer type
     //
     inline operator P() const

--- a/src/coreclr/inc/volatile.h
+++ b/src/coreclr/inc/volatile.h
@@ -532,6 +532,19 @@ public:
     }
 
     //
+    // Bring the base class operator= into scope.  Without this, the compiler-generated
+    // copy assignment operator hides Volatile<P>::operator= and performs a plain store,
+    // bypassing the memory barriers provided by VolatileStore.
+    //
+    using Volatile<P>::operator=;
+
+    //
+    // Copy assignment operator.  The using declaration above does not suppress the
+    // compiler-generated copy assignment, so we must define it explicitly.
+    //
+    inline VolatilePtr<T,P>& operator=(const VolatilePtr<T,P>& other) {this->Store(other.Load()); return *this;}
+
+    //
     // Cast to the pointer type
     //
     inline operator P() const


### PR DESCRIPTION
**Related issue**: #124071
**Main PR**: #124096

**Risk**: Low, purely adds a barrier which is the intended semantics of the class.

**Impact**: Detected as a non-deterministic lock free race that resulted in crashes in the Roslyn language server for internal customers. Mostly happens with really complex solutions that have a lot of threads accessing GC Statics. 

`VolatilePtr` inherits from `Volatile<P>`, which defines `operator=` to call `VolatileStore()` with platform scpecific release semantics. However, `VolatilePtr` did not declare its own `operator=`, so the compiler-generated copy/move assignment operator hid the base class `operator=` and performed plain stores instead, bypassing memory barriers entirely.

Fix by adding a using declaration to bring `Volatile<P>::operator=` into scope, and an explicit copy assignment operator (which the using declaration cannot suppress the compiler from generating).
