### PR TITLE
Fix empty host parsing regression

### DIFF
--- a/src/libraries/System.Private.Uri/src/System/Uri.cs
+++ b/src/libraries/System.Private.Uri/src/System/Uri.cs
@@ -3855,7 +3855,7 @@ namespace System
             // Here we have checked the syntax up to the end of host
             // The only thing that can cause an exception is the port value
             // Spend some (duplicated) cycles on that.
-            else if (hostDelimiter == ':')
+            else if (hostDelimiter == ':' && hostLength != 0)
             {
                 if ((syntaxFlags & UriSyntaxFlags.MayHavePort) != 0)
                 {

--- a/src/libraries/System.Private.Uri/tests/FunctionalTests/UriCreateStringTests.cs
+++ b/src/libraries/System.Private.Uri/tests/FunctionalTests/UriCreateStringTests.cs
@@ -345,6 +345,9 @@ namespace System.PrivateUri.Tests
             yield return new object[] { "unknown://h.-/", "unknown", "", "h.-", UriHostNameType.Basic, -1, true, false };
             yield return new object[] { "unknown://h._", "unknown", "", "h._", UriHostNameType.Basic, -1, true, false };
             yield return new object[] { "unknown://", "unknown", "", "", UriHostNameType.Basic, -1, true, true };
+            yield return new object[] { "unknown:///path", "unknown", "", "", UriHostNameType.Basic, -1, true, true };
+            yield return new object[] { "unknown://?query", "unknown", "", "", UriHostNameType.Basic, -1, true, true };
+            yield return new object[] { "unknown://#fragment", "unknown", "", "", UriHostNameType.Basic, -1, true, true };
 
             // Mailto
             yield return new object[] { "mailto:", "mailto", "", "", UriHostNameType.Basic, 25, true, true };
@@ -372,6 +375,9 @@ namespace System.PrivateUri.Tests
             yield return new object[] { "unknown:", "unknown", "", "", UriHostNameType.Unknown, -1, true, false };
             yield return new object[] { "unknown:path", "unknown", "", "", UriHostNameType.Unknown, -1, true, false };
             yield return new object[] { "unknown://host", "unknown", "", "host", UriHostNameType.Dns, -1, true, false };
+            yield return new object[] { "unknown://a:80", "unknown", "", "a", UriHostNameType.Dns, 80, false, false };
+            yield return new object[] { "unknown://ab:80", "unknown", "", "ab", UriHostNameType.Dns, 80, false, false };
+            yield return new object[] { "unknown://host:80", "unknown", "", "host", UriHostNameType.Dns, 80, false, false };
             yield return new object[] { "unknown://userinfo@host", "unknown", "userinfo", "host", UriHostNameType.Dns, -1, true, false };
             yield return new object[] { "unknown://userinfo@host:80", "unknown", "userinfo", "host", UriHostNameType.Dns, 80, false, false };
             yield return new object[] { "unknown://./", "unknown", "", ".", UriHostNameType.Basic, -1, true, false };
@@ -1273,6 +1279,17 @@ namespace System.PrivateUri.Tests
             yield return new object[] { "uri://a:65536", UriKind.Absolute };
             yield return new object[] { "uri://a:2147483648", UriKind.Absolute };
             yield return new object[] { "uri://a:80:80", UriKind.Absolute };
+
+            // Unknown scheme with no host and a port
+            yield return new object[] { "tcp://:11111", UriKind.Absolute };
+            yield return new object[] { "udp://:11111", UriKind.Absolute };
+            yield return new object[] { "unix://:11111", UriKind.Absolute };
+            yield return new object[] { "unknown://:80", UriKind.Absolute };
+            yield return new object[] { "unknown://:80/path", UriKind.Absolute };
+            yield return new object[] { "unknown://:80?query", UriKind.Absolute };
+            yield return new object[] { "unknown://:80#fragment", UriKind.Absolute };
+            yield return new object[] { "unknown://userinfo@:80", UriKind.Absolute };
+            yield return new object[] { "unknown://userinfo@", UriKind.Absolute };
 
             if (PlatformDetection.IsNotInvariantGlobalization)
             {


### PR DESCRIPTION
Fixes #124426
Regressed in #121671

The previous check had `end < length`, which wasn't so much a range check as a check that `end` was updated
https://github.com/dotnet/runtime/blob/7fb0240cea487926c1a75da30a5c3cb1257092df/src/libraries/System.Private.Uri/src/System/Uri.cs#L3967