### PR TITLE
Disable System.Net.Http.Functional.Tests on Android CoreCLR

### DIFF
--- a/src/libraries/System.Net.Http/tests/FunctionalTests/AssemblyInfo.cs
+++ b/src/libraries/System.Net.Http/tests/FunctionalTests/AssemblyInfo.cs
@@ -6,3 +6,4 @@ using Xunit;
 
 [assembly: SkipOnCoreClr("System.Net.Tests are flaky and/or long running: https://github.com/dotnet/runtime/issues/131", ~RuntimeConfiguration.Release)]
 [assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/131", ~(TestPlatforms.Android | TestPlatforms.Browser | TestPlatforms.Wasi), TargetFrameworkMonikers.Any, TestRuntimes.Mono)] // System.Net.Tests are flaky and/or long running
+[assembly: ActiveIssue("https://github.com/dotnet/runtime/issues/124526", TestPlatforms.Android, TargetFrameworkMonikers.Any, TestRuntimes.CoreCLR)]


### PR DESCRIPTION
For context: https://github.com/dotnet/runtime/issues/124526

Disabling the test suit until full investigation is done.