### PR TITLE
Fix zstd install rules breaking clr.runtime clean build

### DIFF
--- a/src/native/external/zstd.cmake
+++ b/src/native/external/zstd.cmake
@@ -39,7 +39,7 @@ set(BUILD_SHARED_LIBS OFF)
 # from a clean build fails because the install step tries to install
 # zstd_static.lib which was not built as part of the runtime target.
 # This can be replaced by using EXCLUDE_FROM_ALL in FetchContent_Declare on CMAKE 3.28+
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/zstd/build/cmake ${CMAKE_BINARY_DIR}/_deps/zstd-build EXCLUDE_FROM_ALL)
+add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/zstd/build/cmake" "${CMAKE_BINARY_DIR}/_deps/zstd-build" EXCLUDE_FROM_ALL)
 
 set(BUILD_SHARED_LIBS ${__CURRENT_BUILD_SHARED_LIBS})
 

--- a/src/native/external/zstd.cmake
+++ b/src/native/external/zstd.cmake
@@ -1,13 +1,5 @@
 # IMPORTANT: do not use add_compile_options(), add_definitions() or similar functions here since it will leak to the including projects
 
-include(FetchContent)
-
-FetchContent_Declare(
-    zstd
-    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/zstd/build/cmake
-    EXCLUDE_FROM_ALL
-)
-
 set(ZSTD_BUILD_PROGRAMS OFF)
 set(ZSTD_BUILD_TESTS OFF)
 set(ZSTD_BUILD_CONTRIB OFF)
@@ -41,7 +33,14 @@ endif()
 
 set(__CURRENT_BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
-FetchContent_MakeAvailable(zstd)
+
+# Use EXCLUDE_FROM_ALL to prevent zstd's own install() rules from being
+# included in the build's install step. Without this, building clr.runtime
+# from a clean build fails because the install step tries to install
+# zstd_static.lib which was not built as part of the runtime target.
+# This can be replaced by using EXCLUDE_FROM_ALL in FetchContent_Declare on CMAKE 3.28+
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/zstd/build/cmake ${CMAKE_BINARY_DIR}/_deps/zstd-build EXCLUDE_FROM_ALL)
+
 set(BUILD_SHARED_LIBS ${__CURRENT_BUILD_SHARED_LIBS})
 
 if (ANDROID)


### PR DESCRIPTION
## Summary

Fix CMake build failure when building `clr.runtime` from a clean build (instead of `clr.native`).

## Problem

When building `clr.runtime` from clean, the install step fails with:

```
CMake Error at _deps/zstd-build/lib/cmake_install.cmake:53 (file):
    file INSTALL cannot find
    ".../_deps/zstd-build/lib/zstd_static.lib"
```

This happens because zstd's own `install()` rules are included in the build's install step. When the `runtime` component install runs, it tries to install `zstd_static.lib` — but that file was never built because `libzstd_static` is only built as a dependency of `System.IO.Compression.Native`, which is not part of the `runtime` build target.

## Fix

Replace `FetchContent` with a direct `add_subdirectory()` call using `EXCLUDE_FROM_ALL`, which reliably prevents zstd's own `install()` rules from being included in the component install. The `EXCLUDE_FROM_ALL` parameter on `add_subdirectory()` has properly suppressed install rules since CMake 3.14, making it compatible with the project's CMake 3.26 minimum.

The explicit `install()` calls in `System.IO.Compression.Native/CMakeLists.txt` that install `libzstd_static` to the correct destinations continue to work as before since they target the `libzstd_static` target directly (not via zstd's own install rules).

Fixes #124234
