### PR TITLE
[Tests][UserEvents] Improve test timing and re-enable tests

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -146,7 +146,7 @@
     <!-- Testing -->
     <MicrosoftNETCoreCoreDisToolsVersion>1.6.0</MicrosoftNETCoreCoreDisToolsVersion>
     <MicrosoftNETTestSdkVersion>17.4.0-preview-20220707-01</MicrosoftNETTestSdkVersion>
-    <MicrosoftOneCollectRecordTraceVersion>0.1.33304</MicrosoftOneCollectRecordTraceVersion>
+    <MicrosoftOneCollectRecordTraceVersion>0.1.33421</MicrosoftOneCollectRecordTraceVersion>
     <NUnitVersion>3.12.0</NUnitVersion>
     <NUnit3TestAdapterVersion>4.5.0</NUnit3TestAdapterVersion>
     <CoverletCollectorVersion>6.0.4</CoverletCollectorVersion>

--- a/src/tests/tracing/userevents/Directory.Build.props
+++ b/src/tests/tracing/userevents/Directory.Build.props
@@ -3,9 +3,6 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>
-    <!-- ActiveIssue https://github.com/dotnet/runtime/issues/123442 -->
-    <CLRTestTargetUnsupported>true</CLRTestTargetUnsupported>
-
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' == 'Mono'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
 </Project>

--- a/src/tests/tracing/userevents/activity/activity.cs
+++ b/src/tests/tracing/userevents/activity/activity.cs
@@ -165,7 +165,8 @@ namespace Tracing.UserEvents.Tests.Activity
                 args,
                 "activity",
                 ActivityTracee,
-                s_traceValidator);
+                s_traceValidator,
+                ActivityEventSource.Log);
         }
     }
 

--- a/src/tests/tracing/userevents/activity/activity.cs
+++ b/src/tests/tracing/userevents/activity/activity.cs
@@ -45,7 +45,7 @@ namespace Tracing.UserEvents.Tests.Activity
             ActivityEventSource.Log.QueryStop();
         }
 
-        private static readonly Func<EventPipeEventSource, bool> s_traceValidator = source =>
+        private static readonly Func<int, EventPipeEventSource, bool> s_traceValidator = (traceePid, source) =>
         {
             Guid firstWorkActivityId = Guid.Empty;
             Guid secondWorkActivityId = Guid.Empty;
@@ -60,8 +60,16 @@ namespace Tracing.UserEvents.Tests.Activity
             Guid secondWorkQuery1RelatedActivityId = Guid.Empty;
             Guid secondWorkQuery2RelatedActivityId = Guid.Empty;
 
+            int eventsFromOtherProcesses = 0;
+
             source.Dynamic.All += e =>
             {
+                if (e.ProcessID != traceePid)
+                {
+                    eventsFromOtherProcesses++;
+                    return;
+                }
+
                 if (!string.Equals(e.ProviderName, "DemoActivityIDs", StringComparison.Ordinal))
                 {
                     return;
@@ -114,9 +122,14 @@ namespace Tracing.UserEvents.Tests.Activity
 
             source.Process();
 
+            if (eventsFromOtherProcesses > 0)
+            {
+                Console.WriteLine($"Ignored {eventsFromOtherProcesses} events from processes other than tracee (PID {traceePid}).");
+            }
+
             if (firstWorkActivityId == Guid.Empty || secondWorkActivityId == Guid.Empty)
             {
-                Console.Error.WriteLine("The trace did not contain two WorkStart events with ActivityIds for RequestA and RequestB.");
+                Console.Error.WriteLine($"The trace did not contain two WorkStart events with ActivityIds for RequestA and RequestB from tracee PID {traceePid}.");
                 return false;
             }
 

--- a/src/tests/tracing/userevents/basic/basic.cs
+++ b/src/tests/tracing/userevents/basic/basic.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using System.Threading;
 using Tracing.UserEvents.Tests.Common;
 using Microsoft.Diagnostics.Tracing;
@@ -62,13 +63,27 @@ namespace Tracing.UserEvents.Tests.Basic
             return allocationSampledEventFound;
         };
 
+        private static EventSource FindNativeRuntimeEventSource()
+        {
+            foreach (EventSource source in EventSource.GetSources())
+            {
+                if (string.Equals(source.Name, "Microsoft-Windows-DotNETRuntime", StringComparison.Ordinal))
+                {
+                    return source;
+                }
+            }
+
+            throw new InvalidOperationException("NativeRuntimeEventSource should always be registered and found in EventSource.GetSources().");
+        }
+
         public static int Main(string[] args)
         {
             return UserEventsTestRunner.Run(
                 args,
                 "basic",
                 BasicTracee,
-                s_traceValidator);
+                s_traceValidator,
+                FindNativeRuntimeEventSource());
         }
     }
 }

--- a/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
+++ b/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
@@ -283,8 +283,19 @@ namespace Tracing.UserEvents.Tests.Common
                 {
                     foreach (FileInfo fi in ipc)
                     {
-                        Console.WriteLine($"Deleting zombie diagnostic port: {fi.FullName}");
-                        fi.Delete();
+                        try
+                        {
+                            Console.WriteLine($"Deleting zombie diagnostic port: {fi.FullName}");
+                            fi.Delete();
+                        }
+                        catch (UnauthorizedAccessException)
+                        {
+                            Console.WriteLine($"Skipping zombie diagnostic port (permission denied): {fi.FullName}");
+                        }
+                        catch (IOException)
+                        {
+                            Console.WriteLine($"Skipping zombie diagnostic port (I/O error): {fi.FullName}");
+                        }
                     }
                 }
                 else
@@ -295,8 +306,19 @@ namespace Tracing.UserEvents.Tests.Common
                         var duplicates = ipc.OrderBy(fileInfo => fileInfo.CreationTime.Ticks).SkipLast(1);
                         foreach (FileInfo fi in duplicates)
                         {
-                            Console.WriteLine($"Deleting duplicate diagnostic port: {fi.FullName}");
-                            fi.Delete();
+                            try
+                            {
+                                Console.WriteLine($"Deleting duplicate diagnostic port: {fi.FullName}");
+                                fi.Delete();
+                            }
+                            catch (UnauthorizedAccessException)
+                            {
+                                Console.WriteLine($"Skipping duplicate diagnostic port (permission denied): {fi.FullName}");
+                            }
+                            catch (IOException)
+                            {
+                                Console.WriteLine($"Skipping duplicate diagnostic port (I/O error): {fi.FullName}");
+                            }
                         }
                     }
                 }

--- a/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
+++ b/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
@@ -38,7 +38,7 @@ namespace Tracing.UserEvents.Tests.Common
             string[] args,
             string scenarioName,
             Action traceeAction,
-            Func<EventPipeEventSource, bool> traceValidator,
+            Func<int, EventPipeEventSource, bool> traceValidator,
             int traceeExitTimeout = DefaultTraceeExitTimeoutMs,
             int recordTraceExitTimeout = DefaultRecordTraceExitTimeoutMs)
         {
@@ -59,7 +59,7 @@ namespace Tracing.UserEvents.Tests.Common
 
         private static int RunOrchestrator(
             string scenarioName,
-            Func<EventPipeEventSource, bool> traceValidator,
+            Func<int, EventPipeEventSource, bool> traceValidator,
             int traceeExitTimeout,
             int recordTraceExitTimeout)
         {
@@ -227,7 +227,7 @@ namespace Tracing.UserEvents.Tests.Common
             }
 
             using EventPipeEventSource source = new EventPipeEventSource(traceFilePath);
-            if (!traceValidator(source))
+            if (!traceValidator(traceePid, source))
             {
                 Console.Error.WriteLine($"Trace file `{traceFilePath}` does not contain expected events.");
                 UploadTraceFileFromHelix(traceFilePath, scenarioName);

--- a/src/tests/tracing/userevents/custommetadata/custommetadata.cs
+++ b/src/tests/tracing/userevents/custommetadata/custommetadata.cs
@@ -83,7 +83,8 @@ namespace Tracing.UserEvents.Tests.CustomMetadata
                 args,
                 "custommetadata",
                 CustomMetadataTracee,
-                s_traceValidator);
+                s_traceValidator,
+                CustomMetadataEventSource.Log);
         }
     }
 

--- a/src/tests/tracing/userevents/managedevent/managedevent.cs
+++ b/src/tests/tracing/userevents/managedevent/managedevent.cs
@@ -71,7 +71,8 @@ namespace Tracing.UserEvents.Tests.ManagedEvent
                 args,
                 "managedevent",
                 ManagedEventTracee,
-                s_traceValidator);
+                s_traceValidator,
+                ManagedUserEventSource.Log);
         }
     }
 

--- a/src/tests/tracing/userevents/multithread/multithread.cs
+++ b/src/tests/tracing/userevents/multithread/multithread.cs
@@ -110,7 +110,8 @@ namespace Tracing.UserEvents.Tests.MultiThread
                 args,
                 "multithread",
                 MultiThreadTracee,
-                s_traceValidator);
+                s_traceValidator,
+                MultiThreadEventSource.Log);
         }
     }
 }


### PR DESCRIPTION
Fix flaky userevents tracing tests

Fixes #123442

## Root Causes

Investigation identified three independent causes of test flakiness:

### 1. Race between tracee event generation and record-trace setup

record-trace must discover the tracee process, send an EventPipe IPC command (which the runtime processes to register user_events tracepoints), and enable its PerfSession (ring buffer collection) before the tracee writes any events. The tracee has no callback to know when these steps are complete. With the original 200ms delay, the tracee could write events before PerfSession was enabled — a race observed when the tracee is discovered during record-trace's `/proc` scan. Events written in this window are silently lost.

Empirically measured on a 2-core system, which CI runs on and hit the failures more frequently than my local WSL2 environment, both tracepoint registration and PerfSession enable completed within 229ms (p99). The delay is increased to 700ms, providing a ~3x safety margin.

### 2. Cross-process event contamination

record-trace captures events from all .NET processes on the machine, not just the tracee. On CI machines running multiple .NET processes, the trace validators could match events from unrelated processes or fail to find the tracee's events among the noise.

Each validator now receives the tracee's PID and filters events by `ProcessID`, ignoring events from other processes.

### 3. Permission errors cleaning up diagnostic ports

`EnsureCleanDiagnosticPorts` deletes zombie diagnostic IPC sockets in `/tmp`, but on shared CI machines these sockets may be owned by other users. `UnauthorizedAccessException` and `IOException` during deletion would crash the test before it even started.

These exceptions are now caught and logged, allowing the test to proceed.

## Additional Improvements

- **Output ordering**: Subprocess stderr is routed to stdout with `[stdout]`/`[stderr]` tags so test output appears in chronological order, making timing-sensitive failures easier to diagnose.
- **record-trace version**: Bumped from 0.1.33304 to 0.1.33421 to pick up fixes for EventPipe IPC handling.

## Validation

Stress-tested with 500 consecutive runs (100 per scenario) on a 2-core system — **500/500 passed** (0% failure rate, up from ~65% with the original code).
