### PR TITLE
Fix tree type in impStoreNullableFields and impLoadNullableFields for simds

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -2979,7 +2979,7 @@ GenTree* Compiler::impStoreNullableFields(CORINFO_CLASS_HANDLE nullableCls, GenT
 
     CORINFO_FIELD_HANDLE valueFldHnd = info.compCompHnd->getFieldInClass(nullableCls, 1);
     CORINFO_CLASS_HANDLE valueStructCls;
-    var_types            valueType = JITtype2varType(info.compCompHnd->getFieldType(valueFldHnd, &valueStructCls));
+    info.compCompHnd->getFieldType(valueFldHnd, &valueStructCls);
 
     // We still make some assumptions about the layout of Nullable<T> in JIT
     static_assert(OFFSETOF__CORINFO_NullableOfT__hasValue == 0);
@@ -2991,9 +2991,14 @@ GenTree* Compiler::impStoreNullableFields(CORINFO_CLASS_HANDLE nullableCls, GenT
     lvaSetStruct(resultTmp, nullableCls, false);
 
     // Now do two stores:
-    GenTree*     hasValueStore = gtNewStoreLclFldNode(resultTmp, TYP_UBYTE, hasValOffset, gtNewIconNode(1));
-    ClassLayout* layout        = valueType == TYP_STRUCT ? typGetObjLayout(valueStructCls) : nullptr;
-    GenTree*     valueStore    = gtNewStoreLclFldNode(resultTmp, valueType, layout, valueOffset, value);
+    GenTree* hasValueStore = gtNewStoreLclFldNode(resultTmp, TYP_UBYTE, hasValOffset, gtNewIconNode(1));
+
+    ClassLayout* layout;
+    CorInfoType  corFldType = info.compCompHnd->getFieldType(valueFldHnd, &valueStructCls);
+    var_types    valueType  = TypeHandleToVarType(corFldType, valueStructCls, &layout);
+
+    // For SIMD types the layout carries the normalized type (e.g. TYP_SIMD8 for Vector2).
+    GenTree* valueStore = gtNewStoreLclFldNode(resultTmp, valueType, layout, valueOffset, value);
 
     // ABI handling for struct values
     if (varTypeIsStruct(valueStore))
@@ -3024,8 +3029,11 @@ void Compiler::impLoadNullableFields(GenTree*             nullableObj,
 
     CORINFO_FIELD_HANDLE valueFldHnd = info.compCompHnd->getFieldInClass(nullableCls, 1);
     CORINFO_CLASS_HANDLE valueStructCls;
-    var_types            valueType   = JITtype2varType(info.compCompHnd->getFieldType(valueFldHnd, &valueStructCls));
-    ClassLayout*         valueLayout = valueType == TYP_STRUCT ? typGetObjLayout(valueStructCls) : nullptr;
+    info.compCompHnd->getFieldType(valueFldHnd, &valueStructCls);
+
+    ClassLayout* valueLayout;
+    CorInfoType  corFldType = info.compCompHnd->getFieldType(valueFldHnd, &valueStructCls);
+    var_types    valueType  = TypeHandleToVarType(corFldType, valueStructCls, &valueLayout);
 
     static_assert(OFFSETOF__CORINFO_NullableOfT__hasValue == 0);
     unsigned hasValOffset = OFFSETOF__CORINFO_NullableOfT__hasValue;

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -2988,16 +2988,14 @@ GenTree* Compiler::impStoreNullableFields(CORINFO_CLASS_HANDLE nullableCls, GenT
     unsigned resultTmp = lvaGrabTemp(true DEBUGARG("Nullable<T> tmp"));
     lvaSetStruct(resultTmp, nullableCls, false);
 
-    // Now do two stores:
-    GenTree* hasValueStore = gtNewStoreLclFldNode(resultTmp, TYP_UBYTE, hasValOffset, gtNewIconNode(1));
-
     ClassLayout*         layout;
     CORINFO_CLASS_HANDLE valueStructCls;
     CorInfoType          corFldType = info.compCompHnd->getFieldType(valueFldHnd, &valueStructCls);
     var_types            valueType  = TypeHandleToVarType(corFldType, valueStructCls, &layout);
 
-    // For SIMD types the layout carries the normalized type (e.g. TYP_SIMD8 for Vector2).
-    GenTree* valueStore = gtNewStoreLclFldNode(resultTmp, valueType, layout, valueOffset, value);
+    // Now do two stores:
+    GenTree* hasValueStore = gtNewStoreLclFldNode(resultTmp, TYP_UBYTE, hasValOffset, gtNewIconNode(1));
+    GenTree* valueStore    = gtNewStoreLclFldNode(resultTmp, valueType, layout, valueOffset, value);
 
     // ABI handling for struct values
     if (varTypeIsStruct(valueStore))

--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -2978,8 +2978,6 @@ GenTree* Compiler::impStoreNullableFields(CORINFO_CLASS_HANDLE nullableCls, GenT
     assert(info.compCompHnd->isNullableType(nullableCls) == TypeCompareState::Must);
 
     CORINFO_FIELD_HANDLE valueFldHnd = info.compCompHnd->getFieldInClass(nullableCls, 1);
-    CORINFO_CLASS_HANDLE valueStructCls;
-    info.compCompHnd->getFieldType(valueFldHnd, &valueStructCls);
 
     // We still make some assumptions about the layout of Nullable<T> in JIT
     static_assert(OFFSETOF__CORINFO_NullableOfT__hasValue == 0);
@@ -2993,9 +2991,10 @@ GenTree* Compiler::impStoreNullableFields(CORINFO_CLASS_HANDLE nullableCls, GenT
     // Now do two stores:
     GenTree* hasValueStore = gtNewStoreLclFldNode(resultTmp, TYP_UBYTE, hasValOffset, gtNewIconNode(1));
 
-    ClassLayout* layout;
-    CorInfoType  corFldType = info.compCompHnd->getFieldType(valueFldHnd, &valueStructCls);
-    var_types    valueType  = TypeHandleToVarType(corFldType, valueStructCls, &layout);
+    ClassLayout*         layout;
+    CORINFO_CLASS_HANDLE valueStructCls;
+    CorInfoType          corFldType = info.compCompHnd->getFieldType(valueFldHnd, &valueStructCls);
+    var_types            valueType  = TypeHandleToVarType(corFldType, valueStructCls, &layout);
 
     // For SIMD types the layout carries the normalized type (e.g. TYP_SIMD8 for Vector2).
     GenTree* valueStore = gtNewStoreLclFldNode(resultTmp, valueType, layout, valueOffset, value);
@@ -3028,12 +3027,11 @@ void Compiler::impLoadNullableFields(GenTree*             nullableObj,
     assert(info.compCompHnd->isNullableType(nullableCls) == TypeCompareState::Must);
 
     CORINFO_FIELD_HANDLE valueFldHnd = info.compCompHnd->getFieldInClass(nullableCls, 1);
-    CORINFO_CLASS_HANDLE valueStructCls;
-    info.compCompHnd->getFieldType(valueFldHnd, &valueStructCls);
 
-    ClassLayout* valueLayout;
-    CorInfoType  corFldType = info.compCompHnd->getFieldType(valueFldHnd, &valueStructCls);
-    var_types    valueType  = TypeHandleToVarType(corFldType, valueStructCls, &valueLayout);
+    ClassLayout*         valueLayout;
+    CORINFO_CLASS_HANDLE valueStructCls;
+    CorInfoType          corFldType = info.compCompHnd->getFieldType(valueFldHnd, &valueStructCls);
+    var_types            valueType  = TypeHandleToVarType(corFldType, valueStructCls, &valueLayout);
 
     static_assert(OFFSETOF__CORINFO_NullableOfT__hasValue == 0);
     unsigned hasValOffset = OFFSETOF__CORINFO_NullableOfT__hasValue;

--- a/src/tests/JIT/Regression/JitBlue/Runtime_124425/Runtime_124425.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_124425/Runtime_124425.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+public class Runtime_124425
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Vector2? v1 = null;
+        Assert.Throws<NullReferenceException>(() => CastToVector2(v1));
+        Vector3? v2 = null;
+        Assert.Throws<NullReferenceException>(() => CastToVector3(v2));
+        Vector4? v3 = null;
+        Assert.Throws<NullReferenceException>(() => CastToVector4(v3));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void CastToVector2<T>(T? value)
+    {
+        var a = (Vector2)(object)value!;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void CastToVector3<T>(T? value)
+    {
+        var a = (Vector3)(object)value!;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void CastToVector4<T>(T? value)
+    {
+        var a = (Vector4)(object)value!;
+    }
+}

--- a/src/tests/JIT/Regression/JitBlue/Runtime_124425/Runtime_124425.csproj
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_124425/Runtime_124425.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Needed for CLRTestEnvironmentVariable -->
+    <RequiresProcessIsolation>true</RequiresProcessIsolation>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+    <CLRTestEnvironmentVariable Include="DOTNET_JITMinOpts" Value="1" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/124425 - the actual issue is TYP_SIMD* was typed as TYP_STRUCT.

We use TypeHandleToVarType for similar places - it correctly maps CORINFO_CLASS_HANDLE into SIMD.