### PR TITLE
Fix RhpThrowImpl on ARM32

### DIFF
--- a/src/coreclr/nativeaot/Runtime/arm/ExceptionHandling.S
+++ b/src/coreclr/nativeaot/Runtime/arm/ExceptionHandling.S
@@ -144,6 +144,7 @@ NESTED_ENTRY RhpThrowImpl, _TEXT, NoHandler
         ldr         r3, [r0, #OFFSETOF__Thread__m_ppvHijackedReturnAddressLocation]
 
         // r4: exception object
+        // r5: ExKind
         // r1: hijacked return address
         // r0: pThread
         // r3: hijacked return address location

--- a/src/coreclr/nativeaot/Runtime/arm/ExceptionHandling.S
+++ b/src/coreclr/nativeaot/Runtime/arm/ExceptionHandling.S
@@ -182,7 +182,7 @@ LOCAL_LABEL(NotHiJacked):
         str         r3, [r1, #OFFSETOF__ExInfo__m_exception] 	      // init the exception object to null
         mov         r3, #1
         strb        r3, [r1, #OFFSETOF__ExInfo__m_passNumber]       // init to the first pass
-        strb        r5, [r1, #OFFSETOF__ExInfo__m_kind]             // ExKind (from r5, saved from r2)
+        strb        r5, [r1, #OFFSETOF__ExInfo__m_kind]             // ExKind
         mov         r3, #0xFFFFFFFF
         str         r3, [r1, #OFFSETOF__ExInfo__m_idxCurClause]
 

--- a/src/coreclr/nativeaot/Runtime/arm/ExceptionHandling.S
+++ b/src/coreclr/nativeaot/Runtime/arm/ExceptionHandling.S
@@ -127,6 +127,7 @@ NESTED_ENTRY RhpThrowImpl, _TEXT, NoHandler
         str         r4, [sp, #(rsp_offsetof_Context + OFFSETOF__PAL_LIMITED_CONTEXT__SP)]
 
         mov         r4, r0 // Save exception object
+        mov         r5, r2 // Save ExKind
         // r0 = GetThread()
         INLINE_GETTHREAD
 
@@ -180,7 +181,7 @@ LOCAL_LABEL(NotHiJacked):
         str         r3, [r1, #OFFSETOF__ExInfo__m_exception] 	      // init the exception object to null
         mov         r3, #1
         strb        r3, [r1, #OFFSETOF__ExInfo__m_passNumber]       // init to the first pass
-        strb        r2, [r1, #OFFSETOF__ExInfo__m_kind]             // ExKind (from r2)
+        strb        r5, [r1, #OFFSETOF__ExInfo__m_kind]             // ExKind (from r5, saved from r2)
         mov         r3, #0xFFFFFFFF
         str         r3, [r1, #OFFSETOF__ExInfo__m_idxCurClause]
 

--- a/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
+++ b/src/libraries/System.Diagnostics.StackTrace/tests/StackTraceTests.cs
@@ -631,7 +631,6 @@ namespace System.Diagnostics.Tests
             yield return new object[] { () => V2Methods.Bux(), MethodExceptionStrings["Bux"] };
         }
 
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/123979", typeof(PlatformDetection), nameof(PlatformDetection.IsArmProcess))]
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsRuntimeAsyncSupported))]
         [MemberData(nameof(Ctor_Async_TestData))]
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]


### PR DESCRIPTION
In RhpThrowImpl, before calling INLINE_GETTHREAD we were saving the caller-saved register r0 but we should save r2 as well since it contains the exception kind (it's placed in r2 by RhpThrowEx/RhpThrowExact).

Fixes #123979.