### PR TITLE
[cDAC] Relax HRESULT validation to allow divergent failure codes

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataFrame.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataFrame.cs
@@ -91,7 +91,7 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
         {
             uint numArgsLocal;
             int hrLocal = _legacyImpl.GetNumArguments(&numArgsLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
                 Debug.Assert(*numArgs == numArgsLocal, $"cDAC: {*numArgs}, DAC: {numArgsLocal}");
         }
@@ -162,7 +162,7 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
         {
             uint numLocalsLocal;
             int hrLocal = _legacyImpl.GetNumLocalVariables(&numLocalsLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
                 Debug.Assert(*numLocals == numLocalsLocal, $"cDAC: {*numLocals}, DAC: {numLocalsLocal}");
         }
@@ -221,7 +221,7 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
 #if DEBUG
         if (_legacyImpl is not null)
         {
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodInstance.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataMethodInstance.cs
@@ -93,7 +93,7 @@ public sealed unsafe partial class ClrDataMethodInstance : IXCLRDataMethodInstan
             void* legacyModPtr = null;
             int hrLocal = _legacyImpl.GetTokenAndScope(validateToken ? &tokenLocal : null, validateMod ? &legacyModPtr : null);
 
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
 
             if (validateToken)
             {
@@ -172,7 +172,7 @@ public sealed unsafe partial class ClrDataMethodInstance : IXCLRDataMethodInstan
                 hrLocal = _legacyImpl.GetName(flags, bufLen, &nameLenLocal, nameBuf is null ? null : pNameBufLocal);
             }
 
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (nameLen is not null)
                 Debug.Assert(nameLenLocal == *nameLen, $"cDAC: {*nameLen:x}, DAC: {nameLenLocal:x}");
 
@@ -270,8 +270,7 @@ public sealed unsafe partial class ClrDataMethodInstance : IXCLRDataMethodInstan
                     validateIlOffsets ? localIlOffsetsPtr : null);
             }
 
-            // DAC function returns odd failure codes it doesn't make sense to match directly
-            Debug.Assert(hrLocal == hr || (hrLocal < 0 && hr < 0), $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
 
             if (hr == HResults.S_OK)
             {
@@ -362,7 +361,7 @@ public sealed unsafe partial class ClrDataMethodInstance : IXCLRDataMethodInstan
             uint mapNeededLocal;
             ClrDataILAddressMap[]? mapsLocal = mapLen > 0 ? new ClrDataILAddressMap[mapLen] : null;
             int hrLocal = _legacyImpl.GetILAddressMap(mapLen, &mapNeededLocal, mapsLocal);
-            Debug.Assert(hrLocal == hr, $"HResult - cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
 
             if (hr == HResults.S_OK)
             {
@@ -428,7 +427,7 @@ public sealed unsafe partial class ClrDataMethodInstance : IXCLRDataMethodInstan
             ClrDataAddress addrLocal;
             int hrLocal = _legacyImpl.GetRepresentativeEntryAddress(&addrLocal);
 
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             Debug.Assert(addrLocal == *addr, $"cDAC: {*addr:x}, DAC: {addrLocal:x}");
         }
 #endif

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataStackWalk.cs
@@ -67,7 +67,7 @@ public sealed unsafe partial class ClrDataStackWalk : IXCLRDataStackWalk
         {
             byte[] localContextBuf = new byte[contextBufSize];
             int hrLocal = _legacyImpl.GetContext(contextFlags, contextBufSize, null, localContextBuf);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
 
             if (hr == HResults.S_OK)
             {
@@ -136,7 +136,7 @@ public sealed unsafe partial class ClrDataStackWalk : IXCLRDataStackWalk
         {
             int hrLocal = _legacyImpl.Next();
 #if DEBUG
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
 #endif
         }
 
@@ -174,7 +174,7 @@ public sealed unsafe partial class ClrDataStackWalk : IXCLRDataStackWalk
             {
                 hrLocal = _legacyImpl.Request(reqCode, inBufferSize, inBuffer, outBufferSize, localOutBufferPtr);
             }
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
 
             for (int i = 0; i < outBufferSize; i++)
             {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs
@@ -1,0 +1,46 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.Diagnostics.DataContractReader.Legacy;
+
+internal enum HResultValidationMode
+{
+    /// <summary>
+    /// HRESULTs must match exactly.
+    /// </summary>
+    Exact,
+
+    /// <summary>
+    /// Success HRESULTs must match exactly, but any two failing HRESULTs (negative values) are considered equivalent.
+    /// This is the recommended default because the cDAC and native DAC may use different exception types for the
+    /// same invalid input (e.g., InvalidOperationException vs E_INVALIDARG), producing different failing HRESULTs.
+    /// </summary>
+    AllowDivergentFailures,
+}
+
+internal static class DebugExtensions
+{
+    extension(Debug)
+    {
+        [Conditional("DEBUG")]
+        internal static void ValidateHResult(
+            int cdacHr,
+            int dacHr,
+            HResultValidationMode mode = HResultValidationMode.AllowDivergentFailures,
+            [CallerFilePath] string? filePath = null,
+            [CallerLineNumber] int lineNumber = 0)
+        {
+            bool match = mode switch
+            {
+                HResultValidationMode.Exact => cdacHr == dacHr,
+                HResultValidationMode.AllowDivergentFailures => cdacHr == dacHr || (cdacHr < 0 && dacHr < 0),
+                _ => cdacHr == dacHr,
+            };
+            Debug.Assert(match, $"HResult mismatch - cDAC: 0x{unchecked((uint)cdacHr):X8}, DAC: 0x{unchecked((uint)dacHr):X8} ({Path.GetFileName(filePath)}:{lineNumber})");
+        }
+    }
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.IXCLRDataProcess.cs
@@ -374,7 +374,7 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
 #if DEBUG
         if (_legacyProcess is not null)
         {
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
         return hr;
@@ -440,7 +440,7 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
 #if DEBUG
         if (_legacyProcess is not null)
         {
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
 
@@ -550,7 +550,7 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
         {
             uint flagsLocal;
             int hrLocal = _legacyProcess.GetOtherNotificationFlags(&flagsLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             Debug.Assert(*flags == flagsLocal);
         }
 #endif
@@ -595,7 +595,7 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
             {
                 hrLocal = ex.HResult;
             }
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(flags == flagsLocal);
@@ -650,7 +650,7 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
         if (_legacyProcess2 is not null)
         {
             int hrLocal = _legacyProcess2.GetGcNotification(gcEvtArgs);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
         return hr;
@@ -674,7 +674,7 @@ public sealed unsafe partial class SOSDacImpl : IXCLRDataProcess, IXCLRDataProce
         {
             // update the DAC cache
             int hrLocal = _legacyProcess2.SetGcNotification(gcEvtArgs);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
         return hr;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -118,7 +118,7 @@ public sealed unsafe partial class SOSDacImpl
         if (_legacyImpl is not null)
         {
             int hrLocal = _legacyImpl.GetAppDomainConfigFile(appDomain, count, configFile, pNeeded);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
 
@@ -176,7 +176,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpAppDomainData dataLocal = default;
             int hrLocal = _legacyImpl.GetAppDomainData(addr, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->AppDomainPtr == dataLocal.AppDomainPtr);
@@ -225,7 +225,7 @@ public sealed unsafe partial class SOSDacImpl
             ClrDataAddress[] valuesLocal = new ClrDataAddress[count];
             uint neededLocal;
             int hrLocal = _legacyImpl.GetAppDomainList(count, valuesLocal, &neededLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
             if (values is not null && values.Length > 0 && valuesLocal.Length > 0)
             {
@@ -299,7 +299,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetAppDomainName(addr, count, ptr, &neededLocal);
             }
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
@@ -331,7 +331,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 DacpAppDomainStoreData dataLocal = default;
                 int hrLocal = _legacyImpl.GetAppDomainStoreData(&dataLocal);
-                Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+                Debug.ValidateHResult(hr, hrLocal);
                 Debug.Assert(appDomainStoreData->sharedDomain == dataLocal.sharedDomain, $"cDAC: {appDomainStoreData->sharedDomain:x}, DAC: {dataLocal.sharedDomain:x}");
                 Debug.Assert(appDomainStoreData->systemDomain == dataLocal.systemDomain, $"cDAC: {appDomainStoreData->systemDomain:x}, DAC: {dataLocal.systemDomain:x}");
                 Debug.Assert(appDomainStoreData->DomainCount == dataLocal.DomainCount, $"cDAC: {appDomainStoreData->DomainCount}, DAC: {dataLocal.DomainCount}");
@@ -349,7 +349,7 @@ public sealed unsafe partial class SOSDacImpl
         if (_legacyImpl is not null)
         {
             int hrLocal = _legacyImpl.GetApplicationBase(appDomain, count, appBase, pNeeded);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
 
@@ -394,7 +394,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpAssemblyData dataLocal = default;
             int hrLocal = _legacyImpl.GetAssemblyData(domain, assembly, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->AssemblyPtr == dataLocal.AssemblyPtr, $"cDAC: {data->AssemblyPtr:x}, DAC: {dataLocal.AssemblyPtr:x}");
@@ -476,7 +476,7 @@ public sealed unsafe partial class SOSDacImpl
             ClrDataAddress[]? valuesLocal = values != null ? new ClrDataAddress[count] : null;
             int neededLocal;
             int hrLocal = _legacyImpl.GetAssemblyList(addr, count, valuesLocal, &neededLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
@@ -529,7 +529,7 @@ public sealed unsafe partial class SOSDacImpl
             ClrDataAddress[] modulesLocal = new ClrDataAddress[count];
             uint neededLocal;
             int hrLocal = _legacyImpl.GetAssemblyModuleList(assembly, count, modulesLocal, &neededLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
@@ -581,7 +581,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetAssemblyName(assembly, count, ptr, &neededLocal);
             }
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
@@ -634,7 +634,7 @@ public sealed unsafe partial class SOSDacImpl
                 hrLocal = _legacyImpl.GetClrWatsonBuckets(thread, ptr);
             }
 
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(new ReadOnlySpan<byte>(genericModeBlockLocal, 0, sizeOfGenericModeBlock).SequenceEqual(new Span<byte>(pGenericModeBlock, sizeOfGenericModeBlock)));
@@ -698,7 +698,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpCodeHeaderData dataLocal = default;
             int hrLocal = _legacyImpl.GetCodeHeaderData(ip, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->MethodDescPtr == dataLocal.MethodDescPtr, $"cDAC: {data->MethodDescPtr:x}, DAC: {dataLocal.MethodDescPtr:x}");
@@ -736,7 +736,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             ClrDataAddress domainLocal;
             int hrLocal = _legacyImpl.GetDomainFromContext(context, &domainLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(domainLocal == context, $"cDAC: {context:x}, DAC: {domainLocal:x}");
@@ -754,7 +754,7 @@ public sealed unsafe partial class SOSDacImpl
         if (_legacyImpl is not null)
         {
             int hrLocal = _legacyImpl.GetDomainLocalModuleData(addr, data);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
 
@@ -770,7 +770,7 @@ public sealed unsafe partial class SOSDacImpl
         if (_legacyImpl is not null)
         {
             int hrLocal = _legacyImpl.GetDomainLocalModuleDataFromAppDomain(appDomainAddr, moduleID, data);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
 
@@ -785,7 +785,7 @@ public sealed unsafe partial class SOSDacImpl
         if (_legacyImpl is not null)
         {
             int hrLocal = _legacyImpl.GetDomainLocalModuleDataFromModule(moduleAddr, data);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
 
@@ -825,7 +825,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetFailedAssemblyLocation(assembly, count, ptr, &neededLocal);
             }
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
@@ -944,7 +944,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpFieldDescData dataLocal = default;
             int hrLocal = _legacyImpl.GetFieldDescData(fieldDesc, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->Type == dataLocal.Type, $"cDAC: {data->Type}, DAC: {dataLocal.Type}");
@@ -1002,7 +1002,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetFrameName(vtable, count, ptr, &neededLocal);
             }
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
@@ -1047,7 +1047,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpGcHeapData dataLocal = default;
             int hrLocal = _legacyImpl.GetGCHeapData(&dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->bServerMode == dataLocal.bServerMode, $"cDAC: {data->bServerMode}, DAC: {dataLocal.bServerMode}");
@@ -1107,7 +1107,7 @@ public sealed unsafe partial class SOSDacImpl
             ClrDataAddress[] heapsLocal = new ClrDataAddress[count];
             uint neededLocal;
             int hrLocal = _legacyImpl.GetGCHeapList(count, heapsLocal, &neededLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
@@ -1215,7 +1215,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpGcHeapDetails detailsLocal = default;
             int hrLocal = _legacyImpl.GetGCHeapDetails(heap, &detailsLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(details->heapAddr == detailsLocal.heapAddr, $"cDAC: {details->heapAddr:x}, DAC: {detailsLocal.heapAddr:x}");
@@ -1348,7 +1348,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpGcHeapDetails detailsLocal = default;
             int hrLocal = _legacyImpl.GetGCHeapStaticData(&detailsLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(details->heapAddr == detailsLocal.heapAddr, $"cDAC: {details->heapAddr:x}, DAC: {detailsLocal.heapAddr:x}");
@@ -1457,7 +1457,7 @@ public sealed unsafe partial class SOSDacImpl
                 SOSHandleData[] handlesLocal = new SOSHandleData[count];
                 uint neededLocal;
                 int hrLocal = _legacyHandleEnum.Next(count, handlesLocal, &neededLocal);
-                Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+                Debug.ValidateHResult(hr, hrLocal);
                 if (hr == HResults.S_OK || hr == HResults.S_FALSE)
                 {
                     Debug.Assert(*pNeeded == neededLocal, $"cDAC: {*pNeeded}, DAC: {neededLocal}");
@@ -1523,7 +1523,7 @@ public sealed unsafe partial class SOSDacImpl
             if (_legacyImpl is not null)
             {
                 int hrLocal = _legacyImpl.GetHandleEnum(out legacyHandleEnum);
-                Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+                Debug.ValidateHResult(hr, hrLocal);
             }
 #endif
             ppHandleEnum = new SOSHandleEnum(_target, supportedHandleTypes, legacyHandleEnum);
@@ -1550,7 +1550,7 @@ public sealed unsafe partial class SOSDacImpl
             if (_legacyImpl is not null)
             {
                 int hrLocal = _legacyImpl.GetHandleEnumForTypes(types, count, out legacyHandleEnum);
-                Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+                Debug.ValidateHResult(hr, hrLocal);
             }
 #endif
             IGC gc = _target.Contracts.GC;
@@ -1600,7 +1600,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpGcHeapAnalyzeData dataLocal = default;
             int hrLocal = _legacyImpl.GetHeapAnalyzeData(addr, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->heapAddr == dataLocal.heapAddr, $"cDAC: {data->heapAddr:x}, DAC: {dataLocal.heapAddr:x}");
@@ -1646,7 +1646,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpGcHeapAnalyzeData dataLocal = default;
             int hrLocal = _legacyImpl.GetHeapAnalyzeStaticData(&dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->heapAddr == dataLocal.heapAddr, $"cDAC: {data->heapAddr:x}, DAC: {dataLocal.heapAddr:x}");
@@ -1707,7 +1707,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpHeapSegmentData dataLocal = default;
             int hrLocal = _legacyImpl.GetHeapSegmentData(seg, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->segmentAddr == dataLocal.segmentAddr, $"segmentAddr - cDAC: {data->segmentAddr:x}, DAC: {dataLocal.segmentAddr:x}");
@@ -1737,7 +1737,7 @@ public sealed unsafe partial class SOSDacImpl
         if (_legacyImpl is not null)
         {
             int hrLocal = _legacyImpl.GetHillClimbingLogEntry(addr, data);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
 
@@ -1766,7 +1766,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             ClrDataAddress ilLocal;
             int hrLocal = _legacyImpl.GetILForModule(moduleAddr, rva, &ilLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*il == ilLocal, $"cDAC: {*il:x}, DAC: {ilLocal:x}");
@@ -1809,7 +1809,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 DacpJitManagerInfo managerLocal = default;
                 int hrLocal = _legacyImpl.GetJitManagerList(count, &managerLocal, null);
-                Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+                Debug.ValidateHResult(hr, hrLocal);
                 if (hr == HResults.S_OK && count >= 1)
                 {
                     Debug.Assert(managers->managerAddr == managerLocal.managerAddr);
@@ -1821,7 +1821,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 uint neededLocal;
                 int hrLocal = _legacyImpl.GetJitManagerList(0, null, &neededLocal);
-                Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+                Debug.ValidateHResult(hr, hrLocal);
                 if (hr == HResults.S_OK && pNeeded is not null)
                 {
                     Debug.Assert(*pNeeded == neededLocal);
@@ -1883,7 +1883,7 @@ public sealed unsafe partial class SOSDacImpl
             ClrDataAddress targetIPLocal;
             ClrDataAddress targetMDLocal;
             int hrLocal = _legacyImpl.GetJumpThunkTarget(ctx, &targetIPLocal, &targetMDLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*targetIP == targetIPLocal, $"cDAC: {*targetIP:x}, DAC: {targetIPLocal:x}");
@@ -2101,7 +2101,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetMethodDescData(addr, ip, &dataLocal, cRevertedRejitVersions, rgRevertedRejitDataLocalPtr, pcNeededRevertedRejitDataLocal);
             }
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->bHasNativeCode == dataLocal.bHasNativeCode, $"cDAC: {data->bHasNativeCode}, DAC: {dataLocal.bHasNativeCode}");
@@ -2225,7 +2225,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             ClrDataAddress methodDescLocal;
             int hrLocal = _legacyImpl.GetMethodDescFromToken(moduleAddr, token, &methodDescLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*methodDesc == methodDescLocal, $"cDAC: {*methodDesc:x}, DAC: {methodDescLocal:x}");
@@ -2312,7 +2312,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetMethodDescName(addr, count, ptr, &neededLocal);
             }
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
@@ -2349,7 +2349,7 @@ public sealed unsafe partial class SOSDacImpl
             ClrDataAddress ppMDLocal;
             int hrLocal = _legacyImpl.GetMethodDescPtrFromFrame(frameAddr, &ppMDLocal);
 
-            Debug.Assert(hrLocal == hr);
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*ppMD == ppMDLocal);
@@ -2400,7 +2400,7 @@ public sealed unsafe partial class SOSDacImpl
             ClrDataAddress ppMDLocal;
             int hrLocal = _legacyImpl.GetMethodDescPtrFromIP(ip, &ppMDLocal);
 
-            Debug.Assert(hrLocal == hr);
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*ppMD == ppMDLocal);
@@ -2483,7 +2483,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpMethodTableData dataLocal;
             int hrLocal = _legacyImpl.GetMethodTableData(mt, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->module == dataLocal.module);
@@ -2531,7 +2531,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 DacpMethodTableFieldData mtFieldDataLocal = default;
                 int hrLocal = _legacyImpl.GetMethodTableFieldData(mt, &mtFieldDataLocal);
-                Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+                Debug.ValidateHResult(hr, hrLocal);
                 if (hr == HResults.S_OK)
                 {
                     Debug.Assert(data->wNumInstanceFields == mtFieldDataLocal.wNumInstanceFields);
@@ -2566,7 +2566,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             ClrDataAddress valueLocal;
             int hrLocal = _legacyImpl.GetMethodTableForEEClass(eeClassReallyCanonMT, &valueLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
                 Debug.Assert(*value == valueLocal);
         }
@@ -2632,7 +2632,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetMethodTableName(mt, count, ptr, &neededLocal);
             }
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
@@ -2702,7 +2702,7 @@ public sealed unsafe partial class SOSDacImpl
 
             hrLocal = _legacyImpl.GetMethodTableSlot(mt, slot, &valueLocal);
 
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK || hr == HResults.S_FALSE)
             {
                 Debug.Assert(*value == valueLocal, $"cDAC: {*value:x}, DAC: {valueLocal:x}");
@@ -2816,7 +2816,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpModuleData dataLocal;
             int hrLocal = _legacyImpl.GetModuleData(moduleAddr, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->Address == dataLocal.Address);
@@ -2870,7 +2870,7 @@ public sealed unsafe partial class SOSDacImpl
             ClrDataAddress exceptionObjectLocal;
             ClrDataAddress nextNestedExceptionLocal;
             int hrLocal = _legacyImpl.GetNestedExceptionData(exception, &exceptionObjectLocal, &nextNestedExceptionLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*exceptionObject == exceptionObjectLocal);
@@ -2943,7 +2943,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetObjectClassName(obj, count, ptr, &neededLocal);
             }
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
@@ -3042,7 +3042,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpObjectData dataLocal;
             int hrLocal = _legacyImpl.GetObjectData(objAddr, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->MethodTable == dataLocal.MethodTable);
@@ -3090,7 +3090,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetObjectStringData(obj, count, ptr, &neededLocal);
             }
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
@@ -3137,7 +3137,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpOomData dataLocal;
             int hrLocal = _legacyImpl.GetOOMData(oomAddr, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->reason == dataLocal.reason, $"cDAC: {data->reason}, DAC: {dataLocal.reason}");
@@ -3187,7 +3187,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpOomData dataLocal;
             int hrLocal = _legacyImpl.GetOOMStaticData(&dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->reason == dataLocal.reason, $"cDAC: {data->reason}, DAC: {dataLocal.reason}");
@@ -3233,7 +3233,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             ClrDataAddress peBaseLocal;
             int hrLocal = _legacyImpl.GetPEFileBase(addr, &peBaseLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
                 Debug.Assert(*peBase == peBaseLocal);
         }
@@ -3278,7 +3278,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetPEFileName(addr, count, ptr, &neededLocal);
             }
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pNeeded == null || *pNeeded == neededLocal);
@@ -3298,7 +3298,7 @@ public sealed unsafe partial class SOSDacImpl
         if (_legacyImpl is not null)
         {
             int hrLocal = _legacyImpl.GetPrivateBinPaths(appDomain, count, paths, pNeeded);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
 
@@ -3363,7 +3363,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl.GetRegisterName(regName, count, ptr, &neededLocal);
             }
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK || hr == HResults.S_FALSE)
             {
                 Debug.Assert(pNeeded is null || *pNeeded == neededLocal);
@@ -3455,7 +3455,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             ClrDataAddress lowerLocal, upperLocal, fpLocal;
             int hrLocal = _legacyImpl.GetStackLimits(threadPtr, &lowerLocal, &upperLocal, &fpLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(lower == null || *lower == lowerLocal, $"cDAC: {*lower:x}, DAC: {lowerLocal:x}");
@@ -3532,7 +3532,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpSyncBlockCleanupData dataLocal;
             int hrLocal = _legacyImpl.GetSyncBlockCleanupData(addr, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->SyncBlockPointer == dataLocal.SyncBlockPointer, $"cDAC: {data->SyncBlockPointer:x}, DAC: {dataLocal.SyncBlockPointer:x}");
@@ -3604,7 +3604,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpSyncBlockData dataLocal;
             int hrLocal = _legacyImpl.GetSyncBlockData(number, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->Object == dataLocal.Object, $"cDAC: {data->Object:x}, DAC: {dataLocal.Object:x}");
@@ -3651,7 +3651,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpAllocData dataLocal = default;
             int hrLocal = _legacyImpl.GetThreadAllocData(thread, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->allocBytes == dataLocal.allocBytes, $"cDAC: {data->allocBytes:x}, DAC: {dataLocal.allocBytes:x}");
@@ -3701,7 +3701,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpThreadData dataLocal;
             int hrLocal = _legacyImpl.GetThreadData(thread, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->corThreadId == dataLocal.corThreadId, $"cDAC: {data->corThreadId}, DAC: {dataLocal.corThreadId}");
@@ -3743,7 +3743,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             ClrDataAddress pThreadLocal;
             int hrLocal = _legacyImpl.GetThreadFromThinlockID(thinLockId, &pThreadLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*pThread == pThreadLocal);
@@ -3761,7 +3761,7 @@ public sealed unsafe partial class SOSDacImpl
         if (_legacyImpl is not null)
         {
             int hrLocal = _legacyImpl.GetThreadLocalModuleData(thread, index, data);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
 
@@ -3777,7 +3777,7 @@ public sealed unsafe partial class SOSDacImpl
         if (_legacyImpl is not null)
         {
             int hrLocal = _legacyImpl.GetThreadpoolData(data);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
 
@@ -3816,7 +3816,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpThreadStoreData dataLocal;
             int hrLocal = _legacyImpl.GetThreadStoreData(&dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(data->threadCount == dataLocal.threadCount);
@@ -3855,7 +3855,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             uint indexLocal;
             int hrLocal = _legacyImpl.GetTLSIndex(&indexLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK || hr == HResults.S_FALSE)
             {
                 Debug.Assert(*pIndex == indexLocal);
@@ -3934,7 +3934,7 @@ public sealed unsafe partial class SOSDacImpl
         if (_legacyImpl is not null)
         {
             int hrLocal = _legacyImpl.GetWorkRequestData(addrWorkRequest, data);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
         }
 #endif
 
@@ -4003,7 +4003,7 @@ public sealed unsafe partial class SOSDacImpl
             delegate* unmanaged[Stdcall]<uint, ulong, void*, void> callbackDebugPtr = &TraverseModuleMapCallback;
 
             int hrLocal = _legacyImpl.TraverseModuleMap(mmt, moduleAddr, callbackDebugPtr, tokenDebug);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             Debug.Assert(expectedElements[default] == elements.Count(), $"cDAC: {elements.Count()} elements, DAC: {expectedElements[default]} elements");
             GCHandle.FromIntPtr((nint)tokenDebug).Free();
         }
@@ -4063,7 +4063,7 @@ public sealed unsafe partial class SOSDacImpl
             delegate* unmanaged[Stdcall]<ulong, ulong, ulong, Interop.BOOL, void*, Interop.BOOL> callbackDebugPtr = &TraverseRCWCleanupListCallback;
 
             int hrLocal = _legacyImpl.TraverseRCWCleanupList(cleanupListPtr, callbackDebugPtr, tokenDebug);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             Debug.Assert(expectedElements[default] == (ulong)cleanupInfos.Count(), $"cDAC: {cleanupInfos.Count()} elements, DAC: {expectedElements[default]} elements");
             expectedElementsHandle.Free();
         }
@@ -4123,7 +4123,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             int inDCOMProxyLocal;
             int hrLocal = _legacyImpl2.IsRCWDCOMProxy(rcwAddress, &inDCOMProxyLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*inDCOMProxy == inDCOMProxyLocal);
@@ -4166,7 +4166,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpGCInterestingInfoData dataLocal = default;
             int hrLocal = _legacyImpl3.GetGCInterestingInfoData(interestingInfoAddr, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 VerifyGCInterestingInfoData(data, &dataLocal);
@@ -4208,7 +4208,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpGCInterestingInfoData dataLocal = default;
             int hrLocal = _legacyImpl3.GetGCInterestingInfoStaticData(&dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 VerifyGCInterestingInfoData(data, &dataLocal);
@@ -4320,7 +4320,7 @@ public sealed unsafe partial class SOSDacImpl
             fixed (nuint* pLocal = globalMechanismsLocal)
             {
                 int hrLocal = _legacyImpl3.GetGCGlobalMechanisms(pLocal);
-                Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+                Debug.ValidateHResult(hr, hrLocal);
                 if (hr == HResults.S_OK)
                 {
                     for (int i = 0; i < GCConstants.DAC_MAX_GLOBAL_GC_MECHANISMS_COUNT; i++)
@@ -4364,7 +4364,7 @@ public sealed unsafe partial class SOSDacImpl
             ClrDataAddress[] argumentsLocal = new ClrDataAddress[count];
             int neededLocal;
             int hrLocal = _legacyImpl4.GetClrNotification(argumentsLocal, count, &neededLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*pNeeded == neededLocal);
@@ -4417,7 +4417,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpMethodTableCollectibleData dataLocal;
             int hrLocal = _legacyImpl6.GetMethodTableCollectibleData(mt, &dataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert((data->bCollectible == 0) == (dataLocal.bCollectible == 0), $"cDAC: {data->bCollectible}, DAC: {dataLocal.bCollectible}");
@@ -4460,7 +4460,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             int rejitIdLocal;
             int hrLocal = _legacyImpl7.GetPendingReJITID(methodDesc, &rejitIdLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*pRejitId == rejitIdLocal);
@@ -4518,7 +4518,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpReJitData2 rejitDataLocal;
             int hrLocal = _legacyImpl7.GetReJITInformation(methodDesc, rejitId, &rejitDataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pRejitData->rejitID == rejitDataLocal.rejitID);
@@ -4579,7 +4579,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             DacpProfilerILData ilDataLocal;
             int hrLocal = _legacyImpl7.GetProfilerModifiedILInformation(methodDesc, &ilDataLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(pILData->type == ilDataLocal.type, $"cDAC: {pILData->type}, DAC: {ilDataLocal.type}");
@@ -4645,7 +4645,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 hrLocal = _legacyImpl7.GetMethodsWithProfilerModifiedIL(mod, ptr, cMethodDescs, &pcMethodDescsLocal);
             }
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*pcMethodDescs == pcMethodDescsLocal, $"cDAC: {*pcMethodDescs}, DAC: {pcMethodDescsLocal}");
@@ -4686,7 +4686,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             uint pGenerationsLocal;
             int hrLocal = _legacyImpl8.GetNumberGenerations(&pGenerationsLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*pGenerations == pGenerationsLocal);
@@ -4744,7 +4744,7 @@ public sealed unsafe partial class SOSDacImpl
             fixed (DacpGenerationData* pGenDataLocal = genDataLocal)
             {
                 int hrLocal = _legacyImpl8.GetGenerationTable(cGenerations, pGenDataLocal, &pNeededLocal);
-                Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+                Debug.ValidateHResult(hr, hrLocal);
                 if (pNeeded is not null)
                 {
                     Debug.Assert(*pNeeded == pNeededLocal);
@@ -4809,7 +4809,7 @@ public sealed unsafe partial class SOSDacImpl
             fixed (ClrDataAddress* pFillPointersLocal = fillPointersLocal)
             {
                 int hrLocal = _legacyImpl8.GetFinalizationFillPointers(cFillPointers, pFillPointersLocal, &pNeededLocal);
-                Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+                Debug.ValidateHResult(hr, hrLocal);
                 if (pNeeded is not null)
                 {
                     Debug.Assert(*pNeeded == pNeededLocal);
@@ -4875,7 +4875,7 @@ public sealed unsafe partial class SOSDacImpl
             fixed (DacpGenerationData* pGenDataLocal = genDataLocal)
             {
                 int hrLocal = _legacyImpl8.GetGenerationTableSvr(heapAddr, cGenerations, pGenDataLocal, &pNeededLocal);
-                Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+                Debug.ValidateHResult(hr, hrLocal);
                 if (pNeeded is not null)
                 {
                     Debug.Assert(*pNeeded == pNeededLocal);
@@ -4940,7 +4940,7 @@ public sealed unsafe partial class SOSDacImpl
             fixed (ClrDataAddress* pFillPointersLocal = fillPointersLocal)
             {
                 int hrLocal = _legacyImpl8.GetFinalizationFillPointersSvr(heapAddr, cFillPointers, pFillPointersLocal, &pNeededLocal);
-                Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+                Debug.ValidateHResult(hr, hrLocal);
                 if (pNeeded is not null)
                 {
                     Debug.Assert(*pNeeded == pNeededLocal);
@@ -4983,7 +4983,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             ClrDataAddress assemblyLoadContextLocal;
             int hrLocal = _legacyImpl8.GetAssemblyLoadContext(methodTable, &assemblyLoadContextLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*assemblyLoadContext == assemblyLoadContextLocal);
@@ -5037,7 +5037,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             Interop.BOOL isComWrappersCCWLocal;
             int hrLocal = _legacyImpl10.IsComWrappersCCW(ccw, &isComWrappersCCWLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK || hr == HResults.S_FALSE)
             {
                 Debug.Assert(*isComWrappersCCW == isComWrappersCCWLocal);
@@ -5078,7 +5078,7 @@ public sealed unsafe partial class SOSDacImpl
             ClrDataAddress managedObjectLocal;
             int refCountLocal;
             int hrLocal = _legacyImpl10.GetComWrappersCCWData(ccw, &managedObjectLocal, &refCountLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 if (managedObject != null)
@@ -5119,7 +5119,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             Interop.BOOL isComWrappersRCWLocal;
             int hrLocal = _legacyImpl10.IsComWrappersRCW(rcw, &isComWrappersRCWLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK || hr == HResults.S_FALSE)
             {
                 Debug.Assert(*isComWrappersRCW == isComWrappersRCWLocal);
@@ -5153,7 +5153,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             ClrDataAddress identityLocal;
             int hrLocal = _legacyImpl10.GetComWrappersRCWData(rcw, &identityLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*identity == identityLocal);
@@ -5196,7 +5196,7 @@ public sealed unsafe partial class SOSDacImpl
             ClrDataAddress allocPtrLocal = default;
             ClrDataAddress allocLimitLocal = default;
             int hrLocal = _legacyImpl12.GetGlobalAllocationContext(&allocPtrLocal, &allocLimitLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*allocPtr == allocPtrLocal);
@@ -5242,7 +5242,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             ClrDataAddress pLoaderAllocatorLocal;
             int hrLocal = _legacyImpl13.GetDomainLoaderAllocator(domainAddress, &pLoaderAllocatorLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK || hr == HResults.S_FALSE)
             {
                 Debug.Assert(*pLoaderAllocator == pLoaderAllocatorLocal);
@@ -5293,7 +5293,7 @@ public sealed unsafe partial class SOSDacImpl
             ClrDataAddress nonGCStaticsAddressLocal;
             ClrDataAddress GCStaticsAddressLocal;
             int hrLocal = _legacyImpl14.GetStaticBaseAddress(methodTable, &nonGCStaticsAddressLocal, &GCStaticsAddressLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 if (GCStaticsAddress != null)
@@ -5347,7 +5347,7 @@ public sealed unsafe partial class SOSDacImpl
             ClrDataAddress* nonGCStaticsAddressOrNull = nonGCStaticsAddress != null ? &nonGCStaticsAddressLocal : null;
             ClrDataAddress* gcStaticsAddressOrNull = GCStaticsAddress != null ? &GCStaticsAddressLocal : null;
             int hrLocal = _legacyImpl14.GetThreadStaticBaseAddress(methodTable, thread, nonGCStaticsAddressOrNull, gcStaticsAddressOrNull);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 if (nonGCStaticsAddress != null)
@@ -5387,7 +5387,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             MethodTableInitializationFlags initializationStatusLocal;
             int hrLocal = _legacyImpl14.GetMethodTableInitializationFlags(methodTable, &initializationStatusLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK)
             {
                 Debug.Assert(*initializationStatus == initializationStatusLocal);
@@ -5518,7 +5518,7 @@ public sealed unsafe partial class SOSDacImpl
                 uint neededLocal;
                 int hrLocal = _legacyMethodEnum.Next(count, valuesLocal, &neededLocal);
 
-                Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+                Debug.ValidateHResult(hr, hrLocal);
                 if (hr == HResults.S_OK || hr == HResults.S_FALSE)
                 {
                     Debug.Assert(*pNeeded == neededLocal, $"cDAC: {*pNeeded}, DAC: {neededLocal}");
@@ -5599,7 +5599,7 @@ public sealed unsafe partial class SOSDacImpl
             if (_legacyImpl15 is not null)
             {
                 int hrLocal = _legacyImpl15.GetMethodTableSlotEnumerator(mt, out legacyMethodEnum);
-                Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+                Debug.ValidateHResult(hr, hrLocal);
             }
 #endif
 
@@ -5645,7 +5645,7 @@ public sealed unsafe partial class SOSDacImpl
         {
             int dynamicAdaptationModeLocal;
             int hrLocal = _legacyImpl16.GetGCDynamicAdaptationMode(&dynamicAdaptationModeLocal);
-            Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
+            Debug.ValidateHResult(hr, hrLocal);
             if (hr == HResults.S_OK || hr == HResults.S_FALSE)
             {
                 Debug.Assert(pDynamicAdaptationMode == null || *pDynamicAdaptationMode == dynamicAdaptationModeLocal);


### PR DESCRIPTION
## Summary

The cDAC's DEBUG validation asserts compare HRESULTs between the cDAC and legacy DAC using exact equality (`Debug.Assert(hrLocal == hr)`). This causes the debugger process to crash when the cDAC and native DAC return different failure HRESULTs for the same invalid input.

For example, when `GetMethodTableData` is called with a garbage method table pointer, the cDAC may throw `InvalidOperationException` (`0x80131C49`) while the native DAC returns `E_INVALIDARG` (`0x80070057`). Both correctly reject the input, but the exact HRESULT comparison fires a fatal `Debug.Assert` that terminates the debugger mid-command — causing flaky CI failures like `SOS.VarargPInvokeInteropMD` in the `cDAC_windows_x64_release` job.

No consumer (ClrMD, SOS, managed debugger) branches on specific failure codes from these APIs — they only check success vs failure.

## Changes

**New file: `DebugExtensions.cs`** — adds `Debug.ValidateHResult()` as a C# 14 static extension method on `System.Diagnostics.Debug`:

```csharp
Debug.ValidateHResult(hr, hrLocal);
```

With two validation modes via `HResultValidationMode`:
- **`Exact`** — HRESULTs must match exactly (available for APIs where the specific code matters)
- **`AllowDivergentFailures`** (default) — success HRESULTs (`S_OK`, `S_FALSE`) must match exactly, but any two failing HRESULTs (negative values) are considered equivalent

**Converted all 113 call sites** across 5 files from:

```csharp
Debug.Assert(hrLocal == hr, $"cDAC: {hr:x}, DAC: {hrLocal:x}");
```

to:

```csharp
Debug.ValidateHResult(hr, hrLocal);
```