### PR TITLE
Fix nondeterministic test failure for X509CertificateLoader

### DIFF
--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/X509CertificateLoaderTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/X509CertificateLoaderTests.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Buffers.Binary;
-using System.Diagnostics;
 using System.IO;
 using System.IO.MemoryMappedFiles;
 using Test.Cryptography;

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/X509CertificateLoaderTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/X509CertificateLoaderTests.cs
@@ -154,7 +154,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     Assert.Equal(contentType, actualType);
                 }
             }
-            
+
             if (path is null)
             {
                 Assert.ThrowsAny<CryptographicException>(() => LoadCertificateNoFile(data));
@@ -300,13 +300,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public void LoadWrappingCertificate_PEM_WithTrailingData()
         {
-            byte[] source = TestData.NestedCertificates;
-            Array.Resize(ref source, source.Length + 4);
-
-            BinaryPrimitives.WriteInt32LittleEndian(
-                source.AsSpan(TestData.NestedCertificates.Length),
-                Process.GetCurrentProcess().Id);
-
+            byte[] source = [..TestData.NestedCertificates, 1 ,2, 3, 4];
             byte[] data = System.Text.Encoding.ASCII.GetBytes(
                 ByteUtils.PemEncode("CERTIFICATE", source));
 

--- a/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/X509CertificateLoaderTests.cs
+++ b/src/libraries/Common/tests/System/Security/Cryptography/X509Certificates/X509CertificateLoaderTests.cs
@@ -300,7 +300,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public void LoadWrappingCertificate_PEM_WithTrailingData()
         {
-            byte[] source = [..TestData.NestedCertificates, 1 ,2, 3, 4];
+            byte[] source = [..TestData.NestedCertificates, 1, 2, 3, 4];
             byte[] data = System.Text.Encoding.ASCII.GetBytes(
                 ByteUtils.PemEncode("CERTIFICATE", source));
 


### PR DESCRIPTION
OpenSSL does not block trailing data after an X.509 certificate like the test thought it did. OpenSSL permits trailing data as long as it is valid ASN.1. The unit test in question used the process ID as the trailing data. Certain PIDs resemble ASN.1 enough that it allows the parsing to succeed and not throw an exception like the test expected. For example, if the PID was 32816, this would be 30 80 00 00 - an indefinite length ASN.1 BER SEQUENCE.

The trailing data is ignored when the parsing succeeds, it's just a matter of if the trailing data causes an error (invalid ASN.1) or is ignored (valid ASN.1, but remains unconsumed).

Fixes #123630