### PR TITLE
Add OpenBSD target

### DIFF
--- a/eng/build.sh
+++ b/eng/build.sh
@@ -278,6 +278,8 @@ while [[ $# -gt 0 ]]; do
           os="linux" ;;
         freebsd)
           os="freebsd" ;;
+        openbsd)
+          os="openbsd" ;;
         osx)
           os="osx" ;;
         maccatalyst)


### PR DESCRIPTION
Was missing from the OS list.

It doesn't build quite yet but I'm hoping to land some stuff to at least get CoreCLR closer to working.