### PR TITLE
[browser][coreCLR] native stack trace symbols

### DIFF
--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -613,7 +613,7 @@ static int run(const configuration& config)
     // The NodeJS process is kept alive by pending async work via safeSetTimeout() -> runtimeKeepalivePush()
     // The actual exit code would be set by SystemJS_ResolveMainPromise if the managed Main() is async.
     // Or in Module.onExit handler when  managed Main() is synchronous.
-    return 0;
+    return exit_code;
 #else // TARGET_BROWSER
     return corerun_shutdown(exit_code);
 #endif // TARGET_BROWSER

--- a/src/coreclr/hosts/corerun/wasm/libCorerun.js
+++ b/src/coreclr/hosts/corerun/wasm/libCorerun.js
@@ -9,7 +9,8 @@ function libCoreRunFactory() {
         "$FS",
         "$NODEFS",
         "$NODERAWFS",
-        "corerun_shutdown"
+        "corerun_shutdown",
+        "BrowserHost_ShutdownDotnet",
     ];
     const mergeCoreRun = {
         $CORERUN: {
@@ -25,28 +26,11 @@ function libCoreRunFactory() {
                 }
 
                 ENV["DOTNET_SYSTEM_GLOBALIZATION_INVARIANT"] = "true";
-                const originalExitJS = exitJS;
-                exitJS = (status, implicit) => {
-                    if (!implicit) {
-                        EXITSTATUS = status;
-                        ABORT = true;
-                        if (dotnetBrowserUtilsExports.abortBackgroundTimers) {
-                            dotnetBrowserUtilsExports.abortBackgroundTimers();
-                        }
-                    }
-                    if (!keepRuntimeAlive()) {
-                        ABORT = true;
-                        var latched = _corerun_shutdown(EXITSTATUS || 0);
-                        if (EXITSTATUS === undefined) {
-                            EXITSTATUS = latched;
-                        }
-                    }
-                    return originalExitJS(EXITSTATUS, implicit);
-                };
             },
         },
         $CORERUN__postset: "CORERUN.selfInitialize()",
         $CORERUN__deps: commonDeps,
+        BrowserHost_ShutdownDotnet: (exitCode) => _corerun_shutdown(exitCode),
     };
     const patchNODERAWFS = {
         cwd: () => {

--- a/src/coreclr/vm/assembly.cpp
+++ b/src/coreclr/vm/assembly.cpp
@@ -1190,6 +1190,10 @@ struct Param
     LPWSTR *wzArgs;
 } param;
 
+#if defined(TARGET_BROWSER)
+extern "C" void SystemJS_ResolveMainPromise(int exitCode);
+#endif // TARGET_BROWSER
+
 static void RunMainInternal(Param* pParam)
 {
     MethodDescCallSite  threadStart(pParam->pFD);
@@ -1223,6 +1227,9 @@ static void RunMainInternal(Param* pParam)
         // Set the return value to 0 instead of returning random junk
         *pParam->piRetVal = 0;
         threadStart.Call(&stackVar);
+#if defined(TARGET_BROWSER)
+        SystemJS_ResolveMainPromise(*pParam->piRetVal);
+#endif // TARGET_BROWSER
     }
 // WASM-TODO: remove this
 // https://github.com/dotnet/runtime/issues/121064
@@ -1257,6 +1264,9 @@ static void RunMainInternal(Param* pParam)
         // Call the main method
         *pParam->piRetVal = (INT32)threadStart.Call_RetArgSlot(&stackVar);
         SetLatchedExitCode(*pParam->piRetVal);
+#if defined(TARGET_BROWSER)
+        SystemJS_ResolveMainPromise(*pParam->piRetVal);
+#endif // TARGET_BROWSER
     }
 
     GCPROTECT_END();

--- a/src/mono/browser/runtime/logging.ts
+++ b/src/mono/browser/runtime/logging.ts
@@ -185,7 +185,7 @@ function performDeferredSymbolMapParsing () {
 
     //# chrome
     //# at http://127.0.0.1:63817/dotnet.wasm:wasm-function[8963]:0x1e23f4
-    regexes.push(/(?<replaceSection>[a-z]+:\/\/[^ )]*:wasm-function\[(?<funcNum>\d+)\]:0x[a-fA-F\d]+)/);
+    regexes.push(/(?<replaceSection>[a-z]+:\/\/[a-zA-Z0-9.:/_]*:wasm-function\[(?<funcNum>\d+)\]:0x[a-fA-F\d]+)/);
 
     //# <?>.wasm-function[8962]
     regexes.push(/(?<replaceSection><[^ >]+>[.:]wasm-function\[(?<funcNum>[0-9]+)\])/);

--- a/src/mono/sample/wasm/Directory.Build.targets
+++ b/src/mono/sample/wasm/Directory.Build.targets
@@ -54,19 +54,18 @@
     <NestedBuildProperty Include="WasmTestForwardConsole" />
   </ItemGroup>
 
-  <Target Name="BuildSampleInTree"
-      Inputs="
-      Program.cs;
-      $(_WasmMainJSFileName);
-      $(_SampleProject);
-      $(MSBuildProjectFile)
-      $(TargetFileName)
-      "
-      Outputs="
-      bin/$(Configuration)/publish/wwwroot/_framework/dotnet.native.wasm;
-      bin/$(Configuration)/publish/wwwroot/_framework/dotnet.native.js;
-      bin/$(Configuration)/publish/wwwroot/$(_WasmMainJSFileName);
-      ">
+  <Target Name="_ValidateRuntimeFlavorBuild" BeforeTargets="BuildSampleInTree">
+    <PropertyGroup>
+      <_MonoBuildDir>$(ArtifactsObjDir)mono\browser.wasm.$(Configuration)\out\lib\</_MonoBuildDir>
+      <_CoreCLRBuildDir>$(ArtifactsObjDir)coreclr\browser.wasm.$(Configuration)\libs-native\</_CoreCLRBuildDir>
+    </PropertyGroup>
+    <Error Condition="'$(RuntimeFlavor)' == 'Mono' and !Exists('$(_MonoBuildDir)')"
+           Text="Mono build not found at '$(_MonoBuildDir)'. Build Mono for browser-wasm first: ./build.sh mono+libs -os browser -c $(Configuration)" />
+    <Error Condition="'$(RuntimeFlavor)' == 'CoreCLR' and !Exists('$(_CoreCLRBuildDir)')"
+           Text="CoreCLR build not found at '$(_CoreCLRBuildDir)'. Build CoreCLR for browser-wasm first: ./build.sh clr+libs+host -os browser -c $(Configuration)" />
+  </Target>
+
+  <Target Name="BuildSampleInTree">
     <PropertyGroup>
       <_ScriptExt Condition="'$(OS)' == 'Windows_NT'">.cmd</_ScriptExt>
       <_ScriptExt Condition="'$(OS)' != 'Windows_NT'">.sh</_ScriptExt>
@@ -74,6 +73,9 @@
       <_SampleProject Condition="'$(_SampleProject)' == ''">$(MSBuildProjectFile)</_SampleProject>
       <_SampleAssembly Condition="'$(_SampleAssembly)' == ''">$(TargetFileName)</_SampleAssembly>
     </PropertyGroup>
+    <!-- Clean obj (in artifacts) and bin (local) folders to avoid stale artifacts from previous builds, when runtime binaries and scripts change normal clean is too fragile -->
+    <RemoveDir Directories="$(BaseIntermediateOutputPath)" Condition="Exists('$(BaseIntermediateOutputPath)')" />
+    <RemoveDir Directories="$(MSBuildProjectDirectory)\bin" Condition="Exists('$(MSBuildProjectDirectory)\bin')" />
     <ItemGroup>
       <NestedBuildPropertyValue Include="/p:Nested_%(NestedBuildProperty.Identity)=$(%(NestedBuildProperty.Identity))" Condition="'$(%(NestedBuildProperty.Identity))' != '%(NestedBuildProperty.DefaultValue)'" />
     </ItemGroup>

--- a/src/mono/sample/wasm/browser/wwwroot/main.js
+++ b/src/mono/sample/wasm/browser/wwwroot/main.js
@@ -27,8 +27,9 @@ try {
 
     const exports = await getAssemblyExports("Wasm.Browser.Sample");
     await exports.Sample.Test.PrintMeaning(delay(2000).then(() => 42));
-    console.log("Program has exited normally.");
-    await dotnet.runMainAndExit();
+    const exitCode = await dotnet.run();
+    console.log(`Program has exited with code ${exitCode}.`);
+    exit(exitCode);
 }
 catch (err) {
     exit(2, err);

--- a/src/mono/sample/wasm/console-node/wwwroot/main.mjs
+++ b/src/mono/sample/wasm/console-node/wwwroot/main.mjs
@@ -6,4 +6,4 @@ import { dotnet } from './_framework/dotnet.js'
 await dotnet
     .withDiagnosticTracing(false)
     .withApplicationArguments("dotnet", "is", "great!")
-    .run()
+    .runMainAndExit();

--- a/src/native/corehost/browserhost/CMakeLists.txt
+++ b/src/native/corehost/browserhost/CMakeLists.txt
@@ -55,7 +55,7 @@ set(SHARED_LIB_DESTINATION
 set(SHARED_CLR_DESTINATION
     ${CLR_ARTIFACTS_BIN_DIR}/coreclr/browser.wasm.${CMAKE_BUILD_RUNTIME_CONFIGURATION}/sharedFramework)
 
-# these dependencies assume that you built `libs.native+clr.runtime` subsets first
+# CoreCLR runtime .a libraries
 LIST(APPEND NATIVE_LIBS
     ${SHARED_CLR_DESTINATION}/libcoreclr_static.a
     ${SHARED_CLR_DESTINATION}/libnativeresourcestring.a
@@ -63,6 +63,10 @@ LIST(APPEND NATIVE_LIBS
     ${SHARED_CLR_DESTINATION}/libcoreclrminipal.a
     ${SHARED_CLR_DESTINATION}/libcoreclrpal.a
     ${SHARED_CLR_DESTINATION}/libminipal.a
+)
+
+# Shared platform .a libraries
+list(APPEND NATIVE_LIBS
     ${SHARED_LIB_DESTINATION}/libSystem.Native.Browser.a
     ${SHARED_LIB_DESTINATION}/libSystem.Runtime.InteropServices.JavaScript.Native.a
     ${SHARED_LIB_DESTINATION}/libSystem.Native.a
@@ -95,18 +99,13 @@ set_target_properties(browserhost PROPERTIES
 
 if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
     target_link_options(browserhost PRIVATE
-#        -sVERBOSE
-#        -sASSERTIONS=1
-        --emit-symbol-map
+# add -sVERBOSE=1 to debug linking issues
+        -sASSERTIONS=1
         -sLLD_REPORT_UNDEFINED
         -sERROR_ON_UNDEFINED_SYMBOLS=1
     )
 endif ()
 
-# add -sVERBOSE=1 to debug linking issues
-# WASM-TODO    -emit-llvm
-# WASM-TODO    --source-map-base http://microsoft.com
-# WASM-TODO    -sSEPARATE_DWARF=1, -gseparate-dwarf
 target_link_options(browserhost PRIVATE
     -sINITIAL_MEMORY=134217728
     -sMAXIMUM_MEMORY=2147483648
@@ -121,6 +120,7 @@ target_link_options(browserhost PRIVATE
     -sEXPORTED_FUNCTIONS=${CMAKE_EMCC_EXPORTED_FUNCTIONS}
     -sEXPORT_NAME=createDotnetRuntime
     -sENVIRONMENT=web,webview,worker,node,shell
+    --emit-symbol-map
     -Wl,-error-limit=0)
 
 target_link_libraries(browserhost PRIVATE
@@ -135,6 +135,8 @@ install(TARGETS browserhost DESTINATION corehost COMPONENT runtime)
 install(TARGETS browserhost DESTINATION sharedFramework COMPONENT runtime)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dotnet.native.wasm DESTINATION corehost COMPONENT runtime)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dotnet.native.wasm DESTINATION sharedFramework COMPONENT runtime)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dotnet.native.js.symbols DESTINATION corehost COMPONENT runtime)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/dotnet.native.js.symbols DESTINATION sharedFramework COMPONENT runtime)
 
 set_source_files_properties(${BROWSERHOST_SOURCES} PROPERTIES OBJECT_DEPENDS
     "${JS_SYSTEM_NATIVE_BROWSER};${JS_SYSTEM_BROWSER_UTILS};${JS_SYSTEM_RUNTIME_INTEROPSERVICES_JAVASCRIPT_NATIVE};${JS_BROWSER_HOST};${JS_SYSTEM_NATIVE_BROWSER_EXPOST}")

--- a/src/native/corehost/browserhost/browserhost.cpp
+++ b/src/native/corehost/browserhost/browserhost.cpp
@@ -149,8 +149,8 @@ extern "C" int BrowserHost_ShutdownDotnet(int exit_code)
     if (result < 0)
     {
         std::fprintf(stderr, "coreclr_shutdown_2 failed - Error: 0x%08x\n", result);
-        exit_code = -1;
+        return -1;
     }
 
-    return exit_code;
+    return latched_exit_code;
 }

--- a/src/native/corehost/browserhost/browserhost.cpp
+++ b/src/native/corehost/browserhost/browserhost.cpp
@@ -108,7 +108,7 @@ extern "C" void* BrowserHost_CreateHostContract(void)
     return &host_contract;
 }
 
-extern "C" int BrowserHost_InitializeCoreCLR(int propertiesCount, const char** propertyKeys, const char** propertyValues)
+extern "C" int BrowserHost_InitializeDotnet(int propertiesCount, const char** propertyKeys, const char** propertyValues)
 {
     coreclr_set_error_writer(log_error_info);
 
@@ -122,15 +122,35 @@ extern "C" int BrowserHost_InitializeCoreCLR(int propertiesCount, const char** p
     return 0;
 }
 
+static bool executeAssemblyFailed = false;
 extern "C" int BrowserHost_ExecuteAssembly(const char* assemblyPath, int argc, const char** argv)
 {
-    int ignore_exit_code = 0;
-    int retval = coreclr_execute_assembly(CurrentClrInstance, CurrentAppDomainId, argc, argv, assemblyPath, (uint32_t*)&ignore_exit_code);
+    int exit_code = 0;
+    int retval = coreclr_execute_assembly(CurrentClrInstance, CurrentAppDomainId, argc, argv, assemblyPath, (uint32_t*)&exit_code);
 
     if (retval < 0)
     {
         std::fprintf(stderr, "coreclr_execute_assembly failed - Error: 0x%08x\n", retval);
+        executeAssemblyFailed = true;
         return -1;
     }
-    return 0;
+    return exit_code;
+}
+
+extern "C" int BrowserHost_ShutdownDotnet(int exit_code)
+{
+    if (executeAssemblyFailed)
+    {
+        return exit_code;
+    }
+
+    int latched_exit_code = exit_code;
+    int result = coreclr_shutdown_2(CurrentClrInstance, CurrentAppDomainId, &latched_exit_code);
+    if (result < 0)
+    {
+        std::fprintf(stderr, "coreclr_shutdown_2 failed - Error: 0x%08x\n", result);
+        exit_code = -1;
+    }
+
+    return exit_code;
 }

--- a/src/native/corehost/browserhost/browserhost.cpp
+++ b/src/native/corehost/browserhost/browserhost.cpp
@@ -125,6 +125,7 @@ extern "C" int BrowserHost_InitializeDotnet(int propertiesCount, const char** pr
 static bool executeAssemblyFailed = false;
 extern "C" int BrowserHost_ExecuteAssembly(const char* assemblyPath, int argc, const char** argv)
 {
+    executeAssemblyFailed = false;
     int exit_code = 0;
     int retval = coreclr_execute_assembly(CurrentClrInstance, CurrentAppDomainId, argc, argv, assemblyPath, (uint32_t*)&exit_code);
 

--- a/src/native/corehost/browserhost/host/index.ts
+++ b/src/native/corehost/browserhost/host/index.ts
@@ -63,12 +63,6 @@ function setupEmscripten() {
     for (const key in loaderConfig.environmentVariables) {
         _ems_.ENV[key] = loaderConfig.environmentVariables[key];
     }
-
-    _ems_.Module.preInit = [() => {
-        _ems_.FS.createPath("/", loaderConfig.virtualWorkingDirectory!, true, true);
-        _ems_.FS.chdir(loaderConfig.virtualWorkingDirectory!);
-    }, ...(_ems_.Module.preInit || [])];
-
 }
 
 export { BrowserHost_ExternalAssemblyProbe } from "./assets";

--- a/src/native/corehost/browserhost/libBrowserHost.footer.js
+++ b/src/native/corehost/browserhost/libBrowserHost.footer.js
@@ -21,8 +21,9 @@ function libBrowserHostFactory() {
     let explicitDeps = [
         "wasm_load_icu_data",
         "BrowserHost_CreateHostContract",
-        "BrowserHost_InitializeCoreCLR",
-        "BrowserHost_ExecuteAssembly"
+        "BrowserHost_InitializeDotnet",
+        "BrowserHost_ExecuteAssembly",
+        "BrowserHost_ShutdownDotnet",
     ];
     let commonDeps = [
         "$DOTNET",

--- a/src/native/corehost/browserhost/loader/exit.ts
+++ b/src/native/corehost/browserhost/loader/exit.ts
@@ -117,7 +117,7 @@ export function exit(exitCode: number, reason: any): void {
             unregisterExit();
             if (!alreadySilent) {
                 if (runtimeState.onExitListeners.length === 0 && !runtimeState.dotnetReady) {
-                    dotnetLogger.error(`Exiting during runtime startup: ${message}`);
+                    dotnetLogger.error("Exiting during runtime startup: ", message);
                     dotnetLogger.debug(() => stack);
                 }
                 for (const listener of runtimeState.onExitListeners) {
@@ -135,7 +135,7 @@ export function exit(exitCode: number, reason: any): void {
                 dotnetLoaderExports.abortStartup(reason);
             }
         } catch (err) {
-            dotnetLogger.warn("dotnet.js exit() failed", err);
+            dotnetLogger.warn("dotnet.js exit() failed: ", err);
             // don't propagate any failures
         }
 

--- a/src/native/corehost/browserhost/loader/index.ts
+++ b/src/native/corehost/browserhost/loader/index.ts
@@ -16,7 +16,7 @@ import GitHash from "consts:gitHash";
 import { loaderConfig, getLoaderConfig } from "./config";
 import { exit, isExited, isRuntimeRunning, addOnExitListener, registerExit, quitNow } from "./exit";
 import { invokeLibraryInitializers } from "./lib-initializers";
-import { check, error, info, warn, debug, fastCheck } from "./logging";
+import { check, error, info, warn, debug, fastCheck, normalizeException } from "./logging";
 
 import { dotnetAssert, dotnetLoaderExports, dotnetLogger, dotnetUpdateInternals, dotnetUpdateInternalsSubscriber } from "./cross-module";
 import { rejectRunMainPromise, resolveRunMainPromise, getRunMainPromise, abortStartup } from "./run";
@@ -66,6 +66,7 @@ export function dotnetInitializeModule(): RuntimeAPI {
         addOnExitListener,
         abortStartup,
         quitNow,
+        normalizeException,
     };
     Object.assign(dotnetLoaderExports, loaderFunctions);
     const logger: LoggerType = {
@@ -112,6 +113,7 @@ export function dotnetInitializeModule(): RuntimeAPI {
             dotnetLoaderExports.addOnExitListener,
             dotnetLoaderExports.abortStartup,
             dotnetLoaderExports.quitNow,
+            dotnetLoaderExports.normalizeException,
         ];
     }
 

--- a/src/native/corehost/browserhost/loader/logging.ts
+++ b/src/native/corehost/browserhost/loader/logging.ts
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import { loaderConfig } from "./config";
+import { dotnetDiagnosticsExports } from "./cross-module";
 
 export function check(condition: unknown, message: string): asserts condition {
     if (!condition) {
@@ -41,16 +42,48 @@ export function warn(msg: string, ...data: any) {
     console.warn(prefix + msg, ...data);
 }
 
-export function error(msg: string, ...data: any) {
-    if (data && data.length > 0 && data[0] && typeof data[0] === "object") {
-        // don't log silent errors
-        if (data[0].silent) {
-            return;
+export function error(msg: string, reason: any) {
+    if (reason.silent) {
+        return;
+    }
+    console.error(prefix + msg, normalizeException(reason));
+}
+
+export function normalizeException(reason: any) {
+    let res = "unknown exception";
+    let stack: string | undefined;
+    if (reason) {
+        if (typeof reason === "object" && reason.status === undefined) {
+            if (stack !== undefined) {
+                stack = reason.stack;
+            } else {
+                stack = new Error().stack + "";
+            }
         }
-        if (data[0].toString) {
-            console.error(prefix + msg, data[0].toString());
-            return;
+        if (reason.message) {
+            res = reason.message;
+        } else if (typeof reason.toString === "function") {
+            res = reason.toString();
+        } else {
+            res = reason + "";
+        }
+        if (stack) {
+            // Some JS runtimes insert the error message at the top of the stack, some don't,
+            //  so normalize it by using the stack as the result if it already contains the error
+            if (stack.startsWith(res))
+                res = symbolicateStackTrace(stack);
+            else
+                res += "\n" + symbolicateStackTrace(stack);
+        } else {
+            res = symbolicateStackTrace(res);
         }
     }
-    console.error(prefix + msg, ...data);
+    return res;
+}
+
+function symbolicateStackTrace(message: string): string {
+    if (dotnetDiagnosticsExports.symbolicateStackTrace) {
+        return dotnetDiagnosticsExports.symbolicateStackTrace(message);
+    }
+    return message;
 }

--- a/src/native/corehost/browserhost/loader/logging.ts
+++ b/src/native/corehost/browserhost/loader/logging.ts
@@ -43,7 +43,7 @@ export function warn(msg: string, ...data: any) {
 }
 
 export function error(msg: string, reason: any) {
-    if (reason.silent) {
+    if (reason && typeof reason === "object" && reason.silent) {
         return;
     }
     console.error(prefix + msg, normalizeException(reason));

--- a/src/native/corehost/browserhost/loader/logging.ts
+++ b/src/native/corehost/browserhost/loader/logging.ts
@@ -54,8 +54,8 @@ export function normalizeException(reason: any) {
     let stack: string | undefined;
     if (reason) {
         if (typeof reason === "object" && reason.status === undefined) {
-            if (reason.stack !== undefined) {
-                stack = reason.stack;
+            if (reason.stack === undefined) {
+                stack = reason.stack + "";
             } else {
                 stack = new Error().stack + "";
             }

--- a/src/native/corehost/browserhost/loader/logging.ts
+++ b/src/native/corehost/browserhost/loader/logging.ts
@@ -54,7 +54,7 @@ export function normalizeException(reason: any) {
     let stack: string | undefined;
     if (reason) {
         if (typeof reason === "object" && reason.status === undefined) {
-            if (stack !== undefined) {
+            if (reason.stack !== undefined) {
                 stack = reason.stack;
             } else {
                 stack = new Error().stack + "";

--- a/src/native/corehost/browserhost/loader/polyfills.ts
+++ b/src/native/corehost/browserhost/loader/polyfills.ts
@@ -153,6 +153,10 @@ export function responseLike(url: string, body: ArrayBuffer | string | null, opt
             return Promise.resolve(JSON.parse(body));
         },
         text: () => {
+            if (typeof body !== "string" && typeof globalThis.TextDecoder !== "undefined") {
+                const decoder = new globalThis.TextDecoder("utf-8");
+                return Promise.resolve(decoder.decode(body || new Uint8Array()));
+            }
             dotnetAssert.check(body !== null && typeof body === "string", "Response body is not a string.");
             return Promise.resolve(body);
         }

--- a/src/native/corehost/browserhost/loader/run.ts
+++ b/src/native/corehost/browserhost/loader/run.ts
@@ -8,7 +8,7 @@ import { exit, runtimeState } from "./exit";
 import { createPromiseCompletionSource } from "./promise-completion-source";
 import { getIcuResourceName } from "./icu";
 import { loaderConfig, validateLoaderConfig } from "./config";
-import { fetchDll, fetchIcu, fetchPdb, fetchVfs, fetchWasm, loadDotnetModule, loadJSModule, nativeModulePromiseController, verifyAllAssetsDownloaded } from "./assets";
+import { fetchDll, fetchIcu, fetchNativeSymbols, fetchPdb, fetchVfs, fetchWasm, loadDotnetModule, loadJSModule, nativeModulePromiseController, verifyAllAssetsDownloaded } from "./assets";
 import { initPolyfills } from "./polyfills";
 import { validateWasmFeatures } from "./bootstrap";
 
@@ -45,6 +45,9 @@ export async function createRuntime(downloadOnly: boolean): Promise<any> {
         if (loaderConfig.resources.jsModuleDiagnostics && loaderConfig.resources.jsModuleDiagnostics.length > 0) {
             const diagnosticsModule = await loadDotnetModule(loaderConfig.resources.jsModuleDiagnostics[0]);
             diagnosticsModule.dotnetInitializeModule<void>(dotnetInternals);
+            if (loaderConfig.resources.wasmSymbols && loaderConfig.resources.wasmSymbols.length > 0) {
+                await fetchNativeSymbols(loaderConfig.resources.wasmSymbols[0]);
+            }
         }
         const nativeModulePromise: Promise<JsModuleExports> = loadDotnetModule(loaderConfig.resources.jsModuleNative[0]);
         const runtimeModulePromise: Promise<JsModuleExports> = loadDotnetModule(loaderConfig.resources.jsModuleRuntime[0]);

--- a/src/native/corehost/corehost.proj
+++ b/src/native/corehost/corehost.proj
@@ -181,7 +181,7 @@
       <_MicrosoftNetCoreAppRuntimePackNativeDirFiles Include="$(LibrariesSharedFrameworkDir)*.dat" />
       <_MicrosoftNetCoreAppRuntimePackNativeDirFiles Include="$(HostSharedFrameworkDir)libBrowserHost.a" />
       <_MicrosoftNetCoreAppRuntimePackNativeDirFiles Include="$(HostSharedFrameworkDir)dotnet.native.js" />
-      <!-- <_MicrosoftNetCoreAppRuntimePackNativeDirFiles Include="$(HostSharedFrameworkDir)dotnet.native.js.symbols" /> -->
+      <_MicrosoftNetCoreAppRuntimePackNativeDirFiles Include="$(HostSharedFrameworkDir)dotnet.native.js.symbols" />
       <_MicrosoftNetCoreAppRuntimePackNativeDirFiles Include="$(HostSharedFrameworkDir)dotnet.native.wasm" />
     </ItemGroup>
 

--- a/src/native/libs/Common/JavaScript/cross-module/index.ts
+++ b/src/native/libs/Common/JavaScript/cross-module/index.ts
@@ -136,6 +136,7 @@ export function dotnetUpdateInternalsSubscriber() {
             addOnExitListener: table[14],
             abortStartup: table[15],
             quitNow: table[16],
+            normalizeException: table[17],
         };
         Object.assign(dotnetLoaderExports, loaderExportsLocal);
         Object.assign(logger, loggerLocal);
@@ -179,6 +180,7 @@ export function dotnetUpdateInternalsSubscriber() {
     function diagnosticsExportsFromTable(table: DiagnosticsExportsTable, interop: DiagnosticsExports): void {
         const interopLocal: DiagnosticsExports = {
             symbolicateStackTrace: table[0],
+            installNativeSymbols: table[1],
         };
         Object.assign(interop, interopLocal);
     }

--- a/src/native/libs/Common/JavaScript/types/ems-ambient.ts
+++ b/src/native/libs/Common/JavaScript/types/ems-ambient.ts
@@ -29,8 +29,9 @@ export type EmsAmbientSymbolsType = EmscriptenModuleInternal & {
     _SystemJS_ExecuteBackgroundJobCallback: () => void;
     _SystemJS_ExecuteFinalizationCallback: () => void;
     _BrowserHost_CreateHostContract: () => VoidPtr;
-    _BrowserHost_InitializeCoreCLR: (propertiesCount: number, propertyKeys: CharPtrPtr, propertyValues: CharPtrPtr) => number;
+    _BrowserHost_InitializeDotnet: (propertiesCount: number, propertyKeys: CharPtrPtr, propertyValues: CharPtrPtr) => number;
     _BrowserHost_ExecuteAssembly: (mainAssemblyNamePtr: number, argsLength: number, argsPtr: number) => number;
+    _BrowserHost_ShutdownDotnet: (exitCode: number) => number;
     _wasm_load_icu_data: (dataPtr: VoidPtr) => number;
     _SystemInteropJS_GetManagedStackTrace: (args: JSMarshalerArguments) => void;
     _SystemInteropJS_CallDelegate: (args: JSMarshalerArguments) => void;
@@ -38,7 +39,6 @@ export type EmsAmbientSymbolsType = EmscriptenModuleInternal & {
     _SystemInteropJS_ReleaseJSOwnedObjectByGCHandle: (args: JSMarshalerArguments) => void;
     _SystemInteropJS_BindAssemblyExports: (args: JSMarshalerArguments) => void;
     _SystemInteropJS_CallJSExport: (methodHandle: CSFnHandle, args: JSMarshalerArguments) => void;
-    _corerun_shutdown: (code: number) => void;
 
     FS: {
         createPath: (parent: string, path: string, canRead?: boolean, canWrite?: boolean) => string;
@@ -47,9 +47,18 @@ export type EmsAmbientSymbolsType = EmscriptenModuleInternal & {
     }
     ENV: any;
 
-    DOTNET: any;
-    DOTNET_INTEROP: any;
-    BROWSER_HOST: any;
+    DOTNET: {
+        lastScheduledTimerId?: number;
+        lastScheduledThreadPoolId?: number;
+        lastScheduledFinalizationId?: number;
+        cryptoWarnOnce?: boolean;
+        isAborting?: boolean;
+        gitHash?: string;
+    }
+    DOTNET_INTEROP: {
+        gitHash?: string;
+    };
+    BROWSER_HOST: {};
 
     Module: EmscriptenModuleInternal;
     ENVIRONMENT_IS_NODE: boolean;
@@ -74,6 +83,7 @@ export type EmsAmbientSymbolsType = EmscriptenModuleInternal & {
     _exit: (exitCode: number, implicit?: boolean) => void;
     abort: (reason: any) => void;
     ___trap: () => void;
+    ___funcs_on_exit: () => void;
     safeSetTimeout: (func: Function, timeout: number) => number;
     exitJS: (status: number, implicit?: boolean | number) => void;
     runtimeKeepalivePop: () => void;

--- a/src/native/libs/Common/JavaScript/types/exchange.ts
+++ b/src/native/libs/Common/JavaScript/types/exchange.ts
@@ -1,7 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import type { check, error, info, warn, debug, fastCheck } from "../../../../corehost/browserhost/loader/logging";
+import type { check, error, info, warn, debug, fastCheck, normalizeException } from "../../../../corehost/browserhost/loader/logging";
 import type { resolveRunMainPromise, rejectRunMainPromise, getRunMainPromise, abortStartup } from "../../../../corehost/browserhost/loader/run";
 import type { addOnExitListener, isExited, isRuntimeRunning, quitNow } from "../../../../corehost/browserhost/loader/exit";
 
@@ -18,7 +18,7 @@ import type { resolveOrRejectPromise } from "../../../System.Runtime.InteropServ
 import type { cancelPromise } from "../../../System.Runtime.InteropServices.JavaScript.Native/interop/cancelable-promise";
 import type { abortInteropTimers } from "../../../System.Runtime.InteropServices.JavaScript.Native/interop/scheduling";
 
-import type { symbolicateStackTrace } from "../../../System.Native.Browser/diagnostics/symbolicate";
+import type { installNativeSymbols, symbolicateStackTrace } from "../../../System.Native.Browser/diagnostics/symbolicate";
 import type { EmsAmbientSymbolsType } from "../types";
 
 export type RuntimeExports = {
@@ -67,6 +67,7 @@ export type LoaderExports = {
     addOnExitListener: typeof addOnExitListener,
     abortStartup: typeof abortStartup,
     quitNow: typeof quitNow,
+    normalizeException: typeof normalizeException
 }
 
 export type LoaderExportsTable = [
@@ -87,6 +88,7 @@ export type LoaderExportsTable = [
     typeof addOnExitListener,
     typeof abortStartup,
     typeof quitNow,
+    typeof normalizeException,
 ]
 
 export type BrowserHostExports = {
@@ -161,8 +163,10 @@ export type BrowserUtilsExportsTable = [
 
 export type DiagnosticsExportsTable = [
     typeof symbolicateStackTrace,
+    typeof installNativeSymbols,
 ]
 
 export type DiagnosticsExports = {
     symbolicateStackTrace: typeof symbolicateStackTrace,
+    installNativeSymbols: typeof installNativeSymbols,
 }

--- a/src/native/libs/System.Native.Browser/diagnostics/exit.ts
+++ b/src/native/libs/System.Native.Browser/diagnostics/exit.ts
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 import type { LoaderConfigInternal } from "./types";
-import { dotnetLogger, dotnetLoaderExports, dotnetApi, dotnetBrowserUtilsExports, dotnetRuntimeExports } from "./cross-module";
+import { dotnetLogger, dotnetLoaderExports, dotnetApi, dotnetRuntimeExports } from "./cross-module";
 import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_WEB } from "./per-module";
 import { teardownProxyConsole } from "./console-proxy";
 

--- a/src/native/libs/System.Native.Browser/diagnostics/exit.ts
+++ b/src/native/libs/System.Native.Browser/diagnostics/exit.ts
@@ -5,7 +5,6 @@ import type { LoaderConfigInternal } from "./types";
 import { dotnetLogger, dotnetLoaderExports, dotnetApi, dotnetBrowserUtilsExports, dotnetRuntimeExports } from "./cross-module";
 import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_WEB } from "./per-module";
 import { teardownProxyConsole } from "./console-proxy";
-import { symbolicateStackTrace } from "./symbolicate";
 
 let loaderConfig: LoaderConfigInternal = null as any;
 export function registerExit() {
@@ -53,31 +52,21 @@ function onExit(exitCode: number, reason: any, silent: boolean): boolean {
     return true;
 }
 
-function logExitReason(exit_code: number, reason: any) {
-    if (exit_code !== 0 && reason) {
-        const exitStatus = isExitStatus(reason);
-        if (typeof reason === "string") {
-            dotnetLogger.error(reason);
+function logExitReason(exitCode: number, reason: any) {
+    if (exitCode !== 0 && reason) {
+        const hasExitStatus = typeof reason === "object" && reason.status !== undefined;
+        if (dotnetLoaderExports.normalizeException) {
+            reason = dotnetLoaderExports.normalizeException(reason);
         } else {
-            if (reason.stack === undefined && !exitStatus) {
-                reason.stack = new Error().stack + "";
-            }
-            const message = reason.message
-                ? symbolicateStackTrace(reason.message + "\n" + reason.stack)
-                : reason.toString();
-
-            if (exitStatus) {
-                dotnetLogger.debug(message);
-            } else {
-                dotnetLogger.error(message);
-            }
+            reason = reason + "";
+        }
+        const msg = "dotnet exited with: " + exitCode;
+        if (hasExitStatus) {
+            dotnetLogger.debug(msg, reason);
+        } else {
+            dotnetLogger.error(msg, reason);
         }
     }
-}
-
-function isExitStatus(reason: any): boolean {
-    const ExitStatus = dotnetBrowserUtilsExports.getExitStatus();
-    return ExitStatus && reason instanceof ExitStatus;
 }
 
 function logExitCode(exitCode: number): void {
@@ -136,7 +125,7 @@ function fatalHandler(event: any, reason: any, type: string) {
         }
         reason.stack = reason.stack + "";// string conversion (it could be getter)
         if (!reason.silent) {
-            dotnetLogger.error("Unhandled error:", reason);
+            dotnetLogger.error("Unhandled error: ", reason);
             dotnetApi.exit(1, reason);
         }
     } catch (error: any) {
@@ -164,6 +153,6 @@ async function flushNodeStreams() {
         await Promise.race([Promise.all([stdoutFlushed, stderrFlushed]), timeout]);
         clearTimeout(timeoutId);
     } catch (err) {
-        dotnetLogger.error(`flushing std* streams failed: ${err}`);
+        dotnetLogger.error("flushing std* streams failed: ", err);
     }
 }

--- a/src/native/libs/System.Native.Browser/diagnostics/index.ts
+++ b/src/native/libs/System.Native.Browser/diagnostics/index.ts
@@ -8,7 +8,7 @@ import GitHash from "consts:gitHash";
 
 import { dotnetUpdateInternals, dotnetUpdateInternalsSubscriber } from "./cross-module";
 import { registerExit } from "./exit";
-import { symbolicateStackTrace } from "./symbolicate";
+import { installNativeSymbols, symbolicateStackTrace } from "./symbolicate";
 import { installLoggingProxy } from "./console-proxy";
 
 export function dotnetInitializeModule(internals: InternalExchange): void {
@@ -23,6 +23,7 @@ export function dotnetInitializeModule(internals: InternalExchange): void {
 
     internals[InternalExchangeIndex.DiagnosticsExportsTable] = diagnosticsExportsToTable({
         symbolicateStackTrace,
+        installNativeSymbols,
     });
     dotnetUpdateInternals(internals, dotnetUpdateInternalsSubscriber);
 
@@ -34,6 +35,7 @@ export function dotnetInitializeModule(internals: InternalExchange): void {
         // keep in sync with diagnosticsExportsFromTable()
         return [
             map.symbolicateStackTrace,
+            map.installNativeSymbols,
         ];
     }
 }

--- a/src/native/libs/System.Native.Browser/diagnostics/symbolicate.ts
+++ b/src/native/libs/System.Native.Browser/diagnostics/symbolicate.ts
@@ -1,8 +1,83 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-export function symbolicateStackTrace(stack: string): string {
-    // WASM-TODO: implement symbolication https://github.com/dotnet/runtime/issues/122647
-    return stack;
+const symbol_map = new Map<number, string>();
+let symbolTable: string | undefined;
+const regexes: RegExp[] = [];
+
+export function installNativeSymbols(table: string) {
+    symbolTable = table;
 }
 
+export function symbolicateStackTrace(message: string): string {
+    const origMessage = message;
+    initSymbolMap();
+
+    if (symbol_map.size === 0)
+        return message;
+
+    try {
+
+        for (let i = 0; i < regexes.length; i++) {
+            const newRaw = message.replace(regexes[i], (substring, ...args) => {
+                const groups = args.find(arg => {
+                    return typeof (arg) == "object" && arg.replaceSection !== undefined;
+                });
+
+                if (groups === undefined)
+                    return substring;
+
+                const funcNum = groups.funcNum;
+                const replaceSection = groups.replaceSection;
+                const name = symbol_map.get(Number(funcNum));
+
+                if (name === undefined)
+                    return substring;
+
+                return substring.replace(replaceSection, `${name} (${replaceSection})`);
+            });
+
+            if (newRaw !== origMessage)
+                return newRaw;
+        }
+
+        return origMessage;
+    } catch (error) {
+        console.debug(`failed to symbolicate: ${error}`);
+        return message;
+    }
+}
+
+function initSymbolMap() {
+    if (!symbolTable)
+        return;
+
+    // V8
+    //   at <anonymous>:wasm-function[1900]:0x83f63
+    //   at dlfree (<anonymous>:wasm-function[18739]:0x2328ef)
+    regexes.push(/at (?<replaceSection>[^:()]+:wasm-function\[(?<funcNum>\d+)\]:0x[a-fA-F\d]+)((?![^)a-fA-F\d])|$)/g);
+
+    //# 5: WASM [009712b2], function #111 (''), pc=0x7c16595c973 (+0x53), pos=38740 (+11)
+    regexes.push(/(?:WASM \[[\da-zA-Z]+\], (?<replaceSection>function #(?<funcNum>[\d]+) \(''\)))/g);
+
+    //# chrome
+    //# at http://127.0.0.1:63817/dotnet.wasm:wasm-function[8963]:0x1e23f4
+    regexes.push(/(?<replaceSection>[a-z]+:\/\/[a-zA-Z0-9.:/_]*:wasm-function\[(?<funcNum>\d+)\]:0x[a-fA-F\d]+)/g);
+
+    //# <?>.wasm-function[8962]
+    regexes.push(/(?<replaceSection><[^ >]+>[.:]wasm-function\[(?<funcNum>[0-9]+)\])/g);
+
+    const text = symbolTable;
+    symbolTable = undefined;
+    try {
+        text.split(/[\r\n]/).forEach((line: string) => {
+            const parts: string[] = line.split(/:/);
+            if (parts.length < 2)
+                return;
+
+            parts[1] = parts.splice(1).join(":").replace(/\\([0-9a-fA-F]{2})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+            symbol_map.set(Number(parts[0]), parts[1]);
+        });
+    } catch (exc) {
+    }
+}

--- a/src/native/libs/System.Native.Browser/diagnostics/symbolicate.ts
+++ b/src/native/libs/System.Native.Browser/diagnostics/symbolicate.ts
@@ -72,7 +72,7 @@ function initSymbolMap() {
     const text = symbolTable;
     symbolTable = undefined;
     try {
-        text.split(/[\r\n]/).forEach((line: string) => {
+        text.split(/\r?\n|\r/).forEach((line: string) => {
             const parts: string[] = line.split(/:/);
             if (parts.length < 2)
                 return;

--- a/src/native/libs/System.Native.Browser/diagnostics/symbolicate.ts
+++ b/src/native/libs/System.Native.Browser/diagnostics/symbolicate.ts
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+import { dotnetLogger } from "./cross-module";
+
 const symbol_map = new Map<number, string>();
 let symbolTable: string | undefined;
 const regexes: RegExp[] = [];
@@ -43,7 +45,7 @@ export function symbolicateStackTrace(message: string): string {
 
         return origMessage;
     } catch (error) {
-        console.debug(`failed to symbolicate: ${error}`);
+        dotnetLogger.debug(`failed to symbolicate: ${error}`);
         return message;
     }
 }
@@ -79,5 +81,6 @@ function initSymbolMap() {
             symbol_map.set(Number(parts[0]), parts[1]);
         });
     } catch (exc) {
+        dotnetLogger.debug(`failed to parse symbol table: ${exc}`);
     }
 }

--- a/src/native/libs/System.Native.Browser/diagnostics/symbolicate.ts
+++ b/src/native/libs/System.Native.Browser/diagnostics/symbolicate.ts
@@ -62,7 +62,7 @@ function initSymbolMap() {
 
     //# chrome
     //# at http://127.0.0.1:63817/dotnet.wasm:wasm-function[8963]:0x1e23f4
-    regexes.push(/(?<replaceSection>[a-z]+:\/\/[a-zA-Z0-9.:/_]*:wasm-function\[(?<funcNum>\d+)\]:0x[a-fA-F\d]+)/g);
+    regexes.push(/(?<replaceSection>[a-z]+:\/\/[a-zA-Z0-9.:/_~-]*:wasm-function\[(?<funcNum>\d+)\]:0x[a-fA-F\d]+)/g);
 
     //# <?>.wasm-function[8962]
     regexes.push(/(?<replaceSection><[^ >]+>[.:]wasm-function\[(?<funcNum>[0-9]+)\])/g);

--- a/src/native/libs/System.Native.Browser/libSystem.Native.Browser.Utils.footer.js
+++ b/src/native/libs/System.Native.Browser/libSystem.Native.Browser.Utils.footer.js
@@ -22,6 +22,7 @@ function libBrowserUtilsFactory() {
         "$DOTNET",
         "GetDotNetRuntimeContractDescriptor",
         "_exit",
+        "abort",
         "__trap",
         "$readI53FromU64",
         "$readI53FromI64",

--- a/src/native/libs/System.Native.Browser/libSystem.Native.Browser.footer.js
+++ b/src/native/libs/System.Native.Browser/libSystem.Native.Browser.footer.js
@@ -18,10 +18,12 @@ function libDotnetFactory() {
     libNativeBrowser(exports);
 
     let commonDeps = [
+        "$FS",
         "$BROWSER_UTILS",
         "SystemJS_ExecuteTimerCallback",
         "SystemJS_ExecuteBackgroundJobCallback",
         "SystemJS_ExecuteFinalizationCallback",
+        "__funcs_on_exit",
     ];
     const mergeDotnet = {
         $DOTNET: {

--- a/src/native/libs/System.Native.Browser/native/crypto.ts
+++ b/src/native/libs/System.Native.Browser/native/crypto.ts
@@ -11,9 +11,9 @@ export function SystemJS_RandomBytes(bufferPtr: number, bufferLength: number): n
     const batchedQuotaMax = 65536;
 
     if (!globalThis.crypto || !globalThis.crypto.getRandomValues) {
-        if (!_ems_.DOTNET["cryptoWarnOnce"]) {
+        if (!_ems_.DOTNET.cryptoWarnOnce) {
             _ems_.dotnetLogger.debug("This engine doesn't support crypto.getRandomValues. Please use a modern version or provide polyfill for 'globalThis.crypto.getRandomValues'.");
-            _ems_.DOTNET["cryptoWarnOnce"] = true;
+            _ems_.DOTNET.cryptoWarnOnce = true;
         }
         return -1;
     }

--- a/src/native/libs/System.Native.Browser/native/index.ts
+++ b/src/native/libs/System.Native.Browser/native/index.ts
@@ -27,10 +27,34 @@ export function dotnetInitializeModule(internals: InternalExchange): void {
     });
     _ems_.dotnetUpdateInternals(internals, _ems_.dotnetUpdateInternalsSubscriber);
 
+    setupEmscripten();
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     function nativeBrowserExportsToTable(map: NativeBrowserExports): NativeBrowserExportsTable {
         // keep in sync with nativeBrowserExportsFromTable()
         return [
         ];
+    }
+
+    function setupEmscripten() {
+        _ems_.Module.preInit = [() => {
+            if (_ems_.dotnetApi.getConfig) {
+                const virtualWorkingDirectory = _ems_.dotnetApi.getConfig().virtualWorkingDirectory;
+                _ems_.FS.createPath("/", virtualWorkingDirectory!, true, true);
+                _ems_.FS.chdir(virtualWorkingDirectory!);
+            }
+
+            const orig_funcs_on_exit = _ems_.___funcs_on_exit;
+            // it would be better to use addOnExit(), but it's called too late.
+            _ems_.___funcs_on_exit = () => {
+                // this will prevent more timers (like finalizer) to get scheduled during thread destructor
+                if (_ems_.dotnetBrowserUtilsExports.abortBackgroundTimers) {
+                    _ems_.dotnetBrowserUtilsExports.abortBackgroundTimers();
+                }
+                _ems_.EXITSTATUS = _ems_._BrowserHost_ShutdownDotnet(_ems_.EXITSTATUS || 0);
+                orig_funcs_on_exit();
+            };
+
+        }, ...(_ems_.Module.preInit || [])];
     }
 }

--- a/src/native/libs/System.Native.Browser/native/scheduling.ts
+++ b/src/native/libs/System.Native.Browser/native/scheduling.ts
@@ -4,7 +4,7 @@
 import { _ems_ } from "../../Common/JavaScript/ems-ambient";
 
 export function SystemJS_ScheduleTimer(shortestDueTimeMs: number): void {
-    if (_ems_.ABORT) {
+    if (_ems_.ABORT || _ems_.DOTNET.isAborting) {
         // runtime is shutting down
         return;
     }
@@ -30,7 +30,7 @@ export function SystemJS_ScheduleTimer(shortestDueTimeMs: number): void {
 }
 
 export function SystemJS_ScheduleBackgroundJob(): void {
-    if (_ems_.ABORT) {
+    if (_ems_.ABORT || _ems_.DOTNET.isAborting) {
         // runtime is shutting down
         return;
     }
@@ -56,7 +56,7 @@ export function SystemJS_ScheduleBackgroundJob(): void {
 }
 
 export function SystemJS_ScheduleFinalization(): void {
-    if (_ems_.ABORT) {
+    if (_ems_.ABORT || _ems_.DOTNET.isAborting) {
         // runtime is shutting down
         return;
     }

--- a/src/native/libs/System.Native.Browser/utils/host.ts
+++ b/src/native/libs/System.Native.Browser/utils/host.ts
@@ -14,7 +14,7 @@ export function getExitStatus(): new (exitCode: number) => any {
 }
 
 export function runBackgroundTimers(): void {
-    if (_ems_.ABORT) {
+    if (_ems_.ABORT || _ems_.DOTNET.isAborting) {
         // runtime is shutting down
         return;
     }
@@ -32,6 +32,7 @@ export function runBackgroundTimers(): void {
 }
 
 export function abortBackgroundTimers(): void {
+    _ems_.DOTNET.isAborting = true;
     if (_ems_.DOTNET.lastScheduledTimerId) {
         globalThis.clearTimeout(_ems_.DOTNET.lastScheduledTimerId);
         _ems_.runtimeKeepalivePop();
@@ -53,6 +54,7 @@ export function abortPosix(exitCode: number, reason: any, nativeReady: boolean):
     try {
         _ems_.ABORT = true;
         _ems_.EXITSTATUS = exitCode;
+        _ems_.DOTNET.isAborting = true;
         if (exitCode === 0 && nativeReady) {
             _ems_._exit(0);
             return;

--- a/src/native/libs/System.Runtime.InteropServices.JavaScript.Native/interop/invoke-js.ts
+++ b/src/native/libs/System.Runtime.InteropServices.JavaScript.Native/interop/invoke-js.ts
@@ -3,13 +3,13 @@
 
 import BuildConfiguration from "consts:configuration";
 
-import { dotnetBrowserUtilsExports, dotnetApi, dotnetAssert, dotnetLogger, VoidPtrNull, Module } from "./cross-module";
+import { dotnetBrowserUtilsExports, dotnetApi, dotnetAssert, dotnetLogger, VoidPtrNull, Module, dotnetLoaderExports } from "./cross-module";
 
 import type { BindingClosureJS, BoundMarshalerToJs, JSFnHandle, JSFunctionSignature, JSHandle, JSMarshalerArguments, VoidPtr, WrappedJSFunction } from "./types";
 
 import { MarshalerType, MeasuredBlock } from "./types";
 import { getSig, getSignatureArgumentCount, getSignatureFunctionName, getSignatureHandle, getSignatureModuleName, getSignatureType, getSignatureVersion, isReceiverShouldFree, jsInteropState } from "./marshal";
-import { assertJsInterop, assertRuntimeRunning, endMeasure, fixupPointer, normalizeException, startMeasure } from "./utils";
+import { assertJsInterop, assertRuntimeRunning, endMeasure, fixupPointer, startMeasure } from "./utils";
 import { bindArgMarshalToJs } from "./marshal-to-js";
 import { boundJsFunctionSymbol, getJSObjectFromJSHandle, importedJsFunctionSymbol, jsImportWrapperByFnHandle } from "./gc-handles";
 import { bindArgMarshalToCs, marshalExceptionToCs } from "./marshal-to-cs";
@@ -29,7 +29,7 @@ export function bindJSImportST(signature: JSFunctionSignature): VoidPtr {
         bindJsImport(signature);
         return VoidPtrNull;
     } catch (ex: any) {
-        return dotnetBrowserUtilsExports.stringToUTF16Ptr(normalizeException(ex));
+        return dotnetBrowserUtilsExports.stringToUTF16Ptr(dotnetLoaderExports.normalizeException(ex));
     }
 }
 

--- a/src/native/libs/System.Runtime.InteropServices.JavaScript.Native/interop/utils.ts
+++ b/src/native/libs/System.Runtime.InteropServices.JavaScript.Native/interop/utils.ts
@@ -11,26 +11,6 @@ export function fixupPointer(signature: any, shiftAmount: number): any {
     return ((signature as any) >>> shiftAmount) as any;
 }
 
-export function normalizeException(ex: any) {
-    let res = "unknown exception";
-    if (ex) {
-        res = ex.toString();
-        const stack = ex.stack;
-        if (stack) {
-            // Some JS runtimes insert the error message at the top of the stack, some don't,
-            //  so normalize it by using the stack as the result if it already contains the error
-            if (stack.startsWith(res))
-                res = stack;
-            else
-                res += "\n" + stack;
-        }
-        if (dotnetDiagnosticsExports.symbolicateStackTrace) {
-            res = dotnetDiagnosticsExports.symbolicateStackTrace(res);
-        }
-    }
-    return res;
-}
-
 export function isRuntimeRunning(): boolean {
     return dotnetLoaderExports.isRuntimeRunning();
 }

--- a/src/native/libs/System.Runtime.InteropServices.JavaScript.Native/interop/utils.ts
+++ b/src/native/libs/System.Runtime.InteropServices.JavaScript.Native/interop/utils.ts
@@ -3,7 +3,7 @@
 
 import type { TimeStamp } from "./types";
 
-import { dotnetAssert, dotnetDiagnosticsExports, dotnetLoaderExports, Module } from "./cross-module";
+import { dotnetAssert, dotnetLoaderExports, Module } from "./cross-module";
 import { jsInteropState } from "./marshal";
 import { ENVIRONMENT_IS_WEB } from "./per-module";
 


### PR DESCRIPTION
Also more work on
- exit code propagation
- shutdown
- exception logging

Fixes https://github.com/dotnet/runtime/issues/122647
Fixes https://github.com/dotnet/runtime/issues/76710
Fixes https://github.com/dotnet/runtime/issues/122644

when `<EnableDiagnostics>true</EnableDiagnostics>` and `<WasmEmitSymbolMap>true</WasmEmitSymbolMap>` it would translate native stack traces from `wasm-function[1018]` form into a symbol name (even on Release build).



```
Error
    at C (https://localhost:8080/_framework/dotnet.js:271:31)
    at Object.S [as onAbort] (https://localhost:8080/_framework/dotnet.js:256:5)
    at abort (https://localhost:8080/_framework/dotnet.native.b0lnvxzshm.js:8:6505)
    at _abort (https://localhost:8080/_framework/dotnet.native.b0lnvxzshm.js:8:97882)
    at https://localhost:8080/_framework/dotnet.native.vp8656wnw0.wasm:wasm-function[1018]:0x54c75
    at https://localhost:8080/_framework/dotnet.native.vp8656wnw0.wasm:wasm-function[897]:0x46a87
    at https://localhost:8080/_framework/dotnet.native.vp8656wnw0.wasm:wasm-function[2881]:0x127834
    at https://localhost:8080/_framework/dotnet.native.vp8656wnw0.wasm:wasm-function[3100]:0x14cfe1
    at https://localhost:8080/_framework/dotnet.native.vp8656wnw0.wasm:wasm-function[1753]:0x9b746
    at https://localhost:8080/_framework/dotnet.native.vp8656wnw0.wasm:wasm-function[759]:0x3be97
```

Becomes

```
Error
    at C (https://localhost:8080/_framework/dotnet.js:271:31)
    at Object.S [as onAbort] (https://localhost:8080/_framework/dotnet.js:256:5)
    at abort (https://localhost:8080/_framework/dotnet.native.b0lnvxzshm.js:8:6505)
    at _abort (https://localhost:8080/_framework/dotnet.native.b0lnvxzshm.js:8:97882)
    at PROCAbort (https://localhost:8080/_framework/dotnet.native.vp8656wnw0.wasm:wasm-function[1018]:0x54c75)
    at TerminateProcess (https://localhost:8080/_framework/dotnet.native.vp8656wnw0.wasm:wasm-function[897]:0x46a87)
    at SfiNextWorker(StackFrameIterator*, unsigned int*, bool*, bool*) (https://localhost:8080/_framework/dotnet.native.vp8656wnw0.wasm:wasm-function[2881]:0x127834)
    at DispatchExSecondPass(ExInfo*) (https://localhost:8080/_framework/dotnet.native.vp8656wnw0.wasm:wasm-function[3100]:0x14cfe1)
    at DispatchManagedException(Object*, _CONTEXT*, _EXCEPTION_RECORD*, ExKind) (https://localhost:8080/_framework/dotnet.native.vp8656wnw0.wasm:wasm-function[1753]:0x9b746)
    at DispatchManagedException(Object*, ExKind) (https://localhost:8080/_framework/dotnet.native.vp8656wnw0.wasm:wasm-function[759]:0x3be97)
```