### PR TITLE
Fix Optimization Profile writing

### DIFF
--- a/src/coreclr/vm/multicorejit.cpp
+++ b/src/coreclr/vm/multicorejit.cpp
@@ -209,14 +209,16 @@ HRESULT WriteString(const void * pString, unsigned len, FILE * fp)
     {
         len = RoundUp(len) - len;
 
-        if (len != 0)
+        if (len == 0)
         {
-            uint32_t temp = 0;
-            cbWritten = fwrite(&temp, 1, len, fp);
-
-            if (cbWritten == (size_t)len)
-                return S_OK;
+            return S_OK;
         }
+
+        uint32_t temp = 0;
+        cbWritten = fwrite(&temp, 1, len, fp);
+
+        if (cbWritten == (size_t)len)
+            return S_OK;
     }
 
     return E_FAIL;


### PR DESCRIPTION
In NET11 preview 1 optimization profile can't be saved if there is a module with name length DWORD-aligned
This appears to be a regression introduced by PR https://github.com/dotnet/runtime/pull/116203