### PR TITLE
Remove some of unsafe code in Base64 decoder

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64Helper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64Helper.cs
@@ -178,9 +178,9 @@ namespace System.Buffers.Text
             int GetMaxSrcLength(int srcLength, int destLength);
             int GetMaxEncodedLength(int srcLength);
             uint GetInPlaceDestinationLength(int encodedLength, int leftOver);
-            unsafe void EncodeOneOptionallyPadTwo(byte* oneByte, T* dest, ref byte encodingMap);
-            unsafe void EncodeTwoOptionallyPadOne(byte* oneByte, T* dest, ref byte encodingMap);
-            unsafe void EncodeThreeAndWrite(byte* threeBytes, T* destination, ref byte encodingMap);
+            void EncodeOneOptionallyPadTwo(ReadOnlySpan<byte> oneByte, Span<T> dest, ref byte encodingMap);
+            void EncodeTwoOptionallyPadOne(ReadOnlySpan<byte> twoBytes, Span<T> dest, ref byte encodingMap);
+            void EncodeThreeAndWrite(ReadOnlySpan<byte> threeBytes, Span<T> destination, ref byte encodingMap);
             int IncrementPadTwo { get; }
             int IncrementPadOne { get; }
 #if NET
@@ -236,8 +236,8 @@ namespace System.Buffers.Text
             unsafe bool TryLoadArmVector128x4(T* src, T* srcStart, int sourceLength,
                 out Vector128<byte> str1, out Vector128<byte> str2, out Vector128<byte> str3, out Vector128<byte> str4);
 #endif // NET
-            unsafe int DecodeFourElements(T* source, ref sbyte decodingMap);
-            unsafe int DecodeRemaining(T* srcEnd, ref sbyte decodingMap, long remaining, out uint t2, out uint t3);
+            int DecodeFourElements(ReadOnlySpan<T> source, ref sbyte decodingMap);
+            int DecodeRemaining(ReadOnlySpan<T> source, ref sbyte decodingMap, out uint t2, out uint t3);
             int IndexOfAnyExceptWhiteSpace(ReadOnlySpan<T> span);
             OperationStatus DecodeWithWhiteSpaceBlockwiseWrapper<TTBase64Decoder>(TTBase64Decoder decoder, ReadOnlySpan<T> source,
                 Span<byte> bytes, ref int bytesConsumed, ref int bytesWritten, bool isFinalBlock = true)

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlDecoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlDecoder.cs
@@ -464,12 +464,12 @@ namespace System.Buffers.Text
 #endif // NET
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe int DecodeFourElements(byte* source, ref sbyte decodingMap) =>
+            public int DecodeFourElements(ReadOnlySpan<byte> source, ref sbyte decodingMap) =>
                 default(Base64DecoderByte).DecodeFourElements(source, ref decodingMap);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe int DecodeRemaining(byte* srcEnd, ref sbyte decodingMap, long remaining, out uint t2, out uint t3) =>
-                default(Base64DecoderByte).DecodeRemaining(srcEnd, ref decodingMap, remaining, out t2, out t3);
+            public int DecodeRemaining(ReadOnlySpan<byte> source, ref sbyte decodingMap, out uint t2, out uint t3) =>
+                default(Base64DecoderByte).DecodeRemaining(source, ref decodingMap, out t2, out t3);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public int IndexOfAnyExceptWhiteSpace(ReadOnlySpan<byte> span) => default(Base64DecoderByte).IndexOfAnyExceptWhiteSpace(span);
@@ -549,12 +549,12 @@ namespace System.Buffers.Text
 #endif // NET
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe int DecodeFourElements(ushort* source, ref sbyte decodingMap) =>
+            public int DecodeFourElements(ReadOnlySpan<ushort> source, ref sbyte decodingMap) =>
                 default(Base64DecoderChar).DecodeFourElements(source, ref decodingMap);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe int DecodeRemaining(ushort* srcEnd, ref sbyte decodingMap, long remaining, out uint t2, out uint t3) =>
-                default(Base64DecoderChar).DecodeRemaining(srcEnd, ref decodingMap, remaining, out t2, out t3);
+            public int DecodeRemaining(ReadOnlySpan<ushort> source, ref sbyte decodingMap, out uint t2, out uint t3) =>
+                default(Base64DecoderChar).DecodeRemaining(source, ref decodingMap, out t2, out t3);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public int IndexOfAnyExceptWhiteSpace(ReadOnlySpan<ushort> span) => default(Base64DecoderChar).IndexOfAnyExceptWhiteSpace(span);

--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlEncoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Url/Base64UrlEncoder.cs
@@ -243,44 +243,27 @@ namespace System.Buffers.Text
             public int GetMaxEncodedLength(int srcLength) => GetEncodedLength(srcLength);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe void EncodeOneOptionallyPadTwo(byte* oneByte, byte* dest, ref byte encodingMap)
+            public void EncodeOneOptionallyPadTwo(ReadOnlySpan<byte> oneByte, Span<byte> dest, ref byte encodingMap)
             {
                 uint t0 = oneByte[0];
 
                 uint i = t0 << 8;
 
-                byte i0 = Unsafe.Add(ref encodingMap, (IntPtr)(i >> 10));
-                byte i1 = Unsafe.Add(ref encodingMap, (IntPtr)((i >> 4) & 0x3F));
-
-                ushort result;
-
-                if (BitConverter.IsLittleEndian)
-                {
-                    result = (ushort)(i0 | (i1 << 8));
-                }
-                else
-                {
-                    result = (ushort)((i0 << 8) | i1);
-                }
-
-                Unsafe.WriteUnaligned(dest, result);
+                dest[1] = Unsafe.Add(ref encodingMap, (IntPtr)((i >> 4) & 0x3F));
+                dest[0] = Unsafe.Add(ref encodingMap, (IntPtr)(i >> 10));
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe void EncodeTwoOptionallyPadOne(byte* twoBytes, byte* dest, ref byte encodingMap)
+            public void EncodeTwoOptionallyPadOne(ReadOnlySpan<byte> twoBytes, Span<byte> dest, ref byte encodingMap)
             {
                 uint t0 = twoBytes[0];
                 uint t1 = twoBytes[1];
 
                 uint i = (t0 << 16) | (t1 << 8);
 
-                byte i0 = Unsafe.Add(ref encodingMap, (IntPtr)(i >> 18));
-                byte i1 = Unsafe.Add(ref encodingMap, (IntPtr)((i >> 12) & 0x3F));
-                byte i2 = Unsafe.Add(ref encodingMap, (IntPtr)((i >> 6) & 0x3F));
-
-                dest[0] = i0;
-                dest[1] = i1;
-                dest[2] = i2;
+                dest[2] = Unsafe.Add(ref encodingMap, (IntPtr)((i >> 6) & 0x3F));
+                dest[1] = Unsafe.Add(ref encodingMap, (IntPtr)((i >> 12) & 0x3F));
+                dest[0] = Unsafe.Add(ref encodingMap, (IntPtr)(i >> 18));
             }
 
 #if NET
@@ -305,7 +288,7 @@ namespace System.Buffers.Text
 #endif // NET
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe void EncodeThreeAndWrite(byte* threeBytes, byte* destination, ref byte encodingMap) =>
+            public void EncodeThreeAndWrite(ReadOnlySpan<byte> threeBytes, Span<byte> destination, ref byte encodingMap) =>
                 default(Base64EncoderByte).EncodeThreeAndWrite(threeBytes, destination, ref encodingMap);
         }
 
@@ -333,11 +316,11 @@ namespace System.Buffers.Text
             public int GetMaxEncodedLength(int _) => 0;  // not used for char encoding
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe void EncodeOneOptionallyPadTwo(byte* oneByte, ushort* dest, ref byte encodingMap) =>
+            public void EncodeOneOptionallyPadTwo(ReadOnlySpan<byte> oneByte, Span<ushort> dest, ref byte encodingMap) =>
                 Base64Helper.EncodeOneOptionallyPadTwo(oneByte, dest, ref encodingMap);
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe void EncodeTwoOptionallyPadOne(byte* twoBytes, ushort* dest, ref byte encodingMap) =>
+            public void EncodeTwoOptionallyPadOne(ReadOnlySpan<byte> twoBytes, Span<ushort> dest, ref byte encodingMap) =>
                 Base64Helper.EncodeTwoOptionallyPadOne(twoBytes, dest, ref encodingMap);
 
 #if NET
@@ -361,7 +344,7 @@ namespace System.Buffers.Text
 #endif // NET
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public unsafe void EncodeThreeAndWrite(byte* threeBytes, ushort* destination, ref byte encodingMap) =>
+            public void EncodeThreeAndWrite(ReadOnlySpan<byte> threeBytes, Span<ushort> destination, ref byte encodingMap) =>
                 default(Base64EncoderChar).EncodeThreeAndWrite(threeBytes, destination, ref encodingMap);
         }
     }


### PR DESCRIPTION
Still keeping some unsafe for hot SIMD loop (will try to remove that too) or if it has a lot of unsafe callers