### PR TITLE
[HTTP] Re-disable quic.nginx.org interop test

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -1943,8 +1943,6 @@ namespace System.Net.Http.Functional.Tests
             new TheoryData<string>
             {
                 { "https://cloudflare-quic.com/" }, // Cloudflare with content
-                // [ActiveIssue("https://github.com/dotnet/runtime/issues/120257")]
-                // { "https://quic.nginx.org/" }, // Nginx with content
             };
     }
 

--- a/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.Http3.cs
@@ -1943,7 +1943,8 @@ namespace System.Net.Http.Functional.Tests
             new TheoryData<string>
             {
                 { "https://cloudflare-quic.com/" }, // Cloudflare with content
-                { "https://quic.nginx.org/" }, // Nginx with content
+                // [ActiveIssue("https://github.com/dotnet/runtime/issues/120257")]
+                // { "https://quic.nginx.org/" }, // Nginx with content
             };
     }
 


### PR DESCRIPTION
The quic.nginx.org QUIC/HTTP3 interop test URI was re-enabled in #124591 (merged Feb 19), but the external server's QUIC endpoint became unreachable again starting Feb 21, causing **100% failure rate** (26 failures, 0 passes) on `Public_Interop_ExactVersion_BufferContent_Success` across all platforms.

### Analysis

- **Error**: `Connection handshake was canceled due to the configured timeout of 00:00:10 seconds elapsing. (quic.nginx.org:443)` wrapping `QuicException`
- **Scope**: Only the `quic.nginx.org` URI is affected; the `cloudflare-quic.com` URI passes fine
- **Not a code regression**: The server responds to HTTP/1.1 requests normally, but its QUIC/UDP endpoint is not responding from Helix CI machines
- **History**: This is the same class of external server issues that led to the original disablement in #120257

### Example console log

https://helixr1107v0xdcypoyl9e7f.blob.core.windows.net/dotnet-runtime-refs-heads-main-af729cf491f8439bab/System.Net.Http.Functional.Tests/3/console.e4a06694.log?helixlogtype=result

### Change

Remove `quic.nginx.org` from the list of test uris permanently, as it is simply too unreliable to use in our CI.