### PR TITLE
Pass `MessageOrigin` to the `DoAdditional*Processing` methods.

### DIFF
--- a/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/MarkStep.cs
@@ -1856,7 +1856,7 @@ namespace Mono.Linker.Steps
             MarkType(field.FieldType, new DependencyInfo(DependencyKind.FieldType, field), fieldOrigin);
             MarkCustomAttributes(field, new DependencyInfo(DependencyKind.CustomAttribute, field), fieldOrigin);
             MarkMarshalSpec(field, new DependencyInfo(DependencyKind.FieldMarshalSpec, field), fieldOrigin);
-            DoAdditionalFieldProcessing(field);
+            DoAdditionalFieldProcessing(field, fieldOrigin);
 
             // If we accessed a field on a type and the type has explicit/sequential layout, make sure to keep
             // all the other fields.
@@ -2250,7 +2250,7 @@ namespace Mono.Linker.Steps
                 }
             }
 
-            DoAdditionalTypeProcessing(type);
+            DoAdditionalTypeProcessing(type, typeOrigin);
 
             ApplyPreserveInfo(type);
             ApplyPreserveMethods(type, typeOrigin);
@@ -2269,27 +2269,27 @@ namespace Mono.Linker.Steps
         }
 
         // Allow subclassers to mark additional things
-        protected virtual void DoAdditionalTypeProcessing(TypeDefinition type)
+        protected virtual void DoAdditionalTypeProcessing(TypeDefinition type, MessageOrigin origin)
         {
         }
 
         // Allow subclassers to mark additional things
-        protected virtual void DoAdditionalFieldProcessing(FieldDefinition field)
+        protected virtual void DoAdditionalFieldProcessing(FieldDefinition field, MessageOrigin origin)
         {
         }
 
         // Allow subclassers to mark additional things
-        protected virtual void DoAdditionalPropertyProcessing(PropertyDefinition property)
+        protected virtual void DoAdditionalPropertyProcessing(PropertyDefinition property, MessageOrigin origin)
         {
         }
 
         // Allow subclassers to mark additional things
-        protected virtual void DoAdditionalEventProcessing(EventDefinition evt)
+        protected virtual void DoAdditionalEventProcessing(EventDefinition evt, MessageOrigin origin)
         {
         }
 
         // Allow subclassers to mark additional things
-        protected virtual void DoAdditionalInstantiatedTypeProcessing(TypeDefinition type)
+        protected virtual void DoAdditionalInstantiatedTypeProcessing(TypeDefinition type, MessageOrigin origin)
         {
         }
 
@@ -3468,13 +3468,13 @@ namespace Mono.Linker.Steps
                 }
             }
 
-            DoAdditionalMethodProcessing(method);
+            DoAdditionalMethodProcessing(method, methodOrigin);
 
             ApplyPreserveMethods(method, methodOrigin);
         }
 
         // Allow subclassers to mark additional things when marking a method
-        protected virtual void DoAdditionalMethodProcessing(MethodDefinition method)
+        protected virtual void DoAdditionalMethodProcessing(MethodDefinition method, MessageOrigin origin)
         {
         }
 
@@ -3539,7 +3539,7 @@ namespace Mono.Linker.Steps
 
             _typeMapHandler.ProcessInstantiated(type);
 
-            DoAdditionalInstantiatedTypeProcessing(type);
+            DoAdditionalInstantiatedTypeProcessing(type, typeOrigin);
         }
 
         void MarkRuntimeInterfaceImplementation(MethodDefinition method, MethodReference ov)
@@ -3757,7 +3757,7 @@ namespace Mono.Linker.Steps
 
             // Consider making this more similar to MarkEvent method?
             MarkCustomAttributes(prop, new DependencyInfo(DependencyKind.CustomAttribute, prop), propertyOrigin);
-            DoAdditionalPropertyProcessing(prop);
+            DoAdditionalPropertyProcessing(prop, propertyOrigin);
         }
 
         protected internal virtual void MarkEvent(EventDefinition evt, in DependencyInfo reason, MessageOrigin origin)
@@ -3774,7 +3774,7 @@ namespace Mono.Linker.Steps
 
             var eventOrigin = new MessageOrigin(evt);
             MarkCustomAttributes(evt, new DependencyInfo(DependencyKind.CustomAttribute, evt), eventOrigin);
-            DoAdditionalEventProcessing(evt);
+            DoAdditionalEventProcessing(evt, eventOrigin);
         }
 
         internal void MarkMethodIfNotNull(MethodReference method, in DependencyInfo reason, in MessageOrigin origin)


### PR DESCRIPTION
The `MessageOrigin` plays an important role now days.  Pass it along to the `DoAdditional*Processing` methods.