### PR TITLE
Add [RequiresUnsafe] to Unsafe.As<> and baseline

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Array.CoreCLR.cs
@@ -401,7 +401,12 @@ namespace System
         {
             // ! Warning: "this" is an array, not an SZArrayHelper. See comments above
             // ! or you may introduce a security hole!
-            T[] @this = Unsafe.As<T[]>(this);
+            T[] @this;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                @this = Unsafe.As<T[]>(this);
+            }
             int length = @this.Length;
             return length == 0 ? SZGenericArrayEnumerator<T>.Empty : new SZGenericArrayEnumerator<T>(@this, length);
         }
@@ -411,7 +416,12 @@ namespace System
             // ! Warning: "this" is an array, not an SZArrayHelper. See comments above
             // ! or you may introduce a security hole!
 
-            T[] @this = Unsafe.As<T[]>(this);
+            T[] @this;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                @this = Unsafe.As<T[]>(this);
+            }
             Array.Copy(@this, 0, array, index, @this.Length);
         }
 
@@ -419,7 +429,12 @@ namespace System
         {
             // ! Warning: "this" is an array, not an SZArrayHelper. See comments above
             // ! or you may introduce a security hole!
-            T[] @this = Unsafe.As<T[]>(this);
+            T[] @this;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                @this = Unsafe.As<T[]>(this);
+            }
             return @this.Length;
         }
 
@@ -427,7 +442,12 @@ namespace System
         {
             // ! Warning: "this" is an array, not an SZArrayHelper. See comments above
             // ! or you may introduce a security hole!
-            T[] @this = Unsafe.As<T[]>(this);
+            T[] @this;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                @this = Unsafe.As<T[]>(this);
+            }
             if ((uint)index >= (uint)@this.Length)
             {
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessException();
@@ -440,7 +460,12 @@ namespace System
         {
             // ! Warning: "this" is an array, not an SZArrayHelper. See comments above
             // ! or you may introduce a security hole!
-            T[] @this = Unsafe.As<T[]>(this);
+            T[] @this;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                @this = Unsafe.As<T[]>(this);
+            }
             if ((uint)index >= (uint)@this.Length)
             {
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessException();
@@ -459,7 +484,12 @@ namespace System
         {
             // ! Warning: "this" is an array, not an SZArrayHelper. See comments above
             // ! or you may introduce a security hole!
-            T[] @this = Unsafe.As<T[]>(this);
+            T[] @this;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                @this = Unsafe.As<T[]>(this);
+            }
             return Array.IndexOf(@this, value, 0, @this.Length) >= 0;
         }
 
@@ -480,7 +510,12 @@ namespace System
         {
             // ! Warning: "this" is an array, not an SZArrayHelper. See comments above
             // ! or you may introduce a security hole!
-            T[] @this = Unsafe.As<T[]>(this);
+            T[] @this;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                @this = Unsafe.As<T[]>(this);
+            }
             return Array.IndexOf(@this, value, 0, @this.Length);
         }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Delegate.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Delegate.CoreCLR.cs
@@ -435,7 +435,11 @@ namespace System
         private static MulticastDelegate InternalAlloc(RuntimeType type)
         {
             Debug.Assert(type.IsAssignableTo(typeof(MulticastDelegate)));
-            return Unsafe.As<MulticastDelegate>(RuntimeTypeHandle.InternalAlloc(type));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return Unsafe.As<MulticastDelegate>(RuntimeTypeHandle.InternalAlloc(type));
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Enum.CoreCLR.cs
@@ -126,7 +126,13 @@ namespace System
 
             // This type is the only type that will be stored in the _enumInfo field, so we can use Unsafe.As here.
             public static ref EnumInfo<TStorage>? GetStorageRef(RuntimeType.CompositeCacheEntry compositeEntry)
-                => ref Unsafe.As<RuntimeType.IGenericCacheEntry?, EnumInfo<TStorage>?>(ref compositeEntry._enumInfo);
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return ref Unsafe.As<RuntimeType.IGenericCacheEntry?, EnumInfo<TStorage>?>(ref compositeEntry._enumInfo);
+                }
+            }
         }
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/MulticastDelegate.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/MulticastDelegate.CoreCLR.cs
@@ -55,7 +55,12 @@ namespace System
             // the types are the same, obj should also be a
             // MulticastDelegate
             Debug.Assert(obj is MulticastDelegate, "Shouldn't have failed here since we already checked the types are the same!");
-            MulticastDelegate d = Unsafe.As<MulticastDelegate>(obj);
+            MulticastDelegate d;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                d = Unsafe.As<MulticastDelegate>(obj);
+            }
 
             if (_invocationCount != 0)
             {

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -529,7 +529,14 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
-            private ref byte GetResultStorage() => ref Unsafe.As<T?, byte>(ref m_result);
+            private ref byte GetResultStorage()
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return ref Unsafe.As<T?, byte>(ref m_result);
+                }
+            }
 
             private static unsafe Continuation? UnwindToPossibleHandler(Continuation? continuation, Exception ex)
             {

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.CoreCLR.cs
@@ -419,8 +419,12 @@ namespace System.Runtime.CompilerServices
         internal static ref int GetMultiDimensionalArrayBounds(this Array array)
         {
             Debug.Assert(GetMultiDimensionalArrayRank(array) > 0);
+            // TODO(unsafe): Baselining unsafe usage
             // See comment on RawArrayData for details
-            return ref Unsafe.As<byte, int>(ref Unsafe.As<RawArrayData>(array).Data);
+            unsafe
+            {
+                return ref Unsafe.As<byte, int>(ref Unsafe.As<RawArrayData>(array).Data);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/RuntimeType.CoreCLR.cs
@@ -2448,7 +2448,11 @@ namespace System
                 {
                     object? cache = GCHandle.InternalGet(m_cache);
                     Debug.Assert(cache == null || cache is RuntimeTypeCache);
-                    return Unsafe.As<RuntimeTypeCache>(cache);
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return Unsafe.As<RuntimeTypeCache>(cache);
+                    }
                 }
                 return null;
             }
@@ -2465,7 +2469,11 @@ namespace System
                     if (cache != null)
                     {
                         Debug.Assert(cache is RuntimeTypeCache);
-                        return Unsafe.As<RuntimeTypeCache>(cache);
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            return Unsafe.As<RuntimeTypeCache>(cache);
+                        }
                     }
                 }
                 return InitializeCache();

--- a/src/libraries/System.Private.CoreLib/src/System/Activator.RuntimeType.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Activator.RuntimeType.cs
@@ -142,6 +142,7 @@ namespace System
             if (!rtType.IsValueType)
             {
                 object o = rtType.CreateInstanceOfT()!;
+                // TODO(unsafe): Baselining unsafe usage
 
                 // Casting the above object to T is technically invalid because
                 // T can be ByRefLike (that is, ref struct). Roslyn blocks the
@@ -149,12 +150,19 @@ namespace System
                 // which is correct. However, since we are doing the IsValueType
                 // check above, we know this code path will only be taken with
                 // reference types and therefore the below Unsafe.As<> is safe.
-                return Unsafe.As<object, T>(ref o);
+                unsafe
+                {
+                    return Unsafe.As<object, T>(ref o);
+                }
             }
             else
             {
                 T t = default!;
-                rtType.CallDefaultStructConstructor(ref Unsafe.As<T, byte>(ref t));
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    rtType.CallDefaultStructConstructor(ref Unsafe.As<T, byte>(ref t));
+                }
                 return t;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Array.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Array.cs
@@ -1341,7 +1341,13 @@ namespace System
                         return (result >= 0) ? (index + result) : ~(index + ~result);
 
                         static int GenericBinarySearch<T>(Array array, int adjustedIndex, int length, object value) where T : struct, IComparable<T>
-                            => UnsafeArrayAsSpan<T>(array, adjustedIndex, length).BinarySearch(Unsafe.As<byte, T>(ref value.GetRawData()));
+                        {
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                return UnsafeArrayAsSpan<T>(array, adjustedIndex, length).BinarySearch(Unsafe.As<byte, T>(ref value.GetRawData()));
+                            }
+                        }
                     }
                 }
             }
@@ -1849,7 +1855,13 @@ namespace System
                     return (result >= 0 ? startIndex : lb) + result;
 
                     static int GenericIndexOf<T>(Array array, object value, int adjustedIndex, int length) where T : struct, IEquatable<T>
-                        => UnsafeArrayAsSpan<T>(array, adjustedIndex, length).IndexOf(Unsafe.As<byte, T>(ref value.GetRawData()));
+                    {
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            return UnsafeArrayAsSpan<T>(array, adjustedIndex, length).IndexOf(Unsafe.As<byte, T>(ref value.GetRawData()));
+                        }
+                    }
                 }
             }
 
@@ -2076,7 +2088,13 @@ namespace System
                     return (result >= 0 ? endIndex : lb) + result;
 
                     static int GenericLastIndexOf<T>(Array array, object value, int adjustedIndex, int length) where T : struct, IEquatable<T>
-                        => UnsafeArrayAsSpan<T>(array, adjustedIndex, length).LastIndexOf(Unsafe.As<byte, T>(ref value.GetRawData()));
+                    {
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            return UnsafeArrayAsSpan<T>(array, adjustedIndex, length).LastIndexOf(Unsafe.As<byte, T>(ref value.GetRawData()));
+                        }
+                    }
                 }
             }
 
@@ -3069,8 +3087,14 @@ namespace System
             }
         }
 
-        private static Span<T> UnsafeArrayAsSpan<T>(Array array, int adjustedIndex, int length) =>
-            new Span<T>(ref Unsafe.As<byte, T>(ref MemoryMarshal.GetArrayDataReference(array)), array.Length).Slice(adjustedIndex, length);
+        private static Span<T> UnsafeArrayAsSpan<T>(Array array, int adjustedIndex, int length)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return new Span<T>(ref Unsafe.As<byte, T>(ref MemoryMarshal.GetArrayDataReference(array)), array.Length).Slice(adjustedIndex, length);
+            }
+        }
 
         public IEnumerator GetEnumerator()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/SharedArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/SharedArrayPool.cs
@@ -60,7 +60,11 @@ namespace System.Buffers
             SharedArrayPoolThreadLocalArray[]? tlsBuckets = t_tlsBuckets;
             if (tlsBuckets is not null && (uint)bucketIndex < (uint)tlsBuckets.Length)
             {
-                buffer = Unsafe.As<T[]>(tlsBuckets[bucketIndex].Array);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    buffer = Unsafe.As<T[]>(tlsBuckets[bucketIndex].Array);
+                }
                 if (buffer is not null)
                 {
                     tlsBuckets[bucketIndex].Array = null;
@@ -79,7 +83,11 @@ namespace System.Buffers
                 SharedArrayPoolPartitions? b = perCoreBuckets[bucketIndex];
                 if (b is not null)
                 {
-                    buffer = Unsafe.As<T[]>(b.TryPop());
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        buffer = Unsafe.As<T[]>(b.TryPop());
+                    }
                     if (buffer is not null)
                     {
                         if (log.IsEnabled())

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Utf8Parser/Utf8Parser.Integer.Signed.cs
@@ -56,7 +56,11 @@ namespace System.Buffers.Text
 
                 case 'x':
                     Unsafe.SkipInit(out value); // will be populated by TryParseByteX
-                    return TryParseByteX(source, out Unsafe.As<sbyte, byte>(ref value), out bytesConsumed);
+                                                // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return TryParseByteX(source, out Unsafe.As<sbyte, byte>(ref value), out bytesConsumed);
+                    }
 
                 default:
                     return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);
@@ -108,7 +112,11 @@ namespace System.Buffers.Text
 
                 case 'x':
                     Unsafe.SkipInit(out value); // will be populated by TryParseUInt16X
-                    return TryParseUInt16X(source, out Unsafe.As<short, ushort>(ref value), out bytesConsumed);
+                                                // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return TryParseUInt16X(source, out Unsafe.As<short, ushort>(ref value), out bytesConsumed);
+                    }
 
                 default:
                     return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);
@@ -160,7 +168,11 @@ namespace System.Buffers.Text
 
                 case 'x':
                     Unsafe.SkipInit(out value); // will be populated by TryParseUInt32X
-                    return TryParseUInt32X(source, out Unsafe.As<int, uint>(ref value), out bytesConsumed);
+                                                // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return TryParseUInt32X(source, out Unsafe.As<int, uint>(ref value), out bytesConsumed);
+                    }
 
                 default:
                     return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);
@@ -212,7 +224,11 @@ namespace System.Buffers.Text
 
                 case 'x':
                     Unsafe.SkipInit(out value); // will be populated by TryParseUInt64X
-                    return TryParseUInt64X(source, out Unsafe.As<long, ulong>(ref value), out bytesConsumed);
+                                                // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return TryParseUInt64X(source, out Unsafe.As<long, ulong>(ref value), out bytesConsumed);
+                    }
 
                 default:
                     return ParserHelpers.TryParseThrowFormatException(source, out value, out bytesConsumed);

--- a/src/libraries/System.Private.CoreLib/src/System/ByReference.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ByReference.cs
@@ -14,6 +14,13 @@ namespace System
         public readonly ref byte Value;
         public ByReference(ref byte value) => Value = ref value;
 
-        public static ByReference Create<T>(ref T p) => new ByReference(ref Unsafe.As<T, byte>(ref p));
+        public static ByReference Create<T>(ref T p)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return new ByReference(ref Unsafe.As<T, byte>(ref p));
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/BitArray.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/BitArray.cs
@@ -170,8 +170,11 @@ namespace System.Collections
             // Instead, We compare with zeroes (== false) then negate the result to ensure compatibility.
 
             ref byte arrayRef = ref MemoryMarshal.GetArrayDataReference(_array);
-            ref byte value = ref Unsafe.As<bool, byte>(ref MemoryMarshal.GetArrayDataReference<bool>(values));
-            if (Vector512.IsHardwareAccelerated)
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref byte value = ref Unsafe.As<bool, byte>(ref MemoryMarshal.GetArrayDataReference<bool>(values));
+                if (Vector512.IsHardwareAccelerated)
             {
                 for (; i <= (uint)values.Length - Vector512<byte>.Count; i += (uint)Vector512<byte>.Count)
                 {
@@ -208,6 +211,7 @@ namespace System.Collections
                     Unsafe.WriteUnaligned(
                         ref Unsafe.Add(ref arrayRef, sizeof(uint) * (i / 32u)),
                         ~((upperResult << 16) | lowerResult));
+                }
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -2321,7 +2321,11 @@ namespace System.Collections.Concurrent
              where TAlternateKey : notnull, allows ref struct
         {
             Debug.Assert(IsCompatibleKey<TAlternateKey>(tables));
-            return Unsafe.As<IAlternateEqualityComparer<TAlternateKey, TKey>>(tables._comparer!);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return Unsafe.As<IAlternateEqualityComparer<TAlternateKey, TKey>>(tables._comparer!);
+            }
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -737,7 +737,11 @@ namespace System.Collections.Generic
             internal static IAlternateEqualityComparer<TAlternateKey, TKey> GetAlternateComparer(Dictionary<TKey, TValue> dictionary)
             {
                 Debug.Assert(IsCompatibleKey(dictionary));
-                return Unsafe.As<IAlternateEqualityComparer<TAlternateKey, TKey>>(dictionary._comparer)!;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return Unsafe.As<IAlternateEqualityComparer<TAlternateKey, TKey>>(dictionary._comparer)!;
+                }
             }
 
             /// <summary>Gets the value associated with the specified alternate key.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -444,7 +444,11 @@ namespace System.Collections.Generic
             internal static IAlternateEqualityComparer<TAlternate, T> GetAlternateComparer(HashSet<T> set)
             {
                 Debug.Assert(IsCompatibleItem(set));
-                return Unsafe.As<IAlternateEqualityComparer<TAlternate, T>>(set._comparer)!;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return Unsafe.As<IAlternateEqualityComparer<TAlternate, T>>(set._comparer)!;
+                }
             }
 
             /// <summary>Adds the specified element to a set.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/RandomizedStringEqualityComparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/RandomizedStringEqualityComparer.cs
@@ -85,11 +85,17 @@ namespace System.Collections.Generic
                     _seed.p0, _seed.p1);
             }
 
-            int IAlternateEqualityComparer<ReadOnlySpan<char>, string?>.GetHashCode(ReadOnlySpan<char> alternate) =>
-                Marvin.ComputeHash32(
+            int IAlternateEqualityComparer<ReadOnlySpan<char>, string?>.GetHashCode(ReadOnlySpan<char> alternate)
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return Marvin.ComputeHash32(
                     ref Unsafe.As<char, byte>(ref MemoryMarshal.GetReference(alternate)),
                     (uint)alternate.Length * 2,
                     _seed.p0, _seed.p1);
+                }
+            }
         }
 
         private sealed class OrdinalIgnoreCaseComparer : RandomizedStringEqualityComparer, IAlternateEqualityComparer<ReadOnlySpan<char>, string?>

--- a/src/libraries/System.Private.CoreLib/src/System/ComAwareWeakReference.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ComAwareWeakReference.cs
@@ -111,8 +111,12 @@ namespace System
             {
                 if (_comInfo != null)
                 {
+                    // TODO(unsafe): Baselining unsafe usage
                     // Check if the target is still null
-                    target = Unsafe.As<T>(GCHandle.InternalGet(_weakHandle));
+                    unsafe
+                    {
+                        target = Unsafe.As<T>(GCHandle.InternalGet(_weakHandle));
+                    }
                     if (target == null)
                     {
                         // Resolve and reset. Perform runtime cast to catch bugs
@@ -145,23 +149,36 @@ namespace System
                 GCHandle.InternalFree(newHandle);
                 GC.SuppressFinalize(newRef);
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            return Unsafe.As<ComAwareWeakReference>(GCHandle.InternalGet(taggedHandle & ~HandleTagBits)!);
+            unsafe
+            {
+                return Unsafe.As<ComAwareWeakReference>(GCHandle.InternalGet(taggedHandle & ~HandleTagBits)!);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static ComAwareWeakReference GetFromTaggedReference(nint taggedHandle)
         {
             Debug.Assert((taggedHandle & ComAwareBit) != 0);
-            return Unsafe.As<ComAwareWeakReference>(GCHandle.InternalGet(taggedHandle & ~HandleTagBits)!);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return Unsafe.As<ComAwareWeakReference>(GCHandle.InternalGet(taggedHandle & ~HandleTagBits)!);
+            }
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
         internal static void SetTarget(ref nint taggedHandle, object? target, ComInfo? comInfo)
         {
-            ComAwareWeakReference comAwareRef = comInfo != null ?
+            ComAwareWeakReference comAwareRef;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                comAwareRef = comInfo != null ?
                 EnsureComAwareReference(ref taggedHandle) :
                 Unsafe.As<ComAwareWeakReference>(GCHandle.InternalGet(taggedHandle & ~HandleTagBits)!);
+            }
 
             comAwareRef.SetTarget(target, comInfo);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Decimal.DecCalc.cs
@@ -21,7 +21,14 @@ namespace System
 
         internal ulong Low64 => _lo64;
 
-        private static ref DecCalc AsMutable(ref decimal d) => ref Unsafe.As<decimal, DecCalc>(ref d);
+        private static ref DecCalc AsMutable(ref decimal d)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return ref Unsafe.As<decimal, DecCalc>(ref d);
+            }
+        }
 
         #region APIs need by number formatting.
 
@@ -2215,7 +2222,12 @@ ThrowOverflow:
                 // In the operation x % y the sign of y does not matter. Result will have the sign of x.
                 d2.uflags = (d2.uflags & ~SignMask) | (d1.uflags & SignMask);
 
-                int cmp = VarDecCmpSub(in Unsafe.As<DecCalc, decimal>(ref d1), in Unsafe.As<DecCalc, decimal>(ref d2));
+                int cmp;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    cmp = VarDecCmpSub(in Unsafe.As<DecCalc, decimal>(ref d1), in Unsafe.As<DecCalc, decimal>(ref d2));
+                }
                 if (cmp == 0)
                 {
                     d1.ulo = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/Delegate.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Delegate.cs
@@ -78,7 +78,17 @@ namespace System
         /// Gets a value that indicates whether the <see cref="Delegate"/> has a single invocation target.
         /// </summary>
         /// <value>true if the <see cref="Delegate"/> has a single invocation target.</value>
-        public bool HasSingleTarget => Unsafe.As<MulticastDelegate>(this).HasSingleTarget;
+        public bool HasSingleTarget
+        {
+            get
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return Unsafe.As<MulticastDelegate>(this).HasSingleTarget;
+                }
+            }
+        }
 #endif
 
         /// <summary>
@@ -94,7 +104,13 @@ namespace System
         /// The method returns an empty enumerator for null delegate.
         /// </remarks>
         public static System.Delegate.InvocationListEnumerator<TDelegate> EnumerateInvocationList<TDelegate>(TDelegate? d) where TDelegate : System.Delegate
-            => new InvocationListEnumerator<TDelegate>(Unsafe.As<MulticastDelegate>(d));
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return new InvocationListEnumerator<TDelegate>(Unsafe.As<MulticastDelegate>(d));
+            }
+        }
 
         /// <summary>
         /// Provides an enumerator for the invocation list of a delegate.
@@ -128,9 +144,13 @@ namespace System
             public bool MoveNext()
             {
                 int index = _index + 1;
-                if ((_current = Unsafe.As<TDelegate>(_delegate?.TryGetAt(index))) == null)
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    if ((_current = Unsafe.As<TDelegate>(_delegate?.TryGetAt(index))) == null)
                 {
                     return false;
+                    }
                 }
                 _index = index;
                 return true;

--- a/src/libraries/System.Private.CoreLib/src/System/Enum.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Enum.cs
@@ -418,23 +418,50 @@ namespace System
                 case CorElementType.ELEMENT_TYPE_I2:
                 case CorElementType.ELEMENT_TYPE_U2:
                     {
-                        ushort flagsValue = Unsafe.As<byte, ushort>(ref pFlagsValue);
+                        ushort flagsValue;
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        flagsValue = Unsafe.As<byte, ushort>(ref pFlagsValue);
+                    }
+                // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
                         return (Unsafe.As<byte, ushort>(ref pThisValue) & flagsValue) == flagsValue;
                     }
+                }
 
                 case CorElementType.ELEMENT_TYPE_I4:
                 case CorElementType.ELEMENT_TYPE_U4:
                     {
-                        uint flagsValue = Unsafe.As<byte, uint>(ref pFlagsValue);
+                        uint flagsValue;
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        flagsValue = Unsafe.As<byte, uint>(ref pFlagsValue);
+                    }
+                // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
                         return (Unsafe.As<byte, uint>(ref pThisValue) & flagsValue) == flagsValue;
                     }
+                }
 
                 case CorElementType.ELEMENT_TYPE_I8:
                 case CorElementType.ELEMENT_TYPE_U8:
                     {
-                        ulong flagsValue = Unsafe.As<byte, ulong>(ref pFlagsValue);
+                        ulong flagsValue;
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        flagsValue = Unsafe.As<byte, ulong>(ref pFlagsValue);
+                    }
+                // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
                         return (Unsafe.As<byte, ulong>(ref pThisValue) & flagsValue) == flagsValue;
                     }
+                }
 
 #if RARE_ENUMS
                 case CorElementType.ELEMENT_TYPE_BOOLEAN:
@@ -891,20 +918,111 @@ namespace System
             RuntimeType rt = (RuntimeType)typeof(TEnum);
             Type underlyingType = typeof(TEnum).GetEnumUnderlyingType();
 
-            if (underlyingType == typeof(sbyte)) return TryParseByValueOrName<sbyte, byte>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, sbyte>(ref result));
-            if (underlyingType == typeof(byte)) return TryParseByValueOrName<byte, byte>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, byte>(ref result));
-            if (underlyingType == typeof(short)) return TryParseByValueOrName<short, ushort>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, short>(ref result));
-            if (underlyingType == typeof(ushort)) return TryParseByValueOrName<ushort, ushort>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, ushort>(ref result));
-            if (underlyingType == typeof(int)) return TryParseByValueOrName<int, uint>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, int>(ref result));
-            if (underlyingType == typeof(uint)) return TryParseByValueOrName<uint, uint>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, uint>(ref result));
-            if (underlyingType == typeof(long)) return TryParseByValueOrName<long, ulong>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, long>(ref result));
-            if (underlyingType == typeof(ulong)) return TryParseByValueOrName<ulong, ulong>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, ulong>(ref result));
+            if (underlyingType == typeof(sbyte))
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return TryParseByValueOrName<sbyte, byte>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, sbyte>(ref result));
+                }
+            }
+            if (underlyingType == typeof(byte))
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return TryParseByValueOrName<byte, byte>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, byte>(ref result));
+                }
+            }
+            if (underlyingType == typeof(short))
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return TryParseByValueOrName<short, ushort>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, short>(ref result));
+                }
+            }
+            if (underlyingType == typeof(ushort))
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return TryParseByValueOrName<ushort, ushort>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, ushort>(ref result));
+                }
+            }
+            if (underlyingType == typeof(int))
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return TryParseByValueOrName<int, uint>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, int>(ref result));
+                }
+            }
+            if (underlyingType == typeof(uint))
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return TryParseByValueOrName<uint, uint>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, uint>(ref result));
+                }
+            }
+            if (underlyingType == typeof(long))
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return TryParseByValueOrName<long, ulong>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, long>(ref result));
+                }
+            }
+            if (underlyingType == typeof(ulong))
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return TryParseByValueOrName<ulong, ulong>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, ulong>(ref result));
+                }
+            }
 #if RARE_ENUMS
-            if (underlyingType == typeof(nint)) return TryParseRareTypeByValueOrName<nint, nuint>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, nint>(ref result));
-            if (underlyingType == typeof(nuint)) return TryParseRareTypeByValueOrName<nuint, nuint>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, nuint>(ref result));
-            if (underlyingType == typeof(float)) return TryParseRareTypeByValueOrName<float, float>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, float>(ref result));
-            if (underlyingType == typeof(double)) return TryParseRareTypeByValueOrName<double, double>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, double>(ref result));
-            if (underlyingType == typeof(char)) return TryParseRareTypeByValueOrName<char, char>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, char>(ref result));
+            if (underlyingType == typeof(nint))
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return TryParseRareTypeByValueOrName<nint, nuint>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, nint>(ref result));
+                }
+            }
+            if (underlyingType == typeof(nuint))
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return TryParseRareTypeByValueOrName<nuint, nuint>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, nuint>(ref result));
+                }
+            }
+            if (underlyingType == typeof(float))
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return TryParseRareTypeByValueOrName<float, float>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, float>(ref result));
+                }
+            }
+            if (underlyingType == typeof(double))
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return TryParseRareTypeByValueOrName<double, double>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, double>(ref result));
+                }
+            }
+            if (underlyingType == typeof(char))
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return TryParseRareTypeByValueOrName<char, char>(rt, value, ignoreCase, throwOnFailure, out Unsafe.As<TEnum, char>(ref result));
+                }
+            }
 #endif
 
             throw CreateUnknownEnumTypeException();
@@ -935,7 +1053,11 @@ namespace System
                 if (!char.IsAsciiDigit(c) && c != '-' && c != '+')
                 {
                     Unsafe.SkipInit(out result);
-                    return TryParseByName(enumType, value, ignoreCase, throwOnFailure, out Unsafe.As<TUnderlying, TStorage>(ref result));
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return TryParseByName(enumType, value, ignoreCase, throwOnFailure, out Unsafe.As<TUnderlying, TStorage>(ref result));
+                    }
                 }
 
                 NumberFormatInfo numberFormat = NumberFormatInfo.InvariantInfo;
@@ -950,7 +1072,11 @@ namespace System
                 if (status != Number.ParsingStatus.Overflow)
                 {
                     Unsafe.SkipInit(out result);
-                    return TryParseByName(enumType, value, ignoreCase, throwOnFailure, out Unsafe.As<TUnderlying, TStorage>(ref result));
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return TryParseByName(enumType, value, ignoreCase, throwOnFailure, out Unsafe.As<TUnderlying, TStorage>(ref result));
+                    }
                 }
 
                 if (throwOnFailure)
@@ -993,7 +1119,11 @@ namespace System
                 if (!char.IsAsciiDigit(c) && c != '-' && c != '+')
                 {
                     Unsafe.SkipInit(out result);
-                    return TryParseByName(enumType, value, ignoreCase, throwOnFailure, out Unsafe.As<TUnderlying, TStorage>(ref result));
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return TryParseByName(enumType, value, ignoreCase, throwOnFailure, out Unsafe.As<TUnderlying, TStorage>(ref result));
+                    }
                 }
 
 #if RARE_ENUMS
@@ -1017,7 +1147,11 @@ namespace System
                 if (status != Number.ParsingStatus.Overflow)
                 {
                     Unsafe.SkipInit(out result);
-                    return TryParseByName(enumType, value, ignoreCase, throwOnFailure, out Unsafe.As<TUnderlying, TStorage>(ref result));
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return TryParseByName(enumType, value, ignoreCase, throwOnFailure, out Unsafe.As<TUnderlying, TStorage>(ref result));
+                    }
                 }
 
                 if (throwOnFailure)
@@ -1164,7 +1298,10 @@ namespace System
         internal object GetValue()
         {
             ref byte data = ref this.GetRawData();
-            return InternalGetCorElementType() switch
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return InternalGetCorElementType() switch
             {
                 CorElementType.ELEMENT_TYPE_I1 => Unsafe.As<byte, sbyte>(ref data),
                 CorElementType.ELEMENT_TYPE_U1 => data,
@@ -1184,6 +1321,7 @@ namespace System
 #endif
                 _ => throw CreateUnknownEnumTypeException(),
             };
+            }
         }
 
         /// <inheritdoc/>
@@ -1210,15 +1348,27 @@ namespace System
 
                 case CorElementType.ELEMENT_TYPE_I2:
                 case CorElementType.ELEMENT_TYPE_U2:
-                    return Unsafe.As<byte, ushort>(ref pThisValue) == Unsafe.As<byte, ushort>(ref pOtherValue);
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return Unsafe.As<byte, ushort>(ref pThisValue) == Unsafe.As<byte, ushort>(ref pOtherValue);
+                    }
 
                 case CorElementType.ELEMENT_TYPE_I4:
                 case CorElementType.ELEMENT_TYPE_U4:
-                    return Unsafe.As<byte, uint>(ref pThisValue) == Unsafe.As<byte, uint>(ref pOtherValue);
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return Unsafe.As<byte, uint>(ref pThisValue) == Unsafe.As<byte, uint>(ref pOtherValue);
+                    }
 
                 case CorElementType.ELEMENT_TYPE_I8:
                 case CorElementType.ELEMENT_TYPE_U8:
-                    return Unsafe.As<byte, ulong>(ref pThisValue) == Unsafe.As<byte, ulong>(ref pOtherValue);
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return Unsafe.As<byte, ulong>(ref pThisValue) == Unsafe.As<byte, ulong>(ref pOtherValue);
+                    }
 
 #if RARE_ENUMS
                 case CorElementType.ELEMENT_TYPE_BOOLEAN:
@@ -1255,7 +1405,10 @@ namespace System
             // The runtime can bypass calls to Enum::GetHashCode and call the underlying type's GetHashCode directly
             // to avoid boxing the enum.
             ref byte data = ref this.GetRawData();
-            return InternalGetCorElementType() switch
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return InternalGetCorElementType() switch
             {
                 CorElementType.ELEMENT_TYPE_I1 => Unsafe.As<byte, sbyte>(ref data).GetHashCode(),
                 CorElementType.ELEMENT_TYPE_U1 => data.GetHashCode(),
@@ -1275,6 +1428,7 @@ namespace System
 #endif
                 _ => throw CreateUnknownEnumTypeException(),
             };
+            }
         }
 
         /// <inheritdoc/>
@@ -1295,35 +1449,71 @@ namespace System
             switch (InternalGetCorElementType())
             {
                 case CorElementType.ELEMENT_TYPE_I1:
-                    return Unsafe.As<byte, sbyte>(ref pThisValue).CompareTo(Unsafe.As<byte, sbyte>(ref pTargetValue));
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return Unsafe.As<byte, sbyte>(ref pThisValue).CompareTo(Unsafe.As<byte, sbyte>(ref pTargetValue));
+                    }
 
                 case CorElementType.ELEMENT_TYPE_U1:
                     return pThisValue.CompareTo(pTargetValue);
 
                 case CorElementType.ELEMENT_TYPE_I2:
-                    return Unsafe.As<byte, short>(ref pThisValue).CompareTo(Unsafe.As<byte, short>(ref pTargetValue));
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return Unsafe.As<byte, short>(ref pThisValue).CompareTo(Unsafe.As<byte, short>(ref pTargetValue));
+                    }
 
                 case CorElementType.ELEMENT_TYPE_U2:
-                    return Unsafe.As<byte, ushort>(ref pThisValue).CompareTo(Unsafe.As<byte, ushort>(ref pTargetValue));
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return Unsafe.As<byte, ushort>(ref pThisValue).CompareTo(Unsafe.As<byte, ushort>(ref pTargetValue));
+                    }
 
                 case CorElementType.ELEMENT_TYPE_I4:
-                    return Unsafe.As<byte, int>(ref pThisValue).CompareTo(Unsafe.As<byte, int>(ref pTargetValue));
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return Unsafe.As<byte, int>(ref pThisValue).CompareTo(Unsafe.As<byte, int>(ref pTargetValue));
+                    }
 
                 case CorElementType.ELEMENT_TYPE_U4:
-                    return Unsafe.As<byte, uint>(ref pThisValue).CompareTo(Unsafe.As<byte, uint>(ref pTargetValue));
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return Unsafe.As<byte, uint>(ref pThisValue).CompareTo(Unsafe.As<byte, uint>(ref pTargetValue));
+                    }
 
                 case CorElementType.ELEMENT_TYPE_I8:
-                    return Unsafe.As<byte, long>(ref pThisValue).CompareTo(Unsafe.As<byte, long>(ref pTargetValue));
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return Unsafe.As<byte, long>(ref pThisValue).CompareTo(Unsafe.As<byte, long>(ref pTargetValue));
+                    }
 
                 case CorElementType.ELEMENT_TYPE_U8:
-                    return Unsafe.As<byte, ulong>(ref pThisValue).CompareTo(Unsafe.As<byte, ulong>(ref pTargetValue));
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return Unsafe.As<byte, ulong>(ref pThisValue).CompareTo(Unsafe.As<byte, ulong>(ref pTargetValue));
+                    }
 
 #if RARE_ENUMS
                 case CorElementType.ELEMENT_TYPE_R4:
-                    return Unsafe.As<byte, float>(ref pThisValue).CompareTo(Unsafe.As<byte, float>(ref pTargetValue));
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return Unsafe.As<byte, float>(ref pThisValue).CompareTo(Unsafe.As<byte, float>(ref pTargetValue));
+                    }
 
                 case CorElementType.ELEMENT_TYPE_R8:
-                    return Unsafe.As<byte, double>(ref pThisValue).CompareTo(Unsafe.As<byte, double>(ref pTargetValue));
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return Unsafe.As<byte, double>(ref pThisValue).CompareTo(Unsafe.As<byte, double>(ref pTargetValue));
+                    }
 
                 case CorElementType.ELEMENT_TYPE_BOOLEAN:
                     goto case CorElementType.ELEMENT_TYPE_U1;
@@ -1467,7 +1657,12 @@ namespace System
         {
             AssertValidGenerics<TUnderlying, TStorage>();
 
-            TStorage value = Unsafe.As<byte, TStorage>(ref rawData);
+            TStorage value;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                value = Unsafe.As<byte, TStorage>(ref rawData);
+            }
 
             EnumInfo<TStorage> enumInfo = GetEnumInfo<TStorage>(enumType);
             string? result = enumInfo.HasFlagsAttribute ?
@@ -1497,7 +1692,12 @@ namespace System
         {
             AssertValidGenerics<TUnderlying, TStorage>();
 
-            TStorage value = Unsafe.As<byte, TStorage>(ref rawData);
+            TStorage value;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                value = Unsafe.As<byte, TStorage>(ref rawData);
+            }
 
             string? result;
             switch (format | 0x20)
@@ -1693,7 +1893,10 @@ namespace System
 
             if (format.IsEmpty)
             {
-                return corElementType switch
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return corElementType switch
                 {
                     CorElementType.ELEMENT_TYPE_I1 => TryFormatPrimitiveDefault<sbyte, byte>(enumType, (sbyte)rawData, destination, out charsWritten),
                     CorElementType.ELEMENT_TYPE_U1 => TryFormatPrimitiveDefault<byte, byte>(enumType, rawData, destination, out charsWritten),
@@ -1712,10 +1915,14 @@ namespace System
 #endif
                     _ => throw CreateUnknownEnumTypeException(),
                 };
+                }
             }
             else
             {
-                return corElementType switch
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return corElementType switch
                 {
                     CorElementType.ELEMENT_TYPE_I1 => TryFormatPrimitiveNonDefault<sbyte, byte>(enumType, (sbyte)rawData, destination, out charsWritten, format),
                     CorElementType.ELEMENT_TYPE_U1 => TryFormatPrimitiveNonDefault<byte, byte>(enumType, rawData, destination, out charsWritten, format),
@@ -1734,6 +1941,7 @@ namespace System
 #endif
                     _ => throw CreateUnknownEnumTypeException(),
                 };
+                }
             }
         }
 
@@ -1908,7 +2116,11 @@ namespace System
                         return value.TryFormat(destination, out charsWritten, format: default, provider: null);
 
                     case 'x':
-                        return TryFormatNumberAsHex<TStorage>(ref Unsafe.As<TUnderlying, byte>(ref value), destination, out charsWritten);
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            return TryFormatNumberAsHex<TStorage>(ref Unsafe.As<TUnderlying, byte>(ref value), destination, out charsWritten);
+                        }
 
                     case 'f':
                         bool destinationIsTooSmall = false;

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CharUnicodeInfo.cs
@@ -280,14 +280,18 @@ namespace System.Globalization
         internal static char ToUpper(char codePoint)
         {
             nuint offset = GetCategoryCasingTableOffsetNoBoundsChecks((uint)codePoint);
+            // TODO(unsafe): Baselining unsafe usage
 
             // The offset is specified in shorts:
             // Get the 'ref short' corresponding to where the addend is, read it as a signed 16-bit value, then add
 
-            ref short rsStart = ref Unsafe.As<byte, short>(ref MemoryMarshal.GetReference(UppercaseValues));
-            ref short rsDelta = ref Unsafe.Add(ref rsStart, (nint)offset);
-            int delta = (BitConverter.IsLittleEndian) ? rsDelta : BinaryPrimitives.ReverseEndianness(rsDelta);
-            return (char)(delta + codePoint);
+            unsafe
+            {
+                ref short rsStart = ref Unsafe.As<byte, short>(ref MemoryMarshal.GetReference(UppercaseValues));
+                ref short rsDelta = ref Unsafe.Add(ref rsStart, (nint)offset);
+                int delta = (BitConverter.IsLittleEndian) ? rsDelta : BinaryPrimitives.ReverseEndianness(rsDelta);
+                return (char)(delta + codePoint);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -299,30 +303,36 @@ namespace System.Globalization
             }
 
             nuint offset = GetCategoryCasingTableOffsetNoBoundsChecks(codePoint);
+            // TODO(unsafe): Baselining unsafe usage
 
             // The mapped casing for the codePoint usually exists in the same plane as codePoint.
             // This is why we use 16-bit offsets to calculate the delta value from the codePoint.
 
-            ref ushort rsStart = ref Unsafe.As<byte, ushort>(ref MemoryMarshal.GetReference(UppercaseValues));
-            ref ushort rsDelta = ref Unsafe.Add(ref rsStart, (nint)offset);
-            int delta = (BitConverter.IsLittleEndian) ? rsDelta : BinaryPrimitives.ReverseEndianness(rsDelta);
-
-            // We use the mask 0xFFFF0000u as we are sure the casing is in the same plane as codePoint.
-            return (codePoint & 0xFFFF0000u) | (ushort)((uint)delta + codePoint);
+            unsafe
+            {
+                ref ushort rsStart = ref Unsafe.As<byte, ushort>(ref MemoryMarshal.GetReference(UppercaseValues));
+                ref ushort rsDelta = ref Unsafe.Add(ref rsStart, (nint)offset);
+                int delta = (BitConverter.IsLittleEndian) ? rsDelta : BinaryPrimitives.ReverseEndianness(rsDelta);
+                return (codePoint & 0xFFFF0000u) | (ushort)((uint)delta + codePoint);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static char ToLower(char codePoint)
         {
             nuint offset = GetCategoryCasingTableOffsetNoBoundsChecks((uint)codePoint);
+            // TODO(unsafe): Baselining unsafe usage
 
             // The offset is specified in shorts:
             // Get the 'ref short' corresponding to where the addend is, read it as a signed 16-bit value, then add
 
-            ref short rsStart = ref Unsafe.As<byte, short>(ref MemoryMarshal.GetReference(LowercaseValues));
-            ref short rsDelta = ref Unsafe.Add(ref rsStart, (nint)offset);
-            int delta = (BitConverter.IsLittleEndian) ? rsDelta : BinaryPrimitives.ReverseEndianness(rsDelta);
-            return (char)(delta + codePoint);
+            unsafe
+            {
+                ref short rsStart = ref Unsafe.As<byte, short>(ref MemoryMarshal.GetReference(LowercaseValues));
+                ref short rsDelta = ref Unsafe.Add(ref rsStart, (nint)offset);
+                int delta = (BitConverter.IsLittleEndian) ? rsDelta : BinaryPrimitives.ReverseEndianness(rsDelta);
+                return (char)(delta + codePoint);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -334,16 +344,18 @@ namespace System.Globalization
             }
 
             nuint offset = GetCategoryCasingTableOffsetNoBoundsChecks(codePoint);
+            // TODO(unsafe): Baselining unsafe usage
 
             // The mapped casing for the codePoint usually exists in the same plane as codePoint.
             // This is why we use 16-bit offsets to calculate the delta value from the codePoint.
 
-            ref ushort rsStart = ref Unsafe.As<byte, ushort>(ref MemoryMarshal.GetReference(LowercaseValues));
-            ref ushort rsDelta = ref Unsafe.Add(ref rsStart, (nint)offset);
-            int delta = (BitConverter.IsLittleEndian) ? rsDelta : BinaryPrimitives.ReverseEndianness(rsDelta);
-
-            // We use the mask 0xFFFF0000u as we are sure the casing is in the same plane as codePoint.
-            return (codePoint & 0xFFFF0000u) | (ushort)((uint)delta + codePoint);
+            unsafe
+            {
+                ref ushort rsStart = ref Unsafe.As<byte, ushort>(ref MemoryMarshal.GetReference(LowercaseValues));
+                ref ushort rsDelta = ref Unsafe.Add(ref rsStart, (nint)offset);
+                int delta = (BitConverter.IsLittleEndian) ? rsDelta : BinaryPrimitives.ReverseEndianness(rsDelta);
+                return (codePoint & 0xFFFF0000u) | (ushort)((uint)delta + codePoint);
+            }
         }
 
         /*

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/Ordinal.cs
@@ -93,8 +93,16 @@ namespace System.Globalization
             TVector vecZMinusA = TVector.Create('z' - 'a');
             do
             {
-                vec1 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charA), i);
-                vec2 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charB), i);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    vec1 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charA), i);
+                }
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    vec2 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charB), i);
+                }
 
                 if (!Utf16Utility.AllCharsInVectorAreAscii(vec1 | vec2))
                 {
@@ -120,8 +128,16 @@ namespace System.Globalization
             if (i != lengthU)
             {
                 i = lengthU - (nuint)TVector.ElementCount;
-                vec1 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charA), i);
-                vec2 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charB), i);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    vec1 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charA), i);
+                }
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    vec2 = TVector.LoadUnsafe(ref Unsafe.As<char, ushort>(ref charB), i);
+                }
 
                 if (!Utf16Utility.AllCharsInVectorAreAscii(vec1 | vec2))
                 {
@@ -184,8 +200,16 @@ namespace System.Globalization
             // Read 4 chars (64 bits) at a time from each string
             while ((uint)length >= 4)
             {
-                valueAu64 = Unsafe.ReadUnaligned<ulong>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charA, byteOffset)));
-                valueBu64 = Unsafe.ReadUnaligned<ulong>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charB, byteOffset)));
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    valueAu64 = Unsafe.ReadUnaligned<ulong>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charA, byteOffset)));
+                }
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    valueBu64 = Unsafe.ReadUnaligned<ulong>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charB, byteOffset)));
+                }
 
                 // A 32-bit test - even with the bit-twiddling here - is more efficient than a 64-bit test.
                 ulong temp = valueAu64 | valueBu64;
@@ -219,8 +243,16 @@ namespace System.Globalization
             while ((uint)length >= 2)
 #endif
             {
-                valueAu32 = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charA, byteOffset)));
-                valueBu32 = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charB, byteOffset)));
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    valueAu32 = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charA, byteOffset)));
+                }
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    valueBu32 = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref charB, byteOffset)));
+                }
 
                 if (!Utf16Utility.AllCharsInUInt32AreAscii(valueAu32 | valueBu32))
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Guid.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Guid.cs
@@ -245,7 +245,11 @@ namespace System
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public readonly Guid ToGuid()
             {
-                return Unsafe.As<GuidResult, Guid>(ref Unsafe.AsRef(in this));
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return Unsafe.As<GuidResult, Guid>(ref Unsafe.AsRef(in this));
+                }
             }
 
             public void ReverseAbcEndianness()

--- a/src/libraries/System.Private.CoreLib/src/System/IO/BinaryReader.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/BinaryReader.cs
@@ -357,7 +357,12 @@ namespace System.IO
                 if (_isMemoryStream)
                 {
                     Debug.Assert(_stream is MemoryStream);
-                    MemoryStream mStream = Unsafe.As<MemoryStream>(_stream);
+                    MemoryStream mStream;
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        mStream = Unsafe.As<MemoryStream>(_stream);
+                    }
 
                     int position = mStream.InternalGetPosition();
                     numBytes = mStream.InternalEmulateRead(numBytes);
@@ -477,7 +482,11 @@ namespace System.IO
             {
                 // read directly from MemoryStream buffer
                 Debug.Assert(_stream is MemoryStream);
-                return Unsafe.As<MemoryStream>(_stream).InternalReadSpan(buffer.Length);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return Unsafe.As<MemoryStream>(_stream).InternalReadSpan(buffer.Length);
+                }
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IntPtr.cs
@@ -243,26 +243,42 @@ namespace System
         public static bool TryParse([NotNullWhen(true)] string? s, out nint result)
         {
             Unsafe.SkipInit(out result);
-            return nint_t.TryParse(s, out Unsafe.As<nint, nint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nint_t.TryParse(s, out Unsafe.As<nint, nint_t>(ref result));
+            }
         }
 
         /// <inheritdoc cref="IParsable{TSelf}.TryParse(string?, IFormatProvider?, out TSelf)" />
         public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out nint result)
         {
             Unsafe.SkipInit(out result);
-            return nint_t.TryParse(s, provider, out Unsafe.As<nint, nint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nint_t.TryParse(s, provider, out Unsafe.As<nint, nint_t>(ref result));
+            }
         }
 
         public static bool TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out nint result)
         {
             Unsafe.SkipInit(out result);
-            return nint_t.TryParse(s, style, provider, out Unsafe.As<nint, nint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nint_t.TryParse(s, style, provider, out Unsafe.As<nint, nint_t>(ref result));
+            }
         }
 
         public static bool TryParse(ReadOnlySpan<char> s, out nint result)
         {
             Unsafe.SkipInit(out result);
-            return nint_t.TryParse(s, out Unsafe.As<nint, nint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nint_t.TryParse(s, out Unsafe.As<nint, nint_t>(ref result));
+            }
         }
 
         /// <summary>Tries to convert a UTF-8 character span containing the string representation of a number to its signed integer equivalent.</summary>
@@ -272,7 +288,11 @@ namespace System
         public static bool TryParse(ReadOnlySpan<byte> utf8Text, out nint result)
         {
             Unsafe.SkipInit(out result);
-            return nint_t.TryParse(utf8Text, out Unsafe.As<nint, nint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nint_t.TryParse(utf8Text, out Unsafe.As<nint, nint_t>(ref result));
+            }
         }
 
         /// <summary>Tries to parse a string into a value.</summary>
@@ -283,13 +303,21 @@ namespace System
         public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out nint result)
         {
             Unsafe.SkipInit(out result);
-            return nint_t.TryParse(s, provider, out Unsafe.As<nint, nint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nint_t.TryParse(s, provider, out Unsafe.As<nint, nint_t>(ref result));
+            }
         }
 
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out nint result)
         {
             Unsafe.SkipInit(out result);
-            return nint_t.TryParse(s, style, provider, out Unsafe.As<nint, nint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nint_t.TryParse(s, style, provider, out Unsafe.As<nint, nint_t>(ref result));
+            }
         }
 
         //
@@ -1434,7 +1462,11 @@ namespace System
         public static bool TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles style, IFormatProvider? provider, out nint result)
         {
             Unsafe.SkipInit(out result);
-            return nint_t.TryParse(utf8Text, style, provider, out Unsafe.As<nint, nint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nint_t.TryParse(utf8Text, style, provider, out Unsafe.As<nint, nint_t>(ref result));
+            }
         }
 
         /// <inheritdoc cref="IUtf8SpanParsable{TSelf}.Parse(ReadOnlySpan{byte}, IFormatProvider?)" />
@@ -1444,7 +1476,11 @@ namespace System
         public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out nint result)
         {
             Unsafe.SkipInit(out result);
-            return nint_t.TryParse(utf8Text, provider, out Unsafe.As<nint, nint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nint_t.TryParse(utf8Text, provider, out Unsafe.As<nint, nint_t>(ref result));
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Marvin.OrdinalIgnoreCase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Marvin.OrdinalIgnoreCase.cs
@@ -25,7 +25,11 @@ namespace System
 
             while (ucount >= 2)
             {
-                tempValue = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref data, byteOffset)));
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    tempValue = Unsafe.ReadUnaligned<uint>(ref Unsafe.As<char, byte>(ref Unsafe.AddByteOffset(ref data, byteOffset)));
+                }
                 if (!Utf16Utility.AllCharsInUInt32AreAscii(tempValue))
                 {
                     goto NotAscii;
@@ -90,7 +94,12 @@ namespace System
 
             // Slice the array to the size returned by ToUpperInvariant.
             // Multiplication below will not overflow since going from positive Int32 to UInt32.
-            int hash = ComputeHash32(ref Unsafe.As<char, byte>(ref MemoryMarshal.GetReference(scratch)), (uint)charsWritten * 2, p0, p1);
+            int hash;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                hash = ComputeHash32(ref Unsafe.As<char, byte>(ref MemoryMarshal.GetReference(scratch)), (uint)charsWritten * 2, p0, p1);
+            }
 
             // Return the borrowed array if necessary.
             if (borrowedArr != null)

--- a/src/libraries/System.Private.CoreLib/src/System/Memory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Memory.cs
@@ -282,10 +282,18 @@ namespace System
                 {
                     if (typeof(T) == typeof(char) && tmpObject.GetType() == typeof(string))
                     {
+                        // TODO(unsafe): Baselining unsafe usage
                         // Special-case string since it's the most common for ROM<char>.
 
-                        refToReturn = ref Unsafe.As<char, T>(ref ((string)tmpObject).GetRawStringData());
-                        lengthOfUnderlyingSpan = Unsafe.As<string>(tmpObject).Length;
+                        unsafe
+                        {
+                            refToReturn = ref Unsafe.As<char, T>(ref ((string)tmpObject).GetRawStringData());
+                        }
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            lengthOfUnderlyingSpan = Unsafe.As<string>(tmpObject).Length;
+                        }
                     }
                     else if (RuntimeHelpers.ObjectHasComponentSize(tmpObject))
                     {
@@ -300,9 +308,17 @@ namespace System
 
                         // 'tmpObject is T[]' below also handles things like int[] <-> uint[] being convertible
                         Debug.Assert(tmpObject is T[]);
+                        // TODO(unsafe): Baselining unsafe usage
 
-                        refToReturn = ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(tmpObject));
-                        lengthOfUnderlyingSpan = Unsafe.As<T[]>(tmpObject).Length;
+                        unsafe
+                        {
+                            refToReturn = ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(tmpObject));
+                        }
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            lengthOfUnderlyingSpan = Unsafe.As<T[]>(tmpObject).Length;
+                        }
                     }
                     else
                     {
@@ -313,7 +329,12 @@ namespace System
                         // constructor or other public API which would allow such a conversion.
 
                         Debug.Assert(tmpObject is MemoryManager<T>);
-                        Span<T> memoryManagerSpan = Unsafe.As<MemoryManager<T>>(tmpObject).GetSpan();
+                        Span<T> memoryManagerSpan;
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            memoryManagerSpan = Unsafe.As<MemoryManager<T>>(tmpObject).GetSpan();
+                        }
                         refToReturn = ref MemoryMarshal.GetReference(memoryManagerSpan);
                         lengthOfUnderlyingSpan = memoryManagerSpan.Length;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/MemoryExtensions.cs
@@ -1926,38 +1926,54 @@ namespace System
             {
                 if (lowInclusive is byte or sbyte)
                 {
-                    return SpanHelpers.IndexOfAnyInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.IndexOfAnyInRangeUnsignedNumber(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, byte>(lowInclusive),
                         Unsafe.BitCast<T, byte>(highInclusive),
                         span.Length);
+                    }
                 }
 
                 if (lowInclusive is short or ushort or char)
                 {
-                    return SpanHelpers.IndexOfAnyInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.IndexOfAnyInRangeUnsignedNumber(
                         ref Unsafe.As<T, ushort>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, ushort>(lowInclusive),
                         Unsafe.BitCast<T, ushort>(highInclusive),
                         span.Length);
+                    }
                 }
 
                 if (lowInclusive is int or uint || (IntPtr.Size == 4 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.IndexOfAnyInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.IndexOfAnyInRangeUnsignedNumber(
                         ref Unsafe.As<T, uint>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, uint>(lowInclusive),
                         Unsafe.BitCast<T, uint>(highInclusive),
                         span.Length);
+                    }
                 }
 
                 if (lowInclusive is long or ulong || (IntPtr.Size == 8 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.IndexOfAnyInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.IndexOfAnyInRangeUnsignedNumber(
                         ref Unsafe.As<T, ulong>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, ulong>(lowInclusive),
                         Unsafe.BitCast<T, ulong>(highInclusive),
                         span.Length);
+                    }
                 }
             }
 
@@ -1997,38 +2013,54 @@ namespace System
             {
                 if (lowInclusive is byte or sbyte)
                 {
-                    return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, byte>(lowInclusive),
                         Unsafe.BitCast<T, byte>(highInclusive),
                         span.Length);
+                    }
                 }
 
                 if (lowInclusive is short or ushort or char)
                 {
-                    return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber(
                         ref Unsafe.As<T, ushort>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, ushort>(lowInclusive),
                         Unsafe.BitCast<T, ushort>(highInclusive),
                         span.Length);
+                    }
                 }
 
                 if (lowInclusive is int or uint || (IntPtr.Size == 4 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber(
                         ref Unsafe.As<T, uint>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, uint>(lowInclusive),
                         Unsafe.BitCast<T, uint>(highInclusive),
                         span.Length);
+                    }
                 }
 
                 if (lowInclusive is long or ulong || (IntPtr.Size == 8 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.IndexOfAnyExceptInRangeUnsignedNumber(
                         ref Unsafe.As<T, ulong>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, ulong>(lowInclusive),
                         Unsafe.BitCast<T, ulong>(highInclusive),
                         span.Length);
+                    }
                 }
             }
 
@@ -2068,38 +2100,54 @@ namespace System
             {
                 if (lowInclusive is byte or sbyte)
                 {
-                    return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, byte>(lowInclusive),
                         Unsafe.BitCast<T, byte>(highInclusive),
                         span.Length);
+                    }
                 }
 
                 if (lowInclusive is short or ushort or char)
                 {
-                    return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber(
                         ref Unsafe.As<T, ushort>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, ushort>(lowInclusive),
                         Unsafe.BitCast<T, ushort>(highInclusive),
                         span.Length);
+                    }
                 }
 
                 if (lowInclusive is int or uint || (IntPtr.Size == 4 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber(
                         ref Unsafe.As<T, uint>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, uint>(lowInclusive),
                         Unsafe.BitCast<T, uint>(highInclusive),
                         span.Length);
+                    }
                 }
 
                 if (lowInclusive is long or ulong || (IntPtr.Size == 8 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.LastIndexOfAnyInRangeUnsignedNumber(
                         ref Unsafe.As<T, ulong>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, ulong>(lowInclusive),
                         Unsafe.BitCast<T, ulong>(highInclusive),
                         span.Length);
+                    }
                 }
             }
 
@@ -2139,38 +2187,54 @@ namespace System
             {
                 if (lowInclusive is byte or sbyte)
                 {
-                    return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber(
                         ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, byte>(lowInclusive),
                         Unsafe.BitCast<T, byte>(highInclusive),
                         span.Length);
+                    }
                 }
 
                 if (lowInclusive is short or ushort or char)
                 {
-                    return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber(
                         ref Unsafe.As<T, ushort>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, ushort>(lowInclusive),
                         Unsafe.BitCast<T, ushort>(highInclusive),
                         span.Length);
+                    }
                 }
 
                 if (lowInclusive is int or uint || (IntPtr.Size == 4 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber(
                         ref Unsafe.As<T, uint>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, uint>(lowInclusive),
                         Unsafe.BitCast<T, uint>(highInclusive),
                         span.Length);
+                    }
                 }
 
                 if (lowInclusive is long or ulong || (IntPtr.Size == 8 && (lowInclusive is nint or nuint)))
                 {
-                    return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber(
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return SpanHelpers.LastIndexOfAnyExceptInRangeUnsignedNumber(
                         ref Unsafe.As<T, ulong>(ref MemoryMarshal.GetReference(span)),
                         Unsafe.BitCast<T, ulong>(lowInclusive),
                         Unsafe.BitCast<T, ulong>(highInclusive),
                         span.Length);
+                    }
                 }
             }
 
@@ -3536,18 +3600,30 @@ namespace System
             // equality checks, not about CompareTo checks.
 
             if (typeof(T) == typeof(byte))
-                return SpanHelpers.SequenceCompareTo(
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return SpanHelpers.SequenceCompareTo(
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(span)),
                     span.Length,
                     ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(other)),
                     other.Length);
+                }
+            }
 
             if (typeof(T) == typeof(char))
-                return SpanHelpers.SequenceCompareTo(
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return SpanHelpers.SequenceCompareTo(
                     ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(span)),
                     span.Length,
                     ref Unsafe.As<T, char>(ref MemoryMarshal.GetReference(other)),
                     other.Length);
+                }
+            }
 
             return SpanHelpers.SequenceCompareTo(ref MemoryMarshal.GetReference(span), span.Length, ref MemoryMarshal.GetReference(other), other.Length);
         }
@@ -5926,7 +6002,11 @@ namespace System
                 _source = source;
                 if (typeof(T) == typeof(char) && separators.Length == 0)
                 {
-                    _searchValues = Unsafe.As<SearchValues<T>>(string.SearchValuesStorage.WhiteSpaceChars);
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        _searchValues = Unsafe.As<SearchValues<T>>(string.SearchValuesStorage.WhiteSpaceChars);
+                    }
                     _splitMode = SpanSplitEnumeratorMode.SearchValues;
                 }
                 else

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix3x2.Impl.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix3x2.Impl.cs
@@ -17,17 +17,38 @@ namespace System.Numerics
 
         [UnscopedRef]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ref Impl AsImpl() => ref Unsafe.As<Matrix3x2, Impl>(ref this);
+        internal ref Impl AsImpl()
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return ref Unsafe.As<Matrix3x2, Impl>(ref this);
+            }
+        }
 
         [UnscopedRef]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly ref readonly Impl AsROImpl() => ref Unsafe.As<Matrix3x2, Impl>(ref Unsafe.AsRef(in this));
+        internal readonly ref readonly Impl AsROImpl()
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return ref Unsafe.As<Matrix3x2, Impl>(ref Unsafe.AsRef(in this));
+            }
+        }
 
         internal struct Impl : IEquatable<Impl>
         {
             [UnscopedRef]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public ref Matrix3x2 AsM3x2() => ref Unsafe.As<Impl, Matrix3x2>(ref this);
+            public ref Matrix3x2 AsM3x2()
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return ref Unsafe.As<Impl, Matrix3x2>(ref this);
+                }
+            }
 
             private const float RotationEpsilon = 0.001f * float.Pi / 180f;     // 0.1% of a degree
 

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.Impl.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Matrix4x4.Impl.cs
@@ -20,17 +20,38 @@ namespace System.Numerics
 
         [UnscopedRef]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal ref Impl AsImpl() => ref Unsafe.As<Matrix4x4, Impl>(ref this);
+        internal ref Impl AsImpl()
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return ref Unsafe.As<Matrix4x4, Impl>(ref this);
+            }
+        }
 
         [UnscopedRef]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal readonly ref readonly Impl AsROImpl() => ref Unsafe.As<Matrix4x4, Impl>(ref Unsafe.AsRef(in this));
+        internal readonly ref readonly Impl AsROImpl()
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return ref Unsafe.As<Matrix4x4, Impl>(ref Unsafe.AsRef(in this));
+            }
+        }
 
         internal struct Impl : IEquatable<Impl>
         {
             [UnscopedRef]
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public ref Matrix4x4 AsM4x4() => ref Unsafe.As<Impl, Matrix4x4>(ref this);
+            public ref Matrix4x4 AsM4x4()
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return ref Unsafe.As<Impl, Matrix4x4>(ref this);
+                }
+            }
 
             private const float BillboardEpsilon = 1e-4f;
             private const float BillboardMinAngle = 1.0f - (0.1f * (float.Pi / 180.0f)); // 0.1 degrees

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector.cs
@@ -834,7 +834,11 @@ namespace System.Numerics
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.values);
             }
-            return Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector{T}" /> instance with the first element initialized to the specified value and the remaining elements initialized to zero.</summary>
@@ -1983,8 +1987,12 @@ namespace System.Numerics
         public static Vector<T> LoadUnsafe<T>(ref readonly T source)
         {
             ThrowHelper.ThrowForUnsupportedNumericsVectorBaseType<T>();
-            ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.AsRef(in source));
-            return Unsafe.ReadUnaligned<Vector<T>>(in address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.AsRef(in source));
+                return Unsafe.ReadUnaligned<Vector<T>>(in address);
+            }
         }
 
         /// <summary>Loads a vector from the given source and element offset.</summary>
@@ -1999,8 +2007,12 @@ namespace System.Numerics
         public static Vector<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset)
         {
             ThrowHelper.ThrowForUnsupportedNumericsVectorBaseType<T>();
-            ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.Add(ref Unsafe.AsRef(in source), (nint)elementOffset));
-            return Unsafe.ReadUnaligned<Vector<T>>(in address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.Add(ref Unsafe.AsRef(in source), (nint)elementOffset));
+                return Unsafe.ReadUnaligned<Vector<T>>(in address);
+            }
         }
 
         internal static Vector<T> Log<T>(Vector<T> vector)
@@ -3029,8 +3041,12 @@ namespace System.Numerics
         public static void StoreUnsafe<T>(this Vector<T> source, ref T destination)
         {
             ThrowHelper.ThrowForUnsupportedNumericsVectorBaseType<T>();
-            ref byte address = ref Unsafe.As<T, byte>(ref destination);
-            Unsafe.WriteUnaligned(ref address, source);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref byte address = ref Unsafe.As<T, byte>(ref destination);
+                Unsafe.WriteUnaligned(ref address, source);
+            }
         }
 
         /// <summary>Stores a vector at the given destination.</summary>
@@ -3046,7 +3062,11 @@ namespace System.Numerics
         {
             ThrowHelper.ThrowForUnsupportedNumericsVectorBaseType<T>();
             destination = ref Unsafe.Add(ref destination, (nint)elementOffset);
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination), source);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination), source);
+            }
         }
 
         /// <inheritdoc cref="Vector128.Subtract{T}(Vector128{T}, Vector128{T})" />
@@ -3560,16 +3580,24 @@ namespace System.Numerics
         internal static T GetElementUnsafe<T>(in this Vector<T> vector, int index)
         {
             Debug.Assert((index >= 0) && (index < Vector<T>.Count));
-            ref T address = ref Unsafe.As<Vector<T>, T>(ref Unsafe.AsRef(in vector));
-            return Unsafe.Add(ref address, index);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref T address = ref Unsafe.As<Vector<T>, T>(ref Unsafe.AsRef(in vector));
+                return Unsafe.Add(ref address, index);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void SetElementUnsafe<T>(in this Vector<T> vector, int index, T value)
         {
             Debug.Assert((index >= 0) && (index < Vector<T>.Count));
-            ref T address = ref Unsafe.As<Vector<T>, T>(ref Unsafe.AsRef(in vector));
-            Unsafe.Add(ref address, index) = value;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref T address = ref Unsafe.As<Vector<T>, T>(ref Unsafe.AsRef(in vector));
+                Unsafe.Add(ref address, index) = value;
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector2.cs
@@ -408,7 +408,11 @@ namespace System.Numerics
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.values);
             }
-            return Unsafe.ReadUnaligned<Vector2>(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(values)));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector2>(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(values)));
+            }
         }
 
         /// <summary>Creates a vector with <see cref="X" /> initialized to the specified value and the remaining elements initialized to zero.</summary>
@@ -701,8 +705,12 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 LoadUnsafe(ref readonly float source)
         {
-            ref readonly byte address = ref Unsafe.As<float, byte>(ref Unsafe.AsRef(in source));
-            return Unsafe.ReadUnaligned<Vector2>(in address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref readonly byte address = ref Unsafe.As<float, byte>(ref Unsafe.AsRef(in source));
+                return Unsafe.ReadUnaligned<Vector2>(in address);
+            }
         }
 
         /// <inheritdoc cref="Vector4.LoadUnsafe(ref readonly float, nuint)" />
@@ -711,8 +719,12 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 LoadUnsafe(ref readonly float source, nuint elementOffset)
         {
-            ref readonly byte address = ref Unsafe.As<float, byte>(ref Unsafe.Add(ref Unsafe.AsRef(in source), (nint)elementOffset));
-            return Unsafe.ReadUnaligned<Vector2>(in address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref readonly byte address = ref Unsafe.As<float, byte>(ref Unsafe.Add(ref Unsafe.AsRef(in source), (nint)elementOffset));
+                return Unsafe.ReadUnaligned<Vector2>(in address);
+            }
         }
 
         /// <inheritdoc cref="Vector4.Log(Vector4)" />
@@ -970,8 +982,12 @@ namespace System.Numerics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref array[0]), this);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref array[0]), this);
+            }
         }
 
         /// <summary>Copies the elements of the vector to a specified array starting at a specified index position.</summary>
@@ -998,8 +1014,12 @@ namespace System.Numerics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref array[index]), this);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref array[index]), this);
+            }
         }
 
         /// <summary>Copies the vector to the given <see cref="Span{T}" />.The length of the destination span must be at least 2.</summary>
@@ -1012,8 +1032,12 @@ namespace System.Numerics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(destination)), this);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(destination)), this);
+            }
         }
 
         /// <summary>Attempts to copy the vector to the given <see cref="Span{Single}" />. The length of the destination span must be at least 2.</summary>
@@ -1026,8 +1050,12 @@ namespace System.Numerics
             {
                 return false;
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(destination)), this);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(destination)), this);
+            }
             return true;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/Vector3.cs
@@ -443,7 +443,11 @@ namespace System.Numerics
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.values);
             }
-            return Unsafe.ReadUnaligned<Vector3>(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(values)));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector3>(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(values)));
+            }
         }
 
         /// <summary>Creates a vector with <see cref="X" /> initialized to the specified value and the remaining elements initialized to zero.</summary>
@@ -731,8 +735,12 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector3 LoadUnsafe(ref readonly float source)
         {
-            ref readonly byte address = ref Unsafe.As<float, byte>(ref Unsafe.AsRef(in source));
-            return Unsafe.ReadUnaligned<Vector3>(in address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref readonly byte address = ref Unsafe.As<float, byte>(ref Unsafe.AsRef(in source));
+                return Unsafe.ReadUnaligned<Vector3>(in address);
+            }
         }
 
         /// <inheritdoc cref="Vector4.LoadUnsafe(ref readonly float, nuint)" />
@@ -741,8 +749,12 @@ namespace System.Numerics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector3 LoadUnsafe(ref readonly float source, nuint elementOffset)
         {
-            ref readonly byte address = ref Unsafe.As<float, byte>(ref Unsafe.Add(ref Unsafe.AsRef(in source), (nint)elementOffset));
-            return Unsafe.ReadUnaligned<Vector3>(in address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref readonly byte address = ref Unsafe.As<float, byte>(ref Unsafe.Add(ref Unsafe.AsRef(in source), (nint)elementOffset));
+                return Unsafe.ReadUnaligned<Vector3>(in address);
+            }
         }
 
         /// <inheritdoc cref="Vector4.Log(Vector4)" />
@@ -980,8 +992,12 @@ namespace System.Numerics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref array[0]), this);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref array[0]), this);
+            }
         }
 
         /// <summary>Copies the elements of the vector to a specified array starting at a specified index position.</summary>
@@ -1008,8 +1024,12 @@ namespace System.Numerics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref array[index]), this);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref array[index]), this);
+            }
         }
 
         /// <summary>Copies the vector to the given <see cref="Span{T}" />. The length of the destination span must be at least 3.</summary>
@@ -1022,8 +1042,12 @@ namespace System.Numerics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(destination)), this);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(destination)), this);
+            }
         }
 
         /// <summary>Attempts to copy the vector to the given <see cref="Span{Single}" />. The length of the destination span must be at least 3.</summary>
@@ -1036,8 +1060,12 @@ namespace System.Numerics
             {
                 return false;
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(destination)), this);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref MemoryMarshal.GetReference(destination)), this);
+            }
             return true;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Numerics/VectorDebugView_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Numerics/VectorDebugView_1.cs
@@ -30,7 +30,11 @@ namespace System.Numerics
             get
             {
                 var items = new double[Vector<double>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -40,7 +44,11 @@ namespace System.Numerics
             get
             {
                 var items = new short[Vector<short>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -50,7 +58,11 @@ namespace System.Numerics
             get
             {
                 var items = new int[Vector<int>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -60,7 +72,11 @@ namespace System.Numerics
             get
             {
                 var items = new long[Vector<long>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -70,7 +86,11 @@ namespace System.Numerics
             get
             {
                 var items = new nint[Vector<nint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -80,7 +100,11 @@ namespace System.Numerics
             get
             {
                 var items = new nuint[Vector<nuint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -90,7 +114,11 @@ namespace System.Numerics
             get
             {
                 var items = new sbyte[Vector<sbyte>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -100,7 +128,11 @@ namespace System.Numerics
             get
             {
                 var items = new float[Vector<float>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -110,7 +142,11 @@ namespace System.Numerics
             get
             {
                 var items = new ushort[Vector<ushort>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -120,7 +156,11 @@ namespace System.Numerics
             get
             {
                 var items = new uint[Vector<uint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -130,7 +170,11 @@ namespace System.Numerics
             get
             {
                 var items = new ulong[Vector<ulong>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlyMemory.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlyMemory.cs
@@ -204,10 +204,18 @@ namespace System
                 {
                     if (typeof(T) == typeof(char) && tmpObject.GetType() == typeof(string))
                     {
+                        // TODO(unsafe): Baselining unsafe usage
                         // Special-case string since it's the most common for ROM<char>.
 
-                        refToReturn = ref Unsafe.As<char, T>(ref ((string)tmpObject).GetRawStringData());
-                        lengthOfUnderlyingSpan = Unsafe.As<string>(tmpObject).Length;
+                        unsafe
+                        {
+                            refToReturn = ref Unsafe.As<char, T>(ref ((string)tmpObject).GetRawStringData());
+                        }
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            lengthOfUnderlyingSpan = Unsafe.As<string>(tmpObject).Length;
+                        }
                     }
                     else if (RuntimeHelpers.ObjectHasComponentSize(tmpObject))
                     {
@@ -222,9 +230,17 @@ namespace System
 
                         // 'tmpObject is T[]' below also handles things like int[] <-> uint[] being convertible
                         Debug.Assert(tmpObject is T[]);
+                        // TODO(unsafe): Baselining unsafe usage
 
-                        refToReturn = ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(tmpObject));
-                        lengthOfUnderlyingSpan = Unsafe.As<T[]>(tmpObject).Length;
+                        unsafe
+                        {
+                            refToReturn = ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(tmpObject));
+                        }
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            lengthOfUnderlyingSpan = Unsafe.As<T[]>(tmpObject).Length;
+                        }
                     }
                     else
                     {
@@ -235,7 +251,12 @@ namespace System
                         // constructor or other public API which would allow such a conversion.
 
                         Debug.Assert(tmpObject is MemoryManager<T>);
-                        Span<T> memoryManagerSpan = Unsafe.As<MemoryManager<T>>(tmpObject).GetSpan();
+                        Span<T> memoryManagerSpan;
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            memoryManagerSpan = Unsafe.As<MemoryManager<T>>(tmpObject).GetSpan();
+                        }
                         refToReturn = ref MemoryMarshal.GetReference(memoryManagerSpan);
                         lengthOfUnderlyingSpan = memoryManagerSpan.Length;
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/ReadOnlySpan.cs
@@ -224,7 +224,11 @@ namespace System
         /// <remarks>This method uses a covariant cast, producing a read-only span that shares the same memory as the source. The relationships expressed in the type constraints ensure that the cast is a safe operation.</remarks>
         public static ReadOnlySpan<T> CastUp<TDerived>(ReadOnlySpan<TDerived> items) where TDerived : class?, T
         {
-            return new ReadOnlySpan<T>(ref Unsafe.As<TDerived, T>(ref items._reference), items.Length);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return new ReadOnlySpan<T>(ref Unsafe.As<TDerived, T>(ref items._reference), items.Length);
+            }
         }
 
         /// <summary>Gets an enumerator for this span.</summary>
@@ -355,7 +359,11 @@ namespace System
         {
             if (typeof(T) == typeof(char))
             {
-                return new string(new ReadOnlySpan<char>(ref Unsafe.As<T, char>(ref _reference), _length));
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return new string(new ReadOnlySpan<char>(ref Unsafe.As<T, char>(ref _reference), _length));
+                }
             }
             return $"System.ReadOnlySpan<{typeof(T).Name}>[{_length}]";
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/InvokeUtils.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -135,17 +135,42 @@ namespace System.Reflection
                         case CorElementType.ELEMENT_TYPE_CHAR:
                         case CorElementType.ELEMENT_TYPE_I2:
                         case CorElementType.ELEMENT_TYPE_U2:
-                            Unsafe.As<byte, ushort>(ref destElement) = srcElement; break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, ushort>(ref destElement) = srcElement;
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_I4:
                         case CorElementType.ELEMENT_TYPE_U4:
-                            Unsafe.As<byte, uint>(ref destElement) = srcElement; break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, uint>(ref destElement) = srcElement;
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_I8:
                         case CorElementType.ELEMENT_TYPE_U8:
-                            Unsafe.As<byte, ulong>(ref destElement) = srcElement; break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, ulong>(ref destElement) = srcElement;
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = srcElement; break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, float>(ref destElement) = srcElement;
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = srcElement; break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, double>(ref destElement) = srcElement;
+                            }
+                            break;
                         default:
                             Debug.Fail("Expected to be unreachable"); break;
                     }
@@ -155,15 +180,40 @@ namespace System.Reflection
                     switch (destElType)
                     {
                         case CorElementType.ELEMENT_TYPE_I2:
-                            Unsafe.As<byte, short>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, short>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_I4:
-                            Unsafe.As<byte, int>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, int>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_I8:
-                            Unsafe.As<byte, long>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, long>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, sbyte>(ref srcElement);
+                            }
+                            break;
                         default:
                             Debug.Fail("Array.Copy from I1 to another type hit unsupported widening conversion"); break;
                     }
@@ -175,18 +225,43 @@ namespace System.Reflection
                     {
                         case CorElementType.ELEMENT_TYPE_U2:
                         case CorElementType.ELEMENT_TYPE_CHAR:
+                            // TODO(unsafe): Baselining unsafe usage
                             // U2 and CHAR are identical in conversion
-                            Unsafe.As<byte, ushort>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement); break;
+                            unsafe
+                            {
+                                Unsafe.As<byte, ushort>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_I4:
                         case CorElementType.ELEMENT_TYPE_U4:
-                            Unsafe.As<byte, uint>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, uint>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_I8:
                         case CorElementType.ELEMENT_TYPE_U8:
-                            Unsafe.As<byte, ulong>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, ulong>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, ushort>(ref srcElement);
+                            }
+                            break;
                         default:
                             Debug.Fail("Array.Copy from U2 to another type hit unsupported widening conversion"); break;
                     }
@@ -196,13 +271,33 @@ namespace System.Reflection
                     switch (destElType)
                     {
                         case CorElementType.ELEMENT_TYPE_I4:
-                            Unsafe.As<byte, int>(ref destElement) = Unsafe.As<byte, short>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, int>(ref destElement) = Unsafe.As<byte, short>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_I8:
-                            Unsafe.As<byte, long>(ref destElement) = Unsafe.As<byte, short>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, long>(ref destElement) = Unsafe.As<byte, short>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, short>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, short>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, short>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, short>(ref srcElement);
+                            }
+                            break;
                         default:
                             Debug.Fail("Array.Copy from I2 to another type hit unsupported widening conversion"); break;
                     }
@@ -213,11 +308,26 @@ namespace System.Reflection
                     {
                         case CorElementType.ELEMENT_TYPE_I8:
                         case CorElementType.ELEMENT_TYPE_U8:
-                            Unsafe.As<byte, ulong>(ref destElement) = Unsafe.As<byte, uint>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, ulong>(ref destElement) = Unsafe.As<byte, uint>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, uint>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, uint>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, uint>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, uint>(ref srcElement);
+                            }
+                            break;
                         default:
                             Debug.Fail("Array.Copy from U4 to another type hit unsupported widening conversion"); break;
                     }
@@ -227,11 +337,26 @@ namespace System.Reflection
                     switch (destElType)
                     {
                         case CorElementType.ELEMENT_TYPE_I8:
-                            Unsafe.As<byte, long>(ref destElement) = Unsafe.As<byte, int>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, long>(ref destElement) = Unsafe.As<byte, int>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, int>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, int>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, int>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, int>(ref srcElement);
+                            }
+                            break;
                         default:
                             Debug.Fail("Array.Copy from I4 to another type hit unsupported widening conversion"); break;
                     }
@@ -241,9 +366,19 @@ namespace System.Reflection
                     switch (destElType)
                     {
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, ulong>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, ulong>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, ulong>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, ulong>(ref srcElement);
+                            }
+                            break;
                         default:
                             Debug.Fail("Array.Copy from U8 to another type hit unsupported widening conversion"); break;
                     }
@@ -253,9 +388,19 @@ namespace System.Reflection
                     switch (destElType)
                     {
                         case CorElementType.ELEMENT_TYPE_R4:
-                            Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, long>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, float>(ref destElement) = Unsafe.As<byte, long>(ref srcElement);
+                            }
+                            break;
                         case CorElementType.ELEMENT_TYPE_R8:
-                            Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, long>(ref srcElement); break;
+                            // TODO(unsafe): Baselining unsafe usage
+                            unsafe
+                            {
+                                Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, long>(ref srcElement);
+                            }
+                            break;
                         default:
                             Debug.Fail("Array.Copy from I8 to another type hit unsupported widening conversion"); break;
                     }
@@ -263,7 +408,12 @@ namespace System.Reflection
 
                 case CorElementType.ELEMENT_TYPE_R4:
                     Debug.Assert(destElType == CorElementType.ELEMENT_TYPE_R8);
-                    Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, float>(ref srcElement); break;
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        Unsafe.As<byte, double>(ref destElement) = Unsafe.As<byte, float>(ref srcElement);
+                    }
+                    break;
 
                 default:
                     Debug.Fail("Fell through outer switch in PrimitiveWiden!  Unknown primitive type for source array!"); break;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncTaskMethodBuilderT.cs
@@ -105,13 +105,21 @@ namespace System.Runtime.CompilerServices
 
             if ((null != (object?)default(TAwaiter)) && (awaiter is ITaskAwaiter))
             {
-                ref TaskAwaiter ta = ref Unsafe.As<TAwaiter, TaskAwaiter>(ref awaiter); // relies on TaskAwaiter/TaskAwaiter<T> having the same layout
-                TaskAwaiter.UnsafeOnCompletedInternal(ta.m_task, box, continueOnCapturedContext: true);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    ref TaskAwaiter ta = ref Unsafe.As<TAwaiter, TaskAwaiter>(ref awaiter);
+                    TaskAwaiter.UnsafeOnCompletedInternal(ta.m_task, box, continueOnCapturedContext: true);
+                }
             }
             else if ((null != (object?)default(TAwaiter)) && (awaiter is IConfiguredTaskAwaiter))
             {
-                ref ConfiguredTaskAwaitable.ConfiguredTaskAwaiter ta = ref Unsafe.As<TAwaiter, ConfiguredTaskAwaitable.ConfiguredTaskAwaiter>(ref awaiter);
-                TaskAwaiter.UnsafeOnCompletedInternal(ta.m_task, box, (ta.m_options & ConfigureAwaitOptions.ContinueOnCapturedContext) != 0);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    ref ConfiguredTaskAwaitable.ConfiguredTaskAwaiter ta = ref Unsafe.As<TAwaiter, ConfiguredTaskAwaitable.ConfiguredTaskAwaiter>(ref awaiter);
+                    TaskAwaiter.UnsafeOnCompletedInternal(ta.m_task, box, (ta.m_options & ConfigureAwaitOptions.ContinueOnCapturedContext) != 0);
+                }
             }
             else if ((null != (object?)default(TAwaiter)) && (awaiter is IStateMachineBoxAwareAwaiter))
             {
@@ -340,7 +348,11 @@ namespace System.Runtime.CompilerServices
                 get
                 {
                     Debug.Assert(m_stateObject is null or ExecutionContext, $"Expected {nameof(m_stateObject)} to be null or an ExecutionContext but was {(m_stateObject is object o ? o.GetType().ToString() : "(null)")}.");
-                    return ref Unsafe.As<object?, ExecutionContext?>(ref m_stateObject);
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return ref Unsafe.As<object?, ExecutionContext?>(ref m_stateObject);
+                    }
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -631,7 +631,11 @@ namespace System.Runtime.CompilerServices
                 Debug.Assert(key != null); // Key already validated as non-null
 
                 int entryIndex = FindEntry(key, out object? secondary);
-                value = Unsafe.As<TValue>(secondary);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    value = Unsafe.As<TValue>(secondary);
+                }
                 return entryIndex != -1;
             }
 
@@ -682,8 +686,16 @@ namespace System.Runtime.CompilerServices
 
                     if (oKey != null)
                     {
-                        key = Unsafe.As<TKey>(oKey);
-                        value = Unsafe.As<TValue>(oValue!);
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            key = Unsafe.As<TKey>(oKey);
+                        }
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            value = Unsafe.As<TValue>(oValue!);
+                        }
                         return true;
                     }
                 }
@@ -711,7 +723,11 @@ namespace System.Runtime.CompilerServices
                 if (entryIndex != -1)
                 {
                     RemoveIndex(entryIndex);
-                    value = Unsafe.As<TValue>(valueObject!);
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        value = Unsafe.As<TValue>(valueObject!);
+                    }
                     return true;
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ConfiguredValueTaskAwaitable.cs
@@ -60,9 +60,13 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    Unsafe.As<IValueTaskSource>(obj).OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        Unsafe.As<IValueTaskSource>(obj).OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
                         ValueTaskSourceOnCompletedFlags.FlowExecutionContext |
                             (_value._continueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None));
+                    }
                 }
                 else
                 {
@@ -82,8 +86,12 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    Unsafe.As<IValueTaskSource>(obj).OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        Unsafe.As<IValueTaskSource>(obj).OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
                         _value._continueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
+                    }
                 }
                 else
                 {
@@ -102,8 +110,12 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token,
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token,
                         _value._continueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
+                    }
                 }
                 else
                 {
@@ -165,9 +177,13 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
                         ValueTaskSourceOnCompletedFlags.FlowExecutionContext |
                             (_value._continueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None));
+                    }
                 }
                 else
                 {
@@ -187,8 +203,12 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token,
                         _value._continueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
+                    }
                 }
                 else
                 {
@@ -207,8 +227,12 @@ namespace System.Runtime.CompilerServices
                 }
                 else if (obj != null)
                 {
-                    Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token,
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token,
                         _value._continueOnCapturedContext ? ValueTaskSourceOnCompletedFlags.UseSchedulingContext : ValueTaskSourceOnCompletedFlags.None);
+                    }
                 }
                 else
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/GenericCache.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/GenericCache.cs
@@ -108,8 +108,12 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ref Entry TableData(Entry[] table)
         {
+            // TODO(unsafe): Baselining unsafe usage
             // points to element 0, which is used for embedded aux data
-            return ref Unsafe.As<byte, Entry>(ref Unsafe.As<RawArrayData>(table).Data);
+            unsafe
+            {
+                return ref Unsafe.As<byte, Entry>(ref Unsafe.As<RawArrayData>(table).Data);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -134,8 +138,12 @@ namespace System.Runtime.CompilerServices
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static ref Entry Element(Entry[] table, int index)
         {
+            // TODO(unsafe): Baselining unsafe usage
             // element 0 is used for embedded aux data, skip it
-            return ref Unsafe.Add(ref Unsafe.As<byte, Entry>(ref Unsafe.As<RawArrayData>(table).Data), index + 1);
+            unsafe
+            {
+                return ref Unsafe.Add(ref Unsafe.As<byte, Entry>(ref Unsafe.As<RawArrayData>(table).Data), index + 1);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/PoolingAsyncValueTaskMethodBuilderT.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/PoolingAsyncValueTaskMethodBuilderT.cs
@@ -367,7 +367,11 @@ namespace System.Runtime.CompilerServices
                     Debug.Assert(transientValue is null || transientValue is StateMachineBox<TStateMachine>,
                         $"Expected null or {nameof(StateMachineBox<TStateMachine>)}, got '{transientValue}'");
 #endif
-                    return ref Unsafe.As<object?, StateMachineBox<TStateMachine>?>(ref s_perCoreCache[i].Object);
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return ref Unsafe.As<object?, StateMachineBox<TStateMachine>?>(ref s_perCoreCache[i].Object);
+                    }
                 }
             }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -47,11 +47,15 @@ namespace System.Runtime.CompilerServices
             }
             else
             {
+                // TODO(unsafe): Baselining unsafe usage
                 // The array is actually a U[] where U:T. We'll make sure to create
                 // an array of the exact same backing type. The cast to T[] will
                 // never fail.
 
-                dest = Unsafe.As<T[]>(Array.CreateInstanceFromArrayType(array.GetType(), length));
+                unsafe
+                {
+                    dest = Unsafe.As<T[]>(Array.CreateInstanceFromArrayType(array.GetType(), length));
+                }
             }
 
             // In either case, the newly-allocated array is the exact same type as the
@@ -158,7 +162,13 @@ namespace System.Runtime.CompilerServices
             // We shortcut this here instead of in `GetSpanDataFrom` to avoid `typeof(T)` below marking T target of reflection.
             => throw new PlatformNotSupportedException();
 #else
-            => new ReadOnlySpan<T>(ref Unsafe.As<byte, T>(ref GetSpanDataFrom(fldHandle, typeof(T).TypeHandle, out int length)), length);
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return new ReadOnlySpan<T>(ref Unsafe.As<byte, T>(ref GetSpanDataFrom(fldHandle, typeof(T).TypeHandle, out int length)), length);
+            }
+        }
 #endif
 
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/Unsafe.cs
@@ -63,6 +63,7 @@ namespace System.Runtime.CompilerServices
         // Mono:As
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [RequiresUnsafe]
         [return: NotNullIfNotNull(nameof(o))]
         public static T? As<T>(object? o) where T : class?
         {
@@ -83,6 +84,7 @@ namespace System.Runtime.CompilerServices
         // Mono:As
         [NonVersionable]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [RequiresUnsafe]
         public static ref TTo As<TFrom, TTo>(ref TFrom source)
             where TFrom : allows ref struct
             where TTo : allows ref struct

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/ValueTaskAwaiter.cs
@@ -55,7 +55,11 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                Unsafe.As<IValueTaskSource>(obj).OnCompleted(s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext | ValueTaskSourceOnCompletedFlags.FlowExecutionContext);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.As<IValueTaskSource>(obj).OnCompleted(s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext | ValueTaskSourceOnCompletedFlags.FlowExecutionContext);
+                }
             }
             else
             {
@@ -75,7 +79,11 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                Unsafe.As<IValueTaskSource>(obj).OnCompleted(s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.As<IValueTaskSource>(obj).OnCompleted(s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+                }
             }
             else
             {
@@ -94,7 +102,11 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.As<IValueTaskSource>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+                }
             }
             else
             {
@@ -137,7 +149,11 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext | ValueTaskSourceOnCompletedFlags.FlowExecutionContext);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext | ValueTaskSourceOnCompletedFlags.FlowExecutionContext);
+                }
             }
             else
             {
@@ -157,7 +173,11 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ValueTaskAwaiter.s_invokeActionDelegate, continuation, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+                }
             }
             else
             {
@@ -176,7 +196,11 @@ namespace System.Runtime.CompilerServices
             }
             else if (obj != null)
             {
-                Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.As<IValueTaskSource<TResult>>(obj).OnCompleted(ThreadPool.s_invokeAsyncStateMachineBox, box, _value._token, ValueTaskSourceOnCompletedFlags.UseSchedulingContext);
+                }
             }
             else
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/GCHandle.T.cs
@@ -48,8 +48,12 @@ namespace System.Runtime.InteropServices
             {
                 IntPtr handle = _handle;
                 GCHandle.CheckUninitialized(handle);
+                // TODO(unsafe): Baselining unsafe usage
                 // Skip the type check to provide lowest overhead.
-                return Unsafe.As<T>(GCHandle.InternalGet(handle)!);
+                unsafe
+                {
+                    return Unsafe.As<T>(GCHandle.InternalGet(handle)!);
+                }
             }
             set
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/NFloat.cs
@@ -695,7 +695,11 @@ namespace System.Runtime.InteropServices
         public static bool TryParse([NotNullWhen(true)] string? s, out NFloat result)
         {
             Unsafe.SkipInit(out result);
-            return NativeType.TryParse(s, out Unsafe.As<NFloat, NativeType>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return NativeType.TryParse(s, out Unsafe.As<NFloat, NativeType>(ref result));
+            }
         }
 
         /// <summary>Tries to convert a character span containing the string representation of a number to its floating-point number equivalent.</summary>
@@ -705,7 +709,11 @@ namespace System.Runtime.InteropServices
         public static bool TryParse(ReadOnlySpan<char> s, out NFloat result)
         {
             Unsafe.SkipInit(out result);
-            return NativeType.TryParse(s, out Unsafe.As<NFloat, NativeType>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return NativeType.TryParse(s, out Unsafe.As<NFloat, NativeType>(ref result));
+            }
         }
 
         /// <summary>Tries to convert a UTF-8 character span containing the string representation of a number to its floating-point number equivalent.</summary>
@@ -715,7 +723,11 @@ namespace System.Runtime.InteropServices
         public static bool TryParse(ReadOnlySpan<byte> utf8Text, out NFloat result)
         {
             Unsafe.SkipInit(out result);
-            return NativeType.TryParse(utf8Text, out Unsafe.As<NFloat, NativeType>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return NativeType.TryParse(utf8Text, out Unsafe.As<NFloat, NativeType>(ref result));
+            }
         }
 
         /// <summary>Tries to convert the string representation of a number in a specified style and culture-specific format to its floating-point number equivalent.</summary>
@@ -732,7 +744,11 @@ namespace System.Runtime.InteropServices
         public static bool TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out NFloat result)
         {
             Unsafe.SkipInit(out result);
-            return NativeType.TryParse(s, style, provider, out Unsafe.As<NFloat, NativeType>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return NativeType.TryParse(s, style, provider, out Unsafe.As<NFloat, NativeType>(ref result));
+            }
         }
 
         /// <summary>Tries to convert a character span containing the string representation of a number in a specified style and culture-specific format to its floating-point number equivalent.</summary>
@@ -749,7 +765,11 @@ namespace System.Runtime.InteropServices
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out NFloat result)
         {
             Unsafe.SkipInit(out result);
-            return NativeType.TryParse(s, style, provider, out Unsafe.As<NFloat, NativeType>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return NativeType.TryParse(s, style, provider, out Unsafe.As<NFloat, NativeType>(ref result));
+            }
         }
 
         /// <summary>Compares this instance to a specified object and returns an integer that indicates whether the value of this instance is less than, equal to, or greater than the value of the specified object.</summary>
@@ -1920,7 +1940,11 @@ namespace System.Runtime.InteropServices
         public static bool TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles style, IFormatProvider? provider, out NFloat result)
         {
             Unsafe.SkipInit(out result);
-            return NativeType.TryParse(utf8Text, style, provider, out Unsafe.As<NFloat, NativeType>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return NativeType.TryParse(utf8Text, style, provider, out Unsafe.As<NFloat, NativeType>(ref result));
+            }
         }
 
         /// <inheritdoc cref="IUtf8SpanParsable{TSelf}.Parse(ReadOnlySpan{byte}, IFormatProvider?)" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/PinnedGCHandle.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/PinnedGCHandle.T.cs
@@ -50,8 +50,12 @@ namespace System.Runtime.InteropServices
             {
                 IntPtr handle = _handle;
                 GCHandle.CheckUninitialized(handle);
+                // TODO(unsafe): Baselining unsafe usage
                 // Skip the type check to provide lowest overhead.
-                return Unsafe.As<T>(GCHandle.InternalGet(handle)!);
+                unsafe
+                {
+                    return Unsafe.As<T>(GCHandle.InternalGet(handle)!);
+                }
             }
             set
             {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
@@ -72,7 +72,12 @@ namespace System.Runtime.InteropServices
             {
                 foreach (GCHandle weakNativeObjectWrapperHandle in s_referenceTrackerNativeObjectWrapperCache)
                 {
-                    ReferenceTrackerNativeObjectWrapper? nativeObjectWrapper = Unsafe.As<ReferenceTrackerNativeObjectWrapper>(weakNativeObjectWrapperHandle.Target);
+                    ReferenceTrackerNativeObjectWrapper? nativeObjectWrapper;
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        nativeObjectWrapper = Unsafe.As<ReferenceTrackerNativeObjectWrapper>(weakNativeObjectWrapperHandle.Target);
+                    }
                     if (nativeObjectWrapper != null &&
                         nativeObjectWrapper._contextToken == contextToken)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/WeakGCHandle.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/WeakGCHandle.T.cs
@@ -53,7 +53,12 @@ namespace System.Runtime.InteropServices
             IntPtr handle = _handle;
             GCHandle.CheckUninitialized(handle);
             // Skip the type check to provide lowest overhead.
-            T? obj = Unsafe.As<T>(GCHandle.InternalGet(handle));
+            T? obj;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                obj = Unsafe.As<T>(GCHandle.InternalGet(handle));
+            }
             target = obj;
             return obj != null;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.Numerics.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.Numerics.cs
@@ -102,9 +102,13 @@ namespace System.Runtime.Intrinsics
         {
             Debug.Assert(Vector<T>.Count >= Vector128<T>.Count);
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector128BaseType<T>();
+            // TODO(unsafe): Baselining unsafe usage
 
-            ref byte address = ref Unsafe.As<Vector<T>, byte>(ref value);
-            return Unsafe.ReadUnaligned<Vector128<T>>(ref address);
+            unsafe
+            {
+                ref byte address = ref Unsafe.As<Vector<T>, byte>(ref value);
+                return Unsafe.ReadUnaligned<Vector128<T>>(ref address);
+            }
         }
 
         /// <summary>Reinterprets a <see langword="Vector2" /> as a new <see cref="Vector128&lt;Single&gt;" />, leaving the new elements undefined.</summary>
@@ -117,7 +121,11 @@ namespace System.Runtime.Intrinsics
             // declaration to let the upper bits be uninitialized.
 
             Unsafe.SkipInit(out Vector128<float> result);
-            Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<float>, byte>(ref result), value);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<float>, byte>(ref result), value);
+            }
             return result;
         }
 
@@ -131,7 +139,11 @@ namespace System.Runtime.Intrinsics
             // declaration to let the upper bits be uninitialized.
 
             Unsafe.SkipInit(out Vector128<float> result);
-            Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<float>, byte>(ref result), value);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector128<float>, byte>(ref result), value);
+            }
             return result;
         }
 
@@ -142,8 +154,12 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector2 AsVector2(this Vector128<float> value)
         {
-            ref byte address = ref Unsafe.As<Vector128<float>, byte>(ref value);
-            return Unsafe.ReadUnaligned<Vector2>(ref address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref byte address = ref Unsafe.As<Vector128<float>, byte>(ref value);
+                return Unsafe.ReadUnaligned<Vector2>(ref address);
+            }
         }
 
         /// <summary>Reinterprets a <see langword="Vector128&lt;Single&gt;" /> as a new <see cref="Vector3" />.</summary>
@@ -153,8 +169,12 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Vector3 AsVector3(this Vector128<float> value)
         {
-            ref byte address = ref Unsafe.As<Vector128<float>, byte>(ref value);
-            return Unsafe.ReadUnaligned<Vector3>(ref address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref byte address = ref Unsafe.As<Vector128<float>, byte>(ref value);
+                return Unsafe.ReadUnaligned<Vector3>(ref address);
+            }
         }
 
         /// <summary>Reinterprets a <see langword="Vector128&lt;Single&gt;" /> as a new <see cref="Vector4" />.</summary>
@@ -176,7 +196,11 @@ namespace System.Runtime.Intrinsics
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector128BaseType<T>();
 
             Vector<T> result = default;
-            Unsafe.WriteUnaligned(ref Unsafe.As<Vector<T>, byte>(ref result), value);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector<T>, byte>(ref result), value);
+            }
             return result;
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128.cs
@@ -758,8 +758,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[0]), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[0]), vector);
+            }
         }
 
         /// <summary>Copies a <see cref="Vector128{T}" /> to a given array starting at the specified index.</summary>
@@ -785,8 +789,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[startIndex]), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[startIndex]), vector);
+            }
         }
 
         /// <summary>Copies a <see cref="Vector128{T}" /> to a given span.</summary>
@@ -802,8 +810,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            }
         }
 
         /// <inheritdoc cref="Vector64.Cos(Vector64{double})" />
@@ -986,8 +998,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            return Unsafe.ReadUnaligned<Vector128<T>>(ref Unsafe.As<T, byte>(ref values[0]));
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector128<T>>(ref Unsafe.As<T, byte>(ref values[0]));
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector128{T}" /> from a given array.</summary>
@@ -1007,8 +1023,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            return Unsafe.ReadUnaligned<Vector128<T>>(ref Unsafe.As<T, byte>(ref values[index]));
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector128<T>>(ref Unsafe.As<T, byte>(ref values[index]));
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector128{T}" /> from a given readonly span.</summary>
@@ -1024,8 +1044,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.values);
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            return Unsafe.ReadUnaligned<Vector128<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector128<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+            }
         }
 
         /// <summary>Creates a new <see langword="Vector128&lt;Byte&gt;" /> instance with each element initialized to the corresponding specified value.</summary>
@@ -2359,8 +2383,12 @@ namespace System.Runtime.Intrinsics
         public static Vector128<T> LoadUnsafe<T>(ref readonly T source)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector128BaseType<T>();
-            ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.AsRef(in source));
-            return Unsafe.ReadUnaligned<Vector128<T>>(in address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.AsRef(in source));
+                return Unsafe.ReadUnaligned<Vector128<T>>(in address);
+            }
         }
 
         /// <summary>Loads a vector from the given source and element offset.</summary>
@@ -2375,20 +2403,38 @@ namespace System.Runtime.Intrinsics
         public static Vector128<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector128BaseType<T>();
-            ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.Add(ref Unsafe.AsRef(in source), (nint)elementOffset));
-            return Unsafe.ReadUnaligned<Vector128<T>>(in address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.Add(ref Unsafe.AsRef(in source), (nint)elementOffset));
+                return Unsafe.ReadUnaligned<Vector128<T>>(in address);
+            }
         }
 
         /// <summary>Loads a vector from the given source and reinterprets it as <see cref="ushort" />.</summary>
         /// <param name="source">The source from which the vector will be loaded.</param>
         /// <returns>The vector loaded from <paramref name="source" />.</returns>
-        internal static Vector128<ushort> LoadUnsafe(ref char source) => LoadUnsafe(ref Unsafe.As<char, ushort>(ref source));
+        internal static Vector128<ushort> LoadUnsafe(ref char source)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return LoadUnsafe(ref Unsafe.As<char, ushort>(ref source));
+            }
+        }
 
         /// <summary>Loads a vector from the given source and element offset and reinterprets it as <see cref="ushort" />.</summary>
         /// <param name="source">The source to which <paramref name="elementOffset" /> will be added before loading the vector.</param>
         /// <param name="elementOffset">The element offset from <paramref name="source" /> from which the vector will be loaded.</param>
         /// <returns>The vector loaded from <paramref name="source" /> plus <paramref name="elementOffset" />.</returns>
-        internal static Vector128<ushort> LoadUnsafe(ref char source, nuint elementOffset) => LoadUnsafe(ref Unsafe.As<char, ushort>(ref source), elementOffset);
+        internal static Vector128<ushort> LoadUnsafe(ref char source, nuint elementOffset)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return LoadUnsafe(ref Unsafe.As<char, ushort>(ref source), elementOffset);
+            }
+        }
 
         /// <inheritdoc cref="Vector64.Log(Vector64{double})" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -3939,8 +3985,12 @@ namespace System.Runtime.Intrinsics
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void StoreLowerUnsafe<T>(this Vector128<T> source, ref T destination, nuint elementOffset = 0)
         {
-            ref byte address = ref Unsafe.As<T, byte>(ref Unsafe.Add(ref destination, elementOffset));
-            Unsafe.WriteUnaligned(ref address, source.AsDouble().ToScalar());
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref byte address = ref Unsafe.As<T, byte>(ref Unsafe.Add(ref destination, elementOffset));
+                Unsafe.WriteUnaligned(ref address, source.AsDouble().ToScalar());
+            }
         }
 
         /// <summary>Stores a vector at the given destination.</summary>
@@ -3953,8 +4003,12 @@ namespace System.Runtime.Intrinsics
         public static void StoreUnsafe<T>(this Vector128<T> source, ref T destination)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector128BaseType<T>();
-            ref byte address = ref Unsafe.As<T, byte>(ref destination);
-            Unsafe.WriteUnaligned(ref address, source);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref byte address = ref Unsafe.As<T, byte>(ref destination);
+                Unsafe.WriteUnaligned(ref address, source);
+            }
         }
 
         /// <summary>Stores a vector at the given destination.</summary>
@@ -3970,7 +4024,11 @@ namespace System.Runtime.Intrinsics
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector128BaseType<T>();
             destination = ref Unsafe.Add(ref destination, (nint)elementOffset);
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination), source);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination), source);
+            }
         }
 
         /// <summary>Subtracts two vectors to compute their element-wise difference.</summary>
@@ -4117,8 +4175,12 @@ namespace System.Runtime.Intrinsics
             {
                 return false;
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            }
             return true;
         }
 
@@ -4455,16 +4517,24 @@ namespace System.Runtime.Intrinsics
         internal static T GetElementUnsafe<T>(in this Vector128<T> vector, int index)
         {
             Debug.Assert((index >= 0) && (index < Vector128<T>.Count));
-            ref T address = ref Unsafe.As<Vector128<T>, T>(ref Unsafe.AsRef(in vector));
-            return Unsafe.Add(ref address, index);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref T address = ref Unsafe.As<Vector128<T>, T>(ref Unsafe.AsRef(in vector));
+                return Unsafe.Add(ref address, index);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void SetElementUnsafe<T>(in this Vector128<T> vector, int index, T value)
         {
             Debug.Assert((index >= 0) && (index < Vector128<T>.Count));
-            ref T address = ref Unsafe.As<Vector128<T>, T>(ref Unsafe.AsRef(in vector));
-            Unsafe.Add(ref address, index) = value;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref T address = ref Unsafe.As<Vector128<T>, T>(ref Unsafe.AsRef(in vector));
+                Unsafe.Add(ref address, index) = value;
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128DebugView_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector128DebugView_1.cs
@@ -29,7 +29,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new double[Vector128<double>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -39,7 +43,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new short[Vector128<short>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -49,7 +57,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new int[Vector128<int>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -59,7 +71,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new long[Vector128<long>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -69,7 +85,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nint[Vector128<nint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -79,7 +99,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nuint[Vector128<nuint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -89,7 +113,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new sbyte[Vector128<sbyte>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -99,7 +127,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new float[Vector128<float>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -109,7 +141,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ushort[Vector128<ushort>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -119,7 +155,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new uint[Vector128<uint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -129,7 +169,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ulong[Vector128<ulong>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256.cs
@@ -366,13 +366,21 @@ namespace System.Runtime.Intrinsics
 
             if (Vector<T>.Count >= Vector256<T>.Count)
             {
-                ref byte address = ref Unsafe.As<Vector<T>, byte>(ref value);
-                return Unsafe.ReadUnaligned<Vector256<T>>(ref address);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    ref byte address = ref Unsafe.As<Vector<T>, byte>(ref value);
+                    return Unsafe.ReadUnaligned<Vector256<T>>(ref address);
+                }
             }
             else
             {
                 Vector256<T> result = default;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<T>, byte>(ref result), value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<Vector256<T>, byte>(ref result), value);
+                }
                 return result;
             }
         }
@@ -390,13 +398,21 @@ namespace System.Runtime.Intrinsics
 
             if (Vector256<T>.Count >= Vector<T>.Count)
             {
-                ref byte address = ref Unsafe.As<Vector256<T>, byte>(ref value);
-                return Unsafe.ReadUnaligned<Vector<T>>(ref address);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    ref byte address = ref Unsafe.As<Vector256<T>, byte>(ref value);
+                    return Unsafe.ReadUnaligned<Vector<T>>(ref address);
+                }
             }
             else
             {
                 Vector<T> result = default;
-                Unsafe.WriteUnaligned(ref Unsafe.As<Vector<T>, byte>(ref result), value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<Vector<T>, byte>(ref result), value);
+                }
                 return result;
             }
         }
@@ -765,8 +781,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[0]), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[0]), vector);
+            }
         }
 
         /// <summary>Copies a <see cref="Vector256{T}" /> to a given array starting at the specified index.</summary>
@@ -792,8 +812,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[startIndex]), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[startIndex]), vector);
+            }
         }
 
         /// <summary>Copies a <see cref="Vector256{T}" /> to a given span.</summary>
@@ -809,8 +833,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            }
         }
 
         /// <inheritdoc cref="Vector128.Cos(Vector128{double})" />
@@ -993,8 +1021,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            return Unsafe.ReadUnaligned<Vector256<T>>(ref Unsafe.As<T, byte>(ref values[0]));
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector256<T>>(ref Unsafe.As<T, byte>(ref values[0]));
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{T}" /> from a given array.</summary>
@@ -1014,8 +1046,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            return Unsafe.ReadUnaligned<Vector256<T>>(ref Unsafe.As<T, byte>(ref values[index]));
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector256<T>>(ref Unsafe.As<T, byte>(ref values[index]));
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector256{T}" /> from a given readonly span.</summary>
@@ -1031,8 +1067,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.values);
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            return Unsafe.ReadUnaligned<Vector256<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector256<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+            }
         }
 
         /// <summary>Creates a new <see langword="Vector256&lt;Byte&gt;" /> instance with each element initialized to the corresponding specified value.</summary>
@@ -2443,8 +2483,12 @@ namespace System.Runtime.Intrinsics
         public static Vector256<T> LoadUnsafe<T>(ref readonly T source)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector256BaseType<T>();
-            ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.AsRef(in source));
-            return Unsafe.ReadUnaligned<Vector256<T>>(in address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.AsRef(in source));
+                return Unsafe.ReadUnaligned<Vector256<T>>(in address);
+            }
         }
 
         /// <summary>Loads a vector from the given source and element offset.</summary>
@@ -2459,20 +2503,38 @@ namespace System.Runtime.Intrinsics
         public static Vector256<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector256BaseType<T>();
-            ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.Add(ref Unsafe.AsRef(in source), (nint)elementOffset));
-            return Unsafe.ReadUnaligned<Vector256<T>>(in address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.Add(ref Unsafe.AsRef(in source), (nint)elementOffset));
+                return Unsafe.ReadUnaligned<Vector256<T>>(in address);
+            }
         }
 
         /// <summary>Loads a vector from the given source and reinterprets it as <see cref="ushort" />.</summary>
         /// <param name="source">The source from which the vector will be loaded.</param>
         /// <returns>The vector loaded from <paramref name="source" />.</returns>
-        internal static Vector256<ushort> LoadUnsafe(ref char source) => LoadUnsafe(ref Unsafe.As<char, ushort>(ref source));
+        internal static Vector256<ushort> LoadUnsafe(ref char source)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return LoadUnsafe(ref Unsafe.As<char, ushort>(ref source));
+            }
+        }
 
         /// <summary>Loads a vector from the given source and element offset and reinterprets it as <see cref="ushort" />.</summary>
         /// <param name="source">The source to which <paramref name="elementOffset" /> will be added before loading the vector.</param>
         /// <param name="elementOffset">The element offset from <paramref name="source" /> from which the vector will be loaded.</param>
         /// <returns>The vector loaded from <paramref name="source" /> plus <paramref name="elementOffset" />.</returns>
-        internal static Vector256<ushort> LoadUnsafe(ref char source, nuint elementOffset) => LoadUnsafe(ref Unsafe.As<char, ushort>(ref source), elementOffset);
+        internal static Vector256<ushort> LoadUnsafe(ref char source, nuint elementOffset)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return LoadUnsafe(ref Unsafe.As<char, ushort>(ref source), elementOffset);
+            }
+        }
 
         /// <inheritdoc cref="Vector128.Log(Vector128{double})" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -3920,8 +3982,12 @@ namespace System.Runtime.Intrinsics
         public static void StoreUnsafe<T>(this Vector256<T> source, ref T destination)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector256BaseType<T>();
-            ref byte address = ref Unsafe.As<T, byte>(ref destination);
-            Unsafe.WriteUnaligned(ref address, source);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref byte address = ref Unsafe.As<T, byte>(ref destination);
+                Unsafe.WriteUnaligned(ref address, source);
+            }
         }
 
         /// <summary>Stores a vector at the given destination.</summary>
@@ -3937,7 +4003,11 @@ namespace System.Runtime.Intrinsics
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector256BaseType<T>();
             destination = ref Unsafe.Add(ref destination, (nint)elementOffset);
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination), source);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination), source);
+            }
         }
 
         /// <inheritdoc cref="Vector128.Subtract{T}(Vector128{T}, Vector128{T})" />
@@ -4072,8 +4142,12 @@ namespace System.Runtime.Intrinsics
             {
                 return false;
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            }
             return true;
         }
 
@@ -4408,16 +4482,24 @@ namespace System.Runtime.Intrinsics
         internal static T GetElementUnsafe<T>(in this Vector256<T> vector, int index)
         {
             Debug.Assert((index >= 0) && (index < Vector256<T>.Count));
-            ref T address = ref Unsafe.As<Vector256<T>, T>(ref Unsafe.AsRef(in vector));
-            return Unsafe.Add(ref address, index);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref T address = ref Unsafe.As<Vector256<T>, T>(ref Unsafe.AsRef(in vector));
+                return Unsafe.Add(ref address, index);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void SetElementUnsafe<T>(in this Vector256<T> vector, int index, T value)
         {
             Debug.Assert((index >= 0) && (index < Vector256<T>.Count));
-            ref T address = ref Unsafe.As<Vector256<T>, T>(ref Unsafe.AsRef(in vector));
-            Unsafe.Add(ref address, index) = value;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref T address = ref Unsafe.As<Vector256<T>, T>(ref Unsafe.AsRef(in vector));
+                Unsafe.Add(ref address, index) = value;
+            }
         }
 
         internal static void SetLowerUnsafe<T>(in this Vector256<T> vector, Vector128<T> value) => Unsafe.AsRef(in vector._lower) = value;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256DebugView_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector256DebugView_1.cs
@@ -29,7 +29,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new double[Vector256<double>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -39,7 +43,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new short[Vector256<short>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -49,7 +57,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new int[Vector256<int>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -59,7 +71,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new long[Vector256<long>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -69,7 +85,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nint[Vector256<nint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -79,7 +99,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nuint[Vector256<nuint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -89,7 +113,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new sbyte[Vector256<sbyte>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -99,7 +127,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new float[Vector256<float>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -109,7 +141,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ushort[Vector256<ushort>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -119,7 +155,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new uint[Vector256<uint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -129,7 +169,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ulong[Vector256<ulong>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512.cs
@@ -365,7 +365,11 @@ namespace System.Runtime.Intrinsics
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector512BaseType<T>();
 
             Vector512<T> result = default;
-            Unsafe.WriteUnaligned(ref Unsafe.As<Vector512<T>, byte>(ref result), value);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<Vector512<T>, byte>(ref result), value);
+            }
             return result;
         }
 
@@ -380,9 +384,13 @@ namespace System.Runtime.Intrinsics
         {
             Debug.Assert(Vector512<T>.Count >= Vector<T>.Count);
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector512BaseType<T>();
+            // TODO(unsafe): Baselining unsafe usage
 
-            ref byte address = ref Unsafe.As<Vector512<T>, byte>(ref value);
-            return Unsafe.ReadUnaligned<Vector<T>>(ref address);
+            unsafe
+            {
+                ref byte address = ref Unsafe.As<Vector512<T>, byte>(ref value);
+                return Unsafe.ReadUnaligned<Vector<T>>(ref address);
+            }
         }
 
         /// <summary>Computes the bitwise-and of two vectors.</summary>
@@ -677,8 +685,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[0]), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[0]), vector);
+            }
         }
 
         /// <summary>Copies a <see cref="Vector512{T}" /> to a given array starting at the specified index.</summary>
@@ -703,8 +715,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[startIndex]), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[startIndex]), vector);
+            }
         }
 
         /// <summary>Copies a <see cref="Vector512{T}" /> to a given span.</summary>
@@ -719,8 +735,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            }
         }
 
         /// <inheritdoc cref="Vector256.Cos(Vector256{double})" />
@@ -895,8 +915,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            return Unsafe.ReadUnaligned<Vector512<T>>(ref Unsafe.As<T, byte>(ref values[0]));
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector512<T>>(ref Unsafe.As<T, byte>(ref values[0]));
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector512{T}" /> from a given array.</summary>
@@ -915,8 +939,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            return Unsafe.ReadUnaligned<Vector512<T>>(ref Unsafe.As<T, byte>(ref values[index]));
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector512<T>>(ref Unsafe.As<T, byte>(ref values[index]));
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector512{T}" /> from a given readonly span.</summary>
@@ -932,8 +960,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.values);
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            return Unsafe.ReadUnaligned<Vector512<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector512<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+            }
         }
 
         /// <summary>Creates a new <see langword="Vector512&lt;Byte&gt;" /> instance with each element initialized to the corresponding specified value.</summary>
@@ -2469,8 +2501,12 @@ namespace System.Runtime.Intrinsics
         public static Vector512<T> LoadUnsafe<T>(ref readonly T source)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector512BaseType<T>();
-            ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.AsRef(in source));
-            return Unsafe.ReadUnaligned<Vector512<T>>(in address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.AsRef(in source));
+                return Unsafe.ReadUnaligned<Vector512<T>>(in address);
+            }
         }
 
         /// <summary>Loads a vector from the given source and element offset.</summary>
@@ -2485,20 +2521,38 @@ namespace System.Runtime.Intrinsics
         public static Vector512<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector512BaseType<T>();
-            ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.Add(ref Unsafe.AsRef(in source), (nint)elementOffset));
-            return Unsafe.ReadUnaligned<Vector512<T>>(in address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.Add(ref Unsafe.AsRef(in source), (nint)elementOffset));
+                return Unsafe.ReadUnaligned<Vector512<T>>(in address);
+            }
         }
 
         /// <summary>Loads a vector from the given source and reinterprets it as <see cref="ushort" />.</summary>
         /// <param name="source">The source from which the vector will be loaded.</param>
         /// <returns>The vector loaded from <paramref name="source" />.</returns>
-        internal static Vector512<ushort> LoadUnsafe(ref char source) => LoadUnsafe(ref Unsafe.As<char, ushort>(ref source));
+        internal static Vector512<ushort> LoadUnsafe(ref char source)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return LoadUnsafe(ref Unsafe.As<char, ushort>(ref source));
+            }
+        }
 
         /// <summary>Loads a vector from the given source and element offset and reinterprets it as <see cref="ushort" />.</summary>
         /// <param name="source">The source to which <paramref name="elementOffset" /> will be added before loading the vector.</param>
         /// <param name="elementOffset">The element offset from <paramref name="source" /> from which the vector will be loaded.</param>
         /// <returns>The vector loaded from <paramref name="source" /> plus <paramref name="elementOffset" />.</returns>
-        internal static Vector512<ushort> LoadUnsafe(ref char source, nuint elementOffset) => LoadUnsafe(ref Unsafe.As<char, ushort>(ref source), elementOffset);
+        internal static Vector512<ushort> LoadUnsafe(ref char source, nuint elementOffset)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return LoadUnsafe(ref Unsafe.As<char, ushort>(ref source), elementOffset);
+            }
+        }
 
         /// <inheritdoc cref="Vector256.Log(Vector256{double})" />
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -3931,8 +3985,12 @@ namespace System.Runtime.Intrinsics
         public static void StoreUnsafe<T>(this Vector512<T> source, ref T destination)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector512BaseType<T>();
-            ref byte address = ref Unsafe.As<T, byte>(ref destination);
-            Unsafe.WriteUnaligned(ref address, source);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref byte address = ref Unsafe.As<T, byte>(ref destination);
+                Unsafe.WriteUnaligned(ref address, source);
+            }
         }
 
         /// <summary>Stores a vector at the given destination.</summary>
@@ -3948,7 +4006,11 @@ namespace System.Runtime.Intrinsics
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector512BaseType<T>();
             destination = ref Unsafe.Add(ref destination, (nint)elementOffset);
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination), source);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination), source);
+            }
         }
 
         /// <inheritdoc cref="Vector128.Subtract{T}(Vector128{T}, Vector128{T})" />
@@ -4049,8 +4111,12 @@ namespace System.Runtime.Intrinsics
             {
                 return false;
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            }
             return true;
         }
 
@@ -4385,16 +4451,24 @@ namespace System.Runtime.Intrinsics
         internal static T GetElementUnsafe<T>(in this Vector512<T> vector, int index)
         {
             Debug.Assert((index >= 0) && (index < Vector512<T>.Count));
-            ref T address = ref Unsafe.As<Vector512<T>, T>(ref Unsafe.AsRef(in vector));
-            return Unsafe.Add(ref address, index);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref T address = ref Unsafe.As<Vector512<T>, T>(ref Unsafe.AsRef(in vector));
+                return Unsafe.Add(ref address, index);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void SetElementUnsafe<T>(in this Vector512<T> vector, int index, T value)
         {
             Debug.Assert((index >= 0) && (index < Vector512<T>.Count));
-            ref T address = ref Unsafe.As<Vector512<T>, T>(ref Unsafe.AsRef(in vector));
-            Unsafe.Add(ref address, index) = value;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref T address = ref Unsafe.As<Vector512<T>, T>(ref Unsafe.AsRef(in vector));
+                Unsafe.Add(ref address, index) = value;
+            }
         }
 
         internal static void SetLowerUnsafe<T>(in this Vector512<T> vector, Vector256<T> value) => Unsafe.AsRef(in vector._lower) = value;

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512DebugView_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector512DebugView_1.cs
@@ -29,7 +29,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new double[Vector512<double>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -39,7 +43,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new short[Vector512<short>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -49,7 +57,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new int[Vector512<int>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -59,7 +71,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new long[Vector512<long>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -69,7 +85,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nint[Vector512<nint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -79,7 +99,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nuint[Vector512<nuint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -89,7 +113,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new sbyte[Vector512<sbyte>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -99,7 +127,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new float[Vector512<float>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -109,7 +141,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ushort[Vector512<ushort>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -119,7 +155,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new uint[Vector512<uint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -129,7 +169,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ulong[Vector512<ulong>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64.cs
@@ -715,8 +715,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[0]), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[0]), vector);
+            }
         }
 
         /// <summary>Copies a <see cref="Vector64{T}" /> to a given array starting at the specified index.</summary>
@@ -742,8 +746,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[startIndex]), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination[startIndex]), vector);
+            }
         }
 
         /// <summary>Copies a <see cref="Vector64{T}" /> to a given span.</summary>
@@ -759,8 +767,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentException_DestinationTooShort();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            }
         }
 
         internal static Vector64<T> Cos<T>(Vector64<T> vector)
@@ -966,8 +978,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            return Unsafe.ReadUnaligned<Vector64<T>>(ref Unsafe.As<T, byte>(ref values[0]));
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector64<T>>(ref Unsafe.As<T, byte>(ref values[0]));
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector64{T}" /> from a given array.</summary>
@@ -987,8 +1003,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentOutOfRange_IndexMustBeLessOrEqualException();
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            return Unsafe.ReadUnaligned<Vector64<T>>(ref Unsafe.As<T, byte>(ref values[index]));
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector64<T>>(ref Unsafe.As<T, byte>(ref values[index]));
+            }
         }
 
         /// <summary>Creates a new <see cref="Vector64{T}" /> from a given readonly span.</summary>
@@ -1004,8 +1024,12 @@ namespace System.Runtime.Intrinsics
             {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.values);
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            return Unsafe.ReadUnaligned<Vector64<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+            unsafe
+            {
+                return Unsafe.ReadUnaligned<Vector64<T>>(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(values)));
+            }
         }
 
         /// <summary>Creates a new <see langword="Vector64&lt;Byte&gt;" /> instance with each element initialized to the corresponding specified value.</summary>
@@ -2342,8 +2366,12 @@ namespace System.Runtime.Intrinsics
         public static Vector64<T> LoadUnsafe<T>(ref readonly T source)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector64BaseType<T>();
-            ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.AsRef(in source));
-            return Unsafe.ReadUnaligned<Vector64<T>>(in address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.AsRef(in source));
+                return Unsafe.ReadUnaligned<Vector64<T>>(in address);
+            }
         }
 
         /// <summary>Loads a vector from the given source and element offset.</summary>
@@ -2358,8 +2386,12 @@ namespace System.Runtime.Intrinsics
         public static Vector64<T> LoadUnsafe<T>(ref readonly T source, nuint elementOffset)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector64BaseType<T>();
-            ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.Add(ref Unsafe.AsRef(in source), (nint)elementOffset));
-            return Unsafe.ReadUnaligned<Vector64<T>>(in address);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref readonly byte address = ref Unsafe.As<T, byte>(ref Unsafe.Add(ref Unsafe.AsRef(in source), (nint)elementOffset));
+                return Unsafe.ReadUnaligned<Vector64<T>>(in address);
+            }
         }
 
         internal static Vector64<T> Log<T>(Vector64<T> vector)
@@ -3831,8 +3863,12 @@ namespace System.Runtime.Intrinsics
         public static void StoreUnsafe<T>(this Vector64<T> source, ref T destination)
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector64BaseType<T>();
-            ref byte address = ref Unsafe.As<T, byte>(ref destination);
-            Unsafe.WriteUnaligned(ref address, source);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref byte address = ref Unsafe.As<T, byte>(ref destination);
+                Unsafe.WriteUnaligned(ref address, source);
+            }
         }
 
         /// <summary>Stores a vector at the given destination.</summary>
@@ -3848,7 +3884,11 @@ namespace System.Runtime.Intrinsics
         {
             ThrowHelper.ThrowForUnsupportedIntrinsicsVector64BaseType<T>();
             destination = ref Unsafe.Add(ref destination, (nint)elementOffset);
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination), source);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref destination), source);
+            }
         }
 
         /// <inheritdoc cref="Vector128.Subtract{T}(Vector128{T}, Vector128{T})" />
@@ -3996,8 +4036,12 @@ namespace System.Runtime.Intrinsics
             {
                 return false;
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            unsafe
+            {
+                Unsafe.WriteUnaligned(ref Unsafe.As<T, byte>(ref MemoryMarshal.GetReference(destination)), vector);
+            }
             return true;
         }
 
@@ -4342,16 +4386,24 @@ namespace System.Runtime.Intrinsics
         internal static T GetElementUnsafe<T>(in this Vector64<T> vector, int index)
         {
             Debug.Assert((index >= 0) && (index < Vector64<T>.Count));
-            ref T address = ref Unsafe.As<Vector64<T>, T>(ref Unsafe.AsRef(in vector));
-            return Unsafe.Add(ref address, index);
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref T address = ref Unsafe.As<Vector64<T>, T>(ref Unsafe.AsRef(in vector));
+                return Unsafe.Add(ref address, index);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void SetElementUnsafe<T>(in this Vector64<T> vector, int index, T value)
         {
             Debug.Assert((index >= 0) && (index < Vector64<T>.Count));
-            ref T address = ref Unsafe.As<Vector64<T>, T>(ref Unsafe.AsRef(in vector));
-            Unsafe.Add(ref address, index) = value;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                ref T address = ref Unsafe.As<Vector64<T>, T>(ref Unsafe.AsRef(in vector));
+                Unsafe.Add(ref address, index) = value;
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64DebugView_1.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/Intrinsics/Vector64DebugView_1.cs
@@ -29,7 +29,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new double[Vector64<double>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<double, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -39,7 +43,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new short[Vector64<short>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<short, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -49,7 +57,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new int[Vector64<int>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<int, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -59,7 +71,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new long[Vector64<long>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<long, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -69,7 +85,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nint[Vector64<nint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<nint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -79,7 +99,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new nuint[Vector64<nuint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<nuint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -89,7 +113,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new sbyte[Vector64<sbyte>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<sbyte, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -99,7 +127,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new float[Vector64<float>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<float, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -109,7 +141,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ushort[Vector64<ushort>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<ushort, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -119,7 +155,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new uint[Vector64<uint>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<uint, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }
@@ -129,7 +169,11 @@ namespace System.Runtime.Intrinsics
             get
             {
                 var items = new ulong[Vector64<ulong>.Count];
-                Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<ulong, byte>(ref items[0]), _value);
+                }
                 return items;
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any1SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any1SearchValues.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -32,19 +32,43 @@ namespace System.Buffers
             *(TImpl*)&value == _e0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int IndexOfAny(ReadOnlySpan<T> span) =>
-            SpanHelpers.NonPackedIndexOfValueType<TImpl, SpanHelpers.DontNegate<TImpl>>(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, span.Length);
+        internal override int IndexOfAny(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.NonPackedIndexOfValueType<TImpl, SpanHelpers.DontNegate<TImpl>>(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int IndexOfAnyExcept(ReadOnlySpan<T> span) =>
-            SpanHelpers.NonPackedIndexOfValueType<TImpl, SpanHelpers.Negate<TImpl>>(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, span.Length);
+        internal override int IndexOfAnyExcept(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.NonPackedIndexOfValueType<TImpl, SpanHelpers.Negate<TImpl>>(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int LastIndexOfAny(ReadOnlySpan<T> span) =>
-            SpanHelpers.LastIndexOfValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, span.Length);
+        internal override int LastIndexOfAny(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.LastIndexOfValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int LastIndexOfAnyExcept(ReadOnlySpan<T> span) =>
-            SpanHelpers.LastIndexOfAnyExceptValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, span.Length);
+        internal override int LastIndexOfAnyExcept(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.LastIndexOfAnyExceptValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, span.Length);
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any2CharPackedIgnoreCaseSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any2CharPackedIgnoreCaseSearchValues.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -52,16 +52,28 @@ namespace System.Buffers
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
-        internal override int LastIndexOfAny(ReadOnlySpan<char> span) =>
-            IndexOfAnyAsciiSearcher.LastIndexOfAny<IndexOfAnyAsciiSearcher.DontNegate, IndexOfAnyAsciiSearcher.Default, SearchValues.FalseConst>(
+        internal override int LastIndexOfAny(ReadOnlySpan<char> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAnyAsciiSearcher.LastIndexOfAny<IndexOfAnyAsciiSearcher.DontNegate, IndexOfAnyAsciiSearcher.Default, SearchValues.FalseConst>(
                 ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)), span.Length, ref _state);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
-        internal override int LastIndexOfAnyExcept(ReadOnlySpan<char> span) =>
-            IndexOfAnyAsciiSearcher.LastIndexOfAny<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Default, SearchValues.FalseConst>(
+        internal override int LastIndexOfAnyExcept(ReadOnlySpan<char> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAnyAsciiSearcher.LastIndexOfAny<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Default, SearchValues.FalseConst>(
                 ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)), span.Length, ref _state);
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any2SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any2SearchValues.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -32,19 +32,43 @@ namespace System.Buffers
             *(TImpl*)&value == _e0 || *(TImpl*)&value == _e1;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int IndexOfAny(ReadOnlySpan<T> span) =>
-            SpanHelpers.NonPackedIndexOfAnyValueType<TImpl, SpanHelpers.DontNegate<TImpl>>(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, span.Length);
+        internal override int IndexOfAny(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.NonPackedIndexOfAnyValueType<TImpl, SpanHelpers.DontNegate<TImpl>>(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int IndexOfAnyExcept(ReadOnlySpan<T> span) =>
-            SpanHelpers.NonPackedIndexOfAnyValueType<TImpl, SpanHelpers.Negate<TImpl>>(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, span.Length);
+        internal override int IndexOfAnyExcept(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.NonPackedIndexOfAnyValueType<TImpl, SpanHelpers.Negate<TImpl>>(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int LastIndexOfAny(ReadOnlySpan<T> span) =>
-            SpanHelpers.LastIndexOfAnyValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, span.Length);
+        internal override int LastIndexOfAny(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.LastIndexOfAnyValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int LastIndexOfAnyExcept(ReadOnlySpan<T> span) =>
-            SpanHelpers.LastIndexOfAnyExceptValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, span.Length);
+        internal override int LastIndexOfAnyExcept(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.LastIndexOfAnyExceptValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, span.Length);
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any3SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any3SearchValues.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -32,19 +32,43 @@ namespace System.Buffers
             *(TImpl*)&value == _e0 || *(TImpl*)&value == _e1 || *(TImpl*)&value == _e2;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int IndexOfAny(ReadOnlySpan<T> span) =>
-            SpanHelpers.NonPackedIndexOfAnyValueType<TImpl, SpanHelpers.DontNegate<TImpl>>(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, span.Length);
+        internal override int IndexOfAny(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.NonPackedIndexOfAnyValueType<TImpl, SpanHelpers.DontNegate<TImpl>>(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int IndexOfAnyExcept(ReadOnlySpan<T> span) =>
-            SpanHelpers.NonPackedIndexOfAnyValueType<TImpl, SpanHelpers.Negate<TImpl>>(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, span.Length);
+        internal override int IndexOfAnyExcept(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.NonPackedIndexOfAnyValueType<TImpl, SpanHelpers.Negate<TImpl>>(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int LastIndexOfAny(ReadOnlySpan<T> span) =>
-            SpanHelpers.LastIndexOfAnyValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, span.Length);
+        internal override int LastIndexOfAny(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.LastIndexOfAnyValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int LastIndexOfAnyExcept(ReadOnlySpan<T> span) =>
-            SpanHelpers.LastIndexOfAnyExceptValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, span.Length);
+        internal override int LastIndexOfAnyExcept(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.LastIndexOfAnyExceptValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, span.Length);
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any4SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any4SearchValues.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -35,19 +35,43 @@ namespace System.Buffers
             *(TImpl*)&value == _e3;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int IndexOfAny(ReadOnlySpan<T> span) =>
-            SpanHelpers.IndexOfAnyValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, span.Length);
+        internal override int IndexOfAny(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.IndexOfAnyValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int IndexOfAnyExcept(ReadOnlySpan<T> span) =>
-            SpanHelpers.IndexOfAnyExceptValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, span.Length);
+        internal override int IndexOfAnyExcept(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.IndexOfAnyExceptValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int LastIndexOfAny(ReadOnlySpan<T> span) =>
-            SpanHelpers.LastIndexOfAnyValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, span.Length);
+        internal override int LastIndexOfAny(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.LastIndexOfAnyValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int LastIndexOfAnyExcept(ReadOnlySpan<T> span) =>
-            SpanHelpers.LastIndexOfAnyExceptValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, span.Length);
+        internal override int LastIndexOfAnyExcept(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.LastIndexOfAnyExceptValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, span.Length);
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any5SearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Any5SearchValues.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -36,19 +36,43 @@ namespace System.Buffers
             *(TImpl*)&value == _e4;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int IndexOfAny(ReadOnlySpan<T> span) =>
-            SpanHelpers.IndexOfAnyValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, _e4, span.Length);
+        internal override int IndexOfAny(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.IndexOfAnyValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, _e4, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int IndexOfAnyExcept(ReadOnlySpan<T> span) =>
-            SpanHelpers.IndexOfAnyExceptValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, _e4, span.Length);
+        internal override int IndexOfAnyExcept(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.IndexOfAnyExceptValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, _e4, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int LastIndexOfAny(ReadOnlySpan<T> span) =>
-            SpanHelpers.LastIndexOfAnyValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, _e4, span.Length);
+        internal override int LastIndexOfAny(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.LastIndexOfAnyValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, _e4, span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int LastIndexOfAnyExcept(ReadOnlySpan<T> span) =>
-            SpanHelpers.LastIndexOfAnyExceptValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, _e4, span.Length);
+        internal override int LastIndexOfAnyExcept(ReadOnlySpan<T> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.LastIndexOfAnyExceptValueType(ref Unsafe.As<T, TImpl>(ref MemoryMarshal.GetReference(span)), _e0, _e1, _e2, _e3, _e4, span.Length);
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/AsciiCharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/AsciiCharSearchValues.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -45,48 +45,84 @@ namespace System.Buffers
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int IndexOfAny(ReadOnlySpan<char> span) =>
-            IndexOfAnyAsciiSearcher.IndexOfAny<IndexOfAnyAsciiSearcher.DontNegate, TOptimizations, TUniqueLowNibble>(
+        internal override int IndexOfAny(ReadOnlySpan<char> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAnyAsciiSearcher.IndexOfAny<IndexOfAnyAsciiSearcher.DontNegate, TOptimizations, TUniqueLowNibble>(
                 ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)), span.Length, ref _state);
+            }
+        }
 
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int IndexOfAnyExcept(ReadOnlySpan<char> span) =>
-            IndexOfAnyAsciiSearcher.IndexOfAny<IndexOfAnyAsciiSearcher.Negate, TOptimizations, TUniqueLowNibble>(
+        internal override int IndexOfAnyExcept(ReadOnlySpan<char> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAnyAsciiSearcher.IndexOfAny<IndexOfAnyAsciiSearcher.Negate, TOptimizations, TUniqueLowNibble>(
                 ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)), span.Length, ref _state);
+            }
+        }
 
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int LastIndexOfAny(ReadOnlySpan<char> span) =>
-            IndexOfAnyAsciiSearcher.LastIndexOfAny<IndexOfAnyAsciiSearcher.DontNegate, TOptimizations, TUniqueLowNibble>(
+        internal override int LastIndexOfAny(ReadOnlySpan<char> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAnyAsciiSearcher.LastIndexOfAny<IndexOfAnyAsciiSearcher.DontNegate, TOptimizations, TUniqueLowNibble>(
                 ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)), span.Length, ref _state);
+            }
+        }
 
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int LastIndexOfAnyExcept(ReadOnlySpan<char> span) =>
-            IndexOfAnyAsciiSearcher.LastIndexOfAny<IndexOfAnyAsciiSearcher.Negate, TOptimizations, TUniqueLowNibble>(
+        internal override int LastIndexOfAnyExcept(ReadOnlySpan<char> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAnyAsciiSearcher.LastIndexOfAny<IndexOfAnyAsciiSearcher.Negate, TOptimizations, TUniqueLowNibble>(
                 ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)), span.Length, ref _state);
+            }
+        }
 
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override bool ContainsAny(ReadOnlySpan<char> span) =>
-            IndexOfAnyAsciiSearcher.ContainsAny<IndexOfAnyAsciiSearcher.DontNegate, TOptimizations, TUniqueLowNibble>(
+        internal override bool ContainsAny(ReadOnlySpan<char> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAnyAsciiSearcher.ContainsAny<IndexOfAnyAsciiSearcher.DontNegate, TOptimizations, TUniqueLowNibble>(
                 ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)), span.Length, ref _state);
+            }
+        }
 
         [CompExactlyDependsOn(typeof(Ssse3))]
         [CompExactlyDependsOn(typeof(AdvSimd))]
         [CompExactlyDependsOn(typeof(PackedSimd))]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override bool ContainsAnyExcept(ReadOnlySpan<char> span) =>
-            IndexOfAnyAsciiSearcher.ContainsAny<IndexOfAnyAsciiSearcher.Negate, TOptimizations, TUniqueLowNibble>(
+        internal override bool ContainsAnyExcept(ReadOnlySpan<char> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAnyAsciiSearcher.ContainsAny<IndexOfAnyAsciiSearcher.Negate, TOptimizations, TUniqueLowNibble>(
                 ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)), span.Length, ref _state);
+            }
+        }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/IndexOfAnyAsciiSearcher.cs
@@ -189,20 +189,44 @@ namespace System.Buffers
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryIndexOfAny(ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index) =>
-            TryIndexOfAny<DontNegate>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, asciiValues, out index);
+        public static bool TryIndexOfAny(ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return TryIndexOfAny<DontNegate>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, asciiValues, out index);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryIndexOfAnyExcept(ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index) =>
-            TryIndexOfAny<Negate>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, asciiValues, out index);
+        public static bool TryIndexOfAnyExcept(ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return TryIndexOfAny<Negate>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, asciiValues, out index);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryLastIndexOfAny(ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index) =>
-            TryLastIndexOfAny<DontNegate>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, asciiValues, out index);
+        public static bool TryLastIndexOfAny(ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return TryLastIndexOfAny<DontNegate>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, asciiValues, out index);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryLastIndexOfAnyExcept(ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index) =>
-            TryLastIndexOfAny<Negate>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, asciiValues, out index);
+        public static bool TryLastIndexOfAnyExcept(ref char searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return TryLastIndexOfAny<Negate>(ref Unsafe.As<char, short>(ref searchSpace), searchSpaceLength, asciiValues, out index);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe bool TryIndexOfAny<TNegator>(ref short searchSpace, int searchSpaceLength, ReadOnlySpan<char> asciiValues, out int index)

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticMap.cs
@@ -82,7 +82,11 @@ namespace System.Buffers
         {
             if (Sse41.IsSupported || AdvSimd.Arm64.IsSupported)
             {
-                Unsafe.Add(ref Unsafe.As<uint, byte>(ref charMap), value & VectorizedIndexMask) |= (byte)(1u << (value >> VectorizedIndexShift));
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.Add(ref Unsafe.As<uint, byte>(ref charMap), value & VectorizedIndexMask) |= (byte)(1u << (value >> VectorizedIndexShift));
+                }
             }
             else
             {
@@ -92,9 +96,16 @@ namespace System.Buffers
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [BypassReadyToRun]
-        private static bool IsCharBitSet(ref uint charMap, byte value) => Sse41.IsSupported || AdvSimd.Arm64.IsSupported
+        private static bool IsCharBitSet(ref uint charMap, byte value)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return Sse41.IsSupported || AdvSimd.Arm64.IsSupported
             ? (Unsafe.Add(ref Unsafe.As<uint, byte>(ref charMap), value & VectorizedIndexMask) & (1u << (value >> VectorizedIndexShift))) != 0
             : (Unsafe.Add(ref charMap, value & PortableIndexMask) & (1u << (value >> PortableIndexShift))) != 0;
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool Contains(ref uint charMap, ReadOnlySpan<char> values, int ch) =>
@@ -103,11 +114,17 @@ namespace System.Buffers
             Contains(values, (char)ch);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool Contains(ReadOnlySpan<char> values, char ch) =>
-            SpanHelpers.NonPackedContainsValueType(
+        internal static bool Contains(ReadOnlySpan<char> values, char ch)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.NonPackedContainsValueType(
                 ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(values)),
                 (short)ch,
                 values.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Avx512Vbmi))]
@@ -425,7 +442,12 @@ namespace System.Buffers
 
             ref char searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
 
-            Vector256<byte> charMap256 = Vector256.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map));
+            Vector256<byte> charMap256;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                charMap256 = Vector256.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map));
+            }
 
             if (searchSpaceLength > 32)
             {
@@ -510,8 +532,18 @@ namespace System.Buffers
             ref char searchSpaceEnd = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
             ref char cur = ref searchSpace;
 
-            Vector128<byte> charMapLower = Vector128.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map));
-            Vector128<byte> charMapUpper = Vector128.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map), (nuint)Vector128<byte>.Count);
+            Vector128<byte> charMapLower;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                charMapLower = Vector128.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map));
+            }
+            Vector128<byte> charMapUpper;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                charMapUpper = Vector128.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map), (nuint)Vector128<byte>.Count);
+            }
 
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough // In this case, we have an else clause which has the same semantic meaning whether or not Avx2 is considered supported or unsupported
             if (Avx2.IsSupported && searchSpaceLength >= 32)
@@ -600,7 +632,12 @@ namespace System.Buffers
 
             ref char cur = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
 
-            Vector256<byte> charMap256 = Vector256.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map));
+            Vector256<byte> charMap256;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                charMap256 = Vector256.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map));
+            }
 
             if (searchSpaceLength > 32)
             {
@@ -687,8 +724,18 @@ namespace System.Buffers
 
             ref char cur = ref Unsafe.Add(ref searchSpace, searchSpaceLength);
 
-            Vector128<byte> charMapLower = Vector128.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map));
-            Vector128<byte> charMapUpper = Vector128.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map), (nuint)Vector128<byte>.Count);
+            Vector128<byte> charMapLower;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                charMapLower = Vector128.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map));
+            }
+            Vector128<byte> charMapUpper;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                charMapUpper = Vector128.LoadUnsafe(ref Unsafe.As<ProbabilisticMap, byte>(ref state.Map), (nuint)Vector128<byte>.Count);
+            }
 
 #pragma warning disable IntrinsicsInSystemPrivateCoreLibAttributeNotSpecificEnough // In this case, we have an else clause which has the same semantic meaning whether or not Avx2 is considered supported or unsupported
             if (Avx2.IsSupported && searchSpaceLength >= 32)

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/ProbabilisticWithAsciiCharSearchValues.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -55,21 +55,29 @@ namespace System.Buffers
                 if ((Ssse3.IsSupported || PackedSimd.IsSupported) && typeof(TOptimizations) == typeof(IndexOfAnyAsciiSearcher.Default))
                 {
                     Debug.Assert(_inverseAsciiState.Lookup.Contains(0), "The inverse bitmap did not contain a 0.");
+                    // TODO(unsafe): Baselining unsafe usage
 
-                    offset = IndexOfAnyAsciiSearcher.IndexOfAny<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle, SearchValues.FalseConst>(
+                    unsafe
+                    {
+                        offset = IndexOfAnyAsciiSearcher.IndexOfAny<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle, SearchValues.FalseConst>(
                         ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
                         span.Length,
                         ref _inverseAsciiState);
+                    }
                 }
                 else
                 {
                     Debug.Assert(!(Ssse3.IsSupported || PackedSimd.IsSupported) || !_inverseAsciiState.Lookup.Contains(0),
                         "The inverse bitmap contained a 0, but we're not using Ssse3AndWasmHandleZeroInNeedle.");
+                    // TODO(unsafe): Baselining unsafe usage
 
-                    offset = IndexOfAnyAsciiSearcher.IndexOfAny<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Default, SearchValues.FalseConst>(
+                    unsafe
+                    {
+                        offset = IndexOfAnyAsciiSearcher.IndexOfAny<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Default, SearchValues.FalseConst>(
                         ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
                         span.Length,
                         ref _inverseAsciiState);
+                    }
                 }
 
                 // If we've reached the end of the span or stopped at an ASCII character, we've found the result.
@@ -104,11 +112,15 @@ namespace System.Buffers
             // in order to minimize the overhead this fast-path has on non-ASCII texts.
             if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count && char.IsAscii(span[0]))
             {
+                // TODO(unsafe): Baselining unsafe usage
                 // Do a regular IndexOfAnyExcept for the ASCII characters. The search will stop if we encounter a non-ASCII char.
-                offset = IndexOfAnyAsciiSearcher.IndexOfAny<IndexOfAnyAsciiSearcher.Negate, TOptimizations, SearchValues.FalseConst>(
+                unsafe
+                {
+                    offset = IndexOfAnyAsciiSearcher.IndexOfAny<IndexOfAnyAsciiSearcher.Negate, TOptimizations, SearchValues.FalseConst>(
                     ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
                     span.Length,
                     ref _asciiState);
+                }
 
                 // If we've reached the end of the span or stopped at an ASCII character, we've found the result.
                 if ((uint)offset >= (uint)span.Length || char.IsAscii(span[offset]))
@@ -154,21 +166,29 @@ namespace System.Buffers
                 if ((Ssse3.IsSupported || PackedSimd.IsSupported) && typeof(TOptimizations) == typeof(IndexOfAnyAsciiSearcher.Default))
                 {
                     Debug.Assert(_inverseAsciiState.Lookup.Contains(0), "The inverse bitmap did not contain a 0.");
+                    // TODO(unsafe): Baselining unsafe usage
 
-                    offset = IndexOfAnyAsciiSearcher.LastIndexOfAny<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle, SearchValues.FalseConst>(
+                    unsafe
+                    {
+                        offset = IndexOfAnyAsciiSearcher.LastIndexOfAny<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Ssse3AndWasmHandleZeroInNeedle, SearchValues.FalseConst>(
                         ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
                         span.Length,
                         ref _inverseAsciiState);
+                    }
                 }
                 else
                 {
                     Debug.Assert(!(Ssse3.IsSupported || PackedSimd.IsSupported) || !_inverseAsciiState.Lookup.Contains(0),
                         "The inverse bitmap contained a 0, but we're not using Ssse3AndWasmHandleZeroInNeedle.");
+                    // TODO(unsafe): Baselining unsafe usage
 
-                    offset = IndexOfAnyAsciiSearcher.LastIndexOfAny<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Default, SearchValues.FalseConst>(
+                    unsafe
+                    {
+                        offset = IndexOfAnyAsciiSearcher.LastIndexOfAny<IndexOfAnyAsciiSearcher.Negate, IndexOfAnyAsciiSearcher.Default, SearchValues.FalseConst>(
                         ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
                         span.Length,
                         ref _inverseAsciiState);
+                    }
                 }
 
                 // If we've reached the end of the span or stopped at an ASCII character, we've found the result.
@@ -194,10 +214,15 @@ namespace System.Buffers
             if (IndexOfAnyAsciiSearcher.IsVectorizationSupported && span.Length >= Vector128<short>.Count && char.IsAscii(span[^1]))
             {
                 // Do a regular LastIndexOfAnyExcept for the ASCII characters. The search will stop if we encounter a non-ASCII char.
-                int offset = IndexOfAnyAsciiSearcher.LastIndexOfAny<IndexOfAnyAsciiSearcher.Negate, TOptimizations, SearchValues.FalseConst>(
+                int offset;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    offset = IndexOfAnyAsciiSearcher.LastIndexOfAny<IndexOfAnyAsciiSearcher.Negate, TOptimizations, SearchValues.FalseConst>(
                     ref Unsafe.As<char, short>(ref MemoryMarshal.GetReference(span)),
                     span.Length,
                     ref _asciiState);
+                }
 
                 // If we've reached the end of the span or stopped at an ASCII character, we've found the result.
                 if ((uint)offset >= (uint)span.Length || char.IsAscii(span[offset]))

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/RangeCharSearchValues.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/RangeCharSearchValues.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Runtime.CompilerServices;
@@ -38,24 +38,36 @@ namespace System.Buffers
             value - _lowUint <= _highMinusLow;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int IndexOfAny(ReadOnlySpan<char> span) =>
-            (PackedSpanHelpers.PackedIndexOfIsSupported && TShouldUsePacked.Value)
+        internal override int IndexOfAny(ReadOnlySpan<char> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (PackedSpanHelpers.PackedIndexOfIsSupported && TShouldUsePacked.Value)
                 ? PackedSpanHelpers.IndexOfAnyInRange(ref MemoryMarshal.GetReference(span), _lowInclusive, _rangeInclusive, span.Length)
                 : SpanHelpers.NonPackedIndexOfAnyInRangeUnsignedNumber<ushort, SpanHelpers.DontNegate<ushort>>(
                     ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(span)),
                     _lowInclusive,
                     _highInclusive,
                     span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override int IndexOfAnyExcept(ReadOnlySpan<char> span) =>
-            (PackedSpanHelpers.PackedIndexOfIsSupported && TShouldUsePacked.Value)
+        internal override int IndexOfAnyExcept(ReadOnlySpan<char> span)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (PackedSpanHelpers.PackedIndexOfIsSupported && TShouldUsePacked.Value)
                 ? PackedSpanHelpers.IndexOfAnyExceptInRange(ref MemoryMarshal.GetReference(span), _lowInclusive, _rangeInclusive, span.Length)
                 : SpanHelpers.NonPackedIndexOfAnyInRangeUnsignedNumber<ushort, SpanHelpers.Negate<ushort>>(
                     ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(span)),
                     _lowInclusive,
                     _highInclusive,
                     span.Length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override int LastIndexOfAny(ReadOnlySpan<char> span) =>

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/SearchValues.T.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -55,9 +55,13 @@ namespace System.Buffers
                 if (values.Length > 0)
                 {
                     display += ", Values = ";
-                    display += typeof(T) == typeof(char) ?
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        display += typeof(T) == typeof(char) ?
                         "\"" + new string(Unsafe.As<T[], char[]>(ref values)) + "\"" :
                         string.Join(",", values);
+                    }
                 }
 
                 return display;

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/AsciiStringSearchValuesTeddyBase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/AsciiStringSearchValuesTeddyBase.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -559,12 +559,16 @@ namespace System.Buffers
 
                     object? bucket = _buckets[candidateOffset];
                     Debug.Assert(bucket is not null);
+                    // TODO(unsafe): Baselining unsafe usage
 
-                    if (TBucketized.Value
+                    unsafe
+                    {
+                        if (TBucketized.Value
                         ? StartsWith<TCaseSensitivity>(ref matchRef, lengthRemaining, Unsafe.As<string[]>(bucket))
                         : StartsWith<TCaseSensitivity>(ref matchRef, lengthRemaining, Unsafe.As<string>(bucket)))
                     {
                         return true;
+                        }
                     }
 
                     candidateMask = BitOperations.ResetLowestSetBit(candidateMask);
@@ -604,12 +608,16 @@ namespace System.Buffers
 
                     object? bucket = _buckets[candidateOffset];
                     Debug.Assert(bucket is not null);
+                    // TODO(unsafe): Baselining unsafe usage
 
-                    if (TBucketized.Value
+                    unsafe
+                    {
+                        if (TBucketized.Value
                         ? StartsWith<TCaseSensitivity>(ref matchRef, lengthRemaining, Unsafe.As<string[]>(bucket))
                         : StartsWith<TCaseSensitivity>(ref matchRef, lengthRemaining, Unsafe.As<string>(bucket)))
                     {
                         return true;
+                        }
                     }
 
                     candidateMask = BitOperations.ResetLowestSetBit(candidateMask);
@@ -649,12 +657,16 @@ namespace System.Buffers
 
                     object? bucket = _buckets[candidateOffset];
                     Debug.Assert(bucket is not null);
+                    // TODO(unsafe): Baselining unsafe usage
 
-                    if (TBucketized.Value
+                    unsafe
+                    {
+                        if (TBucketized.Value
                         ? StartsWith<TCaseSensitivity>(ref matchRef, lengthRemaining, Unsafe.As<string[]>(bucket))
                         : StartsWith<TCaseSensitivity>(ref matchRef, lengthRemaining, Unsafe.As<string>(bucket)))
                     {
                         return true;
+                        }
                     }
 
                     candidateMask = BitOperations.ResetLowestSetBit(candidateMask);

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/AhoCorasick.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/AhoCorasick.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -96,10 +96,15 @@ namespace System.Buffers
                     // If '\0' is one of the starting chars and we're running on Ssse3 hardware, this may return false-positives.
                     // False-positives here are okay, we'll just rule them out below. While we could flow the Ssse3AndWasmHandleZeroInNeedle
                     // generic through, we expect such values to be rare enough that introducing more code is not worth it.
-                    int offset = IndexOfAnyAsciiSearcher.IndexOfAny<IndexOfAnyAsciiSearcher.DontNegate, IndexOfAnyAsciiSearcher.Default, SearchValues.FalseConst>(
+                    int offset;
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        offset = IndexOfAnyAsciiSearcher.IndexOfAny<IndexOfAnyAsciiSearcher.DontNegate, IndexOfAnyAsciiSearcher.Default, SearchValues.FalseConst>(
                         ref Unsafe.As<char, short>(ref Unsafe.Add(ref MemoryMarshal.GetReference(span), i)),
                         remainingLength,
                         ref Unsafe.AsRef(in _startingAsciiChars));
+                    }
 
                     if (offset < 0)
                     {
@@ -205,10 +210,15 @@ namespace System.Buffers
 
                 if (remainingLength >= Vector128<ushort>.Count)
                 {
-                    int offset = IndexOfAnyAsciiSearcher.IndexOfAny<IndexOfAnyAsciiSearcher.DontNegate, IndexOfAnyAsciiSearcher.Default, SearchValues.FalseConst>(
+                    int offset;
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        offset = IndexOfAnyAsciiSearcher.IndexOfAny<IndexOfAnyAsciiSearcher.DontNegate, IndexOfAnyAsciiSearcher.Default, SearchValues.FalseConst>(
                         ref Unsafe.As<char, short>(ref Unsafe.Add(ref MemoryMarshal.GetReference(span), i)),
                         remainingLength,
                         ref Unsafe.AsRef(in _startingAsciiChars));
+                    }
 
                     if (offset < 0)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/AhoCorasickNode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/AhoCorasickNode.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -53,7 +53,11 @@ namespace System.Buffers
             }
             else
             {
-                return Unsafe.As<Dictionary<char, int>>(children).TryGetValue(c, out index);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return Unsafe.As<Dictionary<char, int>>(children).TryGetValue(c, out index);
+                }
             }
 
             index = 0;

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/StringSearchValuesHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/Helpers/StringSearchValuesHelper.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -72,10 +72,14 @@ namespace System.Buffers
         {
             if (typeof(TCaseSensitivity) == typeof(CaseSensitive))
             {
-                return SpanHelpers.SequenceEqual(
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return SpanHelpers.SequenceEqual(
                     ref Unsafe.As<char, byte>(ref matchStart),
                     ref candidate.GetRawStringDataAsUInt8(),
                     (uint)candidate.Length * sizeof(char));
+                }
             }
 
             if (typeof(TCaseSensitivity) == typeof(CaseInsensitiveAscii) ||
@@ -263,18 +267,24 @@ namespace System.Buffers
                 }
                 else if (typeof(TValueLength) == typeof(ValueLength4To8))
                 {
-                    ref byte matchByteStart = ref Unsafe.As<char, byte>(ref matchStart);
-                    ulong differentBits = Unsafe.ReadUnaligned<ulong>(ref matchByteStart) - state.Value64_0;
-                    differentBits |= Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref matchByteStart, state.SecondReadByteOffset)) - state.Value64_1;
-                    return differentBits == 0;
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        ref byte matchByteStart = ref Unsafe.As<char, byte>(ref matchStart);
+                        ulong differentBits = Unsafe.ReadUnaligned<ulong>(ref matchByteStart) - state.Value64_0;
+                        differentBits |= Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref matchByteStart, state.SecondReadByteOffset)) - state.Value64_1;
+                        return differentBits == 0;
+                    }
                 }
                 else
                 {
                     Debug.Assert(state.Value.Length is 2 or 3);
+                    // TODO(unsafe): Baselining unsafe usage
 
-                    ref byte matchByteStart = ref Unsafe.As<char, byte>(ref matchStart);
-
-                    if (AdvSimd.IsSupported)
+                    unsafe
+                    {
+                        ref byte matchByteStart = ref Unsafe.As<char, byte>(ref matchStart);
+                        if (AdvSimd.IsSupported)
                     {
                         // See comments on SingleStringSearchValuesPackedThreeChars.CanSkipAnchorMatchVerification.
                         // When running on Arm64, this helper is also used to confirm vectorized anchor matches.
@@ -295,6 +305,7 @@ namespace System.Buffers
                         Debug.Assert(matchStart == state.Value[0], "This should only be called after the first character has been checked");
 
                         return Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref matchByteStart, state.SecondReadByteOffset)) == state.Value32_1;
+                        }
                     }
                 }
             }
@@ -331,19 +342,25 @@ namespace System.Buffers
                 else if (typeof(TValueLength) == typeof(ValueLength4To8))
                 {
                     const ulong CaseMask = ~0x20002000200020u;
-                    ref byte matchByteStart = ref Unsafe.As<char, byte>(ref matchStart);
-                    ulong differentBits = (Unsafe.ReadUnaligned<ulong>(ref matchByteStart) & CaseMask) - state.Value64_0;
-                    differentBits |= (Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref matchByteStart, state.SecondReadByteOffset)) & CaseMask) - state.Value64_1;
-                    return differentBits == 0;
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        ref byte matchByteStart = ref Unsafe.As<char, byte>(ref matchStart);
+                        ulong differentBits = (Unsafe.ReadUnaligned<ulong>(ref matchByteStart) & CaseMask) - state.Value64_0;
+                        differentBits |= (Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref matchByteStart, state.SecondReadByteOffset)) & CaseMask) - state.Value64_1;
+                        return differentBits == 0;
+                    }
                 }
                 else
                 {
                     Debug.Assert(state.Value.Length is 2 or 3);
 
                     const uint CaseMask = ~0x200020u;
-                    ref byte matchByteStart = ref Unsafe.As<char, byte>(ref matchStart);
-
-                    if (AdvSimd.IsSupported)
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        ref byte matchByteStart = ref Unsafe.As<char, byte>(ref matchStart);
+                        if (AdvSimd.IsSupported)
                     {
                         // See comments on SingleStringSearchValuesPackedThreeChars.CanSkipAnchorMatchVerification.
                         // When running on Arm64, this helper is also used to confirm vectorized anchor matches.
@@ -364,6 +381,7 @@ namespace System.Buffers
                         Debug.Assert(TransformInput(matchStart) == state.Value[0], "This should only be called after the first character has been checked");
 
                         return (Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref matchByteStart, state.SecondReadByteOffset)) & CaseMask) == state.Value32_1;
+                        }
                     }
                 }
             }
@@ -423,19 +441,27 @@ namespace System.Buffers
                 }
                 else if (typeof(TValueLength) == typeof(ValueLength4To8))
                 {
-                    ref byte matchByteStart = ref Unsafe.As<char, byte>(ref matchStart);
-                    ulong differentBits = (Unsafe.ReadUnaligned<ulong>(ref matchByteStart) & state.ToUpperMask64_0) - state.Value64_0;
-                    differentBits |= (Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref matchByteStart, state.SecondReadByteOffset)) & state.ToUpperMask64_1) - state.Value64_1;
-                    return differentBits == 0;
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        ref byte matchByteStart = ref Unsafe.As<char, byte>(ref matchStart);
+                        ulong differentBits = (Unsafe.ReadUnaligned<ulong>(ref matchByteStart) & state.ToUpperMask64_0) - state.Value64_0;
+                        differentBits |= (Unsafe.ReadUnaligned<ulong>(ref Unsafe.Add(ref matchByteStart, state.SecondReadByteOffset)) & state.ToUpperMask64_1) - state.Value64_1;
+                        return differentBits == 0;
+                    }
                 }
                 else
                 {
                     Debug.Assert(state.Value.Length is 2 or 3);
+                    // TODO(unsafe): Baselining unsafe usage
 
-                    ref byte matchByteStart = ref Unsafe.As<char, byte>(ref matchStart);
-                    uint differentBits = (Unsafe.ReadUnaligned<uint>(ref matchByteStart) & state.ToUpperMask32_0) - state.Value32_0;
-                    differentBits |= (Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref matchByteStart, state.SecondReadByteOffset)) & state.ToUpperMask32_1) - state.Value32_1;
-                    return differentBits == 0;
+                    unsafe
+                    {
+                        ref byte matchByteStart = ref Unsafe.As<char, byte>(ref matchStart);
+                        uint differentBits = (Unsafe.ReadUnaligned<uint>(ref matchByteStart) & state.ToUpperMask32_0) - state.Value32_0;
+                        differentBits |= (Unsafe.ReadUnaligned<uint>(ref Unsafe.Add(ref matchByteStart, state.SecondReadByteOffset)) & state.ToUpperMask32_1) - state.Value32_1;
+                        return differentBits == 0;
+                    }
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/SingleStringSearchValuesThreeChars.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SearchValues/Strings/SingleStringSearchValuesThreeChars.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -256,8 +256,18 @@ namespace System.Buffers
             if (typeof(TCaseSensitivity) == typeof(CaseSensitive))
             {
                 Vector128<ushort> cmpCh1 = Vector128.Equals(ch1, Vector128.LoadUnsafe(ref searchSpace));
-                Vector128<ushort> cmpCh2 = Vector128.Equals(ch2, Vector128.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch2ByteOffset).AsUInt16());
-                Vector128<ushort> cmpCh3 = Vector128.Equals(ch3, Vector128.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch3ByteOffset).AsUInt16());
+                Vector128<ushort> cmpCh2;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    cmpCh2 = Vector128.Equals(ch2, Vector128.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch2ByteOffset).AsUInt16());
+                }
+                Vector128<ushort> cmpCh3;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    cmpCh3 = Vector128.Equals(ch3, Vector128.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch3ByteOffset).AsUInt16());
+                }
                 // AND all 3 together to get a mask of possible match positions that match in at least 3 places.
                 return (cmpCh1 & cmpCh2 & cmpCh3).AsByte();
             }
@@ -269,8 +279,18 @@ namespace System.Buffers
                 Vector128<ushort> caseConversion = Vector128.Create(CaseConversionMask);
 
                 Vector128<ushort> cmpCh1 = Vector128.Equals(ch1, Vector128.LoadUnsafe(ref searchSpace) & caseConversion);
-                Vector128<ushort> cmpCh2 = Vector128.Equals(ch2, Vector128.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch2ByteOffset).AsUInt16() & caseConversion);
-                Vector128<ushort> cmpCh3 = Vector128.Equals(ch3, Vector128.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch3ByteOffset).AsUInt16() & caseConversion);
+                Vector128<ushort> cmpCh2;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    cmpCh2 = Vector128.Equals(ch2, Vector128.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch2ByteOffset).AsUInt16() & caseConversion);
+                }
+                Vector128<ushort> cmpCh3;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    cmpCh3 = Vector128.Equals(ch3, Vector128.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch3ByteOffset).AsUInt16() & caseConversion);
+                }
                 // AND all 3 together to get a mask of possible match positions that likely match in at least 3 places.
                 return (cmpCh1 & cmpCh2 & cmpCh3).AsByte();
             }
@@ -284,8 +304,18 @@ namespace System.Buffers
             if (typeof(TCaseSensitivity) == typeof(CaseSensitive))
             {
                 Vector256<ushort> cmpCh1 = Vector256.Equals(ch1, Vector256.LoadUnsafe(ref searchSpace));
-                Vector256<ushort> cmpCh2 = Vector256.Equals(ch2, Vector256.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch2ByteOffset).AsUInt16());
-                Vector256<ushort> cmpCh3 = Vector256.Equals(ch3, Vector256.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch3ByteOffset).AsUInt16());
+                Vector256<ushort> cmpCh2;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    cmpCh2 = Vector256.Equals(ch2, Vector256.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch2ByteOffset).AsUInt16());
+                }
+                Vector256<ushort> cmpCh3;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    cmpCh3 = Vector256.Equals(ch3, Vector256.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch3ByteOffset).AsUInt16());
+                }
                 return (cmpCh1 & cmpCh2 & cmpCh3).AsByte();
             }
             else
@@ -293,8 +323,18 @@ namespace System.Buffers
                 Vector256<ushort> caseConversion = Vector256.Create(CaseConversionMask);
 
                 Vector256<ushort> cmpCh1 = Vector256.Equals(ch1, Vector256.LoadUnsafe(ref searchSpace) & caseConversion);
-                Vector256<ushort> cmpCh2 = Vector256.Equals(ch2, Vector256.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch2ByteOffset).AsUInt16() & caseConversion);
-                Vector256<ushort> cmpCh3 = Vector256.Equals(ch3, Vector256.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch3ByteOffset).AsUInt16() & caseConversion);
+                Vector256<ushort> cmpCh2;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    cmpCh2 = Vector256.Equals(ch2, Vector256.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch2ByteOffset).AsUInt16() & caseConversion);
+                }
+                Vector256<ushort> cmpCh3;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    cmpCh3 = Vector256.Equals(ch3, Vector256.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch3ByteOffset).AsUInt16() & caseConversion);
+                }
                 return (cmpCh1 & cmpCh2 & cmpCh3).AsByte();
             }
         }
@@ -307,8 +347,18 @@ namespace System.Buffers
             if (typeof(TCaseSensitivity) == typeof(CaseSensitive))
             {
                 Vector512<ushort> cmpCh1 = Vector512.Equals(ch1, Vector512.LoadUnsafe(ref searchSpace));
-                Vector512<ushort> cmpCh2 = Vector512.Equals(ch2, Vector512.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch2ByteOffset).AsUInt16());
-                Vector512<ushort> cmpCh3 = Vector512.Equals(ch3, Vector512.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch3ByteOffset).AsUInt16());
+                Vector512<ushort> cmpCh2;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    cmpCh2 = Vector512.Equals(ch2, Vector512.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch2ByteOffset).AsUInt16());
+                }
+                Vector512<ushort> cmpCh3;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    cmpCh3 = Vector512.Equals(ch3, Vector512.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch3ByteOffset).AsUInt16());
+                }
                 return (cmpCh1 & cmpCh2 & cmpCh3).AsByte();
             }
             else
@@ -316,8 +366,18 @@ namespace System.Buffers
                 Vector512<ushort> caseConversion = Vector512.Create(CaseConversionMask);
 
                 Vector512<ushort> cmpCh1 = Vector512.Equals(ch1, Vector512.LoadUnsafe(ref searchSpace) & caseConversion);
-                Vector512<ushort> cmpCh2 = Vector512.Equals(ch2, Vector512.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch2ByteOffset).AsUInt16() & caseConversion);
-                Vector512<ushort> cmpCh3 = Vector512.Equals(ch3, Vector512.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch3ByteOffset).AsUInt16() & caseConversion);
+                Vector512<ushort> cmpCh2;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    cmpCh2 = Vector512.Equals(ch2, Vector512.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch2ByteOffset).AsUInt16() & caseConversion);
+                }
+                Vector512<ushort> cmpCh3;
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    cmpCh3 = Vector512.Equals(ch3, Vector512.LoadUnsafe(ref Unsafe.As<char, byte>(ref searchSpace), ch3ByteOffset).AsUInt16() & caseConversion);
+                }
                 return (cmpCh1 & cmpCh2 & cmpCh3).AsByte();
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Span.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Span.cs
@@ -379,7 +379,11 @@ namespace System
         {
             if (typeof(T) == typeof(char))
             {
-                return new string(new ReadOnlySpan<char>(ref Unsafe.As<T, char>(ref _reference), _length));
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return new string(new ReadOnlySpan<char>(ref Unsafe.As<T, char>(ref _reference), _length));
+                }
             }
             return $"System.Span<{typeof(T).Name}>[{_length}]";
         }

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Char.cs
@@ -33,11 +33,13 @@ namespace System
             {
                 goto SEARCH_TWO_CHARS;
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            ref byte valueTail = ref Unsafe.As<char, byte>(ref Unsafe.Add(ref value, 1));
-            int remainingSearchSpaceLength = searchSpaceMinusValueTailLength;
-
-            while (remainingSearchSpaceLength > 0)
+            unsafe
+            {
+                ref byte valueTail = ref Unsafe.As<char, byte>(ref Unsafe.Add(ref value, 1));
+                int remainingSearchSpaceLength = searchSpaceMinusValueTailLength;
+                while (remainingSearchSpaceLength > 0)
             {
                 // Do a quick search for the first element of "value".
                 // Using the non-packed variant as the input is short and would not benefit from the packed implementation.
@@ -62,6 +64,7 @@ namespace System
 
                 remainingSearchSpaceLength--;
                 offset++;
+                }
             }
             return -1;
 
@@ -117,12 +120,16 @@ namespace System
                         int bitPos = BitOperations.TrailingZeroCount(mask);
                         // div by 2 (shr) because we work with 2-byte chars
                         nint charPos = (nint)((uint)bitPos / 2);
-                        if (valueLength == 2 || // we already matched two chars
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            if (valueLength == 2 || // we already matched two chars
                             SequenceEqual(
                                 ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
                                 ref Unsafe.As<char, byte>(ref value), (nuint)(uint)valueLength * 2))
                         {
                             return (int)(offset + charPos);
+                            }
                         }
 
                         // Clear two the lowest set bits
@@ -182,12 +189,16 @@ namespace System
                     do
                     {
                         nint charPos = (nint)(uint.TrailingZeroCount(mask) / sizeof(ushort));
-                        if (valueLength == 2 || // we already matched two chars
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            if (valueLength == 2 || // we already matched two chars
                             SequenceEqual(
                                 ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
                                 ref Unsafe.As<char, byte>(ref value), (nuint)(uint)valueLength * 2))
                         {
                             return (int)(offset + charPos);
+                            }
                         }
 
                         // Clear two the lowest set bits
@@ -244,12 +255,16 @@ namespace System
                     do
                     {
                         nint charPos = (nint)(uint.TrailingZeroCount(mask) / sizeof(ushort));
-                        if (valueLength == 2 || // we already matched two chars
+                        // TODO(unsafe): Baselining unsafe usage
+                        unsafe
+                        {
+                            if (valueLength == 2 || // we already matched two chars
                             SequenceEqual(
                                 ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
                                 ref Unsafe.As<char, byte>(ref value), (nuint)(uint)valueLength * 2))
                         {
                             return (int)(offset + charPos);
+                            }
                         }
 
                         // Clear two lowest set bits
@@ -271,7 +286,13 @@ namespace System
 
             int valueTailLength = valueLength - 1;
             if (valueTailLength == 0)
-                return LastIndexOfValueType(ref Unsafe.As<char, short>(ref searchSpace), (short)value, searchSpaceLength); // for single-char values use plain LastIndexOf
+            {
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return LastIndexOfValueType(ref Unsafe.As<char, short>(ref searchSpace), (short)value, searchSpaceLength);
+                }
+            } // for single-char values use plain LastIndexOf
 
             int offset = 0;
             char valueHead = value;
@@ -280,10 +301,12 @@ namespace System
             {
                 goto SEARCH_TWO_CHARS;
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            ref byte valueTail = ref Unsafe.As<char, byte>(ref Unsafe.Add(ref value, 1));
-
-            while (true)
+            unsafe
+            {
+                ref byte valueTail = ref Unsafe.As<char, byte>(ref Unsafe.Add(ref value, 1));
+                while (true)
             {
                 Debug.Assert(0 <= offset && offset <= searchSpaceLength); // Ensures no deceptive underflows in the computation of "remainingSearchSpaceLength".
                 int remainingSearchSpaceLength = searchSpaceLength - offset - valueTailLength;
@@ -304,6 +327,7 @@ namespace System
                 }
 
                 offset += remainingSearchSpaceLength - relativeIndex;
+                }
             }
             return -1;
 
@@ -340,13 +364,17 @@ namespace System
                             // unlike IndexOf, here we use LZCNT to process matches starting from the end
                             int bitPos = 62 - BitOperations.LeadingZeroCount(mask);
                             int charPos = (int)((uint)bitPos / 2);
+                            // TODO(unsafe): Baselining unsafe usage
 
-                            if (valueLength == 2 || // we already matched two chars
+                            unsafe
+                            {
+                                if (valueLength == 2 || // we already matched two chars
                                 SequenceEqual(
                                     ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
                                     ref Unsafe.As<char, byte>(ref value), (nuint)(uint)valueLength * 2))
                             {
                                 return charPos + offset;
+                                }
                             }
                             mask &= ~(ulong)((ulong)0b11 << bitPos); // clear two highest set bits.
                         } while (mask != 0);
@@ -390,13 +418,17 @@ namespace System
                             // unlike IndexOf, here we use LZCNT to process matches starting from the end
                             int bitPos = 30 - BitOperations.LeadingZeroCount(mask);
                             int charPos = (int)((uint)bitPos / 2);
+                            // TODO(unsafe): Baselining unsafe usage
 
-                            if (valueLength == 2 || // we already matched two chars
+                            unsafe
+                            {
+                                if (valueLength == 2 || // we already matched two chars
                                 SequenceEqual(
                                     ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
                                     ref Unsafe.As<char, byte>(ref value), (nuint)(uint)valueLength * 2))
                             {
                                 return charPos + offset;
+                                }
                             }
                             mask &= ~(uint)(0b11 << bitPos); // clear two highest set bits.
                         } while (mask != 0);
@@ -440,13 +472,17 @@ namespace System
                             // unlike IndexOf, here we use LZCNT to process matches starting from the end
                             int bitPos = 30 - BitOperations.LeadingZeroCount(mask);
                             int charPos = (int)((uint)bitPos / 2);
+                            // TODO(unsafe): Baselining unsafe usage
 
-                            if (valueLength == 2 || // we already matched two chars
+                            unsafe
+                            {
+                                if (valueLength == 2 || // we already matched two chars
                                 SequenceEqual(
                                     ref Unsafe.As<char, byte>(ref Unsafe.Add(ref searchSpace, offset + charPos)),
                                     ref Unsafe.As<char, byte>(ref value), (nuint)(uint)valueLength * 2))
                             {
                                 return charPos + offset;
+                                }
                             }
                             mask &= ~(uint)(0b11 << bitPos); // clear two the highest set bits.
                         } while (mask != 0);
@@ -896,28 +932,20 @@ namespace System
                 nint lastOffset = remainder - Vector512<ushort>.Count;
                 do
                 {
-                    ref ushort first = ref Unsafe.As<char, ushort>(ref Unsafe.Add(ref buf, offset));
-                    ref ushort last = ref Unsafe.As<char, ushort>(ref Unsafe.Add(ref buf, lastOffset));
-
-                    Vector512<ushort> tempFirst = Vector512.LoadUnsafe(ref first);
-                    Vector512<ushort> tempLast = Vector512.LoadUnsafe(ref last);
-
-                    // Shuffle to reverse each vector:
-                    //     +-------------------------------+
-                    //     | A | B | C | D | E | F | G | H |
-                    //     +-------------------------------+
-                    //          --->
-                    //     +-------------------------------+
-                    //     | H | G | F | E | D | C | B | A |
-                    //     +-------------------------------+
-                    tempFirst = Vector512.Shuffle(tempFirst, Vector512.Create((ushort)31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        ref ushort first = ref Unsafe.As<char, ushort>(ref Unsafe.Add(ref buf, offset));
+                        ref ushort last = ref Unsafe.As<char, ushort>(ref Unsafe.Add(ref buf, lastOffset));
+                        Vector512<ushort> tempFirst = Vector512.LoadUnsafe(ref first);
+                        Vector512<ushort> tempLast = Vector512.LoadUnsafe(ref last);
+                        tempFirst = Vector512.Shuffle(tempFirst, Vector512.Create((ushort)31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
                         15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0));
-                    tempLast = Vector512.Shuffle(tempLast, Vector512.Create((ushort)31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
+                        tempLast = Vector512.Shuffle(tempLast, Vector512.Create((ushort)31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16,
                         15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0));
-
-                    // Store the reversed vectors
-                    tempLast.StoreUnsafe(ref first);
-                    tempFirst.StoreUnsafe(ref last);
+                        tempLast.StoreUnsafe(ref first);
+                        tempFirst.StoreUnsafe(ref last);
+                    }
 
                     offset += Vector512<ushort>.Count;
                     lastOffset -= Vector512<ushort>.Count;
@@ -935,33 +963,20 @@ namespace System
                 nint lastOffset = remainder - Vector256<ushort>.Count;
                 do
                 {
-                    ref byte first = ref Unsafe.As<char, byte>(ref Unsafe.Add(ref buf, offset));
-                    ref byte last = ref Unsafe.As<char, byte>(ref Unsafe.Add(ref buf, lastOffset));
-
-                    Vector256<byte> tempFirst = Vector256.LoadUnsafe(ref first);
-                    Vector256<byte> tempLast = Vector256.LoadUnsafe(ref last);
-
-                    // Avx2 operates on two 128-bit lanes rather than the full 256-bit vector.
-                    // Perform a shuffle to reverse each 128-bit lane, then permute to finish reversing the vector:
-                    //     +---------------------------------------------------------------+
-                    //     | A | B | C | D | E | F | G | H | I | J | K | L | M | N | O | P |
-                    //     +---------------------------------------------------------------+
-                    //         Shuffle --->
-                    //     +---------------------------------------------------------------+
-                    //     | H | G | F | E | D | C | B | A | P | O | N | M | L | K | J | I |
-                    //     +---------------------------------------------------------------+
-                    //         Permute --->
-                    //     +---------------------------------------------------------------+
-                    //     | P | O | N | M | L | K | J | I | H | G | F | E | D | C | B | A |
-                    //     +---------------------------------------------------------------+
-                    tempFirst = Avx2.Shuffle(tempFirst, reverseMask);
-                    tempFirst = Avx2.Permute2x128(tempFirst, tempFirst, 0b00_01);
-                    tempLast = Avx2.Shuffle(tempLast, reverseMask);
-                    tempLast = Avx2.Permute2x128(tempLast, tempLast, 0b00_01);
-
-                    // Store the reversed vectors
-                    tempLast.StoreUnsafe(ref first);
-                    tempFirst.StoreUnsafe(ref last);
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        ref byte first = ref Unsafe.As<char, byte>(ref Unsafe.Add(ref buf, offset));
+                        ref byte last = ref Unsafe.As<char, byte>(ref Unsafe.Add(ref buf, lastOffset));
+                        Vector256<byte> tempFirst = Vector256.LoadUnsafe(ref first);
+                        Vector256<byte> tempLast = Vector256.LoadUnsafe(ref last);
+                        tempFirst = Avx2.Shuffle(tempFirst, reverseMask);
+                        tempFirst = Avx2.Permute2x128(tempFirst, tempFirst, 0b00_01);
+                        tempLast = Avx2.Shuffle(tempLast, reverseMask);
+                        tempLast = Avx2.Permute2x128(tempLast, tempLast, 0b00_01);
+                        tempLast.StoreUnsafe(ref first);
+                        tempFirst.StoreUnsafe(ref last);
+                    }
 
                     offset += Vector256<ushort>.Count;
                     lastOffset -= Vector256<ushort>.Count;
@@ -974,26 +989,18 @@ namespace System
                 nint lastOffset = remainder - Vector128<ushort>.Count;
                 do
                 {
-                    ref ushort first = ref Unsafe.As<char, ushort>(ref Unsafe.Add(ref buf, offset));
-                    ref ushort last = ref Unsafe.As<char, ushort>(ref Unsafe.Add(ref buf, lastOffset));
-
-                    Vector128<ushort> tempFirst = Vector128.LoadUnsafe(ref first);
-                    Vector128<ushort> tempLast = Vector128.LoadUnsafe(ref last);
-
-                    // Shuffle to reverse each vector:
-                    //     +-------------------------------+
-                    //     | A | B | C | D | E | F | G | H |
-                    //     +-------------------------------+
-                    //          --->
-                    //     +-------------------------------+
-                    //     | H | G | F | E | D | C | B | A |
-                    //     +-------------------------------+
-                    tempFirst = Vector128.Shuffle(tempFirst, Vector128.Create((ushort)7, 6, 5, 4, 3, 2, 1, 0));
-                    tempLast = Vector128.Shuffle(tempLast, Vector128.Create((ushort)7, 6, 5, 4, 3, 2, 1, 0));
-
-                    // Store the reversed vectors
-                    tempLast.StoreUnsafe(ref first);
-                    tempFirst.StoreUnsafe(ref last);
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        ref ushort first = ref Unsafe.As<char, ushort>(ref Unsafe.Add(ref buf, offset));
+                        ref ushort last = ref Unsafe.As<char, ushort>(ref Unsafe.Add(ref buf, lastOffset));
+                        Vector128<ushort> tempFirst = Vector128.LoadUnsafe(ref first);
+                        Vector128<ushort> tempLast = Vector128.LoadUnsafe(ref last);
+                        tempFirst = Vector128.Shuffle(tempFirst, Vector128.Create((ushort)7, 6, 5, 4, 3, 2, 1, 0));
+                        tempLast = Vector128.Shuffle(tempLast, Vector128.Create((ushort)7, 6, 5, 4, 3, 2, 1, 0));
+                        tempLast.StoreUnsafe(ref first);
+                        tempFirst.StoreUnsafe(ref last);
+                    }
 
                     offset += Vector128<ushort>.Count;
                     lastOffset -= Vector128<ushort>.Count;

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Packed.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.Packed.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
@@ -30,41 +30,81 @@ namespace System
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
-        public static int IndexOf(ref char searchSpace, char value, int length) =>
-            IndexOf<SpanHelpers.DontNegate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+        public static int IndexOf(ref char searchSpace, char value, int length)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOf<SpanHelpers.DontNegate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
-        public static int IndexOfAnyExcept(ref char searchSpace, char value, int length) =>
-            IndexOf<SpanHelpers.Negate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+        public static int IndexOfAnyExcept(ref char searchSpace, char value, int length)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOf<SpanHelpers.Negate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
-        public static int IndexOfAny(ref char searchSpace, char value0, char value1, int length) =>
-            IndexOfAny<SpanHelpers.DontNegate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+        public static int IndexOfAny(ref char searchSpace, char value0, char value1, int length)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAny<SpanHelpers.DontNegate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
-        public static int IndexOfAnyExcept(ref char searchSpace, char value0, char value1, int length) =>
-            IndexOfAny<SpanHelpers.Negate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+        public static int IndexOfAnyExcept(ref char searchSpace, char value0, char value1, int length)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAny<SpanHelpers.Negate<short>, NopTransform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
-        public static int IndexOfAny(ref char searchSpace, char value0, char value1, char value2, int length) =>
-            IndexOfAny<SpanHelpers.DontNegate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, (short)value2, length);
+        public static int IndexOfAny(ref char searchSpace, char value0, char value1, char value2, int length)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAny<SpanHelpers.DontNegate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, (short)value2, length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
-        public static int IndexOfAnyExcept(ref char searchSpace, char value0, char value1, char value2, int length) =>
-            IndexOfAny<SpanHelpers.Negate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, (short)value2, length);
+        public static int IndexOfAnyExcept(ref char searchSpace, char value0, char value1, char value2, int length)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAny<SpanHelpers.Negate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, (short)value2, length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
         public static int IndexOfAnyIgnoreCase(ref char searchSpace, char value, int length)
         {
             Debug.Assert((value | 0x20) == value);
+            // TODO(unsafe): Baselining unsafe usage
 
-            return IndexOf<SpanHelpers.DontNegate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+            unsafe
+            {
+                return IndexOf<SpanHelpers.DontNegate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -72,8 +112,12 @@ namespace System
         public static int IndexOfAnyExceptIgnoreCase(ref char searchSpace, char value, int length)
         {
             Debug.Assert((value | 0x20) == value);
+            // TODO(unsafe): Baselining unsafe usage
 
-            return IndexOf<SpanHelpers.Negate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+            unsafe
+            {
+                return IndexOf<SpanHelpers.Negate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -82,8 +126,12 @@ namespace System
         {
             Debug.Assert((value0 | 0x20) == value0);
             Debug.Assert((value1 | 0x20) == value1);
+            // TODO(unsafe): Baselining unsafe usage
 
-            return IndexOfAny<SpanHelpers.DontNegate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+            unsafe
+            {
+                return IndexOfAny<SpanHelpers.DontNegate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -92,19 +140,35 @@ namespace System
         {
             Debug.Assert((value0 | 0x20) == value0);
             Debug.Assert((value1 | 0x20) == value1);
+            // TODO(unsafe): Baselining unsafe usage
 
-            return IndexOfAny<SpanHelpers.Negate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+            unsafe
+            {
+                return IndexOfAny<SpanHelpers.Negate<short>, Or20Transform>(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+            }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
-        public static int IndexOfAnyInRange(ref char searchSpace, char lowInclusive, char rangeInclusive, int length) =>
-            IndexOfAnyInRange<SpanHelpers.DontNegate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)lowInclusive, (short)rangeInclusive, length);
+        public static int IndexOfAnyInRange(ref char searchSpace, char lowInclusive, char rangeInclusive, int length)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAnyInRange<SpanHelpers.DontNegate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)lowInclusive, (short)rangeInclusive, length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CompExactlyDependsOn(typeof(Sse2))]
-        public static int IndexOfAnyExceptInRange(ref char searchSpace, char lowInclusive, char rangeInclusive, int length) =>
-            IndexOfAnyInRange<SpanHelpers.Negate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)lowInclusive, (short)rangeInclusive, length);
+        public static int IndexOfAnyExceptInRange(ref char searchSpace, char lowInclusive, char rangeInclusive, int length)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAnyInRange<SpanHelpers.Negate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)lowInclusive, (short)rangeInclusive, length);
+            }
+        }
 
         [CompExactlyDependsOn(typeof(Sse2))]
         public static bool Contains(ref short searchSpace, short value, int length)

--- a/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/SpanHelpers.T.cs
@@ -1463,7 +1463,11 @@ namespace System
         {
             if (PackedSpanHelpers.PackedIndexOfIsSupported && typeof(T) == typeof(short) && PackedSpanHelpers.CanUsePackedIndexOf(value))
             {
-                return PackedSpanHelpers.Contains(ref Unsafe.As<T, short>(ref searchSpace), Unsafe.BitCast<T, short>(value), length);
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return PackedSpanHelpers.Contains(ref Unsafe.As<T, short>(ref searchSpace), Unsafe.BitCast<T, short>(value), length);
+                }
             }
 
             return NonPackedContainsValueType(ref searchSpace, value, length);
@@ -1621,15 +1625,33 @@ namespace System
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int IndexOfChar(ref char searchSpace, char value, int length)
-            => IndexOfValueType(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfValueType(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int LastIndexOfChar(ref char searchSpace, char value, int length)
-            => LastIndexOfValueType(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return LastIndexOfValueType(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int NonPackedIndexOfChar(ref char searchSpace, char value, int length) =>
-            NonPackedIndexOfValueType<short, DontNegate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+        internal static int NonPackedIndexOfChar(ref char searchSpace, char value, int length)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return NonPackedIndexOfValueType<short, DontNegate<short>>(ref Unsafe.As<char, short>(ref searchSpace), (short)value, length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int IndexOfValueType<T>(ref T searchSpace, T value, int length) where T : struct, INumber<T>
@@ -1646,9 +1668,13 @@ namespace System
         {
             if (PackedSpanHelpers.PackedIndexOfIsSupported && typeof(TValue) == typeof(short) && PackedSpanHelpers.CanUsePackedIndexOf(value))
             {
-                return typeof(TNegator) == typeof(DontNegate<short>)
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return typeof(TNegator) == typeof(DontNegate<short>)
                     ? PackedSpanHelpers.IndexOf(ref Unsafe.As<TValue, char>(ref searchSpace), Unsafe.BitCast<TValue, char>(value), length)
                     : PackedSpanHelpers.IndexOfAnyExcept(ref Unsafe.As<TValue, char>(ref searchSpace), Unsafe.BitCast<TValue, char>(value), length);
+                }
             }
 
             return NonPackedIndexOfValueType<TValue, TNegator>(ref searchSpace, value, length);
@@ -1840,11 +1866,23 @@ namespace System
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int IndexOfAnyChar(ref char searchSpace, char value0, char value1, int length)
-            => IndexOfAnyValueType(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IndexOfAnyValueType(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int LastIndexOfAnyChar(ref char searchSpace, char value0, char value1, int length)
-            => LastIndexOfAnyValueType(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return LastIndexOfAnyValueType(ref Unsafe.As<char, short>(ref searchSpace), (short)value0, (short)value1, length);
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int IndexOfAnyValueType<T>(ref T searchSpace, T value0, T value1, int length) where T : struct, INumber<T>
@@ -1872,16 +1910,24 @@ namespace System
                     if ((char0 ^ char1) == 0x20)
                     {
                         char lowerCase = (char)Math.Max(char0, char1);
+                        // TODO(unsafe): Baselining unsafe usage
 
-                        return typeof(TNegator) == typeof(DontNegate<short>)
+                        unsafe
+                        {
+                            return typeof(TNegator) == typeof(DontNegate<short>)
                             ? PackedSpanHelpers.IndexOfAnyIgnoreCase(ref Unsafe.As<TValue, char>(ref searchSpace), lowerCase, length)
                             : PackedSpanHelpers.IndexOfAnyExceptIgnoreCase(ref Unsafe.As<TValue, char>(ref searchSpace), lowerCase, length);
+                        }
                     }
                 }
+                // TODO(unsafe): Baselining unsafe usage
 
-                return typeof(TNegator) == typeof(DontNegate<short>)
+                unsafe
+                {
+                    return typeof(TNegator) == typeof(DontNegate<short>)
                     ? PackedSpanHelpers.IndexOfAny(ref Unsafe.As<TValue, char>(ref searchSpace), char0, char1, length)
                     : PackedSpanHelpers.IndexOfAnyExcept(ref Unsafe.As<TValue, char>(ref searchSpace), char0, char1, length);
+                }
             }
 
             return NonPackedIndexOfAnyValueType<TValue, TNegator>(ref searchSpace, value0, value1, length);
@@ -2121,9 +2167,13 @@ namespace System
         {
             if (PackedSpanHelpers.PackedIndexOfIsSupported && typeof(TValue) == typeof(short) && PackedSpanHelpers.CanUsePackedIndexOf(value0) && PackedSpanHelpers.CanUsePackedIndexOf(value1) && PackedSpanHelpers.CanUsePackedIndexOf(value2))
             {
-                return typeof(TNegator) == typeof(DontNegate<short>)
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    return typeof(TNegator) == typeof(DontNegate<short>)
                     ? PackedSpanHelpers.IndexOfAny(ref Unsafe.As<TValue, char>(ref searchSpace), Unsafe.BitCast<TValue, char>(value0), Unsafe.BitCast<TValue, char>(value1), Unsafe.BitCast<TValue, char>(value2), length)
                     : PackedSpanHelpers.IndexOfAnyExcept(ref Unsafe.As<TValue, char>(ref searchSpace), Unsafe.BitCast<TValue, char>(value0), Unsafe.BitCast<TValue, char>(value1), Unsafe.BitCast<TValue, char>(value2), length);
+                }
             }
 
             return NonPackedIndexOfAnyValueType<TValue, TNegator>(ref searchSpace, value0, value1, value2, length);
@@ -3868,13 +3918,16 @@ namespace System
         {
             if (PackedSpanHelpers.PackedIndexOfIsSupported && typeof(T) == typeof(ushort) && PackedSpanHelpers.CanUsePackedIndexOf(lowInclusive) && PackedSpanHelpers.CanUsePackedIndexOf(highInclusive) && highInclusive >= lowInclusive)
             {
-                ref char charSearchSpace = ref Unsafe.As<T, char>(ref searchSpace);
-                char charLowInclusive = Unsafe.BitCast<T, char>(lowInclusive);
-                char charRange = (char)(Unsafe.BitCast<T, char>(highInclusive) - charLowInclusive);
-
-                return typeof(TNegator) == typeof(DontNegate<ushort>)
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    ref char charSearchSpace = ref Unsafe.As<T, char>(ref searchSpace);
+                    char charLowInclusive = Unsafe.BitCast<T, char>(lowInclusive);
+                    char charRange = (char)(Unsafe.BitCast<T, char>(highInclusive) - charLowInclusive);
+                    return typeof(TNegator) == typeof(DontNegate<ushort>)
                     ? PackedSpanHelpers.IndexOfAnyInRange(ref charSearchSpace, charLowInclusive, charRange, length)
                     : PackedSpanHelpers.IndexOfAnyExceptInRange(ref charSearchSpace, charLowInclusive, charRange, length);
+                }
             }
 
             return NonPackedIndexOfAnyInRangeUnsignedNumber<T, TNegator>(ref searchSpace, lowInclusive, highInclusive, length);

--- a/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Comparison.cs
@@ -684,9 +684,13 @@ namespace System
         public override int GetHashCode()
         {
             ulong seed = Marvin.DefaultSeed;
+            // TODO(unsafe): Baselining unsafe usage
 
             // Multiplication below will not overflow since going from positive Int32 to UInt32.
-            return Marvin.ComputeHash32(ref Unsafe.As<char, byte>(ref _firstChar), (uint)_stringLength * 2 /* in bytes, not chars */, (uint)seed, (uint)(seed >> 32));
+            unsafe
+            {
+                return Marvin.ComputeHash32(ref Unsafe.As<char, byte>(ref _firstChar), (uint)_stringLength * 2 /* in bytes, not chars */, (uint)seed, (uint)(seed >> 32));
+            }
         }
 
         // Gets a hash code for this string and this comparison. If strings A and B and comparison C are such
@@ -705,9 +709,13 @@ namespace System
         public static int GetHashCode(ReadOnlySpan<char> value)
         {
             ulong seed = Marvin.DefaultSeed;
+            // TODO(unsafe): Baselining unsafe usage
 
             // Multiplication below will not overflow since going from positive Int32 to UInt32.
-            return Marvin.ComputeHash32(ref Unsafe.As<char, byte>(ref MemoryMarshal.GetReference(value)), (uint)value.Length * 2 /* in bytes, not chars */, (uint)seed, (uint)(seed >> 32));
+            unsafe
+            {
+                return Marvin.ComputeHash32(ref Unsafe.As<char, byte>(ref MemoryMarshal.GetReference(value)), (uint)value.Length * 2 /* in bytes, not chars */, (uint)seed, (uint)(seed >> 32));
+            }
         }
 
         // A span-based equivalent of String.GetHashCode(StringComparison). Uses the specified comparison type.

--- a/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Manipulation.cs
@@ -943,7 +943,12 @@ namespace System
                     // and string.Concat(IEnumerable<char>) can be used as an efficient
                     // enumerable-based equivalent of new string(char[]).
 
-                    IEnumerator<char> en = Unsafe.As<IEnumerator<char>>(e);
+                    IEnumerator<char> en;
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        en = Unsafe.As<IEnumerator<char>>(e);
+                    }
 
                     char c = en.Current; // save the first value
                     if (!en.MoveNext())
@@ -2072,13 +2077,16 @@ namespace System
             else
             {
                 var map = new ProbabilisticMap(separators);
-                ref uint charMap = ref Unsafe.As<ProbabilisticMap, uint>(ref map);
-
-                for (int i = 0; i < source.Length; i++)
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    ref uint charMap = ref Unsafe.As<ProbabilisticMap, uint>(ref map);
+                    for (int i = 0; i < source.Length; i++)
                 {
                     if (ProbabilisticMap.Contains(ref charMap, separators, source[i]))
                     {
                         sepListBuilder.Append(i);
+                    }
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs
@@ -36,7 +36,13 @@ namespace System
         }
 
         public bool Contains(char value)
-            => SpanHelpers.ContainsValueType(ref Unsafe.As<char, short>(ref _firstChar), (short)value, Length);
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.ContainsValueType(ref Unsafe.As<char, short>(ref _firstChar), (short)value, Length);
+            }
+        }
 
         public bool Contains(char value, StringComparison comparisonType)
         {
@@ -443,7 +449,13 @@ namespace System
         // The character at position startIndex is included in the search.  startIndex is the larger
         // index within the string.
         public int LastIndexOf(char value)
-            => SpanHelpers.LastIndexOfValueType(ref Unsafe.As<char, short>(ref _firstChar), (short)value, Length);
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return SpanHelpers.LastIndexOfValueType(ref Unsafe.As<char, short>(ref _firstChar), (short)value, Length);
+            }
+        }
 
         public int LastIndexOf(char value, int startIndex)
         {
@@ -468,7 +480,12 @@ namespace System
             }
 
             int startSearchAt = startIndex + 1 - count;
-            int result = SpanHelpers.LastIndexOfValueType(ref Unsafe.As<char, short>(ref Unsafe.Add(ref _firstChar, startSearchAt)), (short)value, count);
+            int result;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                result = SpanHelpers.LastIndexOfValueType(ref Unsafe.As<char, short>(ref Unsafe.Add(ref _firstChar, startSearchAt)), (short)value, count);
+            }
 
             return result < 0 ? result : result + startSearchAt;
         }

--- a/src/libraries/System.Private.CoreLib/src/System/String.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/String.cs
@@ -525,8 +525,23 @@ namespace System
         public ref readonly char GetPinnableReference() => ref _firstChar;
 
         internal ref char GetRawStringData() => ref _firstChar;
-        internal ref byte GetRawStringDataAsUInt8() => ref Unsafe.As<char, byte>(ref _firstChar);
-        internal ref ushort GetRawStringDataAsUInt16() => ref Unsafe.As<char, ushort>(ref _firstChar);
+        internal ref byte GetRawStringDataAsUInt8()
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return ref Unsafe.As<char, byte>(ref _firstChar);
+            }
+        }
+
+        internal ref ushort GetRawStringDataAsUInt16()
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return ref Unsafe.As<char, ushort>(ref _firstChar);
+            }
+        }
 
         // Helper for encodings so they can talk to our buffer directly
         // stringLength must be the exact size we'll expect

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Equality.cs
@@ -27,8 +27,14 @@ namespace System.Text
 
         /// <inheritdoc cref="Equals(ReadOnlySpan{byte}, ReadOnlySpan{byte})"/>
         public static bool Equals(ReadOnlySpan<byte> left, ReadOnlySpan<char> right)
-            => left.Length == right.Length
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return left.Length == right.Length
             && Equals<byte, ushort, WideningLoader>(ref MemoryMarshal.GetReference(left), ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(right)), (uint)right.Length);
+            }
+        }
 
         /// <inheritdoc cref="Equals(ReadOnlySpan{byte}, ReadOnlySpan{char})"/>
         public static bool Equals(ReadOnlySpan<char> left, ReadOnlySpan<byte> right)
@@ -36,8 +42,14 @@ namespace System.Text
 
         /// <inheritdoc cref="Equals(ReadOnlySpan{byte}, ReadOnlySpan{char})"/>
         public static bool Equals(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
-            => left.Length == right.Length
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return left.Length == right.Length
             && Equals<ushort, ushort, PlainLoader<ushort>>(ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(left)), ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(right)), (uint)right.Length);
+            }
+        }
 
         private static bool Equals<TLeft, TRight, TLoader>(ref TLeft left, ref TRight right, nuint length)
             where TLeft : unmanaged, INumberBase<TLeft>
@@ -178,8 +190,14 @@ namespace System.Text
 
         /// <inheritdoc cref="EqualsIgnoreCase(ReadOnlySpan{byte}, ReadOnlySpan{byte})"/>
         public static bool EqualsIgnoreCase(ReadOnlySpan<byte> left, ReadOnlySpan<char> right)
-            => left.Length == right.Length
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return left.Length == right.Length
             && EqualsIgnoreCase<byte, ushort, WideningLoader>(ref MemoryMarshal.GetReference(left), ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(right)), (uint)right.Length);
+            }
+        }
 
         /// <inheritdoc cref="EqualsIgnoreCase(ReadOnlySpan{byte}, ReadOnlySpan{byte})"/>
         public static bool EqualsIgnoreCase(ReadOnlySpan<char> left, ReadOnlySpan<byte> right)
@@ -187,11 +205,23 @@ namespace System.Text
 
         /// <inheritdoc cref="EqualsIgnoreCase(ReadOnlySpan{byte}, ReadOnlySpan{byte})"/>
         public static bool EqualsIgnoreCase(ReadOnlySpan<char> left, ReadOnlySpan<char> right)
-            => left.Length == right.Length
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return left.Length == right.Length
             && EqualsIgnoreCase<ushort, ushort, PlainLoader<ushort>>(ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(left)), ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(right)), (uint)right.Length);
+            }
+        }
 
-        internal static bool EqualsIgnoreCase(ref char left, ref char right, nuint length) =>
-            EqualsIgnoreCase<ushort, ushort, PlainLoader<ushort>>(ref Unsafe.As<char, ushort>(ref left), ref Unsafe.As<char, ushort>(ref right), length);
+        internal static bool EqualsIgnoreCase(ref char left, ref char right, nuint length)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return EqualsIgnoreCase<ushort, ushort, PlainLoader<ushort>>(ref Unsafe.As<char, ushort>(ref left), ref Unsafe.As<char, ushort>(ref right), length);
+            }
+        }
 
         private static bool EqualsIgnoreCase<TLeft, TRight, TLoader>(ref TLeft left, ref TRight right, nuint length)
             where TLeft : unmanaged, INumberBase<TLeft>

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.Utility.cs
@@ -2282,13 +2282,21 @@ namespace System.Text
             {
                 Vector128<byte> vecNarrow = AdvSimd.DuplicateToVector128(value).AsByte();
                 Vector128<ulong> vecWide = AdvSimd.Arm64.ZipLow(vecNarrow, Vector128<byte>.Zero).AsUInt64();
-                Unsafe.WriteUnaligned(ref Unsafe.As<char, byte>(ref outputBuffer), vecWide.ToScalar());
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<char, byte>(ref outputBuffer), vecWide.ToScalar());
+                }
             }
             else if (Vector128.IsHardwareAccelerated)
             {
                 Vector128<byte> vecNarrow = Vector128.CreateScalar(value).AsByte();
                 Vector128<ulong> vecWide = Vector128.WidenLower(vecNarrow).AsUInt64();
-                Unsafe.WriteUnaligned(ref Unsafe.As<char, byte>(ref outputBuffer), vecWide.ToScalar());
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
+                    Unsafe.WriteUnaligned(ref Unsafe.As<char, byte>(ref outputBuffer), vecWide.ToScalar());
+                }
             }
             else
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Ascii.cs
@@ -28,8 +28,14 @@ namespace System.Text
         /// <returns>True if <paramref name="value"/> contains only ASCII chars or is
         /// empty; False otherwise.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsValid(ReadOnlySpan<char> value) =>
-            IsValidCore(ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(value)), value.Length);
+        public static bool IsValid(ReadOnlySpan<char> value)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return IsValidCore(ref Unsafe.As<char, ushort>(ref MemoryMarshal.GetReference(value)), value.Length);
+            }
+        }
 
         /// <summary>
         /// Determines whether the provided value is ASCII byte.

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Interlocked.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Interlocked.cs
@@ -38,8 +38,14 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of location is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static uint Decrement(ref uint location) =>
-            (uint)Add(ref Unsafe.As<uint, int>(ref location), -1);
+        public static uint Decrement(ref uint location)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (uint)Add(ref Unsafe.As<uint, int>(ref location), -1);
+            }
+        }
 
         /// <summary>Decrements a specified variable and stores the result, as an atomic operation.</summary>
         /// <param name="location">The variable whose value is to be decremented.</param>
@@ -47,8 +53,14 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of location is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static ulong Decrement(ref ulong location) =>
-            (ulong)Add(ref Unsafe.As<ulong, long>(ref location), -1);
+        public static ulong Decrement(ref ulong location)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (ulong)Add(ref Unsafe.As<ulong, long>(ref location), -1);
+            }
+        }
         #endregion
 
         #region Exchange
@@ -60,8 +72,14 @@ namespace System.Threading
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static sbyte Exchange(ref sbyte location1, sbyte value) =>
-            (sbyte)Exchange(ref Unsafe.As<sbyte, byte>(ref location1), (byte)value);
+        public static sbyte Exchange(ref sbyte location1, sbyte value)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (sbyte)Exchange(ref Unsafe.As<sbyte, byte>(ref location1), (byte)value);
+            }
+        }
 
         /// <summary>Sets a 16-bit unsigned integer to a specified value and returns the original value, as an atomic operation.</summary>
         /// <param name="location1">The variable to set to the specified value.</param>
@@ -70,8 +88,14 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of location1 is a null pointer.</exception>
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static short Exchange(ref short location1, short value) =>
-            (short)Exchange(ref Unsafe.As<short, ushort>(ref location1), (ushort)value);
+        public static short Exchange(ref short location1, short value)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (short)Exchange(ref Unsafe.As<short, ushort>(ref location1), (ushort)value);
+            }
+        }
 
         /// <summary>Sets a 8-bit unsigned integer to a specified value and returns the original value, as an atomic operation.</summary>
         /// <param name="location1">The variable to set to the specified value.</param>
@@ -158,8 +182,14 @@ namespace System.Threading
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static uint Exchange(ref uint location1, uint value) =>
-            (uint)Exchange(ref Unsafe.As<uint, int>(ref location1), (int)value);
+        public static uint Exchange(ref uint location1, uint value)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (uint)Exchange(ref Unsafe.As<uint, int>(ref location1), (int)value);
+            }
+        }
 
         /// <summary>Sets a 64-bit unsigned integer to a specified value and returns the original value, as an atomic operation.</summary>
         /// <param name="location1">The variable to set to the specified value.</param>
@@ -169,8 +199,14 @@ namespace System.Threading
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static ulong Exchange(ref ulong location1, ulong value) =>
-            (ulong)Exchange(ref Unsafe.As<ulong, long>(ref location1), (long)value);
+        public static ulong Exchange(ref ulong location1, ulong value)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (ulong)Exchange(ref Unsafe.As<ulong, long>(ref location1), (long)value);
+            }
+        }
 
         /// <summary>Sets a single-precision floating point number to a specified value and returns the original value, as an atomic operation.</summary>
         /// <param name="location1">The variable to set to the specified value.</param>
@@ -179,7 +215,13 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of location1 is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float Exchange(ref float location1, float value)
-            => Unsafe.BitCast<int, float>(Exchange(ref Unsafe.As<float, int>(ref location1), Unsafe.BitCast<float, int>(value)));
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return Unsafe.BitCast<int, float>(Exchange(ref Unsafe.As<float, int>(ref location1), Unsafe.BitCast<float, int>(value)));
+            }
+        }
 
         /// <summary>Sets a double-precision floating point number to a specified value and returns the original value, as an atomic operation.</summary>
         /// <param name="location1">The variable to set to the specified value.</param>
@@ -188,7 +230,13 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of location1 is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double Exchange(ref double location1, double value)
-            => Unsafe.BitCast<long, double>(Exchange(ref Unsafe.As<double, long>(ref location1), Unsafe.BitCast<double, long>(value)));
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return Unsafe.BitCast<long, double>(Exchange(ref Unsafe.As<double, long>(ref location1), Unsafe.BitCast<double, long>(value)));
+            }
+        }
 
         /// <summary>Sets a native-sized signed integer to a specified value and returns the original value, as an atomic operation.</summary>
         /// <param name="location1">The variable to set to the specified value.</param>
@@ -199,11 +247,15 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nint Exchange(ref nint location1, nint value)
         {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
 #if TARGET_64BIT
-            return (nint)Exchange(ref Unsafe.As<nint, long>(ref location1), (long)value);
+                return (nint)Exchange(ref Unsafe.As<nint, long>(ref location1), (long)value);
 #else
-            return (nint)Exchange(ref Unsafe.As<nint, int>(ref location1), (int)value);
+                return (nint)Exchange(ref Unsafe.As<nint, int>(ref location1), (int)value);
 #endif
+            }
         }
 
         /// <summary>Sets a native-sized unsigned integer to a specified value and returns the original value, as an atomic operation.</summary>
@@ -216,11 +268,15 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nuint Exchange(ref nuint location1, nuint value)
         {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
 #if TARGET_64BIT
-            return (nuint)Exchange(ref Unsafe.As<nuint, long>(ref location1), (long)value);
+                return (nuint)Exchange(ref Unsafe.As<nuint, long>(ref location1), (long)value);
 #else
-            return (nuint)Exchange(ref Unsafe.As<nuint, int>(ref location1), (int)value);
+                return (nuint)Exchange(ref Unsafe.As<nuint, int>(ref location1), (int)value);
 #endif
+            }
         }
 
         /// <summary>Sets a variable of the specified type <typeparamref name="T"/> to a specified value and returns the original value, as an atomic operation.</summary>
@@ -294,8 +350,14 @@ namespace System.Threading
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static sbyte CompareExchange(ref sbyte location1, sbyte value, sbyte comparand) =>
-            (sbyte)CompareExchange(ref Unsafe.As<sbyte, byte>(ref location1), (byte)value, (byte)comparand);
+        public static sbyte CompareExchange(ref sbyte location1, sbyte value, sbyte comparand)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (sbyte)CompareExchange(ref Unsafe.As<sbyte, byte>(ref location1), (byte)value, (byte)comparand);
+            }
+        }
 
         /// <summary>Compares two 16-bit unsigned integers for equality and, if they are equal, replaces the first value.</summary>
         /// <param name="location1">The destination, whose value is compared with <paramref name="comparand"/> and possibly replaced.</param>
@@ -305,8 +367,14 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static short CompareExchange(ref short location1, short value, short comparand) =>
-            (short)CompareExchange(ref Unsafe.As<short, ushort>(ref location1), (ushort)value, (ushort)comparand);
+        public static short CompareExchange(ref short location1, short value, short comparand)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (short)CompareExchange(ref Unsafe.As<short, ushort>(ref location1), (ushort)value, (ushort)comparand);
+            }
+        }
 
         /// <summary>Compares two 8-bit unsigned integers for equality and, if they are equal, replaces the first value.</summary>
         /// <param name="location1">The destination, whose value is compared with <paramref name="comparand"/> and possibly replaced.</param>
@@ -402,8 +470,14 @@ namespace System.Threading
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static uint CompareExchange(ref uint location1, uint value, uint comparand) =>
-            (uint)CompareExchange(ref Unsafe.As<uint, int>(ref location1), (int)value, (int)comparand);
+        public static uint CompareExchange(ref uint location1, uint value, uint comparand)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (uint)CompareExchange(ref Unsafe.As<uint, int>(ref location1), (int)value, (int)comparand);
+            }
+        }
 
         /// <summary>Compares two 64-bit unsigned integers for equality and, if they are equal, replaces the first value.</summary>
         /// <param name="location1">The destination, whose value is compared with <paramref name="comparand"/> and possibly replaced.</param>
@@ -414,8 +488,14 @@ namespace System.Threading
         [Intrinsic]
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static ulong CompareExchange(ref ulong location1, ulong value, ulong comparand) =>
-            (ulong)CompareExchange(ref Unsafe.As<ulong, long>(ref location1), (long)value, (long)comparand);
+        public static ulong CompareExchange(ref ulong location1, ulong value, ulong comparand)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (ulong)CompareExchange(ref Unsafe.As<ulong, long>(ref location1), (long)value, (long)comparand);
+            }
+        }
 
         /// <summary>Compares two single-precision floating point numbers for equality and, if they are equal, replaces the first value.</summary>
         /// <param name="location1">The destination, whose value is compared with <paramref name="comparand"/> and possibly replaced.</param>
@@ -425,7 +505,13 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static float CompareExchange(ref float location1, float value, float comparand)
-            => Unsafe.BitCast<int, float>(CompareExchange(ref Unsafe.As<float, int>(ref location1), Unsafe.BitCast<float, int>(value), Unsafe.BitCast<float, int>(comparand)));
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return Unsafe.BitCast<int, float>(CompareExchange(ref Unsafe.As<float, int>(ref location1), Unsafe.BitCast<float, int>(value), Unsafe.BitCast<float, int>(comparand)));
+            }
+        }
 
         /// <summary>Compares two double-precision floating point numbers for equality and, if they are equal, replaces the first value.</summary>
         /// <param name="location1">The destination, whose value is compared with <paramref name="comparand"/> and possibly replaced.</param>
@@ -435,7 +521,13 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static double CompareExchange(ref double location1, double value, double comparand)
-            => Unsafe.BitCast<long, double>(CompareExchange(ref Unsafe.As<double, long>(ref location1), Unsafe.BitCast<double, long>(value), Unsafe.BitCast<double, long>(comparand)));
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return Unsafe.BitCast<long, double>(CompareExchange(ref Unsafe.As<double, long>(ref location1), Unsafe.BitCast<double, long>(value), Unsafe.BitCast<double, long>(comparand)));
+            }
+        }
 
         /// <summary>Compares two native-sized signed integers for equality and, if they are equal, replaces the first one.</summary>
         /// <param name="location1">The destination, whose value is compared with the value of <paramref name="comparand"/> and possibly replaced by <paramref name="value"/>.</param>
@@ -447,11 +539,15 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nint CompareExchange(ref nint location1, nint value, nint comparand)
         {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
 #if TARGET_64BIT
-            return (nint)CompareExchange(ref Unsafe.As<nint, long>(ref location1), (long)value, (long)comparand);
+                return (nint)CompareExchange(ref Unsafe.As<nint, long>(ref location1), (long)value, (long)comparand);
 #else
-            return (nint)CompareExchange(ref Unsafe.As<nint, int>(ref location1), (int)value, (int)comparand);
+                return (nint)CompareExchange(ref Unsafe.As<nint, int>(ref location1), (int)value, (int)comparand);
 #endif
+            }
         }
 
         /// <summary>Compares two native-sized unsigned integers for equality and, if they are equal, replaces the first one.</summary>
@@ -465,11 +561,15 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static nuint CompareExchange(ref nuint location1, nuint value, nuint comparand)
         {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
 #if TARGET_64BIT
-            return (nuint)CompareExchange(ref Unsafe.As<nuint, long>(ref location1), (long)value, (long)comparand);
+                return (nuint)CompareExchange(ref Unsafe.As<nuint, long>(ref location1), (long)value, (long)comparand);
 #else
-            return (nuint)CompareExchange(ref Unsafe.As<nuint, int>(ref location1), (int)value, (int)comparand);
+                return (nuint)CompareExchange(ref Unsafe.As<nuint, int>(ref location1), (int)value, (int)comparand);
 #endif
+            }
         }
 
         /// <summary>Compares two instances of the specified type <typeparamref name="T"/> for equality and, if they are equal, replaces the first one.</summary>
@@ -546,8 +646,14 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static uint Add(ref uint location1, uint value) =>
-            (uint)Add(ref Unsafe.As<uint, int>(ref location1), (int)value);
+        public static uint Add(ref uint location1, uint value)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (uint)Add(ref Unsafe.As<uint, int>(ref location1), (int)value);
+            }
+        }
 
         /// <summary>Adds two 64-bit unsigned integers and replaces the first integer with the sum, as an atomic operation.</summary>
         /// <param name="location1">A variable containing the first value to be added. The sum of the two values is stored in <paramref name="location1"/>.</param>
@@ -556,8 +662,14 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static ulong Add(ref ulong location1, ulong value) =>
-            (ulong)Add(ref Unsafe.As<ulong, long>(ref location1), (long)value);
+        public static ulong Add(ref ulong location1, ulong value)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (ulong)Add(ref Unsafe.As<ulong, long>(ref location1), (long)value);
+            }
+        }
         #endregion
 
         #region Read
@@ -600,8 +712,14 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static uint And(ref uint location1, uint value) =>
-            (uint)And(ref Unsafe.As<uint, int>(ref location1), (int)value);
+        public static uint And(ref uint location1, uint value)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (uint)And(ref Unsafe.As<uint, int>(ref location1), (int)value);
+            }
+        }
 
         /// <summary>Bitwise "ands" two 64-bit signed integers and replaces the first integer with the result, as an atomic operation.</summary>
         /// <param name="location1">A variable containing the first value to be combined. The result is stored in <paramref name="location1"/>.</param>
@@ -632,8 +750,14 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static ulong And(ref ulong location1, ulong value) =>
-            (ulong)And(ref Unsafe.As<ulong, long>(ref location1), (long)value);
+        public static ulong And(ref ulong location1, ulong value)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (ulong)And(ref Unsafe.As<ulong, long>(ref location1), (long)value);
+            }
+        }
 
         /// <summary>Bitwise "ands" two values of type <typeparamref name="T"/> and replaces the first value with the result, as an atomic operation.</summary>
         /// <param name="location1">A variable containing the first value to be combined. The result is stored in <paramref name="location1"/>.</param>
@@ -743,8 +867,14 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static uint Or(ref uint location1, uint value) =>
-            (uint)Or(ref Unsafe.As<uint, int>(ref location1), (int)value);
+        public static uint Or(ref uint location1, uint value)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (uint)Or(ref Unsafe.As<uint, int>(ref location1), (int)value);
+            }
+        }
 
         /// <summary>Bitwise "ors" two 64-bit signed integers and replaces the first integer with the result, as an atomic operation.</summary>
         /// <param name="location1">A variable containing the first value to be combined. The result is stored in <paramref name="location1"/>.</param>
@@ -775,8 +905,14 @@ namespace System.Threading
         /// <exception cref="NullReferenceException">The address of <paramref name="location1"/> is a null pointer.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         [CLSCompliant(false)]
-        public static ulong Or(ref ulong location1, ulong value) =>
-            (ulong)Or(ref Unsafe.As<ulong, long>(ref location1), (long)value);
+        public static ulong Or(ref ulong location1, ulong value)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (ulong)Or(ref Unsafe.As<ulong, long>(ref location1), (long)value);
+            }
+        }
 
         /// <summary>Bitwise "ors" two values of type <typeparamref name="T"/> and replaces the first value with the result, as an atomic operation.</summary>
         /// <param name="location1">A variable containing the first value to be combined. The result is stored in <paramref name="location1"/>.</param>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -2381,8 +2381,12 @@ namespace System.Threading.Tasks
         private static readonly ContextCallback s_ecCallback = obj =>
         {
             Debug.Assert(obj is Task);
+            // TODO(unsafe): Baselining unsafe usage
             // Only used privately to pass directly to EC.Run
-            Unsafe.As<Task>(obj).InnerInvoke();
+            unsafe
+            {
+                Unsafe.As<Task>(obj).InnerInvoke();
+            }
         };
 
         /// <summary>
@@ -6728,7 +6732,11 @@ namespace System.Threading.Tasks
                 // since if argument was strongly-typed as an array, it would have bound to the array-based overload.
                 if (tasks.GetType() == typeof(List<TTask>))
                 {
-                    return WhenAnyCore((ReadOnlySpan<TTask>)CollectionsMarshal.AsSpan(Unsafe.As<List<TTask>>(tasks)));
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        return WhenAnyCore((ReadOnlySpan<TTask>)CollectionsMarshal.AsSpan(Unsafe.As<List<TTask>>(tasks)));
+                    }
                 }
                 if (tasks is TTask[] tasksAsArray)
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/ValueTask.cs
@@ -173,19 +173,27 @@ namespace System.Threading.Tasks
         {
             object? obj = _obj;
             Debug.Assert(obj == null || obj is Task || obj is IValueTaskSource);
-            return
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return
                 obj == null ? Task.CompletedTask :
                 obj as Task ??
                 GetTaskForValueTaskSource(Unsafe.As<IValueTaskSource>(obj));
+            }
         }
 
         internal object AsTaskOrNotifier()
         {
             object? obj = _obj;
             Debug.Assert(obj is Task || obj is IValueTaskSource);
-            return
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return
                 obj as Task ??
                 (object)new ValueTaskSourceNotifier(Unsafe.As<IValueTaskSource>(obj), _token);
+            }
         }
 
         private sealed class ValueTaskSourceNotifier : IValueTaskSourceNotifier
@@ -333,8 +341,12 @@ namespace System.Threading.Tasks
                 {
                     return t.IsCompleted;
                 }
+                // TODO(unsafe): Baselining unsafe usage
 
-                return Unsafe.As<IValueTaskSource>(obj).GetStatus(_token) != ValueTaskSourceStatus.Pending;
+                unsafe
+                {
+                    return Unsafe.As<IValueTaskSource>(obj).GetStatus(_token) != ValueTaskSourceStatus.Pending;
+                }
             }
         }
 
@@ -356,8 +368,12 @@ namespace System.Threading.Tasks
                 {
                     return t.IsCompletedSuccessfully;
                 }
+                // TODO(unsafe): Baselining unsafe usage
 
-                return Unsafe.As<IValueTaskSource>(obj).GetStatus(_token) == ValueTaskSourceStatus.Succeeded;
+                unsafe
+                {
+                    return Unsafe.As<IValueTaskSource>(obj).GetStatus(_token) == ValueTaskSourceStatus.Succeeded;
+                }
             }
         }
 
@@ -378,8 +394,12 @@ namespace System.Threading.Tasks
                 {
                     return t.IsFaulted;
                 }
+                // TODO(unsafe): Baselining unsafe usage
 
-                return Unsafe.As<IValueTaskSource>(obj).GetStatus(_token) == ValueTaskSourceStatus.Faulted;
+                unsafe
+                {
+                    return Unsafe.As<IValueTaskSource>(obj).GetStatus(_token) == ValueTaskSourceStatus.Faulted;
+                }
             }
         }
 
@@ -405,8 +425,12 @@ namespace System.Threading.Tasks
                 {
                     return t.IsCanceled;
                 }
+                // TODO(unsafe): Baselining unsafe usage
 
-                return Unsafe.As<IValueTaskSource>(obj).GetStatus(_token) == ValueTaskSourceStatus.Canceled;
+                unsafe
+                {
+                    return Unsafe.As<IValueTaskSource>(obj).GetStatus(_token) == ValueTaskSourceStatus.Canceled;
+                }
             }
         }
 
@@ -425,7 +449,11 @@ namespace System.Threading.Tasks
                 }
                 else
                 {
-                    Unsafe.As<IValueTaskSource>(obj).GetResult(_token);
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        Unsafe.As<IValueTaskSource>(obj).GetResult(_token);
+                    }
                 }
             }
         }
@@ -608,17 +636,25 @@ namespace System.Threading.Tasks
             {
                 return t;
             }
+            // TODO(unsafe): Baselining unsafe usage
 
-            return GetTaskForValueTaskSource(Unsafe.As<IValueTaskSource<TResult>>(obj));
+            unsafe
+            {
+                return GetTaskForValueTaskSource(Unsafe.As<IValueTaskSource<TResult>>(obj));
+            }
         }
 
         internal object AsTaskOrNotifier()
         {
             object? obj = _obj;
             Debug.Assert(obj is Task<TResult> || obj is IValueTaskSource<TResult>);
-            return
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return
                 obj as Task ??
                 (object)new ValueTaskSourceNotifier(Unsafe.As<IValueTaskSource<TResult>>(obj), _token);
+            }
         }
 
         private sealed class ValueTaskSourceNotifier : IValueTaskSourceNotifier
@@ -764,8 +800,12 @@ namespace System.Threading.Tasks
                 {
                     return t.IsCompleted;
                 }
+                // TODO(unsafe): Baselining unsafe usage
 
-                return Unsafe.As<IValueTaskSource<TResult>>(obj).GetStatus(_token) != ValueTaskSourceStatus.Pending;
+                unsafe
+                {
+                    return Unsafe.As<IValueTaskSource<TResult>>(obj).GetStatus(_token) != ValueTaskSourceStatus.Pending;
+                }
             }
         }
 
@@ -787,8 +827,12 @@ namespace System.Threading.Tasks
                 {
                     return t.IsCompletedSuccessfully;
                 }
+                // TODO(unsafe): Baselining unsafe usage
 
-                return Unsafe.As<IValueTaskSource<TResult>>(obj).GetStatus(_token) == ValueTaskSourceStatus.Succeeded;
+                unsafe
+                {
+                    return Unsafe.As<IValueTaskSource<TResult>>(obj).GetStatus(_token) == ValueTaskSourceStatus.Succeeded;
+                }
             }
         }
 
@@ -809,8 +853,12 @@ namespace System.Threading.Tasks
                 {
                     return t.IsFaulted;
                 }
+                // TODO(unsafe): Baselining unsafe usage
 
-                return Unsafe.As<IValueTaskSource<TResult>>(obj).GetStatus(_token) == ValueTaskSourceStatus.Faulted;
+                unsafe
+                {
+                    return Unsafe.As<IValueTaskSource<TResult>>(obj).GetStatus(_token) == ValueTaskSourceStatus.Faulted;
+                }
             }
         }
 
@@ -836,8 +884,12 @@ namespace System.Threading.Tasks
                 {
                     return t.IsCanceled;
                 }
+                // TODO(unsafe): Baselining unsafe usage
 
-                return Unsafe.As<IValueTaskSource<TResult>>(obj).GetStatus(_token) == ValueTaskSourceStatus.Canceled;
+                unsafe
+                {
+                    return Unsafe.As<IValueTaskSource<TResult>>(obj).GetStatus(_token) == ValueTaskSourceStatus.Canceled;
+                }
             }
         }
 
@@ -861,8 +913,12 @@ namespace System.Threading.Tasks
                     TaskAwaiter.ValidateEnd(t);
                     return t.ResultOnSuccess;
                 }
+                // TODO(unsafe): Baselining unsafe usage
 
-                return Unsafe.As<IValueTaskSource<TResult>>(obj).GetResult(_token);
+                unsafe
+                {
+                    return Unsafe.As<IValueTaskSource<TResult>>(obj).GetResult(_token);
+                }
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPoolWorkQueue.cs
@@ -1054,7 +1054,11 @@ namespace System.Threading
                 Debug.Assert(workItem is IThreadPoolWorkItem);
                 try
                 {
-                    Unsafe.As<IThreadPoolWorkItem>(workItem).Execute();
+                    // TODO(unsafe): Baselining unsafe usage
+                    unsafe
+                    {
+                        Unsafe.As<IThreadPoolWorkItem>(workItem).Execute();
+                    }
                 }
                 catch (Exception ex) when (ExceptionHandling.IsHandledByGlobalHandler(ex))
                 {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Volatile.cs
@@ -46,14 +46,25 @@ namespace System.Threading
         [NonVersionable]
         public static double Read(ref readonly double location)
         {
-            long result = Read(ref Unsafe.As<double, long>(ref Unsafe.AsRef(in location)));
+            long result;
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                result = Read(ref Unsafe.As<double, long>(ref Unsafe.AsRef(in location)));
+            }
             return BitConverter.Int64BitsToDouble(result);
         }
 
         [Intrinsic]
         [NonVersionable]
-        public static void Write(ref double location, double value) =>
-            Write(ref Unsafe.As<double, long>(ref location), BitConverter.DoubleToInt64Bits(value));
+        public static void Write(ref double location, double value)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                Write(ref Unsafe.As<double, long>(ref location), BitConverter.DoubleToInt64Bits(value));
+            }
+        }
         #endregion
 
         #region Int16
@@ -186,14 +197,26 @@ namespace System.Threading
         [CLSCompliant(false)]
         [Intrinsic]
         [NonVersionable]
-        public static ulong Read(ref readonly ulong location) =>
-            (ulong)Read(ref Unsafe.As<ulong, long>(ref Unsafe.AsRef(in location)));
+        public static ulong Read(ref readonly ulong location)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return (ulong)Read(ref Unsafe.As<ulong, long>(ref Unsafe.AsRef(in location)));
+            }
+        }
 
         [CLSCompliant(false)]
         [Intrinsic]
         [NonVersionable]
-        public static void Write(ref ulong location, ulong value) =>
-            Write(ref Unsafe.As<ulong, long>(ref location), (long)value);
+        public static void Write(ref ulong location, ulong value)
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                Write(ref Unsafe.As<ulong, long>(ref location), (long)value);
+            }
+        }
         #endregion
 
         #region UIntPtr
@@ -218,8 +241,14 @@ namespace System.Threading
         [Intrinsic]
         [NonVersionable]
         [return: NotNullIfNotNull(nameof(location))]
-        public static T Read<T>([NotNullIfNotNull(nameof(location))] ref readonly T location) where T : class? =>
-            Unsafe.As<T>(Unsafe.As<T, VolatileObject>(ref Unsafe.AsRef(in location)).Value)!;
+        public static T Read<T>([NotNullIfNotNull(nameof(location))] ref readonly T location) where T : class?
+        {
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return Unsafe.As<T>(Unsafe.As<T, VolatileObject>(ref Unsafe.AsRef(in location)).Value)!;
+            }
+        }
 
         [Intrinsic]
         [NonVersionable]

--- a/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/UIntPtr.cs
@@ -239,7 +239,11 @@ namespace System
         public static bool TryParse([NotNullWhen(true)] string? s, out nuint result)
         {
             Unsafe.SkipInit(out result);
-            return nuint_t.TryParse(s, out Unsafe.As<nuint, nuint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nuint_t.TryParse(s, out Unsafe.As<nuint, nuint_t>(ref result));
+            }
         }
 
         /// <summary>Tries to parse a string into a value.</summary>
@@ -250,19 +254,31 @@ namespace System
         public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out nuint result)
         {
             Unsafe.SkipInit(out result);
-            return nuint_t.TryParse(s, provider, out Unsafe.As<nuint, nuint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nuint_t.TryParse(s, provider, out Unsafe.As<nuint, nuint_t>(ref result));
+            }
         }
 
         public static bool TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, out nuint result)
         {
             Unsafe.SkipInit(out result);
-            return nuint_t.TryParse(s, style, provider, out Unsafe.As<nuint, nuint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nuint_t.TryParse(s, style, provider, out Unsafe.As<nuint, nuint_t>(ref result));
+            }
         }
 
         public static bool TryParse(ReadOnlySpan<char> s, out nuint result)
         {
             Unsafe.SkipInit(out result);
-            return nuint_t.TryParse(s, out Unsafe.As<nuint, nuint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nuint_t.TryParse(s, out Unsafe.As<nuint, nuint_t>(ref result));
+            }
         }
 
         /// <summary>Tries to convert a UTF-8 character span containing the string representation of a number to its unsigned integer equivalent.</summary>
@@ -272,20 +288,32 @@ namespace System
         public static bool TryParse(ReadOnlySpan<byte> utf8Text, out nuint result)
         {
             Unsafe.SkipInit(out result);
-            return nuint_t.TryParse(utf8Text, out Unsafe.As<nuint, nuint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nuint_t.TryParse(utf8Text, out Unsafe.As<nuint, nuint_t>(ref result));
+            }
         }
 
         /// <inheritdoc cref="IParsable{TSelf}.TryParse(string?, IFormatProvider?, out TSelf)" />
         public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, out nuint result)
         {
             Unsafe.SkipInit(out result);
-            return nuint_t.TryParse(s, provider, out Unsafe.As<nuint, nuint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nuint_t.TryParse(s, provider, out Unsafe.As<nuint, nuint_t>(ref result));
+            }
         }
 
         public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out nuint result)
         {
             Unsafe.SkipInit(out result);
-            return nuint_t.TryParse(s, style, provider, out Unsafe.As<nuint, nuint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nuint_t.TryParse(s, style, provider, out Unsafe.As<nuint, nuint_t>(ref result));
+            }
         }
 
         //
@@ -1227,7 +1255,11 @@ namespace System
         public static bool TryParse(ReadOnlySpan<byte> utf8Text, NumberStyles style, IFormatProvider? provider, out nuint result)
         {
             Unsafe.SkipInit(out result);
-            return nuint_t.TryParse(utf8Text, style, provider, out Unsafe.As<nuint, nuint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nuint_t.TryParse(utf8Text, style, provider, out Unsafe.As<nuint, nuint_t>(ref result));
+            }
         }
 
         /// <inheritdoc cref="IUtf8SpanParsable{TSelf}.Parse(ReadOnlySpan{byte}, IFormatProvider?)" />
@@ -1237,7 +1269,11 @@ namespace System
         public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out nuint result)
         {
             Unsafe.SkipInit(out result);
-            return nuint_t.TryParse(utf8Text, provider, out Unsafe.As<nuint, nuint_t>(ref result));
+            // TODO(unsafe): Baselining unsafe usage
+            unsafe
+            {
+                return nuint_t.TryParse(utf8Text, provider, out Unsafe.As<nuint, nuint_t>(ref result));
+            }
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/WeakReference.T.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/WeakReference.T.cs
@@ -142,8 +142,12 @@ namespace System
                 if ((th & ComAwareBit) != 0)
                 {
                     ComAwareWeakReference cwr = ComAwareWeakReference.GetFromTaggedReference(th);
+                    // TODO(unsafe): Baselining unsafe usage
 
-                    target = Unsafe.As<T>(cwr.Target) ?? cwr.RehydrateTarget<T>();
+                    unsafe
+                    {
+                        target = Unsafe.As<T>(cwr.Target) ?? cwr.RehydrateTarget<T>();
+                    }
 
                     // must keep the instance alive as long as we use the handle.
                     GC.KeepAlive(this);
@@ -153,11 +157,15 @@ namespace System
 #endif
 
                 // unsafe cast is ok as the handle cannot be destroyed and recycled while we keep the instance alive
+                // TODO(unsafe): Baselining unsafe usage
+                unsafe
+                {
 #if FEATURE_JAVAMARSHAL
-                target = Unsafe.As<T>(GCHandle.InternalGetBridgeWait(th));
+                    target = Unsafe.As<T>(GCHandle.InternalGetBridgeWait(th));
 #else
-                target = Unsafe.As<T>(GCHandle.InternalGet(th));
+                    target = Unsafe.As<T>(GCHandle.InternalGet(th));
 #endif
+                }
 
                 // must keep the instance alive as long as we use the handle.
                 GC.KeepAlive(this);


### PR DESCRIPTION
This intentionally wraps every use in an unsafe block, with a comment. The intent is that we review every case and, if the unsafe block is correct, we remove the TODO comment and replace it with an explanation why it is correct.