### PR TITLE
Fix pal_memory.c on OpenBSD

### DIFF
--- a/src/native/libs/System.Native/pal_memory.c
+++ b/src/native/libs/System.Native/pal_memory.c
@@ -50,7 +50,7 @@ void* SystemNative_AlignedRealloc(void* ptr, uintptr_t alignment, uintptr_t new_
         uintptr_t old_size = MALLOC_SIZE(ptr);
         assert((ptr != NULL) || (old_size == 0));
 
-        uintptr_t size_to_copy = (new_size < old_size) ? new_size : old_size
+        uintptr_t size_to_copy = (new_size < old_size) ? new_size : old_size;
 #else
         // Less efficient implementation for platforms that do not provide MALLOC_SIZE.
         ptr = realloc(ptr, new_size);

--- a/src/native/libs/System.Native/pal_memory.c
+++ b/src/native/libs/System.Native/pal_memory.c
@@ -17,8 +17,6 @@
 #elif HAVE_MALLOC_USABLE_SIZE_NP
     #include <malloc_np.h>
     #define MALLOC_SIZE(s) malloc_usable_size(s)
-#elif defined(TARGET_SUNOS)
-    #define MALLOC_SIZE(s) (*((size_t*)(s)-1))
 #endif
 
 void* SystemNative_AlignedAlloc(uintptr_t alignment, uintptr_t size)

--- a/src/native/libs/System.Native/pal_memory.c
+++ b/src/native/libs/System.Native/pal_memory.c
@@ -19,8 +19,6 @@
     #define MALLOC_SIZE(s) malloc_usable_size(s)
 #elif defined(TARGET_SUNOS)
     #define MALLOC_SIZE(s) (*((size_t*)(s)-1))
-#else
-    #error "Platform doesn't support malloc_usable_size or malloc_size"
 #endif
 
 void* SystemNative_AlignedAlloc(uintptr_t alignment, uintptr_t size)
@@ -48,10 +46,23 @@ void* SystemNative_AlignedRealloc(void* ptr, uintptr_t alignment, uintptr_t new_
 
     if (result != NULL)
     {
+#ifdef MALLOC_SIZE
         uintptr_t old_size = MALLOC_SIZE(ptr);
         assert((ptr != NULL) || (old_size == 0));
 
-        memcpy(result, ptr, (new_size < old_size) ? new_size : old_size);
+        uintptr_t size_to_copy = (new_size < old_size) ? new_size : old_size
+#else
+        // Less efficient implementation for platforms that do not provide MALLOC_SIZE.
+        ptr = realloc(ptr, new_size);
+        if (ptr == NULL)
+        {
+            SystemNative_AlignedFree(result);
+            return NULL;
+        }
+        uintptr_t size_to_copy = new_size;
+#endif
+
+        memcpy(result, ptr, size_to_copy);
         SystemNative_AlignedFree(ptr);
     }
 


### PR DESCRIPTION
OpenBSD does not have an implementation of `MALLOC_SIZE` so implement `SystemNative_AlignedRealloc` generically for OpenBSD and other platforms that do not have a `MALLOC_SIZE` equivalent.