### PR TITLE
Always enable static linking when dynamic code compiled feature is false

### DIFF
--- a/src/coreclr/clrfeatures.cmake
+++ b/src/coreclr/clrfeatures.cmake
@@ -3,7 +3,9 @@ if (FEATURE_DYNAMIC_CODE_COMPILED)
   set(FEATURE_REJIT 1)
 endif()
 
-if (CLR_CMAKE_TARGET_ARCH_WASM OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS OR CLR_CMAKE_TARGET_MACCATALYST)
+# On desktop, if dynamic code compiled is false, we still enable static linking so we don't have to add platform manifest entries
+# for interpreter library, which is required for the packs build
+if (CLR_CMAKE_TARGET_ARCH_WASM OR CLR_CMAKE_TARGET_IOS OR CLR_CMAKE_TARGET_TVOS OR CLR_CMAKE_TARGET_MACCATALYST OR NOT FEATURE_DYNAMIC_CODE_COMPILED)
   set(FEATURE_STATICALLY_LINKED 1)
 endif()
 

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -121,9 +121,9 @@
     <PlatformManifestFileEntry Condition="'$(PgoInstrument)' != ''" Include="clrjit.pgd" IsNative="true" />
     <PlatformManifestFileEntry Include="libclrjit.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libclrjit.dylib" IsNative="true" />
-    <PlatformManifestFileEntry Condition="('$(RuntimeConfiguration)' == 'Debug' or '$(RuntimeConfiguration)' == 'Checked') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')" Include="clrinterpreter.dll" IsNative="true" />
-    <PlatformManifestFileEntry Condition="('$(RuntimeConfiguration)' == 'Debug' or '$(RuntimeConfiguration)' == 'Checked') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'riscv64')" Include="libclrinterpreter.so" IsNative="true" />
-    <PlatformManifestFileEntry Condition="('$(RuntimeConfiguration)' == 'Debug' or '$(RuntimeConfiguration)' == 'Checked') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')" Include="libclrinterpreter.dylib" IsNative="true" />
+    <PlatformManifestFileEntry Condition="(('$(RuntimeConfiguration)' == 'Debug' or '$(RuntimeConfiguration)' == 'Checked') or ('$(FeatureDynamicCodeCompiled)' == 'false' and '$(TargetsiOS)' != 'true' and '$(TargetsMacCatalyst)' != 'true' and '$(TargetsBrowser)' != 'true')) and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')" Include="clrinterpreter.dll" IsNative="true" />
+    <PlatformManifestFileEntry Condition="(('$(RuntimeConfiguration)' == 'Debug' or '$(RuntimeConfiguration)' == 'Checked') or ('$(FeatureDynamicCodeCompiled)' == 'false' and '$(TargetsiOS)' != 'true' and '$(TargetsMacCatalyst)' != 'true' and '$(TargetsBrowser)' != 'true')) and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'riscv64')" Include="libclrinterpreter.so" IsNative="true" />
+    <PlatformManifestFileEntry Condition="(('$(RuntimeConfiguration)' == 'Debug' or '$(RuntimeConfiguration)' == 'Checked') or ('$(FeatureDynamicCodeCompiled)' == 'false' and '$(TargetsiOS)' != 'true' and '$(TargetsMacCatalyst)' != 'true' and '$(TargetsBrowser)' != 'true')) and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')" Include="libclrinterpreter.dylib" IsNative="true" />
     <PlatformManifestFileEntry Include="mscordaccore.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordaccore.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordaccore.dylib" IsNative="true" />

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Directory.Build.props
@@ -121,9 +121,9 @@
     <PlatformManifestFileEntry Condition="'$(PgoInstrument)' != ''" Include="clrjit.pgd" IsNative="true" />
     <PlatformManifestFileEntry Include="libclrjit.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libclrjit.dylib" IsNative="true" />
-    <PlatformManifestFileEntry Condition="(('$(RuntimeConfiguration)' == 'Debug' or '$(RuntimeConfiguration)' == 'Checked') or ('$(FeatureDynamicCodeCompiled)' == 'false' and '$(TargetsiOS)' != 'true' and '$(TargetsMacCatalyst)' != 'true' and '$(TargetsBrowser)' != 'true')) and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')" Include="clrinterpreter.dll" IsNative="true" />
-    <PlatformManifestFileEntry Condition="(('$(RuntimeConfiguration)' == 'Debug' or '$(RuntimeConfiguration)' == 'Checked') or ('$(FeatureDynamicCodeCompiled)' == 'false' and '$(TargetsiOS)' != 'true' and '$(TargetsMacCatalyst)' != 'true' and '$(TargetsBrowser)' != 'true')) and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'riscv64')" Include="libclrinterpreter.so" IsNative="true" />
-    <PlatformManifestFileEntry Condition="(('$(RuntimeConfiguration)' == 'Debug' or '$(RuntimeConfiguration)' == 'Checked') or ('$(FeatureDynamicCodeCompiled)' == 'false' and '$(TargetsiOS)' != 'true' and '$(TargetsMacCatalyst)' != 'true' and '$(TargetsBrowser)' != 'true')) and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')" Include="libclrinterpreter.dylib" IsNative="true" />
+    <PlatformManifestFileEntry Condition="('$(RuntimeConfiguration)' == 'Debug' or '$(RuntimeConfiguration)' == 'Checked') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')" Include="clrinterpreter.dll" IsNative="true" />
+    <PlatformManifestFileEntry Condition="('$(RuntimeConfiguration)' == 'Debug' or '$(RuntimeConfiguration)' == 'Checked') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64' or '$(TargetArchitecture)' == 'riscv64')" Include="libclrinterpreter.so" IsNative="true" />
+    <PlatformManifestFileEntry Condition="('$(RuntimeConfiguration)' == 'Debug' or '$(RuntimeConfiguration)' == 'Checked') and ('$(TargetArchitecture)' == 'x64' or '$(TargetArchitecture)' == 'arm64')" Include="libclrinterpreter.dylib" IsNative="true" />
     <PlatformManifestFileEntry Include="mscordaccore.dll" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordaccore.so" IsNative="true" />
     <PlatformManifestFileEntry Include="libmscordaccore.dylib" IsNative="true" />


### PR DESCRIPTION
If dynamic code compiled feature is false then we produce the interpreter library, which currently doesn't have a PlatformManifestEntry. Rather than including this in the manifest entries, simply link the interpreter library into the runtime.