### PR TITLE
[release/10.0] GC handle DAC bugfix

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -7571,12 +7571,23 @@ void DacHandleWalker::WalkHandles()
 
     mEnumerated = true;
 
-    // The table slots are based on the number of GC heaps in the process.
-    int max_slots = 1;
+    // The GC sets the number of slots based on the number of processors. Prior to
+    // DATAS, num_processors == GCHeapCount() for ServerGC. Unfortunately the GC DAC
+    // contract didn't record the number of processors independently until minor
+    // version 8 and DATAS was enabled prior to that. When using a standalone GC version
+    // < 8 the DAC approximates the processor count as GCHeapCount() because we don't
+    // have more accurate data to work with. This may cause handle enumeration to be
+    // incomplete.
+    uint32_t max_slots = 1;
 
 #ifdef FEATURE_SVR_GC
     if (GCHeapUtilities::IsServerHeap())
-        max_slots = GCHeapCount();
+    {
+        if (g_gcDacGlobals->minor_version_number >= 8)
+            max_slots = *g_gcDacGlobals->g_totalCpuCount;
+        else
+            max_slots = GCHeapCount();
+    }
 #endif // FEATURE_SVR_GC
 
     DacHandleWalkerParam param(&mList);
@@ -7588,9 +7599,9 @@ void DacHandleWalker::WalkHandles()
         {
             if (map->pBuckets[i] != NULL)
             {
-                for (int j = 0; j < max_slots && SUCCEEDED(param.Result); ++j)
+                for (uint32_t j = 0; j < max_slots && SUCCEEDED(param.Result); ++j)
                 {
-                    DPTR(dac_handle_table) hTable = map->pBuckets[i]->pTable[j];
+                    DPTR(dac_handle_table) hTable = map->pBuckets[i]->pTable[(int)j];
                     if (hTable)
                     {
                         // handleType is the integer from 1 -> HANDLE_MAX_INTERNAL_TYPES based on the requested handle kinds to walk.

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -53537,7 +53537,6 @@ void PopulateDacVars(GcDacVars *gcDacVars)
 {
     bool v2 = gcDacVars->minor_version_number >= 2;
     bool v4 = gcDacVars->minor_version_number >= 4;
-    bool v6 = gcDacVars->minor_version_number >= 6;
     bool v8 = gcDacVars->minor_version_number >= 8;
 
 #define DEFINE_FIELD(field_name, field_type) offsetof(CLASS_NAME, field_name),

--- a/src/coreclr/gc/gc.cpp
+++ b/src/coreclr/gc/gc.cpp
@@ -46,6 +46,8 @@
 #include "vxsort/do_vxsort.h"
 #endif
 
+extern uint32_t g_totalCpuCount;
+
 #ifdef SERVER_GC
 namespace SVR {
 #else // SERVER_GC
@@ -53535,6 +53537,8 @@ void PopulateDacVars(GcDacVars *gcDacVars)
 {
     bool v2 = gcDacVars->minor_version_number >= 2;
     bool v4 = gcDacVars->minor_version_number >= 4;
+    bool v6 = gcDacVars->minor_version_number >= 6;
+    bool v8 = gcDacVars->minor_version_number >= 8;
 
 #define DEFINE_FIELD(field_name, field_type) offsetof(CLASS_NAME, field_name),
 #define DEFINE_DPTR_FIELD(field_name, field_type) offsetof(CLASS_NAME, field_name),
@@ -53566,7 +53570,7 @@ void PopulateDacVars(GcDacVars *gcDacVars)
     // work differently than .Net SOS.  When making breaking changes here you may need to
     // find NativeAOT's equivalent of SOS_BREAKING_CHANGE_VERSION and increment it.
     gcDacVars->major_version_number = 2;
-    gcDacVars->minor_version_number = 4;
+    gcDacVars->minor_version_number = 8;
     if (v2)
     {
         gcDacVars->total_bookkeeping_elements = total_bookkeeping_elements;
@@ -53671,6 +53675,12 @@ void PopulateDacVars(GcDacVars *gcDacVars)
 #else
         gcDacVars->dynamic_adaptation_mode = nullptr;
 #endif //DYNAMIC_HEAP_COUNT
+    }
+    if (v8)
+    {
+#ifdef MULTIPLE_HEAPS
+        gcDacVars->g_totalCpuCount = &::g_totalCpuCount;
+#endif // MULTIPLE_HEAPS
     }
 }
 

--- a/src/coreclr/gc/gcinterface.dacvars.def
+++ b/src/coreclr/gc/gcinterface.dacvars.def
@@ -91,6 +91,9 @@ GC_DAC_VAL        (size_t,                card_table_info_size)
 // Here is where v5.4 fields starts
 GC_DAC_VAR        (int,                   dynamic_adaptation_mode)
 
+// Here is where v5.8 fields start
+GC_DAC_VAR    (uint32_t,              g_totalCpuCount)
+
 #undef GC_DAC_VAR
 #undef GC_DAC_ARRAY_VAR
 #undef GC_DAC_PTR_VAR

--- a/src/coreclr/gc/gcinterface.h
+++ b/src/coreclr/gc/gcinterface.h
@@ -11,7 +11,7 @@
 // The minor version of the IGCHeap interface. Non-breaking changes are required
 // to bump the minor version number. GCs and EEs with minor version number
 // mismatches can still interoperate correctly, with some care.
-#define GC_INTERFACE_MINOR_VERSION 5
+#define GC_INTERFACE_MINOR_VERSION 8
 
 // The major version of the IGCToCLR interface. Breaking changes to this interface
 // require bumps in the major version number.

--- a/src/coreclr/gc/unix/gcenv.unix.cpp
+++ b/src/coreclr/gc/unix/gcenv.unix.cpp
@@ -138,7 +138,7 @@ typedef cpuset_t cpu_set_t;
 #endif
 
 // The cached total number of CPUs that can be used in the OS.
-static uint32_t g_totalCpuCount = 0;
+uint32_t g_totalCpuCount = 0;
 
 bool CanFlushUsingMembarrier()
 {

--- a/src/coreclr/gc/windows/gcenv.windows.cpp
+++ b/src/coreclr/gc/windows/gcenv.windows.cpp
@@ -19,6 +19,9 @@ GCSystemInfo g_SystemInfo;
 
 static bool g_SeLockMemoryPrivilegeAcquired = false;
 
+// The cached total number of CPUs that can be used in the OS.
+uint32_t g_totalCpuCount = 0;
+
 static AffinitySet g_processAffinitySet;
 
 namespace {
@@ -1106,14 +1109,17 @@ uint64_t GCToOSInterface::GetLowPrecisionTimeStamp()
 //  Number of processors on the machine
 uint32_t GCToOSInterface::GetTotalProcessorCount()
 {
+    if (g_totalCpuCount != 0)
+        return g_totalCpuCount;
     if (CanEnableGCCPUGroups())
     {
-        return g_nProcessors;
+        g_totalCpuCount = g_nProcessors;
     }
     else
     {
-        return g_SystemInfo.dwNumberOfProcessors;
+        g_totalCpuCount = g_SystemInfo.dwNumberOfProcessors;
     }
+    return g_totalCpuCount;
 }
 
 bool GCToOSInterface::CanEnableGCNumaAware()


### PR DESCRIPTION
Backport of #124875 to release/10.0

## Customer Impact

- [ ] Customer reported
- [x] Found internally


This affects the GetHandleEnum, GetHandleEnumForTypes, and GetHandleEnumForGC DAC APIs. A [bug](https://github.com/dotnet/runtime/issues/124872) was found in #124760 where the number of handle tables per bucket is assumed to be equal to the number of heaps in the server-GC mode. However, it is actually fixed at the number of processors; with DATAs enabled, these two may diverge and cause an incomplete enumeration of GC handles. This fix sets the correct bounds for this DAC APIs.

## Regression

- [x] Yes
- [ ] No

Since introduction of DATAs, handle enumeration may not be complete.

## Testing

Tested locally

## Risk

Low. The change corrects bounds for a single DAC enumeration loop.