### PR TITLE
Remove redundant range checks in Uri scheme parsing

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -3552,11 +3552,7 @@ namespace System
             int colonOffset = uriString.AsSpan(i).IndexOf(':');
 
             // NB: A string must have at least 3 characters and at least 1 before ':'
-            if ((uint)(i + 2) >= (uint)uriString.Length ||
-                colonOffset == 0 ||
-                // Redundant checks to eliminate range checks below
-                (uint)i >= (uint)uriString.Length ||
-                (uint)(i + 1) >= (uint)uriString.Length)
+            if ((uint)(i + 2) >= (uint)uriString.Length || colonOffset == 0)
             {
                 err = ParsingError.BadFormat;
                 return 0;


### PR DESCRIPTION
Now that #121262 is fixed, these are no longer needed (and are in fact just overhead)