### PR TITLE
[browser] Simplify synchronization primitives

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/ObjectHeader.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/ObjectHeader.CoreCLR.cs
@@ -56,11 +56,41 @@ namespace System.Threading
             UseSlowPath = 2
         };
 
+#if FEATURE_MULTITHREADING
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern HeaderLockResult AcquireInternal(object obj);
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         public static extern HeaderLockResult Release(object obj);
+#else
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe HeaderLockResult Release(object obj)
+        {
+            ArgumentNullException.ThrowIfNull(obj);
+
+            fixed (byte* pObjectData = &obj.GetRawData())
+            {
+                int* pHeader = GetHeaderPtr(pObjectData);
+                int oldBits = *pHeader;
+
+                if ((oldBits & (BIT_SBLK_IS_HASH_OR_SYNCBLKINDEX | BIT_SBLK_SPIN_LOCK)) != 0)
+                    return HeaderLockResult.UseSlowPath;
+
+                int currentThreadID = ManagedThreadId.Current;
+                if ((oldBits & SBLK_MASK_LOCK_THREADID) != currentThreadID)
+                    return HeaderLockResult.Failure;
+
+                if ((oldBits & SBLK_MASK_LOCK_RECLEVEL) != 0)
+                {
+                    *pHeader = oldBits - SBLK_LOCK_RECLEVEL_INC;
+                    return HeaderLockResult.Success;
+                }
+
+                *pHeader = oldBits & ~SBLK_MASK_LOCK_THREADID;
+                return HeaderLockResult.Success;
+            }
+        }
+#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static unsafe int* GetHeaderPtr(byte* ppObjectData)
@@ -99,6 +129,45 @@ namespace System.Threading
         // back-off as it favors micro-contention scenario, which we expect.
         //
 
+#if !FEATURE_MULTITHREADING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe HeaderLockResult TryAcquireThinLock(object obj)
+        {
+            ArgumentNullException.ThrowIfNull(obj);
+
+            int currentThreadID = ManagedThreadId.Current;
+            if (currentThreadID > SBLK_MASK_LOCK_THREADID)
+                return HeaderLockResult.UseSlowPath;
+
+            fixed (byte* pObjectData = &obj.GetRawData())
+            {
+                int* pHeader = GetHeaderPtr(pObjectData);
+                int oldBits = *pHeader;
+
+                if ((oldBits & (BIT_SBLK_IS_HASH_OR_SYNCBLKINDEX | BIT_SBLK_SPIN_LOCK)) != 0)
+                    return HeaderLockResult.UseSlowPath;
+
+                if ((oldBits & SBLK_MASK_LOCK_THREADID) == currentThreadID)
+                {
+                    int newBits = oldBits + SBLK_LOCK_RECLEVEL_INC;
+                    if ((newBits & SBLK_MASK_LOCK_RECLEVEL) != 0)
+                    {
+                        *pHeader = newBits;
+                        return HeaderLockResult.Success;
+                    }
+                    return HeaderLockResult.UseSlowPath;
+                }
+
+                if ((oldBits & SBLK_MASK_LOCK_THREADID) == 0)
+                {
+                    *pHeader = oldBits | currentThreadID;
+                    return HeaderLockResult.Success;
+                }
+
+                return HeaderLockResult.UseSlowPath;
+            }
+        }
+#else
         // Try acquiring the thin-lock
         public static unsafe HeaderLockResult TryAcquireThinLock(object obj)
         {
@@ -198,6 +267,7 @@ namespace System.Threading
             // owned by somebody else
             return HeaderLockResult.Failure;
         }
+#endif // FEATURE_MULTITHREADING (TryAcquireThinLock + TryAcquireThinLockSpin)
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe HeaderLockResult IsAcquired(object obj)

--- a/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs
@@ -437,7 +437,9 @@ namespace System.Threading
         public void Interrupt()
         {
 #if TARGET_UNIX || TARGET_BROWSER || TARGET_WASI
+#if FEATURE_MULTITHREADING
             WaitSubsystem.Interrupt(this);
+#endif
 #else
             Interrupt(GetNativeHandle());
             GC.KeepAlive(this);
@@ -554,10 +556,13 @@ namespace System.Threading
         }
 
 #if TARGET_UNIX || TARGET_BROWSER || TARGET_WASI
+#pragma warning disable CA1822
         internal WaitSubsystem.ThreadWaitInfo WaitInfo
+#pragma warning restore CA1822
         {
             get
             {
+#if FEATURE_MULTITHREADING
                 return Volatile.Read(ref _waitInfo) ?? AllocateWaitInfo();
 
                 WaitSubsystem.ThreadWaitInfo AllocateWaitInfo()
@@ -565,6 +570,9 @@ namespace System.Threading
                     Interlocked.CompareExchange(ref _waitInfo, new WaitSubsystem.ThreadWaitInfo(this), null!);
                     return _waitInfo;
                 }
+#else
+                throw new PlatformNotSupportedException();
+#endif
             }
         }
 #endif
@@ -577,7 +585,7 @@ namespace System.Threading
             // so that any threads waiting on this thread to end will correctly see that it is stopped
             // when we set the join handle.
             _isDead = true;
-#if TARGET_UNIX || TARGET_BROWSER || TARGET_WASI
+#if (TARGET_UNIX || TARGET_BROWSER || TARGET_WASI) && FEATURE_MULTITHREADING
             // Inform the wait subsystem that the thread is exiting. For instance, this would abandon any mutexes locked by
             // the thread.
             _waitInfo?.OnThreadExiting();

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/BodySubstitutionParser.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/BodySubstitutionParser.cs
@@ -96,7 +96,7 @@ namespace ILCompiler
                     break;
                 default:
 #if !READYTORUN
-                    LogWarning(methodNav, DiagnosticId.XmlUnkownBodyModification, action, method.GetDisplayName());
+                    LogWarning(methodNav, DiagnosticId.XmlUnknownBodyModification, action, method.GetDisplayName());
 #endif
                     break;
             }

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -637,12 +637,14 @@ DEFINE_FIELD(LOCK,                  RECURSION_COUNT,        _recursionCount)
 DEFINE_METHOD(LOCK,                 CTOR,                   .ctor,                IM_RetVoid)
 DEFINE_METHOD(LOCK,                 INITIALIZE_FOR_MONITOR, InitializeForMonitor, SM_PtrLock_Int_UInt_PtrException_RetVoid)
 
+#ifndef !FEATURE_MULTITHREADING
 DEFINE_CLASS(CONDITION,             Threading,              Condition)
 DEFINE_FIELD(CONDITION,             WAITERS_HEAD,           _waitersHead)
 DEFINE_FIELD(CONDITION,             CURRENT_THREAD_WAITER,  t_waiterForCurrentThread)
 
 DEFINE_CLASS(WAITER,                Threading,              Condition+Waiter)
 DEFINE_FIELD(WAITER,                NEXT,                   next)
+#endif // FEATURE_MULTITHREADING
 
 DEFINE_CLASS(THREADID,              Threading,              ManagedThreadId)
 

--- a/src/coreclr/vm/corelib.h
+++ b/src/coreclr/vm/corelib.h
@@ -637,7 +637,7 @@ DEFINE_FIELD(LOCK,                  RECURSION_COUNT,        _recursionCount)
 DEFINE_METHOD(LOCK,                 CTOR,                   .ctor,                IM_RetVoid)
 DEFINE_METHOD(LOCK,                 INITIALIZE_FOR_MONITOR, InitializeForMonitor, SM_PtrLock_Int_UInt_PtrException_RetVoid)
 
-#ifndef !FEATURE_MULTITHREADING
+#ifdef FEATURE_MULTITHREADING
 DEFINE_CLASS(CONDITION,             Threading,              Condition)
 DEFINE_FIELD(CONDITION,             WAITERS_HEAD,           _waitersHead)
 DEFINE_FIELD(CONDITION,             CURRENT_THREAD_WAITER,  t_waiterForCurrentThread)

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeWaitHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeWaitHandle.Unix.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if FEATURE_MULTITHREADING
 using System.Threading;
+#endif
 
 namespace Microsoft.Win32.SafeHandles
 {
@@ -9,7 +11,9 @@ namespace Microsoft.Win32.SafeHandles
     {
         protected override bool ReleaseHandle()
         {
+#if FEATURE_MULTITHREADING
             WaitSubsystem.DeleteHandle(handle);
+#endif
             return true;
         }
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.NativeSinks.cs
@@ -83,6 +83,7 @@ namespace System.Diagnostics.Tracing
             LogContentionLockCreated(LockID, AssociatedObjectID, ClrInstanceID);
         }
 
+#if FEATURE_MULTITHREADING
         [NonEvent]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void ContentionLockCreated(Lock lockObj) =>
@@ -91,6 +92,7 @@ namespace System.Diagnostics.Tracing
 #pragma warning disable CS9216 // A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in 'lock' statement.
                 ObjectIDForEvents(lockObj));
 #pragma warning restore CS9216
+#endif
 
         [Event(81, Level = EventLevel.Informational, Message = Messages.ContentionStart, Task = Tasks.Contention, Opcode = EventOpcode.Start, Version = 2, Keywords = Keywords.ContentionKeyword)]
         private void ContentionStart(
@@ -104,6 +106,7 @@ namespace System.Diagnostics.Tracing
             LogContentionStart(ContentionFlags, ClrInstanceID, LockID, AssociatedObjectID, LockOwnerThreadID);
         }
 
+#if FEATURE_MULTITHREADING
         [NonEvent]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void ContentionStart(Lock lockObj) =>
@@ -115,6 +118,7 @@ namespace System.Diagnostics.Tracing
                 ObjectIDForEvents(lockObj),
 #pragma warning restore CS9216
                 (ulong)lockObj.OwningThreadId);
+#endif
 
         [Event(91, Level = EventLevel.Informational, Message = Messages.ContentionStop, Task = Tasks.Contention, Opcode = EventOpcode.Stop, Version = 1, Keywords = Keywords.ContentionKeyword)]
         private void ContentionStop(ContentionFlagsMap ContentionFlags, ushort ClrInstanceID, double DurationNs)

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Tracing/NativeRuntimeEventSource.Threading.cs
@@ -105,6 +105,7 @@ namespace System.Diagnostics.Tracing
             WriteEventCore(90, 3, data);
         }
 
+#if FEATURE_MULTITHREADING
         [NonEvent]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void ContentionLockCreated(Lock lockObj) =>
@@ -113,6 +114,7 @@ namespace System.Diagnostics.Tracing
 #pragma warning disable CS9216 // A value of type 'System.Threading.Lock' converted to a different type will use likely unintended monitor-based locking in 'lock' statement.
                 ObjectIDForEvents(lockObj));
 #pragma warning restore CS9216
+#endif
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern", Justification = "Parameters to this method are primitive and are trimmer safe")]
         [Event(81, Level = EventLevel.Informational, Message = Messages.ContentionStart, Task = Tasks.Contention, Opcode = EventOpcode.Start, Version = 2, Keywords = Keywords.ContentionKeyword)]
@@ -144,6 +146,7 @@ namespace System.Diagnostics.Tracing
             WriteEventCore(81, 5, data);
         }
 
+#if FEATURE_MULTITHREADING
         [NonEvent]
         [MethodImpl(MethodImplOptions.NoInlining)]
         public void ContentionStart(Lock lockObj) =>
@@ -155,6 +158,7 @@ namespace System.Diagnostics.Tracing
                 ObjectIDForEvents(lockObj),
 #pragma warning restore CS9216
                 (ulong)lockObj.OwningThreadId);
+#endif
 
         [UnconditionalSuppressMessage("ReflectionAnalysis", "IL2026:UnrecognizedReflectionPattern", Justification = "Parameters to this method are primitive and are trimmer safe")]
         [Event(91, Level = EventLevel.Informational, Message = Messages.ContentionStop, Task = Tasks.Contention, Opcode = EventOpcode.Stop, Version = 1, Keywords = Keywords.ContentionKeyword)]

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if FEATURE_MULTITHREADING
+
 #pragma warning disable 0420 //passing volatile fields by ref
 
 using System.Diagnostics;
@@ -187,3 +189,5 @@ namespace System.Threading
         }
     }
 }
+
+#endif // FEATURE_MULTITHREADING

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/EventWaitHandle.Unix.cs
@@ -10,6 +10,40 @@ namespace System.Threading
 {
     public partial class EventWaitHandle
     {
+#if !FEATURE_MULTITHREADING
+#pragma warning disable CA1822, IDE0060
+        private void CreateEventCore(bool initialState, EventResetMode mode)
+        {
+            ValidateMode(mode);
+        }
+
+        private void CreateEventCore(
+            bool initialState,
+            EventResetMode mode,
+            string? name,
+            NamedWaitHandleOptionsInternal options,
+            out bool createdNew)
+        {
+            ValidateMode(mode);
+            createdNew = true;
+        }
+
+        private static OpenExistingResult OpenExistingWorker(
+            string name,
+            NamedWaitHandleOptionsInternal options,
+            out EventWaitHandle? result)
+        {
+            result = null;
+            return OpenExistingResult.NameNotFound;
+        }
+
+        public bool Reset() => true;
+
+        public bool Set() => true;
+
+        internal static bool Set(SafeWaitHandle waitHandle) => true;
+#pragma warning restore CA1822, IDE0060
+#else
         private void CreateEventCore(bool initialState, EventResetMode mode)
         {
             ValidateMode(mode);
@@ -85,6 +119,7 @@ namespace System.Threading
                 waitHandle.DangerousRelease();
             }
         }
+#endif
 
         private SafeWaitHandle ValidateHandle()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Lock.cs
@@ -19,15 +19,18 @@ namespace System.Threading
     /// </remarks>
     public sealed class Lock
     {
+#if FEATURE_MULTITHREADING
         private const short DefaultMaxSpinCount = 22;
         private const short DefaultAdaptiveSpinPeriod = 100;
         private const short SpinSleep0Threshold = 10;
         private const ushort MaxDurationMsForPreemptingWaiters = 100;
 
         private const short SpinCountNotInitialized = short.MinValue;
+#endif
 
         internal const int UninitializedThreadId = 0;
 
+#if FEATURE_MULTITHREADING
         // NOTE: Lock must not have a static (class) constructor, as Lock itself is used to synchronize
         // class construction.  If Lock has its own class constructor, this can lead to infinite recursion.
         // All static data in Lock must be lazy-initialized.
@@ -37,12 +40,16 @@ namespace System.Threading
         private static short s_minSpinCountForAdaptiveSpin;
 
         private static long s_contentionCount;
+#endif
 
         private int _owningThreadId; // cDAC depends on exact name of this field
 
+#pragma warning disable CA1823 // Unused on ST but required by CoreCLR VM via corelib.h
         private uint _state; // see State for layout. cDAC depends on exact name of this field
+#pragma warning restore CA1823
         private uint _recursionCount; // cDAC depends on exact name of this field
 
+#if FEATURE_MULTITHREADING
         // This field serves a few purposes currently:
         // - When positive, it indicates the number of spin-wait iterations that most threads would do upon contention
         // - When zero, it indicates that spin-waiting is to be attempted by a thread to test if it is successful
@@ -53,13 +60,19 @@ namespace System.Threading
 
         private ushort _waiterStartTimeMs;
         private AutoResetEvent? _waitEvent;
+#endif
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Lock"/> class.
         /// </summary>
+#if !FEATURE_MULTITHREADING
+        public Lock() { }
+#else
         public Lock() => _spinCount = SpinCountNotInitialized;
+#endif
 
 
+#if FEATURE_MULTITHREADING
 #if NATIVEAOT // The method needs to be public in NativeAOT so that other private libraries can access it
         public Lock(bool useTrivialWaits)
 #else
@@ -69,6 +82,7 @@ namespace System.Threading
         {
             State.InitializeUseTrivialWaits(this, useTrivialWaits);
         }
+#endif
 
         internal int OwningManagedThreadId => (int)_owningThreadId;
 
@@ -242,6 +256,22 @@ namespace System.Threading
         [MethodImpl(MethodImplOptions.NoInlining)]
         private bool TryEnter_Outlined(int timeoutMs) => TryEnter_Inlined(timeoutMs) != UninitializedThreadId;
 
+#if !FEATURE_MULTITHREADING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private int TryEnter_Inlined(int timeoutMs)
+        {
+            Debug.Assert(timeoutMs >= -1);
+
+            int currentThreadId = ManagedThreadId.CurrentManagedThreadIdUnchecked;
+            if (currentThreadId != UninitializedThreadId && _owningThreadId == UninitializedThreadId)
+            {
+                _owningThreadId = currentThreadId;
+                return currentThreadId;
+            }
+
+            return TryEnterSlow(timeoutMs, currentThreadId);
+        }
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private int TryEnter_Inlined(int timeoutMs)
         {
@@ -258,6 +288,7 @@ namespace System.Threading
 
             return TryEnterSlow(timeoutMs, currentThreadId);
         }
+#endif
 
         /// <summary>
         /// Exits the lock.
@@ -295,6 +326,42 @@ namespace System.Threading
             ExitImpl();
         }
 
+#if !FEATURE_MULTITHREADING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ExitImpl()
+        {
+            Debug.Assert(_owningThreadId != UninitializedThreadId);
+            Debug.Assert(_owningThreadId == ManagedThreadId.CurrentManagedThreadIdUnchecked);
+
+            if (_recursionCount == 0)
+            {
+                _owningThreadId = 0;
+            }
+            else
+            {
+                _recursionCount--;
+            }
+        }
+
+        internal uint ExitAll()
+        {
+            Debug.Assert(IsHeldByCurrentThread);
+
+            uint recursionCount = _recursionCount;
+            _owningThreadId = 0;
+            _recursionCount = 0;
+
+            return recursionCount;
+        }
+
+        internal void Reenter(uint previousRecursionCount)
+        {
+            Debug.Assert(!IsHeldByCurrentThread);
+
+            Enter();
+            _recursionCount = previousRecursionCount;
+        }
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ExitImpl()
         {
@@ -342,7 +409,46 @@ namespace System.Threading
             Enter();
             _recursionCount = previousRecursionCount;
         }
+#endif
 
+#if !FEATURE_MULTITHREADING
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        internal int TryEnterSlow(int timeoutMs, int currentThreadId)
+        {
+            Debug.Assert(timeoutMs >= -1);
+
+            if (currentThreadId == UninitializedThreadId)
+            {
+                currentThreadId = ManagedThreadId.Current;
+                Debug.Assert(_owningThreadId != currentThreadId);
+                if (_owningThreadId == UninitializedThreadId)
+                {
+                    _owningThreadId = currentThreadId;
+                    return currentThreadId;
+                }
+            }
+            else if (_owningThreadId == currentThreadId)
+            {
+                uint newRecursionCount = _recursionCount + 1;
+                if (newRecursionCount != 0)
+                {
+                    _recursionCount = newRecursionCount;
+                    return currentThreadId;
+                }
+
+                throw new LockRecursionException(SR.Lock_Enter_LockRecursionException);
+            }
+
+            if (timeoutMs == 0)
+            {
+                return UninitializedThreadId;
+            }
+
+            // On single-threaded targets, if the lock is held and we cannot acquire it,
+            // this is a deadlock since no other thread can release it.
+            throw new PlatformNotSupportedException();
+        }
+#else
         private static bool IsAdaptiveSpinEnabled(short minSpinCountForAdaptiveSpin) => minSpinCountForAdaptiveSpin <= 0;
 
         [MethodImpl(MethodImplOptions.NoInlining)]
@@ -621,6 +727,9 @@ namespace System.Threading
             return UninitializedThreadId;
         }
 
+#endif // FEATURE_MULTITHREADING (TryEnterSlow)
+
+#if FEATURE_MULTITHREADING
         private void ResetWaiterStartTime() => _waiterStartTimeMs = 0;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -679,6 +788,7 @@ namespace System.Threading
                 Debug.Assert(signaled);
             }
         }
+#endif // FEATURE_MULTITHREADING (ResetWaiterStartTime through SignalWaiterIfNecessary)
 
         /// <summary>
         /// <code>true</code> if the lock is held by the calling thread, <code>false</code> otherwise.
@@ -689,14 +799,24 @@ namespace System.Threading
             {
                 var owningThreadId = _owningThreadId;
                 bool isHeld = owningThreadId != UninitializedThreadId && owningThreadId == ManagedThreadId.CurrentManagedThreadIdUnchecked;
+#if FEATURE_MULTITHREADING
                 Debug.Assert(!isHeld || new State(this).IsLocked);
+#endif
                 return isHeld;
             }
         }
 
+#if !FEATURE_MULTITHREADING
+        internal static long ContentionCount => 0;
+#pragma warning disable CA1822 // Instance method required for API compatibility
+        internal void Dispose() { }
+#pragma warning restore CA1822
+#else
         internal static long ContentionCount => s_contentionCount;
         internal void Dispose() => _waitEvent?.Dispose();
+#endif
 
+#if FEATURE_MULTITHREADING
         internal nint LockIdForEvents
         {
             get
@@ -705,9 +825,25 @@ namespace System.Threading
                 return _waitEvent.SafeWaitHandle.DangerousGetHandle();
             }
         }
+#endif
 
         internal int OwningThreadId => _owningThreadId;
 
+#if !FEATURE_MULTITHREADING
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal bool TryEnterOneShot(int currentManagedThreadId)
+        {
+            Debug.Assert(currentManagedThreadId != UninitializedThreadId);
+
+            if (_owningThreadId == UninitializedThreadId)
+            {
+                _owningThreadId = currentManagedThreadId;
+                return true;
+            }
+
+            return false;
+        }
+#else
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool TryEnterOneShot(int currentManagedThreadId)
         {
@@ -723,6 +859,7 @@ namespace System.Threading
 
             return false;
         }
+#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal bool GetIsHeldByCurrentThread(int currentManagedThreadId)
@@ -730,10 +867,13 @@ namespace System.Threading
             Debug.Assert(currentManagedThreadId != UninitializedThreadId);
 
             bool isHeld = _owningThreadId == currentManagedThreadId;
+#if FEATURE_MULTITHREADING
             Debug.Assert(!isHeld || new State(this).IsLocked);
+#endif
             return isHeld;
         }
 
+#if FEATURE_MULTITHREADING
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private TryLockResult LazyInitializeOrEnter()
         {
@@ -862,19 +1002,27 @@ namespace System.Threading
 
         // Returns false until the static variable is lazy-initialized
         internal static bool IsSingleProcessor => s_isSingleProcessor;
+#else
+        // On single-threaded targets, always report single processor
+        internal static bool IsSingleProcessor => true;
+#endif // FEATURE_MULTITHREADING (LazyInitializeOrEnter through IsSingleProcessor)
 
         // Used to transfer the state when inflating thin locks. The lock is considered unlocked if managedThreadId is zero, and
         // locked otherwise.
         internal void InitializeForMonitor(int managedThreadId, uint recursionCount)
         {
             Debug.Assert(recursionCount == 0 || managedThreadId != UninitializedThreadId);
-            Debug.Assert(!new State(this).UseTrivialWaits);
 
+#if FEATURE_MULTITHREADING
+            Debug.Assert(!new State(this).UseTrivialWaits);
             _state = managedThreadId == 0 ? State.InitialStateValue : State.LockedStateValue;
+#endif
             _owningThreadId = managedThreadId;
             _recursionCount = recursionCount;
 
+#if FEATURE_MULTITHREADING
             Debug.Assert(!new State(this).UseTrivialWaits);
+#endif
         }
 
 #if CORECLR
@@ -893,6 +1041,7 @@ namespace System.Threading
         }
 #endif
 
+#if FEATURE_MULTITHREADING
         private static short DetermineMaxSpinCount()
         {
             if (IsSingleProcessor)
@@ -927,7 +1076,9 @@ namespace System.Threading
 
             return (short)-adaptiveSpinPeriod;
         }
+#endif // FEATURE_MULTITHREADING (DetermineMaxSpinCount through DetermineMinSpinCountForAdaptiveSpin)
 
+#if FEATURE_MULTITHREADING
         private struct State : IEquatable<State>
         {
             // Layout constants for Lock._state
@@ -1491,6 +1642,9 @@ namespace System.Threading
             }
         }
 
+#endif // FEATURE_MULTITHREADING (State struct)
+
+#if FEATURE_MULTITHREADING
         private enum TryLockResult
         {
             Locked,
@@ -1505,5 +1659,6 @@ namespace System.Threading
             PartiallyComplete,
             Complete
         }
+#endif // FEATURE_MULTITHREADING (TryLockResult, StaticsInitializationStage)
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelLock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/LowLevelLock.cs
@@ -14,6 +14,7 @@ namespace System.Threading
     /// </summary>
     internal sealed class LowLevelLock : IDisposable
     {
+#if FEATURE_MULTITHREADING
         private const int SpinCount = 8;
         private const int SpinSleep0Threshold = 4;
 
@@ -21,6 +22,9 @@ namespace System.Threading
         private const int WaiterCountIncrement = 2;
 
         private static readonly Func<object, bool> s_spinWaitTryAcquireCallback = SpinWaitTryAcquireCallback;
+#else
+        private const int LockedMask = 1;
+#endif
 
         // Layout:
         //   - Bit 0: 1 if the lock is locked, 0 otherwise
@@ -33,15 +37,19 @@ namespace System.Threading
 
         // Indicates whether a thread has been signaled, but has not yet been released from the wait. See SignalWaiter. Reads
         // and writes must occur while _monitor is locked.
+#if FEATURE_MULTITHREADING
         private bool _isAnyWaitingThreadSignaled;
 
         private LowLevelSpinWaiter _spinWaiter;
         private LowLevelMonitor _monitor;
+#endif
 
         public LowLevelLock()
         {
+#if FEATURE_MULTITHREADING
             _spinWaiter = default(LowLevelSpinWaiter);
             _monitor.Initialize();
+#endif
         }
 
         ~LowLevelLock() => Dispose();
@@ -50,7 +58,9 @@ namespace System.Threading
         {
             VerifyIsNotLockedByAnyThread();
 
+#if FEATURE_MULTITHREADING
             _monitor.Dispose();
+#endif
             GC.SuppressFinalize(this);
         }
 
@@ -115,6 +125,16 @@ namespace System.Threading
         {
             VerifyIsNotLocked();
 
+#if !FEATURE_MULTITHREADING
+            if ((_state & LockedMask) == 0)
+            {
+                _state = LockedMask;
+                SetOwnerThreadToCurrent();
+                return true;
+            }
+
+            return false;
+#else
             // A common case is that there are no waiters, so hope for that and try to acquire the lock
             int state = Interlocked.CompareExchange(ref _state, LockedMask, 0);
             if (state == 0 || TryAcquire_NoFastPath(state))
@@ -123,8 +143,10 @@ namespace System.Threading
                 return true;
             }
             return false;
+#endif
         }
 
+#if FEATURE_MULTITHREADING
         private bool TryAcquire_NoFastPath(int state)
         {
             // The lock may be available, but there may be waiters. This thread could acquire the lock in that case. Acquiring
@@ -141,15 +163,22 @@ namespace System.Threading
             var thisRef = (LowLevelLock)state;
             return thisRef.TryAcquire_NoFastPath(thisRef._state);
         }
+#endif
 
         public void Acquire()
         {
             if (!TryAcquire())
             {
+#if !FEATURE_MULTITHREADING
+                Debug.Fail("On single-threaded targets, TryAcquire should always succeed.");
+                throw new PlatformNotSupportedException();
+#else
                 WaitAndAcquire();
+#endif
             }
         }
 
+#if FEATURE_MULTITHREADING
         private void WaitAndAcquire()
         {
             VerifyIsNotLocked();
@@ -195,18 +224,24 @@ namespace System.Threading
             Debug.Assert((_state & LockedMask) != 0);
             SetOwnerThreadToCurrent();
         }
+#endif // FEATURE_MULTITHREADING (WaitAndAcquire)
 
         public void Release()
         {
             Debug.Assert((_state & LockedMask) != 0);
             ResetOwnerThread();
 
+#if !FEATURE_MULTITHREADING
+            _state = 0;
+#else
             if (Interlocked.Decrement(ref _state) != 0)
             {
                 SignalWaiter();
             }
+#endif
         }
 
+#if FEATURE_MULTITHREADING
         private void SignalWaiter()
         {
             // Since the lock was already released by the caller, there are no guarantees on the state at this point. For
@@ -232,5 +267,6 @@ namespace System.Threading
 
             _monitor.Release();
         }
+#endif // FEATURE_MULTITHREADING (WaitAndAcquire through SignalWaiter)
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Monitor.cs
@@ -78,6 +78,7 @@ namespace System.Threading
             throw new ArgumentException(SR.Argument_MustBeFalse, "lockTaken");
         }
 
+#if FEATURE_MULTITHREADING
         #region Object->Condition mapping
 
         private static readonly ConditionalWeakTable<object, Condition> s_conditionTable = [];
@@ -116,6 +117,32 @@ namespace System.Threading
         }
 
         #endregion
+#else
+#pragma warning disable CS0169, CS0414, CA1805, CA1823 // Stub field required by CoreCLR VM via corelib.h
+        private static readonly object? s_conditionTable = null;
+#pragma warning restore CS0169, CS0414, CA1805, CA1823
+
+        #region Public Wait/Pulse methods
+
+        [UnsupportedOSPlatform("browser")]
+        public static bool Wait(object obj, int millisecondsTimeout)
+        {
+            RuntimeFeature.ThrowIfMultithreadingIsNotSupported();
+            return default;
+        }
+
+        public static void Pulse(object obj)
+        {
+            ArgumentNullException.ThrowIfNull(obj);
+        }
+
+        public static void PulseAll(object obj)
+        {
+            ArgumentNullException.ThrowIfNull(obj);
+        }
+
+        #endregion
+#endif
 
         #region Metrics
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Mutex.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Mutex.Unix.cs
@@ -10,6 +10,31 @@ namespace System.Threading
 {
     public sealed partial class Mutex
     {
+#if !FEATURE_MULTITHREADING
+#pragma warning disable CA1822, IDE0060
+        private void CreateMutexCore(bool initiallyOwned) { }
+
+        private void CreateMutexCore(
+            bool initiallyOwned,
+            string? name,
+            NamedWaitHandleOptionsInternal options,
+            out bool createdNew)
+        {
+            createdNew = true;
+        }
+
+        private static OpenExistingResult OpenExistingWorker(
+            string name,
+            NamedWaitHandleOptionsInternal options,
+            out Mutex? result)
+        {
+            result = null;
+            return OpenExistingResult.NameNotFound;
+        }
+
+        public void ReleaseMutex() { }
+#pragma warning restore CA1822, IDE0060
+#else
         private void CreateMutexCore(bool initiallyOwned) => SafeWaitHandle = WaitSubsystem.NewMutex(initiallyOwned);
 
         private void CreateMutexCore(
@@ -49,22 +74,6 @@ namespace System.Threading
             return status;
         }
 
-        private static string BuildNameForOptions(string name, NamedWaitHandleOptionsInternal options)
-        {
-            if (options.WasSpecified)
-            {
-                name = options.GetNameWithSessionPrefix(name);
-            }
-
-            if (name.StartsWith(NamedWaitHandleOptionsInternal.CurrentSessionPrefix) &&
-                name.Length > NamedWaitHandleOptionsInternal.CurrentSessionPrefix.Length)
-            {
-                name = name.Substring(NamedWaitHandleOptionsInternal.CurrentSessionPrefix.Length);
-            }
-
-            return name;
-        }
-
         public void ReleaseMutex()
         {
             // The field value is modifiable via the public <see cref="WaitHandle.SafeWaitHandle"/> property, save it locally
@@ -84,6 +93,23 @@ namespace System.Threading
             {
                 waitHandle.DangerousRelease();
             }
+        }
+#endif
+
+        private static string BuildNameForOptions(string name, NamedWaitHandleOptionsInternal options)
+        {
+            if (options.WasSpecified)
+            {
+                name = options.GetNameWithSessionPrefix(name);
+            }
+
+            if (name.StartsWith(NamedWaitHandleOptionsInternal.CurrentSessionPrefix) &&
+                name.Length > NamedWaitHandleOptionsInternal.CurrentSessionPrefix.Length)
+            {
+                name = name.Substring(NamedWaitHandleOptionsInternal.CurrentSessionPrefix.Length);
+            }
+
+            return name;
         }
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Semaphore.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Semaphore.Unix.cs
@@ -10,6 +10,36 @@ namespace System.Threading
 {
     public sealed partial class Semaphore
     {
+#if !FEATURE_MULTITHREADING
+#pragma warning disable CA1822, IDE0060
+        private void CreateSemaphoreCore(int initialCount, int maximumCount)
+        {
+            ValidateArguments(initialCount, maximumCount);
+        }
+
+        private void CreateSemaphoreCore(
+            int initialCount,
+            int maximumCount,
+            string? name,
+            NamedWaitHandleOptionsInternal options,
+            out bool createdNew)
+        {
+            ValidateArguments(initialCount, maximumCount);
+            createdNew = true;
+        }
+
+        private static OpenExistingResult OpenExistingWorker(
+            string name,
+            NamedWaitHandleOptionsInternal options,
+            out Semaphore? result)
+        {
+            result = null;
+            return OpenExistingResult.NameNotFound;
+        }
+
+        private int ReleaseCore(int releaseCount) => 0;
+#pragma warning restore CA1822, IDE0060
+#else
         private void CreateSemaphoreCore(int initialCount, int maximumCount)
         {
             ValidateArguments(initialCount, maximumCount);
@@ -64,5 +94,6 @@ namespace System.Threading
                 waitHandle.DangerousRelease();
             }
         }
+#endif
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SpinLock.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SpinLock.cs
@@ -63,11 +63,13 @@ namespace System.Threading
 
         private volatile int _owner;
 
+#if FEATURE_MULTITHREADING
         // After how many yields, call Sleep(1)
         private const int SLEEP_ONE_FREQUENCY = 40;
 
         // After how many yields, check the timeout
         private const int TIMEOUT_CHECK_FREQUENCY = 10;
+#endif
 
         // The thread tracking disabled mask
         private const int LOCK_ID_DISABLE_MASK = unchecked((int)0x80000000);        // 1000 0000 0000 0000 0000 0000 0000 0000
@@ -76,7 +78,9 @@ namespace System.Threading
         private const int LOCK_ANONYMOUS_OWNED = 0x1;                               // 0000 0000 0000 0000 0000 0000 0000 0001
 
         // Waiters mask if the thread tracking is disabled
+#if FEATURE_MULTITHREADING
         private const int WAITERS_MASK = ~(LOCK_ID_DISABLE_MASK | 1);               // 0111 1111 1111 1111 1111 1111 1111 1110
+#endif
 
         // The Thread tacking is disabled and the lock bit is set, used in Enter fast path to make sure the id is disabled and lock is available
         private const int ID_DISABLED_AND_ANONYMOUS_OWNED = unchecked((int)0x80000001); // 1000 0000 0000 0000 0000 0000 0000 0001
@@ -86,17 +90,30 @@ namespace System.Threading
         // m_owner & LOCK_ANONYMOUS_OWNED = zero and the thread tracking is disabled
         private const int LOCK_UNOWNED = 0;
 
+#if FEATURE_MULTITHREADING
         // The maximum number of waiters (only used if the thread tracking is disabled)
         // The actual maximum waiters count is this number divided by two because each waiter increments the waiters count by 2
         // The waiters count is calculated by m_owner & WAITERS_MASK 01111....110
         private const int MAXIMUM_WAITERS = WAITERS_MASK;
+#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int CompareExchange(ref int location, int value, int comparand, ref bool success)
         {
+#if !FEATURE_MULTITHREADING
+            int result = location;
+            success = (result == comparand);
+            if (success)
+            {
+                location = value;
+            }
+
+            return result;
+#else
             int result = Interlocked.CompareExchange(ref location, value, comparand);
             success = (result == comparand);
             return result;
+#endif
         }
 
         /// <summary>
@@ -287,6 +304,21 @@ namespace System.Threading
                     nameof(millisecondsTimeout), millisecondsTimeout, SR.SpinLock_TryEnter_ArgumentOutOfRange);
             }
 
+#if !FEATURE_MULTITHREADING
+            if (IsThreadOwnerTrackingEnabled)
+            {
+                ContinueTryEnterWithThreadTracking(millisecondsTimeout, 0, ref lockTaken);
+                return;
+            }
+
+            // On single-threaded runtime, try to acquire the lock once. If it fails, no other
+            // thread can release it, so spinning would deadlock.
+            int observedOwner = _owner;
+            if ((observedOwner & LOCK_ANONYMOUS_OWNED) == LOCK_UNOWNED)
+            {
+                CompareExchange(ref _owner, observedOwner | 1, observedOwner, ref lockTaken);
+            }
+#else
             long startTime = 0;
             if (millisecondsTimeout != Timeout.Infinite && millisecondsTimeout != 0)
             {
@@ -380,8 +412,10 @@ namespace System.Threading
                     }
                 }
             }
+#endif
         }
 
+#if FEATURE_MULTITHREADING
         /// <summary>
         /// decrements the waiters, in case of the timeout is expired
         /// </summary>
@@ -400,6 +434,7 @@ namespace System.Threading
                 spinner.SpinOnce();
             }
         }
+#endif
 
         /// <summary>
         /// ContinueTryEnter for the thread tracking mode enabled
@@ -418,6 +453,14 @@ namespace System.Threading
                 throw new LockRecursionException(SR.SpinLock_TryEnter_LockRecursionException);
             }
 
+#if !FEATURE_MULTITHREADING
+            // On single-threaded runtime, try to acquire the lock once. If it fails, no other
+            // thread can release it, so spinning would deadlock.
+            if (_owner == LockUnowned)
+            {
+                CompareExchange(ref _owner, newOwner, LockUnowned, ref lockTaken);
+            }
+#else
             SpinWait spinner = default;
 
             // Loop until the lock has been successfully acquired or, if specified, the timeout expires.
@@ -444,6 +487,7 @@ namespace System.Threading
                     return;
                 }
             }
+#endif
         }
 
         /// <summary>
@@ -462,7 +506,11 @@ namespace System.Threading
             if ((_owner & LOCK_ID_DISABLE_MASK) == 0)
                 ExitSlowPath(true);
             else
+#if !FEATURE_MULTITHREADING
+                _owner--;
+#else
                 Interlocked.Decrement(ref _owner);
+#endif
         }
 
         /// <summary>
@@ -512,6 +560,17 @@ namespace System.Threading
                 ThrowHelper.ThrowSynchronizationLockException_LockExit();
             }
 
+#if !FEATURE_MULTITHREADING
+            if (threadTrackingEnabled)
+            {
+                _owner = LOCK_UNOWNED;
+            }
+            else
+            {
+                int tmpOwner = _owner;
+                _owner = tmpOwner & (~LOCK_ANONYMOUS_OWNED);
+            }
+#else
             if (useMemoryBarrier)
             {
                 if (threadTrackingEnabled)
@@ -535,6 +594,7 @@ namespace System.Threading
                     _owner = tmpOwner & (~LOCK_ANONYMOUS_OWNED);
                 }
             }
+#endif
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Thread.Unix.cs
@@ -38,9 +38,21 @@ namespace System.Threading
         // the closest analog to Sleep(0) on Unix is sched_yield
         internal static void UninterruptibleSleep0() => Thread.Yield();
 
+#if !FEATURE_MULTITHREADING
+        private static void SleepInternal(int millisecondsTimeout) =>
+            throw new PlatformNotSupportedException();
+#else
         private static void SleepInternal(int millisecondsTimeout) => WaitSubsystem.Sleep(millisecondsTimeout);
+#endif
 
 #if !MONO
+#if !FEATURE_MULTITHREADING
+#pragma warning disable CA1822
+        private bool JoinInternal(int millisecondsTimeout) => throw new PlatformNotSupportedException();
+
+        private void SetJoinHandle() { }
+#pragma warning restore CA1822
+#else
         private bool JoinInternal(int millisecondsTimeout)
         {
             // This method assumes the thread has been started
@@ -88,6 +100,7 @@ namespace System.Threading
                 waitHandle.DangerousRelease();
             }
         }
+#endif // FEATURE_MULTITHREADING
 #endif
 
         // sched_getcpu doesn't exist on all platforms. On those it doesn't exist on, the shim returns -1

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadBlockingInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadBlockingInfo.cs
@@ -87,7 +87,7 @@ namespace System.Threading
                     case ObjectKind.Lock:
                         return ((Lock)Unsafe.AsRef<object>(_objectPtr)).OwningManagedThreadId;
 
-#if !MONO
+#if !MONO && FEATURE_MULTITHREADING
                     case ObjectKind.Condition:
                         Debug.Assert(_objectKind == ObjectKind.Condition);
                         return ((Condition)Unsafe.AsRef<object>(_objectPtr)).AssociatedLock.OwningManagedThreadId;
@@ -108,7 +108,7 @@ namespace System.Threading
             public Scope(Lock lockObj, int timeoutMs) : this(lockObj, ObjectKind.Lock, timeoutMs) { }
 #pragma warning restore CS9216
 
-#if !MONO
+#if !MONO && FEATURE_MULTITHREADING
             public Scope(Condition condition, int timeoutMs) : this(condition, ObjectKind.Condition, timeoutMs) { }
 #endif
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitHandle.Unix.cs
@@ -7,6 +7,18 @@ namespace System.Threading
 {
     public abstract partial class WaitHandle
     {
+#if !FEATURE_MULTITHREADING
+#pragma warning disable IDE0060
+        private static int WaitOneCore(IntPtr handle, int millisecondsTimeout, bool useTrivialWaits) =>
+            WaitHandle.WaitSuccess;
+
+        private static int WaitMultipleIgnoringSyncContextCore(ReadOnlySpan<IntPtr> handles, bool waitAll, int millisecondsTimeout) =>
+            WaitHandle.WaitSuccess;
+
+        private static int SignalAndWaitCore(IntPtr handleToSignal, IntPtr handleToWaitOn, int millisecondsTimeout) =>
+            WaitHandle.WaitSuccess;
+#pragma warning restore IDE0060
+#else
         private static int WaitOneCore(IntPtr handle, int millisecondsTimeout, bool useTrivialWaits) =>
             WaitSubsystem.Wait(handle, millisecondsTimeout, interruptible: !useTrivialWaits);
 
@@ -15,5 +27,6 @@ namespace System.Threading
 
         private static int SignalAndWaitCore(IntPtr handleToSignal, IntPtr handleToWaitOn, int millisecondsTimeout) =>
             WaitSubsystem.SignalAndWait(handleToSignal, handleToWaitOn, millisecondsTimeout);
+#endif
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.HandleManager.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.HandleManager.Unix.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if FEATURE_MULTITHREADING
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime;
@@ -84,3 +86,5 @@ namespace System.Threading
         }
     }
 }
+
+#endif // FEATURE_MULTITHREADING

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.ThreadWaitInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.ThreadWaitInfo.Unix.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if FEATURE_MULTITHREADING
+
 using System.Diagnostics;
 using System.IO;
 
@@ -780,3 +782,16 @@ namespace System.Threading
         }
     }
 }
+
+#else // !FEATURE_MULTITHREADING
+
+namespace System.Threading
+{
+    // Minimal stub to keep WaitSubsystem.ThreadWaitInfo type available for Thread field layout.
+    internal static partial class WaitSubsystem
+    {
+        public sealed class ThreadWaitInfo { }
+    }
+}
+
+#endif // FEATURE_MULTITHREADING

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.Unix.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if FEATURE_MULTITHREADING
+
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -532,3 +534,5 @@ namespace System.Threading
         }
     }
 }
+
+#endif // FEATURE_MULTITHREADING

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.WaitableObject.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/WaitSubsystem.WaitableObject.Unix.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+#if FEATURE_MULTITHREADING
+
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -963,3 +965,5 @@ namespace System.Threading
         }
     }
 }
+
+#endif // FEATURE_MULTITHREADING

--- a/src/mono/System.Private.CoreLib/src/System/Threading/ObjectHeader.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/ObjectHeader.Mono.cs
@@ -264,6 +264,24 @@ internal static class ObjectHeader
         return false;
     }
 
+#if !FEATURE_MULTITHREADING
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TryEnterInflatedFast(scoped ref MonoThreadsSync mon, int small_id)
+    {
+        uint old_status = SyncBlock.Status(ref mon);
+        if (MonitorStatus.GetOwner(old_status) == 0)
+        {
+            SyncBlock.Status(ref mon) = MonitorStatus.SetOwner(old_status, small_id);
+            return true;
+        }
+        if (MonitorStatus.GetOwner(old_status) == small_id)
+        {
+            SyncBlock.IncrementNest(ref mon);
+            return true;
+        }
+        return false;
+    }
+#else
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool TryEnterInflatedFast(scoped ref MonoThreadsSync mon, int small_id)
     {
@@ -292,9 +310,44 @@ internal static class ObjectHeader
             return false;
         }
     }
+#endif
 
     // returns false if we should fall back to the slow path
     // returns true if the lock was taken
+#if !FEATURE_MULTITHREADING
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TryEnterFast(object? o)
+    {
+        Debug.Assert(o != null);
+        ObjectHeaderOnStack h = ObjectHeaderOnStack.Create(ref o);
+        LockWord lw = GetLockWord(h);
+        if (!lw.IsInflated && lw.HasHash)
+            return false;
+        int owner = Thread.CurrentThread.GetSmallId();
+        if (lw.IsFree)
+        {
+            h.Header.synchronization = LockWord.NewFlat(owner).AsIntPtr;
+            return true;
+        }
+        else if (lw.IsInflated)
+        {
+            return TryEnterInflatedFast(ref lw.GetInflatedLock(), owner);
+        }
+        else if (lw.IsFlat)
+        {
+            if (lw.GetOwner() == owner)
+            {
+                if (lw.IsNestMax)
+                    return false;
+                h.Header.synchronization = lw.IncrementNest().AsIntPtr;
+                return true;
+            }
+            return false;
+        }
+        Debug.Assert(lw.HasHash);
+        return false;
+    }
+#else
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryEnterFast(object? o)
     {
@@ -345,6 +398,7 @@ internal static class ObjectHeader
         Debug.Assert(lw.HasHash);
         return false;
     }
+#endif
 
     // true if obj is owned by the current thread
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -381,6 +435,21 @@ internal static class ObjectHeader
         return false;
     }
 
+#if !FEATURE_MULTITHREADING
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TryExitInflated(scoped ref MonoThreadsSync mon)
+    {
+        if (SyncBlock.TryDecrementNest(ref mon))
+            return true;
+
+        ref uint status = ref SyncBlock.Status(ref mon);
+        uint old_status = status;
+        if (MonitorStatus.HaveWaiters(old_status))
+            return false;
+        status = MonitorStatus.SetOwner(old_status, 0);
+        return true;
+    }
+#else
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool TryExitInflated(scoped ref MonoThreadsSync mon)
     {
@@ -400,7 +469,22 @@ internal static class ObjectHeader
         else
             return false; // we need to retry, but maybe a waiter arrived, fall back to the slow path
     }
+#endif
 
+#if !FEATURE_MULTITHREADING
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TryExitFlat(ObjectHeaderOnStack h, LockWord lw)
+    {
+        Debug.Assert(!lw.IsInflated);
+        LockWord nlw;
+        if (lw.IsNested)
+            nlw = lw.DecrementNest();
+        else
+            nlw = default;
+        h.Header.synchronization = nlw.AsIntPtr;
+        return true;
+    }
+#else
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool TryExitFlat(ObjectHeaderOnStack h, LockWord lw)
     {
@@ -419,6 +503,7 @@ internal static class ObjectHeader
 
         return false;
     }
+#endif
 
 
     // checks that obj is locked by the current thread

--- a/src/mono/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
+++ b/src/mono/System.Private.CoreLib/src/System/Threading/Thread.Mono.cs
@@ -65,7 +65,7 @@ namespace System.Threading
         private StartHelper? _startHelper;
         internal ExecutionContext? _executionContext;
         internal SynchronizationContext? _synchronizationContext;
-#if TARGET_UNIX || TARGET_BROWSER || TARGET_WASI
+#if (TARGET_UNIX || TARGET_BROWSER || TARGET_WASI) && FEATURE_MULTITHREADING
         internal WaitSubsystem.ThreadWaitInfo? _waitInfo;
 #endif
 
@@ -139,10 +139,13 @@ namespace System.Threading
             }
         }
 #if TARGET_UNIX || TARGET_BROWSER || TARGET_WASI
+#pragma warning disable CA1822
         internal WaitSubsystem.ThreadWaitInfo WaitInfo
+#pragma warning restore CA1822
         {
             get
             {
+#if FEATURE_MULTITHREADING
                 return Volatile.Read(ref _waitInfo) ?? AllocateWaitInfo();
 
                 WaitSubsystem.ThreadWaitInfo AllocateWaitInfo()
@@ -150,6 +153,9 @@ namespace System.Threading
                     Interlocked.CompareExchange(ref _waitInfo, new WaitSubsystem.ThreadWaitInfo(this), null!);
                     return _waitInfo;
                 }
+#else
+                throw new PlatformNotSupportedException();
+#endif
             }
         }
 #endif
@@ -183,7 +189,7 @@ namespace System.Threading
 
         public void Interrupt()
         {
-#if TARGET_UNIX || TARGET_BROWSER || TARGET_WASI // TODO: https://github.com/dotnet/runtime/issues/49521
+#if (TARGET_UNIX || TARGET_BROWSER || TARGET_WASI) && FEATURE_MULTITHREADING // TODO: https://github.com/dotnet/runtime/issues/49521
             WaitSubsystem.Interrupt(this);
 #endif
             InterruptInternal(this);
@@ -287,7 +293,7 @@ namespace System.Threading
 
         private static void OnThreadExiting(Thread thread)
         {
-#if TARGET_UNIX || TARGET_BROWSER || TARGET_WASI
+#if (TARGET_UNIX || TARGET_BROWSER || TARGET_WASI) && FEATURE_MULTITHREADING
             thread.WaitInfo.OnThreadExiting();
 #endif
         }

--- a/src/tools/illink/src/ILLink.Shared/DiagnosticId.cs
+++ b/src/tools/illink/src/ILLink.Shared/DiagnosticId.cs
@@ -71,7 +71,7 @@ namespace ILLink.Shared
         XmlCouldNotResolveType = 2008,
         XmlCouldNotFindMethodOnType = 2009,
         XmlInvalidValueForStub = 2010,
-        XmlUnkownBodyModification = 2011,
+        XmlUnknownBodyModification = 2011,
         XmlCouldNotFindFieldOnType = 2012,
         XmlSubstitutedFieldNeedsToBeStatic = 2013,
         XmlMissingSubstitutionValueForField = 2014,

--- a/src/tools/illink/src/ILLink.Shared/SharedStrings.resx
+++ b/src/tools/illink/src/ILLink.Shared/SharedStrings.resx
@@ -459,10 +459,10 @@
   <data name="XmlInvalidValueForStubMessage" xml:space="preserve">
     <value>Invalid value for '{0}' stub.</value>
   </data>
-  <data name="XmlUnkownBodyModificationTitle" xml:space="preserve">
+  <data name="XmlUnknownBodyModificationTitle" xml:space="preserve">
     <value>The value of the body attribute used in the substitution XML is invalid (the only supported options are remove and stub).</value>
   </data>
-  <data name="XmlUnkownBodyModificationMessage" xml:space="preserve">
+  <data name="XmlUnknownBodyModificationMessage" xml:space="preserve">
     <value>Unknown body modification '{0}' for '{1}'.</value>
   </data>
   <data name="XmlCouldNotFindFieldOnTypeTitle" xml:space="preserve">

--- a/src/tools/illink/src/linker/Linker.Steps/BodySubstitutionParser.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/BodySubstitutionParser.cs
@@ -84,7 +84,7 @@ namespace Mono.Linker.Steps
                     _substitutionInfo.SetMethodAction(method, MethodAction.ConvertToStub);
                     return;
                 default:
-                    LogWarning(methodNav, DiagnosticId.XmlUnkownBodyModification, action, method.GetDisplayName());
+                    LogWarning(methodNav, DiagnosticId.XmlUnknownBodyModification, action, method.GetDisplayName());
                     return;
             }
         }

--- a/src/tools/illink/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
+++ b/src/tools/illink/src/linker/Linker.Steps/UnreachableBlocksOptimizer.cs
@@ -731,7 +731,7 @@ namespace Mono.Linker.Steps
 
                 if (stackDepth != 0)
                 {
-                    Debug.Fail("Invalid IL?");
+                    // throw new InvalidOperationException($"Cannot rewrite instruction at index {index} to nop because of unknown stack behaviour of instruction at index {start_index}");
                     return;
                 }
 

--- a/src/tools/illink/src/linker/Linker/LinkContext.cs
+++ b/src/tools/illink/src/linker/Linker/LinkContext.cs
@@ -1031,7 +1031,14 @@ namespace Mono.Linker
         {
             if (_processed_bodies_for_method.Add(method))
             {
-                _unreachableBlocksOptimizer.ProcessMethod(method);
+                try
+                {
+                    _unreachableBlocksOptimizer.ProcessMethod(method);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    FatalError($"Unexpected error while processing method body for '{method.GetDisplayName()}': {ex.Message}", (int)DiagnosticId.XmlUnknownBodyModification, MessageSubCategory.None, new MessageOrigin(method));
+                }
             }
 
             return MethodIL.Create(method.Body);


### PR DESCRIPTION
# Simplify synchronization primitives for single-threaded browser targets

## Summary

Replace `Interlocked` operations and spinning/waiting logic with plain reads and writes across all synchronization primitives on single-threaded browser WASM targets (`FEATURE_SINGLE_THREADED`). On a single-threaded runtime, atomic operations and spin loops are both unnecessary and expensive (especially under the interpreter), and blocking waits are impossible since no other thread can release a lock.

## Motivation

On the single-threaded browser target:
- **`Interlocked.CompareExchange`/`Decrement`/`Exchange`** are unnecessary — there's only one thread, so plain reads/writes are sufficient and cheaper under the interpreter.
- **Spin loops** are meaningless — if a lock is held, no other thread can release it, so spinning would deadlock.
- **Wait subsystem** (WaitSubsystem, LowLevelMonitor, wait handles) is unreachable — blocking waits are impossible without multiple threads.
- **Contention tracking, waiter signaling, adaptive spin counts** are dead code on ST.

These changes eliminate this overhead at compile time using `#if FEATURE_SINGLE_THREADED`, ensuring both debug and release builds benefit.

## Changes

### 22 files changed, ~620 insertions, ~24 deletions

#### Lock.cs — Fast path and slow path simplification
- `TryEnter_Inlined`: Plain `_owningThreadId` read/write instead of `State.TryLock()` (which uses `Interlocked.CompareExchange`)
- `ExitImpl`: Plain `_owningThreadId`/`_recursionCount` writes instead of `State.Unlock()` (which uses `Interlocked.Decrement`)
- `TryEnterSlow`: Handles recursion via plain field access; throws `PlatformNotSupportedException` for unacquirable locks (deadlock on MT)
- `ExitAll`/`Reenter`/`TryEnterOneShot`: Plain field operations
- Gated dead types: `State` struct (~550 lines), `TryLockResult` enum, `StaticsInitializationStage` enum
- Gated dead methods: `LazyInitializeOrEnter`, `TryInitializeStatics`, spin/waiter helpers, `CreateWaitEvent`, `SignalWaiterIfNecessary`
- Gated dead fields: `_spinCount`, `_waiterStartTimeMs`, `_waitEvent`, all static fields
- `ContentionCount` returns 0; `Dispose()` is no-op; `IsSingleProcessor` returns `true`

#### ObjectHeader.CoreCLR.cs — Thin lock without CAS
- `TryAcquireThinLock`: Reads/writes header directly without `Interlocked.CompareExchange` — checks hash/syncblock → UseSlowPath, checks same thread → increment recursion via plain write, checks free → write threadID
- `Release`: Plain header writes instead of CAS
- `TryAcquireThinLockSpin`: Entire spin loop gated out
- `AcquireInternal` (InternalCall): Gated out on ST

#### ObjectHeader.Mono.cs — Lock word without CAS
- `TryEnterInflatedFast`: Plain write to `SyncBlock.Status` instead of `Interlocked.CompareExchange`
- `TryEnterFast`: Plain write (`h.Header.synchronization`) instead of `LockWordCompareExchange`
- `TryExitInflated`/`TryExitFlat`: Plain writes, always succeeds on ST

#### SpinLock.cs — Eliminate spinning entirely
- `CompareExchange` helper: Plain read/write instead of `Interlocked.CompareExchange`
- `ContinueTryEnter`: Try lock once (no spinning/yielding/waiter management)
- `ContinueTryEnterWithThreadTracking`: Try once (no spin loop)
- `Exit`/`ExitSlowPath`: Plain writes instead of `Interlocked.Decrement`/`Exchange`
- `DecrementWaiters`: Gated out entirely (no waiters on ST)
- MT-only constants gated: `SLEEP_ONE_FREQUENCY`, `TIMEOUT_CHECK_FREQUENCY`, `WAITERS_MASK`, `MAXIMUM_WAITERS`

#### LowLevelLock.cs — Plain lock/unlock
- `TryAcquire`: Plain `_state` read/write instead of `Interlocked.CompareExchange`
- `Release`: `_state = 0` instead of `Interlocked.Decrement` + `SignalWaiter`
- `Acquire`: `Debug.Fail` + throw if `TryAcquire` fails (should never happen on ST)
- Gated: `WaitAndAcquire`, `SignalWaiter`, `TryAcquire_NoFastPath`, MT-only fields/constants

#### Monitor.cs — Wait/Pulse stubs
- `Wait`: Calls `ThrowIfMultithreadingIsNotSupported()` then `return default`
- `Pulse`/`PulseAll`: No-ops (just null check)
- `s_conditionTable`, `GetCondition`: Gated out; stub `s_conditionTable = null` kept for CoreCLR VM

#### Condition.cs — Entire file gated
- Wrapped with `#if !FEATURE_SINGLE_THREADED` — Wait/Pulse impossible on ST

#### WaitSubsystem (4 files) — Entire subsystem gated
- `WaitSubsystem.Unix.cs`, `WaitSubsystem.WaitableObject.Unix.cs`, `WaitSubsystem.HandleManager.Unix.cs`: Wrapped with `#if !FEATURE_SINGLE_THREADED`
- `WaitSubsystem.ThreadWaitInfo.Unix.cs`: Gated + `#else` stub with empty `ThreadWaitInfo` class (required by CoreCLR VM `ThreadBaseObject._waitInfo` field layout)

#### Unix wait primitives — Throwing stubs
- `WaitHandle.Unix.cs`: `WaitOneCore`, `WaitMultipleIgnoringSyncContextCore`, `SignalAndWaitCore` → throw `PlatformNotSupportedException`
- `EventWaitHandle.Unix.cs`: `CreateEventCore`, `Reset`, `Set` → throw
- `Mutex.Unix.cs`: `CreateMutexCore`, `ReleaseMutex` → throw
- `Semaphore.Unix.cs`: `CreateSemaphoreCore`, `ReleaseCore` → throw
- `SafeWaitHandle.Unix.cs`: `WaitSubsystem.DeleteHandle` call gated
- `Thread.Unix.cs`: `SleepInternal` → throw; `JoinInternal` → throw; `SetJoinHandle` → empty

#### Thread files — WaitSubsystem entry point disconnection
- `Thread.CoreCLR.cs`: `WaitInfo` property → throw on ST; `Interrupt` → skip WaitSubsystem call; `OnThreadExiting` → skip WaitInfo cleanup
- `Thread.Mono.cs`: Same pattern; `_waitInfo` field gated out (safe on Mono — no VM layout constraint)

#### Supporting changes
- `ThreadBlockingInfo.cs`: `Condition` references gated with `&& !FEATURE_SINGLE_THREADED`
- `NativeRuntimeEventSource.Threading.cs` + `.NativeSinks.cs`: Lock contention event overloads gated (reference `LockIdForEvents` which doesn't exist on ST)

## Testing

- **System.Threading tests** (browser/wasm, CoreCLR): 631 run, 546 passed, 0 failed, 85 skipped
- **Build verification**: CoreCLR browser/wasm ✅, CoreCLR Windows ✅, Mono browser ✅

## Design decisions

1. **`#if FEATURE_SINGLE_THREADED` (compile-time) over runtime checks**: Ensures dead code is eliminated in both debug and release builds, and avoids interpreter overhead for checking `RuntimeFeature.IsMultithreadingSupported` on every lock operation.

2. **Keep `_state` field in Lock.cs**: Required by CoreCLR VM via `DEFINE_FIELD(LOCK, STATE, _state)` in `corelib.h`. The field exists but is unused on ST.

3. **Keep `WaitSubsystem.ThreadWaitInfo` as stub**: CoreCLR's `ThreadBaseObject` (in `object.h`) defines `_waitInfo` at a fixed layout offset. The empty stub class satisfies the type reference without pulling in the WaitSubsystem dependency chain.

4. **LowLevelLock kept functional (not gated entirely)**: Has consumers beyond WaitSubsystem — `ThreadPoolWorkQueue`, `ThreadInt64PersistentCounter`, `PortableThreadPool`. Simplified to plain read/write instead of removed.

5. **SpinLock try-once semantics**: On ST, `ContinueTryEnter` tries to acquire the lock exactly once. If it fails, it returns `lockTaken=false` (for timeout=0) or was already tried in the fast path. No spinning since it would deadlock.
