### PR TITLE
JIT: clear must keep flag for blocks created in GDV expansions

### DIFF
--- a/src/coreclr/jit/indirectcalltransformer.cpp
+++ b/src/coreclr/jit/indirectcalltransformer.cpp
@@ -210,6 +210,7 @@ private:
         {
             remainderBlock = compiler->fgSplitBlockAfterStatement(currBlock, stmt);
             remainderBlock->SetFlags(BBF_INTERNAL);
+            remainderBlock->RemoveFlags(BBF_DONT_REMOVE);
 
             // We will be adding more blocks after currBlock, so remove edge to remainderBlock.
             //
@@ -237,6 +238,7 @@ private:
             {
                 block->CopyFlags(flagsSource, BBF_SPLIT_GAINED);
             }
+            block->RemoveFlags(BBF_DONT_REMOVE);
             return block;
         }
 


### PR DESCRIPTION
If a GDV is in a must keep block (say first block of a try) we were propagating this to all the new blocks added for a GDV.