### PR TITLE
Replace MethodDescCallSite with UnmanagedCallersOnly for ObjC interop

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveCMarshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveCMarshal.CoreCLR.cs
@@ -48,7 +48,7 @@ namespace System.Runtime.InteropServices.ObjectiveC
                 if (s_unhandledExceptionPropagationHandler is null)
                     return null;
 
-                var runtimeHandle = RuntimeMethodHandle.FromIntPtr(methodDesc);
+                RuntimeMethodHandle runtimeHandle = RuntimeMethodHandle.FromIntPtr(methodDesc);
                 return s_unhandledExceptionPropagationHandler(*pExceptionArg, runtimeHandle, out *pContext);
             }
             catch (Exception ex)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveCMarshal.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/InteropServices/ObjectiveCMarshal.CoreCLR.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 
@@ -40,27 +39,23 @@ namespace System.Runtime.InteropServices.ObjectiveC
             out int memInSizeT,
             out IntPtr mem);
 
-        internal static bool AvailableUnhandledExceptionPropagation()
+        [UnmanagedCallersOnly]
+        internal static unsafe void* InvokeUnhandledExceptionPropagation(Exception* pExceptionArg, IntPtr methodDesc, IntPtr* pContext, Exception* pException)
         {
-            return s_unhandledExceptionPropagationHandler != null;
-        }
+            try
+            {
+                *pContext = IntPtr.Zero;
+                if (s_unhandledExceptionPropagationHandler is null)
+                    return null;
 
-        internal static unsafe void* InvokeUnhandledExceptionPropagation(
-            Exception exception,
-            object methodInfoStub,
-            out IntPtr context)
-        {
-            context = IntPtr.Zero;
-            if (s_unhandledExceptionPropagationHandler == null)
+                var runtimeHandle = RuntimeMethodHandle.FromIntPtr(methodDesc);
+                return s_unhandledExceptionPropagationHandler(*pExceptionArg, runtimeHandle, out *pContext);
+            }
+            catch (Exception ex)
+            {
+                *pException = ex;
                 return null;
-
-            Debug.Assert(methodInfoStub is RuntimeMethodInfoStub);
-            var runtimeHandle = new RuntimeMethodHandle((RuntimeMethodInfoStub)methodInfoStub);
-            var callback = s_unhandledExceptionPropagationHandler(exception, runtimeHandle, out context);
-            if (callback != null)
-                return callback;
-
-            return null;
+            }
         }
     }
 }

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -449,8 +449,7 @@ DEFINE_FIELD_U(_buckets, GCHandleSetObject, _buckets)
 
 #ifdef FEATURE_OBJCMARSHAL
 DEFINE_CLASS(OBJCMARSHAL,    ObjectiveC, ObjectiveCMarshal)
-DEFINE_METHOD(OBJCMARSHAL,   AVAILABLEUNHANDLEDEXCEPTIONPROPAGATION, AvailableUnhandledExceptionPropagation, SM_RetBool)
-DEFINE_METHOD(OBJCMARSHAL,   INVOKEUNHANDLEDEXCEPTIONPROPAGATION,    InvokeUnhandledExceptionPropagation,    SM_Exception_Obj_RefIntPtr_RetVoidPtr)
+DEFINE_METHOD(OBJCMARSHAL,   INVOKEUNHANDLEDEXCEPTIONPROPAGATION,    InvokeUnhandledExceptionPropagation,    SM_PtrException_IntPtr_PtrIntPtr_PtrException_RetVoidPtr)
 #endif // FEATURE_OBJCMARSHAL
 
 DEFINE_CLASS(IENUMERATOR,           Collections,            IEnumerator)

--- a/src/coreclr/vm/metasig.h
+++ b/src/coreclr/vm/metasig.h
@@ -187,7 +187,7 @@ DEFINE_METASIG_T(SM(IntPtr_CreateObjectFlags_RetObj, I g(CREATEOBJECTFLAGS), j))
 DEFINE_METASIG_T(SM(ManagedObjectWrapperHolder_RefGuid_RefIntPtr_RetInt, C(MANAGED_OBJECT_WRAPPER_HOLDER) r(g(GUID)) r(I), i))
 #endif // FEATURE_COMWRAPPERS
 #ifdef FEATURE_OBJCMARSHAL
-DEFINE_METASIG_T(SM(Exception_Obj_RefIntPtr_RetVoidPtr, C(EXCEPTION) j r(I), P(v)))
+DEFINE_METASIG_T(SM(PtrException_IntPtr_PtrIntPtr_PtrException_RetVoidPtr, P(C(EXCEPTION)) I P(I) P(C(EXCEPTION)), P(v)))
 #endif // FEATURE_OBJCMARSHAL
 DEFINE_METASIG(SM(Int_RetVoid, i, v))
 DEFINE_METASIG(SM(Int_RetObj, i, j))
@@ -200,7 +200,6 @@ DEFINE_METASIG_T(SM(Obj_Array_RetVoid, j C(ARRAY), v))
 DEFINE_METASIG(SM(Obj_IntPtr_Obj_RetVoid, j I j, v))
 DEFINE_METASIG(SM(RetIntPtr, _, I))
 DEFINE_METASIG(SM(RetUInt, _, K))
-DEFINE_METASIG(SM(RetBool, _, F))
 DEFINE_METASIG(SM(IntPtr_RetStr, I, s))
 DEFINE_METASIG(SM(Char_Bool_Bool_RetByte, u F F, b))
 DEFINE_METASIG(SM(Byte_RetChar, b, u))


### PR DESCRIPTION
Convert `AvailableUnhandledExceptionPropagation` and `InvokeUnhandledExceptionPropagation` to use `UnmanagedCallersOnly` reverse P/Invoke pattern instead of `MethodDescCallSite`/`CallDescrWorker`.

Part of #123864 (Priority 4 - ObjC interop).