### PR TITLE
[cDAC] Fix NonVirtualEntry2MethodDesc to handle invalid precode addresses

### DIFF
--- a/src/native/managed/cdac/tests/DumpTests/VarargPInvokeDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/VarargPInvokeDumpTests.cs
@@ -170,14 +170,22 @@ public class VarargPInvokeDumpTests : DumpTestBase
                 continue;
 
             // The entry point is a valid precode in a RangeList range section.
+            // First, validate that the entry point itself corresponds to a valid
+            // code header. If it does not, this frame does not meet the test
+            // preconditions, so skip it.
+            DacpCodeHeaderData codeHeaderData;
+            int hr = sosDac.GetCodeHeaderData(new ClrDataAddress(entryPoint.Value), &codeHeaderData);
+            if (hr != 0)
+                continue;
+
             // Offset by 1 byte to create an address that is still in the same
             // RangeList range but is not a valid precode. This is the same
             // scenario that caused the original CI failure: GetCodeHeaderData
             // calls NonVirtualEntry2MethodDesc, which calls GetMethodDescFromStubAddress,
             // which throws InvalidOperationException for invalid precode bytes.
             // The fix catches this and returns E_INVALIDARG (matching the DAC).
-            DacpCodeHeaderData codeHeaderData;
-            int hr = sosDac.GetCodeHeaderData(new ClrDataAddress(entryPoint.Value + 1), &codeHeaderData);
+            DacpCodeHeaderData invalidCodeHeaderData;
+            hr = sosDac.GetCodeHeaderData(new ClrDataAddress(entryPoint.Value + 1), &invalidCodeHeaderData);
             AssertHResult(HResults.E_INVALIDARG, hr);
 
             return;


### PR DESCRIPTION
## Summary

`NonVirtualEntry2MethodDesc` throws `InvalidOperationException` when an address falls in a precode `RangeSection` but doesn't match any known precode type (e.g., a MethodDesc address that coincidentally shares the same memory range). The DAC's C++ implementation returns `NULL` in this case.

This mismatch caused a DEBUG assertion crash in `GetCodeHeaderData` — the cDAC returned `0x80131509` (`COR_E_INVALIDOPERATION`) while the DAC returned `0x80070057` (`E_INVALIDARG`), triggering `Debug.Assert(hrLocal == hr)` and crashing the process. This broke `!clru` on IL stubs in the `cDAC_windows_x64_release` CI job ([build 1313397](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1313397)).

## Fix

Catch `InvalidOperationException` from `GetMethodDescFromStubAddress` in `ExecutionManagerCore.NonVirtualEntry2MethodDesc` and return `TargetPointer.Null`, matching the DAC's C++ behavior where `NonVirtualEntry2MethodDesc` returns `NULL` for unrecognized addresses.

## Test

Adds `VarargPInvoke_GetCodeHeaderDataWithInvalidPrecodeAddress` dump test that:
- Gets a method's precode entry point from the VarargPInvoke dump
- Offsets it by 1 byte to create an address in the RangeList range that isn't a valid precode
- Calls `GetCodeHeaderData` (SOS-level API) and asserts it returns `E_INVALIDARG`

Verified the test **fails without the fix** (returns `COR_E_INVALIDOPERATION`) and **passes with the fix** (returns `E_INVALIDARG`).
