### PR TITLE
[release/10.0] Fix PerfMap crash when Enable IPC command is sent early in startup

### DIFF
--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -832,6 +832,10 @@ void EEStartupHelper()
 
         ExecutionManager::Init();
 
+#ifdef FEATURE_PERFMAP
+        PerfMap::SignalDependenciesReady();
+#endif
+
         JitHost::Init();
 
 #ifndef TARGET_UNIX

--- a/src/coreclr/vm/ceemain.cpp
+++ b/src/coreclr/vm/ceemain.cpp
@@ -715,6 +715,10 @@ void EEStartupHelper()
         }
 #endif
 
+#ifdef FEATURE_PERFMAP
+        PerfMap::Initialize();
+#endif
+
 #ifdef FEATURE_PERFTRACING
         DiagnosticServerAdapter::Initialize();
         DiagnosticServerAdapter::PauseForDiagnosticsMonitor();
@@ -740,7 +744,6 @@ void EEStartupHelper()
 #endif
 
 #ifdef FEATURE_PERFMAP
-        PerfMap::Initialize();
         InitThreadManagerPerfMapData();
 #endif
 

--- a/src/coreclr/vm/perfmap.cpp
+++ b/src/coreclr/vm/perfmap.cpp
@@ -27,6 +27,7 @@
 #endif
 
 Volatile<bool> PerfMap::s_enabled = false;
+Volatile<bool> PerfMap::s_dependenciesReady = false;
 PerfMap * PerfMap::s_Current = nullptr;
 bool PerfMap::s_ShowOptimizationTiers = false;
 bool PerfMap::s_GroupStubsOfSameType = false;
@@ -120,6 +121,17 @@ void PerfMap::Enable(PerfMapType type, bool sendExisting)
 
     if (sendExisting)
     {
+        // When Enable is called very early in startup (e.g., via DiagnosticServer IPC before
+        // SystemDomain::Attach and ExecutionManager::Init), the AppDomain and EEJitManager
+        // may not exist yet. We use s_dependenciesReady (a Volatile<bool>) to guard against
+        // this, rather than null-checking individual pointers which would have race conditions
+        // due to non-Volatile statics like m_pEEJitManager.
+        // Safe to skip: no assemblies are loaded and no code is JIT'd at that point.
+        if (!s_dependenciesReady)
+        {
+            return;
+        }
+
         AppDomain::AssemblyIterator assemblyIterator = GetAppDomain()->IterateAssembliesEx(
             (AssemblyIterationFlags)(kIncludeLoaded | kIncludeExecution));
         CollectibleAssemblyHolder<Assembly *> pAssembly;
@@ -205,6 +217,15 @@ void PerfMap::Disable()
         // PAL_PerfJitDump_Finish is lock protected and can safely be called multiple times
         PAL_PerfJitDump_Finish();
     }
+}
+
+// Signal that all dependencies (AppDomain, ExecutionManager) are ready.
+// This method must be called before any code is JITed or restored from R2R image.
+void PerfMap::SignalDependenciesReady()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    s_dependenciesReady = true;
 }
 
 // Construct a new map for the process.

--- a/src/coreclr/vm/perfmap.h
+++ b/src/coreclr/vm/perfmap.h
@@ -24,6 +24,9 @@ class PerfMap
 private:
     static Volatile<bool> s_enabled;
 
+    // Set to true after all dependencies (AppDomain, ExecutionManager) are initialized.
+    static Volatile<bool> s_dependenciesReady;
+
     // The one and only PerfMap for the process.
     static PerfMap * s_Current;
 
@@ -103,6 +106,9 @@ public:
 
     // Close the map and flush any remaining data.
     static void Disable();
+
+    // Signal that all dependencies (AppDomain, ExecutionManager) are ready.
+    static void SignalDependenciesReady();
 
     static bool LowGranularityStubs() { return !s_IndividualAllocationStubReporting; }
 };


### PR DESCRIPTION
Manual backport of #123226 and #124055 to release/10.0

## Customer Impact

- [ ] Customer reported
- [x] Found internally

The DiagnosticServer allows profilers to enable PerfMap early in start-up, even before PerfMap is initialized and dependencies are ready, inducing a crash. Enabling PerfMap this early in start-up was not tested until user_events support was added in .NET 10, where One-Collect's [record-trace](https://github.com/microsoft/one-collect) aggressively enables PerfMaps as soon as it connects to a .NET Process so it can resolve JIT'd code. As .NET user_events + record-trace gains more users, this crash will likely be observed more frequently.

With the changes in the two PRs, the runtime is resilient to early PerfMap::Enable commands received by the DiagnosticServer.
DiagnosticServer initialization will still be early in start-up, PerfMap initialization is just bumped right before it.

## Regression

- [ ] Yes
- [x] No

## Testing

I validated on a wsl2 instance, pausing the startup logic with DOTNET_DefaultDiagnosticPortSuspend=1 and kicking off a separate app invoking DiagnosticClient.EnablePerfMap. Before the change, it would sigsegv and crash.
After the changes, its resilient and doesn't crash.

## Risk

Low. PerfMap initialization doesn't depend on the logic between its former and proposed location. The logic to handle early IPC PerfMap Enable commands makes the problematic logic a no-op until the dependencies are ready.