### PR TITLE
Fix locating files in `GetCommonSourceFiles`

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
+++ b/src/tools/illink/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
@@ -41,6 +41,12 @@
     <RuntimeHostConfigurationOption Include="Mono.Linker.Tests.LinkerTestDir">
       <Value>$(LinkerTestDir)</Value>
     </RuntimeHostConfigurationOption>
+    <RuntimeHostConfigurationOption Include="Mono.Linker.Tests.ExpectationsDir">
+      <Value>$(LinkerTestDir)\Mono.Linker.Tests.Cases.Expectations</Value>
+    </RuntimeHostConfigurationOption>
+    <RuntimeHostConfigurationOption Include="Mono.Linker.Tests.ILLinkSharedDir">
+      <Value>$(LinkerTestDir)..\src\ILLink.Shared</Value>
+    </RuntimeHostConfigurationOption>
     <RuntimeHostConfigurationOption Include="Mono.Linker.Tests.TargetFramework">
       <Value>$(TargetFramework)</Value>
     </RuntimeHostConfigurationOption>

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompilationMetadataProvider.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/TestCaseCompilationMetadataProvider.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Mono.Cecil;
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
@@ -151,16 +152,13 @@ namespace Mono.Linker.Tests.TestCasesRunner
             throw new InvalidOperationException($"Could not determine ref pack path. Computed path {candidatePath} doesn't exist.");
         }
 
-        public IEnumerable<NPath> GetCommonSourceFiles()
+        public virtual IEnumerable<NPath> GetCommonSourceFiles()
         {
-            yield return _testCase.RootCasesDirectory.Parent
-                .Combine("Mono.Linker.Tests.Cases.Expectations")
+            yield return PathUtilities.GetMonoLinkerTestsExpectationsDirectory().ToNPath()
                 .Combine("Support")
                 .Combine("DynamicallyAccessedMembersAttribute.cs");
 
-            var sharedDir = _testCase.RootCasesDirectory.Parent.Parent
-                .Combine("src")
-                .Combine("ILLink.Shared");
+            var sharedDir = PathUtilities.GetILLinkSharedDirectory().ToNPath();
             yield return sharedDir.Combine("RequiresDynamicCodeAttribute.cs");
             yield return sharedDir.Combine("RequiresUnreferencedCodeAttribute.cs");
         }

--- a/src/tools/illink/test/Trimming.Tests.Shared/PathUtilities.cs
+++ b/src/tools/illink/test/Trimming.Tests.Shared/PathUtilities.cs
@@ -17,7 +17,13 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
         public static string TargetFrameworkMonikerDisplayName => (string)AppContext.GetData("Mono.Linker.Tests.TargetFrameworkMonikerDisplayName")!;
 
-        public static string GetTestsSourceRootDirectory([CallerFilePath] string? thisFile = null) =>
+        public static string GetMonoLinkerTestsExpectationsDirectory() =>
+            Path.GetFullPath((string)AppContext.GetData("Mono.Linker.Tests.ExpectationsDir")!);
+
+        public static string GetILLinkSharedDirectory() =>
+            Path.GetFullPath((string)AppContext.GetData("Mono.Linker.Tests.ILLinkSharedDir")!);
+
+        public static string GetTestsSourceRootDirectory() =>
             Path.GetFullPath((string)AppContext.GetData("Mono.Linker.Tests.LinkerTestDir")!);
 
         public static string GetTestAssemblyRoot(string assemblyName)


### PR DESCRIPTION
`_testCase.RootCasesDirectory` is meant to be configurable.  For example, Unity uses the same test framework to run tests that live in `Unity.Linker.Tests.Cases`.  When we run tests, `_testCase.RootCasesDirectory` is going to be the path to our `Unity.Linker.Tests.Cases` directory.  When that happens `GetCommonSourceFiles` cannot locate the files relative to `_testCase.RootCasesDirectory`.

Since `GetCommonSourceFiles` is trying to explicitly locate files relative to the ILLink test case directory structure the code should be using a known directory to start from rather than a path that is configurable.

I added the new helper methods to `PathUtilities` and followed the `AppContext.GetData` pattern.  I tried to use `[CallerFilePath]` but I couldn't get that to work on CI.

While I was here I thought I'd make `GetCommonSourceFiles` virtual just in case Unity needs to override it in the future.