### PR TITLE
[Android NDK] Make API level configurable

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -32,7 +32,7 @@ The .NET Foundation licenses this file to you under the MIT license.
     <PropertyGroup>
       <!-- API level specified here MUST be the same as the one used by .NET for Android. .NET for Android targets will
            take care to always set this property. -->
-      <CrossCompileAndroidApiLevel Condition="'$(CrossCompileAndroidApiLevel)' == ''">24</CrossCompileAndroidApiLevel>
+      <CrossCompileAndroidApiLevel Condition="'$(CrossCompileAndroidApiLevel)' == ''">21</CrossCompileAndroidApiLevel>
 
       <UseSystemZlib Condition="'$(UseSystemZlib)' == '' and !Exists('$(IlcFrameworkNativePath)libz.a')">true</UseSystemZlib>
       <!-- Use libbrotlicommon.a as the sentinel for the three brotli libs. -->

--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Unix.targets
@@ -30,6 +30,10 @@ The .NET Foundation licenses this file to you under the MIT license.
   <Target Name="SetupOSSpecificProps" DependsOnTargets="$(IlcDynamicBuildPropertyDependencies)">
 
     <PropertyGroup>
+      <!-- API level specified here MUST be the same as the one used by .NET for Android. .NET for Android targets will
+           take care to always set this property. -->
+      <CrossCompileAndroidApiLevel Condition="'$(CrossCompileAndroidApiLevel)' == ''">24</CrossCompileAndroidApiLevel>
+
       <UseSystemZlib Condition="'$(UseSystemZlib)' == '' and !Exists('$(IlcFrameworkNativePath)libz.a')">true</UseSystemZlib>
       <!-- Use libbrotlicommon.a as the sentinel for the three brotli libs. -->
       <UseSystemBrotli Condition="'$(UseSystemBrotli)' == '' and !Exists('$(IlcFrameworkNativePath)libbrotlicommon.a')">true</UseSystemBrotli>
@@ -48,10 +52,10 @@ The .NET Foundation licenses this file to you under the MIT license.
       <CrossCompileArch Condition="$(CrossCompileRid.EndsWith('-arm'))">armv7</CrossCompileArch>
 
       <CrossCompileAbi>gnu</CrossCompileAbi>
-      <CrossCompileAbi Condition="$(CrossCompileRid.StartsWith('linux-bionic-')) or $(CrossCompileRid.StartsWith('android-'))">android21</CrossCompileAbi>
+      <CrossCompileAbi Condition="$(CrossCompileRid.StartsWith('linux-bionic-')) or $(CrossCompileRid.StartsWith('android-'))">android$(CrossCompileAndroidApiLevel)</CrossCompileAbi>
       <CrossCompileAbi Condition="$(CrossCompileRid.StartsWith('linux-musl-')) or $(CrossCompileRid.StartsWith('alpine-'))">musl</CrossCompileAbi>
       <CrossCompileAbi Condition="'$(CrossCompileRid)' == 'linux-arm'">gnueabihf</CrossCompileAbi>
-      <CrossCompileAbi Condition="'$(CrossCompileRid)' == 'linux-bionic-arm' or '$(CrossCompileRid)' == 'android-arm'">androideabi21</CrossCompileAbi>
+      <CrossCompileAbi Condition="'$(CrossCompileRid)' == 'linux-bionic-arm' or '$(CrossCompileRid)' == 'android-arm'">androideabi$(CrossCompileAndroidApiLevel)</CrossCompileAbi>
       <CrossCompileAbi Condition="'$(CrossCompileRid)' == 'linux-musl-arm'">musleabihf</CrossCompileAbi>
     </PropertyGroup>
 


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/9926
Context: https://github.com/dotnet/android/commit/bef768d5ffd4241e54e9b5d9209108d3ddd4aa0f

`.NET for Android` recently switched CoreCLR and NativeAOT NDK API levels from 21 to 24, which uncovered an issue in the NativeAOT `Microsoft.NETCore.Native.Unix.targets` `SetupOSSpecificProps` target, where the target hardcodes the Android API level to `21`.

This causes the following link error when trying to build an Android NativeAOT application:

```
ld.lld : error : undefined symbol: __gnu_strerror_r
ld.lld : error : undefined symbol: stderr
```

The reason for this is that API 24 `libc.so` contains these two symbols, while the one from API 21 does not. Since `.NET for Android` runtime is built with API 24, and `NativeAOT` build forces the API 21 level by passing the `--target=${ARCH}-linux-android21` argument to the linker, we get the above error.

This PR makes the API level configurable and default to 24. The default value is merely the
current API level `.NET for Android` targets, it doesn't need to be updated in the future - the `.NET for Android` targets will take care of setting the property to the appropriate value, should the default change.