### PR TITLE
[release/10.0][HTTP/SSL] Fix stress test

### DIFF
--- a/src/libraries/Common/tests/System/Net/StressTests/run-docker-compose.ps1
+++ b/src/libraries/Common/tests/System/Net/StressTests/run-docker-compose.ps1
@@ -20,6 +20,7 @@ $REPO_ROOT_DIR = $(git -C "$PSScriptRoot" rev-parse --show-toplevel)
 $COMPOSE_FILE = "$TestProjectDir/docker-compose.yml"
 [xml]$xml = Get-Content (Join-Path $RepoRoot "eng\Versions.props")
 $VERSION = "$($xml.Project.PropertyGroup.MajorVersion[0]).$($xml.Project.PropertyGroup.MinorVersion[0])"
+$PRODUCTVERSION = "$VERSION.$($xml.Project.PropertyGroup.PatchVersion[0])"
 
 if (!$dumpsSharePath) {
     $dumpsSharePath = "$TestProjectDir/dumps"
@@ -53,6 +54,7 @@ if (!$noBuild) {
     # Dockerize the stress app using docker-compose
     $BuildArgs = @(
         "--build-arg", "VERSION=$Version",
+        "--build-arg", "PRODUCTVERSION=$PRODUCTVERSION",
         "--build-arg", "CONFIGURATION=$configuration"
     )
     if ($sdkImageName) {

--- a/src/libraries/Common/tests/System/Net/StressTests/run-docker-compose.sh
+++ b/src/libraries/Common/tests/System/Net/StressTests/run-docker-compose.sh
@@ -23,7 +23,9 @@ scriptroot="$( cd -P "$( dirname "$source" )" && pwd )"
 repo_root=$(git -C "$scriptroot" rev-parse --show-toplevel)
 major_version=$(grep -oP '(?<=<MajorVersion>).*?(?=</MajorVersion>)' "$repo_root/eng/Versions.props")
 minor_version=$(grep -oP '(?<=<MinorVersion>).*?(?=</MinorVersion>)' "$repo_root/eng/Versions.props")
+patch_version=$(grep -oP '(?<=<PatchVersion>).*?(?=</PatchVersion>)' "$repo_root/eng/Versions.props")
 version="$major_version.$minor_version"
+productversion="$version.$patch_version"
 imagename="dotnet-sdk-libs-current"
 configuration="Release"
 buildcurrentlibraries=0
@@ -95,7 +97,7 @@ fi
 compose_file="$projectdir/docker-compose.yml"
 
 if [[ "$nobuild" -eq 0 ]]; then
-    build_args="--build-arg VERSION=$version --build-arg CONFIGURATION=$configuration"
+    build_args="--build-arg VERSION=$version --build-arg PRODUCTVERSION=$productversion --build-arg CONFIGURATION=$configuration"
     if [[ -n "$imagename" ]]; then
         build_args="$build_args --build-arg SDK_BASE_IMAGE=$imagename"
     fi

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/Dockerfile
@@ -22,6 +22,7 @@ RUN cd msquic/build/bin/Debug && \
 
 ARG VERSION
 ARG CONFIGURATION
+ARG PRODUCTVERSION
 
 # Build the stress server
 WORKDIR /app
@@ -29,6 +30,7 @@ COPY . .
 
 RUN dotnet build -c $CONFIGURATION \
     -p:NetCoreAppCurrentVersion=$VERSION \
+    -p:ProductVersion=$PRODUCTVERSION \
     -p:MsQuicInteropIncludes="/live-runtime-artifacts/msquic-interop/*.cs" \
     -p:TargetingPacksTargetsLocation=/live-runtime-artifacts/targetingpacks.targets \
     -p:MicrosoftNetCoreAppRefPackDir=/live-runtime-artifacts/microsoft.netcore.app.ref/ \

--- a/src/libraries/System.Net.Http/tests/StressTests/HttpStress/windows.Dockerfile
+++ b/src/libraries/System.Net.Http/tests/StressTests/HttpStress/windows.Dockerfile
@@ -10,9 +10,11 @@ COPY . .
 
 ARG VERSION=9.0
 ARG CONFIGURATION=Release
+ARG PRODUCTVERSION
 
 RUN dotnet build -c $env:CONFIGURATION `
     -p:NetCoreAppCurrentVersion=$env:VERSION `
+    -p:ProductVersion=$env:PRODUCTVERSION `
     -p:MsQuicInteropIncludes="C:/live-runtime-artifacts/msquic-interop/*.cs" `
     -p:TargetingPacksTargetsLocation=C:/live-runtime-artifacts/targetingpacks.targets `
     -p:MicrosoftNetCoreAppRefPackDir=C:/live-runtime-artifacts/microsoft.netcore.app.ref/ `

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/Dockerfile
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/Dockerfile
@@ -7,9 +7,11 @@ WORKDIR /app/System.Net.Security/tests/StressTests/SslStress
 
 ARG VERSION=9.0
 ARG CONFIGURATION=Release
+ARG PRODUCTVERSION
 
 RUN dotnet build -c $CONFIGURATION \
     -p:NetCoreAppCurrentVersion=$VERSION \
+    -p:ProductVersion=$PRODUCTVERSION \
     -p:TargetingPacksTargetsLocation=/live-runtime-artifacts/targetingpacks.targets \
     -p:MicrosoftNetCoreAppRefPackDir=/live-runtime-artifacts/microsoft.netcore.app.ref/ \
     -p:MicrosoftNetCoreAppRuntimePackDir=/live-runtime-artifacts/microsoft.netcore.app.runtime.linux-x64/$CONFIGURATION/

--- a/src/libraries/System.Net.Security/tests/StressTests/SslStress/windows.Dockerfile
+++ b/src/libraries/System.Net.Security/tests/StressTests/SslStress/windows.Dockerfile
@@ -11,9 +11,11 @@ WORKDIR /app/System.Net.Security/tests/StressTests/SslStress
 
 ARG VERSION=9.0
 ARG CONFIGURATION=Release
+ARG PRODUCTVERSION
 
 RUN dotnet build -c $env:CONFIGURATION `
     -p:NetCoreAppCurrentVersion=$env:VERSION `
+    -p:ProductVersion=$env:PRODUCTVERSION `
     -p:TargetingPacksTargetsLocation=C:/live-runtime-artifacts/targetingpacks.targets `
     -p:MicrosoftNetCoreAppRefPackDir=C:/live-runtime-artifacts/microsoft.netcore.app.ref/ `
     -p:MicrosoftNetCoreAppRuntimePackDir=C:/live-runtime-artifacts/microsoft.netcore.app.runtime.win-x64/$env:CONFIGURATION/


### PR DESCRIPTION
## Customer Impact

- [ ] Customer reported
- [x] Found internally

Fixes .NET version for testhost being older than the latest greatest daily build.

## Regression

- [x] Yes
- [ ] No

## Testing

CI stress tests pipeline.

## Risk

Low, test only change, no product code change.