### PR TITLE
[mono][sgen] Fix card scanning in LOS non-array objects

### DIFF
--- a/src/mono/mono/sgen/sgen-cardtable.c
+++ b/src/mono/mono/sgen/sgen-cardtable.c
@@ -203,6 +203,7 @@ sgen_card_table_region_begin_scanning (mword start, mword size)
 {
 	mword end = start + size;
 	/*XXX this can be improved to work on words and have a single loop induction var */
+	start = SGEN_ALIGN_DOWN_TO (start, CARD_SIZE_IN_BYTES);
 	while (start < end) {
 		if (sgen_card_table_card_begin_scanning (start))
 			return TRUE;


### PR DESCRIPTION
`sgen_card_table_region_begin_scanning` needs to determine whether any cards are marked in the object starting at `start` address. The current card size in 512 bytes. Consider an object with start 500 and size 20, so this object lives within 2 cards. We will check the card associated with the address 500. Once this iteration is done, we will check whether  `start + card_size < end` => `500 + 512 < 520`. This is false, so we will no longer scan the second card. The algorithm was expecting the start address to be aligned to the card start, which is what the fix does.

This bug is severe, but, in practice, this code path is not as frequent. This bug would only affect objects greater than 8k, that are not arrays.

Fixes https://github.com/dotnet/runtime/issues/124941