### PR TITLE
Remove nullcheck effect from array len (global AP)

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5297,9 +5297,6 @@ GenTree* Compiler::optAssertionProp(ASSERT_VALARG_TP assertions, GenTree* tree, 
             return optAssertionProp_ModDiv(assertions, tree->AsOp(), stmt, block);
 
         case GT_ARR_LENGTH:
-        // TODO-CQ: Enable for MD arrays as well (produces massive size regressions currently).
-        // case GT_MDARR_LENGTH:
-        // case GT_MDARR_LOWER_BOUND:
             // Unfortunately, doing this in LocalAP produces an asymmetry in exception sets between
             // uses/defs that CSE does not manage to make good use of. As a result, some bounds checks are no longer
             // removed.

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4589,7 +4589,7 @@ GenTree* Compiler::optAssertionProp_Comma(ASSERT_VALARG_TP assertions, GenTree* 
 //
 GenTree* Compiler::optAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt)
 {
-    assert(tree->OperIsIndir());
+    assert(tree->GetIndirOrArrMetaDataAddr());
 
     bool updated = optNonNullAssertionProp_Ind(assertions, tree);
     if (tree->OperIs(GT_STOREIND))
@@ -4776,14 +4776,14 @@ GenTree* Compiler::optNonNullAssertionProp_Call(ASSERT_VALARG_TP assertions, Gen
 //
 bool Compiler::optNonNullAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir)
 {
-    assert(indir->OperIsIndir());
+    assert(indir->GetIndirOrArrMetaDataAddr());
 
     if ((indir->gtFlags & GTF_EXCEPT) == 0)
     {
         return false;
     }
 
-    if (optAssertionIsNonNull(indir->AsIndir()->Addr(), assertions))
+    if (optAssertionIsNonNull(indir->GetIndirOrArrMetaDataAddr(), assertions))
     {
         JITDUMP("Non-null assertion prop for indirection [%06d] in " FMT_BB ":\n", dspTreeID(indir), compCurBB->bbNum);
 
@@ -5295,6 +5295,19 @@ GenTree* Compiler::optAssertionProp(ASSERT_VALARG_TP assertions, GenTree* tree, 
         case GT_UMOD:
         case GT_UDIV:
             return optAssertionProp_ModDiv(assertions, tree->AsOp(), stmt, block);
+
+        case GT_MDARR_LENGTH:
+        case GT_MDARR_LOWER_BOUND:
+        case GT_ARR_LENGTH:
+            // Unfortunately, doing this in LocalAP produces an asymmetry in exception sets between
+            // uses/defs that CSE does not manage to make good use of. As a result, some bounds checks are no longer
+            // removed.
+            // TODO-CSE: Allow CSE'ing uses with defs if the defs promise a superset of exceptions
+            if (!optLocalAssertionProp)
+            {
+                return optAssertionProp_Ind(assertions, tree, stmt);
+            }
+            return nullptr;
 
         case GT_BLK:
         case GT_IND:

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4589,7 +4589,7 @@ GenTree* Compiler::optAssertionProp_Comma(ASSERT_VALARG_TP assertions, GenTree* 
 //
 GenTree* Compiler::optAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* tree, Statement* stmt)
 {
-    assert(tree->GetIndirOrArrMetaDataAddr());
+    assert(tree->OperIsIndirOrArrMetaData());
 
     bool updated = optNonNullAssertionProp_Ind(assertions, tree);
     if (tree->OperIs(GT_STOREIND))

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -5296,9 +5296,10 @@ GenTree* Compiler::optAssertionProp(ASSERT_VALARG_TP assertions, GenTree* tree, 
         case GT_UDIV:
             return optAssertionProp_ModDiv(assertions, tree->AsOp(), stmt, block);
 
-        case GT_MDARR_LENGTH:
-        case GT_MDARR_LOWER_BOUND:
         case GT_ARR_LENGTH:
+        // TODO-CQ: Enable for MD arrays as well (produces massive size regressions currently).
+        // case GT_MDARR_LENGTH:
+        // case GT_MDARR_LOWER_BOUND:
             // Unfortunately, doing this in LocalAP produces an asymmetry in exception sets between
             // uses/defs that CSE does not manage to make good use of. As a result, some bounds checks are no longer
             // removed.

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -4776,7 +4776,7 @@ GenTree* Compiler::optNonNullAssertionProp_Call(ASSERT_VALARG_TP assertions, Gen
 //
 bool Compiler::optNonNullAssertionProp_Ind(ASSERT_VALARG_TP assertions, GenTree* indir)
 {
-    assert(indir->GetIndirOrArrMetaDataAddr());
+    assert(indir->OperIsIndirOrArrMetaData());
 
     if ((indir->gtFlags & GTF_EXCEPT) == 0)
     {

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -7554,6 +7554,9 @@ bool GenTree::OperSupportsOrderingSideEffect() const
 
     switch (OperGet())
     {
+        case GT_ARR_LENGTH:
+        case GT_MDARR_LENGTH:
+        case GT_MDARR_LOWER_BOUND:
         case GT_ARR_ADDR:
         case GT_BOUNDS_CHECK:
         case GT_IND:

--- a/src/coreclr/jit/optimizebools.cpp
+++ b/src/coreclr/jit/optimizebools.cpp
@@ -1209,6 +1209,7 @@ void OptBoolsDsc::optOptimizeBoolsUpdateTrees()
     {
         m_compiler->gtSetStmtInfo(m_testInfo1.testStmt);
         m_compiler->fgSetStmtSeq(m_testInfo1.testStmt);
+        m_compiler->gtUpdateStmtSideEffects(m_testInfo1.testStmt);
     }
 
     /* Modify the target of the conditional jump and update bbRefs and bbPreds */


### PR DESCRIPTION
[Diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1290764&view=ms.vss-build-web.run-extensions-tab)

Same as https://github.com/dotnet/runtime/pull/93531, but enabled for global AP only due to CSE issue.