### PR TITLE
Fix pal_error_common.h on OpenBSD

### DIFF
--- a/src/native/libs/Common/pal_error_common.h
+++ b/src/native/libs/Common/pal_error_common.h
@@ -219,8 +219,10 @@ inline static int32_t ConvertErrorPlatformToPal(int32_t platformErrno)
             return Error_EMLINK;
         case EMSGSIZE:
             return Error_EMSGSIZE;
+#ifdef EMULTIHOP // not available in OpenBSD
         case EMULTIHOP:
             return Error_EMULTIHOP;
+#endif
         case ENAMETOOLONG:
             return Error_ENAMETOOLONG;
         case ENETDOWN:
@@ -241,8 +243,10 @@ inline static int32_t ConvertErrorPlatformToPal(int32_t platformErrno)
             return Error_ENOEXEC;
         case ENOLCK:
             return Error_ENOLCK;
+#ifdef ENOLINK // not available in OpenBSD
         case ENOLINK:
             return Error_ENOLINK;
+#endif
         case ENOMEM:
             return Error_ENOMEM;
         case ENOMSG:
@@ -419,8 +423,10 @@ inline static int32_t ConvertErrorPalToPlatform(int32_t error)
             return EMLINK;
         case Error_EMSGSIZE:
             return EMSGSIZE;
+#ifdef EMULTIHOP // not available in OpenBSD
         case Error_EMULTIHOP:
             return EMULTIHOP;
+#endif
         case Error_ENAMETOOLONG:
             return ENAMETOOLONG;
         case Error_ENETDOWN:
@@ -441,8 +447,10 @@ inline static int32_t ConvertErrorPalToPlatform(int32_t error)
             return ENOEXEC;
         case Error_ENOLCK:
             return ENOLCK;
+#ifdef ENOLINK // not available in OpenBSD
         case Error_ENOLINK:
             return ENOLINK;
+#endif
         case Error_ENOMEM:
             return ENOMEM;
         case Error_ENOMSG:


### PR DESCRIPTION
`EMULTIHOP` and `ENOLINK` do not exist on OpenBSD.