### PR TITLE
Fix Copilot not working in forks

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -7,7 +7,7 @@ jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   # See https://docs.github.com/en/copilot/customizing-copilot/customizing-the-development-environment-for-copilot-coding-agent
   copilot-setup-steps:
-    runs-on: 8-core-ubuntu-latest
+    runs-on: ${{ github.repository_owner == 'dotnet' && '8-core-ubuntu-latest' || 'ubuntu-latest' }}
 
     permissions:
       contents: read


### PR DESCRIPTION
Use a public runner image to allow Copilot setup steps to run in forks of the repository.

Port of https://github.com/dotnet/aspnetcore/pull/65492.
