### PR TITLE
[HTTP] Re-enable GetAsync_CancelDuringResponseBodyReceived_Buffered test

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -142,16 +142,13 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+// There's no LoadIntoBufferAsync(CancellationToken) overload on Framework.
+// So no way to pass and propagate cancellation when buffering response content.
+#if !NETFRAMEWORK
         [Theory]
         [MemberData(nameof(TwoBoolsAndCancellationMode))]
         public async Task GetAsync_CancelDuringResponseBodyReceived_Buffered_TaskCanceledQuickly(bool chunkedTransfer, bool connectionClose, CancellationMode mode)
         {
-            if (IsWinHttpHandler)
-            {
-                // WinHttpHandler does not observe cancellation during buffered response body reads
-                return;
-            }
-
             if (LoopbackServerFactory.Version >= HttpVersion20.Value && (chunkedTransfer || connectionClose))
             {
                 // There is no chunked encoding or connection header in HTTP/2 and later
@@ -201,6 +198,7 @@ namespace System.Net.Http.Functional.Tests
                 });
             }
         }
+#endif
 
         [Theory]
         [MemberData(nameof(ThreeBools))]

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -146,6 +146,12 @@ namespace System.Net.Http.Functional.Tests
         [MemberData(nameof(TwoBoolsAndCancellationMode))]
         public async Task GetAsync_CancelDuringResponseBodyReceived_Buffered_TaskCanceledQuickly(bool chunkedTransfer, bool connectionClose, CancellationMode mode)
         {
+            if (IsWinHttpHandler)
+            {
+                // WinHttpHandler does not observe cancellation during buffered response body reads
+                return;
+            }
+
             if (LoopbackServerFactory.Version >= HttpVersion20.Value && (chunkedTransfer || connectionClose))
             {
                 // There is no chunked encoding or connection header in HTTP/2 and later

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -143,7 +143,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/25760")]
         [MemberData(nameof(TwoBoolsAndCancellationMode))]
         public async Task GetAsync_CancelDuringResponseBodyReceived_Buffered_TaskCanceledQuickly(bool chunkedTransfer, bool connectionClose, CancellationMode mode)
         {


### PR DESCRIPTION
Remove the `ActiveIssue` attribute disabling this cancellation test. The original failure was a timing assertion where elapsed time (31.67s) exceeded a 30-second threshold. The threshold has since been increased to 60 seconds in `ValidateClientCancellationAsync`, which provides sufficient margin for CI environments under load.

Fixes https://github.com/dotnet/runtime/issues/25760