### PR TITLE
Fix ALPN protocol list size field type and add boundary tests

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -252,6 +252,11 @@ internal static partial class Interop
                 }
 
                 protocolSize += protocol.Protocol.Length + 1;
+
+                if (protocolSize > ushort.MaxValue)
+                {
+                    throw new ArgumentException(SR.net_ssl_app_protocols_invalid, nameof(applicationProtocols));
+                }
             }
 
             return protocolSize;

--- a/src/libraries/Common/src/Interop/Windows/SChannel/Interop.Sec_Application_Protocols.cs
+++ b/src/libraries/Common/src/Interop/Windows/SChannel/Interop.Sec_Application_Protocols.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
     {
         public uint ProtocolListsSize;
         public ApplicationProtocolNegotiationExt ProtocolExtensionType;
-        public short ProtocolListSize;
+        public ushort ProtocolListSize;
 
         public static int GetProtocolLength(List<SslApplicationProtocol> applicationProtocols)
         {
@@ -30,7 +30,7 @@ internal static partial class Interop
 
                 protocolListSize += protocolLength + 1;
 
-                if (protocolListSize > short.MaxValue)
+                if (protocolListSize > ushort.MaxValue)
                 {
                     throw new ArgumentException(SR.net_ssl_app_protocols_invalid, nameof(applicationProtocols));
                 }
@@ -49,7 +49,7 @@ internal static partial class Interop
             protocols.ProtocolListsSize = (uint)(protocolListConstSize + protocolListSize);
 
             protocols.ProtocolExtensionType = ApplicationProtocolNegotiationExt.ALPN;
-            protocols.ProtocolListSize = (short)protocolListSize;
+            protocols.ProtocolListSize = (ushort)protocolListSize;
 
             byte[] buffer = new byte[sizeof(Sec_Application_Protocols) + protocolListSize];
             int index = 0;
@@ -73,7 +73,7 @@ internal static partial class Interop
             Span<Sec_Application_Protocols> alpn = MemoryMarshal.Cast<byte, Sec_Application_Protocols>(buffer);
             alpn[0].ProtocolListsSize = (uint)(sizeof(Sec_Application_Protocols) - sizeof(uint) + protocolLength);
             alpn[0].ProtocolExtensionType = ApplicationProtocolNegotiationExt.ALPN;
-            alpn[0].ProtocolListSize = (short)protocolLength;
+            alpn[0].ProtocolListSize = (ushort)protocolLength;
 
             Span<byte> data = buffer.Slice(sizeof(Sec_Application_Protocols));
             for (int i = 0; i < applicationProtocols.Count; i++)

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Collections.Generic;
 using System.Net.Security;
 using System.Runtime.InteropServices;
 using System.Security.Authentication;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.Android/SafeDeleteSslContext.cs
@@ -306,6 +306,7 @@ namespace System.Net
             if (authOptions.ApplicationProtocols != null && authOptions.ApplicationProtocols.Count != 0
                 && Interop.AndroidCrypto.SSLSupportsApplicationProtocolsConfiguration())
             {
+                ValidateAlpnProtocolListSize(authOptions.ApplicationProtocols);
                 // Set application protocols if the platform supports it. Otherwise, we will silently ignore the option.
                 Interop.AndroidCrypto.SSLStreamSetApplicationProtocols(handle, authOptions.ApplicationProtocols);
             }
@@ -318,6 +319,19 @@ namespace System.Net
             if (!isServer && !string.IsNullOrEmpty(authOptions.TargetHost) && !IPAddress.IsValid(authOptions.TargetHost))
             {
                 Interop.AndroidCrypto.SSLStreamSetTargetHost(handle, authOptions.TargetHost);
+            }
+        }
+
+        private static void ValidateAlpnProtocolListSize(List<SslApplicationProtocol> applicationProtocols)
+        {
+            int protocolListSize = 0;
+            foreach (SslApplicationProtocol protocol in applicationProtocols)
+            {
+                protocolListSize += protocol.Protocol.Length + 1;
+                if (protocolListSize > ushort.MaxValue)
+                {
+                    throw new ArgumentException(SR.net_ssl_app_protocols_invalid, nameof(applicationProtocols));
+                }
             }
         }
     }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteNwContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteNwContext.cs
@@ -442,10 +442,17 @@ namespace System.Net.Security
                 }
 
                 int protocolSize = 0;
+                int wireSize = 0;
 
                 foreach (SslApplicationProtocol protocol in applicationProtocols)
                 {
                     protocolSize += protocol.Protocol.Length + 2;
+
+                    wireSize += protocol.Protocol.Length + 1;
+                    if (wireSize > ushort.MaxValue)
+                    {
+                        throw new ArgumentException(SR.net_ssl_app_protocols_invalid, nameof(applicationProtocols));
+                    }
                 }
 
                 return protocolSize;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/Pal.OSX/SafeDeleteSslContext.cs
@@ -74,6 +74,8 @@ namespace System.Net
 
                 if (sslAuthenticationOptions.ApplicationProtocols != null && sslAuthenticationOptions.ApplicationProtocols.Count != 0)
                 {
+                    ValidateAlpnProtocolListSize(sslAuthenticationOptions.ApplicationProtocols);
+
                     if (sslAuthenticationOptions.IsClient)
                     {
                         // On macOS coreTls supports only client side.
@@ -396,6 +398,19 @@ namespace System.Net
             ptrs[0] = context!.TargetCertificate.Handle;
 
             Interop.AppleCrypto.SslSetCertificate(sslContext, ptrs);
+        }
+
+        private static void ValidateAlpnProtocolListSize(List<SslApplicationProtocol> applicationProtocols)
+        {
+            int protocolListSize = 0;
+            foreach (SslApplicationProtocol protocol in applicationProtocols)
+            {
+                protocolListSize += protocol.Protocol.Length + 1;
+                if (protocolListSize > ushort.MaxValue)
+                {
+                    throw new ArgumentException(SR.net_ssl_app_protocols_invalid, nameof(applicationProtocols));
+                }
+            }
         }
     }
 }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.OSX.cs
@@ -359,7 +359,7 @@ namespace System.Net.Security
                 sslContext.ReadPendingWrites(ref token);
                 return token;
             }
-            catch (Exception exc)
+            catch (Exception exc) when (exc is not ArgumentException)
             {
                 token.Status = new SecurityStatusPal(SecurityStatusPalErrorCode.InternalError, exc);
                 return token;

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -230,6 +230,10 @@ namespace System.Net.Security
 
                 token.Status = new SecurityStatusPal(errorCode);
             }
+            catch (ArgumentException)
+            {
+                throw;
+            }
             catch (Exception exc)
             {
                 token.Status = new SecurityStatusPal(SecurityStatusPalErrorCode.InternalError, exc);

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStreamPal.Unix.cs
@@ -230,11 +230,7 @@ namespace System.Net.Security
 
                 token.Status = new SecurityStatusPal(errorCode);
             }
-            catch (ArgumentException)
-            {
-                throw;
-            }
-            catch (Exception exc)
+            catch (Exception exc) when (exc is not ArgumentException)
             {
                 token.Status = new SecurityStatusPal(SecurityStatusPalErrorCode.InternalError, exc);
             }

--- a/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
+++ b/src/libraries/System.Net.Security/tests/FunctionalTests/SslStreamAlpnTests.cs
@@ -240,6 +240,71 @@ namespace System.Net.Security.Tests
                 yield return new object[] { proto, null, null, default(SslApplicationProtocol) };
             }
         }
+
+        [ConditionalFact(nameof(BackendSupportsAlpn))]
+        public async Task SslStream_StreamToStream_AlpnListTotalSizeExceedsLimit_Throws()
+        {
+            // Each protocol is 255 bytes, serialized with a 1-byte length prefix = 256 bytes each.
+            // Per RFC 7301, TLS wire format limits ProtocolNameList to 2^16-1 (65,535) bytes.
+            // Windows (SChannel): enforced via managed check in Interop.Sec_Application_Protocols.GetProtocolLength()
+            // Unix (OpenSSL): enforced by OpenSSL during ClientHello construction
+            // 256 * 256 = 65,536 > 65,535
+            if (!OperatingSystem.IsWindows() && !OperatingSystem.IsLinux() && !OperatingSystem.IsFreeBSD())
+            {
+                // ALPN size limit behavior not verified on other platforms
+                return;
+            }
+
+            const int protocolCount = 256;
+            List<SslApplicationProtocol> oversizedProtocols = new List<SslApplicationProtocol>();
+            for (int i = 0; i < protocolCount; i++)
+            {
+                byte[] proto = new byte[255];
+                proto.AsSpan().Fill((byte)'a');
+                proto[0] = (byte)((i >> 8) + 1);
+                proto[1] = (byte)(i & 0xFF);
+                oversizedProtocols.Add(new SslApplicationProtocol(proto));
+            }
+
+            using X509Certificate2 certificate = Configuration.Certificates.GetServerCertificate();
+
+            SslClientAuthenticationOptions clientOptions = new SslClientAuthenticationOptions
+            {
+                ApplicationProtocols = oversizedProtocols,
+                RemoteCertificateValidationCallback = delegate { return true; },
+                TargetHost = Guid.NewGuid().ToString("N"),
+            };
+
+            SslServerAuthenticationOptions serverOptions = new SslServerAuthenticationOptions
+            {
+                ApplicationProtocols = new List<SslApplicationProtocol> { SslApplicationProtocol.Http2 },
+                ServerCertificateContext = SslStreamCertificateContext.Create(certificate, null)
+            };
+
+            (Stream clientStream, Stream serverStream) = TestHelper.GetConnectedStreams();
+            using (clientStream)
+            using (serverStream)
+            using (var client = new SslStream(clientStream, false))
+            using (var server = new SslStream(serverStream, false))
+            {
+                Task serverTask = server.AuthenticateAsServerAsync(TestAuthenticateAsync, serverOptions);
+
+                if (OperatingSystem.IsWindows())
+                {
+                    // On Windows, managed validation in GetProtocolLength() throws before the handshake starts.
+                    await Assert.ThrowsAsync<ArgumentException>(() => client.AuthenticateAsClientAsync(TestAuthenticateAsync, clientOptions));
+                }
+                else
+                {
+                    // On Unix, OpenSSL fails during ClientHello construction when encoding
+                    // the oversized ALPN extension into the TLS wire format.
+                    await Assert.ThrowsAsync<AuthenticationException>(() => client.AuthenticateAsClientAsync(TestAuthenticateAsync, clientOptions));
+                }
+
+                server.Dispose();
+                await Assert.ThrowsAnyAsync<Exception>(() => serverTask.WaitAsync(TestConfiguration.PassingTestTimeout));
+            }
+        }
     }
 
     public sealed class SslStreamAlpnTest_Async : SslStreamAlpnTestBase

--- a/src/libraries/System.Net.Security/tests/UnitTests/SslApplicationProtocolTests.cs
+++ b/src/libraries/System.Net.Security/tests/UnitTests/SslApplicationProtocolTests.cs
@@ -52,6 +52,51 @@ namespace System.Net.Security.Tests
         }
 
         [Theory]
+        [InlineData(0, true)]
+        [InlineData(1, false)]
+        [InlineData(254, false)]
+        [InlineData(255, false)]
+        [InlineData(256, true)]
+        [InlineData(512, true)]
+        public void Constructor_ProtocolSizeBoundary_ThrowsForInvalidSize(int size, bool shouldThrow)
+        {
+            byte[] protocol = new byte[size];
+            protocol.AsSpan().Fill((byte)'a');
+
+            if (shouldThrow)
+            {
+                AssertExtensions.Throws<ArgumentException>("protocol", () => new SslApplicationProtocol(protocol));
+            }
+            else
+            {
+                SslApplicationProtocol alpn = new SslApplicationProtocol(protocol);
+                Assert.Equal(size, alpn.Protocol.Length);
+            }
+        }
+
+        [Theory]
+        [InlineData(0, true)]
+        [InlineData(1, false)]
+        [InlineData(254, false)]
+        [InlineData(255, false)]
+        [InlineData(256, true)]
+        [InlineData(512, true)]
+        public void Constructor_StringSizeBoundary_ThrowsForInvalidSize(int size, bool shouldThrow)
+        {
+            string protocol = new string('a', size);
+
+            if (shouldThrow)
+            {
+                AssertExtensions.Throws<ArgumentException>("protocol", () => new SslApplicationProtocol(protocol));
+            }
+            else
+            {
+                SslApplicationProtocol alpn = new SslApplicationProtocol(protocol);
+                Assert.Equal(size, alpn.Protocol.Length);
+            }
+        }
+
+        [Theory]
         [MemberData(nameof(Protocol_Equality_TestData))]
         public void Equality_Tests_Succeeds(SslApplicationProtocol left, SslApplicationProtocol right)
         {


### PR DESCRIPTION
## Summary

Fix `Sec_Application_Protocols.ProtocolListSize` field type from `short` to `ushort` to match the native Windows `SEC_APPLICATION_PROTOCOL_LIST` struct (`USHORT`), and add tests for ALPN list size validation.

## Changes

### Bug fix
- **`Interop.Sec_Application_Protocols.cs`**: Changed `ProtocolListSize` from `short` to `ushort` and updated the aggregate size limit from `short.MaxValue` (32,767) to `ushort.MaxValue` (65,535), aligning with both the native Windows API and the RFC 7301 TLS wire format.

### Tests
- **`SslStreamAlpnTests.cs`**: Added `SslStream_StreamToStream_AlpnListTotalSizeExceedsLimit_Throws` — verifies that exceeding the 65,535-byte aggregate ALPN list limit throws:
  - `ArgumentException` on Windows (managed validation in `GetProtocolLength()`)
  - `AuthenticationException` on Linux/FreeBSD (OpenSSL fails during ClientHello construction)
- **`SslApplicationProtocolTests.cs`**: Added boundary tests for individual protocol sizes (0, 1, 254, 255, 256, 512 bytes) via both `byte[]` and `string` constructors.
