### PR TITLE
[ios] HelloiOS - Set RunAOTCompilation only on Mono

### DIFF
--- a/docs/workflow/building/coreclr/ios.md
+++ b/docs/workflow/building/coreclr/ios.md
@@ -77,7 +77,7 @@ A prerequisite for building and running samples locally is to have CoreCLR succe
 To build `HelloiOS`, run the following command from `<repo-root>`:
 
 ```bash
-./dotnet.sh build src/mono/sample/iOS/Program.csproj -c <Release|Debug> /p:TargetOS=<ios|iossimulator|tvossimulator|maccatalyst> /p:TargetArchitecture=arm64 /p:UseMonoRuntime=false /p:RunAOTCompilation=false
+./dotnet.sh build src/mono/sample/iOS/Program.csproj -c <Release|Debug> /p:TargetOS=<ios|iossimulator|tvossimulator|maccatalyst> /p:TargetArchitecture=arm64 /p:UseMonoRuntime=false
 ```
 
 On successful execution, the command will output the iOS app bundle.
@@ -87,7 +87,7 @@ On successful execution, the command will output the iOS app bundle.
 To run the sample, run the following command from `<repo-root>`:
 
 ```bash
-./dotnet.sh publish src/mono/sample/iOS/Program.csproj -c <Release|Debug> /p:TargetOS=<ios|iossimulator|tvossimulator|maccatalyst> /p:TargetArchitecture=arm64 /p:DeployAndRun=true /p:UseMonoRuntime=false /p:RunAOTCompilation=false
+./dotnet.sh publish src/mono/sample/iOS/Program.csproj -c <Release|Debug> /p:TargetOS=<ios|iossimulator|tvossimulator|maccatalyst> /p:TargetArchitecture=arm64 /p:DeployAndRun=true /p:UseMonoRuntime=false
 ```
 
 The command also produces an Xcode project that can be opened for debugging:

--- a/docs/workflow/building/coreclr/ios.md
+++ b/docs/workflow/building/coreclr/ios.md
@@ -77,7 +77,7 @@ A prerequisite for building and running samples locally is to have CoreCLR succe
 To build `HelloiOS`, run the following command from `<repo-root>`:
 
 ```bash
-./dotnet.sh build src/mono/sample/iOS/Program.csproj -c <Release|Debug> /p:TargetOS=<ios|iossimulator|tvossimulator|maccatalyst> /p:TargetArchitecture=arm64 /p:UseMonoRuntime=false
+./dotnet.sh build src/mono/sample/iOS/Program.csproj -c <Release|Debug> /p:TargetOS=<ios|iossimulator|tvossimulator|maccatalyst> /p:TargetArchitecture=arm64 /p:UseMonoRuntime=false /p:RunAOTCompilation=false
 ```
 
 On successful execution, the command will output the iOS app bundle.
@@ -87,7 +87,7 @@ On successful execution, the command will output the iOS app bundle.
 To run the sample, run the following command from `<repo-root>`:
 
 ```bash
-./dotnet.sh publish src/mono/sample/iOS/Program.csproj -c <Release|Debug> /p:TargetOS=<ios|iossimulator|tvossimulator|maccatalyst> /p:TargetArchitecture=arm64 /p:DeployAndRun=true /p:UseMonoRuntime=false
+./dotnet.sh publish src/mono/sample/iOS/Program.csproj -c <Release|Debug> /p:TargetOS=<ios|iossimulator|tvossimulator|maccatalyst> /p:TargetArchitecture=arm64 /p:DeployAndRun=true /p:UseMonoRuntime=false /p:RunAOTCompilation=false
 ```
 
 The command also produces an Xcode project that can be opened for debugging:

--- a/src/mono/sample/iOS/Program.csproj
+++ b/src/mono/sample/iOS/Program.csproj
@@ -10,7 +10,7 @@
     <MainLibraryFileName>$(AssemblyName).dll</MainLibraryFileName>
     <SelfContained>true</SelfContained>
 
-    <RunAOTCompilation Condition="'$(RunAOTCompilation)' == ''">true</RunAOTCompilation>
+    <RunAOTCompilation Condition="'$(RunAOTCompilation)' == '' and '$(UseMonoRuntime)' == 'true'">true</RunAOTCompilation>
     <PublishTrimmed>true</PublishTrimmed>
     <TrimMode>Link</TrimMode>
     <Optimized Condition="'$(Configuration)' == 'Release'">true</Optimized>


### PR DESCRIPTION
## Description

When we have `/p:RunAOTCompilation=true` and `/p:UseMonoRuntime=false`, `dotnet publish` fails with an `ILStrip` error because it routes the CoreCLR build through Mono's AOT-related targets that produce an empty assemblies list for ILStrip.

Because of that, we fix the HelloiOS sample to default to `/p:RunAOTCompilation=true` only on Mono.