### PR TITLE
Streamline `SystemIPGlobalProperties`

### DIFF
--- a/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.NetworkInformation.cs
+++ b/src/libraries/Common/src/Interop/Windows/IpHlpApi/Interop.NetworkInformation.cs
@@ -6,6 +6,7 @@ using System.Buffers.Binary;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -406,12 +407,12 @@ internal static partial class Interop
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct MibTcp6RowOwnerPid
+        internal struct MibTcp6RowOwnerPid
         {
-            internal fixed byte LocalAddr[16];
+            internal InlineArray16<byte> LocalAddr;
             internal uint LocalScopeId;
             internal uint LocalPort;
-            internal fixed byte RemoteAddr[16];
+            internal InlineArray16<byte> RemoteAddr;
             internal uint RemoteScopeId;
             internal uint RemotePort;
             internal TcpState State;
@@ -419,8 +420,8 @@ internal static partial class Interop
 
             // Ports are only 16 bit values (in network WORD order, 3,4,1,2).
             // There are reports where the high order bytes have garbage in them.
-            internal readonly IPEndPoint LocalEndPoint => new(new IPAddress(MemoryMarshal.CreateReadOnlySpan(in LocalAddr[0], 16), LocalScopeId), BinaryPrimitives.ReverseEndianness((ushort)LocalPort));
-            internal readonly IPEndPoint RemoteEndPoint => new(new IPAddress(MemoryMarshal.CreateReadOnlySpan(in RemoteAddr[0], 16), RemoteScopeId), BinaryPrimitives.ReverseEndianness((ushort)RemotePort));
+            internal readonly IPEndPoint LocalEndPoint => new(new IPAddress(LocalAddr, LocalScopeId), BinaryPrimitives.ReverseEndianness((ushort)LocalPort));
+            internal readonly IPEndPoint RemoteEndPoint => new(new IPAddress(RemoteAddr, RemoteScopeId), BinaryPrimitives.ReverseEndianness((ushort)RemotePort));
         }
 
         internal enum TcpTableClass
@@ -469,16 +470,16 @@ internal static partial class Interop
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        internal unsafe struct MibUdp6RowOwnerPid
+        internal struct MibUdp6RowOwnerPid
         {
-            internal fixed byte LocalAddr[16];
+            internal InlineArray16<byte> LocalAddr;
             internal uint LocalScopeId;
             internal uint LocalPort;
             internal uint OwningPid;
 
             // Ports are only 16 bit values (in network WORD order, 3,4,1,2).
             // There are reports where the high order bytes have garbage in them.
-            internal readonly IPEndPoint LocalEndPoint => new(new IPAddress(MemoryMarshal.CreateReadOnlySpan(in LocalAddr[0], 16), LocalScopeId), BinaryPrimitives.ReverseEndianness((ushort)LocalPort));
+            internal readonly IPEndPoint LocalEndPoint => new(new IPAddress(LocalAddr, LocalScopeId), BinaryPrimitives.ReverseEndianness((ushort)LocalPort));
         }
 
         [LibraryImport(Interop.Libraries.IpHlpApi)]

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemIPGlobalProperties.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -73,46 +74,30 @@ namespace System.Net.NetworkInformation
         public override TcpConnectionInformation[] GetActiveTcpConnections()
         {
             List<TcpConnectionInformation> list = new List<TcpConnectionInformation>();
-            List<SystemTcpConnectionInformation> connections = GetAllTcpConnections();
-            foreach (TcpConnectionInformation connection in connections)
-            {
-                if (connection.State != TcpState.Listen)
-                {
-                    list.Add(connection);
-                }
-            }
-
+            GetAllTcpConnections(list, null);
             return list.ToArray();
         }
 
         public override IPEndPoint[] GetActiveTcpListeners()
         {
             List<IPEndPoint> list = new List<IPEndPoint>();
-            List<SystemTcpConnectionInformation> connections = GetAllTcpConnections();
-            foreach (TcpConnectionInformation connection in connections)
-            {
-                if (connection.State == TcpState.Listen)
-                {
-                    list.Add(connection.LocalEndPoint);
-                }
-            }
-
+            GetAllTcpConnections(null, list);
             return list.ToArray();
         }
 
         ///
         /// Gets the active TCP connections. Uses the native GetTcpTable API.
-        private static unsafe List<SystemTcpConnectionInformation> GetAllTcpConnections()
+        private static unsafe void GetAllTcpConnections(List<TcpConnectionInformation>? connections, List<IPEndPoint>? listening)
         {
             uint size = 0;
             uint result;
-            List<SystemTcpConnectionInformation> tcpConnections = new List<SystemTcpConnectionInformation>();
 
             // Check if it supports IPv4 for IPv6 only modes.
             if (Socket.OSSupportsIPv4)
             {
                 // Get the buffer size needed.
-                result = Interop.IpHlpApi.GetTcpTable(IntPtr.Zero, &size, order: true);
+                result = Interop.IpHlpApi.GetExtendedTcpTable(0, &size, order: true, (uint)AddressFamily.InterNetwork,
+                    connections is null ? Interop.IpHlpApi.TcpTableClass.TcpTableBasicListener : Interop.IpHlpApi.TcpTableClass.TcpTableBasicAll, 0);
 
                 while (result == Interop.IpHlpApi.ERROR_INSUFFICIENT_BUFFER)
                 {
@@ -120,24 +105,26 @@ namespace System.Net.NetworkInformation
                     IntPtr buffer = Marshal.AllocHGlobal((int)size);
                     try
                     {
-                        result = Interop.IpHlpApi.GetTcpTable(buffer, &size, order: true);
+                        result = Interop.IpHlpApi.GetExtendedTcpTable(buffer, &size, order: true, (uint)AddressFamily.InterNetwork,
+                            connections is null ? Interop.IpHlpApi.TcpTableClass.TcpTableBasicListener : Interop.IpHlpApi.TcpTableClass.TcpTableBasicAll, 0);
 
                         if (result == Interop.IpHlpApi.ERROR_SUCCESS)
                         {
-                            var span = new ReadOnlySpan<byte>((byte*)buffer, (int)size);
-
-                            // The table info just gives us the number of rows.
-                            ref readonly Interop.IpHlpApi.MibTcpTable tcpTableInfo = ref MemoryMarshal.AsRef<Interop.IpHlpApi.MibTcpTable>(span);
-
-                            if (tcpTableInfo.numberOfEntries > 0)
+                            var table = (Interop.IpHlpApi.MibTcpTable*)buffer;
+                            if (table->NumEntries > 0)
                             {
-                                // Skip over the tableinfo to get the inline rows.
-                                span = span.Slice(sizeof(Interop.IpHlpApi.MibTcpTable));
-
-                                for (int i = 0; i < tcpTableInfo.numberOfEntries; i++)
+                                var span = new ReadOnlySpan<Interop.IpHlpApi.MibTcpRow>(&table->FirstEntry, (int)table->NumEntries);
+                                Debug.Assert(sizeof(uint) + sizeof(Interop.IpHlpApi.MibTcpRow) * span.Length <= size);
+                                foreach (ref readonly Interop.IpHlpApi.MibTcpRow entry in span)
                                 {
-                                    tcpConnections.Add(new SystemTcpConnectionInformation(in MemoryMarshal.AsRef<Interop.IpHlpApi.MibTcpRow>(span)));
-                                    span = span.Slice(sizeof(Interop.IpHlpApi.MibTcpRow));
+                                    if (entry.State == TcpState.Listen)
+                                    {
+                                        listening?.Add(entry.LocalEndPoint);
+                                    }
+                                    else
+                                    {
+                                        connections!.Add(new SystemTcpConnectionInformation(in entry));
+                                    }
                                 }
                             }
                         }
@@ -159,9 +146,8 @@ namespace System.Net.NetworkInformation
             {
                 // Get the buffer size needed.
                 size = 0;
-                result = Interop.IpHlpApi.GetExtendedTcpTable(IntPtr.Zero, &size, order: true,
-                                                                        (uint)AddressFamily.InterNetworkV6,
-                                                                        Interop.IpHlpApi.TcpTableClass.TcpTableOwnerPidAll, 0);
+                result = Interop.IpHlpApi.GetExtendedTcpTable(0, &size, order: true, (uint)AddressFamily.InterNetworkV6,
+                    connections is null ? Interop.IpHlpApi.TcpTableClass.TcpTableOwnerPidListener : Interop.IpHlpApi.TcpTableClass.TcpTableOwnerPidAll, 0);
 
                 while (result == Interop.IpHlpApi.ERROR_INSUFFICIENT_BUFFER)
                 {
@@ -169,27 +155,26 @@ namespace System.Net.NetworkInformation
                     IntPtr buffer = Marshal.AllocHGlobal((int)size);
                     try
                     {
-                        result = Interop.IpHlpApi.GetExtendedTcpTable(buffer, &size, order: true,
-                                                                                (uint)AddressFamily.InterNetworkV6,
-                                                                                Interop.IpHlpApi.TcpTableClass.TcpTableOwnerPidAll, 0);
+                        result = Interop.IpHlpApi.GetExtendedTcpTable(buffer, &size, order: true, (uint)AddressFamily.InterNetworkV6,
+                            connections is null ? Interop.IpHlpApi.TcpTableClass.TcpTableOwnerPidListener : Interop.IpHlpApi.TcpTableClass.TcpTableOwnerPidAll, 0);
+
                         if (result == Interop.IpHlpApi.ERROR_SUCCESS)
                         {
-                            var span = new ReadOnlySpan<byte>((byte*)buffer, (int)size);
-
-                            // The table info just gives us the number of rows.
-                            ref readonly Interop.IpHlpApi.MibTcp6TableOwnerPid tcpTable6OwnerPid = ref MemoryMarshal.AsRef<Interop.IpHlpApi.MibTcp6TableOwnerPid>(span);
-
-                            if (tcpTable6OwnerPid.numberOfEntries > 0)
+                            var table = (Interop.IpHlpApi.MibTcp6TableOwnerPid*)buffer;
+                            if (table->NumEntries > 0)
                             {
-                                // Skip over the tableinfo to get the inline rows.
-                                span = span.Slice(sizeof(Interop.IpHlpApi.MibTcp6TableOwnerPid));
-
-                                for (int i = 0; i < tcpTable6OwnerPid.numberOfEntries; i++)
+                                var span = new ReadOnlySpan<Interop.IpHlpApi.MibTcp6RowOwnerPid>(&table->FirstEntry, (int)table->NumEntries);
+                                Debug.Assert(sizeof(uint) + sizeof(Interop.IpHlpApi.MibTcp6RowOwnerPid) * span.Length <= size);
+                                foreach (ref readonly Interop.IpHlpApi.MibTcp6RowOwnerPid entry in span)
                                 {
-                                    tcpConnections.Add(new SystemTcpConnectionInformation(in MemoryMarshal.AsRef<Interop.IpHlpApi.MibTcp6RowOwnerPid>(span)));
-
-                                    // We increment the pointer to the next row.
-                                    span = span.Slice(sizeof(Interop.IpHlpApi.MibTcp6RowOwnerPid));
+                                    if (entry.State == TcpState.Listen)
+                                    {
+                                        listening?.Add(entry.LocalEndPoint);
+                                    }
+                                    else
+                                    {
+                                        connections!.Add(new SystemTcpConnectionInformation(in entry));
+                                    }
                                 }
                             }
                         }
@@ -206,8 +191,6 @@ namespace System.Net.NetworkInformation
                     throw new NetworkInformationException((int)result);
                 }
             }
-
-            return tcpConnections;
         }
 
         /// Gets the active UDP listeners. Uses the native GetUdpTable API.
@@ -221,37 +204,28 @@ namespace System.Net.NetworkInformation
             if (Socket.OSSupportsIPv4)
             {
                 // Get the buffer size needed.
-                result = Interop.IpHlpApi.GetUdpTable(IntPtr.Zero, &size, order: true);
+                result = Interop.IpHlpApi.GetExtendedUdpTable(0, &size, order: true, (uint)AddressFamily.InterNetwork,
+                    Interop.IpHlpApi.UdpTableClass.UdpTableBasic, 0);
+
                 while (result == Interop.IpHlpApi.ERROR_INSUFFICIENT_BUFFER)
                 {
                     // Allocate the buffer and get the UDP table.
                     IntPtr buffer = Marshal.AllocHGlobal((int)size);
-
                     try
                     {
-                        result = Interop.IpHlpApi.GetUdpTable(buffer, &size, order: true);
+                        result = Interop.IpHlpApi.GetExtendedUdpTable(buffer, &size, order: true, (uint)AddressFamily.InterNetwork,
+                            Interop.IpHlpApi.UdpTableClass.UdpTableBasic, 0);
 
                         if (result == Interop.IpHlpApi.ERROR_SUCCESS)
                         {
-                            var span = new ReadOnlySpan<byte>((byte*)buffer, (int)size);
-
-                            // The table info just gives us the number of rows.
-                            ref readonly Interop.IpHlpApi.MibUdpTable udpTableInfo = ref MemoryMarshal.AsRef<Interop.IpHlpApi.MibUdpTable>(span);
-
-                            if (udpTableInfo.numberOfEntries > 0)
+                            var table = (Interop.IpHlpApi.MibUdpTable*)buffer;
+                            if (table->NumEntries > 0)
                             {
-                                // Skip over the tableinfo to get the inline rows.
-                                span = span.Slice(sizeof(Interop.IpHlpApi.MibUdpTable));
-
-                                for (int i = 0; i < udpTableInfo.numberOfEntries; i++)
+                                var span = new ReadOnlySpan<Interop.IpHlpApi.MibUdpRow>(&table->FirstEntry, (int)table->NumEntries);
+                                Debug.Assert(sizeof(uint) + sizeof(Interop.IpHlpApi.MibUdpRow) * span.Length <= size);
+                                foreach (ref readonly Interop.IpHlpApi.MibUdpRow entry in span)
                                 {
-                                    ref readonly Interop.IpHlpApi.MibUdpRow udpRow = ref MemoryMarshal.AsRef<Interop.IpHlpApi.MibUdpRow>(span);
-                                    int localPort = udpRow.localPort1 << 8 | udpRow.localPort2;
-
-                                    udpListeners.Add(new IPEndPoint(udpRow.localAddr, (int)localPort));
-
-                                    // We increment the pointer to the next row.
-                                    span = span.Slice(sizeof(Interop.IpHlpApi.MibUdpRow));
+                                    udpListeners.Add(entry.LocalEndPoint);
                                 }
                             }
                         }
@@ -288,26 +262,14 @@ namespace System.Net.NetworkInformation
 
                         if (result == Interop.IpHlpApi.ERROR_SUCCESS)
                         {
-                            var span = new ReadOnlySpan<byte>((byte*)buffer, (int)size);
-
-                            // The table info just gives us the number of rows.
-                            ref readonly Interop.IpHlpApi.MibUdp6TableOwnerPid udp6TableOwnerPid = ref MemoryMarshal.AsRef<Interop.IpHlpApi.MibUdp6TableOwnerPid>(span);
-
-                            if (udp6TableOwnerPid.numberOfEntries > 0)
+                            var table = (Interop.IpHlpApi.MibUdp6TableOwnerPid*)buffer;
+                            if (table->NumEntries > 0)
                             {
-                                // Skip over the tableinfo to get the inline rows.
-                                span = span.Slice(sizeof(Interop.IpHlpApi.MibUdp6TableOwnerPid));
-
-                                for (int i = 0; i < udp6TableOwnerPid.numberOfEntries; i++)
+                                var span = new ReadOnlySpan<Interop.IpHlpApi.MibUdp6RowOwnerPid>(&table->FirstEntry, (int)table->NumEntries);
+                                Debug.Assert(sizeof(uint) + sizeof(Interop.IpHlpApi.MibUdp6RowOwnerPid) * span.Length <= size);
+                                foreach (ref readonly Interop.IpHlpApi.MibUdp6RowOwnerPid entry in span)
                                 {
-                                    ref readonly Interop.IpHlpApi.MibUdp6RowOwnerPid udp6RowOwnerPid = ref MemoryMarshal.AsRef<Interop.IpHlpApi.MibUdp6RowOwnerPid>(span);
-                                    int localPort = udp6RowOwnerPid.localPort1 << 8 | udp6RowOwnerPid.localPort2;
-
-                                    udpListeners.Add(new IPEndPoint(new IPAddress(udp6RowOwnerPid.localAddrAsSpan,
-                                        udp6RowOwnerPid.localScopeId), localPort));
-
-                                    // We increment the pointer to the next row.
-                                    span = span.Slice(sizeof(Interop.IpHlpApi.MibUdp6RowOwnerPid));
+                                    udpListeners.Add(entry.LocalEndPoint);
                                 }
                             }
                         }

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemIPGlobalProperties.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemIPGlobalProperties.cs
@@ -85,8 +85,7 @@ namespace System.Net.NetworkInformation
             return list.ToArray();
         }
 
-        ///
-        /// Gets the active TCP connections. Uses the native GetTcpTable API.
+        /// Gets the active TCP connections. Uses the native GetExtendedTcpTable API.
         private static unsafe void GetAllTcpConnections(List<TcpConnectionInformation>? connections, List<IPEndPoint>? listening)
         {
             uint size = 0;
@@ -123,7 +122,7 @@ namespace System.Net.NetworkInformation
                                     }
                                     else
                                     {
-                                        connections!.Add(new SystemTcpConnectionInformation(in entry));
+                                        connections?.Add(new SystemTcpConnectionInformation(in entry));
                                     }
                                 }
                             }
@@ -173,7 +172,7 @@ namespace System.Net.NetworkInformation
                                     }
                                     else
                                     {
-                                        connections!.Add(new SystemTcpConnectionInformation(in entry));
+                                        connections?.Add(new SystemTcpConnectionInformation(in entry));
                                     }
                                 }
                             }
@@ -193,7 +192,7 @@ namespace System.Net.NetworkInformation
             }
         }
 
-        /// Gets the active UDP listeners. Uses the native GetUdpTable API.
+        /// Gets the active UDP listeners. Uses the native GetExtendedUdpTable API.
         public override unsafe IPEndPoint[] GetActiveUdpListeners()
         {
             uint size = 0;

--- a/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemTcpConnection.cs
+++ b/src/libraries/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemTcpConnection.cs
@@ -12,29 +12,17 @@ namespace System.Net.NetworkInformation
 
         internal SystemTcpConnectionInformation(in Interop.IpHlpApi.MibTcpRow row)
         {
-            _state = row.state;
-
-            // Port is returned in Big-Endian - most significant bit on left.
-            // Unfortunately, its done at the word level and not the DWORD level.
-            int localPort = row.localPort1 << 8 | row.localPort2;
-            int remotePort = ((_state == TcpState.Listen) ? 0 : row.remotePort1 << 8 | row.remotePort2);
-
-            _localEndPoint = new IPEndPoint(row.localAddr, (int)localPort);
-            _remoteEndPoint = new IPEndPoint(row.remoteAddr, (int)remotePort);
+            _state = row.State;
+            _localEndPoint = row.LocalEndPoint;
+            _remoteEndPoint = row.RemoteEndPoint;
         }
 
         // IPV6 version of the Tcp row.
         internal SystemTcpConnectionInformation(in Interop.IpHlpApi.MibTcp6RowOwnerPid row)
         {
-            _state = row.state;
-
-            // Port is returned in Big-Endian - most significant bit on left.
-            // Unfortunately, its done at the word level and not the DWORD level.
-            int localPort = row.localPort1 << 8 | row.localPort2;
-            int remotePort = ((_state == TcpState.Listen) ? 0 : row.remotePort1 << 8 | row.remotePort2);
-
-            _localEndPoint = new IPEndPoint(new IPAddress(row.localAddrAsSpan, row.localScopeId), (int)localPort);
-            _remoteEndPoint = new IPEndPoint(new IPAddress(row.remoteAddrAsSpan, row.remoteScopeId), (int)remotePort);
+            _state = row.State;
+            _localEndPoint = row.LocalEndPoint;
+            _remoteEndPoint = row.RemoteEndPoint;
         }
 
         public override TcpState State { get { return _state; } }


### PR DESCRIPTION
- Remove multiple layers of allocations from `GetActiveTcpConnections/GetActiveTcpListeners`.
- Use native API filtering for listeners and entry state filtering for connections.
- Adjust interop structures to more closely match the native declaration.
- Minimize unsafe pointer manipulation and use safe spans instead for enumerating entries.