### PR TITLE
Adjust how we access thread ID for header thin locks

### DIFF
--- a/src/coreclr/vm/comsynchronizable.cpp
+++ b/src/coreclr/vm/comsynchronizable.cpp
@@ -855,7 +855,7 @@ FCIMPL1(ObjHeader::HeaderLockResult, ObjHeader_AcquireThinLock, Object* obj)
 {
     FCALL_CONTRACT;
 
-    return obj->GetHeader()->AcquireHeaderThinLock(GetThread()->GetThreadId());
+    return obj->GetHeader()->AcquireHeaderThinLock(GetThread());
 }
 FCIMPLEND
 
@@ -863,7 +863,7 @@ FCIMPL1(ObjHeader::HeaderLockResult, ObjHeader_ReleaseThinLock, Object* obj)
 {
     FCALL_CONTRACT;
 
-    return obj->GetHeader()->ReleaseHeaderThinLock(GetThread()->GetThreadId());
+    return obj->GetHeader()->ReleaseHeaderThinLock(GetThread());
 }
 FCIMPLEND
 

--- a/src/coreclr/vm/syncblk.h
+++ b/src/coreclr/vm/syncblk.h
@@ -954,9 +954,9 @@ class ObjHeader
         UseSlowPath = 2
     };
 
-    HeaderLockResult AcquireHeaderThinLock(DWORD tid);
+    HeaderLockResult AcquireHeaderThinLock(Thread* pCurThread);
 
-    HeaderLockResult ReleaseHeaderThinLock(DWORD tid);
+    HeaderLockResult ReleaseHeaderThinLock(Thread* pCurThread);
 
     friend struct ::cdac_data<ObjHeader>;
 };


### PR DESCRIPTION
Pass the `Thread*` object instead of the thread ID and only compute thread ID in the paths that need it to convince the compiler to better separate memory accesses for better pipelining.

This brings the emitted assembly of the .NET 11 implementation closer to the .NET 10 implementation, which I think should be enough to get performance back (as the assembly is darn near identical at this point, arguably better for the new implementation).

Fixes https://github.com/dotnet/perf-autofiling-issues/issues/64673
Fixes https://github.com/dotnet/runtime/issues/121350