### PR TITLE
Add support for async thunk methods in GetNativeCodeInfo

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -1187,6 +1187,21 @@ void DacDbiInterfaceImpl::GetNativeCodeInfo(VMPTR_DomainAssembly         vmDomai
     Module *     pModule     = pDomainAssembly->GetAssembly()->GetModule();
 
     MethodDesc* pMethodDesc = FindLoadedMethodRefOrDef(pModule, functionToken);
+    if (pMethodDesc->IsAsyncThunkMethod())
+    {
+        MethodTable * pMT = pMethodDesc->GetMethodTable();
+        MethodTable::IntroducedMethodIterator it(pMT);
+        for (; it.IsValid(); it.Next())
+        {
+            MethodDesc * pMD = it.GetMethodDesc();
+            CONSISTENCY_CHECK(pMD != NULL && pMD->GetMethodTable() == pMT);
+            if (!pMD->IsDiagnosticsHidden())
+            {
+                pMethodDesc = pMD;
+                break;
+            }
+        }
+    }
     pCodeInfo->vmNativeCodeMethodDescToken.SetHostPtr(pMethodDesc);
 
     // if we are loading a module and trying to bind a previously set breakpoint, we may not have

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -1187,9 +1187,13 @@ void DacDbiInterfaceImpl::GetNativeCodeInfo(VMPTR_DomainAssembly         vmDomai
     Module *     pModule     = pDomainAssembly->GetAssembly()->GetModule();
 
     MethodDesc* pMethodDesc = FindLoadedMethodRefOrDef(pModule, functionToken);
-    if (pMethodDesc->IsAsyncThunkMethod())
+    if (pMethodDesc != NULL && pMethodDesc->IsAsyncThunkMethod())
     {
-        pMethodDesc = pMethodDesc->GetAsyncOtherVariantNoCreate();
+        MethodDesc* pAsyncVariant = pMethodDesc->GetAsyncOtherVariantNoCreate();
+        if (pAsyncVariant != NULL)
+        {
+            pMethodDesc = pAsyncVariant;
+        }
     }
     pCodeInfo->vmNativeCodeMethodDescToken.SetHostPtr(pMethodDesc);
 

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -1189,18 +1189,7 @@ void DacDbiInterfaceImpl::GetNativeCodeInfo(VMPTR_DomainAssembly         vmDomai
     MethodDesc* pMethodDesc = FindLoadedMethodRefOrDef(pModule, functionToken);
     if (pMethodDesc->IsAsyncThunkMethod())
     {
-        MethodTable * pMT = pMethodDesc->GetMethodTable();
-        MethodTable::IntroducedMethodIterator it(pMT);
-        for (; it.IsValid(); it.Next())
-        {
-            MethodDesc * pMD = it.GetMethodDesc();
-            CONSISTENCY_CHECK(pMD != NULL && pMD->GetMethodTable() == pMT);
-            if (!pMD->IsDiagnosticsHidden())
-            {
-                pMethodDesc = pMD;
-                break;
-            }
-        }
+        pMethodDesc = pMethodDesc->GetAsyncOtherVariantNoCreate();
     }
     pCodeInfo->vmNativeCodeMethodDescToken.SetHostPtr(pMethodDesc);
 

--- a/src/coreclr/vm/CMakeLists.txt
+++ b/src/coreclr/vm/CMakeLists.txt
@@ -87,6 +87,7 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     gchandleutilities.cpp
     genericdict.cpp
     generics.cpp
+    genmeth.cpp
     hash.cpp
     ilinstrumentation.cpp
     ilstubcache.cpp
@@ -333,7 +334,6 @@ set(VM_SOURCES_WKS
     gcenv.ee.common.cpp
     gchelpers.cpp
     genanalysis.cpp
-    genmeth.cpp
     hosting.cpp
     hostinformation.cpp
     ilmarshalers.cpp

--- a/src/coreclr/vm/generics.cpp
+++ b/src/coreclr/vm/generics.cpp
@@ -494,6 +494,8 @@ ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation(
     RETURN(TypeHandle(pMT));
 } // ClassLoader::CreateTypeHandleForNonCanonicalGenericInstantiation
 
+#endif // !DACCESS_COMPILE
+
 namespace Generics
 {
 
@@ -531,6 +533,13 @@ BOOL CheckInstantiation(Instantiation inst)
     }
     return TRUE;
 }
+
+} // namespace Generics
+
+#ifndef DACCESS_COMPILE
+
+namespace Generics
+{
 
 // Just records the owner and links to the previous graph.
 RecursionGraph::RecursionGraph(RecursionGraph *pPrev, TypeHandle thOwner)

--- a/src/coreclr/vm/instmethhash.cpp
+++ b/src/coreclr/vm/instmethhash.cpp
@@ -86,6 +86,7 @@ PTR_LoaderAllocator InstMethodHashTable::GetLoaderAllocator()
     }
 }
 
+#endif // #ifndef DACCESS_COMPILE
 
 // Calculate a hash value for a method-desc key
 static DWORD Hash(TypeHandle declaringType, mdMethodDef token, Instantiation inst)
@@ -97,9 +98,9 @@ static DWORD Hash(TypeHandle declaringType, mdMethodDef token, Instantiation ins
     DWORD dwHash = 0x87654321;
 #define INST_HASH_ADD(_value) dwHash = ((dwHash << 5) + dwHash) ^ (_value)
 #ifdef TARGET_64BIT
-#define INST_HASH_ADDPOINTER(_value) INST_HASH_ADD((uint32_t)(uintptr_t)_value); INST_HASH_ADD((uint32_t)(((uintptr_t)_value) >> 32))
+#define INST_HASH_ADDPOINTER(_value) INST_HASH_ADD((uint32_t)dac_cast<TADDR>(_value)); INST_HASH_ADD((uint32_t)((dac_cast<TADDR>(_value)) >> 32))
 #else
-#define INST_HASH_ADDPOINTER(_value) INST_HASH_ADD((uint32_t)(uintptr_t)_value);
+#define INST_HASH_ADDPOINTER(_value) INST_HASH_ADD((uint32_t)dac_cast<TADDR>(_value));
 #endif
 
     INST_HASH_ADDPOINTER(declaringType.AsPtr());
@@ -195,6 +196,8 @@ MethodDesc* InstMethodHashTable::FindMethodDesc(TypeHandle declaringType,
 
     return pMDResult;
 }
+
+#ifndef DACCESS_COMPILE
 
 BOOL InstMethodHashTable::ContainsMethodDesc(MethodDesc* pMD)
 {

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1708,6 +1708,11 @@ public:
         return FindOrCreateAssociatedMethodDesc(this, GetMethodTable(), FALSE, GetMethodInstantiation(), allowInstParam, FALSE, TRUE, AsyncVariantLookup::AsyncOtherVariant);
     }
 
+    MethodDesc* GetAsyncOtherVariantNoCreate(BOOL allowInstParam = TRUE)
+    {
+        return FindOrCreateAssociatedMethodDesc(this, GetMethodTable(), FALSE, GetMethodInstantiation(), allowInstParam, FALSE, FALSE, AsyncVariantLookup::AsyncOtherVariant);
+    }
+
     MethodDesc* GetAsyncVariant(BOOL allowInstParam = TRUE)
     {
         _ASSERT(!IsAsyncVariantMethod());


### PR DESCRIPTION
Fork of https://github.com/dotnet/runtime/pull/124354 which uses the existing FindOrCreateAssociatedMethodDesc logic