### PR TITLE
Move runtimeLookup from Agnostic_CORINFO_LOOKUP struct to LWM buffer

### DIFF
--- a/src/coreclr/inc/jiteeversionguid.h
+++ b/src/coreclr/inc/jiteeversionguid.h
@@ -37,11 +37,11 @@
 
 #include <minipal/guid.h>
 
-constexpr GUID JITEEVersionIdentifier = { /* cd664ea4-e14e-4fd4-9cb8-e8fc1e1b5a0a */
-    0xcd664ea4,
-    0xe14e,
-    0x4fd4,
-    {0x9c, 0xb8, 0xe8, 0xfc, 0x1e, 0x1b, 0x5a, 0x0a}
+constexpr GUID JITEEVersionIdentifier = { /* 47fb3d9a-1870-4b21-84e4-9319f5fd8c4a */
+    0x47fb3d9a,
+    0x1870,
+    0x4b21,
+    {0x84, 0xe4, 0x93, 0x19, 0xf5, 0xfd, 0x8c, 0x4a}
   };
 
 #endif // JIT_EE_VERSIONING_GUID_H

--- a/src/coreclr/tools/superpmi/superpmi-shared/agnostic.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/agnostic.h
@@ -298,9 +298,8 @@ struct Agnostic_CORINFO_RUNTIME_LOOKUP
 
 struct Agnostic_CORINFO_LOOKUP
 {
-    Agnostic_CORINFO_LOOKUP_KIND    lookupKind;
-    Agnostic_CORINFO_RUNTIME_LOOKUP runtimeLookup; // This and constLookup actually a union, but with different
-                                                   // layouts.. :-| copy the right one based on lookupKinds value
+    Agnostic_CORINFO_LOOKUP_KIND  lookupKind;
+    DWORD                         runtimeLookup_Index; // Index into LWM buffer for Agnostic_CORINFO_RUNTIME_LOOKUP
     Agnostic_CORINFO_CONST_LOOKUP constLookup;
 };
 

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -1492,7 +1492,7 @@ void MethodContext::dmpGetCallInfo(const Agnostic_GetCallInfo& key, const Agnost
         value.contextHandle,
         value.exactContextNeedsRuntimeLookup,
         (bool)value.exactContextNeedsRuntimeLookup ? "true" : "false",
-        SpmiDumpHelper::DumpAgnostic_CORINFO_LOOKUP(value.stubLookup).c_str(),
+        SpmiDumpHelper::DumpAgnostic_CORINFO_LOOKUP(value.stubLookup, GetCallInfo).c_str(),
         value.instParamLookup.accessType,
         toString((InfoAccessType)value.instParamLookup.accessType),
         value.instParamLookup.handle,
@@ -1666,7 +1666,7 @@ void MethodContext::dmpExpandRawHandleIntrinsic(const Agnostic_ExpandRawHandleIn
 {
     printf("ExpandRawHandleIntrinsic key: %s, value %s cth-%016" PRIx64 " ht-%u",
         SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKENin(key.ResolvedToken).c_str(),
-        SpmiDumpHelper::DumpAgnostic_CORINFO_LOOKUP(result.lookup).c_str(),
+        SpmiDumpHelper::DumpAgnostic_CORINFO_LOOKUP(result.lookup, ExpandRawHandleIntrinsic).c_str(),
         result.compileTimeHandle,
         result.handleType);
 }
@@ -2302,7 +2302,7 @@ void MethodContext::dmpGetReadyToRunDelegateCtorHelper(GetReadyToRunDelegateCtor
 {
     printf("GetReadyToRunDelegateCtorHelper key: method tk{%s} type-%016" PRIX64 " constraint-%08X",
            SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKEN(key.TargetMethod).c_str(), key.delegateType, key.targetConstraint);
-    printf(", value: %s", SpmiDumpHelper::DumpAgnostic_CORINFO_LOOKUP(value).c_str());
+    printf(", value: %s", SpmiDumpHelper::DumpAgnostic_CORINFO_LOOKUP(value, GetReadyToRunDelegateCtorHelper).c_str());
 }
 
 void MethodContext::repGetReadyToRunDelegateCtorHelper(CORINFO_RESOLVED_TOKEN* pTargetMethod,
@@ -3116,7 +3116,7 @@ void MethodContext::dmpEmbedGenericHandle(const Agnostic_EmbedGenericHandle&    
     printf("EmbedGenericHandle key rt{%s} emb-%u, value %s cth-%016" PRIX64 " ht-%u",
         SpmiDumpHelper::DumpAgnostic_CORINFO_RESOLVED_TOKEN(key.ResolvedToken).c_str(),
         key.fEmbedParent,
-        SpmiDumpHelper::DumpAgnostic_CORINFO_LOOKUP(value.lookup).c_str(),
+        SpmiDumpHelper::DumpAgnostic_CORINFO_LOOKUP(value.lookup, EmbedGenericHandle).c_str(),
         value.compileTimeHandle,
         value.handleType);
 }

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -1440,7 +1440,7 @@ void MethodContext::recGetCallInfo(CORINFO_RESOLVED_TOKEN* pResolvedToken,
         value.contextHandle                  = CastHandle(pResult->contextHandle);
         value.exactContextNeedsRuntimeLookup = (DWORD)pResult->exactContextNeedsRuntimeLookup;
 
-        value.stubLookup = SpmiRecordsHelper::StoreAgnostic_CORINFO_LOOKUP(&pResult->stubLookup);
+        value.stubLookup = SpmiRecordsHelper::StoreAgnostic_CORINFO_LOOKUP(&pResult->stubLookup, GetCallInfo);
 
         value.instParamLookup.accessType = (DWORD)pResult->instParamLookup.accessType;
         value.instParamLookup.handle     = CastHandle(pResult->instParamLookup.handle);
@@ -1561,7 +1561,7 @@ void MethodContext::repGetCallInfo(CORINFO_RESOLVED_TOKEN* pResolvedToken,
         pResult->nullInstanceCheck = (bool)value.nullInstanceCheck;
         pResult->contextHandle = (CORINFO_CONTEXT_HANDLE)value.contextHandle;
         pResult->exactContextNeedsRuntimeLookup = (bool)value.exactContextNeedsRuntimeLookup;
-        pResult->stubLookup = SpmiRecordsHelper::RestoreCORINFO_LOOKUP(value.stubLookup);
+        pResult->stubLookup = SpmiRecordsHelper::RestoreCORINFO_LOOKUP(value.stubLookup, GetCallInfo);
 
         if (pResult->kind == CORINFO_VIRTUALCALL_STUB)
         {
@@ -1655,7 +1655,7 @@ void MethodContext::recExpandRawHandleIntrinsic(CORINFO_RESOLVED_TOKEN* pResolve
     key.hCallerHandle = CastHandle(callerHandle);
 
     Agnostic_CORINFO_GENERICHANDLE_RESULT value;
-    value.lookup            = SpmiRecordsHelper::StoreAgnostic_CORINFO_LOOKUP(&pResult->lookup);
+    value.lookup            = SpmiRecordsHelper::StoreAgnostic_CORINFO_LOOKUP(&pResult->lookup, ExpandRawHandleIntrinsic);
     value.compileTimeHandle = CastHandle(pResult->compileTimeHandle);
     value.handleType        = (DWORD)pResult->handleType;
 
@@ -1683,7 +1683,7 @@ void MethodContext::repExpandRawHandleIntrinsic(CORINFO_RESOLVED_TOKEN* pResolve
 
     DEBUG_REP(dmpExpandRawHandleIntrinsic(key, value));
 
-    pResult->lookup            = SpmiRecordsHelper::RestoreCORINFO_LOOKUP(value.lookup);
+    pResult->lookup            = SpmiRecordsHelper::RestoreCORINFO_LOOKUP(value.lookup, ExpandRawHandleIntrinsic);
     pResult->compileTimeHandle = (CORINFO_GENERIC_HANDLE)value.compileTimeHandle;
     pResult->handleType        = (CorInfoGenericHandleType)value.handleType;
 }
@@ -2292,7 +2292,7 @@ void MethodContext::recGetReadyToRunDelegateCtorHelper(CORINFO_RESOLVED_TOKEN* p
     key.targetConstraint          = targetConstraint;
     key.delegateType              = CastHandle(delegateType);
     key.callerHandle              = CastHandle(callerHandle);
-    Agnostic_CORINFO_LOOKUP value = SpmiRecordsHelper::StoreAgnostic_CORINFO_LOOKUP(pLookup);
+    Agnostic_CORINFO_LOOKUP value = SpmiRecordsHelper::StoreAgnostic_CORINFO_LOOKUP(pLookup, GetReadyToRunDelegateCtorHelper);
     GetReadyToRunDelegateCtorHelper->Add(key, value);
     DEBUG_REC(dmpGetReadyToRunDelegateCtorHelper(key, value));
 }
@@ -2325,7 +2325,7 @@ void MethodContext::repGetReadyToRunDelegateCtorHelper(CORINFO_RESOLVED_TOKEN* p
 
     DEBUG_REP(dmpGetReadyToRunDelegateCtorHelper(key, value));
 
-    *pLookup = SpmiRecordsHelper::RestoreCORINFO_LOOKUP(value);
+    *pLookup = SpmiRecordsHelper::RestoreCORINFO_LOOKUP(value, GetReadyToRunDelegateCtorHelper);
 }
 
 void MethodContext::recGetHelperFtn(CorInfoHelpFunc ftnNum, CORINFO_CONST_LOOKUP pNativeEntrypoint,CORINFO_METHOD_HANDLE methodHandle)
@@ -3103,7 +3103,7 @@ void MethodContext::recEmbedGenericHandle(CORINFO_RESOLVED_TOKEN*       pResolve
     key.hCallerHandle = CastHandle(callerHandle);
 
     Agnostic_CORINFO_GENERICHANDLE_RESULT value;
-    value.lookup            = SpmiRecordsHelper::StoreAgnostic_CORINFO_LOOKUP(&pResult->lookup);
+    value.lookup            = SpmiRecordsHelper::StoreAgnostic_CORINFO_LOOKUP(&pResult->lookup, EmbedGenericHandle);
     value.compileTimeHandle = CastHandle(pResult->compileTimeHandle);
     value.handleType        = (DWORD)pResult->handleType;
 
@@ -3137,7 +3137,7 @@ void MethodContext::repEmbedGenericHandle(CORINFO_RESOLVED_TOKEN*       pResolve
 
     DEBUG_REP(dmpEmbedGenericHandle(key, value));
 
-    pResult->lookup            = SpmiRecordsHelper::RestoreCORINFO_LOOKUP(value.lookup);
+    pResult->lookup            = SpmiRecordsHelper::RestoreCORINFO_LOOKUP(value.lookup, EmbedGenericHandle);
     pResult->compileTimeHandle = (CORINFO_GENERIC_HANDLE)value.compileTimeHandle;
     pResult->handleType        = (CorInfoGenericHandleType)value.handleType;
 }

--- a/src/coreclr/tools/superpmi/superpmi-shared/spmidumphelper.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/spmidumphelper.cpp
@@ -74,7 +74,9 @@ std::string SpmiDumpHelper::DumpAgnostic_CORINFO_LOOKUP(const Agnostic_CORINFO_L
     std::string lookupDescription;
     if (lookup.lookupKind.needsRuntimeLookup)
     {
-        lookupDescription = DumpAgnostic_CORINFO_RUNTIME_LOOKUP(lookup.runtimeLookup);
+        char buffer[MAX_BUFFER_SIZE];
+        sprintf_s(buffer, MAX_BUFFER_SIZE, "runtimeLookup bufIdx-%u", lookup.runtimeLookup_Index);
+        lookupDescription = std::string(buffer);
     }
     else
     {

--- a/src/coreclr/tools/superpmi/superpmi-shared/spmidumphelper.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/spmidumphelper.h
@@ -189,6 +189,7 @@ inline std::string SpmiDumpHelper::DumpAgnostic_CORINFO_LOOKUP(
         {
             Agnostic_CORINFO_RUNTIME_LOOKUP agnosticRL;
             memcpy(&agnosticRL, buffers->GetBuffer(lookup.runtimeLookup_Index), sizeof(agnosticRL));
+            buffers->Unlock();
             lookupDescription = DumpAgnostic_CORINFO_RUNTIME_LOOKUP(agnosticRL);
         }
         else

--- a/src/coreclr/tools/superpmi/superpmi-shared/spmidumphelper.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/spmidumphelper.h
@@ -26,6 +26,10 @@ public:
     static std::string DumpAgnostic_CORINFO_LOOKUP(const Agnostic_CORINFO_LOOKUP& lookup);
 
     template <typename key, typename value>
+    static std::string DumpAgnostic_CORINFO_LOOKUP(const Agnostic_CORINFO_LOOKUP& lookup,
+                                                   LightWeightMap<key, value>* buffers);
+
+    template <typename key, typename value>
     static std::string DumpPSig(
         DWORD                       pSig_Index,
         DWORD                       cbSig,
@@ -170,6 +174,35 @@ inline std::string SpmiDumpHelper::DumpAgnostic_CORINFO_SIG_INFO(
     sizeOfBuffer -= cch;
 
     return std::string(buffer);
+}
+
+template <typename key, typename value>
+inline std::string SpmiDumpHelper::DumpAgnostic_CORINFO_LOOKUP(
+    const Agnostic_CORINFO_LOOKUP& lookup,
+    LightWeightMap<key, value>* buffers)
+{
+    std::string kind = DumpAgnostic_CORINFO_LOOKUP_KIND(lookup.lookupKind);
+    std::string lookupDescription;
+    if (lookup.lookupKind.needsRuntimeLookup)
+    {
+        if (buffers != nullptr)
+        {
+            Agnostic_CORINFO_RUNTIME_LOOKUP agnosticRL;
+            memcpy(&agnosticRL, buffers->GetBuffer(lookup.runtimeLookup_Index), sizeof(agnosticRL));
+            lookupDescription = DumpAgnostic_CORINFO_RUNTIME_LOOKUP(agnosticRL);
+        }
+        else
+        {
+            char buffer[MAX_BUFFER_SIZE];
+            sprintf_s(buffer, MAX_BUFFER_SIZE, "runtimeLookup bufIdx-%u", lookup.runtimeLookup_Index);
+            lookupDescription = std::string(buffer);
+        }
+    }
+    else
+    {
+        lookupDescription = DumpAgnostic_CORINFO_CONST_LOOKUP(lookup.constLookup);
+    }
+    return kind + std::string(" ") + lookupDescription;
 }
 
 #endif

--- a/src/coreclr/tools/superpmi/superpmi-shared/spmirecordhelper.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/spmirecordhelper.h
@@ -530,6 +530,7 @@ inline Agnostic_CORINFO_LOOKUP SpmiRecordsHelper::StoreAgnostic_CORINFO_LOOKUP(
     lookup.lookupKind = CreateAgnostic_CORINFO_LOOKUP_KIND(&pLookup->lookupKind);
     if (pLookup->lookupKind.needsRuntimeLookup)
     {
+        Assert(buffers != nullptr);
         Agnostic_CORINFO_RUNTIME_LOOKUP runtimeLookup = StoreAgnostic_CORINFO_RUNTIME_LOOKUP(&pLookup->runtimeLookup);
         lookup.runtimeLookup_Index = (DWORD)buffers->AddBuffer(
             (unsigned char*)&runtimeLookup, sizeof(runtimeLookup));
@@ -551,9 +552,10 @@ inline CORINFO_LOOKUP SpmiRecordsHelper::RestoreCORINFO_LOOKUP(
     lookup.lookupKind = RestoreCORINFO_LOOKUP_KIND(agnosticLookup.lookupKind);
     if (lookup.lookupKind.needsRuntimeLookup)
     {
-        Agnostic_CORINFO_RUNTIME_LOOKUP* pRL =
-            (Agnostic_CORINFO_RUNTIME_LOOKUP*)buffers->GetBuffer(agnosticLookup.runtimeLookup_Index);
-        lookup.runtimeLookup = RestoreCORINFO_RUNTIME_LOOKUP(*pRL);
+        Assert(buffers != nullptr);
+        Agnostic_CORINFO_RUNTIME_LOOKUP agnosticRL;
+        memcpy(&agnosticRL, buffers->GetBuffer(agnosticLookup.runtimeLookup_Index), sizeof(agnosticRL));
+        lookup.runtimeLookup = RestoreCORINFO_RUNTIME_LOOKUP(agnosticRL);
     }
     else
     {

--- a/src/coreclr/tools/superpmi/superpmi-shared/spmirecordhelper.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/spmirecordhelper.h
@@ -555,6 +555,7 @@ inline CORINFO_LOOKUP SpmiRecordsHelper::RestoreCORINFO_LOOKUP(
         Assert(buffers != nullptr);
         Agnostic_CORINFO_RUNTIME_LOOKUP agnosticRL;
         memcpy(&agnosticRL, buffers->GetBuffer(agnosticLookup.runtimeLookup_Index), sizeof(agnosticRL));
+        buffers->Unlock();
         lookup.runtimeLookup = RestoreCORINFO_RUNTIME_LOOKUP(agnosticRL);
     }
     else


### PR DESCRIPTION
_AI-driven contribution to make SPMI artifacts more compact._

Replace the 74-byte Agnostic_CORINFO_RUNTIME_LOOKUP runtimeLookup field in Agnostic_CORINFO_LOOKUP with a 4-byte DWORD runtimeLookup_Index that points into the LWM buffer. The struct shrinks from 94 to 24 bytes.

99.7% of GetCallInfo entries don't use runtimeLookup (needsRuntimeLookup is false), so this eliminates ~40 MB of zero bytes from a typical aspnet MCH file. The Agnostic_CORINFO_RUNTIME_LOOKUP data is stored in the LWM buffer only when needsRuntimeLookup is true.

StoreAgnostic_CORINFO_LOOKUP and RestoreCORINFO_LOOKUP are made templated to accept the LWM pointer for buffer storage. All callers (GetCallInfo, EmbedGenericHandle, ExpandRawHandleIntrinsic, GetReadyToRunDelegateCtorHelper) are updated to pass their LWM.