### PR TITLE
[release/10.0] Fix bug in LowerCallMemmove

### DIFF
--- a/src/coreclr/jit/lower.cpp
+++ b/src/coreclr/jit/lower.cpp
@@ -2448,6 +2448,8 @@ bool Lowering::LowerCallMemmove(GenTreeCall* call, GenTree** next)
 
             GenTree* dstAddr = call->gtArgs.GetUserArgByIndex(0)->GetNode();
             GenTree* srcAddr = call->gtArgs.GetUserArgByIndex(1)->GetNode();
+            assert(!dstAddr->isContained());
+            assert(!srcAddr->isContained());
 
             // TODO-CQ: Try to create an addressing mode
             GenTreeIndir* srcBlk = comp->gtNewIndir(TYP_STRUCT, srcAddr);
@@ -2457,10 +2459,8 @@ bool Lowering::LowerCallMemmove(GenTreeCall* call, GenTree** next)
                 GenTreeBlk(GT_STORE_BLK, TYP_STRUCT, dstAddr, srcBlk, comp->typGetBlkLayout((unsigned)cnsSize));
             storeBlk->gtFlags |= (GTF_IND_UNALIGNED | GTF_ASG | GTF_EXCEPT | GTF_GLOB_REF);
 
-            // TODO-CQ: Use GenTreeBlk::BlkOpKindUnroll here if srcAddr and dstAddr don't overlap, thus, we can
-            // unroll this memmove as memcpy - it doesn't require lots of temp registers
-            storeBlk->gtBlkOpKind = call->IsHelperCall(comp, CORINFO_HELP_MEMCPY) ? GenTreeBlk::BlkOpKindUnroll
-                                                                                  : GenTreeBlk::BlkOpKindUnrollMemmove;
+            // For simplicity, we use BlkOpKindUnrollMemmove even for CORINFO_HELP_MEMCPY.
+            storeBlk->gtBlkOpKind = GenTreeBlk::BlkOpKindUnrollMemmove;
 
             BlockRange().InsertBefore(call, srcBlk);
             BlockRange().InsertBefore(call, storeBlk);
@@ -2478,7 +2478,8 @@ bool Lowering::LowerCallMemmove(GenTreeCall* call, GenTree** next)
 
             JITDUMP("\nNew tree:\n")
             DISPTREE(storeBlk);
-            // TODO: This skips lowering srcBlk and storeBlk.
+            // We've just lowered srcBlk and storeBlk here and it's now what genCodeForMemmove expects.
+            // So the next node to lower is whatever we have after the storeBlk.
             *next = storeBlk->gtNext;
             return true;
         }


### PR DESCRIPTION
Backport of https://github.com/dotnet/runtime/pull/123907 to release/10.0 to fix https://github.com/dotnet/runtime/issues/123748

/cc @EgorBo

## Customer Impact

- [x] Customer reported
- [ ] Found internally

JIT crashes with an access violation (0xC0000005) when compiling calls to C++/CLI functions returning structs with aggregate initialization. The crash occurs in `LowerCallMemmove` during JIT compilation because `BlkOpKindUnroll` was used for `CORINFO_HELP_MEMCPY`, which bypasses the memmove-aware lowering paired with `genCodeForMemmove`. This leads to contained address nodes being passed where non-contained nodes are expected, causing the null dereference.

## Regression

- [x] Yes
- [ ] No

## Fix

Use `BlkOpKindUnrollMemmove` uniformly for both `Memmove` and `MEMCPY` helpers. While slightly more expensive for LSRA (no addressing modes), `CORINFO_HELP_MEMCPY` is rarely used, so the impact is negligible. Also adds asserts to catch contained address nodes early.

## Testing

No diffs in [SPMI replay](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1287687&view=ms.vss-build-web.run-extensions-tab). Verified on main via PR #123907.

## Risk

Low. The change makes memcpy use the same safe code path as memmove, which is already well-tested. The only behavioral difference is slightly different register allocation for the rare `CORINFO_HELP_MEMCPY` case.
