### PR TITLE
[Wasm RyuJit] fix some issues with calls

### DIFF
--- a/src/coreclr/jit/codegenlinear.cpp
+++ b/src/coreclr/jit/codegenlinear.cpp
@@ -801,13 +801,11 @@ BasicBlock* CodeGen::genEmitEndBlock(BasicBlock* block)
             // 2. If this is this is the last block of the hot section.
             // 3. If the subsequent block is a special throw block.
             // 4. On AMD64, if the next block is in a different EH region.
-            bool addedBreakpoint = false;
             if (block->IsLast() || !BasicBlock::sameEHRegion(block, block->Next()) ||
                 (!isFramePointerUsed() && m_compiler->fgIsThrowHlpBlk(block->Next())) ||
                 m_compiler->bbIsFuncletBeg(block->Next()) || block->IsLastHotBlock(m_compiler))
             {
                 instGen(INS_BREAKPOINT); // This should never get executed
-                addedBreakpoint = true;
             }
             // Do likewise for blocks that end in DOES_NOT_RETURN calls
             // that were not caught by the above rules. This ensures that
@@ -821,7 +819,6 @@ BasicBlock* CodeGen::genEmitEndBlock(BasicBlock* block)
                     if (call->AsCall()->IsNoReturn())
                     {
                         instGen(INS_BREAKPOINT); // This should never get executed
-                        addedBreakpoint = true;
                     }
                 }
             }
@@ -829,7 +826,7 @@ BasicBlock* CodeGen::genEmitEndBlock(BasicBlock* block)
 #if defined(TARGET_WASM)
             // For wasm the last instruction in a function or funclet must be end.
             //
-            if (addedBreakpoint && (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next())))
+            if (block->IsLast() || m_compiler->bbIsFuncletBeg(block->Next()))
             {
                 GetEmitter()->emitIns(INS_end);
             }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2346,9 +2346,8 @@ int GenTreeCall::GetNonStandardAddedArgCount(Compiler* compiler) const
 {
 #if defined(TARGET_WASM)
     // TODO-WASM: may need adjustments for other hidden args
-    // For now: managed calls get extra SP + PortableEntryPoint args, but
-    // we're not adding the PE arg yet. So just note one extra arg.
-    return IsUnmanaged() ? 0 : 1;
+    // For now: managed calls get extra SP + PortableEntryPoint args.
+    return IsUnmanaged() ? 0 : 2;
 #endif // defined(TARGET_WASM)
 
     if (IsUnmanaged() && !compiler->opts.ShouldUsePInvokeHelpers())

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1839,7 +1839,7 @@ void CallArgs::AddFinalArgsAndDetermineABIInfo(Compiler* comp, GenTreeCall* call
 
         // TODO-WASM: pass proper portable entry point as the last argument for managed calls
         GenTree* const pePointer = comp->gtNewZeroConNode(TYP_I_IMPL);
-        PushFront(comp, NewCallArg::Primitive(pePointer).WellKnown(WellKnownArg::WasmPortableEntryPoint));
+        PushBack(comp, NewCallArg::Primitive(pePointer).WellKnown(WellKnownArg::WasmPortableEntryPoint));
     }
 
 #endif // defined(TARGET_WASM)

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1836,8 +1836,12 @@ void CallArgs::AddFinalArgsAndDetermineABIInfo(Compiler* comp, GenTreeCall* call
     {
         GenTree* const stackPointer = comp->gtNewLclVarNode(comp->lvaWasmSpArg, TYP_I_IMPL);
         PushFront(comp, NewCallArg::Primitive(stackPointer).WellKnown(WellKnownArg::WasmShadowStackPointer));
+
+        // TODO-WASM: pass proper portable entry point as the last argument for managed calls
+        GenTree* const pePointer = comp->gtNewZeroConNode(TYP_I_IMPL);
+        PushFront(comp, NewCallArg::Primitive(pePointer).WellKnown(WellKnownArg::WasmPortableEntryPoint));
     }
-    // TODO-WASM: pass the portable entry point as the last argument for managed calls
+
 #endif // defined(TARGET_WASM)
 
     ClassifierInfo info;


### PR DESCRIPTION
For calls with managed conventions, pass a faked-up PE pointer as the last argument to match the expected signature.

If the last instruction in the main method or funclet is a call that does not return, make sure to emit an `end` after any `unreachable`.