### PR TITLE
Restore blocking mode after successful ConnectAsync on Unix

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SafeSocketHandle.Unix.cs
@@ -131,7 +131,7 @@ namespace System.Net.Sockets
                 // blocking operations within SocketAsyncContext on top of epoll/kqueue.
                 // This avoids problems with switching to native blocking while there are pending operations.
                 // Note: After ConnectAsync completes, we may restore the native socket to blocking mode
-                // to optimize subsequent synchronous operations (see RestoreBlocking/SetHandleBlocking).
+                // to optimize subsequent synchronous operations (see SetBlocking/SetHandleBlocking).
                 if (value)
                 {
                     AsyncContext.SetHandleNonBlocking();
@@ -142,12 +142,12 @@ namespace System.Net.Sockets
         internal bool IsUnderlyingHandleBlocking => !AsyncContext.IsHandleNonBlocking;
 
         /// <summary>
-        /// Restores the underlying socket to blocking mode after ConnectAsync completes.
-        /// Only restores blocking if the user hasn't explicitly set Blocking = false (i.e., IsNonBlocking is false).
+        /// Sets the underlying socket to blocking mode.
+        /// Only sets blocking if the user hasn't explicitly set Blocking = false (i.e., IsNonBlocking is false).
         /// This is only safe to call when the socket is guaranteed by construction to not be used concurrently
         /// with any other operation, such as at the completion of ConnectAsync.
         /// </summary>
-        internal void RestoreBlocking()
+        internal void SetBlocking()
         {
             if (!IsNonBlocking && !IsClosed)
             {

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -676,7 +676,7 @@ namespace System.Net.Sockets
                 SocketError ec = ErrorCode;
                 Memory<byte> buffer = Buffer;
 
-                if (buffer.Length == 0)
+                if (buffer.Length == 0 || ec != SocketError.Success)
                 {
                     AssociatedContext._socket.SetBlocking();
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -678,7 +678,7 @@ namespace System.Net.Sockets
 
                 if (buffer.Length == 0)
                 {
-                    AssociatedContext._socket.RestoreBlocking();
+                    AssociatedContext._socket.SetBlocking();
 
                     // Invoke callback only when we are completely done.
                     // In case data were provided for Connect we may or may not send them all.
@@ -1586,7 +1586,7 @@ namespace System.Net.Sockets
 
                 if (buffer.Length == 0 || errorCode != SocketError.IOPending)
                 {
-                    _socket.RestoreBlocking();
+                    _socket.SetBlocking();
                 }
                 return errorCode;
             }
@@ -1608,7 +1608,7 @@ namespace System.Net.Sockets
 
                 if (buffer.Length == 0 || operation.ErrorCode != SocketError.Success)
                 {
-                    _socket.RestoreBlocking();
+                    _socket.SetBlocking();
                 }
 
                 return operation.ErrorCode;

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -678,6 +678,8 @@ namespace System.Net.Sockets
 
                 if (buffer.Length == 0)
                 {
+                    AssociatedContext._socket.RestoreBlocking();
+
                     // Invoke callback only when we are completely done.
                     // In case data were provided for Connect we may or may not send them all.
                     // If we did not we will need follow-up with Send operation
@@ -1350,8 +1352,9 @@ namespace System.Net.Sockets
             //
             // Our sockets may start as blocking, and later transition to non-blocking, either because the user
             // explicitly requested non-blocking mode, or because we need non-blocking mode to support async
-            // operations.  We never transition back to blocking mode, to avoid problems synchronizing that
-            // transition with the async infrastructure.
+            // operations. After a successful ConnectAsync, we may transition back to blocking mode to optimize
+            // subsequent synchronous operations (see SetHandleBlocking). The socket will be set back to
+            // non-blocking when another async operation is performed.
             //
             // Note that there's no synchronization here, so we may set the non-blocking option multiple times
             // in a race.  This should be fine.
@@ -1368,6 +1371,23 @@ namespace System.Net.Sockets
         }
 
         public bool IsHandleNonBlocking => _isHandleNonBlocking;
+
+        public void SetHandleBlocking()
+        {
+            if (OperatingSystem.IsWasi())
+            {
+                // WASI sockets are always non-blocking
+                return;
+            }
+
+            if (_isHandleNonBlocking)
+            {
+                if (Interop.Sys.Fcntl.SetIsNonBlocking(_socket, 0) == 0)
+                {
+                    _isHandleNonBlocking = false;
+                }
+            }
+        }
 
         private void PerformSyncOperation<TOperation>(ref OperationQueue<TOperation> queue, TOperation operation, int timeout, int observedSequenceNumber)
             where TOperation : AsyncOperation
@@ -1563,6 +1583,11 @@ namespace System.Net.Sockets
                 {
                     errorCode = SendToAsync(buffer.Slice(sentBytes), 0, remains, SocketFlags.None, Memory<byte>.Empty, ref sentBytes, callback!, default);
                 }
+
+                if (buffer.Length == 0 || errorCode != SocketError.IOPending)
+                {
+                    _socket.RestoreBlocking();
+                }
                 return errorCode;
             }
 
@@ -1580,6 +1605,12 @@ namespace System.Net.Sockets
                 {
                     sentBytes += operation.BytesTransferred;
                 }
+
+                if (buffer.Length == 0 || operation.ErrorCode != SocketError.Success)
+                {
+                    _socket.RestoreBlocking();
+                }
+
                 return operation.ErrorCode;
             }
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1584,7 +1584,7 @@ namespace System.Net.Sockets
                     errorCode = SendToAsync(buffer.Slice(sentBytes), 0, remains, SocketFlags.None, Memory<byte>.Empty, ref sentBytes, callback!, default);
                 }
 
-                if (buffer.Length == 0 || errorCode != SocketError.IOPending)
+                if (remains == 0 || errorCode != SocketError.IOPending)
                 {
                     _socket.SetBlocking();
                 }

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -1352,9 +1352,10 @@ namespace System.Net.Sockets
             //
             // Our sockets may start as blocking, and later transition to non-blocking, either because the user
             // explicitly requested non-blocking mode, or because we need non-blocking mode to support async
-            // operations. After a successful ConnectAsync, we may transition back to blocking mode to optimize
-            // subsequent synchronous operations (see SetHandleBlocking). The socket will be set back to
-            // non-blocking when another async operation is performed.
+            // operations. After ConnectAsync completes (success or failure), if there is no pending follow-up
+            // async send, we may transition back to blocking mode to optimize subsequent synchronous operations
+            // (see SetHandleBlocking). The socket will be set back to non-blocking when another async operation
+            // is performed.
             //
             // Note that there's no synchronization here, so we may set the non-blocking option multiple times
             // in a race.  This should be fine.

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.Unix.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.Unix.cs
@@ -1,0 +1,237 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Sockets.Tests
+{
+    public class ConnectAsyncBlockingModeTests
+    {
+        private static bool IsSocketNonBlocking(Socket socket)
+        {
+            int rv = Interop.Sys.Fcntl.GetIsNonBlocking(socket.SafeHandle, out bool isNonBlocking);
+            Assert.NotEqual(-1, rv);
+            return isNonBlocking;
+        }
+
+        [Fact]
+        public async Task ConnectAsync_Success_SocketIsBlockingAfterCompletion()
+        {
+            using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listener.Listen(1);
+
+            using Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+            Assert.True(client.Blocking);
+            Assert.False(IsSocketNonBlocking(client));
+
+            await client.ConnectAsync((IPEndPoint)listener.LocalEndPoint!);
+
+            Assert.True(client.Blocking);
+            Assert.False(IsSocketNonBlocking(client));
+        }
+
+        [Fact]
+        public async Task ConnectAsync_UserSetNonBlocking_SocketStaysNonBlocking()
+        {
+            using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listener.Listen(1);
+
+            using Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+            client.Blocking = false;
+            Assert.False(client.Blocking);
+            Assert.True(IsSocketNonBlocking(client));
+
+            await client.ConnectAsync((IPEndPoint)listener.LocalEndPoint!);
+
+            Assert.False(client.Blocking);
+            Assert.True(IsSocketNonBlocking(client));
+        }
+
+        [Fact]
+        public async Task ConnectAsync_ThenSendAsync_SocketBecomesNonBlocking()
+        {
+            using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listener.Listen(1);
+
+            using Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+            await client.ConnectAsync((IPEndPoint)listener.LocalEndPoint!);
+
+            Assert.True(client.Blocking);
+            Assert.False(IsSocketNonBlocking(client));
+
+            using Socket accepted = listener.Accept();
+
+            await client.SendAsync(new byte[] { 1, 2, 3 }, SocketFlags.None);
+
+            Assert.True(IsSocketNonBlocking(client));
+        }
+
+        [Fact]
+        public async Task ConnectAsync_ThenReceiveAsync_SocketBecomesNonBlocking()
+        {
+            using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listener.Listen(1);
+
+            using Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+            await client.ConnectAsync((IPEndPoint)listener.LocalEndPoint!);
+
+            Assert.True(client.Blocking);
+            Assert.False(IsSocketNonBlocking(client));
+
+            using Socket accepted = listener.Accept();
+            accepted.Send(new byte[] { 1, 2, 3 });
+
+            byte[] buffer = new byte[10];
+            await client.ReceiveAsync(buffer, SocketFlags.None);
+
+            Assert.True(IsSocketNonBlocking(client));
+        }
+
+        [Fact]
+        public async Task ConnectAsync_Failure_SocketIsRestoredToBlocking()
+        {
+            using Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+            await Assert.ThrowsAsync<SocketException>(async () =>
+                await client.ConnectAsync(new IPEndPoint(IPAddress.Loopback, 1)));
+
+            Assert.False(IsSocketNonBlocking(client));
+        }
+
+        [Fact]
+        public async Task ConnectAsync_WithBuffer_Failure_CallbackInvokedAndSocketIsBlocking()
+        {
+            using Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+            using var saea = new SocketAsyncEventArgs();
+            saea.RemoteEndPoint = new IPEndPoint(IPAddress.Loopback, 1);
+            saea.SetBuffer(new byte[] { 1, 2, 3 }, 0, 3);
+
+            var tcs = new TaskCompletionSource();
+            saea.Completed += (_, _) => tcs.SetResult();
+
+            if (!client.ConnectAsync(saea))
+            {
+                tcs.SetResult();
+            }
+
+            await tcs.Task;
+
+            Assert.NotEqual(SocketError.Success, saea.SocketError);
+            Assert.False(IsSocketNonBlocking(client));
+        }
+
+        [Fact]
+        public async Task AcceptAsync_AcceptedSocketIsBlockingByDefault()
+        {
+            using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listener.Listen(1);
+
+            using Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            client.Connect((IPEndPoint)listener.LocalEndPoint!);
+
+            using Socket accepted = await listener.AcceptAsync();
+
+            Assert.True(accepted.Blocking);
+            Assert.False(IsSocketNonBlocking(accepted));
+        }
+
+        [Fact]
+        public async Task AcceptAsync_AcceptedSocketSyncReceiveWorks()
+        {
+            using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listener.Listen(1);
+
+            using Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            client.Connect((IPEndPoint)listener.LocalEndPoint!);
+
+            using Socket accepted = await listener.AcceptAsync();
+
+            client.Send(new byte[] { 1, 2, 3 });
+
+            byte[] buffer = new byte[10];
+            int received = accepted.Receive(buffer);
+
+            Assert.Equal(3, received);
+            Assert.True(accepted.Blocking);
+            Assert.False(IsSocketNonBlocking(accepted));
+        }
+
+        [Fact]
+        public async Task AcceptAsync_ConcurrentAccepts_DoNotCorruptListenerState()
+        {
+            using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listener.Listen(5);
+
+            Task<Socket> accept1 = listener.AcceptAsync();
+            Task<Socket> accept2 = listener.AcceptAsync();
+
+            using Socket client1 = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            using Socket client2 = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            client1.Connect((IPEndPoint)listener.LocalEndPoint!);
+            client2.Connect((IPEndPoint)listener.LocalEndPoint!);
+
+            using Socket accepted1 = await accept1;
+            using Socket accepted2 = await accept2;
+
+            Assert.True(accepted1.Blocking);
+            Assert.False(IsSocketNonBlocking(accepted1));
+            Assert.True(accepted2.Blocking);
+            Assert.False(IsSocketNonBlocking(accepted2));
+        }
+
+        [Fact]
+        public async Task ConnectAsync_WithBuffer_Succeeds()
+        {
+            using Socket listener = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            listener.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+            listener.Listen(1);
+
+            using Socket client = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+
+            using var saea = new SocketAsyncEventArgs();
+            saea.RemoteEndPoint = (IPEndPoint)listener.LocalEndPoint!;
+            saea.SetBuffer(new byte[] { 1, 2, 3 }, 0, 3);
+
+            var tcs = new TaskCompletionSource();
+            saea.Completed += (_, _) => tcs.SetResult();
+
+            bool completedAsync = client.ConnectAsync(saea);
+            if (!completedAsync)
+            {
+                tcs.SetResult();
+            }
+
+            await tcs.Task;
+
+            Assert.Equal(SocketError.Success, saea.SocketError);
+            Assert.True(client.Blocking);
+
+            if (completedAsync)
+            {
+                // Async path: a follow-up SendToAsync may be in-flight, so
+                // RestoreBlocking is skipped to avoid racing with the send.
+                Assert.True(IsSocketNonBlocking(client));
+            }
+            else
+            {
+                // Sync path: connect and send both completed synchronously,
+                // so RestoreBlocking was called and the socket is blocking.
+                Assert.False(IsSocketNonBlocking(client));
+            }
+        }
+    }
+}

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.Unix.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.Unix.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace System.Net.Sockets.Tests
 {
-    public class ConnectAsyncBlockingModeTests
+    public class SocketBlockingModeTransitionTests
     {
         private static bool IsSocketNonBlocking(Socket socket)
         {

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.Unix.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.Unix.cs
@@ -223,13 +223,13 @@ namespace System.Net.Sockets.Tests
             if (completedAsync)
             {
                 // Async path: a follow-up SendToAsync may be in-flight, so
-                // RestoreBlocking is skipped to avoid racing with the send.
+                // SetBlocking is skipped to avoid racing with the send.
                 Assert.True(IsSocketNonBlocking(client));
             }
             else
             {
                 // Sync path: connect and send both completed synchronously,
-                // so RestoreBlocking was called and the socket is blocking.
+                // so SetBlocking was called and the socket is blocking.
                 Assert.False(IsSocketNonBlocking(client));
             }
         }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.Unix.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.Unix.cs
@@ -220,17 +220,17 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(SocketError.Success, saea.SocketError);
             Assert.True(client.Blocking);
 
-            if (completedAsync)
+            // On macOS, TFO (connectx) may complete the connect+send in a single
+            // syscall, so the socket can end up blocking even on the async path.
+            // On Linux, async connect always leaves the socket non-blocking when
+            // buffer > 0 because SendToAsync is pending.
+            if (!completedAsync || OperatingSystem.IsMacOS())
             {
-                // Async path: a follow-up SendToAsync may be in-flight, so
-                // SetBlocking is skipped to avoid racing with the send.
-                Assert.True(IsSocketNonBlocking(client));
+                Assert.False(IsSocketNonBlocking(client));
             }
             else
             {
-                // Sync path: connect and send both completed synchronously,
-                // so SetBlocking was called and the socket is blocking.
-                Assert.False(IsSocketNonBlocking(client));
+                Assert.True(IsSocketNonBlocking(client));
             }
         }
     }

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -22,6 +22,7 @@
     <Compile Include="DualModeSocketTest.cs" />
     <Compile Include="ExecutionContextFlowTest.cs" />
     <Compile Include="InlineCompletions.Unix.cs" Condition="'$(TargetPlatformIdentifier)' == 'unix'"/>
+    <Compile Include="Connect.Unix.cs" Condition="'$(TargetPlatformIdentifier)' == 'unix'"/>
     <Compile Include="IPPacketInformationTest.cs" />
     <Compile Include="KeepAliveTest.cs" />
     <Compile Include="LingerStateTest.cs" />
@@ -104,6 +105,12 @@
     <Compile Include="$(CommonTestPath)System\IO\TempFile.cs" Link="Common\System\IO\TempFile.cs" />
     <Compile Include="$(CommonTestPath)TestUtilities\System\DisableParallelization.cs"
              Link="Common\TestUtilities\System\DisableParallelization.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetPlatformIdentifier)' == 'unix'">
+    <Compile Include="$(CommonPath)Interop\Unix\Interop.Libraries.cs"
+             Link="Common\Interop\Unix\Interop.Libraries.cs" />
+    <Compile Include="$(CommonPath)Interop\Unix\System.Native\Interop.Fcntl.cs"
+             Link="Common\Interop\Unix\System.Native\Interop.Fcntl.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(CommonTestPath)StreamConformanceTests\StreamConformanceTests.csproj" />


### PR DESCRIPTION
   ## Summary

   On Unix, after a successful `ConnectAsync` completion, this PR restores the underlying socket to blocking mode if the user hasn't explicitly set `Socket.Blocking = false`. This
  optimizes subsequent synchronous operations (`Send`/`Receive`) by using native blocking syscalls instead of emulating blocking on top of epoll/kqueue.

   When `SendAsync`/`ReceiveAsync` (or other async I/O operations) are called later, the socket is switched back to non-blocking mode via the existing `SetHandleNonBlocking()`
  mechanism.

   ## Motivation

   Currently, once any async operation is performed on a Unix socket, the underlying file descriptor is permanently set to non-blocking mode via `fcntl(O_NONBLOCK)`. Subsequent
  synchronous operations must then emulate blocking behavior in managed code using epoll/kqueue, which has performance overhead compared to native blocking syscalls.

   This change benefits the common usage pattern:
   ```csharp
   await socket.ConnectAsync(endpoint);
   // Subsequent sync operations now use native blocking syscalls (more efficient)
   socket.Receive(buffer);
   socket.Send(data);