### PR TITLE
Fix Optimization Profile read

### DIFF
--- a/src/coreclr/vm/multicorejitplayer.cpp
+++ b/src/coreclr/vm/multicorejitplayer.cpp
@@ -1037,7 +1037,7 @@ HRESULT MulticoreJitProfilePlayer::ReadCheckFile(const WCHAR * pFileName)
 
         HeaderRecord header;
 
-        size_t cbRead = fread(&header, sizeof(header), 1, fp);
+        size_t cbRead = fread(&header, 1, sizeof(header), fp);
 
         if (cbRead != sizeof(header))
         {


### PR DESCRIPTION
fread returns the number of elements read, not the number of bytes.