### PR TITLE
Fix memory leak in ICorDebugEnum::Clone on CordbEnumerator

### DIFF
--- a/src/coreclr/debug/di/rsenumerator.hpp
+++ b/src/coreclr/debug/di/rsenumerator.hpp
@@ -213,6 +213,7 @@ HRESULT CordbEnumerator<ElemType,
         CordbEnumerator<ElemType, ElemPublicType, EnumInterfaceType, IID_EnumInterfaceType, GetPublicType>* clone =
             new CordbEnumerator<ElemType, ElemPublicType, EnumInterfaceType, IID_EnumInterfaceType, GetPublicType>(
                 GetProcess(), m_items, m_countItems);
+        GetProcess()->GetContinueNeuterList()->Add(GetProcess(), clone);
         clone->QueryInterface(__uuidof(ICorDebugEnum), (void**)ppEnum);
     }
     EX_CATCH_HRESULT(hr)


### PR DESCRIPTION
Add cloned enumerator to the process continue neuter list so it gets properly neutered during cleanup. Without this, cloned enumerators leak their internal m_items array and trigger a debug assertion failure (_ASSERTE(IsNeutered())) in the destructor.

Fixes #121925