### PR TITLE
Add security-scan skill for security-researcher-style vulnerability a…

### DIFF
--- a/.github/skills/security-scan/SKILL.md
+++ b/.github/skills/security-scan/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: security-scan
+description: Perform a security-focused review of code changes, thinking like a security researcher to find exploitable vulnerabilities. Use when asked to "security scan", "security review", "find vulnerabilities", "check for security issues", or "audit security". Also use when reviewing security-sensitive areas like cryptography, authentication, serialization, or input handling.
+---
+
+# Security Scan
+
+Perform a deep, security-researcher-style audit of code changes in dotnet/runtime. This skill goes beyond pattern matching — it reasons about data flow, trust boundaries, and exploit paths the way an experienced security engineer would.
+
+> 🚨 **Human-in-the-loop**: This skill identifies vulnerabilities and suggests fixes but NEVER auto-applies patches. All findings require human review and approval.
+
+## When to Use This Skill
+
+Use this skill when:
+- Asked to perform a security review or audit of code changes
+- Reviewing changes to security-sensitive areas (cryptography, auth, serialization, networking, input parsing)
+- Checking a PR or branch for exploitable vulnerabilities before merge
+- Investigating whether a code change introduces new attack surface
+- Asked "is this change secure?", "find vulnerabilities", "security scan", or similar
+
+## Gathering Context
+
+### Step 1: Identify What Changed
+
+Determine the scope of the review. Use one of these approaches depending on context:
+
+**For a branch (most common — local review before commit/PR):**
+```bash
+git diff --name-only origin/HEAD...
+git diff --merge-base origin/HEAD
+```
+
+**For a specific PR:**
+Use the GitHub MCP tools to fetch the PR diff and file list:
+- `pull_request_read` with method `get_diff` and `get_files`
+
+**For a set of files the user specifies:**
+Read those files directly.
+
+Collect the full list of changed files and the complete diff content.
+
+### Step 2: Repository Context Research
+
+Before analyzing the changes, understand the security posture of the affected area. Use file exploration tools (`Glob`, `Grep`, `Read`) to:
+
+1. **Identify security frameworks in use** — Look for existing validation helpers, sanitization patterns, `SecureString` usage, permission checks, `SafeHandle` usage, cryptographic API usage in the affected directories.
+2. **Examine existing security patterns** — How does surrounding code handle untrusted input? What validation patterns are established? Are there `// SECURITY:` comments or `[SecurityCritical]` attributes nearby?
+3. **Understand trust boundaries** — Where does user/external input enter the system? What crosses process, AppDomain, or serialization boundaries? What runs with elevated privileges?
+4. **Check related security tests** — Look for existing security-focused tests (`*Security*`, `*Injection*`, `*Sanitiz*`, `*Untrusted*`) in the test projects for the affected libraries.
+
+### Step 3: Analyze the Changes
+
+Execute a three-phase analysis:
+
+**Phase 1 — Comparative Analysis:**
+- Compare new code against existing security patterns in the same area
+- Identify deviations from established secure practices
+- Look for inconsistent security implementations across similar code
+- Flag code that introduces new attack surfaces
+
+**Phase 2 — Vulnerability Assessment:**
+- Examine each modified file for security implications
+- Trace data flow from untrusted inputs to sensitive operations
+- Look for privilege boundaries being crossed unsafely
+- Identify injection points and unsafe deserialization
+- Check for TOCTOU (time-of-check-time-of-use) issues in security-critical paths
+
+**Phase 3 — Self-Critique and Verification:**
+- For each potential finding, attempt to disprove it
+- Check whether the issue is already mitigated by callers, callees, or framework guarantees
+- Verify the finding against the full source file, not just the diff
+- Assign a confidence score — only report findings with confidence ≥ 8/10
+
+## Multi-Agent Verification
+
+When the environment supports launching sub-agents (the `task` tool), use parallel verification to reduce false positives:
+
+1. **Discovery agent**: Launch a `general-purpose` sub-agent that performs the full 3-phase analysis above. Provide it with the diff, changed file list, and the security categories to examine. Ask it to output structured findings.
+
+2. **Verification agents**: For each finding from step 1, launch a parallel `explore` agent that independently assesses whether the finding is a true positive. Provide the finding details and instruct it to:
+   - Read the full source file(s) involved
+   - Check callers and callees for existing mitigations
+   - Search for similar patterns elsewhere in the codebase
+   - Assign a confidence score from 1-10 with justification
+
+3. **Filter**: Only keep findings where the verification agent assigned confidence ≥ 8.
+
+If the environment does not support sub-agents, perform the verification yourself sequentially.
+
+## Security Categories to Examine
+
+### dotnet/runtime-Specific Concerns
+
+**Unsafe Code & Memory Safety:**
+- `unsafe` blocks with pointer arithmetic, `Span<T>`/`Memory<T>` misuse
+- Buffer overflows in native interop (`DllImport`, `LibraryImport`, `Marshal.*`)
+- Use-after-free in `SafeHandle`/`CriticalHandle` implementations
+- Stack buffer overflows via `stackalloc` without bounds checking
+- `Unsafe.As<T>` type punning that violates type safety
+
+**Serialization & Deserialization:**
+- `BinaryFormatter`, `SoapFormatter`, or other insecure deserializers
+- `TypeNameHandling` in JSON serialization allowing type injection
+- Custom `TypeConverter` or `SerializationBinder` that don't restrict types
+- XML deserialization without restricting allowed types (XXE, type injection)
+- `System.Text.Json` custom converters that trust input type discriminators
+
+**Cryptography:**
+- Use of obsolete algorithms (MD5, SHA1 for security, DES, RC2, 3DES)
+- Hardcoded keys, IVs, or salts
+- Missing or incorrect padding modes
+- Non-constant-time comparisons of secrets/MACs (use `CryptographicOperations.FixedTimeEquals`)
+- Improper random number generation (using `Random` instead of `RandomNumberGenerator` for security)
+- Certificate validation bypass (`ServerCertificateCustomValidationCallback` returning `true`)
+
+**Input Validation & Injection:**
+- Path traversal via unsanitized `Path.Combine` or `Path.GetFullPath`
+- Command injection via `Process.Start` with unsanitized arguments
+- LDAP injection, XPath injection in query construction
+- Regex denial-of-service (ReDoS) with untrusted patterns — **only if the regex processes external input**
+- Format string vulnerabilities in native code (`sprintf` without bounds)
+
+**Authentication & Authorization:**
+- Bypassing security checks via reflection or `BindingFlags.NonPublic`
+- `AllowPartiallyTrustedCallers` misuse
+- Elevation of privilege through assembly loading or code generation
+- Missing permission demands on security-critical operations
+
+**Networking & Web:**
+- SSRF via user-controlled URLs (only if attacker can control host/protocol)
+- TLS downgrade or missing certificate validation
+- Cookie handling without `Secure`/`HttpOnly` flags
+- HTTP header injection via unsanitized values
+
+**Native Interop:**
+- Buffer size mismatches between managed and native code
+- Missing null checks on pointers returned from native calls
+- Incorrect `MarshalAs` attributes leading to memory corruption
+- Missing `SetLastError = true` on P/Invoke that checks `GetLastError`
+
+### General Categories
+
+**Injection Attacks:**
+- SQL injection via string concatenation in queries
+- Command injection in system calls or subprocesses
+- XXE injection in XML parsing (missing `DtdProcessing.Prohibit`)
+- Template injection in string formatting with untrusted input
+
+**Data Exposure:**
+- Sensitive data (keys, tokens, PII) in log output
+- Debug information leaking in release builds
+- Exception messages exposing internal paths or state
+- Timing side channels leaking secret-dependent information
+
+## Hard Exclusions — Do NOT Report
+
+These categories produce excessive noise in dotnet/runtime and should be automatically excluded:
+
+1. **Denial of Service (DOS)** — Resource exhaustion, algorithmic complexity attacks, memory/CPU exhaustion
+2. **Rate limiting** — Missing rate limits or throttling
+3. **Resource leaks** — Unclosed files, connections, or memory (not a security vulnerability)
+4. **Open redirects** — Low impact in this context
+5. **Regex injection** — Unless the regex is compiled and processes attacker-controlled input
+6. **Test-only code** — Files under `tests/`, `*Tests*` projects, test helpers, and test data
+7. **Documentation** — Findings in `.md`, `.txt`, or comment-only changes
+8. **Log spoofing** — Writing unsanitized input to logs is not a vulnerability here
+9. **Missing audit logs** — Not a vulnerability
+10. **Environment variables and CLI flags** — Treated as trusted input; attacks requiring control of env vars are invalid
+11. **Outdated dependencies** — Managed separately
+12. **Client-side validation** — Client code is not trusted; server-side is responsible for validation
+13. **Insecure defaults in test/sample code** — Only flag in production code paths
+14. **Memory safety in managed C# code** — The CLR provides memory safety guarantees. Only flag memory issues in `unsafe` blocks, native interop, or C/C++ code under `src/coreclr/` or `src/native/`
+
+## Precedents for dotnet/runtime
+
+These judgment calls reduce false positives specific to this codebase:
+
+1. **`Debug.Assert` is not a security boundary.** Asserts are stripped in release builds. Security checks must use exceptions or fail-fast.
+2. **`internal` is not a security boundary.** Internal APIs can be accessed via reflection. Don't assume internal visibility prevents exploitation.
+3. **`Span<T>` bounds checking is automatic.** The runtime checks bounds on span indexing. Manual bounds checks before span access are defense-in-depth, not vulnerabilities when missing.
+4. **`ThrowHelper` methods are security-relevant.** When `ThrowHelper` is bypassed or conditions are wrong, the security check is ineffective.
+5. **Native code under `src/coreclr/` and `src/native/` IS memory-unsafe.** C/C++ code requires manual bounds checking, null checks, and lifetime management. Flag memory safety issues here.
+6. **`System.Text.Json` source generators are trusted.** Generated serialization code from source generators doesn't need the same scrutiny as hand-written custom converters.
+7. **Volatile/Interlocked correctness matters for security.** Race conditions in security checks (e.g., TOCTOU on permission flags) are real vulnerabilities even though they're hard to exploit.
+
+## Output Format
+
+Present findings using this structure:
+
+```
+## 🔒 Security Scan — <scope description>
+
+### Summary
+
+**Findings**: <N high, N medium> | **Confidence threshold**: ≥ 8/10
+**Verdict**: <✅ No issues found / ⚠️ Issues found — human review required>
+
+---
+
+### Findings
+
+#### 🔴 HIGH: <Brief title> — `path/to/file.cs:42`
+
+- **Category**: <e.g., command_injection, path_traversal, unsafe_deserialization>
+- **Confidence**: <8-10>/10
+- **Description**: <What the vulnerability is, in plain English>
+- **Exploit scenario**: <Concrete attack path — how an attacker would exploit this>
+- **Recommendation**: <Specific fix, with code suggestion if possible>
+
+#### 🟡 MEDIUM: <Brief title> — `path/to/file.cs:87`
+
+- **Category**: ...
+- **Confidence**: ...
+- **Description**: ...
+- **Exploit scenario**: ...
+- **Recommendation**: ...
+
+---
+
+### Files Reviewed
+
+<List of files examined with brief notes on security-relevant observations>
+
+### Methodology Notes
+
+<Brief description of what was checked, tools/agents used, and any limitations>
+```
+
+### Severity Guidelines
+
+- **🔴 HIGH**: Directly exploitable — leads to RCE, data breach, authentication bypass, or arbitrary code execution. Clear attack path exists.
+- **🟡 MEDIUM**: Exploitable under specific conditions with significant impact. Requires particular configuration, timing, or access level.
+- **Do not report LOW severity.** Focus on HIGH and MEDIUM only. Better to miss theoretical issues than flood the report with noise.
+
+### Confidence Scoring
+
+- **9-10**: Certain exploit path identified; verified against full source context
+- **8-9**: Clear vulnerability pattern with known exploitation methods; verified no existing mitigation
+- **Below 8**: Do not report. Too speculative.
+
+## Final Checklist
+
+Before presenting findings:
+
+- [ ] Each finding verified against the **full source file**, not just the diff
+- [ ] Each finding checked for **existing mitigations** in callers/callees
+- [ ] Each finding has a **concrete exploit scenario**, not just a theoretical concern
+- [ ] No findings in **excluded categories** (test code, docs, DOS, etc.)
+- [ ] Confidence ≥ 8 for every reported finding
+- [ ] All code suggestions are **syntactically correct** and would compile

--- a/.github/skills/security-scan/SKILL.md
+++ b/.github/skills/security-scan/SKILL.md
@@ -1,250 +1,77 @@
 ---
 name: security-scan
-description: Perform a security-focused review of code changes, thinking like a security researcher to find exploitable vulnerabilities. Use when asked to "security scan", "security review", "find vulnerabilities", "check for security issues", or "audit security". Also use when reviewing security-sensitive areas like cryptography, authentication, serialization, or input handling.
+description: Perform a security-focused review of code in dotnet/runtime, thinking like a security researcher to find exploitable vulnerabilities. Use when asked to "security scan", "security review", "find vulnerabilities", "check for security issues", or "audit security". Supports reviewing diffs, specific files, or entire directories. Analyzes API contracts, serializer safety, and DOS surface. Anti-pattern catalog is reusable for downstream repos like ASP.NET Core.
 ---
 
 # Security Scan
 
-Perform a deep, security-researcher-style audit of code changes in dotnet/runtime. This skill goes beyond pattern matching — it reasons about data flow, trust boundaries, and exploit paths the way an experienced security engineer would.
+Security-researcher-style audit for dotnet/runtime. Reasons about data flow, trust boundaries, exploit paths, and API contract abuse.
 
-> 🚨 **Human-in-the-loop**: This skill identifies vulnerabilities and suggests fixes but NEVER auto-applies patches. All findings require human review and approval.
+> 🚨 **Human-in-the-loop**: Identifies vulnerabilities and suggests fixes but NEVER auto-applies patches. All findings require human review.
 
-## When to Use This Skill
+## Step 1: Determine Scope and Triage
 
-Use this skill when:
-- Asked to perform a security review or audit of code changes
-- Reviewing changes to security-sensitive areas (cryptography, auth, serialization, networking, input parsing)
-- Checking a PR or branch for exploitable vulnerabilities before merge
-- Investigating whether a code change introduces new attack surface
-- Asked "is this change secure?", "find vulnerabilities", "security scan", or similar
+Infer the review scope from the user's request:
 
-## Gathering Context
+| User intent | Scope | How to gather files |
+|---|---|---|
+| Review my changes / PR review (default) | **diff** | `git diff --merge-base origin/HEAD` or PR diff via MCP |
+| Scan these files | **files** | Read the specified files directly |
+| Audit this directory / library | **directory** | Run triage script, then analyze prioritized files |
 
-### Step 1: Identify What Changed
+**For directory scope**, run the triage script first to focus on security-relevant files:
 
-Determine the scope of the review. Use one of these approaches depending on context:
-
-**For a branch (most common — local review before commit/PR):**
 ```bash
-git diff --name-only origin/HEAD...
-git diff --merge-base origin/HEAD
+python .github/skills/security-scan/scripts/scan_security_surface.py <path> --json
 ```
 
-**For a specific PR:**
-Use the GitHub MCP tools to fetch the PR diff and file list:
-- `pull_request_read` with method `get_diff` and `get_files`
+This outputs a prioritized file list with signal annotations (unsafe code, serialization, DOS surface, public API entry points, etc.). Focus deep analysis on `high` and `medium` priority files only.
 
-**For a set of files the user specifies:**
-Read those files directly.
+For **diff** scope, also collect the full list of changed files with `git diff --name-only origin/HEAD...`.
 
-Collect the full list of changed files and the complete diff content.
+For large-scale scans (multiple libraries, 50+ files), see [references/coordination.md](references/coordination.md) for partitioning, SQL tracking, and subagent delegation.
 
-### Step 2: Repository Context Research
+## Step 2: Research Context
 
-Before analyzing the changes, understand the security posture of the affected area. Use file exploration tools (`Glob`, `Grep`, `Read`) to:
+Before analyzing code, understand the security posture of the affected area using `Glob`, `Grep`, and `Read`:
 
-1. **Identify security frameworks in use** — Look for existing validation helpers, sanitization patterns, `SecureString` usage, permission checks, `SafeHandle` usage, cryptographic API usage in the affected directories.
-2. **Examine existing security patterns** — How does surrounding code handle untrusted input? What validation patterns are established? Are there `// SECURITY:` comments or `[SecurityCritical]` attributes nearby?
-3. **Understand trust boundaries** — Where does user/external input enter the system? What crosses process, AppDomain, or serialization boundaries? What runs with elevated privileges?
-4. **Check related security tests** — Look for existing security-focused tests (`*Security*`, `*Injection*`, `*Sanitiz*`, `*Untrusted*`) in the test projects for the affected libraries.
+1. **Security patterns in use** — validation helpers, `SafeHandle` usage, `[SecurityCritical]` attributes, `// SECURITY:` comments
+2. **Trust boundaries** — where external input enters; what crosses process, AppDomain, or serialization boundaries
+3. **Related security tests** — search for `*Security*`, `*Injection*`, `*Sanitiz*`, `*Untrusted*` in nearby test projects
 
-### Step 3: Analyze the Changes
+## Step 3: Analyze
 
-Execute a three-phase analysis:
+Execute a multi-phase analysis:
 
-**Phase 1 — Comparative Analysis:**
-- Compare new code against existing security patterns in the same area
-- Identify deviations from established secure practices
-- Look for inconsistent security implementations across similar code
-- Flag code that introduces new attack surfaces
+**Phase 1 — Vulnerability assessment:** Trace data flow from untrusted inputs to sensitive operations. Check for injection, unsafe deserialization, privilege boundary crossings, TOCTOU issues, and DOS vectors.
 
-**Phase 2 — Vulnerability Assessment:**
-- Examine each modified file for security implications
-- Trace data flow from untrusted inputs to sensitive operations
-- Look for privilege boundaries being crossed unsafely
-- Identify injection points and unsafe deserialization
-- Check for TOCTOU (time-of-check-time-of-use) issues in security-critical paths
+**Phase 2 — Contract analysis:** For public APIs in scope, check for implicit contracts, missing validation, inconsistent overloads, and cross-component contract mismatches. See [references/contract-analysis.md](references/contract-analysis.md).
 
-**Phase 3 — Self-Critique and Verification:**
-- For each potential finding, attempt to disprove it
-- Check whether the issue is already mitigated by callers, callees, or framework guarantees
-- Verify the finding against the full source file, not just the diff
-- Assign a confidence score — only report findings with confidence ≥ 8/10
+**Phase 3 — Serializer audit:** For any serializer usage flagged by triage, apply the per-serializer checklist. See [references/serializer-audit.md](references/serializer-audit.md).
 
-## Multi-Agent Verification
+**Phase 4 — Self-critique:** For each potential finding, attempt to disprove it. Verify against the full source file, check for mitigations in callers/callees. Only keep findings with confidence ≥ 8/10.
 
-When the environment supports launching sub-agents (the `task` tool), use parallel verification to reduce false positives:
+**Reference materials** (read as needed):
+- **Vulnerability categories**: [references/runtime-categories.md](references/runtime-categories.md)
+- **Exclusions and precedents**: [references/precedents-and-exclusions.md](references/precedents-and-exclusions.md)
+- **Known anti-patterns**: [references/anti-patterns/README.md](references/anti-patterns/README.md)
 
-1. **Discovery agent**: Launch a `general-purpose` sub-agent that performs the full 3-phase analysis above. Provide it with the diff, changed file list, and the security categories to examine. Ask it to output structured findings.
+## Step 4: Multi-Agent Verification
 
-2. **Verification agents**: For each finding from step 1, launch a parallel `explore` agent that independently assesses whether the finding is a true positive. Provide the finding details and instruct it to:
-   - Read the full source file(s) involved
-   - Check callers and callees for existing mitigations
-   - Search for similar patterns elsewhere in the codebase
-   - Assign a confidence score from 1-10 with justification
+When the `task` tool is available, use parallel verification:
 
-3. **Filter**: Only keep findings where the verification agent assigned confidence ≥ 8.
+1. **Discovery agent**: Launch a `general-purpose` sub-agent with the diff/files, changed file list, and the categories from [references/runtime-categories.md](references/runtime-categories.md). Ask it to output structured findings.
 
-If the environment does not support sub-agents, perform the verification yourself sequentially.
+2. **Verification agents**: For each finding, launch a parallel `explore` agent to independently verify it — read full source files, check callers/callees for mitigations, search for similar patterns. Each assigns a confidence score 1-10.
 
-## Security Categories to Examine
+3. **Filter**: Only keep findings with verification confidence ≥ 8.
 
-### dotnet/runtime-Specific Concerns
+Without sub-agents, perform verification sequentially.
 
-**Unsafe Code & Memory Safety:**
-- `unsafe` blocks with pointer arithmetic, `Span<T>`/`Memory<T>` misuse
-- Buffer overflows in native interop (`DllImport`, `LibraryImport`, `Marshal.*`)
-- Use-after-free in `SafeHandle`/`CriticalHandle` implementations
-- Stack buffer overflows via `stackalloc` without bounds checking
-- `Unsafe.As<T>` type punning that violates type safety
+For large-scale scans (multiple libraries, 5+ subagents), see [references/coordination.md](references/coordination.md) for delegation templates, SQL-based progress tracking, finding aggregation, and caching.
 
-**Serialization & Deserialization:**
-- `BinaryFormatter`, `SoapFormatter`, or other insecure deserializers
-- `TypeNameHandling` in JSON serialization allowing type injection
-- Custom `TypeConverter` or `SerializationBinder` that don't restrict types
-- XML deserialization without restricting allowed types (XXE, type injection)
-- `System.Text.Json` custom converters that trust input type discriminators
+## Step 5: Report
 
-**Cryptography:**
-- Use of obsolete algorithms (MD5, SHA1 for security, DES, RC2, 3DES)
-- Hardcoded keys, IVs, or salts
-- Missing or incorrect padding modes
-- Non-constant-time comparisons of secrets/MACs (use `CryptographicOperations.FixedTimeEquals`)
-- Improper random number generation (using `Random` instead of `RandomNumberGenerator` for security)
-- Certificate validation bypass (`ServerCertificateCustomValidationCallback` returning `true`)
+Format findings per the template in [references/output-format.md](references/output-format.md).
 
-**Input Validation & Injection:**
-- Path traversal via unsanitized `Path.Combine` or `Path.GetFullPath`
-- Command injection via `Process.Start` with unsanitized arguments
-- LDAP injection, XPath injection in query construction
-- Regex denial-of-service (ReDoS) with untrusted patterns — **only if the regex processes external input**
-- Format string vulnerabilities in native code (`sprintf` without bounds)
-
-**Authentication & Authorization:**
-- Bypassing security checks via reflection or `BindingFlags.NonPublic`
-- `AllowPartiallyTrustedCallers` misuse
-- Elevation of privilege through assembly loading or code generation
-- Missing permission demands on security-critical operations
-
-**Networking & Web:**
-- SSRF via user-controlled URLs (only if attacker can control host/protocol)
-- TLS downgrade or missing certificate validation
-- Cookie handling without `Secure`/`HttpOnly` flags
-- HTTP header injection via unsanitized values
-
-**Native Interop:**
-- Buffer size mismatches between managed and native code
-- Missing null checks on pointers returned from native calls
-- Incorrect `MarshalAs` attributes leading to memory corruption
-- Missing `SetLastError = true` on P/Invoke that checks `GetLastError`
-
-### General Categories
-
-**Injection Attacks:**
-- SQL injection via string concatenation in queries
-- Command injection in system calls or subprocesses
-- XXE injection in XML parsing (missing `DtdProcessing.Prohibit`)
-- Template injection in string formatting with untrusted input
-
-**Data Exposure:**
-- Sensitive data (keys, tokens, PII) in log output
-- Debug information leaking in release builds
-- Exception messages exposing internal paths or state
-- Timing side channels leaking secret-dependent information
-
-## Hard Exclusions — Do NOT Report
-
-These categories produce excessive noise in dotnet/runtime and should be automatically excluded:
-
-1. **Denial of Service (DOS)** — Resource exhaustion, algorithmic complexity attacks, memory/CPU exhaustion
-2. **Rate limiting** — Missing rate limits or throttling
-3. **Resource leaks** — Unclosed files, connections, or memory (not a security vulnerability)
-4. **Open redirects** — Low impact in this context
-5. **Regex injection** — Unless the regex is compiled and processes attacker-controlled input
-6. **Test-only code** — Files under `tests/`, `*Tests*` projects, test helpers, and test data
-7. **Documentation** — Findings in `.md`, `.txt`, or comment-only changes
-8. **Log spoofing** — Writing unsanitized input to logs is not a vulnerability here
-9. **Missing audit logs** — Not a vulnerability
-10. **Environment variables and CLI flags** — Treated as trusted input; attacks requiring control of env vars are invalid
-11. **Outdated dependencies** — Managed separately
-12. **Client-side validation** — Client code is not trusted; server-side is responsible for validation
-13. **Insecure defaults in test/sample code** — Only flag in production code paths
-14. **Memory safety in managed C# code** — The CLR provides memory safety guarantees. Only flag memory issues in `unsafe` blocks, native interop, or C/C++ code under `src/coreclr/` or `src/native/`
-
-## Precedents for dotnet/runtime
-
-These judgment calls reduce false positives specific to this codebase:
-
-1. **`Debug.Assert` is not a security boundary.** Asserts are stripped in release builds. Security checks must use exceptions or fail-fast.
-2. **`internal` is not a security boundary.** Internal APIs can be accessed via reflection. Don't assume internal visibility prevents exploitation.
-3. **`Span<T>` bounds checking is automatic.** The runtime checks bounds on span indexing. Manual bounds checks before span access are defense-in-depth, not vulnerabilities when missing.
-4. **`ThrowHelper` methods are security-relevant.** When `ThrowHelper` is bypassed or conditions are wrong, the security check is ineffective.
-5. **Native code under `src/coreclr/` and `src/native/` IS memory-unsafe.** C/C++ code requires manual bounds checking, null checks, and lifetime management. Flag memory safety issues here.
-6. **`System.Text.Json` source generators are trusted.** Generated serialization code from source generators doesn't need the same scrutiny as hand-written custom converters.
-7. **Volatile/Interlocked correctness matters for security.** Race conditions in security checks (e.g., TOCTOU on permission flags) are real vulnerabilities even though they're hard to exploit.
-
-## Output Format
-
-Present findings using this structure:
-
-```
-## 🔒 Security Scan — <scope description>
-
-### Summary
-
-**Findings**: <N high, N medium> | **Confidence threshold**: ≥ 8/10
-**Verdict**: <✅ No issues found / ⚠️ Issues found — human review required>
-
----
-
-### Findings
-
-#### 🔴 HIGH: <Brief title> — `path/to/file.cs:42`
-
-- **Category**: <e.g., command_injection, path_traversal, unsafe_deserialization>
-- **Confidence**: <8-10>/10
-- **Description**: <What the vulnerability is, in plain English>
-- **Exploit scenario**: <Concrete attack path — how an attacker would exploit this>
-- **Recommendation**: <Specific fix, with code suggestion if possible>
-
-#### 🟡 MEDIUM: <Brief title> — `path/to/file.cs:87`
-
-- **Category**: ...
-- **Confidence**: ...
-- **Description**: ...
-- **Exploit scenario**: ...
-- **Recommendation**: ...
-
----
-
-### Files Reviewed
-
-<List of files examined with brief notes on security-relevant observations>
-
-### Methodology Notes
-
-<Brief description of what was checked, tools/agents used, and any limitations>
-```
-
-### Severity Guidelines
-
-- **🔴 HIGH**: Directly exploitable — leads to RCE, data breach, authentication bypass, or arbitrary code execution. Clear attack path exists.
-- **🟡 MEDIUM**: Exploitable under specific conditions with significant impact. Requires particular configuration, timing, or access level.
-- **Do not report LOW severity.** Focus on HIGH and MEDIUM only. Better to miss theoretical issues than flood the report with noise.
-
-### Confidence Scoring
-
-- **9-10**: Certain exploit path identified; verified against full source context
-- **8-9**: Clear vulnerability pattern with known exploitation methods; verified no existing mitigation
-- **Below 8**: Do not report. Too speculative.
-
-## Final Checklist
-
-Before presenting findings:
-
-- [ ] Each finding verified against the **full source file**, not just the diff
-- [ ] Each finding checked for **existing mitigations** in callers/callees
-- [ ] Each finding has a **concrete exploit scenario**, not just a theoretical concern
-- [ ] No findings in **excluded categories** (test code, docs, DOS, etc.)
-- [ ] Confidence ≥ 8 for every reported finding
-- [ ] All code suggestions are **syntactically correct** and would compile
+Record any new anti-patterns discovered during the scan in [references/anti-patterns/README.md](references/anti-patterns/README.md) for reuse in downstream repo scans.

--- a/.github/skills/security-scan/references/anti-patterns/README.md
+++ b/.github/skills/security-scan/references/anti-patterns/README.md
@@ -1,0 +1,189 @@
+# Security Anti-Pattern Catalog
+
+Structured catalog of security anti-patterns for .NET runtime APIs. Each entry is designed to be reusable when scanning downstream repos (ASP.NET Core, SDK, etc.).
+
+## Contents
+
+- [Format specification](#format)
+- [AP-001: Unbounded stream read](#ap-001-unbounded-stream-read-from-untrusted-source)
+- [AP-002: Unbounded allocation from external size](#ap-002-unbounded-allocation-from-external-size)
+- [AP-003: BinaryFormatter usage](#ap-003-binaryformatter-usage)
+- [AP-004: TypeNameHandling without binder](#ap-004-typenamehandling-without-restricted-binder)
+- [AP-005: JsonDocument parse without limits](#ap-005-jsondocument-parse-without-size-limits)
+- [AP-006: XmlReader without DTD prohibition](#ap-006-xmlreader-without-dtd-prohibition)
+- [AP-007: Unsanitized path combination](#ap-007-unsanitized-path-combination)
+- [AP-008: Process start with external arguments](#ap-008-process-start-with-external-arguments)
+- [AP-009: Non-constant-time secret comparison](#ap-009-non-constant-time-secret-comparison)
+- [AP-010: Marshal buffer size mismatch](#ap-010-marshal-buffer-size-mismatch)
+- [AP-011: Public API missing input validation](#ap-011-public-api-missing-input-validation)
+- [AP-012: Inconsistent overload validation](#ap-012-inconsistent-overload-validation)
+- [AP-013: Certificate validation bypass](#ap-013-certificate-validation-bypass)
+- [AP-014: ISerializable trusting SerializationInfo](#ap-014-iserializable-trusting-serializationinfo)
+- [AP-015: Collection growth from untrusted input](#ap-015-collection-growth-from-untrusted-input)
+
+## Format
+
+Each anti-pattern follows this structure:
+
+```
+### AP-NNN: <Title>
+- **Component**: Which library/namespace this applies to
+- **API**: Specific APIs involved
+- **Risk**: What happens when this pattern is present (DOS, RCE, data leak, etc.)
+- **Contract violated**: What assumption is broken
+- **Detection**: How to find this pattern (grep, code inspection)
+- **Fix**: How to remediate
+- **Downstream impact**: How this affects consumer repos (ASP.NET Core, SDK, etc.)
+```
+
+---
+
+### AP-001: Unbounded stream read from untrusted source
+
+- **Component**: System.IO, System.Net.Http
+- **API**: `StreamReader.ReadToEnd()`, `StreamReader.ReadToEndAsync()`, `HttpContent.ReadAsStringAsync()`, `HttpContent.ReadAsByteArrayAsync()`
+- **Risk**: DOS — attacker sends multi-GB response/request body, causing OOM
+- **Contract violated**: Caller assumes the source is bounded; the API imposes no limit
+- **Detection**: `grep -rn "ReadToEnd\|ReadAsStringAsync\|ReadAsByteArrayAsync"` — flag when the stream source is network, file upload, or other external input
+- **Fix**: Use `ReadAsync` with a bounded buffer and byte count limit. For HTTP, set `HttpClient.MaxResponseContentBufferSize`. For request bodies, enforce `Content-Length` limits at the middleware level.
+- **Downstream impact**: ASP.NET Core middleware reading request bodies (`Request.Body`), `HttpClient` consumers, file upload handlers
+
+### AP-002: Unbounded allocation from external size
+
+- **Component**: System.Runtime, System.Buffers
+- **API**: `new byte[size]`, `new char[size]`, `ArrayPool.Rent(size)`, `Marshal.AllocHGlobal(size)`
+- **Risk**: DOS — attacker controls `size` parameter, causes OOM or excessive allocation
+- **Contract violated**: Caller assumes `size` is reasonable; no upper bound enforced
+- **Detection**: `grep -rn "new byte\[.*\]\|new char\[.*\]\|ArrayPool.*Rent\|AllocHGlobal"` — flag when the size value traces to external input (HTTP header, content-length, deserialized field)
+- **Fix**: Validate `size` against a maximum before allocating. Use `ArgumentOutOfRangeException.ThrowIfGreaterThan(size, maxAllowed)`.
+- **Downstream impact**: Any consumer that allocates buffers based on protocol headers or deserialized fields
+
+### AP-003: BinaryFormatter usage
+
+- **Component**: System.Runtime.Serialization
+- **API**: `BinaryFormatter.Deserialize()`, `BinaryFormatter.Serialize()`
+- **Risk**: RCE — arbitrary type instantiation via known gadget chains
+- **Contract violated**: Fundamental — no safe configuration exists
+- **Detection**: `grep -rn "BinaryFormatter\|SoapFormatter"`
+- **Fix**: Replace with `System.Text.Json`, `MessagePack`, or `protobuf-net`. For legacy compat, use a restricted `SerializationBinder` as a stopgap only.
+- **Downstream impact**: Any assembly that deserializes data from untrusted sources using BinaryFormatter
+
+### AP-004: TypeNameHandling without restricted binder
+
+- **Component**: Newtonsoft.Json
+- **API**: `JsonSerializerSettings.TypeNameHandling` set to anything other than `None`
+- **Risk**: RCE — attacker injects `$type` in JSON to instantiate arbitrary types
+- **Contract violated**: Serializer assumes type metadata is trusted
+- **Detection**: `grep -rn "TypeNameHandling"` — flag if value is not `None` or if `SerializationBinder` is absent/unrestricted
+- **Fix**: Set `TypeNameHandling = None`. If polymorphism needed, use `System.Text.Json` with explicit `[JsonDerivedType]` attributes.
+- **Downstream impact**: ASP.NET Core JSON endpoints, SignalR message handling, any API accepting JSON with type metadata
+
+### AP-005: JsonDocument parse without size limits
+
+- **Component**: System.Text.Json
+- **API**: `JsonDocument.Parse(stream)`, `JsonDocument.ParseAsync(stream)`, `JsonSerializer.Deserialize(stream)`
+- **Risk**: DOS — multi-GB JSON payload exhausts memory. Deeply nested JSON (>64 levels default) can also cause stack overflow.
+- **Contract violated**: Caller assumes input is well-formed and reasonably sized
+- **Detection**: `grep -rn "JsonDocument.Parse\|JsonSerializer.Deserialize"` — flag when input stream is from network/file without prior size validation
+- **Fix**: Set `JsonDocumentOptions.MaxDepth` / `JsonSerializerOptions.MaxDepth`. Limit stream size before parsing (e.g., `Content-Length` check or wrapping with a length-limited stream).
+- **Downstream impact**: ASP.NET Core model binding, minimal API endpoints, any HTTP handler parsing JSON request bodies
+
+### AP-006: XmlReader without DTD prohibition
+
+- **Component**: System.Xml
+- **API**: `XmlReader.Create(stream)` without `XmlReaderSettings.DtdProcessing = DtdProcessing.Prohibit`
+- **Risk**: XXE — external entity injection can read local files or trigger SSRF
+- **Contract violated**: Caller assumes XML is data-only; DTD processing enables active content
+- **Detection**: `grep -rn "XmlReader.Create"` — flag if `DtdProcessing` is not set to `Prohibit`
+- **Fix**: Always pass `new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit }`.
+- **Downstream impact**: ASP.NET Core XML formatters, SOAP service consumers, config file parsers
+
+### AP-007: Unsanitized path combination
+
+- **Component**: System.IO
+- **API**: `Path.Combine(basePath, userInput)`, `Path.GetFullPath(userInput)`
+- **Risk**: Path traversal — attacker uses `../` to escape intended directory
+- **Contract violated**: Caller assumes `userInput` is a relative filename; API allows absolute paths and traversal
+- **Detection**: `grep -rn "Path.Combine\|Path.GetFullPath"` — flag when second argument traces to user input
+- **Fix**: After combining, verify the result starts with the expected base directory: `Path.GetFullPath(combined).StartsWith(Path.GetFullPath(basePath))`.
+- **Downstream impact**: File upload handlers, static file middleware, template engines
+
+### AP-008: Process start with external arguments
+
+- **Component**: System.Diagnostics
+- **API**: `Process.Start(filename, arguments)`, `ProcessStartInfo` with user-controlled properties
+- **Risk**: Command injection — attacker injects shell metacharacters in arguments
+- **Contract violated**: Caller assumes arguments are data; shell interpretation treats them as commands
+- **Detection**: `grep -rn "Process.Start\|ProcessStartInfo"` — flag when arguments trace to user input
+- **Fix**: Use argument arrays instead of shell strings. Set `UseShellExecute = false`. Validate/escape all arguments.
+- **Downstream impact**: Build tools, code generators, any tool that invokes external processes
+
+### AP-009: Non-constant-time secret comparison
+
+- **Component**: System.Security.Cryptography
+- **API**: `==` or `SequenceEqual` on secrets, MACs, tokens, or hashes
+- **Risk**: Timing side channel — attacker can determine secret value byte-by-byte
+- **Contract violated**: Caller assumes equality comparison doesn't leak information
+- **Detection**: `grep -rn "SequenceEqual\|== .*token\|== .*hash\|== .*mac\|== .*secret"` — flag when comparing security-sensitive values
+- **Fix**: Use `CryptographicOperations.FixedTimeEquals()`.
+- **Downstream impact**: Authentication middleware, token validation, HMAC verification
+
+### AP-010: Marshal buffer size mismatch
+
+- **Component**: System.Runtime.InteropServices
+- **API**: `Marshal.Copy`, `Marshal.PtrToStructure`, P/Invoke calls with buffer parameters
+- **Risk**: Buffer overflow — managed buffer size doesn't match native expectation, causing memory corruption
+- **Contract violated**: Native function assumes buffer is at least N bytes; managed caller allocates fewer
+- **Detection**: Review all `[DllImport]`/`[LibraryImport]` declarations where a buffer + length are passed. Compare managed allocation size with native function's documented requirements.
+- **Fix**: Always derive buffer size from the same source the native function uses. Add assertions in debug builds.
+- **Downstream impact**: Any consumer calling the managed wrapper for native APIs
+
+### AP-011: Public API missing input validation
+
+- **Component**: Any
+- **API**: Any `public` method accepting potentially untrusted parameters
+- **Risk**: Varies — depends on what the unvalidated input is used for
+- **Contract violated**: Implicit assumption that callers pre-validate
+- **Detection**: Find `public` methods that use `string`, `byte[]`, `Stream`, or `Span<T>` parameters in unsafe operations, native interop, or array indexing without prior validation
+- **Fix**: Add explicit parameter validation (`ArgumentNullException.ThrowIfNull`, bounds checks) at the public API boundary.
+- **Downstream impact**: Every consumer of the API inherits the vulnerability
+
+### AP-012: Inconsistent overload validation
+
+- **Component**: Any
+- **API**: Multiple overloads of the same method with different validation behavior
+- **Risk**: Bypass — attacker uses the unvalidated overload to skip security checks
+- **Contract violated**: Caller expects all overloads to enforce the same preconditions
+- **Detection**: Compare overloads of public methods. If one validates a parameter and another doesn't, flag the inconsistency.
+- **Fix**: Extract validation into a shared helper. Call it from all overloads.
+- **Downstream impact**: Consumers using the "wrong" overload unknowingly bypass validation
+
+### AP-013: Certificate validation bypass
+
+- **Component**: System.Net.Security, System.Net.Http
+- **API**: `ServerCertificateCustomValidationCallback` returning `true`, `ServicePointManager.ServerCertificateValidationCallback`
+- **Risk**: MITM — TLS certificate validation disabled, attacker can intercept traffic
+- **Contract violated**: TLS assumes certificate chain is verified
+- **Detection**: `grep -rn "CertificateValidationCallback\|ServerCertificateCustomValidation"` — flag if the callback returns `true` unconditionally
+- **Fix**: Implement proper certificate validation or remove the callback.
+- **Downstream impact**: Any HTTP client or TLS connection in the application
+
+### AP-014: ISerializable trusting SerializationInfo
+
+- **Component**: System.Runtime.Serialization
+- **API**: `ISerializable` deserialization constructor `(SerializationInfo info, StreamingContext context)`
+- **Risk**: Object injection — attacker controls the values in `SerializationInfo`, enabling construction of objects in unexpected states
+- **Contract violated**: Constructor assumes `SerializationInfo` contains valid, well-typed data
+- **Detection**: Find types implementing `ISerializable`. Check if the deserialization constructor validates types and ranges of values from `info.GetValue()`.
+- **Fix**: Validate every value extracted from `SerializationInfo`. Reject unexpected types or out-of-range values.
+- **Downstream impact**: Any code path that deserializes `ISerializable` types from untrusted data
+
+### AP-015: Collection growth from untrusted input
+
+- **Component**: System.Collections, System.Linq
+- **API**: `List<T>.Add()` in a loop, `Dictionary.Add()`, `HashSet.Add()`, `Concat()`, `Append()` — when count is attacker-controlled
+- **Risk**: DOS — attacker sends payload that causes unbounded collection growth, exhausting memory
+- **Contract violated**: Code assumes input count is reasonable; no maximum enforced
+- **Detection**: Look for loops adding to collections where the iteration count comes from external input (deserialized array length, HTTP header, protocol field)
+- **Fix**: Enforce a maximum count before the loop. Reject input exceeding the limit.
+- **Downstream impact**: Request processing pipelines, batch endpoints, any handler that accumulates items from a request

--- a/.github/skills/security-scan/references/contract-analysis.md
+++ b/.github/skills/security-scan/references/contract-analysis.md
@@ -1,0 +1,131 @@
+# Contract Analysis
+
+How to systematically analyze API contracts and find where they can be abused.
+
+## Contents
+
+- [What is a contract?](#what-is-a-contract)
+- [Analysis workflow](#analysis-workflow)
+- [Violation patterns](#contract-violation-patterns)
+- [Cross-component contracts](#cross-component-contracts)
+
+## What Is a Contract?
+
+The set of assumptions a public API makes about its inputs, the guarantees it provides to callers, and the invariants it must maintain. Security bugs emerge when callers (internal or external) violate these contracts — intentionally or accidentally.
+
+Contracts exist at three levels:
+1. **Explicit** — documented via XML docs, `<exception>` tags, `ArgumentException` throws
+2. **Implicit** — assumed but not enforced (e.g., "this stream is seekable", "this length was already bounds-checked")
+3. **Emergent** — arise from how multiple components interact (A's output becomes B's input)
+
+Implicit and emergent contracts are where most security bugs hide.
+
+## Analysis Workflow
+
+### Step 1: Identify the Public Surface
+
+Find all `public` and `protected` methods on public types in the target library:
+
+```bash
+grep -rn "public\s\+\(static\s\+\)\?\(async\s\+\)\?\S\+\s\+\w\+\s*(" src/libraries/<Lib>/src/ --include="*.cs" | grep -v "/ref/" | grep -v "/tests/"
+```
+
+Focus on methods that accept potentially untrusted input: `string`, `byte[]`, `Stream`, `ReadOnlySpan<byte>`, `ReadOnlyMemory<byte>`, `ReadOnlySequence<byte>`.
+
+### Step 2: Map Trust Boundaries
+
+For each public entry point, determine:
+
+| Question | How to check |
+|---|---|
+| Can an attacker control this parameter? | Trace callers — does input originate from network, file, or user input? |
+| Is the input pre-validated by the caller? | Check if callers consistently validate before calling. If inconsistent → contract gap |
+| Does this cross a process/serialization boundary? | Look for `[DllImport]`, serializer calls, HTTP handlers |
+| What privilege level does this code run at? | Check for `[SecurityCritical]`, `SafeHandle` usage, native resource access |
+
+### Step 3: Document Implicit Contracts
+
+Read the method body and identify assumptions that aren't validated:
+
+- **Size assumptions**: "This buffer is at most 4KB" — but is that enforced?
+- **State assumptions**: "Caller already called Initialize()" — but what if they didn't?
+- **Encoding assumptions**: "This string is valid UTF-8" — but what if it contains malformed sequences?
+- **Concurrency assumptions**: "Only one thread calls this" — but is that enforced?
+- **Ownership assumptions**: "Caller won't modify the array after passing it" — but arrays are mutable
+
+### Step 4: Find Contract Gaps
+
+Look for these patterns:
+
+1. **Missing validation on public APIs**: The method assumes valid input but doesn't check. Internal callers validate, but nothing stops external callers from passing garbage.
+
+2. **Inconsistent overloads**: One overload validates a parameter, another accepts the same logical input without validation.
+   ```csharp
+   // This overload validates:
+   public void Write(string text) { ArgumentNullException.ThrowIfNull(text); ... }
+   // This overload doesn't:
+   public void Write(ReadOnlySpan<char> text) { /* no null/length check, just uses it */ }
+   ```
+
+3. **Validation-then-use gap**: Input is validated, then used later in a different context where the validation no longer applies (e.g., validated as a filename, then used in a SQL query).
+
+4. **Error path leaks**: Exception messages or error responses that expose internal state (file paths, stack traces, connection strings).
+
+### Step 5: Trace Cross-Component Contracts
+
+When component A calls component B's public API:
+- Does A satisfy B's documented preconditions?
+- Does A rely on guarantees B doesn't actually provide?
+- If B changes its behavior (within its documented contract), does A break?
+
+Search for cross-component calls:
+```bash
+# Find where System.Text.Json is called from System.Net.Http
+grep -rn "JsonSerializer\|JsonDocument\|Utf8JsonReader" src/libraries/System.Net.Http/src/
+```
+
+## Contract Violation Patterns
+
+### Assumed-Valid Input
+
+**What**: API skips validation because "callers should have checked."
+
+**Why it's dangerous**: Internal callers may validate consistently, but public API consumers don't know the implicit contract. New internal callers may also forget.
+
+**Detection**: Look for public methods that use parameters directly in `unsafe` blocks, native interop calls, or array indexing without bounds checks.
+
+### Inconsistent Overloads
+
+**What**: Multiple overloads of the same logical operation apply different validation rules.
+
+**Detection**: Compare all overloads of a public method. Do they all validate the same constraints?
+
+### Silent Truncation
+
+**What**: API truncates oversized input instead of rejecting it.
+
+**Why it's dangerous**: Caller may rely on the full input being processed. Truncation can bypass length-based security checks upstream.
+
+**Detection**: Look for `Math.Min(input.Length, maxSize)` patterns without throwing when `input.Length > maxSize`.
+
+### Type Confusion in Generics
+
+**What**: Generic API behaves differently based on runtime type, and caller doesn't expect type-dependent behavior.
+
+**Detection**: Look for `typeof(T)` checks, `is` patterns, or `Unsafe.As<T>` inside generic methods.
+
+### State-Dependent Safety
+
+**What**: API is safe only when called in a specific order, but nothing enforces the ordering.
+
+**Detection**: Look for methods that check `_isInitialized`, `_disposed`, or similar state flags. Are these checks in ALL public entry points?
+
+## Downstream Impact Assessment
+
+For each contract gap found, assess:
+
+1. **Who calls this API?** — Is it used by ASP.NET Core, EF Core, SDK, or other framework components?
+2. **Can an external attacker reach this through a downstream caller?** — Trace the call chain from HTTP endpoint to the vulnerable API
+3. **What would happen if a consumer misuses this?** — Document the concrete failure mode (crash, memory corruption, data leak, etc.)
+
+Record findings in the anti-pattern catalog (see [anti-patterns/README.md](anti-patterns/README.md)) with the `Downstream impact` field.

--- a/.github/skills/security-scan/references/coordination.md
+++ b/.github/skills/security-scan/references/coordination.md
@@ -1,0 +1,286 @@
+# Coordination Patterns for Large-Scale Scans
+
+SQL-based progress tracking and subagent delegation for scanning many libraries or files.
+
+## Contents
+
+- [When to use coordination](#when-to-use-coordination)
+- [Progress tracking with SQL](#progress-tracking)
+- [Partitioning work](#partitioning-work)
+- [Subagent delegation](#subagent-delegation)
+- [Aggregating findings](#aggregating-findings)
+- [Caching results](#caching-results)
+
+## When to Use Coordination
+
+| Scope | Files | Use coordination? |
+|---|---|---|
+| Diff review | < 20 changed files | No — analyze directly |
+| Targeted files | < 10 files | No — analyze directly |
+| Single library audit | 1 library | No — single subagent is fine |
+| Multi-library audit | 2-5 libraries | Yes — partition + track |
+| Directory-wide audit | 5+ libraries or 50+ files | Yes — full coordination |
+
+## Progress Tracking
+
+Create a tracking table at the start of any multi-library scan:
+
+```sql
+CREATE TABLE IF NOT EXISTS scan_targets (
+  library TEXT PRIMARY KEY,
+  file_count INT,
+  status TEXT DEFAULT 'pending',  -- pending, scanning, done, skipped
+  agent_id TEXT,                   -- task agent ID if delegated
+  finding_count INT DEFAULT 0,
+  notes TEXT
+);
+```
+
+Insert one row per library or directory to scan:
+
+```sql
+-- Example: auditing all networking libraries
+INSERT INTO scan_targets (library, file_count) VALUES
+  ('System.Net.Http', 42),
+  ('System.Net.Sockets', 38),
+  ('System.Net.Security', 27);
+```
+
+Track progress as agents complete:
+
+```sql
+-- Before dispatching
+UPDATE scan_targets SET status = 'scanning', agent_id = 'agent-xyz' WHERE library = 'System.Net.Http';
+
+-- After agent returns
+UPDATE scan_targets SET status = 'done', finding_count = 2 WHERE library = 'System.Net.Http';
+
+-- Check what's left
+SELECT library, file_count FROM scan_targets WHERE status = 'pending';
+
+-- Summary
+SELECT status, COUNT(*) as count, SUM(finding_count) as findings
+FROM scan_targets GROUP BY status;
+```
+
+## Partitioning Work
+
+### Pre-filter with triage script
+
+Before partitioning, run the triage script to identify security-relevant files:
+
+```bash
+python .github/skills/security-scan/scripts/scan_security_surface.py src/libraries/System.Net.Http/src --json
+```
+
+Only partition and dispatch `high` and `medium` priority files. `skip` files never enter the pipeline.
+
+### Triage agent (Layer 2 — for 20+ security-relevant files)
+
+When the triage script returns 20+ files at `high`/`medium` priority, launch a fast `explore` (Haiku) agent to refine the list:
+
+```
+Review these security-relevant files and refine their priority.
+The triage script flagged them based on pattern matching — your job is to
+check whether the signals represent real attack surface or false positives.
+
+Files:
+{JSON file list from triage script}
+
+For each file:
+1. Read the first 50 lines (imports, class declaration, key methods)
+2. Determine if the security signals are in production code paths or dead code
+3. Check if the file is a thin wrapper vs. contains real logic
+
+Return JSON:
+{
+  "refinements": [
+    { "path": "...", "newPriority": "high|medium|skip", "reason": "..." }
+  ]
+}
+```
+
+### By library (preferred for directory audits)
+
+Each `src/libraries/<Name>` directory is a natural partition. List libraries in scope, then assign each to a subagent:
+
+```bash
+# List libraries under a directory
+ls -d src/libraries/System.Net.*/src | head -20
+```
+
+### By file type (for mixed-language areas)
+
+When scanning `src/coreclr/` or `src/native/`, partition by language since vulnerability categories differ:
+
+| Partition | File types | Focus |
+|---|---|---|
+| Managed C# | `*.cs` | Serialization, injection, auth |
+| Native C/C++ | `*.cpp`, `*.h`, `*.c` | Memory safety, buffer overflows, null derefs |
+| Interop boundary | `*.cs` with `DllImport`/`LibraryImport` | Marshal mismatches, buffer sizes |
+
+### Batch sizing
+
+- **Max 10-15 source files per subagent** — beyond this, analysis quality degrades
+- **Max 5 parallel subagents** — more causes context thrashing in the main agent
+- For large libraries, split into batches of files within the same subagent dispatch
+
+## Subagent Delegation
+
+### Discovery agent template
+
+Launch one `general-purpose` subagent per library/partition:
+
+```
+Security scan the following library: {LIBRARY_NAME}
+
+Source directory: src/libraries/{LIBRARY_NAME}/src/
+Files to scan:
+{FILE_LIST}
+
+Analyze each file for security vulnerabilities. Focus on these categories:
+- [paste relevant categories from references/runtime-categories.md]
+
+Exclusions: Skip test code, docs, and DOS/resource-exhaustion findings.
+
+For each finding, provide:
+1. File path and line number
+2. Category (e.g., command_injection, path_traversal)
+3. Description of the vulnerability
+4. Concrete exploit scenario
+5. Confidence score (1-10)
+
+Return JSON:
+{
+  "library": "{LIBRARY_NAME}",
+  "filesScanned": N,
+  "findings": [
+    {
+      "file": "path/to/file.cs",
+      "line": 42,
+      "category": "path_traversal",
+      "severity": "HIGH",
+      "description": "...",
+      "exploit": "...",
+      "confidence": 9
+    }
+  ]
+}
+```
+
+### Verification agent template
+
+For each finding with confidence ≥ 7, launch a parallel `explore` agent:
+
+```
+Verify this security finding:
+
+File: {FILE_PATH}:{LINE}
+Category: {CATEGORY}
+Claimed vulnerability: {DESCRIPTION}
+
+Steps:
+1. Read the full source file
+2. Check callers of the vulnerable function — are inputs validated upstream?
+3. Check callees — does the called function do its own validation?
+4. Search for similar patterns in the codebase (grep for the function name)
+5. Check if this matches a known-safe pattern in dotnet/runtime
+
+Return JSON:
+{
+  "verified": true/false,
+  "confidence": N,
+  "justification": "...",
+  "mitigations_found": ["caller validates in X.cs:100", ...]
+}
+```
+
+### Storing subagent results
+
+When running 5+ subagents, store findings in SQL instead of holding in context:
+
+```sql
+CREATE TABLE IF NOT EXISTS scan_findings (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  library TEXT,
+  file_path TEXT,
+  line_number INT,
+  category TEXT,
+  severity TEXT,       -- HIGH, MEDIUM
+  description TEXT,
+  exploit_scenario TEXT,
+  confidence INT,      -- 1-10 from discovery agent
+  verified BOOLEAN,    -- NULL until verified
+  verified_confidence INT,  -- from verification agent
+  status TEXT DEFAULT 'pending'  -- pending, verified, dismissed
+);
+```
+
+```sql
+-- After verification, find reportable findings
+SELECT library, file_path, line_number, category, severity, description, exploit_scenario
+FROM scan_findings
+WHERE verified = TRUE AND verified_confidence >= 8
+ORDER BY severity DESC, verified_confidence DESC;
+
+-- Summary by library
+SELECT library, COUNT(*) as findings,
+       SUM(CASE WHEN severity = 'HIGH' THEN 1 ELSE 0 END) as high,
+       SUM(CASE WHEN severity = 'MEDIUM' THEN 1 ELSE 0 END) as medium
+FROM scan_findings WHERE verified = TRUE AND verified_confidence >= 8
+GROUP BY library;
+```
+
+## Aggregating Findings
+
+After all subagents complete and findings are verified:
+
+1. Query `scan_findings` for all verified findings with confidence ≥ 8
+2. Group by library for the "Files Reviewed" section
+3. Deduplicate — same pattern in multiple files should be one finding with multiple locations
+4. Format using the template in [output-format.md](output-format.md)
+
+```sql
+-- Detect duplicates (same category + similar description in same library)
+SELECT category, COUNT(*) as occurrences, GROUP_CONCAT(file_path) as files
+FROM scan_findings
+WHERE verified = TRUE AND verified_confidence >= 8
+GROUP BY library, category
+HAVING occurrences > 1;
+```
+
+## Caching Results
+
+For iterative scans (e.g., re-running after fixes), avoid re-scanning unchanged files:
+
+```sql
+CREATE TABLE IF NOT EXISTS scan_cache (
+  file_path TEXT PRIMARY KEY,
+  file_hash TEXT,          -- git hash of the file at scan time
+  scanned_at TEXT,
+  finding_count INT,
+  findings_json TEXT       -- serialized findings for this file
+);
+```
+
+```bash
+# Get current file hash for cache comparison
+git hash-object src/libraries/System.Net.Http/src/HttpClient.cs
+```
+
+```sql
+-- Check if a file needs re-scanning
+SELECT file_path FROM scan_cache
+WHERE file_path = 'src/libraries/System.Net.Http/src/HttpClient.cs'
+  AND file_hash = 'abc1234';
+-- If row exists, skip this file. If not, scan and insert/update.
+```
+
+When to cache vs. not:
+
+| Scenario | Cache? |
+|---|---|
+| One-off diff review | No |
+| Iterative directory audit (fix → re-scan cycle) | Yes |
+| Periodic full-repo audit | Yes |
+| Scanning after a rebase | Invalidate all — hashes changed |

--- a/.github/skills/security-scan/references/output-format.md
+++ b/.github/skills/security-scan/references/output-format.md
@@ -1,0 +1,65 @@
+# Output Format
+
+## Report Template
+
+```
+## 🔒 Security Scan — <scope description>
+
+### Summary
+
+**Findings**: <N high, N medium> | **Confidence threshold**: ≥ 8/10
+**Verdict**: <✅ No issues found / ⚠️ Issues found — human review required>
+
+---
+
+### Findings
+
+#### 🔴 HIGH: <Brief title> — `path/to/file.cs:42`
+
+- **Category**: <e.g., command_injection, path_traversal, unsafe_deserialization>
+- **Confidence**: <8-10>/10
+- **Description**: <What the vulnerability is, in plain English>
+- **Exploit scenario**: <Concrete attack path — how an attacker would exploit this>
+- **Recommendation**: <Specific fix, with code suggestion if possible>
+
+#### 🟡 MEDIUM: <Brief title> — `path/to/file.cs:87`
+
+- **Category**: ...
+- **Confidence**: ...
+- **Description**: ...
+- **Exploit scenario**: ...
+- **Recommendation**: ...
+
+---
+
+### Files Reviewed
+
+<List of files examined with brief notes on security-relevant observations>
+
+### Methodology Notes
+
+<Brief description of what was checked, tools/agents used, and any limitations>
+```
+
+## Severity Guidelines
+
+- **🔴 HIGH**: Directly exploitable — leads to RCE, data breach, auth bypass, or arbitrary code execution. Clear attack path exists.
+- **🟡 MEDIUM**: Exploitable under specific conditions with significant impact. Requires particular configuration, timing, or access level.
+- **Do not report LOW severity.** Better to miss theoretical issues than flood the report with noise.
+
+## Confidence Scoring
+
+- **9-10**: Certain exploit path identified; verified against full source context
+- **8-9**: Clear vulnerability pattern with known exploitation methods; verified no existing mitigation
+- **Below 8**: Do not report. Too speculative.
+
+## Final Checklist
+
+Before presenting findings:
+
+- [ ] Each finding verified against the **full source file**, not just the diff
+- [ ] Each finding checked for **existing mitigations** in callers/callees
+- [ ] Each finding has a **concrete exploit scenario**, not just a theoretical concern
+- [ ] No findings in **excluded categories** (test code, docs, DOS, etc.)
+- [ ] Confidence ≥ 8 for every reported finding
+- [ ] All code suggestions are **syntactically correct** and would compile

--- a/.github/skills/security-scan/references/precedents-and-exclusions.md
+++ b/.github/skills/security-scan/references/precedents-and-exclusions.md
@@ -1,0 +1,37 @@
+# Precedents and Exclusions for dotnet/runtime
+
+## Contents
+
+- [Hard exclusions](#hard-exclusions--do-not-report)
+- [Codebase-specific precedents](#precedents)
+
+## Hard Exclusions — Do NOT Report
+
+These categories produce excessive noise in dotnet/runtime and must be automatically excluded:
+
+1. **~~Denial of Service (DOS)~~** — Now **in scope** for public API surface reachable by external callers. See [runtime-categories.md](runtime-categories.md#dos--resource-exhaustion). Still excluded for internal-only APIs and test code.
+2. **Rate limiting** — Missing rate limits or throttling
+3. **Resource leaks** — Unclosed files, connections, or memory
+4. **Open redirects** — Low impact in this context
+5. **Regex injection** — Unless compiled and processing attacker-controlled input
+6. **Test-only code** — Files under `tests/`, `*Tests*` projects, test helpers, test data
+7. **Documentation** — Findings in `.md`, `.txt`, or comment-only changes
+8. **Log spoofing** — Writing unsanitized input to logs
+9. **Missing audit logs**
+10. **Environment variables and CLI flags** — Treated as trusted input
+11. **Outdated dependencies** — Managed separately
+12. **Client-side validation** — Server-side is responsible
+13. **Insecure defaults in test/sample code** — Only flag in production code paths
+14. **Memory safety in managed C# code** — Only flag in `unsafe` blocks, native interop, or C/C++ under `src/coreclr/` / `src/native/`
+
+## Precedents
+
+These judgment calls reduce false positives specific to this codebase:
+
+1. **`Debug.Assert` is not a security boundary.** Asserts are stripped in release builds. Security checks must use exceptions or fail-fast.
+2. **`internal` is not a security boundary.** Internal APIs can be accessed via reflection.
+3. **`Span<T>` bounds checking is automatic.** The runtime checks bounds on span indexing. Missing manual bounds checks are not vulnerabilities.
+4. **`ThrowHelper` methods are security-relevant.** When `ThrowHelper` is bypassed or conditions are wrong, the security check is ineffective.
+5. **Native code under `src/coreclr/` and `src/native/` IS memory-unsafe.** C/C++ code requires manual bounds checking, null checks, and lifetime management.
+6. **`System.Text.Json` source generators are trusted.** Generated serialization code doesn't need the same scrutiny as hand-written custom converters.
+7. **Volatile/Interlocked correctness matters for security.** Race conditions in security checks (e.g., TOCTOU on permission flags) are real vulnerabilities.

--- a/.github/skills/security-scan/references/runtime-categories.md
+++ b/.github/skills/security-scan/references/runtime-categories.md
@@ -1,0 +1,114 @@
+# Security Categories for dotnet/runtime
+
+## Contents
+
+- [Unsafe code and memory safety](#unsafe-code--memory-safety)
+- [Serialization](#serialization--deserialization)
+- [Cryptography](#cryptography)
+- [Input validation and injection](#input-validation--injection)
+- [Authentication and authorization](#authentication--authorization)
+- [Networking](#networking--web)
+- [Native interop](#native-interop)
+- [General categories](#general-categories)
+- [DOS and resource exhaustion](#dos--resource-exhaustion)
+- [API contract abuse](#api-contract-abuse)
+
+## dotnet/runtime-Specific Concerns
+
+### Unsafe Code & Memory Safety
+
+- `unsafe` blocks with pointer arithmetic, `Span<T>`/`Memory<T>` misuse
+- Buffer overflows in native interop (`DllImport`, `LibraryImport`, `Marshal.*`)
+- Use-after-free in `SafeHandle`/`CriticalHandle` implementations
+- Stack buffer overflows via `stackalloc` without bounds checking
+- `Unsafe.As<T>` type punning that violates type safety
+
+### Serialization & Deserialization
+
+- `BinaryFormatter`, `SoapFormatter`, or other insecure deserializers
+- `TypeNameHandling` in JSON serialization allowing type injection
+- Custom `TypeConverter` or `SerializationBinder` that don't restrict types
+- XML deserialization without restricting allowed types (XXE, type injection)
+- `System.Text.Json` custom converters that trust input type discriminators
+
+### Cryptography
+
+- Obsolete algorithms (MD5, SHA1 for security, DES, RC2, 3DES)
+- Hardcoded keys, IVs, or salts
+- Missing or incorrect padding modes
+- Non-constant-time comparisons of secrets/MACs (use `CryptographicOperations.FixedTimeEquals`)
+- `Random` instead of `RandomNumberGenerator` for security purposes
+- Certificate validation bypass (`ServerCertificateCustomValidationCallback` returning `true`)
+
+### Input Validation & Injection
+
+- Path traversal via unsanitized `Path.Combine` or `Path.GetFullPath`
+- Command injection via `Process.Start` with unsanitized arguments
+- LDAP injection, XPath injection in query construction
+- ReDoS with untrusted patterns — **only if the regex processes external input**
+- Format string vulnerabilities in native code (`sprintf` without bounds)
+
+### Authentication & Authorization
+
+- Bypassing security checks via reflection or `BindingFlags.NonPublic`
+- `AllowPartiallyTrustedCallers` misuse
+- Elevation of privilege through assembly loading or code generation
+- Missing permission demands on security-critical operations
+
+### Networking & Web
+
+- SSRF via user-controlled URLs (only if attacker can control host/protocol)
+- TLS downgrade or missing certificate validation
+- Cookie handling without `Secure`/`HttpOnly` flags
+- HTTP header injection via unsanitized values
+
+### Native Interop
+
+- Buffer size mismatches between managed and native code
+- Missing null checks on pointers returned from native calls
+- Incorrect `MarshalAs` attributes leading to memory corruption
+- Missing `SetLastError = true` on P/Invoke that checks `GetLastError`
+
+## General Categories
+
+### Injection Attacks
+
+- SQL injection via string concatenation in queries
+- Command injection in system calls or subprocesses
+- XXE injection in XML parsing (missing `DtdProcessing.Prohibit`)
+- Template injection in string formatting with untrusted input
+
+### Data Exposure
+
+- Sensitive data (keys, tokens, PII) in log output
+- Debug information leaking in release builds
+- Exception messages exposing internal paths or state
+- Timing side channels leaking secret-dependent information
+
+## DOS & Resource Exhaustion
+
+Applicable when scanning public API surface reachable by external callers:
+
+- Unbounded stream reads (`ReadToEnd`, `CopyTo`) on untrusted input
+- Allocations sized by external input (`new byte[userSize]`) without upper bounds
+- `JsonDocument.Parse` / `JsonSerializer.Deserialize` on unbounded streams
+- `StringBuilder` / `MemoryStream` created without capacity on untrusted input
+- Collection growth in loops where iteration count is attacker-controlled
+- XML parsing without `MaxCharactersInDocument` / `MaxCharactersFromEntities`
+- Regular expression evaluation on attacker-controlled input without timeout
+- Recursive data structures causing stack overflow (deeply nested JSON/XML)
+
+For detailed anti-patterns, see [anti-patterns/README.md](anti-patterns/README.md) (AP-001, AP-002, AP-005, AP-015).
+
+## API Contract Abuse
+
+Vulnerabilities arising from misunderstood or violated API contracts:
+
+- Public APIs that assume pre-validated input but don't enforce it
+- Inconsistent validation across overloads of the same method
+- Silent truncation of oversized input (bypasses upstream length checks)
+- State-dependent APIs callable in wrong order (missing initialization checks)
+- Cross-component contract mismatches (A's output violates B's preconditions)
+- Implicit encoding/format assumptions not enforced at the boundary
+
+For the full contract analysis methodology, see [contract-analysis.md](contract-analysis.md).

--- a/.github/skills/security-scan/references/serializer-audit.md
+++ b/.github/skills/security-scan/references/serializer-audit.md
@@ -1,0 +1,142 @@
+# Serializer Audit Guide
+
+Deep audit guide for every serializer in the .NET ecosystem. Read this when the triage script flags `serialization` signals.
+
+## Contents
+
+- [Audit checklist (all serializers)](#universal-audit-checklist)
+- [Per-serializer guides](#per-serializer-guides)
+- [Anti-patterns to flag](#anti-patterns-to-flag)
+
+## Risk Summary
+
+| Serializer | Risk | Primary concern |
+|---|---|---|
+| `BinaryFormatter` | 🔴 Critical | Arbitrary type instantiation, known gadget chains |
+| `SoapFormatter` | 🔴 Critical | Same as BinaryFormatter |
+| `Newtonsoft.Json` | 🔴 High | `TypeNameHandling` enables type injection |
+| Custom `ISerializable` | 🔴 High | Arbitrary constructor calls, no type restrictions |
+| `System.Text.Json` | 🟡 Medium-High | Custom converters, polymorphic handling, `JsonDocument` DOS |
+| `XmlSerializer` | 🟡 Medium | XXE by default, `[XmlInclude]` type expansion |
+| `DataContractSerializer` | 🟡 Medium | `[KnownType]` expansion, reference preservation |
+| `MessagePack` / `protobuf` | 🟢 Low-Medium | Schema mismatches, version confusion |
+
+## Universal Audit Checklist
+
+For **every** serializer instance found, answer these questions:
+
+1. **Where is it instantiated?** What configuration options are set?
+2. **Is type discrimination enabled?** (`TypeNameHandling`, `$type`, polymorphic type metadata, `[JsonDerivedType]`)
+   - If yes: is the allowed type list restricted?
+3. **Are there size/depth limits?**
+   - `JsonSerializerOptions.MaxDepth` (default: 64)
+   - `XmlReaderSettings.MaxCharactersInDocument` / `MaxCharactersFromEntities`
+   - Custom limits on `Stream.Read` before deserialization
+4. **Is the input source trusted or untrusted?**
+   - Network input, file from user, database field → untrusted
+   - Compile-time constant, resource embedded in assembly → trusted
+5. **Can an attacker control the type being deserialized?**
+   - Via `$type` property, XML element name, `__type` hint, etc.
+6. **Are custom converters/resolvers present?**
+   - Do they validate input before constructing objects?
+   - Can they be tricked into instantiating unexpected types?
+7. **What happens with malformed input?**
+   - Does it throw, return default, or silently produce corrupt data?
+   - Are exceptions caught and swallowed somewhere upstream?
+
+## Per-Serializer Guides
+
+### BinaryFormatter / SoapFormatter
+
+**Status**: Obsolete and banned. Any usage is a finding.
+
+**What to look for**:
+- Direct instantiation (`new BinaryFormatter()`)
+- Indirect use via `[Serializable]` types that implement `ISerializable`
+- Legacy compat shims that wrap BinaryFormatter
+- `BinaryFormatter.Deserialize(stream)` — this is arbitrary code execution
+
+**Action**: Flag any usage. There are no safe configurations.
+
+### System.Text.Json
+
+**Key areas**:
+
+1. **Custom `JsonConverter<T>`**: Does the `Read` method validate the JSON structure before constructing the object? Can malformed JSON cause it to enter an unexpected state?
+
+2. **Polymorphic serialization** (`[JsonDerivedType]`, `JsonTypeInfo`): Are the allowed types explicitly listed? Can an attacker inject a type discriminator that resolves to an unexpected type?
+
+3. **`JsonDocument` / `JsonElement`**: These hold the entire document in memory. Parsing an untrusted multi-GB stream → OOM. Check:
+   - Is there a `MaxDepth` set?
+   - Is the source stream bounded?
+   - Is `JsonDocument.Parse` called on untrusted input without size limits?
+
+4. **`Utf8JsonReader`**: Lower-level, generally safer, but check for:
+   - `reader.GetString()` on untrusted input without length limits
+   - Missing validation of `reader.TokenType` before accessing values
+
+5. **Source generators** (`JsonSerializerContext`): Generally trusted — generated code is deterministic. Lower audit priority.
+
+### XmlSerializer
+
+**Key areas**:
+
+1. **XXE (XML External Entities)**: `XmlSerializer` itself doesn't process DTDs, but the underlying `XmlReader` might if created without `DtdProcessing.Prohibit`.
+   ```csharp
+   // UNSAFE — default XmlReader processes DTDs
+   var reader = XmlReader.Create(stream);
+   // SAFE
+   var reader = XmlReader.Create(stream, new XmlReaderSettings { DtdProcessing = DtdProcessing.Prohibit });
+   ```
+
+2. **`[XmlInclude]` type expansion**: Can an attacker trigger deserialization of an included type they shouldn't have access to?
+
+3. **`XmlReaderSettings` limits**: Are `MaxCharactersInDocument` and `MaxCharactersFromEntities` set for untrusted input?
+
+### DataContractSerializer
+
+**Key areas**:
+
+1. **`[KnownType]` lists**: Are they minimal? Each known type expands the attack surface.
+
+2. **Reference preservation** (`PreserveObjectReferences`): Can an attacker create circular references that cause stack overflow?
+
+3. **`DataContractResolver`**: Custom resolvers that map type names to types — are the mappings restricted?
+
+### Newtonsoft.Json (Json.NET)
+
+**Key areas**:
+
+1. **`TypeNameHandling`**: ANY value other than `None` is dangerous without a custom `SerializationBinder`:
+   - `TypeNameHandling.All` — attacker controls all deserialized types
+   - `TypeNameHandling.Auto` — attacker can inject `$type` on any polymorphic property
+   - `TypeNameHandling.Objects` / `Arrays` — partial control, still exploitable
+
+2. **`SerializationBinder`**: If present, does it whitelist types or just log? A binder that returns `null` for unknown types still allows `null` injection.
+
+3. **`JsonConverter` implementations**: Same concerns as STJ custom converters.
+
+### ISerializable
+
+**Key areas**:
+
+1. **Constructor**: `ISerializable` types must have a `(SerializationInfo, StreamingContext)` constructor. This constructor is called during deserialization and receives attacker-controlled data via `SerializationInfo`.
+
+2. **`GetObjectData`**: Can expose internal state to serialized output if not carefully implemented.
+
+3. **Trust of `SerializationInfo` values**: Does the constructor validate types and ranges of values from `info.GetValue()`? Trusting these values = trusting attacker input.
+
+## Anti-Patterns to Flag
+
+These are always reportable findings regardless of context:
+
+| Pattern | Severity | Description |
+|---|---|---|
+| Any `BinaryFormatter` / `SoapFormatter` usage | 🔴 HIGH | Known arbitrary code execution |
+| `TypeNameHandling != None` without restricted `SerializationBinder` | 🔴 HIGH | Type injection |
+| `JsonSerializer.Deserialize<object>()` on untrusted input | 🔴 HIGH | No type restriction |
+| `XmlReader.Create(stream)` without `DtdProcessing.Prohibit` | 🟡 MEDIUM | XXE if DTD present |
+| `JsonDocument.Parse(stream)` without size limit on untrusted input | 🟡 MEDIUM | DOS via memory exhaustion |
+| `ISerializable` constructor trusting `SerializationInfo` values | 🟡 MEDIUM | Attacker-controlled construction |
+| Custom `JsonConverter.Read` without `TokenType` validation | 🟡 MEDIUM | Unexpected JSON structure |
+| `DataContractSerializer` with 10+ `[KnownType]` entries | 🟡 MEDIUM | Excessive type surface |

--- a/.github/skills/security-scan/scripts/scan_security_surface.py
+++ b/.github/skills/security-scan/scripts/scan_security_surface.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""
+Security surface triage scanner for dotnet/runtime.
+
+Scans source files for security-sensitive patterns and outputs a prioritized
+JSON file list. Designed to run fast (<5s) with no dependencies beyond stdlib.
+
+Usage:
+    python scan_security_surface.py <path> [--json] [--min-priority medium]
+    python scan_security_surface.py src/libraries/System.Net.Http/src --json
+    python scan_security_surface.py --diff  # scan git diff files only
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Pattern definitions — each maps to a security signal category
+# ---------------------------------------------------------------------------
+
+PATTERNS: dict[str, list[re.Pattern]] = {
+    # Memory safety / unsafe code
+    "unsafe_code": [
+        re.compile(r"\bunsafe\b"),
+        re.compile(r"\bstackalloc\b"),
+        re.compile(r"\bUnsafe\.As\b"),
+        re.compile(r"\bMemoryMarshal\b"),
+        re.compile(r"\bfixed\s*\("),
+    ],
+    # Native interop
+    "native_interop": [
+        re.compile(r"\bDllImport\b"),
+        re.compile(r"\bLibraryImport\b"),
+        re.compile(r"\bMarshal\.\w+"),
+        re.compile(r"\bSafeHandle\b"),
+        re.compile(r"\bCriticalHandle\b"),
+        re.compile(r"\bNativeMemory\b"),
+    ],
+    # Serialization surface (ALL serializers)
+    "serialization": [
+        re.compile(r"\bBinaryFormatter\b"),
+        re.compile(r"\bSoapFormatter\b"),
+        re.compile(r"\bJsonSerializer\b"),
+        re.compile(r"\bJsonConverter\b"),
+        re.compile(r"\bJsonDocument\b"),
+        re.compile(r"\bUtf8JsonReader\b"),
+        re.compile(r"\bUtf8JsonWriter\b"),
+        re.compile(r"\bXmlSerializer\b"),
+        re.compile(r"\bXmlReader\b"),
+        re.compile(r"\bDataContractSerializer\b"),
+        re.compile(r"\bTypeNameHandling\b"),
+        re.compile(r"\bISerializable\b"),
+        re.compile(r"\bTypeConverter\b"),
+        re.compile(r"\bSerializationBinder\b"),
+        re.compile(r"\b\[KnownType\b"),
+    ],
+    # DOS / resource exhaustion
+    "dos_surface": [
+        re.compile(r"\bReadToEnd\b"),
+        re.compile(r"\bReadToEndAsync\b"),
+        re.compile(r"\bCopyTo\b(?!Array)"),
+        re.compile(r"\bCopyToAsync\b"),
+        re.compile(r"\bToArray\s*\("),
+        re.compile(r"\bnew\s+byte\s*\["),
+        re.compile(r"\bnew\s+char\s*\["),
+        re.compile(r"\bStringBuilder\s*\(\s*\)"),  # no capacity
+        re.compile(r"\bMemoryStream\s*\(\s*\)"),   # no capacity
+    ],
+    # Cryptography
+    "crypto": [
+        re.compile(r"\bMD5\b"),
+        re.compile(r"\bSHA1\b(?!Managed)"),
+        re.compile(r"\bDES\b"),
+        re.compile(r"\b(TripleDES|3DES)\b"),
+        re.compile(r"\bRC[24]\b"),
+        re.compile(r"\bAes\b"),
+        re.compile(r"\bRSA\b"),
+        re.compile(r"\bRandomNumberGenerator\b"),
+        re.compile(r"\bFixedTimeEquals\b"),
+        re.compile(r"\bCertificateValidationCallback\b"),
+        re.compile(r"\bX509Certificate\b"),
+    ],
+    # Input validation / injection
+    "injection": [
+        re.compile(r"\bProcess\.Start\b"),
+        re.compile(r"\bProcessStartInfo\b"),
+        re.compile(r"\bPath\.Combine\b"),
+        re.compile(r"\bPath\.GetFullPath\b"),
+        re.compile(r"\bDtdProcessing\b"),
+    ],
+    # Authentication / authorization
+    "auth": [
+        re.compile(r"\bBindingFlags\.NonPublic\b"),
+        re.compile(r"\bAllowPartiallyTrustedCallers\b"),
+        re.compile(r"\bSecurityCritical\b"),
+        re.compile(r"\bSecurityTransparent\b"),
+        re.compile(r"//\s*SECURITY\b"),
+    ],
+    # Network input surface
+    "network": [
+        re.compile(r"\bHttpClient\b"),
+        re.compile(r"\bSocket\b"),
+        re.compile(r"\bTcpListener\b"),
+        re.compile(r"\bSslStream\b"),
+        re.compile(r"\bHttpListener\b"),
+        re.compile(r"\bWebSocket\b"),
+    ],
+    # Public API entry points (potential untrusted input)
+    "public_api": [
+        re.compile(
+            r"public\s+(?:static\s+)?(?:async\s+)?\S+\s+\w+\s*\("
+            r"[^)]*(?:string|byte\[\]|Stream|ReadOnlySpan|ReadOnlyMemory|"
+            r"ReadOnlySequence|Memory<|Span<)[^)]*\)"
+        ),
+    ],
+    # Contract signals (documented preconditions)
+    "contract_signal": [
+        re.compile(r"///\s*<exception\s"),
+        re.compile(r"\bArgumentException\b"),
+        re.compile(r"\bArgumentNullException\b"),
+        re.compile(r"\bArgumentOutOfRangeException\b"),
+        re.compile(r"\bObjectDisposedException\b"),
+        re.compile(r"\bInvalidOperationException\b"),
+    ],
+}
+
+# Files that are always high priority regardless of patterns
+ALWAYS_HIGH_EXTENSIONS = {".c", ".cpp", ".h", ".cc", ".cxx"}
+
+# Files to skip entirely
+SKIP_PATTERNS = [
+    re.compile(r"[\\/]tests?[\\/]", re.IGNORECASE),
+    re.compile(r"[\\/]ref[\\/]"),
+    re.compile(r"\.Designer\.cs$"),
+    re.compile(r"\.g\.cs$"),
+    re.compile(r"\.generated\.cs$"),
+    re.compile(r"[\\/]obj[\\/]"),
+    re.compile(r"[\\/]bin[\\/]"),
+]
+
+SCANNABLE_EXTENSIONS = {
+    ".cs", ".c", ".cpp", ".h", ".cc", ".cxx", ".fs", ".vb",
+}
+
+
+def should_skip(path: str) -> bool:
+    return any(p.search(path) for p in SKIP_PATTERNS)
+
+
+def scan_file(filepath: str) -> dict:
+    """Scan a single file and return its security signals."""
+    signals: dict[str, int] = defaultdict(int)
+    try:
+        with open(filepath, "r", encoding="utf-8", errors="replace") as f:
+            content = f.read()
+    except (OSError, UnicodeDecodeError):
+        return {"signals": {}, "total": 0}
+
+    for category, patterns in PATTERNS.items():
+        for pattern in patterns:
+            matches = pattern.findall(content)
+            if matches:
+                signals[category] += len(matches)
+
+    total = sum(signals.values())
+    return {"signals": dict(signals), "total": total}
+
+
+def prioritize(filepath: str, scan_result: dict) -> str:
+    """Assign priority: high, medium, low, or skip."""
+    ext = Path(filepath).suffix.lower()
+
+    # Native code is always high
+    if ext in ALWAYS_HIGH_EXTENSIONS:
+        return "high"
+
+    total = scan_result["total"]
+    signals = scan_result["signals"]
+
+    # Critical signal categories always bump to high
+    critical = {"unsafe_code", "serialization", "native_interop", "crypto", "injection"}
+    has_critical = any(signals.get(c, 0) > 0 for c in critical)
+
+    if has_critical and total >= 3:
+        return "high"
+    if has_critical or total >= 5:
+        return "medium"
+    if total >= 2:
+        return "low"
+    if total >= 1:
+        return "low"
+    return "skip"
+
+
+def collect_files(path: str) -> list[str]:
+    """Recursively collect scannable source files."""
+    result = []
+    for root, _dirs, files in os.walk(path):
+        for f in files:
+            full = os.path.join(root, f)
+            ext = Path(full).suffix.lower()
+            if ext in SCANNABLE_EXTENSIONS and not should_skip(full):
+                result.append(full)
+    return sorted(result)
+
+
+def collect_diff_files() -> list[str]:
+    """Collect files changed vs origin/HEAD."""
+    try:
+        output = subprocess.check_output(
+            ["git", "diff", "--name-only", "--merge-base", "origin/HEAD"],
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        print("Error: git diff failed. Are you in a git repo?", file=sys.stderr)
+        sys.exit(1)
+
+    files = []
+    for line in output.strip().splitlines():
+        line = line.strip()
+        if line and Path(line).suffix.lower() in SCANNABLE_EXTENSIONS and not should_skip(line):
+            files.append(line)
+    return sorted(files)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scan source files for security-sensitive patterns."
+    )
+    parser.add_argument(
+        "path", nargs="?", default=".",
+        help="Directory or file to scan (default: current directory)",
+    )
+    parser.add_argument(
+        "--diff", action="store_true",
+        help="Scan only files changed vs origin/HEAD",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Output JSON instead of human-readable table",
+    )
+    parser.add_argument(
+        "--min-priority", choices=["high", "medium", "low", "skip"],
+        default="low",
+        help="Minimum priority to include in output (default: low)",
+    )
+    args = parser.parse_args()
+
+    priority_order = ["high", "medium", "low", "skip"]
+    min_idx = priority_order.index(args.min_priority)
+
+    if args.diff:
+        files = collect_diff_files()
+    elif os.path.isfile(args.path):
+        files = [args.path]
+    else:
+        files = collect_files(args.path)
+
+    results = []
+    for filepath in files:
+        scan = scan_file(filepath)
+        priority = prioritize(filepath, scan)
+        if priority_order.index(priority) <= min_idx:
+            results.append({
+                "path": filepath,
+                "priority": priority,
+                "signals": sorted(scan["signals"].keys()),
+                "signalCount": scan["total"],
+                "signalDetails": scan["signals"],
+            })
+
+    # Sort: high first, then medium, then by signal count descending
+    results.sort(key=lambda r: (priority_order.index(r["priority"]), -r["signalCount"]))
+
+    summary = {
+        "totalFiles": len(files),
+        "securityRelevant": sum(1 for r in results if r["priority"] != "skip"),
+        "high": sum(1 for r in results if r["priority"] == "high"),
+        "medium": sum(1 for r in results if r["priority"] == "medium"),
+        "low": sum(1 for r in results if r["priority"] == "low"),
+    }
+
+    if args.json:
+        output = {"summary": summary, "files": results}
+        print(json.dumps(output, indent=2))
+    else:
+        print(f"Scanned {summary['totalFiles']} files: "
+              f"{summary['high']} high, {summary['medium']} medium, "
+              f"{summary['low']} low, "
+              f"{summary['totalFiles'] - summary['securityRelevant']} skipped")
+        print()
+        for r in results:
+            signals_str = ", ".join(r["signals"])
+            print(f"  [{r['priority'].upper():6s}] {r['path']}")
+            print(f"           signals: {signals_str} ({r['signalCount']} hits)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
…nalysis

Adds a reusable skill that performs deep security audits of code changes, modeled after the Claude Code Security approach: 3-phase analysis (context research → comparative analysis → vulnerability assessment), multi-agent verification for false positive reduction, and dotnet/runtime-specific security categories (unsafe code, native interop, serialization, cryptography).