### PR TITLE
[browser][CoreCLR] Loading Webcil - JS part

### DIFF
--- a/src/native/libs/Common/JavaScript/cross-module/index.ts
+++ b/src/native/libs/Common/JavaScript/cross-module/index.ts
@@ -152,6 +152,7 @@ export function dotnetUpdateInternalsSubscriber() {
             initializeCoreCLR: table[3],
             registerPdbBytes: table[4],
             instantiateWasm: table[5],
+            instantiateWebcilModule: table[6],
         };
         Object.assign(native, nativeLocal);
     }
@@ -172,6 +173,8 @@ export function dotnetUpdateInternalsSubscriber() {
     // keep in sync with nativeBrowserExportsToTable()
     function nativeBrowserExportsFromTable(table: NativeBrowserExportsTable, interop: NativeBrowserExports): void {
         const interopLocal: NativeBrowserExports = {
+            getWasmMemory: table[0],
+            getWasmTable: table[1],
         };
         Object.assign(interop, interopLocal);
     }

--- a/src/native/libs/Common/JavaScript/host/index.ts
+++ b/src/native/libs/Common/JavaScript/host/index.ts
@@ -8,7 +8,7 @@ import { _ems_ } from "../ems-ambient";
 import GitHash from "consts:gitHash";
 
 import { runMain, runMainAndExit, initializeCoreCLR } from "./host";
-import { registerPdbBytes, registerDllBytes, installVfsFile, loadIcuData, instantiateWasm, } from "./assets";
+import { registerPdbBytes, instantiateWebcilModule, registerDllBytes, installVfsFile, loadIcuData, instantiateWasm, } from "./assets";
 
 export function dotnetInitializeModule(internals: InternalExchange): void {
     if (!Array.isArray(internals)) throw new Error("Expected internals to be an array");
@@ -30,6 +30,7 @@ export function dotnetInitializeModule(internals: InternalExchange): void {
         initializeCoreCLR,
         registerPdbBytes,
         instantiateWasm,
+        instantiateWebcilModule,
     });
     _ems_.dotnetUpdateInternals(internals, _ems_.dotnetUpdateInternalsSubscriber);
 
@@ -44,6 +45,7 @@ export function dotnetInitializeModule(internals: InternalExchange): void {
             map.initializeCoreCLR,
             map.registerPdbBytes,
             map.instantiateWasm,
+            map.instantiateWebcilModule,
         ];
     }
 }

--- a/src/native/libs/Common/JavaScript/loader/dotnet.d.ts
+++ b/src/native/libs/Common/JavaScript/loader/dotnet.d.ts
@@ -441,7 +441,11 @@ type AssetBehaviors = SingleAssetBehaviors |
 /**
  * The javascript module that came from nuget package .
  */
- | "js-module-library-initializer";
+ | "js-module-library-initializer"
+/**
+ * Managed assembly packaged as Webcil v 1.0
+ */
+ | "webcil10";
 declare const enum GlobalizationMode {
     /**
      * Load sharded ICU data.

--- a/src/native/libs/Common/JavaScript/loader/run.ts
+++ b/src/native/libs/Common/JavaScript/loader/run.ts
@@ -14,7 +14,6 @@ import { validateWasmFeatures } from "./bootstrap";
 
 const runMainPromiseController = createPromiseCompletionSource<number>();
 
-// WASM-TODO: webCIL
 // WASM-TODO: downloadOnly - blazor render mode auto pre-download. Really no start.
 // WASM-TODO: loadAllSatelliteResources
 // WASM-TODO: debugLevel

--- a/src/native/libs/Common/JavaScript/per-module/index.ts
+++ b/src/native/libs/Common/JavaScript/per-module/index.ts
@@ -14,3 +14,4 @@ export const VoidPtrNull: VoidPtr = <VoidPtr><any>0;
 export const CharPtrNull: CharPtr = <CharPtr><any>0;
 export const NativePointerNull: NativePointer = <NativePointer><any>0;
 export const browserVirtualAppBase = "/"; // keep in sync other places that define browserVirtualAppBase
+export const sizeOfPtr = 4;

--- a/src/native/libs/Common/JavaScript/types/ems-ambient.ts
+++ b/src/native/libs/Common/JavaScript/types/ems-ambient.ts
@@ -92,4 +92,7 @@ export type EmsAmbientSymbolsType = EmscriptenModuleInternal & {
     writeI53ToI64(ptr: MemOffset, value: number): void;
     readI53FromI64(ptr: MemOffset): number;
     readI53FromU64(ptr: MemOffset): number;
+
+    wasmMemory: WebAssembly.Memory;
+    wasmTable: WebAssembly.Table;
 }

--- a/src/native/libs/Common/JavaScript/types/exchange.ts
+++ b/src/native/libs/Common/JavaScript/types/exchange.ts
@@ -6,7 +6,7 @@ import type { resolveRunMainPromise, rejectRunMainPromise, getRunMainPromise, ab
 import type { addOnExitListener, isExited, isRuntimeRunning, quitNow } from "../loader/exit";
 
 import type { initializeCoreCLR } from "../host/host";
-import type { instantiateWasm, installVfsFile, registerDllBytes, loadIcuData, registerPdbBytes } from "../host/assets";
+import type { instantiateWasm, installVfsFile, registerDllBytes, loadIcuData, registerPdbBytes, instantiateWebcilModule } from "../host/assets";
 import type { createPromiseCompletionSource, getPromiseCompletionSource, isControllablePromise } from "../loader/promise-completion-source";
 
 import type { isSharedArrayBuffer, zeroRegion } from "../../../System.Native.Browser/utils/memory";
@@ -20,6 +20,10 @@ import type { abortInteropTimers } from "../../../System.Runtime.InteropServices
 
 import type { installNativeSymbols, symbolicateStackTrace } from "../../../System.Native.Browser/diagnostics/symbolicate";
 import type { EmsAmbientSymbolsType } from "../types";
+
+
+type getWasmMemoryType = () => WebAssembly.Memory;
+type getWasmTableType = () => WebAssembly.Table;
 
 export type RuntimeExports = {
     bindJSImportST: typeof bindJSImportST,
@@ -98,6 +102,7 @@ export type BrowserHostExports = {
     initializeCoreCLR: typeof initializeCoreCLR
     registerPdbBytes: typeof registerPdbBytes
     instantiateWasm: typeof instantiateWasm
+    instantiateWebcilModule: typeof instantiateWebcilModule
 }
 
 export type BrowserHostExportsTable = [
@@ -107,6 +112,7 @@ export type BrowserHostExportsTable = [
     typeof initializeCoreCLR,
     typeof registerPdbBytes,
     typeof instantiateWasm,
+    typeof instantiateWebcilModule,
 ]
 
 export type InteropJavaScriptExports = {
@@ -128,9 +134,13 @@ export type InteropJavaScriptExportsTable = [
 ]
 
 export type NativeBrowserExports = {
+    getWasmMemory: getWasmMemoryType,
+    getWasmTable: getWasmTableType,
 }
 
 export type NativeBrowserExportsTable = [
+    getWasmMemoryType,
+    getWasmTableType,
 ]
 
 export type BrowserUtilsExports = {

--- a/src/native/libs/Common/JavaScript/types/public-api.ts
+++ b/src/native/libs/Common/JavaScript/types/public-api.ts
@@ -405,7 +405,12 @@ export type AssetBehaviors = SingleAssetBehaviors |
     /**
      * The javascript module that came from nuget package .
      */
-    | "js-module-library-initializer";
+    | "js-module-library-initializer"
+    /**
+     * Managed assembly packaged as Webcil v 1.0
+     */
+    | "webcil10"
+    ;
 export declare const enum GlobalizationMode {
     /**
      * Load sharded ICU data.

--- a/src/native/libs/System.Native.Browser/native/index.ts
+++ b/src/native/libs/System.Native.Browser/native/index.ts
@@ -24,6 +24,8 @@ export function dotnetInitializeModule(internals: InternalExchange): void {
     }
 
     internals[InternalExchangeIndex.NativeBrowserExportsTable] = nativeBrowserExportsToTable({
+        getWasmMemory,
+        getWasmTable,
     });
     _ems_.dotnetUpdateInternals(internals, _ems_.dotnetUpdateInternalsSubscriber);
 
@@ -33,7 +35,17 @@ export function dotnetInitializeModule(internals: InternalExchange): void {
     function nativeBrowserExportsToTable(map: NativeBrowserExports): NativeBrowserExportsTable {
         // keep in sync with nativeBrowserExportsFromTable()
         return [
+            map.getWasmMemory,
+            map.getWasmTable,
         ];
+    }
+
+    function getWasmMemory(): WebAssembly.Memory {
+        return _ems_.wasmMemory;
+    }
+
+    function getWasmTable(): WebAssembly.Table {
+        return _ems_.wasmTable;
     }
 
     function setupEmscripten() {


### PR DESCRIPTION
Split of JS part of https://github.com/dotnet/runtime/pull/124268

- New `instantiateWebCILModule()` in host assets: 
    - instantiates the `.wasm` wrapper as a WebAssembly module
    - calls `getWebcilSize`/`getWebcilPayload` exports to extract the raw WebCIL
    - copies the payload into 16-byte aligned memory, registers it under the `.dll` virtual path.
- New `getWasmMemory` / `getWasmTable`
