### PR TITLE
Add letter casing mismatch validation and start triggering SYSLIB1021

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/LoggerMessageGenerator.Parser.cs
@@ -248,6 +248,13 @@ namespace Microsoft.Extensions.Logging.Generators
                                         keepMethod = false;
                                     }
 
+                                    bool casingValid = ValidateTemplatesCasingConsistency(lm.TemplateList);
+                                    if (!casingValid)
+                                    {
+                                        Diag(DiagnosticDescriptors.InconsistentTemplateCasing, method.Identifier.GetLocation(), method.Identifier.ToString());
+                                        keepMethod = false;
+                                    }
+
                                     if (lm.Name[0] == '_')
                                     {
                                         // can't have logging method names that start with _ since that can lead to conflicting symbol names
@@ -786,6 +793,36 @@ namespace Microsoft.Extensions.Logging.Generators
                 }
 
                 return success;
+            }
+
+            /// <summary>
+            /// Validates that templates list does not contains templates with mixed casing like {hello} and {Hello}
+            /// </summary>
+            /// <returns>Value indicating lack of mixed casing within templates list</returns>
+            private static bool ValidateTemplatesCasingConsistency(List<string> templates)
+            {
+                int count = templates.Count;
+
+                for (int i = 1; i < count; i++)
+                {
+                    string templateI = templates[i];
+
+                    for (int j = 0; j < i; j++)
+                    {
+                        string templateJ = templates[j];
+
+                        bool matchIgnoreCase = StringComparer.OrdinalIgnoreCase.Compare(templateI, templateJ) == 0;
+                        bool matchExact = StringComparer.Ordinal.Compare(templateI, templateJ) == 0;
+
+                        if (matchIgnoreCase && !matchExact)
+                        {
+                            return false;
+                        }
+
+                    }
+                }
+
+                return true;
             }
 
             /// <summary>

--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/LoggerMessageGeneratorParserTests.cs
@@ -284,6 +284,21 @@ namespace Microsoft.Extensions.Logging.Generators.Tests
         }
 
         [Fact]
+        public async Task MixedCasing()
+        {
+            IReadOnlyList<Diagnostic> diagnostics = await RunGenerator(@"
+                partial class C
+                {
+                    [LoggerMessage(EventId = 0, Level = LogLevel.Debug, Message = ""M1 {par1} {PAr1} {a}"")]
+                    static partial void M1(ILogger logger, int par1, int a);
+                }
+            ");
+
+            Assert.Single(diagnostics);
+            Assert.Equal(DiagnosticDescriptors.InconsistentTemplateCasing.Id, diagnostics[0].Id);
+        }
+
+        [Fact]
         public async Task DoubleLogLevel_InAttributeAndAsParameterButMissingInTemplate_ProducesDiagnostic()
         {
             IReadOnlyList<Diagnostic> diagnostics = await RunGenerator(@"


### PR DESCRIPTION
Fix #52228

Adds test case listed in issue and add code which validates template arguments and possibly triggers SYSLIB1021 diagnostics which is already defined, and documented, but as far as I know there were no place triggering it before which was briefly mentioned in issue:

> Note: SYSLIB1021 diagnostic descriptor [is already merged on main](https://github.com/dotnet/runtime/blob/ff12237f483eb0afdabf1aeb71b69ff992d6bd40/src/libraries/Microsoft.Extensions.Logging.Abstractions/gen/DiagnosticDescriptors.cs#L163-L169), but it is not being triggered.
