### PR TITLE
Remove RequiresProcessIsolation from AsyncCovariantReturn

### DIFF
--- a/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/AsyncCovariantReturn.csproj
+++ b/src/tests/Loader/classloader/MethodImpl/CovariantReturns/UnitTest/AsyncCovariantReturn.csproj
@@ -1,7 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <RequiresProcessIsolation>true</RequiresProcessIsolation>
-  </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />
   </ItemGroup>


### PR DESCRIPTION
We should probably just delete this test when tests for #124238 are added, but let's at least make it less expensive for now.