### PR TITLE
Add CoreCLR runtime build for browser-wasm performance benchmarks

### DIFF
--- a/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
@@ -33,3 +33,5 @@ jobs:
           parameters:
             configForBuild: Release
             artifactName: BrowserWasmCoreCLR
+            sdkDirName: dotnet-none
+            includeRefPack: false

--- a/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
@@ -32,5 +32,4 @@ jobs:
         - template: /eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
           parameters:
             configForBuild: Release
-            runtimeFlavor: CoreCLR
             artifactName: BrowserWasmCoreCLR

--- a/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-build-jobs.yml
@@ -1,4 +1,5 @@
 jobs:
+# Build Mono runtime for browser-wasm (used by default wasm benchmarks)
 - template: /eng/pipelines/common/platform-matrix.yml
   parameters:
     jobTemplate: /eng/pipelines/common/global-build-job.yml
@@ -14,3 +15,22 @@ jobs:
         - template: /eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
           parameters:
             configForBuild: Release
+
+# Build CoreCLR runtime for browser-wasm (used by --wasm-coreclr benchmarks)
+- template: /eng/pipelines/common/platform-matrix.yml
+  parameters:
+    jobTemplate: /eng/pipelines/common/global-build-job.yml
+    buildConfig: Release
+    runtimeFlavor: coreclr
+    platforms:
+    - browser_wasm
+    jobParameters:
+      buildArgs: -s clr+libs+host+packs -c $(_BuildConfig) /p:AotHostArchitecture=x64 /p:AotHostOS=$(_hostedOS)
+      nameSuffix: wasm_coreclr
+      isOfficialBuild: false
+      postBuildSteps:
+        - template: /eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
+          parameters:
+            configForBuild: Release
+            runtimeFlavor: CoreCLR
+            artifactName: BrowserWasmCoreCLR

--- a/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
@@ -2,6 +2,8 @@ parameters:
   configForBuild: 'Release'
   artifactName: 'BrowserWasm'
   runtimeFlavor: 'mono'
+  sdkDirName: 'dotnet-latest'
+  includeRefPack: true
 
 steps:
   - script: >-
@@ -12,27 +14,21 @@ steps:
       /t:InstallWorkloadUsingArtifacts
       /bl:$(Build.SourcesDirectory)/artifacts/log/${{ parameters.configForBuild }}/InstallWorkloadUsingArtifacts.binlog
       $(Build.SourcesDirectory)/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
-    displayName: "Install ${{ parameters.runtimeFlavor }} workload using artifacts"
+    displayName: "Install workload using artifacts"
 
-  # Mono uses dotnet-latest (full SDK with workload), CoreCLR uses dotnet-none (minimal SDK)
-  - ${{ if eq(parameters.runtimeFlavor, 'mono') }}:
-    - script: cp -r $(Build.SourcesDirectory)/artifacts/bin/dotnet-latest $(Build.SourcesDirectory)/artifacts/staging
-      displayName: "Stage SDK (dotnet-latest)"
-  - ${{ if eq(parameters.runtimeFlavor, 'coreclr') }}:
-    - script: cp -r $(Build.SourcesDirectory)/artifacts/bin/dotnet-none $(Build.SourcesDirectory)/artifacts/staging
-      displayName: "Stage SDK (dotnet-none)"
-
+  # Stage artifacts: create staging/, copy SDK, runtime pack, and nugets
   - script: >-
       mkdir -p $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
+      cp -r $(Build.SourcesDirectory)/artifacts/bin/${{ parameters.sdkDirName }} $(Build.SourcesDirectory)/artifacts/staging &&
       cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm $(Build.SourcesDirectory)/artifacts/staging &&
       cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NET.Sdk.WebAssembly.Pack* $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
       cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NETCore.App.Ref* $(Build.SourcesDirectory)/artifacts/staging/built-nugets
-    displayName: "Prepare ${{ parameters.runtimeFlavor }} artifacts staging directory"
+    displayName: "Prepare artifacts staging directory"
 
   # Mono also needs the ref pack directory (CoreCLR gets it from nugets)
-  - ${{ if eq(parameters.runtimeFlavor, 'mono') }}:
+  - ${{ if eq(parameters.includeRefPack, true) }}:
     - script: cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.ref $(Build.SourcesDirectory)/artifacts/staging
-      displayName: "Stage ref pack directory (Mono)"
+      displayName: "Stage ref pack directory"
 
   - template: /eng/pipelines/common/upload-artifact-step.yml
     parameters:

--- a/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
@@ -12,27 +12,27 @@ steps:
       /t:InstallWorkloadUsingArtifacts
       /bl:$(Build.SourcesDirectory)/artifacts/log/${{ parameters.configForBuild }}/InstallWorkloadUsingArtifacts.binlog
       $(Build.SourcesDirectory)/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
-    displayName: "Install workload using artifacts"
+    displayName: "Install ${{ parameters.runtimeFlavor }} workload using artifacts"
 
-  # Mono needs full SDK + nugets; CoreCLR only needs the runtime pack
+  # Mono uses dotnet-latest (full SDK with workload), CoreCLR uses dotnet-none (minimal SDK)
   - ${{ if eq(parameters.runtimeFlavor, 'mono') }}:
-    - script: >-
-        mkdir -p $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
-        cp -r $(Build.SourcesDirectory)/artifacts/bin/dotnet-latest $(Build.SourcesDirectory)/artifacts/staging &&
-        cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm $(Build.SourcesDirectory)/artifacts/staging &&
-        cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.ref $(Build.SourcesDirectory)/artifacts/staging &&
-        cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NET.Sdk.WebAssembly.Pack* $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
-        cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NETCore.App.Ref* $(Build.SourcesDirectory)/artifacts/staging/built-nugets
-      displayName: "Prepare artifacts staging directory (Mono)"
-
+    - script: cp -r $(Build.SourcesDirectory)/artifacts/bin/dotnet-latest $(Build.SourcesDirectory)/artifacts/staging
+      displayName: "Stage SDK (dotnet-latest)"
   - ${{ if eq(parameters.runtimeFlavor, 'coreclr') }}:
-    - script: >-
-        mkdir -p $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
-        cp -r $(Build.SourcesDirectory)/artifacts/bin/dotnet-none $(Build.SourcesDirectory)/artifacts/staging &&
-        cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm $(Build.SourcesDirectory)/artifacts/staging &&
-        cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NET.Sdk.WebAssembly.Pack* $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
-        cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NETCore.App.Ref* $(Build.SourcesDirectory)/artifacts/staging/built-nugets
-      displayName: "Prepare artifacts staging directory (CoreCLR)"
+    - script: cp -r $(Build.SourcesDirectory)/artifacts/bin/dotnet-none $(Build.SourcesDirectory)/artifacts/staging
+      displayName: "Stage SDK (dotnet-none)"
+
+  - script: >-
+      mkdir -p $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
+      cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm $(Build.SourcesDirectory)/artifacts/staging &&
+      cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NET.Sdk.WebAssembly.Pack* $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
+      cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NETCore.App.Ref* $(Build.SourcesDirectory)/artifacts/staging/built-nugets
+    displayName: "Prepare ${{ parameters.runtimeFlavor }} artifacts staging directory"
+
+  # Mono also needs the ref pack directory (CoreCLR gets it from nugets)
+  - ${{ if eq(parameters.runtimeFlavor, 'mono') }}:
+    - script: cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.ref $(Build.SourcesDirectory)/artifacts/staging
+      displayName: "Stage ref pack directory (Mono)"
 
   - template: /eng/pipelines/common/upload-artifact-step.yml
     parameters:

--- a/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
@@ -1,7 +1,7 @@
 parameters:
   configForBuild: 'Release'
-  runtimeFlavor: 'Mono'
   artifactName: 'BrowserWasm'
+  runtimeFlavor: 'mono'
 
 steps:
   - script: >-
@@ -15,7 +15,7 @@ steps:
     displayName: "Install workload using artifacts"
 
   # Mono needs full SDK + nugets; CoreCLR only needs the runtime pack
-  - ${{ if eq(parameters.runtimeFlavor, 'Mono') }}:
+  - ${{ if eq(parameters.runtimeFlavor, 'mono') }}:
     - script: >-
         mkdir -p $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
         cp -r $(Build.SourcesDirectory)/artifacts/bin/dotnet-latest $(Build.SourcesDirectory)/artifacts/staging &&
@@ -25,11 +25,13 @@ steps:
         cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NETCore.App.Ref* $(Build.SourcesDirectory)/artifacts/staging/built-nugets
       displayName: "Prepare artifacts staging directory (Mono)"
 
-  - ${{ if eq(parameters.runtimeFlavor, 'CoreCLR') }}:
+  - ${{ if eq(parameters.runtimeFlavor, 'coreclr') }}:
     - script: >-
-        mkdir -p $(Build.SourcesDirectory)/artifacts/staging &&
+        mkdir -p $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
         cp -r $(Build.SourcesDirectory)/artifacts/bin/dotnet-none $(Build.SourcesDirectory)/artifacts/staging &&
-        cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm $(Build.SourcesDirectory)/artifacts/staging
+        cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm $(Build.SourcesDirectory)/artifacts/staging &&
+        cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NET.Sdk.WebAssembly.Pack* $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
+        cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NETCore.App.Ref* $(Build.SourcesDirectory)/artifacts/staging/built-nugets
       displayName: "Prepare artifacts staging directory (CoreCLR)"
 
   - template: /eng/pipelines/common/upload-artifact-step.yml

--- a/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
+++ b/eng/pipelines/performance/templates/perf-wasm-prepare-artifacts-steps.yml
@@ -1,32 +1,43 @@
 parameters:
   configForBuild: 'Release'
+  runtimeFlavor: 'Mono'
+  artifactName: 'BrowserWasm'
 
 steps:
   - script: >-
       ./dotnet.sh build -p:TargetOS=browser -p:TargetArchitecture=wasm /nr:false /p:TreatWarningsAsErrors=true
       /p:Configuration=${{ parameters.configForBuild }}
       /p:ContinuousIntegrationBuild=true
-      /p:RuntimeFlavor=Mono
+      /p:RuntimeFlavor=${{ parameters.runtimeFlavor }}
       /t:InstallWorkloadUsingArtifacts
       /bl:$(Build.SourcesDirectory)/artifacts/log/${{ parameters.configForBuild }}/InstallWorkloadUsingArtifacts.binlog
       $(Build.SourcesDirectory)/src/mono/wasm/Wasm.Build.Tests/Wasm.Build.Tests.csproj
     displayName: "Install workload using artifacts"
 
-  - script: >-
-      mkdir -p $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
-      cp -r $(Build.SourcesDirectory)/artifacts/bin/dotnet-latest $(Build.SourcesDirectory)/artifacts/staging &&
-      cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm $(Build.SourcesDirectory)/artifacts/staging &&
-      cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.ref $(Build.SourcesDirectory)/artifacts/staging &&
-      cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NET.Sdk.WebAssembly.Pack* $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
-      cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NETCore.App.Ref* $(Build.SourcesDirectory)/artifacts/staging/built-nugets
-    displayName: "Prepare artifacts staging directory"
+  # Mono needs full SDK + nugets; CoreCLR only needs the runtime pack
+  - ${{ if eq(parameters.runtimeFlavor, 'Mono') }}:
+    - script: >-
+        mkdir -p $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
+        cp -r $(Build.SourcesDirectory)/artifacts/bin/dotnet-latest $(Build.SourcesDirectory)/artifacts/staging &&
+        cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm $(Build.SourcesDirectory)/artifacts/staging &&
+        cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.ref $(Build.SourcesDirectory)/artifacts/staging &&
+        cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NET.Sdk.WebAssembly.Pack* $(Build.SourcesDirectory)/artifacts/staging/built-nugets &&
+        cp -r $(Build.SourcesDirectory)/artifacts/packages/${{ parameters.configForBuild }}/Shipping/Microsoft.NETCore.App.Ref* $(Build.SourcesDirectory)/artifacts/staging/built-nugets
+      displayName: "Prepare artifacts staging directory (Mono)"
+
+  - ${{ if eq(parameters.runtimeFlavor, 'CoreCLR') }}:
+    - script: >-
+        mkdir -p $(Build.SourcesDirectory)/artifacts/staging &&
+        cp -r $(Build.SourcesDirectory)/artifacts/bin/dotnet-none $(Build.SourcesDirectory)/artifacts/staging &&
+        cp -r $(Build.SourcesDirectory)/artifacts/bin/microsoft.netcore.app.runtime.browser-wasm $(Build.SourcesDirectory)/artifacts/staging
+      displayName: "Prepare artifacts staging directory (CoreCLR)"
 
   - template: /eng/pipelines/common/upload-artifact-step.yml
     parameters:
       rootFolder: '$(Build.SourcesDirectory)/artifacts/staging'
       includeRootFolder: true
       displayName: Browser Wasm Artifacts
-      artifactName: BrowserWasm
+      artifactName: ${{ parameters.artifactName }}
       archiveType: tar
       tarCompression: gz
       archiveExtension: '.tar.gz'


### PR DESCRIPTION
This PR adds support for building and testing CoreCLR on browser-wasm in the performance pipeline, alongside the existing Mono builds.

Changes:

Add a new build job in `perf-wasm-build-jobs.yml` for CoreCLR targeting browser_wasm with artifact name BrowserWasmCoreCLR.
Parameterize `perf-wasm-prepare-artifacts-steps.yml` with runtimeFlavor and artifactName to support both runtimes
CoreCLR artifacts are smaller (only runtime pack needed) vs Mono (full SDK + nugets)
This enables running wasm benchmarks with `--wasm-coreclr` to compare performance between the two runtimes.