### PR TITLE
[release/10.0] Fix SampleType field in ThreadSample event from Sample Profiler

### DIFF
--- a/src/coreclr/vm/amd64/asmconstants.h
+++ b/src/coreclr/vm/amd64/asmconstants.h
@@ -567,9 +567,9 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__ThreadLocalInfo__m_pThread == offsetof(ThreadLoc
 ASMCONSTANTS_C_ASSERT(OFFSETOF__InterpMethod__pCallStub == offsetof(InterpMethod, pCallStub))
 
 #ifdef TARGET_UNIX
-#define OFFSETOF__Thread__m_pInterpThreadContext 0xb50
+#define OFFSETOF__Thread__m_pInterpThreadContext 0xb48
 #else // TARGET_UNIX
-#define OFFSETOF__Thread__m_pInterpThreadContext 0xba8
+#define OFFSETOF__Thread__m_pInterpThreadContext 0xba0
 #endif // TARGET_UNIX
 ASMCONSTANTS_C_ASSERT(OFFSETOF__Thread__m_pInterpThreadContext == offsetof(Thread, m_pInterpThreadContext))
 

--- a/src/coreclr/vm/arm64/asmconstants.h
+++ b/src/coreclr/vm/arm64/asmconstants.h
@@ -303,9 +303,9 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__ThreadLocalInfo__m_pThread == offsetof(ThreadLoc
 ASMCONSTANTS_C_ASSERT(OFFSETOF__InterpMethod__pCallStub == offsetof(InterpMethod, pCallStub))
 
 #ifdef TARGET_UNIX
-#define OFFSETOF__Thread__m_pInterpThreadContext 0xb78
+#define OFFSETOF__Thread__m_pInterpThreadContext 0xb70
 #else // TARGET_UNIX
-#define OFFSETOF__Thread__m_pInterpThreadContext 0xba0
+#define OFFSETOF__Thread__m_pInterpThreadContext 0xb98
 #endif // TARGET_UNIX
 ASMCONSTANTS_C_ASSERT(OFFSETOF__Thread__m_pInterpThreadContext == offsetof(Thread, m_pInterpThreadContext))
 

--- a/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.cpp
+++ b/src/coreclr/vm/eventing/eventpipe/ep-rt-coreclr.cpp
@@ -114,10 +114,9 @@ walk_managed_stack_for_threads (
 
 		// Walk the stack and write it out as an event.
 		if (ep_rt_coreclr_walk_managed_stack_for_thread (target_thread, current_stack_contents) && !ep_stack_contents_is_empty (current_stack_contents)) {
-			// Set the payload.  If the GC mode on suspension > 0, then the thread was in cooperative mode.
-			// Even though there are some cases where this is not managed code, we assume it is managed code here.
-			// If the GC mode on suspension == 0 then the thread was in preemptive mode, which we qualify as external here.
-			uint32_t payload_data = target_thread->GetGCModeOnSuspension () ? EP_SAMPLE_PROFILER_SAMPLE_TYPE_MANAGED : EP_SAMPLE_PROFILER_SAMPLE_TYPE_EXTERNAL;
+			// Set the payload. If the thread is trapped for suspension, it was in cooperative mode (managed code).
+			// Otherwise, it was in preemptive mode (external code).
+			uint32_t payload_data = target_thread->HasThreadState (Thread::TS_SuspensionTrapped) ? EP_SAMPLE_PROFILER_SAMPLE_TYPE_MANAGED : EP_SAMPLE_PROFILER_SAMPLE_TYPE_EXTERNAL;
 
 			// Write the sample.
 			ep_write_sample_profile_event (
@@ -128,9 +127,6 @@ walk_managed_stack_for_threads (
 				(uint8_t *)&payload_data,
 				sizeof (payload_data));
 		}
-
-		// Reset the GC mode.
-		target_thread->ClearGCModeOnSuspension ();
 	}
 
 	ep_stack_contents_fini (current_stack_contents);

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -522,7 +522,7 @@ public:
 
         TS_AbortRequested         = 0x00000001,    // Abort the thread
 
-        // unused                 = 0x00000002,
+        TS_SuspensionTrapped      = 0x00000002,    // Thread is trapped waiting for suspension to complete (was in managed code)
         TS_GCSuspendRedirected    = 0x00000004,    // ThreadSuspend::SuspendRuntime has redirected the thread to suspention routine.
 
         TS_DebugSuspendPending    = 0x00000008,    // Is the debugger suspending threads?
@@ -3748,32 +3748,11 @@ public:
 #ifdef FEATURE_PERFTRACING
 private:
 
-    // SampleProfiler thread state.  This is set on suspension and cleared before restart.
-    // True if the thread was in cooperative mode.  False if it was in preemptive when the suspension started.
-    Volatile<ULONG> m_gcModeOnSuspension;
-
     // The activity ID for the current thread.
     // An activity ID of zero means the thread is not executing in the context of an activity.
     GUID m_activityId;
 
 public:
-    bool GetGCModeOnSuspension()
-    {
-        LIMITED_METHOD_CONTRACT;
-        return m_gcModeOnSuspension != 0U;
-    }
-
-    void SaveGCModeOnSuspension()
-    {
-        LIMITED_METHOD_CONTRACT;
-        m_gcModeOnSuspension = m_fPreemptiveGCDisabled;
-    }
-
-    void ClearGCModeOnSuspension()
-    {
-        m_gcModeOnSuspension = 0;
-    }
-
     LPCGUID GetActivityId() const
     {
         LIMITED_METHOD_CONTRACT;

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -2194,6 +2194,10 @@ void Thread::RareDisablePreemptiveGC()
 
         if (ThreadStore::IsTrappingThreadsForSuspension())
         {
+            // Mark that this thread is trapped for suspension.
+            // Used by the sample profiler to determine this thread was in managed code.
+            SetThreadState(TS_SuspensionTrapped);
+
             EnablePreemptiveGC();
 
 #ifdef PROFILING_SUPPORTED
@@ -2232,6 +2236,9 @@ void Thread::RareDisablePreemptiveGC()
 
             // disable preemptive gc.
             m_fPreemptiveGCDisabled.StoreWithoutBarrier(1);
+
+            // Clear the suspension trapped flag now that we're resuming.
+            ResetThreadState(TS_SuspensionTrapped);
 
             // check again if we have something to do
             continue;


### PR DESCRIPTION
Backport of #124019 to release/10.0

## Customer Impact

- [X] Customer reported
- [ ] Found internally

The SampleType field in ThreadSample events from SampleProfiler was always reporting EP_SAMPLE_PROFILER_SAMPLE_TYPE_EXTERNAL even when threads were executing managed code. This causes incorrect profiling data for customers using diagnostics tools that rely on this event.

Fixes #123996

## Regression

- [X] Yes
- [ ] No

This regressed in .NET 9 when SuspendAllThreads was ported from NativeAOT to CoreCLR (commit 00a897369db).

## Testing
Manual

## Risk
Low

The change is minimal and self-contained:
- Adds a new thread state flag (TS_SuspensionTrapped) using a previously unused bit
- Sets/clears the flag in RareDisablePreemptiveGC when threads voluntarily suspend
- Uses the flag instead of the removed m_gcModeOnSuspension field for sample type detection
- The change is pay-for-play: only threads that were actually executing managed code participate