### PR TITLE
Fix browser-wasm test restore NU1102 failures

### DIFF
--- a/src/tests/build.proj
+++ b/src/tests/build.proj
@@ -209,9 +209,9 @@
   <Target Name="RestorePackage">
     <PropertyGroup>
       <_ConfigurationProperties>/p:TargetOS=$(TargetOS) /p:TargetArchitecture=$(TargetArchitecture) /p:Configuration=$(Configuration) /p:CrossBuild=$(CrossBuild)</_ConfigurationProperties>
-      <_ConfigurationProperties Condition="'$(UseLocalAppHostPack)' == 'true'">$(_ConfigurationProperties) -p:EnableAppHostPackDownload=false -p:EnableTargetingPackDownload=false -p:EnableRuntimePackDownload=false</_ConfigurationProperties>
+      <_ConfigurationProperties Condition="'$(UseLocalAppHostPack)' == 'true'">$(_ConfigurationProperties) -p:EnableAppHostPackDownload=false</_ConfigurationProperties>
       <_ForceRestore Condition="'$(_ForceRestore)' == 'true'">-f</_ForceRestore>
-      <DotnetRestoreCommand>"$(DotNetTool)" restore $(_ForceRestore) -r $(RuntimeIdentifier) $(RestoreProj) $(PackageVersionArg) /p:SetTFMForRestore=true /p:RuntimeIdentifier=$(RuntimeIdentifier) $(_ConfigurationProperties)</DotnetRestoreCommand>
+      <DotnetRestoreCommand>"$(DotNetTool)" restore $(_ForceRestore) -r $(RuntimeIdentifier) $(RestoreProj) $(PackageVersionArg) /p:SetTFMForRestore=true /p:RuntimeIdentifier=$(RuntimeIdentifier) -p:EnableTargetingPackDownload=false -p:EnableRuntimePackDownload=false $(_ConfigurationProperties)</DotnetRestoreCommand>
     </PropertyGroup>
     <Exec Command="$(DotnetRestoreCommand)"/>
   </Target>


### PR DESCRIPTION
## Problem

After UseMonoRuntime was removed from in-tree wasm props (PR #121789 by @maraf), browser-wasm test restores fail with NU1102 (package not found).

The `RestorePackage` target in `build.proj` runs `dotnet restore` for test dependency projects. These projects use `Microsoft.NET.Sdk` (not the WebAssembly SDK), so `UseMonoRuntime` is not set. Without it, the newer SDK tries to download `Microsoft.NETCore.App.Runtime.browser-wasm` (CoreCLR pattern) or `Microsoft.NETCore.App.Runtime.Mono.browser-wasm` from NuGet — packages that don't exist for .NET 11.

The test restore doesn't need runtime or targeting packs from NuGet — those come from the local build and are wired up during the test build step. However, `EnableRuntimePackDownload=false` and `EnableTargetingPackDownload=false` were only passed conditionally (when `UseLocalAppHostPack=true`), and browser-wasm sets `UseLocalAppHostPack=false`.

## Fix

Unconditionally pass `-p:EnableRuntimePackDownload=false -p:EnableTargetingPackDownload=false` to the test dependency restore command. This fixes both Mono and CoreCLR browser-wasm configurations since neither needs pack downloads during restore.

## Context

- Root cause PR: #121789 (Remove duplicated UseMonoRuntime=true from SDK)
- Follow-up pattern: #123181 (Added RuntimeFlavor=Mono to perf pipeline)
- Affected codeflow PR: #124232

cc @maraf @akoeplinger