### PR TITLE
More AP-related optimizations

### DIFF
--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2097,7 +2097,7 @@ void Compiler::optAssertionGen(GenTree* tree)
                 {
                     ValueNum lenVN = vnStore->VNIgnoreIntToLongCast(optConservativeNormalVN(lenArg));
                     if ((lenVN != ValueNumStore::NoVN) && !vnStore->IsVNConstant(lenVN) &&
-                        vnStore->TypeOfVN(lenVN) == TYP_INT)
+                        (vnStore->TypeOfVN(lenVN) == TYP_INT))
                     {
                         ValueNum zeroVN = vnStore->VNZeroForType(TYP_INT);
                         assertionInfo = optAddAssertion(AssertionDsc::CreateConstantBound(this, VNF_GE, lenVN, zeroVN));
@@ -2110,7 +2110,8 @@ void Compiler::optAssertionGen(GenTree* tree)
                 //
                 // arr[idx] = value; - creates idx is within bounds of arr assertion
                 //
-                if (call->IsHelperCall(this, CORINFO_HELP_ARRADDR_ST))
+                CorInfoHelpFunc helperId = eeGetHelperNum(call->gtCallMethHnd);
+                if ((helperId == CORINFO_HELP_ARRADDR_ST) || (helperId == CORINFO_HELP_LDELEMA_REF))
                 {
                     assert(call->gtArgs.CountUserArgs() == 3);
                     GenTree* arrRef = call->gtArgs.GetUserArgByIndex(0)->GetNode();

--- a/src/coreclr/jit/assertionprop.cpp
+++ b/src/coreclr/jit/assertionprop.cpp
@@ -2112,6 +2112,7 @@ void Compiler::optAssertionGen(GenTree* tree)
                 //
                 if (call->IsHelperCall(this, CORINFO_HELP_ARRADDR_ST))
                 {
+                    assert(call->gtArgs.CountUserArgs() == 3);
                     GenTree* arrRef = call->gtArgs.GetUserArgByIndex(0)->GetNode();
                     GenTree* idx    = call->gtArgs.GetUserArgByIndex(1)->GetNode();
 

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -7595,7 +7595,7 @@ public:
 
     typedef JitHashTable<unsigned, JitSmallPrimitiveKeyFuncs<unsigned>, GenTree*> LocalNumberToNullCheckTreeMap;
 
-    GenTree*    getArrayLengthFromAllocation(GenTree* tree DEBUGARG(BasicBlock* block));
+    GenTree*    getArrayLengthFromAllocation(GenTree* tree);
     GenTree*    optPropGetValueRec(unsigned lclNum, unsigned ssaNum, optPropKind valueKind, int walkDepth);
     GenTree*    optPropGetValue(unsigned lclNum, unsigned ssaNum, optPropKind valueKind);
     GenTree*    optEarlyPropRewriteTree(GenTree* tree, LocalNumberToNullCheckTreeMap* nullCheckMap);

--- a/src/coreclr/jit/earlyprop.cpp
+++ b/src/coreclr/jit/earlyprop.cpp
@@ -281,7 +281,7 @@ GenTree* Compiler::optPropGetValueRec(unsigned lclNum, unsigned ssaNum, optPropK
         {
             if (valueKind == optPropKind::OPK_ARRAYLEN)
             {
-                value = getArrayLengthFromAllocation(defValue DEBUGARG(ssaVarDsc->GetBlock()));
+                value = getArrayLengthFromAllocation(defValue);
                 if (value != nullptr)
                 {
                     if (!value->IsCnsIntOrI())

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -2050,13 +2050,12 @@ bool GenTreeCall::IsPure(Compiler* compiler) const
 //                               helper call.
 //
 // Arguments:
-//    tree           - The array allocation helper call.
-//    block          - tree's basic block.
+//    tree - The array allocation helper call.
 //
 // Return Value:
 //    Return the array length node.
 
-GenTree* Compiler::getArrayLengthFromAllocation(GenTree* tree DEBUGARG(BasicBlock* block))
+GenTree* Compiler::getArrayLengthFromAllocation(GenTree* tree)
 {
     assert(tree != nullptr);
 
@@ -2252,7 +2251,7 @@ bool GenTreeCall::HasSideEffects(Compiler* compiler, bool ignoreExceptions, bool
     // Consider array allocators side-effect free for constant length (if it's not negative and fits into i32)
     if (helperProperties.IsAllocator(helper))
     {
-        GenTree* arrLen = compiler->getArrayLengthFromAllocation((GenTree*)this DEBUGARG(nullptr));
+        GenTree* arrLen = compiler->getArrayLengthFromAllocation((GenTree*)this);
         // if arrLen is nullptr it means it wasn't an array allocator
         if ((arrLen != nullptr) && arrLen->IsIntCnsFitsInI32())
         {

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -2062,6 +2062,11 @@ ValueNum ValueNumStore::VNForCastOper(var_types castToType, bool srcIsUnsigned)
 //
 ValueNum ValueNumStore::VNIgnoreIntToLongCast(ValueNum vn)
 {
+    if (TypeOfVN(vn) != TYP_LONG)
+    {
+        return vn;
+    }
+
     VNFuncApp funcApp;
     if (GetVNFunc(vn, &funcApp) && funcApp.FuncIs(VNF_Cast))
     {
@@ -2072,6 +2077,11 @@ ValueNum ValueNumStore::VNIgnoreIntToLongCast(ValueNum vn)
         {
             return funcApp.m_args[0];
         }
+    }
+    int intCns;
+    if (IsVNIntegralConstant(vn, &intCns))
+    {
+        return VNForIntCon(intCns);
     }
     return vn;
 }

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -508,7 +508,6 @@ public:
     // Unpacks the information stored by VNForCastOper in the constant represented by the value number.
     void GetCastOperFromVN(ValueNum vn, var_types* pCastToType, bool* pSrcIsUnsigned);
 
-    // Returns the underlying value number if 'vn' represents a sign-extending int-to-long cast; otherwise returns 'vn'.
     ValueNum VNIgnoreIntToLongCast(ValueNum vn);
 
     // We keep handle values in a separate pool, so we don't confuse a handle with an int constant

--- a/src/coreclr/jit/valuenum.h
+++ b/src/coreclr/jit/valuenum.h
@@ -508,6 +508,9 @@ public:
     // Unpacks the information stored by VNForCastOper in the constant represented by the value number.
     void GetCastOperFromVN(ValueNum vn, var_types* pCastToType, bool* pSrcIsUnsigned);
 
+    // Returns the underlying value number if 'vn' represents a sign-extending int-to-long cast; otherwise returns 'vn'.
+    ValueNum VNIgnoreIntToLongCast(ValueNum vn);
+
     // We keep handle values in a separate pool, so we don't confuse a handle with an int constant
     // that happens to be the same...
     ValueNum VNForHandle(ssize_t cnsVal, GenTreeFlags iconFlags);


### PR DESCRIPTION
This PR creates more assertions that can be used by various optimizations. Minimal examples:
```cs
    object Case1(object[] arr, int i, object b)
    {
        // covariant stores used to be ignored by range check
        arr[3] = b; // arr is >= 4 elements long

        return arr[2]; // no bounds check anymore
    }

    bool Case2(int a, int b)
    {
        int c = a / b;

        // b is never 0 here
        return b == 0;
    }

    byte[] Case3(int numBytes, IntPtr pbData)
    {
        byte[] data = new byte[numBytes];

        if (numBytes < 0) // never true
            throw new InvalidOperationException();
        return data;
    }
```

```diff
 ; Method Examples:Case1(System.Object[],int,System.Object):System.Object:this (FullOpts)
        push     rbx
        sub      rsp, 32
        mov      rbx, rdx
        mov      rcx, rbx
        mov      r8, r9
        mov      edx, 3
        call     CORINFO_HELP_ARRADDR_ST
-       cmp      dword ptr [rbx+0x08], 2
-       jbe      SHORT G_M25522_IG04
        mov      rax, gword ptr [rbx+0x20]
        add      rsp, 32
        pop      rbx
        ret      
-G_M25522_IG04:
-       call     CORINFO_HELP_RNGCHKFAIL
-       int3     
-; Total bytes of code: 46
+; Total bytes of code: 34
 
 
 ; Method Examples:Case2(int,int):bool:this (FullOpts)
        mov      eax, edx
        cdq      
        idiv     edx:eax, r8d
-       test     r8d, r8d
-       sete     al
-       movzx    rax, al
+       xor      eax, eax
        ret      
-; Total bytes of code: 16
+; Total bytes of code: 9
 
 
 ; Method Examples:Case3(int,nint):byte[]:this (FullOpts)
-       push     rbx
-       sub      rsp, 32
-       mov      ebx, edx
-       movsxd   rdx, ebx
+       sub      rsp, 40
+       movsxd   rdx, edx
        mov      rcx, 0x7FFF08D305B8      ; byte[]
        call     CORINFO_HELP_NEWARR_1_VC
-       test     ebx, ebx
-       jl       SHORT G_M3253_IG04
-       add      rsp, 32
-       pop      rbx
-       ret      
-G_M3253_IG04:
-       mov      rcx, 0x7FFF08D8CB60      ; System.InvalidOperationException
-       call     CORINFO_HELP_NEWSFAST
-       mov      rbx, rax
-       mov      rcx, rbx
-       call     [System.InvalidOperationException:.ctor():this]
-       mov      rcx, rbx
-       call     CORINFO_HELP_THROW
-       int3
-; Total bytes of code: 71
+       nop      
+       add      rsp, 40
+       ret      
+; Total bytes of code: 28
```

[diffs](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1304188&view=ms.vss-build-web.run-extensions-tab)