### PR TITLE
[wasm][coreclr] Update contract of SystemJS_ExecuteFinalizationCallback

### DIFF
--- a/src/coreclr/vm/finalizerthread.cpp
+++ b/src/coreclr/vm/finalizerthread.cpp
@@ -49,7 +49,11 @@ extern "C" void SystemJS_ExecuteFinalizationCallback()
 {
     CONTRACTL
     {
+#ifdef TARGET_UNIX // because UNINSTALL_UNHANDLED_MANAGED_EXCEPTION_TRAP is catching exceptions only on Unix. On Windows OS is handling that.
         NOTHROW;
+#else // TARGET_UNIX
+        THROWS;
+#endif // TARGET_UNIX
         GC_TRIGGERS;
         MODE_PREEMPTIVE;
     }


### PR DESCRIPTION
After `ManagedThreadBase::KickOff` call was enabled again, the contract needs same treatment as in `FinalizerThread::FinalizerThreadStart`