### PR TITLE
Use PF_LINK on SunOS

### DIFF
--- a/src/native/libs/System.Native/pal_interfaceaddresses.c
+++ b/src/native/libs/System.Native/pal_interfaceaddresses.c
@@ -46,6 +46,13 @@
 #include "ios/net/if_media.h"
 #endif
 
+// SunOS defines both AF_LINK and AF_PACKET but AF_LINK is preferred.
+// Using AF_PACKET on SunOS requires access to system-private headers.
+// Use undef to keep all the changes here.
+#if defined(TARGET_SUNOS)
+#undef AF_PACKET
+#endif
+
 #if defined(AF_PACKET)
 #include <sys/ioctl.h>
 #if HAVE_NETPACKET_PACKET_H

--- a/src/native/libs/System.Native/pal_interfaceaddresses.c
+++ b/src/native/libs/System.Native/pal_interfaceaddresses.c
@@ -455,6 +455,24 @@ int32_t SystemNative_GetNetworkInterfaces(int32_t * interfaceCount, NetworkInter
             nii->HardwareType = MapHardwareType(sadl->sdl_type);
             nii->NumAddressBytes =  sadl->sdl_alen;
             memcpy_s(&nii->AddressBytes, sizeof_member(NetworkInterfaceInfo, AddressBytes), (uint8_t*)LLADDR(sadl), sadl->sdl_alen);
+
+#if defined(SIOCGIFMTU)
+            struct ifreq ifr;
+            strncpy(ifr.ifr_name, nii->Name, sizeof(ifr.ifr_name));
+            ifr.ifr_name[sizeof(ifr.ifr_name) - 1] = '\0';
+            if (socketfd == -1)
+            {
+                socketfd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
+            }
+
+            if (socketfd > -1)
+            {
+                if (ioctl(socketfd, SIOCGIFMTU, &ifr) == 0)
+                {
+                    nii->Mtu = ifr.ifr_mtu;
+                }
+            }
+#endif // SIOCGIFMTU
         }
 #endif
 #if defined(AF_PACKET)

--- a/src/native/libs/System.Native/pal_maphardwaretype.c
+++ b/src/native/libs/System.Native/pal_maphardwaretype.c
@@ -7,6 +7,13 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
+// SunOS defines both AF_LINK and AF_PACKET but AF_LINK is preferred.
+// Using AF_PACKET on SunOS requires access to system-private headers.
+// Use undef to keep all the changes here.
+#if defined(TARGET_SUNOS)
+#undef AF_PACKET
+#endif
+
 #if defined(AF_PACKET)
 #if HAVE_NETPACKET_PACKET_H
 #include <netpacket/packet.h>

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -204,6 +204,11 @@ static bool TryConvertAddressFamilyPlatformToPal(sa_family_t platformAddressFami
             *palAddressFamily = AddressFamily_AF_PACKET;
             return true;
 #endif
+#ifdef AF_LINK
+        case AF_LINK:
+            *palAddressFamily = AddressFamily_AF_LINK;
+            return true;
+#endif
 #ifdef AF_CAN
         case AF_CAN:
             *palAddressFamily = AddressFamily_AF_CAN;
@@ -239,6 +244,11 @@ static bool TryConvertAddressFamilyPalToPlatform(int32_t palAddressFamily, sa_fa
 #ifdef AF_PACKET
         case AddressFamily_AF_PACKET:
             *platformAddressFamily = AF_PACKET;
+            return true;
+#endif
+#ifdef AF_LINK
+        case AddressFamily_AF_LINK:
+            *platformAddressFamily = AF_LINK;
             return true;
 #endif
 #ifdef AF_CAN
@@ -2546,6 +2556,11 @@ static bool TryConvertProtocolTypePalToPlatform(int32_t palAddressFamily, int32_
             *platformProtocolType = palProtocolType;
             return true;
 #endif
+#ifdef AF_LINK
+        case AddressFamily_AF_LINK:
+            *platformProtocolType = palProtocolType;
+            return true;
+#endif
 #if HAVE_LINUX_CAN_H
         case AddressFamily_AF_CAN:
             switch (palProtocolType)
@@ -2682,6 +2697,11 @@ static bool TryConvertProtocolTypePlatformToPal(int32_t palAddressFamily, int pl
 #ifdef AF_PACKET
         case AddressFamily_AF_PACKET:
             // protocol is the IEEE 802.3 protocol number in network order.
+            *palProtocolType = platformProtocolType;
+            return true;
+#endif
+#ifdef AF_LINK
+        case AddressFamily_AF_LINK:
             *palProtocolType = platformProtocolType;
             return true;
 #endif

--- a/src/native/libs/System.Native/pal_networking.h
+++ b/src/native/libs/System.Native/pal_networking.h
@@ -66,6 +66,7 @@ typedef enum
     AddressFamily_AF_UNIX = 1,     // System.Net.AddressFamily.Unix
     AddressFamily_AF_INET = 2,     // System.Net.AddressFamily.InterNetwork
     AddressFamily_AF_INET6 = 23,   // System.Net.AddressFamily.InterNetworkV6
+    AddressFamily_AF_LINK = 13,       // System.Net.AddressFamily.DataLink
     AddressFamily_AF_PACKET = 65536,  // System.Net.AddressFamily.Packet
     AddressFamily_AF_CAN = 65537,     // System.Net.AddressFamily.ControllerAreaNetwork
 } AddressFamily;


### PR DESCRIPTION
I've been working on updates to arcate/eng/common/cross/build-rootfs.sh
and discovered it doing some undesirable header copying for illumos.
With this small configuration change, that's no longer needed.
As the comment in the change explains:

SunOS defines both AF_LINK and AF_PACKET but AF_LINK is preferred.
Using AF_PACKET on SunOS requires access to system-private headers.
