### PR TITLE
Fix assert in JIT:new() during early initialization

### DIFF
--- a/src/coreclr/jit/alloc.cpp
+++ b/src/coreclr/jit/alloc.cpp
@@ -330,9 +330,12 @@ void ArenaAllocator::dumpMaxMemStats(FILE* file)
 
 #ifdef JIT_STANDALONE_BUILD
 
+// Note that code in libstdc++ (for example) may call the global new
+// during thread initialization etc. so don't assert during init.
+
 void* __cdecl operator new(std::size_t size)
 {
-    assert(!"Global new called; use HostAllocator if long-lived allocation was intended");
+    assert((g_jitHost == nullptr) || !"Global new called; use HostAllocator if long-lived allocation was intended");
 
     if (size == 0)
     {
@@ -350,7 +353,7 @@ void* __cdecl operator new(std::size_t size)
 
 void* __cdecl operator new[](std::size_t size)
 {
-    assert(!"Global new called; use HostAllocator if long-lived allocation was intended");
+    assert((g_jitHost == nullptr) || !"Global new called; use HostAllocator if long-lived allocation was intended");
 
     if (size == 0)
     {


### PR DESCRIPTION
The JIT's standalone build overrides the throwing operator new but not the nothrow variants. When libstdc++'s nothrow implementation calls the throwing version internally, it gets the JIT's assert-enabled override instead of the standard library's throwing version.

Solution needed: Add nothrow operator new/delete overrides to src/coreclr/jit/alloc.cpp to prevent libstdc++ from calling through to the asserting throwing version.

Without these additions, dotnet crashes with an assertion.

Prerequisite for: https://github.com/dotnet/runtime/pull/124716
