### PR TITLE
[issue-labeler] Use env var for prediction threshold; default to 0.05

### DIFF
--- a/.github/workflows/labeler-predict-issues.yml
+++ b/.github/workflows/labeler-predict-issues.yml
@@ -27,7 +27,7 @@ env:
   ALLOW_FAILURE: ${{ github.event_name == 'workflow_dispatch' }}
 
   LABEL_PREFIX: "area-"
-  THRESHOLD: 0.40
+  THRESHOLD: ${{ vars.ISSUE_LABELER_PREDICTION_THRESHOLD || '0.05' }}
   DEFAULT_LABEL: "needs-area-label"
 
 jobs:

--- a/.github/workflows/labeler-predict-pulls.yml
+++ b/.github/workflows/labeler-predict-pulls.yml
@@ -46,7 +46,7 @@ env:
   ALLOW_FAILURE: ${{ github.event_name == 'workflow_dispatch' }}
 
   LABEL_PREFIX: "area-"
-  THRESHOLD: 0.40
+  THRESHOLD: ${{ vars.ISSUE_LABELER_PREDICTION_THRESHOLD || '0.05' }}
   DEFAULT_LABEL: "needs-area-label"
 
 jobs:

--- a/.github/workflows/labeler-train.yml
+++ b/.github/workflows/labeler-train.yml
@@ -48,7 +48,7 @@ env:
   CACHE_KEY: ${{ inputs.cache_key_suffix }}
   REPOSITORY: ${{ github.repository }}
   LABEL_PREFIX: "area-"
-  THRESHOLD: "0.40"
+  THRESHOLD: ${{ vars.ISSUE_LABELER_PREDICTION_THRESHOLD || '0.05' }}
   LIMIT: ${{ inputs.limit }}
   PAGE_SIZE: ${{ inputs.page_size }}
   PAGE_LIMIT: ${{ inputs.page_limit }}

--- a/.github/workflows/labeler.md
+++ b/.github/workflows/labeler.md
@@ -30,3 +30,11 @@ Across these workflows, the following changes were made to configure the issue l
     - `labeler-train.yml`
 6. Update the cache retention cron schedule to an arbitrary time of day:
     - `labeler-cache-retention.yml`
+
+## Repository Variables
+
+The following [repository variables](../../settings/variables/actions) can be configured to override default workflow behavior:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ISSUE_LABELER_PREDICTION_THRESHOLD` | The minimum prediction confidence threshold for applying an area label. Predictions below this threshold will apply the `DEFAULT_LABEL` instead. | `0.05` |


### PR DESCRIPTION
We ran several training runs of the issue-labeler to evaluate different prediction thresholds. With input from several team members and a vote, we are lowering the threshold down to 0.05 to minimize the https://github.com/dotnet/runtime/labels/needs-area-label occurrences.

This PR adds support for configuring the threshold via an `ISSUE_LABELER_PREDICTION_THRESHOLD` actions env var, applying the 0.05 value as the default for this repo.

Threshold | Matches | Mismatches | No Prediction
-- | -- | -- | --
1️⃣ 0.05 ([test run](https://github.com/jeffhandley/runtime/actions/runs/21921522304)) | 91.91% (42,866) | 8.06% (3,760) | 0.03% (13)
2️⃣ 0.10 ([test run](https://github.com/jeffhandley/runtime/actions/runs/21918226090)) | 91.71% (42,770) | 7.81% (3,640) | 0.48% (224)
3️⃣ 0.15 ([test run](https://github.com/jeffhandley/runtime/actions/runs/21897875351#summary-63218193783)) | 91.21% (42,520) | 7.40% (3,451) | 1.39% (646)
4️⃣ 0.20 ([test run](https://github.com/jeffhandley/runtime/actions/runs/21895928509#summary-63211946920)) | 90.40% (42,140) | 6.69% (3,117) | 2.92% (1,359)
5️⃣ 0.28 ([test run](https://github.com/jeffhandley/runtime/actions/runs/21895913699#summary-63211901673)) | 88.61% (41,307) | 5.41% (2,521) | 5.98% (2,788)
6️⃣ 0.40 ([test run](https://github.com/jeffhandley/runtime/actions/runs/21895919994)) [current setting] | 84.59% (39,431) | 3.62% (1,687) | 11.79% (5,498)
