### PR TITLE
Propagate _abortException in Http2Connection.SetupAsync (#119022)

### DIFF
--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/Http2Connection.cs
@@ -255,8 +255,10 @@ namespace System.Net.Http
                     throw;
                 }
 
-                // TODO: Review this case!
-                throw new IOException(SR.net_http_http2_connection_not_established, e);
+                // Use _abortException if available, as it contains the real reason for the connection failure.
+                // For example, when ProcessIncomingFramesAsync detects a server-initiated disconnect and calls Abort(),
+                // _abortException will have the original IOException, while 'e' here may be an uninformative ObjectDisposedException.
+                throw new IOException(SR.net_http_http2_connection_not_established, _abortException ?? e);
             }
 
             // Avoid capturing the initial request's ExecutionContext for the entire lifetime of the new connection.

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http2.cs
@@ -687,8 +687,10 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ConditionalFact(nameof(SupportsAlpn))]
-        public async Task ServerDisconnectDuringSetup_PropagatesMeaningfulException()
+        [ConditionalTheory(nameof(SupportsAlpn))]
+        [InlineData(false)] // server disconnects without sending SETTINGS
+        [InlineData(true)]  // server sends GOAWAY instead of SETTINGS
+        public async Task ServerDisconnectDuringSetup_PropagatesMeaningfulException(bool sendGoAway)
         {
             using (Http2LoopbackServer server = Http2LoopbackServer.CreateServer())
             using (HttpClient client = CreateHttpClient())
@@ -698,19 +700,32 @@ namespace System.Net.Http.Functional.Tests
                 // Accept connection and read client preface, but do NOT send SETTINGS.
                 Http2LoopbackConnection connection = await server.AcceptConnectionAsync();
 
-                // Immediately shut down the connection without sending SETTINGS.
-                // This simulates a server-side disconnect during HTTP/2 setup.
-                await connection.ShutdownSendAsync();
+                if (sendGoAway)
+                {
+                    // Send GOAWAY instead of SETTINGS, then shut down.
+                    await connection.SendGoAway(0, ProtocolErrors.ENHANCE_YOUR_CALM);
+                    await connection.ShutdownSendAsync();
 
-                // The client should throw HttpRequestException(InvalidResponse) wrapping
-                // HttpIOException(InvalidResponse) -> HttpIOException(ResponseEnded),
-                // indicating the server disconnected before sending SETTINGS.
-                HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => sendTask);
-                Assert.Equal(HttpRequestError.InvalidResponse, ex.HttpRequestError);
-                HttpIOException httpIoEx = Assert.IsAssignableFrom<HttpIOException>(ex.InnerException);
-                Assert.Equal(HttpRequestError.InvalidResponse, httpIoEx.HttpRequestError);
-                HttpIOException innerHttpIoEx = Assert.IsAssignableFrom<HttpIOException>(httpIoEx.InnerException);
-                Assert.Equal(HttpRequestError.ResponseEnded, innerHttpIoEx.HttpRequestError);
+                    // The client should throw HttpRequestException(HttpProtocolError) wrapping
+                    // HttpProtocolException with the GOAWAY error code.
+                    await AssertProtocolErrorAsync(sendTask, ProtocolErrors.ENHANCE_YOUR_CALM);
+                }
+                else
+                {
+                    // Immediately shut down the connection without sending SETTINGS.
+                    // This simulates a server-side disconnect during HTTP/2 setup.
+                    await connection.ShutdownSendAsync();
+
+                    // The client should throw HttpRequestException(InvalidResponse) wrapping
+                    // HttpIOException(InvalidResponse) -> HttpIOException(ResponseEnded),
+                    // indicating the server disconnected before sending SETTINGS.
+                    HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() => sendTask);
+                    Assert.Equal(HttpRequestError.InvalidResponse, ex.HttpRequestError);
+                    HttpIOException httpIoEx = Assert.IsAssignableFrom<HttpIOException>(ex.InnerException);
+                    Assert.Equal(HttpRequestError.InvalidResponse, httpIoEx.HttpRequestError);
+                    HttpIOException innerHttpIoEx = Assert.IsAssignableFrom<HttpIOException>(httpIoEx.InnerException);
+                    Assert.Equal(HttpRequestError.ResponseEnded, innerHttpIoEx.HttpRequestError);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- Propagate `_abortException` instead of `ObjectDisposedException` in `Http2Connection.SetupAsync` catch block, surfacing the actual failure reason (e.g., server-initiated disconnect) instead of a generic ODE
- Add test verifying that server disconnect during HTTP/2 setup propagates a meaningful exception

## Details

When `ProcessIncomingFramesAsync` detects a server-initiated disconnect and calls `Abort()`, the original failure reason is stored in `_abortException`. However, `SetupAsync`'s catch block (line 258) was wrapping the uninformative `ObjectDisposedException` instead of the actual cause.

This change uses `_abortException ?? e` as the inner exception, consistent with the existing pattern in `PerformWriteAsync` (line 1192) and `AddStream` (line 1598).

## Test plan

- [x] New test: `ServerDisconnectDuringSetup_PropagatesMeaningfulException`
- [x] All existing Http2 tests pass (858 passed, 9 skipped, 0 failed)

Fixes #119022