### PR TITLE
Use Helix ListFiles endpoint to work around dnceng#6072

### DIFF
--- a/.github/skills/ci-analysis/references/helix-artifacts.md
+++ b/.github/skills/ci-analysis/references/helix-artifacts.md
@@ -49,7 +49,7 @@ Artifacts may be at the root level or nested in subdirectories like `xharness-ou
 
 > **Note:** The Helix work item Details API has a known bug ([dotnet/dnceng#6072](https://github.com/dotnet/dnceng/issues/6072)) where
 > file URIs for subdirectory files are incorrect, and unicode characters in filenames are rejected.
-> The script works around this by using the separate `ListFiles` endpoint (`GET .../workitems/{id}/files`)
+> The script works around this by using the separate `ListFiles` endpoint (`GET .../workitems/{workItemName}/files`)
 > which returns direct blob storage URIs that work for all filenames regardless of subdirectories or unicode.
 
 ## Binlog Files

--- a/.github/skills/ci-analysis/references/helix-artifacts.md
+++ b/.github/skills/ci-analysis/references/helix-artifacts.md
@@ -47,9 +47,10 @@ Always query the specific work item to see what's available rather than assuming
 
 Artifacts may be at the root level or nested in subdirectories like `xharness-output/logs/`.
 
-> **Note:** The Helix API has a known bug ([dotnet/dnceng#6072](https://github.com/dotnet/dnceng/issues/6072)) where
-> file URIs for subdirectory files are incorrect. The script works around this by rebuilding URIs from the `FileName`
-> field, but raw API responses may return broken links for files like `xharness-output/wasm-console.log`.
+> **Note:** The Helix work item Details API has a known bug ([dotnet/dnceng#6072](https://github.com/dotnet/dnceng/issues/6072)) where
+> file URIs for subdirectory files are incorrect, and unicode characters in filenames are rejected.
+> The script works around this by using the separate `ListFiles` endpoint (`GET .../workitems/{id}/files`)
+> which returns direct blob storage URIs that work for all filenames regardless of subdirectories or unicode.
 
 ## Binlog Files
 

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -1379,7 +1379,8 @@ function Get-HelixWorkItemFiles {
 function Get-HelixWorkItemDetails {
     param([string]$JobId, [string]$WorkItemName)
 
-    $url = "https://helix.dot.net/api/2019-06-17/jobs/$JobId/workitems/$WorkItemName"
+    $encodedWorkItem = [uri]::EscapeDataString($WorkItemName)
+    $url = "https://helix.dot.net/api/2019-06-17/jobs/$JobId/workitems/$encodedWorkItem"
 
     try {
         $response = Invoke-CachedRestMethod -Uri $url -TimeoutSec $TimeoutSec -AsJson


### PR DESCRIPTION
## Summary

Work around [dotnet/dnceng#6072](https://github.com/dotnet/dnceng/issues/6072) in the CI analysis skill by using the Helix \ListFiles\ endpoint instead of file URIs from the \Details\ endpoint.

## Problem

The Helix work item Details API (\GET .../workitems/{id}\) has two bugs in its \Files[].Uri\ values:

1. **Subdirectory flattening**: Files uploaded from subdirectories (e.g. \xharness-output/logs/test/build.binlog\) get URIs with only the base filename (\.../files/build.binlog\), so multiple distinct files with the same base name collide
2. **Unicode rejection**: The \/files/{name}\ endpoint validates against an ASCII-only regex, rejecting filenames containing unicode characters (e.g. CJK test directory names like \鿀蜒枛遫䡫煉\)

The previous workaround reconstructed permalink URIs from the \FileName\ field, but this still routed through the broken \/files/\ endpoint which rejects unicode.

## Fix

Use the separate \ListFiles\ endpoint (\GET .../workitems/{id}/files\) which returns direct blob storage URIs. These URIs:
- Preserve full subdirectory paths
- Have properly percent-encoded unicode
- Don't route through the permalink/regex validation layer

Verified against PR #124125 CI artifacts: 53 files with unicode paths all return HTTP 200 via ListFiles blob URIs, vs broken/colliding URIs from the Details endpoint.