### PR TITLE
Fix some Linux (and windows) Dac crashes when given reasonable inputs

### DIFF
--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -5716,10 +5716,6 @@ HRESULT STDMETHODCALLTYPE ClrDataAccess::GetThreadStaticBaseAddress(CLRDATA_ADDR
     {
         hr = E_INVALIDARG;
     }
-    else if (mTable->GetClass() == NULL)
-    {
-        hr = E_INVALIDARG;
-    }
     else
     {
         PTR_EEClass pClass = mTable->GetClassWithPossibleAV();

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -1864,7 +1864,8 @@ ClrDataAccess::GetMethodTableData(CLRDATA_ADDRESS mt, struct DacpMethodTableData
         {
             MTData->Module = HOST_CDADDR(pMT->GetModule());
             // Note: DacpMethodTableData::Class is really a pointer to the canonical method table
-            MTData->Class = HOST_CDADDR(pMT->GetClass()->GetMethodTable());
+            PTR_EEClass pClass = pMT->GetClassWithPossibleAV();
+            MTData->Class = pClass != NULL ? HOST_CDADDR(pClass->GetMethodTable()) : 0;
             MTData->ParentMethodTable = HOST_CDADDR(pMT->GetParentMethodTable());;
             MTData->wNumInterfaces = (WORD)pMT->GetNumInterfaces();
             MTData->wNumMethods = pMT->GetNumMethods(); // printed as "number of vtable slots" and used to iterate over method slots
@@ -2054,6 +2055,10 @@ ClrDataAccess::GetMethodTableFieldData(CLRDATA_ADDRESS mt, struct DacpMethodTabl
     PTR_MethodTable pMT = PTR_MethodTable(TO_TADDR(mt));
     BOOL bIsFree = FALSE;
     if (!pMT || !DacValidateMethodTable(pMT, bIsFree))
+    {
+        hr = E_INVALIDARG;
+    }
+    else if (pMT->GetClassWithPossibleAV() == NULL)
     {
         hr = E_INVALIDARG;
     }
@@ -5650,6 +5655,10 @@ HRESULT STDMETHODCALLTYPE ClrDataAccess::GetThreadStaticBaseAddress(CLRDATA_ADDR
 
     BOOL bIsFree = FALSE;
     if (!DacValidateMethodTable(mTable, bIsFree))
+    {
+        hr = E_INVALIDARG;
+    }
+    else if (mTable->GetClassWithPossibleAV() == NULL)
     {
         hr = E_INVALIDARG;
     }

--- a/src/coreclr/debug/daccess/request.cpp
+++ b/src/coreclr/debug/daccess/request.cpp
@@ -1866,8 +1866,7 @@ ClrDataAccess::GetMethodTableData(CLRDATA_ADDRESS mt, struct DacpMethodTableData
         {
             MTData->Module = HOST_CDADDR(pMT->GetModule());
             // Note: DacpMethodTableData::Class is really a pointer to the canonical method table
-            PTR_EEClass pClass = pMT->GetClassWithPossibleAV();
-            MTData->Class = pClass != NULL ? HOST_CDADDR(pClass->GetMethodTable()) : 0;
+            MTData->Class = HOST_CDADDR(pMT->GetClass()->GetMethodTable());
             MTData->ParentMethodTable = HOST_CDADDR(pMT->GetParentMethodTable());;
             MTData->wNumInterfaces = (WORD)pMT->GetNumInterfaces();
             MTData->wNumMethods = pMT->GetNumMethods(); // printed as "number of vtable slots" and used to iterate over method slots
@@ -2060,7 +2059,7 @@ ClrDataAccess::GetMethodTableFieldData(CLRDATA_ADDRESS mt, struct DacpMethodTabl
     {
         hr = E_INVALIDARG;
     }
-    else if (pMT->GetClassWithPossibleAV() == NULL)
+    else if (pMT->GetClass() == NULL)
     {
         hr = E_INVALIDARG;
     }
@@ -5717,7 +5716,7 @@ HRESULT STDMETHODCALLTYPE ClrDataAccess::GetThreadStaticBaseAddress(CLRDATA_ADDR
     {
         hr = E_INVALIDARG;
     }
-    else if (mTable->GetClassWithPossibleAV() == NULL)
+    else if (mTable->GetClass() == NULL)
     {
         hr = E_INVALIDARG;
     }


### PR DESCRIPTION
There's a lot of places where the dac will crash when we feed it bad input.  This doesn't completely fix or exhaust all of those places, but it makes a significant dent in the number of places we trust input that shouldn't be strictly trusted.

This primarily affects Linux (and probably macos, though I don't have a machine to test there).  There were a few places windows could throw an AV too.

The underlying fixes were pretty rote, so I let copilot take care of a lot of them.  I have a dac test app that does the bare minimum to test every api with the most basic inputs and this was the result.  I ran the resulting dac/runtime through ClrMD's test suite and all tests pass.

Dac tests live here temporarily: https://github.com/leculver/dac-tests/.  Planning to move them to a unit test at some point (here or the diagnostics repo) to make sure we don't regress these.  Even though we don't change the surface of the dac private apis much anymore, underlying runtime changes can cause some crashes, especially on linux/osx.

Fixes #124640.