### PR TITLE
ArrayBufferWriter double grow boundary fix

### DIFF
--- a/src/libraries/Common/src/System/Buffers/ArrayBufferWriter.cs
+++ b/src/libraries/Common/src/System/Buffers/ArrayBufferWriter.cs
@@ -220,7 +220,7 @@ namespace System.Buffers
 
                 int newSize = currentLength + growBy;
 
-                if ((uint)newSize > int.MaxValue)
+                if ((uint)newSize > ArrayMaxLength)
                 {
                     // Attempt to grow to ArrayMaxLength.
                     uint needed = (uint)(currentLength - FreeCapacity + sizeHint);


### PR DESCRIPTION
ArrayBufferWriter unexpectedly fails to reallocate if current length is int.MaxValue/2, e.g.:

var abw = new ArrayBufferWriter<byte>(int.MaxValue / 2);
abw.Advance(abw.Capacity);
abw.GetMemory(1); // throws

Unfortunately it's hard to write a test because the result will be OutOfMemoryException, same as if there is just not enough memory.

Found by Linux Verification Center (linuxtesting.org).
