### PR TITLE
Add support for async thunk methods in GetNativeCodeInfo

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -1282,18 +1282,7 @@ HRESULT DacDbiInterfaceImpl::GetNativeCodeInfo(VMPTR_DomainAssembly vmDomainAsse
     MethodDesc* pMethodDesc = FindLoadedMethodRefOrDef(pModule, functionToken);
     if (pMethodDesc->IsAsyncThunkMethod())
     {
-        MethodTable * pMT = pMethodDesc->GetMethodTable();
-        MethodTable::IntroducedMethodIterator it(pMT);
-        for (; it.IsValid(); it.Next())
-        {
-            MethodDesc * pMD = it.GetMethodDesc();
-            CONSISTENCY_CHECK(pMD != NULL && pMD->GetMethodTable() == pMT);
-            if (!pMD->IsDiagnosticsHidden())
-            {
-                pMethodDesc = pMD;
-                break;
-            }
-        }
+        pMethodDesc = pMethodDesc->GetAsyncOtherVariantNoCreate();
     }
     pCodeInfo->vmNativeCodeMethodDescToken.SetHostPtr(pMethodDesc);
 

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -1279,16 +1279,16 @@ HRESULT DacDbiInterfaceImpl::GetNativeCodeInfo(VMPTR_DomainAssembly vmDomainAsse
         DomainAssembly * pDomainAssembly = vmDomainAssembly.GetDacPtr();
         Module *     pModule     = pDomainAssembly->GetAssembly()->GetModule();
 
-    MethodDesc* pMethodDesc = FindLoadedMethodRefOrDef(pModule, functionToken);
-    if (pMethodDesc != NULL && pMethodDesc->IsAsyncThunkMethod())
-    {
-        MethodDesc* pAsyncVariant = pMethodDesc->GetAsyncOtherVariantNoCreate();
-        if (pAsyncVariant != NULL)
+        MethodDesc* pMethodDesc = FindLoadedMethodRefOrDef(pModule, functionToken);
+        if (pMethodDesc != NULL && pMethodDesc->IsAsyncThunkMethod())
         {
-            pMethodDesc = pAsyncVariant;
+            MethodDesc* pAsyncVariant = pMethodDesc->GetAsyncOtherVariantNoCreate();
+            if (pAsyncVariant != NULL)
+            {
+                pMethodDesc = pAsyncVariant;
+            }
         }
-    }
-    pCodeInfo->vmNativeCodeMethodDescToken.SetHostPtr(pMethodDesc);
+        pCodeInfo->vmNativeCodeMethodDescToken.SetHostPtr(pMethodDesc);
 
         // if we are loading a module and trying to bind a previously set breakpoint, we may not have
         // a method desc yet, so check for that situation

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -1280,9 +1280,13 @@ HRESULT DacDbiInterfaceImpl::GetNativeCodeInfo(VMPTR_DomainAssembly vmDomainAsse
         Module *     pModule     = pDomainAssembly->GetAssembly()->GetModule();
 
     MethodDesc* pMethodDesc = FindLoadedMethodRefOrDef(pModule, functionToken);
-    if (pMethodDesc->IsAsyncThunkMethod())
+    if (pMethodDesc != NULL && pMethodDesc->IsAsyncThunkMethod())
     {
-        pMethodDesc = pMethodDesc->GetAsyncOtherVariantNoCreate();
+        MethodDesc* pAsyncVariant = pMethodDesc->GetAsyncOtherVariantNoCreate();
+        if (pAsyncVariant != NULL)
+        {
+            pMethodDesc = pAsyncVariant;
+        }
     }
     pCodeInfo->vmNativeCodeMethodDescToken.SetHostPtr(pMethodDesc);
 

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -1279,8 +1279,23 @@ HRESULT DacDbiInterfaceImpl::GetNativeCodeInfo(VMPTR_DomainAssembly vmDomainAsse
         DomainAssembly * pDomainAssembly = vmDomainAssembly.GetDacPtr();
         Module *     pModule     = pDomainAssembly->GetAssembly()->GetModule();
 
-        MethodDesc* pMethodDesc = FindLoadedMethodRefOrDef(pModule, functionToken);
-        pCodeInfo->vmNativeCodeMethodDescToken.SetHostPtr(pMethodDesc);
+    MethodDesc* pMethodDesc = FindLoadedMethodRefOrDef(pModule, functionToken);
+    if (pMethodDesc->IsAsyncThunkMethod())
+    {
+        MethodTable * pMT = pMethodDesc->GetMethodTable();
+        MethodTable::IntroducedMethodIterator it(pMT);
+        for (; it.IsValid(); it.Next())
+        {
+            MethodDesc * pMD = it.GetMethodDesc();
+            CONSISTENCY_CHECK(pMD != NULL && pMD->GetMethodTable() == pMT);
+            if (!pMD->IsDiagnosticsHidden())
+            {
+                pMethodDesc = pMD;
+                break;
+            }
+        }
+    }
+    pCodeInfo->vmNativeCodeMethodDescToken.SetHostPtr(pMethodDesc);
 
         // if we are loading a module and trying to bind a previously set breakpoint, we may not have
         // a method desc yet, so check for that situation

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -88,6 +88,7 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     gchandleutilities.cpp
     genericdict.cpp
     generics.cpp
+    genmeth.cpp
     hash.cpp
     ilinstrumentation.cpp
     ilstubcache.cpp
@@ -335,7 +336,6 @@ set(VM_SOURCES_WKS
     gcenv.ee.common.cpp
     gchelpers.cpp
     genanalysis.cpp
-    genmeth.cpp
     hosting.cpp
     hostinformation.cpp
     ilmarshalers.cpp

--- a/src/coreclr/vm/generics.cpp
+++ b/src/coreclr/vm/generics.cpp
@@ -494,6 +494,8 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
     RETURN(TypeHandle(pMT));
 } // ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation
 
+#endif // !DACCESS_COMPILE
+
 namespace Generics
 {
 
@@ -531,6 +533,13 @@ BOOL CheckInstantiation(Instantiation inst)
     }
     return TRUE;
 }
+
+} // namespace Generics
+
+#ifndef DACCESS_COMPILE
+
+namespace Generics
+{
 
 // Just records the owner and links to the previous graph.
 RecursionGraph::RecursionGraph(RecursionGraph *pPrev, TypeHandle thOwner)

--- a/src/coreclr/vm/instmethhash.cpp
+++ b/src/coreclr/vm/instmethhash.cpp
@@ -86,6 +86,7 @@ PTR_LoaderAllocator InstMethodHashTable::GetLoaderAllocator()
     }
 }
 
+#endif // #ifndef DACCESS_COMPILE
 
 // Calculate a hash value for a method-desc key
 static DWORD Hash(TypeHandle declaringType, mdMethodDef token, Instantiation inst)
@@ -97,9 +98,9 @@ static DWORD Hash(TypeHandle declaringType, mdMethodDef token, Instantiation ins
     DWORD dwHash = 0x87654321;
 #define INST_HASH_ADD(_value) dwHash = ((dwHash << 5) + dwHash) ^ (_value)
 #ifdef TARGET_64BIT
-#define INST_HASH_ADDPOINTER(_value) INST_HASH_ADD((uint32_t)(uintptr_t)_value); INST_HASH_ADD((uint32_t)(((uintptr_t)_value) >> 32))
+#define INST_HASH_ADDPOINTER(_value) INST_HASH_ADD((uint32_t)dac_cast<TADDR>(_value)); INST_HASH_ADD((uint32_t)((dac_cast<TADDR>(_value)) >> 32))
 #else
-#define INST_HASH_ADDPOINTER(_value) INST_HASH_ADD((uint32_t)(uintptr_t)_value);
+#define INST_HASH_ADDPOINTER(_value) INST_HASH_ADD((uint32_t)dac_cast<TADDR>(_value));
 #endif
 
     INST_HASH_ADDPOINTER(declaringType.AsPtr());
@@ -195,6 +196,8 @@ MethodDesc* InstMethodHashTable::FindMethodDesc(TypeHandle declaringType,
 
     return pMDResult;
 }
+
+#ifndef DACCESS_COMPILE
 
 BOOL InstMethodHashTable::ContainsMethodDesc(MethodDesc* pMD)
 {

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1722,6 +1722,11 @@ public:
         return FindOrCreateAssociatedMethodDesc(this, GetMethodTable(), FALSE, GetMethodInstantiation(), allowInstParam, FALSE, TRUE, AsyncVariantLookup::AsyncOtherVariant);
     }
 
+    MethodDesc* GetAsyncOtherVariantNoCreate(BOOL allowInstParam = TRUE)
+    {
+        return FindOrCreateAssociatedMethodDesc(this, GetMethodTable(), FALSE, GetMethodInstantiation(), allowInstParam, FALSE, FALSE, AsyncVariantLookup::AsyncOtherVariant);
+    }
+
     MethodDesc* GetAsyncVariant(BOOL allowInstParam = TRUE)
     {
         _ASSERT(!IsAsyncVariantMethod());

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1724,6 +1724,7 @@ public:
 
     MethodDesc* GetAsyncOtherVariantNoCreate(BOOL allowInstParam = TRUE)
     {
+        _ASSERTE(HasAsyncOtherVariant());
         return FindOrCreateAssociatedMethodDesc(this, GetMethodTable(), FALSE, GetMethodInstantiation(), allowInstParam, FALSE, FALSE, AsyncVariantLookup::AsyncOtherVariant);
     }
 


### PR DESCRIPTION
The runtime by default caches the async thunk when looking up runtime async methods in the methoddef map: https://github.com/dotnet/runtime/blob/0c7ef81aa7d25dcac00eb81d156e03f4c0ca396b/src/coreclr/vm/clsload.cpp#L2804-L2810
This causes `DacDbiInterfaceImpl::GetNativeCodeInfo` to incorrectly return data for the async thunk and not the actual method.