### PR TITLE
Fix type formatting in logging source generator test

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithRefReadOnlyParam.generated.txt
+++ b/src/libraries/Microsoft.Extensions.Logging.Abstractions/tests/Microsoft.Extensions.Logging.Generators.Tests/Baselines/TestWithRefReadOnlyParam.generated.txt
@@ -6,15 +6,15 @@ namespace Microsoft.Extensions.Logging.Generators.Tests.TestClasses
     partial class TestWithRefReadOnlyParam
     {
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "%VERSION%")]
-        private static readonly global::System.Action<global::Microsoft.Extensions.Logging.ILogger, global::System.Int32, global::System.Exception?> __MCallback =
-            global::Microsoft.Extensions.Logging.LoggerMessage.Define<global::System.Int32>(global::Microsoft.Extensions.Logging.LogLevel.Debug, new global::Microsoft.Extensions.Logging.EventId(0, nameof(M)), "Parameter {p1}", new global::Microsoft.Extensions.Logging.LogDefineOptions() { SkipEnabledCheck = true });
+        private static readonly global::System.Action<global::Microsoft.Extensions.Logging.ILogger, int, global::System.Exception?> __MCallback =
+            global::Microsoft.Extensions.Logging.LoggerMessage.Define<int>(global::Microsoft.Extensions.Logging.LogLevel.Debug, new global::Microsoft.Extensions.Logging.EventId(0, nameof(M)), "Parameter {p1}", new global::Microsoft.Extensions.Logging.LogDefineOptions() { SkipEnabledCheck = true });
 
         /// <summary>
         /// <para><b>Message:</b> Parameter {p1}</para>
         /// <para><b>Level:</b> Debug</para>
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "%VERSION%")]
-        public static partial void M(global::Microsoft.Extensions.Logging.ILogger logger, ref readonly global::System.Int32 p1)
+        public static partial void M(global::Microsoft.Extensions.Logging.ILogger logger, ref readonly int p1)
         {
             if (logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
             {


### PR DESCRIPTION
This happened because I didn't test https://github.com/dotnet/runtime/pull/124638 and https://github.com/dotnet/runtime/pull/124589 together (they contained changes that influenced each other).

This fixes the CI failure mentioned in https://github.com/dotnet/runtime/pull/124957#issuecomment-3972477480.

cc: @akoeplinger 