### PR TITLE
Clean up `SkipUnresolved` handling in linker test framework.

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/CoreLibraryAssemblyAttributesAreKept.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/CoreLibraryAssemblyAttributesAreKept.cs
@@ -10,7 +10,7 @@ namespace Mono.Linker.Tests.Cases.Attributes
     [SetupLinkerTrimMode("link")]
     // System.dll referenced by a dynamically (for example in TypeConverterAttribute on IComponent)
     // has unresolved references.
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [KeptAttributeInAssembly(PlatformAssemblies.CoreLib, typeof(AssemblyDescriptionAttribute))]
     [KeptAttributeInAssembly(PlatformAssemblies.CoreLib, typeof(AssemblyCompanyAttribute))]
 #if !NET

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/IVTUsed.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/IVTUsed.cs
@@ -13,7 +13,7 @@ namespace Mono.Linker.Tests.Cases.Attributes
 
     // This is a bit fragile but it's used to test that ITV attribute is marked correctly
     [SetupLinkerTrimMode("link")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [KeptTypeInAssembly(PlatformAssemblies.CoreLib, typeof(InternalsVisibleToAttribute))]
     class IVTUsed
     {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnGenericParameterIsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnGenericParameterIsRemoved.cs
@@ -3,7 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [SetupLinkerArgument("--used-attrs-only", "true")]
     [Define("IL_ASSEMBLY_AVAILABLE")]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/AssemblyWithUnusedAttributeOnGenericParameter.il" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnReturnTypeIsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Attributes/OnlyKeepUsed/UnusedAttributeOnReturnTypeIsRemoved.cs
@@ -3,7 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Attributes.OnlyKeepUsed
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [SetupLinkerArgument("--used-attrs-only", "true")]
     [Define("IL_ASSEMBLY_AVAILABLE")]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/AssemblyWithUnusedAttributeOnReturnParameterDefinition.il" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/ComponentModel/CustomTypeConvertor.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/ComponentModel/CustomTypeConvertor.cs
@@ -57,7 +57,7 @@ namespace Mono.Linker.Tests.Cases.ComponentModel
     [Reference("System.dll")]
     // System.dll referenced by a dynamically (for example in TypeConverterAttribute on IComponent)
     // has unresolved references.
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     public class CustomTypeConvertor
     {
         public static void Main()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CppCLI/CppCLIAssemblyIsAnalyzed.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CppCLI/CppCLIAssemblyIsAnalyzed.cs
@@ -9,7 +9,7 @@ namespace Mono.Linker.Tests.Cases.CppCLI
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
     [ReferenceDependency("Dependencies/TestLibrary.dll")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
 
     [SetupCompileBefore("ManagedSide.dll", new[] { "Dependencies/CallCppCLIFromManagedRef.cs" })]
     [SetupCompileAfter("ManagedSide.dll", new[] { "Dependencies/CallCppCLIFromManaged.cs" }, references: new[] { "TestLibrary.dll" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CppCLI/NonCopyActionWarnOnCppCLI.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CppCLI/NonCopyActionWarnOnCppCLI.cs
@@ -9,7 +9,7 @@ namespace Mono.Linker.Tests.Cases.CppCLI
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
     [ReferenceDependency("Dependencies/TestLibrary.dll")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
 
     [SetupLinkerDefaultAction("copy")]
     [SetupLinkerAction("copyused", "TestLibrary")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/UnresolvedMembers.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DataFlow/UnresolvedMembers.cs
@@ -15,7 +15,7 @@ namespace Mono.Linker.Tests.Cases.DataFlow
     // it would fail to JIT/run anyway.
 
     [SkipILVerify]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [SetupCompileBefore("UnresolvedLibrary.dll", new[] { "Dependencies/UnresolvedLibrary.cs" }, removeFromLinkerInput: true)]
     [ExpectedNoWarnings]
     class UnresolvedMembers

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/DynamicDependencies/DynamicDependencyMethodInAssembly.cs
@@ -7,7 +7,7 @@ namespace Mono.Linker.Tests.Cases.DynamicDependencies
     [KeptMemberInAssembly("library.dll", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyMethodInAssemblyLibrary", ".ctor()")]
     [KeptMemberInAssembly("library.dll", "Mono.Linker.Tests.Cases.DynamicDependencies.Dependencies.DynamicDependencyMethodInAssemblyLibrary", "privateField")]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/DynamicDependencyMethodInAssemblyLibrary.cs" })]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     public class DynamicDependencyMethodInAssembly
     {
         public static void Main()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/DimProvidedByRecursiveInterface.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/DimProvidedByRecursiveInterface.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [TestCaseRequirements(TestRunCharacteristics.SupportsDefaultInterfaceMethods, "Requires support for default interface methods")]
     [Define("IL_ASSEMBLY_AVAILABLE")]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/DimProvidedByRecursiveInterface.il" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/InterfaceWithAttributeOnImplementation.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/InterfaceWithAttributeOnImplementation.cs
@@ -3,7 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [TestCaseRequirements(TestRunCharacteristics.SupportsDefaultInterfaceMethods, "Requires support for default interface methods")]
     [Define("IL_ASSEMBLY_AVAILABLE")]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/InterfaceWithAttributeOnImpl.il" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/MultipleDimsProvidedByRecursiveInterface.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/MultipleDimsProvidedByRecursiveInterface.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [TestCaseRequirements(TestRunCharacteristics.SupportsDefaultInterfaceMethods, "Requires support for default interface methods")]
     [Define("IL_ASSEMBLY_AVAILABLE")]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/MultipleDimsProvidedByRecursiveInterface.il" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/StaticDimProvidedByUnreferencedIfaceInHierarchy.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/DefaultInterfaceMethods/StaticDimProvidedByUnreferencedIfaceInHierarchy.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.DefaultInterfaceMethods
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [TestCaseRequirements(TestRunCharacteristics.SupportsDefaultInterfaceMethods, "Requires support for default interface methods")]
     [Define("IL_ASSEMBLY_AVAILABLE")]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/StaticDimProvidedByUnreferencedIfaceInHierarchy.il" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/InterfaceImplementedThroughBaseInterface.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/InterfaceImplementedThroughBaseInterface.cs
@@ -11,7 +11,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [SetupLinkerArgument("-a", "test.exe", "library")]
     [SetupLinkerArgument("-a", "library.dll", "library")]
     [TestCaseRequirements(TestRunCharacteristics.SupportsDefaultInterfaceMethods, "Requires support for default interface methods")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndAssemblyPreserveAll.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndAssemblyPreserveAll.cs
@@ -3,7 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
 
     [SetupCompileBefore("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
     [KeptInterfaceOnTypeInAssemblyAttribute("library",

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveAll.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveAll.cs
@@ -3,7 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
     [KeptInterfaceOnTypeInAssembly("library",
         "Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFields.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFields.cs
@@ -3,7 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 
     // The interfaces should be removed because the interface types are not marked

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFieldsWithInterfacesMarked.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveFieldsWithInterfacesMarked.cs
@@ -3,7 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Define("IL_ASSEMBLY_COMPILED")]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethods.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethods.cs
@@ -3,7 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 
     // The interfaces should be removed because the interface types are not marked

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethodsWithInterfacesMarked.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveMethodsWithInterfacesMarked.cs
@@ -3,7 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Define("IL_ASSEMBLY_COMPILED")]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveNone.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/OnReferenceType/NoInstanceCtor/NoInstanceCtorAndTypePreserveNone.cs
@@ -3,7 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/NoInstanceCtorAndAssemblyPreserveAll_Lib.il" })]
     [RemovedInterfaceOnTypeInAssembly("library",
         "Mono.Linker.Tests.Cases.Inheritance.Interfaces.OnReferenceType.NoInstanceCtor.Dependencies.NoInstanceCtorAndAssemblyPreserveAll_Lib/A",

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/RecursiveInterfaces/GenericInterfaceImplementedRecursively.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/RecursiveInterfaces/GenericInterfaceImplementedRecursively.cs
@@ -11,7 +11,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.RecursiveInterfaces
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [TestCaseRequirements(TestRunCharacteristics.SupportsDefaultInterfaceMethods, "Requires support for default interface methods")]
     [Define("IL_ASSEMBLY_AVAILABLE")]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/GenericInterfaceImplementedRecursively.il" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/RecursiveInterfaces/InterfaceImplementedRecursively.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/RecursiveInterfaces/InterfaceImplementedRecursively.cs
@@ -11,7 +11,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.RecursiveInterfaces
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [TestCaseRequirements(TestRunCharacteristics.SupportsDefaultInterfaceMethods, "Requires support for default interface methods")]
     [Define("IL_ASSEMBLY_AVAILABLE")]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/InterfaceImplementedRecursively.il" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/RecursiveInterfaces/OverrideOfRecursiveInterfaceIsRemoved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/RecursiveInterfaces/OverrideOfRecursiveInterfaceIsRemoved.cs
@@ -11,7 +11,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.RecursiveInterfaces
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Define("IL_ASSEMBLY_AVAILABLE")]
     [SetupCompileBefore("library.dll", new string[] { "Dependencies/OverrideOfRecursiveInterfaceIsRemoved.il" })]
     [Kept]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/InstanceMethodsWithOverridesSwept.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Inheritance.Interfaces/StaticInterfaceMethods/InstanceMethodsWithOverridesSwept.cs
@@ -17,7 +17,7 @@ namespace Mono.Linker.Tests.Cases.Inheritance.Interfaces.StaticInterfaceMethods
     /// Currently, the linker will always mark the .override method for instance methods, so there is not much testing required here.
     /// However, if that were to change, this test should be updated to verify that the .override is removed if the .interfaceImpl is kept.
     /// </summary>
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Define("IL_ASSEMBLY_AVAILABLE")]
     [SetupCompileBefore("library.dll", new string[] { "Dependencies/InstanceMethods.il" })]
     [Kept]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/LibraryWithUnresolvedInterfaces.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Libraries/LibraryWithUnresolvedInterfaces.cs
@@ -10,7 +10,7 @@ namespace Mono.Linker.Tests.Cases.Libraries
     [IgnoreTestCase("NativeAOT doesn't implement library trimming the same way", IgnoredBy = Tool.NativeAot)]
     [KeptAttributeAttribute(typeof(IgnoreTestCaseAttribute), By = Tool.Trimmer)]
     [SetupCompileBefore("copylibrary.dll", new[] { "Dependencies/CopyLibrary.cs" }, removeFromLinkerInput: true)]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [SetupLinkerArgument("-a", "test.exe", "library")]
     [SetupLinkerArgument("--enable-opt", "ipconstprop")]
     [VerifyMetadataNames]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkAttributeErrorCases.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkAttributes/LinkAttributeErrorCases.cs
@@ -7,7 +7,7 @@ namespace Mono.Linker.Tests.Cases.LinkAttributes
 {
     [SetupLinkAttributesFile("LinkAttributeErrorCases.xml")]
     [IgnoreLinkAttributes(false)]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [SetupCompileBefore("library.dll", new string[] { "Dependencies/EmbeddedAttributeErrorCases.cs" },
         resources: new object[] { new string[] { "Dependencies/EmbeddedAttributeErrorCases.xml", "ILLink.LinkAttributes.xml" } })]
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/LinkXml/LinkXmlErrorCases.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.LinkXml
 {
     [SetupLinkerDescriptorFile("LinkXmlErrorCases.xml")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [SetupLinkerArgument("--verbose")]
 
     [ExpectedWarning("IL2001", "TypeWithNoFields", FileName = "LinkXmlErrorCases.xml", SourceLine = 3, SourceColumn = 6)]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyErrorCases.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/PreserveDependencies/PreserveDependencyErrorCases.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 namespace Mono.Linker.Tests.Cases.PreserveDependencies
 {
     [SetupCompileBefore("FakeSystemAssembly.dll", new[] { "Dependencies/PreserveDependencyAttribute.cs" })]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     class PreserveDependencyErrorCases
     {
         public static void Main()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Individual/CanSkipUnresolved.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/Individual/CanSkipUnresolved.cs
@@ -5,7 +5,7 @@ namespace Mono.Linker.Tests.Cases.References.Individual
 {
     [SetupCompileBefore("library1.dll", new[] { "Dependencies/CanSkipUnresolved_Library.cs" })]
     [SetupCompileAfter("library1.dll", new[] { "Dependencies/CanSkipUnresolved_Library.cs" }, defines: new[] { "EXCLUDE_STUFF" })]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     public class CanSkipUnresolved
     {
         static void Main()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/MissingReferenceInUnusedCodePath.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/MissingReferenceInUnusedCodePath.cs
@@ -11,7 +11,7 @@ namespace Mono.Linker.Tests.Cases.References;
 [NoLinkedOutput]
 [SetupCompileBefore("missing.dll", new[] { "Dependencies/MissingAssembly.cs" })]
 [DeleteBefore("missing.dll")]
-[SetupLinkerArgument("--skip-unresolved", "false")]
+[SkipUnresolved(false)]
 public class MissingReferenceInUnusedCodePath
 {
     public static void Main()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/References/MissingReferenceInUsedCodePath.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/References/MissingReferenceInUsedCodePath.cs
@@ -11,7 +11,7 @@ namespace Mono.Linker.Tests.Cases.References;
 [NoLinkedOutput]
 [SetupCompileBefore("missing.dll", new[] { "Dependencies/MissingAssembly.cs" })]
 [DeleteBefore("missing.dll")]
-[SetupLinkerArgument("--skip-unresolved", "false")]
+[SkipUnresolved(false)]
 public class MissingReferenceInUsedCodePath
 {
     public static void Main()

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdb.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdb.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Reference("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
     [ReferenceDependency("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
     [SetupLinkerLinkSymbols("false")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbCopyAction.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbCopyAction.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Reference("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
     [ReferenceDependency("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
     [SetupLinkerLinkSymbols("false")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteAction.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteAction.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Reference("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
     [ReferenceDependency("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
     [SetupLinkerLinkSymbols("false")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteActionAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithMdbDeleteActionAndSymbolLinkingEnabled.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Reference("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
     [ReferenceDependency("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
     [SetupLinkerLinkSymbols("true")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdb.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdb.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Reference("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
     [ReferenceDependency("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
     [SetupLinkerLinkSymbols("false")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabled.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Reference("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
     [ReferenceDependency("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
     [SetupLinkerLinkSymbols("true")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndDeterministicMvid.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndDeterministicMvid.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Reference("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
     [ReferenceDependency("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
     [SetupLinkerLinkSymbols("true")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndNewMvid.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbAndSymbolLinkingEnabledAndNewMvid.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Reference("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
     [ReferenceDependency("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
     [SetupLinkerLinkSymbols("true")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbCopyAction.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbCopyAction.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Reference("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
     [ReferenceDependency("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
     [SetupLinkerLinkSymbols("false")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteAction.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteAction.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Reference("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
     [ReferenceDependency("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
     [SetupLinkerLinkSymbols("false")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteActionAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferenceWithPdbDeleteActionAndSymbolLinkingEnabled.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Reference("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
     [ReferenceDependency("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
     [SetupLinkerLinkSymbols("true")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypes.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypes.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Reference("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
     [ReferenceDependency("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypesAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypesAndSymbolLinkingEnabled.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Symbols.Dependencies;
 namespace Mono.Linker.Tests.Cases.Symbols
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Reference("Dependencies/LibraryWithPdb/LibraryWithPdb.dll")]
     [ReferenceDependency("Dependencies/LibraryWithPdb/LibraryWithPdb.pdb")]
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypesWithMdbAndSymbolLinkingEnabled.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Symbols/ReferencesWithMixedSymbolTypesWithMdbAndSymbolLinkingEnabled.cs
@@ -9,7 +9,7 @@ namespace Mono.Linker.Tests.Cases.Symbols
 {
     [IgnoreTestCase("Test relies on checked-in binaries: https://github.com/dotnet/runtime/issues/78344")]
     [TestCaseRequirements(TestRunCharacteristics.TargetingNetFramework, "mdb files are not supported with .NET Core")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Reference("Dependencies/LibraryWithMdb/LibraryWithMdb.dll")]
     [ReferenceDependency("Dependencies/LibraryWithMdb/LibraryWithMdb.dll.mdb")]
 

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileILAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/CanCompileILAssembly.cs
@@ -4,7 +4,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.TestFramework
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Define("IL_ASSEMBLY_AVAILABLE")]
     [SetupCompileBefore("ILAssembly.dll", new[] { "Dependencies/ILAssemblySample.il" })]
     [KeptMemberInAssembly("ILAssembly.dll", "Mono.Linker.Tests.Cases.TestFramework.Dependencies.ILAssemblySample", "GiveMeAValue()")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/ILVerificationErrorsCanBeIgnored.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/ILVerificationErrorsCanBeIgnored.cs
@@ -8,7 +8,7 @@ namespace Mono.Linker.Tests.Cases.TestFramework;
 
 [DisableILVerifyDiffing] // Needed to produce an il failure
 [IgnoreILFailure("Mono.Linker.Tests.Cases.TestFramework.Dependencies.AssemblyWithInvalidIL.GiveMeAValue() - ReturnMissing: Return value missing on the stack. -  Offset IL_0000")]
-[SetupLinkerArgument("--skip-unresolved", "true")] // needed due to the mscorlib shim
+[SkipUnresolved(true)] // needed due to the mscorlib shim
 [Define("IL_ASSEMBLY_AVAILABLE")]
 [SetupCompileBefore("ILAssembly.dll", new[] { "Dependencies/AssemblyWithInvalidIL.il" })]
 [KeptMemberInAssembly("ILAssembly.dll", "Mono.Linker.Tests.Cases.TestFramework.Dependencies.AssemblyWithInvalidIL", "GiveMeAValue()")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/ILVerificationWorks.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/ILVerificationWorks.cs
@@ -10,7 +10,7 @@ namespace Mono.Linker.Tests.Cases.TestFramework;
 [ExpectILFailure("Mono.Linker.Tests.Cases.TestFramework.Dependencies.AssemblyWithInvalidIL.GiveMeAValue()",
     "ReturnMissing: Return value missing on the stack",
     "Offset IL_0000")]
-[SetupLinkerArgument("--skip-unresolved", "true")] // needed due to the mscorlib shim
+[SkipUnresolved(true)] // needed due to the mscorlib shim
 [Define("IL_ASSEMBLY_AVAILABLE")]
 [SetupCompileBefore("ILAssembly.dll", new[] { "Dependencies/AssemblyWithInvalidIL.il" })]
 [KeptMemberInAssembly("ILAssembly.dll", "Mono.Linker.Tests.Cases.TestFramework.Dependencies.AssemblyWithInvalidIL", "GiveMeAValue()")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/SecurityAttributeScope.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/SecurityAttributeScope.cs
@@ -12,7 +12,7 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
     ///
     /// In order words, until https://github.com/dotnet/linker/issues/1703 is addressed this test will pass with or without the fix to update the scope on security attributes
     /// </summary>
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [SetupLinkerArgument("--strip-security", "false")]
     [Define("IL_ASSEMBLY_AVAILABLE")]
     [SetupLinkerAction("copy", "Library")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardersModifiers.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardersModifiers.cs
@@ -3,7 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.TypeForwarding
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     // Actions:
     // link - This assembly, TypeForwarderModifiersLibDef.dll and TypeForwardersModifiersLib.dll
     [SetupLinkerDefaultAction("link")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardersRewrite.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TypeForwarding/TypeForwardersRewrite.cs
@@ -7,7 +7,7 @@ namespace Mono.Linker.Tests.Cases.TypeForwarding
     // Actions:
     // link - This assembly, Forwarder.dll and Implementation.dll
 
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
 
     [SetupCompileArgument("/unsafe")]
     [SetupCompileBefore("Forwarder.dll", new[] { "Dependencies/TypeForwardersRewriteLib.cs" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/EndScopeOnMethoEnd.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/EndScopeOnMethoEnd.cs
@@ -5,7 +5,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBlock
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Define("IL_ASSEMBLY_AVAILABLE")]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/EndScopeOnMethod.il" })]
     public class EndScopeOnMethoEnd

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/UninitializedLocals.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBlock/UninitializedLocals.cs
@@ -5,7 +5,7 @@ namespace Mono.Linker.Tests.Cases.UnreachableBlock
 {
     [SetupCSharpCompilerToUse("csc")]
     [SetupCompileArgument("/optimize+")]
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Define("IL_ASSEMBLY_AVAILABLE")]
     [SetupCompileBefore("library.dll", new[] { "Dependencies/LocalsWithoutStore.il" })]
     [SetupLinkerArgument("--enable-opt", "ipconstprop")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBody/DoesNotApplyToCopiedAssembly2.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBody/DoesNotApplyToCopiedAssembly2.cs
@@ -3,7 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBody
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Define("OTHER_INCLUDED")]
     [SetupLinkerAction("copy", "other")]
     [SetupCompileBefore("other.dll", new[] { "Dependencies/OtherAssemblyNoInstanceCtor.il" })]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBody/LinkedOtherIncludedLibraryNoInstanceCtor.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/UnreachableBody/LinkedOtherIncludedLibraryNoInstanceCtor.cs
@@ -3,7 +3,7 @@ using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
 namespace Mono.Linker.Tests.Cases.UnreachableBody
 {
-    [SetupLinkerArgument("--skip-unresolved", "true")]
+    [SkipUnresolved(true)]
     [Define("OTHER_INCLUDED")]
 #if NET
     [SetupLinkerArgument("-a", "other.dll", "visible")]

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadataProvider.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestCaseMetadataProvider.cs
@@ -31,7 +31,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
                 LinkSymbols = GetOptionAttributeValue(nameof(SetupLinkerLinkSymbolsAttribute), string.Empty),
                 TrimMode = GetOptionAttributeValue<string>(nameof(SetupLinkerTrimModeAttribute), null),
                 DefaultAssembliesAction = GetOptionAttributeValue<string>(nameof(SetupLinkerDefaultActionAttribute), null),
-                SkipUnresolved = GetOptionAttributeValue(nameof(SkipUnresolvedAttribute), false),
+                SkipUnresolved = GetOptionAttributeValue(nameof(SkipUnresolvedAttribute), true),
                 StripDescriptors = GetOptionAttributeValue(nameof(StripDescriptorsAttribute), true),
                 StripSubstitutions = GetOptionAttributeValue(nameof(StripSubstitutionsAttribute), true),
                 StripLinkAttributes = GetOptionAttributeValue(nameof(StripLinkAttributesAttribute), true),

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TrimmingArgumentBuilder.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TrimmingArgumentBuilder.cs
@@ -121,11 +121,8 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
         public virtual void AddSkipUnresolved(bool skipUnresolved)
         {
-            if (skipUnresolved)
-            {
-                Append("--skip-unresolved");
-                Append("true");
-            }
+            Append("--skip-unresolved");
+            Append(skipUnresolved.ToString());
         }
 
         public virtual void AddStripDescriptors(bool stripDescriptors)


### PR DESCRIPTION
* The default value of `SkipUnresolved` in the test framework was false.  This doesn't align with the default value used by ILLink itself which is true.

* When `SkipUnresolved` was false, `AddSkipUnresolved` would do nothing.  This meant that tests that explicitly try to use false wouldn't actually run with SkipUnresolved=False.  Instead the linker would run with it's default value of `true`.

* Switch SkipUnresolved tests to use the attribute.  Using the attribute ensures that we either get the default value or the value the test requested.