### PR TITLE
[Wasm RyuJIT] Block Stores pt. 2

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2519,7 +2519,7 @@ void CodeGen::genCodeForCpObj(GenTreeBlk* cpObjNode)
         {
             // Load the sp onto the stack for the helper call.
             // TODO-WASM: Implement a special calling convention for this helper that doesn't accept sp/pep.
-            emit->emitIns_I(INS_local_get, EA_4BYTE, WasmRegToIndex(GetStackPointerReg()));
+            emit->emitIns_I(INS_local_get, EA_PTRSIZE, WasmRegToIndex(GetStackPointerReg()));
             // Compute the actual dest/src of the slot being copied to pass to the helper.
             emit->emitIns_I(INS_local_get, attrDstAddr, WasmRegToIndex(dstReg));
             emit->emitIns_I(INS_I_const, attrDstAddr, dstOffset);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2447,7 +2447,6 @@ void CodeGen::genCodeForCpObj(GenTreeBlk* cpObjNode)
     }
 
     noway_assert(source->IsLocal());
-    noway_assert(dstAddr->IsLocal());
 
     // If the destination is on the stack we don't need the write barrier.
     bool dstOnStack = cpObjNode->IsAddressNotOnHeap(m_compiler);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2434,9 +2434,9 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
 //
 void CodeGen::genCodeForCpObj(GenTreeBlk* cpObjNode)
 {
-    GenTree*  dstAddr       = cpObjNode->Addr();
-    GenTree*  source        = cpObjNode->Data();
-    var_types srcAddrType   = TYP_BYREF;
+    GenTree*  dstAddr     = cpObjNode->Addr();
+    GenTree*  source      = cpObjNode->Data();
+    var_types srcAddrType = TYP_BYREF;
 
     assert(source->isContained());
     if (source->OperIs(GT_IND))

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2464,8 +2464,6 @@ void CodeGen::genCodeForCpObj(GenTreeBlk* cpObjNode)
         srcReg = GetFramePointerReg();
     }
 
-    noway_assert(source->IsLocal());
-
     // If the destination is on the stack we don't need the write barrier.
     bool dstOnStack = cpObjNode->IsAddressNotOnHeap(m_compiler);
     // We should have generated a memory.copy for this scenario in lowering.

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2450,6 +2450,8 @@ void CodeGen::genCodeForCpObj(GenTreeBlk* cpObjNode)
 
     // If the destination is on the stack we don't need the write barrier.
     bool dstOnStack = cpObjNode->IsAddressNotOnHeap(m_compiler);
+    // We should have generated a memory.copy for this scenario in lowering.
+    assert(!dstOnStack);
 
 #ifdef DEBUG
     assert(!dstAddr->isContained());
@@ -2461,9 +2463,6 @@ void CodeGen::genCodeForCpObj(GenTreeBlk* cpObjNode)
 
     genConsumeOperands(cpObjNode);
 
-    ClassLayout* layout = cpObjNode->GetLayout();
-    unsigned     slots  = layout->GetSlotCount();
-
     regNumber srcReg = GetMultiUseOperandReg(source);
     regNumber dstReg = GetMultiUseOperandReg(dstAddr);
 
@@ -2472,7 +2471,12 @@ void CodeGen::genCodeForCpObj(GenTreeBlk* cpObjNode)
         // TODO-WASM: Memory barrier
     }
 
+    // TODO: Do we need an implicit null check here?
+
     emitter* emit = GetEmitter();
+
+    ClassLayout* layout = cpObjNode->GetLayout();
+    unsigned     slots  = layout->GetSlotCount();
 
     emitAttr attrSrcAddr = emitActualTypeSize(srcAddrType);
     emitAttr attrDstAddr = emitActualTypeSize(dstAddr->TypeGet());

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2451,14 +2451,14 @@ void CodeGen::genCodeForCpObj(GenTreeBlk* cpObjNode)
         source = source->gtGetOp1();
         assert(!source->isContained());
         srcAddrType = source->TypeGet();
-        srcReg = GetMultiUseOperandReg(source);
-        srcOffset = 0;
+        srcReg      = GetMultiUseOperandReg(source);
+        srcOffset   = 0;
     }
     else
     {
         noway_assert(source->OperIs(GT_LCL_FLD, GT_LCL_VAR));
-        GenTreeLclVarCommon *lclVar = source->AsLclVarCommon();
-        bool fpBased;
+        GenTreeLclVarCommon* lclVar = source->AsLclVarCommon();
+        bool                 fpBased;
         srcOffset = m_compiler->lvaFrameAddress(lclVar->GetLclNum(), &fpBased) + lclVar->GetLclOffs();
         noway_assert(fpBased);
         srcReg = GetFramePointerReg();

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2460,7 +2460,7 @@ void CodeGen::genCodeForCpObj(GenTreeBlk* cpObjNode)
     assert(cpObjNode->GetLayout()->HasGCPtr());
 #endif // DEBUG
 
-    genConsumeRegs(cpObjNode);
+    genConsumeOperands(cpObjNode);
 
     ClassLayout* layout = cpObjNode->GetLayout();
     unsigned     slots  = layout->GetSlotCount();
@@ -2497,11 +2497,11 @@ void CodeGen::genCodeForCpObj(GenTreeBlk* cpObjNode)
         {
             // Compute the actual dest/src of the slot being copied to pass to the helper.
             emit->emitIns_I(INS_local_get, attrDstAddr, WasmRegToIndex(dstReg));
-            emit->emitIns_I(INS_i32_const, attrDstAddr, offset);
-            emit->emitIns(INS_i32_add);
+            emit->emitIns_I(INS_I_const, attrDstAddr, offset);
+            emit->emitIns(INS_I_add);
             emit->emitIns_I(INS_local_get, attrSrcAddr, WasmRegToIndex(srcReg));
-            emit->emitIns_I(INS_i32_const, attrSrcAddr, offset);
-            emit->emitIns(INS_i32_add);
+            emit->emitIns_I(INS_I_const, attrSrcAddr, offset);
+            emit->emitIns(INS_I_add);
             // Call the byref assign helper. On other targets this updates the dst/src regs but here it won't,
             //  so we have to do the local.get+i32.const+i32.add dance every time.
             genEmitHelperCall(CORINFO_HELP_ASSIGN_BYREF, 0, EA_PTRSIZE);
@@ -2510,7 +2510,8 @@ void CodeGen::genCodeForCpObj(GenTreeBlk* cpObjNode)
         ++i;
         offset += TARGET_POINTER_SIZE;
     }
-    assert(gcPtrCount == 0);
+
+    assert(dstOnStack || (gcPtrCount == 0));
 
     if (cpObjNode->IsVolatile())
     {

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2486,9 +2486,9 @@ void CodeGen::genCodeForCpObj(GenTreeBlk* cpObjNode)
     unsigned i = 0, offset = 0;
     while (i < slots)
     {
-        // Copy the pointer-sized non-gc-pointer slots one at a time (and GC pointer slots if the destination is stack)
-        //  using regular I-sized load/store pairs.
-        if (dstOnStack || !layout->IsGCPtr(i))
+        // Copy the pointer-sized non-gc-pointer slots one at a time using regular I-sized load/store pairs,
+        //  and gc-pointer slots using a write barrier.
+        if (!layout->IsGCPtr(i))
         {
             // Do a pointer-sized load+store pair at the appropriate offset relative to dest and source
             emit->emitIns_I(INS_local_get, attrDstAddr, WasmRegToIndex(dstReg));
@@ -2514,7 +2514,7 @@ void CodeGen::genCodeForCpObj(GenTreeBlk* cpObjNode)
         offset += TARGET_POINTER_SIZE;
     }
 
-    assert(dstOnStack || (gcPtrCount == 0));
+    assert(gcPtrCount == 0);
 
     if (cpObjNode->IsVolatile())
     {

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -2020,6 +2020,8 @@ void CodeGen::genCodeForStoreInd(GenTreeStoreInd* tree)
     GenTree* data = tree->Data();
     GenTree* addr = tree->Addr();
 
+    assert(!addr->isContained());
+
     // We must consume the operands in the proper execution order,
     // so that liveness is updated appropriately.
     genConsumeAddress(addr);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -431,7 +431,7 @@ void CodeGen::WasmProduceReg(GenTree* node)
 //
 // If the operand is a candidate, we use that candidate's current register.
 // Otherwise it must have been allocated into a temporary register initialized
-// in 'WasmProduceReg'. To do this, set the LIR::Flags::MultiplyUsed flag during
+// in 'WasmProduceReg'. To do this, call treeNode->SetMultiplyUsed() during
 // lowering or other pre-regalloc phases, and ensure that regalloc is updated to
 // call CollectReferences on the node(s) that need to be used multiple times.
 //

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2566,6 +2566,10 @@ class Compiler
     friend class ReplaceVisitor;
     friend class FlowGraphNaturalLoop;
 
+#ifdef TARGET_WASM
+    friend class WasmRegAlloc; // For m_pLowering
+#endif
+
 #ifdef FEATURE_HW_INTRINSICS
     friend struct GenTreeHWIntrinsic;
     friend struct HWIntrinsicInfo;

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -2566,10 +2566,6 @@ class Compiler
     friend class ReplaceVisitor;
     friend class FlowGraphNaturalLoop;
 
-#ifdef TARGET_WASM
-    friend class WasmRegAlloc; // For m_pLowering
-#endif
-
 #ifdef FEATURE_HW_INTRINSICS
     friend struct GenTreeHWIntrinsic;
     friend struct HWIntrinsicInfo;
@@ -8683,6 +8679,11 @@ public:
 
     const ParameterRegisterLocalMapping* FindParameterRegisterLocalMappingByRegister(regNumber reg);
     const ParameterRegisterLocalMapping* FindParameterRegisterLocalMappingByLocal(unsigned lclNum, unsigned offset);
+
+    Lowering* GetLowering() const
+    {
+        return m_pLowering;
+    }
 
     /*
     XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -12844,7 +12844,7 @@ void Compiler::gtDispTree(GenTree*                    tree,
 
 #ifdef TARGET_WASM
                     case GenTreeBlk::BlkOpKindNativeOpcode:
-                        printf(" (memory.copy|fill)");
+                        printf(" (memory.%s)", tree->OperIsCopyBlkOp() ? "copy" : "fill");
                         break;
 #endif
 

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1228,6 +1228,10 @@ public:
     // LIR flags
     //   These helper methods, along with the flag values they manipulate, are defined in lir.h
     //
+#ifdef TARGET_WASM
+    // Asks the register allocator to allocate a dedicated register for this node so we can use its value multiple times.
+    inline void SetMultiplyUsed();
+#endif
     // UnusedValue indicates that, although this node produces a value, it is unused.
     inline void SetUnusedValue();
     inline void ClearUnusedValue();

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -1229,7 +1229,8 @@ public:
     //   These helper methods, along with the flag values they manipulate, are defined in lir.h
     //
 #ifdef TARGET_WASM
-    // Asks the register allocator to allocate a dedicated register for this node so we can use its value multiple times.
+    // Asks the register allocator to allocate a dedicated register for this node so we can use its value multiple
+    // times.
     inline void SetMultiplyUsed();
 #endif
     // UnusedValue indicates that, although this node produces a value, it is unused.

--- a/src/coreclr/jit/lir.h
+++ b/src/coreclr/jit/lir.h
@@ -339,6 +339,14 @@ public:
     static GenTree* FirstNode(GenTree* node1, GenTree* node2);
 };
 
+#ifdef TARGET_WASM
+inline void GenTree::SetMultiplyUsed()
+{
+    assert(gtType != TYP_STRUCT);
+    gtLIRFlags |= LIR::Flags::MultiplyUsed;
+}
+#endif
+
 inline void GenTree::SetUnusedValue()
 {
     gtLIRFlags |= LIR::Flags::UnusedValue;

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -530,9 +530,7 @@ void Lowering::AfterLowerBlock()
                     {
                         JITDUMP("Stackifier moving node [%06u] after [%06u]\n", Compiler::dspTreeID(node),
                                 Compiler::dspTreeID(prev));
-#if DEBUG
                         assert(m_lower->IsInvariantInRange(node, prev->gtNext));
-#endif
                         m_lower->BlockRange().Remove(node);
                         m_lower->BlockRange().InsertAfter(prev, node);
                         break;

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -360,16 +360,6 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
     {
         return;
     }
-
-    // TODO-WASM-CQ: contain suitable LEAs here. Take note of the fact that for this to be correct we must prove the
-    // LEA doesn't overflow. It will involve creating a new frontend node to represent "nuw" (offset) addition.
-    GenTree* addr = indirNode->Addr();
-    if (addr->OperIs(GT_LCL_ADDR) && IsContainableLclAddr(addr->AsLclFld(), indirNode->Size()))
-    {
-        // These nodes go into an addr mode:
-        // - GT_LCL_ADDR is a stack addr mode.
-        MakeSrcContained(indirNode, addr);
-    }
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -244,6 +244,11 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
         ClassLayout* layout  = blkNode->GetLayout();
         bool         doCpObj = layout->HasGCPtr();
 
+        // If copying to the stack instead of the heap, we should treat it as a raw memcpy for
+        //  smaller generated code and potentially better performance.
+        if (blkNode->IsAddressNotOnHeap(m_compiler))
+            doCpObj = false;
+
         // CopyObj or CopyBlk
         if (doCpObj)
         {

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -522,8 +522,7 @@ void Lowering::AfterLowerBlock()
                     //  i.e. cpobj where the src and dest get stashed at the start and then used as add operands
                     //  repeatedly.
                     // Locals can also be safely moved as long as they aren't address-exposed due to local var nodes
-                    // being
-                    //  implicitly pseudo-contained.
+                    //  being implicitly pseudo-contained.
                     // TODO-WASM: Verify that it is actually safe to do this for all contained nodes.
                     if (node->IsInvariant() || node->isContained() ||
                         (node->OperIs(GT_LCL_VAR) &&

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -168,8 +168,8 @@ GenTree* Lowering::LowerBinaryArithmetic(GenTreeOp* binOp)
 
     if (binOp->gtOverflow())
     {
-        binOp->gtGetOp1()->gtLIRFlags |= LIR::Flags::MultiplyUsed;
-        binOp->gtGetOp2()->gtLIRFlags |= LIR::Flags::MultiplyUsed;
+        binOp->gtGetOp1()->SetMultiplyUsed();
+        binOp->gtGetOp2()->SetMultiplyUsed();
     }
 
     return binOp->gtNext;
@@ -188,12 +188,12 @@ void Lowering::LowerDivOrMod(GenTreeOp* divMod)
     ExceptionSetFlags exSetFlags = divMod->OperExceptions(m_compiler);
     if ((exSetFlags & ExceptionSetFlags::ArithmeticException) != ExceptionSetFlags::None)
     {
-        divMod->gtGetOp1()->gtLIRFlags |= LIR::Flags::MultiplyUsed;
-        divMod->gtGetOp2()->gtLIRFlags |= LIR::Flags::MultiplyUsed;
+        divMod->gtGetOp1()->SetMultiplyUsed();
+        divMod->gtGetOp2()->SetMultiplyUsed();
     }
     else if ((exSetFlags & ExceptionSetFlags::DivideByZeroException) != ExceptionSetFlags::None)
     {
-        divMod->gtGetOp2()->gtLIRFlags |= LIR::Flags::MultiplyUsed;
+        divMod->gtGetOp2()->SetMultiplyUsed();
     }
 
     ContainCheckDivOrMod(divMod);
@@ -259,11 +259,11 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
             }
 
             blkNode->gtBlkOpKind = GenTreeBlk::BlkOpKindCpObjUnroll;
-            dstAddr->gtLIRFlags |= LIR::Flags::MultiplyUsed;
+            dstAddr->SetMultiplyUsed();
             if (src->OperIs(GT_IND))
-                src->gtGetOp1()->gtLIRFlags |= LIR::Flags::MultiplyUsed;
+                src->gtGetOp1()->SetMultiplyUsed();
             else
-                src->gtLIRFlags |= LIR::Flags::MultiplyUsed;
+                src->SetMultiplyUsed();
         }
         else
         {
@@ -300,7 +300,7 @@ void Lowering::LowerCast(GenTree* tree)
 
     if (tree->gtOverflow())
     {
-        tree->gtGetOp1()->gtLIRFlags |= LIR::Flags::MultiplyUsed;
+        tree->gtGetOp1()->SetMultiplyUsed();
     }
     ContainCheckCast(tree->AsCast());
 }
@@ -613,6 +613,6 @@ void Lowering::AfterLowerArgsForCall(GenTreeCall* call)
     {
         // Prepare for explicit null check
         CallArg* thisArg = call->gtArgs.GetThisArg();
-        thisArg->GetNode()->gtLIRFlags |= LIR::Flags::MultiplyUsed;
+        thisArg->GetNode()->SetMultiplyUsed();
     }
 }

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -525,14 +525,15 @@ void Lowering::AfterLowerBlock()
                     // being
                     //  implicitly pseudo-contained.
                     // TODO-WASM: Verify that it is actually safe to do this for all contained nodes.
-                    if (
-                        m_lower->IsInvariantInRange(node, prev->gtNext) ||
-                        node->isContained() ||
+                    if (node->IsInvariant() || node->isContained() ||
                         (node->OperIs(GT_LCL_VAR) &&
                          !m_lower->m_compiler->lvaGetDesc(node->AsLclVarCommon())->IsAddressExposed()))
                     {
                         JITDUMP("Stackifier moving node [%06u] after [%06u]\n", Compiler::dspTreeID(node),
                                 Compiler::dspTreeID(prev));
+#if DEBUG
+                        assert(m_lower->IsInvariantInRange(node, prev->gtNext));
+#endif
                         m_lower->BlockRange().Remove(node);
                         m_lower->BlockRange().InsertAfter(prev, node);
                         break;

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -525,18 +525,18 @@ void Lowering::AfterLowerBlock()
                     // Invariant nodes can be safely moved by the stackifier with no side effects.
                     // For other nodes, the side effects would require us to turn them into a temporary local, but this
                     //  is not possible for contained nodes like an IND inside a STORE_BLK. However, the few types of
-                    //  contained nodes we have in Wasm should be safe to move freely since the lack of 'dup' or persistent
-                    //  registers in Wasm means that the actual codegen will trigger the side effect(s) and store the result
-                    //  into a Wasm local for any later uses during the containing node's execution, i.e. cpobj where the
-                    //  src and dest get stashed at the start and then used as add operands repeatedly.
-                    // Locals can also be safely moved as long as they aren't address-exposed due to local var nodes being
+                    //  contained nodes we have in Wasm should be safe to move freely since the lack of 'dup' or
+                    //  persistent registers in Wasm means that the actual codegen will trigger the side effect(s) and
+                    //  store the result into a Wasm local for any later uses during the containing node's execution,
+                    //  i.e. cpobj where the src and dest get stashed at the start and then used as add operands
+                    //  repeatedly.
+                    // Locals can also be safely moved as long as they aren't address-exposed due to local var nodes
+                    // being
                     //  implicitly pseudo-contained.
                     // TODO-WASM: Verify that it is actually safe to do this for all contained nodes.
-                    if (
-                        node->IsInvariant() ||
-                        node->isContained() ||
-                        (node->OperIs(GT_LCL_VAR) && !m_lower->m_compiler->lvaGetDesc(node->AsLclVarCommon())->IsAddressExposed())
-                    )
+                    if (node->IsInvariant() || node->isContained() ||
+                        (node->OperIs(GT_LCL_VAR) &&
+                         !m_lower->m_compiler->lvaGetDesc(node->AsLclVarCommon())->IsAddressExposed()))
                     {
                         JITDUMP("Stackifier moving node [%06u] after [%06u]\n", Compiler::dspTreeID(node),
                                 Compiler::dspTreeID(prev));
@@ -561,8 +561,9 @@ void Lowering::AfterLowerBlock()
                         // FIXME-WASM: TryGetUse is inefficient here, replace it with something more optimal
                         if (!m_lower->BlockRange().TryGetUse(node, &nodeUse))
                         {
-                            JITDUMP("node==[%06u] prev==[%06u]\n", Compiler::dspTreeID(node), Compiler::dspTreeID(prev));
-                            NYI_WASM("Could not get a LIR::Use for the node to be moved by the stackifier");
+                            JITDUMP("node==[%06u] prev==[%06u]\n", Compiler::dspTreeID(node),
+                    Compiler::dspTreeID(prev)); NYI_WASM("Could not get a LIR::Use for the node to be moved by the
+                    stackifier");
                         }
 
                         unsigned lclNum = nodeUse.ReplaceWithLclVar(m_lower->m_compiler);
@@ -570,8 +571,8 @@ void Lowering::AfterLowerBlock()
                         JITDUMP("Stackifier replaced node [%06u] with lcl var %u\n", Compiler::dspTreeID(node), lclNum);
                         m_lower->BlockRange().Remove(newNode);
                         m_lower->BlockRange().InsertAfter(prev, newNode);
-                        JITDUMP("Stackifier moved new node [%06u] after [%06u]\n", Compiler::dspTreeID(newNode), Compiler::dspTreeID(prev));
-                        break;
+                        JITDUMP("Stackifier moved new node [%06u] after [%06u]\n", Compiler::dspTreeID(newNode),
+                    Compiler::dspTreeID(prev)); break;
                     }
                     */
 

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -536,37 +536,6 @@ void Lowering::AfterLowerBlock()
                         break;
                     }
 
-                    /*
-                    else
-                    {
-                        // To resolve this scenario we have two options:
-                        // 1. We try moving the whole tree rooted at `node`.
-                        //    To avoid quadratic behavior, we first stackify it and collect all the side effects
-                        //    from it. Then we check for interference of those side effects with nodes between
-                        //    'node' and 'prev'.
-                        // 2. Failing that, we insert a temporary ('ReplaceWithLclVar') for 'node'.
-                        //    To avoid explosion of temporaries, we maintain a busy/free set of them.
-                        // For now, for simplicity we are implementing #2 only.
-
-                        LIR::Use nodeUse;
-                        // FIXME-WASM: TryGetUse is inefficient here, replace it with something more optimal
-                        if (!m_lower->BlockRange().TryGetUse(node, &nodeUse))
-                        {
-                            JITDUMP("node==[%06u] prev==[%06u]\n", Compiler::dspTreeID(node),
-                    Compiler::dspTreeID(prev)); NYI_WASM("Could not get a LIR::Use for the node to be moved by the
-                    stackifier");
-                        }
-
-                        unsigned lclNum = nodeUse.ReplaceWithLclVar(m_lower->m_compiler);
-                        GenTree* newNode = nodeUse.Def();
-                        JITDUMP("Stackifier replaced node [%06u] with lcl var %u\n", Compiler::dspTreeID(node), lclNum);
-                        m_lower->BlockRange().Remove(newNode);
-                        m_lower->BlockRange().InsertAfter(prev, newNode);
-                        JITDUMP("Stackifier moved new node [%06u] after [%06u]\n", Compiler::dspTreeID(newNode),
-                    Compiler::dspTreeID(prev)); break;
-                    }
-                    */
-
                     JITDUMP("node==[%06u] prev==[%06u]\n", Compiler::dspTreeID(node), Compiler::dspTreeID(prev));
                     NYI_WASM("IR not in a stackified form");
                 }

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -519,7 +519,8 @@ void Lowering::AfterLowerBlock()
 
                     if (node->IsInvariant())
                     {
-                        JITDUMP("Stackifier moving invariant node [%06u] after [%06u]\n", Compiler::dspTreeID(node), Compiler::dspTreeID(prev));
+                        JITDUMP("Stackifier moving invariant node [%06u] after [%06u]\n", Compiler::dspTreeID(node),
+                                Compiler::dspTreeID(prev));
                         m_lower->BlockRange().Remove(node);
                         m_lower->BlockRange().InsertAfter(prev, node);
                         break;

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -525,7 +525,9 @@ void Lowering::AfterLowerBlock()
                     // being
                     //  implicitly pseudo-contained.
                     // TODO-WASM: Verify that it is actually safe to do this for all contained nodes.
-                    if (node->IsInvariant() || node->isContained() ||
+                    if (
+                        m_lower->IsInvariantInRange(node, prev->gtNext) ||
+                        node->isContained() ||
                         (node->OperIs(GT_LCL_VAR) &&
                          !m_lower->m_compiler->lvaGetDesc(node->AsLclVarCommon())->IsAddressExposed()))
                     {

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -486,14 +486,11 @@ void Lowering::AfterLowerBlock()
             }
         }
 
-        bool CanMoveNodePast (GenTree* node, GenTree* past)
+        bool CanMoveNodePast(GenTree* node, GenTree* past)
         {
-            bool result = node->IsInvariant() ||
-                node->isContained() ||
-                (
-                    node->OperIs(GT_LCL_VAR) &&
-                    !m_lower->m_compiler->lvaGetDesc(node->AsLclVarCommon())->IsAddressExposed()
-                );
+            bool result = node->IsInvariant() || node->isContained() ||
+                          (node->OperIs(GT_LCL_VAR) &&
+                           !m_lower->m_compiler->lvaGetDesc(node->AsLclVarCommon())->IsAddressExposed());
 
             if (result)
             {

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -360,6 +360,9 @@ void Lowering::ContainCheckIndir(GenTreeIndir* indirNode)
     {
         return;
     }
+
+    // TODO-WASM-CQ: contain suitable LEAs here. Take note of the fact that for this to be correct we must prove the
+    // LEA doesn't overflow. It will involve creating a new frontend node to represent "nuw" (offset) addition.
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/lowerwasm.cpp
+++ b/src/coreclr/jit/lowerwasm.cpp
@@ -262,8 +262,6 @@ void Lowering::LowerBlockStore(GenTreeBlk* blkNode)
             dstAddr->SetMultiplyUsed();
             if (src->OperIs(GT_IND))
                 src->gtGetOp1()->SetMultiplyUsed();
-            else
-                src->SetMultiplyUsed();
         }
         else
         {

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -645,42 +645,6 @@ RefPosition* LinearScan::newRefPosition(Interval*        theInterval,
 }
 
 //------------------------------------------------------------------------
-// IsContainableMemoryOp: Checks whether this is a memory op that can be contained.
-//
-// Arguments:
-//    node        - the node of interest.
-//
-// Return value:
-//    True if this will definitely be a memory reference that could be contained.
-//
-// Notes:
-//    This differs from the isMemoryOp() method on GenTree because it checks for
-//    the case of doNotEnregister local. This won't include locals that
-//    for some other reason do not become register candidates, nor those that get
-//    spilled.
-//    Also, because we usually call this before we redo dataflow, any new lclVars
-//    introduced after the last dataflow analysis will not yet be marked lvTracked,
-//    so we don't use that.
-//
-bool LinearScan::isContainableMemoryOp(GenTree* node)
-{
-    if (node->isMemoryOp())
-    {
-        return true;
-    }
-    if (node->IsLocal())
-    {
-        if (!enregisterLocalVars)
-        {
-            return true;
-        }
-        const LclVarDsc* varDsc = m_compiler->lvaGetDesc(node->AsLclVar());
-        return varDsc->lvDoNotEnregister;
-    }
-    return false;
-}
-
-//------------------------------------------------------------------------
 // addKillForRegs: Adds a RefTypeKill ref position for the given registers.
 //
 // Arguments:

--- a/src/coreclr/jit/regalloc.cpp
+++ b/src/coreclr/jit/regalloc.cpp
@@ -462,3 +462,39 @@ bool RegAllocImpl::isRegCandidate(LclVarDsc* varDsc)
 
     return true;
 }
+
+//------------------------------------------------------------------------
+// IsContainableMemoryOp: Checks whether this is a memory op that can be contained.
+//
+// Arguments:
+//    node        - the node of interest.
+//
+// Return value:
+//    True if this will definitely be a memory reference that could be contained.
+//
+// Notes:
+//    This differs from the isMemoryOp() method on GenTree because it checks for
+//    the case of doNotEnregister local. This won't include locals that
+//    for some other reason do not become register candidates, nor those that get
+//    spilled.
+//    Also, because we usually call this before we redo dataflow, any new lclVars
+//    introduced after the last dataflow analysis will not yet be marked lvTracked,
+//    so we don't use that.
+//
+bool RegAllocImpl::isContainableMemoryOp(GenTree* node)
+{
+    if (node->isMemoryOp())
+    {
+        return true;
+    }
+    if (node->IsLocal())
+    {
+        if (!willEnregisterLocalVars())
+        {
+            return true;
+        }
+        const LclVarDsc* varDsc = m_compiler->lvaGetDesc(node->AsLclVar());
+        return varDsc->lvDoNotEnregister;
+    }
+    return false;
+}

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -580,7 +580,7 @@ void WasmRegAlloc::ConsumeTemporaryRegForOperand(GenTree* operand DEBUGARG(const
     }
 
     regNumber reg = ReleaseTemporaryRegister(genActualType(operand));
-assert((reg == operand->GetRegNum()) && "Temporary reg being consumed out of order");
+    assert((reg == operand->GetRegNum()) && "Temporary reg being consumed out of order");
     CollectReference(operand);
 
     operand->gtLIRFlags &= ~LIR::Flags::MultiplyUsed;
@@ -624,7 +624,7 @@ void WasmRegAlloc::ResolveReferences()
     {
         TemporaryRegStack& temporaryRegs          = m_temporaryRegs[static_cast<unsigned>(type)];
         TemporaryRegBank&  allocatedTemporaryRegs = temporaryRegMap[static_cast<unsigned>(type)];
-assert((temporaryRegs.Count == 0) && "Some temporary regs were not consumed/released");
+        assert((temporaryRegs.Count == 0) && "Some temporary regs were not consumed/released");
 
         allocatedTemporaryRegs.Count = temporaryRegs.MaxCount;
         if (allocatedTemporaryRegs.Count == 0)

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -493,7 +493,7 @@ void WasmRegAlloc::RewriteLocalStackStore(GenTreeLclVarCommon* lclNode)
     CurrentRange().InsertBefore(insertionPoint, lclNode);
 
     LIR::ReadOnlyRange storeRange(store, store);
-    m_compiler->m_pLowering->LowerRange(m_currentBlock, storeRange);
+    m_compiler->GetLowering()->LowerRange(m_currentBlock, storeRange);
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -632,7 +632,8 @@ void WasmRegAlloc::ResolveReferences()
     {
         TemporaryRegStack& temporaryRegs          = m_temporaryRegs[static_cast<unsigned>(type)];
         TemporaryRegBank&  allocatedTemporaryRegs = temporaryRegMap[static_cast<unsigned>(type)];
-        // If temporaryRegs.Count != 0 that means CollectReferences failed to CollectReference one or more multiply-used nodes.
+        // If temporaryRegs.Count != 0 that means CollectReferences failed to CollectReference one or more multiply-used
+        // nodes.
         assert(temporaryRegs.Count == 0);
 
         allocatedTemporaryRegs.Count = temporaryRegs.MaxCount;

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -52,7 +52,19 @@ void WasmRegAlloc::dumpLsraStatsSummary(FILE* file)
 
 bool WasmRegAlloc::isContainableMemoryOp(GenTree* node)
 {
-    NYI_WASM("isContainableMemoryOp");
+    if (node->isMemoryOp())
+    {
+        return true;
+    }
+    if (node->IsLocal())
+    {
+        if (!m_compiler->compEnregLocals())
+        {
+            return true;
+        }
+        const LclVarDsc* varDsc = m_compiler->lvaGetDesc(node->AsLclVar());
+        return varDsc->lvDoNotEnregister;
+    }
     return false;
 }
 

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -330,6 +330,7 @@ void WasmRegAlloc::CollectReferencesForNode(GenTree* node)
         case GT_SUB:
         case GT_MUL:
             CollectReferencesForBinop(node->AsOp());
+            break;
 
         case GT_STORE_BLK:
             CollectReferencesForBlockStore(node->AsBlk());

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -50,24 +50,6 @@ void WasmRegAlloc::dumpLsraStatsSummary(FILE* file)
 }
 #endif // TRACK_LSRA_STATS
 
-bool WasmRegAlloc::isContainableMemoryOp(GenTree* node)
-{
-    if (node->isMemoryOp())
-    {
-        return true;
-    }
-    if (node->IsLocal())
-    {
-        if (!m_compiler->compEnregLocals())
-        {
-            return true;
-        }
-        const LclVarDsc* varDsc = m_compiler->lvaGetDesc(node->AsLclVar());
-        return varDsc->lvDoNotEnregister;
-    }
-    return false;
-}
-
 //------------------------------------------------------------------------
 // CurrentRange: Get the LIR range under current processing.
 //

--- a/src/coreclr/jit/regallocwasm.h
+++ b/src/coreclr/jit/regallocwasm.h
@@ -124,8 +124,8 @@ private:
     void      CollectReferencesForCall(GenTreeCall* callNode);
     void      CollectReferencesForCast(GenTreeOp* castNode);
     void      CollectReferencesForBinop(GenTreeOp* binOpNode);
-    void      CollectReferencesForLclVar(GenTreeLclVar* lclVar);
     void      CollectReferencesForBlockStore(GenTreeBlk* node);
+    void      CollectReferencesForLclVar(GenTreeLclVar* lclVar);
     void      RewriteLocalStackStore(GenTreeLclVarCommon* node);
     void      CollectReference(GenTree* node);
     void      RequestTemporaryRegisterForMultiplyUsedNode(GenTree* node);

--- a/src/coreclr/jit/regallocwasm.h
+++ b/src/coreclr/jit/regallocwasm.h
@@ -125,6 +125,7 @@ private:
     void      CollectReferencesForCast(GenTreeOp* castNode);
     void      CollectReferencesForBinop(GenTreeOp* binOpNode);
     void      CollectReferencesForLclVar(GenTreeLclVar* lclVar);
+    void      CollectReferencesForBlockStore(GenTreeBlk* node);
     void      RewriteLocalStackStore(GenTreeLclVarCommon* node);
     void      CollectReference(GenTree* node);
     void      RequestTemporaryRegisterForMultiplyUsedNode(GenTree* node);

--- a/src/coreclr/jit/stacklevelsetter.cpp
+++ b/src/coreclr/jit/stacklevelsetter.cpp
@@ -287,6 +287,7 @@ void StackLevelSetter::SetThrowHelperBlocks(GenTree* node, BasicBlock* block)
 #if defined(TARGET_WASM)
         // TODO-WASM: add other opers that imply null checks
         case GT_NULLCHECK:
+        case GT_STORE_BLK:
             SetThrowHelperBlock(SCK_NULL_CHECK, block);
             break;
 


### PR DESCRIPTION
* Implement genCodeForCpObj
* Fix two NIY scenarios in the stackifier
* Fix generated stores not being lowered after RewriteLocalStackStore
* Implement isContainableMemoryOp
* Expand and add comments to ease development

This is sufficient to compile the following to valid WASM (It crashes when attempting to call the write barrier helper):
```csharp
    [StructLayout(LayoutKind.Explicit)]
    public struct S2 {
        [FieldOffset(0)]
        public string A;
        [FieldOffset(8)]
        public int b;
        [FieldOffset(16)]
        public string C;
        [FieldOffset(24)]
        public int d;
    }

    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
    static unsafe void copyStructWithRefs (ref S2 a, ref S2 b) {
        a = b;
    }
```

And the following just plain works, since copies to the stack don't need a write barrier:
```csharp
    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
    static unsafe void loadStructWithRefs (ref S2 src) {
        S2 local = src;
    }
```

The following now works thanks to implementing isContainableMemoryOp and fixing a related bug:
```csharp
    [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
    static unsafe void fillStructFromLocal (ref S2 dest) {
        S2 local = default;
        local.b = 37;
        dest = local;
    }
```

Fixes #124903