### PR TITLE
Disable localhost subdomain AddressFamily tests on Android

### DIFF
--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostAddressesTest.cs
@@ -249,6 +249,7 @@ namespace System.Net.NameResolution.Tests
         [Theory]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124751", TestPlatforms.Android)]
         public async Task DnsGetHostAddresses_LocalhostSubdomain_RespectsAddressFamily(AddressFamily addressFamily)
         {
             // Skip IPv6 test if OS doesn't support it.

--- a/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
+++ b/src/libraries/System.Net.NameResolution/tests/FunctionalTests/GetHostEntryTest.cs
@@ -414,6 +414,7 @@ namespace System.Net.NameResolution.Tests
         [Theory]
         [InlineData(AddressFamily.InterNetwork)]
         [InlineData(AddressFamily.InterNetworkV6)]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124751", TestPlatforms.Android)]
         public async Task DnsGetHostEntry_LocalhostSubdomain_RespectsAddressFamily(AddressFamily addressFamily)
         {
             // Skip IPv6 test if OS doesn't support it.


### PR DESCRIPTION
Disables `DnsGetHostEntry_LocalhostSubdomain_RespectsAddressFamily` and `DnsGetHostAddresses_LocalhostSubdomain_RespectsAddressFamily` on Android using `[ActiveIssue]`.

## Problem

These tests (introduced in #123076 for RFC 6761 localhost subdomain handling) consistently fail on Android CI (`windows.11.amd64.android.open`):

```
System.Net.Sockets.SocketException : hostname nor servname provided, or not known
   at System.Net.Dns.GetHostEntryOrAddressesCore(...)
   at System.Net.Dns.GetHostEntryOrAddressesCore(...)  // fallback for "localhost"
   at System.Net.Dns.GetHostEntryCore(...)
   at System.Net.Dns.GetHostEntry(...)
```

The tests call e.g. `Dns.GetHostEntry("test.localhost", AddressFamily.InterNetwork)`. The RFC 6761 implementation tries the OS resolver for `"test.localhost"` first, then falls back to resolving `"localhost"` with the same `AddressFamily`. On Android, `getaddrinfo("localhost", ..., AF_INET/AF_INET6)` may fail with `EAI_NONAME` while `getaddrinfo("localhost", ..., AF_UNSPEC)` succeeds — causing both the initial and fallback resolution to fail.

Other localhost subdomain tests that use `AddressFamily.Unspecified` (e.g. `ReturnsLoopback`) pass on Android.

Example console log: https://helixr1107v0xdeko0k025g8.blob.core.windows.net/dotnet-runtime-refs-heads-main-76f79e897d5246b58a/System.Net.NameResolution.Functional.Tests/1/console.858b3560.log?helixlogtype=result

Contributes to #124751