### PR TITLE
Remove duplicate typeof(decimal) check in IsKnownComparable<T>

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Constants.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/Constants.cs
@@ -53,7 +53,6 @@ namespace System.Collections.Frozen
             typeof(T) == typeof(uint) ||
             typeof(T) == typeof(long) ||
             typeof(T) == typeof(ulong) ||
-            typeof(T) == typeof(decimal) ||
             typeof(T) == typeof(float) ||
             typeof(T) == typeof(double) ||
             typeof(T) == typeof(decimal) ||


### PR DESCRIPTION
In `Constants.IsKnownComparable<T>()`, the condition `typeof(T) == typeof(decimal)` appeared twice.
Therefore, I have removed the duplicated check.