### PR TITLE
Add ActiveIssue to GetTotalAllocatedBytes test

### DIFF
--- a/src/tests/GC/API/GC/GetTotalAllocatedBytes.cs
+++ b/src/tests/GC/API/GC/GetTotalAllocatedBytes.cs
@@ -177,6 +177,7 @@ public class Test_GetTotalAllocatedBytes
     }
 
     [ActiveIssue("needs triage", TestRuntimes.Mono)]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/119187", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot), nameof(TestLibrary.Utilities.IsArm))]
     [Fact]
     public static void TestEntryPoint() 
     {

--- a/src/tests/GC/API/GC/GetTotalAllocatedBytes.cs
+++ b/src/tests/GC/API/GC/GetTotalAllocatedBytes.cs
@@ -177,7 +177,7 @@ public class Test_GetTotalAllocatedBytes
     }
 
     [ActiveIssue("needs triage", TestRuntimes.Mono)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/119187", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsNativeAot), nameof(TestLibrary.Utilities.IsArm))]
+    [ActiveIssue("https://github.com/dotnet/runtime/issues/121482", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsArm))]
     [Fact]
     public static void TestEntryPoint() 
     {


### PR DESCRIPTION
This test very often OOMs in outerloop. We'll get more fully green outerloops if we just stop running it.

Cc @dotnet/ilc-contrib 