### PR TITLE
Move async variant resolution into `getCallInfo`

### DIFF
--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -1434,14 +1434,14 @@ enum CORINFO_THIS_TRANSFORM
 
 enum CORINFO_CALLINFO_FLAGS
 {
-    CORINFO_CALLINFO_NONE           = 0x0000,
-    CORINFO_CALLINFO_ALLOWINSTPARAM = 0x0001,   // Can the compiler generate code to pass an instantiation parameters? Simple compilers should not use this flag
-    CORINFO_CALLINFO_CALLVIRT       = 0x0002,   // Is it a virtual call?
-    // UNUSED                       = 0x0004,
-    CORINFO_CALLINFO_DISALLOW_STUB  = 0x0008,   // Do not use a stub for this call, even if it is a virtual call.
-    CORINFO_CALLINFO_SECURITYCHECKS = 0x0010,   // Perform security checks.
-    CORINFO_CALLINFO_LDFTN          = 0x0020,   // Resolving target of LDFTN
-    // UNUSED                       = 0x0040,
+    CORINFO_CALLINFO_NONE              = 0x0000,
+    CORINFO_CALLINFO_ALLOWINSTPARAM    = 0x0001,   // Can the compiler generate code to pass an instantiation parameters? Simple compilers should not use this flag
+    CORINFO_CALLINFO_CALLVIRT          = 0x0002,   // Is it a virtual call?
+    CORINFO_CALLINFO_ALLOWASYNCVARIANT = 0x0004,   // allow resolution to an async variant
+    CORINFO_CALLINFO_DISALLOW_STUB     = 0x0008,   // Do not use a stub for this call, even if it is a virtual call.
+    CORINFO_CALLINFO_SECURITYCHECKS    = 0x0010,   // Perform security checks.
+    CORINFO_CALLINFO_LDFTN             = 0x0020,   // Resolving target of LDFTN
+    // UNUSED                          = 0x0040,
 };
 
 enum CorInfoIsAccessAllowedResult
@@ -1484,10 +1484,6 @@ enum CorInfoTokenKind
 
     // token comes from devirtualizing a method
     CORINFO_TOKENKIND_DevirtualizedMethod = 0x800 | CORINFO_TOKENKIND_Method,
-
-    // token comes from runtime async awaiting pattern
-    CORINFO_TOKENKIND_Await = 0x2000 | CORINFO_TOKENKIND_Method,
-    CORINFO_TOKENKIND_AwaitVirtual = 0x4000 | CORINFO_TOKENKIND_Method,
 };
 
 struct CORINFO_RESOLVED_TOKEN
@@ -1560,6 +1556,12 @@ struct CORINFO_CALL_INFO
     CORINFO_CONST_LOOKUP    instParamLookup;
 
     bool                    wrapperDelegateInvoke;
+
+    // If CORINFO_CALLINFO_ALLOWASYNCVARIANT was passed, this is the resolved
+    // async variant or NULL if no async variant was resolved.
+    // This is the async variant of the token's method and differs from hMethod
+    // of this class in cases of sharing, constrained resolution etc.
+    CORINFO_METHOD_HANDLE   resolvedAsyncVariant;
 };
 
 enum CORINFO_DEVIRTUALIZATION_DETAIL

--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -37,11 +37,11 @@
 
 #include <minipal/guid.h>
 
-constexpr GUID JITEEVersionIdentifier = { /* 8f2ee94f-5111-4b7b-97bd-5c689d476385 */
-    0x8f2ee94f,
-    0x5111,
-    0x4b7b,
-    {0x97, 0xbd, 0x5c, 0x68, 0x9d, 0x47, 0x63, 0x85}
+constexpr GUID JITEEVersionIdentifier = { /* 8edbe247-3d6f-43ca-81de-648d358d36f4 */
+    0x8edbe247,
+    0x3d6f,
+    0x43ca,
+    {0x81, 0xde, 0x64, 0x8d, 0x35, 0x8d, 0x36, 0xf4}
   };
 
 #endif // JIT_EE_VERSIONING_GUID_H

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -927,7 +927,6 @@ private:
     bool    IsLdftnDelegateCtorPeep(const uint8_t* ip, OpcodePeepElement* peep, void** outComputedInfo);
     int     ApplyLdftnDelegateCtorPeep(const uint8_t* ip, OpcodePeepElement* peep, void* computedInfo);
 
-    bool ResolveAsyncCallToken(const uint8_t* ip);
     enum class ContinuationContextHandling : uint8_t
     {
         ContinueOnCapturedContext,

--- a/src/coreclr/jit/ee_il_dll.hpp
+++ b/src/coreclr/jit/ee_il_dll.hpp
@@ -339,7 +339,12 @@ inline var_types Compiler::TypeHandleToVarType(CorInfoType jitType, CORINFO_CLAS
     return type;
 }
 
-inline CORINFO_CALLINFO_FLAGS combine(CORINFO_CALLINFO_FLAGS flag1, CORINFO_CALLINFO_FLAGS flag2)
+constexpr CORINFO_CALLINFO_FLAGS operator|(CORINFO_CALLINFO_FLAGS a, CORINFO_CALLINFO_FLAGS b)
 {
-    return (CORINFO_CALLINFO_FLAGS)(flag1 | flag2);
+    return (CORINFO_CALLINFO_FLAGS)((uint32_t)a | (uint32_t)b);
+}
+
+inline CORINFO_CALLINFO_FLAGS& operator|=(CORINFO_CALLINFO_FLAGS& a, CORINFO_CALLINFO_FLAGS b)
+{
+    return a = (CORINFO_CALLINFO_FLAGS)((uint32_t)a | (uint32_t)b);
 }

--- a/src/coreclr/jit/importercalls.cpp
+++ b/src/coreclr/jit/importercalls.cpp
@@ -6917,11 +6917,6 @@ void Compiler::impSetupAsyncCall(GenTreeCall* call, OPCODE opcode, unsigned pref
             JITDUMP("  Continuation continues on thread pool\n");
         }
     }
-    else if (opcode == CEE_CALLI)
-    {
-        // Used for unboxing/instantiating stubs
-        JITDUMP("Call is an async calli\n");
-    }
     else
     {
         JITDUMP("Call is an async non-task await\n");

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -5358,14 +5358,14 @@ GenTree* Compiler::fgMorphTailCallViaHelpers(GenTreeCall* call, CORINFO_TAILCALL
         {
             assert(!call->tailCallInfo->GetSig()->hasTypeArg());
 
-            CORINFO_CALL_INFO callInfo;
-            unsigned          flags = CORINFO_CALLINFO_LDFTN;
+            CORINFO_CALL_INFO      callInfo;
+            CORINFO_CALLINFO_FLAGS flags = CORINFO_CALLINFO_LDFTN;
             if (call->tailCallInfo->IsCallvirt())
             {
                 flags |= CORINFO_CALLINFO_CALLVIRT;
             }
 
-            eeGetCallInfo(call->tailCallInfo->GetToken(), nullptr, (CORINFO_CALLINFO_FLAGS)flags, &callInfo);
+            eeGetCallInfo(call->tailCallInfo->GetToken(), nullptr, flags, &callInfo);
             target = getVirtMethodPointerTree(thisPtrStubArg, call->tailCallInfo->GetToken(), &callInfo);
         }
 

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1778,10 +1778,18 @@ namespace Internal.JitInterface
             if (pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Newarr)
                 result = ((TypeDesc)result).MakeArrayType();
 
-            if (pResolvedToken.tokenType is CorInfoTokenKind.CORINFO_TOKENKIND_Await or CorInfoTokenKind.CORINFO_TOKENKIND_AwaitVirtual)
+            return result;
+        }
+
+        private MethodDesc GetRuntimeDeterminedMethodForTokenWithTemplate(ref CORINFO_RESOLVED_TOKEN pResolvedToken, MethodDesc templateMethod)
+        {
+            object result = GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
+            Debug.Assert(result is MethodDesc);
+
+            if (templateMethod.IsAsyncVariant())
                 result = _compilation.TypeSystemContext.GetAsyncVariantMethod((MethodDesc)result);
 
-            return result;
+            return (MethodDesc)result;
         }
 
         private static object GetRuntimeDeterminedObjectForToken(MethodILScope methodIL, object typeOrMethodContext, mdToken token)
@@ -1868,45 +1876,8 @@ namespace Internal.JitInterface
                 _compilation.NodeFactory.MetadataManager.GetDependenciesDueToAccess(ref _additionalDependencies, _compilation.NodeFactory, (MethodIL)methodIL, method);
 #endif
 
-                if (pResolvedToken.tokenType is CorInfoTokenKind.CORINFO_TOKENKIND_Await or CorInfoTokenKind.CORINFO_TOKENKIND_AwaitVirtual)
-                {
-                    // in rare cases a method that returns Task is not actually TaskReturning (i.e. returns T).
-                    // we cannot resolve to an Async variant in such case.
-                    // return NULL, so that caller would re-resolve as a regular method call
-                    bool allowAsyncVariant = method.GetTypicalMethodDefinition().Signature.ReturnsTaskOrValueTask();
-
-                    // Don't get async variant of Delegate.Invoke method; the pointed to method is not an async variant either.
-                    allowAsyncVariant = allowAsyncVariant && !method.OwningType.IsDelegate;
-
-#if !READYTORUN
-                    if (allowAsyncVariant)
-                    {
-                        bool isDirect = pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Await || method.IsCallEffectivelyDirect();
-                        if (isDirect && !method.IsAsync)
-                        {
-                            // Async variant would be a thunk. Do not resolve direct calls
-                            // to async thunks. That just creates and JITs unnecessary
-                            // thunks, and the thunks are harder for the JIT to optimize.
-                            allowAsyncVariant = false;
-                        }
-                    }
-#endif
-
-                    method = allowAsyncVariant
-                        ? _compilation.TypeSystemContext.GetAsyncVariantMethod(method)
-                        : null;
-                }
-
-                if (method != null)
-                {
-                    pResolvedToken.hMethod = ObjectToHandle(method);
-                    pResolvedToken.hClass = ObjectToHandle(method.OwningType);
-                }
-                else
-                {
-                    pResolvedToken.hMethod = null;
-                    pResolvedToken.hClass = null;
-                }
+                pResolvedToken.hMethod = ObjectToHandle(method);
+                pResolvedToken.hClass = ObjectToHandle(method.OwningType);
             }
             else
             if (result is FieldDesc)

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1763,6 +1763,19 @@ namespace Internal.JitInterface
             return result;
         }
 
+        private MethodDesc GetRuntimeDeterminedMethodForTokenWithTemplate(ref CORINFO_RESOLVED_TOKEN pResolvedToken, MethodDesc templateMethod)
+        {
+            object result = GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
+            Debug.Assert(result is MethodDesc);
+
+            if (templateMethod.IsAsyncVariant() && !((MethodDesc)result).IsAsyncVariant())
+            {
+                result = _compilation.TypeSystemContext.GetAsyncVariantMethod((MethodDesc)result);
+            }
+
+            return (MethodDesc)result;
+        }
+
         private object GetRuntimeDeterminedObjectForToken(ref CORINFO_RESOLVED_TOKEN pResolvedToken)
         {
             // Since RyuJIT operates on canonical types (as opposed to runtime determined ones), but the
@@ -1779,17 +1792,6 @@ namespace Internal.JitInterface
                 result = ((TypeDesc)result).MakeArrayType();
 
             return result;
-        }
-
-        private MethodDesc GetRuntimeDeterminedMethodForTokenWithTemplate(ref CORINFO_RESOLVED_TOKEN pResolvedToken, MethodDesc templateMethod)
-        {
-            object result = GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
-            Debug.Assert(result is MethodDesc);
-
-            if (templateMethod.IsAsyncVariant())
-                result = _compilation.TypeSystemContext.GetAsyncVariantMethod((MethodDesc)result);
-
-            return (MethodDesc)result;
         }
 
         private static object GetRuntimeDeterminedObjectForToken(MethodILScope methodIL, object typeOrMethodContext, mdToken token)

--- a/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoImpl.cs
@@ -1763,20 +1763,7 @@ namespace Internal.JitInterface
             return result;
         }
 
-        private MethodDesc GetRuntimeDeterminedMethodForTokenWithTemplate(ref CORINFO_RESOLVED_TOKEN pResolvedToken, MethodDesc templateMethod)
-        {
-            object result = GetRuntimeDeterminedObjectForToken(ref pResolvedToken);
-            Debug.Assert(result is MethodDesc);
-
-            if (templateMethod.IsAsyncVariant() && !((MethodDesc)result).IsAsyncVariant())
-            {
-                result = _compilation.TypeSystemContext.GetAsyncVariantMethod((MethodDesc)result);
-            }
-
-            return (MethodDesc)result;
-        }
-
-        private object GetRuntimeDeterminedObjectForToken(ref CORINFO_RESOLVED_TOKEN pResolvedToken)
+        private object GetRuntimeDeterminedObjectForToken(ref CORINFO_RESOLVED_TOKEN pResolvedToken, bool isAsyncVariant = false)
         {
             // Since RyuJIT operates on canonical types (as opposed to runtime determined ones), but the
             // dependency analysis operates on runtime determined ones, we convert the resolved token
@@ -1790,6 +1777,8 @@ namespace Internal.JitInterface
             object result = GetRuntimeDeterminedObjectForToken(methodIL, typeOrMethodContext, pResolvedToken.token);
             if (pResolvedToken.tokenType == CorInfoTokenKind.CORINFO_TOKENKIND_Newarr)
                 result = ((TypeDesc)result).MakeArrayType();
+            if (isAsyncVariant && !((MethodDesc)result).IsAsyncVariant())
+                result = _compilation.TypeSystemContext.GetAsyncVariantMethod((MethodDesc)result);
 
             return result;
         }

--- a/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
+++ b/src/coreclr/tools/Common/JitInterface/CorInfoTypes.cs
@@ -411,7 +411,7 @@ namespace Internal.JitInterface
         CORINFO_CALLINFO_NONE = 0x0000,
         CORINFO_CALLINFO_ALLOWINSTPARAM = 0x0001, // Can the compiler generate code to pass an instantiation parameters? Simple compilers should not use this flag
         CORINFO_CALLINFO_CALLVIRT = 0x0002, // Is it a virtual call?
-        // UNUSED = 0x0004,
+        CORINFO_CALLINFO_ALLOWASYNCVARIANT = 0x0004, // allow resolution to an async variant
         CORINFO_CALLINFO_DISALLOW_STUB = 0x0008, // Do not use a stub for this call, even if it is a virtual call.
         CORINFO_CALLINFO_SECURITYCHECKS = 0x0010, // Perform security checks.
         CORINFO_CALLINFO_LDFTN = 0x0020, // Resolving target of LDFTN
@@ -1146,6 +1146,8 @@ namespace Internal.JitInterface
 
         public byte _wrapperDelegateInvoke;
         public bool wrapperDelegateInvoke { get { return _wrapperDelegateInvoke != 0; } set { _wrapperDelegateInvoke = value ? (byte)1 : (byte)0; } }
+
+        public CORINFO_METHOD_STRUCT_* resolvedAsyncVariant;
     }
 
     public enum CORINFO_DEVIRTUALIZATION_DETAIL
@@ -1477,10 +1479,6 @@ namespace Internal.JitInterface
 
         // token comes from resolved static virtual method
         CORINFO_TOKENKIND_ResolvedStaticVirtualMethod = 0x1000 | CORINFO_TOKENKIND_Method,
-
-        // token comes from runtime async awaiting pattern
-        CORINFO_TOKENKIND_Await = 0x2000 | CORINFO_TOKENKIND_Method,
-        CORINFO_TOKENKIND_AwaitVirtual = 0x4000 | CORINFO_TOKENKIND_Method,
     };
 
     // These are error codes returned by CompileMethod

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -374,7 +374,7 @@ namespace Internal.JitInterface
             MethodDesc expectedTargetMethod = HandleToObject(pTargetMethod.hMethod);
             TypeDesc delegateTypeDesc = HandleToObject(delegateType);
 
-            MethodDesc targetMethod = GetRuntimeDeterminedMethodForTokenWithTemplate(ref pTargetMethod, expectedTargetMethod);
+            MethodDesc targetMethod = (MethodDesc)GetRuntimeDeterminedObjectForToken(ref pTargetMethod, expectedTargetMethod.IsAsyncVariant());
 
             // If this was a constrained+ldftn sequence, we need to resolve the constraint
             TypeDesc constrainedType = null;
@@ -1432,7 +1432,7 @@ namespace Internal.JitInterface
                 ReadyToRunHelperId lookupHelper;
                 if (forceUseRuntimeLookup)
                 {
-                    MethodDesc runtimeDeterminedInterfaceMethod = GetRuntimeDeterminedMethodForTokenWithTemplate(ref pResolvedToken, method);
+                    MethodDesc runtimeDeterminedInterfaceMethod = (MethodDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken, pResult->resolvedAsyncVariant != null);
 
                     targetOfLookup = new ConstrainedCallInfo(runtimeDeterminedConstrainedType, runtimeDeterminedInterfaceMethod);
                     lookupHelper = ReadyToRunHelperId.ConstrainedDirectCall;
@@ -1452,7 +1452,7 @@ namespace Internal.JitInterface
                         lookupMethod = targetMethod.GetMethodDefinition();
                     if (lookupMethod.HasInstantiation)
                     {
-                        var methodToGetInstantiation = GetRuntimeDeterminedMethodForTokenWithTemplate(ref pResolvedToken, method);
+                        var methodToGetInstantiation = (MethodDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken, pResult->resolvedAsyncVariant != null);
                         lookupMethod = lookupMethod.MakeInstantiatedMethod(methodToGetInstantiation.Instantiation);
                     }
                     Debug.Assert(lookupMethod.GetCanonMethodTarget(CanonicalFormKind.Specific) == targetMethod.GetCanonMethodTarget(CanonicalFormKind.Specific));
@@ -1488,7 +1488,7 @@ namespace Internal.JitInterface
                     pResult->codePointerOrStubLookup.runtimeLookup.indirections = CORINFO.USEHELPER;
                     pResult->codePointerOrStubLookup.lookupKind.runtimeLookupKind = GetGenericRuntimeLookupKind(HandleToObject(callerHandle));
                     pResult->codePointerOrStubLookup.lookupKind.runtimeLookupFlags = (ushort)ReadyToRunHelperId.MethodEntry;
-                    pResult->codePointerOrStubLookup.lookupKind.runtimeLookupArgs = (void*)ObjectToHandle(GetRuntimeDeterminedMethodForTokenWithTemplate(ref pResolvedToken, method));
+                    pResult->codePointerOrStubLookup.lookupKind.runtimeLookupArgs = (void*)ObjectToHandle(GetRuntimeDeterminedObjectForToken(ref pResolvedToken, pResult->resolvedAsyncVariant != null));
                 }
                 else
                 {
@@ -1592,7 +1592,7 @@ namespace Internal.JitInterface
                 pResult->kind = CORINFO_CALL_KIND.CORINFO_CALL_CODE_POINTER;
 
                 TypeDesc runtimeDeterminedConstrainedType = (TypeDesc)GetRuntimeDeterminedObjectForToken(ref *pConstrainedResolvedToken);
-                MethodDesc runtimeDeterminedInterfaceMethod = GetRuntimeDeterminedMethodForTokenWithTemplate(ref pResolvedToken, method);
+                MethodDesc runtimeDeterminedInterfaceMethod = (MethodDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken, pResult->resolvedAsyncVariant != null);
 
                 var constrainedCallInfo = new ConstrainedCallInfo(runtimeDeterminedConstrainedType, runtimeDeterminedInterfaceMethod);
                 var constrainedHelperId = ReadyToRunHelperId.ConstrainedDirectCall;
@@ -1619,7 +1619,7 @@ namespace Internal.JitInterface
                 pResult->codePointerOrStubLookup.constLookup.accessType = InfoAccessType.IAT_VALUE;
                 pResult->nullInstanceCheck = true;
 
-                MethodDesc targetOfLookup = _compilation.GetTargetOfGenericVirtualMethodCall((MethodDesc)GetRuntimeDeterminedMethodForTokenWithTemplate(ref pResolvedToken, method));
+                MethodDesc targetOfLookup = _compilation.GetTargetOfGenericVirtualMethodCall((MethodDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken, pResult->resolvedAsyncVariant != null));
 
                 _compilation.DetectGenericCycles(
                     ((MethodILScope)HandleToObject((void*)pResolvedToken.tokenScope)).OwningMethod,
@@ -1644,7 +1644,7 @@ namespace Internal.JitInterface
                 if (pResult->exactContextNeedsRuntimeLookup)
                 {
                     ComputeLookup(ref pResolvedToken,
-                        GetRuntimeDeterminedMethodForTokenWithTemplate(ref pResolvedToken, method),
+                        (MethodDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken, pResult->resolvedAsyncVariant != null),
                         ReadyToRunHelperId.VirtualDispatchCell,
                         HandleToObject(callerHandle),
                         ref pResult->codePointerOrStubLookup);
@@ -1776,7 +1776,7 @@ namespace Internal.JitInterface
                     helperId = ReadyToRunHelperId.MethodDictionary;
                 }
 
-                target = GetRuntimeDeterminedMethodForTokenWithTemplate(ref pResolvedToken, md);
+                target = (MethodDesc)GetRuntimeDeterminedObjectForToken(ref pResolvedToken, md.IsAsyncVariant());
             }
             else if (!fEmbedParent && pResolvedToken.hField != null)
             {

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -4958,7 +4958,6 @@ void CEEInfo::getCallInfo(
     INDEBUG(memset(pResult, 0xCC, sizeof(*pResult)));
 
     pResult->stubLookup.lookupKind.needsRuntimeLookup = false;
-    pResult->resolvedAsyncVariant = NULL;
 
     MethodDesc* pMD = (MethodDesc *)pResolvedToken->hMethod;
     TypeHandle th(pResolvedToken->hClass);
@@ -5176,7 +5175,8 @@ void CEEInfo::getCallInfo(
     // See if we can resolve to an async variant. Task-returning methods may
     // not always have such a variant (for a T return where T is task, for
     // example).
-    if ((flags & CORINFO_CALLINFO_ALLOWASYNCVARIANT) && pTargetMD->ReturnsTaskOrValueTask())
+    pResult->resolvedAsyncVariant = NULL;
+    if ((flags & CORINFO_CALLINFO_ALLOWASYNCVARIANT) && pMD->ReturnsTaskOrValueTask())
     {
         if (!directCall || pTargetMD->IsAsyncThunkMethod())
         {
@@ -5184,7 +5184,7 @@ void CEEInfo::getCallInfo(
             // is user-defined. Switch to the async variant in these cases.
             if (pMD == pTargetMD)
             {
-                pMD = pTargetMD = pMD->GetAsyncVariant(/*allowInstParam */ FALSE);
+                pMD = pTargetMD = pMD->GetAsyncVariant(/* allowInstParam */ FALSE);
             }
             else
             {


### PR DESCRIPTION
- Remove await `CORINFO_TOKENKIND`s
- Add `CORINFO_CALLINFO_ALLOWASYNCVARIANT` flag and pass this for `getCallInfo`
- Teach `getCallInfo` to resolve async variants
- Reorder some code in `getCallInfo` so that we can know if an await is direct or not at the time where we resolve async variants

Another benefit is that we now automatically take `IsEffectivelySealed` into account in NAOT.

Fix #124545
