### PR TITLE
[cDAC] Fix com lifetime bug in GetHandleEnum

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -1510,6 +1510,7 @@ public sealed unsafe partial class SOSDacImpl
             }
 #endif
             ppHandleEnum = new SOSHandleEnum(_target, supportedHandleTypes, legacyHandleEnum);
+            _ = Marshal.GetIUnknownForObject(ppHandleEnum);
         }
         catch (System.Exception ex)
         {
@@ -1536,6 +1537,7 @@ public sealed unsafe partial class SOSDacImpl
             IGC gc = _target.Contracts.GC;
             HandleType[] handleTypes = gc.GetHandleTypes(types);
             ppHandleEnum = new SOSHandleEnum(_target, handleTypes, legacyHandleEnum);
+            _ = Marshal.GetIUnknownForObject(ppHandleEnum);
         }
         catch (System.Exception ex)
         {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -1510,7 +1510,9 @@ public sealed unsafe partial class SOSDacImpl
             }
 #endif
             ppHandleEnum = new SOSHandleEnum(_target, supportedHandleTypes, legacyHandleEnum);
-            _ = Marshal.GetIUnknownForObject(ppHandleEnum);
+            // COMPAT: In the legacy DAC, this API leaks a ref-count of the returned enumerator.
+            // Manually leak a refcount here to match previous behavior and avoid breaking customer code.
+            ComInterfaceMarshaller<ISOSHandleEnum>.ConvertToUnmanaged(ppHandleEnum);
         }
         catch (System.Exception ex)
         {
@@ -1537,7 +1539,9 @@ public sealed unsafe partial class SOSDacImpl
             IGC gc = _target.Contracts.GC;
             HandleType[] handleTypes = gc.GetHandleTypes(types);
             ppHandleEnum = new SOSHandleEnum(_target, handleTypes, legacyHandleEnum);
-            _ = Marshal.GetIUnknownForObject(ppHandleEnum);
+            // COMPAT: In the legacy DAC, this API leaks a ref-count of the returned enumerator.
+            // Manually leak a refcount here to match previous behavior and avoid breaking customer code.
+            ComInterfaceMarshaller<ISOSHandleEnum>.ConvertToUnmanaged(ppHandleEnum);
         }
         catch (System.Exception ex)
         {


### PR DESCRIPTION
Fixing bug shown in https://dev.azure.com/dnceng-public/public/_build/results?buildId=1311638. We do a QI in the dac, incrementing the refcount; this fix increments the refcount in the cDAC as well.