### PR TITLE
Improve performance-benchmark/SKILL.md

### DIFF
--- a/.github/skills/performance-benchmark/SKILL.md
+++ b/.github/skills/performance-benchmark/SKILL.md
@@ -3,9 +3,10 @@ name: performance-benchmark
 description: Generate and run ad hoc performance benchmarks to validate code changes. Use this when asked to benchmark, profile, or validate the performance impact of a code change in dotnet/runtime.
 ---
 
-# Ad Hoc Performance Benchmarking
+# Ad Hoc Performance Benchmarking with @EgorBot
 
-When you need to validate the performance impact of a code change, follow this process to write a BenchmarkDotNet benchmark and trigger EgorBot to run it.
+When you need to validate the performance impact of a code change, follow this process to write a BenchmarkDotNet benchmark and trigger @EgorBot to run it.
+The bot will trigger you back so don't wait for the results.
 
 ## Step 1: Write the Benchmark
 
@@ -120,50 +121,37 @@ public class Bench
 }
 ```
 
-## Step 2: Post the EgorBot Comment
+## Step 2: Mention @EgorBot in a comment/PR description
 
 Post a comment on the PR to trigger EgorBot with your benchmark. The general format is:
 
-```
-@EgorBot [target flags] [options] [BenchmarkDotNet args]
+@EgorBot [target] [options] [BenchmarkDotNet args]
 
 ```cs
 // Your benchmark code here
 ```
-```
+NOTE: The @EgorBot command must not be inside the code block. Only the benchmark code should be inside the code block.
 
-### Target Flags (Required - Choose at Least One)
+### Target Flags
 
-| Flag | Architecture | Description |
-|------|--------------|-------------|
-| `-x64` or `-amd` | x64 | Linux Azure Genoa (AMD EPYC) - default x64 target |
-| `-arm` | ARM64 | Linux Azure Cobalt100 (Neoverse-N2) |
-| `-intel` | x64 | Azure Cascade Lake (more flaky due to JCC Erratum and loop alignment sensitivity) |
-| `-windows_x64` | x64 | Windows x64 (when Windows-specific testing is needed) |
+-linux_amd
+-linux_intel
+-windows_amd
+-windows_intel
+-linux_arm64
+-osx_arm64 (baremetal, feel free to always include it)
 
-**Choosing targets:**
-
-- **Default for most changes**: Use `-x64` for quick verification of non-architecture/non-OS specific changes
-- **Default when ARM might differ**: Use `-x64 -arm` if there's any suspicion the change might behave differently on ARM
-- **Windows-specific changes**: Use `-windows_x64` when Windows behavior needs testing
-- **Noisy results suspected**: Use `-arm -intel -amd` to get results from multiple x64 CPUs (note: `-intel` targets are more flaky)
+The most common combination is `-linux_amd -windows_intel -osx_arm64`. Do not include more than 4 targets.
 
 ### Common Options
 
-| Option | Description |
-|--------|-------------|
-| `-profiler` | Collect flamegraph/hot assembly using perf record |
-| `--envvars KEY:VALUE` | Set environment variables (e.g., `DOTNET_JitDisasm:MethodName`) |
-| `-commit <hash>` | Run against a specific commit |
-| `-commit <hash1> vs <hash2>` | Compare two commits |
-| `-commit <hash> vs previous` | Compare commit with its parent |
+Use `-profiler` along with `-linux_arm64` or/and `-linux_amd64` to include `perf` profiling and disassembly in the results.
 
 ### Example: Basic PR Benchmark
 
 To benchmark the current PR changes against the base branch:
 
-```
-@EgorBot -x64 -arm
+@EgorBot -linux_amd -windows_intel -osx_arm64
 
 ```cs
 using BenchmarkDotNet.Attributes;
@@ -182,61 +170,6 @@ public class Bench
     }
 }
 ```
-```
-
-### Example: Benchmark with Profiling and Disassembly
-
-```
-@EgorBot -x64 -profiler --envvars DOTNET_JitDisasm:SumArray
-
-```cs
-using System.Linq;
-using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Running;
-
-BenchmarkSwitcher.FromAssembly(typeof(Bench).Assembly).Run(args);
-
-public class Bench
-{
-    private int[] _data = Enumerable.Range(0, 1000).ToArray();
-
-    [Benchmark]
-    public int SumArray() => _data.Sum();
-}
-```
-```
-
-### Example: Compare Two Commits
-
-```
-@EgorBot -amd -commit abc1234 vs def5678
-
-```cs
-using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Running;
-
-BenchmarkSwitcher.FromAssembly(typeof(Bench).Assembly).Run(args);
-
-public class Bench
-{
-    [Benchmark]
-    public void TestMethod()
-    {
-        // Benchmark code
-    }
-}
-```
-```
-
-### Example: Run Existing dotnet/performance Benchmarks
-
-To run benchmarks from the dotnet/performance repository (no code snippet needed):
-
-```
-@EgorBot -arm -intel --filter `*TryGetValueFalse<String, String>*`
-```
-
-**Note**: Surround filter expressions with backticks to avoid issues with special characters.
 
 ## Important Notes
 
@@ -244,11 +177,10 @@ To run benchmarks from the dotnet/performance repository (no code snippet needed
 - **Supported repositories**: EgorBot monitors `dotnet/runtime` and `EgorBot/runtime-utils`
 - **PR mode (default)**: When posting in a PR, EgorBot automatically compares the PR changes against the base branch
 - **Results variability**: Results may vary between runs due to VM differences. Do not compare results across different architectures or cloud providers
-- **Check the manual**: EgorBot replies include a link to the [manual](https://github.com/EgorBot/runtime-utils) for advanced options
+- **Check the manual**: EgorBot replies include a link to the [manual](https://github.com/egorbo/EgorBot?tab=readme-ov-file#github-usage) for advanced options
 
 ## Additional Resources
 
 - [Microbenchmark Design Guidelines](https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md) - Essential reading for writing effective benchmarks
 - [BenchmarkDotNet CLI Arguments](https://github.com/dotnet/BenchmarkDotNet/blob/master/docs/articles/guides/console-args.md)
-- [EgorBot Manual](https://github.com/EgorBot/runtime-utils)
-- [BenchmarkDotNet Filter Simulator](http://egorbot.westus2.cloudapp.azure.com:5042/microbenchmarks)
+- [EgorBot Manual](https://github.com/egorbo/EgorBot?tab=readme-ov-file#github-usage)

--- a/.github/skills/performance-benchmark/SKILL.md
+++ b/.github/skills/performance-benchmark/SKILL.md
@@ -145,7 +145,7 @@ The most common combination is `-linux_amd -windows_intel -osx_arm64`. Do not in
 
 ### Common Options
 
-Use `-profiler` when absolutely necessary along with `-linux_arm64` or/and `-linux_amd` to include `perf` profiling and disassembly in the results.
+Use `-profiler` when absolutely necessary along with `-linux_arm64` and/or `-linux_amd` to include `perf` profiling and disassembly in the results.
 
 ### Example: Basic PR Benchmark
 

--- a/.github/skills/performance-benchmark/SKILL.md
+++ b/.github/skills/performance-benchmark/SKILL.md
@@ -125,7 +125,7 @@ public class Bench
 
 Post a comment on the PR to trigger EgorBot with your benchmark. The general format is:
 
-@EgorBot [target] [options] [BenchmarkDotNet args]
+@EgorBot [targets] [options] [BenchmarkDotNet args]
 
 ```cs
 // Your benchmark code here

--- a/.github/skills/performance-benchmark/SKILL.md
+++ b/.github/skills/performance-benchmark/SKILL.md
@@ -141,7 +141,7 @@ Post a comment on the PR to trigger EgorBot with your benchmark. The general for
 - `-linux_arm64`
 - `-osx_arm64` (baremetal, feel free to always include it)
 
-The most common combination is `-linux_amd -windows_intel -osx_arm64`. Do not include more than 4 targets.
+The most common combination is `-linux_amd -osx_arm64`. Do not include more than 4 targets.
 
 ### Common Options
 
@@ -151,7 +151,7 @@ Use `-profiler` when absolutely necessary along with `-linux_arm64` and/or `-lin
 
 To benchmark the current PR changes against the base branch:
 
-@EgorBot -linux_amd -windows_intel -osx_arm64
+@EgorBot -linux_amd -osx_arm64
 
 ```cs
 using BenchmarkDotNet.Attributes;

--- a/.github/skills/performance-benchmark/SKILL.md
+++ b/.github/skills/performance-benchmark/SKILL.md
@@ -134,12 +134,12 @@ NOTE: The @EgorBot command must not be inside the code block. Only the benchmark
 
 ### Target Flags
 
--linux_amd
--linux_intel
--windows_amd
--windows_intel
--linux_arm64
--osx_arm64 (baremetal, feel free to always include it)
+- `-linux_amd`
+- `-linux_intel`
+- `-windows_amd`
+- `-windows_intel`
+- `-linux_arm64`
+- `-osx_arm64` (baremetal, feel free to always include it)
 
 The most common combination is `-linux_amd -windows_intel -osx_arm64`. Do not include more than 4 targets.
 

--- a/.github/skills/performance-benchmark/SKILL.md
+++ b/.github/skills/performance-benchmark/SKILL.md
@@ -145,7 +145,7 @@ The most common combination is `-linux_amd -windows_intel -osx_arm64`. Do not in
 
 ### Common Options
 
-Use `-profiler` along with `-linux_arm64` or/and `-linux_amd64` to include `perf` profiling and disassembly in the results.
+Use `-profiler` when absolutely necessary along with `-linux_arm64` or/and `-linux_amd64` to include `perf` profiling and disassembly in the results.
 
 ### Example: Basic PR Benchmark
 

--- a/.github/skills/performance-benchmark/SKILL.md
+++ b/.github/skills/performance-benchmark/SKILL.md
@@ -6,7 +6,7 @@ description: Generate and run ad hoc performance benchmarks to validate code cha
 # Ad Hoc Performance Benchmarking with @EgorBot
 
 When you need to validate the performance impact of a code change, follow this process to write a BenchmarkDotNet benchmark and trigger @EgorBot to run it.
-The bot will trigger you back so don't wait for the results.
+The bot will notify you when results are ready, so don't wait for them.
 
 ## Step 1: Write the Benchmark
 

--- a/.github/skills/performance-benchmark/SKILL.md
+++ b/.github/skills/performance-benchmark/SKILL.md
@@ -145,7 +145,7 @@ The most common combination is `-linux_amd -windows_intel -osx_arm64`. Do not in
 
 ### Common Options
 
-Use `-profiler` when absolutely necessary along with `-linux_arm64` or/and `-linux_amd64` to include `perf` profiling and disassembly in the results.
+Use `-profiler` when absolutely necessary along with `-linux_arm64` or/and `-linux_amd` to include `perf` profiling and disassembly in the results.
 
 ### Example: Basic PR Benchmark
 
@@ -177,10 +177,10 @@ public class Bench
 - **Supported repositories**: EgorBot monitors `dotnet/runtime` and `EgorBot/runtime-utils`
 - **PR mode (default)**: When posting in a PR, EgorBot automatically compares the PR changes against the base branch
 - **Results variability**: Results may vary between runs due to VM differences. Do not compare results across different architectures or cloud providers
-- **Check the manual**: EgorBot replies include a link to the [manual](https://github.com/egorbo/EgorBot?tab=readme-ov-file#github-usage) for advanced options
+- **Check the manual**: EgorBot replies include a link to the [manual](https://github.com/EgorBo/EgorBot?tab=readme-ov-file#github-usage) for advanced options
 
 ## Additional Resources
 
 - [Microbenchmark Design Guidelines](https://github.com/dotnet/performance/blob/main/docs/microbenchmark-design-guidelines.md) - Essential reading for writing effective benchmarks
 - [BenchmarkDotNet CLI Arguments](https://github.com/dotnet/BenchmarkDotNet/blob/master/docs/articles/guides/console-args.md)
-- [EgorBot Manual](https://github.com/egorbo/EgorBot?tab=readme-ov-file#github-usage)
+- [EgorBot Manual](https://github.com/EgorBo/EgorBot?tab=readme-ov-file#github-usage)

--- a/.github/skills/performance-benchmark/SKILL.md
+++ b/.github/skills/performance-benchmark/SKILL.md
@@ -130,7 +130,7 @@ Post a comment on the PR to trigger EgorBot with your benchmark. The general for
 ```cs
 // Your benchmark code here
 ```
-NOTE: The @EgorBot command must not be inside the code block. Only the benchmark code should be inside the code block.
+> **Note:** The @EgorBot command must not be inside the code block. Only the benchmark code should be inside the code block.
 
 ### Target Flags
 


### PR DESCRIPTION
1. Copilot sometimes wraps the command into a code block too - told it to avoid that
2. Removed the -commit mode, Copilot typically works inside PRs only anyway, so let's make the skill smaller
3. Recommended it to prefer `osx_arm64` target. EgorBot uses Helix for it and it's baremetal so it's free (for me) and is the fastest. Also, the fact that it's baremetal makes the results more stable.
