### PR TITLE
Fix Arm64: for 124357

### DIFF
--- a/src/coreclr/jit/lsra.h
+++ b/src/coreclr/jit/lsra.h
@@ -1429,6 +1429,7 @@ private:
         return nextConsecutiveRefPositionMap;
     }
     FORCEINLINE RefPosition* getNextConsecutiveRefPosition(RefPosition* refPosition);
+    FORCEINLINE regNumber    getNextFPRegWraparound(regNumber reg);
     SingleTypeRegSet         getOperandCandidates(GenTreeHWIntrinsic* intrinsicTree, HWIntrinsic intrin, size_t opNum);
     GenTree*                 getDelayFreeOperand(GenTreeHWIntrinsic* intrinsicTree, bool embedded = false);
     GenTree*                 getVectorAddrOperand(GenTreeHWIntrinsic* intrinsicTree);

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -91,7 +91,7 @@ void LinearScan::assignConsecutiveRegisters(RefPosition* firstRefPosition, regNu
     assert(firstRefPosition->refType != RefTypeUpperVectorRestore);
 
     INDEBUG(int refPosCount = 1);
-    consecutiveRegsInUseThisLocation = 0;
+    consecutiveRegsInUseThisLocation = RBM_NONE;
     regNumber consecutiveReg         = firstRegAssigned;
     for (int i = 0; i < firstRefPosition->regCount; i++)
     {

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -76,7 +76,6 @@ void LinearScan::assignConsecutiveRegisters(RefPosition* firstRefPosition, regNu
     assert(firstRefPosition->refType != RefTypeUpperVectorRestore);
 
     INDEBUG(int refPosCount = 1);
-    //consecutiveRegsInUseThisLocation = (((1ULL << firstRefPosition->regCount) - 1) << firstRegAssigned);
     consecutiveRegsInUseThisLocation = 0;
     regNumber consecutiveReg = firstRegAssigned;
     for (int i = 0; i < firstRefPosition->regCount; i++)

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -76,7 +76,14 @@ void LinearScan::assignConsecutiveRegisters(RefPosition* firstRefPosition, regNu
     assert(firstRefPosition->refType != RefTypeUpperVectorRestore);
 
     INDEBUG(int refPosCount = 1);
-    consecutiveRegsInUseThisLocation = (((1ULL << firstRefPosition->regCount) - 1) << firstRegAssigned);
+    //consecutiveRegsInUseThisLocation = (((1ULL << firstRefPosition->regCount) - 1) << firstRegAssigned);
+    consecutiveRegsInUseThisLocation = 0;
+    regNumber consecutiveReg = firstRegAssigned;
+    for (int i = 0; i < firstRefPosition->regCount; i++)
+    {
+        consecutiveRegsInUseThisLocation |= genSingleTypeRegMask(consecutiveReg);
+        consecutiveReg = consecutiveReg == REG_FP_LAST ? REG_FP_FIRST : REG_NEXT(consecutiveReg);
+    }
 
     while (consecutiveRefPosition != nullptr)
     {

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -92,7 +92,7 @@ void LinearScan::assignConsecutiveRegisters(RefPosition* firstRefPosition, regNu
 
     INDEBUG(int refPosCount = 1);
     consecutiveRegsInUseThisLocation = 0;
-    regNumber consecutiveReg = firstRegAssigned;
+    regNumber consecutiveReg         = firstRegAssigned;
     for (int i = 0; i < firstRefPosition->regCount; i++)
     {
         consecutiveRegsInUseThisLocation |= genSingleTypeRegMask(consecutiveReg);


### PR DESCRIPTION
Running out of consecutive registers for arm64 under jit reg stress.  Lsra is trying to place `C380, C381, V363, V364` into four consecutive registers `d31, d0, d1, d2` for a VectorTableLookup (TBL) and runs out of registers when trying to assign V364 as `d2`.

LSRA can normally handle this wraparound.  Issue is that the C381 def also occupies d2, so d2 is incorrectly considered not available for V364.  Normally this conflict is handled by the `LinearScan::consecutiveRegsInUseThisLocation` mask - but the way the mask is calculated does not handle the d31->d0 wraparound properly.

fixes #124357 