### PR TITLE
[Tests][UserEvents] Bump tracee timeout and add logs

### DIFF
--- a/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
+++ b/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
@@ -124,6 +124,7 @@ namespace Tracing.UserEvents.Tests.Common
             // As a workaround, deleting the temp file and allowing record-trace to create it works reliably.
             File.Delete(traceFilePath);
             traceFilePath = Path.ChangeExtension(traceFilePath, ".nettrace");
+            string recordTraceLogPath = Path.ChangeExtension(traceFilePath, ".log");
 
             ProcessStartInfo recordTraceStartInfo = new();
             recordTraceStartInfo.FileName = "sudo";
@@ -133,10 +134,8 @@ namespace Tracing.UserEvents.Tests.Common
             recordTraceStartInfo.ArgumentList.Add(scriptFilePath);
             recordTraceStartInfo.ArgumentList.Add("--out");
             recordTraceStartInfo.ArgumentList.Add(traceFilePath);
-            recordTraceStartInfo.ArgumentList.Add("--log-filter");
-            recordTraceStartInfo.ArgumentList.Add("one_collect::helpers::exporting=warn,one_collect::perf_event=warn,one_collect::tracefs=warn,one_collect::scripting=warn,ruwind=warn,engine=warn");
-            recordTraceStartInfo.ArgumentList.Add("--log-mode");
-            recordTraceStartInfo.ArgumentList.Add("console");
+            recordTraceStartInfo.ArgumentList.Add("--log-path");
+            recordTraceStartInfo.ArgumentList.Add(recordTraceLogPath);
             recordTraceStartInfo.WorkingDirectory = userEventsScenarioDir;
             recordTraceStartInfo.UseShellExecute = false;
             recordTraceStartInfo.RedirectStandardOutput = true;
@@ -249,6 +248,7 @@ namespace Tracing.UserEvents.Tests.Common
             if (!File.Exists(traceFilePath))
             {
                 Console.Error.WriteLine($"Expected trace file not found at `{traceFilePath}`");
+                UploadArtifactsFromHelixOnFailure(scenarioName, recordTraceLogPath);
                 return -1;
             }
 
@@ -256,7 +256,7 @@ namespace Tracing.UserEvents.Tests.Common
             if (!traceValidator(traceePid, source))
             {
                 Console.Error.WriteLine($"Trace file `{traceFilePath}` does not contain expected events.");
-                UploadTraceFileFromHelix(traceFilePath, scenarioName);
+                UploadArtifactsFromHelixOnFailure(scenarioName, traceFilePath, recordTraceLogPath);
                 return -1;
             }
 
@@ -351,14 +351,24 @@ namespace Tracing.UserEvents.Tests.Common
             }
         }
 
-        private static void UploadTraceFileFromHelix(string traceFilePath, string scenarioName)
+        private static void UploadArtifactsFromHelixOnFailure(string scenarioName, params string[] filePaths)
         {
             var helixWorkItemDirectory = Environment.GetEnvironmentVariable("HELIX_WORKITEM_UPLOAD_ROOT");
-            if (helixWorkItemDirectory != null && Directory.Exists(helixWorkItemDirectory))
+            if (helixWorkItemDirectory is null || !Directory.Exists(helixWorkItemDirectory))
+                return;
+
+            foreach (string filePath in filePaths)
             {
-                var destPath = Path.Combine(helixWorkItemDirectory, $"{scenarioName}.nettrace");
-                Console.WriteLine($"Uploading trace file to Helix work item directory: {destPath}");
-                File.Copy(traceFilePath, destPath, overwrite: true);
+                if (!File.Exists(filePath))
+                {
+                    Console.WriteLine($"Artifact not found at `{filePath}`, skipping upload.");
+                    continue;
+                }
+
+                string extension = Path.GetExtension(filePath);
+                string destPath = Path.Combine(helixWorkItemDirectory, $"{scenarioName}{extension}");
+                Console.WriteLine($"Uploading artifact to Helix work item directory: {destPath}");
+                File.Copy(filePath, destPath, overwrite: true);
             }
         }
     }

--- a/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
+++ b/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
@@ -17,7 +17,7 @@ namespace Tracing.UserEvents.Tests.Common
     public class UserEventsTestRunner
     {
         private const int SIGINT = 2;
-        private const int DefaultTraceeExitTimeoutMs = 5000;
+        private const int DefaultTraceeExitTimeoutMs = 60000;
         private const int DefaultRecordTraceExitTimeoutMs = 20000;
 
         // Delay before starting the tracee to let record-trace finish setup. The
@@ -60,7 +60,9 @@ namespace Tracing.UserEvents.Tests.Common
                     enabledEvent.Set();
                 }
 
+                Console.WriteLine("Tracee waiting for EventSource to be enabled via IPC...");
                 enabledEvent.Wait();
+                Console.WriteLine("Tracee EventSource enabled, emitting events.");
 
                 traceeAction();
                 return 0;
@@ -131,6 +133,10 @@ namespace Tracing.UserEvents.Tests.Common
             recordTraceStartInfo.ArgumentList.Add(scriptFilePath);
             recordTraceStartInfo.ArgumentList.Add("--out");
             recordTraceStartInfo.ArgumentList.Add(traceFilePath);
+            recordTraceStartInfo.ArgumentList.Add("--log-filter");
+            recordTraceStartInfo.ArgumentList.Add("one_collect::helpers::exporting=warn,one_collect::perf_event=warn,one_collect::tracefs=warn,one_collect::scripting=warn,ruwind=warn,engine=warn");
+            recordTraceStartInfo.ArgumentList.Add("--log-mode");
+            recordTraceStartInfo.ArgumentList.Add("console");
             recordTraceStartInfo.WorkingDirectory = userEventsScenarioDir;
             recordTraceStartInfo.UseShellExecute = false;
             recordTraceStartInfo.RedirectStandardOutput = true;


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/123442

The tracee hit the 5s timeout on the jitstress lane. Given that jitstress lanes are known to be slow, I'm expecting non-jitstress lanes to still complete quickly despite the longer timeout. Also added logs to 1) indicate whether the Tracee's EventSource was enabled and 2) reveal which .NET processes record-trace detected and sent an IPC command.

Below is an example output with these in effect
record-trace emits `Enabled .NET events for process: pid=13803`
Tracee EventSource enabled, emitting events.

```bash
Starting record-trace: sudo -n /home/mihw/repo/runtime/artifacts/tests/coreclr/linux.x64.Debug/tracing/userevents/common/userevents_common/record-trace --script-file /home/mihw/repo/runtime/artifacts/tests/coreclr/linux.x64.Debug/tracing/userevents/custommetadata/custommetadata/custommetadata.script --out /tmp/tmpBl0cAg.nettrace --log-filter one_collect::helpers::exporting=warn,one_collect::perf_event=warn,one_collect::tracefs=warn,one_collect::scripting=warn,ruwind=warn,engine=warn --log-mode console
record-trace started with PID: 13789
Delaying tracee startup 300ms for record-trace setup...
[record-trace][stdout] 2026-03-05T18:20:38.062008Z  INFO one_collect::helpers::dotnet::os::linux: Enabled .NET events for process: pid=4998
[record-trace][stdout] Recording started.  Press CTRL+C to stop.
[record-trace][stdout] 2026-03-05T18:20:38.068201Z  INFO one_collect::helpers::dotnet::os::linux: Enabled .NET events for process: pid=13767
Starting tracee process: /home/mihw/repo/runtime/artifacts/tests/coreclr/linux.x64.Debug/Tests/Core_Root/corerun /home/mihw/repo/runtime/artifacts/tests/coreclr/linux.x64.Debug/tracing/userevents/custommetadata/custommetadata/custommetadata.dll tracee
Tracee process started with PID: 13803
Waiting for tracee process to exit...
[record-trace][stdout] 2026-03-05T18:20:38.369549Z  INFO one_collect::helpers::dotnet::os::linux: Enabled .NET events for process: pid=13803
[tracee][stdout] Tracee waiting for EventSource to be enabled via IPC...
[tracee][stdout] Tracee EventSource enabled, emitting events.
Stopping record-trace with SIGINT.
Waiting for record-trace to exit...
[record-trace][stdout] 2026-03-05T18:20:38.509142Z  WARN one_collect::helpers::dotnet::os::linux: Failed to open diagnostic socket: pid=13803, nspid=13803
[record-trace][stdout] Recording stopped.
[record-trace][stdout] Resolving symbols.
[record-trace][stdout] Finished recording trace.
[record-trace][stdout] Trace written to /tmp/tmpBl0cAg.nettrace
[record-trace][stdout] 2026-03-05T18:20:38.666852Z  INFO record_trace: record-trace exiting: exit_code=0
CustomMetadata event: Id=1, Name=Item1
Ignored 4441 events from processes other than tracee (PID 13803).
Expected: 100
Actual: 100
END EXECUTION - PASSED
```