### PR TITLE
[RyuJit/WASM] Register allocation for multiply used operands

### DIFF
--- a/src/coreclr/jit/codegen.h
+++ b/src/coreclr/jit/codegen.h
@@ -214,7 +214,8 @@ protected:
     ArrayStack<WasmInterval*>* wasmControlFlowStack = nullptr;
     unsigned                   wasmCursor           = 0;
     unsigned                   findTargetDepth(BasicBlock* target);
-    regNumber                  MakeOperandMultiUse(GenTree* node, GenTree* operand);
+    void                       WasmProduceReg(GenTree* node);
+    regNumber                  GetMultiUseOperandReg(GenTree* operand);
 #endif
 
     void        genEmitStartBlock(BasicBlock* block);

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -40,6 +40,11 @@ public:
 
             RegOptional = 0x04, // Set on a node if it produces a value, but does not
                                 // require a register (i.e. it can be used from memory).
+
+#ifdef TARGET_WASM
+            MultiplyUsed = 0x08, // Set by lowering on nodes that the RA should allocate into
+                                 // a dedicated register (WASM local), for multiple uses.
+#endif                           // TARGET_WASM
         };
     };
 

--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -416,11 +416,7 @@ GenTree* Lowering::LowerNode(GenTree* node)
 
         case GT_UDIV:
         case GT_UMOD:
-            if (!LowerUnsignedDivOrMod(node->AsOp()))
-            {
-                ContainCheckDivOrMod(node->AsOp());
-            }
-            break;
+            return LowerUnsignedDivOrMod(node->AsOp());
 
         case GT_DIV:
         case GT_MOD:
@@ -8023,7 +8019,25 @@ GenTree* Lowering::LowerAdd(GenTreeOp* node)
 // LowerUnsignedDivOrMod: Lowers a GT_UDIV/GT_UMOD node.
 //
 // Arguments:
-//    divMod - pointer to the GT_UDIV/GT_UMOD node to be lowered
+//    divMod - the GT_UDIV/GT_UMOD node to be lowered
+//
+// Return Value:
+//    The next node to lower.
+//
+GenTree* Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
+{
+    if (!TryLowerConstIntUDivOrUMod(divMod))
+    {
+        LowerDivOrMod(divMod);
+    }
+    return divMod->gtNext;
+}
+
+//------------------------------------------------------------------------
+// LowerConstIntUDivOrUMod: Lowers a GT_UDIV/GT_UMOD node with a constant divisor.
+//
+// Arguments:
+//    divMod - the GT_UDIV/GT_UMOD node to be lowered
 //
 // Return Value:
 //    Returns a boolean indicating whether the node was transformed.
@@ -8033,8 +8047,7 @@ GenTree* Lowering::LowerAdd(GenTreeOp* node)
 //    - Transform UDIV by constant >= 2^(N-1) into GE
 //    - Transform UDIV/UMOD by constant >= 3 into "magic division"
 //
-
-bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
+bool Lowering::TryLowerConstIntUDivOrUMod(GenTreeOp* divMod)
 {
     assert(divMod->OperIs(GT_UDIV, GT_UMOD));
 
@@ -8125,7 +8138,7 @@ bool Lowering::LowerUnsignedDivOrMod(GenTreeOp* divMod)
         }
     }
 
-// TODO-ARM-CQ: Currently there's no GT_MULHI for ARM32
+    // TODO-ARM-CQ: Currently there's no GT_MULHI for ARM32
 #if defined(TARGET_XARCH) || defined(TARGET_ARM64) || defined(TARGET_LOONGARCH64) || defined(TARGET_RISCV64)
     if (!m_compiler->opts.MinOpts() && (divisorValue >= 3))
     {
@@ -8639,10 +8652,26 @@ GenTree* Lowering::LowerSignedDivOrMod(GenTree* node)
         }
         assert(nextNode == nullptr);
     }
-    ContainCheckDivOrMod(node->AsOp());
 
+    LowerDivOrMod(node->AsOp());
     return node->gtNext;
 }
+
+#ifndef TARGET_WASM
+//------------------------------------------------------------------------
+// LowerDivOrMod: Lowers a GT_[U]DIV/GT_[U]MOD node.
+//
+// Target-specific lowering, called **after** the possible transformation
+// into 'magic' division.
+//
+// Arguments:
+//    divMod - the node to be lowered
+//
+void Lowering::LowerDivOrMod(GenTreeOp* divMod)
+{
+    ContainCheckDivOrMod(divMod);
+}
+#endif // !TARGET_WASM
 
 //------------------------------------------------------------------------
 // TryFoldBinop: Try removing a binop node by constant folding.

--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -395,9 +395,11 @@ private:
     GenTree* LowerMul(GenTreeOp* mul);
     bool     TryLowerAndNegativeOne(GenTreeOp* node, GenTree** nextNode);
     GenTree* LowerBinaryArithmetic(GenTreeOp* binOp);
-    bool     LowerUnsignedDivOrMod(GenTreeOp* divMod);
+    GenTree* LowerUnsignedDivOrMod(GenTreeOp* divMod);
+    bool     TryLowerConstIntUDivOrUMod(GenTreeOp* divMod);
     bool     TryLowerConstIntDivOrMod(GenTree* node, GenTree** nextNode);
     GenTree* LowerSignedDivOrMod(GenTree* node);
+    void     LowerDivOrMod(GenTreeOp* divMod);
     void     LowerBlockStore(GenTreeBlk* blkNode);
     void     LowerBlockStoreCommon(GenTreeBlk* blkNode);
     void     LowerBlockStoreAsHelperCall(GenTreeBlk* blkNode);

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -164,6 +164,30 @@ GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
 }
 
 //------------------------------------------------------------------------
+// LowerDivOrMod: Lowers a GT_[U]DIV/GT_[U]MOD node.
+//
+// Mark operands that need multiple uses for exception-inducing checks.
+//
+// Arguments:
+//    divMod - the node to be lowered
+//
+void Lowering::LowerDivOrMod(GenTreeOp* divMod)
+{
+    ExceptionSetFlags exSetFlags = divMod->OperExceptions(m_compiler);
+    if ((exSetFlags & ExceptionSetFlags::ArithmeticException) != ExceptionSetFlags::None)
+    {
+        divMod->gtGetOp1()->gtLIRFlags |= LIR::Flags::MultiplyUsed;
+        divMod->gtGetOp2()->gtLIRFlags |= LIR::Flags::MultiplyUsed;
+    }
+    else if ((exSetFlags & ExceptionSetFlags::DivideByZeroException) != ExceptionSetFlags::None)
+    {
+        divMod->gtGetOp2()->gtLIRFlags |= LIR::Flags::MultiplyUsed;
+    }
+
+    ContainCheckDivOrMod(divMod);
+}
+
+//------------------------------------------------------------------------
 // LowerBlockStore: Lower a block store node
 //
 // Arguments:

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -440,7 +440,7 @@ void WasmRegAlloc::ConsumeTemporaryRegForOperand(GenTree* operand DEBUGARG(const
 //
 void WasmRegAlloc::ResolveReferences()
 {
-    // Finish the allocation by allocating temprary registers to virtual registers.
+    // Finish the allocation by allocating temporary registers to virtual registers.
     struct TemporaryRegBank
     {
         regNumber* Regs;

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -186,7 +186,7 @@ regNumber WasmRegAlloc::AllocateVirtualRegister(WasmValueType type)
 }
 
 //------------------------------------------------------------------------
-// AllocateInternalRegister: Allocate a new internal (virtual) register.
+// AllocateTemporaryRegister: Allocate a new temporary (virtual) register.
 //
 // Arguments:
 //    type - The register's type
@@ -195,29 +195,31 @@ regNumber WasmRegAlloc::AllocateVirtualRegister(WasmValueType type)
 //    The allocated register.
 //
 // Notes:
-//    Internal (virtual) regisers live in an index space different from
+//    Temporary (virtual) regisers live in an index space different from
 //    the ordinary virtual registers, to which they are mapped just before
 //    resolution.
 //
-regNumber WasmRegAlloc::AllocateInternalRegister(var_types type)
+regNumber WasmRegAlloc::AllocateTemporaryRegister(var_types type)
 {
     WasmValueType wasmType = TypeToWasmValueType(type);
-    unsigned      index    = m_internalRegs[static_cast<unsigned>(wasmType)].Push();
+    unsigned      index    = m_temporaryRegs[static_cast<unsigned>(wasmType)].Push();
     return MakeWasmReg(index, wasmType);
 }
 
 //------------------------------------------------------------------------
-// FreeInternalRegisters: Release the currently allocated internal registers.
+// ReleaseTemporaryRegister: Release the most recently allocated temporary register.
 //
-// Call this after processing a node that required internal registers to
-// make them available for the next node.
+// Arguments:
+//    type - The register's type
 //
-void WasmRegAlloc::FreeInternalRegisters()
+// Return Value:
+//    The released register.
+//
+regNumber WasmRegAlloc::ReleaseTemporaryRegister(var_types type)
 {
-    for (WasmValueType type = WasmValueType::First; type < WasmValueType::Count; ++type)
-    {
-        m_internalRegs[static_cast<unsigned>(type)].PopAll();
-    }
+    WasmValueType wasmType = TypeToWasmValueType(type);
+    unsigned      index    = m_temporaryRegs[static_cast<unsigned>(wasmType)].Pop();
+    return MakeWasmReg(index, wasmType);
 }
 
 //------------------------------------------------------------------------
@@ -284,27 +286,22 @@ void WasmRegAlloc::CollectReferencesForNode(GenTree* node)
             assert(!node->OperIsLocalStore());
             break;
     }
+
+    RequestTemporaryRegisterForMultiplyUsedNode(node);
 }
 
 //------------------------------------------------------------------------
 // CollectReferencesForDivMod: Collect virtual register references for a DIV/MOD.
 //
-// Allocates internal registers for the div-by-zero and overflow checks.
+// Consumes temporary registers for the div-by-zero and overflow checks.
 //
 // Arguments:
 //    divModNode - The [U]DIV/[U]MOD node
 //
 void WasmRegAlloc::CollectReferencesForDivMod(GenTreeOp* divModNode)
 {
-    ExceptionSetFlags exSetFlags = divModNode->OperExceptions(m_compiler);
-
-    // TODO-WASM: implement overflow checking.
-    if ((exSetFlags & ExceptionSetFlags::DivideByZeroException) != ExceptionSetFlags::None)
-    {
-        RequestInternalRegForOperand(divModNode, divModNode->gtGetOp2() DEBUGARG("div by zero check - divisor"));
-    }
-
-    FreeInternalRegisters();
+    ConsumeTemporaryRegForOperand(divModNode->gtGetOp2() DEBUGARG("div-by-zero / overflow check"));
+    ConsumeTemporaryRegForOperand(divModNode->gtGetOp1() DEBUGARG("div-by-zero / overflow check"));
 }
 
 //------------------------------------------------------------------------
@@ -362,7 +359,7 @@ void WasmRegAlloc::RewriteLocalStackStore(GenTreeLclVarCommon* lclNode)
 // Arguments:
 //    node - The node to collect
 //
-void WasmRegAlloc::CollectReference(GenTreeLclVarCommon* node)
+void WasmRegAlloc::CollectReference(GenTree* node)
 {
     VirtualRegReferences* refs = m_virtualRegRefs;
     if (refs == nullptr)
@@ -382,26 +379,58 @@ void WasmRegAlloc::CollectReference(GenTreeLclVarCommon* node)
     refs->Nodes[m_lastVirtualRegRefsCount++] = node;
 }
 
-//------------------------------------------------------------------------
-// RequestInternalRegForOperand: Add an internal register to 'node' if needed.
-//
-// So that 'operand' can be used multiple times in codegen. Thus we can skip
-// adding internal registers when 'operand' is a candidate, expecting codegen
-// to use the local assigned to 'operand' directly.
-//
-// Arguments:
-//    node - The node to add internal registers
-//
-void WasmRegAlloc::RequestInternalRegForOperand(GenTree* node, GenTree* operand DEBUGARG(const char* reason))
+void WasmRegAlloc::RequestTemporaryRegisterForMultiplyUsedNode(GenTree* node)
 {
-    if (operand->OperIs(GT_LCL_VAR) && m_compiler->lvaGetDesc(operand->AsLclVar())->lvIsRegCandidate())
+    if ((node->gtLIRFlags & LIR::Flags::MultiplyUsed) == LIR::Flags::None)
     {
         return;
     }
 
-    regNumber reg = AllocateInternalRegister(genActualType(operand));
-    m_codeGen->internalRegisters.Add(node, reg);
-    JITDUMP("Allocated an internal reg for [%06u]: %s\n", Compiler::dspTreeID(node), reason);
+    assert(node->IsValue());
+    if (node->IsUnusedValue())
+    {
+        // Liveness removed the parent node - no need to do anything.
+        node->gtLIRFlags &= ~LIR::Flags::MultiplyUsed;
+        return;
+    }
+
+    if (node->OperIs(GT_LCL_VAR) && m_compiler->lvaGetDesc(node->AsLclVar())->lvIsRegCandidate())
+    {
+        // Will be allocated into its own register, no need for a temporary.
+        node->gtLIRFlags &= ~LIR::Flags::MultiplyUsed;
+        return;
+    }
+
+    // Note how due to the fact we're processing nodes in stack order,
+    // we don't need to maintain free/busy sets, only a simple stack.
+    regNumber reg = AllocateTemporaryRegister(genActualType(node));
+    node->SetRegNum(reg);
+}
+
+//------------------------------------------------------------------------
+// ConsumeTemporaryRegForOperand: Consume the temporary register for a multiply-used operand.
+//
+// The contract with codegen is that such operands will have their register
+// number set to a valid WASM local, to be "local.tee"d after the node is
+// generated.
+//
+// Arguments:
+//    operand - The node to consume the register for
+//    reason  - What was the register allocated for
+//
+void WasmRegAlloc::ConsumeTemporaryRegForOperand(GenTree* operand DEBUGARG(const char* reason))
+{
+    if ((operand->gtLIRFlags & LIR::Flags::MultiplyUsed) == LIR::Flags::None)
+    {
+        return;
+    }
+
+    regNumber reg = ReleaseTemporaryRegister(genActualType(operand));
+    assert(reg == operand->GetRegNum());
+    CollectReference(operand);
+
+    operand->gtLIRFlags &= ~LIR::Flags::MultiplyUsed;
+    JITDUMP("Consumed a temporary reg for [%06u]: %s\n", Compiler::dspTreeID(operand), reason);
 }
 
 //------------------------------------------------------------------------
@@ -411,23 +440,29 @@ void WasmRegAlloc::RequestInternalRegForOperand(GenTree* node, GenTree* operand 
 //
 void WasmRegAlloc::ResolveReferences()
 {
-    // Finish the allocation by allocating internal registers to virtual registers.
-    struct InternalRegBank
+    // Finish the allocation by allocating temprary registers to virtual registers.
+    struct TemporaryRegBank
     {
-        regNumber Regs[InternalRegs::MAX_REG_COUNT];
-        unsigned  Count;
+        regNumber* Regs;
+        unsigned   Count;
     };
-    InternalRegBank internalRegMap[static_cast<unsigned>(WasmValueType::Count)];
+    TemporaryRegBank temporaryRegMap[static_cast<unsigned>(WasmValueType::Count)];
     for (WasmValueType type = WasmValueType::First; type < WasmValueType::Count; ++type)
     {
-        InternalRegStack& internalRegs          = m_internalRegs[static_cast<unsigned>(type)];
-        InternalRegBank&  allocatedInternalRegs = internalRegMap[static_cast<unsigned>(type)];
-        assert(internalRegs.Count == 0);
+        TemporaryRegStack& temporaryRegs          = m_temporaryRegs[static_cast<unsigned>(type)];
+        TemporaryRegBank&  allocatedTemporaryRegs = temporaryRegMap[static_cast<unsigned>(type)];
+        assert(temporaryRegs.Count == 0);
 
-        allocatedInternalRegs.Count = internalRegs.MaxCount;
-        for (unsigned i = 0; i < allocatedInternalRegs.Count; i++)
+        allocatedTemporaryRegs.Count = temporaryRegs.MaxCount;
+        if (allocatedTemporaryRegs.Count == 0)
         {
-            allocatedInternalRegs.Regs[i] = AllocateVirtualRegister(type);
+            continue;
+        }
+
+        allocatedTemporaryRegs.Regs = new (m_compiler->getAllocator(CMK_LSRA)) regNumber[allocatedTemporaryRegs.Count];
+        for (unsigned i = 0; i < allocatedTemporaryRegs.Count; i++)
+        {
+            allocatedTemporaryRegs.Regs[i] = AllocateVirtualRegister(type);
         }
     }
 
@@ -552,10 +587,10 @@ void WasmRegAlloc::ResolveReferences()
 
     for (WasmValueType type = WasmValueType::First; type < WasmValueType::Count; ++type)
     {
-        InternalRegBank& internalRegs = internalRegMap[static_cast<unsigned>(type)];
-        for (unsigned i = 0; i < internalRegs.Count; i++)
+        TemporaryRegBank& regs = temporaryRegMap[static_cast<unsigned>(type)];
+        for (unsigned i = 0; i < regs.Count; i++)
         {
-            internalRegs.Regs[i] = allocPhysReg(internalRegs.Regs[i], nullptr);
+            regs.Regs[i] = allocPhysReg(regs.Regs[i], nullptr);
         }
     }
 
@@ -565,9 +600,21 @@ void WasmRegAlloc::ResolveReferences()
     {
         for (size_t i = 0; i < refsCount; i++)
         {
-            GenTreeLclVarCommon* node   = refs->Nodes[i];
-            LclVarDsc*           varDsc = m_compiler->lvaGetDesc(node);
-            node->SetRegNum(varDsc->GetRegNum());
+            regNumber physReg;
+            GenTree*  node = refs->Nodes[i];
+            if (node->OperIs(GT_STORE_LCL_VAR))
+            {
+                physReg = m_compiler->lvaGetDesc(node->AsLclVarCommon())->GetRegNum();
+            }
+            else
+            {
+                assert(!node->OperIsLocal() || !m_compiler->lvaGetDesc(node->AsLclVarCommon())->lvIsRegCandidate());
+                WasmValueType type;
+                unsigned      index = UnpackWasmReg(node->GetRegNum(), &type);
+                physReg             = temporaryRegMap[static_cast<unsigned>(type)].Regs[index];
+            }
+
+            node->SetRegNum(physReg);
         }
         refsCount = ARRAY_SIZE(refs->Nodes);
     }
@@ -580,7 +627,7 @@ void WasmRegAlloc::ResolveReferences()
         {
             WasmValueType type;
             unsigned      index   = UnpackWasmReg(regs->GetAt(i), &type);
-            regNumber     physReg = internalRegMap[static_cast<unsigned>(type)].Regs[index];
+            regNumber     physReg = temporaryRegMap[static_cast<unsigned>(type)].Regs[index];
             regs->SetAt(i, physReg);
         }
     }

--- a/src/coreclr/jit/regallocwasm.h
+++ b/src/coreclr/jit/regallocwasm.h
@@ -48,7 +48,7 @@ public:
     }
 };
 
-struct InternalRegStack
+struct TemporaryRegStack
 {
     unsigned Count    = 0;
     unsigned MaxCount = 0;
@@ -56,20 +56,20 @@ struct InternalRegStack
     unsigned Push()
     {
         unsigned index = Count++;
-        assert(Count <= InternalRegs::MAX_REG_COUNT);
+        MaxCount       = max(MaxCount, Count);
         return index;
     }
 
-    void PopAll()
+    unsigned Pop()
     {
-        MaxCount = max(MaxCount, Count);
-        Count    = 0;
+        assert(Count > 0);
+        return --Count;
     }
 };
 
 struct VirtualRegReferences
 {
-    GenTreeLclVarCommon*  Nodes[16];
+    GenTree*              Nodes[16];
     VirtualRegReferences* Prev = nullptr;
 };
 
@@ -81,7 +81,7 @@ class WasmRegAlloc : public RegAllocInterface
     VirtualRegStack       m_virtualRegs[static_cast<int>(WasmValueType::Count)];
     unsigned              m_lastVirtualRegRefsCount = 0;
     VirtualRegReferences* m_virtualRegRefs          = nullptr;
-    InternalRegStack      m_internalRegs[static_cast<int>(WasmValueType::Count)];
+    TemporaryRegStack     m_temporaryRegs[static_cast<int>(WasmValueType::Count)];
 
     // The meaning of these fields is borrowed (partially) from the C ABI for WASM. We define "the SP" to be the local
     // which is used to make calls - the stack on entry to callees. We term "the FP" to be the local which is used to
@@ -112,16 +112,17 @@ private:
     void      AllocateFramePointer();
     regNumber AllocateVirtualRegister(var_types type);
     regNumber AllocateVirtualRegister(WasmValueType type);
-    regNumber AllocateInternalRegister(var_types type);
-    void      FreeInternalRegisters();
+    regNumber AllocateTemporaryRegister(var_types type);
+    regNumber ReleaseTemporaryRegister(var_types type);
 
     void CollectReferences();
     void CollectReferencesForBlock(BasicBlock* block);
     void CollectReferencesForNode(GenTree* node);
     void CollectReferencesForDivMod(GenTreeOp* divModNode);
     void RewriteLocalStackStore(GenTreeLclVarCommon* node);
-    void CollectReference(GenTreeLclVarCommon* node);
-    void RequestInternalRegForOperand(GenTree* node, GenTree* operand DEBUGARG(const char* reason));
+    void CollectReference(GenTree* node);
+    void RequestTemporaryRegisterForMultiplyUsedNode(GenTree* node);
+    void ConsumeTemporaryRegForOperand(GenTree* operand DEBUGARG(const char* reason));
 
     void ResolveReferences();
 


### PR DESCRIPTION
We define two new contracts:
1) Lowering to RA: multiply-used operands must be marked with a new LIR flag, so
   that RA can track when their lifetime begins in a forward walk without lookahead.
2) RA to codegen: SDSU nodes with valid registers on them must be assigned
   those registers via "local.tee"s.

Combined, these allow us to make arbitrary operands multi-use.

Different choices could have been made regarding these mechanisms. '1' could have been replaced by lookahead / some other clever scheme confined to RA. '2' could have been replaced by a new LOCAL_TEE node that would be responsible for producing the registers.

Since we will need this mechanism for most stores, and we need some customization for "genProduceReg" anyway due to the drop requirement, it seems to be acceptable in complexity terms to introduce these contracts. They are TP-positive.

Notably, this change makes the internal register mechanism unused. It can still be useful for "true" internal registers, ones unrelated to the operands, so it is left in place for now.

Ref: https://github.com/dotnet/runtime/pull/124298.