### PR TITLE
Fix XmlReader ArgumentOutOfRangeException for malformed UTF-8 in XML …

### DIFF
--- a/src/libraries/System.Private.Xml/tests/XmlReader/Tests/ReaderEncodingTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlReader/Tests/ReaderEncodingTests.cs
@@ -126,11 +126,9 @@ namespace System.Xml.XmlReaderTests
         [Fact]
         public static void ReadWithInvalidUtf8ByteInXmlDeclaration()
         {
-            // Regression test for dotnet/runtime#113061: malformed UTF-8 byte (0xBF) in
-            // XML declaration caused ArgumentOutOfRangeException instead of XmlException.
-            // The 0xBF byte is decoded as U+00BF by SafeAsciiDecoder (1 byte -> 1 char),
-            // but UTF8.GetByteCount would produce 2 bytes for it, causing UnDecodeChars
-            // to compute an invalid bytePos > bytesUsed.
+            // Bare 0xBF (invalid standalone UTF-8 continuation byte) in XML declaration.
+            // SafeAsciiDecoder maps 0xBF -> U+00BF (1 byte -> 1 char), but
+            // UTF8.GetByteCount(U+00BF) = 2, inflating bytePos beyond bytesUsed.
             // Input: <?xml version="1.0[0xBF]"?><a/>
             var bytes = new byte[] { 0x3C, 0x3F, 0x78, 0x6D, 0x6C, 0x20, 0x76, 0x65,
                                      0x72, 0x73, 0x69, 0x6F, 0x6E, 0x3D, 0x22, 0x31,
@@ -139,6 +137,26 @@ namespace System.Xml.XmlReaderTests
             var reader = XmlReader.Create(new MemoryStream(bytes));
 
             // Should throw XmlException, not ArgumentOutOfRangeException
+            XmlException ex = Assert.Throws<XmlException>(() =>
+            {
+                while (reader.Read()) { }
+            });
+            Assert.Contains(_invalidCharInThisEncoding, ex.Message);
+        }
+
+        [Fact]
+        public static void ReadWithMultiByteUtf8CharInXmlDeclaration()
+        {
+            // Multi-byte UTF-8 sequence 0xC2 0xBF (U+00BF) in XML declaration.
+            // SafeAsciiDecoder maps these two bytes to two chars (U+00C2, U+00BF),
+            // both >0x7F, inflating GetByteCount by 2 extra bytes.
+            // Input: <?xml version="1.0[0xC2][0xBF]"?><a/>
+            var bytes = new byte[] { 0x3C, 0x3F, 0x78, 0x6D, 0x6C, 0x20, 0x76, 0x65,
+                                     0x72, 0x73, 0x69, 0x6F, 0x6E, 0x3D, 0x22, 0x31,
+                                     0x2E, 0x30, 0xC2, 0xBF, 0x22, 0x3F, 0x3E,
+                                     0x3C, 0x61, 0x2F, 0x3E };
+            var reader = XmlReader.Create(new MemoryStream(bytes));
+
             XmlException ex = Assert.Throws<XmlException>(() =>
             {
                 while (reader.Read()) { }


### PR DESCRIPTION
Fix XmlReader ArgumentOutOfRangeException for malformed UTF-8 in XML declaration
When SafeAsciiDecoder is used during initial XML declaration parsing, it maps
each byte to a char 1:1, including bytes >0x7F. UnDecodeChars() previously
used Encoding.GetByteCount() on these chars to compute bytePos, but non-ASCII
chars like U+00BF (from byte 0xBF) produce 2 bytes in UTF-8, inflating bytePos
beyond bytesUsed and causing ArgumentOutOfRangeException in BlockCopy.

Fix: detect SafeAsciiDecoder and use charPos directly (correct 1:1 mapping),
then validate that the target encoding byte count matches. If mismatched,
throw XmlException with Xml_InvalidCharInThisEncoding, detecting invalid bytes
before they corrupt ParsingState.

Fixes dotnet/runtime#113061