### PR TITLE
Fix failed ElidedBoundsChecks test

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1388,9 +1388,7 @@ AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
 
             // Additionally, check for the pattern of "VN + const == checkedBndVN" and register "VN" as well.
             ValueNum addOpVN;
-            int      addOpCns;
-            if ((newAssertion.GetOp2().GetCheckedBoundConstant() == 0) &&
-                vnStore->IsVNBinFuncWithConst(newAssertion.GetOp1().GetVN(), VNF_ADD, &addOpVN, &addOpCns))
+            if (vnStore->IsVNBinFuncWithConst<int>(newAssertion.GetOp1().GetVN(), VNF_ADD, &addOpVN, nullptr))
             {
                 mayHaveDuplicates |= optAssertionHasAssertionsForVN(addOpVN, /* addIfNotFound */ canAddNewAssertions);
             }

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -1385,6 +1385,15 @@ AssertionIndex Compiler::optAddAssertion(const AssertionDsc& newAssertion)
         {
             mayHaveDuplicates |= optAssertionHasAssertionsForVN(newAssertion.GetOp2().GetCheckedBound(),
                                                                 /* addIfNotFound */ canAddNewAssertions);
+
+            // Additionally, check for the pattern of "VN + const == checkedBndVN" and register "VN" as well.
+            ValueNum addOpVN;
+            int      addOpCns;
+            if ((newAssertion.GetOp2().GetCheckedBoundConstant() == 0) &&
+                vnStore->IsVNBinFuncWithConst(newAssertion.GetOp1().GetVN(), VNF_ADD, &addOpVN, &addOpCns))
+            {
+                mayHaveDuplicates |= optAssertionHasAssertionsForVN(addOpVN, /* addIfNotFound */ canAddNewAssertions);
+            }
         }
 
         if (mayHaveDuplicates)


### PR DESCRIPTION
Bad merge of two PRs at once.
https://github.com/dotnet/runtime/pull/124132 - introduced a VN cache to find out if we have any assertions for a VN. And https://github.com/dotnet/runtime/pull/124242 introduced a VN decomposition inside MergeEdgeAssertion loop where it tries to match VNF_ADD(X, CNS). So the fix is to register VNF_ADD's op1 VN as well.

As the result, https://github.com/dotnet/runtime/pull/124242 couldn't find the matching assertion and the FILECHECK test failed due to bounds check in the codegen.