### PR TITLE
ci-analysis skill: restore domain examples from eval regression analysis

### DIFF
--- a/.github/skills/ci-analysis/SKILL.md
+++ b/.github/skills/ci-analysis/SKILL.md
@@ -75,7 +75,7 @@ The script operates in three distinct modes depending on what information you ha
 ## What the Script Does
 
 ### PR Analysis Mode (`-PRNumber`)
-1. Discovers AzDO builds associated with the PR (from GitHub check status; for full build history, query AzDO builds API)
+1. Discovers AzDO builds associated with the PR (from GitHub check status; for full build history, query AzDO builds on `refs/pull/{PR}/merge` branch)
 2. Fetches Build Analysis for known issues
 3. Gets failed jobs from Azure DevOps timeline
 4. **Separates canceled jobs from failed jobs** (canceled may be dependency-canceled or timeout-canceled)

--- a/.github/skills/ci-analysis/references/build-progression-analysis.md
+++ b/.github/skills/ci-analysis/references/build-progression-analysis.md
@@ -22,7 +22,9 @@ On large PRs, the user is usually iterating toward a solution. The recent builds
 
 **With AzDO (preferred):**
 
-Query AzDO for builds on `refs/pull/{PR}/merge` branch, sorted by queue time descending. The response includes `triggerInfo` with `pr.sourceSha` — the PR's HEAD commit for each build.
+Query AzDO for builds on `refs/pull/{PR}/merge` branch, sorted by queue time descending, top 20, in the `public` project. The response includes `triggerInfo` with `pr.sourceSha` — the PR's HEAD commit for each build.
+
+> 💡 Key parameters: `branchName: "refs/pull/{PR}/merge"`, `queryOrder: "QueueTimeDescending"`, `top: 20`, project `public` (for dnceng-public org).
 
 **Without MCP (fallback):**
 ```powershell
@@ -45,7 +47,13 @@ Each build's `triggerInfo` contains `pr.sourceSha` — the PR's HEAD commit when
 
 For the current/latest build, the merge ref (`refs/pull/{PR}/merge`) is available via the GitHub API. The merge commit's first parent is the target branch HEAD at the time GitHub computed the merge:
 
-Look up the merge commit's parents — the first parent is the target branch HEAD. The `sourceVersion` from the AzDO build is the merge commit SHA (not `pr.sourceSha`). This is simpler than parsing checkout logs.
+Look up the merge commit's parents — the first parent is the target branch HEAD. Use the GitHub API or MCP (`get_commit` with the `sourceVersion` SHA) to get the commit details. The `sourceVersion` from the AzDO build is the merge commit SHA (not `pr.sourceSha`). Example:
+
+```
+gh api repos/{owner}/{repo}/git/commits/{sourceVersion} --jq '.parents[0].sha'
+```
+
+This is simpler than parsing checkout logs.
 
 > ⚠️ **This only works for the latest build.** GitHub recomputes `refs/pull/{PR}/merge` on each push, so the merge commit changes. For historical builds in a progression analysis, the merge ref no longer reflects what was built — use the checkout log method below.
 
@@ -55,10 +63,12 @@ The AzDO build API doesn't expose the target branch SHA. Extract it from the che
 
 **With AzDO (preferred):**
 
-Fetch the checkout task log (typically log ID 5) for the build. Search the output for the merge line:
+Fetch the checkout task log for the build — typically **log ID 5**, starting around **line 500+** (skip the early git-fetch output). Search the output for the merge line:
 ```
 HEAD is now at {mergeCommit} Merge {prSourceSha} into {targetBranchHead}
 ```
+
+> 💡 `logId: 5` is the first checkout task in most dotnet pipelines. If it doesn't contain the merge line, check the build timeline for "Checkout" tasks to find the correct log ID.
 
 **Without MCP (fallback):**
 ```powershell
@@ -163,6 +173,8 @@ Report what the progression shows:
 - Which builds passed and which failed
 - What commits were added between the last passing and first failing build
 - Whether the failing commits were added in response to review feedback (check review threads)
+
+> 💡 **Stop when you have the progression table and the pass→fail transition identified.** The table + transition commits + error category is enough for the user to act. Don't investigate further (e.g., comparing individual commits, checking passing builds, exploring main branch history) unless the user asks.
 
 **Do not** make fix recommendations based solely on build progression. The progression narrows the investigation — it doesn't determine the right fix. The human may have context about why changes were made, what constraints exist, or what the reviewer intended.
 

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -102,7 +102,7 @@ This pattern scales to any number of builds — launch N subagents for N builds,
 ```
 Extract the target branch HEAD from AzDO build {BUILD_ID}.
 
-Fetch the checkout task log (typically log ID 5, around line 500+)
+Fetch the checkout task log (typically **log ID 5**, starting around **line 500+** to skip git-fetch output)
 
 Search for: "HEAD is now at {mergeCommit} Merge {prSourceSha} into {targetBranchHead}"
 

--- a/.github/skills/ci-analysis/references/delegation-patterns.md
+++ b/.github/skills/ci-analysis/references/delegation-patterns.md
@@ -102,7 +102,7 @@ This pattern scales to any number of builds — launch N subagents for N builds,
 ```
 Extract the target branch HEAD from AzDO build {BUILD_ID}.
 
-Fetch the checkout task log (typically **log ID 5**, starting around **line 500+** to skip git-fetch output)
+Fetch the checkout task log (typically LOG ID 5, starting around LINE 500+ to skip git-fetch output)
 
 Search for: "HEAD is now at {mergeCommit} Merge {prSourceSha} into {targetBranchHead}"
 


### PR DESCRIPTION
## Summary

Waza eval progression testing (16 runs across 4 skill versions, then 12 more runs validating fixes) revealed the tool-agnostic refactor (#124398) caused a **68% regression in tool calls** (25→42) for the build progression task while other tasks were stable or improved.

**Root cause:** Three domain-specific examples were incorrectly classified as tool schema restatements and removed. These are domain knowledge the agent genuinely cannot infer from tool descriptions:

| Restored | Why it matters |
|---|---|
| `refs/pull/{PR}/merge` branch pattern + AzDO query params | Agent can't infer the PR merge branch ref format |
| `gh api .../git/commits/{sha} --jq '.parents[0].sha'` + `get_commit` MCP alternative | Merge commit parent extraction pattern |
| **log ID 5**, **line 500+** hints with emphasis | Magic numbers for checkout log location |
| Stop signal in Step 4 | Agent was doing 5-7 extra tool calls after having enough data |

## Eval Results (Tool Calls)

Each fix was validated independently with a full 4-task eval run:

| Version | Build Progression | CI Status | Helix | Retry | **Total** |
|---------|:-:|:-:|:-:|:-:|:-:|
| 8fdec1f (pre-refactor best) | 25 | 5 | 20 | 5 | 55 |
| 833041c (tool-agnostic, #124398) | 42 📉 | 10 📉 | 21 | **4** | **77** |
| 75f75d3 (restore domain examples) | 36 | 7 | 24 | 4 | 71 |
| a9f5140 (+branch ref hints) | 32 | 6 | 26 | 4 | 68 |
| **aa4193b (this PR)** | **25** ✅ | 6 | **14** | 4 | **49** ✅ |

## Eval Results (Duration)

| Version | Build Progression | CI Status | Helix | Retry | **Total** |
|---------|:-:|:-:|:-:|:-:|:-:|
| 8fdec1f (pre-refactor best) | 5m20s | 1m28s | 3m13s | 1m03s | **11m04s** |
| 833041c (tool-agnostic, #124398) | 7m38s | 1m38s | 3m34s | 0m56s | **13m45s** |
| **aa4193b (this PR)** | **4m25s** | 1m08s | **2m28s** | 0m45s | **8m46s** |

The final version matches the pre-refactor best on Build Progression (25 tools) and beats it overall (49 vs 55 total tools, 8m46s vs 11m04s).

## Key Insight

**Simple tasks** (retry, CI status) benefit from less prescriptive guidance — retry improved from 5 to 4 calls. **Complex multi-step tasks** (build progression) need specific domain examples showing branch ref patterns, field names, and log locations. The rule of thumb: if removing an example leaves the agent unable to accomplish the task efficiently AND the information isn't in any tool description, it's a domain example — keep it.

## Changes

- `build-progression-analysis.md`: Restore key parameters, merge parent extraction example, checkout log hints, stop signal
- `delegation-patterns.md`: ALL CAPS emphasis on log ID/line hints in subagent template
- `SKILL.md`: Mention `refs/pull/{PR}/merge` in step 1
