### PR TITLE
SPMI: Run superpmi-diffs on windows-x64

### DIFF
--- a/eng/pipelines/coreclr/superpmi-diffs.yml
+++ b/eng/pipelines/coreclr/superpmi-diffs.yml
@@ -100,7 +100,7 @@ extends:
           jobTemplate: /eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
           buildConfig: checked
           platforms:
-          - linux_x64
+          - windows_x64
           - windows_x86
           helixQueueGroup: superpmi-diffs
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/coreclr/superpmi-diffs.yml
+++ b/eng/pipelines/coreclr/superpmi-diffs.yml
@@ -54,7 +54,7 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: checked
           platforms:
-          - osx_arm64
+          - linux_x64
           - windows_x86
           # Not needed for subsequent steps, but this ensures we get some build
           # coverage of community JITs in CI on JIT PRs.
@@ -62,12 +62,6 @@ extends:
           jobParameters:
             buildArgs: -s clr.alljitscommunity+clr.spmi -c $(_BuildConfig)
             postBuildSteps:
-              # Build CLR assets for x64 as well as the target as we need an x64 mcs
-              - template: /eng/pipelines/common/templates/global-build-step.yml
-                parameters:
-                  buildArgs: -s clr.spmi -c $(_BuildConfig)
-                  archParameter: -arch x64
-                  displayName: Build SuperPMI
               - template: /eng/pipelines/common/upload-artifact-step.yml
                 parameters:
                   rootFolder: $(Build.SourcesDirectory)/artifacts/bin/coreclr
@@ -106,7 +100,7 @@ extends:
           jobTemplate: /eng/pipelines/coreclr/templates/superpmi-diffs-job.yml
           buildConfig: checked
           platforms:
-          - osx_arm64
+          - linux_x64
           - windows_x86
           helixQueueGroup: superpmi-diffs
           helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml

--- a/eng/pipelines/coreclr/superpmi-diffs.yml
+++ b/eng/pipelines/coreclr/superpmi-diffs.yml
@@ -54,11 +54,8 @@ extends:
           jobTemplate: /eng/pipelines/common/global-build-job.yml
           buildConfig: checked
           platforms:
-          - linux_x64
-          - windows_x86
-          # Not needed for subsequent steps, but this ensures we get some build
-          # coverage of community JITs in CI on JIT PRs.
           - windows_x64
+          - windows_x86
           jobParameters:
             buildArgs: -s clr.alljitscommunity+clr.spmi -c $(_BuildConfig)
             postBuildSteps:

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -69,8 +69,8 @@ bool Compiler::impILConsumesAddr(const BYTE* codeAddr, const BYTE* codeEndp)
 
 void Compiler::impResolveToken(const BYTE* addr, CORINFO_RESOLVED_TOKEN* pResolvedToken, CorInfoTokenKind kind)
 {
-    pResolvedToken->tokenScope   = info.compScopeHnd;
     pResolvedToken->tokenContext = impTokenLookupContextHandle;
+    pResolvedToken->tokenScope   = info.compScopeHnd;
     pResolvedToken->token        = getU4LittleEndian(addr);
     pResolvedToken->tokenType    = kind;
 

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -69,8 +69,8 @@ bool Compiler::impILConsumesAddr(const BYTE* codeAddr, const BYTE* codeEndp)
 
 void Compiler::impResolveToken(const BYTE* addr, CORINFO_RESOLVED_TOKEN* pResolvedToken, CorInfoTokenKind kind)
 {
-    pResolvedToken->tokenContext = impTokenLookupContextHandle;
     pResolvedToken->tokenScope   = info.compScopeHnd;
+    pResolvedToken->tokenContext = impTokenLookupContextHandle;
     pResolvedToken->token        = getU4LittleEndian(addr);
     pResolvedToken->tokenType    = kind;
 


### PR DESCRIPTION
While osx-arm64 is the fastest Helix queues we have the AzDO pool is currently heavily overloaded and causes hour long waits before builds start or Helix jobs are even submitted. Switch to windows-x64 for diffs to avoid this.