### PR TITLE
JIT: Handle some def/use conflicts less conservatively in LSRA

### DIFF
--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -331,6 +331,10 @@ void LinearScan::resolveConflictingDefAndUse(Interval* interval, RefPosition* de
             useRegConflict = true;
         }
     }
+    // Case #3 is currently disabled; the logic is sound, but part of LSRA does
+    // not like the fact that a fixed reg def can end up with multiple
+    // candidate registers on it. (The single candidate was case #2).
+#if 0
     if ((defReg != REG_NA) && !useRegConflict)
     {
         // This is case #3.
@@ -338,6 +342,7 @@ void LinearScan::resolveConflictingDefAndUse(Interval* interval, RefPosition* de
         defRefPosition->registerAssignment = useRegAssignment;
         return;
     }
+#endif
     if ((useReg != REG_NA) && !defRegConflict && canChangeUseAssignment)
     {
         // This is case #4.

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -320,6 +320,15 @@ void LinearScan::resolveConflictingDefAndUse(Interval* interval, RefPosition* de
             }
             if (!useRegConflict)
             {
+                // The use-reg may be busy at this point due to being a
+                // delay-free use from the previous location.
+                if (isRegInUse(useReg, interval->registerType))
+                {
+                    useRegConflict = true;
+                }
+            }
+            if (!useRegConflict)
+            {
                 // This is case #2.  Use the useRegAssignment
                 INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_DEFUSE_CASE2, interval));
                 defRefPosition->registerAssignment = useRegAssignment;

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -255,8 +255,8 @@ void LinearScan::resolveConflictingDefAndUse(Interval* interval, RefPosition* de
     SingleTypeRegSet useRegAssignment = useRefPosition->registerAssignment;
     regNumber        defReg           = REG_NA;
     regNumber        useReg           = REG_NA;
-    bool             defRegConflict   = ((defRegAssignment & useRegAssignment) == RBM_NONE);
-    bool             useRegConflict   = defRegConflict;
+    bool             defRegConflict   = false;
+    bool             useRegConflict   = false;
 
     // If the useRefPosition is a "delayRegFree", we can't change the registerAssignment
     // on it, or we will fail to ensure that the fixedReg is busy at the time the target
@@ -268,7 +268,7 @@ void LinearScan::resolveConflictingDefAndUse(Interval* interval, RefPosition* de
     {
         INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_DEFUSE_FIXED_DELAY_USE));
     }
-    if (defRefPosition->isFixedRegRef && !defRegConflict)
+    if (defRefPosition->isFixedRegRef)
     {
         defReg = defRefPosition->assignedReg();
         if (canChangeUseAssignment)
@@ -294,7 +294,7 @@ void LinearScan::resolveConflictingDefAndUse(Interval* interval, RefPosition* de
             }
         }
     }
-    if (useRefPosition->isFixedRegRef && !useRegConflict)
+    if (useRefPosition->isFixedRegRef)
     {
         useReg = useRefPosition->assignedReg();
 

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -353,7 +353,7 @@ void LinearScan::resolveConflictingDefAndUse(Interval* interval, RefPosition* de
         // This is case #4.
         INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_DEFUSE_CASE4, interval));
         useRefPosition->registerAssignment = defRegAssignment;
-        useRefPosition->isFixedRegRef = false;
+        useRefPosition->isFixedRegRef      = false;
         return;
     }
     if ((defReg != REG_NA) && (useReg != REG_NA))

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -353,6 +353,7 @@ void LinearScan::resolveConflictingDefAndUse(Interval* interval, RefPosition* de
         // This is case #4.
         INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_DEFUSE_CASE4, interval));
         useRefPosition->registerAssignment = defRegAssignment;
+        useRefPosition->isFixedRegRef = false;
         return;
     }
     if ((defReg != REG_NA) && (useReg != REG_NA))

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -336,7 +336,7 @@ void LinearScan::resolveConflictingDefAndUse(Interval* interval, RefPosition* de
         // This is case #3.
         INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_DEFUSE_CASE3, interval));
         defRefPosition->registerAssignment = useRegAssignment;
-        defRefPosition->isFixedRegRef = false;
+        defRefPosition->isFixedRegRef      = false;
         return;
     }
     if ((useReg != REG_NA) && !defRegConflict && canChangeUseAssignment)

--- a/src/coreclr/jit/lsrabuild.cpp
+++ b/src/coreclr/jit/lsrabuild.cpp
@@ -331,18 +331,14 @@ void LinearScan::resolveConflictingDefAndUse(Interval* interval, RefPosition* de
             useRegConflict = true;
         }
     }
-    // Case #3 is currently disabled; the logic is sound, but part of LSRA does
-    // not like the fact that a fixed reg def can end up with multiple
-    // candidate registers on it. (The single candidate was case #2).
-#if 0
     if ((defReg != REG_NA) && !useRegConflict)
     {
         // This is case #3.
         INDEBUG(dumpLsraAllocationEvent(LSRA_EVENT_DEFUSE_CASE3, interval));
         defRefPosition->registerAssignment = useRegAssignment;
+        defRefPosition->isFixedRegRef = false;
         return;
     }
-#endif
     if ((useReg != REG_NA) && !defRegConflict && canChangeUseAssignment)
     {
         // This is case #4.


### PR DESCRIPTION
A def-use conflict happens for SDSU intervals when the def and use share no common candidate register. For these cases we run through a set of potential ways to resolve the conflict that make use of the contract between LSRA and codegen. For example, when the definition requires a single fixed register, it is still valid for LSRA to assign a different register. This means that codegen can use the original fixed register, but that it must insert a copy into the register assigned by LSRA.

In the worst case we cannot use any of the approaches to solve the conflict and then we will fall back to spilling/copying as necessary.

It appears that several of the cases were overly conservative. Particularly case 1 and 2, as described by the function header, were never reachable; we assign `defRegConflict` and `useRegConflict` based on whether there is a conflict in register constraints, but that is always true when we get into this function. It appears the original intention of these variables were whether there is a conflict with a _different_ use of the registers we could otherwise have resolved the original conflict with. This PR restores the meaning to that.