### PR TITLE
[cDAC] Fix EEClass validation corner case

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/TypeValidation.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/RuntimeTypeSystemHelpers/TypeValidation.cs
@@ -67,6 +67,8 @@ internal sealed class TypeValidation
                 }
             }
         }
+
+        internal readonly bool ValidateReadable() => ValidateDataReadable<MethodTable>(_target, Address);
     }
 
     internal struct NonValidatedEEClass
@@ -84,6 +86,8 @@ internal sealed class TypeValidation
         }
 
         internal TargetPointer MethodTable => _target.ReadPointer(Address + (ulong)_type.Fields[nameof(MethodTable)].Offset);
+
+        internal readonly bool ValidateReadable() => ValidateDataReadable<EEClass>(_target, Address);
     }
 
     internal static NonValidatedMethodTable GetMethodTableData(Target target, TargetPointer methodTablePointer)
@@ -108,6 +112,11 @@ internal sealed class TypeValidation
     {
         try
         {
+            // Make sure that we can read the method table's data.
+            if (!umt.ValidateReadable())
+            {
+                return false;
+            }
             if (!ValidateThrowing(umt))
             {
                 return false;
@@ -146,6 +155,10 @@ internal sealed class TypeValidation
         if (eeClassPtr != TargetPointer.Null)
         {
             NonValidatedEEClass eeClass = GetEEClassData(_target, eeClassPtr);
+            if (!eeClass.ValidateReadable())
+            {
+                return false;
+            }
             TargetPointer methodTablePtrFromClass = eeClass.MethodTable;
             if (methodTable.Address == methodTablePtrFromClass)
             {
@@ -154,6 +167,10 @@ internal sealed class TypeValidation
             if (methodTable.Flags.HasInstantiation || methodTable.Flags.IsArray)
             {
                 NonValidatedMethodTable methodTableFromClass = GetMethodTableData(_target, methodTablePtrFromClass);
+                if (!methodTableFromClass.ValidateReadable())
+                {
+                    return false;
+                }
                 TargetPointer classFromMethodTable = GetClassThrowing(methodTableFromClass);
                 return classFromMethodTable == eeClassPtr;
             }
@@ -174,6 +191,19 @@ internal sealed class TypeValidation
         return true;
     }
 
+    private static bool ValidateDataReadable<T>(Target target, TargetPointer dataAddress) where T : IData<T>
+    {
+        try
+        {
+            T dataClass = T.Create(target, dataAddress);
+            return true;
+        }
+        catch (VirtualReadException)
+        {
+            return false;
+        }
+    }
+
     private TargetPointer GetClassThrowing(NonValidatedMethodTable methodTable)
     {
         TargetPointer eeClassOrCanonMT = methodTable.EEClassOrCanonMT;
@@ -186,6 +216,10 @@ internal sealed class TypeValidation
         {
             TargetPointer canonicalMethodTablePtr = methodTable.CanonMT;
             NonValidatedMethodTable umt = GetMethodTableData(_target, canonicalMethodTablePtr);
+            if (!umt.ValidateReadable())
+            {
+                throw new InvalidOperationException("canon MT is not readable");
+            }
             return umt.EEClass;
         }
     }

--- a/src/native/managed/cdac/tests/DumpTests/Microsoft.Diagnostics.DataContractReader.DumpTests.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Microsoft.Diagnostics.DataContractReader.DumpTests.csproj
@@ -26,6 +26,7 @@
 
   <ItemGroup>
       <Compile Include="$(LibrariesProjectRoot)Common\src\System\HResults.cs" Link="Common\System\HResults.cs" />
+      <Compile Include="..\TestHelpers.cs" Link="TestHelpers.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/native/managed/cdac/tests/DumpTests/VarargPInvokeDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/VarargPInvokeDumpTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
 using Microsoft.Diagnostics.DataContractReader.Legacy;
 using Xunit;
+using static Microsoft.Diagnostics.DataContractReader.Tests.TestHelpers;
 
 namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 
@@ -95,7 +96,7 @@ public class VarargPInvokeDumpTests : DumpTestBase
             TargetPointer mt = rts.GetMethodTable(mdHandle);
             DacpMethodTableData mtData;
             int hr = sosDac.GetMethodTableData(new ClrDataAddress(mt), &mtData);
-            Assert.Equal(HResults.S_OK, hr);
+            AssertHResult(HResults.S_OK, hr);
 
             return;
         }
@@ -135,7 +136,7 @@ public class VarargPInvokeDumpTests : DumpTestBase
                 Target, mdHandle, TargetPointer.Null, legacyImpl: null);
             uint mapNeeded;
             int hr = methodInstance.GetILAddressMap(0, &mapNeeded, null);
-            Assert.Equal(HResults.E_FAIL, hr);
+            AssertHResult(HResults.E_FAIL, hr);
 
             return;
         }

--- a/src/native/managed/cdac/tests/MethodTableTests.cs
+++ b/src/native/managed/cdac/tests/MethodTableTests.cs
@@ -3,9 +3,11 @@
 
 using System;
 using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
 using Microsoft.Diagnostics.DataContractReader.RuntimeTypeSystemHelpers;
 using Moq;
 using Xunit;
+using static Microsoft.Diagnostics.DataContractReader.Tests.TestHelpers;
 
 namespace Microsoft.Diagnostics.DataContractReader.Tests;
 
@@ -225,5 +227,115 @@ public class MethodTableTests
             Assert.Equal(arrayInstanceComponentSize, metadataContract.GetComponentSize(arrayInstanceTypeHandle));
         });
 
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public unsafe void GetMethodTableDataReturnsEInvalidArgWhenEEClassPartiallyReadable(MockTarget.Architecture arch)
+    {
+        // Reproduces the HResult mismatch from dotnet/diagnostics CI where the cDAC returned
+        // CORDBG_E_READVIRTUAL_FAILURE (0x80131c49) instead of E_INVALIDARG (0x80070057)
+        // when GetMethodTableData was called with an address whose MethodTable validation
+        // passes but subsequent EEClass reads fail.
+        TargetPointer methodTablePtr = default;
+
+        RTSContractHelper(arch,
+        (rtsBuilder) =>
+        {
+            TargetTestHelpers helpers = rtsBuilder.Builder.TargetTestHelpers;
+
+            // Create a full MethodTable that will pass validation
+            methodTablePtr = rtsBuilder.AddMethodTable("PartialEEClass MT",
+                mtflags: default, mtflags2: default, baseSize: helpers.ObjectBaseSize,
+                module: TargetPointer.Null, parentMethodTable: TargetPointer.Null,
+                numInterfaces: 0, numVirtuals: 3);
+
+            // Create a tiny EEClass fragment — only the MethodTable pointer field.
+            // Previously, validation only read NonValidatedEEClass.MethodTable (at offset 0),
+            // so this minimal fragment was sufficient for validation to pass while later
+            // EEClass reads (for MethodDescChunk, NumMethods, etc.) at subsequent offsets
+            // would fail with VirtualReadException. After the TypeValidation fix, the full
+            // EEClass is eagerly read during validation, so this now correctly reports
+            // E_INVALIDARG instead of surfacing VirtualReadException from those later reads.
+            int pointerSize = helpers.PointerSize;
+            MockMemorySpace.HeapFragment tinyEEClass = rtsBuilder.TypeSystemAllocator.Allocate(
+                (ulong)pointerSize, "Tiny EEClass (MethodTable field only)");
+            helpers.WritePointer(tinyEEClass.Data, methodTablePtr);
+            rtsBuilder.Builder.AddHeapFragment(tinyEEClass);
+
+            // Point the MethodTable's EEClassOrCanonMT at the tiny EEClass
+            rtsBuilder.SetMethodTableEEClassOrCanonMTRaw(methodTablePtr, tinyEEClass.Address);
+        },
+        (target) =>
+        {
+            ISOSDacInterface sosDac = new SOSDacImpl(target, legacyObj: null);
+
+            DacpMethodTableData mtData = default;
+            int hr = sosDac.GetMethodTableData(new ClrDataAddress(methodTablePtr), &mtData);
+
+            // Should return E_INVALIDARG to match legacy DAC behavior
+            AssertHResult(HResults.E_INVALIDARG, hr);
+        });
+    }
+
+    [Theory]
+    [ClassData(typeof(MockTarget.StdArch))]
+    public unsafe void GetMethodTableDataReturnsEInvalidArgWhenMethodTablePartiallyReadable(MockTarget.Architecture arch)
+    {
+        // Analogous to the EEClass test above but for the MethodTable itself.
+        // If a MethodTable is only partially readable (enough for validation fields
+        // like MTFlags, BaseSize, MTFlags2, EEClassOrCanonMT) but not the full
+        // structure (Module, ParentMethodTable, etc.), validation currently passes
+        // because NonValidatedMethodTable reads fields lazily. The subsequent
+        // Data.MethodTable construction then fails with VirtualReadException,
+        // surfacing CORDBG_E_READVIRTUAL_FAILURE instead of E_INVALIDARG.
+        TargetPointer tinyMethodTableAddr = default;
+
+        RTSContractHelper(arch,
+        (rtsBuilder) =>
+        {
+            TargetTestHelpers helpers = rtsBuilder.Builder.TargetTestHelpers;
+            Target.TypeInfo mtTypeInfo = rtsBuilder.Types[DataType.MethodTable];
+
+            // Create a valid EEClass that will point back to our tiny MethodTable
+            TargetPointer eeClassPtr = rtsBuilder.AddEEClass("PartialMT EEClass",
+                attr: 0, numMethods: 0, numNonVirtualSlots: 0);
+
+            // Allocate a tiny MethodTable fragment — only enough for the fields that
+            // validation reads (MTFlags, BaseSize, MTFlags2, EEClassOrCanonMT) but
+            // not the full MethodTable. Fields like Module, ParentMethodTable, etc.
+            // at subsequent offsets will be unreadable.
+            int eeClassOrCanonMTOffset = mtTypeInfo.Fields[nameof(Data.MethodTable.EEClassOrCanonMT)].Offset;
+            ulong partialSize = (ulong)(eeClassOrCanonMTOffset + helpers.PointerSize);
+            MockMemorySpace.HeapFragment tinyMT = rtsBuilder.TypeSystemAllocator.Allocate(
+                partialSize, "Tiny MethodTable (validation fields only)");
+
+            Span<byte> dest = tinyMT.Data;
+            helpers.Write(dest.Slice(mtTypeInfo.Fields[nameof(Data.MethodTable.MTFlags)].Offset), (uint)0);
+            helpers.Write(dest.Slice(mtTypeInfo.Fields[nameof(Data.MethodTable.BaseSize)].Offset), (uint)helpers.ObjectBaseSize);
+            helpers.Write(dest.Slice(mtTypeInfo.Fields[nameof(Data.MethodTable.MTFlags2)].Offset), (uint)0);
+            helpers.WritePointer(dest.Slice(eeClassOrCanonMTOffset), eeClassPtr);
+
+            rtsBuilder.Builder.AddHeapFragment(tinyMT);
+            tinyMethodTableAddr = tinyMT.Address;
+
+            // Point the EEClass back at the tiny MethodTable to pass validation
+            Target.TypeInfo eeClassTypeInfo = rtsBuilder.Types[DataType.EEClass];
+            Span<byte> eeClassBytes = rtsBuilder.Builder.BorrowAddressRange(
+                eeClassPtr, (int)eeClassTypeInfo.Size.Value);
+            helpers.WritePointer(
+                eeClassBytes.Slice(eeClassTypeInfo.Fields[nameof(Data.EEClass.MethodTable)].Offset,
+                helpers.PointerSize), tinyMethodTableAddr);
+        },
+        (target) =>
+        {
+            ISOSDacInterface sosDac = new SOSDacImpl(target, legacyObj: null);
+
+            DacpMethodTableData mtData = default;
+            int hr = sosDac.GetMethodTableData(new ClrDataAddress(tinyMethodTableAddr), &mtData);
+
+            // Should return E_INVALIDARG to match legacy DAC behavior
+            AssertHResult(HResults.E_INVALIDARG, hr);
+        });
     }
 }

--- a/src/native/managed/cdac/tests/TestHelpers.cs
+++ b/src/native/managed/cdac/tests/TestHelpers.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.Diagnostics.DataContractReader.Tests;
+
+internal static class TestHelpers
+{
+    internal static string FormatHResult(int hr)
+    {
+        string hex = $"0x{unchecked((uint)hr):X8}";
+        foreach (Type type in new[] { typeof(HResults), typeof(CorDbgHResults) })
+        {
+            foreach (FieldInfo field in type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static))
+            {
+                if (field.FieldType == typeof(int) && (int)field.GetValue(null)! == hr)
+                    return $"{field.Name} ({hex})";
+            }
+        }
+        return hex;
+    }
+
+    internal static void AssertHResult(int expected, int actual)
+    {
+        Assert.True(expected == actual,
+            $"Expected: {FormatHResult(expected)}, Actual: {FormatHResult(actual)}");
+    }
+}


### PR DESCRIPTION
Looked into the persistent CI failure and think I found the issue. It looks like SOS is calling GetMethodTableData on a random address that happens to pass validation because it has a pointer going back to the MethodTable. However, when we try to read the full EEClass it isn't available and we throw a different error.

This change should make sure the EEClass is validated and readable. Added unit test to verify.

<details>
<summary>CI Failure</summary>

```
        STDIN: 00:00.374: !runcommand !clrstack
        00:00.683: OS Thread Id: 0xb08 (0)
        00:00.692:         Child SP               IP Call Site
        00:00.692: 0000002EEDD7E9E0 00007ff99863d280 [InlinedCallFrame: 0000002eedd7e9e0] VarargPInvokeInteropMD.Interop.printf(System.String, ...)
        00:00.697: 0000002EEDD7E9E0 00007ff8e620021a [InlinedCallFrame: 0000002eedd7e9e0] VarargPInvokeInteropMD.Interop.printf(System.String, ...)
        00:00.697: 0000002EEDD7E9B0 00007FF8E620021A ILStubClass.IL_STUB_PInvoke(System.String, Int32, Double, ...)
        00:00.745: 0000002EEDD7EAD0 00007FF8E61218B0 VarargPInvokeInteropMD.Program.Main() [/_/src/tests/SOS.UnitTests/Debuggees/VarargPInvokeInteropMD/Program.cs @ 16]
        00:00.751: <END_COMMAND_OUTPUT>
        00:00.751: 0:000> 
        STDIN: 00:00.752: !runcommand !IP2MD 00007FF8E620021A
        00:00.754: MethodDesc:   00007ff8e61e7b38
        00:00.754: Method Name:          ILStubClass.IL_STUB_PInvoke(System.String, Int32, Double, ...)
        00:00.754: Class:                00007ff8e61e7ac8
        00:00.754: MethodTable:          00007ff8e61e7ac8
        00:00.754: mdToken:              0000000006000000
        00:00.754: Module:               00007ff8e61e1b00
        00:00.754: IsJitted:             yes
        00:00.754: Current CodeAddr:     00007ff8e6200040
        00:00.754: Version History:
        00:00.755:   ILCodeVersion:      0000000000000000
        00:00.755:   ReJIT ID:           0
        00:00.755:   IL Addr:            0000000000000000
        00:00.755:      CodeAddr:           00007ff8e6200040  (MinOptJitted)
        00:00.755:      NativeCodeVersion:  0000000000000000
        00:00.757: <END_COMMAND_OUTPUT>
        00:00.757: 0:000> 
        STDIN: 00:00.757: !runcommand !clru 00007ff8e61e7b38
        00:00.758: Normal JIT generated code
        00:00.758: ILStubClass.IL_STUB_PInvoke(System.String, Int32, Double, ...)
        00:00.758: Begin 00007FF8E6200040, size 279
        00:00.759: 00007ff8`e6200040 48894c2408      mov     qword ptr [rsp+8],rcx
        00:00.761: 00007ff8`e6200045 4889542410      mov     qword ptr [rsp+10h],rdx
        00:00.762: 00007ff8`e620004a 4c89442418      mov     qword ptr [rsp+18h],r8
        00:00.763: 00007ff8`e620004f 4c894c2420      mov     qword ptr [rsp+20h],r9
        00:00.764: 00007ff8`e6200054 55              push    rbp
        00:00.766: 00007ff8`e6200055 4157            push    r15
        00:00.767: 00007ff8`e6200057 4156            push    r14
        00:00.768: 00007ff8`e6200059 4155            push    r13
        00:00.769: 00007ff8`e620005b 4154            push    r12
        00:00.770: 00007ff8`e620005d 57              push    rdi
        00:00.771: 00007ff8`e620005e 56              push    rsi
        00:00.773: 00007ff8`e620005f 53              push    rbx
        00:00.774: 00007ff8`e6200060 4881ecd8000000  sub     rsp,0D8h
        00:00.775: 00007ff8`e6200067 488d6c2420      lea     rbp,[rsp+20h]
        STDERROR: 00:00.787: Process terminated. Assertion failed.
        STDERROR: 00:00.788: cDAC: 80131c49, DAC: 80070057
        STDERROR: 00:00.788:    at System.Diagnostics.DebugProvider.Fail(String, String)
        STDERROR: 00:00.788:    at System.Diagnostics.Debug.Fail(String, String)
        STDERROR: 00:00.788:    at System.Diagnostics.Debug.Assert(Boolean, String, String)
        STDERROR: 00:00.788:    at System.Diagnostics.Debug.Assert(Boolean, String)
        STDERROR: 00:00.788:    at System.Diagnostics.Debug.Assert(Boolean, Debug.AssertInterpolatedStringHandler&)
        STDERROR: 00:00.788:    at Microsoft.Diagnostics.DataContractReader.Legacy.SOSDacImpl.Microsoft.Diagnostics.DataContractReader.Legacy.ISOSDacInterface.GetMethodTableData(ClrDataAddress, DacpMethodTableData*)
        STDERROR: 00:00.788:    at <Microsoft_Diagnostics_DataContractReader_Legacy_ISOSDacInterface>F7D08DFA63EEFD39A651C932BEE9B168F60916DB84778D32AACF3004D988BD863__InterfaceImplementation.ABI_GetMethodTableData(ComWrappers.ComInterfaceDispatch*, UInt64, DacpMethodTableData*)
    }
```
</details>