### PR TITLE
[Wasm RyuJit] avoid reverse ops

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4878,6 +4878,13 @@ static void SetIndirectStoreEvalOrder(Compiler* comp, GenTreeIndir* store, bool*
 {
     assert(store->OperIs(GT_STORE_BLK, GT_STOREIND));
 
+#if defined(TARGET_WASM)
+    // TODO-WASM-CQ: we might want to allow reversal here but will need to handle it in lower
+    // by spilling the out of normal order computation to a temp.
+    *allowReversal = false;
+    return;
+#endif
+
     GenTree* addr  = store->Addr();
     GenTree* data  = store->Data();
     *allowReversal = true;
@@ -6078,8 +6085,13 @@ unsigned Compiler::gtSetEvalOrder(GenTree* tree)
                         break;
 
                     default:
+
+#if defined(TARGET_WASM)
+                        // For WASM if we can't swap the operands or swap the operator, don't swap.
+#else
                         // Mark the operand's evaluation order to be swapped.
                         tree->gtFlags ^= GTF_REVERSE_OPS;
+#endif
                         break;
                 }
             }
@@ -6429,8 +6441,13 @@ unsigned Compiler::gtSetEvalOrderMinOpts(GenTree* tree)
                 }
                 else
                 {
+
+#if defined(TARGET_WASM)
+                    // For WASM if we can't swap the operands or swap the operator, don't swap.
+#else
                     // Mark the operand's evaluation order to be swapped.
                     tree->gtFlags ^= GTF_REVERSE_OPS;
+#endif
                 }
             }
         }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -4879,8 +4879,6 @@ static void SetIndirectStoreEvalOrder(Compiler* comp, GenTreeIndir* store, bool*
     assert(store->OperIs(GT_STORE_BLK, GT_STOREIND));
 
 #if defined(TARGET_WASM)
-    // TODO-WASM-CQ: we might want to allow reversal here but will need to handle it in lower
-    // by spilling the out of normal order computation to a temp.
     *allowReversal = false;
     return;
 #endif
@@ -6696,6 +6694,10 @@ bool Compiler::gtTreeHasLocalStore(GenTree* tree, unsigned lclNum)
 #ifdef DEBUG
 bool GenTree::OperSupportsReverseOpEvalOrder(Compiler* comp) const
 {
+#if defined(TARGET_WASM)
+    return false;
+#endif
+
     if (OperIsBinary())
     {
         if ((AsOp()->gtGetOp1() == nullptr) || (AsOp()->gtGetOp2() == nullptr))


### PR DESCRIPTION
For Wasm we generally want operands evaluated in the normal order. So, suppress marking nodes with GT_REVERSE_OPS. On Wasm reversal is still possible for relops (where we can change the oper) and for commutative ops (where we can swap the operands).

We may want to enable reversal in other cases where there is a big imbalance in child tree complexity, but then we'll need to add changes to lower to spill the out of order tree to a temp to handle this.