### PR TITLE
Allow box_this pattern on composite r2r

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -2471,6 +2471,10 @@ namespace Internal.JitInterface
                 {
                     // alllowed, non-virtual method's on Object will never become virtual, and will also always trigger a BOX_THIS pattern
                 }
+                else if (_compilation.NodeFactory.CompilationModuleGroup.VersionsWithType(constrainedType))
+                {
+                    // The constrained value type is within the version bubble, so target method will always require boxing
+                }
                 else
                 {
                     throw new RequiresRuntimeJitException(pResult->thisTransform.ToString());


### PR DESCRIPTION
For the following code:
```
struct MyStruct
{
   public int Value;
}

static string CallToString<T>(ref T val) where T : struct
{
   // constrained. T callvirt ToString()
   return val.ToString();
}

var s = new MyStruct { Value = 42 };
Console.WriteLine(CallToString(ref s));
```

The CallToString method would be skipped by r2r because, in this state, if user would change MyStruct to contain an override for `ToString` then the generated code for CallToString would be incorrect since it should no longer do any boxing. For composite r2r however, this is not a problem if the valuetype (MyStruct) and the compiled method (CallToString) are in the same version bubble. The fix adds a check that these are in the same version bubble.