### PR TITLE
[release/10.0] `PersistedAssemblyBuilder`: Fix encoding of custom modifiers. (#123925)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/FieldOnTypeBuilderInstantiation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/FieldOnTypeBuilderInstantiation.cs
@@ -56,6 +56,7 @@ namespace System.Reflection.Emit
         #region Public Abstract\Virtual Members
         public override Type[] GetRequiredCustomModifiers() { return _field.GetRequiredCustomModifiers(); }
         public override Type[] GetOptionalCustomModifiers() { return _field.GetOptionalCustomModifiers(); }
+        public override Type GetModifiedFieldType() => _field.GetModifiedFieldType();
         public override void SetValueDirect(TypedReference obj, object value)
         {
             throw new NotImplementedException();

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/MethodOnTypeBuilderInstantiation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/MethodOnTypeBuilderInstantiation.cs
@@ -118,7 +118,7 @@ namespace System.Reflection.Emit
 
         #region Public Abstract\Virtual Members
         public override Type ReturnType => _method.ReturnType;
-        public override ParameterInfo ReturnParameter => throw new NotSupportedException();
+        public override ParameterInfo ReturnParameter => _method.ReturnParameter;
         public override ICustomAttributeProvider ReturnTypeCustomAttributes => throw new NotSupportedException();
         public override MethodInfo GetBaseDefinition() { throw new NotSupportedException(); }
         #endregion

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/ModifiedType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/ModifiedType.cs
@@ -172,8 +172,10 @@ namespace System.Reflection
         public override bool IsEnum => _unmodifiedType.IsEnum;
         protected override bool IsPrimitiveImpl() => _unmodifiedType.IsPrimitive;
         protected override bool IsByRefImpl() => _unmodifiedType.IsByRef;
+        public override bool IsGenericParameter => _unmodifiedType.IsGenericParameter;
         public override bool IsGenericTypeParameter => _unmodifiedType.IsGenericTypeParameter;
         public override bool IsGenericMethodParameter => _unmodifiedType.IsGenericMethodParameter;
+        public override int GenericParameterPosition => _unmodifiedType.GenericParameterPosition;
         protected override bool IsPointerImpl() => _unmodifiedType.IsPointer;
         protected override bool IsValueTypeImpl() => _unmodifiedType.IsValueType;
         protected override bool IsCOMObjectImpl() => _unmodifiedType.IsCOMObject;

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/FieldBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/FieldBuilderImpl.cs
@@ -113,6 +113,8 @@ namespace System.Reflection.Emit
 
         public override Type[] GetOptionalCustomModifiers() => _optionalCustomModifiers ?? Type.EmptyTypes;
 
+        public override Type GetModifiedFieldType() => FieldType;
+
         #endregion
 
         #region ICustomAttributeProvider Implementation

--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ParameterBuilderImpl.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/ParameterBuilderImpl.cs
@@ -68,8 +68,7 @@ namespace System.Reflection.Emit
     internal sealed class ParameterInfoWrapper : ParameterInfo
     {
         private readonly ParameterBuilderImpl _pb;
-        private readonly Type _type
-;
+        private readonly Type _type;
         public ParameterInfoWrapper(ParameterBuilderImpl pb, Type type)
         {
             _pb = pb;
@@ -87,5 +86,7 @@ namespace System.Reflection.Emit
         public override bool HasDefaultValue => _pb._defaultValue != DBNull.Value;
 
         public override object? DefaultValue => HasDefaultValue ? _pb._defaultValue : null;
+
+        public override Type GetModifiedParameterType() => ParameterType;
     }
 }

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveILGeneratorTests.cs
@@ -2637,9 +2637,9 @@ public class MyType
                 TypeBuilder nestedItem = type.DefineNestedType("ItemInfo", TypeAttributes.NestedPublic);
                 GenericTypeParameterBuilder itemParam = nestedItem.DefineGenericParameters(genParams)[0];
                 TypeBuilder nestedSector = type.DefineNestedType("Sector", TypeAttributes.NestedPublic);
-                GenericTypeParameterBuilder nestedParam = nestedSector.DefineGenericParameters(genParams)[0];
+                GenericTypeParameterBuilder sectorParam = nestedSector.DefineGenericParameters(genParams)[0];
 
-                Type nestedOfT = nestedItem.MakeGenericType(nestedParam);
+                Type nestedOfT = nestedItem.MakeGenericType(sectorParam);
                 Type parent = typeof(HashSet<>).MakeGenericType(nestedOfT);
                 nestedSector.SetParent(parent);
 

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderAPIsTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderAPIsTests.cs
@@ -633,13 +633,13 @@ namespace System.Reflection.Emit.Tests
                     Type[] par0RequiredMods = allModMethod.GetParameters()[0].GetRequiredCustomModifiers();
                     Type[] par0OptionalMods = allModMethod.GetParameters()[0].GetOptionalCustomModifiers();
                     Assert.Equal(2, returnReqMods.Length);
-                    Assert.Equal(mlc.CoreAssembly.GetType(typeof(short).FullName), returnReqMods[0]);
-                    Assert.Equal(mlc.CoreAssembly.GetType(typeof(int).FullName), returnReqMods[1]);
+                    Assert.Equal(mlc.CoreAssembly.GetType(typeof(int).FullName), returnReqMods[0]);
+                    Assert.Equal(mlc.CoreAssembly.GetType(typeof(short).FullName), returnReqMods[1]);
                     Assert.Equal(1, returnOptMods.Length);
                     Assert.Equal(mlc.CoreAssembly.GetType(typeof(Version).FullName), returnOptMods[0]);
                     Assert.Equal(cmodsReq1.Length, par0RequiredMods.Length);
-                    Assert.Equal(mlc.CoreAssembly.GetType(cmodsReq1[1].FullName), par0RequiredMods[0]);
-                    Assert.Equal(mlc.CoreAssembly.GetType(cmodsReq1[0].FullName), par0RequiredMods[1]);
+                    Assert.Equal(mlc.CoreAssembly.GetType(cmodsReq1[0].FullName), par0RequiredMods[0]);
+                    Assert.Equal(mlc.CoreAssembly.GetType(cmodsReq1[1].FullName), par0RequiredMods[1]);
                     Assert.Equal(cmodsOpt1.Length, par0OptionalMods.Length);
                     Assert.Equal(mlc.CoreAssembly.GetType(cmodsOpt1[0].FullName), par0OptionalMods[0]);
                     Assert.Equal(cmodsReq2.Length, allModMethod.GetParameters()[1].GetRequiredCustomModifiers().Length);

--- a/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderTests.cs
+++ b/src/libraries/System.Reflection.Emit/tests/PersistedAssemblyBuilder/AssemblySaveTypeBuilderTests.cs
@@ -5,8 +5,11 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Reflection.Emit.Tests
@@ -789,6 +792,155 @@ namespace System.Reflection.Emit.Tests
             Assert.Equal("ValueTypeChildren", fields[1].Name);
             Assert.True(fields[1].FieldType.GetGenericArguments()[0].IsValueType);
         }
+
+        [Fact]
+        public void SaveFunctionPointerFields()
+        {
+            using TempFile file = TempFile.Create();
+            using MetadataLoadContext mlc = new MetadataLoadContext(new CoreMetadataAssemblyResolver());
+
+            PersistedAssemblyBuilder ab = AssemblySaveTools.PopulateAssemblyAndModule(out ModuleBuilder mb);
+            TypeBuilder tb = mb.DefineType("TestType", TypeAttributes.Public | TypeAttributes.Class);
+
+            // delegate*<int, int>
+            Type funcPtr1 = typeof(delegate*<int, int>);
+            tb.DefineField("FuncPtr1", funcPtr1, FieldAttributes.Public | FieldAttributes.Static);
+
+            // delegate* unmanaged[Cdecl]<int, float, double>
+            Type funcPtr4 = new ModifiedTypeHelpers.FunctionPointer(
+                typeof(delegate* unmanaged[Cdecl]<int, float, double>),
+                [typeof(CallConvCdecl)]);
+            tb.DefineField("FuncPtr2", funcPtr4, FieldAttributes.Public | FieldAttributes.Static);
+
+            // delegate* unmanaged[Stdcall]<string, in int, void>
+            Type funcPtr5 = new ModifiedTypeHelpers.FunctionPointer(
+                typeof(delegate* unmanaged[Stdcall]<string, in int, void>),
+                [typeof(CallConvStdcall)],
+                customParameterTypes: [typeof(string), new ModifiedTypeHelpers.ModifiedType(typeof(int).MakeByRefType(), [typeof(InAttribute)], [])]);
+            tb.DefineField("FuncPtr3", funcPtr5, FieldAttributes.Public | FieldAttributes.Static);
+
+            tb.CreateType();
+            ab.Save(file.Path);
+
+            Assembly assemblyFromDisk = mlc.LoadFromAssemblyPath(file.Path);
+            Type testType = assemblyFromDisk.Modules.First().GetType("TestType");
+            Assert.NotNull(testType);
+
+            FieldInfo field1 = testType.GetField("FuncPtr1");
+            Assert.NotNull(field1);
+            Assert.True(field1.FieldType.IsFunctionPointer);
+            Assert.False(field1.FieldType.IsUnmanagedFunctionPointer);
+            Type[] paramTypes1 = field1.FieldType.GetFunctionPointerParameterTypes();
+            Assert.Equal(1, paramTypes1.Length);
+            Assert.Equal(typeof(int).FullName, paramTypes1[0].FullName);
+            Assert.Equal(typeof(int).FullName, field1.FieldType.GetFunctionPointerReturnType().FullName);
+
+            FieldInfo field2 = testType.GetField("FuncPtr2");
+            Type field2Type = field2.GetModifiedFieldType();
+            Assert.NotNull(field2);
+            Assert.True(field2Type.IsFunctionPointer);
+            Assert.True(field2Type.IsUnmanagedFunctionPointer);
+            Type[] paramTypes2 = field2Type.GetFunctionPointerParameterTypes();
+            Assert.Equal(2, paramTypes2.Length);
+            Assert.Equal(typeof(int).FullName, paramTypes2[0].FullName);
+            Assert.Equal(typeof(float).FullName, paramTypes2[1].FullName);
+            Assert.Equal(typeof(double).FullName, field2Type.GetFunctionPointerReturnType().FullName);
+            Type[] callingConventions2 = field2Type.GetFunctionPointerCallingConventions();
+            Assert.Contains(callingConventions2, t => t.FullName == typeof(CallConvCdecl).FullName);
+
+            FieldInfo field3 = testType.GetField("FuncPtr3");
+            Type field3Type = field3.GetModifiedFieldType();
+            Assert.NotNull(field3);
+            Assert.True(field3Type.IsFunctionPointer);
+            Assert.True(field3Type.IsUnmanagedFunctionPointer);
+            Type[] paramTypes3 = field3Type.GetFunctionPointerParameterTypes();
+            Assert.Equal(2, paramTypes3.Length);
+            Assert.Equal(typeof(string).FullName, paramTypes3[0].FullName);
+            Assert.Equal(typeof(int).MakeByRefType().FullName, paramTypes3[1].FullName);
+            Assert.Contains(paramTypes3[1].GetRequiredCustomModifiers(), t => t.FullName == typeof(InAttribute).FullName);
+            Assert.Equal(typeof(void).FullName, field3Type.GetFunctionPointerReturnType().FullName);
+            Type[] callingConventions3 = field3Type.GetFunctionPointerCallingConventions();
+            Assert.Contains(callingConventions3, t => t.FullName == typeof(CallConvStdcall).FullName);
+        }
+
+        [Fact]
+        public void ConsumeFunctionPointerFields()
+        {
+            // public unsafe class Container
+            // {
+            //     public static delegate*<int, int, int> Method;
+            // 
+            //     public static int Add(int a, int b) => a + b;
+            //     public static void Init() => Method = &Add;
+            // }
+
+            TempFile assembly1Path = TempFile.Create();
+            PersistedAssemblyBuilder assembly1 = new(new AssemblyName("Assembly1"), typeof(object).Assembly);
+            ModuleBuilder mod1 = assembly1.DefineDynamicModule("Module1");
+            TypeBuilder containerType = mod1.DefineType("Container", TypeAttributes.Public | TypeAttributes.Class);
+            FieldBuilder methodField = containerType.DefineField("Method", typeof(delegate*<int, int, int>), FieldAttributes.Public | FieldAttributes.Static);
+            MethodBuilder addMethod = containerType.DefineMethod("Add", MethodAttributes.Public | MethodAttributes.Static);
+            addMethod.SetParameters(typeof(int), typeof(int));
+            addMethod.SetReturnType(typeof(int));
+            ILGenerator addMethodIL = addMethod.GetILGenerator();
+            addMethodIL.Emit(OpCodes.Ldarg_0);
+            addMethodIL.Emit(OpCodes.Ldarg_1);
+            addMethodIL.Emit(OpCodes.Add);
+            addMethodIL.Emit(OpCodes.Ret);
+            MethodBuilder initMethod = containerType.DefineMethod("Init", MethodAttributes.Public | MethodAttributes.Static);
+            initMethod.SetReturnType(typeof(void));
+            ILGenerator initMethodIL = initMethod.GetILGenerator();
+            initMethodIL.Emit(OpCodes.Ldftn, addMethod);
+            initMethodIL.Emit(OpCodes.Stsfld, methodField);
+            initMethodIL.Emit(OpCodes.Ret);
+            containerType.CreateType();
+            assembly1.Save(assembly1Path.Path);
+
+            // class Program
+            // {
+            //     public static int Main()
+            //     {
+            //         Container.Init();
+            //         return Container.Method(2, 3);
+            //     }
+            // }
+
+            TestAssemblyLoadContext context = new();
+
+            TempFile assembly2Path = TempFile.Create();
+            Assembly assembly1FromDisk = context.LoadFromAssemblyPath(assembly1Path.Path);
+            PersistedAssemblyBuilder assembly2 = new(new AssemblyName("Assembly2"), typeof(object).Assembly);
+            ModuleBuilder mod2 = assembly2.DefineDynamicModule("Module2");
+            TypeBuilder programType = mod2.DefineType("Program");
+            MethodBuilder mainMethod = programType.DefineMethod("Main", MethodAttributes.Public | MethodAttributes.Static);
+            mainMethod.SetReturnType(typeof(int));
+            ILGenerator il = mainMethod.GetILGenerator();
+            il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerFields).GetField("field1"));
+            il.Emit(OpCodes.Pop);
+            // References to fields with unmanaged calling convention are broken
+            // [ActiveIssue("https://github.com/dotnet/runtime/issues/120909")]
+            // il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerFields).GetField("field2"));
+            // il.Emit(OpCodes.Pop);
+            // il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerFields).GetField("field3"));
+            // il.Emit(OpCodes.Pop);
+            // il.Emit(OpCodes.Ldsfld, typeof(ClassWithFunctionPointerFields).GetField("field4"));
+            // il.Emit(OpCodes.Pop);
+            il.Emit(OpCodes.Call, assembly1FromDisk.GetType("Container").GetMethod("Init"));
+            il.Emit(OpCodes.Ldc_I4_2);
+            il.Emit(OpCodes.Ldc_I4_3);
+            il.Emit(OpCodes.Ldsfld, assembly1FromDisk.GetType("Container").GetField("Method"));
+            il.EmitCalli(OpCodes.Calli, CallingConventions.Standard, typeof(int), [typeof(int), typeof(int)], null);
+            il.Emit(OpCodes.Ret);
+            programType.CreateType();
+            assembly2.Save(assembly2Path.Path);
+
+            Assembly assembly2FromDisk = context.LoadFromAssemblyPath(assembly2Path.Path);
+            int result = (int)assembly2FromDisk.GetType("Program").GetMethod("Main").Invoke(null, null);
+            Assert.Equal(5, result);
+
+            assembly1Path.Dispose();
+            assembly2Path.Dispose();
+        }
     }
 
     // Test Types
@@ -835,5 +987,13 @@ namespace System.Reflection.Emit.Tests
     {
         public EmptyTestClass field1;
         public byte field2;
+    }
+
+    public unsafe class ClassWithFunctionPointerFields
+    {
+        public static delegate*<ClassWithFunctionPointerFields> field1;
+        public static delegate* unmanaged<int> field2;
+        public static delegate* unmanaged[Cdecl]<Guid> field3;
+        public static delegate* unmanaged[Cdecl, SuppressGCTransition]<Vector<int>, Vector<int>> field4;
     }
 }

--- a/src/libraries/System.Reflection.Emit/tests/System.Reflection.Emit.Tests.csproj
+++ b/src/libraries/System.Reflection.Emit/tests/System.Reflection.Emit.Tests.csproj
@@ -135,6 +135,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Reflection.Emit\src\System.Reflection.Emit.csproj" />
     <ProjectReference Include="$(LibrariesProjectRoot)System.Reflection.MetadataLoadContext\src\System.Reflection.MetadataLoadContext.csproj" />
   </ItemGroup>
 

--- a/src/libraries/System.Reflection.Emit/tests/Utilities.cs
+++ b/src/libraries/System.Reflection.Emit/tests/Utilities.cs
@@ -164,4 +164,54 @@ namespace System.Reflection.Emit.Tests
             return name;
         }
     }
+
+    public static class ModifiedTypeHelpers
+    {
+        public class FunctionPointer : TypeDelegator
+        {
+            private readonly Type[] callingConventions;
+            private readonly Type returnType;
+            private readonly Type[] parameterTypes;
+            private readonly Type[] requiredModifiers;
+            private readonly Type[] optionalModifiers;
+
+            public FunctionPointer(
+                Type baseFunctionPointerType,
+                Type[] conventions = null,
+                Type customReturnType = null,
+                Type[] customParameterTypes = null,
+                Type[] fnPtrRequiredMods = null,
+                Type[] fnPtrOptionalMods = null)
+                : base(baseFunctionPointerType)
+            {
+                callingConventions = conventions ?? [];
+                returnType = customReturnType ?? baseFunctionPointerType.GetFunctionPointerReturnType();
+                parameterTypes = customParameterTypes ?? baseFunctionPointerType.GetFunctionPointerParameterTypes();
+                requiredModifiers = fnPtrRequiredMods ?? [];
+                optionalModifiers = fnPtrOptionalMods ?? [];
+            }
+
+            public override Type[] GetFunctionPointerCallingConventions() => callingConventions;
+            public override Type GetFunctionPointerReturnType() => returnType;
+            public override Type[] GetFunctionPointerParameterTypes() => parameterTypes;
+            public override Type[] GetRequiredCustomModifiers() => requiredModifiers;
+            public override Type[] GetOptionalCustomModifiers() => optionalModifiers;
+        }
+
+        public class ModifiedType : TypeDelegator
+        {
+            private readonly Type[] requiredModifiers;
+            private readonly Type[] optionalModifiers;
+
+            public ModifiedType(Type delegatingType, Type[] requiredMods = null, Type[] optionalMods = null)
+                : base(delegatingType)
+            {
+                requiredModifiers = requiredMods ?? [];
+                optionalModifiers = optionalMods ?? [];
+            }
+
+            public override Type[] GetRequiredCustomModifiers() => requiredModifiers;
+            public override Type[] GetOptionalCustomModifiers() => optionalModifiers;
+        }
+    }
 }

--- a/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Reflection/RuntimeParameterInfo.cs
@@ -425,6 +425,6 @@ namespace System.Reflection
 
         internal Type[] GetCustomModifiersFromModifiedType(bool optional, int genericArgumentPosition) => GetTypeModifiers(ParameterType, Member, Position, optional, genericArgumentPosition) ?? Type.EmptyTypes;
 
-        public override Type GetModifiedParameterType() => ModifiedType.Create(ParameterType, this, PositionImpl + 1);
+        public override Type GetModifiedParameterType() => ModifiedType.Create(ParameterType, this);
     }
 }


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/119935, https://github.com/dotnet/runtime/pull/121128, https://github.com/dotnet/runtime/pull/123925 to release/10.0

## Customer Impact

- [X] Customer reported
- [ ] Found internally

Unable to emit references to methods and fields with signatures that include modopts and modreqs using `PersistedAssemblyBuilder` (e.g. method signatures that use C# `readonly ref` or `in`).

## Regression

- [ ] Yes
- [X] No

This is a bug in PersistedAssemblyBuilder that shipped in .NET 9. Adoption blocker with no workaround.

## Testing

Dedicated tests.

## Risk

Medium. The change is a combination of 3 different PRs that fixed different aspects of the bug. The size of the delta makes is a medium risk.