### PR TITLE
Simplify RID graph: keep floating and last versioned RIDs

### DIFF
--- a/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
+++ b/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
@@ -47,615 +47,51 @@
         "linux-musl-x86"
       ]
     },
-    "alpine.3.10": {
-      "#import": [
-        "alpine.3.9"
-      ]
-    },
-    "alpine.3.10-arm": {
-      "#import": [
-        "alpine.3.10",
-        "alpine.3.9-arm"
-      ]
-    },
-    "alpine.3.10-arm64": {
-      "#import": [
-        "alpine.3.10",
-        "alpine.3.9-arm64"
-      ]
-    },
-    "alpine.3.10-armv6": {
-      "#import": [
-        "alpine.3.10",
-        "alpine.3.9-armv6"
-      ]
-    },
-    "alpine.3.10-ppc64le": {
-      "#import": [
-        "alpine.3.10",
-        "alpine.3.9-ppc64le"
-      ]
-    },
-    "alpine.3.10-s390x": {
-      "#import": [
-        "alpine.3.10",
-        "alpine.3.9-s390x"
-      ]
-    },
-    "alpine.3.10-x64": {
-      "#import": [
-        "alpine.3.10",
-        "alpine.3.9-x64"
-      ]
-    },
-    "alpine.3.10-x86": {
-      "#import": [
-        "alpine.3.10",
-        "alpine.3.9-x86"
-      ]
-    },
-    "alpine.3.11": {
-      "#import": [
-        "alpine.3.10"
-      ]
-    },
-    "alpine.3.11-arm": {
-      "#import": [
-        "alpine.3.11",
-        "alpine.3.10-arm"
-      ]
-    },
-    "alpine.3.11-arm64": {
-      "#import": [
-        "alpine.3.11",
-        "alpine.3.10-arm64"
-      ]
-    },
-    "alpine.3.11-armv6": {
-      "#import": [
-        "alpine.3.11",
-        "alpine.3.10-armv6"
-      ]
-    },
-    "alpine.3.11-ppc64le": {
-      "#import": [
-        "alpine.3.11",
-        "alpine.3.10-ppc64le"
-      ]
-    },
-    "alpine.3.11-s390x": {
-      "#import": [
-        "alpine.3.11",
-        "alpine.3.10-s390x"
-      ]
-    },
-    "alpine.3.11-x64": {
-      "#import": [
-        "alpine.3.11",
-        "alpine.3.10-x64"
-      ]
-    },
-    "alpine.3.11-x86": {
-      "#import": [
-        "alpine.3.11",
-        "alpine.3.10-x86"
-      ]
-    },
-    "alpine.3.12": {
-      "#import": [
-        "alpine.3.11"
-      ]
-    },
-    "alpine.3.12-arm": {
-      "#import": [
-        "alpine.3.12",
-        "alpine.3.11-arm"
-      ]
-    },
-    "alpine.3.12-arm64": {
-      "#import": [
-        "alpine.3.12",
-        "alpine.3.11-arm64"
-      ]
-    },
-    "alpine.3.12-armv6": {
-      "#import": [
-        "alpine.3.12",
-        "alpine.3.11-armv6"
-      ]
-    },
-    "alpine.3.12-ppc64le": {
-      "#import": [
-        "alpine.3.12",
-        "alpine.3.11-ppc64le"
-      ]
-    },
-    "alpine.3.12-s390x": {
-      "#import": [
-        "alpine.3.12",
-        "alpine.3.11-s390x"
-      ]
-    },
-    "alpine.3.12-x64": {
-      "#import": [
-        "alpine.3.12",
-        "alpine.3.11-x64"
-      ]
-    },
-    "alpine.3.12-x86": {
-      "#import": [
-        "alpine.3.12",
-        "alpine.3.11-x86"
-      ]
-    },
-    "alpine.3.13": {
-      "#import": [
-        "alpine.3.12"
-      ]
-    },
-    "alpine.3.13-arm": {
-      "#import": [
-        "alpine.3.13",
-        "alpine.3.12-arm"
-      ]
-    },
-    "alpine.3.13-arm64": {
-      "#import": [
-        "alpine.3.13",
-        "alpine.3.12-arm64"
-      ]
-    },
-    "alpine.3.13-armv6": {
-      "#import": [
-        "alpine.3.13",
-        "alpine.3.12-armv6"
-      ]
-    },
-    "alpine.3.13-ppc64le": {
-      "#import": [
-        "alpine.3.13",
-        "alpine.3.12-ppc64le"
-      ]
-    },
-    "alpine.3.13-s390x": {
-      "#import": [
-        "alpine.3.13",
-        "alpine.3.12-s390x"
-      ]
-    },
-    "alpine.3.13-x64": {
-      "#import": [
-        "alpine.3.13",
-        "alpine.3.12-x64"
-      ]
-    },
-    "alpine.3.13-x86": {
-      "#import": [
-        "alpine.3.13",
-        "alpine.3.12-x86"
-      ]
-    },
-    "alpine.3.14": {
-      "#import": [
-        "alpine.3.13"
-      ]
-    },
-    "alpine.3.14-arm": {
-      "#import": [
-        "alpine.3.14",
-        "alpine.3.13-arm"
-      ]
-    },
-    "alpine.3.14-arm64": {
-      "#import": [
-        "alpine.3.14",
-        "alpine.3.13-arm64"
-      ]
-    },
-    "alpine.3.14-armv6": {
-      "#import": [
-        "alpine.3.14",
-        "alpine.3.13-armv6"
-      ]
-    },
-    "alpine.3.14-ppc64le": {
-      "#import": [
-        "alpine.3.14",
-        "alpine.3.13-ppc64le"
-      ]
-    },
-    "alpine.3.14-s390x": {
-      "#import": [
-        "alpine.3.14",
-        "alpine.3.13-s390x"
-      ]
-    },
-    "alpine.3.14-x64": {
-      "#import": [
-        "alpine.3.14",
-        "alpine.3.13-x64"
-      ]
-    },
-    "alpine.3.14-x86": {
-      "#import": [
-        "alpine.3.14",
-        "alpine.3.13-x86"
-      ]
-    },
-    "alpine.3.15": {
-      "#import": [
-        "alpine.3.14"
-      ]
-    },
-    "alpine.3.15-arm": {
-      "#import": [
-        "alpine.3.15",
-        "alpine.3.14-arm"
-      ]
-    },
-    "alpine.3.15-arm64": {
-      "#import": [
-        "alpine.3.15",
-        "alpine.3.14-arm64"
-      ]
-    },
-    "alpine.3.15-armv6": {
-      "#import": [
-        "alpine.3.15",
-        "alpine.3.14-armv6"
-      ]
-    },
-    "alpine.3.15-ppc64le": {
-      "#import": [
-        "alpine.3.15",
-        "alpine.3.14-ppc64le"
-      ]
-    },
-    "alpine.3.15-s390x": {
-      "#import": [
-        "alpine.3.15",
-        "alpine.3.14-s390x"
-      ]
-    },
-    "alpine.3.15-x64": {
-      "#import": [
-        "alpine.3.15",
-        "alpine.3.14-x64"
-      ]
-    },
-    "alpine.3.15-x86": {
-      "#import": [
-        "alpine.3.15",
-        "alpine.3.14-x86"
-      ]
-    },
-    "alpine.3.16": {
-      "#import": [
-        "alpine.3.15"
-      ]
-    },
-    "alpine.3.16-arm": {
-      "#import": [
-        "alpine.3.16",
-        "alpine.3.15-arm"
-      ]
-    },
-    "alpine.3.16-arm64": {
-      "#import": [
-        "alpine.3.16",
-        "alpine.3.15-arm64"
-      ]
-    },
-    "alpine.3.16-armv6": {
-      "#import": [
-        "alpine.3.16",
-        "alpine.3.15-armv6"
-      ]
-    },
-    "alpine.3.16-ppc64le": {
-      "#import": [
-        "alpine.3.16",
-        "alpine.3.15-ppc64le"
-      ]
-    },
-    "alpine.3.16-s390x": {
-      "#import": [
-        "alpine.3.16",
-        "alpine.3.15-s390x"
-      ]
-    },
-    "alpine.3.16-x64": {
-      "#import": [
-        "alpine.3.16",
-        "alpine.3.15-x64"
-      ]
-    },
-    "alpine.3.16-x86": {
-      "#import": [
-        "alpine.3.16",
-        "alpine.3.15-x86"
-      ]
-    },
-    "alpine.3.17": {
-      "#import": [
-        "alpine.3.16"
-      ]
-    },
-    "alpine.3.17-arm": {
-      "#import": [
-        "alpine.3.17",
-        "alpine.3.16-arm"
-      ]
-    },
-    "alpine.3.17-arm64": {
-      "#import": [
-        "alpine.3.17",
-        "alpine.3.16-arm64"
-      ]
-    },
-    "alpine.3.17-armv6": {
-      "#import": [
-        "alpine.3.17",
-        "alpine.3.16-armv6"
-      ]
-    },
-    "alpine.3.17-ppc64le": {
-      "#import": [
-        "alpine.3.17",
-        "alpine.3.16-ppc64le"
-      ]
-    },
-    "alpine.3.17-s390x": {
-      "#import": [
-        "alpine.3.17",
-        "alpine.3.16-s390x"
-      ]
-    },
-    "alpine.3.17-x64": {
-      "#import": [
-        "alpine.3.17",
-        "alpine.3.16-x64"
-      ]
-    },
-    "alpine.3.17-x86": {
-      "#import": [
-        "alpine.3.17",
-        "alpine.3.16-x86"
-      ]
-    },
     "alpine.3.18": {
       "#import": [
-        "alpine.3.17"
+        "alpine"
       ]
     },
     "alpine.3.18-arm": {
       "#import": [
         "alpine.3.18",
-        "alpine.3.17-arm"
+        "alpine-arm"
       ]
     },
     "alpine.3.18-arm64": {
       "#import": [
         "alpine.3.18",
-        "alpine.3.17-arm64"
+        "alpine-arm64"
       ]
     },
     "alpine.3.18-armv6": {
       "#import": [
         "alpine.3.18",
-        "alpine.3.17-armv6"
+        "alpine-armv6"
       ]
     },
     "alpine.3.18-ppc64le": {
       "#import": [
         "alpine.3.18",
-        "alpine.3.17-ppc64le"
+        "alpine-ppc64le"
       ]
     },
     "alpine.3.18-s390x": {
       "#import": [
         "alpine.3.18",
-        "alpine.3.17-s390x"
+        "alpine-s390x"
       ]
     },
     "alpine.3.18-x64": {
       "#import": [
         "alpine.3.18",
-        "alpine.3.17-x64"
+        "alpine-x64"
       ]
     },
     "alpine.3.18-x86": {
       "#import": [
         "alpine.3.18",
-        "alpine.3.17-x86"
-      ]
-    },
-    "alpine.3.6": {
-      "#import": [
-        "alpine"
-      ]
-    },
-    "alpine.3.6-arm": {
-      "#import": [
-        "alpine.3.6",
-        "alpine-arm"
-      ]
-    },
-    "alpine.3.6-arm64": {
-      "#import": [
-        "alpine.3.6",
-        "alpine-arm64"
-      ]
-    },
-    "alpine.3.6-armv6": {
-      "#import": [
-        "alpine.3.6",
-        "alpine-armv6"
-      ]
-    },
-    "alpine.3.6-ppc64le": {
-      "#import": [
-        "alpine.3.6",
-        "alpine-ppc64le"
-      ]
-    },
-    "alpine.3.6-s390x": {
-      "#import": [
-        "alpine.3.6",
-        "alpine-s390x"
-      ]
-    },
-    "alpine.3.6-x64": {
-      "#import": [
-        "alpine.3.6",
-        "alpine-x64"
-      ]
-    },
-    "alpine.3.6-x86": {
-      "#import": [
-        "alpine.3.6",
         "alpine-x86"
-      ]
-    },
-    "alpine.3.7": {
-      "#import": [
-        "alpine.3.6"
-      ]
-    },
-    "alpine.3.7-arm": {
-      "#import": [
-        "alpine.3.7",
-        "alpine.3.6-arm"
-      ]
-    },
-    "alpine.3.7-arm64": {
-      "#import": [
-        "alpine.3.7",
-        "alpine.3.6-arm64"
-      ]
-    },
-    "alpine.3.7-armv6": {
-      "#import": [
-        "alpine.3.7",
-        "alpine.3.6-armv6"
-      ]
-    },
-    "alpine.3.7-ppc64le": {
-      "#import": [
-        "alpine.3.7",
-        "alpine.3.6-ppc64le"
-      ]
-    },
-    "alpine.3.7-s390x": {
-      "#import": [
-        "alpine.3.7",
-        "alpine.3.6-s390x"
-      ]
-    },
-    "alpine.3.7-x64": {
-      "#import": [
-        "alpine.3.7",
-        "alpine.3.6-x64"
-      ]
-    },
-    "alpine.3.7-x86": {
-      "#import": [
-        "alpine.3.7",
-        "alpine.3.6-x86"
-      ]
-    },
-    "alpine.3.8": {
-      "#import": [
-        "alpine.3.7"
-      ]
-    },
-    "alpine.3.8-arm": {
-      "#import": [
-        "alpine.3.8",
-        "alpine.3.7-arm"
-      ]
-    },
-    "alpine.3.8-arm64": {
-      "#import": [
-        "alpine.3.8",
-        "alpine.3.7-arm64"
-      ]
-    },
-    "alpine.3.8-armv6": {
-      "#import": [
-        "alpine.3.8",
-        "alpine.3.7-armv6"
-      ]
-    },
-    "alpine.3.8-ppc64le": {
-      "#import": [
-        "alpine.3.8",
-        "alpine.3.7-ppc64le"
-      ]
-    },
-    "alpine.3.8-s390x": {
-      "#import": [
-        "alpine.3.8",
-        "alpine.3.7-s390x"
-      ]
-    },
-    "alpine.3.8-x64": {
-      "#import": [
-        "alpine.3.8",
-        "alpine.3.7-x64"
-      ]
-    },
-    "alpine.3.8-x86": {
-      "#import": [
-        "alpine.3.8",
-        "alpine.3.7-x86"
-      ]
-    },
-    "alpine.3.9": {
-      "#import": [
-        "alpine.3.8"
-      ]
-    },
-    "alpine.3.9-arm": {
-      "#import": [
-        "alpine.3.9",
-        "alpine.3.8-arm"
-      ]
-    },
-    "alpine.3.9-arm64": {
-      "#import": [
-        "alpine.3.9",
-        "alpine.3.8-arm64"
-      ]
-    },
-    "alpine.3.9-armv6": {
-      "#import": [
-        "alpine.3.9",
-        "alpine.3.8-armv6"
-      ]
-    },
-    "alpine.3.9-ppc64le": {
-      "#import": [
-        "alpine.3.9",
-        "alpine.3.8-ppc64le"
-      ]
-    },
-    "alpine.3.9-s390x": {
-      "#import": [
-        "alpine.3.9",
-        "alpine.3.8-s390x"
-      ]
-    },
-    "alpine.3.9-x64": {
-      "#import": [
-        "alpine.3.9",
-        "alpine.3.8-x64"
-      ]
-    },
-    "alpine.3.9-x86": {
-      "#import": [
-        "alpine.3.9",
-        "alpine.3.8-x86"
       ]
     },
     "android": {
@@ -687,352 +123,33 @@
         "linux-bionic-x86"
       ]
     },
-    "android.21": {
-      "#import": [
-        "android"
-      ]
-    },
-    "android.21-arm": {
-      "#import": [
-        "android.21",
-        "android-arm"
-      ]
-    },
-    "android.21-arm64": {
-      "#import": [
-        "android.21",
-        "android-arm64"
-      ]
-    },
-    "android.21-x64": {
-      "#import": [
-        "android.21",
-        "android-x64"
-      ]
-    },
-    "android.21-x86": {
-      "#import": [
-        "android.21",
-        "android-x86"
-      ]
-    },
-    "android.22": {
-      "#import": [
-        "android.21"
-      ]
-    },
-    "android.22-arm": {
-      "#import": [
-        "android.22",
-        "android.21-arm"
-      ]
-    },
-    "android.22-arm64": {
-      "#import": [
-        "android.22",
-        "android.21-arm64"
-      ]
-    },
-    "android.22-x64": {
-      "#import": [
-        "android.22",
-        "android.21-x64"
-      ]
-    },
-    "android.22-x86": {
-      "#import": [
-        "android.22",
-        "android.21-x86"
-      ]
-    },
-    "android.23": {
-      "#import": [
-        "android.22"
-      ]
-    },
-    "android.23-arm": {
-      "#import": [
-        "android.23",
-        "android.22-arm"
-      ]
-    },
-    "android.23-arm64": {
-      "#import": [
-        "android.23",
-        "android.22-arm64"
-      ]
-    },
-    "android.23-x64": {
-      "#import": [
-        "android.23",
-        "android.22-x64"
-      ]
-    },
-    "android.23-x86": {
-      "#import": [
-        "android.23",
-        "android.22-x86"
-      ]
-    },
-    "android.24": {
-      "#import": [
-        "android.23"
-      ]
-    },
-    "android.24-arm": {
-      "#import": [
-        "android.24",
-        "android.23-arm"
-      ]
-    },
-    "android.24-arm64": {
-      "#import": [
-        "android.24",
-        "android.23-arm64"
-      ]
-    },
-    "android.24-x64": {
-      "#import": [
-        "android.24",
-        "android.23-x64"
-      ]
-    },
-    "android.24-x86": {
-      "#import": [
-        "android.24",
-        "android.23-x86"
-      ]
-    },
-    "android.25": {
-      "#import": [
-        "android.24"
-      ]
-    },
-    "android.25-arm": {
-      "#import": [
-        "android.25",
-        "android.24-arm"
-      ]
-    },
-    "android.25-arm64": {
-      "#import": [
-        "android.25",
-        "android.24-arm64"
-      ]
-    },
-    "android.25-x64": {
-      "#import": [
-        "android.25",
-        "android.24-x64"
-      ]
-    },
-    "android.25-x86": {
-      "#import": [
-        "android.25",
-        "android.24-x86"
-      ]
-    },
-    "android.26": {
-      "#import": [
-        "android.25"
-      ]
-    },
-    "android.26-arm": {
-      "#import": [
-        "android.26",
-        "android.25-arm"
-      ]
-    },
-    "android.26-arm64": {
-      "#import": [
-        "android.26",
-        "android.25-arm64"
-      ]
-    },
-    "android.26-x64": {
-      "#import": [
-        "android.26",
-        "android.25-x64"
-      ]
-    },
-    "android.26-x86": {
-      "#import": [
-        "android.26",
-        "android.25-x86"
-      ]
-    },
-    "android.27": {
-      "#import": [
-        "android.26"
-      ]
-    },
-    "android.27-arm": {
-      "#import": [
-        "android.27",
-        "android.26-arm"
-      ]
-    },
-    "android.27-arm64": {
-      "#import": [
-        "android.27",
-        "android.26-arm64"
-      ]
-    },
-    "android.27-x64": {
-      "#import": [
-        "android.27",
-        "android.26-x64"
-      ]
-    },
-    "android.27-x86": {
-      "#import": [
-        "android.27",
-        "android.26-x86"
-      ]
-    },
-    "android.28": {
-      "#import": [
-        "android.27"
-      ]
-    },
-    "android.28-arm": {
-      "#import": [
-        "android.28",
-        "android.27-arm"
-      ]
-    },
-    "android.28-arm64": {
-      "#import": [
-        "android.28",
-        "android.27-arm64"
-      ]
-    },
-    "android.28-x64": {
-      "#import": [
-        "android.28",
-        "android.27-x64"
-      ]
-    },
-    "android.28-x86": {
-      "#import": [
-        "android.28",
-        "android.27-x86"
-      ]
-    },
-    "android.29": {
-      "#import": [
-        "android.28"
-      ]
-    },
-    "android.29-arm": {
-      "#import": [
-        "android.29",
-        "android.28-arm"
-      ]
-    },
-    "android.29-arm64": {
-      "#import": [
-        "android.29",
-        "android.28-arm64"
-      ]
-    },
-    "android.29-x64": {
-      "#import": [
-        "android.29",
-        "android.28-x64"
-      ]
-    },
-    "android.29-x86": {
-      "#import": [
-        "android.29",
-        "android.28-x86"
-      ]
-    },
-    "android.30": {
-      "#import": [
-        "android.29"
-      ]
-    },
-    "android.30-arm": {
-      "#import": [
-        "android.30",
-        "android.29-arm"
-      ]
-    },
-    "android.30-arm64": {
-      "#import": [
-        "android.30",
-        "android.29-arm64"
-      ]
-    },
-    "android.30-x64": {
-      "#import": [
-        "android.30",
-        "android.29-x64"
-      ]
-    },
-    "android.30-x86": {
-      "#import": [
-        "android.30",
-        "android.29-x86"
-      ]
-    },
-    "android.31": {
-      "#import": [
-        "android.30"
-      ]
-    },
-    "android.31-arm": {
-      "#import": [
-        "android.31",
-        "android.30-arm"
-      ]
-    },
-    "android.31-arm64": {
-      "#import": [
-        "android.31",
-        "android.30-arm64"
-      ]
-    },
-    "android.31-x64": {
-      "#import": [
-        "android.31",
-        "android.30-x64"
-      ]
-    },
-    "android.31-x86": {
-      "#import": [
-        "android.31",
-        "android.30-x86"
-      ]
-    },
     "android.32": {
       "#import": [
-        "android.31"
+        "android"
       ]
     },
     "android.32-arm": {
       "#import": [
         "android.32",
-        "android.31-arm"
+        "android-arm"
       ]
     },
     "android.32-arm64": {
       "#import": [
         "android.32",
-        "android.31-arm64"
+        "android-arm64"
       ]
     },
     "android.32-x64": {
       "#import": [
         "android.32",
-        "android.31-x64"
+        "android-x64"
       ]
     },
     "android.32-x86": {
       "#import": [
         "android.32",
-        "android.31-x86"
+        "android-x86"
       ]
     },
     "any": {
@@ -1056,9 +173,7 @@
         "linux-x64"
       ]
     },
-    "base": {
-      "#import": []
-    },
+    "base": {},
     "browser": {
       "#import": [
         "any"
@@ -1084,39 +199,6 @@
       "#import": [
         "centos",
         "rhel-x64"
-      ]
-    },
-    "centos.7": {
-      "#import": [
-        "centos",
-        "rhel.7"
-      ]
-    },
-    "centos.7-x64": {
-      "#import": [
-        "centos.7",
-        "centos-x64",
-        "rhel.7-x64"
-      ]
-    },
-    "centos.8": {
-      "#import": [
-        "centos",
-        "rhel.8"
-      ]
-    },
-    "centos.8-arm64": {
-      "#import": [
-        "centos.8",
-        "centos-arm64",
-        "rhel.8-arm64"
-      ]
-    },
-    "centos.8-x64": {
-      "#import": [
-        "centos.8",
-        "centos-x64",
-        "rhel.8-x64"
       ]
     },
     "centos.9": {
@@ -1174,76 +256,6 @@
         "linux-x86"
       ]
     },
-    "debian.10": {
-      "#import": [
-        "debian"
-      ]
-    },
-    "debian.10-arm": {
-      "#import": [
-        "debian.10",
-        "debian-arm"
-      ]
-    },
-    "debian.10-arm64": {
-      "#import": [
-        "debian.10",
-        "debian-arm64"
-      ]
-    },
-    "debian.10-armel": {
-      "#import": [
-        "debian.10",
-        "debian-armel"
-      ]
-    },
-    "debian.10-x64": {
-      "#import": [
-        "debian.10",
-        "debian-x64"
-      ]
-    },
-    "debian.10-x86": {
-      "#import": [
-        "debian.10",
-        "debian-x86"
-      ]
-    },
-    "debian.11": {
-      "#import": [
-        "debian"
-      ]
-    },
-    "debian.11-arm": {
-      "#import": [
-        "debian.11",
-        "debian-arm"
-      ]
-    },
-    "debian.11-arm64": {
-      "#import": [
-        "debian.11",
-        "debian-arm64"
-      ]
-    },
-    "debian.11-armel": {
-      "#import": [
-        "debian.11",
-        "debian-armel"
-      ]
-    },
-    "debian.11-x64": {
-      "#import": [
-        "debian.11",
-        "debian-x64"
-      ]
-    },
-    "debian.11-x86": {
-      "#import": [
-        "debian.11",
-        "debian-x86"
-      ]
-    },
     "debian.12": {
       "#import": [
         "debian"
@@ -1279,76 +291,6 @@
         "debian-x86"
       ]
     },
-    "debian.8": {
-      "#import": [
-        "debian"
-      ]
-    },
-    "debian.8-arm": {
-      "#import": [
-        "debian.8",
-        "debian-arm"
-      ]
-    },
-    "debian.8-arm64": {
-      "#import": [
-        "debian.8",
-        "debian-arm64"
-      ]
-    },
-    "debian.8-armel": {
-      "#import": [
-        "debian.8",
-        "debian-armel"
-      ]
-    },
-    "debian.8-x64": {
-      "#import": [
-        "debian.8",
-        "debian-x64"
-      ]
-    },
-    "debian.8-x86": {
-      "#import": [
-        "debian.8",
-        "debian-x86"
-      ]
-    },
-    "debian.9": {
-      "#import": [
-        "debian"
-      ]
-    },
-    "debian.9-arm": {
-      "#import": [
-        "debian.9",
-        "debian-arm"
-      ]
-    },
-    "debian.9-arm64": {
-      "#import": [
-        "debian.9",
-        "debian-arm64"
-      ]
-    },
-    "debian.9-armel": {
-      "#import": [
-        "debian.9",
-        "debian-armel"
-      ]
-    },
-    "debian.9-x64": {
-      "#import": [
-        "debian.9",
-        "debian-x64"
-      ]
-    },
-    "debian.9-x86": {
-      "#import": [
-        "debian.9",
-        "debian-x86"
-      ]
-    },
     "exherbo": {
       "#import": [
         "linux"
@@ -1375,278 +317,6 @@
       "#import": [
         "fedora",
         "linux-x64"
-      ]
-    },
-    "fedora.23": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.23-arm64": {
-      "#import": [
-        "fedora.23",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.23-x64": {
-      "#import": [
-        "fedora.23",
-        "fedora-x64"
-      ]
-    },
-    "fedora.24": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.24-arm64": {
-      "#import": [
-        "fedora.24",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.24-x64": {
-      "#import": [
-        "fedora.24",
-        "fedora-x64"
-      ]
-    },
-    "fedora.25": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.25-arm64": {
-      "#import": [
-        "fedora.25",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.25-x64": {
-      "#import": [
-        "fedora.25",
-        "fedora-x64"
-      ]
-    },
-    "fedora.26": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.26-arm64": {
-      "#import": [
-        "fedora.26",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.26-x64": {
-      "#import": [
-        "fedora.26",
-        "fedora-x64"
-      ]
-    },
-    "fedora.27": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.27-arm64": {
-      "#import": [
-        "fedora.27",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.27-x64": {
-      "#import": [
-        "fedora.27",
-        "fedora-x64"
-      ]
-    },
-    "fedora.28": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.28-arm64": {
-      "#import": [
-        "fedora.28",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.28-x64": {
-      "#import": [
-        "fedora.28",
-        "fedora-x64"
-      ]
-    },
-    "fedora.29": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.29-arm64": {
-      "#import": [
-        "fedora.29",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.29-x64": {
-      "#import": [
-        "fedora.29",
-        "fedora-x64"
-      ]
-    },
-    "fedora.30": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.30-arm64": {
-      "#import": [
-        "fedora.30",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.30-x64": {
-      "#import": [
-        "fedora.30",
-        "fedora-x64"
-      ]
-    },
-    "fedora.31": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.31-arm64": {
-      "#import": [
-        "fedora.31",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.31-x64": {
-      "#import": [
-        "fedora.31",
-        "fedora-x64"
-      ]
-    },
-    "fedora.32": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.32-arm64": {
-      "#import": [
-        "fedora.32",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.32-x64": {
-      "#import": [
-        "fedora.32",
-        "fedora-x64"
-      ]
-    },
-    "fedora.33": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.33-arm64": {
-      "#import": [
-        "fedora.33",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.33-x64": {
-      "#import": [
-        "fedora.33",
-        "fedora-x64"
-      ]
-    },
-    "fedora.34": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.34-arm64": {
-      "#import": [
-        "fedora.34",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.34-x64": {
-      "#import": [
-        "fedora.34",
-        "fedora-x64"
-      ]
-    },
-    "fedora.35": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.35-arm64": {
-      "#import": [
-        "fedora.35",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.35-x64": {
-      "#import": [
-        "fedora.35",
-        "fedora-x64"
-      ]
-    },
-    "fedora.36": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.36-arm64": {
-      "#import": [
-        "fedora.36",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.36-x64": {
-      "#import": [
-        "fedora.36",
-        "fedora-x64"
-      ]
-    },
-    "fedora.37": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.37-arm64": {
-      "#import": [
-        "fedora.37",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.37-x64": {
-      "#import": [
-        "fedora.37",
-        "fedora-x64"
-      ]
-    },
-    "fedora.38": {
-      "#import": [
-        "fedora"
-      ]
-    },
-    "fedora.38-arm64": {
-      "#import": [
-        "fedora.38",
-        "fedora-arm64"
-      ]
-    },
-    "fedora.38-x64": {
-      "#import": [
-        "fedora.38",
-        "fedora-x64"
       ]
     },
     "fedora.39": {
@@ -1683,38 +353,21 @@
         "unix-x64"
       ]
     },
-    "freebsd.12": {
-      "#import": [
-        "freebsd"
-      ]
-    },
-    "freebsd.12-arm64": {
-      "#import": [
-        "freebsd.12",
-        "freebsd-arm64"
-      ]
-    },
-    "freebsd.12-x64": {
-      "#import": [
-        "freebsd.12",
-        "freebsd-x64"
-      ]
-    },
     "freebsd.13": {
       "#import": [
-        "freebsd.12"
+        "freebsd"
       ]
     },
     "freebsd.13-arm64": {
       "#import": [
         "freebsd.13",
-        "freebsd.12-arm64"
+        "freebsd-arm64"
       ]
     },
     "freebsd.13-x64": {
       "#import": [
         "freebsd.13",
-        "freebsd.12-x64"
+        "freebsd-x64"
       ]
     },
     "gentoo": {
@@ -1779,118 +432,21 @@
         "unix-x86"
       ]
     },
-    "ios.10": {
-      "#import": [
-        "ios"
-      ]
-    },
-    "ios.10-arm": {
-      "#import": [
-        "ios.10",
-        "ios-arm"
-      ]
-    },
-    "ios.10-arm64": {
-      "#import": [
-        "ios.10",
-        "ios-arm64"
-      ]
-    },
-    "ios.10-x64": {
-      "#import": [
-        "ios.10",
-        "ios-x64"
-      ]
-    },
-    "ios.10-x86": {
-      "#import": [
-        "ios.10",
-        "ios-x86"
-      ]
-    },
-    "ios.11": {
-      "#import": [
-        "ios.10"
-      ]
-    },
-    "ios.11-arm64": {
-      "#import": [
-        "ios.11",
-        "ios.10-arm64"
-      ]
-    },
-    "ios.11-x64": {
-      "#import": [
-        "ios.11",
-        "ios.10-x64"
-      ]
-    },
-    "ios.12": {
-      "#import": [
-        "ios.11"
-      ]
-    },
-    "ios.12-arm64": {
-      "#import": [
-        "ios.12",
-        "ios.11-arm64"
-      ]
-    },
-    "ios.12-x64": {
-      "#import": [
-        "ios.12",
-        "ios.11-x64"
-      ]
-    },
-    "ios.13": {
-      "#import": [
-        "ios.12"
-      ]
-    },
-    "ios.13-arm64": {
-      "#import": [
-        "ios.13",
-        "ios.12-arm64"
-      ]
-    },
-    "ios.13-x64": {
-      "#import": [
-        "ios.13",
-        "ios.12-x64"
-      ]
-    },
-    "ios.14": {
-      "#import": [
-        "ios.13"
-      ]
-    },
-    "ios.14-arm64": {
-      "#import": [
-        "ios.14",
-        "ios.13-arm64"
-      ]
-    },
-    "ios.14-x64": {
-      "#import": [
-        "ios.14",
-        "ios.13-x64"
-      ]
-    },
     "ios.15": {
       "#import": [
-        "ios.14"
+        "ios"
       ]
     },
     "ios.15-arm64": {
       "#import": [
         "ios.15",
-        "ios.14-arm64"
+        "ios-arm64"
       ]
     },
     "ios.15-x64": {
       "#import": [
         "ios.15",
-        "ios.14-x64"
+        "ios-x64"
       ]
     },
     "iossimulator": {
@@ -1916,112 +472,21 @@
         "ios-x86"
       ]
     },
-    "iossimulator.10": {
-      "#import": [
-        "iossimulator"
-      ]
-    },
-    "iossimulator.10-arm64": {
-      "#import": [
-        "iossimulator.10",
-        "iossimulator-arm64"
-      ]
-    },
-    "iossimulator.10-x64": {
-      "#import": [
-        "iossimulator.10",
-        "iossimulator-x64"
-      ]
-    },
-    "iossimulator.10-x86": {
-      "#import": [
-        "iossimulator.10",
-        "iossimulator-x86"
-      ]
-    },
-    "iossimulator.11": {
-      "#import": [
-        "iossimulator.10"
-      ]
-    },
-    "iossimulator.11-arm64": {
-      "#import": [
-        "iossimulator.11",
-        "iossimulator.10-arm64"
-      ]
-    },
-    "iossimulator.11-x64": {
-      "#import": [
-        "iossimulator.11",
-        "iossimulator.10-x64"
-      ]
-    },
-    "iossimulator.12": {
-      "#import": [
-        "iossimulator.11"
-      ]
-    },
-    "iossimulator.12-arm64": {
-      "#import": [
-        "iossimulator.12",
-        "iossimulator.11-arm64"
-      ]
-    },
-    "iossimulator.12-x64": {
-      "#import": [
-        "iossimulator.12",
-        "iossimulator.11-x64"
-      ]
-    },
-    "iossimulator.13": {
-      "#import": [
-        "iossimulator.12"
-      ]
-    },
-    "iossimulator.13-arm64": {
-      "#import": [
-        "iossimulator.13",
-        "iossimulator.12-arm64"
-      ]
-    },
-    "iossimulator.13-x64": {
-      "#import": [
-        "iossimulator.13",
-        "iossimulator.12-x64"
-      ]
-    },
-    "iossimulator.14": {
-      "#import": [
-        "iossimulator.13"
-      ]
-    },
-    "iossimulator.14-arm64": {
-      "#import": [
-        "iossimulator.14",
-        "iossimulator.13-arm64"
-      ]
-    },
-    "iossimulator.14-x64": {
-      "#import": [
-        "iossimulator.14",
-        "iossimulator.13-x64"
-      ]
-    },
     "iossimulator.15": {
       "#import": [
-        "iossimulator.14"
+        "iossimulator"
       ]
     },
     "iossimulator.15-arm64": {
       "#import": [
         "iossimulator.15",
-        "iossimulator.14-arm64"
+        "iossimulator-arm64"
       ]
     },
     "iossimulator.15-x64": {
       "#import": [
         "iossimulator.15",
-        "iossimulator.14-x64"
+        "iossimulator-x64"
       ]
     },
     "linux": {
@@ -2123,6 +588,12 @@
         "linux-armv6"
       ]
     },
+    "linux-musl-loongarch64": {
+      "#import": [
+        "linux-musl",
+        "linux-loongarch64"
+      ]
+    },
     "linux-musl-ppc64le": {
       "#import": [
         "linux-musl",
@@ -2133,12 +604,6 @@
       "#import": [
         "linux-musl",
         "linux-riscv64"
-      ]
-    },
-    "linux-musl-loongarch64": {
-      "#import": [
-        "linux-musl",
-        "linux-loongarch64"
       ]
     },
     "linux-musl-s390x": {
@@ -2189,125 +654,15 @@
         "unix-x86"
       ]
     },
-    "linuxmint.17": {
-      "#import": [
-        "ubuntu.14.04"
-      ]
-    },
-    "linuxmint.17-x64": {
-      "#import": [
-        "linuxmint.17",
-        "ubuntu.14.04-x64"
-      ]
-    },
-    "linuxmint.17.1": {
-      "#import": [
-        "linuxmint.17"
-      ]
-    },
-    "linuxmint.17.1-x64": {
-      "#import": [
-        "linuxmint.17.1",
-        "linuxmint.17-x64"
-      ]
-    },
-    "linuxmint.17.2": {
-      "#import": [
-        "linuxmint.17.1"
-      ]
-    },
-    "linuxmint.17.2-x64": {
-      "#import": [
-        "linuxmint.17.2",
-        "linuxmint.17.1-x64"
-      ]
-    },
-    "linuxmint.17.3": {
-      "#import": [
-        "linuxmint.17.2"
-      ]
-    },
-    "linuxmint.17.3-x64": {
-      "#import": [
-        "linuxmint.17.3",
-        "linuxmint.17.2-x64"
-      ]
-    },
-    "linuxmint.18": {
-      "#import": [
-        "ubuntu.16.04"
-      ]
-    },
-    "linuxmint.18-x64": {
-      "#import": [
-        "linuxmint.18",
-        "ubuntu.16.04-x64"
-      ]
-    },
-    "linuxmint.18.1": {
-      "#import": [
-        "linuxmint.18"
-      ]
-    },
-    "linuxmint.18.1-x64": {
-      "#import": [
-        "linuxmint.18.1",
-        "linuxmint.18-x64"
-      ]
-    },
-    "linuxmint.18.2": {
-      "#import": [
-        "linuxmint.18.1"
-      ]
-    },
-    "linuxmint.18.2-x64": {
-      "#import": [
-        "linuxmint.18.2",
-        "linuxmint.18.1-x64"
-      ]
-    },
-    "linuxmint.18.3": {
-      "#import": [
-        "linuxmint.18.2"
-      ]
-    },
-    "linuxmint.18.3-x64": {
-      "#import": [
-        "linuxmint.18.3",
-        "linuxmint.18.2-x64"
-      ]
-    },
-    "linuxmint.19": {
-      "#import": [
-        "ubuntu.18.04"
-      ]
-    },
-    "linuxmint.19-x64": {
-      "#import": [
-        "linuxmint.19",
-        "ubuntu.18.04-x64"
-      ]
-    },
-    "linuxmint.19.1": {
-      "#import": [
-        "linuxmint.19"
-      ]
-    },
-    "linuxmint.19.1-x64": {
-      "#import": [
-        "linuxmint.19.1",
-        "linuxmint.19-x64"
-      ]
-    },
     "linuxmint.19.2": {
       "#import": [
-        "linuxmint.19.1"
+        "ubuntu"
       ]
     },
     "linuxmint.19.2-x64": {
       "#import": [
         "linuxmint.19.2",
-        "linuxmint.19.1-x64"
+        "ubuntu-x64"
       ]
     },
     "maccatalyst": {
@@ -2327,55 +682,21 @@
         "ios-x64"
       ]
     },
-    "maccatalyst.13": {
-      "#import": [
-        "maccatalyst"
-      ]
-    },
-    "maccatalyst.13-arm64": {
-      "#import": [
-        "maccatalyst.13",
-        "maccatalyst-arm64"
-      ]
-    },
-    "maccatalyst.13-x64": {
-      "#import": [
-        "maccatalyst.13",
-        "maccatalyst-x64"
-      ]
-    },
-    "maccatalyst.14": {
-      "#import": [
-        "maccatalyst.13"
-      ]
-    },
-    "maccatalyst.14-arm64": {
-      "#import": [
-        "maccatalyst.14",
-        "maccatalyst.13-arm64"
-      ]
-    },
-    "maccatalyst.14-x64": {
-      "#import": [
-        "maccatalyst.14",
-        "maccatalyst.13-x64"
-      ]
-    },
     "maccatalyst.15": {
       "#import": [
-        "maccatalyst.14"
+        "maccatalyst"
       ]
     },
     "maccatalyst.15-arm64": {
       "#import": [
         "maccatalyst.15",
-        "maccatalyst.14-arm64"
+        "maccatalyst-arm64"
       ]
     },
     "maccatalyst.15-x64": {
       "#import": [
         "maccatalyst.15",
-        "maccatalyst.14-x64"
+        "maccatalyst-x64"
       ]
     },
     "manjaro": {
@@ -2398,19 +719,6 @@
       "#import": [
         "miraclelinux",
         "rhel-x64"
-      ]
-    },
-    "miraclelinux.8": {
-      "#import": [
-        "miraclelinux",
-        "rhel.8"
-      ]
-    },
-    "miraclelinux.8-x64": {
-      "#import": [
-        "miraclelinux.8",
-        "miraclelinux-x64",
-        "rhel.8-x64"
       ]
     },
     "miraclelinux.9": {
@@ -2437,134 +745,15 @@
         "rhel-x64"
       ]
     },
-    "ol.7": {
-      "#import": [
-        "ol",
-        "rhel.7"
-      ]
-    },
-    "ol.7-x64": {
-      "#import": [
-        "ol.7",
-        "ol-x64",
-        "rhel.7-x64"
-      ]
-    },
-    "ol.7.0": {
-      "#import": [
-        "ol.7",
-        "rhel.7.0"
-      ]
-    },
-    "ol.7.0-x64": {
-      "#import": [
-        "ol.7.0",
-        "ol.7-x64",
-        "rhel.7.0-x64"
-      ]
-    },
-    "ol.7.1": {
-      "#import": [
-        "ol.7.0",
-        "rhel.7.1"
-      ]
-    },
-    "ol.7.1-x64": {
-      "#import": [
-        "ol.7.1",
-        "ol.7.0-x64",
-        "rhel.7.1-x64"
-      ]
-    },
-    "ol.7.2": {
-      "#import": [
-        "ol.7.1",
-        "rhel.7.2"
-      ]
-    },
-    "ol.7.2-x64": {
-      "#import": [
-        "ol.7.2",
-        "ol.7.1-x64",
-        "rhel.7.2-x64"
-      ]
-    },
-    "ol.7.3": {
-      "#import": [
-        "ol.7.2",
-        "rhel.7.3"
-      ]
-    },
-    "ol.7.3-x64": {
-      "#import": [
-        "ol.7.3",
-        "ol.7.2-x64",
-        "rhel.7.3-x64"
-      ]
-    },
-    "ol.7.4": {
-      "#import": [
-        "ol.7.3",
-        "rhel.7.4"
-      ]
-    },
-    "ol.7.4-x64": {
-      "#import": [
-        "ol.7.4",
-        "ol.7.3-x64",
-        "rhel.7.4-x64"
-      ]
-    },
-    "ol.7.5": {
-      "#import": [
-        "ol.7.4",
-        "rhel.7.5"
-      ]
-    },
-    "ol.7.5-x64": {
-      "#import": [
-        "ol.7.5",
-        "ol.7.4-x64",
-        "rhel.7.5-x64"
-      ]
-    },
-    "ol.7.6": {
-      "#import": [
-        "ol.7.5",
-        "rhel.7.6"
-      ]
-    },
-    "ol.7.6-x64": {
-      "#import": [
-        "ol.7.6",
-        "ol.7.5-x64",
-        "rhel.7.6-x64"
-      ]
-    },
-    "ol.8": {
-      "#import": [
-        "ol",
-        "rhel.8"
-      ]
-    },
-    "ol.8-x64": {
-      "#import": [
-        "ol.8",
-        "ol-x64",
-        "rhel.8-x64"
-      ]
-    },
     "ol.8.0": {
       "#import": [
-        "ol.8",
-        "rhel.8.0"
+        "ol"
       ]
     },
     "ol.8.0-x64": {
       "#import": [
         "ol.8.0",
-        "ol.8-x64",
-        "rhel.8.0-x64"
+        "ol-x64"
       ]
     },
     "omnios": {
@@ -2611,61 +800,6 @@
         "linux-x64"
       ]
     },
-    "opensuse.13.2": {
-      "#import": [
-        "opensuse"
-      ]
-    },
-    "opensuse.13.2-x64": {
-      "#import": [
-        "opensuse.13.2",
-        "opensuse-x64"
-      ]
-    },
-    "opensuse.15.0": {
-      "#import": [
-        "opensuse"
-      ]
-    },
-    "opensuse.15.0-x64": {
-      "#import": [
-        "opensuse.15.0",
-        "opensuse-x64"
-      ]
-    },
-    "opensuse.15.1": {
-      "#import": [
-        "opensuse"
-      ]
-    },
-    "opensuse.15.1-x64": {
-      "#import": [
-        "opensuse.15.1",
-        "opensuse-x64"
-      ]
-    },
-    "opensuse.42.1": {
-      "#import": [
-        "opensuse"
-      ]
-    },
-    "opensuse.42.1-x64": {
-      "#import": [
-        "opensuse.42.1",
-        "opensuse-x64"
-      ]
-    },
-    "opensuse.42.2": {
-      "#import": [
-        "opensuse"
-      ]
-    },
-    "opensuse.42.2-x64": {
-      "#import": [
-        "opensuse.42.2",
-        "opensuse-x64"
-      ]
-    },
     "opensuse.42.3": {
       "#import": [
         "opensuse"
@@ -2694,174 +828,21 @@
         "unix-x64"
       ]
     },
-    "osx.10.10": {
-      "#import": [
-        "osx"
-      ]
-    },
-    "osx.10.10-arm64": {
-      "#import": [
-        "osx.10.10",
-        "osx-arm64"
-      ]
-    },
-    "osx.10.10-x64": {
-      "#import": [
-        "osx.10.10",
-        "osx-x64"
-      ]
-    },
-    "osx.10.11": {
-      "#import": [
-        "osx.10.10"
-      ]
-    },
-    "osx.10.11-arm64": {
-      "#import": [
-        "osx.10.11",
-        "osx.10.10-arm64"
-      ]
-    },
-    "osx.10.11-x64": {
-      "#import": [
-        "osx.10.11",
-        "osx.10.10-x64"
-      ]
-    },
-    "osx.10.12": {
-      "#import": [
-        "osx.10.11"
-      ]
-    },
-    "osx.10.12-arm64": {
-      "#import": [
-        "osx.10.12",
-        "osx.10.11-arm64"
-      ]
-    },
-    "osx.10.12-x64": {
-      "#import": [
-        "osx.10.12",
-        "osx.10.11-x64"
-      ]
-    },
-    "osx.10.13": {
-      "#import": [
-        "osx.10.12"
-      ]
-    },
-    "osx.10.13-arm64": {
-      "#import": [
-        "osx.10.13",
-        "osx.10.12-arm64"
-      ]
-    },
-    "osx.10.13-x64": {
-      "#import": [
-        "osx.10.13",
-        "osx.10.12-x64"
-      ]
-    },
-    "osx.10.14": {
-      "#import": [
-        "osx.10.13"
-      ]
-    },
-    "osx.10.14-arm64": {
-      "#import": [
-        "osx.10.14",
-        "osx.10.13-arm64"
-      ]
-    },
-    "osx.10.14-x64": {
-      "#import": [
-        "osx.10.14",
-        "osx.10.13-x64"
-      ]
-    },
-    "osx.10.15": {
-      "#import": [
-        "osx.10.14"
-      ]
-    },
-    "osx.10.15-arm64": {
-      "#import": [
-        "osx.10.15",
-        "osx.10.14-arm64"
-      ]
-    },
-    "osx.10.15-x64": {
-      "#import": [
-        "osx.10.15",
-        "osx.10.14-x64"
-      ]
-    },
-    "osx.10.16": {
-      "#import": [
-        "osx.10.15"
-      ]
-    },
-    "osx.10.16-arm64": {
-      "#import": [
-        "osx.10.16",
-        "osx.10.15-arm64"
-      ]
-    },
-    "osx.10.16-x64": {
-      "#import": [
-        "osx.10.16",
-        "osx.10.15-x64"
-      ]
-    },
-    "osx.11.0": {
-      "#import": [
-        "osx.10.16"
-      ]
-    },
-    "osx.11.0-arm64": {
-      "#import": [
-        "osx.11.0",
-        "osx.10.16-arm64"
-      ]
-    },
-    "osx.11.0-x64": {
-      "#import": [
-        "osx.11.0",
-        "osx.10.16-x64"
-      ]
-    },
-    "osx.12": {
-      "#import": [
-        "osx.11.0"
-      ]
-    },
-    "osx.12-arm64": {
-      "#import": [
-        "osx.12",
-        "osx.11.0-arm64"
-      ]
-    },
-    "osx.12-x64": {
-      "#import": [
-        "osx.12",
-        "osx.11.0-x64"
-      ]
-    },
     "osx.13": {
       "#import": [
-        "osx.12"
+        "osx"
       ]
     },
     "osx.13-arm64": {
       "#import": [
         "osx.13",
-        "osx.12-arm64"
+        "osx-arm64"
       ]
     },
     "osx.13-x64": {
       "#import": [
         "osx.13",
-        "osx.12-x64"
+        "osx-x64"
       ]
     },
     "rhel": {
@@ -2879,156 +860,6 @@
       "#import": [
         "rhel",
         "linux-x64"
-      ]
-    },
-    "rhel.6": {
-      "#import": [
-        "rhel"
-      ]
-    },
-    "rhel.6-x64": {
-      "#import": [
-        "rhel.6",
-        "rhel-x64"
-      ]
-    },
-    "rhel.7": {
-      "#import": [
-        "rhel"
-      ]
-    },
-    "rhel.7-x64": {
-      "#import": [
-        "rhel.7",
-        "rhel-x64"
-      ]
-    },
-    "rhel.7.0": {
-      "#import": [
-        "rhel.7"
-      ]
-    },
-    "rhel.7.0-x64": {
-      "#import": [
-        "rhel.7.0",
-        "rhel.7-x64"
-      ]
-    },
-    "rhel.7.1": {
-      "#import": [
-        "rhel.7.0"
-      ]
-    },
-    "rhel.7.1-x64": {
-      "#import": [
-        "rhel.7.1",
-        "rhel.7.0-x64"
-      ]
-    },
-    "rhel.7.2": {
-      "#import": [
-        "rhel.7.1"
-      ]
-    },
-    "rhel.7.2-x64": {
-      "#import": [
-        "rhel.7.2",
-        "rhel.7.1-x64"
-      ]
-    },
-    "rhel.7.3": {
-      "#import": [
-        "rhel.7.2"
-      ]
-    },
-    "rhel.7.3-x64": {
-      "#import": [
-        "rhel.7.3",
-        "rhel.7.2-x64"
-      ]
-    },
-    "rhel.7.4": {
-      "#import": [
-        "rhel.7.3"
-      ]
-    },
-    "rhel.7.4-x64": {
-      "#import": [
-        "rhel.7.4",
-        "rhel.7.3-x64"
-      ]
-    },
-    "rhel.7.5": {
-      "#import": [
-        "rhel.7.4"
-      ]
-    },
-    "rhel.7.5-x64": {
-      "#import": [
-        "rhel.7.5",
-        "rhel.7.4-x64"
-      ]
-    },
-    "rhel.7.6": {
-      "#import": [
-        "rhel.7.5"
-      ]
-    },
-    "rhel.7.6-x64": {
-      "#import": [
-        "rhel.7.6",
-        "rhel.7.5-x64"
-      ]
-    },
-    "rhel.8": {
-      "#import": [
-        "rhel"
-      ]
-    },
-    "rhel.8-arm64": {
-      "#import": [
-        "rhel.8",
-        "rhel-arm64"
-      ]
-    },
-    "rhel.8-x64": {
-      "#import": [
-        "rhel.8",
-        "rhel-x64"
-      ]
-    },
-    "rhel.8.0": {
-      "#import": [
-        "rhel.8"
-      ]
-    },
-    "rhel.8.0-arm64": {
-      "#import": [
-        "rhel.8.0",
-        "rhel.8-arm64"
-      ]
-    },
-    "rhel.8.0-x64": {
-      "#import": [
-        "rhel.8.0",
-        "rhel.8-x64"
-      ]
-    },
-    "rhel.8.1": {
-      "#import": [
-        "rhel.8.0"
-      ]
-    },
-    "rhel.8.1-arm64": {
-      "#import": [
-        "rhel.8.1",
-        "rhel.8.0-arm64"
-      ]
-    },
-    "rhel.8.1-x64": {
-      "#import": [
-        "rhel.8.1",
-        "rhel.8.0-x64"
       ]
     },
     "rhel.9": {
@@ -3065,26 +896,6 @@
         "rhel-x64"
       ]
     },
-    "rocky.8": {
-      "#import": [
-        "rocky",
-        "rhel.8"
-      ]
-    },
-    "rocky.8-arm64": {
-      "#import": [
-        "rocky.8",
-        "rocky-arm64",
-        "rhel.8-arm64"
-      ]
-    },
-    "rocky.8-x64": {
-      "#import": [
-        "rocky.8",
-        "rocky-x64",
-        "rhel.8-x64"
-      ]
-    },
     "rocky.9": {
       "#import": [
         "rocky",
@@ -3116,81 +927,15 @@
         "linux-x64"
       ]
     },
-    "sles.12": {
-      "#import": [
-        "sles"
-      ]
-    },
-    "sles.12-x64": {
-      "#import": [
-        "sles.12",
-        "sles-x64"
-      ]
-    },
-    "sles.12.1": {
-      "#import": [
-        "sles.12"
-      ]
-    },
-    "sles.12.1-x64": {
-      "#import": [
-        "sles.12.1",
-        "sles.12-x64"
-      ]
-    },
-    "sles.12.2": {
-      "#import": [
-        "sles.12.1"
-      ]
-    },
-    "sles.12.2-x64": {
-      "#import": [
-        "sles.12.2",
-        "sles.12.1-x64"
-      ]
-    },
-    "sles.12.3": {
-      "#import": [
-        "sles.12.2"
-      ]
-    },
-    "sles.12.3-x64": {
-      "#import": [
-        "sles.12.3",
-        "sles.12.2-x64"
-      ]
-    },
-    "sles.12.4": {
-      "#import": [
-        "sles.12.3"
-      ]
-    },
-    "sles.12.4-x64": {
-      "#import": [
-        "sles.12.4",
-        "sles.12.3-x64"
-      ]
-    },
-    "sles.15": {
-      "#import": [
-        "sles.12.4"
-      ]
-    },
-    "sles.15-x64": {
-      "#import": [
-        "sles.15",
-        "sles.12.4-x64"
-      ]
-    },
     "sles.15.1": {
       "#import": [
-        "sles.15"
+        "sles"
       ]
     },
     "sles.15.1-x64": {
       "#import": [
         "sles.15.1",
-        "sles.15-x64"
+        "sles-x64"
       ]
     },
     "smartos": {
@@ -3204,26 +949,15 @@
         "illumos-x64"
       ]
     },
-    "smartos.2020": {
-      "#import": [
-        "smartos"
-      ]
-    },
-    "smartos.2020-x64": {
-      "#import": [
-        "smartos.2020",
-        "smartos-x64"
-      ]
-    },
     "smartos.2021": {
       "#import": [
-        "smartos.2020"
+        "smartos"
       ]
     },
     "smartos.2021-x64": {
       "#import": [
         "smartos.2021",
-        "smartos.2020-x64"
+        "smartos-x64"
       ]
     },
     "solaris": {
@@ -3271,142 +1005,27 @@
         "linux-x86"
       ]
     },
-    "tizen.4.0.0": {
-      "#import": [
-        "tizen"
-      ]
-    },
-    "tizen.4.0.0-arm64": {
-      "#import": [
-        "tizen.4.0.0",
-        "tizen-arm64"
-      ]
-    },
-    "tizen.4.0.0-armel": {
-      "#import": [
-        "tizen.4.0.0",
-        "tizen-armel"
-      ]
-    },
-    "tizen.4.0.0-x86": {
-      "#import": [
-        "tizen.4.0.0",
-        "tizen-x86"
-      ]
-    },
-    "tizen.5.0.0": {
-      "#import": [
-        "tizen.4.0.0"
-      ]
-    },
-    "tizen.5.0.0-arm64": {
-      "#import": [
-        "tizen.5.0.0",
-        "tizen.4.0.0-arm64"
-      ]
-    },
-    "tizen.5.0.0-armel": {
-      "#import": [
-        "tizen.5.0.0",
-        "tizen.4.0.0-armel"
-      ]
-    },
-    "tizen.5.0.0-x86": {
-      "#import": [
-        "tizen.5.0.0",
-        "tizen.4.0.0-x86"
-      ]
-    },
-    "tizen.5.5.0": {
-      "#import": [
-        "tizen.5.0.0"
-      ]
-    },
-    "tizen.5.5.0-arm64": {
-      "#import": [
-        "tizen.5.5.0",
-        "tizen.5.0.0-arm64"
-      ]
-    },
-    "tizen.5.5.0-armel": {
-      "#import": [
-        "tizen.5.5.0",
-        "tizen.5.0.0-armel"
-      ]
-    },
-    "tizen.5.5.0-x86": {
-      "#import": [
-        "tizen.5.5.0",
-        "tizen.5.0.0-x86"
-      ]
-    },
-    "tizen.6.0.0": {
-      "#import": [
-        "tizen.5.5.0"
-      ]
-    },
-    "tizen.6.0.0-arm64": {
-      "#import": [
-        "tizen.6.0.0",
-        "tizen.5.5.0-arm64"
-      ]
-    },
-    "tizen.6.0.0-armel": {
-      "#import": [
-        "tizen.6.0.0",
-        "tizen.5.5.0-armel"
-      ]
-    },
-    "tizen.6.0.0-x86": {
-      "#import": [
-        "tizen.6.0.0",
-        "tizen.5.5.0-x86"
-      ]
-    },
-    "tizen.6.5.0": {
-      "#import": [
-        "tizen.6.0.0"
-      ]
-    },
-    "tizen.6.5.0-arm64": {
-      "#import": [
-        "tizen.6.5.0",
-        "tizen.6.0.0-arm64"
-      ]
-    },
-    "tizen.6.5.0-armel": {
-      "#import": [
-        "tizen.6.5.0",
-        "tizen.6.0.0-armel"
-      ]
-    },
-    "tizen.6.5.0-x86": {
-      "#import": [
-        "tizen.6.5.0",
-        "tizen.6.0.0-x86"
-      ]
-    },
     "tizen.7.0.0": {
       "#import": [
-        "tizen.6.5.0"
+        "tizen"
       ]
     },
     "tizen.7.0.0-arm64": {
       "#import": [
         "tizen.7.0.0",
-        "tizen.6.5.0-arm64"
+        "tizen-arm64"
       ]
     },
     "tizen.7.0.0-armel": {
       "#import": [
         "tizen.7.0.0",
-        "tizen.6.5.0-armel"
+        "tizen-armel"
       ]
     },
     "tizen.7.0.0-x86": {
       "#import": [
         "tizen.7.0.0",
-        "tizen.6.5.0-x86"
+        "tizen-x86"
       ]
     },
     "tvos": {
@@ -3426,106 +1045,21 @@
         "unix-x64"
       ]
     },
-    "tvos.10": {
-      "#import": [
-        "tvos"
-      ]
-    },
-    "tvos.10-arm64": {
-      "#import": [
-        "tvos.10",
-        "tvos-arm64"
-      ]
-    },
-    "tvos.10-x64": {
-      "#import": [
-        "tvos.10",
-        "tvos-x64"
-      ]
-    },
-    "tvos.11": {
-      "#import": [
-        "tvos.10"
-      ]
-    },
-    "tvos.11-arm64": {
-      "#import": [
-        "tvos.11",
-        "tvos.10-arm64"
-      ]
-    },
-    "tvos.11-x64": {
-      "#import": [
-        "tvos.11",
-        "tvos.10-x64"
-      ]
-    },
-    "tvos.12": {
-      "#import": [
-        "tvos.11"
-      ]
-    },
-    "tvos.12-arm64": {
-      "#import": [
-        "tvos.12",
-        "tvos.11-arm64"
-      ]
-    },
-    "tvos.12-x64": {
-      "#import": [
-        "tvos.12",
-        "tvos.11-x64"
-      ]
-    },
-    "tvos.13": {
-      "#import": [
-        "tvos.12"
-      ]
-    },
-    "tvos.13-arm64": {
-      "#import": [
-        "tvos.13",
-        "tvos.12-arm64"
-      ]
-    },
-    "tvos.13-x64": {
-      "#import": [
-        "tvos.13",
-        "tvos.12-x64"
-      ]
-    },
-    "tvos.14": {
-      "#import": [
-        "tvos.13"
-      ]
-    },
-    "tvos.14-arm64": {
-      "#import": [
-        "tvos.14",
-        "tvos.13-arm64"
-      ]
-    },
-    "tvos.14-x64": {
-      "#import": [
-        "tvos.14",
-        "tvos.13-x64"
-      ]
-    },
     "tvos.15": {
       "#import": [
-        "tvos.14"
+        "tvos"
       ]
     },
     "tvos.15-arm64": {
       "#import": [
         "tvos.15",
-        "tvos.14-arm64"
+        "tvos-arm64"
       ]
     },
     "tvos.15-x64": {
       "#import": [
         "tvos.15",
-        "tvos.14-x64"
+        "tvos-x64"
       ]
     },
     "tvossimulator": {
@@ -3545,106 +1079,21 @@
         "tvos-x64"
       ]
     },
-    "tvossimulator.10": {
-      "#import": [
-        "tvossimulator"
-      ]
-    },
-    "tvossimulator.10-arm64": {
-      "#import": [
-        "tvossimulator.10",
-        "tvossimulator-arm64"
-      ]
-    },
-    "tvossimulator.10-x64": {
-      "#import": [
-        "tvossimulator.10",
-        "tvossimulator-x64"
-      ]
-    },
-    "tvossimulator.11": {
-      "#import": [
-        "tvossimulator.10"
-      ]
-    },
-    "tvossimulator.11-arm64": {
-      "#import": [
-        "tvossimulator.11",
-        "tvossimulator.10-arm64"
-      ]
-    },
-    "tvossimulator.11-x64": {
-      "#import": [
-        "tvossimulator.11",
-        "tvossimulator.10-x64"
-      ]
-    },
-    "tvossimulator.12": {
-      "#import": [
-        "tvossimulator.11"
-      ]
-    },
-    "tvossimulator.12-arm64": {
-      "#import": [
-        "tvossimulator.12",
-        "tvossimulator.11-arm64"
-      ]
-    },
-    "tvossimulator.12-x64": {
-      "#import": [
-        "tvossimulator.12",
-        "tvossimulator.11-x64"
-      ]
-    },
-    "tvossimulator.13": {
-      "#import": [
-        "tvossimulator.12"
-      ]
-    },
-    "tvossimulator.13-arm64": {
-      "#import": [
-        "tvossimulator.13",
-        "tvossimulator.12-arm64"
-      ]
-    },
-    "tvossimulator.13-x64": {
-      "#import": [
-        "tvossimulator.13",
-        "tvossimulator.12-x64"
-      ]
-    },
-    "tvossimulator.14": {
-      "#import": [
-        "tvossimulator.13"
-      ]
-    },
-    "tvossimulator.14-arm64": {
-      "#import": [
-        "tvossimulator.14",
-        "tvossimulator.13-arm64"
-      ]
-    },
-    "tvossimulator.14-x64": {
-      "#import": [
-        "tvossimulator.14",
-        "tvossimulator.13-x64"
-      ]
-    },
     "tvossimulator.15": {
       "#import": [
-        "tvossimulator.14"
+        "tvossimulator"
       ]
     },
     "tvossimulator.15-arm64": {
       "#import": [
         "tvossimulator.15",
-        "tvossimulator.14-arm64"
+        "tvossimulator-arm64"
       ]
     },
     "tvossimulator.15-x64": {
       "#import": [
         "tvossimulator.15",
-        "tvossimulator.14-x64"
+        "tvossimulator-x64"
       ]
     },
     "ubuntu": {
@@ -3674,533 +1123,6 @@
       "#import": [
         "ubuntu",
         "debian-x86"
-      ]
-    },
-    "ubuntu.14.04": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.14.04-arm": {
-      "#import": [
-        "ubuntu.14.04",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.14.04-x64": {
-      "#import": [
-        "ubuntu.14.04",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.14.04-x86": {
-      "#import": [
-        "ubuntu.14.04",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.14.10": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.14.10-arm": {
-      "#import": [
-        "ubuntu.14.10",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.14.10-x64": {
-      "#import": [
-        "ubuntu.14.10",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.14.10-x86": {
-      "#import": [
-        "ubuntu.14.10",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.15.04": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.15.04-arm": {
-      "#import": [
-        "ubuntu.15.04",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.15.04-x64": {
-      "#import": [
-        "ubuntu.15.04",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.15.04-x86": {
-      "#import": [
-        "ubuntu.15.04",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.15.10": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.15.10-arm": {
-      "#import": [
-        "ubuntu.15.10",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.15.10-x64": {
-      "#import": [
-        "ubuntu.15.10",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.15.10-x86": {
-      "#import": [
-        "ubuntu.15.10",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.16.04": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.16.04-arm": {
-      "#import": [
-        "ubuntu.16.04",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.16.04-arm64": {
-      "#import": [
-        "ubuntu.16.04",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.16.04-x64": {
-      "#import": [
-        "ubuntu.16.04",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.16.04-x86": {
-      "#import": [
-        "ubuntu.16.04",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.16.10": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.16.10-arm": {
-      "#import": [
-        "ubuntu.16.10",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.16.10-arm64": {
-      "#import": [
-        "ubuntu.16.10",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.16.10-x64": {
-      "#import": [
-        "ubuntu.16.10",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.16.10-x86": {
-      "#import": [
-        "ubuntu.16.10",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.17.04": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.17.04-arm": {
-      "#import": [
-        "ubuntu.17.04",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.17.04-arm64": {
-      "#import": [
-        "ubuntu.17.04",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.17.04-x64": {
-      "#import": [
-        "ubuntu.17.04",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.17.04-x86": {
-      "#import": [
-        "ubuntu.17.04",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.17.10": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.17.10-arm": {
-      "#import": [
-        "ubuntu.17.10",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.17.10-arm64": {
-      "#import": [
-        "ubuntu.17.10",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.17.10-x64": {
-      "#import": [
-        "ubuntu.17.10",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.17.10-x86": {
-      "#import": [
-        "ubuntu.17.10",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.18.04": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.18.04-arm": {
-      "#import": [
-        "ubuntu.18.04",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.18.04-arm64": {
-      "#import": [
-        "ubuntu.18.04",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.18.04-x64": {
-      "#import": [
-        "ubuntu.18.04",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.18.04-x86": {
-      "#import": [
-        "ubuntu.18.04",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.18.10": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.18.10-arm": {
-      "#import": [
-        "ubuntu.18.10",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.18.10-arm64": {
-      "#import": [
-        "ubuntu.18.10",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.18.10-x64": {
-      "#import": [
-        "ubuntu.18.10",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.18.10-x86": {
-      "#import": [
-        "ubuntu.18.10",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.19.04": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.19.04-arm": {
-      "#import": [
-        "ubuntu.19.04",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.19.04-arm64": {
-      "#import": [
-        "ubuntu.19.04",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.19.04-x64": {
-      "#import": [
-        "ubuntu.19.04",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.19.04-x86": {
-      "#import": [
-        "ubuntu.19.04",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.19.10": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.19.10-arm": {
-      "#import": [
-        "ubuntu.19.10",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.19.10-arm64": {
-      "#import": [
-        "ubuntu.19.10",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.19.10-x64": {
-      "#import": [
-        "ubuntu.19.10",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.19.10-x86": {
-      "#import": [
-        "ubuntu.19.10",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.20.04": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.20.04-arm": {
-      "#import": [
-        "ubuntu.20.04",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.20.04-arm64": {
-      "#import": [
-        "ubuntu.20.04",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.20.04-x64": {
-      "#import": [
-        "ubuntu.20.04",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.20.04-x86": {
-      "#import": [
-        "ubuntu.20.04",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.20.10": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.20.10-arm": {
-      "#import": [
-        "ubuntu.20.10",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.20.10-arm64": {
-      "#import": [
-        "ubuntu.20.10",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.20.10-x64": {
-      "#import": [
-        "ubuntu.20.10",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.20.10-x86": {
-      "#import": [
-        "ubuntu.20.10",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.21.04": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.21.04-arm": {
-      "#import": [
-        "ubuntu.21.04",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.21.04-arm64": {
-      "#import": [
-        "ubuntu.21.04",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.21.04-x64": {
-      "#import": [
-        "ubuntu.21.04",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.21.04-x86": {
-      "#import": [
-        "ubuntu.21.04",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.21.10": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.21.10-arm": {
-      "#import": [
-        "ubuntu.21.10",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.21.10-arm64": {
-      "#import": [
-        "ubuntu.21.10",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.21.10-x64": {
-      "#import": [
-        "ubuntu.21.10",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.21.10-x86": {
-      "#import": [
-        "ubuntu.21.10",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.22.04": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.22.04-arm": {
-      "#import": [
-        "ubuntu.22.04",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.22.04-arm64": {
-      "#import": [
-        "ubuntu.22.04",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.22.04-x64": {
-      "#import": [
-        "ubuntu.22.04",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.22.04-x86": {
-      "#import": [
-        "ubuntu.22.04",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.22.10": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.22.10-arm": {
-      "#import": [
-        "ubuntu.22.10",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.22.10-arm64": {
-      "#import": [
-        "ubuntu.22.10",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.22.10-x64": {
-      "#import": [
-        "ubuntu.22.10",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.22.10-x86": {
-      "#import": [
-        "ubuntu.22.10",
-        "ubuntu-x86"
-      ]
-    },
-    "ubuntu.23.04": {
-      "#import": [
-        "ubuntu"
-      ]
-    },
-    "ubuntu.23.04-arm": {
-      "#import": [
-        "ubuntu.23.04",
-        "ubuntu-arm"
-      ]
-    },
-    "ubuntu.23.04-arm64": {
-      "#import": [
-        "ubuntu.23.04",
-        "ubuntu-arm64"
-      ]
-    },
-    "ubuntu.23.04-x64": {
-      "#import": [
-        "ubuntu.23.04",
-        "ubuntu-x64"
-      ]
-    },
-    "ubuntu.23.04-x86": {
-      "#import": [
-        "ubuntu.23.04",
-        "ubuntu-x86"
       ]
     },
     "ubuntu.23.10": {
@@ -4378,7 +1300,6 @@
       "#import": [
         "win10-aot",
         "win10-arm",
-        "win10",
         "win81-arm-aot"
       ]
     },
@@ -4392,7 +1313,6 @@
       "#import": [
         "win10-aot",
         "win10-arm64",
-        "win10",
         "win81-arm64-aot"
       ]
     },
@@ -4406,7 +1326,6 @@
       "#import": [
         "win10-aot",
         "win10-x64",
-        "win10",
         "win81-x64-aot"
       ]
     },
@@ -4420,7 +1339,6 @@
       "#import": [
         "win10-aot",
         "win10-x86",
-        "win10",
         "win81-x86-aot"
       ]
     },
@@ -4445,7 +1363,6 @@
       "#import": [
         "win7-aot",
         "win7-arm",
-        "win7",
         "win-arm-aot"
       ]
     },
@@ -4459,7 +1376,6 @@
       "#import": [
         "win7-aot",
         "win7-arm64",
-        "win7",
         "win-arm64-aot"
       ]
     },
@@ -4473,7 +1389,6 @@
       "#import": [
         "win7-aot",
         "win7-x64",
-        "win7",
         "win-x64-aot"
       ]
     },
@@ -4487,7 +1402,6 @@
       "#import": [
         "win7-aot",
         "win7-x86",
-        "win7",
         "win-x86-aot"
       ]
     },
@@ -4512,7 +1426,6 @@
       "#import": [
         "win8-aot",
         "win8-arm",
-        "win8",
         "win7-arm-aot"
       ]
     },
@@ -4526,7 +1439,6 @@
       "#import": [
         "win8-aot",
         "win8-arm64",
-        "win8",
         "win7-arm64-aot"
       ]
     },
@@ -4540,7 +1452,6 @@
       "#import": [
         "win8-aot",
         "win8-x64",
-        "win8",
         "win7-x64-aot"
       ]
     },
@@ -4554,7 +1465,6 @@
       "#import": [
         "win8-aot",
         "win8-x86",
-        "win8",
         "win7-x86-aot"
       ]
     },
@@ -4579,7 +1489,6 @@
       "#import": [
         "win81-aot",
         "win81-arm",
-        "win81",
         "win8-arm-aot"
       ]
     },
@@ -4593,7 +1502,6 @@
       "#import": [
         "win81-aot",
         "win81-arm64",
-        "win81",
         "win8-arm64-aot"
       ]
     },
@@ -4607,7 +1515,6 @@
       "#import": [
         "win81-aot",
         "win81-x64",
-        "win81",
         "win8-x64-aot"
       ]
     },
@@ -4621,7 +1528,6 @@
       "#import": [
         "win81-aot",
         "win81-x86",
-        "win81",
         "win8-x86-aot"
       ]
     }


### PR DESCRIPTION
Replaces: https://github.com/dotnet/runtime/pull/123161

Softer approach to RID graph simplification. Instead of removing all versioned and distro-specific RIDs, this keeps:

- All portable/base RIDs (any, unix, linux, win, etc.)
- All floating (unversioned) OS RIDs (alpine, ubuntu, osx, etc.)
- The last versioned RID for each OS family and its arch variants

This reduces runtime.json from ~4600 lines (798 RIDs) to ~1500 lines (266 RIDs) while preserving a migration path for packages that reference the most recent versioned RIDs.

We can do more cleanup later. This approach is a much safer starting point with easier migration guidance. It's also more defensible.

Removed RIDs: all intermediate versioned RIDs (e.g. alpine.3.7 through alpine.3.17, ubuntu.14.04 through ubuntu.23.04, osx.10.10 through osx.12, etc.)

Kept last versions include: alpine.3.18, android.32, centos.9, debian.12, fedora.39, freebsd.13, ios.15, osx.13, rhel.9, rocky.9, tizen.7.0.0, tvos.15, ubuntu.23.10, and others.