### PR TITLE
[cDAC] Magic enums - add comments to native code where they are defined so that we know to version the cDAC when they change. Also prune unused or suboptimal enums from cDAC.

### DIFF
--- a/docs/design/datacontracts/Loader.md
+++ b/docs/design/datacontracts/Loader.md
@@ -118,7 +118,7 @@ TargetPointer GetDynamicIL(ModuleHandle handle, uint token);
 | `Assembly` | `IsDynamic` | Flag indicating if this module is dynamic |
 | `Assembly` | `Error` | Pointer to exception. No error if nullptr |
 | `Assembly` | `NotifyFlags` | Flags relating to the debugger/profiler notification state of the assembly |
-| `Assembly` | `Level` | File load level of the assembly |
+| `Assembly` | `IsLoaded` | Whether assembly has been loaded |
 | `PEAssembly` | `PEImage` | Pointer to the PEAssembly's PEImage |
 | `PEAssembly` | `AssemblyBinder` | Pointer to the PEAssembly's binder |
 | `AssemblyBinder` | `AssemblyLoadContext` | Pointer to the AssemblyBinder's AssemblyLoadContext |
@@ -170,7 +170,6 @@ TargetPointer GetDynamicIL(ModuleHandle handle, uint token);
 ### Contract Constants:
 | Name | Type | Purpose | Value |
 | --- | --- | --- | --- |
-| `ASSEMBLY_LEVEL_LOADED` | uint | The value of Assembly Level required for an Assembly to be considered loaded. In the runtime, this is `FILE_LOAD_DELIVER_EVENTS` | `0x4` |
 | `ASSEMBLY_NOTIFYFLAGS_PROFILER_NOTIFIED` | uint | Flag in Assembly NotifyFlags indicating the Assembly will notify profilers. | `0x1` |
 
 Contracts used:
@@ -248,7 +247,7 @@ IEnumerable<ModuleHandle> GetModuleHandles(TargetPointer appDomain, AssemblyIter
             // IncludeAvailableToProfilers contains some loaded AND loading
             // assemblies.
         }
-        else if (assembly.Level >= ASSEMBLY_LEVEL_LOADED)
+        else if (assembly.IsLoaded)
         {
             if (!iterationFlags.HasFlag(AssemblyIterationFlags.IncludeLoaded))
             {
@@ -612,7 +611,7 @@ bool IsAssemblyLoaded(ModuleHandle handle)
 {
     TargetPointer assembly = target.ReadPointer(handle.Address + /*Module::Assembly*/);
     uint loadLevel = target.Read<uint>(assembly + /* Assembly::Level*/);
-    return assembly.Level >= ASSEMBLY_LEVEL_LOADED;
+    return assembly.IsLoaded;
 }
 
 TargetPointer GetGlobalLoaderAllocator()

--- a/docs/design/datacontracts/Loader.md
+++ b/docs/design/datacontracts/Loader.md
@@ -610,8 +610,8 @@ bool IsDynamic(ModuleHandle handle)
 bool IsAssemblyLoaded(ModuleHandle handle)
 {
     TargetPointer assembly = target.ReadPointer(handle.Address + /*Module::Assembly*/);
-    uint loadLevel = target.Read<uint>(assembly + /* Assembly::Level*/);
-    return assembly.IsLoaded;
+    bool isLoaded = target.Read<byte>(assembly + /* Assembly::IsLoaded*/) != 0;
+    return isLoaded;
 }
 
 TargetPointer GetGlobalLoaderAllocator()

--- a/docs/design/datacontracts/ReJIT.md
+++ b/docs/design/datacontracts/ReJIT.md
@@ -55,13 +55,9 @@ public enum RejitFlags : uint
 {
     kStateRequested = 0x00000000,
 
-    kStateGettingReJITParameters = 0x00000001,
-
     kStateActive = 0x00000002,
 
-    kStateMask = 0x0000000F,
-
-    kSuppressParams = 0x80000000
+    kStateMask = 0x0000000F
 }
 
 bool IsEnabled()

--- a/docs/design/datacontracts/enums.md
+++ b/docs/design/datacontracts/enums.md
@@ -1,0 +1,3 @@
+# Enums
+
+There are several enums that the cDAC depends on the values of. These are to be commented in the native code; anyone who tries to change the numerical value of these enums should see these comments and know to version the cDAC. The comments start with `[cDAC] [<Contract Name>]` so that they can be easily searched by contract name.

--- a/src/coreclr/inc/cordebuginfo.h
+++ b/src/coreclr/inc/cordebuginfo.h
@@ -37,7 +37,7 @@ public:
     // a sequence point will also be a stack_empty point, and/or a call site.
     // The debugger will check to see if a boundary offset's source field &
     // SEQUENCE_POINT is true to determine if the boundary is a sequence point.
-    // DebugInfo cDAC contract depends on the values of SOURCE_TYPE_INVALID, STACK_EMPTY, CALL_INSTRUCTION, and ASYNC.
+    // [cDAC] [DebugInfo]: Contract depends on the values of SOURCE_TYPE_INVALID, STACK_EMPTY, CALL_INSTRUCTION, and ASYNC.
 
     enum SourceTypes
     {

--- a/src/coreclr/inc/cordebuginfo.h
+++ b/src/coreclr/inc/cordebuginfo.h
@@ -37,6 +37,7 @@ public:
     // a sequence point will also be a stack_empty point, and/or a call site.
     // The debugger will check to see if a boundary offset's source field &
     // SEQUENCE_POINT is true to determine if the boundary is a sequence point.
+    // DebugInfo cDAC contract depends on the values of SOURCE_TYPE_INVALID, STACK_EMPTY, CALL_INSTRUCTION, and ASYNC.
 
     enum SourceTypes
     {

--- a/src/coreclr/inc/corhdr.h
+++ b/src/coreclr/inc/corhdr.h
@@ -869,7 +869,6 @@ typedef char * MDUTF8STR;
 //
 //*****************************************************************************
 
-// RuntimeTypeSystem cDAC contract depends on the values of this enum.
 
 typedef enum CorElementType
 {
@@ -914,6 +913,7 @@ typedef enum CorElementType
     ELEMENT_TYPE_CMOD_OPT       = 0x20,     // optional C modifier : E_T_CMOD_OPT <mdTypeRef/mdTypeDef>
 
     // This is for signatures generated internally (which will not be persisted in any way).
+    // [cDAC] [RuntimeTypeSystem]: Contract depends on the values of ELEMENT_TYPE_INTERNAL and ELEMENT_TYPE_CMOD_INTERNAL.
     ELEMENT_TYPE_INTERNAL       = 0x21,     // INTERNAL <typehandle>
     ELEMENT_TYPE_CMOD_INTERNAL  = 0x22,     // CMOD_INTERNAL <required (1 byte: non-zero if required, 0 if optional)> <typehandle>
 

--- a/src/coreclr/inc/corhdr.h
+++ b/src/coreclr/inc/corhdr.h
@@ -869,6 +869,8 @@ typedef char * MDUTF8STR;
 //
 //*****************************************************************************
 
+// RuntimeTypeSystem cDAC contract depends on the values of this enum.
+
 typedef enum CorElementType
 {
     ELEMENT_TYPE_END            = 0x00,

--- a/src/coreclr/inc/corprof.idl
+++ b/src/coreclr/inc/corprof.idl
@@ -514,6 +514,7 @@ typedef enum
     // NOTE: ReJIT is now supported again.  The profiler must set this flag on
     // startup in order to use RequestReJIT or RequestRevert.  If the profiler specifies
     // this flag, then the profiler must also specify COR_PRF_DISABLE_ALL_NGEN_IMAGES
+    // ReJIT cDAC contract depends on this enum value.
     COR_PRF_ENABLE_REJIT                = 0x00040000,
 
     // V2 MIGRATION WARNING: DEPRECATED

--- a/src/coreclr/inc/corprof.idl
+++ b/src/coreclr/inc/corprof.idl
@@ -514,7 +514,7 @@ typedef enum
     // NOTE: ReJIT is now supported again.  The profiler must set this flag on
     // startup in order to use RequestReJIT or RequestRevert.  If the profiler specifies
     // this flag, then the profiler must also specify COR_PRF_DISABLE_ALL_NGEN_IMAGES
-    // ReJIT cDAC contract depends on this enum value.
+    // [cDAC] [ReJIT]: Contract depends on this enum value.
     COR_PRF_ENABLE_REJIT                = 0x00040000,
 
     // V2 MIGRATION WARNING: DEPRECATED

--- a/src/coreclr/inc/pedecoder.h
+++ b/src/coreclr/inc/pedecoder.h
@@ -387,9 +387,9 @@ class PEDecoder
     // Instance members
     // ------------------------------------------------------------
 
-    // Loader cDAC contract depends on the value of FLAG_MAPPED.
     enum
     {
+        // [cDAC] [Loader]: Contract depends on the value of FLAG_MAPPED.
         FLAG_MAPPED             = 0x01, // the file is mapped/hydrated (vs. the raw disk layout)
         FLAG_CONTENTS           = 0x02, // the file has contents
         FLAG_RELOCATED          = 0x04, // relocs have been applied

--- a/src/coreclr/inc/pedecoder.h
+++ b/src/coreclr/inc/pedecoder.h
@@ -387,6 +387,7 @@ class PEDecoder
     // Instance members
     // ------------------------------------------------------------
 
+    // Loader cDAC contract depends on the value of FLAG_MAPPED.
     enum
     {
         FLAG_MAPPED             = 0x01, // the file is mapped/hydrated (vs. the raw disk layout)

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -446,8 +446,6 @@ enum
 // The flags can be combined so if you want all loaded assemblies, you must specify:
 //
 ///     kIncludeLoaded|kIncludeExecution
-/// Loader cDAC contract depends on the values of kIncludeLoaded, kIncludeLoading, kIncludeAvailableToProfilers,
-/// kIncludeExecution, kIncludeFailedToLoad, kExcludeCollectible, and kIncludeCollected.
 
 enum AssemblyIterationFlags
 {

--- a/src/coreclr/vm/appdomain.hpp
+++ b/src/coreclr/vm/appdomain.hpp
@@ -446,6 +446,8 @@ enum
 // The flags can be combined so if you want all loaded assemblies, you must specify:
 //
 ///     kIncludeLoaded|kIncludeExecution
+/// Loader cDAC contract depends on the values of kIncludeLoaded, kIncludeLoading, kIncludeAvailableToProfilers,
+/// kIncludeExecution, kIncludeFailedToLoad, kExcludeCollectible, and kIncludeCollected.
 
 enum AssemblyIterationFlags
 {

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -129,6 +129,7 @@ Assembly::Assembly(PEAssembly* pPEAssembly, LoaderAllocator *pLoaderAllocator)
 #endif
     , m_isDynamic(false)
     , m_isLoading{true}
+    , m_isLoaded{false}
     , m_isTerminated{false}
     , m_level{FILE_LOAD_CREATE}
     , m_notifyFlags{NOT_NOTIFIED}

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -516,7 +516,7 @@ Assembly *Assembly::CreateDynamic(AssemblyBinder* pBinder, NativeAssemblyNamePar
         pAssem->DeliverAsyncEvents();
         pAssem->FinishLoad();
         pAssem->ClearLoading();
-        pAssem->m_level = FILE_ACTIVE;
+        pAssem->SetLoadLevel(FILE_ACTIVE);
     }
 
     {
@@ -2303,7 +2303,7 @@ void Assembly::FinishLoad()
     CONTRACTL_END;
 
     // Must set this a bit prematurely for the DAC stuff to work
-    m_level = FILE_LOADED;
+    SetLoadLevel(FILE_LOADED);
 
     // Now the DAC can find this module by enumerating assemblies in a domain.
     DACNotify::DoModuleLoadNotification(m_pModule);

--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -62,6 +62,7 @@ public:
 
     // Loaded means that the file can be used passively. This includes loading types, reflection,
     // and jitting.
+    // Loader cDAC contract depends on the logic of this method.
     bool IsLoaded() { LIMITED_METHOD_DAC_CONTRACT; return m_level >= FILE_LOAD_DELIVER_EVENTS; }
 
     // Active means that the file can be used actively. This includes code execution, static field

--- a/src/coreclr/vm/assembly.hpp
+++ b/src/coreclr/vm/assembly.hpp
@@ -62,8 +62,7 @@ public:
 
     // Loaded means that the file can be used passively. This includes loading types, reflection,
     // and jitting.
-    // Loader cDAC contract depends on the logic of this method.
-    bool IsLoaded() { LIMITED_METHOD_DAC_CONTRACT; return m_level >= FILE_LOAD_DELIVER_EVENTS; }
+    bool IsLoaded() { LIMITED_METHOD_DAC_CONTRACT; return m_isLoaded; }
 
     // Active means that the file can be used actively. This includes code execution, static field
     // access, and instance allocation.
@@ -84,7 +83,12 @@ public:
     BOOL DoIncrementalLoad(FileLoadLevel targetLevel);
 
     void ClearLoading() { LIMITED_METHOD_CONTRACT; m_isLoading = false; }
-    void SetLoadLevel(FileLoadLevel level) { LIMITED_METHOD_CONTRACT; m_level = level; }
+    void SetLoadLevel(FileLoadLevel level)
+    {
+        LIMITED_METHOD_CONTRACT;
+        m_level = level;
+        m_isLoaded = (level >= FILE_LOAD_DELIVER_EVENTS);
+    }
 
     BOOL NotifyDebuggerLoad(int flags, BOOL attaching);
     void NotifyDebuggerUnload();
@@ -526,6 +530,7 @@ private:
 
     // Load state tracking
     bool            m_isLoading;
+    bool            m_isLoaded;
     bool            m_isTerminated;
     FileLoadLevel   m_level;
     DWORD           m_notifyFlags;
@@ -554,7 +559,7 @@ struct cdac_data<Assembly>
     static constexpr size_t Module = offsetof(Assembly, m_pModule);
     static constexpr size_t Error = offsetof(Assembly, m_pError);
     static constexpr size_t NotifyFlags = offsetof(Assembly, m_notifyFlags);
-    static constexpr size_t Level = offsetof(Assembly, m_level);
+    static constexpr size_t IsLoaded = offsetof(Assembly, m_isLoaded);
 };
 
 #ifndef DACCESS_COMPILE

--- a/src/coreclr/vm/assemblyspec.hpp
+++ b/src/coreclr/vm/assemblyspec.hpp
@@ -40,7 +40,7 @@ enum FileLoadLevel
     FILE_ACTIVE                     // Fully active (constructors run & security checked)
 };
 
-// Loader cDAC contract depends on the value of PROFILER_NOTIFIED.
+// [cDAC] [Loader]: Contract depends on the value of PROFILER_NOTIFIED.
 enum NotificationStatus
 {
     NOT_NOTIFIED=0,

--- a/src/coreclr/vm/assemblyspec.hpp
+++ b/src/coreclr/vm/assemblyspec.hpp
@@ -40,6 +40,7 @@ enum FileLoadLevel
     FILE_ACTIVE                     // Fully active (constructors run & security checked)
 };
 
+// Loader cDAC contract depends on the value of PROFILER_NOTIFIED.
 enum NotificationStatus
 {
     NOT_NOTIFIED=0,

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -620,6 +620,7 @@ private:
 
     enum {
         // These are the values set in m_dwTransientFlags.
+        // Loader cDAC contract depends on the values of MODULE_IS_TENURED, IS_EDIT_AND_CONTINUE, and IS_REFLECTION_EMIT.
 
         MODULE_IS_TENURED           = 0x00000001,   // Set once we know for sure the Module will not be freed until the appdomain itself exits
         // unused                   = 0x00000002,

--- a/src/coreclr/vm/ceeload.h
+++ b/src/coreclr/vm/ceeload.h
@@ -620,7 +620,7 @@ private:
 
     enum {
         // These are the values set in m_dwTransientFlags.
-        // Loader cDAC contract depends on the values of MODULE_IS_TENURED, IS_EDIT_AND_CONTINUE, and IS_REFLECTION_EMIT.
+        // [cDAC] [Loader]: Contract depends on the values of MODULE_IS_TENURED, IS_EDIT_AND_CONTINUE, and IS_REFLECTION_EMIT.
 
         MODULE_IS_TENURED           = 0x00000001,   // Set once we know for sure the Module will not be freed until the appdomain itself exits
         // unused                   = 0x00000002,

--- a/src/coreclr/vm/codeversion.h
+++ b/src/coreclr/vm/codeversion.h
@@ -147,6 +147,7 @@ private:
 
 #ifdef FEATURE_CODE_VERSIONING
 
+// ReJIT cDAC contract depends on the values of kStateRequested, kStateGettingReJITParameters, kStateActive, kStateMask, and kSuppressParams.
 enum class RejitFlags : uint32_t
 {
     // The profiler has requested a ReJit, so we've allocated stuff, but we haven't
@@ -315,6 +316,7 @@ private:
     DAC_IGNORE(const) unsigned m_ilOffset;
 #endif
 
+    // CodeVersions cDAC contract depends on the value of IsActiveChildFlag.
     enum NativeCodeVersionNodeFlags
     {
         IsActiveChildFlag = 1
@@ -496,6 +498,7 @@ public:
 private:
     PTR_MethodDesc m_pMethodDesc;
 
+    // CodeVersions cDAC contract depends on the value of IsDefaultVersionActiveChildFlag.
     enum MethodDescVersioningStateFlags
     {
         IsDefaultVersionActiveChildFlag = 0x4

--- a/src/coreclr/vm/codeversion.h
+++ b/src/coreclr/vm/codeversion.h
@@ -147,13 +147,13 @@ private:
 
 #ifdef FEATURE_CODE_VERSIONING
 
-// ReJIT cDAC contract depends on the values of kStateRequested, kStateGettingReJITParameters, kStateActive, kStateMask, and kSuppressParams.
 enum class RejitFlags : uint32_t
 {
     // The profiler has requested a ReJit, so we've allocated stuff, but we haven't
     // called back to the profiler to get any info or indicate that the ReJit has
     // started. (This Info can be 'reused' for a new ReJit if the
     // profiler calls RequestRejit again before we transition to the next state.)
+    // [cDAC] [ReJIT]: Contract depends on this value.
     kStateRequested = 0x00000000,
 
     // The CLR has initiated the call to the profiler's GetReJITParameters() callback
@@ -165,8 +165,10 @@ enum class RejitFlags : uint32_t
 
     // We have asked the profiler about this method via ICorProfilerFunctionControl,
     // and have thus stored the IL and codegen flags the profiler specified.
+    // [cDAC] [ReJIT]: Contract depends on this value.
     kStateActive = 0x00000002,
 
+    // [cDAC] [ReJIT]: Contract depends on this value.
     kStateMask = 0x0000000F,
 
     // Indicates that the method being ReJITted is an inliner of the actual
@@ -316,7 +318,7 @@ private:
     DAC_IGNORE(const) unsigned m_ilOffset;
 #endif
 
-    // CodeVersions cDAC contract depends on the value of IsActiveChildFlag.
+    // [cDAC] [CodeVersions]: Contract depends on the value of IsActiveChildFlag.
     enum NativeCodeVersionNodeFlags
     {
         IsActiveChildFlag = 1
@@ -498,7 +500,7 @@ public:
 private:
     PTR_MethodDesc m_pMethodDesc;
 
-    // CodeVersions cDAC contract depends on the value of IsDefaultVersionActiveChildFlag.
+    // [cDAC] [CodeVersions]: Contract depends on the value of IsDefaultVersionActiveChildFlag.
     enum MethodDescVersioningStateFlags
     {
         IsDefaultVersionActiveChildFlag = 0x4

--- a/src/coreclr/vm/datadescriptor/datadescriptor.inc
+++ b/src/coreclr/vm/datadescriptor/datadescriptor.inc
@@ -205,7 +205,7 @@ CDAC_TYPE_FIELD(Assembly, /*bool*/, IsDynamic, cdac_data<Assembly>::IsDynamic)
 CDAC_TYPE_FIELD(Assembly, /*pointer*/, Module, cdac_data<Assembly>::Module)
 CDAC_TYPE_FIELD(Assembly, /*pointer*/, Error, cdac_data<Assembly>::Error)
 CDAC_TYPE_FIELD(Assembly, /*uint32*/, NotifyFlags, cdac_data<Assembly>::NotifyFlags)
-CDAC_TYPE_FIELD(Assembly, /*uint32*/, Level, cdac_data<Assembly>::Level)
+CDAC_TYPE_FIELD(Assembly, /*bool*/, IsLoaded, cdac_data<Assembly>::IsLoaded)
 CDAC_TYPE_END(Assembly)
 
 CDAC_TYPE_BEGIN(LoaderAllocator)

--- a/src/coreclr/vm/field.h
+++ b/src/coreclr/vm/field.h
@@ -44,7 +44,7 @@ class FieldDesc
 
     // See also: FieldDesc::InitializeFrom method
 
-    union { //create a union so I can get the correct offset for ClrDump. RuntimeTypeSystem cDAC contract depends on these offsets.
+    union { //create a union so I can get the correct offset for ClrDump. [cDAC] [RuntimeTypeSystem]: Contract depends on these offsets.
         unsigned m_dword1;
         struct {
         unsigned m_mb               : 24;
@@ -61,7 +61,7 @@ class FieldDesc
         struct {
         // Note: this has been as low as 22 bits in the past & seemed to be OK.
         // we can steal some more bits here if we need them.
-        // RuntimeTypeSystem cDAC contract depends on these offsets.
+        // [cDAC] [RuntimeTypeSystem]: Contract depends on these offsets.
         unsigned m_dwOffset         : 27;
         unsigned m_type             : 5;
         };

--- a/src/coreclr/vm/field.h
+++ b/src/coreclr/vm/field.h
@@ -44,7 +44,7 @@ class FieldDesc
 
     // See also: FieldDesc::InitializeFrom method
 
-    union { //create a union so I can get the correct offset for ClrDump.
+    union { //create a union so I can get the correct offset for ClrDump. RuntimeTypeSystem cDAC contract depends on these offsets.
         unsigned m_dword1;
         struct {
         unsigned m_mb               : 24;
@@ -61,6 +61,7 @@ class FieldDesc
         struct {
         // Note: this has been as low as 22 bits in the past & seemed to be OK.
         // we can steal some more bits here if we need them.
+        // RuntimeTypeSystem cDAC contract depends on these offsets.
         unsigned m_dwOffset         : 27;
         unsigned m_type             : 5;
         };

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -177,6 +177,7 @@ FORCEINLINE mdToken MergeToken(UINT16 tokrange, UINT16 tokremainder)
 // so that when a method is replaced its relevant flags are updated
 
 // Used in MethodDesc
+// RuntimeTypeSystem cDAC contract depends on the values of mcIL, mcFCall, mcPInvoke, mcEEImpl, mcArray, mcInstantiated, mcComInterop, and mcDynamic.
 enum MethodClassification
 {
     mcIL        = 0, // IL
@@ -196,6 +197,8 @@ enum MethodClassification
 
 
 // All flags in the MethodDesc now reside in a single 16-bit field.
+// RuntimeTypeSystem cDAC contract depends on the values of mdfClassification, mdfHasNonVtableSlot, mdfMethodImpl,
+// mdfHasNativeCodeSlot, and mdfHasAsyncMethodData.
 
 enum MethodDescFlags
 {
@@ -1823,6 +1826,7 @@ protected:
     {
         // There are flags available for use here (currently 4 flags bits are available); however, new bits are hard to come by, so any new flags bits should
         // have a fairly strong justification for existence.
+        // RuntimeTypeSystem cDAC contract depends on the values of enum_flag3_HasStableEntryPoint, enum_flag3_HasPrecode, enum_flag3_IsUnboxingStub, and enum_flag3_IsEligibleForTieredCompilation.
         enum_flag3_TokenRemainderMask                       = 0x0FFF, // This must equal METHOD_TOKEN_REMAINDER_MASK calculated higher in this file.
                                                                       // for this method.
         // enum_flag3_HasPrecode implies that enum_flag3_HasStableEntryPoint is set in non-portable entrypoint scenarios.
@@ -1837,6 +1841,7 @@ protected:
 
     BYTE        m_chunkIndex;
 
+    // RuntimeTypeSystem cDAC contract depends on the value of enum_flag4_TemporaryEntryPointAssigned.
     enum {
         enum_flag4_ComputedRequiresStableEntryPoint         = 0x01,
         enum_flag4_RequiresStableEntryPoint                 = 0x02,
@@ -2797,6 +2802,7 @@ public:
     DPTR(struct InterpreterPrecode) m_interpreterPrecode;
 #endif
 
+    // RuntimeTypeSystem cDAC contract depends on the values of StubPInvokeVarArg and StubCLRToCOMInterop.
     enum ILStubType : DWORD
     {
         StubNotSet = 0,
@@ -2830,6 +2836,7 @@ public:
     {
         // Flags for DynamicMethodDesc
         // Define new flags in descending order. This allows the IL type enumeration to increase naturally.
+        // RuntimeTypeSystem cDAC contract depends on the values of FlagIsLCGMethod, FlagIsILStub, and ILStubTypeMask.
         FlagNone                = 0x00000000,
         FlagPublic              = 0x00000800,
         FlagStatic              = 0x00001000,
@@ -3748,6 +3755,7 @@ public: // <TODO>make private: JITinterface.cpp accesses through this </TODO>
     PTR_Dictionary m_pPerInstInfo;  //SHARED
 
 private:
+    // RuntimeTypeSystem cDAC contract depends on the values of KindMask, GenericMethodDefinition, UnsharedMethodInstantiation, SharedMethodInstantiation, and WrapperStubWithInstantiations.
     enum
     {
         KindMask                        = 0x07,

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -177,7 +177,7 @@ FORCEINLINE mdToken MergeToken(UINT16 tokrange, UINT16 tokremainder)
 // so that when a method is replaced its relevant flags are updated
 
 // Used in MethodDesc
-// RuntimeTypeSystem cDAC contract depends on the values of mcIL, mcFCall, mcPInvoke, mcEEImpl, mcArray, mcInstantiated, mcComInterop, and mcDynamic.
+// [cDAC] [RuntimeTypeSystem]: Contract depends on the values of mcIL, mcFCall, mcPInvoke, mcEEImpl, mcArray, mcInstantiated, mcComInterop, and mcDynamic.
 enum MethodClassification
 {
     mcIL        = 0, // IL
@@ -197,7 +197,7 @@ enum MethodClassification
 
 
 // All flags in the MethodDesc now reside in a single 16-bit field.
-// RuntimeTypeSystem cDAC contract depends on the values of mdfClassification, mdfHasNonVtableSlot, mdfMethodImpl,
+// [cDAC] [RuntimeTypeSystem]: Contract depends on the values of mdfClassification, mdfHasNonVtableSlot, mdfMethodImpl,
 // mdfHasNativeCodeSlot, and mdfHasAsyncMethodData.
 
 enum MethodDescFlags
@@ -1826,7 +1826,7 @@ protected:
     {
         // There are flags available for use here (currently 4 flags bits are available); however, new bits are hard to come by, so any new flags bits should
         // have a fairly strong justification for existence.
-        // RuntimeTypeSystem cDAC contract depends on the values of enum_flag3_HasStableEntryPoint, enum_flag3_HasPrecode, enum_flag3_IsUnboxingStub, and enum_flag3_IsEligibleForTieredCompilation.
+        // [cDAC] [RuntimeTypeSystem]: Contract depends on the values of enum_flag3_HasStableEntryPoint, enum_flag3_HasPrecode, enum_flag3_IsUnboxingStub, and enum_flag3_IsEligibleForTieredCompilation.
         enum_flag3_TokenRemainderMask                       = 0x0FFF, // This must equal METHOD_TOKEN_REMAINDER_MASK calculated higher in this file.
                                                                       // for this method.
         // enum_flag3_HasPrecode implies that enum_flag3_HasStableEntryPoint is set in non-portable entrypoint scenarios.
@@ -1841,7 +1841,7 @@ protected:
 
     BYTE        m_chunkIndex;
 
-    // RuntimeTypeSystem cDAC contract depends on the value of enum_flag4_TemporaryEntryPointAssigned.
+    // [cDAC] [RuntimeTypeSystem]: Contract depends on the value of enum_flag4_TemporaryEntryPointAssigned.
     enum {
         enum_flag4_ComputedRequiresStableEntryPoint         = 0x01,
         enum_flag4_RequiresStableEntryPoint                 = 0x02,
@@ -2802,41 +2802,40 @@ public:
     DPTR(struct InterpreterPrecode) m_interpreterPrecode;
 #endif
 
-    // RuntimeTypeSystem cDAC contract depends on the values of StubPInvokeVarArg and StubCLRToCOMInterop.
+    // [cDAC] [RuntimeTypeSystem]: Contract depends on the values of StubPInvokeVarArg and StubCLRToCOMInterop.
     enum ILStubType : DWORD
     {
         StubNotSet = 0,
-        StubPInvoke,
-        StubPInvokeDelegate,
-        StubPInvokeCalli,
-        StubPInvokeVarArg,
-        StubReversePInvoke,
-        StubCLRToCOMInterop,
-        StubCOMToCLRInterop,
-        StubStructMarshalInterop,
-        StubArrayOp,
-        StubMulticastDelegate,
-        StubWrapperDelegate,
-        StubUnboxingIL,
-        StubInstantiating,
-        StubTailCallStoreArgs,
-        StubTailCallCallTarget,
+        StubPInvoke = 1,
+        StubPInvokeDelegate = 2,
+        StubPInvokeCalli = 3,
+        StubPInvokeVarArg = 4,
+        StubReversePInvoke = 5,
+        StubCLRToCOMInterop = 6,
+        StubCOMToCLRInterop = 7,
+        StubStructMarshalInterop = 8,
+        StubArrayOp = 9,
+        StubMulticastDelegate = 10,
+        StubWrapperDelegate = 11,
+        StubUnboxingIL = 12,
+        StubInstantiating = 13,
+        StubTailCallStoreArgs = 14,
+        StubTailCallCallTarget = 15,
 
-        StubVirtualStaticMethodDispatch,
-        StubDelegateShuffleThunk,
+        StubVirtualStaticMethodDispatch = 16,
+        StubDelegateShuffleThunk = 17,
 
-        StubDelegateInvokeMethod,
+        StubDelegateInvokeMethod = 18,
 
-        StubAsyncResume,
-
-        StubLast
+        StubAsyncResume = 19,
+        StubLast = 20
     };
 
     enum Flag : DWORD
     {
         // Flags for DynamicMethodDesc
         // Define new flags in descending order. This allows the IL type enumeration to increase naturally.
-        // RuntimeTypeSystem cDAC contract depends on the values of FlagIsLCGMethod, FlagIsILStub, and ILStubTypeMask.
+        // [cDAC] [RuntimeTypeSystem]: Contract depends on the values of FlagIsLCGMethod, FlagIsILStub, and ILStubTypeMask.
         FlagNone                = 0x00000000,
         FlagPublic              = 0x00000800,
         FlagStatic              = 0x00001000,
@@ -3755,7 +3754,7 @@ public: // <TODO>make private: JITinterface.cpp accesses through this </TODO>
     PTR_Dictionary m_pPerInstInfo;  //SHARED
 
 private:
-    // RuntimeTypeSystem cDAC contract depends on the values of KindMask, GenericMethodDefinition, UnsharedMethodInstantiation, SharedMethodInstantiation, and WrapperStubWithInstantiations.
+    // [cDAC] [RuntimeTypeSystem]: Contract depends on the values of KindMask, GenericMethodDefinition, UnsharedMethodInstantiation, SharedMethodInstantiation, and WrapperStubWithInstantiations.
     enum
     {
         KindMask                        = 0x07,

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -325,7 +325,7 @@ struct MethodTableAuxiliaryData
         // AS YOU ADD NEW FLAGS PLEASE CONSIDER WHETHER Generics::NewInstantiation NEEDS
         // TO BE UPDATED IN ORDER TO ENSURE THAT METHODTABLES DUPLICATED FOR GENERIC INSTANTIATIONS
         // CARRY THE CORRECT INITIAL FLAGS.
-        // RuntimeTypeSystem cDAC contract depends on the values of enum_flag_Initialized, enum_flag_IsInitError, and enum_flag_IsNotFullyLoaded.
+        // [cDAC] [RuntimeTypeSystem]: Contract depends on the values of enum_flag_Initialized, enum_flag_IsInitError, and enum_flag_IsNotFullyLoaded.
 
         enum_flag_Initialized               = 0x0001,
         enum_flag_HasCheckedCanCompareBitsOrUseFastGetHashCode  = 0x0002,  // Whether we have checked the overridden Equals or GetHashCode
@@ -3714,7 +3714,7 @@ private:
         // AS YOU ADD NEW FLAGS PLEASE CONSIDER WHETHER Generics::NewInstantiation NEEDS
         // TO BE UPDATED IN ORDER TO ENSURE THAT METHODTABLES DUPLICATED FOR GENERIC INSTANTIATIONS
         // CARRY THE CORECT FLAGS.
-        // RuntimeTypeSystem cDAC contract depends on the values of enum_flag_GenericsMask, enum_flag_GenericsMask_NonGeneric, and enum_flag_GenericsMask_TypicalInst.
+        // [cDAC] [RuntimeTypeSystem]: Contract depends on the values of enum_flag_GenericsMask, enum_flag_GenericsMask_NonGeneric, and enum_flag_GenericsMask_TypicalInst.
 
         // We are overloading the low 2 bytes of m_dwFlags to be a component size for Strings
         // and Arrays and some set of flags which we can be assured are of a specified state
@@ -3789,45 +3789,40 @@ private:
         // The following bits describe mutually exclusive locations of the type
         // in the type hierarchy.
 
-        // RuntimeTypeSystem cDAC contract depends on the values of:
-        // enum_flag_Category_Mask, enum_flag_Category_ElementTypeMask, enum_flag_Category_Array_Mask,
-        // enum_flag_Category_IfArrayThenSzArray, enum_flag_Category_Array, enum_flag_Category_ValueType,
-        // enum_flag_Category_Nullable, enum_flag_Category_PrimitiveValueType, enum_flag_Category_TruePrimitive,
-        // enum_flag_Category_Interface, enum_flag_Collectible, enum_flag_ContainsGCPointers, and enum_flag_HasComponentSize.
-        enum_flag_Category_Mask             = 0x000F0000,
+        enum_flag_Category_Mask             = 0x000F0000, // [cDAC] [RuntimeTypeSystem]: Contract depends on this value
 
         enum_flag_Category_Class            = 0x00000000,
         enum_flag_Category_Unused_1         = 0x00010000,
         enum_flag_Category_Unused_2         = 0x00020000,
         enum_flag_Category_Unused_3         = 0x00030000,
 
-        enum_flag_Category_ValueType        = 0x00040000,
+        enum_flag_Category_ValueType        = 0x00040000, // [cDAC] [RuntimeTypeSystem]: Contract depends on this value
         enum_flag_Category_ValueType_Mask   = 0x000C0000,
-        enum_flag_Category_Nullable         = 0x00050000, // sub-category of ValueType
-        enum_flag_Category_PrimitiveValueType=0x00060000, // sub-category of ValueType, Enum or primitive value type
-        enum_flag_Category_TruePrimitive    = 0x00070000, // sub-category of ValueType, Primitive (ELEMENT_TYPE_I, etc.)
+        enum_flag_Category_Nullable         = 0x00050000, // sub-category of ValueType. [cDAC] [RuntimeTypeSystem]: Contract depends on this value
+        enum_flag_Category_PrimitiveValueType=0x00060000, // sub-category of ValueType, Enum or primitive value type. [cDAC] [RuntimeTypeSystem]: Contract depends on this value
+        enum_flag_Category_TruePrimitive    = 0x00070000, // sub-category of ValueType, Primitive (ELEMENT_TYPE_I, etc.). [cDAC] [RuntimeTypeSystem]: Contract depends on this value
 
-        enum_flag_Category_Array            = 0x00080000,
-        enum_flag_Category_Array_Mask       = 0x000C0000,
+        enum_flag_Category_Array            = 0x00080000, // [cDAC] [RuntimeTypeSystem]: Contract depends on this value
+        enum_flag_Category_Array_Mask       = 0x000C0000, // [cDAC] [RuntimeTypeSystem]: Contract depends on this value
         // enum_flag_Category_IfArrayThenUnused                 = 0x00010000, // sub-category of Array
-        enum_flag_Category_IfArrayThenSzArray                   = 0x00020000, // sub-category of Array
+        enum_flag_Category_IfArrayThenSzArray                   = 0x00020000, // sub-category of Array. [cDAC] [RuntimeTypeSystem]: Contract depends on this value
 
-        enum_flag_Category_Interface        = 0x000C0000,
+        enum_flag_Category_Interface        = 0x000C0000, // [cDAC] [RuntimeTypeSystem]: Contract depends on this value
         enum_flag_Category_Unused_4         = 0x000D0000,
         enum_flag_Category_Unused_5         = 0x000E0000,
         enum_flag_Category_Unused_6         = 0x000F0000,
 
-        enum_flag_Category_ElementTypeMask  = 0x000E0000, // bits that matter for element type mask
+        enum_flag_Category_ElementTypeMask  = 0x000E0000, // bits that matter for element type mask. [cDAC] [RuntimeTypeSystem]: Contract depends on this value
 
         enum_flag_HasFinalizer                = 0x00100000, // instances require finalization. GC depends on this bit.
-        enum_flag_Collectible                 = 0x00200000, // GC depends on this bit.
+        enum_flag_Collectible                 = 0x00200000, // GC depends on this bit. [cDAC] [RuntimeTypeSystem]: Contract depends on this value
         // enum_flag_unused                   = 0x00400000,
 
 #ifdef FEATURE_64BIT_ALIGNMENT
         enum_flag_RequiresAlign8              = 0x00800000, // Type requires 8-byte alignment (only set on platforms that require this and don't get it implicitly)
 #endif
 
-        enum_flag_ContainsGCPointers          = 0x01000000, // Contains object references
+        enum_flag_ContainsGCPointers          = 0x01000000, // Contains object references. [cDAC] [RuntimeTypeSystem]: Contract depends on this value
         enum_flag_HasTypeEquivalence          = 0x02000000, // can be equivalent to another type
         enum_flag_IsTrackedReferenceWithFinalizer = 0x04000000,
         // unused                             = 0x08000000,
@@ -3836,7 +3831,7 @@ private:
         enum_flag_ContainsGenericVariables    = 0x20000000, // we cache this flag to help detect these efficiently and
                                                             // to detect this condition when restoring
         enum_flag_ComObject                   = 0x40000000, // class is a com object
-        enum_flag_HasComponentSize            = 0x80000000, // This is set if component size is used for flags.
+        enum_flag_HasComponentSize            = 0x80000000, // This is set if component size is used for flags. [cDAC] [RuntimeTypeSystem]: Contract depends on this value
 
         // Types that require non-trivial interface cast have this bit set in the category
         enum_flag_NonTrivialInterfaceCast   =  enum_flag_Category_Array
@@ -3858,7 +3853,7 @@ private:
         // AS YOU ADD NEW FLAGS PLEASE CONSIDER WHETHER Generics::NewInstantiation NEEDS
         // TO BE UPDATED IN ORDER TO ENSURE THAT METHODTABLES DUPLICATED FOR GENERIC INSTANTIATIONS
         // CARRY THE CORECT FLAGS.
-        // RuntimeTypeSystem cDAC contract depends on the value of enum_flag_DynamicStatics.
+        // [cDAC] [RuntimeTypeSystem]: Contract depends on the value of enum_flag_DynamicStatics.
 
         enum_flag_HasPerInstInfo            = 0x0001,
         enum_flag_DynamicStatics            = 0x0002,
@@ -3985,7 +3980,7 @@ private:
     PTR_MethodTableAuxiliaryData m_pAuxiliaryData;
 
     // The value of lowest two bits describe what the union contains
-    // RuntimeTypeSystem cDAC contract depends on the values of UNION_EECLASS and UNION_METHODTABLE.
+    // [cDAC] [RuntimeTypeSystem]: Contract depends on the values of UNION_EECLASS and UNION_METHODTABLE.
     enum LowBits {
         UNION_EECLASS      = 0,    //  0 - pointer to EEClass. This MethodTable is the canonical method table.
         UNION_METHODTABLE  = 1,    //  1 - pointer to canonical MethodTable.

--- a/src/coreclr/vm/methodtable.h
+++ b/src/coreclr/vm/methodtable.h
@@ -325,6 +325,7 @@ struct MethodTableAuxiliaryData
         // AS YOU ADD NEW FLAGS PLEASE CONSIDER WHETHER Generics::NewInstantiation NEEDS
         // TO BE UPDATED IN ORDER TO ENSURE THAT METHODTABLES DUPLICATED FOR GENERIC INSTANTIATIONS
         // CARRY THE CORRECT INITIAL FLAGS.
+        // RuntimeTypeSystem cDAC contract depends on the values of enum_flag_Initialized, enum_flag_IsInitError, and enum_flag_IsNotFullyLoaded.
 
         enum_flag_Initialized               = 0x0001,
         enum_flag_HasCheckedCanCompareBitsOrUseFastGetHashCode  = 0x0002,  // Whether we have checked the overridden Equals or GetHashCode
@@ -3713,7 +3714,7 @@ private:
         // AS YOU ADD NEW FLAGS PLEASE CONSIDER WHETHER Generics::NewInstantiation NEEDS
         // TO BE UPDATED IN ORDER TO ENSURE THAT METHODTABLES DUPLICATED FOR GENERIC INSTANTIATIONS
         // CARRY THE CORECT FLAGS.
-        //
+        // RuntimeTypeSystem cDAC contract depends on the values of enum_flag_GenericsMask, enum_flag_GenericsMask_NonGeneric, and enum_flag_GenericsMask_TypicalInst.
 
         // We are overloading the low 2 bytes of m_dwFlags to be a component size for Strings
         // and Arrays and some set of flags which we can be assured are of a specified state
@@ -3787,6 +3788,12 @@ private:
 
         // The following bits describe mutually exclusive locations of the type
         // in the type hierarchy.
+
+        // RuntimeTypeSystem cDAC contract depends on the values of:
+        // enum_flag_Category_Mask, enum_flag_Category_ElementTypeMask, enum_flag_Category_Array_Mask,
+        // enum_flag_Category_IfArrayThenSzArray, enum_flag_Category_Array, enum_flag_Category_ValueType,
+        // enum_flag_Category_Nullable, enum_flag_Category_PrimitiveValueType, enum_flag_Category_TruePrimitive,
+        // enum_flag_Category_Interface, enum_flag_Collectible, enum_flag_ContainsGCPointers, and enum_flag_HasComponentSize.
         enum_flag_Category_Mask             = 0x000F0000,
 
         enum_flag_Category_Class            = 0x00000000,
@@ -3851,6 +3858,7 @@ private:
         // AS YOU ADD NEW FLAGS PLEASE CONSIDER WHETHER Generics::NewInstantiation NEEDS
         // TO BE UPDATED IN ORDER TO ENSURE THAT METHODTABLES DUPLICATED FOR GENERIC INSTANTIATIONS
         // CARRY THE CORECT FLAGS.
+        // RuntimeTypeSystem cDAC contract depends on the value of enum_flag_DynamicStatics.
 
         enum_flag_HasPerInstInfo            = 0x0001,
         enum_flag_DynamicStatics            = 0x0002,
@@ -3977,6 +3985,7 @@ private:
     PTR_MethodTableAuxiliaryData m_pAuxiliaryData;
 
     // The value of lowest two bits describe what the union contains
+    // RuntimeTypeSystem cDAC contract depends on the values of UNION_EECLASS and UNION_METHODTABLE.
     enum LowBits {
         UNION_EECLASS      = 0,    //  0 - pointer to EEClass. This MethodTable is the canonical method table.
         UNION_METHODTABLE  = 1,    //  1 - pointer to canonical MethodTable.

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -499,6 +499,7 @@ public:
     // debugging or GC.  -- That's not stricly true.  It is allowed to resume such a
     // thread so long as it was ALSO suspended by the user.  In other words, this
     // ensures that user resumptions aren't unbalanced from user suspensions.
+    // Thread cDAC contract depends on the values of TS_Unknown, TS_Hijacked, TS_Background, TS_Unstarted, TS_Dead, and TS_TPWorkerThread.
     //
     enum ThreadState
     {

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -499,11 +499,10 @@ public:
     // debugging or GC.  -- That's not stricly true.  It is allowed to resume such a
     // thread so long as it was ALSO suspended by the user.  In other words, this
     // ensures that user resumptions aren't unbalanced from user suspensions.
-    // Thread cDAC contract depends on the values of TS_Unknown, TS_Hijacked, TS_Background, TS_Unstarted, TS_Dead, and TS_TPWorkerThread.
     //
     enum ThreadState
     {
-        TS_Unknown                = 0x00000000,    // threads are initialized this way
+        TS_Unknown                = 0x00000000,    // threads are initialized this way. [cDAC] [Thread]: Contract depends on this value.
 
         TS_AbortRequested         = 0x00000001,    // Abort the thread
 
@@ -518,13 +517,13 @@ public:
         TS_ExecutingOnAltStack    = 0x00000040,    // Runtime is executing on an alternate stack located anywhere in the memory
 
 #ifdef FEATURE_HIJACK
-        TS_Hijacked               = 0x00000080,    // Return address has been hijacked
+        TS_Hijacked               = 0x00000080,    // Return address has been hijacked. [cDAC] [Thread]: Contract depends on this value.
 #endif // FEATURE_HIJACK
 
         // unused                 = 0x00000100,
-        TS_Background             = 0x00000200,    // Thread is a background thread
-        TS_Unstarted              = 0x00000400,    // Thread has never been started
-        TS_Dead                   = 0x00000800,    // Thread is dead
+        TS_Background             = 0x00000200,    // Thread is a background thread. [cDAC] [Thread]: Contract depends on this value.
+        TS_Unstarted              = 0x00000400,    // Thread has never been started. [cDAC] [Thread]: Contract depends on this value.
+        TS_Dead                   = 0x00000800,    // Thread is dead. [cDAC] [Thread]: Contract depends on this value.
 
         TS_WeOwn                  = 0x00001000,    // Exposed object initiated this thread
 #ifdef FEATURE_COMINTEROP_APARTMENT_SUPPORT
@@ -549,7 +548,7 @@ public:
         // unused                 = 0x00400000,
 
         // unused                 = 0x00800000,
-        TS_TPWorkerThread         = 0x01000000,    // is this a threadpool worker thread?
+        TS_TPWorkerThread         = 0x01000000,    // is this a threadpool worker thread? [cDAC] [Thread]: Contract depends on this value.
 
         TS_Interruptible          = 0x02000000,    // sitting in a Sleep(), Wait(), Join()
         TS_Interrupted            = 0x04000000,    // was awakened by an interrupt APC. !!! This can be moved to TSNC

--- a/src/coreclr/vm/threadstatics.h
+++ b/src/coreclr/vm/threadstatics.h
@@ -43,12 +43,12 @@
 
 class Thread;
 
-// Thread cDAC contract depends on the values of NonCollectible, Collectible, and DirectOnThreadLocalData.
+// [cDAC] [Thread]: Contract depends on the values of NonCollectible, Collectible, and DirectOnThreadLocalData.
 enum class TLSIndexType
 {
-    NonCollectible, // IndexOffset for this form of TLSIndex is scaled by sizeof(OBJECTREF) and used as an index into the array at ThreadLocalData::pNonCollectibleTlsArrayData to get the final address
-    Collectible, // IndexOffset for this form of TLSIndex is scaled by sizeof(void*) and then added to ThreadLocalData::pCollectibleTlsArrayData to get the final address
-    DirectOnThreadLocalData, // IndexOffset for this form of TLS index is an offset into the ThreadLocalData structure itself. This is used for very high performance scenarios, and scenario where the runtime native code needs to hold a TLS pointer to a managed TLS slot. Each one of these is hand-opted into this model.
+    NonCollectible = 0, // IndexOffset for this form of TLSIndex is scaled by sizeof(OBJECTREF) and used as an index into the array at ThreadLocalData::pNonCollectibleTlsArrayData to get the final address
+    Collectible = 1, // IndexOffset for this form of TLSIndex is scaled by sizeof(void*) and then added to ThreadLocalData::pCollectibleTlsArrayData to get the final address
+    DirectOnThreadLocalData = 2, // IndexOffset for this form of TLS index is an offset into the ThreadLocalData structure itself. This is used for very high performance scenarios, and scenario where the runtime native code needs to hold a TLS pointer to a managed TLS slot. Each one of these is hand-opted into this model.
 };
 
 struct TLSIndex

--- a/src/coreclr/vm/threadstatics.h
+++ b/src/coreclr/vm/threadstatics.h
@@ -43,6 +43,7 @@
 
 class Thread;
 
+// Thread cDAC contract depends on the values of NonCollectible, Collectible, and DirectOnThreadLocalData.
 enum class TLSIndexType
 {
     NonCollectible, // IndexOffset for this form of TLSIndex is scaled by sizeof(OBJECTREF) and used as an index into the array at ThreadLocalData::pNonCollectibleTlsArrayData to get the final address

--- a/src/coreclr/vm/typehandle.h
+++ b/src/coreclr/vm/typehandle.h
@@ -80,6 +80,7 @@ class ComCallWrapperTemplate;
 // The entries in these tables (i.e. the code) are, however, often shared.
 // Clients of TypeHandle don't need to know any of this detail; just use the
 // GetInstantiation and HasInstantiation methods.
+// If ever the scheme of having the lower two bits be zero for MethodTables and two for TypeDescs is changed, version the RuntimeTypeSystem cDAC contract.
 
 class TypeHandle
 {

--- a/src/coreclr/vm/typehandle.h
+++ b/src/coreclr/vm/typehandle.h
@@ -80,7 +80,7 @@ class ComCallWrapperTemplate;
 // The entries in these tables (i.e. the code) are, however, often shared.
 // Clients of TypeHandle don't need to know any of this detail; just use the
 // GetInstantiation and HasInstantiation methods.
-// If ever the scheme of having the lower two bits be zero for MethodTables and two for TypeDescs is changed, version the RuntimeTypeSystem cDAC contract.
+// [cDAC] [RuntimeTypeSystem]: If ever the scheme of having the lower two bits be zero for MethodTables and two for TypeDescs is changed, version the RuntimeTypeSystem cDAC contract.
 
 class TypeHandle
 {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
@@ -20,25 +20,8 @@ public readonly struct ModuleHandle
 public enum ModuleFlags
 {
     Tenured = 0x1,                  // Set once we know for sure the Module will not be freed until the appdomain itself exits
-    ClassFreed = 0x4,
     EditAndContinue = 0x8,          // Edit and Continue is enabled for this module
-
-    ProfilerNotified = 0x10,
-    EtwNotified = 0x20,
-
     ReflectionEmit = 0x40,          // Reflection.Emit was used to create this module
-    ProfilerDisableOptimizations = 0x80,
-    ProfilerDisableInlining = 0x100,
-
-    DebuggerUserOverridePriv = 0x400,
-    DebuggerAllowJitOptsPriv = 0x800,
-    DebuggerTrackJitInfoPriv = 0x1000,
-    DebuggerEnCEnabledPriv = 0x2000,
-    DebuggerPDBsCopied = 0x4000,
-    DebuggerIgnorePDbs = 0x8000,
-
-    IJWFixedUp = 0x80000,
-    BeingUnloaded = 0x100000,
 }
 
 [Flags]

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/ILoader.cs
@@ -20,8 +20,25 @@ public readonly struct ModuleHandle
 public enum ModuleFlags
 {
     Tenured = 0x1,                  // Set once we know for sure the Module will not be freed until the appdomain itself exits
+    ClassFreed = 0x4,
     EditAndContinue = 0x8,          // Edit and Continue is enabled for this module
+
+    ProfilerNotified = 0x10,
+    EtwNotified = 0x20,
+
     ReflectionEmit = 0x40,          // Reflection.Emit was used to create this module
+    ProfilerDisableOptimizations = 0x80,
+    ProfilerDisableInlining = 0x100,
+
+    DebuggerUserOverridePriv = 0x400,
+    DebuggerAllowJitOptsPriv = 0x800,
+    DebuggerTrackJitInfoPriv = 0x1000,
+    DebuggerEnCEnabledPriv = 0x2000,
+    DebuggerPDBsCopied = 0x4000,
+    DebuggerIgnorePDbs = 0x8000,
+
+    IJWFixedUp = 0x80000,
+    BeingUnloaded = 0x100000,
 }
 
 [Flags]

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
@@ -12,31 +12,13 @@ namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
 internal readonly struct Loader_1 : ILoader
 {
-    private const uint ASSEMBLY_LEVEL_LOADED = 4; // Assembly Level required to be considered Loaded
     private const uint ASSEMBLY_NOTIFYFLAGS_PROFILER_NOTIFIED = 0x1; // Assembly Notify Flag for profiler notification
 
     private enum ModuleFlags_1 : uint
     {
         Tenured = 0x1,           // Set once we know for sure the Module will not be freed until the appdomain itself exits
-        ClassFreed = 0x4,
         EditAndContinue = 0x8, // Edit and Continue is enabled for this module
-
-        ProfilerNotified = 0x10,
-        EtwNotified = 0x20,
-
         ReflectionEmit = 0x40,    // Reflection.Emit was used to create this module
-        ProfilerDisableOptimizations = 0x80,
-        ProfilerDisableInlining = 0x100,
-
-        DebuggerUserOverridePriv = 0x400,
-        DebuggerAllowJitOptsPriv = 0x800,
-        DebuggerTrackJitInfoPriv = 0x1000,
-        DebuggerEnCEnabledPriv = 0x2000,
-        DebuggerPDBsCopied = 0x4000,
-        DebuggerIgnorePDbs = 0x8000,
-
-        IJWFixedUp = 0x80000,
-        BeingUnloaded = 0x100000,
     }
 
     private enum PEImageFlags : uint
@@ -104,7 +86,7 @@ internal readonly struct Loader_1 : ILoader
                 // IncludeAvailableToProfilers contains some loaded AND loading
                 // assemblies.
             }
-            else if (assembly.Level >= ASSEMBLY_LEVEL_LOADED /* IsLoaded */)
+            else if (assembly.IsLoaded)
             {
                 if (!iterationFlags.HasFlag(AssemblyIterationFlags.IncludeLoaded))
                     continue; // skip loaded assemblies
@@ -328,36 +310,10 @@ internal readonly struct Loader_1 : ILoader
         ModuleFlags flags = default;
         if (runtimeFlags.HasFlag(ModuleFlags_1.Tenured))
             flags |= ModuleFlags.Tenured;
-        if (runtimeFlags.HasFlag(ModuleFlags_1.ClassFreed))
-            flags |= ModuleFlags.ClassFreed;
         if (runtimeFlags.HasFlag(ModuleFlags_1.EditAndContinue))
             flags |= ModuleFlags.EditAndContinue;
-        if (runtimeFlags.HasFlag(ModuleFlags_1.ProfilerNotified))
-            flags |= ModuleFlags.ProfilerNotified;
-        if (runtimeFlags.HasFlag(ModuleFlags_1.EtwNotified))
-            flags |= ModuleFlags.EtwNotified;
         if (runtimeFlags.HasFlag(ModuleFlags_1.ReflectionEmit))
             flags |= ModuleFlags.ReflectionEmit;
-        if (runtimeFlags.HasFlag(ModuleFlags_1.ProfilerDisableOptimizations))
-            flags |= ModuleFlags.ProfilerDisableOptimizations;
-        if (runtimeFlags.HasFlag(ModuleFlags_1.ProfilerDisableInlining))
-            flags |= ModuleFlags.ProfilerDisableInlining;
-        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerUserOverridePriv))
-            flags |= ModuleFlags.DebuggerUserOverridePriv;
-        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerAllowJitOptsPriv))
-            flags |= ModuleFlags.DebuggerAllowJitOptsPriv;
-        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerTrackJitInfoPriv))
-            flags |= ModuleFlags.DebuggerTrackJitInfoPriv;
-        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerEnCEnabledPriv))
-            flags |= ModuleFlags.DebuggerEnCEnabledPriv;
-        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerPDBsCopied))
-            flags |= ModuleFlags.DebuggerPDBsCopied;
-        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerIgnorePDbs))
-            flags |= ModuleFlags.DebuggerIgnorePDbs;
-        if (runtimeFlags.HasFlag(ModuleFlags_1.IJWFixedUp))
-            flags |= ModuleFlags.IJWFixedUp;
-        if (runtimeFlags.HasFlag(ModuleFlags_1.BeingUnloaded))
-            flags |= ModuleFlags.BeingUnloaded;
 
         return flags;
     }
@@ -496,7 +452,7 @@ internal readonly struct Loader_1 : ILoader
     {
         Data.Module module = _target.ProcessedData.GetOrAdd<Data.Module>(handle.Address);
         Data.Assembly assembly = _target.ProcessedData.GetOrAdd<Data.Assembly>(module.Assembly);
-        return assembly.Level >= ASSEMBLY_LEVEL_LOADED /* IsLoaded */;
+        return assembly.IsLoaded;
     }
 
     TargetPointer ILoader.GetGlobalLoaderAllocator()

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/Loader_1.cs
@@ -17,8 +17,25 @@ internal readonly struct Loader_1 : ILoader
     private enum ModuleFlags_1 : uint
     {
         Tenured = 0x1,           // Set once we know for sure the Module will not be freed until the appdomain itself exits
+        ClassFreed = 0x4,
         EditAndContinue = 0x8, // Edit and Continue is enabled for this module
+
+        ProfilerNotified = 0x10,
+        EtwNotified = 0x20,
+
         ReflectionEmit = 0x40,    // Reflection.Emit was used to create this module
+        ProfilerDisableOptimizations = 0x80,
+        ProfilerDisableInlining = 0x100,
+
+        DebuggerUserOverridePriv = 0x400,
+        DebuggerAllowJitOptsPriv = 0x800,
+        DebuggerTrackJitInfoPriv = 0x1000,
+        DebuggerEnCEnabledPriv = 0x2000,
+        DebuggerPDBsCopied = 0x4000,
+        DebuggerIgnorePDbs = 0x8000,
+
+        IJWFixedUp = 0x80000,
+        BeingUnloaded = 0x100000,
     }
 
     private enum PEImageFlags : uint
@@ -310,10 +327,36 @@ internal readonly struct Loader_1 : ILoader
         ModuleFlags flags = default;
         if (runtimeFlags.HasFlag(ModuleFlags_1.Tenured))
             flags |= ModuleFlags.Tenured;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.ClassFreed))
+            flags |= ModuleFlags.ClassFreed;
         if (runtimeFlags.HasFlag(ModuleFlags_1.EditAndContinue))
             flags |= ModuleFlags.EditAndContinue;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.ProfilerNotified))
+            flags |= ModuleFlags.ProfilerNotified;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.EtwNotified))
+            flags |= ModuleFlags.EtwNotified;
         if (runtimeFlags.HasFlag(ModuleFlags_1.ReflectionEmit))
             flags |= ModuleFlags.ReflectionEmit;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.ProfilerDisableOptimizations))
+            flags |= ModuleFlags.ProfilerDisableOptimizations;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.ProfilerDisableInlining))
+            flags |= ModuleFlags.ProfilerDisableInlining;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerUserOverridePriv))
+            flags |= ModuleFlags.DebuggerUserOverridePriv;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerAllowJitOptsPriv))
+            flags |= ModuleFlags.DebuggerAllowJitOptsPriv;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerTrackJitInfoPriv))
+            flags |= ModuleFlags.DebuggerTrackJitInfoPriv;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerEnCEnabledPriv))
+            flags |= ModuleFlags.DebuggerEnCEnabledPriv;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerPDBsCopied))
+            flags |= ModuleFlags.DebuggerPDBsCopied;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.DebuggerIgnorePDbs))
+            flags |= ModuleFlags.DebuggerIgnorePDbs;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.IJWFixedUp))
+            flags |= ModuleFlags.IJWFixedUp;
+        if (runtimeFlags.HasFlag(ModuleFlags_1.BeingUnloaded))
+            flags |= ModuleFlags.BeingUnloaded;
 
         return flags;
     }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ReJIT_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/ReJIT_1.cs
@@ -25,13 +25,9 @@ internal readonly partial struct ReJIT_1 : IReJIT
     {
         kStateRequested = 0x00000000,
 
-        kStateGettingReJITParameters = 0x00000001,
-
         kStateActive = 0x00000002,
 
-        kStateMask = 0x0000000F,
-
-        kSuppressParams = 0x80000000
+        kStateMask = 0x0000000F
     }
 
     public ReJIT_1(Target target, Data.ProfControlBlock profControlBlock)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Assembly.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/Assembly.cs
@@ -17,7 +17,7 @@ internal sealed class Assembly : IData<Assembly>
         IsDynamic = target.Read<byte>(address + (ulong)type.Fields[nameof(IsDynamic)].Offset) != 0;
         Error = target.ReadPointer(address + (ulong)type.Fields[nameof(Error)].Offset);
         NotifyFlags = target.Read<uint>(address + (ulong)type.Fields[nameof(NotifyFlags)].Offset);
-        Level = target.Read<uint>(address + (ulong)type.Fields[nameof(Level)].Offset);
+        IsLoaded = target.Read<byte>(address + (ulong)type.Fields[nameof(IsLoaded)].Offset) != 0;
     }
 
     public TargetPointer Module { get; init; }
@@ -25,7 +25,7 @@ internal sealed class Assembly : IData<Assembly>
     public bool IsDynamic { get; init; }
     public TargetPointer Error { get; init; }
     public uint NotifyFlags { get; init; }
-    public uint Level { get; init; }
+    public bool IsLoaded { get; init; }
 
     public bool IsError => Error != TargetPointer.Null;
 }

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.ReJIT.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.ReJIT.cs
@@ -20,13 +20,9 @@ internal partial class MockDescriptors
         {
             kStateRequested = 0x00000000,
 
-            kStateGettingReJITParameters = 0x00000001,
-
             kStateActive = 0x00000002,
 
-            kStateMask = 0x0000000F,
-
-            kSuppressParams = 0x80000000
+            kStateMask = 0x0000000F
         }
 
         private static readonly TypeFields ProfControlBlockFields = new TypeFields()

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.cs
@@ -167,7 +167,7 @@ internal partial class MockDescriptors
             new(nameof(Data.Assembly.IsDynamic), DataType.uint8),
             new(nameof(Data.Assembly.Error), DataType.pointer),
             new(nameof(Data.Assembly.NotifyFlags), DataType.uint32),
-            new(nameof(Data.Assembly.Level), DataType.uint32),
+            new(nameof(Data.Assembly.IsLoaded), DataType.uint8),
         ]
     };
 

--- a/src/native/managed/cdac/tests/ReJITTests.cs
+++ b/src/native/managed/cdac/tests/ReJITTests.cs
@@ -74,7 +74,6 @@ public class ReJITTests
             { ILCodeVersionHandle.CreateSynthetic(new TargetPointer(/* arbitrary */ 0x100), /* arbitrary */ 100), RejitState.Active },
             { mockRejit.AddExplicitILCodeVersion(new TargetNUInt(1), MockReJIT.RejitFlags.kStateActive), RejitState.Active },
             { mockRejit.AddExplicitILCodeVersion(new TargetNUInt(2), MockReJIT.RejitFlags.kStateRequested), RejitState.Requested },
-            { mockRejit.AddExplicitILCodeVersion(new TargetNUInt(3), MockReJIT.RejitFlags.kSuppressParams | MockReJIT.RejitFlags.kStateRequested), RejitState.Requested }
         };
 
         var target = CreateTarget(arch, mockRejit);


### PR DESCRIPTION
* Many of these have not been changed since migration
* Of those that have been, it would seem that adding a new value is much more common than changing an existing numerical value
* Unlikely to simply change numerical value and not change underlying functionality
* Already done with debugger-related names such as https://github.com/dotnet/runtime/blob/56a1b4dc67607eb6f15388c4acfa01a61aca4d03/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs#L175