### PR TITLE
Fix abandoned jit regression tests

### DIFF
--- a/.github/skills/jit-regression-test/SKILL.md
+++ b/.github/skills/jit-regression-test/SKILL.md
@@ -86,13 +86,14 @@ public class Runtime_99391
 }
 ```
 
-## [Optional] Step 4: Create a .csproj File (Only When Needed)
+## Step 4: Create a .csproj File
 
 A custom `.csproj` file is **only required** when:
 - Environment variables are needed to reproduce the bug (such as `DOTNET_JitStressModeNames`)
 - Special compilation settings are required
+Otherwise, register the test file in the existing `src/tests/JIT/Regression/Regression_ro_2.csproj` file and skip creating a new .csproj.
 
-It should be located next to the test source file with the following name: `Runtime_<issue_number>.csproj`. Example:
+If a custom .csproj file is needed, it should be located next to the test source file with the following name: `Runtime_<issue_number>.csproj`. Example:
 
 ```xml
 <Project Sdk="Microsoft.NET.Sdk">
@@ -112,7 +113,7 @@ It should be located next to the test source file with the following name: `Runt
 
 ## Important Notes
 
-- **No .csproj needed for simple tests**: Most tests only need the `.cs` file. The test infrastructure uses default settings that work for most cases.
+- **No .csproj needed for simple tests**: Most tests only need the `.cs` file in a separate `src/tests/JIT/Regression/JitBlue/Runtime_*/` folder and being registered in `Regression_ro_2.csproj`.
 - **Look at recent tests**: When in doubt, examine recent tests under `src/tests/JIT/Regression/JitBlue/Runtime_*` for the latest conventions.
 - **Use `[MethodImpl(MethodImplOptions.NoInlining)]`**: When you need to prevent inlining to reproduce a JIT bug.
 - **Minimize the reproduction**: Strip down the test code to the minimal case that reproduces the issue.

--- a/.github/skills/jit-regression-test/SKILL.md
+++ b/.github/skills/jit-regression-test/SKILL.md
@@ -86,7 +86,7 @@ public class Runtime_99391
 }
 ```
 
-## Step 4: Create a .csproj File
+## Step 4: Create a .csproj File or add to Regression_ro_2.csproj
 
 A custom `.csproj` file is **only required** when:
 - Environment variables are needed to reproduce the bug (such as `DOTNET_JitStressModeNames`)

--- a/.github/skills/jit-regression-test/SKILL.md
+++ b/.github/skills/jit-regression-test/SKILL.md
@@ -86,12 +86,12 @@ public class Runtime_99391
 }
 ```
 
-## Step 4: Create a .csproj File or add to Regression_ro_2.csproj
+## Step 4: Create a .csproj File or add to the existing Regression_*.csproj
 
 A custom `.csproj` file is **only required** when:
 - Environment variables are needed to reproduce the bug (such as `DOTNET_JitStressModeNames`)
 - Special compilation settings are required
-Otherwise, register the test file in the existing `src/tests/JIT/Regression/Regression_ro_2.csproj` file and skip creating a new .csproj.
+Otherwise, register the test file in the existing `src/tests/JIT/Regression/Regression_*.csproj` (`Regression_ro_2.csproj` is a good default) file and skip creating a new .csproj.
 
 If a custom .csproj file is needed, it should be located next to the test source file with the following name: `Runtime_<issue_number>.csproj`. Example:
 

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -9,7 +9,7 @@
 
 #include "lower.h" // for LowerRange()
 
-// Flowgraph Optimizatio
+// Flowgraph Optimization
 
 //------------------------------------------------------------------------
 // fgComputeReturnBlocks: Compute the set of BBJ_RETURN blocks.

--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -9,7 +9,7 @@
 
 #include "lower.h" // for LowerRange()
 
-// Flowgraph Optimization
+// Flowgraph Optimizatio
 
 //------------------------------------------------------------------------
 // fgComputeReturnBlocks: Compute the set of BBJ_RETURN blocks.

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -83,6 +83,11 @@
     <Compile Include="JitBlue\Runtime_96591\Runtime_96591_2.cs" />
     <Compile Include="JitBlue\Runtime_96591\Runtime_96591.cs" />
     <Compile Include="JitBlue\Runtime_96939\Runtime_96939.cs" />
+    <Compile Include="JitBlue\Runtime_122254\Runtime_122254.cs" />
+    <Compile Include="JitBlue\Runtime_122288\Runtime_122288.cs" />
+    <Compile Include="JitBlue\Runtime_123583\Runtime_123583.cs" />
+    <Compile Include="JitBlue\Runtime_123790\Runtime_123790.cs" />
+    <Compile Include="JitBlue\Runtime_124082\Runtime_124082.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
Found by @jakobbotsch. I didn't realize in the new model they have to be registered in one of the merged csproj, I thought they were included with a glob pattern. Also, adjust the skill.