### PR TITLE
[wasm][coreclr] Use 4GB limit for corerun

### DIFF
--- a/src/coreclr/hosts/corerun/CMakeLists.txt
+++ b/src/coreclr/hosts/corerun/CMakeLists.txt
@@ -78,7 +78,7 @@ else()
                 RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
             target_link_options(corerun PRIVATE
                 -sINITIAL_MEMORY=134217728
-                -sMAXIMUM_MEMORY=2147483648
+                -sMAXIMUM_MEMORY=4294967296
                 -sALLOW_MEMORY_GROWTH=1
                 -sSTACK_SIZE=5MB
                 -sMODULARIZE=1

--- a/src/tests/JIT/jit64/regress/vsw/373472/test.il
+++ b/src/tests/JIT/jit64/regress/vsw/373472/test.il
@@ -50,11 +50,6 @@
         type([TestLibrary]TestLibrary.PlatformDetection)
         string[1] ('IsAppleMobile')
     }
-    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ActiveIssueAttribute::.ctor(string, class [mscorlib]System.Type, string[]) = {
-        string('https://github.com/dotnet/runtime/issues/120708')
-        type([TestLibrary]TestLibrary.PlatformDetection)
-        string[1] ('IsWasm')
-    }
     .entrypoint
     // Code size       40 (0x28)
     .maxstack  2


### PR DESCRIPTION
And enable disabled test.

This is follow up to https://github.com/dotnet/runtime/pull/123377 where this change was disabled as potential problem when looking for regression.