### PR TITLE
Fix ManagedNtlm on big-endian architectures

### DIFF
--- a/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/NegotiateAuthenticationPal.ManagedNtlm.cs
@@ -134,7 +134,6 @@ namespace System.Net
                     readonly get =>BitConverter.IsLittleEndian? _payloadOffset: BinaryPrimitives.ReverseEndianness(_payloadOffset);
                     set =>_payloadOffset = BitConverter.IsLittleEndian? value: BinaryPrimitives.ReverseEndianness(value);
                 }
-
             }
 
             [StructLayout(LayoutKind.Sequential)]
@@ -175,7 +174,7 @@ namespace System.Net
                 public Version Version;
                 public Flags Flags
                 {
-                    readonly get =>BitConverter.IsLittleEndian? _flag: (Flags)BinaryPrimitives.ReverseEndianness((uint)_flags);
+                    readonly get =>BitConverter.IsLittleEndian? _flags: (Flags)BinaryPrimitives.ReverseEndianness((uint)_flags);
                     set =>_flags = BitConverter.IsLittleEndian? value: (Flags)BinaryPrimitives.ReverseEndianness((uint)value);
                 }
             }


### PR DESCRIPTION
Fixes multiple endianness bugs in ManagedNtlm that caused incorrect behavior on big-endian platforms. 
Validated via existing Ntlm test cases.