### PR TITLE
Strip ARM64 TBI tag byte from addresses before pread on /proc/<pid>/mem

### DIFF
--- a/src/coreclr/pal/src/debug/debug.cpp
+++ b/src/coreclr/pal/src/debug/debug.cpp
@@ -730,8 +730,10 @@ PAL_ReadProcessMemory(
     //
     // Currently only Android allocators set a non-zero top byte, so on other ARM64 Linux
     // configurations this is a no-op. However, any future use of TBI tagging (e.g., ARM MTE)
-    // on other Linux distros would hit the same issue, so the strip is applied unconditionally.
+    // on other Linux distros would hit the same issue.
+#ifdef TARGET_ARM64
     address &= 0x00FFFFFFFFFFFFFFULL;
+#endif
     read = pread(handle, buffer, size, address);
     if (read == (size_t)-1)
     {


### PR DESCRIPTION
Android's scudo heap allocator uses ARM64 Top-Byte Ignore (TBI) to tag heap pointers with a non-zero top byte (e.g., 0xB4). While the CPU ignores this byte during memory access, pread on /proc/<pid>/mem treats the offset as a file position where TBI does not apply, causing EINVAL.

Strip the top byte before pread in PAL_ReadProcessMemory and createdump's ReadProcessMemory. This is a no-op on non-Android ARM64 Linux today, but guards against future TBI/MTE adoption on other distributions.

See https://www.kernel.org/doc/html/latest/arch/arm64/tagged-address-abi.html