### PR TITLE
Fix type map assembly target traversal in ILC

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypeMapMetadata.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypeMapMetadata.cs
@@ -59,6 +59,7 @@ namespace ILCompiler
 
             private readonly Dictionary<TypeDesc, TypeDesc> _associatedTypeMap = [];
             private readonly Dictionary<string, (TypeDesc type, TypeDesc trimmingTarget)> _externalTypeMap = [];
+            private readonly List<ModuleDesc> _targetModules = [];
             private ThrowingMethodStub _externalTypeMapExceptionStub;
             private ThrowingMethodStub _associatedTypeMapExceptionStub;
 
@@ -104,6 +105,39 @@ namespace ILCompiler
                 _associatedTypeMapExceptionStub ??= new ThrowingMethodStub(stubModule.GetGlobalModuleType(), TypeMapGroup, externalTypeMap: false, exception);
             }
 
+            public void MergePendingMap(Map pendingMap)
+            {
+                if (_associatedTypeMapExceptionStub is null)
+                {
+                    if (pendingMap._associatedTypeMapExceptionStub is not null)
+                    {
+                        _associatedTypeMapExceptionStub = pendingMap._associatedTypeMapExceptionStub;
+                    }
+                    else
+                    {
+                        foreach (KeyValuePair<TypeDesc, TypeDesc> kvp in pendingMap._associatedTypeMap)
+                        {
+                            AddAssociatedTypeMapEntry(kvp.Key, kvp.Value);
+                        }
+                    }
+                }
+
+                if (_externalTypeMapExceptionStub is null)
+                {
+                    if (pendingMap._externalTypeMapExceptionStub is not null)
+                    {
+                        _externalTypeMapExceptionStub = pendingMap._externalTypeMapExceptionStub;
+                    }
+                    else
+                    {
+                        foreach (KeyValuePair<string, (TypeDesc type, TypeDesc trimmingTarget)> kvp in pendingMap._externalTypeMap)
+                        {
+                            AddExternalTypeMapEntry(kvp.Key, kvp.Value.type, kvp.Value.trimmingTarget);
+                        }
+                    }
+                }
+            }
+
             public IExternalTypeMapNode GetExternalTypeMapNode()
             {
                 if (_externalTypeMapExceptionStub is not null)
@@ -121,6 +155,16 @@ namespace ILCompiler
                 }
                 return new ProxyTypeMapNode(TypeMapGroup, _associatedTypeMap);
             }
+
+            public void AddTargetModule(ModuleDesc targetModule)
+            {
+                _targetModules.Add(targetModule);
+            }
+
+            /// <summary>
+            /// The modules targeted with TypeMapAssemblyTarget attributes for this type map group. This is only populated when TypeMapMetadata is created with TypeMapAssemblyTargetsMode.Record. When TypeMapMetadata is created with TypeMapAssemblyTargetsMode.Traverse, this will be empty as the target assemblies will be traversed to include their type maps instead of just being recorded as targets.
+            /// </summary>
+            public IEnumerable<ModuleDesc> TargetModules => _targetModules;
         }
 
         public static readonly TypeMapMetadata Empty = new TypeMapMetadata(new Dictionary<TypeDesc, Map>(), "No type maps");
@@ -141,22 +185,48 @@ namespace ILCompiler
 
         public string DiagnosticName { get; }
 
-        public static TypeMapMetadata CreateFromAssembly(EcmaAssembly assembly, CompilerTypeSystemContext typeSystemContext)
+        public static TypeMapMetadata CreateFromAssembly(EcmaAssembly assembly, TypeSystemContext typeSystemContext, ModuleDesc throwHelperEmitModule, TypeMapAssemblyTargetsMode assemblyTargetsMode)
         {
             Dictionary<TypeDesc, Map> typeMapStates = [];
-            HashSet<EcmaAssembly> scannedAssemblies = [];
+            // The pendingMaps collection represents assemblies that have been scanned, but the provided assembly
+            // has not been added as a target yet for the specified type map group.
+            // This can occur when an assembly is the target of a TypeMapAssemblyTarget attribute for a different group.
+            Dictionary<(EcmaAssembly assembly, TypeDesc typeMapGroup), (TypeDesc scannedDuringGroup, Map map)> pendingMaps = [];
+            HashSet<(EcmaAssembly assembly, TypeDesc typeMapGroup)> scannedAssemblies = [];
 
-            Queue<EcmaAssembly> assembliesToScan = new Queue<EcmaAssembly>();
-            assembliesToScan.Enqueue(assembly);
+            Queue<(EcmaAssembly assembly, TypeDesc typeMapGroup)> assembliesToScan = [];
+            assembliesToScan.Enqueue((assembly, null));
 
             while (assembliesToScan.Count > 0)
             {
-                EcmaAssembly currentAssembly = assembliesToScan.Dequeue();
-                if (scannedAssemblies.Contains(currentAssembly))
-                    continue;
+                (EcmaAssembly currentAssembly, TypeDesc currentTypeMapGroup) = assembliesToScan.Dequeue();
 
-                scannedAssemblies.Add(currentAssembly);
+                // A null currentTypeMapGroup means we're looking at all type maps in the assembly, not just traversing one.
+                // Otherwise, we're searching for a specific one.
+                // Don't rescan specific assembly + type map group combos as the results will be identical.
+                if (currentTypeMapGroup is not null)
+                {
+                    if (scannedAssemblies.Contains((currentAssembly, currentTypeMapGroup)))
+                    {
+                        if (pendingMaps.TryGetValue((currentAssembly, currentTypeMapGroup), out var pendingMap))
+                        {
+                            // We have already scanned this assembly, but we haven't added the results to the type map state for the specified type map group.
+                            // Merge in the results.
+                            if (!typeMapStates.TryGetValue(currentTypeMapGroup, out Map typeMapState))
+                            {
+                                typeMapStates[currentTypeMapGroup] = typeMapState = new Map(currentTypeMapGroup);
+                            }
+                            typeMapState.MergePendingMap(pendingMap.map);
+                            pendingMaps.Remove((currentAssembly, currentTypeMapGroup));
+                        }
+                        // We've already scanned this assembly for this type map group.
+                        // There's no more work to do for this case.
+                        continue;
+                    }
+                }
 
+                // Either we haven't seen this assembly + group combo before
+                // or we are scanning all type map groups in the assembly.
                 foreach (CustomAttributeHandle attrHandle in currentAssembly.MetadataReader.GetCustomAttributes(EntityHandle.AssemblyDefinition))
                 {
                     CustomAttribute attr = currentAssembly.MetadataReader.GetCustomAttribute(attrHandle);
@@ -185,20 +255,55 @@ namespace ILCompiler
 
                     TypeDesc typeMapGroup = type.Instantiation[0];
 
+                    Map typeMapState;
+
+                    if (currentTypeMapGroup is null || typeMapGroup == currentTypeMapGroup)
+                    {
+                        // This attribute is definitely included in the type map.
+                        if (!typeMapStates.TryGetValue(typeMapGroup, out typeMapState))
+                        {
+                            typeMapStates[typeMapGroup] = typeMapState = new Map(typeMapGroup);
+                        }
+                    }
+                    else
+                    {
+                        // This attribute may be included in the type map, but this type map group isn't the one that triggered us to scan this assembly,
+                        // so we need to save it as a pending map in case its type map group is triggered later when we scan another assembly.
+                        if (!pendingMaps.TryGetValue((currentAssembly, typeMapGroup), out var pendingMap))
+                        {
+                            typeMapState = new Map(typeMapGroup);
+                            pendingMaps[(currentAssembly, typeMapGroup)] = (currentTypeMapGroup, typeMapState);
+                        }
+                        else
+                        {
+                            if (pendingMap.scannedDuringGroup != currentTypeMapGroup)
+                            {
+                                // We already scanned this assembly for this type map group while
+                                // processing a different type map group.
+                                // Skip processing it again to avoid hitting duplicate entries.
+                                continue;
+                            }
+                            typeMapState = pendingMap.map;
+                        }
+                    }
+
+                    // Mark this assembly + type map group as scanned to avoid redundant work in the future.
+                    scannedAssemblies.Add((currentAssembly, typeMapGroup));
+
                     try
                     {
                         switch (attrKind)
                         {
                             case TypeMapAttributeKind.TypeMapAssemblyTarget:
-                                ProcessTypeMapAssemblyTargetAttribute(attrValue);
+                                ProcessTypeMapAssemblyTargetAttribute(attrValue, typeMapState);
                                 break;
 
                             case TypeMapAttributeKind.TypeMap:
-                                ProcessTypeMapAttribute(attrValue, typeMapGroup);
+                                ProcessTypeMapAttribute(attrValue, typeMapState);
                                 break;
 
                             case TypeMapAttributeKind.TypeMapAssociation:
-                                ProcessTypeMapAssociationAttribute(attrValue, typeMapGroup);
+                                ProcessTypeMapAssociationAttribute(attrValue, typeMapState);
                                 break;
 
                             default:
@@ -216,17 +321,25 @@ namespace ILCompiler
 
                         if (attrKind is TypeMapAttributeKind.TypeMapAssemblyTarget or TypeMapAttributeKind.TypeMap)
                         {
-                            value.SetExternalTypeMapException(typeSystemContext.GeneratedAssembly, ex);
+                            value.SetExternalTypeMapException(throwHelperEmitModule, ex);
                         }
 
                         if (attrKind is TypeMapAttributeKind.TypeMapAssemblyTarget or TypeMapAttributeKind.TypeMapAssociation)
                         {
-                            value.SetAssociatedTypeMapException(typeSystemContext.GeneratedAssembly, ex);
+                            value.SetAssociatedTypeMapException(throwHelperEmitModule, ex);
                         }
                     }
                 }
 
-                void ProcessTypeMapAssemblyTargetAttribute(CustomAttributeValue<TypeDesc> attrValue)
+                if (currentTypeMapGroup is not null)
+                {
+                    // Mark this assembly + type map group as scanned to avoid redundant work in the future.
+                    // We can hit this case when the type map group has no entries in the current assembly.
+                    scannedAssemblies.Add((currentAssembly, currentTypeMapGroup));
+                }
+
+
+                void ProcessTypeMapAssemblyTargetAttribute(CustomAttributeValue<TypeDesc> attrValue, Map typeMapState)
                 {
                     if (attrValue.FixedArguments is not [{ Value: string assemblyName }])
                     {
@@ -236,29 +349,33 @@ namespace ILCompiler
 
                     EcmaAssembly targetAssembly = (EcmaAssembly)assembly.Context.ResolveAssembly(AssemblyNameInfo.Parse(assemblyName), throwIfNotFound: true);
 
-                    assembliesToScan.Enqueue(targetAssembly);
+                    switch (assemblyTargetsMode)
+                    {
+                        case TypeMapAssemblyTargetsMode.Traverse:
+                            assembliesToScan.Enqueue((targetAssembly, typeMapState.TypeMapGroup));
+                            // We will traverse the target assembly to include its type maps.
+                            break;
+                        case TypeMapAssemblyTargetsMode.Record:
+                            typeMapState.AddTargetModule(targetAssembly);
+                            return;
+                        default:
+                            Debug.Fail($"Unexpected TypeMapAssemblyTargetsMode: {assemblyTargetsMode}");
+                            return;
+                    }
                 }
 
-                void ProcessTypeMapAttribute(CustomAttributeValue<TypeDesc> attrValue, TypeDesc typeMapGroup)
+                void ProcessTypeMapAttribute(CustomAttributeValue<TypeDesc> attrValue, Map typeMapState)
                 {
                     switch (attrValue.FixedArguments)
                     {
                         case [{ Value: string typeName }, { Value: TypeDesc targetType }]:
                         {
-                            if (!typeMapStates.TryGetValue(typeMapGroup, out Map typeMapState))
-                            {
-                                typeMapStates[typeMapGroup] = typeMapState = new Map(typeMapGroup);
-                            }
                             typeMapState.AddExternalTypeMapEntry(typeName, targetType, null);
                             break;
                         }
 
                         case [{ Value: string typeName }, { Value: TypeDesc targetType }, { Value: TypeDesc trimTargetType }]:
                         {
-                            if (!typeMapStates.TryGetValue(typeMapGroup, out Map typeMapState))
-                            {
-                                typeMapStates[typeMapGroup] = typeMapState = new Map(typeMapGroup);
-                            }
                             typeMapState.AddExternalTypeMapEntry(typeName, targetType, trimTargetType);
                             break;
                         }
@@ -269,7 +386,7 @@ namespace ILCompiler
                     }
                 }
 
-                void ProcessTypeMapAssociationAttribute(CustomAttributeValue<TypeDesc> attrValue, TypeDesc typeMapGroup)
+                void ProcessTypeMapAssociationAttribute(CustomAttributeValue<TypeDesc> attrValue, Map typeMapState)
                 {
                     // If attribute is TypeMapAssociationAttribute, we need to extract the generic argument (type map group)
                     // and process it.
@@ -279,16 +396,23 @@ namespace ILCompiler
                         return;
                     }
 
-                    if (!typeMapStates.TryGetValue(typeMapGroup, out Map typeMapState))
-                    {
-                        typeMapStates[typeMapGroup] = typeMapState = new Map(typeMapGroup);
-                    }
-
                     typeMapState.AddAssociatedTypeMapEntry(type, associatedType);
                 }
             }
 
             return new TypeMapMetadata(typeMapStates, $"Type maps rooted at {assembly}");
         }
+    }
+
+    public enum TypeMapAssemblyTargetsMode
+    {
+        /// <summary>
+        /// Traverse the TypeMapAssemblyTarget attributes and include type maps from the target assemblies.
+        /// </summary>
+        Traverse,
+        /// <summary>
+        /// Record the TypeMapAssemblyTarget attributes but do not traverse them to include type maps from the target assemblies.
+        /// </summary>
+        Record
     }
 }

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
@@ -150,12 +150,12 @@ namespace Mono.Linker.Tests.TestCasesRunner
             if (options.TypeMapEntryAssembly is not null
                 && typeSystemContext.ResolveAssembly(AssemblyNameInfo.Parse(options.TypeMapEntryAssembly), throwIfNotFound: true) is EcmaAssembly typeMapEntryAssembly)
             {
-                typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(typeMapEntryAssembly, typeSystemContext, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
+                typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(typeMapEntryAssembly, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
             }
             else if (entrypointModule is { Assembly: EcmaAssembly entryAssembly })
             {
                 // Pass null for typeMappingEntryAssembly to use default entry assembly behavior in tests
-                typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(entryAssembly, typeSystemContext, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
+                typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(entryAssembly, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
             }
 
             CompilationBuilder builder = new RyuJitCompilationBuilder(typeSystemContext, compilationGroup)

--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TrimmingDriver.cs
@@ -150,12 +150,12 @@ namespace Mono.Linker.Tests.TestCasesRunner
             if (options.TypeMapEntryAssembly is not null
                 && typeSystemContext.ResolveAssembly(AssemblyNameInfo.Parse(options.TypeMapEntryAssembly), throwIfNotFound: true) is EcmaAssembly typeMapEntryAssembly)
             {
-                typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(typeMapEntryAssembly, typeSystemContext));
+                typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(typeMapEntryAssembly, typeSystemContext, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
             }
             else if (entrypointModule is { Assembly: EcmaAssembly entryAssembly })
             {
                 // Pass null for typeMappingEntryAssembly to use default entry assembly behavior in tests
-                typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(entryAssembly, typeSystemContext));
+                typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(entryAssembly, typeSystemContext, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
             }
 
             CompilationBuilder builder = new RyuJitCompilationBuilder(typeSystemContext, compilationGroup)

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -202,7 +202,7 @@ namespace ILCompiler
                 compilationRoots.Add(new SingleMethodRootProvider(singleMethod));
                 if (singleMethod.OwningType is MetadataType { Module.Assembly: EcmaAssembly assembly })
                 {
-                    typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(assembly, typeSystemContext, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
+                    typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(assembly, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
                 }
             }
             else
@@ -319,12 +319,12 @@ namespace ILCompiler
                 if (typeMappingEntryAssembly is not null)
                 {
                     var typeMapEntryAssembly = (EcmaAssembly)typeSystemContext.ResolveAssembly(AssemblyNameInfo.Parse(typeMappingEntryAssembly), throwIfNotFound: true);
-                    typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(typeMapEntryAssembly, typeSystemContext, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
+                    typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(typeMapEntryAssembly, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
                 }
                 else if (entrypointModule is { Assembly: EcmaAssembly entryAssembly })
                 {
                     // Fall back to entryassembly if not specified
-                    typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(entryAssembly, typeSystemContext, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
+                    typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(entryAssembly, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
                 }
             }
 

--- a/src/coreclr/tools/aot/ILCompiler/Program.cs
+++ b/src/coreclr/tools/aot/ILCompiler/Program.cs
@@ -202,7 +202,7 @@ namespace ILCompiler
                 compilationRoots.Add(new SingleMethodRootProvider(singleMethod));
                 if (singleMethod.OwningType is MetadataType { Module.Assembly: EcmaAssembly assembly })
                 {
-                    typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(assembly, typeSystemContext));
+                    typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(assembly, typeSystemContext, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
                 }
             }
             else
@@ -319,12 +319,12 @@ namespace ILCompiler
                 if (typeMappingEntryAssembly is not null)
                 {
                     var typeMapEntryAssembly = (EcmaAssembly)typeSystemContext.ResolveAssembly(AssemblyNameInfo.Parse(typeMappingEntryAssembly), throwIfNotFound: true);
-                    typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(typeMapEntryAssembly, typeSystemContext));
+                    typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(typeMapEntryAssembly, typeSystemContext, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
                 }
                 else if (entrypointModule is { Assembly: EcmaAssembly entryAssembly })
                 {
                     // Fall back to entryassembly if not specified
-                    typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(entryAssembly, typeSystemContext));
+                    typeMapManager = new UsageBasedTypeMapManager(TypeMapMetadata.CreateFromAssembly(entryAssembly, typeSystemContext, typeSystemContext.GeneratedAssembly, TypeMapAssemblyTargetsMode.Traverse));
                 }
             }
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/TypeMapReferencedAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/Dependencies/TypeMapReferencedAssembly.cs
@@ -14,6 +14,8 @@ using Mono.Linker.Tests.Cases.Reflection.Dependencies.Library;
 [assembly: TypeMapAssociation<UnusedTypeMapUniverse>(typeof(ProxySource2), typeof(ProxyTarget2))]
 [assembly: TypeMapAssemblyTarget<UsedTypeMapUniverse>("library2")]
 
+[assembly: TypeMap<UsedWithoutAssemblyTargetUniverse>("UnimportantString", typeof(TargetTypeUnconditional3))]
+
 namespace Mono.Linker.Tests.Cases.Reflection.Dependencies
 {
     public class TypeMapReferencedAssembly
@@ -29,11 +31,13 @@ namespace Mono.Linker.Tests.Cases.Reflection.Dependencies
             // Mark expected type map universe
             _ = TypeMapping.GetOrCreateExternalTypeMapping<UsedTypeMapUniverse>();
             _ = TypeMapping.GetOrCreateProxyTypeMapping<UsedTypeMapUniverse>();
+            _ = TypeMapping.GetOrCreateExternalTypeMapping<UsedWithoutAssemblyTargetUniverse>();
         }
     }
 
     public class UsedTypeMapUniverse;
     public class UnusedTypeMapUniverse;
+    public class UsedWithoutAssemblyTargetUniverse;
 }
 
 namespace Mono.Linker.Tests.Cases.Reflection.Dependencies.Library
@@ -48,4 +52,5 @@ namespace Mono.Linker.Tests.Cases.Reflection.Dependencies.Library
     public class ProxyTarget2;
     public class TrimTarget1;
     public class TrimTarget2;
+    public class TargetTypeUnconditional3;
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMap.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMap.cs
@@ -58,8 +58,10 @@ using Mono.Linker.Tests.Cases.Reflection.Dependencies.Library;
 // TypeMapAssemblyTarget is kept regardless of which type map the program needs (External or Proxy)
 [assembly: KeptAttributeAttribute(typeof(TypeMapAssemblyTargetAttribute<UsedProxyTypeMap>))]
 [assembly: KeptAttributeAttribute(typeof(TypeMapAssemblyTargetAttribute<UsedExternalTypeMap>))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAssemblyTargetAttribute<UsedTypeMapUniverse>))]
 [assembly: TypeMapAssemblyTarget<UsedProxyTypeMap>("library")]
 [assembly: TypeMapAssemblyTarget<UsedExternalTypeMap>("library")]
+[assembly: TypeMapAssemblyTarget<UsedTypeMapUniverse>("library")]
 [assembly: TypeMapAssemblyTarget<UnusedTypeMap2>("library")] // Should be removed
 
 namespace Mono.Linker.Tests.Cases.Reflection

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMap.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMap.cs
@@ -96,11 +96,11 @@ namespace Mono.Linker.Tests.Cases.Reflection
     // and in the vast majority of user scenarios, assemblies will be correctly referenced with TypeMapAssemblyTargetAttribute.
     // Nearly every case where this behavior would kick in is a bug in user code.
     [KeptTypeInAssembly("library.dll", typeof(TargetTypeUnconditional3), Tool = Tool.Trimmer)]
+    [KeptAttributeInAssembly("library.dll", typeof(TypeMapAttribute<UsedWithoutAssemblyTargetUniverse>))]
 
     [KeptAttributeInAssembly("library.dll", typeof(TypeMapAttribute<UsedTypeMapUniverse>))]
     [KeptAttributeInAssembly("library.dll", typeof(TypeMapAssociationAttribute<UsedTypeMapUniverse>))]
     [KeptAttributeInAssembly("library.dll", typeof(TypeMapAssemblyTargetAttribute<UsedTypeMapUniverse>))]
-    [KeptAttributeInAssembly("library.dll", typeof(TypeMapAssemblyTargetAttribute<UsedWithoutAssemblyTargetUniverse>))]
     [RemovedAttributeInAssembly("library.dll", typeof(TypeMapAttribute<UnusedTypeMapUniverse>))]
     [RemovedAttributeInAssembly("library.dll", typeof(TypeMapAssociationAttribute<UnusedTypeMapUniverse>))]
 


### PR DESCRIPTION
Type map assembly target references should only be followed for the provided type map group type (ie, type maps in target assemblies that aren't referenced by AssemblyTarget for that type group shouldn't preserve types).
