### PR TITLE
Remove stale information in ArrayPool.Shared remarks

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Buffers/ArrayPool.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Buffers/ArrayPool.cs
@@ -32,8 +32,6 @@ namespace System.Buffers
         /// array than was requested. Renting a buffer from it with <see cref="Rent"/> will result in an
         /// existing buffer being taken from the pool if an appropriate buffer is available or in a new
         /// buffer being allocated if one is not available.
-        /// byte[] and char[] are the most commonly pooled array types. For these we use a special pool type
-        /// optimized for very fast access speeds, at the expense of more memory consumption.
         /// The shared pool instance is created lazily on first access.
         /// </remarks>
         public static ArrayPool<T> Shared => s_shared;


### PR DESCRIPTION
I was copying the SharedArrayPool implementation to create a slightly modified version of it.
Stumbled across this part of the doc comment, looking for this special handling to replicate it too.
But I couldn't find any special handling for byte or char arrays.
Pretty sure his was removed at some point and the comment was not updated to reflect the changes.

I searched through the history and this seems to be the commit that removed the special handling:
https://github.com/dotnet/runtime/commit/55117cd2b3929d26a229d2756aa8861f397128a8#diff-ea6685d3a394b3859a91b3765060078fe0b7a9dc9989f30cd8893bd55cc853f3

