### PR TITLE
Don't dispose SslStream.RemoteCertificate when custom validation callback is used

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.Protocol.cs
@@ -167,7 +167,9 @@ namespace System.Net.Security
 
         internal void CloseContext()
         {
-            if (!_remoteCertificateExposed)
+            // If a RemoteCertificateValidationCallback was supplied, the remote certificate instance
+            // is exposed to user code via that callback and must not be disposed by SslStream.
+            if (!_remoteCertificateExposed && _sslAuthenticationOptions.CertValidationDelegate is null)
             {
                 _remoteCertificate?.Dispose();
                 _remoteCertificate = null;


### PR DESCRIPTION
Related to #124279.

For consistency, we may not want to dispose remote cert if it got exposed (and potentially captured) by remote certificate validation callback.