### PR TITLE
Skip special formatting for stackoverflow exceptions in trivial cases

### DIFF
--- a/src/coreclr/vm/eepolicy.cpp
+++ b/src/coreclr/vm/eepolicy.cpp
@@ -287,6 +287,12 @@ public:
             }
         }
 
+        // Skip special formatting if it would make the output more verbose (add more lines)
+        if (largestCommonRepeat * largestCommonLength < 4)
+        {
+            largestCommonLength = 0;
+        }
+
         for (int i = 0; i < largestCommonStartOffset; i++)
         {
             PrintFrame(i, pWordAt);


### PR DESCRIPTION
Skip special formatting for stackoverflow exceptions if it would make the output more verbose (more lines).