### PR TITLE
Fix debug assertion in FindTightlyBoundUnboxingStub_DEBUG / FindTightlyBoundWrappedMethodDesc_DEBUG

### DIFF
--- a/src/coreclr/vm/genmeth.cpp
+++ b/src/coreclr/vm/genmeth.cpp
@@ -248,20 +248,16 @@ static MethodDesc * FindTightlyBoundWrappedMethodDesc_DEBUG(MethodDesc * pMD)
     Module *pModule = pMD->GetModule();
     bool isAsyncVariantMethod = pMD->IsAsyncVariantMethod();
 
-    MethodTable::MethodIterator it(pMD->GetCanonicalMethodTable());
-    it.MoveToEnd();
-    for (; it.IsValid(); it.Prev()) {
-        if (!it.IsVirtual()) {
-            // Get the MethodDesc for current method
-            MethodDesc* pCurMethod = it.GetMethodDesc();
+    MethodTable::IntroducedMethodIterator it(pMD->GetCanonicalMethodTable());
+    for (; it.IsValid(); it.Next()) {
+        MethodDesc* pCurMethod = it.GetMethodDesc();
 
-            if (pCurMethod && !pCurMethod->IsUnboxingStub()) {
-                if ((pCurMethod->GetMemberDef() == methodDef)  &&
-                    (pCurMethod->GetModule() == pModule) &&
-                    (pCurMethod->IsAsyncVariantMethod() == isAsyncVariantMethod))
-                {
-                    return pCurMethod;
-                }
+        if (pCurMethod && !pCurMethod->IsUnboxingStub()) {
+            if ((pCurMethod->GetMemberDef() == methodDef)  &&
+                (pCurMethod->GetModule() == pModule) &&
+                (pCurMethod->IsAsyncVariantMethod() == isAsyncVariantMethod))
+            {
+                return pCurMethod;
             }
         }
     }
@@ -288,17 +284,14 @@ static MethodDesc * FindTightlyBoundUnboxingStub_DEBUG(MethodDesc * pMD)
     Module *pModule = pMD->GetModule();
     bool isAsyncVariantMethod = pMD->IsAsyncVariantMethod();
 
-    MethodTable::MethodIterator it(pMD->GetCanonicalMethodTable());
-    it.MoveToEnd();
-    for (; it.IsValid(); it.Prev()) {
-        if (it.IsVirtual()) {
-            MethodDesc* pCurMethod = it.GetMethodDesc();
-            if (pCurMethod && pCurMethod->IsUnboxingStub()) {
-                if ((pCurMethod->GetMemberDef() == methodDef) &&
-                    (pCurMethod->GetModule() == pModule) &&
-                    (pCurMethod->IsAsyncVariantMethod() == isAsyncVariantMethod)) {
-                    return pCurMethod;
-                }
+    MethodTable::IntroducedMethodIterator it(pMD->GetCanonicalMethodTable());
+    for (; it.IsValid(); it.Next()) {
+        MethodDesc* pCurMethod = it.GetMethodDesc();
+        if (pCurMethod && pCurMethod->IsUnboxingStub()) {
+            if ((pCurMethod->GetMemberDef() == methodDef) &&
+                (pCurMethod->GetModule() == pModule) &&
+                (pCurMethod->IsAsyncVariantMethod() == isAsyncVariantMethod)) {
+                return pCurMethod;
             }
         }
     }


### PR DESCRIPTION
## Problem

The debug-only verification functions `FindTightlyBoundUnboxingStub_DEBUG` and `FindTightlyBoundWrappedMethodDesc_DEBUG` in `src/coreclr/vm/genmeth.cpp` use a different iteration strategy than their production counterparts, causing them to miss certain MethodDescs and trigger false assertion failures.

The production functions (`FindTightlyBoundUnboxingStub` and `FindTightlyBoundWrappedMethodDesc`) use **chunk-based** iteration via `MethodTable::IntroducedMethodIterator::GetNext()`, which physically walks all MethodDescs in the MethodDescChunks owned by the MethodTable. This correctly enumerates every MethodDesc regardless of its slot assignment.

The debug functions used **slot-based** iteration via `MethodTable::MethodIterator`, which iterates slot indices 0..`GetNumMethods()-1` and resolves each slot to a MethodDesc via `GetMethodDescForSlot()`. Additionally, each function applied a virtual/non-virtual filter:

- `FindTightlyBoundUnboxingStub_DEBUG` filtered with `IsVirtual()` — only checked slots in the virtual range (index < `GetNumVirtuals()`)
- `FindTightlyBoundWrappedMethodDesc_DEBUG` filtered with `!IsVirtual()` — only checked slots in the non-virtual range (index >= `GetNumVirtuals()`)

This causes failures because slot-based iteration can miss MethodDescs that are not reachable through the slot table, and the virtual/non-virtual filters further restrict the search to the wrong range.

## Root cause

For **generic value types**, the `MethodTableBuilder` allocates tightly-bound unboxing stubs as follows (`methodtablebuilder.cpp`, around line 7113):

```cpp
if (NeedsTightlyBoundUnboxingStub(*it))
{
    if (bmtGenerics->GetNumGenericArgs() == 0) {
        size += sizeof(MethodDesc::NonVtableSlot);  // non-generic: wrapped copy gets NonVtableSlot
    }
    else {
        bmtVT->cVtableSlots++;  // generic: wrapped copy gets a vtable slot
    }
}
```

For generic value types, the "wrapped" (non-unboxing) copy of each method is placed in a **vtable slot** (virtual range). But `FindTightlyBoundWrappedMethodDesc_DEBUG` only searched **non-virtual** slots via its `!IsVirtual()` filter, so it never found the wrapped method for generic value types and returned NULL.

The assertion at the call site then fails:

```cpp
_ASSERTE(pResultMD == pMDescInCanonMT ||
         pResultMD == FindTightlyBoundWrappedMethodDesc_DEBUG(pMDescInCanonMT));
```

Because the production function correctly found the wrapped method (via chunk walk), but the debug function returned NULL (due to the wrong slot filter).

## Why is this latent

The assertion only fires when `FindOrCreateAssociatedMethodDesc` is called with specific parameters that reach the `FindTightlyBoundWrappedMethodDesc` or `FindTightlyBoundUnboxingStub` code paths. These paths are exercised during:

- **JIT compilation**: When `getCallInfo` resolves a virtual method on a generic value type with `allowInstParam=TRUE`, it reaches `FindTightlyBoundWrappedMethodDesc`.
- **Reflection**: When `FindOrCreateAssociatedMethodDescForReflection` resolves a virtual method on a value type with `forceBoxedEntryPoint=TRUE`, it reaches `FindTightlyBoundUnboxingStub`.

Both paths are commonly exercised during normal execution, but the assertion failure only manifests in Debug builds. In Release builds, the `_ASSERTE` macros are no-ops, so the bug is invisible.

The assertion fires when the specific method being resolved has an unboxing stub whose slot assignment falls outside the range searched by the debug function — this is the common case for generic value types.

## Fix

Changed both debug functions to use `IntroducedMethodIterator` (chunk-based iteration) instead of `MethodIterator` (slot-based iteration), matching the approach used by the production functions. Removed the `IsVirtual()` / `!IsVirtual()` filters since chunk-based iteration enumerates all MethodDescs directly without relying on slot indices.

### Before (slot-based, with wrong filter)

```cpp
MethodTable::MethodIterator it(pMD->GetCanonicalMethodTable());
it.MoveToEnd();
for (; it.IsValid(); it.Prev()) {
    if (it.IsVirtual()) {           // or !it.IsVirtual() for the other function
        MethodDesc* pCurMethod = it.GetMethodDesc();
        // ... matching logic ...
    }
}
```

### After (chunk-based, no filter needed)

```cpp
MethodTable::IntroducedMethodIterator it(pMD->GetCanonicalMethodTable());
for (; it.IsValid(); it.Next()) {
    MethodDesc* pCurMethod = it.GetMethodDesc();
    // ... matching logic ...
}
```

## TODO Test - https://github.com/dotnet/runtime/pull/124386

Added `src/tests/Loader/classloader/generics/VSD/Struct_UnboxingStubLookup.cs` which:

1. Defines a generic struct `Processor<T>` implementing multiple interfaces (`IProcessor<T>`, `IIdentity`) with virtual methods and object overrides.
2. Calls virtual methods on the generic struct through `[MethodImpl(NoInlining)]` helper methods with various type instantiations (reference types and value types). This triggers JIT's `getCallInfo` → `FindOrCreateAssociatedMethodDesc` → `FindTightlyBoundWrappedMethodDesc` on the canonical method table.
3. Exercises the reflection path (`GetInterfaceMap` on generic struct instantiations) to trigger `FindOrCreateAssociatedMethodDescForReflection` → `FindTightlyBoundUnboxingStub`.

In Debug builds without the fix, this test crashes with the assertion failure. With the fix, it passes.
