### PR TITLE
Re-enable generator tests on big endian architectures

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/SourceGenerationTests/GeneratorTests.cs
@@ -20,12 +20,8 @@ using Xunit;
 namespace Microsoft.Extensions.SourceGeneration.Configuration.Binder.Tests
 {
     [ActiveIssue("https://github.com/dotnet/runtime/issues/52062", TestPlatforms.Browser)]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/105311", typeof(ConfigurationBindingGeneratorTests), nameof(IsBigEndian))]
     public partial class ConfigurationBindingGeneratorTests : ConfigurationBinderTestsBase
     {
-        // The source hash applied to the [Interceptable] attribute treats chars as bytes which fails baseline comparisons on big-endian.
-        public static bool IsBigEndian => !BitConverter.IsLittleEndian;
-
         [Theory]
         [InlineData(LanguageVersion.CSharp11)]
         [InlineData(LanguageVersion.CSharp10)]


### PR DESCRIPTION
The Roslyn issue https://github.com/dotnet/roslyn/issues/74682 was fixed, so the tests should now pass on big endian architectures.

This reverts https://github.com/dotnet/runtime/pull/105485.

Resolves https://github.com/dotnet/runtime/issues/105311.