### PR TITLE
[cDAC] Add managed definitions for IXCLRData COM interfaces

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ICLRData.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ICLRData.cs
@@ -57,6 +57,31 @@ public unsafe partial interface ICLRDataTarget
 }
 
 [GeneratedComInterface]
+[Guid("6d05fae3-189c-4630-a6dc-1c251e1c01ab")]
+public unsafe partial interface ICLRDataTarget2 : ICLRDataTarget
+{
+    [PreserveSig]
+    int AllocVirtual(ulong addr, uint size, uint typeFlags, uint protectFlags, ulong* virt);
+    [PreserveSig]
+    int FreeVirtual(ulong addr, uint size, uint typeFlags);
+}
+
+// Note: ICLRDataTarget3 from clrdata.idl (guid a5664f95...) extends ICLRDataTarget2.
+// IXCLRDataTarget3 from xclrdata.idl (guid 59d9b5e1...) also extends ICLRDataTarget2 but is a different interface.
+// ICLRDataTarget3 is defined here; IXCLRDataTarget3 is in IXCLRData.cs.
+[GeneratedComInterface]
+[Guid("a5664f95-0af4-4a1b-960e-2f3346b4214c")]
+public unsafe partial interface ICLRDataTarget3 : ICLRDataTarget2
+{
+    [PreserveSig]
+    int GetExceptionRecord(uint bufferSize, uint* bufferUsed, byte* buffer);
+    [PreserveSig]
+    int GetExceptionContextRecord(uint bufferSize, uint* bufferUsed, byte* buffer);
+    [PreserveSig]
+    int GetExceptionThreadID(uint* threadID);
+}
+
+[GeneratedComInterface]
 [Guid("17d5b8c6-34a9-407f-af4f-a930201d4e02")]
 public unsafe partial interface ICLRContractLocator
 {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ICLRData.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ICLRData.cs
@@ -61,9 +61,9 @@ public unsafe partial interface ICLRDataTarget
 public unsafe partial interface ICLRDataTarget2 : ICLRDataTarget
 {
     [PreserveSig]
-    int AllocVirtual(ulong addr, uint size, uint typeFlags, uint protectFlags, ulong* virt);
+    int AllocVirtual(ClrDataAddress addr, uint size, uint typeFlags, uint protectFlags, ClrDataAddress* virt);
     [PreserveSig]
-    int FreeVirtual(ulong addr, uint size, uint typeFlags);
+    int FreeVirtual(ClrDataAddress addr, uint size, uint typeFlags);
 }
 
 // Note: ICLRDataTarget3 from clrdata.idl (guid a5664f95...) extends ICLRDataTarget2.

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/IXCLRData.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/IXCLRData.cs
@@ -581,3 +581,564 @@ public unsafe partial interface IXCLRDataMethodInstance
     [PreserveSig]
     int GetRepresentativeEntryAddress(ClrDataAddress* addr);
 }
+
+[GeneratedComInterface]
+[Guid("7CA04601-C702-4670-A63C-FA44F7DA7BD5")]
+public unsafe partial interface IXCLRDataAppDomain
+{
+    [PreserveSig]
+    int GetProcess(/*IXCLRDataProcess*/ void** process);
+    [PreserveSig]
+    int GetName(uint bufLen, uint* nameLen, char* name);
+    [PreserveSig]
+    int GetUniqueID(ulong* id);
+    [PreserveSig]
+    int GetFlags(uint* flags);
+    [PreserveSig]
+    int IsSameObject(/*IXCLRDataAppDomain*/ void* appDomain);
+    [PreserveSig]
+    int GetManagedObject(/*IXCLRDataValue*/ void** value);
+    [PreserveSig]
+    int Request(uint reqCode, uint inBufferSize, byte* inBuffer, uint outBufferSize, byte* outBuffer);
+}
+
+[GeneratedComInterface]
+[Guid("2FA17588-43C2-46ab-9B51-C8F01E39C9AC")]
+public unsafe partial interface IXCLRDataAssembly
+{
+    [PreserveSig]
+    int StartEnumModules(ulong* handle);
+    [PreserveSig]
+    int EnumModule(ulong* handle, /*IXCLRDataModule*/ void** mod);
+    [PreserveSig]
+    int EndEnumModules(ulong handle);
+
+    [PreserveSig]
+    int GetName(uint bufLen, uint* nameLen, char* name);
+    [PreserveSig]
+    int GetFileName(uint bufLen, uint* nameLen, char* name);
+    [PreserveSig]
+    int GetFlags(uint* flags);
+    [PreserveSig]
+    int IsSameObject(/*IXCLRDataAssembly*/ void* assembly);
+
+    [PreserveSig]
+    int Request(uint reqCode, uint inBufferSize, byte* inBuffer, uint outBufferSize, byte* outBuffer);
+
+    [PreserveSig]
+    int StartEnumAppDomains(ulong* handle);
+    [PreserveSig]
+    int EnumAppDomain(ulong* handle, /*IXCLRDataAppDomain*/ void** appDomain);
+    [PreserveSig]
+    int EndEnumAppDomains(ulong handle);
+
+    [PreserveSig]
+    int GetDisplayName(uint bufLen, uint* nameLen, char* name);
+}
+
+[GeneratedComInterface]
+[Guid("4675666C-C275-45b8-9F6C-AB165D5C1E09")]
+public unsafe partial interface IXCLRDataTypeDefinition
+{
+    [PreserveSig]
+    int GetModule(/*IXCLRDataModule*/ void** mod);
+
+    [PreserveSig]
+    int StartEnumMethodDefinitions(ulong* handle);
+    [PreserveSig]
+    int EnumMethodDefinition(ulong* handle, /*IXCLRDataMethodDefinition*/ void** methodDefinition);
+    [PreserveSig]
+    int EndEnumMethodDefinitions(ulong handle);
+
+    [PreserveSig]
+    int StartEnumMethodDefinitionsByName(char* name, uint flags, ulong* handle);
+    [PreserveSig]
+    int EnumMethodDefinitionByName(ulong* handle, /*IXCLRDataMethodDefinition*/ void** method);
+    [PreserveSig]
+    int EndEnumMethodDefinitionsByName(ulong handle);
+
+    [PreserveSig]
+    int GetMethodDefinitionByToken(/*mdMethodDef*/ uint token, /*IXCLRDataMethodDefinition*/ void** methodDefinition);
+
+    [PreserveSig]
+    int StartEnumInstances(/*IXCLRDataAppDomain*/ void* appDomain, ulong* handle);
+    [PreserveSig]
+    int EnumInstance(ulong* handle, /*IXCLRDataTypeInstance*/ void** instance);
+    [PreserveSig]
+    int EndEnumInstances(ulong handle);
+
+    [PreserveSig]
+    int GetName(uint flags, uint bufLen, uint* nameLen, char* nameBuf);
+    [PreserveSig]
+    int GetTokenAndScope(/*mdTypeDef*/ uint* token, /*IXCLRDataModule*/ void** mod);
+    [PreserveSig]
+    int GetCorElementType(/*CorElementType*/ uint* type);
+    [PreserveSig]
+    int GetFlags(uint* flags);
+    [PreserveSig]
+    int IsSameObject(/*IXCLRDataTypeDefinition*/ void* type);
+
+    [PreserveSig]
+    int Request(uint reqCode, uint inBufferSize, byte* inBuffer, uint outBufferSize, byte* outBuffer);
+
+    [PreserveSig]
+    int GetArrayRank(uint* rank);
+    [PreserveSig]
+    int GetBase(/*IXCLRDataTypeDefinition*/ void** @base);
+    [PreserveSig]
+    int GetNumFields(uint flags, uint* numFields);
+
+    [PreserveSig]
+    int StartEnumFields(uint flags, ulong* handle);
+    [PreserveSig]
+    int EnumField(
+        ulong* handle,
+        uint nameBufLen,
+        uint* nameLen,
+        char* nameBuf,
+        /*IXCLRDataTypeDefinition*/ void** type,
+        uint* flags,
+        /*mdFieldDef*/ uint* token);
+    [PreserveSig]
+    int EndEnumFields(ulong handle);
+
+    [PreserveSig]
+    int StartEnumFieldsByName(char* name, uint nameFlags, uint fieldFlags, ulong* handle);
+    [PreserveSig]
+    int EnumFieldByName(ulong* handle, /*IXCLRDataTypeDefinition*/ void** type, uint* flags, /*mdFieldDef*/ uint* token);
+    [PreserveSig]
+    int EndEnumFieldsByName(ulong handle);
+
+    [PreserveSig]
+    int GetFieldByToken(
+        /*mdFieldDef*/ uint token,
+        uint nameBufLen,
+        uint* nameLen,
+        char* nameBuf,
+        /*IXCLRDataTypeDefinition*/ void** type,
+        uint* flags);
+
+    [PreserveSig]
+    int GetTypeNotification(uint* flags);
+    [PreserveSig]
+    int SetTypeNotification(uint flags);
+
+    [PreserveSig]
+    int EnumField2(
+        ulong* handle,
+        uint nameBufLen,
+        uint* nameLen,
+        char* nameBuf,
+        /*IXCLRDataTypeDefinition*/ void** type,
+        uint* flags,
+        /*IXCLRDataModule*/ void** tokenScope,
+        /*mdFieldDef*/ uint* token);
+    [PreserveSig]
+    int EnumFieldByName2(
+        ulong* handle,
+        /*IXCLRDataTypeDefinition*/ void** type,
+        uint* flags,
+        /*IXCLRDataModule*/ void** tokenScope,
+        /*mdFieldDef*/ uint* token);
+    [PreserveSig]
+    int GetFieldByToken2(
+        /*IXCLRDataModule*/ void* tokenScope,
+        /*mdFieldDef*/ uint token,
+        uint nameBufLen,
+        uint* nameLen,
+        char* nameBuf,
+        /*IXCLRDataTypeDefinition*/ void** type,
+        uint* flags);
+}
+
+[GeneratedComInterface]
+[Guid("4D078D91-9CB3-4b0d-97AC-28C8A5A82597")]
+public unsafe partial interface IXCLRDataTypeInstance
+{
+    [PreserveSig]
+    int StartEnumMethodInstances(ulong* handle);
+    [PreserveSig]
+    int EnumMethodInstance(ulong* handle, /*IXCLRDataMethodInstance*/ void** methodInstance);
+    [PreserveSig]
+    int EndEnumMethodInstances(ulong handle);
+
+    [PreserveSig]
+    int StartEnumMethodInstancesByName(char* name, uint flags, ulong* handle);
+    [PreserveSig]
+    int EnumMethodInstanceByName(ulong* handle, /*IXCLRDataMethodInstance*/ void** method);
+    [PreserveSig]
+    int EndEnumMethodInstancesByName(ulong handle);
+
+    [PreserveSig]
+    int GetNumStaticFields(uint* numFields);
+    [PreserveSig]
+    int GetStaticFieldByIndex(
+        uint index,
+        /*IXCLRDataTask*/ void* tlsTask,
+        /*IXCLRDataValue*/ void** field,
+        uint bufLen,
+        uint* nameLen,
+        char* nameBuf,
+        /*mdFieldDef*/ uint* token);
+
+    [PreserveSig]
+    int StartEnumStaticFieldsByName(char* name, uint flags, /*IXCLRDataTask*/ void* tlsTask, ulong* handle);
+    [PreserveSig]
+    int EnumStaticFieldByName(ulong* handle, /*IXCLRDataValue*/ void** value);
+    [PreserveSig]
+    int EndEnumStaticFieldsByName(ulong handle);
+
+    [PreserveSig]
+    int GetNumTypeArguments(uint* numTypeArgs);
+    [PreserveSig]
+    int GetTypeArgumentByIndex(uint index, /*IXCLRDataTypeInstance*/ void** typeArg);
+
+    [PreserveSig]
+    int GetName(uint flags, uint bufLen, uint* nameLen, char* nameBuf);
+    [PreserveSig]
+    int GetModule(/*IXCLRDataModule*/ void** mod);
+    [PreserveSig]
+    int GetDefinition(/*IXCLRDataTypeDefinition*/ void** typeDefinition);
+    [PreserveSig]
+    int GetFlags(uint* flags);
+    [PreserveSig]
+    int IsSameObject(/*IXCLRDataTypeInstance*/ void* type);
+
+    [PreserveSig]
+    int Request(uint reqCode, uint inBufferSize, byte* inBuffer, uint outBufferSize, byte* outBuffer);
+
+    [PreserveSig]
+    int GetNumStaticFields2(uint flags, uint* numFields);
+
+    [PreserveSig]
+    int StartEnumStaticFields(uint flags, /*IXCLRDataTask*/ void* tlsTask, ulong* handle);
+    [PreserveSig]
+    int EnumStaticField(ulong* handle, /*IXCLRDataValue*/ void** value);
+    [PreserveSig]
+    int EndEnumStaticFields(ulong handle);
+
+    [PreserveSig]
+    int StartEnumStaticFieldsByName2(char* name, uint nameFlags, uint fieldFlags, /*IXCLRDataTask*/ void* tlsTask, ulong* handle);
+    [PreserveSig]
+    int EnumStaticFieldByName2(ulong* handle, /*IXCLRDataValue*/ void** value);
+    [PreserveSig]
+    int EndEnumStaticFieldsByName2(ulong handle);
+
+    [PreserveSig]
+    int GetStaticFieldByToken(
+        /*mdFieldDef*/ uint token,
+        /*IXCLRDataTask*/ void* tlsTask,
+        /*IXCLRDataValue*/ void** field,
+        uint bufLen,
+        uint* nameLen,
+        char* nameBuf);
+
+    [PreserveSig]
+    int GetBase(/*IXCLRDataTypeInstance*/ void** @base);
+
+    [PreserveSig]
+    int EnumStaticField2(
+        ulong* handle,
+        /*IXCLRDataValue*/ void** value,
+        uint bufLen,
+        uint* nameLen,
+        char* nameBuf,
+        /*IXCLRDataModule*/ void** tokenScope,
+        /*mdFieldDef*/ uint* token);
+    [PreserveSig]
+    int EnumStaticFieldByName3(
+        ulong* handle,
+        /*IXCLRDataValue*/ void** value,
+        /*IXCLRDataModule*/ void** tokenScope,
+        /*mdFieldDef*/ uint* token);
+    [PreserveSig]
+    int GetStaticFieldByToken2(
+        /*IXCLRDataModule*/ void* tokenScope,
+        /*mdFieldDef*/ uint token,
+        /*IXCLRDataTask*/ void* tlsTask,
+        /*IXCLRDataValue*/ void** field,
+        uint bufLen,
+        uint* nameLen,
+        char* nameBuf);
+}
+
+public struct ClrDataMethodDefinitionExtent
+{
+    public ClrDataAddress startAddress;
+    public ClrDataAddress endAddress;
+    public uint enCVersion;
+    public uint /* CLRDataMethodDefinitionExtentType */ type;
+}
+
+[GeneratedComInterface]
+[Guid("AAF60008-FB2C-420b-8FB1-42D244A54A97")]
+public unsafe partial interface IXCLRDataMethodDefinition
+{
+    [PreserveSig]
+    int GetTypeDefinition(/*IXCLRDataTypeDefinition*/ void** typeDefinition);
+
+    [PreserveSig]
+    int StartEnumInstances(/*IXCLRDataAppDomain*/ void* appDomain, ulong* handle);
+    [PreserveSig]
+    int EnumInstance(ulong* handle, /*IXCLRDataMethodInstance*/ void** instance);
+    [PreserveSig]
+    int EndEnumInstances(ulong handle);
+
+    [PreserveSig]
+    int GetName(uint flags, uint bufLen, uint* nameLen, char* name);
+    [PreserveSig]
+    int GetTokenAndScope(/*mdMethodDef*/ uint* token, /*IXCLRDataModule*/ void** mod);
+    [PreserveSig]
+    int GetFlags(uint* flags);
+    [PreserveSig]
+    int IsSameObject(/*IXCLRDataMethodDefinition*/ void* method);
+    [PreserveSig]
+    int GetLatestEnCVersion(uint* version);
+
+    [PreserveSig]
+    int StartEnumExtents(ulong* handle);
+    [PreserveSig]
+    int EnumExtent(ulong* handle, ClrDataMethodDefinitionExtent* extent);
+    [PreserveSig]
+    int EndEnumExtents(ulong handle);
+
+    [PreserveSig]
+    int GetCodeNotification(uint* flags);
+    [PreserveSig]
+    int SetCodeNotification(uint flags);
+
+    [PreserveSig]
+    int Request(uint reqCode, uint inBufferSize, byte* inBuffer, uint outBufferSize, byte* outBuffer);
+
+    [PreserveSig]
+    int GetRepresentativeEntryAddress(ClrDataAddress* addr);
+    [PreserveSig]
+    int HasClassOrMethodInstantiation(int* bGeneric);
+}
+
+[GeneratedComInterface]
+[Guid("75DA9E4C-BD33-43C8-8F5C-96E8A5241F57")]
+public unsafe partial interface IXCLRDataExceptionState
+{
+    [PreserveSig]
+    int GetFlags(uint* flags);
+    [PreserveSig]
+    int GetPrevious(/*IXCLRDataExceptionState*/ void** exState);
+    [PreserveSig]
+    int GetManagedObject(/*IXCLRDataValue*/ void** value);
+    [PreserveSig]
+    int GetBaseType(/*CLRDataBaseExceptionType*/ uint* type);
+    [PreserveSig]
+    int GetCode(uint* code);
+    [PreserveSig]
+    int GetString(uint bufLen, uint* strLen, char* str);
+
+    [PreserveSig]
+    int Request(uint reqCode, uint inBufferSize, byte* inBuffer, uint outBufferSize, byte* outBuffer);
+
+    [PreserveSig]
+    int IsSameState(/*EXCEPTION_RECORD64*/ void* exRecord, uint contextSize, byte* cxRecord);
+    [PreserveSig]
+    int IsSameState2(uint flags, /*EXCEPTION_RECORD64*/ void* exRecord, uint contextSize, byte* cxRecord);
+    [PreserveSig]
+    int GetTask(/*IXCLRDataTask*/ void** task);
+}
+
+[GeneratedComInterface]
+[Guid("96EC93C7-1000-4e93-8991-98D8766E6666")]
+public unsafe partial interface IXCLRDataValue
+{
+    [PreserveSig]
+    int GetFlags(uint* flags);
+    [PreserveSig]
+    int GetAddress(ClrDataAddress* address);
+    [PreserveSig]
+    int GetSize(ulong* size);
+
+    [PreserveSig]
+    int GetBytes(uint bufLen, uint* dataSize, byte* buffer);
+    [PreserveSig]
+    int SetBytes(uint bufLen, uint* dataSize, byte* buffer);
+
+    [PreserveSig]
+    int GetType(/*IXCLRDataTypeInstance*/ void** typeInstance);
+
+    [PreserveSig]
+    int GetNumFields(uint* numFields);
+    [PreserveSig]
+    int GetFieldByIndex(
+        uint index,
+        /*IXCLRDataValue*/ void** field,
+        uint bufLen,
+        uint* nameLen,
+        char* nameBuf,
+        /*mdFieldDef*/ uint* token);
+
+    [PreserveSig]
+    int Request(uint reqCode, uint inBufferSize, byte* inBuffer, uint outBufferSize, byte* outBuffer);
+
+    [PreserveSig]
+    int GetNumFields2(uint flags, /*IXCLRDataTypeInstance*/ void* fromType, uint* numFields);
+
+    [PreserveSig]
+    int StartEnumFields(uint flags, /*IXCLRDataTypeInstance*/ void* fromType, ulong* handle);
+    [PreserveSig]
+    int EnumField(
+        ulong* handle,
+        /*IXCLRDataValue*/ void** field,
+        uint nameBufLen,
+        uint* nameLen,
+        char* nameBuf,
+        /*mdFieldDef*/ uint* token);
+    [PreserveSig]
+    int EndEnumFields(ulong handle);
+
+    [PreserveSig]
+    int StartEnumFieldsByName(char* name, uint nameFlags, uint fieldFlags, /*IXCLRDataTypeInstance*/ void* fromType, ulong* handle);
+    [PreserveSig]
+    int EnumFieldByName(ulong* handle, /*IXCLRDataValue*/ void** field, /*mdFieldDef*/ uint* token);
+    [PreserveSig]
+    int EndEnumFieldsByName(ulong handle);
+
+    [PreserveSig]
+    int GetFieldByToken(
+        /*mdFieldDef*/ uint token,
+        /*IXCLRDataValue*/ void** field,
+        uint bufLen,
+        uint* nameLen,
+        char* nameBuf);
+
+    [PreserveSig]
+    int GetAssociatedValue(/*IXCLRDataValue*/ void** assocValue);
+    [PreserveSig]
+    int GetAssociatedType(/*IXCLRDataTypeInstance*/ void** assocType);
+
+    [PreserveSig]
+    int GetString(uint bufLen, uint* strLen, char* str);
+
+    [PreserveSig]
+    int GetArrayProperties(uint* rank, uint* totalElements, uint numDim, uint* dims, uint numBases, int* bases);
+    [PreserveSig]
+    int GetArrayElement(uint numInd, int* indices, /*IXCLRDataValue*/ void** value);
+
+    [PreserveSig]
+    int EnumField2(
+        ulong* handle,
+        /*IXCLRDataValue*/ void** field,
+        uint nameBufLen,
+        uint* nameLen,
+        char* nameBuf,
+        /*IXCLRDataModule*/ void** tokenScope,
+        /*mdFieldDef*/ uint* token);
+    [PreserveSig]
+    int EnumFieldByName2(
+        ulong* handle,
+        /*IXCLRDataValue*/ void** field,
+        /*IXCLRDataModule*/ void** tokenScope,
+        /*mdFieldDef*/ uint* token);
+    [PreserveSig]
+    int GetFieldByToken2(
+        /*IXCLRDataModule*/ void* tokenScope,
+        /*mdFieldDef*/ uint token,
+        /*IXCLRDataValue*/ void** field,
+        uint bufLen,
+        uint* nameLen,
+        char* nameBuf);
+
+    [PreserveSig]
+    int GetNumLocations(uint* numLocs);
+    [PreserveSig]
+    int GetLocationByIndex(uint loc, uint* flags, ClrDataAddress* arg);
+}
+
+[GeneratedComInterface]
+[Guid("2D95A079-42A1-4837-818F-0B97D7048E0E")]
+public unsafe partial interface IXCLRDataExceptionNotification
+{
+    [PreserveSig]
+    int OnCodeGenerated(IXCLRDataMethodInstance* method);
+    [PreserveSig]
+    int OnCodeDiscarded(IXCLRDataMethodInstance* method);
+    [PreserveSig]
+    int OnProcessExecution(uint state);
+    [PreserveSig]
+    int OnTaskExecution(/*IXCLRDataTask*/ void* task, uint state);
+    [PreserveSig]
+    int OnModuleLoaded(/*IXCLRDataModule*/ void* mod);
+    [PreserveSig]
+    int OnModuleUnloaded(/*IXCLRDataModule*/ void* mod);
+    [PreserveSig]
+    int OnTypeLoaded(/*IXCLRDataTypeInstance*/ void* typeInst);
+    [PreserveSig]
+    int OnTypeUnloaded(/*IXCLRDataTypeInstance*/ void* typeInst);
+}
+
+[GeneratedComInterface]
+[Guid("31201a94-4337-49b7-aef7-0c755054091f")]
+public unsafe partial interface IXCLRDataExceptionNotification2 : IXCLRDataExceptionNotification
+{
+    [PreserveSig]
+    int OnAppDomainLoaded(/*IXCLRDataAppDomain*/ void* domain);
+    [PreserveSig]
+    int OnAppDomainUnloaded(/*IXCLRDataAppDomain*/ void* domain);
+    [PreserveSig]
+    int OnException(/*IXCLRDataExceptionState*/ void* exception);
+}
+
+[GeneratedComInterface]
+[Guid("31201a94-4337-49b7-aef7-0c7550540920")]
+public unsafe partial interface IXCLRDataExceptionNotification3 : IXCLRDataExceptionNotification2
+{
+    [PreserveSig]
+    int OnGcEvent(GcEvtArgs gcEvtArgs);
+}
+
+[GeneratedComInterface]
+[Guid("C25E926E-5F09-4AA2-BBAD-B7FC7F10CFD7")]
+public unsafe partial interface IXCLRDataExceptionNotification4 : IXCLRDataExceptionNotification3
+{
+    [PreserveSig]
+    int ExceptionCatcherEnter(IXCLRDataMethodInstance* catchingMethod, uint catcherNativeOffset);
+}
+
+[GeneratedComInterface]
+[Guid("e77a39ea-3548-44d9-b171-8569ed1a9423")]
+public unsafe partial interface IXCLRDataExceptionNotification5 : IXCLRDataExceptionNotification4
+{
+    [PreserveSig]
+    int OnCodeGenerated2(IXCLRDataMethodInstance* method, ClrDataAddress nativeCodeLocation);
+}
+
+// IXCLRDataTarget3 extends ICLRDataTarget2 which extends ICLRDataTarget (defined in ICLRData.cs).
+// See src/coreclr/inc/xclrdata.idl
+[GeneratedComInterface]
+[Guid("59d9b5e1-4a6f-4531-84c3-51d12da22fd4")]
+public unsafe partial interface IXCLRDataTarget3 : ICLRDataTarget2
+{
+    [PreserveSig]
+    int GetMetaData(
+        char* imagePath,
+        uint imageTimestamp,
+        uint imageSize,
+        Guid* mvid,
+        uint mdRva,
+        uint flags,
+        uint bufferSize,
+        byte* buffer,
+        uint* dataSize);
+}
+
+[GeneratedComInterface]
+[Guid("E5F3039D-2C0C-4230-A69E-12AF1C3E563C")]
+public unsafe partial interface IXCLRLibrarySupport
+{
+    [PreserveSig]
+    int LoadHardboundDependency(char* name, Guid* mvid, nuint* loadedBase);
+    [PreserveSig]
+    int LoadSoftboundDependency(char* name, byte* assemblymetadataBinding, byte* hash, uint hashLength, nuint* loadedBase);
+}
+
+// IXCLRDisassemblySupport and IXCLRDataDisplay are omitted because they use
+// varargs (...) and non-HRESULT return types (SIZE_T, BOOL, void*) that are
+// not expressible with [GeneratedComInterface]. These are NativeImageDumper
+// tooling interfaces and are not needed by the cDAC diagnostic path.


### PR DESCRIPTION
This PR adds managed `[GeneratedComInterface]` definitions for IXCLRData* and ICLRData* COM interfaces from `xclrdata.idl` and `clrdata.idl`.

## Changes

### New interface definitions (IXCLRData.cs)

Added managed definitions for 14 interfaces that were previously missing:
- `IXCLRDataAppDomain`
- `IXCLRDataAssembly`
- `IXCLRDataTypeDefinition`
- `IXCLRDataTypeInstance`
- `IXCLRDataMethodDefinition`
- `IXCLRDataExceptionState`
- `IXCLRDataValue`
- `IXCLRDataExceptionNotification` / `IXCLRDataExceptionNotification2` / `IXCLRDataExceptionNotification3` / `IXCLRDataExceptionNotification4` / `IXCLRDataExceptionNotification5`
- `IXCLRDataTarget3`
- `IXCLRLibrarySupport`

Also added the `ClrDataMethodDefinitionExtent` struct.

**Note:** `IXCLRDisassemblySupport` and `IXCLRDataDisplay` are intentionally omitted because they use varargs (`...`) and non-HRESULT return types incompatible with `[GeneratedComInterface]`.

### New interface definitions (ICLRData.cs)

Added managed definitions for 2 interfaces:
- `ICLRDataTarget2`
- `ICLRDataTarget3`

Also changed `ICLRDataTarget2.AllocVirtual` and `ICLRDataTarget2.FreeVirtual` address parameters from `ulong` to `ClrDataAddress` to match `CLRDATA_ADDRESS` in the IDL.

All GUIDs and vtable ordering verified against `src/coreclr/inc/xclrdata.idl` and `src/coreclr/inc/clrdata.idl`.

### Files changed
- **IXCLRData.cs** — 14 new interface definitions + `ClrDataMethodDefinitionExtent` struct
- **ICLRData.cs** — Added `ICLRDataTarget2`, `ICLRDataTarget3`, and `ClrDataAddress` fix