### PR TITLE
[clr-interp] Add reverse P/Invoke support for the Swift calling convention to the CoreCLR interpreter on arm64

### DIFF
--- a/src/coreclr/vm/arm64/asmconstants.h
+++ b/src/coreclr/vm/arm64/asmconstants.h
@@ -321,6 +321,9 @@ ASMCONSTANTS_C_ASSERT(OFFSETOF__InterpThreadContext__pStackPointer == offsetof(I
 #define OFFSETOF__CallStubHeader__HasSwiftError 0x0D
 ASMCONSTANTS_C_ASSERT(OFFSETOF__CallStubHeader__HasSwiftError == offsetof(CallStubHeader, HasSwiftError))
 
+#define OFFSETOF__CallStubHeader__HasSwiftReturnLowering 0x0E
+ASMCONSTANTS_C_ASSERT(OFFSETOF__CallStubHeader__HasSwiftReturnLowering == offsetof(CallStubHeader, HasSwiftReturnLowering))
+
 #define OFFSETOF__CallStubHeader__Routines 0x18
 ASMCONSTANTS_C_ASSERT(OFFSETOF__CallStubHeader__Routines == offsetof(CallStubHeader, Routines))
 

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -739,7 +739,6 @@ LOCAL_LABEL(HaveInterpThreadContext):
     add x10, x9, #OFFSETOF__CallStubHeader__Routines
     ldr x9, [x11, #OFFSETOF__InterpThreadContext__pStackPointer]
 #ifdef TARGET_APPLE
-    // Initialize Swift error value slot to zero (in extraLocals area)
     str xzr, [sp, #0]
 #endif
     // x19 contains IR bytecode address
@@ -747,19 +746,32 @@ LOCAL_LABEL(HaveInterpThreadContext):
     ldr x11, [x10], #8
     blr x11
 
-    // Skip ContinuationContext load if this is a Swift lowered return (x2 holds return data)
+    // Swift-specific epilog handling. There are three cases to consider:
+    //
+    // - Swift return lowering:
+    //    If HasSwiftReturnLowering is set, the return value was lowered and x2
+    //    may already contains the return data. In that case, do not load the
+    //    ContinuationContext from the stack.
+    //
+    // - Swift error set in UnmanagedCallersOnly:
+    //    If [sp, #0] is non-zero, a Swift error was set.
+    //    Restore x21 and return via the Swift-error epilog.
+    //
+    // - Swift error set in direct P/Invoke:
+    //    If HasSwiftError is set, use the Swift-error epilog.
+    //    Otherwise, use the normal epilog.
+
     ldrb w11, [x23, #OFFSETOF__CallStubHeader__HasSwiftReturnLowering]
     cbnz x11, LOCAL_LABEL(InterpreterStub_SkipSwiftReturnLowering)
     // Fill in the ContinuationContext register
     ldr x2, [sp, #(__PWTB_ArgumentRegister_FirstArg + 16)]
 LOCAL_LABEL(InterpreterStub_SkipSwiftReturnLowering):
 
-    // Check if this stub has Swift error handling
     ldr x11, [sp, #0]
-    cbz x11, LOCAL_LABEL(InterpreterStub_SkipSwiftError)
+    cbz x11, LOCAL_LABEL(InterpreterStub_SkipStoreSwiftError)
     mov x21, x11
     EPILOG_WITH_TRANSITION_BLOCK_RETURN_SKIP_SWIFT_ERROR
-LOCAL_LABEL(InterpreterStub_SkipSwiftError):
+LOCAL_LABEL(InterpreterStub_SkipStoreSwiftError):
 
     ldrb w11, [x23, #OFFSETOF__CallStubHeader__HasSwiftError]
     cbz x11, LOCAL_LABEL(InterpreterStub_Epilog)
@@ -1026,30 +1038,22 @@ NESTED_ENTRY InterpreterStubRet4Vector128, _TEXT, NoHandler
 NESTED_END InterpreterStubRet4Vector128, _TEXT
 
 #ifdef TARGET_APPLE
-// Swift lowered return handler for reverse PInvoke callbacks.
-// Calls ExecuteInterpretedMethod to get result, then chains to
-// Load_X*_AtOffset routines to decompose the struct return into registers.
+// Swift lowered return handler for reverse PInvoke callbacks
 NESTED_ENTRY SwiftReverseReturnLoweredHandler, _TEXT, NoHandler
-    // Save x10 (routines pointer) in the float argument area of the
-    // transition block (no longer needed after arg Store routines ran).
-    str x10, [sp, #0]
+    str x10, [sp, #0] // Save routines pointer
     PROLOG_SAVE_REG_PAIR_NO_FP_INDEXED   fp, lr, -16
     // The +16 is for the fp, lr above
     add x0, sp, #__PWTB_TransitionBlock + 16
     mov x1, x19 // the IR bytecode pointer
     mov x2, xzr
     bl C_FUNC(ExecuteInterpretedMethod)
-    // x0 = pointer to result struct on interpreter stack
-    mov x9, x0
-    // Restore x10 from the float arg area (sp+16 = pre-push sp, then +0)
-    ldr x10, [sp, #16]
-    // Chain to Load_X*_AtOffset routines for return decomposition
+    mov x9, x0 // x0 is pointer to result struct on interpreter stack
+    ldr x10, [sp, #16] // restore x10
     ldr x11, [x10], #8
     EPILOG_BRANCH_REG x11
 NESTED_END SwiftReverseReturnLoweredHandler, _TEXT
 
-// Terminator for reverse PInvoke Swift lowered return.
-// Restores fp/lr saved by SwiftReverseReturnLoweredHandler and returns.
+// Terminator for reverse PInvoke Swift lowered return
 LEAF_ENTRY SwiftReverseReturnLoweredTerminator
     ldp fp, lr, [sp], #16
     ret
@@ -1242,9 +1246,9 @@ LEAF_ENTRY Load_SwiftError
 LEAF_END Load_SwiftError
 
 LEAF_ENTRY Store_SwiftError
-    sub x11, fp, #__PWTB_StackAlloc  // Get address of error value slot from fp (stable across calls)
-    str x11, [x9], #8        // Pass address to managed code as SwiftError* parameter
-    ldr x11, [x10], #8       // Load next routine address
+    sub x11, fp, #__PWTB_StackAlloc
+    str x11, [x9], #8
+    ldr x11, [x10], #8
     EPILOG_BRANCH_REG x11
 LEAF_END Store_SwiftError
 
@@ -1255,8 +1259,7 @@ LEAF_ENTRY Load_SwiftIndirectResult
 LEAF_END Load_SwiftIndirectResult
 
 LEAF_ENTRY Store_SwiftSelf
-    // x20 was overwritten by INLINE_GETTHREAD; load original from [fp + 24].
-    ldr x11, [fp, #24]
+    ldr x11, [fp, #24] // x20 was overwritten by INLINE_GETTHREAD; load original from [fp + 24]
     str x11, [x9], #8
     ldr x11, [x10], #8
     EPILOG_BRANCH_REG x11
@@ -1365,8 +1368,7 @@ LEAF_ENTRY Load_Stack_AtOffset
     EPILOG_BRANCH_REG x11
 LEAF_END Load_Stack_AtOffset
 
-// Reverse direction: read from caller's stack frame and store to interpreter stack
-.macro Store_Stack_AtOffset_Common
+.macro Store_Stack_AtOffset_Prolog
     ldr x12, [x10], #8       // Load offset|structSize|stackOffset
     and w11, w12, #0xFFFF    // Extract offset (lower 16 bits)
     lsr x14, x12, #32        // Extract stackOffset (upper 32 bits)
@@ -1375,7 +1377,7 @@ LEAF_END Load_Stack_AtOffset
 .endm
 
 .macro Store_Stack_AtOffset_Epilog
-    str x13, [x9, x11]       // Store 8 bytes to [x9 + offset] (interpreter stack)
+    str x13, [x9, x11]       // Store 8 bytes to [x9 + offset]
     ubfx x12, x12, #16, #16  // Extract structSize (bits 16-31)
     add x9, x9, x12          // Advance x9 by structSize
     ldr x11, [x10], #8
@@ -1383,25 +1385,25 @@ LEAF_END Load_Stack_AtOffset
 .endm
 
 LEAF_ENTRY Store_Stack_AtOffset
-    Store_Stack_AtOffset_Common
+    Store_Stack_AtOffset_Prolog
     ldr x13, [x14]
     Store_Stack_AtOffset_Epilog
 LEAF_END Store_Stack_AtOffset
 
 LEAF_ENTRY Store_Stack_4B_AtOffset
-    Store_Stack_AtOffset_Common
+    Store_Stack_AtOffset_Prolog
     ldr w13, [x14]
     Store_Stack_AtOffset_Epilog
 LEAF_END Store_Stack_4B_AtOffset
 
 LEAF_ENTRY Store_Stack_2B_AtOffset
-    Store_Stack_AtOffset_Common
+    Store_Stack_AtOffset_Prolog
     ldrh w13, [x14]
     Store_Stack_AtOffset_Epilog
 LEAF_END Store_Stack_2B_AtOffset
 
 LEAF_ENTRY Store_Stack_1B_AtOffset
-    Store_Stack_AtOffset_Common
+    Store_Stack_AtOffset_Prolog
     ldrb w13, [x14]
     Store_Stack_AtOffset_Epilog
 LEAF_END Store_Stack_1B_AtOffset

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -746,20 +746,25 @@ LOCAL_LABEL(HaveInterpThreadContext):
     // Copy the arguments to the interpreter stack, invoke the InterpExecMethod and load the return value
     ldr x11, [x10], #8
     blr x11
+
+    // Skip ContinuationContext load if this is a Swift lowered return (x2 holds return data)
+    ldrb w11, [x23, #OFFSETOF__CallStubHeader__HasSwiftReturnLowering]
+    cbnz x11, LOCAL_LABEL(InterpreterStub_SkipSwiftReturnLowering)
     // Fill in the ContinuationContext register
     ldr x2, [sp, #(__PWTB_ArgumentRegister_FirstArg + 16)]
+LOCAL_LABEL(InterpreterStub_SkipSwiftReturnLowering):
 
     // Check if this stub has Swift error handling
     ldr x11, [sp, #0]
-    cbz x11, LOCAL_LABEL(InterpreterStub_NoReverseSwiftError)
+    cbz x11, LOCAL_LABEL(InterpreterStub_SkipSwiftError)
     mov x21, x11
     EPILOG_WITH_TRANSITION_BLOCK_RETURN_SKIP_SWIFT_ERROR
+LOCAL_LABEL(InterpreterStub_SkipSwiftError):
 
-LOCAL_LABEL(InterpreterStub_NoReverseSwiftError):
     ldrb w11, [x23, #OFFSETOF__CallStubHeader__HasSwiftError]
-    cbz x11, LOCAL_LABEL(InterpreterStub_NoSwiftError)
+    cbz x11, LOCAL_LABEL(InterpreterStub_Epilog)
     EPILOG_WITH_TRANSITION_BLOCK_RETURN_SKIP_SWIFT_ERROR
-LOCAL_LABEL(InterpreterStub_NoSwiftError):
+LOCAL_LABEL(InterpreterStub_Epilog):
     EPILOG_WITH_TRANSITION_BLOCK_RETURN
 
 NESTED_END InterpreterStub, _TEXT
@@ -1020,6 +1025,37 @@ NESTED_ENTRY InterpreterStubRet4Vector128, _TEXT, NoHandler
     EPILOG_RETURN
 NESTED_END InterpreterStubRet4Vector128, _TEXT
 
+#ifdef TARGET_APPLE
+// Swift lowered return handler for reverse PInvoke callbacks.
+// Calls ExecuteInterpretedMethod to get result, then chains to
+// Load_X*_AtOffset routines to decompose the struct return into registers.
+NESTED_ENTRY SwiftReverseReturnLoweredHandler, _TEXT, NoHandler
+    // Save x10 (routines pointer) in the float argument area of the
+    // transition block (no longer needed after arg Store routines ran).
+    str x10, [sp, #0]
+    PROLOG_SAVE_REG_PAIR_NO_FP_INDEXED   fp, lr, -16
+    // The +16 is for the fp, lr above
+    add x0, sp, #__PWTB_TransitionBlock + 16
+    mov x1, x19 // the IR bytecode pointer
+    mov x2, xzr
+    bl C_FUNC(ExecuteInterpretedMethod)
+    // x0 = pointer to result struct on interpreter stack
+    mov x9, x0
+    // Restore x10 from the float arg area (sp+16 = pre-push sp, then +0)
+    ldr x10, [sp, #16]
+    // Chain to Load_X*_AtOffset routines for return decomposition
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+NESTED_END SwiftReverseReturnLoweredHandler, _TEXT
+
+// Terminator for reverse PInvoke Swift lowered return.
+// Restores fp/lr saved by SwiftReverseReturnLoweredHandler and returns.
+LEAF_ENTRY SwiftReverseReturnLoweredTerminator
+    ldp fp, lr, [sp], #16
+    ret
+LEAF_END SwiftReverseReturnLoweredTerminator
+#endif // TARGET_APPLE
+
 // Copy arguments from the processor stack to the interpreter stack
 // The CPU stack slots are aligned to pointer size.
 
@@ -1218,6 +1254,20 @@ LEAF_ENTRY Load_SwiftIndirectResult
     EPILOG_BRANCH_REG x11
 LEAF_END Load_SwiftIndirectResult
 
+LEAF_ENTRY Store_SwiftSelf
+    // x20 was overwritten by INLINE_GETTHREAD; load original from [fp + 24].
+    ldr x11, [fp, #24]
+    str x11, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_SwiftSelf
+
+LEAF_ENTRY Store_SwiftIndirectResult
+    str x8, [x9], #8
+    ldr x11, [x10], #8
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_SwiftIndirectResult
+
 .macro SwiftLoad_AtOffset reg
     ldr x12, [x10], #8       // Load offset|struct_size
     and w11, w12, #0xFFFF    // Extract offset (lower 16 bits)
@@ -1315,10 +1365,53 @@ LEAF_ENTRY Load_Stack_AtOffset
     EPILOG_BRANCH_REG x11
 LEAF_END Load_Stack_AtOffset
 
-.macro SwiftStore_AtOffset reg
+// Reverse direction: read from caller's stack frame and store to interpreter stack
+.macro Store_Stack_AtOffset_Common
+    ldr x12, [x10], #8       // Load offset|structSize|stackOffset
+    and w11, w12, #0xFFFF    // Extract offset (lower 16 bits)
+    lsr x14, x12, #32        // Extract stackOffset (upper 32 bits)
+    add x14, sp, x14         // sp + stackOffset
+    add x14, x14, #__PWTB_TransitionBlock + SIZEOF__TransitionBlock
+.endm
+
+.macro Store_Stack_AtOffset_Epilog
+    str x13, [x9, x11]       // Store 8 bytes to [x9 + offset] (interpreter stack)
+    ubfx x12, x12, #16, #16  // Extract structSize (bits 16-31)
+    add x9, x9, x12          // Advance x9 by structSize
     ldr x11, [x10], #8
-    and w11, w11, #0xFFFF
-    str \reg, [x9, x11]
+    EPILOG_BRANCH_REG x11
+.endm
+
+LEAF_ENTRY Store_Stack_AtOffset
+    Store_Stack_AtOffset_Common
+    ldr x13, [x14]
+    Store_Stack_AtOffset_Epilog
+LEAF_END Store_Stack_AtOffset
+
+LEAF_ENTRY Store_Stack_4B_AtOffset
+    Store_Stack_AtOffset_Common
+    ldr w13, [x14]
+    Store_Stack_AtOffset_Epilog
+LEAF_END Store_Stack_4B_AtOffset
+
+LEAF_ENTRY Store_Stack_2B_AtOffset
+    Store_Stack_AtOffset_Common
+    ldrh w13, [x14]
+    Store_Stack_AtOffset_Epilog
+LEAF_END Store_Stack_2B_AtOffset
+
+LEAF_ENTRY Store_Stack_1B_AtOffset
+    Store_Stack_AtOffset_Common
+    ldrb w13, [x14]
+    Store_Stack_AtOffset_Epilog
+LEAF_END Store_Stack_1B_AtOffset
+
+.macro SwiftStore_AtOffset reg
+    ldr x12, [x10], #8       // Load offset|struct_size
+    and w11, w12, #0xFFFF    // Extract offset (lower 16 bits)
+    str \reg, [x9, x11]      // Store to [x9 + offset]
+    lsr x12, x12, #16        // Shift to get struct_size
+    add x9, x9, x12          // Advance x9 by struct_size (no-op if zero)
     ldr x11, [x10], #8
     br x11
 .endm
@@ -1339,10 +1432,28 @@ LEAF_ENTRY Store_X3_AtOffset
     SwiftStore_AtOffset x3
 LEAF_END Store_X3_AtOffset
 
+LEAF_ENTRY Store_X4_AtOffset
+    SwiftStore_AtOffset x4
+LEAF_END Store_X4_AtOffset
+
+LEAF_ENTRY Store_X5_AtOffset
+    SwiftStore_AtOffset x5
+LEAF_END Store_X5_AtOffset
+
+LEAF_ENTRY Store_X6_AtOffset
+    SwiftStore_AtOffset x6
+LEAF_END Store_X6_AtOffset
+
+LEAF_ENTRY Store_X7_AtOffset
+    SwiftStore_AtOffset x7
+LEAF_END Store_X7_AtOffset
+
 .macro SwiftStoreFloat_AtOffset reg
-    ldr x11, [x10], #8
-    and w11, w11, #0xFFFF
-    str \reg, [x9, x11]
+    ldr x12, [x10], #8       // Load offset|struct_size
+    and w11, w12, #0xFFFF    // Extract offset (lower 16 bits)
+    str \reg, [x9, x11]      // Store to [x9 + offset]
+    lsr x12, x12, #16        // Shift to get struct_size
+    add x9, x9, x12          // Advance x9 by struct_size (no-op if zero)
     ldr x11, [x10], #8
     br x11
 .endm
@@ -1362,6 +1473,22 @@ LEAF_END Store_D2_AtOffset
 LEAF_ENTRY Store_D3_AtOffset
     SwiftStoreFloat_AtOffset d3
 LEAF_END Store_D3_AtOffset
+
+LEAF_ENTRY Store_D4_AtOffset
+    SwiftStoreFloat_AtOffset d4
+LEAF_END Store_D4_AtOffset
+
+LEAF_ENTRY Store_D5_AtOffset
+    SwiftStoreFloat_AtOffset d5
+LEAF_END Store_D5_AtOffset
+
+LEAF_ENTRY Store_D6_AtOffset
+    SwiftStoreFloat_AtOffset d6
+LEAF_END Store_D6_AtOffset
+
+LEAF_ENTRY Store_D7_AtOffset
+    SwiftStoreFloat_AtOffset d7
+LEAF_END Store_D7_AtOffset
 
 #endif // TARGET_APPLE
 
@@ -3298,10 +3425,10 @@ LOCAL_LABEL(CallJittedMethodRetSwiftLowered_Epilog):
 NESTED_END CallJittedMethodRetSwiftLowered, _TEXT
 
 // Terminator routine branches back to the epilog
-LEAF_ENTRY SwiftLoweredReturnTerminator
+LEAF_ENTRY SwiftReturnLoweredTerminator
     ldr x11, [fp, #32]
     br x11
-LEAF_END SwiftLoweredReturnTerminator
+LEAF_END SwiftReturnLoweredTerminator
 
 #endif // TARGET_APPLE
 

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -1040,7 +1040,7 @@ NESTED_END InterpreterStubRet4Vector128, _TEXT
 #ifdef TARGET_APPLE
 // Swift lowered return handler for reverse PInvoke callbacks
 NESTED_ENTRY SwiftReverseReturnLoweredHandler, _TEXT, NoHandler
-    str x10, [sp, #0] // Save routines pointer
+    str x10, [sp, #8] // Save routines pointer
     PROLOG_SAVE_REG_PAIR_NO_FP_INDEXED   fp, lr, -16
     // The +16 is for the fp, lr above
     add x0, sp, #__PWTB_TransitionBlock + 16
@@ -1048,7 +1048,7 @@ NESTED_ENTRY SwiftReverseReturnLoweredHandler, _TEXT, NoHandler
     mov x2, xzr
     bl C_FUNC(ExecuteInterpretedMethod)
     mov x9, x0 // x0 is pointer to result struct on interpreter stack
-    ldr x10, [sp, #16] // restore x10
+    ldr x10, [sp, #24] // restore x10
     ldr x11, [x10], #8
     EPILOG_BRANCH_REG x11
 NESTED_END SwiftReverseReturnLoweredHandler, _TEXT

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -738,6 +738,10 @@ LOCAL_LABEL(HaveInterpThreadContext):
     mov x23, x9 // Save CallStubHeader* for later use
     add x10, x9, #OFFSETOF__CallStubHeader__Routines
     ldr x9, [x11, #OFFSETOF__InterpThreadContext__pStackPointer]
+#ifdef TARGET_APPLE
+    // Initialize Swift error value slot to zero (in extraLocals area)
+    str xzr, [sp, #0]
+#endif
     // x19 contains IR bytecode address
     // Copy the arguments to the interpreter stack, invoke the InterpExecMethod and load the return value
     ldr x11, [x10], #8
@@ -746,6 +750,12 @@ LOCAL_LABEL(HaveInterpThreadContext):
     ldr x2, [sp, #(__PWTB_ArgumentRegister_FirstArg + 16)]
 
     // Check if this stub has Swift error handling
+    ldr x11, [sp, #0]
+    cbz x11, LOCAL_LABEL(InterpreterStub_NoReverseSwiftError)
+    mov x21, x11
+    EPILOG_WITH_TRANSITION_BLOCK_RETURN_SKIP_SWIFT_ERROR
+
+LOCAL_LABEL(InterpreterStub_NoReverseSwiftError):
     ldrb w11, [x23, #OFFSETOF__CallStubHeader__HasSwiftError]
     cbz x11, LOCAL_LABEL(InterpreterStub_NoSwiftError)
     EPILOG_WITH_TRANSITION_BLOCK_RETURN_SKIP_SWIFT_ERROR
@@ -1194,6 +1204,13 @@ LEAF_ENTRY Load_SwiftError
     ldr x11, [x10], #8
     EPILOG_BRANCH_REG x11
 LEAF_END Load_SwiftError
+
+LEAF_ENTRY Store_SwiftError
+    sub x11, fp, #__PWTB_StackAlloc  // Get address of error value slot from fp (stable across calls)
+    str x11, [x9], #8        // Pass address to managed code as SwiftError* parameter
+    ldr x11, [x10], #8       // Load next routine address
+    EPILOG_BRANCH_REG x11
+LEAF_END Store_SwiftError
 
 LEAF_ENTRY Load_SwiftIndirectResult
     ldr x8, [x9], #8

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -769,6 +769,7 @@ LOCAL_LABEL(HaveInterpThreadContext):
     ldr x2, [sp, #(__PWTB_ArgumentRegister_FirstArg + 16)]
 LOCAL_LABEL(InterpreterStub_SkipSwiftReturnLowering):
 
+#ifdef TARGET_APPLE
     ldr x11, [sp, #0]
     cbz x11, LOCAL_LABEL(InterpreterStub_SkipStoreSwiftError)
     mov x21, x11
@@ -779,6 +780,7 @@ LOCAL_LABEL(InterpreterStub_SkipStoreSwiftError):
     cbz x11, LOCAL_LABEL(InterpreterStub_Epilog)
     EPILOG_WITH_TRANSITION_BLOCK_RETURN_SKIP_SWIFT_ERROR
 LOCAL_LABEL(InterpreterStub_Epilog):
+#endif // TARGET_APPLE
     EPILOG_WITH_TRANSITION_BLOCK_RETURN
 
 NESTED_END InterpreterStub, _TEXT
@@ -1368,8 +1370,7 @@ LEAF_END Load_Stack_AtOffset
     add x14, x14, #__PWTB_TransitionBlock + SIZEOF__TransitionBlock
 .endm
 
-.macro Store_Stack_AtOffset_Epilog
-    str x13, [x9, x11]       // Store 8 bytes to [x9 + offset]
+.macro Store_Stack_AtOffset_Epilog_Common
     ubfx x12, x12, #16, #16  // Extract structSize (bits 16-31)
     add x9, x9, x12          // Advance x9 by structSize
     ldr x11, [x10], #8
@@ -1379,25 +1380,29 @@ LEAF_END Load_Stack_AtOffset
 LEAF_ENTRY Store_Stack_AtOffset
     Store_Stack_AtOffset_Prolog
     ldr x13, [x14]
-    Store_Stack_AtOffset_Epilog
+    str x13, [x9, x11]       // Store 8 bytes to [x9 + offset]
+    Store_Stack_AtOffset_Epilog_Common
 LEAF_END Store_Stack_AtOffset
 
 LEAF_ENTRY Store_Stack_4B_AtOffset
     Store_Stack_AtOffset_Prolog
     ldr w13, [x14]
-    Store_Stack_AtOffset_Epilog
+    str w13, [x9, x11]       // Store 4 bytes to [x9 + offset]
+    Store_Stack_AtOffset_Epilog_Common
 LEAF_END Store_Stack_4B_AtOffset
 
 LEAF_ENTRY Store_Stack_2B_AtOffset
     Store_Stack_AtOffset_Prolog
     ldrh w13, [x14]
-    Store_Stack_AtOffset_Epilog
+    strh w13, [x9, x11]      // Store 2 bytes to [x9 + offset]
+    Store_Stack_AtOffset_Epilog_Common
 LEAF_END Store_Stack_2B_AtOffset
 
 LEAF_ENTRY Store_Stack_1B_AtOffset
     Store_Stack_AtOffset_Prolog
     ldrb w13, [x14]
-    Store_Stack_AtOffset_Epilog
+    strb w13, [x9, x11]      // Store 1 byte to [x9 + offset]
+    Store_Stack_AtOffset_Epilog_Common
 LEAF_END Store_Stack_1B_AtOffset
 
 .macro SwiftStore_AtOffset reg

--- a/src/coreclr/vm/arm64/asmhelpers.S
+++ b/src/coreclr/vm/arm64/asmhelpers.S
@@ -739,6 +739,8 @@ LOCAL_LABEL(HaveInterpThreadContext):
     add x10, x9, #OFFSETOF__CallStubHeader__Routines
     ldr x9, [x11, #OFFSETOF__InterpThreadContext__pStackPointer]
 #ifdef TARGET_APPLE
+    // Swift error slot for reverse P/Invoke. Store_SwiftError assigns the SwiftError*
+    // argument address to this slot. The epilog restores it to x21.
     str xzr, [sp, #0]
 #endif
     // x19 contains IR bytecode address
@@ -1313,46 +1315,36 @@ LEAF_ENTRY Load_X7_AtOffset
     SwiftLoad_AtOffset x7
 LEAF_END Load_X7_AtOffset
 
-.macro SwiftLoadFloat_AtOffset reg
-    ldr x12, [x10], #8       // Load offset|struct_size
-    and w11, w12, #0xFFFF    // Extract offset (lower 16 bits)
-    ldr \reg, [x9, x11]      // Load float from [x9 + offset]
-    lsr x12, x12, #16        // Shift to get struct_size
-    add x9, x9, x12          // Advance x9 by struct_size (no-op if zero)
-    ldr x11, [x10], #8
-    EPILOG_BRANCH_REG x11
-.endm
-
 LEAF_ENTRY Load_D0_AtOffset
-    SwiftLoadFloat_AtOffset d0
+    SwiftLoad_AtOffset d0
 LEAF_END Load_D0_AtOffset
 
 LEAF_ENTRY Load_D1_AtOffset
-    SwiftLoadFloat_AtOffset d1
+    SwiftLoad_AtOffset d1
 LEAF_END Load_D1_AtOffset
 
 LEAF_ENTRY Load_D2_AtOffset
-    SwiftLoadFloat_AtOffset d2
+    SwiftLoad_AtOffset d2
 LEAF_END Load_D2_AtOffset
 
 LEAF_ENTRY Load_D3_AtOffset
-    SwiftLoadFloat_AtOffset d3
+    SwiftLoad_AtOffset d3
 LEAF_END Load_D3_AtOffset
 
 LEAF_ENTRY Load_D4_AtOffset
-    SwiftLoadFloat_AtOffset d4
+    SwiftLoad_AtOffset d4
 LEAF_END Load_D4_AtOffset
 
 LEAF_ENTRY Load_D5_AtOffset
-    SwiftLoadFloat_AtOffset d5
+    SwiftLoad_AtOffset d5
 LEAF_END Load_D5_AtOffset
 
 LEAF_ENTRY Load_D6_AtOffset
-    SwiftLoadFloat_AtOffset d6
+    SwiftLoad_AtOffset d6
 LEAF_END Load_D6_AtOffset
 
 LEAF_ENTRY Load_D7_AtOffset
-    SwiftLoadFloat_AtOffset d7
+    SwiftLoad_AtOffset d7
 LEAF_END Load_D7_AtOffset
 
 LEAF_ENTRY Load_Stack_AtOffset
@@ -1450,46 +1442,36 @@ LEAF_ENTRY Store_X7_AtOffset
     SwiftStore_AtOffset x7
 LEAF_END Store_X7_AtOffset
 
-.macro SwiftStoreFloat_AtOffset reg
-    ldr x12, [x10], #8       // Load offset|struct_size
-    and w11, w12, #0xFFFF    // Extract offset (lower 16 bits)
-    str \reg, [x9, x11]      // Store to [x9 + offset]
-    lsr x12, x12, #16        // Shift to get struct_size
-    add x9, x9, x12          // Advance x9 by struct_size (no-op if zero)
-    ldr x11, [x10], #8
-    br x11
-.endm
-
 LEAF_ENTRY Store_D0_AtOffset
-    SwiftStoreFloat_AtOffset d0
+    SwiftStore_AtOffset d0
 LEAF_END Store_D0_AtOffset
 
 LEAF_ENTRY Store_D1_AtOffset
-    SwiftStoreFloat_AtOffset d1
+    SwiftStore_AtOffset d1
 LEAF_END Store_D1_AtOffset
 
 LEAF_ENTRY Store_D2_AtOffset
-    SwiftStoreFloat_AtOffset d2
+    SwiftStore_AtOffset d2
 LEAF_END Store_D2_AtOffset
 
 LEAF_ENTRY Store_D3_AtOffset
-    SwiftStoreFloat_AtOffset d3
+    SwiftStore_AtOffset d3
 LEAF_END Store_D3_AtOffset
 
 LEAF_ENTRY Store_D4_AtOffset
-    SwiftStoreFloat_AtOffset d4
+    SwiftStore_AtOffset d4
 LEAF_END Store_D4_AtOffset
 
 LEAF_ENTRY Store_D5_AtOffset
-    SwiftStoreFloat_AtOffset d5
+    SwiftStore_AtOffset d5
 LEAF_END Store_D5_AtOffset
 
 LEAF_ENTRY Store_D6_AtOffset
-    SwiftStoreFloat_AtOffset d6
+    SwiftStore_AtOffset d6
 LEAF_END Store_D6_AtOffset
 
 LEAF_ENTRY Store_D7_AtOffset
-    SwiftStoreFloat_AtOffset d7
+    SwiftStore_AtOffset d7
 LEAF_END Store_D7_AtOffset
 
 #endif // TARGET_APPLE

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -2943,7 +2943,8 @@ void CallStubGenerator::RewriteSignatureForSwiftLowering(MetaSig &sig, SigBuilde
                 pArgMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTOR128T)) ||
                 pArgMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTOR256T)) ||
                 pArgMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTOR512T)) ||
-                pArgMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTORT)))
+                pArgMT->HasSameTypeDefAs(CoreLibBinder::GetClass(CLASS__VECTORT)) ||
+                (pArgMT->IsIntrinsicType() && pArgMT->IsHFA()))
             {
                 COMPlusThrow(kInvalidProgramException);
             }
@@ -2972,6 +2973,10 @@ void CallStubGenerator::RewriteSignatureForSwiftLowering(MetaSig &sig, SigBuilde
 
             if (pArgMT == CoreLibBinder::GetClass(CLASS__SWIFT_ERROR))
             {
+                if (argType == ELEMENT_TYPE_VALUETYPE)
+                {
+                    COMPlusThrow(kInvalidProgramException);
+                }
                 swiftErrorCount++;
                 m_hasSwiftError = true;
                 if (swiftErrorCount > 1)

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -1157,6 +1157,10 @@ PCODE CallStubGenerator::GetSwiftSelfByRefRoutine()
 #if LOG_COMPUTE_CALL_STUB
     LOG2((LF2_INTERPRETER, LL_INFO10000, "GetSwiftSelfByRefRoutine\n"));
 #endif
+    if (!m_interpreterToNative)
+    {
+        COMPlusThrow(kPlatformNotSupportedException, W("SwiftSelf<T> is not supported for reverse PInvoke"));
+    }
     _ASSERTE(m_interpreterToNative && "SwiftSelf<T> is not supported for reverse PInvoke");
     return (PCODE)Load_SwiftSelf_ByRef;
 }

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -1161,7 +1161,6 @@ PCODE CallStubGenerator::GetSwiftSelfByRefRoutine()
     {
         COMPlusThrow(kPlatformNotSupportedException, W("SwiftSelf<T> is not supported for reverse PInvoke"));
     }
-    _ASSERTE(m_interpreterToNative && "SwiftSelf<T> is not supported for reverse PInvoke");
     return (PCODE)Load_SwiftSelf_ByRef;
 }
 

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -3298,13 +3298,16 @@ void CallStubGenerator::EmitSwiftReturnLoweringRoutines(PCODE *pRoutines)
         CorInfoType elemType = m_swiftReturnLowering.loweredElements[i];
         uint32_t offset = m_swiftReturnLowering.offsets[i];
 
+        _ASSERTE(offset <= 0xFFFF && "Swift return offset must fit in 16 bits");
+        PCODE packedOffset = (PCODE)(offset & 0xFFFF);
+
         bool isFloat = (elemType == CORINFO_TYPE_FLOAT || elemType == CORINFO_TYPE_DOUBLE);
 
         if (isFloat)
         {
             _ASSERTE(fpRegIndex < 4);
             pRoutines[m_routineIndex++] = GetSwiftStoreFPAtOffsetRoutine(fpRegIndex);
-            pRoutines[m_routineIndex++] = (PCODE)offset;
+            pRoutines[m_routineIndex++] = packedOffset;
             fpRegIndex++;
 #if LOG_COMPUTE_CALL_STUB
             LOG2((LF2_INTERPRETER, LL_INFO10000, "Swift return store FP d%d at offset %d\n", fpRegIndex - 1, offset));
@@ -3314,7 +3317,7 @@ void CallStubGenerator::EmitSwiftReturnLoweringRoutines(PCODE *pRoutines)
         {
             _ASSERTE(gpRegIndex < 4);
             pRoutines[m_routineIndex++] = GetSwiftStoreGPAtOffsetRoutine(gpRegIndex);
-            pRoutines[m_routineIndex++] = (PCODE)offset;
+            pRoutines[m_routineIndex++] = packedOffset;
             gpRegIndex++;
 #if LOG_COMPUTE_CALL_STUB
             LOG2((LF2_INTERPRETER, LL_INFO10000, "Swift return store GP x%d at offset %d\n", gpRegIndex - 1, offset));

--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -1724,6 +1724,8 @@ CallStubHeader *CallStubGenerator::GenerateCallStubForSig(MetaSig &sig)
         sig.IsAsyncCall(),
 #if defined(TARGET_APPLE) && defined(TARGET_ARM64)
         m_hasSwiftError,
+#else
+        false,
 #endif
         m_pInvokeFunction);
 
@@ -1742,7 +1744,12 @@ CallStubHeader *CallStubGenerator::GenerateCallStubForSig(MetaSig &sig)
         // We only need to allocate the actual pRoutines array, and then we can just use the cachedHeader we already constructed
         size_t finalCachedCallStubSize = sizeof(CachedCallStub) + m_routineIndex * sizeof(PCODE);
         void* pHeaderStorage = amTracker.Track(SystemDomain::GetGlobalLoaderAllocator()->GetHighFrequencyHeap()->AllocMem(S_SIZE_T(finalCachedCallStubSize)));
-        CachedCallStub *pHeader = new (pHeaderStorage) CachedCallStub(cachedHeaderKey.HashCode, m_routineIndex, m_targetSlotIndex, pRoutines, ALIGN_UP(m_totalStackSize, STACK_ALIGN_SIZE), sig.IsAsyncCall(), m_hasSwiftError, m_hasSwiftReturnLowering, m_pInvokeFunction);
+        // hasSwiftReturnLowering is always false here because m_interpreterToNative = true (see line 1601's logic)
+#if defined(TARGET_APPLE) && defined(TARGET_ARM64)
+        CachedCallStub *pHeader = new (pHeaderStorage) CachedCallStub(cachedHeaderKey.HashCode, m_routineIndex, m_targetSlotIndex, pRoutines, ALIGN_UP(m_totalStackSize, STACK_ALIGN_SIZE), sig.IsAsyncCall(), m_hasSwiftError, false /* hasSwiftReturnLowering */, m_pInvokeFunction);
+#else
+        CachedCallStub *pHeader = new (pHeaderStorage) CachedCallStub(cachedHeaderKey.HashCode, m_routineIndex, m_targetSlotIndex, pRoutines, ALIGN_UP(m_totalStackSize, STACK_ALIGN_SIZE), sig.IsAsyncCall(), false, false, m_pInvokeFunction);
+#endif
         s_callStubCache->Add(pHeader);
         amTracker.SuppressRelease();
 

--- a/src/coreclr/vm/callstubgenerator.h
+++ b/src/coreclr/vm/callstubgenerator.h
@@ -194,6 +194,7 @@ class CallStubGenerator
     int m_swiftSelfByRefSize = 0;
     CORINFO_SWIFT_LOWERING m_swiftReturnLowering = {};
     bool m_hasSwiftReturnLowering = false;
+    bool m_isSwiftILStub = false;
 
     // Swift routine helpers
     PCODE GetSwiftSelfRoutine();

--- a/src/coreclr/vm/callstubgenerator.h
+++ b/src/coreclr/vm/callstubgenerator.h
@@ -173,8 +173,6 @@ class CallStubGenerator
 
     CallStubHeader::InvokeFunctionPtr m_pInvokeFunction = NULL;
     bool m_interpreterToNative = false;
-    bool m_hasSwiftError = false;
-    bool m_isSwiftCallConv = false;
 
 #if !defined(UNIX_AMD64_ABI) && defined(ENREGISTERED_PARAMTYPE_MAXSIZE)
     PCODE GetGPRegRefRoutine(int r);
@@ -193,10 +191,12 @@ class CallStubGenerator
 #endif // TARGET_ARM64
 #if defined(TARGET_APPLE) && defined(TARGET_ARM64)
     // Swift calling convention state
+    bool m_isSwiftCallConv = false;
+    bool m_isSwiftILStub = false;
+    bool m_hasSwiftError = false;
+    bool m_hasSwiftReturnLowering = false;
     int m_swiftSelfByRefSize = 0;
     CORINFO_SWIFT_LOWERING m_swiftReturnLowering = {};
-    bool m_hasSwiftReturnLowering = false;
-    bool m_isSwiftILStub = false;
 
     // Swift routine helpers
     PCODE GetSwiftSelfRoutine();

--- a/src/tests/Interop/Swift/SwiftAbiStress/SwiftAbiStress.csproj
+++ b/src/tests/Interop/Swift/SwiftAbiStress/SwiftAbiStress.csproj
@@ -3,7 +3,7 @@
     <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/93631 -->
+    <!-- Swift interop is supported on Apple platforms only -->
     <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' != 'true' and '$(TargetsAppleMobile)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/Swift/SwiftCallbackAbiStress/SwiftCallbackAbiStress.cs
+++ b/src/tests/Interop/Swift/SwiftCallbackAbiStress/SwiftCallbackAbiStress.cs
@@ -64,7 +64,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc0()
     {
         Console.Write("Running SwiftCallbackFunc0: ");
@@ -176,7 +175,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc1()
     {
         Console.Write("Running SwiftCallbackFunc1: ");
@@ -268,7 +266,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc2()
     {
         Console.Write("Running SwiftCallbackFunc2: ");
@@ -379,7 +376,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc3()
     {
         Console.Write("Running SwiftCallbackFunc3: ");
@@ -465,7 +461,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc4()
     {
         Console.Write("Running SwiftCallbackFunc4: ");
@@ -594,7 +589,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc5()
     {
         Console.Write("Running SwiftCallbackFunc5: ");
@@ -719,7 +713,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc6()
     {
         Console.Write("Running SwiftCallbackFunc6: ");
@@ -793,7 +786,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc7()
     {
         Console.Write("Running SwiftCallbackFunc7: ");
@@ -875,7 +867,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc8()
     {
         Console.Write("Running SwiftCallbackFunc8: ");
@@ -1022,7 +1013,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc9()
     {
         Console.Write("Running SwiftCallbackFunc9: ");
@@ -1072,7 +1062,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc10()
     {
         Console.Write("Running SwiftCallbackFunc10: ");
@@ -1181,7 +1170,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc11()
     {
         Console.Write("Running SwiftCallbackFunc11: ");
@@ -1264,7 +1252,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc12()
     {
         Console.Write("Running SwiftCallbackFunc12: ");
@@ -1366,7 +1353,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc13()
     {
         Console.Write("Running SwiftCallbackFunc13: ");
@@ -1422,7 +1408,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc14()
     {
         Console.Write("Running SwiftCallbackFunc14: ");
@@ -1505,7 +1490,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc15()
     {
         Console.Write("Running SwiftCallbackFunc15: ");
@@ -1605,7 +1589,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc16()
     {
         Console.Write("Running SwiftCallbackFunc16: ");
@@ -1675,7 +1658,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc17()
     {
         Console.Write("Running SwiftCallbackFunc17: ");
@@ -1761,7 +1743,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc18()
     {
         Console.Write("Running SwiftCallbackFunc18: ");
@@ -1875,7 +1856,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc19()
     {
         Console.Write("Running SwiftCallbackFunc19: ");
@@ -1981,7 +1961,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc20()
     {
         Console.Write("Running SwiftCallbackFunc20: ");
@@ -2056,7 +2035,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc21()
     {
         Console.Write("Running SwiftCallbackFunc21: ");
@@ -2180,7 +2158,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc22()
     {
         Console.Write("Running SwiftCallbackFunc22: ");
@@ -2235,7 +2212,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc23()
     {
         Console.Write("Running SwiftCallbackFunc23: ");
@@ -2339,7 +2315,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc24()
     {
         Console.Write("Running SwiftCallbackFunc24: ");
@@ -2441,7 +2416,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc25()
     {
         Console.Write("Running SwiftCallbackFunc25: ");
@@ -2538,7 +2512,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc26()
     {
         Console.Write("Running SwiftCallbackFunc26: ");
@@ -2630,7 +2603,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc27()
     {
         Console.Write("Running SwiftCallbackFunc27: ");
@@ -2730,7 +2702,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc28()
     {
         Console.Write("Running SwiftCallbackFunc28: ");
@@ -2858,7 +2829,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc29()
     {
         Console.Write("Running SwiftCallbackFunc29: ");
@@ -2937,7 +2907,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc30()
     {
         Console.Write("Running SwiftCallbackFunc30: ");
@@ -3013,7 +2982,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc31()
     {
         Console.Write("Running SwiftCallbackFunc31: ");
@@ -3067,7 +3035,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc32()
     {
         Console.Write("Running SwiftCallbackFunc32: ");
@@ -3173,7 +3140,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc33()
     {
         Console.Write("Running SwiftCallbackFunc33: ");
@@ -3223,7 +3189,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc34()
     {
         Console.Write("Running SwiftCallbackFunc34: ");
@@ -3313,7 +3278,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc35()
     {
         Console.Write("Running SwiftCallbackFunc35: ");
@@ -3364,7 +3328,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc36()
     {
         Console.Write("Running SwiftCallbackFunc36: ");
@@ -3451,7 +3414,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc37()
     {
         Console.Write("Running SwiftCallbackFunc37: ");
@@ -3530,7 +3492,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc38()
     {
         Console.Write("Running SwiftCallbackFunc38: ");
@@ -3627,7 +3588,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc39()
     {
         Console.Write("Running SwiftCallbackFunc39: ");
@@ -3716,7 +3676,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc40()
     {
         Console.Write("Running SwiftCallbackFunc40: ");
@@ -3772,7 +3731,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc41()
     {
         Console.Write("Running SwiftCallbackFunc41: ");
@@ -3831,7 +3789,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc42()
     {
         Console.Write("Running SwiftCallbackFunc42: ");
@@ -3892,7 +3849,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc43()
     {
         Console.Write("Running SwiftCallbackFunc43: ");
@@ -3997,7 +3953,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc44()
     {
         Console.Write("Running SwiftCallbackFunc44: ");
@@ -4082,7 +4037,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc45()
     {
         Console.Write("Running SwiftCallbackFunc45: ");
@@ -4142,7 +4096,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc46()
     {
         Console.Write("Running SwiftCallbackFunc46: ");
@@ -4259,7 +4212,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc47()
     {
         Console.Write("Running SwiftCallbackFunc47: ");
@@ -4335,7 +4287,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc48()
     {
         Console.Write("Running SwiftCallbackFunc48: ");
@@ -4404,7 +4355,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc49()
     {
         Console.Write("Running SwiftCallbackFunc49: ");
@@ -4522,7 +4472,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc50()
     {
         Console.Write("Running SwiftCallbackFunc50: ");
@@ -4583,7 +4532,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc51()
     {
         Console.Write("Running SwiftCallbackFunc51: ");
@@ -4657,7 +4605,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc52()
     {
         Console.Write("Running SwiftCallbackFunc52: ");
@@ -4817,7 +4764,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc53()
     {
         Console.Write("Running SwiftCallbackFunc53: ");
@@ -4937,7 +4883,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc54()
     {
         Console.Write("Running SwiftCallbackFunc54: ");
@@ -5036,7 +4981,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc55()
     {
         Console.Write("Running SwiftCallbackFunc55: ");
@@ -5080,7 +5024,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc56()
     {
         Console.Write("Running SwiftCallbackFunc56: ");
@@ -5172,7 +5115,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc57()
     {
         Console.Write("Running SwiftCallbackFunc57: ");
@@ -5247,7 +5189,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc58()
     {
         Console.Write("Running SwiftCallbackFunc58: ");
@@ -5282,7 +5223,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc59()
     {
         Console.Write("Running SwiftCallbackFunc59: ");
@@ -5339,7 +5279,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc60()
     {
         Console.Write("Running SwiftCallbackFunc60: ");
@@ -5441,7 +5380,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc61()
     {
         Console.Write("Running SwiftCallbackFunc61: ");
@@ -5497,7 +5435,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc62()
     {
         Console.Write("Running SwiftCallbackFunc62: ");
@@ -5540,7 +5477,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc63()
     {
         Console.Write("Running SwiftCallbackFunc63: ");
@@ -5625,7 +5561,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc64()
     {
         Console.Write("Running SwiftCallbackFunc64: ");
@@ -5725,7 +5660,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc65()
     {
         Console.Write("Running SwiftCallbackFunc65: ");
@@ -5793,7 +5727,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc66()
     {
         Console.Write("Running SwiftCallbackFunc66: ");
@@ -5892,7 +5825,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc67()
     {
         Console.Write("Running SwiftCallbackFunc67: ");
@@ -6002,7 +5934,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc68()
     {
         Console.Write("Running SwiftCallbackFunc68: ");
@@ -6102,7 +6033,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc69()
     {
         Console.Write("Running SwiftCallbackFunc69: ");
@@ -6219,7 +6149,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc70()
     {
         Console.Write("Running SwiftCallbackFunc70: ");
@@ -6275,7 +6204,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc71()
     {
         Console.Write("Running SwiftCallbackFunc71: ");
@@ -6333,7 +6261,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc72()
     {
         Console.Write("Running SwiftCallbackFunc72: ");
@@ -6434,7 +6361,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc73()
     {
         Console.Write("Running SwiftCallbackFunc73: ");
@@ -6493,7 +6419,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc74()
     {
         Console.Write("Running SwiftCallbackFunc74: ");
@@ -6587,7 +6512,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc75()
     {
         Console.Write("Running SwiftCallbackFunc75: ");
@@ -6695,7 +6619,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc76()
     {
         Console.Write("Running SwiftCallbackFunc76: ");
@@ -6787,7 +6710,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc77()
     {
         Console.Write("Running SwiftCallbackFunc77: ");
@@ -6884,7 +6806,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc78()
     {
         Console.Write("Running SwiftCallbackFunc78: ");
@@ -6947,7 +6868,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc79()
     {
         Console.Write("Running SwiftCallbackFunc79: ");
@@ -7027,7 +6947,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc80()
     {
         Console.Write("Running SwiftCallbackFunc80: ");
@@ -7089,7 +7008,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc81()
     {
         Console.Write("Running SwiftCallbackFunc81: ");
@@ -7188,7 +7106,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc82()
     {
         Console.Write("Running SwiftCallbackFunc82: ");
@@ -7240,7 +7157,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc83()
     {
         Console.Write("Running SwiftCallbackFunc83: ");
@@ -7345,7 +7261,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc84()
     {
         Console.Write("Running SwiftCallbackFunc84: ");
@@ -7468,7 +7383,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc85()
     {
         Console.Write("Running SwiftCallbackFunc85: ");
@@ -7573,7 +7487,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc86()
     {
         Console.Write("Running SwiftCallbackFunc86: ");
@@ -7628,7 +7541,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc87()
     {
         Console.Write("Running SwiftCallbackFunc87: ");
@@ -7723,7 +7635,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc88()
     {
         Console.Write("Running SwiftCallbackFunc88: ");
@@ -7793,7 +7704,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc89()
     {
         Console.Write("Running SwiftCallbackFunc89: ");
@@ -7902,7 +7812,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc90()
     {
         Console.Write("Running SwiftCallbackFunc90: ");
@@ -8023,7 +7932,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc91()
     {
         Console.Write("Running SwiftCallbackFunc91: ");
@@ -8117,7 +8025,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc92()
     {
         Console.Write("Running SwiftCallbackFunc92: ");
@@ -8181,7 +8088,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc93()
     {
         Console.Write("Running SwiftCallbackFunc93: ");
@@ -8291,7 +8197,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc94()
     {
         Console.Write("Running SwiftCallbackFunc94: ");
@@ -8381,7 +8286,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc95()
     {
         Console.Write("Running SwiftCallbackFunc95: ");
@@ -8452,7 +8356,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc96()
     {
         Console.Write("Running SwiftCallbackFunc96: ");
@@ -8546,7 +8449,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc97()
     {
         Console.Write("Running SwiftCallbackFunc97: ");
@@ -8592,7 +8494,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc98()
     {
         Console.Write("Running SwiftCallbackFunc98: ");
@@ -8659,7 +8560,6 @@ public unsafe class SwiftCallbackAbiStress
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSwiftCallbackFunc99()
     {
         Console.Write("Running SwiftCallbackFunc99: ");

--- a/src/tests/Interop/Swift/SwiftCallbackAbiStress/SwiftCallbackAbiStress.csproj
+++ b/src/tests/Interop/Swift/SwiftCallbackAbiStress/SwiftCallbackAbiStress.csproj
@@ -3,7 +3,7 @@
     <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/93631 -->
+    <!-- Swift interop is supported on Apple platforms only -->
     <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' != 'true' and '$(TargetsAppleMobile)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>

--- a/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.cs
+++ b/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.cs
@@ -130,7 +130,6 @@ public class ErrorHandlingTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static unsafe void TestUnmanagedCallersOnly()
     {
         SwiftError error;
@@ -146,7 +145,6 @@ public class ErrorHandlingTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static unsafe void TestUnmanagedCallersOnlyWithReturn()
     {
         SwiftError error;

--- a/src/tests/Interop/Swift/SwiftIndirectResult/SwiftIndirectResult.cs
+++ b/src/tests/Interop/Swift/SwiftIndirectResult/SwiftIndirectResult.cs
@@ -47,7 +47,6 @@ public unsafe class SwiftIndirectResultTests
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/120049", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestSumReturnedNonFrozenStruct()
     {
         int result = SumReturnedNonFrozenStruct(&ReversePInvokeReturnNonFrozenStruct, null);

--- a/src/tests/Interop/Swift/SwiftInvalidCallConv/SwiftInvalidCallConv.cs
+++ b/src/tests/Interop/Swift/SwiftInvalidCallConv/SwiftInvalidCallConv.cs
@@ -82,7 +82,10 @@ public class InvalidCallingConvTests
         // Invalid due to a non-primitive argument.
         StringClass arg1 = new StringClass();
         arg1.value = "fail";
-        Assert.ThrowsAny<SystemException>(() => FuncWithNonPrimitiveArg(arg1));
+        Exception ex = Assert.ThrowsAny<Exception>(() => FuncWithNonPrimitiveArg(arg1));
+        Assert.True(
+            ex is InvalidProgramException or MarshalDirectiveException or PlatformNotSupportedException,
+            $"Unexpected exception type: {ex.GetType().FullName}");
     }
 
     [Fact]

--- a/src/tests/Interop/Swift/SwiftInvalidCallConv/SwiftInvalidCallConv.cs
+++ b/src/tests/Interop/Swift/SwiftInvalidCallConv/SwiftInvalidCallConv.cs
@@ -82,7 +82,7 @@ public class InvalidCallingConvTests
         // Invalid due to a non-primitive argument.
         StringClass arg1 = new StringClass();
         arg1.value = "fail";
-        Assert.Throws<InvalidProgramException>(() => FuncWithNonPrimitiveArg(arg1));
+        Assert.ThrowsAny<SystemException>(() => FuncWithNonPrimitiveArg(arg1));
     }
 
     [Fact]

--- a/src/tests/Interop/Swift/SwiftInvalidCallConv/SwiftInvalidCallConv.csproj
+++ b/src/tests/Interop/Swift/SwiftInvalidCallConv/SwiftInvalidCallConv.csproj
@@ -5,8 +5,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!-- Swift interop is supported on Apple platforms only -->
     <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' != 'true' and '$(TargetsAppleMobile)' != 'true'">true</CLRTestTargetUnsupported>
-    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/93631 -->
-    <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' != 'mono'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildProjectName).cs" />

--- a/src/tests/Interop/Swift/SwiftRetAbiStress/SwiftRetAbiStress.csproj
+++ b/src/tests/Interop/Swift/SwiftRetAbiStress/SwiftRetAbiStress.csproj
@@ -3,7 +3,7 @@
     <!-- Needed for CLRTestTargetUnsupported, CMakeProjectReference -->
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Tracking issue: https://github.com/dotnet/runtime/issues/93631 -->
+    <!-- Swift interop is supported on Apple platforms only -->
     <CLRTestTargetUnsupported Condition="'$(TargetsOSX)' != 'true' and '$(TargetsAppleMobile)' != 'true'">true</CLRTestTargetUnsupported>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
# Description

This PR adds reverse P/Invoke support for the Swift calling convention to the CoreCLR interpreter on arm64 Apple platforms. It extends the existing Swift call stubs so Swift managed callbacks work correctly under the interpreter, including special registers, argument rewriting, and return handling.

### SwiftSelf

A new `Store_SwiftSelf` routine is added to restores the original `x20` value from the transition frame (since it may be clobbered by thread setup) and writes it into the interpreter argument area.

`SwiftSelf<T>` is unsupported for reverse P/Invoke and throws `PlatformNotSupportedException` if encountered.

### SwiftError

`SwiftError*` is excluded from the rewritten signature because it does not participate in normal argument register allocation. To preserve the byref error location for managed code, the stub generator emits a `Store_SwiftError` routine before regular argument processing. This routine stores the address of the local stack error slot into the interpreter argument area. The interpreter stub epilog is updated to correctly propagate the error register.

### SwiftIndirectResult

A new `Store_SwiftIndirectResult` routine writes the `x8` value into the interpreter argument area so managed callbacks can handle the indirect result correctly.

### Lowering

For Swift-lowered struct arguments, the stub generator now emits store at offset routines when generating reverse stubs. These routines read values from the appropriate GP/FP register or native stack slot and store them into the interpreter buffer using explicit offsets. The implementation handles unaligned fields within lowered structs and emits correctly sized stack loads. 

A `HasSwiftReturnLowering` flag is added to the `CallStubHeader`. When this flag is set, the interpreter stub epilog skips loading the continuation context because the lowered return path (x2) has the return data.

Fixes https://github.com/dotnet/runtime/issues/120049
