### PR TITLE
Fix `getAsyncOtherVariant` JIT-EE implementation in VM

### DIFF
--- a/src/coreclr/inc/corinfo.h
+++ b/src/coreclr/inc/corinfo.h
@@ -2291,6 +2291,7 @@ public:
     // If this is a method with async calling convention: returns the corresponding task-returning method.
     // If this is a task-returning method: returns the corresponding method with async calling convention.
     // Otherwise returns null.
+    // variantIsThunk is set to true if the returned method is a thunk provided by the VM.
     virtual CORINFO_METHOD_HANDLE getAsyncOtherVariant(
         CORINFO_METHOD_HANDLE ftn,
         bool*                 variantIsThunk

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.cpp
@@ -3398,8 +3398,8 @@ CORINFO_METHOD_HANDLE MethodContext::repGetInstantiatedEntry(CORINFO_METHOD_HAND
 }
 
 void MethodContext::recGetAsyncOtherVariant(CORINFO_METHOD_HANDLE ftn,
-                                       bool*                 variantIsThunk,
-                                       CORINFO_METHOD_HANDLE result)
+                                            bool                  variantIsThunk,
+                                            CORINFO_METHOD_HANDLE result)
 {
     if (GetAsyncOtherVariant == nullptr)
     {
@@ -3409,7 +3409,7 @@ void MethodContext::recGetAsyncOtherVariant(CORINFO_METHOD_HANDLE ftn,
     DWORDLONG key = CastHandle(ftn);
     DLD       value;
     value.A = CastHandle(result);
-    value.B = (DWORD)*variantIsThunk ? 1 : 0;
+    value.B = (DWORD)variantIsThunk ? 1 : 0;
     GetAsyncOtherVariant->Add(key, value);
     DEBUG_REC(dmpGetAsyncOtherVariant(key, value));
 }

--- a/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.h
+++ b/src/coreclr/tools/superpmi/superpmi-shared/methodcontext.h
@@ -459,7 +459,7 @@ public:
                                                   CORINFO_METHOD_HANDLE* methodHandle,
                                                   CORINFO_CLASS_HANDLE* classHandle);
 
-    void recGetAsyncOtherVariant(CORINFO_METHOD_HANDLE ftn, bool* variantIsThunk, CORINFO_METHOD_HANDLE result);
+    void recGetAsyncOtherVariant(CORINFO_METHOD_HANDLE ftn, bool variantIsThunk, CORINFO_METHOD_HANDLE result);
     void dmpGetAsyncOtherVariant(DWORDLONG key, DLD value);
     CORINFO_METHOD_HANDLE repGetAsyncOtherVariant(CORINFO_METHOD_HANDLE ftn, bool* variantIsThunk);
 

--- a/src/coreclr/tools/superpmi/superpmi-shim-collector/icorjitinfo.cpp
+++ b/src/coreclr/tools/superpmi/superpmi-shim-collector/icorjitinfo.cpp
@@ -266,13 +266,8 @@ CORINFO_METHOD_HANDLE interceptor_ICJI::getInstantiatedEntry(CORINFO_METHOD_HAND
 CORINFO_METHOD_HANDLE interceptor_ICJI::getAsyncOtherVariant(CORINFO_METHOD_HANDLE ftn, bool* variantIsThunk)
 {
     mc->cr->AddCall("getAsyncOtherVariant");
-    bool                  localVariantIsThunk = false;
-    CORINFO_METHOD_HANDLE result = original_ICorJitInfo->getAsyncOtherVariant(ftn, &localVariantIsThunk);
-    mc->recGetAsyncOtherVariant(ftn, &localVariantIsThunk, result);
-    if (variantIsThunk != nullptr)
-    {
-        *variantIsThunk = localVariantIsThunk;
-    }
+    CORINFO_METHOD_HANDLE result = original_ICorJitInfo->getAsyncOtherVariant(ftn, variantIsThunk);
+    mc->recGetAsyncOtherVariant(ftn, *variantIsThunk, result);
     return result;
 }
 

--- a/src/coreclr/vm/jitinterface.cpp
+++ b/src/coreclr/vm/jitinterface.cpp
@@ -8984,7 +8984,8 @@ CORINFO_METHOD_HANDLE CEEInfo::getAsyncOtherVariant(
 
     MethodDesc* pMD = GetMethod(ftn);
     MethodDesc* pAsyncOtherVariant = NULL;
-    if (pMD->HasAsyncMethodData())
+
+    if (pMD->HasAsyncOtherVariant())
     {
          pAsyncOtherVariant = pMD->GetAsyncOtherVariant();
     }

--- a/src/coreclr/vm/method.hpp
+++ b/src/coreclr/vm/method.hpp
@@ -1710,8 +1710,14 @@ public:
                                                                      TypeHandle instType,
                                                                      Instantiation methodInst);
 
+    inline bool HasAsyncOtherVariant() const
+    {
+        return IsAsyncVariantMethod() || ReturnsTaskOrValueTask();
+    }
+
     MethodDesc* GetAsyncOtherVariant(BOOL allowInstParam = TRUE)
     {
+        _ASSERTE(HasAsyncOtherVariant());
         return FindOrCreateAssociatedMethodDesc(this, GetMethodTable(), FALSE, GetMethodInstantiation(), allowInstParam, FALSE, TRUE, AsyncVariantLookup::AsyncOtherVariant);
     }
 

--- a/src/coreclr/vm/methodtablebuilder.cpp
+++ b/src/coreclr/vm/methodtablebuilder.cpp
@@ -6152,7 +6152,7 @@ MethodTableBuilder::bmtMethodHandle MethodTableBuilder::FindDeclMethodOnClassInH
                     {
                         if (variantLookup == AsyncVariantLookup::AsyncOtherVariant)
                         {
-                            if (pCurMD->IsAsyncVariantMethod() || pCurMD->ReturnsTaskOrValueTask())
+                            if (pCurMD->HasAsyncOtherVariant())
                             {
                                 pCurMD = pCurMD->GetAsyncOtherVariant();
                             }


### PR DESCRIPTION
We could end up calling GetAsyncOtherVariant for explicitly-async methods like AsyncHelpers.Await, which do not have other variants.
This was happening under `EnableExtraSuperPmiQueries` mode that queries both variants proactively. Also simplify SPMI implementation of the recording of this function.