### PR TITLE
[browser] cut HexConverter -> Vector128 dependecy

### DIFF
--- a/src/libraries/Common/src/System/HexConverter.cs
+++ b/src/libraries/Common/src/System/HexConverter.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Numerics;
 
 #if SYSTEM_PRIVATE_CORELIB
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics;
 using System.Runtime.Intrinsics.Arm;
@@ -19,6 +20,12 @@ namespace System
 {
     internal static class HexConverter
     {
+#if SYSTEM_PRIVATE_CORELIB
+        [FeatureSwitchDefinition("System.HexConverter.UseVectorizedImplementation")]
+        private static bool UseVectorizedImplementation =>
+            AppContext.TryGetSwitch("System.HexConverter.UseVectorizedImplementation", out bool v) ? v : true;
+#endif
+
         public enum Casing : uint
         {
             // Output [ '0' .. '9' ] and [ 'A' .. 'F' ].
@@ -187,7 +194,7 @@ namespace System
             Debug.Assert(utf8Destination.Length >= (source.Length * 2));
 
 #if SYSTEM_PRIVATE_CORELIB
-            if ((AdvSimd.Arm64.IsSupported || Ssse3.IsSupported) && (source.Length >= (Vector128<byte>.Count / 2)))
+            if (UseVectorizedImplementation && (AdvSimd.Arm64.IsSupported || Ssse3.IsSupported) && (source.Length >= (Vector128<byte>.Count / 2)))
             {
                 EncodeTo_Vector128(source, utf8Destination, casing);
                 return;
@@ -204,7 +211,7 @@ namespace System
             Debug.Assert(destination.Length >= (source.Length * 2));
 
 #if SYSTEM_PRIVATE_CORELIB
-            if ((AdvSimd.Arm64.IsSupported || Ssse3.IsSupported) && (source.Length >= (Vector128<ushort>.Count / 2)))
+            if (UseVectorizedImplementation && (AdvSimd.Arm64.IsSupported || Ssse3.IsSupported) && (source.Length >= (Vector128<ushort>.Count / 2)))
             {
                 EncodeTo_Vector128(source, Unsafe.BitCast<Span<char>, Span<ushort>>(destination), casing);
                 return;
@@ -274,7 +281,7 @@ namespace System
         public static bool TryDecodeFromUtf8(ReadOnlySpan<byte> utf8Source, Span<byte> destination, out int bytesProcessed)
         {
 #if SYSTEM_PRIVATE_CORELIB
-            if (BitConverter.IsLittleEndian && (Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) &&
+            if (UseVectorizedImplementation && BitConverter.IsLittleEndian && (Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) &&
                 (utf8Source.Length >= Vector128<byte>.Count))
             {
                 return TryDecodeFrom_Vector128(utf8Source, destination, out bytesProcessed);
@@ -286,7 +293,7 @@ namespace System
         public static bool TryDecodeFromUtf16(ReadOnlySpan<char> source, Span<byte> destination, out int charsProcessed)
         {
 #if SYSTEM_PRIVATE_CORELIB
-            if (BitConverter.IsLittleEndian && (Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) &&
+            if (UseVectorizedImplementation && BitConverter.IsLittleEndian && (Ssse3.IsSupported || AdvSimd.Arm64.IsSupported || PackedSimd.IsSupported) &&
                 (source.Length >= (Vector128<ushort>.Count * 2)))
             {
                 return TryDecodeFrom_Vector128(Unsafe.BitCast<ReadOnlySpan<char>, ReadOnlySpan<ushort>>(source), destination, out charsProcessed);

--- a/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.WASM.xml
+++ b/src/libraries/System.Private.CoreLib/src/ILLink/ILLink.Substitutions.WASM.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<linker>
+	<assembly fullname="System.Private.CoreLib">
+		<type fullname="System.HexConverter">
+			<method signature="System.Boolean get_UseVectorizedImplementation()" body="stub" value="false" />
+		</type>
+	</assembly>
+</linker>

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -65,6 +65,7 @@
     <ILLinkSubstitutionsXmls Include="$(ILLinkSharedDirectory)ILLink.Substitutions.NoX86Intrinsics.xml" Condition="'$(SupportsX86Intrinsics)' != 'true'" />
     <ILLinkSubstitutionsXmls Include="$(ILLinkSharedDirectory)ILLink.Substitutions.NoWasmIntrinsics.xml" Condition="'$(SupportsWasmIntrinsics)' != 'true'" />
     <ILLinkSubstitutionsXmls Include="$(ILLinkSharedDirectory)ILLink.Substitutions.iOS.xml" Condition="'$(IsiOSLike)' == 'true'" />
+    <ILLinkSubstitutionsXmls Include="$(ILLinkSharedDirectory)ILLink.Substitutions.WASM.xml" Condition="'$(TargetsBrowser)' == 'true'" />
     <ILLinkLinkAttributesXmls Include="$(ILLinkSharedDirectory)ILLink.LinkAttributes.Shared.xml" />
     <ILLinkSuppressionsLibraryBuildXml Include="$(ILLinkSharedDirectory)ILLink.Suppressions.LibraryBuild.xml" />
     <ILLinkDescriptorsLibraryBuildXml Include="$(ILLinkSharedDirectory)ILLink.Descriptors.LibraryBuild.xml" />


### PR DESCRIPTION
# Break HexConverter → Vector128 chain for browser IL trimming

## Motivation

On browser/WASM targets with SIMD enabled (`WasmEnableSIMD=true`, the default), the IL
trimmer preserves `HexConverter.TryDecodeFrom_Vector128` and its transitive dependencies
because `PackedSimd.IsSupported` is stubbed to `true`. This creates **64 dependency edges**
from the Infrastructure category into the Vector category in the trimming graph:

```
Reflection → AssemblyName → AssemblyNameParser.TryParsePKT
  → HexConverter.TryDecodeFromUtf16
    → TryDecodeFrom_Vector128
      → Vector128.LoadUnsafe, Vector128.Create, Vector128.Shuffle,
        PackedSimd.BitwiseSelect, PackedSimd.AddPairwiseWidening, ...
```

The only call site in the Reflection stack is `AssemblyNameParser.TryParsePKT`, which
parses public key tokens — always exactly 16 hex characters. This is well below the
`Vector128<ushort>.Count * 2` threshold, so the vectorized path would never execute at
runtime anyway. Yet the trimmer cannot prove this statically, so it must preserve the
entire Vector128 code.

## What this PR does

Adds a feature switch `System.HexConverter.UseVectorizedImplementation` (default: `true`)
that guards all four Vector128 entry points in `HexConverter`:

- `EncodeToUtf8` → `EncodeTo_Vector128`
- `EncodeToUtf16` → `EncodeTo_Vector128`
- `TryDecodeFromUtf8` → `TryDecodeFrom_Vector128`
- `TryDecodeFromUtf16` → `TryDecodeFrom_Vector128`

A new ILLink substitution file (`ILLink.Substitutions.WASM.xml`) sets this switch to
`false` for browser targets. When the trimmer processes this substitution, the property
getter returns a constant `false`, making all `if (UseVectorizedImplementation && ...)`
branches dead code. The trimmer then removes the vectorized methods and their transitive
Vector128/PackedSimd dependencies.

Non-browser platforms are unaffected — the switch defaults to `true` and no substitution
is applied.

## When does this help?

This change benefits **minimal browser/WASM applications** where Vector128 infrastructure
is not pulled in by other code paths. Examples:

- **Small WASM modules** that perform computation, interop, or orchestration without
  heavy text processing. These apps may use `AssemblyName` parsing (via reflection or
  type loading) but never touch string search, UTF-8 transcoding, or Base64.

- **WASI command-line tools** and lightweight services where trimming aggressiveness
  matters for download size and startup time.

- **Blazor/browser apps with aggressive trimming** where every unnecessary type pulled
  into the dependency graph increases the final `.wasm` bundle size. Even when Vector128
  *is* needed elsewhere, removing redundant dependency edges gives the trimmer more
  freedom to eliminate unused generic instantiations and helper methods.

The real win is breaking the **Reflection → Vector** dependency chain. Even if Vector128
is retained through other paths, having fewer roots into the Vector infrastructure means
the trimmer can more aggressively prune unused Vector128 method instantiations and
internal helpers.

## When does this NOT matter?

In most non-trivial browser apps, Vector128 will be pulled in regardless through other
hot paths in System.Private.CoreLib:

| Code path | What pulls it in |
|-----------|-----------------|
| `Utf8Utility` / `Ascii.Utility` | Any UTF-8 validation, transcoding, or ASCII detection |
| `SearchValues` / `IndexOfAnyAsciiSearcher` | `string.IndexOfAny`, `Span<T>.IndexOfAny` |
| `Ascii.CaseConversion` | `string.ToUpper/ToLower` |
| `Base64Helper` | Any Base64 encode/decode |
| `Ordinal.Utf8` | Ordinal string comparison on UTF-8 data |
| `Number formatting/parsing` | `int.ToString()`, `double.Parse()`, etc. |

For these apps the Vector128 code is already retained and the HexConverter contribution
is marginal. The feature switch still prevents the unnecessary *additional* edges but
won't noticeably change bundle size.
