### PR TITLE
Build zstd with `/source-charset:utf-8` option

### DIFF
--- a/src/native/external/zstd.cmake
+++ b/src/native/external/zstd.cmake
@@ -53,3 +53,6 @@ endif()
 
 # disable warnings that occur in the zstd library
 target_compile_options(libzstd_static PRIVATE $<$<COMPILE_LANG_AND_ID:C,Clang,AppleClang,GNU>:-Wno-implicit-fallthrough>)
+
+# Avoid errors caused by non-ASCII characters
+target_compile_options(libzstd_static PRIVATE $<$<COMPILE_LANG_AND_ID:C,MSVC>:/source-charset:utf-8>)

--- a/src/native/external/zstd/lib/compress/zstd_compress.c
+++ b/src/native/external/zstd/lib/compress/zstd_compress.c
@@ -7404,7 +7404,7 @@ BlockSummary ZSTD_get1BlockSummary(const ZSTD_Sequence* seqs, size_t nbSeqs)
 
     /* Process 2 structs (32 bytes) at a time */
     for (i = 0; i + 2 <= nbSeqs; i += 2) {
-        /* Load two consecutive ZSTD_Sequence (8×4 = 32 bytes) */
+        /* Load two consecutive ZSTD_Sequence (8x4 = 32 bytes) */
         __m256i data     = _mm256_loadu_si256((const __m256i*)(const void*)&seqs[i]);
         /* check end of block signal */
         __m256i cmp      = _mm256_cmpeq_epi32(data, zeroVec);

--- a/src/native/external/zstd/lib/compress/zstd_compress.c
+++ b/src/native/external/zstd/lib/compress/zstd_compress.c
@@ -7404,7 +7404,7 @@ BlockSummary ZSTD_get1BlockSummary(const ZSTD_Sequence* seqs, size_t nbSeqs)
 
     /* Process 2 structs (32 bytes) at a time */
     for (i = 0; i + 2 <= nbSeqs; i += 2) {
-        /* Load two consecutive ZSTD_Sequence (8x4 = 32 bytes) */
+        /* Load two consecutive ZSTD_Sequence (8×4 = 32 bytes) */
         __m256i data     = _mm256_loadu_si256((const __m256i*)(const void*)&seqs[i]);
         /* check end of block signal */
         __m256i cmp      = _mm256_cmpeq_epi32(data, zeroVec);


### PR DESCRIPTION
Fix #124474
