### PR TITLE
Add default value when FeatureDynamicCodeCompiled is undefined

### DIFF
--- a/src/coreclr/runtime.proj
+++ b/src/coreclr/runtime.proj
@@ -54,7 +54,7 @@
       <_CoreClrBuildArg Condition="'$(HasCdacBuildTool)' == 'true'" Include="-cmakeargs &quot;-DCDAC_BUILD_TOOL_BINARY_PATH=$(RuntimeBinDir)cdac-build-tool\cdac-build-tool.dll&quot;" />
       <_CoreClrBuildArg Condition="'$(FeatureXplatEventSource)' == 'false'" Include="-cmakeargs &quot;-DFEATURE_EVENTSOURCE_XPLAT=0&quot;" />
       <_CoreClrBuildArg Condition="'$(FeatureInterpreter)' == 'true'" Include="-cmakeargs &quot;-DFEATURE_INTERPRETER=1&quot;" />
-      <_CoreClrBuildArg Condition="'$(FeatureDynamicCodeCompiled)' == 'true'" Include="-cmakeargs &quot;-DFEATURE_DYNAMIC_CODE_COMPILED=1&quot;" />
+      <_CoreClrBuildArg Condition="'$(FeatureDynamicCodeCompiled)' == 'true' or '$(FeatureDynamicCodeCompiled)' == ''" Include="-cmakeargs &quot;-DFEATURE_DYNAMIC_CODE_COMPILED=1&quot;" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(CxxStandardLibrary)' != ''">


### PR DESCRIPTION
This property is normally passed to msbuild when building runtime.proj, with a true or false value. An exception happens when building from vs, with `./build.cmd -vs coreclr.slnx`. Feature defines need to have a default value for this scenario. Rather than adding a default in clrfeatures.cmake, which would require duplicating target os logic from the build scripts, this commit handles the default at a higher level in runtime.proj.