### PR TITLE
Use a platform-neutral name for `Microsoft.DiaSymReader.Native`

### DIFF
--- a/eng/DiaSymReaderNative.targets
+++ b/eng/DiaSymReaderNative.targets
@@ -23,11 +23,13 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
       <Pack>false</Pack>
+      <TargetPath>Microsoft.DiaSymReader.Native.dll</TargetPath>
     </Content>
     <Content Include="$(NuGetPackageRoot)\microsoft.diasymreader.native\$(MicrosoftDiaSymReaderNativeVersion)\runtimes\win\native\Microsoft.DiaSymReader.Native.amd64.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
       <Pack>false</Pack>
+      <TargetPath>Microsoft.DiaSymReader.Native.dll</TargetPath>
     </Content>
 
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" ExcludeAssets="all"/>

--- a/eng/DiaSymReaderNative.targets
+++ b/eng/DiaSymReaderNative.targets
@@ -23,13 +23,11 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
       <Pack>false</Pack>
-      <TargetPath>Microsoft.DiaSymReader.Native.dll</TargetPath>
     </Content>
     <Content Include="$(NuGetPackageRoot)\microsoft.diasymreader.native\$(MicrosoftDiaSymReaderNativeVersion)\runtimes\win\native\Microsoft.DiaSymReader.Native.amd64.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Visible>false</Visible>
       <Pack>false</Pack>
-      <TargetPath>Microsoft.DiaSymReader.Native.dll</TargetPath>
     </Content>
 
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="$(MicrosoftDiaSymReaderNativeVersion)" ExcludeAssets="all"/>

--- a/src/coreclr/scripts/superpmi_collect_setup.py
+++ b/src/coreclr/scripts/superpmi_collect_setup.py
@@ -162,6 +162,7 @@ native_binaries_to_ignore = [
     "KernelTraceControl.Win61.dll",
     "llvm-mca.exe",
     "mcs.exe",
+    "Microsoft.DiaSymReader.Native.dll",
     "Microsoft.DiaSymReader.Native.amd64.dll",
     "Microsoft.DiaSymReader.Native.x86.dll",
     "mscordaccore.dll",

--- a/src/coreclr/tools/aot/ILCompiler.Diagnostics/PdbWriter.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Diagnostics/PdbWriter.cs
@@ -92,26 +92,6 @@ namespace ILCompiler.Diagnostics
         UIntPtr _pdbMod;
         ISymNGenWriter2 _ngenWriter;
 
-        static PdbWriter()
-        {
-            NativeLibrary.SetDllImportResolver(typeof(PdbWriter).Assembly, DllImportResolver);
-        }
-
-        private static IntPtr DllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
-        {
-            IntPtr libraryHandle = IntPtr.Zero;
-            if (libraryName == DiaSymReaderLibrary)
-            {
-                string archSuffix = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-                if (archSuffix == "x64")
-                {
-                    archSuffix = "amd64";
-                }
-                libraryHandle = NativeLibrary.Load(DiaSymReaderLibrary + "." + archSuffix + ".dll", assembly, searchPath);
-            }
-            return libraryHandle;
-        }
-
         [DefaultDllImportSearchPaths(DllImportSearchPath.AssemblyDirectory | DllImportSearchPath.SafeDirectories)]
         [LibraryImport(DiaSymReaderLibrary, StringMarshalling = StringMarshalling.Utf16)]
         private static partial void CreateNGenPdbWriter(

--- a/src/coreclr/tools/aot/crossgen2/crossgen2.props
+++ b/src/coreclr/tools/aot/crossgen2/crossgen2.props
@@ -89,7 +89,7 @@
     <DiaSymReaderTargetArchFileName>Microsoft.DiaSymReader.Native.$(DiaSymReaderTargetArch).dll</DiaSymReaderTargetArchFileName>
     <DiaSymReaderTargetArchPath Condition="'$(PkgMicrosoft_DiaSymReader_Native)' != ''">$(PkgMicrosoft_DiaSymReader_Native)\runtimes\win\native\$(DiaSymReaderTargetArchFileName)</DiaSymReaderTargetArchPath>
     <!-- When publishing we won't have the NuGet packages, so use the copy from the build artifacts directory. -->
-    <DiaSymReaderTargetArchPath Condition="'$(PkgMicrosoft_DiaSymReader_Native)' == ''">$(CoreCLRArtifactsPath)crossgen2/$(DiaSymReaderTargetArchFileName)</DiaSymReaderTargetArchPath>
+    <DiaSymReaderTargetArchPath Condition="'$(PkgMicrosoft_DiaSymReader_Native)' == ''">$(CoreCLRArtifactsPath)crossgen2/Microsoft.DiaSymReader.Native.dll</DiaSymReaderTargetArchPath>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetOS)' == 'windows'">
@@ -97,7 +97,8 @@
       CopyToOutputDirectory="PreserveNewest"
       CopyToPublishDirectory="PreserveNewest"
       ExcludeFromSingleFile="$(PublishSingleFile)"
-      Link="%(FileName)%(Extension)"
+      Link="Microsoft.DiaSymReader.Native.dll"
+      TargetPath="Microsoft.DiaSymReader.Native.dll"
       />
   </ItemGroup>
 </Project>

--- a/src/coreclr/tools/r2rdump/Program.cs
+++ b/src/coreclr/tools/r2rdump/Program.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
+using System.Runtime.InteropServices;
 using System.Text;
 using ILCompiler.Diagnostics;
 using ILCompiler.Reflection.ReadyToRun;
@@ -226,6 +227,22 @@ namespace R2RDump
 
                 if (createPDB)
                 {
+                    NativeLibrary.SetDllImportResolver(typeof(PdbWriter).Assembly,
+                        (string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath) =>
+                        {
+                            IntPtr libraryHandle = IntPtr.Zero;
+                            if (libraryName == "Microsoft.DiaSymReader.Native")
+                            {
+                                string archSuffix = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+                                if (archSuffix == "x64")
+                                {
+                                    archSuffix = "amd64";
+                                }
+                                libraryHandle = NativeLibrary.Load(libraryName + "." + archSuffix + ".dll", assembly, searchPath);
+                            }
+                            return libraryHandle;
+                        });
+
                     string pdbPath = Get(_command.PdbPath);
                     if (String.IsNullOrEmpty(pdbPath))
                     {

--- a/src/coreclr/tools/r2rdump/Program.cs
+++ b/src/coreclr/tools/r2rdump/Program.cs
@@ -227,22 +227,6 @@ namespace R2RDump
 
                 if (createPDB)
                 {
-                    NativeLibrary.SetDllImportResolver(typeof(PdbWriter).Assembly,
-                        (string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath) =>
-                        {
-                            IntPtr libraryHandle = IntPtr.Zero;
-                            if (libraryName == "Microsoft.DiaSymReader.Native")
-                            {
-                                string archSuffix = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
-                                if (archSuffix == "x64")
-                                {
-                                    archSuffix = "amd64";
-                                }
-                                libraryHandle = NativeLibrary.Load(libraryName + "." + archSuffix + ".dll", assembly, searchPath);
-                            }
-                            return libraryHandle;
-                        });
-
                     string pdbPath = Get(_command.PdbPath);
                     if (String.IsNullOrEmpty(pdbPath))
                     {
@@ -412,6 +396,22 @@ namespace R2RDump
 
         public int Run()
         {
+            NativeLibrary.SetDllImportResolver(typeof(PdbWriter).Assembly,
+                (string libraryName, System.Reflection.Assembly assembly, DllImportSearchPath? searchPath) =>
+                {
+                    IntPtr libraryHandle = IntPtr.Zero;
+                    if (libraryName == "Microsoft.DiaSymReader.Native")
+                    {
+                        string archSuffix = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
+                        if (archSuffix == "x64")
+                        {
+                            archSuffix = "amd64";
+                        }
+                        libraryHandle = NativeLibrary.Load(libraryName + "." + archSuffix + ".dll", assembly, searchPath);
+                    }
+                    return libraryHandle;
+                });
+
             Disassembler disassembler = null;
             List<string> inputs = Get(_command.In);
             bool inlineSignatureBinary = Get(_command.InlineSignatureBinary);


### PR DESCRIPTION
Fixes issues that we're running into when rebootstrapping the dotnet/dotnet build (https://github.com/dotnet/dotnet/pull/5155#issuecomment-3989895314).

`Microsoft.DiaSymReader.Native.(x86|x64|arm64).dll` clashes with the same name DLL in the runtime pack. Not having a suffix is simpler in the end.

Cc @dotnet/appmodel 