### PR TITLE
JIT: fix liveness in throw helper blocks

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -6792,6 +6792,7 @@ public:
     AddCodeDsc* fgGetExcptnTarget(SpecialCodeKind kind, BasicBlock* fromBlock, bool createIfNeeded = false);
     bool fgUseThrowHelperBlocks();
     void fgCreateThrowHelperBlockCode(AddCodeDsc* add);
+    void fgSetThrowHelpBlockLiveness(BasicBlock* block);
     void fgSequenceLocals(Statement* stmt);
 
 private:

--- a/src/coreclr/jit/flowgraph.cpp
+++ b/src/coreclr/jit/flowgraph.cpp
@@ -3492,6 +3492,10 @@ void Compiler::fgCreateThrowHelperBlock(AddCodeDsc* add)
     //
     add->acdDstBlk = newBlk;
 
+    // Set up liveness
+    //
+    fgSetThrowHelpBlockLiveness(newBlk);
+
 #ifdef DEBUG
     if (verbose)
     {


### PR DESCRIPTION
PR #123781 changed things so that throw helper blocks are now created just after lower. Because of this they no longer get the special liveness update for unreachable blocks.

Add this update in explicitly when the blocks are created.

Fixes #123929