### PR TITLE
Add missing GC.KeepAlives to WMIInterop

### DIFF
--- a/src/libraries/System.Management/src/System/Management/InteropClasses/WMIInterop.cs
+++ b/src/libraries/System.Management/src/System/Management/InteropClasses/WMIInterop.cs
@@ -225,6 +225,7 @@ namespace System.Management
             if (pWbemClassObject == IntPtr.Zero)
                 throw new ObjectDisposedException(name);
             int res = WmiNetUtilsHelper.CompareTo_f(16, pWbemClassObject, lFlags, pCompareTo.pWbemClassObject);
+            GC.KeepAlive(pCompareTo);
             GC.KeepAlive(this);
             return res;
         }
@@ -270,6 +271,8 @@ namespace System.Management
             if (pWbemClassObject == IntPtr.Zero)
                 throw new ObjectDisposedException(name);
             int res = WmiNetUtilsHelper.PutMethod_f(20, pWbemClassObject, wszName, lFlags, pInSignature, pOutSignature);
+            GC.KeepAlive(pInSignature);
+            GC.KeepAlive(pOutSignature);
             GC.KeepAlive(this);
             return res;
         }


### PR DESCRIPTION
Opus highlighted these as potential issues.

We pass IntPtr fields to native callbacks, but we don't root the object holding them (it's possible that it's implicitly is done by GC.KeepAlive(this), but I wasn't able to prove that).