### PR TITLE
Fix Ping RoundtripTime returning 0 for TtlExpired replies

### DIFF
--- a/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.cs
+++ b/src/libraries/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Windows.cs
@@ -344,21 +344,21 @@ namespace System.Net.NetworkInformation
             IPAddress address = new IPAddress(reply.address);
             IPStatus ipStatus = GetStatusFromCode((int)reply.status);
 
-            long rtt;
+            // The ICMP_ECHO_REPLY RoundTripTime field is always populated by the OS
+            // for any received reply, regardless of status (e.g. TTL expired, unreachable).
+            long rtt = reply.roundTripTime;
             PingOptions? options;
             byte[] buffer;
 
             if (ipStatus == IPStatus.Success)
             {
                 // Only copy the data if we succeed w/ the ping operation.
-                rtt = reply.roundTripTime;
                 options = new PingOptions(reply.options.ttl, (reply.options.flags & DontFragmentFlag) > 0);
                 buffer = new byte[reply.dataSize];
                 Marshal.Copy(reply.data, buffer, 0, reply.dataSize);
             }
             else
             {
-                rtt = 0;
                 options = null;
                 buffer = Array.Empty<byte>();
             }
@@ -371,19 +371,19 @@ namespace System.Net.NetworkInformation
             IPAddress address = new IPAddress(reply.Address.Address, reply.Address.ScopeID);
             IPStatus ipStatus = GetStatusFromCode((int)reply.Status);
 
-            long rtt;
+            // The ICMPV6_ECHO_REPLY RoundTripTime field is always populated by the OS
+            // for any received reply, regardless of status (e.g. TTL expired, unreachable).
+            long rtt = reply.RoundTripTime;
             byte[] buffer;
 
             if (ipStatus == IPStatus.Success)
             {
                 // Only copy the data if we succeed w/ the ping operation.
-                rtt = reply.RoundTripTime;
                 buffer = new byte[sendSize];
                 Marshal.Copy(dataPtr + 36, buffer, 0, sendSize);
             }
             else
             {
-                rtt = 0;
                 buffer = Array.Empty<byte>();
             }
 

--- a/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
+++ b/src/libraries/System.Net.Ping/tests/FunctionalTests/PingTest.cs
@@ -787,6 +787,62 @@ namespace System.Net.NetworkInformation.Tests
             Assert.NotEqual(IPAddress.Any, pingReply.Address);
         }
 
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        [OuterLoop] // Depends on external host
+        public async Task SendPingWithLowTtl_RoundtripTimeIsNonZero()
+        {
+            // Regression test: non-Success replies (e.g. TtlExpired) should preserve the
+            // round-trip time from the ICMP reply, not hardcode it to 0.
+            if (UsesPingUtility)
+            {
+                throw new SkipTestException("Test is only applicable to the IcmpSendEcho code path.");
+            }
+
+            string host = System.Net.Test.Common.Configuration.Ping.PingHost;
+            PingOptions options = new PingOptions();
+            byte[] payload = TestSettings.PayloadAsBytesShort;
+
+            using Ping ping = new Ping();
+
+            // Verify host is reachable first.
+            bool reachable = false;
+            for (int i = 0; i < s_pingcount; i++)
+            {
+                PingReply checkReply = await ping.SendPingAsync(host, TestSettings.PingTimeout, payload);
+                if (checkReply.Status == IPStatus.Success)
+                {
+                    reachable = true;
+                    break;
+                }
+            }
+            if (!reachable)
+            {
+                throw new SkipTestException($"Host {host} is not reachable. Skipping test.");
+            }
+
+            // RTT can legitimately be 0ms on very fast networks, so retry a few times
+            // and assert that at least one reply reports a non-zero RTT.
+            options.Ttl = 1;
+            bool gotNonZeroRtt = false;
+            for (int attempt = 0; attempt < 3; attempt++)
+            {
+                PingReply pingReply = await ping.SendPingAsync(host, TestSettings.PingTimeout, payload, options);
+
+                Assert.True(
+                    pingReply.Status == IPStatus.TimeExceeded || pingReply.Status == IPStatus.TtlExpired,
+                    $"pingReply.Status was {pingReply.Status} instead of TimeExceeded or TtlExpired");
+
+                if (pingReply.RoundtripTime > 0)
+                {
+                    gotNonZeroRtt = true;
+                    break;
+                }
+            }
+
+            Assert.True(gotNonZeroRtt,
+                "Expected at least one TtlExpired reply with non-zero RoundtripTime across 3 attempts");
+        }
+
         private async Task Ping_TimedOut_Core(Func<Ping, string, Task<PingReply>> sendPing)
         {
             Ping sender = new Ping();


### PR DESCRIPTION
When a Ping results in TtlExpired or TimeExceeded, the underlying ICMP_ECHO_REPLY struct contains a valid round-trip time from the intermediate router. Previously this was discarded and hardcoded to 0 for all non-Success statuses.

This change reads the RTT from the reply for TtlExpired and TimeExceeded statuses in both IPv4 and IPv6 Windows code paths, matching the behavior of the raw socket implementation on Unix.

Fixes #118150