### PR TITLE
Convert IDacDbiInterface to COM interface

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -222,7 +222,7 @@ template<class T> void DeleteDbiArrayMemory(T *p, int count)
 //    pAllocator  - pointer to client allocator object. This lets DD allocate objects and
 //                  pass them out back to the client, which can then delete them.
 //                  DD takes a weak ref to this, so client must keep it alive until it
-//                  calls Destroy.
+//                  calls Release.
 //    pMetadataLookup - callback interface to do internal metadata lookup. This is because
 //                  metadata is not dac-ized.
 //    ppInterface - mandatory out-parameter
@@ -238,7 +238,7 @@ template<class T> void DeleteDbiArrayMemory(T *p, int count)
 //    This will yield an IDacDbiInterface to provide structured access to the
 //    data-target.
 //
-//    Must call Destroy to on interface to free its resources.
+//    Must call Release on interface to free its resources.
 //
 //---------------------------------------------------------------------------------------
 STDAPI
@@ -295,7 +295,7 @@ DacDbiInterfaceInstance(
 //    pAllocator  - pointer to client allocator object. This lets DD allocate objects and
 //                  pass them out back to the client, which can then delete them.
 //                  DD takes a weak ref to this, so client must keep it alive until it
-//                  calls Destroy.
+//                  calls Release.
 //    pMetadataLookup - callback interface to do internal metadata lookup. This is because
 //                  metadata is not dac-ized.
 //
@@ -333,7 +333,7 @@ DacDbiInterfaceImpl::DacDbiInterfaceImpl(
 // Destructor.
 //
 // Notes:
-//    This gets invoked after Destroy().
+//    This gets invoked when the ref count drops to 0 via Release().
 //-----------------------------------------------------------------------------
 DacDbiInterfaceImpl::~DacDbiInterfaceImpl()
 {
@@ -441,24 +441,38 @@ interface IMDInternalImport* DacDbiInterfaceImpl::GetMDImport(
 // See DacDbiInterface.h for full descriptions of all of these functions
 //-----------------------------------------------------------------------------
 
-// Destroy the connection, freeing up any resources.
-HRESULT DacDbiInterfaceImpl::Destroy()
+// IUnknown implementation for DacDbiInterfaceImpl.
+// Delegates to ClrDataAccess's ref-counting and adds support for IDacDbiInterface IID.
+STDMETHODIMP
+DacDbiInterfaceImpl::QueryInterface(THIS_ IN REFIID interfaceId, OUT PVOID* iface)
 {
-    HRESULT hr = S_OK;
-    EX_TRY
-    {
-        m_pAllocator = NULL;
+    if (iface == NULL)
+        return E_POINTER;
 
-        this->Release();
-        // Memory is deleted, don't access this object any more
+    if (IsEqualIID(interfaceId, __uuidof(IDacDbiInterface)))
+    {
+        AddRef();
+        *iface = static_cast<IDacDbiInterface*>(this);
+        return S_OK;
     }
-    EX_CATCH_HRESULT(hr);
-    return hr;
+    return ClrDataAccess::QueryInterface(interfaceId, iface);
+}
+
+STDMETHODIMP_(ULONG)
+DacDbiInterfaceImpl::AddRef(THIS)
+{
+    return ClrDataAccess::AddRef();
+}
+
+STDMETHODIMP_(ULONG)
+DacDbiInterfaceImpl::Release(THIS)
+{
+    return ClrDataAccess::Release();
 }
 
 // Check whether the version of the DBI matches the version of the runtime.
 // See code:CordbProcess::CordbProcess#DBIVersionChecking for more information regarding version checking.
-HRESULT DacDbiInterfaceImpl::CheckDbiVersion(const DbiVersion * pVersion)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::CheckDbiVersion(const DbiVersion * pVersion)
 {
     DD_ENTER_MAY_THROW;
 
@@ -477,7 +491,7 @@ HRESULT DacDbiInterfaceImpl::CheckDbiVersion(const DbiVersion * pVersion)
 }
 
 // Flush the DAC cache. This should be called when target memory changes.
-HRESULT DacDbiInterfaceImpl::FlushCache()
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::FlushCache()
 {
     // Non-reentrant. We don't want to flush cached instances from a callback.
     // That would remove host DAC instances while they're being used.
@@ -495,7 +509,7 @@ HRESULT DacDbiInterfaceImpl::FlushCache()
 }
 
 // enable or disable DAC target consistency checks
-HRESULT DacDbiInterfaceImpl::DacSetTargetConsistencyChecks(bool fEnableAsserts)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::DacSetTargetConsistencyChecks(BOOL fEnableAsserts)
 {
     HRESULT hr = S_OK;
     EX_TRY
@@ -508,7 +522,7 @@ HRESULT DacDbiInterfaceImpl::DacSetTargetConsistencyChecks(bool fEnableAsserts)
 }
 
 // Query if Left-side is started up?
-HRESULT DacDbiInterfaceImpl::IsLeftSideInitialized(OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsLeftSideInitialized(OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -541,7 +555,7 @@ HRESULT DacDbiInterfaceImpl::IsLeftSideInitialized(OUT BOOL * pResult)
 
 
 // Determines if a given address is a CLR stub.
-HRESULT DacDbiInterfaceImpl::IsTransitionStub(CORDB_ADDRESS address, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsTransitionStub(CORDB_ADDRESS address, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -586,7 +600,7 @@ HRESULT DacDbiInterfaceImpl::IsTransitionStub(CORDB_ADDRESS address, OUT BOOL * 
 }
 
 // Gets the type of 'address'.
-HRESULT DacDbiInterfaceImpl::GetAddressType(CORDB_ADDRESS address, OUT AddressType * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAddressType(CORDB_ADDRESS address, OUT AddressType * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -621,7 +635,7 @@ HRESULT DacDbiInterfaceImpl::GetAddressType(CORDB_ADDRESS address, OUT AddressTy
 
 
 // Get a VM appdomain pointer that matches the appdomain ID
-HRESULT DacDbiInterfaceImpl::GetAppDomainFromId(ULONG appdomainId, OUT VMPTR_AppDomain * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAppDomainFromId(ULONG appdomainId, OUT VMPTR_AppDomain * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -657,7 +671,7 @@ HRESULT DacDbiInterfaceImpl::GetAppDomainFromId(ULONG appdomainId, OUT VMPTR_App
 
 
 // Get the AppDomain ID for an AppDomain.
-HRESULT DacDbiInterfaceImpl::GetAppDomainId(VMPTR_AppDomain vmAppDomain, OUT ULONG * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAppDomainId(VMPTR_AppDomain vmAppDomain, OUT ULONG * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -680,7 +694,7 @@ HRESULT DacDbiInterfaceImpl::GetAppDomainId(VMPTR_AppDomain vmAppDomain, OUT ULO
 }
 
 // Get the managed AppDomain object for an AppDomain.
-HRESULT DacDbiInterfaceImpl::GetAppDomainObject(VMPTR_AppDomain vmAppDomain, OUT VMPTR_OBJECTHANDLE * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAppDomainObject(VMPTR_AppDomain vmAppDomain, OUT VMPTR_OBJECTHANDLE * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -700,7 +714,7 @@ HRESULT DacDbiInterfaceImpl::GetAppDomainObject(VMPTR_AppDomain vmAppDomain, OUT
 }
 
 // Get the full AD friendly name for the given EE AppDomain.
-HRESULT DacDbiInterfaceImpl::GetAppDomainFullName(VMPTR_AppDomain vmAppDomain, IStringHolder * pStrName)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAppDomainFullName(VMPTR_AppDomain vmAppDomain, IStringHolder * pStrName)
 {
     DD_ENTER_MAY_THROW;
 
@@ -721,7 +735,7 @@ HRESULT DacDbiInterfaceImpl::GetAppDomainFullName(VMPTR_AppDomain vmAppDomain, I
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 // Get the values of the JIT Optimization and EnC flags.
-HRESULT DacDbiInterfaceImpl::GetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pfAllowJITOpts, OUT BOOL * pfEnableEnC)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pfAllowJITOpts, OUT BOOL * pfEnableEnC)
 {
     DD_ENTER_MAY_THROW;
 
@@ -780,7 +794,7 @@ bool DacDbiInterfaceImpl::CanSetEnCBits(Module * pModule)
 } // DacDbiInterfaceImpl::SetEnCBits
 
 // Set the values of the JIT optimization and EnC flags.
-HRESULT DacDbiInterfaceImpl::SetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly,
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::SetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly,
                                            BOOL             fAllowJitOpts,
                                            BOOL             fEnableEnC)
 {
@@ -836,7 +850,7 @@ HRESULT DacDbiInterfaceImpl::SetCompilerFlags(VMPTR_DomainAssembly vmDomainAssem
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 // Initialize the native/IL sequence points and native var info for a function.
-HRESULT DacDbiInterfaceImpl::GetNativeCodeSequencePointsAndVarInfo(VMPTR_MethodDesc vmMethodDesc, CORDB_ADDRESS startAddress, BOOL fCodeAvailable, OUT NativeVarData * pNativeVarData, OUT SequencePoints * pSequencePoints)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetNativeCodeSequencePointsAndVarInfo(VMPTR_MethodDesc vmMethodDesc, CORDB_ADDRESS startAddress, BOOL fCodeAvailable, OUT NativeVarData * pNativeVarData, OUT SequencePoints * pSequencePoints)
 {
     DD_ENTER_MAY_THROW;
 
@@ -1025,7 +1039,7 @@ void DacDbiInterfaceImpl::GetSequencePoints(MethodDesc *     pMethodDesc,
 // a module and a token. The info will come from a MethodDesc, if
 // one exists or from metadata.
 //
-HRESULT DacDbiInterfaceImpl::GetILCodeAndSig(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT TargetBuffer * pCodeInfo, OUT mdToken * pLocalSigToken)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetILCodeAndSig(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT TargetBuffer * pCodeInfo, OUT mdToken * pLocalSigToken)
 {
     DD_ENTER_MAY_THROW;
 
@@ -1172,8 +1186,11 @@ mdSignature DacDbiInterfaceImpl::GetILCodeAndSigHelper(Module *       pModule,
 }
 
 
-HRESULT DacDbiInterfaceImpl::GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly, DWORD & dwTimeStamp, DWORD & dwImageSize, IStringHolder* pStrFilename, OUT bool * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly, DWORD * pTimeStamp, DWORD * pImageSize, IStringHolder* pStrFilename, OUT BOOL * pResult)
 {
+    if (pTimeStamp == NULL || pImageSize == NULL || pStrFilename == NULL || pResult == NULL)
+        return E_POINTER;
+
     DD_ENTER_MAY_THROW;
 
     HRESULT hr = S_OK;
@@ -1186,15 +1203,16 @@ HRESULT DacDbiInterfaceImpl::GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPE
         _ASSERTE(pPEAssembly != NULL);
         if (pPEAssembly == NULL)
         {
-            *pResult = false;
+            *pResult = FALSE;
+            return E_FAIL;
         }
         else
         {
         WCHAR wszFilePath[MAX_LONGPATH] = {0};
         DWORD cchFilePath = MAX_LONGPATH;
         bool ret = ClrDataAccess::GetMetaDataFileInfoFromPEFile(pPEAssembly,
-                                                                dwTimeStamp,
-                                                                dwImageSize,
+                                                                *pTimeStamp,
+                                                                *pImageSize,
                                                                 dwDataSize,
                                                                 dwRvaHint,
                                                                 wszFilePath,
@@ -1263,7 +1281,7 @@ void DacDbiInterfaceImpl::GetMethodRegionInfo(MethodDesc *             pMethodDe
 // isn't currently available. In this case, all values in pCodeInfo will be
 // cleared.
 
-HRESULT DacDbiInterfaceImpl::GetNativeCodeInfo(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT NativeCodeFunctionData * pCodeInfo)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetNativeCodeInfo(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT NativeCodeFunctionData * pCodeInfo)
 {
     DD_ENTER_MAY_THROW;
 
@@ -1309,7 +1327,7 @@ HRESULT DacDbiInterfaceImpl::GetNativeCodeInfo(VMPTR_DomainAssembly vmDomainAsse
 //    - hot and cold region information
 //    - its module
 //    - its metadata token.
-HRESULT DacDbiInterfaceImpl::GetNativeCodeInfoForAddr(CORDB_ADDRESS codeAddress, NativeCodeFunctionData * pCodeInfo, VMPTR_Module * pVmModule, mdToken * pFunctionToken)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetNativeCodeInfoForAddr(CORDB_ADDRESS codeAddress, NativeCodeFunctionData * pCodeInfo, VMPTR_Module * pVmModule, mdToken * pFunctionToken)
 {
     DD_ENTER_MAY_THROW;
 
@@ -1675,7 +1693,7 @@ void DacDbiInterfaceImpl::CollectFields(TypeHandle                   thExact,
 
 
 // Determine if a type is a ValueType
-HRESULT DacDbiInterfaceImpl::IsValueType(VMPTR_TypeHandle th, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsValueType(VMPTR_TypeHandle th, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -1691,7 +1709,7 @@ HRESULT DacDbiInterfaceImpl::IsValueType(VMPTR_TypeHandle th, OUT BOOL * pResult
 }
 
 // Determine if a type has generic parameters
-HRESULT DacDbiInterfaceImpl::HasTypeParams(VMPTR_TypeHandle th, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::HasTypeParams(VMPTR_TypeHandle th, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -1707,7 +1725,7 @@ HRESULT DacDbiInterfaceImpl::HasTypeParams(VMPTR_TypeHandle th, OUT BOOL * pResu
 }
 
 // DacDbi API: Get type information for a class
-HRESULT DacDbiInterfaceImpl::GetClassInfo(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle thExact, ClassInfo * pData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetClassInfo(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle thExact, ClassInfo * pData)
 {
     DD_ENTER_MAY_THROW;
 
@@ -1733,7 +1751,7 @@ HRESULT DacDbiInterfaceImpl::GetClassInfo(VMPTR_AppDomain vmAppDomain, VMPTR_Typ
 }
 
 // DacDbi API: Get field information and object size for an instantiated generic type
-HRESULT DacDbiInterfaceImpl::GetInstantiationFieldInfo(VMPTR_DomainAssembly vmDomainAssembly, VMPTR_TypeHandle vmThExact, VMPTR_TypeHandle vmThApprox, OUT DacDbiArrayList<FieldData> * pFieldList, OUT SIZE_T * pObjectSize)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetInstantiationFieldInfo(VMPTR_DomainAssembly vmDomainAssembly, VMPTR_TypeHandle vmThExact, VMPTR_TypeHandle vmThApprox, OUT DacDbiArrayList<FieldData> * pFieldList, OUT SIZE_T * pObjectSize)
 {
     DD_ENTER_MAY_THROW;
 
@@ -2584,7 +2602,7 @@ void DacDbiInterfaceImpl::TypeHandleToBasicTypeInfo(TypeHandle                  
 } // DacDbiInterfaceImpl::TypeHandleToBasicTypeInfo
 
 
-HRESULT DacDbiInterfaceImpl::GetObjectExpandedTypeInfoFromID(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, COR_TYPEID id, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetObjectExpandedTypeInfoFromID(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, COR_TYPEID id, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo)
 {
     DD_ENTER_MAY_THROW;
 
@@ -2598,7 +2616,7 @@ HRESULT DacDbiInterfaceImpl::GetObjectExpandedTypeInfoFromID(AreValueTypesBoxed 
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::GetObjectExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, CORDB_ADDRESS addr, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetObjectExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, CORDB_ADDRESS addr, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo)
 {
     DD_ENTER_MAY_THROW;
 
@@ -2614,7 +2632,7 @@ HRESULT DacDbiInterfaceImpl::GetObjectExpandedTypeInfo(AreValueTypesBoxed boxed,
 }
 
 // DacDbi API: use a type handle to get the information needed to create the corresponding RS CordbType instance
-HRESULT DacDbiInterfaceImpl::TypeHandleToExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, DebuggerIPCE_ExpandedTypeData * pTypeInfo)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::TypeHandleToExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, DebuggerIPCE_ExpandedTypeData * pTypeInfo)
 {
     DD_ENTER_MAY_THROW;
 
@@ -2680,7 +2698,7 @@ void DacDbiInterfaceImpl::TypeHandleToExpandedTypeInfoImpl(AreValueTypesBoxed   
 } // DacDbiInterfaceImpl::TypeHandleToExpandedTypeInfo
 
 // Get type handle for a TypeDef token, if one exists. For generics this returns the open type.
-HRESULT DacDbiInterfaceImpl::GetTypeHandle(VMPTR_Module vmModule, mdTypeDef metadataToken, OUT VMPTR_TypeHandle * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetTypeHandle(VMPTR_Module vmModule, mdTypeDef metadataToken, OUT VMPTR_TypeHandle * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -2706,7 +2724,7 @@ HRESULT DacDbiInterfaceImpl::GetTypeHandle(VMPTR_Module vmModule, mdTypeDef meta
 
 // DacDbi API: GetAndSendApproxTypeHandle finds the type handle for the layout of the instance fields of an
 // instantiated type if it is available.
-HRESULT DacDbiInterfaceImpl::GetApproxTypeHandle(TypeInfoList * pTypeData, OUT VMPTR_TypeHandle * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetApproxTypeHandle(TypeInfoList * pTypeData, OUT VMPTR_TypeHandle * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -2741,10 +2759,13 @@ HRESULT DacDbiInterfaceImpl::GetApproxTypeHandle(TypeInfoList * pTypeData, OUT V
 }
 
 // DacDbiInterface API: Get the exact type handle from type data
-HRESULT DacDbiInterfaceImpl::GetExactTypeHandle(DebuggerIPCE_ExpandedTypeData * pTypeData,
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetExactTypeHandle(DebuggerIPCE_ExpandedTypeData * pTypeData,
                                                 ArgInfoList *   pArgInfo,
-                                                VMPTR_TypeHandle& vmTypeHandle)
+                                                VMPTR_TypeHandle * pVmTypeHandle)
 {
+    if (pVmTypeHandle == NULL)
+        return E_POINTER;
+
     DD_ENTER_MAY_THROW;
 
     LOG((LF_CORDB, LL_INFO10000, "D::GETH: getting info.\n"));
@@ -2753,12 +2774,12 @@ HRESULT DacDbiInterfaceImpl::GetExactTypeHandle(DebuggerIPCE_ExpandedTypeData * 
 
     EX_TRY
     {
-        vmTypeHandle = vmTypeHandle.NullPtr();
+        *pVmTypeHandle = VMPTR_TypeHandle::NullPtr();
 
         // convert the type information to a type handle
         TypeHandle typeHandle = ExpandedTypeInfoToTypeHandle(pTypeData, pArgInfo);
         _ASSERTE(!typeHandle.IsNull());
-        vmTypeHandle.SetDacTargetPtr(typeHandle.AsTAddr());
+        pVmTypeHandle->SetDacTargetPtr(typeHandle.AsTAddr());
     }
     EX_CATCH_HRESULT(hr);
 
@@ -2767,7 +2788,7 @@ HRESULT DacDbiInterfaceImpl::GetExactTypeHandle(DebuggerIPCE_ExpandedTypeData * 
 
 // Retrieve the generic type params for a given MethodDesc.  This function is specifically
 // for stackwalking because it requires the generic type token on the stack.
-HRESULT DacDbiInterfaceImpl::GetMethodDescParams(VMPTR_AppDomain vmAppDomain, VMPTR_MethodDesc vmMethodDesc, GENERICS_TYPE_TOKEN genericsToken, OUT UINT32 * pcGenericClassTypeParams, OUT TypeParamsList * pGenericTypeParams)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetMethodDescParams(VMPTR_AppDomain vmAppDomain, VMPTR_MethodDesc vmMethodDesc, GENERICS_TYPE_TOKEN genericsToken, OUT UINT32 * pcGenericClassTypeParams, OUT TypeParamsList * pGenericTypeParams)
 {
     DD_ENTER_MAY_THROW;
 
@@ -3179,7 +3200,7 @@ TypeHandle DacDbiInterfaceImpl::ExpandedTypeInfoToTypeHandle(DebuggerIPCE_Expand
 //
 // This can commonly fail, in which case, it will return NULL.
 // ----------------------------------------------------------------------------
-HRESULT DacDbiInterfaceImpl::GetThreadStaticAddress(VMPTR_FieldDesc vmField, VMPTR_Thread vmRuntimeThread, OUT CORDB_ADDRESS * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetThreadStaticAddress(VMPTR_FieldDesc vmField, VMPTR_Thread vmRuntimeThread, OUT CORDB_ADDRESS * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -3212,7 +3233,7 @@ HRESULT DacDbiInterfaceImpl::GetThreadStaticAddress(VMPTR_FieldDesc vmField, VMP
 }
 
     // Get the target field address of a collectible types static.
-HRESULT DacDbiInterfaceImpl::GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmField, VMPTR_AppDomain vmAppDomain, OUT CORDB_ADDRESS * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmField, VMPTR_AppDomain vmAppDomain, OUT CORDB_ADDRESS * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -3268,7 +3289,7 @@ HRESULT DacDbiInterfaceImpl::GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmF
 //   for "Dict<String,List<int>>", and sends it back to the right side.
 // - pParams is allocated and initialized by this function
 // - This should not fail except for OOM
-HRESULT DacDbiInterfaceImpl::GetTypeHandleParams(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, OUT TypeParamsList * pParams)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetTypeHandleParams(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, OUT TypeParamsList * pParams)
 {
     DD_ENTER_MAY_THROW
 
@@ -3307,7 +3328,7 @@ HRESULT DacDbiInterfaceImpl::GetTypeHandleParams(VMPTR_AppDomain vmAppDomain, VM
 // DacDbi API: GetSimpleType
 // gets the metadata token and domain file corresponding to a simple type
 //-----------------------------------------------------------------------------
-HRESULT DacDbiInterfaceImpl::GetSimpleType(VMPTR_AppDomain vmAppDomain, CorElementType simpleType, OUT mdTypeDef * pMetadataToken, OUT VMPTR_Module * pVmModule, OUT VMPTR_DomainAssembly * pVmDomainAssembly)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetSimpleType(VMPTR_AppDomain vmAppDomain, CorElementType simpleType, OUT mdTypeDef * pMetadataToken, OUT VMPTR_Module * pVmModule, OUT VMPTR_DomainAssembly * pVmDomainAssembly)
 {
     DD_ENTER_MAY_THROW;
 
@@ -3353,7 +3374,7 @@ HRESULT DacDbiInterfaceImpl::GetSimpleType(VMPTR_AppDomain vmAppDomain, CorEleme
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::IsExceptionObject(VMPTR_Object vmObject, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsExceptionObject(VMPTR_Object vmObject, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -3389,7 +3410,7 @@ BOOL DacDbiInterfaceImpl::IsExceptionObject(MethodTable* pMT)
     return FALSE;
 }
 
-HRESULT DacDbiInterfaceImpl::GetMethodDescPtrFromIpEx(TADDR funcIp, VMPTR_MethodDesc* ppMD)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetMethodDescPtrFromIpEx(TADDR funcIp, VMPTR_MethodDesc* ppMD)
 {
     DD_ENTER_MAY_THROW;
 
@@ -3412,7 +3433,7 @@ HRESULT DacDbiInterfaceImpl::GetMethodDescPtrFromIpEx(TADDR funcIp, VMPTR_Method
     return S_OK;
 }
 
-HRESULT DacDbiInterfaceImpl::IsDelegate(VMPTR_Object vmObject, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsDelegate(VMPTR_Object vmObject, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -3439,7 +3460,7 @@ HRESULT DacDbiInterfaceImpl::IsDelegate(VMPTR_Object vmObject, OUT BOOL * pResul
 // DacDbi API: GetDelegateType
 // Given a delegate pointer, compute the type of delegate according to the data held in it.
 //-----------------------------------------------------------------------------
-HRESULT DacDbiInterfaceImpl::GetDelegateType(VMPTR_Object delegateObject, DelegateType *delegateType)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetDelegateType(VMPTR_Object delegateObject, DelegateType *delegateType)
 {
     DD_ENTER_MAY_THROW;
 
@@ -3522,7 +3543,7 @@ HRESULT DacDbiInterfaceImpl::GetDelegateType(VMPTR_Object delegateObject, Delega
     return CORDBG_E_UNSUPPORTED_DELEGATE;
 }
 
-HRESULT DacDbiInterfaceImpl::GetDelegateFunctionData(
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetDelegateFunctionData(
     DelegateType delegateType,
     VMPTR_Object delegateObject,
     OUT VMPTR_DomainAssembly *ppFunctionDomainAssembly,
@@ -3564,7 +3585,7 @@ HRESULT DacDbiInterfaceImpl::GetDelegateFunctionData(
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::GetDelegateTargetObject(
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetDelegateTargetObject(
     DelegateType delegateType,
     VMPTR_Object delegateObject,
     OUT VMPTR_Object *ppTargetObj,
@@ -3697,7 +3718,7 @@ void DacDbiInterfaceImpl::EnumerateMemRangesForJitCodeHeaps(CQuickArrayList<COR_
     }
 }
 
-HRESULT DacDbiInterfaceImpl::GetLoaderHeapMemoryRanges(DacDbiArrayList<COR_MEMORY_RANGE> *pRanges)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetLoaderHeapMemoryRanges(DacDbiArrayList<COR_MEMORY_RANGE> *pRanges)
 {
     LOG((LF_CORDB, LL_INFO10000, "DDBII::GLHMR\n"));
     DD_ENTER_MAY_THROW;
@@ -3732,8 +3753,11 @@ HRESULT DacDbiInterfaceImpl::GetLoaderHeapMemoryRanges(DacDbiArrayList<COR_MEMOR
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::GetStackFramesFromException(VMPTR_Object vmObject, DacDbiArrayList<DacExceptionCallStackData>& dacStackFrames)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetStackFramesFromException(VMPTR_Object vmObject, DacDbiArrayList<DacExceptionCallStackData>* pDacStackFrames)
 {
+    if (pDacStackFrames == NULL)
+        return E_POINTER;
+
     DD_ENTER_MAY_THROW;
 
     HRESULT hr = S_OK;
@@ -3761,12 +3785,12 @@ HRESULT DacDbiInterfaceImpl::GetStackFramesFromException(VMPTR_Object vmObject, 
 
         if (dacStackFramesLength > 0)
         {
-            dacStackFrames.Alloc(dacStackFramesLength);
+            pDacStackFrames->Alloc(dacStackFramesLength);
 
             for (INT32 index = 0; index < dacStackFramesLength; ++index)
             {
                 DebugStackTrace::Element const& currentElement = stackFramesData.pElements[index];
-                DacExceptionCallStackData& currentFrame = dacStackFrames[index];
+                DacExceptionCallStackData& currentFrame = (*pDacStackFrames)[index];
 
                 AppDomain* pDomain = AppDomain::GetCurrentDomain();
                 _ASSERTE(pDomain != NULL);
@@ -3812,7 +3836,7 @@ PTR_RCW GetRcwFromVmptrObject(VMPTR_Object vmObject)
 
 #endif
 
-HRESULT DacDbiInterfaceImpl::IsRcw(VMPTR_Object vmObject, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsRcw(VMPTR_Object vmObject, OUT BOOL * pResult)
 {
 #ifdef FEATURE_COMINTEROP
     DD_ENTER_MAY_THROW;
@@ -3830,7 +3854,7 @@ HRESULT DacDbiInterfaceImpl::IsRcw(VMPTR_Object vmObject, OUT BOOL * pResult)
 #endif // FEATURE_COMINTEROP
 }
 
-HRESULT DacDbiInterfaceImpl::GetRcwCachedInterfaceTypes(VMPTR_Object vmObject, VMPTR_AppDomain vmAppDomain, BOOL bIInspectableOnly, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pDacInterfaces)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetRcwCachedInterfaceTypes(VMPTR_Object vmObject, VMPTR_AppDomain vmAppDomain, BOOL bIInspectableOnly, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pDacInterfaces)
 {
     HRESULT hr = S_OK;
     EX_TRY
@@ -3842,7 +3866,7 @@ HRESULT DacDbiInterfaceImpl::GetRcwCachedInterfaceTypes(VMPTR_Object vmObject, V
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::GetRcwCachedInterfacePointers(VMPTR_Object vmObject, BOOL bIInspectableOnly, OUT DacDbiArrayList<CORDB_ADDRESS> * pDacItfPtrs)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetRcwCachedInterfacePointers(VMPTR_Object vmObject, BOOL bIInspectableOnly, OUT DacDbiArrayList<CORDB_ADDRESS> * pDacItfPtrs)
 {
 #ifdef FEATURE_COMINTEROP
 
@@ -3882,8 +3906,11 @@ HRESULT DacDbiInterfaceImpl::GetRcwCachedInterfacePointers(VMPTR_Object vmObject
 #endif // FEATURE_COMINTEROP
 }
 
-HRESULT DacDbiInterfaceImpl::GetCachedWinRTTypesForIIDs(VMPTR_AppDomain vmAppDomain, DacDbiArrayList<GUID> & iids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetCachedWinRTTypesForIIDs(VMPTR_AppDomain vmAppDomain, DacDbiArrayList<GUID> * pIids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes)
 {
+    if (pIids == NULL || pTypes == NULL)
+        return E_POINTER;
+
     HRESULT hr = S_OK;
     EX_TRY
     {
@@ -3893,7 +3920,7 @@ HRESULT DacDbiInterfaceImpl::GetCachedWinRTTypesForIIDs(VMPTR_AppDomain vmAppDom
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::GetCachedWinRTTypes(VMPTR_AppDomain vmAppDomain, OUT DacDbiArrayList<GUID> * piids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetCachedWinRTTypes(VMPTR_AppDomain vmAppDomain, OUT DacDbiArrayList<GUID> * piids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes)
 {
     HRESULT hr = S_OK;
     EX_TRY
@@ -4073,7 +4100,7 @@ void DacDbiInterfaceImpl::InitFieldData(const FieldDesc *           pFD,
 // GENERICS: TODO: this method will need to be modified if we ever support EnC on
 // generic classes.
 //-----------------------------------------------------------------------------
-HRESULT DacDbiInterfaceImpl::GetEnCHangingFieldInfo(const EnCHangingFieldInfo * pEnCFieldInfo, OUT FieldData * pFieldData, OUT BOOL * pfStatic)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetEnCHangingFieldInfo(const EnCHangingFieldInfo * pEnCFieldInfo, OUT FieldData * pFieldData, OUT BOOL * pfStatic)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4109,7 +4136,7 @@ HRESULT DacDbiInterfaceImpl::GetEnCHangingFieldInfo(const EnCHangingFieldInfo * 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
-HRESULT DacDbiInterfaceImpl::GetAssemblyFromDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Assembly * vmAssembly)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAssemblyFromDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Assembly * vmAssembly)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4127,7 +4154,7 @@ HRESULT DacDbiInterfaceImpl::GetAssemblyFromDomainAssembly(VMPTR_DomainAssembly 
 }
 
 // Determines whether the runtime security system has assigned full-trust to this assembly.
-HRESULT DacDbiInterfaceImpl::IsAssemblyFullyTrusted(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsAssemblyFullyTrusted(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4142,7 +4169,7 @@ HRESULT DacDbiInterfaceImpl::IsAssemblyFullyTrusted(VMPTR_DomainAssembly vmDomai
 }
 
 // Get the full path and file name to the assembly's manifest module.
-HRESULT DacDbiInterfaceImpl::GetAssemblyPath(VMPTR_Assembly vmAssembly, IStringHolder * pStrFilename, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAssemblyPath(VMPTR_Assembly vmAssembly, IStringHolder * pStrFilename, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4177,7 +4204,7 @@ HRESULT DacDbiInterfaceImpl::GetAssemblyPath(VMPTR_Assembly vmAssembly, IStringH
 // DAC/DBI API
 // Get a resolved type def from a type ref. The type ref may come from a module other than the
 // referencing module.
-HRESULT DacDbiInterfaceImpl::ResolveTypeReference(const TypeRefData * pTypeRefInfo, TypeRefData * pTargetRefInfo)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::ResolveTypeReference(const TypeRefData * pTypeRefInfo, TypeRefData * pTargetRefInfo)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4226,7 +4253,7 @@ HRESULT DacDbiInterfaceImpl::ResolveTypeReference(const TypeRefData * pTypeRefIn
 
 
 // Get the full path and file name to the module (if any).
-HRESULT DacDbiInterfaceImpl::GetModulePath(VMPTR_Module vmModule, IStringHolder * pStrFilename, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetModulePath(VMPTR_Module vmModule, IStringHolder * pStrFilename, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4275,7 +4302,7 @@ HRESULT DacDbiInterfaceImpl::GetModulePath(VMPTR_Module vmModule, IStringHolder 
 }
 
 // Implementation of IDacDbiInterface::GetModuleSimpleName
-HRESULT DacDbiInterfaceImpl::GetModuleSimpleName(VMPTR_Module vmModule, IStringHolder * pStrFilename)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetModuleSimpleName(VMPTR_Module vmModule, IStringHolder * pStrFilename)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4295,7 +4322,7 @@ HRESULT DacDbiInterfaceImpl::GetModuleSimpleName(VMPTR_Module vmModule, IStringH
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::IsModuleMapped(VMPTR_Module pModule, OUT BOOL *isModuleMapped)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsModuleMapped(VMPTR_Module pModule, OUT BOOL *isModuleMapped)
 {
     LOG((LF_CORDB, LL_INFO10000, "DDBII::IMM - TADDR 0x%x\n", pModule));
     DD_ENTER_MAY_THROW;
@@ -4319,7 +4346,7 @@ HRESULT DacDbiInterfaceImpl::IsModuleMapped(VMPTR_Module pModule, OUT BOOL *isMo
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::MetadataUpdatesApplied(OUT bool * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::MetadataUpdatesApplied(OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4329,7 +4356,7 @@ HRESULT DacDbiInterfaceImpl::MetadataUpdatesApplied(OUT bool * pResult)
     #ifdef FEATURE_METADATA_UPDATER
         *pResult = g_metadataUpdatesApplied;
     #else
-        *pResult = false;
+        *pResult = FALSE;
     #endif
     }
     EX_CATCH_HRESULT(hr);
@@ -4390,7 +4417,7 @@ void InitTargetBufferFromTargetSBuffer(PTR_SBuffer pBuffer, TargetBuffer * pTarg
 
 
 // Implementation of IDacDbiInterface::GetMetadata
-HRESULT DacDbiInterfaceImpl::GetMetadata(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetMetadata(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4438,7 +4465,7 @@ HRESULT DacDbiInterfaceImpl::GetMetadata(VMPTR_Module vmModule, OUT TargetBuffer
 }
 
 // Implementation of IDacDbiInterface::GetSymbolsBuffer
-HRESULT DacDbiInterfaceImpl::GetSymbolsBuffer(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer, OUT SymbolFormat * pSymbolFormat)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetSymbolsBuffer(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer, OUT SymbolFormat * pSymbolFormat)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4478,7 +4505,7 @@ HRESULT DacDbiInterfaceImpl::GetSymbolsBuffer(VMPTR_Module vmModule, OUT TargetB
 
 
 
-HRESULT DacDbiInterfaceImpl::GetModuleForDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Module * pModule)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetModuleForDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Module * pModule)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4497,7 +4524,7 @@ HRESULT DacDbiInterfaceImpl::GetModuleForDomainAssembly(VMPTR_DomainAssembly vmD
 
 
 // Implement IDacDbiInterface::GetDomainAssemblyData
-HRESULT DacDbiInterfaceImpl::GetDomainAssemblyData(VMPTR_DomainAssembly vmDomainAssembly, OUT DomainAssemblyInfo * pData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetDomainAssemblyData(VMPTR_DomainAssembly vmDomainAssembly, OUT DomainAssemblyInfo * pData)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4520,7 +4547,7 @@ HRESULT DacDbiInterfaceImpl::GetDomainAssemblyData(VMPTR_DomainAssembly vmDomain
 }
 
 // Implement IDacDbiInterface::GetModuleData
-HRESULT DacDbiInterfaceImpl::GetModuleData(VMPTR_Module vmModule, OUT ModuleInfo * pData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetModuleData(VMPTR_Module vmModule, OUT ModuleInfo * pData)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4567,7 +4594,7 @@ HRESULT DacDbiInterfaceImpl::GetModuleData(VMPTR_Module vmModule, OUT ModuleInfo
 
 
 // Enumerate all AppDomains in the process.
-HRESULT DacDbiInterfaceImpl::EnumerateAppDomains(FP_APPDOMAIN_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::EnumerateAppDomains(FP_APPDOMAIN_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4590,7 +4617,7 @@ HRESULT DacDbiInterfaceImpl::EnumerateAppDomains(FP_APPDOMAIN_ENUMERATION_CALLBA
 }
 
 // Enumerate all Assemblies in an appdomain.
-HRESULT DacDbiInterfaceImpl::EnumerateAssembliesInAppDomain(VMPTR_AppDomain vmAppDomain, FP_ASSEMBLY_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::EnumerateAssembliesInAppDomain(VMPTR_AppDomain vmAppDomain, FP_ASSEMBLY_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4631,7 +4658,7 @@ HRESULT DacDbiInterfaceImpl::EnumerateAssembliesInAppDomain(VMPTR_AppDomain vmAp
 
 // Implementation of IDacDbiInterface::EnumerateModulesInAssembly,
 // Enumerate all the modules (non-resource) in an assembly.
-HRESULT DacDbiInterfaceImpl::EnumerateModulesInAssembly(VMPTR_DomainAssembly vmAssembly, FP_MODULE_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::EnumerateModulesInAssembly(VMPTR_DomainAssembly vmAssembly, FP_MODULE_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4662,7 +4689,7 @@ HRESULT DacDbiInterfaceImpl::EnumerateModulesInAssembly(VMPTR_DomainAssembly vmA
 
 // Implementation of IDacDbiInterface::ResolveAssembly
 // Returns NULL if not found.
-HRESULT DacDbiInterfaceImpl::ResolveAssembly(VMPTR_DomainAssembly vmScope, mdToken tkAssemblyRef, OUT VMPTR_DomainAssembly * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::ResolveAssembly(VMPTR_DomainAssembly vmScope, mdToken tkAssemblyRef, OUT VMPTR_DomainAssembly * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4690,7 +4717,7 @@ HRESULT DacDbiInterfaceImpl::ResolveAssembly(VMPTR_DomainAssembly vmScope, mdTok
 
 // When stopped at an event, request a synchronization.
 // See DacDbiInterface.h for full comments
-HRESULT DacDbiInterfaceImpl::RequestSyncAtEvent()
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::RequestSyncAtEvent()
 {
     DD_ENTER_MAY_THROW;
 
@@ -4712,7 +4739,7 @@ HRESULT DacDbiInterfaceImpl::RequestSyncAtEvent()
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::SetSendExceptionsOutsideOfJMC(BOOL sendExceptionsOutsideOfJMC)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::SetSendExceptionsOutsideOfJMC(BOOL sendExceptionsOutsideOfJMC)
 {
     DD_ENTER_MAY_THROW
 
@@ -4731,7 +4758,7 @@ HRESULT DacDbiInterfaceImpl::SetSendExceptionsOutsideOfJMC(BOOL sendExceptionsOu
 
 // Notify the debuggee that a debugger attach is pending.
 // See DacDbiInterface.h for full comments
-HRESULT DacDbiInterfaceImpl::MarkDebuggerAttachPending()
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::MarkDebuggerAttachPending()
 {
     DD_ENTER_MAY_THROW;
 
@@ -4763,7 +4790,7 @@ HRESULT DacDbiInterfaceImpl::MarkDebuggerAttachPending()
 
 // Notify the debuggee that a debugger is attached.
 // See DacDbiInterface.h for full comments
-HRESULT DacDbiInterfaceImpl::MarkDebuggerAttached(BOOL fAttached)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::MarkDebuggerAttached(BOOL fAttached)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4807,7 +4834,7 @@ HRESULT DacDbiInterfaceImpl::MarkDebuggerAttached(BOOL fAttached)
 
 
 // Enumerate all threads in the process.
-HRESULT DacDbiInterfaceImpl::EnumerateThreads(FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::EnumerateThreads(FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4843,7 +4870,7 @@ HRESULT DacDbiInterfaceImpl::EnumerateThreads(FP_THREAD_ENUMERATION_CALLBACK fpC
 }
 
 // public implementation of IsThreadMarkedDead
-HRESULT DacDbiInterfaceImpl::IsThreadMarkedDead(VMPTR_Thread vmThread, OUT bool * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsThreadMarkedDead(VMPTR_Thread vmThread, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4881,7 +4908,7 @@ bool DacDbiInterfaceImpl::IsThreadMarkedDeadWorker(Thread * pThread)
 
 
 // Return the handle of the specified thread.
-HRESULT DacDbiInterfaceImpl::GetThreadHandle(VMPTR_Thread vmThread, OUT HANDLE * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetThreadHandle(VMPTR_Thread vmThread, OUT HANDLE * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4897,7 +4924,7 @@ HRESULT DacDbiInterfaceImpl::GetThreadHandle(VMPTR_Thread vmThread, OUT HANDLE *
 }
 
 // Return the object handle for the managed Thread object corresponding to the specified thread.
-HRESULT DacDbiInterfaceImpl::GetThreadObject(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetThreadObject(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4926,7 +4953,7 @@ HRESULT DacDbiInterfaceImpl::GetThreadObject(VMPTR_Thread vmThread, OUT VMPTR_OB
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::GetThreadAllocInfo(VMPTR_Thread vmThread, DacThreadAllocInfo* threadAllocInfo)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetThreadAllocInfo(VMPTR_Thread vmThread, DacThreadAllocInfo* threadAllocInfo)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4953,7 +4980,7 @@ HRESULT DacDbiInterfaceImpl::GetThreadAllocInfo(VMPTR_Thread vmThread, DacThread
 
 // Set and reset the TSNC_DebuggerUserSuspend bit on the state of the specified thread
 // according to the CorDebugThreadState.
-HRESULT DacDbiInterfaceImpl::SetDebugState(VMPTR_Thread vmThread, CorDebugThreadState debugState)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::SetDebugState(VMPTR_Thread vmThread, CorDebugThreadState debugState)
 {
     DD_ENTER_MAY_THROW;
 
@@ -4986,7 +5013,7 @@ HRESULT DacDbiInterfaceImpl::SetDebugState(VMPTR_Thread vmThread, CorDebugThread
 }
 
 // Gets the debugger unhandled exception threadstate flag
-HRESULT DacDbiInterfaceImpl::HasUnhandledException(VMPTR_Thread vmThread, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::HasUnhandledException(VMPTR_Thread vmThread, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5030,7 +5057,7 @@ HRESULT DacDbiInterfaceImpl::HasUnhandledException(VMPTR_Thread vmThread, OUT BO
 }
 
 // Return the user state of the specified thread.
-HRESULT DacDbiInterfaceImpl::GetUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5056,7 +5083,7 @@ HRESULT DacDbiInterfaceImpl::GetUserState(VMPTR_Thread vmThread, OUT CorDebugUse
 
 
 // Return the connection ID of the specified thread.
-HRESULT DacDbiInterfaceImpl::GetConnectionID(VMPTR_Thread vmThread, OUT CONNID * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetConnectionID(VMPTR_Thread vmThread, OUT CONNID * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5071,7 +5098,7 @@ HRESULT DacDbiInterfaceImpl::GetConnectionID(VMPTR_Thread vmThread, OUT CONNID *
 }
 
 // Return the task ID of the specified thread.
-HRESULT DacDbiInterfaceImpl::GetTaskID(VMPTR_Thread vmThread, OUT TASKID * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetTaskID(VMPTR_Thread vmThread, OUT TASKID * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5086,7 +5113,7 @@ HRESULT DacDbiInterfaceImpl::GetTaskID(VMPTR_Thread vmThread, OUT TASKID * pRetV
 }
 
 // Return the OS thread ID of the specified thread
-HRESULT DacDbiInterfaceImpl::TryGetVolatileOSThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::TryGetVolatileOSThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5117,7 +5144,7 @@ HRESULT DacDbiInterfaceImpl::TryGetVolatileOSThreadID(VMPTR_Thread vmThread, OUT
 }
 
 // Return the unique thread ID of the specified thread.
-HRESULT DacDbiInterfaceImpl::GetUniqueThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetUniqueThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5136,7 +5163,7 @@ HRESULT DacDbiInterfaceImpl::GetUniqueThreadID(VMPTR_Thread vmThread, OUT DWORD 
 
 // Return the object handle to the managed Exception object of the current exception
 // on the specified thread.  The return value could be NULL if there is no current exception.
-HRESULT DacDbiInterfaceImpl::GetCurrentException(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetCurrentException(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5166,7 +5193,7 @@ HRESULT DacDbiInterfaceImpl::GetCurrentException(VMPTR_Thread vmThread, OUT VMPT
 }
 
 // Return the object handle to the managed object for a given CCW pointer.
-HRESULT DacDbiInterfaceImpl::GetObjectForCCW(CORDB_ADDRESS ccwPtr, OUT VMPTR_OBJECTHANDLE * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetObjectForCCW(CORDB_ADDRESS ccwPtr, OUT VMPTR_OBJECTHANDLE * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5207,7 +5234,7 @@ HRESULT DacDbiInterfaceImpl::GetObjectForCCW(CORDB_ADDRESS ccwPtr, OUT VMPTR_OBJ
 // if and only if we are currently inside a CustomNotification Callback (or a dump was generated while in this
 // callback)
 //
-HRESULT DacDbiInterfaceImpl::GetCurrentCustomDebuggerNotification(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetCurrentCustomDebuggerNotification(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5229,7 +5256,7 @@ HRESULT DacDbiInterfaceImpl::GetCurrentCustomDebuggerNotification(VMPTR_Thread v
 }
 
 // Return the current appdomain.
-HRESULT DacDbiInterfaceImpl::GetCurrentAppDomain(OUT VMPTR_AppDomain * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetCurrentAppDomain(OUT VMPTR_AppDomain * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5249,7 +5276,7 @@ HRESULT DacDbiInterfaceImpl::GetCurrentAppDomain(OUT VMPTR_AppDomain * pRetVal)
 
 // Returns a bitfield reflecting the managed debugging state at the time of
 // the jit attach.
-HRESULT DacDbiInterfaceImpl::GetAttachStateFlags(OUT CLR_DEBUGGING_PROCESS_FLAGS * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAttachStateFlags(OUT CLR_DEBUGGING_PROCESS_FLAGS * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5438,7 +5465,7 @@ void DacDbiInterfaceImpl::WriteExceptionRecordHelper(CORDB_ADDRESS pRemotePtr,
 }
 
 // Implement IDacDbiInterface::Hijack
-HRESULT DacDbiInterfaceImpl::Hijack(VMPTR_Thread vmThread, ULONG32 dwThreadId, const EXCEPTION_RECORD * pRecord, T_CONTEXT * pOriginalContext, ULONG32 cbSizeContext, EHijackReason::EHijackReason reason, void * pUserData, CORDB_ADDRESS * pRemoteContextAddr)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::Hijack(VMPTR_Thread vmThread, ULONG32 dwThreadId, const EXCEPTION_RECORD * pRecord, T_CONTEXT * pOriginalContext, ULONG32 cbSizeContext, EHijackReason::EHijackReason reason, void * pUserData, CORDB_ADDRESS * pRemoteContextAddr)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5658,7 +5685,7 @@ HRESULT DacDbiInterfaceImpl::Hijack(VMPTR_Thread vmThread, ULONG32 dwThreadId, c
 }
 
 // Return the filter CONTEXT on the LS.
-HRESULT DacDbiInterfaceImpl::GetManagedStoppedContext(VMPTR_Thread vmThread, OUT VMPTR_CONTEXT * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetManagedStoppedContext(VMPTR_Thread vmThread, OUT VMPTR_CONTEXT * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5701,7 +5728,7 @@ HRESULT DacDbiInterfaceImpl::GetManagedStoppedContext(VMPTR_Thread vmThread, OUT
 }
 
 // Return a TargetBuffer for the raw vararg signature.
-HRESULT DacDbiInterfaceImpl::GetVarArgSig(CORDB_ADDRESS VASigCookieAddr, OUT CORDB_ADDRESS * pArgBase, OUT TargetBuffer * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetVarArgSig(CORDB_ADDRESS VASigCookieAddr, OUT CORDB_ADDRESS * pArgBase, OUT TargetBuffer * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5734,7 +5761,7 @@ HRESULT DacDbiInterfaceImpl::GetVarArgSig(CORDB_ADDRESS VASigCookieAddr, OUT COR
 }
 
 // returns TRUE if the type requires 8-byte alignment
-HRESULT DacDbiInterfaceImpl::RequiresAlign8(VMPTR_TypeHandle thExact, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::RequiresAlign8(VMPTR_TypeHandle thExact, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5757,7 +5784,7 @@ HRESULT DacDbiInterfaceImpl::RequiresAlign8(VMPTR_TypeHandle thExact, OUT BOOL *
 
 // Resolve the raw generics token to the real generics type token.  The resolution is based on the
 // given index.
-HRESULT DacDbiInterfaceImpl::ResolveExactGenericArgsToken(DWORD dwExactGenericArgsTokenIndex, GENERICS_TYPE_TOKEN rawToken, OUT GENERICS_TYPE_TOKEN * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::ResolveExactGenericArgsToken(DWORD dwExactGenericArgsTokenIndex, GENERICS_TYPE_TOKEN rawToken, OUT GENERICS_TYPE_TOKEN * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5814,7 +5841,7 @@ HRESULT DacDbiInterfaceImpl::ResolveExactGenericArgsToken(DWORD dwExactGenericAr
 }
 
 // Check if the given method is a DiagnosticHidden or an LCG method.
-HRESULT DacDbiInterfaceImpl::IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc, OUT DynamicMethodType * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc, OUT DynamicMethodType * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -5898,7 +5925,7 @@ BOOL DacDbiInterfaceImpl::IsThreadAtGCSafePlace(VMPTR_Thread vmThread)
 //    Return the partial user state except for USER_UNSAFE_POINT
 //
 
-HRESULT DacDbiInterfaceImpl::GetPartialUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetPartialUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6034,7 +6061,7 @@ void DacDbiInterfaceImpl::LookupEnCVersions(Module*          pModule,
 // Arguments: none
 // Return Value: The remote address of the Debugger control block allocated on the helper thread
 //               if it has been successfully allocated or NULL otherwise.
-HRESULT DacDbiInterfaceImpl::GetDebuggerControlBlockAddress(OUT CORDB_ADDRESS * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetDebuggerControlBlockAddress(OUT CORDB_ADDRESS * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6057,7 +6084,7 @@ HRESULT DacDbiInterfaceImpl::GetDebuggerControlBlockAddress(OUT CORDB_ADDRESS * 
 }
 
 // DacDbi API: Get the context for a particular thread of the target process
-HRESULT DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContextBuffer)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContextBuffer)
 {
     DD_ENTER_MAY_THROW
 
@@ -6143,7 +6170,7 @@ HRESULT DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pCon
 // Create a VMPTR_Object from a target object address
 // @dbgtodo validate the VMPTR_Object is in fact a object, possibly by DACizing
 //          Object::Validate
-HRESULT DacDbiInterfaceImpl::GetObject(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetObject(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6159,19 +6186,19 @@ HRESULT DacDbiInterfaceImpl::GetObject(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRe
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::EnableNGENPolicy(CorDebugNGENPolicy ePolicy)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::EnableNGENPolicy(CorDebugNGENPolicy ePolicy)
 {
     return E_NOTIMPL;
 }
 
-HRESULT DacDbiInterfaceImpl::SetNGENCompilerFlags(DWORD dwFlags)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::SetNGENCompilerFlags(DWORD dwFlags)
 {
     DD_ENTER_MAY_THROW;
 
     return CORDBG_E_NGEN_NOT_SUPPORTED;
 }
 
-HRESULT DacDbiInterfaceImpl::GetNGENCompilerFlags(DWORD *pdwFlags)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetNGENCompilerFlags(DWORD *pdwFlags)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6183,7 +6210,7 @@ typedef DPTR(OBJECTREF) PTR_ObjectRef;
 // Create a VMPTR_Object from an address which points to a reference to an object
 // @dbgtodo validate the VMPTR_Object is in fact a object, possibly by DACizing
 //          Object::Validate
-HRESULT DacDbiInterfaceImpl::GetObjectFromRefPtr(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetObjectFromRefPtr(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6202,7 +6229,7 @@ HRESULT DacDbiInterfaceImpl::GetObjectFromRefPtr(CORDB_ADDRESS ptr, OUT VMPTR_Ob
 }
 
 // Create a VMPTR_OBJECTHANDLE from a handle
-HRESULT DacDbiInterfaceImpl::GetVmObjectHandle(CORDB_ADDRESS handleAddress, OUT VMPTR_OBJECTHANDLE * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetVmObjectHandle(CORDB_ADDRESS handleAddress, OUT VMPTR_OBJECTHANDLE * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6221,7 +6248,7 @@ HRESULT DacDbiInterfaceImpl::GetVmObjectHandle(CORDB_ADDRESS handleAddress, OUT 
 
 
 // Validate that the VMPTR_OBJECTHANDLE refers to a legitimate managed object
-HRESULT DacDbiInterfaceImpl::IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6257,18 +6284,21 @@ HRESULT DacDbiInterfaceImpl::IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle, 
 }
 
 // determines if the specified module is a WinRT module
-HRESULT DacDbiInterfaceImpl::IsWinRTModule(VMPTR_Module vmModule, BOOL& isWinRT)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsWinRTModule(VMPTR_Module vmModule, BOOL * pIsWinRT)
 {
+    if (pIsWinRT == NULL)
+        return E_POINTER;
+
     DD_ENTER_MAY_THROW;
 
     HRESULT hr = S_OK;
-    isWinRT = FALSE;
+    *pIsWinRT = FALSE;
 
     return hr;
 }
 
 // Determines the app domain id for the object referred to by a given VMPTR_OBJECTHANDLE
-HRESULT DacDbiInterfaceImpl::GetAppDomainIdFromVmObjectHandle(VMPTR_OBJECTHANDLE vmHandle, OUT ULONG * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAppDomainIdFromVmObjectHandle(VMPTR_OBJECTHANDLE vmHandle, OUT ULONG * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6283,7 +6313,7 @@ HRESULT DacDbiInterfaceImpl::GetAppDomainIdFromVmObjectHandle(VMPTR_OBJECTHANDLE
 }
 
 // Get the target address from a VMPTR_OBJECTHANDLE, i.e., the handle address
-HRESULT DacDbiInterfaceImpl::GetHandleAddressFromVmHandle(VMPTR_OBJECTHANDLE vmHandle, OUT CORDB_ADDRESS * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetHandleAddressFromVmHandle(VMPTR_OBJECTHANDLE vmHandle, OUT CORDB_ADDRESS * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6300,7 +6330,7 @@ HRESULT DacDbiInterfaceImpl::GetHandleAddressFromVmHandle(VMPTR_OBJECTHANDLE vmH
 }
 
 // Create a TargetBuffer which describes the location of the object
-HRESULT DacDbiInterfaceImpl::GetObjectContents(VMPTR_Object obj, OUT TargetBuffer * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetObjectContents(VMPTR_Object obj, OUT TargetBuffer * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6330,7 +6360,7 @@ HRESULT DacDbiInterfaceImpl::GetObjectContents(VMPTR_Object obj, OUT TargetBuffe
 // Arguments:
 //     input: objPtr - address of the object we are checking
 // Return Value: E_INVALIDARG or S_OK.
-HRESULT DacDbiInterfaceImpl::FastSanityCheckObject(PTR_Object objPtr)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::FastSanityCheckObject(PTR_Object objPtr)
 {
     CONTRACTL
     {
@@ -6479,7 +6509,7 @@ void DacDbiInterfaceImpl::InitObjectData(PTR_Object                objPtr,
 // }
 
 // Initializes the objRef and typedByRefType fields of pObjectData (type info for the referent).
-HRESULT DacDbiInterfaceImpl::GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData)
 {
      DD_ENTER_MAY_THROW;
 
@@ -6517,7 +6547,7 @@ HRESULT DacDbiInterfaceImpl::GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, VMPTR_
 // Get the string data associated withn obj and put it into the pointers
 // DAC/DBI API
 // Get the string length and offset to string base for a string object
-HRESULT DacDbiInterfaceImpl::GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6548,7 +6578,7 @@ HRESULT DacDbiInterfaceImpl::GetStringData(CORDB_ADDRESS objectAddress, Debugger
 // DAC/DBI API
 // Get information for an array type referent of an objRef, including rank, upper and lower
 // bounds, element size and type, and the number of elements.
-HRESULT DacDbiInterfaceImpl::GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6608,7 +6638,7 @@ HRESULT DacDbiInterfaceImpl::GetArrayData(CORDB_ADDRESS objectAddress, DebuggerI
 
 // DAC/DBI API: Get information about an object for which we have a reference, including the object size and
 // type information.
-HRESULT DacDbiInterfaceImpl::GetBasicObjectInfo(CORDB_ADDRESS objectAddress, CorElementType type, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetBasicObjectInfo(CORDB_ADDRESS objectAddress, CorElementType type, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6631,7 +6661,7 @@ HRESULT DacDbiInterfaceImpl::GetBasicObjectInfo(CORDB_ADDRESS objectAddress, Cor
 
 // DAC/DBI API:
 // Returns the thread which owns the monitor lock on an object and the acquisition count
-HRESULT DacDbiInterfaceImpl::GetThreadOwningMonitorLock(VMPTR_Object vmObject, OUT MonitorLockInfo * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetThreadOwningMonitorLock(VMPTR_Object vmObject, OUT MonitorLockInfo * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6678,7 +6708,7 @@ HRESULT DacDbiInterfaceImpl::GetThreadOwningMonitorLock(VMPTR_Object vmObject, O
 
 // DAC/DBI API:
 // Enumerate all threads waiting on the monitor event for an object
-HRESULT DacDbiInterfaceImpl::EnumerateMonitorEventWaitList(VMPTR_Object vmObject, FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::EnumerateMonitorEventWaitList(VMPTR_Object vmObject, FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
 {
     DD_ENTER_MAY_THROW;
 
@@ -6743,12 +6773,12 @@ HRESULT DacDbiInterfaceImpl::EnumerateMonitorEventWaitList(VMPTR_Object vmObject
 }
 
 
-HRESULT DacDbiInterfaceImpl::AreGCStructuresValid(OUT bool * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::AreGCStructuresValid(OUT BOOL * pResult)
 {
     HRESULT hr = S_OK;
     EX_TRY
     {
-        *pResult = true;
+        *pResult = TRUE;
     }
     EX_CATCH_HRESULT(hr);
     return hr;
@@ -7290,7 +7320,7 @@ HRESULT DacHeapWalker::InitHeapDataWks(HeapData *&pHeaps, size_t &pCount)
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::DeleteHeapWalk(HeapWalkHandle handle)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::DeleteHeapWalk(HeapWalkHandle handle)
 {
     DD_ENTER_MAY_THROW;
 
@@ -7306,7 +7336,7 @@ HRESULT DacDbiInterfaceImpl::DeleteHeapWalk(HeapWalkHandle handle)
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::WalkHeap(HeapWalkHandle handle,
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::WalkHeap(HeapWalkHandle handle,
                     ULONG count,
                     OUT COR_HEAPOBJECT * objects,
                     OUT ULONG *fetched)
@@ -7354,7 +7384,7 @@ HRESULT DacDbiInterfaceImpl::WalkHeap(HeapWalkHandle handle,
 
 
 
-HRESULT DacDbiInterfaceImpl::GetHeapSegments(OUT DacDbiArrayList<COR_SEGMENT> *pSegments)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetHeapSegments(OUT DacDbiArrayList<COR_SEGMENT> *pSegments)
 {
     DD_ENTER_MAY_THROW;
 
@@ -7467,7 +7497,7 @@ HRESULT DacDbiInterfaceImpl::GetHeapSegments(OUT DacDbiArrayList<COR_SEGMENT> *p
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::IsValidObject(CORDB_ADDRESS obj, OUT bool * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsValidObject(CORDB_ADDRESS obj, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -7475,7 +7505,7 @@ HRESULT DacDbiInterfaceImpl::IsValidObject(CORDB_ADDRESS obj, OUT bool * pResult
     EX_TRY
     {
 
-        bool isValid = false;
+        BOOL isValid = FALSE;
 
         if (obj != 0 && obj != (CORDB_ADDRESS)-1)
         {
@@ -7487,13 +7517,13 @@ HRESULT DacDbiInterfaceImpl::IsValidObject(CORDB_ADDRESS obj, OUT bool * pResult
                 PTR_EEClass cls = mt->GetClass();
 
                 if (mt == cls->GetMethodTable())
-                    isValid = true;
+                    isValid = TRUE;
                 else if (!mt->IsCanonicalMethodTable() || mt->IsContinuation())
                     isValid = cls->GetMethodTable()->GetClass() == cls;
             }
             EX_CATCH
             {
-                isValid = false;
+                isValid = FALSE;
             }
             EX_END_CATCH
         }
@@ -7504,7 +7534,7 @@ HRESULT DacDbiInterfaceImpl::IsValidObject(CORDB_ADDRESS obj, OUT bool * pResult
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::GetAppDomainForObject(CORDB_ADDRESS obj, OUT VMPTR_AppDomain * pApp, OUT VMPTR_Module * pModule, OUT VMPTR_DomainAssembly * pDomainAssembly, OUT bool * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAppDomainForObject(CORDB_ADDRESS obj, OUT VMPTR_AppDomain * pApp, OUT VMPTR_Module * pModule, OUT VMPTR_DomainAssembly * pDomainAssembly, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -7514,7 +7544,7 @@ HRESULT DacDbiInterfaceImpl::GetAppDomainForObject(CORDB_ADDRESS obj, OUT VMPTR_
 
         if (obj == 0 || obj == (CORDB_ADDRESS)-1)
         {
-            *pResult = false;
+            *pResult = FALSE;
         }
         else
         {
@@ -7526,14 +7556,14 @@ HRESULT DacDbiInterfaceImpl::GetAppDomainForObject(CORDB_ADDRESS obj, OUT VMPTR_
             pModule->SetDacTargetPtr(PTR_HOST_TO_TADDR(module));
             pDomainAssembly->SetDacTargetPtr(PTR_HOST_TO_TADDR(module->GetDomainAssembly()));
 
-            *pResult = true;
+            *pResult = TRUE;
         }
     }
     EX_CATCH_HRESULT(hr);
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::CreateRefWalk(OUT RefWalkHandle * pHandle, BOOL walkStacks, BOOL walkFQ, UINT32 handleWalkMask)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::CreateRefWalk(OUT RefWalkHandle * pHandle, BOOL walkStacks, BOOL walkFQ, UINT32 handleWalkMask)
 {
     DD_ENTER_MAY_THROW;
 
@@ -7556,7 +7586,7 @@ HRESULT DacDbiInterfaceImpl::CreateRefWalk(OUT RefWalkHandle * pHandle, BOOL wal
 }
 
 
-HRESULT DacDbiInterfaceImpl::DeleteRefWalk(RefWalkHandle handle)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::DeleteRefWalk(RefWalkHandle handle)
 {
     DD_ENTER_MAY_THROW;
 
@@ -7574,7 +7604,7 @@ HRESULT DacDbiInterfaceImpl::DeleteRefWalk(RefWalkHandle handle)
 }
 
 
-HRESULT DacDbiInterfaceImpl::WalkRefs(RefWalkHandle handle, ULONG count, OUT DacGcReference * objects, OUT ULONG *pFetched)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::WalkRefs(RefWalkHandle handle, ULONG count, OUT DacGcReference * objects, OUT ULONG *pFetched)
 {
     if (objects == NULL || pFetched == NULL)
         return E_POINTER;
@@ -7588,7 +7618,7 @@ HRESULT DacDbiInterfaceImpl::WalkRefs(RefWalkHandle handle, ULONG count, OUT Dac
    return walker->Next(count, objects, pFetched);
 }
 
-HRESULT DacDbiInterfaceImpl::GetTypeID(CORDB_ADDRESS dbgObj, COR_TYPEID *pID)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetTypeID(CORDB_ADDRESS dbgObj, COR_TYPEID *pID)
 {
     DD_ENTER_MAY_THROW;
 
@@ -7604,7 +7634,7 @@ HRESULT DacDbiInterfaceImpl::GetTypeID(CORDB_ADDRESS dbgObj, COR_TYPEID *pID)
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::GetTypeIDForType(VMPTR_TypeHandle vmTypeHandle, COR_TYPEID *pID)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetTypeIDForType(VMPTR_TypeHandle vmTypeHandle, COR_TYPEID *pID)
 {
     DD_ENTER_MAY_THROW;
 
@@ -7619,7 +7649,7 @@ HRESULT DacDbiInterfaceImpl::GetTypeIDForType(VMPTR_TypeHandle vmTypeHandle, COR
     return S_OK;
 }
 
-HRESULT DacDbiInterfaceImpl::GetObjectFields(COR_TYPEID id, ULONG32 celt, COR_FIELD *layout, ULONG32 *pceltFetched)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetObjectFields(COR_TYPEID id, ULONG32 celt, COR_FIELD *layout, ULONG32 *pceltFetched)
 {
     if (pceltFetched == NULL)
         return E_POINTER;
@@ -7697,7 +7727,7 @@ HRESULT DacDbiInterfaceImpl::GetObjectFields(COR_TYPEID id, ULONG32 celt, COR_FI
 }
 
 
-HRESULT DacDbiInterfaceImpl::GetTypeLayout(COR_TYPEID id, COR_TYPE_LAYOUT *pLayout)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetTypeLayout(COR_TYPEID id, COR_TYPE_LAYOUT *pLayout)
 {
     if (pLayout == NULL)
         return E_POINTER;
@@ -7727,7 +7757,7 @@ HRESULT DacDbiInterfaceImpl::GetTypeLayout(COR_TYPEID id, COR_TYPE_LAYOUT *pLayo
     return S_OK;
 }
 
-HRESULT DacDbiInterfaceImpl::GetArrayLayout(COR_TYPEID id, COR_ARRAY_LAYOUT *pLayout)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetArrayLayout(COR_TYPEID id, COR_ARRAY_LAYOUT *pLayout)
 {
     if (pLayout == NULL)
         return E_POINTER;
@@ -7795,7 +7825,7 @@ HRESULT DacDbiInterfaceImpl::GetArrayLayout(COR_TYPEID id, COR_ARRAY_LAYOUT *pLa
 }
 
 
-HRESULT DacDbiInterfaceImpl::GetGCHeapInformation(OUT COR_HEAPINFO * pHeapInfo)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetGCHeapInformation(OUT COR_HEAPINFO * pHeapInfo)
 {
     DD_ENTER_MAY_THROW;
 
@@ -7827,7 +7857,7 @@ HRESULT DacDbiInterfaceImpl::GetGCHeapInformation(OUT COR_HEAPINFO * pHeapInfo)
 }
 
 
-HRESULT DacDbiInterfaceImpl::GetPEFileMDInternalRW(VMPTR_PEAssembly vmPEAssembly, OUT TADDR* pAddrMDInternalRW)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetPEFileMDInternalRW(VMPTR_PEAssembly vmPEAssembly, OUT TADDR* pAddrMDInternalRW)
 {
     DD_ENTER_MAY_THROW;
     if (pAddrMDInternalRW == NULL)
@@ -7837,7 +7867,7 @@ HRESULT DacDbiInterfaceImpl::GetPEFileMDInternalRW(VMPTR_PEAssembly vmPEAssembly
     return S_OK;
 }
 
-HRESULT DacDbiInterfaceImpl::GetReJitInfo(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ReJitInfo* pvmReJitInfo)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetReJitInfo(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ReJitInfo* pvmReJitInfo)
 {
     DD_ENTER_MAY_THROW;
     _ASSERTE(!"You shouldn't be calling this - use GetActiveRejitILCodeVersionNode instead");
@@ -7845,7 +7875,7 @@ HRESULT DacDbiInterfaceImpl::GetReJitInfo(VMPTR_Module vmModule, mdMethodDef met
 }
 
 #ifdef FEATURE_CODE_VERSIONING
-HRESULT DacDbiInterfaceImpl::GetActiveRejitILCodeVersionNode(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ILCodeVersionNode* pVmILCodeVersionNode)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetActiveRejitILCodeVersionNode(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ILCodeVersionNode* pVmILCodeVersionNode)
 {
     DD_ENTER_MAY_THROW;
     if (pVmILCodeVersionNode == NULL)
@@ -7875,7 +7905,7 @@ HRESULT DacDbiInterfaceImpl::GetActiveRejitILCodeVersionNode(VMPTR_Module vmModu
     return S_OK;
 }
 
-HRESULT DacDbiInterfaceImpl::GetNativeCodeVersionNode(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeStartAddress, OUT VMPTR_NativeCodeVersionNode* pVmNativeCodeVersionNode)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetNativeCodeVersionNode(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeStartAddress, OUT VMPTR_NativeCodeVersionNode* pVmNativeCodeVersionNode)
 {
     DD_ENTER_MAY_THROW;
     if (pVmNativeCodeVersionNode == NULL)
@@ -7891,7 +7921,7 @@ HRESULT DacDbiInterfaceImpl::GetNativeCodeVersionNode(VMPTR_MethodDesc vmMethod,
     return S_OK;
 }
 
-HRESULT DacDbiInterfaceImpl::GetILCodeVersionNode(VMPTR_NativeCodeVersionNode vmNativeCodeVersionNode, VMPTR_ILCodeVersionNode* pVmILCodeVersionNode)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetILCodeVersionNode(VMPTR_NativeCodeVersionNode vmNativeCodeVersionNode, VMPTR_ILCodeVersionNode* pVmILCodeVersionNode)
 {
     DD_ENTER_MAY_THROW;
     if (pVmILCodeVersionNode == NULL)
@@ -7915,7 +7945,7 @@ HRESULT DacDbiInterfaceImpl::GetILCodeVersionNode(VMPTR_NativeCodeVersionNode vm
     return S_OK;
 }
 
-HRESULT DacDbiInterfaceImpl::GetILCodeVersionNodeData(VMPTR_ILCodeVersionNode vmILCodeVersionNode, DacSharedReJitInfo* pData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetILCodeVersionNodeData(VMPTR_ILCodeVersionNode vmILCodeVersionNode, DacSharedReJitInfo* pData)
 {
     DD_ENTER_MAY_THROW;
 #ifdef FEATURE_REJIT
@@ -7941,14 +7971,14 @@ HRESULT DacDbiInterfaceImpl::GetILCodeVersionNodeData(VMPTR_ILCodeVersionNode vm
 }
 #endif // FEATURE_CODE_VERSIONING
 
-HRESULT DacDbiInterfaceImpl::GetReJitInfo(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeStartAddress, OUT VMPTR_ReJitInfo* pvmReJitInfo)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetReJitInfoByAddress(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeStartAddress, OUT VMPTR_ReJitInfo* pvmReJitInfo)
 {
     DD_ENTER_MAY_THROW;
     _ASSERTE(!"You shouldn't be calling this - use GetNativeCodeVersionNode instead");
     return S_OK;
 }
 
-HRESULT DacDbiInterfaceImpl::AreOptimizationsDisabled(VMPTR_Module vmModule, mdMethodDef methodTk, OUT BOOL* pOptimizationsDisabled)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::AreOptimizationsDisabled(VMPTR_Module vmModule, mdMethodDef methodTk, OUT BOOL* pOptimizationsDisabled)
 {
     DD_ENTER_MAY_THROW;
     PTR_Module pModule = vmModule.GetDacPtr();
@@ -7969,21 +7999,21 @@ HRESULT DacDbiInterfaceImpl::AreOptimizationsDisabled(VMPTR_Module vmModule, mdM
     return S_OK;
 }
 
-HRESULT DacDbiInterfaceImpl::GetSharedReJitInfo(VMPTR_ReJitInfo vmReJitInfo, OUT VMPTR_SharedReJitInfo* pvmSharedReJitInfo)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetSharedReJitInfo(VMPTR_ReJitInfo vmReJitInfo, OUT VMPTR_SharedReJitInfo* pvmSharedReJitInfo)
 {
     DD_ENTER_MAY_THROW;
     _ASSERTE(!"You shouldn't be calling this - use GetILCodeVersionNode instead");
     return S_OK;
 }
 
-HRESULT DacDbiInterfaceImpl::GetSharedReJitInfoData(VMPTR_SharedReJitInfo vmSharedReJitInfo, DacSharedReJitInfo* pData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetSharedReJitInfoData(VMPTR_SharedReJitInfo vmSharedReJitInfo, DacSharedReJitInfo* pData)
 {
     DD_ENTER_MAY_THROW;
     _ASSERTE(!"You shouldn't be calling this - use GetILCodeVersionNodeData instead");
     return S_OK;
 }
 
-HRESULT DacDbiInterfaceImpl::GetDefinesBitField(ULONG32 *pDefines)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetDefinesBitField(ULONG32 *pDefines)
 {
     DD_ENTER_MAY_THROW;
     if (pDefines == NULL)
@@ -7996,7 +8026,7 @@ HRESULT DacDbiInterfaceImpl::GetDefinesBitField(ULONG32 *pDefines)
     return S_OK;
 }
 
-HRESULT DacDbiInterfaceImpl::GetMDStructuresVersion(ULONG32* pMDStructuresVersion)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetMDStructuresVersion(ULONG32* pMDStructuresVersion)
 {
     DD_ENTER_MAY_THROW;
     if (pMDStructuresVersion == NULL)
@@ -8009,7 +8039,7 @@ HRESULT DacDbiInterfaceImpl::GetMDStructuresVersion(ULONG32* pMDStructuresVersio
     return S_OK;
 }
 
-HRESULT DacDbiInterfaceImpl::EnableGCNotificationEvents(BOOL fEnable)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::EnableGCNotificationEvents(BOOL fEnable)
 {
     DD_ENTER_MAY_THROW
 
@@ -8026,7 +8056,7 @@ HRESULT DacDbiInterfaceImpl::EnableGCNotificationEvents(BOOL fEnable)
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::GetDomainAssemblyFromModule(VMPTR_Module vmModule, OUT VMPTR_DomainAssembly *pVmDomainAssembly)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetDomainAssemblyFromModule(VMPTR_Module vmModule, OUT VMPTR_DomainAssembly *pVmDomainAssembly)
 {
     DD_ENTER_MAY_THROW;
 
@@ -8043,7 +8073,7 @@ HRESULT DacDbiInterfaceImpl::GetDomainAssemblyFromModule(VMPTR_Module vmModule, 
     return S_OK;
 }
 
-HRESULT DacDbiInterfaceImpl::ParseContinuation(
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::ParseContinuation(
     CORDB_ADDRESS continuationAddress,
     OUT PCODE* pDiagnosticIP,
     OUT CORDB_ADDRESS* pNextContinuation,
@@ -8109,7 +8139,7 @@ static BYTE* DebugInfoStoreNew(void * pData, size_t cBytes)
     return new (nothrow) BYTE[cBytes];
 }
 
-HRESULT DacDbiInterfaceImpl::GetAsyncLocals(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeAddr, UINT32 state, OUT DacDbiArrayList<AsyncLocalData>* pAsyncLocals)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetAsyncLocals(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeAddr, UINT32 state, OUT DacDbiArrayList<AsyncLocalData>* pAsyncLocals)
 {
     DD_ENTER_MAY_THROW;
 
@@ -8177,7 +8207,7 @@ HRESULT DacDbiInterfaceImpl::GetAsyncLocals(VMPTR_MethodDesc vmMethod, CORDB_ADD
     return hr;
 }
 
-HRESULT DacDbiInterfaceImpl::GetGenericArgTokenIndex(VMPTR_MethodDesc vmMethod, OUT UINT32* pIndex)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetGenericArgTokenIndex(VMPTR_MethodDesc vmMethod, OUT UINT32* pIndex)
 {
     DD_ENTER_MAY_THROW;
 

--- a/src/coreclr/debug/daccess/dacdbiimpl.h
+++ b/src/coreclr/debug/daccess/dacdbiimpl.h
@@ -51,6 +51,14 @@ public:
     // Destructor.
     virtual ~DacDbiInterfaceImpl(void);
 
+    // IUnknown.
+    // IDacDbiInterface now extends IUnknown, so DacDbiInterfaceImpl must resolve the
+    // diamond inheritance by delegating to ClrDataAccess's existing IUnknown implementation
+    // and adding support for the IDacDbiInterface IID.
+    STDMETHOD(QueryInterface)(THIS_ IN REFIID interfaceId, OUT PVOID* iface);
+    STDMETHOD_(ULONG, AddRef)(THIS);
+    STDMETHOD_(ULONG, Release)(THIS);
+
     // Overridden from ClrDataAccess. Gets an internal metadata importer for the file.
     virtual IMDInternalImport* GetMDImport(
         const PEAssembly* pPEAssembly,
@@ -59,17 +67,13 @@ public:
 
 
     // Check whether the version of the DBI matches the version of the runtime.
-    HRESULT CheckDbiVersion(const DbiVersion * pVersion);
+    HRESULT STDMETHODCALLTYPE CheckDbiVersion(const DbiVersion * pVersion);
 
     // Flush the DAC cache. This should be called when target memory changes.
-    HRESULT FlushCache();
+    HRESULT STDMETHODCALLTYPE FlushCache();
 
     // enable or disable DAC target consistency checks
-    HRESULT DacSetTargetConsistencyChecks(bool fEnableAsserts);
-
-    // Destroy the interface object. The client should call this when it's done
-    // with the IDacDbiInterface to free up any resources.
-    HRESULT Destroy();
+    HRESULT STDMETHODCALLTYPE DacSetTargetConsistencyChecks(BOOL fEnableAsserts);
 
     IAllocator * GetAllocator()
     {
@@ -78,23 +82,23 @@ public:
 
 
     // Is Left-side started up?
-    HRESULT IsLeftSideInitialized(OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE IsLeftSideInitialized(OUT BOOL * pResult);
 
     // Get an LS Appdomain via an AppDomain unique ID.
     // Fails if the AD is not found or if the ID is invalid.
-    HRESULT GetAppDomainFromId(ULONG appdomainId, OUT VMPTR_AppDomain * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetAppDomainFromId(ULONG appdomainId, OUT VMPTR_AppDomain * pRetVal);
 
     // Get the AppDomain ID for an AppDomain.
-    HRESULT GetAppDomainId(VMPTR_AppDomain vmAppDomain, OUT ULONG * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetAppDomainId(VMPTR_AppDomain vmAppDomain, OUT ULONG * pRetVal);
 
     // Get the managed AppDomain object for an AppDomain.
-    HRESULT GetAppDomainObject(VMPTR_AppDomain vmAppDomain, OUT VMPTR_OBJECTHANDLE * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetAppDomainObject(VMPTR_AppDomain vmAppDomain, OUT VMPTR_OBJECTHANDLE * pRetVal);
 
     // Get the full AD friendly name for the appdomain.
-    HRESULT GetAppDomainFullName(VMPTR_AppDomain vmAppDomain, IStringHolder * pStrName);
+    HRESULT STDMETHODCALLTYPE GetAppDomainFullName(VMPTR_AppDomain vmAppDomain, IStringHolder * pStrName);
 
     // Get the values of the JIT Optimization and EnC flags.
-    HRESULT GetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly,
+    HRESULT STDMETHODCALLTYPE GetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly,
                            OUT BOOL * pfAllowJITOpts,
                            OUT BOOL * pfEnableEnC);
 
@@ -102,69 +106,69 @@ public:
     bool CanSetEnCBits(Module * pModule);
 
     // Set the values of the JIT optimization and EnC flags.
-    HRESULT SetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly,
+    HRESULT STDMETHODCALLTYPE SetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly,
                              BOOL             fAllowJitOpts,
                              BOOL             fEnableEnC);
 
 
     // Initialize the native/IL sequence points and native var info for a function.
-    HRESULT GetNativeCodeSequencePointsAndVarInfo(VMPTR_MethodDesc vmMethodDesc, CORDB_ADDRESS startAddress, BOOL fCodeAvailable, OUT NativeVarData * pNativeVarData, OUT SequencePoints * pSequencePoints);
+    HRESULT STDMETHODCALLTYPE GetNativeCodeSequencePointsAndVarInfo(VMPTR_MethodDesc vmMethodDesc, CORDB_ADDRESS startAddress, BOOL fCodeAvailable, OUT NativeVarData * pNativeVarData, OUT SequencePoints * pSequencePoints);
 
-    HRESULT IsThreadSuspendedOrHijacked(VMPTR_Thread vmThread, OUT bool * pResult);
+    HRESULT STDMETHODCALLTYPE IsThreadSuspendedOrHijacked(VMPTR_Thread vmThread, OUT BOOL * pResult);
 
 
-    HRESULT AreGCStructuresValid(OUT bool * pResult);
-    HRESULT CreateHeapWalk(HeapWalkHandle *pHandle);
-    HRESULT DeleteHeapWalk(HeapWalkHandle handle);
+    HRESULT STDMETHODCALLTYPE AreGCStructuresValid(OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE CreateHeapWalk(HeapWalkHandle *pHandle);
+    HRESULT STDMETHODCALLTYPE DeleteHeapWalk(HeapWalkHandle handle);
 
-    HRESULT WalkHeap(HeapWalkHandle handle,
+    HRESULT STDMETHODCALLTYPE WalkHeap(HeapWalkHandle handle,
                      ULONG count,
                      OUT COR_HEAPOBJECT * objects,
                      OUT ULONG *fetched);
 
-    HRESULT GetHeapSegments(OUT DacDbiArrayList<COR_SEGMENT> *pSegments);
+    HRESULT STDMETHODCALLTYPE GetHeapSegments(OUT DacDbiArrayList<COR_SEGMENT> *pSegments);
 
 
-    HRESULT IsValidObject(CORDB_ADDRESS obj, OUT bool * pResult);
+    HRESULT STDMETHODCALLTYPE IsValidObject(CORDB_ADDRESS obj, OUT BOOL * pResult);
 
-    HRESULT GetAppDomainForObject(CORDB_ADDRESS obj, OUT VMPTR_AppDomain * pApp, OUT VMPTR_Module * pModule, OUT VMPTR_DomainAssembly * pDomainAssembly, OUT bool * pResult);
+    HRESULT STDMETHODCALLTYPE GetAppDomainForObject(CORDB_ADDRESS obj, OUT VMPTR_AppDomain * pApp, OUT VMPTR_Module * pModule, OUT VMPTR_DomainAssembly * pDomainAssembly, OUT BOOL * pResult);
 
 
 
-    HRESULT CreateRefWalk(RefWalkHandle * pHandle, BOOL walkStacks, BOOL walkFQ, UINT32 handleWalkMask);
-    HRESULT DeleteRefWalk(RefWalkHandle handle);
-    HRESULT WalkRefs(RefWalkHandle handle, ULONG count, OUT DacGcReference * objects, OUT ULONG *pFetched);
+    HRESULT STDMETHODCALLTYPE CreateRefWalk(RefWalkHandle * pHandle, BOOL walkStacks, BOOL walkFQ, UINT32 handleWalkMask);
+    HRESULT STDMETHODCALLTYPE DeleteRefWalk(RefWalkHandle handle);
+    HRESULT STDMETHODCALLTYPE WalkRefs(RefWalkHandle handle, ULONG count, OUT DacGcReference * objects, OUT ULONG *pFetched);
 
-    HRESULT GetTypeID(CORDB_ADDRESS obj, COR_TYPEID *pID);
+    HRESULT STDMETHODCALLTYPE GetTypeID(CORDB_ADDRESS obj, COR_TYPEID *pID);
 
-    HRESULT GetTypeIDForType(VMPTR_TypeHandle vmTypeHandle, COR_TYPEID *pID);
+    HRESULT STDMETHODCALLTYPE GetTypeIDForType(VMPTR_TypeHandle vmTypeHandle, COR_TYPEID *pID);
 
-    HRESULT GetObjectFields(COR_TYPEID id, ULONG32 celt, COR_FIELD *layout, ULONG32 *pceltFetched);
-    HRESULT GetTypeLayout(COR_TYPEID id, COR_TYPE_LAYOUT *pLayout);
-    HRESULT GetArrayLayout(COR_TYPEID id, COR_ARRAY_LAYOUT *pLayout);
-    HRESULT GetGCHeapInformation(OUT COR_HEAPINFO * pHeapInfo);
-    HRESULT GetPEFileMDInternalRW(VMPTR_PEAssembly vmPEAssembly, OUT TADDR* pAddrMDInternalRW);
-    HRESULT GetReJitInfo(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ReJitInfo* pReJitInfo);
+    HRESULT STDMETHODCALLTYPE GetObjectFields(COR_TYPEID id, ULONG32 celt, COR_FIELD *layout, ULONG32 *pceltFetched);
+    HRESULT STDMETHODCALLTYPE GetTypeLayout(COR_TYPEID id, COR_TYPE_LAYOUT *pLayout);
+    HRESULT STDMETHODCALLTYPE GetArrayLayout(COR_TYPEID id, COR_ARRAY_LAYOUT *pLayout);
+    HRESULT STDMETHODCALLTYPE GetGCHeapInformation(OUT COR_HEAPINFO * pHeapInfo);
+    HRESULT STDMETHODCALLTYPE GetPEFileMDInternalRW(VMPTR_PEAssembly vmPEAssembly, OUT TADDR* pAddrMDInternalRW);
+    HRESULT STDMETHODCALLTYPE GetReJitInfo(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ReJitInfo* pReJitInfo);
 #ifdef FEATURE_CODE_VERSIONING
-    HRESULT GetActiveRejitILCodeVersionNode(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ILCodeVersionNode* pVmILCodeVersionNode);
-    HRESULT GetNativeCodeVersionNode(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeStartAddress, OUT VMPTR_NativeCodeVersionNode* pVmNativeCodeVersionNode);
-    HRESULT GetILCodeVersionNode(VMPTR_NativeCodeVersionNode vmNativeCodeVersionNode, VMPTR_ILCodeVersionNode* pVmILCodeVersionNode);
-    HRESULT GetILCodeVersionNodeData(VMPTR_ILCodeVersionNode vmILCodeVersionNode, DacSharedReJitInfo* pData);
+    HRESULT STDMETHODCALLTYPE GetActiveRejitILCodeVersionNode(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ILCodeVersionNode* pVmILCodeVersionNode);
+    HRESULT STDMETHODCALLTYPE GetNativeCodeVersionNode(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeStartAddress, OUT VMPTR_NativeCodeVersionNode* pVmNativeCodeVersionNode);
+    HRESULT STDMETHODCALLTYPE GetILCodeVersionNode(VMPTR_NativeCodeVersionNode vmNativeCodeVersionNode, VMPTR_ILCodeVersionNode* pVmILCodeVersionNode);
+    HRESULT STDMETHODCALLTYPE GetILCodeVersionNodeData(VMPTR_ILCodeVersionNode vmILCodeVersionNode, DacSharedReJitInfo* pData);
 #endif // FEATURE_CODE_VERSIONING
-    HRESULT GetReJitInfo(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeStartAddress, OUT VMPTR_ReJitInfo* pReJitInfo);
-    HRESULT AreOptimizationsDisabled(VMPTR_Module vmModule, mdMethodDef methodTk, OUT BOOL* pOptimizationsDisabled);
-    HRESULT GetSharedReJitInfo(VMPTR_ReJitInfo vmReJitInfo, VMPTR_SharedReJitInfo* pSharedReJitInfo);
-    HRESULT GetSharedReJitInfoData(VMPTR_SharedReJitInfo sharedReJitInfo, DacSharedReJitInfo* pData);
-    HRESULT GetDefinesBitField(ULONG32 *pDefines);
-    HRESULT GetMDStructuresVersion(ULONG32* pMDStructuresVersion);
-    HRESULT EnableGCNotificationEvents(BOOL fEnable);
-    HRESULT GetDomainAssemblyFromModule(VMPTR_Module vmModule, OUT VMPTR_DomainAssembly *pVmDomainAssembly);
-    HRESULT ParseContinuation(CORDB_ADDRESS continuationAddress,
+    HRESULT STDMETHODCALLTYPE GetReJitInfoByAddress(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeStartAddress, OUT VMPTR_ReJitInfo* pReJitInfo);
+    HRESULT STDMETHODCALLTYPE AreOptimizationsDisabled(VMPTR_Module vmModule, mdMethodDef methodTk, OUT BOOL* pOptimizationsDisabled);
+    HRESULT STDMETHODCALLTYPE GetSharedReJitInfo(VMPTR_ReJitInfo vmReJitInfo, VMPTR_SharedReJitInfo* pSharedReJitInfo);
+    HRESULT STDMETHODCALLTYPE GetSharedReJitInfoData(VMPTR_SharedReJitInfo sharedReJitInfo, DacSharedReJitInfo* pData);
+    HRESULT STDMETHODCALLTYPE GetDefinesBitField(ULONG32 *pDefines);
+    HRESULT STDMETHODCALLTYPE GetMDStructuresVersion(ULONG32* pMDStructuresVersion);
+    HRESULT STDMETHODCALLTYPE EnableGCNotificationEvents(BOOL fEnable);
+    HRESULT STDMETHODCALLTYPE GetDomainAssemblyFromModule(VMPTR_Module vmModule, OUT VMPTR_DomainAssembly *pVmDomainAssembly);
+    HRESULT STDMETHODCALLTYPE ParseContinuation(CORDB_ADDRESS continuationAddress,
                                               OUT PCODE *pDiagnosticIP,
                                               OUT CORDB_ADDRESS *pNextContinuation,
                                               OUT UINT32 *pState);
-    HRESULT GetAsyncLocals(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeAddr, UINT32 state, OUT DacDbiArrayList<AsyncLocalData>* pAsyncLocals);
-    HRESULT GetGenericArgTokenIndex(VMPTR_MethodDesc vmMethod, OUT UINT32* pIndex);
+    HRESULT STDMETHODCALLTYPE GetAsyncLocals(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeAddr, UINT32 state, OUT DacDbiArrayList<AsyncLocalData>* pAsyncLocals);
+    HRESULT STDMETHODCALLTYPE GetGenericArgTokenIndex(VMPTR_MethodDesc vmMethod, OUT UINT32* pIndex);
 
 private:
     void TypeHandleToExpandedTypeInfoImpl(AreValueTypesBoxed              boxed,
@@ -215,7 +219,7 @@ public:
     // a module and a token. The info will come from a MethodDesc, if
     // one exists or from metadata.
     //
-    HRESULT GetILCodeAndSig(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT TargetBuffer * pCodeInfo, OUT mdToken * pLocalSigToken);
+    HRESULT STDMETHODCALLTYPE GetILCodeAndSig(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT TargetBuffer * pCodeInfo, OUT mdToken * pLocalSigToken);
 
     // Gets the following information about the native code blob for a function, if the native
     // code is available:
@@ -223,7 +227,7 @@ public:
     //    whether it's an instantiated generic
     //    its EnC version number
     //    hot and cold region information.
-    HRESULT GetNativeCodeInfo(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT NativeCodeFunctionData * pCodeInfo);
+    HRESULT STDMETHODCALLTYPE GetNativeCodeInfo(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT NativeCodeFunctionData * pCodeInfo);
 
     // Gets the following information about the native code blob for a function
     //    its method desc
@@ -232,7 +236,7 @@ public:
     //    hot and cold region information
     //    its module
     //    its metadata token.
-    HRESULT GetNativeCodeInfoForAddr(CORDB_ADDRESS codeAddress, NativeCodeFunctionData * pCodeInfo, VMPTR_Module * pVmModule, mdToken * pFunctionToken);
+    HRESULT STDMETHODCALLTYPE GetNativeCodeInfoForAddr(CORDB_ADDRESS codeAddress, NativeCodeFunctionData * pCodeInfo, VMPTR_Module * pVmModule, mdToken * pFunctionToken);
 
 private:
     // Get start addresses and sizes for hot and cold regions for a native code blob
@@ -241,112 +245,112 @@ private:
 
 public:
     // Determine if a type is a ValueType
-    HRESULT IsValueType(VMPTR_TypeHandle th, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE IsValueType(VMPTR_TypeHandle th, OUT BOOL * pResult);
 
     // Determine if a type has generic parameters
-    HRESULT HasTypeParams(VMPTR_TypeHandle th, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE HasTypeParams(VMPTR_TypeHandle th, OUT BOOL * pResult);
 
     // Get type information for a class
-    HRESULT GetClassInfo(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle thExact, ClassInfo * pData);
+    HRESULT STDMETHODCALLTYPE GetClassInfo(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle thExact, ClassInfo * pData);
 
     // get field information and object size for an instantiated generic type
-    HRESULT GetInstantiationFieldInfo(VMPTR_DomainAssembly vmDomainAssembly, VMPTR_TypeHandle vmThExact, VMPTR_TypeHandle vmThApprox, OUT DacDbiArrayList<FieldData> * pFieldList, OUT SIZE_T * pObjectSize);
+    HRESULT STDMETHODCALLTYPE GetInstantiationFieldInfo(VMPTR_DomainAssembly vmDomainAssembly, VMPTR_TypeHandle vmThExact, VMPTR_TypeHandle vmThApprox, OUT DacDbiArrayList<FieldData> * pFieldList, OUT SIZE_T * pObjectSize);
 
 
-    HRESULT GetObjectExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, CORDB_ADDRESS addr, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo);
+    HRESULT STDMETHODCALLTYPE GetObjectExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, CORDB_ADDRESS addr, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo);
 
 
-    HRESULT GetObjectExpandedTypeInfoFromID(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, COR_TYPEID id, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo);
+    HRESULT STDMETHODCALLTYPE GetObjectExpandedTypeInfoFromID(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, COR_TYPEID id, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo);
 
 
     // @dbgtodo Microsoft inspection: change DebuggerIPCE_ExpandedTypeData to DacDbiStructures type hierarchy
     // once ICorDebugType and ICorDebugClass are DACized
     // use a type handle to get the information needed to create the corresponding RS CordbType instance
-    HRESULT TypeHandleToExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, DebuggerIPCE_ExpandedTypeData * pTypeInfo);
+    HRESULT STDMETHODCALLTYPE TypeHandleToExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, DebuggerIPCE_ExpandedTypeData * pTypeInfo);
 
     // Get type handle for a TypeDef token, if one exists. For generics this returns the open type.
-    HRESULT GetTypeHandle(VMPTR_Module vmModule, mdTypeDef metadataToken, OUT VMPTR_TypeHandle * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetTypeHandle(VMPTR_Module vmModule, mdTypeDef metadataToken, OUT VMPTR_TypeHandle * pRetVal);
 
     // Get the approximate type handle for an instantiated type. This may be identical to the exact type handle,
     // but if we have code sharing for generics,it may differ in that it may have canonical type parameters.
-    HRESULT GetApproxTypeHandle(TypeInfoList * pTypeData, OUT VMPTR_TypeHandle * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetApproxTypeHandle(TypeInfoList * pTypeData, OUT VMPTR_TypeHandle * pRetVal);
 
     // Get the exact type handle from type data
-    HRESULT GetExactTypeHandle(DebuggerIPCE_ExpandedTypeData * pTypeData,
+    HRESULT STDMETHODCALLTYPE GetExactTypeHandle(DebuggerIPCE_ExpandedTypeData * pTypeData,
                                ArgInfoList *   pArgInfo,
-                               VMPTR_TypeHandle& vmTypeHandle);
+                               VMPTR_TypeHandle * pVmTypeHandle);
 
     // Retrieve the generic type params for a given MethodDesc.  This function is specifically
     // for stackwalking because it requires the generic type token on the stack.
-    HRESULT GetMethodDescParams(VMPTR_AppDomain vmAppDomain, VMPTR_MethodDesc vmMethodDesc, GENERICS_TYPE_TOKEN genericsToken, OUT UINT32 * pcGenericClassTypeParams, OUT TypeParamsList * pGenericTypeParams);
+    HRESULT STDMETHODCALLTYPE GetMethodDescParams(VMPTR_AppDomain vmAppDomain, VMPTR_MethodDesc vmMethodDesc, GENERICS_TYPE_TOKEN genericsToken, OUT UINT32 * pcGenericClassTypeParams, OUT TypeParamsList * pGenericTypeParams);
 
     // Get the target field address of a context or thread local static.
-    HRESULT GetThreadStaticAddress(VMPTR_FieldDesc vmField, VMPTR_Thread vmRuntimeThread, OUT CORDB_ADDRESS * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetThreadStaticAddress(VMPTR_FieldDesc vmField, VMPTR_Thread vmRuntimeThread, OUT CORDB_ADDRESS * pRetVal);
 
     // Get the target field address of a collectible types static.
-    HRESULT GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmField, VMPTR_AppDomain vmAppDomain, OUT CORDB_ADDRESS * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmField, VMPTR_AppDomain vmAppDomain, OUT CORDB_ADDRESS * pRetVal);
 
     // Get information about a field added with Edit And Continue.
-    HRESULT GetEnCHangingFieldInfo(const EnCHangingFieldInfo * pEnCFieldInfo, OUT FieldData * pFieldData, OUT BOOL * pfStatic);
+    HRESULT STDMETHODCALLTYPE GetEnCHangingFieldInfo(const EnCHangingFieldInfo * pEnCFieldInfo, OUT FieldData * pFieldData, OUT BOOL * pfStatic);
 
     // GetTypeHandleParams gets the necessary data for a type handle, i.e. its
     // type parameters, e.g. "String" and "List<int>" from the type handle
     // for "Dict<String,List<int>>", and sends it back to the right side.
     // This should not fail except for OOM
 
-    HRESULT GetTypeHandleParams(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, OUT TypeParamsList * pParams);
+    HRESULT STDMETHODCALLTYPE GetTypeHandleParams(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, OUT TypeParamsList * pParams);
 
     // DacDbi API: GetSimpleType
     // gets the metadata token and domain file corresponding to a simple type
-    HRESULT GetSimpleType(VMPTR_AppDomain vmAppDomain, CorElementType simpleType, OUT mdTypeDef * pMetadataToken, OUT VMPTR_Module * pVmModule, OUT VMPTR_DomainAssembly * pVmDomainAssembly);
+    HRESULT STDMETHODCALLTYPE GetSimpleType(VMPTR_AppDomain vmAppDomain, CorElementType simpleType, OUT mdTypeDef * pMetadataToken, OUT VMPTR_Module * pVmModule, OUT VMPTR_DomainAssembly * pVmDomainAssembly);
 
-    HRESULT IsExceptionObject(VMPTR_Object vmObject, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE IsExceptionObject(VMPTR_Object vmObject, OUT BOOL * pResult);
 
-    HRESULT GetStackFramesFromException(VMPTR_Object vmObject, DacDbiArrayList<DacExceptionCallStackData>& dacStackFrames);
+    HRESULT STDMETHODCALLTYPE GetStackFramesFromException(VMPTR_Object vmObject, DacDbiArrayList<DacExceptionCallStackData>* pDacStackFrames);
 
     // Returns true if the argument is a runtime callable wrapper
-    HRESULT IsRcw(VMPTR_Object vmObject, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE IsRcw(VMPTR_Object vmObject, OUT BOOL * pResult);
 
-    HRESULT IsDelegate(VMPTR_Object vmObject, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE IsDelegate(VMPTR_Object vmObject, OUT BOOL * pResult);
 
-    HRESULT GetDelegateType(VMPTR_Object delegateObject, DelegateType *delegateType);
+    HRESULT STDMETHODCALLTYPE GetDelegateType(VMPTR_Object delegateObject, DelegateType *delegateType);
 
-    HRESULT GetDelegateFunctionData(
+    HRESULT STDMETHODCALLTYPE GetDelegateFunctionData(
         DelegateType delegateType,
         VMPTR_Object delegateObject,
         OUT VMPTR_DomainAssembly *ppFunctionDomainAssembly,
         OUT mdMethodDef *pMethodDef);
 
-    HRESULT GetDelegateTargetObject(
+    HRESULT STDMETHODCALLTYPE GetDelegateTargetObject(
         DelegateType delegateType,
         VMPTR_Object delegateObject,
         OUT VMPTR_Object *ppTargetObj,
         OUT VMPTR_AppDomain *ppTargetAppDomain);
 
-    HRESULT GetLoaderHeapMemoryRanges(OUT DacDbiArrayList<COR_MEMORY_RANGE> * pRanges);
+    HRESULT STDMETHODCALLTYPE GetLoaderHeapMemoryRanges(OUT DacDbiArrayList<COR_MEMORY_RANGE> * pRanges);
 
-    HRESULT IsModuleMapped(VMPTR_Module pModule, OUT BOOL *isModuleMapped);
+    HRESULT STDMETHODCALLTYPE IsModuleMapped(VMPTR_Module pModule, OUT BOOL *isModuleMapped);
 
-    HRESULT MetadataUpdatesApplied(OUT bool * pResult);
+    HRESULT STDMETHODCALLTYPE MetadataUpdatesApplied(OUT BOOL * pResult);
 
     // retrieves the list of COM interfaces implemented by vmObject, as it is known at
     // the time of the call (the list may change as new interface types become available
     // in the runtime)
-    HRESULT GetRcwCachedInterfaceTypes(VMPTR_Object vmObject, VMPTR_AppDomain vmAppDomain, BOOL bIInspectableOnly, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pDacInterfaces);
+    HRESULT STDMETHODCALLTYPE GetRcwCachedInterfaceTypes(VMPTR_Object vmObject, VMPTR_AppDomain vmAppDomain, BOOL bIInspectableOnly, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pDacInterfaces);
 
     // retrieves the list of interfaces pointers implemented by vmObject, as it is known at
     // the time of the call (the list may change as new interface types become available
     // in the runtime)
-    HRESULT GetRcwCachedInterfacePointers(VMPTR_Object vmObject, BOOL bIInspectableOnly, OUT DacDbiArrayList<CORDB_ADDRESS> * pDacItfPtrs);
+    HRESULT STDMETHODCALLTYPE GetRcwCachedInterfacePointers(VMPTR_Object vmObject, BOOL bIInspectableOnly, OUT DacDbiArrayList<CORDB_ADDRESS> * pDacItfPtrs);
 
     // retrieves a list of interface types corresponding to the passed in
     // list of IIDs. the interface types are retrieved from an app domain
     // IID / Type cache, that is updated as new types are loaded. will
     // have NULL entries corresponding to unknown IIDs in "iids"
-    HRESULT GetCachedWinRTTypesForIIDs(VMPTR_AppDomain vmAppDomain, DacDbiArrayList<GUID> & iids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes);
+    HRESULT STDMETHODCALLTYPE GetCachedWinRTTypesForIIDs(VMPTR_AppDomain vmAppDomain, DacDbiArrayList<GUID> * pIids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes);
 
     // retrieves the whole app domain cache of IID / Type mappings.
-    HRESULT GetCachedWinRTTypes(VMPTR_AppDomain vmAppDomain, OUT DacDbiArrayList<GUID> * piids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes);
+    HRESULT STDMETHODCALLTYPE GetCachedWinRTTypes(VMPTR_AppDomain vmAppDomain, OUT DacDbiArrayList<GUID> * piids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes);
 
 private:
     // Helper to enumerate all possible memory ranges help by a loader allocator.
@@ -364,7 +368,7 @@ private:
     //   S_OK on success.
     //   If it's a jitted method, error codes equivalent to GetMethodDescPtrFromIp
     //   E_INVALIDARG if a non-jitted method can't be located in the stubs.
-    HRESULT GetMethodDescPtrFromIpEx(
+    HRESULT STDMETHODCALLTYPE GetMethodDescPtrFromIpEx(
         TADDR funcIp,
         OUT VMPTR_MethodDesc *ppMD);
 
@@ -584,29 +588,29 @@ private:
 public:
     // Get object information for a TypedByRef object. Initializes the objRef and typedByRefType fields of
     // pObjectData (type info for the referent).
-    HRESULT GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT STDMETHODCALLTYPE GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData);
 
     // Get the string length and offset to string base for a string object
-    HRESULT GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT STDMETHODCALLTYPE GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData);
 
     // Get information for an array type referent of an objRef, including rank, upper and lower bounds,
     // element size and type, and the number of elements.
-    HRESULT GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT STDMETHODCALLTYPE GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData);
 
     // Get information about an object for which we have a reference, including the object size and
     // type information.
-    HRESULT GetBasicObjectInfo(CORDB_ADDRESS objectAddress, CorElementType type, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT STDMETHODCALLTYPE GetBasicObjectInfo(CORDB_ADDRESS objectAddress, CorElementType type, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData);
 
     // Returns the thread which owns the monitor lock on an object and the acquisition count
-    HRESULT GetThreadOwningMonitorLock(VMPTR_Object vmObject, OUT MonitorLockInfo * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetThreadOwningMonitorLock(VMPTR_Object vmObject, OUT MonitorLockInfo * pRetVal);
 
 
     // Enumerate all threads waiting on the monitor event for an object
-    HRESULT EnumerateMonitorEventWaitList(VMPTR_Object vmObject, FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
+    HRESULT STDMETHODCALLTYPE EnumerateMonitorEventWaitList(VMPTR_Object vmObject, FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
 
 private:
     // Helper function for CheckRef. Sanity check an object.
-    HRESULT FastSanityCheckObject(PTR_Object objPtr);
+    HRESULT STDMETHODCALLTYPE FastSanityCheckObject(PTR_Object objPtr);
 
     // Perform a sanity check on an object address to determine if this _could be_ a valid object. We can't
     // tell this for certain without walking the GC heap, but we do some fast tests to rule out clearly
@@ -627,8 +631,8 @@ private:
 
 #ifdef TEST_DATA_CONSISTENCY
 public:
-    HRESULT TestCrst(VMPTR_Crst vmCrst);
-    HRESULT TestRWLock(VMPTR_SimpleRWLock vmRWLock);
+    HRESULT STDMETHODCALLTYPE TestCrst(VMPTR_Crst vmCrst);
+    HRESULT STDMETHODCALLTYPE TestRWLock(VMPTR_SimpleRWLock vmRWLock);
 #endif
 
 // ============================================================================
@@ -640,202 +644,202 @@ public:
 
 public:
     // Get the full path and file name to the assembly's manifest module.
-    HRESULT GetAssemblyPath(VMPTR_Assembly vmAssembly, IStringHolder * pStrFilename, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE GetAssemblyPath(VMPTR_Assembly vmAssembly, IStringHolder * pStrFilename, OUT BOOL * pResult);
 
-    HRESULT GetAssemblyFromDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Assembly * vmAssembly);
+    HRESULT STDMETHODCALLTYPE GetAssemblyFromDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Assembly * vmAssembly);
 
     // Determines whether the runtime security system has assigned full-trust to this assembly.
-    HRESULT IsAssemblyFullyTrusted(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE IsAssemblyFullyTrusted(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pResult);
 
     // get a type def resolved across modules
-    HRESULT ResolveTypeReference(const TypeRefData * pTypeRefInfo, TypeRefData * pTargetRefInfo);
+    HRESULT STDMETHODCALLTYPE ResolveTypeReference(const TypeRefData * pTypeRefInfo, TypeRefData * pTargetRefInfo);
 
     // Get the full path and file name to the module (if any).
-    HRESULT GetModulePath(VMPTR_Module vmModule, IStringHolder * pStrFilename, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE GetModulePath(VMPTR_Module vmModule, IStringHolder * pStrFilename, OUT BOOL * pResult);
 
     // Implementation of IDacDbiInterface::GetModuleSimpleName
-    HRESULT GetModuleSimpleName(VMPTR_Module vmModule, IStringHolder * pStrFilename);
+    HRESULT STDMETHODCALLTYPE GetModuleSimpleName(VMPTR_Module vmModule, IStringHolder * pStrFilename);
 
     // Implementation of IDacDbiInterface::GetMetadata
-    HRESULT GetMetadata(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer);
+    HRESULT STDMETHODCALLTYPE GetMetadata(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer);
 
     // Implementation of IDacDbiInterface::GetSymbolsBuffer
-    HRESULT GetSymbolsBuffer(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer, OUT SymbolFormat * pSymbolFormat);
+    HRESULT STDMETHODCALLTYPE GetSymbolsBuffer(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer, OUT SymbolFormat * pSymbolFormat);
 
     // Gets properties for a module
-    HRESULT GetModuleData(VMPTR_Module vmModule, OUT ModuleInfo * pData);
+    HRESULT STDMETHODCALLTYPE GetModuleData(VMPTR_Module vmModule, OUT ModuleInfo * pData);
 
     // Gets properties for a domain assembly
-    HRESULT GetDomainAssemblyData(VMPTR_DomainAssembly vmDomainAssembly, OUT DomainAssemblyInfo * pData);
+    HRESULT STDMETHODCALLTYPE GetDomainAssemblyData(VMPTR_DomainAssembly vmDomainAssembly, OUT DomainAssemblyInfo * pData);
 
-    HRESULT GetModuleForDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Module * pModule);
+    HRESULT STDMETHODCALLTYPE GetModuleForDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Module * pModule);
 
     // Yields true if the address is a CLR stub.
-    HRESULT IsTransitionStub(CORDB_ADDRESS address, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE IsTransitionStub(CORDB_ADDRESS address, OUT BOOL * pResult);
 
     // Get the "type" of address.
-    HRESULT GetAddressType(CORDB_ADDRESS address, OUT AddressType * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetAddressType(CORDB_ADDRESS address, OUT AddressType * pRetVal);
 
 
     // Enumerate the appdomains
-    HRESULT EnumerateAppDomains(FP_APPDOMAIN_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
+    HRESULT STDMETHODCALLTYPE EnumerateAppDomains(FP_APPDOMAIN_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
 
     // Enumerate the assemblies in the appdomain.
-    HRESULT EnumerateAssembliesInAppDomain(VMPTR_AppDomain vmAppDomain, FP_ASSEMBLY_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
+    HRESULT STDMETHODCALLTYPE EnumerateAssembliesInAppDomain(VMPTR_AppDomain vmAppDomain, FP_ASSEMBLY_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
 
     // Enumerate the moduels in the given assembly.
-    HRESULT EnumerateModulesInAssembly(VMPTR_DomainAssembly vmAssembly, FP_MODULE_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
+    HRESULT STDMETHODCALLTYPE EnumerateModulesInAssembly(VMPTR_DomainAssembly vmAssembly, FP_MODULE_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
 
     // When stopped at an event, request a synchronization.
-    HRESULT RequestSyncAtEvent();
+    HRESULT STDMETHODCALLTYPE RequestSyncAtEvent();
 
     //sets flag Debugger::m_sendExceptionsOutsideOfJMC on the LS
-    HRESULT SetSendExceptionsOutsideOfJMC(BOOL sendExceptionsOutsideOfJMC);
+    HRESULT STDMETHODCALLTYPE SetSendExceptionsOutsideOfJMC(BOOL sendExceptionsOutsideOfJMC);
 
     // Notify the debuggee that a debugger attach is pending.
-    HRESULT MarkDebuggerAttachPending();
+    HRESULT STDMETHODCALLTYPE MarkDebuggerAttachPending();
 
     // Notify the debuggee that a debugger is attached.
-    HRESULT MarkDebuggerAttached(BOOL fAttached);
+    HRESULT STDMETHODCALLTYPE MarkDebuggerAttached(BOOL fAttached);
 
     // Enumerate connections in the process.
     void EnumerateConnections(FP_CONNECTION_CALLBACK fpCallback, void * pUserData);
 
-    HRESULT EnumerateThreads(FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
+    HRESULT STDMETHODCALLTYPE EnumerateThreads(FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
 
-    HRESULT IsThreadMarkedDead(VMPTR_Thread vmThread, OUT bool * pResult);
+    HRESULT STDMETHODCALLTYPE IsThreadMarkedDead(VMPTR_Thread vmThread, OUT BOOL * pResult);
 
     // Return the handle of the specified thread.
-    HRESULT GetThreadHandle(VMPTR_Thread vmThread, OUT HANDLE * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetThreadHandle(VMPTR_Thread vmThread, OUT HANDLE * pRetVal);
 
     // Return the object handle for the managed Thread object corresponding to the specified thread.
-    HRESULT GetThreadObject(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetThreadObject(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal);
 
     // Get the alocated bytes for this thread.
-    HRESULT GetThreadAllocInfo(VMPTR_Thread vmThread, DacThreadAllocInfo* threadAllocInfo);
+    HRESULT STDMETHODCALLTYPE GetThreadAllocInfo(VMPTR_Thread vmThread, DacThreadAllocInfo* threadAllocInfo);
 
     // Set and reset the TSNC_DebuggerUserSuspend bit on the state of the specified thread
     // according to the CorDebugThreadState.
-    HRESULT SetDebugState(VMPTR_Thread vmThread, CorDebugThreadState debugState);
+    HRESULT STDMETHODCALLTYPE SetDebugState(VMPTR_Thread vmThread, CorDebugThreadState debugState);
 
     // Returns TRUE if there is a current exception which is unhandled
-    HRESULT HasUnhandledException(VMPTR_Thread vmThread, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE HasUnhandledException(VMPTR_Thread vmThread, OUT BOOL * pResult);
 
     // Return the user state of the specified thread.
-    HRESULT GetUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal);
 
     // Returns the user state of the specified thread except for USER_UNSAFE_POINT.
-    HRESULT GetPartialUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetPartialUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal);
 
     // Return the connection ID of the specified thread.
-    HRESULT GetConnectionID(VMPTR_Thread vmThread, OUT CONNID * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetConnectionID(VMPTR_Thread vmThread, OUT CONNID * pRetVal);
 
     // Return the task ID of the specified thread.
-    HRESULT GetTaskID(VMPTR_Thread vmThread, OUT TASKID * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetTaskID(VMPTR_Thread vmThread, OUT TASKID * pRetVal);
 
     // Return the OS thread ID of the specified thread
-    HRESULT TryGetVolatileOSThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal);
+    HRESULT STDMETHODCALLTYPE TryGetVolatileOSThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal);
 
     // Return the unique thread ID of the specified thread.
-    HRESULT GetUniqueThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetUniqueThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal);
 
     // Return the object handle to the managed Exception object of the current exception
     // on the specified thread.  The return value could be NULL if there is no current exception.
-    HRESULT GetCurrentException(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetCurrentException(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal);
 
     // Return the object handle to the managed object for a given CCW pointer.
-    HRESULT GetObjectForCCW(CORDB_ADDRESS ccwPtr, OUT VMPTR_OBJECTHANDLE * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetObjectForCCW(CORDB_ADDRESS ccwPtr, OUT VMPTR_OBJECTHANDLE * pRetVal);
 
     // Return the object handle to the managed CustomNotification object of the current notification
     // on the specified thread.  The return value could be NULL if there is no current notification.
     // This will return non-null if and only if we are currently inside a CustomNotification Callback
     // (or a dump was generated while in this callback)
-    HRESULT GetCurrentCustomDebuggerNotification(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetCurrentCustomDebuggerNotification(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal);
 
     // Return the current appdomain
-    HRESULT GetCurrentAppDomain(OUT VMPTR_AppDomain * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetCurrentAppDomain(OUT VMPTR_AppDomain * pRetVal);
 
     // Given an assembly ref token and metadata scope (via the DomainAssembly), resolve the assembly.
-    HRESULT ResolveAssembly(VMPTR_DomainAssembly vmScope, mdToken tkAssemblyRef, OUT VMPTR_DomainAssembly * pRetVal);
+    HRESULT STDMETHODCALLTYPE ResolveAssembly(VMPTR_DomainAssembly vmScope, mdToken tkAssemblyRef, OUT VMPTR_DomainAssembly * pRetVal);
 
 
     // Hijack the thread
-    HRESULT Hijack(VMPTR_Thread vmThread, ULONG32 dwThreadId, const EXCEPTION_RECORD * pRecord, T_CONTEXT * pOriginalContext, ULONG32 cbSizeContext, EHijackReason::EHijackReason reason, void * pUserData, CORDB_ADDRESS * pRemoteContextAddr);
+    HRESULT STDMETHODCALLTYPE Hijack(VMPTR_Thread vmThread, ULONG32 dwThreadId, const EXCEPTION_RECORD * pRecord, T_CONTEXT * pOriginalContext, ULONG32 cbSizeContext, EHijackReason::EHijackReason reason, void * pUserData, CORDB_ADDRESS * pRemoteContextAddr);
 
     // Return the filter CONTEXT on the LS.
-    HRESULT GetManagedStoppedContext(VMPTR_Thread vmThread, OUT VMPTR_CONTEXT * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetManagedStoppedContext(VMPTR_Thread vmThread, OUT VMPTR_CONTEXT * pRetVal);
 
     // Create and return a stackwalker on the specified thread.
-    HRESULT CreateStackWalk(VMPTR_Thread vmThread, DT_CONTEXT * pInternalContextBuffer, OUT StackWalkHandle * ppSFIHandle);
+    HRESULT STDMETHODCALLTYPE CreateStackWalk(VMPTR_Thread vmThread, DT_CONTEXT * pInternalContextBuffer, OUT StackWalkHandle * ppSFIHandle);
 
     // Delete the stackwalk object
-    HRESULT DeleteStackWalk(StackWalkHandle ppSFIHandle);
+    HRESULT STDMETHODCALLTYPE DeleteStackWalk(StackWalkHandle ppSFIHandle);
 
     // Get the CONTEXT of the current frame at which the stackwalker is stopped.
-    HRESULT GetStackWalkCurrentContext(StackWalkHandle pSFIHandle, DT_CONTEXT * pContext);
+    HRESULT STDMETHODCALLTYPE GetStackWalkCurrentContext(StackWalkHandle pSFIHandle, DT_CONTEXT * pContext);
 
     void GetStackWalkCurrentContext(StackFrameIterator * pIter, DT_CONTEXT * pContext);
 
     // Set the stackwalker to the specified CONTEXT.
-    HRESULT SetStackWalkCurrentContext(VMPTR_Thread vmThread, StackWalkHandle pSFIHandle, CorDebugSetContextFlag flag, DT_CONTEXT * pContext);
+    HRESULT STDMETHODCALLTYPE SetStackWalkCurrentContext(VMPTR_Thread vmThread, StackWalkHandle pSFIHandle, CorDebugSetContextFlag flag, DT_CONTEXT * pContext);
 
     // Unwind the stackwalker to the next frame.
-    HRESULT UnwindStackWalkFrame(StackWalkHandle pSFIHandle, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE UnwindStackWalkFrame(StackWalkHandle pSFIHandle, OUT BOOL * pResult);
 
-    HRESULT CheckContext(VMPTR_Thread       vmThread,
+    HRESULT STDMETHODCALLTYPE CheckContext(VMPTR_Thread       vmThread,
                          const DT_CONTEXT * pContext);
 
     // Retrieve information about the current frame from the stackwalker.
-    HRESULT GetStackWalkCurrentFrameInfo(StackWalkHandle pSFIHandle, OPTIONAL DebuggerIPCE_STRData * pFrameData, OUT FrameType * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetStackWalkCurrentFrameInfo(StackWalkHandle pSFIHandle, OPTIONAL DebuggerIPCE_STRData * pFrameData, OUT FrameType * pRetVal);
 
     // Return the number of internal frames on the specified thread.
-    HRESULT GetCountOfInternalFrames(VMPTR_Thread vmThread, OUT ULONG32 * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetCountOfInternalFrames(VMPTR_Thread vmThread, OUT ULONG32 * pRetVal);
 
     // Enumerate the internal frames on the specified thread and invoke the provided callback on each of them.
-    HRESULT EnumerateInternalFrames(VMPTR_Thread vmThread, FP_INTERNAL_FRAME_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
+    HRESULT STDMETHODCALLTYPE EnumerateInternalFrames(VMPTR_Thread vmThread, FP_INTERNAL_FRAME_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData);
 
     // Given the FramePointer of the parent frame and the FramePointer of the current frame,
     // check if the current frame is the parent frame.
-    HRESULT IsMatchingParentFrame(FramePointer fpToCheck, FramePointer fpParent, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE IsMatchingParentFrame(FramePointer fpToCheck, FramePointer fpParent, OUT BOOL * pResult);
 
     // Return the stack parameter size of the given method.
-    HRESULT GetStackParameterSize(CORDB_ADDRESS controlPC, OUT ULONG32 * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetStackParameterSize(CORDB_ADDRESS controlPC, OUT ULONG32 * pRetVal);
 
     // Return the stack parameter size of the given method.
     ULONG32 GetStackParameterSize(EECodeInfo * pCodeInfo);
 
     // Return the FramePointer of the current frame at which the stackwalker is stopped.
-    HRESULT GetFramePointer(StackWalkHandle pSFIHandle, OUT FramePointer * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetFramePointer(StackWalkHandle pSFIHandle, OUT FramePointer * pRetVal);
 
     FramePointer GetFramePointerWorker(StackFrameIterator * pIter);
 
     // Return TRUE if the specified CONTEXT is the CONTEXT of the leaf frame.
     // @dbgtodo  filter CONTEXT - Currently we check for the filter CONTEXT first.
-    HRESULT IsLeafFrame(VMPTR_Thread vmThread, const DT_CONTEXT * pContext, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE IsLeafFrame(VMPTR_Thread vmThread, const DT_CONTEXT * pContext, OUT BOOL * pResult);
 
     // DacDbi API: Get the context for a particular thread of the target process
-    HRESULT GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContextBuffer);
+    HRESULT STDMETHODCALLTYPE GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContextBuffer);
 
     // This is a simple helper function to convert a CONTEXT to a DebuggerREGDISPLAY.  We need to do this
     // inside DDI because the RS has no notion of REGDISPLAY.
-    HRESULT ConvertContextToDebuggerRegDisplay(const DT_CONTEXT * pInContext, DebuggerREGDISPLAY * pOutDRD, BOOL fActive);
+    HRESULT STDMETHODCALLTYPE ConvertContextToDebuggerRegDisplay(const DT_CONTEXT * pInContext, DebuggerREGDISPLAY * pOutDRD, BOOL fActive);
 
     // Check if the given method is a DiagnosticHidden or an LCG method.
-    HRESULT IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc, OUT DynamicMethodType * pRetVal);
+    HRESULT STDMETHODCALLTYPE IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc, OUT DynamicMethodType * pRetVal);
 
     // Return a TargetBuffer for the raw vararg signature.
-    HRESULT GetVarArgSig(CORDB_ADDRESS VASigCookieAddr, OUT CORDB_ADDRESS * pArgBase, OUT TargetBuffer * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetVarArgSig(CORDB_ADDRESS VASigCookieAddr, OUT CORDB_ADDRESS * pArgBase, OUT TargetBuffer * pRetVal);
 
     // returns TRUE if the type requires 8-byte alignment
-    HRESULT RequiresAlign8(VMPTR_TypeHandle thExact, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE RequiresAlign8(VMPTR_TypeHandle thExact, OUT BOOL * pResult);
 
     // Resolve the raw generics token to the real generics type token.  The resolution is based on the
     // given index.
-    HRESULT ResolveExactGenericArgsToken(DWORD dwExactGenericArgsTokenIndex, GENERICS_TYPE_TOKEN rawToken, OUT GENERICS_TYPE_TOKEN * pRetVal);
+    HRESULT STDMETHODCALLTYPE ResolveExactGenericArgsToken(DWORD dwExactGenericArgsTokenIndex, GENERICS_TYPE_TOKEN rawToken, OUT GENERICS_TYPE_TOKEN * pRetVal);
 
     // Returns a bitfield reflecting the managed debugging state at the time of
     // the jit attach.
-    HRESULT GetAttachStateFlags(OUT CLR_DEBUGGING_PROCESS_FLAGS * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetAttachStateFlags(OUT CLR_DEBUGGING_PROCESS_FLAGS * pRetVal);
 
 protected:
     // This class used to be stateless, but we are relaxing the requirements
@@ -892,41 +896,41 @@ protected:
 
     // Get the address of the Debugger control block on the helper thread. Returns
     // NULL if the control block has not been successfully allocated
-    HRESULT GetDebuggerControlBlockAddress(OUT CORDB_ADDRESS * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetDebuggerControlBlockAddress(OUT CORDB_ADDRESS * pRetVal);
 
     // Creates a VMPTR of an Object from a target address
-    HRESULT GetObject(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetObject(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal);
 
     // sets state in the native binder
-    HRESULT EnableNGENPolicy(CorDebugNGENPolicy ePolicy);
+    HRESULT STDMETHODCALLTYPE EnableNGENPolicy(CorDebugNGENPolicy ePolicy);
 
     // Sets the NGEN compiler flags. This restricts NGEN to only use images with certain
     // types of pregenerated code.
-    HRESULT SetNGENCompilerFlags(DWORD dwFlags);
+    HRESULT STDMETHODCALLTYPE SetNGENCompilerFlags(DWORD dwFlags);
 
     // Gets the NGEN compiler flags currently in effect.
-    HRESULT GetNGENCompilerFlags(DWORD *pdwFlags);
+    HRESULT STDMETHODCALLTYPE GetNGENCompilerFlags(DWORD *pdwFlags);
 
     // Creates a VMPTR of an Object from a target address pointing to an OBJECTREF
-    HRESULT GetObjectFromRefPtr(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetObjectFromRefPtr(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal);
 
     // Get the target address from a VMPTR_OBJECTHANDLE, i.e., the handle address
-    HRESULT GetHandleAddressFromVmHandle(VMPTR_OBJECTHANDLE vmHandle, OUT CORDB_ADDRESS * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetHandleAddressFromVmHandle(VMPTR_OBJECTHANDLE vmHandle, OUT CORDB_ADDRESS * pRetVal);
 
     // Gets the target address of an VMPTR of an Object
-    HRESULT GetObjectContents(VMPTR_Object obj, OUT TargetBuffer * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetObjectContents(VMPTR_Object obj, OUT TargetBuffer * pRetVal);
 
     // Create a VMPTR_OBJECTHANDLE from a CORDB_ADDRESS pointing to an object handle
-    HRESULT GetVmObjectHandle(CORDB_ADDRESS handleAddress, OUT VMPTR_OBJECTHANDLE * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetVmObjectHandle(CORDB_ADDRESS handleAddress, OUT VMPTR_OBJECTHANDLE * pRetVal);
 
     // Validate that the VMPTR_OBJECTHANDLE refers to a legitimate managed object
-    HRESULT IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle, OUT BOOL * pResult);
+    HRESULT STDMETHODCALLTYPE IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle, OUT BOOL * pResult);
 
     // if the specified module is a WinRT module then isWinRT will equal TRUE
-    HRESULT IsWinRTModule(VMPTR_Module vmModule, BOOL& isWinRT);
+    HRESULT STDMETHODCALLTYPE IsWinRTModule(VMPTR_Module vmModule, BOOL * pIsWinRT);
 
     // Determines the app domain id for the object referred to by a given VMPTR_OBJECTHANDLE
-    HRESULT GetAppDomainIdFromVmObjectHandle(VMPTR_OBJECTHANDLE vmHandle, OUT ULONG * pRetVal);
+    HRESULT STDMETHODCALLTYPE GetAppDomainIdFromVmObjectHandle(VMPTR_OBJECTHANDLE vmHandle, OUT ULONG * pRetVal);
 
 private:
     bool IsThreadMarkedDeadWorker(Thread * pThread);
@@ -1002,7 +1006,7 @@ private:
 
 public:
     // API for picking up the info needed for a debugger to look up an image from its search path.
-    HRESULT GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly, DWORD & dwTimeStamp, DWORD & dwImageSize, IStringHolder* pStrFilename, OUT bool * pResult);
+    HRESULT STDMETHODCALLTYPE GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly, DWORD * pTimeStamp, DWORD * pImageSize, IStringHolder* pStrFilename, OUT BOOL * pResult);
 };
 
 

--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -109,7 +109,7 @@ T_CONTEXT * GetContextBufferFromHandle(StackWalkHandle pSFIHandle)
 
 
 // Create and return a stackwalker on the specified thread.
-HRESULT DacDbiInterfaceImpl::CreateStackWalk(VMPTR_Thread vmThread, DT_CONTEXT * pInternalContextBuffer, OUT StackWalkHandle * ppSFIHandle)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::CreateStackWalk(VMPTR_Thread vmThread, DT_CONTEXT * pInternalContextBuffer, OUT StackWalkHandle * ppSFIHandle)
 {
     DD_ENTER_MAY_THROW;
 
@@ -144,7 +144,7 @@ HRESULT DacDbiInterfaceImpl::CreateStackWalk(VMPTR_Thread vmThread, DT_CONTEXT *
 }
 
 // Delete the stackwalk object allocated by code:AllocateStackwalk
-HRESULT DacDbiInterfaceImpl::DeleteStackWalk(StackWalkHandle ppSFIHandle)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::DeleteStackWalk(StackWalkHandle ppSFIHandle)
 {
     HRESULT hr = S_OK;
     EX_TRY
@@ -156,7 +156,7 @@ HRESULT DacDbiInterfaceImpl::DeleteStackWalk(StackWalkHandle ppSFIHandle)
 }
 
 // Get the CONTEXT of the current frame at which the stackwalker is stopped.
-HRESULT DacDbiInterfaceImpl::GetStackWalkCurrentContext(StackWalkHandle pSFIHandle, DT_CONTEXT * pContext)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetStackWalkCurrentContext(StackWalkHandle pSFIHandle, DT_CONTEXT * pContext)
 {
     DD_ENTER_MAY_THROW;
 
@@ -189,7 +189,7 @@ void DacDbiInterfaceImpl::GetStackWalkCurrentContext(StackFrameIterator * pIter,
 
 
 // Set the stackwalker to the specified CONTEXT.
-HRESULT DacDbiInterfaceImpl::SetStackWalkCurrentContext(VMPTR_Thread vmThread, StackWalkHandle pSFIHandle, CorDebugSetContextFlag flag, DT_CONTEXT * pContext)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::SetStackWalkCurrentContext(VMPTR_Thread vmThread, StackWalkHandle pSFIHandle, CorDebugSetContextFlag flag, DT_CONTEXT * pContext)
 {
     DD_ENTER_MAY_THROW;
 
@@ -229,7 +229,7 @@ HRESULT DacDbiInterfaceImpl::SetStackWalkCurrentContext(VMPTR_Thread vmThread, S
 
 
 // Unwind the stackwalker to the next frame.
-HRESULT DacDbiInterfaceImpl::UnwindStackWalkFrame(StackWalkHandle pSFIHandle, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::UnwindStackWalkFrame(StackWalkHandle pSFIHandle, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -348,7 +348,7 @@ bool g_fSkipStackCheckInit = false;
 
 // Check whether the specified CONTEXT is valid.  The only check we perform right now is whether the
 // SP in the specified CONTEXT is in the stack range of the thread.
-HRESULT DacDbiInterfaceImpl::CheckContext(VMPTR_Thread       vmThread,
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::CheckContext(VMPTR_Thread       vmThread,
                                           const DT_CONTEXT * pContext)
 {
     DD_ENTER_MAY_THROW;
@@ -386,7 +386,7 @@ HRESULT DacDbiInterfaceImpl::CheckContext(VMPTR_Thread       vmThread,
 }
 
 // Retrieve information about the current frame from the stackwalker.
-HRESULT DacDbiInterfaceImpl::GetStackWalkCurrentFrameInfo(StackWalkHandle pSFIHandle, OPTIONAL DebuggerIPCE_STRData * pFrameData, OUT FrameType * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetStackWalkCurrentFrameInfo(StackWalkHandle pSFIHandle, OPTIONAL DebuggerIPCE_STRData * pFrameData, OUT FrameType * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -491,7 +491,7 @@ HRESULT DacDbiInterfaceImpl::GetStackWalkCurrentFrameInfo(StackWalkHandle pSFIHa
 //    Internal frames are interesting if they are not of type STUBFRAME_NONE.
 //
 
-HRESULT DacDbiInterfaceImpl::GetCountOfInternalFrames(VMPTR_Thread vmThread, OUT ULONG32 * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetCountOfInternalFrames(VMPTR_Thread vmThread, OUT ULONG32 * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -551,7 +551,7 @@ HRESULT DacDbiInterfaceImpl::GetCountOfInternalFrames(VMPTR_Thread vmThread, OUT
 //    pUserData  - user-defined custom data to be passed to the callback
 //
 
-HRESULT DacDbiInterfaceImpl::EnumerateInternalFrames(VMPTR_Thread vmThread, FP_INTERNAL_FRAME_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::EnumerateInternalFrames(VMPTR_Thread vmThread, FP_INTERNAL_FRAME_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData)
 {
     DD_ENTER_MAY_THROW;
 
@@ -674,7 +674,7 @@ HRESULT DacDbiInterfaceImpl::EnumerateInternalFrames(VMPTR_Thread vmThread, FP_I
 
 // Given the FramePointer of the parent frame and the FramePointer of the current frame,
 // check if the current frame is the parent frame.
-HRESULT DacDbiInterfaceImpl::IsMatchingParentFrame(FramePointer fpToCheck, FramePointer fpParent, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsMatchingParentFrame(FramePointer fpToCheck, FramePointer fpParent, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -695,7 +695,7 @@ HRESULT DacDbiInterfaceImpl::IsMatchingParentFrame(FramePointer fpToCheck, Frame
 }
 
 // Return the stack parameter size of the given method.
-HRESULT DacDbiInterfaceImpl::GetStackParameterSize(CORDB_ADDRESS controlPC, OUT ULONG32 * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetStackParameterSize(CORDB_ADDRESS controlPC, OUT ULONG32 * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -713,7 +713,7 @@ HRESULT DacDbiInterfaceImpl::GetStackParameterSize(CORDB_ADDRESS controlPC, OUT 
 }
 
 // Return the FramePointer of the current frame at which the stackwalker is stopped.
-HRESULT DacDbiInterfaceImpl::GetFramePointer(StackWalkHandle pSFIHandle, OUT FramePointer * pRetVal)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::GetFramePointer(StackWalkHandle pSFIHandle, OUT FramePointer * pRetVal)
 {
     DD_ENTER_MAY_THROW;
 
@@ -780,7 +780,7 @@ FramePointer DacDbiInterfaceImpl::GetFramePointerWorker(StackFrameIterator * pIt
 
 // Return TRUE if the specified CONTEXT is the CONTEXT of the leaf frame.
 // @dbgtodo  filter CONTEXT - Currently we check for the filter CONTEXT first.
-HRESULT DacDbiInterfaceImpl::IsLeafFrame(VMPTR_Thread vmThread, const DT_CONTEXT * pContext, OUT BOOL * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsLeafFrame(VMPTR_Thread vmThread, const DT_CONTEXT * pContext, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -800,7 +800,7 @@ HRESULT DacDbiInterfaceImpl::IsLeafFrame(VMPTR_Thread vmThread, const DT_CONTEXT
 
 // This is a simple helper function to convert a CONTEXT to a DebuggerREGDISPLAY.  We need to do this
 // inside DDI because the RS has no notion of REGDISPLAY.
-HRESULT DacDbiInterfaceImpl::ConvertContextToDebuggerRegDisplay(const DT_CONTEXT * pInContext, DebuggerREGDISPLAY * pOutDRD, BOOL fActive)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::ConvertContextToDebuggerRegDisplay(const DT_CONTEXT * pInContext, DebuggerREGDISPLAY * pOutDRD, BOOL fActive)
 {
     DD_ENTER_MAY_THROW;
 
@@ -1417,7 +1417,7 @@ BOOL DacDbiInterfaceImpl::UnwindRuntimeStackFrame(StackFrameIterator * pIter)
 //    Return true iff TS_SyncSuspended or TS_Hijacked is set on the specified thread.
 //
 
-HRESULT DacDbiInterfaceImpl::IsThreadSuspendedOrHijacked(VMPTR_Thread vmThread, OUT bool * pResult)
+HRESULT STDMETHODCALLTYPE DacDbiInterfaceImpl::IsThreadSuspendedOrHijacked(VMPTR_Thread vmThread, OUT BOOL * pResult)
 {
     DD_ENTER_MAY_THROW;
 
@@ -1429,17 +1429,17 @@ HRESULT DacDbiInterfaceImpl::IsThreadSuspendedOrHijacked(VMPTR_Thread vmThread, 
         Thread::ThreadState ts = pThread->GetSnapshotState();
         if ((ts & Thread::TS_SyncSuspended) != 0)
         {
-            *pResult = true;
+            *pResult = TRUE;
         }
     #ifdef FEATURE_HIJACK
         else if ((ts & Thread::TS_Hijacked) != 0)
         {
-            *pResult = true;
+            *pResult = TRUE;
         }
     #endif
         else
         {
-            *pResult = false;
+            *pResult = FALSE;
         }
     }
     EX_CATCH_HRESULT(hr);

--- a/src/coreclr/debug/di/divalue.cpp
+++ b/src/coreclr/debug/di/divalue.cpp
@@ -2460,7 +2460,7 @@ HRESULT CordbObjectValue::EnumerateExceptionCallStack(ICorDebugExceptionObjectCa
 
     DacDbiArrayList<DacExceptionCallStackData> dacStackFrames;
 
-    IfFailThrow(pDAC->GetStackFramesFromException(vmObj, dacStackFrames));
+    IfFailThrow(pDAC->GetStackFramesFromException(vmObj, &dacStackFrames));
     int stackFramesLength = dacStackFrames.Count();
 
     if (stackFramesLength > 0)

--- a/src/coreclr/debug/di/module.cpp
+++ b/src/coreclr/debug/di/module.cpp
@@ -797,10 +797,10 @@ HRESULT CordbModule::InitPublicMetaDataFromFile(const WCHAR * pszFullPathName,
 
         _ASSERTE(!m_vmPEFile.IsNull());
         // MetaData lookup favors the NGEN image, which is what we want here.
-        bool _mdFileInfoResult;
+        BOOL _mdFileInfoResult;
         IfFailThrow(this->GetProcess()->GetDAC()->GetMetaDataFileInfoFromPEFile(m_vmPEFile,
-                                                                         dwImageTimeStamp,
-                                                                         dwImageSize,
+                                                                         &dwImageTimeStamp,
+                                                                         &dwImageSize,
                                                                          &filePath,
                                                                          &_mdFileInfoResult));
         if (!_mdFileInfoResult)
@@ -1187,10 +1187,10 @@ HRESULT CordbModule::GetName(ULONG32 cchName, ULONG32 *pcchName, _Out_writes_to_
             StringCopyHolder filePath;
 
             _ASSERTE(!m_vmPEFile.IsNull());
-            bool _mdFileInfoResult;
+            BOOL _mdFileInfoResult;
             IfFailThrow(this->GetProcess()->GetDAC()->GetMetaDataFileInfoFromPEFile(m_vmPEFile,
-                                                                             dwImageTimeStamp,
-                                                                             dwImageSize,
+                                                                             &dwImageTimeStamp,
+                                                                             &dwImageSize,
                                                                              &filePath,
                                                                              &_mdFileInfoResult));
             if (_mdFileInfoResult)

--- a/src/coreclr/debug/di/process.cpp
+++ b/src/coreclr/debug/di/process.cpp
@@ -416,8 +416,8 @@ IMDInternalImport * CordbProcess::LookupMetaDataFromDebugger(
     IMDInternalImport * pMDII = NULL;
 
     // First, see if the debugger can locate the exact metadata we want.
-    bool _metaDataFileInfoResult;
-    IfFailThrow(this->GetDAC()->GetMetaDataFileInfoFromPEFile(vmPEAssembly, dwImageTimeStamp, dwImageSize, &filePath, &_metaDataFileInfoResult));
+    BOOL _metaDataFileInfoResult;
+    IfFailThrow(this->GetDAC()->GetMetaDataFileInfoFromPEFile(vmPEAssembly, &dwImageTimeStamp, &dwImageSize, &filePath, &_metaDataFileInfoResult));
     if (_metaDataFileInfoResult)
     {
         _ASSERTE(filePath.IsSet());
@@ -1626,7 +1626,7 @@ void CordbProcess::FreeDac()
 
     if (m_pDacPrimitives != NULL)
     {
-        m_pDacPrimitives->Destroy();
+        m_pDacPrimitives->Release();
         m_pDacPrimitives = NULL;
     }
 
@@ -2195,6 +2195,14 @@ HRESULT CordbProcess::QueryInterface(REFIID id, void **pInterface)
     {
         *pInterface = static_cast<ICorDebugProcess12*>(this);
     }
+    else if (id == IID_IDacDbiAllocator)
+    {
+        *pInterface = static_cast<IDacDbiInterface::IAllocator*>(this);
+    }
+    else if (id == IID_IDacDbiMetaDataLookup)
+    {
+        *pInterface = static_cast<IDacDbiInterface::IMetaDataLookup*>(this);
+    }
     else if (id == IID_IUnknown)
     {
         *pInterface = static_cast<IUnknown*>(static_cast<ICorDebugProcess*>(this));
@@ -2250,7 +2258,7 @@ HRESULT CordbProcess::EnumerateHeap(ICorDebugHeapEnum **ppObjects)
 
     EX_TRY
     {
-        bool gcValid;
+        BOOL gcValid;
         IfFailThrow(m_pDacPrimitives->AreGCStructuresValid(&gcValid));
         if (gcValid)
         {
@@ -2333,7 +2341,7 @@ HRESULT CordbProcess::GetObjectInternal(CORDB_ADDRESS addr, ICorDebugObjectValue
 
     EX_TRY
     {
-        bool validObj;
+        BOOL validObj;
         IfFailThrow(m_pDacPrimitives->IsValidObject(addr, &validObj));
         if (!validObj)
         {
@@ -2601,7 +2609,7 @@ COM_METHOD CordbProcess::GetAsyncStack(CORDB_ADDRESS continuationAddress, ICorDe
 
     EX_TRY
     {
-        bool validObj;
+        BOOL validObj;
         IfFailThrow(m_pDacPrimitives->IsValidObject(continuationAddress, &validObj));
         if (!validObj)
         {
@@ -2637,7 +2645,7 @@ HRESULT CordbProcess::GetTypeForObject(CORDB_ADDRESS addr, CordbType **ppType, C
     VMPTR_DomainAssembly domainAssembly;
 
     HRESULT hr = E_FAIL;
-    bool _appDomainResult;
+    BOOL _appDomainResult;
     IfFailThrow(GetDAC()->GetAppDomainForObject(addr, &appDomain, &mod, &domainAssembly, &_appDomainResult));
     if (_appDomainResult)
     {
@@ -14579,7 +14587,7 @@ void CordbWin32EventThread::AttachProcess()
     EX_TRY
     {
         // Don't allow attach if any metadata/IL updates have been applied
-        bool _metadataUpdatesApplied;
+        BOOL _metadataUpdatesApplied;
         IfFailThrow(pProcess->GetDAC()->MetadataUpdatesApplied(&_metadataUpdatesApplied));
         if (_metadataUpdatesApplied)
         {
@@ -15754,7 +15762,7 @@ bool CordbProcess::IsThreadSuspendedOrHijacked(ICorDebugThread * pICorDebugThrea
     PUBLIC_REENTRANT_API_ENTRY_FOR_SHIM(this);
 
     CordbThread * pCordbThread = static_cast<CordbThread *> (pICorDebugThread);
-    bool _isSuspendedOrHijacked;
+    BOOL _isSuspendedOrHijacked;
     IfFailThrow(GetDAC()->IsThreadSuspendedOrHijacked(pCordbThread->m_vmThreadToken, &_isSuspendedOrHijacked));
     return _isSuspendedOrHijacked;
 }

--- a/src/coreclr/debug/di/rspriv.h
+++ b/src/coreclr/debug/di/rspriv.h
@@ -117,7 +117,7 @@ class CordbEval;
 class RSLock;
 class NeuterList;
 
-class IDacDbiInterface;
+struct IDacDbiInterface;
 
 #if defined(FEATURE_DBGIPC_TRANSPORT_DI)
 class DbgTransportTarget;

--- a/src/coreclr/debug/di/rsthread.cpp
+++ b/src/coreclr/debug/di/rsthread.cpp
@@ -912,9 +912,9 @@ bool CordbThread::IsThreadWaitingOrSleeping()
 //
 bool CordbThread::IsThreadDead()
 {
-    bool _isDead;
+    BOOL _isDead;
     IfFailThrow(GetProcess()->GetDAC()->IsThreadMarkedDead(m_vmThreadToken, &_isDead));
-    return _isDead;
+    return _isDead != FALSE;
 }
 
 // Helper to return CORDBG_E_BAD_THREAD_STATE if IsThreadDead

--- a/src/coreclr/debug/di/rstype.cpp
+++ b/src/coreclr/debug/di/rstype.cpp
@@ -1569,7 +1569,7 @@ HRESULT CordbType::InitInstantiationTypeHandle(BOOL fForceInit)
         {
             // Get the TypeHandle based on the type data
             RSLockHolder lockHolder(GetProcess()->GetProcessLock());
-            hr = pProcess->GetDAC()->GetExactTypeHandle(&typeData, &argInfo, m_typeHandleExact);
+            hr = pProcess->GetDAC()->GetExactTypeHandle(&typeData, &argInfo, &m_typeHandleExact);
         }
     }
     EX_CATCH_HRESULT(hr);

--- a/src/coreclr/debug/inc/dacdbiinterface.h
+++ b/src/coreclr/debug/inc/dacdbiinterface.h
@@ -163,7 +163,10 @@ const DWORD kCurrentDbiVersionFormat = 1;
 //
 //
 //-----------------------------------------------------------------------------
-class IDacDbiInterface
+
+// {DB505C1B-A327-4A46-8C32-AF55A56F8E09}
+MIDL_INTERFACE("DB505C1B-A327-4A46-8C32-AF55A56F8E09")
+IDacDbiInterface : public IUnknown
 {
 public:
     class IStringHolder;
@@ -187,8 +190,7 @@ public:
     // Notes:
     //    THIS MUST BE THE FIRST API ON THE INTERFACE!
     //
-    virtual
-    HRESULT CheckDbiVersion(const DbiVersion * pVersion) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CheckDbiVersion(const DbiVersion * pVersion) = 0;
 
     //
     // Flush the DAC cache. This should be called when target memory changes.
@@ -200,10 +202,9 @@ public:
     // Notes:
     //    If this fails, the interface is in an undefined state.
     //    This must be called anytime target memory changes, else all other functions
-    //    (besides Destroy) may yield out-of-date or semantically incorrect results.
+    //    (besides Release) may yield out-of-date or semantically incorrect results.
     //
-    virtual
-    HRESULT FlushCache() = 0;
+    virtual HRESULT STDMETHODCALLTYPE FlushCache() = 0;
 
     //
     // Control DAC's checking of the target's consistency. Specifically, if this is disabled then
@@ -226,19 +227,7 @@ public:
     //   consistency failures exceptions (this is independent from asserts - there are legitimate
     //   scenarios for all 4 combinations).
     //
-    virtual HRESULT DacSetTargetConsistencyChecks(bool fEnableAsserts) = 0;
-
-    //
-    // Destroy the interface object. The client should call this when it's done
-    // with the IDacDbiInterface to free up any resources.
-    //
-    // Return Value:
-    //    S_OK on success; otherwise, an appropriate failure HRESULT.
-    //
-    // Notes:
-    //    The client should not call anything else on this interface after Destroy.
-    //
-    virtual HRESULT Destroy() = 0;
+    virtual HRESULT STDMETHODCALLTYPE DacSetTargetConsistencyChecks(BOOL fEnableAsserts) = 0;
 
     //-----------------------------------------------------------------------------
     // General purpose target inspection functions
@@ -258,7 +247,7 @@ public:
     //   If the left-side is started up, then data is ready. (Although data may be temporarily inconsistent,
     //   see DataSafe). We may still get a Startup Exception in these cases, but it can be ignored.
     //
-    virtual HRESULT IsLeftSideInitialized(OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsLeftSideInitialized(OUT BOOL * pResult) = 0;
 
 
     //
@@ -278,7 +267,7 @@ public:
     //   An AppDomainId is unique for the lifetime of the VM.
     //   This is the inverse function of GetAppDomainId().
     //
-    virtual HRESULT GetAppDomainFromId(ULONG appdomainId, OUT VMPTR_AppDomain * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetAppDomainFromId(ULONG appdomainId, OUT VMPTR_AppDomain * pRetVal) = 0;
 
 
     //
@@ -294,7 +283,7 @@ public:
     // Notes:
     //   An AppDomainId is unique for the lifetime of the VM. It is non-zero.
     //
-    virtual HRESULT GetAppDomainId(VMPTR_AppDomain vmAppDomain, OUT ULONG * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetAppDomainId(VMPTR_AppDomain vmAppDomain, OUT ULONG * pRetVal) = 0;
 
     //
     // Get the managed AppDomain object for an AppDomain.
@@ -310,9 +299,9 @@ public:
     //   The AppDomain managed object is lazily constructed on the AppDomain the first time
     //   it is requested. It may be NULL.
     //
-    virtual HRESULT GetAppDomainObject(VMPTR_AppDomain vmAppDomain, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetAppDomainObject(VMPTR_AppDomain vmAppDomain, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
-    virtual HRESULT GetAssemblyFromDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Assembly * vmAssembly) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetAssemblyFromDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Assembly * vmAssembly) = 0;
 
     //
     // Determines whether the runtime security system has assigned full-trust to this assembly.
@@ -328,7 +317,7 @@ public:
     //      Of course trusted malicious code in the process could always cause this API to lie.  However,
     //      an assembly loaded without full-trust should have no way of causing this API to return true.
     //
-    virtual HRESULT IsAssemblyFullyTrusted(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsAssemblyFullyTrusted(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pResult) = 0;
 
 
     //
@@ -347,7 +336,7 @@ public:
     //    so callers should be prepared to listen for name-change events and requery.
     //    AD names are specified by the user.
     //
-    virtual HRESULT GetAppDomainFullName(VMPTR_AppDomain vmAppDomain, IStringHolder * pStrName) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetAppDomainFullName(VMPTR_AppDomain vmAppDomain, IStringHolder * pStrName) = 0;
 
 
     //
@@ -402,7 +391,7 @@ public:
     //   relationship to the filename, and it's not necessarily the metadata name.
     //   Do not use the simple name for anything other than as a pretty string to give the an end user.
     //
-    virtual HRESULT GetModuleSimpleName(VMPTR_Module vmModule, IStringHolder * pStrFilename) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetModuleSimpleName(VMPTR_Module vmModule, IStringHolder * pStrFilename) = 0;
 
 
     //
@@ -428,7 +417,7 @@ public:
     //     which will not be saved to disk) there is no filename.  In that case this API
     //     returns an empty string.
     //
-    virtual HRESULT GetAssemblyPath(VMPTR_Assembly vmAssembly, IStringHolder * pStrFilename, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetAssemblyPath(VMPTR_Assembly vmAssembly, IStringHolder * pStrFilename, OUT BOOL * pResult) = 0;
 
 
     // get a type def resolved across modules
@@ -437,7 +426,7 @@ public:
     //     output: pTargetRefInfo - domain file and type def from the referenced type (this may
     //                              come from a module other than the referencing module)
     // Note: returns an appropriate failure HRESULT on error
-    virtual HRESULT ResolveTypeReference(const TypeRefData * pTypeRefInfo, TypeRefData * pTargetRefInfo) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ResolveTypeReference(const TypeRefData * pTypeRefInfo, TypeRefData * pTargetRefInfo) = 0;
     //
     // Get the full path and file name to the module (if any).
     //
@@ -462,7 +451,7 @@ public:
     //     We intentionally don't use the function name "GetModuleFileName" here because
     //     winbase #defines that token (along with many others) to have an A or W suffix.
     //
-    virtual HRESULT GetModulePath(VMPTR_Module vmModule, IStringHolder * pStrFilename, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetModulePath(VMPTR_Module vmModule, IStringHolder * pStrFilename, OUT BOOL * pResult) = 0;
 
     // Get the metadata for the target module
     //
@@ -497,7 +486,7 @@ public:
     //    scenario with missing memory. Client should use alternative metadata location techniques (such as
     //    an ImagePath to locate the original image and then pulling metadata from that file).
     //
-    virtual HRESULT GetMetadata(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetMetadata(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer) = 0;
 
 
     // Definitions for possible symbol formats
@@ -530,7 +519,7 @@ public:
     //   - hosted modules where the host (such as SQL) store the PDB.
     //
     //   In all cases, this can commonly fail. Executable code does not need to have a PDB.
-    virtual HRESULT GetSymbolsBuffer(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer, OUT SymbolFormat * pSymbolFormat) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetSymbolsBuffer(VMPTR_Module vmModule, OUT TargetBuffer * pTargetBuffer, OUT SymbolFormat * pSymbolFormat) = 0;
 
     //
     // Get properties for a module
@@ -542,7 +531,7 @@ public:
     // Notes:
     //    See definition of DomainAssemblyInfo for more details about what properties
     //    this gives back.
-    virtual HRESULT GetModuleData(VMPTR_Module vmModule, OUT ModuleInfo * pData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetModuleData(VMPTR_Module vmModule, OUT ModuleInfo * pData) = 0;
 
 
     //
@@ -555,9 +544,9 @@ public:
     // Notes:
     //    See definition of DomainAssemblyInfo for more details about what properties
     //    this gives back.
-    virtual HRESULT GetDomainAssemblyData(VMPTR_DomainAssembly vmDomainAssembly, OUT DomainAssemblyInfo * pData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetDomainAssemblyData(VMPTR_DomainAssembly vmDomainAssembly, OUT DomainAssemblyInfo * pData) = 0;
 
-    virtual HRESULT GetModuleForDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Module * pModule) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetModuleForDomainAssembly(VMPTR_DomainAssembly vmDomainAssembly, OUT VMPTR_Module * pModule) = 0;
 
     //.........................................................................
     // These methods were the methods that DBI was calling from IXClrData in V2.
@@ -596,7 +585,7 @@ public:
     //    This is provided for V3 compatibility to support Interop-debugging.
     //    This should eventually be deprecated.
     //
-    virtual HRESULT GetAddressType(CORDB_ADDRESS address, OUT AddressType * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetAddressType(CORDB_ADDRESS address, OUT AddressType * pRetVal) = 0;
 
 
     //
@@ -615,7 +604,7 @@ public:
     //    This yields true if the address is claimed by a CLR stub manager, or if the IP is in mscorwks.
     //    Conceptually, This should eventually be merged with GetAddressType().
     //
-    virtual HRESULT IsTransitionStub(CORDB_ADDRESS address, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsTransitionStub(CORDB_ADDRESS address, OUT BOOL * pResult) = 0;
 
     //.........................................................................
     // Get the values of the JIT Optimization and EnC flags.
@@ -634,7 +623,7 @@ public:
     //    ICorDebugCode2::GetCompilerFlags.
     //.........................................................................
 
-    virtual HRESULT GetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pfAllowJITOpts, OUT BOOL * pfEnableEnC) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly, OUT BOOL * pfAllowJITOpts, OUT BOOL * pfEnableEnC) = 0;
 
     //.........................................................................
     // Set the values of the JIT optimization and EnC flags.
@@ -661,8 +650,7 @@ public:
     //    ICorDebugModule::EnableJITDebugging.
     //.........................................................................
 
-    virtual
-    HRESULT SetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly,
+    virtual HRESULT STDMETHODCALLTYPE SetCompilerFlags(VMPTR_DomainAssembly vmDomainAssembly,
                           BOOL             fAllowJitOpts,
                           BOOL             fEnableEnC) = 0;
 
@@ -683,7 +671,7 @@ public:
     //    See enumeration rules for details.
     //
     typedef void (*FP_APPDOMAIN_ENUMERATION_CALLBACK)(VMPTR_AppDomain vmAppDomain, CALLBACK_DATA pUserData);
-    virtual HRESULT EnumerateAppDomains(FP_APPDOMAIN_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE EnumerateAppDomains(FP_APPDOMAIN_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
 
 
     //
@@ -712,7 +700,7 @@ public:
     //
 
     typedef void (*FP_ASSEMBLY_ENUMERATION_CALLBACK)(VMPTR_DomainAssembly vmDomainAssembly, CALLBACK_DATA pUserData);
-    virtual HRESULT EnumerateAssembliesInAppDomain(VMPTR_AppDomain vmAppDomain, FP_ASSEMBLY_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE EnumerateAssembliesInAppDomain(VMPTR_AppDomain vmAppDomain, FP_ASSEMBLY_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
 
 
 
@@ -741,7 +729,7 @@ public:
     //    - Resource modules (which have no code or metadata)
     //    - Inspection-only modules. These are viewed as pure data from the debugger's perspective.
     //
-    virtual HRESULT EnumerateModulesInAssembly(VMPTR_DomainAssembly vmAssembly, FP_MODULE_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE EnumerateModulesInAssembly(VMPTR_DomainAssembly vmAssembly, FP_MODULE_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
 
 
 
@@ -764,7 +752,7 @@ public:
     //
     //    This is also like a precursor to "AsyncBreakAllOtherThreads"
     //
-    virtual HRESULT RequestSyncAtEvent() = 0;
+    virtual HRESULT STDMETHODCALLTYPE RequestSyncAtEvent() = 0;
 
     // Sets a flag inside LS.Debugger that indicates that
     // 1. all "first chance exception" events should not be sent to the debugger
@@ -777,8 +765,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // Note: This call is used by ICorDebugProcess8.EnableExceptionCallbacksOutsideOfMyCode.
-    virtual
-    HRESULT SetSendExceptionsOutsideOfJMC(BOOL sendExceptionsOutsideOfJMC) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetSendExceptionsOutsideOfJMC(BOOL sendExceptionsOutsideOfJMC) = 0;
 
     //
     // Notify the debuggee that a debugger atach is pending.
@@ -794,7 +781,7 @@ public:
     //     This doesn't do anything else (eg, no fake events).
     //
     //     @dbgtodo- still an open Feature-Crew decision how this is exposed publicly.
-    virtual HRESULT MarkDebuggerAttachPending() = 0;
+    virtual HRESULT STDMETHODCALLTYPE MarkDebuggerAttachPending() = 0;
 
     //
     // Notify the debuggee that a debugger is attached / detached.
@@ -811,7 +798,7 @@ public:
     //     This lets the V3 codepaths invade the LS to subscribe to events.
     //
     //     @dbgtodo- still an open Feature-Crew decision how this is exposed publicly.
-    virtual HRESULT MarkDebuggerAttached(BOOL fAttached) = 0;
+    virtual HRESULT STDMETHODCALLTYPE MarkDebuggerAttached(BOOL fAttached) = 0;
 
 
 
@@ -856,7 +843,7 @@ public:
     //    stackwalker that the GC uses. It must be in cooperative mode, and push a Frame on the
     //    frame chain to protect the managed frames it hijacked from before it goes to preemptive mode.
 
-    virtual HRESULT Hijack(VMPTR_Thread vmThread, ULONG32 dwThreadId, const EXCEPTION_RECORD * pRecord, T_CONTEXT * pOriginalContext, ULONG32 cbSizeContext, EHijackReason::EHijackReason reason, void * pUserData, CORDB_ADDRESS * pRemoteContextAddr) = 0;
+    virtual HRESULT STDMETHODCALLTYPE Hijack(VMPTR_Thread vmThread, ULONG32 dwThreadId, const EXCEPTION_RECORD * pRecord, T_CONTEXT * pOriginalContext, ULONG32 cbSizeContext, EHijackReason::EHijackReason reason, void * pUserData, CORDB_ADDRESS * pRemoteContextAddr) = 0;
 
 
     //
@@ -901,7 +888,7 @@ public:
     // Callback invoked for each thread.
     typedef void (*FP_THREAD_ENUMERATION_CALLBACK)(VMPTR_Thread vmThread, CALLBACK_DATA pUserData);
 
-    virtual HRESULT EnumerateThreads(FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE EnumerateThreads(FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
 
 
     // Check if the thread is dead
@@ -957,7 +944,7 @@ public:
     //    Whether a thread is dead can be inferred from the ICorDebug API. However, we have this
     //    on DacDbi to ensure that this definition is consistent with the other DacDbi methods,
     //    especially the enumeration and discovery rules.
-    virtual HRESULT IsThreadMarkedDead(VMPTR_Thread vmThread, OUT bool * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsThreadMarkedDead(VMPTR_Thread vmThread, OUT BOOL * pResult) = 0;
 
 
     //
@@ -972,7 +959,7 @@ public:
     //
     // @dbgtodo- this should go away in V3. This is useless on a dump.
 
-    virtual HRESULT GetThreadHandle(VMPTR_Thread vmThread, OUT HANDLE * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetThreadHandle(VMPTR_Thread vmThread, OUT HANDLE * pRetVal) = 0;
 
     //
     // Get the object handle for the managed Thread object corresponding to the specified thread.
@@ -987,7 +974,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
-    virtual HRESULT GetThreadObject(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetThreadObject(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
     //
     // Get the allocation info corresponding to the specified thread.
@@ -997,7 +984,7 @@ public:
     //    threadAllocInfo - the allocated bytes from SOH and UOH so far on this thread
     //
 
-    virtual HRESULT GetThreadAllocInfo(VMPTR_Thread vmThread, DacThreadAllocInfo* threadAllocInfo) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetThreadAllocInfo(VMPTR_Thread vmThread, DacThreadAllocInfo* threadAllocInfo) = 0;
 
     //
     // Set and reset the TSNC_DebuggerUserSuspend bit on the state of the specified thread
@@ -1008,7 +995,7 @@ public:
     //    debugState - the desired CorDebugThreadState
     //
 
-    virtual HRESULT SetDebugState(VMPTR_Thread vmThread, CorDebugThreadState debugState) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetDebugState(VMPTR_Thread vmThread, CorDebugThreadState debugState) = 0;
 
     //
     // Check whether this thread has an unhandled exception
@@ -1020,7 +1007,7 @@ public:
     // Return Value:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
-    virtual HRESULT HasUnhandledException(VMPTR_Thread vmThread, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE HasUnhandledException(VMPTR_Thread vmThread, OUT BOOL * pResult) = 0;
 
     //
     // Get the user state of the specified thread.  Most of the state are derived from
@@ -1035,7 +1022,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
-    virtual HRESULT GetUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal) = 0;
 
 
     //
@@ -1054,7 +1041,7 @@ public:
     // Return Value:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
-    virtual HRESULT GetPartialUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetPartialUserState(VMPTR_Thread vmThread, OUT CorDebugUserState * pRetVal) = 0;
 
 
     //
@@ -1068,7 +1055,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
-    virtual HRESULT GetConnectionID(VMPTR_Thread vmThread, OUT CONNID * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetConnectionID(VMPTR_Thread vmThread, OUT CONNID * pRetVal) = 0;
 
     //
     // Get the task ID of the specified thread.
@@ -1081,7 +1068,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
-    virtual HRESULT GetTaskID(VMPTR_Thread vmThread, OUT TASKID * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetTaskID(VMPTR_Thread vmThread, OUT TASKID * pRetVal) = 0;
 
     //
     // Get the OS thread ID of the specified thread
@@ -1094,7 +1081,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
-    virtual HRESULT TryGetVolatileOSThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE TryGetVolatileOSThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal) = 0;
 
     //
     // Get the unique thread ID of the specified thread. The value used for the thread ID changes
@@ -1112,7 +1099,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
-    virtual HRESULT GetUniqueThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetUniqueThreadID(VMPTR_Thread vmThread, OUT DWORD * pRetVal) = 0;
 
     //
     // Get the object handle to the managed Exception object of the current exception
@@ -1129,7 +1116,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
-    virtual HRESULT GetCurrentException(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCurrentException(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
     //
     // Get the object handle to the managed object for a given CCW pointer.
@@ -1142,7 +1129,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
-    virtual HRESULT GetObjectForCCW(CORDB_ADDRESS ccwPtr, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetObjectForCCW(CORDB_ADDRESS ccwPtr, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
     //
     // Get the object handle to the managed CustomNotification object of the current notification
@@ -1158,7 +1145,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
-    virtual HRESULT GetCurrentCustomDebuggerNotification(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCurrentCustomDebuggerNotification(VMPTR_Thread vmThread, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
 
     //
@@ -1171,7 +1158,7 @@ public:
     //    This function returns a failure HRESULT if the current appdomain is NULL for whatever reason.
     //
 
-    virtual HRESULT GetCurrentAppDomain(OUT VMPTR_AppDomain * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCurrentAppDomain(OUT VMPTR_AppDomain * pRetVal) = 0;
 
 
     //
@@ -1194,7 +1181,7 @@ public:
     //
     //    The debugger can't duplicate this policy with 100% accuracy, and
     //    so we need DAC to lookup the assembly that was actually loaded.
-    virtual HRESULT ResolveAssembly(VMPTR_DomainAssembly vmScope, mdToken tkAssemblyRef, OUT VMPTR_DomainAssembly * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ResolveAssembly(VMPTR_DomainAssembly vmScope, mdToken tkAssemblyRef, OUT VMPTR_DomainAssembly * pRetVal) = 0;
 
     //-----------------------------------------------------------------------------
     // Interface for initializing the native/IL sequence points and native var info
@@ -1216,7 +1203,7 @@ public:
     // Notes:
     //-----------------------------------------------------------------------------
 
-    virtual HRESULT GetNativeCodeSequencePointsAndVarInfo(VMPTR_MethodDesc vmMethodDesc, CORDB_ADDRESS startAddress, BOOL fCodeAvailable, OUT NativeVarData * pNativeVarData, OUT SequencePoints * pSequencePoints) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetNativeCodeSequencePointsAndVarInfo(VMPTR_MethodDesc vmMethodDesc, CORDB_ADDRESS startAddress, BOOL fCodeAvailable, OUT NativeVarData * pNativeVarData, OUT SequencePoints * pSequencePoints) = 0;
 
     //
     // Get the filter CONTEXT on the LS.  Once we move entirely over to the new managed pipeline
@@ -1234,7 +1221,7 @@ public:
     //    we don't have a filter CONTEXT on the LS anymore.
     //
 
-    virtual HRESULT GetManagedStoppedContext(VMPTR_Thread vmThread, OUT VMPTR_CONTEXT * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetManagedStoppedContext(VMPTR_Thread vmThread, OUT VMPTR_CONTEXT * pRetVal) = 0;
 
     typedef enum
     {
@@ -1266,10 +1253,10 @@ public:
     //    This is a special case that violates the 'no state' tenant.
     //
 
-    virtual HRESULT CreateStackWalk(VMPTR_Thread vmThread, DT_CONTEXT * pInternalContextBuffer, OUT StackWalkHandle * ppSFIHandle) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateStackWalk(VMPTR_Thread vmThread, DT_CONTEXT * pInternalContextBuffer, OUT StackWalkHandle * ppSFIHandle) = 0;
 
     // Delete the stackwalk object created from CreateStackWalk.
-    virtual HRESULT DeleteStackWalk(StackWalkHandle ppSFIHandle) = 0;
+    virtual HRESULT STDMETHODCALLTYPE DeleteStackWalk(StackWalkHandle ppSFIHandle) = 0;
 
     //
     // Get the CONTEXT of the current frame where the stackwalker is stopped at.
@@ -1279,7 +1266,7 @@ public:
     //    pContext   - OUT: the CONTEXT to be filled out. The context control flags are ignored.
     //
 
-    virtual HRESULT GetStackWalkCurrentContext(StackWalkHandle pSFIHandle, DT_CONTEXT * pContext) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetStackWalkCurrentContext(StackWalkHandle pSFIHandle, DT_CONTEXT * pContext) = 0;
 
     //
     // Set the stackwalker to the given CONTEXT.  The CorDebugSetContextFlag indicates whether
@@ -1293,7 +1280,7 @@ public:
     //    pContext   - the specified CONTEXT. This may make correctional adjustments to the context's IP.
     //
 
-    virtual HRESULT SetStackWalkCurrentContext(VMPTR_Thread vmThread, StackWalkHandle pSFIHandle, CorDebugSetContextFlag flag, DT_CONTEXT * pContext) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetStackWalkCurrentContext(VMPTR_Thread vmThread, StackWalkHandle pSFIHandle, CorDebugSetContextFlag flag, DT_CONTEXT * pContext) = 0;
 
     //
     // Unwind the stackwalker to the next frame.  The next frame could be any actual stack frame,
@@ -1308,7 +1295,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
-    virtual HRESULT UnwindStackWalkFrame(StackWalkHandle pSFIHandle, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE UnwindStackWalkFrame(StackWalkHandle pSFIHandle, OUT BOOL * pResult) = 0;
 
     //
     // Check whether the specified CONTEXT is valid.  The only check we perform right now is whether the
@@ -1322,8 +1309,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
-    virtual
-    HRESULT CheckContext(VMPTR_Thread       vmThread,
+    virtual HRESULT STDMETHODCALLTYPE CheckContext(VMPTR_Thread       vmThread,
                          const DT_CONTEXT * pContext) = 0;
 
     //
@@ -1340,7 +1326,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
-    virtual HRESULT GetStackWalkCurrentFrameInfo(StackWalkHandle pSFIHandle, OPTIONAL DebuggerIPCE_STRData * pFrameData, OUT FrameType * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetStackWalkCurrentFrameInfo(StackWalkHandle pSFIHandle, OPTIONAL DebuggerIPCE_STRData * pFrameData, OUT FrameType * pRetVal) = 0;
 
     //
     // Get the number of internal frames on the specified thread.
@@ -1363,7 +1349,7 @@ public:
     //    out how many interesting internal frames there are.
     //
 
-    virtual HRESULT GetCountOfInternalFrames(VMPTR_Thread vmThread, OUT ULONG32 * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCountOfInternalFrames(VMPTR_Thread vmThread, OUT ULONG32 * pRetVal) = 0;
 
     //
     // Enumerate the internal frames on the specified thread and invoke the provided callback on each of
@@ -1381,7 +1367,7 @@ public:
 
     typedef void (*FP_INTERNAL_FRAME_ENUMERATION_CALLBACK)(const DebuggerIPCE_STRData * pFrameData, CALLBACK_DATA pUserData);
 
-    virtual HRESULT EnumerateInternalFrames(VMPTR_Thread vmThread, FP_INTERNAL_FRAME_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE EnumerateInternalFrames(VMPTR_Thread vmThread, FP_INTERNAL_FRAME_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
 
     //
     // Given the FramePointer of the parent frame and the FramePointer of the current frame,
@@ -1401,7 +1387,7 @@ public:
     //    ask the ExInfo to do it.
     //
 
-    virtual HRESULT IsMatchingParentFrame(FramePointer fpToCheck, FramePointer fpParent, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsMatchingParentFrame(FramePointer fpToCheck, FramePointer fpParent, OUT BOOL * pResult) = 0;
 
     //
     // Get the stack parameter size of a given method.  This is necessary on x86 for unwinding.
@@ -1417,7 +1403,7 @@ public:
     //    The callee stack parameter size is constant throughout a method.
     //
 
-    virtual HRESULT GetStackParameterSize(CORDB_ADDRESS controlPC, OUT ULONG32 * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetStackParameterSize(CORDB_ADDRESS controlPC, OUT ULONG32 * pRetVal) = 0;
 
     //
     // Get the FramePointer of the current frame where the stackwalker is stopped at.
@@ -1442,7 +1428,7 @@ public:
     //    The FramePointer of an explicit frame is just the stack address of the explicit frame.
     //
 
-    virtual HRESULT GetFramePointer(StackWalkHandle pSFIHandle, OUT FramePointer * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetFramePointer(StackWalkHandle pSFIHandle, OUT FramePointer * pRetVal) = 0;
 
     //
     // Check whether the specified CONTEXT is the CONTEXT of the leaf frame.  This function doesn't care
@@ -1461,7 +1447,7 @@ public:
     //    This will be deprecated in V3.
     //
 
-    virtual HRESULT IsLeafFrame(VMPTR_Thread vmThread, const DT_CONTEXT * pContext, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsLeafFrame(VMPTR_Thread vmThread, const DT_CONTEXT * pContext, OUT BOOL * pResult) = 0;
 
     // Get the context for a particular thread of the target process.
     // Arguments:
@@ -1469,7 +1455,7 @@ public:
     //     output: pContextBuffer - the address of the CONTEXT to be initialized.
     //                              The memory for this belongs to the caller. It must not be NULL.
     // Note: returns an appropriate failure HRESULT on error
-    virtual HRESULT GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContextBuffer) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pContextBuffer) = 0;
 
     //
     // This is a simple helper function to convert a CONTEXT to a DebuggerREGDISPLAY.  We need to do this
@@ -1484,7 +1470,7 @@ public:
     //                 unwinding.
     //
 
-    virtual HRESULT ConvertContextToDebuggerRegDisplay(const DT_CONTEXT * pInContext, DebuggerREGDISPLAY * pOutDRD, BOOL fActive) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ConvertContextToDebuggerRegDisplay(const DT_CONTEXT * pInContext, DebuggerREGDISPLAY * pOutDRD, BOOL fActive) = 0;
 
     typedef enum
     {
@@ -1507,7 +1493,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
-    virtual HRESULT IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc, OUT DynamicMethodType * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsDiagnosticsHiddenOrLCGMethod(VMPTR_MethodDesc vmMethodDesc, OUT DynamicMethodType * pRetVal) = 0;
 
     //
     // Get a TargetBuffer for the raw vararg signature.
@@ -1537,7 +1523,7 @@ public:
     //    in mscordbi.dll.
     //
 
-    virtual HRESULT GetVarArgSig(CORDB_ADDRESS VASigCookieAddr, OUT CORDB_ADDRESS * pArgBase, OUT TargetBuffer * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetVarArgSig(CORDB_ADDRESS VASigCookieAddr, OUT CORDB_ADDRESS * pArgBase, OUT TargetBuffer * pRetVal) = 0;
 
     //
     // Indicates if the specified type requires 8-byte alignment.
@@ -1550,7 +1536,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
 
-    virtual HRESULT RequiresAlign8(VMPTR_TypeHandle thExact, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE RequiresAlign8(VMPTR_TypeHandle thExact, OUT BOOL * pResult) = 0;
 
     //
     // Resolve the raw generics token to the real generics type token.  The resolution is based on the
@@ -1580,7 +1566,7 @@ public:
     //    However, we don't want the RS to know all this logic.
     //
 
-    virtual HRESULT ResolveExactGenericArgsToken(DWORD dwExactGenericArgsTokenIndex, GENERICS_TYPE_TOKEN rawToken, OUT GENERICS_TYPE_TOKEN * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE ResolveExactGenericArgsToken(DWORD dwExactGenericArgsTokenIndex, GENERICS_TYPE_TOKEN rawToken, OUT GENERICS_TYPE_TOKEN * pRetVal) = 0;
 
     //-----------------------------------------------------------------------------
     // Functions to get information about code objects
@@ -1598,7 +1584,7 @@ public:
     //    codeInfo       - start address and size of the IL
     //    pLocalSigToken - signature token for the method
     //    pCodeInfo - [out]
-    virtual HRESULT GetILCodeAndSig(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT TargetBuffer * pCodeInfo, OUT mdToken * pLocalSigToken) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetILCodeAndSig(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT TargetBuffer * pCodeInfo, OUT mdToken * pLocalSigToken) = 0;
 
     // Gets information about a native code blob:
     //    it's method desc, whether it's an instantiated generic, its EnC version number
@@ -1614,7 +1600,7 @@ public:
     //        is unavailable for any reason, the output parameter will also be
     //        invalid (i.e., pCodeInfo->IsValid is false).
 
-    virtual HRESULT GetNativeCodeInfo(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT NativeCodeFunctionData * pCodeInfo) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetNativeCodeInfo(VMPTR_DomainAssembly vmDomainAssembly, mdToken functionToken, OUT NativeCodeFunctionData * pCodeInfo) = 0;
 
     // Gets information about a native code blob:
     //    it's method desc, whether it's an instantiated generic, its EnC version number
@@ -1632,7 +1618,7 @@ public:
     //        pVmModule     - module containing metadata for the method
     //        pFunctionToken - metadata token for the function
 
-    virtual HRESULT GetNativeCodeInfoForAddr(CORDB_ADDRESS codeAddress, NativeCodeFunctionData * pCodeInfo, VMPTR_Module * pVmModule, mdToken * pFunctionToken) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetNativeCodeInfoForAddr(CORDB_ADDRESS codeAddress, NativeCodeFunctionData * pCodeInfo, VMPTR_Module * pVmModule, mdToken * pFunctionToken) = 0;
 
     //-----------------------------------------------------------------------------
     // Functions to get information about types
@@ -1647,7 +1633,7 @@ public:
     // Return:
     //        TRUE iff the type is a ValueType
 
-    virtual HRESULT IsValueType(VMPTR_TypeHandle th, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsValueType(VMPTR_TypeHandle th, OUT BOOL * pResult) = 0;
 
     // Determine if a type has generic parameters
     //
@@ -1658,7 +1644,7 @@ public:
     // Return:
     //        TRUE iff the type has generic parameters
 
-    virtual HRESULT HasTypeParams(VMPTR_TypeHandle th, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE HasTypeParams(VMPTR_TypeHandle th, OUT BOOL * pResult) = 0;
 
     // Get type information for a class
     //
@@ -1669,7 +1655,7 @@ public:
     //             pData         - structure containing information about the class and its
     //                             fields
 
-    virtual HRESULT GetClassInfo(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle thExact, ClassInfo * pData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetClassInfo(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle thExact, ClassInfo * pData) = 0;
 
     // get field information and object size for an instantiated generic
     //
@@ -1682,7 +1668,7 @@ public:
     //                             contents. Allocated and initialized by this function.
     //             pObjectSize   - size of the instantiated object
     //
-    virtual HRESULT GetInstantiationFieldInfo(VMPTR_DomainAssembly vmDomainAssembly, VMPTR_TypeHandle vmThExact, VMPTR_TypeHandle vmThApprox, OUT DacDbiArrayList<FieldData> * pFieldList, OUT SIZE_T * pObjectSize) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetInstantiationFieldInfo(VMPTR_DomainAssembly vmDomainAssembly, VMPTR_TypeHandle vmThExact, VMPTR_TypeHandle vmThApprox, OUT DacDbiArrayList<FieldData> * pFieldList, OUT SIZE_T * pObjectSize) = 0;
 
     // use a type handle to get the information needed to create the corresponding RS CordbType instance
     //
@@ -1693,12 +1679,12 @@ public:
     //             vmTypeHandle - type handle for the type
     //     output: pTypeInfo    - holds information needed to build the corresponding CordbType
     //
-    virtual HRESULT TypeHandleToExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, DebuggerIPCE_ExpandedTypeData * pTypeInfo) = 0;
+    virtual HRESULT STDMETHODCALLTYPE TypeHandleToExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, DebuggerIPCE_ExpandedTypeData * pTypeInfo) = 0;
 
-    virtual HRESULT GetObjectExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, CORDB_ADDRESS addr, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetObjectExpandedTypeInfo(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, CORDB_ADDRESS addr, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo) = 0;
 
 
-    virtual HRESULT GetObjectExpandedTypeInfoFromID(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, COR_TYPEID id, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetObjectExpandedTypeInfoFromID(AreValueTypesBoxed boxed, VMPTR_AppDomain vmAppDomain, COR_TYPEID id, OUT DebuggerIPCE_ExpandedTypeData * pTypeInfo) = 0;
 
 
     // Get type handle for a TypeDef token, if one exists. For generics this returns the open type.
@@ -1714,7 +1700,7 @@ public:
     // Return value:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
-    virtual HRESULT GetTypeHandle(VMPTR_Module vmModule, mdTypeDef metadataToken, OUT VMPTR_TypeHandle * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetTypeHandle(VMPTR_Module vmModule, mdTypeDef metadataToken, OUT VMPTR_TypeHandle * pRetVal) = 0;
 
     // Get the approximate type handle for an instantiated type. This may be identical to the exact type handle,
     // but if we have code sharing for generics, it may differ in that it may have canonical type parameters.
@@ -1728,7 +1714,7 @@ public:
     // Return value:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
-    virtual HRESULT GetApproxTypeHandle(TypeInfoList * pTypeData, OUT VMPTR_TypeHandle * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetApproxTypeHandle(TypeInfoList * pTypeData, OUT VMPTR_TypeHandle * pRetVal) = 0;
 
     // Get the exact type handle from type data.
     // Arguments:
@@ -1742,13 +1728,12 @@ public:
     //                                    for generics or they may represent the element type or referent
     //                                    type.
     //                 pGenericArgData  - list of type parameters
-    //                 vmTypeHandle     - the exact type handle derived from the type information
+    //            pVmTypeHandle    - [out] the exact type handle derived from the type information
     // Return Value:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
-    virtual
-    HRESULT GetExactTypeHandle(DebuggerIPCE_ExpandedTypeData * pTypeData,
+    virtual HRESULT STDMETHODCALLTYPE GetExactTypeHandle(DebuggerIPCE_ExpandedTypeData * pTypeData,
                                ArgInfoList *   pArgInfo,
-                               VMPTR_TypeHandle& vmTypeHandle) = 0;
+                               VMPTR_TypeHandle * pVmTypeHandle) = 0;
 
     //
     // Retrieve the generic type params for a given MethodDesc.  This function is specifically
@@ -1771,7 +1756,7 @@ public:
     //    The caller is responsible for releasing it.
     //
 
-    virtual HRESULT GetMethodDescParams(VMPTR_AppDomain vmAppDomain, VMPTR_MethodDesc vmMethodDesc, GENERICS_TYPE_TOKEN genericsToken, OUT UINT32 * pcGenericClassTypeParams, OUT TypeParamsList * pGenericTypeParams) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetMethodDescParams(VMPTR_AppDomain vmAppDomain, VMPTR_MethodDesc vmMethodDesc, GENERICS_TYPE_TOKEN genericsToken, OUT UINT32 * pcGenericClassTypeParams, OUT TypeParamsList * pGenericTypeParams) = 0;
 
     // Get the target field address of a thread local static.
     // Arguments:
@@ -1787,7 +1772,7 @@ public:
     //  This is an inspection only method and can not allocate the static storage.
     //  Field storage is constant once allocated, so this value can be cached.
 
-    virtual HRESULT GetThreadStaticAddress(VMPTR_FieldDesc vmField, VMPTR_Thread vmRuntimeThread, OUT CORDB_ADDRESS * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetThreadStaticAddress(VMPTR_FieldDesc vmField, VMPTR_Thread vmRuntimeThread, OUT CORDB_ADDRESS * pRetVal) = 0;
 
     // Get the target field address of a collectible types static.
     // Arguments:
@@ -1804,7 +1789,7 @@ public:
     //  Field storage is not constant once allocated so this value can not be cached
     //  across a Continue
 
-    virtual HRESULT GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmField, VMPTR_AppDomain vmAppDomain, OUT CORDB_ADDRESS * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCollectibleTypeStaticAddress(VMPTR_FieldDesc vmField, VMPTR_AppDomain vmAppDomain, OUT CORDB_ADDRESS * pRetVal) = 0;
 
     // Get information about a field added with Edit And Continue.
     // Arguments:
@@ -1817,7 +1802,7 @@ public:
     //                              an indication of the type: whether it's a class or value type
     //     output:  pFieldData    - information about the EnC added field
     //              pfStatic      - flag to indicate whether the field is static
-    virtual HRESULT GetEnCHangingFieldInfo(const EnCHangingFieldInfo * pEnCFieldInfo, OUT FieldData * pFieldData, OUT BOOL * pfStatic) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetEnCHangingFieldInfo(const EnCHangingFieldInfo * pEnCFieldInfo, OUT FieldData * pFieldData, OUT BOOL * pfStatic) = 0;
 
 
     // GetTypeHandleParams gets the necessary data for a type handle, i.e. its
@@ -1834,7 +1819,7 @@ public:
     //                           heap in this function.
     // This will not fail except for OOM
 
-    virtual HRESULT GetTypeHandleParams(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, OUT TypeParamsList * pParams) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetTypeHandleParams(VMPTR_AppDomain vmAppDomain, VMPTR_TypeHandle vmTypeHandle, OUT TypeParamsList * pParams) = 0;
 
     // GetSimpleType
     // gets the metadata token and domain file corresponding to a simple type
@@ -1851,35 +1836,35 @@ public:
     //    If the type has been loaded, vmDomainAssembly will be non-null unless the target is somehow corrupted.
     //    In that case, we will return CORDBG_E_TARGET_INCONSISTENT.
 
-    virtual HRESULT GetSimpleType(VMPTR_AppDomain vmAppDomain, CorElementType simpleType, OUT mdTypeDef * pMetadataToken, OUT VMPTR_Module * pVmModule, OUT VMPTR_DomainAssembly * pVmDomainAssembly) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetSimpleType(VMPTR_AppDomain vmAppDomain, CorElementType simpleType, OUT mdTypeDef * pMetadataToken, OUT VMPTR_Module * pVmModule, OUT VMPTR_DomainAssembly * pVmDomainAssembly) = 0;
 
     // For the specified object, check whether the object derives from System.Exception.
-    virtual HRESULT IsExceptionObject(VMPTR_Object vmObject, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsExceptionObject(VMPTR_Object vmObject, OUT BOOL * pResult) = 0;
 
     // Get the list of raw stack frames for the specified exception object.
-    virtual HRESULT GetStackFramesFromException(VMPTR_Object vmObject, DacDbiArrayList<DacExceptionCallStackData>& dacStackFrames) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetStackFramesFromException(VMPTR_Object vmObject, DacDbiArrayList<DacExceptionCallStackData>* pDacStackFrames) = 0;
 
     // Check whether the argument is a runtime callable wrapper.
-    virtual HRESULT IsRcw(VMPTR_Object vmObject, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsRcw(VMPTR_Object vmObject, OUT BOOL * pResult) = 0;
 
     // retrieves the list of COM interfaces implemented by vmObject, as it is known at
     // the time of the call (the list may change as new interface types become available
     // in the runtime)
-    virtual HRESULT GetRcwCachedInterfaceTypes(VMPTR_Object vmObject, VMPTR_AppDomain vmAppDomain, BOOL bIInspectableOnly, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pDacInterfaces) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetRcwCachedInterfaceTypes(VMPTR_Object vmObject, VMPTR_AppDomain vmAppDomain, BOOL bIInspectableOnly, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pDacInterfaces) = 0;
 
     // retrieves the list of interfaces pointers implemented by vmObject, as it is known at
     // the time of the call (the list may change as new interface types become available
     // in the runtime)
-    virtual HRESULT GetRcwCachedInterfacePointers(VMPTR_Object vmObject, BOOL bIInspectableOnly, OUT DacDbiArrayList<CORDB_ADDRESS> * pDacItfPtrs) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetRcwCachedInterfacePointers(VMPTR_Object vmObject, BOOL bIInspectableOnly, OUT DacDbiArrayList<CORDB_ADDRESS> * pDacItfPtrs) = 0;
 
     // retrieves a list of interface types corresponding to the passed in
     // list of IIDs. the interface types are retrieved from an app domain
     // IID / Type cache, that is updated as new types are loaded. will
     // have NULL entries corresponding to unknown IIDs in "iids"
-    virtual HRESULT GetCachedWinRTTypesForIIDs(VMPTR_AppDomain vmAppDomain, DacDbiArrayList<GUID> & iids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCachedWinRTTypesForIIDs(VMPTR_AppDomain vmAppDomain, DacDbiArrayList<GUID> * pIids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes) = 0;
 
     // retrieves the whole app domain cache of IID / Type mappings.
-    virtual HRESULT GetCachedWinRTTypes(VMPTR_AppDomain vmAppDomain, OUT DacDbiArrayList<GUID> * piids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetCachedWinRTTypes(VMPTR_AppDomain vmAppDomain, OUT DacDbiArrayList<GUID> * piids, OUT DacDbiArrayList<DebuggerIPCE_ExpandedTypeData> * pTypes) = 0;
 
 
     // ----------------------------------------------------------------------------
@@ -1893,7 +1878,7 @@ public:
     //             vmAppDomain - AppDomain for the type of the object referenced
     //     output: pObjectData - information about the object referenced by pTypedByRef
     // Note: returns an appropriate failure HRESULT on error
-    virtual HRESULT GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetTypedByRefInfo(CORDB_ADDRESS pTypedByRef, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData) = 0;
 
     // Get the string length and offset to string base for a string object
     // Arguments:
@@ -1901,7 +1886,7 @@ public:
     //     output: pObjectData - fills in the string fields stringInfo.offsetToStringBase and
     //             stringInfo.length
     // Note: returns an appropriate failure HRESULT on error
-    virtual HRESULT GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetStringData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData) = 0;
 
     // Get information for an array type referent of an objRef, including rank, upper and lower bounds,
     // element size and type, and the number of elements.
@@ -1915,7 +1900,7 @@ public:
     //                             arrayInfo.rank,
     //                             arrayInfo.elementSize,
     // Note: returns an appropriate failure HRESULT on error
-    virtual HRESULT GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetArrayData(CORDB_ADDRESS objectAddress, DebuggerIPCE_ObjectData * pObjectData) = 0;
 
     // Get information about an object for which we have a reference, including the object size and
     // type information.
@@ -1926,7 +1911,7 @@ public:
     //             vmAppDomain   - the appdomain to which the object belong
     //     output: pObjectData   - fills in the size and type information fields
     // Note: returns an appropriate failure HRESULT on error
-    virtual HRESULT GetBasicObjectInfo(CORDB_ADDRESS objectAddress, CorElementType type, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetBasicObjectInfo(CORDB_ADDRESS objectAddress, CorElementType type, VMPTR_AppDomain vmAppDomain, DebuggerIPCE_ObjectData * pObjectData) = 0;
 
     // --------------------------------------------------------------------------------------------
 #ifdef TEST_DATA_CONSISTENCY
@@ -1941,7 +1926,7 @@ public:
     // Notes:
     //     Returns an appropriate failure HRESULT on error
     //     For this code to run, the environment variable TestDataConsistency must be set to 1.
-    virtual HRESULT TestCrst(VMPTR_Crst vmCrst) = 0;
+    virtual HRESULT STDMETHODCALLTYPE TestCrst(VMPTR_Crst vmCrst) = 0;
 
     // Determine whether a crst is held by the left side. When the DAC is executing VM code that takes a
     // lock, we want to know whether the LS already holds that lock. If it does, we will assume the locked
@@ -1955,7 +1940,7 @@ public:
     //     Returns an appropriate failure HRESULT on error
     //     For this code to run, the environment variable TestDataConsistency must be set to 1.
 
-    virtual HRESULT TestRWLock(VMPTR_SimpleRWLock vmRWLock) = 0;
+    virtual HRESULT STDMETHODCALLTYPE TestRWLock(VMPTR_SimpleRWLock vmRWLock) = 0;
 #endif
     // --------------------------------------------------------------------------------------------
     // Get the address of the Debugger control block on the helper thread. The debugger control block
@@ -1966,7 +1951,7 @@ public:
     //             helper thread if it has been successfully allocated or NULL otherwise.
     // Return Value:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
-    virtual HRESULT GetDebuggerControlBlockAddress(OUT CORDB_ADDRESS * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetDebuggerControlBlockAddress(OUT CORDB_ADDRESS * pRetVal) = 0;
 
     // Creates a VMPTR of an Object. The Object is found by dereferencing ptr
     // as though it is a target address to an OBJECTREF. This is similar to
@@ -1984,7 +1969,7 @@ public:
     //    This function will return a failure HRESULT if given a NULL or otherwise invalid pointer,
     //    but if given a valid address to an invalid pointer, it will produce
     //    a VMPTR_Object which points to invalid memory.
-    virtual HRESULT GetObjectFromRefPtr(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetObjectFromRefPtr(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal) = 0;
 
     // Creates a VMPTR of an Object. The Object is assumed to be at the target
     // address supplied by ptr
@@ -2000,7 +1985,7 @@ public:
     //    The VMPTR this produces can be deconstructed by GetObjectContents.
     //    This will produce a VMPTR_Object regardless of whether the pointer is
     //    valid or not.
-    virtual HRESULT GetObject(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetObject(CORDB_ADDRESS ptr, OUT VMPTR_Object * pRetVal) = 0;
 
     // Sets state in the native binder.
     //
@@ -2010,8 +1995,7 @@ public:
     // Return Value:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
-    virtual
-    HRESULT EnableNGENPolicy(CorDebugNGENPolicy ePolicy) = 0;
+    virtual HRESULT STDMETHODCALLTYPE EnableNGENPolicy(CorDebugNGENPolicy ePolicy) = 0;
 
     // Sets the NGEN compiler flags. This restricts NGEN to only use images with certain
     // types of pregenerated code. With respect to debugging this is used to specify that
@@ -2035,8 +2019,7 @@ public:
     // Return Value:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
-    virtual
-    HRESULT SetNGENCompilerFlags(DWORD dwFlags) = 0;
+    virtual HRESULT STDMETHODCALLTYPE SetNGENCompilerFlags(DWORD dwFlags) = 0;
 
     // Gets the NGEN compiler flags currently in effect. This accounts for settings that
     // were caused by SetDesiredNGENCompilerFlags as well as other configuration sources.
@@ -2048,8 +2031,7 @@ public:
     // Return Value:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
-    virtual
-    HRESULT GetNGENCompilerFlags(DWORD *pdwFlags) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetNGENCompilerFlags(DWORD *pdwFlags) = 0;
 
     // Create a VMPTR_OBJECTHANDLE from a CORDB_ADDRESS pointing to an object handle
     //
@@ -2064,7 +2046,7 @@ public:
     //     This will produce a VMPTR_OBJECTHANDLE regardless of whether handle is
     //     valid.
     //     Ideally we'd be using only strongly-typed variables on the RS, and then this would be unnecessary
-    virtual HRESULT GetVmObjectHandle(CORDB_ADDRESS handleAddress, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetVmObjectHandle(CORDB_ADDRESS handleAddress, OUT VMPTR_OBJECTHANDLE * pRetVal) = 0;
 
     // Validate that the VMPTR_OBJECTHANDLE refers to a legitimate managed object
     //
@@ -2075,19 +2057,18 @@ public:
     // Return value:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
-    virtual HRESULT IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsVmObjectHandleValid(VMPTR_OBJECTHANDLE vmHandle, OUT BOOL * pResult) = 0;
 
     // indicates if the specified module is a WinRT module
     //
     // Arguments:
     //     vmModule: the module to check
-    //     isWinRT: out parameter indicating state of module
+    //     pIsWinRT: [out] indicating state of module
     //
     // Return value:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
-    virtual
-    HRESULT IsWinRTModule(VMPTR_Module vmModule, BOOL& isWinRT) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsWinRTModule(VMPTR_Module vmModule, BOOL * pIsWinRT) = 0;
 
     // Determines the app domain id for the object referred to by a given VMPTR_OBJECTHANDLE
     //
@@ -2099,7 +2080,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     // This may return a failure HRESULT if the object handle is corrupt (it doesn't refer to a managed object)
-    virtual HRESULT GetAppDomainIdFromVmObjectHandle(VMPTR_OBJECTHANDLE vmHandle, OUT ULONG * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetAppDomainIdFromVmObjectHandle(VMPTR_OBJECTHANDLE vmHandle, OUT ULONG * pRetVal) = 0;
 
 
     // Get the target address from a VMPTR_OBJECTHANDLE, i.e., the handle address
@@ -2109,7 +2090,7 @@ public:
     // Return value:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
-    virtual HRESULT GetHandleAddressFromVmHandle(VMPTR_OBJECTHANDLE vmHandle, OUT CORDB_ADDRESS * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetHandleAddressFromVmHandle(VMPTR_OBJECTHANDLE vmHandle, OUT CORDB_ADDRESS * pRetVal) = 0;
 
     // Given a VMPTR to an Object, get the target address.
     //
@@ -2125,7 +2106,7 @@ public:
     //    providing the address stored in the returned TargetBuffer. This has
     //    undefined behavior for invalid VMPTR_Objects.
 
-    virtual HRESULT GetObjectContents(VMPTR_Object obj, OUT TargetBuffer * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetObjectContents(VMPTR_Object obj, OUT TargetBuffer * pRetVal) = 0;
 
     //
     // Get the thread which owns the monitor lock on an object and the acquisition
@@ -2140,7 +2121,7 @@ public:
     // Return Value:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
-    virtual HRESULT GetThreadOwningMonitorLock(VMPTR_Object vmObject, OUT MonitorLockInfo * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetThreadOwningMonitorLock(VMPTR_Object vmObject, OUT MonitorLockInfo * pRetVal) = 0;
 
     //
     // Enumerate all threads waiting on the monitor event for an object
@@ -2154,7 +2135,7 @@ public:
     //    S_OK on success; otherwise, an appropriate failure HRESULT.
     //
     //
-    virtual HRESULT EnumerateMonitorEventWaitList(VMPTR_Object vmObject, FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE EnumerateMonitorEventWaitList(VMPTR_Object vmObject, FP_THREAD_ENUMERATION_CALLBACK fpCallback, CALLBACK_DATA pUserData) = 0;
 
     //
     // Get the managed debugging flags for the process (a combination
@@ -2163,11 +2144,11 @@ public:
     // event (if one exists) is caused by a Debugger.Launch(). This is
     // important b/c Debugger.Launch calls should *NOT* cause the debugger
     // to terminate the process when the attach is canceled.
-    virtual HRESULT GetAttachStateFlags(OUT CLR_DEBUGGING_PROCESS_FLAGS * pRetVal) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetAttachStateFlags(OUT CLR_DEBUGGING_PROCESS_FLAGS * pRetVal) = 0;
 
-    virtual HRESULT GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly, DWORD & dwTimeStamp, DWORD & dwImageSize, IStringHolder* pStrFilename, OUT bool * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetMetaDataFileInfoFromPEFile(VMPTR_PEAssembly vmPEAssembly, DWORD * pTimeStamp, DWORD * pImageSize, IStringHolder* pStrFilename, OUT BOOL * pResult) = 0;
 
-    virtual HRESULT IsThreadSuspendedOrHijacked(VMPTR_Thread vmThread, OUT bool * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsThreadSuspendedOrHijacked(VMPTR_Thread vmThread, OUT BOOL * pResult) = 0;
 
 
     typedef void* * HeapWalkHandle;
@@ -2175,7 +2156,7 @@ public:
     // Returns true if it is safe to walk the heap.  If this function returns false,
     // you could still create a heap walk and attempt to walk it, but there's no
     // telling how much of the heap will be available.
-    virtual HRESULT AreGCStructuresValid(OUT bool * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE AreGCStructuresValid(OUT BOOL * pResult) = 0;
 
     // Creates a HeapWalkHandle which can be used to walk the managed heap with the
     // WalkHeap function.  Note if this function completes successfully you will need
@@ -2186,13 +2167,12 @@ public:
     //
     // Returns:
     //   S_OK on success, an error code on failure.
-    virtual
-    HRESULT CreateHeapWalk(OUT HeapWalkHandle * pHandle) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateHeapWalk(OUT HeapWalkHandle * pHandle) = 0;
 
 
     // Deletes the give HeapWalkHandle.  Note you must call this function if
     // CreateHeapWalk returns success.
-    virtual HRESULT DeleteHeapWalk(HeapWalkHandle handle) = 0;
+    virtual HRESULT STDMETHODCALLTYPE DeleteHeapWalk(HeapWalkHandle handle) = 0;
 
     // Walks the heap using the given heap walk handle, enumerating objects
     // on the managed heap.  Note that walking the heap requires that the GC
@@ -2216,18 +2196,16 @@ public:
     //   You should iteratively call WalkHeap requesting more values until
     //   *pFetched != count..  This signifies that we have reached the end
     //   of the heap walk.
-    virtual
-    HRESULT WalkHeap(HeapWalkHandle handle,
+    virtual HRESULT STDMETHODCALLTYPE WalkHeap(HeapWalkHandle handle,
                      ULONG count,
                      OUT COR_HEAPOBJECT * objects,
                      OUT ULONG * pFetched) = 0;
 
-    virtual
-    HRESULT GetHeapSegments(OUT DacDbiArrayList<COR_SEGMENT> * pSegments) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetHeapSegments(OUT DacDbiArrayList<COR_SEGMENT> * pSegments) = 0;
 
-    virtual HRESULT IsValidObject(CORDB_ADDRESS obj, OUT bool * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsValidObject(CORDB_ADDRESS obj, OUT BOOL * pResult) = 0;
 
-    virtual HRESULT GetAppDomainForObject(CORDB_ADDRESS obj, OUT VMPTR_AppDomain * pApp, OUT VMPTR_Module * pModule, OUT VMPTR_DomainAssembly * pDomainAssembly, OUT bool * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetAppDomainForObject(CORDB_ADDRESS obj, OUT VMPTR_AppDomain * pApp, OUT VMPTR_Module * pModule, OUT VMPTR_DomainAssembly * pDomainAssembly, OUT BOOL * pResult) = 0;
 
 
     //   Reference Walking.
@@ -2242,15 +2220,14 @@ public:
     //      An HRESULT indicating whether it succeeded or failed.
     //  Exceptions:
     //      Returns an HRESULT indicating success or failure.
-    virtual
-    HRESULT CreateRefWalk(OUT RefWalkHandle * pHandle, BOOL walkStacks, BOOL walkFQ, UINT32 handleWalkMask) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateRefWalk(OUT RefWalkHandle * pHandle, BOOL walkStacks, BOOL walkFQ, UINT32 handleWalkMask) = 0;
 
     // Deletes a reference walk.
     // Parameters:
     //      handle - in - the handle of the reference walk to delete
     // Excecptions:
     //      Returns an HRESULT indicating success or failure.
-    virtual HRESULT DeleteRefWalk(RefWalkHandle handle) = 0;
+    virtual HRESULT STDMETHODCALLTYPE DeleteRefWalk(RefWalkHandle handle) = 0;
 
     // Enumerates GC references in the process based on the parameters passed to CreateRefWalk.
     // Parameters:
@@ -2258,25 +2235,19 @@ public:
     //      count - in - the capacity of "refs"
     //      refs - in/out - an array to write the references to
     //      pFetched - out - the number of references written
-    virtual
-    HRESULT WalkRefs(RefWalkHandle handle, ULONG count, OUT DacGcReference * refs, OUT ULONG * pFetched) = 0;
+    virtual HRESULT STDMETHODCALLTYPE WalkRefs(RefWalkHandle handle, ULONG count, OUT DacGcReference * refs, OUT ULONG * pFetched) = 0;
 
-    virtual
-    HRESULT GetTypeID(CORDB_ADDRESS obj, COR_TYPEID * pType) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetTypeID(CORDB_ADDRESS obj, COR_TYPEID * pType) = 0;
 
-    virtual
-    HRESULT GetTypeIDForType(VMPTR_TypeHandle vmTypeHandle, COR_TYPEID *pId) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetTypeIDForType(VMPTR_TypeHandle vmTypeHandle, COR_TYPEID *pId) = 0;
 
-    virtual
-    HRESULT GetObjectFields(COR_TYPEID id, ULONG32 celt, OUT COR_FIELD * layout, OUT ULONG32 * pceltFetched) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetObjectFields(COR_TYPEID id, ULONG32 celt, OUT COR_FIELD * layout, OUT ULONG32 * pceltFetched) = 0;
 
-    virtual
-    HRESULT GetTypeLayout(COR_TYPEID id, COR_TYPE_LAYOUT * pLayout) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetTypeLayout(COR_TYPEID id, COR_TYPE_LAYOUT * pLayout) = 0;
 
-    virtual
-    HRESULT GetArrayLayout(COR_TYPEID id, COR_ARRAY_LAYOUT * pLayout) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetArrayLayout(COR_TYPEID id, COR_ARRAY_LAYOUT * pLayout) = 0;
 
-    virtual HRESULT GetGCHeapInformation(OUT COR_HEAPINFO * pHeapInfo) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetGCHeapInformation(OUT COR_HEAPINFO * pHeapInfo) = 0;
 
     // If a PEAssembly has an RW capable IMDInternalImport, this gets the address of the MDInternalRW
     // object which implements it.
@@ -2287,8 +2258,7 @@ public:
     //    pAddrMDInternalRW - If a PEAssembly has an RW capable IMDInternalImport, this will be set to the address
     //                        of the MDInternalRW object which implements it. Otherwise it will be NULL.
     //
-    virtual
-    HRESULT GetPEFileMDInternalRW(VMPTR_PEAssembly vmPEAssembly, OUT TADDR* pAddrMDInternalRW) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetPEFileMDInternalRW(VMPTR_PEAssembly vmPEAssembly, OUT TADDR* pAddrMDInternalRW) = 0;
 
     // DEPRECATED - use GetActiveRejitILCodeVersionNode
     // Retrieves the active ReJitInfo for a given module/methodDef, if it exists.
@@ -2306,8 +2276,7 @@ public:
     //    S_OK regardless of whether a rejit request is active or not, as long as the answer is certain
     //    error HRESULTs such as CORDBG_READ_VIRTUAL_FAILURE are possible
     //
-    virtual
-    HRESULT GetReJitInfo(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ReJitInfo* pReJitInfo) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetReJitInfo(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ReJitInfo* pReJitInfo) = 0;
 
     // DEPRECATED - use GetNativeCodeVersionNode
     // Retrieves the ReJitInfo for a given MethodDesc/code address, if it exists.
@@ -2324,8 +2293,7 @@ public:
     //    S_OK regardless of whether a rejit request is active or not, as long as the answer is certain
     //    error HRESULTs such as CORDBG_READ_VIRTUAL_FAILURE are possible
     //
-    virtual
-    HRESULT GetReJitInfo(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeStartAddress, OUT VMPTR_ReJitInfo* pReJitInfo) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetReJitInfoByAddress(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeStartAddress, OUT VMPTR_ReJitInfo* pReJitInfo) = 0;
 
     // DEPRECATED - use GetILCodeVersion
     // Retrieves the SharedReJitInfo for a given ReJitInfo.
@@ -2339,8 +2307,7 @@ public:
     //    S_OK if no error
     //    error HRESULTs such as CORDBG_READ_VIRTUAL_FAILURE are possible
     //
-    virtual
-    HRESULT GetSharedReJitInfo(VMPTR_ReJitInfo vmReJitInfo, VMPTR_SharedReJitInfo* pSharedReJitInfo) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetSharedReJitInfo(VMPTR_ReJitInfo vmReJitInfo, VMPTR_SharedReJitInfo* pSharedReJitInfo) = 0;
 
     // DEPRECATED - use GetILCodeVersionData
     // Retrieves useful data from a SharedReJitInfo such as IL code and IL mapping.
@@ -2354,8 +2321,7 @@ public:
     //    S_OK if no error
     //    error HRESULTs such as CORDBG_READ_VIRTUAL_FAILURE are possible
     //
-    virtual
-    HRESULT GetSharedReJitInfoData(VMPTR_SharedReJitInfo sharedReJitInfo, DacSharedReJitInfo* pData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetSharedReJitInfoData(VMPTR_SharedReJitInfo sharedReJitInfo, DacSharedReJitInfo* pData) = 0;
 
     // Retrieves a bool indicating whether or not a method's optimizations have been disabled
     // defined in Debugger::IsMethodDeoptimized
@@ -2372,8 +2338,7 @@ public:
     //    S_OK if no error
     //    error HRESULTs are possible
     //
-    virtual
-    HRESULT AreOptimizationsDisabled(VMPTR_Module vmModule, mdMethodDef methodTk, OUT BOOL* pOptimizationsDisabled) = 0;
+    virtual HRESULT STDMETHODCALLTYPE AreOptimizationsDisabled(VMPTR_Module vmModule, mdMethodDef methodTk, OUT BOOL* pOptimizationsDisabled) = 0;
 
     // Retrieves a bit field indicating which defines were in use when clr was built. This only includes
     // defines that are specified in the Debugger::_Target_Defines enumeration, which is a small subset of
@@ -2388,8 +2353,7 @@ public:
     //    S_OK if no error
     //    error HRESULTs such as CORDBG_READ_VIRTUAL_FAILURE are possible
     //
-    virtual
-    HRESULT GetDefinesBitField(ULONG32 *pDefines) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetDefinesBitField(ULONG32 *pDefines) = 0;
 
     // Retrieves a version number indicating the shape of the data structures used in the Metadata implementation
     // inside clr.dll. This number changes anytime a datatype layout changes so that they can be correctly
@@ -2404,8 +2368,7 @@ public:
     //    S_OK if no error
     //    error HRESULTs such as CORDBG_READ_VIRTUAL_FAILURE are possible
     //
-    virtual
-    HRESULT GetMDStructuresVersion(ULONG32* pMDStructuresVersion) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetMDStructuresVersion(ULONG32* pMDStructuresVersion) = 0;
 
 #ifdef FEATURE_CODE_VERSIONING
     // Retrieves the active rejit ILCodeVersionNode for a given module/methodDef, if it exists.
@@ -2423,8 +2386,7 @@ public:
     //    S_OK regardless of whether a rejit request is active or not, as long as the answer is certain
     //    error HRESULTs such as CORDBG_READ_VIRTUAL_FAILURE are possible
     //
-    virtual
-        HRESULT GetActiveRejitILCodeVersionNode(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ILCodeVersionNode* pVmILCodeVersionNode) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetActiveRejitILCodeVersionNode(VMPTR_Module vmModule, mdMethodDef methodTk, OUT VMPTR_ILCodeVersionNode* pVmILCodeVersionNode) = 0;
 
     // Retrieves the NativeCodeVersionNode for a given MethodDesc/code address, if it exists.
     // NOTE: The initial (default) code generated for a MethodDesc is a valid MethodDesc/code address pair but it won't have a corresponding
@@ -2441,8 +2403,7 @@ public:
     //    S_OK regardless of whether a rejit request is active or not, as long as the answer is certain
     //    error HRESULTs such as CORDBG_READ_VIRTUAL_FAILURE are possible
     //
-    virtual
-        HRESULT GetNativeCodeVersionNode(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeStartAddress, OUT VMPTR_NativeCodeVersionNode* pVmNativeCodeVersionNode) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetNativeCodeVersionNode(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeStartAddress, OUT VMPTR_NativeCodeVersionNode* pVmNativeCodeVersionNode) = 0;
 
     // Retrieves the ILCodeVersionNode for a given NativeCodeVersionNode.
     // This may return a NULL node if the native code belongs to the default IL version for this method.
@@ -2456,8 +2417,7 @@ public:
     //    S_OK if no error
     //    error HRESULTs such as CORDBG_READ_VIRTUAL_FAILURE are possible
     //
-    virtual
-        HRESULT GetILCodeVersionNode(VMPTR_NativeCodeVersionNode vmNativeCodeVersionNode, VMPTR_ILCodeVersionNode* pVmILCodeVersionNode) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetILCodeVersionNode(VMPTR_NativeCodeVersionNode vmNativeCodeVersionNode, VMPTR_ILCodeVersionNode* pVmILCodeVersionNode) = 0;
 
     // Retrieves useful data from an ILCodeVersion such as IL code and IL mapping.
     //
@@ -2470,8 +2430,7 @@ public:
     //    S_OK if no error
     //    error HRESULTs such as CORDBG_READ_VIRTUAL_FAILURE are possible
     //
-    virtual
-        HRESULT GetILCodeVersionNodeData(VMPTR_ILCodeVersionNode ilCodeVersionNode, DacSharedReJitInfo* pData) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetILCodeVersionNodeData(VMPTR_ILCodeVersionNode ilCodeVersionNode, DacSharedReJitInfo* pData) = 0;
 #endif // FEATURE_CODE_VERSIONING
 
     // Enable or disable the GC notification events. The GC notification events are turned off by default
@@ -2485,8 +2444,7 @@ public:
     //    S_OK if no error
     //    error HRESULTs such as CORDBG_READ_VIRTUAL_FAILURE are possible
     //
-    virtual
-        HRESULT EnableGCNotificationEvents(BOOL fEnable) = 0;
+    virtual HRESULT STDMETHODCALLTYPE EnableGCNotificationEvents(BOOL fEnable) = 0;
 
 
     typedef enum
@@ -2507,48 +2465,40 @@ public:
     //    vmObject - pointer to runtime object to query for.
     //    pResult - [out]
     //
-    virtual HRESULT IsDelegate(VMPTR_Object vmObject, OUT BOOL * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsDelegate(VMPTR_Object vmObject, OUT BOOL * pResult) = 0;
 
     // Get the delegate type
-    virtual
-    HRESULT GetDelegateType(VMPTR_Object delegateObject, DelegateType *delegateType) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetDelegateType(VMPTR_Object delegateObject, DelegateType *delegateType) = 0;
 
-    virtual
-    HRESULT GetDelegateFunctionData(
+    virtual HRESULT STDMETHODCALLTYPE GetDelegateFunctionData(
         DelegateType delegateType,
         VMPTR_Object delegateObject,
         OUT VMPTR_DomainAssembly *ppFunctionDomainAssembly,
         OUT mdMethodDef *pMethodDef) = 0;
 
-    virtual
-    HRESULT GetDelegateTargetObject(
+    virtual HRESULT STDMETHODCALLTYPE GetDelegateTargetObject(
         DelegateType delegateType,
         VMPTR_Object delegateObject,
         OUT VMPTR_Object *ppTargetObj,
         OUT VMPTR_AppDomain *ppTargetAppDomain) = 0;
 
-    virtual
-    HRESULT GetLoaderHeapMemoryRanges(OUT DacDbiArrayList<COR_MEMORY_RANGE> *pRanges) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetLoaderHeapMemoryRanges(OUT DacDbiArrayList<COR_MEMORY_RANGE> *pRanges) = 0;
 
-    virtual
-    HRESULT IsModuleMapped(VMPTR_Module pModule, OUT BOOL *isModuleMapped) = 0;
+    virtual HRESULT STDMETHODCALLTYPE IsModuleMapped(VMPTR_Module pModule, OUT BOOL *isModuleMapped) = 0;
 
-    virtual HRESULT MetadataUpdatesApplied(OUT bool * pResult) = 0;
+    virtual HRESULT STDMETHODCALLTYPE MetadataUpdatesApplied(OUT BOOL * pResult) = 0;
 
-    virtual
-    HRESULT GetDomainAssemblyFromModule(VMPTR_Module vmModule, OUT VMPTR_DomainAssembly *pVmDomainAssembly) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetDomainAssemblyFromModule(VMPTR_Module vmModule, OUT VMPTR_DomainAssembly *pVmDomainAssembly) = 0;
 
-    virtual
-    HRESULT ParseContinuation(
+    virtual HRESULT STDMETHODCALLTYPE ParseContinuation(
         CORDB_ADDRESS continuationAddress,
         OUT PCODE* pDiagnosticIP,
         OUT CORDB_ADDRESS* pNextContinuation,
         OUT UINT32* pState) = 0;
 
-    virtual HRESULT GetAsyncLocals(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeAddr, UINT32 state, OUT DacDbiArrayList<AsyncLocalData>* pAsyncLocals) = 0;
+    virtual HRESULT STDMETHODCALLTYPE GetAsyncLocals(VMPTR_MethodDesc vmMethod, CORDB_ADDRESS codeAddr, UINT32 state, OUT DacDbiArrayList<AsyncLocalData>* pAsyncLocals) = 0;
 
-    virtual
-    HRESULT GetGenericArgTokenIndex(
+    virtual HRESULT STDMETHODCALLTYPE GetGenericArgTokenIndex(
         VMPTR_MethodDesc vmMethod,
         OUT UINT32* pTokenIndex) = 0;
 
@@ -2565,8 +2515,7 @@ public:
     // different DLLs with their own heap allocation mechanism, while avoiding
     // the ugly and verbose 2-call C-style string passing API pattern.
     //-----------------------------------------------------------------------------
-    class IStringHolder
-    {
+    class IStringHolder {
     public:
         //
         // Store a copy of of the provided string.
@@ -2595,7 +2544,7 @@ public:
     // Note that mscordacwks.dll and clients cannot share the same heap allocator,
     // DAC statically links the CRT to avoid run-time dependencies on non-OS libraries.
     //-----------------------------------------------------------------------------
-    class IAllocator
+    class IAllocator : public IUnknown
     {
     public:
         // Allocate
@@ -2612,7 +2561,7 @@ public:
     //-----------------------------------------------------------------------------
     // Callback interface to provide Metadata lookup.
     //-----------------------------------------------------------------------------
-    class IMetaDataLookup
+    class IMetaDataLookup : public IUnknown
     {
     public:
         //
@@ -2644,5 +2593,10 @@ public:
 
 }; // end IDacDbiInterface
 
+// IID declaration for non-Windows platforms where __uuidof() expands to IID_##type.
+// The actual IID is defined in corguids (via dacdbi_i.cpp).
+EXTERN_C const IID IID_IDacDbiInterface;
+EXTERN_C const IID IID_IDacDbiAllocator;
+EXTERN_C const IID IID_IDacDbiMetaDataLookup;
 
 #endif // _DACDBI_INTERFACE_H_

--- a/src/coreclr/inc/CMakeLists.txt
+++ b/src/coreclr/inc/CMakeLists.txt
@@ -7,6 +7,7 @@ set( CORGUIDS_IDL_SOURCES
   corprof.idl
   corsym.idl
   sospriv.idl
+  dacdbi.idl
 )
 
 if(CLR_CMAKE_HOST_WIN32)

--- a/src/coreclr/inc/dacdbi.idl
+++ b/src/coreclr/inc/dacdbi.idl
@@ -1,0 +1,490 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+/*****************************************************************************
+ **                                                                         **
+ ** dacdbi.idl - The interface used for DAC to DBI communication in the     **
+ **              .NET runtime debugger.                                      **
+ **                                                                         **
+ *****************************************************************************/
+import "unknwn.idl";
+
+//
+// Forward-declared structs defined in other headers.
+//
+struct DbiVersion;
+struct TypeRefData;
+struct TargetBuffer;
+struct ModuleInfo;
+struct DomainAssemblyInfo;
+struct DacThreadAllocInfo;
+struct NativeVarData;
+struct SequencePoints;
+struct DebuggerIPCE_STRData;
+struct DebuggerREGDISPLAY;
+struct NativeCodeFunctionData;
+struct ClassInfo;
+struct FieldData;
+struct DebuggerIPCE_ExpandedTypeData;
+struct DebuggerIPCE_BasicTypeData;
+struct EnCHangingFieldInfo;
+struct DacExceptionCallStackData;
+struct DebuggerIPCE_ObjectData;
+struct MonitorLockInfo;
+struct DacGcReference;
+struct DacSharedReJitInfo;
+struct AsyncLocalData;
+
+//
+// Types MIDL cannot handle natively. These dummy definitions satisfy the MIDL
+// parser; the real definitions come from C++ headers at compile time.
+//
+cpp_quote("#if 0")
+
+// FramePointer - wrapper around a single pointer (LPVOID m_sp in native code)
+// Passed by value in IsMatchingParentFrame, GetFramePointer, and the internal frame callback.
+typedef struct { UINT_PTR m_sp; } FramePointer;
+
+// VMPTR types - opaque pointer-sized wrappers
+typedef ULONG64 VMPTR_AppDomain;
+typedef ULONG64 VMPTR_OBJECTHANDLE;
+typedef ULONG64 VMPTR_DomainAssembly;
+typedef ULONG64 VMPTR_Assembly;
+typedef ULONG64 VMPTR_Module;
+typedef ULONG64 VMPTR_Thread;
+typedef ULONG64 VMPTR_MethodDesc;
+typedef ULONG64 VMPTR_CONTEXT;
+typedef ULONG64 VMPTR_TypeHandle;
+typedef ULONG64 VMPTR_FieldDesc;
+typedef ULONG64 VMPTR_Object;
+typedef ULONG64 VMPTR_PEAssembly;
+typedef ULONG64 VMPTR_Crst;
+typedef ULONG64 VMPTR_SimpleRWLock;
+typedef ULONG64 VMPTR_ReJitInfo;
+typedef ULONG64 VMPTR_SharedReJitInfo;
+typedef ULONG64 VMPTR_ILCodeVersionNode;
+typedef ULONG64 VMPTR_NativeCodeVersionNode;
+
+// Address and token types
+typedef ULONG64 CORDB_ADDRESS;
+typedef ULONG64 GENERICS_TYPE_TOKEN;
+typedef ULONG64 PCODE;
+typedef ULONG64 TADDR;
+typedef int CONNID;
+typedef ULONG64 TASKID;
+typedef int mdToken;
+typedef int mdTypeDef;
+typedef int mdMethodDef;
+
+// Context types
+typedef int T_CONTEXT;
+typedef int DT_CONTEXT;
+typedef int EXCEPTION_RECORD;
+
+// Metadata interface
+typedef int IMDInternalImport;
+
+// Enum types
+typedef int CorDebugThreadState;
+typedef int CorDebugUserState;
+typedef int CorDebugSetContextFlag;
+typedef int CorDebugNGENPolicy;
+typedef int CorElementType;
+typedef int AddressType;
+typedef int SymbolFormat;
+typedef int AreValueTypesBoxed;
+typedef int DelegateType;
+typedef int DynamicMethodType;
+typedef int FrameType;
+typedef int EHijackReason;
+typedef int CLR_DEBUGGING_PROCESS_FLAGS;
+
+// Size type
+typedef unsigned int SIZE_T;
+
+// HANDLE type (void* in native header)
+typedef UINT_PTR HANDLE;
+
+// Handle types (void** in native header, use UINT_PTR for pointer-sized IDL compatibility)
+typedef UINT_PTR StackWalkHandle;
+typedef UINT_PTR HeapWalkHandle;
+typedef UINT_PTR RefWalkHandle;
+
+// Callback data
+typedef LPVOID CALLBACK_DATA;
+
+// Cordebug types
+typedef int COR_HEAPOBJECT;
+typedef int COR_SEGMENT;
+typedef int COR_TYPEID;
+typedef int COR_FIELD;
+typedef int COR_TYPE_LAYOUT;
+typedef int COR_ARRAY_LAYOUT;
+typedef int COR_HEAPINFO;
+typedef int COR_MEMORY_RANGE;
+
+// DacDbiArrayList type params
+typedef int TypeInfoList;
+typedef int ArgInfoList;
+typedef int TypeParamsList;
+
+// DacDbiArrayList instantiations
+typedef struct { void *pList; int nEntries; } DacDbiArrayList_FieldData;
+typedef struct { void *pList; int nEntries; } DacDbiArrayList_DacExceptionCallStackData;
+typedef struct { void *pList; int nEntries; } DacDbiArrayList_ExpandedTypeData;
+typedef struct { void *pList; int nEntries; } DacDbiArrayList_CORDB_ADDRESS;
+typedef struct { void *pList; int nEntries; } DacDbiArrayList_GUID;
+typedef struct { void *pList; int nEntries; } DacDbiArrayList_COR_SEGMENT;
+typedef struct { void *pList; int nEntries; } DacDbiArrayList_COR_MEMORY_RANGE;
+typedef struct { void *pList; int nEntries; } DacDbiArrayList_AsyncLocalData;
+
+cpp_quote("#endif")
+
+//
+// Callback function pointer typedefs
+//
+typedef void (*FP_APPDOMAIN_ENUMERATION_CALLBACK)(VMPTR_AppDomain vmAppDomain, CALLBACK_DATA pUserData);
+typedef void (*FP_ASSEMBLY_ENUMERATION_CALLBACK)(VMPTR_DomainAssembly vmDomainAssembly, CALLBACK_DATA pUserData);
+typedef void (*FP_MODULE_ENUMERATION_CALLBACK)(VMPTR_Module vmModule, CALLBACK_DATA pUserData);
+typedef void (*FP_THREAD_ENUMERATION_CALLBACK)(VMPTR_Thread vmThread, CALLBACK_DATA pUserData);
+typedef BOOL (*FP_INTERNAL_FRAME_ENUMERATION_CALLBACK)(FramePointer fpFrame, CALLBACK_DATA pUserData);
+
+
+//
+// Inner callback interfaces
+//
+
+// IStringHolder - utility for passing strings out of DAC to DBI.
+// Not a COM interface — it is a plain C++ abstract class that may be stack-allocated.
+// Represented as an opaque pointer in the IDL.
+typedef void * IDacDbiStringHolder;
+
+// IAllocator - utility for DAC to allocate buffers in DBI memory space.
+[
+    object,
+    local,
+    uuid(97441D33-C82F-4106-B025-A912CB507526)
+]
+interface IDacDbiAllocator : IUnknown
+{
+    void * Alloc([in] SIZE_T lenBytes);
+    void Free([in] void * p);
+};
+
+// IMetaDataLookup - callback for DAC to obtain metadata importers from DBI.
+[
+    object,
+    local,
+    uuid(EF037312-925C-4A13-A9B5-3C1BB07B56FD)
+]
+interface IDacDbiMetaDataLookup : IUnknown
+{
+    IMDInternalImport * LookupMetaData([in] VMPTR_PEAssembly addressPEAssembly);
+};
+
+
+//
+// IDacDbiInterface - The main DAC to DBI communication interface.
+//
+// This interface provides the contract between the debugger's right-side (DBI)
+// and the data access component (DAC). All methods return HRESULT.
+//
+[
+    object,
+    local,
+    uuid(DB505C1B-A327-4A46-8C32-AF55A56F8E09)
+]
+interface IDacDbiInterface : IUnknown
+{
+    // Initialization
+    HRESULT CheckDbiVersion([in] const struct DbiVersion * pVersion);
+    HRESULT FlushCache();
+    HRESULT DacSetTargetConsistencyChecks([in] BOOL fEnableAsserts);
+
+    // Process State
+    HRESULT IsLeftSideInitialized([out] BOOL * pResult);
+
+    // App Domains
+    HRESULT GetAppDomainFromId([in] ULONG appdomainId, [out] VMPTR_AppDomain * pRetVal);
+    HRESULT GetAppDomainId([in] VMPTR_AppDomain vmAppDomain, [out] ULONG * pRetVal);
+    HRESULT GetAppDomainObject([in] VMPTR_AppDomain vmAppDomain, [out] VMPTR_OBJECTHANDLE * pRetVal);
+    HRESULT GetAssemblyFromDomainAssembly([in] VMPTR_DomainAssembly vmDomainAssembly, [out] VMPTR_Assembly * vmAssembly);
+    HRESULT IsAssemblyFullyTrusted([in] VMPTR_DomainAssembly vmDomainAssembly, [out] BOOL * pResult);
+    HRESULT GetAppDomainFullName([in] VMPTR_AppDomain vmAppDomain, [in] IDacDbiStringHolder pStrName);
+    HRESULT GetModuleSimpleName([in] VMPTR_Module vmModule, [in] IDacDbiStringHolder pStrFilename);
+    HRESULT GetAssemblyPath([in] VMPTR_Assembly vmAssembly, [in] IDacDbiStringHolder pStrFilename, [out] BOOL * pResult);
+
+    // Module
+    HRESULT ResolveTypeReference([in] const struct TypeRefData * pTypeRefInfo, [out] struct TypeRefData * pTargetRefInfo);
+    HRESULT GetModulePath([in] VMPTR_Module vmModule, [in] IDacDbiStringHolder pStrFilename, [out] BOOL * pResult);
+    HRESULT GetMetadata([in] VMPTR_Module vmModule, [out] struct TargetBuffer * pTargetBuffer);
+    HRESULT GetSymbolsBuffer([in] VMPTR_Module vmModule, [out] struct TargetBuffer * pTargetBuffer, [out] SymbolFormat * pSymbolFormat);
+    HRESULT GetModuleData([in] VMPTR_Module vmModule, [out] struct ModuleInfo * pData);
+    HRESULT GetDomainAssemblyData([in] VMPTR_DomainAssembly vmDomainAssembly, [out] struct DomainAssemblyInfo * pData);
+    HRESULT GetModuleForDomainAssembly([in] VMPTR_DomainAssembly vmDomainAssembly, [out] VMPTR_Module * pModule);
+
+    // Address
+    HRESULT GetAddressType([in] CORDB_ADDRESS address, [out] AddressType * pRetVal);
+    HRESULT IsTransitionStub([in] CORDB_ADDRESS address, [out] BOOL * pResult);
+
+    // Compiler
+    HRESULT GetCompilerFlags([in] VMPTR_DomainAssembly vmDomainAssembly, [out] BOOL * pfAllowJITOpts, [out] BOOL * pfEnableEnC);
+    HRESULT SetCompilerFlags([in] VMPTR_DomainAssembly vmDomainAssembly, [in] BOOL fAllowJitOpts, [in] BOOL fEnableEnC);
+
+    // Enumeration
+    HRESULT EnumerateAppDomains([in] FP_APPDOMAIN_ENUMERATION_CALLBACK fpCallback, [in] CALLBACK_DATA pUserData);
+    HRESULT EnumerateAssembliesInAppDomain([in] VMPTR_AppDomain vmAppDomain, [in] FP_ASSEMBLY_ENUMERATION_CALLBACK fpCallback, [in] CALLBACK_DATA pUserData);
+    HRESULT EnumerateModulesInAssembly([in] VMPTR_DomainAssembly vmAssembly, [in] FP_MODULE_ENUMERATION_CALLBACK fpCallback, [in] CALLBACK_DATA pUserData);
+
+    // Debug Events
+    HRESULT RequestSyncAtEvent();
+    HRESULT SetSendExceptionsOutsideOfJMC([in] BOOL sendExceptionsOutsideOfJMC);
+    HRESULT MarkDebuggerAttachPending();
+    HRESULT MarkDebuggerAttached([in] BOOL fAttached);
+    HRESULT Hijack(
+        [in] VMPTR_Thread vmThread,
+        [in] ULONG32 dwThreadId,
+        [in] const EXCEPTION_RECORD * pRecord,
+        [in] T_CONTEXT * pOriginalContext,
+        [in] ULONG32 cbSizeContext,
+        [in] EHijackReason reason,
+        [in] void * pUserData,
+        [out] CORDB_ADDRESS * pRemoteContextAddr);
+
+    // Thread
+    HRESULT EnumerateThreads([in] FP_THREAD_ENUMERATION_CALLBACK fpCallback, [in] CALLBACK_DATA pUserData);
+    HRESULT IsThreadMarkedDead([in] VMPTR_Thread vmThread, [out] BOOL * pResult);
+    HRESULT GetThreadHandle([in] VMPTR_Thread vmThread, [out] HANDLE * pRetVal);
+    HRESULT GetThreadObject([in] VMPTR_Thread vmThread, [out] VMPTR_OBJECTHANDLE * pRetVal);
+    HRESULT GetThreadAllocInfo([in] VMPTR_Thread vmThread, [out] struct DacThreadAllocInfo * threadAllocInfo);
+    HRESULT SetDebugState([in] VMPTR_Thread vmThread, [in] CorDebugThreadState debugState);
+    HRESULT HasUnhandledException([in] VMPTR_Thread vmThread, [out] BOOL * pResult);
+    HRESULT GetUserState([in] VMPTR_Thread vmThread, [out] CorDebugUserState * pRetVal);
+    HRESULT GetPartialUserState([in] VMPTR_Thread vmThread, [out] CorDebugUserState * pRetVal);
+    HRESULT GetConnectionID([in] VMPTR_Thread vmThread, [out] CONNID * pRetVal);
+    HRESULT GetTaskID([in] VMPTR_Thread vmThread, [out] TASKID * pRetVal);
+    HRESULT TryGetVolatileOSThreadID([in] VMPTR_Thread vmThread, [out] DWORD * pRetVal);
+    HRESULT GetUniqueThreadID([in] VMPTR_Thread vmThread, [out] DWORD * pRetVal);
+    HRESULT GetCurrentException([in] VMPTR_Thread vmThread, [out] VMPTR_OBJECTHANDLE * pRetVal);
+    HRESULT GetObjectForCCW([in] CORDB_ADDRESS ccwPtr, [out] VMPTR_OBJECTHANDLE * pRetVal);
+    HRESULT GetCurrentCustomDebuggerNotification([in] VMPTR_Thread vmThread, [out] VMPTR_OBJECTHANDLE * pRetVal);
+    HRESULT GetCurrentAppDomain([out] VMPTR_AppDomain * pRetVal);
+
+    // Assembly
+    HRESULT ResolveAssembly([in] VMPTR_DomainAssembly vmScope, [in] mdToken tkAssemblyRef, [out] VMPTR_DomainAssembly * pRetVal);
+
+    // Code and Debugging Info
+    HRESULT GetNativeCodeSequencePointsAndVarInfo(
+        [in] VMPTR_MethodDesc vmMethodDesc,
+        [in] CORDB_ADDRESS startAddress,
+        [in] BOOL fCodeAvailable,
+        [out] struct NativeVarData * pNativeVarData,
+        [out] struct SequencePoints * pSequencePoints);
+
+    // Context and Stack Walking
+    HRESULT GetManagedStoppedContext([in] VMPTR_Thread vmThread, [out] VMPTR_CONTEXT * pRetVal);
+    HRESULT CreateStackWalk([in] VMPTR_Thread vmThread, [in, out] DT_CONTEXT * pInternalContextBuffer, [out] StackWalkHandle * ppSFIHandle);
+    HRESULT DeleteStackWalk([in] StackWalkHandle ppSFIHandle);
+    HRESULT GetStackWalkCurrentContext([in] StackWalkHandle pSFIHandle, [out] DT_CONTEXT * pContext);
+    HRESULT SetStackWalkCurrentContext([in] VMPTR_Thread vmThread, [in] StackWalkHandle pSFIHandle, [in] CorDebugSetContextFlag flag, [in] DT_CONTEXT * pContext);
+    HRESULT UnwindStackWalkFrame([in] StackWalkHandle pSFIHandle, [out] BOOL * pResult);
+    HRESULT CheckContext([in] VMPTR_Thread vmThread, [in] const DT_CONTEXT * pContext);
+    HRESULT GetStackWalkCurrentFrameInfo([in] StackWalkHandle pSFIHandle, [out] struct DebuggerIPCE_STRData * pFrameData, [out] FrameType * pRetVal);
+    HRESULT GetCountOfInternalFrames([in] VMPTR_Thread vmThread, [out] ULONG32 * pRetVal);
+    HRESULT EnumerateInternalFrames([in] VMPTR_Thread vmThread, [in] FP_INTERNAL_FRAME_ENUMERATION_CALLBACK fpCallback, [in] CALLBACK_DATA pUserData);
+    HRESULT IsMatchingParentFrame([in] FramePointer fpToCheck, [in] FramePointer fpParent, [out] BOOL * pResult);
+    HRESULT GetStackParameterSize([in] CORDB_ADDRESS controlPC, [out] ULONG32 * pRetVal);
+    HRESULT GetFramePointer([in] StackWalkHandle pSFIHandle, [out] FramePointer * pRetVal);
+    HRESULT IsLeafFrame([in] VMPTR_Thread vmThread, [in] const DT_CONTEXT * pContext, [out] BOOL * pResult);
+    HRESULT GetContext([in] VMPTR_Thread vmThread, [out] DT_CONTEXT * pContextBuffer);
+    HRESULT ConvertContextToDebuggerRegDisplay([in] const DT_CONTEXT * pInContext, [out] struct DebuggerREGDISPLAY * pOutDRD, [in] BOOL fActive);
+
+    // Method
+    HRESULT IsDiagnosticsHiddenOrLCGMethod([in] VMPTR_MethodDesc vmMethodDesc, [out] DynamicMethodType * pRetVal);
+    HRESULT GetVarArgSig([in] CORDB_ADDRESS VASigCookieAddr, [out] CORDB_ADDRESS * pArgBase, [out] struct TargetBuffer * pRetVal);
+    HRESULT RequiresAlign8([in] VMPTR_TypeHandle thExact, [out] BOOL * pResult);
+    HRESULT ResolveExactGenericArgsToken([in] DWORD dwExactGenericArgsTokenIndex, [in] GENERICS_TYPE_TOKEN rawToken, [out] GENERICS_TYPE_TOKEN * pRetVal);
+    HRESULT GetILCodeAndSig([in] VMPTR_DomainAssembly vmDomainAssembly, [in] mdToken functionToken, [out] struct TargetBuffer * pCodeInfo, [out] mdToken * pLocalSigToken);
+    HRESULT GetNativeCodeInfo([in] VMPTR_DomainAssembly vmDomainAssembly, [in] mdToken functionToken, [out] struct NativeCodeFunctionData * pCodeInfo);
+    HRESULT GetNativeCodeInfoForAddr(
+        [in] CORDB_ADDRESS codeAddress,
+        [out] struct NativeCodeFunctionData * pCodeInfo,
+        [out] VMPTR_Module * pVmModule,
+        [out] mdToken * pFunctionToken);
+
+    // Type
+    HRESULT IsValueType([in] VMPTR_TypeHandle th, [out] BOOL * pResult);
+    HRESULT HasTypeParams([in] VMPTR_TypeHandle th, [out] BOOL * pResult);
+    HRESULT GetClassInfo([in] VMPTR_AppDomain vmAppDomain, [in] VMPTR_TypeHandle thExact, [out] struct ClassInfo * pData);
+    HRESULT GetInstantiationFieldInfo(
+        [in] VMPTR_DomainAssembly vmDomainAssembly,
+        [in] VMPTR_TypeHandle vmThExact,
+        [in] VMPTR_TypeHandle vmThApprox,
+        [out] DacDbiArrayList_FieldData * pFieldList,
+        [out] SIZE_T * pObjectSize);
+    HRESULT TypeHandleToExpandedTypeInfo([in] AreValueTypesBoxed boxed, [in] VMPTR_AppDomain vmAppDomain, [in] VMPTR_TypeHandle vmTypeHandle, [out] struct DebuggerIPCE_ExpandedTypeData * pTypeInfo);
+    HRESULT GetObjectExpandedTypeInfo([in] AreValueTypesBoxed boxed, [in] VMPTR_AppDomain vmAppDomain, [in] CORDB_ADDRESS addr, [out] struct DebuggerIPCE_ExpandedTypeData * pTypeInfo);
+    HRESULT GetObjectExpandedTypeInfoFromID([in] AreValueTypesBoxed boxed, [in] VMPTR_AppDomain vmAppDomain, [in] COR_TYPEID id, [out] struct DebuggerIPCE_ExpandedTypeData * pTypeInfo);
+    HRESULT GetTypeHandle([in] VMPTR_Module vmModule, [in] mdTypeDef metadataToken, [out] VMPTR_TypeHandle * pRetVal);
+    HRESULT GetApproxTypeHandle([in] TypeInfoList * pTypeData, [out] VMPTR_TypeHandle * pRetVal);
+    HRESULT GetExactTypeHandle([in] struct DebuggerIPCE_ExpandedTypeData * pTypeData, [in] ArgInfoList * pArgInfo, [out] VMPTR_TypeHandle * pVmTypeHandle);
+    HRESULT GetMethodDescParams(
+        [in] VMPTR_AppDomain vmAppDomain,
+        [in] VMPTR_MethodDesc vmMethodDesc,
+        [in] GENERICS_TYPE_TOKEN genericsToken,
+        [out] UINT32 * pcGenericClassTypeParams,
+        [out] TypeParamsList * pGenericTypeParams);
+
+    // Field
+    HRESULT GetThreadStaticAddress([in] VMPTR_FieldDesc vmField, [in] VMPTR_Thread vmRuntimeThread, [out] CORDB_ADDRESS * pRetVal);
+    HRESULT GetCollectibleTypeStaticAddress([in] VMPTR_FieldDesc vmField, [in] VMPTR_AppDomain vmAppDomain, [out] CORDB_ADDRESS * pRetVal);
+    HRESULT GetEnCHangingFieldInfo([in] const struct EnCHangingFieldInfo * pEnCFieldInfo, [out] struct FieldData * pFieldData, [out] BOOL * pfStatic);
+    HRESULT GetTypeHandleParams([in] VMPTR_AppDomain vmAppDomain, [in] VMPTR_TypeHandle vmTypeHandle, [out] TypeParamsList * pParams);
+    HRESULT GetSimpleType(
+        [in] VMPTR_AppDomain vmAppDomain,
+        [in] CorElementType simpleType,
+        [out] mdTypeDef * pMetadataToken,
+        [out] VMPTR_Module * pVmModule,
+        [out] VMPTR_DomainAssembly * pVmDomainAssembly);
+
+    // Exception and COM Interop
+    HRESULT IsExceptionObject([in] VMPTR_Object vmObject, [out] BOOL * pResult);
+    HRESULT GetStackFramesFromException([in] VMPTR_Object vmObject, [out] DacDbiArrayList_DacExceptionCallStackData * pDacStackFrames);
+    HRESULT IsRcw([in] VMPTR_Object vmObject, [out] BOOL * pResult);
+    HRESULT GetRcwCachedInterfaceTypes([in] VMPTR_Object vmObject, [in] VMPTR_AppDomain vmAppDomain, [in] BOOL bIInspectableOnly, [out] DacDbiArrayList_ExpandedTypeData * pDacInterfaces);
+    HRESULT GetRcwCachedInterfacePointers([in] VMPTR_Object vmObject, [in] BOOL bIInspectableOnly, [out] DacDbiArrayList_CORDB_ADDRESS * pDacItfPtrs);
+    HRESULT GetCachedWinRTTypesForIIDs([in] VMPTR_AppDomain vmAppDomain, [in] DacDbiArrayList_GUID * pIids, [out] DacDbiArrayList_ExpandedTypeData * pTypes);
+    HRESULT GetCachedWinRTTypes([in] VMPTR_AppDomain vmAppDomain, [out] DacDbiArrayList_GUID * piids, [out] DacDbiArrayList_ExpandedTypeData * pTypes);
+
+    // Object Data
+    HRESULT GetTypedByRefInfo([in] CORDB_ADDRESS pTypedByRef, [in] VMPTR_AppDomain vmAppDomain, [out] struct DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT GetStringData([in] CORDB_ADDRESS objectAddress, [out] struct DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT GetArrayData([in] CORDB_ADDRESS objectAddress, [out] struct DebuggerIPCE_ObjectData * pObjectData);
+    HRESULT GetBasicObjectInfo([in] CORDB_ADDRESS objectAddress, [in] CorElementType type, [in] VMPTR_AppDomain vmAppDomain, [out] struct DebuggerIPCE_ObjectData * pObjectData);
+
+    // Data Consistency (TEST_DATA_CONSISTENCY only)
+    HRESULT TestCrst([in] VMPTR_Crst vmCrst);
+    HRESULT TestRWLock([in] VMPTR_SimpleRWLock vmRWLock);
+
+    // Debugger Control Block
+    HRESULT GetDebuggerControlBlockAddress([out] CORDB_ADDRESS * pRetVal);
+
+    // Object Handles
+    HRESULT GetObjectFromRefPtr([in] CORDB_ADDRESS ptr, [out] VMPTR_Object * pRetVal);
+    HRESULT GetObject([in] CORDB_ADDRESS ptr, [out] VMPTR_Object * pRetVal);
+
+    // NGEN
+    HRESULT EnableNGENPolicy([in] CorDebugNGENPolicy ePolicy);
+    HRESULT SetNGENCompilerFlags([in] DWORD dwFlags);
+    HRESULT GetNGENCompilerFlags([out] DWORD * pdwFlags);
+
+    // VM Object Handle
+    HRESULT GetVmObjectHandle([in] CORDB_ADDRESS handleAddress, [out] VMPTR_OBJECTHANDLE * pRetVal);
+    HRESULT IsVmObjectHandleValid([in] VMPTR_OBJECTHANDLE vmHandle, [out] BOOL * pResult);
+    HRESULT IsWinRTModule([in] VMPTR_Module vmModule, [out] BOOL * pIsWinRT);
+    HRESULT GetAppDomainIdFromVmObjectHandle([in] VMPTR_OBJECTHANDLE vmHandle, [out] ULONG * pRetVal);
+    HRESULT GetHandleAddressFromVmHandle([in] VMPTR_OBJECTHANDLE vmHandle, [out] CORDB_ADDRESS * pRetVal);
+
+    // Object Contents and Monitor
+    HRESULT GetObjectContents([in] VMPTR_Object obj, [out] struct TargetBuffer * pRetVal);
+    HRESULT GetThreadOwningMonitorLock([in] VMPTR_Object vmObject, [out] struct MonitorLockInfo * pRetVal);
+    HRESULT EnumerateMonitorEventWaitList([in] VMPTR_Object vmObject, [in] FP_THREAD_ENUMERATION_CALLBACK fpCallback, [in] CALLBACK_DATA pUserData);
+
+    // Attach State
+    HRESULT GetAttachStateFlags([out] CLR_DEBUGGING_PROCESS_FLAGS * pRetVal);
+
+    // Metadata
+    HRESULT GetMetaDataFileInfoFromPEFile(
+        [in] VMPTR_PEAssembly vmPEAssembly,
+        [out] DWORD * pTimeStamp,
+        [out] DWORD * pImageSize,
+        [in] IDacDbiStringHolder pStrFilename,
+        [out] BOOL * pResult);
+
+    // Thread State
+    HRESULT IsThreadSuspendedOrHijacked([in] VMPTR_Thread vmThread, [out] BOOL * pResult);
+
+    // GC
+    HRESULT AreGCStructuresValid([out] BOOL * pResult);
+    HRESULT CreateHeapWalk([out] HeapWalkHandle * pHandle);
+    HRESULT DeleteHeapWalk([in] HeapWalkHandle handle);
+    HRESULT WalkHeap([in] HeapWalkHandle handle, [in] ULONG count, [out] COR_HEAPOBJECT * objects, [out] ULONG * pFetched);
+    HRESULT GetHeapSegments([out] DacDbiArrayList_COR_SEGMENT * pSegments);
+    HRESULT IsValidObject([in] CORDB_ADDRESS obj, [out] BOOL * pResult);
+    HRESULT GetAppDomainForObject(
+        [in] CORDB_ADDRESS obj,
+        [out] VMPTR_AppDomain * pApp,
+        [out] VMPTR_Module * pModule,
+        [out] VMPTR_DomainAssembly * pDomainAssembly,
+        [out] BOOL * pResult);
+
+    // Reference Walking
+    HRESULT CreateRefWalk([out] RefWalkHandle * pHandle, [in] BOOL walkStacks, [in] BOOL walkFQ, [in] UINT32 handleWalkMask);
+    HRESULT DeleteRefWalk([in] RefWalkHandle handle);
+    HRESULT WalkRefs([in] RefWalkHandle handle, [in] ULONG count, [out] struct DacGcReference * refs, [out] ULONG * pFetched);
+
+    // Type ID
+    HRESULT GetTypeID([in] CORDB_ADDRESS obj, [out] COR_TYPEID * pType);
+    HRESULT GetTypeIDForType([in] VMPTR_TypeHandle vmTypeHandle, [out] COR_TYPEID * pId);
+    HRESULT GetObjectFields([in] COR_TYPEID id, [in] ULONG32 celt, [out] COR_FIELD * layout, [out] ULONG32 * pceltFetched);
+    HRESULT GetTypeLayout([in] COR_TYPEID id, [out] COR_TYPE_LAYOUT * pLayout);
+    HRESULT GetArrayLayout([in] COR_TYPEID id, [out] COR_ARRAY_LAYOUT * pLayout);
+    HRESULT GetGCHeapInformation([out] COR_HEAPINFO * pHeapInfo);
+
+    // PE File
+    HRESULT GetPEFileMDInternalRW([in] VMPTR_PEAssembly vmPEAssembly, [out] TADDR * pAddrMDInternalRW);
+
+    // ReJit
+    HRESULT GetReJitInfo([in] VMPTR_Module vmModule, [in] mdMethodDef methodTk, [out] VMPTR_ReJitInfo * pReJitInfo);
+    // Note: Named GetReJitInfoByAddress in IDL because COM does not support overloads.
+    // Corresponds to the second GetReJitInfo overload in dacdbiinterface.h.
+    HRESULT GetReJitInfoByAddress([in] VMPTR_MethodDesc vmMethod, [in] CORDB_ADDRESS codeStartAddress, [out] VMPTR_ReJitInfo * pReJitInfo);
+    HRESULT GetSharedReJitInfo([in] VMPTR_ReJitInfo vmReJitInfo, [out] VMPTR_SharedReJitInfo * pSharedReJitInfo);
+    HRESULT GetSharedReJitInfoData([in] VMPTR_SharedReJitInfo sharedReJitInfo, [out] struct DacSharedReJitInfo * pData);
+    HRESULT AreOptimizationsDisabled([in] VMPTR_Module vmModule, [in] mdMethodDef methodTk, [out] BOOL * pOptimizationsDisabled);
+
+    // Defines
+    HRESULT GetDefinesBitField([out] ULONG32 * pDefines);
+    HRESULT GetMDStructuresVersion([out] ULONG32 * pMDStructuresVersion);
+
+    // Code Versioning (FEATURE_CODE_VERSIONING only)
+    HRESULT GetActiveRejitILCodeVersionNode([in] VMPTR_Module vmModule, [in] mdMethodDef methodTk, [out] VMPTR_ILCodeVersionNode * pVmILCodeVersionNode);
+    HRESULT GetNativeCodeVersionNode([in] VMPTR_MethodDesc vmMethod, [in] CORDB_ADDRESS codeStartAddress, [out] VMPTR_NativeCodeVersionNode * pVmNativeCodeVersionNode);
+    HRESULT GetILCodeVersionNode([in] VMPTR_NativeCodeVersionNode vmNativeCodeVersionNode, [out] VMPTR_ILCodeVersionNode * pVmILCodeVersionNode);
+    HRESULT GetILCodeVersionNodeData([in] VMPTR_ILCodeVersionNode ilCodeVersionNode, [out] struct DacSharedReJitInfo * pData);
+
+    // Miscellaneous
+    HRESULT EnableGCNotificationEvents([in] BOOL fEnable);
+
+    // Delegate
+    HRESULT IsDelegate([in] VMPTR_Object vmObject, [out] BOOL * pResult);
+    HRESULT GetDelegateType([in] VMPTR_Object delegateObject, [out] DelegateType * delegateType);
+    HRESULT GetDelegateFunctionData(
+        [in] DelegateType delegateType,
+        [in] VMPTR_Object delegateObject,
+        [out] VMPTR_DomainAssembly * ppFunctionDomainAssembly,
+        [out] mdMethodDef * pMethodDef);
+    HRESULT GetDelegateTargetObject(
+        [in] DelegateType delegateType,
+        [in] VMPTR_Object delegateObject,
+        [out] VMPTR_Object * ppTargetObj,
+        [out] VMPTR_AppDomain * ppTargetAppDomain);
+
+    // Loader Heap
+    HRESULT GetLoaderHeapMemoryRanges([out] DacDbiArrayList_COR_MEMORY_RANGE * pRanges);
+
+    // Module Mapping
+    HRESULT IsModuleMapped([in] VMPTR_Module pModule, [out] BOOL * isModuleMapped);
+    HRESULT MetadataUpdatesApplied([out] BOOL * pResult);
+    HRESULT GetDomainAssemblyFromModule([in] VMPTR_Module vmModule, [out] VMPTR_DomainAssembly * pVmDomainAssembly);
+
+    // Async and Continuations
+    HRESULT ParseContinuation(
+        [in] CORDB_ADDRESS continuationAddress,
+        [out] PCODE * pDiagnosticIP,
+        [out] CORDB_ADDRESS * pNextContinuation,
+        [out] UINT32 * pState);
+    HRESULT GetAsyncLocals([in] VMPTR_MethodDesc vmMethod, [in] CORDB_ADDRESS codeAddr, [in] UINT32 state, [out] DacDbiArrayList_AsyncLocalData * pAsyncLocals);
+
+    // Generic Arg Token
+    HRESULT GetGenericArgTokenIndex([in] VMPTR_MethodDesc vmMethod, [out] UINT32 * pTokenIndex);
+};

--- a/src/coreclr/pal/prebuilt/idl/dacdbi_i.cpp
+++ b/src/coreclr/pal/prebuilt/idl/dacdbi_i.cpp
@@ -1,0 +1,87 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+/* this ALWAYS GENERATED file contains the IIDs and CLSIDs */
+
+/* link this file in with the server and any clients */
+
+
+ /* File created by MIDL compiler version 8.01.0628 */
+/* Compiler settings for dacdbi.idl:
+    Oicf, W1, Zp8, env=Win64 (32b run), target_arch=AMD64 8.01.0628
+    protocol : dce , ms_ext, c_ext, robust
+    error checks: allocation ref bounds_check enum stub_data
+    VC __declspec() decoration level:
+         __declspec(uuid()), __declspec(selectany), __declspec(novtable)
+         DECLSPEC_UUID(), MIDL_INTERFACE()
+*/
+/* @@MIDL_FILE_HEADING(  ) */
+
+#pragma warning( disable: 4049 )  /* more than 64k source lines */
+
+
+#ifdef __cplusplus
+extern "C"{
+#endif
+
+
+#include <rpc.h>
+#include <rpcndr.h>
+
+#ifdef _MIDL_USE_GUIDDEF_
+
+#ifndef INITGUID
+#define INITGUID
+#include <guiddef.h>
+#undef INITGUID
+#else
+#include <guiddef.h>
+#endif
+
+#define MIDL_DEFINE_GUID(type,name,l,w1,w2,b1,b2,b3,b4,b5,b6,b7,b8) \
+        DEFINE_GUID(name,l,w1,w2,b1,b2,b3,b4,b5,b6,b7,b8)
+
+#else // !_MIDL_USE_GUIDDEF_
+
+#ifndef __IID_DEFINED__
+#define __IID_DEFINED__
+
+typedef struct _IID
+{
+    unsigned long x;
+    unsigned short s1;
+    unsigned short s2;
+    unsigned char  c[8];
+} IID;
+
+#endif // __IID_DEFINED__
+
+#ifndef CLSID_DEFINED
+#define CLSID_DEFINED
+typedef IID CLSID;
+#endif // CLSID_DEFINED
+
+#define MIDL_DEFINE_GUID(type,name,l,w1,w2,b1,b2,b3,b4,b5,b6,b7,b8) \
+        EXTERN_C __declspec(selectany) const type name = {l,w1,w2,{b1,b2,b3,b4,b5,b6,b7,b8}}
+
+#endif // !_MIDL_USE_GUIDDEF_
+
+
+// IDacDbiAllocator: {97441D33-C82F-4106-B025-A912CB507526}
+MIDL_DEFINE_GUID(IID, IID_IDacDbiAllocator,0x97441d33,0xc82f,0x4106,0xb0,0x25,0xa9,0x12,0xcb,0x50,0x75,0x26);
+
+
+// IDacDbiMetaDataLookup: {EF037312-925C-4A13-A9B5-3C1BB07B56FD}
+MIDL_DEFINE_GUID(IID, IID_IDacDbiMetaDataLookup,0xef037312,0x925c,0x4a13,0xa9,0xb5,0x3c,0x1b,0xb0,0x7b,0x56,0xfd);
+
+
+// IDacDbiInterface: {DB505C1B-A327-4A46-8C32-AF55A56F8E09}
+MIDL_DEFINE_GUID(IID, IID_IDacDbiInterface,0xdb505c1b,0xa327,0x4a46,0x8c,0x32,0xaf,0x55,0xa5,0x6f,0x8e,0x09);
+
+#undef MIDL_DEFINE_GUID
+
+#ifdef __cplusplus
+}
+#endif
+
+

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/Dbi/IDacDbiInterface.cs
@@ -1,0 +1,624 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+
+namespace Microsoft.Diagnostics.DataContractReader.Legacy;
+
+[StructLayout(LayoutKind.Sequential)]
+public struct DbiVersion
+{
+    public uint m_dwFormat;
+    public uint m_dwDbiVersion;
+    public uint m_dwProtocolBreakingChangeCounter;
+    public uint m_dwReservedMustBeZero1;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct COR_TYPEID
+{
+    public ulong token1;
+    public ulong token2;
+}
+
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+
+[StructLayout(LayoutKind.Sequential)]
+public struct DacDbiTargetBuffer
+{
+    public ulong pAddress;
+    public uint cbSize;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct DacDbiDomainAssemblyInfo
+{
+    public ulong vmAppDomain;
+    public ulong vmDomainAssembly;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct DacDbiModuleInfo
+{
+    public ulong vmAssembly;
+    public ulong pPEBaseAddress;
+    public ulong vmPEAssembly;
+    public uint nPESize;
+    public Interop.BOOL fIsDynamic;
+    public Interop.BOOL fInMemory;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct DacDbiMonitorLockInfo
+{
+    public ulong lockOwner;
+    public uint acquisitionCount;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct DacDbiThreadAllocInfo
+{
+    public ulong allocBytesSOH;
+    public ulong allocBytesUOH;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct DacDbiTypeRefData
+{
+    public ulong vmDomainAssembly;
+    public uint typeToken;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct DacDbiSharedReJitInfo
+{
+    public uint state;
+    public ulong pbIL;
+    public uint dwCodegenFlags;
+    public uint cInstrumentedMapEntries;
+    public ulong rgInstrumentedMapEntries;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct DacDbiExceptionCallStackData
+{
+    public ulong vmAppDomain;
+    public ulong vmDomainAssembly;
+    public ulong ip;
+    public uint methodDef;
+    public Interop.BOOL isLastForeignExceptionFrame;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct COR_HEAPINFO
+{
+    public Interop.BOOL areGCStructuresValid;
+    public uint pointerSize;
+    public uint numHeaps;
+    public Interop.BOOL concurrent;
+    public int gcType;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct COR_HEAPOBJECT
+{
+    public ulong address;
+    public ulong size;
+    public COR_TYPEID type;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct COR_SEGMENT
+{
+    public ulong start;
+    public ulong end;
+    public int type;
+    public uint heap;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct COR_TYPE_LAYOUT
+{
+    public COR_TYPEID parentID;
+    public uint objectSize;
+    public uint numFields;
+    public uint boxOffset;
+    public int type;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct COR_FIELD
+{
+    public uint token;
+    public uint offset;
+    public COR_TYPEID id;
+    public int fieldType;
+}
+
+#pragma warning restore CS0649
+
+// Name-surface projection of IDacDbiInterface in native method order for COM binding validation.
+// Parameter shapes are intentionally coarse placeholders and will be refined with method implementation work.
+[GeneratedComInterface]
+[Guid("DB505C1B-A327-4A46-8C32-AF55A56F8E09")]
+public unsafe partial interface IDacDbiInterface
+{
+    [PreserveSig]
+    int CheckDbiVersion(DbiVersion* pVersion);
+
+    [PreserveSig]
+    int FlushCache();
+
+    [PreserveSig]
+    int DacSetTargetConsistencyChecks(Interop.BOOL fEnableAsserts);
+
+    [PreserveSig]
+    int IsLeftSideInitialized(Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int GetAppDomainFromId(uint appdomainId, ulong* pRetVal);
+
+    [PreserveSig]
+    int GetAppDomainId(ulong vmAppDomain, uint* pRetVal);
+
+    [PreserveSig]
+    int GetAppDomainObject(ulong vmAppDomain, ulong* pRetVal);
+
+    [PreserveSig]
+    int GetAssemblyFromDomainAssembly(ulong vmDomainAssembly, ulong* vmAssembly);
+
+    [PreserveSig]
+    int IsAssemblyFullyTrusted(ulong vmDomainAssembly, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int GetAppDomainFullName(ulong vmAppDomain, nint pStrName);
+
+    [PreserveSig]
+    int GetModuleSimpleName(ulong vmModule, nint pStrFilename);
+
+    [PreserveSig]
+    int GetAssemblyPath(ulong vmAssembly, nint pStrFilename, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int ResolveTypeReference(DacDbiTypeRefData* pTypeRefInfo, DacDbiTypeRefData* pTargetRefInfo);
+
+    [PreserveSig]
+    int GetModulePath(ulong vmModule, nint pStrFilename, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int GetMetadata(ulong vmModule, DacDbiTargetBuffer* pTargetBuffer);
+
+    [PreserveSig]
+    int GetSymbolsBuffer(ulong vmModule, DacDbiTargetBuffer* pTargetBuffer, int* pSymbolFormat);
+
+    [PreserveSig]
+    int GetModuleData(ulong vmModule, DacDbiModuleInfo* pData);
+
+    [PreserveSig]
+    int GetDomainAssemblyData(ulong vmDomainAssembly, DacDbiDomainAssemblyInfo* pData);
+
+    [PreserveSig]
+    int GetModuleForDomainAssembly(ulong vmDomainAssembly, ulong* pModule);
+
+    [PreserveSig]
+    int GetAddressType(ulong address, int* pRetVal);
+
+    [PreserveSig]
+    int IsTransitionStub(ulong address, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int GetCompilerFlags(ulong vmDomainAssembly, Interop.BOOL* pfAllowJITOpts, Interop.BOOL* pfEnableEnC);
+
+    [PreserveSig]
+    int SetCompilerFlags(ulong vmDomainAssembly, Interop.BOOL fAllowJitOpts, Interop.BOOL fEnableEnC);
+
+    [PreserveSig]
+    int EnumerateAppDomains(nint fpCallback, nint pUserData);
+
+    [PreserveSig]
+    int EnumerateAssembliesInAppDomain(ulong vmAppDomain, nint fpCallback, nint pUserData);
+
+    [PreserveSig]
+    int EnumerateModulesInAssembly(ulong vmAssembly, nint fpCallback, nint pUserData);
+
+    [PreserveSig]
+    int RequestSyncAtEvent();
+
+    [PreserveSig]
+    int SetSendExceptionsOutsideOfJMC(Interop.BOOL sendExceptionsOutsideOfJMC);
+
+    [PreserveSig]
+    int MarkDebuggerAttachPending();
+
+    [PreserveSig]
+    int MarkDebuggerAttached(Interop.BOOL fAttached);
+
+    [PreserveSig]
+    int Hijack(ulong vmThread, uint dwThreadId, nint pRecord, nint pOriginalContext, uint cbSizeContext, int reason, nint pUserData, ulong* pRemoteContextAddr);
+
+    [PreserveSig]
+    int EnumerateThreads(nint fpCallback, nint pUserData);
+
+    [PreserveSig]
+    int IsThreadMarkedDead(ulong vmThread, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int GetThreadHandle(ulong vmThread, nint pRetVal);
+
+    [PreserveSig]
+    int GetThreadObject(ulong vmThread, ulong* pRetVal);
+
+    [PreserveSig]
+    int GetThreadAllocInfo(ulong vmThread, DacDbiThreadAllocInfo* pThreadAllocInfo);
+
+    [PreserveSig]
+    int SetDebugState(ulong vmThread, int debugState);
+
+    [PreserveSig]
+    int HasUnhandledException(ulong vmThread, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int GetUserState(ulong vmThread, int* pRetVal);
+
+    [PreserveSig]
+    int GetPartialUserState(ulong vmThread, int* pRetVal);
+
+    [PreserveSig]
+    int GetConnectionID(ulong vmThread, uint* pRetVal);
+
+    [PreserveSig]
+    int GetTaskID(ulong vmThread, ulong* pRetVal);
+
+    [PreserveSig]
+    int TryGetVolatileOSThreadID(ulong vmThread, uint* pRetVal);
+
+    [PreserveSig]
+    int GetUniqueThreadID(ulong vmThread, uint* pRetVal);
+
+    [PreserveSig]
+    int GetCurrentException(ulong vmThread, ulong* pRetVal);
+
+    [PreserveSig]
+    int GetObjectForCCW(ulong ccwPtr, ulong* pRetVal);
+
+    [PreserveSig]
+    int GetCurrentCustomDebuggerNotification(ulong vmThread, ulong* pRetVal);
+
+    [PreserveSig]
+    int GetCurrentAppDomain(ulong* pRetVal);
+
+    [PreserveSig]
+    int ResolveAssembly(ulong vmScope, uint tkAssemblyRef, ulong* pRetVal);
+
+    [PreserveSig]
+    int GetNativeCodeSequencePointsAndVarInfo(ulong vmMethodDesc, ulong startAddress, Interop.BOOL fCodeAvailable, nint pNativeVarData, nint pSequencePoints);
+
+    [PreserveSig]
+    int GetManagedStoppedContext(ulong vmThread, ulong* pRetVal);
+
+    [PreserveSig]
+    int CreateStackWalk(ulong vmThread, nint pInternalContextBuffer, nuint* ppSFIHandle);
+
+    [PreserveSig]
+    int DeleteStackWalk(nuint ppSFIHandle);
+
+    [PreserveSig]
+    int GetStackWalkCurrentContext(nuint pSFIHandle, nint pContext);
+
+    [PreserveSig]
+    int SetStackWalkCurrentContext(ulong vmThread, nuint pSFIHandle, int flag, nint pContext);
+
+    [PreserveSig]
+    int UnwindStackWalkFrame(nuint pSFIHandle, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int CheckContext(ulong vmThread, nint pContext);
+
+    [PreserveSig]
+    int GetStackWalkCurrentFrameInfo(nuint pSFIHandle, nint pFrameData, int* pRetVal);
+
+    [PreserveSig]
+    int GetCountOfInternalFrames(ulong vmThread, uint* pRetVal);
+
+    [PreserveSig]
+    int EnumerateInternalFrames(ulong vmThread, nint fpCallback, nint pUserData);
+
+    [PreserveSig]
+    int IsMatchingParentFrame(ulong fpToCheck, ulong fpParent, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int GetStackParameterSize(ulong controlPC, uint* pRetVal);
+
+    [PreserveSig]
+    int GetFramePointer(nuint pSFIHandle, ulong* pRetVal);
+
+    [PreserveSig]
+    int IsLeafFrame(ulong vmThread, nint pContext, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int GetContext(ulong vmThread, nint pContextBuffer);
+
+    [PreserveSig]
+    int ConvertContextToDebuggerRegDisplay(nint pInContext, nint pOutDRD, Interop.BOOL fActive);
+
+    [PreserveSig]
+    int IsDiagnosticsHiddenOrLCGMethod(ulong vmMethodDesc, int* pRetVal);
+
+    [PreserveSig]
+    int GetVarArgSig(ulong VASigCookieAddr, ulong* pArgBase, DacDbiTargetBuffer* pRetVal);
+
+    [PreserveSig]
+    int RequiresAlign8(ulong thExact, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int ResolveExactGenericArgsToken(uint dwExactGenericArgsTokenIndex, ulong rawToken, ulong* pRetVal);
+
+    [PreserveSig]
+    int GetILCodeAndSig(ulong vmDomainAssembly, uint functionToken, DacDbiTargetBuffer* pTargetBuffer, uint* pLocalSigToken);
+
+    [PreserveSig]
+    int GetNativeCodeInfo(ulong vmDomainAssembly, uint functionToken, nint pJitManagerList);
+
+    [PreserveSig]
+    int GetNativeCodeInfoForAddr(ulong codeAddress, nint pCodeInfo, ulong* pVmModule, uint* pFunctionToken);
+
+    [PreserveSig]
+    int IsValueType(ulong vmTypeHandle, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int HasTypeParams(ulong vmTypeHandle, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int GetClassInfo(ulong vmAppDomain, ulong thExact, nint pData);
+
+    [PreserveSig]
+    int GetInstantiationFieldInfo(ulong vmDomainAssembly, ulong vmTypeHandle, ulong vmExactMethodTable, nint pFieldList, nuint* pObjectSize);
+
+    [PreserveSig]
+    int TypeHandleToExpandedTypeInfo(int boxed, ulong vmAppDomain, ulong vmTypeHandle, nint pData);
+
+    [PreserveSig]
+    int GetObjectExpandedTypeInfo(int boxed, ulong vmAppDomain, ulong addr, nint pTypeInfo);
+
+    [PreserveSig]
+    int GetObjectExpandedTypeInfoFromID(int boxed, ulong vmAppDomain, COR_TYPEID id, nint pTypeInfo);
+
+    [PreserveSig]
+    int GetTypeHandle(ulong vmModule, uint metadataToken, ulong* pRetVal);
+
+    [PreserveSig]
+    int GetApproxTypeHandle(nint pTypeData, ulong* pRetVal);
+
+    [PreserveSig]
+    int GetExactTypeHandle(nint pTypeData, nint pArgInfo, ulong* pVmTypeHandle);
+
+    [PreserveSig]
+    int GetMethodDescParams(ulong vmAppDomain, ulong vmMethodDesc, ulong genericsToken, uint* pcGenericClassTypeParams, nint pGenericTypeParams);
+
+    [PreserveSig]
+    int GetThreadStaticAddress(ulong vmField, ulong vmRuntimeThread, ulong* pRetVal);
+
+    [PreserveSig]
+    int GetCollectibleTypeStaticAddress(ulong vmField, ulong vmAppDomain, ulong* pRetVal);
+
+    [PreserveSig]
+    int GetEnCHangingFieldInfo(nint pEnCFieldInfo, nint pFieldData, Interop.BOOL* pfStatic);
+
+    [PreserveSig]
+    int GetTypeHandleParams(ulong vmAppDomain, ulong vmTypeHandle, nint pParams);
+
+    [PreserveSig]
+    int GetSimpleType(ulong vmAppDomain, int simpleType, uint* pMetadataToken, ulong* pVmModule, ulong* pVmDomainAssembly);
+
+    [PreserveSig]
+    int IsExceptionObject(ulong vmObject, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int GetStackFramesFromException(ulong vmObject, nint pDacStackFrames);
+
+    [PreserveSig]
+    int IsRcw(ulong vmObject, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int GetRcwCachedInterfaceTypes(ulong vmObject, ulong vmAppDomain, Interop.BOOL bIInspectableOnly, nint pDacInterfaces);
+
+    [PreserveSig]
+    int GetRcwCachedInterfacePointers(ulong vmObject, Interop.BOOL bIInspectableOnly, nint pDacItfPtrs);
+
+    [PreserveSig]
+    int GetCachedWinRTTypesForIIDs(ulong vmAppDomain, nint pIids, nint pTypes);
+
+    [PreserveSig]
+    int GetCachedWinRTTypes(ulong vmAppDomain, nint piids, nint pTypes);
+
+    [PreserveSig]
+    int GetTypedByRefInfo(ulong pTypedByRef, ulong vmAppDomain, nint pObjectData);
+
+    [PreserveSig]
+    int GetStringData(ulong objectAddress, nint pObjectData);
+
+    [PreserveSig]
+    int GetArrayData(ulong objectAddress, nint pObjectData);
+
+    [PreserveSig]
+    int GetBasicObjectInfo(ulong objectAddress, int type, ulong vmAppDomain, nint pObjectData);
+
+    [PreserveSig]
+    int TestCrst(ulong vmCrst);
+
+    [PreserveSig]
+    int TestRWLock(ulong vmRWLock);
+
+    [PreserveSig]
+    int GetDebuggerControlBlockAddress(ulong* pRetVal);
+
+    [PreserveSig]
+    int GetObjectFromRefPtr(ulong ptr, ulong* pRetVal);
+
+    [PreserveSig]
+    int GetObject(ulong ptr, ulong* pRetVal);
+
+    [PreserveSig]
+    int EnableNGENPolicy(int ePolicy);
+
+    [PreserveSig]
+    int SetNGENCompilerFlags(uint dwFlags);
+
+    [PreserveSig]
+    int GetNGENCompilerFlags(uint* pdwFlags);
+
+    [PreserveSig]
+    int GetVmObjectHandle(ulong handleAddress, ulong* pRetVal);
+
+    [PreserveSig]
+    int IsVmObjectHandleValid(ulong vmHandle, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int IsWinRTModule(ulong vmModule, Interop.BOOL* isWinRT);
+
+    [PreserveSig]
+    int GetAppDomainIdFromVmObjectHandle(ulong vmHandle, uint* pRetVal);
+
+    [PreserveSig]
+    int GetHandleAddressFromVmHandle(ulong vmHandle, ulong* pRetVal);
+
+    [PreserveSig]
+    int GetObjectContents(ulong obj, DacDbiTargetBuffer* pRetVal);
+
+    [PreserveSig]
+    int GetThreadOwningMonitorLock(ulong vmObject, DacDbiMonitorLockInfo* pRetVal);
+
+    [PreserveSig]
+    int EnumerateMonitorEventWaitList(ulong vmObject, nint fpCallback, nint pUserData);
+
+    [PreserveSig]
+    int GetAttachStateFlags(int* pRetVal);
+
+    [PreserveSig]
+    int GetMetaDataFileInfoFromPEFile(ulong vmPEAssembly, uint* dwTimeStamp, uint* dwImageSize, nint pStrFilename, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int IsThreadSuspendedOrHijacked(ulong vmThread, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int AreGCStructuresValid(Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int CreateHeapWalk(nuint* pHandle);
+
+    [PreserveSig]
+    int DeleteHeapWalk(nuint handle);
+
+    [PreserveSig]
+    int WalkHeap(nuint handle, uint count, COR_HEAPOBJECT* objects, uint* fetched);
+
+    [PreserveSig]
+    int GetHeapSegments(nint pSegments);
+
+    [PreserveSig]
+    int IsValidObject(ulong obj, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int GetAppDomainForObject(ulong obj, ulong* pApp, ulong* pModule, ulong* pDomainAssembly, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int CreateRefWalk(nuint* pHandle, Interop.BOOL walkStacks, Interop.BOOL walkFQ, uint handleWalkMask);
+
+    [PreserveSig]
+    int DeleteRefWalk(nuint handle);
+
+    [PreserveSig]
+    int WalkRefs(nuint handle, uint count, nint refs, uint* pFetched);
+
+    [PreserveSig]
+    int GetTypeID(ulong obj, COR_TYPEID* pType);
+
+    [PreserveSig]
+    int GetTypeIDForType(ulong vmTypeHandle, COR_TYPEID* pId);
+
+    [PreserveSig]
+    int GetObjectFields(nint id, uint celt, COR_FIELD* layout, uint* pceltFetched);
+
+    [PreserveSig]
+    int GetTypeLayout(nint id, COR_TYPE_LAYOUT* pLayout);
+
+    [PreserveSig]
+    int GetArrayLayout(nint id, nint pLayout);
+
+    [PreserveSig]
+    int GetGCHeapInformation(COR_HEAPINFO* pHeapInfo);
+
+    [PreserveSig]
+    int GetPEFileMDInternalRW(ulong vmPEAssembly, ulong* pAddrMDInternalRW);
+
+    [PreserveSig]
+    int GetReJitInfo(ulong vmModule, uint methodTk, ulong* pReJitInfo);
+
+    [PreserveSig]
+    // DEPRECATED - use GetNativeCodeVersionNode
+    int GetReJitInfoByAddress(ulong vmMethod, ulong codeStartAddress, ulong* pReJitInfo);
+
+    [PreserveSig]
+    int GetSharedReJitInfo(ulong vmReJitInfo, ulong* pSharedReJitInfo);
+
+    [PreserveSig]
+    int GetSharedReJitInfoData(ulong sharedReJitInfo, DacDbiSharedReJitInfo* pData);
+
+    [PreserveSig]
+    int AreOptimizationsDisabled(ulong vmModule, uint methodTk, Interop.BOOL* pOptimizationsDisabled);
+
+    [PreserveSig]
+    int GetDefinesBitField(uint* pDefines);
+
+    [PreserveSig]
+    int GetMDStructuresVersion(uint* pMDStructuresVersion);
+
+    [PreserveSig]
+    int GetActiveRejitILCodeVersionNode(ulong vmModule, uint methodTk, ulong* pVmILCodeVersionNode);
+
+    [PreserveSig]
+    int GetNativeCodeVersionNode(ulong vmMethod, ulong codeStartAddress, ulong* pVmNativeCodeVersionNode);
+
+    [PreserveSig]
+    int GetILCodeVersionNode(ulong vmNativeCodeVersionNode, ulong* pVmILCodeVersionNode);
+
+    [PreserveSig]
+    int GetILCodeVersionNodeData(ulong ilCodeVersionNode, DacDbiSharedReJitInfo* pData);
+
+    [PreserveSig]
+    int EnableGCNotificationEvents(Interop.BOOL fEnable);
+
+    [PreserveSig]
+    int IsDelegate(ulong vmObject, Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int GetDelegateType(ulong delegateObject, int* delegateType);
+
+    [PreserveSig]
+    int GetDelegateFunctionData(int delegateType, ulong delegateObject, ulong* ppFunctionDomainAssembly, uint* pMethodDef);
+
+    [PreserveSig]
+    int GetDelegateTargetObject(int delegateType, ulong delegateObject, ulong* ppTargetObj, ulong* ppTargetAppDomain);
+
+    [PreserveSig]
+    int GetLoaderHeapMemoryRanges(nint pRanges);
+
+    [PreserveSig]
+    int IsModuleMapped(ulong pModule, int* isModuleMapped);
+
+    [PreserveSig]
+    int MetadataUpdatesApplied(Interop.BOOL* pResult);
+
+    [PreserveSig]
+    int GetDomainAssemblyFromModule(ulong vmModule, ulong* pVmDomainAssembly);
+
+    [PreserveSig]
+    int ParseContinuation(ulong continuationAddress, ulong* pDiagnosticIP, ulong* pNextContinuation, uint* pState);
+
+    [PreserveSig]
+    int GetAsyncLocals(ulong vmMethod, ulong codeAddr, uint state, nint pAsyncLocals);
+
+    [PreserveSig]
+    int GetGenericArgTokenIndex(ulong vmMethod, uint* pIndex);
+}


### PR DESCRIPTION
## Summary

Converts `IDacDbiInterface` from a plain C++ abstract class into a proper COM interface, enabling future implementation in managed C# via the cDAC. This follows the same pattern used by `ISOSDacInterface` / `SOSDacImpl`.

### Motivation

This is Phase 1 of enabling the cDAC (contract-based Data Access Component) to implement `IDacDbiInterface` in managed C#. The prior PR #124836 converted all methods to return HRESULT; this PR completes the COM conversion by making `IDacDbiInterface` a standard COM interface that can be consumed via `[GeneratedComInterface]` in C#.

### Types of Changes

Each change below was required to convert from a C++ abstract class to a valid COM interface:

#### 1. IUnknown Inheritance
`IDacDbiInterface` now inherits from `IUnknown` via `MIDL_INTERFACE`. This gives the interface a stable GUID identity, enabling `QueryInterface` discovery and standard COM ref-counting. Required because COM interfaces must derive from `IUnknown` -- it's the root of all COM.

#### 2. Lifecycle: Destroy() to Release()
Removed the custom `Destroy()` method. COM objects manage their lifetime through `AddRef()`/`Release()` ref-counting -- when the last reference is released, the destructor runs automatically. Having a separate `Destroy()` would conflict with this model.

#### 3. QueryInterface/AddRef/Release Implementation
`DacDbiInterfaceImpl` inherits `IUnknown` from two paths (via `ClrDataAccess` and via `IDacDbiInterface`), creating diamond inheritance. The explicit QI/AddRef/Release implementations resolve this by delegating to `ClrDataAccess` while also handling the new `IDacDbiInterface` IID.

#### 4. STDMETHODCALLTYPE Calling Convention
All interface methods now use `STDMETHODCALLTYPE` (`__stdcall` on Windows) to match the COM binary standard. This follows the same pattern used by `ClrDataAccess` in dacimpl.h. Required because COM defines a fixed calling convention for vtable dispatch.

#### 5. bool to BOOL
All `bool` parameters converted to `BOOL` (a 32-bit `int`). C++ `bool` is 1 byte with platform-dependent behavior, which can't be reliably marshaled across COM boundaries. `BOOL` is the standard COM boolean type with well-defined size and marshaling.

#### 6. References to Pointers
C++ reference parameters (`T&`) converted to pointers (`T*`) with `E_POINTER` null checks. References are a C++ language feature with no representation in IDL or other languages. COM uses pointers for all indirection, and the null checks follow COM convention for validating output parameters.

#### 7. IAllocator & IMetaDataLookup to IUnknown
These inner callback interfaces now inherit from `IUnknown` with their own GUIDs. They're implemented by heap-allocated `CordbProcess` and passed across the DAC/DBI boundary, so they need proper COM identity. `CordbProcess::QueryInterface` updated to expose them.

#### 8. IStringHolder -- NOT Converted
`IStringHolder` intentionally remains a plain C++ abstract class. It's implemented by stack-allocated `StringCopyHolder` objects, which violates COM's ref-counting contract (you can't `delete this` on a stack object). It's represented as an opaque `void*` in the IDL.

#### 9. Forward Declaration: class to struct
`MIDL_INTERFACE(...)` expands to `struct __declspec(uuid(...))`, so forward declarations updated from `class IDacDbiInterface` to `struct IDacDbiInterface` to avoid type mismatch.

#### 10. Overload Rename: GetReJitInfoByAddress
COM interfaces cannot have overloaded methods (IDL doesn't support them, and vtable slot ordering would be ambiguous). The second `GetReJitInfo` overload renamed to `GetReJitInfoByAddress` to give each method a unique name.

#### 11. Caller-Side Updates
All call sites updated to pass `&variable` where references became pointers, and to use `BOOL`/`TRUE`/`FALSE` where `bool` changed.

#### 12. New Files
- **dacdbi.idl** -- Formal IDL definition of the COM interface (159 methods). Marked `[local]` since these interfaces are in-process only (no cross-process marshaling).
- **dacdbi_i.cpp** -- Prebuilt GUID definitions for non-Windows platforms that can't run MIDL.
- **IDacDbiInterface.cs** -- C# managed interface with `[GeneratedComInterface]` and all supporting struct definitions.

### Minor Bug Fixes

While converting the interface, the following pre-existing issues were fixed:

- **`GetMetaDataFileInfoFromPEFile`**: When `pPEAssembly` is NULL, the original code set `*pResult = FALSE` but still returned `S_OK`, leaving other out-parameters untouched. Now returns `E_FAIL` so callers can detect the failure.
- **`IsThreadDead` (rsthread.cpp)**: Changed `return _isDead;` to `return _isDead != FALSE;` to properly normalize `BOOL` to `bool` (avoids relying on `BOOL` always being exactly 0 or 1).

### Testing

- Local Release build verified (daccess.lib, mscordbi.dll, mscordaccore.dll, mscordaccore_universal.dll) -- 0 errors, 0 warnings
- Internal ICorDebug diagnostic test suite: 761 total, 0 failed, 0 errors (identical to baseline)
- Verified our build was loaded via deliberate failure injection (poison test)
