### PR TITLE
Make System.Net.Mail test more trim friendly

### DIFF
--- a/src/libraries/System.Net.Mail/tests/Functional/MailMessageTest.cs
+++ b/src/libraries/System.Net.Mail/tests/Functional/MailMessageTest.cs
@@ -261,8 +261,7 @@ blah blah
                                 culture: null,
                                 activationAttributes: null);
 
-            var syncSendAdapterType = typeof(MailMessage).Assembly.GetTypes()
-                .FirstOrDefault(t => t.Name == "SyncReadWriteAdapter");
+            var syncSendAdapterType = Type.GetType("System.Net.SyncReadWriteAdapter, System.Net.Mail");
 
             // Send the message.
             typeof(MailMessage)


### PR DESCRIPTION
We were lucking out previously that this worked with native AOT. With runtime async, this pattern is running out of luck, likely because we're able to optimize more.

In #122526 this test is failing with:

```
[FAIL] System.Net.Mail.Tests.MailMessageTest.SendMailMessageTest
System.ArgumentNullException : Value cannot be null.
   at System.Reflection.Runtime.MethodInfos.RuntimeNamedMethodInfo`1.MakeGenericMethod(Type[]) in /_/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/Runtime/MethodInfos/RuntimeNamedMethodInfo.cs:line 134
   at System.Net.Mail.Tests.MailMessageTest.DecodeSentMailMessage(MailMessage mail) in /_/src/libraries/System.Net.Mail/tests/Functional/MailMessageTest.cs:line 268
   at System.Net.Mail.Tests.MailMessageTest.SendMailMessageTest() in /_/src/libraries/System.Net.Mail/tests/Functional/MailMessageTest.cs:line 157
   at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean) in /_/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs:line 230
```