### PR TITLE
Fix copy-paste error in `is` check for character base64 decoding

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64DecoderHelper.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/Text/Base64Helper/Base64DecoderHelper.cs
@@ -607,7 +607,7 @@ namespace System.Buffers.Text
 
                 bool hasAnotherBlock;
 
-                if (decoder is Base64DecoderByte)
+                if (decoder is Base64DecoderChar)
                 {
                     hasAnotherBlock = source.Length >= BlockSize;
                 }


### PR DESCRIPTION
Looks like the `DecodeWithWhiteSpaceBlockwise` method was copied in https://github.com/dotnet/runtime/pull/123151 and didn't update the `is` check when going from `IBase64Decoder<byte>` -> `IBase64Decoder<ushort>`. This results in the `is` check always being false which will create a little bit of extra work in `DecodeFrom`.