### PR TITLE
[clr-interp] Fix Swift error handling for marshaled P/Invokes in interpreter

### DIFF
--- a/src/coreclr/vm/callstubgenerator.cpp
+++ b/src/coreclr/vm/callstubgenerator.cpp
@@ -1687,7 +1687,7 @@ void InitCallStubGenerator()
     s_callStubCache = new CallStubCacheHash;
 }
 
-CallStubHeader *CallStubGenerator::GenerateCallStubForSig(MetaSig &sig)
+CallStubHeader *CallStubGenerator::GenerateCallStubForSig(MetaSig &sig, MethodDesc *pContextMD)
 {
     STANDARD_VM_CONTRACT;
 
@@ -1699,7 +1699,7 @@ CallStubHeader *CallStubGenerator::GenerateCallStubForSig(MetaSig &sig)
 
     m_interpreterToNative = true; // We always generate the interpreter to native call stub here
 
-    ComputeCallStub(sig, pRoutines, NULL);
+    ComputeCallStub(sig, pRoutines, pContextMD);
 
     xxHash hashState;
     for (int i = 0; i < m_routineIndex; i++)

--- a/src/coreclr/vm/callstubgenerator.h
+++ b/src/coreclr/vm/callstubgenerator.h
@@ -237,7 +237,7 @@ class CallStubGenerator
 public:
     // Generate the call stub for the given method.
     CallStubHeader *GenerateCallStub(MethodDesc *pMD, AllocMemTracker *pamTracker, bool interpreterToNative);
-    CallStubHeader *GenerateCallStubForSig(MetaSig &sig);
+    CallStubHeader *GenerateCallStubForSig(MetaSig &sig, MethodDesc *pContextMD = nullptr);
 
 private:
     static size_t ComputeTempStorageSize(const MetaSig& sig)

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -548,12 +548,12 @@ void InvokeCalliStub(CalliStubParam* pParam)
     pHeader->Invoke(pHeader->Routines, pArgs, pRet, pHeader->TotalStackSize, pContinuationRet);
 }
 
-void* GetCookieForCalliSig(MetaSig metaSig)
+void* GetCookieForCalliSig(MetaSig metaSig, MethodDesc *pContextMD)
 {
     STANDARD_VM_CONTRACT;
 
     CallStubGenerator callStubGenerator;
-    return callStubGenerator.GenerateCallStubForSig(metaSig);
+    return callStubGenerator.GenerateCallStubForSig(metaSig, pContextMD);
 }
 
 // Create call stub for calling interpreted methods from JITted/AOTed code.

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -11418,7 +11418,7 @@ LPVOID CEEInfo::GetCookieForInterpreterCalliSig(CORINFO_SIG_INFO* szMetaSig)
 #ifdef FEATURE_INTERPRETER
 
 // Forward declare the function for mapping MetaSig to a cookie.
-void* GetCookieForCalliSig(MetaSig metaSig);
+void* GetCookieForCalliSig(MetaSig metaSig, MethodDesc *pContextMD);
 
 LPVOID CInterpreterJitInfo::GetCookieForInterpreterCalliSig(CORINFO_SIG_INFO* szMetaSig)
 {
@@ -11437,7 +11437,18 @@ LPVOID CInterpreterJitInfo::GetCookieForInterpreterCalliSig(CORINFO_SIG_INFO* sz
 
     _ASSERTE(szMetaSig->isAsyncCall() == sig.IsAsyncCall());
 
-    result = GetCookieForCalliSig(sig);
+    // When compiling a calli inside an IL stub for a P/Invoke, pass the target
+    // P/Invoke MethodDesc so ComputeCallStub can detect the Swift calling convention.
+    MethodDesc* pContextMD = nullptr;
+    if (m_pMethodBeingCompiled != nullptr && m_pMethodBeingCompiled->IsILStub())
+    {
+        MethodDesc* pTargetMD = m_pMethodBeingCompiled->AsDynamicMethodDesc()->GetILStubResolver()->GetStubTargetMethodDesc();
+        if (pTargetMD != nullptr)
+        {
+            pContextMD = pTargetMD;
+        }
+    }
+    result = GetCookieForCalliSig(sig, pContextMD);
 
     EE_TO_JIT_TRANSITION();
     return result;

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2300,34 +2300,34 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT, CallerGCMode callerGCMo
         if (pCode == (PCODE)NULL)
         {
             pCode = GetStubForInteropMethod(this);
-        }
 
 #ifdef FEATURE_INTERPRETER
-        // Store the IL stub interpreter data on the P/Invoke MethodDesc so the
-        // interpreter can run the IL stub as a child frame with a single native
-        // transition. On WASM this is done for all P/Invokes; on ARM64 Apple it
-        // is needed specifically for Swift to avoid a stale SwiftError (x21).
+            // Store the IL stub interpreter data on the P/Invoke MethodDesc so the
+            // interpreter can run the IL stub as a child frame with a single native
+            // transition. On WASM this is done for all P/Invokes; on ARM64 Apple it
+            // is needed specifically for Swift to avoid a stale SwiftError (x21).
 #ifdef FEATURE_PORTABLE_ENTRYPOINTS
-        void* ilStubInterpData = PortableEntryPoint::GetInterpreterData(pCode);
-        _ASSERTE(ilStubInterpData != NULL);
-        SetInterpreterCode((InterpByteCodeStart*)ilStubInterpData);
+            void* ilStubInterpData = PortableEntryPoint::GetInterpreterData(pCode);
+            _ASSERTE(ilStubInterpData != NULL);
+            SetInterpreterCode((InterpByteCodeStart*)ilStubInterpData);
 #else // !FEATURE_PORTABLE_ENTRYPOINTS
 #if defined(TARGET_APPLE) && defined(TARGET_ARM64)
-        {
-            CorInfoCallConvExtension callConv;
-            PInvoke::GetCallingConvention_IgnoreErrors(this, &callConv, nullptr);
-            if (callConv == CorInfoCallConvExtension::Swift)
             {
-                TADDR ilStubInterpCode = GetInterpreterCodeFromInterpreterPrecodeIfPresent(pCode);
-                if (ilStubInterpCode != (TADDR)pCode)
+                CorInfoCallConvExtension callConv;
+                PInvoke::GetCallingConvention_IgnoreErrors(this, &callConv, nullptr);
+                if (callConv == CorInfoCallConvExtension::Swift)
                 {
-                    SetInterpreterCode(dac_cast<InterpByteCodeStart*>(ilStubInterpCode));
+                    TADDR ilStubInterpCode = GetInterpreterCodeFromInterpreterPrecodeIfPresent(pCode);
+                    if (ilStubInterpCode != (TADDR)pCode)
+                    {
+                        SetInterpreterCode(dac_cast<InterpByteCodeStart*>(ilStubInterpCode));
+                    }
                 }
             }
-        }
 #endif // TARGET_APPLE && TARGET_ARM64
 #endif // FEATURE_PORTABLE_ENTRYPOINTS
 #endif // FEATURE_INTERPRETER
+        }
     }
     else if (IsFCall())
     {

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2302,13 +2302,32 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT, CallerGCMode callerGCMo
             pCode = GetStubForInteropMethod(this);
         }
 
+#ifdef FEATURE_INTERPRETER
+        // Store the IL stub interpreter data on the P/Invoke MethodDesc so the
+        // interpreter can run the IL stub as a child frame with a single native
+        // transition. On WASM this is done for all P/Invokes; on ARM64 Apple it
+        // is needed specifically for Swift to avoid a stale SwiftError (x21).
 #ifdef FEATURE_PORTABLE_ENTRYPOINTS
-        // Store the IL Stub interpreter data on the actual
-        // P/Invoke MethodDesc.
         void* ilStubInterpData = PortableEntryPoint::GetInterpreterData(pCode);
         _ASSERTE(ilStubInterpData != NULL);
         SetInterpreterCode((InterpByteCodeStart*)ilStubInterpData);
+#else // !FEATURE_PORTABLE_ENTRYPOINTS
+#if defined(TARGET_APPLE) && defined(TARGET_ARM64)
+        {
+            CorInfoCallConvExtension callConv;
+            PInvoke::GetCallingConvention_IgnoreErrors(this, &callConv, nullptr);
+            if (callConv == CorInfoCallConvExtension::Swift)
+            {
+                TADDR ilStubInterpCode = GetInterpreterCodeFromInterpreterPrecodeIfPresent(pCode);
+                if (ilStubInterpCode != (TADDR)pCode)
+                {
+                    SetInterpreterCode(dac_cast<InterpByteCodeStart*>(ilStubInterpCode));
+                }
+            }
+        }
+#endif // TARGET_APPLE && TARGET_ARM64
 #endif // FEATURE_PORTABLE_ENTRYPOINTS
+#endif // FEATURE_INTERPRETER
     }
     else if (IsFCall())
     {

--- a/src/coreclr/vm/wasm/helpers.cpp
+++ b/src/coreclr/vm/wasm/helpers.cpp
@@ -722,7 +722,7 @@ namespace
     }
 }
 
-void* GetCookieForCalliSig(MetaSig metaSig)
+void* GetCookieForCalliSig(MetaSig metaSig, MethodDesc *pContextMD)
 {
     STANDARD_VM_CONTRACT;
 
@@ -761,7 +761,7 @@ void* GetUnmanagedCallersOnlyThunk(MethodDesc* pMD)
 void InvokeManagedMethod(ManagedMethodParam *pParam)
 {
     MetaSig sig(pParam->pMD);
-    void* cookie = GetCookieForCalliSig(sig);
+    void* cookie = GetCookieForCalliSig(sig, pParam->pMD);
 
     _ASSERTE(cookie != NULL);
 


### PR DESCRIPTION
## Description

When a Swift P/Invoke requires marshaling (e.g. ref SwiftError), the interpreter creates an IL stub with a calli to the native function. Previously, the P/Invoke MethodDesc had no interpreter code, so INTOP_CALL fell through to InvokeManagedMethod, creating an outer native transition via InterpreterStub. The inner calli created a second transition. The inner Load_SwiftError captured x21 correctly, but ExecuteInterpretedMethod could save/restore x21 as a callee-saved register, causing the outer epilog to read a stale value.

Debug actually also had two native transitions but it just passed by coincidence because the unoptimized C compiler didn't use x21 as a scratch register, so the SwiftError value survived through ExecuteInterpretedMethod.