### PR TITLE
Cleanup EH / stackwalk interpreter frame handling

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -171,9 +171,10 @@ namespace System.Runtime.CompilerServices
     public static partial class AsyncHelpers
     {
 #if FEATURE_INTERPRETER
-        [LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AsyncHelpers_ResumeInterpreterContinuation")]
+        //[LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AsyncHelpers_ResumeInterpreterContinuation")]
+        [MethodImpl(MethodImplOptions.InternalCall)]
         [StackTraceHidden]
-        private static partial void AsyncHelpers_ResumeInterpreterContinuation(ObjectHandleOnStack cont, ref byte resultStorage);
+        private static extern void AsyncHelpers_ResumeInterpreterContinuation(ObjectHandleOnStack cont, ref byte resultStorage);
 
         [StackTraceHidden]
         internal static Continuation? ResumeInterpreterContinuation(Continuation cont, ref byte resultStorage)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -171,7 +171,6 @@ namespace System.Runtime.CompilerServices
     public static partial class AsyncHelpers
     {
 #if FEATURE_INTERPRETER
-        //[LibraryImport(RuntimeHelpers.QCall, EntryPoint = "AsyncHelpers_ResumeInterpreterContinuation")]
         [MethodImpl(MethodImplOptions.InternalCall)]
         [StackTraceHidden]
         private static extern void AsyncHelpers_ResumeInterpreterContinuation(ObjectHandleOnStack cont, ref byte resultStorage);

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -173,15 +173,7 @@ namespace System.Runtime.CompilerServices
 #if FEATURE_INTERPRETER
         [MethodImpl(MethodImplOptions.InternalCall)]
         [StackTraceHidden]
-        private static extern void AsyncHelpers_ResumeInterpreterContinuation(ObjectHandleOnStack cont, ref byte resultStorage);
-
-        [StackTraceHidden]
-        internal static Continuation? ResumeInterpreterContinuation(Continuation cont, ref byte resultStorage)
-        {
-            ObjectHandleOnStack contHandle = ObjectHandleOnStack.Create(ref cont);
-            AsyncHelpers_ResumeInterpreterContinuation(contHandle, ref resultStorage);
-            return cont;
-        }
+        internal static extern Continuation? ResumeInterpreterContinuation(Continuation cont, ref byte resultStorage);
 #endif
 
         // This is the "magic" method on which other "Await" methods are built.

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -172,7 +172,6 @@ namespace System.Runtime.CompilerServices
     {
 #if FEATURE_INTERPRETER
         [MethodImpl(MethodImplOptions.InternalCall)]
-        [StackTraceHidden]
         internal static extern Continuation? ResumeInterpreterContinuation(Continuation cont, ref byte resultStorage);
 #endif
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/ExceptionServices/AsmOffsets.cs
@@ -58,18 +58,8 @@ class AsmOffsets
 
 #if TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x8;
-#if FEATURE_INTERPRETER
-#if TARGET_AMD64 && !TARGET_UNIX
-    public const int SIZEOF__StackFrameIterator = 0x178;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x170;
-#else
-    public const int SIZEOF__StackFrameIterator = 0x170;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x168;
-#endif    
-#else
     public const int SIZEOF__StackFrameIterator = 0x150;
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x148;
-#endif
     public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x132;
 #elif TARGET_X86
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
@@ -78,13 +68,8 @@ class AsmOffsets
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x3cc;
 #else // TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
-#if FEATURE_INTERPRETER
-    public const int SIZEOF__StackFrameIterator = 0xd8;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0xd4;
-#else
     public const int SIZEOF__StackFrameIterator = 0xc8;
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0xc4;
-#endif
     public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0xba;
 #endif // TARGET_64BIT
 
@@ -134,18 +119,8 @@ class AsmOffsets
 
 #if TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x8;
-#if FEATURE_INTERPRETER
-#if TARGET_UNIX
-    public const int SIZEOF__StackFrameIterator = 0x168;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x160;
-#else // TARGET_UNIX
-    public const int SIZEOF__StackFrameIterator = 0x170;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x168;
-#endif // TARGET_UNIX
-#else
     public const int SIZEOF__StackFrameIterator = 0x148;
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x140;
-#endif
     public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0x12a;
 #elif TARGET_X86
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
@@ -154,13 +129,8 @@ class AsmOffsets
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0x3c4;
 #else // TARGET_64BIT
     public const int OFFSETOF__REGDISPLAY__m_pCurrentContext = 0x4;
-#if FEATURE_INTERPRETER
-    public const int SIZEOF__StackFrameIterator = 0xd0;
-    public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0xcc;
-#else
     public const int SIZEOF__StackFrameIterator = 0xc0;
     public const int OFFSETOF__StackFrameIterator__m_AdjustedControlPC = 0xbc;
-#endif
     public const int OFFSETOF__StackFrameIterator__m_isRuntimeWrappedExceptions = 0xb2;
 #endif // TARGET_64BIT
 

--- a/src/coreclr/pal/inc/unixasmmacrosarm.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosarm.inc
@@ -152,10 +152,35 @@ C_FUNC(\Name):
 // d2
 // d1
 // d0                          <- __PWTB_FloatArgumentRegisters
-.macro PROLOG_WITH_TRANSITION_BLOCK extraLocals = 0, saveFpArgs = 1, pushArgRegs = 0
+// Optional: Callee saved floating point registers (if PushCalleeSavedFloats=1)
+//   d15
+//   d14
+//   d13
+//   d12
+//   d11
+//   d10
+//   d9
+//   d8                        <- __PWTB_FloatCalleeSavedRegisters
+//
+// PushCalleeSavedFloats - Optional parameter. If set to 1, the macro will also save
+//                         the callee-saved floating point registers (d8-d15) to the stack.
+//                         These registers are NOT restored by the EPILOG_WITH_TRANSITION_BLOCK variants.
+//
+.macro PROLOG_WITH_TRANSITION_BLOCK extraLocals = 0, saveFpArgs = 1, pushArgRegs = 0, PushCalleeSavedFloats = 0
 
-        __PWTB_FloatArgumentRegisters = \extraLocals
+        __PWTB_FloatCalleeSavedRegisters = \extraLocals
         __PWTB_SaveFPArgs = \saveFpArgs
+        __PWTB_PushCalleeSavedFloats = \PushCalleeSavedFloats
+
+        // If PushCalleeSavedFloats is specified, reserve space for d8-d15 (8 registers * 8 bytes = 64 bytes)
+        .if (__PWTB_PushCalleeSavedFloats == 1)
+                .if ((__PWTB_FloatCalleeSavedRegisters % 8) != 0)
+                __PWTB_FloatCalleeSavedRegisters = __PWTB_FloatCalleeSavedRegisters + 4
+                .endif
+                __PWTB_FloatArgumentRegisters = __PWTB_FloatCalleeSavedRegisters + 64
+        .else
+                __PWTB_FloatArgumentRegisters = \extraLocals
+        .endif
 
         .if (__PWTB_SaveFPArgs == 1)
                 .if ((__PWTB_FloatArgumentRegisters % 8) != 0)
@@ -187,6 +212,12 @@ C_FUNC(\Name):
         .if (__PWTB_SaveFPArgs == 1)
                 add r6, sp, #(__PWTB_FloatArgumentRegisters)
                 vstm r6, {d0-d7}
+        .endif
+
+        // Save callee-saved floating point registers if requested
+        .if (__PWTB_PushCalleeSavedFloats == 1)
+                add r6, sp, #(__PWTB_FloatCalleeSavedRegisters)
+                vstm r6, {d8-d15}
         .endif
 
         CHECK_STACK_ALIGNMENT

--- a/src/coreclr/pal/inc/unixasmmacrosarm.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosarm.inc
@@ -152,7 +152,7 @@ C_FUNC(\Name):
 // d2
 // d1
 // d0                          <- __PWTB_FloatArgumentRegisters
-// Optional: Callee saved floating point registers (if PushCalleeSavedFloats=1)
+// Optional: Callee saved floating point registers (if pushCalleeSavedFloatRegs=1)
 //   d15
 //   d14
 //   d13
@@ -162,18 +162,18 @@ C_FUNC(\Name):
 //   d9
 //   d8                        <- __PWTB_FloatCalleeSavedRegisters
 //
-// PushCalleeSavedFloats - Optional parameter. If set to 1, the macro will also save
-//                         the callee-saved floating point registers (d8-d15) to the stack.
-//                         These registers are NOT restored by the EPILOG_WITH_TRANSITION_BLOCK variants.
+// pushCalleeSavedFloatRegs - Optional parameter. If set to 1, the macro will also save
+//                            the callee-saved floating point registers (d8-d15) to the stack.
+//                            These registers are NOT restored by the EPILOG_WITH_TRANSITION_BLOCK variants.
 //
-.macro PROLOG_WITH_TRANSITION_BLOCK extraLocals = 0, saveFpArgs = 1, pushArgRegs = 0, PushCalleeSavedFloats = 0
+.macro PROLOG_WITH_TRANSITION_BLOCK extraLocals = 0, saveFpArgs = 1, pushArgRegs = 0, pushCalleeSavedFloatRegs = 0
 
         __PWTB_FloatCalleeSavedRegisters = \extraLocals
         __PWTB_SaveFPArgs = \saveFpArgs
-        __PWTB_PushCalleeSavedFloats = \PushCalleeSavedFloats
+        __PWTB_PushCalleeSavedFloatRegs = \pushCalleeSavedFloatRegs
 
-        // If PushCalleeSavedFloats is specified, reserve space for d8-d15 (8 registers * 8 bytes = 64 bytes)
-        .if (__PWTB_PushCalleeSavedFloats == 1)
+        // If pushCalleeSavedFloatRegs is specified, reserve space for d8-d15 (8 registers * 8 bytes = 64 bytes)
+        .if (__PWTB_PushCalleeSavedFloatRegs == 1)
                 .if ((__PWTB_FloatCalleeSavedRegisters % 8) != 0)
                 __PWTB_FloatCalleeSavedRegisters = __PWTB_FloatCalleeSavedRegisters + 4
                 .endif
@@ -215,7 +215,7 @@ C_FUNC(\Name):
         .endif
 
         // Save callee-saved floating point registers if requested
-        .if (__PWTB_PushCalleeSavedFloats == 1)
+        .if (__PWTB_PushCalleeSavedFloatRegs == 1)
                 add r6, sp, #(__PWTB_FloatCalleeSavedRegisters)
                 vstm r6, {d8-d15}
         .endif

--- a/src/coreclr/pal/inc/unixasmmacrosarm64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosarm64.inc
@@ -198,7 +198,7 @@ C_FUNC(\Name\()_End):
 // FloatRegisters::q2
 // FloatRegisters::q1
 // FloatRegisters::q0
-// Optional: Callee saved floating point registers (if PushCalleeSavedFloats=1)
+// Optional: Callee saved floating point registers (if pushCalleeSavedFloatRegs=1)
 //   d15
 //   d14
 //   d13
@@ -208,22 +208,22 @@ C_FUNC(\Name\()_End):
 //   d9
 //   d8
 //
-// PushCalleeSavedFloats - Optional parameter. If set to 1, the macro will also save
-//                         the callee-saved floating point registers (d8-d15) to the stack.
-//                         These registers are NOT restored by the EPILOG_WITH_TRANSITION_BLOCK variants.
+// pushCalleeSavedFloatRegs - Optional parameter. If set to 1, the macro will also save
+//                            the callee-saved floating point registers (d8-d15) to the stack.
+//                            These registers are NOT restored by the EPILOG_WITH_TRANSITION_BLOCK variants.
 //
-.macro PROLOG_WITH_TRANSITION_BLOCK extraLocals = 0, SaveFPArgs = 1, SaveGPArgs = 1, PushCalleeSavedFloats = 0
+.macro PROLOG_WITH_TRANSITION_BLOCK extraLocals = 0, SaveFPArgs = 1, SaveGPArgs = 1, pushCalleeSavedFloatRegs = 0
 
         __PWTB_FloatCalleeSavedRegisters = \extraLocals
         __PWTB_SaveFPArgs = \SaveFPArgs
-        __PWTB_PushCalleeSavedFloats = \PushCalleeSavedFloats
+        __PWTB_PushCalleeSavedFloatRegs = \pushCalleeSavedFloatRegs
 
         .if ((__PWTB_FloatCalleeSavedRegisters % 16) != 0)
                 __PWTB_FloatCalleeSavedRegisters = __PWTB_FloatCalleeSavedRegisters + 8
         .endif
 
-        // If PushCalleeSavedFloats is specified, reserve space for d8-d15 (8 registers * 8 bytes = 64 bytes)
-        .if (__PWTB_PushCalleeSavedFloats == 1)
+        // If pushCalleeSavedFloatRegs is specified, reserve space for d8-d15 (8 registers * 8 bytes = 64 bytes)
+        .if (__PWTB_PushCalleeSavedFloatRegs == 1)
                 __PWTB_FloatArgumentRegisters = __PWTB_FloatCalleeSavedRegisters + 64
         .else
                 __PWTB_FloatArgumentRegisters = __PWTB_FloatCalleeSavedRegisters
@@ -260,11 +260,11 @@ C_FUNC(\Name\()_End):
         .endif
 
         // Save callee-saved floating point registers if requested
-        .if (__PWTB_PushCalleeSavedFloats == 1)
-                stp     d8, d9, [sp, #__PWTB_FloatCalleeSavedRegisters]
-                stp     d10, d11, [sp, #(__PWTB_FloatCalleeSavedRegisters + 16)]
-                stp     d12, d13, [sp, #(__PWTB_FloatCalleeSavedRegisters + 32)]
-                stp     d14, d15, [sp, #(__PWTB_FloatCalleeSavedRegisters + 48)]
+        .if (__PWTB_PushCalleeSavedFloatRegs == 1)
+                PROLOG_SAVE_REG_PAIR d8, d9, __PWTB_FloatCalleeSavedRegisters
+                PROLOG_SAVE_REG_PAIR d10, d11, __PWTB_FloatCalleeSavedRegisters + 16
+                PROLOG_SAVE_REG_PAIR d12, d13, __PWTB_FloatCalleeSavedRegisters + 32
+                PROLOG_SAVE_REG_PAIR d14, d15, __PWTB_FloatCalleeSavedRegisters + 48
         .endif
 
 .endm

--- a/src/coreclr/pal/inc/unixasmmacrosarm64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosarm64.inc
@@ -198,13 +198,35 @@ C_FUNC(\Name\()_End):
 // FloatRegisters::q2
 // FloatRegisters::q1
 // FloatRegisters::q0
-.macro PROLOG_WITH_TRANSITION_BLOCK extraLocals = 0, SaveFPArgs = 1, SaveGPArgs = 1
+// Optional: Callee saved floating point registers (if PushCalleeSavedFloats=1)
+//   d15
+//   d14
+//   d13
+//   d12
+//   d11
+//   d10
+//   d9
+//   d8
+//
+// PushCalleeSavedFloats - Optional parameter. If set to 1, the macro will also save
+//                         the callee-saved floating point registers (d8-d15) to the stack.
+//                         These registers are NOT restored by the EPILOG_WITH_TRANSITION_BLOCK variants.
+//
+.macro PROLOG_WITH_TRANSITION_BLOCK extraLocals = 0, SaveFPArgs = 1, SaveGPArgs = 1, PushCalleeSavedFloats = 0
 
-        __PWTB_FloatArgumentRegisters = \extraLocals
+        __PWTB_FloatCalleeSavedRegisters = \extraLocals
         __PWTB_SaveFPArgs = \SaveFPArgs
+        __PWTB_PushCalleeSavedFloats = \PushCalleeSavedFloats
 
-        .if ((__PWTB_FloatArgumentRegisters % 16) != 0)
-                __PWTB_FloatArgumentRegisters = __PWTB_FloatArgumentRegisters + 8
+        .if ((__PWTB_FloatCalleeSavedRegisters % 16) != 0)
+                __PWTB_FloatCalleeSavedRegisters = __PWTB_FloatCalleeSavedRegisters + 8
+        .endif
+
+        // If PushCalleeSavedFloats is specified, reserve space for d8-d15 (8 registers * 8 bytes = 64 bytes)
+        .if (__PWTB_PushCalleeSavedFloats == 1)
+                __PWTB_FloatArgumentRegisters = __PWTB_FloatCalleeSavedRegisters + 64
+        .else
+                __PWTB_FloatArgumentRegisters = __PWTB_FloatCalleeSavedRegisters
         .endif
 
         __PWTB_TransitionBlock = __PWTB_FloatArgumentRegisters
@@ -234,7 +256,15 @@ C_FUNC(\Name\()_End):
         .endif
 
         .if (__PWTB_SaveFPArgs == 1)
-                SAVE_FLOAT_ARGUMENT_REGISTERS sp, \extraLocals
+                SAVE_FLOAT_ARGUMENT_REGISTERS sp, __PWTB_FloatArgumentRegisters
+        .endif
+
+        // Save callee-saved floating point registers if requested
+        .if (__PWTB_PushCalleeSavedFloats == 1)
+                stp     d8, d9, [sp, #__PWTB_FloatCalleeSavedRegisters]
+                stp     d10, d11, [sp, #(__PWTB_FloatCalleeSavedRegisters + 16)]
+                stp     d12, d13, [sp, #(__PWTB_FloatCalleeSavedRegisters + 32)]
+                stp     d14, d15, [sp, #(__PWTB_FloatCalleeSavedRegisters + 48)]
         .endif
 
 .endm

--- a/src/coreclr/pal/inc/unixasmmacrosriscv64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosriscv64.inc
@@ -260,14 +260,26 @@ C_FUNC(\Name):
 //            FPR_f8 / fs0
 // Extra:
 //
-.macro PROLOG_WITH_TRANSITION_BLOCK extraParameters = 0, extraLocals = 0, SaveFPRegs = 1
+// PushCalleeSavedFloats - Optional parameter. If set to 1, the macro will also save
+//                         the callee-saved floating point registers (fs0-fs11) to the stack.
+//                         These registers are NOT restored by the EPILOG_WITH_TRANSITION_BLOCK variants.
+//
+.macro PROLOG_WITH_TRANSITION_BLOCK extraParameters = 0, extraLocals = 0, SaveFPRegs = 1, PushCalleeSavedFloats = 0
     __PWTB_SaveFPArgs = \SaveFPRegs
+    __PWTB_PushCalleeSavedFloats = \PushCalleeSavedFloats
 
-    __PWTB_FloatArgumentRegisters = \extraLocals
+    __PWTB_FloatCalleeSavedRegisters = \extraLocals
 
     // Note, stack (see __PWTB_StackAlloc variable) must be 16 byte aligned.
-    .if ((__PWTB_FloatArgumentRegisters % 16) != 0)
-        __PWTB_FloatArgumentRegisters = __PWTB_FloatArgumentRegisters + 8
+    .if ((__PWTB_FloatCalleeSavedRegisters % 16) != 0)
+        __PWTB_FloatCalleeSavedRegisters = __PWTB_FloatCalleeSavedRegisters + 8
+    .endif
+
+    // If PushCalleeSavedFloats is specified, reserve space for fs0-fs11 (12 registers * 8 bytes = 96 bytes)
+    .if (__PWTB_PushCalleeSavedFloats == 1)
+        __PWTB_FloatArgumentRegisters = __PWTB_FloatCalleeSavedRegisters + 96
+    .else
+        __PWTB_FloatArgumentRegisters = __PWTB_FloatCalleeSavedRegisters
     .endif
 
     __PWTB_TransitionBlock = __PWTB_FloatArgumentRegisters
@@ -294,6 +306,22 @@ C_FUNC(\Name):
     // saving is f10-17.
     .if (__PWTB_SaveFPArgs == 1)
         SAVE_FLOAT_ARGUMENT_REGISTERS sp, __PWTB_FloatArgumentRegisters
+    .endif
+
+    // Save callee-saved floating point registers if requested (fs0-fs11)
+    .if (__PWTB_PushCalleeSavedFloats == 1)
+        fsd     fs0, (__PWTB_FloatCalleeSavedRegisters)(sp)
+        fsd     fs1, (__PWTB_FloatCalleeSavedRegisters + 8)(sp)
+        fsd     fs2, (__PWTB_FloatCalleeSavedRegisters + 16)(sp)
+        fsd     fs3, (__PWTB_FloatCalleeSavedRegisters + 24)(sp)
+        fsd     fs4, (__PWTB_FloatCalleeSavedRegisters + 32)(sp)
+        fsd     fs5, (__PWTB_FloatCalleeSavedRegisters + 40)(sp)
+        fsd     fs6, (__PWTB_FloatCalleeSavedRegisters + 48)(sp)
+        fsd     fs7, (__PWTB_FloatCalleeSavedRegisters + 56)(sp)
+        fsd     fs8, (__PWTB_FloatCalleeSavedRegisters + 64)(sp)
+        fsd     fs9, (__PWTB_FloatCalleeSavedRegisters + 72)(sp)
+        fsd     fs10, (__PWTB_FloatCalleeSavedRegisters + 80)(sp)
+        fsd     fs11, (__PWTB_FloatCalleeSavedRegisters + 88)(sp)
     .endif
 
 .endm

--- a/src/coreclr/pal/inc/unixasmmacrosriscv64.inc
+++ b/src/coreclr/pal/inc/unixasmmacrosriscv64.inc
@@ -260,13 +260,13 @@ C_FUNC(\Name):
 //            FPR_f8 / fs0
 // Extra:
 //
-// PushCalleeSavedFloats - Optional parameter. If set to 1, the macro will also save
-//                         the callee-saved floating point registers (fs0-fs11) to the stack.
-//                         These registers are NOT restored by the EPILOG_WITH_TRANSITION_BLOCK variants.
+// pushCalleeSavedFloatRegs - Optional parameter. If set to 1, the macro will also save
+//                            the callee-saved floating point registers (fs0-fs11) to the stack.
+//                            These registers are NOT restored by the EPILOG_WITH_TRANSITION_BLOCK variants.
 //
-.macro PROLOG_WITH_TRANSITION_BLOCK extraParameters = 0, extraLocals = 0, SaveFPRegs = 1, PushCalleeSavedFloats = 0
+.macro PROLOG_WITH_TRANSITION_BLOCK extraParameters = 0, extraLocals = 0, SaveFPRegs = 1, pushCalleeSavedFloatRegs = 0
     __PWTB_SaveFPArgs = \SaveFPRegs
-    __PWTB_PushCalleeSavedFloats = \PushCalleeSavedFloats
+    __PWTB_PushCalleeSavedFloatRegs = \pushCalleeSavedFloatRegs
 
     __PWTB_FloatCalleeSavedRegisters = \extraLocals
 
@@ -275,8 +275,8 @@ C_FUNC(\Name):
         __PWTB_FloatCalleeSavedRegisters = __PWTB_FloatCalleeSavedRegisters + 8
     .endif
 
-    // If PushCalleeSavedFloats is specified, reserve space for fs0-fs11 (12 registers * 8 bytes = 96 bytes)
-    .if (__PWTB_PushCalleeSavedFloats == 1)
+    // If pushCalleeSavedFloatRegs is specified, reserve space for fs0-fs11 (12 registers * 8 bytes = 96 bytes)
+    .if (__PWTB_PushCalleeSavedFloatRegs == 1)
         __PWTB_FloatArgumentRegisters = __PWTB_FloatCalleeSavedRegisters + 96
     .else
         __PWTB_FloatArgumentRegisters = __PWTB_FloatCalleeSavedRegisters
@@ -309,7 +309,7 @@ C_FUNC(\Name):
     .endif
 
     // Save callee-saved floating point registers if requested (fs0-fs11)
-    .if (__PWTB_PushCalleeSavedFloats == 1)
+    .if (__PWTB_PushCalleeSavedFloatRegs == 1)
         fsd     fs0, (__PWTB_FloatCalleeSavedRegisters)(sp)
         fsd     fs1, (__PWTB_FloatCalleeSavedRegisters + 8)(sp)
         fsd     fs2, (__PWTB_FloatCalleeSavedRegisters + 16)(sp)

--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -1308,7 +1308,7 @@ NESTED_ENTRY CallInterpreterFunclet, _TEXT
         ; Pass TransitionBlock* as last (6th) argument on stack
         ; Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
         ; Original args: rcx=throwable, rdx=pHandler, r8=pRD, r9=pExInfo, [rsp+__PWTB_ArgumentRegisters+20h]=isFilter
-        
+
         ; Move isFilter to 5th param slot
         mov     rax, [rsp + __PWTB_ArgumentRegisters + 20h] ; isFilter (5th param from original caller)
         mov     [rsp + 20h], rax                            ; pass isFilter as 5th param on stack

--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -1347,6 +1347,28 @@ NESTED_ENTRY CallInterpreterFunclet, _TEXT
 
 NESTED_END CallInterpreterFunclet, _TEXT
 
+extern AsyncHelpers_ResumeInterpreterContinuationWorker:proc
+
+NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation, _TEXT
+        PROLOG_WITH_TRANSITION_BLOCK 0a0h
+        movdqa  [rsp + 20h], xmm6
+        movdqa  [rsp + 30h], xmm7
+        movdqa  [rsp + 40h], xmm8
+        movdqa  [rsp + 50h], xmm9
+        movdqa  [rsp + 60h], xmm10
+        movdqa  [rsp + 70h], xmm11
+        movdqa  [rsp + 80h], xmm12
+        movdqa  [rsp + 90h], xmm13
+        movdqa  [rsp + 0a0h], xmm14
+        movdqa  [rsp + 0b0h], xmm15
+
+        lea r8, [rsp + __PWTB_TransitionBlock]
+        call AsyncHelpers_ResumeInterpreterContinuationWorker
+
+        EPILOG_WITH_TRANSITION_BLOCK_RETURN
+
+NESTED_END AsyncHelpers_ResumeInterpreterContinuation, _TEXT
+
 endif ; FEATURE_INTERPRETER
 
 ;==========================================================================

--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -17,6 +17,7 @@ extern IL_Rethrow_Impl:proc
 ifdef FEATURE_INTERPRETER
 extern ExecuteInterpretedMethod:proc
 extern GetInterpThreadContextWithPossiblyMissingThreadOrCallStub:proc
+extern CallInterpreterFuncletWorker:proc
 endif
 
 extern g_pPollGC:QWORD
@@ -1285,6 +1286,44 @@ END_PROLOGUE
         pop rbp
         ret
 NESTED_END CallJittedMethodRetU2, _TEXT
+
+;==========================================================================
+; Create a real TransitionBlock and call CallInterpreterFuncletWorker
+; to execute an interpreter funclet (catch/finally/filter handler).
+;
+; extern "C" DWORD_PTR CallInterpreterFunclet(
+;     OBJECTREF throwable,        // rcx
+;     void* pHandler,             // rdx
+;     REGDISPLAY *pRD,            // r8
+;     ExInfo *pExInfo,            // r9
+;     bool isFilter               // [rsp+28h]
+; );
+;==========================================================================
+extern CallInterpreterFuncletWorker:proc
+
+NESTED_ENTRY CallInterpreterFunclet, _TEXT
+
+        PROLOG_WITH_TRANSITION_BLOCK
+
+        ; Pass TransitionBlock* as last (6th) argument on stack
+        ; Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
+        ; Original args: rcx=throwable, rdx=pHandler, r8=pRD, r9=pExInfo, [rsp+__PWTB_ArgumentRegisters+28h]=isFilter
+        
+        ; Move isFilter to 5th param slot
+        mov     rax, [rsp + __PWTB_ArgumentRegisters + 20h] ; isFilter (5th param from original caller)
+        mov     [rsp + 20h], rax                            ; pass isFilter as 5th param on stack
+
+        ; Put TransitionBlock* as 6th param on stack
+        lea     rax, [rsp + __PWTB_TransitionBlock]
+        mov     [rsp + 28h], rax                            ; TransitionBlock* as 6th param
+
+        ; rcx, rdx, r8, r9 remain unchanged (throwable, pHandler, pRD, pExInfo)
+
+        call    CallInterpreterFuncletWorker
+
+        EPILOG_WITH_TRANSITION_BLOCK_RETURN
+
+NESTED_END CallInterpreterFunclet, _TEXT
 
 endif ; FEATURE_INTERPRETER
 

--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -1314,18 +1314,7 @@ extern CallInterpreterFuncletWorker:proc
 
 NESTED_ENTRY CallInterpreterFunclet, _TEXT
 
-;        PROLOG_WITH_TRANSITION_BLOCK 010h
-        PROLOG_WITH_TRANSITION_BLOCK 0b0h
-        movdqa  [rsp + 30h], xmm6
-        movdqa  [rsp + 40h], xmm7
-        movdqa  [rsp + 50h], xmm8
-        movdqa  [rsp + 60h], xmm9
-        movdqa  [rsp + 70h], xmm10
-        movdqa  [rsp + 80h], xmm11
-        movdqa  [rsp + 90h], xmm12
-        movdqa  [rsp + 0a0h], xmm13
-        movdqa  [rsp + 0b0h], xmm14
-        movdqa  [rsp + 0c0h], xmm15
+        PROLOG_WITH_TRANSITION_BLOCK 16, <PushCalleeSavedFloats>
 
         ; Pass TransitionBlock* as last (6th) argument on stack
         ; Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
@@ -1350,17 +1339,7 @@ NESTED_END CallInterpreterFunclet, _TEXT
 extern AsyncHelpers_ResumeInterpreterContinuationWorker:proc
 
 NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation, _TEXT
-        PROLOG_WITH_TRANSITION_BLOCK 0a0h
-        movdqa  [rsp + 20h], xmm6
-        movdqa  [rsp + 30h], xmm7
-        movdqa  [rsp + 40h], xmm8
-        movdqa  [rsp + 50h], xmm9
-        movdqa  [rsp + 60h], xmm10
-        movdqa  [rsp + 70h], xmm11
-        movdqa  [rsp + 80h], xmm12
-        movdqa  [rsp + 90h], xmm13
-        movdqa  [rsp + 0a0h], xmm14
-        movdqa  [rsp + 0b0h], xmm15
+        PROLOG_WITH_TRANSITION_BLOCK 0, <PushCalleeSavedFloats>
 
         lea r8, [rsp + __PWTB_TransitionBlock]
         call AsyncHelpers_ResumeInterpreterContinuationWorker

--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -560,18 +560,7 @@ ifdef FEATURE_INTERPRETER
 
 NESTED_ENTRY InterpreterStub, _TEXT
 
-;        PROLOG_WITH_TRANSITION_BLOCK
-        PROLOG_WITH_TRANSITION_BLOCK 0a0h
-        movdqa  [rsp + 20h], xmm6
-        movdqa  [rsp + 30h], xmm7
-        movdqa  [rsp + 40h], xmm8
-        movdqa  [rsp + 50h], xmm9
-        movdqa  [rsp + 60h], xmm10
-        movdqa  [rsp + 70h], xmm11
-        movdqa  [rsp + 80h], xmm12
-        movdqa  [rsp + 90h], xmm13
-        movdqa  [rsp + 0a0h], xmm14
-        movdqa  [rsp + 0b0h], xmm15
+        PROLOG_WITH_TRANSITION_BLOCK 0, <PushCalleeSavedFloatRegs>
 
         __InterpreterStubArgumentRegistersOffset = __PWTB_ArgumentRegisters
         ; IR bytecode address
@@ -1314,7 +1303,7 @@ extern CallInterpreterFuncletWorker:proc
 
 NESTED_ENTRY CallInterpreterFunclet, _TEXT
 
-        PROLOG_WITH_TRANSITION_BLOCK 16, <PushCalleeSavedFloats>
+        PROLOG_WITH_TRANSITION_BLOCK 16, <PushCalleeSavedFloatRegs>
 
         ; Pass TransitionBlock* as last (6th) argument on stack
         ; Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
@@ -1339,7 +1328,7 @@ NESTED_END CallInterpreterFunclet, _TEXT
 extern AsyncHelpers_ResumeInterpreterContinuationWorker:proc
 
 NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation, _TEXT
-        PROLOG_WITH_TRANSITION_BLOCK 0, <PushCalleeSavedFloats>
+        PROLOG_WITH_TRANSITION_BLOCK 0, <PushCalleeSavedFloatRegs>
 
         lea r8, [rsp + __PWTB_TransitionBlock]
         call AsyncHelpers_ResumeInterpreterContinuationWorker

--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -560,7 +560,18 @@ ifdef FEATURE_INTERPRETER
 
 NESTED_ENTRY InterpreterStub, _TEXT
 
-        PROLOG_WITH_TRANSITION_BLOCK
+;        PROLOG_WITH_TRANSITION_BLOCK
+        PROLOG_WITH_TRANSITION_BLOCK 0a0h
+        movdqa  [rsp + 20h], xmm6
+        movdqa  [rsp + 30h], xmm7
+        movdqa  [rsp + 40h], xmm8
+        movdqa  [rsp + 50h], xmm9
+        movdqa  [rsp + 60h], xmm10
+        movdqa  [rsp + 70h], xmm11
+        movdqa  [rsp + 80h], xmm12
+        movdqa  [rsp + 90h], xmm13
+        movdqa  [rsp + 0a0h], xmm14
+        movdqa  [rsp + 0b0h], xmm15
 
         __InterpreterStubArgumentRegistersOffset = __PWTB_ArgumentRegisters
         ; IR bytecode address
@@ -1303,7 +1314,18 @@ extern CallInterpreterFuncletWorker:proc
 
 NESTED_ENTRY CallInterpreterFunclet, _TEXT
 
-        PROLOG_WITH_TRANSITION_BLOCK
+;        PROLOG_WITH_TRANSITION_BLOCK 010h
+        PROLOG_WITH_TRANSITION_BLOCK 0b0h
+        movdqa  [rsp + 30h], xmm6
+        movdqa  [rsp + 40h], xmm7
+        movdqa  [rsp + 50h], xmm8
+        movdqa  [rsp + 60h], xmm9
+        movdqa  [rsp + 70h], xmm10
+        movdqa  [rsp + 80h], xmm11
+        movdqa  [rsp + 90h], xmm12
+        movdqa  [rsp + 0a0h], xmm13
+        movdqa  [rsp + 0b0h], xmm14
+        movdqa  [rsp + 0c0h], xmm15
 
         ; Pass TransitionBlock* as last (6th) argument on stack
         ; Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)

--- a/src/coreclr/vm/amd64/AsmHelpers.asm
+++ b/src/coreclr/vm/amd64/AsmHelpers.asm
@@ -1307,7 +1307,7 @@ NESTED_ENTRY CallInterpreterFunclet, _TEXT
 
         ; Pass TransitionBlock* as last (6th) argument on stack
         ; Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
-        ; Original args: rcx=throwable, rdx=pHandler, r8=pRD, r9=pExInfo, [rsp+__PWTB_ArgumentRegisters+28h]=isFilter
+        ; Original args: rcx=throwable, rdx=pHandler, r8=pRD, r9=pExInfo, [rsp+__PWTB_ArgumentRegisters+20h]=isFilter
         
         ; Move isFilter to 5th param slot
         mov     rax, [rsp + __PWTB_ArgumentRegisters + 20h] ; isFilter (5th param from original caller)

--- a/src/coreclr/vm/amd64/AsmMacros.inc
+++ b/src/coreclr/vm/amd64/AsmMacros.inc
@@ -355,18 +355,28 @@ RESTORE_FLOAT_ARGUMENT_REGISTERS macro ofs
 ; xmm2
 ; xmm1
 ; xmm0                      <- __PWTB_FloatArgumentRegisters
+; Optional: Callee saved floating point registers
+;   xmm15
+;   .
+;   .
+;   xmm6
 ; extra locals + padding to qword align
 ; callee's r9
 ; callee's r8
 ; callee's rdx
 ; callee's rcx
 
-PROLOG_WITH_TRANSITION_BLOCK macro extraLocals := <0>, stackAllocOnEntry := <0>, stackAllocSpill1, stackAllocSpill2, stackAllocSpill3
+PROLOG_WITH_TRANSITION_BLOCK macro extraLocals := <0>, calleeSavedFloats := <DoNotPushCalleeSavedFloats>, stackAllocOnEntry := <0>, stackAllocSpill1, stackAllocSpill2, stackAllocSpill3
 
         __PWTB_FloatArgumentRegisters = SIZEOF_MAX_OUTGOING_ARGUMENT_HOMES + extraLocals
 
         if (__PWTB_FloatArgumentRegisters mod 16) ne 0
         __PWTB_FloatArgumentRegisters = __PWTB_FloatArgumentRegisters + 8
+        endif
+
+        ifidn <calleeSavedFloats>, <PushCalleeSavedFloats>
+        __PWTB_FloatCalleeSavedRegisters = __PWTB_FloatArgumentRegisters
+        __PWTB_FloatArgumentRegisters = __PWTB_FloatArgumentRegisters + 10 * 16
         endif
 
         __PWTB_StackAlloc = __PWTB_FloatArgumentRegisters + 4 * 16 + 8
@@ -402,6 +412,19 @@ PROLOG_WITH_TRANSITION_BLOCK macro extraLocals := <0>, stackAllocOnEntry := <0>,
         alloc_stack     __PWTB_StackAlloc
         SAVE_ARGUMENT_REGISTERS __PWTB_ArgumentRegisters
         SAVE_FLOAT_ARGUMENT_REGISTERS __PWTB_FloatArgumentRegisters
+
+        ifidn <calleeSavedFloats>, <PushCalleeSavedFloats>
+        movdqa  [rsp + __PWTB_FloatCalleeSavedRegisters], xmm6
+        movdqa  [rsp + __PWTB_FloatCalleeSavedRegisters + 10h], xmm7
+        movdqa  [rsp + __PWTB_FloatCalleeSavedRegisters + 20h], xmm8
+        movdqa  [rsp + __PWTB_FloatCalleeSavedRegisters + 30h], xmm9
+        movdqa  [rsp + __PWTB_FloatCalleeSavedRegisters + 40h], xmm10
+        movdqa  [rsp + __PWTB_FloatCalleeSavedRegisters + 50h], xmm11
+        movdqa  [rsp + __PWTB_FloatCalleeSavedRegisters + 60h], xmm12
+        movdqa  [rsp + __PWTB_FloatCalleeSavedRegisters + 70h], xmm13
+        movdqa  [rsp + __PWTB_FloatCalleeSavedRegisters + 80h], xmm14
+        movdqa  [rsp + __PWTB_FloatCalleeSavedRegisters + 90h], xmm15
+        endif
 
         if stackAllocOnEntry ge 3*8
         mov stackAllocSpill3, [rsp + __PWTB_StackAlloc + 28h]
@@ -490,9 +513,9 @@ POP_COOP_PINVOKE_FRAME macro
 ; need to capture the complete register state including FP callee-saved registers.
 ;
 ; Stack layout (from high to low address after prologue):
+;   Outgoing argument homes (32 bytes)
 ;   Return address (m_ReturnAddress)
 ;   CalleeSavedRegisters (r15, r14, r13, r12, rbp, rbx, rsi, rdi - 64 bytes) <- TransitionBlock starts here
-;   Outgoing argument homes (32 bytes)
 ;   FloatArgumentRegisters (xmm0-xmm3, 64 bytes)
 ;   FP Callee-saved registers (xmm6-xmm15, 160 bytes)
 ;   Shadow space for call (32 bytes)

--- a/src/coreclr/vm/amd64/AsmMacros.inc
+++ b/src/coreclr/vm/amd64/AsmMacros.inc
@@ -366,7 +366,7 @@ RESTORE_FLOAT_ARGUMENT_REGISTERS macro ofs
 ; callee's rdx
 ; callee's rcx
 
-PROLOG_WITH_TRANSITION_BLOCK macro extraLocals := <0>, calleeSavedFloats := <DoNotPushCalleeSavedFloats>, stackAllocOnEntry := <0>, stackAllocSpill1, stackAllocSpill2, stackAllocSpill3
+PROLOG_WITH_TRANSITION_BLOCK macro extraLocals := <0>, calleeSavedFloatRegs := <DoNotPushCalleeSavedFloatRegs>, stackAllocOnEntry := <0>, stackAllocSpill1, stackAllocSpill2, stackAllocSpill3
 
         __PWTB_FloatArgumentRegisters = SIZEOF_MAX_OUTGOING_ARGUMENT_HOMES + extraLocals
 
@@ -374,7 +374,7 @@ PROLOG_WITH_TRANSITION_BLOCK macro extraLocals := <0>, calleeSavedFloats := <DoN
         __PWTB_FloatArgumentRegisters = __PWTB_FloatArgumentRegisters + 8
         endif
 
-        ifidn <calleeSavedFloats>, <PushCalleeSavedFloats>
+        ifidn <calleeSavedFloatRegs>, <PushCalleeSavedFloatRegs>
         __PWTB_FloatCalleeSavedRegisters = __PWTB_FloatArgumentRegisters
         __PWTB_FloatArgumentRegisters = __PWTB_FloatArgumentRegisters + 10 * 16
         endif
@@ -413,7 +413,7 @@ PROLOG_WITH_TRANSITION_BLOCK macro extraLocals := <0>, calleeSavedFloats := <DoN
         SAVE_ARGUMENT_REGISTERS __PWTB_ArgumentRegisters
         SAVE_FLOAT_ARGUMENT_REGISTERS __PWTB_FloatArgumentRegisters
 
-        ifidn <calleeSavedFloats>, <PushCalleeSavedFloats>
+        ifidn <calleeSavedFloatRegs>, <PushCalleeSavedFloatRegs>
         movdqa  [rsp + __PWTB_FloatCalleeSavedRegisters], xmm6
         movdqa  [rsp + __PWTB_FloatCalleeSavedRegisters + 10h], xmm7
         movdqa  [rsp + __PWTB_FloatCalleeSavedRegisters + 20h], xmm8

--- a/src/coreclr/vm/amd64/ExternalMethodFixupThunk.asm
+++ b/src/coreclr/vm/amd64/ExternalMethodFixupThunk.asm
@@ -14,7 +14,7 @@ ifdef FEATURE_READYTORUN
 
 NESTED_ENTRY DelayLoad_MethodCall, _TEXT
 
-        PROLOG_WITH_TRANSITION_BLOCK 0, DoNotPushCalleeSavedFloats, 10h, r8, r9
+        PROLOG_WITH_TRANSITION_BLOCK 0, DoNotPushCalleeSavedFloatRegs, 10h, r8, r9
 
         lea     rcx, [rsp + __PWTB_TransitionBlock] ; pTransitionBlock
         mov     rdx, rax                            ; pIndirection
@@ -33,7 +33,7 @@ DYNAMICHELPER macro frameFlags, suffix
 
 NESTED_ENTRY DelayLoad_Helper&suffix, _TEXT
 
-        PROLOG_WITH_TRANSITION_BLOCK 8h, DoNotPushCalleeSavedFloats, 10h, r8, r9
+        PROLOG_WITH_TRANSITION_BLOCK 8h, DoNotPushCalleeSavedFloatRegs, 10h, r8, r9
 
         mov     qword ptr [rsp + SIZEOF_MAX_OUTGOING_ARGUMENT_HOMES], frameFlags
         lea     rcx, [rsp + __PWTB_TransitionBlock] ; pTransitionBlock

--- a/src/coreclr/vm/amd64/ExternalMethodFixupThunk.asm
+++ b/src/coreclr/vm/amd64/ExternalMethodFixupThunk.asm
@@ -14,7 +14,7 @@ ifdef FEATURE_READYTORUN
 
 NESTED_ENTRY DelayLoad_MethodCall, _TEXT
 
-        PROLOG_WITH_TRANSITION_BLOCK 0, 10h, r8, r9
+        PROLOG_WITH_TRANSITION_BLOCK 0, DoNotPushCalleeSavedFloats, 10h, r8, r9
 
         lea     rcx, [rsp + __PWTB_TransitionBlock] ; pTransitionBlock
         mov     rdx, rax                            ; pIndirection
@@ -33,7 +33,7 @@ DYNAMICHELPER macro frameFlags, suffix
 
 NESTED_ENTRY DelayLoad_Helper&suffix, _TEXT
 
-        PROLOG_WITH_TRANSITION_BLOCK 8h, 10h, r8, r9
+        PROLOG_WITH_TRANSITION_BLOCK 8h, DoNotPushCalleeSavedFloats, 10h, r8, r9
 
         mov     qword ptr [rsp + SIZEOF_MAX_OUTGOING_ARGUMENT_HOMES], frameFlags
         lea     rcx, [rsp + __PWTB_TransitionBlock] ; pTransitionBlock

--- a/src/coreclr/vm/amd64/VirtualCallStubAMD64.asm
+++ b/src/coreclr/vm/amd64/VirtualCallStubAMD64.asm
@@ -24,7 +24,7 @@ INITIAL_SUCCESS_COUNT           equ  100h
 
 NESTED_ENTRY ResolveWorkerAsmStub, _TEXT
 
-        PROLOG_WITH_TRANSITION_BLOCK 0, 8, r8
+        PROLOG_WITH_TRANSITION_BLOCK 0, <DoNotPushCalleeSavedFloats>, 8, r8
 
         ; token stored in r8 by prolog
 

--- a/src/coreclr/vm/amd64/VirtualCallStubAMD64.asm
+++ b/src/coreclr/vm/amd64/VirtualCallStubAMD64.asm
@@ -24,7 +24,7 @@ INITIAL_SUCCESS_COUNT           equ  100h
 
 NESTED_ENTRY ResolveWorkerAsmStub, _TEXT
 
-        PROLOG_WITH_TRANSITION_BLOCK 0, <DoNotPushCalleeSavedFloats>, 8, r8
+        PROLOG_WITH_TRANSITION_BLOCK 0, <DoNotPushCalleeSavedFloatRegs>, 8, r8
 
         ; token stored in r8 by prolog
 

--- a/src/coreclr/vm/amd64/asmhelpers.S
+++ b/src/coreclr/vm/amd64/asmhelpers.S
@@ -2015,7 +2015,7 @@ NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
         // Pass TransitionBlock* as last (6th) argument
         // Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
         // Original args: rdi=throwable, rsi=pHandler, rdx=pRD, rcx=pExInfo, r8=isFilter
-        
+
         lea     r9, [rsp + __PWTB_TransitionBlock]         // TransitionBlock* as 6th param (r9)
 
         // rdi, rsi, rdx, rcx, r8 remain unchanged (throwable, pHandler, pRD, pExInfo, isFilter)

--- a/src/coreclr/vm/amd64/asmhelpers.S
+++ b/src/coreclr/vm/amd64/asmhelpers.S
@@ -1996,6 +1996,36 @@ END_PROLOGUE
         ret
 NESTED_END CallJittedMethodRetDoubleDouble, _TEXT
 
+//==========================================================================
+// Create a real TransitionBlock and call CallInterpreterFuncletWorker
+// to execute an interpreter funclet (catch/finally/filter handler).
+//
+// extern "C" DWORD_PTR CallInterpreterFunclet(
+//     OBJECTREF throwable,        // rdi
+//     void* pHandler,             // rsi
+//     REGDISPLAY *pRD,            // rdx
+//     ExInfo *pExInfo,            // rcx
+//     bool isFilter               // r8
+// );
+//==========================================================================
+NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
+
+        PROLOG_WITH_TRANSITION_BLOCK
+
+        // Pass TransitionBlock* as last (6th) argument
+        // Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
+        // Original args: rdi=throwable, rsi=pHandler, rdx=pRD, rcx=pExInfo, r8=isFilter
+        
+        lea     r9, [rsp + __PWTB_TransitionBlock]         // TransitionBlock* as 6th param (r9)
+
+        // rdi, rsi, rdx, rcx, r8 remain unchanged (throwable, pHandler, pRD, pExInfo, isFilter)
+
+        call    C_FUNC(CallInterpreterFuncletWorker)
+
+        EPILOG_WITH_TRANSITION_BLOCK_RETURN
+
+NESTED_END CallInterpreterFunclet, _TEXT
+
 #endif // FEATURE_INTERPRETER
 
 // ------------------------------------------------------------------

--- a/src/coreclr/vm/amd64/asmhelpers.S
+++ b/src/coreclr/vm/amd64/asmhelpers.S
@@ -2026,6 +2026,16 @@ NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
 
 NESTED_END CallInterpreterFunclet, _TEXT
 
+NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation, _TEXT, NoHandler
+        PROLOG_WITH_TRANSITION_BLOCK
+
+        lea rdx, [rsp + __PWTB_TransitionBlock]
+        call C_FUNC(AsyncHelpers_ResumeInterpreterContinuationWorker)
+
+        EPILOG_WITH_TRANSITION_BLOCK_RETURN
+
+NESTED_END AsyncHelpers_ResumeInterpreterContinuation, _TEXT
+
 #endif // FEATURE_INTERPRETER
 
 // ------------------------------------------------------------------

--- a/src/coreclr/vm/amd64/cgenamd64.cpp
+++ b/src/coreclr/vm/amd64/cgenamd64.cpp
@@ -138,22 +138,26 @@ void ResolveHelperFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updat
 }
 #endif // FEATURE_RESOLVE_HELPER_DISPATCH
 
+#ifdef FEATURE_INTERPRETER
 #ifndef DACCESS_COMPILE
 void InterpreterFrame::UpdateFloatingPointRegisters(const PREGDISPLAY pRD)
 {
     LIMITED_METHOD_CONTRACT;
 
+#ifndef UNIX_AMD64_ABI
     // The interpreter frame saves the floating point registers in the TransitionBlock, so we need to update them in the REGDISPLAY when we update the REGDISPLAY for an interpreter frame.
+    // Note: Unix AMD64 ABI has no callee-saved floating point registers, so this is Windows-only.
     TADDR pTransitionBlock = GetTransitionBlock();
     M128A *pCalleeSavedFloats = (M128A*)((BYTE*)pTransitionBlock - 232);
-//    M128A *pCalleeSavedFloats = (M128A *)(pTransitionBlock + TransitionBlock::GetOffsetOfFloatArgumentRegisters() - 0xa0);
     for (int i = 0; i < 10; i++)
     {
         (&pRD->pCurrentContext->Xmm6)[i] = pCalleeSavedFloats[i];
         (&pRD->pCurrentContextPointers->Xmm6)[i] = &pCalleeSavedFloats[i];
     }
+#endif // !UNIX_AMD64_ABI
 }
 #endif // DACCESS_COMPILE
+#endif // FEATURE_INTERPRETER
 
 void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {

--- a/src/coreclr/vm/amd64/cgenamd64.cpp
+++ b/src/coreclr/vm/amd64/cgenamd64.cpp
@@ -138,7 +138,7 @@ void ResolveHelperFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updat
 
 #ifdef FEATURE_INTERPRETER
 #ifndef DACCESS_COMPILE
-void InterpreterFrame::UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR targetSP)
+void InterpreterFrame::UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR)
 {
     LIMITED_METHOD_CONTRACT;
 

--- a/src/coreclr/vm/amd64/cgenamd64.cpp
+++ b/src/coreclr/vm/amd64/cgenamd64.cpp
@@ -138,6 +138,23 @@ void ResolveHelperFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updat
 }
 #endif // FEATURE_RESOLVE_HELPER_DISPATCH
 
+#ifndef DACCESS_COMPILE
+void InterpreterFrame::UpdateFloatingPointRegisters(const PREGDISPLAY pRD)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    // The interpreter frame saves the floating point registers in the TransitionBlock, so we need to update them in the REGDISPLAY when we update the REGDISPLAY for an interpreter frame.
+    TADDR pTransitionBlock = GetTransitionBlock();
+    M128A *pCalleeSavedFloats = (M128A*)((BYTE*)pTransitionBlock - 232);
+//    M128A *pCalleeSavedFloats = (M128A *)(pTransitionBlock + TransitionBlock::GetOffsetOfFloatArgumentRegisters() - 0xa0);
+    for (int i = 0; i < 10; i++)
+    {
+        (&pRD->pCurrentContext->Xmm6)[i] = pCalleeSavedFloats[i];
+        (&pRD->pCurrentContextPointers->Xmm6)[i] = &pCalleeSavedFloats[i];
+    }
+}
+#endif // DACCESS_COMPILE
+
 void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
     CONTRACTL

--- a/src/coreclr/vm/amd64/cgenamd64.cpp
+++ b/src/coreclr/vm/amd64/cgenamd64.cpp
@@ -88,8 +88,6 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
     if (updateFloats)
     {
         UpdateFloatingPointRegisters(pRD, GetSP());
-        _ASSERTE(pRD->pCurrentContext->Rip == GetReturnAddress());
-        _ASSERTE(pRD->pCurrentContext->Rsp == GetSP());
     }
 #endif // DACCESS_COMPILE
 
@@ -140,13 +138,14 @@ void ResolveHelperFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updat
 
 #ifdef FEATURE_INTERPRETER
 #ifndef DACCESS_COMPILE
-void InterpreterFrame::UpdateFloatingPointRegisters(const PREGDISPLAY pRD)
+void InterpreterFrame::UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR targetSP)
 {
     LIMITED_METHOD_CONTRACT;
 
 #ifndef UNIX_AMD64_ABI
     // The interpreter frame saves the floating point registers in the TransitionBlock, so we need to update them in the REGDISPLAY when we update the REGDISPLAY for an interpreter frame.
     // Note: Unix AMD64 ABI has no callee-saved floating point registers, so this is Windows-only.
+    // FP callee-saved are at TransitionBlock - 232 (8 for stack alignment + 4 * 16 for FP argument registers + 10 * 16 for callee saved floating point registers).
     TADDR pTransitionBlock = GetTransitionBlock();
     M128A *pCalleeSavedFloats = (M128A*)((BYTE*)pTransitionBlock - 232);
     for (int i = 0; i < 10; i++)
@@ -182,7 +181,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 #ifndef DACCESS_COMPILE
     if (updateFloats)
     {
-        UpdateFloatingPointRegisters(pRD);
+        UpdateFloatingPointRegisters(pRD, dac_cast<TADDR>(GetCallSiteSP()));
         // The float updating unwinds the stack so the pRD->pCurrentContext->Rip contains correct unwound Rip
         // This is used for exception handling and the Rip extracted from m_pCallerReturnAddress is slightly
         // off, which causes problem with searching for the return address on shadow stack on x64, so

--- a/src/coreclr/vm/arm/asmhelpers.S
+++ b/src/coreclr/vm/arm/asmhelpers.S
@@ -1368,4 +1368,48 @@ NESTED_ENTRY InterpreterStubRetBuffR1, _TEXT, NoHandler
     EPILOG_POP {pc}
 NESTED_END InterpreterStubRetBuffR1, _TEXT
 
+// ------------------------------------------------------------------
+// Create a real TransitionBlock and call CallInterpreterFuncletWorker
+// to execute an interpreter funclet (catch/finally/filter handler).
+//
+// extern "C" DWORD_PTR CallInterpreterFunclet(
+//     OBJECTREF throwable,        // r0
+//     void* pHandler,             // r1
+//     REGDISPLAY *pRD,            // r2
+//     ExInfo *pExInfo,            // r3
+//     bool isFilter               // [sp, #0]
+// );
+// ------------------------------------------------------------------
+NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
+
+    PROLOG_WITH_TRANSITION_BLOCK
+
+    // Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
+    // Original args: r0=throwable, r1=pHandler, r2=pRD, r3=pExInfo, isFilter on stack
+    // For ARM32, first 4 args go in r0-r3, args 5-6 go on stack
+
+    // First, allocate space for stack args (2 words for isFilter and TransitionBlock*)
+    sub         sp, sp, #8
+
+    // Put TransitionBlock* as 6th param (2nd stack arg)
+    add         r12, sp, #8 + __PWTB_TransitionBlock  // TransitionBlock* 
+    str         r12, [sp, #4]
+
+    // Load isFilter from original stack location and store as 5th param (1st stack arg)
+    // After PROLOG_WITH_TRANSITION_BLOCK, original stack args are at __PWTB_TransitionBlock offset
+    // The 5th param (isFilter) was pushed before our stack allocation
+    ldr         r12, [sp, #8 + __PWTB_TransitionBlock + SIZEOF__ArgumentRegisters]
+    str         r12, [sp, #0]
+
+    // r0-r3 remain unchanged
+
+    CHECK_STACK_ALIGNMENT
+    bl          C_FUNC(CallInterpreterFuncletWorker)
+
+    add         sp, sp, #8
+
+    EPILOG_WITH_TRANSITION_BLOCK_RETURN
+
+NESTED_END CallInterpreterFunclet, _TEXT
+
 #endif // FEATURE_INTERPRETER

--- a/src/coreclr/vm/arm/asmhelpers.S
+++ b/src/coreclr/vm/arm/asmhelpers.S
@@ -1417,8 +1417,8 @@ NESTED_END CallInterpreterFunclet, _TEXT
 // The worker function will restore callee-saved registers from the
 // TransitionBlock.
 //
-// extern "C" void AsyncHelpers_ResumeInterpreterContinuation(
-//     QCall::ObjectHandleOnStack cont,  // r0
+// extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuation(
+//     ContinuationObject* cont,          // r0
 //     uint8_t* resultStorage             // r1
 // );
 // ------------------------------------------------------------------

--- a/src/coreclr/vm/arm/asmhelpers.S
+++ b/src/coreclr/vm/arm/asmhelpers.S
@@ -1392,7 +1392,7 @@ NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
     sub         sp, sp, #8
 
     // Put TransitionBlock* as 6th param (2nd stack arg)
-    add         r12, sp, #8 + __PWTB_TransitionBlock  // TransitionBlock* 
+    add         r12, sp, #8 + __PWTB_TransitionBlock  // TransitionBlock*
     str         r12, [sp, #4]
 
     // Load isFilter from original stack location and store as 5th param (1st stack arg)
@@ -1417,10 +1417,8 @@ NESTED_END CallInterpreterFunclet, _TEXT
 // The worker function will restore callee-saved registers from the
 // TransitionBlock.
 //
-// extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuation(
-//     ContinuationObject* cont,          // r0
-//     uint8_t* resultStorage             // r1
-// );
+// FCDECL2(ContinuationObject*, AsyncHelpers_ResumeInterpreterContinuation, ContinuationObject* cont, uint8_t* resultStorage);
+//
 // ------------------------------------------------------------------
 NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation, _TEXT, NoHandler
 

--- a/src/coreclr/vm/arm/asmhelpers.S
+++ b/src/coreclr/vm/arm/asmhelpers.S
@@ -1382,7 +1382,7 @@ NESTED_END InterpreterStubRetBuffR1, _TEXT
 // ------------------------------------------------------------------
 NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
 
-    PROLOG_WITH_TRANSITION_BLOCK
+    PROLOG_WITH_TRANSITION_BLOCK PushCalleeSavedFloats=1
 
     // Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
     // Original args: r0=throwable, r1=pHandler, r2=pRD, r3=pExInfo, isFilter on stack
@@ -1411,5 +1411,31 @@ NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
     EPILOG_WITH_TRANSITION_BLOCK_RETURN
 
 NESTED_END CallInterpreterFunclet, _TEXT
+
+// ------------------------------------------------------------------
+// Resume an interpreter continuation after an async await.
+// The worker function will restore callee-saved registers from the
+// TransitionBlock.
+//
+// extern "C" void AsyncHelpers_ResumeInterpreterContinuation(
+//     QCall::ObjectHandleOnStack cont,  // r0
+//     uint8_t* resultStorage             // r1
+// );
+// ------------------------------------------------------------------
+NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation, _TEXT, NoHandler
+
+    PROLOG_WITH_TRANSITION_BLOCK PushCalleeSavedFloats=1
+
+    // Worker signature: AsyncHelpers_ResumeInterpreterContinuationWorker(cont, resultStorage, TransitionBlock*)
+    // r0, r1 remain unchanged
+
+    add         r2, sp, #__PWTB_TransitionBlock     // TransitionBlock* as 3rd param (r2)
+
+    CHECK_STACK_ALIGNMENT
+    bl          C_FUNC(AsyncHelpers_ResumeInterpreterContinuationWorker)
+
+    EPILOG_WITH_TRANSITION_BLOCK_RETURN
+
+NESTED_END AsyncHelpers_ResumeInterpreterContinuation, _TEXT
 
 #endif // FEATURE_INTERPRETER

--- a/src/coreclr/vm/arm/asmhelpers.S
+++ b/src/coreclr/vm/arm/asmhelpers.S
@@ -1254,7 +1254,7 @@ NESTED_ENTRY CallJittedMethodRetU2, _TEXT, NoHandler
 NESTED_END CallJittedMethodRetU2, _TEXT
 
 NESTED_ENTRY InterpreterStub, _TEXT, NoHandler
-    PROLOG_WITH_TRANSITION_BLOCK
+    PROLOG_WITH_TRANSITION_BLOCK pushCalleeSavedFloatRegs=1
 
     // IR bytecode address
     mov r4, METHODDESC_REGISTER // InterpMethod
@@ -1382,7 +1382,7 @@ NESTED_END InterpreterStubRetBuffR1, _TEXT
 // ------------------------------------------------------------------
 NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
 
-    PROLOG_WITH_TRANSITION_BLOCK PushCalleeSavedFloats=1
+    PROLOG_WITH_TRANSITION_BLOCK pushCalleeSavedFloatRegs=1
 
     // Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
     // Original args: r0=throwable, r1=pHandler, r2=pRD, r3=pExInfo, isFilter on stack
@@ -1424,7 +1424,7 @@ NESTED_END CallInterpreterFunclet, _TEXT
 // ------------------------------------------------------------------
 NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation, _TEXT, NoHandler
 
-    PROLOG_WITH_TRANSITION_BLOCK PushCalleeSavedFloats=1
+    PROLOG_WITH_TRANSITION_BLOCK pushCalleeSavedFloatRegs=1
 
     // Worker signature: AsyncHelpers_ResumeInterpreterContinuationWorker(cont, resultStorage, TransitionBlock*)
     // r0, r1 remain unchanged

--- a/src/coreclr/vm/arm/stubs.cpp
+++ b/src/coreclr/vm/arm/stubs.cpp
@@ -1277,7 +1277,7 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
 
 #ifdef FEATURE_INTERPRETER
 #ifndef DACCESS_COMPILE
-void InterpreterFrame::UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR targetSP)
+void InterpreterFrame::UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -1352,7 +1352,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 #ifndef DACCESS_COMPILE
     if (updateFloats)
     {
-        UpdateFloatingPointRegisters(pRD);
+        UpdateFloatingPointRegisters(pRD, dac_cast<TADDR>(GetCallSiteSP()));
     }
 #endif // DACCESS_COMPILE
 

--- a/src/coreclr/vm/arm/stubs.cpp
+++ b/src/coreclr/vm/arm/stubs.cpp
@@ -1244,7 +1244,6 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
     if (updateFloats)
     {
         UpdateFloatingPointRegisters(pRD, GetSP());
-        _ASSERTE(pRD->pCurrentContext->Pc == GetReturnAddress());
     }
 #endif // DACCESS_COMPILE
 

--- a/src/coreclr/vm/arm/stubs.cpp
+++ b/src/coreclr/vm/arm/stubs.cpp
@@ -1277,14 +1277,14 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
 
 #ifdef FEATURE_INTERPRETER
 #ifndef DACCESS_COMPILE
-void InterpreterFrame::UpdateFloatingPointRegisters(const PREGDISPLAY pRD)
+void InterpreterFrame::UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR targetSP)
 {
     LIMITED_METHOD_CONTRACT;
 
     // The interpreter frame saves the floating point callee-saved registers (d8-d15) in the TransitionBlock,
     // so we need to update them in the REGDISPLAY when we update the REGDISPLAY for an interpreter frame.
     //
-    // Stack layout when PushCalleeSavedFloats is used:
+    // Stack layout when pushCalleeSavedFloatRegs is used:
     //   [d8-d15 (64 bytes)] [padding (4 bytes)] [d0-d7 (64 bytes)] [padding (4 bytes)] [TransitionBlock]
     // FP callee-saved are at TransitionBlock - 136 (64 + 4 + 64 + 4)
     TADDR pTransitionBlock = GetTransitionBlock();

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -3321,8 +3321,8 @@ NESTED_END CallInterpreterFunclet, _TEXT
 // The worker function will restore callee-saved registers from the
 // TransitionBlock.
 //
-// extern "C" void AsyncHelpers_ResumeInterpreterContinuation(
-//     QCall::ObjectHandleOnStack cont,  // x0
+// extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuation(
+//     ContinuationObject* cont,          // x0
 //     uint8_t* resultStorage             // x1
 // );
 // ------------------------------------------------------------------

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -686,9 +686,9 @@ LEAF_END ThisPtrRetBufPrecodeWorker, _TEXT
 NESTED_ENTRY InterpreterStub, _TEXT, NoHandler
 
 #ifdef TARGET_APPLE
-    PROLOG_WITH_TRANSITION_BLOCK extraLocals=8*16, SaveFPArgs=0,SaveGPArgs=0
+    PROLOG_WITH_TRANSITION_BLOCK extraLocals=8*16, SaveFPArgs=0,SaveGPArgs=0, pushCalleeSavedFloatRegs=1
 #else
-    PROLOG_WITH_TRANSITION_BLOCK
+    PROLOG_WITH_TRANSITION_BLOCK pushCalleeSavedFloatRegs=1
 #endif
 
     // IR bytecode address
@@ -3301,7 +3301,7 @@ LEAF_END SwiftLoweredReturnTerminator
 // ------------------------------------------------------------------
 NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
 
-    PROLOG_WITH_TRANSITION_BLOCK PushCalleeSavedFloats=1
+    PROLOG_WITH_TRANSITION_BLOCK pushCalleeSavedFloatRegs=1
 
     // Pass TransitionBlock* as last (6th) argument
     // Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
@@ -3328,7 +3328,7 @@ NESTED_END CallInterpreterFunclet, _TEXT
 // ------------------------------------------------------------------
 NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation, _TEXT, NoHandler
 
-    PROLOG_WITH_TRANSITION_BLOCK PushCalleeSavedFloats=1
+    PROLOG_WITH_TRANSITION_BLOCK pushCalleeSavedFloatRegs=1
 
     // Worker signature: AsyncHelpers_ResumeInterpreterContinuationWorker(cont, resultStorage, TransitionBlock*)
     // x0, x1 remain unchanged

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -3301,7 +3301,7 @@ LEAF_END SwiftLoweredReturnTerminator
 // ------------------------------------------------------------------
 NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
 
-    PROLOG_WITH_TRANSITION_BLOCK
+    PROLOG_WITH_TRANSITION_BLOCK PushCalleeSavedFloats=1
 
     // Pass TransitionBlock* as last (6th) argument
     // Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
@@ -3315,6 +3315,31 @@ NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
     EPILOG_WITH_TRANSITION_BLOCK_RETURN
 
 NESTED_END CallInterpreterFunclet, _TEXT
+
+// ------------------------------------------------------------------
+// Resume an interpreter continuation after an async await.
+// The worker function will restore callee-saved registers from the
+// TransitionBlock.
+//
+// extern "C" void AsyncHelpers_ResumeInterpreterContinuation(
+//     QCall::ObjectHandleOnStack cont,  // x0
+//     uint8_t* resultStorage             // x1
+// );
+// ------------------------------------------------------------------
+NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation, _TEXT, NoHandler
+
+    PROLOG_WITH_TRANSITION_BLOCK PushCalleeSavedFloats=1
+
+    // Worker signature: AsyncHelpers_ResumeInterpreterContinuationWorker(cont, resultStorage, TransitionBlock*)
+    // x0, x1 remain unchanged
+
+    add     x2, sp, #__PWTB_TransitionBlock     // TransitionBlock* as 3rd param (x2)
+
+    bl      C_FUNC(AsyncHelpers_ResumeInterpreterContinuationWorker)
+
+    EPILOG_WITH_TRANSITION_BLOCK_RETURN
+
+NESTED_END AsyncHelpers_ResumeInterpreterContinuation, _TEXT
 
 
 #endif // FEATURE_INTERPRETER

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -3321,10 +3321,8 @@ NESTED_END CallInterpreterFunclet, _TEXT
 // The worker function will restore callee-saved registers from the
 // TransitionBlock.
 //
-// extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuation(
-//     ContinuationObject* cont,          // x0
-//     uint8_t* resultStorage             // x1
-// );
+// FCDECL2(ContinuationObject*, AsyncHelpers_ResumeInterpreterContinuation, ContinuationObject* cont, uint8_t* resultStorage);
+//
 // ------------------------------------------------------------------
 NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation, _TEXT, NoHandler
 

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -3287,6 +3287,35 @@ LEAF_ENTRY SwiftLoweredReturnTerminator
 LEAF_END SwiftLoweredReturnTerminator
 
 #endif // TARGET_APPLE
+// ------------------------------------------------------------------
+// Create a real TransitionBlock and call CallInterpreterFuncletWorker
+// to execute an interpreter funclet (catch/finally/filter handler).
+//
+// extern "C" DWORD_PTR CallInterpreterFunclet(
+//     OBJECTREF throwable,        // x0
+//     void* pHandler,             // x1
+//     REGDISPLAY *pRD,            // x2
+//     ExInfo *pExInfo,            // x3
+//     bool isFilter               // x4
+// );
+// ------------------------------------------------------------------
+NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
+
+    PROLOG_WITH_TRANSITION_BLOCK
+
+    // Pass TransitionBlock* as last (6th) argument
+    // Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
+    // Original args: x0=throwable, x1=pHandler, x2=pRD, x3=pExInfo, x4=isFilter
+    // x0-x4 remain unchanged
+
+    add     x5, sp, #__PWTB_TransitionBlock     // TransitionBlock* as 6th param (x5)
+
+    bl      C_FUNC(CallInterpreterFuncletWorker)
+
+    EPILOG_WITH_TRANSITION_BLOCK_RETURN
+
+NESTED_END CallInterpreterFunclet, _TEXT
+
 
 #endif // FEATURE_INTERPRETER
 

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -3172,9 +3172,9 @@ CopyLoop
 ;; The worker function will restore callee-saved registers from the
 ;; TransitionBlock.
 ;;
-;; extern "C" void AsyncHelpers_ResumeInterpreterContinuation(
-;;     QCall::ObjectHandleOnStack cont,  ; x0
-;;     uint8_t* resultStorage             ; x1
+;; extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuation(
+;;     ContinuationObject* cont,          // x0
+;;     uint8_t* resultStorage             // x1
 ;; );
 ;; ------------------------------------------------------------------
     IMPORT AsyncHelpers_ResumeInterpreterContinuationWorker

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -1094,7 +1094,7 @@ JIT_PollGCRarePath
 
     NESTED_ENTRY InterpreterStub
 
-        PROLOG_WITH_TRANSITION_BLOCK
+        PROLOG_WITH_TRANSITION_BLOCK , , PushCalleeSavedFloatRegs
 
         INLINE_GETTHREAD x20, x19
         mov x19, METHODDESC_REGISTER ; x19 contains IR bytecode address
@@ -3152,7 +3152,7 @@ CopyLoop
 
     NESTED_ENTRY CallInterpreterFunclet
 
-        PROLOG_WITH_TRANSITION_BLOCK , , PushCalleeSavedFloats
+        PROLOG_WITH_TRANSITION_BLOCK , , PushCalleeSavedFloatRegs
 
         ; Pass TransitionBlock* as last (6th) argument
         ; Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
@@ -3181,7 +3181,7 @@ CopyLoop
 
     NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation
 
-        PROLOG_WITH_TRANSITION_BLOCK , , PushCalleeSavedFloats
+        PROLOG_WITH_TRANSITION_BLOCK , , PushCalleeSavedFloatRegs
 
         ; Worker signature: AsyncHelpers_ResumeInterpreterContinuationWorker(cont, resultStorage, TransitionBlock*)
         ; x0, x1 remain unchanged

--- a/src/coreclr/vm/arm64/asmhelpers.asm
+++ b/src/coreclr/vm/arm64/asmhelpers.asm
@@ -3136,6 +3136,35 @@ CopyLoop
         EPILOG_RETURN
     NESTED_END CallJittedMethodRet4Vector128
 
+;; ------------------------------------------------------------------
+;; Create a real TransitionBlock and call CallInterpreterFuncletWorker
+;; to execute an interpreter funclet (catch/finally/filter handler).
+;;
+;; extern "C" DWORD_PTR CallInterpreterFunclet(
+;;     OBJECTREF throwable,        ; x0
+;;     void* pHandler,             ; x1
+;;     REGDISPLAY *pRD,            ; x2
+;;     ExInfo *pExInfo,            ; x3
+;;     bool isFilter               ; x4
+;; );
+;; ------------------------------------------------------------------
+    NESTED_ENTRY CallInterpreterFunclet
+
+        PROLOG_WITH_TRANSITION_BLOCK
+
+        ; Pass TransitionBlock* as last (6th) argument
+        ; Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
+        ; Original args: x0=throwable, x1=pHandler, x2=pRD, x3=pExInfo, x4=isFilter
+        ; x0-x4 remain unchanged
+
+        add     x5, sp, #__PWTB_TransitionBlock     ; TransitionBlock* as 6th param (x5)
+
+        bl      CallInterpreterFuncletWorker
+
+        EPILOG_WITH_TRANSITION_BLOCK_RETURN
+
+    NESTED_END CallInterpreterFunclet
+
 
 #endif // FEATURE_INTERPRETER
 

--- a/src/coreclr/vm/arm64/asmmacros.h
+++ b/src/coreclr/vm/arm64/asmmacros.h
@@ -33,12 +33,12 @@ $name   SETS    "|$symbol|"
 ; Define the prolog for a TransitionFrame-based method. This macro should be called first in the method and
 ; comprises the entire prolog (i.e. don't modify SP after calling this).The locals must be 8 byte aligned
 ;
-; $calleeSavedFloats - Optional parameter. If set to "PushCalleeSavedFloats", the macro will also save
-;                      the callee-saved floating point registers (d8-d15) to the stack. These registers
-;                      are NOT restored by the EPILOG_WITH_TRANSITION_BLOCK variants.
+; $pushCalleeSavedFloatRegs - Optional parameter. If set to PushCalleeSavedFloats, the macro will also save
+;                             the callee-saved floating point registers (d8-d15) to the stack. These registers
+;                             are NOT restored by the EPILOG_WITH_TRANSITION_BLOCK variants.
 ;
     MACRO
-        PROLOG_WITH_TRANSITION_BLOCK $extraLocals, $SaveFPArgs, $calleeSavedFloats
+        PROLOG_WITH_TRANSITION_BLOCK $extraLocals, $SaveFPArgs, $pushCalleeSavedFloatRegs
 
         GBLA __PWTB_FloatArgumentRegisters
         GBLA __PWTB_FloatCalleeSavedRegisters
@@ -65,8 +65,8 @@ __PWTB_FloatCalleeSavedRegisters SETA 0
 __PWTB_FloatCalleeSavedRegisters SETA __PWTB_FloatCalleeSavedRegisters + 8
         ENDIF
 
-        ; If PushCalleeSavedFloats is specified, reserve space for d8-d15 (8 registers * 8 bytes = 64 bytes)
-        IF "$calleeSavedFloats" == "PushCalleeSavedFloats"
+        ; If PushCalleeSavedFloatRegs is specified, reserve space for d8-d15 (8 registers * 8 bytes = 64 bytes)
+        IF "$pushCalleeSavedFloatRegs" == "PushCalleeSavedFloatRegs"
 __PWTB_FloatArgumentRegisters SETA __PWTB_FloatCalleeSavedRegisters + 64
         ELSE
 __PWTB_FloatArgumentRegisters SETA __PWTB_FloatCalleeSavedRegisters
@@ -101,7 +101,7 @@ __PWTB_ArgumentRegister_FirstArg SETA __PWTB_ArgumentRegisters + 8
         ENDIF
 
         ; Save callee-saved floating point registers if requested
-        IF "$calleeSavedFloats" == "PushCalleeSavedFloats"
+        IF "$pushCalleeSavedFloatRegs" == "PushCalleeSavedFloatRegs"
         stp     d8, d9, [sp, #__PWTB_FloatCalleeSavedRegisters]
         stp     d10, d11, [sp, #(__PWTB_FloatCalleeSavedRegisters + 16)]
         stp     d12, d13, [sp, #(__PWTB_FloatCalleeSavedRegisters + 32)]

--- a/src/coreclr/vm/arm64/asmmacros.h
+++ b/src/coreclr/vm/arm64/asmmacros.h
@@ -33,10 +33,15 @@ $name   SETS    "|$symbol|"
 ; Define the prolog for a TransitionFrame-based method. This macro should be called first in the method and
 ; comprises the entire prolog (i.e. don't modify SP after calling this).The locals must be 8 byte aligned
 ;
+; $calleeSavedFloats - Optional parameter. If set to "PushCalleeSavedFloats", the macro will also save
+;                      the callee-saved floating point registers (d8-d15) to the stack. These registers
+;                      are NOT restored by the EPILOG_WITH_TRANSITION_BLOCK variants.
+;
     MACRO
-        PROLOG_WITH_TRANSITION_BLOCK $extraLocals, $SaveFPArgs
+        PROLOG_WITH_TRANSITION_BLOCK $extraLocals, $SaveFPArgs, $calleeSavedFloats
 
         GBLA __PWTB_FloatArgumentRegisters
+        GBLA __PWTB_FloatCalleeSavedRegisters
         GBLA __PWTB_ArgumentRegisters
         GBLA __PWTB_ArgumentRegister_FirstArg ; We save the x8 register ahead of the first argument, so this
                                               ; is different from the start of the argument register save area.
@@ -51,13 +56,20 @@ __PWTB_SaveFPArgs SETL {true}
         ENDIF
 
         IF "$extraLocals" != ""
-__PWTB_FloatArgumentRegisters SETA $extraLocals
+__PWTB_FloatCalleeSavedRegisters SETA $extraLocals
         ELSE
-__PWTB_FloatArgumentRegisters SETA 0
+__PWTB_FloatCalleeSavedRegisters SETA 0
         ENDIF
 
-        IF __PWTB_FloatArgumentRegisters:MOD:16 != 0
-__PWTB_FloatArgumentRegisters SETA __PWTB_FloatArgumentRegisters + 8
+        IF __PWTB_FloatCalleeSavedRegisters:MOD:16 != 0
+__PWTB_FloatCalleeSavedRegisters SETA __PWTB_FloatCalleeSavedRegisters + 8
+        ENDIF
+
+        ; If PushCalleeSavedFloats is specified, reserve space for d8-d15 (8 registers * 8 bytes = 64 bytes)
+        IF "$calleeSavedFloats" == "PushCalleeSavedFloats"
+__PWTB_FloatArgumentRegisters SETA __PWTB_FloatCalleeSavedRegisters + 64
+        ELSE
+__PWTB_FloatArgumentRegisters SETA __PWTB_FloatCalleeSavedRegisters
         ENDIF
 
         IF __PWTB_SaveFPArgs
@@ -86,6 +98,14 @@ __PWTB_ArgumentRegister_FirstArg SETA __PWTB_ArgumentRegisters + 8
 
         IF __PWTB_SaveFPArgs
         SAVE_FLOAT_ARGUMENT_REGISTERS  sp, __PWTB_FloatArgumentRegisters
+        ENDIF
+
+        ; Save callee-saved floating point registers if requested
+        IF "$calleeSavedFloats" == "PushCalleeSavedFloats"
+        stp     d8, d9, [sp, #__PWTB_FloatCalleeSavedRegisters]
+        stp     d10, d11, [sp, #(__PWTB_FloatCalleeSavedRegisters + 16)]
+        stp     d12, d13, [sp, #(__PWTB_FloatCalleeSavedRegisters + 32)]
+        stp     d14, d15, [sp, #(__PWTB_FloatCalleeSavedRegisters + 48)]
         ENDIF
 
     MEND

--- a/src/coreclr/vm/arm64/asmmacros.h
+++ b/src/coreclr/vm/arm64/asmmacros.h
@@ -33,7 +33,7 @@ $name   SETS    "|$symbol|"
 ; Define the prolog for a TransitionFrame-based method. This macro should be called first in the method and
 ; comprises the entire prolog (i.e. don't modify SP after calling this).The locals must be 8 byte aligned
 ;
-; $pushCalleeSavedFloatRegs - Optional parameter. If set to PushCalleeSavedFloats, the macro will also save
+; $pushCalleeSavedFloatRegs - Optional parameter. If set to PushCalleeSavedFloatRegs, the macro will also save
 ;                             the callee-saved floating point registers (d8-d15) to the stack. These registers
 ;                             are NOT restored by the EPILOG_WITH_TRANSITION_BLOCK variants.
 ;

--- a/src/coreclr/vm/arm64/stubs.cpp
+++ b/src/coreclr/vm/arm64/stubs.cpp
@@ -218,7 +218,6 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
     if (updateFloats)
     {
         UpdateFloatingPointRegisters(pRD, GetSP());
-        _ASSERTE(pRD->pCurrentContext->Pc == GetReturnAddress());
     }
 #endif // DACCESS_COMPILE
 

--- a/src/coreclr/vm/arm64/stubs.cpp
+++ b/src/coreclr/vm/arm64/stubs.cpp
@@ -280,14 +280,14 @@ void ResolveHelperFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updat
 
 #ifdef FEATURE_INTERPRETER
 #ifndef DACCESS_COMPILE
-void InterpreterFrame::UpdateFloatingPointRegisters(const PREGDISPLAY pRD)
+void InterpreterFrame::UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR targetSP)
 {
     LIMITED_METHOD_CONTRACT;
 
     // The interpreter frame saves the floating point callee-saved registers (d8-d15) in the TransitionBlock,
     // so we need to update them in the REGDISPLAY when we update the REGDISPLAY for an interpreter frame.
     //
-    // Stack layout when PushCalleeSavedFloats is used:
+    // Stack layout when pushCalleeSavedFloatRegs is used:
     //   [d8-d15 (64 bytes)] [q0-q7 (128 bytes)] [TransitionBlock]
     // FP callee-saved are at TransitionBlock - 192 (64 + 128)
     TADDR pTransitionBlock = GetTransitionBlock();

--- a/src/coreclr/vm/arm64/stubs.cpp
+++ b/src/coreclr/vm/arm64/stubs.cpp
@@ -280,7 +280,7 @@ void ResolveHelperFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updat
 
 #ifdef FEATURE_INTERPRETER
 #ifndef DACCESS_COMPILE
-void InterpreterFrame::UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR targetSP)
+void InterpreterFrame::UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -363,7 +363,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 #ifndef DACCESS_COMPILE
     if (updateFloats)
     {
-        UpdateFloatingPointRegisters(pRD);
+        UpdateFloatingPointRegisters(pRD, dac_cast<TADDR>(GetCallSiteSP()));
     }
 #endif // DACCESS_COMPILE
 

--- a/src/coreclr/vm/corelib.cpp
+++ b/src/coreclr/vm/corelib.cpp
@@ -259,6 +259,8 @@ const CoreLibFieldDescription c_rgCoreLibFieldDescriptions[] =
 };
 const USHORT c_nCoreLibFieldDescriptions = ARRAY_SIZE(c_rgCoreLibFieldDescriptions) + 1;
 
+extern "C" void AsyncHelpers_ResumeInterpreterContinuation(QCall::ObjectHandleOnStack cont, uint8_t* resultStorage);
+
 ///////////////////////////////////////////////////////////////////////////////
 //
 // ECalls

--- a/src/coreclr/vm/corelib.cpp
+++ b/src/coreclr/vm/corelib.cpp
@@ -74,6 +74,7 @@
 #endif //FEATURE_PERFTRACING
 
 #include "tailcallhelp.h"
+#include "interpexec.h"
 
 ///////////////////////////////////////////////////////////////////////////////
 //
@@ -258,8 +259,6 @@ const CoreLibFieldDescription c_rgCoreLibFieldDescriptions[] =
     #include "corelib.h"
 };
 const USHORT c_nCoreLibFieldDescriptions = ARRAY_SIZE(c_rgCoreLibFieldDescriptions) + 1;
-
-extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuation(ContinuationObject* cont, uint8_t* resultStorage);
 
 ///////////////////////////////////////////////////////////////////////////////
 //

--- a/src/coreclr/vm/corelib.cpp
+++ b/src/coreclr/vm/corelib.cpp
@@ -259,7 +259,7 @@ const CoreLibFieldDescription c_rgCoreLibFieldDescriptions[] =
 };
 const USHORT c_nCoreLibFieldDescriptions = ARRAY_SIZE(c_rgCoreLibFieldDescriptions) + 1;
 
-extern "C" void AsyncHelpers_ResumeInterpreterContinuation(QCall::ObjectHandleOnStack cont, uint8_t* resultStorage);
+extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuation(ContinuationObject* cont, uint8_t* resultStorage);
 
 ///////////////////////////////////////////////////////////////////////////////
 //

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -153,6 +153,10 @@ FCFuncStart(gRuntimeMethodHandle)
     FCFuncElement("GetLoaderAllocatorInternal", RuntimeMethodHandle::GetLoaderAllocatorInternal)
 FCFuncEnd()
 
+FCFuncStart(gAsyncHelpers)
+    FCFuncElement("AsyncHelpers_ResumeInterpreterContinuation", AsyncHelpers_ResumeInterpreterContinuation)
+FCFuncEnd()
+
 FCFuncStart(gCOMFieldHandleNewFuncs)
     FCFuncElement("GetUtf8NameInternal", RuntimeFieldHandle::GetUtf8Name)
     FCFuncElement("GetAttributes", RuntimeFieldHandle::GetAttributes)
@@ -386,6 +390,7 @@ FCFuncEnd()
 
 FCClassElement("Array", "System", gArrayFuncs)
 FCClassElement("AssemblyLoadContext", "System.Runtime.Loader", gAssemblyLoadContextFuncs)
+FCClassElement("AsyncHelpers", "System.Runtime.CompilerServices", gAsyncHelpers)
 FCClassElement("Buffer", "System", gBufferFuncs)
 FCClassElement("CastHelpers", "System.Runtime.CompilerServices", gCastHelpers)
 FCClassElement("Delegate", "System", gDelegateFuncs)

--- a/src/coreclr/vm/ecalllist.h
+++ b/src/coreclr/vm/ecalllist.h
@@ -153,9 +153,11 @@ FCFuncStart(gRuntimeMethodHandle)
     FCFuncElement("GetLoaderAllocatorInternal", RuntimeMethodHandle::GetLoaderAllocatorInternal)
 FCFuncEnd()
 
+#ifdef FEATURE_INTERPRETER
 FCFuncStart(gAsyncHelpers)
-    FCFuncElement("AsyncHelpers_ResumeInterpreterContinuation", AsyncHelpers_ResumeInterpreterContinuation)
+    FCFuncElement("ResumeInterpreterContinuation", AsyncHelpers_ResumeInterpreterContinuation)
 FCFuncEnd()
+#endif // FEATURE_INTERPRETER
 
 FCFuncStart(gCOMFieldHandleNewFuncs)
     FCFuncElement("GetUtf8NameInternal", RuntimeFieldHandle::GetUtf8Name)
@@ -390,7 +392,9 @@ FCFuncEnd()
 
 FCClassElement("Array", "System", gArrayFuncs)
 FCClassElement("AssemblyLoadContext", "System.Runtime.Loader", gAssemblyLoadContextFuncs)
+#ifdef FEATURE_INTERPRETER
 FCClassElement("AsyncHelpers", "System.Runtime.CompilerServices", gAsyncHelpers)
+#endif
 FCClassElement("Buffer", "System", gBufferFuncs)
 FCClassElement("CastHelpers", "System.Runtime.CompilerServices", gCastHelpers)
 FCClassElement("Delegate", "System", gDelegateFuncs)

--- a/src/coreclr/vm/eetwain.cpp
+++ b/src/coreclr/vm/eetwain.cpp
@@ -1825,6 +1825,78 @@ void EECodeManager::UpdateSSP(PREGDISPLAY pRD)
 #endif // HOST_AMD64 && HOST_WINDOWS
 
 #ifdef FEATURE_INTERPRETER
+
+#if defined(HOST_AMD64) && defined(HOST_WINDOWS)
+
+// ASM helper that creates a TransitionBlock and calls this worker
+extern "C" DWORD_PTR STDCALL CallInterpreterFunclet(OBJECTREF throwable, void* pHandler, REGDISPLAY *pRD, ExInfo *pExInfo, bool isFilter);
+
+// Worker function called from the ASM helper with a real TransitionBlock
+extern "C" DWORD_PTR STDCALL CallInterpreterFuncletWorker(OBJECTREF throwable, void* pHandler, REGDISPLAY *pRD, ExInfo *pExInfo, bool isFilter, TransitionBlock *pTransitionBlock)
+{
+    Thread *pThread = GetThread();
+    InterpThreadContext *threadContext = pThread->GetInterpThreadContext();
+    int8_t *sp = threadContext->pStackPointer;
+
+    // This construct ensures that the InterpreterFrame is always stored at a higher address than the
+    // InterpMethodContextFrame. This is important for the stack walking code.
+    struct Frames
+    {
+        InterpMethodContextFrame interpMethodContextFrame = {0};
+        InterpreterFrame interpreterFrame;
+
+        Frames(TransitionBlock* pTransitionBlock)
+        : interpreterFrame(pTransitionBlock, &interpMethodContextFrame)
+        {
+        }
+    }
+    frames(pTransitionBlock);
+
+    // Use the InterpreterFrame address as a representation of the caller SP of the funclet
+    // Note: this needs to match what the VirtualUnwindInterpreterCallFrame sets as the SP
+    // when it unwinds out of a block of interpreter frames belonging to that InterpreterFrame.
+    pExInfo->m_csfEHClause.SP = (TADDR)&frames.interpreterFrame;
+
+    InterpMethodContextFrame *pOriginalFrame = (InterpMethodContextFrame*)GetRegdisplaySP(pRD);
+
+    StackVal retVal;
+
+    frames.interpMethodContextFrame.startIp = pOriginalFrame->startIp;
+    frames.interpMethodContextFrame.pStack = isFilter ? sp : pOriginalFrame->pStack;
+    frames.interpMethodContextFrame.pRetVal = (int8_t*)&retVal;
+
+    ExceptionClauseArgs exceptionClauseArgs;
+    exceptionClauseArgs.ip = (const int32_t *)pHandler;
+    exceptionClauseArgs.pFrame = pOriginalFrame;
+    exceptionClauseArgs.isFilter = isFilter;
+    exceptionClauseArgs.throwable = throwable;
+
+    GCPROTECT_BEGIN(exceptionClauseArgs.throwable);
+    InterpExecMethod(&frames.interpreterFrame, &frames.interpMethodContextFrame, threadContext, &exceptionClauseArgs);
+    GCPROTECT_END();
+
+    frames.interpreterFrame.Pop();
+
+    if (isFilter)
+    {
+        // The filter funclet returns the result of the filter funclet (EXCEPTION_CONTINUE_SEARCH (0) or EXCEPTION_EXECUTE_HANDLER (1))
+        return retVal.data.i;
+    }
+    else
+    {
+        // The catch funclet returns the address to resume at after the catch returns.
+        return (DWORD_PTR)retVal.data.s;
+    }
+}
+
+DWORD_PTR InterpreterCodeManager::CallFunclet(OBJECTREF throwable, void* pHandler, REGDISPLAY *pRD, ExInfo *pExInfo, bool isFilter)
+{
+    // Call the ASM helper which creates a real TransitionBlock
+    return CallInterpreterFunclet(throwable, pHandler, pRD, pExInfo, isFilter);
+}
+
+#else // HOST_AMD64 && HOST_WINDOWS
+
 DWORD_PTR InterpreterCodeManager::CallFunclet(OBJECTREF throwable, void* pHandler, REGDISPLAY *pRD, ExInfo *pExInfo, bool isFilter)
 {
     Thread *pThread = GetThread();
@@ -1881,6 +1953,8 @@ DWORD_PTR InterpreterCodeManager::CallFunclet(OBJECTREF throwable, void* pHandle
         return (DWORD_PTR)retVal.data.s;
     }
 }
+
+#endif // HOST_AMD64 && HOST_WINDOWS
 
 void InterpreterCodeManager::ResumeAfterCatch(CONTEXT *pContext, size_t targetSSP, bool fIntercepted)
 {

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3114,16 +3114,6 @@ void CallCatchFunclet(OBJECTREF throwable, BYTE* pHandlerIP, REGDISPLAY* pvRegDi
     DWORD_PTR dwResumePC = 0;
     UINT_PTR callerTargetSp = 0;
 
-#ifdef FEATURE_INTERPRETER
-    if (GetControlPC(pvRegDisplay) == InterpreterFrame::DummyCallerIP)
-    {
-        // This is a case when we have unwound out of an interpreted filter funclet. The "Next" moves the
-        // REGDISPLAY to the native code context that was there before we started to iterate over the
-        // interpreted frames.
-        exInfo->m_frameIter.Next();
-    }
-#endif // FEATURE_INTERPRETER
-
 #if defined(HOST_AMD64) && defined(HOST_WINDOWS)
     size_t targetSSP = exInfo->m_frameIter.m_crawl.GetRegisterSet()->SSP;
     // Verify the SSP points to the slot that matches the ControlPC of the frame containing the catch funclet.

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -635,9 +635,11 @@ void Frame::PopIfChained()
 #endif // TARGET_UNIX && !DACCESS_COMPILE
 
 #if (!defined(TARGET_X86) || defined(TARGET_UNIX)) && !defined(TARGET_WASM)
-/* static */
-void Frame::UpdateFloatingPointRegisters(const PREGDISPLAY pRD, TADDR targetSP)
+
+void Frame::UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR targetSP)
 {
+    LIMITED_METHOD_CONTRACT;
+    // Default implementation unwinds floating point registers to target SP
     _ASSERTE(!ExecutionManager::IsManagedCode(::GetIP(pRD->pCurrentContext)));
 
     do
@@ -653,13 +655,25 @@ void Frame::UpdateFloatingPointRegisters(const PREGDISPLAY pRD, TADDR targetSP)
     _ASSERTE(::GetSP(pRD->pCurrentContext) == targetSP);
 }
 
-void InlinedCallFrame::UpdateFloatingPointRegisters(const PREGDISPLAY pRD)
+void Frame::UpdateFloatingPointRegisters(const PREGDISPLAY pRD, TADDR targetSP)
+{
+    switch (GetFrameIdentifier())
+    {
+#define FRAME_TYPE_NAME(frameType) case FrameIdentifier::frameType: { return dac_cast<PTR_##frameType>(this)->UpdateFloatingPointRegisters_Impl(pRD, targetSP); }
+#include "FrameTypes.h"
+    default:
+        FRAME_POLYMORPHIC_DISPATCH_UNREACHABLE();
+        return;
+    }
+}
+
+void InlinedCallFrame::UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR targetSP)
 {
 #ifdef FEATURE_INTERPRETER
     if (IsInInterpreter())
     {
         InterpreterFrame *pInterpreterFrame = (InterpreterFrame *)m_Next;
-        Frame::UpdateFloatingPointRegisters(pRD, pInterpreterFrame->GetInterpExecMethodSP());
+        pInterpreterFrame->UpdateFloatingPointRegisters(pRD, pInterpreterFrame->GetInterpExecMethodSP());
         pInterpreterFrame->SetContextToInterpMethodContextFrame(pRD->pCurrentContext);
         return;
     }
@@ -1963,13 +1977,7 @@ void InterpreterFrame::SetContextToInterpMethodContextFrame(T_CONTEXT * pContext
 void InterpreterFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
     SyncRegDisplayToCurrentContext(pRD);
-    TransitionFrame::UpdateRegDisplay_Impl(pRD, FALSE /* updateFloats */);
-#ifndef DACCESS_COMPILE
-    if (updateFloats)
-    {
-        UpdateFloatingPointRegisters(pRD);
-    }
-#endif //!DACCESS_COMPILE
+    TransitionFrame::UpdateRegDisplay_Impl(pRD, updateFloats);
 
 #if defined(TARGET_AMD64) && defined(TARGET_WINDOWS) && !defined(DACCESS_COMPILE)
     // Update the SSP to match the updated regdisplay

--- a/src/coreclr/vm/frames.cpp
+++ b/src/coreclr/vm/frames.cpp
@@ -1963,7 +1963,14 @@ void InterpreterFrame::SetContextToInterpMethodContextFrame(T_CONTEXT * pContext
 void InterpreterFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFloats)
 {
     SyncRegDisplayToCurrentContext(pRD);
-    TransitionFrame::UpdateRegDisplay_Impl(pRD, updateFloats);
+    TransitionFrame::UpdateRegDisplay_Impl(pRD, FALSE /* updateFloats */);
+#ifndef DACCESS_COMPILE
+    if (updateFloats)
+    {
+        UpdateFloatingPointRegisters(pRD);
+    }
+#endif //!DACCESS_COMPILE
+
 #if defined(TARGET_AMD64) && defined(TARGET_WINDOWS) && !defined(DACCESS_COMPILE)
     // Update the SSP to match the updated regdisplay
     size_t *targetSSP = (size_t *)GetInterpExecMethodSSP();

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2511,6 +2511,12 @@ public:
     void ExceptionUnwind_Impl();
 #endif
 
+#ifndef DACCESS_COMPILE
+#if (!defined(TARGET_X86) || defined(TARGET_UNIX)) && !defined(TARGET_WASM)
+    void UpdateFloatingPointRegisters(const PREGDISPLAY pRD);
+#endif // (!TARGET_X86 || TARGET_UNIX) && !TARGET_WASM
+#endif // DACCESS_COMPILE
+
     PTR_InterpMethodContextFrame GetTopInterpMethodContextFrame();
 
     void SetContextToInterpMethodContextFrame(T_CONTEXT * pContext);

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -596,7 +596,12 @@ protected:
 
 #ifndef DACCESS_COMPILE
 #if (!defined(TARGET_X86) || defined(TARGET_UNIX)) && !defined(TARGET_WASM)
-    static void UpdateFloatingPointRegisters(const PREGDISPLAY pRD, TADDR targetSP);
+    // Pseudo-virtual method for updating floating point registers during stack walk
+    void UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR targetSP);
+public:
+    // Public dispatch method for UpdateFloatingPointRegisters
+    void UpdateFloatingPointRegisters(const PREGDISPLAY pRD, TADDR targetSP);
+protected:
 #endif // (!TARGET_X86 || TARGET_UNIX) && !TARGET_WASM
 #endif // DACCESS_COMPILE
 
@@ -2233,7 +2238,7 @@ public:
 
 #ifndef DACCESS_COMPILE
 #if (!defined(TARGET_X86) || defined(TARGET_UNIX)) && !defined(TARGET_WASM)
-    void UpdateFloatingPointRegisters(const PREGDISPLAY pRD);
+    void UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR targetSP);
 #endif // (!TARGET_X86 || TARGET_UNIX) && !TARGET_WASM
 #endif // DACCESS_COMPILE
 
@@ -2513,7 +2518,7 @@ public:
 
 #ifndef DACCESS_COMPILE
 #if (!defined(TARGET_X86) || defined(TARGET_UNIX)) && !defined(TARGET_WASM)
-    void UpdateFloatingPointRegisters(const PREGDISPLAY pRD);
+    void UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR targetSP);
 #endif // (!TARGET_X86 || TARGET_UNIX) && !TARGET_WASM
 #endif // DACCESS_COMPILE
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1079,7 +1079,7 @@ extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuationWorker(
 }
 
 #ifdef TARGET_WASM
-extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuation(ContinuationObject* cont, uint8_t* resultStorage)
+FCIMPL2(ContinuationObject*, AsyncHelpers_ResumeInterpreterContinuation, ContinuationObject* cont, uint8_t* resultStorage)
 {
     STATIC_CONTRACT_WRAPPER;
 
@@ -1088,6 +1088,7 @@ extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuation(Contin
 
     return AsyncHelpers_ResumeInterpreterContinuationWorker(cont, resultStorage, &transitionBlock);
 }
+FCIMPLEND
 #endif // TARGET_WASM
 
 static void DECLSPEC_NORETURN HandleInterpreterStackOverflow(InterpreterFrame* pInterpreterFrame)

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1019,6 +1019,8 @@ void AsyncHelpers_ResumeInterpreterContinuation(QCall::ObjectHandleOnStack cont,
     }
     frames(NULL);
 
+    _ASSERTE_MSG(false, "NULL transition block!!!");
+
     CONTINUATIONREF contRef = (CONTINUATIONREF)ObjectToOBJECTREF(cont.Get());
     NULL_CHECK(contRef);
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -993,7 +993,7 @@ void* DoGenericLookup(void* genericVarAsPtr, InterpGenericLookup* pLookup)
     return result;
 }
 
-extern "C" Object* AsyncHelpers_ResumeInterpreterContinuationWorker(Object* cont, uint8_t* resultStorage, TransitionBlock* pTransitionBlock)
+extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuationWorker(ContinuationObject* cont, uint8_t* resultStorage, TransitionBlock* pTransitionBlock)
 {
     CONTRACTL
     {
@@ -1072,10 +1072,10 @@ extern "C" Object* AsyncHelpers_ResumeInterpreterContinuationWorker(Object* cont
         }
     }
 
-    contRef = frames.interpreterFrame.GetContinuation();
+    contRef = (CONTINUATIONREF)frames.interpreterFrame.GetContinuation();
     frames.interpreterFrame.Pop();
 
-    return OBJECTREFToObject(contRef);
+    return (ContinuationObject*)OBJECTREFToObject(contRef);
 }
 
 static void DECLSPEC_NORETURN HandleInterpreterStackOverflow(InterpreterFrame* pInterpreterFrame)

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1078,6 +1078,18 @@ extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuationWorker(
     return (ContinuationObject*)OBJECTREFToObject(contRef);
 }
 
+#ifdef TARGET_WASM
+extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuation(ContinuationObject* cont, uint8_t* resultStorage)
+{
+    STATIC_CONTRACT_WRAPPER;
+
+    TransitionBlock transitionBlock{};
+    transitionBlock.m_ReturnAddress = (TADDR)&AsyncHelpers_ResumeInterpreterContinuation;
+
+    return AsyncHelpers_ResumeInterpreterContinuationWorker(cont, resultStorage, &transitionBlock);
+}
+#endif // TARGET_WASM
+
 static void DECLSPEC_NORETURN HandleInterpreterStackOverflow(InterpreterFrame* pInterpreterFrame)
 {
     CONTRACTL

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -993,7 +993,7 @@ void* DoGenericLookup(void* genericVarAsPtr, InterpGenericLookup* pLookup)
     return result;
 }
 
-extern "C" void AsyncHelpers_ResumeInterpreterContinuationWorker(QCall::ObjectHandleOnStack cont, uint8_t* resultStorage, TransitionBlock* pTransitionBlock)
+extern "C" Object* AsyncHelpers_ResumeInterpreterContinuationWorker(Object* cont, uint8_t* resultStorage, TransitionBlock* pTransitionBlock)
 {
     CONTRACTL
     {
@@ -1021,7 +1021,7 @@ extern "C" void AsyncHelpers_ResumeInterpreterContinuationWorker(QCall::ObjectHa
     }
     frames(pTransitionBlock);
 
-    CONTINUATIONREF contRef = (CONTINUATIONREF)ObjectToOBJECTREF(cont.Get());
+    CONTINUATIONREF contRef = (CONTINUATIONREF)ObjectToOBJECTREF(cont);
     NULL_CHECK(contRef);
 
     // We are working with an interpreter async continuation, move things around to get the InterpAsyncSuspendData
@@ -1072,8 +1072,10 @@ extern "C" void AsyncHelpers_ResumeInterpreterContinuationWorker(QCall::ObjectHa
         }
     }
 
-    cont.Set(frames.interpreterFrame.GetContinuation());
+    contRef = frames.interpreterFrame.GetContinuation();
     frames.interpreterFrame.Pop();
+
+    return OBJECTREFToObject(contRef);
 }
 
 static void DECLSPEC_NORETURN HandleInterpreterStackOverflow(InterpreterFrame* pInterpreterFrame)

--- a/src/coreclr/vm/interpexec.h
+++ b/src/coreclr/vm/interpexec.h
@@ -78,7 +78,7 @@ struct ExceptionClauseArgs
 };
 
 void InterpExecMethod(InterpreterFrame *pInterpreterFrame, InterpMethodContextFrame *pFrame, InterpThreadContext *pThreadContext, ExceptionClauseArgs *pExceptionClauseArgs = NULL);
-extern "C" void AsyncHelpers_ResumeInterpreterContinuation(QCall::ObjectHandleOnStack cont, uint8_t* resultStorage);
+extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuation(ContinuationObject* cont, uint8_t* resultStorage);
 
 extern "C" void LookupMethodByName(const char* fullQualifiedTypeName, const char* methodName, MethodDesc** ppMD);
 extern "C" void ExecuteInterpretedMethodFromUnmanaged(MethodDesc* pMD, int8_t* args, size_t argSize, int8_t* ret, PCODE callerIp);

--- a/src/coreclr/vm/interpexec.h
+++ b/src/coreclr/vm/interpexec.h
@@ -78,7 +78,7 @@ struct ExceptionClauseArgs
 };
 
 void InterpExecMethod(InterpreterFrame *pInterpreterFrame, InterpMethodContextFrame *pFrame, InterpThreadContext *pThreadContext, ExceptionClauseArgs *pExceptionClauseArgs = NULL);
-extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuation(ContinuationObject* cont, uint8_t* resultStorage);
+EXTERN_C FCDECL2(ContinuationObject*, AsyncHelpers_ResumeInterpreterContinuation, ContinuationObject* cont, uint8_t* resultStorage);
 
 extern "C" void LookupMethodByName(const char* fullQualifiedTypeName, const char* methodName, MethodDesc** ppMD);
 extern "C" void ExecuteInterpretedMethodFromUnmanaged(MethodDesc* pMD, int8_t* args, size_t argSize, int8_t* ret, PCODE callerIp);

--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -269,7 +269,6 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
     if (updateFloats)
     {
         UpdateFloatingPointRegisters(pRD, GetSP());
-        _ASSERTE(pRD->pCurrentContext->Pc == GetReturnAddress());
     }
 #endif // DACCESS_COMPILE
 

--- a/src/coreclr/vm/loongarch64/stubs.cpp
+++ b/src/coreclr/vm/loongarch64/stubs.cpp
@@ -349,7 +349,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 #ifndef DACCESS_COMPILE
     if (updateFloats)
     {
-        UpdateFloatingPointRegisters(pRD);
+        UpdateFloatingPointRegisters(pRD, dac_cast<TADDR>(GetCallSiteSP()));
     }
 #endif // DACCESS_COMPILE
 

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -541,7 +541,7 @@ static const Entry s_QCall[] =
     DllImportEntry(SystemJS_ScheduleBackgroundJob)
 #endif // TARGET_BROWSER
 #ifdef FEATURE_INTERPRETER
-    DllImportEntry(AsyncHelpers_ResumeInterpreterContinuation)
+//    DllImportEntry(AsyncHelpers_ResumeInterpreterContinuation)
 #endif // FEATURE_INTERPRETER
 };
 

--- a/src/coreclr/vm/qcallentrypoints.cpp
+++ b/src/coreclr/vm/qcallentrypoints.cpp
@@ -540,9 +540,6 @@ static const Entry s_QCall[] =
     DllImportEntry(SystemJS_ScheduleTimer)
     DllImportEntry(SystemJS_ScheduleBackgroundJob)
 #endif // TARGET_BROWSER
-#ifdef FEATURE_INTERPRETER
-//    DllImportEntry(AsyncHelpers_ResumeInterpreterContinuation)
-#endif // FEATURE_INTERPRETER
 };
 
 const void* QCallResolveDllImport(const char* name)

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -2592,7 +2592,7 @@ LEAF_END Store_FA7
 // ------------------------------------------------------------------
 NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
 
-    PROLOG_WITH_TRANSITION_BLOCK
+    PROLOG_WITH_TRANSITION_BLOCK PushCalleeSavedFloats=1
 
     // Pass TransitionBlock* as last (6th) argument
     // Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
@@ -2606,5 +2606,30 @@ NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
     EPILOG_WITH_TRANSITION_BLOCK_RETURN
 
 NESTED_END CallInterpreterFunclet, _TEXT
+
+// ------------------------------------------------------------------
+// Resume an interpreter continuation after an async await.
+// The worker function will restore callee-saved registers from the
+// TransitionBlock.
+//
+// extern "C" void AsyncHelpers_ResumeInterpreterContinuation(
+//     QCall::ObjectHandleOnStack cont,  // a0
+//     uint8_t* resultStorage             // a1
+// );
+// ------------------------------------------------------------------
+NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation, _TEXT, NoHandler
+
+    PROLOG_WITH_TRANSITION_BLOCK PushCalleeSavedFloats=1
+
+    // Worker signature: AsyncHelpers_ResumeInterpreterContinuationWorker(cont, resultStorage, TransitionBlock*)
+    // a0, a1 remain unchanged
+
+    addi    a2, sp, __PWTB_TransitionBlock     // TransitionBlock* as 3rd param (a2)
+
+    call    C_FUNC(AsyncHelpers_ResumeInterpreterContinuationWorker)
+
+    EPILOG_WITH_TRANSITION_BLOCK_RETURN
+
+NESTED_END AsyncHelpers_ResumeInterpreterContinuation, _TEXT
 
 #endif // FEATURE_INTERPRETER

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -1403,7 +1403,7 @@ NESTED_END CallJittedMethodRetIntFloat, _TEXT
 
 NESTED_ENTRY InterpreterStub, _TEXT, NoHandler
 
-    PROLOG_WITH_TRANSITION_BLOCK
+    PROLOG_WITH_TRANSITION_BLOCK pushCalleeSavedFloatRegs=1
 
     // IR bytecode address
     mv t6, METHODDESC_REGISTER
@@ -2592,7 +2592,7 @@ LEAF_END Store_FA7
 // ------------------------------------------------------------------
 NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
 
-    PROLOG_WITH_TRANSITION_BLOCK PushCalleeSavedFloats=1
+    PROLOG_WITH_TRANSITION_BLOCK pushCalleeSavedFloatRegs=1
 
     // Pass TransitionBlock* as last (6th) argument
     // Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
@@ -2619,7 +2619,7 @@ NESTED_END CallInterpreterFunclet, _TEXT
 // ------------------------------------------------------------------
 NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation, _TEXT, NoHandler
 
-    PROLOG_WITH_TRANSITION_BLOCK PushCalleeSavedFloats=1
+    PROLOG_WITH_TRANSITION_BLOCK pushCalleeSavedFloatRegs=1
 
     // Worker signature: AsyncHelpers_ResumeInterpreterContinuationWorker(cont, resultStorage, TransitionBlock*)
     // a0, a1 remain unchanged

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -2612,10 +2612,8 @@ NESTED_END CallInterpreterFunclet, _TEXT
 // The worker function will restore callee-saved registers from the
 // TransitionBlock.
 //
-// extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuation(
-//     ContinuationObject* cont,          // x0
-//     uint8_t* resultStorage             // x1
-// );
+// FCDECL2(ContinuationObject*, AsyncHelpers_ResumeInterpreterContinuation, ContinuationObject* cont, uint8_t* resultStorage);
+//
 // ------------------------------------------------------------------
 NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation, _TEXT, NoHandler
 

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -2612,9 +2612,9 @@ NESTED_END CallInterpreterFunclet, _TEXT
 // The worker function will restore callee-saved registers from the
 // TransitionBlock.
 //
-// extern "C" void AsyncHelpers_ResumeInterpreterContinuation(
-//     QCall::ObjectHandleOnStack cont,  // a0
-//     uint8_t* resultStorage             // a1
+// extern "C" ContinuationObject* AsyncHelpers_ResumeInterpreterContinuation(
+//     ContinuationObject* cont,          // x0
+//     uint8_t* resultStorage             // x1
 // );
 // ------------------------------------------------------------------
 NESTED_ENTRY AsyncHelpers_ResumeInterpreterContinuation, _TEXT, NoHandler

--- a/src/coreclr/vm/riscv64/asmhelpers.S
+++ b/src/coreclr/vm/riscv64/asmhelpers.S
@@ -2578,4 +2578,33 @@ LEAF_ENTRY Store_FA7
     EPILOG_BRANCH_REG t4
 LEAF_END Store_FA7
 
+// ------------------------------------------------------------------
+// Create a real TransitionBlock and call CallInterpreterFuncletWorker
+// to execute an interpreter funclet (catch/finally/filter handler).
+//
+// extern "C" DWORD_PTR CallInterpreterFunclet(
+//     OBJECTREF throwable,        // a0
+//     void* pHandler,             // a1
+//     REGDISPLAY *pRD,            // a2
+//     ExInfo *pExInfo,            // a3
+//     bool isFilter               // a4
+// );
+// ------------------------------------------------------------------
+NESTED_ENTRY CallInterpreterFunclet, _TEXT, NoHandler
+
+    PROLOG_WITH_TRANSITION_BLOCK
+
+    // Pass TransitionBlock* as last (6th) argument
+    // Worker signature: CallInterpreterFuncletWorker(throwable, pHandler, pRD, pExInfo, isFilter, TransitionBlock*)
+    // Original args: a0=throwable, a1=pHandler, a2=pRD, a3=pExInfo, a4=isFilter
+    // a0-a4 remain unchanged
+
+    addi    a5, sp, __PWTB_TransitionBlock     // TransitionBlock* as 6th param (a5)
+
+    call    C_FUNC(CallInterpreterFuncletWorker)
+
+    EPILOG_WITH_TRANSITION_BLOCK_RETURN
+
+NESTED_END CallInterpreterFunclet, _TEXT
+
 #endif // FEATURE_INTERPRETER

--- a/src/coreclr/vm/riscv64/stubs.cpp
+++ b/src/coreclr/vm/riscv64/stubs.cpp
@@ -250,14 +250,14 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
 
 #ifdef FEATURE_INTERPRETER
 #ifndef DACCESS_COMPILE
-void InterpreterFrame::UpdateFloatingPointRegisters(const PREGDISPLAY pRD)
+void InterpreterFrame::UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR targetSP)
 {
     LIMITED_METHOD_CONTRACT;
 
     // The interpreter frame saves the floating point callee-saved registers (fs0-fs11) in the TransitionBlock,
     // so we need to update them in the REGDISPLAY when we update the REGDISPLAY for an interpreter frame.
     //
-    // Stack layout when PushCalleeSavedFloats is used:
+    // Stack layout when pushCalleeSavedFloatRegs is used:
     //   [fs0-fs11 (96 bytes)] [fa0-fa7 (64 bytes)] [TransitionBlock]
     // FP callee-saved are at TransitionBlock - 160 (96 + 64)
     //

--- a/src/coreclr/vm/riscv64/stubs.cpp
+++ b/src/coreclr/vm/riscv64/stubs.cpp
@@ -223,7 +223,6 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
     if (updateFloats)
     {
         UpdateFloatingPointRegisters(pRD, GetSP());
-        _ASSERTE(pRD->pCurrentContext->Pc == GetReturnAddress());
     }
 #endif // DACCESS_COMPILE
 

--- a/src/coreclr/vm/riscv64/stubs.cpp
+++ b/src/coreclr/vm/riscv64/stubs.cpp
@@ -250,7 +250,7 @@ void TransitionFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateFl
 
 #ifdef FEATURE_INTERPRETER
 #ifndef DACCESS_COMPILE
-void InterpreterFrame::UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR targetSP)
+void InterpreterFrame::UpdateFloatingPointRegisters_Impl(const PREGDISPLAY pRD, TADDR)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -337,7 +337,7 @@ void InlinedCallFrame::UpdateRegDisplay_Impl(const PREGDISPLAY pRD, bool updateF
 #ifndef DACCESS_COMPILE
     if (updateFloats)
     {
-        UpdateFloatingPointRegisters(pRD);
+        UpdateFloatingPointRegisters(pRD, dac_cast<TADDR>(GetCallSiteSP()));
     }
 #endif // DACCESS_COMPILE
 

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -2155,6 +2155,7 @@ StackWalkAction StackFrameIterator::NextRaw(void)
             goto Cleanup;
         }
 
+#ifdef FEATURE_INTERPRETER
         if (GetIP(m_crawl.pRD->pCurrentContext) == InterpreterFrame::DummyCallerIP)
         {
             PTR_InterpreterFrame pInterpreterFrame = dac_cast<PTR_InterpreterFrame>(GetSP(m_crawl.pRD->pCurrentContext));
@@ -2162,6 +2163,7 @@ StackWalkAction StackFrameIterator::NextRaw(void)
             pInterpreterFrame->UpdateRegDisplay(m_crawl.pRD, m_flags & UNWIND_FLOATS);
             m_crawl.GotoNextFrame();
         }
+#endif // FEATURE_INTERPRETER
 
 #define FAIL_IF_SPECULATIVE_WALK(condition)             \
         if (m_flags & PROFILER_DO_STACK_SNAPSHOT)       \
@@ -2421,9 +2423,7 @@ void StackFrameIterator::ProcessCurrentFrame(void)
                 _ASSERTE(GetIP(pRD->pCurrentContext) != (PCODE)InterpreterFrame::DummyCallerIP);
                 // We have hit the InterpreterFrame while we were not processing the interpreter frames.
                 // Switch to walking the underlying interpreted frames.
-                // Save the registers the interpreter frames walking reuses so that we can restore them
-                // after we are done with the interpreter frames.
-                LOG((LF_GCROOTS, LL_INFO10000, "STACKWALK: Switching to interpreted frames for InterpreterFrame %p, saving SP=%p, IP=%p\n", m_crawl.pFrame, GetIP(pRD->pCurrentContext), GetSP(pRD->pCurrentContext)));
+                LOG((LF_GCROOTS, LL_INFO10000, "STACKWALK: Switching to interpreted frames for InterpreterFrame %p\n"));
                 ((PTR_InterpreterFrame)m_crawl.pFrame)->SetContextToInterpMethodContextFrame(pRD->pCurrentContext);
                 if (pRD->pCurrentContext->ContextFlags & CONTEXT_EXCEPTION_ACTIVE)
                 {

--- a/src/coreclr/vm/stackwalk.cpp
+++ b/src/coreclr/vm/stackwalk.cpp
@@ -2423,7 +2423,7 @@ void StackFrameIterator::ProcessCurrentFrame(void)
                 _ASSERTE(GetIP(pRD->pCurrentContext) != (PCODE)InterpreterFrame::DummyCallerIP);
                 // We have hit the InterpreterFrame while we were not processing the interpreter frames.
                 // Switch to walking the underlying interpreted frames.
-                LOG((LF_GCROOTS, LL_INFO10000, "STACKWALK: Switching to interpreted frames for InterpreterFrame %p\n"));
+                LOG((LF_GCROOTS, LL_INFO10000, "STACKWALK: Switching to interpreted frames for InterpreterFrame %p\n", m_crawl.pFrame));
                 ((PTR_InterpreterFrame)m_crawl.pFrame)->SetContextToInterpMethodContextFrame(pRD->pCurrentContext);
                 if (pRD->pCurrentContext->ContextFlags & CONTEXT_EXCEPTION_ACTIVE)
                 {

--- a/src/coreclr/vm/stackwalk.h
+++ b/src/coreclr/vm/stackwalk.h
@@ -639,18 +639,6 @@ private:
     bool          m_isRuntimeWrappedExceptions;
     // Indicates that the stack walk has moved past a funclet
     bool          m_fFoundFirstFunclet;
-#ifdef FEATURE_INTERPRETER
-    // Saved registers of the context of the InterpExecMethod. These registers are reused for interpreter frames,
-    // but we need to restore the original values after we are done with all the interpreted frames belonging to
-    // that InterpExecMethod.
-    TADDR         m_interpExecMethodIP;
-    TADDR         m_interpExecMethodSP;
-    TADDR         m_interpExecMethodFP;
-    TADDR         m_interpExecMethodFirstArgReg;
-#if defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
-    TADDR         m_interpExecMethodSSP;
-#endif // TARGET_AMD64 && TARGET_WINDOWS
-#endif // FEATURE_INTERPRETER
 
     LPVOID m_pvResumableFrameTargetSP;
     ExInfo* m_pNextExInfo;


### PR DESCRIPTION
Currently, the transition from the topmost interpreted frame belonging to
an `InterpreterFrame` to the managed / native caller is not hidden in
the stack frame iterator, but exposed internally. The iterator returns
a frame with instruction pointer set to a dummy value, the
`InterpreterFrame::DummyCallerIP`. The EH code then handles that 
in a special way in the `SfiNextWorker` to detect transitions to native
calling code.

This PR changes that so that this is completely hidden in the stack frame
iterator and all the special handling in the EH code is removed.

Another change this PR makes is to get rid of the saved SP, IP and FP
when transitioning to interpreted frames and from them. That was 
complicating implementation of debugger single stepping. The way 
to achieve that is to always have transition frame for interpreter invocation
and to extend that transition frame by callee saved floating point registers.
This also removes the need to use virtual unwinding to restore the callee
saved floating point register values when moving out of interpreted
frames under an `InterpreterFrame`. This is in line with another effort
that is trying to reduce and possibly remove usage of libunwind.
I had to change the `AsyncHelpers_ResumeInterpreterContinuation`
from a QCALL to an asm helper to let it also have valid transition block.
Also the interpreted EH funclets are now called through an asm helper
for the same reason. Before that, both of these cases used NULL transition
block and needed to handle it in a special way.
