### PR TITLE
Add official build freshness check to vmr-codeflow-status skill

### DIFF
--- a/.github/skills/vmr-codeflow-status/SKILL.md
+++ b/.github/skills/vmr-codeflow-status/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: vmr-codeflow-status
 description: Analyze VMR codeflow PR status for dotnet repositories. Use when investigating stale codeflow PRs, checking if fixes have flowed through the VMR pipeline, or debugging dependency update issues in PRs authored by dotnet-maestro[bot].
+license: MIT
 ---
 
 # VMR Codeflow Status
@@ -8,6 +9,11 @@ description: Analyze VMR codeflow PR status for dotnet repositories. Use when in
 Analyze the health of VMR codeflow PRs in both directions:
 - **Backflow**: `dotnet/dotnet` → product repos (e.g., `dotnet/sdk`)
 - **Forward flow**: product repos → `dotnet/dotnet`
+
+## Prerequisites
+
+- **GitHub CLI (`gh`)** — must be installed and authenticated (`gh auth login`)
+- Run scripts **from the skill directory** or use the full path to the script
 
 ## When to Use This Skill
 
@@ -40,14 +46,14 @@ Use this skill when:
 
 ## Key Parameters
 
-| Parameter | Description |
-|-----------|-------------|
-| `-PRNumber` | GitHub PR number to analyze (required unless `-CheckMissing`) |
-| `-Repository` | Target repo in `owner/repo` format (default: `dotnet/sdk`) |
-| `-TraceFix` | Trace a repo PR through the pipeline (e.g., `dotnet/runtime#123974`) |
-| `-ShowCommits` | Show individual VMR commits between PR snapshot and branch HEAD |
-| `-CheckMissing` | Check overall flow health: missing backflow PRs and forward flow PR status |
-| `-Branch` | With `-CheckMissing`, only check a specific branch |
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `-PRNumber` | Yes (unless `-CheckMissing`) | — | GitHub PR number to analyze |
+| `-Repository` | No | `dotnet/sdk` | Target repo in `owner/repo` format |
+| `-TraceFix` | No | — | Trace a repo PR through the pipeline. Format: `owner/repo#number` (e.g., `dotnet/runtime#123974`) |
+| `-ShowCommits` | No | `$false` | Show individual VMR commits between PR snapshot and branch HEAD |
+| `-CheckMissing` | No | `$false` | Check overall flow health: missing backflow PRs, forward flow status, and official build freshness |
+| `-Branch` | No | — | With `-CheckMissing`, only check a specific branch (e.g., `main`, `release/10.0`) |
 
 ## What the Script Does
 
@@ -61,6 +67,7 @@ Use this skill when:
 8. **Recommends actions** — Suggests force trigger, close/reopen, merge as-is, resolve conflicts, or wait
 9. **Checks for missing backflow** (optional) — Finds branches where a backflow PR should exist but doesn't
 10. **Scans forward flow** (optional) — Checks open forward flow PRs into `dotnet/dotnet` for staleness and conflicts
+11. **Checks official build freshness** (optional) — When missing backflow is detected, queries `aka.ms` shortlinks to check when the last successful VMR build was published, helping diagnose whether Maestro is stuck or the VMR build is broken
 
 ## Interpreting Results
 
@@ -114,4 +121,5 @@ Install darc via `eng\common\darc-init.ps1` in any arcade-enabled repository.
 ## References
 
 - **VMR codeflow concepts**: See [references/vmr-codeflow-reference.md](references/vmr-codeflow-reference.md)
+- **VMR build topology & staleness diagnosis**: See [references/vmr-build-topology.md](references/vmr-build-topology.md) — explains how to diagnose widespread backflow staleness by checking VMR build health, the bootstrap chicken-and-egg problem, and the channel/subscription flow
 - **Codeflow PR documentation**: [dotnet/dotnet Codeflow-PRs.md](https://github.com/dotnet/dotnet/blob/main/docs/Codeflow-PRs.md)

--- a/.github/skills/vmr-codeflow-status/SKILL.md
+++ b/.github/skills/vmr-codeflow-status/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: vmr-codeflow-status
 description: Analyze VMR codeflow PR status for dotnet repositories. Use when investigating stale codeflow PRs, checking if fixes have flowed through the VMR pipeline, or debugging dependency update issues in PRs authored by dotnet-maestro[bot].
-license: MIT
 ---
 
 # VMR Codeflow Status

--- a/.github/skills/vmr-codeflow-status/references/vmr-build-topology.md
+++ b/.github/skills/vmr-codeflow-status/references/vmr-build-topology.md
@@ -62,6 +62,7 @@ $client = [System.Net.Http.HttpClient]::new($handler)
 # Step 1: Resolve aka.ms → ci.dot.net blob URL
 $resp = $client.GetAsync("https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-win-x64.zip").Result
 $blobUrl = $resp.Headers.Location.ToString()  # Only if StatusCode is 301
+$resp.Dispose()
 
 # Step 2: HEAD the blob for Last-Modified
 $head = Invoke-WebRequest -Uri $blobUrl -Method Head -UseBasicParsing
@@ -69,6 +70,7 @@ $published = [DateTimeOffset]::Parse($head.Headers['Last-Modified']).UtcDateTime
 $age = [DateTime]::UtcNow - $published
 
 $client.Dispose()
+$handler.Dispose()
 ```
 
 ### Interpreting results

--- a/.github/skills/vmr-codeflow-status/references/vmr-build-topology.md
+++ b/.github/skills/vmr-codeflow-status/references/vmr-build-topology.md
@@ -1,0 +1,250 @@
+# VMR Build Topology and Staleness Diagnosis
+
+## Overview
+
+When backflow PRs are missing across multiple repositories simultaneously, the root cause
+is usually not Maestro — it's that the VMR can't build successfully, so no new channel
+builds are produced, and subscriptions have nothing to trigger on.
+
+This reference explains how to diagnose that situation using publicly available signals.
+
+## Build Pipeline Structure
+
+The VMR (`dotnet/dotnet`) has two tiers of builds:
+
+### Public CI (validation only)
+- **AzDO org**: `dnceng-public`
+- **Project**: `public` (ID: `cbb18261-c48f-4abb-8651-8cdcb5474649`)
+- **Pipeline**: `dotnet-unified-build` (definition 278)
+- **Purpose**: Validates PRs and runs scheduled CI on `refs/heads/main` and release branches
+- **Does NOT publish** to Maestro channels — cannot trigger subscriptions
+
+### Official builds (channel publishing)
+- **AzDO org**: `dnceng` (internal, requires auth)
+- **Purpose**: Produces signed builds that publish to Maestro channels (e.g., `.NET 11.0.1xx SDK`)
+- **These are the builds that trigger Maestro subscriptions and create backflow PRs**
+- Not queryable without internal access
+
+### Key insight
+When investigating stale backflow, the **public CI builds are a useful proxy**. If the public
+scheduled build on `refs/heads/main` is failing, the official build is almost certainly
+failing too (they build the same source). A string of failed public builds strongly suggests
+the official pipeline is also broken.
+
+## Checking Official Build Freshness (aka.ms)
+
+The most direct way to check if official VMR builds are producing output is to query
+the SDK blob storage via `aka.ms` shortlinks. When official builds succeed, they publish
+SDK artifacts to `ci.dot.net`. We can check when the latest build was published.
+
+### How it works
+
+1. Resolve the aka.ms redirect (returns 301 with the blob URL):
+   ```
+   https://aka.ms/dotnet/{channel}/daily/dotnet-sdk-win-x64.zip
+   ```
+   Example channels: `11.0.1xx`, `11.0.1xx-preview1`, `10.0.3xx`, `10.0.1xx`
+
+2. The 301 Location header gives the actual blob URL on `ci.dot.net`, which includes
+   the version number in the path.
+
+3. HEAD the blob URL — the `Last-Modified` header tells you exactly when the build was
+   published.
+
+### Example (PowerShell)
+
+```powershell
+Add-Type -AssemblyName System.Net.Http
+$handler = [System.Net.Http.HttpClientHandler]::new()
+$handler.AllowAutoRedirect = $false
+$client = [System.Net.Http.HttpClient]::new($handler)
+
+# Step 1: Resolve aka.ms → ci.dot.net blob URL
+$resp = $client.GetAsync("https://aka.ms/dotnet/11.0.1xx/daily/dotnet-sdk-win-x64.zip").Result
+$blobUrl = $resp.Headers.Location.ToString()  # Only if StatusCode is 301
+
+# Step 2: HEAD the blob for Last-Modified
+$head = Invoke-WebRequest -Uri $blobUrl -Method Head -UseBasicParsing
+$published = [DateTimeOffset]::Parse($head.Headers['Last-Modified']).UtcDateTime
+$age = [DateTime]::UtcNow - $published
+
+$client.Dispose()
+```
+
+### Interpreting results
+- **< 1 day old**: Official builds are healthy for this channel
+- **1-2 days old**: Normal for daily builds, especially over weekends
+- **3+ days old**: Official builds are likely failing — investigate further
+- **Multiple channels stale simultaneously**: Strong signal of a systemic VMR build problem
+
+### Validating with darc (when auth is available)
+
+The aka.ms approach is an auth-free proxy. When `darc` is installed and authenticated,
+you can get the authoritative answer directly from Maestro:
+
+```bash
+# Latest build on a channel (exact match for what triggers subscriptions)
+darc get-latest-build --repo dotnet/dotnet --channel ".NET 11.0.1xx SDK"
+
+# Check what build a subscription last acted on
+darc get-subscriptions --source-repo dotnet/dotnet --target-repo dotnet/aspnetcore
+```
+
+The `Date Produced` from `darc get-latest-build` will be ~6 hours earlier than the
+aka.ms blob `Last-Modified` (due to signing/publishing delay), but they refer to the
+same build. If the subscription's `Last Build` SHA matches the channel's latest build,
+then Maestro already fired — no newer builds exist.
+
+### Channel-to-branch mapping
+
+| Channel | VMR branch | Backflow targets |
+|---------|-----------|-----------------|
+| `11.0.1xx` | `main` | runtime, sdk, aspnetcore (main) |
+| `11.0.1xx-preview1` | `release/11.0.1xx-preview1` | runtime, sdk, aspnetcore (preview) |
+| `10.0.3xx` | `release/10.0.3xx` | sdk (release/10.0.3xx) |
+| `10.0.2xx` | `release/10.0.2xx` | sdk (release/10.0.2xx) |
+| `10.0.1xx` | `release/10.0.1xx` | runtime, sdk, aspnetcore (release/10.0) |
+
+### Cross-referencing with Version.Details.xml and PR metadata
+
+There are two sources of truth for what VMR build a repo is synced to:
+
+**1. `eng/Version.Details.xml` in the target repo (authoritative):**
+```xml
+<Source Uri="https://github.com/dotnet/dotnet" Mapping="sdk"
+  Sha="ec846aee7f12180381c444dfeeba0c5022e1d110" BarId="297974" />
+```
+- `Sha` = the exact VMR commit the repo is synced to
+- `BarId` = the Maestro build ID (queryable via `darc get-build --id 297974` for date/channel)
+- Dependency version strings encode build dates (e.g., `26069.105` → year 26, day-code 069)
+
+**2. Backflow PR body (when a PR is open):**
+```
+- **Date Produced**: February 4, 2026 11:05:10 AM UTC
+- **Build**: [20260203.11](...) ([300217](https://maestro.dot.net/channel/8298/.../build/300217))
+```
+
+**Comparing against aka.ms build date:**
+- If they match → the backflow PR is based on the latest successful build
+- If the aka.ms build is newer → a newer build succeeded but hasn't triggered backflow yet
+- If the aka.ms build matches the PR but is old → no new successful builds since
+
+## Querying Public VMR CI Builds
+
+Public CI builds (separate from official builds) can confirm whether the VMR source is
+buildable. These don't publish to channels but use the same source.
+
+### AzDO REST API endpoints
+
+Recent scheduled builds on a branch:
+```
+GET https://dev.azure.com/dnceng-public/public/_apis/build/builds?definitions=278&branchName=refs/heads/main&$top=5&api-version=7.0
+```
+
+Last successful build:
+```
+GET https://dev.azure.com/dnceng-public/public/_apis/build/builds?definitions=278&branchName=refs/heads/main&resultFilter=succeeded&$top=1&api-version=7.0
+```
+
+Build timeline (to find failing jobs):
+```
+GET https://dev.azure.com/dnceng-public/public/_apis/build/builds/{buildId}/timeline?api-version=7.0
+```
+
+### Interpreting results
+- **`reason: schedule`** — Scheduled daily builds, closest proxy to official builds
+- **`reason: pullRequest`** — PR validation only
+- **`result: failed`** with consecutive scheduled builds — strong signal of broken VMR
+- Check the timeline for which jobs/stages failed to understand the root cause
+
+## Diagnosing Widespread Backflow Staleness
+
+### Pattern: Multiple repos missing backflow simultaneously
+
+When `CheckMissing` shows missing backflow across 3+ repos (e.g., runtime, SDK, aspnetcore
+all stale), this is almost always a VMR build problem, not a Maestro problem.
+
+**Diagnosis steps:**
+
+1. **Check public VMR builds**: Query the last 5 scheduled builds on the affected branch.
+   If all are failing, the VMR build is broken.
+
+2. **Find the failure**: Get the timeline of the most recent failed build. Look for failed
+   stages/jobs — common failures include:
+   - **macOS signing** (SignTool crashes on non-PE files)
+   - **Windows build** (individual repo build failures within the VMR)
+   - **Source-build validation** (packaging or dependency issues)
+
+3. **Check for known issues**: Search `dotnet/dotnet` issues with label `[Operational Issue]`
+   or search for the error message.
+
+4. **Check the last successful build date**: A gap of days or weeks confirms the VMR has been
+   broken for an extended period.
+
+### Pattern: Single repo missing backflow
+
+When only one repo is missing backflow but others are healthy, the issue is more likely:
+- Maestro subscription disabled or misconfigured
+- The specific repo's forward flow is blocking (conflict or staleness)
+- Channel mismatch
+
+Use `darc get-subscriptions --source-repo dotnet/dotnet --target-repo dotnet/<repo>` to check.
+
+## The Bootstrap / Chicken-and-Egg Problem
+
+The VMR builds arcade and other infrastructure from source. When an infrastructure fix
+(e.g., in `dotnet/arcade`) is needed to unblock the VMR build itself, a circular dependency
+can occur:
+
+1. Arcade fix merges in `dotnet/arcade`
+2. Arcade forward-flows to VMR (`dotnet/dotnet`)
+3. VMR now has the fix **in source**, but the build tooling used to build may still be the
+   old version (from a previous successful bootstrap)
+4. The build fails because the **bootstrap SDK** (cached from a prior build) doesn't have
+   the fix yet
+
+**Resolution** (by VMR maintainers):
+- Re-bootstrap: Build a new `source-built-sdks` package from a working state
+- Manual intervention: Patch the bootstrap or skip the failing step
+- Wait for a full re-bootstrap cycle after a milestone release
+
+This is not something that can be fixed by triggering subscriptions or resolving conflicts.
+When you see this pattern, flag it as needing VMR infrastructure team intervention.
+
+## Channels and Subscription Flow
+
+```
+dotnet/arcade ──forward flow──► dotnet/dotnet (VMR)
+dotnet/runtime ─forward flow──► dotnet/dotnet (VMR)
+dotnet/sdk ────forward flow──► dotnet/dotnet (VMR)
+    ...other repos...
+
+dotnet/dotnet (VMR)
+    │
+    ├── official build succeeds
+    │       │
+    │       ▼
+    │   publishes to channel (e.g., ".NET 11.0.1xx SDK")
+    │       │
+    │       ▼
+    │   Maestro fires subscriptions
+    │       │
+    │       ├──► dotnet/runtime backflow PR
+    │       ├──► dotnet/sdk backflow PR
+    │       ├──► dotnet/aspnetcore backflow PR
+    │       └──► ...etc
+    │
+    └── official build FAILS
+            │
+            ▼
+        nothing publishes → no subscriptions fire → all backflow stalls
+```
+
+## Quick Reference: Common VMR Build Failures
+
+| Failure | Symptom | Root cause |
+|---------|---------|------------|
+| SignTool crash | `Unknown file format` in Sign.proj on macOS | Non-PE file in signing input (e.g., tar.gz) |
+| Repo build failure | `error MSB...` in a specific repo's build | Source incompatibility within VMR |
+| Source-build validation | Packaging or prebuilt detection errors | New prebuilt dependency introduced |
+| Infrastructure timeout | Build exceeds time limit | Resource contention or build perf regression |

--- a/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
+++ b/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
@@ -126,8 +126,10 @@ function Get-VMRBuildFreshness {
                     if ([int]$resp.StatusCode -eq 301 -and $resp.Headers.Location) {
                         $channel = $ch
                         $blobUrl = $resp.Headers.Location.ToString()
+                        $resp.Dispose()
                         break
                     }
+                    $resp.Dispose()
                 } catch { }
             }
         }
@@ -144,9 +146,11 @@ function Get-VMRBuildFreshness {
         if (-not $blobUrl) {
             $resp = $client.GetAsync("https://aka.ms/dotnet/$channel/daily/dotnet-sdk-win-x64.zip").Result
             if ([int]$resp.StatusCode -ne 301 -or -not $resp.Headers.Location) {
+                $resp.Dispose()
                 return $null
             }
             $blobUrl = $resp.Headers.Location.ToString()
+            $resp.Dispose()
         }
 
         $version = if ($blobUrl -match '/Sdk/([^/]+)/') { $Matches[1] } else { $null }

--- a/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
+++ b/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
@@ -316,7 +316,8 @@ if ($CheckMissing) {
                     $ageStr = if ($ageDays -ge 1) { "$([math]::Round($ageDays, 1))d" } else { "$([math]::Round($freshness.Age.TotalHours, 1))h" }
                     $color = if ($ageDays -gt 3) { 'Red' } elseif ($ageDays -gt 1) { 'Yellow' } else { 'Green' }
                     $versionStr = if ($freshness.Version) { $freshness.Version } else { "unknown" }
-                    Write-Host "  $($freshness.Channel.PadRight(25)) $($versionStr.PadRight(48)) $($freshness.Published.ToString('yyyy-MM-dd HH:mm')) UTC  ($ageStr ago)" -ForegroundColor $color
+                    $branchLabel = "$($entry.Key) → $($freshness.Channel)"
+                    Write-Host "  $($branchLabel.PadRight(40)) $($versionStr.PadRight(48)) $($freshness.Published.ToString('yyyy-MM-dd HH:mm')) UTC  ($ageStr ago)" -ForegroundColor $color
                     if ($ageDays -gt 3) { $anyVeryStale = $true }
                 }
             }
@@ -432,7 +433,8 @@ if ($CheckMissing) {
                 $ageStr = if ($ageDays -ge 1) { "$([math]::Round($ageDays, 1))d" } else { "$([math]::Round($freshness.Age.TotalHours, 1))h" }
                 $color = if ($ageDays -gt 3) { 'Red' } elseif ($ageDays -gt 1) { 'Yellow' } else { 'Green' }
                 $versionStr = if ($freshness.Version) { $freshness.Version } else { "unknown" }
-                Write-Host "  $($freshness.Channel.PadRight(25)) $($versionStr.PadRight(48)) $($freshness.Published.ToString('yyyy-MM-dd HH:mm')) UTC  ($ageStr ago)" -ForegroundColor $color
+                $branchLabel = "$($entry.Key) → $($freshness.Channel)"
+                Write-Host "  $($branchLabel.PadRight(40)) $($versionStr.PadRight(48)) $($freshness.Published.ToString('yyyy-MM-dd HH:mm')) UTC  ($ageStr ago)" -ForegroundColor $color
                 if ($ageDays -gt 3) { $buildsAreStale = $true }
             }
         }

--- a/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
+++ b/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
@@ -458,7 +458,8 @@ if ($CheckMissing) {
         if ($openBranches.ContainsKey($branchName)) {
             $bfHealth = Get-CodeflowPRHealth -PRNumber $openBranches[$branchName] -Repo $Repository
             Write-Host "    Open backflow PR #$($openBranches[$branchName]): $($bfHealth.Status)" -ForegroundColor $bfHealth.Color
-            if ($bfHealth.HasConflict -or $bfHealth.HasStaleness) { $blockedCount++ } else { $coveredCount++ }
+            if ($bfHealth.HasConflict -or $bfHealth.HasStaleness) { $blockedCount++ }
+            elseif ($bfHealth.Status -notlike '*Unknown*') { $coveredCount++ }
             continue
         }
 
@@ -547,7 +548,8 @@ if ($CheckMissing) {
             Write-Host "  Branch: $branchName" -ForegroundColor White
             $bfHealth = Get-CodeflowPRHealth -PRNumber $openBranches[$branchName] -Repo $Repository
             Write-Host "    Open backflow PR #$($openBranches[$branchName]): $($bfHealth.Status)" -ForegroundColor $bfHealth.Color
-            if ($bfHealth.HasConflict -or $bfHealth.HasStaleness) { $blockedCount++ } else { $coveredCount++ }
+            if ($bfHealth.HasConflict -or $bfHealth.HasStaleness) { $blockedCount++ }
+            elseif ($bfHealth.Status -notlike '*Unknown*') { $coveredCount++ }
         }
     }
 
@@ -580,7 +582,7 @@ if ($CheckMissing) {
 
             if ($fwdHealth.HasConflict) { $fwdConflict++ }
             elseif ($fwdHealth.HasStaleness) { $fwdStale++ }
-            else { $fwdHealthy++ }
+            elseif ($fwdHealth.Status -notlike '*Unknown*') { $fwdHealthy++ }
 
             Write-Host "  PR #$($fpr.number) [$fprBranch]: $($fwdHealth.Status)" -ForegroundColor $fwdHealth.Color
             Write-Host "    https://github.com/dotnet/dotnet/pull/$($fpr.number)" -ForegroundColor DarkGray


### PR DESCRIPTION
## Summary

Adds official build freshness checking, improved conflict/staleness detection, and better diagnostic output to the vmr-codeflow-status Copilot skill.

### Motivation

When investigating widespread backflow staleness across dotnet repos, the root cause is often broken VMR official builds — not Maestro subscription issues. The skill previously had no way to surface this, leading to misleading "Maestro may be stuck" warnings. Open backflow PRs were also reported as healthy even when they had unresolved conflicts.

## Changes

### Build freshness check (`Get-VMRBuildFreshness`)
- Queries `aka.ms/dotnet/{channel}/daily/dotnet-sdk-win-x64.zip` (301 redirect → ci.dot.net blob)
- HEADs the blob to get `Last-Modified` timestamp = last successful official build publish
- Maps VMR branches to aka.ms channels (main, preview, release)
- Uses `HttpClient` throughout (no `Invoke-WebRequest` mixing), 15-second timeouts, proper disposal
- Shown **before** per-branch analysis so users understand upstream context first

### Smarter conflict/staleness detection (`Get-CodeflowPRHealth`)
- Shared helper checks both backflow and forward flow PRs
- Detects conflict/staleness from Maestro comments, then checks Codeflow verification status
- Correctly distinguishes active conflicts from resolved ones ("✅ Conflict resolved")
- Staleness resolution requires commits after the warning (not just Codeflow verification)
- Open backflow PRs are now checked for health (previously just "✅ exists")

### Better diagnostic messaging
- When builds are stale: "backflow blocked upstream" instead of "Maestro may be stuck"
- `dotnet/dotnet` self-check skips nonsensical self-backflow, shows only build freshness
- Forward flow shows resolution status: "Conflict resolved", "Updated since staleness warning"

### New: references/vmr-build-topology.md
Reference doc covering build pipeline structure, aka.ms technique, channel mapping, Version.Details.xml cross-referencing, darc validation, diagnosis patterns, bootstrap problem, and common failures.

### Bug fixes
- Merged PR selection uses `closedAt` comparison (not `gh search --sort updated` order)
- `gh search` failures warn explicitly instead of silently treating as empty results
- `HttpResponseMessage` objects properly disposed in all code paths

### SKILL.md
- Added Prerequisites section
- Expanded Key Parameters table
- Documented build freshness check in "What the Script Does"
