### PR TITLE
[RyuJit/WASM] Rewrite SP references into PHYSREGs

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -522,6 +522,10 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
             genCodeForStoreLclVar(treeNode->AsLclVar());
             break;
 
+        case GT_PHYSREG:
+            genCodeForPhysReg(treeNode->AsPhysReg());
+            break;
+
         case GT_JTRUE:
             genCodeForJTrue(treeNode->AsOp());
             break;
@@ -1812,6 +1816,19 @@ void CodeGen::genCodeForStoreLclVar(GenTreeLclVar* tree)
 
     GetEmitter()->emitIns_I(INS_local_set, emitTypeSize(tree), WasmRegToIndex(targetReg));
     genUpdateLifeStore(tree, targetReg, varDsc);
+}
+
+//------------------------------------------------------------------------
+// genCodeForPhysReg: Produce code for a PHYSREG node.
+//
+// Arguments:
+//    tree - the GT_PHYSREG node
+//
+void CodeGen::genCodeForPhysReg(GenTreePhysReg* tree)
+{
+    assert(genIsValidReg(tree->gtSrcReg));
+    GetEmitter()->emitIns_I(INS_local_get, emitActualTypeSize(tree), WasmRegToIndex(tree->gtSrcReg));
+    WasmProduceReg(tree);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -72,7 +72,7 @@ LIR::Range& WasmRegAlloc::CurrentRange()
 //
 void WasmRegAlloc::IdentifyCandidates()
 {
-    m_spVarDsc = m_compiler->lvaGetDesc(m_compiler->lvaWasmSpArg);
+    InitializeStackPointer();
 
     bool anyFrameLocals = false;
     for (unsigned lclNum = 0; lclNum < m_compiler->lvaCount; lclNum++)
@@ -114,27 +114,43 @@ void WasmRegAlloc::InitializeCandidate(LclVarDsc* varDsc)
 }
 
 //------------------------------------------------------------------------
-// AllocateStackPointer: Allocate a virtual register for the SP.
+// InitializeStackPointer: Initialize the stack pointer local.
 //
-regNumber WasmRegAlloc::AllocateStackPointer()
+// The stack pointer (as referenced in IR) presents a bit of a problem for
+// the allocator. We don't have precise liveness for it due to the various
+// implicit uses, so it can't be a complete candidate. At the same time, we
+// don't want to needlessly spill it to the stack even in debug code.
+// We solve these problems by neutering the SP local descriptor to represent
+// an unreferenced local and rewriting all references to it into PHYS_REGs.
+//
+// It is a fudge, but this way we don't need to introduce any new contracts
+// between RA and codegen beyond "SetStackPointerReg".
+//
+void WasmRegAlloc::InitializeStackPointer()
 {
-    if (m_spVarDsc->lvIsRegCandidate())
-    {
-        assert(genIsValidReg(m_spVarDsc->GetRegNum())); // Already allocated.
-    }
-    else
-    {
-        // For allocation purposes it is convenient to consider the SP always enregistered. Some references to it
-        // (e. g. through the frame pointer) are implicit, so we need to track it regardless. This way, the tracking
-        // is uniform for candidate and non-candidate cases.
-        assert(!genIsValidReg(m_spVarDsc->GetRegNum()));
-        m_spVarDsc->SetRegNum(AllocateVirtualRegister(TYP_I_IMPL));
-    }
-    return m_spVarDsc->GetRegNum();
+    LclVarDsc* spVarDsc = m_compiler->lvaGetDesc(m_compiler->lvaWasmSpArg);
+    assert(spVarDsc->lvRefCnt() != 0); // TODO-WASM-RA-CQ: precise usage tracking for SP.
+
+    // We don't neuter the live sets and such since that's currently not needed.
+    spVarDsc->lvImplicitlyReferenced = false;
+    spVarDsc->setLvRefCnt(0);
+
+    AllocateStackPointer();
 }
 
 //------------------------------------------------------------------------
-// AllocateStackPointer: Allocate a virtual register for the FP.
+// AllocateStackPointer: Allocate a virtual register for the SP.
+//
+void WasmRegAlloc::AllocateStackPointer()
+{
+    if (m_spReg == REG_NA)
+    {
+        m_spReg = AllocateVirtualRegister(TYP_I_IMPL);
+    }
+}
+
+//------------------------------------------------------------------------
+// AllocateFramePointer: Allocate a virtual register for the FP.
 //
 void WasmRegAlloc::AllocateFramePointer()
 {
@@ -149,7 +165,7 @@ void WasmRegAlloc::AllocateFramePointer()
     }
     else
     {
-        m_fpReg = m_spVarDsc->GetRegNum();
+        m_fpReg = m_spReg;
     }
 }
 
@@ -259,6 +275,10 @@ void WasmRegAlloc::CollectReferencesForNode(GenTree* node)
 {
     switch (node->OperGet())
     {
+        case GT_LCL_VAR:
+            CollectReferencesForLclVar(node->AsLclVar());
+            break;
+
         case GT_STORE_LCL_VAR:
         case GT_STORE_LCL_FLD:
         {
@@ -341,6 +361,24 @@ void WasmRegAlloc::CollectReferencesForCall(GenTreeCall* callNode)
 void WasmRegAlloc::CollectReferencesForCast(GenTreeOp* castNode)
 {
     ConsumeTemporaryRegForOperand(castNode->gtGetOp1() DEBUGARG("cast overflow check"));
+}
+
+//------------------------------------------------------------------------
+// CollectReferencesForLclVar: Collect virtual register references for a LCL_VAR.
+//
+// Rewrites SP references into PHYS_REGs.
+//
+// Arguments:
+//    lclVar - The LCL_VAR node
+//
+void WasmRegAlloc::CollectReferencesForLclVar(GenTreeLclVar* lclVar)
+{
+    if (lclVar->GetLclNum() == m_compiler->lvaWasmSpArg)
+    {
+        lclVar->ChangeOper(GT_PHYSREG);
+        lclVar->AsPhysReg()->gtSrcReg = m_spReg;
+        CollectReference(lclVar);
+    }
 }
 
 //------------------------------------------------------------------------
@@ -537,7 +575,7 @@ void WasmRegAlloc::ResolveReferences()
                 indexBase              = max(indexBase, argIndex + 1);
 
                 LclVarDsc* argVarDsc = m_compiler->lvaGetDesc(argLclNum);
-                if (argVarDsc->GetRegNum() == argReg)
+                if ((argVarDsc->GetRegNum() == argReg) || (m_spReg == argReg))
                 {
                     assert(abiInfo.HasExactlyOneRegisterSegment());
                     virtToPhysRegMap[static_cast<unsigned>(argType)].DeclaredCount--;
@@ -602,14 +640,14 @@ void WasmRegAlloc::ResolveReferences()
     };
 
     // Allocate all our virtual registers to physical ones.
-    regNumber spVirtReg = m_spVarDsc->GetRegNum();
-    if (genIsValidReg(spVirtReg))
+    regNumber spVirtReg = m_spReg;
+    if (spVirtReg != REG_NA)
     {
-        m_spVarDsc->SetRegNum(allocPhysReg(spVirtReg, m_spVarDsc));
+        m_spReg = allocPhysReg(spVirtReg, m_compiler->lvaGetDesc(m_compiler->lvaWasmSpArg));
     }
     if (m_fpReg != REG_NA)
     {
-        m_fpReg = (spVirtReg == m_fpReg) ? m_spVarDsc->GetRegNum() : allocPhysReg(m_fpReg, nullptr);
+        m_fpReg = (spVirtReg == m_fpReg) ? m_spReg : allocPhysReg(m_fpReg, nullptr);
     }
 
     for (unsigned varIndex = 0; varIndex < m_compiler->lvaTrackedCount; varIndex++)
@@ -642,8 +680,16 @@ void WasmRegAlloc::ResolveReferences()
     {
         for (size_t i = 0; i < refsCount; i++)
         {
+            GenTree* node = refs->Nodes[i];
+            if (node->OperIs(GT_PHYSREG))
+            {
+                assert(node->AsPhysReg()->gtSrcReg == spVirtReg);
+                node->AsPhysReg()->gtSrcReg = m_spReg;
+                assert(!genIsValidReg(node->GetRegNum())); // Currently we do not need to multi-use any PHYSREGs.
+                continue;
+            }
+
             regNumber physReg;
-            GenTree*  node = refs->Nodes[i];
             if (node->OperIs(GT_STORE_LCL_VAR))
             {
                 physReg = m_compiler->lvaGetDesc(node->AsLclVarCommon())->GetRegNum();
@@ -692,21 +738,16 @@ void WasmRegAlloc::ResolveReferences()
 //
 void WasmRegAlloc::PublishAllocationResults()
 {
-    regNumber spReg = m_spVarDsc->GetRegNum();
-    if (genIsValidReg(spReg))
+    if (m_spReg != REG_NA)
     {
-        m_codeGen->SetStackPointerReg(spReg);
-
-        // Revert the RA-local "enregistering" of SP if needed.
-        if (!m_spVarDsc->lvIsRegCandidate())
-        {
-            m_spVarDsc->SetRegNum(REG_STK);
-        }
+        m_codeGen->SetStackPointerReg(m_spReg);
+        JITDUMP("Allocated SP into %s\n", getRegName(m_spReg));
     }
     if (m_fpReg != REG_NA)
     {
         m_codeGen->SetFramePointerReg(m_fpReg);
         m_codeGen->setFramePointerUsed(true);
+        JITDUMP("Allocated FP into %s\n", getRegName(m_fpReg));
     }
     else
     {

--- a/src/coreclr/jit/regallocwasm.h
+++ b/src/coreclr/jit/regallocwasm.h
@@ -86,8 +86,8 @@ class WasmRegAlloc : public RegAllocInterface
     // The meaning of these fields is borrowed (partially) from the C ABI for WASM. We define "the SP" to be the local
     // which is used to make calls - the stack on entry to callees. We term "the FP" to be the local which is used to
     // access the fixed potion of the frame. For fixed-size frames (no localloc), these will be the same.
-    LclVarDsc* m_spVarDsc = nullptr;
-    regNumber  m_fpReg    = REG_NA;
+    regNumber m_spReg = REG_NA;
+    regNumber m_fpReg = REG_NA;
 
 public:
     WasmRegAlloc(Compiler* compiler);
@@ -108,7 +108,8 @@ private:
 
     void      IdentifyCandidates();
     void      InitializeCandidate(LclVarDsc* varDsc);
-    regNumber AllocateStackPointer();
+    void      InitializeStackPointer();
+    void      AllocateStackPointer();
     void      AllocateFramePointer();
     regNumber AllocateVirtualRegister(var_types type);
     regNumber AllocateVirtualRegister(WasmValueType type);
@@ -121,6 +122,7 @@ private:
     void CollectReferencesForDivMod(GenTreeOp* divModNode);
     void CollectReferencesForCall(GenTreeCall* callNode);
     void CollectReferencesForCast(GenTreeOp* castNode);
+    void CollectReferencesForLclVar(GenTreeLclVar* lclVar);
     void RewriteLocalStackStore(GenTreeLclVarCommon* node);
     void CollectReference(GenTree* node);
     void RequestTemporaryRegisterForMultiplyUsedNode(GenTree* node);


### PR DESCRIPTION
The special SP local presents unique challenges for RA:
1) It can't be a proper candidate since it lacks correct liveness due to implicit uses.
2) Even if we change liveness, we don't want to allocate it to stack even in debug mode. Both because it is wasteful and because it makes the contract for opcodes like LCLHEAP more complicated.

The solution implemented here is to treat the SP specially in RA:
1) Neuter its local to make it look as if it has no references. That makes sure we don't spill it to stack in debug code and straightens out the contract with codegen w.r.t. candidate liveness.
2) Rewrite all explicit references into PHYSREG nodes.

In effect, we transfer the 'ownership' of the SP value from the local to the "SP reg" well-known codegen location, confining all the "specialness" to RA.