### PR TITLE
ci-analysis: structured output, MCP integration, and deep investigation guides

### DIFF
--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -75,7 +75,7 @@ The script operates in three distinct modes depending on what information you ha
 ## What the Script Does
 
 ### PR Analysis Mode (`-PRNumber`)
-1. Discovers all AzDO builds associated with the PR
+1. Discovers AzDO builds associated with the PR (via `gh pr checks` — finds failing builds and one non-failing build as fallback; for full build history, use `azure-devops-pipelines_get_builds`)
 2. Fetches Build Analysis for known issues
 3. Gets failed jobs from Azure DevOps timeline
 4. **Separates canceled jobs from failed jobs** (canceled may be dependency-canceled or timeout-canceled)

--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -100,9 +100,9 @@ The script operates in three distinct modes depending on what information you ha
 
 **Known Issues section**: Failures matching existing GitHub issues - these are tracked and being investigated.
 
-**Canceled jobs**: Jobs that were canceled (not failed) due to earlier stage failures or timeouts. Dependency-canceled jobs (canceled because an earlier stage failed) don't need investigation. Timeout-canceled jobs may still have recoverable Helix results — see "Recovering Results from Canceled Jobs" below.
+**Canceled/timed-out jobs**: Jobs canceled due to earlier stage failures or AzDO timeouts. Dependency-canceled jobs don't need investigation. **Timeout-canceled jobs may have all-passing Helix results** — the "failure" is just the AzDO job wrapper timing out, not actual test failures. To verify: use `hlx_status` on each Helix job in the timed-out build. If all work items passed, the build effectively passed.
 
-> ❌ **Don't dismiss canceled jobs.** Timeout-canceled jobs may have passing Helix results that prove the "failure" was just an AzDO timeout wrapper issue.
+> ❌ **Don't dismiss timed-out builds.** A build marked "failed" due to a 3-hour AzDO timeout can have 100% passing Helix work items. Check before concluding it failed.
 
 **PR Change Correlation**: Files changed by PR appearing in failures - likely PR-related.
 

--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -142,7 +142,7 @@ Then layer in nuance the heuristic can't capture:
 - **Canceled jobs with recoverable results**: If `canceledJobNames` is non-empty, mention that canceled jobs may have passing Helix results (see "Recovering Results from Canceled Jobs").
 - **Build still in progress**: If `lastBuildJobSummary.pending > 0`, note that more failures may appear.
 - **Multiple builds**: If `builds` has >1 entry, `lastBuildJobSummary` reflects only the last build — use `totalFailedJobs` for the aggregate count.
-- **BuildId mode**: `knownIssues` and `prCorrelation` will be empty (those require a PR number). Don't say "no known issues" — say "Build Analysis not available in BuildId mode."
+- **BuildId mode**: `knownIssues` will be empty and `prCorrelation` will show `hasCorrelation = false` with `changedFileCount = 0` (PR correlation is not available without a PR number). Don't say "no known issues" or "no correlation" — say "Build Analysis and PR correlation not available in BuildId mode."
 - **Infrastructure vs code**: Don't label failures as "infrastructure" unless Build Analysis flagged them or the same test passes on the target branch. See the anti-patterns in "Interpreting Results" above.
 
 ### How to Retry

--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -190,6 +190,11 @@ Run with `-ShowLogs` for detailed failure info.
    - Failure is **not** in Build Analysis → Investigate further before assuming transient
    - Device failures, Docker pulls, network timeouts → *Could* be infrastructure, but verify against the target branch first
    - Test timeout but tests passed → Executor issue, not test failure
+5. **Check for mismatch with user's question** — The script only reports builds for the current head SHA. If the user asks about a job, error, or cancellation that doesn't appear in the results, **ask** if they're referring to a prior build. Common triggers:
+   - User mentions a canceled job but `canceledJobNames` is empty
+   - User says "CI is failing" but the latest build is green
+   - User references a specific job name not in the current results
+   Offer to re-run with `-BuildId` if the user can provide the earlier build ID from AzDO.
 
 ### Step 3: Verify before claiming
 

--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -213,7 +213,7 @@ Run with `-ShowLogs` for detailed failure info.
 
 ### Step 2: Analyze results
 
-1. **Check Build Analysis** — If the Build Analysis GitHub check is **green**, all failures matched known issues and it's safe to retry. If it's **red**, some failures are unaccounted for — you must identify which failing jobs are covered by known issues and which are not. Never say "all failures are known issues" when Build Analysis is red.
+1. **Check Build Analysis** — If the Build Analysis GitHub check is **green**, all failures matched known issues and it's safe to retry. If it's **red**, some failures are unaccounted for — you must identify which failing jobs are covered by known issues and which are not. For 3+ failures, use SQL tracking to avoid missed matches (see [references/sql-tracking.md](references/sql-tracking.md)).
 2. **Correlate with PR changes** — Same files failing = likely PR-related
 3. **Compare with baseline** — If a test passes on the target branch but fails on the PR, compare Helix binlogs. See [references/binlog-comparison.md](references/binlog-comparison.md) — **delegate binlog download/extraction to subagents** to avoid burning context on mechanical work.
 4. **Check build progression** — If the PR has multiple builds (multiple pushes), check whether earlier builds passed. A failure that appeared after a specific push narrows the investigation to those commits. See [references/build-progression-analysis.md](references/build-progression-analysis.md). Present findings as facts, not fix recommendations.
@@ -247,6 +247,7 @@ Before stating a failure's cause, verify your claim:
 - **Subagent delegation patterns**: See [references/delegation-patterns.md](references/delegation-patterns.md)
 - **Azure CLI deep investigation**: See [references/azure-cli.md](references/azure-cli.md)
 - **Manual investigation steps**: See [references/manual-investigation.md](references/manual-investigation.md)
+- **SQL tracking for investigations**: See [references/sql-tracking.md](references/sql-tracking.md)
 - **AzDO/Helix details**: See [references/azdo-helix-reference.md](references/azdo-helix-reference.md)
 
 ## Tips

--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -230,6 +230,6 @@ Before stating a failure's cause, verify your claim:
 1. Check if same test fails on the target branch before assuming transient
 2. Look for `[ActiveIssue]` attributes for known skipped tests
 3. Use `-SearchMihuBot` for semantic search of related issues
-4. Use the MSBuild MCP server (`binlog.mcp`) to search binlogs for Helix job IDs, build errors, and properties
+4. Use the binlog MCP tools (`mcp-binlog-tool-*`) to search binlogs for Helix job IDs, build errors, and properties
 5. `gh pr checks --json` valid fields: `bucket`, `completedAt`, `description`, `event`, `link`, `name`, `startedAt`, `state`, `workflow` — no `conclusion` field, `state` has `SUCCESS`/`FAILURE` directly
 6. "Canceled" ≠ "Failed" — canceled jobs may have recoverable Helix results. Check artifacts before concluding results are lost.

--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -66,7 +66,7 @@ The script operates in three distinct modes depending on what information you ha
 
 | You have... | Use | What you get |
 |-------------|-----|-------------|
-| A GitHub PR number | `-PRNumber 12345` | Full analysis: all builds, failures, known issues, retry recommendation |
+| A GitHub PR number | `-PRNumber 12345` | Full analysis: all builds, failures, known issues, structured JSON summary |
 | An AzDO build ID | `-BuildId 1276327` | Single build analysis: timeline, failures, Helix results |
 | A Helix job ID (optionally a specific work item) | `-HelixJob "..." [-WorkItem "..."]` | Deep dive: list work items for the job, or with `-WorkItem`, focus on a single work item's console logs, artifacts, and test results |
 

--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -130,7 +130,7 @@ When an AzDO job is canceled (timeout) or Helix work items show `Crash` (exit co
 
 1. **Find the Helix job IDs** — Read the AzDO "Send to Helix" step log (use `azure-devops-pipelines_get_build_log_by_id`) and search for lines containing `Sent Helix Job`. Extract the job GUIDs.
 
-2. **Check Helix job status** — Use `hlx_batch_status` (batches of 4) or `hlx_status` per job. Look at `failedCount` vs `passedCount`.
+2. **Check Helix job status** — Use `hlx_batch_status` (accepts comma-separated job IDs) or `hlx_status` per job. Look at `failedCount` vs `passedCount`.
 
 3. **For work items marked Crash/Failed** — Use `hlx_files` to check if `testResults.xml` was uploaded. If it exists:
    - Download it with `hlx_download_url`

--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -186,13 +186,14 @@ Run with `-ShowLogs` for detailed failure info.
 1. **Check Build Analysis** — Known issues are safe to retry
 2. **Correlate with PR changes** — Same files failing = likely PR-related
 3. **Compare with baseline** — If a test passes on the target branch but fails on the PR, compare Helix binlogs. See [references/binlog-comparison.md](references/binlog-comparison.md) — **delegate binlog download/extraction to subagents** to avoid burning context on mechanical work.
-4. **Interpret patterns** (but don't jump to conclusions):
+4. **Check build progression** — If the PR has multiple builds (multiple pushes), check whether earlier builds passed. A failure that appeared after a specific push narrows the investigation to those commits. See [references/build-progression-analysis.md](references/build-progression-analysis.md). Present findings as facts, not fix recommendations.
+5. **Interpret patterns** (but don't jump to conclusions):
    - Same error across many jobs → Real code issue
    - Build Analysis flags a known issue → Safe to retry
    - Failure is **not** in Build Analysis → Investigate further before assuming transient
    - Device failures, Docker pulls, network timeouts → *Could* be infrastructure, but verify against the target branch first
    - Test timeout but tests passed → Executor issue, not test failure
-5. **Check for mismatch with user's question** — The script only reports builds for the current head SHA. If the user asks about a job, error, or cancellation that doesn't appear in the results, **ask** if they're referring to a prior build. Common triggers:
+6. **Check for mismatch with user's question** — The script only reports builds for the current head SHA. If the user asks about a job, error, or cancellation that doesn't appear in the results, **ask** if they're referring to a prior build. Common triggers:
    - User mentions a canceled job but `canceledJobNames` is empty
    - User says "CI is failing" but the latest build is green
    - User references a specific job name not in the current results
@@ -238,6 +239,7 @@ Specific next steps: retry, fix specific files, investigate further. Include `/a
 
 - **Helix artifacts & binlogs**: See [references/helix-artifacts.md](references/helix-artifacts.md)
 - **Binlog comparison (passing vs failing)**: See [references/binlog-comparison.md](references/binlog-comparison.md)
+- **Build progression (commit-to-build correlation)**: See [references/build-progression-analysis.md](references/build-progression-analysis.md)
 - **Subagent delegation patterns**: See [references/delegation-patterns.md](references/delegation-patterns.md)
 - **Azure CLI deep investigation**: See [references/azure-cli.md](references/azure-cli.md)
 - **Manual investigation steps**: See [references/manual-investigation.md](references/manual-investigation.md)

--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -133,6 +133,8 @@ Read `recommendationHint` as a starting point, then layer in context:
 | `LIKELY_PR_RELATED` | Failures correlate with PR changes. Lead with "fix these before retrying" and list `correlatedFiles`. |
 | `POSSIBLY_TRANSIENT` | No correlation with PR changes, no known issues. Suggest checking the target branch, searching for issues, or retrying. |
 | `REVIEW_REQUIRED` | Could not auto-determine cause. Review failures manually. |
+| `MERGE_CONFLICTS` | PR has merge conflicts — CI won't run. Tell the user to resolve conflicts. Offer to analyze a previous build by ID. |
+| `NO_BUILDS` | No AzDO builds found (CI not triggered). Offer to check if CI needs to be triggered or analyze a previous build. |
 
 Then layer in nuance the heuristic can't capture:
 

--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -165,7 +165,7 @@ Read `recommendationHint` as a starting point, then layer in context:
 Then layer in nuance the heuristic can't capture:
 
 - **Mixed signals**: Some failures match known issues AND some correlate with PR changes → separate them. Known issues = safe to retry; correlated = fix first.
-- **Canceled jobs with recoverable results**: If `canceledJobNames` is non-empty, mention that canceled jobs may have passing Helix results (see "Recovering Results from Canceled Jobs").
+- **Canceled jobs with recoverable results**: If `canceledJobNames` is non-empty, mention that canceled jobs may have passing Helix results (see "Recovering Results from Crashed/Canceled Jobs").
 - **Build still in progress**: If `lastBuildJobSummary.pending > 0`, note that more failures may appear.
 - **Multiple builds**: If `builds` has >1 entry, `lastBuildJobSummary` reflects only the last build — use `totalFailedJobs` for the aggregate count.
 - **BuildId mode**: `knownIssues` and `prCorrelation` won't be populated. Say "Build Analysis and PR correlation not available in BuildId mode."

--- a/.github/skills/ci-analysis/references/azure-cli.md
+++ b/.github/skills/ci-analysis/references/azure-cli.md
@@ -1,0 +1,93 @@
+# Deep Investigation with Azure CLI
+
+When the CI script and GitHub APIs aren't enough (e.g., investigating internal pipeline definitions or downloading build artifacts), use the Azure CLI with the `azure-devops` extension.
+
+> 💡 **Prefer `az pipelines` / `az devops` commands over raw REST API calls.** The CLI handles authentication, pagination, and JSON output formatting. Only fall back to manual `Invoke-RestMethod` calls when the CLI doesn't expose the endpoint you need (e.g., build timelines). The CLI's `--query` (JMESPath) and `-o table` flags are powerful for filtering without extra scripting.
+
+## Checking Authentication
+
+Before making AzDO API calls, verify the CLI is installed and authenticated:
+
+```powershell
+# Ensure az is on PATH (Windows may need a refresh after install)
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+
+# Check if az CLI is available
+az --version 2>$null | Select-Object -First 1
+
+# Check if logged in and get current account
+az account show --query "{name:name, user:user.name}" -o table 2>$null
+
+# If not logged in, prompt the user to authenticate:
+#   az login                              # Interactive browser login
+#   az login --use-device-code            # Device code flow (for remote/headless)
+
+# Get an AAD access token for AzDO REST API calls (only needed for raw REST)
+$accessToken = (az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+$headers = @{ "Authorization" = "Bearer $accessToken" }
+```
+
+> ⚠️ If `az` is not installed, use `winget install -e --id Microsoft.AzureCLI` (Windows). The `azure-devops` extension is also required — install or verify it with `az extension add --name azure-devops` (safe to run if already installed). Ask the user to authenticate if needed.
+
+> ⚠️ **Do NOT use `az devops configure --defaults`** — it sets user-wide defaults that may not match the organization/project needed for dotnet repositories. Always pass `--org` and `--project` (or `-p`) explicitly on each command.
+
+## Querying Pipeline Definitions and Builds
+
+```powershell
+$org = "https://dev.azure.com/dnceng"
+$project = "internal"
+
+# Find a pipeline definition by name
+az pipelines list --name "dotnet-unified-build" --org $org -p $project --query "[].{id:id, name:name, path:path}" -o table
+
+# Get pipeline definition details (shows YAML path, triggers, etc.)
+az pipelines show --id 1330 --org $org -p $project --query "{id:id, name:name, yamlPath:process.yamlFilename, repo:repository.name}" -o table
+
+# List recent builds for a pipeline (with filtering)
+az pipelines runs list --pipeline-ids 1330 --branch "refs/heads/main" --top 5 --org $org -p $project --query "[].{id:id, result:result, finish:finishTime}" -o table
+
+# Get a specific build's details
+az pipelines runs show --id $buildId --org $org -p $project --query "{id:id, result:result, sourceBranch:sourceBranch}" -o table
+
+# List build artifacts
+az pipelines runs artifact list --run-id $buildId --org $org -p $project --query "[].{name:name, type:resource.type}" -o table
+
+# Download a build artifact
+az pipelines runs artifact download --run-id $buildId --artifact-name "TestBuild_linux_x64" --path "$env:TEMP\artifact" --org $org -p $project
+```
+
+## REST API Fallback
+
+Fall back to REST API only when the CLI doesn't expose what you need:
+
+```powershell
+# Get build timeline (stages, jobs, tasks with results and durations) — no CLI equivalent
+$accessToken = (az account get-access-token --resource 499b84ac-1321-427f-aa17-267ca6975798 --query accessToken -o tsv)
+$headers = @{ "Authorization" = "Bearer $accessToken" }
+$timelineUrl = "https://dev.azure.com/dnceng/internal/_apis/build/builds/$buildId/timeline?api-version=7.1"
+$timeline = (Invoke-RestMethod -Uri $timelineUrl -Headers $headers)
+$timeline.records | Where-Object { $_.result -eq "failed" -and $_.type -eq "Job" }
+```
+
+## Examining Pipeline YAML
+
+All dotnet repos that use arcade put their pipeline definitions under `eng/pipelines/`. Use `az pipelines show` to find the YAML file path, then fetch it:
+
+```powershell
+# Find the YAML path for a pipeline
+az pipelines show --id 1330 --org $org -p $project --query "{yamlPath:process.yamlFilename, repo:repository.name}" -o table
+
+# Fetch the YAML from the repo (example: dotnet/runtime's runtime-official pipeline)
+#   github-mcp-server-get_file_contents owner:dotnet repo:runtime path:eng/pipelines/runtime-official.yml
+
+# For VMR unified builds, the YAML is in dotnet/dotnet:
+#   github-mcp-server-get_file_contents owner:dotnet repo:dotnet path:eng/pipelines/unified-build.yml
+
+# Templates are usually in eng/pipelines/common/ or eng/pipelines/templates/
+```
+
+This is especially useful when:
+- A job name doesn't clearly indicate what it builds
+- You need to understand stage dependencies (why a job was canceled)
+- You want to find which template defines a specific step
+- Investigating whether a pipeline change caused new failures

--- a/.github/skills/ci-analysis/references/azure-cli.md
+++ b/.github/skills/ci-analysis/references/azure-cli.md
@@ -43,8 +43,8 @@ az pipelines list --name "dotnet-unified-build" --org $org -p $project --query "
 # Get pipeline definition details (shows YAML path, triggers, etc.)
 az pipelines show --id 1330 --org $org -p $project --query "{id:id, name:name, yamlPath:process.yamlFilename, repo:repository.name}" -o table
 
-# List recent builds for a pipeline (with filtering)
-az pipelines runs list --pipeline-ids 1330 --branch "refs/heads/main" --top 5 --org $org -p $project --query "[].{id:id, result:result, finish:finishTime}" -o table
+# List recent builds for a pipeline (replace {TARGET_BRANCH} with the PR's base branch, e.g., main or release/9.0)
+az pipelines runs list --pipeline-ids 1330 --branch "refs/heads/{TARGET_BRANCH}" --top 5 --org $org -p $project --query "[].{id:id, result:result, finish:finishTime}" -o table
 
 # Get a specific build's details
 az pipelines runs show --id $buildId --org $org -p $project --query "{id:id, result:result, sourceBranch:sourceBranch}" -o table

--- a/.github/skills/ci-analysis/references/binlog-comparison.md
+++ b/.github/skills/ci-analysis/references/binlog-comparison.md
@@ -1,0 +1,144 @@
+# Deep Investigation: Binlog Comparison
+
+When a test **passes on main but fails on a PR**, comparing MSBuild binlogs from both runs reveals the exact difference in task parameters without guessing.
+
+## When to Use This Pattern
+
+- Test assertion compares "expected vs actual" build outputs (e.g., CSC args, reference lists)
+- A build succeeds on one branch but fails on another with different MSBuild behavior
+- You need to find which MSBuild property/item change caused a specific task to behave differently
+
+## The Pattern: Delegate to Subagents
+
+> ⚠️ **Do NOT download, load, and parse binlogs in the main conversation context.** This burns 10+ turns on mechanical work. Delegate to subagents instead.
+
+### Step 1: Identify the two work items to compare
+
+Use `Get-CIStatus.ps1` to find the failing Helix job + work item, then find a corresponding passing build (recent PR merged to main, or a main CI run).
+
+**Finding Helix job IDs from build artifacts (binlogs to find binlogs):**
+When the failing work item's Helix job ID isn't visible (e.g., canceled jobs, or finding a matching job from a passing build), the IDs are inside the build's `SendToHelix.binlog`:
+
+1. Download the build artifact with `az`:
+   ```
+   az pipelines runs artifact list --run-id $buildId --org "https://dev.azure.com/dnceng-public" -p public --query "[].name" -o tsv
+   az pipelines runs artifact download --run-id $buildId --artifact-name "TestBuild_linux_x64" --path "$env:TEMP\artifact" --org "https://dev.azure.com/dnceng-public" -p public
+   ```
+2. Load the binlog and search for job IDs:
+   ```
+   binlog-load_binlog  path:"$env:TEMP\artifact\...\SendToHelix.binlog"
+   binlog-search_binlog  binlog_file:"..."  query:"Sent Helix Job"
+   ```
+3. Query each Helix job GUID with the CI script:
+   ```
+   ./scripts/Get-CIStatus.ps1 -HelixJob "{GUID}" -FindBinlogs
+   ```
+
+**For Helix work item binlogs (the common case):**
+The CI script shows binlog URLs directly when you query a specific work item:
+```
+./scripts/Get-CIStatus.ps1 -HelixJob "{JOB_ID}" -WorkItem "{WORK_ITEM}"
+# Output includes: 🔬 msbuild.binlog: https://helix...blob.core.windows.net/...
+```
+
+### Step 2: Dispatch parallel subagents for extraction
+
+Launch two `task` subagents (can run in parallel), each with a prompt like:
+
+```
+Download the msbuild.binlog from Helix job {JOB_ID} work item {WORK_ITEM}.
+Use the CI skill script to get the artifact URL:
+  C:\Users\lewing\.copilot\skills\ci-analysis\scripts\Get-CIStatus.ps1 -HelixJob "{JOB_ID}" -WorkItem "{WORK_ITEM}"
+Download the binlog URL to $env:TEMP\{label}.binlog.
+Load it with the binlog MCP server (binlog-load_binlog).
+Search for the {TASK_NAME} task (binlog-search_tasks_by_name).
+Get full task details (binlog-list_tasks_in_target) for the target containing the task.
+Extract the CommandLineArguments parameter value.
+Normalize paths:
+  - Replace Helix work dirs (/datadisks/disk1/work/XXXXXXXX) with {W}
+  - Replace runfile hashes (Program-[a-f0-9]+) with Program-{H}
+  - Replace temp dir names (dotnetSdkTests.[a-zA-Z0-9]+) with dotnetSdkTests.{T}
+Parse into individual args using regex: (?:"[^"]+"|/[^\s]+|[^\s]+)
+Sort the list and return it.
+Report the total arg count prominently.
+```
+
+**Important:** When diffing, look for **extra or missing args** (different count), not value differences in existing args. A Debug/Release difference in `/define:` is expected noise — an extra `/analyzerconfig:` or `/reference:` arg is the real signal.
+
+### Step 3: Diff the results
+
+With two normalized arg lists, `Compare-Object` instantly reveals the difference.
+
+## Useful Binlog MCP Queries
+
+After loading a binlog with `binlog-load_binlog`, use these queries (pass the loaded path as `binlog_file`):
+
+```
+# Find all invocations of a specific task
+binlog-search_tasks_by_name  binlog_file:"$env:TEMP\my.binlog"  taskName:"Csc"
+
+# Search for a property value
+binlog-search_binlog  binlog_file:"..."  query:"analysislevel"
+
+# Find what happened inside a specific target
+binlog-search_binlog  binlog_file:"..."  query:"under($target AddGlobalAnalyzerConfigForPackage_MicrosoftCodeAnalysisNetAnalyzers)"
+
+# Get all properties matching a pattern
+binlog-search_binlog  binlog_file:"..."  query:"GlobalAnalyzerConfig"
+
+# List tasks in a target (returns full parameter details including CommandLineArguments)
+binlog-list_tasks_in_target  binlog_file:"..."  projectId:22  targetId:167
+```
+
+## Path Normalization
+
+Helix work items run on different machines with different paths. Normalize before comparing:
+
+| Pattern | Replacement | Example |
+|---------|-------------|---------|
+| `/datadisks/disk1/work/[A-F0-9]{8}` | `{W}` | Helix work directory (Linux) |
+| `C:\h\w\[A-F0-9]{8}` | `{W}` | Helix work directory (Windows) |
+| `Program-[a-f0-9]{64}` | `Program-{H}` | Runfile content hash |
+| `dotnetSdkTests\.[a-zA-Z0-9]+` | `dotnetSdkTests.{T}` | Temp test directory |
+
+### After normalizing paths, focus on structural differences
+
+> ⚠️ **Ignore value-only differences in existing args** (e.g., Debug vs Release in `/define:`, different hash paths). These are expected configuration differences. Focus on **extra or missing args** — a different arg count indicates a real build behavior change.
+
+## Example: CscArguments Investigation
+
+A merge PR (release/10.0.3xx → main) had 208 CSC args vs 207 on main. The diff:
+
+```
+FAIL-ONLY: /analyzerconfig:{W}/p/d/sdk/11.0.100-ci/Sdks/Microsoft.NET.Sdk/analyzers/build/config/analysislevel_11_default.globalconfig
+```
+
+### What the binlog properties showed
+
+Both builds had identical property resolution:
+- `EffectiveAnalysisLevel = 11.0`
+- `_GlobalAnalyzerConfigFileName = analysislevel_11_default.globalconfig`
+- `_GlobalAnalyzerConfigFile = .../config/analysislevel_11_default.globalconfig`
+
+### The actual root cause
+
+The `AddGlobalAnalyzerConfigForPackage` target has an `Exists()` condition:
+```xml
+<ItemGroup Condition="Exists('$(_GlobalAnalyzerConfigFile_...)')">
+  <EditorConfigFiles Include="$(_GlobalAnalyzerConfigFile_...)" />
+</ItemGroup>
+```
+
+The merge's SDK layout **shipped** `analysislevel_11_default.globalconfig` on disk (from a newer roslyn-analyzers that flowed from 10.0.3xx), while main's SDK didn't have that file yet. Same property values, different files on disk = different build behavior.
+
+### Lesson learned
+
+Same MSBuild property resolution + different files on disk = different build behavior. Always check what's actually in the SDK layout, not just what the targets compute.
+
+## Anti-Patterns
+
+> ❌ **Don't manually split/parse CSC command lines in the main conversation.** CSC args have quoted paths, spaces, and complex structure. Regex parsing in PowerShell is fragile and burns turns on trial-and-error. Use a subagent.
+
+> ❌ **Don't assume the MSBuild property diff explains the behavior diff.** Two branches can compute identical property values but produce different outputs because of different files on disk, different NuGet packages, or different task assemblies. Compare the actual task invocation.
+
+> ❌ **Don't load large binlogs and browse them interactively in main context.** Use targeted searches: `binlog-search_tasks_by_name` for a specific task, `binlog-search_binlog` with a focused query. Get in, get the data, get out.

--- a/.github/skills/ci-analysis/references/binlog-comparison.md
+++ b/.github/skills/ci-analysis/references/binlog-comparison.md
@@ -26,8 +26,8 @@ When the failing work item's Helix job ID isn't visible (e.g., canceled jobs, or
    ```
 2. Load the binlog and search for job IDs:
    ```
-   binlog-load_binlog  path:"$env:TEMP\artifact\...\SendToHelix.binlog"
-   binlog-search_binlog  binlog_file:"..."  query:"Sent Helix Job"
+   mcp-binlog-tool-load_binlog  path:"$env:TEMP\artifact\...\SendToHelix.binlog"
+   mcp-binlog-tool-search_binlog  binlog_file:"..."  query:"Sent Helix Job"
    ```
 3. Query each Helix job GUID with the CI script:
    ```
@@ -50,9 +50,9 @@ Download the msbuild.binlog from Helix job {JOB_ID} work item {WORK_ITEM}.
 Use the CI skill script to get the artifact URL:
   ./scripts/Get-CIStatus.ps1 -HelixJob "{JOB_ID}" -WorkItem "{WORK_ITEM}"
 Download the binlog URL to $env:TEMP\{label}.binlog.
-Load it with the binlog MCP server (binlog-load_binlog).
-Search for the {TASK_NAME} task (binlog-search_tasks_by_name).
-Get full task details (binlog-list_tasks_in_target) for the target containing the task.
+Load it with the binlog MCP server (mcp-binlog-tool-load_binlog).
+Search for the {TASK_NAME} task (mcp-binlog-tool-search_tasks_by_name).
+Get full task details (mcp-binlog-tool-list_tasks_in_target) for the target containing the task.
 Extract the CommandLineArguments parameter value.
 Normalize paths:
   - Replace Helix work dirs (/datadisks/disk1/work/XXXXXXXX) with {W}
@@ -71,23 +71,23 @@ With two normalized arg lists, `Compare-Object` instantly reveals the difference
 
 ## Useful Binlog MCP Queries
 
-After loading a binlog with `binlog-load_binlog`, use these queries (pass the loaded path as `binlog_file`):
+After loading a binlog with `mcp-binlog-tool-load_binlog`, use these queries (pass the loaded path as `binlog_file`):
 
 ```
 # Find all invocations of a specific task
-binlog-search_tasks_by_name  binlog_file:"$env:TEMP\my.binlog"  taskName:"Csc"
+mcp-binlog-tool-search_tasks_by_name  binlog_file:"$env:TEMP\my.binlog"  taskName:"Csc"
 
 # Search for a property value
-binlog-search_binlog  binlog_file:"..."  query:"analysislevel"
+mcp-binlog-tool-search_binlog  binlog_file:"..."  query:"analysislevel"
 
 # Find what happened inside a specific target
-binlog-search_binlog  binlog_file:"..."  query:"under($target AddGlobalAnalyzerConfigForPackage_MicrosoftCodeAnalysisNetAnalyzers)"
+mcp-binlog-tool-search_binlog  binlog_file:"..."  query:"under($target AddGlobalAnalyzerConfigForPackage_MicrosoftCodeAnalysisNetAnalyzers)"
 
 # Get all properties matching a pattern
-binlog-search_binlog  binlog_file:"..."  query:"GlobalAnalyzerConfig"
+mcp-binlog-tool-search_binlog  binlog_file:"..."  query:"GlobalAnalyzerConfig"
 
 # List tasks in a target (returns full parameter details including CommandLineArguments)
-binlog-list_tasks_in_target  binlog_file:"..."  projectId:22  targetId:167
+mcp-binlog-tool-list_tasks_in_target  binlog_file:"..."  projectId:22  targetId:167
 ```
 
 ## Path Normalization
@@ -141,4 +141,4 @@ Same MSBuild property resolution + different files on disk = different build beh
 
 > ❌ **Don't assume the MSBuild property diff explains the behavior diff.** Two branches can compute identical property values but produce different outputs because of different files on disk, different NuGet packages, or different task assemblies. Compare the actual task invocation.
 
-> ❌ **Don't load large binlogs and browse them interactively in main context.** Use targeted searches: `binlog-search_tasks_by_name` for a specific task, `binlog-search_binlog` with a focused query. Get in, get the data, get out.
+> ❌ **Don't load large binlogs and browse them interactively in main context.** Use targeted searches: `mcp-binlog-tool-search_tasks_by_name` for a specific task, `mcp-binlog-tool-search_binlog` with a focused query. Get in, get the data, get out.

--- a/.github/skills/ci-analysis/references/binlog-comparison.md
+++ b/.github/skills/ci-analysis/references/binlog-comparison.md
@@ -1,6 +1,6 @@
 # Deep Investigation: Binlog Comparison
 
-When a test **passes on main but fails on a PR**, comparing MSBuild binlogs from both runs reveals the exact difference in task parameters without guessing.
+When a test **passes on the target branch but fails on a PR**, comparing MSBuild binlogs from both runs reveals the exact difference in task parameters without guessing.
 
 ## When to Use This Pattern
 
@@ -14,7 +14,7 @@ When a test **passes on main but fails on a PR**, comparing MSBuild binlogs from
 
 ### Step 1: Identify the two work items to compare
 
-Use `Get-CIStatus.ps1` to find the failing Helix job + work item, then find a corresponding passing build (recent PR merged to main, or a main CI run).
+Use `Get-CIStatus.ps1` to find the failing Helix job + work item, then find a corresponding passing build (recent PR merged to the target branch, or a CI run on that branch).
 
 **Finding Helix job IDs from build artifacts (binlogs to find binlogs):**
 When the failing work item's Helix job ID isn't visible (e.g., canceled jobs, or finding a matching job from a passing build), the IDs are inside the build's `SendToHelix.binlog`:
@@ -48,7 +48,7 @@ Launch two `task` subagents (can run in parallel), each with a prompt like:
 ```
 Download the msbuild.binlog from Helix job {JOB_ID} work item {WORK_ITEM}.
 Use the CI skill script to get the artifact URL:
-  C:\Users\lewing\.copilot\skills\ci-analysis\scripts\Get-CIStatus.ps1 -HelixJob "{JOB_ID}" -WorkItem "{WORK_ITEM}"
+  ./scripts/Get-CIStatus.ps1 -HelixJob "{JOB_ID}" -WorkItem "{WORK_ITEM}"
 Download the binlog URL to $env:TEMP\{label}.binlog.
 Load it with the binlog MCP server (binlog-load_binlog).
 Search for the {TASK_NAME} task (binlog-search_tasks_by_name).

--- a/.github/skills/ci-analysis/references/build-progression-analysis.md
+++ b/.github/skills/ci-analysis/references/build-progression-analysis.md
@@ -59,7 +59,7 @@ When the progression shows that a failure appeared after new commits, check whet
 
 ```powershell
 # Get review comments with timestamps
-gh api "repos/{OWNER}/{REPO}/pulls/{PR}/comments" \
+gh api "repos/{OWNER}/{REPO}/pulls/{PR}/comments" `
     --jq '.[] | {author: .user.login, body: .body, created: .created_at}'
 ```
 

--- a/.github/skills/ci-analysis/references/build-progression-analysis.md
+++ b/.github/skills/ci-analysis/references/build-progression-analysis.md
@@ -1,0 +1,92 @@
+# Deep Investigation: Build Progression Analysis
+
+When the current build is failing, the PR's build history can reveal whether the failure existed from the start or appeared after specific changes. This is a fact-gathering technique — like target-branch comparison — that provides context for understanding the current failure.
+
+## When to Use This Pattern
+
+- Standard analysis (script + logs) hasn't identified the root cause of the current failure
+- The PR has multiple pushes and you want to know whether earlier builds passed or failed
+- You need to understand whether a failure is inherent to the PR's approach or was introduced by a later change
+
+## The Pattern
+
+### Step 1: List all builds for the PR
+
+`gh pr checks` only shows checks for the current HEAD SHA. To see the full build history, query AzDO:
+
+```powershell
+$org = "https://dev.azure.com/dnceng-public"
+$project = "public"
+az pipelines runs list --branch "refs/pull/{PR}/merge" --top 20 --org $org -p $project `
+    --query "[].{id:id, result:result, sourceVersion:sourceVersion, finishTime:finishTime}" -o table
+```
+
+### Step 2: Map builds to commits
+
+For each build, identify the source commit and use `git log` to see what was included:
+
+```powershell
+# Get source version for a build
+az pipelines runs show --id $buildId --org $org -p $project `
+    --query "{id:id, result:result, sourceVersion:sourceVersion}" -o json
+
+# See what commits are between two source versions
+# git log --oneline $passingCommit..$failingCommit
+```
+
+### Step 3: Build a progression table
+
+Present the facts as a table:
+
+| Build | Source commit | Result | What changed since previous build |
+|-------|-------------|--------|----------------------------------|
+| 1284433 | abc123 | ✅ 9/9 | Initial PR commits |
+| 1286087 | def456 | ❌ 7/9 | Added commit C |
+| 1286967 | ghi789 | ❌ 7/9 | Modified commit C |
+
+### Step 4: Present findings, not conclusions
+
+Report what the progression shows:
+- Which builds passed and which failed
+- What commits were added between the last passing and first failing build
+- Whether the failing commits were added in response to review feedback (check review threads)
+
+**Do not** make fix recommendations based solely on build progression. The progression narrows the investigation — it doesn't determine the right fix. The human may have context about why changes were made, what constraints exist, or what the reviewer intended.
+
+## Checking review context
+
+When the progression shows that a failure appeared after new commits, check whether those commits were review-requested:
+
+```powershell
+# Get review comments with timestamps
+gh api "repos/{OWNER}/{REPO}/pulls/{PR}/comments" \
+    --jq '.[] | {author: .user.login, body: .body, created: .created_at}'
+```
+
+Present this as additional context: "Commit C was pushed after reviewer X commented requesting Y." Let the author decide how to proceed.
+
+## Combining with Binlog Comparison
+
+Build progression identifies **which change** correlates with the current failure. Binlog comparison (see [binlog-comparison.md](binlog-comparison.md)) shows **what's different** in the build between a passing and failing state. Together they provide a complete picture:
+
+1. Progression → "The current failure first appeared in build N+1, which added commit C"
+2. Binlog comparison → "In the current (failing) build, task X receives parameter Y=Z, whereas in the passing build it received Y=W"
+
+## Relationship to Target-Branch Comparison
+
+Both techniques compare a failing build against a passing one:
+
+| Technique | Passing build from | Answers |
+|-----------|-------------------|---------|
+| **Target-branch comparison** | Recent build on the base branch (e.g., main) | "Does this test pass without the PR's changes at all?" |
+| **Build progression** | Earlier build on the same PR | "Did this test pass with the PR's *earlier* changes?" |
+
+Use target-branch comparison first to confirm the failure is PR-related. Use build progression to narrow down *which part* of the PR introduced it.
+
+## Anti-Patterns
+
+> ❌ **Don't treat build history as a substitute for analyzing the current build.** The current build determines CI status. Build history is context for understanding and investigating the current failure.
+
+> ❌ **Don't make fix recommendations from progression alone.** "Build N passed and build N+1 failed after adding commit C" is a fact worth reporting. "Therefore revert commit C" is a judgment that requires more context than the agent has — the commit may be addressing a critical review concern, fixing a different bug, or partially correct.
+
+> ❌ **Don't assume earlier passing builds prove the original approach was complete.** A build may pass because it didn't change enough to trigger the failing test scenario. The reviewer who requested additional changes may have identified a real gap.

--- a/.github/skills/ci-analysis/references/build-progression-analysis.md
+++ b/.github/skills/ci-analysis/references/build-progression-analysis.md
@@ -40,7 +40,7 @@ az pipelines runs list --branch "refs/pull/{PR}/merge" --top 20 --org $org -p $p
 
 ### Step 2: Map builds to the PR's head commit
 
-Each build's `triggerInfo` contains `pr.sourceSha` — the PR's HEAD commit when the build was triggered. Extract it from the `get_builds` response or the `az` JSON output.
+Each build's `triggerInfo` contains `pr.sourceSha` — the PR's HEAD commit when the build was triggered. Extract it from the `azure-devops-pipelines_get_builds` response or the `az` JSON output.
 
 > ⚠️ **`sourceVersion` is the merge commit**, not the PR's head commit. Use `triggerInfo.'pr.sourceSha'` instead.
 

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -1,101 +1,105 @@
 # Subagent Delegation Patterns
 
-CI investigations often involve repetitive, mechanical work that burns main conversation context. Delegate these to subagents.
+CI investigations involve repetitive, mechanical work that burns main conversation context. Delegate data gathering to subagents; keep interpretation in the main agent.
 
 ## Pattern 1: Scanning Multiple Console Logs
 
-**When:** Multiple failing work items across several jobs — need to extract and deduplicate test failure names.
-
-**Problem:** Each work item's console log can be thousands of lines. Reading 5+ logs in main context burns most of your context budget on raw output.
+**When:** Multiple failing work items across several jobs.
 
 **Delegate:**
 ```
-Fetch Helix console logs for these work items and extract all unique test failures:
+Extract all unique test failures from these Helix work items:
 
-Job: {JOB_ID_1}
-  Work items: dotnet.Tests.dll.19, dotnet.Tests.dll.23
+Job: {JOB_ID_1}, Work items: {ITEM_1}, {ITEM_2}
+Job: {JOB_ID_2}, Work items: {ITEM_3}
 
-Job: {JOB_ID_2}
-  Work items: dotnet.Tests.dll.19
-
-For each, use:
+For each, run:
   ./scripts/Get-CIStatus.ps1 -HelixJob "{JOB}" -WorkItem "{ITEM}"
 
-From the console output, extract lines matching xUnit failure format:
-  [xUnit.net HH:MM:SS.ss] TestNamespace.TestClass.TestMethod [FAIL]
+Extract lines ending with [FAIL] (xUnit format). Ignore [OUTPUT] and [PASS] lines.
 
-IMPORTANT: Lines with [OUTPUT] or [PASS] are NOT failures.
-Only lines ending with [FAIL] indicate actual test failures.
-
-Deduplicate across all work items.
-Return: unique FAIL test names + which work items they appeared in.
+Return JSON: { "failures": [{ "test": "Namespace.Class.Method", "workItems": ["item1", "item2"] }] }
 ```
-
-**Result:** A clean list of unique failures instead of pages of raw logs.
 
 ## Pattern 2: Finding a Baseline Build
 
-**When:** A test fails on a PR — need to confirm it passes on the PR's target/base branch to prove the failure is PR-caused.
-
-**Problem:** Requires searching recent merged PRs or target branch CI runs, finding the matching build, locating the right Helix job and work item. Multiple API calls.
+**When:** A test fails on a PR — need to confirm it passes on the target branch.
 
 **Delegate:**
 ```
-Find a recent passing build on the PR's target/base branch of dotnet/{REPO} that ran the same test leg as this failing build.
+Find a recent passing build on {TARGET_BRANCH} of dotnet/{REPO} that ran the same test leg.
 
-Failing build: {BUILD_ID} (PR #{PR_NUMBER})
-Failing job name: {JOB_NAME} (e.g., "TestBuild linux x64")
-Failing work item: {WORK_ITEM} (e.g., "dotnet.Tests.dll.19")
+Failing build: {BUILD_ID}, job: {JOB_NAME}, work item: {WORK_ITEM}
 
 Steps:
-1. Use GitHub MCP to find recently merged PRs targeting the same base branch as this PR:
+1. Search for recently merged PRs:
    github-mcp-server-search_pull_requests query:"is:merged base:{TARGET_BRANCH}" owner:dotnet repo:{REPO}
-2. Set {TARGET_BRANCH} to the PR's base branch (e.g., main, release/9.0) and pick the most recent merged PR
-3. Run the CI script to check its build status:
-   ./scripts/Get-CIStatus.ps1 -PRNumber {MERGED_PR} -Repository "dotnet/{REPO}"
-4. Find the build that passed with the same job name
-5. Find the Helix job ID for that job (may need to download build artifacts — see azure-cli.md and binlog-comparison.md for "binlogs to find binlogs")
-6. Confirm the matching work item passed
+2. Run: ./scripts/Get-CIStatus.ps1 -PRNumber {MERGED_PR} -Repository "dotnet/{REPO}"
+3. Find the build with same job name that passed
+4. Locate the Helix job ID (may need artifact download — see azure-cli.md)
 
-Return: the passing build ID, Helix job ID, and work item name, or "no recent passing build found".
+Return JSON: { "found": true, "buildId": N, "helixJob": "...", "workItem": "...", "result": "Pass" }
+Or: { "found": false, "reason": "no passing build in last 5 merged PRs" }
+
+If authentication fails or API returns errors, STOP and return the error — don't troubleshoot.
 ```
 
-## Pattern 3: Narrowing Merge Diffs to Relevant Files
+## Pattern 3: Extracting Merge PR Changed Files
 
-**When:** A large merge PR (hundreds of commits, hundreds of changed files) has test failures — need to identify which changes are relevant.
-
-**Problem:** `git diff` on a 458-file merge is overwhelming. Most changes are unrelated to the specific failure.
+**When:** A large merge PR (hundreds of files) has test failures — need the file list for the main agent to analyze.
 
 **Delegate:**
 ```
-Given these test failures on merge PR #{PR_NUMBER} (branch: {SOURCE} → {TARGET}):
-  - {TEST_1}
-  - {TEST_2}
+List all changed files on merge PR #{PR_NUMBER} in dotnet/{REPO}.
 
-Find the changed files most likely to cause these failures.
+Use: github-mcp-server-pull_request_read method:get_files owner:dotnet repo:{REPO} pullNumber:{PR_NUMBER}
 
-Steps:
-1. Get the list of changed files: git diff --name-only {TARGET}...{SOURCE}
-2. Filter to files matching these patterns (adjust per failure type):
-   - For MSBuild/build failures: *.targets, *.props, Directory.Build.*, eng/Versions.props
-   - For test failures: test project files, test assets
-   - For specific SDK areas: src/Tasks/, src/Cli/, src/WasmSdk/
-3. For each relevant file, show the key diff hunks (not the full diff)
-4. Look for version bumps, property changes, or behavioral changes
+For each file, note: path, change type (added/modified/deleted), lines changed.
 
-Return: the 5-10 most relevant changed files with a one-line summary of what changed in each.
+Return JSON: { "totalFiles": N, "files": [{ "path": "...", "changeType": "modified", "linesChanged": N }] }
 ```
 
-## Pattern 4: Parallel Binlog Extraction
+> The main agent decides which files are relevant to the specific failures — don't filter in the subagent.
 
-**When:** Comparing two builds — see [binlog-comparison.md](binlog-comparison.md).
+## Pattern 4: Parallel Artifact Extraction
 
-**Key insight:** Launch two subagents simultaneously (one per build). Each downloads a binlog, loads it into the MCP server, extracts task parameters, normalizes paths, and returns a sorted arg list. The main agent just diffs the two lists.
+**When:** Multiple builds or artifacts need independent analysis — binlog comparison, canceled job recovery, multi-build progression.
+
+**Key insight:** Launch one subagent per build/artifact in parallel. Each does its mechanical extraction independently. The main agent synthesizes results across all of them.
+
+**Delegate (per build, for binlog analysis):**
+```
+Download and analyze binlog from AzDO build {BUILD_ID}, artifact {ARTIFACT_NAME}.
+
+Steps:
+1. Download the artifact (see azure-cli.md)
+2. Load: mcp-binlog-tool-load_binlog path:"{BINLOG_PATH}"
+3. Extract target info: mcp-binlog-tool-search_tasks_by_name taskName:"Csc"
+4. Get task parameters: mcp-binlog-tool-get_task_info
+
+Return JSON: { "buildId": N, "project": "...", "args": ["..."] }
+```
+
+**Delegate (per build, for canceled job recovery):**
+```
+Check if canceled job "{JOB_NAME}" from build {BUILD_ID} has recoverable Helix results.
+
+Steps:
+1. Download the testResults.xml artifact from the canceled job (see azure-cli.md)
+2. If available, parse for pass/fail counts and work item status
+
+Return JSON: { "jobName": "...", "hasResults": true, "passed": N, "failed": N }
+Or: { "jobName": "...", "hasResults": false, "reason": "no artifacts" }
+```
+
+This pattern scales to any number of builds — launch N subagents for N builds, collect results, compare.
 
 ## General Guidelines
 
-- **Use `task` agent type** for all delegation (it has shell + MCP access)
-- **Run independent tasks in parallel** (e.g., two binlog extractions)
-- **Include the CI script path** in every prompt — subagents don't inherit skill context
-- **Ask for structured output** — "return a list of X" not "show me what you find"
-- **Don't delegate interpretation** — subagents extract data, main agent interprets meaning
+- **Use `task` agent type** — it has shell + MCP access
+- **Run independent tasks in parallel** — the whole point of delegation
+- **Include script paths** — subagents don't inherit skill context
+- **Require structured JSON output** — enables comparison across subagents
+- **Don't delegate interpretation** — subagents return facts, main agent reasons
+- **STOP on errors** — subagents should return error details immediately, not troubleshoot auth/environment issues
+- **Use SQL for many results** — when launching 5+ subagents or doing multi-phase delegation, store results in a SQL table (`CREATE TABLE results (agent_id TEXT, build_id INT, data TEXT, status TEXT)`) so you can query across all results instead of holding them in context

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -73,9 +73,9 @@ Download and analyze binlog from AzDO build {BUILD_ID}, artifact {ARTIFACT_NAME}
 
 Steps:
 1. Download the artifact (see azure-cli.md)
-2. Load: mcp-binlog-tool-load_binlog path:"{BINLOG_PATH}"
-3. Extract target info: mcp-binlog-tool-search_tasks_by_name taskName:"Csc"
-4. Get task parameters: mcp-binlog-tool-get_task_info
+2. Load: binlog-load_binlog path:"{BINLOG_PATH}"
+3. Find tasks: binlog-search_tasks_by_name taskName:"Csc"
+4. Get task parameters: binlog-get_task_info
 
 Return JSON: { "buildId": N, "project": "...", "args": ["..."] }
 ```

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -113,7 +113,7 @@ Return JSON: { "buildId": N, "targetHead": "abc1234", "mergeCommit": "def5678" }
 Or: { "buildId": N, "targetHead": null, "error": "merge line not found in log 5" }
 ```
 
-Launch one per build in parallel. The main agent combines with `get_builds` results to build the full progression table.
+Launch one per build in parallel. The main agent combines with `azure-devops-pipelines_get_builds` results to build the full progression table.
 
 ## General Guidelines
 

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -41,7 +41,7 @@ Return: unique FAIL test names + which work items they appeared in.
 
 **Delegate:**
 ```
-Find a recent passing build on the main branch of dotnet/{REPO} that ran the same test leg as this failing build.
+Find a recent passing build on the PR's target/base branch of dotnet/{REPO} that ran the same test leg as this failing build.
 
 Failing build: {BUILD_ID} (PR #{PR_NUMBER})
 Failing job name: {JOB_NAME} (e.g., "TestBuild linux x64")

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -48,9 +48,9 @@ Failing job name: {JOB_NAME} (e.g., "TestBuild linux x64")
 Failing work item: {WORK_ITEM} (e.g., "dotnet.Tests.dll.19")
 
 Steps:
-1. Use GitHub MCP to find recently merged PRs to main:
-   github-mcp-server-search_pull_requests query:"is:merged base:main" owner:dotnet repo:{REPO}
-2. Pick the most recent merged PR
+1. Use GitHub MCP to find recently merged PRs targeting the same base branch as this PR:
+   github-mcp-server-search_pull_requests query:"is:merged base:{TARGET_BRANCH}" owner:dotnet repo:{REPO}
+2. Set {TARGET_BRANCH} to the PR's base branch (e.g., main, release/9.0) and pick the most recent merged PR
 3. Run the CI script to check its build status:
    ./scripts/Get-CIStatus.ps1 -PRNumber {MERGED_PR} -Repository "dotnet/{REPO}"
 4. Find the build that passed with the same job name

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -86,8 +86,8 @@ Return JSON: { "buildId": N, "project": "...", "args": ["..."] }
 Check if canceled job "{JOB_NAME}" from build {BUILD_ID} has recoverable Helix results.
 
 Steps:
-1. Use hlx-hlx_files with jobId:"{HELIX_JOB_ID}" workItem:"{WORK_ITEM}" to find testResults.xml
-2. Download with hlx-hlx_download_url using the testResults.xml URI
+1. Use hlx_files with jobId:"{HELIX_JOB_ID}" workItem:"{WORK_ITEM}" to find testResults.xml
+2. Download with hlx_download_url using the testResults.xml URI
 3. Parse the XML for pass/fail counts on the <assembly> element
 
 Return JSON: { "jobName": "...", "hasResults": true, "passed": N, "failed": N }

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -1,0 +1,101 @@
+# Subagent Delegation Patterns
+
+CI investigations often involve repetitive, mechanical work that burns main conversation context. Delegate these to subagents.
+
+## Pattern 1: Scanning Multiple Console Logs
+
+**When:** Multiple failing work items across several jobs — need to extract and deduplicate test failure names.
+
+**Problem:** Each work item's console log can be thousands of lines. Reading 5+ logs in main context burns most of your context budget on raw output.
+
+**Delegate:**
+```
+Fetch Helix console logs for these work items and extract all unique test failures:
+
+Job: {JOB_ID_1}
+  Work items: dotnet.Tests.dll.19, dotnet.Tests.dll.23
+
+Job: {JOB_ID_2}
+  Work items: dotnet.Tests.dll.19
+
+For each, use:
+  C:\Users\lewing\.copilot\skills\ci-analysis\scripts\Get-CIStatus.ps1 -HelixJob "{JOB}" -WorkItem "{ITEM}"
+
+From the console output, extract lines matching xUnit failure format:
+  [xUnit.net HH:MM:SS.ss] TestNamespace.TestClass.TestMethod [FAIL]
+
+IMPORTANT: Lines with [OUTPUT] or [PASS] are NOT failures.
+Only lines ending with [FAIL] indicate actual test failures.
+
+Deduplicate across all work items.
+Return: unique FAIL test names + which work items they appeared in.
+```
+
+**Result:** A clean list of unique failures instead of pages of raw logs.
+
+## Pattern 2: Finding a Baseline Build
+
+**When:** A test fails on a PR — need to confirm it passes on main to prove the failure is PR-caused.
+
+**Problem:** Requires searching recent merged PRs or main CI runs, finding the matching build, locating the right Helix job and work item. Multiple API calls.
+
+**Delegate:**
+```
+Find a recent passing build on the main branch of dotnet/{REPO} that ran the same test leg as this failing build.
+
+Failing build: {BUILD_ID} (PR #{PR_NUMBER})
+Failing job name: {JOB_NAME} (e.g., "TestBuild linux x64")
+Failing work item: {WORK_ITEM} (e.g., "dotnet.Tests.dll.19")
+
+Steps:
+1. Use GitHub MCP to find recently merged PRs to main:
+   github-mcp-server-search_pull_requests query:"is:merged base:main" owner:dotnet repo:{REPO}
+2. Pick the most recent merged PR
+3. Run the CI script to check its build status:
+   ./scripts/Get-CIStatus.ps1 -PRNumber {MERGED_PR} -Repository "dotnet/{REPO}"
+4. Find the build that passed with the same job name
+5. Find the Helix job ID for that job (may need to download build artifacts — see azure-cli.md and binlog-comparison.md for "binlogs to find binlogs")
+6. Confirm the matching work item passed
+
+Return: the passing build ID, Helix job ID, and work item name, or "no recent passing build found".
+```
+
+## Pattern 3: Narrowing Merge Diffs to Relevant Files
+
+**When:** A large merge PR (hundreds of commits, hundreds of changed files) has test failures — need to identify which changes are relevant.
+
+**Problem:** `git diff` on a 458-file merge is overwhelming. Most changes are unrelated to the specific failure.
+
+**Delegate:**
+```
+Given these test failures on merge PR #{PR_NUMBER} (branch: {SOURCE} → {TARGET}):
+  - {TEST_1}
+  - {TEST_2}
+
+Find the changed files most likely to cause these failures.
+
+Steps:
+1. Get the list of changed files: git diff --name-only {TARGET}...{SOURCE}
+2. Filter to files matching these patterns (adjust per failure type):
+   - For MSBuild/build failures: *.targets, *.props, Directory.Build.*, eng/Versions.props
+   - For test failures: test project files, test assets
+   - For specific SDK areas: src/Tasks/, src/Cli/, src/WasmSdk/
+3. For each relevant file, show the key diff hunks (not the full diff)
+4. Look for version bumps, property changes, or behavioral changes
+
+Return: the 5-10 most relevant changed files with a one-line summary of what changed in each.
+```
+
+## Pattern 4: Parallel Binlog Extraction
+
+**When:** Comparing two builds — see [binlog-comparison.md](binlog-comparison.md).
+
+**Key insight:** Launch two subagents simultaneously (one per build). Each downloads a binlog, loads it into the MCP server, extracts task parameters, normalizes paths, and returns a sorted arg list. The main agent just diffs the two lists.
+
+## General Guidelines
+
+- **Use `task` agent type** for all delegation (it has shell + MCP access)
+- **Run independent tasks in parallel** (e.g., two binlog extractions)
+- **Include the CI script path** in every prompt — subagents don't inherit skill context
+- **Ask for structured output** — "return a list of X" not "show me what you find"
+- **Don't delegate interpretation** — subagents extract data, main agent interprets meaning

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -74,9 +74,9 @@ Download and analyze binlog from AzDO build {BUILD_ID}, artifact {ARTIFACT_NAME}
 
 Steps:
 1. Download the artifact (see azure-cli.md)
-2. Load: binlog-load_binlog path:"{BINLOG_PATH}"
-3. Find tasks: binlog-search_tasks_by_name taskName:"Csc"
-4. Get task parameters: binlog-get_task_info
+2. Load: mcp-binlog-tool-load_binlog path:"{BINLOG_PATH}"
+3. Find tasks: mcp-binlog-tool-search_tasks_by_name taskName:"Csc"
+4. Get task parameters: mcp-binlog-tool-get_task_info
 
 Return JSON: { "buildId": N, "project": "...", "args": ["..."] }
 ```

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -19,7 +19,7 @@ Job: {JOB_ID_2}
   Work items: dotnet.Tests.dll.19
 
 For each, use:
-  C:\Users\lewing\.copilot\skills\ci-analysis\scripts\Get-CIStatus.ps1 -HelixJob "{JOB}" -WorkItem "{ITEM}"
+  ./scripts/Get-CIStatus.ps1 -HelixJob "{JOB}" -WorkItem "{ITEM}"
 
 From the console output, extract lines matching xUnit failure format:
   [xUnit.net HH:MM:SS.ss] TestNamespace.TestClass.TestMethod [FAIL]

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -35,9 +35,9 @@ Return: unique FAIL test names + which work items they appeared in.
 
 ## Pattern 2: Finding a Baseline Build
 
-**When:** A test fails on a PR — need to confirm it passes on main to prove the failure is PR-caused.
+**When:** A test fails on a PR — need to confirm it passes on the PR's target/base branch to prove the failure is PR-caused.
 
-**Problem:** Requires searching recent merged PRs or main CI runs, finding the matching build, locating the right Helix job and work item. Multiple API calls.
+**Problem:** Requires searching recent merged PRs or target branch CI runs, finding the matching build, locating the right Helix job and work item. Multiple API calls.
 
 **Delegate:**
 ```

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -37,7 +37,7 @@ Steps:
    github-mcp-server-search_pull_requests query:"is:merged base:{TARGET_BRANCH}" owner:dotnet repo:{REPO}
 2. Run: ./scripts/Get-CIStatus.ps1 -PRNumber {MERGED_PR} -Repository "dotnet/{REPO}"
 3. Find the build with same job name that passed
-4. Locate the Helix job ID (may need artifact download — see azure-cli.md)
+4. Locate the Helix job ID (may need artifact download — see [azure-cli.md](azure-cli.md))
 
 Return JSON: { "found": true, "buildId": N, "helixJob": "...", "workItem": "...", "result": "Pass" }
 Or: { "found": false, "reason": "no passing build in last 5 merged PRs" }
@@ -73,7 +73,7 @@ Return JSON: { "totalFiles": N, "files": [{ "path": "...", "changeType": "modifi
 Download and analyze binlog from AzDO build {BUILD_ID}, artifact {ARTIFACT_NAME}.
 
 Steps:
-1. Download the artifact (see azure-cli.md)
+1. Download the artifact (see [azure-cli.md](azure-cli.md))
 2. Load: mcp-binlog-tool-load_binlog path:"{BINLOG_PATH}"
 3. Find tasks: mcp-binlog-tool-search_tasks_by_name taskName:"Csc"
 4. Get task parameters: mcp-binlog-tool-get_task_info

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -117,7 +117,7 @@ Launch one per build in parallel. The main agent combines with `azure-devops-pip
 
 ## General Guidelines
 
-- **Use `general-purpose` agent type** — it has shell + MCP access (hlx-*, azure-devops-*, mcp-binlog-tool-*)
+- **Use `general-purpose` agent type** — it has shell + MCP access (`hlx_status`, `azure-devops-pipelines_get_builds`, `mcp-binlog-tool-load_binlog`, etc.)
 - **Run independent tasks in parallel** — the whole point of delegation
 - **Include script paths** — subagents don't inherit skill context
 - **Require structured JSON output** — enables comparison across subagents

--- a/.github/skills/ci-analysis/references/helix-artifacts.md
+++ b/.github/skills/ci-analysis/references/helix-artifacts.md
@@ -188,9 +188,13 @@ If a test runs `dotnet build` internally (like SDK end-to-end tests), both sourc
 
 When you download artifacts via MCP tools or manually, the directory structure can be confusing. Here's what to expect.
 
-### Helix Work Item Downloads (`hlx_download`)
+### Helix Work Item Downloads
 
-`hlx_download` saves files to a temp directory and returns local paths. The structure is **flat** — all files from the work item land in one directory:
+Two MCP tools download Helix artifacts:
+- **`hlx_download`** — downloads multiple files from a work item, with optional glob `pattern` (e.g., `pattern:"*.binlog"`). Returns local file paths.
+- **`hlx_download_url`** — downloads a single file by direct URI (from `hlx_files` output). Use when you know exactly which file you need.
+
+`hlx_download` saves files to a temp directory. The structure is **flat** — all files from the work item land in one directory:
 
 ```
 C:\...\Temp\helix-{hash}\

--- a/.github/skills/ci-analysis/references/helix-artifacts.md
+++ b/.github/skills/ci-analysis/references/helix-artifacts.md
@@ -226,12 +226,17 @@ $env:TEMP\TestBuild_linux_x64\
 
 ### Mapping Binlogs to Failures
 
-| You want to investigate... | Use this binlog | Source |
-|---------------------------|-----------------|--------|
-| Why a test's internal `dotnet build` failed | `msbuild.binlog` or `msbuild{N}.binlog` | Helix work item |
-| Why the CI build itself failed to compile | `Build.binlog` | AzDO build artifact |
-| Which Helix jobs were dispatched | `SendToHelix.binlog` | AzDO build artifact |
-| AOT compilation failure | `AOTBuild.binlog` | Helix work item |
+This table shows the **typical** source for each binlog type. The boundaries aren't absolute — some repos run tests on the build agent (producing test binlogs in AzDO artifacts), and Helix work items for SDK/Blazor tests invoke `dotnet build` internally (producing build binlogs as Helix artifacts).
+
+| You want to investigate... | Look here first | But also check... |
+|---------------------------|-----------------|-------------------|
+| Why a test's internal `dotnet build` failed | Helix work item (`msbuild{N}.binlog`) | AzDO artifact if tests ran on agent |
+| Why the CI build itself failed to compile | AzDO build artifact (`Build.binlog`) | — |
+| Which Helix jobs were dispatched | AzDO build artifact (`SendToHelix.binlog`) | — |
+| AOT compilation failure | Helix work item (`AOTBuild.binlog`) | — |
+| Test build/publish behavior | Helix work item (`publish.msbuild.binlog`) | AzDO artifact (`TestBuildTests.binlog`) |
+
+> **Rule of thumb:** If the failing job name contains "Helix" or "Send to Helix", the test binlogs are in Helix. If the job runs tests directly (common in dotnet/sdk), check AzDO artifacts.
 
 ### Tracking Downloaded Artifacts with SQL
 
@@ -265,7 +270,7 @@ Use this whenever you're juggling artifacts from 2+ Helix jobs (especially durin
 ### Tips
 
 - **Multiple binlogs ≠ multiple builds.** A single work item can produce several binlogs if the test suite runs multiple `dotnet build`/`dotnet publish` commands.
-- **Helix binlogs are test-time, AzDO binlogs are build-time.** If a test was built wrong, check AzDO artifacts. If it ran a build that produced wrong output, check Helix artifacts.
+- **Helix and AzDO binlogs can overlap.** Helix binlogs are *usually* from test execution and AzDO binlogs from the build phase, but SDK/Blazor tests invoke MSBuild inside Helix (producing build-like binlogs), and some repos run tests directly on the build agent (producing test binlogs in AzDO). Check both sources if you can't find what you need.
 - **Not all work items have binlogs.** Standard unit tests only produce `testResults.xml` and console logs.
 - **Use `hlx_download` with `pattern:"*.binlog"`** to filter downloads and avoid pulling large console logs.
 

--- a/.github/skills/ci-analysis/references/helix-artifacts.md
+++ b/.github/skills/ci-analysis/references/helix-artifacts.md
@@ -184,6 +184,91 @@ Get-ChildItem -Path $extractPath -Filter "*.binlog" -Recurse | ForEach-Object {
 
 If a test runs `dotnet build` internally (like SDK end-to-end tests), both sources may have relevant binlogs.
 
+## Downloaded Artifact Layout
+
+When you download artifacts via MCP tools or manually, the directory structure can be confusing. Here's what to expect.
+
+### Helix Work Item Downloads (`hlx_download`)
+
+`hlx_download` saves files to a temp directory and returns local paths. The structure is **flat** — all files from the work item land in one directory:
+
+```
+C:\...\Temp\helix-{hash}\
+├── console.d991a56d.log          # Console output
+├── testResults.xml               # Test pass/fail details
+├── msbuild.binlog                # Only if test invoked MSBuild
+├── publish.msbuild.binlog        # Only if test did a publish
+├── msbuild0.binlog               # Numbered: first test's build
+├── msbuild1.binlog               # Numbered: second test's build
+└── core.1000.34                  # Only on crash
+```
+
+**Key confusion point:** Numbered binlogs (`msbuild0.binlog`, `msbuild1.binlog`) correspond to individual test cases within the work item, not to build phases. A work item like `Microsoft.NET.Build.Tests.dll.18` runs dozens of tests, each invoking MSBuild separately. To map a binlog to a specific test:
+1. Load it with `mcp-binlog-tool-load_binlog`
+2. Check the project paths inside — they usually contain the test name
+3. Or check `testResults.xml` to correlate test execution order with binlog numbering
+
+### AzDO Build Artifact Downloads
+
+AzDO artifacts download as **ZIP files** with nested directory structures:
+
+```
+$env:TEMP\TestBuild_linux_x64\
+└── TestBuild_linux_x64\          # Artifact name repeated as subfolder
+    └── log\Release\
+        ├── Build.binlog           # Main build
+        ├── TestBuildTests.binlog   # Test build verification
+        ├── ToolsetRestore.binlog   # Toolset restore
+        └── SendToHelix.binlog     # Contains Helix job GUIDs
+```
+
+**Key confusion point:** The artifact name appears twice in the path (extract folder + subfolder inside the ZIP). Use the full nested path with `mcp-binlog-tool-load_binlog`.
+
+### Mapping Binlogs to Failures
+
+| You want to investigate... | Use this binlog | Source |
+|---------------------------|-----------------|--------|
+| Why a test's internal `dotnet build` failed | `msbuild.binlog` or `msbuild{N}.binlog` | Helix work item |
+| Why the CI build itself failed to compile | `Build.binlog` | AzDO build artifact |
+| Which Helix jobs were dispatched | `SendToHelix.binlog` | AzDO build artifact |
+| AOT compilation failure | `AOTBuild.binlog` | Helix work item |
+
+### Tracking Downloaded Artifacts with SQL
+
+When downloading from multiple work items (e.g., binlog comparison between passing and failing builds), use SQL to avoid losing track of what's where:
+
+```sql
+CREATE TABLE IF NOT EXISTS downloaded_artifacts (
+  local_path TEXT PRIMARY KEY,
+  helix_job TEXT,
+  work_item TEXT,
+  build_id INT,
+  artifact_source TEXT,  -- 'helix' or 'azdo'
+  file_type TEXT,        -- 'binlog', 'testResults', 'console', 'crash'
+  notes TEXT             -- e.g., 'passing baseline', 'failing PR build'
+);
+```
+
+Key queries:
+```sql
+-- Find the pair of binlogs for comparison
+SELECT local_path, notes FROM downloaded_artifacts
+WHERE file_type = 'binlog' ORDER BY notes;
+
+-- What have I downloaded from a specific work item?
+SELECT local_path, file_type FROM downloaded_artifacts
+WHERE work_item = 'Microsoft.NET.Build.Tests.dll.18';
+```
+
+Use this whenever you're juggling artifacts from 2+ Helix jobs (especially during the binlog comparison pattern in [binlog-comparison.md](binlog-comparison.md)).
+
+### Tips
+
+- **Multiple binlogs ≠ multiple builds.** A single work item can produce several binlogs if the test suite runs multiple `dotnet build`/`dotnet publish` commands.
+- **Helix binlogs are test-time, AzDO binlogs are build-time.** If a test was built wrong, check AzDO artifacts. If it ran a build that produced wrong output, check Helix artifacts.
+- **Not all work items have binlogs.** Standard unit tests only produce `testResults.xml` and console logs.
+- **Use `hlx_download` with `pattern:"*.binlog"`** to filter downloads and avoid pulling large console logs.
+
 ## Artifact Retention
 
 Helix artifacts are retained for a limited time (typically 30 days). Download important artifacts promptly if needed for long-term analysis.

--- a/.github/skills/ci-analysis/references/manual-investigation.md
+++ b/.github/skills/ci-analysis/references/manual-investigation.md
@@ -73,10 +73,11 @@ Binlogs contain detailed MSBuild execution traces for diagnosing:
 - NuGet restore problems
 - Target execution order issues
 
-**Using MSBuild MCP Server:**
+**Using MSBuild binlog MCP tools:**
 ```
-msbuild-mcp analyze --binlog path/to/build.binlog --errors
-msbuild-mcp analyze --binlog path/to/build.binlog --target ResolveReferences
+mcp-binlog-tool-load_binlog path: "path/to/build.binlog"
+mcp-binlog-tool-get_diagnostics binlog_file: "path/to/build.binlog"
+mcp-binlog-tool-search_binlog binlog_file: "path/to/build.binlog" query: "$error"
 ```
 
 **Manual Analysis:**

--- a/.github/skills/ci-analysis/references/manual-investigation.md
+++ b/.github/skills/ci-analysis/references/manual-investigation.md
@@ -75,9 +75,9 @@ Binlogs contain detailed MSBuild execution traces for diagnosing:
 
 **Using MSBuild binlog MCP tools:**
 ```
-mcp-binlog-tool-load_binlog path: "path/to/build.binlog"
-mcp-binlog-tool-get_diagnostics binlog_file: "path/to/build.binlog"
-mcp-binlog-tool-search_binlog binlog_file: "path/to/build.binlog" query: "$error"
+mcp-binlog-tool-load_binlog path:"path/to/build.binlog"
+mcp-binlog-tool-get_diagnostics binlog_file:"path/to/build.binlog"
+mcp-binlog-tool-search_binlog binlog_file:"path/to/build.binlog" query:"$error"
 ```
 
 **Manual Analysis:**

--- a/.github/skills/ci-analysis/references/manual-investigation.md
+++ b/.github/skills/ci-analysis/references/manual-investigation.md
@@ -77,7 +77,7 @@ Binlogs contain detailed MSBuild execution traces for diagnosing:
 ```
 mcp-binlog-tool-load_binlog path:"path/to/build.binlog"
 mcp-binlog-tool-get_diagnostics binlog_file:"path/to/build.binlog"
-mcp-binlog-tool-search_binlog binlog_file:"path/to/build.binlog" query:"$error"
+mcp-binlog-tool-search_binlog binlog_file:"path/to/build.binlog" query:"error"
 ```
 
 **Manual Analysis:**

--- a/.github/skills/ci-analysis/references/sql-tracking.md
+++ b/.github/skills/ci-analysis/references/sql-tracking.md
@@ -100,3 +100,4 @@ WHERE body LIKE '%PTAL%' OR body LIKE '%could you%look%';
 | Crash recovery across multiple work items | Yes — cache testResults.xml findings |
 | Single build, single failure | No — overkill |
 | PR chain or long-lived PR with extensive triage comments | Yes — preserves diagnosis context across tool calls |
+| Downloading artifacts from 2+ Helix jobs (e.g., binlog comparison) | Yes — see [helix-artifacts.md](helix-artifacts.md) |

--- a/.github/skills/ci-analysis/references/sql-tracking.md
+++ b/.github/skills/ci-analysis/references/sql-tracking.md
@@ -52,6 +52,10 @@ SELECT job_name, error_snippet FROM failed_jobs WHERE is_pr_correlated = TRUE;
 
 See [build-progression-analysis.md](build-progression-analysis.md) for the `build_progression` and `build_failures` tables that track pass/fail across multiple builds.
 
+> **`failed_jobs` vs `build_failures` — when to use each:**
+> - `failed_jobs` (above): **Job-level** — maps each failed AzDO job to a known issue. Use for single-build triage ("are all failures accounted for?").
+> - `build_failures` (build-progression-analysis.md): **Test-level** — tracks individual test names across builds. Use for progression analysis ("which tests started failing after commit X?").
+
 ## PR Comment Tracking
 
 For deep-dive analysis — especially across a chain of related PRs (e.g., dependency flow failures, sequential merge PRs, or long-lived PRs with weeks of triage) — store PR comments so you can query them without re-fetching:

--- a/.github/skills/ci-analysis/references/sql-tracking.md
+++ b/.github/skills/ci-analysis/references/sql-tracking.md
@@ -1,0 +1,63 @@
+# SQL Tracking for CI Investigations
+
+Use the SQL tool to track structured data during complex investigations. This avoids losing context across tool calls and enables queries that catch mistakes (like claiming "all failures known" when some are unmatched).
+
+## Failed Job Tracking
+
+Track each failure from the script output and map it to known issues as you verify them:
+
+```sql
+CREATE TABLE IF NOT EXISTS failed_jobs (
+  build_id INT,
+  job_name TEXT,
+  error_category TEXT,   -- from failedJobDetails: test-failure, build-error, crash, etc.
+  error_snippet TEXT,
+  known_issue_url TEXT,  -- NULL if unmatched
+  known_issue_title TEXT,
+  is_pr_correlated BOOLEAN DEFAULT FALSE,
+  recovery_status TEXT DEFAULT 'not-checked',  -- effectively-passed, real-failure, no-results
+  notes TEXT,
+  PRIMARY KEY (build_id, job_name)
+);
+```
+
+### Key queries
+
+```sql
+-- Unmatched failures (Build Analysis red = these exist)
+SELECT job_name, error_category, error_snippet FROM failed_jobs
+WHERE known_issue_url IS NULL;
+
+-- Are ALL failures accounted for?
+SELECT COUNT(*) as total,
+       SUM(CASE WHEN known_issue_url IS NOT NULL THEN 1 ELSE 0 END) as matched
+FROM failed_jobs;
+
+-- Which crash/canceled jobs need recovery verification?
+SELECT job_name, build_id FROM failed_jobs
+WHERE error_category IN ('crash', 'unclassified') AND recovery_status = 'not-checked';
+
+-- PR-correlated failures (fix before retrying)
+SELECT job_name, error_snippet FROM failed_jobs WHERE is_pr_correlated = TRUE;
+```
+
+### Workflow
+
+1. After the script runs, insert one row per failed job from `failedJobDetails`
+2. For each known issue from `knownIssues`, UPDATE matching rows with the issue URL
+3. Query for unmatched failures — these need investigation
+4. For crash/canceled jobs, update `recovery_status` after checking Helix results
+
+## Build Progression
+
+See [build-progression-analysis.md](build-progression-analysis.md) for the `build_progression` and `build_failures` tables that track pass/fail across multiple builds.
+
+## When to Use SQL vs. Not
+
+| Situation | Use SQL? |
+|-----------|----------|
+| 1-2 failed jobs, all match known issues | No — straightforward, hold in context |
+| 3+ failed jobs across multiple builds | Yes — prevents missed matches |
+| Build progression with 5+ builds | Yes — see build-progression-analysis.md |
+| Crash recovery across multiple work items | Yes — cache testResults.xml findings |
+| Single build, single failure | No — overkill |

--- a/.github/skills/ci-analysis/references/sql-tracking.md
+++ b/.github/skills/ci-analysis/references/sql-tracking.md
@@ -43,7 +43,7 @@ SELECT job_name, error_snippet FROM failed_jobs WHERE is_pr_correlated = TRUE;
 
 ### Workflow
 
-1. After the script runs, insert one row per failed job from `failedJobDetails`
+1. After the script runs, insert one row per failed job from `failedJobDetails` (each entry includes `buildId`)
 2. For each known issue from `knownIssues`, UPDATE matching rows with the issue URL
 3. Query for unmatched failures — these need investigation
 4. For crash/canceled jobs, update `recovery_status` after checking Helix results

--- a/.github/skills/ci-analysis/references/sql-tracking.md
+++ b/.github/skills/ci-analysis/references/sql-tracking.md
@@ -96,7 +96,7 @@ WHERE body LIKE '%PTAL%' OR body LIKE '%could you%look%';
 |-----------|----------|
 | 1-2 failed jobs, all match known issues | No — straightforward, hold in context |
 | 3+ failed jobs across multiple builds | Yes — prevents missed matches |
-| Build progression with 5+ builds | Yes — see build-progression-analysis.md |
+| Build progression with 5+ builds | Yes — see [build-progression-analysis.md](build-progression-analysis.md) |
 | Crash recovery across multiple work items | Yes — cache testResults.xml findings |
 | Single build, single failure | No — overkill |
 | PR chain or long-lived PR with extensive triage comments | Yes — preserves diagnosis context across tool calls |

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -2181,7 +2181,9 @@ if ($prChangedFiles.Count -gt 0 -and $allFailuresForCorrelation.Count -gt 0) {
 }
 
 # Compute recommendation hint
-if ($knownIssuesFromBuildAnalysis.Count -gt 0) {
+if (-not $lastBuildJobSummary -and $buildIds.Count -gt 0) {
+    $summary.recommendationHint = "REVIEW_REQUIRED"
+} elseif ($knownIssuesFromBuildAnalysis.Count -gt 0) {
     $summary.recommendationHint = "KNOWN_ISSUES_DETECTED"
 } elseif ($totalFailedJobs -eq 0 -and $totalLocalFailures -eq 0) {
     $summary.recommendationHint = "BUILD_SUCCESSFUL"

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -2221,6 +2221,7 @@ $summary = [ordered]@{
     } }
     failedJobNames = @($allFailedJobNames)
     failedJobDetails = @($allFailedJobDetails)
+    failedJobDetailsTruncated = ($allFailedJobNames.Count -gt $allFailedJobDetails.Count)
     canceledJobNames = @($allCanceledJobNames)
     knownIssues = @($knownIssuesFromBuildAnalysis | ForEach-Object {
         [ordered]@{ number = $_.Number; title = $_.Title; url = $_.Url }

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -1966,7 +1966,6 @@ try {
                     jobName = $job.name
                     errorSnippet = ""
                     helixWorkItems = @()
-                    knownIssues = @()
                     errorCategory = "unclassified"
                 }
 

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -364,7 +364,7 @@ function Get-AzDOBuildIdFromPR {
     $prMergeState = $null
     try {
         $prMergeState = gh api "repos/$Repository/pulls/$PR" --jq '.mergeable_state' 2>$null
-    } catch {}
+    } catch { Write-Verbose "Could not determine PR merge state: $_" }
 
     # Find ALL failing Azure DevOps builds
     $failingBuilds = @{}
@@ -621,7 +621,7 @@ function Show-PRCorrelationSummary {
             }
         }
 
-        Write-Host "`nThese failures are likely PR-related." -ForegroundColor Yellow
+        Write-Host "`nCorrelated files found — check JSON summary for details." -ForegroundColor Yellow
     }
 }
 

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -363,7 +363,8 @@ function Get-AzDOBuildIdFromPR {
     # Check if PR has merge conflicts (no CI runs when mergeable_state is dirty)
     $prMergeState = $null
     try {
-        $prMergeState = gh api "repos/$Repository/pulls/$PR" --jq '.mergeable_state' 2>$null
+        $prMergeState = (gh api "repos/$Repository/pulls/$PR" --jq '.mergeable_state' 2>$null)
+        if ($prMergeState) { $prMergeState = $prMergeState.Trim() }
     } catch { Write-Verbose "Could not determine PR merge state: $_" }
 
     # Find ALL failing Azure DevOps builds

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -2187,7 +2187,7 @@ if ($knownIssuesFromBuildAnalysis.Count -gt 0) {
     $summary.recommendationHint = "BUILD_SUCCESSFUL"
 } elseif ($summary.prCorrelation.hasCorrelation) {
     $summary.recommendationHint = "LIKELY_PR_RELATED"
-} elseif ($prChangedFiles.Count -gt 0) {
+} elseif ($prChangedFiles.Count -gt 0 -and $allFailuresForCorrelation.Count -gt 0) {
     $summary.recommendationHint = "POSSIBLY_TRANSIENT"
 } else {
     $summary.recommendationHint = "REVIEW_REQUIRED"

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -2183,6 +2183,8 @@ if ($prChangedFiles.Count -gt 0 -and $allFailuresForCorrelation.Count -gt 0) {
 }
 
 # Compute recommendation hint
+# Priority: KNOWN_ISSUES wins over LIKELY_PR_RELATED intentionally.
+# When both exist, SKILL.md "Mixed signals" guidance tells the agent to separate them.
 if (-not $lastBuildJobSummary -and $buildIds.Count -gt 0) {
     $summary.recommendationHint = "REVIEW_REQUIRED"
 } elseif ($knownIssuesFromBuildAnalysis.Count -gt 0) {

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -1390,7 +1390,7 @@ function Get-HelixWorkItemDetails {
         # (https://github.com/dotnet/dnceng/issues/6072). ListFiles returns direct
         # blob storage URIs that always work.
         $listFiles = Get-HelixWorkItemFiles -JobId $JobId -WorkItemName $WorkItemName
-        if ($listFiles) {
+        if ($null -ne $listFiles) {
             $response.Files = @($listFiles | ForEach-Object {
                 [PSCustomObject]@{
                     FileName = $_.Name

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -1471,6 +1471,8 @@ function Format-TestFailure {
     $failureCount = 0
 
     # Expanded failure detection patterns
+    # CAUTION: These trigger "failure block" capture. Overly broad patterns (e.g. \w+Error:)
+    # will grab Python harness/reporter noise and swamp the real test failure.
     $failureStartPatterns = @(
         '\[FAIL\]',
         'Assert\.\w+\(\)\s+Failure',
@@ -1479,8 +1481,6 @@ function Format-TestFailure {
         'FAILED\s*$',
         'END EXECUTION - FAILED',
         'System\.\w+Exception:',
-        'Traceback \(most recent call last\)',
-        '\w+Error:',
         'Timed Out \(timeout'
     )
     $combinedPattern = ($failureStartPatterns -join '|')

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -539,43 +539,6 @@ function Get-PRChangedFiles {
 function Get-PRCorrelation {
     param(
         [array]$ChangedFiles,
-        [string]$FailureInfo
-    )
-
-    # Extract potential file/test names from the failure info
-    $correlations = @()
-
-    foreach ($file in $ChangedFiles) {
-        $fileName = [System.IO.Path]::GetFileNameWithoutExtension($file)
-        $fileNameWithExt = [System.IO.Path]::GetFileName($file)
-
-        # Check if the failure mentions this file
-        if ($FailureInfo -match [regex]::Escape($fileName) -or
-            $FailureInfo -match [regex]::Escape($fileNameWithExt)) {
-            $correlations += @{
-                File = $file
-                MatchType = "direct"
-            }
-        }
-
-        # Check for test file patterns
-        if ($file -match '\.Tests?\.' -or $file -match '/tests?/' -or $file -match '\\tests?\\') {
-            # This is a test file - check if the test name appears in failures
-            if ($FailureInfo -match [regex]::Escape($fileName)) {
-                $correlations += @{
-                    File = $file
-                    MatchType = "test"
-                }
-            }
-        }
-    }
-
-    return $correlations | Select-Object -Unique -Property File, MatchType
-}
-
-function Get-PRCorrelation {
-    param(
-        [array]$ChangedFiles,
         [array]$AllFailures
     )
 

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -1833,7 +1833,7 @@ try {
             skipped = $skippedJobs
         }
 
-        if((-not $failedJobs -or $failedJobs.Count -eq 0) -and $localTestFailures.Count -eq 0) {
+        if ((-not $failedJobs -or $failedJobs.Count -eq 0) -and $localTestFailures.Count -eq 0) {
             if ($buildStatus -and $buildStatus.Status -eq "inProgress") {
                 Write-Host "`nNo failures yet - build still in progress" -ForegroundColor Cyan
                 Write-Host "Run again later to check for failures, or use -NoCache to get fresh data" -ForegroundColor Gray

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -388,7 +388,7 @@ function Get-AzDOBuildIdFromPR {
                 $buildIdStr = $anyBuildMatch.Groups[1].Value
                 $buildIdInt = 0
                 if ([int]::TryParse($buildIdStr, [ref]$buildIdInt)) {
-                    return @($buildIdInt)
+                    return @{ BuildIds = @($buildIdInt); Reason = $null; MergeState = $prMergeState }
                 }
             }
         }
@@ -413,7 +413,7 @@ function Get-AzDOBuildIdFromPR {
         }
     }
 
-    return $buildIds
+    return @{ BuildIds = $buildIds; Reason = $null; MergeState = $prMergeState }
 }
 
 function Get-BuildAnalysisKnownIssues {
@@ -1754,7 +1754,7 @@ try {
     $noBuildReason = $null
     if ($PSCmdlet.ParameterSetName -eq 'PRNumber') {
         $buildResult = Get-AzDOBuildIdFromPR -PR $PRNumber
-        if ($buildResult -is [hashtable] -and $buildResult.Reason) {
+        if ($buildResult.Reason) {
             # No builds found — emit summary with reason and exit
             $noBuildReason = $buildResult.Reason
             $buildIds = @()
@@ -1786,7 +1786,7 @@ try {
             Write-Host "[/CI_ANALYSIS_SUMMARY]"
             exit 0
         }
-        $buildIds = @($buildResult)
+        $buildIds = @($buildResult.BuildIds)
 
         # Check Build Analysis for known issues
         $knownIssuesFromBuildAnalysis = @(Get-BuildAnalysisKnownIssues -PR $PRNumber)

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -1736,6 +1736,7 @@ try {
                     total = 0; succeeded = 0; failed = 0; canceled = 0; pending = 0; warnings = 0; skipped = 0
                 }
                 failedJobNames = @()
+                failedJobDetails = @()
                 canceledJobNames = @()
                 knownIssues = @()
                 prCorrelation = [ordered]@{

--- a/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
+++ b/.github/skills/ci-analysis/scripts/Get-CIStatus.ps1
@@ -1969,6 +1969,7 @@ try {
                 # Track per-job failure details for JSON summary
                 $jobDetail = [ordered]@{
                     jobName = $job.name
+                    buildId = $currentBuildId
                     errorSnippet = ""
                     helixWorkItems = @()
                     errorCategory = "unclassified"
@@ -2030,7 +2031,7 @@ try {
                                             # Categorize failure from log content
                                             if ($failureInfo -match 'Timed Out \(timeout') {
                                                 $jobDetail.errorCategory = "test-timeout"
-                                            } elseif ($failureInfo -match 'Exit Code:\s*(139|134)' -or $failureInfo -match 'createdump') {
+                                            } elseif ($failureInfo -match 'Exit Code:\s*(139|134|-4)' -or $failureInfo -match 'createdump') {
                                                 # Crash takes highest precedence — don't downgrade
                                                 if ($jobDetail.errorCategory -notin @("crash")) {
                                                     $jobDetail.errorCategory = "crash"


### PR DESCRIPTION
## ci-analysis: structured output, MCP integration, and deep investigation guides

### Changes to `Get-CIStatus.ps1` (+216/-132)
- **Add `[CI_ANALYSIS_SUMMARY]` JSON block** — structured summary emitted at end of script with all key facts (builds, failed jobs, known issues, PR correlation, recommendation hint)
- **Replace 47-line if/elseif recommendation chain** with a single `recommendationHint` field in JSON (one of: `BUILD_SUCCESSFUL`, `KNOWN_ISSUES_DETECTED`, `LIKELY_PR_RELATED`, `POSSIBLY_TRANSIENT`, `REVIEW_REQUIRED`, `MERGE_CONFLICTS`, `NO_BUILDS`)
- **Add `failedJobDetails` to JSON** — per-job `errorCategory` (test-failure, build-error, test-timeout, crash, tests-passed-reporter-failed, unclassified), `errorSnippet`, and `helixWorkItems`
- **Add `failedJobDetailsTruncated`** — boolean flag indicating when `-MaxJobs` cap means `failedJobDetails` is incomplete vs `failedJobNames`
- **Add top-level `knownIssues`** from Build Analysis (not per-job — Build Analysis reports at the PR level, not per-job)
- **Add timeout pattern** to `Format-TestFailure` — catches `Timed Out (timeout` that was previously invisible
- **Show log tail in PR mode** when no failure pattern matches (Helix Job mode already did this)
- **Add accumulation variables** for cross-build aggregation (`totalFailedJobs`, `totalLocalFailures`, `lastBuildJobSummary`)
- **Fix early-continue scoping bug** — job summary computation was at end of build loop, after 3 `continue` paths that skipped it
- **Fix empty array falsy check** — `if ($listFiles)` → proper count check
- **Fix `mergeable_state` trimming** — `gh api --jq` output trimmed to prevent whitespace comparison failures
- **Remove interpretive prose** — "These failures are likely PR-related" moved from script to agent reasoning
- **Fix empty catch** — merge state error now logged via `Write-Verbose`

### Changes to `SKILL.md` (+97/-144, net reduction)
- **Add Step 0: Gather Context** — PR type classification table (code, flow, backport, merge, dependency update)
- **Add Step 3: Verify before claiming** — systematic checklist
- **Add build progression analysis** (Step 2, item 4) — comparing pass/fail across PR builds to narrow down which commit introduced a failure
- **Add prior-build mismatch detection** (Step 2, item 6) — ask user when they reference jobs not in current results
- **Document `failedJobDetails`** — per-failure error categories in Interpreting Results
- **Add Build Analysis check status enforcement** — red check means unaccounted failures exist, never claim "all known" when it's red
- **Add timeout recovery workflow** — explicit guidance for verifying timed-out builds have passing Helix results via `hlx_status`
- **Add crash/canceled job recovery procedure** — step-by-step using `hlx_batch_status`, `hlx_files`, `hlx_download_url` to recover results from crashed Helix work items
- **Fix MCP tool references** — use canonical short-form tool names consistently
- **Condense anti-patterns** — tighter, more targeted, near relevant steps
- **Net token reduction** — despite adding new content, SKILL.md shrank from ~4.6K to ~3.5K tokens

### New reference files
- `references/azure-cli.md` — Azure CLI deep investigation guide
- `references/binlog-comparison.md` — binlog comparison workflow
- `references/delegation-patterns.md` — subagent delegation patterns (5 patterns including parallel artifact extraction and canceled job recovery)
- `references/build-progression-analysis.md` — commit-to-build correlation using `triggerInfo.pr.sourceSha`, SQL-based progression tracking, MCP-first with AzDO MCP tools as primary

### Updated reference files
- `references/manual-investigation.md` — fix nonexistent `msbuild-mcp analyze` tool refs, use real `mcp-binlog-tool-*` tools

### Design principles
- **Data/reasoning boundary**: Script emits structured JSON facts → agent synthesizes recommendations. No more canned prose from the script.
- **MCP-first**: AzDO MCP tools (`get_builds`, `get_build_log_by_id`) and Helix MCP tools (`hlx_status`, `hlx_logs`) positioned as primary, CLI/script as fallback.
- **Token budget**: Orchestrating SKILL.md kept within 2K-4K token budget by extracting depth to `references/`.
- **SQL for structured investigations**: Build progression tracking uses SQL tables to persist SHAs across context, enabling queries for pass→fail transitions and target branch movement.

### Testing
- Multi-model subagent testing (Sonnet 4 + GPT-5 + Opus 4.5) — two review rounds with findings addressed
- Live MCP integration test confirmed `hlx_status`, `hlx_logs`, `get_builds`, `get_build_log_by_id` all work
- Real-world validation against PRs #123245, #123883, #124125, #124232