### PR TITLE
Skip NonBacktracking deep nesting test on single-threaded WASM

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -2637,11 +2637,16 @@ namespace System.Text.RegularExpressions.Tests
             }
         }
 
-        [Theory]
+        [ConditionalTheory]
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Fix is not available on .NET Framework")]
         [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
         public async Task CharClassSubtraction_DeepNesting_DoesNotStackOverflow(RegexEngine engine)
         {
+            if (RegexHelpers.IsNonBacktracking(engine) && !PlatformDetection.IsMultithreadingSupported)
+            {
+                throw new SkipTestException("Deep nesting with NonBacktracking hits threading APIs not supported on single-threaded WASM.");
+            }
+
             // Build a pattern with deeply nested character class subtractions: [a-[a-[a-[...[a]...]]]]
             // This previously caused a StackOverflowException due to unbounded recursion in the parser.
             // Use a reduced depth for SourceGenerated to avoid overwhelming Roslyn compilation.


### PR DESCRIPTION
The `CharClassSubtraction_DeepNesting_DoesNotStackOverflow` test added in #124995 fails with NonBacktracking engine on platforms without multithreading support (e.g. browser-wasm). The 10,000-deep nesting triggers an internal code path that calls `Task.InternalWaitCore`, which throws `PlatformNotSupportedException` via `ThrowIfMultithreadingIsNotSupported`.

This PR:
- Changes `[Theory]` to `[ConditionalTheory]` so `SkipTestException` works correctly
- Adds an in-test guard that skips only the NonBacktracking engine variant when `!PlatformDetection.IsMultithreadingSupported`

Other engine variants (Interpreter, Compiled) continue to run on all platforms.

Fixes #125020