### PR TITLE
Add null check in LCGMethodResolver::GetManagedResolver

### DIFF
--- a/src/coreclr/vm/dynamicmethod.cpp
+++ b/src/coreclr/vm/dynamicmethod.cpp
@@ -1555,8 +1555,10 @@ void LCGMethodResolver::GetEHInfo(unsigned EHnumber, CORINFO_EH_CLAUSE* clause)
 OBJECTREF LCGMethodResolver::GetManagedResolver()
 {
     LIMITED_METHOD_CONTRACT;
+#ifdef DACCESS_COMPILE
     if (m_managedResolver == (OBJECTHANDLE)NULL)
         return NULL;
+#endif // DACCESS_COMPILE
     return ObjectFromHandle(m_managedResolver);
 }
 

--- a/src/coreclr/vm/dynamicmethod.cpp
+++ b/src/coreclr/vm/dynamicmethod.cpp
@@ -1555,6 +1555,8 @@ void LCGMethodResolver::GetEHInfo(unsigned EHnumber, CORINFO_EH_CLAUSE* clause)
 OBJECTREF LCGMethodResolver::GetManagedResolver()
 {
     LIMITED_METHOD_CONTRACT;
+    if (m_managedResolver == NULL)
+        return NULL;
     return ObjectFromHandle(m_managedResolver);
 }
 

--- a/src/coreclr/vm/dynamicmethod.cpp
+++ b/src/coreclr/vm/dynamicmethod.cpp
@@ -1555,7 +1555,7 @@ void LCGMethodResolver::GetEHInfo(unsigned EHnumber, CORINFO_EH_CLAUSE* clause)
 OBJECTREF LCGMethodResolver::GetManagedResolver()
 {
     LIMITED_METHOD_CONTRACT;
-    if (m_managedResolver == NULL)
+    if (m_managedResolver == (OBJECTHANDLE)NULL)
         return NULL;
     return ObjectFromHandle(m_managedResolver);
 }


### PR DESCRIPTION
SOS's `dumplog` hits a crash when calling GetManagedResolver, because it can see a null m_managedResolver handle in diagnostic code that we wouldn't normally run into in the runtime.  This avoids the crash while writing out the stresslog.

I took a look at the callsites of the function, some of them do not check that the return value isn't null...but this change is safe simply because we would have been crashing on `return ObjectFromHandle(m_managedResolver);` anyway if this were a problem.  I don't think we need an assert at those callsites, but happy to add them if requested.

@jkotas fixes the issue you filed here: dotnet/diagnostics#1837