### PR TITLE
[HTTP] Remove stale ActiveIssue overrides for #72586 

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamConformanceTests.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/ResponseStreamConformanceTests.cs
@@ -21,27 +21,6 @@ namespace System.Net.Http.Functional.Tests
             return pair;
         }
 
-        [Theory]
-        [InlineData(0)]
-        [InlineData(100)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72586")]
-#pragma warning disable xUnit1026 // unused parameter
-        public override Task ReadAsync_CancelPendingTask_ThrowsCancellationException(int cancellationDelay)
-        {
-            return Task.CompletedTask;
-        }
-#pragma warning restore xUnit1026
-
-        [Theory]
-        [InlineData(0)]
-        [InlineData(100)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72586")]
-#pragma warning disable xUnit1026 // unused parameter
-        public override Task ReadAsync_CancelPendingValueTask_ThrowsCancellationException(int cancellationDelay)
-        {
-            return Task.CompletedTask;
-        }
-#pragma warning restore xUnit1026
     }
 
     public sealed class Http1RawResponseStreamConformanceTests : ResponseConnectedStreamConformanceTests
@@ -56,16 +35,6 @@ namespace System.Net.Http.Functional.Tests
             return pair;
         }
 
-        [Theory]
-        [InlineData(0)]
-        [InlineData(100)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/72586")]
-#pragma warning disable xUnit1026 // unused parameter
-        public override Task ReadAsync_CancelPendingTask_ThrowsCancellationException(int cancellationDelay)
-        {
-            return Task.CompletedTask;
-        }
-#pragma warning restore xUnit1026
     }
 
     public sealed class Http1ContentLengthResponseStreamConformanceTests : ResponseStandaloneStreamConformanceTests


### PR DESCRIPTION
Issue #72586 was closed (completed) in Oct 2022. The three test method overrides that returned Task.CompletedTask are no longer needed, allowing the base class CancelPending tests to run.