### PR TITLE
Fix ConnectAsync sending stale ReceiveAsync buffer via ConnectEx

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.Tasks.cs
@@ -97,6 +97,10 @@ namespace System.Net.Sockets
 
             saea.RemoteEndPoint = remoteEP;
 
+            // Clear any buffer from a previous operation (e.g. ReceiveAsync) so that
+            // DoOperationConnectEx doesn't pass stale data to ConnectEx's lpSendBuffer.
+            saea.SetBuffer(default);
+
             return saea.ConnectAsync(this, cancellationToken);
         }
 


### PR DESCRIPTION
## Summary

`Socket.ConnectAsync(EndPoint)` reuses the cached `_singleBufferReceiveEventArgs` (`AwaitableSocketAsyncEventArgs`), which may still hold `_buffer`/`_count` from a prior `ReceiveAsync` call. `StartOperationConnect` does not clear these fields, so `DoOperationConnectEx` passes the stale buffer to `ConnectEx`'s `lpSendBuffer`/`dwSendDataLength` — causing `ConnectEx` to send stale receive data as "send-on-connect" data with the new TCP connection.

This is particularly problematic after `DisconnectAsync(reuseSocket: true)`, where the reused socket's second connection silently sends data received during the first connection, corrupting any protocol handshake (e.g. TLS `ClientHello` is preceded by the previous connection's data).

## Fix

Clear the buffer via `SetBuffer(default)` before calling `ConnectAsync` on the cached SAEA, ensuring `ConnectEx` is called with a `NULL` send buffer (no send-on-connect data).

## Reproduction

1. Create a TCP socket, connect, receive data, then `DisconnectAsync(reuseSocket: true)`
2. `ConnectAsync` to the same or different endpoint
3. The server receives stale data from the first connection before any data the client explicitly sends

This was verified with:
- A .NET loopback test (server receives 65536 leaked bytes = `ReceiveBufferSize`)
- A pure C reproduction proving the Windows kernel is correct — `ConnectEx(NULL, 0)` sends nothing; the bug is .NET passing stale buffer/count
- Wireshark captures showing stale TLS records from connection 1 being sent on connection 2

Fix #124353