### PR TITLE
[wasm][coreclr] Move DoPrestub call out of CallDescrWorkerInternal

### DIFF
--- a/src/coreclr/vm/callhelpers.cpp
+++ b/src/coreclr/vm/callhelpers.cpp
@@ -190,6 +190,11 @@ void* DispatchCallSimple(
     }
     CONTRACTL_END;
 
+#ifdef FEATURE_PORTABLE_ENTRYPOINTS
+    MethodDesc* pMethod = PortableEntryPoint::GetMethodDesc(pTargetAddress);
+    (void)pMethod->GetInterpreterCodeWithPrestub();
+#endif // FEATURE_PORTABLE_ENTRYPOINTS
+
 #ifdef DEBUGGING_SUPPORTED
     if (CORDebuggerTraceCall())
         g_pDebugInterface->TraceCall((const BYTE *)pTargetAddress);
@@ -299,6 +304,11 @@ void MethodDescCallSite::CallTargetWorker(const ARG_SLOT *pArguments, ARG_SLOT *
         PRECONDITION(m_pMD->CheckActivated());          // EnsureActive will trigger, so we must already be activated
     }
     CONTRACTL_END;
+
+#ifdef FEATURE_PORTABLE_ENTRYPOINTS
+    MethodDesc* pMethod = PortableEntryPoint::GetMethodDesc(m_pCallTarget);
+    (void)pMethod->GetInterpreterCodeWithPrestub();
+#endif // FEATURE_PORTABLE_ENTRYPOINTS
 
     // If we're invoking an CoreLib method, lift the restriction on type load limits. Calls into CoreLib are
     // typically calls into specific and controlled helper methods for security checks and other linktime tasks.

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1878,6 +1878,18 @@ public:
         _ASSERTE(dac_cast<TADDR>(m_interpreterCode) != INTERPRETER_CODE_POISON);
         VolatileStore(&m_interpreterCode, interpreterCode);
     }
+#ifdef FEATURE_PORTABLE_ENTRYPOINTS
+    const PTR_InterpByteCodeStart GetInterpreterCodeWithPrestub()
+    {
+        InterpByteCodeStart* targetIp = GetInterpreterCode();
+        if (targetIp != NULL)
+            return targetIp;
+
+        GCX_PREEMP();
+        (void)DoPrestub(NULL /* MethodTable */, CallerGCMode::Coop);
+        return GetInterpreterCode();
+    }
+#endif // FEATURE_PORTABLE_ENTRYPOINTS
 
     // Call this if the m_interpreterCode will never be set to a valid value
     void PoisonInterpreterCode()

--- a/src/coreclr/vm/wasm/calldescrworkerwasm.cpp
+++ b/src/coreclr/vm/wasm/calldescrworkerwasm.cpp
@@ -14,19 +14,9 @@ extern "C" void STDCALL CallDescrWorkerInternal(CallDescrData* pCallDescrData)
     _ASSERTE(pCallDescrData != NULL);
     _ASSERTE(pCallDescrData->pTarget != (PCODE)NULL);
 
-    // WASM-TODO: This path has a flaw. The DoPrestub call may trigger a GC, and there is no
-    // explicit protection for the arguments. All platforms assume part of the call is
-    // a no GC trigger region, but DoPrestub may trigger a GC. Therefore this needs to be
-    // revisited to ensure correctness.
-
     MethodDesc* pMethod = PortableEntryPoint::GetMethodDesc(pCallDescrData->pTarget);
     InterpByteCodeStart* targetIp = pMethod->GetInterpreterCode();
-    if (targetIp == NULL)
-    {
-        GCX_PREEMP();
-        (void)pMethod->DoPrestub(NULL /* MethodTable */, CallerGCMode::Coop);
-        targetIp = pMethod->GetInterpreterCode();
-    }
+    _ASSERTE(targetIp != nullptr);
 
     size_t argsSize = pCallDescrData->nArgsSize;
     void* retBuff;


### PR DESCRIPTION
To call it before we potentially put object references on stack, because DoPrestub can trigger GC.