### PR TITLE
JIT: some GT_INDEX_ADDRs won't need throw helpers

### DIFF
--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -313,7 +313,7 @@ GTNODE(JTRUE            , GenTreeOp          ,0,1,GTK_UNOP|GTK_NOVALUE)
 //  Other nodes that have special structure:
 //-----------------------------------------------------------------------------
 
-GTNODE(ARR_ELEM         , GenTreeArrElem     ,0,0,GTK_SPECIAL)            // Multi-dimensional array-element address
+GTNODE(ARR_ELEM         , GenTreeArrElem     ,0,0,GTK_SPECIAL|DBK_NOTHIR)  // Multi-dimensional array-element address
 GTNODE(CALL             , GenTreeCall        ,0,0,GTK_SPECIAL|DBK_NOCONTAIN)
 GTNODE(FIELD_LIST       , GenTreeFieldList   ,0,0,GTK_SPECIAL)            // List of fields of a struct, when passed as an argument
 

--- a/src/coreclr/jit/gtlist.h
+++ b/src/coreclr/jit/gtlist.h
@@ -313,7 +313,7 @@ GTNODE(JTRUE            , GenTreeOp          ,0,1,GTK_UNOP|GTK_NOVALUE)
 //  Other nodes that have special structure:
 //-----------------------------------------------------------------------------
 
-GTNODE(ARR_ELEM         , GenTreeArrElem     ,0,0,GTK_SPECIAL|DBK_NOTHIR)  // Multi-dimensional array-element address
+GTNODE(ARR_ELEM         , GenTreeArrElem     ,0,0,GTK_SPECIAL|DBK_NOTLIR)  // Multi-dimensional array-element address
 GTNODE(CALL             , GenTreeCall        ,0,0,GTK_SPECIAL|DBK_NOCONTAIN)
 GTNODE(FIELD_LIST       , GenTreeFieldList   ,0,0,GTK_SPECIAL)            // List of fields of a struct, when passed as an argument
 

--- a/src/coreclr/jit/lsraarm.cpp
+++ b/src/coreclr/jit/lsraarm.cpp
@@ -494,13 +494,6 @@ int LinearScan::BuildNode(GenTree* tree)
             BuildUse(tree->AsBoundsChk()->GetArrayLength());
             break;
 
-        case GT_ARR_ELEM:
-            // These must have been lowered
-            noway_assert(!"We should never see a GT_ARR_ELEM in lowering");
-            srcCount = 0;
-            assert(dstCount == 0);
-            break;
-
         case GT_LEA:
         {
             GenTreeAddrMode* lea    = tree->AsAddrMode();

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1175,13 +1175,6 @@ int LinearScan::BuildNode(GenTree* tree)
         }
         break;
 
-        case GT_ARR_ELEM:
-            // These must have been lowered
-            noway_assert(!"We should never see a GT_ARR_ELEM in lowering");
-            srcCount = 0;
-            assert(dstCount == 0);
-            break;
-
         case GT_LEA:
         {
             GenTreeAddrMode* lea = tree->AsAddrMode();

--- a/src/coreclr/jit/lsraloongarch64.cpp
+++ b/src/coreclr/jit/lsraloongarch64.cpp
@@ -481,13 +481,6 @@ int LinearScan::BuildNode(GenTree* tree)
         }
         break;
 
-        case GT_ARR_ELEM:
-            // These must have been lowered
-            noway_assert(!"We should never see a GT_ARR_ELEM in lowering");
-            srcCount = 0;
-            assert(dstCount == 0);
-            break;
-
         case GT_LEA:
         {
             GenTreeAddrMode* lea = tree->AsAddrMode();

--- a/src/coreclr/jit/lsrariscv64.cpp
+++ b/src/coreclr/jit/lsrariscv64.cpp
@@ -663,13 +663,6 @@ int LinearScan::BuildNode(GenTree* tree)
         }
         break;
 
-        case GT_ARR_ELEM:
-            // These must have been lowered
-            noway_assert(!"We should never see a GT_ARR_ELEM in lowering");
-            srcCount = 0;
-            assert(dstCount == 0);
-            break;
-
         case GT_LEA:
         {
             GenTreeAddrMode* lea = tree->AsAddrMode();

--- a/src/coreclr/jit/lsraxarch.cpp
+++ b/src/coreclr/jit/lsraxarch.cpp
@@ -561,12 +561,6 @@ int LinearScan::BuildNode(GenTree* tree)
             srcCount += BuildOperandUses(tree->AsBoundsChk()->GetArrayLength());
             break;
 
-        case GT_ARR_ELEM:
-            // These must have been lowered
-            noway_assert(!"We should never see a GT_ARR_ELEM after Lowering.");
-            srcCount = 0;
-            break;
-
         case GT_LEA:
             // The LEA usually passes its operands through to the GT_IND, in which case it will
             // be contained, but we may be instantiating an address, in which case we set them here.

--- a/src/coreclr/jit/stacklevelsetter.cpp
+++ b/src/coreclr/jit/stacklevelsetter.cpp
@@ -239,11 +239,6 @@ void StackLevelSetter::SetThrowHelperBlocks(GenTree* node, BasicBlock* block)
         break;
 #endif // defined(FEATURE_HW_INTRINSICS) && defined(TARGET_XARCH)
 
-        case GT_ARR_ELEM:
-            // Should not exist after morph.
-            assert(!"GT_ARR_ELEM should not exist after morph");
-            break;
-
         case GT_INDEX_ADDR:
             if (node->AsIndexAddr()->IsBoundsChecked())
             {

--- a/src/coreclr/jit/stacklevelsetter.cpp
+++ b/src/coreclr/jit/stacklevelsetter.cpp
@@ -239,9 +239,16 @@ void StackLevelSetter::SetThrowHelperBlocks(GenTree* node, BasicBlock* block)
         break;
 #endif // defined(FEATURE_HW_INTRINSICS) && defined(TARGET_XARCH)
 
-        case GT_INDEX_ADDR:
         case GT_ARR_ELEM:
-            SetThrowHelperBlock(SCK_RNGCHK_FAIL, block);
+            // Should not exist after morph.
+            assert(!"GT_ARR_ELEM should not exist after morph");
+            break;
+
+        case GT_INDEX_ADDR:
+            if (node->AsIndexAddr()->IsBoundsChecked())
+            {
+                SetThrowHelperBlock(SCK_RNGCHK_FAIL, block);
+            }
             break;
 
         case GT_CKFINITE:


### PR DESCRIPTION
Saves a bit of code size for unoptimized methods.

Also we should not see GT_ARR_ELEM post-morph.