### PR TITLE
Fix: Allow inline regex options in conditional expression branches

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1000,8 +1000,9 @@ namespace System.Text.RegularExpressions
                         --_pos;
 
                         nodeType = RegexNodeKind.Group;
-                        // Disallow options in the children of a testgroup node
-                        if (_group!.Kind != RegexNodeKind.ExpressionConditional)
+                        // Disallow options as the test expression of a conditional (when no test has been added yet),
+                        // but allow them in the yes/no branches.
+                        if (_group!.Kind != RegexNodeKind.ExpressionConditional || _group.ChildCount() > 0)
                         {
                             ScanOptions();
                         }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexParser.cs
@@ -1000,8 +1000,8 @@ namespace System.Text.RegularExpressions
                         --_pos;
 
                         nodeType = RegexNodeKind.Group;
-                        // Disallow options as the test expression of a conditional (when no test has been added yet),
-                        // but allow them in the yes/no branches.
+                        // While parsing the test of a conditional (ExpressionConditional with no children yet),
+                        // disallow inline options; allow them once the test has been parsed and in the yes/no branches.
                         if (_group!.Kind != RegexNodeKind.ExpressionConditional || _group.ChildCount() > 0)
                         {
                             ScanOptions();

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -907,6 +907,7 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"(?(?=cat)(?i)CAT|dog)", "cat", RegexOptions.None, 0, 3, true, "cat");
                 yield return (@"(cat)?(?(1)(?i)dog|pig)", "catDOG", RegexOptions.None, 0, 6, true, "catDOG");
                 yield return (@"(cat)?(?(1)(?i)dog|pig)", "pig", RegexOptions.None, 0, 3, true, "pig");
+                yield return (@"(?((?i)cat)CAT|dog)", "CAT", RegexOptions.None, 0, 3, true, "CAT");
                 yield return ("(a|ab|abc|abcd)d", "abcd", RegexOptions.RightToLeft, 0, 4, true, "abcd");
 
                 yield return ("(?>(?:a|ab|abc|abcd))d", "abcd", RegexOptions.None, 0, 4, false, string.Empty);

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -899,7 +899,7 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"(?(abc)\w+|\w{0,2})dog", "catdog", RegexOptions.None, 0, 6, true, "atdog");
                 yield return (@"(?(abc)cat|\w{0,2})dog", "catdog", RegexOptions.None, 0, 6, true, "atdog");
 
-                // Inline options inside conditional branches (https://github.com/dotnet/runtime/issues/111633)
+                // Inline options inside conditional branches
                 yield return (@"(?(cat)(?i)CAT|dog)", "cat", RegexOptions.None, 0, 3, true, "cat");
                 yield return (@"(?(cat)(?i)cat|dog)", "dog", RegexOptions.None, 0, 3, true, "dog");
                 yield return (@"(?(cat)cat|(?i)dog)", "DOG", RegexOptions.None, 0, 3, true, "DOG");

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -898,6 +898,15 @@ namespace System.Text.RegularExpressions.Tests
                 yield return (@"(?(\w+)\w+)dog", "catdog", RegexOptions.None, 0, 6, true, "catdog");
                 yield return (@"(?(abc)\w+|\w{0,2})dog", "catdog", RegexOptions.None, 0, 6, true, "atdog");
                 yield return (@"(?(abc)cat|\w{0,2})dog", "catdog", RegexOptions.None, 0, 6, true, "atdog");
+
+                // Inline options inside conditional branches (https://github.com/dotnet/runtime/issues/111633)
+                yield return (@"(?(cat)(?i)CAT|dog)", "cat", RegexOptions.None, 0, 3, true, "cat");
+                yield return (@"(?(cat)(?i)cat|dog)", "dog", RegexOptions.None, 0, 3, true, "dog");
+                yield return (@"(?(cat)cat|(?i)dog)", "DOG", RegexOptions.None, 0, 3, true, "DOG");
+                yield return (@"(?(cat)(?i:CAT)|dog)", "cat", RegexOptions.None, 0, 3, true, "cat");
+                yield return (@"(?(?=cat)(?i)CAT|dog)", "cat", RegexOptions.None, 0, 3, true, "cat");
+                yield return (@"(cat)?(?(1)(?i)dog|pig)", "catDOG", RegexOptions.None, 0, 6, true, "catDOG");
+                yield return (@"(cat)?(?(1)(?i)dog|pig)", "pig", RegexOptions.None, 0, 3, true, "pig");
                 yield return ("(a|ab|abc|abcd)d", "abcd", RegexOptions.RightToLeft, 0, 4, true, "abcd");
 
                 yield return ("(?>(?:a|ab|abc|abcd))d", "abcd", RegexOptions.None, 0, 4, false, string.Empty);

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexParserTests.netcoreapp.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexParserTests.netcoreapp.cs
@@ -26,6 +26,7 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(@"(?(?X))", RegexOptions.None, RegexParseError.InvalidGroupingConstruct, 5)]
         [InlineData(@"(?(?n))", RegexOptions.None, RegexParseError.InvalidGroupingConstruct, 5)]
         [InlineData(@"(?(?m))", RegexOptions.None, RegexParseError.InvalidGroupingConstruct, 5)]
+        [InlineData(@"(?(?i)yes|no)", RegexOptions.None, RegexParseError.InvalidGroupingConstruct, 5)] // options as test expression with branches still blocked
         [InlineData("(?<-", RegexOptions.None, RegexParseError.InvalidGroupingConstruct, 3)]
         [InlineData("(?<-", RegexOptions.IgnorePatternWhitespace, RegexParseError.InvalidGroupingConstruct, 3)]
         [InlineData(@"^[^<>]*(((?'Open'<)[^<>]*)+((?'Close-Open'>)[^<>]*)+)*(?(Open)(?!))$", RegexOptions.None, null)]

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexParserTests.netcoreapp.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexParserTests.netcoreapp.cs
@@ -26,7 +26,7 @@ namespace System.Text.RegularExpressions.Tests
         [InlineData(@"(?(?X))", RegexOptions.None, RegexParseError.InvalidGroupingConstruct, 5)]
         [InlineData(@"(?(?n))", RegexOptions.None, RegexParseError.InvalidGroupingConstruct, 5)]
         [InlineData(@"(?(?m))", RegexOptions.None, RegexParseError.InvalidGroupingConstruct, 5)]
-        [InlineData(@"(?(?i)yes|no)", RegexOptions.None, RegexParseError.InvalidGroupingConstruct, 5)] // options as test expression with branches still blocked
+        [InlineData(@"(?(?i)yes|no)", RegexOptions.None, RegexParseError.InvalidGroupingConstruct, 5)] // does not throw on .NET Framework, but that is a parser bug there
         [InlineData("(?<-", RegexOptions.None, RegexParseError.InvalidGroupingConstruct, 3)]
         [InlineData("(?<-", RegexOptions.IgnorePatternWhitespace, RegexParseError.InvalidGroupingConstruct, 3)]
         [InlineData(@"^[^<>]*(((?'Open'<)[^<>]*)+((?'Close-Open'>)[^<>]*)+)*(?(Open)(?!))$", RegexOptions.None, null)]


### PR DESCRIPTION
Fixes #111633.

## Problem

The regex parser rejects inline options like `(?i)` inside the yes/no branches of expression conditionals (e.g. `(?(test)(?i)yes|no)`), throwing `Unrecognized grouping construct`. This is a regression from .NET Framework, introduced in corefx PR #16609.

`BackreferenceConditional` (e.g. `(?(1)(?i)yes|no)`) was never blocked, confirming the restriction on `ExpressionConditional` was unintentional.

## Root Cause

In `RegexParser.ScanGroupOpen()`, `ScanOptions()` was skipped whenever `_group.Kind == ExpressionConditional`. This was intended to protect the test expression, but by the time we're parsing the yes/no branches, `_group` is still the `ExpressionConditional` node (the test expression is parsed inside its own sub-group). So the check blocked options in the branches rather than in the test.

## Fix

Changed the condition to also check `_group.ChildCount() > 0`: options are only blocked when the conditional has no test expression yet (`ChildCount == 0`), allowing them in the branches after the test expression has been added (`ChildCount > 0`).

## Testing

- 5 new test cases for inline options in conditional branches (expression conditional, backreference conditional, lookahead conditional, options group syntax, options in no-branch)
- All 30,801 existing regex tests pass on net11.0
- All 1,980 tests pass on .NET Framework 4.8.1, confirming the patterns were always valid there
- Verified the new tests fail without the code fix