### PR TITLE
Fix UdpClient.EnableBroadcast not preventing broadcast sends

### DIFF
--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
@@ -162,8 +162,6 @@ namespace System.Net.Sockets
             }
         }
 
-        private bool _isBroadcastSetByUser;
-
         public bool EnableBroadcast
         {
             get
@@ -250,6 +248,7 @@ namespace System.Net.Sockets
         }
 
         private bool _isBroadcast;
+        private bool _isBroadcastSetByUser;
         private void CheckForBroadcast(IPAddress ipAddress)
         {
             // Here we check to see if the user is trying to use a Broadcast IP address

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
@@ -162,6 +162,8 @@ namespace System.Net.Sockets
             }
         }
 
+        private bool _isBroadcastSetByUser;
+
         public bool EnableBroadcast
         {
             get
@@ -171,6 +173,7 @@ namespace System.Net.Sockets
             set
             {
                 _clientSocket.EnableBroadcast = value;
+                _isBroadcastSetByUser = true;
             }
         }
 
@@ -254,7 +257,10 @@ namespace System.Net.Sockets
             // and in that case we set SocketOptionName.Broadcast on the socket to allow its use.
             // if the user really wants complete control over Broadcast addresses they need to
             // inherit from UdpClient and gain control over the Socket and do whatever is appropriate.
-            if (_clientSocket != null && !_isBroadcast && IsBroadcast(ipAddress))
+            //
+            // If the user has explicitly set EnableBroadcast, we respect their choice
+            // and do not auto-enable broadcast.
+            if (_clientSocket != null && !_isBroadcast && !_isBroadcastSetByUser && IsBroadcast(ipAddress))
             {
                 // We need to set the Broadcast socket option.
                 // Note that once we set the option on the Socket we never reset it.

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
@@ -320,12 +320,14 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [SkipOnPlatform(TestPlatforms.Wasi, "Not supported on Wasi.")]
-        public void EnableBroadcast_ExplicitlyDisabled_NotAutoEnabled()
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void EnableBroadcast_ExplicitlyDisabled_NotAutoEnabled(bool setTrueFirst)
         {
             using (var udpClient = new UdpClient())
             {
+                if (setTrueFirst) udpClient.EnableBroadcast = true;
                 udpClient.EnableBroadcast = false;
 
                 // Sending to a broadcast address should not auto-enable
@@ -345,30 +347,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [SkipOnPlatform(TestPlatforms.Wasi, "Not supported on Wasi.")]
-        public void EnableBroadcast_ExplicitlyEnabledThenDisabled_NotAutoEnabled()
-        {
-            using (var udpClient = new UdpClient())
-            {
-                udpClient.EnableBroadcast = true;
-                udpClient.EnableBroadcast = false;
-
-                // After toggling enable then disable, sending to a broadcast
-                // address should still not auto-enable broadcast.
-                try
-                {
-                    udpClient.Send(new byte[1], 1, new IPEndPoint(IPAddress.Broadcast, UnusedPort));
-                }
-                catch (SocketException)
-                {
-                }
-
-                Assert.False(udpClient.EnableBroadcast);
-            }
-        }
-
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
-        [SkipOnPlatform(TestPlatforms.Wasi, "Not supported on Wasi.")]
         public void EnableBroadcast_NotExplicitlySet_AutoEnabled()
         {
             using (var udpClient = new UdpClient())

--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/UdpClientTest.cs
@@ -320,7 +320,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
         [InlineData(false)]
         [InlineData(true)]
         public void EnableBroadcast_ExplicitlyDisabled_NotAutoEnabled(bool setTrueFirst)
@@ -346,7 +346,7 @@ namespace System.Net.Sockets.Tests
             }
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingSupported))]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
         public void EnableBroadcast_NotExplicitlySet_AutoEnabled()
         {
             using (var udpClient = new UdpClient())


### PR DESCRIPTION
## Summary

Fixes #118055

`UdpClient.CheckForBroadcast()` unconditionally auto-enables the `Broadcast` socket option when sending to `IPAddress.Broadcast`, even when the user has explicitly set `EnableBroadcast = false`. This PR makes `CheckForBroadcast()` respect the user's explicit choice.

## Changes

- Added `_isBroadcastSetByUser` field to track whether `EnableBroadcast` has been explicitly set by the user
- Modified `CheckForBroadcast()` to skip auto-enable when the user has explicitly set `EnableBroadcast`
- Backward-compatible: auto-enable behavior is preserved when users have not explicitly set the property

**Note:** The pre-existing `_isBroadcast` flag is not reset when the `Client` socket is replaced via the property setter. The new `_isBroadcastSetByUser` flag follows this same pattern for consistency. Resetting state on socket replacement could be a follow-up improvement.

## Testing

- `EnableBroadcast_ExplicitlyDisabled_NotAutoEnabled` — verifies that explicitly disabling broadcast prevents auto-enable on broadcast send
- `EnableBroadcast_ExplicitlyEnabledThenDisabled_NotAutoEnabled` — verifies the toggle case (enable → disable) also prevents auto-enable
- `EnableBroadcast_NotExplicitlySet_AutoEnabled` — verifies backward compatibility: auto-enable still works when the user hasn't set the property