### PR TITLE
Don't build managed ilasm in the VMR yet

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -484,7 +484,9 @@
 
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler\ILCompiler_publish.csproj" Condition="'$(SdkToolsSupported)' == 'true'" Category="clr" />
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\crossgen2\crossgen2_publish.csproj" Condition="'$(SdkToolsSupported)' == 'true'" Category="clr" />
-    <ProjectToBuild Include="$(ToolsProjectRoot)ilasm\src\ilasm\ilasm.csproj" Condition="'$(SdkToolsSupported)' == 'true'" Category="clr" />
+
+    <!-- Build ilasm as part of the clr tools subset when building just dotnet/runtime as we use it in runtime testing. Don't do so for VMR builds as we aren't shipping it yet and it pulls in prebuilts that we haven't handled for source-build. -->
+    <ProjectToBuild Include="$(ToolsProjectRoot)ilasm\src\ilasm\ilasm.csproj" Condition="'$(SdkToolsSupported)' == 'true' and '$(DotNetBuildFromVMR)' != 'true'" Category="clr" />
 
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler\ILCompiler.csproj" Condition="'$(SdkToolsSupported)' == 'true'" Category="clr" />
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\crossgen2\crossgen2.csproj" Condition="'$(SdkToolsSupported)' == 'true'" Category="clr" />

--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -485,7 +485,7 @@
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler\ILCompiler_publish.csproj" Condition="'$(SdkToolsSupported)' == 'true'" Category="clr" />
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\crossgen2\crossgen2_publish.csproj" Condition="'$(SdkToolsSupported)' == 'true'" Category="clr" />
 
-    <!-- Build ilasm as part of the clr tools subset when building just dotnet/runtime as we use it in runtime testing. Don't do so for VMR builds as we aren't shipping it yet and it pulls in prebuilts that we haven't handled for source-build. -->
+    <!-- Build managed ilasm as part of the clr tools subset when building just dotnet/runtime as we use it in runtime testing. Don't do so for VMR builds as we aren't shipping it yet and it pulls in prebuilts that we haven't handled for source-build. -->
     <ProjectToBuild Include="$(ToolsProjectRoot)ilasm\src\ilasm\ilasm.csproj" Condition="'$(SdkToolsSupported)' == 'true' and '$(DotNetBuildFromVMR)' != 'true'" Category="clr" />
 
     <ProjectToBuild Include="$(CoreClrProjectRoot)tools\aot\ILCompiler\ILCompiler.csproj" Condition="'$(SdkToolsSupported)' == 'true'" Category="clr" />


### PR DESCRIPTION
We aren't ready to build it in source-build scenarios (need SB-externals work and some local dependency changes too) and it's not shipping anyway at the moment.