### PR TITLE
JIT: fix don't remove issue for loop/try split

### DIFF
--- a/src/coreclr/jit/optimizer.cpp
+++ b/src/coreclr/jit/optimizer.cpp
@@ -2683,6 +2683,11 @@ bool Compiler::optSplitHeaderIfNecessary(FlowGraphNaturalLoop* loop)
     }
     assert(outermostHBtab != nullptr);
 
+    // header is no longer a try entry, so update its flags
+    //
+    assert(!bbIsTryBeg(header));
+    header->RemoveFlags(BBF_DONT_REMOVE);
+
     // Recompute preheader placement
     //
     const unsigned enclosingTryIndex = outermostHBtab->ebdEnclosingTryIndex;


### PR DESCRIPTION
Wasm codegen is currently very sensitive to blocks that end up unreachable and also can't be removed. While we may need to tolerate this at some point, we can also see if the removal blocker is legitimate. Here's one case where it wasn't.

If we split a try entry that's also a loop header (so that the try begins inside the loop), the original block no longer needs special protection.