### PR TITLE
Use SearchValues for Setrep/Setloop regex interpreter opcodes

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreterCode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreterCode.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
@@ -19,8 +20,52 @@ namespace System.Text.RegularExpressions
         public readonly string[] Strings = strings;
         /// <summary>ASCII lookup table optimization for sets in <see cref="Strings"/>.</summary>
         public readonly uint[]?[] StringsAsciiLookup = new uint[strings.Length][];
+        /// <summary>Precomputed set matchers for character class strings in <see cref="Strings"/>, enabling vectorized scanning for Set opcodes.</summary>
+        public readonly SetSearchValues?[] StringsSetSearchValues = CreateSetSearchValues(strings);
         /// <summary>How many instructions in <see cref="Codes"/> use backtracking.</summary>
         public readonly int TrackCount = trackcount;
+
+        /// <summary>Tries to create SetSearchValues for each character class string.</summary>
+        private static SetSearchValues?[] CreateSetSearchValues(string[] strings)
+        {
+            var result = new SetSearchValues?[strings.Length];
+            Span<char> chars = stackalloc char[128];
+
+            for (int i = 0; i < strings.Length; i++)
+            {
+                string set = strings[i];
+                if (set.Length >= RegexCharClass.SetStartIndex)
+                {
+                    // GetSetChars enumerates the characters described by the set (ignoring negation).
+                    // If the set uses Unicode categories or has too many chars, it returns 0.
+                    int count = RegexCharClass.GetSetChars(set, chars);
+                    if (count > 0)
+                    {
+                        result[i] = new SetSearchValues(
+                            SearchValues.Create(chars.Slice(0, count)),
+                            RegexCharClass.IsNegated(set));
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>Wraps a <see cref="SearchValues{Char}"/> with the set's negation flag so the interpreter
+        /// can test "is character in class" without knowing whether the class was defined as negated.</summary>
+        internal readonly struct SetSearchValues(SearchValues<char> values, bool negated)
+        {
+            private readonly SearchValues<char> _values = values;
+            private readonly bool _negated = negated;
+
+            /// <summary>Returns true if all characters in <paramref name="span"/> are in the character class.</summary>
+            public bool AllMatch(ReadOnlySpan<char> span) =>
+                _negated ? !span.ContainsAny(_values) : !span.ContainsAnyExcept(_values);
+
+            /// <summary>Returns the index of the first character not in the character class, or -1 if all match.</summary>
+            public int IndexOfAnyNonMatch(ReadOnlySpan<char> span) =>
+                _negated ? span.IndexOfAny(_values) : span.IndexOfAnyExcept(_values);
+        }
 
         /// <summary>Gets whether the specified opcode may incur backtracking.</summary>
         public static bool OpcodeBacktracks(RegexOpcode opcode)

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -3231,5 +3231,20 @@ namespace System.Text.RegularExpressions.Tests
                 }
             }
         }
+
+        [Fact]
+        public void Match_MultiLiteralResemblingCharClassEncoding()
+        {
+            // Regression test: a Multi literal string that happens to resemble a character class
+            // encoding could cause GetSetChars to throw IndexOutOfRangeException.
+            // The pattern below produces a Multi opcode whose literal string has:
+            //   [0]='\0' (looks like non-negated flag), [1]='\u0002' (even "set length"),
+            //   [2]='\0' (no categories), [3]='X' — but no [4], so the range enumeration
+            //   in GetSetChars would access past the end of the string.
+            // CreateSetSearchValues must validate the char-class encoding before calling GetSetChars.
+            string input = "\x00\x02\x00X";
+            var regex = new Regex(input);
+            Assert.True(regex.IsMatch(input));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Precompute `SearchValues<char>` for character class strings at regex construction time, and use them in the `Setrep` and `Setloop`/`Setloopatomic` interpreter opcode handlers to replace per-character `CharInClass` loops with vectorized SIMD-accelerated span operations.

Character classes that use Unicode categories, subtraction+negation, or have more than 128 characters fall back to the existing per-character path. A `SetSearchValues` wrapper struct encapsulates `SearchValues<char>` and the set's negation flag so the interpreter doesn't need to know whether the class was defined as negated.

This is a follow-up to #124628 which vectorized the `Oneloop`, `Onerep`, `Notonerep`, and `MatchString` opcodes.

## Benchmark Results

| Benchmark | Before (ns) | After (ns) | Ratio | Speedup |
|-----------|------------|-----------|-------|---------|
| Setloop_AZ_64 | 115.12 | 47.04 | 0.41 | **2.4x** |
| Setloop_AZ_256 | 290.71 | 47.36 | 0.16 | **6.1x** |
| Setloop_Digit_256 | 285.67 | 51.36 | 0.18 | **5.6x** |
| Setrep_AZ_64 | 91.59 | 30.67 | 0.33 | **3.0x** |
| Setrep_AZ_256 | 247.85 | 32.99 | 0.13 | **7.5x** |

<details>
<summary>Benchmark code</summary>

```csharp
using BenchmarkDotNet.Attributes;
using MicroBenchmarks;

namespace System.Text.RegularExpressions.Tests
{
    [BenchmarkCategory(Categories.Libraries, Categories.Regex)]
    public class Perf_Regex_Interpreter_Vectorize
    {
        // === Setloop: greedy character class loops like [a-z]+, \w+, [A-Za-z0-9]+ ===
        // These use SearchValues + IndexOfAnyExcept in the optimized path

        private Regex _setloopAZ64, _setloopAZ256, _setloopDigit256;

        [GlobalSetup(Target = nameof(Setloop_AZ_64))]
        public void Setup_Setloop_AZ_64() => _setloopAZ64 = new Regex("[a-z]+", RegexOptions.None);

        [GlobalSetup(Target = nameof(Setloop_AZ_256))]
        public void Setup_Setloop_AZ_256() => _setloopAZ256 = new Regex("[a-z]+", RegexOptions.None);

        [GlobalSetup(Target = nameof(Setloop_Digit_256))]
        public void Setup_Setloop_Digit_256() => _setloopDigit256 = new Regex("[0-9]+", RegexOptions.None);

        private const string LowerAZ64 = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijkl"; // 64 chars
        private const string LowerAZ256 = LowerAZ64 + LowerAZ64 + LowerAZ64 + LowerAZ64;
        private const string Digits256 = "1234567890123456789012345678901234567890123456789012345678901234" +
                                         "1234567890123456789012345678901234567890123456789012345678901234" +
                                         "1234567890123456789012345678901234567890123456789012345678901234" +
                                         "1234567890123456789012345678901234567890123456789012345678901234";

        [Benchmark]
        public Match Setloop_AZ_64() => _setloopAZ64.Match(LowerAZ64);

        [Benchmark]
        public Match Setloop_AZ_256() => _setloopAZ256.Match(LowerAZ256);

        [Benchmark]
        public Match Setloop_Digit_256() => _setloopDigit256.Match(Digits256);

        // === Setrep: fixed-count character class like [a-z]{64}, [a-z]{256} ===
        // These use SearchValues + ContainsAnyExcept in the optimized path

        private Regex _setrepAZ64, _setrepAZ256;

        [GlobalSetup(Target = nameof(Setrep_AZ_64))]
        public void Setup_Setrep_AZ_64() => _setrepAZ64 = new Regex("[a-z]{64}", RegexOptions.None);

        [GlobalSetup(Target = nameof(Setrep_AZ_256))]
        public void Setup_Setrep_AZ_256() => _setrepAZ256 = new Regex("[a-z]{256}", RegexOptions.None);

        [Benchmark]
        public bool Setrep_AZ_64() => _setrepAZ64.IsMatch(LowerAZ64);

        [Benchmark]
        public bool Setrep_AZ_256() => _setrepAZ256.IsMatch(LowerAZ256);
    }
}
```

</details>
