### PR TITLE
fix seq points assert check read on in mono

### DIFF
--- a/src/mono/mono/metadata/seq-points-data.c
+++ b/src/mono/mono/metadata/seq-points-data.c
@@ -409,7 +409,7 @@ mono_seq_point_data_read (SeqPointData *data, char *path)
 	fseek(f, 0, SEEK_SET);
 
 	buffer_orig = buffer = (guint8 *)g_malloc (fsize + 1);
-	size_t len = fread(buffer_orig, fsize, 1, f);
+	size_t len = fread(buffer_orig, 1, fsize, f);
 	if (ferror(f)) {
 		fclose(f);
 		return FALSE;


### PR DESCRIPTION
fread returns the number of elements read, not the number of bytes.
So the check of g_assert (len == fsize  is incorrect