### PR TITLE
Add vmr-codeflow-status Copilot skill

### DIFF
--- a/.github/skills/vmr-codeflow-status/SKILL.md
+++ b/.github/skills/vmr-codeflow-status/SKILL.md
@@ -104,7 +104,6 @@ darc get-build --id <bar-build-id>
 
 # Resolve codeflow conflicts locally
 darc vmr resolve-conflict --subscription <subscription-id>
-darc vmr resolve --subscription <subscription-id> --build <bar-build-id>
 ```
 
 Install darc via `eng\common\darc-init.ps1` in any arcade-enabled repository.

--- a/.github/skills/vmr-codeflow-status/SKILL.md
+++ b/.github/skills/vmr-codeflow-status/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: vmr-codeflow-status
+description: Analyze VMR codeflow PR status for dotnet repositories. Use when investigating stale codeflow PRs, checking if fixes have flowed through the VMR pipeline, or debugging dependency update issues in PRs authored by dotnet-maestro[bot].
+license: MIT
+metadata:
+  author: lewing
+  version: "1.0"
+---
+
+# VMR Codeflow Status
+
+Analyze the health of VMR codeflow PRs (backflow from `dotnet/dotnet` to product repositories like `dotnet/sdk`).
+
+## When to Use This Skill
+
+Use this skill when:
+- A codeflow PR (from `dotnet-maestro[bot]`) has failing tests and you need to know if it's stale
+- You need to check if a specific fix has flowed through the VMR pipeline to a codeflow PR
+- A PR has a Maestro staleness warning ("codeflow cannot continue")
+- You need to understand what manual commits would be lost if a codeflow PR is closed
+- Asked questions like "is this codeflow PR up to date", "has the runtime revert reached this PR", "why is the codeflow blocked"
+
+## Quick Start
+
+```powershell
+# Check codeflow PR status (most common)
+./scripts/Get-CodeflowStatus.ps1 -PRNumber 52727 -Repository "dotnet/sdk"
+
+# Trace a specific fix through the pipeline
+./scripts/Get-CodeflowStatus.ps1 -PRNumber 52727 -Repository "dotnet/sdk" -TraceFix "dotnet/runtime#123974"
+
+# Show individual VMR commits that are missing
+./scripts/Get-CodeflowStatus.ps1 -PRNumber 52727 -Repository "dotnet/sdk" -ShowCommits
+```
+
+## Key Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `-PRNumber` | GitHub PR number to analyze (required) |
+| `-Repository` | Target repo in `owner/repo` format (default: `dotnet/sdk`) |
+| `-TraceFix` | Trace a repo PR through the pipeline (e.g., `dotnet/runtime#123974`) |
+| `-ShowCommits` | Show individual VMR commits between PR snapshot and branch HEAD |
+
+## What the Script Does
+
+1. **Parses PR metadata** — Extracts VMR commit, subscription ID, build info from PR body
+2. **Checks VMR freshness** — Compares PR's VMR snapshot against current VMR branch HEAD
+3. **Detects staleness** — Finds Maestro "codeflow cannot continue" warnings
+4. **Analyzes PR commits** — Categorizes as auto-updates vs manual commits
+5. **Traces fixes** (optional) — Checks if a specific fix has flowed through VMR → codeflow PR
+6. **Recommends actions** — Suggests force trigger, close/reopen, merge as-is, or wait
+
+## Interpreting Results
+
+### Freshness
+- **✅ Up to date**: PR has the latest VMR snapshot
+- **⚠️ VMR is N commits ahead**: The PR is missing updates. Check if the missing commits contain the fix you need.
+
+### Staleness
+- **✅ No staleness warnings**: Maestro can freely update the PR
+- **⚠️ Staleness warning detected**: A forward flow merged while this backflow PR was open. Maestro blocked further updates.
+
+### Manual Commits
+Manual commits on the PR branch are at risk if the PR is closed or force-triggered. The script lists them so you can decide whether to preserve them.
+
+### Fix Tracing
+When using `-TraceFix`:
+- **✅ Fix is in VMR manifest**: The fix has flowed to the VMR
+- **✅ Fix is in PR snapshot**: The codeflow PR already includes this fix
+- **❌ Fix is NOT in PR snapshot**: The PR needs a codeflow update to get this fix
+
+## Darc Commands for Remediation
+
+After analyzing the codeflow status, common next steps involve `darc` commands:
+
+```bash
+# Force trigger the subscription to get a fresh codeflow update
+darc trigger-subscriptions --id <subscription-id> --force
+
+# Normal trigger (only works if not stale)
+darc trigger-subscriptions --id <subscription-id>
+
+# Check subscription details
+darc get-subscriptions --target-repo dotnet/sdk --source-repo dotnet/dotnet
+
+# Get BAR build details
+darc get-build --id <bar-build-id>
+
+# Resolve codeflow conflicts locally
+darc vmr resolve --subscription <subscription-id> --build <bar-build-id>
+```
+
+Install darc via `eng\common\darc-init.ps1` in any arcade-enabled repository.
+
+## References
+
+- **VMR codeflow concepts**: See [references/vmr-codeflow-reference.md](references/vmr-codeflow-reference.md)
+- **Codeflow PR documentation**: [dotnet/dotnet Codeflow-PRs.md](https://github.com/dotnet/dotnet/blob/main/docs/Codeflow-PRs.md)

--- a/.github/skills/vmr-codeflow-status/SKILL.md
+++ b/.github/skills/vmr-codeflow-status/SKILL.md
@@ -27,16 +27,24 @@ Use this skill when:
 
 # Show individual VMR commits that are missing
 ./scripts/Get-CodeflowStatus.ps1 -PRNumber 52727 -Repository "dotnet/sdk" -ShowCommits
+
+# Check if any backflow PRs are missing for a repo
+./scripts/Get-CodeflowStatus.ps1 -Repository "dotnet/roslyn" -CheckMissing
+
+# Check a specific branch only
+./scripts/Get-CodeflowStatus.ps1 -Repository "dotnet/sdk" -CheckMissing -Branch "main"
 ```
 
 ## Key Parameters
 
 | Parameter | Description |
 |-----------|-------------|
-| `-PRNumber` | GitHub PR number to analyze (required) |
+| `-PRNumber` | GitHub PR number to analyze (required unless `-CheckMissing`) |
 | `-Repository` | Target repo in `owner/repo` format (default: `dotnet/sdk`) |
 | `-TraceFix` | Trace a repo PR through the pipeline (e.g., `dotnet/runtime#123974`) |
 | `-ShowCommits` | Show individual VMR commits between PR snapshot and branch HEAD |
+| `-CheckMissing` | Check if backflow PRs are expected but missing for a repository |
+| `-Branch` | With `-CheckMissing`, only check a specific branch |
 
 ## What the Script Does
 
@@ -46,6 +54,7 @@ Use this skill when:
 4. **Analyzes PR commits** — Categorizes as auto-updates vs manual commits
 5. **Traces fixes** (optional) — Checks if a specific fix has flowed through VMR → codeflow PR
 6. **Recommends actions** — Suggests force trigger, close/reopen, merge as-is, or wait
+7. **Checks for missing backflow** (optional) — Finds branches where a backflow PR should exist but doesn't
 
 ## Interpreting Results
 

--- a/.github/skills/vmr-codeflow-status/SKILL.md
+++ b/.github/skills/vmr-codeflow-status/SKILL.md
@@ -12,8 +12,9 @@ Analyze the health of VMR codeflow PRs (backflow from `dotnet/dotnet` to product
 Use this skill when:
 - A codeflow PR (from `dotnet-maestro[bot]`) has failing tests and you need to know if it's stale
 - You need to check if a specific fix has flowed through the VMR pipeline to a codeflow PR
-- A PR has a Maestro staleness warning ("codeflow cannot continue")
+- A PR has a Maestro staleness warning ("codeflow cannot continue") or conflict
 - You need to understand what manual commits would be lost if a codeflow PR is closed
+- You want to know if expected backflow PRs are missing for a repo/branch
 - Asked questions like "is this codeflow PR up to date", "has the runtime revert reached this PR", "why is the codeflow blocked"
 
 ## Quick Start
@@ -49,22 +50,31 @@ Use this skill when:
 ## What the Script Does
 
 1. **Parses PR metadata** — Extracts VMR commit, subscription ID, build info from PR body
-2. **Checks VMR freshness** — Compares PR's VMR snapshot against current VMR branch HEAD
-3. **Detects staleness** — Finds Maestro "codeflow cannot continue" warnings
-4. **Analyzes PR commits** — Categorizes as auto-updates vs manual commits
-5. **Traces fixes** (optional) — Checks if a specific fix has flowed through VMR → codeflow PR
-6. **Recommends actions** — Suggests force trigger, close/reopen, merge as-is, or wait
-7. **Checks for missing backflow** (optional) — Finds branches where a backflow PR should exist but doesn't
+2. **Validates snapshot** — Cross-references PR body commit against branch commit messages to detect stale metadata
+3. **Checks VMR freshness** — Compares PR's VMR snapshot against current VMR branch HEAD
+4. **Shows pending forward flow** — For behind backflow PRs, finds open forward flow PRs that would close part of the gap
+5. **Detects staleness & conflicts** — Finds Maestro "codeflow cannot continue" warnings and "Conflict detected" messages with file lists and resolve commands
+6. **Analyzes PR commits** — Categorizes as auto-updates vs manual commits
+7. **Traces fixes** (optional) — Checks if a specific fix has flowed through VMR → codeflow PR
+8. **Recommends actions** — Suggests force trigger, close/reopen, merge as-is, resolve conflicts, or wait
+9. **Checks for missing backflow** (optional) — Finds branches where a backflow PR should exist but doesn't
 
 ## Interpreting Results
 
 ### Freshness
 - **✅ Up to date**: PR has the latest VMR snapshot
 - **⚠️ VMR is N commits ahead**: The PR is missing updates. Check if the missing commits contain the fix you need.
+- **📊 Forward flow coverage**: Shows how many missing repos have pending forward flow PRs that would close part of the gap once merged.
 
-### Staleness
-- **✅ No staleness warnings**: Maestro can freely update the PR
-- **⚠️ Staleness warning detected**: A forward flow merged while this backflow PR was open. Maestro blocked further updates.
+### Snapshot Validation
+- **✅ Match**: PR body commit matches the branch's actual "Backflow from" commit
+- **⚠️ Mismatch**: PR body is stale — the script automatically uses the branch-derived commit for freshness checks
+- **ℹ️ Initial commit only**: PR body can't be verified yet (no "Backflow from" commit exists)
+
+### Staleness & Conflicts
+- **✅ No warnings**: Maestro can freely update the PR
+- **⚠️ Staleness warning**: A forward flow merged while this backflow PR was open. Maestro blocked further updates.
+- **🔴 Conflict detected**: Maestro found merge conflicts. Shows conflicting files and `darc vmr resolve-conflict` command.
 
 ### Manual Commits
 Manual commits on the PR branch are at risk if the PR is closed or force-triggered. The script lists them so you can decide whether to preserve them.
@@ -93,6 +103,7 @@ darc get-subscriptions --target-repo dotnet/sdk --source-repo dotnet/dotnet
 darc get-build --id <bar-build-id>
 
 # Resolve codeflow conflicts locally
+darc vmr resolve-conflict --subscription <subscription-id>
 darc vmr resolve --subscription <subscription-id> --build <bar-build-id>
 ```
 

--- a/.github/skills/vmr-codeflow-status/SKILL.md
+++ b/.github/skills/vmr-codeflow-status/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: vmr-codeflow-status
 description: Analyze VMR codeflow PR status for dotnet repositories. Use when investigating stale codeflow PRs, checking if fixes have flowed through the VMR pipeline, or debugging dependency update issues in PRs authored by dotnet-maestro[bot].
-license: MIT
-metadata:
-  author: lewing
-  version: "1.0"
 ---
 
 # VMR Codeflow Status

--- a/.github/skills/vmr-codeflow-status/references/vmr-codeflow-reference.md
+++ b/.github/skills/vmr-codeflow-status/references/vmr-codeflow-reference.md
@@ -1,0 +1,144 @@
+# VMR Codeflow Reference
+
+## Key Concepts
+
+### Codeflow Types
+- **Backflow** (VMR → product repo): Automated PRs created by Maestro that bring VMR source updates + dependency updates into product repos (e.g., `dotnet/sdk`). These are titled `[branch] Source code updates from dotnet/dotnet`.
+- **Forward flow** (product repo → VMR): Changes from product repos flowing into the VMR. These are titled `[branch] Source code updates from dotnet/<repo>`.
+
+### Staleness
+When a product repo pushes changes to the VMR (forward flow merges) while a backflow PR is already open, Maestro blocks further codeflow updates to that PR. The bot posts a warning comment with options:
+1. Merge the PR as-is, then Maestro creates a new PR with remaining changes
+2. Close the PR and let Maestro open a fresh one (loses manual commits)
+3. Force trigger: `darc trigger-subscriptions --id <subscription-id> --force` (manual commits may be reverted)
+
+### Key Files
+- **`src/source-manifest.json`** (in VMR): Tracks the exact commit SHA for each product repo synchronized into the VMR. This is the authoritative source of truth.
+- **`eng/Version.Details.xml`** (in product repos): Tracks dependencies and includes a `<Source>` tag for codeflow tracking.
+
+## PR Body Metadata Format
+
+Codeflow PRs have structured metadata in their body:
+
+```
+[marker]: <> (Begin:<subscription-id>)
+## From https://github.com/dotnet/dotnet
+- **Subscription**: [<subscription-id>](https://maestro.dot.net/subscriptions?search=<subscription-id>)
+- **Build**: [<build-number>](<azdo-build-url>) ([<bar-id>](<maestro-channel-url>))
+- **Date Produced**: <date>
+- **Commit**: [<vmr-commit-sha>](<vmr-commit-url>)
+- **Commit Diff**: [<from>...<to>](<compare-url>)
+- **Branch**: [<branch>](<branch-url>)
+[marker]: <> (End:<subscription-id>)
+```
+
+## Darc CLI Commands
+
+The `darc` tool (Dependency ARcade) manages dependency flow in the .NET ecosystem. Install via `eng\common\darc-init.ps1` in any arcade-enabled repo.
+
+### Essential Commands for Codeflow Analysis
+
+#### Get subscription details
+```bash
+# Find all subscriptions flowing to a repo
+darc get-subscriptions --target-repo dotnet/sdk --source-repo dotnet/dotnet
+
+# Output shows subscription ID, channel, update frequency, merge policies
+```
+
+#### Trigger a codeflow update
+```bash
+# Normal trigger (only works if not stale)
+darc trigger-subscriptions --id <subscription-id>
+
+# Force trigger (works even when stale, but may revert manual commits)
+darc trigger-subscriptions --id <subscription-id> --force
+
+# Trigger with a specific build
+darc trigger-subscriptions --id <subscription-id> --build <bar-build-id>
+```
+
+#### Get build information
+```bash
+# Get BAR build details by ID (found in PR body or AzDO logs)
+darc get-build --id <bar-build-id>
+
+# Get latest build for a repo on a channel
+darc get-latest-build --repo dotnet/dotnet --channel ".NET 11 Preview 1"
+```
+
+#### Check subscription health
+```bash
+# See if dependencies are missing subscriptions or have issues
+darc get-health --channel ".NET 11 Preview 1"
+```
+
+#### Simulate a subscription update locally
+```bash
+# Dry-run to see what a subscription would update
+darc update-dependencies --subscription <subscription-id> --dry-run
+```
+
+### VMR-Specific Commands
+
+```bash
+# Resolve codeflow conflicts locally
+darc vmr resolve --subscription <subscription-id> --build <bar-build-id>
+
+# Flow source from VMR → local repo
+darc vmr backflow --subscription <subscription-id>
+
+# Flow source from local repo → local VMR
+darc vmr forwardflow --subscription <subscription-id>
+
+# Get version (SHA) of a repo in the VMR
+darc vmr get-version
+
+# Diff VMR vs product repos
+darc vmr diff
+```
+
+### Halting and Restarting Dependency Flow
+
+- **Disable default channel**: `darc default-channel-status --disable --id <id>` — stops new builds from flowing
+- **Disable subscription**: `darc subscription-status --disable --id <id>` — stops flow between specific repos
+- **Pin dependency**: Add `Pinned="true"` to dependency in `Version.Details.xml` — prevents specific dependency from updating
+
+## API Endpoints
+
+### GitHub API
+- PR details: `GET /repos/{owner}/{repo}/pulls/{pr_number}`
+- PR comments: `GET /repos/{owner}/{repo}/issues/{pr_number}/comments`
+- PR commits: `GET /repos/{owner}/{repo}/pulls/{pr_number}/commits`
+- Compare commits: `GET /repos/{owner}/{repo}/compare/{base}...{head}`
+- File contents: `GET /repos/{owner}/{repo}/contents/{path}?ref={branch}`
+
+### VMR Source Manifest
+```
+GET /repos/dotnet/dotnet/contents/src/source-manifest.json?ref={branch}
+```
+Returns JSON with `repositories[]` array, each having `path`, `remoteUri`, `commitSha`.
+
+### Maestro/BAR REST API
+Base URL: `https://maestro.dot.net`
+- Swagger: `https://maestro.dot.net/swagger`
+- Get subscriptions: `GET /api/subscriptions`
+- Get builds: `GET /api/builds`
+- Get build by ID: `GET /api/builds/{id}`
+
+## Common Scenarios
+
+### 1. Codeflow is stale — a fix landed but hasn't reached the PR
+**Symptoms**: Tests failing on the codeflow PR; the fix is merged in a product repo.
+**Diagnosis**: Compare `source-manifest.json` on VMR branch HEAD vs the PR's VMR snapshot commit.
+**Resolution**: Close PR + reopen, or force trigger the subscription.
+
+### 2. Opposite codeflow merged — staleness warning
+**Symptoms**: Maestro bot comment saying "codeflow cannot continue".
+**Diagnosis**: Check PR comments for the warning. Check if forward flow PRs merged after the backflow PR was opened.
+**Resolution**: Follow the options in the bot's comment.
+
+### 3. Manual commits on the codeflow PR
+**Symptoms**: Developers added manual fixes to unblock the PR (baseline updates, workarounds).
+**Diagnosis**: Analyze PR commits to identify non-maestro commits.
+**Risk**: Closing the PR loses these. Force-triggering may revert them.

--- a/.github/skills/vmr-codeflow-status/references/vmr-codeflow-reference.md
+++ b/.github/skills/vmr-codeflow-status/references/vmr-codeflow-reference.md
@@ -83,7 +83,7 @@ darc update-dependencies --subscription <subscription-id> --dry-run
 
 ```bash
 # Resolve codeflow conflicts locally
-darc vmr resolve --subscription <subscription-id> --build <bar-build-id>
+darc vmr resolve-conflict --subscription <subscription-id> --build <bar-build-id>
 
 # Flow source from VMR → local repo
 darc vmr backflow --subscription <subscription-id>

--- a/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
+++ b/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
@@ -59,7 +59,7 @@ function Invoke-GitHubApi {
             return $null
         }
         if ($Raw) { return $result -join "`n" }
-        return $result | ConvertFrom-Json
+        return ($result -join "`n") | ConvertFrom-Json
     }
     catch {
         Write-Warning "Error calling GitHub API: $_"
@@ -100,7 +100,7 @@ if ($LASTEXITCODE -ne 0) {
     Write-Error "Could not fetch PR #$PRNumber from $Repository"
     return
 }
-$pr = $prJson | ConvertFrom-Json
+$pr = ($prJson -join "`n") | ConvertFrom-Json
 
 Write-Status "Title" $pr.title
 Write-Status "State" $pr.state
@@ -375,7 +375,6 @@ if ($TraceFix) {
                 Write-Status "Merged at" $fixPR.merged_at
                 Write-Status "Merge commit" $fixPR.merge_commit_sha
                 $fixMergeCommit = $fixPR.merge_commit_sha
-                $fixTargetBranch = $fixPR.base.ref
             }
         }
 
@@ -468,7 +467,6 @@ if ($TraceFix) {
 Write-Section "Recommendations"
 
 $issues = @()
-$recommendations = @()
 
 # Summarize issues
 if ($stalenessWarnings.Count -gt 0) {

--- a/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
+++ b/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
@@ -105,8 +105,7 @@ function Write-Status {
 }
 
 # --- Parse repo owner/name ---
-$repoParts = $Repository -split '/'
-if ($repoParts.Count -ne 2) {
+if ($Repository -notmatch '^[^/]+/[^/]+$') {
     Write-Error "Repository must be in format 'owner/repo' (e.g., 'dotnet/sdk')"
     return
 }

--- a/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
+++ b/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
@@ -1,0 +1,523 @@
+<#
+.SYNOPSIS
+    Analyzes VMR codeflow PR status for dotnet repositories.
+
+.DESCRIPTION
+    Checks whether a codeflow PR (backflow from dotnet/dotnet VMR) is up to date,
+    detects staleness warnings, traces specific fixes through the pipeline, and
+    provides actionable recommendations.
+
+.PARAMETER PRNumber
+    GitHub PR number to analyze.
+
+.PARAMETER Repository
+    Target repository (default: dotnet/sdk). Format: owner/repo.
+
+.PARAMETER TraceFix
+    Optional. A repo PR to trace through the pipeline (e.g., "dotnet/runtime#123974").
+    Checks if the fix has flowed through VMR into the codeflow PR.
+
+.PARAMETER ShowCommits
+    Show individual VMR commits between the PR snapshot and current branch HEAD.
+
+.EXAMPLE
+    ./Get-CodeflowStatus.ps1 -PRNumber 52727 -Repository "dotnet/sdk"
+
+.EXAMPLE
+    ./Get-CodeflowStatus.ps1 -PRNumber 52727 -Repository "dotnet/sdk" -TraceFix "dotnet/runtime#123974"
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [int]$PRNumber,
+
+    [string]$Repository = "dotnet/sdk",
+
+    [string]$TraceFix,
+
+    [switch]$ShowCommits
+)
+
+$ErrorActionPreference = "Stop"
+
+# --- Helpers ---
+
+function Invoke-GitHubApi {
+    param([string]$Endpoint)
+    try {
+        $result = gh api $Endpoint 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "GitHub API call failed: $Endpoint"
+            return $null
+        }
+        return $result | ConvertFrom-Json
+    }
+    catch {
+        Write-Warning "Error calling GitHub API: $_"
+        return $null
+    }
+}
+
+function Get-ShortSha {
+    param([string]$Sha, [int]$Length = 12)
+    if (-not $Sha) { return "(unknown)" }
+    return $Sha.Substring(0, [Math]::Min($Length, $Sha.Length))
+}
+
+function ConvertFrom-Base64Content {
+    param([string]$Content)
+    try {
+        $clean = $Content -replace '\s', ''
+        return [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($clean))
+    }
+    catch {
+        Write-Warning "Failed to decode Base64 content: $_"
+        return $null
+    }
+}
+
+function Write-Section {
+    param([string]$Title)
+    Write-Host ""
+    Write-Host "=== $Title ===" -ForegroundColor Cyan
+}
+
+function Write-Status {
+    param([string]$Label, [string]$Value, [string]$Color = "White")
+    Write-Host "  ${Label}: " -NoNewline
+    Write-Host $Value -ForegroundColor $Color
+}
+
+# --- Parse repo owner/name ---
+$repoParts = $Repository -split '/'
+if ($repoParts.Count -ne 2) {
+    Write-Error "Repository must be in format 'owner/repo' (e.g., 'dotnet/sdk')"
+    return
+}
+$repoOwner = $repoParts[0]
+$repoName = $repoParts[1]
+
+# --- Step 1: Get PR details ---
+Write-Section "Codeflow PR #$PRNumber in $Repository"
+
+$pr = Invoke-GitHubApi "/repos/$Repository/pulls/$PRNumber"
+if (-not $pr) {
+    Write-Error "Could not fetch PR #$PRNumber from $Repository"
+    return
+}
+
+Write-Status "Title" $pr.title
+Write-Status "State" $pr.state
+Write-Status "Branch" "$($pr.head.ref) -> $($pr.base.ref)"
+Write-Status "Created" $pr.created_at
+Write-Status "Updated" $pr.updated_at
+Write-Host "  URL: $($pr.html_url)"
+
+# Check if this is actually a codeflow PR
+$isMaestroPR = $pr.user.login -eq "dotnet-maestro[bot]"
+$isCodeflowPR = $pr.title -match "Source code updates from dotnet/dotnet"
+if (-not $isMaestroPR -and -not $isCodeflowPR) {
+    Write-Warning "This does not appear to be a codeflow PR (author: $($pr.user.login), title: $($pr.title))"
+    Write-Warning "Expected author 'dotnet-maestro[bot]' and title containing 'Source code updates from dotnet/dotnet'"
+}
+
+# --- Step 2: Parse PR body metadata ---
+Write-Section "Codeflow Metadata"
+
+$body = $pr.body
+
+# Extract subscription ID
+$subscriptionId = $null
+if ($body -match '\(Begin:([a-f0-9-]+)\)') {
+    $subscriptionId = $Matches[1]
+    Write-Status "Subscription" $subscriptionId
+}
+
+# Extract VMR commit
+$vmrCommit = $null
+if ($body -match '\*\*Commit\*\*:\s*\[([a-f0-9]+)\]') {
+    $vmrCommit = $Matches[1]
+    Write-Status "VMR Commit" $vmrCommit
+}
+
+# Extract build info
+if ($body -match '\*\*Build\*\*:\s*\[([^\]]+)\]\(([^\)]+)\)') {
+    Write-Status "Build" "$($Matches[1])"
+    Write-Status "Build URL" $Matches[2]
+}
+
+# Extract date produced
+if ($body -match '\*\*Date Produced\*\*:\s*(.+)') {
+    Write-Status "Date Produced" $Matches[1].Trim()
+}
+
+# Extract VMR branch
+$vmrBranch = $null
+if ($body -match '\*\*Branch\*\*:\s*\[([^\]]+)\]') {
+    $vmrBranch = $Matches[1]
+    Write-Status "VMR Branch" $vmrBranch
+}
+
+# Extract commit diff
+if ($body -match '\*\*Commit Diff\*\*:\s*\[([^\]]+)\]\(([^\)]+)\)') {
+    Write-Status "Commit Diff" $Matches[1]
+}
+
+# Extract associated repo changes from footer
+$repoChanges = @()
+$changeMatches = [regex]::Matches($body, '- (https://github\.com/([^/]+/[^/]+)/compare/([a-f0-9]+)\.\.\.([a-f0-9]+))')
+foreach ($m in $changeMatches) {
+    $repoChanges += @{
+        URL      = $m.Groups[1].Value
+        Repo     = $m.Groups[2].Value
+        FromSha  = $m.Groups[3].Value
+        ToSha    = $m.Groups[4].Value
+    }
+}
+if ($repoChanges.Count -gt 0) {
+    Write-Status "Associated Repos" "$($repoChanges.Count) repos with source changes"
+}
+
+if (-not $vmrCommit -or -not $vmrBranch) {
+    Write-Warning "Could not parse VMR metadata from PR body. This may not be a codeflow PR."
+    if (-not $vmrBranch) {
+        # Try to infer from the PR target branch
+        $vmrBranch = $pr.base.ref
+        Write-Status "Inferred VMR Branch" $vmrBranch "(from PR target)"
+    }
+}
+
+# --- Step 3: Check VMR freshness ---
+Write-Section "VMR Freshness"
+
+$vmrHeadSha = $null
+$aheadBy = 0
+
+if ($vmrCommit -and $vmrBranch) {
+    # Get current VMR branch HEAD
+    $vmrHead = Invoke-GitHubApi "/repos/dotnet/dotnet/commits/$vmrBranch"
+    if ($vmrHead) {
+        $vmrHeadSha = $vmrHead.sha
+        $vmrHeadDate = $vmrHead.commit.committer.date
+        Write-Status "PR snapshot" "$(Get-ShortSha $vmrCommit) (from PR body)"
+        Write-Status "VMR HEAD" "$(Get-ShortSha $vmrHeadSha) ($vmrHeadDate)"
+
+        if ($vmrCommit -eq $vmrHeadSha -or $vmrHeadSha.StartsWith($vmrCommit)) {
+            Write-Host "  ✅ PR is up to date with VMR branch" -ForegroundColor Green
+        }
+        else {
+            # Compare to find how many commits ahead the VMR is
+            $compare = Invoke-GitHubApi "/repos/dotnet/dotnet/compare/$(Get-ShortSha $vmrCommit)...$(Get-ShortSha $vmrHeadSha)"
+            if ($compare) {
+                $aheadBy = $compare.ahead_by
+                $behindBy = $compare.behind_by
+                Write-Host "  ⚠️  VMR is $aheadBy commit(s) ahead of the PR snapshot" -ForegroundColor Yellow
+
+                if ($ShowCommits -and $compare.commits) {
+                    Write-Host ""
+                    Write-Host "  Commits since PR snapshot:" -ForegroundColor Yellow
+                    foreach ($c in $compare.commits) {
+                        $msg = ($c.commit.message -split "`n")[0]
+                        if ($msg.Length -gt 100) { $msg = $msg.Substring(0, 97) + "..." }
+                        $date = $c.commit.committer.date
+                        Write-Host "    $($c.sha.Substring(0,8)) $date $msg"
+                    }
+                }
+
+                # Check which repos have updates in the missing commits
+                $missingRepoUpdates = @()
+                if ($compare.commits) {
+                    foreach ($c in $compare.commits) {
+                        $msg = ($c.commit.message -split "`n")[0]
+                        if ($msg -match 'Source code updates from ([^\s(]+)') {
+                            $missingRepoUpdates += $Matches[1]
+                        }
+                    }
+                }
+                if ($missingRepoUpdates.Count -gt 0) {
+                    $uniqueRepos = $missingRepoUpdates | Select-Object -Unique
+                    Write-Host ""
+                    Write-Host "  Missing updates from: $($uniqueRepos -join ', ')" -ForegroundColor Yellow
+                }
+            }
+        }
+    }
+}
+else {
+    Write-Warning "Cannot check VMR freshness without VMR commit and branch info"
+}
+
+# --- Step 4: Check staleness warnings ---
+Write-Section "Staleness Check"
+
+$comments = Invoke-GitHubApi "/repos/$Repository/issues/$PRNumber/comments?per_page=100"
+$stalenessWarnings = @()
+$lastStalenessComment = $null
+
+if ($comments) {
+    if ($comments.Count -ge 100) {
+        Write-Warning "PR has 100+ comments — staleness warnings beyond the first page may be missed"
+    }
+    foreach ($comment in $comments) {
+        if ($comment.user.login -eq "dotnet-maestro[bot]" -and
+            ($comment.body -match "codeflow cannot continue" -or $comment.body -match "darc trigger-subscriptions")) {
+            $stalenessWarnings += $comment
+            $lastStalenessComment = $comment
+        }
+    }
+}
+
+if ($stalenessWarnings.Count -gt 0) {
+    Write-Host "  ⚠️  Staleness warning detected ($($stalenessWarnings.Count) warning(s))" -ForegroundColor Yellow
+    Write-Status "Latest warning" $lastStalenessComment.created_at
+    Write-Host "  The VMR received opposite codeflow (forward flow merged) while this PR was open." -ForegroundColor Yellow
+    Write-Host "  Maestro has blocked further codeflow updates to this PR." -ForegroundColor Yellow
+
+    # Extract darc commands from the warning
+    if ($lastStalenessComment.body -match 'darc trigger-subscriptions --id ([a-f0-9-]+)(?:\s+--force)?') {
+        Write-Host ""
+        Write-Host "  Suggested commands from Maestro:" -ForegroundColor White
+        if ($lastStalenessComment.body -match '(darc trigger-subscriptions --id [a-f0-9-]+)\s*\n') {
+            Write-Host "    Normal trigger: $($Matches[1])"
+        }
+        if ($lastStalenessComment.body -match '(darc trigger-subscriptions --id [a-f0-9-]+ --force)') {
+            Write-Host "    Force trigger:  $($Matches[1])"
+        }
+    }
+}
+else {
+    Write-Host "  ✅ No staleness warnings found" -ForegroundColor Green
+}
+
+# --- Step 5: Analyze PR branch commits ---
+Write-Section "PR Branch Analysis"
+
+$manualCommits = @()
+$prCommits = Invoke-GitHubApi "/repos/$Repository/pulls/$PRNumber/commits?per_page=100"
+if ($prCommits) {
+    if ($prCommits.Count -ge 100) {
+        Write-Warning "PR has 100+ commits — commits beyond the first page may be missed"
+    }
+    $maestroCommits = @()
+    $manualCommits = @()
+    $mergeCommits = @()
+
+    foreach ($c in $prCommits) {
+        $msg = ($c.commit.message -split "`n")[0]
+        $author = $c.commit.author.name
+
+        if ($msg -match "^Merge branch") {
+            $mergeCommits += $c
+        }
+        elseif ($author -eq "dotnet-maestro[bot]" -or $msg -eq "Update dependencies") {
+            $maestroCommits += $c
+        }
+        else {
+            $manualCommits += $c
+        }
+    }
+
+    Write-Status "Total commits" $prCommits.Count
+    Write-Status "Maestro auto-updates" $maestroCommits.Count
+    Write-Status "Merge commits" $mergeCommits.Count
+    Write-Status "Manual commits" $manualCommits.Count "$(if ($manualCommits.Count -gt 0) { 'Yellow' } else { 'Green' })"
+
+    if ($manualCommits.Count -gt 0) {
+        Write-Host ""
+        Write-Host "  Manual commits (at risk if PR is closed/force-triggered):" -ForegroundColor Yellow
+        foreach ($c in $manualCommits) {
+            $msg = ($c.commit.message -split "`n")[0]
+            if ($msg.Length -gt 80) { $msg = $msg.Substring(0, 77) + "..." }
+            Write-Host "    $($c.sha.Substring(0,8)) [$($c.commit.author.name)] $msg"
+        }
+    }
+}
+
+# --- Step 6: Trace a specific fix (optional) ---
+if ($TraceFix) {
+    Write-Section "Tracing Fix: $TraceFix"
+
+    # Parse TraceFix format: "owner/repo#number" or "repo#number"
+    $traceMatch = [regex]::Match($TraceFix, '(?:([^/]+)/)?([^#]+)#(\d+)')
+    if (-not $traceMatch.Success) {
+        Write-Warning "Could not parse TraceFix format. Expected: 'owner/repo#number' or 'repo#number'"
+    }
+    else {
+        $traceOwner = if ($traceMatch.Groups[1].Value) { $traceMatch.Groups[1].Value } else { "dotnet" }
+        $traceRepo = $traceMatch.Groups[2].Value
+        $traceNumber = $traceMatch.Groups[3].Value
+        $traceFullRepo = "$traceOwner/$traceRepo"
+
+        # Check if the fix PR is merged
+        $fixPR = Invoke-GitHubApi "/repos/$traceFullRepo/pulls/$traceNumber"
+        if ($fixPR) {
+            Write-Status "Fix PR" "${traceFullRepo}#${traceNumber}: $($fixPR.title)"
+            Write-Status "State" $fixPR.state
+            Write-Status "Merged" "$(if ($fixPR.merged) { '✅ Yes' } else { '❌ No' })" "$(if ($fixPR.merged) { 'Green' } else { 'Red' })"
+            if ($fixPR.merged) {
+                Write-Status "Merged at" $fixPR.merged_at
+                Write-Status "Merge commit" $fixPR.merge_commit_sha
+                $fixMergeCommit = $fixPR.merge_commit_sha
+                $fixTargetBranch = $fixPR.base.ref
+            }
+        }
+
+        # Check if the fix is in the VMR source-manifest.json on the target branch
+        if ($fixPR.merged -and $vmrBranch) {
+            Write-Host ""
+            Write-Host "  Checking VMR source-manifest.json on $vmrBranch..." -ForegroundColor White
+
+            $manifestUrl = "/repos/dotnet/dotnet/contents/src/source-manifest.json?ref=$vmrBranch"
+            $manifestResponse = Invoke-GitHubApi $manifestUrl
+            if ($manifestResponse -and $manifestResponse.content) {
+                $manifestJson = ConvertFrom-Base64Content $manifestResponse.content
+                if (-not $manifestJson) {
+                    Write-Warning "Failed to decode source-manifest.json from VMR branch"
+                }
+                else {
+                $manifest = $manifestJson | ConvertFrom-Json
+
+                # Find the repo in the manifest
+                $escapedRepo = [regex]::Escape($traceRepo)
+                $repoEntry = $manifest.repositories | Where-Object {
+                    $_.remoteUri -match "${escapedRepo}(\.git)?$" -or $_.path -eq $traceRepo
+                }
+
+                if ($repoEntry) {
+                    $manifestCommit = $repoEntry.commitSha
+                    Write-Status "VMR manifest commit" "$(Get-ShortSha $manifestCommit) for $($repoEntry.path)"
+
+                    # Check if the fix merge commit is an ancestor of the manifest commit
+                    if ($fixMergeCommit -eq $manifestCommit) {
+                        Write-Host "  ✅ Fix merge commit IS the VMR manifest commit" -ForegroundColor Green
+                    }
+                    else {
+                        # Check if fix is an ancestor of the manifest commit
+                        $ancestorCheck = Invoke-GitHubApi "/repos/$traceFullRepo/compare/$(Get-ShortSha $fixMergeCommit)...$(Get-ShortSha $manifestCommit)"
+                        if ($ancestorCheck) {
+                            if ($ancestorCheck.status -eq "ahead" -or $ancestorCheck.status -eq "identical") {
+                                Write-Host "  ✅ Fix is included in VMR manifest (manifest is ahead or identical)" -ForegroundColor Green
+                            }
+                            elseif ($ancestorCheck.status -eq "behind") {
+                                Write-Host "  ❌ Fix is NOT in VMR manifest yet (manifest is behind the fix)" -ForegroundColor Red
+                            }
+                            else {
+                                Write-Host "  ⚠️  Fix and manifest have diverged (status: $($ancestorCheck.status))" -ForegroundColor Yellow
+                            }
+                        }
+                    }
+
+                    # Now check if the PR's VMR snapshot includes this
+                    if ($vmrCommit) {
+                        Write-Host ""
+                        Write-Host "  Checking if fix is in the PR's VMR snapshot..." -ForegroundColor White
+
+                        $snapshotManifestUrl = "/repos/dotnet/dotnet/contents/src/source-manifest.json?ref=$vmrCommit"
+                        $snapshotManifest = Invoke-GitHubApi $snapshotManifestUrl
+                        if ($snapshotManifest -and $snapshotManifest.content) {
+                            $snapshotJson = ConvertFrom-Base64Content $snapshotManifest.content
+                            if ($snapshotJson) {
+                            $snapshotData = $snapshotJson | ConvertFrom-Json
+
+                            $snapshotEntry = $snapshotData.repositories | Where-Object {
+                                $_.remoteUri -match "${escapedRepo}(\.git)?$" -or $_.path -eq $traceRepo
+                            }
+
+                            if ($snapshotEntry) {
+                                $snapshotCommit = $snapshotEntry.commitSha
+                                Write-Status "PR snapshot commit" "$(Get-ShortSha $snapshotCommit) for $($snapshotEntry.path)"
+
+                                if ($snapshotCommit -eq $fixMergeCommit) {
+                                    Write-Host "  ✅ Fix IS in the PR's VMR snapshot" -ForegroundColor Green
+                                }
+                                else {
+                                    $snapshotCheck = Invoke-GitHubApi "/repos/$traceFullRepo/compare/$(Get-ShortSha $fixMergeCommit)...$(Get-ShortSha $snapshotCommit)"
+                                    if ($snapshotCheck) {
+                                        if ($snapshotCheck.status -eq "ahead" -or $snapshotCheck.status -eq "identical") {
+                                            Write-Host "  ✅ Fix is included in PR snapshot" -ForegroundColor Green
+                                        }
+                                        else {
+                                            Write-Host "  ❌ Fix is NOT in the PR's VMR snapshot" -ForegroundColor Red
+                                            Write-Host "  The PR needs a codeflow update to pick up this fix." -ForegroundColor Yellow
+                                        }
+                                    }
+                                }
+                            }
+                            }
+                        }
+                    }
+                }
+                else {
+                    Write-Warning "Could not find $traceRepo in VMR source-manifest.json"
+                }
+                }
+            }
+        }
+    }
+}
+
+# --- Step 7: Recommendations ---
+Write-Section "Recommendations"
+
+$issues = @()
+$recommendations = @()
+
+# Summarize issues
+if ($stalenessWarnings.Count -gt 0) {
+    $issues += "Staleness warning active — codeflow is blocked"
+}
+
+if ($vmrCommit -and $vmrHead -and $vmrCommit -ne $vmrHeadSha -and -not $vmrHeadSha.StartsWith($vmrCommit)) {
+    $issues += "VMR branch is ahead of PR snapshot ($aheadBy commits behind)"
+}
+
+if ($manualCommits -and $manualCommits.Count -gt 0) {
+    $issues += "$($manualCommits.Count) manual commit(s) on PR branch"
+}
+
+if ($issues.Count -eq 0) {
+    Write-Host "  ✅ CODEFLOW HEALTHY" -ForegroundColor Green
+    Write-Host "  The PR appears to be up to date with no issues detected."
+}
+else {
+    Write-Host "  ⚠️  CODEFLOW NEEDS ATTENTION" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "  Issues:" -ForegroundColor White
+    foreach ($issue in $issues) {
+        Write-Host "    • $issue" -ForegroundColor Yellow
+    }
+
+    Write-Host ""
+    Write-Host "  Options:" -ForegroundColor White
+
+    if ($stalenessWarnings.Count -gt 0 -and $manualCommits.Count -gt 0) {
+        Write-Host "    1. Merge as-is — keep manual commits, get remaining changes in next codeflow PR" -ForegroundColor White
+        Write-Host "    2. Force trigger — updates codeflow but may revert manual commits" -ForegroundColor White
+        if ($subscriptionId) {
+            Write-Host "       darc trigger-subscriptions --id $subscriptionId --force" -ForegroundColor DarkGray
+        }
+        Write-Host "    3. Close & reopen — loses manual commits, gets fresh codeflow" -ForegroundColor White
+    }
+    elseif ($stalenessWarnings.Count -gt 0) {
+        Write-Host "    1. Merge as-is — get remaining changes in next codeflow PR" -ForegroundColor White
+        Write-Host "    2. Close & reopen — gets fresh codeflow with all updates" -ForegroundColor White
+        Write-Host "    3. Force trigger — forces codeflow update into this PR" -ForegroundColor White
+        if ($subscriptionId) {
+            Write-Host "       darc trigger-subscriptions --id $subscriptionId --force" -ForegroundColor DarkGray
+        }
+    }
+    elseif ($manualCommits.Count -gt 0) {
+        Write-Host "    1. Wait — Maestro should auto-update (if not stale)" -ForegroundColor White
+        Write-Host "    2. Trigger manually — if auto-updates seem delayed" -ForegroundColor White
+        if ($subscriptionId) {
+            Write-Host "       darc trigger-subscriptions --id $subscriptionId" -ForegroundColor DarkGray
+        }
+    }
+    else {
+        Write-Host "    1. Wait — Maestro should auto-update the PR" -ForegroundColor White
+        Write-Host "    2. Trigger manually — if auto-updates seem delayed" -ForegroundColor White
+        if ($subscriptionId) {
+            Write-Host "       darc trigger-subscriptions --id $subscriptionId" -ForegroundColor DarkGray
+        }
+    }
+}

--- a/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
+++ b/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
@@ -195,7 +195,7 @@ if ($CheckMissing) {
 
         $vmrCommitFromPR = $null
         $vmrBranchFromPR = $null
-        if ($prDetail.body -match '\*\*Commit\*\*:\s*\[([a-f0-9]+)\]') {
+        if ($prDetail.body -match '\*\*Commit\*\*:\s*\[([a-fA-F0-9]+)\]') {
             $vmrCommitFromPR = $Matches[1]
         }
         if ($prDetail.body -match '\*\*Branch\*\*:\s*\[([^\]]+)\]') {
@@ -237,7 +237,7 @@ if ($CheckMissing) {
             Write-Host "    Last merged VMR commit: $(Get-ShortSha $vmrCommitFromPR)" -ForegroundColor DarkGray
 
             # Check how long ago the last PR merged
-            $mergedTime = [DateTime]::Parse($lastPR.closedAt)
+            $mergedTime = [DateTimeOffset]::Parse($lastPR.closedAt).UtcDateTime
             $elapsed = [DateTime]::UtcNow - $mergedTime
             if ($elapsed.TotalHours -gt 6) {
                 Write-Host "    ⚠️  Last PR merged $([math]::Round($elapsed.TotalHours, 1)) hours ago — Maestro may be stuck" -ForegroundColor Yellow
@@ -331,7 +331,7 @@ if ($body -match '\(Begin:([a-f0-9-]+)\)') {
 
 # Extract source commit (VMR commit for backflow, repo commit for forward flow)
 $sourceCommit = $null
-if ($body -match '\*\*Commit\*\*:\s*\[([a-f0-9]+)\]') {
+if ($body -match '\*\*Commit\*\*:\s*\[([a-fA-F0-9]+)\]') {
     $sourceCommit = $Matches[1]
     $commitLabel = if ($isForwardFlow) { "Source Commit" } else { "VMR Commit" }
     Write-Status $commitLabel $sourceCommit
@@ -668,7 +668,7 @@ if ($stalenessWarnings.Count -gt 0 -or $conflictWarnings.Count -gt 0) {
         }
 
         # Extract resolve command
-        if ($lastConflictComment.body -match '(darc vmr resolve-conflict --subscription [a-fA-F0-9-]+)') {
+        if ($lastConflictComment.body -match '(darc vmr resolve-conflict --subscription [a-fA-F0-9-]+(?:\s+--build [a-fA-F0-9-]+)?)') {
             Write-Host ""
             Write-Host "  Resolve command:" -ForegroundColor White
             Write-Host "    $($Matches[1])" -ForegroundColor DarkGray


### PR DESCRIPTION
## Summary

Adds a new Copilot Agent Skill (`.github/skills/vmr-codeflow-status/`) that automates analysis of VMR codeflow PR health for dotnet repositories. Handles both backflow (VMR → product repos) and forward flow (product repos → VMR).

### What it does

**PR Analysis Mode:**
1. **Parses PR metadata** — Extracts VMR commit, subscription ID, build info from the PR body
2. **Validates snapshot** — Cross-references PR body commit against branch "Backflow from" commit messages to detect stale metadata
3. **Checks freshness** — Compares PR's snapshot against the current source branch HEAD, showing how many commits behind and which repos have updates
4. **Shows pending forward flow** — For behind backflow PRs, finds open forward flow PRs that would close part of the freshness gap
5. **Detects staleness & conflicts** — Finds Maestro "codeflow cannot continue" warnings and "Conflict detected" messages (with conflicting files and resolve commands)
6. **Analyzes PR commits** — Categorizes commits as auto-updates vs manual (which would be lost on close/force-trigger)
7. **Traces fixes** (optional) — Checks if a specific fix PR has flowed through VMR into the codeflow PR
8. **Recommends actions** — Suggests force trigger, close/reopen, merge as-is, resolve conflicts, or wait, with ready-to-use darc commands

**Missing Backflow Mode:**
- Discovers all branches with backflow subscriptions by examining recently merged PRs
- Compares VMR branch HEAD against the last merged backflow commit
- Flags branches where the VMR has moved but no new backflow PR exists
- Warns when Maestro may be stuck (>6 hours since last merge with VMR ahead)

### Example Prompts

- "check the codeflow status of dotnet/sdk#52727"
- "is dotnet/runtime#124098 up to date with the VMR?"
- "has the runtime revert in dotnet/runtime#123974 reached the codeflow PR dotnet/sdk#52727?"
- "why is this codeflow PR blocked?"
- "are there any missing backflow PRs for dotnet/roslyn?"
- "report on the codeflow status for dotnet/aspnetcore"
- "what forward flow PRs are pending for the preview1 VMR branch?"

### Motivation

Investigating stale codeflow PRs is a common and tedious task — checking VMR freshness, finding staleness warnings, tracing whether specific fixes have flowed through. This skill automates the entire workflow and provides actionable darc commands.

Tested against 10+ codeflow PRs across dotnet/sdk, dotnet/runtime, dotnet/roslyn, dotnet/aspnetcore, and dotnet/dotnet on multiple branches (main, preview1, release/10.0.x).

### Files

- `SKILL.md` — Skill definition with frontmatter (matching existing skills in this repo)
- `scripts/Get-CodeflowStatus.ps1` — Main analysis script (~750 lines)
- `references/vmr-codeflow-reference.md` — Reference docs (VMR concepts, darc CLI, API endpoints)