### PR TITLE
Revert forwarding activation signal

### DIFF
--- a/src/coreclr/pal/src/exception/signal.cpp
+++ b/src/coreclr/pal/src/exception/signal.cpp
@@ -970,20 +970,22 @@ static void inject_activation_handler(int code, siginfo_t *siginfo, void *contex
             CONTEXTToNativeContext(&winContext, ucontext);
         }
     }
-
-    // Call the original handler when it is not ignored or default (terminate).
-    if (g_previous_activation.sa_flags & SA_SIGINFO)
-    {
-        _ASSERTE(g_previous_activation.sa_sigaction != NULL);
-        g_previous_activation.sa_sigaction(code, siginfo, context);
-    }
     else
     {
-        if (g_previous_activation.sa_handler != SIG_IGN &&
-            g_previous_activation.sa_handler != SIG_DFL)
+        // Call the original handler when it is not ignored or default (terminate).
+        if (g_previous_activation.sa_flags & SA_SIGINFO)
         {
-            _ASSERTE(g_previous_activation.sa_handler != NULL);
-            g_previous_activation.sa_handler(code);
+            _ASSERTE(g_previous_activation.sa_sigaction != NULL);
+            g_previous_activation.sa_sigaction(code, siginfo, context);
+        }
+        else
+        {
+            if (g_previous_activation.sa_handler != SIG_IGN &&
+                g_previous_activation.sa_handler != SIG_DFL)
+            {
+                _ASSERTE(g_previous_activation.sa_handler != NULL);
+                g_previous_activation.sa_handler(code);
+            }
         }
     }
 }


### PR DESCRIPTION
Recent change to fix lookup of current thread in the activation handler also added forwarding of the activation signal to the previously registered handler. That part of the change was unrelated to the actual issue the change was fixing. It turned out that it breaks vsdbg that doesn't expect to get the SIGUSR1 used for the activation on macOS.

This change reverts that part of the change to unblock vsdbg.