### PR TITLE
Remove redundant directory separator normalization in deps.json parsing

### DIFF
--- a/src/native/corehost/hostpolicy/deps_entry.cpp
+++ b/src/native/corehost/hostpolicy/deps_entry.cpp
@@ -127,46 +127,49 @@ static bool to_path(const pal::string_t& base, const pal::string_t& relative_pat
 //
 bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options, bool& found_in_bundle) const
 {
-    pal::string_t relative_path = asset.local_path;
-    if (relative_path.empty())
+    search_options &= ~deps_entry_t::search_options::is_servicing;
+
+    // If local_path is set, use it directly without copying
+    if (!asset.local_path.empty())
     {
-        relative_path = asset.relative_path;
-        if (library_type != _X("runtimepack")) // runtimepack assets set the path to the local path
-        {
-            pal::string_t file_name = get_filename(relative_path);
-
-            // Compute the expected relative path for this asset.
-            //   resource: <ietf-code>/<asset_file_name>
-            //   runtime/native: <asset_file_name>
-            if (asset_type == asset_types::resources)
-            {
-                // Resources are represented as "lib/<netstandrd_ver>/<ietf-code>/<ResourceAssemblyName.dll>" in the deps.json.
-                // The <ietf-code> is the "directory" in the relative_path below, so extract it.
-                pal::string_t ietf_dir = get_directory(relative_path);
-
-                // get_directory returns with DIR_SEPARATOR appended that we need to remove.
-                assert(ietf_dir.back() == DIR_SEPARATOR);
-                remove_trailing_dir_separator(&ietf_dir);
-
-                // Extract IETF code from "lib/<netstandrd_ver>/<ietf-code>"
-                ietf_dir = get_filename(ietf_dir);
-
-                trace::verbose(_X("  Detected a resource asset, will query <base>/<ietf>/<file_name> base: %s ietf: %s asset: %s"),
-                    base.c_str(), ietf_dir.c_str(), asset.name.c_str());
-
-                relative_path = ietf_dir;
-                append_path(&relative_path, file_name.c_str());
-            }
-            else
-            {
-                relative_path = std::move(file_name);
-            }
-        }
-
-        trace::verbose(_X("  Computed relative path: %s"), relative_path.c_str());
+        return to_path(base, asset.local_path, str, search_options, found_in_bundle);
     }
 
-    search_options &= ~deps_entry_t::search_options::is_servicing;
+    // runtimepack assets set the path to the local path - use relative_path as-is
+    if (library_type == _X("runtimepack"))
+    {
+        return to_path(base, asset.relative_path, str, search_options, found_in_bundle);
+    }
+
+    // Compute the expected relative path for this asset.
+    //   resource: <ietf-code>/<asset_file_name>
+    //   runtime/native: <asset_file_name>
+    pal::string_t relative_path;
+    if (asset_type == asset_types::resources)
+    {
+        // Resources are represented as "lib/<netstandrd_ver>/<ietf-code>/<ResourceAssemblyName.dll>" in the deps.json.
+        // The <ietf-code> is the "directory" in the relative_path below, so extract it.
+        pal::string_t ietf_dir = get_directory(asset.relative_path);
+
+        // get_directory returns with DIR_SEPARATOR appended that we need to remove.
+        assert(ietf_dir.back() == DIR_SEPARATOR);
+        remove_trailing_dir_separator(&ietf_dir);
+
+        // Extract IETF code from "lib/<netstandrd_ver>/<ietf-code>"
+        ietf_dir = get_filename(ietf_dir);
+
+        trace::verbose(_X("  Detected a resource asset, will query <base>/<ietf>/<file_name> base: %s ietf: %s asset: %s"),
+            base.c_str(), ietf_dir.c_str(), asset.name.c_str());
+
+        relative_path = ietf_dir;
+        append_path(&relative_path, get_filename(asset.relative_path).c_str());
+    }
+    else
+    {
+        relative_path = get_filename(asset.relative_path);
+    }
+
+    trace::verbose(_X("  Computed relative path: %s"), relative_path.c_str());
     return to_path(base, relative_path, str, search_options, found_in_bundle);
 }
 

--- a/src/native/corehost/hostpolicy/deps_entry.cpp
+++ b/src/native/corehost/hostpolicy/deps_entry.cpp
@@ -135,7 +135,7 @@ bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str, ui
         return to_path(base, asset.local_path, str, search_options, found_in_bundle);
     }
 
-    // runtimepack assets set the path to the local path - use relative_path as-is
+    // For runtimepack assets without a local path set, the relative path is set to the local path on disk - use it as is
     if (library_type == _X("runtimepack"))
     {
         return to_path(base, asset.relative_path, str, search_options, found_in_bundle);

--- a/src/native/corehost/hostpolicy/deps_entry.cpp
+++ b/src/native/corehost/hostpolicy/deps_entry.cpp
@@ -7,19 +7,6 @@
 #include "trace.h"
 #include "bundle/runner.h"
 
-static pal::string_t normalize_dir_separator(const pal::string_t& path)
-{
-    // Entry relative path contains '/' separator, sanitize it to use
-    // platform separator. Perf: avoid extra copy if it matters.
-    pal::string_t normalized_path = path;
-    if (_X('/') != DIR_SEPARATOR)
-    {
-        replace_char(&normalized_path, _X('/'), DIR_SEPARATOR);
-    }
-
-    return normalized_path;
-}
-
 // -----------------------------------------------------------------------------
 // Given a "base" directory, determine the resolved path for this file.
 //
@@ -140,10 +127,10 @@ static bool to_path(const pal::string_t& base, const pal::string_t& relative_pat
 //
 bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options, bool& found_in_bundle) const
 {
-    pal::string_t relative_path = normalize_dir_separator(asset.local_path);
+    pal::string_t relative_path = asset.local_path;
     if (relative_path.empty())
     {
-        relative_path = normalize_dir_separator(asset.relative_path);
+        relative_path = asset.relative_path;
         if (library_type != _X("runtimepack")) // runtimepack assets set the path to the local path
         {
             pal::string_t file_name = get_filename(relative_path);
@@ -198,7 +185,7 @@ bool deps_entry_t::to_dir_path(const pal::string_t& base, pal::string_t* str, ui
 bool deps_entry_t::to_package_path(const pal::string_t& base, pal::string_t* str, uint32_t search_options) const
 {
     bool found_in_bundle;
-    bool result = to_path(base, normalize_dir_separator(asset.relative_path), str, search_options, found_in_bundle);
+    bool result = to_path(base, asset.relative_path, str, search_options, found_in_bundle);
     assert(!found_in_bundle);
     return result;
 }

--- a/src/native/corehost/hostpolicy/deps_entry.h
+++ b/src/native/corehost/hostpolicy/deps_entry.h
@@ -19,10 +19,11 @@ struct deps_asset_t
 
     deps_asset_t(const pal::string_t& name, const pal::string_t& relative_path, const version_t& assembly_version, const version_t& file_version, const pal::string_t& local_path)
         : name(name)
-        , relative_path(get_replaced_char(relative_path, _X('\\'), _X('/'))) // Deps file does not follow spec. It uses '\\', should use '/'
+        // Deps file uses '/' as separator (or '\\' for non-compliant files). Normalize to platform separator.
+        , relative_path(get_replaced_char(relative_path, _X('/') == DIR_SEPARATOR ? _X('\\') : _X('/'), DIR_SEPARATOR))
         , assembly_version(assembly_version)
         , file_version(file_version)
-        , local_path(local_path.empty() ? pal::string_t() : get_replaced_char(local_path, _X('\\'), _X('/'))) { }
+        , local_path(local_path.empty() ? pal::string_t() : get_replaced_char(local_path, _X('/') == DIR_SEPARATOR ? _X('\\') : _X('/'), DIR_SEPARATOR)) { }
 
     pal::string_t name;
     pal::string_t relative_path;

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -71,8 +71,7 @@ namespace
         existing->insert(path);
     }
 
-    // Return the filename from deps path; a deps path always uses a '/' for the separator.
-    // A uniqifying append helperthat doesn't let two entries with the same
+    // A uniqifying append helper that doesn't let two entries with the same
     // "asset_name" be part of the "items" paths.
     void add_tpa_asset(
         const pal::string_t& name,

--- a/src/native/corehost/hostpolicy/deps_resolver.cpp
+++ b/src/native/corehost/hostpolicy/deps_resolver.cpp
@@ -72,23 +72,7 @@ namespace
     }
 
     // Return the filename from deps path; a deps path always uses a '/' for the separator.
-    pal::string_t get_deps_filename(const pal::string_t& path)
-    {
-        if (path.empty())
-        {
-            return path;
-        }
-
-        auto name_pos = path.find_last_of('/');
-        if (name_pos == pal::string_t::npos)
-        {
-            return path;
-        }
-
-        return path.substr(name_pos + 1);
-    }
-
-    // A uniqifying append helper that doesn't let two entries with the same
+    // A uniqifying append helperthat doesn't let two entries with the same
     // "asset_name" be part of the "items" paths.
     void add_tpa_asset(
         const pal::string_t& name,
@@ -434,7 +418,7 @@ bool deps_resolver_t::resolve_tpa_list(
         }
 
         // Ignore placeholders
-        if (utils::ends_with(entry.asset.relative_path, _X("/_._"), false))
+        if (utils::ends_with(entry.asset.relative_path, DIR_SEPARATOR_STR _X("_._"), false))
         {
             return true;
         }
@@ -465,7 +449,7 @@ bool deps_resolver_t::resolve_tpa_list(
         else
         {
             // Verify the extension is the same as the previous verified entry
-            if (get_deps_filename(entry.asset.relative_path) != get_filename(existing->second.resolved_path))
+            if (get_filename(entry.asset.relative_path) != get_filename(existing->second.resolved_path))
             {
                 trace::error(
                     DuplicateAssemblyWithDifferentExtensionMessage,
@@ -780,7 +764,7 @@ bool deps_resolver_t::resolve_probe_dirs(
         }
 
         // Ignore placeholders
-        if (utils::ends_with(entry.asset.relative_path, _X("/_._"), false))
+        if (utils::ends_with(entry.asset.relative_path, DIR_SEPARATOR_STR _X("_._"), false))
         {
             return true;
         }


### PR DESCRIPTION
Normalize paths to the platform separator (DIR_SEPARATOR) once in the
deps_asset_t constructor instead of normalizing them to '/` to store them
and re-normalizing to platform separator on every use.

Removes >400 allocations on startup.

@dotnet/appmodel @AaronRobinsonMSFT 