### PR TITLE
[HTTP] Fix HttpListener tests blocking xunit workers (#21870)

### DIFF
--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerContextTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerContextTests.cs
@@ -243,7 +243,7 @@ namespace System.Net.Tests
         {
             using (Socket client = Factory.GetConnectedSocket())
             {
-                client.Send(Factory.GetContent("1.1", "POST", null, "Text", headers, true));
+                await client.SendAsync(Factory.GetContent("1.1", "POST", null, "Text", headers, true));
 
                 HttpListener listener = Factory.GetListener();
                 await contextAction(await listener.GetContextAsync());

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerRequestTests.cs
@@ -26,8 +26,8 @@ namespace System.Net.Tests
 
         public void Dispose()
         {
-            Factory?.Dispose();
             Client?.Dispose();
+            Factory?.Dispose();
         }
 
         [Theory]
@@ -271,7 +271,7 @@ namespace System.Net.Tests
         public async Task GetClientCertificateAsync_NoCertificate_ReturnsNull()
         {
             HttpListenerRequest request = await GetRequest("POST", null, null);
-            Assert.Null(request.GetClientCertificateAsync().Result);
+            Assert.Null(await request.GetClientCertificateAsync());
         }
 
         [Fact]
@@ -602,7 +602,7 @@ namespace System.Net.Tests
 
         private async Task<HttpListenerRequest> GetRequest(string requestType, string query, string[] headers, string content = "Text\r\n", string httpVersion = "1.1")
         {
-            Client.Send(Factory.GetContent(httpVersion, requestType, query, content, headers, true));
+            await Client.SendAsync(Factory.GetContent(httpVersion, requestType, query, content, headers, true));
 
             HttpListener listener = Factory.GetListener();
             return (await listener.GetContextAsync()).Request;

--- a/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpListenerResponseTests.cs
@@ -50,7 +50,7 @@ namespace System.Net.Tests
 
         protected async Task<HttpListenerResponse> GetResponse(string httpVersion = "1.1")
         {
-            Client.Send(Factory.GetContent(httpVersion, "POST", null, "Give me a context, please", null, headerOnly: false));
+            await Client.SendAsync(Factory.GetContent(httpVersion, "POST", null, "Give me a context, please", null, headerOnly: false));
             HttpListenerContext context = await Factory.GetListener().GetContextAsync();
             return context.Response;
         }
@@ -157,7 +157,7 @@ namespace System.Net.Tests
         [ConditionalFact(nameof(Helpers) + "." + nameof(Helpers.IsWindowsImplementation))] // [ActiveIssue("https://github.com/dotnet/runtime/issues/21808", TestPlatforms.AnyUnix)]
         public async Task Abort_Invoke_ForciblyTerminatesConnection()
         {
-            Client.Send(Factory.GetContent("1.1", "POST", null, "Give me a context, please", null, headerOnly: false));
+            await Client.SendAsync(Factory.GetContent("1.1", "POST", null, "Give me a context, please", null, headerOnly: false));
             HttpListenerContext context = await Factory.GetListener().GetContextAsync();
             HttpListenerResponse response = context.Response;
             Stream outputStream = response.OutputStream;
@@ -415,7 +415,7 @@ namespace System.Net.Tests
             using (Socket client = factory.GetConnectedSocket())
             {
                 // Send a header to the HttpListener to give it a context.
-                client.Send(factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
+                await client.SendAsync(factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
                 HttpListener listener = factory.GetListener();
                 HttpListenerContext context = await listener.GetContextAsync();
 

--- a/src/libraries/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpRequestStreamTests.cs
@@ -663,7 +663,7 @@ namespace System.Net.Tests
                 // If the content is missing, then the HttpListener needs
                 // to get the content. However, the socket has been closed
                 // before the reading of the content, so reading should fail.
-                client.Send(_factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
+                await client.SendAsync(_factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
                 HttpListenerContext context = await _listener.GetContextAsync();
 
                 // Disconnect the Socket from the HttpListener.
@@ -689,7 +689,7 @@ namespace System.Net.Tests
                 // If the content is missing, then the HttpListener needs
                 // to get the content. However, the socket has been closed
                 // before the reading of the content, so reading should fail.
-                client.Send(_factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
+                await client.SendAsync(_factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
                 HttpListenerContext context = await _listener.GetContextAsync();
 
                 // Disconnect the Socket from the HttpListener.

--- a/src/libraries/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
+++ b/src/libraries/System.Net.HttpListener/tests/HttpResponseStreamTests.cs
@@ -390,7 +390,7 @@ namespace System.Net.Tests
             using (Socket client = factory.GetConnectedSocket())
             {
                 // Send a header to the HttpListener to give it a context.
-                client.Send(factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
+                await client.SendAsync(factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
                 HttpListener listener = factory.GetListener();
                 listener.IgnoreWriteExceptions = ignoreWriteExceptions;
                 HttpListenerContext context = await listener.GetContextAsync();
@@ -428,7 +428,7 @@ namespace System.Net.Tests
             using (Socket client = factory.GetConnectedSocket())
             {
                 // Send a header to the HttpListener to give it a context.
-                client.Send(factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
+                await client.SendAsync(factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
                 HttpListener listener = factory.GetListener();
                 listener.IgnoreWriteExceptions = ignoreWriteExceptions;
                 HttpListenerContext context = await listener.GetContextAsync();
@@ -468,7 +468,7 @@ namespace System.Net.Tests
             using (Socket client = factory.GetConnectedSocket())
             {
                 // Send a header to the HttpListener to give it a context.
-                client.Send(factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
+                await client.SendAsync(factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
                 HttpListener listener = factory.GetListener();
                 listener.IgnoreWriteExceptions = ignoreWriteExceptions;
                 HttpListenerContext context = await listener.GetContextAsync();
@@ -508,7 +508,7 @@ namespace System.Net.Tests
             using (Socket client = factory.GetConnectedSocket())
             {
                 // Send a header to the HttpListener to give it a context.
-                client.Send(factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
+                await client.SendAsync(factory.GetContent(RequestTypes.POST, Text, headerOnly: true));
                 HttpListener listener = factory.GetListener();
                 listener.IgnoreWriteExceptions = ignoreWriteExceptions;
                 HttpListenerContext context = await listener.GetContextAsync();

--- a/src/libraries/System.Net.HttpListener/tests/XUnitAssemblyAttributes.cs
+++ b/src/libraries/System.Net.HttpListener/tests/XUnitAssemblyAttributes.cs
@@ -3,6 +3,4 @@
 
 using Xunit;
 
-// [ActiveIssue("https://github.com/dotnet/runtime/issues/21870")]: Disabling parallel execution of HttpListener tests
-// until all of the hangs can be addressed
-[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true, MaxParallelThreads = 1)]
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]


### PR DESCRIPTION
Replace blocking patterns that cause deadlocks when xunit parallel execution is enabled:

- Replace .Result with await on task completions
- Replace Task.Run(() => GetContext()) with GetContextAsync()
- Replace Task.Run(() => Receive()) with ReceiveAsync()
- Convert synchronous Socket.Send() to SendAsync() in async methods
- Re-enable parallel test execution by removing DisableTestParallelization and MaxParallelThreads = 1
- Fix disposal order in HttpListenerRequestTests to close the client socket before the listener, avoiding a 1s linger timeout per test

Fixes #21870