### PR TITLE
[HTTP] Re-enable AuthProxy__ValidCreds_ProxySendsRequestToServer test

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Proxy.cs
@@ -56,7 +56,6 @@ namespace System.Net.Http.Functional.Tests
             Assert.False(proxy.Disposed);
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/1507")]
         [OuterLoop("Uses external servers")]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsNotWindowsNanoServer))]
         [InlineData(AuthenticationSchemes.Ntlm, true, false)]


### PR DESCRIPTION
Remove the `ActiveIssue` attribute disabling this outerloop proxy authentication test. The test was disabled in October 2018 due to assertion failures in `Http2Connection.InvalidateHttp2Connection` and connection reset errors. The HTTP/2 connection pool has been completely rewritten since then.

Ran locally for 20 iterations without a failure.

Fixes https://github.com/dotnet/runtime/issues/1507