### PR TITLE
Fix S.N.Tensors SLNX to remove project file that no longer exists

### DIFF
--- a/src/libraries/System.Numerics.Tensors/System.Numerics.Tensors.slnx
+++ b/src/libraries/System.Numerics.Tensors/System.Numerics.Tensors.slnx
@@ -12,7 +12,6 @@
   </Folder>
   <Folder Name="/tests/">
     <Project Path="../Common/tests/TestUtilities/TestUtilities.csproj" />
-    <Project Path="tests/Net8Tests/System.Numerics.Tensors.Net8.Tests.csproj" />
     <Project Path="tests/System.Numerics.Tensors.Tests.csproj" />
   </Folder>
   <Folder Name="/tools/" />


### PR DESCRIPTION
The `System.Numerics.Tensors.Net8.Tests.csproj` file was deleted in https://github.com/dotnet/runtime/pull/121853/changes#diff-4478015a451ed358edc911dc9f41e04725c1413bafec61fd9c3a2767fab11e16 however it was not removed from the SLNX.