### PR TITLE
[Wasm RyuJit] more fixes from crossgen2 of spc

### DIFF
--- a/src/coreclr/jit/fgopt.cpp
+++ b/src/coreclr/jit/fgopt.cpp
@@ -1746,6 +1746,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
         GenTree* switchVal = switchTree->AsOp()->gtOp1;
         noway_assert(genActualTypeIsIntOrI(switchVal->TypeGet()));
 
+#if !defined(TARGET_WASM)
         // If we are in LIR, remove the jump table from the block.
         if (block->IsLIR())
         {
@@ -1753,6 +1754,7 @@ bool Compiler::fgOptimizeSwitchBranches(BasicBlock* block)
             assert(jumpTable->OperIs(GT_JMPTABLE));
             blockRange->Remove(jumpTable);
         }
+#endif // !defined(TARGET_WASM)
 
         // Change the GT_SWITCH(switchVal) into GT_JTRUE(GT_EQ(switchVal==0)).
         // Also mark the node as GTF_DONT_CSE as further down JIT is not capable of handling it.

--- a/src/coreclr/jit/fgwasm.cpp
+++ b/src/coreclr/jit/fgwasm.cpp
@@ -1076,6 +1076,7 @@ PhaseStatus Compiler::fgWasmControlFlow()
     if (hasBlocksOnlyReachableViaEH)
     {
         JITDUMP("\nThere are blocks only reachable via EH, bailing out for now\n");
+        NYI_WASM("Method has blocks only reachable via EH");
         return PhaseStatus::MODIFIED_NOTHING;
     }
 

--- a/src/coreclr/jit/layout.h
+++ b/src/coreclr/jit/layout.h
@@ -198,7 +198,7 @@ public:
                 return TYP_USHORT;
             case 4:
                 return TYP_INT;
-#ifdef TARGET_64BIT
+#if defined(TARGET_64BIT) || defined(TARGET_WASM)
             case 8:
                 return TYP_LONG;
 #endif

--- a/src/coreclr/jit/valuenum.cpp
+++ b/src/coreclr/jit/valuenum.cpp
@@ -13788,7 +13788,7 @@ void Compiler::fgValueNumberHelperCallFunc(GenTreeCall* call, VNFunc vnf, ValueN
 
                 curArg = curArg->GetNext();
                 assert(nArgs == 3); // Our current maximum.
-                assert(curArg == nullptr);
+                assert((curArg == nullptr) || (curArg->GetWellKnownArg() == WellKnownArg::WasmPortableEntryPoint));
                 if (generateUniqueVN)
                 {
                     call->gtVNPair = vnStore->VNPairForFunc(call->TypeGet(), vnf, vnp0, vnp1, vnp2, vnpUniq);

--- a/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
+++ b/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
@@ -75,6 +75,11 @@ namespace Internal.JitInterface
 
             TypeDesc abiType = LowerToAbiType(type);
 
+            if (abiType == null)
+            {
+                return pointerType;
+            }
+
             switch (abiType.UnderlyingType.Category)
             {
                 case TypeFlags.Int32:


### PR DESCRIPTION
- Wasm codegen does not use jump tables
- Bail with NYI for now if there are blocks only reachable via EH
- 8 byte structs can be returned as primitives
- another vn case where we need to tolerate the final pep arg
- handle structs passed/returned by-ref in signature gen code