### PR TITLE
Revert "Increase number of assertions (GlobalAP) + VN cache (#124132)"

### DIFF
--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -8428,8 +8428,7 @@ protected:
     JitExpandArray<ASSERT_TP>* optAssertionDep = nullptr; // table that holds dependent assertions (assertions
                                                           // using the value of a local var) for each local var
     AssertionDsc*  optAssertionTabPrivate;                // table that holds info about assertions
-    VNSet*         optAssertionVNsMap = nullptr;
-    AssertionIndex optAssertionCount  = 0; // total number of assertions in the assertion table
+    AssertionIndex optAssertionCount = 0;                 // total number of assertions in the assertion table
     AssertionIndex optMaxAssertionCount;
     bool           optCrossBlockLocalAssertionProp;
     unsigned       optAssertionOverflow;
@@ -8558,7 +8557,6 @@ public:
 
     bool optCreateJumpTableImpliedAssertions(BasicBlock* switchBb);
 
-    bool optAssertionHasAssertionsForVN(ValueNum vn, bool addIfNotFound = false);
 #ifdef DEBUG
     void optPrintAssertion(const AssertionDsc& newAssertion, AssertionIndex assertionIndex = 0);
     void optPrintAssertionIndex(AssertionIndex index);

--- a/src/coreclr/jit/rangecheck.cpp
+++ b/src/coreclr/jit/rangecheck.cpp
@@ -977,7 +977,7 @@ void RangeCheck::MergeEdgeAssertions(Compiler*        comp,
         return;
     }
 
-    if (!comp->optAssertionHasAssertionsForVN(normalLclVN))
+    if (normalLclVN == ValueNumStore::NoVN)
     {
         return;
     }


### PR DESCRIPTION
This reverts commit 92741bebcae5b82cd537979eef962674627e7f89.

This was causing excessive memory allocation during jitting (see https://github.com/dotnet/dotnet/pull/4933).