### PR TITLE
Fix regression introduced in #123925

### DIFF
--- a/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/libraries/System.Reflection.Emit/src/System/Reflection/Emit/SignatureHelper.cs
@@ -258,13 +258,23 @@ namespace System.Reflection.Emit
             MethodSignatureEncoder sigEncoder = signature.FunctionPointer(callConv, attribs);
             sigEncoder.Parameters(paramTypes.Length, out ReturnTypeEncoder retTypeEncoder, out ParametersEncoder paramsEncoder);
 
-            WriteSignatureForType(retTypeEncoder.Type(), returnType, module);
+            WriteSignatureForType(
+                retTypeEncoder.Type(),
+                returnType,
+                module,
+                returnType.GetRequiredCustomModifiers(),
+                returnType.GetOptionalCustomModifiers());
 
             foreach (Type paramType in paramTypes)
             {
                 ParameterTypeEncoder paramEncoder = paramsEncoder.AddParameter();
 
-                WriteSignatureForType(paramEncoder.Type(), paramType, module);
+                WriteSignatureForType(
+                    paramEncoder.Type(),
+                    paramType,
+                    module,
+                    paramType.GetRequiredCustomModifiers(),
+                    paramType.GetOptionalCustomModifiers());
             }
         }
 

--- a/src/libraries/System.Reflection.Emit/tests/Utilities.cs
+++ b/src/libraries/System.Reflection.Emit/tests/Utilities.cs
@@ -177,11 +177,11 @@ namespace System.Reflection.Emit.Tests
 
             public FunctionPointer(
                 Type baseFunctionPointerType,
-                Type[] conventions = null,
+                Type[]? conventions = null,
                 Type customReturnType = null,
-                Type[] customParameterTypes = null,
-                Type[] fnPtrRequiredMods = null,
-                Type[] fnPtrOptionalMods = null)
+                Type[]? customParameterTypes = null,
+                Type[]? fnPtrRequiredMods = null,
+                Type[]? fnPtrOptionalMods = null)
                 : base(baseFunctionPointerType)
             {
                 callingConventions = conventions ?? [];
@@ -203,7 +203,7 @@ namespace System.Reflection.Emit.Tests
             private readonly Type[] requiredModifiers;
             private readonly Type[] optionalModifiers;
 
-            public ModifiedType(Type delegatingType, Type[] requiredMods = null, Type[] optionalMods = null)
+            public ModifiedType(Type delegatingType, Type[]? requiredMods = null, Type[]? optionalMods = null)
                 : base(delegatingType)
             {
                 requiredModifiers = requiredMods ?? [];


### PR DESCRIPTION
#123925 breaks the functionality introduced in #119935.

This PR fixes this issue and adds an appropriate test. I decided to also address the [comments](https://github.com/dotnet/runtime/pull/124537#discussion_r2831325848) in #124537 here.