### PR TITLE
Improve vmr-codeflow-status skill: current-state-first analysis, force push & empty diff detection

### DIFF
--- a/.github/skills/vmr-codeflow-status/SKILL.md
+++ b/.github/skills/vmr-codeflow-status/SKILL.md
@@ -161,13 +161,15 @@ Then layer in context from `warnings`, `freshness`, and `commits`:
 
 ### Darc commands to include
 
-When recommending actions, include the relevant `darc` command with the actual `subscriptionId` from the summary:
+When recommending actions, include the relevant `darc` command with the actual `subscriptionId` from the summary. Be precise about what each command does:
 
-```
-darc trigger-subscriptions --id <subscriptionId>           # normal trigger
-darc trigger-subscriptions --id <subscriptionId> --force   # force trigger (overwrites PR)
-darc vmr resolve-conflict --subscription <subscriptionId>  # resolve conflicts locally
-```
+| Command | What it does | When to use |
+|---------|-------------|-------------|
+| `darc trigger-subscriptions --id <id>` | Normal trigger — only works if subscription isn't stale. Creates a new PR if none exists. | PR was closed, or no PR exists |
+| `darc trigger-subscriptions --id <id> --force` | Force trigger — **overwrites the existing PR branch** with fresh VMR content. Does not create a new PR. | PR exists but is stale/no-op and you want to reuse it |
+| `darc vmr resolve-conflict --subscription <id>` | Resolve conflicts locally and push to the PR branch | PR has merge conflicts |
+
+> ⚠️ **Common mistake**: Don't say "close then force-trigger" — force-trigger pushes to the *existing* PR. If you close first, use a normal trigger instead (which creates a new PR). The two paths are: (A) force-trigger to refresh the existing PR, or (B) close + normal-trigger to get a new PR.
 
 ### Tone
 

--- a/.github/skills/vmr-codeflow-status/SKILL.md
+++ b/.github/skills/vmr-codeflow-status/SKILL.md
@@ -75,7 +75,7 @@ Use this skill when:
 > **Design principle**: Assess current state from primary signals first, then use Maestro comments as historical context — not the other way around. Comments tell you the history, not the present.
 
 1. **PR Overview** — Basic PR info, flow direction (backflow vs forward flow)
-2. **Current State** — Independent assessment from primary signals: empty diff, force pushes, merge status. Produces a one-line verdict (NO-OP / IN PROGRESS / STALE / ACTIVE) before reading any comments
+2. **Current State** — Independent assessment from primary signals: empty diff, force pushes, merge status. Produces a one-line verdict (NO-OP / IN PROGRESS / STALE / ACTIVE / MERGED / CLOSED) before reading any comments
 3. **Codeflow Metadata** — Extracts VMR commit, subscription ID, build info from PR body
 4. **Snapshot Validation** — Cross-references PR body commit against Version.Details.xml and branch commits to detect stale metadata
 5. **Source Freshness** — Compares PR's VMR snapshot against current VMR branch HEAD; shows pending forward flow PRs

--- a/.github/skills/vmr-codeflow-status/SKILL.md
+++ b/.github/skills/vmr-codeflow-status/SKILL.md
@@ -95,7 +95,9 @@ Use this skill when:
 ## Interpreting Results
 
 ### Current State (assessed first, from primary signals)
-- **📭 NO-OP**: Empty diff with force push — PR likely already resolved, changes landed via other paths
+- **✅ MERGED**: PR has been merged — no action needed
+- **✖️ CLOSED**: PR was closed without merging — Maestro should create a replacement
+- **📭 NO-OP**: Empty diff — PR likely already resolved, changes landed via other paths
 - **🔄 IN PROGRESS**: Recent force push within 24h — someone is actively working on it
 - **⏳ STALE**: No activity for >3 days — may need attention
 - **✅ ACTIVE**: PR has content and recent activity

--- a/.github/skills/vmr-codeflow-status/SKILL.md
+++ b/.github/skills/vmr-codeflow-status/SKILL.md
@@ -137,7 +137,10 @@ After the script outputs the `[CODEFLOW_SUMMARY]` JSON block, **you** synthesize
 
 ### Decision logic
 
-Read `currentState` first:
+Check `isCodeflowPR` first — if `false`, skip all codeflow-specific advice:
+- **Not a codeflow PR** (`isCodeflowPR = false` or `flowDirection = "unknown"`): State this clearly. No darc commands, no codeflow recommendations. Treat as a normal PR.
+
+Then read `currentState`:
 
 | State | Action |
 |-------|--------|

--- a/.github/skills/vmr-codeflow-status/SKILL.md
+++ b/.github/skills/vmr-codeflow-status/SKILL.md
@@ -105,6 +105,10 @@ Use this skill when:
 - **⚠️ Staleness warning**: A forward flow merged while this backflow PR was open. Maestro blocked further updates.
 - **🔴 Conflict detected**: Maestro found merge conflicts. Shows conflicting files and `darc vmr resolve-conflict` command.
 
+### Force Push & Empty Diff Detection
+- **🔄 Force push detected**: Shows who force-pushed and when. Cross-references against conflict/staleness warnings to determine if someone already acted (e.g., ran `darc vmr resolve-conflict`).
+- **📭 Empty diff**: PR has 0 changed files. If this follows a force push after warnings, the PR is likely a no-op — its changes already landed in the target branch via other paths. Recommendations shift to merge-empty/close/force-trigger.
+
 ### Manual Commits
 Manual commits on the PR branch are at risk if the PR is closed or force-triggered. The script lists them so you can decide whether to preserve them.
 
@@ -136,6 +140,29 @@ darc vmr resolve-conflict --subscription <subscription-id>
 ```
 
 Install darc via `eng\common\darc-init.ps1` in any arcade-enabled repository.
+
+### When the script reports "Maestro may be stuck"
+
+When the script shows a missing backflow PR with "Maestro may be stuck" (builds are fresh but no PR was created), follow these diagnostic steps:
+
+1. **Check the subscription** to find when it last consumed a build:
+   ```bash
+   darc get-subscriptions --target-repo <repo> --source-repo dotnet/dotnet
+   ```
+   Look at the `Last Build` field — if it's weeks old while the channel has newer builds, the subscription is stuck.
+
+2. **Compare against the latest channel build** to confirm the gap:
+   ```bash
+   darc get-latest-build --repo dotnet/dotnet --channel "<channel-name>"
+   ```
+   Channel names follow patterns like `.NET 11.0.1xx SDK`, `.NET 10.0.1xx SDK`, `.NET 11.0.1xx SDK Preview 1`.
+
+3. **Trigger the subscription manually** to unstick it:
+   ```bash
+   darc trigger-subscriptions --id <subscription-id>
+   ```
+
+4. **If triggering doesn't produce a PR within a few minutes**, the issue may be deeper — check Maestro health or open an issue on `dotnet/arcade`.
 
 ## References
 

--- a/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
+++ b/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
@@ -1397,7 +1397,8 @@ $summary = [ordered]@{
     repository      = $Repository
     prState         = $pr.state
     currentState    = $currentState
-    isCodeflowPR    = ($isMaestroPR -or $isBackflow -or $isForwardFlow)
+    isCodeflowPR    = ($isBackflow -or $isForwardFlow)
+    isMaestroAuthored = $isMaestroPR
     flowDirection   = if ($isForwardFlow) { "forward" } elseif ($isBackflow) { "backflow" } else { "unknown" }
     isEmptyDiff     = $isEmptyDiff
     changedFiles    = [int]$pr.changedFiles
@@ -1409,13 +1410,13 @@ $summary = [ordered]@{
 }
 
 # Freshness
-$hasFresnessData = ($null -ne $vmrCommit -and $null -ne $sourceHeadSha)
+$hasFreshnessData = ($null -ne $vmrCommit -and $null -ne $sourceHeadSha)
 $summary.freshness = [ordered]@{
     sourceHeadSha   = if ($sourceHeadSha) { Get-ShortSha $sourceHeadSha } else { $null }
     compareStatus   = $compareStatus
     aheadBy         = $aheadBy
     behindBy        = $behindBy
-    isUpToDate      = if ($hasFresnessData) { ($vmrCommit -eq $sourceHeadSha -or $compareStatus -eq 'identical') } else { $null }
+    isUpToDate      = if ($hasFreshnessData) { ($vmrCommit -eq $sourceHeadSha -or $compareStatus -eq 'identical') } else { $null }
 }
 
 # Force pushes

--- a/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
+++ b/.github/skills/vmr-codeflow-status/scripts/Get-CodeflowStatus.ps1
@@ -703,8 +703,6 @@ $currentState = if ($isMerged) {
     "MERGED"
 } elseif ($isClosed) {
     "CLOSED"
-} elseif ($isEmptyDiff -and $forcePushEvents.Count -gt 0) {
-    "NO-OP"
 } elseif ($isEmptyDiff) {
     "NO-OP"
 } elseif ($forcePushEvents.Count -gt 0 -and $lastForcePushTime -and ([DateTime]::UtcNow - $lastForcePushTime).TotalHours -lt 24) {
@@ -1111,8 +1109,8 @@ if ($lastForcePushTime) {
         }
     }
     if ($stalenessWarnings.Count -gt 0 -and $lastStalenessComment) {
-        $lastWarnTime2 = [DateTimeOffset]::Parse($lastStalenessComment.createdAt).UtcDateTime
-        if ($lastForcePushTime -gt $lastWarnTime2) {
+        $lastStalenessTime = [DateTimeOffset]::Parse($lastStalenessComment.createdAt).UtcDateTime
+        if ($lastForcePushTime -gt $lastStalenessTime) {
             $stalenessMayBeResolved = $true
         }
     }


### PR DESCRIPTION
This improves the vmr-codeflow-status Copilot CLI skill with enhancements discovered while investigating a stale codeflow PR ([#124095](https://github.com/dotnet/runtime/pull/124095)).

## Design Change: Current State First

Inspired by the code-review skill restructuring in #124229, the analysis now follows a **"current state first, comments as history"** pattern:

1. **Assess current state** from primary signals (PR state, diff size, force pushes, timeline) before reading any Maestro comments
2. **Form an independent verdict** (MERGED / CLOSED / NO-OP / IN PROGRESS / STALE / ACTIVE)
3. **Then** read comments as historical context to explain how we got to the current state
4. **Recommendations** are generated by the agent from a structured JSON summary, not hardcoded script logic

Previously, the script read Maestro conflict/staleness comments first and drew conclusions from them — even when those comments were stale (e.g., after someone had already force-pushed a resolution). Recommendations were a 130-line if/elseif chain that couldn't adapt to edge cases.

## New Capabilities

### 1. Current State Assessment (Step 2)
Synthesizes primary signals into an immediate verdict before any comment parsing:
- `✅ MERGED` — PR has been merged, no action needed
- `✖️ CLOSED` — PR was closed without merging, Maestro should create a replacement
- `📭 NO-OP` — empty diff, likely already resolved
- `🔄 IN PROGRESS` — recent force push, awaiting update
- `⏳ STALE` — no activity for >3 days
- `✅ ACTIVE` — PR has content and recent activity

### 2. Force Push Detection
Queries PR timeline for `head_ref_force_pushed` events, showing who force-pushed and when. Uses `--slurp` for correct pagination handling.

### 3. Empty Diff Detection
Checks `changedFiles`/`additions`/`deletions` to flag 0-change PRs as NO-OP (regardless of whether a force push caused it).

### 4. Post-Action Staleness Analysis
Cross-references force push timestamps against conflict/staleness warnings. When a force push post-dates these warnings, the script correctly identifies the issues as potentially resolved.

### 5. JSON Summary + Agent-Generated Recommendations
The script's hardcoded recommendations (130+ lines of branching logic) have been replaced with:
- A `[CODEFLOW_SUMMARY]` JSON block emitted at the end of the script with all key facts
- `isCodeflowPR` boolean for explicit codeflow vs non-codeflow classification
- A "Generating Recommendations" section in SKILL.md that teaches the agent how to reason over the summary
- The agent now synthesizes contextual, nuanced recommendations instead of picking from a canned decision tree

### 6. Codeflow History (renamed section)
The former "Staleness & Conflict Check" is now "Codeflow History" with a framing line: *"Maestro warnings (historical — see Current State for present status)"*. This signals that comments describe past events, not necessarily current state.

## Testing
- Verified against PR #124095 (closed backflow with conflicts + force push) and PR #124231 (non-codeflow PR)
- Multi-model review round 1 (Claude Sonnet 4, GPT-5): consensus findings → added merged/closed state handling, empty-diff-only NO-OP, `--slurp` pagination fix
- Multi-model test round 2 (Claude Sonnet 4, GPT-5): functional test of JSON summary → fixed `isUpToDate` null handling, negative `daysSinceUpdate`, added `isCodeflowPR` field, clean exit codes, non-codeflow guidance in SKILL.md
