### PR TITLE
Add references for getAsyncInfo

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -332,10 +332,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     SetModuleTokenForTypeSystemEntity(_typeToRefTokens, ecmaType, token);
                 }
             }
-            else if (type.IsCanonicalDefinitionType(CanonicalFormKind.Specific))
-            {
-                return;
-            }
             else if (!specialTypeFound)
             {
                 throw new NotImplementedException(type.ToString());

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/ModuleTokenResolver.cs
@@ -129,6 +129,38 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
         }
 
+        public ModuleToken GetModuleTokenForField(FieldDesc field, bool allowDynamicallyCreatedReference, bool throwIfNotFound)
+        {
+            if (field.GetTypicalFieldDefinition() is EcmaField ecmaField)
+            {
+                if (_compilationModuleGroup.VersionsWithType(ecmaField.OwningType))
+                {
+                    return new ModuleToken(ecmaField.Module, ecmaField.Handle);
+                }
+
+                // If that didn't work, it may be in the manifest module used for version resilient cross module inlining
+                if (allowDynamicallyCreatedReference)
+                {
+                    var handle = _manifestMutableModule.TryGetExistingEntityHandle(ecmaField);
+                    if (handle.HasValue)
+                    {
+                        return new ModuleToken(_manifestMutableModule, handle.Value);
+                    }
+                }
+            }
+
+            // Reverse lookup failed
+            if (throwIfNotFound)
+            {
+                throw new NotImplementedException(field.ToString());
+            }
+            else
+            {
+                return default(ModuleToken);
+            }
+        }
+
+
         public void AddModuleTokenForMethod(MethodDesc method, ModuleToken token)
         {
             if (token.TokenType == CorTokenType.mdtMethodSpec)
@@ -299,6 +331,10 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 {
                     SetModuleTokenForTypeSystemEntity(_typeToRefTokens, ecmaType, token);
                 }
+            }
+            else if (type.IsCanonicalDefinitionType(CanonicalFormKind.Specific))
+            {
+                return;
             }
             else if (!specialTypeFound)
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -703,8 +703,8 @@ namespace ILCompiler
                                 _methodsWhichNeedMutableILBodies.Add(ecmaMethod);
                         }
 
-                        if (!CorInfoImpl.ShouldCodeNotBeCompiledIntoFinalImage(InstructionSetSupport, method)
-                            && method.IsAsyncCall())
+                        if (method.IsAsyncCall()
+                            && !CorInfoImpl.ShouldCodeNotBeCompiledIntoFinalImage(InstructionSetSupport, method))
                         {
                             AddNecessaryAsyncReferences(method);
                         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -984,7 +984,7 @@ namespace ILCompiler
             DefType continuation = TypeSystemContext.ContinuationType;
             var asyncHelpers = TypeSystemContext.SystemModule.GetKnownType("System.Runtime.CompilerServices"u8, "AsyncHelpers"u8);
             // AsyncHelpers should already be referenced in the module for the call to Await()
-            Debug.Assert(!_nodeFactory.Resolver.GetModuleTokenForType(asyncHelpers, allowDynamicallyCreatedReference: true, throwIfNotFound: true).IsNull);
+            Debug.Assert(!_nodeFactory.Resolver.GetModuleTokenForType(asyncHelpers, allowDynamicallyCreatedReference: true, throwIfNotFound: false).IsNull);
             TypeDesc[] requiredTypes = [continuation];
             FieldDesc[] requiredFields =
             [

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -21,6 +21,7 @@ using ILCompiler.DependencyAnalysis.ReadyToRun;
 using ILCompiler.DependencyAnalysisFramework;
 using ILCompiler.Reflection.ReadyToRun;
 using Internal.TypeSystem.Ecma;
+using ILCompiler.ReadyToRun.TypeSystem;
 
 namespace ILCompiler
 {
@@ -672,6 +673,7 @@ namespace ILCompiler
         private int _finishedThreadCount;
         private ManualResetEventSlim _compilationSessionComplete = new ManualResetEventSlim();
         private bool _hasCreatedCompilationThreads = false;
+        private bool _hasAddedAsyncReferences = false;
 
         protected override void ComputeDependencyNodeDependencies(List<DependencyNodeCore<NodeFactory>> obj)
         {
@@ -701,56 +703,14 @@ namespace ILCompiler
                                 _methodsWhichNeedMutableILBodies.Add(ecmaMethod);
                         }
 
-                        if (!_nodeFactory.CompilationModuleGroup.VersionsWithMethodBody(method))
+                        if (!CorInfoImpl.ShouldCodeNotBeCompiledIntoFinalImage(InstructionSetSupport, method)
+                            && method.IsAsyncCall())
                         {
-                            // Validate that the typedef tokens for all of the instantiation parameters of the method
-                            // have tokens.
-                            foreach (var type in method.Instantiation)
-                                EnsureTypeDefTokensAreReady(type);
-                            foreach (var type in method.OwningType.Instantiation)
-                                EnsureTypeDefTokensAreReady(type);
-
-                            void EnsureTypeDefTokensAreReady(TypeDesc type)
-                            {
-                                // Type represented by simple element type
-                                if (type.IsPrimitive || type.IsVoid || type.IsObject || type.IsString || type.IsTypedReference)
-                                    return;
-
-                                if (type is EcmaType ecmaType)
-                                {
-                                    if (!_nodeFactory.Resolver.GetModuleTokenForType(ecmaType, allowDynamicallyCreatedReference: false, throwIfNotFound: false).IsNull)
-                                        return;
-                                    try
-                                    {
-                                        Debug.Assert(_nodeFactory.CompilationModuleGroup.CrossModuleInlineableModule(ecmaType.Module));
-                                        _nodeFactory.ManifestMetadataTable._mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences
-                                            = ecmaType.Module;
-                                        if (!_nodeFactory.ManifestMetadataTable._mutableModule.TryGetEntityHandle(ecmaType).HasValue)
-                                            throw new InternalCompilerErrorException($"Unable to create token to {ecmaType}");
-                                    }
-                                    finally
-                                    {
-                                        _nodeFactory.ManifestMetadataTable._mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences
-                                            = null;
-                                    }
-                                    return;
-                                }
-
-                                if (type.HasInstantiation)
-                                {
-                                    EnsureTypeDefTokensAreReady(type.GetTypeDefinition());
-
-                                    foreach (TypeDesc instParam in type.Instantiation)
-                                    {
-                                        EnsureTypeDefTokensAreReady(instParam);
-                                    }
-                                }
-                                else if (type.IsParameterizedType)
-                                {
-                                    EnsureTypeDefTokensAreReady(type.GetParameterType());
-                                }
-                            }
+                            AddNecessaryAsyncReferences(method);
                         }
+
+                        if (!_nodeFactory.CompilationModuleGroup.VersionsWithMethodBody(method))
+                            EnsureInstantiationReferencesArePresentForExternalMethod(method);
                     }
                 }
 
@@ -961,6 +921,118 @@ namespace ILCompiler
                     if (Logger.IsVerbose)
                         Logger.Writer.WriteLine($"Warning: Method `{method}` was not compiled because `{ex.Message}` requires runtime JIT");
                 }
+            }
+        }
+
+        private void EnsureInstantiationReferencesArePresentForExternalMethod(MethodDesc method)
+        {
+            // Validate that the typedef tokens for all of the instantiation parameters of the method
+            // have tokens.
+            foreach (var type in method.Instantiation)
+                EnsureTypeDefTokensAreReady(type);
+            foreach (var type in method.OwningType.Instantiation)
+                EnsureTypeDefTokensAreReady(type);
+
+            void EnsureTypeDefTokensAreReady(TypeDesc type)
+            {
+                // Type represented by simple element type
+                if (type.IsPrimitive || type.IsVoid || type.IsObject || type.IsString || type.IsTypedReference)
+                    return;
+
+                if (type is EcmaType ecmaType)
+                {
+                    if (!_nodeFactory.Resolver.GetModuleTokenForType(ecmaType, allowDynamicallyCreatedReference: false, throwIfNotFound: false).IsNull)
+                        return;
+                    try
+                    {
+                        Debug.Assert(_nodeFactory.CompilationModuleGroup.CrossModuleInlineableModule(ecmaType.Module));
+                        _nodeFactory.ManifestMetadataTable._mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences
+                            = ecmaType.Module;
+                        if (!_nodeFactory.ManifestMetadataTable._mutableModule.TryGetEntityHandle(ecmaType).HasValue)
+                            throw new InternalCompilerErrorException($"Unable to create token to {ecmaType}");
+                    }
+                    finally
+                    {
+                        _nodeFactory.ManifestMetadataTable._mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences
+                            = null;
+                    }
+                    return;
+                }
+
+                if (type.HasInstantiation)
+                {
+                    EnsureTypeDefTokensAreReady(type.GetTypeDefinition());
+
+                    foreach (TypeDesc instParam in type.Instantiation)
+                    {
+                        EnsureTypeDefTokensAreReady(instParam);
+                    }
+                }
+                else if (type.IsParameterizedType)
+                {
+                    EnsureTypeDefTokensAreReady(type.GetParameterType());
+                }
+            }
+        }
+
+        private void AddNecessaryAsyncReferences(MethodDesc method)
+        {
+            if (_hasAddedAsyncReferences)
+                return;
+
+            // Keep in sync with CorInfoImpl.getAsyncInfo()
+            DefType continuation = TypeSystemContext.ContinuationType;
+            var runtimeHelpers = TypeSystemContext.SystemModule.GetKnownType("System.Runtime.CompilerServices"u8, "RuntimeHelpers"u8);
+            var asyncHelpers = TypeSystemContext.SystemModule.GetKnownType("System.Runtime.CompilerServices"u8, "AsyncHelpers"u8);
+            // AsyncHelpers should already be referenced in the module for the call to Await()
+            Debug.Assert(!_nodeFactory.Resolver.GetModuleTokenForType(asyncHelpers, allowDynamicallyCreatedReference: true, throwIfNotFound: true).IsNull);
+            TypeDesc[] requiredTypes = [continuation];
+            FieldDesc[] requiredFields = [
+                // For CorInfoImpl.getAsyncInfo
+                continuation.GetKnownField("Next"u8),
+                                continuation.GetKnownField("ResumeInfo"u8),
+                                continuation.GetKnownField("State"u8),
+                                continuation.GetKnownField("Flags"u8),
+                            ];
+            MethodDesc[] requiredMethods = [
+                // For CorInfoImpl.getAsyncInfo
+                asyncHelpers.GetKnownMethod("CaptureExecutionContext"u8, null),
+                                asyncHelpers.GetKnownMethod("RestoreExecutionContext"u8, null),
+                                asyncHelpers.GetKnownMethod("CaptureContinuationContext"u8, null),
+                                asyncHelpers.GetKnownMethod("CaptureContexts"u8, null),
+                                asyncHelpers.GetKnownMethod("RestoreContexts"u8, null),
+                                asyncHelpers.GetKnownMethod("RestoreContextsOnSuspension"u8, null),
+
+                                // R2R Helpers
+                                asyncHelpers.GetKnownMethod("AllocContinuation"u8, null),
+                                asyncHelpers.GetKnownMethod("AllocContinuationClass"u8, null),
+                                asyncHelpers.GetKnownMethod("AllocContinuationMethod"u8, null),
+                            ];
+            _nodeFactory.ManifestMetadataTable._mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences = ((EcmaMethod)method.GetPrimaryMethodDesc().GetTypicalMethodDefinition()).Module;
+            try
+            {
+                // Unconditionally add references to the MutableModule. These members are internal / private and
+                // shouldn't be referenced already, and this lets us avoid doing this more than once
+                foreach (var td in requiredTypes)
+                {
+                    if (!_nodeFactory.ManifestMetadataTable._mutableModule.TryGetEntityHandle(td).HasValue)
+                        throw new InternalCompilerErrorException($"Unable to create token to {td}");
+                }
+                foreach (var fd in requiredFields)
+                {
+                    if (!_nodeFactory.ManifestMetadataTable._mutableModule.TryGetEntityHandle(fd).HasValue)
+                        throw new InternalCompilerErrorException($"Unable to create token to {fd}");
+                }
+                foreach (var md in requiredMethods)
+                {
+                    if (!_nodeFactory.ManifestMetadataTable._mutableModule.TryGetEntityHandle(md).HasValue)
+                        throw new InternalCompilerErrorException($"Unable to create token to {md}");
+                }
+                _hasAddedAsyncReferences = true;
+            }
+            finally
+            {
+                _nodeFactory.ManifestMetadataTable._mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences = null;
             }
         }
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -805,7 +805,7 @@ namespace ILCompiler
                 while (true)
                 {
                     _compilationThreadSemaphore.Wait();
-                    lock(this)
+                    lock (this)
                     {
                         if (_doneAllCompiling)
                             return;
@@ -987,27 +987,29 @@ namespace ILCompiler
             // AsyncHelpers should already be referenced in the module for the call to Await()
             Debug.Assert(!_nodeFactory.Resolver.GetModuleTokenForType(asyncHelpers, allowDynamicallyCreatedReference: true, throwIfNotFound: true).IsNull);
             TypeDesc[] requiredTypes = [continuation];
-            FieldDesc[] requiredFields = [
+            FieldDesc[] requiredFields =
+            [
                 // For CorInfoImpl.getAsyncInfo
                 continuation.GetKnownField("Next"u8),
-                                continuation.GetKnownField("ResumeInfo"u8),
-                                continuation.GetKnownField("State"u8),
-                                continuation.GetKnownField("Flags"u8),
-                            ];
-            MethodDesc[] requiredMethods = [
+                continuation.GetKnownField("ResumeInfo"u8),
+                continuation.GetKnownField("State"u8),
+                continuation.GetKnownField("Flags"u8),
+            ];
+            MethodDesc[] requiredMethods =
+            [
                 // For CorInfoImpl.getAsyncInfo
                 asyncHelpers.GetKnownMethod("CaptureExecutionContext"u8, null),
-                                asyncHelpers.GetKnownMethod("RestoreExecutionContext"u8, null),
-                                asyncHelpers.GetKnownMethod("CaptureContinuationContext"u8, null),
-                                asyncHelpers.GetKnownMethod("CaptureContexts"u8, null),
-                                asyncHelpers.GetKnownMethod("RestoreContexts"u8, null),
-                                asyncHelpers.GetKnownMethod("RestoreContextsOnSuspension"u8, null),
+                asyncHelpers.GetKnownMethod("RestoreExecutionContext"u8, null),
+                asyncHelpers.GetKnownMethod("CaptureContinuationContext"u8, null),
+                asyncHelpers.GetKnownMethod("CaptureContexts"u8, null),
+                asyncHelpers.GetKnownMethod("RestoreContexts"u8, null),
+                asyncHelpers.GetKnownMethod("RestoreContextsOnSuspension"u8, null),
 
-                                // R2R Helpers
-                                asyncHelpers.GetKnownMethod("AllocContinuation"u8, null),
-                                asyncHelpers.GetKnownMethod("AllocContinuationClass"u8, null),
-                                asyncHelpers.GetKnownMethod("AllocContinuationMethod"u8, null),
-                            ];
+                // R2R Helpers
+                asyncHelpers.GetKnownMethod("AllocContinuation"u8, null),
+                asyncHelpers.GetKnownMethod("AllocContinuationClass"u8, null),
+                asyncHelpers.GetKnownMethod("AllocContinuationMethod"u8, null),
+            ];
             _nodeFactory.ManifestMetadataTable._mutableModule.ModuleThatIsCurrentlyTheSourceOfNewReferences = ((EcmaMethod)method.GetPrimaryMethodDesc().GetTypicalMethodDefinition()).Module;
             try
             {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -982,7 +982,6 @@ namespace ILCompiler
 
             // Keep in sync with CorInfoImpl.getAsyncInfo()
             DefType continuation = TypeSystemContext.ContinuationType;
-            var runtimeHelpers = TypeSystemContext.SystemModule.GetKnownType("System.Runtime.CompilerServices"u8, "RuntimeHelpers"u8);
             var asyncHelpers = TypeSystemContext.SystemModule.GetKnownType("System.Runtime.CompilerServices"u8, "AsyncHelpers"u8);
             // AsyncHelpers should already be referenced in the module for the call to Await()
             Debug.Assert(!_nodeFactory.Resolver.GetModuleTokenForType(asyncHelpers, allowDynamicallyCreatedReference: true, throwIfNotFound: true).IsNull);


### PR DESCRIPTION
Add references for CorInfoImpl.getAsyncInfo.

Add GetHandleForField for Continuation field accesses.

Create AddNecessaryAsyncReferences to put the references required by getAsyncInfo into the mutable module.

Move code that ensured typedef tokens are present for instantiated methods outside the version bubble to EnsureInstantiationReferencesArePresentForExternalMethod.