### PR TITLE
[r2r] Don't skip methods with AggressiveOptimization attribute on ios

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -523,7 +523,8 @@ namespace Internal.JitInterface
 
         public static bool ShouldSkipCompilation(InstructionSetSupport instructionSetSupport, MethodDesc methodNeedingCode)
         {
-            if (methodNeedingCode.IsAggressiveOptimization)
+            bool targetAllowsRuntimeCodeGeneration = ((ReadyToRunCompilerContext)methodNeedingCode.Context).TargetAllowsRuntimeCodeGeneration;
+            if (methodNeedingCode.IsAggressiveOptimization && targetAllowsRuntimeCodeGeneration)
             {
                 return true;
             }
@@ -532,8 +533,7 @@ namespace Internal.JitInterface
             // On platforms where we cannot JIT, we need to ensure that we have a fallback implementation pre-compiled
             // so any code that uses hardware intrinsics and is interpreted has an implementation to use.
             // This allows us to avoid the high cost of manually implementing intrinsics in the interpreter.
-            if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(methodNeedingCode)
-                && ((ReadyToRunCompilerContext)methodNeedingCode.Context).TargetAllowsRuntimeCodeGeneration)
+            if (HardwareIntrinsicHelpers.IsHardwareIntrinsic(methodNeedingCode) && targetAllowsRuntimeCodeGeneration)
             {
                 return true;
             }


### PR DESCRIPTION
These methods were likely skipped on r2r so they can end up with better generated code at runtime, from the JIT. On iOS, this would have the exact opposite effect. By not using r2r for them, the methods would be interpreted with terrible perf.