### PR TITLE
Fix DuplicateRootAssembly assert failure

### DIFF
--- a/src/tools/illink/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/tools/illink/src/ILLink.Shared/DiagnosticId.cs
@@ -58,6 +58,7 @@ namespace ILLink.Shared
         UnexpectedAttributeArgumentType = 1045,
         InvalidMetadataOption = 1046,
         InvalidDependenciesFileFormat = 1047,
+        MultipleEntryPointRoots = 1048,
 
         // Trimming diagnostic ids.
         TypeHasNoFieldsToPreserve = 2001,

--- a/src/tools/illink/src/ILLink.Shared/SharedStrings.resx
+++ b/src/tools/illink/src/ILLink.Shared/SharedStrings.resx
@@ -1221,6 +1221,12 @@
   <data name="InvalidDependenciesFileFormatTitle" xml:space="preserve">
     <value>Unrecognized dependencies file type.</value>
   </data>
+  <data name="MultipleEntryPointRootsMessage" xml:space="preserve">
+    <value>Multiple root assemblies specified with 'entrypoint' root mode. Assembly '{0}' conflicts with '{1}'.</value>
+  </data>
+  <data name="MultipleEntryPointRootsTitle" xml:space="preserve">
+    <value>Multiple root assemblies specified with 'entrypoint' root mode.</value>
+  </data>
   <data name="RedundantSuppressionMessage" xml:space="preserve">
     <value>Unused 'UnconditionalSuppressMessageAttribute' for warning '{0}'. Consider removing the unused warning suppression.</value>
   </data>

--- a/src/tools/illink/src/linker/Linker.Steps/RootAssemblyInputStep.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/RootAssemblyInputStep.cs
@@ -52,6 +52,13 @@ namespace Mono.Linker.Steps
                         return;
                     }
 
+                    var existingEntryPointAssembly = Annotations.GetEntryPointAssembly();
+                    if (existingEntryPointAssembly is not null && existingEntryPointAssembly != assembly)
+                    {
+                        Context.LogError(null, DiagnosticId.MultipleEntryPointRoots, assembly.Name.ToString(), existingEntryPointAssembly.Name.ToString());
+                        return;
+                    }
+
                     Annotations.Mark(ep.DeclaringType, di, origin);
                     Annotations.AddPreservedMethod(ep.DeclaringType, ep);
                     Annotations.SetEntryPointAssembly(assembly);

--- a/src/tools/illink/src/linker/Linker/Annotations.cs
+++ b/src/tools/illink/src/linker/Linker/Annotations.cs
@@ -609,7 +609,7 @@ namespace Mono.Linker
 
         public void SetEntryPointAssembly(AssemblyDefinition asmDef)
         {
-            Debug.Assert(entry_assembly is null);
+            Debug.Assert(entry_assembly is null || entry_assembly == asmDef);
             entry_assembly = asmDef;
         }
 

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/CommandLineTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/CommandLineTests.g.cs
@@ -40,6 +40,12 @@ namespace ILLink.RoslynAnalyzer.Tests
         }
 
         [Fact]
+        public Task MultipleEntryPointRoots()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
         public Task ResponseFilesWork()
         {
             return RunTest(allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CommandLine/Dependencies/MultipleEntryPointRoots_Lib.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CommandLine/Dependencies/MultipleEntryPointRoots_Lib.cs
@@ -1,0 +1,12 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Mono.Linker.Tests.Cases.CommandLine.Dependencies
+{
+    public class MultipleEntryPointRoots_Lib
+    {
+        public static void Main()
+        {
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CommandLine/MultipleEntryPointRoots.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CommandLine/MultipleEntryPointRoots.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.CommandLine;
+
+[ExpectNonZeroExitCode(1)]
+[SetupCompileBefore("other.exe", new[] { "Dependencies/MultipleEntryPointRoots_Lib.cs" })]
+[SetupLinkerArgument("-a", "test.exe", "entrypoint")]
+[SetupLinkerArgument("-a", "other.exe", "entrypoint")]
+[LogContains("IL1048")]
+[NoLinkedOutput]
+public class MultipleEntryPointRoots
+{
+    public static void Main()
+    {
+    }
+}


### PR DESCRIPTION
and add IL1048 error for multiple entrypoint roots

The Debug.Assert(entry_assembly is null) added in PR #116555 did not account for the same assembly being specified twice via different paths (e.g. 'test.exe' and '../input/test.exe'), which broke the existing DuplicateRootAssembly test.

Relax the assert to tolerate the same AssemblyDefinition object being set again, and add a proper IL1048 error when two *different* assemblies are both specified with 'entrypoint' root mode.