### PR TITLE
[HTTP] Re-enable Http3 nginx interop test

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -1943,8 +1943,7 @@ namespace System.Net.Http.Functional.Tests
             new TheoryData<string>
             {
                 { "https://cloudflare-quic.com/" }, // Cloudflare with content
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/120257")]
-                // { "https://quic.nginx.org/" }, // Nginx with content
+                { "https://quic.nginx.org/" }, // Nginx with content
             };
     }
 


### PR DESCRIPTION
The quic.nginx.org interop test was disabled due to TLS alert 112 errors. Retested and the test is passing, indicating the external server issue has been resolved.

Re-enable the test URI in `InteropUrisWithContent()`.

Fixes https://github.com/dotnet/runtime/issues/120257