### PR TITLE
vmr-codeflow-status skill: structured routing, dynamic channels, CheckMissing JSON

### DIFF
--- a/.github/skills/vmr-codeflow-status/references/vmr-build-topology.md
+++ b/.github/skills/vmr-codeflow-status/references/vmr-build-topology.md
@@ -99,13 +99,17 @@ then Maestro already fired — no newer builds exist.
 
 ### Channel-to-branch mapping
 
-| Channel | VMR branch | Backflow targets |
+Channel names follow the pattern `{major}.0.{band}xx` where `{band}` is typically `1`, `2`, or `3`.
+The major version tracks .NET version = current year - 2015 (e.g., 2026 → .NET 11).
+
+| Channel Pattern | VMR branch | Notes |
 |---------|-----------|-----------------|
-| `11.0.1xx` | `main` | runtime, sdk, aspnetcore (main) |
-| `11.0.1xx-preview1` | `release/11.0.1xx-preview1` | runtime, sdk, aspnetcore (preview) |
-| `10.0.3xx` | `release/10.0.3xx` | sdk (release/10.0.3xx) |
-| `10.0.2xx` | `release/10.0.2xx` | sdk (release/10.0.2xx) |
-| `10.0.1xx` | `release/10.0.1xx` | runtime, sdk, aspnetcore (release/10.0) |
+| `{N}.0.1xx` | `main` (during development) | Primary SDK band, runtime + sdk + aspnetcore |
+| `{N}.0.1xx-preview{X}` | `release/{N}.0.1xx-preview{X}` | Preview branches |
+| `{N}.0.{band}xx` | `release/{N}.0.{band}xx` | Servicing bands (2xx, 3xx) |
+| `{N-1}.0.{band}xx` | `release/{N-1}.0.{band}xx` | Previous major servicing |
+
+Example (2026): `11.0.1xx` → `main`, `10.0.3xx` → `release/10.0.3xx`
 
 ### Cross-referencing with Version.Details.xml and PR metadata
 

--- a/.github/skills/vmr-codeflow-status/references/vmr-codeflow-reference.md
+++ b/.github/skills/vmr-codeflow-status/references/vmr-codeflow-reference.md
@@ -142,3 +142,21 @@ Base URL: `https://maestro.dot.net`
 **Symptoms**: Developers added manual fixes to unblock the PR (baseline updates, workarounds).
 **Diagnosis**: Analyze PR commits to identify non-maestro commits.
 **Risk**: Closing the PR loses these. Force-triggering may revert them.
+
+### 4. Script reports "Maestro may be stuck"
+**Symptoms**: Builds are fresh (aka.ms shows recent publish) but no backflow PR was created.
+**Diagnosis**:
+1. Check the subscription to find when it last consumed a build:
+   ```bash
+   darc get-subscriptions --target-repo <repo> --source-repo dotnet/dotnet
+   ```
+   Look at the `Last Build` field — if it's weeks old while the channel has newer builds, the subscription is stuck.
+2. Compare against the latest channel build:
+   ```bash
+   darc get-latest-build --repo dotnet/dotnet --channel "<channel-name>"
+   ```
+3. Trigger the subscription manually:
+   ```bash
+   darc trigger-subscriptions --id <subscription-id>
+   ```
+4. If triggering doesn't produce a PR within a few minutes, check Maestro health or open an issue on `dotnet/arcade`.


### PR DESCRIPTION
## VMR Codeflow Status Skill Improvements

### Changes

**Darc CLI Integration (optional, auto-detected)**
- Detects `darc` at startup via `$script:hasDarc` with `CODEFLOW_NO_DARC` env var override for testing
- `Get-VMRBuildFreshnessDarc`: parses `darc get-latest-build` output for exact commit, build date, build link, Released status
- `Get-VMRBuildFreshness` wrapper: tries darc first, falls back to aka.ms redirect probing
- Locale-safe DateTime parsing using InvariantCulture
- Build freshness section header shows "via darc" or "via aka.ms"
- Preview channel name mapping (e.g., `.NET 11.0.1xx SDK Preview 1`)

**Subscription Health Cross-Reference**
- `Get-SubscriptionHealth`: parses subscription state (Enabled, UpdateFrequency, LastBuild), compares against latest published build
- Diagnostics: `maestro-stuck`, `subscription-disabled`, `subscription-missing`, `channel-frozen`, `frequency-limited`, `healthy`, `unknown`
- Wired into CheckMissing for missing backflow PRs and released previews
- Script reports raw facts; agent reasons over the `subscriptionHealth` JSON array
- JSON enriched with channel, lastBuild, latestBuild, commit, buildLink, source fields

**Preview Branch Detection**
- Detects released previews in CheckMissing (>14 days since last merged PR on preview branch)
- Released previews count as up-to-date, not missing
- Preview channel build freshness shown in DarkGray, does not trigger buildsAreStale

**PS 5.1 Compatibility**
- UTF-8 BOM for emoji character support
- `ErrorActionPreference = Continue` for native command stderr compat
- try/catch in all `Complete-AsyncJob` fallback scriptblocks

**Other Fixes**
- `-Repository` is now mandatory (removes footgun default)
- `$script:canParallel` explicit scope
- Fixed comment typos (Complete-AsyncJob, channel probe order)
- Mergeable state check in cached health path

**SKILL.md Updates**
- Subscription Health interpretation section with diagnostic meanings
- Branch name mapping guidance (per-repo branch names)
- PR link presentation guidance (markdown links to correct repo)
- Darc repo discovery guidance with fallback list
- Cross-reference diagnosis in recommendation layer
