### PR TITLE
Fix SYSLIB1045 code fixer generating duplicate MyRegex names across partial class declarations

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexAnalyzer.cs
@@ -153,7 +153,7 @@ namespace System.Text.RegularExpressions.Generator
         /// Validates the operation arguments ensuring the pattern and options are constant values.
         /// Returns false if a timeout argument is used.
         /// </summary>
-        private static bool ValidateParameters(ImmutableArray<IArgumentOperation> arguments)
+        internal static bool ValidateParameters(ImmutableArray<IArgumentOperation> arguments)
         {
             const string timeoutArgumentName = "timeout";
             const string matchTimeoutArgumentName = "matchTimeout";

--- a/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexAnalyzer.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexAnalyzer.cs
@@ -29,7 +29,25 @@ namespace System.Text.RegularExpressions.Generator
         internal const string OptionsArgumentName = "options";
 
         /// <summary>Names of static Regex methods the analyzer considers fixable.</summary>
-        internal static readonly HashSet<string> FixableMethodNames = new() { "Count", "EnumerateMatches", "IsMatch", "Match", "Matches", "Split", "Replace" };
+        private static readonly HashSet<string> s_fixableMethodNames = new() { "Count", "EnumerateMatches", "IsMatch", "Match", "Matches", "Split", "Replace" };
+
+        /// <summary>
+        /// Determines whether the given operation is a fixable Regex call (constructor or static method).
+        /// Used by both the analyzer and the code fixer to share fixability logic.
+        /// </summary>
+        internal static bool IsFixableRegexOperation(IOperation operation, INamedTypeSymbol regexSymbol) => operation switch
+        {
+            IInvocationOperation inv =>
+                inv.TargetMethod.IsStatic &&
+                SymbolEqualityComparer.Default.Equals(inv.TargetMethod.ContainingType, regexSymbol) &&
+                s_fixableMethodNames.Contains(inv.TargetMethod.Name) &&
+                ValidateParameters(inv.Arguments),
+            IObjectCreationOperation create =>
+                SymbolEqualityComparer.Default.Equals(create.Type, regexSymbol) &&
+                create.Arguments.Length <= 2 &&
+                ValidateParameters(create.Arguments),
+            _ => false
+        };
 
         /// <inheritdoc />
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(DiagnosticDescriptors.UseRegexSourceGeneration);
@@ -51,101 +69,18 @@ namespace System.Text.RegularExpressions.Generator
                     return;
                 }
 
-                // Pre-compute a hash with all of the method symbols that we want to analyze for possibly emitting
-                // a diagnostic.
-                HashSet<IMethodSymbol> staticMethodsToDetect = GetMethodSymbolHash(regexTypeSymbol,
-                    FixableMethodNames);
-
-                // Register analysis of calls to the Regex constructors
-                context.RegisterOperationAction(context => AnalyzeObjectCreation(context, regexTypeSymbol), OperationKind.ObjectCreation);
-
-                // Register analysis of calls to Regex static methods
-                context.RegisterOperationAction(context => AnalyzeInvocation(context, regexTypeSymbol, staticMethodsToDetect), OperationKind.Invocation);
-            });
-
-            // Creates a HashSet of all of the method Symbols containing the static methods to analyze.
-            static HashSet<IMethodSymbol> GetMethodSymbolHash(INamedTypeSymbol regexTypeSymbol, HashSet<string> methodNames)
-            {
-                HashSet<IMethodSymbol> hash = new HashSet<IMethodSymbol>(SymbolEqualityComparer.Default);
-                ImmutableArray<ISymbol> allMembers = regexTypeSymbol.GetMembers();
-
-                foreach (ISymbol member in allMembers)
+                context.RegisterOperationAction(context =>
                 {
-                    if (member is IMethodSymbol method &&
-                        method.IsStatic &&
-                        methodNames.Contains(method.Name))
+                    if (IsFixableRegexOperation(context.Operation, regexTypeSymbol))
                     {
-                        hash.Add(method);
+                        // Report the diagnostic with a location that doesn't span the potentially multi-line pattern.
+                        SyntaxNode? syntaxNodeForDiagnostic = context.Operation.Syntax;
+                        Debug.Assert(syntaxNodeForDiagnostic is not null);
+                        Location location = GetLocationBeforeArguments(syntaxNodeForDiagnostic);
+                        context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.UseRegexSourceGeneration, location));
                     }
-                }
-
-                return hash;
-            }
-        }
-
-        /// <summary>
-        /// Analyzes an invocation expression to see if the invocation is a call to one of the Regex static methods,
-        /// and checks if they could be using the source generator instead.
-        /// </summary>
-        /// <param name="context">The compilation context representing the invocation.</param>
-        private static void AnalyzeInvocation(OperationAnalysisContext context, INamedTypeSymbol regexTypeSymbol, HashSet<IMethodSymbol> staticMethodsToDetect)
-        {
-            // Ensure the invocation is a Regex static method.
-            IInvocationOperation invocationOperation = (IInvocationOperation)context.Operation;
-            IMethodSymbol method = invocationOperation.TargetMethod;
-            if (!method.IsStatic || !SymbolEqualityComparer.Default.Equals(method.ContainingType, regexTypeSymbol))
-            {
-                return;
-            }
-
-            // We need to save the parameters as properties so that we can save them onto the diagnostic so that the
-            // code fixer can later use that property bag to generate the code fix and emit the GeneratedRegex attribute.
-            if (staticMethodsToDetect.Contains(method))
-            {
-                // Validate that arguments pattern and options are constant and timeout was not passed in.
-                if (!ValidateParameters(invocationOperation.Arguments))
-                {
-                    return;
-                }
-
-                // Report the diagnostic with a location that doesn't span the potentially multi-line pattern.
-                SyntaxNode? syntaxNodeForDiagnostic = invocationOperation.Syntax;
-                Debug.Assert(syntaxNodeForDiagnostic is not null);
-                Location location = GetLocationBeforeArguments(syntaxNodeForDiagnostic);
-                context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.UseRegexSourceGeneration, location));
-            }
-        }
-
-        /// <summary>
-        /// Analyzes an object creation expression to see if the invocation is a call to one of the Regex constructors,
-        /// and checks if they could be using the source generator instead.
-        /// </summary>
-        /// <param name="context">The object creation context.</param>
-        private static void AnalyzeObjectCreation(OperationAnalysisContext context, INamedTypeSymbol regexTypeSymbol)
-        {
-            // Ensure the object creation is a call to the Regex constructor.
-            IObjectCreationOperation operation = (IObjectCreationOperation)context.Operation;
-            if (!SymbolEqualityComparer.Default.Equals(operation.Type, regexTypeSymbol))
-            {
-                return;
-            }
-
-            // If the constructor also has a timeout argument, then don't emit a diagnostic.
-            if (operation.Arguments.Length > 2)
-            {
-                return;
-            }
-
-            if (!ValidateParameters(operation.Arguments))
-            {
-                return;
-            }
-
-            // Report the diagnostic with a location that doesn't span the potentially multi-line pattern.
-            SyntaxNode? syntaxNodeForDiagnostic = operation.Syntax;
-            Debug.Assert(syntaxNodeForDiagnostic is not null);
-            Location location = GetLocationBeforeArguments(syntaxNodeForDiagnostic);
-            context.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.UseRegexSourceGeneration, location));
+                }, OperationKind.ObjectCreation, OperationKind.Invocation);
+            });
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
@@ -512,6 +512,7 @@ namespace System.Text.RegularExpressions.Generator
                     {
                         IInvocationOperation inv => inv.TargetMethod.IsStatic &&
                             SymbolEqualityComparer.Default.Equals(inv.TargetMethod.ContainingType, regexSymbol) &&
+                            UpgradeToGeneratedRegexAnalyzer.FixableMethodNames.Contains(inv.TargetMethod.Name) &&
                             UpgradeToGeneratedRegexAnalyzer.ValidateParameters(inv.Arguments),
                         IObjectCreationOperation create => SymbolEqualityComparer.Default.Equals(create.Type, regexSymbol) &&
                             create.Arguments.Length <= 2 &&

--- a/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
@@ -501,8 +501,11 @@ namespace System.Text.RegularExpressions.Generator
                     // Skip call sites inside nested type declarations — they belong to
                     // a different type and won't affect this type's generated names.
                     // Extension blocks are not nested types, so don't skip those.
-                    if (descendant.Ancestors().Any(a =>
-                        a is TypeDeclarationSyntax && a != declSyntax && a is not ExtensionBlockDeclarationSyntax))
+                    // Only check ancestors up to (not including) declSyntax, so that
+                    // types *containing* declSyntax (e.g., an outer class) are not
+                    // mistaken for nested types.
+                    if (descendant.Ancestors().TakeWhile(a => a != declSyntax).Any(a =>
+                        a is TypeDeclarationSyntax && a is not ExtensionBlockDeclarationSyntax))
                     {
                         continue;
                     }

--- a/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
@@ -339,6 +339,10 @@ namespace System.Text.RegularExpressions.Generator
             // Add the member to the type.
             if (oldMember is null)
             {
+                // Prepend a blank line so the generated member is visually separated from preceding members.
+                newMember = newMember.WithLeadingTrivia(
+                    newMember.GetLeadingTrivia().Insert(0, SyntaxFactory.ElasticCarriageReturnLineFeed));
+
                 newTypeDeclarationOrCompilationUnit = newTypeDeclarationOrCompilationUnit is TypeDeclarationSyntax newTypeDeclaration ?
                     newTypeDeclaration.AddMembers((MemberDeclarationSyntax)newMember) :
                     ((CompilationUnitSyntax)newTypeDeclarationOrCompilationUnit).AddMembers((ClassDeclarationSyntax)generator.ClassDeclaration("Program", modifiers: DeclarationModifiers.Partial, members: new[] { newMember }));

--- a/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
@@ -525,8 +525,12 @@ namespace System.Text.RegularExpressions.Generator
                     // Only check ancestors up to (not including) declSyntax, so that
                     // types *containing* declSyntax (e.g., an outer class) are not
                     // mistaken for nested types.
+                    // Also skip call sites inside field/property declarations — those are
+                    // fixed via ConvertFieldToGeneratedRegexProperty / ConvertPropertyToGeneratedRegexProperty,
+                    // which keep the original member name and don't compete for MyRegex* names.
                     if (descendant.Ancestors().TakeWhile(a => a != declSyntax).Any(a =>
-                        a is TypeDeclarationSyntax && a is not ExtensionBlockDeclarationSyntax))
+                        a is TypeDeclarationSyntax && a is not ExtensionBlockDeclarationSyntax ||
+                        a is FieldDeclarationSyntax or PropertyDeclarationSyntax))
                     {
                         continue;
                     }

--- a/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
@@ -477,19 +477,36 @@ namespace System.Text.RegularExpressions.Generator
         /// Counts how many Regex call sites in the same type (across all partial declarations)
         /// appear before the given node in a deterministic order. This ensures that when the
         /// BatchFixer applies fixes concurrently against the original compilation, each fix
-        /// picks a unique generated method name.
+        /// picks a unique generated property name.
         /// </summary>
         private static int CountPrecedingRegexCallSites(
             INamedTypeSymbol typeSymbol, Compilation compilation,
             INamedTypeSymbol regexSymbol, SyntaxNode nodeToFix,
             CancellationToken cancellationToken)
         {
-            var callSites = new List<(string FilePath, int Position)>();
+            // Build a map from SyntaxTree to its index in the compilation, used as a
+            // tiebreaker when FilePath is null/empty (e.g., in-memory documents).
+            var treeIndexMap = new Dictionary<SyntaxTree, int>();
+            int treeCounter = 0;
+            foreach (SyntaxTree tree in compilation.SyntaxTrees)
+            {
+                treeIndexMap[tree] = treeCounter++;
+            }
+
+            var callSites = new List<(string FilePath, int TreeIndex, int Position)>();
+            var semanticModelCache = new Dictionary<SyntaxTree, SemanticModel>();
 
             foreach (SyntaxReference syntaxRef in typeSymbol.DeclaringSyntaxReferences)
             {
                 SyntaxNode declSyntax = syntaxRef.GetSyntax(cancellationToken);
-                SemanticModel declModel = compilation.GetSemanticModel(syntaxRef.SyntaxTree);
+
+                if (!semanticModelCache.TryGetValue(syntaxRef.SyntaxTree, out SemanticModel? declModel))
+                {
+                    declModel = compilation.GetSemanticModel(syntaxRef.SyntaxTree);
+                    semanticModelCache[syntaxRef.SyntaxTree] = declModel;
+                }
+
+                int treeIndex = treeIndexMap.TryGetValue(syntaxRef.SyntaxTree, out int idx) ? idx : -1;
 
                 foreach (SyntaxNode descendant in declSyntax.DescendantNodes())
                 {
@@ -525,7 +542,7 @@ namespace System.Text.RegularExpressions.Generator
 
                     if (isFixableRegexCall)
                     {
-                        callSites.Add((syntaxRef.SyntaxTree.FilePath ?? string.Empty, descendant.SpanStart));
+                        callSites.Add((syntaxRef.SyntaxTree.FilePath ?? string.Empty, treeIndex, descendant.SpanStart));
                     }
                 }
             }
@@ -538,14 +555,19 @@ namespace System.Text.RegularExpressions.Generator
             callSites.Sort((a, b) =>
             {
                 int cmp = StringComparer.Ordinal.Compare(a.FilePath, b.FilePath);
+                if (cmp != 0) return cmp;
+                cmp = a.TreeIndex.CompareTo(b.TreeIndex);
                 return cmp != 0 ? cmp : a.Position.CompareTo(b.Position);
             });
 
             string currentFilePath = nodeToFix.SyntaxTree.FilePath ?? string.Empty;
+            int currentTreeIndex = treeIndexMap.TryGetValue(nodeToFix.SyntaxTree, out int currentIdx) ? currentIdx : -1;
             int currentPosition = nodeToFix.SpanStart;
 
             int index = callSites.FindIndex(c =>
-                StringComparer.Ordinal.Equals(c.FilePath, currentFilePath) && c.Position == currentPosition);
+                StringComparer.Ordinal.Equals(c.FilePath, currentFilePath) &&
+                c.TreeIndex == currentTreeIndex &&
+                c.Position == currentPosition);
 
             return index > 0 ? index : 0;
         }

--- a/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/UpgradeToGeneratedRegexCodeFixer.cs
@@ -116,24 +116,24 @@ namespace System.Text.RegularExpressions.Generator
                 semanticModel.GetDeclaredSymbol((CompilationUnitSyntax)typeDeclarationOrCompilationUnit, cancellationToken)?.ContainingType;
             if (typeSymbol is not null)
             {
-                int memberCount = 1;
-                while (GetAllMembers(typeSymbol).Any(m => m.Name == memberName))
-                {
-                    memberName = $"{DefaultRegexPropertyName}{memberCount++}";
-                }
-
                 // When the BatchFixer applies multiple fixes concurrently, each fix sees the
                 // original compilation and picks the same first-available name. To avoid
                 // duplicates, determine this node's position among all Regex call sites in
-                // the type that would generate new names, and offset accordingly.
+                // the type that would generate new names, and skip that many available names.
                 int precedingCount = CountPrecedingRegexCallSites(
                     typeSymbol, compilation, regexSymbol, nodeToFix, cancellationToken);
-                for (int i = 0; i < precedingCount; i++)
+
+                // Find the (precedingCount)th name (0-indexed) that doesn't collide with
+                // existing members. The Nth concurrent fixer claims the Nth available name.
+                int suffix = 0;
+                for (int available = 0; ; suffix++)
                 {
-                    memberName = $"{DefaultRegexPropertyName}{memberCount++}";
-                    while (GetAllMembers(typeSymbol).Any(m => m.Name == memberName))
+                    memberName = suffix == 0 ? DefaultRegexPropertyName : $"{DefaultRegexPropertyName}{suffix}";
+                    if (!GetAllMembers(typeSymbol).Any(m => m.Name == memberName))
                     {
-                        memberName = $"{DefaultRegexPropertyName}{memberCount++}";
+                        if (available == precedingCount)
+                            break;
+                        available++;
                     }
                 }
             }
@@ -536,19 +536,7 @@ namespace System.Text.RegularExpressions.Generator
                     }
 
                     IOperation? op = declModel.GetOperation(descendant, cancellationToken);
-                    bool isFixableRegexCall = op switch
-                    {
-                        IInvocationOperation inv => inv.TargetMethod.IsStatic &&
-                            SymbolEqualityComparer.Default.Equals(inv.TargetMethod.ContainingType, regexSymbol) &&
-                            UpgradeToGeneratedRegexAnalyzer.FixableMethodNames.Contains(inv.TargetMethod.Name) &&
-                            UpgradeToGeneratedRegexAnalyzer.ValidateParameters(inv.Arguments),
-                        IObjectCreationOperation create => SymbolEqualityComparer.Default.Equals(create.Type, regexSymbol) &&
-                            create.Arguments.Length <= 2 &&
-                            UpgradeToGeneratedRegexAnalyzer.ValidateParameters(create.Arguments),
-                        _ => false
-                    };
-
-                    if (isFixableRegexCall)
+                    if (op is not null && UpgradeToGeneratedRegexAnalyzer.IsFixableRegexOperation(op, regexSymbol))
                     {
                         callSites.Add((syntaxRef.SyntaxTree.FilePath ?? string.Empty, treeIndex, descendant.SpanStart));
                     }

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/UpgradeToGeneratedRegexAnalyzerTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/UpgradeToGeneratedRegexAnalyzerTests.cs
@@ -1073,6 +1073,7 @@ public partial class Program
 
     [GeneratedRegex(""a|b"")]
     private static partial Regex MyRegex { get; }
+
     [GeneratedRegex(""c|d"", RegexOptions.CultureInvariant)]
     private static partial Regex MyRegex1 { get; }
 }

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/UpgradeToGeneratedRegexAnalyzerTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/UpgradeToGeneratedRegexAnalyzerTests.cs
@@ -1451,6 +1451,335 @@ internal partial class C
         }
 
         [Fact]
+        public async Task CodeFixerNestedTypeCallsDoNotAffectOuterTypeNaming()
+        {
+            string test = @"using System.Text.RegularExpressions;
+
+internal partial class C
+{
+    public static Regex A()
+    {
+        return [|new Regex|](""abc"");
+    }
+
+    class Inner
+    {
+        public static Regex X()
+        {
+            return [|new Regex|](""inner"");
+        }
+    }
+}
+
+internal partial class C
+{
+    public static Regex B()
+    {
+        return [|new Regex|](""def"");
+    }
+}
+";
+
+            string fixedSource = @"using System.Text.RegularExpressions;
+
+internal partial class C
+{
+    public static Regex A()
+    {
+        return MyRegex;
+    }
+
+    partial class Inner
+    {
+        public static Regex X()
+        {
+            return MyRegex;
+        }
+
+        [GeneratedRegex(""inner"")]
+        private static partial Regex MyRegex { get; }
+    }
+
+    [GeneratedRegex(""abc"")]
+    private static partial Regex MyRegex { get; }
+}
+
+internal partial class C
+{
+    public static Regex B()
+    {
+        return MyRegex1;
+    }
+
+    [GeneratedRegex(""def"")]
+    private static partial Regex MyRegex1 { get; }
+}
+";
+
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = fixedSource,
+                NumberOfFixAllIterations = 2,
+            }.RunAsync();
+        }
+
+        [Fact]
+        public async Task CodeFixerNonConstantPatternDoesNotAffectNaming()
+        {
+            string test = @"using System.Text.RegularExpressions;
+
+internal partial class C
+{
+    public static Regex A(string pattern)
+    {
+        var r = new Regex(pattern);
+        return r;
+    }
+
+    public static Regex B()
+    {
+        return [|new Regex|](""abc"");
+    }
+}
+
+internal partial class C
+{
+    public static Regex D()
+    {
+        return [|new Regex|](""def"");
+    }
+}
+";
+
+            string fixedSource = @"using System.Text.RegularExpressions;
+
+internal partial class C
+{
+    public static Regex A(string pattern)
+    {
+        var r = new Regex(pattern);
+        return r;
+    }
+
+    public static Regex B()
+    {
+        return MyRegex;
+    }
+
+    [GeneratedRegex(""abc"")]
+    private static partial Regex MyRegex { get; }
+}
+
+internal partial class C
+{
+    public static Regex D()
+    {
+        return MyRegex1;
+    }
+
+    [GeneratedRegex(""def"")]
+    private static partial Regex MyRegex1 { get; }
+}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(test, fixedSource);
+        }
+
+        [Fact]
+        public async Task CodeFixerPartialStructGeneratesUniqueNames()
+        {
+            string test = @"using System.Text.RegularExpressions;
+
+internal partial struct S
+{
+    public static Regex A()
+    {
+        return [|new Regex|](""abc"");
+    }
+}
+
+internal partial struct S
+{
+    public static Regex B()
+    {
+        return [|new Regex|](""def"");
+    }
+}
+";
+
+            string fixedSource = @"using System.Text.RegularExpressions;
+
+internal partial struct S
+{
+    public static Regex A()
+    {
+        return MyRegex;
+    }
+
+    [GeneratedRegex(""abc"")]
+    private static partial Regex MyRegex { get; }
+}
+
+internal partial struct S
+{
+    public static Regex B()
+    {
+        return MyRegex1;
+    }
+
+    [GeneratedRegex(""def"")]
+    private static partial Regex MyRegex1 { get; }
+}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(test, fixedSource);
+        }
+
+        [Fact]
+        public async Task CodeFixerMixedConstructorAndStaticMethodCallsAcrossPartials()
+        {
+            string test = @"using System.Text.RegularExpressions;
+
+internal partial class C
+{
+    public static Regex A()
+    {
+        return [|new Regex|](""abc"");
+    }
+}
+
+internal partial class C
+{
+    public static bool B(string input)
+    {
+        return [|Regex.IsMatch|](input, ""def"");
+    }
+}
+";
+
+            string fixedSource = @"using System.Text.RegularExpressions;
+
+internal partial class C
+{
+    public static Regex A()
+    {
+        return MyRegex;
+    }
+
+    [GeneratedRegex(""abc"")]
+    private static partial Regex MyRegex { get; }
+}
+
+internal partial class C
+{
+    public static bool B(string input)
+    {
+        return MyRegex1.IsMatch(input);
+    }
+
+    [GeneratedRegex(""def"")]
+    private static partial Regex MyRegex1 { get; }
+}
+";
+
+            await VerifyCS.VerifyCodeFixAsync(test, fixedSource);
+        }
+
+        [Fact]
+        public async Task CodeFixerNestedPartialTypeDoesNotInterfereWithOuterPartial()
+        {
+            string test = @"using System.Text.RegularExpressions;
+
+internal partial class Outer
+{
+    public static Regex A()
+    {
+        return [|new Regex|](""outer1"");
+    }
+
+    internal partial class Inner
+    {
+        public static Regex X()
+        {
+            return [|new Regex|](""inner1"");
+        }
+    }
+}
+
+internal partial class Outer
+{
+    public static Regex B()
+    {
+        return [|new Regex|](""outer2"");
+    }
+
+    internal partial class Inner
+    {
+        public static Regex Y()
+        {
+            return [|new Regex|](""inner2"");
+        }
+    }
+}
+";
+
+            string fixedSource = @"using System.Text.RegularExpressions;
+
+internal partial class Outer
+{
+    public static Regex A()
+    {
+        return MyRegex;
+    }
+
+    internal partial class Inner
+    {
+        public static Regex X()
+        {
+            return MyRegex;
+        }
+
+        [GeneratedRegex(""inner1"")]
+        private static partial Regex MyRegex { get; }
+    }
+
+    [GeneratedRegex(""outer1"")]
+    private static partial Regex MyRegex { get; }
+}
+
+internal partial class Outer
+{
+    public static Regex B()
+    {
+        return MyRegex1;
+    }
+
+    internal partial class Inner
+    {
+        public static Regex Y()
+        {
+            return MyRegex1;
+        }
+
+        [GeneratedRegex(""inner2"")]
+        private static partial Regex MyRegex1 { get; }
+    }
+
+    [GeneratedRegex(""outer2"")]
+    private static partial Regex MyRegex1 { get; }
+}
+";
+
+            await new VerifyCS.Test
+            {
+                TestCode = test,
+                FixedCode = fixedSource,
+                NumberOfFixAllIterations = 2,
+            }.RunAsync();
+        }
+
+        [Fact]
         public async Task CodeFixerSupportsNamedParameters()
         {
             string test = @"using System.Text.RegularExpressions;

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/UpgradeToGeneratedRegexAnalyzerTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/UpgradeToGeneratedRegexAnalyzerTests.cs
@@ -1050,13 +1050,24 @@ public class Program
         [Fact]
         public async Task AnayzerSupportsMultipleDiagnostics()
         {
+            // The first diagnostic is a method-body call, so FixAll for CreateGeneratedRegexProperty
+            // runs first on the original document. The field (between the two method calls in source
+            // order) is fixed by a different equivalence key and must not inflate the name offset
+            // for method-body fixes: regex2 should get MyRegex1 (not MyRegex2).
             string test = @"using System.Text.RegularExpressions;
 
 public class Program
 {
-    public static void Main()
+    public static void M1()
     {
         Regex regex1 = [|new Regex|](""a|b"");
+    }
+
+    private static readonly Regex s_field = [|new Regex|](""x"");
+
+    public static void M2()
+    {
+        var _ = s_field;
         Regex regex2 = [|new Regex|](""c|d"", RegexOptions.CultureInvariant);
     }
 }
@@ -1065,9 +1076,17 @@ public class Program
 
 public partial class Program
 {
-    public static void Main()
+    public static void M1()
     {
         Regex regex1 = MyRegex;
+    }
+
+    [GeneratedRegex(""x"")]
+    private static partial Regex s_field { get; }
+
+    public static void M2()
+    {
+        var _ = s_field;
         Regex regex2 = MyRegex1;
     }
 
@@ -1082,7 +1101,7 @@ public partial class Program
             {
                 TestCode = test,
                 FixedCode = fixedSource,
-                NumberOfFixAllIterations = 2,
+                NumberOfFixAllIterations = 3,
             }.RunAsync();
         }
 

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/UpgradeToGeneratedRegexAnalyzerTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/UpgradeToGeneratedRegexAnalyzerTests.cs
@@ -1048,7 +1048,7 @@ public class Program
         }
 
         [Fact]
-        public async Task AnayzerSupportsMultipleDiagnostics()
+        public async Task AnalyzerSupportsMultipleDiagnostics()
         {
             // The first diagnostic is a method-body call, so FixAll for CreateGeneratedRegexProperty
             // runs first on the original document. The field (between the two method calls in source


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/77409

## Problem

When the SYSLIB1045 `BatchFixer` applies multiple code fixes concurrently to separate partial class declarations, each fix independently checks existing members via the semantic model. Since all fixers see the **original** compilation (before any fix is applied), they all conclude `MyRegex` is available and generate duplicate property names, causing CS0756.

## Fix

In `UpgradeToGeneratedRegexCodeFixer.CreateGeneratedRegexProperty`, after finding the first available name via the semantic model, the new `CountPrecedingRegexCallSites` helper scans all `DeclaringSyntaxReferences` of the containing type for Regex constructor/static-method call sites that would also generate new property names. These are sorted deterministically (by file path, then span position). The current node's index in that sorted list determines how many names to skip, giving each concurrent fixer a unique name.

## Test

Added `CodeFixerGeneratesUniqueNamesAcrossPartialClassDeclarations` — two `new Regex(...)` calls in separate partial class declarations of the same type, verifying `MyRegex` and `MyRegex1` are generated. Verified the test fails without the fix (both declarations produce `MyRegex`).