### PR TITLE
JIT: Handle LCL_ADDR in TreeLifeUpdater

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -469,7 +469,7 @@ void AsyncLiveness::StartBlock(BasicBlock* block)
 //
 void AsyncLiveness::Update(GenTree* node)
 {
-    m_updater.UpdateLife(node);
+    m_updater.UpdateLife<true>(node);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -591,7 +591,7 @@ void CodeGen::genMarkLabelsForCodegen()
 
 void CodeGenInterface::genUpdateLife(GenTree* tree)
 {
-    treeLifeUpdater->UpdateLife(tree);
+    treeLifeUpdater->UpdateLife<false>(tree);
 }
 
 void CodeGenInterface::genUpdateLife(VARSET_VALARG_TP newLife)

--- a/src/coreclr/jit/copyprop.cpp
+++ b/src/coreclr/jit/copyprop.cpp
@@ -404,7 +404,7 @@ bool Compiler::optBlockCopyProp(BasicBlock* block, LclNumToLiveDefsMap* curSsaNa
         // SSA renaming process.
         for (GenTree* const tree : stmt->TreeList())
         {
-            treeLifeUpdater.UpdateLife(tree);
+            treeLifeUpdater.UpdateLife<false>(tree);
 
             if (tree->OperIsSsaDef())
             {

--- a/src/coreclr/jit/treelifeupdater.cpp
+++ b/src/coreclr/jit/treelifeupdater.cpp
@@ -285,7 +285,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree, GenTreeLclVarComm
 //    tree - the tree which effect on liveness is processed.
 //
 template <bool ForCodeGen>
-template <bool ProcessLclAddrs>
+template <bool GeneralLclAddrHandling>
 void TreeLifeUpdater<ForCodeGen>::UpdateLife(GenTree* tree)
 {
     assert(m_compiler->GetCurLVEpoch() == epoch);
@@ -300,7 +300,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLife(GenTree* tree)
     {
         UpdateLifeVar(tree, tree->AsLclVarCommon());
     }
-    else if (tree->OperIsIndir() && tree->AsIndir()->Addr()->OperIs(GT_LCL_ADDR))
+    else if (!GeneralLclAddrHandling && tree->OperIsIndir() && tree->AsIndir()->Addr()->OperIs(GT_LCL_ADDR))
     {
         UpdateLifeVar(tree, tree->AsIndir()->Addr()->AsLclVarCommon());
     }
@@ -312,7 +312,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLife(GenTree* tree)
         };
         tree->VisitLocalDefNodes(m_compiler, visitDef);
     }
-    else if (ProcessLclAddrs && tree->OperIs(GT_LCL_ADDR))
+    else if (GeneralLclAddrHandling && tree->OperIs(GT_LCL_ADDR))
     {
         UpdateLifeVar(tree, tree->AsLclVarCommon());
     }

--- a/src/coreclr/jit/treelifeupdater.cpp
+++ b/src/coreclr/jit/treelifeupdater.cpp
@@ -285,6 +285,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLifeVar(GenTree* tree, GenTreeLclVarComm
 //    tree - the tree which effect on liveness is processed.
 //
 template <bool ForCodeGen>
+template <bool ProcessLclAddrs>
 void TreeLifeUpdater<ForCodeGen>::UpdateLife(GenTree* tree)
 {
     assert(m_compiler->GetCurLVEpoch() == epoch);
@@ -311,7 +312,7 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLife(GenTree* tree)
         };
         tree->VisitLocalDefNodes(m_compiler, visitDef);
     }
-    else if (tree->OperIs(GT_LCL_ADDR))
+    else if (ProcessLclAddrs && tree->OperIs(GT_LCL_ADDR))
     {
         UpdateLifeVar(tree, tree->AsLclVarCommon());
     }
@@ -409,3 +410,6 @@ void TreeLifeUpdater<ForCodeGen>::DumpLifeDelta(GenTree* tree)
 
 template class TreeLifeUpdater<true>;
 template class TreeLifeUpdater<false>;
+template void TreeLifeUpdater<false>::UpdateLife<false>(GenTree*);
+template void TreeLifeUpdater<false>::UpdateLife<true>(GenTree*);
+template void TreeLifeUpdater<true>::UpdateLife<false>(GenTree*);

--- a/src/coreclr/jit/treelifeupdater.cpp
+++ b/src/coreclr/jit/treelifeupdater.cpp
@@ -311,6 +311,10 @@ void TreeLifeUpdater<ForCodeGen>::UpdateLife(GenTree* tree)
         };
         tree->VisitLocalDefNodes(m_compiler, visitDef);
     }
+    else if (tree->OperIs(GT_LCL_ADDR))
+    {
+        UpdateLifeVar(tree, tree->AsLclVarCommon());
+    }
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/treelifeupdater.h
+++ b/src/coreclr/jit/treelifeupdater.h
@@ -13,7 +13,7 @@ class TreeLifeUpdater
 {
 public:
     TreeLifeUpdater(Compiler* compiler);
-    template<bool ProcessLclAddrs>
+    template <bool ProcessLclAddrs>
     void UpdateLife(GenTree* tree);
     bool UpdateLifeFieldVar(GenTreeLclVar* lclNode, unsigned multiRegIndex);
 

--- a/src/coreclr/jit/treelifeupdater.h
+++ b/src/coreclr/jit/treelifeupdater.h
@@ -13,6 +13,7 @@ class TreeLifeUpdater
 {
 public:
     TreeLifeUpdater(Compiler* compiler);
+    template<bool ProcessLclAddrs>
     void UpdateLife(GenTree* tree);
     bool UpdateLifeFieldVar(GenTreeLclVar* lclNode, unsigned multiRegIndex);
 

--- a/src/coreclr/jit/treelifeupdater.h
+++ b/src/coreclr/jit/treelifeupdater.h
@@ -13,7 +13,7 @@ class TreeLifeUpdater
 {
 public:
     TreeLifeUpdater(Compiler* compiler);
-    template <bool ProcessLclAddrs>
+    template <bool GeneralLclAddrHandling>
     void UpdateLife(GenTree* tree);
     bool UpdateLifeFieldVar(GenTreeLclVar* lclNode, unsigned multiRegIndex);
 


### PR DESCRIPTION
We wouldn't handle `GTF_VAR_DEATH` on `LCL_ADDR` nodes, which would cause us to keep thinking these were live in the async transformation. That wouldn't cause issues but it was conservative.