### PR TITLE
[wasm][coreclr] Re-enable runtime tests

### DIFF
--- a/src/tests/JIT/Methodical/eh/basics/throwinfilter.il
+++ b/src/tests/JIT/Methodical/eh/basics/throwinfilter.il
@@ -30,11 +30,6 @@
         type([TestLibrary]TestLibrary.PlatformDetection)
         string[1] ('IsMonoInterpreter')
     }
-    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ActiveIssueAttribute::.ctor(string, class [mscorlib]System.Type, string[]) = {
-        string('https://github.com/dotnet/runtime/issues/123793')
-        type([TestLibrary]TestLibrary.PlatformDetection)
-        string[1] ('IsWasm')
-    }
     .entrypoint
     .maxstack  2
     .locals init (

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b68872/b68872.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b68872/b68872.il
@@ -9,8 +9,6 @@
 }
 .assembly 'b68872' { }
 .assembly extern xunit.core {}
-.assembly extern TestLibrary { .ver 0:0:0:0 }
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
 .namespace JitTest
 {
   .class public auto ansi beforefieldinit Test

--- a/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b68872/b68872.il
+++ b/src/tests/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b68872/b68872.il
@@ -22,11 +22,6 @@
       .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
           01 00 00 00
       )
-      .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ActiveIssueAttribute::.ctor(string, class [mscorlib]System.Type, string[]) = {
-          string('https://github.com/dotnet/runtime/issues/123793')
-          type([TestLibrary]TestLibrary.PlatformDetection)
-          string[1] ('IsWasm')
-      }
       .entrypoint
       // Code size       120 (0x78)
       .maxstack  2

--- a/src/tests/JIT/Regression/JitBlue/GitHub_4044/GitHub_4044.cs
+++ b/src/tests/JIT/Regression/JitBlue/GitHub_4044/GitHub_4044.cs
@@ -10,7 +10,6 @@ public class C
 {
     [Fact]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/114908", typeof(PlatformDetection), nameof(PlatformDetection.IsAppleMobile))]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/123793", typeof(PlatformDetection), nameof(PlatformDetection.IsWasm))]
     [SkipOnMono("needs triage")]
     public static int TestEntryPoint()
     {


### PR DESCRIPTION
The underlying issue should be fixed by part of
https://github.com/dotnet/runtime/pull/124296

This resolves https://github.com/dotnet/runtime/issues/123793