### PR TITLE
Lower GT_RETURN_SUSPEND blocks to BBJ_RETURN

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6054,6 +6054,33 @@ void Lowering::LowerReturnSuspend(GenTree* node)
     {
         InsertPInvokeMethodEpilog(m_compiler->compCurBB DEBUGARG(node));
     }
+
+    BasicBlock* block = m_compiler->compCurBB;
+    if (!block->KindIs(BBJ_RETURN))
+    {
+        bool profileInconsistent = false;
+        for (BasicBlock* const succBlock : block->Succs())
+        {
+            FlowEdge* const succEdge = m_compiler->fgRemoveAllRefPreds(succBlock, block);
+
+            if (block->hasProfileWeight() && succBlock->hasProfileWeight())
+            {
+                succBlock->decreaseBBProfileWeight(succEdge->getLikelyWeight());
+                profileInconsistent |= (succBlock->NumSucc() > 0);
+            }
+        }
+
+        if (profileInconsistent)
+        {
+            JITDUMP("Flow removal of " FMT_BB " needs to be propagated. Data %s inconsistent.\n", block->bbNum,
+                    m_compiler->fgPgoConsistent ? "is now" : "was already");
+            m_compiler->fgPgoConsistent = false;
+        }
+
+        block->SetKind(BBJ_RETURN);
+
+        m_compiler->fgInvalidateDfsTree();
+    }
 }
 
 //----------------------------------------------------------------------------------------------

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6050,11 +6050,6 @@ void Lowering::LowerReturnSuspend(GenTree* node)
         BlockRange().Remove(BlockRange().LastNode(), true);
     }
 
-    if (m_compiler->compMethodRequiresPInvokeFrame())
-    {
-        InsertPInvokeMethodEpilog(m_compiler->compCurBB DEBUGARG(node));
-    }
-
     BasicBlock* block = m_compiler->compCurBB;
     if (!block->KindIs(BBJ_RETURN))
     {
@@ -6080,6 +6075,11 @@ void Lowering::LowerReturnSuspend(GenTree* node)
         block->SetKindAndTargetEdge(BBJ_RETURN);
 
         m_compiler->fgInvalidateDfsTree();
+    }
+
+    if (m_compiler->compMethodRequiresPInvokeFrame())
+    {
+        InsertPInvokeMethodEpilog(m_compiler->compCurBB DEBUGARG(node));
     }
 }
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -6077,7 +6077,7 @@ void Lowering::LowerReturnSuspend(GenTree* node)
             m_compiler->fgPgoConsistent = false;
         }
 
-        block->SetKind(BBJ_RETURN);
+        block->SetKindAndTargetEdge(BBJ_RETURN);
 
         m_compiler->fgInvalidateDfsTree();
     }


### PR DESCRIPTION
When the AsyncSuspend intrinsic is used we can end up with GT_RETURN_SUSPEND present in a block that is not `BBJ_RETURN`. That would happen for instance because of return merging due to ELT profiler hooks.

Expand the lowering for this node to convert the block containing `GT_RETURN_SUSPEND` into a `BBJ_RETURN` block.

Fix #124162