### PR TITLE
Fix inverted IsNull check in RangeSectionMap::EnumMemoryRangeSectionMapLevel

### DIFF
--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -1550,7 +1550,7 @@ public:
 
         for (uintptr_t i = 0; i < entriesPerMapLevel; i++)
         {
-            if (level[i].IsNull())
+            if (!level[i].IsNull())
             {
                 EnumMemoryRangeSectionMapLevel(flags, *level[i].VolatileLoad(pLockState), pLockState);
             }


### PR DESCRIPTION
## Summary

One-line fix: invert the IsNull() condition in the template overload of EnumMemoryRangeSectionMapLevel to match the non-template L1 overload.

## Problem

The template overload of `EnumMemoryRangeSectionMapLevel` (handling levels L2–L5 on 64-bit) has an inverted condition at line 1553 of `codeman.h`:

```cpp
// BUG: recurses into NULL entries, skips populated ones
if (level[i].IsNull())
{
    EnumMemoryRangeSectionMapLevel(flags, *level[i].VolatileLoad(pLockState), pLockState);
}
```

The non-template L1 overload at line 1538 correctly uses \!IsNull()\:

```cpp
// CORRECT: only recurse into populated entries
if (!level[i].IsNull())
{
    EnumMemoryRangeSectionMapLevel(flags, level[i], pLockState);
}
```

This bug means `EnumMemoryRegions` for the `RangeSectionMap` never enumerates anything below the top level on 64-bit (where levels L2–L5 use the template), and attempts to dereference null pointers for empty slots. This could cause incomplete DAC memory enumeration during dump generation.

