### PR TITLE
JIT: Enable inlining of runtime async methods without awaits

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -184,9 +184,17 @@ PhaseStatus Compiler::SaveAsyncContexts()
 
     // Insert RestoreContexts call in fault (exceptional case)
     // First argument: started = (continuation == null)
-    GenTree* continuation = gtNewLclvNode(lvaAsyncContinuationArg, TYP_REF);
-    GenTree* null         = gtNewNull();
-    GenTree* resumed      = gtNewOperNode(GT_NE, TYP_INT, continuation, null);
+    GenTree* resumed;
+    if (compIsForInlining())
+    {
+        resumed = gtNewFalse();
+    }
+    else
+    {
+        GenTree* continuation = gtNewLclvNode(lvaAsyncContinuationArg, TYP_REF);
+        GenTree* null         = gtNewNull();
+        resumed      = gtNewOperNode(GT_NE, TYP_INT, continuation, null);
+    }
 
     GenTreeCall* restoreCall = gtNewCallNode(CT_USER_FUNC, asyncInfo->restoreContextsMethHnd, TYP_VOID);
     restoreCall->gtArgs.PushFront(this,
@@ -205,7 +213,10 @@ PhaseStatus Compiler::SaveAsyncContexts()
 
     for (BasicBlock* block : Blocks())
     {
-        AddContextArgsToAsyncCalls(block);
+        if (!compIsForInlining())
+        {
+            AddContextArgsToAsyncCalls(block);
+        }
 
         if (!block->KindIs(BBJ_RETURN) || (block == newReturnBB))
         {
@@ -220,23 +231,28 @@ PhaseStatus Compiler::SaveAsyncContexts()
             newReturnBB->inheritWeightPercentage(block, 0);
         }
 
-        // Store return value to common local
-        Statement* retStmt = block->lastStmt();
-        assert((retStmt != nullptr) && retStmt->GetRootNode()->OperIs(GT_RETURN));
-
-        if (mergedReturnLcl != BAD_VAR_NUM)
+        // When inlining we do merging during import, so we do not need to do
+        // any storing there.
+        if (!compIsForInlining())
         {
-            GenTree*   retVal      = retStmt->GetRootNode()->AsOp()->GetReturnValue();
-            Statement* insertAfter = retStmt;
-            GenTree*   storeRetVal =
-                gtNewTempStore(mergedReturnLcl, retVal, CHECK_SPILL_NONE, &insertAfter, retStmt->GetDebugInfo(), block);
-            Statement* storeStmt = fgNewStmtFromTree(storeRetVal);
-            fgInsertStmtAtEnd(block, storeStmt);
-            JITDUMP("Inserted store to common return local\n");
-            DISPSTMT(storeStmt);
-        }
+            // Store return value to common local
+            Statement* retStmt = block->lastStmt();
+            assert((retStmt != nullptr) && retStmt->GetRootNode()->OperIs(GT_RETURN));
 
-        retStmt->GetRootNode()->gtBashToNOP();
+            if (mergedReturnLcl != BAD_VAR_NUM)
+            {
+                GenTree*   retVal      = retStmt->GetRootNode()->AsOp()->GetReturnValue();
+                Statement* insertAfter = retStmt;
+                GenTree*   storeRetVal =
+                    gtNewTempStore(mergedReturnLcl, retVal, CHECK_SPILL_NONE, &insertAfter, retStmt->GetDebugInfo(), block);
+                Statement* storeStmt = fgNewStmtFromTree(storeRetVal);
+                fgInsertStmtAtEnd(block, storeStmt);
+                JITDUMP("Inserted store to common return local\n");
+                DISPSTMT(storeStmt);
+            }
+
+            retStmt->GetRootNode()->gtBashToNOP();
+        }
 
         // Jump to new shared restore + return block
         block->SetKindAndTargetEdge(BBJ_ALWAYS, fgAddRefPred(newReturnBB, block));
@@ -334,9 +350,17 @@ BasicBlock* Compiler::CreateReturnBB(unsigned* mergedReturnLcl)
     // Insert "restore" call
     CORINFO_ASYNC_INFO* asyncInfo = eeGetAsyncInfo();
 
-    GenTree* continuation = gtNewLclvNode(lvaAsyncContinuationArg, TYP_REF);
-    GenTree* null         = gtNewNull();
-    GenTree* resumed      = gtNewOperNode(GT_NE, TYP_INT, continuation, null);
+    GenTree* resumed;
+    if (compIsForInlining())
+    {
+        resumed = gtNewFalse();
+    }
+    else
+    {
+        GenTree* continuation = gtNewLclvNode(lvaAsyncContinuationArg, TYP_REF);
+        GenTree* null         = gtNewNull();
+        resumed      = gtNewOperNode(GT_NE, TYP_INT, continuation, null);
+    }
 
     GenTreeCall* restoreCall = gtNewCallNode(CT_USER_FUNC, asyncInfo->restoreContextsMethHnd, TYP_VOID);
     restoreCall->gtArgs.PushFront(this,

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -183,7 +183,7 @@ PhaseStatus Compiler::SaveAsyncContexts()
     }
 
     // Insert RestoreContexts call in fault (exceptional case)
-    // First argument: started = (continuation == null)
+    // First argument: resumed = (continuation != null)
     GenTree* resumed;
     if (compIsForInlining())
     {

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -193,7 +193,7 @@ PhaseStatus Compiler::SaveAsyncContexts()
     {
         GenTree* continuation = gtNewLclvNode(lvaAsyncContinuationArg, TYP_REF);
         GenTree* null         = gtNewNull();
-        resumed      = gtNewOperNode(GT_NE, TYP_INT, continuation, null);
+        resumed               = gtNewOperNode(GT_NE, TYP_INT, continuation, null);
     }
 
     GenTreeCall* restoreCall = gtNewCallNode(CT_USER_FUNC, asyncInfo->restoreContextsMethHnd, TYP_VOID);
@@ -243,9 +243,9 @@ PhaseStatus Compiler::SaveAsyncContexts()
             {
                 GenTree*   retVal      = retStmt->GetRootNode()->AsOp()->GetReturnValue();
                 Statement* insertAfter = retStmt;
-                GenTree*   storeRetVal =
-                    gtNewTempStore(mergedReturnLcl, retVal, CHECK_SPILL_NONE, &insertAfter, retStmt->GetDebugInfo(), block);
-                Statement* storeStmt = fgNewStmtFromTree(storeRetVal);
+                GenTree*   storeRetVal = gtNewTempStore(mergedReturnLcl, retVal, CHECK_SPILL_NONE, &insertAfter,
+                                                        retStmt->GetDebugInfo(), block);
+                Statement* storeStmt   = fgNewStmtFromTree(storeRetVal);
                 fgInsertStmtAtEnd(block, storeStmt);
                 JITDUMP("Inserted store to common return local\n");
                 DISPSTMT(storeStmt);
@@ -359,7 +359,7 @@ BasicBlock* Compiler::CreateReturnBB(unsigned* mergedReturnLcl)
     {
         GenTree* continuation = gtNewLclvNode(lvaAsyncContinuationArg, TYP_REF);
         GenTree* null         = gtNewNull();
-        resumed      = gtNewOperNode(GT_NE, TYP_INT, continuation, null);
+        resumed               = gtNewOperNode(GT_NE, TYP_INT, continuation, null);
     }
 
     GenTreeCall* restoreCall = gtNewCallNode(CT_USER_FUNC, asyncInfo->restoreContextsMethHnd, TYP_VOID);

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -3455,7 +3455,7 @@ void Compiler::fgFindBasicBlocks()
 
     // Are there any exception handlers?
     //
-    if (info.compXcptnsCount > 0)
+    if (info.compXcptnsCount > 0 || ((info.compMethodInfo->options & CORINFO_ASYNC_SAVE_CONTEXTS) != 0))
     {
         assert(!compIsForInlining() || opts.compInlineMethodsWithEH);
 

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -3464,7 +3464,14 @@ void Compiler::fgFindBasicBlocks()
             // Verify we can expand the EH table as needed to incorporate the callee's EH clauses.
             // Failing here should be extremely rare.
             //
-            EHblkDsc* const dsc = fgTryAddEHTableEntries(0, info.compXcptnsCount, /* deferAdding */ true);
+            unsigned numEHEntries = info.compXcptnsCount;
+            // We will introduce another EH clause in the inlinee to restore async contexts
+            if ((info.compMethodInfo->options & CORINFO_ASYNC_SAVE_CONTEXTS) != 0)
+            {
+                numEHEntries++;
+            }
+
+            EHblkDsc* const dsc = fgTryAddEHTableEntries(0, numEHEntries, /* deferAdding */ true);
             if (dsc == nullptr)
             {
                 compInlineResult->NoteFatal(InlineObservation::CALLSITE_EH_TABLE_FULL);

--- a/src/coreclr/jit/fgbasic.cpp
+++ b/src/coreclr/jit/fgbasic.cpp
@@ -3465,7 +3465,7 @@ void Compiler::fgFindBasicBlocks()
             // Failing here should be extremely rare.
             //
             unsigned numEHEntries = info.compXcptnsCount;
-            // We will introduce another EH clause in the inlinee to restore async contexts
+            // We will introduce another EH clause before inlining finishes to restore async contexts
             if ((info.compMethodInfo->options & CORINFO_ASYNC_SAVE_CONTEXTS) != 0)
             {
                 numEHEntries++;

--- a/src/coreclr/jit/inline.def
+++ b/src/coreclr/jit/inline.def
@@ -56,6 +56,7 @@ INLINE_OBSERVATION(STACK_CRAWL_MARK,          bool,   "uses stack crawl mark",  
 INLINE_OBSERVATION(STFLD_NEEDS_HELPER,        bool,   "stfld needs helper",                   FATAL,       CALLEE)
 INLINE_OBSERVATION(TOO_MANY_ARGUMENTS,        bool,   "too many arguments",                   FATAL,       CALLEE)
 INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",                      FATAL,       CALLEE)
+INLINE_OBSERVATION(AWAIT,                     bool,   "has await",                            FATAL,       CALLEE)
 
 // ------ Callee Performance -------
 
@@ -161,7 +162,6 @@ INLINE_OBSERVATION(RETURN_TYPE_MISMATCH,      bool,   "return type mismatch",   
 INLINE_OBSERVATION(STFLD_NEEDS_HELPER,        bool,   "stfld needs helper",                   FATAL,       CALLSITE)
 INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",                      FATAL,       CALLSITE)
 INLINE_OBSERVATION(PINVOKE_EH,                bool,   "PInvoke call site with EH",            FATAL,       CALLSITE)
-INLINE_OBSERVATION(CONTINUATION_HANDLING,     bool,   "Callsite needs continuation handling", FATAL,       CALLSITE)
 
 // ------ Call Site Performance -------
 


### PR DESCRIPTION
While inlining runtime async methods in general is tricky, it is relatively simple to allow inlining async methods that do not have any awaits in them, and I suspect this is a large fraction of them.