### PR TITLE
Handle BadImageFormatException in OpenAssociatedSymbolFile

### DIFF
--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -328,7 +328,15 @@ namespace ILCompiler
                 if (debugEntry.Type != DebugDirectoryEntryType.CodeView)
                     continue;
 
-                CodeViewDebugDirectoryData debugDirectoryData = peReader.ReadCodeViewDebugDirectoryData(debugEntry);
+                CodeViewDebugDirectoryData debugDirectoryData;
+                try
+                {
+                    debugDirectoryData = peReader.ReadCodeViewDebugDirectoryData(debugEntry);
+                }
+                catch (BadImageFormatException)
+                {
+                    continue;
+                }
 
                 string candidatePath  = debugDirectoryData.Path;
                 if (!Path.IsPathRooted(candidatePath) || !File.Exists(candidatePath))

--- a/src/coreclr/tools/dotnet-pgo/TraceTypeSystemContext.cs
+++ b/src/coreclr/tools/dotnet-pgo/TraceTypeSystemContext.cs
@@ -369,7 +369,15 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                 if (debugEntry.Type != DebugDirectoryEntryType.CodeView)
                     continue;
 
-                CodeViewDebugDirectoryData debugDirectoryData = peReader.ReadCodeViewDebugDirectoryData(debugEntry);
+                CodeViewDebugDirectoryData debugDirectoryData;
+                try
+                {
+                    debugDirectoryData = peReader.ReadCodeViewDebugDirectoryData(debugEntry);
+                }
+                catch (BadImageFormatException)
+                {
+                    continue;
+                }
 
                 string candidatePath = debugDirectoryData.Path;
                 if (!Path.IsPathRooted(candidatePath) || !File.Exists(candidatePath))


### PR DESCRIPTION
Catch BadImageFormatException from PEReader.ReadCodeViewDebugDirectoryData and skip malformed CodeView entries instead of crashing. This is consistent with how other PDB loading failures are handled in the same method.

https://github.com/dotnet/runtime/issues/124181