### PR TITLE
Convert IDacDbiInterface to return HRESULT to fix cross-DSO exception handling on mobile platforms

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -2848,10 +2848,10 @@ HRESULT DacDbiInterfaceImpl::GetMethodDescParams(VMPTR_AppDomain vmAppDomain, VM
                 // Fill in the struct using the TypeHandle of the current type parameter if we can.
                 VMPTR_TypeHandle vmTypeHandle = VMPTR_TypeHandle::NullPtr();
                 vmTypeHandle.SetDacTargetPtr(thCurrent.AsTAddr());
-                TypeHandleToExpandedTypeInfo(NoValueTypeBoxing,
-                                             vmAppDomain,
-                                             vmTypeHandle,
-                                             &((*pGenericTypeParams)[i]));
+                IfFailThrow(TypeHandleToExpandedTypeInfo(NoValueTypeBoxing,
+                                                         vmAppDomain,
+                                                         vmTypeHandle,
+                                                         &((*pGenericTypeParams)[i])));
             }
             EX_CATCH_ALLOW_DATATARGET_MISSING_MEMORY_WITH_HANDLER
             {
@@ -2859,10 +2859,10 @@ HRESULT DacDbiInterfaceImpl::GetMethodDescParams(VMPTR_AppDomain vmAppDomain, VM
                 VMPTR_TypeHandle vmTHCanon = VMPTR_TypeHandle::NullPtr();
                 TypeHandle thCanon = TypeHandle(g_pCanonMethodTableClass);
                 vmTHCanon.SetDacTargetPtr(thCanon.AsTAddr());
-                TypeHandleToExpandedTypeInfo(NoValueTypeBoxing,
-                                             vmAppDomain,
-                                             vmTHCanon,
-                                             &((*pGenericTypeParams)[i]));
+                IfFailThrow(TypeHandleToExpandedTypeInfo(NoValueTypeBoxing,
+                                                         vmAppDomain,
+                                                         vmTHCanon,
+                                                         &((*pGenericTypeParams)[i])));
             }
             EX_END_CATCH_ALLOW_DATATARGET_MISSING_MEMORY_WITH_HANDLER
         }
@@ -3291,10 +3291,10 @@ HRESULT DacDbiInterfaceImpl::GetTypeHandleParams(VMPTR_AppDomain vmAppDomain, VM
             VMPTR_TypeHandle thInst = VMPTR_TypeHandle::NullPtr();
             thInst.SetDacTargetPtr(typeHandle.GetInstantiation()[i].AsTAddr());
 
-            TypeHandleToExpandedTypeInfo(NoValueTypeBoxing,
-                                         vmAppDomain,
-                                         thInst,
-                                         &((*pParams)[i]));
+            IfFailThrow(TypeHandleToExpandedTypeInfo(NoValueTypeBoxing,
+                                                     vmAppDomain,
+                                                     thInst,
+                                                     &((*pParams)[i])));
         }
 
         LOG((LF_CORDB, LL_INFO10000, "D::GTHP: sending  result"));
@@ -3448,7 +3448,9 @@ HRESULT DacDbiInterfaceImpl::GetDelegateType(VMPTR_Object delegateObject, Delega
 
 #ifdef _DEBUG
     // ensure we have a Delegate object
-    IsDelegate(delegateObject);
+    BOOL fIsDelegate = FALSE;
+    IsDelegate(delegateObject, &fIsDelegate);
+    _ASSERTE(fIsDelegate);
 #endif
 
     // Ideally, we would share the implementation of this method with the runtime, or get the same information
@@ -3530,7 +3532,9 @@ HRESULT DacDbiInterfaceImpl::GetDelegateFunctionData(
 
 #ifdef _DEBUG
     // ensure we have a Delegate object
-    IsDelegate(delegateObject);
+    BOOL fIsDelegate = FALSE;
+    IsDelegate(delegateObject, &fIsDelegate);
+    _ASSERTE(fIsDelegate);
 #endif
 
     HRESULT hr = S_OK;
@@ -3570,7 +3574,9 @@ HRESULT DacDbiInterfaceImpl::GetDelegateTargetObject(
 
 #ifdef _DEBUG
     // ensure we have a Delegate object
-    IsDelegate(delegateObject);
+    BOOL fIsDelegate = FALSE;
+    IsDelegate(delegateObject, &fIsDelegate);
+    _ASSERTE(fIsDelegate);
 #endif
 
     HRESULT hr = S_OK;
@@ -6396,7 +6402,7 @@ void DacDbiInterfaceImpl::InitObjectData(PTR_Object                objPtr,
     pObjectData->objSize = objPtr->GetSize();
     pObjectData->objOffsetToVars = dac_cast<TADDR>((objPtr)->GetData()) - dac_cast<TADDR>(objPtr);
 
-    TypeHandleToExpandedTypeInfo(AllBoxed, vmAppDomain, vmTypeHandle, &(pObjectData->objTypeData));
+    IfFailThrow(TypeHandleToExpandedTypeInfo(AllBoxed, vmAppDomain, vmTypeHandle, &(pObjectData->objTypeData)));
 
     // If this is a string object, set the type to ELEMENT_TYPE_STRING.
     if (objPtr->GetGCSafeMethodTable() == g_pStringClass)

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -436,12 +436,18 @@ interface IMDInternalImport* DacDbiInterfaceImpl::GetMDImport(
 //-----------------------------------------------------------------------------
 
 // Destroy the connection, freeing up any resources.
-void DacDbiInterfaceImpl::Destroy()
+HRESULT DacDbiInterfaceImpl::Destroy()
 {
-    m_pAllocator = NULL;
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+        m_pAllocator = NULL;
 
-    this->Release();
-    // Memory is deleted, don't access this object any more
+        this->Release();
+        // Memory is deleted, don't access this object any more
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Check whether the version of the DBI matches the version of the runtime.
@@ -483,165 +489,225 @@ HRESULT DacDbiInterfaceImpl::FlushCache()
 }
 
 // enable or disable DAC target consistency checks
-void DacDbiInterfaceImpl::DacSetTargetConsistencyChecks(bool fEnableAsserts)
+HRESULT DacDbiInterfaceImpl::DacSetTargetConsistencyChecks(bool fEnableAsserts)
 {
-    // forward on to our ClrDataAccess base class
-    ClrDataAccess::SetTargetConsistencyChecks(fEnableAsserts);
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+        // forward on to our ClrDataAccess base class
+        ClrDataAccess::SetTargetConsistencyChecks(fEnableAsserts);
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Query if Left-side is started up?
-BOOL DacDbiInterfaceImpl::IsLeftSideInitialized()
+HRESULT DacDbiInterfaceImpl::IsLeftSideInitialized(OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-    if (g_pDebugger != NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        // This check is "safe".
-        // The initialize order in the left-side is:
-        // 1) g_pDebugger is an RVA based global initialized to NULL when the module is loaded.
-        // 2) Allocate a "Debugger" object.
-        // 3) run the ctor, which will set m_fLeftSideInitialized = FALSE.
-        // 4) assign the object to g_pDebugger.
-        // 5) later, LS initialization code will assign g_pDebugger->m_fLeftSideInitialized = TRUE.
-        //
-        // The memory write in #5 is atomic.  There is no window where we're reading uninitialized data.
 
-        return (g_pDebugger->m_fLeftSideInitialized != 0);
+        if (g_pDebugger != NULL)
+        {
+            // This check is "safe".
+            // The initialize order in the left-side is:
+            // 1) g_pDebugger is an RVA based global initialized to NULL when the module is loaded.
+            // 2) Allocate a "Debugger" object.
+            // 3) run the ctor, which will set m_fLeftSideInitialized = FALSE.
+            // 4) assign the object to g_pDebugger.
+            // 5) later, LS initialization code will assign g_pDebugger->m_fLeftSideInitialized = TRUE.
+            //
+            // The memory write in #5 is atomic.  There is no window where we're reading uninitialized data.
+
+            *pResult = (g_pDebugger->m_fLeftSideInitialized != 0);
+        }
+        else
+        {
+            *pResult = FALSE;
+        }
     }
-
-    return FALSE;
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
 // Determines if a given address is a CLR stub.
-BOOL DacDbiInterfaceImpl::IsTransitionStub(CORDB_ADDRESS address)
+HRESULT DacDbiInterfaceImpl::IsTransitionStub(CORDB_ADDRESS address, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-    BOOL fIsStub = FALSE;
-
-#if defined(TARGET_UNIX)
-    // Currently IsIPInModule() is not implemented in the PAL.  Rather than skipping the check, we should
-    // either E_NOTIMPL this API or implement IsIPInModule() in the PAL.  Since ICDProcess::IsTransitionStub()
-    // is only called by VS in mixed-mode debugging scenarios, and mixed-mode debugging is not supported on
-    // POSIX systems, there is really no incentive to implement this API at this point.
-    ThrowHR(E_NOTIMPL);
-
-#else // !TARGET_UNIX
-
-    TADDR ip = (TADDR)address;
-
-    if (ip == NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        fIsStub = FALSE;
-    }
-    else
-    {
-        fIsStub = StubManager::IsStub(ip);
-    }
 
-    // If it's in Mscorwks, count that as a stub too.
-    if (fIsStub == FALSE)
-    {
-        fIsStub = IsIPInModule(m_globalBase, ip);
+        BOOL fIsStub = FALSE;
+
+    #if defined(TARGET_UNIX)
+        // Currently IsIPInModule() is not implemented in the PAL.  Rather than skipping the check, we should
+        // either E_NOTIMPL this API or implement IsIPInModule() in the PAL.  Since ICDProcess::IsTransitionStub()
+        // is only called by VS in mixed-mode debugging scenarios, and mixed-mode debugging is not supported on
+        // POSIX systems, there is really no incentive to implement this API at this point.
+        ThrowHR(E_NOTIMPL);
+
+    #else // !TARGET_UNIX
+
+        TADDR ip = (TADDR)address;
+
+        if (ip == NULL)
+        {
+            fIsStub = FALSE;
+        }
+        else
+        {
+            fIsStub = StubManager::IsStub(ip);
+        }
+
+        // If it's in Mscorwks, count that as a stub too.
+        if (fIsStub == FALSE)
+        {
+            fIsStub = IsIPInModule(m_globalBase, ip);
+        }
+
+    #endif // TARGET_UNIX
+
+        *pResult = fIsStub;
     }
-
-#endif // TARGET_UNIX
-
-    return fIsStub;
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Gets the type of 'address'.
-IDacDbiInterface::AddressType DacDbiInterfaceImpl::GetAddressType(CORDB_ADDRESS address)
+HRESULT DacDbiInterfaceImpl::GetAddressType(CORDB_ADDRESS address, OUT AddressType * pRetVal)
 {
     DD_ENTER_MAY_THROW;
-    TADDR taAddr = CORDB_ADDRESS_TO_TADDR(address);
 
-    if (IsPossibleCodeAddress(taAddr) == S_OK)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        if (ExecutionManager::IsManagedCode(taAddr))
-        {
-            return kAddressManagedMethod;
-        }
+        TADDR taAddr = CORDB_ADDRESS_TO_TADDR(address);
 
-        if (StubManager::IsStub(taAddr))
+        if (IsPossibleCodeAddress(taAddr) == S_OK)
         {
-            return kAddressRuntimeUnmanagedStub;
+            if (ExecutionManager::IsManagedCode(taAddr))
+            {
+                *pRetVal = kAddressManagedMethod;
+            }
+            else if (StubManager::IsStub(taAddr))
+            {
+                *pRetVal = kAddressRuntimeUnmanagedStub;
+            }
+            else
+            {
+                *pRetVal = kAddressUnrecognized;
+            }
+        }
+        else
+        {
+            *pRetVal = kAddressUnrecognized;
         }
     }
-
-    return kAddressUnrecognized;
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
 // Get a VM appdomain pointer that matches the appdomain ID
-VMPTR_AppDomain DacDbiInterfaceImpl::GetAppDomainFromId(ULONG appdomainId)
+HRESULT DacDbiInterfaceImpl::GetAppDomainFromId(ULONG appdomainId, OUT VMPTR_AppDomain * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    VMPTR_AppDomain vmAppDomain;
-
-    // @dbgtodo   dac support - We would like to wean ourselves off the IXClrData interfaces.
-    IXCLRDataProcess *   pDAC = this;
-    ReleaseHolder<IXCLRDataAppDomain> pDacAppDomain;
-
-    HRESULT hrStatus = pDAC->GetAppDomainByUniqueID(appdomainId, &pDacAppDomain);
-    IfFailThrow(hrStatus);
-
-    IXCLRDataAppDomain * pIAppDomain = pDacAppDomain;
-    AppDomain * pAppDomain = (static_cast<ClrDataAppDomain *> (pIAppDomain))->GetAppDomain();
-    SIMPLIFYING_ASSUMPTION(pAppDomain != NULL);
-    if (pAppDomain == NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        ThrowHR(E_FAIL); // corrupted left-side?
+
+        VMPTR_AppDomain vmAppDomain;
+
+        // @dbgtodo   dac support - We would like to wean ourselves off the IXClrData interfaces.
+        IXCLRDataProcess *   pDAC = this;
+        ReleaseHolder<IXCLRDataAppDomain> pDacAppDomain;
+
+        HRESULT hrStatus = pDAC->GetAppDomainByUniqueID(appdomainId, &pDacAppDomain);
+        IfFailThrow(hrStatus);
+
+        IXCLRDataAppDomain * pIAppDomain = pDacAppDomain;
+        AppDomain * pAppDomain = (static_cast<ClrDataAppDomain *> (pIAppDomain))->GetAppDomain();
+        SIMPLIFYING_ASSUMPTION(pAppDomain != NULL);
+        if (pAppDomain == NULL)
+        {
+            ThrowHR(E_FAIL); // corrupted left-side?
+        }
+
+        TADDR addrAppDomain = PTR_HOST_TO_TADDR(pAppDomain);
+        vmAppDomain.SetDacTargetPtr(addrAppDomain);
+
+        *pRetVal = vmAppDomain;
     }
-
-    TADDR addrAppDomain = PTR_HOST_TO_TADDR(pAppDomain);
-    vmAppDomain.SetDacTargetPtr(addrAppDomain);
-
-    return vmAppDomain;
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
 // Get the AppDomain ID for an AppDomain.
-ULONG DacDbiInterfaceImpl::GetAppDomainId(VMPTR_AppDomain   vmAppDomain)
+HRESULT DacDbiInterfaceImpl::GetAppDomainId(VMPTR_AppDomain vmAppDomain, OUT ULONG * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    if (vmAppDomain.IsNull())
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        return 0;
+
+        if (vmAppDomain.IsNull())
+        {
+            *pRetVal = 0;
+        }
+        else
+        {
+            AppDomain * pAppDomain = vmAppDomain.GetDacPtr();
+            *pRetVal = DefaultADID;
+        }
     }
-    else
-    {
-        AppDomain * pAppDomain = vmAppDomain.GetDacPtr();
-        return DefaultADID;
-    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Get the managed AppDomain object for an AppDomain.
-VMPTR_OBJECTHANDLE DacDbiInterfaceImpl::GetAppDomainObject(VMPTR_AppDomain vmAppDomain)
+HRESULT DacDbiInterfaceImpl::GetAppDomainObject(VMPTR_AppDomain vmAppDomain, OUT VMPTR_OBJECTHANDLE * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    AppDomain* pAppDomain = vmAppDomain.GetDacPtr();
-    OBJECTHANDLE hAppDomainManagedObject = pAppDomain->GetRawExposedObjectHandleForDebugger();
-    VMPTR_OBJECTHANDLE vmObj = VMPTR_OBJECTHANDLE::NullPtr();
-    vmObj.SetDacTargetPtr(hAppDomainManagedObject);
-    return vmObj;
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
+        AppDomain* pAppDomain = vmAppDomain.GetDacPtr();
+        OBJECTHANDLE hAppDomainManagedObject = pAppDomain->GetRawExposedObjectHandleForDebugger();
+        VMPTR_OBJECTHANDLE vmObj = VMPTR_OBJECTHANDLE::NullPtr();
+        vmObj.SetDacTargetPtr(hAppDomainManagedObject);
+        *pRetVal = vmObj;
+
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Get the full AD friendly name for the given EE AppDomain.
-void DacDbiInterfaceImpl::GetAppDomainFullName(
-    VMPTR_AppDomain   vmAppDomain,
-    IStringHolder *   pStrName )
+HRESULT DacDbiInterfaceImpl::GetAppDomainFullName(VMPTR_AppDomain vmAppDomain, IStringHolder * pStrName)
 {
     DD_ENTER_MAY_THROW;
-    AppDomain * pAppDomain = vmAppDomain.GetDacPtr();
 
-    // Get the AppDomain name from the VM without changing anything
-    IfFailThrow(pStrName->AssignCopy(pAppDomain->GetFriendlyName()));
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+        AppDomain * pAppDomain = vmAppDomain.GetDacPtr();
+
+        // Get the AppDomain name from the VM without changing anything
+        IfFailThrow(pStrName->AssignCopy(pAppDomain->GetFriendlyName()));
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -649,27 +715,31 @@ void DacDbiInterfaceImpl::GetAppDomainFullName(
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 // Get the values of the JIT Optimization and EnC flags.
-void DacDbiInterfaceImpl::GetCompilerFlags (
-    VMPTR_DomainAssembly vmDomainAssembly,
-    BOOL *pfAllowJITOpts,
-    BOOL *pfEnableEnC)
+HRESULT DacDbiInterfaceImpl::GetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pfAllowJITOpts, OUT BOOL * pfEnableEnC)
 {
     DD_ENTER_MAY_THROW;
 
-    DomainAssembly * pDomainAssembly = vmDomainAssembly.GetDacPtr();
-
-    if (pDomainAssembly == NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        ThrowHR(E_FAIL);
+
+        DomainAssembly * pDomainAssembly = vmDomainAssembly.GetDacPtr();
+
+        if (pDomainAssembly == NULL)
+        {
+            ThrowHR(E_FAIL);
+        }
+
+        // Get the underlying module - none of this is AppDomain specific
+        Module * pModule = pDomainAssembly->GetAssembly()->GetModule();
+        *pfAllowJITOpts = !pModule->AreJITOptimizationsDisabled();
+        *pfEnableEnC = pModule->IsEditAndContinueEnabled();
+
+
     }
-
-    // Get the underlying module - none of this is AppDomain specific
-    Module * pModule = pDomainAssembly->GetAssembly()->GetModule();
-    *pfAllowJITOpts = !pModule->AreJITOptimizationsDisabled();
-    *pfEnableEnC = pModule->IsEditAndContinueEnabled();
-
-
-} //GetCompilerFlags
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 //-----------------------------------------------------------------------------
 // Helper function for SetCompilerFlags to set EnC status.
@@ -760,27 +830,30 @@ HRESULT DacDbiInterfaceImpl::SetCompilerFlags(VMPTR_DomainAssembly vmDomainAssem
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 // Initialize the native/IL sequence points and native var info for a function.
-void DacDbiInterfaceImpl::GetNativeCodeSequencePointsAndVarInfo(VMPTR_MethodDesc  vmMethodDesc,
-                                                                CORDB_ADDRESS     startAddr,
-                                                                BOOL              fCodeAvailable,
-                                                                NativeVarData *   pNativeVarData,
-                                                                SequencePoints *  pSequencePoints)
+HRESULT DacDbiInterfaceImpl::GetNativeCodeSequencePointsAndVarInfo(VMPTR_MethodDesc vmMethodDesc, CORDB_ADDRESS startAddress, BOOL fCodeAvailable, OUT NativeVarData * pNativeVarData, OUT SequencePoints * pSequencePoints)
 {
     DD_ENTER_MAY_THROW;
 
-    _ASSERTE(!vmMethodDesc.IsNull());
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    MethodDesc * pMD = vmMethodDesc.GetDacPtr();
+        _ASSERTE(!vmMethodDesc.IsNull());
 
-    _ASSERTE(fCodeAvailable != 0);
+        MethodDesc * pMD = vmMethodDesc.GetDacPtr();
 
-    // get information about the locations of arguments and local variables
-    GetNativeVarData(pMD, startAddr, GetArgCount(pMD), pNativeVarData);
+        _ASSERTE(fCodeAvailable != 0);
 
-    // get the sequence points
-    GetSequencePoints(pMD, startAddr, pSequencePoints);
+        // get information about the locations of arguments and local variables
+        GetNativeVarData(pMD, startAddress, GetArgCount(pMD), pNativeVarData);
 
-} // GetNativeCodeSequencePointsAndVarInfo
+        // get the sequence points
+        GetSequencePoints(pMD, startAddress, pSequencePoints);
+
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 //-----------------------------------------------------------------------------
 // Get the number of fixed arguments to a function, i.e., the explicit args and the "this" pointer.
@@ -946,61 +1019,65 @@ void DacDbiInterfaceImpl::GetSequencePoints(MethodDesc *     pMethodDesc,
 // a module and a token. The info will come from a MethodDesc, if
 // one exists or from metadata.
 //
-void DacDbiInterfaceImpl::GetILCodeAndSig(VMPTR_DomainAssembly vmDomainAssembly,
-                                          mdToken          functionToken,
-                                          TargetBuffer *   pCodeInfo,
-                                          mdToken *        pLocalSigToken)
+HRESULT DacDbiInterfaceImpl::GetILCodeAndSig(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT TargetBuffer * pCodeInfo, OUT mdToken * pLocalSigToken)
 {
     DD_ENTER_MAY_THROW;
 
-    DomainAssembly * pDomainAssembly = vmDomainAssembly.GetDacPtr();
-    Module *     pModule     = pDomainAssembly->GetAssembly()->GetModule();
-    RVA          methodRVA   = 0;
-    DWORD        implFlags;
-
-    // preinitialize out params
-    pCodeInfo->Clear();
-    *pLocalSigToken = mdSignatureNil;
-
-    // Get the RVA and impl flags for this method.
-    IfFailThrow(pModule->GetMDImport()->GetMethodImplProps(functionToken,
-                                                           &methodRVA,
-                                                           &implFlags));
-
-    MethodDesc* pMethodDesc =
-        FindLoadedMethodRefOrDef(pModule, functionToken);
-
-    // If the RVA is 0 or it's native, then the method is not IL
-    if (methodRVA == 0)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        LOG((LF_CORDB,LL_INFO100000, "DDI::GICAS: Function is not IL - methodRVA == NULL!\n"));
-        // return (CORDBG_E_FUNCTION_NOT_IL);
-        // Sanity check this....
 
-        if(!pMethodDesc || !pMethodDesc->IsIL())
+        DomainAssembly * pDomainAssembly = vmDomainAssembly.GetDacPtr();
+        Module *     pModule     = pDomainAssembly->GetAssembly()->GetModule();
+        RVA          methodRVA   = 0;
+        DWORD        implFlags;
+
+        // preinitialize out params
+        pCodeInfo->Clear();
+        *pLocalSigToken = mdSignatureNil;
+
+        // Get the RVA and impl flags for this method.
+        IfFailThrow(pModule->GetMDImport()->GetMethodImplProps(functionToken,
+                                                               &methodRVA,
+                                                               &implFlags));
+
+        MethodDesc* pMethodDesc =
+            FindLoadedMethodRefOrDef(pModule, functionToken);
+
+        // If the RVA is 0 or it's native, then the method is not IL
+        if (methodRVA == 0)
         {
-            LOG((LF_CORDB,LL_INFO100000, "DDI::GICAS: And the MD agrees..\n"));
+            LOG((LF_CORDB,LL_INFO100000, "DDI::GICAS: Function is not IL - methodRVA == NULL!\n"));
+            // return (CORDBG_E_FUNCTION_NOT_IL);
+            // Sanity check this....
+
+            if(!pMethodDesc || !pMethodDesc->IsIL())
+            {
+                LOG((LF_CORDB,LL_INFO100000, "DDI::GICAS: And the MD agrees..\n"));
+                ThrowHR(CORDBG_E_FUNCTION_NOT_IL);
+            }
+            else
+            {
+                LOG((LF_CORDB,LL_INFO100000, "DDI::GICAS: But the MD says it's IL..\n"));
+            }
+
+            if (pMethodDesc != NULL && pMethodDesc->GetRVA() == 0)
+            {
+                LOG((LF_CORDB,LL_INFO100000, "DDI::GICAS: Actually, MD says RVA is 0 too - keep going...!\n"));
+            }
+        }
+        if (IsMiNative(implFlags))
+        {
+            LOG((LF_CORDB,LL_INFO100000, "DDI::GICAS: Function is not IL - IsMiNative!\n"));
             ThrowHR(CORDBG_E_FUNCTION_NOT_IL);
         }
-        else
-        {
-            LOG((LF_CORDB,LL_INFO100000, "DDI::GICAS: But the MD says it's IL..\n"));
-        }
 
-        if (pMethodDesc != NULL && pMethodDesc->GetRVA() == 0)
-        {
-            LOG((LF_CORDB,LL_INFO100000, "DDI::GICAS: Actually, MD says RVA is 0 too - keep going...!\n"));
-        }
+        *pLocalSigToken = GetILCodeAndSigHelper(pModule, pMethodDesc, functionToken, methodRVA, pCodeInfo);
+
     }
-    if (IsMiNative(implFlags))
-    {
-        LOG((LF_CORDB,LL_INFO100000, "DDI::GICAS: Function is not IL - IsMiNative!\n"));
-        ThrowHR(CORDBG_E_FUNCTION_NOT_IL);
-    }
-
-    *pLocalSigToken = GetILCodeAndSigHelper(pModule, pMethodDesc, functionToken, methodRVA, pCodeInfo);
-
-} // GetILCodeAndSig
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 #ifdef _MSC_VER
 #pragma optimize("", on)
@@ -1089,32 +1166,40 @@ mdSignature DacDbiInterfaceImpl::GetILCodeAndSigHelper(Module *       pModule,
 }
 
 
-bool DacDbiInterfaceImpl::GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly,
-                                                        DWORD &dwTimeStamp,
-                                                        DWORD &dwSize,
-                                                        IStringHolder* pStrFilename)
+HRESULT DacDbiInterfaceImpl::GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly, DWORD & dwTimeStamp, DWORD & dwImageSize, IStringHolder* pStrFilename, OUT bool * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-    DWORD dwDataSize;
-    DWORD dwRvaHint;
-    PEAssembly * pPEAssembly = vmPEAssembly.GetDacPtr();
-    _ASSERTE(pPEAssembly != NULL);
-    if (pPEAssembly == NULL)
-        return false;
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    WCHAR wszFilePath[MAX_LONGPATH] = {0};
-    DWORD cchFilePath = MAX_LONGPATH;
-    bool ret = ClrDataAccess::GetMetaDataFileInfoFromPEFile(pPEAssembly,
-                                                            dwTimeStamp,
-                                                            dwSize,
-                                                            dwDataSize,
-                                                            dwRvaHint,
-                                                            wszFilePath,
-                                                            cchFilePath);
+        DWORD dwDataSize;
+        DWORD dwRvaHint;
+        PEAssembly * pPEAssembly = vmPEAssembly.GetDacPtr();
+        _ASSERTE(pPEAssembly != NULL);
+        if (pPEAssembly == NULL)
+        {
+            *pResult = false;
+        }
+        else
+        {
+        WCHAR wszFilePath[MAX_LONGPATH] = {0};
+        DWORD cchFilePath = MAX_LONGPATH;
+        bool ret = ClrDataAccess::GetMetaDataFileInfoFromPEFile(pPEAssembly,
+                                                                dwTimeStamp,
+                                                                dwImageSize,
+                                                                dwDataSize,
+                                                                dwRvaHint,
+                                                                wszFilePath,
+                                                                cchFilePath);
 
-    pStrFilename->AssignCopy(wszFilePath);
-    return ret;
+        pStrFilename->AssignCopy(wszFilePath);
+        *pResult = ret;
+        }
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Get start addresses and sizes for hot and cold regions for a native code blob.
@@ -1172,39 +1257,44 @@ void DacDbiInterfaceImpl::GetMethodRegionInfo(MethodDesc *             pMethodDe
 // isn't currently available. In this case, all values in pCodeInfo will be
 // cleared.
 
-void DacDbiInterfaceImpl::GetNativeCodeInfo(VMPTR_DomainAssembly         vmDomainAssembly,
-                                            mdToken                  functionToken,
-                                            NativeCodeFunctionData * pCodeInfo)
+HRESULT DacDbiInterfaceImpl::GetNativeCodeInfo(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT NativeCodeFunctionData * pCodeInfo)
 {
     DD_ENTER_MAY_THROW;
 
-    _ASSERTE(pCodeInfo != NULL);
-
-    // pre-initialize:
-    pCodeInfo->Clear();
-
-    DomainAssembly * pDomainAssembly = vmDomainAssembly.GetDacPtr();
-    Module *     pModule     = pDomainAssembly->GetAssembly()->GetModule();
-
-    MethodDesc* pMethodDesc = FindLoadedMethodRefOrDef(pModule, functionToken);
-    pCodeInfo->vmNativeCodeMethodDescToken.SetHostPtr(pMethodDesc);
-
-    // if we are loading a module and trying to bind a previously set breakpoint, we may not have
-    // a method desc yet, so check for that situation
-    if(pMethodDesc != NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        GetMethodRegionInfo(pMethodDesc, pCodeInfo);
-        if (pCodeInfo->m_rgCodeRegions[kHot].pAddress != (CORDB_ADDRESS)NULL)
+
+        _ASSERTE(pCodeInfo != NULL);
+
+        // pre-initialize:
+        pCodeInfo->Clear();
+
+        DomainAssembly * pDomainAssembly = vmDomainAssembly.GetDacPtr();
+        Module *     pModule     = pDomainAssembly->GetAssembly()->GetModule();
+
+        MethodDesc* pMethodDesc = FindLoadedMethodRefOrDef(pModule, functionToken);
+        pCodeInfo->vmNativeCodeMethodDescToken.SetHostPtr(pMethodDesc);
+
+        // if we are loading a module and trying to bind a previously set breakpoint, we may not have
+        // a method desc yet, so check for that situation
+        if(pMethodDesc != NULL)
         {
-            pCodeInfo->isInstantiatedGeneric = pMethodDesc->HasClassOrMethodInstantiation();
-            LookupEnCVersions(pModule,
-                              pCodeInfo->vmNativeCodeMethodDescToken,
-                              functionToken,
-                              pCodeInfo->m_rgCodeRegions[kHot].pAddress,
-                              &(pCodeInfo->encVersion));
+            GetMethodRegionInfo(pMethodDesc, pCodeInfo);
+            if (pCodeInfo->m_rgCodeRegions[kHot].pAddress != (CORDB_ADDRESS)NULL)
+            {
+                pCodeInfo->isInstantiatedGeneric = pMethodDesc->HasClassOrMethodInstantiation();
+                LookupEnCVersions(pModule,
+                                  pCodeInfo->vmNativeCodeMethodDescToken,
+                                  functionToken,
+                                  pCodeInfo->m_rgCodeRegions[kHot].pAddress,
+                                  &(pCodeInfo->encVersion));
+            }
         }
     }
-} // GetNativeCodeInfo
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 // Gets the following information about a native code blob:
 //    - its method desc
@@ -1213,88 +1303,92 @@ void DacDbiInterfaceImpl::GetNativeCodeInfo(VMPTR_DomainAssembly         vmDomai
 //    - hot and cold region information
 //    - its module
 //    - its metadata token.
-void DacDbiInterfaceImpl::GetNativeCodeInfoForAddr(CORDB_ADDRESS            codeAddress,
-                                                   NativeCodeFunctionData * pCodeInfo,
-                                                   VMPTR_Module *           pVmModule,
-                                                   mdToken *                pFunctionToken)
+HRESULT DacDbiInterfaceImpl::GetNativeCodeInfoForAddr(CORDB_ADDRESS codeAddress, NativeCodeFunctionData * pCodeInfo, VMPTR_Module * pVmModule, mdToken * pFunctionToken)
 {
     DD_ENTER_MAY_THROW;
 
-    _ASSERTE(pCodeInfo != NULL);
-
-    if (codeAddress == (CORDB_ADDRESS)NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        // if the start address is NULL, the code isn't available yet, so just return
-        _ASSERTE(!pCodeInfo->IsValid());
-        return;
+
+        _ASSERTE(pCodeInfo != NULL);
+
+        if (codeAddress == (CORDB_ADDRESS)NULL)
+        {
+            // if the start address is NULL, the code isn't available yet, so just return
+            _ASSERTE(!pCodeInfo->IsValid());
+            return S_OK;
+        }
+
+        IJitManager::MethodRegionInfo methodRegionInfo = {(TADDR)NULL, 0, (TADDR)NULL, 0};
+        TADDR codeAddr = CORDB_ADDRESS_TO_TADDR(codeAddress);
+
+        EX_TRY_ALLOW_DATATARGET_MISSING_MEMORY
+        {
+            codeAddr = GetInterpreterCodeFromInterpreterPrecodeIfPresent(codeAddr);
+        }
+        EX_END_CATCH_ALLOW_DATATARGET_MISSING_MEMORY;
+
+    #ifdef TARGET_ARM
+        // TADDR should not have the thumb code bit set.
+        _ASSERTE((codeAddr & THUMB_CODE) == 0);
+        codeAddr &= ~THUMB_CODE;
+    #endif
+
+        EECodeInfo codeInfo(codeAddr);
+        _ASSERTE(codeInfo.IsValid());
+
+        TADDR codeStartAddr = codeInfo.GetStartAddress();
+
+        // We may not have the memory for the cold code region in a minidump.
+        // Do not fail stackwalking because of this.
+        EX_TRY_ALLOW_DATATARGET_MISSING_MEMORY
+        {
+            codeInfo.GetMethodRegionInfo(&methodRegionInfo);
+        }
+        EX_END_CATCH_ALLOW_DATATARGET_MISSING_MEMORY;
+
+        // Even if GetMethodRegionInfo() fails to retrieve the cold code region info,
+        // we should still be able to get the hot code region info.  We are counting on this for
+        // stackwalking to work in dump debugging scenarios.
+        _ASSERTE(methodRegionInfo.hotStartAddress == codeStartAddr);
+
+        // now get the rest of the region information
+        pCodeInfo->m_rgCodeRegions[kHot].Init(PCODEToPINSTR(methodRegionInfo.hotStartAddress),
+                                              (ULONG)methodRegionInfo.hotSize);
+        pCodeInfo->m_rgCodeRegions[kCold].Init(PCODEToPINSTR(methodRegionInfo.coldStartAddress),
+                                                   (ULONG)methodRegionInfo.coldSize);
+        _ASSERTE(pCodeInfo->IsValid());
+
+        VMPTR_MethodDesc vmMethodDesc;
+        vmMethodDesc.SetHostPtr(codeInfo.GetMethodDesc());
+        MethodDesc* pMethodDesc = vmMethodDesc.GetDacPtr();
+        pCodeInfo->isInstantiatedGeneric = pMethodDesc->HasClassOrMethodInstantiation();
+        pCodeInfo->vmNativeCodeMethodDescToken = vmMethodDesc;
+
+        SIZE_T unusedLatestEncVersion;
+        Module * pModule = pMethodDesc->GetModule();
+        _ASSERTE(pModule != NULL);
+        LookupEnCVersions(pModule,
+                          vmMethodDesc,
+                          pMethodDesc->GetMemberDef(),
+                          codeStartAddr,
+                          &unusedLatestEncVersion, //unused by caller
+                          &(pCodeInfo->encVersion));
+
+        if (pVmModule != NULL)
+        {
+            pVmModule->SetDacTargetPtr(dac_cast<TADDR>(pModule));
+        }
+
+        if (pFunctionToken != NULL)
+        {
+            *pFunctionToken = pMethodDesc->GetMemberDef();
+        }
     }
-
-    IJitManager::MethodRegionInfo methodRegionInfo = {(TADDR)NULL, 0, (TADDR)NULL, 0};
-    TADDR codeAddr = CORDB_ADDRESS_TO_TADDR(codeAddress);
-
-    EX_TRY_ALLOW_DATATARGET_MISSING_MEMORY
-    {
-        codeAddr = GetInterpreterCodeFromInterpreterPrecodeIfPresent(codeAddr);
-    }
-    EX_END_CATCH_ALLOW_DATATARGET_MISSING_MEMORY;
-
-#ifdef TARGET_ARM
-    // TADDR should not have the thumb code bit set.
-    _ASSERTE((codeAddr & THUMB_CODE) == 0);
-    codeAddr &= ~THUMB_CODE;
-#endif
-
-    EECodeInfo codeInfo(codeAddr);
-    _ASSERTE(codeInfo.IsValid());
-
-    TADDR codeStartAddr = codeInfo.GetStartAddress();
-
-    // We may not have the memory for the cold code region in a minidump.
-    // Do not fail stackwalking because of this.
-    EX_TRY_ALLOW_DATATARGET_MISSING_MEMORY
-    {
-        codeInfo.GetMethodRegionInfo(&methodRegionInfo);
-    }
-    EX_END_CATCH_ALLOW_DATATARGET_MISSING_MEMORY;
-
-    // Even if GetMethodRegionInfo() fails to retrieve the cold code region info,
-    // we should still be able to get the hot code region info.  We are counting on this for
-    // stackwalking to work in dump debugging scenarios.
-    _ASSERTE(methodRegionInfo.hotStartAddress == codeStartAddr);
-
-    // now get the rest of the region information
-    pCodeInfo->m_rgCodeRegions[kHot].Init(PCODEToPINSTR(methodRegionInfo.hotStartAddress),
-                                          (ULONG)methodRegionInfo.hotSize);
-    pCodeInfo->m_rgCodeRegions[kCold].Init(PCODEToPINSTR(methodRegionInfo.coldStartAddress),
-                                               (ULONG)methodRegionInfo.coldSize);
-    _ASSERTE(pCodeInfo->IsValid());
-
-    VMPTR_MethodDesc vmMethodDesc;
-    vmMethodDesc.SetHostPtr(codeInfo.GetMethodDesc());
-    MethodDesc* pMethodDesc = vmMethodDesc.GetDacPtr();
-    pCodeInfo->isInstantiatedGeneric = pMethodDesc->HasClassOrMethodInstantiation();
-    pCodeInfo->vmNativeCodeMethodDescToken = vmMethodDesc;
-
-    SIZE_T unusedLatestEncVersion;
-    Module * pModule = pMethodDesc->GetModule();
-    _ASSERTE(pModule != NULL);
-    LookupEnCVersions(pModule,
-                      vmMethodDesc,
-                      pMethodDesc->GetMemberDef(),
-                      codeStartAddr,
-                      &unusedLatestEncVersion, //unused by caller
-                      &(pCodeInfo->encVersion));
-
-    if (pVmModule != NULL)
-    {
-        pVmModule->SetDacTargetPtr(dac_cast<TADDR>(pModule));
-    }
-
-    if (pFunctionToken != NULL)
-    {
-        *pFunctionToken = pMethodDesc->GetMemberDef();
-    }
-} // GetNativeCodeInfo
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -1575,65 +1669,87 @@ void DacDbiInterfaceImpl::CollectFields(TypeHandle                   thExact,
 
 
 // Determine if a type is a ValueType
-BOOL DacDbiInterfaceImpl::IsValueType (VMPTR_TypeHandle vmTypeHandle)
+HRESULT DacDbiInterfaceImpl::IsValueType(VMPTR_TypeHandle th, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-    TypeHandle th = TypeHandle::FromPtr(vmTypeHandle.GetDacPtr());
-    return th.IsValueType();
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        TypeHandle typeHandle = TypeHandle::FromPtr(th.GetDacPtr());
+        *pResult = typeHandle.IsValueType();
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Determine if a type has generic parameters
-BOOL DacDbiInterfaceImpl::HasTypeParams (VMPTR_TypeHandle vmTypeHandle)
+HRESULT DacDbiInterfaceImpl::HasTypeParams(VMPTR_TypeHandle th, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-    TypeHandle th = TypeHandle::FromPtr(vmTypeHandle.GetDacPtr());
-    return th.ContainsGenericVariables();
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        TypeHandle typeHandle = TypeHandle::FromPtr(th.GetDacPtr());
+        *pResult = typeHandle.ContainsGenericVariables();
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // DacDbi API: Get type information for a class
-void DacDbiInterfaceImpl::GetClassInfo(VMPTR_AppDomain  vmAppDomain,
-                                       VMPTR_TypeHandle vmThExact,
-                                       ClassInfo *      pData)
+HRESULT DacDbiInterfaceImpl::GetClassInfo(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle thExact, ClassInfo * pData)
 {
     DD_ENTER_MAY_THROW;
 
-    AppDomain * pAppDomain = vmAppDomain.GetDacPtr();
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    TypeHandle  thExact;
-    TypeHandle  thApprox;
+        AppDomain * pAppDomain = vmAppDomain.GetDacPtr();
 
-    GetTypeHandles(vmThExact, vmThExact, &thExact, &thApprox);
+        TypeHandle  typeHandleExact;
+        TypeHandle  thApprox;
 
-    // initialize field count, generic args count, size and value class flag
-    InitClassData(thApprox, false, pData);
+        GetTypeHandles(thExact, thExact, &typeHandleExact, &thApprox);
 
-    if (pAppDomain != NULL)
-        CollectFields(thExact, thApprox, pAppDomain, &(pData->m_fieldList));
-} // DacDbiInterfaceImpl::GetClassInfo
+        // initialize field count, generic args count, size and value class flag
+        InitClassData(thApprox, false, pData);
+
+        if (pAppDomain != NULL)
+            CollectFields(typeHandleExact, thApprox, pAppDomain, &(pData->m_fieldList));
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 // DacDbi API: Get field information and object size for an instantiated generic type
-void DacDbiInterfaceImpl::GetInstantiationFieldInfo (VMPTR_DomainAssembly             vmDomainAssembly,
-                                                     VMPTR_TypeHandle             vmThExact,
-                                                     VMPTR_TypeHandle             vmThApprox,
-                                                     DacDbiArrayList<FieldData> * pFieldList,
-                                                     SIZE_T *                     pObjectSize)
+HRESULT DacDbiInterfaceImpl::GetInstantiationFieldInfo(VMPTR_DomainAssembly vmDomainAssembly, VMPTR_TypeHandle vmThExact, VMPTR_TypeHandle vmThApprox, OUT DacDbiArrayList<FieldData> * pFieldList, OUT SIZE_T * pObjectSize)
 {
     DD_ENTER_MAY_THROW;
 
-    TypeHandle  thExact;
-    TypeHandle  thApprox;
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    GetTypeHandles(vmThExact, vmThApprox, &thExact, &thApprox);
+        TypeHandle  thExact;
+        TypeHandle  thApprox;
 
-    *pObjectSize = thApprox.GetMethodTable()->GetNumInstanceFieldBytes();
+        GetTypeHandles(vmThExact, vmThApprox, &thExact, &thApprox);
 
-    pFieldList->Alloc(GetTotalFieldCount(thApprox));
+        *pObjectSize = thApprox.GetMethodTable()->GetNumInstanceFieldBytes();
 
-    CollectFields(thExact, thApprox, AppDomain::GetCurrentDomain(), pFieldList);
+        pFieldList->Alloc(GetTotalFieldCount(thApprox));
 
-} // DacDbiInterfaceImpl::GetInstantiationFieldInfo
+        CollectFields(thExact, thApprox, AppDomain::GetCurrentDomain(), pFieldList);
+
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 //-----------------------------------------------------------------------------------
 // DacDbiInterfaceImpl::TypeDataWalk member functions
@@ -2462,38 +2578,50 @@ void DacDbiInterfaceImpl::TypeHandleToBasicTypeInfo(TypeHandle                  
 } // DacDbiInterfaceImpl::TypeHandleToBasicTypeInfo
 
 
-void DacDbiInterfaceImpl::GetObjectExpandedTypeInfoFromID(AreValueTypesBoxed boxed,
-                                       VMPTR_AppDomain vmAppDomain,
-                                       COR_TYPEID id,
-                                       DebuggerIPCE_ExpandedTypeData *pTypeInfo)
+HRESULT DacDbiInterfaceImpl::GetObjectExpandedTypeInfoFromID(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, COR_TYPEID id, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo)
 {
     DD_ENTER_MAY_THROW;
 
-    TypeHandleToExpandedTypeInfoImpl(boxed, vmAppDomain, TypeHandle::FromPtr(TO_TADDR(id.token1)), pTypeInfo);
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        TypeHandleToExpandedTypeInfoImpl(boxed, vmAppDomain, TypeHandle::FromPtr(TO_TADDR(id.token1)), pTypeInfo);
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
-void DacDbiInterfaceImpl::GetObjectExpandedTypeInfo(AreValueTypesBoxed boxed,
-                                       VMPTR_AppDomain vmAppDomain,
-                                       CORDB_ADDRESS addr,
-                                       DebuggerIPCE_ExpandedTypeData *pTypeInfo)
+HRESULT DacDbiInterfaceImpl::GetObjectExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, CORDB_ADDRESS addr, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo)
 {
     DD_ENTER_MAY_THROW;
 
-    PTR_Object obj(TO_TADDR(addr));
-    TypeHandleToExpandedTypeInfoImpl(boxed, vmAppDomain, obj->GetGCSafeTypeHandle(), pTypeInfo);
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        PTR_Object obj(TO_TADDR(addr));
+        TypeHandleToExpandedTypeInfoImpl(boxed, vmAppDomain, obj->GetGCSafeTypeHandle(), pTypeInfo);
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // DacDbi API: use a type handle to get the information needed to create the corresponding RS CordbType instance
-void DacDbiInterfaceImpl::TypeHandleToExpandedTypeInfo(AreValueTypesBoxed              boxed,
-                                                       VMPTR_AppDomain                 vmAppDomain,
-                                                       VMPTR_TypeHandle                vmTypeHandle,
-                                                       DebuggerIPCE_ExpandedTypeData * pTypeInfo)
+HRESULT DacDbiInterfaceImpl::TypeHandleToExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, DebuggerIPCE_ExpandedTypeData * pTypeInfo)
 {
     DD_ENTER_MAY_THROW;
 
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    TypeHandle typeHandle = TypeHandle::FromPtr(vmTypeHandle.GetDacPtr());
-    TypeHandleToExpandedTypeInfoImpl(boxed, vmAppDomain, typeHandle, pTypeInfo);
+
+        TypeHandle typeHandle = TypeHandle::FromPtr(vmTypeHandle.GetDacPtr());
+        TypeHandleToExpandedTypeInfoImpl(boxed, vmAppDomain, typeHandle, pTypeInfo);
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
@@ -2546,52 +2674,65 @@ void DacDbiInterfaceImpl::TypeHandleToExpandedTypeInfoImpl(AreValueTypesBoxed   
 } // DacDbiInterfaceImpl::TypeHandleToExpandedTypeInfo
 
 // Get type handle for a TypeDef token, if one exists. For generics this returns the open type.
-VMPTR_TypeHandle DacDbiInterfaceImpl::GetTypeHandle(VMPTR_Module vmModule,
-                                                    mdTypeDef metadataToken)
+HRESULT DacDbiInterfaceImpl::GetTypeHandle(VMPTR_Module vmModule, mdTypeDef metadataToken, OUT VMPTR_TypeHandle * pRetVal)
 {
     DD_ENTER_MAY_THROW;
-    Module* pModule = vmModule.GetDacPtr();
-    VMPTR_TypeHandle vmTypeHandle = VMPTR_TypeHandle::NullPtr();
 
-    TypeHandle th = ClassLoader::LookupTypeDefOrRefInModule(pModule, metadataToken);
-    if (th.IsNull())
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        LOG((LF_CORDB, LL_INFO10000, "D::GTH: class isn't loaded.\n"));
-        ThrowHR(CORDBG_E_CLASS_NOT_LOADED);
-    }
+        Module* pModule = vmModule.GetDacPtr();
+        VMPTR_TypeHandle vmTypeHandle = VMPTR_TypeHandle::NullPtr();
 
-    vmTypeHandle.SetDacTargetPtr(th.AsTAddr());
-    return vmTypeHandle;
+        TypeHandle th = ClassLoader::LookupTypeDefOrRefInModule(pModule, metadataToken);
+        if (th.IsNull())
+        {
+            LOG((LF_CORDB, LL_INFO10000, "D::GTH: class isn't loaded.\n"));
+            ThrowHR(CORDBG_E_CLASS_NOT_LOADED);
+        }
+
+        vmTypeHandle.SetDacTargetPtr(th.AsTAddr());
+        *pRetVal = vmTypeHandle;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // DacDbi API: GetAndSendApproxTypeHandle finds the type handle for the layout of the instance fields of an
 // instantiated type if it is available.
-VMPTR_TypeHandle DacDbiInterfaceImpl::GetApproxTypeHandle(TypeInfoList * pTypeData)
+HRESULT DacDbiInterfaceImpl::GetApproxTypeHandle(TypeInfoList * pTypeData, OUT VMPTR_TypeHandle * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    LOG((LF_CORDB, LL_INFO10000, "D::GATH: getting info.\n"));
-
-
-    TypeDataWalk walk(&((*pTypeData)[0]), pTypeData->Count());
-    TypeHandle typeHandle = walk.ReadLoadedTypeHandle(TypeDataWalk::kGetCanonical);
-    VMPTR_TypeHandle vmTypeHandle = VMPTR_TypeHandle::NullPtr();
-
-    vmTypeHandle.SetDacTargetPtr(typeHandle.AsTAddr());
-    if (!typeHandle.IsNull())
+    HRESULT hr = S_OK;
+    EX_TRY
     {
+
+        LOG((LF_CORDB, LL_INFO10000, "D::GATH: getting info.\n"));
+
+
+        TypeDataWalk walk(&((*pTypeData)[0]), pTypeData->Count());
+        TypeHandle typeHandle = walk.ReadLoadedTypeHandle(TypeDataWalk::kGetCanonical);
+        VMPTR_TypeHandle vmTypeHandle = VMPTR_TypeHandle::NullPtr();
+
         vmTypeHandle.SetDacTargetPtr(typeHandle.AsTAddr());
-    }
-    else
-    {
-        ThrowHR(CORDBG_E_CLASS_NOT_LOADED);
-    }
+        if (!typeHandle.IsNull())
+        {
+            vmTypeHandle.SetDacTargetPtr(typeHandle.AsTAddr());
+        }
+        else
+        {
+            ThrowHR(CORDBG_E_CLASS_NOT_LOADED);
+        }
 
-    LOG((LF_CORDB, LL_INFO10000,
-        "D::GATH: sending result, result = 0x%0x8\n",
-        typeHandle));
-    return vmTypeHandle;
-} // DacDbiInterfaceImpl::GetApproxTypeHandle
+        LOG((LF_CORDB, LL_INFO10000,
+            "D::GATH: sending result, result = 0x%0x8\n",
+            typeHandle));
+        *pRetVal = vmTypeHandle;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 // DacDbiInterface API: Get the exact type handle from type data
 HRESULT DacDbiInterfaceImpl::GetExactTypeHandle(DebuggerIPCE_ExpandedTypeData * pTypeData,
@@ -2620,106 +2761,108 @@ HRESULT DacDbiInterfaceImpl::GetExactTypeHandle(DebuggerIPCE_ExpandedTypeData * 
 
 // Retrieve the generic type params for a given MethodDesc.  This function is specifically
 // for stackwalking because it requires the generic type token on the stack.
-void DacDbiInterfaceImpl::GetMethodDescParams(
-    VMPTR_AppDomain     vmAppDomain,
-    VMPTR_MethodDesc    vmMethodDesc,
-    GENERICS_TYPE_TOKEN genericsToken,
-    UINT32 *            pcGenericClassTypeParams,
-    TypeParamsList *    pGenericTypeParams)
+HRESULT DacDbiInterfaceImpl::GetMethodDescParams(VMPTR_AppDomain vmAppDomain, VMPTR_MethodDesc vmMethodDesc, GENERICS_TYPE_TOKEN genericsToken, OUT UINT32 * pcGenericClassTypeParams, OUT TypeParamsList * pGenericTypeParams)
 {
     DD_ENTER_MAY_THROW;
 
-    if (vmAppDomain.IsNull() || vmMethodDesc.IsNull())
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        ThrowHR(E_INVALIDARG);
+
+        if (vmAppDomain.IsNull() || vmMethodDesc.IsNull())
+        {
+            ThrowHR(E_INVALIDARG);
+        }
+
+        _ASSERTE((pcGenericClassTypeParams != NULL) && (pGenericTypeParams != NULL));
+
+        MethodDesc * pMD = vmMethodDesc.GetDacPtr();
+
+        // Retrieve the number of type parameters for the class and
+        // the number of type parameters for the method itself.
+        // For example, the method Foo<T, U>::Bar<V>() has 2 class type parameters and 1 method type parameters.
+        UINT32 cGenericClassTypeParams  = pMD->GetNumGenericClassArgs();
+        UINT32 cGenericMethodTypeParams = pMD->GetNumGenericMethodArgs();
+        UINT32 cTotalGenericTypeParams  = cGenericClassTypeParams + cGenericMethodTypeParams;
+
+        // Set the out parameter.
+        *pcGenericClassTypeParams = cGenericClassTypeParams;
+
+        TypeHandle   thSpecificClass;
+        MethodDesc * pSpecificMethod = NULL;
+
+        // Try to retrieve a more specific MethodDesc and TypeHandle via the generics type token.
+        // The generics token is not always guaranteed to be available.
+        // For example, it may be unavailable in prologs and epilogs.
+        // In dumps, not available can also mean a thrown exception for missing memory.
+        BOOL fExact = FALSE;
+        ALLOW_DATATARGET_MISSING_MEMORY(
+            fExact = Generics::GetExactInstantiationsOfMethodAndItsClassFromCallInformation(
+                pMD,
+                PTR_VOID((TADDR)genericsToken),
+                &thSpecificClass,
+                &pSpecificMethod);
+                );
+        if (!fExact ||
+            !thSpecificClass.GetMethodTable()->SanityCheck() ||
+            !pSpecificMethod->GetMethodTable()->SanityCheck())
+        {
+            // Use the canonical MethodTable and MethodDesc if the exact generics token is not available.
+            thSpecificClass = TypeHandle(pMD->GetMethodTable());
+            pSpecificMethod = pMD;
+        }
+
+        // Retrieve the array of class type parameters and the array of method type parameters.
+        Instantiation classInst  = pSpecificMethod->GetExactClassInstantiation(thSpecificClass);
+        Instantiation methodInst = pSpecificMethod->GetMethodInstantiation();
+
+        _ASSERTE((classInst.IsEmpty())  == (cGenericClassTypeParams  == 0));
+        _ASSERTE((methodInst.IsEmpty()) == (cGenericMethodTypeParams == 0));
+
+        // allocate memory for the return array
+        pGenericTypeParams->Alloc(cTotalGenericTypeParams);
+
+        for (UINT32 i = 0; i < cTotalGenericTypeParams; i++)
+        {
+            // Retrieve the current type parameter depending on the index.
+            TypeHandle thCurrent;
+            if (i < cGenericClassTypeParams)
+            {
+                thCurrent = classInst[i];
+            }
+            else
+            {
+                thCurrent = methodInst[i - cGenericClassTypeParams];
+            }
+
+            // There is the possibility that we'll get this far with a dump and not fail, but still
+            // not be able to get full info for a particular param.
+            EX_TRY_ALLOW_DATATARGET_MISSING_MEMORY_WITH_HANDLER
+            {
+                // Fill in the struct using the TypeHandle of the current type parameter if we can.
+                VMPTR_TypeHandle vmTypeHandle = VMPTR_TypeHandle::NullPtr();
+                vmTypeHandle.SetDacTargetPtr(thCurrent.AsTAddr());
+                TypeHandleToExpandedTypeInfo(NoValueTypeBoxing,
+                                             vmAppDomain,
+                                             vmTypeHandle,
+                                             &((*pGenericTypeParams)[i]));
+            }
+            EX_CATCH_ALLOW_DATATARGET_MISSING_MEMORY_WITH_HANDLER
+            {
+                // On failure for a particular type, default it back to System.__Canon.
+                VMPTR_TypeHandle vmTHCanon = VMPTR_TypeHandle::NullPtr();
+                TypeHandle thCanon = TypeHandle(g_pCanonMethodTableClass);
+                vmTHCanon.SetDacTargetPtr(thCanon.AsTAddr());
+                TypeHandleToExpandedTypeInfo(NoValueTypeBoxing,
+                                             vmAppDomain,
+                                             vmTHCanon,
+                                             &((*pGenericTypeParams)[i]));
+            }
+            EX_END_CATCH_ALLOW_DATATARGET_MISSING_MEMORY_WITH_HANDLER
+        }
     }
-
-    _ASSERTE((pcGenericClassTypeParams != NULL) && (pGenericTypeParams != NULL));
-
-    MethodDesc * pMD = vmMethodDesc.GetDacPtr();
-
-    // Retrieve the number of type parameters for the class and
-    // the number of type parameters for the method itself.
-    // For example, the method Foo<T, U>::Bar<V>() has 2 class type parameters and 1 method type parameters.
-    UINT32 cGenericClassTypeParams  = pMD->GetNumGenericClassArgs();
-    UINT32 cGenericMethodTypeParams = pMD->GetNumGenericMethodArgs();
-    UINT32 cTotalGenericTypeParams  = cGenericClassTypeParams + cGenericMethodTypeParams;
-
-    // Set the out parameter.
-    *pcGenericClassTypeParams = cGenericClassTypeParams;
-
-    TypeHandle   thSpecificClass;
-    MethodDesc * pSpecificMethod = NULL;
-
-    // Try to retrieve a more specific MethodDesc and TypeHandle via the generics type token.
-    // The generics token is not always guaranteed to be available.
-    // For example, it may be unavailable in prologs and epilogs.
-    // In dumps, not available can also mean a thrown exception for missing memory.
-    BOOL fExact = FALSE;
-    ALLOW_DATATARGET_MISSING_MEMORY(
-        fExact = Generics::GetExactInstantiationsOfMethodAndItsClassFromCallInformation(
-            pMD,
-            PTR_VOID((TADDR)genericsToken),
-            &thSpecificClass,
-            &pSpecificMethod);
-            );
-    if (!fExact ||
-        !thSpecificClass.GetMethodTable()->SanityCheck() ||
-        !pSpecificMethod->GetMethodTable()->SanityCheck())
-    {
-        // Use the canonical MethodTable and MethodDesc if the exact generics token is not available.
-        thSpecificClass = TypeHandle(pMD->GetMethodTable());
-        pSpecificMethod = pMD;
-    }
-
-    // Retrieve the array of class type parameters and the array of method type parameters.
-    Instantiation classInst  = pSpecificMethod->GetExactClassInstantiation(thSpecificClass);
-    Instantiation methodInst = pSpecificMethod->GetMethodInstantiation();
-
-    _ASSERTE((classInst.IsEmpty())  == (cGenericClassTypeParams  == 0));
-    _ASSERTE((methodInst.IsEmpty()) == (cGenericMethodTypeParams == 0));
-
-    // allocate memory for the return array
-    pGenericTypeParams->Alloc(cTotalGenericTypeParams);
-
-    for (UINT32 i = 0; i < cTotalGenericTypeParams; i++)
-    {
-        // Retrieve the current type parameter depending on the index.
-        TypeHandle thCurrent;
-        if (i < cGenericClassTypeParams)
-        {
-            thCurrent = classInst[i];
-        }
-        else
-        {
-            thCurrent = methodInst[i - cGenericClassTypeParams];
-        }
-
-        // There is the possibility that we'll get this far with a dump and not fail, but still
-        // not be able to get full info for a particular param.
-        EX_TRY_ALLOW_DATATARGET_MISSING_MEMORY_WITH_HANDLER
-        {
-            // Fill in the struct using the TypeHandle of the current type parameter if we can.
-            VMPTR_TypeHandle vmTypeHandle = VMPTR_TypeHandle::NullPtr();
-            vmTypeHandle.SetDacTargetPtr(thCurrent.AsTAddr());
-            TypeHandleToExpandedTypeInfo(NoValueTypeBoxing,
-                                         vmAppDomain,
-                                         vmTypeHandle,
-                                         &((*pGenericTypeParams)[i]));
-        }
-        EX_CATCH_ALLOW_DATATARGET_MISSING_MEMORY_WITH_HANDLER
-        {
-            // On failure for a particular type, default it back to System.__Canon.
-            VMPTR_TypeHandle vmTHCanon = VMPTR_TypeHandle::NullPtr();
-            TypeHandle thCanon = TypeHandle(g_pCanonMethodTableClass);
-            vmTHCanon.SetDacTargetPtr(thCanon.AsTAddr());
-            TypeHandleToExpandedTypeInfo(NoValueTypeBoxing,
-                                         vmAppDomain,
-                                         vmTHCanon,
-                                         &((*pGenericTypeParams)[i]));
-        }
-        EX_END_CATCH_ALLOW_DATATARGET_MISSING_MEMORY_WITH_HANDLER
-    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 //-----------------------------------------------------------------------------
@@ -3030,166 +3173,195 @@ TypeHandle DacDbiInterfaceImpl::ExpandedTypeInfoToTypeHandle(DebuggerIPCE_Expand
 //
 // This can commonly fail, in which case, it will return NULL.
 // ----------------------------------------------------------------------------
-CORDB_ADDRESS DacDbiInterfaceImpl::GetThreadStaticAddress(VMPTR_FieldDesc vmField,
-                                                          VMPTR_Thread    vmRuntimeThread)
+HRESULT DacDbiInterfaceImpl::GetThreadStaticAddress(VMPTR_FieldDesc vmField, VMPTR_Thread vmRuntimeThread, OUT CORDB_ADDRESS * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    Thread * pRuntimeThread = vmRuntimeThread.GetDacPtr();
-    PTR_FieldDesc pFieldDesc = vmField.GetDacPtr();
-    TADDR fieldAddress = (TADDR)NULL;
-
-    _ASSERTE(pRuntimeThread != NULL);
-
-    // Find out whether the field is thread local and get its address.
-    if (pFieldDesc->IsThreadStatic())
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        fieldAddress = pRuntimeThread->GetStaticFieldAddrNoCreate(pFieldDesc);
-    }
-    else
-    {
-        // In case we have more special cases added later, this will allow us to notice the need to
-        // update this function.
-        ThrowHR(E_NOTIMPL);
-    }
-    return fieldAddress;
 
-} // DacDbiInterfaceImpl::GetThreadStaticAddress
+        Thread * pRuntimeThread = vmRuntimeThread.GetDacPtr();
+        PTR_FieldDesc pFieldDesc = vmField.GetDacPtr();
+        TADDR fieldAddress = (TADDR)NULL;
+
+        _ASSERTE(pRuntimeThread != NULL);
+
+        // Find out whether the field is thread local and get its address.
+        if (pFieldDesc->IsThreadStatic())
+        {
+            fieldAddress = pRuntimeThread->GetStaticFieldAddrNoCreate(pFieldDesc);
+        }
+        else
+        {
+            // In case we have more special cases added later, this will allow us to notice the need to
+            // update this function.
+            ThrowHR(E_NOTIMPL);
+        }
+        *pRetVal = fieldAddress;
+
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
     // Get the target field address of a collectible types static.
-CORDB_ADDRESS DacDbiInterfaceImpl::GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmField,
-                                                                   VMPTR_AppDomain vmAppDomain)
+HRESULT DacDbiInterfaceImpl::GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmField, VMPTR_AppDomain vmAppDomain, OUT CORDB_ADDRESS * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    AppDomain * pAppDomain = vmAppDomain.GetDacPtr();
-    PTR_FieldDesc pFieldDesc = vmField.GetDacPtr();
-    _ASSERTE(pAppDomain != NULL);
-
-    //
-    // Verify this field is of the right type
-    //
-    if(!pFieldDesc->IsStatic() ||
-       pFieldDesc->IsSpecialStatic())
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        _ASSERTE(!"BUG: Unsupported static field type for collectible types");
+
+        AppDomain * pAppDomain = vmAppDomain.GetDacPtr();
+        PTR_FieldDesc pFieldDesc = vmField.GetDacPtr();
+        _ASSERTE(pAppDomain != NULL);
+
+        //
+        // Verify this field is of the right type
+        //
+        if(!pFieldDesc->IsStatic() ||
+           pFieldDesc->IsSpecialStatic())
+        {
+            _ASSERTE(!"BUG: Unsupported static field type for collectible types");
+        }
+
+        //
+        // Check that the data is available
+        //
+        /* TODO: Ideally we should be checking if the class is allocated first, however
+                 we don't appear to be doing this even for non-collectible statics and
+                 we have never seen an issue.
+        */
+
+        //
+        // Get the address
+        //
+        PTR_VOID base = pFieldDesc->GetBase();
+        if (base == PTR_NULL)
+        {
+            *pRetVal = PTR_HOST_TO_TADDR(NULL);
+        }
+        else
+        {
+            //
+            // Store the result and return
+            //
+            PTR_VOID addr = pFieldDesc->GetStaticAddressHandle(base);
+            *pRetVal = PTR_TO_TADDR(addr);
+        }
+
     }
-
-    //
-    // Check that the data is available
-    //
-    /* TODO: Ideally we should be checking if the class is allocated first, however
-             we don't appear to be doing this even for non-collectible statics and
-             we have never seen an issue.
-    */
-
-    //
-    // Get the address
-    //
-    PTR_VOID base = pFieldDesc->GetBase();
-    if (base == PTR_NULL)
-    {
-        return PTR_HOST_TO_TADDR(NULL);
-    }
-
-    //
-    // Store the result and return
-    //
-    PTR_VOID addr = pFieldDesc->GetStaticAddressHandle(base);
-    return PTR_TO_TADDR(addr);
-
-} // DacDbiInterfaceImpl::GetCollectibleTypeStaticAddress
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 // DacDbi API: GetTypeHandleParams
 // - gets the necessary data for a type handle, i.e. its type parameters, e.g. "String" and "List<int>" from the type handle
 //   for "Dict<String,List<int>>", and sends it back to the right side.
 // - pParams is allocated and initialized by this function
 // - This should not fail except for OOM
-void DacDbiInterfaceImpl::GetTypeHandleParams(VMPTR_AppDomain  vmAppDomain,
-                                              VMPTR_TypeHandle vmTypeHandle,
-                                              TypeParamsList * pParams)
+HRESULT DacDbiInterfaceImpl::GetTypeHandleParams(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, OUT TypeParamsList * pParams)
 {
     DD_ENTER_MAY_THROW
 
-    TypeHandle typeHandle = TypeHandle::FromPtr(vmTypeHandle.GetDacPtr());
-    LOG((LF_CORDB, LL_INFO10000, "D::GTHP: getting type parameters for 0x%08x 0x%0x8.\n",
-         vmAppDomain.GetDacPtr(), typeHandle.AsPtr()));
-
-
-    // Find the class given its type handle.
-    _ASSERTE(pParams->IsEmpty());
-    pParams->Alloc(typeHandle.GetNumGenericArgs());
-
-    // collect type information for each type parameter
-    for (unsigned int i = 0; i < pParams->Count(); ++i)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        VMPTR_TypeHandle thInst = VMPTR_TypeHandle::NullPtr();
-        thInst.SetDacTargetPtr(typeHandle.GetInstantiation()[i].AsTAddr());
 
-        TypeHandleToExpandedTypeInfo(NoValueTypeBoxing,
-                                     vmAppDomain,
-                                     thInst,
-                                     &((*pParams)[i]));
+        TypeHandle typeHandle = TypeHandle::FromPtr(vmTypeHandle.GetDacPtr());
+        LOG((LF_CORDB, LL_INFO10000, "D::GTHP: getting type parameters for 0x%08x 0x%0x8.\n",
+             vmAppDomain.GetDacPtr(), typeHandle.AsPtr()));
+
+
+        // Find the class given its type handle.
+        _ASSERTE(pParams->IsEmpty());
+        pParams->Alloc(typeHandle.GetNumGenericArgs());
+
+        // collect type information for each type parameter
+        for (unsigned int i = 0; i < pParams->Count(); ++i)
+        {
+            VMPTR_TypeHandle thInst = VMPTR_TypeHandle::NullPtr();
+            thInst.SetDacTargetPtr(typeHandle.GetInstantiation()[i].AsTAddr());
+
+            TypeHandleToExpandedTypeInfo(NoValueTypeBoxing,
+                                         vmAppDomain,
+                                         thInst,
+                                         &((*pParams)[i]));
+        }
+
+        LOG((LF_CORDB, LL_INFO10000, "D::GTHP: sending  result"));
     }
-
-    LOG((LF_CORDB, LL_INFO10000, "D::GTHP: sending  result"));
-} // DacDbiInterfaceImpl::GetTypeHandleParams
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 //-----------------------------------------------------------------------------
 // DacDbi API: GetSimpleType
 // gets the metadata token and domain file corresponding to a simple type
 //-----------------------------------------------------------------------------
-void DacDbiInterfaceImpl::GetSimpleType(VMPTR_AppDomain    vmAppDomain,
-                                        CorElementType     simpleType,
-                                        mdTypeDef         *pMetadataToken,
-                                        VMPTR_Module      *pVmModule,
-                                        VMPTR_DomainAssembly  *pVmDomainAssembly)
+HRESULT DacDbiInterfaceImpl::GetSimpleType(VMPTR_AppDomain vmAppDomain, CorElementType simpleType, OUT mdTypeDef * pMetadataToken, OUT VMPTR_Module * pVmModule, OUT VMPTR_DomainAssembly * pVmDomainAssembly)
 {
     DD_ENTER_MAY_THROW;
 
-    AppDomain *pAppDomain = vmAppDomain.GetDacPtr();
-
-    // if we fail to get either a valid type handle or module, we will want to send back
-    // a NULL domain file too, so we'll to preinitialize this here.
-    _ASSERTE(pVmDomainAssembly != NULL);
-    *pVmDomainAssembly = VMPTR_DomainAssembly::NullPtr();
-    // FindLoadedElementType will return NULL if the type hasn't been loaded yet.
-    TypeHandle typeHandle =  FindLoadedElementType(simpleType);
-
-    if (typeHandle.IsNull())
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        ThrowHR(CORDBG_E_CLASS_NOT_LOADED);
-    }
-    else
-    {
-        _ASSERTE(pMetadataToken != NULL);
-        *pMetadataToken = typeHandle.GetCl();
 
-        Module * pModule = typeHandle.GetModule();
-        if (pModule == NULL)
-            ThrowHR(CORDBG_E_TARGET_INCONSISTENT);
+        AppDomain *pAppDomain = vmAppDomain.GetDacPtr();
 
-        pVmModule->SetHostPtr(pModule);
+        // if we fail to get either a valid type handle or module, we will want to send back
+        // a NULL domain file too, so we'll to preinitialize this here.
+        _ASSERTE(pVmDomainAssembly != NULL);
+        *pVmDomainAssembly = VMPTR_DomainAssembly::NullPtr();
+        // FindLoadedElementType will return NULL if the type hasn't been loaded yet.
+        TypeHandle typeHandle =  FindLoadedElementType(simpleType);
 
-        if (pAppDomain)
+        if (typeHandle.IsNull())
         {
-            pVmDomainAssembly->SetHostPtr(pModule->GetDomainAssembly());
-            if (pVmDomainAssembly->IsNull())
-                ThrowHR(CORDBG_E_TARGET_INCONSISTENT);
+            ThrowHR(CORDBG_E_CLASS_NOT_LOADED);
         }
+        else
+        {
+            _ASSERTE(pMetadataToken != NULL);
+            *pMetadataToken = typeHandle.GetCl();
+
+            Module * pModule = typeHandle.GetModule();
+            if (pModule == NULL)
+                ThrowHR(CORDBG_E_TARGET_INCONSISTENT);
+
+            pVmModule->SetHostPtr(pModule);
+
+            if (pAppDomain)
+            {
+                pVmDomainAssembly->SetHostPtr(pModule->GetDomainAssembly());
+                if (pVmDomainAssembly->IsNull())
+                    ThrowHR(CORDBG_E_TARGET_INCONSISTENT);
+            }
+        }
+
+        LOG((LF_CORDB, LL_INFO10000, "D::STI: sending result.\n"));
     }
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
-    LOG((LF_CORDB, LL_INFO10000, "D::STI: sending result.\n"));
-} // DacDbiInterfaceImpl::GetSimpleType
-
-BOOL DacDbiInterfaceImpl::IsExceptionObject(VMPTR_Object vmObject)
+HRESULT DacDbiInterfaceImpl::IsExceptionObject(VMPTR_Object vmObject, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-    Object* objPtr = vmObject.GetDacPtr();
-    MethodTable* pMT = objPtr->GetMethodTable();
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    return IsExceptionObject(pMT);
+        Object* objPtr = vmObject.GetDacPtr();
+        MethodTable* pMT = objPtr->GetMethodTable();
+
+        *pResult = IsExceptionObject(pMT);
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 BOOL DacDbiInterfaceImpl::IsExceptionObject(MethodTable* pMT)
@@ -3234,15 +3406,26 @@ HRESULT DacDbiInterfaceImpl::GetMethodDescPtrFromIpEx(TADDR funcIp, VMPTR_Method
     return S_OK;
 }
 
-BOOL DacDbiInterfaceImpl::IsDelegate(VMPTR_Object vmObject)
+HRESULT DacDbiInterfaceImpl::IsDelegate(VMPTR_Object vmObject, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-    if (vmObject.IsNull())
-        return FALSE;
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    Object *pObj = vmObject.GetDacPtr();
-    return pObj->GetGCSafeMethodTable()->IsDelegate();
+        if (vmObject.IsNull())
+        {
+            *pResult = FALSE;
+        }
+        else
+        {
+            Object *pObj = vmObject.GetDacPtr();
+            *pResult = pObj->GetGCSafeMethodTable()->IsDelegate();
+        }
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
@@ -3537,52 +3720,59 @@ HRESULT DacDbiInterfaceImpl::GetLoaderHeapMemoryRanges(DacDbiArrayList<COR_MEMOR
     return hr;
 }
 
-void DacDbiInterfaceImpl::GetStackFramesFromException(VMPTR_Object vmObject, DacDbiArrayList<DacExceptionCallStackData>& dacStackFrames)
+HRESULT DacDbiInterfaceImpl::GetStackFramesFromException(VMPTR_Object vmObject, DacDbiArrayList<DacExceptionCallStackData>& dacStackFrames)
 {
     DD_ENTER_MAY_THROW;
 
-    PTR_Object objPtr = vmObject.GetDacPtr();
-
-#ifdef _DEBUG
-    // ensure we have an Exception object
-    MethodTable* pMT = objPtr->GetMethodTable();
-    _ASSERTE(IsExceptionObject(pMT));
-#endif
-
-    OBJECTREF objRef = ObjectToOBJECTREF(objPtr);
-
-    DebugStackTrace::GetStackFramesData stackFramesData;
-
-    stackFramesData.pDomain = NULL;
-    stackFramesData.NumFramesRequested = 0;
-
-    DebugStackTrace::GetStackFramesFromException(&objRef, &stackFramesData);
-
-    INT32 dacStackFramesLength = stackFramesData.cElements;
-
-    if (dacStackFramesLength > 0)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        dacStackFrames.Alloc(dacStackFramesLength);
 
-        for (INT32 index = 0; index < dacStackFramesLength; ++index)
+        PTR_Object objPtr = vmObject.GetDacPtr();
+
+    #ifdef _DEBUG
+        // ensure we have an Exception object
+        MethodTable* pMT = objPtr->GetMethodTable();
+        _ASSERTE(IsExceptionObject(pMT));
+    #endif
+
+        OBJECTREF objRef = ObjectToOBJECTREF(objPtr);
+
+        DebugStackTrace::GetStackFramesData stackFramesData;
+
+        stackFramesData.pDomain = NULL;
+        stackFramesData.NumFramesRequested = 0;
+
+        DebugStackTrace::GetStackFramesFromException(&objRef, &stackFramesData);
+
+        INT32 dacStackFramesLength = stackFramesData.cElements;
+
+        if (dacStackFramesLength > 0)
         {
-            DebugStackTrace::Element const& currentElement = stackFramesData.pElements[index];
-            DacExceptionCallStackData& currentFrame = dacStackFrames[index];
+            dacStackFrames.Alloc(dacStackFramesLength);
 
-            AppDomain* pDomain = AppDomain::GetCurrentDomain();
-            _ASSERTE(pDomain != NULL);
+            for (INT32 index = 0; index < dacStackFramesLength; ++index)
+            {
+                DebugStackTrace::Element const& currentElement = stackFramesData.pElements[index];
+                DacExceptionCallStackData& currentFrame = dacStackFrames[index];
 
-            Module* pModule = currentElement.pFunc->GetModule();
-            DomainAssembly* pDomainAssembly = pModule->GetDomainAssembly();
-            _ASSERTE(pDomainAssembly != NULL);
+                AppDomain* pDomain = AppDomain::GetCurrentDomain();
+                _ASSERTE(pDomain != NULL);
 
-            currentFrame.vmAppDomain.SetHostPtr(pDomain);
-            currentFrame.vmDomainAssembly.SetHostPtr(pDomainAssembly);
-            currentFrame.ip = currentElement.ip;
-            currentFrame.methodDef = currentElement.pFunc->GetMemberDef();
-            currentFrame.isLastForeignExceptionFrame = (currentElement.flags & STEF_LAST_FRAME_FROM_FOREIGN_STACK_TRACE) != 0;
+                Module* pModule = currentElement.pFunc->GetModule();
+                DomainAssembly* pDomainAssembly = pModule->GetDomainAssembly();
+                _ASSERTE(pDomainAssembly != NULL);
+
+                currentFrame.vmAppDomain.SetHostPtr(pDomain);
+                currentFrame.vmDomainAssembly.SetHostPtr(pDomainAssembly);
+                currentFrame.ip = currentElement.ip;
+                currentFrame.methodDef = currentElement.pFunc->GetMemberDef();
+                currentFrame.isLastForeignExceptionFrame = (currentElement.flags & STEF_LAST_FRAME_FROM_FOREIGN_STACK_TRACE) != 0;
+            }
         }
     }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 #ifdef FEATURE_COMINTEROP
@@ -3610,74 +3800,96 @@ PTR_RCW GetRcwFromVmptrObject(VMPTR_Object vmObject)
 
 #endif
 
-BOOL DacDbiInterfaceImpl::IsRcw(VMPTR_Object vmObject)
+HRESULT DacDbiInterfaceImpl::IsRcw(VMPTR_Object vmObject, OUT BOOL * pResult)
 {
 #ifdef FEATURE_COMINTEROP
     DD_ENTER_MAY_THROW;
-    return GetRcwFromVmptrObject(vmObject) != NULL;
+
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+        *pResult = GetRcwFromVmptrObject(vmObject) != NULL;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 #else
-    return FALSE;
+    *pResult = FALSE;
+    return S_OK;
 #endif // FEATURE_COMINTEROP
-
 }
 
-void DacDbiInterfaceImpl::GetRcwCachedInterfaceTypes(
-                        VMPTR_Object vmObject,
-                        VMPTR_AppDomain vmAppDomain,
-                        BOOL bIInspectableOnly,
-                        DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pDacInterfaces)
+HRESULT DacDbiInterfaceImpl::GetRcwCachedInterfaceTypes(VMPTR_Object vmObject, VMPTR_AppDomain vmAppDomain, BOOL bIInspectableOnly, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pDacInterfaces)
 {
-    // Legacy WinRT API.
-    pDacInterfaces->Alloc(0);
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+        // Legacy WinRT API.
+        pDacInterfaces->Alloc(0);
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
-void DacDbiInterfaceImpl::GetRcwCachedInterfacePointers(
-                    VMPTR_Object vmObject,
-                    BOOL bIInspectableOnly,
-                    DacDbiArrayList<CORDB_ADDRESS> * pDacItfPtrs)
+HRESULT DacDbiInterfaceImpl::GetRcwCachedInterfacePointers(VMPTR_Object vmObject, BOOL bIInspectableOnly, OUT DacDbiArrayList<CORDB_ADDRESS> * pDacItfPtrs)
 {
 #ifdef FEATURE_COMINTEROP
 
     DD_ENTER_MAY_THROW;
 
-    Object* objPtr = vmObject.GetDacPtr();
-
-    InlineSArray<TADDR, INTERFACE_ENTRY_CACHE_SIZE> rgUnks;
-
-    PTR_RCW pRCW = GetRcwFromVmptrObject(vmObject);
-    if (pRCW != NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        pRCW->GetCachedInterfacePointers(bIInspectableOnly, &rgUnks);
 
-        pDacItfPtrs->Alloc(rgUnks.GetCount());
+        Object* objPtr = vmObject.GetDacPtr();
 
-        for (COUNT_T i = 0; i < rgUnks.GetCount(); ++i)
+        InlineSArray<TADDR, INTERFACE_ENTRY_CACHE_SIZE> rgUnks;
+
+        PTR_RCW pRCW = GetRcwFromVmptrObject(vmObject);
+        if (pRCW != NULL)
         {
-            (*pDacItfPtrs)[i] = (CORDB_ADDRESS)(rgUnks[i]);
+            pRCW->GetCachedInterfacePointers(bIInspectableOnly, &rgUnks);
+
+            pDacItfPtrs->Alloc(rgUnks.GetCount());
+
+            for (COUNT_T i = 0; i < rgUnks.GetCount(); ++i)
+            {
+                (*pDacItfPtrs)[i] = (CORDB_ADDRESS)(rgUnks[i]);
+            }
+
         }
-
+        else
+        {
+            pDacItfPtrs->Alloc(0);
+        }
     }
-    else
+    EX_CATCH_HRESULT(hr);
+    return hr;
+#else
+    pDacItfPtrs->Alloc(0);
+    return S_OK;
 #endif // FEATURE_COMINTEROP
+}
+
+HRESULT DacDbiInterfaceImpl::GetCachedWinRTTypesForIIDs(VMPTR_AppDomain vmAppDomain, DacDbiArrayList<GUID> & iids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes)
+{
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        pDacItfPtrs->Alloc(0);
+        pTypes->Alloc(0);
     }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
-void DacDbiInterfaceImpl::GetCachedWinRTTypesForIIDs(
-                    VMPTR_AppDomain vmAppDomain,
-					DacDbiArrayList<GUID> & iids,
-    				OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes)
+HRESULT DacDbiInterfaceImpl::GetCachedWinRTTypes(VMPTR_AppDomain vmAppDomain, OUT DacDbiArrayList<GUID> * piids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes)
 {
-    pTypes->Alloc(0);
-}
-
-void DacDbiInterfaceImpl::GetCachedWinRTTypes(
-                    VMPTR_AppDomain vmAppDomain,
-                    OUT DacDbiArrayList<GUID> * pGuids,
-                    OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes)
-{
-    pTypes->Alloc(0);
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+        pTypes->Alloc(0);
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 //-----------------------------------------------------------------------------
@@ -3849,171 +4061,226 @@ void DacDbiInterfaceImpl::InitFieldData(const FieldDesc *           pFD,
 // GENERICS: TODO: this method will need to be modified if we ever support EnC on
 // generic classes.
 //-----------------------------------------------------------------------------
-void DacDbiInterfaceImpl::GetEnCHangingFieldInfo(const EnCHangingFieldInfo * pEnCFieldInfo,
-                                                 FieldData *           pFieldData,
-                                                 BOOL *                pfStatic)
+HRESULT DacDbiInterfaceImpl::GetEnCHangingFieldInfo(const EnCHangingFieldInfo * pEnCFieldInfo, OUT FieldData * pFieldData, OUT BOOL * pfStatic)
 {
     DD_ENTER_MAY_THROW;
 
-    LOG((LF_CORDB, LL_INFO100000, "DDI::IEnCHFI: Obj:0x%x, objType"
-        ":0x%x, offset:0x%x\n", pEnCFieldInfo->m_pObject, pEnCFieldInfo->m_objectTypeData.elementType,
-        pEnCFieldInfo->m_offsetToVars));
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    FieldDesc *  pFD      = NULL;
-    PTR_CBYTE    pORField = NULL;
+        LOG((LF_CORDB, LL_INFO100000, "DDI::IEnCHFI: Obj:0x%x, objType"
+            ":0x%x, offset:0x%x\n", pEnCFieldInfo->m_pObject, pEnCFieldInfo->m_objectTypeData.elementType,
+            pEnCFieldInfo->m_offsetToVars));
 
-    pFD = GetEnCFieldDesc(pEnCFieldInfo);
-    _ASSERTE(pFD->IsEnCNew()); // We shouldn't be here if it wasn't added to an
-                               // already loaded class.
+        FieldDesc *  pFD      = NULL;
+        PTR_CBYTE    pORField = NULL;
 
-#ifdef FEATURE_METADATA_UPDATER
-    pORField = GetPtrToEnCField(pFD, pEnCFieldInfo);
-#else
-    _ASSERTE(!"We shouldn't be here: EnC not supported");
-#endif // FEATURE_METADATA_UPDATER
+        pFD = GetEnCFieldDesc(pEnCFieldInfo);
+        _ASSERTE(pFD->IsEnCNew()); // We shouldn't be here if it wasn't added to an
+                                   // already loaded class.
 
-    InitFieldData(pFD, pORField, pEnCFieldInfo, pFieldData);
-    *pfStatic = (pFD->IsStatic() != 0);
+    #ifdef FEATURE_METADATA_UPDATER
+        pORField = GetPtrToEnCField(pFD, pEnCFieldInfo);
+    #else
+        _ASSERTE(!"We shouldn't be here: EnC not supported");
+    #endif // FEATURE_METADATA_UPDATER
 
-} // DacDbiInterfaceImpl::GetEnCHangingFieldInfo
+        InitFieldData(pFD, pORField, pEnCFieldInfo, pFieldData);
+        *pfStatic = (pFD->IsStatic() != 0);
+
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
-void DacDbiInterfaceImpl::GetAssemblyFromDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, VMPTR_Assembly *vmAssembly)
+HRESULT DacDbiInterfaceImpl::GetAssemblyFromDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Assembly * vmAssembly)
 {
     DD_ENTER_MAY_THROW;
 
-    _ASSERTE(vmAssembly != NULL);
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    DomainAssembly * pDomainAssembly = vmDomainAssembly.GetDacPtr();
-    vmAssembly->SetHostPtr(pDomainAssembly->GetAssembly());
+        _ASSERTE(vmAssembly != NULL);
+
+        DomainAssembly * pDomainAssembly = vmDomainAssembly.GetDacPtr();
+        vmAssembly->SetHostPtr(pDomainAssembly->GetAssembly());
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Determines whether the runtime security system has assigned full-trust to this assembly.
-BOOL DacDbiInterfaceImpl::IsAssemblyFullyTrusted(VMPTR_DomainAssembly vmDomainAssembly)
+HRESULT DacDbiInterfaceImpl::IsAssemblyFullyTrusted(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-    return TRUE;
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        *pResult = TRUE;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Get the full path and file name to the assembly's manifest module.
-BOOL DacDbiInterfaceImpl::GetAssemblyPath(
-    VMPTR_Assembly  vmAssembly,
-    IStringHolder * pStrFilename)
+HRESULT DacDbiInterfaceImpl::GetAssemblyPath(VMPTR_Assembly vmAssembly, IStringHolder * pStrFilename, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-    // Get the manifest module for this assembly
-    Assembly * pAssembly = vmAssembly.GetDacPtr();
-    Module * pManifestModule = pAssembly->GetModule();
-
-    // Get the path for the manifest module.
-    // since we no longer support Win9x, we assume all paths will be in unicode format already
-    const WCHAR * szPath = pManifestModule->GetPath().DacGetRawUnicode();
-    HRESULT hrStatus = pStrFilename->AssignCopy(szPath);
-    IfFailThrow(hrStatus);
-
-    if(szPath == NULL || *szPath=='\0')
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        // The asembly has no (and will never have a) file name, but we didn't really fail
-        return FALSE;
-    }
 
-    return TRUE;
+        // Get the manifest module for this assembly
+        Assembly * pAssembly = vmAssembly.GetDacPtr();
+        Module * pManifestModule = pAssembly->GetModule();
+
+        // Get the path for the manifest module.
+        // since we no longer support Win9x, we assume all paths will be in unicode format already
+        const WCHAR * szPath = pManifestModule->GetPath().DacGetRawUnicode();
+        HRESULT hrStatus = pStrFilename->AssignCopy(szPath);
+        IfFailThrow(hrStatus);
+
+        if(szPath == NULL || *szPath=='\0')
+        {
+            // The asembly has no (and will never have a) file name, but we didn't really fail
+            *pResult = FALSE;
+        }
+        else
+        {
+            *pResult = TRUE;
+        }
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // DAC/DBI API
 // Get a resolved type def from a type ref. The type ref may come from a module other than the
 // referencing module.
-void DacDbiInterfaceImpl::ResolveTypeReference(const TypeRefData * pTypeRefInfo,
-                                               TypeRefData *       pTargetRefInfo)
+HRESULT DacDbiInterfaceImpl::ResolveTypeReference(const TypeRefData * pTypeRefInfo, TypeRefData * pTargetRefInfo)
 {
     DD_ENTER_MAY_THROW;
-    DomainAssembly * pDomainAssembly        = pTypeRefInfo->vmDomainAssembly.GetDacPtr();
-    Module *     pReferencingModule = pDomainAssembly->GetAssembly()->GetModule();
-    BOOL         fSuccess = FALSE;
 
-    // Resolve the type ref
-    // g_pEEInterface->FindLoadedClass is almost what we want, but it isn't guaranteed to work if
-    // the typeRef was originally loaded from a different assembly.  Also, we need to ensure that
-    // we can resolve even unloaded types in fully loaded assemblies, so APIs such as
-    // LoadTypeDefOrRefThrowing aren't acceptable.
-
-    Module * pTargetModule = NULL;
-    mdTypeDef targetTypeDef = mdTokenNil;
-
-    // The loader won't need to trigger a GC or throw because we've told it not to load anything
-    ENABLE_FORBID_GC_LOADER_USE_IN_THIS_SCOPE();
-
-    fSuccess = ClassLoader::ResolveTokenToTypeDefThrowing(pReferencingModule,
-                                                          pTypeRefInfo->typeToken,
-                                                          &pTargetModule,
-                                                          &targetTypeDef,
-                                                          Loader::SafeLookup   //don't load, no locks/allocations
-                                                          );
-    if (fSuccess)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        _ASSERTE(pTargetModule != NULL);
-        _ASSERTE( TypeFromToken(targetTypeDef) == mdtTypeDef );
+        DomainAssembly * pDomainAssembly        = pTypeRefInfo->vmDomainAssembly.GetDacPtr();
+        Module *     pReferencingModule = pDomainAssembly->GetAssembly()->GetModule();
+        BOOL         fSuccess = FALSE;
 
-        pTargetRefInfo->vmDomainAssembly.SetDacTargetPtr(PTR_HOST_TO_TADDR(pTargetModule->GetDomainAssembly()));
-        pTargetRefInfo->typeToken = targetTypeDef;
+        // Resolve the type ref
+        // g_pEEInterface->FindLoadedClass is almost what we want, but it isn't guaranteed to work if
+        // the typeRef was originally loaded from a different assembly.  Also, we need to ensure that
+        // we can resolve even unloaded types in fully loaded assemblies, so APIs such as
+        // LoadTypeDefOrRefThrowing aren't acceptable.
+
+        Module * pTargetModule = NULL;
+        mdTypeDef targetTypeDef = mdTokenNil;
+
+        // The loader won't need to trigger a GC or throw because we've told it not to load anything
+        ENABLE_FORBID_GC_LOADER_USE_IN_THIS_SCOPE();
+
+        fSuccess = ClassLoader::ResolveTokenToTypeDefThrowing(pReferencingModule,
+                                                              pTypeRefInfo->typeToken,
+                                                              &pTargetModule,
+                                                              &targetTypeDef,
+                                                              Loader::SafeLookup   //don't load, no locks/allocations
+                                                              );
+        if (fSuccess)
+        {
+            _ASSERTE(pTargetModule != NULL);
+            _ASSERTE( TypeFromToken(targetTypeDef) == mdtTypeDef );
+
+            pTargetRefInfo->vmDomainAssembly.SetDacTargetPtr(PTR_HOST_TO_TADDR(pTargetModule->GetDomainAssembly()));
+            pTargetRefInfo->typeToken = targetTypeDef;
+        }
+        else
+        {
+            // failed - presumably because the target assembly isn't loaded
+            ThrowHR(CORDBG_E_CLASS_NOT_LOADED);
+        }
     }
-    else
-    {
-        // failed - presumably because the target assembly isn't loaded
-        ThrowHR(CORDBG_E_CLASS_NOT_LOADED);
-    }
-} // DacDbiInterfaceImpl::ResolveTypeReference
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 
 // Get the full path and file name to the module (if any).
-BOOL DacDbiInterfaceImpl::GetModulePath(VMPTR_Module vmModule,
-                                        IStringHolder *  pStrFilename)
+HRESULT DacDbiInterfaceImpl::GetModulePath(VMPTR_Module vmModule, IStringHolder * pStrFilename, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-    Module * pModule = vmModule.GetDacPtr();
-    PEAssembly * pPEAssembly = pModule->GetPEAssembly();
-    if (pPEAssembly != NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        if( !pPEAssembly->GetPath().IsEmpty() )
+
+        Module * pModule = vmModule.GetDacPtr();
+        PEAssembly * pPEAssembly = pModule->GetPEAssembly();
+        if (pPEAssembly != NULL)
         {
-            // Module has an on-disk path
-            const WCHAR * szPath = pPEAssembly->GetPath().DacGetRawUnicode();
-            if (szPath == NULL)
+            if( !pPEAssembly->GetPath().IsEmpty() )
             {
-                szPath = pPEAssembly->GetModuleFileNameHint().DacGetRawUnicode();
+                // Module has an on-disk path
+                const WCHAR * szPath = pPEAssembly->GetPath().DacGetRawUnicode();
                 if (szPath == NULL)
                 {
-                    goto NoFileName;
+                    szPath = pPEAssembly->GetModuleFileNameHint().DacGetRawUnicode();
+                }
+                if (szPath != NULL)
+                {
+                    IfFailThrow(pStrFilename->AssignCopy(szPath));
+                    *pResult = TRUE;
+                }
+                else
+                {
+                    IfFailThrow(pStrFilename->AssignCopy(W("")));
+                    *pResult = FALSE;
                 }
             }
-            IfFailThrow(pStrFilename->AssignCopy(szPath));
-            return TRUE;
+            else
+            {
+                IfFailThrow(pStrFilename->AssignCopy(W("")));
+                *pResult = FALSE;
+            }
+        }
+        else
+        {
+            // no filename
+            IfFailThrow(pStrFilename->AssignCopy(W("")));
+            *pResult = FALSE;
         }
     }
-
-NoFileName:
-    // no filename
-    IfFailThrow(pStrFilename->AssignCopy(W("")));
-    return FALSE;
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Implementation of IDacDbiInterface::GetModuleSimpleName
-void DacDbiInterfaceImpl::GetModuleSimpleName(VMPTR_Module vmModule, IStringHolder * pStrFilename)
+HRESULT DacDbiInterfaceImpl::GetModuleSimpleName(VMPTR_Module vmModule, IStringHolder * pStrFilename)
 {
     DD_ENTER_MAY_THROW;
 
-    _ASSERTE(pStrFilename != NULL);
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    Module * pModule = vmModule.GetDacPtr();
-    LPCUTF8 szNameUtf8 = pModule->GetSimpleName();
+        _ASSERTE(pStrFilename != NULL);
 
-    SString convert(SString::Utf8, szNameUtf8);
-    IfFailThrow(pStrFilename->AssignCopy(convert.GetUnicode()));
+        Module * pModule = vmModule.GetDacPtr();
+        LPCUTF8 szNameUtf8 = pModule->GetSimpleName();
+
+        SString convert(SString::Utf8, szNameUtf8);
+        IfFailThrow(pStrFilename->AssignCopy(convert.GetUnicode()));
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 HRESULT DacDbiInterfaceImpl::IsModuleMapped(VMPTR_Module pModule, OUT BOOL *isModuleMapped)
@@ -4040,14 +4307,21 @@ HRESULT DacDbiInterfaceImpl::IsModuleMapped(VMPTR_Module pModule, OUT BOOL *isMo
     return hr;
 }
 
-bool DacDbiInterfaceImpl::MetadataUpdatesApplied()
+HRESULT DacDbiInterfaceImpl::MetadataUpdatesApplied(OUT bool * pResult)
 {
     DD_ENTER_MAY_THROW;
-#ifdef FEATURE_METADATA_UPDATER
-    return g_metadataUpdatesApplied;
-#else
-    return false;
-#endif
+
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+    #ifdef FEATURE_METADATA_UPDATER
+        *pResult = g_metadataUpdatesApplied;
+    #else
+        *pResult = false;
+    #endif
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Helper to initialize a TargetBuffer from a MemoryRange
@@ -4104,267 +4378,326 @@ void InitTargetBufferFromTargetSBuffer(PTR_SBuffer pBuffer, TargetBuffer * pTarg
 
 
 // Implementation of IDacDbiInterface::GetMetadata
-void DacDbiInterfaceImpl::GetMetadata(VMPTR_Module vmModule, TargetBuffer * pTargetBuffer)
+HRESULT DacDbiInterfaceImpl::GetMetadata(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer)
 {
     DD_ENTER_MAY_THROW;
 
-    pTargetBuffer->Clear();
-
-    Module     * pModule = vmModule.GetDacPtr();
-
-    // Target should only be asking about modules that are visible to debugger.
-    _ASSERTE(pModule->IsVisibleToDebugger());
-
-    // For dynamic modules, metadata is stored as an eagerly-serialized buffer hanging off the Reflection Module.
-    if (pModule->IsReflectionEmit())
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        // Here is the fetch.
-        ReflectionModule * pReflectionModule = pModule->GetReflectionModule();
 
-        TADDR metadataBuffer = pReflectionModule->GetDynamicMetadataBuffer();
-        CORDB_ADDRESS addr = PTR_TO_CORDB_ADDRESS(metadataBuffer + offsetof(DynamicMetadata, Data));
-        pTargetBuffer->Init(addr, dac_cast<DPTR(DynamicMetadata)>(metadataBuffer)->Size);
+        pTargetBuffer->Clear();
+
+        Module     * pModule = vmModule.GetDacPtr();
+
+        // Target should only be asking about modules that are visible to debugger.
+        _ASSERTE(pModule->IsVisibleToDebugger());
+
+        // For dynamic modules, metadata is stored as an eagerly-serialized buffer hanging off the Reflection Module.
+        if (pModule->IsReflectionEmit())
+        {
+            // Here is the fetch.
+            ReflectionModule * pReflectionModule = pModule->GetReflectionModule();
+
+            TADDR metadataBuffer = pReflectionModule->GetDynamicMetadataBuffer();
+            CORDB_ADDRESS addr = PTR_TO_CORDB_ADDRESS(metadataBuffer + offsetof(DynamicMetadata, Data));
+            pTargetBuffer->Init(addr, dac_cast<DPTR(DynamicMetadata)>(metadataBuffer)->Size);
+        }
+        else
+        {
+            PEAssembly * pPEAssembly = pModule->GetPEAssembly();
+
+            // For non-dynamic modules, metadata is in the pe-image.
+            COUNT_T size;
+            CORDB_ADDRESS address = PTR_TO_CORDB_ADDRESS(dac_cast<TADDR>(pPEAssembly->GetLoadedMetadata(&size)));
+
+            pTargetBuffer->Init(address, (ULONG) size);
+        }
+
+        if (pTargetBuffer->IsEmpty())
+        {
+            // We never expect this to happen in a well-behaved scenario. But just in case.
+            ThrowHR(CORDBG_E_MISSING_METADATA);
+        }
+
     }
-    else
-    {
-        PEAssembly * pPEAssembly = pModule->GetPEAssembly();
-
-        // For non-dynamic modules, metadata is in the pe-image.
-        COUNT_T size;
-        CORDB_ADDRESS address = PTR_TO_CORDB_ADDRESS(dac_cast<TADDR>(pPEAssembly->GetLoadedMetadata(&size)));
-
-        pTargetBuffer->Init(address, (ULONG) size);
-    }
-
-    if (pTargetBuffer->IsEmpty())
-    {
-        // We never expect this to happen in a well-behaved scenario. But just in case.
-        ThrowHR(CORDBG_E_MISSING_METADATA);
-    }
-
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Implementation of IDacDbiInterface::GetSymbolsBuffer
-void DacDbiInterfaceImpl::GetSymbolsBuffer(VMPTR_Module vmModule, TargetBuffer * pTargetBuffer, SymbolFormat * pSymbolFormat)
+HRESULT DacDbiInterfaceImpl::GetSymbolsBuffer(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer, OUT SymbolFormat * pSymbolFormat)
 {
     DD_ENTER_MAY_THROW;
 
-    pTargetBuffer->Clear();
-    *pSymbolFormat = kSymbolFormatNone;
-
-    Module * pModule = vmModule.GetDacPtr();
-
-    // Target should only be asking about modules that are visible to debugger.
-    _ASSERTE(pModule->IsVisibleToDebugger());
-
-    PTR_CGrowableStream pStream = pModule->GetInMemorySymbolStream();
-    if (pStream == NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        // Common case is to not have PDBs in-memory.
-        return;
-    }
 
-    const MemoryRange m = pStream->GetRawBuffer();
-    if (m.Size() == 0)
-    {
-        // We may be prepared to store symbols (in some particular format) but none are there yet.
-        // We treat this the same as not having any symbols above.
-        return;
-    }
-    InitTargetBufferFromMemoryRange(m, pTargetBuffer);
+        pTargetBuffer->Clear();
+        *pSymbolFormat = kSymbolFormatNone;
 
-    *pSymbolFormat = kSymbolFormatPDB;
+        Module * pModule = vmModule.GetDacPtr();
+
+        // Target should only be asking about modules that are visible to debugger.
+        _ASSERTE(pModule->IsVisibleToDebugger());
+
+        PTR_CGrowableStream pStream = pModule->GetInMemorySymbolStream();
+        if (pStream == NULL)
+        {
+            // Common case is to not have PDBs in-memory.
+            return hr;
+        }
+
+        const MemoryRange m = pStream->GetRawBuffer();
+        if (m.Size() == 0)
+        {
+            // We may be prepared to store symbols (in some particular format) but none are there yet.
+            // We treat this the same as not having any symbols above.
+            return hr;
+        }
+        InitTargetBufferFromMemoryRange(m, pTargetBuffer);
+
+        *pSymbolFormat = kSymbolFormatPDB;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
 
-void DacDbiInterfaceImpl::GetModuleForDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Module * pModule)
+HRESULT DacDbiInterfaceImpl::GetModuleForDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Module * pModule)
 {
     DD_ENTER_MAY_THROW;
 
-    _ASSERTE(pModule != NULL);
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    DomainAssembly * pDomainAssembly = vmDomainAssembly.GetDacPtr();
-    pModule->SetHostPtr(pDomainAssembly->GetAssembly()->GetModule());
+        _ASSERTE(pModule != NULL);
+
+        DomainAssembly * pDomainAssembly = vmDomainAssembly.GetDacPtr();
+        pModule->SetHostPtr(pDomainAssembly->GetAssembly()->GetModule());
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
 // Implement IDacDbiInterface::GetDomainAssemblyData
-void DacDbiInterfaceImpl::GetDomainAssemblyData(VMPTR_DomainAssembly vmDomainAssembly, DomainAssemblyInfo * pData)
+HRESULT DacDbiInterfaceImpl::GetDomainAssemblyData(VMPTR_DomainAssembly vmDomainAssembly, OUT DomainAssemblyInfo * pData)
 {
     DD_ENTER_MAY_THROW;
 
-    _ASSERTE(pData != NULL);
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    ZeroMemory(pData, sizeof(*pData));
+        _ASSERTE(pData != NULL);
 
-    DomainAssembly * pDomainAssembly  = vmDomainAssembly.GetDacPtr();
+        ZeroMemory(pData, sizeof(*pData));
 
-    // @dbgtodo - is this efficient DAC usage (perhaps a dac-cop rule)? Are we round-tripping the pointer?
-    pData->vmDomainAssembly.SetHostPtr(pDomainAssembly);
-    pData->vmAppDomain.SetHostPtr(AppDomain::GetCurrentDomain());
+        DomainAssembly * pDomainAssembly  = vmDomainAssembly.GetDacPtr();
+
+        // @dbgtodo - is this efficient DAC usage (perhaps a dac-cop rule)? Are we round-tripping the pointer?
+        pData->vmDomainAssembly.SetHostPtr(pDomainAssembly);
+        pData->vmAppDomain.SetHostPtr(AppDomain::GetCurrentDomain());
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Implement IDacDbiInterface::GetModuleData
-void DacDbiInterfaceImpl::GetModuleData(VMPTR_Module vmModule, ModuleInfo * pData)
+HRESULT DacDbiInterfaceImpl::GetModuleData(VMPTR_Module vmModule, OUT ModuleInfo * pData)
 {
     DD_ENTER_MAY_THROW;
 
-    _ASSERTE(pData != NULL);
-
-    ZeroMemory(pData, sizeof(*pData));
-
-    Module     * pModule      = vmModule.GetDacPtr();
-    PEAssembly * pPEAssembly        = pModule->GetPEAssembly();
-
-    pData->vmPEAssembly.SetHostPtr(pPEAssembly);
-    pData->vmAssembly.SetHostPtr(pModule->GetAssembly());
-
-    // Is it dynamic?
-    BOOL fIsDynamic = pModule->IsReflectionEmit();
-    pData->fIsDynamic = fIsDynamic;
-
-    // Get PE BaseAddress and Size
-    // For dynamic modules, these are 0. Else,
-    pData->pPEBaseAddress = (CORDB_ADDRESS)NULL;
-    pData->nPESize = 0;
-
-    if (!fIsDynamic)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        COUNT_T size = 0;
-        pData->pPEBaseAddress = PTR_TO_TADDR(pPEAssembly->GetDebuggerContents(&size));
-        pData->nPESize = (ULONG) size;
-    }
 
-    // In-memory is determined by whether the module has a filename.
-    pData->fInMemory = FALSE;
-    if (pPEAssembly != NULL)
-    {
-        pData->fInMemory = pPEAssembly->GetPath().IsEmpty();
+        _ASSERTE(pData != NULL);
+
+        ZeroMemory(pData, sizeof(*pData));
+
+        Module     * pModule      = vmModule.GetDacPtr();
+        PEAssembly * pPEAssembly        = pModule->GetPEAssembly();
+
+        pData->vmPEAssembly.SetHostPtr(pPEAssembly);
+        pData->vmAssembly.SetHostPtr(pModule->GetAssembly());
+
+        // Is it dynamic?
+        BOOL fIsDynamic = pModule->IsReflectionEmit();
+        pData->fIsDynamic = fIsDynamic;
+
+        // Get PE BaseAddress and Size
+        // For dynamic modules, these are 0. Else,
+        pData->pPEBaseAddress = (CORDB_ADDRESS)NULL;
+        pData->nPESize = 0;
+
+        if (!fIsDynamic)
+        {
+            COUNT_T size = 0;
+            pData->pPEBaseAddress = PTR_TO_TADDR(pPEAssembly->GetDebuggerContents(&size));
+            pData->nPESize = (ULONG) size;
+        }
+
+        // In-memory is determined by whether the module has a filename.
+        pData->fInMemory = FALSE;
+        if (pPEAssembly != NULL)
+        {
+            pData->fInMemory = pPEAssembly->GetPath().IsEmpty();
+        }
     }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
 // Enumerate all AppDomains in the process.
-void DacDbiInterfaceImpl::EnumerateAppDomains(
-    FP_APPDOMAIN_ENUMERATION_CALLBACK fpCallback,
-    void * pUserData)
+HRESULT DacDbiInterfaceImpl::EnumerateAppDomains(FP_APPDOMAIN_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
 {
     DD_ENTER_MAY_THROW;
 
-    _ASSERTE(fpCallback != NULL);
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    // It's critical that we don't yield appdomains after the unload event has been sent.
-    // See code:IDacDbiInterface#Enumeration for details.
-    AppDomain * pAppDomain = AppDomain::GetCurrentDomain();
+        _ASSERTE(fpCallback != NULL);
 
-    VMPTR_AppDomain vmAppDomain = VMPTR_AppDomain::NullPtr();
-    vmAppDomain.SetHostPtr(pAppDomain);
-    fpCallback(vmAppDomain, pUserData);
+        // It's critical that we don't yield appdomains after the unload event has been sent.
+        // See code:IDacDbiInterface#Enumeration for details.
+        AppDomain * pAppDomain = AppDomain::GetCurrentDomain();
+
+        VMPTR_AppDomain vmAppDomain = VMPTR_AppDomain::NullPtr();
+        vmAppDomain.SetHostPtr(pAppDomain);
+        fpCallback(vmAppDomain, pUserData);
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Enumerate all Assemblies in an appdomain.
-void  DacDbiInterfaceImpl::EnumerateAssembliesInAppDomain(
-    VMPTR_AppDomain vmAppDomain,
-    FP_ASSEMBLY_ENUMERATION_CALLBACK fpCallback,
-    void * pUserData
-)
+HRESULT DacDbiInterfaceImpl::EnumerateAssembliesInAppDomain(VMPTR_AppDomain vmAppDomain, FP_ASSEMBLY_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
 {
     DD_ENTER_MAY_THROW;
 
-    _ASSERTE(fpCallback != NULL);
-
-    // Iterate through all Assemblies (including shared) in the appdomain.
-    AppDomain::AssemblyIterator iterator;
-
-    // If the containing appdomain is unloading, then don't enumerate any assemblies
-    // in the domain. This is to enforce rules at code:IDacDbiInterface#Enumeration.
-    // See comment in code:DacDbiInterfaceImpl::EnumerateModulesInAssembly code for details.
-    AppDomain * pAppDomain = vmAppDomain.GetDacPtr();
-
-    if (pAppDomain == nullptr)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        return;
+
+        _ASSERTE(fpCallback != NULL);
+
+        // Iterate through all Assemblies (including shared) in the appdomain.
+        AppDomain::AssemblyIterator iterator;
+
+        // If the containing appdomain is unloading, then don't enumerate any assemblies
+        // in the domain. This is to enforce rules at code:IDacDbiInterface#Enumeration.
+        // See comment in code:DacDbiInterfaceImpl::EnumerateModulesInAssembly code for details.
+        AppDomain * pAppDomain = vmAppDomain.GetDacPtr();
+
+        if (pAppDomain == nullptr)
+        {
+            return hr;
+        }
+
+        // Pass the magical flags to the loader enumerator to get all Execution-only assemblies.
+        iterator = pAppDomain->IterateAssembliesEx((AssemblyIterationFlags)(kIncludeLoading | kIncludeLoaded | kIncludeExecution));
+        CollectibleAssemblyHolder<Assembly *> pAssembly;
+
+        while (iterator.Next(pAssembly.This()))
+        {
+            VMPTR_DomainAssembly vmDomainAssembly = VMPTR_DomainAssembly::NullPtr();
+            vmDomainAssembly.SetHostPtr(pAssembly->GetDomainAssembly());
+
+            fpCallback(vmDomainAssembly, pUserData);
+        }
     }
-
-    // Pass the magical flags to the loader enumerator to get all Execution-only assemblies.
-    iterator = pAppDomain->IterateAssembliesEx((AssemblyIterationFlags)(kIncludeLoading | kIncludeLoaded | kIncludeExecution));
-    CollectibleAssemblyHolder<Assembly *> pAssembly;
-
-    while (iterator.Next(pAssembly.This()))
-    {
-        VMPTR_DomainAssembly vmDomainAssembly = VMPTR_DomainAssembly::NullPtr();
-        vmDomainAssembly.SetHostPtr(pAssembly->GetDomainAssembly());
-
-        fpCallback(vmDomainAssembly, pUserData);
-    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Implementation of IDacDbiInterface::EnumerateModulesInAssembly,
 // Enumerate all the modules (non-resource) in an assembly.
-void DacDbiInterfaceImpl::EnumerateModulesInAssembly(
-    VMPTR_DomainAssembly vmAssembly,
-    FP_MODULE_ENUMERATION_CALLBACK fpCallback,
-    void * pUserData)
+HRESULT DacDbiInterfaceImpl::EnumerateModulesInAssembly(VMPTR_DomainAssembly vmAssembly, FP_MODULE_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
 {
     DD_ENTER_MAY_THROW;
 
-    _ASSERTE(fpCallback != NULL);
-
-    DomainAssembly * pDomainAssembly = vmAssembly.GetDacPtr();
-
-    // Debugger isn't notified of Resource / Inspection-only modules.
-    if (pDomainAssembly->GetAssembly()->GetModule()->IsVisibleToDebugger())
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        // If domain assembly isn't yet loaded, just return
-        if (!pDomainAssembly->GetAssembly()->IsLoaded())
-            return;
 
-        VMPTR_DomainAssembly vmDomainAssembly = VMPTR_DomainAssembly::NullPtr();
-        vmDomainAssembly.SetHostPtr(pDomainAssembly);
+        _ASSERTE(fpCallback != NULL);
 
-        fpCallback(vmDomainAssembly, pUserData);
+        DomainAssembly * pDomainAssembly = vmAssembly.GetDacPtr();
+
+        // Debugger isn't notified of Resource / Inspection-only modules.
+        if (pDomainAssembly->GetAssembly()->GetModule()->IsVisibleToDebugger())
+        {
+            // If domain assembly isn't yet loaded, just return
+            if (!pDomainAssembly->GetAssembly()->IsLoaded())
+                return hr;
+
+            VMPTR_DomainAssembly vmDomainAssembly = VMPTR_DomainAssembly::NullPtr();
+            vmDomainAssembly.SetHostPtr(pDomainAssembly);
+
+            fpCallback(vmDomainAssembly, pUserData);
+        }
     }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Implementation of IDacDbiInterface::ResolveAssembly
 // Returns NULL if not found.
-VMPTR_DomainAssembly DacDbiInterfaceImpl::ResolveAssembly(
-    VMPTR_DomainAssembly vmScope,
-    mdToken tkAssemblyRef)
+HRESULT DacDbiInterfaceImpl::ResolveAssembly(VMPTR_DomainAssembly vmScope, mdToken tkAssemblyRef, OUT VMPTR_DomainAssembly * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-
-    DomainAssembly * pDomainAssembly  = vmScope.GetDacPtr();
-    Module     * pModule      = pDomainAssembly->GetAssembly()->GetModule();
-
-    VMPTR_DomainAssembly vmDomainAssembly = VMPTR_DomainAssembly::NullPtr();
-
-    Assembly * pAssembly = pModule->LookupAssemblyRef(tkAssemblyRef);
-    if (pAssembly != NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        DomainAssembly * pDomainAssembly = pAssembly->GetDomainAssembly();
-        vmDomainAssembly.SetHostPtr(pDomainAssembly);
+
+
+        DomainAssembly * pDomainAssembly  = vmScope.GetDacPtr();
+        Module     * pModule      = pDomainAssembly->GetAssembly()->GetModule();
+
+        VMPTR_DomainAssembly vmDomainAssembly = VMPTR_DomainAssembly::NullPtr();
+
+        Assembly * pAssembly = pModule->LookupAssemblyRef(tkAssemblyRef);
+        if (pAssembly != NULL)
+        {
+            DomainAssembly * pDomainAssembly = pAssembly->GetDomainAssembly();
+            vmDomainAssembly.SetHostPtr(pDomainAssembly);
+        }
+        *pRetVal = vmDomainAssembly;
     }
-    return vmDomainAssembly;
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // When stopped at an event, request a synchronization.
 // See DacDbiInterface.h for full comments
-void DacDbiInterfaceImpl::RequestSyncAtEvent()
+HRESULT DacDbiInterfaceImpl::RequestSyncAtEvent()
 {
     DD_ENTER_MAY_THROW;
 
-    // To request a sync, we just need to set g_pDebugger->m_RSRequestedSync high.
-    if (g_pDebugger != NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        TADDR addr = PTR_HOST_MEMBER_TADDR(Debugger, g_pDebugger, m_RSRequestedSync);
 
-        BOOL fTrue = TRUE;
-        SafeWriteStructOrThrow<BOOL>(addr, &fTrue);
+        // To request a sync, we just need to set g_pDebugger->m_RSRequestedSync high.
+        if (g_pDebugger != NULL)
+        {
+            TADDR addr = PTR_HOST_MEMBER_TADDR(Debugger, g_pDebugger, m_RSRequestedSync);
 
+            BOOL fTrue = TRUE;
+            SafeWriteStructOrThrow<BOOL>(addr, &fTrue);
+
+        }
     }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 HRESULT DacDbiInterfaceImpl::SetSendExceptionsOutsideOfJMC(BOOL sendExceptionsOutsideOfJMC)
@@ -4386,102 +4719,130 @@ HRESULT DacDbiInterfaceImpl::SetSendExceptionsOutsideOfJMC(BOOL sendExceptionsOu
 
 // Notify the debuggee that a debugger attach is pending.
 // See DacDbiInterface.h for full comments
-void DacDbiInterfaceImpl::MarkDebuggerAttachPending()
+HRESULT DacDbiInterfaceImpl::MarkDebuggerAttachPending()
 {
     DD_ENTER_MAY_THROW;
 
-    if (g_pDebugger != NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        DWORD flags = g_CORDebuggerControlFlags;
-        flags |= DBCF_PENDING_ATTACH;
 
-        // Uses special DAC writing. PTR_TO_TADDR doesn't fetch for globals.
-        // @dbgtodo  dac support - the exact mechanism of writing to the target needs to be flushed out,
-        // especially as it relates to DAC cop and enforcing undac-ized writes.
-        g_CORDebuggerControlFlags = flags;
+        if (g_pDebugger != NULL)
+        {
+            DWORD flags = g_CORDebuggerControlFlags;
+            flags |= DBCF_PENDING_ATTACH;
+
+            // Uses special DAC writing. PTR_TO_TADDR doesn't fetch for globals.
+            // @dbgtodo  dac support - the exact mechanism of writing to the target needs to be flushed out,
+            // especially as it relates to DAC cop and enforcing undac-ized writes.
+            g_CORDebuggerControlFlags = flags;
+        }
+        else
+        {
+            // Caller should have guaranteed that the LS is loaded.
+            // If we're detaching, then don't throw because we don't care.
+            ThrowHR(CORDBG_E_NOTREADY);
+        }
     }
-    else
-    {
-        // Caller should have guaranteed that the LS is loaded.
-        // If we're detaching, then don't throw because we don't care.
-        ThrowHR(CORDBG_E_NOTREADY);
-    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
 // Notify the debuggee that a debugger is attached.
 // See DacDbiInterface.h for full comments
-void DacDbiInterfaceImpl::MarkDebuggerAttached(BOOL fAttached)
+HRESULT DacDbiInterfaceImpl::MarkDebuggerAttached(BOOL fAttached)
 {
     DD_ENTER_MAY_THROW;
 
-    if (g_pDebugger != NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        // To be attached, we need to set the following
-        //   g_CORDebuggerControlFlags |= DBCF_ATTACHED;
-        // To detach (if !fAttached), we need to do the opposite.
 
-        DWORD flags = g_CORDebuggerControlFlags;
-        if (fAttached)
+        if (g_pDebugger != NULL)
         {
-            flags |= DBCF_ATTACHED;
+            // To be attached, we need to set the following
+            //   g_CORDebuggerControlFlags |= DBCF_ATTACHED;
+            // To detach (if !fAttached), we need to do the opposite.
+
+            DWORD flags = g_CORDebuggerControlFlags;
+            if (fAttached)
+            {
+                flags |= DBCF_ATTACHED;
+            }
+            else
+            {
+                flags &= ~ (DBCF_ATTACHED | DBCF_PENDING_ATTACH);
+            }
+
+            // Uses special DAC writing. PTR_TO_TADDR doesn't fetch for globals.
+            // @dbgtodo  dac support - the exact mechanism of writing to the target needs to be flushed out,
+            // especially as it relates to DAC cop and enforcing undac-ized writes.
+            g_CORDebuggerControlFlags = flags;
         }
-        else
+        else if (fAttached)
         {
-            flags &= ~ (DBCF_ATTACHED | DBCF_PENDING_ATTACH);
+            // Caller should have guaranteed that the LS is loaded.
+            // If we're detaching, then don't throw because we don't care.
+            ThrowHR(CORDBG_E_NOTREADY);
         }
 
-        // Uses special DAC writing. PTR_TO_TADDR doesn't fetch for globals.
-        // @dbgtodo  dac support - the exact mechanism of writing to the target needs to be flushed out,
-        // especially as it relates to DAC cop and enforcing undac-ized writes.
-        g_CORDebuggerControlFlags = flags;
     }
-    else if (fAttached)
-    {
-        // Caller should have guaranteed that the LS is loaded.
-        // If we're detaching, then don't throw because we don't care.
-        ThrowHR(CORDBG_E_NOTREADY);
-    }
-
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
 
 // Enumerate all threads in the process.
-void DacDbiInterfaceImpl::EnumerateThreads(FP_THREAD_ENUMERATION_CALLBACK fpCallback, void * pUserData)
+HRESULT DacDbiInterfaceImpl::EnumerateThreads(FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
 {
     DD_ENTER_MAY_THROW;
 
-    if (ThreadStore::s_pThreadStore == NULL)
-    {
-        return;
-    }
-
-    Thread *pThread = ThreadStore::GetThreadList(NULL);
-
-    while (pThread != NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
 
-        // Don't want to publish threads via enumeration before they're ready to be inspected.
-        // Use the same window that we used in whidbey.
-        Thread::ThreadState threadState = pThread->GetSnapshotState();
-        if (!((IsThreadMarkedDeadWorker(pThread)) || (threadState & Thread::TS_Unstarted)))
+        if (ThreadStore::s_pThreadStore == NULL)
         {
-            VMPTR_Thread vmThread = VMPTR_Thread::NullPtr();
-            vmThread.SetHostPtr(pThread);
-            fpCallback(vmThread, pUserData);
+            return hr;
         }
 
-        pThread = ThreadStore::GetThreadList(pThread);
+        Thread *pThread = ThreadStore::GetThreadList(NULL);
+
+        while (pThread != NULL)
+        {
+
+            // Don't want to publish threads via enumeration before they're ready to be inspected.
+            // Use the same window that we used in whidbey.
+            Thread::ThreadState threadState = pThread->GetSnapshotState();
+            if (!((IsThreadMarkedDeadWorker(pThread)) || (threadState & Thread::TS_Unstarted)))
+            {
+                VMPTR_Thread vmThread = VMPTR_Thread::NullPtr();
+                vmThread.SetHostPtr(pThread);
+                fpCallback(vmThread, pUserData);
+            }
+
+            pThread = ThreadStore::GetThreadList(pThread);
+        }
     }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // public implementation of IsThreadMarkedDead
-bool DacDbiInterfaceImpl::IsThreadMarkedDead(VMPTR_Thread vmThread)
+HRESULT DacDbiInterfaceImpl::IsThreadMarkedDead(VMPTR_Thread vmThread, OUT bool * pResult)
 {
     DD_ENTER_MAY_THROW;
-    Thread * pThread = vmThread.GetDacPtr();
-    return IsThreadMarkedDeadWorker(pThread);
+
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+        Thread * pThread = vmThread.GetDacPtr();
+        *pResult = IsThreadMarkedDeadWorker(pThread);
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Private worker for IsThreadMarkedDead
@@ -4508,231 +4869,322 @@ bool DacDbiInterfaceImpl::IsThreadMarkedDeadWorker(Thread * pThread)
 
 
 // Return the handle of the specified thread.
-HANDLE DacDbiInterfaceImpl::GetThreadHandle(VMPTR_Thread vmThread)
+HRESULT DacDbiInterfaceImpl::GetThreadHandle(VMPTR_Thread vmThread, OUT HANDLE * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    Thread * pThread = vmThread.GetDacPtr();
-    return pThread->GetThreadHandle();
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        Thread * pThread = vmThread.GetDacPtr();
+        *pRetVal = pThread->GetThreadHandle();
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Return the object handle for the managed Thread object corresponding to the specified thread.
-VMPTR_OBJECTHANDLE DacDbiInterfaceImpl::GetThreadObject(VMPTR_Thread vmThread)
+HRESULT DacDbiInterfaceImpl::GetThreadObject(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    Thread * pThread = vmThread.GetDacPtr();
-    Thread::ThreadState threadState = pThread->GetSnapshotState();
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    if ( (threadState & Thread::TS_Dead) ||
-         (threadState & Thread::TS_Unstarted) ||
-         (threadState & Thread::TS_Detached) ||
-         g_fProcessDetach )
-    {
-        ThrowHR(CORDBG_E_BAD_THREAD_STATE);
+        Thread * pThread = vmThread.GetDacPtr();
+        Thread::ThreadState threadState = pThread->GetSnapshotState();
+
+        if ( (threadState & Thread::TS_Dead) ||
+             (threadState & Thread::TS_Unstarted) ||
+             (threadState & Thread::TS_Detached) ||
+             g_fProcessDetach )
+        {
+            ThrowHR(CORDBG_E_BAD_THREAD_STATE);
+        }
+        else
+        {
+            VMPTR_OBJECTHANDLE vmObjHandle = VMPTR_OBJECTHANDLE::NullPtr();
+            vmObjHandle.SetDacTargetPtr(pThread->GetExposedObjectHandleForDebugger());
+            *pRetVal = vmObjHandle;
+        }
     }
-    else
-    {
-        VMPTR_OBJECTHANDLE vmObjHandle = VMPTR_OBJECTHANDLE::NullPtr();
-        vmObjHandle.SetDacTargetPtr(pThread->GetExposedObjectHandleForDebugger());
-        return vmObjHandle;
-    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
-void DacDbiInterfaceImpl::GetThreadAllocInfo(VMPTR_Thread        vmThread,
-                                             DacThreadAllocInfo* threadAllocInfo)
+HRESULT DacDbiInterfaceImpl::GetThreadAllocInfo(VMPTR_Thread vmThread, DacThreadAllocInfo* threadAllocInfo)
 {
     DD_ENTER_MAY_THROW;
 
-    Thread * pThread = vmThread.GetDacPtr();
-    gc_alloc_context* allocContext = pThread->GetAllocContext();
-    if (allocContext != nullptr)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        threadAllocInfo->m_allocBytesSOH = allocContext->alloc_bytes - (allocContext->alloc_limit - allocContext->alloc_ptr);
-        threadAllocInfo->m_allocBytesUOH = allocContext->alloc_bytes_uoh;
+
+        Thread * pThread = vmThread.GetDacPtr();
+        gc_alloc_context* allocContext = pThread->GetAllocContext();
+        if (allocContext != nullptr)
+        {
+            threadAllocInfo->m_allocBytesSOH = allocContext->alloc_bytes - (allocContext->alloc_limit - allocContext->alloc_ptr);
+            threadAllocInfo->m_allocBytesUOH = allocContext->alloc_bytes_uoh;
+        }
+        else
+        {
+                threadAllocInfo->m_allocBytesSOH = 0;
+                threadAllocInfo->m_allocBytesUOH = 0;
+        }
     }
-    else
-    {
-            threadAllocInfo->m_allocBytesSOH = 0;
-            threadAllocInfo->m_allocBytesUOH = 0;
-    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Set and reset the TSNC_DebuggerUserSuspend bit on the state of the specified thread
 // according to the CorDebugThreadState.
-void DacDbiInterfaceImpl::SetDebugState(VMPTR_Thread        vmThread,
-                                        CorDebugThreadState debugState)
+HRESULT DacDbiInterfaceImpl::SetDebugState(VMPTR_Thread vmThread, CorDebugThreadState debugState)
 {
     DD_ENTER_MAY_THROW;
 
-    Thread * pThread = vmThread.GetDacPtr();
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    // update the field on the host copy
-    if (debugState == THREAD_SUSPEND)
-    {
-        pThread->SetThreadStateNC(Thread::TSNC_DebuggerUserSuspend);
-    }
-    else if (debugState == THREAD_RUN)
-    {
-        pThread->ResetThreadStateNC(Thread::TSNC_DebuggerUserSuspend);
-    }
-    else
-    {
-        ThrowHR(E_INVALIDARG);
-    }
+        Thread * pThread = vmThread.GetDacPtr();
 
-    // update the field on the target copy
-    TADDR taThreadState = PTR_HOST_MEMBER_TADDR(Thread, pThread, m_StateNC);
-    SafeWriteStructOrThrow<Thread::ThreadStateNoConcurrency>(taThreadState, &(pThread->m_StateNC));
+        // update the field on the host copy
+        if (debugState == THREAD_SUSPEND)
+        {
+            pThread->SetThreadStateNC(Thread::TSNC_DebuggerUserSuspend);
+        }
+        else if (debugState == THREAD_RUN)
+        {
+            pThread->ResetThreadStateNC(Thread::TSNC_DebuggerUserSuspend);
+        }
+        else
+        {
+            ThrowHR(E_INVALIDARG);
+        }
+
+        // update the field on the target copy
+        TADDR taThreadState = PTR_HOST_MEMBER_TADDR(Thread, pThread, m_StateNC);
+        SafeWriteStructOrThrow<Thread::ThreadStateNoConcurrency>(taThreadState, &(pThread->m_StateNC));
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Gets the debugger unhandled exception threadstate flag
-BOOL DacDbiInterfaceImpl::HasUnhandledException(VMPTR_Thread vmThread)
+HRESULT DacDbiInterfaceImpl::HasUnhandledException(VMPTR_Thread vmThread, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-    Thread * pThread = vmThread.GetDacPtr();
-
-    // some managed exceptions don't have any underlying
-    // native exception processing going on. They just consist
-    // of a managed throwable that we have stashed away followed
-    // by a debugger notification and some form of failfast.
-    // Everything that comes through EEFatalError is in this category
-    if(pThread->IsLastThrownObjectUnhandled())
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        return TRUE;
-    }
 
-    // most managed exceptions are just a throwable bound to a
-    // native exception. In that case this handle will be non-null
-    OBJECTHANDLE ohException = pThread->GetThrowableAsHandle();
-    if (ohException != (OBJECTHANDLE)NULL)
-    {
-        // during the UEF we set the unhandled bit, if it is set the exception
-        // was unhandled
-        // however if the exception has intercept info then we consider it handled
-        // again
-        return pThread->GetExceptionState()->GetFlags()->IsUnhandled() &&
-            !(pThread->GetExceptionState()->GetFlags()->DebuggerInterceptInfo());
-    }
+        Thread * pThread = vmThread.GetDacPtr();
 
-    return FALSE;
+        // some managed exceptions don't have any underlying
+        // native exception processing going on. They just consist
+        // of a managed throwable that we have stashed away followed
+        // by a debugger notification and some form of failfast.
+        // Everything that comes through EEFatalError is in this category
+        if(pThread->IsLastThrownObjectUnhandled())
+        {
+            *pResult = TRUE;
+        }
+        else
+        {
+            // most managed exceptions are just a throwable bound to a
+            // native exception. In that case this handle will be non-null
+            OBJECTHANDLE ohException = pThread->GetThrowableAsHandle();
+            if (ohException != (OBJECTHANDLE)NULL)
+            {
+                // during the UEF we set the unhandled bit, if it is set the exception
+                // was unhandled
+                // however if the exception has intercept info then we consider it handled
+                // again
+                *pResult = pThread->GetExceptionState()->GetFlags()->IsUnhandled() &&
+                    !(pThread->GetExceptionState()->GetFlags()->DebuggerInterceptInfo());
+            }
+            else
+            {
+                *pResult = FALSE;
+            }
+        }
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Return the user state of the specified thread.
-CorDebugUserState DacDbiInterfaceImpl::GetUserState(VMPTR_Thread vmThread)
+HRESULT DacDbiInterfaceImpl::GetUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    UINT result = 0;
-    result = GetPartialUserState(vmThread);
-
-    if (!IsThreadAtGCSafePlace(vmThread))
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        result |= USER_UNSAFE_POINT;
-    }
 
-    return (CorDebugUserState)result;
+        UINT result = 0;
+        CorDebugUserState partialState;
+        IfFailThrow(GetPartialUserState(vmThread, &partialState));
+        result = (UINT)partialState;
+
+        if (!IsThreadAtGCSafePlace(vmThread))
+        {
+            result |= USER_UNSAFE_POINT;
+        }
+
+        *pRetVal = (CorDebugUserState)result;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
 // Return the connection ID of the specified thread.
-CONNID DacDbiInterfaceImpl::GetConnectionID(VMPTR_Thread vmThread)
+HRESULT DacDbiInterfaceImpl::GetConnectionID(VMPTR_Thread vmThread, OUT CONNID * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    return INVALID_CONNECTION_ID;
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        *pRetVal = INVALID_CONNECTION_ID;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Return the task ID of the specified thread.
-TASKID DacDbiInterfaceImpl::GetTaskID(VMPTR_Thread vmThread)
+HRESULT DacDbiInterfaceImpl::GetTaskID(VMPTR_Thread vmThread, OUT TASKID * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    return INVALID_TASK_ID;
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        *pRetVal = INVALID_TASK_ID;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Return the OS thread ID of the specified thread
-DWORD DacDbiInterfaceImpl::TryGetVolatileOSThreadID(VMPTR_Thread vmThread)
+HRESULT DacDbiInterfaceImpl::TryGetVolatileOSThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    Thread * pThread = vmThread.GetDacPtr();
-    _ASSERTE(pThread != NULL);
-
-    DWORD dwThreadId = pThread->GetOSThreadIdForDebugger();
-
-    // If the thread ID is a the magical cookie value, then this is really
-    // a switched out thread and doesn't have an OS tid. In that case, the
-    // DD contract is to return 0 (a much more sane value)
-    const DWORD dwSwitchedOutThreadId = SWITCHED_OUT_FIBER_OSID;
-    if (dwThreadId == dwSwitchedOutThreadId)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        return 0;
+
+        Thread * pThread = vmThread.GetDacPtr();
+        _ASSERTE(pThread != NULL);
+
+        DWORD dwThreadId = pThread->GetOSThreadIdForDebugger();
+
+        // If the thread ID is a the magical cookie value, then this is really
+        // a switched out thread and doesn't have an OS tid. In that case, the
+        // DD contract is to return 0 (a much more sane value)
+        const DWORD dwSwitchedOutThreadId = SWITCHED_OUT_FIBER_OSID;
+        if (dwThreadId == dwSwitchedOutThreadId)
+        {
+            *pRetVal = 0;
+        }
+        else
+        {
+            *pRetVal = dwThreadId;
+        }
     }
-    return dwThreadId;
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Return the unique thread ID of the specified thread.
-DWORD DacDbiInterfaceImpl::GetUniqueThreadID(VMPTR_Thread vmThread)
+HRESULT DacDbiInterfaceImpl::GetUniqueThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    Thread * pThread = vmThread.GetDacPtr();
-    _ASSERTE(pThread != NULL);
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    return pThread->GetOSThreadId();
+        Thread * pThread = vmThread.GetDacPtr();
+        _ASSERTE(pThread != NULL);
+
+        *pRetVal = pThread->GetOSThreadId();
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Return the object handle to the managed Exception object of the current exception
 // on the specified thread.  The return value could be NULL if there is no current exception.
-VMPTR_OBJECTHANDLE DacDbiInterfaceImpl::GetCurrentException(VMPTR_Thread vmThread)
+HRESULT DacDbiInterfaceImpl::GetCurrentException(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    Thread * pThread = vmThread.GetDacPtr();
-
-    // OBJECTHANDLEs are really just TADDRs.
-    OBJECTHANDLE ohException = pThread->GetThrowableAsHandle();        // ohException can be NULL
-
-    if (ohException == (OBJECTHANDLE)NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        if (pThread->IsLastThrownObjectUnhandled())
-        {
-            ohException = pThread->LastThrownObjectHandle();
-        }
-    }
 
-    VMPTR_OBJECTHANDLE vmObjHandle;
-    vmObjHandle.SetDacTargetPtr(ohException);
-    return vmObjHandle;
+        Thread * pThread = vmThread.GetDacPtr();
+
+        // OBJECTHANDLEs are really just TADDRs.
+        OBJECTHANDLE ohException = pThread->GetThrowableAsHandle();        // ohException can be NULL
+
+        if (ohException == (OBJECTHANDLE)NULL)
+        {
+            if (pThread->IsLastThrownObjectUnhandled())
+            {
+                ohException = pThread->LastThrownObjectHandle();
+            }
+        }
+
+        VMPTR_OBJECTHANDLE vmObjHandle;
+        vmObjHandle.SetDacTargetPtr(ohException);
+        *pRetVal = vmObjHandle;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Return the object handle to the managed object for a given CCW pointer.
-VMPTR_OBJECTHANDLE DacDbiInterfaceImpl::GetObjectForCCW(CORDB_ADDRESS ccwPtr)
+HRESULT DacDbiInterfaceImpl::GetObjectForCCW(CORDB_ADDRESS ccwPtr, OUT VMPTR_OBJECTHANDLE * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    OBJECTHANDLE ohCCW = (OBJECTHANDLE)NULL;
-
-#ifdef FEATURE_COMWRAPPERS
-    if (DACTryGetComWrappersHandleFromCCW(ccwPtr, &ohCCW) != S_OK)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-#endif
-#ifdef FEATURE_COMINTEROP
-    ComCallWrapper *pCCW = DACGetCCWFromAddress(ccwPtr);
-    if (pCCW)
-    {
-        ohCCW = pCCW->GetObjectHandle();
-    }
-#endif
-#ifdef FEATURE_COMWRAPPERS
-    }
-#endif
 
-    VMPTR_OBJECTHANDLE vmObjHandle;
-    vmObjHandle.SetDacTargetPtr(ohCCW);
-    return vmObjHandle;
+        OBJECTHANDLE ohCCW = (OBJECTHANDLE)NULL;
+
+    #ifdef FEATURE_COMWRAPPERS
+        if (DACTryGetComWrappersHandleFromCCW(ccwPtr, &ohCCW) != S_OK)
+        {
+    #endif
+    #ifdef FEATURE_COMINTEROP
+        ComCallWrapper *pCCW = DACGetCCWFromAddress(ccwPtr);
+        if (pCCW)
+        {
+            ohCCW = pCCW->GetObjectHandle();
+        }
+    #endif
+    #ifdef FEATURE_COMWRAPPERS
+        }
+    #endif
+
+        VMPTR_OBJECTHANDLE vmObjHandle;
+        vmObjHandle.SetDacTargetPtr(ohCCW);
+        *pRetVal = vmObjHandle;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Return the object handle to the managed CustomNotification object of the current notification
@@ -4743,51 +5195,72 @@ VMPTR_OBJECTHANDLE DacDbiInterfaceImpl::GetObjectForCCW(CORDB_ADDRESS ccwPtr)
 // if and only if we are currently inside a CustomNotification Callback (or a dump was generated while in this
 // callback)
 //
-VMPTR_OBJECTHANDLE DacDbiInterfaceImpl::GetCurrentCustomDebuggerNotification(VMPTR_Thread vmThread)
+HRESULT DacDbiInterfaceImpl::GetCurrentCustomDebuggerNotification(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    Thread * pThread = vmThread.GetDacPtr();
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    // OBJECTHANDLEs are really just TADDRs.
-    OBJECTHANDLE ohNotification = pThread->GetThreadCurrNotification();        // ohNotification can be NULL
+        Thread * pThread = vmThread.GetDacPtr();
 
-    VMPTR_OBJECTHANDLE vmObjHandle;
-    vmObjHandle.SetDacTargetPtr(ohNotification);
-    return vmObjHandle;
+        // OBJECTHANDLEs are really just TADDRs.
+        OBJECTHANDLE ohNotification = pThread->GetThreadCurrNotification();        // ohNotification can be NULL
+
+        VMPTR_OBJECTHANDLE vmObjHandle;
+        vmObjHandle.SetDacTargetPtr(ohNotification);
+        *pRetVal = vmObjHandle;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Return the current appdomain.
-VMPTR_AppDomain DacDbiInterfaceImpl::GetCurrentAppDomain()
+HRESULT DacDbiInterfaceImpl::GetCurrentAppDomain(OUT VMPTR_AppDomain * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    AppDomain * pAppDomain = AppDomain::GetCurrentDomain();
-    VMPTR_AppDomain vmAppDomain = VMPTR_AppDomain::NullPtr();
-    vmAppDomain.SetDacTargetPtr(PTR_HOST_TO_TADDR(pAppDomain));
-    return vmAppDomain;
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        AppDomain * pAppDomain = AppDomain::GetCurrentDomain();
+        VMPTR_AppDomain vmAppDomain = VMPTR_AppDomain::NullPtr();
+        vmAppDomain.SetDacTargetPtr(PTR_HOST_TO_TADDR(pAppDomain));
+        *pRetVal = vmAppDomain;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
 // Returns a bitfield reflecting the managed debugging state at the time of
 // the jit attach.
-CLR_DEBUGGING_PROCESS_FLAGS DacDbiInterfaceImpl::GetAttachStateFlags()
+HRESULT DacDbiInterfaceImpl::GetAttachStateFlags(OUT CLR_DEBUGGING_PROCESS_FLAGS * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    CLR_DEBUGGING_PROCESS_FLAGS res = (CLR_DEBUGGING_PROCESS_FLAGS)0;
-    if (g_pDebugger != NULL)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        res = g_pDebugger->GetAttachStateFlags();
+
+        CLR_DEBUGGING_PROCESS_FLAGS res = (CLR_DEBUGGING_PROCESS_FLAGS)0;
+        if (g_pDebugger != NULL)
+        {
+            res = g_pDebugger->GetAttachStateFlags();
+        }
+        else
+        {
+            // When launching the process under a managed debugger we
+            // request these flags when CLR is loaded (before g_pDebugger
+            // had a chance to be initialized). In these cases simply
+            // return 0
+        }
+        *pRetVal = res;
     }
-    else
-    {
-        // When launching the process under a managed debugger we
-        // request these flags when CLR is loaded (before g_pDebugger
-        // had a chance to be initialized). In these cases simply
-        // return 0
-    }
-    return res;
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 //---------------------------------------------------------------------------------------
@@ -4953,360 +5426,397 @@ void DacDbiInterfaceImpl::WriteExceptionRecordHelper(CORDB_ADDRESS pRemotePtr,
 }
 
 // Implement IDacDbiInterface::Hijack
-void DacDbiInterfaceImpl::Hijack(
-    VMPTR_Thread                 vmThread,
-    ULONG32                      dwThreadId,
-    const EXCEPTION_RECORD *     pRecord,
-    T_CONTEXT *                  pOriginalContext,
-    ULONG32                      cbSizeContext,
-    EHijackReason::EHijackReason reason,
-    void *                       pUserData,
-    CORDB_ADDRESS *              pRemoteContextAddr)
+HRESULT DacDbiInterfaceImpl::Hijack(VMPTR_Thread vmThread, ULONG32 dwThreadId, const EXCEPTION_RECORD * pRecord, T_CONTEXT * pOriginalContext, ULONG32 cbSizeContext, EHijackReason::EHijackReason reason, void * pUserData, CORDB_ADDRESS * pRemoteContextAddr)
 {
     DD_ENTER_MAY_THROW;
 
-    //
-    // Validate parameters
-    //
-
-    // pRecord may be NULL if we're not hijacking at an exception
-    // pOriginalContext may be NULL if caller doesn't want a copy of the context.
-    // (The hijack function already has the context)
-    _ASSERTE((pOriginalContext == NULL) == (cbSizeContext == 0));
-    _ASSERTE(EHijackReason::IsValid(reason));
-#ifdef TARGET_UNIX
-    _ASSERTE(!"Not supported on this platform");
-#endif
-
-    //
-    // If we hijack a thread which might not be managed we can set vmThread = NULL
-    // The only side-effect in this case is that we can't reuse CONTEXT and
-    // EXCEPTION_RECORD space on the stack by an already underway in-process exception
-    // filter. If you depend on those being used and updated you must provide the vmThread
-    //
-    Thread* pThread = NULL;
-    if(!vmThread.IsNull())
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        pThread = vmThread.GetDacPtr();
-        _ASSERTE(pThread->GetOSThreadIdForDebugger() == dwThreadId);
-    }
 
-    TADDR pfnHijackFunction = GetHijackAddress();
+        //
+        // Validate parameters
+        //
 
-    //
-    // Setup context for hijack
-    //
-    T_CONTEXT ctx;
-#if !defined(CROSS_COMPILE) && !defined(TARGET_WINDOWS) && (defined(DTCONTEXT_IS_AMD64) || defined(DTCONTEXT_IS_ARM64))
-    // If the host or target is not Windows, then we can assume that the DT_CONTEXT
-    // is the same as the T_CONTEXT, except for the XSTATE registers.
-    static_assert(sizeof(DT_CONTEXT) == offsetof(T_CONTEXT, XStateFeaturesMask), "DT_CONTEXT does not include the XSTATE registers");
-#else
-    // Since Dac + DBI are tightly coupled, context sizes should be the same.
-    static_assert(sizeof(DT_CONTEXT) == sizeof(T_CONTEXT), "DT_CONTEXT size must equal the T_CONTEXT size");
-#endif
-    HRESULT hr = m_pTarget->GetThreadContext(
-        dwThreadId,
-        CONTEXT_FULL | CONTEXT_FLOATING_POINT
-#ifdef CONTEXT_EXTENDED_REGISTERS
-        | CONTEXT_EXTENDED_REGISTERS
-#endif
-        ,
-        sizeof(DT_CONTEXT),
-        (BYTE*) &ctx);
-    IfFailThrow(hr);
+        // pRecord may be NULL if we're not hijacking at an exception
+        // pOriginalContext may be NULL if caller doesn't want a copy of the context.
+        // (The hijack function already has the context)
+        _ASSERTE((pOriginalContext == NULL) == (cbSizeContext == 0));
+        _ASSERTE(EHijackReason::IsValid(reason));
+    #ifdef TARGET_UNIX
+        _ASSERTE(!"Not supported on this platform");
+    #endif
 
-    // If caller requested, copy back the original context that we're hijacking from.
-    if (pOriginalContext != NULL)
-    {
+        //
+        // If we hijack a thread which might not be managed we can set vmThread = NULL
+        // The only side-effect in this case is that we can't reuse CONTEXT and
+        // EXCEPTION_RECORD space on the stack by an already underway in-process exception
+        // filter. If you depend on those being used and updated you must provide the vmThread
+        //
+        Thread* pThread = NULL;
+        if(!vmThread.IsNull())
+        {
+            pThread = vmThread.GetDacPtr();
+            _ASSERTE(pThread->GetOSThreadIdForDebugger() == dwThreadId);
+        }
+
+        TADDR pfnHijackFunction = GetHijackAddress();
+
+        //
+        // Setup context for hijack
+        //
+        T_CONTEXT ctx;
+    #if !defined(CROSS_COMPILE) && !defined(TARGET_WINDOWS) && (defined(DTCONTEXT_IS_AMD64) || defined(DTCONTEXT_IS_ARM64))
+        // If the host or target is not Windows, then we can assume that the DT_CONTEXT
+        // is the same as the T_CONTEXT, except for the XSTATE registers.
+        static_assert(sizeof(DT_CONTEXT) == offsetof(T_CONTEXT, XStateFeaturesMask), "DT_CONTEXT does not include the XSTATE registers");
+    #else
         // Since Dac + DBI are tightly coupled, context sizes should be the same.
-        if (cbSizeContext != sizeof(T_CONTEXT))
+        static_assert(sizeof(DT_CONTEXT) == sizeof(T_CONTEXT), "DT_CONTEXT size must equal the T_CONTEXT size");
+    #endif
+        HRESULT hr = m_pTarget->GetThreadContext(
+            dwThreadId,
+            CONTEXT_FULL | CONTEXT_FLOATING_POINT
+    #ifdef CONTEXT_EXTENDED_REGISTERS
+            | CONTEXT_EXTENDED_REGISTERS
+    #endif
+            ,
+            sizeof(DT_CONTEXT),
+            (BYTE*) &ctx);
+        IfFailThrow(hr);
+
+        // If caller requested, copy back the original context that we're hijacking from.
+        if (pOriginalContext != NULL)
         {
-            ThrowHR(E_INVALIDARG);
+            // Since Dac + DBI are tightly coupled, context sizes should be the same.
+            if (cbSizeContext != sizeof(T_CONTEXT))
+            {
+                ThrowHR(E_INVALIDARG);
+            }
+
+            memcpy(pOriginalContext, &ctx, cbSizeContext);
         }
 
-        memcpy(pOriginalContext, &ctx, cbSizeContext);
-    }
+        // Make sure the trace flag isn't on. This can happen if we were single stepping the thread when we faulted. This
+        // will ensure that we don't try to single step through the OS's exception logic, which greatly confuses our second
+        // chance hijack logic. This also mimics what the OS does for us automaically when single stepping in process, i.e.,
+        // when you turn the trace flag on in-process and go, if there is a fault, the fault is reported and the trace flag
+        // is automatically turned off.
+        //
+        // The debugger could always re-enable the single-step flag if it wants to.
+    #ifndef FEATURE_EMULATE_SINGLESTEP
+        UnsetSSFlag(reinterpret_cast<DT_CONTEXT *>(&ctx));
+    #endif
 
-    // Make sure the trace flag isn't on. This can happen if we were single stepping the thread when we faulted. This
-    // will ensure that we don't try to single step through the OS's exception logic, which greatly confuses our second
-    // chance hijack logic. This also mimics what the OS does for us automaically when single stepping in process, i.e.,
-    // when you turn the trace flag on in-process and go, if there is a fault, the fault is reported and the trace flag
-    // is automatically turned off.
-    //
-    // The debugger could always re-enable the single-step flag if it wants to.
-#ifndef FEATURE_EMULATE_SINGLESTEP
-    UnsetSSFlag(reinterpret_cast<DT_CONTEXT *>(&ctx));
-#endif
+        // Push pointers
+        void* espContext = NULL;
+        void* espRecord = NULL;
+        const void* pData = pUserData;
 
-    // Push pointers
-    void* espContext = NULL;
-    void* espRecord = NULL;
-    const void* pData = pUserData;
+        // @dbgtodo  cross-plat - this is not cross plat
+        CORDB_ADDRESS esp = GetSP(&ctx);
 
-    // @dbgtodo  cross-plat - this is not cross plat
-    CORDB_ADDRESS esp = GetSP(&ctx);
+        //
+        // Find out where the OS exception dispatcher has pushed the EXCEPTION_RECORD and CONTEXT. The ExInfo
+        // has pointers to these data structures, but when we get the unhandled exception notification,
+        // the OS exception dispatcher is no longer on the stack, so these pointers are no longer
+        // valid.  We need to either update these pointers in the ExInfo/ExcepionTracker, or reuse the stack
+        // space used by the OS exception dispatcher.  We are using the latter approach here.
+        //
 
-    //
-    // Find out where the OS exception dispatcher has pushed the EXCEPTION_RECORD and CONTEXT. The ExInfo
-    // has pointers to these data structures, but when we get the unhandled exception notification,
-    // the OS exception dispatcher is no longer on the stack, so these pointers are no longer
-    // valid.  We need to either update these pointers in the ExInfo/ExcepionTracker, or reuse the stack
-    // space used by the OS exception dispatcher.  We are using the latter approach here.
-    //
-
-    CORDB_ADDRESS espOSContext = (CORDB_ADDRESS)NULL;
-    CORDB_ADDRESS espOSRecord  = (CORDB_ADDRESS)NULL;
-    if (pThread != NULL && pThread->IsExceptionInProgress())
-    {
-        espOSContext = (CORDB_ADDRESS)PTR_TO_TADDR(pThread->GetExceptionState()->GetContextRecord());
-        espOSRecord  = (CORDB_ADDRESS)PTR_TO_TADDR(pThread->GetExceptionState()->GetExceptionRecord());
-
-        // The managed exception may not be related to the unhandled exception for which we are trying to
-        // hijack.  An example would be when a thread hits a managed exception, VS tries to do func eval on
-        // the thread, but the func eval causes an unhandled exception (e.g. AV in mscorwks.dll).  In this
-        // case, the pointers stored on the ExInfo are closer to the root than the current SP of the thread.
-        // The check below makes sure we don't reuse the pointers in this case.
-        if (espOSContext < esp)
+        CORDB_ADDRESS espOSContext = (CORDB_ADDRESS)NULL;
+        CORDB_ADDRESS espOSRecord  = (CORDB_ADDRESS)NULL;
+        if (pThread != NULL && pThread->IsExceptionInProgress())
         {
-            SafeWriteStructOrThrow(espOSContext, &ctx);
-            espContext = CORDB_ADDRESS_TO_PTR(espOSContext);
+            espOSContext = (CORDB_ADDRESS)PTR_TO_TADDR(pThread->GetExceptionState()->GetContextRecord());
+            espOSRecord  = (CORDB_ADDRESS)PTR_TO_TADDR(pThread->GetExceptionState()->GetExceptionRecord());
 
-            // We should have an EXCEPTION_RECORD if we are hijacked at an exception.
-            // We need to be careful when we overwrite the exception record.  On x86, the OS doesn't
-            // always push the full record onto the stack, and so we can't blindly use sizeof(EXCEPTION_RECORD).
-            // Instead, we have to look at the number of exception parameters and calculate the size.
-            _ASSERTE(pRecord != NULL);
-            WriteExceptionRecordHelper(espOSRecord, pRecord);
-            espRecord  = CORDB_ADDRESS_TO_PTR(espOSRecord);
+            // The managed exception may not be related to the unhandled exception for which we are trying to
+            // hijack.  An example would be when a thread hits a managed exception, VS tries to do func eval on
+            // the thread, but the func eval causes an unhandled exception (e.g. AV in mscorwks.dll).  In this
+            // case, the pointers stored on the ExInfo are closer to the root than the current SP of the thread.
+            // The check below makes sure we don't reuse the pointers in this case.
+            if (espOSContext < esp)
+            {
+                SafeWriteStructOrThrow(espOSContext, &ctx);
+                espContext = CORDB_ADDRESS_TO_PTR(espOSContext);
 
-            esp = min(espOSContext, espOSRecord);
+                // We should have an EXCEPTION_RECORD if we are hijacked at an exception.
+                // We need to be careful when we overwrite the exception record.  On x86, the OS doesn't
+                // always push the full record onto the stack, and so we can't blindly use sizeof(EXCEPTION_RECORD).
+                // Instead, we have to look at the number of exception parameters and calculate the size.
+                _ASSERTE(pRecord != NULL);
+                WriteExceptionRecordHelper(espOSRecord, pRecord);
+                espRecord  = CORDB_ADDRESS_TO_PTR(espOSRecord);
+
+                esp = min(espOSContext, espOSRecord);
+            }
         }
-    }
 
-    // If we haven't reused the pointers, then push everything at the leaf of the stack.
-    if (espContext == NULL)
-    {
-        _ASSERTE(espRecord == NULL);
-
-        // Push on full Context and ExceptionRecord structures. We'll then push pointers to these,
-        // and those pointers will serve as the actual args to the function.
-        espContext = CORDB_ADDRESS_TO_PTR(PushHelper(&esp, &ctx, TRUE));
-
-        // If caller didn't pass an exception-record, then we're not being hijacked at an exception.
-        // We'll just pass NULL for the exception-record to the Hijack function.
-        if (pRecord != NULL)
+        // If we haven't reused the pointers, then push everything at the leaf of the stack.
+        if (espContext == NULL)
         {
-            espRecord  = CORDB_ADDRESS_TO_PTR(PushHelper(&esp, pRecord, TRUE));
+            _ASSERTE(espRecord == NULL);
+
+            // Push on full Context and ExceptionRecord structures. We'll then push pointers to these,
+            // and those pointers will serve as the actual args to the function.
+            espContext = CORDB_ADDRESS_TO_PTR(PushHelper(&esp, &ctx, TRUE));
+
+            // If caller didn't pass an exception-record, then we're not being hijacked at an exception.
+            // We'll just pass NULL for the exception-record to the Hijack function.
+            if (pRecord != NULL)
+            {
+                espRecord  = CORDB_ADDRESS_TO_PTR(PushHelper(&esp, pRecord, TRUE));
+            }
         }
+
+        if(pRemoteContextAddr != NULL)
+        {
+            *pRemoteContextAddr = PTR_TO_CORDB_ADDRESS(espContext);
+        }
+
+        //
+        // Push args onto the stack to be able to call the hijack function
+        //
+
+        // Prototype of hijack is:
+        //     void __stdcall ExceptionHijackWorker(CONTEXT * pContext, EXCEPTION_RECORD * pRecord, EHijackReason, void * pData)
+        // Set up everything so that the hijack stub can just do a "call" instruction.
+        //
+        // Regarding stack overflow: We could do an explicit check against the thread's stack base limit.
+        // However, we don't need an explicit overflow check because if the stack does overflow,
+        // the hijack will just hit a regular stack-overflow exception.
+    #if defined(TARGET_X86)  // TARGET
+        // X86 calling convention is to push args on the stack in reverse order.
+        // If we fail here, the stack is written, but esp hasn't been committed yet so it shouldn't matter.
+        PushHelper(&esp, &pData, TRUE);
+        PushHelper(&esp, &reason, TRUE);
+        PushHelper(&esp, &espRecord, TRUE);
+        PushHelper(&esp, &espContext, TRUE);
+    #elif defined (TARGET_AMD64) // TARGET
+        // AMD64 calling convention is to place first 4 parameters in: rcx, rdx, r8 and r9
+        ctx.Rcx = (DWORD64) espContext;
+        ctx.Rdx = (DWORD64) espRecord;
+        ctx.R8  = (DWORD64) reason;
+        ctx.R9  = (DWORD64) pData;
+
+        // Caller must allocate stack space to spill for args.
+        // Push the arguments onto the outgoing argument homes.
+        // Make sure we push pointer-sized values to keep the stack aligned.
+        PushHelper(&esp, reinterpret_cast<SIZE_T *>(&(ctx.R9)), FALSE);
+        PushHelper(&esp, reinterpret_cast<SIZE_T *>(&(ctx.R8)), FALSE);
+        PushHelper(&esp, reinterpret_cast<SIZE_T *>(&(ctx.Rdx)), FALSE);
+        PushHelper(&esp, reinterpret_cast<SIZE_T *>(&(ctx.Rcx)), FALSE);
+    #elif defined(TARGET_ARM)
+        ctx.R0 = (DWORD)espContext;
+        ctx.R1 = (DWORD)espRecord;
+        ctx.R2 = (DWORD)reason;
+        ctx.R3 = (DWORD)pData;
+    #elif defined(TARGET_ARM64)
+        ctx.X0 = (DWORD64)espContext;
+        ctx.X1 = (DWORD64)espRecord;
+        ctx.X2 = (DWORD64)reason;
+        ctx.X3 = (DWORD64)pData;
+    #else
+        PORTABILITY_ASSERT("CordbThread::HijackForUnhandledException is not implemented on this platform.");
+    #endif
+        SetSP(&ctx, CORDB_ADDRESS_TO_TADDR(esp));
+
+        // @dbgtodo  cross-plat - not cross-platform safe
+        SetIP(&ctx, pfnHijackFunction);
+
+        //
+        // Commit the context.
+        //
+        hr = m_pMutableTarget->SetThreadContext(dwThreadId, sizeof(DT_CONTEXT), reinterpret_cast<BYTE*> (&ctx));
+        IfFailThrow(hr);
     }
-
-    if(pRemoteContextAddr != NULL)
-    {
-        *pRemoteContextAddr = PTR_TO_CORDB_ADDRESS(espContext);
-    }
-
-    //
-    // Push args onto the stack to be able to call the hijack function
-    //
-
-    // Prototype of hijack is:
-    //     void __stdcall ExceptionHijackWorker(CONTEXT * pContext, EXCEPTION_RECORD * pRecord, EHijackReason, void * pData)
-    // Set up everything so that the hijack stub can just do a "call" instruction.
-    //
-    // Regarding stack overflow: We could do an explicit check against the thread's stack base limit.
-    // However, we don't need an explicit overflow check because if the stack does overflow,
-    // the hijack will just hit a regular stack-overflow exception.
-#if defined(TARGET_X86)  // TARGET
-    // X86 calling convention is to push args on the stack in reverse order.
-    // If we fail here, the stack is written, but esp hasn't been committed yet so it shouldn't matter.
-    PushHelper(&esp, &pData, TRUE);
-    PushHelper(&esp, &reason, TRUE);
-    PushHelper(&esp, &espRecord, TRUE);
-    PushHelper(&esp, &espContext, TRUE);
-#elif defined (TARGET_AMD64) // TARGET
-    // AMD64 calling convention is to place first 4 parameters in: rcx, rdx, r8 and r9
-    ctx.Rcx = (DWORD64) espContext;
-    ctx.Rdx = (DWORD64) espRecord;
-    ctx.R8  = (DWORD64) reason;
-    ctx.R9  = (DWORD64) pData;
-
-    // Caller must allocate stack space to spill for args.
-    // Push the arguments onto the outgoing argument homes.
-    // Make sure we push pointer-sized values to keep the stack aligned.
-    PushHelper(&esp, reinterpret_cast<SIZE_T *>(&(ctx.R9)), FALSE);
-    PushHelper(&esp, reinterpret_cast<SIZE_T *>(&(ctx.R8)), FALSE);
-    PushHelper(&esp, reinterpret_cast<SIZE_T *>(&(ctx.Rdx)), FALSE);
-    PushHelper(&esp, reinterpret_cast<SIZE_T *>(&(ctx.Rcx)), FALSE);
-#elif defined(TARGET_ARM)
-    ctx.R0 = (DWORD)espContext;
-    ctx.R1 = (DWORD)espRecord;
-    ctx.R2 = (DWORD)reason;
-    ctx.R3 = (DWORD)pData;
-#elif defined(TARGET_ARM64)
-    ctx.X0 = (DWORD64)espContext;
-    ctx.X1 = (DWORD64)espRecord;
-    ctx.X2 = (DWORD64)reason;
-    ctx.X3 = (DWORD64)pData;
-#else
-    PORTABILITY_ASSERT("CordbThread::HijackForUnhandledException is not implemented on this platform.");
-#endif
-    SetSP(&ctx, CORDB_ADDRESS_TO_TADDR(esp));
-
-    // @dbgtodo  cross-plat - not cross-platform safe
-    SetIP(&ctx, pfnHijackFunction);
-
-    //
-    // Commit the context.
-    //
-    hr = m_pMutableTarget->SetThreadContext(dwThreadId, sizeof(DT_CONTEXT), reinterpret_cast<BYTE*> (&ctx));
-    IfFailThrow(hr);
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Return the filter CONTEXT on the LS.
-VMPTR_CONTEXT DacDbiInterfaceImpl::GetManagedStoppedContext(VMPTR_Thread vmThread)
+HRESULT DacDbiInterfaceImpl::GetManagedStoppedContext(VMPTR_Thread vmThread, OUT VMPTR_CONTEXT * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    VMPTR_CONTEXT vmContext = VMPTR_CONTEXT::NullPtr();
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    Thread * pThread = vmThread.GetDacPtr();
-    if (pThread->GetInteropDebuggingHijacked())
-    {
-        _ASSERTE(!ISREDIRECTEDTHREAD(pThread));
-        vmContext = VMPTR_CONTEXT::NullPtr();
-    }
-    else
-    {
-        DT_CONTEXT * pLSContext = reinterpret_cast<DT_CONTEXT *>(pThread->GetFilterContext());
-        if (pLSContext != NULL)
+        VMPTR_CONTEXT vmContext = VMPTR_CONTEXT::NullPtr();
+
+        Thread * pThread = vmThread.GetDacPtr();
+        if (pThread->GetInteropDebuggingHijacked())
         {
             _ASSERTE(!ISREDIRECTEDTHREAD(pThread));
-            vmContext.SetHostPtr(pLSContext);
+            vmContext = VMPTR_CONTEXT::NullPtr();
         }
-        else if (ISREDIRECTEDTHREAD(pThread))
+        else
         {
-            pLSContext = reinterpret_cast<DT_CONTEXT *>(GETREDIRECTEDCONTEXT(pThread));
-            _ASSERTE(pLSContext != NULL);
-
+            DT_CONTEXT * pLSContext = reinterpret_cast<DT_CONTEXT *>(pThread->GetFilterContext());
             if (pLSContext != NULL)
             {
+                _ASSERTE(!ISREDIRECTEDTHREAD(pThread));
                 vmContext.SetHostPtr(pLSContext);
             }
-        }
-    }
+            else if (ISREDIRECTEDTHREAD(pThread))
+            {
+                pLSContext = reinterpret_cast<DT_CONTEXT *>(GETREDIRECTEDCONTEXT(pThread));
+                _ASSERTE(pLSContext != NULL);
 
-    return vmContext;
+                if (pLSContext != NULL)
+                {
+                    vmContext.SetHostPtr(pLSContext);
+                }
+            }
+        }
+
+        *pRetVal = vmContext;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Return a TargetBuffer for the raw vararg signature.
-TargetBuffer DacDbiInterfaceImpl::GetVarArgSig(CORDB_ADDRESS   VASigCookieAddr,
-                                               CORDB_ADDRESS * pArgBase)
+HRESULT DacDbiInterfaceImpl::GetVarArgSig(CORDB_ADDRESS VASigCookieAddr, OUT CORDB_ADDRESS * pArgBase, OUT TargetBuffer * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    _ASSERTE(pArgBase != NULL);
-    *pArgBase = (CORDB_ADDRESS)NULL;
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    // First, read the VASigCookie pointer.
-    TADDR taVASigCookie = (TADDR)NULL;
-    SafeReadStructOrThrow(VASigCookieAddr, &taVASigCookie);
+        _ASSERTE(pArgBase != NULL);
+        *pArgBase = (CORDB_ADDRESS)NULL;
 
-    // Now create a DAC copy of VASigCookie.
-    VASigCookie * pVACookie = PTR_VASigCookie(taVASigCookie);
+        // First, read the VASigCookie pointer.
+        TADDR taVASigCookie = (TADDR)NULL;
+        SafeReadStructOrThrow(VASigCookieAddr, &taVASigCookie);
 
-    // Figure out where the first argument is.
-#if defined(TARGET_X86) // (STACK_GROWS_DOWN_ON_ARGS_WALK)
-    *pArgBase = VASigCookieAddr + pVACookie->sizeOfArgs;
-#else  // !TARGET_X86 (STACK_GROWS_UP_ON_ARGS_WALK)
-    *pArgBase = VASigCookieAddr + sizeof(VASigCookie *);
-#endif // !TARGET_X86 (STACK_GROWS_UP_ON_ARGS_WALK)
+        // Now create a DAC copy of VASigCookie.
+        VASigCookie * pVACookie = PTR_VASigCookie(taVASigCookie);
 
-    return TargetBuffer(PTR_TO_CORDB_ADDRESS(pVACookie->signature.GetRawSig()),
-                        pVACookie->signature.GetRawSigLen());
+        // Figure out where the first argument is.
+    #if defined(TARGET_X86) // (STACK_GROWS_DOWN_ON_ARGS_WALK)
+        *pArgBase = VASigCookieAddr + pVACookie->sizeOfArgs;
+    #else  // !TARGET_X86 (STACK_GROWS_UP_ON_ARGS_WALK)
+        *pArgBase = VASigCookieAddr + sizeof(VASigCookie *);
+    #endif // !TARGET_X86 (STACK_GROWS_UP_ON_ARGS_WALK)
+
+        *pRetVal = TargetBuffer(PTR_TO_CORDB_ADDRESS(pVACookie->signature.GetRawSig()),
+                            pVACookie->signature.GetRawSigLen());
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // returns TRUE if the type requires 8-byte alignment
-BOOL DacDbiInterfaceImpl::RequiresAlign8(VMPTR_TypeHandle thExact)
+HRESULT DacDbiInterfaceImpl::RequiresAlign8(VMPTR_TypeHandle thExact, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-#ifdef FEATURE_64BIT_ALIGNMENT
-    TypeHandle th = TypeHandle::FromPtr(thExact.GetDacPtr());
-    PTR_MethodTable mt = th.AsMethodTable();
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    return mt->RequiresAlign8();
-#else
-    ThrowHR(E_NOTIMPL);
-#endif
+    #ifdef FEATURE_64BIT_ALIGNMENT
+        TypeHandle th = TypeHandle::FromPtr(thExact.GetDacPtr());
+        PTR_MethodTable mt = th.AsMethodTable();
+
+        *pResult = mt->RequiresAlign8();
+    #else
+        ThrowHR(E_NOTIMPL);
+    #endif
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Resolve the raw generics token to the real generics type token.  The resolution is based on the
 // given index.
-GENERICS_TYPE_TOKEN DacDbiInterfaceImpl::ResolveExactGenericArgsToken(DWORD               dwExactGenericArgsTokenIndex,
-                                                                      GENERICS_TYPE_TOKEN rawToken)
+HRESULT DacDbiInterfaceImpl::ResolveExactGenericArgsToken(DWORD dwExactGenericArgsTokenIndex, GENERICS_TYPE_TOKEN rawToken, OUT GENERICS_TYPE_TOKEN * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    if (dwExactGenericArgsTokenIndex == 0)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        // In a rare case of VS4Mac debugging VS4Mac ARM64 optimized code we get a null generics argument token. We aren't sure
-        // why the token is null, it may be a bug or it may be by design in the runtime. In the interest of time we are working
-        // around the issue rather than investigating the root cause. This workaround should only cause us to degrade generic
-        // types from exact type parameters to approximate or canonical type parameters. In the future if we discover this issue
-        // is happening more frequently than we expect or the workaround is more impactful than we expect we may need to remove
-        // this workaround and resolve the underlying issue.
-        if (rawToken == 0)
+
+        if (dwExactGenericArgsTokenIndex == 0)
         {
-            return rawToken;
+            // In a rare case of VS4Mac debugging VS4Mac ARM64 optimized code we get a null generics argument token. We aren't sure
+            // why the token is null, it may be a bug or it may be by design in the runtime. In the interest of time we are working
+            // around the issue rather than investigating the root cause. This workaround should only cause us to degrade generic
+            // types from exact type parameters to approximate or canonical type parameters. In the future if we discover this issue
+            // is happening more frequently than we expect or the workaround is more impactful than we expect we may need to remove
+            // this workaround and resolve the underlying issue.
+            if (rawToken == 0)
+            {
+                *pRetVal = rawToken;
+            }
+            else
+            {
+                // In this case the real generics type token is the MethodTable of the "this" object.
+                // Note that we want the target address here.
+
+                // Incoming rawToken is actually a PTR_Object for the 'this' pointer.
+                // Need to do some casting to convert GENERICS_TYPE_TOKEN --> PTR_Object
+                TADDR addrObjThis = CORDB_ADDRESS_TO_TADDR(rawToken);
+                PTR_Object pObjThis = dac_cast<PTR_Object>(addrObjThis);
+
+
+                PTR_MethodTable pMT = pObjThis->GetMethodTable();
+
+                // Now package up the PTR_MethodTable back into a GENERICS_TYPE_TOKEN
+                TADDR addrMT = dac_cast<TADDR>(pMT);
+                GENERICS_TYPE_TOKEN realToken = (GENERICS_TYPE_TOKEN) addrMT;
+                *pRetVal = realToken;
+            }
         }
-        // In this case the real generics type token is the MethodTable of the "this" object.
-        // Note that we want the target address here.
-
-        // Incoming rawToken is actually a PTR_Object for the 'this' pointer.
-        // Need to do some casting to convert GENERICS_TYPE_TOKEN --> PTR_Object
-        TADDR addrObjThis = CORDB_ADDRESS_TO_TADDR(rawToken);
-        PTR_Object pObjThis = dac_cast<PTR_Object>(addrObjThis);
-
-
-        PTR_MethodTable pMT = pObjThis->GetMethodTable();
-
-        // Now package up the PTR_MethodTable back into a GENERICS_TYPE_TOKEN
-        TADDR addrMT = dac_cast<TADDR>(pMT);
-        GENERICS_TYPE_TOKEN realToken = (GENERICS_TYPE_TOKEN) addrMT;
-        return realToken;
+        else if (dwExactGenericArgsTokenIndex == (DWORD)ICorDebugInfo::TYPECTXT_ILNUM)
+        {
+            // rawToken is already initialized correctly.  Nothing to do here.
+            *pRetVal = rawToken;
+        }
+        else
+        {
+            // The index of the generics type token should not be anything else.
+            // This is indeed an error condition, and so we throw here.
+            _ASSERTE(!"DDII::REGAT - Unexpected generics type token index.");
+            ThrowHR(CORDBG_E_TARGET_INCONSISTENT);
+        }
     }
-    else if (dwExactGenericArgsTokenIndex == (DWORD)ICorDebugInfo::TYPECTXT_ILNUM)
-    {
-        // rawToken is already initialized correctly.  Nothing to do here.
-        return  rawToken;
-    }
-
-    // The index of the generics type token should not be anything else.
-    // This is indeed an error condition, and so we throw here.
-    _ASSERTE(!"DDII::REGAT - Unexpected generics type token index.");
-    ThrowHR(CORDBG_E_TARGET_INCONSISTENT);
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Check if the given method is a DiagnosticHidden or an LCG method.
-IDacDbiInterface::DynamicMethodType DacDbiInterfaceImpl::IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc)
+HRESULT DacDbiInterfaceImpl::IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc, OUT DynamicMethodType * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    MethodDesc * pMD = vmMethodDesc.GetDacPtr();
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    if (pMD->IsDiagnosticsHidden())
-    {
-        return kDiagnosticHidden;
+        MethodDesc * pMD = vmMethodDesc.GetDacPtr();
+
+        if (pMD->IsDiagnosticsHidden())
+        {
+            *pRetVal = kDiagnosticHidden;
+        }
+        else if (pMD->IsLCGMethod())
+        {
+            *pRetVal = kLCGMethod;
+        }
+        else
+        {
+            *pRetVal = kNone;
+        }
     }
-    else if (pMD->IsLCGMethod())
-    {
-        return kLCGMethod;
-    }
-    else
-    {
-        return kNone;
-    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 //---------------------------------------------------------------------------------------
@@ -5366,47 +5876,54 @@ BOOL DacDbiInterfaceImpl::IsThreadAtGCSafePlace(VMPTR_Thread vmThread)
 //    Return the partial user state except for USER_UNSAFE_POINT
 //
 
-CorDebugUserState DacDbiInterfaceImpl::GetPartialUserState(VMPTR_Thread vmThread)
+HRESULT DacDbiInterfaceImpl::GetPartialUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    Thread * pThread = vmThread.GetDacPtr();
-    Thread::ThreadState ts = pThread->GetSnapshotState();
-
-    UINT result = 0;
-    if (ts & Thread::TS_Background)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        result |= USER_BACKGROUND;
+
+        Thread * pThread = vmThread.GetDacPtr();
+        Thread::ThreadState ts = pThread->GetSnapshotState();
+
+        UINT result = 0;
+        if (ts & Thread::TS_Background)
+        {
+            result |= USER_BACKGROUND;
+        }
+
+        if (ts & Thread::TS_Unstarted)
+        {
+            result |= USER_UNSTARTED;
+        }
+
+        // Don't report a StopRequested if the thread has actually stopped.
+        if (ts & Thread::TS_Dead)
+        {
+            result |= USER_STOPPED;
+        }
+
+        // Don't report Thread::TS_AbortRequested
+
+        // The interruptible flag is unreliable (see issue 699245)
+        // The Debugger_SleepWaitJoin is always accurate when it is present, but it is still
+        // just a band-aid fix to cover some of the race conditions interruptible has.
+
+        if (ts & Thread::TS_Interruptible || pThread->HasThreadStateNC(Thread::TSNC_DebuggerSleepWaitJoin))
+        {
+            result |= USER_WAIT_SLEEP_JOIN;
+        }
+
+        if (pThread->IsThreadPoolThread())
+        {
+            result |= USER_THREADPOOL;
+        }
+
+        *pRetVal = (CorDebugUserState)result;
     }
-
-    if (ts & Thread::TS_Unstarted)
-    {
-        result |= USER_UNSTARTED;
-    }
-
-    // Don't report a StopRequested if the thread has actually stopped.
-    if (ts & Thread::TS_Dead)
-    {
-        result |= USER_STOPPED;
-    }
-
-    // Don't report Thread::TS_AbortRequested
-
-    // The interruptible flag is unreliable (see issue 699245)
-    // The Debugger_SleepWaitJoin is always accurate when it is present, but it is still
-    // just a band-aid fix to cover some of the race conditions interruptible has.
-
-    if (ts & Thread::TS_Interruptible || pThread->HasThreadStateNC(Thread::TSNC_DebuggerSleepWaitJoin))
-    {
-        result |= USER_WAIT_SLEEP_JOIN;
-    }
-
-    if (pThread->IsThreadPoolThread())
-    {
-        result |= USER_THREADPOOL;
-    }
-
-    return (CorDebugUserState)result;
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 //---------------------------------------------------------------------------------------
@@ -5495,96 +6012,119 @@ void DacDbiInterfaceImpl::LookupEnCVersions(Module*          pModule,
 // Arguments: none
 // Return Value: The remote address of the Debugger control block allocated on the helper thread
 //               if it has been successfully allocated or NULL otherwise.
-CORDB_ADDRESS DacDbiInterfaceImpl::GetDebuggerControlBlockAddress()
+HRESULT DacDbiInterfaceImpl::GetDebuggerControlBlockAddress(OUT CORDB_ADDRESS * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    if ((g_pDebugger != NULL) &&
-        (g_pDebugger->m_pRCThread != NULL))
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-    return CORDB_ADDRESS(dac_cast<TADDR>(g_pDebugger->m_pRCThread->GetDCB()));
-    }
 
-    return (CORDB_ADDRESS)NULL;
-}
-
-// DacDbi API: Get the context for a particular thread of the target process
-void DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContextBuffer)
-{
-    DD_ENTER_MAY_THROW
-
-    _ASSERTE(pContextBuffer != NULL);
-
-    Thread *  pThread  = vmThread.GetDacPtr();
-
-    // @dbgtodo  Once the filter context is removed, then we should always
-    // start with the leaf CONTEXT.
-    DT_CONTEXT * pFilterContext = reinterpret_cast<DT_CONTEXT *>(pThread->GetFilterContext());
-
-    if (pFilterContext == NULL)
-    {
-        // If the filter context is NULL, then we use the true context of the thread.
-        pContextBuffer->ContextFlags = DT_CONTEXT_ALL;
-        HRESULT hr = m_pTarget->GetThreadContext(pThread->GetOSThreadId(),
-                                                pContextBuffer->ContextFlags,
-                                                sizeof(DT_CONTEXT),
-                                                reinterpret_cast<BYTE *>(pContextBuffer));
-        if (hr == E_NOTIMPL)
+        if ((g_pDebugger != NULL) &&
+            (g_pDebugger->m_pRCThread != NULL))
         {
-            // GetThreadContext is not implemented on this data target.
-            // That's why we have to make do with context we can obtain from Frames explicitly stored in Thread object.
-            // It suffices for managed debugging stackwalk.
-            REGDISPLAY tmpRd = {};
-            T_CONTEXT tmpContext = {};
-            FillRegDisplay(&tmpRd, &tmpContext);
-
-            // Going through thread Frames and looking for first (deepest one) one that
-            // that has context available for stackwalking (SP and PC)
-            // For example: RedirectedThreadFrame, InlinedCallFrame, DynamicHelperFrame, CLRToCOMMethodFrame
-            Frame *frame = pThread->GetFrame();
-            while (frame != NULL && frame != FRAME_TOP)
-            {
-                frame->UpdateRegDisplay(&tmpRd);
-                if (GetRegdisplaySP(&tmpRd) != 0 && GetControlPC(&tmpRd) != 0)
-                {
-                    UpdateContextFromRegDisp(&tmpRd, &tmpContext);
-                    CopyMemory(pContextBuffer, &tmpContext, sizeof(*pContextBuffer));
-                    pContextBuffer->ContextFlags = DT_CONTEXT_CONTROL
-#if defined(TARGET_AMD64) || defined(TARGET_ARM)
-                                                | DT_CONTEXT_INTEGER  // DT_CONTEXT_INTEGER is needed to include the frame register on ARM32 and AMD64 architectures
-                                                                      // DT_CONTEXT_CONTROL already includes the frame register for X86 and ARM64 architectures
-#endif
-                    ;
-                    return;
-                }
-                frame = frame->Next();
-            }
-
-            // It looks like this thread is not running managed code.
-            ZeroMemory(pContextBuffer, sizeof(*pContextBuffer));
+            *pRetVal = CORDB_ADDRESS(dac_cast<TADDR>(g_pDebugger->m_pRCThread->GetDCB()));
         }
         else
         {
-            IfFailThrow(hr);
+            *pRetVal = (CORDB_ADDRESS)NULL;
         }
     }
-    else
-    {
-        *pContextBuffer = *pFilterContext;
-    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
-} // DacDbiInterfaceImpl::GetContext
+// DacDbi API: Get the context for a particular thread of the target process
+HRESULT DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContextBuffer)
+{
+    DD_ENTER_MAY_THROW
+
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        _ASSERTE(pContextBuffer != NULL);
+
+        Thread *  pThread  = vmThread.GetDacPtr();
+
+        // @dbgtodo  Once the filter context is removed, then we should always
+        // start with the leaf CONTEXT.
+        DT_CONTEXT * pFilterContext = reinterpret_cast<DT_CONTEXT *>(pThread->GetFilterContext());
+
+        if (pFilterContext == NULL)
+        {
+            // If the filter context is NULL, then we use the true context of the thread.
+            pContextBuffer->ContextFlags = DT_CONTEXT_ALL;
+            HRESULT hr = m_pTarget->GetThreadContext(pThread->GetOSThreadId(),
+                                                    pContextBuffer->ContextFlags,
+                                                    sizeof(DT_CONTEXT),
+                                                    reinterpret_cast<BYTE *>(pContextBuffer));
+            if (hr == E_NOTIMPL)
+            {
+                // GetThreadContext is not implemented on this data target.
+                // That's why we have to make do with context we can obtain from Frames explicitly stored in Thread object.
+                // It suffices for managed debugging stackwalk.
+                REGDISPLAY tmpRd = {};
+                T_CONTEXT tmpContext = {};
+                FillRegDisplay(&tmpRd, &tmpContext);
+
+                // Going through thread Frames and looking for first (deepest one) one that
+                // that has context available for stackwalking (SP and PC)
+                // For example: RedirectedThreadFrame, InlinedCallFrame, DynamicHelperFrame, CLRToCOMMethodFrame
+                Frame *frame = pThread->GetFrame();
+                while (frame != NULL && frame != FRAME_TOP)
+                {
+                    frame->UpdateRegDisplay(&tmpRd);
+                    if (GetRegdisplaySP(&tmpRd) != 0 && GetControlPC(&tmpRd) != 0)
+                    {
+                        UpdateContextFromRegDisp(&tmpRd, &tmpContext);
+                        CopyMemory(pContextBuffer, &tmpContext, sizeof(*pContextBuffer));
+                        pContextBuffer->ContextFlags = DT_CONTEXT_CONTROL
+    #if defined(TARGET_AMD64) || defined(TARGET_ARM)
+                                                    | DT_CONTEXT_INTEGER  // DT_CONTEXT_INTEGER is needed to include the frame register on ARM32 and AMD64 architectures
+                                                                          // DT_CONTEXT_CONTROL already includes the frame register for X86 and ARM64 architectures
+    #endif
+                        ;
+                        return hr;
+                    }
+                    frame = frame->Next();
+                }
+
+                // It looks like this thread is not running managed code.
+                ZeroMemory(pContextBuffer, sizeof(*pContextBuffer));
+            }
+            else
+            {
+                IfFailThrow(hr);
+            }
+        }
+        else
+        {
+            *pContextBuffer = *pFilterContext;
+        }
+
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 // Create a VMPTR_Object from a target object address
 // @dbgtodo validate the VMPTR_Object is in fact a object, possibly by DACizing
 //          Object::Validate
-VMPTR_Object DacDbiInterfaceImpl::GetObject(CORDB_ADDRESS ptr)
+HRESULT DacDbiInterfaceImpl::GetObject(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    VMPTR_Object vmObj = VMPTR_Object::NullPtr();
-    vmObj.SetDacTargetPtr(CORDB_ADDRESS_TO_TADDR(ptr));
-    return vmObj;
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        VMPTR_Object vmObj = VMPTR_Object::NullPtr();
+        vmObj.SetDacTargetPtr(CORDB_ADDRESS_TO_TADDR(ptr));
+        *pRetVal = vmObj;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 HRESULT DacDbiInterfaceImpl::EnableNGENPolicy(CorDebugNGENPolicy ePolicy)
@@ -5611,56 +6151,77 @@ typedef DPTR(OBJECTREF) PTR_ObjectRef;
 // Create a VMPTR_Object from an address which points to a reference to an object
 // @dbgtodo validate the VMPTR_Object is in fact a object, possibly by DACizing
 //          Object::Validate
-VMPTR_Object DacDbiInterfaceImpl::GetObjectFromRefPtr(CORDB_ADDRESS ptr)
+HRESULT DacDbiInterfaceImpl::GetObjectFromRefPtr(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    VMPTR_Object vmObj = VMPTR_Object::NullPtr();
-    PTR_ObjectRef objRef = PTR_ObjectRef(CORDB_ADDRESS_TO_TADDR(ptr));
-    vmObj.SetDacTargetPtr(PTR_TO_TADDR(*objRef));
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    return vmObj;
+        VMPTR_Object vmObj = VMPTR_Object::NullPtr();
+        PTR_ObjectRef objRef = PTR_ObjectRef(CORDB_ADDRESS_TO_TADDR(ptr));
+        vmObj.SetDacTargetPtr(PTR_TO_TADDR(*objRef));
+
+        *pRetVal = vmObj;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Create a VMPTR_OBJECTHANDLE from a handle
-VMPTR_OBJECTHANDLE DacDbiInterfaceImpl::GetVmObjectHandle(CORDB_ADDRESS handleAddress)
+HRESULT DacDbiInterfaceImpl::GetVmObjectHandle(CORDB_ADDRESS handleAddress, OUT VMPTR_OBJECTHANDLE * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    VMPTR_OBJECTHANDLE vmObjHandle = VMPTR_OBJECTHANDLE::NullPtr();
-    vmObjHandle.SetDacTargetPtr(CORDB_ADDRESS_TO_TADDR(handleAddress));
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    return vmObjHandle;
+        VMPTR_OBJECTHANDLE vmObjHandle = VMPTR_OBJECTHANDLE::NullPtr();
+        vmObjHandle.SetDacTargetPtr(CORDB_ADDRESS_TO_TADDR(handleAddress));
+
+        *pRetVal = vmObjHandle;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
 // Validate that the VMPTR_OBJECTHANDLE refers to a legitimate managed object
-BOOL DacDbiInterfaceImpl::IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle)
+HRESULT DacDbiInterfaceImpl::IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-    BOOL ret = FALSE;
-    // this may cause unallocated debuggee memory to be read
-    // SEH exceptions will be caught
+    HRESULT hr = S_OK;
     EX_TRY
     {
-        OBJECTREF objRef = ObjectFromHandle((OBJECTHANDLE)vmHandle.GetDacPtr());
 
-        // NULL is certainly valid...
-        if (objRef != NULL)
+        BOOL ret = FALSE;
+        // this may cause unallocated debuggee memory to be read
+        // SEH exceptions will be caught
+        EX_TRY
         {
-            if (objRef->ValidateObjectWithPossibleAV())
+            OBJECTREF objRef = ObjectFromHandle((OBJECTHANDLE)vmHandle.GetDacPtr());
+
+            // NULL is certainly valid...
+            if (objRef != NULL)
             {
-                ret = TRUE;
+                if (objRef->ValidateObjectWithPossibleAV())
+                {
+                    ret = TRUE;
+                }
             }
         }
-    }
-    EX_CATCH
-    {
-    }
-    EX_END_CATCH
+        EX_CATCH
+        {
+        }
+        EX_END_CATCH
 
-    return ret;
+        *pResult = ret;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // determines if the specified module is a WinRT module
@@ -5675,31 +6236,52 @@ HRESULT DacDbiInterfaceImpl::IsWinRTModule(VMPTR_Module vmModule, BOOL& isWinRT)
 }
 
 // Determines the app domain id for the object referred to by a given VMPTR_OBJECTHANDLE
-ULONG DacDbiInterfaceImpl::GetAppDomainIdFromVmObjectHandle(VMPTR_OBJECTHANDLE vmHandle)
+HRESULT DacDbiInterfaceImpl::GetAppDomainIdFromVmObjectHandle(VMPTR_OBJECTHANDLE vmHandle, OUT ULONG * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    return DefaultADID;
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        *pRetVal = DefaultADID;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Get the target address from a VMPTR_OBJECTHANDLE, i.e., the handle address
-CORDB_ADDRESS DacDbiInterfaceImpl::GetHandleAddressFromVmHandle(VMPTR_OBJECTHANDLE vmHandle)
+HRESULT DacDbiInterfaceImpl::GetHandleAddressFromVmHandle(VMPTR_OBJECTHANDLE vmHandle, OUT CORDB_ADDRESS * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
-    CORDB_ADDRESS handle = vmHandle.GetDacPtr();
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    return handle;
+        CORDB_ADDRESS handle = vmHandle.GetDacPtr();
+
+        *pRetVal = handle;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // Create a TargetBuffer which describes the location of the object
-TargetBuffer DacDbiInterfaceImpl::GetObjectContents(VMPTR_Object vmObj)
+HRESULT DacDbiInterfaceImpl::GetObjectContents(VMPTR_Object obj, OUT TargetBuffer * pRetVal)
 {
     DD_ENTER_MAY_THROW;
-    PTR_Object objPtr = vmObj.GetDacPtr();
 
-    _ASSERTE(objPtr->GetSize() <= 0xffffffff);
-    return TargetBuffer(PTR_TO_TADDR(objPtr), (ULONG)objPtr->GetSize());
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+        PTR_Object objPtr = obj.GetDacPtr();
+
+        _ASSERTE(objPtr->GetSize() <= 0xffffffff);
+        *pRetVal = TargetBuffer(PTR_TO_TADDR(objPtr), (ULONG)objPtr->GetSize());
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // ============================================================================
@@ -5865,234 +6447,279 @@ void DacDbiInterfaceImpl::InitObjectData(PTR_Object                objPtr,
 // }
 
 // Initializes the objRef and typedByRefType fields of pObjectData (type info for the referent).
-void DacDbiInterfaceImpl::GetTypedByRefInfo(CORDB_ADDRESS             pTypedByRef,
-                                            VMPTR_AppDomain           vmAppDomain,
-                                            DebuggerIPCE_ObjectData * pObjectData)
+HRESULT DacDbiInterfaceImpl::GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData)
 {
      DD_ENTER_MAY_THROW;
 
-    // pTypedByRef is really the address of a TypedByRef struct rather than of a normal object.
-    // The data field of the TypedByRef struct is the actual object ref.
-    PTR_TypedByRef refAddr = PTR_TypedByRef(TADDR(pTypedByRef));
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    _ASSERTE(refAddr != NULL);
-    _ASSERTE(pObjectData != NULL);
+        // pTypedByRef is really the address of a TypedByRef struct rather than of a normal object.
+        // The data field of the TypedByRef struct is the actual object ref.
+        PTR_TypedByRef refAddr = PTR_TypedByRef(TADDR(pTypedByRef));
 
-    // The type of the referent is in the type field of the TypedByRef. We need to initialize the object
-    // data type information.
-    TypeHandleToBasicTypeInfo(refAddr->type,
-                              &(pObjectData->typedByrefInfo.typedByrefType),
-                              vmAppDomain.GetDacPtr());
+        _ASSERTE(refAddr != NULL);
+        _ASSERTE(pObjectData != NULL);
 
-    // The reference to the object is in the data field of the TypedByRef.
-    CORDB_ADDRESS tempRef = dac_cast<TADDR>(refAddr->data);
-    pObjectData->objRef = CORDB_ADDRESS_TO_PTR(tempRef);
+        // The type of the referent is in the type field of the TypedByRef. We need to initialize the object
+        // data type information.
+        TypeHandleToBasicTypeInfo(refAddr->type,
+                                  &(pObjectData->typedByrefInfo.typedByrefType),
+                                  vmAppDomain.GetDacPtr());
 
-    LOG((LF_CORDB, LL_INFO10000, "D::GASOI: sending REFANY result: "
-         "ref=0x%08x, cls=0x%08x, mod=0x%p\n",
-         pObjectData->objRef,
-         pObjectData->typedByrefType.metadataToken,
-         pObjectData->typedByrefType.vmDomainAssembly.GetDacPtr()));
-} // DacDbiInterfaceImpl::GetTypedByRefInfo
+        // The reference to the object is in the data field of the TypedByRef.
+        CORDB_ADDRESS tempRef = dac_cast<TADDR>(refAddr->data);
+        pObjectData->objRef = CORDB_ADDRESS_TO_PTR(tempRef);
+
+        LOG((LF_CORDB, LL_INFO10000, "D::GASOI: sending REFANY result: "
+             "ref=0x%08x, cls=0x%08x, mod=0x%p\n",
+             pObjectData->objRef,
+             pObjectData->typedByrefType.metadataToken,
+             pObjectData->typedByrefType.vmDomainAssembly.GetDacPtr()));
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 // Get the string data associated withn obj and put it into the pointers
 // DAC/DBI API
 // Get the string length and offset to string base for a string object
-void DacDbiInterfaceImpl::GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData)
+HRESULT DacDbiInterfaceImpl::GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData)
 {
     DD_ENTER_MAY_THROW;
 
-    PTR_Object objPtr = PTR_Object(TADDR(objectAddress));
-    LOG((LF_CORDB, LL_INFO10000, "D::GOI: The referent is a string.\n"));
-
-    if (objPtr->GetGCSafeMethodTable() != g_pStringClass)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        ThrowHR(CORDBG_E_TARGET_INCONSISTENT);
+
+        PTR_Object objPtr = PTR_Object(TADDR(objectAddress));
+        LOG((LF_CORDB, LL_INFO10000, "D::GOI: The referent is a string.\n"));
+
+        if (objPtr->GetGCSafeMethodTable() != g_pStringClass)
+        {
+            ThrowHR(CORDBG_E_TARGET_INCONSISTENT);
+        }
+
+        PTR_StringObject pStrObj = dac_cast<PTR_StringObject>(objPtr);
+
+        _ASSERTE(pStrObj != NULL);
+        pObjectData->stringInfo.length = pStrObj->GetStringLength();
+        pObjectData->stringInfo.offsetToStringBase = (UINT_PTR) pStrObj->GetBufferOffset();
+
     }
-
-    PTR_StringObject pStrObj = dac_cast<PTR_StringObject>(objPtr);
-
-    _ASSERTE(pStrObj != NULL);
-    pObjectData->stringInfo.length = pStrObj->GetStringLength();
-    pObjectData->stringInfo.offsetToStringBase = (UINT_PTR) pStrObj->GetBufferOffset();
-
-} // DacDbiInterfaceImpl::GetStringData
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 
 // DAC/DBI API
 // Get information for an array type referent of an objRef, including rank, upper and lower
 // bounds, element size and type, and the number of elements.
-void DacDbiInterfaceImpl::GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData)
+HRESULT DacDbiInterfaceImpl::GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData)
 {
     DD_ENTER_MAY_THROW;
 
-    PTR_Object objPtr = PTR_Object(TADDR(objectAddress));
-    PTR_MethodTable pMT = objPtr->GetGCSafeMethodTable();
-
-    if (!objPtr->GetGCSafeTypeHandle().IsArray())
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        LOG((LF_CORDB, LL_INFO10000,
-             "D::GASOI: object should be an array.\n"));
 
-        pObjectData->objRefBad = true;
-    }
-    else
-    {
-        PTR_ArrayBase arrPtr = dac_cast<PTR_ArrayBase>(objPtr);
+        PTR_Object objPtr = PTR_Object(TADDR(objectAddress));
+        PTR_MethodTable pMT = objPtr->GetGCSafeMethodTable();
 
-        // this is also returned in the type information for the array - we return both for sanity checking...
-        pObjectData->arrayInfo.rank = arrPtr->GetRank();
-        pObjectData->arrayInfo.componentCount = arrPtr->GetNumComponents();
-        pObjectData->arrayInfo.offsetToArrayBase = arrPtr->GetDataPtrOffset(pMT);
-
-        if (arrPtr->IsMultiDimArray())
+        if (!objPtr->GetGCSafeTypeHandle().IsArray())
         {
-            pObjectData->arrayInfo.offsetToUpperBounds = SIZE_T(arrPtr->GetBoundsOffset(pMT));
+            LOG((LF_CORDB, LL_INFO10000,
+                 "D::GASOI: object should be an array.\n"));
 
-            pObjectData->arrayInfo.offsetToLowerBounds = SIZE_T(arrPtr->GetLowerBoundsOffset(pMT));
+            pObjectData->objRefBad = true;
         }
         else
         {
-            pObjectData->arrayInfo.offsetToUpperBounds = 0;
-            pObjectData->arrayInfo.offsetToLowerBounds = 0;
+            PTR_ArrayBase arrPtr = dac_cast<PTR_ArrayBase>(objPtr);
+
+            // this is also returned in the type information for the array - we return both for sanity checking...
+            pObjectData->arrayInfo.rank = arrPtr->GetRank();
+            pObjectData->arrayInfo.componentCount = arrPtr->GetNumComponents();
+            pObjectData->arrayInfo.offsetToArrayBase = arrPtr->GetDataPtrOffset(pMT);
+
+            if (arrPtr->IsMultiDimArray())
+            {
+                pObjectData->arrayInfo.offsetToUpperBounds = SIZE_T(arrPtr->GetBoundsOffset(pMT));
+
+                pObjectData->arrayInfo.offsetToLowerBounds = SIZE_T(arrPtr->GetLowerBoundsOffset(pMT));
+            }
+            else
+            {
+                pObjectData->arrayInfo.offsetToUpperBounds = 0;
+                pObjectData->arrayInfo.offsetToLowerBounds = 0;
+            }
+
+            pObjectData->arrayInfo.elementSize = arrPtr->GetComponentSize();
+
+            LOG((LF_CORDB, LL_INFO10000, "D::GOI: array info: "
+                "baseOff=%d, lowerOff=%d, upperOff=%d, cnt=%d, rank=%d, rank (2) = %d,"
+                 "eleSize=%d, eleType=0x%02x\n",
+                 pObjectData->arrayInfo.offsetToArrayBase,
+                 pObjectData->arrayInfo.offsetToLowerBounds,
+                 pObjectData->arrayInfo.offsetToUpperBounds,
+                 pObjectData->arrayInfo.componentCount,
+                 pObjectData->arrayInfo.rank,
+                 pObjectData->objTypeData.ArrayTypeData.arrayRank,
+                 pObjectData->arrayInfo.elementSize,
+                 pObjectData->objTypeData.ArrayTypeData.arrayTypeArg.elementType));
         }
-
-        pObjectData->arrayInfo.elementSize = arrPtr->GetComponentSize();
-
-        LOG((LF_CORDB, LL_INFO10000, "D::GOI: array info: "
-            "baseOff=%d, lowerOff=%d, upperOff=%d, cnt=%d, rank=%d, rank (2) = %d,"
-             "eleSize=%d, eleType=0x%02x\n",
-             pObjectData->arrayInfo.offsetToArrayBase,
-             pObjectData->arrayInfo.offsetToLowerBounds,
-             pObjectData->arrayInfo.offsetToUpperBounds,
-             pObjectData->arrayInfo.componentCount,
-             pObjectData->arrayInfo.rank,
-             pObjectData->objTypeData.ArrayTypeData.arrayRank,
-             pObjectData->arrayInfo.elementSize,
-             pObjectData->objTypeData.ArrayTypeData.arrayTypeArg.elementType));
     }
-} // DacDbiInterfaceImpl::GetArrayData
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 // DAC/DBI API: Get information about an object for which we have a reference, including the object size and
 // type information.
-void DacDbiInterfaceImpl::GetBasicObjectInfo(CORDB_ADDRESS             objectAddress,
-                                             CorElementType            type,
-                                             VMPTR_AppDomain           vmAppDomain,
-                                             DebuggerIPCE_ObjectData * pObjectData)
+HRESULT DacDbiInterfaceImpl::GetBasicObjectInfo(CORDB_ADDRESS objectAddress, CorElementType type, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData)
 {
     DD_ENTER_MAY_THROW;
 
-    PTR_Object objPtr = PTR_Object(TADDR(objectAddress));
-    pObjectData->objRefBad = CheckRef(objPtr);
-    if (pObjectData->objRefBad != true)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        // initialize object type, size, offset information. Note: We may have a different element type
-        // after this. For example, we may start with E_T_CLASS but return with something more specific.
-        InitObjectData (objPtr, vmAppDomain, pObjectData);
+
+        PTR_Object objPtr = PTR_Object(TADDR(objectAddress));
+        pObjectData->objRefBad = CheckRef(objPtr);
+        if (pObjectData->objRefBad != true)
+        {
+            // initialize object type, size, offset information. Note: We may have a different element type
+            // after this. For example, we may start with E_T_CLASS but return with something more specific.
+            InitObjectData (objPtr, vmAppDomain, pObjectData);
+        }
     }
-} // DacDbiInterfaceImpl::GetBasicObjectInfo
+    EX_CATCH_HRESULT(hr);
+    return hr;
+}
 
 // DAC/DBI API:
 // Returns the thread which owns the monitor lock on an object and the acquisition count
-MonitorLockInfo DacDbiInterfaceImpl::GetThreadOwningMonitorLock(VMPTR_Object vmObject)
+HRESULT DacDbiInterfaceImpl::GetThreadOwningMonitorLock(VMPTR_Object vmObject, OUT MonitorLockInfo * pRetVal)
 {
     DD_ENTER_MAY_THROW;
-    MonitorLockInfo info;
-    info.lockOwner = VMPTR_Thread::NullPtr();
-    info.acquisitionCount = 0;
 
-    Object* pObj = vmObject.GetDacPtr();
-
-    DWORD threadId = 0;
-    DWORD recursionCount = 0;
-    BOOL isLockHeld = pObj->GetHeader()->PassiveGetSyncBlock()->TryGetLockInfo(&threadId, &recursionCount);
-
-    if (!isLockHeld)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        // The lock is not owned by any thread, so no thread owning the monitor lock
-        return info;
-    }
+        MonitorLockInfo info;
+        info.lockOwner = VMPTR_Thread::NullPtr();
+        info.acquisitionCount = 0;
 
-    Thread *pThread = ThreadStore::GetThreadList(NULL);
-    while (pThread != NULL)
-    {
-        if(pThread->GetThreadId() == threadId)
+        Object* pObj = vmObject.GetDacPtr();
+
+        DWORD threadId = 0;
+        DWORD recursionCount = 0;
+        BOOL isLockHeld = pObj->GetHeader()->PassiveGetSyncBlock()->TryGetLockInfo(&threadId, &recursionCount);
+
+        if (!isLockHeld)
         {
-            info.lockOwner.SetDacTargetPtr(PTR_HOST_TO_TADDR(pThread));
-            info.acquisitionCount = recursionCount + 1; // The runtime tracks recursion count starting at 0, but diagnostics users expect it to start at 1.
-            return info;
+            *pRetVal = info;
         }
-        pThread = ThreadStore::GetThreadList(pThread);
+        else
+        {
+            Thread *pThread = ThreadStore::GetThreadList(NULL);
+            while (pThread != NULL)
+            {
+                if(pThread->GetThreadId() == threadId)
+                {
+                    info.lockOwner.SetDacTargetPtr(PTR_HOST_TO_TADDR(pThread));
+                    info.acquisitionCount = recursionCount + 1; // The runtime tracks recursion count starting at 0, but diagnostics users expect it to start at 1.
+                    break;
+                }
+                pThread = ThreadStore::GetThreadList(pThread);
+            }
+            if (pThread == NULL)
+            {
+                _ASSERTE(!"A thread should have been found");
+            }
+            *pRetVal = info;
+        }
     }
-    _ASSERTE(!"A thread should have been found");
-    return info;
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 // DAC/DBI API:
 // Enumerate all threads waiting on the monitor event for an object
-void DacDbiInterfaceImpl::EnumerateMonitorEventWaitList(VMPTR_Object                   vmObject,
-                                                        FP_THREAD_ENUMERATION_CALLBACK fpCallback,
-                                                        CALLBACK_DATA                  pUserData)
+HRESULT DacDbiInterfaceImpl::EnumerateMonitorEventWaitList(VMPTR_Object vmObject, FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
 {
     DD_ENTER_MAY_THROW;
 
-    Object* pObj = vmObject.GetDacPtr();
-
-    SyncBlock* psb = pObj->PassiveGetSyncBlock();
-
-    // no sync block means no wait list
-    if(psb == NULL)
-        return;
-
-    FieldDesc* pConditionTableField = (&g_CoreLib)->GetField(FIELD__MONITOR__CONDITION_TABLE);
-    CONDITIONAL_WEAK_TABLE_REF conditionTable = *(DPTR(CONDITIONAL_WEAK_TABLE_REF))PTR_TO_TADDR(pConditionTableField->GetStaticAddressHandle(pConditionTableField->GetBase()));
-
-
-    OBJECTREF condition = NULL;
-    if (!conditionTable->TryGetValue(OBJECTREF(pObj), &condition))
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        return;
-    }
 
-    MapSHash<TADDR, Thread*> waiterToThreadMap;
-    FieldDesc* pConditionWaiterField = (&g_CoreLib)->GetField(FIELD__CONDITION__WAITERS_HEAD);
-    FieldDesc* pWaiterNextField = (&g_CoreLib)->GetField(FIELD__WAITER__NEXT);
-    FieldDesc* pThisThreadWaiterField = (&g_CoreLib)->GetField(FIELD__CONDITION__CURRENT_THREAD_WAITER);
+        Object* pObj = vmObject.GetDacPtr();
 
-    // Build a map of Waiter objects to their owning Threads.
-    for (Thread *pThread = ThreadStore::GetThreadList(NULL); pThread != NULL; pThread = ThreadStore::GetThreadList(pThread))
-    {
-        PTR_PTR_Object pThisThreadWaiterStorage = dac_cast<PTR_PTR_Object>(pThread->GetStaticFieldAddrNoCreate(pThisThreadWaiterField));
-        if (pThisThreadWaiterStorage == NULL || *pThisThreadWaiterStorage == NULL)
+        SyncBlock* psb = pObj->PassiveGetSyncBlock();
+
+        // no sync block means no wait list
+        if(psb == NULL)
+            return hr;
+
+        FieldDesc* pConditionTableField = (&g_CoreLib)->GetField(FIELD__MONITOR__CONDITION_TABLE);
+        CONDITIONAL_WEAK_TABLE_REF conditionTable = *(DPTR(CONDITIONAL_WEAK_TABLE_REF))PTR_TO_TADDR(pConditionTableField->GetStaticAddressHandle(pConditionTableField->GetBase()));
+
+
+        OBJECTREF condition = NULL;
+        if (!conditionTable->TryGetValue(OBJECTREF(pObj), &condition))
         {
-            continue; // this thread is not waiting on the monitor for this object. It has never waited on any monitor.
+            return hr;
         }
 
-        OBJECTREF pThisThreadWaiter = *pThisThreadWaiterStorage;
-        waiterToThreadMap.Add(dac_cast<TADDR>(pThisThreadWaiter), pThread);
-    }
+        MapSHash<TADDR, Thread*> waiterToThreadMap;
+        FieldDesc* pConditionWaiterField = (&g_CoreLib)->GetField(FIELD__CONDITION__WAITERS_HEAD);
+        FieldDesc* pWaiterNextField = (&g_CoreLib)->GetField(FIELD__WAITER__NEXT);
+        FieldDesc* pThisThreadWaiterField = (&g_CoreLib)->GetField(FIELD__CONDITION__CURRENT_THREAD_WAITER);
 
-    // Iterate through the waiters in the condition object and invoke the user's callback for each thread
-    for (OBJECTREF pWaiter = pConditionWaiterField->GetRefValue(condition); pWaiter != NULL; pWaiter = pWaiterNextField->GetRefValue(pWaiter))
-    {
-        Thread* pThread = NULL;
-        if (!waiterToThreadMap.Lookup(dac_cast<TADDR>(pWaiter), &pThread))
+        // Build a map of Waiter objects to their owning Threads.
+        for (Thread *pThread = ThreadStore::GetThreadList(NULL); pThread != NULL; pThread = ThreadStore::GetThreadList(pThread))
         {
-            // This waiter is not in the map, so we can't find its thread.
-            LOG((LF_CORDB, LL_INFO10000, "D::EMEWL: Waiter not found in waiter->thread map.\n"));
-            continue;
+            PTR_PTR_Object pThisThreadWaiterStorage = dac_cast<PTR_PTR_Object>(pThread->GetStaticFieldAddrNoCreate(pThisThreadWaiterField));
+            if (pThisThreadWaiterStorage == NULL || *pThisThreadWaiterStorage == NULL)
+            {
+                continue; // this thread is not waiting on the monitor for this object. It has never waited on any monitor.
+            }
+
+            OBJECTREF pThisThreadWaiter = *pThisThreadWaiterStorage;
+            waiterToThreadMap.Add(dac_cast<TADDR>(pThisThreadWaiter), pThread);
         }
-        VMPTR_Thread vmThread = VMPTR_Thread::NullPtr();
-        vmThread.SetDacTargetPtr(PTR_HOST_TO_TADDR(pThread));
-        // Invoke the user's callback with the thread and user data
-        fpCallback(vmThread, pUserData);
+
+        // Iterate through the waiters in the condition object and invoke the user's callback for each thread
+        for (OBJECTREF pWaiter = pConditionWaiterField->GetRefValue(condition); pWaiter != NULL; pWaiter = pWaiterNextField->GetRefValue(pWaiter))
+        {
+            Thread* pThread = NULL;
+            if (!waiterToThreadMap.Lookup(dac_cast<TADDR>(pWaiter), &pThread))
+            {
+                // This waiter is not in the map, so we can't find its thread.
+                LOG((LF_CORDB, LL_INFO10000, "D::EMEWL: Waiter not found in waiter->thread map.\n"));
+                continue;
+            }
+            VMPTR_Thread vmThread = VMPTR_Thread::NullPtr();
+            vmThread.SetDacTargetPtr(PTR_HOST_TO_TADDR(pThread));
+            // Invoke the user's callback with the thread and user data
+            fpCallback(vmThread, pUserData);
+        }
     }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
-bool DacDbiInterfaceImpl::AreGCStructuresValid()
+HRESULT DacDbiInterfaceImpl::AreGCStructuresValid(OUT bool * pResult)
 {
-    return true;
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+        *pResult = true;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 HeapData::HeapData()
@@ -6631,13 +7258,20 @@ HRESULT DacHeapWalker::InitHeapDataWks(HeapData *&pHeaps, size_t &pCount)
     return hr;
 }
 
-void DacDbiInterfaceImpl::DeleteHeapWalk(HeapWalkHandle handle)
+HRESULT DacDbiInterfaceImpl::DeleteHeapWalk(HeapWalkHandle handle)
 {
     DD_ENTER_MAY_THROW;
 
-    DacHeapWalker *data = reinterpret_cast<DacHeapWalker*>(handle);
-    if (data)
-        delete data;
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        DacHeapWalker *data = reinterpret_cast<DacHeapWalker*>(handle);
+        if (data)
+            delete data;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 HRESULT DacDbiInterfaceImpl::WalkHeap(HeapWalkHandle handle,
@@ -6801,55 +7435,70 @@ HRESULT DacDbiInterfaceImpl::GetHeapSegments(OUT DacDbiArrayList<COR_SEGMENT> *p
     return hr;
 }
 
-bool DacDbiInterfaceImpl::IsValidObject(CORDB_ADDRESS addr)
+HRESULT DacDbiInterfaceImpl::IsValidObject(CORDB_ADDRESS obj, OUT bool * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-    bool isValid = false;
-
-    if (addr != 0 && addr != (CORDB_ADDRESS)-1)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        EX_TRY
-        {
-            PTR_Object obj(TO_TADDR(addr));
 
-            PTR_MethodTable mt = obj->GetMethodTable();
-            PTR_EEClass cls = mt->GetClass();
+        bool isValid = false;
 
-            if (mt == cls->GetMethodTable())
-                isValid = true;
-            else if (!mt->IsCanonicalMethodTable() || mt->IsContinuation())
-                isValid = cls->GetMethodTable()->GetClass() == cls;
-        }
-        EX_CATCH
+        if (obj != 0 && obj != (CORDB_ADDRESS)-1)
         {
-            isValid = false;
+            EX_TRY
+            {
+                PTR_Object pObj(TO_TADDR(obj));
+
+                PTR_MethodTable mt = pObj->GetMethodTable();
+                PTR_EEClass cls = mt->GetClass();
+
+                if (mt == cls->GetMethodTable())
+                    isValid = true;
+                else if (!mt->IsCanonicalMethodTable() || mt->IsContinuation())
+                    isValid = cls->GetMethodTable()->GetClass() == cls;
+            }
+            EX_CATCH
+            {
+                isValid = false;
+            }
+            EX_END_CATCH
         }
-        EX_END_CATCH
+
+        *pResult = isValid;
     }
-
-    return isValid;
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
-bool DacDbiInterfaceImpl::GetAppDomainForObject(CORDB_ADDRESS addr, OUT VMPTR_AppDomain * pAppDomain,
-                                                OUT VMPTR_Module *pModule, OUT VMPTR_DomainAssembly *pDomainAssembly)
+HRESULT DacDbiInterfaceImpl::GetAppDomainForObject(CORDB_ADDRESS obj, OUT VMPTR_AppDomain * pApp, OUT VMPTR_Module * pModule, OUT VMPTR_DomainAssembly * pDomainAssembly, OUT bool * pResult)
 {
     DD_ENTER_MAY_THROW;
 
-    if (addr == 0 || addr == (CORDB_ADDRESS)-1)
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        return false;
+
+        if (obj == 0 || obj == (CORDB_ADDRESS)-1)
+        {
+            *pResult = false;
+        }
+        else
+        {
+            PTR_Object pObj(TO_TADDR(obj));
+            MethodTable *mt = pObj->GetMethodTable();
+            PTR_Module module = mt->GetModule();
+
+            pApp->SetDacTargetPtr(PTR_HOST_TO_TADDR(AppDomain::GetCurrentDomain()));
+            pModule->SetDacTargetPtr(PTR_HOST_TO_TADDR(module));
+            pDomainAssembly->SetDacTargetPtr(PTR_HOST_TO_TADDR(module->GetDomainAssembly()));
+
+            *pResult = true;
+        }
     }
-
-    PTR_Object obj(TO_TADDR(addr));
-    MethodTable *mt = obj->GetMethodTable();
-    PTR_Module module = mt->GetModule();
-
-    pAppDomain->SetDacTargetPtr(PTR_HOST_TO_TADDR(AppDomain::GetCurrentDomain()));
-    pModule->SetDacTargetPtr(PTR_HOST_TO_TADDR(module));
-    pDomainAssembly->SetDacTargetPtr(PTR_HOST_TO_TADDR(module->GetDomainAssembly()));
-
-    return true;
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 HRESULT DacDbiInterfaceImpl::CreateRefWalk(OUT RefWalkHandle * pHandle, BOOL walkStacks, BOOL walkFQ, UINT32 handleWalkMask)
@@ -6875,14 +7524,21 @@ HRESULT DacDbiInterfaceImpl::CreateRefWalk(OUT RefWalkHandle * pHandle, BOOL wal
 }
 
 
-void DacDbiInterfaceImpl::DeleteRefWalk(IN RefWalkHandle handle)
+HRESULT DacDbiInterfaceImpl::DeleteRefWalk(RefWalkHandle handle)
 {
     DD_ENTER_MAY_THROW;
 
-    DacRefWalker *walker = reinterpret_cast<DacRefWalker*>(handle);
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
 
-    if (walker)
-        delete walker;
+        DacRefWalker *walker = reinterpret_cast<DacRefWalker*>(handle);
+
+        if (walker)
+            delete walker;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
@@ -7107,28 +7763,35 @@ HRESULT DacDbiInterfaceImpl::GetArrayLayout(COR_TYPEID id, COR_ARRAY_LAYOUT *pLa
 }
 
 
-void DacDbiInterfaceImpl::GetGCHeapInformation(COR_HEAPINFO * pHeapInfo)
+HRESULT DacDbiInterfaceImpl::GetGCHeapInformation(OUT COR_HEAPINFO * pHeapInfo)
 {
     DD_ENTER_MAY_THROW;
 
-    size_t heapCount = 0;
-    pHeapInfo->areGCStructuresValid = *g_gcDacGlobals->gc_structures_invalid_cnt == 0;
-
-#ifdef FEATURE_SVR_GC
-    if (GCHeapUtilities::IsServerHeap())
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        pHeapInfo->gcType = CorDebugServerGC;
-        pHeapInfo->numHeaps = DacGetNumHeaps();
-    }
-    else
-#endif
-    {
-        pHeapInfo->gcType = CorDebugWorkstationGC;
-        pHeapInfo->numHeaps = 1;
-    }
 
-    pHeapInfo->pointerSize = sizeof(TADDR);
-    pHeapInfo->concurrent = g_pConfig->GetGCconcurrent() ? TRUE : FALSE;
+        size_t heapCount = 0;
+        pHeapInfo->areGCStructuresValid = *g_gcDacGlobals->gc_structures_invalid_cnt == 0;
+
+    #ifdef FEATURE_SVR_GC
+        if (GCHeapUtilities::IsServerHeap())
+        {
+            pHeapInfo->gcType = CorDebugServerGC;
+            pHeapInfo->numHeaps = DacGetNumHeaps();
+        }
+        else
+    #endif
+        {
+            pHeapInfo->gcType = CorDebugWorkstationGC;
+            pHeapInfo->numHeaps = 1;
+        }
+
+        pHeapInfo->pointerSize = sizeof(TADDR);
+        pHeapInfo->concurrent = g_pConfig->GetGCconcurrent() ? TRUE : FALSE;
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 
@@ -7414,69 +8077,72 @@ static BYTE* DebugInfoStoreNew(void * pData, size_t cBytes)
     return new (nothrow) BYTE[cBytes];
 }
 
-void DacDbiInterfaceImpl::GetAsyncLocals(
-    VMPTR_MethodDesc vmMethod,
-    CORDB_ADDRESS codeAddr,
-    UINT32 state,
-    DacDbiArrayList<AsyncLocalData> * pAsyncLocals)
+HRESULT DacDbiInterfaceImpl::GetAsyncLocals(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeAddr, UINT32 state, OUT DacDbiArrayList<AsyncLocalData>* pAsyncLocals)
 {
     DD_ENTER_MAY_THROW;
 
-    MethodDesc* pMethodDesc = vmMethod.GetDacPtr();
-    if (pMethodDesc->IsAsyncThunkMethod())
+    HRESULT hr = S_OK;
+    EX_TRY
     {
-        return;
-    }
-    TADDR nativeCodeStartAddr;
-    if (codeAddr != (TADDR)NULL)
-    {
-        NativeCodeVersion requestedNativeCodeVersion = ExecutionManager::GetNativeCodeVersion(static_cast<PCODE>(codeAddr));
-        if (requestedNativeCodeVersion.IsNull() || requestedNativeCodeVersion.GetNativeCode() == (PCODE)NULL)
+
+        MethodDesc* pMethodDesc = vmMethod.GetDacPtr();
+        if (pMethodDesc->IsAsyncThunkMethod())
         {
-            return;
+            return hr;
         }
-        nativeCodeStartAddr = PCODEToPINSTR(requestedNativeCodeVersion.GetNativeCode());
+        TADDR nativeCodeStartAddr;
+        if (codeAddr != (TADDR)NULL)
+        {
+            NativeCodeVersion requestedNativeCodeVersion = ExecutionManager::GetNativeCodeVersion(static_cast<PCODE>(codeAddr));
+            if (requestedNativeCodeVersion.IsNull() || requestedNativeCodeVersion.GetNativeCode() == (PCODE)NULL)
+            {
+                return hr;
+            }
+            nativeCodeStartAddr = PCODEToPINSTR(requestedNativeCodeVersion.GetNativeCode());
+        }
+        else
+        {
+            nativeCodeStartAddr = PCODEToPINSTR(pMethodDesc->GetNativeCode());
+        }
+
+        DebugInfoRequest request;
+        request.InitFromStartingAddr(pMethodDesc, nativeCodeStartAddr);
+
+        ICorDebugInfo::AsyncInfo asyncInfo = {};
+        NewArrayHolder<ICorDebugInfo::AsyncSuspensionPoint> asyncSuspensionPoints(NULL);
+        NewArrayHolder<ICorDebugInfo::AsyncContinuationVarInfo> asyncVars(NULL);
+        ULONG32 cAsyncVars = 0;
+
+        BOOL success = DebugInfoManager::GetAsyncDebugInfo(
+            request,
+            DebugInfoStoreNew,
+            nullptr,
+            &asyncInfo,
+            &asyncSuspensionPoints,
+            &asyncVars,
+            &cAsyncVars);
+
+        if (!success) return hr;
+        if (state >= asyncInfo.NumSuspensionPoints) return hr;
+
+        UINT32 varBeginIndex = 0;
+        for (UINT32 i = 0; i < state; i++)
+        {
+            varBeginIndex += asyncSuspensionPoints[i].NumContinuationVars;
+        }
+
+        UINT32 varCount = asyncSuspensionPoints[state].NumContinuationVars;
+        pAsyncLocals->Alloc(varCount);
+
+        _ASSERTE(varBeginIndex + varCount <= cAsyncVars);
+        for (UINT32 i = 0; i < varCount; i++)
+        {
+            (*pAsyncLocals)[i].offset = asyncVars[varBeginIndex + i].Offset;
+            (*pAsyncLocals)[i].ilVarNum = asyncVars[varBeginIndex + i].VarNumber;
+        }
     }
-    else
-    {
-        nativeCodeStartAddr = PCODEToPINSTR(pMethodDesc->GetNativeCode());
-    }
-
-    DebugInfoRequest request;
-    request.InitFromStartingAddr(pMethodDesc, nativeCodeStartAddr);
-
-    ICorDebugInfo::AsyncInfo asyncInfo = {};
-    NewArrayHolder<ICorDebugInfo::AsyncSuspensionPoint> asyncSuspensionPoints(NULL);
-    NewArrayHolder<ICorDebugInfo::AsyncContinuationVarInfo> asyncVars(NULL);
-    ULONG32 cAsyncVars = 0;
-
-    BOOL success = DebugInfoManager::GetAsyncDebugInfo(
-        request,
-        DebugInfoStoreNew,
-        nullptr,
-        &asyncInfo,
-        &asyncSuspensionPoints,
-        &asyncVars,
-        &cAsyncVars);
-
-    if (!success) return;
-    if (state >= asyncInfo.NumSuspensionPoints) return;
-
-    UINT32 varBeginIndex = 0;
-    for (UINT32 i = 0; i < state; i++)
-    {
-        varBeginIndex += asyncSuspensionPoints[i].NumContinuationVars;
-    }
-
-    UINT32 varCount = asyncSuspensionPoints[state].NumContinuationVars;
-    pAsyncLocals->Alloc(varCount);
-
-    _ASSERTE(varBeginIndex + varCount <= cAsyncVars);
-    for (UINT32 i = 0; i < varCount; i++)
-    {
-        (*pAsyncLocals)[i].offset = asyncVars[varBeginIndex + i].Offset;
-        (*pAsyncLocals)[i].ilVarNum = asyncVars[varBeginIndex + i].VarNumber;
-    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
 HRESULT DacDbiInterfaceImpl::GetGenericArgTokenIndex(VMPTR_MethodDesc vmMethod, OUT UINT32* pIndex)

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -34,7 +34,9 @@
 //-----------------------------------------------------------------------------
 // Have standard enter and leave macros at the DacDbi boundary to enforce
 // standard behavior.
-// 1. catch exceptions and convert them at the boundary.
+// 1. Methods return HRESULT and wrap their bodies with EX_TRY/EX_CATCH_HRESULT
+//    to catch exceptions inside the DAC and convert them to HRESULTs before
+//    crossing the DSO boundary.
 // 2. provide a space to hook logging and transitions.
 // 3. provide a hook to verify return values.
 //
@@ -46,11 +48,15 @@
 //  Foo()
 //  {
 //      DD_ENTER_MAY_THROW
-//      ...
-//      if (...) { ThrowHr(E_SOME_FAILURE); }
-//      ...
-//      if (...) { return; } // early success case
-//      ...
+//      HRESULT hr = S_OK;
+//      EX_TRY
+//      {
+//          ...
+//          if (...) { ThrowHR(E_SOME_FAILURE); }
+//          ...
+//      }
+//      EX_CATCH_HRESULT(hr);
+//      return hr;
 //  }
 //-----------------------------------------------------------------------------
 

--- a/src/coreclr/debug/daccess/dacdbiimpl.h
+++ b/src/coreclr/debug/daccess/dacdbiimpl.h
@@ -65,11 +65,11 @@ public:
     HRESULT FlushCache();
 
     // enable or disable DAC target consistency checks
-    void DacSetTargetConsistencyChecks(bool fEnableAsserts);
+    HRESULT DacSetTargetConsistencyChecks(bool fEnableAsserts);
 
     // Destroy the interface object. The client should call this when it's done
     // with the IDacDbiInterface to free up any resources.
-    void Destroy();
+    HRESULT Destroy();
 
     IAllocator * GetAllocator()
     {
@@ -78,27 +78,25 @@ public:
 
 
     // Is Left-side started up?
-    BOOL IsLeftSideInitialized();
+    HRESULT IsLeftSideInitialized(OUT BOOL * pResult);
 
     // Get an LS Appdomain via an AppDomain unique ID.
     // Fails if the AD is not found or if the ID is invalid.
-    VMPTR_AppDomain GetAppDomainFromId(ULONG appdomainId);
+    HRESULT GetAppDomainFromId(ULONG appdomainId, OUT VMPTR_AppDomain * pRetVal);
 
     // Get the AppDomain ID for an AppDomain.
-    ULONG GetAppDomainId(VMPTR_AppDomain vmAppDomain);
+    HRESULT GetAppDomainId(VMPTR_AppDomain vmAppDomain, OUT ULONG * pRetVal);
 
     // Get the managed AppDomain object for an AppDomain.
-    VMPTR_OBJECTHANDLE GetAppDomainObject(VMPTR_AppDomain vmAppDomain);
+    HRESULT GetAppDomainObject(VMPTR_AppDomain vmAppDomain, OUT VMPTR_OBJECTHANDLE * pRetVal);
 
     // Get the full AD friendly name for the appdomain.
-    void GetAppDomainFullName(
-        VMPTR_AppDomain vmAppDomain,
-        IStringHolder * pStrName);
+    HRESULT GetAppDomainFullName(VMPTR_AppDomain vmAppDomain, IStringHolder * pStrName);
 
     // Get the values of the JIT Optimization and EnC flags.
-    void GetCompilerFlags (VMPTR_DomainAssembly vmDomainAssembly,
-                           BOOL * pfAllowJITOpts,
-                           BOOL * pfEnableEnC);
+    HRESULT GetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly,
+                           OUT BOOL * pfAllowJITOpts,
+                           OUT BOOL * pfEnableEnC);
 
     // Helper function for SetCompilerFlags to set EnC status
     bool CanSetEnCBits(Module * pModule);
@@ -110,18 +108,14 @@ public:
 
 
     // Initialize the native/IL sequence points and native var info for a function.
-    void GetNativeCodeSequencePointsAndVarInfo(VMPTR_MethodDesc  vmMethodDesc,
-                                               CORDB_ADDRESS     startAddr,
-                                               BOOL              fCodeAvailable,
-                                               NativeVarData *   pNativeVarData,
-                                               SequencePoints *  pSequencePoints);
+    HRESULT GetNativeCodeSequencePointsAndVarInfo(VMPTR_MethodDesc vmMethodDesc, CORDB_ADDRESS startAddress, BOOL fCodeAvailable, OUT NativeVarData * pNativeVarData, OUT SequencePoints * pSequencePoints);
 
-    bool IsThreadSuspendedOrHijacked(VMPTR_Thread vmThread);
+    HRESULT IsThreadSuspendedOrHijacked(VMPTR_Thread vmThread, OUT bool * pResult);
 
 
-    bool AreGCStructuresValid();
+    HRESULT AreGCStructuresValid(OUT bool * pResult);
     HRESULT CreateHeapWalk(HeapWalkHandle *pHandle);
-    void DeleteHeapWalk(HeapWalkHandle handle);
+    HRESULT DeleteHeapWalk(HeapWalkHandle handle);
 
     HRESULT WalkHeap(HeapWalkHandle handle,
                      ULONG count,
@@ -131,14 +125,14 @@ public:
     HRESULT GetHeapSegments(OUT DacDbiArrayList<COR_SEGMENT> *pSegments);
 
 
-    bool IsValidObject(CORDB_ADDRESS obj);
+    HRESULT IsValidObject(CORDB_ADDRESS obj, OUT bool * pResult);
 
-    bool GetAppDomainForObject(CORDB_ADDRESS obj, OUT VMPTR_AppDomain * pApp, OUT VMPTR_Module *pModule, OUT VMPTR_DomainAssembly *mod);
+    HRESULT GetAppDomainForObject(CORDB_ADDRESS obj, OUT VMPTR_AppDomain * pApp, OUT VMPTR_Module * pModule, OUT VMPTR_DomainAssembly * pDomainAssembly, OUT bool * pResult);
 
 
 
     HRESULT CreateRefWalk(RefWalkHandle * pHandle, BOOL walkStacks, BOOL walkFQ, UINT32 handleWalkMask);
-    void DeleteRefWalk(RefWalkHandle handle);
+    HRESULT DeleteRefWalk(RefWalkHandle handle);
     HRESULT WalkRefs(RefWalkHandle handle, ULONG count, OUT DacGcReference * objects, OUT ULONG *pFetched);
 
     HRESULT GetTypeID(CORDB_ADDRESS obj, COR_TYPEID *pID);
@@ -148,7 +142,7 @@ public:
     HRESULT GetObjectFields(COR_TYPEID id, ULONG32 celt, COR_FIELD *layout, ULONG32 *pceltFetched);
     HRESULT GetTypeLayout(COR_TYPEID id, COR_TYPE_LAYOUT *pLayout);
     HRESULT GetArrayLayout(COR_TYPEID id, COR_ARRAY_LAYOUT *pLayout);
-    void GetGCHeapInformation(COR_HEAPINFO * pHeapInfo);
+    HRESULT GetGCHeapInformation(OUT COR_HEAPINFO * pHeapInfo);
     HRESULT GetPEFileMDInternalRW(VMPTR_PEAssembly vmPEAssembly, OUT TADDR* pAddrMDInternalRW);
     HRESULT GetReJitInfo(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ReJitInfo* pReJitInfo);
 #ifdef FEATURE_CODE_VERSIONING
@@ -169,10 +163,7 @@ public:
                                               OUT PCODE *pDiagnosticIP,
                                               OUT CORDB_ADDRESS *pNextContinuation,
                                               OUT UINT32 *pState);
-    void GetAsyncLocals(VMPTR_MethodDesc vmMethod,
-                        CORDB_ADDRESS codeAddr,
-                        UINT32 state,
-                        DacDbiArrayList<AsyncLocalData> * pAsyncLocals);
+    HRESULT GetAsyncLocals(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeAddr, UINT32 state, OUT DacDbiArrayList<AsyncLocalData>* pAsyncLocals);
     HRESULT GetGenericArgTokenIndex(VMPTR_MethodDesc vmMethod, OUT UINT32* pIndex);
 
 private:
@@ -224,10 +215,7 @@ public:
     // a module and a token. The info will come from a MethodDesc, if
     // one exists or from metadata.
     //
-    void GetILCodeAndSig(VMPTR_DomainAssembly vmDomainAssembly,
-                         mdToken          functionToken,
-                         TargetBuffer *   pCodeInfo,
-                         mdToken *        pLocalSigToken);
+    HRESULT GetILCodeAndSig(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT TargetBuffer * pCodeInfo, OUT mdToken * pLocalSigToken);
 
     // Gets the following information about the native code blob for a function, if the native
     // code is available:
@@ -235,9 +223,7 @@ public:
     //    whether it's an instantiated generic
     //    its EnC version number
     //    hot and cold region information.
-    void GetNativeCodeInfo(VMPTR_DomainAssembly         vmDomainAssembly,
-                           mdToken                  functionToken,
-                           NativeCodeFunctionData * pCodeInfo);
+    HRESULT GetNativeCodeInfo(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT NativeCodeFunctionData * pCodeInfo);
 
     // Gets the following information about the native code blob for a function
     //    its method desc
@@ -246,10 +232,7 @@ public:
     //    hot and cold region information
     //    its module
     //    its metadata token.
-    void GetNativeCodeInfoForAddr(CORDB_ADDRESS            codeAddress,
-                                  NativeCodeFunctionData * pCodeInfo,
-                                  VMPTR_Module *           pVmModule,
-                                  mdToken *                pFunctionToken);
+    HRESULT GetNativeCodeInfoForAddr(CORDB_ADDRESS codeAddress, NativeCodeFunctionData * pCodeInfo, VMPTR_Module * pVmModule, mdToken * pFunctionToken);
 
 private:
     // Get start addresses and sizes for hot and cold regions for a native code blob
@@ -258,51 +241,35 @@ private:
 
 public:
     // Determine if a type is a ValueType
-    BOOL IsValueType (VMPTR_TypeHandle th);
+    HRESULT IsValueType(VMPTR_TypeHandle th, OUT BOOL * pResult);
 
     // Determine if a type has generic parameters
-    BOOL HasTypeParams (VMPTR_TypeHandle th);
+    HRESULT HasTypeParams(VMPTR_TypeHandle th, OUT BOOL * pResult);
 
     // Get type information for a class
-    void GetClassInfo (VMPTR_AppDomain  vmAppDomain,
-                       VMPTR_TypeHandle thExact,
-                       ClassInfo *      pData);
+    HRESULT GetClassInfo(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle thExact, ClassInfo * pData);
 
     // get field information and object size for an instantiated generic type
-    void GetInstantiationFieldInfo (VMPTR_DomainAssembly             vmDomainAssembly,
-                                    VMPTR_TypeHandle             vmThExact,
-                                    VMPTR_TypeHandle             vmThApprox,
-                                    DacDbiArrayList<FieldData> * pFieldList,
-                                    SIZE_T *                     pObjectSize);
+    HRESULT GetInstantiationFieldInfo(VMPTR_DomainAssembly vmDomainAssembly, VMPTR_TypeHandle vmThExact, VMPTR_TypeHandle vmThApprox, OUT DacDbiArrayList<FieldData> * pFieldList, OUT SIZE_T * pObjectSize);
 
 
-    void GetObjectExpandedTypeInfo(AreValueTypesBoxed boxed,
-                                   VMPTR_AppDomain vmAppDomain,
-                                   CORDB_ADDRESS addr,
-                                   DebuggerIPCE_ExpandedTypeData *pTypeInfo);
+    HRESULT GetObjectExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, CORDB_ADDRESS addr, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo);
 
 
-    void GetObjectExpandedTypeInfoFromID(AreValueTypesBoxed boxed,
-                                         VMPTR_AppDomain vmAppDomain,
-                                         COR_TYPEID id,
-                                         DebuggerIPCE_ExpandedTypeData *pTypeInfo);
+    HRESULT GetObjectExpandedTypeInfoFromID(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, COR_TYPEID id, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo);
 
 
     // @dbgtodo Microsoft inspection: change DebuggerIPCE_ExpandedTypeData to DacDbiStructures type hierarchy
     // once ICorDebugType and ICorDebugClass are DACized
     // use a type handle to get the information needed to create the corresponding RS CordbType instance
-    void TypeHandleToExpandedTypeInfo(AreValueTypesBoxed                       boxed,
-                                      VMPTR_AppDomain                          vmAppDomain,
-                                      VMPTR_TypeHandle                         vmTypeHandle,
-                                      DebuggerIPCE_ExpandedTypeData *          pTypeInfo);
+    HRESULT TypeHandleToExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, DebuggerIPCE_ExpandedTypeData * pTypeInfo);
 
     // Get type handle for a TypeDef token, if one exists. For generics this returns the open type.
-    VMPTR_TypeHandle GetTypeHandle(VMPTR_Module vmModule,
-                                   mdTypeDef metadataToken);
+    HRESULT GetTypeHandle(VMPTR_Module vmModule, mdTypeDef metadataToken, OUT VMPTR_TypeHandle * pRetVal);
 
     // Get the approximate type handle for an instantiated type. This may be identical to the exact type handle,
     // but if we have code sharing for generics,it may differ in that it may have canonical type parameters.
-    VMPTR_TypeHandle GetApproxTypeHandle(TypeInfoList * pTypeData);
+    HRESULT GetApproxTypeHandle(TypeInfoList * pTypeData, OUT VMPTR_TypeHandle * pRetVal);
 
     // Get the exact type handle from type data
     HRESULT GetExactTypeHandle(DebuggerIPCE_ExpandedTypeData * pTypeData,
@@ -311,50 +278,36 @@ public:
 
     // Retrieve the generic type params for a given MethodDesc.  This function is specifically
     // for stackwalking because it requires the generic type token on the stack.
-    void GetMethodDescParams(VMPTR_AppDomain     vmAppDomain,
-                             VMPTR_MethodDesc    vmMethodDesc,
-                             GENERICS_TYPE_TOKEN genericsToken,
-                             UINT32 *            pcGenericClassTypeParams,
-                             TypeParamsList *    pGenericTypeParams);
+    HRESULT GetMethodDescParams(VMPTR_AppDomain vmAppDomain, VMPTR_MethodDesc vmMethodDesc, GENERICS_TYPE_TOKEN genericsToken, OUT UINT32 * pcGenericClassTypeParams, OUT TypeParamsList * pGenericTypeParams);
 
     // Get the target field address of a context or thread local static.
-    CORDB_ADDRESS GetThreadStaticAddress(VMPTR_FieldDesc vmField,
-                                         VMPTR_Thread    vmRuntimeThread);
+    HRESULT GetThreadStaticAddress(VMPTR_FieldDesc vmField, VMPTR_Thread vmRuntimeThread, OUT CORDB_ADDRESS * pRetVal);
 
     // Get the target field address of a collectible types static.
-    CORDB_ADDRESS GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmField,
-                                                  VMPTR_AppDomain vmAppDomain);
+    HRESULT GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmField, VMPTR_AppDomain vmAppDomain, OUT CORDB_ADDRESS * pRetVal);
 
     // Get information about a field added with Edit And Continue.
-    void GetEnCHangingFieldInfo(const EnCHangingFieldInfo * pEnCFieldInfo,
-                                FieldData *           pFieldData,
-                                BOOL *                pfStatic);
+    HRESULT GetEnCHangingFieldInfo(const EnCHangingFieldInfo * pEnCFieldInfo, OUT FieldData * pFieldData, OUT BOOL * pfStatic);
 
     // GetTypeHandleParams gets the necessary data for a type handle, i.e. its
     // type parameters, e.g. "String" and "List<int>" from the type handle
     // for "Dict<String,List<int>>", and sends it back to the right side.
     // This should not fail except for OOM
 
-    void GetTypeHandleParams(VMPTR_AppDomain  vmAppDomain,
-                             VMPTR_TypeHandle vmTypeHandle,
-                             TypeParamsList * pParams);
+    HRESULT GetTypeHandleParams(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, OUT TypeParamsList * pParams);
 
     // DacDbi API: GetSimpleType
     // gets the metadata token and domain file corresponding to a simple type
-    void GetSimpleType(VMPTR_AppDomain    vmAppDomain,
-                       CorElementType     simpleType,
-                       mdTypeDef *        pMetadataToken,
-                       VMPTR_Module     * pVmModule,
-                       VMPTR_DomainAssembly * pVmDomainAssembly);
+    HRESULT GetSimpleType(VMPTR_AppDomain vmAppDomain, CorElementType simpleType, OUT mdTypeDef * pMetadataToken, OUT VMPTR_Module * pVmModule, OUT VMPTR_DomainAssembly * pVmDomainAssembly);
 
-    BOOL IsExceptionObject(VMPTR_Object vmObject);
+    HRESULT IsExceptionObject(VMPTR_Object vmObject, OUT BOOL * pResult);
 
-    void GetStackFramesFromException(VMPTR_Object vmObject, DacDbiArrayList<DacExceptionCallStackData>& dacStackFrames);
+    HRESULT GetStackFramesFromException(VMPTR_Object vmObject, DacDbiArrayList<DacExceptionCallStackData>& dacStackFrames);
 
     // Returns true if the argument is a runtime callable wrapper
-    BOOL IsRcw(VMPTR_Object vmObject);
+    HRESULT IsRcw(VMPTR_Object vmObject, OUT BOOL * pResult);
 
-    BOOL IsDelegate(VMPTR_Object vmObject);
+    HRESULT IsDelegate(VMPTR_Object vmObject, OUT BOOL * pResult);
 
     HRESULT GetDelegateType(VMPTR_Object delegateObject, DelegateType *delegateType);
 
@@ -374,39 +327,26 @@ public:
 
     HRESULT IsModuleMapped(VMPTR_Module pModule, OUT BOOL *isModuleMapped);
 
-    bool MetadataUpdatesApplied();
+    HRESULT MetadataUpdatesApplied(OUT bool * pResult);
 
     // retrieves the list of COM interfaces implemented by vmObject, as it is known at
     // the time of the call (the list may change as new interface types become available
     // in the runtime)
-    void GetRcwCachedInterfaceTypes(
-                        VMPTR_Object vmObject,
-                        VMPTR_AppDomain vmAppDomain,
-                        BOOL bIInspectableOnly,
-                        OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pDacInterfaces);
+    HRESULT GetRcwCachedInterfaceTypes(VMPTR_Object vmObject, VMPTR_AppDomain vmAppDomain, BOOL bIInspectableOnly, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pDacInterfaces);
 
     // retrieves the list of interfaces pointers implemented by vmObject, as it is known at
     // the time of the call (the list may change as new interface types become available
     // in the runtime)
-    void GetRcwCachedInterfacePointers(
-                        VMPTR_Object vmObject,
-                        BOOL bIInspectableOnly,
-                        OUT DacDbiArrayList<CORDB_ADDRESS> * pDacItfPtrs);
+    HRESULT GetRcwCachedInterfacePointers(VMPTR_Object vmObject, BOOL bIInspectableOnly, OUT DacDbiArrayList<CORDB_ADDRESS> * pDacItfPtrs);
 
     // retrieves a list of interface types corresponding to the passed in
     // list of IIDs. the interface types are retrieved from an app domain
     // IID / Type cache, that is updated as new types are loaded. will
     // have NULL entries corresponding to unknown IIDs in "iids"
-    void GetCachedWinRTTypesForIIDs(
-                        VMPTR_AppDomain vmAppDomain,
-    					DacDbiArrayList<GUID> & iids,
-	    				OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes);
+    HRESULT GetCachedWinRTTypesForIIDs(VMPTR_AppDomain vmAppDomain, DacDbiArrayList<GUID> & iids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes);
 
     // retrieves the whole app domain cache of IID / Type mappings.
-    void GetCachedWinRTTypes(
-                        VMPTR_AppDomain vmAppDomain,
-                        OUT DacDbiArrayList<GUID> * pGuids,
-                        OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes);
+    HRESULT GetCachedWinRTTypes(VMPTR_AppDomain vmAppDomain, OUT DacDbiArrayList<GUID> * piids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes);
 
 private:
     // Helper to enumerate all possible memory ranges help by a loader allocator.
@@ -428,7 +368,7 @@ private:
         TADDR funcIp,
         OUT VMPTR_MethodDesc *ppMD);
 
-    BOOL IsExceptionObject(MethodTable* pMT);
+    HRESULT IsExceptionObject(VMPTR_Object vmObject, OUT BOOL * pResult);
 
     // Get the approximate and exact type handles for a type
     void GetTypeHandles(VMPTR_TypeHandle  vmThExact,
@@ -644,32 +584,25 @@ private:
 public:
     // Get object information for a TypedByRef object. Initializes the objRef and typedByRefType fields of
     // pObjectData (type info for the referent).
-    void GetTypedByRefInfo(CORDB_ADDRESS             pTypedByRef,
-                           VMPTR_AppDomain           vmAppDomain,
-                           DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData);
 
     // Get the string length and offset to string base for a string object
-    void GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData);
 
     // Get information for an array type referent of an objRef, including rank, upper and lower bounds,
     // element size and type, and the number of elements.
-    void GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData);
 
     // Get information about an object for which we have a reference, including the object size and
     // type information.
-    void GetBasicObjectInfo(CORDB_ADDRESS             objectAddress,
-                            CorElementType            type,
-                            VMPTR_AppDomain           vmAppDomain,
-                            DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT GetBasicObjectInfo(CORDB_ADDRESS objectAddress, CorElementType type, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData);
 
     // Returns the thread which owns the monitor lock on an object and the acquisition count
-    MonitorLockInfo GetThreadOwningMonitorLock(VMPTR_Object vmObject);
+    HRESULT GetThreadOwningMonitorLock(VMPTR_Object vmObject, OUT MonitorLockInfo * pRetVal);
 
 
     // Enumerate all threads waiting on the monitor event for an object
-    void EnumerateMonitorEventWaitList(VMPTR_Object                   vmObject,
-                                       FP_THREAD_ENUMERATION_CALLBACK fpCallback,
-                                       CALLBACK_DATA                  pUserData);
+    HRESULT EnumerateMonitorEventWaitList(VMPTR_Object vmObject, FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
 
 private:
     // Helper function for CheckRef. Sanity check an object.
@@ -694,8 +627,8 @@ private:
 
 #ifdef TEST_DATA_CONSISTENCY
 public:
-    void TestCrst(VMPTR_Crst vmCrst);
-    void TestRWLock(VMPTR_SimpleRWLock vmRWLock);
+    HRESULT TestCrst(VMPTR_Crst vmCrst);
+    HRESULT TestRWLock(VMPTR_SimpleRWLock vmRWLock);
 #endif
 
 // ============================================================================
@@ -707,232 +640,199 @@ public:
 
 public:
     // Get the full path and file name to the assembly's manifest module.
-    BOOL GetAssemblyPath(VMPTR_Assembly  vmAssembly,
-                         IStringHolder * pStrFilename);
+    HRESULT GetAssemblyPath(VMPTR_Assembly vmAssembly, IStringHolder * pStrFilename, OUT BOOL * pResult);
 
-    void GetAssemblyFromDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, VMPTR_Assembly *vmAssembly);
+    HRESULT GetAssemblyFromDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Assembly * vmAssembly);
 
     // Determines whether the runtime security system has assigned full-trust to this assembly.
-    BOOL IsAssemblyFullyTrusted(VMPTR_DomainAssembly vmDomainAssembly);
+    HRESULT IsAssemblyFullyTrusted(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pResult);
 
     // get a type def resolved across modules
-    void ResolveTypeReference(const TypeRefData * pTypeRefInfo,
-                              TypeRefData *       pTargetRefInfo);
+    HRESULT ResolveTypeReference(const TypeRefData * pTypeRefInfo, TypeRefData * pTargetRefInfo);
 
     // Get the full path and file name to the module (if any).
-    BOOL GetModulePath(VMPTR_Module vmModule,
-                       IStringHolder *  pStrFilename);
+    HRESULT GetModulePath(VMPTR_Module vmModule, IStringHolder * pStrFilename, OUT BOOL * pResult);
 
     // Implementation of IDacDbiInterface::GetModuleSimpleName
-    void GetModuleSimpleName(VMPTR_Module vmModule, IStringHolder * pStrFilename);
+    HRESULT GetModuleSimpleName(VMPTR_Module vmModule, IStringHolder * pStrFilename);
 
     // Implementation of IDacDbiInterface::GetMetadata
-    void GetMetadata(VMPTR_Module vmModule, TargetBuffer * pTargetBuffer);
+    HRESULT GetMetadata(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer);
 
     // Implementation of IDacDbiInterface::GetSymbolsBuffer
-    void GetSymbolsBuffer(VMPTR_Module vmModule, TargetBuffer * pTargetBuffer, SymbolFormat * pSymbolFormat);
+    HRESULT GetSymbolsBuffer(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer, OUT SymbolFormat * pSymbolFormat);
 
     // Gets properties for a module
-    void GetModuleData(VMPTR_Module vmModule, ModuleInfo * pData);
+    HRESULT GetModuleData(VMPTR_Module vmModule, OUT ModuleInfo * pData);
 
     // Gets properties for a domain assembly
-    void GetDomainAssemblyData(VMPTR_DomainAssembly vmDomainAssembly, DomainAssemblyInfo * pData);
+    HRESULT GetDomainAssemblyData(VMPTR_DomainAssembly vmDomainAssembly, OUT DomainAssemblyInfo * pData);
 
-    void GetModuleForDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Module * pModule);
+    HRESULT GetModuleForDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Module * pModule);
 
     // Yields true if the address is a CLR stub.
-    BOOL IsTransitionStub(CORDB_ADDRESS address);
+    HRESULT IsTransitionStub(CORDB_ADDRESS address, OUT BOOL * pResult);
 
     // Get the "type" of address.
-    AddressType GetAddressType(CORDB_ADDRESS address);
+    HRESULT GetAddressType(CORDB_ADDRESS address, OUT AddressType * pRetVal);
 
 
     // Enumerate the appdomains
-    void EnumerateAppDomains(FP_APPDOMAIN_ENUMERATION_CALLBACK fpCallback,
-                                void *                            pUserData);
+    HRESULT EnumerateAppDomains(FP_APPDOMAIN_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
 
     // Enumerate the assemblies in the appdomain.
-    void  EnumerateAssembliesInAppDomain(VMPTR_AppDomain vmAppDomain,
-                                           FP_ASSEMBLY_ENUMERATION_CALLBACK fpCallback,
-                                           void *                           pUserData);
+    HRESULT EnumerateAssembliesInAppDomain(VMPTR_AppDomain vmAppDomain, FP_ASSEMBLY_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
 
     // Enumerate the moduels in the given assembly.
-    void EnumerateModulesInAssembly(
-        VMPTR_DomainAssembly vmAssembly,
-        FP_MODULE_ENUMERATION_CALLBACK fpCallback,
-        void * pUserData
-        );
+    HRESULT EnumerateModulesInAssembly(VMPTR_DomainAssembly vmAssembly, FP_MODULE_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
 
     // When stopped at an event, request a synchronization.
-    void RequestSyncAtEvent();
+    HRESULT RequestSyncAtEvent();
 
     //sets flag Debugger::m_sendExceptionsOutsideOfJMC on the LS
     HRESULT SetSendExceptionsOutsideOfJMC(BOOL sendExceptionsOutsideOfJMC);
 
     // Notify the debuggee that a debugger attach is pending.
-    void MarkDebuggerAttachPending();
+    HRESULT MarkDebuggerAttachPending();
 
     // Notify the debuggee that a debugger is attached.
-    void MarkDebuggerAttached(BOOL fAttached);
+    HRESULT MarkDebuggerAttached(BOOL fAttached);
 
     // Enumerate connections in the process.
     void EnumerateConnections(FP_CONNECTION_CALLBACK fpCallback, void * pUserData);
 
-    void EnumerateThreads(FP_THREAD_ENUMERATION_CALLBACK fpCallback, void * pUserData);
+    HRESULT EnumerateThreads(FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
 
-    bool IsThreadMarkedDead(VMPTR_Thread vmThread);
+    HRESULT IsThreadMarkedDead(VMPTR_Thread vmThread, OUT bool * pResult);
 
     // Return the handle of the specified thread.
-    HANDLE GetThreadHandle(VMPTR_Thread vmThread);
+    HRESULT GetThreadHandle(VMPTR_Thread vmThread, OUT HANDLE * pRetVal);
 
     // Return the object handle for the managed Thread object corresponding to the specified thread.
-    VMPTR_OBJECTHANDLE GetThreadObject(VMPTR_Thread vmThread);
+    HRESULT GetThreadObject(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal);
 
     // Get the alocated bytes for this thread.
-    void GetThreadAllocInfo(VMPTR_Thread vmThread, DacThreadAllocInfo* threadAllocInfo);
+    HRESULT GetThreadAllocInfo(VMPTR_Thread vmThread, DacThreadAllocInfo* threadAllocInfo);
 
     // Set and reset the TSNC_DebuggerUserSuspend bit on the state of the specified thread
     // according to the CorDebugThreadState.
-    void SetDebugState(VMPTR_Thread        vmThread,
-                       CorDebugThreadState debugState);
+    HRESULT SetDebugState(VMPTR_Thread vmThread, CorDebugThreadState debugState);
 
     // Returns TRUE if there is a current exception which is unhandled
-    BOOL HasUnhandledException(VMPTR_Thread vmThread);
+    HRESULT HasUnhandledException(VMPTR_Thread vmThread, OUT BOOL * pResult);
 
     // Return the user state of the specified thread.
-    CorDebugUserState GetUserState(VMPTR_Thread vmThread);
+    HRESULT GetUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal);
 
     // Returns the user state of the specified thread except for USER_UNSAFE_POINT.
-    CorDebugUserState GetPartialUserState(VMPTR_Thread vmThread);
+    HRESULT GetPartialUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal);
 
     // Return the connection ID of the specified thread.
-    CONNID GetConnectionID(VMPTR_Thread vmThread);
+    HRESULT GetConnectionID(VMPTR_Thread vmThread, OUT CONNID * pRetVal);
 
     // Return the task ID of the specified thread.
-    TASKID GetTaskID(VMPTR_Thread vmThread);
+    HRESULT GetTaskID(VMPTR_Thread vmThread, OUT TASKID * pRetVal);
 
     // Return the OS thread ID of the specified thread
-    DWORD TryGetVolatileOSThreadID(VMPTR_Thread vmThread);
+    HRESULT TryGetVolatileOSThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal);
 
     // Return the unique thread ID of the specified thread.
-    DWORD GetUniqueThreadID(VMPTR_Thread vmThread);
+    HRESULT GetUniqueThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal);
 
     // Return the object handle to the managed Exception object of the current exception
     // on the specified thread.  The return value could be NULL if there is no current exception.
-    VMPTR_OBJECTHANDLE GetCurrentException(VMPTR_Thread vmThread);
+    HRESULT GetCurrentException(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal);
 
     // Return the object handle to the managed object for a given CCW pointer.
-    VMPTR_OBJECTHANDLE GetObjectForCCW(CORDB_ADDRESS ccwPtr);
+    HRESULT GetObjectForCCW(CORDB_ADDRESS ccwPtr, OUT VMPTR_OBJECTHANDLE * pRetVal);
 
     // Return the object handle to the managed CustomNotification object of the current notification
     // on the specified thread.  The return value could be NULL if there is no current notification.
     // This will return non-null if and only if we are currently inside a CustomNotification Callback
     // (or a dump was generated while in this callback)
-    VMPTR_OBJECTHANDLE GetCurrentCustomDebuggerNotification(VMPTR_Thread vmThread);
+    HRESULT GetCurrentCustomDebuggerNotification(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal);
 
     // Return the current appdomain
-    VMPTR_AppDomain GetCurrentAppDomain();
+    HRESULT GetCurrentAppDomain(OUT VMPTR_AppDomain * pRetVal);
 
     // Given an assembly ref token and metadata scope (via the DomainAssembly), resolve the assembly.
-    VMPTR_DomainAssembly ResolveAssembly(VMPTR_DomainAssembly vmScope, mdToken tkAssemblyRef);
+    HRESULT ResolveAssembly(VMPTR_DomainAssembly vmScope, mdToken tkAssemblyRef, OUT VMPTR_DomainAssembly * pRetVal);
 
 
     // Hijack the thread
-    void Hijack(
-        VMPTR_Thread                 vmThread,
-        ULONG32                      dwThreadId,
-        const EXCEPTION_RECORD *     pRecord,
-        T_CONTEXT *                  pOriginalContext,
-        ULONG32                      cbSizeContext,
-        EHijackReason::EHijackReason reason,
-        void *                       pUserData,
-        CORDB_ADDRESS *              pRemoteContextAddr);
+    HRESULT Hijack(VMPTR_Thread vmThread, ULONG32 dwThreadId, const EXCEPTION_RECORD * pRecord, T_CONTEXT * pOriginalContext, ULONG32 cbSizeContext, EHijackReason::EHijackReason reason, void * pUserData, CORDB_ADDRESS * pRemoteContextAddr);
 
     // Return the filter CONTEXT on the LS.
-    VMPTR_CONTEXT GetManagedStoppedContext(VMPTR_Thread vmThread);
+    HRESULT GetManagedStoppedContext(VMPTR_Thread vmThread, OUT VMPTR_CONTEXT * pRetVal);
 
     // Create and return a stackwalker on the specified thread.
-    void CreateStackWalk(VMPTR_Thread       vmThread,
-                         DT_CONTEXT *       pInternalContextBuffer,
-                         StackWalkHandle *  ppSFIHandle);
+    HRESULT CreateStackWalk(VMPTR_Thread vmThread, DT_CONTEXT * pInternalContextBuffer, OUT StackWalkHandle * ppSFIHandle);
 
     // Delete the stackwalk object
-    void DeleteStackWalk(StackWalkHandle ppSFIHandle);
+    HRESULT DeleteStackWalk(StackWalkHandle ppSFIHandle);
 
     // Get the CONTEXT of the current frame at which the stackwalker is stopped.
-    void GetStackWalkCurrentContext(StackWalkHandle pSFIHandle,
-                                    DT_CONTEXT *    pContext);
+    HRESULT GetStackWalkCurrentContext(StackWalkHandle pSFIHandle, DT_CONTEXT * pContext);
 
-    void GetStackWalkCurrentContext(StackFrameIterator * pIter, DT_CONTEXT * pContext);
+    HRESULT GetStackWalkCurrentContext(StackWalkHandle pSFIHandle, DT_CONTEXT * pContext);
 
     // Set the stackwalker to the specified CONTEXT.
-    void SetStackWalkCurrentContext(VMPTR_Thread           vmThread,
-                                    StackWalkHandle        pSFIHandle,
-                                    CorDebugSetContextFlag flag,
-                                    DT_CONTEXT *           pContext);
+    HRESULT SetStackWalkCurrentContext(VMPTR_Thread vmThread, StackWalkHandle pSFIHandle, CorDebugSetContextFlag flag, DT_CONTEXT * pContext);
 
     // Unwind the stackwalker to the next frame.
-    BOOL UnwindStackWalkFrame(StackWalkHandle pSFIHandle);
+    HRESULT UnwindStackWalkFrame(StackWalkHandle pSFIHandle, OUT BOOL * pResult);
 
     HRESULT CheckContext(VMPTR_Thread       vmThread,
                          const DT_CONTEXT * pContext);
 
     // Retrieve information about the current frame from the stackwalker.
-    FrameType GetStackWalkCurrentFrameInfo(StackWalkHandle        pSFIHandle,
-                                           DebuggerIPCE_STRData * pFrameData);
+    HRESULT GetStackWalkCurrentFrameInfo(StackWalkHandle pSFIHandle, OPTIONAL DebuggerIPCE_STRData * pFrameData, OUT FrameType * pRetVal);
 
     // Return the number of internal frames on the specified thread.
-    ULONG32 GetCountOfInternalFrames(VMPTR_Thread vmThread);
+    HRESULT GetCountOfInternalFrames(VMPTR_Thread vmThread, OUT ULONG32 * pRetVal);
 
     // Enumerate the internal frames on the specified thread and invoke the provided callback on each of them.
-    void EnumerateInternalFrames(VMPTR_Thread                           vmThread,
-                                 FP_INTERNAL_FRAME_ENUMERATION_CALLBACK fpCallback,
-                                 void *                                 pUserData);
+    HRESULT EnumerateInternalFrames(VMPTR_Thread vmThread, FP_INTERNAL_FRAME_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
 
     // Given the FramePointer of the parent frame and the FramePointer of the current frame,
     // check if the current frame is the parent frame.
-    BOOL IsMatchingParentFrame(FramePointer fpToCheck, FramePointer fpParent);
+    HRESULT IsMatchingParentFrame(FramePointer fpToCheck, FramePointer fpParent, OUT BOOL * pResult);
 
     // Return the stack parameter size of the given method.
-    ULONG32 GetStackParameterSize(CORDB_ADDRESS controlPC);
+    HRESULT GetStackParameterSize(CORDB_ADDRESS controlPC, OUT ULONG32 * pRetVal);
 
     // Return the FramePointer of the current frame at which the stackwalker is stopped.
-    FramePointer GetFramePointer(StackWalkHandle pSFIHandle);
+    HRESULT GetFramePointer(StackWalkHandle pSFIHandle, OUT FramePointer * pRetVal);
 
     FramePointer GetFramePointerWorker(StackFrameIterator * pIter);
 
     // Return TRUE if the specified CONTEXT is the CONTEXT of the leaf frame.
     // @dbgtodo  filter CONTEXT - Currently we check for the filter CONTEXT first.
-    BOOL IsLeafFrame(VMPTR_Thread       vmThread,
-                     const DT_CONTEXT * pContext);
+    HRESULT IsLeafFrame(VMPTR_Thread vmThread, const DT_CONTEXT * pContext, OUT BOOL * pResult);
 
     // DacDbi API: Get the context for a particular thread of the target process
-    void GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContextBuffer);
+    HRESULT GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContextBuffer);
 
     // This is a simple helper function to convert a CONTEXT to a DebuggerREGDISPLAY.  We need to do this
     // inside DDI because the RS has no notion of REGDISPLAY.
-    void ConvertContextToDebuggerRegDisplay(const DT_CONTEXT * pInContext,
-                                            DebuggerREGDISPLAY * pOutDRD,
-                                            BOOL fActive);
+    HRESULT ConvertContextToDebuggerRegDisplay(const DT_CONTEXT * pInContext, DebuggerREGDISPLAY * pOutDRD, BOOL fActive);
 
     // Check if the given method is a DiagnosticHidden or an LCG method.
-    DynamicMethodType IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc);
+    HRESULT IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc, OUT DynamicMethodType * pRetVal);
 
     // Return a TargetBuffer for the raw vararg signature.
-    TargetBuffer GetVarArgSig(CORDB_ADDRESS   VASigCookieAddr,
-                              CORDB_ADDRESS * pArgBase);
+    HRESULT GetVarArgSig(CORDB_ADDRESS VASigCookieAddr, OUT CORDB_ADDRESS * pArgBase, OUT TargetBuffer * pRetVal);
 
     // returns TRUE if the type requires 8-byte alignment
-    BOOL RequiresAlign8(VMPTR_TypeHandle thExact);
+    HRESULT RequiresAlign8(VMPTR_TypeHandle thExact, OUT BOOL * pResult);
 
     // Resolve the raw generics token to the real generics type token.  The resolution is based on the
     // given index.
-    GENERICS_TYPE_TOKEN ResolveExactGenericArgsToken(DWORD               dwExactGenericArgsTokenIndex,
-                                                     GENERICS_TYPE_TOKEN rawToken);
+    HRESULT ResolveExactGenericArgsToken(DWORD dwExactGenericArgsTokenIndex, GENERICS_TYPE_TOKEN rawToken, OUT GENERICS_TYPE_TOKEN * pRetVal);
 
     // Returns a bitfield reflecting the managed debugging state at the time of
     // the jit attach.
-    CLR_DEBUGGING_PROCESS_FLAGS GetAttachStateFlags();
+    HRESULT GetAttachStateFlags(OUT CLR_DEBUGGING_PROCESS_FLAGS * pRetVal);
 
 protected:
     // This class used to be stateless, but we are relaxing the requirements
@@ -989,10 +889,10 @@ protected:
 
     // Get the address of the Debugger control block on the helper thread. Returns
     // NULL if the control block has not been successfully allocated
-    CORDB_ADDRESS GetDebuggerControlBlockAddress();
+    HRESULT GetDebuggerControlBlockAddress(OUT CORDB_ADDRESS * pRetVal);
 
     // Creates a VMPTR of an Object from a target address
-    VMPTR_Object GetObject(CORDB_ADDRESS ptr);
+    HRESULT GetObject(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal);
 
     // sets state in the native binder
     HRESULT EnableNGENPolicy(CorDebugNGENPolicy ePolicy);
@@ -1005,25 +905,25 @@ protected:
     HRESULT GetNGENCompilerFlags(DWORD *pdwFlags);
 
     // Creates a VMPTR of an Object from a target address pointing to an OBJECTREF
-    VMPTR_Object GetObjectFromRefPtr(CORDB_ADDRESS ptr);
+    HRESULT GetObjectFromRefPtr(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal);
 
     // Get the target address from a VMPTR_OBJECTHANDLE, i.e., the handle address
-    CORDB_ADDRESS GetHandleAddressFromVmHandle(VMPTR_OBJECTHANDLE vmHandle);
+    HRESULT GetHandleAddressFromVmHandle(VMPTR_OBJECTHANDLE vmHandle, OUT CORDB_ADDRESS * pRetVal);
 
     // Gets the target address of an VMPTR of an Object
-    TargetBuffer GetObjectContents(VMPTR_Object vmObj);
+    HRESULT GetObjectContents(VMPTR_Object obj, OUT TargetBuffer * pRetVal);
 
     // Create a VMPTR_OBJECTHANDLE from a CORDB_ADDRESS pointing to an object handle
-    VMPTR_OBJECTHANDLE GetVmObjectHandle(CORDB_ADDRESS handleAddress);
+    HRESULT GetVmObjectHandle(CORDB_ADDRESS handleAddress, OUT VMPTR_OBJECTHANDLE * pRetVal);
 
     // Validate that the VMPTR_OBJECTHANDLE refers to a legitimate managed object
-    BOOL IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle);
+    HRESULT IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle, OUT BOOL * pResult);
 
     // if the specified module is a WinRT module then isWinRT will equal TRUE
     HRESULT IsWinRTModule(VMPTR_Module vmModule, BOOL& isWinRT);
 
     // Determines the app domain id for the object referred to by a given VMPTR_OBJECTHANDLE
-    ULONG GetAppDomainIdFromVmObjectHandle(VMPTR_OBJECTHANDLE vmHandle);
+    HRESULT GetAppDomainIdFromVmObjectHandle(VMPTR_OBJECTHANDLE vmHandle, OUT ULONG * pRetVal);
 
 private:
     bool IsThreadMarkedDeadWorker(Thread * pThread);
@@ -1045,7 +945,7 @@ private:
                              DebuggerIPCE_JITFuncData * pJITFuncData);
 
     // Return the stack parameter size of the given method.
-    ULONG32 GetStackParameterSize(EECodeInfo * pCodeInfo);
+    HRESULT GetStackParameterSize(CORDB_ADDRESS controlPC, OUT ULONG32 * pRetVal);
 
     typedef enum
     {
@@ -1102,10 +1002,7 @@ private:
 
 public:
     // API for picking up the info needed for a debugger to look up an image from its search path.
-    bool GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly,
-                                       DWORD &dwTimeStamp,
-                                       DWORD &dwSize,
-                                       IStringHolder* pStrFilename);
+    HRESULT GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly, DWORD & dwTimeStamp, DWORD & dwImageSize, IStringHolder* pStrFilename, OUT bool * pResult);
 };
 
 

--- a/src/coreclr/debug/daccess/dacdbiimpl.h
+++ b/src/coreclr/debug/daccess/dacdbiimpl.h
@@ -368,7 +368,7 @@ private:
         TADDR funcIp,
         OUT VMPTR_MethodDesc *ppMD);
 
-    HRESULT IsExceptionObject(VMPTR_Object vmObject, OUT BOOL * pResult);
+    BOOL IsExceptionObject(MethodTable* pMT);
 
     // Get the approximate and exact type handles for a type
     void GetTypeHandles(VMPTR_TypeHandle  vmThExact,
@@ -774,7 +774,7 @@ public:
     // Get the CONTEXT of the current frame at which the stackwalker is stopped.
     HRESULT GetStackWalkCurrentContext(StackWalkHandle pSFIHandle, DT_CONTEXT * pContext);
 
-    HRESULT GetStackWalkCurrentContext(StackWalkHandle pSFIHandle, DT_CONTEXT * pContext);
+    void GetStackWalkCurrentContext(StackFrameIterator * pIter, DT_CONTEXT * pContext);
 
     // Set the stackwalker to the specified CONTEXT.
     HRESULT SetStackWalkCurrentContext(VMPTR_Thread vmThread, StackWalkHandle pSFIHandle, CorDebugSetContextFlag flag, DT_CONTEXT * pContext);
@@ -800,6 +800,9 @@ public:
 
     // Return the stack parameter size of the given method.
     HRESULT GetStackParameterSize(CORDB_ADDRESS controlPC, OUT ULONG32 * pRetVal);
+
+    // Return the stack parameter size of the given method.
+    ULONG32 GetStackParameterSize(EECodeInfo * pCodeInfo);
 
     // Return the FramePointer of the current frame at which the stackwalker is stopped.
     HRESULT GetFramePointer(StackWalkHandle pSFIHandle, OUT FramePointer * pRetVal);
@@ -943,9 +946,6 @@ private:
     // Fill in the information about the parent frame.
     void InitParentFrameInfo(CrawlFrame * pCF,
                              DebuggerIPCE_JITFuncData * pJITFuncData);
-
-    // Return the stack parameter size of the given method.
-    HRESULT GetStackParameterSize(CORDB_ADDRESS controlPC, OUT ULONG32 * pRetVal);
 
     typedef enum
     {

--- a/src/coreclr/debug/daccess/dacdbiimpl.h
+++ b/src/coreclr/debug/daccess/dacdbiimpl.h
@@ -1048,6 +1048,8 @@ protected:
 
 
 // Use this macro at the start of each DD function.
+// "MAY_THROW" refers to the code within the function body (inside EX_TRY blocks) that may throw;
+// the methods themselves catch all exceptions via EX_CATCH_HRESULT and return HRESULT to callers.
 // This may nest if a DD primitive takes in a callback that then calls another DD primitive.
 #define DD_ENTER_MAY_THROW \
     DDHolder __dacHolder(this, true); \

--- a/src/coreclr/debug/daccess/dacdbiimpllocks.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpllocks.cpp
@@ -25,18 +25,32 @@
 #ifdef TEST_DATA_CONSISTENCY
 #include "crst.h"
 
-void DacDbiInterfaceImpl::TestCrst(VMPTR_Crst vmCrst)
+HRESULT DacDbiInterfaceImpl::TestCrst(VMPTR_Crst vmCrst)
 {
     DD_ENTER_MAY_THROW;
 
-    DebugTryCrst(vmCrst.GetDacPtr());
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        DebugTryCrst(vmCrst.GetDacPtr());
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 
-void DacDbiInterfaceImpl::TestRWLock(VMPTR_SimpleRWLock vmRWLock)
+HRESULT DacDbiInterfaceImpl::TestRWLock(VMPTR_SimpleRWLock vmRWLock)
 {
     DD_ENTER_MAY_THROW;
 
-    DebugTryRWLock(vmRWLock.GetDacPtr());
+    HRESULT hr = S_OK;
+    EX_TRY
+    {
+
+        DebugTryRWLock(vmRWLock.GetDacPtr());
+    }
+    EX_CATCH_HRESULT(hr);
+    return hr;
 }
 #endif
 

--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -131,13 +131,13 @@ HRESULT DacDbiInterfaceImpl::CreateStackWalk(VMPTR_Thread vmThread, DT_CONTEXT *
 
         // initialize the CONTEXT.
         // SetStackWalk will initial the RegDisplay from this context.
-        GetContext(vmThread, pInternalContextBuffer);
+        IfFailThrow(GetContext(vmThread, pInternalContextBuffer));
 
         // initialize the stackwalker
-        SetStackWalkCurrentContext(vmThread,
-                                   *ppSFIHandle,
-                                   SET_CONTEXT_FLAG_ACTIVE_FRAME,
-                                   pInternalContextBuffer);
+        IfFailThrow(SetStackWalkCurrentContext(vmThread,
+                                               *ppSFIHandle,
+                                               SET_CONTEXT_FLAG_ACTIVE_FRAME,
+                                               pInternalContextBuffer));
     }
     EX_CATCH_HRESULT(hr);
     return hr;
@@ -768,7 +768,7 @@ HRESULT DacDbiInterfaceImpl::IsLeafFrame(VMPTR_Thread vmThread, const DT_CONTEXT
     {
 
         DT_CONTEXT ctxLeaf;
-        GetContext(vmThread, &ctxLeaf);
+        IfFailThrow(GetContext(vmThread, &ctxLeaf));
 
         // Call a platform-specific helper to compare the two contexts.
         *pResult = CompareControlRegisters(pContext, &ctxLeaf);

--- a/src/coreclr/debug/di/divalue.cpp
+++ b/src/coreclr/debug/di/divalue.cpp
@@ -4824,8 +4824,8 @@ HRESULT CordbHeapValue3Impl::GetMonitorEventWaitList(CordbProcess* pProcess,
         VMPTR_Object vmObj;
         IfFailThrow(pDac->GetObject(remoteObjAddress, &vmObj));
         CQuickArrayList<VMPTR_Thread> threads;
-        pDac->EnumerateMonitorEventWaitList(vmObj,
-            (IDacDbiInterface::FP_THREAD_ENUMERATION_CALLBACK)ThreadEnumerationCallback, (VOID*)&threads);
+        IfFailThrow(pDac->EnumerateMonitorEventWaitList(vmObj,
+            (IDacDbiInterface::FP_THREAD_ENUMERATION_CALLBACK)ThreadEnumerationCallback, (VOID*)&threads));
 
         rsThreads = new RSSmartPtr<CordbThread>[threads.Size()];
         {

--- a/src/coreclr/debug/di/divalue.cpp
+++ b/src/coreclr/debug/di/divalue.cpp
@@ -1525,19 +1525,19 @@ void CordbReferenceValue::GetObjectData(CordbProcess *            pProcess,
     // make sure we don't end up with old garbage values in case the reference is bad
     PreInitObjectData(pInfo, objectAddress, type);
 
-    pInterface->GetBasicObjectInfo(objTargetAddr, type, vmAppdomain, pInfo);
+    IfFailThrow(pInterface->GetBasicObjectInfo(objTargetAddr, type, vmAppdomain, pInfo));
 
     if (!pInfo->objRefBad)
     {
         // for certain referent types, we need a bit more information:
         if (pInfo->objTypeData.elementType == ELEMENT_TYPE_STRING)
         {
-            pInterface->GetStringData(objTargetAddr, pInfo);
+            IfFailThrow(pInterface->GetStringData(objTargetAddr, pInfo));
         }
         else if ((pInfo->objTypeData.elementType == ELEMENT_TYPE_ARRAY) ||
                  (pInfo->objTypeData.elementType == ELEMENT_TYPE_SZARRAY))
         {
-            pInterface->GetArrayData(objTargetAddr, pInfo);
+            IfFailThrow(pInterface->GetArrayData(objTargetAddr, pInfo));
         }
     }
 

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -705,7 +705,7 @@ CordbProcess::CreateDacDbiInterface()
     m_pDacPrimitives = pInterfacePtr;
 
     // Setup DAC target consistency checking based on what we're using for DBI
-    m_pDacPrimitives->DacSetTargetConsistencyChecks( m_fAssertOnTargetInconsistency );
+    IfFailThrow(m_pDacPrimitives->DacSetTargetConsistencyChecks( m_fAssertOnTargetInconsistency ));
 }
 
 //---------------------------------------------------------------------------------------
@@ -2358,7 +2358,7 @@ HRESULT CordbProcess::GetObjectInternal(CORDB_ADDRESS addr, ICorDebugObjectValue
                 _ASSERTE(cdbAppDomain != NULL);
 
                 DebuggerIPCE_ObjectData objData;
-                m_pDacPrimitives->GetBasicObjectInfo(addr, ELEMENT_TYPE_CLASS, cdbAppDomain->GetADToken(), &objData);
+                IfFailThrow(m_pDacPrimitives->GetBasicObjectInfo(addr, ELEMENT_TYPE_CLASS, cdbAppDomain->GetADToken(), &objData));
 
                 NewHolder<CordbObjectValue> pNewObjectValue(new CordbObjectValue(cdbAppDomain, pType, TargetBuffer(addr, (ULONG)objData.objSize), &objData));
                 hr = pNewObjectValue->Init();

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -416,7 +416,9 @@ IMDInternalImport * CordbProcess::LookupMetaDataFromDebugger(
     IMDInternalImport * pMDII = NULL;
 
     // First, see if the debugger can locate the exact metadata we want.
-    if (this->GetDAC()->GetMetaDataFileInfoFromPEFile(vmPEAssembly, dwImageTimeStamp, dwImageSize, &filePath))
+    bool _metaDataFileInfoResult;
+    IfFailThrow(this->GetDAC()->GetMetaDataFileInfoFromPEFile(vmPEAssembly, dwImageTimeStamp, dwImageSize, &filePath, &_metaDataFileInfoResult));
+    if (_metaDataFileInfoResult)
     {
         _ASSERTE(filePath.IsSet());
 
@@ -1832,7 +1834,7 @@ HRESULT CordbProcess::Init()
             {
                 // Invoke DAC primitive.
                 _ASSERTE(m_pDacPrimitives != NULL);
-                fIsLSStarted = m_pDacPrimitives->IsLeftSideInitialized();
+                IfFailThrow(m_pDacPrimitives->IsLeftSideInitialized(&fIsLSStarted));
             }
             else
             {
@@ -1957,7 +1959,7 @@ void CordbProcess::QueueManagedAttachIfNeededWorker()
     if (m_fDoDelayedManagedAttached && GetShim()->GetAttached())
     {
         RSLockHolder lockHolder(&this->m_processMutex);
-        GetDAC()->MarkDebuggerAttachPending();
+        IfFailThrow(GetDAC()->MarkDebuggerAttachPending());
 
         hrQueue = this->QueueManagedAttach();
     }
@@ -2108,7 +2110,8 @@ CordbThread * CordbProcess::TryLookupThreadByVolatileOSId(DWORD dwThreadId)
         _ASSERTE(pThread != NULL);
 
         // Get the OS tid. This returns 0 if the thread is switched out.
-        DWORD dwThreadId2 = GetDAC()->TryGetVolatileOSThreadID(pThread->m_vmThreadToken);
+        DWORD dwThreadId2;
+        IfFailThrow(GetDAC()->TryGetVolatileOSThreadID(pThread->m_vmThreadToken, &dwThreadId2));
         if (dwThreadId2 == dwThreadId)
         {
             return pThread;
@@ -2247,7 +2250,9 @@ HRESULT CordbProcess::EnumerateHeap(ICorDebugHeapEnum **ppObjects)
 
     EX_TRY
     {
-        if (m_pDacPrimitives->AreGCStructuresValid())
+        bool gcValid;
+        IfFailThrow(m_pDacPrimitives->AreGCStructuresValid(&gcValid));
+        if (gcValid)
         {
             CordbHeapEnum *pHeapEnum = new CordbHeapEnum(this);
             GetContinueNeuterList()->Add(this, pHeapEnum);
@@ -2274,7 +2279,7 @@ HRESULT CordbProcess::GetGCHeapInformation(COR_HEAPINFO *pHeapInfo)
 
     EX_TRY
     {
-        GetDAC()->GetGCHeapInformation(pHeapInfo);
+        IfFailThrow(GetDAC()->GetGCHeapInformation(pHeapInfo));
     }
     EX_CATCH_HRESULT(hr);
 
@@ -2328,7 +2333,9 @@ HRESULT CordbProcess::GetObjectInternal(CORDB_ADDRESS addr, ICorDebugObjectValue
 
     EX_TRY
     {
-        if (!m_pDacPrimitives->IsValidObject(addr))
+        bool validObj;
+        IfFailThrow(m_pDacPrimitives->IsValidObject(addr, &validObj));
+        if (!validObj)
         {
             hr = CORDBG_E_CORRUPT_OBJECT;
         }
@@ -2448,7 +2455,7 @@ HRESULT CordbProcess::GetTypeForTypeID(COR_TYPEID id, ICorDebugType **ppType)
     EX_TRY
     {
         DebuggerIPCE_ExpandedTypeData data;
-        GetDAC()->GetObjectExpandedTypeInfoFromID(AllBoxed, VMPTR_AppDomain::NullPtr(), id, &data);
+        IfFailThrow(GetDAC()->GetObjectExpandedTypeInfoFromID(AllBoxed, VMPTR_AppDomain::NullPtr(), id, &data));
 
         CordbType *type = 0;
         hr = CordbType::TypeDataToType(GetAppDomain(), &data, &type);
@@ -2594,7 +2601,9 @@ COM_METHOD CordbProcess::GetAsyncStack(CORDB_ADDRESS continuationAddress, ICorDe
 
     EX_TRY
     {
-        if (!m_pDacPrimitives->IsValidObject(continuationAddress))
+        bool validObj;
+        IfFailThrow(m_pDacPrimitives->IsValidObject(continuationAddress, &validObj));
+        if (!validObj)
         {
             // throw if not a valid object
             ThrowHR(E_INVALIDARG);
@@ -2628,14 +2637,16 @@ HRESULT CordbProcess::GetTypeForObject(CORDB_ADDRESS addr, CordbType **ppType, C
     VMPTR_DomainAssembly domainAssembly;
 
     HRESULT hr = E_FAIL;
-    if (GetDAC()->GetAppDomainForObject(addr, &appDomain, &mod, &domainAssembly))
+    bool _appDomainResult;
+    IfFailThrow(GetDAC()->GetAppDomainForObject(addr, &appDomain, &mod, &domainAssembly, &_appDomainResult));
+    if (_appDomainResult)
     {
         CordbAppDomain *cdbAppDomain = appDomain.IsNull() ? GetAppDomain() : LookupOrCreateAppDomain(appDomain);
 
         _ASSERTE(cdbAppDomain);
 
         DebuggerIPCE_ExpandedTypeData data;
-        GetDAC()->GetObjectExpandedTypeInfo(AllBoxed, appDomain, addr, &data);
+        IfFailThrow(GetDAC()->GetObjectExpandedTypeInfo(AllBoxed, appDomain, addr, &data));
 
         CordbType *type = 0;
         hr = CordbType::TypeDataToType(cdbAppDomain, &data, &type);
@@ -2673,7 +2684,7 @@ void CordbRefEnum::Neuter()
     {
         if (mRefHandle)
         {
-            GetProcess()->GetDAC()->DeleteRefWalk(mRefHandle);
+            IfFailThrow(GetProcess()->GetDAC()->DeleteRefWalk(mRefHandle));
             mRefHandle = 0;
         }
     }
@@ -2722,7 +2733,7 @@ HRESULT CordbRefEnum::Reset()
     {
         if (mRefHandle)
         {
-            GetProcess()->GetDAC()->DeleteRefWalk(mRefHandle);
+            IfFailThrow(GetProcess()->GetDAC()->DeleteRefWalk(mRefHandle));
             mRefHandle = 0;
         }
     }
@@ -2889,7 +2900,7 @@ void CordbHeapEnum::Clear()
     {
         if (mHeapHandle)
         {
-            GetProcess()->GetDAC()->DeleteHeapWalk(mHeapHandle);
+            IfFailThrow(GetProcess()->GetDAC()->DeleteHeapWalk(mHeapHandle));
             mHeapHandle = 0;
         }
     }
@@ -3074,7 +3085,7 @@ HRESULT CordbProcess::Detach()
             HRESULT hrIgnore = S_OK;
             EX_TRY
             {
-                GetDAC()->MarkDebuggerAttached(FALSE);
+                IfFailThrow(GetDAC()->MarkDebuggerAttached(FALSE));
             }
             EX_CATCH_HRESULT(hrIgnore);
         }
@@ -4486,10 +4497,10 @@ void CordbProcess::GetAssembliesInLoadOrder(
     ShimAssemblyCallbackData data(pAppDomainInternal, pAssemblies, countAssemblies);
 
     // Enumerate through and fill out pAssemblies table.
-    GetDAC()->EnumerateAssembliesInAppDomain(
+    IfFailThrow(GetDAC()->EnumerateAssembliesInAppDomain(
         pAppDomainInternal->GetADToken(),
         ShimAssemblyCallbackData::Callback,
-        &data); // user data
+        &data)); // user data
 
     // pAssemblies array has now been updated.
 }
@@ -4635,10 +4646,10 @@ void CordbProcess::GetModulesInLoadOrder(
     ShimModuleCallbackData data(pAssemblyInternal, pModules, countModules);
 
     // Enumerate through and fill out pModules table.
-    GetDAC()->EnumerateModulesInAssembly(
+    IfFailThrow(GetDAC()->EnumerateModulesInAssembly(
         pAssemblyInternal->GetDomainAssemblyPtr(),
         ShimModuleCallbackData::Callback,
-        &data); // user data
+        &data)); // user data
 
     // pModules array has now been updated.
 }
@@ -4858,9 +4869,9 @@ void CordbProcess::DbgAssertAppDomainDeleted(VMPTR_AppDomain vmAppDomainDeleted)
     callbackData.m_pThis = this;
     callbackData.m_vmAppDomainDeleted = vmAppDomainDeleted;
 
-    GetDAC()->EnumerateAppDomains(
+    IfFailThrow(GetDAC()->EnumerateAppDomains(
         CordbProcess::DbgAssertAppDomainDeletedCallback,
-        &callbackData);
+        &callbackData));
 }
 
 #endif  // _DEBUG
@@ -5940,7 +5951,7 @@ void CordbProcess::RawDispatchEvent(
             EX_TRY
             {
                 // the left side has signaled that we should test whether pEvent->TestCrstData.vmCrst is held
-                GetDAC()->TestCrst(pEvent->TestCrstData.vmCrst);
+                IfFailThrow(GetDAC()->TestCrst(pEvent->TestCrstData.vmCrst));
             }
             EX_CATCH_HRESULT(hr);
 
@@ -5972,7 +5983,7 @@ void CordbProcess::RawDispatchEvent(
             EX_TRY
             {
                 // the left side has signaled that we should test whether pEvent->TestRWLockData.vmRWLock is held
-                GetDAC()->TestRWLock(pEvent->TestRWLockData.vmRWLock);
+                IfFailThrow(GetDAC()->TestRWLock(pEvent->TestRWLockData.vmRWLock));
             }
             EX_CATCH_HRESULT(hr);
 
@@ -6038,7 +6049,7 @@ void CordbProcess::PrepopulateThreadsOrThrow()
     if (IsDacInitialized())
     {
         STRESS_LOG0(LF_CORDB, LL_INFO1000, "PrepopulateThreadsOrThrow()\n");
-        GetDAC()->EnumerateThreads(ThreadEnumerationCallback, this);
+        IfFailThrow(GetDAC()->EnumerateThreads(ThreadEnumerationCallback, this));
     }
 }
 
@@ -6318,7 +6329,8 @@ HRESULT CordbProcess::IsTransitionStub(CORDB_ADDRESS address, BOOL *pfTransition
 
         // Check against DAC primitives
         {
-            BOOL fIsStub2 = GetDAC()->IsTransitionStub(address);
+            BOOL fIsStub2;
+            IfFailThrow(GetDAC()->IsTransitionStub(address, &fIsStub2));
             (void)fIsStub2; //prevent "unused variable" error from GCC
             CONSISTENCY_CHECK_MSGF(*pfTransitionStub == fIsStub2, ("IsStub2 failed, DAC2:%d, IPC:%d, addr:0x%p", (int) fIsStub2, (int) *pfTransitionStub, CORDB_ADDRESS_TO_PTR(address)));
 
@@ -7155,7 +7167,8 @@ HRESULT CordbProcess::FindPatchByAddress(CORDB_ADDRESS address, bool *pfPatchFou
                 EX_TRY
                 {
                     // We should be able to double check w/ DAC that this really is outside of the runtime.
-                    IDacDbiInterface::AddressType addrType = GetDAC()->GetAddressType(address);
+                    IDacDbiInterface::AddressType addrType;
+                    IfFailThrow(GetDAC()->GetAddressType(address, &addrType));
                     CONSISTENCY_CHECK_MSGF(addrType == IDacDbiInterface::kAddressUnrecognized, ("Bad address type = %d", addrType));
                 }
                 EX_CATCH_HRESULT(hrDac);
@@ -7543,7 +7556,7 @@ void CordbProcess::GetEventBlock(BOOL * pfBlockExists)
             // This is not technically necessary for Mac debugging.  The event channel doesn't rely on
             // knowing the target address of the DCB on the LS.
             CORDB_ADDRESS pLeftSideDCB = (CORDB_ADDRESS)NULL;
-            pLeftSideDCB = (GetDAC()->GetDebuggerControlBlockAddress());
+            IfFailThrow(GetDAC()->GetDebuggerControlBlockAddress(&pLeftSideDCB));
             if (pLeftSideDCB == (CORDB_ADDRESS)NULL)
             {
                 *pfBlockExists = false;
@@ -8779,7 +8792,8 @@ CordbAppDomain * CordbProcess::GetAppDomain()
         return appDomain;
     }
 
-    VMPTR_AppDomain vmAppDomain = GetDAC()->GetCurrentAppDomain();
+    VMPTR_AppDomain vmAppDomain;
+    IfFailThrow(GetDAC()->GetCurrentAppDomain(&vmAppDomain));
     appDomain = LookupOrCreateAppDomain(vmAppDomain);
     return appDomain;
 }
@@ -8886,9 +8900,9 @@ void CordbProcess::PrepopulateAppDomainsOrThrow()
     }
 
     // DD-primitive  that invokes a callback.  This may throw.
-    GetDAC()->EnumerateAppDomains(
+    IfFailThrow(GetDAC()->EnumerateAppDomains(
         CordbProcess::AppDomainEnumerationCallback,
-        this);
+        this));
 }
 
 //---------------------------------------------------------------------------------------
@@ -11154,7 +11168,7 @@ void CordbProcess::FilterClrNotification(
             InitializeDac();
 
             // @dbgtodo 'attach-bit': we don't want the debugger automatically invading the process.
-            GetDAC()->MarkDebuggerAttached(TRUE);
+            IfFailThrow(GetDAC()->MarkDebuggerAttached(TRUE));
         }
         else if (pManagedEvent->type == DB_IPCE_SYNC_COMPLETE)
         {
@@ -11914,7 +11928,7 @@ void CordbProcess::ContinueStatusChanged(DWORD dwThreadId, CORDB_CONTINUE_STATUS
 //---------------------------------------------------------------------------------------
 void CordbProcess::RequestSyncAtEvent()
 {
-    GetDAC()->RequestSyncAtEvent();
+    IfFailThrow(GetDAC()->RequestSyncAtEvent());
 }
 
 //---------------------------------------------------------------------------------------
@@ -12658,7 +12672,7 @@ Reaction CordbProcess::Triage1stChanceNonSpecial(CordbUnmanagedThread * pUnmanag
 
     IDacDbiInterface::AddressType addrType;
 
-    addrType = GetDAC()->GetAddressType(address);
+    IfFailThrow(GetDAC()->GetAddressType(address, &addrType));
     bool fIsCorCode =((addrType == IDacDbiInterface::kAddressManagedMethod) ||
                       (addrType == IDacDbiInterface::kAddressRuntimeManagedCode) ||
                       (addrType == IDacDbiInterface::kAddressRuntimeUnmanagedCode));
@@ -14565,7 +14579,9 @@ void CordbWin32EventThread::AttachProcess()
     EX_TRY
     {
         // Don't allow attach if any metadata/IL updates have been applied
-        if (pProcess->GetDAC()->MetadataUpdatesApplied())
+        bool _metadataUpdatesApplied;
+        IfFailThrow(pProcess->GetDAC()->MetadataUpdatesApplied(&_metadataUpdatesApplied));
+        if (_metadataUpdatesApplied)
         {
             hr = CORDBG_E_ASSEMBLY_UPDATES_APPLIED;
             goto LExit;
@@ -15370,13 +15386,18 @@ HRESULT CordbProcess::GetReferenceValueFromGCHandle(
         }
 
         IDacDbiInterface* pDAC = GetProcess()->GetDAC();
-        VMPTR_OBJECTHANDLE vmObjHandle = pDAC->GetVmObjectHandle(gcHandle);
-        if(!pDAC->IsVmObjectHandleValid(vmObjHandle))
+        VMPTR_OBJECTHANDLE vmObjHandle;
+        IfFailThrow(pDAC->GetVmObjectHandle(gcHandle, &vmObjHandle));
+        BOOL isValid;
+        IfFailThrow(pDAC->IsVmObjectHandleValid(vmObjHandle, &isValid));
+        if(!isValid)
         {
             ThrowHR(CORDBG_E_BAD_REFERENCE_VALUE);
         }
-        ULONG appDomainId = pDAC->GetAppDomainIdFromVmObjectHandle(vmObjHandle);
-        VMPTR_AppDomain vmAppDomain = pDAC->GetAppDomainFromId(appDomainId);
+        ULONG appDomainId;
+        IfFailThrow(pDAC->GetAppDomainIdFromVmObjectHandle(vmObjHandle, &appDomainId));
+        VMPTR_AppDomain vmAppDomain;
+        IfFailThrow(pDAC->GetAppDomainFromId(appDomainId, &vmAppDomain));
 
         RSLockHolder lockHolder(GetProcessLock());
         CordbAppDomain * pAppDomain = LookupOrCreateAppDomain(vmAppDomain);
@@ -15519,7 +15540,7 @@ CordbClass * CordbProcess::LookupClass(ICorDebugAppDomain * pAppDomain, VMPTR_Do
     if (pAppDomain != NULL)
     {
         VMPTR_Module vmModule = VMPTR_Module::NullPtr();
-        GetProcess()->GetDAC()->GetModuleForDomainAssembly(vmDomainAssembly, &vmModule);
+        IfFailThrow(GetProcess()->GetDAC()->GetModuleForDomainAssembly(vmDomainAssembly, &vmModule));
         _ASSERTE(!vmModule.IsNull());
         CordbModule * pModule = ((CordbAppDomain *)pAppDomain)->m_modules.GetBase(VmPtrToCookie(vmModule));
         if (pModule != NULL)
@@ -15555,7 +15576,7 @@ CordbModule * CordbProcess::LookupOrCreateModule(VMPTR_DomainAssembly vmDomainAs
     _ASSERTE(!vmDomainAssembly.IsNull());
 
     DomainAssemblyInfo data;
-    GetDAC()->GetDomainAssemblyData(vmDomainAssembly, &data); // throws
+    IfFailThrow(GetDAC()->GetDomainAssemblyData(vmDomainAssembly, &data));
 
     CordbAppDomain * pAppDomain = LookupOrCreateAppDomain(data.vmAppDomain);
     return pAppDomain->LookupOrCreateModule(vmDomainAssembly);
@@ -15654,7 +15675,7 @@ HRESULT CordbProcess::GetAttachStateFlags(CLR_DEBUGGING_PROCESS_FLAGS *pFlags)
         if(pFlags == NULL)
             hr = E_POINTER;
         else
-            *pFlags = GetDAC()->GetAttachStateFlags();
+            IfFailThrow(GetDAC()->GetAttachStateFlags(pFlags));
     }
     PUBLIC_API_END(hr);
 
@@ -15733,7 +15754,9 @@ bool CordbProcess::IsThreadSuspendedOrHijacked(ICorDebugThread * pICorDebugThrea
     PUBLIC_REENTRANT_API_ENTRY_FOR_SHIM(this);
 
     CordbThread * pCordbThread = static_cast<CordbThread *> (pICorDebugThread);
-    return GetDAC()->IsThreadSuspendedOrHijacked(pCordbThread->m_vmThreadToken);
+    bool _isSuspendedOrHijacked;
+    IfFailThrow(GetDAC()->IsThreadSuspendedOrHijacked(pCordbThread->m_vmThreadToken, &_isSuspendedOrHijacked));
+    return _isSuspendedOrHijacked;
 }
 
 void CordbProcess::HandleControlCTrapResult(HRESULT result)

--- a/src/coreclr/debug/di/rsappdomain.cpp
+++ b/src/coreclr/debug/di/rsappdomain.cpp
@@ -205,12 +205,13 @@ HRESULT CordbAppDomain::RefreshName()
 
     #ifdef _DEBUG
         // For debug, double-check the cached value against getting the AD via an AppDomainId.
-        VMPTR_AppDomain pAppDomain = pDac->GetAppDomainFromId(m_AppDomainId);
+        VMPTR_AppDomain pAppDomain;
+        IfFailThrow(pDac->GetAppDomainFromId(m_AppDomainId, &pAppDomain));
         _ASSERTE(m_vmAppDomain == pAppDomain);
     #endif
 
         // Get the actual string contents.
-        pDac->GetAppDomainFullName(m_vmAppDomain, &m_strAppDomainName);
+        IfFailThrow(pDac->GetAppDomainFullName(m_vmAppDomain, &m_strAppDomainName));
 
         // Now that m_strAppDomainName is set, don't fail without clearing it.
     }

--- a/src/coreclr/debug/di/rsassembly.cpp
+++ b/src/coreclr/debug/di/rsassembly.cpp
@@ -106,10 +106,10 @@ void CordbAssembly::DbgAssertAssemblyDeletedCallback(VMPTR_DomainAssembly vmDoma
 //
 void CordbAssembly::DbgAssertAssemblyDeleted()
 {
-    GetProcess()->GetDAC()->EnumerateAssembliesInAppDomain(
+    IfFailThrow(GetProcess()->GetDAC()->EnumerateAssembliesInAppDomain(
         GetAppDomain()->GetADToken(),
         CordbAssembly::DbgAssertAssemblyDeletedCallback,
-        this);
+        this));
 }
 #endif // _DEBUG
 
@@ -245,7 +245,8 @@ HRESULT CordbAssembly::GetName(ULONG32 cchName,
         if (!m_strAssemblyFileName.IsSet())
         {
             IDacDbiInterface * pDac = m_pProcess->GetDAC(); // throws
-            BOOL fNonEmpty = pDac->GetAssemblyPath(m_vmAssembly, &m_strAssemblyFileName); // throws
+            BOOL fNonEmpty;
+            IfFailThrow(pDac->GetAssemblyPath(m_vmAssembly, &m_strAssemblyFileName, &fNonEmpty)); // throws
             _ASSERTE(m_strAssemblyFileName.IsSet());
 
 
@@ -302,7 +303,8 @@ HRESULT CordbAssembly::IsFullyTrusted( BOOL *pbFullyTrusted )
         CordbProcess * pProcess = m_pAppDomain->GetProcess();
         IDacDbiInterface * pDac = pProcess->GetDAC();
 
-        BOOL fIsFullTrust = pDac->IsAssemblyFullyTrusted(m_vmDomainAssembly);
+        BOOL fIsFullTrust;
+        IfFailThrow(pDac->IsAssemblyFullyTrusted(m_vmDomainAssembly, &fIsFullTrust));
 
         // Once the trust level of an assembly is known, it cannot change.
         m_foptIsFullTrust = fIsFullTrust;

--- a/src/coreclr/debug/di/rsclass.cpp
+++ b/src/coreclr/debug/di/rsclass.cpp
@@ -791,10 +791,10 @@ void CordbClass::Init(ClassLoadLevel desiredLoadLevel)
             if (!vmDomainAssembly.IsNull())
             {
                 DomainAssemblyInfo info;
-                pDac->GetDomainAssemblyData(vmDomainAssembly, &info);
+                IfFailThrow(pDac->GetDomainAssemblyData(vmDomainAssembly, &info));
                 vmAppDomain = info.vmAppDomain;
             }
-            pDac->GetClassInfo(vmAppDomain, vmTypeHandle, &m_classInfo);
+            IfFailThrow(pDac->GetClassInfo(vmAppDomain, vmTypeHandle, &m_classInfo));
 
             BOOL fGotUnallocatedStatic = GotUnallocatedStatic(&m_classInfo.m_fieldList);
 

--- a/src/coreclr/debug/di/rsfunction.cpp
+++ b/src/coreclr/debug/di/rsfunction.cpp
@@ -571,7 +571,7 @@ HRESULT CordbFunction::GetActiveReJitRequestILCode(ICorDebugILCode **ppReJitedIL
         *ppReJitedILCode = NULL;
 
         VMPTR_ILCodeVersionNode vmILCodeVersionNode = VMPTR_ILCodeVersionNode::NullPtr();
-        GetProcess()->GetDAC()->GetActiveRejitILCodeVersionNode(GetModule()->m_vmModule, m_MDToken, &vmILCodeVersionNode);
+        IfFailThrow(GetProcess()->GetDAC()->GetActiveRejitILCodeVersionNode(GetModule()->m_vmModule, m_MDToken, &vmILCodeVersionNode));
         if (!vmILCodeVersionNode.IsNull())
         {
             RSSmartPtr<CordbReJitILCode> pILCode;
@@ -788,10 +788,10 @@ HRESULT CordbFunction::GetILCodeAndSigToken()
                 // and we also fallback on creating an empty ILCode object.
                 // See issue DD 273199 for cases where IL and NGEN metadata mismatch (different RVAs).
                 ALLOW_DATATARGET_MISSING_OR_INCONSISTENT_MEMORY(
-                    pProcess->GetDAC()->GetILCodeAndSig(m_pModule->GetRuntimeDomainAssembly(),
+                    IfFailThrow(pProcess->GetDAC()->GetILCodeAndSig(m_pModule->GetRuntimeDomainAssembly(),
                                                             m_MDToken,
                                                             &codeInfo,
-                                                            &localVarSigToken);
+                                                            &localVarSigToken));
                 );
 
                 currentEnCVersion = m_pModule->LookupFunctionLatestVersion(m_MDToken)->m_dwEnCVersionNumber;
@@ -933,7 +933,7 @@ HRESULT CordbFunction::InitNativeCodeInfo()
             // All we actually need is the start address and method desc which are cheap to get relative
             // to some of the other members. So far this doesn't appear to be a perf hotspot, but if it
             // shows up in some scenario it wouldn't be too hard to improve it
-            pProcess->GetDAC()->GetNativeCodeInfo(m_pModule->GetRuntimeDomainAssembly(), m_MDToken, &codeInfo);
+            IfFailThrow(pProcess->GetDAC()->GetNativeCodeInfo(m_pModule->GetRuntimeDomainAssembly(), m_MDToken, &codeInfo));
         }
 
         // populate the m_nativeCode pointer with the code info we found

--- a/src/coreclr/debug/di/rsstackwalk.cpp
+++ b/src/coreclr/debug/di/rsstackwalk.cpp
@@ -903,11 +903,11 @@ HRESULT CordbAsyncStackWalk::PopulateFrame()
         NativeCodeFunctionData codeData;
         VMPTR_Module pModule;
         mdMethodDef methodDef;
-        pDac->GetNativeCodeInfoForAddr(
+        IfFailThrow(pDac->GetNativeCodeInfoForAddr(
             diagnosticIP,
             &codeData,
             &pModule,
-            &methodDef);
+            &methodDef));
 
         IDacDbiInterface::DynamicMethodType dynMethodType;
         IfFailThrow(pDac->IsDiagnosticsHiddenOrLCGMethod(codeData.vmNativeCodeMethodDescToken, &dynMethodType));

--- a/src/coreclr/debug/di/rsstackwalk.cpp
+++ b/src/coreclr/debug/di/rsstackwalk.cpp
@@ -38,9 +38,9 @@ void CordbStackWalk::Init()
     m_lastSyncFlushCounter = pProcess->m_flushCounter;
 
     IDacDbiInterface * pDAC = pProcess->GetDAC();
-    pDAC->CreateStackWalk(m_pCordbThread->m_vmThreadToken,
+    IfFailThrow(pDAC->CreateStackWalk(m_pCordbThread->m_vmThreadToken,
                           &m_context,
-                          &m_pSFIHandle);
+                          &m_pSFIHandle));
 
     // see the function header of code:CordbStackWalk::CheckForLegacyHijackCase
     CheckForLegacyHijackCase();
@@ -80,10 +80,10 @@ void CordbStackWalk::CheckForLegacyHijackCase()
                 m_context.ContextFlags = DT_CONTEXT_FULL;
                 pUT->GetThreadContext(&m_context);
                 IDacDbiInterface * pDAC = GetProcess()->GetDAC();
-                pDAC->SetStackWalkCurrentContext(m_pCordbThread->m_vmThreadToken,
+                IfFailThrow(pDAC->SetStackWalkCurrentContext(m_pCordbThread->m_vmThreadToken,
                                                  m_pSFIHandle,
                                                  SET_CONTEXT_FLAG_ACTIVE_FRAME,
-                                                 &m_context);
+                                                 &m_context));
             }
         }
     }
@@ -129,7 +129,7 @@ void CordbStackWalk::DeleteAll()
 #endif // FEATURE_DBGIPC_TRANSPORT_DI
             {
                 // This Delete call shouldn't actually throw. Worst case, the DDImpl leaked memory.
-                GetProcess()->GetDAC()->DeleteStackWalk(m_pSFIHandle);
+                IfFailThrow(GetProcess()->GetDAC()->DeleteStackWalk(m_pSFIHandle));
             }
         }
         EX_CATCH_HRESULT(hr);
@@ -218,9 +218,9 @@ void CordbStackWalk::RefreshIfNeeded()
         DeleteAll();
 
         // create a new stackwalk handle
-        pProcess->GetDAC()->CreateStackWalk(m_pCordbThread->m_vmThreadToken,
+        IfFailThrow(pProcess->GetDAC()->CreateStackWalk(m_pCordbThread->m_vmThreadToken,
                                             &m_context,
-                                            &m_pSFIHandle);
+                                            &m_pSFIHandle));
 
         // advance the stackwalker to where we originally were
         SetContextWorker(m_cachedSetContextFlag, sizeof(DT_CONTEXT), reinterpret_cast<BYTE *>(&ctx));
@@ -305,7 +305,8 @@ HRESULT CordbStackWalk::GetContext(ULONG32   contextFlags,
                 // No easy way out in this case.  We have to call the DDI.
                 IDacDbiInterface * pDAC = GetProcess()->GetDAC();
 
-                IDacDbiInterface::FrameType ft = pDAC->GetStackWalkCurrentFrameInfo(m_pSFIHandle, NULL);
+                IDacDbiInterface::FrameType ft;
+                IfFailThrow(pDAC->GetStackWalkCurrentFrameInfo(m_pSFIHandle, NULL, &ft));
                 if (ft == IDacDbiInterface::kInvalid)
                 {
                     ThrowHR(E_FAIL);
@@ -398,10 +399,10 @@ void CordbStackWalk::SetContextWorker(CorDebugSetContextFlag flag, ULONG32 conte
     m_context = tmpCtx;
     m_cachedSetContextFlag = flag;
 
-    pDAC->SetStackWalkCurrentContext(m_pCordbThread->m_vmThreadToken,
+    IfFailThrow(pDAC->SetStackWalkCurrentContext(m_pCordbThread->m_vmThreadToken,
                                      m_pSFIHandle,
                                      flag,
-                                     &m_context);
+                                     &m_context));
 }
 
 //---------------------------------------------------------------------------------------
@@ -422,11 +423,12 @@ BOOL CordbStackWalk::UnwindStackFrame()
     _ASSERTE(pProcess->GetProcessLock()->HasLock());
 
     IDacDbiInterface * pDAC = pProcess->GetDAC();
-    BOOL retVal = pDAC->UnwindStackWalkFrame(m_pSFIHandle);
+    BOOL retVal;
+    IfFailThrow(pDAC->UnwindStackWalkFrame(m_pSFIHandle, &retVal));
 
     // Now that we have unwound, make sure we update the CONTEXT buffer to reflect the current stack frame.
     // This call is safe regardless of whether the unwind is successful or not.
-    pDAC->GetStackWalkCurrentContext(m_pSFIHandle, &m_context);
+    IfFailThrow(pDAC->GetStackWalkCurrentContext(m_pSFIHandle, &m_context));
 
     return retVal;
 } // CordbStackWalk::UnwindStackWalkFrame
@@ -465,7 +467,7 @@ HRESULT CordbStackWalk::Next()
             IDacDbiInterface * pDAC = GetProcess()->GetDAC();
             IDacDbiInterface::FrameType ft = IDacDbiInterface::kInvalid;
 
-            ft = pDAC->GetStackWalkCurrentFrameInfo(this->m_pSFIHandle, NULL);
+            IfFailThrow(pDAC->GetStackWalkCurrentFrameInfo(this->m_pSFIHandle, NULL, &ft));
             if (ft == IDacDbiInterface::kAtEndOfStack)
             {
                 ThrowHR(CORDBG_E_PAST_END_OF_STACK);
@@ -578,7 +580,7 @@ HRESULT CordbStackWalk::GetFrameWorker(ICorDebugFrame ** ppFrame)
     IDacDbiInterface::FrameType ft = IDacDbiInterface::kInvalid;
 
     pDAC = GetProcess()->GetDAC();
-    ft = pDAC->GetStackWalkCurrentFrameInfo(m_pSFIHandle, &frameData);
+    IfFailThrow(pDAC->GetStackWalkCurrentFrameInfo(m_pSFIHandle, &frameData, &ft));
 
     if (ft == IDacDbiInterface::kInvalid)
     {
@@ -622,7 +624,7 @@ HRESULT CordbStackWalk::GetFrameWorker(ICorDebugFrame ** ppFrame)
 
         m_fIsOneFrameAhead = true;
 #if defined(TARGET_X86)
-        frameData.fp = pDAC->GetFramePointer(m_pSFIHandle);
+        IfFailThrow(pDAC->GetFramePointer(m_pSFIHandle, &frameData.fp));
 #endif // TARGET_X86
 
         // currentFuncData contains general information about the method.
@@ -807,7 +809,7 @@ HRESULT CordbStackWalk::GetFrameWorker(ICorDebugFrame ** ppFrame)
 
         m_fIsOneFrameAhead = true;
 #if defined(TARGET_X86)
-        frameData.fp = pDAC->GetFramePointer(m_pSFIHandle);
+        IfFailThrow(pDAC->GetFramePointer(m_pSFIHandle, &frameData.fp));
 #endif // TARGET_X86
 
         // Lookup the appdomain that the thread was in when it was executing code for this frame. We pass this
@@ -907,7 +909,8 @@ HRESULT CordbAsyncStackWalk::PopulateFrame()
             &pModule,
             &methodDef);
 
-        IDacDbiInterface::DynamicMethodType dynMethodType = pDac->IsDiagnosticsHiddenOrLCGMethod(codeData.vmNativeCodeMethodDescToken);
+        IDacDbiInterface::DynamicMethodType dynMethodType;
+        IfFailThrow(pDac->IsDiagnosticsHiddenOrLCGMethod(codeData.vmNativeCodeMethodDescToken, &dynMethodType));
         if (dynMethodType == IDacDbiInterface::kDiagnosticHidden)
         {
             // Skipping async frame creation for async thunks. These can not be converted to a CordbAsyncFrame as they lack DebugInfo

--- a/src/coreclr/debug/di/valuehome.cpp
+++ b/src/coreclr/debug/di/valuehome.cpp
@@ -882,7 +882,7 @@ CORDB_ADDRESS HandleValueHome::GetAddress()
     CORDB_ADDRESS handle = PTR_TO_CORDB_ADDRESS((void *)NULL);
     EX_TRY
     {
-        handle = m_pProcess->GetDAC()->GetHandleAddressFromVmHandle(m_vmObjectHandle);
+        IfFailThrow(m_pProcess->GetDAC()->GetHandleAddressFromVmHandle(m_vmObjectHandle, &handle));
     }
     EX_CATCH
     {
@@ -897,7 +897,7 @@ void HandleValueHome::GetValue(MemoryRange dest)
 {
     _ASSERTE((m_pProcess != NULL) && !m_vmObjectHandle.IsNull());
     CORDB_ADDRESS objPtr = PTR_TO_CORDB_ADDRESS((void *)NULL);
-    objPtr = m_pProcess->GetDAC()->GetHandleAddressFromVmHandle(m_vmObjectHandle);
+    IfFailThrow(m_pProcess->GetDAC()->GetHandleAddressFromVmHandle(m_vmObjectHandle, &objPtr));
 
     _ASSERTE(dest.Size() <= sizeof(void *));
     _ASSERTE(dest.StartAddress() != NULL);

--- a/src/coreclr/debug/inc/dacdbiinterface.h
+++ b/src/coreclr/debug/inc/dacdbiinterface.h
@@ -233,7 +233,7 @@ public:
     // with the IDacDbiInterface to free up any resources.
     //
     // Return Value:
-    //    None.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    The client should not call anything else on this interface after Destroy.
@@ -249,7 +249,7 @@ public:
     //
     //
     // Return Value:
-    //    BOOL whether Left-side is initialized.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //   If the Left-side is not yet started up, then data in the LS is not yet initialized enough
@@ -267,9 +267,10 @@ public:
     //
     // Arguments:
     //  appdomainId      - "unique appdomain ID". Must be a valid Id.
+    //  pRetVal - [out] VMPTR_AppDomain for the corresponding AppDomain ID.
     //
     // Return Value:
-    //    VMPTR_AppDomain for the corresponding AppDomain ID.  Returns an appropriate failure HRESULT on error.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //   This query is based off the lifespan of the AppDomain from the VM's perspective.
@@ -285,9 +286,10 @@ public:
     //
     // Arguments:
     //  vmAppDomain  - VM pointer to the AppDomain object of interest
+    //  pRetVal - [out] AppDomain ID for appdomain.
     //
     // Return Value:
-    //    AppDomain ID for appdomain. Returns an appropriate failure HRESULT on error.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //   An AppDomainId is unique for the lifetime of the VM. It is non-zero.
@@ -299,10 +301,10 @@ public:
     //
     // Arguments:
     //  vmAppDomain  - VM pointer to the AppDomain object of interest
+    //  pRetVal - [out] Objecthandle for the managed app domain object or the Null VMPTR if there is no object created yet.
     //
     // Return Value:
-    //    objecthandle for the managed app domain object or the Null VMPTR if there is no
-    //    object created yet
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //   The AppDomain managed object is lazily constructed on the AppDomain the first time
@@ -317,10 +319,10 @@ public:
     //
     // Arguments:
     //      vmDomainAssembly - VM pointer to the assembly in question.
+    //      pResult - [out] Trust status for the assembly.
     //
     // Return Value:
-    //      Returns trust status for the assembly.
-    //      Returns an appropriate failure HRESULT on error.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //      Of course trusted malicious code in the process could always cause this API to lie.  However,
@@ -386,9 +388,7 @@ public:
     //    pStrFileName - string holder to get simple name.
     //
     // Return Value:
-    //     None, but pStrFilename will be initialized upon return.
-    //     Returns an appropriate failure HRESULT if there was a problem reading the data with DAC or on OOM,
-    //     in which case no string was stored into pStrFilename.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //   See code:#ModuleNames for an overview on module names.
@@ -411,13 +411,12 @@ public:
     // Arguments:
     //     vmAssembly       - VM pointer to the Assembly.
     //     pStrFilename     - required out parameter where the filename will be stored.
+    //     pResult - [out] TRUE on success, in which case the filename was stored into pStrFilename.
+    //              FALSE if the assembly has no filename (eg. for in-memory assemblies), in which case
+    //              an empty string was stored into pStrFilename.
     //
     // Return Value:
-    //     TRUE on success, in which case the filename was stored into pStrFilename
-    //     FALSE if the assembly has no filename (eg. for in-memory assemblies), in which
-    //     case an empty string was stored into pStrFilename.
-    //     Returns an appropriate failure HRESULT if there was a problem reading the data with DAC, in which case
-    //     no string was stored into pStrFilename.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //     See code:#ModuleNames for an overview on module names.
@@ -445,13 +444,12 @@ public:
     // Arguments:
     //     vmModule - VM pointer to the module.
     //     pStrFilename - required out parameter where the filename will be stored.
+    //     pResult - [out] TRUE on success, in which case the filename was stored into pStrFilename.
+    //              FALSE if the module has no filename (eg. for in-memory assemblies), in which case
+    //              an empty string was stored into pStrFilename.
     //
     // Return Value:
-    //     TRUE on success, in which case the filename was stored into pStrFilename
-    //     FALSE the module has no filename (eg. for in-memory assemblies), in which
-    //     case an empty string was stored into pStrFilename.
-    //     Returns an appropriate failure HRESULT if there was a problem reading the data with DAC, in which case
-    //     no string was stored into pStrFilename.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //     See code:#ModuleNames for an overview on module names.
@@ -519,12 +517,7 @@ public:
     //    pSymbolFormat - out parameter to get the format of the symbols.
     //
     // Returns:
-    //   1) If there are in-memory symbols for the given module, pTargetBuffer is set to the buffer describing
-    //   the symbols and pSymbolFormat is set to indicate PDB or ILDB format. This buffer can then be read,
-    //   converted into an IStream, and passed to ISymUnmanagedBinder::CreateReaderForStream.
-    //   2) If the target is valid, but there is no symbols for the module, then pTargetBuffer->IsEmpty() == true
-    //   and *pSymbolFormat == kSymbolFormatNone.
-    //   3) Else, returns an appropriate failure HRESULT.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     //
     // Notes:
@@ -593,9 +586,10 @@ public:
     //
     // Arguments:
     //    address      - address to query type.
+    //    pRetVal - [out] Type of address.
     //
     // Return Value:
-    //    Type of address. Returns an appropriate failure HRESULT on error.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    This is taken exactly from the IXClrData definition.
@@ -610,10 +604,11 @@ public:
     //
     // Arguments:
     //   address  - Target address to query for.
+    //   pResult - [out] True if the address is a CLR stub.
     //
     //
     // Return Value:
-    //    true if the address is a CLR stub.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    This is used to implement ICorDebugProcess::IsTransitionStub
@@ -779,7 +774,7 @@ public:
     //    sendExceptionsOutsideOfJMC - new value for the flag Debugger::m_sendExceptionsOutsideOfJMC.
     //
     // Return Value:
-    //    Returns error code, never throws.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Note: This call is used by ICorDebugProcess8.EnableExceptionCallbacksOutsideOfMyCode.
     virtual
@@ -914,7 +909,8 @@ public:
     // Arguments:
     //    vmThread - valid thread to check if it's dead.
     //
-    // Returns: true if the thread is "dead", which means it can never call managed code again.
+    // Returns:
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    #IsThreadMarkedDead
@@ -965,28 +961,30 @@ public:
 
 
     //
-    // Return the handle of the specified thread.
+    // Get the handle of the specified thread.
     //
     // Arguments:
     //    vmThread - the specified thread
+    //    pRetVal - [out] The handle of the specified thread.
     //
     // Return Value:
-    //    the handle of the specified thread
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // @dbgtodo- this should go away in V3. This is useless on a dump.
 
     virtual HRESULT GetThreadHandle(VMPTR_Thread vmThread, OUT HANDLE * pRetVal) = 0;
 
     //
-    // Return the object handle for the managed Thread object corresponding to the specified thread.
+    // Get the object handle for the managed Thread object corresponding to the specified thread.
     //
     // Arguments:
     //    vmThread - the specified thread
+    //    pRetVal - [out] The object handle for the managed Thread object corresponding to
+    //             the specified thread.  The value may be NULL if a managed Thread object
+    //             has not been created for the specified thread yet.
     //
     // Return Value:
-    //    This function returns the object handle for the managed Thread object corresponding to the
-    //    specified thread.  The return value may be NULL if a managed Thread object has not been created
-    //    for the specified thread yet.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
     virtual HRESULT GetThreadObject(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
@@ -1013,26 +1011,28 @@ public:
     virtual HRESULT SetDebugState(VMPTR_Thread vmThread, CorDebugThreadState debugState) = 0;
 
     //
-    // Returns TRUE if this thread has an unhandled exception
+    // Check whether this thread has an unhandled exception
     //
     // Arguments:
     //    vmThread   - the thread to query
+    //    pResult - [out]
     //
-    // Return Value
-    //    TRUE iff this thread has an unhandled exception
+    // Return Value:
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     virtual HRESULT HasUnhandledException(VMPTR_Thread vmThread, OUT BOOL * pResult) = 0;
 
     //
-    // Return the user state of the specified thread.  Most of the state are derived from
+    // Get the user state of the specified thread.  Most of the state are derived from
     // the ThreadState of the specified thread, e.g. TS_Background, TS_Unstarted, etc.
     // The exception is USER_UNSAFE_POINT, which we need to do a one-frame stackwalk to figure out.
     //
     // Arguments:
     //    vmThread - the specified thread
+    //    pRetVal - [out] The user state of the specified thread.
     //
     // Return Value:
-    //    the user state of the specified thread
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
     virtual HRESULT GetUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal) = 0;
@@ -1049,51 +1049,55 @@ public:
     //
     // Arguments:
     //    vmThread - the specified thread
+    //    pRetVal - [out] The user state of the specified thread.
     //
     // Return Value:
-    //    the user state of the specified thread
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     virtual HRESULT GetPartialUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal) = 0;
 
 
     //
-    // Return the connection ID of the specified thread.
+    // Get the connection ID of the specified thread.
     //
     // Arguments:
     //    vmThread - the specified thread
+    //    pRetVal - [out] The connection ID of the specified thread.
     //
     // Return Value:
-    //    the connection ID of the specified thread
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
     virtual HRESULT GetConnectionID(VMPTR_Thread vmThread, OUT CONNID * pRetVal) = 0;
 
     //
-    // Return the task ID of the specified thread.
+    // Get the task ID of the specified thread.
     //
     // Arguments:
     //    vmThread - the specified thread
+    //    pRetVal - [out] The task ID of the specified thread.
     //
     // Return Value:
-    //    the task ID of the specified thread
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
     virtual HRESULT GetTaskID(VMPTR_Thread vmThread, OUT TASKID * pRetVal) = 0;
 
     //
-    // Return the OS thread ID of the specified thread
+    // Get the OS thread ID of the specified thread
     //
     // Arguments:
     //    vmThread - the specified thread; cannot be NULL
+    //    pRetVal - [out] The OS thread ID of the specified thread. Returns 0 if not scheduled.
     //
     // Return Value:
-    //    the OS thread ID of the specified thread. Returns 0 if not scheduled.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
     virtual HRESULT TryGetVolatileOSThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal) = 0;
 
     //
-    // Return the unique thread ID of the specified thread. The value used for the thread ID changes
+    // Get the unique thread ID of the specified thread. The value used for the thread ID changes
     // depending on whether the runtime is being hosted. In non-hosted scenarios, a managed thread will
     // always be associated with the same native thread, and so we can use the OS thread ID as the thread ID
     // for the managed thread. In hosted scenarios, however, a managed thread may run on multiple native
@@ -1102,60 +1106,66 @@ public:
     //
     // Arguments:
     //    vmThread - the specified thread; cannot be NULL
+    //    pRetVal - [out] A stable and unique thread ID for the lifetime of the specified managed thread.
     //
     // Return Value:
-    //    Returns a stable and unique thread ID for the lifetime of the specified managed thread.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
     virtual HRESULT GetUniqueThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal) = 0;
 
     //
-    // Return the object handle to the managed Exception object of the current exception
-    // on the specified thread.  The return value could be NULL if there is no current exception.
+    // Get the object handle to the managed Exception object of the current exception
+    // on the specified thread.  The value may be NULL if there is no current exception.
     //
     // Arguments:
     //    vmThread - the specified thread
+    //    pRetVal - [out] The object handle to the managed Exception object of the current
+    //             exception. The value may be NULL if there is no exception being processed,
+    //             or if the specified thread is an unmanaged thread which has entered and
+    //             exited the runtime.
     //
     // Return Value:
-    //    This function returns the object handle to the managed Exception object of the current exception.
-    //    The return value may be NULL if there is no exception being processed, or if the specified thread
-    //    is an unmanaged thread which has entered and exited the runtime.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
     virtual HRESULT GetCurrentException(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
     //
-    // Return the object handle to the managed object for a given CCW pointer.
+    // Get the object handle to the managed object for a given CCW pointer.
     //
     // Arguments:
     //    ccwPtr - the specified ccw pointer
+    //    pRetVal - [out] The object handle to the managed object for a given CCW pointer.
     //
     // Return Value:
-    //    This function returns the object handle to the managed object for a given CCW pointer.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
     virtual HRESULT GetObjectForCCW(CORDB_ADDRESS ccwPtr, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
     //
-    // Return the object handle to the managed CustomNotification object of the current notification
-    // on the specified thread.  The return value could be NULL if there is no current notification.
+    // Get the object handle to the managed CustomNotification object of the current notification
+    // on the specified thread.  The value may be NULL if there is no current notification.
     //
     // Arguments:
     //    vmThread - the specified thread on which the notification occurred
+    //    pRetVal - [out] The object handle to the managed CustomNotification object of
+    //             the current notification. The value may be NULL if there is no current
+    //             notification.
     //
     // Return Value:
-    //    This function returns the object handle to the managed CustomNotification object of the current notification.
-    //    The return value may be NULL if there is no current notification.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
     virtual HRESULT GetCurrentCustomDebuggerNotification(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
 
     //
-    // Return the current appdomain.
+    // Get the current appdomain.
     //
     // Return Value:
-    //    the current appdomain
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    This function returns a failure HRESULT if the current appdomain is NULL for whatever reason.
@@ -1170,11 +1180,11 @@ public:
     // Arguments:
     //    vmScope - module containing metadata that the token is scoped to.
     //    tkAssemblyRef - assembly ref token to lookup.
+    //    pRetVal - [out] Assembly that the loader/fusion has bound to the given assembly
+    //             ref. Returns NULL if the assembly has not yet been loaded (a common case).
     //
     // Returns:
-    //    Assembly that the loader/fusion has bound to the given assembly ref.
-    //    Returns NULL if the assembly has not yet been loaded (a common case).
-    //    Returns an appropriate failure HRESULT on error.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    A single module has metadata that specifies references via tokens. The
@@ -1209,14 +1219,15 @@ public:
     virtual HRESULT GetNativeCodeSequencePointsAndVarInfo(VMPTR_MethodDesc vmMethodDesc, CORDB_ADDRESS startAddress, BOOL fCodeAvailable, OUT NativeVarData * pNativeVarData, OUT SequencePoints * pSequencePoints) = 0;
 
     //
-    // Return the filter CONTEXT on the LS.  Once we move entirely over to the new managed pipeline
+    // Get the filter CONTEXT on the LS.  Once we move entirely over to the new managed pipeline
     // built on top of the Win32 debugging API, this won't be necessary.
     //
     // Arguments:
     //    vmThread - the specified thread
+    //    pRetVal - [out] The filter CONTEXT of the specified thread.
     //
     // Return Value:
-    //    the filter CONTEXT of the specified thread
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    This function should go away when everything is moved OOP and
@@ -1291,11 +1302,10 @@ public:
     //
     // Arguments:
     //    pSFIHandle - the handle to the stackwalker
+    //    pResult - [out] TRUE if we successfully unwind to the next frame. Return FALSE if there is no more frames to walk.
     //
     // Return Value:
-    //    Return TRUE if we successfully unwind to the next frame.
-    //    Return FALSE if there is no more frames to walk.
-    //    Returns an appropriate failure HRESULT on error.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
     virtual HRESULT UnwindStackWalkFrame(StackWalkHandle pSFIHandle, OUT BOOL * pResult) = 0;
@@ -1309,10 +1319,7 @@ public:
     //    pContext   - the CONTEXT to be checked
     //
     // Return Value:
-    //    Return S_OK if the CONTEXT passes our checks.
-    //    Returns CORDBG_E_NON_MATCHING_CONTEXT if the SP in the specified CONTEXT doesn't fall in the stack
-    //         range of the thread.
-    //    Returns an appropriate failure HRESULT on error.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
     virtual
@@ -1327,21 +1334,23 @@ public:
     //    pSFIHandle - the handle to the stackwalker
     //    pFrameData - the DebuggerIPCE_STRData to be filled out;
     //                 it can be NULL if you just want to know the frame type
+    //    pRetVal - [out] The type of the current frame.
     //
     // Return Value:
-    //    Return the type of the current frame
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
     virtual HRESULT GetStackWalkCurrentFrameInfo(StackWalkHandle pSFIHandle, OPTIONAL DebuggerIPCE_STRData * pFrameData, OUT FrameType * pRetVal) = 0;
 
     //
-    // Return the number of internal frames on the specified thread.
+    // Get the number of internal frames on the specified thread.
     //
     // Arguments:
     //    vmThread - the thread whose internal frames are being retrieved
+    //    pRetVal - [out] The number of internal frames.
     //
     // Return Value:
-    //    Return the number of internal frames.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    Explicit frames are "marker objects" the runtime pushes on the stack to mark special places, e.g.
@@ -1382,9 +1391,10 @@ public:
     // Arguments:
     //    fpToCheck - the FramePointer of the current frame
     //    fpParent  - the FramePointer of the parent frame; should have been returned earlier by the DDI
+    //    pResult - [out] TRUE if the current frame is indeed the parent frame.
     //
     // Return Value:
-    //    Return TRUE if the current frame is indeed the parent frame
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Note:
     //    Because of the complexity involved in checking for the parent frame, we should always
@@ -1394,14 +1404,14 @@ public:
     virtual HRESULT IsMatchingParentFrame(FramePointer fpToCheck, FramePointer fpParent, OUT BOOL * pResult) = 0;
 
     //
-    // Return the stack parameter size of a given method.  This is necessary on x86 for unwinding.
+    // Get the stack parameter size of a given method.  This is necessary on x86 for unwinding.
     //
     // Arguments:
     //    controlPC - any address in the specified method; you can use the current PC of the stack frame
+    //    pRetVal - [out] The size of the stack parameters of the given method. Return 0 for vararg methods.
     //
     // Return Value:
-    //    Return the size of the stack parameters of the given method.
-    //    Return 0 for vararg methods.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Assumptions:
     //    The callee stack parameter size is constant throughout a method.
@@ -1410,13 +1420,14 @@ public:
     virtual HRESULT GetStackParameterSize(CORDB_ADDRESS controlPC, OUT ULONG32 * pRetVal) = 0;
 
     //
-    // Return the FramePointer of the current frame where the stackwalker is stopped at.
+    // Get the FramePointer of the current frame where the stackwalker is stopped at.
     //
     // Arguments:
     //    pSFIHandle - the handle to the stackwalker
+    //    pRetVal - [out] The FramePointer of the current frame.
     //
     // Return Value:
-    //    the FramePointer of the current frame
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    The FramePointer of a stack frame is:
@@ -1440,9 +1451,10 @@ public:
     // Arguments:
     //    vmThread  - the specified thread
     //    pContext  - the CONTEXT to check
+    //    pResult - [out] TRUE if the specified CONTEXT is the leaf CONTEXT.
     //
     // Return Value:
-    //    Return TRUE if the specified CONTEXT is the leaf CONTEXT.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    Currently we check the specified CONTEXT against the filter CONTEXT first.
@@ -1487,25 +1499,27 @@ public:
     //
     // Arguments:
     //    vmMethodDesc - the method to be checked
+    //    pRetVal - [out] KNone if the method is neither a DiagnosticHidden or an LCG
+    //             method. Return kDiagnosticHidden if the method is a DiagnosticHidden
+    //             method. Return kLCGMethod if the method is an LCG method.
     //
     // Return Value:
-    //    Return kNone if the method is neither a DiagnosticHidden or an LCG method.
-    //    Return kDiagnosticHidden if the method is a DiagnosticHidden method.
-    //    Return kLCGMethod if the method is an LCG method.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
     virtual HRESULT IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc, OUT DynamicMethodType * pRetVal) = 0;
 
     //
-    // Return a TargetBuffer for the raw vararg signature.
-    // Also return the address of the first argument in the vararg signature.
+    // Get a TargetBuffer for the raw vararg signature.
+    // Also get the address of the first argument in the vararg signature.
     //
     // Arguments:
     //    VASigCookieAddr - the target address of the VASigCookie pointer (double indirection)
     //    pArgBase        - out parameter; return the target address of the first word of the arguments
+    //    pRetVal - [out] A TargetBuffer for the raw vararg signature.
     //
     // Return Value:
-    //    Return a TargetBuffer for the raw vararg signature.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    We can't take a VMPTR here because VASigCookieAddr does not come from the DDI.  Instead,
@@ -1530,9 +1544,10 @@ public:
     //
     // Arguments:
     //    thExact - the exact TypeHandle of the type to query
+    //    pResult - [out] TRUE if the type requires 8-byte alignment.
     //
     // Return Value:
-    //    TRUE if the type requires 8-byte alignment.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
     virtual HRESULT RequiresAlign8(VMPTR_TypeHandle thExact, OUT BOOL * pResult) = 0;
@@ -1544,9 +1559,10 @@ public:
     // Arguments:
     //    dwExactGenericArgsTokenIndex - the variable index of the generics type token
     //    rawToken                     - the raw token to be resolved
+    //    pRetVal - [out] The actual generics type token.
     //
     // Return Value:
-    //    Return the actual generics type token.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    DDI tells the RS which variable stores the generics type token, but DDI doesn't retrieve the value
@@ -1570,7 +1586,7 @@ public:
     // Functions to get information about code objects
     //-----------------------------------------------------------------------------
 
-    // GetILCodeAndSig returns the function's ILCode and SigToken given
+    // GetILCodeAndSig gets the function's ILCode and SigToken given
     // a module and a token. The info will come from a MethodDesc, if
     // one exists or from metadata.
     //
@@ -1581,6 +1597,7 @@ public:
     //    Output (required):
     //    codeInfo       - start address and size of the IL
     //    pLocalSigToken - signature token for the method
+    //    pCodeInfo - [out]
     virtual HRESULT GetILCodeAndSig(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT TargetBuffer * pCodeInfo, OUT mdToken * pLocalSigToken) = 0;
 
     // Gets information about a native code blob:
@@ -1625,6 +1642,7 @@ public:
     //
     // Arguments:
     //     input:  vmTypeHandle  - the type being checked (works even on unrestored types)
+    //     pResult - [out]
     //
     // Return:
     //        TRUE iff the type is a ValueType
@@ -1635,6 +1653,7 @@ public:
     //
     // Arguments:
     //     input:  vmTypeHandle  - the type being checked (works even on unrestored types)
+    //     pResult - [out]
     //
     // Return:
     //        TRUE iff the type has generic parameters
@@ -1690,8 +1709,10 @@ public:
     // Arguments:
     //     input: vmModule      - the module scope in which to look up the type def
     //            metadataToken - the type definition to retrieve
+    //     pRetVal - [out] The type handle if it exists, or returns CORDBG_E_CLASS_NOT_LOADED if it isn't loaded.
     //
-    // Return value: the type handle if it exists, or returns CORDBG_E_CLASS_NOT_LOADED if it isn't loaded
+    // Return value:
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     virtual HRESULT GetTypeHandle(VMPTR_Module vmModule, mdTypeDef metadataToken, OUT VMPTR_TypeHandle * pRetVal) = 0;
 
@@ -1703,7 +1724,9 @@ public:
     // Arguments:
     //     input: pTypeData  - information needed to get the type handle, this includes a list of type parameters
     //                         and the number of entries in the list. Allocated and initialized by the caller.
-    // Return value: the approximate type handle
+    //     pRetVal - [out] The approximate type handle.
+    // Return value:
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     virtual HRESULT GetApproxTypeHandle(TypeInfoList * pTypeData, OUT VMPTR_TypeHandle * pRetVal) = 0;
 
@@ -1720,7 +1743,8 @@ public:
     //                                    type.
     //                 pGenericArgData  - list of type parameters
     //                 vmTypeHandle     - the exact type handle derived from the type information
-    // Return Value: an HRESULT indicating the result of the operation
+    // Return Value:
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     virtual
     HRESULT GetExactTypeHandle(DebuggerIPCE_ExpandedTypeData * pTypeData,
                                ArgInfoList *   pArgInfo,
@@ -1734,6 +1758,8 @@ public:
     //    vmAppDomain   - the appdomain of the MethodDesc
     //    vmMethodDesc  - the method in question
     //    genericsToken - the generic type token in the stack frame owned by the method
+    //    pcGenericClassTypeParams - [out]
+    //    pGenericTypeParams - [out]
     //
     //    pcGenericClassTypeParams - out parameter; returns the number of type parameters for the class
     //                               containing the method in question; must not be NULL
@@ -1752,8 +1778,9 @@ public:
     //     input: vmField         - pointer to the field descriptor for the static field
     //            vmRuntimeThread - thread to which the static field belongs. This must
     //                              NOT be NULL
-    // Return Value: The target address of the field if the field is allocated.
-    //               NULL if the field storage is not yet allocated.
+    //     pRetVal - [out] The target address of the field if the field is allocated. NULL if the field storage is not yet allocated.
+    // Return Value:
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Note:
     //  Static field storage is lazily allocated, so this may commonly return NULL.
@@ -1767,8 +1794,9 @@ public:
     //     input: vmField         - pointer to the field descriptor for the static field
     //            vmAppDomain     - AppDomain to which the static field belongs. This must
     //                              NOT be NULL
-    // Return Value: The target address of the field if the field is allocated.
-    //               NULL if the field storage is not yet allocated.
+    //     pRetVal - [out] The target address of the field if the field is allocated. NULL if the field storage is not yet allocated.
+    // Return Value:
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Note:
     //  Static field storage may not exist yet, so this may commonly return NULL.
@@ -1816,6 +1844,7 @@ public:
     //     output: pMetadataToken - the metadata token corresponding to simpleType,
     //                              in the scope of vmDomainAssembly.
     //             vmDomainAssembly   - the domainAssembly for simpleType
+    //             pVmModule - [out]
     // Notes:
     //    This is inspection-only. If the type is not yet loaded, it will return CORDBG_E_CLASS_NOT_LOADED.
     //    It will not try to load a type.
@@ -1824,13 +1853,13 @@ public:
 
     virtual HRESULT GetSimpleType(VMPTR_AppDomain vmAppDomain, CorElementType simpleType, OUT mdTypeDef * pMetadataToken, OUT VMPTR_Module * pVmModule, OUT VMPTR_DomainAssembly * pVmDomainAssembly) = 0;
 
-    // for the specified object returns TRUE if the object derives from System.Exception
+    // For the specified object, check whether the object derives from System.Exception.
     virtual HRESULT IsExceptionObject(VMPTR_Object vmObject, OUT BOOL * pResult) = 0;
 
-    // gets the list of raw stack frames for the specified exception object
+    // Get the list of raw stack frames for the specified exception object.
     virtual HRESULT GetStackFramesFromException(VMPTR_Object vmObject, DacDbiArrayList<DacExceptionCallStackData>& dacStackFrames) = 0;
 
-    // Returns true if the argument is a runtime callable wrapper
+    // Check whether the argument is a runtime callable wrapper.
     virtual HRESULT IsRcw(VMPTR_Object vmObject, OUT BOOL * pResult) = 0;
 
     // retrieves the list of COM interfaces implemented by vmObject, as it is known at
@@ -1933,8 +1962,10 @@ public:
     // contains information about the status of the debugger, handles to various events and space to hold
     // information sent back and forth between the debugger and the debuggee's helper thread.
     // Arguments: none
-    // Return Value: The remote address of the Debugger control block allocated on the helper thread
-    //               if it has been successfully allocated or NULL otherwise.
+    //    pRetVal - [out] The remote address of the Debugger control block allocated on the
+    //             helper thread if it has been successfully allocated or NULL otherwise.
+    // Return Value:
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     virtual HRESULT GetDebuggerControlBlockAddress(OUT CORDB_ADDRESS * pRetVal) = 0;
 
     // Creates a VMPTR of an Object. The Object is found by dereferencing ptr
@@ -1943,9 +1974,10 @@ public:
     //
     // Arguments:
     //    ptr     - A target address pointing to an OBJECTREF
+    //    pRetVal - [out] A VMPTR to the Object which ptr points to.
     //
     // Return Value:
-    //    A VMPTR to the Object which ptr points to
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    The VMPTR this produces can be deconstructed by GetObjectContents.
@@ -1959,9 +1991,10 @@ public:
     //
     // Arguments:
     //    ptr     - A target address to an Object
+    //    pRetVal - [out] A VMPTR to the Object which was at ptr.
     //
     // Return Value:
-    //    A VMPTR to the Object which was at ptr
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    The VMPTR this produces can be deconstructed by GetObjectContents.
@@ -1975,7 +2008,7 @@ public:
     //    ePolicy - the NGEN policy to change
     //
     // Return Value:
-    //    HRESULT indicating if the state was successfully updated
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     virtual
     HRESULT EnableNGENPolicy(CorDebugNGENPolicy ePolicy) = 0;
@@ -2000,8 +2033,7 @@ public:
     //    dwFlags - the new NGEN compiler flags that should go into effect
     //
     // Return Value:
-    //    HRESULT indicating if the state was successfully updated. On error the
-    //    current flags in effect will not have changed.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     virtual
     HRESULT SetNGENCompilerFlags(DWORD dwFlags) = 0;
@@ -2014,7 +2046,7 @@ public:
     //    pdwFlags - the NGEN compiler flags currently in effect
     //
     // Return Value:
-    //    HRESULT indicating if the state was successfully retrieved.
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     virtual
     HRESULT GetNGENCompilerFlags(DWORD *pdwFlags) = 0;
@@ -2023,6 +2055,7 @@ public:
     //
     // Arguments:
     //     handle: target address of a GC handle
+    //     pRetVal - [out]
     //
     // ReturnValue:
     //     returns a VMPTR_OBJECTHANDLE with the handle as the m_addr field
@@ -2037,9 +2070,10 @@ public:
     //
     // Arguments:
     //     handle: the GC handle to be validated
+    //     pResult - [out] TRUE if the object appears to be valid (its a heuristic), FALSE if it definately is not valid.
     //
     // Return value:
-    //     TRUE if the object appears to be valid (its a heuristic), FALSE if it definately is not valid
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     virtual HRESULT IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle, OUT BOOL * pResult) = 0;
 
@@ -2050,7 +2084,7 @@ public:
     //     isWinRT: out parameter indicating state of module
     //
     // Return value:
-    //     S_OK indicating that the operation succeeded
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     virtual
     HRESULT IsWinRTModule(VMPTR_Module vmModule, BOOL& isWinRT) = 0;
@@ -2059,9 +2093,10 @@ public:
     //
     // Arguments:
     //     handle: the GC handle which refers to the object of interest
+    //     pRetVal - [out] The app domain id of the object of interest.
     //
     // Return value:
-    //     The app domain id of the object of interest
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // This may return a failure HRESULT if the object handle is corrupt (it doesn't refer to a managed object)
     virtual HRESULT GetAppDomainIdFromVmObjectHandle(VMPTR_OBJECTHANDLE vmHandle, OUT ULONG * pRetVal) = 0;
@@ -2070,17 +2105,20 @@ public:
     // Get the target address from a VMPTR_OBJECTHANDLE, i.e., the handle address
     // Arguments:
     //     vmHandle - (input) the VMPTR_OBJECTHANDLE from which we need the target address
-    // Return value: the target address from the VMPTR_OBJECTHANDLE
+    //     pRetVal - [out] The target address from the VMPTR_OBJECTHANDLE.
+    // Return value:
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     virtual HRESULT GetHandleAddressFromVmHandle(VMPTR_OBJECTHANDLE vmHandle, OUT CORDB_ADDRESS * pRetVal) = 0;
 
-    // Given a VMPTR to an Object return the target address
+    // Given a VMPTR to an Object, get the target address.
     //
     // Arguments:
     //    obj      - the Object VMPTR to get the address from
+    //    pRetVal - [out] The target address which obj is using.
     //
     // Return Value:
-    //    Return the target address which obj is using
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Notes:
     //    The VMPTR this consumes can be reconstructed using GetObject and
@@ -2090,18 +2128,17 @@ public:
     virtual HRESULT GetObjectContents(VMPTR_Object obj, OUT TargetBuffer * pRetVal) = 0;
 
     //
-    // Returns the thread which owns the monitor lock on an object and the acquisition
+    // Get the thread which owns the monitor lock on an object and the acquisition
     // count
     //
     // Arguments:
     //    vmObject          - The object to check for ownership
-
+    //    pRetVal           - [out] Inside the structure we have: 
+    //      pVmThread - the owning thread or VMPTR_Thread::NullPtr() if unowned, 
+    //      pAcquisitionCount - the number of times the lock would need to be released in order for it to be unowned.
     //
     // Return Value:
-    //    Returns an appropriate failure HRESULT on error. Inside the structure we have:
-    //    pVmThread         - the owning or thread or VMPTR_Thread::NullPtr() if unowned
-    //    pAcquisitionCount - the number of times the lock would need to be released in
-    //                        order for it to be unowned
+    //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     virtual HRESULT GetThreadOwningMonitorLock(VMPTR_Object vmObject, OUT MonitorLockInfo * pRetVal) = 0;
 
@@ -2120,7 +2157,7 @@ public:
     virtual HRESULT EnumerateMonitorEventWaitList(VMPTR_Object vmObject, FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
 
     //
-    // Returns the managed debugging flags for the process (a combination
+    // Get the managed debugging flags for the process (a combination
     // of the CLR_DEBUGGING_PROCESS_FLAGS flags). This function specifies,
     // beyond whether or not a managed debug event is pending, also if the
     // event (if one exists) is caused by a Debugger.Launch(). This is
@@ -2241,7 +2278,7 @@ public:
 
     virtual HRESULT GetGCHeapInformation(OUT COR_HEAPINFO * pHeapInfo) = 0;
 
-    // If a PEAssembly has an RW capable IMDInternalImport, this returns the address of the MDInternalRW
+    // If a PEAssembly has an RW capable IMDInternalImport, this gets the address of the MDInternalRW
     // object which implements it.
     //
     //
@@ -2468,10 +2505,11 @@ public:
     //
     // Arguments:
     //    vmObject - pointer to runtime object to query for.
+    //    pResult - [out]
     //
     virtual HRESULT IsDelegate(VMPTR_Object vmObject, OUT BOOL * pResult) = 0;
 
-    // Returns the delegate type
+    // Get the delegate type
     virtual
     HRESULT GetDelegateType(VMPTR_Object delegateObject, DelegateType *delegateType) = 0;
 

--- a/src/coreclr/debug/inc/dacdbiinterface.h
+++ b/src/coreclr/debug/inc/dacdbiinterface.h
@@ -219,8 +219,7 @@ public:
     //   consistency failures exceptions (this is independent from asserts - there are legitimate
     //   scenarios for all 4 combinations).
     //
-    virtual
-    void DacSetTargetConsistencyChecks(bool fEnableAsserts) = 0;
+    virtual HRESULT DacSetTargetConsistencyChecks(bool fEnableAsserts) = 0;
 
     //
     // Destroy the interface object. The client should call this when it's done
@@ -232,8 +231,7 @@ public:
     // Notes:
     //    The client should not call anything else on this interface after Destroy.
     //
-    virtual
-    void Destroy() = 0;
+    virtual HRESULT Destroy() = 0;
 
     //-----------------------------------------------------------------------------
     // General purpose target inspection functions
@@ -253,8 +251,7 @@ public:
     //   If the left-side is started up, then data is ready. (Although data may be temporarily inconsistent,
     //   see DataSafe). We may still get a Startup Exception in these cases, but it can be ignored.
     //
-    virtual
-    BOOL IsLeftSideInitialized() = 0;
+    virtual HRESULT IsLeftSideInitialized(OUT BOOL * pResult) = 0;
 
 
     //
@@ -273,8 +270,7 @@ public:
     //   An AppDomainId is unique for the lifetime of the VM.
     //   This is the inverse function of GetAppDomainId().
     //
-    virtual
-    VMPTR_AppDomain GetAppDomainFromId(ULONG appdomainId) = 0;
+    virtual HRESULT GetAppDomainFromId(ULONG appdomainId, OUT VMPTR_AppDomain * pRetVal) = 0;
 
 
     //
@@ -289,8 +285,7 @@ public:
     // Notes:
     //   An AppDomainId is unique for the lifetime of the VM. It is non-zero.
     //
-    virtual
-    ULONG GetAppDomainId(VMPTR_AppDomain vmAppDomain) = 0;
+    virtual HRESULT GetAppDomainId(VMPTR_AppDomain vmAppDomain, OUT ULONG * pRetVal) = 0;
 
     //
     // Get the managed AppDomain object for an AppDomain.
@@ -306,11 +301,9 @@ public:
     //   The AppDomain managed object is lazily constructed on the AppDomain the first time
     //   it is requested. It may be NULL.
     //
-    virtual
-    VMPTR_OBJECTHANDLE GetAppDomainObject(VMPTR_AppDomain vmAppDomain) = 0;
+    virtual HRESULT GetAppDomainObject(VMPTR_AppDomain vmAppDomain, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
-    virtual
-    void GetAssemblyFromDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Assembly * vmAssembly) = 0;
+    virtual HRESULT GetAssemblyFromDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Assembly * vmAssembly) = 0;
 
     //
     // Determines whether the runtime security system has assigned full-trust to this assembly.
@@ -326,8 +319,7 @@ public:
     //      Of course trusted malicious code in the process could always cause this API to lie.  However,
     //      an assembly loaded without full-trust should have no way of causing this API to return true.
     //
-    virtual
-    BOOL IsAssemblyFullyTrusted(VMPTR_DomainAssembly vmDomainAssembly) = 0;
+    virtual HRESULT IsAssemblyFullyTrusted(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pResult) = 0;
 
 
     //
@@ -346,10 +338,7 @@ public:
     //    so callers should be prepared to listen for name-change events and requery.
     //    AD names are specified by the user.
     //
-    virtual
-    void GetAppDomainFullName(
-        VMPTR_AppDomain vmAppDomain,
-        IStringHolder * pStrName) = 0;
+    virtual HRESULT GetAppDomainFullName(VMPTR_AppDomain vmAppDomain, IStringHolder * pStrName) = 0;
 
 
     //
@@ -406,8 +395,7 @@ public:
     //   relationship to the filename, and it's not necessarily the metadata name.
     //   Do not use the simple name for anything other than as a pretty string to give the an end user.
     //
-    virtual
-    void GetModuleSimpleName(VMPTR_Module vmModule, IStringHolder * pStrFilename) = 0;
+    virtual HRESULT GetModuleSimpleName(VMPTR_Module vmModule, IStringHolder * pStrFilename) = 0;
 
 
     //
@@ -434,9 +422,7 @@ public:
     //     which will not be saved to disk) there is no filename.  In that case this API
     //     returns an empty string.
     //
-    virtual
-    BOOL GetAssemblyPath(VMPTR_Assembly   vmAssembly,
-                         IStringHolder *  pStrFilename) = 0;
+    virtual HRESULT GetAssemblyPath(VMPTR_Assembly vmAssembly, IStringHolder * pStrFilename, OUT BOOL * pResult) = 0;
 
 
     // get a type def resolved across modules
@@ -445,9 +431,7 @@ public:
     //     output: pTargetRefInfo - domain file and type def from the referenced type (this may
     //                              come from a module other than the referencing module)
     // Note: throws
-    virtual
-    void ResolveTypeReference(const TypeRefData * pTypeRefInfo,
-                              TypeRefData *       pTargetRefInfo) = 0;
+    virtual HRESULT ResolveTypeReference(const TypeRefData * pTypeRefInfo, TypeRefData * pTargetRefInfo) = 0;
     //
     // Get the full path and file name to the module (if any).
     //
@@ -473,9 +457,7 @@ public:
     //     We intentionally don't use the function name "GetModuleFileName" here because
     //     winbase #defines that token (along with many others) to have an A or W suffix.
     //
-    virtual
-    BOOL GetModulePath(VMPTR_Module vmModule,
-                       IStringHolder *  pStrFilename) = 0;
+    virtual HRESULT GetModulePath(VMPTR_Module vmModule, IStringHolder * pStrFilename, OUT BOOL * pResult) = 0;
 
     // Get the metadata for the target module
     //
@@ -510,8 +492,7 @@ public:
     //    scenario with missing memory. Client should use alternative metadata location techniques (such as
     //    an ImagePath to locate the original image and then pulling metadata from that file).
     //
-    virtual
-    void GetMetadata(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer) = 0;
+    virtual HRESULT GetMetadata(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer) = 0;
 
 
     // Definitions for possible symbol formats
@@ -549,8 +530,7 @@ public:
     //   - hosted modules where the host (such as SQL) store the PDB.
     //
     //   In all cases, this can commonly fail. Executable code does not need to have a PDB.
-    virtual
-    void GetSymbolsBuffer(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer, OUT SymbolFormat * pSymbolFormat) = 0;
+    virtual HRESULT GetSymbolsBuffer(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer, OUT SymbolFormat * pSymbolFormat) = 0;
 
     //
     // Get properties for a module
@@ -562,8 +542,7 @@ public:
     // Notes:
     //    See definition of DomainAssemblyInfo for more details about what properties
     //    this gives back.
-    virtual
-    void GetModuleData(VMPTR_Module vmModule, OUT ModuleInfo * pData) = 0;
+    virtual HRESULT GetModuleData(VMPTR_Module vmModule, OUT ModuleInfo * pData) = 0;
 
 
     //
@@ -576,11 +555,9 @@ public:
     // Notes:
     //    See definition of DomainAssemblyInfo for more details about what properties
     //    this gives back.
-    virtual
-    void GetDomainAssemblyData(VMPTR_DomainAssembly vmDomainAssembly, OUT DomainAssemblyInfo * pData) = 0;
+    virtual HRESULT GetDomainAssemblyData(VMPTR_DomainAssembly vmDomainAssembly, OUT DomainAssemblyInfo * pData) = 0;
 
-    virtual
-    void GetModuleForDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Module * pModule) = 0;
+    virtual HRESULT GetModuleForDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Module * pModule) = 0;
 
     //.........................................................................
     // These methods were the methods that DBI was calling from IXClrData in V2.
@@ -618,8 +595,7 @@ public:
     //    This is provided for V3 compatibility to support Interop-debugging.
     //    This should eventually be deprecated.
     //
-    virtual
-    AddressType GetAddressType(CORDB_ADDRESS address) = 0;
+    virtual HRESULT GetAddressType(CORDB_ADDRESS address, OUT AddressType * pRetVal) = 0;
 
 
     //
@@ -637,8 +613,7 @@ public:
     //    This yields true if the address is claimed by a CLR stub manager, or if the IP is in mscorwks.
     //    Conceptually, This should eventually be merged with GetAddressType().
     //
-    virtual
-    BOOL IsTransitionStub(CORDB_ADDRESS address) = 0;
+    virtual HRESULT IsTransitionStub(CORDB_ADDRESS address, OUT BOOL * pResult) = 0;
 
     //.........................................................................
     // Get the values of the JIT Optimization and EnC flags.
@@ -657,11 +632,7 @@ public:
     //    ICorDebugCode2::GetCompilerFlags.
     //.........................................................................
 
-    virtual
-    void GetCompilerFlags(
-        VMPTR_DomainAssembly vmDomainAssembly,
-        OUT BOOL * pfAllowJITOpts,
-        OUT BOOL * pfEnableEnC) = 0;
+    virtual HRESULT GetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pfAllowJITOpts, OUT BOOL * pfEnableEnC) = 0;
 
     //.........................................................................
     // Set the values of the JIT optimization and EnC flags.
@@ -710,9 +681,7 @@ public:
     //    See enumeration rules for details.
     //
     typedef void (*FP_APPDOMAIN_ENUMERATION_CALLBACK)(VMPTR_AppDomain vmAppDomain, CALLBACK_DATA pUserData);
-    virtual
-    void EnumerateAppDomains(FP_APPDOMAIN_ENUMERATION_CALLBACK fpCallback,
-                                CALLBACK_DATA                            pUserData) = 0;
+    virtual HRESULT EnumerateAppDomains(FP_APPDOMAIN_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
 
 
     //
@@ -741,10 +710,7 @@ public:
     //
 
     typedef void (*FP_ASSEMBLY_ENUMERATION_CALLBACK)(VMPTR_DomainAssembly vmDomainAssembly, CALLBACK_DATA pUserData);
-    virtual
-    void EnumerateAssembliesInAppDomain(VMPTR_AppDomain                  vmAppDomain,
-                                           FP_ASSEMBLY_ENUMERATION_CALLBACK fpCallback,
-                                           CALLBACK_DATA                           pUserData) = 0;
+    virtual HRESULT EnumerateAssembliesInAppDomain(VMPTR_AppDomain vmAppDomain, FP_ASSEMBLY_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
 
 
 
@@ -773,11 +739,7 @@ public:
     //    - Resource modules (which have no code or metadata)
     //    - Inspection-only modules. These are viewed as pure data from the debugger's perspective.
     //
-    virtual
-    void EnumerateModulesInAssembly(
-            VMPTR_DomainAssembly vmAssembly,
-            FP_MODULE_ENUMERATION_CALLBACK fpCallback,
-            CALLBACK_DATA pUserData) = 0;
+    virtual HRESULT EnumerateModulesInAssembly(VMPTR_DomainAssembly vmAssembly, FP_MODULE_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
 
 
 
@@ -800,8 +762,7 @@ public:
     //
     //    This is also like a precursor to "AsyncBreakAllOtherThreads"
     //
-    virtual
-    void RequestSyncAtEvent() = 0;
+    virtual HRESULT RequestSyncAtEvent() = 0;
 
     // Sets a flag inside LS.Debugger that indicates that
     // 1. all "first chance exception" events should not be sent to the debugger
@@ -831,8 +792,7 @@ public:
     //     This doesn't do anything else (eg, no fake events).
     //
     //     @dbgtodo- still an open Feature-Crew decision how this is exposed publicly.
-    virtual
-    void MarkDebuggerAttachPending() = 0;
+    virtual HRESULT MarkDebuggerAttachPending() = 0;
 
     //
     // Notify the debuggee that a debugger is attached / detached.
@@ -849,8 +809,7 @@ public:
     //     This lets the V3 codepaths invade the LS to subscribe to events.
     //
     //     @dbgtodo- still an open Feature-Crew decision how this is exposed publicly.
-    virtual
-    void MarkDebuggerAttached(BOOL fAttached) = 0;
+    virtual HRESULT MarkDebuggerAttached(BOOL fAttached) = 0;
 
 
 
@@ -895,16 +854,7 @@ public:
     //    stackwalker that the GC uses. It must be in cooperative mode, and push a Frame on the
     //    frame chain to protect the managed frames it hijacked from before it goes to preemptive mode.
 
-    virtual
-    void Hijack(
-        VMPTR_Thread                 vmThread,
-        ULONG32                      dwThreadId,
-        const EXCEPTION_RECORD *     pRecord,
-        T_CONTEXT *                    pOriginalContext,
-        ULONG32                      cbSizeContext,
-        EHijackReason::EHijackReason reason,
-        void *                       pUserData,
-        CORDB_ADDRESS *              pRemoteContextAddr) = 0;
+    virtual HRESULT Hijack(VMPTR_Thread vmThread, ULONG32 dwThreadId, const EXCEPTION_RECORD * pRecord, T_CONTEXT * pOriginalContext, ULONG32 cbSizeContext, EHijackReason::EHijackReason reason, void * pUserData, CORDB_ADDRESS * pRemoteContextAddr) = 0;
 
 
     //
@@ -949,8 +899,7 @@ public:
     // Callback invoked for each thread.
     typedef void (*FP_THREAD_ENUMERATION_CALLBACK)(VMPTR_Thread vmThread, CALLBACK_DATA pUserData);
 
-    virtual
-    void EnumerateThreads(FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
+    virtual HRESULT EnumerateThreads(FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
 
 
     // Check if the thread is dead
@@ -1005,8 +954,7 @@ public:
     //    Whether a thread is dead can be inferred from the ICorDebug API. However, we have this
     //    on DacDbi to ensure that this definition is consistent with the other DacDbi methods,
     //    especially the enumeration and discovery rules.
-    virtual
-    bool IsThreadMarkedDead(VMPTR_Thread vmThread) = 0;
+    virtual HRESULT IsThreadMarkedDead(VMPTR_Thread vmThread, OUT bool * pResult) = 0;
 
 
     //
@@ -1020,8 +968,7 @@ public:
     //
     // @dbgtodo- this should go away in V3. This is useless on a dump.
 
-    virtual
-    HANDLE GetThreadHandle(VMPTR_Thread vmThread) = 0;
+    virtual HRESULT GetThreadHandle(VMPTR_Thread vmThread, OUT HANDLE * pRetVal) = 0;
 
     //
     // Return the object handle for the managed Thread object corresponding to the specified thread.
@@ -1035,8 +982,7 @@ public:
     //    for the specified thread yet.
     //
 
-    virtual
-    VMPTR_OBJECTHANDLE GetThreadObject(VMPTR_Thread vmThread) = 0;
+    virtual HRESULT GetThreadObject(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
     //
     // Get the allocation info corresponding to the specified thread.
@@ -1046,8 +992,7 @@ public:
     //    threadAllocInfo - the allocated bytes from SOH and UOH so far on this thread
     //
 
-    virtual
-    void GetThreadAllocInfo(VMPTR_Thread vmThread, DacThreadAllocInfo* threadAllocInfo) = 0;
+    virtual HRESULT GetThreadAllocInfo(VMPTR_Thread vmThread, DacThreadAllocInfo* threadAllocInfo) = 0;
 
     //
     // Set and reset the TSNC_DebuggerUserSuspend bit on the state of the specified thread
@@ -1058,9 +1003,7 @@ public:
     //    debugState - the desired CorDebugThreadState
     //
 
-    virtual
-    void SetDebugState(VMPTR_Thread        vmThread,
-                       CorDebugThreadState debugState) = 0;
+    virtual HRESULT SetDebugState(VMPTR_Thread vmThread, CorDebugThreadState debugState) = 0;
 
     //
     // Returns TRUE if this thread has an unhandled exception
@@ -1071,8 +1014,7 @@ public:
     // Return Value
     //    TRUE iff this thread has an unhandled exception
     //
-    virtual
-     BOOL HasUnhandledException(VMPTR_Thread vmThread) = 0;
+    virtual HRESULT HasUnhandledException(VMPTR_Thread vmThread, OUT BOOL * pResult) = 0;
 
     //
     // Return the user state of the specified thread.  Most of the state are derived from
@@ -1086,8 +1028,7 @@ public:
     //    the user state of the specified thread
     //
 
-    virtual
-    CorDebugUserState GetUserState(VMPTR_Thread vmThread) = 0;
+    virtual HRESULT GetUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal) = 0;
 
 
     //
@@ -1105,8 +1046,7 @@ public:
     // Return Value:
     //    the user state of the specified thread
     //
-    virtual
-    CorDebugUserState GetPartialUserState(VMPTR_Thread vmThread) = 0;
+    virtual HRESULT GetPartialUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal) = 0;
 
 
     //
@@ -1119,8 +1059,7 @@ public:
     //    the connection ID of the specified thread
     //
 
-    virtual
-    CONNID GetConnectionID(VMPTR_Thread vmThread) = 0;
+    virtual HRESULT GetConnectionID(VMPTR_Thread vmThread, OUT CONNID * pRetVal) = 0;
 
     //
     // Return the task ID of the specified thread.
@@ -1132,8 +1071,7 @@ public:
     //    the task ID of the specified thread
     //
 
-    virtual
-    TASKID GetTaskID(VMPTR_Thread vmThread) = 0;
+    virtual HRESULT GetTaskID(VMPTR_Thread vmThread, OUT TASKID * pRetVal) = 0;
 
     //
     // Return the OS thread ID of the specified thread
@@ -1145,8 +1083,7 @@ public:
     //    the OS thread ID of the specified thread. Returns 0 if not scheduled.
     //
 
-    virtual
-    DWORD TryGetVolatileOSThreadID(VMPTR_Thread vmThread) = 0;
+    virtual HRESULT TryGetVolatileOSThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal) = 0;
 
     //
     // Return the unique thread ID of the specified thread. The value used for the thread ID changes
@@ -1163,8 +1100,7 @@ public:
     //    Returns a stable and unique thread ID for the lifetime of the specified managed thread.
     //
 
-    virtual
-    DWORD GetUniqueThreadID(VMPTR_Thread vmThread) = 0;
+    virtual HRESULT GetUniqueThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal) = 0;
 
     //
     // Return the object handle to the managed Exception object of the current exception
@@ -1179,8 +1115,7 @@ public:
     //    is an unmanaged thread which has entered and exited the runtime.
     //
 
-    virtual
-    VMPTR_OBJECTHANDLE GetCurrentException(VMPTR_Thread vmThread) = 0;
+    virtual HRESULT GetCurrentException(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
     //
     // Return the object handle to the managed object for a given CCW pointer.
@@ -1192,8 +1127,7 @@ public:
     //    This function returns the object handle to the managed object for a given CCW pointer.
     //
 
-    virtual
-    VMPTR_OBJECTHANDLE GetObjectForCCW(CORDB_ADDRESS ccwPtr) = 0;
+    virtual HRESULT GetObjectForCCW(CORDB_ADDRESS ccwPtr, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
     //
     // Return the object handle to the managed CustomNotification object of the current notification
@@ -1207,8 +1141,7 @@ public:
     //    The return value may be NULL if there is no current notification.
     //
 
-    virtual
-    VMPTR_OBJECTHANDLE GetCurrentCustomDebuggerNotification(VMPTR_Thread vmThread) = 0;
+    virtual HRESULT GetCurrentCustomDebuggerNotification(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
 
     //
@@ -1221,8 +1154,7 @@ public:
     //    This function throws if the current appdomain is NULL for whatever reason.
     //
 
-    virtual
-    VMPTR_AppDomain GetCurrentAppDomain() = 0;
+    virtual HRESULT GetCurrentAppDomain(OUT VMPTR_AppDomain * pRetVal) = 0;
 
 
     //
@@ -1245,8 +1177,7 @@ public:
     //
     //    The debugger can't duplicate this policy with 100% accuracy, and
     //    so we need DAC to lookup the assembly that was actually loaded.
-    virtual
-    VMPTR_DomainAssembly ResolveAssembly(VMPTR_DomainAssembly vmScope, mdToken tkAssemblyRef) = 0;
+    virtual HRESULT ResolveAssembly(VMPTR_DomainAssembly vmScope, mdToken tkAssemblyRef, OUT VMPTR_DomainAssembly * pRetVal) = 0;
 
     //-----------------------------------------------------------------------------
     // Interface for initializing the native/IL sequence points and native var info
@@ -1268,12 +1199,7 @@ public:
     // Notes:
     //-----------------------------------------------------------------------------
 
-    virtual
-    void GetNativeCodeSequencePointsAndVarInfo(VMPTR_MethodDesc  vmMethodDesc,
-                                               CORDB_ADDRESS     startAddress,
-                                               BOOL              fCodeAvailable,
-                                               OUT NativeVarData *   pNativeVarData,
-                                               OUT SequencePoints *  pSequencePoints) = 0;
+    virtual HRESULT GetNativeCodeSequencePointsAndVarInfo(VMPTR_MethodDesc vmMethodDesc, CORDB_ADDRESS startAddress, BOOL fCodeAvailable, OUT NativeVarData * pNativeVarData, OUT SequencePoints * pSequencePoints) = 0;
 
     //
     // Return the filter CONTEXT on the LS.  Once we move entirely over to the new managed pipeline
@@ -1290,8 +1216,7 @@ public:
     //    we don't have a filter CONTEXT on the LS anymore.
     //
 
-    virtual
-    VMPTR_CONTEXT GetManagedStoppedContext(VMPTR_Thread vmThread) = 0;
+    virtual HRESULT GetManagedStoppedContext(VMPTR_Thread vmThread, OUT VMPTR_CONTEXT * pRetVal) = 0;
 
     typedef enum
     {
@@ -1323,14 +1248,10 @@ public:
     //    This is a special case that violates the 'no state' tenant.
     //
 
-    virtual
-    void CreateStackWalk(VMPTR_Thread           vmThread,
-                         DT_CONTEXT *           pInternalContextBuffer,
-                         OUT StackWalkHandle *  ppSFIHandle) = 0;
+    virtual HRESULT CreateStackWalk(VMPTR_Thread vmThread, DT_CONTEXT * pInternalContextBuffer, OUT StackWalkHandle * ppSFIHandle) = 0;
 
     // Delete the stackwalk object created from CreateStackWalk.
-    virtual
-    void DeleteStackWalk(StackWalkHandle ppSFIHandle) = 0;
+    virtual HRESULT DeleteStackWalk(StackWalkHandle ppSFIHandle) = 0;
 
     //
     // Get the CONTEXT of the current frame where the stackwalker is stopped at.
@@ -1340,9 +1261,7 @@ public:
     //    pContext   - OUT: the CONTEXT to be filled out. The context control flags are ignored.
     //
 
-    virtual
-    void GetStackWalkCurrentContext(StackWalkHandle pSFIHandle,
-                                    DT_CONTEXT *    pContext) = 0;
+    virtual HRESULT GetStackWalkCurrentContext(StackWalkHandle pSFIHandle, DT_CONTEXT * pContext) = 0;
 
     //
     // Set the stackwalker to the given CONTEXT.  The CorDebugSetContextFlag indicates whether
@@ -1356,11 +1275,7 @@ public:
     //    pContext   - the specified CONTEXT. This may make correctional adjustments to the context's IP.
     //
 
-    virtual
-    void SetStackWalkCurrentContext(VMPTR_Thread           vmThread,
-                                    StackWalkHandle        pSFIHandle,
-                                    CorDebugSetContextFlag flag,
-                                    DT_CONTEXT *           pContext) = 0;
+    virtual HRESULT SetStackWalkCurrentContext(VMPTR_Thread vmThread, StackWalkHandle pSFIHandle, CorDebugSetContextFlag flag, DT_CONTEXT * pContext) = 0;
 
     //
     // Unwind the stackwalker to the next frame.  The next frame could be any actual stack frame,
@@ -1376,8 +1291,7 @@ public:
     //    Throw on error.
     //
 
-    virtual
-    BOOL UnwindStackWalkFrame(StackWalkHandle pSFIHandle) = 0;
+    virtual HRESULT UnwindStackWalkFrame(StackWalkHandle pSFIHandle, OUT BOOL * pResult) = 0;
 
     //
     // Check whether the specified CONTEXT is valid.  The only check we perform right now is whether the
@@ -1411,9 +1325,7 @@ public:
     //    Return the type of the current frame
     //
 
-    virtual
-    FrameType GetStackWalkCurrentFrameInfo(StackWalkHandle                 pSFIHandle,
-                                           OPTIONAL DebuggerIPCE_STRData * pFrameData) = 0;
+    virtual HRESULT GetStackWalkCurrentFrameInfo(StackWalkHandle pSFIHandle, OPTIONAL DebuggerIPCE_STRData * pFrameData, OUT FrameType * pRetVal) = 0;
 
     //
     // Return the number of internal frames on the specified thread.
@@ -1435,8 +1347,7 @@ public:
     //    out how many interesting internal frames there are.
     //
 
-    virtual
-    ULONG32 GetCountOfInternalFrames(VMPTR_Thread vmThread) = 0;
+    virtual HRESULT GetCountOfInternalFrames(VMPTR_Thread vmThread, OUT ULONG32 * pRetVal) = 0;
 
     //
     // Enumerate the internal frames on the specified thread and invoke the provided callback on each of
@@ -1454,10 +1365,7 @@ public:
 
     typedef void (*FP_INTERNAL_FRAME_ENUMERATION_CALLBACK)(const DebuggerIPCE_STRData * pFrameData, CALLBACK_DATA pUserData);
 
-    virtual
-    void EnumerateInternalFrames(VMPTR_Thread                            vmThread,
-                                 FP_INTERNAL_FRAME_ENUMERATION_CALLBACK  fpCallback,
-                                 CALLBACK_DATA                           pUserData) = 0;
+    virtual HRESULT EnumerateInternalFrames(VMPTR_Thread vmThread, FP_INTERNAL_FRAME_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
 
     //
     // Given the FramePointer of the parent frame and the FramePointer of the current frame,
@@ -1476,8 +1384,7 @@ public:
     //    ask the ExInfo to do it.
     //
 
-    virtual
-    BOOL IsMatchingParentFrame(FramePointer fpToCheck, FramePointer fpParent) = 0;
+    virtual HRESULT IsMatchingParentFrame(FramePointer fpToCheck, FramePointer fpParent, OUT BOOL * pResult) = 0;
 
     //
     // Return the stack parameter size of a given method.  This is necessary on x86 for unwinding.
@@ -1493,8 +1400,7 @@ public:
     //    The callee stack parameter size is constant throughout a method.
     //
 
-    virtual
-    ULONG32 GetStackParameterSize(CORDB_ADDRESS controlPC) = 0;
+    virtual HRESULT GetStackParameterSize(CORDB_ADDRESS controlPC, OUT ULONG32 * pRetVal) = 0;
 
     //
     // Return the FramePointer of the current frame where the stackwalker is stopped at.
@@ -1518,8 +1424,7 @@ public:
     //    The FramePointer of an explicit frame is just the stack address of the explicit frame.
     //
 
-    virtual
-    FramePointer GetFramePointer(StackWalkHandle pSFIHandle) = 0;
+    virtual HRESULT GetFramePointer(StackWalkHandle pSFIHandle, OUT FramePointer * pRetVal) = 0;
 
     //
     // Check whether the specified CONTEXT is the CONTEXT of the leaf frame.  This function doesn't care
@@ -1537,9 +1442,7 @@ public:
     //    This will be deprecated in V3.
     //
 
-    virtual
-    BOOL IsLeafFrame(VMPTR_Thread       vmThread,
-                     const DT_CONTEXT * pContext) = 0;
+    virtual HRESULT IsLeafFrame(VMPTR_Thread vmThread, const DT_CONTEXT * pContext, OUT BOOL * pResult) = 0;
 
     // Get the context for a particular thread of the target process.
     // Arguments:
@@ -1547,8 +1450,7 @@ public:
     //     output: pContextBuffer - the address of the CONTEXT to be initialized.
     //                              The memory for this belongs to the caller. It must not be NULL.
     // Note: throws
-    virtual
-    void GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContextBuffer) = 0;
+    virtual HRESULT GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContextBuffer) = 0;
 
     //
     // This is a simple helper function to convert a CONTEXT to a DebuggerREGDISPLAY.  We need to do this
@@ -1563,10 +1465,7 @@ public:
     //                 unwinding.
     //
 
-    virtual
-    void ConvertContextToDebuggerRegDisplay(const DT_CONTEXT * pInContext,
-                                            DebuggerREGDISPLAY * pOutDRD,
-                                            BOOL fActive) = 0;
+    virtual HRESULT ConvertContextToDebuggerRegDisplay(const DT_CONTEXT * pInContext, DebuggerREGDISPLAY * pOutDRD, BOOL fActive) = 0;
 
     typedef enum
     {
@@ -1588,8 +1487,7 @@ public:
     //    Return kLCGMethod if the method is an LCG method.
     //
 
-    virtual
-    DynamicMethodType IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc) = 0;
+    virtual HRESULT IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc, OUT DynamicMethodType * pRetVal) = 0;
 
     //
     // Return a TargetBuffer for the raw vararg signature.
@@ -1618,9 +1516,7 @@ public:
     //    in mscordbi.dll.
     //
 
-    virtual
-    TargetBuffer GetVarArgSig(CORDB_ADDRESS   VASigCookieAddr,
-                              OUT CORDB_ADDRESS * pArgBase) = 0;
+    virtual HRESULT GetVarArgSig(CORDB_ADDRESS VASigCookieAddr, OUT CORDB_ADDRESS * pArgBase, OUT TargetBuffer * pRetVal) = 0;
 
     //
     // Indicates if the specified type requires 8-byte alignment.
@@ -1632,8 +1528,7 @@ public:
     //    TRUE if the type requires 8-byte alignment.
     //
 
-    virtual
-    BOOL RequiresAlign8(VMPTR_TypeHandle thExact) = 0;
+    virtual HRESULT RequiresAlign8(VMPTR_TypeHandle thExact, OUT BOOL * pResult) = 0;
 
     //
     // Resolve the raw generics token to the real generics type token.  The resolution is based on the
@@ -1662,9 +1557,7 @@ public:
     //    However, we don't want the RS to know all this logic.
     //
 
-    virtual
-    GENERICS_TYPE_TOKEN ResolveExactGenericArgsToken(DWORD               dwExactGenericArgsTokenIndex,
-                                                     GENERICS_TYPE_TOKEN rawToken) = 0;
+    virtual HRESULT ResolveExactGenericArgsToken(DWORD dwExactGenericArgsTokenIndex, GENERICS_TYPE_TOKEN rawToken, OUT GENERICS_TYPE_TOKEN * pRetVal) = 0;
 
     //-----------------------------------------------------------------------------
     // Functions to get information about code objects
@@ -1681,11 +1574,7 @@ public:
     //    Output (required):
     //    codeInfo       - start address and size of the IL
     //    pLocalSigToken - signature token for the method
-    virtual
-    void GetILCodeAndSig(VMPTR_DomainAssembly vmDomainAssembly,
-                         mdToken          functionToken,
-                         OUT TargetBuffer *   pCodeInfo,
-                         OUT mdToken *        pLocalSigToken) = 0;
+    virtual HRESULT GetILCodeAndSig(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT TargetBuffer * pCodeInfo, OUT mdToken * pLocalSigToken) = 0;
 
     // Gets information about a native code blob:
     //    it's method desc, whether it's an instantiated generic, its EnC version number
@@ -1701,10 +1590,7 @@ public:
     //        is unavailable for any reason, the output parameter will also be
     //        invalid (i.e., pCodeInfo->IsValid is false).
 
-    virtual
-    void GetNativeCodeInfo(VMPTR_DomainAssembly         vmDomainAssembly,
-                           mdToken                  functionToken,
-                           OUT NativeCodeFunctionData * pCodeInfo) = 0;
+    virtual HRESULT GetNativeCodeInfo(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT NativeCodeFunctionData * pCodeInfo) = 0;
 
     // Gets information about a native code blob:
     //    it's method desc, whether it's an instantiated generic, its EnC version number
@@ -1722,11 +1608,7 @@ public:
     //        pVmModule     - module containing metadata for the method
     //        pFunctionToken - metadata token for the function
 
-    virtual
-    void GetNativeCodeInfoForAddr(CORDB_ADDRESS codeAddress,
-                                  NativeCodeFunctionData * pCodeInfo,
-                                  VMPTR_Module *           pVmModule,
-                                  mdToken * pFunctionToken) = 0;
+    virtual HRESULT GetNativeCodeInfoForAddr(CORDB_ADDRESS codeAddress, NativeCodeFunctionData * pCodeInfo, VMPTR_Module * pVmModule, mdToken * pFunctionToken) = 0;
 
     //-----------------------------------------------------------------------------
     // Functions to get information about types
@@ -1740,8 +1622,7 @@ public:
     // Return:
     //        TRUE iff the type is a ValueType
 
-    virtual
-    BOOL IsValueType (VMPTR_TypeHandle th) = 0;
+    virtual HRESULT IsValueType(VMPTR_TypeHandle th, OUT BOOL * pResult) = 0;
 
     // Determine if a type has generic parameters
     //
@@ -1751,8 +1632,7 @@ public:
     // Return:
     //        TRUE iff the type has generic parameters
 
-    virtual
-    BOOL HasTypeParams (VMPTR_TypeHandle th) = 0;
+    virtual HRESULT HasTypeParams(VMPTR_TypeHandle th, OUT BOOL * pResult) = 0;
 
     // Get type information for a class
     //
@@ -1763,10 +1643,7 @@ public:
     //             pData         - structure containing information about the class and its
     //                             fields
 
-    virtual
-    void GetClassInfo (VMPTR_AppDomain  vmAppDomain,
-                       VMPTR_TypeHandle thExact,
-                       ClassInfo *      pData) = 0;
+    virtual HRESULT GetClassInfo(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle thExact, ClassInfo * pData) = 0;
 
     // get field information and object size for an instantiated generic
     //
@@ -1779,12 +1656,7 @@ public:
     //                             contents. Allocated and initialized by this function.
     //             pObjectSize   - size of the instantiated object
     //
-    virtual
-    void GetInstantiationFieldInfo (VMPTR_DomainAssembly             vmDomainAssembly,
-                                    VMPTR_TypeHandle             vmThExact,
-                                    VMPTR_TypeHandle             vmThApprox,
-                                    OUT DacDbiArrayList<FieldData> * pFieldList,
-                                    OUT SIZE_T *                     pObjectSize) = 0;
+    virtual HRESULT GetInstantiationFieldInfo(VMPTR_DomainAssembly vmDomainAssembly, VMPTR_TypeHandle vmThExact, VMPTR_TypeHandle vmThApprox, OUT DacDbiArrayList<FieldData> * pFieldList, OUT SIZE_T * pObjectSize) = 0;
 
     // use a type handle to get the information needed to create the corresponding RS CordbType instance
     //
@@ -1795,24 +1667,12 @@ public:
     //             vmTypeHandle - type handle for the type
     //     output: pTypeInfo    - holds information needed to build the corresponding CordbType
     //
-    virtual
-    void TypeHandleToExpandedTypeInfo(AreValueTypesBoxed                       boxed,
-                                      VMPTR_AppDomain                          vmAppDomain,
-                                      VMPTR_TypeHandle                         vmTypeHandle,
-                                      DebuggerIPCE_ExpandedTypeData *          pTypeInfo) = 0;
+    virtual HRESULT TypeHandleToExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, DebuggerIPCE_ExpandedTypeData * pTypeInfo) = 0;
 
-    virtual
-    void GetObjectExpandedTypeInfo(AreValueTypesBoxed                   boxed,
-                                   VMPTR_AppDomain                      vmAppDomain,
-                                   CORDB_ADDRESS                        addr,
-                                   OUT DebuggerIPCE_ExpandedTypeData *  pTypeInfo) = 0;
+    virtual HRESULT GetObjectExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, CORDB_ADDRESS addr, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo) = 0;
 
 
-    virtual
-    void GetObjectExpandedTypeInfoFromID(AreValueTypesBoxed                   boxed,
-                                         VMPTR_AppDomain                      vmAppDomain,
-                                         COR_TYPEID                           id,
-                                         OUT DebuggerIPCE_ExpandedTypeData *  pTypeInfo) = 0;
+    virtual HRESULT GetObjectExpandedTypeInfoFromID(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, COR_TYPEID id, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo) = 0;
 
 
     // Get type handle for a TypeDef token, if one exists. For generics this returns the open type.
@@ -1826,9 +1686,7 @@ public:
     //
     // Return value: the type handle if it exists or throws CORDBG_E_CLASS_NOT_LOADED if it isn't loaded
     //
-    virtual
-    VMPTR_TypeHandle GetTypeHandle(VMPTR_Module vmModule,
-                                   mdTypeDef metadataToken) = 0;
+    virtual HRESULT GetTypeHandle(VMPTR_Module vmModule, mdTypeDef metadataToken, OUT VMPTR_TypeHandle * pRetVal) = 0;
 
     // Get the approximate type handle for an instantiated type. This may be identical to the exact type handle,
     // but if we have code sharing for generics, it may differ in that it may have canonical type parameters.
@@ -1840,8 +1698,7 @@ public:
     //                         and the number of entries in the list. Allocated and initialized by the caller.
     // Return value: the approximate type handle
     //
-    virtual
-    VMPTR_TypeHandle GetApproxTypeHandle(TypeInfoList * pTypeData) = 0;
+    virtual HRESULT GetApproxTypeHandle(TypeInfoList * pTypeData, OUT VMPTR_TypeHandle * pRetVal) = 0;
 
     // Get the exact type handle from type data.
     // Arguments:
@@ -1881,12 +1738,7 @@ public:
     //    The caller is responsible for releasing it.
     //
 
-    virtual
-    void GetMethodDescParams(VMPTR_AppDomain     vmAppDomain,
-                             VMPTR_MethodDesc    vmMethodDesc,
-                             GENERICS_TYPE_TOKEN genericsToken,
-                             OUT UINT32 *            pcGenericClassTypeParams,
-                             OUT TypeParamsList *    pGenericTypeParams) = 0;
+    virtual HRESULT GetMethodDescParams(VMPTR_AppDomain vmAppDomain, VMPTR_MethodDesc vmMethodDesc, GENERICS_TYPE_TOKEN genericsToken, OUT UINT32 * pcGenericClassTypeParams, OUT TypeParamsList * pGenericTypeParams) = 0;
 
     // Get the target field address of a thread local static.
     // Arguments:
@@ -1901,9 +1753,7 @@ public:
     //  This is an inspection only method and can not allocate the static storage.
     //  Field storage is constant once allocated, so this value can be cached.
 
-    virtual
-    CORDB_ADDRESS GetThreadStaticAddress(VMPTR_FieldDesc vmField,
-                                         VMPTR_Thread    vmRuntimeThread) = 0;
+    virtual HRESULT GetThreadStaticAddress(VMPTR_FieldDesc vmField, VMPTR_Thread vmRuntimeThread, OUT CORDB_ADDRESS * pRetVal) = 0;
 
     // Get the target field address of a collectible types static.
     // Arguments:
@@ -1919,9 +1769,7 @@ public:
     //  Field storage is not constant once allocated so this value can not be cached
     //  across a Continue
 
-    virtual
-    CORDB_ADDRESS GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmField,
-                                                  VMPTR_AppDomain vmAppDomain) = 0;
+    virtual HRESULT GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmField, VMPTR_AppDomain vmAppDomain, OUT CORDB_ADDRESS * pRetVal) = 0;
 
     // Get information about a field added with Edit And Continue.
     // Arguments:
@@ -1934,10 +1782,7 @@ public:
     //                              an indication of the type: whether it's a class or value type
     //     output:  pFieldData    - information about the EnC added field
     //              pfStatic      - flag to indicate whether the field is static
-    virtual
-    void GetEnCHangingFieldInfo(const EnCHangingFieldInfo * pEnCFieldInfo,
-                                OUT FieldData *           pFieldData,
-                                OUT BOOL *                pfStatic) = 0;
+    virtual HRESULT GetEnCHangingFieldInfo(const EnCHangingFieldInfo * pEnCFieldInfo, OUT FieldData * pFieldData, OUT BOOL * pfStatic) = 0;
 
 
     // GetTypeHandleParams gets the necessary data for a type handle, i.e. its
@@ -1954,10 +1799,7 @@ public:
     //                           heap in this function.
     // This will not fail except for OOM
 
-    virtual
-    void GetTypeHandleParams(VMPTR_AppDomain  vmAppDomain,
-                             VMPTR_TypeHandle vmTypeHandle,
-                             OUT TypeParamsList * pParams) = 0;
+    virtual HRESULT GetTypeHandleParams(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, OUT TypeParamsList * pParams) = 0;
 
     // GetSimpleType
     // gets the metadata token and domain file corresponding to a simple type
@@ -1973,60 +1815,35 @@ public:
     //    If the type has been loaded, vmDomainAssembly will be non-null unless the target is somehow corrupted.
     //    In that case, we will throw CORDBG_E_TARGET_INCONSISTENT.
 
-    virtual
-    void GetSimpleType(VMPTR_AppDomain    vmAppDomain,
-                       CorElementType     simpleType,
-                       OUT mdTypeDef *        pMetadataToken,
-                       OUT VMPTR_Module     * pVmModule,
-                       OUT VMPTR_DomainAssembly * pVmDomainAssembly) = 0;
+    virtual HRESULT GetSimpleType(VMPTR_AppDomain vmAppDomain, CorElementType simpleType, OUT mdTypeDef * pMetadataToken, OUT VMPTR_Module * pVmModule, OUT VMPTR_DomainAssembly * pVmDomainAssembly) = 0;
 
     // for the specified object returns TRUE if the object derives from System.Exception
-    virtual
-    BOOL IsExceptionObject(VMPTR_Object vmObject) = 0;
+    virtual HRESULT IsExceptionObject(VMPTR_Object vmObject, OUT BOOL * pResult) = 0;
 
     // gets the list of raw stack frames for the specified exception object
-    virtual
-    void GetStackFramesFromException(VMPTR_Object vmObject, DacDbiArrayList<DacExceptionCallStackData>& dacStackFrames) = 0;
+    virtual HRESULT GetStackFramesFromException(VMPTR_Object vmObject, DacDbiArrayList<DacExceptionCallStackData>& dacStackFrames) = 0;
 
     // Returns true if the argument is a runtime callable wrapper
-    virtual
-    BOOL IsRcw(VMPTR_Object vmObject) = 0;
+    virtual HRESULT IsRcw(VMPTR_Object vmObject, OUT BOOL * pResult) = 0;
 
     // retrieves the list of COM interfaces implemented by vmObject, as it is known at
     // the time of the call (the list may change as new interface types become available
     // in the runtime)
-    virtual
-    void GetRcwCachedInterfaceTypes(
-                        VMPTR_Object vmObject,
-                        VMPTR_AppDomain vmAppDomain,
-                        BOOL bIInspectableOnly,
-                        OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pDacInterfaces) = 0;
+    virtual HRESULT GetRcwCachedInterfaceTypes(VMPTR_Object vmObject, VMPTR_AppDomain vmAppDomain, BOOL bIInspectableOnly, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pDacInterfaces) = 0;
 
     // retrieves the list of interfaces pointers implemented by vmObject, as it is known at
     // the time of the call (the list may change as new interface types become available
     // in the runtime)
-    virtual
-    void GetRcwCachedInterfacePointers(
-                        VMPTR_Object vmObject,
-                        BOOL bIInspectableOnly,
-                        OUT DacDbiArrayList<CORDB_ADDRESS> * pDacItfPtrs) = 0;
+    virtual HRESULT GetRcwCachedInterfacePointers(VMPTR_Object vmObject, BOOL bIInspectableOnly, OUT DacDbiArrayList<CORDB_ADDRESS> * pDacItfPtrs) = 0;
 
     // retrieves a list of interface types corresponding to the passed in
     // list of IIDs. the interface types are retrieved from an app domain
     // IID / Type cache, that is updated as new types are loaded. will
     // have NULL entries corresponding to unknown IIDs in "iids"
-    virtual
-    void GetCachedWinRTTypesForIIDs(
-                        VMPTR_AppDomain vmAppDomain,
-    					DacDbiArrayList<GUID> & iids,
-	    				OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes) = 0;
+    virtual HRESULT GetCachedWinRTTypesForIIDs(VMPTR_AppDomain vmAppDomain, DacDbiArrayList<GUID> & iids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes) = 0;
 
     // retrieves the whole app domain cache of IID / Type mappings.
-    virtual
-    void GetCachedWinRTTypes(
-                        VMPTR_AppDomain vmAppDomain,
-                        OUT DacDbiArrayList<GUID> * piids,
-                        OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes) = 0;
+    virtual HRESULT GetCachedWinRTTypes(VMPTR_AppDomain vmAppDomain, OUT DacDbiArrayList<GUID> * piids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes) = 0;
 
 
     // ----------------------------------------------------------------------------
@@ -2040,10 +1857,7 @@ public:
     //             vmAppDomain - AppDomain for the type of the object referenced
     //     output: pObjectData - information about the object referenced by pTypedByRef
     // Note: Throws
-    virtual
-    void GetTypedByRefInfo(CORDB_ADDRESS             pTypedByRef,
-                           VMPTR_AppDomain           vmAppDomain,
-                           DebuggerIPCE_ObjectData * pObjectData) = 0;
+    virtual HRESULT GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData) = 0;
 
     // Get the string length and offset to string base for a string object
     // Arguments:
@@ -2051,8 +1865,7 @@ public:
     //     output: pObjectData - fills in the string fields stringInfo.offsetToStringBase and
     //             stringInfo.length
     // Note: throws
-    virtual
-    void GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData) = 0;
+    virtual HRESULT GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData) = 0;
 
     // Get information for an array type referent of an objRef, including rank, upper and lower bounds,
     // element size and type, and the number of elements.
@@ -2066,8 +1879,7 @@ public:
     //                             arrayInfo.rank,
     //                             arrayInfo.elementSize,
     // Note: throws
-    virtual
-    void GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData) = 0;
+    virtual HRESULT GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData) = 0;
 
     // Get information about an object for which we have a reference, including the object size and
     // type information.
@@ -2078,11 +1890,7 @@ public:
     //             vmAppDomain   - the appdomain to which the object belong
     //     output: pObjectData   - fills in the size and type information fields
     // Note: throws
-    virtual
-    void GetBasicObjectInfo(CORDB_ADDRESS             objectAddress,
-                            CorElementType            type,
-                            VMPTR_AppDomain           vmAppDomain,
-                            DebuggerIPCE_ObjectData * pObjectData) = 0;
+    virtual HRESULT GetBasicObjectInfo(CORDB_ADDRESS objectAddress, CorElementType type, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData) = 0;
 
     // --------------------------------------------------------------------------------------------
 #ifdef TEST_DATA_CONSISTENCY
@@ -2097,8 +1905,7 @@ public:
     // Notes:
     //     Throws
     //     For this code to run, the environment variable TestDataConsistency must be set to 1.
-    virtual
-    void TestCrst(VMPTR_Crst vmCrst) = 0;
+    virtual HRESULT TestCrst(VMPTR_Crst vmCrst) = 0;
 
     // Determine whether a crst is held by the left side. When the DAC is executing VM code that takes a
     // lock, we want to know whether the LS already holds that lock. If it does, we will assume the locked
@@ -2112,8 +1919,7 @@ public:
     //     Throws
     //     For this code to run, the environment variable TestDataConsistency must be set to 1.
 
-    virtual
-    void TestRWLock(VMPTR_SimpleRWLock vmRWLock) = 0;
+    virtual HRESULT TestRWLock(VMPTR_SimpleRWLock vmRWLock) = 0;
 #endif
     // --------------------------------------------------------------------------------------------
     // Get the address of the Debugger control block on the helper thread. The debugger control block
@@ -2122,8 +1928,7 @@ public:
     // Arguments: none
     // Return Value: The remote address of the Debugger control block allocated on the helper thread
     //               if it has been successfully allocated or NULL otherwise.
-    virtual
-    CORDB_ADDRESS GetDebuggerControlBlockAddress() = 0;
+    virtual HRESULT GetDebuggerControlBlockAddress(OUT CORDB_ADDRESS * pRetVal) = 0;
 
     // Creates a VMPTR of an Object. The Object is found by dereferencing ptr
     // as though it is a target address to an OBJECTREF. This is similar to
@@ -2140,8 +1945,7 @@ public:
     //    This function will throw if given a NULL or otherwise invalid pointer,
     //    but if given a valid address to an invalid pointer, it will produce
     //    a VMPTR_Object which points to invalid memory.
-    virtual
-    VMPTR_Object GetObjectFromRefPtr(CORDB_ADDRESS ptr) = 0;
+    virtual HRESULT GetObjectFromRefPtr(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal) = 0;
 
     // Creates a VMPTR of an Object. The Object is assumed to be at the target
     // address supplied by ptr
@@ -2156,8 +1960,7 @@ public:
     //    The VMPTR this produces can be deconstructed by GetObjectContents.
     //    This will produce a VMPTR_Object regardless of whether the pointer is
     //    valid or not.
-    virtual
-    VMPTR_Object GetObject(CORDB_ADDRESS ptr) = 0;
+    virtual HRESULT GetObject(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal) = 0;
 
     // Sets state in the native binder.
     //
@@ -2221,8 +2024,7 @@ public:
     //     This will produce a VMPTR_OBJECTHANDLE regardless of whether handle is
     //     valid.
     //     Ideally we'd be using only strongly-typed variables on the RS, and then this would be unnecessary
-    virtual
-    VMPTR_OBJECTHANDLE GetVmObjectHandle(CORDB_ADDRESS handleAddress) = 0;
+    virtual HRESULT GetVmObjectHandle(CORDB_ADDRESS handleAddress, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
     // Validate that the VMPTR_OBJECTHANDLE refers to a legitimate managed object
     //
@@ -2232,8 +2034,7 @@ public:
     // Return value:
     //     TRUE if the object appears to be valid (its a heuristic), FALSE if it definately is not valid
     //
-    virtual
-    BOOL IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle) = 0;
+    virtual HRESULT IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle, OUT BOOL * pResult) = 0;
 
     // indicates if the specified module is a WinRT module
     //
@@ -2256,8 +2057,7 @@ public:
     //     The app domain id of the object of interest
     //
     // This may throw if the object handle is corrupt (it doesn't refer to a managed object)
-    virtual
-    ULONG GetAppDomainIdFromVmObjectHandle(VMPTR_OBJECTHANDLE vmHandle) = 0;
+    virtual HRESULT GetAppDomainIdFromVmObjectHandle(VMPTR_OBJECTHANDLE vmHandle, OUT ULONG * pRetVal) = 0;
 
 
     // Get the target address from a VMPTR_OBJECTHANDLE, i.e., the handle address
@@ -2265,8 +2065,7 @@ public:
     //     vmHandle - (input) the VMPTR_OBJECTHANDLE from which we need the target address
     // Return value: the target address from the VMPTR_OBJECTHANDLE
     //
-    virtual
-    CORDB_ADDRESS GetHandleAddressFromVmHandle(VMPTR_OBJECTHANDLE vmHandle) = 0;
+    virtual HRESULT GetHandleAddressFromVmHandle(VMPTR_OBJECTHANDLE vmHandle, OUT CORDB_ADDRESS * pRetVal) = 0;
 
     // Given a VMPTR to an Object return the target address
     //
@@ -2281,8 +2080,7 @@ public:
     //    providing the address stored in the returned TargetBuffer. This has
     //    undefined behavior for invalid VMPTR_Objects.
 
-    virtual
-    TargetBuffer GetObjectContents(VMPTR_Object obj) = 0;
+    virtual HRESULT GetObjectContents(VMPTR_Object obj, OUT TargetBuffer * pRetVal) = 0;
 
     //
     // Returns the thread which owns the monitor lock on an object and the acquisition
@@ -2298,8 +2096,7 @@ public:
     //    pAcquisitionCount - the number of times the lock would need to be released in
     //                        order for it to be unowned
     //
-    virtual
-    MonitorLockInfo GetThreadOwningMonitorLock(VMPTR_Object vmObject) = 0;
+    virtual HRESULT GetThreadOwningMonitorLock(VMPTR_Object vmObject, OUT MonitorLockInfo * pRetVal) = 0;
 
     //
     // Enumerate all threads waiting on the monitor event for an object
@@ -2313,10 +2110,7 @@ public:
     //    Returns on success. Throws on error.
     //
     //
-    virtual
-    void EnumerateMonitorEventWaitList(VMPTR_Object                   vmObject,
-                                       FP_THREAD_ENUMERATION_CALLBACK fpCallback,
-                                       CALLBACK_DATA                  pUserData) = 0;
+    virtual HRESULT EnumerateMonitorEventWaitList(VMPTR_Object vmObject, FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
 
     //
     // Returns the managed debugging flags for the process (a combination
@@ -2325,17 +2119,11 @@ public:
     // event (if one exists) is caused by a Debugger.Launch(). This is
     // important b/c Debugger.Launch calls should *NOT* cause the debugger
     // to terminate the process when the attach is canceled.
-    virtual
-    CLR_DEBUGGING_PROCESS_FLAGS GetAttachStateFlags() = 0;
+    virtual HRESULT GetAttachStateFlags(OUT CLR_DEBUGGING_PROCESS_FLAGS * pRetVal) = 0;
 
-    virtual
-    bool GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly,
-                                       DWORD & dwTimeStamp,
-                                       DWORD & dwImageSize,
-                                       IStringHolder* pStrFilename) = 0;
+    virtual HRESULT GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly, DWORD & dwTimeStamp, DWORD & dwImageSize, IStringHolder* pStrFilename, OUT bool * pResult) = 0;
 
-    virtual
-    bool IsThreadSuspendedOrHijacked(VMPTR_Thread vmThread) = 0;
+        virtual HRESULT IsThreadSuspendedOrHijacked(VMPTR_Thread vmThread, OUT bool * pResult) = 0;
 
 
     typedef void* * HeapWalkHandle;
@@ -2343,8 +2131,7 @@ public:
     // Returns true if it is safe to walk the heap.  If this function returns false,
     // you could still create a heap walk and attempt to walk it, but there's no
     // telling how much of the heap will be available.
-    virtual
-    bool AreGCStructuresValid() = 0;
+    virtual HRESULT AreGCStructuresValid(OUT bool * pResult) = 0;
 
     // Creates a HeapWalkHandle which can be used to walk the managed heap with the
     // WalkHeap function.  Note if this function completes successfully you will need
@@ -2361,8 +2148,7 @@ public:
 
     // Deletes the give HeapWalkHandle.  Note you must call this function if
     // CreateHeapWalk returns success.
-    virtual
-    void DeleteHeapWalk(HeapWalkHandle handle) = 0;
+    virtual HRESULT DeleteHeapWalk(HeapWalkHandle handle) = 0;
 
     // Walks the heap using the given heap walk handle, enumerating objects
     // on the managed heap.  Note that walking the heap requires that the GC
@@ -2395,13 +2181,9 @@ public:
     virtual
     HRESULT GetHeapSegments(OUT DacDbiArrayList<COR_SEGMENT> * pSegments) = 0;
 
-    virtual
-    bool IsValidObject(CORDB_ADDRESS obj) = 0;
+    virtual HRESULT IsValidObject(CORDB_ADDRESS obj, OUT bool * pResult) = 0;
 
-    virtual
-    bool GetAppDomainForObject(CORDB_ADDRESS obj, OUT VMPTR_AppDomain * pApp,
-                                OUT VMPTR_Module * pModule,
-                                OUT VMPTR_DomainAssembly * pDomainAssembly) = 0;
+    virtual HRESULT GetAppDomainForObject(CORDB_ADDRESS obj, OUT VMPTR_AppDomain * pApp, OUT VMPTR_Module * pModule, OUT VMPTR_DomainAssembly * pDomainAssembly, OUT bool * pResult) = 0;
 
 
     //   Reference Walking.
@@ -2424,8 +2206,7 @@ public:
     //      handle - in - the handle of the reference walk to delete
     // Excecptions:
     //      Does not throw, but does not catch exceptions either.
-    virtual
-    void DeleteRefWalk(RefWalkHandle handle) = 0;
+    virtual HRESULT DeleteRefWalk(RefWalkHandle handle) = 0;
 
     // Enumerates GC references in the process based on the parameters passed to CreateRefWalk.
     // Parameters:
@@ -2451,8 +2232,7 @@ public:
     virtual
     HRESULT GetArrayLayout(COR_TYPEID id, COR_ARRAY_LAYOUT * pLayout) = 0;
 
-    virtual
-    void GetGCHeapInformation(OUT COR_HEAPINFO * pHeapInfo) = 0;
+    virtual HRESULT GetGCHeapInformation(OUT COR_HEAPINFO * pHeapInfo) = 0;
 
     // If a PEAssembly has an RW capable IMDInternalImport, this returns the address of the MDInternalRW
     // object which implements it.
@@ -2682,8 +2462,7 @@ public:
     // Arguments:
     //    vmObject - pointer to runtime object to query for.
     //
-    virtual
-    BOOL IsDelegate(VMPTR_Object vmObject) = 0;
+    virtual HRESULT IsDelegate(VMPTR_Object vmObject, OUT BOOL * pResult) = 0;
 
     // Returns the delegate type
     virtual
@@ -2709,8 +2488,7 @@ public:
     virtual
     HRESULT IsModuleMapped(VMPTR_Module pModule, OUT BOOL *isModuleMapped) = 0;
 
-    virtual
-    bool MetadataUpdatesApplied() = 0;
+    virtual HRESULT MetadataUpdatesApplied(OUT bool * pResult) = 0;
 
     virtual
     HRESULT GetDomainAssemblyFromModule(VMPTR_Module vmModule, OUT VMPTR_DomainAssembly *pVmDomainAssembly) = 0;
@@ -2722,12 +2500,7 @@ public:
         OUT CORDB_ADDRESS* pNextContinuation,
         OUT UINT32* pState) = 0;
 
-    virtual
-    void GetAsyncLocals(
-        VMPTR_MethodDesc vmMethod,
-        CORDB_ADDRESS codeAddr,
-        UINT32 state,
-        OUT DacDbiArrayList<AsyncLocalData>* pAsyncLocals) = 0;
+    virtual HRESULT GetAsyncLocals(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeAddr, UINT32 state, OUT DacDbiArrayList<AsyncLocalData>* pAsyncLocals) = 0;
 
     virtual
     HRESULT GetGenericArgTokenIndex(


### PR DESCRIPTION
On mobile platforms, C++ exceptions thrown from DAC (libmscordaccore.so) are never caught by DBI (libmscordbi.so). This causes all ICorDebug operations that involve DAC calls to fail with E_FAIL.

**Root cause:** 

Our mobile configurations statically link libc++ into each DSO. Combined with -fvisibility=hidden and -Bsymbolic, each DSO gets private copies of all C++ typeinfo. libc++'s RTTI uses pointer-only comparison (no string
fallback), so catch(Exception*) in DBI never matches exceptions thrown from DAC — the typeinfo pointers are different.

**Solution**

Convert all 119 non-HRESULT methods in IDacDbiInterface to return HRESULT, with former return values moved to OUT parameters. Each DAC implementation body is wrapped with EX_TRY/EX_CATCH_HRESULT so exceptions are caught inside the DAC and converted to HRESULT
before crossing the DSO boundary. DBI callers are updated to use IfFailThrow() to convert the HRESULT back to an exception within the DBI's own DSO, preserving existing error handling behavior.

This eliminates C++ exceptions crossing the DAC→DBI boundary entirely. 

**Changes**

 - dacdbiinterface.h — 119 method signatures changed from void/value-returning to HRESULT + OUT parameter
 - dacdbiimpl.h — Matching implementation class declarations
 - dacdbiimpl.cpp, dacdbiimplstackwalk.cpp, dacdbiimpllocks.cpp — 119 method bodies wrapped with EX_TRY/EX_CATCH_HRESULT
 - 11 DBI caller files (process.cpp, rsthread.cpp, divalue.cpp, etc.) — 164 call sites updated to handle HRESULT returns