### PR TITLE
[Runtime Async] do not hold to continuation state when completing reusable valuetask sources

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Sources/ManualResetValueTaskSourceCore.cs
@@ -221,28 +221,30 @@ namespace System.Threading.Tasks.Sources
 
             if (continuation is not null)
             {
-                Debug.Assert(continuation is not null, $"{nameof(continuation)} is null");
-
+                object? state = _continuationState;
+                _continuationState = null;
                 object? context = _capturedContext;
+                _capturedContext = null;
+
                 if (context is null)
                 {
                     if (_runContinuationsAsynchronously)
                     {
-                        ThreadPool.UnsafeQueueUserWorkItem(continuation, _continuationState, preferLocal: true);
+                        ThreadPool.UnsafeQueueUserWorkItem(continuation, state, preferLocal: true);
                     }
                     else
                     {
-                        continuation(_continuationState);
+                        continuation(state);
                     }
                 }
                 else if (context is ExecutionContext or CapturedSchedulerAndExecutionContext)
                 {
-                    ManualResetValueTaskSourceCoreShared.InvokeContinuationWithContext(context, continuation, _continuationState, _runContinuationsAsynchronously);
+                    ManualResetValueTaskSourceCoreShared.InvokeContinuationWithContext(context, continuation, state, _runContinuationsAsynchronously);
                 }
                 else
                 {
                     Debug.Assert(context is TaskScheduler or SynchronizationContext, $"context is {context}");
-                    ManualResetValueTaskSourceCoreShared.ScheduleCapturedContext(context, continuation, _continuationState);
+                    ManualResetValueTaskSourceCoreShared.ScheduleCapturedContext(context, continuation, state);
                 }
             }
         }

--- a/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
+++ b/src/libraries/System.Threading.Channels/src/System/Threading/Channels/AsyncOperation.cs
@@ -266,11 +266,14 @@ namespace System.Threading.Channels
                 ctx as ExecutionContext ??
                 (ctx as CapturedSchedulerAndExecutionContext)?._executionContext;
 
+            _capturedContext = null;
             if (ec is null)
             {
                 Action<object?> c = _continuation!;
                 _continuation = s_completedSentinel;
-                c(_continuationState);
+                object? state = _continuationState;
+                _continuationState = null;
+                c(state);
             }
             else
             {
@@ -279,7 +282,9 @@ namespace System.Threading.Channels
                     var thisRef = (AsyncOperation)s!;
                     Action<object?> c = thisRef._continuation!;
                     thisRef._continuation = s_completedSentinel;
-                    c(thisRef._continuationState);
+                    object? state = thisRef._continuationState;
+                    thisRef._continuationState = null;
+                    c(state);
                 }, this);
             }
         }


### PR DESCRIPTION
Not exactly in the Runtime Async implementation, but the issue was found while testing Runtime Async in Libraries.

There is a scenario where ValueTaskSource upon completion invokes stashed `{_continuation, _continuationState}`. It is a one-shot invocation. Neither of `{_continuation, _continuationState}` are needed after that. However, while we naturally unroot `_continuation` by replacing it with a sentinel, the `_continuationState` will stay rooted until the VTS is reused. 

As a result, if continuation expects that some state (like `Http3ReadStream`) gets finalized, it may not see that no matter how long it waits/checks/retries. 

The retention was observable in intermittent failures in:

```
System.Net.Http.Functional.Tests.SocketsHttpHandler_HttpClientHandler_Finalization_Http3.IncompleteResponseStream_ResponseDropped_CancelsRequestToServer
```
(scenario may depend on mutual timings between Server and Client and whether sync/async paths are taken)

The whole purpose of the test is to see that if client drops the connection on the floor, it becomes unreachable reasonably soon and Finalization logic closes the connection. 

What we see instead is the test waits for a long time and eventually times out.

A similar code pattern was observed in `Threading/Channels/AsyncOperation`. 
Although I did not see any failures due to that, I applied the same fix of zeroing out the `_continuationState` before invoking the continuation.

Same applies to the `_capturedContext`. No need to hold to that for longer than needed.