### PR TITLE
[HTTP] Re-enable GetAsync_UnicodeHostName_SuccessStatusCodeInResponse test

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -1526,27 +1526,6 @@ namespace System.Net.Http.Functional.Tests
             });
         }
 
-        [OuterLoop("Uses external servers")]
-        [Fact]
-        public async Task GetAsync_UnicodeHostName_SuccessStatusCodeInResponse()
-        {
-            // The site doesn't support HTTP/3.
-            if (UseVersion == HttpVersion30)
-            {
-                return;
-            }
-
-            using (HttpClient client = CreateHttpClient())
-            {
-                // international version of the Starbucks website
-                // punycode: xn--oy2b35ckwhba574atvuzkc.com
-                string server = "http://\uc2a4\ud0c0\ubc85\uc2a4\ucf54\ub9ac\uc544.com";
-                using (HttpResponseMessage response = await client.GetAsync(server))
-                {
-                    response.EnsureSuccessStatusCode();
-                }
-            }
-        }
 
         #region Post Methods Tests
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.cs
@@ -1528,9 +1528,14 @@ namespace System.Net.Http.Functional.Tests
 
         [OuterLoop("Uses external servers")]
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/29424")]
         public async Task GetAsync_UnicodeHostName_SuccessStatusCodeInResponse()
         {
+            // The site doesn't support HTTP/3.
+            if (UseVersion == HttpVersion30)
+            {
+                return;
+            }
+
             using (HttpClient client = CreateHttpClient())
             {
                 // international version of the Starbucks website


### PR DESCRIPTION
~The external Korean Starbucks website (스타벅스코리아.com / xn--oy2b35ckwhba574atvuzkc.com) that was unreachable in 2019 is now accessible again. Remove the `ActiveIssue` attribute to re-enable the test, keeping the original test logic that exercises the full Unicode hostname to punycode IDN conversion path.~

~Excludes H/3 as the site doesn't support it.~

The test is removed, the target is unreliable.

Fixes https://github.com/dotnet/runtime/issues/29424