### PR TITLE
Disable runtime async feature on Apple mobile

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -7,6 +7,7 @@
     and '$(TargetOS)' != 'browser'
     and '$(TargetOS)' != 'wasi'
     and '$(RuntimeFlavor)' != 'Mono'
+    and '$(TargetsAppleMobile)' != 'true'
     and '$(UseRuntimeAsync)' != 'false'">
     <EnablePreviewFeatures>true</EnablePreviewFeatures>
     <Features>$(Features);runtime-async=on</Features>

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -628,7 +628,6 @@ namespace System.Diagnostics.Tests
 
         [ActiveIssue("https://github.com/dotnet/runtime/issues/123979", typeof(PlatformDetection), nameof(PlatformDetection.IsArmProcess))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/124015", typeof(PlatformDetection), nameof(PlatformDetection.IsArm64Process))]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/124044", typeof(PlatformDetection), nameof(PlatformDetection.IsCoreClrInterpreter))]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsRuntimeAsyncSupported))]
         [MemberData(nameof(Ctor_Async_TestData))]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]

--- a/src/libraries/System.Diagnostics.StackTrace/tests/System.Diagnostics.StackTrace.Tests.csproj
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/System.Diagnostics.StackTrace.Tests.csproj
@@ -4,7 +4,8 @@
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <EnablePreviewFeatures>true</EnablePreviewFeatures>
+    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/124044 -->
+    <EnablePreviewFeatures Condition="'$(TargetsAppleMobile)' != 'true'">true</EnablePreviewFeatures>
 
     <!-- these tests depend on the pdb files -->
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(TargetOS)' == 'browser'">true</DebuggerSupport>

--- a/src/libraries/System.Diagnostics.StackTrace/tests/System.Diagnostics.StackTrace.Tests.csproj
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/System.Diagnostics.StackTrace.Tests.csproj
@@ -4,8 +4,7 @@
     <TestRuntime>true</TestRuntime>
     <IncludeRemoteExecutor>true</IncludeRemoteExecutor>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/124044 -->
-    <EnablePreviewFeatures Condition="'$(TargetsAppleMobile)' != 'true'">true</EnablePreviewFeatures>
+    <EnablePreviewFeatures>true</EnablePreviewFeatures>
 
     <!-- these tests depend on the pdb files -->
     <DebuggerSupport Condition="'$(DebuggerSupport)' == '' and '$(TargetOS)' == 'browser'">true</DebuggerSupport>


### PR DESCRIPTION
## Description

This PR disables runtime async feature on Apple mobile due to https://github.com/dotnet/runtime/issues/124044.