### PR TITLE
[native] Fix build of strrchr

### DIFF
--- a/src/native/external/libunwind-version.txt
+++ b/src/native/external/libunwind-version.txt
@@ -12,3 +12,4 @@ Apply https://github.com/libunwind/libunwind/pull/734
 Apply https://github.com/libunwind/libunwind/pull/758
 Apply https://github.com/libunwind/libunwind/pull/741
 Apply https://github.com/libunwind/libunwind/pull/931
+Apply https://github.com/libunwind/libunwind/pull/940

--- a/src/native/external/libunwind/src/elfxx.c
+++ b/src/native/external/libunwind/src/elfxx.c
@@ -916,7 +916,7 @@ elf_w (load_debuginfo) (const char* file, struct elf_image *ei, int is_local)
     {
       char linkbuf[shdr->sh_size];
       char *link = ((char *) ei->image) + shdr->sh_offset;
-      char *p;
+      const char *p;
       static const char *debugdir = "/usr/lib/debug";
       char basedir[strlen(file) + 1];
       char newname[shdr->sh_size + strlen (debugdir) + strlen (file) + 9];


### PR DESCRIPTION
After the recent update of glic from 2.42 -> 2.43, `strrchr` returns `const char*` if the arg is `const char*`, see https://sourceware.org/pipermail/libc-alpha/2026-January/174374.html:
> * For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr,
  strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return
  pointers into their input arrays now have definitions as macros that
  return a pointer to a const-qualified type when the input argument is
  a pointer to a const-qualified type.
  
The standard `build.sh clr+libs -rc release` was failing for me on line 933:
```c
p = strrchr (file, '/');
```
so I change the type of `p` to `const char*`.

I'm not sure this is the right way to fix this, so please let me know how else could I do it. But without any change, I'm not able to build the runtime.

cc @janvorli 