### PR TITLE
fixes validation of stubbed methods

### DIFF
--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/TestFrameworkTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/TestFrameworkTests.g.cs
@@ -106,6 +106,12 @@ namespace ILLink.RoslynAnalyzer.Tests
         }
 
         [Fact]
+        public Task VerifyLocalsAreChanged()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
         public Task VerifyResourceInAssemblyAttributesBehavior()
         {
             return RunTest(allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/VerifyLocalsAreChanged.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/VerifyLocalsAreChanged.cs
@@ -1,0 +1,44 @@
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.TestFramework
+{
+    [SetupLinkerSubstitutionFile("VerifyLocalsAreChanged.xml")]
+    public class VerifyLocalsAreChanged
+    {
+        public static void Main()
+        {
+            TestMethod_1();
+
+            TestMethod_2();
+        }
+
+        [Kept]
+        struct NestedType
+        {
+            public NestedType(int arg)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Kept]
+        [ExpectBodyModified]
+        [ExpectLocalsModified]
+        static NestedType TestMethod_1()
+        {
+            var value = new NestedType(42);
+            return value;
+        }
+
+        [Kept]
+        [ExpectedLocalsSequence(["Mono.Linker.Tests.Cases.TestFramework.VerifyLocalsAreChanged/NestedType"])]
+        [ExpectBodyModified]
+        static NestedType TestMethod_2()
+        {
+            var value = new NestedType(2);
+            return value;
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/VerifyLocalsAreChanged.xml
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/VerifyLocalsAreChanged.xml
@@ -1,0 +1,11 @@
+<linker>
+  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.TestFramework.VerifyLocalsAreChanged">
+      <method signature="Mono.Linker.Tests.Cases.TestFramework.VerifyLocalsAreChanged/NestedType TestMethod_1()" body="stub">
+      </method>
+
+      <method signature="Mono.Linker.Tests.Cases.TestFramework.VerifyLocalsAreChanged/NestedType TestMethod_2()" body="stub">
+      </method>
+    </type>
+  </assembly>
+</linker>

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -820,7 +820,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
             if (src.CustomAttributes.Any(attr => attr.AttributeType.Name == expectModifiedAttributeName))
             {
-                if (linkedValues.ToHashSet().SetEquals(srcValues.ToHashSet()))
+                if (linkedValues.SequenceEqual(srcValues))
                 {
                     yield return $"Expected method `{src} to have it's {propertyDescription} modified, however, the {propertyDescription} were the same as the original\n{FormattingUtils.FormatSequenceCompareFailureMessage(linkedValues, srcValues)}";
                 }
@@ -828,14 +828,14 @@ namespace Mono.Linker.Tests.TestCasesRunner
             else if (expectedSequenceAttribute != null)
             {
                 var expected = getExpectFromSequenceAttribute(expectedSequenceAttribute).ToArray();
-                if (!linkedValues.ToHashSet().SetEquals(expected.ToHashSet()))
+                if (!linkedValues.SequenceEqual(expected))
                 {
                     yield return $"Expected method `{src} to have it's {propertyDescription} modified, however, the sequence of {propertyDescription} does not match the expected value\n{FormattingUtils.FormatSequenceCompareFailureMessage2(linkedValues, expected, srcValues)}";
                 }
             }
             else
             {
-                if (!linkedValues.ToHashSet().SetEquals(srcValues.ToHashSet()))
+                if (!linkedValues.SequenceEqual(srcValues))
                 {
                     yield return $"Expected method `{src} to have it's {propertyDescription} unchanged, however, the {propertyDescription} differ from the original\n{FormattingUtils.FormatSequenceCompareFailureMessage(linkedValues, srcValues)}";
                 }


### PR DESCRIPTION
The conversion of arrays of strings to a HashSet<string> was removing duplicates. This would lead to false positives when comparing the result of stubbing a method with 2 or more locals of the same type since both the expectation as
well the actual values would contain a single entry.

The same issue was present when comparing method instructions.