### PR TITLE
Fix StackOverflowException from deeply nested character class subtractions

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1273,23 +1273,34 @@ namespace System.Text.RegularExpressions
 
         private static bool CharInClassRecursive(char ch, string set, int start)
         {
-            int setLength = set[start + SetLengthIndex];
-            int categoryLength = set[start + CategoryLengthIndex];
-            int endPosition = start + SetStartIndex + setLength + categoryLength;
+            bool inClass = false;
 
-            bool inClass = CharInClassInternal(ch, set, start, setLength, categoryLength);
-
-            // Note that we apply the negation *before* performing the subtraction.  This is because
-            // the negation only applies to the first char class, not the entire subtraction.
-            if (IsNegated(set, start))
+            while (true)
             {
+                int setLength = set[start + SetLengthIndex];
+                int categoryLength = set[start + CategoryLengthIndex];
+                int endPosition = start + SetStartIndex + setLength + categoryLength;
+
+                bool inThisLevel = CharInClassInternal(ch, set, start, setLength, categoryLength);
+
+                if (IsNegated(set, start))
+                {
+                    inThisLevel = !inThisLevel;
+                }
+
+                if (!inThisLevel)
+                {
+                    break;
+                }
+
                 inClass = !inClass;
-            }
 
-            // Subtract if necessary
-            if (inClass && set.Length > endPosition)
-            {
-                inClass = !CharInClassRecursive(ch, set, endPosition);
+                if (set.Length <= endPosition)
+                {
+                    break;
+                }
+
+                start = endPosition;
             }
 
             return inClass;
@@ -1431,28 +1442,46 @@ namespace System.Text.RegularExpressions
 
         private static RegexCharClass ParseRecursive(string charClass, int start)
         {
-            int setLength = charClass[start + SetLengthIndex];
-            int categoryLength = charClass[start + CategoryLengthIndex];
-            int endPosition = start + SetStartIndex + setLength + categoryLength;
+            RegexCharClass? outermost = null;
+            RegexCharClass? current = null;
 
-            int i = start + SetStartIndex;
-            int end = i + setLength;
-
-            List<(char First, char Last)>? ranges = ComputeRanges(charClass.AsSpan(start));
-
-            RegexCharClass? sub = null;
-            if (charClass.Length > endPosition)
+            int pos = start;
+            while (true)
             {
-                sub = ParseRecursive(charClass, endPosition);
+                int setLength = charClass[pos + SetLengthIndex];
+                int categoryLength = charClass[pos + CategoryLengthIndex];
+                int endPosition = pos + SetStartIndex + setLength + categoryLength;
+
+                List<(char First, char Last)>? ranges = ComputeRanges(charClass.AsSpan(pos));
+
+                StringBuilder? categoriesBuilder = null;
+                if (categoryLength > 0)
+                {
+                    int end = pos + SetStartIndex + setLength;
+                    categoriesBuilder = new StringBuilder().Append(charClass.AsSpan(end, categoryLength));
+                }
+
+                var level = new RegexCharClass(IsNegated(charClass, pos), ranges, categoriesBuilder, subtraction: null);
+
+                if (outermost is null)
+                {
+                    outermost = level;
+                }
+                else
+                {
+                    current!.AddSubtraction(level);
+                }
+                current = level;
+
+                if (charClass.Length <= endPosition)
+                {
+                    break;
+                }
+
+                pos = endPosition;
             }
 
-            StringBuilder? categoriesBuilder = null;
-            if (categoryLength > 0)
-            {
-                categoriesBuilder = new StringBuilder().Append(charClass.AsSpan(end, categoryLength));
-            }
-
-            return new RegexCharClass(IsNegated(charClass, start), ranges, categoriesBuilder, sub);
+            return outermost!;
         }
 
         /// <summary>Computes a list of all of the character ranges in the set string.</summary>
@@ -1597,45 +1626,49 @@ namespace System.Text.RegularExpressions
 
         private void ToStringClass(ref ValueStringBuilder vsb)
         {
-            Canonicalize();
-
-            int initialLength = vsb.Length;
-            int categoriesLength = _categories?.Length ?? 0;
-            Span<char> headerSpan = vsb.AppendSpan(SetStartIndex);
-            headerSpan[FlagsIndex] = (char)(_negate ? 1 : 0);
-            headerSpan[SetLengthIndex] = '\0'; // (will be replaced once we know how long a range we've added)
-            headerSpan[CategoryLengthIndex] = (char)categoriesLength;
-
-            // Append ranges
-            List<(char First, char Last)>? rangelist = _rangelist;
-            if (rangelist != null)
+            RegexCharClass? current = this;
+            do
             {
-                for (int i = 0; i < rangelist.Count; i++)
+                current.Canonicalize();
+
+                int initialLength = vsb.Length;
+                int categoriesLength = current._categories?.Length ?? 0;
+                Span<char> headerSpan = vsb.AppendSpan(SetStartIndex);
+                headerSpan[FlagsIndex] = (char)(current._negate ? 1 : 0);
+                headerSpan[SetLengthIndex] = '\0'; // (will be replaced once we know how long a range we've added)
+                headerSpan[CategoryLengthIndex] = (char)categoriesLength;
+
+                // Append ranges
+                List<(char First, char Last)>? rangelist = current._rangelist;
+                if (rangelist != null)
                 {
-                    (char First, char Last) currentRange = rangelist[i];
-                    vsb.Append(currentRange.First);
-                    if (currentRange.Last != LastChar)
+                    for (int i = 0; i < rangelist.Count; i++)
                     {
-                        vsb.Append((char)(currentRange.Last + 1));
+                        (char First, char Last) currentRange = rangelist[i];
+                        vsb.Append(currentRange.First);
+                        if (currentRange.Last != LastChar)
+                        {
+                            vsb.Append((char)(currentRange.Last + 1));
+                        }
                     }
                 }
-            }
 
-            // Update the range length.  The ValueStringBuilder may have already had some
-            // contents (if this is a subtactor), so we need to offset by the initial length.
-            vsb[initialLength + SetLengthIndex] = (char)(vsb.Length - initialLength - SetStartIndex);
+                // Update the range length.  The ValueStringBuilder may have already had some
+                // contents (if this is a subtactor), so we need to offset by the initial length.
+                vsb[initialLength + SetLengthIndex] = (char)(vsb.Length - initialLength - SetStartIndex);
 
-            // Append categories
-            if (categoriesLength != 0)
-            {
-                foreach (ReadOnlyMemory<char> chunk in _categories!.GetChunks())
+                // Append categories
+                if (categoriesLength != 0)
                 {
-                    vsb.Append(chunk.Span);
+                    foreach (ReadOnlyMemory<char> chunk in current._categories!.GetChunks())
+                    {
+                        vsb.Append(chunk.Span);
+                    }
                 }
-            }
 
-            // Append a subtractor if there is one.
-            _subtractor?.ToStringClass(ref vsb);
+                current = current._subtractor;
+            }
+            while (current is not null);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1237,7 +1237,7 @@ namespace System.Text.RegularExpressions
             // For ASCII, lazily initialize. For non-ASCII, just compute the value.
             return ch < 128 ?
                 InitializeValue(ch, set, ref asciiLazyCache) :
-                CharInClassRecursive(ch, set, 0);
+                CharInClassIterative(ch, set, 0);
 
             static bool InitializeValue(char ch, string set, ref uint[]? asciiLazyCache)
             {
@@ -1269,9 +1269,9 @@ namespace System.Text.RegularExpressions
         /// Determines a character's membership in a character class (via the string representation of the class).
         /// </summary>
         public static bool CharInClass(char ch, string set) =>
-            CharInClassRecursive(ch, set, 0);
+            CharInClassIterative(ch, set, 0);
 
-        private static bool CharInClassRecursive(char ch, string set, int start)
+        private static bool CharInClassIterative(char ch, string set, int start)
         {
             bool inClass = false;
 
@@ -1438,14 +1438,12 @@ namespace System.Text.RegularExpressions
             return result;
         }
 
-        public static RegexCharClass Parse(string charClass) => ParseRecursive(charClass, 0);
-
-        private static RegexCharClass ParseRecursive(string charClass, int start)
+        public static RegexCharClass Parse(string charClass)
         {
             RegexCharClass? outermost = null;
             RegexCharClass? current = null;
 
-            int pos = start;
+            int pos = 0;
             while (true)
             {
                 int setLength = charClass[pos + SetLengthIndex];
@@ -1620,12 +1618,7 @@ namespace System.Text.RegularExpressions
         public string ToStringClass()
         {
             var vsb = new ValueStringBuilder(stackalloc char[256]);
-            ToStringClass(ref vsb);
-            return vsb.ToString();
-        }
 
-        private void ToStringClass(ref ValueStringBuilder vsb)
-        {
             RegexCharClass? current = this;
             do
             {
@@ -1669,6 +1662,8 @@ namespace System.Text.RegularExpressions
                 current = current._subtractor;
             }
             while (current is not null);
+
+            return vsb.ToString();
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -1281,14 +1281,7 @@ namespace System.Text.RegularExpressions
                 int categoryLength = set[start + CategoryLengthIndex];
                 int endPosition = start + SetStartIndex + setLength + categoryLength;
 
-                bool inThisLevel = CharInClassInternal(ch, set, start, setLength, categoryLength);
-
-                if (IsNegated(set, start))
-                {
-                    inThisLevel = !inThisLevel;
-                }
-
-                if (!inThisLevel)
+                if (CharInClassInternal(ch, set, start, setLength, categoryLength) == IsNegated(set, start))
                 {
                     break;
                 }

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -2632,6 +2632,54 @@ namespace System.Text.RegularExpressions.Tests
             }
         }
 
+        [Theory]
+        [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Fix is not available on .NET Framework")]
+        [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
+        public async Task CharClassSubtraction_DeepNesting_DoesNotStackOverflow(RegexEngine engine)
+        {
+            // Build a pattern with deeply nested character class subtractions: [a-[a-[a-[...[a]...]]]]
+            // This previously caused a StackOverflowException due to unbounded recursion in the parser.
+            // Use a reduced depth for SourceGenerated to avoid overwhelming Roslyn compilation.
+            int depth = engine == RegexEngine.SourceGenerated ? RegexHelpers.StressTestNestingDepth : 10_000;
+            var sb = new System.Text.StringBuilder();
+            sb.Append('[');
+            for (int i = 0; i < depth; i++)
+            {
+                sb.Append("a-[");
+            }
+            sb.Append('a');
+            sb.Append(']', depth + 1);
+
+            Regex r = await RegexHelpers.GetRegexAsync(engine, sb.ToString());
+            Assert.True(r.IsMatch("a"));
+            Assert.False(r.IsMatch("b"));
+        }
+
+        [Theory]
+        [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
+        public async Task CharClassSubtraction_Correctness(RegexEngine engine)
+        {
+            // [a-z-[d-w]] should match a-c and x-z
+            Regex r1 = await RegexHelpers.GetRegexAsync(engine, "[a-z-[d-w]]");
+            Assert.True(r1.IsMatch("a"));
+            Assert.True(r1.IsMatch("c"));
+            Assert.True(r1.IsMatch("x"));
+            Assert.True(r1.IsMatch("z"));
+            Assert.False(r1.IsMatch("d"));
+            Assert.False(r1.IsMatch("m"));
+            Assert.False(r1.IsMatch("w"));
+
+            // [a-z-[d-w-[m]]] should match a-c, m, and x-z
+            Regex r2 = await RegexHelpers.GetRegexAsync(engine, "[a-z-[d-w-[m]]]");
+            Assert.True(r2.IsMatch("a"));
+            Assert.True(r2.IsMatch("m"));
+            Assert.True(r2.IsMatch("z"));
+            Assert.False(r2.IsMatch("d"));
+            Assert.False(r2.IsMatch("l"));
+            Assert.False(r2.IsMatch("n"));
+            Assert.False(r2.IsMatch("w"));
+        }
+
         public static IEnumerable<object[]> StressTestNfaMode_TestData()
         {
             yield return new object[] { "(?:a|aa|[abc]?[ab]?[abcd]).{20}$", "aaa01234567890123456789", 23 };

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -2640,7 +2640,7 @@ namespace System.Text.RegularExpressions.Tests
             // Build a pattern with deeply nested character class subtractions: [a-[a-[a-[...[a]...]]]]
             // This previously caused a StackOverflowException due to unbounded recursion in the parser.
             // Use a reduced depth for SourceGenerated to avoid overwhelming Roslyn compilation.
-            int depth = engine == RegexEngine.SourceGenerated ? RegexHelpers.StressTestNestingDepth : 10_000;
+            int depth = engine == RegexEngine.SourceGenerated ? 1_000 : 10_000;
             var sb = new System.Text.StringBuilder();
             sb.Append('[');
             for (int i = 0; i < depth; i++)
@@ -2678,6 +2678,57 @@ namespace System.Text.RegularExpressions.Tests
             Assert.False(r2.IsMatch("l"));
             Assert.False(r2.IsMatch("n"));
             Assert.False(r2.IsMatch("w"));
+        }
+
+        [Theory]
+        [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
+        public async Task CharClassSubtraction_CaseInsensitive(RegexEngine engine)
+        {
+            // [a-z-[D-W]] with IgnoreCase should behave like [a-z-[d-w]], matching a-c and x-z.
+            Regex r = await RegexHelpers.GetRegexAsync(engine, "[a-z-[D-W]]", RegexOptions.IgnoreCase);
+            Assert.True(r.IsMatch("a"));
+            Assert.True(r.IsMatch("c"));
+            Assert.True(r.IsMatch("x"));
+            Assert.True(r.IsMatch("z"));
+            Assert.False(r.IsMatch("d"));
+            Assert.False(r.IsMatch("D"));
+            Assert.False(r.IsMatch("m"));
+            Assert.False(r.IsMatch("w"));
+        }
+
+        [Theory]
+        [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
+        public async Task CharClassSubtraction_NegatedOuter(RegexEngine engine)
+        {
+            // [^a-z-[m-p]] = (NOT a-z) minus m-p. Since m-p is a subset of a-z,
+            // the subtraction has no effect: matches anything outside a-z.
+            Regex r = await RegexHelpers.GetRegexAsync(engine, "[^a-z-[m-p]]");
+            Assert.True(r.IsMatch("A"));
+            Assert.True(r.IsMatch("5"));
+            Assert.False(r.IsMatch("a"));
+            Assert.False(r.IsMatch("m"));
+            Assert.False(r.IsMatch("z"));
+        }
+
+        [Theory]
+        [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
+        public async Task CharClassSubtraction_FourLevels(RegexEngine engine)
+        {
+            // [a-z-[b-y-[c-x-[d-w]]]]
+            // Level 0: a-z
+            // Level 1: subtract b-y  => a, z
+            // Level 2: subtract c-x from b-y => add back c-x => a, c-x, z
+            // Level 3: subtract d-w from c-x => remove d-w again => a, c, x, z
+            Regex r = await RegexHelpers.GetRegexAsync(engine, "[a-z-[b-y-[c-x-[d-w]]]]");
+            Assert.True(r.IsMatch("a"));
+            Assert.True(r.IsMatch("c"));
+            Assert.True(r.IsMatch("x"));
+            Assert.True(r.IsMatch("z"));
+            Assert.False(r.IsMatch("b"));
+            Assert.False(r.IsMatch("d"));
+            Assert.False(r.IsMatch("m"));
+            Assert.False(r.IsMatch("w"));
+            Assert.False(r.IsMatch("y"));
         }
 
         public static IEnumerable<object[]> StressTestNfaMode_TestData()

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Tests.Common.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Tests.Common.cs
@@ -16,8 +16,6 @@ namespace System.Text.RegularExpressions.Tests
     {
         public const string DefaultMatchTimeout_ConfigKeyName = "REGEX_DEFAULT_MATCH_TIMEOUT";
 
-        public const int StressTestNestingDepth = 1000;
-
         /// <summary>RegexOptions.NonBacktracking.</summary>
         /// <remarks>Defined here to be able to reference the value by name even on .NET Framework test builds.</remarks>
         public const RegexOptions RegexOptionNonBacktracking = (RegexOptions)0x400;


### PR DESCRIPTION
A regex pattern with deeply nested character class subtractions (`[a-[b-[c-[...]]]]`) causes an uncatchable `StackOverflowException` that terminates the process, because the parser and several `RegexCharClass` methods recurse for each nesting level.

All regex modes are affected (`None`, `Compiled`, `NonBacktracking`) because the crash occurs during parsing.

## Changes

Converted all recursive subtraction processing to iterative:

- **`RegexParser.ScanCharClass`**: Uses an explicit `List` parent stack. When a subtraction `[` is encountered, the current char class is pushed and a new one started. When `]` closes a level, the child is set as the parent's subtraction.
- **`RegexCharClass.ToStringClass`**: Converted to a `do/while` loop over `_subtractor`.
- **`RegexCharClass.CharInClassIterative`** (renamed from `CharInClassRecursive`): Converted to a toggle-based `while` loop - each consecutive level where the character matches toggles the result.
- **`RegexCharClass.Parse`** (inlined from `ParseRecursive`): Converted to forward iterative construction of the subtraction chain.

Character class subtraction was the only recursive parsing path in `RegexParser`. Other nestable constructs such as groups (`(((...)))`) are already parsed iteratively via an explicit stack (`PushGroup`/`PopGroup`).

## Tests

- **`CharClassSubtraction_DeepNesting_DoesNotStackOverflow`**: 10,000 depth (1,000 for SourceGenerated). Verifies parsing + matching succeeds.
- **`CharClassSubtraction_Correctness`**: Validates `[a-z-[d-w]]` and `[a-z-[d-w-[m]]]` produce correct match/non-match results across all engines.
- **`CharClassSubtraction_CaseInsensitive`**: Validates `[a-z-[D-W]]` with `IgnoreCase` works correctly.
- **`CharClassSubtraction_NegatedOuter`**: Validates `[^a-z-[m-p]]` with a negated outer class.
- **`CharClassSubtraction_FourLevels`**: Validates `[a-z-[b-y-[c-x-[d-w]]]]` - 4 levels of nesting to exercise the toggle logic at each depth.