### PR TITLE
[cDAC] Strip collectible tag bit from RangeSectionFragment.Next pointer

### DIFF
--- a/docs/design/datacontracts/ExecutionManager.md
+++ b/docs/design/datacontracts/ExecutionManager.md
@@ -62,7 +62,7 @@ Data descriptors used:
 | `RangeSectionFragment`| `RangeBegin` | Begin address of the fragment |
 | `RangeSectionFragment`| `RangeEndOpen` | End address of the fragment |
 | `RangeSectionFragment`| `RangeSection` | Pointer to the corresponding `RangeSection` |
-| `RangeSectionFragment`| `Next` | Pointer to the next fragment |
+| `RangeSectionFragment`| `Next` | Tagged pointer to the next fragment (bit 0 is the collectible flag; must be stripped to obtain the address) |
 | `RangeSection` | `RangeBegin` | Begin address of the range section |
 | `RangeSection` | `RangeEndOpen` | End address of the range section |
 | `RangeSection` | `NextForDelete` | Pointer to next range section for deletion |
@@ -399,6 +399,10 @@ On 64-bit targets, we take advantage of the fact that most architectures don't s
 
 That is, level 5 has 256 entires pointing to level 4 maps (or nothing if there's no
 code allocated in that address range), level 4 entires point to level 3 maps and so on.  Each level 1 map has 256 entries covering a 128 KiB chunk and pointing to a linked list of range section fragments that fall within that 128 KiB chunk.
+
+#### Tagged pointers in the range section map
+
+Both the interior map pointers and the `RangeSectionFragment::Next` linked-list pointers use bit 0 as a collectible flag (see `RangeSectionFragmentPointer` in `codeman.h`). When a range section fragment belongs to a collectible assembly load context, the runtime sets bit 0 on the pointer. Readers must strip this bit (mask with `~1`) before dereferencing the pointer to obtain the actual address.
 
 ### Native Format
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/RangeSectionFragment.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Data/RangeSectionFragment.cs
@@ -14,7 +14,9 @@ internal sealed class RangeSectionFragment : IData<RangeSectionFragment>
         RangeBegin = target.ReadPointer(address + (ulong)type.Fields[nameof(RangeBegin)].Offset);
         RangeEndOpen = target.ReadPointer(address + (ulong)type.Fields[nameof(RangeEndOpen)].Offset);
         RangeSection = target.ReadPointer(address + (ulong)type.Fields[nameof(RangeSection)].Offset);
-        Next = target.ReadPointer(address + (ulong)type.Fields[nameof(Next)].Offset);
+        // The Next pointer uses the low bit as a collectible flag (see RangeSectionFragmentPointer in codeman.h).
+        // Strip it to get the actual address.
+        Next = target.ReadPointer(address + (ulong)type.Fields[nameof(Next)].Offset) & ~1ul;
     }
 
     public TargetPointer RangeBegin { get; init; }

--- a/src/native/managed/cdac/tests/ExecutionManager/ExecutionManagerTests.cs
+++ b/src/native/managed/cdac/tests/ExecutionManager/ExecutionManagerTests.cs
@@ -28,7 +28,7 @@ public class ExecutionManagerTests
     [MemberData(nameof(StdArchAllVersions))]
     public void GetCodeBlockHandle_Null(int version, MockTarget.Architecture arch)
     {
-        MockDescriptors.ExecutionManager emBuilder = new (version, arch, MockDescriptors.ExecutionManager.DefaultAllocationRange);
+        MockDescriptors.ExecutionManager emBuilder = new(version, arch, MockDescriptors.ExecutionManager.DefaultAllocationRange);
         var target = CreateTarget(emBuilder);
 
         var em = target.Contracts.ExecutionManager;
@@ -41,7 +41,7 @@ public class ExecutionManagerTests
     [MemberData(nameof(StdArchAllVersions))]
     public void GetCodeBlockHandle_NoRangeSections(int version, MockTarget.Architecture arch)
     {
-        MockDescriptors.ExecutionManager emBuilder = new (version, arch, MockDescriptors.ExecutionManager.DefaultAllocationRange);
+        MockDescriptors.ExecutionManager emBuilder = new(version, arch, MockDescriptors.ExecutionManager.DefaultAllocationRange);
         var target = CreateTarget(emBuilder);
 
         var em = target.Contracts.ExecutionManager;
@@ -58,7 +58,7 @@ public class ExecutionManagerTests
         const uint codeRangeSize = 0xc000u; // arbitrary
         const uint methodSize = 0x450; // arbitrary
 
-        TargetPointer jitManagerAddress = new (0x000b_ff00); // arbitrary
+        TargetPointer jitManagerAddress = new(0x000b_ff00); // arbitrary
 
         TargetPointer expectedMethodDescAddress = new TargetPointer(0x0101_aaa0);
 
@@ -105,7 +105,7 @@ public class ExecutionManagerTests
         const ulong codeRangeStart = 0x0a0a_0000u; // arbitrary
         const uint codeRangeSize = 0xc000u; // arbitrary
 
-        TargetPointer jitManagerAddress = new (0x000b_ff00); // arbitrary
+        TargetPointer jitManagerAddress = new(0x000b_ff00); // arbitrary
 
         MockDescriptors.ExecutionManager emBuilder = new(version, arch, MockDescriptors.ExecutionManager.DefaultAllocationRange);
         var jittedCode = emBuilder.AllocateJittedCodeRange(codeRangeStart, codeRangeSize);
@@ -142,7 +142,7 @@ public class ExecutionManagerTests
         const uint codeRangeSize = 0xc000u; // arbitrary
         const uint methodSize = 0x450; // arbitrary
 
-        TargetPointer jitManagerAddress = new (0x000b_ff00); // arbitrary
+        TargetPointer jitManagerAddress = new(0x000b_ff00); // arbitrary
 
         MockDescriptors.ExecutionManager emBuilder = new(version, arch, MockDescriptors.ExecutionManager.DefaultAllocationRange);
         var jittedCode = emBuilder.AllocateJittedCodeRange(codeRangeStart, codeRangeSize);
@@ -255,12 +255,12 @@ public class ExecutionManagerTests
         const uint codeRangeSize = 0xc000u; // arbitrary
         TargetPointer jitManagerAddress = new(0x000b_ff00); // arbitrary
 
-        TargetPointer[] methodDescAddresses = [ 0x0101_aaa0, 0x0201_aaa0];
+        TargetPointer[] methodDescAddresses = [0x0101_aaa0, 0x0201_aaa0];
 
         MockDescriptors.ExecutionManager emBuilder = new(version, arch, MockDescriptors.ExecutionManager.DefaultAllocationRange);
         var jittedCode = emBuilder.AllocateJittedCodeRange(codeRangeStart, codeRangeSize);
 
-        uint[] runtimeFunctions = [ 0x100, 0xc00 ];
+        uint[] runtimeFunctions = [0x100, 0xc00];
 
         TargetPointer r2rInfo = emBuilder.AddReadyToRunInfo(runtimeFunctions, []);
         MockDescriptors.HashMap hashMapBuilder = new(emBuilder.Builder);
@@ -396,13 +396,61 @@ public class ExecutionManagerTests
         Assert.Equal(new TargetPointer(codeRangeStart), actualBaseAddress);
     }
 
+    [Theory]
+    [MemberData(nameof(StdArchAllVersions))]
+    public void GetMethodDesc_CollectibleFragmentNext(int version, MockTarget.Architecture arch)
+    {
+        // Regression test: RangeSectionFragment.Next uses bit 0 as a collectible flag (see
+        // RangeSectionFragmentPointer in codeman.h). If the cDAC fails to strip this bit before
+        // following the pointer, it reads from a misaligned address and produces garbage data.
+        // This test creates a two-fragment chain where the head fragment (in the map) has an empty
+        // range and its Next pointer has the collectible tag bit set. The tail fragment (not in the
+        // map) covers the actual code range. The lookup must traverse the chain to find the method.
+        const ulong codeRangeStart = 0x0a0a_0000u;
+        const uint codeRangeSize = 0xc000u;
+        const uint methodSize = 0x450;
+
+        TargetPointer jitManagerAddress = new(0x000b_ff00);
+        TargetPointer expectedMethodDescAddress = new TargetPointer(0x0101_aaa0);
+
+        MockDescriptors.ExecutionManager emBuilder = new(version, arch, MockDescriptors.ExecutionManager.DefaultAllocationRange);
+        var jittedCode = emBuilder.AllocateJittedCodeRange(codeRangeStart, codeRangeSize);
+
+        TargetCodePointer methodStart = emBuilder.AddJittedMethod(jittedCode, methodSize, expectedMethodDescAddress);
+
+        NibbleMapTestBuilderBase nibBuilder = emBuilder.CreateNibbleMap(codeRangeStart, codeRangeSize);
+        nibBuilder.AllocateCodeChunk(methodStart, methodSize);
+
+        TargetPointer codeHeapListNodeAddress = emBuilder.AddCodeHeapListNode(TargetPointer.Null, codeRangeStart, codeRangeStart + codeRangeSize, codeRangeStart, nibBuilder.NibbleMapFragment.Address);
+        TargetPointer rangeSectionAddress = emBuilder.AddRangeSection(jittedCode, jitManagerAddress, codeHeapListNodeAddress);
+
+        // Tail fragment: covers the real code range but is NOT in the range section map.
+        // It is only reachable by following the head fragment's Next pointer.
+        TargetPointer tailFragmentAddress = emBuilder.AddUnmappedRangeSectionFragment(jittedCode, rangeSectionAddress);
+
+        // Head fragment: inserted into the map with an empty range (Contains always returns false)
+        // and Next = tailFragmentAddress | 1 (collectible tag bit set).
+        TargetPointer headFragmentAddress = emBuilder.AddRangeSectionFragmentWithCollectibleNext(jittedCode, rangeSectionAddress, tailFragmentAddress);
+
+        var target = CreateTarget(emBuilder);
+
+        var em = target.Contracts.ExecutionManager;
+        Assert.NotNull(em);
+
+        var eeInfo = em.GetCodeBlockHandle(methodStart);
+        Assert.NotNull(eeInfo);
+        TargetPointer actualMethodDesc = em.GetMethodDesc(eeInfo.Value);
+        Assert.Equal(expectedMethodDescAddress, actualMethodDesc);
+    }
+
     public static IEnumerable<object[]> StdArchAllVersions()
     {
         const int highestVersion = 2;
-        foreach(object[] arr in new MockTarget.StdArch())
+        foreach (object[] arr in new MockTarget.StdArch())
         {
             MockTarget.Architecture arch = (MockTarget.Architecture)arr[0];
-            for(int version = 1; version <= highestVersion; version++){
+            for (int version = 1; version <= highestVersion; version++)
+            {
                 yield return new object[] { version, arch };
             }
         }

--- a/src/native/managed/cdac/tests/ExecutionManager/ExecutionManagerTests.cs
+++ b/src/native/managed/cdac/tests/ExecutionManager/ExecutionManagerTests.cs
@@ -430,7 +430,7 @@ public class ExecutionManagerTests
 
         // Head fragment: inserted into the map with an empty range (Contains always returns false)
         // and Next = tailFragmentAddress | 1 (collectible tag bit set).
-        TargetPointer headFragmentAddress = emBuilder.AddRangeSectionFragmentWithCollectibleNext(jittedCode, rangeSectionAddress, tailFragmentAddress);
+        _ = emBuilder.AddRangeSectionFragmentWithCollectibleNext(jittedCode, rangeSectionAddress, tailFragmentAddress);
 
         var target = CreateTarget(emBuilder);
 

--- a/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.ExecutionManager.cs
+++ b/src/native/managed/cdac/tests/MockDescriptors/MockDescriptors.ExecutionManager.cs
@@ -371,11 +371,29 @@ internal partial class MockDescriptors
 
         public TargetPointer AddRangeSectionFragment(JittedCodeRange jittedCodeRange, TargetPointer rangeSectionAddress)
         {
+            return AddRangeSectionFragment(jittedCodeRange, rangeSectionAddress, insertIntoMap: true);
+        }
+
+        /// <summary>
+        /// Creates a range section fragment in memory without inserting it into the range section map.
+        /// Use this for fragments that should only be reachable via another fragment's <c>Next</c> pointer
+        /// (e.g., the tail of a collectible fragment chain).
+        /// </summary>
+        public TargetPointer AddUnmappedRangeSectionFragment(JittedCodeRange jittedCodeRange, TargetPointer rangeSectionAddress)
+        {
+            return AddRangeSectionFragment(jittedCodeRange, rangeSectionAddress, insertIntoMap: false);
+        }
+
+        private TargetPointer AddRangeSectionFragment(JittedCodeRange jittedCodeRange, TargetPointer rangeSectionAddress, bool insertIntoMap)
+        {
             var tyInfo = Types[DataType.RangeSectionFragment];
             uint rangeSectionFragmentSize = tyInfo.Size.Value;
             MockMemorySpace.HeapFragment rangeSectionFragment = _rangeSectionMapAllocator.Allocate(rangeSectionFragmentSize, "RangeSectionFragment");
-            // FIXME: this shouldn't really be called InsertAddressRange, but maybe InsertRangeSectionFragment?
-            _rsmBuilder.InsertAddressRange(jittedCodeRange.RangeStart, (uint)jittedCodeRange.RangeSize, rangeSectionFragment.Address);
+            if (insertIntoMap)
+            {
+                // FIXME: this shouldn't really be called InsertAddressRange, but maybe InsertRangeSectionFragment?
+                _rsmBuilder.InsertAddressRange(jittedCodeRange.RangeStart, (uint)jittedCodeRange.RangeSize, rangeSectionFragment.Address);
+            }
             Builder.AddHeapFragment(rangeSectionFragment);
             int pointerSize = Builder.TargetTestHelpers.PointerSize;
             Span<byte> rsf = Builder.BorrowAddressRange(rangeSectionFragment.Address, (int)rangeSectionFragmentSize);
@@ -383,7 +401,35 @@ internal partial class MockDescriptors
             Builder.TargetTestHelpers.WritePointer(rsf.Slice(tyInfo.Fields[nameof(Data.RangeSectionFragment.RangeEndOpen)].Offset, pointerSize), jittedCodeRange.RangeEnd);
             Builder.TargetTestHelpers.WritePointer(rsf.Slice(tyInfo.Fields[nameof(Data.RangeSectionFragment.RangeSection)].Offset, pointerSize), rangeSectionAddress);
             /* Next = nullptr */
-            // nothing
+            return rangeSectionFragment.Address;
+        }
+
+        /// <summary>
+        /// Adds a range section fragment whose <c>Next</c> pointer has bit 0 set (the collectible tag).
+        /// In the native runtime, <c>RangeSectionFragmentPointer</c> (see codeman.h) uses bit 0 to mark
+        /// fragments belonging to collectible assembly load contexts. The cDAC must strip this bit before
+        /// dereferencing <c>Next</c>; failing to do so causes reads at a misaligned address, producing
+        /// garbage field values. This helper enables testing that the tag bit is correctly stripped.
+        /// </summary>
+        /// <param name="mapCodeRange">The code range whose map entries should point to this fragment.</param>
+        /// <param name="rangeSectionAddress">The <c>RangeSection</c> this fragment belongs to.</param>
+        /// <param name="nextFragmentAddress">The actual address of the next fragment in the linked list
+        /// (the collectible tag bit will be OR'd onto this value).</param>
+        /// <returns>The address of the newly created head fragment.</returns>
+        public TargetPointer AddRangeSectionFragmentWithCollectibleNext(JittedCodeRange mapCodeRange, TargetPointer rangeSectionAddress, TargetPointer nextFragmentAddress)
+        {
+            var tyInfo = Types[DataType.RangeSectionFragment];
+            uint rangeSectionFragmentSize = tyInfo.Size.Value;
+            MockMemorySpace.HeapFragment rangeSectionFragment = _rangeSectionMapAllocator.Allocate(rangeSectionFragmentSize, "RangeSectionFragment (collectible head)");
+            // Insert this fragment into the map, overriding any existing entry for the range
+            _rsmBuilder.InsertAddressRange(mapCodeRange.RangeStart, (uint)mapCodeRange.RangeSize, rangeSectionFragment.Address);
+            Builder.AddHeapFragment(rangeSectionFragment);
+            int pointerSize = Builder.TargetTestHelpers.PointerSize;
+            Span<byte> rsf = Builder.BorrowAddressRange(rangeSectionFragment.Address, (int)rangeSectionFragmentSize);
+            // RangeBegin and RangeEndOpen are zero-initialized (empty range, Contains always returns false)
+            Builder.TargetTestHelpers.WritePointer(rsf.Slice(tyInfo.Fields[nameof(Data.RangeSectionFragment.RangeSection)].Offset, pointerSize), rangeSectionAddress);
+            // Write Next with the collectible tag bit (bit 0) set
+            Builder.TargetTestHelpers.WritePointer(rsf.Slice(tyInfo.Fields[nameof(Data.RangeSectionFragment.Next)].Offset, pointerSize), nextFragmentAddress.Value | 1);
             return rangeSectionFragment.Address;
         }
 


### PR DESCRIPTION
## Summary

The native runtime's `RangeSectionFragmentPointer` (codeman.h) uses bit 0 of the `Next` pointer as a collectible flag for fragments belonging to collectible assembly load contexts. The cDAC was reading the raw tagged pointer without stripping this bit, causing reads at a misaligned address that produced garbage field values and `VirtualReadException` during stack walks.

## Root Cause

In the native runtime, `RangeSectionFragment` nodes are linked via `RangeSectionFragmentPointer`, which stores a tagged pointer where bit 0 indicates whether the fragment belongs to a collectible ALC. The native code's `VolatileLoadWithoutBarrier` strips this bit before returning the fragment address. The cDAC's `Data.RangeSectionFragment` class was reading the raw `Next` field without stripping the bit. When following a linked list of fragments, the cDAC used the tagged address (off by 1 byte), causing all subsequent field reads to return garbage data.

Note: The cDAC already correctly strips the tag from interior map pointers via `InteriorMapValue.Address` and from the initial fragment pointer in `FindFragment`. Only the `RangeSectionFragment.Next` linked-list pointer was missed.

## Fix

Strip bit 0 from the `Next` pointer when reading it in the `RangeSectionFragment` constructor:

```csharp
Next = target.ReadPointer(address + (ulong)type.Fields[nameof(Next)].Offset) & ~1ul;
```

## Testing

- Added `GetMethodDesc_CollectibleFragmentNext` regression test that creates a two-fragment chain where the head fragment's `Next` has the collectible tag bit set. The test **fails without the fix** (`VirtualReadException`) and **passes with it**.
- All 876 existing cDAC unit tests pass.
- Verified against a CI dump from a failing `SOS.DualRuntimes` test: all 15 threads now walk to completion.

## Documentation

- Updated `docs/design/datacontracts/ExecutionManager.md` to document the tagged pointer convention on `RangeSectionFragment.Next` and added a "Tagged pointers in the range section map" subsection.
