### PR TITLE
Skip PROCAbortInitialize on WASM

### DIFF
--- a/src/coreclr/pal/src/init/pal.cpp
+++ b/src/coreclr/pal/src/init/pal.cpp
@@ -693,9 +693,6 @@ PAL_InitializeCoreCLR(const char *szExePath, BOOL runningInExe)
     {
         return ERROR_DLL_INIT_FAILED;
     }
-#endif // !TARGET_WASM
-
-#ifndef TARGET_WASM
     if (!PROCAbortInitialize())
     {
         printf("PROCAbortInitialize FAILED %d (%s)\n", errno, strerror(errno));

--- a/src/coreclr/pal/src/init/pal.cpp
+++ b/src/coreclr/pal/src/init/pal.cpp
@@ -685,7 +685,7 @@ PAL_InitializeCoreCLR(const char *szExePath, BOOL runningInExe)
         return ERROR_SUCCESS;
     }
 
-#ifndef TARGET_WASM // we don't use shared libraries on wasm
+#ifndef TARGET_WASM // we don't use shared libraries on wasm and don't support dbg mini dump
     // Now that the PAL is initialized it's safe to call the initialization methods for the code that used to
     // be dynamically loaded libraries but is now statically linked into CoreCLR just like the PAL, i.e. the
     // PAL RT and mscorwks.

--- a/src/coreclr/pal/src/init/pal.cpp
+++ b/src/coreclr/pal/src/init/pal.cpp
@@ -695,11 +695,13 @@ PAL_InitializeCoreCLR(const char *szExePath, BOOL runningInExe)
     }
 #endif // !TARGET_WASM
 
+#ifndef TARGET_WASM
     if (!PROCAbortInitialize())
     {
         printf("PROCAbortInitialize FAILED %d (%s)\n", errno, strerror(errno));
         return ERROR_PALINIT_PROCABORT_INITIALIZE;
     }
+#endif // !TARGET_WASM
 
     return ERROR_SUCCESS;
 }


### PR DESCRIPTION
Mini dumps are not supported on WASM - the createdump binary doesn't exist and the browser environment doesn't support crash dumps.

Setting DOTNET_DbgEnableMiniDump=1 was causing runtime init to fail because PROCAbortInitialize depends on g_szCoreCLRPath which is never set on WASM (LOADInitializeCoreCLRModule is already skipped).

Fixes #124088