### PR TITLE
Sve2 Scatters need a temp register for indices

### DIFF
--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -2438,7 +2438,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
 
                     assert(intrin.numOperands == 4);
 
-                    ssize_t shift = 0;
+                    ssize_t   shift   = 0;
                     regNumber tempReg = internalRegisters.GetSingle(node, RBM_ALLFLOAT);
 
                     if (intrin.id == NI_Sve2_Scatter16BitNarrowingNonTemporal)

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -2430,7 +2430,6 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
 
             case NI_Sve2_Scatter16BitNarrowingNonTemporal:
             case NI_Sve2_Scatter32BitNarrowingNonTemporal:
-            case NI_Sve2_Scatter8BitNarrowingNonTemporal:
             case NI_Sve2_ScatterNonTemporal:
             {
                 if (!varTypeIsSIMD(intrin.op2->gtType))
@@ -2439,23 +2438,26 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
 
                     assert(intrin.numOperands == 4);
 
-                    // SVE2 instruction only directly support byte offsets. Convert indices to bytes.
+                    ssize_t shift = 0;
                     regNumber tempReg = internalRegisters.GetSingle(node, RBM_ALLFLOAT);
+
                     if (intrin.id == NI_Sve2_Scatter16BitNarrowingNonTemporal)
                     {
-                        GetEmitter()->emitIns_R_R_I(INS_sve_lsl, emitSize, tempReg, op3Reg, 1, opt);
+                        shift = 1;
                     }
                     else if (intrin.id == NI_Sve2_Scatter32BitNarrowingNonTemporal)
                     {
-                        GetEmitter()->emitIns_R_R_I(INS_sve_lsl, emitSize, tempReg, op3Reg, 2, opt);
+                        shift = 2;
                     }
-                    else if (intrin.id == NI_Sve2_ScatterNonTemporal)
+                    else
                     {
-                        assert(emitActualTypeSize(intrin.baseType) == 8);
-                        GetEmitter()->emitIns_R_R_I(INS_sve_lsl, emitSize, tempReg, op3Reg, 3, opt);
+                        assert(intrin.id == NI_Sve2_ScatterNonTemporal);
+                        shift = 3;
                     }
 
-                    // op2Reg and op3Reg are swapped
+                    // SVE2 instruction only directly support byte offsets. Convert indices to bytes.
+                    GetEmitter()->emitIns_R_R_I(INS_sve_lsl, emitSize, tempReg, op3Reg, shift, opt);
+
                     GetEmitter()->emitIns_R_R_R_R(ins, emitSize, op4Reg, op1Reg, tempReg, op2Reg, opt);
                 }
                 else
@@ -2467,6 +2469,21 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                 }
                 break;
             }
+
+            case NI_Sve2_Scatter8BitNarrowingNonTemporal:
+                if (!varTypeIsSIMD(intrin.op2->gtType))
+                {
+                    // Scatter...(Vector<T> mask, T* address, Vector<T2> indices, Vector<T> data)
+                    assert(intrin.numOperands == 4);
+                    GetEmitter()->emitIns_R_R_R_R(ins, emitSize, op4Reg, op1Reg, op3Reg, op2Reg, opt);
+                }
+                else
+                {
+                    // Scatter...(Vector<T> mask, Vector<T> addresses, Vector<T> data)
+                    assert(intrin.numOperands == 3);
+                    GetEmitter()->emitIns_R_R_R_R(ins, emitSize, op3Reg, op1Reg, op2Reg, REG_ZR, opt);
+                }
+                break;
 
             case NI_Sve2_Scatter16BitWithByteOffsetsNarrowingNonTemporal:
             case NI_Sve2_Scatter32BitWithByteOffsetsNarrowingNonTemporal:

--- a/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
+++ b/src/coreclr/jit/hwintrinsiccodegenarm64.cpp
@@ -2455,7 +2455,7 @@ void CodeGen::genHWIntrinsic(GenTreeHWIntrinsic* node)
                         shift = 3;
                     }
 
-                    // SVE2 instruction only directly support byte offsets. Convert indices to bytes.
+                    // The SVE2 instructions only support byte offsets. Convert indices to bytes.
                     GetEmitter()->emitIns_R_R_I(INS_sve_lsl, emitSize, tempReg, op3Reg, shift, opt);
 
                     GetEmitter()->emitIns_R_R_R_R(ins, emitSize, op4Reg, op1Reg, tempReg, op2Reg, opt);

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1365,6 +1365,19 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree, int* pDstCou
     // Build any immediates
     BuildHWIntrinsicImmediate(intrinsicTree, intrin);
 
+    // Build any additional special cases
+    switch (intrin.id)
+    {
+        case NI_Sve2_Scatter16BitNarrowingNonTemporal:
+        case NI_Sve2_Scatter32BitNarrowingNonTemporal:
+        case NI_Sve2_ScatterNonTemporal:
+            buildInternalFloatRegisterDefForNode(intrinsicTree, internalFloatRegCandidates());
+            break;
+
+        default:
+            break;
+    }
+
     // Build all Operands
     for (size_t opNum = 1; opNum <= intrin.numOperands; opNum++)
     {

--- a/src/coreclr/jit/lsraarm64.cpp
+++ b/src/coreclr/jit/lsraarm64.cpp
@@ -1371,7 +1371,10 @@ int LinearScan::BuildHWIntrinsic(GenTreeHWIntrinsic* intrinsicTree, int* pDstCou
         case NI_Sve2_Scatter16BitNarrowingNonTemporal:
         case NI_Sve2_Scatter32BitNarrowingNonTemporal:
         case NI_Sve2_ScatterNonTemporal:
-            buildInternalFloatRegisterDefForNode(intrinsicTree, internalFloatRegCandidates());
+            if (!varTypeIsSIMD(intrin.op2->gtType))
+            {
+                buildInternalFloatRegisterDefForNode(intrinsicTree, internalFloatRegCandidates());
+            }
             break;
 
         default:


### PR DESCRIPTION
Fixes #124750

There are three forms of scatter instructions supported by CoreCLR
* Vector of addresses
* A single address plus a vector of indices (vector length offsets)
* A single address plus a vector of byte offsets

There are encodings for all of these in SVE1.

SVE2 duplicates all the scatter instructions, providing non temporal versions of them. The encodings all match SVE1, except for the indices version, which is missing. This can be replicated by simply shifting the offsets before calling the instruction (and is exactly what happens in the equivalent C++ instrinsics).

Therefore, ensure there is a temp register to hold the shifted value.