### PR TITLE
JIT: Disqualify inlinees using AsyncSuspend intrinsic

### DIFF
--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -3385,6 +3385,12 @@ GenTree* Compiler::impIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
 
     if (ni == NI_System_Runtime_CompilerServices_AsyncHelpers_AsyncSuspend)
     {
+        if (compIsForInlining())
+        {
+            compInlineResult->NoteFatal(InlineObservation::CALLEE_ASYNC_SUSPEND);
+            return nullptr;
+        }
+
         GenTree* node = gtNewOperNode(GT_RETURN_SUSPEND, TYP_VOID, impPopStack().val);
         node->SetHasOrderingSideEffect();
         node->gtFlags |= GTF_CALL | GTF_GLOB_REF;

--- a/src/coreclr/jit/inline.def
+++ b/src/coreclr/jit/inline.def
@@ -57,6 +57,7 @@ INLINE_OBSERVATION(STFLD_NEEDS_HELPER,        bool,   "stfld needs helper",     
 INLINE_OBSERVATION(TOO_MANY_ARGUMENTS,        bool,   "too many arguments",                   FATAL,       CALLEE)
 INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",                      FATAL,       CALLEE)
 INLINE_OBSERVATION(AWAIT,                     bool,   "has await",                            FATAL,       CALLEE)
+INLINE_OBSERVATION(ASYNC_SUSPEND,             bool,   "has async suspend",                    FATAL,       CALLEE)
 
 // ------ Callee Performance -------
 


### PR DESCRIPTION
Noticed that methods like AsyncHelpers.Await end up being inline candidates after recent inlining changes. But we cannot support inlining these since we rely on the caller creating a proper continuation when they suspend, and that will not happen if we inline an `AsyncSuspend` intrinsic.