### PR TITLE
CodeQL ilasm fixes

### DIFF
--- a/src/coreclr/ilasm/asmparse.h
+++ b/src/coreclr/ilasm/asmparse.h
@@ -223,10 +223,10 @@ typedef unsigned(*PFN_SYM)(char*);
 unsigned SymAU(_In_ __nullterminated char* curPos);
 unsigned SymW(_In_ __nullterminated char* curPos);
 /*--------------------------------------------------------------------------*/
-typedef char*(*PFN_NEWSTRFROMTOKEN)(char*,size_t);
+typedef char*(*PFN_NEWSTRFROMTOKEN)(void*,size_t);
 
-char* NewStrFromTokenAU(_In_reads_(tokLen) char* curTok, size_t tokLen);
-char* NewStrFromTokenW(_In_reads_(tokLen) char* curTok, size_t tokLen);
+char* NewStrFromTokenAU(_In_reads_(tokLen) void* curTok, size_t tokLen);
+char* NewStrFromTokenW(_In_reads_(tokLen) void* curTok, size_t tokLen);
 /*--------------------------------------------------------------------------*/
 typedef char*(*PFN_NEWSTATICSTRFROMTOKEN)(char*,size_t,char*,size_t);
 

--- a/src/coreclr/ilasm/grammar_after.cpp
+++ b/src/coreclr/ilasm/grammar_after.cpp
@@ -238,7 +238,7 @@ void yyerror(_In_ __nullterminated const char* str) {
     const char* fmt = "%s(%d) : error : %s at token '%s' in: %s\n";
     if(Sym == SymW) // Unicode file
     {
-        // CodeQL [SM02986] Casting yygetline result to WCHAR* is safe because tokBuff is WCHAR-aligned and properly null terminated
+        // CodeQL [SM02986] Casting tokBuff to WCHAR* is safe because tokBuff is WCHAR-aligned and properly null terminated
         MAKE_UTF8PTR_FROMWIDE(tokBuffUtf8, (WCHAR*)tokBuff);
         // CodeQL [SM02986] Casting yygetline result to WCHAR* is safe because buff is guaranteed to be WCHAR-aligned
         MAKE_UTF8PTR_FROMWIDE(curLineUtf8, (WCHAR*)yygetline(PENV->curLine));

--- a/src/coreclr/ilasm/grammar_after.cpp
+++ b/src/coreclr/ilasm/grammar_after.cpp
@@ -86,6 +86,11 @@ char* nextcharW(_In_ __nullterminated char* pos)
     return (pos+2);
 }
 /*--------------------------------------------------------------------------*/
+bool PtrIsWCHARAligned(char* ptr)
+{
+    return ((uintptr_t)ptr & (sizeof(WCHAR) - 1)) == 0;
+}
+/*--------------------------------------------------------------------------*/
 unsigned SymAU(_In_ __nullterminated char* curPos)
 {
     return (unsigned)*curPos;
@@ -93,7 +98,9 @@ unsigned SymAU(_In_ __nullterminated char* curPos)
 
 unsigned SymW(_In_ __nullterminated char* curPos)
 {
-    return (unsigned)*((WCHAR*)curPos);
+    WCHAR wc;
+    memcpy(&wc, curPos, sizeof(WCHAR));
+    return (unsigned)wc;
 }
 /*--------------------------------------------------------------------------*/
 char* NewStrFromTokenAU(_In_reads_(tokLen) char* curTok, size_t tokLen)
@@ -108,6 +115,11 @@ char* NewStrFromTokenAU(_In_reads_(tokLen) char* curTok, size_t tokLen)
 }
 char* NewStrFromTokenW(_In_reads_(tokLen) char* curTok, size_t tokLen)
 {
+    if (!PtrIsWCHARAligned(curTok))
+    {
+        _ASSERTE(!"NewStrFromTokenW: misaligned curTok");
+        return NULL;
+    }
     WCHAR* wcurTok = (WCHAR*)curTok;
     char *nb = new char[(tokLen<<1) + 2];
     if(nb != NULL)
@@ -127,6 +139,11 @@ char* NewStaticStrFromTokenAU(_In_reads_(tokLen) char* curTok, size_t tokLen, _O
 }
 char* NewStaticStrFromTokenW(_In_reads_(tokLen) char* curTok, size_t tokLen, _Out_writes_(bufSize) char* staticBuf, size_t bufSize)
 {
+    if (!PtrIsWCHARAligned(curTok))
+    {
+        _ASSERTE(!"NewStaticStrFromTokenW: misaligned curTok");
+        return NULL;
+    }
     WCHAR* wcurTok = (WCHAR*)curTok;
     if(tokLen >= bufSize/2) return NULL;
     tokLen = WideCharToMultiByte(CP_UTF8,0,(LPCWSTR)wcurTok,(int)(tokLen >> 1),staticBuf,(int)bufSize,NULL,NULL);
@@ -147,9 +164,12 @@ unsigned GetDoubleAU(_In_ __nullterminated char* begNum, unsigned L, double** pp
 
 unsigned GetDoubleW(_In_ __nullterminated char* begNum, unsigned L, double** ppRes)
 {
-    static char dbuff[256];
+    alignas(WCHAR) static char dbuff[256];
     char* pdummy = NULL;
     if(L > 254) L = 254;
+    // L must be even in the Unicode case, so the null
+    // termination isn't split across two WCHARs
+    L &= ~(size_t)1;
     memcpy(dbuff,begNum,L);
     dbuff[L] = 0;
     dbuff[L+1] = 0;
@@ -159,7 +179,7 @@ unsigned GetDoubleW(_In_ __nullterminated char* begNum, unsigned L, double** ppR
 /*--------------------------------------------------------------------------*/
 char* yygetline(int Line)
 {
-    static char buff[0x4000];
+    alignas(WCHAR) static char buff[0x4000];
     char *pLine=NULL, *pNextLine=NULL;
     char *pBegin=NULL, *pEnd = NULL;
     unsigned uCount = parser->getAll(&pBegin);
@@ -199,12 +219,18 @@ char* yygetline(int Line)
 }
 
 void yyerror(_In_ __nullterminated const char* str) {
-    char tokBuff[64];
+    alignas(WCHAR) char tokBuff[64];
     const char* szfile = PENV->in->name();
     int iline = PENV->curLine;
 
     size_t len = PENV->curPos - PENV->curTok;
     if (len > 62) len = 62;
+    if (Sym == SymW)
+    {
+        // len must be even in the Unicode case, so the null
+        // termination isn't split across two WCHARs
+        len &= ~(size_t)1;
+    }
     memcpy(tokBuff, PENV->curTok, len);
     tokBuff[len] = 0;
     tokBuff[len+1] = 0;

--- a/src/coreclr/ilasm/grammar_after.cpp
+++ b/src/coreclr/ilasm/grammar_after.cpp
@@ -166,18 +166,13 @@ unsigned GetDoubleAU(_In_ __nullterminated char* begNum, unsigned L, double** pp
 
 unsigned GetDoubleW(_In_ __nullterminated char* begNum, unsigned L, double** ppRes)
 {
-    alignas(WCHAR) static char dbuff[256];
+    WCHAR dbuff[128] = {0};
     char* pdummy = NULL;
     if(L > 254) L = 254;
-    // L must be even in the Unicode case, so the null
-    // termination isn't split across two WCHARs
-    L &= ~1u;
-    memcpy(dbuff,begNum,L);
-    dbuff[L] = 0;
-    dbuff[L+1] = 0;
-    // CodeQL [SM02986] Cast to WCHAR is safe because dbuff is properly aligned and we ensure proper null termination above
-    *ppRes = new double(u16_strtod((const WCHAR*)dbuff, (WCHAR**)&pdummy));
-    return ((unsigned)(pdummy - dbuff));
+    L &= ~1u; // round down to WCHAR boundary
+    memcpy(dbuff, begNum, L);
+    *ppRes = new double(u16_strtod(dbuff, (WCHAR**)&pdummy));
+    return ((unsigned)(pdummy - (char*)dbuff));
 }
 /*--------------------------------------------------------------------------*/
 char* yygetline(int Line)

--- a/src/coreclr/ilasm/grammar_after.cpp
+++ b/src/coreclr/ilasm/grammar_after.cpp
@@ -171,7 +171,7 @@ unsigned GetDoubleW(_In_ __nullterminated char* begNum, unsigned L, double** ppR
     if(L > 254) L = 254;
     // L must be even in the Unicode case, so the null
     // termination isn't split across two WCHARs
-    L &= ~(size_t)1;
+    L &= ~1u;
     memcpy(dbuff,begNum,L);
     dbuff[L] = 0;
     dbuff[L+1] = 0;

--- a/src/coreclr/ilasm/grammar_after.cpp
+++ b/src/coreclr/ilasm/grammar_after.cpp
@@ -86,7 +86,7 @@ char* nextcharW(_In_ __nullterminated char* pos)
     return (pos+2);
 }
 /*--------------------------------------------------------------------------*/
-bool PtrIsWCHARAligned(char* ptr)
+static bool PtrIsWCHARAligned(char* ptr)
 {
     return ((uintptr_t)ptr & (sizeof(WCHAR) - 1)) == 0;
 }

--- a/src/coreclr/ilasm/grammar_after.cpp
+++ b/src/coreclr/ilasm/grammar_after.cpp
@@ -120,6 +120,7 @@ char* NewStrFromTokenW(_In_reads_(tokLen) char* curTok, size_t tokLen)
         _ASSERTE(!"NewStrFromTokenW: misaligned curTok");
         return NULL;
     }
+    // CodeQL [SM02986] Cast to WCHAR is safe because we bail if curTok is not properly aligned
     WCHAR* wcurTok = (WCHAR*)curTok;
     char *nb = new char[(tokLen<<1) + 2];
     if(nb != NULL)
@@ -144,6 +145,7 @@ char* NewStaticStrFromTokenW(_In_reads_(tokLen) char* curTok, size_t tokLen, _Ou
         _ASSERTE(!"NewStaticStrFromTokenW: misaligned curTok");
         return NULL;
     }
+    // CodeQL [SM02986] Cast to WCHAR is safe because we bail if curTok is not properly aligned
     WCHAR* wcurTok = (WCHAR*)curTok;
     if(tokLen >= bufSize/2) return NULL;
     tokLen = WideCharToMultiByte(CP_UTF8,0,(LPCWSTR)wcurTok,(int)(tokLen >> 1),staticBuf,(int)bufSize,NULL,NULL);
@@ -173,6 +175,7 @@ unsigned GetDoubleW(_In_ __nullterminated char* begNum, unsigned L, double** ppR
     memcpy(dbuff,begNum,L);
     dbuff[L] = 0;
     dbuff[L+1] = 0;
+    // CodeQL [SM02986] Cast to WCHAR is safe because dbuff is properly aligned and we ensure proper null termination above
     *ppRes = new double(u16_strtod((const WCHAR*)dbuff, (WCHAR**)&pdummy));
     return ((unsigned)(pdummy - dbuff));
 }
@@ -199,9 +202,11 @@ char* yygetline(int Line)
         }
         if(Sym == SymW) // Unicode file
         {
+            // CodeQL [SM02986] pNextLine (via parser->getAll) points into properly WCHAR aligned data (MapViewOfFile) and is safely incremented by nextchar
             if(*((WCHAR*)pNextLine - 1) == '\r') pNextLine -= 2;
             uCount = (unsigned)(pNextLine - pLine);
             uCount &= 0x1FFF; // limit: 8K wchars
+            // CodeQL [SM02986] this cast is safe because buff is WCHAR aligned and we null terminate below
             WCHAR* wzBuff = (WCHAR*)buff;
             memcpy(buff,pLine,uCount);
             wzBuff[uCount >> 1] = 0;
@@ -243,7 +248,9 @@ void yyerror(_In_ __nullterminated const char* str) {
     const char* fmt = "%s(%d) : error : %s at token '%s' in: %s\n";
     if(Sym == SymW) // Unicode file
     {
+        // CodeQL [SM02986] Casting yygetline result to WCHAR* is safe because tokBuff is WCHAR-aligned and properly null terminated
         MAKE_UTF8PTR_FROMWIDE(tokBuffUtf8, (WCHAR*)tokBuff);
+        // CodeQL [SM02986] Casting yygetline result to WCHAR* is safe because buff is guaranteed to be WCHAR-aligned
         MAKE_UTF8PTR_FROMWIDE(curLineUtf8, (WCHAR*)yygetline(PENV->curLine));
         fprintf(stderr, fmt,
                 szfile, iline, str, tokBuffUtf8, curLineUtf8);

--- a/src/coreclr/ilasm/grammar_after.cpp
+++ b/src/coreclr/ilasm/grammar_after.cpp
@@ -103,7 +103,7 @@ unsigned SymW(_In_ __nullterminated char* curPos)
     return (unsigned)wc;
 }
 /*--------------------------------------------------------------------------*/
-char* NewStrFromTokenAU(_In_reads_(tokLen) char* curTok, size_t tokLen)
+char* NewStrFromTokenAU(_In_reads_(tokLen) void* curTok, size_t tokLen)
 {
     char *nb = new char[tokLen+1];
     if(nb != NULL)
@@ -113,14 +113,9 @@ char* NewStrFromTokenAU(_In_reads_(tokLen) char* curTok, size_t tokLen)
     }
     return nb;
 }
-char* NewStrFromTokenW(_In_reads_(tokLen) char* curTok, size_t tokLen)
+char* NewStrFromTokenW(_In_reads_(tokLen) void* curTok, size_t tokLen)
 {
-    if (!PtrIsWCHARAligned(curTok))
-    {
-        _ASSERTE(!"NewStrFromTokenW: misaligned curTok");
-        return NULL;
-    }
-    // CodeQL [SM02986] Cast to WCHAR is safe because we bail if curTok is not properly aligned
+    _ASSERTE(PtrIsWCHARAligned((char*) curTok) && "NewStrFromTokenW: misaligned curTok");
     WCHAR* wcurTok = (WCHAR*)curTok;
     char *nb = new char[(tokLen<<1) + 2];
     if(nb != NULL)

--- a/src/coreclr/ilasm/writer.cpp
+++ b/src/coreclr/ilasm/writer.cpp
@@ -1720,7 +1720,7 @@ HRESULT Assembler::CreatePEFile(_In_ __nullterminated WCHAR *pwzOutputFilename)
         pb = (BYTE*)(((size_t)pb + 3) & ~3);
         PSTORAGEHEADER pSHdr = (PSTORAGEHEADER)pb;
         PSTORAGESTREAM pStr = (PSTORAGESTREAM)(pSHdr+1);
-        for(short iStr = 1; iStr <= VAL16(pSHdr->iStreams); iStr++)
+        for(USHORT iStr = 1; iStr <= VAL16(pSHdr->iStreams); iStr++)
         {
             if((strcmp(pStr->rcName,"#-")==0)||(strcmp(pStr->rcName,"#~")==0))
             {

--- a/src/coreclr/ilasm/writer.cpp
+++ b/src/coreclr/ilasm/writer.cpp
@@ -1720,7 +1720,8 @@ HRESULT Assembler::CreatePEFile(_In_ __nullterminated WCHAR *pwzOutputFilename)
         pb = (BYTE*)(((size_t)pb + 3) & ~3);
         PSTORAGEHEADER pSHdr = (PSTORAGEHEADER)pb;
         PSTORAGESTREAM pStr = (PSTORAGESTREAM)(pSHdr+1);
-        for(USHORT iStr = 1; iStr <= VAL16(pSHdr->iStreams); iStr++)
+        USHORT streamCount = VAL16(pSHdr->iStreams);
+        for(unsigned int iStr = 1; iStr <= streamCount; iStr++)
         {
             if((strcmp(pStr->rcName,"#-")==0)||(strcmp(pStr->rcName,"#~")==0))
             {


### PR DESCRIPTION
Fix two issues that got flagged

1 - Fix a mistyped loop counter.

2 - One of the files frequently casts CHAR*->WCHAR*.  Retyping isn't reasonable, because these methods are called through function pointers using char*.  These casts are probably safe since they all point into MapViewOfFile, but I add alignment constraints and bailouts if somehow we have an odd pointer.  The analyzer still complains however, so I also need an explicit suppression of the warning.

I'm kicking off another analysis pipeline in a bit to make sure the suppressions get picked up