### PR TITLE
ci-analysis: Add Azure CLI guidance for AzDO pipeline investigation

### DIFF
--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -174,7 +174,7 @@ Canceled jobs (typically from timeouts) often still have useful artifacts. The H
 
 ## Deep Investigation with Azure CLI
 
-When the script and GitHub APIs aren't enough (e.g., investigating internal pipeline definitions, downloading build artifacts, querying build timelines directly), you can use the Azure CLI with the `azure-devops` extension.
+When the script and GitHub APIs aren't enough (e.g., investigating internal pipeline definitions or downloading build artifacts), you can use the Azure CLI with the `azure-devops` extension.
 
 > 💡 **Prefer `az pipelines` / `az devops` commands over raw REST API calls.** The CLI handles authentication, pagination, and JSON output formatting. Only fall back to manual `Invoke-RestMethod` calls when the CLI doesn't expose the endpoint you need (e.g., artifact download URLs, specialized timeline queries). The CLI's `--query` (JMESPath) and `-o table` flags are powerful for filtering without extra scripting.
 
@@ -196,9 +196,9 @@ az account show --query "{name:name, user:user.name}" -o table 2>$null
 #   az login                              # Interactive browser login
 #   az login --use-device-code            # Device code flow (for remote/headless)
 
-# Get an AzDO PAT for direct REST API calls
-$token = (az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
-$headers = @{ "Authorization" = "Bearer $token" }
+# Get an AAD access token for AzDO REST API calls
+$accessToken = (az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+$headers = @{ "Authorization" = "Bearer $accessToken" }
 ```
 
 > ⚠️ If `az` is not installed, use `winget install -e --id Microsoft.AzureCLI` (Windows) then `az extension add --name azure-devops`. Ask the user to authenticate if needed.
@@ -235,8 +235,8 @@ az pipelines runs artifact list --run-id $buildId --org $org -p $project --query
 
 ```powershell
 # Get build timeline (stages, jobs, tasks with results and durations) — no CLI equivalent
-$token = (az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
-$headers = @{ "Authorization" = "Bearer $token" }
+$accessToken = (az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+$headers = @{ "Authorization" = "Bearer $accessToken" }
 $timelineUrl = "https://dev.azure.com/dnceng/internal/_apis/build/builds/$buildId/timeline?api-version=7.1"
 $timeline = (Invoke-RestMethod -Uri $timelineUrl -Headers $headers)
 $timeline.records | Where-Object { $_.result -eq "failed" -and $_.type -eq "Job" }

--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -247,13 +247,19 @@ Invoke-WebRequest -Uri $downloadUrl -Headers $headers -OutFile "$env:TEMP\artifa
 
 ### Examining Pipeline YAML
 
-For VMR/unified builds, the pipeline YAML lives in the dotnet/dotnet repository. To understand what a specific job does:
+All dotnet repos that use arcade put their pipeline definitions under `eng/pipelines/`. Use `az pipelines show` to find the YAML file path, then fetch it:
 
 ```powershell
-# Check pipeline YAML in dotnet/dotnet repo
-# The VMR uses: eng/pipelines/unified-build.yml (or similar)
-# Use GitHub MCP server to fetch the file:
+# Find the YAML path for a pipeline
+az pipelines show --id 1330 --query "{yamlPath:process.yamlFilename, repo:repository.name}" -o table
+
+# Fetch the YAML from the repo (example: dotnet/runtime's runtime-official pipeline)
+#   github-mcp-server-get_file_contents owner:dotnet repo:runtime path:eng/pipelines/runtime-official.yml
+
+# For VMR unified builds, the YAML is in dotnet/dotnet:
 #   github-mcp-server-get_file_contents owner:dotnet repo:dotnet path:eng/pipelines/unified-build.yml
+
+# Templates are usually in eng/pipelines/common/ or eng/pipelines/templates/
 ```
 
 This is especially useful when:

--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -201,7 +201,7 @@ $accessToken = (az account get-access-token --resource 499b84ac-1321-427f-aa17-2
 $headers = @{ "Authorization" = "Bearer $accessToken" }
 ```
 
-> ⚠️ If `az` is not installed, use `winget install -e --id Microsoft.AzureCLI` (Windows) then `az extension add --name azure-devops`. Ask the user to authenticate if needed.
+> ⚠️ If `az` is not installed, use `winget install -e --id Microsoft.AzureCLI` (Windows). The `azure-devops` extension is also required — install or verify it with `az extension add --name azure-devops` (safe to run if already installed). Ask the user to authenticate if needed.
 
 > ⚠️ **Do NOT use `az devops configure --defaults`** — it writes to a global config file and will cause conflicts if multiple agents are running concurrently. Always pass `--org` and `--project` (or `-p`) explicitly on each command.
 
@@ -209,7 +209,7 @@ $headers = @{ "Authorization" = "Bearer $accessToken" }
 
 When investigating build failures, it's often useful to look at the pipeline definition itself to understand what stages, jobs, and templates are involved.
 
-**Use `az` CLI commands first** — they're simpler and handle auth automatically:
+**Use `az` CLI commands first** — they're simpler and handle auth automatically. Set `$buildId` from a runs list or from the AzDO URL:
 
 ```powershell
 $org = "https://dev.azure.com/dnceng"
@@ -253,7 +253,7 @@ All dotnet repos that use arcade put their pipeline definitions under `eng/pipel
 
 ```powershell
 # Find the YAML path for a pipeline
-az pipelines show --id 1330 --query "{yamlPath:process.yamlFilename, repo:repository.name}" -o table
+az pipelines show --id 1330 --org $org -p $project --query "{yamlPath:process.yamlFilename, repo:repository.name}" -o table
 
 # Fetch the YAML from the repo (example: dotnet/runtime's runtime-official pipeline)
 #   github-mcp-server-get_file_contents owner:dotnet repo:runtime path:eng/pipelines/runtime-official.yml


### PR DESCRIPTION
## Summary

Adds Azure CLI guidance to the ci-analysis skill for investigating AzDO pipelines directly, reducing reliance on manual REST API construction.

## Changes

- **New section: "Deep Investigation with Azure CLI"**
  - Auth checking: how to verify `az` is installed/authenticated, refresh PATH on Windows, check `azure-devops` extension
  - Pipeline querying: `az pipelines list`, `az pipelines show`, `az pipelines runs list/show`
  - Artifact listing: `az pipelines runs artifact list`
  - REST API fallback: only for build timelines and artifact downloads (no CLI equivalent)
  - Pipeline YAML: all arcade-based dotnet repos use `eng/pipelines/`; use `az pipelines show` to find the YAML path

- **Key principle: prefer `az` CLI over manual REST API construction**
  - CLI handles auth, pagination, and output formatting automatically
  - `--query` (JMESPath) and `-o table` reduce scripting overhead

- **Concurrency safety: never use `az devops configure --defaults`**
  - Global config causes conflicts when multiple agents run concurrently
  - Always pass `--org` and `-p` explicitly

- **Terminology fix: AAD access token, not PAT**

- **New tip #8**: verify `az account show` before making REST calls
