### PR TITLE
[HTTP] Re-enable PostAsync_Cancel_CancellationTokenPassedToContent test

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -520,7 +520,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
 #if !NETFRAMEWORK
-        [OuterLoop("Uses Task.Delay")]
         [Theory]
         [MemberData(nameof(PostAsync_Cancel_CancellationTokenPassedToContent_MemberData))]
         public async Task PostAsync_Cancel_CancellationTokenPassedToContent(HttpContent content, CancellationTokenSource cancellationTokenSource)

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -556,7 +556,7 @@ namespace System.Net.Http.Functional.Tests
                         await server.HandleRequestAsync(content: "Hello World");
                     }
                     catch (Exception) { }
-                });
+                }).WaitAsync(TestHelper.PassingTestTimeout);
         }
 #endif
 

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.Cancellation.cs
@@ -520,7 +520,6 @@ namespace System.Net.Http.Functional.Tests
         }
 
 #if !NETFRAMEWORK
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/41531")]
         [OuterLoop("Uses Task.Delay")]
         [Theory]
         [MemberData(nameof(PostAsync_Cancel_CancellationTokenPassedToContent_MemberData))]


### PR DESCRIPTION
Remove the `ActiveIssue` attribute disabling this outerloop test. The test was disabled in January 2021 due to sporadic 60-second timeouts in CI. The HTTP/2 implementation has been significantly rewritten since then, and the underlying race conditions are likely resolved.

Also removed `outerloop` as the reason was out of date, ohh boy this will absolutely return with vengeance. I can't wait to see this test in CI report next week :smile: 

Ran for 20 iterations locally without a problem.

Fixes https://github.com/dotnet/runtime/issues/41531

If this re-appears, I'll either investigate or disable again, but it's been disabled for years now, so let's see.

TLDR explanation:

<details>

The original failure was a System.TimeoutException: Task timed out after 00:01:00 in `PostAsync_Cancel_CancellationTokenPassedToContent`. This was a flaky timing issue — the test was hitting a
60-second timeout during cancellation. It wasn't caused by a bug in the product code; it was a test that was sensitive to machine load and scheduling delays in CI.

Over time, the runtime's cancellation and HTTP/2 stream handling has been significantly improved (many fixes have landed since 2020 when this was filed). The test simply works reliably now because
the underlying timing/cancellation behavior is more robust. There's no single code change to point to — it's the cumulative effect of years of improvements.

</details>
