### PR TITLE
Disable ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed on macOS

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -81,6 +81,7 @@ namespace System.Net.Http.Functional.Tests
 
 #if !WINHTTPHANDLER_TEST
         [PlatformSpecific(TestPlatforms.AnyUnix)] // The default proxy is resolved via WinINet on Windows.
+        [SkipOnPlatform(TestPlatforms.OSX, "Crashes due to a double-free bug in macOS GSS framework (https://github.com/dotnet/runtime/issues/125150)")]
         [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         [InlineData(false)]
         [InlineData(true)]

--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.DefaultProxyCredentials.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.DefaultProxyCredentials.cs
@@ -81,7 +81,7 @@ namespace System.Net.Http.Functional.Tests
 
 #if !WINHTTPHANDLER_TEST
         [PlatformSpecific(TestPlatforms.AnyUnix)] // The default proxy is resolved via WinINet on Windows.
-        [SkipOnPlatform(TestPlatforms.OSX, "Crashes due to a double-free bug in macOS GSS framework (https://github.com/dotnet/runtime/issues/125150)")]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/125150", TestPlatforms.OSX)] // Crashes due to a double-free bug in macOS GSS framework
         [ConditionalTheory(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         [InlineData(false)]
         [InlineData(true)]


### PR DESCRIPTION
Fixes #125150

main PR: N/A — this is a test-only change specific to .NET 8 (the underlying macOS GSS bug doesn't affect .NET 9+ which uses managed NTLM/SPNEGO).

# Description

Skip the `ProxySetViaEnvironmentVariable_DefaultProxyCredentialsUsed` test on macOS. The test crashes with SIGABRT (exit code 134) on macOS 14 due to a double-free bug in Apple's GSS framework (`_gss_scram_release_cred`) when cleaning up SPNEGO/Negotiate authentication contexts via `NetSecurityNative_DeleteSecContext`. This is the same underlying issue as #97966 and #71463.

# Customer Impact

None. This is a test-only change — no product code is modified.

# Regression

No. The crash is caused by a bug in Apple's macOS GSS framework, not by a .NET code change. It started appearing in CI after the macOS build images were updated (PR #122423), and has been failing since build 1252235 (Jan 13, 2026).

# Testing

No additional testing needed. The change only adds a `[SkipOnPlatform]` attribute to skip one test on macOS.

# Risk

Low. This is a single-line test attribute addition that skips a test known to crash due to an external (Apple) bug. No product code is changed.

# Package authoring signed off?

N/A — no package/product code changes.
