### PR TITLE
Adjustments to how compiler generated types are ignored.

### DIFF
--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -67,14 +67,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
                     return s.FullName;
                 }), StringComparer.Ordinal);
 
-                // Workaround for compiler injected attribute to describe the language version
-                linkedMembers.Remove("System.Void Microsoft.CodeAnalysis.EmbeddedAttribute::.ctor()");
-                linkedMembers.Remove("System.Int32 System.Runtime.CompilerServices.RefSafetyRulesAttribute::Version");
-                linkedMembers.Remove("System.Void System.Runtime.CompilerServices.RefSafetyRulesAttribute::.ctor(System.Int32)");
-
-                // Workaround for compiler injected attribute to describe the language version
-                verifiedGeneratedTypes.Add("Microsoft.CodeAnalysis.EmbeddedAttribute");
-                verifiedGeneratedTypes.Add("System.Runtime.CompilerServices.RefSafetyRulesAttribute");
+                PrepareToVerifyAssembly(originalAssembly);
 
                 var membersToAssert = originalAssembly.MainModule.Types;
                 foreach (var originalMember in membersToAssert)
@@ -102,6 +95,25 @@ namespace Mono.Linker.Tests.TestCasesRunner
                     foreach (var err in linkedMembers.Select(m => $"Member `{m}' was not expected to be kept"))
                         yield return err;
             }
+        }
+
+        /// <summary>
+        /// An opportunity to adjust what has been verified.  Helpful for dealing with polyfills or compiler generated types
+        /// </summary>
+        /// <param name="original"></param>
+        protected virtual void PrepareToVerifyAssembly(AssemblyDefinition original)
+        {
+        }
+
+        /// <summary>
+        /// The type will not be verified
+        /// </summary>
+        /// <param name="type"></param>
+        protected void IgnoreGeneratedTypeAndItsMembers(TypeDefinition type)
+        {
+            verifiedGeneratedTypes.Add(type.FullName);
+            foreach (var member in type.AllMembers())
+                linkedMembers.Remove(member.FullName);
         }
 
         static bool IsBackingField(FieldDefinition field) => field.Name.StartsWith("<") && field.Name.EndsWith(">k__BackingField");


### PR DESCRIPTION
Unity is still verifying the ILLink tests mostly pass when ran through an old version of UnityLinker that still supports .NET Framework.  We also have tests that will root types in `test.exe`.  Both of these scenarios lead to compiler generated polyfills that survive and mess up asserting.

`AssemblyChecker` had some logic to deal with compiler generated attributes.  These specific attributes no longer appear to require special handling during the illink tests so I've removed them.

In order to help Unity deal with it's tests I've exposed a new method `PrepareToVerifyAssembly` that we can hook into and do the same sort of thing that was happening  for attributes such as `EmbeddedAttribute` but also do it for other types such as `NullableAttribute`.

I've exposed a helper method `IgnoreTypeAndItsMembers` that makes it easier to ignore a type and it's members.