### PR TITLE
Prefer partial declarations with commented-out existing APIs in api-proposal skill

### DIFF
--- a/.github/skills/api-proposal/SKILL.md
+++ b/.github/skills/api-proposal/SKILL.md
@@ -203,18 +203,7 @@ public partial class JsonNamingPolicy
 }
 ```
 
-When existing members ARE needed for context (e.g., to show sibling overloads), use `diff` blocks or `csharp` blocks with `// EXISTING` and `// NEW` markers. Prefer `// EXISTING`/`// NEW` markers when the diff format would be unwieldy (e.g., many existing members with a few additions interspersed):
-
-```diff
-namespace System.Text.Json;
-
-public partial class JsonNamingPolicy
-{
-     public static JsonNamingPolicy CamelCase { get; }
-+    public static JsonNamingPolicy SnakeLowerCase { get; }
-+    public static JsonNamingPolicy SnakeUpperCase { get; }
-}
-```
+When existing members ARE needed for context (e.g., to show sibling overloads), comment them out with a `// EXISTING` marker. This makes it easy for the meeting chair to delete them when posting final approval notes:
 
 ```csharp
 namespace System.Text.Json;
@@ -222,9 +211,8 @@ namespace System.Text.Json;
 public partial class JsonNamingPolicy
 {
     // EXISTING
-    public static JsonNamingPolicy CamelCase { get; }
+    // public static JsonNamingPolicy CamelCase { get; }
 
-    // NEW
     public static JsonNamingPolicy SnakeLowerCase { get; }
     public static JsonNamingPolicy SnakeUpperCase { get; }
 }

--- a/.github/skills/api-proposal/SKILL.md
+++ b/.github/skills/api-proposal/SKILL.md
@@ -203,7 +203,7 @@ public partial class JsonNamingPolicy
 }
 ```
 
-When existing members ARE needed for context (e.g., to show sibling overloads), comment them out with a `// EXISTING` marker. This makes it easy for the meeting chair to delete them when posting final approval notes:
+When existing members ARE needed for context (e.g., to show sibling overloads), comment out those existing members in the snippet and add a `// EXISTING` marker immediately above them. This makes it easy for the meeting chair to delete them when posting final approval notes:
 
 ```csharp
 namespace System.Text.Json;

--- a/.github/skills/api-proposal/references/api-proposal-checklist.md
+++ b/.github/skills/api-proposal/references/api-proposal-checklist.md
@@ -16,7 +16,7 @@ Use this checklist to validate an API proposal before publishing. Items are orde
 
 - [ ] **DO** extract the exact API surface from `GenerateReferenceAssemblySource` output
 - [ ] **DO** use clean declaration format for new self-contained types
-- [ ] **DO** use `diff` blocks showing relevant context (sibling overloads) for additions to existing types
+- [ ] **DO** use `partial` declarations with commented-out `// EXISTING` members showing relevant context (sibling overloads) for additions to existing types
 - [ ] **DO** validate all names against the [Framework Design Guidelines](https://github.com/dotnet/runtime/blob/main/docs/coding-guidelines/framework-design-guidelines-digest.md)
 - [ ] **DO** verify naming consistency with existing APIs in the target namespace
 - [ ] **DO NOT** include implementation code in the API surface


### PR DESCRIPTION
Addresses @bartonjs late review feedback from #124808.

Changes the api-proposal skill to prefer `partial` class declarations with **commented-out** existing members over `diff` blocks when showing additions to existing types. This makes it easy for the meeting chair to delete existing API context when posting final approval notes.

### Changes

- **SKILL.md**: Remove `diff` block example; update the `// EXISTING` / `// NEW` example to comment out existing members and drop the `// NEW` marker
- **api-proposal-checklist.md**: Replace \\diff\\ block recommendation with \\partial\\ + commented-out \\// EXISTING\\ member guidance