### PR TITLE
Remove bounds checks for 'i + cns < len' pattern

### DIFF
--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -871,17 +871,16 @@ Range RangeCheck::GetRangeFromAssertions(Compiler* comp, ValueNum num, ASSERT_VA
 
 //------------------------------------------------------------------------
 // TightenLimit: Given two limits for the same variable, return a tighter limit
+//    Example: l1: 10 and l2: 20. For lower limit, we can tighten to 20. For upper limit, we can tighten to 10.
 //
 // Arguments:
-//    l1             - the first limit to compare
-//    l2             - the second limit to compare
-//    preferredBound - when one of the limits is based on this preferredBound, we will choose it over the other
-//                     limit if it is not worse. This is used to prefer BinOpArray limits based on the array length
-//                     variable that we are checking bounds for.
+//    l1             - The first limit
+//    l2             - The second limit
+//    preferredBound - We might prefer this VN limit over the other.
 //    isLower        - true if the limits are lower limits, false if the limits are upper limits.
 //
 // Return Value:
-//    The tighter limit
+//    The more tightened limit between l1 and l2.
 //
 Limit RangeCheck::TightenLimit(Limit l1, Limit l2, ValueNum preferredBound, bool isLower)
 {

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1017,8 +1017,8 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
                 limit      = Limit(Limit::keBinOpArray, preferredBoundVN, -addOpCns);
                 isUnsigned = false;
                 // The comparison being unsigned may also hint that the lower bound is -CNS1, but it's
-                // unlikely to be useful, so we ignore it for now. The whole thing will work only if some other assertion
-                // proves that the normalLclVN's lower bound is non-negative.
+                // unlikely to be useful, so we ignore it for now. The whole thing will work only if some other
+                // assertion proves that the normalLclVN's lower bound is non-negative.
             }
             else
             {

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -927,11 +927,10 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
             if (comp->vnStore->IsVNBinFuncWithConst(curAssertion.GetOp1().GetVN(), VNF_ADD, &addOpVN, &addOpCns) &&
                 (addOpVN == normalLclVN) && (addOpCns >= 0))
             {
-                // We can deduce normalLclVN is [-CNS1..checkedBndVN - CNS1]
-                cmpOper = Compiler::AssertionDsc::ToCompareOper(curAssertion.GetKind(), &isUnsigned);
-                limit   = Limit(Limit::keBinOpArray, curAssertion.GetOp2().GetCheckedBound(), -addOpCns);
-                assert(cmpOper == GT_LT);
-                assert(isUnsigned);
+                // normalLclVN is [-CNS..preferredBoundVN - CNS]
+                cmpOper    = GT_LT;
+                isUnsigned = true;
+                limit      = Limit(Limit::keBinOpArray, preferredBoundVN, -addOpCns);
             }
             else
             {

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -951,7 +951,7 @@ Limit RangeCheck::TightenLimit(Limit l1, Limit l2, ValueNum preferredBound, bool
         return isLower ? l2 : l1;
     }
     unreached();
-};
+}
 
 //------------------------------------------------------------------------
 // MergeEdgeAssertions: Merge assertions on the edge flowing into the block about a variable
@@ -1275,8 +1275,8 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
                 assertedRange.ToString(comp));
 
         Range copy  = *pRange;
-        copy.lLimit = tightenLimit(assertedRange.lLimit, copy.lLimit, preferredBoundVN, true);
-        copy.uLimit = tightenLimit(assertedRange.uLimit, copy.uLimit, preferredBoundVN, false);
+        copy.lLimit = TightenLimit(assertedRange.lLimit, copy.lLimit, preferredBoundVN, true);
+        copy.uLimit = TightenLimit(assertedRange.uLimit, copy.uLimit, preferredBoundVN, false);
 
         JITDUMP("[%s]\n", copy.ToString(comp));
         if (copy.IsValid())

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -1002,7 +1002,6 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         // Example: "(uint)(i + 2) < (uint)span.Length" or just "i + 2 < span.Length"
         if (canUseCheckedBounds && curAssertion.KindIs(Compiler::OAK_LT_UN, Compiler::OAK_LT) &&
             curAssertion.GetOp2().KindIs(Compiler::O2K_CHECKED_BOUND_ADD_CNS) &&
-            (curAssertion.GetOp2().GetCheckedBoundConstant() == 0) &&
             curAssertion.GetOp2().IsCheckedBoundNeverNegative() &&
             (curAssertion.GetOp2().GetCheckedBound() == preferredBoundVN) &&
             (curAssertion.GetOp1().GetVN() != normalLclVN))
@@ -1016,7 +1015,8 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
                 limit      = Limit(Limit::keBinOpArray, preferredBoundVN, -addOpCns);
                 isUnsigned = false;
                 // The difference between signed and unsigned is that for unsigned the lower bound can also be
-                // deduced to be -cns instead of INT32_MIN, but we only report the upper bound here.
+                // deduced to be -cns instead of INT32_MIN (but only if curAssertion.GetOp2().GetCheckedBoundConstant()
+                // is true) but we only report one bound at a time in MergeEdgeAssertions.
             }
             else
             {

--- a/src/coreclr/jit/rangecheck.h
+++ b/src/coreclr/jit/rangecheck.h
@@ -803,6 +803,8 @@ private:
     // refine the "pRange" value.
     void MergeEdgeAssertions(GenTreeLclVarCommon* lcl, ASSERT_VALARG_TP assertions, Range* pRange);
 
+    static Limit TightenLimit(Limit l1, Limit l2, ValueNum preferredBound, bool isLower);
+
     // Inspect the assertions about the current ValueNum to refine pRange
     static void MergeEdgeAssertions(Compiler*        comp,
                                     ValueNum         num,

--- a/src/tests/JIT/opt/RangeChecks/ElidedBoundsChecks.cs
+++ b/src/tests/JIT/opt/RangeChecks/ElidedBoundsChecks.cs
@@ -65,6 +65,24 @@ public class ElidedBoundsChecks
         return span[i & (span.Length - 1)];
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool IndexPlusConstLessThanLen(ReadOnlySpan<char> span)
+    {
+        // X64-NOT: CORINFO_HELP_RNGCHKFAIL
+        // ARM64-NOT: CORINFO_HELP_RNGCHKFAIL
+        for (int i = 0; i < span.Length; i++)
+        {
+            if (span[i] == '%' && (uint)(i + 2) < (uint)span.Length)
+            {
+                if (span[i + 1] == 'F' && span[i + 2] == 'F')
+                {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     [Fact]
     public static int TestEntryPoint()
     {
@@ -90,6 +108,15 @@ public class ElidedBoundsChecks
             return 0;
 
         if (AndByLength(255) != 4)
+            return 0;
+
+        if (IndexPlusConstLessThanLen("%FF".AsSpan()) != true)
+            return 0;
+
+        if (IndexPlusConstLessThanLen("%F".AsSpan()) != false)
+            return 0;
+
+        if (IndexPlusConstLessThanLen("hello".AsSpan()) != false)
             return 0;
 
         return 100;


### PR DESCRIPTION
Closes https://github.com/dotnet/runtime/issues/121262

```cs
public static bool Test(ReadOnlySpan<char> span)
{
    for (int i = 0; i < span.Length; i++)
    {
        if (span[i] == '%' && (uint)(i + 2) < (uint)span.Length)
        {
            if (span[i + 1] == 'F' && // Bounds check
                span[i + 2] == 'F')
            {
                return true;
            }
        }
    }
    return false;
}
```
New codegen:
```asm
; Method Prog:Test(System.ReadOnlySpan`1[char]):bool (FullOpts)
       mov      rax, bword ptr [rcx]
       mov      ecx, dword ptr [rcx+0x08]
       xor      edx, edx
       test     ecx, ecx
       je       SHORT G_M967_IG06
       align    [0 bytes for IG03]
G_M967_IG03:
       cmp      word  ptr [rax+2*rdx], 37
       jne      SHORT G_M967_IG05
       lea      r8d, [rdx+0x02]
       cmp      r8d, ecx
       jae      SHORT G_M967_IG05
       lea      r10d, [rdx+0x01]
       cmp      word  ptr [rax+2*r10], 70
       jne      SHORT G_M967_IG05
       cmp      word  ptr [rax+2*r8], 70
       je       SHORT G_M967_IG08
G_M967_IG05:
       inc      edx
       cmp      edx, ecx
       jl       SHORT G_M967_IG03
G_M967_IG06:
       xor      eax, eax
       ret      
G_M967_IG08:
       mov      eax, 1
       ret      
; Total bytes of code: 63
```

[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1288650&view=ms.vss-build-web.run-extensions-tab)