### PR TITLE
JIT: Remove `dataSection` flexible array

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -6831,7 +6831,7 @@ void CodeGen::genReportAsyncDebugInfo()
         uint32_t diagNativeOffset = 0;
         if (genAsyncResumeInfoTable != nullptr)
         {
-            emitLocation& emitLoc = genAsyncResumeInfoTable->dsLocations[i];
+            emitLocation& emitLoc = genAsyncResumeInfoTable->Locations()[i];
             if (emitLoc.Valid())
             {
                 diagNativeOffset = emitLoc.CodeOffset(GetEmitter());

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -6831,7 +6831,7 @@ void CodeGen::genReportAsyncDebugInfo()
         uint32_t diagNativeOffset = 0;
         if (genAsyncResumeInfoTable != nullptr)
         {
-            emitLocation& emitLoc = ((emitLocation*)genAsyncResumeInfoTable->dsCont)[i];
+            emitLocation& emitLoc = genAsyncResumeInfoTable->dsLocations[i];
             if (emitLoc.Valid())
             {
                 diagNativeOffset = emitLoc.CodeOffset(GetEmitter());

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -961,7 +961,7 @@ void CodeGen::genRecordAsyncResume(GenTreeVal* asyncResume)
     emitter::dataSection* asyncResumeInfo;
     genEmitAsyncResumeInfoTable(&asyncResumeInfo);
 
-    ((emitLocation*)asyncResumeInfo->dsCont)[index] = emitLocation(GetEmitter());
+    asyncResumeInfo->dsLocations[index] = emitLocation(GetEmitter());
 }
 
 /*

--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -961,7 +961,7 @@ void CodeGen::genRecordAsyncResume(GenTreeVal* asyncResume)
     emitter::dataSection* asyncResumeInfo;
     genEmitAsyncResumeInfoTable(&asyncResumeInfo);
 
-    asyncResumeInfo->dsLocations[index] = emitLocation(GetEmitter());
+    asyncResumeInfo->Locations()[index] = emitLocation(GetEmitter());
 }
 
 /*

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -7811,7 +7811,8 @@ UNATIVE_OFFSET emitter::emitDataGenBeg(unsigned size, unsigned alignment, var_ty
 
     /* Allocate a data section descriptor and add it to the list */
 
-    dataSection* secDesc = emitDataSecCur = (dataSection*)emitGetMem(roundUp(sizeof(*secDesc) + size));
+    dataSection* secDesc = emitDataSecCur = (dataSection*)emitGetMem(sizeof(*secDesc));
+    secDesc->dsData                       = (BYTE*)emitGetMem(size);
 
     secDesc->dsSize = size;
 
@@ -7864,7 +7865,8 @@ UNATIVE_OFFSET emitter::emitBBTableDataGenBeg(unsigned numEntries, bool relative
 
     /* Allocate a data section descriptor and add it to the list */
 
-    secDesc = emitDataSecCur = (dataSection*)emitGetMem(roundUp(sizeof(*secDesc) + numEntries * sizeof(BasicBlock*)));
+    secDesc = emitDataSecCur = (dataSection*)emitGetMem(sizeof(*secDesc));
+    secDesc->dsBlocks        = (BasicBlock**)emitGetMem(numEntries * sizeof(BasicBlock*));
 
     secDesc->dsSize = emittedSize;
 
@@ -7905,10 +7907,11 @@ void emitter::emitAsyncResumeTable(unsigned numEntries, UNATIVE_OFFSET* dataSecO
     unsigned       emittedSize = sizeof(CORINFO_AsyncResumeInfo) * numEntries;
     emitConsDsc.dsdOffs += emittedSize;
 
-    dataSection* secDesc = (dataSection*)emitGetMem(roundUp(sizeof(dataSection) + numEntries * sizeof(emitLocation)));
+    dataSection* secDesc = (dataSection*)emitGetMem(sizeof(dataSection));
+    secDesc->dsLocations = (emitLocation*)emitGetMem(numEntries * sizeof(emitLocation));
 
     for (unsigned i = 0; i < numEntries; i++)
-        new (secDesc->dsCont + i * sizeof(emitLocation), jitstd::placement_t()) emitLocation();
+        new (&secDesc->dsLocations[i], jitstd::placement_t()) emitLocation();
 
     secDesc->dsSize      = emittedSize;
     secDesc->dsAlignment = TARGET_POINTER_SIZE;
@@ -7949,7 +7952,7 @@ void emitter::emitDataGenData(unsigned offs, const void* data, UNATIVE_OFFSET si
 
     assert(emitDataSecCur->dsType == dataSection::data);
 
-    memcpy(emitDataSecCur->dsCont + offs, data, size);
+    memcpy(emitDataSecCur->dsData + offs, data, size);
 }
 
 /*****************************************************************************
@@ -7967,7 +7970,7 @@ void emitter::emitDataGenData(unsigned index, BasicBlock* label)
 
     assert(emitDataSecCur->dsSize >= emittedElemSize * (index + 1));
 
-    ((BasicBlock**)(emitDataSecCur->dsCont))[index] = label;
+    emitDataSecCur->dsBlocks[index] = label;
 }
 
 /*****************************************************************************
@@ -8011,7 +8014,7 @@ UNATIVE_OFFSET emitter::emitDataGenFind(const void* cnsAddr, unsigned cnsSize, u
         //
         if ((secDesc->dsType == dataSection::data) && (secDesc->dsSize >= cnsSize) && ((curOffs % alignment) == 0))
         {
-            if (memcmp(cnsAddr, secDesc->dsCont, cnsSize) == 0)
+            if (memcmp(cnsAddr, secDesc->dsData, cnsSize) == 0)
             {
                 cnum = curOffs;
 
@@ -8393,7 +8396,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
             target_size_t* bDstRW   = (target_size_t*)dstRW;
             for (unsigned i = 0; i < numElems; i++)
             {
-                BasicBlock* block = ((BasicBlock**)dsc->dsCont)[i];
+                BasicBlock* block = dsc->dsBlocks[i];
 
                 // Convert the BasicBlock* value to an IG address
                 insGroup* lab = (insGroup*)emitCodeGetCookie(block);
@@ -8424,7 +8427,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
 
             for (unsigned i = 0; i < numElems; i++)
             {
-                BasicBlock* block = ((BasicBlock**)dsc->dsCont)[i];
+                BasicBlock* block = dsc->dsBlocks[i];
 
                 // Convert the BasicBlock* value to an IG address
                 insGroup* lab = (insGroup*)emitCodeGetCookie(block);
@@ -8444,7 +8447,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
             CORINFO_AsyncResumeInfo* aDstRW = (CORINFO_AsyncResumeInfo*)dstRW;
             for (size_t i = 0; i < numElems; i++)
             {
-                emitLocation* emitLoc = &((emitLocation*)dsc->dsCont)[i];
+                emitLocation* emitLoc = &dsc->dsLocations[i];
 
                 // Async call may have been removed very late, after we have introduced suspension/resumption.
                 // In those cases just encode null.
@@ -8468,7 +8471,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
             // Simple binary data: copy the bytes to the target
             assert(dsc->dsType == dataSection::data);
 
-            memcpy(dstRW, dsc->dsCont, dscSize);
+            memcpy(dstRW, dsc->dsData, dscSize);
 
 #ifdef DEBUG
             if (EMITVERBOSE)
@@ -8477,7 +8480,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
 
                 for (size_t i = 0; i < dscSize; i++)
                 {
-                    printf("%02x ", dsc->dsCont[i]);
+                    printf("%02x ", dsc->dsData[i]);
                     if ((((i + 1) % 16) == 0) && (i + 1 != dscSize))
                     {
                         printf("\n\t\t\t\t\t");
@@ -8487,10 +8490,10 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
                 {
                     case TYP_FLOAT:
                         printf(" ; float  %9.6g",
-                               FloatingPointUtils::convertToDouble(*reinterpret_cast<float*>(&dsc->dsCont)));
+                               FloatingPointUtils::convertToDouble(*reinterpret_cast<float*>(dsc->dsData)));
                         break;
                     case TYP_DOUBLE:
-                        printf(" ; double %12.9g", *reinterpret_cast<double*>(&dsc->dsCont));
+                        printf(" ; double %12.9g", *reinterpret_cast<double*>(dsc->dsData));
                         break;
                     default:
                         break;
@@ -8551,7 +8554,7 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                     printf(labelFormat, "");
                 }
 
-                BasicBlock* block = reinterpret_cast<BasicBlock**>(data->dsCont)[i];
+                BasicBlock* block = data->dsBlocks[i];
                 insGroup*   ig    = static_cast<insGroup*>(emitCodeGetCookie(block));
 
                 const char* blockLabel = emitLabelString(ig);
@@ -8617,7 +8620,7 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                     printf(labelFormat, label);
                 }
 
-                emitLocation* emitLoc = &((emitLocation*)data->dsCont)[i];
+                emitLocation* emitLoc = &data->dsLocations[i];
 
                 printf("\tdq\t%s\n", resumeStubName);
 
@@ -8668,9 +8671,9 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                         {
                             printf("\t<Unexpected data size %d (expected >= 4)\n", data->dsSize);
                         }
-                        printf("\tdd\t%08llXh\t", (UINT64) * reinterpret_cast<uint32_t*>(&data->dsCont[i]));
+                        printf("\tdd\t%08llXh\t", (UINT64) * reinterpret_cast<uint32_t*>(&data->dsData[i]));
                         printf("\t; %9.6g",
-                               FloatingPointUtils::convertToDouble(*reinterpret_cast<float*>(&data->dsCont[i])));
+                               FloatingPointUtils::convertToDouble(*reinterpret_cast<float*>(&data->dsData[i])));
                         i += 4;
                         break;
 
@@ -8679,8 +8682,8 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                         {
                             printf("\t<Unexpected data size %d (expected >= 8)\n", data->dsSize);
                         }
-                        printf("\tdq\t%016llXh", *reinterpret_cast<uint64_t*>(&data->dsCont[i]));
-                        printf("\t; %12.9g", *reinterpret_cast<double*>(&data->dsCont[i]));
+                        printf("\tdq\t%016llXh", *reinterpret_cast<uint64_t*>(&data->dsData[i]));
+                        printf("\t; %12.9g", *reinterpret_cast<double*>(&data->dsData[i]));
                         i += 8;
                         break;
 
@@ -8688,12 +8691,12 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                         switch (elemSize)
                         {
                             case 1:
-                                printf("\tdb\t%02Xh", *reinterpret_cast<uint8_t*>(&data->dsCont[i]));
+                                printf("\tdb\t%02Xh", *reinterpret_cast<uint8_t*>(&data->dsData[i]));
                                 for (j = 1; j < 16; j++)
                                 {
                                     if (i + j >= data->dsSize)
                                         break;
-                                    printf(", %02Xh", *reinterpret_cast<uint8_t*>(&data->dsCont[i + j]));
+                                    printf(", %02Xh", *reinterpret_cast<uint8_t*>(&data->dsData[i + j]));
                                 }
                                 i += j;
                                 break;
@@ -8703,12 +8706,12 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                                 {
                                     printf("\t<Unexpected data size %d (expected size%%2 == 0)\n", data->dsSize);
                                 }
-                                printf("\tdw\t%04Xh", *reinterpret_cast<uint16_t*>(&data->dsCont[i]));
+                                printf("\tdw\t%04Xh", *reinterpret_cast<uint16_t*>(&data->dsData[i]));
                                 for (j = 2; j < 24; j += 2)
                                 {
                                     if (i + j >= data->dsSize)
                                         break;
-                                    printf(", %04Xh", *reinterpret_cast<uint16_t*>(&data->dsCont[i + j]));
+                                    printf(", %04Xh", *reinterpret_cast<uint16_t*>(&data->dsData[i + j]));
                                 }
                                 i += j;
                                 break;
@@ -8719,12 +8722,12 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                                 {
                                     printf("\t<Unexpected data size %d (expected size%%4 == 0)\n", data->dsSize);
                                 }
-                                printf("\tdd\t%08Xh", *reinterpret_cast<uint32_t*>(&data->dsCont[i]));
+                                printf("\tdd\t%08Xh", *reinterpret_cast<uint32_t*>(&data->dsData[i]));
                                 for (j = 4; j < 24; j += 4)
                                 {
                                     if (i + j >= data->dsSize)
                                         break;
-                                    printf(", %08Xh", *reinterpret_cast<uint32_t*>(&data->dsCont[i + j]));
+                                    printf(", %08Xh", *reinterpret_cast<uint32_t*>(&data->dsData[i + j]));
                                 }
                                 i += j;
                                 break;
@@ -8737,12 +8740,12 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                                 {
                                     printf("\t<Unexpected data size %d (expected size%%8 == 0)\n", data->dsSize);
                                 }
-                                printf("\tdq\t%016llXh", *reinterpret_cast<uint64_t*>(&data->dsCont[i]));
+                                printf("\tdq\t%016llXh", *reinterpret_cast<uint64_t*>(&data->dsData[i]));
                                 for (j = 8; j < 64; j += 8)
                                 {
                                     if (i + j >= data->dsSize)
                                         break;
-                                    printf(", %016llXh", *reinterpret_cast<uint64_t*>(&data->dsCont[i + j]));
+                                    printf(", %016llXh", *reinterpret_cast<uint64_t*>(&data->dsData[i + j]));
                                 }
                                 i += j;
                                 break;

--- a/src/coreclr/jit/emit.cpp
+++ b/src/coreclr/jit/emit.cpp
@@ -7812,13 +7812,12 @@ UNATIVE_OFFSET emitter::emitDataGenBeg(unsigned size, unsigned alignment, var_ty
     /* Allocate a data section descriptor and add it to the list */
 
     dataSection* secDesc = emitDataSecCur = (dataSection*)emitGetMem(sizeof(*secDesc));
-    secDesc->dsData                       = (BYTE*)emitGetMem(size);
+    secDesc->dsType                       = dataSection::data;
+    secDesc->Data()                       = (BYTE*)emitGetMem(size);
 
     secDesc->dsSize = size;
 
     secDesc->dsAlignment = alignment;
-
-    secDesc->dsType = dataSection::data;
 
     secDesc->dsDataType = dataType;
 
@@ -7866,13 +7865,12 @@ UNATIVE_OFFSET emitter::emitBBTableDataGenBeg(unsigned numEntries, bool relative
     /* Allocate a data section descriptor and add it to the list */
 
     secDesc = emitDataSecCur = (dataSection*)emitGetMem(sizeof(*secDesc));
-    secDesc->dsBlocks        = (BasicBlock**)emitGetMem(numEntries * sizeof(BasicBlock*));
+    secDesc->dsType          = relativeAddr ? dataSection::blockRelative32 : dataSection::blockAbsoluteAddr;
+    secDesc->Blocks()        = (BasicBlock**)emitGetMem(numEntries * sizeof(BasicBlock*));
 
     secDesc->dsSize = emittedSize;
 
     secDesc->dsAlignment = elemSize;
-
-    secDesc->dsType = relativeAddr ? dataSection::blockRelative32 : dataSection::blockAbsoluteAddr;
 
     secDesc->dsDataType = TYP_UNKNOWN;
 
@@ -7908,14 +7906,14 @@ void emitter::emitAsyncResumeTable(unsigned numEntries, UNATIVE_OFFSET* dataSecO
     emitConsDsc.dsdOffs += emittedSize;
 
     dataSection* secDesc = (dataSection*)emitGetMem(sizeof(dataSection));
-    secDesc->dsLocations = (emitLocation*)emitGetMem(numEntries * sizeof(emitLocation));
+    secDesc->dsType      = dataSection::asyncResumeInfo;
+    secDesc->Locations() = (emitLocation*)emitGetMem(numEntries * sizeof(emitLocation));
 
     for (unsigned i = 0; i < numEntries; i++)
-        new (&secDesc->dsLocations[i], jitstd::placement_t()) emitLocation();
+        new (&secDesc->Locations()[i], jitstd::placement_t()) emitLocation();
 
     secDesc->dsSize      = emittedSize;
     secDesc->dsAlignment = TARGET_POINTER_SIZE;
-    secDesc->dsType      = dataSection::asyncResumeInfo;
     secDesc->dsDataType  = TYP_UNKNOWN;
     secDesc->dsNext      = nullptr;
 
@@ -7952,7 +7950,7 @@ void emitter::emitDataGenData(unsigned offs, const void* data, UNATIVE_OFFSET si
 
     assert(emitDataSecCur->dsType == dataSection::data);
 
-    memcpy(emitDataSecCur->dsData + offs, data, size);
+    memcpy(emitDataSecCur->Data() + offs, data, size);
 }
 
 /*****************************************************************************
@@ -7970,7 +7968,7 @@ void emitter::emitDataGenData(unsigned index, BasicBlock* label)
 
     assert(emitDataSecCur->dsSize >= emittedElemSize * (index + 1));
 
-    emitDataSecCur->dsBlocks[index] = label;
+    emitDataSecCur->Blocks()[index] = label;
 }
 
 /*****************************************************************************
@@ -8014,7 +8012,7 @@ UNATIVE_OFFSET emitter::emitDataGenFind(const void* cnsAddr, unsigned cnsSize, u
         //
         if ((secDesc->dsType == dataSection::data) && (secDesc->dsSize >= cnsSize) && ((curOffs % alignment) == 0))
         {
-            if (memcmp(cnsAddr, secDesc->dsData, cnsSize) == 0)
+            if (memcmp(cnsAddr, secDesc->Data(), cnsSize) == 0)
             {
                 cnum = curOffs;
 
@@ -8396,7 +8394,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
             target_size_t* bDstRW   = (target_size_t*)dstRW;
             for (unsigned i = 0; i < numElems; i++)
             {
-                BasicBlock* block = dsc->dsBlocks[i];
+                BasicBlock* block = dsc->Blocks()[i];
 
                 // Convert the BasicBlock* value to an IG address
                 insGroup* lab = (insGroup*)emitCodeGetCookie(block);
@@ -8427,7 +8425,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
 
             for (unsigned i = 0; i < numElems; i++)
             {
-                BasicBlock* block = dsc->dsBlocks[i];
+                BasicBlock* block = dsc->Blocks()[i];
 
                 // Convert the BasicBlock* value to an IG address
                 insGroup* lab = (insGroup*)emitCodeGetCookie(block);
@@ -8447,7 +8445,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
             CORINFO_AsyncResumeInfo* aDstRW = (CORINFO_AsyncResumeInfo*)dstRW;
             for (size_t i = 0; i < numElems; i++)
             {
-                emitLocation* emitLoc = &dsc->dsLocations[i];
+                emitLocation* emitLoc = &dsc->Locations()[i];
 
                 // Async call may have been removed very late, after we have introduced suspension/resumption.
                 // In those cases just encode null.
@@ -8471,7 +8469,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
             // Simple binary data: copy the bytes to the target
             assert(dsc->dsType == dataSection::data);
 
-            memcpy(dstRW, dsc->dsData, dscSize);
+            memcpy(dstRW, dsc->Data(), dscSize);
 
 #ifdef DEBUG
             if (EMITVERBOSE)
@@ -8480,7 +8478,7 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
 
                 for (size_t i = 0; i < dscSize; i++)
                 {
-                    printf("%02x ", dsc->dsData[i]);
+                    printf("%02x ", dsc->Data()[i]);
                     if ((((i + 1) % 16) == 0) && (i + 1 != dscSize))
                     {
                         printf("\n\t\t\t\t\t");
@@ -8490,10 +8488,10 @@ void emitter::emitOutputDataSec(dataSecDsc* sec, AllocMemChunk* chunks)
                 {
                     case TYP_FLOAT:
                         printf(" ; float  %9.6g",
-                               FloatingPointUtils::convertToDouble(*reinterpret_cast<float*>(dsc->dsData)));
+                               FloatingPointUtils::convertToDouble(*reinterpret_cast<float*>(dsc->Data())));
                         break;
                     case TYP_DOUBLE:
-                        printf(" ; double %12.9g", *reinterpret_cast<double*>(dsc->dsData));
+                        printf(" ; double %12.9g", *reinterpret_cast<double*>(dsc->Data()));
                         break;
                     default:
                         break;
@@ -8554,7 +8552,7 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                     printf(labelFormat, "");
                 }
 
-                BasicBlock* block = data->dsBlocks[i];
+                BasicBlock* block = data->Blocks()[i];
                 insGroup*   ig    = static_cast<insGroup*>(emitCodeGetCookie(block));
 
                 const char* blockLabel = emitLabelString(ig);
@@ -8620,7 +8618,7 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                     printf(labelFormat, label);
                 }
 
-                emitLocation* emitLoc = &data->dsLocations[i];
+                emitLocation* emitLoc = &data->Locations()[i];
 
                 printf("\tdq\t%s\n", resumeStubName);
 
@@ -8671,9 +8669,9 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                         {
                             printf("\t<Unexpected data size %d (expected >= 4)\n", data->dsSize);
                         }
-                        printf("\tdd\t%08llXh\t", (UINT64) * reinterpret_cast<uint32_t*>(&data->dsData[i]));
+                        printf("\tdd\t%08llXh\t", (UINT64) * reinterpret_cast<uint32_t*>(&data->Data()[i]));
                         printf("\t; %9.6g",
-                               FloatingPointUtils::convertToDouble(*reinterpret_cast<float*>(&data->dsData[i])));
+                               FloatingPointUtils::convertToDouble(*reinterpret_cast<float*>(&data->Data()[i])));
                         i += 4;
                         break;
 
@@ -8682,8 +8680,8 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                         {
                             printf("\t<Unexpected data size %d (expected >= 8)\n", data->dsSize);
                         }
-                        printf("\tdq\t%016llXh", *reinterpret_cast<uint64_t*>(&data->dsData[i]));
-                        printf("\t; %12.9g", *reinterpret_cast<double*>(&data->dsData[i]));
+                        printf("\tdq\t%016llXh", *reinterpret_cast<uint64_t*>(&data->Data()[i]));
+                        printf("\t; %12.9g", *reinterpret_cast<double*>(&data->Data()[i]));
                         i += 8;
                         break;
 
@@ -8691,12 +8689,12 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                         switch (elemSize)
                         {
                             case 1:
-                                printf("\tdb\t%02Xh", *reinterpret_cast<uint8_t*>(&data->dsData[i]));
+                                printf("\tdb\t%02Xh", *reinterpret_cast<uint8_t*>(&data->Data()[i]));
                                 for (j = 1; j < 16; j++)
                                 {
                                     if (i + j >= data->dsSize)
                                         break;
-                                    printf(", %02Xh", *reinterpret_cast<uint8_t*>(&data->dsData[i + j]));
+                                    printf(", %02Xh", *reinterpret_cast<uint8_t*>(&data->Data()[i + j]));
                                 }
                                 i += j;
                                 break;
@@ -8706,12 +8704,12 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                                 {
                                     printf("\t<Unexpected data size %d (expected size%%2 == 0)\n", data->dsSize);
                                 }
-                                printf("\tdw\t%04Xh", *reinterpret_cast<uint16_t*>(&data->dsData[i]));
+                                printf("\tdw\t%04Xh", *reinterpret_cast<uint16_t*>(&data->Data()[i]));
                                 for (j = 2; j < 24; j += 2)
                                 {
                                     if (i + j >= data->dsSize)
                                         break;
-                                    printf(", %04Xh", *reinterpret_cast<uint16_t*>(&data->dsData[i + j]));
+                                    printf(", %04Xh", *reinterpret_cast<uint16_t*>(&data->Data()[i + j]));
                                 }
                                 i += j;
                                 break;
@@ -8722,12 +8720,12 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                                 {
                                     printf("\t<Unexpected data size %d (expected size%%4 == 0)\n", data->dsSize);
                                 }
-                                printf("\tdd\t%08Xh", *reinterpret_cast<uint32_t*>(&data->dsData[i]));
+                                printf("\tdd\t%08Xh", *reinterpret_cast<uint32_t*>(&data->Data()[i]));
                                 for (j = 4; j < 24; j += 4)
                                 {
                                     if (i + j >= data->dsSize)
                                         break;
-                                    printf(", %08Xh", *reinterpret_cast<uint32_t*>(&data->dsData[i + j]));
+                                    printf(", %08Xh", *reinterpret_cast<uint32_t*>(&data->Data()[i + j]));
                                 }
                                 i += j;
                                 break;
@@ -8740,12 +8738,12 @@ void emitter::emitDispDataSec(dataSecDsc* section, AllocMemChunk* dataChunks)
                                 {
                                     printf("\t<Unexpected data size %d (expected size%%8 == 0)\n", data->dsSize);
                                 }
-                                printf("\tdq\t%016llXh", *reinterpret_cast<uint64_t*>(&data->dsData[i]));
+                                printf("\tdq\t%016llXh", *reinterpret_cast<uint64_t*>(&data->Data()[i]));
                                 for (j = 8; j < 64; j += 8)
                                 {
                                     if (i + j >= data->dsSize)
                                         break;
-                                    printf(", %016llXh", *reinterpret_cast<uint64_t*>(&data->dsData[i + j]));
+                                    printf(", %016llXh", *reinterpret_cast<uint64_t*>(&data->Data()[i + j]));
                                 }
                                 i += j;
                                 break;

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -3554,12 +3554,33 @@ public:
         UNATIVE_OFFSET dsSize;
         sectionType    dsType;
         var_types      dsDataType;
+
+    private:
         union
         {
             BYTE*         dsData;      // for data blobs
             BasicBlock**  dsBlocks;    // for block-based sections
             emitLocation* dsLocations; // for async resume info
         };
+
+    public:
+        BYTE*& Data()
+        {
+            assert(dsType == sectionType::data);
+            return dsData;
+        }
+
+        BasicBlock**& Blocks()
+        {
+            assert((dsType == sectionType::blockAbsoluteAddr) || (dsType == sectionType::blockRelative32));
+            return dsBlocks;
+        }
+
+        emitLocation*& Locations()
+        {
+            assert(dsType == sectionType::asyncResumeInfo);
+            return dsLocations;
+        }
     };
 
     /* These describe the entire initialized/uninitialized data sections */

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -3554,11 +3554,12 @@ public:
         UNATIVE_OFFSET dsSize;
         sectionType    dsType;
         var_types      dsDataType;
-
-        // variable-sized array used to store the constant data, BasicBlock*
-        // array in the block cases, or emitLocation for the asyncResumeInfo
-        // case.
-        BYTE dsCont[0];
+        union
+        {
+            BYTE*         dsData;      // for data blobs
+            BasicBlock**  dsBlocks;    // for block-based sections
+            emitLocation* dsLocations; // for async resume info
+        };
     };
 
     /* These describe the entire initialized/uninitialized data sections */

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -7326,7 +7326,7 @@ void emitter::emitDispInsHelp(
                 if (jdsc != nullptr && id->idIns() == INS_movt)
                 {
                     unsigned     cnt = jdsc->dsSize / TARGET_POINTER_SIZE;
-                    BasicBlock** bbp = (BasicBlock**)jdsc->dsCont;
+                    BasicBlock** bbp = jdsc->dsBlocks;
 
                     bool isBound = (emitCodeGetCookie(*bbp) != nullptr);
 

--- a/src/coreclr/jit/emitarm.cpp
+++ b/src/coreclr/jit/emitarm.cpp
@@ -7326,7 +7326,7 @@ void emitter::emitDispInsHelp(
                 if (jdsc != nullptr && id->idIns() == INS_movt)
                 {
                     unsigned     cnt = jdsc->dsSize / TARGET_POINTER_SIZE;
-                    BasicBlock** bbp = jdsc->dsBlocks;
+                    BasicBlock** bbp = jdsc->Blocks();
 
                     bool isBound = (emitCodeGetCookie(*bbp) != nullptr);
 

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -12347,7 +12347,7 @@ void emitter::emitDispAddrMode(instrDesc* id, bool noDetail) const
     if (jdsc && !noDetail)
     {
         unsigned     cnt = (jdsc->dsSize - 1) / TARGET_POINTER_SIZE;
-        BasicBlock** bbp = jdsc->dsBlocks;
+        BasicBlock** bbp = jdsc->Blocks();
 
 #ifdef TARGET_AMD64
 #define SIZE_LETTER "Q"

--- a/src/coreclr/jit/emitxarch.cpp
+++ b/src/coreclr/jit/emitxarch.cpp
@@ -12347,7 +12347,7 @@ void emitter::emitDispAddrMode(instrDesc* id, bool noDetail) const
     if (jdsc && !noDetail)
     {
         unsigned     cnt = (jdsc->dsSize - 1) / TARGET_POINTER_SIZE;
-        BasicBlock** bbp = (BasicBlock**)jdsc->dsCont;
+        BasicBlock** bbp = jdsc->dsBlocks;
 
 #ifdef TARGET_AMD64
 #define SIZE_LETTER "Q"


### PR DESCRIPTION
Storing pointers and `emitLocation` instances in this `BYTE` flexible array is problematic due to alignment. We could use `alignas`, but the flexible array here is a micro optimization so just go with a simpler representation without the footguns.

Fix #124350