### PR TITLE
Refactor C# DIM resolution to match C++ structure and fix static virtual dispatch

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/DispatchResolve.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/DispatchResolve.cs
@@ -65,6 +65,14 @@ namespace System.Runtime
                 goto again;
             }
 
+            // If we haven't found an implementation, do a third pass looking for a variant default implementation.
+            if ((flags & ResolveFlags.Variant) == 0)
+            {
+                flags |= ResolveFlags.Variant;
+                pCur = pTgtType;
+                goto again;
+            }
+
             return IntPtr.Zero;
         }
 
@@ -76,8 +84,8 @@ namespace System.Runtime
                                         ushort* pImplSlotNumber,
                                         MethodTable** ppGenericContext)
         {
-            // We set this below during second pass, callers should not set this.
-            Debug.Assert((flags & ResolveFlags.Variant) == 0);
+            // We set this below during second pass for non-default interface method dispatch, callers should not set this.
+            Debug.Assert((flags & ResolveFlags.Variant) == 0 || (flags & ResolveFlags.DefaultInterfaceImplementation) != 0);
 
             bool fRes = false;
 
@@ -102,7 +110,7 @@ namespace System.Runtime
                 fRes = FindImplSlotInSimpleMap(
                     pTgtType, pItfType, itfSlotNumber, pImplSlotNumber, ppGenericContext, flags);
 
-                if (!fRes)
+                if (!fRes && (flags & ResolveFlags.DefaultInterfaceImplementation) == 0)
                 {
                     flags |= ResolveFlags.Variant; // check variance for second scan of dispatch map
                     fRes = FindImplSlotInSimpleMap(

--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -416,8 +416,6 @@ namespace ILCompiler
         {
             forceRuntimeLookup = false;
 
-            bool isStaticVirtualMethod = interfaceMethod.Signature.IsStatic;
-
             // Interface method may or may not be fully canonicalized here.
             // It would be canonical on the CoreCLR side so canonicalize here to keep the algorithms similar.
             Instantiation methodInstantiation = interfaceMethod.Instantiation;
@@ -425,7 +423,7 @@ namespace ILCompiler
 
             // Static virtual methods are resolved separately, matching the C++ early return path
             // in MethodTable::TryResolveConstraintMethodApprox.
-            if (isStaticVirtualMethod)
+            if (interfaceMethod.Signature.IsStatic)
             {
                 // ResolveVirtualStaticMethod in the C++ only resolves when the interface and method
                 // are exact (not shared by generic instantiations). For canonical forms, return null.
@@ -523,11 +521,6 @@ namespace ILCompiler
                     {
                         potentialMatchingInterfaces++;
 
-                        // The below code is just trying to prevent one of the matches from requiring boxing
-                        // It doesn't apply to static virtual methods.
-                        if (isStaticVirtualMethod)
-                            continue;
-
                         MethodDesc potentialInterfaceMethod = genInterfaceMethod;
                         if (potentialInterfaceMethod.OwningType != potentialInterfaceType)
                         {
@@ -571,20 +564,9 @@ namespace ILCompiler
                             // We can resolve to exact method
                             MethodDesc exactInterfaceMethod = context.GetMethodForInstantiatedType(
                                 genInterfaceMethod.GetTypicalMethodDefinition(), (InstantiatedType)interfaceType);
-                            if (isStaticVirtualMethod)
-                            {
-                                method = constrainedType.ResolveVariantInterfaceMethodToStaticVirtualMethodOnType(exactInterfaceMethod);
-                                if (method == null)
-                                {
-                                    staticResolution = constrainedType.ResolveVariantInterfaceMethodToDefaultImplementationOnType(exactInterfaceMethod, out method);
-                                    if (staticResolution != DefaultInterfaceMethodResolution.DefaultImplementation)
-                                        method = null;
-                                }
-                            }
-                            else
-                            {
-                                method = constrainedType.ResolveVariantInterfaceMethodToVirtualMethodOnType(exactInterfaceMethod);
-                            }
+
+                            method = constrainedType.ResolveVariantInterfaceMethodToVirtualMethodOnType(exactInterfaceMethod);
+
                             isExactMethodResolved = method != null;
                         }
                     }
@@ -607,20 +589,8 @@ namespace ILCompiler
                         if (genInterfaceMethod.OwningType != interfaceType)
                             exactInterfaceMethod = context.GetMethodForInstantiatedType(
                                 genInterfaceMethod.GetTypicalMethodDefinition(), (InstantiatedType)interfaceType);
-                        if (isStaticVirtualMethod)
-                        {
-                            method = constrainedType.ResolveVariantInterfaceMethodToStaticVirtualMethodOnType(exactInterfaceMethod);
-                            if (method == null)
-                            {
-                                staticResolution = constrainedType.ResolveVariantInterfaceMethodToDefaultImplementationOnType(exactInterfaceMethod, out method);
-                                if (staticResolution != DefaultInterfaceMethodResolution.DefaultImplementation)
-                                    method = null;
-                            }
-                        }
-                        else
-                        {
-                            method = constrainedType.ResolveVariantInterfaceMethodToVirtualMethodOnType(exactInterfaceMethod);
-                        }
+
+                        method = constrainedType.ResolveVariantInterfaceMethodToVirtualMethodOnType(exactInterfaceMethod);
                     }
                 }
             }
@@ -645,7 +615,7 @@ namespace ILCompiler
             //#TryResolveConstraintMethodApprox_DoNotReturnParentMethod
             // Only return a method if the value type itself declares the method,
             // otherwise we might get a method from Object or System.ValueType
-            if (!isStaticVirtualMethod && !method.OwningType.IsValueType)
+            if (!method.OwningType.IsValueType)
             {
                 // Fall back to VSD
                 return null;

--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -418,13 +418,6 @@ namespace ILCompiler
 
             bool isStaticVirtualMethod = interfaceMethod.Signature.IsStatic;
 
-            // We can't resolve constraint calls effectively for reference types, and there's
-            // not a lot of perf. benefit in doing it anyway.
-            if (!constrainedType.IsValueType && (!isStaticVirtualMethod || constrainedType.IsCanonicalDefinitionType(CanonicalFormKind.Any)))
-            {
-                return null;
-            }
-
             // Interface method may or may not be fully canonicalized here.
             // It would be canonical on the CoreCLR side so canonicalize here to keep the algorithms similar.
             Instantiation methodInstantiation = interfaceMethod.Instantiation;
@@ -494,6 +487,13 @@ namespace ILCompiler
                     result = result.MakeInstantiatedMethod(methodInstantiation);
 
                 return result;
+            }
+
+            // We can't resolve constraint calls effectively for reference types, and there's
+            // not a lot of perf. benefit in doing it anyway.
+            if (!constrainedType.IsValueType)
+            {
+                return null;
             }
 
             // 1. Find the (possibly generic) method that would implement the

--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -430,6 +430,59 @@ namespace ILCompiler
             Instantiation methodInstantiation = interfaceMethod.Instantiation;
             interfaceMethod = interfaceMethod.GetCanonMethodTarget(CanonicalFormKind.Specific);
 
+            // Static virtual methods are resolved separately, matching the C++ early return path
+            // in MethodTable::TryResolveConstraintMethodApprox.
+            if (isStaticVirtualMethod)
+            {
+                // ResolveVirtualStaticMethod in the C++ only resolves when the interface and method
+                // are exact (not shared by generic instantiations). For canonical forms, return null.
+                // Note: interfaceMethod was canonicalized above so its instantiation may contain
+                // __Canon even when the original was exact. Check methodInstantiation (saved before
+                // canonicalization) to match the C++ IsSharedByGenericMethodInstantiations check.
+                // We additionally check the constrained type, because the ILC scanner cannot handle
+                // resolved static virtual methods in shared generic code.
+                bool methodHasCanonInstantiation = false;
+                foreach (TypeDesc arg in methodInstantiation)
+                {
+                    if (arg.IsCanonicalSubtype(CanonicalFormKind.Any))
+                    {
+                        methodHasCanonInstantiation = true;
+                        break;
+                    }
+                }
+
+                if (methodHasCanonInstantiation ||
+                    interfaceType.IsCanonicalSubtype(CanonicalFormKind.Any) ||
+                    constrainedType.IsCanonicalSubtype(CanonicalFormKind.Any))
+                {
+                    return null;
+                }
+
+                MethodDesc staticMethodDef = interfaceMethod.GetMethodDefinition();
+                MethodDesc exactInterfaceMethod = staticMethodDef;
+                if (staticMethodDef.OwningType != interfaceType)
+                    exactInterfaceMethod = constrainedType.Context.GetMethodForInstantiatedType(
+                        staticMethodDef.GetTypicalMethodDefinition(), (InstantiatedType)interfaceType);
+
+                MethodDesc result = constrainedType.ResolveVariantInterfaceMethodToStaticVirtualMethodOnType(exactInterfaceMethod);
+                if (result is null)
+                {
+                    staticResolution = constrainedType.ResolveVariantInterfaceMethodToDefaultImplementationOnType(exactInterfaceMethod, out result);
+                    if (staticResolution != DefaultInterfaceMethodResolution.DefaultImplementation)
+                        result = null;
+                }
+
+                if (result is null)
+                {
+                    return null;
+                }
+
+                if (methodInstantiation.Length != 0)
+                    result = result.MakeInstantiatedMethod(methodInstantiation);
+
+                return result;
+            }
+
             // 1. Find the (possibly generic) method that would implement the
             // constraint if we were making a call on a boxed value type.
 

--- a/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
+++ b/src/coreclr/tools/Common/Compiler/TypeExtensions.cs
@@ -439,8 +439,6 @@ namespace ILCompiler
                 // Note: interfaceMethod was canonicalized above so its instantiation may contain
                 // __Canon even when the original was exact. Check methodInstantiation (saved before
                 // canonicalization) to match the C++ IsSharedByGenericMethodInstantiations check.
-                // We additionally check the constrained type, because the ILC scanner cannot handle
-                // resolved static virtual methods in shared generic code.
                 bool methodHasCanonInstantiation = false;
                 foreach (TypeDesc arg in methodInstantiation)
                 {
@@ -452,10 +450,25 @@ namespace ILCompiler
                 }
 
                 if (methodHasCanonInstantiation ||
-                    interfaceType.IsCanonicalSubtype(CanonicalFormKind.Any) ||
-                    constrainedType.IsCanonicalSubtype(CanonicalFormKind.Any))
+                    interfaceType.IsCanonicalSubtype(CanonicalFormKind.Any))
                 {
                     return null;
+                }
+
+                // Check that there is no implementation of the interface on this type which is the canonical interface for a shared generic. If so, that indicates that
+                // we cannot exactly compute a target method result, as even if there is an exact match in the type hierarchy
+                // it isn't guaranteed that we will always find the right result, as we may find a match on a base type when we should find the match
+                // on a more derived type.
+                TypeDesc interfaceTypeCanonical = interfaceType.ConvertToCanonForm(CanonicalFormKind.Specific);
+                if (interfaceType != interfaceTypeCanonical)
+                {
+                    foreach (DefType runtimeIface in constrainedType.RuntimeInterfaces)
+                    {
+                        if (runtimeIface == interfaceTypeCanonical)
+                        {
+                            return null;
+                        }
+                    }
                 }
 
                 MethodDesc staticMethodDef = interfaceMethod.GetMethodDefinition();

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -854,31 +854,31 @@ namespace Internal.TypeSystem
         }
 
         private static bool TryGetCandidateImplementation(
-            MetadataType runtimeInterface,
+            MetadataType currentMT,
             MethodDesc interfaceMethod,
-            TypeDesc interfaceMethodOwningType,
+            TypeDesc interfaceMT,
             bool allowVariance,
-            out MethodDesc candidateMethod)
+            out MethodDesc candidateMD)
         {
-            candidateMethod = null;
+            candidateMD = null;
             MethodDesc interfaceMethodDefinition = interfaceMethod.GetMethodDefinition();
 
-            if (runtimeInterface == interfaceMethodOwningType)
+            if (currentMT == interfaceMT)
             {
                 // exact match
                 if (!interfaceMethod.IsAbstract)
                 {
-                    candidateMethod = interfaceMethodDefinition;
+                    candidateMD = interfaceMethodDefinition;
                 }
             }
-            else if (runtimeInterface.CanCastTo(interfaceMethodOwningType))
+            else if (currentMT.CanCastTo(interfaceMT))
             {
-                if (runtimeInterface.HasSameTypeDefinition(interfaceMethodOwningType))
+                if (currentMT.HasSameTypeDefinition(interfaceMT))
                 {
                     // Generic variance match - we'll instantiate pCurMD with the right type arguments later
                     if (allowVariance && !interfaceMethod.IsAbstract)
                     {
-                        candidateMethod = runtimeInterface.FindMethodOnTypeWithMatchingTypicalMethod(interfaceMethodDefinition);
+                        candidateMD = currentMT.FindMethodOnTypeWithMatchingTypicalMethod(interfaceMethodDefinition);
                     }
                 }
                 else
@@ -887,7 +887,7 @@ namespace Internal.TypeSystem
                     // A more specific interface - search for an methodimpl for explicit override
                     // Implicit override in default interface methods are not allowed
                     //
-                    MethodImplRecord[] possibleImpls = runtimeInterface.FindMethodsImplWithMatchingDeclName(interfaceMethod.Name);
+                    MethodImplRecord[] possibleImpls = currentMT.FindMethodsImplWithMatchingDeclName(interfaceMethod.Name);
                     if (possibleImpls != null)
                     {
                         foreach (MethodImplRecord implRecord in possibleImpls)
@@ -898,11 +898,11 @@ namespace Internal.TypeSystem
                             // We do CanCastTo to also cover variance.
                             // We already know this is a method on the same type definition as the (generic)
                             // interface but we need to make sure the instantiations match.
-                            if (!interfaceMethodOwningType.HasInstantiation
-                                || implRecord.Decl.OwningType == interfaceMethodOwningType
-                                || (allowVariance && implRecord.Decl.OwningType.CanCastTo(interfaceMethodOwningType)))
+                            if (!interfaceMT.HasInstantiation
+                                || implRecord.Decl.OwningType == interfaceMT
+                                || (allowVariance && implRecord.Decl.OwningType.CanCastTo(interfaceMT)))
                             {
-                                candidateMethod = implRecord.Body;
+                                candidateMD = implRecord.Body;
                                 break;
                             }
                         }
@@ -910,7 +910,7 @@ namespace Internal.TypeSystem
                 }
             }
 
-            return candidateMethod is not null;
+            return candidateMD is not null;
         }
 
         // Find the default interface implementation method for interface dispatch
@@ -922,7 +922,7 @@ namespace Internal.TypeSystem
             bool allowVariance,
             out MethodDesc impl)
         {
-            TypeDesc interfaceMethodOwningType = interfaceMethod.OwningType;
+            TypeDesc interfaceMT = interfaceMethod.OwningType;
             MethodDesc interfaceMethodDefinition = interfaceMethod.GetMethodDefinition();
             impl = null;
 
@@ -938,15 +938,13 @@ namespace Internal.TypeSystem
                 consideredInterfaces[consideredInterfaces.Length - 1] = currentType.IsGenericDefinition ? (DefType)currentType.InstantiateAsOpen() : currentType;
             }
 
-            // We need to maintain the invariant that the candidates are always the most specific
-            // in all path scaned so far. There might be multiple incompatible candidates
             MetadataType[] candidateInterfaces = new MetadataType[consideredInterfaces.Length];
             MethodDesc[] candidateMethods = new MethodDesc[consideredInterfaces.Length];
             int candidatesCount = 0;
 
-            foreach (MetadataType runtimeInterface in consideredInterfaces)
+            foreach (MetadataType currentMT in consideredInterfaces)
             {
-                if (!TryGetCandidateImplementation(runtimeInterface, interfaceMethod, interfaceMethodOwningType, allowVariance, out MethodDesc candidateMethod))
+                if (!TryGetCandidateImplementation(currentMT, interfaceMethod, interfaceMT, allowVariance, out MethodDesc currentMD))
                     continue;
 
                 //
@@ -955,31 +953,33 @@ namespace Internal.TypeSystem
                 bool needToInsert = true;
                 bool seenMoreSpecific = false;
 
+                // We need to maintain the invariant that the candidates are always the most specific
+                // in all path scaned so far. There might be multiple incompatible candidates
                 for (int i = 0; i < candidatesCount; i++)
                 {
                     MetadataType candidateMT = candidateInterfaces[i];
                     if (candidateMT is null)
                         continue;
 
-                    if (candidateMT == runtimeInterface)
+                    if (candidateMT == currentMT)
                     {
                         // A dup - we are done
                         needToInsert = false;
                         break;
                     }
 
-                    if (allowVariance && candidateMT.HasSameTypeDefinition(runtimeInterface))
+                    if (allowVariance && candidateMT.HasSameTypeDefinition(currentMT))
                     {
                         // Variant match on the same type - this is a tie
                     }
-                    else if (runtimeInterface.CanCastTo(candidateMT))
+                    else if (currentMT.CanCastTo(candidateMT))
                     {
                         // pCurMT is a more specific choice than IFoo/IBar both overrides IBlah :
                         if (!seenMoreSpecific)
                         {
                             seenMoreSpecific = true;
-                            candidateInterfaces[i] = runtimeInterface;
-                            candidateMethods[i] = candidateMethod;
+                            candidateInterfaces[i] = currentMT;
+                            candidateMethods[i] = currentMD;
                         }
                         else
                         {
@@ -988,7 +988,7 @@ namespace Internal.TypeSystem
                         }
                         needToInsert = false;
                     }
-                    else if (candidateMT.CanCastTo(runtimeInterface))
+                    else if (candidateMT.CanCastTo(currentMT))
                     {
                         // pCurMT is less specific - we don't need to scan more entries as this entry can
                         // represent pCurMT (other entries are incompatible with pCurMT)
@@ -1004,8 +1004,8 @@ namespace Internal.TypeSystem
                 if (needToInsert)
                 {
                     Debug.Assert(candidatesCount < candidateInterfaces.Length);
-                    candidateInterfaces[candidatesCount] = runtimeInterface;
-                    candidateMethods[candidatesCount] = candidateMethod;
+                    candidateInterfaces[candidatesCount] = currentMT;
+                    candidateMethods[candidatesCount] = currentMD;
                     candidatesCount++;
                 }
             }
@@ -1013,40 +1013,40 @@ namespace Internal.TypeSystem
             // scan to see if there are any conflicts
             // If we are doing second pass (allowing variance), we know don't actually look for
             // a conflict anymore, but pick the first match.
-            MetadataType bestCandidateInterface = null;
-            MethodDesc bestCandidateMethod = null;
+            MetadataType bestCandidateMT = null;
+            MethodDesc bestCandidateMD = null;
             for (int i = 0; i < candidatesCount; i++)
             {
                 if (candidateInterfaces[i] is null)
                     continue;
 
-                if (bestCandidateInterface is null)
+                if (bestCandidateMT is null)
                 {
-                    bestCandidateInterface = candidateInterfaces[i];
-                    bestCandidateMethod = candidateMethods[i];
+                    bestCandidateMT = candidateInterfaces[i];
+                    bestCandidateMD = candidateMethods[i];
 
                     // If this is a second pass lookup, we know this is a variant match. As such
                     // we pick the first result as the winner and don't look for a conflict for instance methods.
                     if (allowVariance && !interfaceMethod.Signature.IsStatic)
                         break;
                 }
-                else if (bestCandidateInterface != candidateInterfaces[i])
+                else if (bestCandidateMT != candidateInterfaces[i])
                 {
                     return DefaultInterfaceMethodResolution.Diamond;
                 }
             }
 
-            if (bestCandidateMethod is null)
+            if (bestCandidateMD is null)
             {
                 return DefaultInterfaceMethodResolution.None;
             }
 
-            if (bestCandidateMethod.IsAbstract)
+            if (bestCandidateMD.IsAbstract)
             {
                 return DefaultInterfaceMethodResolution.Reabstraction;
             }
 
-            impl = bestCandidateMethod;
+            impl = bestCandidateMD;
             if (interfaceMethod != interfaceMethodDefinition)
                 impl = impl.MakeInstantiatedMethod(interfaceMethod.Instantiation);
 

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -850,6 +850,10 @@ namespace Internal.TypeSystem
 
         public static DefaultInterfaceMethodResolution ResolveVariantInterfaceMethodToDefaultImplementationOnType(MethodDesc interfaceMethod, MetadataType currentType, out MethodDesc impl)
         {
+            DefaultInterfaceMethodResolution resolution = FindDefaultInterfaceImplementation(interfaceMethod, currentType, allowVariance: false, out impl);
+            if (resolution != DefaultInterfaceMethodResolution.None)
+                return resolution;
+
             return FindDefaultInterfaceImplementation(interfaceMethod, currentType, allowVariance: true, out impl);
         }
 
@@ -942,72 +946,90 @@ namespace Internal.TypeSystem
             MethodDesc[] candidateMethods = new MethodDesc[consideredInterfaces.Length];
             int candidatesCount = 0;
 
-            foreach (MetadataType currentMT in consideredInterfaces)
+            // Walk interface from derived class to parent class
+            // (parent interface are laid out first in interface map)
+            MetadataType pMT = currentType;
+
+            while (pMT != null)
             {
-                if (!TryGetCandidateImplementation(currentMT, interfaceMethod, interfaceMT, allowVariance, out MethodDesc currentMD))
-                    continue;
+                MetadataType pParentMT = pMT.BaseType;
+                int dwParentInterfaces = pParentMT != null ? pParentMT.RuntimeInterfaces.Length : 0;
 
-                //
-                // Found a match. But is it a more specific match (we want most specific interfaces)
-                //
-                bool needToInsert = true;
-                bool seenMoreSpecific = false;
+                // Scanning only current class only if the current class have more interface than parent
+                int totalInterfaces = currentType.IsInterface && pMT == currentType
+                    ? consideredInterfaces.Length
+                    : pMT.RuntimeInterfaces.Length;
 
-                // We need to maintain the invariant that the candidates are always the most specific
-                // in all path scaned so far. There might be multiple incompatible candidates
-                for (int i = 0; i < candidatesCount; i++)
+                for (int index = dwParentInterfaces; index < totalInterfaces; index++)
                 {
-                    MetadataType candidateMT = candidateInterfaces[i];
-                    if (candidateMT is null)
+                    MetadataType currentMT = (MetadataType)consideredInterfaces[index];
+                    if (!TryGetCandidateImplementation(currentMT, interfaceMethod, interfaceMT, allowVariance, out MethodDesc currentMD))
                         continue;
 
-                    if (candidateMT == currentMT)
-                    {
-                        // A dup - we are done
-                        needToInsert = false;
-                        break;
-                    }
+                    //
+                    // Found a match. But is it a more specific match (we want most specific interfaces)
+                    //
+                    bool needToInsert = true;
+                    bool seenMoreSpecific = false;
 
-                    if (allowVariance && candidateMT.HasSameTypeDefinition(currentMT))
+                    // We need to maintain the invariant that the candidates are always the most specific
+                    // in all path scaned so far. There might be multiple incompatible candidates
+                    for (int i = 0; i < candidatesCount; i++)
                     {
-                        // Variant match on the same type - this is a tie
-                    }
-                    else if (currentMT.CanCastTo(candidateMT))
-                    {
-                        // pCurMT is a more specific choice than IFoo/IBar both overrides IBlah :
-                        if (!seenMoreSpecific)
+                        MetadataType candidateMT = candidateInterfaces[i];
+                        if (candidateMT is null)
+                            continue;
+
+                        if (candidateMT == currentMT)
                         {
-                            seenMoreSpecific = true;
-                            candidateInterfaces[i] = currentMT;
-                            candidateMethods[i] = currentMD;
+                            // A dup - we are done
+                            needToInsert = false;
+                            break;
+                        }
+
+                        if (allowVariance && candidateMT.HasSameTypeDefinition(currentMT))
+                        {
+                            // Variant match on the same type - this is a tie
+                        }
+                        else if (currentMT.CanCastTo(candidateMT))
+                        {
+                            // pCurMT is a more specific choice than IFoo/IBar both overrides IBlah :
+                            if (!seenMoreSpecific)
+                            {
+                                seenMoreSpecific = true;
+                                candidateInterfaces[i] = currentMT;
+                                candidateMethods[i] = currentMD;
+                            }
+                            else
+                            {
+                                candidateInterfaces[i] = null;
+                                candidateMethods[i] = null;
+                            }
+                            needToInsert = false;
+                        }
+                        else if (candidateMT.CanCastTo(currentMT))
+                        {
+                            // pCurMT is less specific - we don't need to scan more entries as this entry can
+                            // represent pCurMT (other entries are incompatible with pCurMT)
+                            needToInsert = false;
+                            break;
                         }
                         else
                         {
-                            candidateInterfaces[i] = null;
-                            candidateMethods[i] = null;
+                            // pCurMT is incompatible - keep scanning
                         }
-                        needToInsert = false;
                     }
-                    else if (candidateMT.CanCastTo(currentMT))
+
+                    if (needToInsert)
                     {
-                        // pCurMT is less specific - we don't need to scan more entries as this entry can
-                        // represent pCurMT (other entries are incompatible with pCurMT)
-                        needToInsert = false;
-                        break;
-                    }
-                    else
-                    {
-                        // pCurMT is incompatible - keep scanning
+                        Debug.Assert(candidatesCount < candidateInterfaces.Length);
+                        candidateInterfaces[candidatesCount] = currentMT;
+                        candidateMethods[candidatesCount] = currentMD;
+                        candidatesCount++;
                     }
                 }
 
-                if (needToInsert)
-                {
-                    Debug.Assert(candidatesCount < candidateInterfaces.Length);
-                    candidateInterfaces[candidatesCount] = currentMT;
-                    candidateMethods[candidatesCount] = currentMD;
-                    candidatesCount++;
-                }
+                pMT = pParentMT;
             }
 
             // scan to see if there are any conflicts
@@ -1026,8 +1048,8 @@ namespace Internal.TypeSystem
                     bestCandidateMD = candidateMethods[i];
 
                     // If this is a second pass lookup, we know this is a variant match. As such
-                    // we pick the first result as the winner and don't look for a conflict for instance methods.
-                    if (allowVariance && !interfaceMethod.Signature.IsStatic)
+                    // we pick the first result as the winner
+                    if (allowVariance)
                         break;
                 }
                 else if (bestCandidateMT != candidateInterfaces[i])

--- a/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
+++ b/src/coreclr/tools/Common/TypeSystem/Common/MetadataVirtualMethodAlgorithm.cs
@@ -840,93 +840,7 @@ namespace Internal.TypeSystem
 
         public override DefaultInterfaceMethodResolution ResolveInterfaceMethodToDefaultImplementationOnType(MethodDesc interfaceMethod, TypeDesc currentType, out MethodDesc impl)
         {
-            return ResolveInterfaceMethodToDefaultImplementationOnType(interfaceMethod, (MetadataType)currentType, out impl);
-        }
-
-        private static DefaultInterfaceMethodResolution ResolveInterfaceMethodToDefaultImplementationOnType(MethodDesc interfaceMethod, MetadataType currentType, out MethodDesc impl)
-        {
-            TypeDesc interfaceMethodOwningType = interfaceMethod.OwningType;
-            MetadataType mostSpecificInterface = null;
-            bool diamondCase = false;
-            impl = null;
-
-            MethodDesc interfaceMethodDefinition = interfaceMethod.GetMethodDefinition();
-            DefType[] consideredInterfaces;
-            if (!currentType.IsInterface)
-            {
-                // If this is not an interface, only things on the interface list could provide
-                // default implementations.
-                consideredInterfaces = currentType.RuntimeInterfaces;
-            }
-            else
-            {
-                // If we're asking about an interface, include the interface in the list.
-                consideredInterfaces = new DefType[currentType.RuntimeInterfaces.Length + 1];
-                Array.Copy(currentType.RuntimeInterfaces, consideredInterfaces, currentType.RuntimeInterfaces.Length);
-                consideredInterfaces[consideredInterfaces.Length - 1] = currentType.IsGenericDefinition ? (DefType)currentType.InstantiateAsOpen() : currentType;
-            }
-
-            foreach (MetadataType runtimeInterface in consideredInterfaces)
-            {
-                if (runtimeInterface == interfaceMethodOwningType)
-                {
-                    // Also consider the default interface method implementation on the interface itself
-                    // if we don't have anything else yet
-                    if (mostSpecificInterface == null && !interfaceMethod.IsAbstract)
-                    {
-                        mostSpecificInterface = runtimeInterface;
-                        impl = interfaceMethodDefinition;
-                    }
-                }
-                else if (Array.IndexOf(runtimeInterface.RuntimeInterfaces, interfaceMethodOwningType) >= 0)
-                {
-                    // This interface might provide a default implementation
-                    MethodImplRecord[] possibleImpls = runtimeInterface.FindMethodsImplWithMatchingDeclName(interfaceMethod.Name);
-                    if (possibleImpls != null)
-                    {
-                        foreach (MethodImplRecord implRecord in possibleImpls)
-                        {
-                            if (implRecord.Decl == interfaceMethodDefinition)
-                            {
-                                // This interface provides a default implementation.
-                                // Is it also most specific?
-                                if (mostSpecificInterface == null || Array.IndexOf(runtimeInterface.RuntimeInterfaces, mostSpecificInterface) >= 0)
-                                {
-                                    mostSpecificInterface = runtimeInterface;
-                                    impl = implRecord.Body;
-                                    diamondCase = false;
-                                }
-                                else if (Array.IndexOf(mostSpecificInterface.RuntimeInterfaces, runtimeInterface) < 0)
-                                {
-                                    diamondCase = true;
-                                }
-
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (diamondCase)
-            {
-                impl = null;
-                return DefaultInterfaceMethodResolution.Diamond;
-            }
-            else if (impl == null)
-            {
-                return DefaultInterfaceMethodResolution.None;
-            }
-            else if (impl.IsAbstract)
-            {
-                impl = null;
-                return DefaultInterfaceMethodResolution.Reabstraction;
-            }
-
-            if (interfaceMethod != interfaceMethodDefinition)
-                impl = impl.MakeInstantiatedMethod(interfaceMethod.Instantiation);
-
-            return DefaultInterfaceMethodResolution.DefaultImplementation;
+            return FindDefaultInterfaceImplementation(interfaceMethod, (MetadataType)currentType, allowVariance: false, out impl);
         }
 
         public override DefaultInterfaceMethodResolution ResolveVariantInterfaceMethodToDefaultImplementationOnType(MethodDesc interfaceMethod, TypeDesc currentType, out MethodDesc impl)
@@ -936,33 +850,207 @@ namespace Internal.TypeSystem
 
         public static DefaultInterfaceMethodResolution ResolveVariantInterfaceMethodToDefaultImplementationOnType(MethodDesc interfaceMethod, MetadataType currentType, out MethodDesc impl)
         {
-            MetadataType interfaceType = (MetadataType)interfaceMethod.OwningType;
-            bool foundInterface = IsInterfaceImplementedOnType(currentType, interfaceType);
+            return FindDefaultInterfaceImplementation(interfaceMethod, currentType, allowVariance: true, out impl);
+        }
 
-            if (foundInterface)
-            {
-                DefaultInterfaceMethodResolution resolution = ResolveInterfaceMethodToDefaultImplementationOnType(interfaceMethod, currentType, out impl);
-                if (resolution != DefaultInterfaceMethodResolution.None)
-                    return resolution;
-            }
-
+        private static bool TryGetCandidateImplementation(
+            MetadataType runtimeInterface,
+            MethodDesc interfaceMethod,
+            TypeDesc interfaceMethodOwningType,
+            bool allowVariance,
+            out MethodDesc candidateMethod)
+        {
+            candidateMethod = null;
             MethodDesc interfaceMethodDefinition = interfaceMethod.GetMethodDefinition();
-            foreach (TypeDesc iface in currentType.RuntimeInterfaces)
+
+            if (runtimeInterface == interfaceMethodOwningType)
             {
-                if (iface.HasSameTypeDefinition(interfaceType) && iface.CanCastTo(interfaceType))
+                // exact match
+                if (!interfaceMethod.IsAbstract)
                 {
-                    MethodDesc variantMethod = iface.FindMethodOnTypeWithMatchingTypicalMethod(interfaceMethodDefinition);
-                    Debug.Assert(variantMethod != null);
-                    if (interfaceMethod != interfaceMethodDefinition)
-                        variantMethod = variantMethod.MakeInstantiatedMethod(interfaceMethod.Instantiation);
-                    DefaultInterfaceMethodResolution resolution = ResolveInterfaceMethodToDefaultImplementationOnType(variantMethod, currentType, out impl);
-                    if (resolution != DefaultInterfaceMethodResolution.None)
-                        return resolution;
+                    candidateMethod = interfaceMethodDefinition;
+                }
+            }
+            else if (runtimeInterface.CanCastTo(interfaceMethodOwningType))
+            {
+                if (runtimeInterface.HasSameTypeDefinition(interfaceMethodOwningType))
+                {
+                    // Generic variance match - we'll instantiate pCurMD with the right type arguments later
+                    if (allowVariance && !interfaceMethod.IsAbstract)
+                    {
+                        candidateMethod = runtimeInterface.FindMethodOnTypeWithMatchingTypicalMethod(interfaceMethodDefinition);
+                    }
+                }
+                else
+                {
+                    //
+                    // A more specific interface - search for an methodimpl for explicit override
+                    // Implicit override in default interface methods are not allowed
+                    //
+                    MethodImplRecord[] possibleImpls = runtimeInterface.FindMethodsImplWithMatchingDeclName(interfaceMethod.Name);
+                    if (possibleImpls != null)
+                    {
+                        foreach (MethodImplRecord implRecord in possibleImpls)
+                        {
+                            if (implRecord.Decl.GetTypicalMethodDefinition() != interfaceMethodDefinition.GetTypicalMethodDefinition())
+                                continue;
+
+                            // We do CanCastTo to also cover variance.
+                            // We already know this is a method on the same type definition as the (generic)
+                            // interface but we need to make sure the instantiations match.
+                            if (!interfaceMethodOwningType.HasInstantiation
+                                || implRecord.Decl.OwningType == interfaceMethodOwningType
+                                || (allowVariance && implRecord.Decl.OwningType.CanCastTo(interfaceMethodOwningType)))
+                            {
+                                candidateMethod = implRecord.Body;
+                                break;
+                            }
+                        }
+                    }
                 }
             }
 
+            return candidateMethod is not null;
+        }
+
+        // Find the default interface implementation method for interface dispatch
+        // It is either the interface method with default interface method implementation,
+        // or an most specific interface with an explicit methodimpl overriding the method
+        private static DefaultInterfaceMethodResolution FindDefaultInterfaceImplementation(
+            MethodDesc interfaceMethod,
+            MetadataType currentType,
+            bool allowVariance,
+            out MethodDesc impl)
+        {
+            TypeDesc interfaceMethodOwningType = interfaceMethod.OwningType;
+            MethodDesc interfaceMethodDefinition = interfaceMethod.GetMethodDefinition();
             impl = null;
-            return DefaultInterfaceMethodResolution.None;
+
+            DefType[] consideredInterfaces;
+            if (!currentType.IsInterface)
+            {
+                consideredInterfaces = currentType.RuntimeInterfaces;
+            }
+            else
+            {
+                consideredInterfaces = new DefType[currentType.RuntimeInterfaces.Length + 1];
+                Array.Copy(currentType.RuntimeInterfaces, consideredInterfaces, currentType.RuntimeInterfaces.Length);
+                consideredInterfaces[consideredInterfaces.Length - 1] = currentType.IsGenericDefinition ? (DefType)currentType.InstantiateAsOpen() : currentType;
+            }
+
+            // We need to maintain the invariant that the candidates are always the most specific
+            // in all path scaned so far. There might be multiple incompatible candidates
+            MetadataType[] candidateInterfaces = new MetadataType[consideredInterfaces.Length];
+            MethodDesc[] candidateMethods = new MethodDesc[consideredInterfaces.Length];
+            int candidatesCount = 0;
+
+            foreach (MetadataType runtimeInterface in consideredInterfaces)
+            {
+                if (!TryGetCandidateImplementation(runtimeInterface, interfaceMethod, interfaceMethodOwningType, allowVariance, out MethodDesc candidateMethod))
+                    continue;
+
+                //
+                // Found a match. But is it a more specific match (we want most specific interfaces)
+                //
+                bool needToInsert = true;
+                bool seenMoreSpecific = false;
+
+                for (int i = 0; i < candidatesCount; i++)
+                {
+                    MetadataType candidateMT = candidateInterfaces[i];
+                    if (candidateMT is null)
+                        continue;
+
+                    if (candidateMT == runtimeInterface)
+                    {
+                        // A dup - we are done
+                        needToInsert = false;
+                        break;
+                    }
+
+                    if (allowVariance && candidateMT.HasSameTypeDefinition(runtimeInterface))
+                    {
+                        // Variant match on the same type - this is a tie
+                    }
+                    else if (runtimeInterface.CanCastTo(candidateMT))
+                    {
+                        // pCurMT is a more specific choice than IFoo/IBar both overrides IBlah :
+                        if (!seenMoreSpecific)
+                        {
+                            seenMoreSpecific = true;
+                            candidateInterfaces[i] = runtimeInterface;
+                            candidateMethods[i] = candidateMethod;
+                        }
+                        else
+                        {
+                            candidateInterfaces[i] = null;
+                            candidateMethods[i] = null;
+                        }
+                        needToInsert = false;
+                    }
+                    else if (candidateMT.CanCastTo(runtimeInterface))
+                    {
+                        // pCurMT is less specific - we don't need to scan more entries as this entry can
+                        // represent pCurMT (other entries are incompatible with pCurMT)
+                        needToInsert = false;
+                        break;
+                    }
+                    else
+                    {
+                        // pCurMT is incompatible - keep scanning
+                    }
+                }
+
+                if (needToInsert)
+                {
+                    Debug.Assert(candidatesCount < candidateInterfaces.Length);
+                    candidateInterfaces[candidatesCount] = runtimeInterface;
+                    candidateMethods[candidatesCount] = candidateMethod;
+                    candidatesCount++;
+                }
+            }
+
+            // scan to see if there are any conflicts
+            // If we are doing second pass (allowing variance), we know don't actually look for
+            // a conflict anymore, but pick the first match.
+            MetadataType bestCandidateInterface = null;
+            MethodDesc bestCandidateMethod = null;
+            for (int i = 0; i < candidatesCount; i++)
+            {
+                if (candidateInterfaces[i] is null)
+                    continue;
+
+                if (bestCandidateInterface is null)
+                {
+                    bestCandidateInterface = candidateInterfaces[i];
+                    bestCandidateMethod = candidateMethods[i];
+
+                    // If this is a second pass lookup, we know this is a variant match. As such
+                    // we pick the first result as the winner and don't look for a conflict for instance methods.
+                    if (allowVariance && !interfaceMethod.Signature.IsStatic)
+                        break;
+                }
+                else if (bestCandidateInterface != candidateInterfaces[i])
+                {
+                    return DefaultInterfaceMethodResolution.Diamond;
+                }
+            }
+
+            if (bestCandidateMethod is null)
+            {
+                return DefaultInterfaceMethodResolution.None;
+            }
+
+            if (bestCandidateMethod.IsAbstract)
+            {
+                return DefaultInterfaceMethodResolution.Reabstraction;
+            }
+
+            impl = bestCandidateMethod;
+            if (interfaceMethod != interfaceMethodDefinition)
+                impl = impl.MakeInstantiatedMethod(interfaceMethod.Instantiation);
+
+            return DefaultInterfaceMethodResolution.DefaultImplementation;
         }
 
         public override IEnumerable<MethodDesc> ComputeAllVirtualSlots(TypeDesc type)

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/GenericLookupResult.cs
@@ -1069,7 +1069,7 @@ namespace ILCompiler.DependencyAnalysis
 
             // If we're producing a full vtable for the type, we don't need to report virtual method use.
             // We also don't report virtual method use for generic virtual methods - tracking those is orthogonal.
-            if (!factory.VTable(canonMethod.OwningType).HasKnownVirtualMethodUse && !canonMethod.HasInstantiation)
+            if (!canonMethod.HasInstantiation && !factory.VTable(canonMethod.OwningType).HasKnownVirtualMethodUse)
             {
                 // Report the method as virtually used so that types that could be used here at runtime
                 // have the appropriate implementations generated.

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/DependencyAnalysis/InterfaceDispatchMapNode.cs
@@ -140,6 +140,7 @@ namespace ILCompiler.DependencyAnalysis
 
             DefType declType = _type.GetClosestDefType();
             TypeDesc declTypeDefinition = declType.GetTypeDefinition();
+            TypeDesc declTypeBaseDefinition = declTypeDefinition.BaseType?.GetTypeDefinition();
             DefType[] declTypeRuntimeInterfaces = declType.RuntimeInterfaces;
             DefType[] declTypeDefinitionRuntimeInterfaces = declTypeDefinition.RuntimeInterfaces;
 
@@ -226,6 +227,13 @@ namespace ILCompiler.DependencyAnalysis
                         int? implSlot = null;
 
                         DefaultInterfaceMethodResolution result = declTypeDefinition.ResolveInterfaceMethodToDefaultImplementationOnType(declMethod, out implMethod);
+                        if (result != DefaultInterfaceMethodResolution.None && declTypeBaseDefinition != null)
+                        {
+                            DefaultInterfaceMethodResolution baseResult = declTypeBaseDefinition.ResolveInterfaceMethodToDefaultImplementationOnType(declMethod, out MethodDesc baseImplMethod);
+                            if (baseResult == result && implMethod == baseImplMethod)
+                                result = DefaultInterfaceMethodResolution.None;
+                        }
+
                         DefType providingInterfaceDefinitionType = null;
                         if (result == DefaultInterfaceMethodResolution.DefaultImplementation)
                         {

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/ILImporter.Scanner.cs
@@ -737,8 +737,7 @@ namespace Internal.IL
                 else
                 {
                     // We have the canonical version of the method - find the runtime determined version.
-                    // This is simplified because we know the method is on a valuetype.
-                    Debug.Assert(targetMethod.OwningType.IsValueType);
+                    Debug.Assert(targetMethod.OwningType.IsValueType || targetMethod.Signature.IsStatic);
 
                     MethodDesc targetOfLookup;
                     if (_constrained.IsRuntimeDeterminedType)

--- a/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.RyuJit/JitInterface/CorInfoImpl.RyuJit.cs
@@ -391,8 +391,8 @@ namespace Internal.JitInterface
                 }
                 else if (directMethod != null)
                 {
-                    // We resolved on a canonical form of the valuetype. Now find the method on the runtime determined form.
-                    Debug.Assert(directMethod.OwningType.IsValueType);
+                    // We resolved on a canonical form. Now find the method on the runtime determined form.
+                    Debug.Assert(directMethod.OwningType.IsValueType || directMethod.Signature.IsStatic);
                     Debug.Assert(!forceRuntimeLookup);
 
                     MethodDesc targetOfLookup;

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/Platform.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/Platform.cs
@@ -245,6 +245,7 @@ namespace System.Runtime.CompilerServices
     {
         public const string ByRefFields = nameof(ByRefFields);
         public const string ByRefLikeGenerics = nameof(ByRefLikeGenerics);
+        public const string DefaultImplementationsOfInterfaces = nameof(DefaultImplementationsOfInterfaces);
         public const string UnmanagedSignatureCallingConvention = nameof(UnmanagedSignatureCallingConvention);
         public const string VirtualStaticsInInterfaces = nameof(VirtualStaticsInInterfaces);
         public const string CovariantReturnsOfClasses = "CovariantReturnsOfClasses";

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/VirtualStaticInterfaceMethods.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/CoreTestAssembly/VirtualStaticInterfaceMethods.cs
@@ -59,6 +59,19 @@ namespace VirtualStaticInterfaceMethods
         public static string WhichMethod(T b) => throw null;
     }
 
+    interface ICovariantInstance<out T>
+    {
+        string Func() => throw null;
+    }
+
+    interface ICovariantInstanceDim<out T> : ICovariantInstance<T>
+    {
+        string ICovariantInstance<T>.Func() => throw null;
+    }
+
+    class CovariantInstanceDimBase : ICovariantInstanceDim<Base> { }
+    class CovariantInstanceDimDerived : CovariantInstanceDimBase, ICovariantInstanceDim<Derived> { }
+
     class Base { }
     class Mid : Base { }
     class Derived : Mid { }

--- a/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/VirtualStaticInterfaceMethodTests.cs
+++ b/src/coreclr/tools/aot/ILCompiler.TypeSystem.Tests/VirtualStaticInterfaceMethodTests.cs
@@ -65,5 +65,26 @@ namespace TypeSystemTests
             MethodDesc result = theClass.ResolveVariantInterfaceMethodToStaticVirtualMethodOnType(intfMethod);
             Assert.Equal(expected, result);
         }
+
+        [Fact]
+        public void TestVariantDimIterationOrder()
+        {
+            var context = new TestTypeSystemContext(TargetArchitecture.Unknown);
+            ModuleDesc testModule = context.CreateModuleForSimpleName("CoreTestAssembly");
+            context.SetSystemModule(testModule);
+
+            MetadataType derived = testModule.GetType("VirtualStaticInterfaceMethods"u8, "Derived"u8);
+            MetadataType iCovariantInstanceDim = testModule.GetType("VirtualStaticInterfaceMethods"u8, "ICovariantInstanceDim`1"u8);
+            MetadataType covariantInstanceDimDerived = testModule.GetType("VirtualStaticInterfaceMethods"u8, "CovariantInstanceDimDerived"u8);
+
+            MetadataType iCovariantInstance = testModule.GetType("VirtualStaticInterfaceMethods"u8, "ICovariantInstance`1"u8);
+            TypeDesc objectType = context.GetWellKnownType(WellKnownType.Object);
+            MethodDesc funcMethod = iCovariantInstance.MakeInstantiatedType(objectType).GetMethod("Func"u8, null);
+
+            DefaultInterfaceMethodResolution resolution = covariantInstanceDimDerived.ResolveVariantInterfaceMethodToDefaultImplementationOnType(funcMethod, out MethodDesc implMethod);
+
+            Assert.Equal(DefaultInterfaceMethodResolution.DefaultImplementation, resolution);
+            Assert.Equal(iCovariantInstanceDim.MakeInstantiatedType(derived), implMethod.OwningType);
+        }
     }
 }

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/VariantDIMIterationOrder.cs
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/VariantDIMIterationOrder.cs
@@ -1,0 +1,32 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace VariantDIMIterationOrder
+{
+    interface IFoo<out T>
+    {
+        Type Func() { return typeof(T); }
+    }
+
+    interface IMoreSpecific<out T> : IFoo<T>
+    {
+        Type IFoo<T>.Func() { return typeof(List<T>); }
+    }
+
+    class Base : IMoreSpecific<Base> { }
+    class Derived : Base, IMoreSpecific<Derived> { }
+
+    public class Tests
+    {
+        [Fact]
+        public static void TestEntryPoint()
+        {
+            Type result = ((IFoo<object>)(new Derived())).Func();
+            Assert.Equal(typeof(List<Derived>), result);
+        }
+    }
+}

--- a/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/VariantDIMIterationOrder.csproj
+++ b/src/tests/Loader/classloader/DefaultInterfaceMethods/regressions/VariantDIMIterationOrder.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/InterfaceVariance/ComplexHierarchyPositive.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/InterfaceVariance/ComplexHierarchyPositive.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Reflection;
 using System.Runtime;
 using TestLibrary;
 using Xunit;
@@ -14,7 +15,6 @@ namespace VariantStaticInterfaceDispatchRegressionTest
     {
         [Fact]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/88689", TestRuntimes.Mono)]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/88690", typeof(Utilities), nameof(Utilities.IsNativeAot))]
         public static void TestEntryPoint()
         {
             Console.WriteLine("Test cases");
@@ -74,8 +74,17 @@ namespace VariantStaticInterfaceDispatchRegressionTest
             TestTheBarString<FooBarBazBoz2, Derived>("IBoz");
         }
 
+        static Type s_temp;
+        static Type Roundtrip(Type t)
+        {
+            s_temp = t;
+            return s_temp;
+        }
+
         static string GetTheFooString<T, U>() where T : IFoo<U> { try { return T.GetString(); } catch (AmbiguousImplementationException) { return "AmbiguousImplementationException"; } }
         static string GetTheBarString<T, U>() where T : IBar<U> { try { return T.GetString(); } catch (AmbiguousImplementationException) { return "AmbiguousImplementationException"; } }
+        static string GetTheFooStringDynamic<T, U>() where T : class, IFoo<U> where U : class { try { return T.GetString(); } catch (AmbiguousImplementationException) { return "AmbiguousImplementationException"; } }
+        static string GetTheBarStringDynamic<T, U>() where T : class, IBar<U> where U : class { try { return T.GetString(); } catch (AmbiguousImplementationException) { return "AmbiguousImplementationException"; } }
         static string GetTheFooStringInstance<T, U>() where T : IFoo<U>, new() { try { return (new T()).GetStringInstance(); } catch (AmbiguousImplementationException) { return "AmbiguousImplementationException"; } }
         static string GetTheBarStringInstance<T, U>() where T : IBar<U>, new() { try { return (new T()).GetStringInstance(); } catch (AmbiguousImplementationException) { return "AmbiguousImplementationException"; } }
 
@@ -84,6 +93,8 @@ namespace VariantStaticInterfaceDispatchRegressionTest
             Console.WriteLine($"TestTheFooString {typeof(T).Name} {typeof(U).Name} {expected}");
             Assert.Equal(expected, GetTheFooString<T, U>());
             Assert.Equal(expected, GetTheFooStringInstance<T, U>());
+            Assert.Equal(expected, (string)typeof(Test).GetMethod(nameof(GetTheFooStringDynamic), BindingFlags.NonPublic | BindingFlags.Static)
+                .MakeGenericMethod([Roundtrip(typeof(T)), Roundtrip(typeof(U))]).Invoke(null, []));
         }
 
         static void TestTheBarString<T, U>(string expected) where T : IBar<U>, new()
@@ -91,6 +102,8 @@ namespace VariantStaticInterfaceDispatchRegressionTest
             Console.WriteLine($"TestTheBarString {typeof(T).Name} {typeof(U).Name} {expected}");
             Assert.Equal(expected, GetTheBarString<T, U>());
             Assert.Equal(expected, GetTheBarStringInstance<T, U>());
+            Assert.Equal(expected, (string)typeof(Test).GetMethod(nameof(GetTheBarStringDynamic), BindingFlags.NonPublic | BindingFlags.Static)
+                .MakeGenericMethod([Roundtrip(typeof(T)), Roundtrip(typeof(U))]).Invoke(null, []));
         }
 
         interface IFoo<in T>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/CanonicalEquivalentFound.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/CanonicalEquivalentFound.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace CanonicalEquivalentFound
+{
+    // Tests the canonicalEquivalentFound code path in TryResolveConstraintMethodApprox.
+    // When a generic class implements IFoo<T> (which canonicalizes to IFoo<__Canon>),
+    // calling through shared generic code with different concrete type arguments exercises
+    // the canonical handling where the compiler must determine whether to resolve statically
+    // or defer to a runtime lookup.
+
+    interface IProcessor<T>
+    {
+        static abstract string Process();
+    }
+
+    // This class implements IProcessor<T> (becomes IProcessor<__Canon> in shared code)
+    // which is the canonical equivalent of IProcessor<string>.
+    class GenericProcessor<T> : IProcessor<T>
+    {
+        public static string Process() => typeof(T).Name;
+    }
+
+    struct GenericStructProcessor<T> : IProcessor<T>
+    {
+        public static string Process() => typeof(T).Name;
+    }
+
+    // Non-generic class implementing a specific instantiation
+    class StringProcessor : IProcessor<string>
+    {
+        public static string Process() => "ExplicitString";
+    }
+
+    // Generic class implementing a fixed interface instantiation (not its own T)
+    class MismatchProcessor<T> : IProcessor<string>
+    {
+        public static string Process() => $"Mismatch<{typeof(T).Name}>";
+    }
+
+    public class Tests
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static string CallProcess<TImpl, T>() where TImpl : IProcessor<T>
+            => TImpl.Process();
+
+        [Fact]
+        public static void TestEntryPoint()
+        {
+            // Generic class through shared generic constrained call with different type args.
+            // Each call uses the same shared code but different concrete types.
+            Assert.Equal("Int32", CallProcess<GenericProcessor<int>, int>());
+            Assert.Equal("String", CallProcess<GenericProcessor<string>, string>());
+            Assert.Equal("Object", CallProcess<GenericProcessor<object>, object>());
+
+            // Generic struct through same path
+            Assert.Equal("Int32", CallProcess<GenericStructProcessor<int>, int>());
+            Assert.Equal("String", CallProcess<GenericStructProcessor<string>, string>());
+
+            // Non-generic class implementing specific instantiation
+            Assert.Equal("ExplicitString", CallProcess<StringProcessor, string>());
+
+            // Generic class implementing a fixed interface instantiation
+            Assert.Equal("Mismatch<Int32>", CallProcess<MismatchProcessor<int>, string>());
+            Assert.Equal("Mismatch<Object>", CallProcess<MismatchProcessor<object>, string>());
+        }
+    }
+}

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/CanonicalEquivalentFound.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/CanonicalEquivalentFound.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GenericStaticVirtualMethod.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GenericStaticVirtualMethod.cs
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace GenericStaticVirtualMethod
+{
+    // Tests static virtual methods that have their own generic type parameters
+    // (method-level generics). This exercises the methodHasCanonInstantiation check
+    // and the MakeInstantiatedMethod path in TryResolveConstraintMethodApprox.
+
+    interface IFactory
+    {
+        static abstract T Create<T>() where T : new();
+        static abstract U Transform<U>(U input);
+    }
+
+    struct StructFactory : IFactory
+    {
+        public static T Create<T>() where T : new() => new T();
+        public static U Transform<U>(U input) => input;
+    }
+
+    class ClassFactory : IFactory
+    {
+        public static T Create<T>() where T : new() => new T();
+        public static U Transform<U>(U input) => input;
+    }
+
+    public class Tests
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static T CallCreate<TFactory, T>() where TFactory : IFactory where T : new()
+            => TFactory.Create<T>();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static U CallTransform<TFactory, U>(U input) where TFactory : IFactory
+            => TFactory.Transform(input);
+
+        [Fact]
+        public static void TestEntryPoint()
+        {
+            // Generic static virtual method on struct
+            object obj = CallCreate<StructFactory, object>();
+            Assert.NotNull(obj);
+
+            // Generic static virtual method on class
+            obj = CallCreate<ClassFactory, object>();
+            Assert.NotNull(obj);
+
+            // Transform with different type args
+            Assert.Equal(42, CallTransform<StructFactory, int>(42));
+            Assert.Equal("hello", CallTransform<ClassFactory, string>("hello"));
+        }
+    }
+}

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GenericStaticVirtualMethod.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/GenericStaticVirtualMethod.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/SimpleStaticVirtual.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/SimpleStaticVirtual.cs
@@ -1,0 +1,31 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace SimpleStaticVirtual
+{
+    public class Tests
+    {
+        [Fact]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/122863", TestRuntimes.Mono)]
+        public static void TestEntryPoint()
+        {
+            Assert.Equal(nameof(IGetter), Get<IGetter>());
+            Assert.Equal("Object", GetVariant<IGetter<object>, string>());
+        }
+
+        static string Get<T>() where T : IGetter => T.Get();
+        static string GetVariant<T, U>() where T : IGetter<U> => T.Get();
+    }
+
+    interface IGetter
+    {
+        static virtual string Get() => nameof(IGetter);
+    }
+
+    interface IGetter<in T>
+    {
+        static virtual string Get() => typeof(T).Name;
+    }
+}

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/SimpleStaticVirtual.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/SimpleStaticVirtual.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/StaticVirtualDIMOnReferenceType.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/StaticVirtualDIMOnReferenceType.cs
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace StaticVirtualDIMOnReferenceType
+{
+    // Tests static virtual default interface method implementations on reference types
+    // (classes) through constrained calls. This combines reference type dispatch with DIM
+    // resolution, exercising both the assertion relaxation and FindDefaultInterfaceImplementation.
+
+    interface IBase
+    {
+        static abstract string GetValue();
+    }
+
+    interface IWithDefault : IBase
+    {
+        static string IBase.GetValue() => "DefaultImpl";
+    }
+
+    interface IWithOverride : IBase
+    {
+        static string IBase.GetValue() => "OverrideImpl";
+    }
+
+    // Class using DIM from IWithDefault
+    class ClassWithDIM : IWithDefault
+    {
+    }
+
+    // Class using DIM from IWithOverride (more derived override)
+    class ClassWithOverrideDIM : IWithOverride
+    {
+    }
+
+    // IWithDefault is more specific than IBase for GetValue, so ClassWithMostSpecificDIM
+    // should resolve to IWithDefault's implementation, not IWithOverride's.
+    interface IWithMoreSpecific : IWithDefault
+    {
+        static string IBase.GetValue() => "MostSpecificImpl";
+    }
+
+    class ClassWithMostSpecificDIM : IWithMoreSpecific
+    {
+    }
+
+    // Struct using DIM from IWithDefault
+    struct StructWithDIM : IWithDefault
+    {
+    }
+
+    // Class with explicit implementation (no DIM)
+    class ClassWithExplicitImpl : IBase
+    {
+        public static string GetValue() => "ExplicitImpl";
+    }
+
+    // Generic interface with DIM
+    interface IGenericBase<T>
+    {
+        static abstract string Describe();
+    }
+
+    interface IGenericWithDefault<T> : IGenericBase<T>
+    {
+        static string IGenericBase<T>.Describe() => $"Default<{typeof(T).Name}>";
+    }
+
+    class GenericClassWithDIM<T> : IGenericWithDefault<T>
+    {
+    }
+
+    public class Tests
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static string CallGetValue<T>() where T : IBase => T.GetValue();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static string CallDescribe<T, U>() where T : IGenericBase<U> => T.Describe();
+
+        [Fact]
+        public static void TestEntryPoint()
+        {
+            // DIM on reference type
+            Assert.Equal("DefaultImpl", CallGetValue<ClassWithDIM>());
+
+            // DIM on reference type from independent interface
+            Assert.Equal("OverrideImpl", CallGetValue<ClassWithOverrideDIM>());
+
+            // More specific DIM wins (IWithMoreSpecific derives from IWithDefault)
+            Assert.Equal("MostSpecificImpl", CallGetValue<ClassWithMostSpecificDIM>());
+
+            // DIM on value type (existing scenario, for comparison)
+            Assert.Equal("DefaultImpl", CallGetValue<StructWithDIM>());
+
+            // Explicit implementation on reference type
+            Assert.Equal("ExplicitImpl", CallGetValue<ClassWithExplicitImpl>());
+
+            // Generic DIM on reference type
+            Assert.Equal("Default<Int32>", CallDescribe<GenericClassWithDIM<int>, int>());
+            Assert.Equal("Default<String>", CallDescribe<GenericClassWithDIM<string>, string>());
+        }
+    }
+}

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/StaticVirtualDIMOnReferenceType.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/StaticVirtualDIMOnReferenceType.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileName).cs" />
+  </ItemGroup>
+</Project>

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/StaticVirtualOnReferenceType.cs
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/StaticVirtualOnReferenceType.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace StaticVirtualOnReferenceType
+{
+    // Tests static virtual method dispatch on reference types (classes) through
+    // shared generic constrained calls. This exercises the code path where
+    // TryResolveConstraintMethodApprox resolves a static virtual on a non-value-type,
+    // which requires the relaxed assertion (IsValueType || Signature.IsStatic).
+
+    interface IIdentity
+    {
+        static abstract string Name();
+    }
+
+    class ClassImpl : IIdentity
+    {
+        public static string Name() => nameof(ClassImpl);
+    }
+
+    class AnotherClassImpl : IIdentity
+    {
+        public static string Name() => nameof(AnotherClassImpl);
+    }
+
+    struct StructImpl : IIdentity
+    {
+        public static string Name() => nameof(StructImpl);
+    }
+
+    interface IGenericIdentity<T>
+    {
+        static abstract string Name();
+    }
+
+    class GenericClassImpl<T> : IGenericIdentity<T>
+    {
+        public static string Name() => typeof(T).Name;
+    }
+
+    public class Tests
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static string GetName<T>() where T : IIdentity => T.Name();
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static string GetGenericName<T, U>() where T : IGenericIdentity<U> => T.Name();
+
+        [Fact]
+        public static void TestEntryPoint()
+        {
+            // Static virtual on reference type (class) through constrained call
+            Assert.Equal(nameof(ClassImpl), GetName<ClassImpl>());
+            Assert.Equal(nameof(AnotherClassImpl), GetName<AnotherClassImpl>());
+
+            // Static virtual on value type (struct) through same constrained call
+            Assert.Equal(nameof(StructImpl), GetName<StructImpl>());
+
+            // Generic interface with reference type implementation
+            Assert.Equal("Int32", GetGenericName<GenericClassImpl<int>, int>());
+            Assert.Equal("String", GetGenericName<GenericClassImpl<string>, string>());
+        }
+    }
+}

--- a/src/tests/Loader/classloader/StaticVirtualMethods/Regression/StaticVirtualOnReferenceType.csproj
+++ b/src/tests/Loader/classloader/StaticVirtualMethods/Regression/StaticVirtualOnReferenceType.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Supersedes #121167.

Fixes #88690.

This PR refactors the C# default interface method (DIM) resolution in NativeAOT's type system to match the C++ runtime implementation structure, fixes bugs in static virtual method dispatch, and adds comprehensive test coverage.

## Changes

### DIM resolution refactoring
- Unified variant and non-variant DIM resolution into a single `FindDefaultInterfaceImplementation` worker method with an `allowVariance` flag, matching the C++ `MethodTable::FindDefaultInterfaceImplementation` structure
- Extracted `TryGetCandidateImplementation` helper matching the C++ equivalent
- Aligned variable names and comments with the C++ implementation

### Static virtual method dispatch fixes
- Fixed `TryResolveConstraintMethodApprox` to handle static virtuals on reference types (classes), not just value types
- Reordered the static virtual check before the value type check to match C++ `TryResolveConstraintMethodApprox`
- Replaced `IsCanonicalDefinitionType` guard with proper `canonicalEquivalentFound` check matching C++ `ResolveVirtualStaticMethod`
- Relaxed Scanner and RyuJIT assertions from `IsValueType` to `IsValueType || Signature.IsStatic`
- Cleaned up dead `isStaticVirtualMethod` code after the early return restructuring

### ILC Scanner crash fix
- Fixed crash in `ConstrainedMethodUseLookupResult.NonRelocDependenciesFromUsage` for interfaces with only generic virtual methods (GVMs)
- Swapped check order so `HasInstantiation` is evaluated before `factory.VTable()` to avoid calling `ScannedVTableProvider.GetSlice` for interfaces whose VTable was never scanned (GVMs are excluded from VTable slots)

### New test coverage
- `StaticVirtualOnReferenceType`: static virtual on classes via shared generic constrained calls
- `GenericStaticVirtualMethod`: method-level generic type parameters
- `CanonicalEquivalentFound`: canonical equivalence in shared code
- `StaticVirtualDIMOnReferenceType`: default interface methods on reference types

All 646 Loader tests pass (up from 642).