### PR TITLE
Fix localization of ExtendedPropertyDescriptor.DisplayName

### DIFF
--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtendedPropertyDescriptor.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ExtendedPropertyDescriptor.cs
@@ -99,7 +99,7 @@ namespace System.ComponentModel
                     string? providerName = site?.Name;
                     if (providerName != null && providerName.Length > 0)
                     {
-                        name = SR.Format(SR.UsingResourceKeys() ? "{0} on {1}" : SR.MetaExtenderName, name, providerName);
+                        name = SR.Format(SR.MetaExtenderName, name, providerName);
                     }
                 }
                 return name;


### PR DESCRIPTION
Fixes #108422

## Summary

`ExtendedPropertyDescriptor.DisplayName` was using a ternary that fell back to the hardcoded English string `"{0} on {1}"` when `SR.UsingResourceKeys()` returned `true` (e.g. in trimmed or WASM environments), bypassing the already-localized `SR.MetaExtenderName` resource.

## Change

Removed the unnecessary ternary. `SR.Format(SR.MetaExtenderName, ...)` already handles all environments correctly and uses the localized string as intended.

## Testing

- All existing tests in `System.ComponentModel.TypeConverter` pass.