### PR TITLE
Make report-green.yml run on agentless server job

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-Documents Index
+Documents Index 
 ===============
 
 This repo includes several documents that explain both high-level and low-level concepts about the .NET runtime and libraries. These are very useful for contributors, to get context that can be very difficult to acquire from just reading code.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-Documents Index 
+Documents Index
 ===============
 
 This repo includes several documents that explain both high-level and low-level concepts about the .NET runtime and libraries. These are very useful for contributors, to get context that can be very difficult to acquire from just reading code.

--- a/eng/pipelines/report-green.yml
+++ b/eng/pipelines/report-green.yml
@@ -27,17 +27,10 @@ pr:
 
 # ABG - Always Be Green
 jobs:
-- template: /eng/common/templates/jobs/jobs.yml
-  parameters:
-    enableTelemetry: true
-    helixRepo: dotnet/runtime
-    jobs:
-    - job: Report_Green
-      enableSBOM: false
-      pool:
-        vmImage: ubuntu-22.04
-      steps:
-      - powershell: |
-          Write-Host "This is a documentation-only change. Exiting successfully."
-          exit 0
-        displayName: Exit 0 for doc-only changes
+  - job: Report_Green
+    pool: server
+    steps:
+    # This is a documentation-only change. Use no-op task to exit successfully.
+    - task: Delay@1
+      inputs:
+        delayForMinutes: '0'


### PR DESCRIPTION
We only need to no-op and can avoid allocating a CI machine.