### PR TITLE
Fix StreamPipeReader.CopyToAsync not advancing past buffered data

### DIFF
--- a/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
+++ b/src/libraries/System.IO.Pipelines/src/System/IO/Pipelines/StreamPipeReader.cs
@@ -354,6 +354,11 @@ namespace System.IO.Pipelines
                         {
                             AdvanceTo(segment, segment.End, segment, segment.End);
                         }
+                        else if (_readTail != null)
+                        {
+                            // All buffered segments were successfully written - advance past them
+                            AdvanceTo(_readTail, _readTail.End, _readTail, _readTail.End);
+                        }
                     }
 
                     await InnerStream.CopyToAsync(destination, tokenSource.Token).ConfigureAwait(false);
@@ -409,6 +414,11 @@ namespace System.IO.Pipelines
                         if (segment != null)
                         {
                             AdvanceTo(segment, segment.End, segment, segment.End);
+                        }
+                        else if (_readTail != null)
+                        {
+                            // All buffered segments were successfully written - advance past them
+                            AdvanceTo(_readTail, _readTail.End, _readTail, _readTail.End);
                         }
                     }
 

--- a/src/libraries/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
+++ b/src/libraries/System.IO.Pipelines/tests/PipeReaderCopyToAsyncTests.cs
@@ -355,6 +355,7 @@ namespace System.IO.Pipelines.Tests
             Assert.Equal(buffer.Length, pipeResult.Buffer.Length);
             Assert.Equal("Hello World", Encoding.ASCII.GetString(pipeResult.Buffer.ToArray()));
             pipe.Reader.AdvanceTo(pipeResult.Buffer.End);
+            pipe.Reader.Complete();
 
             // Verify the reader state is clean - no buffered data should remain
             readResult = await PipeReader.ReadAsync();


### PR DESCRIPTION
Both CopyToAsync overloads on StreamPipeReader (PipeWriter and Stream destinations) iterate buffered segments, but on successful drain the loop exits with segment set to null. The finally block only called AdvanceTo when segment was non-null, so buffered data remained in _readHead/_readIndex and would be returned again on subsequent reads.

Add an else-if branch to the finally block that advances past all buffered data (_readTail) when the segment loop completes normally.