### PR TITLE
[release/8.0-staging] Fix thread safety in SafeEvpPKeyHandle.DuplicateHandle

### DIFF
--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SafeEvpPKeyHandle.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SafeEvpPKeyHandle.OpenSsl.cs
@@ -53,24 +53,41 @@ namespace System.Security.Cryptography
             if (IsInvalid)
                 throw new InvalidOperationException(SR.Cryptography_OpenInvalidHandle);
 
-            // Reliability: Allocate the SafeHandle before calling UpRefEvpPkey so
-            // that we don't lose a tracked reference in low-memory situations.
-            SafeEvpPKeyHandle safeHandle = new SafeEvpPKeyHandle();
+            // Keep the source handle alive so that a concurrent Dispose on another
+            // thread does not zero the handle field between UpRef and the copy below.
+            bool addedRef = false;
 
-            int success = Interop.Crypto.UpRefEvpPkey(this);
-
-            if (success != 1)
+            try
             {
-                Debug.Fail("Called UpRefEvpPkey on a key which was already marked for destruction");
-                Exception e = Interop.Crypto.CreateOpenSslCryptographicException();
-                safeHandle.Dispose();
-                throw e;
-            }
+                DangerousAddRef(ref addedRef);
 
-            // Since we didn't actually create a new handle, copy the handle
-            // to the new SafeHandle.
-            safeHandle.SetHandle(handle);
-            return safeHandle;
+                // Reliability: Allocate the SafeHandle before calling UpRefEvpPkey so
+                // that we don't lose a tracked reference in low-memory situations.
+                SafeEvpPKeyHandle safeHandle = new SafeEvpPKeyHandle();
+
+                int success = Interop.Crypto.UpRefEvpPkey(this);
+
+                if (success != 1)
+                {
+                    Debug.Fail("Called UpRefEvpPkey on a key which was already marked for destruction");
+                    Exception e = Interop.Crypto.CreateOpenSslCryptographicException();
+                    safeHandle.Dispose();
+                    throw e;
+                }
+
+                // Since we didn't actually create a new handle, copy the handle
+                // to the new SafeHandle. DangerousAddRef prevents ReleaseHandle
+                // from being called, so handle and ExtraHandle are stable here.
+                safeHandle.SetHandle(handle);
+                return safeHandle;
+            }
+            finally
+            {
+                if (addedRef)
+                {
+                    DangerousRelease();
+                }
+            }
         }
 
         /// <summary>

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SafeEvpPKeyHandle.OpenSsl.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/SafeEvpPKeyHandle.OpenSsl.cs
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography
 
                 // Since we didn't actually create a new handle, copy the handle
                 // to the new SafeHandle. DangerousAddRef prevents ReleaseHandle
-                // from being called, so handle and ExtraHandle are stable here.
+                // from being called, so handle is stable here.
                 safeHandle.SetHandle(handle);
                 return safeHandle;
             }


### PR DESCRIPTION
Manual backport of https://github.com/dotnet/runtime/pull/124485 to release/8.0-staging

## Customer Impact

- [ ] Customer reported
- [X] Found internally

Parallel calls to Dispose and DuplicateHandle on SafeEvpPKeyHandle can result in a state where the native handle gets up-ref'd, but the SafeHandle returned from DuplicateHandle is tracking the zero-valued handle, so the underlying free never gets called (and interacting with the returned SafeHandle doesn't do what you want, either).

## Regression

- [ ] Yes
- [X] No

## Testing

A dedicated test is added with this change.

## Risk

Low.  DangerousAddRef/DangerousRelease is a standard treatment for SafeHandle atomicity.