### PR TITLE
Increase number of assertions (GlobalAP) + VN cache

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1380,7 +1380,7 @@ AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
     {
         bool mayHaveDuplicates =
             optAssertionHasAssertionsForVN(newAssertion.GetOp1().GetVN(), /* addIfNotFound */ canAddNewAssertions);
-        // We need to register op2.vn too, even if know for sure there are no duplicates
+        // We need to register op2.vn too, even if we know for sure there are no duplicates
         if (newAssertion.GetOp2().KindIs(O2K_CHECKED_BOUND_ADD_CNS))
         {
             mayHaveDuplicates |= optAssertionHasAssertionsForVN(newAssertion.GetOp2().GetCheckedBound(),

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -725,16 +725,14 @@ void Compiler::optAssertionInit(bool isLocalProp)
         optLocalAssertionProp           = false;
         optCrossBlockLocalAssertionProp = false;
 
-        // Use a function countFunc to determine a proper maximum assertion count for the
-        // method being compiled. The function is linear to the IL size for small and
-        // moderate methods. For large methods, considering throughput impact, we track no
-        // more than 64 assertions.
-        // Note this tracks at most only 256 assertions.
+        // Heuristic for sizing the assertion table.
         //
-        static const AssertionIndex countFunc[] = {64, 128, 256, 128, 64};
-        static const unsigned       upperBound  = ArrLen(countFunc) - 1;
-        const unsigned              codeSize    = info.compILCodeSize / 512;
-        optMaxAssertionCount                    = countFunc[min(upperBound, codeSize)];
+        // The weighting of basicBlocks vs locals reflects their relative contribution observed empirically.
+        // Validated against 1,115,046 compiled methods:
+        //   - 94.6% of methods stay at the floor of 64 (only 1.9% actually need more).
+        //   - Underpredicts for 481 methods (0.043%), with a worst-case deficit of 127.
+        //   - Only 0.4% of methods hit the 256 cap.
+        optMaxAssertionCount = (AssertionIndex)max(64, min(256, (int)(lvaTrackedCount + 3 * fgBBcount + 48) >> 2));
 
         optComplementaryAssertionMap = new (this, CMK_AssertionProp)
             AssertionIndex[optMaxAssertionCount + 1](); // zero-inited (NO_ASSERTION_INDEX)
@@ -1352,6 +1350,8 @@ bool Compiler::optIsTreeKnownIntValue(bool vnBased, GenTree* tree, ssize_t* pCon
  */
 AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
 {
+    bool canAddNewAssertions = optAssertionCount < optMaxAssertionCount;
+
     // See if we already have this assertion in the table.
     //
     // For local assertion prop we can speed things up by checking the dep vector.
@@ -1378,21 +1378,33 @@ AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
     }
     else
     {
-        // For global prop we search the entire table.
-        //
-        // Check if exists already, so we can skip adding new one. Search backwards.
-        for (AssertionIndex index = optAssertionCount; index >= 1; index--)
+        bool mayHaveDuplicates =
+            optAssertionHasAssertionsForVN(newAssertion.GetOp1().GetVN(), /* addIfNotFound */ canAddNewAssertions);
+        // We need to register op2.vn too, even if know for sure there are no duplicates
+        if (newAssertion.GetOp2().KindIs(O2K_CHECKED_BOUND_ADD_CNS))
         {
-            const AssertionDsc& curAssertion = optGetAssertion(index);
-            if (curAssertion.Equals(newAssertion, /* vnBased */ true))
+            mayHaveDuplicates |= optAssertionHasAssertionsForVN(newAssertion.GetOp2().GetCheckedBound(),
+                                                                /* addIfNotFound */ canAddNewAssertions);
+        }
+
+        if (mayHaveDuplicates)
+        {
+            // For global prop we search the entire table.
+            //
+            // Check if exists already, so we can skip adding new one. Search backwards.
+            for (AssertionIndex index = optAssertionCount; index >= 1; index--)
             {
-                return index;
+                const AssertionDsc& curAssertion = optGetAssertion(index);
+                if (curAssertion.Equals(newAssertion, /* vnBased */ true))
+                {
+                    return index;
+                }
             }
         }
     }
 
     // Check if we are within max count.
-    if (optAssertionCount >= optMaxAssertionCount)
+    if (!canAddNewAssertions)
     {
         optAssertionOverflow++;
         return NO_ASSERTION_INDEX;
@@ -1437,6 +1449,49 @@ AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
     optDebugCheckAssertions(optAssertionCount);
 #endif
     return optAssertionCount;
+}
+
+//------------------------------------------------------------------------
+// optAssertionHasAssertionsForVN: Check if we already have assertions for the given VN.
+//    If "addIfNotFound" is true, add the VN to the map if it's not already there.
+//
+// Arguments:
+//    vn            - the VN to check for
+//    addIfNotFound - whether to add the VN to the map if it's not found
+//
+// Return Value:
+//    true if we already have assertions for the given VN, false otherwise.
+//
+bool Compiler::optAssertionHasAssertionsForVN(ValueNum vn, bool addIfNotFound)
+{
+    assert(!optLocalAssertionProp);
+    if (vn == ValueNumStore::NoVN)
+    {
+        assert(!addIfNotFound);
+        return false;
+    }
+
+    if (addIfNotFound)
+    {
+        // Lazy initialize the map when we first need to add to it
+        if (optAssertionVNsMap == nullptr)
+        {
+            optAssertionVNsMap = new (this, CMK_AssertionProp) VNSet(getAllocator(CMK_AssertionProp));
+        }
+
+        // Avoid double lookup by using the return value of LookupPointerOrAdd to
+        // determine whether the VN was already in the map.
+        bool* pValue = optAssertionVNsMap->LookupPointerOrAdd(vn, false);
+        if (!*pValue)
+        {
+            *pValue = true;
+            return false;
+        }
+        return true;
+    }
+
+    // Otherwise just do a normal lookup
+    return (optAssertionVNsMap != nullptr) && optAssertionVNsMap->Lookup(vn);
 }
 
 #ifdef DEBUG
@@ -3275,11 +3330,17 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTreeL
     // For local assertion prop we can filter the assertion set down.
     //
     const unsigned lclNum = tree->GetLclNum();
+    ValueNum       treeVN = optConservativeNormalVN(tree);
 
     ASSERT_TP filteredAssertions = assertions;
     if (optLocalAssertionProp)
     {
         filteredAssertions = BitVecOps::Intersection(apTraits, GetAssertionDep(lclNum), filteredAssertions);
+    }
+    else if (!optAssertionHasAssertionsForVN(treeVN))
+    {
+        // There are no assertions for this VN
+        return nullptr;
     }
 
     BitVecOps::Iter iter(apTraits, filteredAssertions);
@@ -3342,7 +3403,7 @@ GenTree* Compiler::optAssertionProp_LclVar(ASSERT_VALARG_TP assertions, GenTreeL
         else
         {
             // Check VN in Global Assertion Prop
-            if (curAssertion.GetOp1().GetVN() == vnStore->VNConservativeNormalValue(tree->gtVNPair))
+            if (curAssertion.GetOp1().GetVN() == treeVN)
             {
                 return optConstantAssertionProp(curAssertion, tree, stmt DEBUGARG(assertionIndex));
             }
@@ -4607,7 +4668,7 @@ bool Compiler::optAssertionVNIsNonNull(ValueNum vn, ASSERT_VALARG_TP assertions)
         return true;
     }
 
-    if (!BitVecOps::MayBeUninit(assertions))
+    if (!BitVecOps::MayBeUninit(assertions) && optAssertionHasAssertionsForVN(vn))
     {
         BitVecOps::Iter iter(apTraits, assertions);
         unsigned        index = 0;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8410,7 +8410,8 @@ protected:
     JitExpandArray<ASSERT_TP>* optAssertionDep = nullptr; // table that holds dependent assertions (assertions
                                                           // using the value of a local var) for each local var
     AssertionDsc*  optAssertionTabPrivate;                // table that holds info about assertions
-    AssertionIndex optAssertionCount = 0;                 // total number of assertions in the assertion table
+    VNSet*         optAssertionVNsMap = nullptr;
+    AssertionIndex optAssertionCount  = 0; // total number of assertions in the assertion table
     AssertionIndex optMaxAssertionCount;
     bool           optCrossBlockLocalAssertionProp;
     unsigned       optAssertionOverflow;
@@ -8538,6 +8539,7 @@ public:
 
     bool optCreateJumpTableImpliedAssertions(BasicBlock* switchBb);
 
+    bool optAssertionHasAssertionsForVN(ValueNum vn, bool addIfNotFound = false);
 #ifdef DEBUG
     void optPrintAssertion(const AssertionDsc& newAssertion, AssertionIndex assertionIndex = 0);
     void optPrintAssertionIndex(AssertionIndex index);

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -889,7 +889,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         return;
     }
 
-    if (normalLclVN == ValueNumStore::NoVN)
+    if (!comp->optAssertionHasAssertionsForVN(normalLclVN))
     {
         return;
     }


### PR DESCRIPTION
[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1284439&view=ms.vss-build-web.run-extensions-tab)

This PR does two things:

1. Implements a quick O(1) check to answer: “Do we have any assertions for this VN?”
I initially tried to use this cache everywhere, but ended up keeping it only in a few places where it had a noticeable TP benefit. This change alone has zero size diffs and reduces the TP regression from change (2) by 2×.
2. Increases the maximum number of assertions (GlobalAP) using a heuristic.
With help from SPMI, I analyzed 1M methods and built a large table: `| BB count | TrackedLocals count | assertions created |`. I then fed it to an AI agent, which iterated for a while, generated some Python scripts, and proposed a heuristic (after several rounds of SPMI TP/size feedback). This is the best trade-off between improvements and TP regression that I was able to find. We could potentially incorporate more parameters (e.g., number of conditional blocks against null/constant, number of indirects), but I think the current version is good enough for now. 

<img width="914" height="351" alt="{3217F8D3-BE47-4C82-AA12-0281D51D519C}" src="https://github.com/user-attachments/assets/e76eb379-bfda-4792-9c5b-d918b29a6a62" />

_* I had 3 variants and ended up picking the 3rd one due to better TP results_ (obviously, less of =256 entities)

NOTE: If I unconditionally set `optMaxAssertionCount` to **256** the size diffs become ~8% better and TP regresses by 3x

The worst-case +0.3% TP regression should be more than covered by my earlier refactoring PRs that improved TP (the combined net effect should be around -0.5%).

<img width="1161" height="587" alt="image" src="https://github.com/user-attachments/assets/46cd5c6d-c2ac-4341-9d0f-0cf7a92c8164" />
Overall, TP-wise, the most expensive thing is the forward flow analysis