### PR TITLE
[maccatalyst][coreclr] Fix native build failure on Xcode 26.2

### DIFF
--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -91,9 +91,11 @@ build_native()
     if [[ "$targetOS" == maccatalyst ]]; then
         cmakeArgs="-C $__RepoRootDir/eng/native/tryrun_ios_tvos.cmake $cmakeArgs"
 
-        # set default macCatalyst deployment target
-        # keep in sync with SetOSTargetMinVersions in the root Directory.Build.props
-        cmakeArgs="-DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_SYSROOT=macosx -DCMAKE_SYSTEM_VARIANT=maccatalyst -DCMAKE_OSX_DEPLOYMENT_TARGET=17.0 $cmakeArgs"
+        # CMAKE_OSX_DEPLOYMENT_TARGET is set to the macOS equivalent (14.0) of the
+        # Catalyst min version (17.0) so CMake's compiler test emits a valid
+        # -mmacosx-version-min flag. The effective Catalyst min version is enforced
+        # via the -target triple in eng/native/configurecompiler.cmake, not this value.
+        cmakeArgs="-DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_SYSROOT=macosx -DCMAKE_SYSTEM_VARIANT=maccatalyst -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 $cmakeArgs"
     fi
 
     if [[ "$targetOS" == android || "$targetOS" == linux-bionic ]]; then

--- a/eng/native/build-commons.sh
+++ b/eng/native/build-commons.sh
@@ -91,11 +91,12 @@ build_native()
     if [[ "$targetOS" == maccatalyst ]]; then
         cmakeArgs="-C $__RepoRootDir/eng/native/tryrun_ios_tvos.cmake $cmakeArgs"
 
-        # CMAKE_OSX_DEPLOYMENT_TARGET is set to the macOS equivalent (14.0) of the
-        # Catalyst min version (17.0) so CMake's compiler test emits a valid
-        # -mmacosx-version-min flag. The effective Catalyst min version is enforced
-        # via the -target triple in eng/native/configurecompiler.cmake, not this value.
-        cmakeArgs="-DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_SYSROOT=macosx -DCMAKE_SYSTEM_VARIANT=maccatalyst -DCMAKE_OSX_DEPLOYMENT_TARGET=14.0 $cmakeArgs"
+        # Intentionally do not set CMAKE_OSX_DEPLOYMENT_TARGET for maccatalyst here:
+        # - CMake interprets CMAKE_OSX_DEPLOYMENT_TARGET as a macOS minimum version
+        #   instead of MacCatalyst, causing newer clang to reject it as invalid.
+        # - The effective Catalyst minimum version is enforced via the
+        #   -target *-apple-ios<version>-macabi flag in eng/native/configurecompiler.cmake
+        cmakeArgs="-DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_OSX_SYSROOT=macosx -DCMAKE_SYSTEM_VARIANT=maccatalyst $cmakeArgs"
     fi
 
     if [[ "$targetOS" == android || "$targetOS" == linux-bionic ]]; then

--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -727,6 +727,8 @@ if (CLR_CMAKE_HOST_UNIX OR CLR_CMAKE_HOST_WASI)
       endif()
     endif()
     add_link_options(${DISABLE_OVERRIDING_MIN_VERSION_ERROR})
+    # Keep the Catalyst version in the -target triples below in sync
+    # with MacCatalystVersionMin in SetOSTargetMinVersions in Directory.Build.props.
     if(CLR_CMAKE_HOST_ARCH_ARM64)
       set(CLR_CMAKE_MACCATALYST_COMPILER_TARGET "arm64-apple-ios17.0-macabi")
       add_link_options(-target ${CLR_CMAKE_MACCATALYST_COMPILER_TARGET})


### PR DESCRIPTION
## Summary

Remove `CMAKE_OSX_DEPLOYMENT_TARGET` from the maccatalyst cmake args in `eng/native/build-commons.sh`.

## Problem

Building for maccatalyst fails on Xcode 26.2 with:

```
clang: error: invalid version number in '-mmacosx-version-min=17.0'
```

The build sets `CMAKE_SYSTEM_NAME=Darwin` with `CMAKE_OSX_SYSROOT=macosx`, so CMake interprets `CMAKE_OSX_DEPLOYMENT_TARGET=17.0` as a macOS deployment target and emits `-mmacosx-version-min=17.0`. But `17.0` is a Mac Catalyst version number, not a macOS version. Older clang accepted this silently; Xcode 26.2's clang rejects it as a hard error during CMake's compiler test, before `configurecompiler.cmake` can apply the correct `-target arm64-apple-ios17.0-macabi` triple.

## Fix

Remove `CMAKE_OSX_DEPLOYMENT_TARGET` entirely. The value is not consumed — the effective Catalyst minimum version is enforced separately via the `-target *-apple-ios<version>-macabi` triple in `eng/native/configurecompiler.cmake`.

## Validation

Full `clr+clr.runtime+libs+packs` build for maccatalyst-arm64 succeeds with this change on Xcode 26.2 / CMake 4.2.0.