### PR TITLE
Make `CustomizeTrimming` virtual

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TestRunner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Trimming.Tests/TestCasesRunner/TestRunner.cs
@@ -40,7 +40,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
             }
         }
 
-        protected partial TrimmingCustomizations? CustomizeTrimming(TrimmingDriver linker, TestCaseMetadataProvider metadataProvider)
+        protected virtual partial TrimmingCustomizations? CustomizeTrimming(TrimmingDriver linker, TestCaseMetadataProvider metadataProvider)
             => null;
 
         protected partial void AddDumpDependenciesOptions(TestCaseLinkerOptions caseDefinedOptions, ManagedCompilationResult compilationResult, TrimmingArgumentBuilder builder, TestCaseMetadataProvider metadataProvider)

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestRunner.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestRunner.cs
@@ -40,7 +40,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
             }
         }
 
-        protected partial TrimmingCustomizations? CustomizeTrimming(TrimmingDriver linker, TestCaseMetadataProvider metadataProvider)
+        protected virtual partial TrimmingCustomizations? CustomizeTrimming(TrimmingDriver linker, TestCaseMetadataProvider metadataProvider)
         {
             TrimmingCustomizations customizations = new TrimmingCustomizations();
 

--- a/src/tools/illink/test/Trimming.Tests.Shared/TestRunner.cs
+++ b/src/tools/illink/test/Trimming.Tests.Shared/TestRunner.cs
@@ -201,7 +201,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
             builder.ProcessTestInputAssembly(compilationResult.InputAssemblyPath);
         }
 
-        protected partial TrimmingCustomizations? CustomizeTrimming(TrimmingDriver linker, TestCaseMetadataProvider metadataProvider);
+        protected virtual partial TrimmingCustomizations? CustomizeTrimming(TrimmingDriver linker, TestCaseMetadataProvider metadataProvider);
 
         protected partial void AddDumpDependenciesOptions(TestCaseLinkerOptions caseDefinedOptions, ManagedCompilationResult compilationResult, TrimmingArgumentBuilder builder, TestCaseMetadataProvider metadataProvider);
 


### PR DESCRIPTION
Unity's test framework needs to override this.  At some point between net8 and now this was refactored and the `virtual` was dropped.