### PR TITLE
Eliminate forwarder stubs by reusing method precodes for call counting indirection

### DIFF
--- a/src/coreclr/vm/callcounting.h
+++ b/src/coreclr/vm/callcounting.h
@@ -19,15 +19,18 @@ When starting call counting for a method (see CallCountingManager::SetCodeEntryP
 - A CallCountingStub is created. It contains a small amount of code that decrements the remaining call count and checks for
   zero. When nonzero, it jumps to the code version's native code entry point. When zero, it forwards to a helper function that
   handles tier promotion.
-- For tiered methods that don't have a precode (virtual and interface methods when slot backpatching is enabled), the method's
-  own temporary entry point (precode) is redirected to the call counting stub, and vtable slots are reset to point to the
-  temporary entry point. This ensures calls flow through precode -> call counting stub -> native code, and the call counting
-  stub can be safely deleted since vtable slots don't point to it directly. GetMethodEntryPoint() is kept at the native code
-  entry point (not the temporary entry point) so that DoBackpatch() can still record new vtable slots after the precode
-  reverts to prestub. During call counting, there is a bounded window where new vtable slots may not be recorded because the
-  precode target is the call counting stub rather than the prestub. These slots are corrected once call counting stubs are
-  deleted and the precode reverts to prestub.
-- For methods with a precode, the method's code entry point is set to the call counting stub directly.
+- For tiered methods that do not normally use a MethodDesc precode as the stable entry point (virtual and interface methods
+  when slot backpatching is enabled), the method's own temporary-entrypoint precode is redirected to the call counting stub,
+  and vtable slots are reset to point to the temporary entry point. This ensures calls flow through temporary-entrypoint
+  precode -> call counting stub -> native code, and the call counting stub can be safely deleted since vtable slots don't
+  point to it directly. GetMethodEntryPoint() is kept at the native code entry point (not the temporary entry point) so that
+  DoBackpatch() can still record new vtable slots after the precode reverts to prestub. During call counting, there is a
+  bounded window where new vtable slots may not be recorded because the precode target is the call counting stub rather than
+  the prestub. These slots are corrected once call counting stubs are deleted and the precode reverts to prestub.
+  When call counting ends, the precode is always reset to prestub (never to native code), preserving the invariant
+  that new vtable slots can be discovered and recorded by DoBackpatch().
+- For methods with a precode (or when slot backpatching is disabled), the method's code entry point is set to the call
+  counting stub directly.
 
 When the call count threshold is reached (see CallCountingManager::OnCallCountThresholdReached):
 - The helper call enqueues completion of call counting for background processing

--- a/src/coreclr/vm/callcounting.h
+++ b/src/coreclr/vm/callcounting.h
@@ -22,7 +22,11 @@ When starting call counting for a method (see CallCountingManager::SetCodeEntryP
 - For tiered methods that don't have a precode (virtual and interface methods when slot backpatching is enabled), the method's
   own temporary entry point (precode) is redirected to the call counting stub, and vtable slots are reset to point to the
   temporary entry point. This ensures calls flow through precode -> call counting stub -> native code, and the call counting
-  stub can be safely deleted since vtable slots don't point to it directly.
+  stub can be safely deleted since vtable slots don't point to it directly. GetMethodEntryPoint() is kept at the native code
+  entry point (not the temporary entry point) so that DoBackpatch() can still record new vtable slots after the precode
+  reverts to prestub. During call counting, there is a bounded window where new vtable slots may not be recorded because the
+  precode target is the call counting stub rather than the prestub. These slots are corrected once call counting stubs are
+  deleted and the precode reverts to prestub.
 - For methods with a precode, the method's code entry point is set to the call counting stub directly.
 
 When the call count threshold is reached (see CallCountingManager::OnCallCountThresholdReached):

--- a/src/coreclr/vm/callcounting.h
+++ b/src/coreclr/vm/callcounting.h
@@ -19,11 +19,11 @@ When starting call counting for a method (see CallCountingManager::SetCodeEntryP
 - A CallCountingStub is created. It contains a small amount of code that decrements the remaining call count and checks for
   zero. When nonzero, it jumps to the code version's native code entry point. When zero, it forwards to a helper function that
   handles tier promotion.
-- For tiered methods that don't have a precode (virtual and interface methods when slot backpatching is enabled), a forwarder
-  stub (a precode) is created and it forwards to the call counting stub. This is so that the call counting stub can be safely
-  and easily deleted. The forwarder stubs are only used when counting calls, there is one per method (not per code version), and
-  they are not deleted.
-- The method's code entry point is set to the forwarder stub or the call counting stub to count calls to the code version
+- For tiered methods that don't have a precode (virtual and interface methods when slot backpatching is enabled), the method's
+  own temporary entry point (precode) is redirected to the call counting stub, and vtable slots are reset to point to the
+  temporary entry point. This ensures calls flow through precode -> call counting stub -> native code, and the call counting
+  stub can be safely deleted since vtable slots don't point to it directly.
+- For methods with a precode, the method's code entry point is set to the call counting stub directly.
 
 When the call count threshold is reached (see CallCountingManager::OnCallCountThresholdReached):
 - The helper call enqueues completion of call counting for background processing
@@ -36,8 +36,6 @@ After all work queued for promotion is completed and methods transitioned to opt
 - All call counting stubs are deleted. For code versions that have not completed counting, the method's code entry point is
   reset such that call counting would be reestablished on the next call.
 - Completed call counting infos are deleted
-- For methods that no longer have any code versions that need to be counted, the forwarder stubs are no longer tracked. If a
-  new IL code version is added thereafter (perhaps by a profiler), a new forwarder stub may be created.
 
 Miscellaneous
 -------------
@@ -287,27 +285,6 @@ private:
     };
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    // CallCountingManager::MethodDescForwarderStub
-
-private:
-    class MethodDescForwarderStubHashTraits : public DefaultSHashTraits<Precode *>
-    {
-    private:
-        typedef DefaultSHashTraits<Precode *> Base;
-    public:
-        typedef Base::element_t element_t;
-        typedef Base::count_t count_t;
-        typedef MethodDesc *key_t;
-
-    public:
-        static key_t GetKey(const element_t &e);
-        static BOOL Equals(const key_t &k1, const key_t &k2);
-        static count_t Hash(const key_t &k);
-    };
-
-    typedef SHash<MethodDescForwarderStubHashTraits> MethodDescForwarderStubHash;
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // CallCountingManager::CallCountingManagerHashTraits
 
 private:
@@ -341,7 +318,6 @@ private:
 private:
     CallCountingInfoByCodeVersionHash m_callCountingInfoByCodeVersionHash;
     CallCountingStubAllocator m_callCountingStubAllocator;
-    MethodDescForwarderStubHash m_methodDescForwarderStubHash;
     SArray<CallCountingInfo *> m_callCountingInfosPendingCompletion;
 
 public:

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -3144,7 +3144,7 @@ void MethodDesc::RecordAndBackpatchEntryPointSlot_Locked(
     backpatchTracker->AddSlotAndPatch_Locked(this, slotLoaderAllocator, slot, slotType, currentEntryPoint);
 }
 
-FORCEINLINE bool MethodDesc::TryBackpatchEntryPointSlots(
+bool MethodDesc::TryBackpatchEntryPointSlots(
     PCODE entryPoint,
     bool isPrestubEntryPoint,
     bool onlyFromPrestubEntryPoint)

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -106,10 +106,15 @@ PCODE MethodDesc::DoBackpatch(MethodTable * pMT, MethodTable *pDispatchingMT, bo
         //     MethodDesc::BackpatchEntryPointSlots()
 
         // Backpatching the temporary entry point:
-        //     The temporary entry point is never backpatched for methods versionable with vtable slot backpatch. New vtable
-        //     slots inheriting the method will initially point to the temporary entry point and it must point to the prestub
-        //     and come here for backpatching such that the new vtable slot can be discovered and recorded for future
-        //     backpatching.
+        //     The temporary entry point is not directly backpatched for methods versionable with vtable slot backpatch.
+        //     New vtable slots inheriting the method will initially point to the temporary entry point. During call
+        //     counting, the temporary entry point's precode target may be temporarily redirected to a call counting
+        //     stub, but it must revert to the prestub when call counting stubs are deleted. This ensures new vtable
+        //     slots will come here for backpatching so they can be discovered and recorded for future backpatching.
+        //
+        //     To enable slot recording after the precode reverts to prestub, GetMethodEntryPoint() must be set to the
+        //     native code entry point (not the temporary entry point) during call counting. This prevents the
+        //     pExpected == pTarget check above from short-circuiting slot recording.
 
         _ASSERTE(!HasNonVtableSlot());
     }

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -109,8 +109,12 @@ PCODE MethodDesc::DoBackpatch(MethodTable * pMT, MethodTable *pDispatchingMT, bo
         //     The temporary entry point is not directly backpatched for methods versionable with vtable slot backpatch.
         //     New vtable slots inheriting the method will initially point to the temporary entry point. During call
         //     counting, the temporary entry point's precode target may be temporarily redirected to a call counting
-        //     stub, but it must revert to the prestub when call counting stubs are deleted. This ensures new vtable
-        //     slots will come here for backpatching so they can be discovered and recorded for future backpatching.
+        //     stub, but it must revert to the prestub when call counting ends (not to native code). This ensures new
+        //     vtable slots will come here for backpatching so they can be discovered and recorded for future
+        //     backpatching. The precode for backpatchable methods should only ever point to:
+        //       1. The prestub (default, and when call counting is not active)
+        //       2. A call counting stub (during active call counting only)
+        //     It must never point directly to native code, as that would permanently bypass slot recording.
         //
         //     To enable slot recording after the precode reverts to prestub, GetMethodEntryPoint() must be set to the
         //     native code entry point (not the temporary entry point) during call counting. This prevents the


### PR DESCRIPTION
For methods versioned with vtable slot backpatching (virtual/interface methods), the call counting infrastructure previously allocated separate forwarder stub precodes to serve as stable indirection points between vtable slots and deletable call counting stubs. This added memory overhead and complexity for tracking, resetting, and trimming these per-method forwarder stubs.

This change reuses the method's own temporary entry point (precode) as the stable indirection during call counting. Instead of allocating a forwarder stub and backpatching vtable slots to it, vtable slots are reset to point to the method's precode, and the precode target is redirected to the call counting stub via \SetTargetInterlocked\. This preserves the safety property that vtable slots never point directly to deletable call counting stubs, while eliminating the separate forwarder stub allocation entirely.

## Key invariant

For backpatchable methods, the temporary entry point's precode target must only ever be one of two values:
1. **The prestub** (default, and whenever call counting is not active)
2. **A call counting stub** (during active call counting only)

It must **never** point directly to native code. Setting the precode to native code would bypass \DoBackpatch()\ slot recording, preventing new vtable slots from being discovered. This would leave those slots permanently stale if a code version change (e.g. ReJIT) occurs later.

To maintain correct \DoBackpatch()\ behavior during call counting, \GetMethodEntryPoint()\ is kept at the native code entry point (not the temporary entry point). This prevents the \pExpected == pTarget\ early-exit check in \DoBackpatch()\ from short-circuiting slot recording once the precode reverts to prestub.

## Components updated

- **CallCountingManager::SetCodeEntryPoint**: For backpatchable methods, replaced forwarder stub creation with \BackpatchToResetEntryPointSlots()\ (to reset vtable slots to the precode) followed by \SetMethodEntryPoint(nativeCode)\ and \SetTargetInterlocked(callCountingStub)\ on the method's precode. When call counting completes (threshold reached or stage >= PendingCompletion), the precode is reset to prestub via \ResetTargetInterlocked()\ while \SetCodeEntryPoint()\ handles recorded slot updates through the normal \BackpatchEntryPointSlots()\ path.

- **CallCountingManager::CompleteCallCounting**: Calls \SetCodeEntryPoint()\/\ResetCodeEntryPoint()\ for all methods (backpatchable and non-backpatchable alike), then resets the precode to prestub via \ResetTargetInterlocked()\ for backpatchable methods. This ensures recorded slots are properly updated while the precode reverts to prestub for new slot discovery.

- **CallCountingManager::StopAllCallCounting**: Calls \ResetCodeEntryPoint()\ for all methods, then resets the precode target to prestub via \ResetTargetInterlocked()\ for backpatchable methods. Removed the forwarder stub reset loop.

- **CallCountingManager::DeleteAllCallCountingStubs**: Adds a safety-net \ResetTargetInterlocked()\ for backpatchable methods in Stage::Complete before deleting the call counting info. This guarantees the precode is at prestub even if an earlier reset was missed. Removed forwarder stub lookup and removal.

- **CallCountingManager::TrimCollections**: Removed forwarder stub hash table trimming.

- **callcounting.h**: Removed \MethodDescForwarderStubHashTraits\, \MethodDescForwarderStubHash\, and \m_methodDescForwarderStubHash\. Updated documentation to describe the precode-reuse approach and the two-state precode invariant.

- **prestub.cpp**: Updated \DoBackpatch()\ comments to document the precode invariant: the precode for backpatchable methods should only ever point to prestub or a call counting stub, never directly to native code.