### PR TITLE
[HTTP] Stress fix for the new Windows VM

### DIFF
--- a/eng/docker/build-docker-sdk.ps1
+++ b/eng/docker/build-docker-sdk.ps1
@@ -15,8 +15,6 @@ $REPO_ROOT_DIR=$(git -C "$PSScriptRoot" rev-parse --show-toplevel)
 [xml]$xml = Get-Content (Join-Path $REPO_ROOT_DIR "eng\Versions.props")
 $VERSION="$($xml.Project.PropertyGroup.MajorVersion[0]).$($xml.Project.PropertyGroup.MinorVersion[0])"
 
-$dockerFilePrefix="$PSScriptRoot/libraries-sdk"
-
 if ($buildWindowsContainers)
 {
   # Due to size concerns, we don't currently do docker builds on windows.
@@ -28,8 +26,6 @@ if ($buildWindowsContainers)
   {
     exit $LASTEXITCODE
   }
-
-  $dockerFile="$dockerFilePrefix.windows.Dockerfile"
 
   # Collect the following artifacts to folder, that will be used as build context for the container,
   # so projects can build and test against the live-built runtime:
@@ -55,6 +51,8 @@ if ($buildWindowsContainers)
                      -Destination $dockerContext\targetingpacks.targets
   Copy-Item -Recurse -Path $REPO_ROOT_DIR\src\libraries\System.Net.Quic\src\System\Net\Quic\Interop `
                      -Destination $dockerContext\msquic-interop
+  Copy-Item          -Path $PSScriptRoot\libraries-sdk.windows.Dockerfile `
+                     -Destination $dockerContext
 
   # In case of non-CI builds, testhost may already contain Microsoft.AspNetCore.App (see build-local.ps1 in HttpStress):
   $testHostAspNetCorePath="$dockerContext\testhost\net$VERSION-windows-$configuration-x64/shared/Microsoft.AspNetCore.App"
@@ -65,18 +63,17 @@ if ($buildWindowsContainers)
   docker build --tag $imageName `
     --build-arg CONFIGURATION=$configuration `
     --build-arg VERSION=$VERSION `
-    --file $dockerFile `
+    --file $dockerContext\libraries-sdk.windows.Dockerfile `
     $dockerContext
 }
 else
 {
   # Docker build libraries and copy to dotnet sdk image
-  $dockerFile="$dockerFilePrefix.linux.Dockerfile"
 
   docker build --tag $imageName `
       --build-arg CONFIGURATION=$configuration `
       --build-arg "VERSION=$VERSION" `
-      --file $dockerFile `
+      --file $PSScriptRoot/libraries-sdk.linux.Dockerfile `
       $REPO_ROOT_DIR
 }
 

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -138,7 +138,7 @@ extends:
             $env:STRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 3.0"
             $env:STRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 3.0"
             New-Item -Force $env:DUMPS_SHARE -ItemType Directory
-            docker compose up --abort-on-container-exit --no-color
+            docker-compose up --abort-on-container-exit --no-color
           displayName: Run HttpStress - HTTP 3.0
           condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 
@@ -147,7 +147,7 @@ extends:
             $env:STRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 2.0"
             $env:STRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 2.0"
             New-Item -Force $env:DUMPS_SHARE -ItemType Directory
-            docker compose up --abort-on-container-exit --no-color
+            docker-compose up --abort-on-container-exit --no-color
           displayName: Run HttpStress - HTTP 2.0
           condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 
@@ -156,7 +156,7 @@ extends:
             $env:STRESS_CLIENT_ARGS = "$env:HTTPSTRESS_CLIENT_ARGS -http 1.1"
             $env:STRESS_SERVER_ARGS = "$env:HTTPSTRESS_SERVER_ARGS -http 1.1"
             New-Item -Force $env:DUMPS_SHARE -ItemType Directory
-            docker compose up --abort-on-container-exit --no-color
+            docker-compose up --abort-on-container-exit --no-color
           displayName: Run HttpStress - HTTP 1.1
           condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -96,7 +96,7 @@ extends:
             $env:STRESS_CLIENT_ARGS = $env:SSLSTRESS_CLIENT_ARGS
             $env:STRESS_SERVER_ARGS = $env:SSLSTRESS_SERVER_ARGS
             New-Item -Force $env:DUMPS_SHARE -ItemType Directory
-            docker compose up --abort-on-container-exit --no-color
+            docker-compose up --abort-on-container-exit --no-color
           displayName: Run SslStress
 
         - publish: $(Build.ArtifactStagingDirectory)/dumps

--- a/src/libraries/Common/tests/System/Net/StressTests/run-docker-compose.ps1
+++ b/src/libraries/Common/tests/System/Net/StressTests/run-docker-compose.ps1
@@ -61,10 +61,10 @@ if (!$noBuild) {
     $originalErrorPreference = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'
     try {
-        write-output "docker compose --file $COMPOSE_FILE build $buildArgs"
-        docker compose --file $COMPOSE_FILE build @buildArgs 2>&1
+        write-output "docker-compose --file $COMPOSE_FILE build $buildArgs"
+        docker-compose --file $COMPOSE_FILE build @buildArgs 2>&1
         if ($LASTEXITCODE -ne 0) {
-            throw "docker compose exited with error code $LASTEXITCODE"
+            throw "docker-compose exited with error code $LASTEXITCODE"
         }
     }
     finally {
@@ -86,5 +86,5 @@ if (!$buildOnly) {
 
     $env:STRESS_CLIENT_ARGS = $clientStressArgs
     $env:STRESS_SERVER_ARGS = $serverStressArgs
-    docker compose --file "$COMPOSE_FILE" up --abort-on-container-exit
+    docker-compose --file "$COMPOSE_FILE" up --abort-on-container-exit
 }


### PR DESCRIPTION
The new Windows VM image has newer `docker` command, so the dockerfile must be within the build context.
And it doesn't have `docker compose` but `docker-compose`.