### PR TITLE
Implement ValueAsnReader

### DIFF
--- a/src/libraries/Common/src/Internal/Cryptography/PkcsHelpers.cs
+++ b/src/libraries/Common/src/Internal/Cryptography/PkcsHelpers.cs
@@ -377,8 +377,8 @@ namespace Internal.Cryptography
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(normalizedValue, AsnEncodingRules.DER);
-                AsnValueReader setReader = reader.ReadSetOf();
+                ValueAsnReader reader = new ValueAsnReader(normalizedValue, AsnEncodingRules.DER);
+                ValueAsnReader setReader = reader.ReadSetOf();
                 AttributeAsn[] decodedSet = new AttributeAsn[setItems.Length];
                 int i = 0;
                 while (setReader.HasData)

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AlgorithmIdentifierAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AlgorithmIdentifierAsn.xml.cs
@@ -56,7 +56,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out AlgorithmIdentifierAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -68,12 +68,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out AlgorithmIdentifierAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out AlgorithmIdentifierAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out AlgorithmIdentifierAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out AlgorithmIdentifierAsn decoded)
         {
             try
             {
@@ -85,10 +85,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out AlgorithmIdentifierAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out AlgorithmIdentifierAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AttributeAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AttributeAsn.xml.cs
@@ -59,7 +59,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out AttributeAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -71,12 +71,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out AttributeAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out AttributeAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out AttributeAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out AttributeAsn decoded)
         {
             try
             {
@@ -88,11 +88,11 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out AttributeAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out AttributeAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader collectionReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/CurveAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/CurveAsn.xml.cs
@@ -44,7 +44,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out CurveAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -56,12 +56,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out CurveAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out CurveAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CurveAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CurveAsn decoded)
         {
             try
             {
@@ -73,10 +73,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CurveAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CurveAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/DigestInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/DigestInfoAsn.xml.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out DigestInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -49,12 +49,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out DigestInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out DigestInfoAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out DigestInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out DigestInfoAsn decoded)
         {
             try
             {
@@ -66,10 +66,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out DigestInfoAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out DigestInfoAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/DirectoryStringAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/DirectoryStringAsn.xml.cs
@@ -114,7 +114,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, encoded, out DirectoryStringAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -126,7 +126,7 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out DirectoryStringAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out DirectoryStringAsn decoded)
         {
             try
             {
@@ -138,7 +138,7 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out DirectoryStringAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out DirectoryStringAsn decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/DssParms.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/DssParms.xml.cs
@@ -39,7 +39,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, out DssParms decoded);
                 reader.ThrowIfNotEmpty();
@@ -51,12 +51,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, out DssParms decoded)
+        internal static void Decode(ref ValueAsnReader reader, out DssParms decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, out DssParms decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, out DssParms decoded)
         {
             try
             {
@@ -68,10 +68,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, out DssParms decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, out DssParms decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
             decoded.P = sequenceReader.ReadInteger();
             decoded.Q = sequenceReader.ReadInteger();

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/ECDomainParameters.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/ECDomainParameters.xml.cs
@@ -72,7 +72,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, encoded, out ECDomainParameters decoded);
                 reader.ThrowIfNotEmpty();
@@ -84,7 +84,7 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out ECDomainParameters decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out ECDomainParameters decoded)
         {
             try
             {
@@ -96,7 +96,7 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out ECDomainParameters decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out ECDomainParameters decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/ECPrivateKey.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/ECPrivateKey.xml.cs
@@ -55,7 +55,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out ECPrivateKey decoded);
                 reader.ThrowIfNotEmpty();
@@ -67,12 +67,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out ECPrivateKey decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out ECPrivateKey decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out ECPrivateKey decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out ECPrivateKey decoded)
         {
             try
             {
@@ -84,11 +84,11 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out ECPrivateKey decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out ECPrivateKey decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/EdiPartyNameAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/EdiPartyNameAsn.xml.cs
@@ -46,7 +46,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out EdiPartyNameAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -58,12 +58,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out EdiPartyNameAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out EdiPartyNameAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EdiPartyNameAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EdiPartyNameAsn decoded)
         {
             try
             {
@@ -75,11 +75,11 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EdiPartyNameAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EdiPartyNameAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
 
 
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 0)))

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/EncryptedPrivateKeyInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/EncryptedPrivateKeyInfoAsn.xml.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out EncryptedPrivateKeyInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -49,12 +49,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out EncryptedPrivateKeyInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out EncryptedPrivateKeyInfoAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncryptedPrivateKeyInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncryptedPrivateKeyInfoAsn decoded)
         {
             try
             {
@@ -66,10 +66,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncryptedPrivateKeyInfoAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncryptedPrivateKeyInfoAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/FieldID.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/FieldID.xml.cs
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out FieldID decoded);
                 reader.ThrowIfNotEmpty();
@@ -63,12 +63,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out FieldID decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out FieldID decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out FieldID decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out FieldID decoded)
         {
             try
             {
@@ -80,10 +80,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out FieldID decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out FieldID decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/GeneralNameAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/GeneralNameAsn.xml.cs
@@ -174,7 +174,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, encoded, out GeneralNameAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -186,7 +186,7 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out GeneralNameAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out GeneralNameAsn decoded)
         {
             try
             {
@@ -198,11 +198,11 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out GeneralNameAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out GeneralNameAsn decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();
-            AsnValueReader explicitReader;
+            ValueAsnReader explicitReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/GeneralSubtreeAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/GeneralSubtreeAsn.xml.cs
@@ -21,9 +21,9 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         static GeneralSubtreeAsn()
         {
             GeneralSubtreeAsn decoded = default;
-            AsnValueReader reader;
+            ValueAsnReader reader;
 
-            reader = new AsnValueReader(DefaultMinimum, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultMinimum, AsnEncodingRules.DER);
 
             if (!reader.TryReadInt32(out decoded.Minimum))
             {
@@ -79,7 +79,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out GeneralSubtreeAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -91,12 +91,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out GeneralSubtreeAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out GeneralSubtreeAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out GeneralSubtreeAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out GeneralSubtreeAsn decoded)
         {
             try
             {
@@ -108,12 +108,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out GeneralSubtreeAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out GeneralSubtreeAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
-            AsnValueReader defaultReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
+            ValueAsnReader defaultReader;
 
             System.Security.Cryptography.Asn1.GeneralNameAsn.Decode(ref sequenceReader, rebind, out decoded.Base);
 
@@ -130,7 +130,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultMinimum, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultMinimum, AsnEncodingRules.DER);
 
                 if (!defaultReader.TryReadInt32(out decoded.Minimum))
                 {

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLDsaPrivateKeyAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLDsaPrivateKeyAsn.xml.cs
@@ -76,7 +76,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, encoded, out MLDsaPrivateKeyAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -88,7 +88,7 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out MLDsaPrivateKeyAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out MLDsaPrivateKeyAsn decoded)
         {
             try
             {
@@ -100,7 +100,7 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out MLDsaPrivateKeyAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out MLDsaPrivateKeyAsn decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLDsaPrivateKeyBothAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLDsaPrivateKeyBothAsn.xml.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out MLDsaPrivateKeyBothAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -49,12 +49,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out MLDsaPrivateKeyBothAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out MLDsaPrivateKeyBothAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MLDsaPrivateKeyBothAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MLDsaPrivateKeyBothAsn decoded)
         {
             try
             {
@@ -66,10 +66,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MLDsaPrivateKeyBothAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MLDsaPrivateKeyBothAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLKemPrivateKeyAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLKemPrivateKeyAsn.xml.cs
@@ -76,7 +76,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, encoded, out MLKemPrivateKeyAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -88,7 +88,7 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out MLKemPrivateKeyAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out MLKemPrivateKeyAsn decoded)
         {
             try
             {
@@ -100,7 +100,7 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out MLKemPrivateKeyAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out MLKemPrivateKeyAsn decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLKemPrivateKeyBothAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLKemPrivateKeyBothAsn.xml.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out MLKemPrivateKeyBothAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -49,12 +49,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out MLKemPrivateKeyBothAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out MLKemPrivateKeyBothAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MLKemPrivateKeyBothAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MLKemPrivateKeyBothAsn decoded)
         {
             try
             {
@@ -66,10 +66,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MLKemPrivateKeyBothAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MLKemPrivateKeyBothAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/NameConstraintsAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/NameConstraintsAsn.xml.cs
@@ -62,7 +62,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out NameConstraintsAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -74,12 +74,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out NameConstraintsAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out NameConstraintsAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out NameConstraintsAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out NameConstraintsAsn decoded)
         {
             try
             {
@@ -91,11 +91,11 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out NameConstraintsAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out NameConstraintsAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader collectionReader;
 
 
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 0)))

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/OaepParamsAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/OaepParamsAsn.xml.cs
@@ -26,17 +26,17 @@ namespace System.Security.Cryptography.Asn1
         {
             OaepParamsAsn decoded = default;
             ReadOnlyMemory<byte> rebind = default;
-            AsnValueReader reader;
+            ValueAsnReader reader;
 
-            reader = new AsnValueReader(DefaultHashFunc, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultHashFunc, AsnEncodingRules.DER);
             System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref reader, rebind, out decoded.HashFunc);
             reader.ThrowIfNotEmpty();
 
-            reader = new AsnValueReader(DefaultMaskGenFunc, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultMaskGenFunc, AsnEncodingRules.DER);
             System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref reader, rebind, out decoded.MaskGenFunc);
             reader.ThrowIfNotEmpty();
 
-            reader = new AsnValueReader(DefaultPSourceFunc, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultPSourceFunc, AsnEncodingRules.DER);
             System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref reader, rebind, out decoded.PSourceFunc);
             reader.ThrowIfNotEmpty();
         }
@@ -105,7 +105,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out OaepParamsAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -117,12 +117,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out OaepParamsAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out OaepParamsAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OaepParamsAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OaepParamsAsn decoded)
         {
             try
             {
@@ -134,12 +134,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OaepParamsAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OaepParamsAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
-            AsnValueReader defaultReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
+            ValueAsnReader defaultReader;
 
 
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 0)))
@@ -150,7 +150,7 @@ namespace System.Security.Cryptography.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultHashFunc, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultHashFunc, AsnEncodingRules.DER);
                 System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref defaultReader, rebind, out decoded.HashFunc);
             }
 
@@ -163,7 +163,7 @@ namespace System.Security.Cryptography.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultMaskGenFunc, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultMaskGenFunc, AsnEncodingRules.DER);
                 System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref defaultReader, rebind, out decoded.MaskGenFunc);
             }
 
@@ -176,7 +176,7 @@ namespace System.Security.Cryptography.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultPSourceFunc, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultPSourceFunc, AsnEncodingRules.DER);
                 System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref defaultReader, rebind, out decoded.PSourceFunc);
             }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/OtherNameAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/OtherNameAsn.xml.cs
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out OtherNameAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -65,12 +65,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out OtherNameAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out OtherNameAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OtherNameAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OtherNameAsn decoded)
         {
             try
             {
@@ -82,11 +82,11 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OtherNameAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OtherNameAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PBEParameter.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PBEParameter.xml.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out PBEParameter decoded);
                 reader.ThrowIfNotEmpty();
@@ -49,12 +49,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out PBEParameter decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out PBEParameter decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PBEParameter decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PBEParameter decoded)
         {
             try
             {
@@ -66,10 +66,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PBEParameter decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PBEParameter decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PBES2Params.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PBES2Params.xml.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out PBES2Params decoded);
                 reader.ThrowIfNotEmpty();
@@ -49,12 +49,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out PBES2Params decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out PBES2Params decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PBES2Params decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PBES2Params decoded)
         {
             try
             {
@@ -66,10 +66,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PBES2Params decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PBES2Params decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
             System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref sequenceReader, rebind, out decoded.KeyDerivationFunc);
             System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref sequenceReader, rebind, out decoded.EncryptionScheme);

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pbkdf2Params.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pbkdf2Params.xml.cs
@@ -23,9 +23,9 @@ namespace System.Security.Cryptography.Asn1
         {
             Pbkdf2Params decoded = default;
             ReadOnlyMemory<byte> rebind = default;
-            AsnValueReader reader;
+            ValueAsnReader reader;
 
-            reader = new AsnValueReader(DefaultPrf, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultPrf, AsnEncodingRules.DER);
             System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref reader, rebind, out decoded.Prf);
             reader.ThrowIfNotEmpty();
         }
@@ -72,7 +72,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out Pbkdf2Params decoded);
                 reader.ThrowIfNotEmpty();
@@ -84,12 +84,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out Pbkdf2Params decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out Pbkdf2Params decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Pbkdf2Params decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Pbkdf2Params decoded)
         {
             try
             {
@@ -101,11 +101,11 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Pbkdf2Params decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Pbkdf2Params decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader defaultReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader defaultReader;
 
             System.Security.Cryptography.Asn1.Pbkdf2SaltChoice.Decode(ref sequenceReader, rebind, out decoded.Salt);
 
@@ -136,7 +136,7 @@ namespace System.Security.Cryptography.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultPrf, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultPrf, AsnEncodingRules.DER);
                 System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref defaultReader, rebind, out decoded.Prf);
             }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pbkdf2SaltChoice.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pbkdf2SaltChoice.xml.cs
@@ -65,7 +65,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, encoded, out Pbkdf2SaltChoice decoded);
                 reader.ThrowIfNotEmpty();
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out Pbkdf2SaltChoice decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out Pbkdf2SaltChoice decoded)
         {
             try
             {
@@ -89,7 +89,7 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out Pbkdf2SaltChoice decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out Pbkdf2SaltChoice decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/CertBagAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/CertBagAsn.xml.cs
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out CertBagAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -65,12 +65,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out CertBagAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out CertBagAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertBagAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertBagAsn decoded)
         {
             try
             {
@@ -82,11 +82,11 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertBagAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertBagAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/MacData.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/MacData.xml.cs
@@ -21,9 +21,9 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
         static MacData()
         {
             MacData decoded = default;
-            AsnValueReader reader;
+            ValueAsnReader reader;
 
-            reader = new AsnValueReader(DefaultIterationCount, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultIterationCount, AsnEncodingRules.DER);
 
             if (!reader.TryReadInt32(out decoded.IterationCount))
             {
@@ -70,7 +70,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out MacData decoded);
                 reader.ThrowIfNotEmpty();
@@ -82,12 +82,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out MacData decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out MacData decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MacData decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MacData decoded)
         {
             try
             {
@@ -99,11 +99,11 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MacData decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MacData decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader defaultReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader defaultReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;
@@ -131,7 +131,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultIterationCount, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultIterationCount, AsnEncodingRules.DER);
 
                 if (!defaultReader.TryReadInt32(out decoded.IterationCount))
                 {

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/PfxAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/PfxAsn.xml.cs
@@ -44,7 +44,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out PfxAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -56,12 +56,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out PfxAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out PfxAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PfxAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PfxAsn decoded)
         {
             try
             {
@@ -73,10 +73,10 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PfxAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PfxAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
 
             if (!sequenceReader.TryReadInt32(out decoded.Version))

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/SafeBagAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/SafeBagAsn.xml.cs
@@ -68,7 +68,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out SafeBagAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -80,12 +80,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out SafeBagAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out SafeBagAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SafeBagAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SafeBagAsn decoded)
         {
             try
             {
@@ -97,12 +97,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SafeBagAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SafeBagAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
+            ValueAsnReader collectionReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/SecretBagAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/SecretBagAsn.xml.cs
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out SecretBagAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -65,12 +65,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out SecretBagAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out SecretBagAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SecretBagAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SecretBagAsn decoded)
         {
             try
             {
@@ -82,11 +82,11 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SecretBagAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SecretBagAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/CertificateChoiceAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/CertificateChoiceAsn.xml.cs
@@ -162,7 +162,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, encoded, out CertificateChoiceAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -174,7 +174,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out CertificateChoiceAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out CertificateChoiceAsn decoded)
         {
             try
             {
@@ -186,7 +186,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out CertificateChoiceAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out CertificateChoiceAsn decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/ContentInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/ContentInfoAsn.xml.cs
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out ContentInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -65,12 +65,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out ContentInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out ContentInfoAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out ContentInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out ContentInfoAsn decoded)
         {
             try
             {
@@ -82,11 +82,11 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out ContentInfoAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out ContentInfoAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/EncapsulatedContentInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/EncapsulatedContentInfoAsn.xml.cs
@@ -58,7 +58,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out EncapsulatedContentInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -70,12 +70,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out EncapsulatedContentInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out EncapsulatedContentInfoAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncapsulatedContentInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncapsulatedContentInfoAsn decoded)
         {
             try
             {
@@ -87,11 +87,11 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncapsulatedContentInfoAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncapsulatedContentInfoAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/EncryptedContentInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/EncryptedContentInfoAsn.xml.cs
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out EncryptedContentInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -63,12 +63,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out EncryptedContentInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out EncryptedContentInfoAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncryptedContentInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncryptedContentInfoAsn decoded)
         {
             try
             {
@@ -80,10 +80,10 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncryptedContentInfoAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncryptedContentInfoAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/EncryptedDataAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/EncryptedDataAsn.xml.cs
@@ -52,7 +52,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out EncryptedDataAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -64,12 +64,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out EncryptedDataAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out EncryptedDataAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncryptedDataAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncryptedDataAsn decoded)
         {
             try
             {
@@ -81,11 +81,11 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncryptedDataAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EncryptedDataAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader collectionReader;
 
 
             if (!sequenceReader.TryReadInt32(out decoded.Version))

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/IssuerAndSerialNumberAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/IssuerAndSerialNumberAsn.xml.cs
@@ -53,7 +53,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out IssuerAndSerialNumberAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -65,12 +65,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out IssuerAndSerialNumberAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out IssuerAndSerialNumberAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out IssuerAndSerialNumberAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out IssuerAndSerialNumberAsn decoded)
         {
             try
             {
@@ -82,10 +82,10 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out IssuerAndSerialNumberAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out IssuerAndSerialNumberAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/OtherCertificateFormat.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/OtherCertificateFormat.xml.cs
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out OtherCertificateFormat decoded);
                 reader.ThrowIfNotEmpty();
@@ -63,12 +63,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out OtherCertificateFormat decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out OtherCertificateFormat decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OtherCertificateFormat decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OtherCertificateFormat decoded)
         {
             try
             {
@@ -80,10 +80,10 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OtherCertificateFormat decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OtherCertificateFormat decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/SignedDataAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/SignedDataAsn.xml.cs
@@ -91,7 +91,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out SignedDataAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -103,12 +103,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out SignedDataAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out SignedDataAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SignedDataAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SignedDataAsn decoded)
         {
             try
             {
@@ -120,11 +120,11 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SignedDataAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SignedDataAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader collectionReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/SignerIdentifierAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/SignerIdentifierAsn.xml.cs
@@ -65,7 +65,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, encoded, out SignerIdentifierAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out SignerIdentifierAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out SignerIdentifierAsn decoded)
         {
             try
             {
@@ -89,7 +89,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out SignerIdentifierAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out SignerIdentifierAsn decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/SignerInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/SignerInfoAsn.xml.cs
@@ -81,7 +81,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out SignerInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -93,12 +93,12 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out SignerInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out SignerInfoAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SignerInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SignerInfoAsn decoded)
         {
             try
             {
@@ -110,11 +110,11 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SignerInfoAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SignerInfoAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader collectionReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PrivateKeyInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PrivateKeyInfoAsn.xml.cs
@@ -54,7 +54,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out PrivateKeyInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -66,12 +66,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out PrivateKeyInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out PrivateKeyInfoAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PrivateKeyInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PrivateKeyInfoAsn decoded)
         {
             try
             {
@@ -83,11 +83,11 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PrivateKeyInfoAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PrivateKeyInfoAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader collectionReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PssParamsAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PssParamsAsn.xml.cs
@@ -29,17 +29,17 @@ namespace System.Security.Cryptography.Asn1
         {
             PssParamsAsn decoded = default;
             ReadOnlyMemory<byte> rebind = default;
-            AsnValueReader reader;
+            ValueAsnReader reader;
 
-            reader = new AsnValueReader(DefaultHashAlgorithm, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultHashAlgorithm, AsnEncodingRules.DER);
             System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref reader, rebind, out decoded.HashAlgorithm);
             reader.ThrowIfNotEmpty();
 
-            reader = new AsnValueReader(DefaultMaskGenAlgorithm, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultMaskGenAlgorithm, AsnEncodingRules.DER);
             System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref reader, rebind, out decoded.MaskGenAlgorithm);
             reader.ThrowIfNotEmpty();
 
-            reader = new AsnValueReader(DefaultSaltLength, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultSaltLength, AsnEncodingRules.DER);
 
             if (!reader.TryReadInt32(out decoded.SaltLength))
             {
@@ -48,7 +48,7 @@ namespace System.Security.Cryptography.Asn1
 
             reader.ThrowIfNotEmpty();
 
-            reader = new AsnValueReader(DefaultTrailerField, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultTrailerField, AsnEncodingRules.DER);
 
             if (!reader.TryReadInt32(out decoded.TrailerField))
             {
@@ -138,7 +138,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out PssParamsAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -150,12 +150,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out PssParamsAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out PssParamsAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PssParamsAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PssParamsAsn decoded)
         {
             try
             {
@@ -167,12 +167,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PssParamsAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PssParamsAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
-            AsnValueReader defaultReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
+            ValueAsnReader defaultReader;
 
 
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 0)))
@@ -183,7 +183,7 @@ namespace System.Security.Cryptography.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultHashAlgorithm, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultHashAlgorithm, AsnEncodingRules.DER);
                 System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref defaultReader, rebind, out decoded.HashAlgorithm);
             }
 
@@ -196,7 +196,7 @@ namespace System.Security.Cryptography.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultMaskGenAlgorithm, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultMaskGenAlgorithm, AsnEncodingRules.DER);
                 System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref defaultReader, rebind, out decoded.MaskGenAlgorithm);
             }
 
@@ -214,7 +214,7 @@ namespace System.Security.Cryptography.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultSaltLength, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultSaltLength, AsnEncodingRules.DER);
 
                 if (!defaultReader.TryReadInt32(out decoded.SaltLength))
                 {
@@ -237,7 +237,7 @@ namespace System.Security.Cryptography.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultTrailerField, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultTrailerField, AsnEncodingRules.DER);
 
                 if (!defaultReader.TryReadInt32(out decoded.TrailerField))
                 {

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/RSAPrivateKeyAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/RSAPrivateKeyAsn.xml.cs
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out RSAPrivateKeyAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -63,12 +63,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out RSAPrivateKeyAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out RSAPrivateKeyAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RSAPrivateKeyAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RSAPrivateKeyAsn decoded)
         {
             try
             {
@@ -80,10 +80,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RSAPrivateKeyAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RSAPrivateKeyAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/RSAPublicKeyAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/RSAPublicKeyAsn.xml.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out RSAPublicKeyAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -49,12 +49,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out RSAPublicKeyAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out RSAPublicKeyAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RSAPublicKeyAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RSAPublicKeyAsn decoded)
         {
             try
             {
@@ -66,10 +66,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RSAPublicKeyAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RSAPublicKeyAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Rc2CbcParameters.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Rc2CbcParameters.xml.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out Rc2CbcParameters decoded);
                 reader.ThrowIfNotEmpty();
@@ -49,12 +49,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out Rc2CbcParameters decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out Rc2CbcParameters decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rc2CbcParameters decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rc2CbcParameters decoded)
         {
             try
             {
@@ -66,10 +66,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rc2CbcParameters decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rc2CbcParameters decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/SpecifiedECDomain.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/SpecifiedECDomain.xml.cs
@@ -64,7 +64,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out SpecifiedECDomain decoded);
                 reader.ThrowIfNotEmpty();
@@ -76,12 +76,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out SpecifiedECDomain decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out SpecifiedECDomain decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SpecifiedECDomain decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SpecifiedECDomain decoded)
         {
             try
             {
@@ -93,10 +93,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SpecifiedECDomain decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SpecifiedECDomain decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/SubjectPublicKeyInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/SubjectPublicKeyInfoAsn.xml.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out SubjectPublicKeyInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -49,12 +49,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out SubjectPublicKeyInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out SubjectPublicKeyInfoAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SubjectPublicKeyInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SubjectPublicKeyInfoAsn decoded)
         {
             try
             {
@@ -66,10 +66,10 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SubjectPublicKeyInfoAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SubjectPublicKeyInfoAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.xml.cs
@@ -21,9 +21,9 @@ namespace System.Security.Cryptography.Asn1
         static X509ExtensionAsn()
         {
             X509ExtensionAsn decoded = default;
-            AsnValueReader reader;
+            ValueAsnReader reader;
 
-            reader = new AsnValueReader(DefaultCritical, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultCritical, AsnEncodingRules.DER);
             decoded.Critical = reader.ReadBoolean();
             reader.ThrowIfNotEmpty();
         }
@@ -72,7 +72,7 @@ namespace System.Security.Cryptography.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out X509ExtensionAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -84,12 +84,12 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out X509ExtensionAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out X509ExtensionAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out X509ExtensionAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out X509ExtensionAsn decoded)
         {
             try
             {
@@ -101,11 +101,11 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out X509ExtensionAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out X509ExtensionAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader defaultReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader defaultReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;
@@ -118,7 +118,7 @@ namespace System.Security.Cryptography.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultCritical, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultCritical, AsnEncodingRules.DER);
                 decoded.Critical = defaultReader.ReadBoolean();
             }
 

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/asn.xslt
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/asn.xslt
@@ -74,8 +74,8 @@ namespace <xsl:value-of select="@namespace" />
         {
             <xsl:value-of select="@name" /> decoded = default;<xsl:if test="asn:AsnType[@defaultDerInit] | *[@defaultDerInit]/asn:AsnType">
             ReadOnlyMemory&lt;byte&gt; rebind = default;</xsl:if>
-            AsnValueReader reader;<xsl:if test="asn:SequenceOf[@defaultDerInit] | asn:SetOf[@defaultDerInit]">
-            AsnValueReader collectionReader;</xsl:if><xsl:apply-templates mode="DefaultFieldVerify" />
+            ValueAsnReader reader;<xsl:if test="asn:SequenceOf[@defaultDerInit] | asn:SetOf[@defaultDerInit]">
+            ValueAsnReader collectionReader;</xsl:if><xsl:apply-templates mode="DefaultFieldVerify" />
         }
 #endif
 </xsl:if>
@@ -100,7 +100,7 @@ namespace <xsl:value-of select="@namespace" />
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, <xsl:if test="$hasRebind &gt; 0">encoded, </xsl:if>out <xsl:value-of select="@name" /> decoded);
                 reader.ThrowIfNotEmpty();
@@ -112,12 +112,12 @@ namespace <xsl:value-of select="@namespace" />
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader,<xsl:if test="$hasRebind &gt; 0"> ReadOnlyMemory&lt;byte&gt; rebind,</xsl:if> out <xsl:value-of select="@name" /> decoded)
+        internal static void Decode(ref ValueAsnReader reader,<xsl:if test="$hasRebind &gt; 0"> ReadOnlyMemory&lt;byte&gt; rebind,</xsl:if> out <xsl:value-of select="@name" /> decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, <xsl:if test="$hasRebind &gt; 0">rebind, </xsl:if>out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag,<xsl:if test="$hasRebind &gt; 0"> ReadOnlyMemory&lt;byte&gt; rebind,</xsl:if> out <xsl:value-of select="@name" /> decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag,<xsl:if test="$hasRebind &gt; 0"> ReadOnlyMemory&lt;byte&gt; rebind,</xsl:if> out <xsl:value-of select="@name" /> decoded)
         {
             try
             {
@@ -129,13 +129,13 @@ namespace <xsl:value-of select="@namespace" />
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag,<xsl:if test="$hasRebind &gt; 0"> ReadOnlyMemory&lt;byte&gt; rebind,</xsl:if> out <xsl:value-of select="@name" /> decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag,<xsl:if test="$hasRebind &gt; 0"> ReadOnlyMemory&lt;byte&gt; rebind,</xsl:if> out <xsl:value-of select="@name" /> decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);<xsl:if test="*[@explicitTag]">
-            AsnValueReader explicitReader;</xsl:if><xsl:if test="*[@defaultDerInit]">
-            AsnValueReader defaultReader;</xsl:if><xsl:if test="asn:SequenceOf | asn:SetOf">
-            AsnValueReader collectionReader;</xsl:if><xsl:if test="$hasMemoryField &gt; 0">
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);<xsl:if test="*[@explicitTag]">
+            ValueAsnReader explicitReader;</xsl:if><xsl:if test="*[@defaultDerInit]">
+            ValueAsnReader defaultReader;</xsl:if><xsl:if test="asn:SequenceOf | asn:SetOf">
+            ValueAsnReader collectionReader;</xsl:if><xsl:if test="$hasMemoryField &gt; 0">
             ReadOnlySpan&lt;byte&gt; rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan&lt;byte&gt; tmpSpan;</xsl:if>
@@ -193,7 +193,7 @@ namespace <xsl:value-of select="@namespace" />
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, <xsl:if test="not(@rebind='false')">encoded, </xsl:if>out <xsl:value-of select="@name" /> decoded);
                 reader.ThrowIfNotEmpty();
@@ -205,7 +205,7 @@ namespace <xsl:value-of select="@namespace" />
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, <xsl:if test="not(@rebind='false')">ReadOnlyMemory&lt;byte&gt; rebind, </xsl:if>out <xsl:value-of select="@name" /> decoded)
+        internal static void Decode(ref ValueAsnReader reader, <xsl:if test="not(@rebind='false')">ReadOnlyMemory&lt;byte&gt; rebind, </xsl:if>out <xsl:value-of select="@name" /> decoded)
         {
             try
             {
@@ -217,12 +217,12 @@ namespace <xsl:value-of select="@namespace" />
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, <xsl:if test="not(@rebind='false')">ReadOnlyMemory&lt;byte&gt; rebind, </xsl:if>out <xsl:value-of select="@name" /> decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, <xsl:if test="not(@rebind='false')">ReadOnlyMemory&lt;byte&gt; rebind, </xsl:if>out <xsl:value-of select="@name" /> decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();<xsl:if test="*[@explicitTag]">
-            AsnValueReader explicitReader;</xsl:if><xsl:if test="asn:SequenceOf | asn:SetOf">
-            AsnValueReader collectionReader;</xsl:if><xsl:if test="$hasMemoryField &gt; 0">
+            ValueAsnReader explicitReader;</xsl:if><xsl:if test="asn:SequenceOf | asn:SetOf">
+            ValueAsnReader collectionReader;</xsl:if><xsl:if test="$hasMemoryField &gt; 0">
             ReadOnlySpan&lt;byte&gt; rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan&lt;byte&gt; tmpSpan;</xsl:if>
@@ -258,7 +258,7 @@ namespace <xsl:value-of select="@namespace" />
 
   <xsl:template match="*[@defaultDerInit]" mode="DefaultFieldVerify">
 
-            reader = new AsnValueReader(<xsl:call-template name="DefaultValueField"/>, AsnEncodingRules.DER);<xsl:apply-templates select="." mode="DecodeSimpleValue"><xsl:with-param name="readerName" select="'reader'"/></xsl:apply-templates>
+            reader = new ValueAsnReader(<xsl:call-template name="DefaultValueField"/>, AsnEncodingRules.DER);<xsl:apply-templates select="." mode="DecodeSimpleValue"><xsl:with-param name="readerName" select="'reader'"/></xsl:apply-templates>
             reader.ThrowIfNotEmpty();</xsl:template>
 
   <xsl:template match="*" mode="EnsureUniqueTag" xml:space="default">
@@ -938,7 +938,7 @@ namespace <xsl:value-of select="@namespace" />
   <xsl:template name="DefaultValueDecoder"><xsl:if test="@defaultDerInit">
             else
             {
-                defaultReader = new AsnValueReader(<xsl:call-template name="DefaultValueField"/>, AsnEncodingRules.DER);<xsl:apply-templates select="." mode="DecodeSimpleValue"><xsl:with-param name="readerName" select="'defaultReader'"/><xsl:with-param name="indent" select="'    '"/></xsl:apply-templates>
+                defaultReader = new ValueAsnReader(<xsl:call-template name="DefaultValueField"/>, AsnEncodingRules.DER);<xsl:apply-templates select="." mode="DecodeSimpleValue"><xsl:with-param name="readerName" select="'defaultReader'"/><xsl:with-param name="indent" select="'    '"/></xsl:apply-templates>
             }</xsl:if></xsl:template>
 
   <xsl:template name="DefaultOrContextTag" xml:space="default">

--- a/src/libraries/Common/src/System/Security/Cryptography/AsymmetricAlgorithmHelpers.Der.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/AsymmetricAlgorithmHelpers.Der.cs
@@ -65,8 +65,8 @@ namespace System.Security.Cryptography
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(input, AsnEncodingRules.DER);
-                AsnValueReader sequenceReader = reader.ReadSequence();
+                ValueAsnReader reader = new ValueAsnReader(input, AsnEncodingRules.DER);
+                ValueAsnReader sequenceReader = reader.ReadSequence();
                 reader.ThrowIfNotEmpty();
                 ReadOnlySpan<byte> rDer = sequenceReader.ReadIntegerBytes();
                 ReadOnlySpan<byte> sDer = sequenceReader.ReadIntegerBytes();

--- a/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
@@ -104,7 +104,7 @@ namespace System.Security.Cryptography
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(source.Span, AsnEncodingRules.BER);
+                ValueAsnReader reader = new ValueAsnReader(source.Span, AsnEncodingRules.BER);
                 read = reader.PeekEncodedValue().Length;
                 EncryptedPrivateKeyInfoAsn.Decode(ref reader, source, out epki);
             }
@@ -288,7 +288,7 @@ namespace System.Security.Cryptography
 
                     try
                     {
-                        AsnValueReader reader = new(decrypted, AsnEncodingRules.BER);
+                        ValueAsnReader reader = new(decrypted, AsnEncodingRules.BER);
                         reader.ReadEncodedValue();
                         reader.ThrowIfNotEmpty();
                         return keyReader(decrypted);
@@ -316,7 +316,7 @@ namespace System.Security.Cryptography
                 using (PointerMemoryManager<byte> manager = new(pointer, source.Length))
                 {
                     ArraySegment<byte> decrypted = KeyFormatHelper.DecryptPkcs8(passwordBytes, manager.Memory, out bytesRead);
-                    AsnValueReader reader = new(decrypted, AsnEncodingRules.BER);
+                    ValueAsnReader reader = new(decrypted, AsnEncodingRules.BER);
                     reader.ReadEncodedValue();
 
                     try
@@ -347,7 +347,7 @@ namespace System.Security.Cryptography
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(source.Span, AsnEncodingRules.BER);
+                ValueAsnReader reader = new ValueAsnReader(source.Span, AsnEncodingRules.BER);
                 localRead = reader.PeekEncodedValue().Length;
                 EncryptedPrivateKeyInfoAsn.Decode(ref reader, source, out epki);
             }

--- a/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.cs
@@ -40,7 +40,7 @@ namespace System.Security.Cryptography
             try
             {
                 // X.509 SubjectPublicKeyInfo is described as DER.
-                AsnValueReader reader = new AsnValueReader(source.Span, AsnEncodingRules.DER);
+                ValueAsnReader reader = new ValueAsnReader(source.Span, AsnEncodingRules.DER);
                 read = reader.PeekEncodedValue().Length;
                 SubjectPublicKeyInfoAsn.Decode(ref reader, source, out spki);
             }
@@ -71,7 +71,7 @@ namespace System.Security.Cryptography
             try
             {
                 // X.509 SubjectPublicKeyInfo is described as DER.
-                AsnValueReader reader = new AsnValueReader(source.Span, AsnEncodingRules.DER);
+                ValueAsnReader reader = new ValueAsnReader(source.Span, AsnEncodingRules.DER);
                 read = reader.PeekEncodedValue().Length;
                 SubjectPublicKeyInfoAsn.Decode(ref reader, source, out spki);
             }
@@ -112,7 +112,7 @@ namespace System.Security.Cryptography
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(source.Span, AsnEncodingRules.BER);
+                ValueAsnReader reader = new ValueAsnReader(source.Span, AsnEncodingRules.BER);
                 int read = reader.PeekEncodedValue().Length;
                 PrivateKeyInfoAsn.Decode(ref reader, source, out PrivateKeyInfoAsn privateKeyInfo);
 
@@ -139,7 +139,7 @@ namespace System.Security.Cryptography
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(source.Span, AsnEncodingRules.BER);
+                ValueAsnReader reader = new ValueAsnReader(source.Span, AsnEncodingRules.BER);
                 int read = reader.PeekEncodedValue().Length;
                 PrivateKeyInfoAsn.Decode(ref reader, source, out PrivateKeyInfoAsn privateKeyInfo);
 

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
@@ -1382,7 +1382,7 @@ namespace System.Security.Cryptography
                 {
                     using (PointerMemoryManager<byte> manager = new(pointer, source.Length))
                     {
-                        AsnValueReader reader = new AsnValueReader(source, AsnEncodingRules.DER);
+                        ValueAsnReader reader = new ValueAsnReader(source, AsnEncodingRules.DER);
                         SubjectPublicKeyInfoAsn.Decode(ref reader, manager.Memory, out SubjectPublicKeyInfoAsn spki);
 
                         MLDsaAlgorithm algorithm = GetAlgorithmIdentifier(ref spki.Algorithm);

--- a/src/libraries/Common/src/System/Security/Cryptography/Oids.Shared.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Oids.Shared.cs
@@ -57,23 +57,23 @@ namespace System.Security.Cryptography
             return oid;
         }
 
-        internal static Oid GetSharedOrNewOid(ref ValueAsnReader ValueAsnReader)
+        internal static Oid GetSharedOrNewOid(ref ValueAsnReader valueAsnReader)
         {
-            Oid? ret = GetSharedOrNullOid(ref ValueAsnReader);
+            Oid? ret = GetSharedOrNullOid(ref valueAsnReader);
 
             if (ret is not null)
             {
                 return ret;
             }
 
-            string oidValue = ValueAsnReader.ReadObjectIdentifier();
+            string oidValue = valueAsnReader.ReadObjectIdentifier();
             return new Oid(oidValue, null);
         }
 
-        internal static Oid? GetSharedOrNullOid(ref ValueAsnReader ValueAsnReader, Asn1Tag? expectedTag = null)
+        internal static Oid? GetSharedOrNullOid(ref ValueAsnReader valueAsnReader, Asn1Tag? expectedTag = null)
         {
 #if NET
-            Asn1Tag tag = ValueAsnReader.PeekTag();
+            Asn1Tag tag = valueAsnReader.PeekTag();
 
             // This isn't a valid OID, so return null and let whatever's going to happen happen.
             if (tag.IsConstructed)
@@ -94,7 +94,7 @@ namespace System.Security.Cryptography
                 return null;
             }
 
-            ReadOnlySpan<byte> contentBytes = ValueAsnReader.PeekContentBytes();
+            ReadOnlySpan<byte> contentBytes = valueAsnReader.PeekContentBytes();
 
             Oid? ret = contentBytes switch
             {
@@ -112,7 +112,7 @@ namespace System.Security.Cryptography
             if (ret is not null)
             {
                 // Move to the next item.
-                ValueAsnReader.ReadEncodedValue();
+                valueAsnReader.ReadEncodedValue();
             }
 
             return ret;

--- a/src/libraries/Common/src/System/Security/Cryptography/Oids.Shared.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Oids.Shared.cs
@@ -57,23 +57,23 @@ namespace System.Security.Cryptography
             return oid;
         }
 
-        internal static Oid GetSharedOrNewOid(ref AsnValueReader asnValueReader)
+        internal static Oid GetSharedOrNewOid(ref ValueAsnReader ValueAsnReader)
         {
-            Oid? ret = GetSharedOrNullOid(ref asnValueReader);
+            Oid? ret = GetSharedOrNullOid(ref ValueAsnReader);
 
             if (ret is not null)
             {
                 return ret;
             }
 
-            string oidValue = asnValueReader.ReadObjectIdentifier();
+            string oidValue = ValueAsnReader.ReadObjectIdentifier();
             return new Oid(oidValue, null);
         }
 
-        internal static Oid? GetSharedOrNullOid(ref AsnValueReader asnValueReader, Asn1Tag? expectedTag = null)
+        internal static Oid? GetSharedOrNullOid(ref ValueAsnReader ValueAsnReader, Asn1Tag? expectedTag = null)
         {
 #if NET
-            Asn1Tag tag = asnValueReader.PeekTag();
+            Asn1Tag tag = ValueAsnReader.PeekTag();
 
             // This isn't a valid OID, so return null and let whatever's going to happen happen.
             if (tag.IsConstructed)
@@ -94,7 +94,7 @@ namespace System.Security.Cryptography
                 return null;
             }
 
-            ReadOnlySpan<byte> contentBytes = asnValueReader.PeekContentBytes();
+            ReadOnlySpan<byte> contentBytes = ValueAsnReader.PeekContentBytes();
 
             Oid? ret = contentBytes switch
             {
@@ -112,7 +112,7 @@ namespace System.Security.Cryptography
             if (ret is not null)
             {
                 // Move to the next item.
-                asnValueReader.ReadEncodedValue();
+                ValueAsnReader.ReadEncodedValue();
             }
 
             return ret;

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12Info.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12Info.cs
@@ -107,8 +107,8 @@ namespace System.Security.Cryptography.Pkcs
             List<ContentInfoAsn> authSafeData = new List<ContentInfoAsn>();
             try
             {
-                AsnValueReader authSafeReader = new AsnValueReader(authSafeBytes.Span, AsnEncodingRules.BER);
-                AsnValueReader sequenceReader = authSafeReader.ReadSequence();
+                ValueAsnReader authSafeReader = new ValueAsnReader(authSafeBytes.Span, AsnEncodingRules.BER);
+                ValueAsnReader sequenceReader = authSafeReader.ReadSequence();
 
                 authSafeReader.ThrowIfNotEmpty();
                 while (sequenceReader.HasData)

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12SafeContents.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs12SafeContents.cs
@@ -283,8 +283,8 @@ namespace System.Security.Cryptography.Pkcs
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(serialized.Span, AsnEncodingRules.BER);
-                AsnValueReader sequenceReader = reader.ReadSequence();
+                ValueAsnReader reader = new ValueAsnReader(serialized.Span, AsnEncodingRules.BER);
+                ValueAsnReader sequenceReader = reader.ReadSequence();
 
                 reader.ThrowIfNotEmpty();
                 while (sequenceReader.HasData)

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs8PrivateKeyInfo.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs8PrivateKeyInfo.cs
@@ -71,7 +71,7 @@ namespace System.Security.Cryptography.Pkcs
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(source.Span, AsnEncodingRules.BER);
+                ValueAsnReader reader = new ValueAsnReader(source.Span, AsnEncodingRules.BER);
                 // By using the default/empty ReadOnlyMemory value, the Decode method will have to
                 // make copies of the data when assigning ReadOnlyMemory fields.
                 ReadOnlyMemory<byte> rebind = skipCopy ? source : default;

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAKeyFormatHelper.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAKeyFormatHelper.cs
@@ -44,7 +44,7 @@ namespace System.Security.Cryptography
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(keyData.Span, AsnEncodingRules.DER);
+                ValueAsnReader reader = new ValueAsnReader(keyData.Span, AsnEncodingRules.DER);
                 read = reader.PeekEncodedValue().Length;
                 RSAPublicKeyAsn.Decode(keyData, AsnEncodingRules.BER);
             }

--- a/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Pkcs12.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Pkcs12.cs
@@ -187,8 +187,8 @@ namespace System.Security.Cryptography.X509Certificates
                     bagState.ConfirmPassword();
                 }
 
-                AsnValueReader outer = new AsnValueReader(authSafeContents, AsnEncodingRules.BER);
-                AsnValueReader reader = outer.ReadSequence();
+                ValueAsnReader outer = new ValueAsnReader(authSafeContents, AsnEncodingRules.BER);
+                ValueAsnReader reader = outer.ReadSequence();
                 outer.ThrowIfNotEmpty();
 
                 ReadOnlyMemory<byte> rebind = pfxAsn.AuthSafe.Content;
@@ -276,8 +276,8 @@ namespace System.Security.Cryptography.X509Certificates
             ref int? workRemaining,
             ref BagState bagState)
         {
-            AsnValueReader outer = new AsnValueReader(contentData.Span, AsnEncodingRules.BER);
-            AsnValueReader reader = outer.ReadSequence();
+            ValueAsnReader outer = new ValueAsnReader(contentData.Span, AsnEncodingRules.BER);
+            ValueAsnReader reader = outer.ReadSequence();
             outer.ThrowIfNotEmpty();
 
             HashSet<string> duplicateAttributeCheck = new();
@@ -1002,7 +1002,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                     try
                     {
-                        AsnValueReader reader = new AsnValueReader(
+                        ValueAsnReader reader = new ValueAsnReader(
                             _decryptBuffer.AsSpan(saveOffset, written),
                             AsnEncodingRules.BER);
 
@@ -1114,7 +1114,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                                 try
                                 {
-                                    AsnValueReader reader = new AsnValueReader(decrypted, AsnEncodingRules.BER);
+                                    ValueAsnReader reader = new ValueAsnReader(decrypted, AsnEncodingRules.BER);
                                     reader.ReadSequence();
                                     reader.ThrowIfNotEmpty();
                                 }
@@ -1142,7 +1142,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                                 try
                                 {
-                                    AsnValueReader reader = new AsnValueReader(decrypted, AsnEncodingRules.BER);
+                                    ValueAsnReader reader = new ValueAsnReader(decrypted, AsnEncodingRules.BER);
                                     reader.ReadSequence();
                                     reader.ThrowIfNotEmpty();
                                 }

--- a/src/libraries/System.Formats.Asn1/ref/System.Formats.Asn1.cs
+++ b/src/libraries/System.Formats.Asn1/ref/System.Formats.Asn1.cs
@@ -253,4 +253,50 @@ namespace System.Formats.Asn1
         ObjectIdentifierIRI = 35,
         RelativeObjectIdentifierIRI = 36,
     }
+    public ref partial struct ValueAsnReader
+    {
+        private object _dummy;
+        private int _dummyPrimitive;
+        public ValueAsnReader(System.ReadOnlySpan<byte> data, System.Formats.Asn1.AsnEncodingRules ruleSet, System.Formats.Asn1.AsnReaderOptions options = default(System.Formats.Asn1.AsnReaderOptions)) { throw null; }
+        public readonly bool HasData { get { throw null; } }
+        public readonly System.Formats.Asn1.AsnEncodingRules RuleSet { get { throw null; } }
+        public readonly System.ReadOnlySpan<byte> PeekContentBytes() { throw null; }
+        public readonly System.ReadOnlySpan<byte> PeekEncodedValue() { throw null; }
+        public readonly System.Formats.Asn1.Asn1Tag PeekTag() { throw null; }
+        public byte[] ReadBitString(out int unusedBitCount, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public bool ReadBoolean(System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public string ReadCharacterString(System.Formats.Asn1.UniversalTagNumber encodingType, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public System.ReadOnlySpan<byte> ReadEncodedValue() { throw null; }
+        public System.ReadOnlySpan<byte> ReadEnumeratedBytes(System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public System.Enum ReadEnumeratedValue(System.Type enumType, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public TEnum ReadEnumeratedValue<TEnum>(System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) where TEnum : System.Enum { throw null; }
+        public System.DateTimeOffset ReadGeneralizedTime(System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public System.Numerics.BigInteger ReadInteger(System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public System.ReadOnlySpan<byte> ReadIntegerBytes(System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public System.Collections.BitArray ReadNamedBitList(System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public System.Enum ReadNamedBitListValue(System.Type flagsEnumType, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) where TFlagsEnum : System.Enum { throw null; }
+        public void ReadNull(System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { }
+        public string ReadObjectIdentifier(System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public byte[] ReadOctetString(System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public System.Formats.Asn1.ValueAsnReader ReadSequence(System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public System.Formats.Asn1.ValueAsnReader ReadSetOf(bool skipSortOrderValidation, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public System.Formats.Asn1.ValueAsnReader ReadSetOf(System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public System.DateTimeOffset ReadUtcTime(int twoDigitYearMax, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public System.DateTimeOffset ReadUtcTime(System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public readonly void ThrowIfNotEmpty() { }
+        public bool TryReadBitString(System.Span<byte> destination, out int unusedBitCount, out int bytesWritten, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public bool TryReadCharacterString(System.Span<char> destination, System.Formats.Asn1.UniversalTagNumber encodingType, out int charsWritten, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public bool TryReadCharacterStringBytes(System.Span<byte> destination, System.Formats.Asn1.Asn1Tag expectedTag, out int bytesWritten) { throw null; }
+        public bool TryReadInt32(out int value, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public bool TryReadInt64(out long value, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public bool TryReadOctetString(System.Span<byte> destination, out int bytesWritten, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public bool TryReadPrimitiveBitString(out int unusedBitCount, out System.ReadOnlySpan<byte> value, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        public bool TryReadPrimitiveCharacterStringBytes(System.Formats.Asn1.Asn1Tag expectedTag, out System.ReadOnlySpan<byte> contents) { throw null; }
+        public bool TryReadPrimitiveOctetString(out System.ReadOnlySpan<byte> contents, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public bool TryReadUInt32(out uint value, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+        [System.CLSCompliantAttribute(false)]
+        public bool TryReadUInt64(out ulong value, System.Formats.Asn1.Asn1Tag? expectedTag = default(System.Formats.Asn1.Asn1Tag?)) { throw null; }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.BitString.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.BitString.cs
@@ -847,4 +847,173 @@ namespace System.Formats.Asn1
             return ret;
         }
     }
+
+    public ref partial struct ValueAsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a BIT STRING with a specified tag, returning the contents
+        ///   as a <see cref="ReadOnlySpan{T}"/> over the original data.
+        /// </summary>
+        /// <param name="unusedBitCount">
+        ///   On success, receives the number of bits in the last byte which were reported as
+        ///   "unused" by the writer.
+        /// </param>
+        /// <param name="value">
+        ///   On success, receives a <see cref="ReadOnlySpan{T}"/> over the original data
+        ///   corresponding to the value of the BIT STRING.
+        /// </param>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 3).
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> and advances the reader if the BIT STRING value had a primitive encoding,
+        ///   <see langword="false"/> and does not advance the reader if it had a constructed encoding.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <seealso cref="TryReadBitString"/>
+        public bool TryReadPrimitiveBitString(
+            out int unusedBitCount,
+            out ReadOnlySpan<byte> value,
+            Asn1Tag? expectedTag = null)
+        {
+            bool ret = AsnDecoder.TryReadPrimitiveBitString(
+                _data,
+                RuleSet,
+                out unusedBitCount,
+                out value,
+                out int consumed,
+                expectedTag);
+
+            if (ret)
+            {
+                _data = _data.Slice(consumed);
+            }
+
+            return ret;
+        }
+
+        /// <summary>
+        ///   Reads the next value as a BIT STRING with a specified tag, copying the value
+        ///   into a provided destination buffer.
+        /// </summary>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="unusedBitCount">
+        ///   On success, receives the number of bits in the last byte which were reported as
+        ///   "unused" by the writer.
+        /// </param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 3).
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <see langword="false"/> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveBitString"/>
+        /// <seealso cref="ReadBitString"/>
+        public bool TryReadBitString(
+            Span<byte> destination,
+            out int unusedBitCount,
+            out int bytesWritten,
+            Asn1Tag? expectedTag = null)
+        {
+            bool ret = AsnDecoder.TryReadBitString(
+                _data,
+                destination,
+                RuleSet,
+                out unusedBitCount,
+                out int consumed,
+                out bytesWritten,
+                expectedTag);
+
+            if (ret)
+            {
+                _data = _data.Slice(consumed);
+            }
+
+            return ret;
+        }
+
+        /// <summary>
+        ///   Reads the next value as a BIT STRING with a specified tag, returning the value
+        ///   in a byte array.
+        /// </summary>
+        /// <param name="unusedBitCount">
+        ///   On success, receives the number of bits in the last byte which were reported as
+        ///   "unused" by the writer.
+        /// </param>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 3).
+        /// </param>
+        /// <returns>
+        ///   A copy of the value in a newly allocated, precisely sized, array.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveBitString"/>
+        /// <seealso cref="TryReadBitString"/>
+        public byte[] ReadBitString(out int unusedBitCount, Asn1Tag? expectedTag = null)
+        {
+            byte[] ret = AsnDecoder.ReadBitString(
+                _data,
+                RuleSet,
+                out unusedBitCount,
+                out int consumed,
+                expectedTag);
+
+            _data = _data.Slice(consumed);
+            return ret;
+        }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Boolean.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Boolean.cs
@@ -116,4 +116,40 @@ namespace System.Formats.Asn1
             return ret;
         }
     }
+
+    public ref partial struct ValueAsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a Boolean with a specified tag.
+        /// </summary>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 1).
+        /// </param>
+        /// <returns>
+        ///   The decoded value.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        public bool ReadBoolean(Asn1Tag? expectedTag = null)
+        {
+            bool ret = AsnDecoder.ReadBoolean(_data, RuleSet, out int bytesConsumed, expectedTag);
+            _data = _data.Slice(bytesConsumed);
+            return ret;
+        }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Enumerated.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Enumerated.cs
@@ -408,4 +408,149 @@ namespace System.Formats.Asn1
             return ret;
         }
     }
+
+    public ref partial struct ValueAsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as an Enumerated with a specified tag, returning the contents
+        ///   as a <see cref="ReadOnlySpan{T}"/> over the original data.
+        /// </summary>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 10).
+        /// </param>
+        /// <returns>
+        ///   The bytes of the Enumerated value, in signed big-endian form.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <seealso cref="ReadEnumeratedValue{TEnum}"/>
+        public ReadOnlySpan<byte> ReadEnumeratedBytes(Asn1Tag? expectedTag = null)
+        {
+            ReadOnlySpan<byte> bytes =
+                AsnDecoder.ReadEnumeratedBytes(_data, RuleSet, out int consumed, expectedTag);
+
+            _data = _data.Slice(consumed);
+            return bytes;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Enumerated with a specified tag, converting it to the
+        ///   non-[<see cref="FlagsAttribute"/>] enum specified by <typeparamref name="TEnum"/>.
+        /// </summary>
+        /// <typeparam name="TEnum">The destination enum type.</typeparam>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 10).
+        /// </param>
+        /// <returns>
+        ///   The Enumerated value converted to a <typeparamref name="TEnum"/>.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The encoded value is too big to fit in a <typeparamref name="TEnum"/> value.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <typeparamref name="TEnum"/> is not an enum type.
+        ///
+        ///   -or-
+        ///
+        ///   <typeparamref name="TEnum"/> was declared with <see cref="FlagsAttribute"/>.
+        ///
+        ///   -or-
+        ///
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <remarks>
+        ///   This method does not validate that the return value is defined within
+        ///   <typeparamref name="TEnum"/>.
+        /// </remarks>
+        public TEnum ReadEnumeratedValue<TEnum>(Asn1Tag? expectedTag = null) where TEnum : Enum
+        {
+            TEnum ret = AsnDecoder.ReadEnumeratedValue<TEnum>(_data, RuleSet, out int consumed, expectedTag);
+            _data = _data.Slice(consumed);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Enumerated with a specified tag, converting it to the
+        ///   non-[<see cref="FlagsAttribute"/>] enum specified by <paramref name="enumType"/>.
+        /// </summary>
+        /// <param name="enumType">Type object representing the destination type.</param>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 10).
+        /// </param>
+        /// <returns>
+        ///   The Enumerated value converted to a <paramref name="enumType"/>.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The encoded value is too big to fit in a <paramref name="enumType"/> value.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="enumType"/> is not an enum type.
+        ///
+        ///   -or-
+        ///
+        ///   <paramref name="enumType"/> was declared with <see cref="FlagsAttribute"/>.
+        ///
+        ///   -or-
+        ///
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="enumType"/> is <see langword="null" />.
+        /// </exception>
+        /// <remarks>
+        ///   This method does not validate that the return value is defined within
+        ///   <paramref name="enumType"/>.
+        /// </remarks>
+        public Enum ReadEnumeratedValue(Type enumType, Asn1Tag? expectedTag = null)
+        {
+            Enum ret = AsnDecoder.ReadEnumeratedValue(_data, RuleSet, enumType, out int consumed, expectedTag);
+            _data = _data.Slice(consumed);
+            return ret;
+        }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.GeneralizedTime.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.GeneralizedTime.cs
@@ -435,4 +435,40 @@ namespace System.Formats.Asn1
             return ret;
         }
     }
+
+    public ref partial struct ValueAsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a GeneralizedTime with a specified tag.
+        /// </summary>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 24).
+        /// </param>
+        /// <returns>
+        ///   The decoded value.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        public DateTimeOffset ReadGeneralizedTime(Asn1Tag? expectedTag = null)
+        {
+            DateTimeOffset ret = AsnDecoder.ReadGeneralizedTime(_data, RuleSet, out int consumed, expectedTag);
+            _data = _data.Slice(consumed);
+            return ret;
+        }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Integer.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Integer.cs
@@ -746,4 +746,234 @@ namespace System.Formats.Asn1
             return ret;
         }
     }
+
+    public ref partial struct ValueAsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a Integer with a specified tag, returning the contents
+        ///   as a <see cref="ReadOnlySpan{T}"/> over the original data.
+        /// </summary>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 2).
+        /// </param>
+        /// <returns>
+        ///   The bytes of the Integer value, in signed big-endian form.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        public ReadOnlySpan<byte> ReadIntegerBytes(Asn1Tag? expectedTag = null)
+        {
+            ReadOnlySpan<byte> bytes =
+                AsnDecoder.ReadIntegerBytes(_data, RuleSet, out int consumed, expectedTag);
+
+            _data = _data.Slice(consumed);
+            return bytes;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an Integer with a specified tag.
+        /// </summary>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 2).
+        /// </param>
+        /// <returns>
+        ///   The decoded value.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        public BigInteger ReadInteger(Asn1Tag? expectedTag = null)
+        {
+            BigInteger ret = AsnDecoder.ReadInteger(_data, RuleSet, out int consumed, expectedTag);
+            _data = _data.Slice(consumed);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Attempts to read the next value as an Integer with a specified tag,
+        ///   as a signed 32-bit value.
+        /// </summary>
+        /// <param name="value">
+        ///   On success, receives the decoded value.
+        /// </param>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 2).
+        /// </param>
+        /// <returns>
+        ///   <see langword="false"/> and does not advance the reader if the value is not between
+        ///   <see cref="int.MinValue">Int32.MinValue</see> and <see cref="int.MaxValue">Int32.MaxValue</see>, inclusive; otherwise
+        ///   <see langword="true"/> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        public bool TryReadInt32(out int value, Asn1Tag? expectedTag = null)
+        {
+            bool ret = AsnDecoder.TryReadInt32(_data, RuleSet, out value, out int read, expectedTag);
+            _data = _data.Slice(read);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Attempts to read the next value as an Integer with a specified tag,
+        ///   as an unsigned 32-bit value.
+        /// </summary>
+        /// <param name="value">
+        ///   On success, receives the decoded value.
+        /// </param>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 2).
+        /// </param>
+        /// <returns>
+        ///   <see langword="false"/> and does not advance the reader if the value is not between
+        ///   <see cref="uint.MinValue">UInt32.MinValue</see> and <see cref="uint.MaxValue">UInt32.MaxValue</see>, inclusive; otherwise
+        ///   <see langword="true"/> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        [CLSCompliant(false)]
+        public bool TryReadUInt32(out uint value, Asn1Tag? expectedTag = null)
+        {
+            bool ret = AsnDecoder.TryReadUInt32(_data, RuleSet, out value, out int read, expectedTag);
+            _data = _data.Slice(read);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Attempts to read the next value as an Integer with a specified tag,
+        ///   as a signed 64-bit value.
+        /// </summary>
+        /// <param name="value">
+        ///   On success, receives the decoded value.
+        /// </param>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 2).
+        /// </param>
+        /// <returns>
+        ///   <see langword="false"/> and does not advance the reader if the value is not between
+        ///   <see cref="long.MinValue">Int64.MinValue</see> and <see cref="long.MaxValue">Int64.MaxValue</see>, inclusive; otherwise
+        ///   <see langword="true"/> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        public bool TryReadInt64(out long value, Asn1Tag? expectedTag = null)
+        {
+            bool ret = AsnDecoder.TryReadInt64(_data, RuleSet, out value, out int read, expectedTag);
+            _data = _data.Slice(read);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Attempts to read the next value as an Integer with a specified tag,
+        ///   as an unsigned 64-bit value.
+        /// </summary>
+        /// <param name="value">
+        ///   On success, receives the decoded value.
+        /// </param>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 2).
+        /// </param>
+        /// <returns>
+        ///   <see langword="false"/> and does not advance the reader if the value is not between
+        ///   <see cref="ulong.MinValue">UInt64.MinValue</see> and <see cref="ulong.MaxValue">UInt64.MaxValue</see>, inclusive; otherwise
+        ///   <see langword="true"/> is returned and the reader advances.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        [CLSCompliant(false)]
+        public bool TryReadUInt64(out ulong value, Asn1Tag? expectedTag = null)
+        {
+            bool ret = AsnDecoder.TryReadUInt64(_data, RuleSet, out value, out int read, expectedTag);
+            _data = _data.Slice(read);
+            return ret;
+        }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.NamedBitList.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.NamedBitList.cs
@@ -580,4 +580,186 @@ namespace System.Formats.Asn1
             return ret;
         }
     }
+
+    public ref partial struct ValueAsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a NamedBitList with a specified tag, converting it to the
+        ///   [<see cref="FlagsAttribute"/>] enum specified by <typeparamref name="TFlagsEnum"/>.
+        /// </summary>
+        /// <typeparam name="TFlagsEnum">The destination enum type.</typeparam>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <returns>
+        ///   The NamedBitList value converted to a <typeparamref name="TFlagsEnum"/>.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The encoded value is too big to fit in a <typeparamref name="TFlagsEnum"/> value.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <typeparamref name="TFlagsEnum"/> is not an enum type.
+        ///
+        ///   -or-
+        ///
+        ///   <typeparamref name="TFlagsEnum"/> was not declared with <see cref="FlagsAttribute"/>
+        ///
+        ///   -or-
+        ///
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <remarks>
+        ///   The bit alignment performed by this method is to interpret the most significant bit
+        ///   in the first byte of the value as the least significant bit in <typeparamref name="TFlagsEnum"/>,
+        ///   with bits increasing in value until the least significant bit of the first byte, proceeding
+        ///   with the most significant bit of the second byte, and so on. Under this scheme, the following
+        ///   ASN.1 type declaration and C# enumeration can be used together:
+        ///
+        ///   <code>
+        ///     KeyUsage ::= BIT STRING {
+        ///       digitalSignature   (0),
+        ///       nonRepudiation     (1),
+        ///       keyEncipherment    (2),
+        ///       dataEncipherment   (3),
+        ///       keyAgreement       (4),
+        ///       keyCertSign        (5),
+        ///       cRLSign            (6),
+        ///       encipherOnly       (7),
+        ///       decipherOnly       (8) }
+        ///   </code>
+        ///
+        ///   <code>
+        ///     [Flags]
+        ///     enum KeyUsage
+        ///     {
+        ///         None              = 0,
+        ///         DigitalSignature  = 1 &lt;&lt; (0),
+        ///         NonRepudiation    = 1 &lt;&lt; (1),
+        ///         KeyEncipherment   = 1 &lt;&lt; (2),
+        ///         DataEncipherment  = 1 &lt;&lt; (3),
+        ///         KeyAgreement      = 1 &lt;&lt; (4),
+        ///         KeyCertSign       = 1 &lt;&lt; (5),
+        ///         CrlSign           = 1 &lt;&lt; (6),
+        ///         EncipherOnly      = 1 &lt;&lt; (7),
+        ///         DecipherOnly      = 1 &lt;&lt; (8),
+        ///     }
+        ///   </code>
+        ///
+        ///   While the example here uses the KeyUsage NamedBitList from
+        ///   <a href="https://tools.ietf.org/html/rfc3280#section-4.2.1.3">RFC 3280 (4.2.1.3)</a>,
+        ///   the example enum uses values that are different from
+        ///   System.Security.Cryptography.X509Certificates.X509KeyUsageFlags.
+        /// </remarks>
+        public TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(Asn1Tag? expectedTag = null) where TFlagsEnum : Enum
+        {
+            TFlagsEnum ret = AsnDecoder.ReadNamedBitListValue<TFlagsEnum>(
+                _data,
+                RuleSet,
+                out int consumed,
+                expectedTag);
+
+            _data = _data.Slice(consumed);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Reads the next value as a NamedBitList with a specified tag, converting it to the
+        ///   [<see cref="FlagsAttribute"/>] enum specified by <paramref name="flagsEnumType"/>.
+        /// </summary>
+        /// <param name="flagsEnumType">Type object representing the destination type.</param>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <returns>
+        ///   The NamedBitList value converted to a <paramref name="flagsEnumType"/>.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The encoded value is too big to fit in a <paramref name="flagsEnumType"/> value.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="flagsEnumType"/> is not an enum type.
+        ///
+        ///   -or-
+        ///
+        ///   <paramref name="flagsEnumType"/> was not declared with <see cref="FlagsAttribute"/>
+        ///
+        ///   -or-
+        ///
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   <paramref name="flagsEnumType"/> is <see langword="null" />
+        /// </exception>
+        /// <seealso cref="ReadNamedBitListValue{TFlagsEnum}"/>
+        public Enum ReadNamedBitListValue(Type flagsEnumType, Asn1Tag? expectedTag = null)
+        {
+            Enum ret = AsnDecoder.ReadNamedBitListValue(
+                _data,
+                RuleSet,
+                flagsEnumType,
+                out int consumed,
+                expectedTag);
+
+            _data = _data.Slice(consumed);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Reads the next value as a NamedBitList with a specified tag.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <returns>
+        ///   The bits from the encoded value.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <seealso cref="ReadNamedBitListValue{TFlagsEnum}"/>
+        public BitArray ReadNamedBitList(Asn1Tag? expectedTag = null)
+        {
+            BitArray ret = AsnDecoder.ReadNamedBitList(_data, RuleSet, out int consumed, expectedTag);
+            _data = _data.Slice(consumed);
+            return ret;
+        }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Null.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Null.cs
@@ -93,4 +93,36 @@ namespace System.Formats.Asn1
             _data = _data.Slice(consumed);
         }
     }
+
+    public ref partial struct ValueAsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a NULL with a specified tag.
+        /// </summary>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 5).
+        /// </param>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        public void ReadNull(Asn1Tag? expectedTag = null)
+        {
+            AsnDecoder.ReadNull(_data, RuleSet, out int consumed, expectedTag);
+            _data = _data.Slice(consumed);
+        }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.OctetString.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.OctetString.cs
@@ -679,4 +679,149 @@ namespace System.Formats.Asn1
             return ret;
         }
     }
+
+    public ref partial struct ValueAsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as an OCTET STRING with a specified tag, copying the value
+        ///   into a provided destination buffer.
+        /// </summary>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 4).
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <see langword="false"/> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveOctetString"/>
+        /// <seealso cref="ReadOctetString"/>
+        public bool TryReadOctetString(
+            Span<byte> destination,
+            out int bytesWritten,
+            Asn1Tag? expectedTag = null)
+        {
+            bool ret = AsnDecoder.TryReadOctetString(
+                _data,
+                destination,
+                RuleSet,
+                out int bytesConsumed,
+                out bytesWritten,
+                expectedTag);
+
+            if (ret)
+            {
+                _data = _data.Slice(bytesConsumed);
+            }
+
+            return ret;
+        }
+
+        /// <summary>
+        ///   Reads the next value as an OCTET STRING with tag UNIVERSAL 4, returning the value
+        ///   in a byte array.
+        /// </summary>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 4).
+        /// </param>
+        /// <returns>
+        ///   A copy of the value in a newly allocated, precisely sized, array.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveOctetString"/>
+        /// <seealso cref="TryReadOctetString"/>
+        public byte[] ReadOctetString(Asn1Tag? expectedTag = null)
+        {
+            byte[] ret = AsnDecoder.ReadOctetString(_data, RuleSet, out int consumed, expectedTag);
+            _data = _data.Slice(consumed);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Attempts to read the next value as an OCTET STRING with a specified tag, returning the contents
+        ///   as a <see cref="ReadOnlySpan{T}"/> over the original data.
+        /// </summary>
+        /// <param name="contents">
+        ///   On success, receives a <see cref="ReadOnlySpan{T}"/> over the original data
+        ///   corresponding to the value of the OCTET STRING.
+        /// </param>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <returns>
+        ///   <see langword="true"/> and advances the reader if the OCTET STRING value had a primitive encoding,
+        ///   <see langword="false"/> and does not advance the reader if it had a constructed encoding.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <seealso cref="TryReadOctetString"/>
+        public bool TryReadPrimitiveOctetString(
+            out ReadOnlySpan<byte> contents,
+            Asn1Tag? expectedTag = null)
+        {
+            bool ret = AsnDecoder.TryReadPrimitiveOctetString(
+                _data,
+                RuleSet,
+                out contents,
+                out int consumed,
+                expectedTag);
+
+            if (ret)
+            {
+                _data = _data.Slice(consumed);
+            }
+
+            return ret;
+        }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Oid.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Oid.cs
@@ -372,4 +372,40 @@ namespace System.Formats.Asn1
             return oidValue;
         }
     }
+
+    public ref partial struct ValueAsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as an OBJECT IDENTIFIER with a specified tag, returning
+        ///   the value in a dotted decimal format string.
+        /// </summary>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 6).
+        /// </param>
+        /// <returns>The decoded object identifier in the dotted-decimal notation.</returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        public string ReadObjectIdentifier(Asn1Tag? expectedTag = null)
+        {
+            string oidValue = AsnDecoder.ReadObjectIdentifier(_data, RuleSet, out int consumed, expectedTag);
+
+            _data = _data.Slice(consumed);
+            return oidValue;
+        }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Sequence.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Sequence.cs
@@ -145,4 +145,55 @@ namespace System.Formats.Asn1
             return ret;
         }
     }
+
+    public ref partial struct ValueAsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a SEQUENCE or SEQUENCE-OF with the specified tag
+        ///   and returns the result as a new reader positioned at the first
+        ///   value in the sequence (or with <see cref="HasData"/> == <see langword="false"/>).
+        /// </summary>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 16).
+        /// </param>
+        /// <returns>
+        ///   A new reader positioned at the first
+        ///   value in the sequence (or with <see cref="HasData"/> == <see langword="false"/>).
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <remarks>
+        ///   The nested content is not evaluated by this method, and might contain data
+        ///   that's not valid under the current encoding rules.
+        /// </remarks>
+        public ValueAsnReader ReadSequence(Asn1Tag? expectedTag = null)
+        {
+            AsnDecoder.ReadSequence(
+                _data,
+                RuleSet,
+                out int contentStart,
+                out int contentLength,
+                out int bytesConsumed,
+                expectedTag);
+
+            ValueAsnReader ret = new ValueAsnReader(_data.Slice(contentStart, contentLength), RuleSet, _options);
+            _data = _data.Slice(bytesConsumed);
+            return ret;
+        }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.SetOf.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.SetOf.cs
@@ -223,4 +223,101 @@ namespace System.Formats.Asn1
             return ret;
         }
     }
+
+    public ref partial struct ValueAsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a SET-OF with the specified tag
+        ///   and returns the result as a new reader positioned at the first
+        ///   value in the set-of (or with <see cref="HasData"/> == <see langword="false"/>),
+        ///   using the <see cref="AsnReaderOptions.SkipSetSortOrderVerification"/> value
+        ///   from the constructor (default <see langword="false"/>).
+        /// </summary>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 17).
+        /// </param>
+        /// <returns>
+        ///   A new reader positioned at the first
+        ///   value in the set-of (or with <see cref="HasData"/> == <see langword="false"/>).
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <remarks>
+        ///   The nested content is not evaluated by this method (aside from sort order, when
+        ///   required) and might contain data that's not valid under the current encoding rules.
+        /// </remarks>
+        public ValueAsnReader ReadSetOf(Asn1Tag? expectedTag = null)
+        {
+            return ReadSetOf(_options.SkipSetSortOrderVerification, expectedTag);
+        }
+
+        /// <summary>
+        ///   Reads the next value as a SET-OF with the specified tag
+        ///   and returns the result as a new reader positioned at the first
+        ///   value in the set-of (or with <see cref="HasData"/> == <see langword="false"/>).
+        /// </summary>
+        /// <param name="skipSortOrderValidation">
+        ///   <see langword="true"/> to always accept the data in the order it is presented,
+        ///   <see langword="false"/> to verify that the data is sorted correctly when the
+        ///   encoding rules say sorting was required (CER and DER).
+        /// </param>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 17).
+        /// </param>
+        /// <returns>
+        ///   A new reader positioned at the first
+        ///   value in the set-of (or with <see cref="HasData"/> == <see langword="false"/>).
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <remarks>
+        ///   The nested content is not evaluated by this method (aside from sort order, when
+        ///   required) and might contain data that's not valid under the current encoding rules.
+        /// </remarks>
+        public ValueAsnReader ReadSetOf(bool skipSortOrderValidation, Asn1Tag? expectedTag = null)
+        {
+            AsnDecoder.ReadSetOf(
+                _data,
+                RuleSet,
+                out int contentOffset,
+                out int contentLength,
+                out int bytesConsumed,
+                skipSortOrderValidation,
+                expectedTag);
+
+            ValueAsnReader ret = new ValueAsnReader(_data.Slice(contentOffset, contentLength), RuleSet, _options);
+            _data = _data.Slice(bytesConsumed);
+            return ret;
+        }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Text.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.Text.cs
@@ -731,4 +731,238 @@ namespace System.Formats.Asn1
             return ret;
         }
     }
+
+    public ref partial struct ValueAsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a character with a specified tag, returning the contents
+        ///   as an unprocessed <see cref="ReadOnlySpan{T}"/> over the original data.
+        /// </summary>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="contents">
+        ///   On success, receives a <see cref="ReadOnlySpan{T}"/> over the original data
+        ///   corresponding to the value of the character string.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> and advances the reader if the character string value had a primitive encoding,
+        ///   <see langword="false"/> and does not advance the reader if it had a constructed encoding.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not a character
+        ///   string tag type.
+        /// </exception>
+        /// <remarks>
+        ///   This method does not determine if the string used only characters defined by the encoding.
+        /// </remarks>
+        /// <seealso cref="TryReadCharacterStringBytes"/>
+        public bool TryReadPrimitiveCharacterStringBytes(
+            Asn1Tag expectedTag,
+            out ReadOnlySpan<byte> contents)
+        {
+            bool ret = AsnDecoder.TryReadPrimitiveCharacterStringBytes(
+                _data,
+                RuleSet,
+                expectedTag,
+                out contents,
+                out int consumed);
+
+            if (ret)
+            {
+                _data = _data.Slice(consumed);
+            }
+
+            return ret;
+        }
+
+        /// <summary>
+        ///   Reads the next value as character string with the specified tag,
+        ///   copying the unprocessed bytes into a provided destination buffer.
+        /// </summary>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="expectedTag">The tag to check for before reading.</param>
+        /// <param name="bytesWritten">
+        ///   On success, receives the number of bytes written to <paramref name="destination"/>.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <see langword="false"/> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not a character
+        ///   string tag type.
+        /// </exception>
+        /// <remarks>
+        ///   This method does not determine if the string used only characters defined by the encoding.
+        /// </remarks>
+        /// <seealso cref="TryReadPrimitiveCharacterStringBytes"/>
+        /// <seealso cref="ReadCharacterString"/>
+        /// <seealso cref="TryReadCharacterString"/>
+        public bool TryReadCharacterStringBytes(
+            Span<byte> destination,
+            Asn1Tag expectedTag,
+            out int bytesWritten)
+        {
+            bool ret = AsnDecoder.TryReadCharacterStringBytes(
+                _data,
+                destination,
+                RuleSet,
+                expectedTag,
+                out int consumed,
+                out bytesWritten);
+
+            if (ret)
+            {
+                _data = _data.Slice(consumed);
+            }
+
+            return ret;
+        }
+
+        /// <summary>
+        ///   Reads the next value as character string with the specified tag and
+        ///   encoding type, copying the decoded value into a provided destination buffer.
+        /// </summary>
+        /// <param name="destination">The buffer in which to write.</param>
+        /// <param name="encodingType">
+        ///   One of the enumeration values representing the value type to process.
+        /// </param>
+        /// <param name="charsWritten">
+        ///   On success, receives the number of chars written to <paramref name="destination"/>.
+        /// </param>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the universal tag that is
+        ///   appropriate to the requested encoding type.
+        /// </param>
+        /// <returns>
+        ///   <see langword="true"/> and advances the reader if <paramref name="destination"/> had sufficient
+        ///   length to receive the value, otherwise
+        ///   <see langword="false"/> and the reader does not advance.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a known character string type.
+        /// </exception>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The string did not successfully decode.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not the same as
+        ///   <paramref name="encodingType"/>.
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveCharacterStringBytes"/>
+        /// <seealso cref="TryReadCharacterStringBytes"/>
+        /// <seealso cref="ReadCharacterString"/>
+        public bool TryReadCharacterString(
+            Span<char> destination,
+            UniversalTagNumber encodingType,
+            out int charsWritten,
+            Asn1Tag? expectedTag = null)
+        {
+            bool ret = AsnDecoder.TryReadCharacterString(
+                _data,
+                destination,
+                RuleSet,
+                encodingType,
+                out int consumed,
+                out charsWritten,
+                expectedTag);
+
+            _data = _data.Slice(consumed);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Reads the next value as character string with the specified tag and
+        ///   encoding type, returning the decoded value as a string.
+        /// </summary>
+        /// <param name="encodingType">
+        ///   One of the enumeration values representing the value type to process.
+        /// </param>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the universal tag that is
+        ///   appropriate to the requested encoding type.
+        /// </param>
+        /// <returns>
+        ///   The decoded value.
+        /// </returns>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="encodingType"/> is not a known character string type.
+        /// </exception>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The string did not successfully decode.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not the same as
+        ///   <paramref name="encodingType"/>.
+        /// </exception>
+        /// <seealso cref="TryReadPrimitiveCharacterStringBytes"/>
+        /// <seealso cref="TryReadCharacterStringBytes"/>
+        /// <seealso cref="TryReadCharacterString"/>
+        public string ReadCharacterString(UniversalTagNumber encodingType, Asn1Tag? expectedTag = null)
+        {
+            string ret = AsnDecoder.ReadCharacterString(
+                _data,
+                RuleSet,
+                encodingType,
+                out int consumed,
+                expectedTag);
+
+            _data = _data.Slice(consumed);
+            return ret;
+        }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.UtcTime.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.UtcTime.cs
@@ -322,4 +322,89 @@ namespace System.Formats.Asn1
             return ret;
         }
     }
+
+    public ref partial struct ValueAsnReader
+    {
+        /// <summary>
+        ///   Reads the next value as a UTCTime with a specified tag using the
+        ///   <see cref="AsnReaderOptions.UtcTimeTwoDigitYearMax"/> value from options passed to
+        ///   the constructor (with a default of 2049).
+        /// </summary>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 23).
+        /// </param>
+        /// <returns>
+        ///   The decoded value.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <seealso cref="ReadUtcTime(int,Nullable{Asn1Tag})"/>
+        public DateTimeOffset ReadUtcTime(Asn1Tag? expectedTag = null)
+        {
+            DateTimeOffset ret = AsnDecoder.ReadUtcTime(
+                _data,
+                RuleSet,
+                out int consumed,
+                _options.UtcTimeTwoDigitYearMax,
+                expectedTag);
+
+            _data = _data.Slice(consumed);
+            return ret;
+        }
+
+        /// <summary>
+        ///   Reads the next value as a UTCTime with a specified tag.
+        /// </summary>
+        /// <param name="twoDigitYearMax">
+        ///   The largest year to represent with this value.
+        /// </param>
+        /// <param name="expectedTag">
+        ///   The tag to check for before reading, or <see langword="null"/> for the default tag (Universal 23).
+        /// </param>
+        /// <returns>
+        ///   The decoded value.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The next value does not have the correct tag.
+        ///
+        ///   -or-
+        ///
+        ///   The length encoding is not valid under the current encoding rules.
+        ///
+        ///   -or-
+        ///
+        ///   The contents are not valid under the current encoding rules.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagClass"/> is
+        ///   <see cref="TagClass.Universal"/>, but
+        ///   <paramref name="expectedTag"/>.<see cref="Asn1Tag.TagValue"/> is not correct for
+        ///   the method.
+        /// </exception>
+        /// <seealso cref="ReadUtcTime(Nullable{Asn1Tag})"/>
+        /// <seealso cref="System.Globalization.Calendar.TwoDigitYearMax"/>
+        public DateTimeOffset ReadUtcTime(int twoDigitYearMax, Asn1Tag? expectedTag = null)
+        {
+            DateTimeOffset ret =
+                AsnDecoder.ReadUtcTime(_data, RuleSet, out int consumed, twoDigitYearMax, expectedTag);
+
+            _data = _data.Slice(consumed);
+            return ret;
+        }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.cs
+++ b/src/libraries/System.Formats.Asn1/src/System/Formats/Asn1/AsnDecoder.cs
@@ -901,4 +901,146 @@ namespace System.Formats.Asn1
             return new AsnReader(_data.Slice(start, length), RuleSet, _options);
         }
     }
+
+    /// <summary>
+    ///   Represents a stateful, forward-only reader for BER-encoded, CER-encoded, or DER-encoded ASN.1 data.
+    /// </summary>
+    public ref partial struct ValueAsnReader
+    {
+        internal const int MaxCERSegmentSize = AsnDecoder.MaxCERSegmentSize;
+
+        private ReadOnlySpan<byte> _data;
+        private readonly AsnReaderOptions _options;
+
+        /// <summary>
+        ///   Gets the encoding rules in use by this reader.
+        /// </summary>
+        /// <value>
+        ///   The encoding rules in use by this reader.
+        /// </value>
+        public readonly AsnEncodingRules RuleSet { get; }
+
+        /// <summary>
+        ///   Gets a value that indicates whether the reader has remaining data available to process.
+        /// </summary>
+        /// <value>
+        ///   <see langword="true"/> if there is more data available for the reader to process;
+        ///   otherwise, <see langword="false"/>.
+        /// </value>
+        public readonly bool HasData => !_data.IsEmpty;
+
+        /// <summary>
+        ///   Construct a <see cref="ValueAsnReader"/> over <paramref name="data"/> with a given ruleset.
+        /// </summary>
+        /// <param name="data">The data to read.</param>
+        /// <param name="ruleSet">The encoding constraints for the reader.</param>
+        /// <param name="options">Additional options for the reader.</param>
+        /// <exception cref="ArgumentOutOfRangeException">
+        ///   <paramref name="ruleSet"/> is not defined.
+        /// </exception>
+        /// <remarks>
+        ///   This constructor does not evaluate <paramref name="data"/> for correctness.
+        ///   Any correctness checks are done as part of member methods.
+        ///
+        ///   This constructor does not copy <paramref name="data"/>. The caller is responsible for
+        ///   ensuring that the values do not change until the reader is finished.
+        /// </remarks>
+        public ValueAsnReader(ReadOnlySpan<byte> data, AsnEncodingRules ruleSet, AsnReaderOptions options = default)
+        {
+            AsnDecoder.CheckEncodingRules(ruleSet);
+
+            _data = data;
+            RuleSet = ruleSet;
+            _options = options;
+        }
+
+        /// <summary>
+        ///   Throws a standardized <see cref="AsnContentException"/> if the reader has remaining
+        ///   data, or performs no function if <see cref="HasData"/> returns <see langword="false"/>.
+        /// </summary>
+        /// <remarks>
+        ///   This method provides a standardized target and standardized exception for reading a
+        ///   "closed" structure, such as the nested content for an explicitly tagged value.
+        /// </remarks>
+        public readonly void ThrowIfNotEmpty()
+        {
+            if (HasData)
+            {
+                throw new AsnContentException(SR.ContentException_TooMuchData);
+            }
+        }
+
+        /// <summary>
+        ///   Reads the encoded tag at the next data position, without advancing the reader.
+        /// </summary>
+        /// <returns>
+        ///   The decoded tag value.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   A tag could not be decoded at the reader's current position.
+        /// </exception>
+        public readonly Asn1Tag PeekTag()
+        {
+            return Asn1Tag.Decode(_data, out _);
+        }
+
+        /// <summary>
+        ///   Gets a <see cref="ReadOnlySpan{T}"/> view of the next encoded value without
+        ///   advancing the reader. For indefinite length encodings, this includes the
+        ///   End of Contents marker.
+        /// </summary>
+        /// <returns>
+        ///   The bytes of the next encoded value.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The reader is positioned at a point where the tag or length is invalid
+        ///   under the current encoding rules.
+        /// </exception>
+        /// <seealso cref="PeekContentBytes"/>
+        public readonly ReadOnlySpan<byte> PeekEncodedValue()
+        {
+            AsnDecoder.ReadEncodedValue(_data, RuleSet, out _, out _, out int bytesConsumed);
+            return _data.Slice(0, bytesConsumed);
+        }
+
+        /// <summary>
+        ///   Gets a <see cref="ReadOnlySpan{T}"/> view of the content octets (bytes) of the
+        ///   next encoded value without advancing the reader.
+        /// </summary>
+        /// <returns>
+        ///   The bytes of the contents octets of the next encoded value.
+        /// </returns>
+        /// <exception cref="AsnContentException">
+        ///   The reader is positioned at a point where the tag or length is invalid
+        ///   under the current encoding rules.
+        /// </exception>
+        /// <seealso cref="PeekEncodedValue"/>
+        public readonly ReadOnlySpan<byte> PeekContentBytes()
+        {
+            AsnDecoder.ReadEncodedValue(
+                _data,
+                RuleSet,
+                out int contentOffset,
+                out int contentLength,
+                out _);
+
+            return _data.Slice(contentOffset, contentLength);
+        }
+
+        /// <summary>
+        ///   Get a <see cref="ReadOnlySpan{T}"/> view of the next encoded value,
+        ///   and advance the reader past it. For an indefinite length encoding, this includes
+        ///   the End of Contents marker.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="ReadOnlySpan{T}"/> view of the next encoded value.
+        /// </returns>
+        /// <seealso cref="PeekEncodedValue"/>
+        public ReadOnlySpan<byte> ReadEncodedValue()
+        {
+            ReadOnlySpan<byte> encodedValue = PeekEncodedValue();
+            _data = _data.Slice(encodedValue.Length);
+            return encodedValue;
+        }
+    }
 }

--- a/src/libraries/System.Formats.Asn1/tests/Reader/AsnReaderWrapper.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/AsnReaderWrapper.cs
@@ -1,0 +1,554 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Formats.Asn1.Tests.Reader
+{
+    internal ref struct AsnReaderWrapper
+    {
+        private AsnReader _classReader;
+        private ValueAsnReader _valueReader;
+
+        internal static AsnReaderWrapper CreateClassReader(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options)
+        {
+            AsnReaderWrapper wrapper = new();
+            wrapper._classReader = new AsnReader(data, ruleSet, options);
+            return wrapper;
+        }
+
+        internal static AsnReaderWrapper CreateValueReader(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options)
+        {
+            AsnReaderWrapper wrapper = new();
+            wrapper._valueReader = new ValueAsnReader(data.Span, ruleSet, options);
+            return wrapper;
+        }
+
+        private static AsnReaderWrapper FromClassReader(AsnReader reader)
+        {
+            AsnReaderWrapper wrapper = new();
+            wrapper._classReader = reader;
+            return wrapper;
+        }
+
+        private static AsnReaderWrapper FromValueReader(ValueAsnReader reader)
+        {
+            AsnReaderWrapper wrapper = new();
+            wrapper._valueReader = reader;
+            return wrapper;
+        }
+
+        internal void ReadNull(Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                _classReader.ReadNull(expectedTag);
+            }
+            else
+            {
+                _valueReader.ReadNull(expectedTag);
+            }
+        }
+
+        internal bool HasData
+        {
+            get
+            {
+                if (_classReader is not null)
+                {
+                    return _classReader.HasData;
+                }
+                else
+                {
+                    return _valueReader.HasData;
+                }
+            }
+        }
+
+        internal AsnEncodingRules RuleSet
+        {
+            get
+            {
+                if (_classReader is not null)
+                {
+                    return _classReader.RuleSet;
+                }
+                else
+                {
+                    return _valueReader.RuleSet;
+                }
+            }
+        }
+
+        // For the ValueAsnReader, return-by-value is effectively a copy (clone).
+        internal AsnReaderWrapper Clone()
+        {
+            if (_classReader is not null)
+            {
+                return FromClassReader(_classReader.Clone());
+            }
+            else
+            {
+                return this;
+            }
+        }
+
+        internal Asn1Tag PeekTag()
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.PeekTag();
+            }
+            else
+            {
+                return _valueReader.PeekTag();
+            }
+        }
+
+        internal bool ReadBoolean(Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadBoolean(expectedTag);
+            }
+            else
+            {
+                return _valueReader.ReadBoolean(expectedTag);
+            }
+        }
+
+        internal string ReadObjectIdentifier(Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadObjectIdentifier(expectedTag);
+            }
+            else
+            {
+                return _valueReader.ReadObjectIdentifier(expectedTag);
+            }
+        }
+
+        internal DateTimeOffset ReadUtcTime(Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadUtcTime(expectedTag);
+            }
+            else
+            {
+                return _valueReader.ReadUtcTime(expectedTag);
+            }
+        }
+
+        internal DateTimeOffset ReadUtcTime(int twoDigitYearMax, Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadUtcTime(twoDigitYearMax, expectedTag);
+            }
+            else
+            {
+                return _valueReader.ReadUtcTime(twoDigitYearMax, expectedTag);
+            }
+        }
+
+        internal DateTimeOffset ReadGeneralizedTime(Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadGeneralizedTime(expectedTag);
+            }
+            else
+            {
+                return _valueReader.ReadGeneralizedTime(expectedTag);
+            }
+        }
+
+        internal bool TryReadPrimitiveBitString(
+            out int unusedBitCount,
+            out ReadOnlySpan<byte> value,
+            Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                bool result = _classReader.TryReadPrimitiveBitString(out unusedBitCount, out ReadOnlyMemory<byte> memory, expectedTag);
+                value = memory.Span;
+                return result;
+            }
+            else
+            {
+                return _valueReader.TryReadPrimitiveBitString(out unusedBitCount, out value, expectedTag);
+            }
+        }
+
+        internal bool TryReadBitString(
+            Span<byte> destination,
+            out int unusedBitCount,
+            out int bytesWritten,
+            Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.TryReadBitString(destination, out unusedBitCount, out bytesWritten, expectedTag);
+            }
+            else
+            {
+                return _valueReader.TryReadBitString(destination, out unusedBitCount, out bytesWritten, expectedTag);
+            }
+        }
+
+        internal byte[] ReadBitString(out int unusedBitCount, Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadBitString(out unusedBitCount, expectedTag);
+            }
+            else
+            {
+                return _valueReader.ReadBitString(out unusedBitCount, expectedTag);
+            }
+        }
+
+        internal string ReadCharacterString(UniversalTagNumber encodingType, Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadCharacterString(encodingType, expectedTag);
+            }
+            else
+            {
+                return _valueReader.ReadCharacterString(encodingType, expectedTag);
+            }
+        }
+
+        internal bool TryReadCharacterString(
+            Span<char> destination,
+            UniversalTagNumber encodingType,
+            out int charsWritten,
+            Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.TryReadCharacterString(destination, encodingType, out charsWritten, expectedTag);
+            }
+            else
+            {
+                return _valueReader.TryReadCharacterString(destination, encodingType, out charsWritten, expectedTag);
+            }
+        }
+
+        internal bool TryReadCharacterStringBytes(
+            Span<byte> destination,
+            Asn1Tag expectedTag,
+            out int bytesWritten)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.TryReadCharacterStringBytes(destination, expectedTag, out bytesWritten);
+            }
+            else
+            {
+                return _valueReader.TryReadCharacterStringBytes(destination, expectedTag, out bytesWritten);
+            }
+        }
+
+        internal bool TryReadPrimitiveCharacterStringBytes(
+            Asn1Tag expectedTag,
+            out ReadOnlySpan<byte> value)
+        {
+            if (_classReader is not null)
+            {
+                bool result = _classReader.TryReadPrimitiveCharacterStringBytes(expectedTag, out ReadOnlyMemory<byte> memory);
+                value = memory.Span;
+                return result;
+            }
+            else
+            {
+                return _valueReader.TryReadPrimitiveCharacterStringBytes(expectedTag, out value);
+            }
+        }
+
+        internal ReadOnlySpan<byte> PeekEncodedValue()
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.PeekEncodedValue().Span;
+            }
+            else
+            {
+                return _valueReader.PeekEncodedValue();
+            }
+        }
+
+        internal ReadOnlySpan<byte> PeekContentBytes()
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.PeekContentBytes().Span;
+            }
+            else
+            {
+                return _valueReader.PeekContentBytes();
+            }
+        }
+
+        internal ReadOnlySpan<byte> ReadEncodedValue()
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadEncodedValue().Span;
+            }
+            else
+            {
+                return _valueReader.ReadEncodedValue();
+            }
+        }
+
+        internal void ThrowIfNotEmpty()
+        {
+            if (_classReader is not null)
+            {
+                _classReader.ThrowIfNotEmpty();
+            }
+            else
+            {
+                _valueReader.ThrowIfNotEmpty();
+            }
+        }
+
+        internal TEnum ReadEnumeratedValue<TEnum>(Asn1Tag? expectedTag = default) where TEnum : Enum
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadEnumeratedValue<TEnum>(expectedTag);
+            }
+            else
+            {
+                return _valueReader.ReadEnumeratedValue<TEnum>(expectedTag);
+            }
+        }
+
+        internal Enum ReadEnumeratedValue(Type enumType, Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadEnumeratedValue(enumType, expectedTag);
+            }
+            else
+            {
+                return _valueReader.ReadEnumeratedValue(enumType, expectedTag);
+            }
+        }
+
+        internal ReadOnlySpan<byte> ReadEnumeratedBytes(Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadEnumeratedBytes(expectedTag).Span;
+            }
+            else
+            {
+                return _valueReader.ReadEnumeratedBytes(expectedTag);
+            }
+        }
+
+        internal ReadOnlySpan<byte> ReadIntegerBytes(Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadIntegerBytes(expectedTag).Span;
+            }
+            else
+            {
+                return _valueReader.ReadIntegerBytes(expectedTag);
+            }
+        }
+
+        internal BigInteger ReadInteger(Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadInteger(expectedTag);
+            }
+            else
+            {
+                return _valueReader.ReadInteger(expectedTag);
+            }
+        }
+
+        internal bool TryReadInt32(out int value, Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.TryReadInt32(out value, expectedTag);
+            }
+            else
+            {
+                return _valueReader.TryReadInt32(out value, expectedTag);
+            }
+        }
+
+        internal bool TryReadUInt32(out uint value, Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.TryReadUInt32(out value, expectedTag);
+            }
+            else
+            {
+                return _valueReader.TryReadUInt32(out value, expectedTag);
+            }
+        }
+
+        internal bool TryReadInt64(out long value, Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.TryReadInt64(out value, expectedTag);
+            }
+            else
+            {
+                return _valueReader.TryReadInt64(out value, expectedTag);
+            }
+        }
+
+        internal bool TryReadUInt64(out ulong value, Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.TryReadUInt64(out value, expectedTag);
+            }
+            else
+            {
+                return _valueReader.TryReadUInt64(out value, expectedTag);
+            }
+        }
+
+        internal bool TryReadPrimitiveOctetString(
+            out ReadOnlySpan<byte> contents,
+            Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                bool result = _classReader.TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> memory, expectedTag);
+                contents = memory.Span;
+                return result;
+            }
+            else
+            {
+                return _valueReader.TryReadPrimitiveOctetString(out contents, expectedTag);
+            }
+        }
+
+        internal bool TryReadOctetString(
+            Span<byte> destination,
+            out int bytesWritten,
+            Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.TryReadOctetString(destination, out bytesWritten, expectedTag);
+            }
+            else
+            {
+                return _valueReader.TryReadOctetString(destination, out bytesWritten, expectedTag);
+            }
+        }
+
+        internal byte[] ReadOctetString(Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadOctetString(expectedTag);
+            }
+            else
+            {
+                return _valueReader.ReadOctetString(expectedTag);
+            }
+        }
+
+        internal AsnReaderWrapper ReadSequence(Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return FromClassReader(_classReader.ReadSequence(expectedTag));
+            }
+            else
+            {
+                return FromValueReader(_valueReader.ReadSequence(expectedTag));
+            }
+        }
+
+        internal AsnReaderWrapper ReadSetOf(Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return FromClassReader(_classReader.ReadSetOf(expectedTag));
+            }
+            else
+            {
+                return FromValueReader(_valueReader.ReadSetOf(expectedTag));
+            }
+        }
+
+        internal AsnReaderWrapper ReadSetOf(bool skipSortOrderValidation, Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return FromClassReader(_classReader.ReadSetOf(skipSortOrderValidation, expectedTag));
+            }
+            else
+            {
+                return FromValueReader(_valueReader.ReadSetOf(skipSortOrderValidation, expectedTag));
+            }
+        }
+
+        internal TFlagsEnum ReadNamedBitListValue<TFlagsEnum>(Asn1Tag? expectedTag = default) where TFlagsEnum : Enum
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadNamedBitListValue<TFlagsEnum>(expectedTag);
+            }
+            else
+            {
+                return _valueReader.ReadNamedBitListValue<TFlagsEnum>(expectedTag);
+            }
+        }
+
+        internal Enum ReadNamedBitListValue(Type flagsEnumType, Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadNamedBitListValue(flagsEnumType, expectedTag);
+            }
+            else
+            {
+                return _valueReader.ReadNamedBitListValue(flagsEnumType, expectedTag);
+            }
+        }
+
+        internal BitArray ReadNamedBitList(Asn1Tag? expectedTag = default)
+        {
+            if (_classReader is not null)
+            {
+                return _classReader.ReadNamedBitList(expectedTag);
+            }
+            else
+            {
+                return _valueReader.ReadNamedBitList(expectedTag);
+            }
+        }
+    }
+}

--- a/src/libraries/System.Formats.Asn1/tests/Reader/AssertHelpers.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/AssertHelpers.cs
@@ -1,0 +1,67 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+using Xunit.Sdk;
+
+namespace System.Formats.Asn1.Tests.Reader
+{
+    internal delegate void AsnReaderWrapperCallback(ref AsnReaderWrapper reader);
+
+    internal static class AssertHelpers
+    {
+        extension(Assert)
+        {
+            internal static E Throws<E>(ref AsnReaderWrapper reader, AsnReaderWrapperCallback action) where E : Exception
+            {
+                Exception exception;
+
+                try
+                {
+                    action(ref reader);
+                    exception = null;
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+
+                switch(exception)
+                {
+                    case null:
+                        throw ThrowsException.ForNoException(typeof(E));
+                    case E ex when (ex.GetType() == typeof(E)):
+                        return ex;
+                    default:
+                        throw ThrowsException.ForIncorrectExceptionType(typeof(E), exception);
+                }
+            }
+
+            internal static E Throws<E>(ref AsnReaderWrapper reader, string expectedParamName, AsnReaderWrapperCallback action) where E : ArgumentException
+            {
+                Exception exception;
+
+                try
+                {
+                    action(ref reader);
+                    exception = null;
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+
+                switch(exception)
+                {
+                    case null:
+                        throw ThrowsException.ForNoException(typeof(E));
+                    case E ex when (ex.GetType() == typeof(E)):
+                        Assert.Equal(expectedParamName, ex.ParamName);
+                        return ex;
+                    default:
+                        throw ThrowsException.ForIncorrectExceptionType(typeof(E), exception);
+                }
+            }
+        }
+    }
+}

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ComprehensiveReadTests.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ComprehensiveReadTests.cs
@@ -5,7 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Test.Cryptography;
 using Xunit;
-using X509KeyUsageCSharpStyle=System.Formats.Asn1.Tests.Reader.ReadNamedBitList.X509KeyUsageCSharpStyle;
+using X509KeyUsageCSharpStyle=System.Formats.Asn1.Tests.Reader.ReadNamedBitListBase.X509KeyUsageCSharpStyle;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
@@ -153,6 +153,148 @@ namespace System.Formats.Asn1.Tests.Reader
             Assert.False(sigAlgReader.HasData);
         }
 
+        [Fact]
+        public static void ReadMicrosoftComCert_ValueReader()
+        {
+            byte[] bytes = MicrosoftDotComSslCertBytes;
+            ValueAsnReader fileReader = new ValueAsnReader(bytes, AsnEncodingRules.DER);
+
+            ValueAsnReader certReader = fileReader.ReadSequence();
+            Assert.False(fileReader.HasData, "fileReader.HasData");
+
+            ValueAsnReader tbsCertReader = certReader.ReadSequence();
+            ValueAsnReader sigAlgReader = certReader.ReadSequence();
+
+            Assert.True(
+                certReader.TryReadPrimitiveBitString(
+                    out int unusedBitCount,
+                    out ReadOnlySpan<byte> signature),
+                "certReader.TryReadPrimitiveBitStringValue");
+
+            Assert.Equal(0, unusedBitCount);
+            AssertRefSame(signature, ref bytes[1176], "Signature is a ref to bytes[1176]");
+
+            Assert.False(certReader.HasData, "certReader.HasData");
+
+            ValueAsnReader versionExplicitWrapper = tbsCertReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+            Assert.True(versionExplicitWrapper.TryReadInt32(out int certVersion));
+            Assert.Equal(2, certVersion);
+            Assert.False(versionExplicitWrapper.HasData, "versionExplicitWrapper.HasData");
+
+            ReadOnlySpan<byte> serialBytes = tbsCertReader.ReadIntegerBytes();
+            AssertRefSame(serialBytes, ref bytes[15], "Serial number starts at bytes[15]");
+
+            ValueAsnReader tbsSigAlgReader = tbsCertReader.ReadSequence();
+            Assert.Equal("1.2.840.113549.1.1.11", tbsSigAlgReader.ReadObjectIdentifier());
+            Assert.True(tbsSigAlgReader.HasData, "tbsSigAlgReader.HasData before ReadNull");
+            tbsSigAlgReader.ReadNull();
+            Assert.False(tbsSigAlgReader.HasData, "tbsSigAlgReader.HasData after ReadNull");
+
+            ValueAsnReader issuerReader = tbsCertReader.ReadSequence();
+            Asn1Tag printableString = new Asn1Tag(UniversalTagNumber.PrintableString);
+            AssertRdn(ref issuerReader, "2.5.4.6", 57, printableString, bytes, "issuer[C]");
+            AssertRdn(ref issuerReader, "2.5.4.10", 70, printableString, bytes, "issuer[O]");
+            AssertRdn(ref issuerReader, "2.5.4.11", 101, printableString, bytes, "issuer[OU]");
+            AssertRdn(ref issuerReader, "2.5.4.3", 134, printableString, bytes, "issuer[CN]");
+            Assert.False(issuerReader.HasData, "issuerReader.HasData");
+
+            ValueAsnReader validityReader = tbsCertReader.ReadSequence();
+            Assert.Equal(new DateTimeOffset(2014, 10, 15, 0, 0, 0, TimeSpan.Zero), validityReader.ReadUtcTime());
+            Assert.Equal(new DateTimeOffset(2016, 10, 15, 23, 59, 59, TimeSpan.Zero), validityReader.ReadUtcTime());
+            Assert.False(validityReader.HasData, "validityReader.HasData");
+
+            ValueAsnReader subjectReader = tbsCertReader.ReadSequence();
+            Asn1Tag utf8String = new Asn1Tag(UniversalTagNumber.UTF8String);
+            AssertRdn(ref subjectReader, "1.3.6.1.4.1.311.60.2.1.3", 220, printableString, bytes, "subject[EV Country]");
+            AssertRdn(ref subjectReader, "1.3.6.1.4.1.311.60.2.1.2", 241, utf8String, bytes, "subject[EV State]", "Washington");
+            AssertRdn(ref subjectReader, "2.5.4.15", 262, printableString, bytes, "subject[Business Category]");
+            AssertRdn(ref subjectReader, "2.5.4.5", 293, printableString, bytes, "subject[Serial Number]");
+            AssertRdn(ref subjectReader, "2.5.4.6", 313, printableString, bytes, "subject[C]");
+            AssertRdn(ref subjectReader, "2.5.4.17", 326, utf8String, bytes, "subject[Postal Code]", "98052");
+            AssertRdn(ref subjectReader, "2.5.4.8", 342, utf8String, bytes, "subject[ST]", "Washington");
+            AssertRdn(ref subjectReader, "2.5.4.7", 363, utf8String, bytes, "subject[L]", "Redmond");
+            AssertRdn(ref subjectReader, "2.5.4.9", 381, utf8String, bytes, "subject[Street Address]", "1 Microsoft Way");
+            AssertRdn(ref subjectReader, "2.5.4.10", 407, utf8String, bytes, "subject[O]", "Microsoft Corporation");
+            AssertRdn(ref subjectReader, "2.5.4.11", 439, utf8String, bytes, "subject[OU]", "MSCOM");
+            AssertRdn(ref subjectReader, "2.5.4.3", 455, utf8String, bytes, "subject[CN]", "www.microsoft.com");
+            Assert.False(subjectReader.HasData, "subjectReader.HasData");
+
+            ValueAsnReader subjectPublicKeyInfo = tbsCertReader.ReadSequence();
+            ValueAsnReader spkiAlgorithm = subjectPublicKeyInfo.ReadSequence();
+            Assert.Equal("1.2.840.113549.1.1.1", spkiAlgorithm.ReadObjectIdentifier());
+            spkiAlgorithm.ReadNull();
+            Assert.False(spkiAlgorithm.HasData, "spkiAlgorithm.HasData");
+
+            Assert.True(
+                subjectPublicKeyInfo.TryReadPrimitiveBitString(
+                    out unusedBitCount,
+                    out ReadOnlySpan<byte> encodedPublicKey),
+                "subjectPublicKeyInfo.TryReadBitStringBytes");
+
+            Assert.Equal(0, unusedBitCount);
+            AssertRefSame(encodedPublicKey, ref bytes[498], "Encoded public key starts at byte 498");
+
+            Assert.False(subjectPublicKeyInfo.HasData, "subjectPublicKeyInfo.HasData");
+
+            ValueAsnReader publicKeyReader = new ValueAsnReader(encodedPublicKey, AsnEncodingRules.DER);
+            ValueAsnReader rsaPublicKeyReader = publicKeyReader.ReadSequence();
+            AssertRefSame(rsaPublicKeyReader.ReadIntegerBytes(), ref bytes[506], "RSA Modulus is at bytes[502]");
+            Assert.True(rsaPublicKeyReader.TryReadInt32(out int rsaExponent));
+            Assert.Equal(65537, rsaExponent);
+            Assert.False(rsaPublicKeyReader.HasData, "rsaPublicKeyReader.HasData");
+            Assert.False(publicKeyReader.HasData, "publicKeyReader.HasData");
+
+            ValueAsnReader extensionsContainer = tbsCertReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 3));
+            ValueAsnReader extensions = extensionsContainer.ReadSequence();
+            Assert.False(extensionsContainer.HasData, "extensionsContainer.HasData");
+
+            ValueAsnReader sanExtension = extensions.ReadSequence();
+            Assert.Equal("2.5.29.17", sanExtension.ReadObjectIdentifier());
+            Assert.True(sanExtension.TryReadPrimitiveOctetString(out ReadOnlySpan<byte> sanExtensionBytes));
+            Assert.False(sanExtension.HasData, "sanExtension.HasData");
+
+            ValueAsnReader sanExtensionPayload = new ValueAsnReader(sanExtensionBytes, AsnEncodingRules.DER);
+            ValueAsnReader sanExtensionValue = sanExtensionPayload.ReadSequence();
+            Assert.False(sanExtensionPayload.HasData, "sanExtensionPayload.HasData");
+            Asn1Tag dnsName = new Asn1Tag(TagClass.ContextSpecific, 2);
+            Assert.Equal("www.microsoft.com", sanExtensionValue.ReadCharacterString(UniversalTagNumber.IA5String, dnsName));
+            Assert.Equal("wwwqa.microsoft.com", sanExtensionValue.ReadCharacterString(UniversalTagNumber.IA5String, dnsName));
+            Assert.False(sanExtensionValue.HasData, "sanExtensionValue.HasData");
+
+            ValueAsnReader basicConstraints = extensions.ReadSequence();
+            Assert.Equal("2.5.29.19", basicConstraints.ReadObjectIdentifier());
+            Assert.True(basicConstraints.TryReadPrimitiveOctetString(out ReadOnlySpan<byte> basicConstraintsBytes));
+
+            ValueAsnReader basicConstraintsPayload = new ValueAsnReader(basicConstraintsBytes, AsnEncodingRules.DER);
+            ValueAsnReader basicConstraintsValue = basicConstraintsPayload.ReadSequence();
+            Assert.False(basicConstraintsValue.HasData, "basicConstraintsValue.HasData");
+            Assert.False(basicConstraintsPayload.HasData, "basicConstraintsPayload.HasData");
+
+            ValueAsnReader keyUsageExtension = extensions.ReadSequence();
+            Assert.Equal("2.5.29.15", keyUsageExtension.ReadObjectIdentifier());
+            Assert.True(keyUsageExtension.ReadBoolean(), "keyUsageExtension.ReadBoolean() (IsCritical)");
+            Assert.True(keyUsageExtension.TryReadPrimitiveOctetString(out ReadOnlySpan<byte> keyUsageBytes));
+
+            ValueAsnReader keyUsagePayload = new ValueAsnReader(keyUsageBytes, AsnEncodingRules.DER);
+
+            Assert.Equal(
+                X509KeyUsageCSharpStyle.DigitalSignature | X509KeyUsageCSharpStyle.KeyEncipherment,
+                keyUsagePayload.ReadNamedBitListValue<X509KeyUsageCSharpStyle>());
+
+            Assert.False(keyUsagePayload.HasData, "keyUsagePayload.HasData");
+
+            AssertExtension(ref extensions, "2.5.29.37", false, 863, bytes);
+            AssertExtension(ref extensions, "2.5.29.32", false, 894, bytes);
+            AssertExtension(ref extensions, "2.5.29.35", false, 998, bytes);
+            AssertExtension(ref extensions, "2.5.29.31", false, 1031, bytes);
+            AssertExtension(ref extensions, "1.3.6.1.5.5.7.1.1", false, 1081, bytes);
+            Assert.False(extensions.HasData, "extensions.HasData");
+
+            Assert.Equal("1.2.840.113549.1.1.11", sigAlgReader.ReadObjectIdentifier());
+            sigAlgReader.ReadNull();
+            Assert.False(sigAlgReader.HasData);
+        }
+
         private static void AssertExtension(AsnReader extensions, string oid, bool critical, int index, byte[] bytes)
         {
             AsnReader extension = extensions.ReadSequence();
@@ -164,6 +306,20 @@ namespace System.Formats.Asn1.Tests.Reader
             }
 
             Assert.True(extension.TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> extensionBytes));
+            AssertRefSame(extensionBytes, ref bytes[index], $"{oid} extension value is at byte {index}");
+        }
+
+        private static void AssertExtension(ref ValueAsnReader extensions, string oid, bool critical, int index, byte[] bytes)
+        {
+            ValueAsnReader extension = extensions.ReadSequence();
+            Assert.Equal(oid, extension.ReadObjectIdentifier());
+
+            if (critical)
+            {
+                Assert.True(extension.ReadBoolean(), $"{oid} is critical");
+            }
+
+            Assert.True(extension.TryReadPrimitiveOctetString(out ReadOnlySpan<byte> extensionBytes));
             AssertRefSame(extensionBytes, ref bytes[index], $"{oid} extension value is at byte {index}");
         }
 
@@ -203,9 +359,49 @@ namespace System.Formats.Asn1.Tests.Reader
             Assert.False(rdn.HasData, $"rdn.HasData ({label})");
         }
 
+        private static void AssertRdn(
+            ref ValueAsnReader reader,
+            string atvOid,
+            int offset,
+            Asn1Tag valueTag,
+            byte[] bytes,
+            string label,
+            string stringValue=null)
+        {
+            ValueAsnReader rdn = reader.ReadSetOf();
+            ValueAsnReader attributeTypeAndValue = rdn.ReadSequence();
+            Assert.Equal(atvOid, attributeTypeAndValue.ReadObjectIdentifier());
+
+            ReadOnlySpan<byte> valueSpan = attributeTypeAndValue.ReadEncodedValue();
+
+            Assert.True(Asn1Tag.TryDecode(valueSpan, out Asn1Tag actualTag, out int bytesRead));
+            Assert.Equal(1, bytesRead);
+            Assert.Equal(valueTag, actualTag);
+
+            AssertRefSame(
+                ref MemoryMarshal.GetReference(valueSpan),
+                ref bytes[offset],
+                $"{label} is at bytes[{offset}]");
+
+            if (stringValue != null)
+            {
+                ValueAsnReader valueReader = new ValueAsnReader(valueSpan, AsnEncodingRules.DER);
+                Assert.Equal(stringValue, valueReader.ReadCharacterString((UniversalTagNumber)valueTag.TagValue));
+                Assert.False(valueReader.HasData, "valueReader.HasData");
+            }
+
+            Assert.False(attributeTypeAndValue.HasData, $"attributeTypeAndValue.HasData ({label})");
+            Assert.False(rdn.HasData, $"rdn.HasData ({label})");
+        }
+
         private static void AssertRefSame(ReadOnlyMemory<byte> a, ref byte b, string msg)
         {
             AssertRefSame(ref MemoryMarshal.GetReference(a.Span), ref b, msg);
+        }
+
+        private static void AssertRefSame(ReadOnlySpan<byte> a, ref byte b, string msg)
+        {
+            AssertRefSame(ref MemoryMarshal.GetReference(a), ref b, msg);
         }
 
         private static void AssertRefSame(ref byte a, ref byte b, string msg)

--- a/src/libraries/System.Formats.Asn1/tests/Reader/PeekTests.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/PeekTests.cs
@@ -36,6 +36,7 @@ namespace System.Formats.Asn1.Tests.Reader
             ReadOnlyMemory<byte> data,
             AsnEncodingRules ruleSet,
             AsnReaderOptions options = default);
+
         [Fact]
         public void ReaderPeekTag_Valid()
         {

--- a/src/libraries/System.Formats.Asn1/tests/Reader/PeekTests.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/PeekTests.cs
@@ -8,14 +8,40 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class PeekTests
+    public sealed class PeekTestsAsnReaderTests : PeekTestsBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class PeekTestsValueAsnReaderTests : PeekTestsBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class PeekTestsBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
         [Fact]
-        public static void ReaderPeekTag_Valid()
+        public void ReaderPeekTag_Valid()
         {
             // SEQUENCE(NULL)
             byte[] data = { 0x30, 0x02, 0x05, 0x00 };
-            AsnReader reader = new AsnReader(data, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(data, AsnEncodingRules.BER);
             Asn1Tag tag = reader.PeekTag();
 
             Assert.Equal((int)UniversalTagNumber.Sequence, tag.TagValue);
@@ -24,24 +50,26 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void ReaderPeekTag_Invalid()
+        public void ReaderPeekTag_Invalid()
         {
             // (UNIVERSAL [continue into next byte])
             byte[] data = { 0x1F };
-            AsnReader reader = new AsnReader(data, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(data, AsnEncodingRules.BER);
 
-            Assert.Throws<AsnContentException>(() => reader.PeekTag());
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.PeekTag());
         }
 
         [Fact]
-        public static void PeekEncodedValue_Primitive()
+        public void PeekEncodedValue_Primitive()
         {
             const string EncodedContents = "010203040506";
             const string EncodedValue = "0406" + EncodedContents;
 
             byte[] data = (EncodedValue + "0500").HexToByteArray();
 
-            AsnReader reader = new AsnReader(data, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(data, AsnEncodingRules.BER);
             Assert.Equal(EncodedValue, reader.PeekEncodedValue().ByteArrayToHex());
 
             // It's Peek, so it's reproducible.
@@ -49,14 +77,14 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void PeekEncodedValue_Indefinite()
+        public void PeekEncodedValue_Indefinite()
         {
             const string EncodedContents = "040101" + "04050203040506";
             const string EncodedValue = "2480" + EncodedContents + "0000";
 
             byte[] data = (EncodedValue + "0500").HexToByteArray();
 
-            AsnReader reader = new AsnReader(data, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(data, AsnEncodingRules.BER);
             Assert.Equal(EncodedValue, reader.PeekEncodedValue().ByteArrayToHex());
 
             // It's Peek, so it's reproducible.
@@ -64,7 +92,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void PeekEncodedValue_Corrupt_Throws()
+        public void PeekEncodedValue_Corrupt_Throws()
         {
             const string EncodedContents = "040101" + "04050203040506";
             // Constructed bit isn't set, so indefinite length is invalid.
@@ -72,23 +100,22 @@ namespace System.Formats.Asn1.Tests.Reader
 
             byte[] data = (EncodedValue + "0500").HexToByteArray();
 
+            AsnReaderWrapper reader = CreateWrapper(data, AsnEncodingRules.BER);
+
             Assert.Throws<AsnContentException>(
-                () =>
-                {
-                    AsnReader reader = new AsnReader(data, AsnEncodingRules.BER);
-                    reader.PeekEncodedValue();
-                });
+                ref reader,
+                static (ref reader) => reader.PeekEncodedValue());
         }
 
         [Fact]
-        public static void PeekContentSpan_Primitive()
+        public void PeekContentSpan_Primitive()
         {
             const string EncodedContents = "010203040506";
             const string EncodedValue = "0406" + EncodedContents;
 
             byte[] data = (EncodedValue + "0500").HexToByteArray();
 
-            AsnReader reader = new AsnReader(data, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(data, AsnEncodingRules.BER);
             Assert.Equal(EncodedContents, reader.PeekContentBytes().ByteArrayToHex());
 
             // It's Peek, so it's reproducible.
@@ -96,14 +123,14 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void PeekContentSpan_Indefinite()
+        public void PeekContentSpan_Indefinite()
         {
             const string EncodedContents = "040101" + "04050203040506";
             const string EncodedValue = "2480" + EncodedContents + "0000";
 
             byte[] data = (EncodedValue + "0500").HexToByteArray();
 
-            AsnReader reader = new AsnReader(data, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(data, AsnEncodingRules.BER);
             Assert.Equal(EncodedContents, reader.PeekContentBytes().ByteArrayToHex());
 
             // It's Peek, so it's reproducible.
@@ -111,7 +138,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void PeekContentSpan_Corrupt_Throws()
+        public void PeekContentSpan_Corrupt_Throws()
         {
             const string EncodedContents = "040101" + "04050203040506";
             // Constructed bit isn't set, so indefinite length is invalid.
@@ -119,18 +146,17 @@ namespace System.Formats.Asn1.Tests.Reader
 
             byte[] data = (EncodedValue + "0500").HexToByteArray();
 
+            AsnReaderWrapper reader = CreateWrapper(data, AsnEncodingRules.BER);
+
             Assert.Throws<AsnContentException>(
-                () =>
-                {
-                    AsnReader reader = new AsnReader(data, AsnEncodingRules.BER);
-                    reader.PeekContentBytes();
-                });
+                ref reader,
+                static (ref reader) => reader.PeekContentBytes());
         }
 
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public static void PeekContentSpan_ExtremelyNested(bool fullArray)
+        public void PeekContentSpan_ExtremelyNested(bool fullArray)
         {
             byte[] dataBytes = new byte[4 * 16384];
 
@@ -161,16 +187,16 @@ namespace System.Formats.Asn1.Tests.Reader
                 dataBytes[i + 1] = 0x80;
             }
 
-            AsnReader reader = new AsnReader(dataBytes, AsnEncodingRules.BER);
-            ReadOnlyMemory<byte> contents = reader.PeekContentBytes();
+            AsnReaderWrapper reader = CreateWrapper(dataBytes, AsnEncodingRules.BER);
+            ReadOnlySpan<byte> contents = reader.PeekContentBytes();
             Assert.Equal(expectedLength, contents.Length);
-            Assert.True(Unsafe.AreSame(ref dataBytes[2], ref MemoryMarshal.GetReference(contents.Span)));
+            Assert.True(Unsafe.AreSame(ref dataBytes[2], ref MemoryMarshal.GetReference(contents)));
         }
 
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public static void PeekEncodedValue_ExtremelyNested(bool fullArray)
+        public void PeekEncodedValue_ExtremelyNested(bool fullArray)
         {
             byte[] dataBytes = new byte[4 * 16384];
 
@@ -196,10 +222,10 @@ namespace System.Formats.Asn1.Tests.Reader
                 dataBytes[i + 1] = 0x80;
             }
 
-            AsnReader reader = new AsnReader(dataBytes, AsnEncodingRules.BER);
-            ReadOnlyMemory<byte> contents = reader.PeekEncodedValue();
+            AsnReaderWrapper reader = CreateWrapper(dataBytes, AsnEncodingRules.BER);
+            ReadOnlySpan<byte> contents = reader.PeekEncodedValue();
             Assert.Equal(expectedLength, contents.Length);
-            Assert.True(Unsafe.AreSame(ref dataBytes[0], ref MemoryMarshal.GetReference(contents.Span)));
+            Assert.True(Unsafe.AreSame(ref dataBytes[0], ref MemoryMarshal.GetReference(contents)));
 
             Assert.True(
                 AsnDecoder.TryReadEncodedValue(
@@ -217,14 +243,18 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void PeekEncodedValue_InvalidLength()
+        public void PeekEncodedValue_InvalidLength()
         {
             byte[] badLength = "04040203".HexToByteArray();
 
-            AsnReader reader = new AsnReader(badLength, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(badLength, AsnEncodingRules.BER);
 
-            Assert.Throws<AsnContentException>(() => reader.PeekEncodedValue());
-            Assert.Throws<AsnContentException>(() => reader.ReadEncodedValue());
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.PeekEncodedValue());
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadEncodedValue());
 
             Assert.False(
                 AsnDecoder.TryReadEncodedValue(
@@ -242,13 +272,15 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void PeekContentBytes_InvalidLength()
+        public void PeekContentBytes_InvalidLength()
         {
             byte[] badLength = "04040203".HexToByteArray();
 
-            AsnReader reader = new AsnReader(badLength, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(badLength, AsnEncodingRules.BER);
 
-            Assert.Throws<AsnContentException>(() => reader.PeekContentBytes());
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.PeekContentBytes());
         }
     }
 }

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadBMPString.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadBMPString.cs
@@ -9,8 +9,35 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadBMPString
+    public sealed class ReadBMPStringAsnReaderTests : ReadBMPStringBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadBMPStringValueAsnReaderTests : ReadBMPStringBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadBMPStringBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
+
         public static IEnumerable<object[]> ValidEncodingData { get; } =
             new object[][]
             {
@@ -120,13 +147,13 @@ namespace System.Formats.Asn1.Tests.Reader
 
         [Theory]
         [MemberData(nameof(ValidEncodingData))]
-        public static void GetBMPString_Success(
+        public void GetBMPString_Success(
             AsnEncodingRules ruleSet,
             string inputHex,
             string expectedValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             string value = reader.ReadCharacterString(UniversalTagNumber.BMPString);
 
             Assert.Equal(expectedValue, value);
@@ -134,7 +161,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
         [Theory]
         [MemberData(nameof(ValidEncodingData))]
-        public static void TryCopyBMPString(
+        public void TryCopyBMPString(
             AsnEncodingRules ruleSet,
             string inputHex,
             string expectedValue)
@@ -142,7 +169,7 @@ namespace System.Formats.Asn1.Tests.Reader
             byte[] inputData = inputHex.HexToByteArray();
             char[] output = new char[expectedValue.Length];
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             bool copied;
             int charsWritten;
 
@@ -171,7 +198,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
         [Theory]
         [MemberData(nameof(ValidEncodingData))]
-        public static void TryCopyBMPStringBytes(
+        public void TryCopyBMPStringBytes(
             AsnEncodingRules ruleSet,
             string inputHex,
             string expectedString)
@@ -180,7 +207,7 @@ namespace System.Formats.Asn1.Tests.Reader
             string expectedHex = Text.Encoding.BigEndianUnicode.GetBytes(expectedString).ByteArrayToHex();
             byte[] output = new byte[expectedHex.Length / 2];
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             bool copied;
             int bytesWritten;
 
@@ -212,15 +239,15 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "1E020020", true)]
         [InlineData(AsnEncodingRules.BER, "3E80" + "04020020" + "0000", false)]
         [InlineData(AsnEncodingRules.BER, "3E04" + "04020020", false)]
-        public static void TryReadBMPStringBytes(
+        public void TryReadBMPStringBytes(
             AsnEncodingRules ruleSet,
             string inputHex,
             bool expectSuccess)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            bool got = reader.TryReadBMPStringBytes(out ReadOnlyMemory<byte> contents);
+            bool got = reader.TryReadBMPStringBytes(out ReadOnlySpan<byte> contents);
 
             if (expectSuccess)
             {
@@ -228,7 +255,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
                 Assert.True(
                     Unsafe.AreSame(
-                        ref MemoryMarshal.GetReference(contents.Span),
+                        ref MemoryMarshal.GetReference(contents),
                         ref inputData[2]));
             }
             else
@@ -252,19 +279,20 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("Length Too Long", AsnEncodingRules.CER, "1E0600480069")]
         [InlineData("Length Too Long", AsnEncodingRules.DER, "1E0600480069")]
         [InlineData("Constructed Form", AsnEncodingRules.DER, "3E0404020049")]
-        public static void TryReadBMPStringBytes_Throws(
+        public void TryReadBMPStringBytes_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () =>
+                ref reader,
+                static (ref reader) =>
                 {
-                    reader.TryReadBMPStringBytes(out ReadOnlyMemory<byte> contents);
+                    reader.TryReadBMPStringBytes(out _);
                 });
         }
 
@@ -311,7 +339,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("NonEmpty Null", AsnEncodingRules.BER, "3E80000100")]
         [InlineData("NonEmpty Null", AsnEncodingRules.CER, "3E80000100")]
         [InlineData("LongLength Null", AsnEncodingRules.BER, "3E80008100")]
-        public static void TryCopyBMPStringBytes_Throws(
+        public void TryCopyBMPStringBytes_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
@@ -323,10 +351,11 @@ namespace System.Formats.Asn1.Tests.Reader
 
             int bytesWritten = -1;
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () =>
+                ref reader,
+                (ref reader) =>
                 {
                     reader.TryCopyBMPStringBytes(outputData, out bytesWritten);
                 });
@@ -335,16 +364,17 @@ namespace System.Formats.Asn1.Tests.Reader
             Assert.Equal(252, outputData[0]);
         }
 
-        private static void TryCopyBMPString_Throws_Helper(AsnEncodingRules ruleSet, byte[] inputData)
+        private void TryCopyBMPString_Throws_Helper(AsnEncodingRules ruleSet, byte[] inputData)
         {
             char[] outputData = new char[inputData.Length + 1];
             outputData[0] = 'a';
 
             int bytesWritten = -1;
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () =>
+                ref reader,
+                (ref reader) =>
                 {
                     reader.TryCopyBMPString(
                         outputData,
@@ -374,17 +404,18 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("Bad BMP value (high private surrogate)", AsnEncodingRules.BER, "1E02DB81")]
         [InlineData("Bad BMP value (low surrogate)", AsnEncodingRules.BER, "1E02DC00")]
         [InlineData("Wrong Tag", AsnEncodingRules.BER, "04024869")]
-        public static void GetBMPString_Throws(
+        public void GetBMPString_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () =>
+                ref reader,
+                static (ref reader) =>
                 {
                     reader.ReadCharacterString(UniversalTagNumber.BMPString);
                 });
@@ -437,7 +468,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("Bad BMP value (high surrogate)", AsnEncodingRules.BER, "1E02D800")]
         [InlineData("Bad BMP value (high private surrogate)", AsnEncodingRules.BER, "1E02DB81")]
         [InlineData("Bad BMP value (low surrogate)", AsnEncodingRules.BER, "1E02DC00")]
-        public static void TryCopyBMPString_Throws(
+        public void TryCopyBMPString_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
@@ -448,7 +479,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyBMPString_Throws_CER_NestedTooLong()
+        public void TryCopyBMPString_Throws_CER_NestedTooLong()
         {
             // CER says that the maximum encoding length for a BMPString primitive
             // is 1000.
@@ -477,7 +508,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyBMPString_Throws_CER_NestedTooShortIntermediate()
+        public void TryCopyBMPString_Throws_CER_NestedTooShortIntermediate()
         {
             // CER says that the maximum encoding length for a BMPString primitive
             // is 1000, and in the constructed form the lengths must be
@@ -515,7 +546,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyBMPStringBytes_Success_CER_MaxPrimitiveLength()
+        public void TryCopyBMPStringBytes_Success_CER_MaxPrimitiveLength()
         {
             // CER says that the maximum encoding length for a BMPString primitive
             // is 1000.
@@ -537,7 +568,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
             byte[] output = new byte[1000];
 
-            AsnReader reader = new AsnReader(input, AsnEncodingRules.CER);
+            AsnReaderWrapper reader = CreateWrapper(input, AsnEncodingRules.CER);
             bool success = reader.TryCopyBMPStringBytes(output, out int bytesWritten);
 
             Assert.True(success, "reader.TryCopyBMPStringBytes");
@@ -549,7 +580,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyBMPStringBytes_Success_CER_MinConstructedLength()
+        public void TryCopyBMPStringBytes_Success_CER_MinConstructedLength()
         {
             // CER says that the maximum encoding length for a BMPString primitive
             // is 1000, and that a constructed form must be used for values greater
@@ -601,7 +632,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
             byte[] output = new byte[1001];
 
-            AsnReader reader = new AsnReader(input, AsnEncodingRules.CER);
+            AsnReaderWrapper reader = CreateWrapper(input, AsnEncodingRules.CER);
             bool success = reader.TryCopyBMPStringBytes(output, out int bytesWritten);
 
             Assert.True(success, "reader.TryCopyBMPStringBytes");
@@ -616,23 +647,25 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 0x1E, 4, 0, (byte)'h', 0, (byte)'i' };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.TryReadBMPStringBytes(Asn1Tag.Null, out _));
+                static (ref reader) => reader.TryReadBMPStringBytes(Asn1Tag.Null, out _));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadBMPStringBytes(new Asn1Tag(TagClass.ContextSpecific, 0), out _));
+                ref reader,
+                static (ref reader) => reader.TryReadBMPStringBytes(new Asn1Tag(TagClass.ContextSpecific, 0), out _));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
-            Assert.True(reader.TryReadBMPStringBytes(out ReadOnlyMemory<byte> value));
+            Assert.True(reader.TryReadBMPStringBytes(out ReadOnlySpan<byte> value));
             Assert.Equal("00680069", value.ByteArrayToHex());
             Assert.False(reader.HasData, "HasData after read");
         }
@@ -641,35 +674,40 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 0x87, 2, 0x20, 0x10 };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.TryReadBMPStringBytes(Asn1Tag.Null, out _));
+                static (ref reader) => reader.TryReadBMPStringBytes(Asn1Tag.Null, out _));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.TryReadBMPStringBytes(out _));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.TryReadBMPStringBytes(out _));
 
             Assert.True(reader.HasData, "HasData after default tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadBMPStringBytes(new Asn1Tag(TagClass.Application, 0), out _));
+                ref reader,
+                static (ref reader) => reader.TryReadBMPStringBytes(new Asn1Tag(TagClass.Application, 0), out _));
 
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadBMPStringBytes(new Asn1Tag(TagClass.ContextSpecific, 1), out _));
+                ref reader,
+                static (ref reader) => reader.TryReadBMPStringBytes(new Asn1Tag(TagClass.ContextSpecific, 1), out _));
 
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
             Assert.True(
                 reader.TryReadBMPStringBytes(
                     new Asn1Tag(TagClass.ContextSpecific, 7),
-                    out ReadOnlyMemory<byte> value));
+                    out ReadOnlySpan<byte> value));
 
             Assert.Equal("2010", value.ByteArrayToHex());
             Assert.False(reader.HasData, "HasData after reading value");
@@ -682,28 +720,28 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "8002FE60", TagClass.ContextSpecific, 0)]
         [InlineData(AsnEncodingRules.CER, "4C02FE60", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "DF8A4602FE60", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
             int tagValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.True(
                 reader.TryReadBMPStringBytes(
                     new Asn1Tag(tagClass, tagValue, true),
-                    out ReadOnlyMemory<byte> val1));
+                    out ReadOnlySpan<byte> val1));
 
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             Assert.True(
                 reader.TryReadBMPStringBytes(
                     new Asn1Tag(tagClass, tagValue, false),
-                    out ReadOnlyMemory<byte> val2));
+                    out ReadOnlySpan<byte> val2));
 
             Assert.False(reader.HasData);
 
@@ -714,8 +752,8 @@ namespace System.Formats.Asn1.Tests.Reader
     internal static class ReaderBMPExtensions
     {
         public static bool TryReadBMPStringBytes(
-            this AsnReader reader,
-            out ReadOnlyMemory<byte> contents)
+            this ref AsnReaderWrapper reader,
+            out ReadOnlySpan<byte> contents)
         {
             return reader.TryReadPrimitiveCharacterStringBytes(
                 new Asn1Tag(UniversalTagNumber.BMPString),
@@ -723,9 +761,9 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         public static bool TryReadBMPStringBytes(
-            this AsnReader reader,
+            this ref AsnReaderWrapper reader,
             Asn1Tag expectedTag,
-            out ReadOnlyMemory<byte> contents)
+            out ReadOnlySpan<byte> contents)
         {
             return reader.TryReadPrimitiveCharacterStringBytes(
                 expectedTag,
@@ -733,7 +771,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         public static bool TryCopyBMPStringBytes(
-            this AsnReader reader,
+            this ref AsnReaderWrapper reader,
             Span<byte> destination,
             out int bytesWritten)
         {
@@ -744,7 +782,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         public static bool TryCopyBMPString(
-            this AsnReader reader,
+            this ref AsnReaderWrapper reader,
             Span<char> destination,
             out int charsWritten)
         {

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadBitString.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadBitString.cs
@@ -8,8 +8,35 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public static class ReadBitString
+    public sealed class ReadBitStringAsnReaderTests : ReadBitStringBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadBitStringValueAsnReaderTests : ReadBitStringBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadBitStringBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
+
         [Theory]
         [InlineData("Uncleared unused bit", AsnEncodingRules.BER, "030201FF")]
         [InlineData("Constructed Payload", AsnEncodingRules.BER, "2302030100")]
@@ -17,20 +44,20 @@ namespace System.Formats.Asn1.Tests.Reader
         // This value is actually invalid CER, but it returns false since it's not primitive and
         // it isn't worth preempting the descent to find out it was invalid.
         [InlineData("Constructed Payload-Indefinite", AsnEncodingRules.CER, "238003010000")]
-        public static void TryReadPrimitiveBitStringValue_Fails(
+        public void TryReadPrimitiveBitStringValue_Fails(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             bool didRead = reader.TryReadPrimitiveBitString(
                 out int unusedBitCount,
-                out ReadOnlyMemory<byte> contents);
+                out ReadOnlySpan<byte> contents);
 
-            Assert.False(didRead, "reader.TryReadBitStringBytes");
+            Assert.False(didRead, "reader.TryReadPrimitiveBitString");
             Assert.Equal(0, unusedBitCount);
             Assert.Equal(0, contents.Length);
         }
@@ -41,20 +68,20 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, 2, 4, "030502FEEFF00C")]
         [InlineData(AsnEncodingRules.DER, 7, 1, "03020780")]
         [InlineData(AsnEncodingRules.DER, 0, 4, "030500FEEFF00D" + "0500")]
-        public static void TryReadPrimitiveBitStringValue_Success(
+        public void TryReadPrimitiveBitStringValue_Success(
             AsnEncodingRules ruleSet,
             int expectedUnusedBitCount,
             int expectedLength,
             string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             bool didRead = reader.TryReadPrimitiveBitString(
                 out int unusedBitCount,
-                out ReadOnlyMemory<byte> contents);
+                out ReadOnlySpan<byte> contents);
 
-            Assert.True(didRead, "reader.TryReadBitStringBytes");
+            Assert.True(didRead, "reader.TryReadPrimitiveBitString");
             Assert.Equal(expectedUnusedBitCount, unusedBitCount);
             Assert.Equal(expectedLength, contents.Length);
         }
@@ -70,38 +97,30 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("Bad Length", AsnEncodingRules.CER, "030200")]
         [InlineData("Bad Length", AsnEncodingRules.DER, "030200")]
         [InlineData("Constructed Form", AsnEncodingRules.DER, "2303030100")]
-        public static void TryReadPrimitiveBitStringValue_Throws(
+        public void TryReadPrimitiveBitStringValue_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () =>
-                {
-                    reader.TryReadPrimitiveBitString(
-                        out int unusedBitCount,
-                        out ReadOnlyMemory<byte> contents);
-                });
+                ref reader,
+                static (ref reader) => reader.TryReadPrimitiveBitString(out _, out _));
 
             Assert.Throws<AsnContentException>(
-                () =>
-                {
-                    reader.TryReadBitString(
-                        new byte[inputData.Length],
-                        out int unusedBitCount,
-                        out int written);
-                });
+                ref reader,
+                (ref reader) => reader.TryReadBitString(new byte[inputData.Length], out _, out _));
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadBitString(out int unusedBitCount));
+                ref reader,
+                static (ref reader) => reader.ReadBitString(out _));
         }
 
         [Fact]
-        public static void TryReadPrimitiveBitStringValue_Throws_CER_TooLong()
+        public void TryReadPrimitiveBitStringValue_Throws_CER_TooLong()
         {
             // CER says that the maximum encoding length for a BitString primitive is
             // 1000 (999 value bytes and 1 unused bit count byte).
@@ -115,31 +134,22 @@ namespace System.Formats.Asn1.Tests.Reader
             input[2] = 0x03;
             input[3] = 0xE9;
 
-            AsnReader reader = new AsnReader(input, AsnEncodingRules.CER);
+            AsnReaderWrapper reader = CreateWrapper(input, AsnEncodingRules.CER);
 
             Assert.Throws<AsnContentException>(
-                () =>
-                {
-                    reader.TryReadPrimitiveBitString(
-                        out int unusedBitCount,
-                        out ReadOnlyMemory<byte> contents);
-                });
+                ref reader,
+                static (ref reader) => reader.TryReadPrimitiveBitString(out _, out _));
 
             Assert.Throws<AsnContentException>(
-                () =>
-                {
-                    reader.TryReadBitString(
-                        new byte[input.Length],
-                        out int unusedBitCount,
-                        out int written);
-                });
-
+                ref reader,
+                (ref reader) => reader.TryReadBitString(new byte[input.Length], out _, out _));
             Assert.Throws<AsnContentException>(
-                () => reader.ReadBitString(out int unusedBitCount));
+                ref reader,
+                static (ref reader) => reader.ReadBitString(out _));
         }
 
         [Fact]
-        public static void TryReadPrimitiveBitStringValue_Success_CER_MaxLength()
+        public void TryReadPrimitiveBitStringValue_Success_CER_MaxLength()
         {
             // CER says that the maximum encoding length for a BitString primitive is
             // 1000 (999 value bytes and 1 unused bit count byte).
@@ -161,20 +171,20 @@ namespace System.Formats.Asn1.Tests.Reader
             input[1002] = 0xA5;
             input[1003] = 0xFC;
 
-            AsnReader reader = new AsnReader(input, AsnEncodingRules.CER);
+            AsnReaderWrapper reader = CreateWrapper(input, AsnEncodingRules.CER);
 
             bool success = reader.TryReadPrimitiveBitString(
                 out int unusedBitCount,
-                out ReadOnlyMemory<byte> contents);
+                out ReadOnlySpan<byte> contents);
 
-            Assert.True(success, "reader.TryReadBitStringBytes");
+            Assert.True(success, "reader.TryReadPrimitiveBitString");
             Assert.Equal(input[4], unusedBitCount);
             Assert.Equal(999, contents.Length);
 
             // Check that it is, in fact, the same memory. No copies with this API.
             Assert.True(
                 Unsafe.AreSame(
-                    ref MemoryMarshal.GetReference(contents.Span),
+                    ref MemoryMarshal.GetReference(contents),
                     ref input[5]));
         }
 
@@ -190,10 +200,10 @@ namespace System.Formats.Asn1.Tests.Reader
                 "0000" +
               "03020000" +
               "0000")]
-        public static void TryCopyBitStringBytes_Fails(AsnEncodingRules ruleSet, string inputHex)
+        public void TryCopyBitStringBytes_Fails(AsnEncodingRules ruleSet, string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             bool didRead = reader.TryReadBitString(
                 Span<byte>.Empty,
@@ -254,7 +264,7 @@ namespace System.Formats.Asn1.Tests.Reader
               "0000",
             "FACEF00D010203F8",
             3)]
-        public static void TryCopyBitStringBytes_Success(
+        public void TryCopyBitStringBytes_Success(
             AsnEncodingRules ruleSet,
             string inputHex,
             string expectedHex,
@@ -262,7 +272,7 @@ namespace System.Formats.Asn1.Tests.Reader
         {
             byte[] inputData = inputHex.HexToByteArray();
             byte[] output = new byte[expectedHex.Length / 2];
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             bool didRead = reader.TryReadBitString(
                 output,
@@ -274,14 +284,15 @@ namespace System.Formats.Asn1.Tests.Reader
             Assert.Equal(expectedHex, output.AsSpan(0, bytesWritten).ByteArrayToHex());
         }
 
-        private static void TryReadBitString_Throws_Helper(
+        private void TryReadBitString_Throws_Helper(
             AsnEncodingRules ruleSet,
             byte[] input)
         {
-            AsnReader reader = new AsnReader(input, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(input, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () =>
+                ref reader,
+                static (ref reader) =>
                 {
                     reader.TryReadBitString(
                         Span<byte>.Empty,
@@ -290,12 +301,14 @@ namespace System.Formats.Asn1.Tests.Reader
                 });
         }
 
-        private static void ReadBitString_Throws(
+        private void ReadBitString_Throws_Helper(
             AsnEncodingRules ruleSet,
             byte[] input)
         {
-            AsnReader reader = new AsnReader(input, ruleSet);
-            Assert.Throws<AsnContentException>(() => reader.ReadBitString(out int unusedBitCount));
+            AsnReaderWrapper reader = CreateWrapper(input, ruleSet);
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadBitString(out _));
         }
 
         [Theory]
@@ -353,7 +366,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("NonEmpty Null", AsnEncodingRules.CER, "2380000100")]
         [InlineData("LongLength Null", AsnEncodingRules.BER, "2380008100")]
         [InlineData("Constructed Payload-TooShort", AsnEncodingRules.CER, "23800301000000")]
-        public static void TryCopyBitStringBytes_Throws(
+        public void TryCopyBitStringBytes_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
@@ -361,11 +374,11 @@ namespace System.Formats.Asn1.Tests.Reader
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
             TryReadBitString_Throws_Helper(ruleSet, inputData);
-            ReadBitString_Throws(ruleSet, inputData);
+            ReadBitString_Throws_Helper(ruleSet, inputData);
         }
 
         [Fact]
-        public static void TryCopyBitStringBytes_Throws_CER_TooLong()
+        public void TryCopyBitStringBytes_Throws_CER_TooLong()
         {
             // CER says that the maximum encoding length for a BitString primitive is
             // 1000 (999 value bytes and 1 unused bit count byte).
@@ -380,11 +393,11 @@ namespace System.Formats.Asn1.Tests.Reader
             input[3] = 0xE9;
 
             TryReadBitString_Throws_Helper(AsnEncodingRules.CER, input);
-            ReadBitString_Throws(AsnEncodingRules.CER, input);
+            ReadBitString_Throws_Helper(AsnEncodingRules.CER, input);
         }
 
         [Fact]
-        public static void TryCopyBitStringBytes_Throws_CER_NestedTooLong()
+        public void TryCopyBitStringBytes_Throws_CER_NestedTooLong()
         {
             // CER says that the maximum encoding length for a BitString primitive is
             // 1000 (999 value bytes and 1 unused bit count byte).
@@ -410,11 +423,11 @@ namespace System.Formats.Asn1.Tests.Reader
             // EOC implicit since the byte[] initializes to zeros
 
             TryReadBitString_Throws_Helper(AsnEncodingRules.CER, input);
-            ReadBitString_Throws(AsnEncodingRules.CER, input);
+            ReadBitString_Throws_Helper(AsnEncodingRules.CER, input);
         }
 
         [Fact]
-        public static void TryCopyBitStringBytes_Throws_CER_NestedTooShortIntermediate()
+        public void TryCopyBitStringBytes_Throws_CER_NestedTooShortIntermediate()
         {
             // CER says that the maximum encoding length for a BitString primitive is
             // 1000 (999 value bytes and 1 unused bit count byte), and in the constructed
@@ -453,7 +466,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyBitStringBytes_Success_CER_MaxPrimitiveLength()
+        public void TryCopyBitStringBytes_Success_CER_MaxPrimitiveLength()
         {
             // CER says that the maximum encoding length for a BitString primitive is
             // 1000 (999 value bytes and 1 unused bit count byte).
@@ -477,7 +490,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
             byte[] output = new byte[999];
 
-            AsnReader reader = new AsnReader(input, AsnEncodingRules.CER);
+            AsnReaderWrapper reader = CreateWrapper(input, AsnEncodingRules.CER);
 
             bool success = reader.TryReadBitString(
                 output,
@@ -492,14 +505,14 @@ namespace System.Formats.Asn1.Tests.Reader
                 input.AsSpan(5).ByteArrayToHex(),
                 output.ByteArrayToHex());
 
-            reader = new AsnReader(input, AsnEncodingRules.CER);
+            reader = CreateWrapper(input, AsnEncodingRules.CER);
             byte[] output2 = reader.ReadBitString(out int ubc2);
             Assert.Equal(unusedBitCount, ubc2);
             Assert.Equal(output, output2);
         }
 
         [Fact]
-        public static void TryCopyBitStringBytes_Success_CER_MinConstructedLength()
+        public void TryCopyBitStringBytes_Success_CER_MinConstructedLength()
         {
             // CER says that the maximum encoding length for a BitString primitive is
             // 1000 (999 value bytes and 1 unused bit count byte), and that a constructed
@@ -557,7 +570,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
             byte[] output = new byte[1000];
 
-            AsnReader reader = new AsnReader(input, AsnEncodingRules.CER);
+            AsnReaderWrapper reader = CreateWrapper(input, AsnEncodingRules.CER);
 
             bool success = reader.TryReadBitString(
                 output,
@@ -572,7 +585,7 @@ namespace System.Formats.Asn1.Tests.Reader
                 expected.ByteArrayToHex(),
                 output.ByteArrayToHex());
 
-            reader = new AsnReader(input, AsnEncodingRules.CER);
+            reader = CreateWrapper(input, AsnEncodingRules.CER);
             byte[] output2 = reader.ReadBitString(out int ubc2);
             Assert.Equal(unusedBitCount, ubc2);
             Assert.Equal(output, output2);
@@ -582,23 +595,25 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 3, 2, 1, 0x7E };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.TryReadPrimitiveBitString(out _, out _, Asn1Tag.Null));
+                static (ref reader) => reader.TryReadPrimitiveBitString(out _, out _, Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadPrimitiveBitString(out _, out _, new Asn1Tag(TagClass.ContextSpecific, 0)));
+                ref reader,
+                static (ref reader) => reader.TryReadPrimitiveBitString(out _, out _, new Asn1Tag(TagClass.ContextSpecific, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
-            Assert.True(reader.TryReadPrimitiveBitString(out int unusedBitCount, out ReadOnlyMemory<byte> contents));
+            Assert.True(reader.TryReadPrimitiveBitString(out int unusedBitCount, out ReadOnlySpan<byte> contents));
             Assert.Equal("7E", contents.ByteArrayToHex());
             Assert.Equal(1, unusedBitCount);
             Assert.False(reader.HasData, "HasData after read");
@@ -608,54 +623,75 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 0x87, 2, 0, 0x80 };
             byte[] output = new byte[inputData.Length];
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Asn1Tag wrongTag1 = new Asn1Tag(TagClass.Application, 0);
             Asn1Tag wrongTag2 = new Asn1Tag(TagClass.ContextSpecific, 1);
             Asn1Tag correctTag = new Asn1Tag(TagClass.ContextSpecific, 7);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.TryReadPrimitiveBitString(out _, out _, Asn1Tag.Null));
-            AssertExtensions.Throws<ArgumentException>(
+                static (ref reader) => reader.TryReadPrimitiveBitString(out _, out _, Asn1Tag.Null));
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.TryReadBitString(output, out _, out _, Asn1Tag.Null));
-            AssertExtensions.Throws<ArgumentException>(
+                (ref reader) => reader.TryReadBitString(output, out _, out _, Asn1Tag.Null));
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadBitString(out _, Asn1Tag.Null));
+                static (ref reader) => reader.ReadBitString(out _, Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.TryReadPrimitiveBitString(out _, out _));
-            Assert.Throws<AsnContentException>(() => reader.TryReadBitString(output, out _, out _));
-            Assert.Throws<AsnContentException>(() => reader.ReadBitString(out _));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.TryReadPrimitiveBitString(out _, out _));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                (ref reader) => reader.TryReadBitString(output, out _, out _));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadBitString(out _));
             Assert.True(reader.HasData, "HasData after default tag");
 
-            Assert.Throws<AsnContentException>(() => reader.TryReadPrimitiveBitString(out _, out _, wrongTag1));
-            Assert.Throws<AsnContentException>(() => reader.TryReadBitString(output, out _, out _, wrongTag1));
-            Assert.Throws<AsnContentException>(() => reader.ReadBitString(out _, wrongTag1));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                (ref reader) => reader.TryReadPrimitiveBitString(out _, out _, wrongTag1));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                (ref reader) => reader.TryReadBitString(output, out _, out _, wrongTag1));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                (ref reader) => reader.ReadBitString(out _, wrongTag1));
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
-            Assert.Throws<AsnContentException>(() => reader.TryReadPrimitiveBitString(out _, out _, wrongTag2));
-            Assert.Throws<AsnContentException>(() => reader.TryReadBitString(output, out _, out _, wrongTag2));
-            Assert.Throws<AsnContentException>(() => reader.ReadBitString(out _, wrongTag2));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                (ref reader) => reader.TryReadPrimitiveBitString(out _, out _, wrongTag2));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                (ref reader) => reader.TryReadBitString(output, out _, out _, wrongTag2));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                (ref reader) => reader.ReadBitString(out _, wrongTag2));
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
             Assert.True(
                 reader.TryReadPrimitiveBitString(
                     out int unusedBitCount,
-                    out ReadOnlyMemory<byte> contents,
+                    out ReadOnlySpan<byte> contents,
                     correctTag));
 
             Assert.Equal("80", contents.ByteArrayToHex());
             Assert.Equal(0, unusedBitCount);
             Assert.False(reader.HasData, "HasData after reading value");
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             Assert.True(
                 reader.TryReadBitString(
@@ -668,7 +704,7 @@ namespace System.Formats.Asn1.Tests.Reader
             Assert.Equal(0, unusedBitCount);
             Assert.False(reader.HasData, "HasData after reading value");
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
             byte[] output2 = reader.ReadBitString(out unusedBitCount, correctTag);
 
             Assert.Equal("80", output2.ByteArrayToHex());
@@ -683,40 +719,31 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "800200FF", TagClass.ContextSpecific, 0)]
         [InlineData(AsnEncodingRules.CER, "4C0200FF", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "DF8A460200FF", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
             int tagValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
             Asn1Tag correctConstructed = new Asn1Tag(tagClass, tagValue, true);
             Asn1Tag correctPrimitive = new Asn1Tag(tagClass, tagValue, false);
 
-            Assert.True(
-                reader.TryReadPrimitiveBitString(
-                    out int ubc1,
-                    out ReadOnlyMemory<byte> val1,
-                    correctConstructed));
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
+            Assert.True(reader.TryReadPrimitiveBitString(out int ubc1, out ReadOnlySpan<byte> val1, correctConstructed));
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.True(
-                reader.TryReadPrimitiveBitString(
-                    out int ubc2,
-                    out ReadOnlyMemory<byte> val2,
-                    correctPrimitive));
-
+            Assert.True(reader.TryReadPrimitiveBitString(out int ubc2, out ReadOnlySpan<byte> val2, correctPrimitive));
             Assert.False(reader.HasData);
 
             string val1Hex = val1.ByteArrayToHex();
             Assert.Equal(val1Hex, val2.ByteArrayToHex());
             Assert.Equal(ubc1, ubc2);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
             byte[] output1 = new byte[inputData.Length];
 
             Assert.True(reader.TryReadBitString(output1.AsSpan(1), out ubc1, out int written, correctConstructed));
@@ -724,21 +751,21 @@ namespace System.Formats.Asn1.Tests.Reader
             Assert.Equal(val1Hex, output1.AsSpan(1, written).ByteArrayToHex());
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             Assert.True(reader.TryReadBitString(output1.AsSpan(2), out ubc1, out written, correctPrimitive));
             Assert.Equal(ubc2, ubc1);
             Assert.Equal(val1Hex, output1.AsSpan(2, written).ByteArrayToHex());
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
             byte[] output2 = reader.ReadBitString(out ubc1, correctConstructed);
 
             Assert.Equal(ubc2, ubc1);
             Assert.Equal(val1Hex, output2.ByteArrayToHex());
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
             byte[] output3 = reader.ReadBitString(out ubc1, correctPrimitive);
 
             Assert.Equal(ubc2, ubc1);
@@ -747,7 +774,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyBitStringBytes_ExtremelyNested()
+        public void TryCopyBitStringBytes_ExtremelyNested()
         {
             byte[] dataBytes = new byte[4 * 16384];
 
@@ -767,7 +794,7 @@ namespace System.Formats.Asn1.Tests.Reader
                 dataBytes[i + 1] = 0x80;
             }
 
-            AsnReader reader = new AsnReader(dataBytes, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(dataBytes, AsnEncodingRules.BER);
 
             int bytesWritten;
             int unusedBitCount;
@@ -778,7 +805,7 @@ namespace System.Formats.Asn1.Tests.Reader
             Assert.Equal(0, bytesWritten);
             Assert.Equal(0, unusedBitCount);
 
-            reader = new AsnReader(dataBytes, AsnEncodingRules.BER);
+            reader = CreateWrapper(dataBytes, AsnEncodingRules.BER);
             byte[] output = reader.ReadBitString(out unusedBitCount);
             Assert.Equal(0, unusedBitCount);
 

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadBoolean.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadBoolean.cs
@@ -6,8 +6,35 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadBoolean
+    public sealed class ReadBooleanAsnReaderTests : ReadBooleanBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadBooleanValueAsnReaderTests : ReadBooleanBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadBooleanBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
+
         [Theory]
         [InlineData(AsnEncodingRules.BER, false, 3, "010100")]
         [InlineData(AsnEncodingRules.BER, true, 3, "010101")]
@@ -24,14 +51,14 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.DER, true, 4, "5F1F01FF0500")]
         // Private 253
         [InlineData(AsnEncodingRules.CER, false, 5, "DF817D01000500")]
-        public static void ReadBoolean_Success(
+        public void ReadBoolean_Success(
             AsnEncodingRules ruleSet,
             bool expectedValue,
             int expectedBytesRead,
             string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Asn1Tag tag = reader.PeekTag();
             bool value;
@@ -68,19 +95,21 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 1, 1, 0 };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadBoolean(Asn1Tag.Null));
+                static (ref reader) => reader.ReadBoolean(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadBoolean(new Asn1Tag(TagClass.ContextSpecific, 0)));
+                ref reader,
+                static (ref reader) => reader.ReadBoolean(new Asn1Tag(TagClass.ContextSpecific, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
@@ -93,28 +122,33 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 0x80, 1, 0xFF };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadBoolean(Asn1Tag.Null));
+                static (ref reader) => reader.ReadBoolean(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadBoolean());
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadBoolean());
 
             Assert.True(reader.HasData, "HasData after default tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadBoolean(new Asn1Tag(TagClass.Application, 0)));
+                ref reader,
+                static (ref reader) => reader.ReadBoolean(new Asn1Tag(TagClass.Application, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadBoolean(new Asn1Tag(TagClass.ContextSpecific, 1)));
+                ref reader,
+                static (ref reader) => reader.ReadBoolean(new Asn1Tag(TagClass.ContextSpecific, 1)));
 
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
@@ -130,17 +164,17 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "8001FF", TagClass.ContextSpecific, 0)]
         [InlineData(AsnEncodingRules.CER, "4C01FF", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "DF8A4601FF", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
             int tagValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             bool val1 = reader.ReadBoolean(new Asn1Tag(tagClass, tagValue, true));
             Assert.False(reader.HasData);
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
             bool val2 = reader.ReadBoolean(new Asn1Tag(tagClass, tagValue, false));
             Assert.False(reader.HasData);
 
@@ -185,7 +219,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("IndefiniteLength", AsnEncodingRules.BER, "01800101FF00")]
         [InlineData("IndefiniteLength", AsnEncodingRules.CER, "01800101FF00")]
         [InlineData("IndefiniteLength", AsnEncodingRules.DER, "01800101FF00")]
-        public static void ReadBoolean_Failure(
+        public void ReadBoolean_Failure(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
@@ -193,8 +227,8 @@ namespace System.Formats.Asn1.Tests.Reader
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
-            Asn1Tag tag = default(Asn1Tag);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
+            Asn1Tag tag = default;
 
             if (inputData.Length > 0)
             {
@@ -203,11 +237,15 @@ namespace System.Formats.Asn1.Tests.Reader
 
             if (tag.TagClass == TagClass.Universal)
             {
-                Assert.Throws<AsnContentException>(() => reader.ReadBoolean());
+                Assert.Throws<AsnContentException>(
+                    ref reader,
+                    static (ref reader) => reader.ReadBoolean());
             }
             else
             {
-                Assert.Throws<AsnContentException>(() => reader.ReadBoolean(tag));
+                Assert.Throws<AsnContentException>(
+                    ref reader,
+                    (ref reader) => reader.ReadBoolean(tag));
             }
 
             if (inputData.Length == 0)

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadEnumerated.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadEnumerated.cs
@@ -7,8 +7,35 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadEnumerated
+    public sealed class ReadEnumeratedAsnReaderTests : ReadEnumeratedBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadEnumeratedValueAsnReaderTests : ReadEnumeratedBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadEnumeratedBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
+
         public enum ByteBacked : byte
         {
             Zero = 0,
@@ -62,14 +89,14 @@ namespace System.Formats.Asn1.Tests.Reader
             Fluff = 0xFACEF00DCAFEBEEF,
         }
 
-        private static void GetExpectedValue<TEnum>(
+        private void GetExpectedValue<TEnum>(
             AsnEncodingRules ruleSet,
             TEnum expectedValue,
             string inputHex)
             where TEnum : Enum
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             TEnum value = reader.ReadEnumeratedValue<TEnum>();
             Assert.Equal(expectedValue, value);
         }
@@ -85,7 +112,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, (ByteBacked)128, "0A020080")]
         [InlineData(AsnEncodingRules.DER, (ByteBacked)129, "0A020081")]
         [InlineData(AsnEncodingRules.BER, (ByteBacked)254, "0A82000200FE")]
-        public static void GetExpectedValue_ByteBacked(
+        public void GetExpectedValue_ByteBacked(
             AsnEncodingRules ruleSet,
             ByteBacked expectedValue,
             string inputHex)
@@ -104,7 +131,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, (SByteBacked)sbyte.MinValue, "0A0180")]
         [InlineData(AsnEncodingRules.DER, (SByteBacked)sbyte.MinValue + 1, "0A0181")]
         [InlineData(AsnEncodingRules.BER, SByteBacked.Pillow, "0A820001EF")]
-        public static void GetExpectedValue_SByteBacked(
+        public void GetExpectedValue_SByteBacked(
             AsnEncodingRules ruleSet,
             SByteBacked expectedValue,
             string inputHex)
@@ -123,7 +150,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, (ShortBacked)short.MinValue, "0A028000")]
         [InlineData(AsnEncodingRules.DER, (ShortBacked)short.MinValue + 1, "0A028001")]
         [InlineData(AsnEncodingRules.BER, ShortBacked.Pillow, "0A820002FC00")]
-        public static void GetExpectedValue_ShortBacked(
+        public void GetExpectedValue_ShortBacked(
             AsnEncodingRules ruleSet,
             ShortBacked expectedValue,
             string inputHex)
@@ -143,7 +170,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.DER, (UShortBacked)0x7FED, "0A027FED")]
         [InlineData(AsnEncodingRules.BER, (UShortBacked)ushort.MaxValue, "0A82000300FFFF")]
         [InlineData(AsnEncodingRules.BER, (UShortBacked)0x8123, "0A820003008123")]
-        public static void GetExpectedValue_UShortBacked(
+        public void GetExpectedValue_UShortBacked(
             AsnEncodingRules ruleSet,
             UShortBacked expectedValue,
             string inputHex)
@@ -162,7 +189,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, (IntBacked)int.MinValue, "0A0480000000")]
         [InlineData(AsnEncodingRules.DER, (IntBacked)int.MinValue + 1, "0A0480000001")]
         [InlineData(AsnEncodingRules.BER, IntBacked.Pillow, "0A820003FEFFFF")]
-        public static void GetExpectedValue_IntBacked(
+        public void GetExpectedValue_IntBacked(
             AsnEncodingRules ruleSet,
             IntBacked expectedValue,
             string inputHex)
@@ -182,7 +209,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.DER, (UIntBacked)0x7FED, "0A027FED")]
         [InlineData(AsnEncodingRules.BER, (UIntBacked)uint.MaxValue, "0A82000500FFFFFFFF")]
         [InlineData(AsnEncodingRules.BER, (UIntBacked)0x8123, "0A820003008123")]
-        public static void GetExpectedValue_UIntBacked(
+        public void GetExpectedValue_UIntBacked(
             AsnEncodingRules ruleSet,
             UIntBacked expectedValue,
             string inputHex)
@@ -201,7 +228,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, (LongBacked)short.MinValue, "0A028000")]
         [InlineData(AsnEncodingRules.DER, (LongBacked)short.MinValue + 1, "0A028001")]
         [InlineData(AsnEncodingRules.BER, LongBacked.Pillow, "0A820005FF00000000")]
-        public static void GetExpectedValue_LongBacked(
+        public void GetExpectedValue_LongBacked(
             AsnEncodingRules ruleSet,
             LongBacked expectedValue,
             string inputHex)
@@ -222,7 +249,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, (ULongBacked)uint.MaxValue, "0A82000500FFFFFFFF")]
         [InlineData(AsnEncodingRules.BER, (ULongBacked)ulong.MaxValue, "0A82000900FFFFFFFFFFFFFFFF")]
         [InlineData(AsnEncodingRules.BER, (ULongBacked)0x8123, "0A820003008123")]
-        public static void GetExpectedValue_ULongBacked(
+        public void GetExpectedValue_ULongBacked(
             AsnEncodingRules ruleSet,
             ULongBacked expectedValue,
             string inputHex)
@@ -277,12 +304,12 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.DER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.BER, "2A030A0100")]
-        public static void ReadEnumeratedValue_Invalid_Byte(AsnEncodingRules ruleSet, string inputHex)
+        public void ReadEnumeratedValue_Invalid_Byte(AsnEncodingRules ruleSet, string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadEnumeratedValue<ByteBacked>());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadEnumeratedValue<ByteBacked>());
         }
 
         [Theory]
@@ -329,12 +356,12 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.DER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.BER, "2A030A0100")]
-        public static void ReadEnumeratedValue_Invalid_SByte(AsnEncodingRules ruleSet, string inputHex)
+        public void ReadEnumeratedValue_Invalid_SByte(AsnEncodingRules ruleSet, string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadEnumeratedValue<SByteBacked>());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadEnumeratedValue<SByteBacked>());
         }
 
         [Theory]
@@ -378,12 +405,12 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.DER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.BER, "2A030A0100")]
-        public static void ReadEnumeratedValue_Invalid_Short(AsnEncodingRules ruleSet, string inputHex)
+        public void ReadEnumeratedValue_Invalid_Short(AsnEncodingRules ruleSet, string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadEnumeratedValue<ShortBacked>());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadEnumeratedValue<ShortBacked>());
         }
 
         [Theory]
@@ -430,12 +457,12 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.DER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.BER, "2A030A0100")]
-        public static void ReadEnumeratedValue_Invalid_UShort(AsnEncodingRules ruleSet, string inputHex)
+        public void ReadEnumeratedValue_Invalid_UShort(AsnEncodingRules ruleSet, string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadEnumeratedValue<UShortBacked>());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadEnumeratedValue<UShortBacked>());
         }
 
 
@@ -474,12 +501,12 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.DER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.BER, "2A030A0100")]
-        public static void ReadEnumeratedValue_Invalid_Int(AsnEncodingRules ruleSet, string inputHex)
+        public void ReadEnumeratedValue_Invalid_Int(AsnEncodingRules ruleSet, string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadEnumeratedValue<IntBacked>());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadEnumeratedValue<IntBacked>());
         }
 
         [Theory]
@@ -517,12 +544,12 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.DER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.BER, "2A030A0100")]
-        public static void ReadEnumeratedValue_Invalid_UInt(AsnEncodingRules ruleSet, string inputHex)
+        public void ReadEnumeratedValue_Invalid_UInt(AsnEncodingRules ruleSet, string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadEnumeratedValue<UIntBacked>());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadEnumeratedValue<UIntBacked>());
         }
 
         [Theory]
@@ -554,12 +581,12 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.DER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.BER, "2A030A0100")]
-        public static void ReadEnumeratedValue_Invalid_Long(AsnEncodingRules ruleSet, string inputHex)
+        public void ReadEnumeratedValue_Invalid_Long(AsnEncodingRules ruleSet, string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadEnumeratedValue<LongBacked>());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadEnumeratedValue<LongBacked>());
         }
 
         [Theory]
@@ -591,26 +618,27 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.DER, "0A09010203040506070809")]
         [InlineData(AsnEncodingRules.BER, "2A030A0100")]
-        public static void ReadEnumeratedValue_Invalid_ULong(AsnEncodingRules ruleSet, string inputHex)
+        public void ReadEnumeratedValue_Invalid_ULong(AsnEncodingRules ruleSet, string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadEnumeratedValue<ULongBacked>());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadEnumeratedValue<ULongBacked>());
         }
 
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadEnumeratedValue_RequiresTypeArg(AsnEncodingRules ruleSet)
+        public void ReadEnumeratedValue_RequiresTypeArg(AsnEncodingRules ruleSet)
         {
             byte[] data = { 0x0A, 0x01, 0x00 };
-            AsnReader reader = new AsnReader(data, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(data, ruleSet);
 
-            AssertExtensions.Throws<ArgumentNullException>(
+            Assert.Throws<ArgumentNullException>(
+                ref reader,
                 "enumType",
-                () => reader.ReadEnumeratedValue(null!));
+                static (ref reader) => reader.ReadEnumeratedValue(null!));
 
             Assert.True(reader.HasData, "reader.HasData");
         }
@@ -619,41 +647,42 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadEnumeratedValue_NonEnumType(AsnEncodingRules ruleSet)
+        public void ReadEnumeratedValue_NonEnumType(AsnEncodingRules ruleSet)
         {
             byte[] data = { 0x0A, 0x01, 0x00 };
-            AsnReader reader = new AsnReader(data, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(data, ruleSet);
 
-            Assert.Throws<ArgumentException>(() => reader.ReadEnumeratedValue(typeof(Guid)));
+            Assert.Throws<ArgumentException>(ref reader, static (ref reader) => reader.ReadEnumeratedValue(typeof(Guid)));
         }
 
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadEnumeratedValue_FlagsEnum(AsnEncodingRules ruleSet)
+        public void ReadEnumeratedValue_FlagsEnum(AsnEncodingRules ruleSet)
         {
             byte[] data = { 0x0A, 0x01, 0x00 };
-            AsnReader reader = new AsnReader(data, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(data, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "enumType",
-                () => reader.ReadEnumeratedValue<AssemblyFlags>());
+                static (ref reader) => reader.ReadEnumeratedValue<AssemblyFlags>());
         }
 
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadEnumeratedBytes(AsnEncodingRules ruleSet)
+        public void ReadEnumeratedBytes(AsnEncodingRules ruleSet)
         {
             const string Payload = "0102030405060708090A0B0C0D0E0F10";
 
             // ENUMERATED (payload) followed by INTEGER (0)
             byte[] data = ("0A10" + Payload + "020100").HexToByteArray();
-            AsnReader reader = new AsnReader(data, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(data, ruleSet);
 
-            ReadOnlyMemory<byte> contents = reader.ReadEnumeratedBytes();
+            ReadOnlySpan<byte> contents = reader.ReadEnumeratedBytes();
             Assert.Equal(0x10, contents.Length);
             Assert.Equal(Payload, contents.ByteArrayToHex());
         }
@@ -680,31 +709,33 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "0A81")]
         [InlineData(AsnEncodingRules.CER, "0A81")]
         [InlineData(AsnEncodingRules.DER, "0A81")]
-        public static void ReadEnumeratedBytes_Throws(AsnEncodingRules ruleSet, string inputHex)
+        public void ReadEnumeratedBytes_Throws(AsnEncodingRules ruleSet, string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadEnumeratedBytes());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadEnumeratedBytes());
         }
 
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 0x0A, 1, 0x7E };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadEnumeratedValue<ShortBacked>(Asn1Tag.Null));
+                static (ref reader) => reader.ReadEnumeratedValue<ShortBacked>(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadEnumeratedValue<ShortBacked>(new Asn1Tag(TagClass.ContextSpecific, 0)));
+                ref reader,
+                static (ref reader) => reader.ReadEnumeratedValue<ShortBacked>(new Asn1Tag(TagClass.ContextSpecific, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
@@ -717,28 +748,33 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 0x87, 2, 0, 0x80 };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadEnumeratedValue<ShortBacked>(Asn1Tag.Null));
+                static (ref reader) => reader.ReadEnumeratedValue<ShortBacked>(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadEnumeratedValue<ShortBacked>());
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadEnumeratedValue<ShortBacked>());
 
             Assert.True(reader.HasData, "HasData after default tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadEnumeratedValue<ShortBacked>(new Asn1Tag(TagClass.Application, 0)));
+                ref reader,
+                static (ref reader) => reader.ReadEnumeratedValue<ShortBacked>(new Asn1Tag(TagClass.Application, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadEnumeratedValue<ShortBacked>(new Asn1Tag(TagClass.ContextSpecific, 1)));
+                ref reader,
+                static (ref reader) => reader.ReadEnumeratedValue<ShortBacked>(new Asn1Tag(TagClass.ContextSpecific, 1)));
 
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
@@ -754,7 +790,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "8001FF", TagClass.ContextSpecific, 0)]
         [InlineData(AsnEncodingRules.CER, "4C01FF", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "DF8A4601FF", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
@@ -764,34 +800,34 @@ namespace System.Formats.Asn1.Tests.Reader
             Asn1Tag constructedTag = new Asn1Tag(tagClass, tagValue, true);
             byte[] inputData = inputHex.HexToByteArray();
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             ShortBacked val1 = reader.ReadEnumeratedValue<ShortBacked>(constructedTag);
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
             ShortBacked val2 = reader.ReadEnumeratedValue<ShortBacked>(primitiveTag);
             Assert.False(reader.HasData);
 
             Assert.Equal(val1, val2);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
             ShortBacked val3 = (ShortBacked)reader.ReadEnumeratedValue(typeof(ShortBacked), constructedTag);
             Assert.False(reader.HasData);
 
             Assert.Equal(val1, val3);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
             ShortBacked val4 = (ShortBacked)reader.ReadEnumeratedValue(typeof(ShortBacked), primitiveTag);
             Assert.False(reader.HasData);
 
             Assert.Equal(val1, val4);
 
-            reader = new AsnReader(inputData, ruleSet);
-            ReadOnlyMemory<byte> bytes1 = reader.ReadEnumeratedBytes(constructedTag);
+            reader = CreateWrapper(inputData, ruleSet);
+            ReadOnlySpan<byte> bytes1 = reader.ReadEnumeratedBytes(constructedTag);
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
-            ReadOnlyMemory<byte> bytes2 = reader.ReadEnumeratedBytes(primitiveTag);
+            reader = CreateWrapper(inputData, ruleSet);
+            ReadOnlySpan<byte> bytes2 = reader.ReadEnumeratedBytes(primitiveTag);
             Assert.False(reader.HasData);
 
             Assert.Equal(bytes1.ByteArrayToHex(), bytes2.ByteArrayToHex());

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadGeneralizedTime.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadGeneralizedTime.cs
@@ -7,8 +7,35 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadGeneralizedTime
+    public sealed class ReadGeneralizedTimeAsnReaderTests : ReadGeneralizedTimeBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadGeneralizedTimeValueAsnReaderTests : ReadGeneralizedTimeBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadGeneralizedTimeBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
+
         [Theory]
         // yyyyMMddHH (2017090821)
         [InlineData(AsnEncodingRules.BER, "180A32303137303930383231", 2017, 9, 8, 21, 0, 0, 0, null, 0)]
@@ -66,7 +93,7 @@ namespace System.Formats.Asn1.Tests.Reader
         // yyyyMMddHHmmss.secondFracZ (20161106012345,7654Z)
         [InlineData(AsnEncodingRules.CER, "181432303136313130363031323334352E373635345A", 2016, 11, 6, 1, 23, 45, 765, 0, 0)]
         [InlineData(AsnEncodingRules.DER, "181432303136313130363031323334352E373635345A", 2016, 11, 6, 1, 23, 45, 765, 0, 0)]
-        public static void ParseTime_Valid(
+        public void ParseTime_Valid(
             AsnEncodingRules ruleSet,
             string inputHex,
             int year,
@@ -81,7 +108,7 @@ namespace System.Formats.Asn1.Tests.Reader
         {
             byte[] inputData = inputHex.HexToByteArray();
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             DateTimeOffset value = reader.ReadGeneralizedTime();
             Assert.False(reader.HasData, "reader.HasData");
 
@@ -189,17 +216,21 @@ namespace System.Formats.Asn1.Tests.Reader
               "040131" +
               "0405323334355A" +
               "0000")]
-        public static void ParseTime_BerOnly(string inputHex)
+        public void ParseTime_BerOnly(string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader cerReader = new AsnReader(inputData, AsnEncodingRules.CER);
-            AsnReader derReader = new AsnReader(inputData, AsnEncodingRules.DER);
+            AsnReaderWrapper cerReader = CreateWrapper(inputData, AsnEncodingRules.CER);
+            AsnReaderWrapper derReader = CreateWrapper(inputData, AsnEncodingRules.DER);
 
-            Assert.Throws<AsnContentException>(() => cerReader.ReadGeneralizedTime());
-            Assert.Throws<AsnContentException>(() => derReader.ReadGeneralizedTime());
+            Assert.Throws<AsnContentException>(
+                ref cerReader,
+                static (ref reader) => reader.ReadGeneralizedTime());
+            Assert.Throws<AsnContentException>(
+                ref derReader,
+                static (ref reader) => reader.ReadGeneralizedTime());
 
             // Prove it was not just corrupt input
-            AsnReader berReader = new AsnReader(inputData, AsnEncodingRules.BER);
+            AsnReaderWrapper berReader = CreateWrapper(inputData, AsnEncodingRules.BER);
             berReader.ReadGeneralizedTime();
             Assert.False(berReader.HasData, "berReader.HasData");
             Assert.True(cerReader.HasData, "cerReader.HasData");
@@ -212,7 +243,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "20171219000406.9999991Z")]
         [InlineData(AsnEncodingRules.CER, "20171219000406.9999991Z")]
         [InlineData(AsnEncodingRules.DER, "20171219000406.9999991Z")]
-        public static void MaximumEffectivePrecision(AsnEncodingRules ruleSet, string dateAscii)
+        public void MaximumEffectivePrecision(AsnEncodingRules ruleSet, string dateAscii)
         {
             DateTimeOffset expectedTime = new DateTimeOffset(2017, 12, 19, 0, 4, 6, TimeSpan.Zero);
             expectedTime += new TimeSpan(TimeSpan.TicksPerSecond - 9);
@@ -222,16 +253,16 @@ namespace System.Formats.Asn1.Tests.Reader
             inputData[1] = (byte)dateAscii.Length;
             Text.Encoding.ASCII.GetBytes(dateAscii, 0, dateAscii.Length, inputData, 2);
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             Assert.Equal(expectedTime, reader.ReadGeneralizedTime());
         }
 
         [Fact]
-        public static void ExcessivelyPreciseFraction()
+        public void ExcessivelyPreciseFraction()
         {
             byte[] inputData = "\u0018\u002A2017092118.012345678901234567890123456789Z"u8.ToArray();
 
-            AsnReader berReader = new AsnReader(inputData, AsnEncodingRules.BER);
+            AsnReaderWrapper berReader = CreateWrapper(inputData, AsnEncodingRules.BER);
             DateTimeOffset value = berReader.ReadGeneralizedTime();
             Assert.False(berReader.HasData, "berReader.HasData");
 
@@ -242,11 +273,11 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void ExcessivelyPreciseFraction_OneTenthPlusEpsilon()
+        public void ExcessivelyPreciseFraction_OneTenthPlusEpsilon()
         {
             byte[] inputData = "\u0018\u002A20170921180044.10000000000000000000000001Z"u8.ToArray();
 
-            AsnReader derReader = new AsnReader(inputData, AsnEncodingRules.DER);
+            AsnReaderWrapper derReader = CreateWrapper(inputData, AsnEncodingRules.DER);
             DateTimeOffset value = derReader.ReadGeneralizedTime();
             Assert.False(derReader.HasData, "derReader.HasData");
 
@@ -258,7 +289,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
-        public static void MultiSegmentExcessivelyPreciseFraction(AsnEncodingRules ruleSet)
+        public void MultiSegmentExcessivelyPreciseFraction(AsnEncodingRules ruleSet)
         {
             // This builds "20171207173522.0000...0001Z" where the Z required a second CER segment.
             // This is a bit of nonsense, really, because it is encoding 1e-985 seconds, which is
@@ -278,37 +309,43 @@ namespace System.Formats.Asn1.Tests.Reader
             byte[] cdr = { 0x04, 0x01, (byte)'Z', 0x00, 0x00 };
             byte[] inputData = header.Concat(contents0).Concat(cdr).ToArray();
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             DateTimeOffset value = reader.ReadGeneralizedTime(new Asn1Tag(TagClass.ContextSpecific, 0));
             DateTimeOffset expected = new DateTimeOffset(2017, 12, 7, 17, 35, 22, TimeSpan.Zero);
             Assert.Equal(expected, value);
         }
 
         [Fact]
-        public static void ExcessivelyPreciseFraction_OneTenthPlusEpsilonAndZero()
+        public void ExcessivelyPreciseFraction_OneTenthPlusEpsilonAndZero()
         {
             byte[] inputData = "\u0018\u002A20170921180044.10000000000000000000000010Z"u8.ToArray();
 
-            AsnReader berReader = new AsnReader(inputData, AsnEncodingRules.BER);
+            AsnReaderWrapper berReader = CreateWrapper(inputData, AsnEncodingRules.BER);
             DateTimeOffset value = berReader.ReadGeneralizedTime();
             Assert.False(berReader.HasData, "berReader.HasData");
 
             DateTimeOffset expected = new DateTimeOffset(2017, 9, 21, 18, 0, 44, 100, TimeSpan.Zero);
             Assert.Equal(expected, value);
 
-            AsnReader cerReader = new AsnReader(inputData, AsnEncodingRules.CER);
-            AsnReader derReader = new AsnReader(inputData, AsnEncodingRules.DER);
-            Assert.Throws<AsnContentException>(() => cerReader.ReadGeneralizedTime());
-            Assert.Throws<AsnContentException>(() => derReader.ReadGeneralizedTime());
+            AsnReaderWrapper cerReader = CreateWrapper(inputData, AsnEncodingRules.CER);
+            AsnReaderWrapper derReader = CreateWrapper(inputData, AsnEncodingRules.DER);
+            Assert.Throws<AsnContentException>(
+                ref cerReader,
+                static (ref reader) => reader.ReadGeneralizedTime());
+            Assert.Throws<AsnContentException>(
+                ref derReader,
+                static (ref reader) => reader.ReadGeneralizedTime());
         }
 
         [Fact]
-        public static void ExcessivelyPreciseNonFraction()
+        public void ExcessivelyPreciseNonFraction()
         {
             byte[] inputData = "\u0018\u002A2017092118.012345678901234567890123Q56789Z"u8.ToArray();
-            AsnReader berReader = new AsnReader(inputData, AsnEncodingRules.BER);
+            AsnReaderWrapper berReader = CreateWrapper(inputData, AsnEncodingRules.BER);
 
-            Assert.Throws<AsnContentException>(() => berReader.ReadGeneralizedTime());
+            Assert.Throws<AsnContentException>(
+                ref berReader,
+                static (ref reader) => reader.ReadGeneralizedTime());
         }
 
         [Theory]
@@ -376,32 +413,36 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("yyyyMMddHHmm.minuteFrac-HH:mm", "18183230313730393038323335382E30303030352D30313A3138")]
         [InlineData("yyyyMMddHHmmss,secondFrac-HH:mm", "181932303136313130363031323334352C393939392D30313A3138")]
         [InlineData("yyyyMMddHHmmss.secondFrac-HH:mm", "181932303136313130363031323334352E393939392D30313A3138")]
-        public static void GetGeneralizedTime_Throws(string description, string inputHex)
+        public void GetGeneralizedTime_Throws(string description, string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(inputData, AsnEncodingRules.BER);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadGeneralizedTime());
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadGeneralizedTime());
         }
 
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "180F32303136313130363031323334355A".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadGeneralizedTime(Asn1Tag.Null));
+                static (ref reader) => reader.ReadGeneralizedTime(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadGeneralizedTime(new Asn1Tag(TagClass.ContextSpecific, 0)));
+                ref reader,
+                static (ref reader) => reader.ReadGeneralizedTime(new Asn1Tag(TagClass.ContextSpecific, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
@@ -416,28 +457,33 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "850F32303136313130363031323334355A".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadGeneralizedTime(Asn1Tag.Null));
+                static (ref reader) => reader.ReadGeneralizedTime(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadUtcTime());
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadGeneralizedTime());
 
             Assert.True(reader.HasData, "HasData after default tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadGeneralizedTime(new Asn1Tag(TagClass.Application, 5)));
+                ref reader,
+                static (ref reader) => reader.ReadGeneralizedTime(new Asn1Tag(TagClass.Application, 5)));
 
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadGeneralizedTime(new Asn1Tag(TagClass.ContextSpecific, 7)));
+                ref reader,
+                static (ref reader) => reader.ReadGeneralizedTime(new Asn1Tag(TagClass.ContextSpecific, 7)));
 
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
@@ -455,20 +501,20 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "800F31393530303130323132333435365A", TagClass.ContextSpecific, 0)]
         [InlineData(AsnEncodingRules.CER, "4C0F31393530303130323132333435365A", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "DF8A460F31393530303130323132333435365A", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
             int tagValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             DateTimeOffset val1 = reader.ReadGeneralizedTime(new Asn1Tag(tagClass, tagValue, true));
 
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             DateTimeOffset val2 = reader.ReadGeneralizedTime(new Asn1Tag(tagClass, tagValue, false));
 

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadIA5String.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadIA5String.cs
@@ -38,6 +38,7 @@ namespace System.Formats.Asn1.Tests.Reader
             ReadOnlyMemory<byte> data,
             AsnEncodingRules ruleSet,
             AsnReaderOptions options = default);
+
         public static IEnumerable<object[]> ValidEncodingData { get; } =
             new object[][]
             {

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadIA5String.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadIA5String.cs
@@ -10,8 +10,34 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadIA5String
+    public sealed class ReadIA5StringAsnReaderTests : ReadIA5StringBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadIA5StringValueAsnReaderTests : ReadIA5StringBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadIA5StringBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
         public static IEnumerable<object[]> ValidEncodingData { get; } =
             new object[][]
             {
@@ -117,13 +143,13 @@ namespace System.Formats.Asn1.Tests.Reader
 
         [Theory]
         [MemberData(nameof(ValidEncodingData))]
-        public static void GetIA5String_Success(
+        public void GetIA5String_Success(
             AsnEncodingRules ruleSet,
             string inputHex,
             string expectedValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             string value = reader.ReadCharacterString(UniversalTagNumber.IA5String);
 
             Assert.Equal(expectedValue, value);
@@ -131,7 +157,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
         [Theory]
         [MemberData(nameof(ValidEncodingData))]
-        public static void TryCopyIA5String(
+        public void TryCopyIA5String(
             AsnEncodingRules ruleSet,
             string inputHex,
             string expectedValue)
@@ -139,7 +165,7 @@ namespace System.Formats.Asn1.Tests.Reader
             byte[] inputData = inputHex.HexToByteArray();
             char[] output = new char[expectedValue.Length];
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             bool copied;
             int charsWritten;
 
@@ -166,7 +192,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
         [Theory]
         [MemberData(nameof(ValidEncodingData))]
-        public static void TryCopyIA5StringBytes(
+        public void TryCopyIA5StringBytes(
             AsnEncodingRules ruleSet,
             string inputHex,
             string expectedString)
@@ -175,7 +201,7 @@ namespace System.Formats.Asn1.Tests.Reader
             string expectedHex = Text.Encoding.ASCII.GetBytes(expectedString).ByteArrayToHex();
             byte[] output = new byte[expectedHex.Length / 2];
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             bool copied;
             int bytesWritten;
 
@@ -207,15 +233,15 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "160120", true)]
         [InlineData(AsnEncodingRules.BER, "3680" + "040120" + "0000", false)]
         [InlineData(AsnEncodingRules.BER, "3603" + "040120", false)]
-        public static void TryGetIA5StringBytes(
+        public void TryGetIA5StringBytes(
             AsnEncodingRules ruleSet,
             string inputHex,
             bool expectSuccess)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            bool got = reader.TryGetIA5StringBytes(out ReadOnlyMemory<byte> contents);
+            bool got = reader.TryGetIA5StringBytes(out ReadOnlySpan<byte> contents);
 
             if (expectSuccess)
             {
@@ -223,7 +249,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
                 Assert.True(
                     Unsafe.AreSame(
-                        ref MemoryMarshal.GetReference(contents.Span),
+                        ref MemoryMarshal.GetReference(contents),
                         ref inputData[2]));
             }
             else
@@ -247,17 +273,18 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("Length Too Long", AsnEncodingRules.CER, "16034869")]
         [InlineData("Length Too Long", AsnEncodingRules.DER, "16034869")]
         [InlineData("Constructed Form", AsnEncodingRules.DER, "3603040149")]
-        public static void TryGetIA5StringBytes_Throws(
+        public void TryGetIA5StringBytes_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryGetIA5StringBytes(out ReadOnlyMemory<byte> contents));
+                ref reader,
+                static (ref reader) => reader.TryGetIA5StringBytes(out _));
         }
 
         [Theory]
@@ -303,7 +330,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("NonEmpty Null", AsnEncodingRules.BER, "3680000100")]
         [InlineData("NonEmpty Null", AsnEncodingRules.CER, "3680000100")]
         [InlineData("LongLength Null", AsnEncodingRules.BER, "3680008100")]
-        public static void TryCopyIA5StringBytes_Throws(
+        public void TryCopyIA5StringBytes_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
@@ -314,25 +341,27 @@ namespace System.Formats.Asn1.Tests.Reader
             outputData[0] = 252;
 
             int bytesWritten = -1;
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryCopyIA5StringBytes(outputData, out bytesWritten));
+                ref reader,
+                (ref reader) => reader.TryCopyIA5StringBytes(outputData, out bytesWritten));
 
             Assert.Equal(-1, bytesWritten);
             Assert.Equal(252, outputData[0]);
         }
 
-        private static void TryCopyIA5String_Throws_Helper(AsnEncodingRules ruleSet, byte[] inputData)
+        private void TryCopyIA5String_Throws_Helper(AsnEncodingRules ruleSet, byte[] inputData)
         {
             char[] outputData = new char[inputData.Length + 1];
             outputData[0] = 'a';
 
             int bytesWritten = -1;
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryCopyIA5String(outputData, out bytesWritten));
+                ref reader,
+                (ref reader) => reader.TryCopyIA5String(outputData, out bytesWritten));
 
             Assert.Equal(-1, bytesWritten);
             Assert.Equal('a', outputData[0]);
@@ -343,17 +372,18 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("Bad IA5 value", AsnEncodingRules.CER, "1602E280")]
         [InlineData("Bad IA5 value", AsnEncodingRules.DER, "1602E280")]
         [InlineData("Wrong Tag", AsnEncodingRules.BER, "04024869")]
-        public static void GetIA5String_Throws(
+        public void GetIA5String_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadCharacterString(UniversalTagNumber.IA5String));
+                ref reader,
+                static (ref reader) => reader.ReadCharacterString(UniversalTagNumber.IA5String));
         }
 
         [Theory]
@@ -400,7 +430,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("NonEmpty Null", AsnEncodingRules.CER, "3680000100")]
         [InlineData("LongLength Null", AsnEncodingRules.BER, "3680008100")]
         [InlineData("Bad IA5 value", AsnEncodingRules.BER, "1602E280")]
-        public static void TryCopyIA5String_Throws(
+        public void TryCopyIA5String_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
@@ -411,7 +441,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyIA5String_Throws_CER_NestedTooLong()
+        public void TryCopyIA5String_Throws_CER_NestedTooLong()
         {
             // CER says that the maximum encoding length for a IA5String primitive
             // is 1000.
@@ -440,7 +470,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyIA5String_Throws_CER_NestedTooShortIntermediate()
+        public void TryCopyIA5String_Throws_CER_NestedTooShortIntermediate()
         {
             // CER says that the maximum encoding length for a IA5String primitive
             // is 1000, and in the constructed form the lengths must be
@@ -478,7 +508,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyIA5StringBytes_Success_CER_MaxPrimitiveLength()
+        public void TryCopyIA5StringBytes_Success_CER_MaxPrimitiveLength()
         {
             // CER says that the maximum encoding length for a IA5String primitive
             // is 1000.
@@ -500,7 +530,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
             byte[] output = new byte[1000];
 
-            AsnReader reader = new AsnReader(input, AsnEncodingRules.CER);
+            AsnReaderWrapper reader = CreateWrapper(input, AsnEncodingRules.CER);
 
             bool success = reader.TryCopyIA5StringBytes(output,
                 out int bytesWritten);
@@ -514,7 +544,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyIA5StringBytes_Success_CER_MinConstructedLength()
+        public void TryCopyIA5StringBytes_Success_CER_MinConstructedLength()
         {
             // CER says that the maximum encoding length for a IA5String primitive
             // is 1000, and that a constructed form must be used for values greater
@@ -566,7 +596,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
             byte[] output = new byte[1001];
 
-            AsnReader reader = new AsnReader(input, AsnEncodingRules.CER);
+            AsnReaderWrapper reader = CreateWrapper(input, AsnEncodingRules.CER);
 
             bool success = reader.TryCopyIA5StringBytes(output,
                 out int bytesWritten);
@@ -583,23 +613,25 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 0x16, 2, (byte)'e', (byte)'l' };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.TryGetIA5StringBytes(Asn1Tag.Null, out _));
+                static (ref reader) => reader.TryGetIA5StringBytes(Asn1Tag.Null, out _));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryGetIA5StringBytes(new Asn1Tag(TagClass.ContextSpecific, 0), out _));
+                ref reader,
+                static (ref reader) => reader.TryGetIA5StringBytes(new Asn1Tag(TagClass.ContextSpecific, 0), out _));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
-            Assert.True(reader.TryGetIA5StringBytes(out ReadOnlyMemory<byte> value));
+            Assert.True(reader.TryGetIA5StringBytes(out ReadOnlySpan<byte> value));
             Assert.Equal("656C", value.ByteArrayToHex());
             Assert.False(reader.HasData, "HasData after read");
         }
@@ -608,35 +640,40 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 0x87, 2, (byte)'h', (byte)'i' };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.TryGetIA5StringBytes(Asn1Tag.Null, out _));
+                static (ref reader) => reader.TryGetIA5StringBytes(Asn1Tag.Null, out _));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.TryGetIA5StringBytes(out _));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.TryGetIA5StringBytes(out _));
 
             Assert.True(reader.HasData, "HasData after default tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryGetIA5StringBytes(new Asn1Tag(TagClass.Application, 0), out _));
+                ref reader,
+                static (ref reader) => reader.TryGetIA5StringBytes(new Asn1Tag(TagClass.Application, 0), out _));
 
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryGetIA5StringBytes(new Asn1Tag(TagClass.ContextSpecific, 1), out _));
+                ref reader,
+                static (ref reader) => reader.TryGetIA5StringBytes(new Asn1Tag(TagClass.ContextSpecific, 1), out _));
 
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
             Assert.True(
                 reader.TryGetIA5StringBytes(
                     new Asn1Tag(TagClass.ContextSpecific, 7),
-                    out ReadOnlyMemory<byte> value));
+                    out ReadOnlySpan<byte> value));
 
             Assert.Equal("6869", value.ByteArrayToHex());
             Assert.False(reader.HasData, "HasData after reading value");
@@ -649,7 +686,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "80023132", TagClass.ContextSpecific, 0)]
         [InlineData(AsnEncodingRules.CER, "4C023132", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "DF8A46023132", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
@@ -658,41 +695,41 @@ namespace System.Formats.Asn1.Tests.Reader
             byte[] inputData = inputHex.HexToByteArray();
             Asn1Tag correctCons = new Asn1Tag(tagClass, tagValue, true);
             Asn1Tag correctPrim = new Asn1Tag(tagClass, tagValue, false);
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.True(
                 reader.TryGetIA5StringBytes(
                     correctCons,
-                    out ReadOnlyMemory<byte> val1));
+                    out ReadOnlySpan<byte> val1));
 
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             Assert.True(
                 reader.TryGetIA5StringBytes(
                     correctPrim,
-                    out ReadOnlyMemory<byte> val2));
+                    out ReadOnlySpan<byte> val2));
 
             Assert.False(reader.HasData);
 
             Assert.Equal(val1.ByteArrayToHex(), val2.ByteArrayToHex());
 
 #if NET
-            string expected = Encoding.ASCII.GetString(val1.Span);
+            string expected = Encoding.ASCII.GetString(val1);
 #else
             string expected = Encoding.ASCII.GetString(val1.ToArray());
 #endif
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
             Assert.Equal(expected, reader.ReadCharacterString(UniversalTagNumber.IA5String, correctPrim));
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
             Assert.Equal(expected, reader.ReadCharacterString(UniversalTagNumber.IA5String, correctCons));
 
             char[] output = new char[28];
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             Assert.True(
                 reader.TryReadCharacterString(
@@ -703,7 +740,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
             Assert.Equal(expected, output.AsSpan(1, charsWritten).ToString());
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             Assert.True(
                 reader.TryReadCharacterString(
@@ -716,22 +753,23 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryReadCharacterStringBytes_WrongKind()
+        public void TryReadCharacterStringBytes_WrongKind()
         {
             byte[] inputData = "16026869".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(inputData, AsnEncodingRules.BER);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.TryReadCharacterStringBytes(Span<byte>.Empty, Asn1Tag.Boolean, out _));
+                static (ref reader) => reader.TryReadCharacterStringBytes(Span<byte>.Empty, Asn1Tag.Boolean, out _));
         }
     }
 
     internal static class ReaderIA5Extensions
     {
         public static bool TryGetIA5StringBytes(
-            this AsnReader reader,
-            out ReadOnlyMemory<byte> contents)
+            this ref AsnReaderWrapper reader,
+            out ReadOnlySpan<byte> contents)
         {
             return reader.TryReadPrimitiveCharacterStringBytes(
                 new Asn1Tag(UniversalTagNumber.IA5String),
@@ -739,9 +777,9 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         public static bool TryGetIA5StringBytes(
-            this AsnReader reader,
+            this ref AsnReaderWrapper reader,
             Asn1Tag expectedTag,
-            out ReadOnlyMemory<byte> contents)
+            out ReadOnlySpan<byte> contents)
         {
             return reader.TryReadPrimitiveCharacterStringBytes(
                 expectedTag,
@@ -749,7 +787,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         public static bool TryCopyIA5StringBytes(
-            this AsnReader reader,
+            this ref AsnReaderWrapper reader,
             Span<byte> destination,
             out int bytesWritten)
         {
@@ -760,7 +798,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         public static bool TryCopyIA5String(
-            this AsnReader reader,
+            this ref AsnReaderWrapper reader,
             Span<char> destination,
             out int charsWritten)
         {

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadInteger.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadInteger.cs
@@ -7,8 +7,35 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadInteger
+    public sealed class ReadIntegerAsnReaderTests : ReadIntegerBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadIntegerValueAsnReaderTests : ReadIntegerBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadIntegerBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
+
         [Theory]
         [InlineData("Constructed Encoding", AsnEncodingRules.BER, "2203020100")]
         [InlineData("Constructed Encoding-Indefinite", AsnEncodingRules.BER, "228002010000")]
@@ -25,16 +52,16 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("Redundant Leading 0xFF", AsnEncodingRules.BER, "0202FF80")]
         [InlineData("Redundant Leading 0xFF", AsnEncodingRules.CER, "0202FF80")]
         [InlineData("Redundant Leading 0xFF", AsnEncodingRules.DER, "0202FF80")]
-        public static void InvalidData(
+        public void InvalidData(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] data = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(data, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(data, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadIntegerBytes());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadIntegerBytes());
         }
 
         [Theory]
@@ -51,13 +78,13 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, "0203008ACE", 0x8ACE)]
         [InlineData(AsnEncodingRules.BER, "0203FACE01", unchecked((int)0xFFFA_CE01))]
         [InlineData(AsnEncodingRules.BER, "02820003FACE01", unchecked((int)0xFFFA_CE01))]
-        public static void ReadInt32_Success(
+        public void ReadInt32_Success(
             AsnEncodingRules ruleSet,
             string inputHex,
             int expectedValue)
         {
             byte[] data = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(data, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(data, ruleSet);
 
             bool didRead = reader.TryReadInt32(out int value);
 
@@ -69,12 +96,12 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "02050102030405")]
         [InlineData(AsnEncodingRules.CER, "02050102030405")]
         [InlineData(AsnEncodingRules.DER, "02050102030405")]
-        public static void ReadInt32_TooMuchData(
+        public void ReadInt32_TooMuchData(
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             byte[] data = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(data, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(data, ruleSet);
 
             bool didRead = reader.TryReadInt32(out int value);
 
@@ -92,13 +119,13 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.DER, "020475828180", 0x75828180)]
         [InlineData(AsnEncodingRules.DER, "02050083828180", 0x83828180)]
         [InlineData(AsnEncodingRules.BER, "02830000050083828180", 0x83828180)]
-        public static void ReadUInt32_Success(
+        public void ReadUInt32_Success(
             AsnEncodingRules ruleSet,
             string inputHex,
             uint expectedValue)
         {
             byte[] data = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(data, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(data, ruleSet);
 
             bool didRead = reader.TryReadUInt32(out uint value);
 
@@ -117,10 +144,10 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.DER, "0203800000")]
         [InlineData(AsnEncodingRules.DER, "020480000000")]
         [InlineData(AsnEncodingRules.DER, "02050100000000")]
-        public static void ReadUInt32_Failure(AsnEncodingRules ruleSet, string inputHex)
+        public void ReadUInt32_Failure(AsnEncodingRules ruleSet, string inputHex)
         {
             byte[] data = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(data, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(data, ruleSet);
 
             bool didRead = reader.TryReadUInt32(out uint value);
 
@@ -155,13 +182,13 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.DER, "02088685848382818012", unchecked((long)0x86858483_82818012))]
         [InlineData(AsnEncodingRules.DER, "02088000000000000000", long.MinValue)]
         [InlineData(AsnEncodingRules.BER, "028800000000000000088000000000000000", long.MinValue)]
-        public static void ReadInt64_Success(
+        public void ReadInt64_Success(
             AsnEncodingRules ruleSet,
             string inputHex,
             long expectedValue)
         {
             byte[] data = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(data, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(data, ruleSet);
 
             bool didRead = reader.TryReadInt64(out long value);
 
@@ -173,12 +200,12 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "0209010203040506070809")]
         [InlineData(AsnEncodingRules.CER, "0209010203040506070809")]
         [InlineData(AsnEncodingRules.DER, "0209010203040506070809")]
-        public static void ReadInt64_TooMuchData(
+        public void ReadInt64_TooMuchData(
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             byte[] data = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(data, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(data, ruleSet);
 
             bool didRead = reader.TryReadInt64(out long value);
 
@@ -204,13 +231,13 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.DER, "02087FFFFFFFFFFFFFFF", long.MaxValue)]
         [InlineData(AsnEncodingRules.DER, "0209008000000000000000", 0x80000000_00000000)]
         [InlineData(AsnEncodingRules.DER, "020900FFFFFFFFFFFFFFFF", ulong.MaxValue)]
-        public static void ReadUInt64_Success(
+        public void ReadUInt64_Success(
             AsnEncodingRules ruleSet,
             string inputHex,
             ulong expectedValue)
         {
             byte[] data = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(data, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(data, ruleSet);
 
             bool didRead = reader.TryReadUInt64(out ulong value);
 
@@ -233,10 +260,10 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.DER, "020780000000000000")]
         [InlineData(AsnEncodingRules.DER, "02088000000000000000")]
         [InlineData(AsnEncodingRules.DER, "0209010000000000000000")]
-        public static void ReadUInt64_Failure(AsnEncodingRules ruleSet, string inputHex)
+        public void ReadUInt64_Failure(AsnEncodingRules ruleSet, string inputHex)
         {
             byte[] data = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(data, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(data, ruleSet);
 
             bool didRead = reader.TryReadUInt64(out ulong value);
 
@@ -245,15 +272,15 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void ReadIntegerBytes()
+        public void ReadIntegerBytes()
         {
             const string Payload = "0102030405060708090A0B0C0D0E0F10";
 
             // INTEGER (payload) followed by INTEGER (0)
             byte[] data = ("0210" + Payload + "020100").HexToByteArray();
-            AsnReader reader = new AsnReader(data, AsnEncodingRules.DER);
+            AsnReaderWrapper reader = CreateWrapper(data, AsnEncodingRules.DER);
 
-            ReadOnlyMemory<byte> contents = reader.ReadIntegerBytes();
+            ReadOnlySpan<byte> contents = reader.ReadIntegerBytes();
             Assert.Equal(0x10, contents.Length);
             Assert.Equal(Payload, contents.ByteArrayToHex());
         }
@@ -262,7 +289,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void GetBigInteger(AsnEncodingRules ruleSet)
+        public void GetBigInteger(AsnEncodingRules ruleSet)
         {
             byte[] inputData = (
                 "0282010100A46861FA9D5DB763633BF5A64EF6E7C2C2367F48D2D46643A22DFC" +
@@ -287,7 +314,7 @@ namespace System.Formats.Asn1.Tests.Reader
                 "1367336140572971505716740825623220507359429297584634909330541150" +
                 "79473593821332264673455059897928082590541");
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             Assert.Equal(expected, reader.ReadInteger());
         }
 
@@ -295,7 +322,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void GetNegativeBigInteger(AsnEncodingRules ruleSet)
+        public void GetNegativeBigInteger(AsnEncodingRules ruleSet)
         {
             // This uses a length that doesn't line up with the array pool size so
             // the fill code gets tested on netstandard.
@@ -325,7 +352,7 @@ namespace System.Formats.Asn1.Tests.Reader
                 "6924486017215979427815833587119797658480104671279234402026468966" +
                 "86109928634475300812601680679147599027");
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             Assert.Equal(expected, reader.ReadInteger());
         }
 
@@ -333,7 +360,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void GetDiminutiveBigInteger(AsnEncodingRules ruleSet)
+        public void GetDiminutiveBigInteger(AsnEncodingRules ruleSet)
         {
             // GetBigInteger with the last byte removed.
             // Since it is no longer an ArrayPool alignment size the fill code gets tested on netstandard.
@@ -360,7 +387,7 @@ namespace System.Formats.Asn1.Tests.Reader
                 "1367336140572971505716740825623220507359429297584634909330541150" +
                 "79473593821332264673455059897928082590541") >> 8;
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             Assert.Equal(expected, reader.ReadInteger());
         }
 
@@ -368,22 +395,22 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 2, 1, 0x7E };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
-                "expectedTag",
-                () => reader.ReadIntegerBytes(Asn1Tag.Null));
+            Assert.Throws<ArgumentException>(
+                ref reader, "expectedTag", static (ref reader) => reader.ReadIntegerBytes(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadIntegerBytes(new Asn1Tag(TagClass.ContextSpecific, 0)));
+            Assert.Throws<AsnContentException>(
+                ref reader, static (ref reader) => reader.ReadIntegerBytes(new Asn1Tag(TagClass.ContextSpecific, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
-            ReadOnlyMemory<byte> value = reader.ReadIntegerBytes();
+            ReadOnlySpan<byte> value = reader.ReadIntegerBytes();
             Assert.Equal("7E", value.ByteArrayToHex());
             Assert.False(reader.HasData, "HasData after read");
         }
@@ -392,30 +419,31 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 0x87, 2, 0, 0x80 };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
-                "expectedTag",
-                () => reader.ReadIntegerBytes(Asn1Tag.Null));
+            Assert.Throws<ArgumentException>(
+                ref reader, "expectedTag", static (ref reader) => reader.ReadIntegerBytes(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadIntegerBytes());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadIntegerBytes());
 
             Assert.True(reader.HasData, "HasData after default tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadIntegerBytes(new Asn1Tag(TagClass.Application, 0)));
+            Assert.Throws<AsnContentException>(
+                ref reader, static (ref reader) => reader.ReadIntegerBytes(new Asn1Tag(TagClass.Application, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadIntegerBytes(new Asn1Tag(TagClass.ContextSpecific, 1)));
+            Assert.Throws<AsnContentException>(
+                ref reader, static (ref reader) => reader.ReadIntegerBytes(new Asn1Tag(TagClass.ContextSpecific, 1)));
 
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
-            ReadOnlyMemory<byte> value = reader.ReadIntegerBytes(new Asn1Tag(TagClass.ContextSpecific, 7));
+            ReadOnlySpan<byte> value = reader.ReadIntegerBytes(new Asn1Tag(TagClass.ContextSpecific, 7));
             Assert.Equal("0080", value.ByteArrayToHex());
             Assert.False(reader.HasData, "HasData after reading value");
         }
@@ -427,18 +455,18 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "8001FF", TagClass.ContextSpecific, 0)]
         [InlineData(AsnEncodingRules.CER, "4C01FF", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "DF8A4601FF", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
             int tagValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
-            ReadOnlyMemory<byte> val1 = reader.ReadIntegerBytes(new Asn1Tag(tagClass, tagValue, true));
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
+            ReadOnlySpan<byte> val1 = reader.ReadIntegerBytes(new Asn1Tag(tagClass, tagValue, true));
             Assert.False(reader.HasData);
-            reader = new AsnReader(inputData, ruleSet);
-            ReadOnlyMemory<byte> val2 = reader.ReadIntegerBytes(new Asn1Tag(tagClass, tagValue, false));
+            reader = CreateWrapper(inputData, ruleSet);
+            ReadOnlySpan<byte> val2 = reader.ReadIntegerBytes(new Asn1Tag(tagClass, tagValue, false));
             Assert.False(reader.HasData);
 
             Assert.Equal(val1.ByteArrayToHex(), val2.ByteArrayToHex());

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadNamedBitList.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadNamedBitList.cs
@@ -37,6 +37,7 @@ namespace System.Formats.Asn1.Tests.Reader
             ReadOnlyMemory<byte> data,
             AsnEncodingRules ruleSet,
             AsnReaderOptions options = default);
+
         [Flags]
         public enum X509KeyUsageCSharpStyle
         {

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadNamedBitList.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadNamedBitList.cs
@@ -515,7 +515,7 @@ namespace System.Formats.Asn1.Tests.Reader
             byte[] actual = new byte[allTheBytes.Length];
             bits.CopyTo(actual, 0);
 
-            Assert.Equal(actual, actual);
+            Assert.Equal(allTheBytes, actual);
         }
 
         [Theory]

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadNamedBitList.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadNamedBitList.cs
@@ -9,8 +9,34 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadNamedBitList
+    public sealed class ReadNamedBitListAsnReaderTests : ReadNamedBitListBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadNamedBitListValueAsnReaderTests : ReadNamedBitListBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadNamedBitListBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
         [Flags]
         public enum X509KeyUsageCSharpStyle
         {
@@ -161,7 +187,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.DER, typeof(LongFlags), (long)LongFlags.AllBits, "030900FFFFFFFFFFFFFFFF")]
         [InlineData(AsnEncodingRules.CER, typeof(LongFlags), (long)LongFlags.AllBits, "030900FFFFFFFFFFFFFFFF")]
         [InlineData(AsnEncodingRules.BER, typeof(LongFlags), (long)LongFlags.AllBits, "030900FFFFFFFFFFFFFFFF")]
-        public static void VerifyReadNamedBitListEncodings(
+        public void VerifyReadNamedBitListEncodings(
             AsnEncodingRules ruleSet,
             Type enumType,
             long enumValue,
@@ -169,7 +195,7 @@ namespace System.Formats.Asn1.Tests.Reader
         {
             byte[] inputBytes = inputHex.HexToByteArray();
 
-            AsnReader reader = new AsnReader(inputBytes, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputBytes, ruleSet);
             Enum readValue = reader.ReadNamedBitListValue(enumType);
 
             Assert.Equal(Enum.ToObject(enumType, enumValue), readValue);
@@ -191,7 +217,7 @@ namespace System.Formats.Asn1.Tests.Reader
             typeof(ULongFlags),
             (ulong)(ULongFlags.Min | ULongFlags.Max),
             "0309008000000000000001")]
-        public static void VerifyReadNamedBitListEncodings_ULong(
+        public void VerifyReadNamedBitListEncodings_ULong(
             AsnEncodingRules ruleSet,
             Type enumType,
             ulong enumValue,
@@ -199,7 +225,7 @@ namespace System.Formats.Asn1.Tests.Reader
         {
             byte[] inputBytes = inputHex.HexToByteArray();
 
-            AsnReader reader = new AsnReader(inputBytes, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputBytes, ruleSet);
             Enum readValue = reader.ReadNamedBitListValue(enumType);
 
             Assert.Equal(Enum.ToObject(enumType, enumValue), readValue);
@@ -209,10 +235,10 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void VerifyGenericReadNamedBitList(AsnEncodingRules ruleSet)
+        public void VerifyGenericReadNamedBitList(AsnEncodingRules ruleSet)
         {
             string inputHex = "0306078000000080" + "0309010000000080000002";
-            AsnReader reader = new AsnReader(inputHex.HexToByteArray(), ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputHex.HexToByteArray(), ruleSet);
 
             ULongFlags uLongFlags = reader.ReadNamedBitListValue<ULongFlags>();
             LongFlags longFlags = reader.ReadNamedBitListValue<LongFlags>();
@@ -226,14 +252,15 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadNamedBitList_RequiresTypeArg(AsnEncodingRules ruleSet)
+        public void ReadNamedBitList_RequiresTypeArg(AsnEncodingRules ruleSet)
         {
             string inputHex = "030100";
-            AsnReader reader = new AsnReader(inputHex.HexToByteArray(), ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputHex.HexToByteArray(), ruleSet);
 
-            AssertExtensions.Throws<ArgumentNullException>(
+            Assert.Throws<ArgumentNullException>(
+                ref reader,
                 "flagsEnumType",
-                () => reader.ReadNamedBitListValue(null!));
+                static (ref reader) => reader.ReadNamedBitListValue((Type)null!));
 
             Assert.True(reader.HasData, "reader.HasData");
         }
@@ -242,14 +269,15 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadNamedBitList_RequiresFlags(AsnEncodingRules ruleSet)
+        public void ReadNamedBitList_RequiresFlags(AsnEncodingRules ruleSet)
         {
             string inputHex = "030100";
-            AsnReader reader = new AsnReader(inputHex.HexToByteArray(), ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputHex.HexToByteArray(), ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "flagsEnumType",
-                () => reader.ReadNamedBitListValue<AsnEncodingRules>());
+                static (ref reader) => reader.ReadNamedBitListValue<AsnEncodingRules>());
 
             Assert.True(reader.HasData, "reader.HasData");
         }
@@ -258,14 +286,14 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadNamedBitList_DataOutOfRange(AsnEncodingRules ruleSet)
+        public void ReadNamedBitList_DataOutOfRange(AsnEncodingRules ruleSet)
         {
             string inputHex = "0309000000000100000001";
 
-            AsnReader reader = new AsnReader(inputHex.HexToByteArray(), ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputHex.HexToByteArray(), ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>());
+                ref reader, static (ref reader) => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>());
 
             Assert.True(reader.HasData, "reader.HasData");
         }
@@ -273,14 +301,14 @@ namespace System.Formats.Asn1.Tests.Reader
         [Theory]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadNamedBitList_ExcessiveBytes(AsnEncodingRules ruleSet)
+        public void ReadNamedBitList_ExcessiveBytes(AsnEncodingRules ruleSet)
         {
             string inputHex = "03050014800000";
 
-            AsnReader reader = new AsnReader(inputHex.HexToByteArray(), ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputHex.HexToByteArray(), ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>());
+                ref reader, static (ref reader) => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>());
 
             Assert.True(reader.HasData, "reader.HasData");
         }
@@ -288,14 +316,14 @@ namespace System.Formats.Asn1.Tests.Reader
         [Theory]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadNamedBitList_ExcessiveBits(AsnEncodingRules ruleSet)
+        public void ReadNamedBitList_ExcessiveBits(AsnEncodingRules ruleSet)
         {
             string inputHex = "0303061480";
 
-            AsnReader reader = new AsnReader(inputHex.HexToByteArray(), ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputHex.HexToByteArray(), ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>());
+                ref reader, static (ref reader) => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>());
 
             Assert.True(reader.HasData, "reader.HasData");
         }
@@ -304,19 +332,22 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 3, 2, 1, 2 };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>(Asn1Tag.Null));
+                static (ref reader) => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(
-                () => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>(new Asn1Tag(TagClass.ContextSpecific, 0)));
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) =>
+            {
+                reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>(new Asn1Tag(TagClass.ContextSpecific, 0));
+            });
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
@@ -330,29 +361,34 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 0x87, 2, 2, 4 };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>(Asn1Tag.Null));
+                static (ref reader) => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>());
+                ref reader, static (ref reader) => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>());
 
             Assert.True(reader.HasData, "HasData after default tag");
 
-            Assert.Throws<AsnContentException>(
-                () => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>(new Asn1Tag(TagClass.Application, 0)));
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) =>
+            {
+                reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>(new Asn1Tag(TagClass.Application, 0));
+            });
 
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
-            Assert.Throws<AsnContentException>(
-                () => reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>(new Asn1Tag(TagClass.ContextSpecific, 1)));
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) =>
+            {
+                reader.ReadNamedBitListValue<X509KeyUsageCSharpStyle>(new Asn1Tag(TagClass.ContextSpecific, 1));
+            });
 
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
@@ -370,14 +406,14 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "8003070080", TagClass.ContextSpecific, 0)]
         [InlineData(AsnEncodingRules.CER, "4C03070080", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "DF8A4603070080", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
             int tagValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Equal(
                 X509KeyUsageCSharpStyle.DecipherOnly,
@@ -386,7 +422,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Equal(
                 X509KeyUsageCSharpStyle.DecipherOnly,
@@ -400,13 +436,13 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadNamedBitList_BitArray(AsnEncodingRules ruleSet)
+        public void ReadNamedBitList_BitArray(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "440406400100".HexToByteArray();
             bool[] expected = new bool[18];
             expected[1] = expected[15] = true;
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             BitArray bits = reader.ReadNamedBitList(new Asn1Tag(TagClass.Application, 4));
             Assert.Equal(expected.Length, bits.Length);
@@ -422,10 +458,10 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadNamedBitList_BitArray_Empty(AsnEncodingRules ruleSet)
+        public void ReadNamedBitList_BitArray_Empty(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "030100".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             BitArray bits = reader.ReadNamedBitList();
             Assert.Equal(0, bits.Length);
@@ -436,7 +472,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadNamedBitList_BitArray_EveryPattern(AsnEncodingRules ruleSet)
+        public void ReadNamedBitList_BitArray_EveryPattern(AsnEncodingRules ruleSet)
         {
             const string InputHex =
                 // Tag
@@ -463,7 +499,7 @@ namespace System.Formats.Asn1.Tests.Reader
                 "078747C727A767E7179757D737B777F70F8F4FCF2FAF6FEF1F9F5FDF3FBF7FFF";
 
             byte[] inputData = InputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             byte[] allTheBytes = new byte[256];
 
@@ -486,7 +522,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadNamedBitList_BitArray_7992Bits(AsnEncodingRules ruleSet)
+        public void ReadNamedBitList_BitArray_7992Bits(AsnEncodingRules ruleSet)
         {
             string inputHex = "848203E80008" + new string('0', 1994) + "02";
             byte[] inputData = inputHex.HexToByteArray();
@@ -495,7 +531,7 @@ namespace System.Formats.Asn1.Tests.Reader
             expected.Set(4, true);
             expected.Set(7990, true);
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             BitArray actual = reader.ReadNamedBitList(new Asn1Tag(TagClass.ContextSpecific, 4));
             Assert.False(reader.HasData);
 
@@ -506,7 +542,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadNamedBitList_BitArray_7993Bits(AsnEncodingRules ruleSet)
+        public void ReadNamedBitList_BitArray_7993Bits(AsnEncodingRules ruleSet)
         {
             string inputHex;
 
@@ -520,7 +556,7 @@ namespace System.Formats.Asn1.Tests.Reader
             }
 
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             BitArray actual = reader.ReadNamedBitList(new Asn1Tag(TagClass.ContextSpecific, 5));
             Assert.False(reader.HasData);
 
@@ -535,7 +571,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void VerifyReadNamedBitList_KeyUsage_OneByte(AsnEncodingRules ruleSet)
+        public void VerifyReadNamedBitList_KeyUsage_OneByte(AsnEncodingRules ruleSet)
         {
             //     KeyUsage ::= BIT STRING {
             //       digitalSignature   (0),
@@ -556,7 +592,7 @@ namespace System.Formats.Asn1.Tests.Reader
             expected.Set(6, true);
             expected.Set(5, true);
 
-            AsnReader reader = new AsnReader(kuExt.RawData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(kuExt.RawData, ruleSet);
             BitArray actual = reader.ReadNamedBitList();
 
             Assert.Equal(expected.Cast<bool>(), actual.Cast<bool>());
@@ -567,7 +603,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void VerifyReadNamedBitList_KeyUsage_TwoByte(AsnEncodingRules ruleSet)
+        public void VerifyReadNamedBitList_KeyUsage_TwoByte(AsnEncodingRules ruleSet)
         {
             X509KeyUsageExtension kuExt = new X509KeyUsageExtension(
                 X509KeyUsageFlags.KeyAgreement | X509KeyUsageFlags.DecipherOnly,
@@ -577,7 +613,7 @@ namespace System.Formats.Asn1.Tests.Reader
             expected.Set(4, true);
             expected.Set(8, true);
 
-            AsnReader reader = new AsnReader(kuExt.RawData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(kuExt.RawData, ruleSet);
             BitArray actual = reader.ReadNamedBitList();
 
             Assert.Equal(expected.Cast<bool>(), actual.Cast<bool>());

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadNull.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadNull.cs
@@ -6,17 +6,44 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadNull
+    public sealed class ReadNullAsnReaderTests : ReadNullBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadNullValueAsnReaderTests : ReadNullBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadNullBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
+
         [Theory]
         [InlineData(AsnEncodingRules.BER, "0500")]
         [InlineData(AsnEncodingRules.CER, "0500")]
         [InlineData(AsnEncodingRules.DER, "0500")]
         [InlineData(AsnEncodingRules.BER, "0583000000")]
-        public static void ReadNull_Success(AsnEncodingRules ruleSet, string inputHex)
+        public void ReadNull_Success(AsnEncodingRules ruleSet, string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             reader.ReadNull();
             Assert.False(reader.HasData, "reader.HasData");
@@ -39,13 +66,15 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("NonEmpty", AsnEncodingRules.CER, "050100")]
         [InlineData("NonEmpty", AsnEncodingRules.DER, "050100")]
         [InlineData("Incomplete length", AsnEncodingRules.BER, "0581")]
-        public static void ReadNull_Throws(string description, AsnEncodingRules ruleSet, string inputHex)
+        public void ReadNull_Throws(string description, AsnEncodingRules ruleSet, string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadNull());
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadNull());
         }
 
 
@@ -53,18 +82,21 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 5, 0 };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadNull(new Asn1Tag(UniversalTagNumber.Integer)));
+                static (ref reader) => reader.ReadNull(new Asn1Tag(UniversalTagNumber.Integer)));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadNull(new Asn1Tag(TagClass.ContextSpecific, 0)));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadNull(new Asn1Tag(TagClass.ContextSpecific, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
@@ -76,26 +108,33 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 0x87, 0 };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadNull(new Asn1Tag(UniversalTagNumber.Integer)));
+                static (ref reader) => reader.ReadNull(new Asn1Tag(UniversalTagNumber.Integer)));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadNull());
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadNull());
 
             Assert.True(reader.HasData, "HasData after default tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadNull(new Asn1Tag(TagClass.Application, 0)));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadNull(new Asn1Tag(TagClass.Application, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadNull(new Asn1Tag(TagClass.ContextSpecific, 1)));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadNull(new Asn1Tag(TagClass.ContextSpecific, 1)));
 
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
@@ -110,18 +149,18 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "8000", TagClass.ContextSpecific, 0)]
         [InlineData(AsnEncodingRules.CER, "4C00", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "DF8A4600", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
             int tagValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             reader.ReadNull(new Asn1Tag(tagClass, tagValue, true));
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
             reader.ReadNull(new Asn1Tag(tagClass, tagValue, false));
             Assert.False(reader.HasData);
         }

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadObjectIdentifier.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadObjectIdentifier.cs
@@ -7,8 +7,35 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadObjectIdentifier
+    public sealed class ReadObjectIdentifierAsnReaderTests : ReadObjectIdentifierBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadObjectIdentifierValueAsnReaderTests : ReadObjectIdentifierBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadObjectIdentifierBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
+
         [Theory]
         [InlineData("Wrong tag", AsnEncodingRules.BER, "010100")]
         [InlineData("Wrong tag", AsnEncodingRules.CER, "010100")]
@@ -31,16 +58,18 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("Sub-Identifier with leading 0x80", AsnEncodingRules.BER, "060488378001")]
         [InlineData("Sub-Identifier with leading 0x80", AsnEncodingRules.CER, "060488378001")]
         [InlineData("Sub-Identifier with leading 0x80", AsnEncodingRules.DER, "060488378001")]
-        public static void ReadObjectIdentifier_Throws(
+        public void ReadObjectIdentifier_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadObjectIdentifier());
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadObjectIdentifier());
         }
 
         [Theory]
@@ -59,13 +88,13 @@ namespace System.Formats.Asn1.Tests.Reader
             // this is
             // { joint-iso-itu-t(2) uuid(255) thatuuid(329800735698586629295641978511506172918) three(3) }
             "2.255.329800735698586629295641978511506172918.3")]
-        public static void ReadObjectIdentifier_Success(
+        public void ReadObjectIdentifier_Success(
             AsnEncodingRules ruleSet,
             string inputHex,
             string expectedValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             string oidValue = reader.ReadObjectIdentifier();
             Assert.Equal(expectedValue, oidValue);
@@ -96,10 +125,10 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("060383F01D", "2.63437")]
         [InlineData("06028370", "2.416")]
         [InlineData("060103", "0.3")]
-        public static void VerifyMultiByteParsing(string inputHex, string expectedValue)
+        public void VerifyMultiByteParsing(string inputHex, string expectedValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, AsnEncodingRules.DER);
+            AsnReaderWrapper reader = CreateWrapper(inputData, AsnEncodingRules.DER);
 
             string oidValue = reader.ReadObjectIdentifier();
             Assert.Equal(expectedValue, oidValue);
@@ -109,19 +138,21 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "06028837".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadIntegerBytes(Asn1Tag.Null));
+                static (ref reader) => reader.ReadObjectIdentifier(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadObjectIdentifier(new Asn1Tag(TagClass.ContextSpecific, 0)));
+                ref reader,
+                static (ref reader) => reader.ReadObjectIdentifier(new Asn1Tag(TagClass.ContextSpecific, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
@@ -133,28 +164,33 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "87028837".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadIntegerBytes(Asn1Tag.Null));
+                static (ref reader) => reader.ReadObjectIdentifier(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadObjectIdentifier());
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadObjectIdentifier());
 
             Assert.True(reader.HasData, "HasData after default tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadObjectIdentifier(new Asn1Tag(TagClass.Application, 0)));
+                ref reader,
+                static (ref reader) => reader.ReadObjectIdentifier(new Asn1Tag(TagClass.Application, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadObjectIdentifier(new Asn1Tag(TagClass.ContextSpecific, 1)));
+                ref reader,
+                static (ref reader) => reader.ReadObjectIdentifier(new Asn1Tag(TagClass.ContextSpecific, 1)));
 
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
@@ -172,7 +208,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "80028837", TagClass.ContextSpecific, 0)]
         [InlineData(AsnEncodingRules.CER, "4C028837", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "DF8A46028837", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
@@ -181,19 +217,22 @@ namespace System.Formats.Asn1.Tests.Reader
             byte[] inputData = inputHex.HexToByteArray();
             Asn1Tag constructedTag = new Asn1Tag(tagClass, tagValue, true);
             Asn1Tag primitiveTag = new Asn1Tag(tagClass, tagValue, false);
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             string val1 = reader.ReadObjectIdentifier(constructedTag);
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             string val2 = reader.ReadObjectIdentifier(primitiveTag);
             Assert.False(reader.HasData);
 
             Assert.Equal(val1, val2);
         }
+    }
 
+    public static class ReadObjectIdentifierDecoderTests
+    {
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadOctetString.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadOctetString.cs
@@ -8,24 +8,51 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadOctetString
+    public sealed class ReadOctetStringAsnReaderTests : ReadOctetStringBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadOctetStringValueAsnReaderTests : ReadOctetStringBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadOctetStringBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
+
         [Theory]
         [InlineData("Constructed Payload", AsnEncodingRules.BER, "2402040100")]
         [InlineData("Constructed Payload-Indefinite", AsnEncodingRules.BER, "248004010000")]
         // This value is actually invalid CER, but it returns false since it's not primitive and
         // it isn't worth preempting the descent to find out it was invalid.
         [InlineData("Constructed Payload-Indefinite", AsnEncodingRules.CER, "248004010000")]
-        public static void TryReadPrimitiveOctetStringBytes_Fails(
+        public void TryReadPrimitiveOctetStringBytes_Fails(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            bool didRead = reader.TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> contents);
+            bool didRead = reader.TryReadPrimitiveOctetString(out ReadOnlySpan<byte> contents);
 
             Assert.False(didRead, "reader.TryReadOctetStringBytes");
             Assert.Equal(0, contents.Length);
@@ -38,15 +65,15 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, 5, "040502FEEFF00C")]
         [InlineData(AsnEncodingRules.DER, 2, "04020780")]
         [InlineData(AsnEncodingRules.DER, 5, "040500FEEFF00D" + "0500")]
-        public static void TryReadPrimitiveOctetStringBytes_Success(
+        public void TryReadPrimitiveOctetStringBytes_Success(
             AsnEncodingRules ruleSet,
             int expectedLength,
             string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            bool didRead = reader.TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> contents);
+            bool didRead = reader.TryReadPrimitiveOctetString(out ReadOnlySpan<byte> contents);
 
             Assert.True(didRead, "reader.TryReadOctetStringBytes");
             Assert.Equal(expectedLength, contents.Length);
@@ -60,21 +87,22 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("Bad Length", AsnEncodingRules.CER, "040200")]
         [InlineData("Bad Length", AsnEncodingRules.DER, "040200")]
         [InlineData("Constructed Form", AsnEncodingRules.DER, "2403040100")]
-        public static void TryReadPrimitiveOctetStringBytes_Throws(
+        public void TryReadPrimitiveOctetStringBytes_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> contents));
+                ref reader,
+                static (ref reader) => reader.TryReadPrimitiveOctetString(out _));
         }
 
         [Fact]
-        public static void TryReadPrimitiveOctetStringBytes_Throws_CER_TooLong()
+        public void TryReadPrimitiveOctetStringBytes_Throws_CER_TooLong()
         {
             // CER says that the maximum encoding length for an OctetString primitive
             // is 1000.
@@ -88,19 +116,21 @@ namespace System.Formats.Asn1.Tests.Reader
             input[2] = 0x03;
             input[3] = 0xE9;
 
-            AsnReader reader = new AsnReader(input, AsnEncodingRules.CER);
+            AsnReaderWrapper reader = CreateWrapper(input, AsnEncodingRules.CER);
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> contents));
+                ref reader,
+                static (ref reader) => reader.TryReadPrimitiveOctetString(out _));
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadOctetString(new byte[input.Length], out _));
+                ref reader,
+                (ref reader) => reader.TryReadOctetString(new byte[input.Length], out _));
 
-            Assert.Throws<AsnContentException>(() => reader.ReadOctetString());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadOctetString());
         }
 
         [Fact]
-        public static void TryReadPrimitiveOctetStringBytes_Success_CER_MaxLength()
+        public void TryReadPrimitiveOctetStringBytes_Success_CER_MaxLength()
         {
             // CER says that the maximum encoding length for an OctetString primitive
             // is 1000.
@@ -120,9 +150,9 @@ namespace System.Formats.Asn1.Tests.Reader
             input[1002] = 0xA5;
             input[1003] = 0xFC;
 
-            AsnReader reader = new AsnReader(input, AsnEncodingRules.CER);
+            AsnReaderWrapper reader = CreateWrapper(input, AsnEncodingRules.CER);
 
-            bool success = reader.TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> contents);
+            bool success = reader.TryReadPrimitiveOctetString(out ReadOnlySpan<byte> contents);
 
             Assert.True(success, "reader.TryReadOctetStringBytes");
             Assert.Equal(1000, contents.Length);
@@ -130,7 +160,7 @@ namespace System.Formats.Asn1.Tests.Reader
             // Check that it is, in fact, the same memory. No copies with this API.
             Assert.True(
                 Unsafe.AreSame(
-                    ref MemoryMarshal.GetReference(contents.Span),
+                    ref MemoryMarshal.GetReference(contents),
                     ref input[4]));
         }
 
@@ -146,10 +176,10 @@ namespace System.Formats.Asn1.Tests.Reader
                 "0000" +
               "04020000" +
               "0000")]
-        public static void TryReadOctetStringBytes_Fails(AsnEncodingRules ruleSet, string inputHex)
+        public void TryReadOctetStringBytes_Fails(AsnEncodingRules ruleSet, string inputHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             bool didRead = reader.TryReadOctetString(
                 Span<byte>.Empty,
@@ -195,14 +225,14 @@ namespace System.Formats.Asn1.Tests.Reader
                 "0000" +
               "0000",
             "FACEF00D000100020303FF")]
-        public static void TryReadOctetStringBytes_Success(
+        public void TryReadOctetStringBytes_Success(
             AsnEncodingRules ruleSet,
             string inputHex,
             string expectedHex)
         {
             byte[] inputData = inputHex.HexToByteArray();
             byte[] output = new byte[expectedHex.Length / 2];
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             bool didRead = reader.TryReadOctetString(
                 output,
@@ -211,19 +241,20 @@ namespace System.Formats.Asn1.Tests.Reader
             Assert.True(didRead, "reader.TryReadOctetString");
             Assert.Equal(expectedHex, output.AsSpan(0, bytesWritten).ByteArrayToHex());
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
             byte[] output2 = reader.ReadOctetString();
             Assert.Equal(output, output2);
         }
 
-        private static void TryReadOctetStringBytes_Throws_Helper(
+        private void TryReadOctetStringBytes_Throws_Helper(
             AsnEncodingRules ruleSet,
             byte[] input)
         {
-            AsnReader reader = new AsnReader(input, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(input, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () =>
+                ref reader,
+                static (ref reader) =>
                 {
                     reader.TryReadOctetString(
                         Span<byte>.Empty,
@@ -231,17 +262,15 @@ namespace System.Formats.Asn1.Tests.Reader
                 });
         }
 
-        private static void ReadOctetStringBytes_Throws_Helper(
+        private void ReadOctetStringBytes_Throws_Helper(
             AsnEncodingRules ruleSet,
             byte[] input)
         {
-            AsnReader reader = new AsnReader(input, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(input, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () =>
-                {
-                    reader.ReadOctetString();
-                });
+                ref reader,
+                static (ref reader) => reader.ReadOctetString());
         }
 
         [Theory]
@@ -273,7 +302,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("NonEmpty Null", AsnEncodingRules.CER, "2480000100")]
         [InlineData("LongLength Null", AsnEncodingRules.BER, "2480008100")]
         [InlineData("Constructed Payload-TooShort", AsnEncodingRules.CER, "24800401000000")]
-        public static void TryReadOctetStringBytes_Throws(
+        public void TryReadOctetStringBytes_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
@@ -285,7 +314,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyOctetStringBytes_Throws_CER_NestedTooLong()
+        public void TryCopyOctetStringBytes_Throws_CER_NestedTooLong()
         {
             // CER says that the maximum encoding length for an OctetString primitive
             // is 1000.
@@ -315,7 +344,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyOctetStringBytes_Throws_CER_NestedTooShortIntermediate()
+        public void TryCopyOctetStringBytes_Throws_CER_NestedTooShortIntermediate()
         {
             // CER says that the maximum encoding length for an OctetString primitive
             // is 1000, and in the constructed form the lengths must be
@@ -354,7 +383,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyOctetStringBytes_Success_CER_MaxPrimitiveLength()
+        public void TryCopyOctetStringBytes_Success_CER_MaxPrimitiveLength()
         {
             // CER says that the maximum encoding length for an OctetString primitive
             // is 1000.
@@ -376,7 +405,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
             byte[] output = new byte[1000];
 
-            AsnReader reader = new AsnReader(input, AsnEncodingRules.CER);
+            AsnReaderWrapper reader = CreateWrapper(input, AsnEncodingRules.CER);
 
             bool success = reader.TryReadOctetString(
                 output,
@@ -389,13 +418,13 @@ namespace System.Formats.Asn1.Tests.Reader
                 input.AsSpan(4).ByteArrayToHex(),
                 output.ByteArrayToHex());
 
-            reader = new AsnReader(input, AsnEncodingRules.CER);
+            reader = CreateWrapper(input, AsnEncodingRules.CER);
             byte[] output2 = reader.ReadOctetString();
             Assert.Equal(output, output2);
         }
 
         [Fact]
-        public static void TryCopyOctetStringBytes_Success_CER_MinConstructedLength()
+        public void TryCopyOctetStringBytes_Success_CER_MinConstructedLength()
         {
             // CER says that the maximum encoding length for an OctetString primitive
             // is 1000, and that a constructed form must be used for values greater
@@ -447,7 +476,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
             byte[] output = new byte[1001];
 
-            AsnReader reader = new AsnReader(input, AsnEncodingRules.CER);
+            AsnReaderWrapper reader = CreateWrapper(input, AsnEncodingRules.CER);
 
             bool success = reader.TryReadOctetString(
                 output,
@@ -460,7 +489,7 @@ namespace System.Formats.Asn1.Tests.Reader
                 expected.ByteArrayToHex(),
                 output.ByteArrayToHex());
 
-            reader = new AsnReader(input, AsnEncodingRules.CER);
+            reader = CreateWrapper(input, AsnEncodingRules.CER);
             byte[] output2 = reader.ReadOctetString();
             Assert.Equal(output, output2);
         }
@@ -469,23 +498,25 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 4, 1, 0x7E };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.TryReadPrimitiveOctetString(out _, Asn1Tag.Null));
+                static (ref reader) => reader.TryReadPrimitiveOctetString(out _, Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadPrimitiveOctetString(out _, new Asn1Tag(TagClass.ContextSpecific, 0)));
+                ref reader,
+                static (ref reader) => reader.TryReadPrimitiveOctetString(out _, new Asn1Tag(TagClass.ContextSpecific, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
-            Assert.True(reader.TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> value));
+            Assert.True(reader.TryReadPrimitiveOctetString(out ReadOnlySpan<byte> value));
             Assert.Equal("7E", value.ByteArrayToHex());
             Assert.False(reader.HasData, "HasData after read");
         }
@@ -494,54 +525,66 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 0x87, 2, 0, 0x80 };
             byte[] output = new byte[inputData.Length];
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Asn1Tag wrongTag1 = new Asn1Tag(TagClass.Application, 0);
             Asn1Tag wrongTag2 = new Asn1Tag(TagClass.ContextSpecific, 1);
             Asn1Tag correctTag = new Asn1Tag(TagClass.ContextSpecific, 7);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.TryReadPrimitiveOctetString(out _, Asn1Tag.Null));
-            AssertExtensions.Throws<ArgumentException>(
+                static (ref reader) => reader.TryReadPrimitiveOctetString(out _, Asn1Tag.Null));
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.TryReadOctetString(output, out _, Asn1Tag.Null));
-            AssertExtensions.Throws<ArgumentException>(
+                (ref reader) => reader.TryReadOctetString(output, out _, Asn1Tag.Null));
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadOctetString(Asn1Tag.Null));
+                static (ref reader) => reader.ReadOctetString(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.TryReadPrimitiveOctetString(out _));
-            Assert.Throws<AsnContentException>(() => reader.TryReadOctetString(output, out _));
-            Assert.Throws<AsnContentException>(() => reader.ReadOctetString());
+            Assert.Throws<AsnContentException>(
+                ref reader, static (ref reader) => reader.TryReadPrimitiveOctetString(out _));
+            Assert.Throws<AsnContentException>(
+                ref reader, (ref reader) => reader.TryReadOctetString(output, out _));
+            Assert.Throws<AsnContentException>(
+                ref reader, static (ref reader) => reader.ReadOctetString());
             Assert.True(reader.HasData, "HasData after default tag");
 
-            Assert.Throws<AsnContentException>(() => reader.TryReadPrimitiveOctetString(out _, wrongTag1));
-            Assert.Throws<AsnContentException>(() => reader.TryReadOctetString(output, out _, wrongTag1));
-            Assert.Throws<AsnContentException>(() => reader.ReadOctetString(wrongTag1));
+            Assert.Throws<AsnContentException>(
+                ref reader, (ref reader) => reader.TryReadPrimitiveOctetString(out _, wrongTag1));
+            Assert.Throws<AsnContentException>(
+                ref reader, (ref reader) => reader.TryReadOctetString(output, out _, wrongTag1));
+            Assert.Throws<AsnContentException>(
+                ref reader, (ref reader) => reader.ReadOctetString(wrongTag1));
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
-            Assert.Throws<AsnContentException>(() => reader.TryReadPrimitiveOctetString(out _, wrongTag2));
-            Assert.Throws<AsnContentException>(() => reader.TryReadOctetString(output, out _, wrongTag2));
-            Assert.Throws<AsnContentException>(() => reader.ReadOctetString(wrongTag2));
+            Assert.Throws<AsnContentException>(
+                ref reader, (ref reader) => reader.TryReadPrimitiveOctetString(out _, wrongTag2));
+            Assert.Throws<AsnContentException>(
+                ref reader, (ref reader) => reader.TryReadOctetString(output, out _, wrongTag2));
+            Assert.Throws<AsnContentException>(
+                ref reader, (ref reader) => reader.ReadOctetString(wrongTag2));
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
-            Assert.True(reader.TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> value, correctTag));
+            Assert.True(reader.TryReadPrimitiveOctetString(out ReadOnlySpan<byte> value, correctTag));
             Assert.Equal("0080", value.ByteArrayToHex());
             Assert.False(reader.HasData, "HasData after reading value");
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             Assert.True(reader.TryReadOctetString(output.AsSpan(1), out int written, correctTag));
             Assert.Equal("0080", output.AsSpan(1, written).ByteArrayToHex());
             Assert.False(reader.HasData, "HasData after reading value");
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             byte[] output2 = reader.ReadOctetString(correctTag);
             Assert.Equal("0080", output2.ByteArrayToHex());
@@ -555,27 +598,27 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "8001FF", TagClass.ContextSpecific, 0)]
         [InlineData(AsnEncodingRules.CER, "4C01FF", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "DF8A4601FF", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
             int tagValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.True(
                 reader.TryReadPrimitiveOctetString(
-                    out ReadOnlyMemory<byte> val1,
+                    out ReadOnlySpan<byte> val1,
                     new Asn1Tag(tagClass, tagValue, true)));
 
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             Assert.True(
                 reader.TryReadPrimitiveOctetString(
-                    out ReadOnlyMemory<byte> val2,
+                    out ReadOnlySpan<byte> val2,
                     new Asn1Tag(tagClass, tagValue, false)));
 
             Assert.False(reader.HasData);
@@ -584,7 +627,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyOctetStringBytes_ExtremelyNested()
+        public void TryCopyOctetStringBytes_ExtremelyNested()
         {
             byte[] dataBytes = new byte[4 * 16384];
 
@@ -604,14 +647,14 @@ namespace System.Formats.Asn1.Tests.Reader
                 dataBytes[i + 1] = 0x80;
             }
 
-            AsnReader reader = new AsnReader(dataBytes, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(dataBytes, AsnEncodingRules.BER);
 
             int bytesWritten;
 
             Assert.True(reader.TryReadOctetString(Span<byte>.Empty, out bytesWritten));
             Assert.Equal(0, bytesWritten);
 
-            reader = new AsnReader(dataBytes, AsnEncodingRules.BER);
+            reader = CreateWrapper(dataBytes, AsnEncodingRules.BER);
             byte[] output2 = reader.ReadOctetString();
 
             // It's Same (ReferenceEqual) on .NET Core, but just Equal on .NET Framework

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadSequence.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadSequence.cs
@@ -6,8 +6,35 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadSequence
+    public sealed class ReadSequenceAsnReaderTests : ReadSequenceBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadSequenceValueAsnReaderTests : ReadSequenceBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadSequenceBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
+
         [Theory]
         [InlineData(AsnEncodingRules.BER, "3000", false, -1)]
         [InlineData(AsnEncodingRules.BER, "30800000", false, -1)]
@@ -19,7 +46,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, "3080" + "0500" + "0000", false, 5)]
         [InlineData(AsnEncodingRules.CER, "3080" + "010100" + "0000" + "0500", true, 1)]
         [InlineData(AsnEncodingRules.DER, "3005" + "0500" + "0101FF", false, 5)]
-        public static void ReadSequence_Success(
+        public void ReadSequence_Success(
             AsnEncodingRules ruleSet,
             string inputHex,
             bool expectDataRemaining,
@@ -27,8 +54,8 @@ namespace System.Formats.Asn1.Tests.Reader
         {
             byte[] inputData = inputHex.HexToByteArray();
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
-            AsnReader sequence = reader.ReadSequence();
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
+            AsnReaderWrapper sequence = reader.ReadSequence();
 
             if (expectDataRemaining)
             {
@@ -81,32 +108,36 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("Wrong Tag - Definite", AsnEncodingRules.DER, "3100")]
         [InlineData("Wrong Tag - Indefinite", AsnEncodingRules.BER, "3180" + "0000")]
         [InlineData("Wrong Tag - Indefinite", AsnEncodingRules.CER, "3180" + "0000")]
-        public static void ReadSequence_Throws(
+        public void ReadSequence_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadSequence());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadSequence());
         }
 
-        private static void ReadEcPublicKey(AsnEncodingRules ruleSet, byte[] inputData)
+        private void ReadEcPublicKey(AsnEncodingRules ruleSet, byte[] inputData)
         {
-            AsnReader mainReader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper mainReader = CreateWrapper(inputData, ruleSet);
 
-            AsnReader spkiReader = mainReader.ReadSequence();
+            AsnReaderWrapper spkiReader = mainReader.ReadSequence();
             Assert.False(mainReader.HasData, "mainReader.HasData after reading SPKI");
 
-            AsnReader algorithmReader = spkiReader.ReadSequence();
+            AsnReaderWrapper algorithmReader = spkiReader.ReadSequence();
             Assert.True(spkiReader.HasData, "spkiReader.HasData after reading algorithm");
 
-            ReadOnlyMemory<byte> publicKeyValue;
+            string publicKeyHex = string.Empty;
             int unusedBitCount;
 
-            if (!spkiReader.TryReadPrimitiveBitString(out unusedBitCount, out publicKeyValue))
+            if (spkiReader.TryReadPrimitiveBitString(out unusedBitCount, out ReadOnlySpan<byte> publicKeyValue))
+            {
+                publicKeyHex = publicKeyValue.ByteArrayToHex();
+            }
+            else
             {
                 // The correct answer is 65 bytes.
                 for (int i = 10; ; i *= 2)
@@ -115,7 +146,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
                     if (spkiReader.TryReadBitString(buf, out unusedBitCount, out int bytesWritten))
                     {
-                        publicKeyValue = new ReadOnlyMemory<byte>(buf, 0, bytesWritten);
+                        publicKeyHex = buf.AsSpan(0, bytesWritten).ByteArrayToHex();
                         break;
                     }
                 }
@@ -139,14 +170,14 @@ namespace System.Formats.Asn1.Tests.Reader
                 "2363DD131DA65E899A2E63E9E05E50C830D4994662FFE883DB2B9A767DCCABA2" +
                 "F07081B5711BE1DEE90DFC8DE17970C2D937A16CD34581F52B8D59C9E9532D13";
 
-            Assert.Equal(PublicKeyValue, publicKeyValue.ByteArrayToHex());
+            Assert.Equal(PublicKeyValue, publicKeyHex);
             Assert.Equal(0, unusedBitCount);
         }
 
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadEcPublicKey_DefiniteLength(AsnEncodingRules ruleSet)
+        public void ReadEcPublicKey_DefiniteLength(AsnEncodingRules ruleSet)
         {
             const string InputHex =
                 "3059" +
@@ -166,7 +197,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
-        public static void ReadEcPublicKey_IndefiniteLength(AsnEncodingRules ruleSet)
+        public void ReadEcPublicKey_IndefiniteLength(AsnEncodingRules ruleSet)
         {
             const string InputHex =
                 "3080" +
@@ -188,23 +219,25 @@ namespace System.Formats.Asn1.Tests.Reader
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal_Definite(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal_Definite(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "30020500".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadSequence(Asn1Tag.Null));
+                static (ref reader) => reader.ReadSequence(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0)));
+                ref reader,
+                static (ref reader) => reader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
-            AsnReader seq = reader.ReadSequence();
+            AsnReaderWrapper seq = reader.ReadSequence();
             Assert.Equal("0500", seq.ReadEncodedValue().ByteArrayToHex());
 
             Assert.False(reader.HasData, "HasData after read");
@@ -213,23 +246,25 @@ namespace System.Formats.Asn1.Tests.Reader
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
-        public static void TagMustBeCorrect_Universal_Indefinite(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal_Indefinite(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "308005000000".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadSequence(Asn1Tag.Null));
+                static (ref reader) => reader.ReadSequence(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0)));
+                ref reader,
+                static (ref reader) => reader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
-            AsnReader seq = reader.ReadSequence();
+            AsnReaderWrapper seq = reader.ReadSequence();
             Assert.Equal("0500", seq.ReadEncodedValue().ByteArrayToHex());
 
             Assert.False(reader.HasData, "HasData after read");
@@ -238,32 +273,35 @@ namespace System.Formats.Asn1.Tests.Reader
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom_Definite(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom_Definite(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "A5020500".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadSequence(Asn1Tag.Null));
+                static (ref reader) => reader.ReadSequence(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadSequence());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadSequence());
 
             Assert.True(reader.HasData, "HasData after default tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadSequence(new Asn1Tag(TagClass.Application, 5)));
+                ref reader,
+                static (ref reader) => reader.ReadSequence(new Asn1Tag(TagClass.Application, 5)));
 
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 7)));
+                ref reader,
+                static (ref reader) => reader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 7)));
 
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
-            AsnReader seq = reader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 5));
+            AsnReaderWrapper seq = reader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 5));
             Assert.Equal("0500", seq.ReadEncodedValue().ByteArrayToHex());
 
             Assert.False(reader.HasData, "HasData after reading value");
@@ -272,32 +310,35 @@ namespace System.Formats.Asn1.Tests.Reader
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
-        public static void TagMustBeCorrect_Custom_Indefinite(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom_Indefinite(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "A58005000000".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadSequence(Asn1Tag.Null));
+                static (ref reader) => reader.ReadSequence(Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadSequence());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadSequence());
 
             Assert.True(reader.HasData, "HasData after default tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadSequence(new Asn1Tag(TagClass.Application, 5)));
+                ref reader,
+                static (ref reader) => reader.ReadSequence(new Asn1Tag(TagClass.Application, 5)));
 
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 7)));
+                ref reader,
+                static (ref reader) => reader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 7)));
 
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
-            AsnReader seq = reader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 5));
+            AsnReaderWrapper seq = reader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 5));
             Assert.Equal("0500", seq.ReadEncodedValue().ByteArrayToHex());
 
             Assert.False(reader.HasData, "HasData after reading value");
@@ -312,22 +353,22 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "A1800101000000", TagClass.ContextSpecific, 1)]
         [InlineData(AsnEncodingRules.CER, "6C800101000000", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "FF8A46030101FF", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
             int tagValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AsnReader val1 = reader.ReadSequence(new Asn1Tag(tagClass, tagValue, true));
+            AsnReaderWrapper val1 = reader.ReadSequence(new Asn1Tag(tagClass, tagValue, true));
 
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
-            AsnReader val2 = reader.ReadSequence(new Asn1Tag(tagClass, tagValue, false));
+            AsnReaderWrapper val2 = reader.ReadSequence(new Asn1Tag(tagClass, tagValue, false));
 
             Assert.False(reader.HasData);
 
@@ -338,7 +379,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadSequenceOf_PreservesOptions(AsnEncodingRules ruleSet)
+        public void ReadSequenceOf_PreservesOptions(AsnEncodingRules ruleSet)
         {
             // [5] (UtcTime) 500102123456Z
             // UtcTime 120102235959Z
@@ -368,21 +409,21 @@ namespace System.Formats.Asn1.Tests.Reader
                 UtcTimeTwoDigitYearMax = 2011,
             };
 
-            AsnReader initial = new AsnReader(inputData, ruleSet, options);
-            AsnReader outer = initial.ReadSequence();
+            AsnReaderWrapper initial = CreateWrapper(inputData, ruleSet, options);
+            AsnReaderWrapper outer = initial.ReadSequence();
             Assert.False(initial.HasData);
-            AsnReader inner = outer.ReadSequence(new Asn1Tag(TagClass.Private, 9));
+            AsnReaderWrapper inner = outer.ReadSequence(new Asn1Tag(TagClass.Private, 9));
             Assert.False(outer.HasData);
 
             Asn1Tag setTag = new Asn1Tag(TagClass.ContextSpecific, 2);
 
             if (ruleSet != AsnEncodingRules.BER)
             {
-                Assert.Throws<AsnContentException>(() => inner.ReadSetOf(false, setTag));
+                Assert.Throws<AsnContentException>(ref inner, (ref reader) => reader.ReadSetOf(false, setTag));
             }
 
             // This confirms that we've passed SkipSetOrderVerification this far.
-            AsnReader setOf = inner.ReadSetOf(setTag);
+            AsnReaderWrapper setOf = inner.ReadSetOf(setTag);
             Assert.True(inner.HasData);
 
             Assert.Equal(
@@ -406,6 +447,10 @@ namespace System.Formats.Asn1.Tests.Reader
             initial.ThrowIfNotEmpty();
         }
 
+    }
+
+    public sealed class ReadSequenceDecoderTests
+    {
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadSetOf.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadSetOf.cs
@@ -6,8 +6,35 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadSetOf
+    public sealed class ReadSetOfAsnReaderTests : ReadSetOfBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadSetOfValueAsnReaderTests : ReadSetOfBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadSetOfBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
+
         [Theory]
         [InlineData(AsnEncodingRules.BER, "3100", false, -1)]
         [InlineData(AsnEncodingRules.BER, "31800000", false, -1)]
@@ -20,7 +47,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.CER, "3180" + "010100" + "0000" + "0500", true, 1)]
         [InlineData(AsnEncodingRules.CER, "3180" + "010100" + "0101FF" + "0500" + "0000", false, 1)]
         [InlineData(AsnEncodingRules.DER, "3105" + "0101FF" + "0500", false, 1)]
-        public static void ReadSetOf_Success(
+        public void ReadSetOf_Success(
             AsnEncodingRules ruleSet,
             string inputHex,
             bool expectDataRemaining,
@@ -28,8 +55,8 @@ namespace System.Formats.Asn1.Tests.Reader
         {
             byte[] inputData = inputHex.HexToByteArray();
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
-            AsnReader sequence = reader.ReadSetOf();
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
+            AsnReaderWrapper sequence = reader.ReadSetOf();
 
             if (expectDataRemaining)
             {
@@ -82,16 +109,16 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("Wrong Tag - Definite", AsnEncodingRules.DER, "3000")]
         [InlineData("Wrong Tag - Indefinite", AsnEncodingRules.BER, "3080" + "0000")]
         [InlineData("Wrong Tag - Indefinite", AsnEncodingRules.CER, "3080" + "0000")]
-        public static void ReadSetOf_Throws(
+        public void ReadSetOf_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadSetOf());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadSetOf());
         }
 
         [Theory]
@@ -113,7 +140,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.DER, "3105" + "010100" + "0500", true, 5)]
         [InlineData(AsnEncodingRules.DER, "3108" + "010100" + "0101FF" + "0500", true, 5)]
         [InlineData(AsnEncodingRules.DER, "3108" + "010100" + "010100" + "0500", true, 5)]
-        public static void ReadSetOf_DataSorting(
+        public void ReadSetOf_DataSorting(
             AsnEncodingRules ruleSet,
             string inputHex,
             bool expectSuccess,
@@ -121,10 +148,10 @@ namespace System.Formats.Asn1.Tests.Reader
         {
             byte[] inputData = inputHex.HexToByteArray();
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
-            AsnReader setOf;
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
+            AsnReaderWrapper setOf;
 
-            AsnReader laxReader = new AsnReader(
+            AsnReaderWrapper laxReader = CreateWrapper(
                 inputData,
                 ruleSet,
                 new AsnReaderOptions { SkipSetSortOrderVerification = true });
@@ -135,9 +162,9 @@ namespace System.Formats.Asn1.Tests.Reader
             }
             else
             {
-                AsnReader alsoReader = new AsnReader(inputData, ruleSet);
-                Assert.Throws<AsnContentException>(() => alsoReader.ReadSetOf());
-                Assert.Throws<AsnContentException>(() => laxReader.ReadSetOf(false));
+                AsnReaderWrapper alsoReader = CreateWrapper(inputData, ruleSet);
+                Assert.Throws<AsnContentException>(ref alsoReader, static (ref reader) => reader.ReadSetOf());
+                Assert.Throws<AsnContentException>(ref laxReader, static (ref reader) => reader.ReadSetOf(false));
 
                 setOf = reader.ReadSetOf(skipSortOrderValidation: true);
             }
@@ -173,23 +200,22 @@ namespace System.Formats.Asn1.Tests.Reader
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal_Definite(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal_Definite(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "31020500".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
-                "expectedTag",
-                () => reader.ReadSetOf(expectedTag: Asn1Tag.Null));
+            Assert.Throws<ArgumentException>(
+                ref reader, "expectedTag", static (ref reader) => reader.ReadSetOf(expectedTag: Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 0)));
+                ref reader, static (ref reader) => reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
-            AsnReader seq = reader.ReadSetOf();
+            AsnReaderWrapper seq = reader.ReadSetOf();
             Assert.Equal("0500", seq.ReadEncodedValue().ByteArrayToHex());
 
             Assert.False(reader.HasData, "HasData after read");
@@ -198,23 +224,22 @@ namespace System.Formats.Asn1.Tests.Reader
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
-        public static void TagMustBeCorrect_Universal_Indefinite(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal_Indefinite(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "318005000000".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
-                "expectedTag",
-                () => reader.ReadSetOf(expectedTag: Asn1Tag.Null));
+            Assert.Throws<ArgumentException>(
+                ref reader, "expectedTag", static (ref reader) => reader.ReadSetOf(expectedTag: Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 0)));
+                ref reader, static (ref reader) => reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
-            AsnReader seq = reader.ReadSetOf();
+            AsnReaderWrapper seq = reader.ReadSetOf();
             Assert.Equal("0500", seq.ReadEncodedValue().ByteArrayToHex());
 
             Assert.False(reader.HasData, "HasData after read");
@@ -223,32 +248,31 @@ namespace System.Formats.Asn1.Tests.Reader
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom_Definite(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom_Definite(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "A5020500".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
-                "expectedTag",
-                () => reader.ReadSetOf(expectedTag: Asn1Tag.Null));
+            Assert.Throws<ArgumentException>(
+                ref reader, "expectedTag", static (ref reader) => reader.ReadSetOf(expectedTag: Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadSetOf());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadSetOf());
 
             Assert.True(reader.HasData, "HasData after default tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.Application, 5)));
+                ref reader, static (ref reader) => reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.Application, 5)));
 
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 7)));
+                ref reader, static (ref reader) => reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 7)));
 
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
-            AsnReader seq = reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 5));
+            AsnReaderWrapper seq = reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 5));
             Assert.Equal("0500", seq.ReadEncodedValue().ByteArrayToHex());
 
             Assert.False(reader.HasData, "HasData after reading value");
@@ -257,32 +281,31 @@ namespace System.Formats.Asn1.Tests.Reader
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
-        public static void TagMustBeCorrect_Custom_Indefinite(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom_Indefinite(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "A58005000000".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
-                "expectedTag",
-                () => reader.ReadSetOf(expectedTag: Asn1Tag.Null));
+            Assert.Throws<ArgumentException>(
+                ref reader, "expectedTag", static (ref reader) => reader.ReadSetOf(expectedTag: Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadSetOf());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ReadSetOf());
 
             Assert.True(reader.HasData, "HasData after default tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.Application, 5)));
+                ref reader, static (ref reader) => reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.Application, 5)));
 
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 7)));
+                ref reader, static (ref reader) => reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 7)));
 
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
-            AsnReader seq = reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 5));
+            AsnReaderWrapper seq = reader.ReadSetOf(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 5));
             Assert.Equal("0500", seq.ReadEncodedValue().ByteArrayToHex());
 
             Assert.False(reader.HasData, "HasData after reading value");
@@ -297,21 +320,21 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "A1800101000000", TagClass.ContextSpecific, 1)]
         [InlineData(AsnEncodingRules.CER, "6C800101000000", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "FF8A46030101FF", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
             int tagValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AsnReader val1 = reader.ReadSetOf(expectedTag: new Asn1Tag(tagClass, tagValue, true));
+            AsnReaderWrapper val1 = reader.ReadSetOf(expectedTag: new Asn1Tag(tagClass, tagValue, true));
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
-            AsnReader val2 = reader.ReadSetOf(expectedTag: new Asn1Tag(tagClass, tagValue, false));
+            AsnReaderWrapper val2 = reader.ReadSetOf(expectedTag: new Asn1Tag(tagClass, tagValue, false));
             Assert.False(reader.HasData);
 
             Assert.Equal(val1.ReadEncodedValue().ByteArrayToHex(), val2.ReadEncodedValue().ByteArrayToHex());
@@ -321,7 +344,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void ReadSetOf_PreservesOptions(AsnEncodingRules ruleSet)
+        public void ReadSetOf_PreservesOptions(AsnEncodingRules ruleSet)
         {
             // [5] (UtcTime) 500102123456Z
             // UtcTime 120102235959Z
@@ -350,25 +373,25 @@ namespace System.Formats.Asn1.Tests.Reader
                 UtcTimeTwoDigitYearMax = 2011,
             };
 
-            AsnReader initial = new AsnReader(inputData, ruleSet, options);
+            AsnReaderWrapper initial = CreateWrapper(inputData, ruleSet, options);
 
             if (ruleSet != AsnEncodingRules.BER)
             {
-                Assert.Throws<AsnContentException>(() => initial.ReadSetOf(false));
+                Assert.Throws<AsnContentException>(ref initial, static (ref reader) => reader.ReadSetOf(false));
             }
 
-            AsnReader outer = initial.ReadSetOf();
+            AsnReaderWrapper outer = initial.ReadSetOf();
             Assert.False(initial.HasData);
 
             Asn1Tag innerTag = new Asn1Tag(TagClass.ContextSpecific, 2);
 
             if (ruleSet != AsnEncodingRules.BER)
             {
-                Assert.Throws<AsnContentException>(() => outer.ReadSetOf(false, innerTag));
+                Assert.Throws<AsnContentException>(ref outer, (ref reader) => reader.ReadSetOf(false, innerTag));
             }
 
             // This confirms that we've passed SkipSetOrderVerification this far.
-            AsnReader inner = outer.ReadSetOf(innerTag);
+            AsnReaderWrapper inner = outer.ReadSetOf(innerTag);
             Assert.True(outer.HasData);
 
             Assert.Equal(
@@ -390,7 +413,10 @@ namespace System.Formats.Asn1.Tests.Reader
             outer.ThrowIfNotEmpty();
             initial.ThrowIfNotEmpty();
         }
+    }
 
+    public sealed class ReadSetOfDecoderTests
+    {
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadT61String.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadT61String.cs
@@ -7,8 +7,35 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadT61String
+    public sealed class ReadT61StringAsnReaderTests : ReadT61StringBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadT61StringValueAsnReaderTests : ReadT61StringBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadT61StringBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
+
         public static IEnumerable<object[]> ValidEncodingData { get; } =
             new object[][]
             {
@@ -63,13 +90,13 @@ namespace System.Formats.Asn1.Tests.Reader
 
         [Theory]
         [MemberData(nameof(ValidEncodingData))]
-        public static void GetT61String_Success(
+        public void GetT61String_Success(
             AsnEncodingRules ruleSet,
             string inputHex,
             string expectedValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             string value = reader.ReadCharacterString(UniversalTagNumber.T61String);
 
             Assert.Equal(expectedValue, value);
@@ -77,7 +104,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
         [Theory]
         [MemberData(nameof(ValidEncodingData))]
-        public static void TryCopyT61String(
+        public void TryCopyT61String(
             AsnEncodingRules ruleSet,
             string inputHex,
             string expectedValue)
@@ -85,7 +112,7 @@ namespace System.Formats.Asn1.Tests.Reader
             byte[] inputData = inputHex.HexToByteArray();
             char[] output = new char[expectedValue.Length];
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             bool copied;
             int charsWritten;
 

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadUTF8String.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadUTF8String.cs
@@ -9,8 +9,34 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadUTF8String
+    public sealed class ReadUTF8StringAsnReaderTests : ReadUTF8StringBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadUTF8StringValueAsnReaderTests : ReadUTF8StringBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadUTF8StringBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
         public static IEnumerable<object[]> ValidEncodingData { get; } =
             new object[][]
             {
@@ -120,13 +146,13 @@ namespace System.Formats.Asn1.Tests.Reader
 
         [Theory]
         [MemberData(nameof(ValidEncodingData))]
-        public static void GetUTF8String_Success(
+        public void GetUTF8String_Success(
             AsnEncodingRules ruleSet,
             string inputHex,
             string expectedValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             string value = reader.ReadCharacterString(UniversalTagNumber.UTF8String);
 
             Assert.Equal(expectedValue, value);
@@ -134,7 +160,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
         [Theory]
         [MemberData(nameof(ValidEncodingData))]
-        public static void TryCopyUTF8String(
+        public void TryCopyUTF8String(
             AsnEncodingRules ruleSet,
             string inputHex,
             string expectedValue)
@@ -142,7 +168,7 @@ namespace System.Formats.Asn1.Tests.Reader
             byte[] inputData = inputHex.HexToByteArray();
             char[] output = new char[expectedValue.Length];
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             bool copied;
             int charsWritten;
 
@@ -170,7 +196,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
         [Theory]
         [MemberData(nameof(ValidEncodingData))]
-        public static void TryCopyUTF8StringBytes(
+        public void TryCopyUTF8StringBytes(
             AsnEncodingRules ruleSet,
             string inputHex,
             string expectedString)
@@ -179,7 +205,7 @@ namespace System.Formats.Asn1.Tests.Reader
             string expectedHex = Text.Encoding.UTF8.GetBytes(expectedString).ByteArrayToHex();
             byte[] output = new byte[expectedHex.Length / 2];
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             bool copied;
             int bytesWritten;
 
@@ -215,17 +241,17 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "0C0120", true)]
         [InlineData(AsnEncodingRules.BER, "2C80" + "040120" + "0000", false)]
         [InlineData(AsnEncodingRules.BER, "2C03" + "040120", false)]
-        public static void TryGetUTF8StringBytes(
+        public void TryGetUTF8StringBytes(
             AsnEncodingRules ruleSet,
             string inputHex,
             bool expectSuccess)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             bool got = reader.TryReadPrimitiveCharacterStringBytes(
                 new Asn1Tag(UniversalTagNumber.UTF8String),
-                out ReadOnlyMemory<byte> contents);
+                out ReadOnlySpan<byte> contents);
 
             if (expectSuccess)
             {
@@ -233,7 +259,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
                 Assert.True(
                     Unsafe.AreSame(
-                        ref MemoryMarshal.GetReference(contents.Span),
+                        ref MemoryMarshal.GetReference(contents),
                         ref inputData[2]));
             }
             else
@@ -257,17 +283,18 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("Length Too Long", AsnEncodingRules.CER, "0C034869")]
         [InlineData("Length Too Long", AsnEncodingRules.DER, "0C034869")]
         [InlineData("Constructed Form", AsnEncodingRules.DER, "2C03040149")]
-        public static void TryGetUTF8StringBytes_Throws(
+        public void TryGetUTF8StringBytes_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadPrimitiveCharacterStringBytes(new Asn1Tag(UniversalTagNumber.UTF8String), out _));
+                ref reader,
+                static (ref reader) => reader.TryReadPrimitiveCharacterStringBytes(new Asn1Tag(UniversalTagNumber.UTF8String), out _));
         }
 
         [Theory]
@@ -313,7 +340,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("NonEmpty Null", AsnEncodingRules.BER, "2C80000100")]
         [InlineData("NonEmpty Null", AsnEncodingRules.CER, "2C80000100")]
         [InlineData("LongLength Null", AsnEncodingRules.BER, "2C80008100")]
-        public static void TryCopyUTF8StringBytes_Throws(
+        public void TryCopyUTF8StringBytes_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
@@ -324,10 +351,11 @@ namespace System.Formats.Asn1.Tests.Reader
             outputData[0] = 252;
 
             int bytesWritten = -1;
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadCharacterStringBytes(
+                ref reader,
+                (ref reader) => reader.TryReadCharacterStringBytes(
                     outputData,
                     new Asn1Tag(UniversalTagNumber.UTF8String),
                     out bytesWritten));
@@ -336,16 +364,17 @@ namespace System.Formats.Asn1.Tests.Reader
             Assert.Equal(252, outputData[0]);
         }
 
-        private static void TryCopyUTF8String_Throws_Helper(AsnEncodingRules ruleSet, byte[] inputData)
+        private void TryCopyUTF8String_Throws_Helper(AsnEncodingRules ruleSet, byte[] inputData)
         {
             char[] outputData = new char[inputData.Length + 1];
             outputData[0] = 'a';
 
             int bytesWritten = -1;
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadCharacterString(outputData, UniversalTagNumber.UTF8String, out bytesWritten));
+                ref reader,
+                (ref reader) => reader.TryReadCharacterString(outputData, UniversalTagNumber.UTF8String, out bytesWritten));
 
             Assert.Equal(-1, bytesWritten);
             Assert.Equal('a', outputData[0]);
@@ -356,17 +385,18 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("Bad UTF8 value", AsnEncodingRules.CER, "0C02E280")]
         [InlineData("Bad UTF8 value", AsnEncodingRules.DER, "0C02E280")]
         [InlineData("Wrong Tag", AsnEncodingRules.BER, "04024869")]
-        public static void GetUTF8String_Throws(
+        public void GetUTF8String_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadCharacterString(UniversalTagNumber.UTF8String));
+                ref reader,
+                static (ref reader) => reader.ReadCharacterString(UniversalTagNumber.UTF8String));
         }
 
         [Theory]
@@ -413,7 +443,7 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("NonEmpty Null", AsnEncodingRules.CER, "2C80000100")]
         [InlineData("LongLength Null", AsnEncodingRules.BER, "2C80008100")]
         [InlineData("Bad UTF8 value", AsnEncodingRules.BER, "0C02E280")]
-        public static void TryCopyUTF8String_Throws(
+        public void TryCopyUTF8String_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
@@ -424,7 +454,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyUTF8String_Throws_CER_NestedTooLong()
+        public void TryCopyUTF8String_Throws_CER_NestedTooLong()
         {
             // CER says that the maximum encoding length for a UTF8String primitive
             // is 1000.
@@ -453,7 +483,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyUTF8String_Throws_CER_NestedTooShortIntermediate()
+        public void TryCopyUTF8String_Throws_CER_NestedTooShortIntermediate()
         {
             // CER says that the maximum encoding length for a UTF8String primitive
             // is 1000, and in the constructed form the lengths must be
@@ -491,7 +521,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyUTF8StringBytes_Success_CER_MaxPrimitiveLength()
+        public void TryCopyUTF8StringBytes_Success_CER_MaxPrimitiveLength()
         {
             // CER says that the maximum encoding length for a UTF8String primitive
             // is 1000.
@@ -513,7 +543,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
             byte[] output = new byte[1000];
 
-            AsnReader reader = new AsnReader(input, AsnEncodingRules.CER);
+            AsnReaderWrapper reader = CreateWrapper(input, AsnEncodingRules.CER);
 
             bool success = reader.TryReadCharacterStringBytes(
                 output,
@@ -529,7 +559,7 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void TryCopyUTF8StringBytes_Success_CER_MinConstructedLength()
+        public void TryCopyUTF8StringBytes_Success_CER_MinConstructedLength()
         {
             // CER says that the maximum encoding length for a UTF8String primitive
             // is 1000, and that a constructed form must be used for values greater
@@ -581,7 +611,7 @@ namespace System.Formats.Asn1.Tests.Reader
 
             byte[] output = new byte[1001];
 
-            AsnReader reader = new AsnReader(input, AsnEncodingRules.CER);
+            AsnReaderWrapper reader = CreateWrapper(input, AsnEncodingRules.CER);
 
             bool success = reader.TryReadCharacterStringBytes(
                 output,
@@ -600,24 +630,26 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 0x0C, 2, (byte)'e', (byte)'l' };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             const UniversalTagNumber EncodingType = UniversalTagNumber.UTF8String;
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.TryReadPrimitiveCharacterStringBytes(Asn1Tag.Null, out _));
+                static (ref reader) => reader.TryReadPrimitiveCharacterStringBytes(Asn1Tag.Null, out _));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadPrimitiveCharacterStringBytes(new Asn1Tag(TagClass.ContextSpecific, 0), out _));
+                ref reader,
+                static (ref reader) => reader.TryReadPrimitiveCharacterStringBytes(new Asn1Tag(TagClass.ContextSpecific, 0), out _));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
-            Assert.True(reader.TryReadPrimitiveCharacterStringBytes(new Asn1Tag(EncodingType), out ReadOnlyMemory<byte> value));
+            Assert.True(reader.TryReadPrimitiveCharacterStringBytes(new Asn1Tag(EncodingType), out ReadOnlySpan<byte> value));
             Assert.Equal("656C", value.ByteArrayToHex());
             Assert.False(reader.HasData, "HasData after read");
         }
@@ -626,38 +658,42 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
         {
             byte[] inputData = { 0x87, 2, (byte)'h', (byte)'i' };
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             const UniversalTagNumber EncodingType = UniversalTagNumber.UTF8String;
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.TryReadPrimitiveCharacterStringBytes(Asn1Tag.Null, out _));
+                static (ref reader) => reader.TryReadPrimitiveCharacterStringBytes(Asn1Tag.Null, out _));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadPrimitiveCharacterStringBytes(new Asn1Tag(EncodingType), out _));
+                ref reader,
+                static (ref reader) => reader.TryReadPrimitiveCharacterStringBytes(new Asn1Tag(EncodingType), out _));
 
             Assert.True(reader.HasData, "HasData after default tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadPrimitiveCharacterStringBytes(new Asn1Tag(TagClass.Application, 0), out _));
+                ref reader,
+                static (ref reader) => reader.TryReadPrimitiveCharacterStringBytes(new Asn1Tag(TagClass.Application, 0), out _));
 
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
             Assert.Throws<AsnContentException>(
-                () => reader.TryReadPrimitiveCharacterStringBytes(new Asn1Tag(TagClass.ContextSpecific, 1), out _));
+                ref reader,
+                static (ref reader) => reader.TryReadPrimitiveCharacterStringBytes(new Asn1Tag(TagClass.ContextSpecific, 1), out _));
 
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
             Assert.True(
                 reader.TryReadPrimitiveCharacterStringBytes(
                     new Asn1Tag(TagClass.ContextSpecific, 7),
-                    out ReadOnlyMemory<byte> value));
+                    out ReadOnlySpan<byte> value));
 
             Assert.Equal("6869", value.ByteArrayToHex());
             Assert.False(reader.HasData, "HasData after reading value");
@@ -670,28 +706,28 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "80023132", TagClass.ContextSpecific, 0)]
         [InlineData(AsnEncodingRules.CER, "4C023132", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "DF8A46023132", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
             int tagValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
             Assert.True(
                 reader.TryReadPrimitiveCharacterStringBytes(
                     new Asn1Tag(tagClass, tagValue, true),
-                    out ReadOnlyMemory<byte> val1));
+                    out ReadOnlySpan<byte> val1));
 
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             Assert.True(
                 reader.TryReadPrimitiveCharacterStringBytes(
                     new Asn1Tag(tagClass, tagValue, false),
-                    out ReadOnlyMemory<byte> val2));
+                    out ReadOnlySpan<byte> val2));
 
             Assert.False(reader.HasData);
 

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadUTF8String.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadUTF8String.cs
@@ -37,6 +37,7 @@ namespace System.Formats.Asn1.Tests.Reader
             ReadOnlyMemory<byte> data,
             AsnEncodingRules ruleSet,
             AsnReaderOptions options = default);
+
         public static IEnumerable<object[]> ValidEncodingData { get; } =
             new object[][]
             {

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReadUtcTime.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReadUtcTime.cs
@@ -6,8 +6,35 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public sealed class ReadUtcTime
+    public sealed class ReadUtcTimeAsnReaderTests : ReadUtcTimeBase
     {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReadUtcTimeValueAsnReaderTests : ReadUtcTimeBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReadUtcTimeBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
+
         [Theory]
         // A, B2, C2
         [InlineData(AsnEncodingRules.BER, "17113137303930383130333530332D30373030", 2017, 9, 8, 10, 35, 3, -7, 0)]
@@ -36,7 +63,7 @@ namespace System.Formats.Asn1.Tests.Reader
               "04830000015A" +
               "0000",
             2012, 1, 2, 23, 59, 0, 0, 0)]
-        public static void ParseTime_Valid(
+        public void ParseTime_Valid(
             AsnEncodingRules ruleSet,
             string inputHex,
             int year,
@@ -50,7 +77,7 @@ namespace System.Formats.Asn1.Tests.Reader
         {
             byte[] inputData = inputHex.HexToByteArray();
 
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
             DateTimeOffset value = reader.ReadUtcTime();
 
             Assert.Equal(year, value.Year);
@@ -64,16 +91,15 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void ParseTime_InvalidValue_LegalString()
+        public void ParseTime_InvalidValue_LegalString()
         {
             byte[] inputData = "17113030303030303030303030302D31353030".HexToByteArray();
 
+            AsnReaderWrapper reader = CreateWrapper(inputData, AsnEncodingRules.BER);
+
             var exception = Assert.Throws<AsnContentException>(
-                () =>
-                {
-                    AsnReader reader = new AsnReader(inputData, AsnEncodingRules.BER);
-                    reader.ReadUtcTime();
-                });
+                ref reader,
+                static (ref reader) => reader.ReadUtcTime());
 
             Assert.NotNull(exception.InnerException);
             Assert.IsType<ArgumentOutOfRangeException>(exception.InnerException);
@@ -89,11 +115,11 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(12, 12)]
         [InlineData(99, 12)]
         [InlineData(111, 12)]
-        public static void ReadUtcTime_TwoYearMaximum(int maximum, int interpretedYear)
+        public void ReadUtcTime_TwoYearMaximum(int maximum, int interpretedYear)
         {
             byte[] inputData = "170D3132303130323233353935395A".HexToByteArray();
 
-            AsnReader reader = new AsnReader(inputData, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(inputData, AsnEncodingRules.BER);
             DateTimeOffset value = reader.ReadUtcTime(maximum);
 
             Assert.Equal(interpretedYear, value.Year);
@@ -109,12 +135,12 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(12, 12)]
         [InlineData(99, 12)]
         [InlineData(111, 12)]
-        public static void ReadUtcTime_TwoYearMaximum_FromOptions(int maximum, int interpretedYear)
+        public void ReadUtcTime_TwoYearMaximum_FromOptions(int maximum, int interpretedYear)
         {
             byte[] inputData = "170D3132303130323233353935395A".HexToByteArray();
 
             AsnReaderOptions options = new AsnReaderOptions { UtcTimeTwoDigitYearMax = maximum };
-            AsnReader reader = new AsnReader(inputData, AsnEncodingRules.BER, options);
+            AsnReaderWrapper reader = CreateWrapper(inputData, AsnEncodingRules.BER, options);
             DateTimeOffset value = reader.ReadUtcTime(maximum);
 
             Assert.Equal(interpretedYear, value.Year);
@@ -130,12 +156,12 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(12, 12)]
         [InlineData(99, 12)]
         [InlineData(111, 12)]
-        public static void ReadUtcTime_TwoYearMaximum_FromOptions_CustomTag(int maximum, int interpretedYear)
+        public void ReadUtcTime_TwoYearMaximum_FromOptions_CustomTag(int maximum, int interpretedYear)
         {
             byte[] inputData = "820D3132303130323233353935395A".HexToByteArray();
 
             AsnReaderOptions options = new AsnReaderOptions { UtcTimeTwoDigitYearMax = maximum };
-            AsnReader reader = new AsnReader(inputData, AsnEncodingRules.BER, options);
+            AsnReaderWrapper reader = CreateWrapper(inputData, AsnEncodingRules.BER, options);
             DateTimeOffset value = reader.ReadUtcTime(maximum, new Asn1Tag(TagClass.ContextSpecific, 2));
 
             Assert.Equal(interpretedYear, value.Year);
@@ -157,20 +183,22 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData("A,B2,C2-MissingDigit", AsnEncodingRules.BER, "17103137303930383130333530332C303730")]
         [InlineData("A,B2,C2-TooLong", AsnEncodingRules.BER, "17123137303930383130333530332B3037303030")]
         [InlineData("WrongTag", AsnEncodingRules.BER, "1A0D3132303130323233353935395A")]
-        public static void ReadUtcTime_Throws(
+        public void ReadUtcTime_Throws(
             string description,
             AsnEncodingRules ruleSet,
             string inputHex)
         {
             _ = description;
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadUtcTime());
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadUtcTime());
         }
 
         [Fact]
-        public static void ReadUtcTime_WayTooBig_Throws()
+        public void ReadUtcTime_WayTooBig_Throws()
         {
             // Need to exceed the length that the shared pool will return for 17:
             byte[] inputData = new byte[4097+4];
@@ -179,28 +207,32 @@ namespace System.Formats.Asn1.Tests.Reader
             inputData[2] = 0x10;
             inputData[3] = 0x01;
 
-            AsnReader reader = new AsnReader(inputData, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(inputData, AsnEncodingRules.BER);
 
-            Assert.Throws<AsnContentException>(() => reader.ReadUtcTime());
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadUtcTime());
         }
 
         [Theory]
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Universal(AsnEncodingRules ruleSet)
         {
             byte[] inputData = "170D3530303130323132333435365A".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadUtcTime(expectedTag: Asn1Tag.Null));
+                static (ref reader) => reader.ReadUtcTime(expectedTag: Asn1Tag.Null));
 
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadUtcTime(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 0)));
+                ref reader,
+                static (ref reader) => reader.ReadUtcTime(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 0)));
 
             Assert.True(reader.HasData, "HasData after wrong tag");
 
@@ -215,42 +247,52 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER)]
         [InlineData(AsnEncodingRules.CER)]
         [InlineData(AsnEncodingRules.DER)]
-        public static void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
+        public void TagMustBeCorrect_Custom(AsnEncodingRules ruleSet)
         {
             const int TwoDigitYearMax = 2052;
             byte[] inputData = "850D3530303130323132333435365A".HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadUtcTime(expectedTag: Asn1Tag.Null));
+                static (ref reader) => reader.ReadUtcTime(expectedTag: Asn1Tag.Null));
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            AssertExtensions.Throws<ArgumentException>(
+            Assert.Throws<ArgumentException>(
+                ref reader,
                 "expectedTag",
-                () => reader.ReadUtcTime(TwoDigitYearMax, expectedTag: Asn1Tag.Null));
+                static (ref reader) => reader.ReadUtcTime(TwoDigitYearMax, expectedTag: Asn1Tag.Null));
             Assert.True(reader.HasData, "HasData after bad universal tag");
 
-            Assert.Throws<AsnContentException>(() => reader.ReadUtcTime());
-            Assert.True(reader.HasData, "HasData after default tag");
-
-            Assert.Throws<AsnContentException>(() => reader.ReadUtcTime(TwoDigitYearMax));
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadUtcTime());
             Assert.True(reader.HasData, "HasData after default tag");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadUtcTime(expectedTag: new Asn1Tag(TagClass.Application, 5)));
+                ref reader,
+                static (ref reader) => reader.ReadUtcTime(TwoDigitYearMax));
+            Assert.True(reader.HasData, "HasData after default tag");
+
+            Assert.Throws<AsnContentException>(
+                ref reader,
+                static (ref reader) => reader.ReadUtcTime(expectedTag: new Asn1Tag(TagClass.Application, 5)));
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadUtcTime(TwoDigitYearMax, expectedTag: new Asn1Tag(TagClass.Application, 5)));
+                ref reader,
+                static (ref reader) => reader.ReadUtcTime(TwoDigitYearMax, expectedTag: new Asn1Tag(TagClass.Application, 5)));
             Assert.True(reader.HasData, "HasData after wrong custom class");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadUtcTime(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 7)));
+                ref reader,
+                static (ref reader) => reader.ReadUtcTime(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 7)));
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
             Assert.Throws<AsnContentException>(
-                () => reader.ReadUtcTime(TwoDigitYearMax, expectedTag: new Asn1Tag(TagClass.ContextSpecific, 7)));
+                ref reader,
+                static (ref reader) => reader.ReadUtcTime(TwoDigitYearMax, expectedTag: new Asn1Tag(TagClass.ContextSpecific, 7)));
             Assert.True(reader.HasData, "HasData after wrong custom tag value");
 
             Assert.Equal(
@@ -258,7 +300,7 @@ namespace System.Formats.Asn1.Tests.Reader
                 reader.ReadUtcTime(expectedTag: new Asn1Tag(TagClass.ContextSpecific, 5)));
             Assert.False(reader.HasData, "HasData after reading value");
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             Assert.Equal(
                 new DateTimeOffset(2050, 1, 2, 12, 34, 56, TimeSpan.Zero),
@@ -273,20 +315,20 @@ namespace System.Formats.Asn1.Tests.Reader
         [InlineData(AsnEncodingRules.BER, "800D3530303130323132333435365A", TagClass.ContextSpecific, 0)]
         [InlineData(AsnEncodingRules.CER, "4C0D3530303130323132333435365A", TagClass.Application, 12)]
         [InlineData(AsnEncodingRules.DER, "DF8A460D3530303130323132333435365A", TagClass.Private, 1350)]
-        public static void ExpectedTag_IgnoresConstructed(
+        public void ExpectedTag_IgnoresConstructed(
             AsnEncodingRules ruleSet,
             string inputHex,
             TagClass tagClass,
             int tagValue)
         {
             byte[] inputData = inputHex.HexToByteArray();
-            AsnReader reader = new AsnReader(inputData, ruleSet);
+            AsnReaderWrapper reader = CreateWrapper(inputData, ruleSet);
 
-            DateTimeOffset val1 = reader.ReadUtcTime(expectedTag:  new Asn1Tag(tagClass, tagValue, true));
+            DateTimeOffset val1 = reader.ReadUtcTime(expectedTag: new Asn1Tag(tagClass, tagValue, true));
 
             Assert.False(reader.HasData);
 
-            reader = new AsnReader(inputData, ruleSet);
+            reader = CreateWrapper(inputData, ruleSet);
 
             DateTimeOffset val2 = reader.ReadUtcTime(expectedTag: new Asn1Tag(tagClass, tagValue, false));
 

--- a/src/libraries/System.Formats.Asn1/tests/Reader/ReaderStateTests.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Reader/ReaderStateTests.cs
@@ -6,14 +6,41 @@ using Xunit;
 
 namespace System.Formats.Asn1.Tests.Reader
 {
-    public static class ReaderStateTests
+    public sealed class ReaderStateAsnReaderTests : ReaderStateBase
     {
-        [Fact]
-        public static void HasDataAndThrowIfNotEmpty()
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
         {
-            AsnReader reader = new AsnReader(new byte[] { 0x01, 0x01, 0x00 }, AsnEncodingRules.BER);
+            return AsnReaderWrapper.CreateClassReader(data, ruleSet, options);
+        }
+    }
+
+    public sealed class ReaderStateValueAsnReaderTests : ReaderStateBase
+    {
+        internal override AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default)
+        {
+            return AsnReaderWrapper.CreateValueReader(data, ruleSet, options);
+        }
+    }
+
+    public abstract class ReaderStateBase
+    {
+        internal abstract AsnReaderWrapper CreateWrapper(
+            ReadOnlyMemory<byte> data,
+            AsnEncodingRules ruleSet,
+            AsnReaderOptions options = default);
+
+        [Fact]
+        public void HasDataAndThrowIfNotEmpty()
+        {
+            AsnReaderWrapper reader = CreateWrapper(new byte[] { 0x01, 0x01, 0x00 }, AsnEncodingRules.BER);
             Assert.True(reader.HasData);
-            Assert.Throws<AsnContentException>(() => reader.ThrowIfNotEmpty());
+            Assert.Throws<AsnContentException>(ref reader, static (ref reader) => reader.ThrowIfNotEmpty());
 
             // Consume the current value and move on.
             reader.ReadEncodedValue();
@@ -24,16 +51,16 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void HasDataAndThrowIfNotEmpty_StartsEmpty()
+        public void HasDataAndThrowIfNotEmpty_StartsEmpty()
         {
-            AsnReader reader = new AsnReader(ReadOnlyMemory<byte>.Empty, AsnEncodingRules.BER);
+            AsnReaderWrapper reader = CreateWrapper(ReadOnlyMemory<byte>.Empty, AsnEncodingRules.BER);
             Assert.False(reader.HasData);
             // Assert.NoThrow
             reader.ThrowIfNotEmpty();
         }
 
         [Fact]
-        public static void Clone_CopiesCurrentState()
+        public void Clone_CopiesCurrentState()
         {
             // Sequence {
             //   SetOf {
@@ -51,23 +78,23 @@ namespace System.Formats.Asn1.Tests.Reader
                 SkipSetSortOrderVerification = true,
             };
 
-            AsnReader sequence = new AsnReader(asn, AsnEncodingRules.DER, options);
-            AsnReader reader = sequence.ReadSequence();
+            AsnReaderWrapper sequence = CreateWrapper(asn, AsnEncodingRules.DER, options);
+            AsnReaderWrapper reader = sequence.ReadSequence();
             sequence.ThrowIfNotEmpty();
 
-            AsnReader clone = reader.Clone();
+            AsnReaderWrapper clone = reader.Clone();
             Assert.Equal(reader.RuleSet, clone.RuleSet);
 
-            AssertReader(reader);
+            AssertReader(ref reader);
             Assert.False(reader.HasData, "reader.HasData");
             Assert.True(clone.HasData, "clone.HasData");
 
-            AssertReader(clone);
+            AssertReader(ref clone);
             Assert.False(clone.HasData, "clone.HasData");
 
-            static void AssertReader(AsnReader reader)
+            static void AssertReader(ref AsnReaderWrapper reader)
             {
-                AsnReader setOf = reader.ReadSetOf();
+                AsnReaderWrapper setOf = reader.ReadSetOf();
                 reader.ThrowIfNotEmpty();
 
                 DateTimeOffset dateTime = setOf.ReadUtcTime();
@@ -78,24 +105,24 @@ namespace System.Formats.Asn1.Tests.Reader
         }
 
         [Fact]
-        public static void Clone_Empty()
+        public void Clone_Empty()
         {
-            AsnReader reader = new AsnReader(ReadOnlyMemory<byte>.Empty, AsnEncodingRules.DER);
-            AsnReader clone = reader.Clone();
+            AsnReaderWrapper reader = CreateWrapper(ReadOnlyMemory<byte>.Empty, AsnEncodingRules.DER);
+            AsnReaderWrapper clone = reader.Clone();
             Assert.False(reader.HasData, "reader.HasData");
             Assert.False(clone.HasData, "clone.HasData");
         }
 
         [Fact]
-        public static void Clone_SameUnderlyingData()
+        public void Clone_SameUnderlyingData()
         {
             ReadOnlyMemory<byte> data = "04050102030405".HexToByteArray();
-            AsnReader reader = new AsnReader(data, AsnEncodingRules.DER);
-            AsnReader clone = reader.Clone();
+            AsnReaderWrapper reader = CreateWrapper(data, AsnEncodingRules.DER);
+            AsnReaderWrapper clone = reader.Clone();
 
-            Assert.True(reader.TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> readerData));
-            Assert.True(clone.TryReadPrimitiveOctetString(out ReadOnlyMemory<byte> cloneData));
-            Assert.True(readerData.Span == cloneData.Span, "readerData == cloneData");
+            Assert.True(reader.TryReadPrimitiveOctetString(out ReadOnlySpan<byte> readerData));
+            Assert.True(clone.TryReadPrimitiveOctetString(out ReadOnlySpan<byte> cloneData));
+            Assert.True(readerData == cloneData, "readerData == cloneData");
         }
     }
 }

--- a/src/libraries/System.Formats.Asn1/tests/System.Formats.Asn1.Tests.csproj
+++ b/src/libraries/System.Formats.Asn1/tests/System.Formats.Asn1.Tests.csproj
@@ -6,6 +6,8 @@
   <ItemGroup>
     <Compile Include="Asn1TagTests.cs" />
     <Compile Include="Decoder\ReadEncodedValueTests.cs" />
+    <Compile Include="Reader\AsnReaderWrapper.cs" />
+    <Compile Include="Reader\AssertHelpers.cs" />
     <Compile Include="Reader\ComprehensiveReadTests.cs" />
     <Compile Include="Reader\OverlappedReads.cs" />
     <Compile Include="Reader\ParseTag.cs" />

--- a/src/libraries/System.Formats.Asn1/tests/Writer/ComprehensiveWriteTest.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Writer/ComprehensiveWriteTest.cs
@@ -5,7 +5,7 @@ using System.Formats.Asn1.Tests.Reader;
 using System.Numerics;
 using Test.Cryptography;
 using Xunit;
-using X509KeyUsageCSharpStyle = System.Formats.Asn1.Tests.Reader.ReadNamedBitList.X509KeyUsageCSharpStyle;
+using X509KeyUsageCSharpStyle = System.Formats.Asn1.Tests.Reader.ReadNamedBitListBase.X509KeyUsageCSharpStyle;
 
 namespace System.Formats.Asn1.Tests.Writer
 {

--- a/src/libraries/System.Formats.Asn1/tests/Writer/WriteEnumerated.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Writer/WriteEnumerated.cs
@@ -11,14 +11,14 @@ namespace System.Formats.Asn1.Tests.Writer
     public class WriteEnumerated : Asn1WriterTests
     {
         [Theory]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.SByteBacked.Zero, false, "0A0100")]
-        [InlineData(AsnEncodingRules.CER, ReadEnumerated.SByteBacked.Pillow, true, "9E01EF")]
-        [InlineData(AsnEncodingRules.DER, ReadEnumerated.SByteBacked.Fluff, false, "0A0153")]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.SByteBacked.Fluff, true, "9E0153")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.SByteBacked)(-127), true, "9E0181")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.SByteBacked.Zero, false, "0A0100")]
+        [InlineData(AsnEncodingRules.CER, ReadEnumeratedBase.SByteBacked.Pillow, true, "9E01EF")]
+        [InlineData(AsnEncodingRules.DER, ReadEnumeratedBase.SByteBacked.Fluff, false, "0A0153")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.SByteBacked.Fluff, true, "9E0153")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.SByteBacked)(-127), true, "9E0181")]
         public void VerifyWriteEnumerated_SByte(
             AsnEncodingRules ruleSet,
-            ReadEnumerated.SByteBacked value,
+            ReadEnumeratedBase.SByteBacked value,
             bool customTag,
             string expectedHex)
         {
@@ -37,14 +37,14 @@ namespace System.Formats.Asn1.Tests.Writer
         }
 
         [Theory]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.ByteBacked.Zero, false, "0A0100")]
-        [InlineData(AsnEncodingRules.CER, ReadEnumerated.ByteBacked.NotFluffy, true, "9A010B")]
-        [InlineData(AsnEncodingRules.DER, ReadEnumerated.ByteBacked.Fluff, false, "0A010C")]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.ByteBacked.Fluff, true, "9A010C")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.ByteBacked)253, false, "0A0200FD")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.ByteBacked.Zero, false, "0A0100")]
+        [InlineData(AsnEncodingRules.CER, ReadEnumeratedBase.ByteBacked.NotFluffy, true, "9A010B")]
+        [InlineData(AsnEncodingRules.DER, ReadEnumeratedBase.ByteBacked.Fluff, false, "0A010C")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.ByteBacked.Fluff, true, "9A010C")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.ByteBacked)253, false, "0A0200FD")]
         public void VerifyWriteEnumerated_Byte(
             AsnEncodingRules ruleSet,
-            ReadEnumerated.ByteBacked value,
+            ReadEnumeratedBase.ByteBacked value,
             bool customTag,
             string expectedHex)
         {
@@ -63,16 +63,16 @@ namespace System.Formats.Asn1.Tests.Writer
         }
 
         [Theory]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.ShortBacked.Zero, true, "DF81540100")]
-        [InlineData(AsnEncodingRules.CER, ReadEnumerated.ShortBacked.Pillow, true, "DF815402FC00")]
-        [InlineData(AsnEncodingRules.DER, ReadEnumerated.ShortBacked.Fluff, false, "0A020209")]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.ShortBacked.Fluff, true, "DF8154020209")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.ShortBacked)25321, false, "0A0262E9")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.ShortBacked)(-12345), false, "0A02CFC7")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.ShortBacked)(-1), true, "DF815401FF")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.ShortBacked.Zero, true, "DF81540100")]
+        [InlineData(AsnEncodingRules.CER, ReadEnumeratedBase.ShortBacked.Pillow, true, "DF815402FC00")]
+        [InlineData(AsnEncodingRules.DER, ReadEnumeratedBase.ShortBacked.Fluff, false, "0A020209")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.ShortBacked.Fluff, true, "DF8154020209")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.ShortBacked)25321, false, "0A0262E9")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.ShortBacked)(-12345), false, "0A02CFC7")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.ShortBacked)(-1), true, "DF815401FF")]
         public void VerifyWriteEnumerated_Short(
             AsnEncodingRules ruleSet,
-            ReadEnumerated.ShortBacked value,
+            ReadEnumeratedBase.ShortBacked value,
             bool customTag,
             string expectedHex)
         {
@@ -91,16 +91,16 @@ namespace System.Formats.Asn1.Tests.Writer
         }
 
         [Theory]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.UShortBacked.Zero, false, "0A0100")]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.UShortBacked.Zero, true, "4D0100")]
-        [InlineData(AsnEncodingRules.DER, ReadEnumerated.UShortBacked.Fluff, false, "0A03008000")]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.UShortBacked.Fluff, true, "4D03008000")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.UShortBacked)11, false, "0A010B")]
-        [InlineData(AsnEncodingRules.DER, (ReadEnumerated.UShortBacked)short.MaxValue, false, "0A027FFF")]
-        [InlineData(AsnEncodingRules.BER, (ReadEnumerated.UShortBacked)ushort.MaxValue, true, "4D0300FFFF")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.UShortBacked.Zero, false, "0A0100")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.UShortBacked.Zero, true, "4D0100")]
+        [InlineData(AsnEncodingRules.DER, ReadEnumeratedBase.UShortBacked.Fluff, false, "0A03008000")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.UShortBacked.Fluff, true, "4D03008000")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.UShortBacked)11, false, "0A010B")]
+        [InlineData(AsnEncodingRules.DER, (ReadEnumeratedBase.UShortBacked)short.MaxValue, false, "0A027FFF")]
+        [InlineData(AsnEncodingRules.BER, (ReadEnumeratedBase.UShortBacked)ushort.MaxValue, true, "4D0300FFFF")]
         public void VerifyWriteEnumerated_UShort(
             AsnEncodingRules ruleSet,
-            ReadEnumerated.UShortBacked value,
+            ReadEnumeratedBase.UShortBacked value,
             bool customTag,
             string expectedHex)
         {
@@ -119,18 +119,18 @@ namespace System.Formats.Asn1.Tests.Writer
         }
 
         [Theory]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.IntBacked.Zero, true, "5F81FF7F0100")]
-        [InlineData(AsnEncodingRules.CER, ReadEnumerated.IntBacked.Pillow, true, "5F81FF7F03FEFFFF")]
-        [InlineData(AsnEncodingRules.DER, ReadEnumerated.IntBacked.Fluff, false, "0A03010001")]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.IntBacked.Fluff, true, "5F81FF7F03010001")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.IntBacked)25321, false, "0A0262E9")]
-        [InlineData(AsnEncodingRules.DER, (ReadEnumerated.IntBacked)(-12345), false, "0A02CFC7")]
-        [InlineData(AsnEncodingRules.BER, (ReadEnumerated.IntBacked)(-1), true, "5F81FF7F01FF")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.IntBacked)int.MinValue, true, "5F81FF7F0480000000")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.IntBacked)int.MaxValue, false, "0A047FFFFFFF")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.IntBacked.Zero, true, "5F81FF7F0100")]
+        [InlineData(AsnEncodingRules.CER, ReadEnumeratedBase.IntBacked.Pillow, true, "5F81FF7F03FEFFFF")]
+        [InlineData(AsnEncodingRules.DER, ReadEnumeratedBase.IntBacked.Fluff, false, "0A03010001")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.IntBacked.Fluff, true, "5F81FF7F03010001")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.IntBacked)25321, false, "0A0262E9")]
+        [InlineData(AsnEncodingRules.DER, (ReadEnumeratedBase.IntBacked)(-12345), false, "0A02CFC7")]
+        [InlineData(AsnEncodingRules.BER, (ReadEnumeratedBase.IntBacked)(-1), true, "5F81FF7F01FF")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.IntBacked)int.MinValue, true, "5F81FF7F0480000000")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.IntBacked)int.MaxValue, false, "0A047FFFFFFF")]
         public void VerifyWriteEnumerated_Int(
             AsnEncodingRules ruleSet,
-            ReadEnumerated.IntBacked value,
+            ReadEnumeratedBase.IntBacked value,
             bool customTag,
             string expectedHex)
         {
@@ -149,16 +149,16 @@ namespace System.Formats.Asn1.Tests.Writer
         }
 
         [Theory]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.UIntBacked.Zero, false, "0A0100")]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.UIntBacked.Zero, true, "9F610100")]
-        [InlineData(AsnEncodingRules.DER, ReadEnumerated.UIntBacked.Fluff, false, "0A050080000005")]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.UIntBacked.Fluff, true, "9F61050080000005")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.UIntBacked)11, false, "0A010B")]
-        [InlineData(AsnEncodingRules.DER, (ReadEnumerated.UIntBacked)short.MaxValue, false, "0A027FFF")]
-        [InlineData(AsnEncodingRules.BER, (ReadEnumerated.UIntBacked)ushort.MaxValue, true, "9F610300FFFF")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.UIntBacked.Zero, false, "0A0100")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.UIntBacked.Zero, true, "9F610100")]
+        [InlineData(AsnEncodingRules.DER, ReadEnumeratedBase.UIntBacked.Fluff, false, "0A050080000005")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.UIntBacked.Fluff, true, "9F61050080000005")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.UIntBacked)11, false, "0A010B")]
+        [InlineData(AsnEncodingRules.DER, (ReadEnumeratedBase.UIntBacked)short.MaxValue, false, "0A027FFF")]
+        [InlineData(AsnEncodingRules.BER, (ReadEnumeratedBase.UIntBacked)ushort.MaxValue, true, "9F610300FFFF")]
         public void VerifyWriteEnumerated_UInt(
             AsnEncodingRules ruleSet,
-            ReadEnumerated.UIntBacked value,
+            ReadEnumeratedBase.UIntBacked value,
             bool customTag,
             string expectedHex)
         {
@@ -177,20 +177,20 @@ namespace System.Formats.Asn1.Tests.Writer
         }
 
         [Theory]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.LongBacked.Zero, true, "800100")]
-        [InlineData(AsnEncodingRules.CER, ReadEnumerated.LongBacked.Pillow, true, "8005FF00000000")]
-        [InlineData(AsnEncodingRules.DER, ReadEnumerated.LongBacked.Fluff, false, "0A050200000441")]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.LongBacked.Fluff, true, "80050200000441")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.LongBacked)25321, false, "0A0262E9")]
-        [InlineData(AsnEncodingRules.DER, (ReadEnumerated.LongBacked)(-12345), false, "0A02CFC7")]
-        [InlineData(AsnEncodingRules.BER, (ReadEnumerated.LongBacked)(-1), true, "8001FF")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.LongBacked)int.MinValue, true, "800480000000")]
-        [InlineData(AsnEncodingRules.DER, (ReadEnumerated.LongBacked)int.MaxValue, false, "0A047FFFFFFF")]
-        [InlineData(AsnEncodingRules.BER, (ReadEnumerated.LongBacked)long.MinValue, false, "0A088000000000000000")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.LongBacked)long.MaxValue, true, "80087FFFFFFFFFFFFFFF")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.LongBacked.Zero, true, "800100")]
+        [InlineData(AsnEncodingRules.CER, ReadEnumeratedBase.LongBacked.Pillow, true, "8005FF00000000")]
+        [InlineData(AsnEncodingRules.DER, ReadEnumeratedBase.LongBacked.Fluff, false, "0A050200000441")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.LongBacked.Fluff, true, "80050200000441")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.LongBacked)25321, false, "0A0262E9")]
+        [InlineData(AsnEncodingRules.DER, (ReadEnumeratedBase.LongBacked)(-12345), false, "0A02CFC7")]
+        [InlineData(AsnEncodingRules.BER, (ReadEnumeratedBase.LongBacked)(-1), true, "8001FF")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.LongBacked)int.MinValue, true, "800480000000")]
+        [InlineData(AsnEncodingRules.DER, (ReadEnumeratedBase.LongBacked)int.MaxValue, false, "0A047FFFFFFF")]
+        [InlineData(AsnEncodingRules.BER, (ReadEnumeratedBase.LongBacked)long.MinValue, false, "0A088000000000000000")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.LongBacked)long.MaxValue, true, "80087FFFFFFFFFFFFFFF")]
         public void VerifyWriteEnumerated_Long(
             AsnEncodingRules ruleSet,
-            ReadEnumerated.LongBacked value,
+            ReadEnumeratedBase.LongBacked value,
             bool customTag,
             string expectedHex)
         {
@@ -209,18 +209,18 @@ namespace System.Formats.Asn1.Tests.Writer
         }
 
         [Theory]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.ULongBacked.Zero, false, "0A0100")]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.ULongBacked.Zero, true, "C10100")]
-        [InlineData(AsnEncodingRules.DER, ReadEnumerated.ULongBacked.Fluff, false, "0A0900FACEF00DCAFEBEEF")]
-        [InlineData(AsnEncodingRules.BER, ReadEnumerated.ULongBacked.Fluff, true, "C10900FACEF00DCAFEBEEF")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.ULongBacked)11, false, "0A010B")]
-        [InlineData(AsnEncodingRules.DER, (ReadEnumerated.ULongBacked)short.MaxValue, false, "0A027FFF")]
-        [InlineData(AsnEncodingRules.BER, (ReadEnumerated.ULongBacked)ushort.MaxValue, true, "C10300FFFF")]
-        [InlineData(AsnEncodingRules.CER, (ReadEnumerated.ULongBacked)long.MaxValue, true, "C1087FFFFFFFFFFFFFFF")]
-        [InlineData(AsnEncodingRules.DER, (ReadEnumerated.ULongBacked)ulong.MaxValue, false, "0A0900FFFFFFFFFFFFFFFF")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.ULongBacked.Zero, false, "0A0100")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.ULongBacked.Zero, true, "C10100")]
+        [InlineData(AsnEncodingRules.DER, ReadEnumeratedBase.ULongBacked.Fluff, false, "0A0900FACEF00DCAFEBEEF")]
+        [InlineData(AsnEncodingRules.BER, ReadEnumeratedBase.ULongBacked.Fluff, true, "C10900FACEF00DCAFEBEEF")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.ULongBacked)11, false, "0A010B")]
+        [InlineData(AsnEncodingRules.DER, (ReadEnumeratedBase.ULongBacked)short.MaxValue, false, "0A027FFF")]
+        [InlineData(AsnEncodingRules.BER, (ReadEnumeratedBase.ULongBacked)ushort.MaxValue, true, "C10300FFFF")]
+        [InlineData(AsnEncodingRules.CER, (ReadEnumeratedBase.ULongBacked)long.MaxValue, true, "C1087FFFFFFFFFFFFFFF")]
+        [InlineData(AsnEncodingRules.DER, (ReadEnumeratedBase.ULongBacked)ulong.MaxValue, false, "0A0900FFFFFFFFFFFFFFFF")]
         public void VerifyWriteEnumerated_ULong(
             AsnEncodingRules ruleSet,
-            ReadEnumerated.ULongBacked value,
+            ReadEnumeratedBase.ULongBacked value,
             bool customTag,
             string expectedHex)
         {
@@ -277,11 +277,11 @@ namespace System.Formats.Asn1.Tests.Writer
 
             AssertExtensions.Throws<ArgumentException>(
                 "tag",
-                () => writer.WriteEnumeratedValue(ReadEnumerated.IntBacked.Pillow, Asn1Tag.Null));
+                () => writer.WriteEnumeratedValue(ReadEnumeratedBase.IntBacked.Pillow, Asn1Tag.Null));
 
             AssertExtensions.Throws<ArgumentException>(
                 "tag",
-                () => writer.WriteEnumeratedValue((Enum)ReadEnumerated.IntBacked.Pillow, Asn1Tag.Null));
+                () => writer.WriteEnumeratedValue((Enum)ReadEnumeratedBase.IntBacked.Pillow, Asn1Tag.Null));
         }
 
         [Theory]
@@ -312,14 +312,14 @@ namespace System.Formats.Asn1.Tests.Writer
             AsnWriter objWriter = new AsnWriter(ruleSet);
             AsnWriter genWriter = new AsnWriter(ruleSet);
 
-            genWriter.WriteEnumeratedValue(ReadEnumerated.UIntBacked.Fluff);
-            objWriter.WriteEnumeratedValue((Enum)ReadEnumerated.UIntBacked.Fluff);
+            genWriter.WriteEnumeratedValue(ReadEnumeratedBase.UIntBacked.Fluff);
+            objWriter.WriteEnumeratedValue((Enum)ReadEnumeratedBase.UIntBacked.Fluff);
 
-            genWriter.WriteEnumeratedValue(ReadEnumerated.SByteBacked.Fluff);
-            objWriter.WriteEnumeratedValue((Enum)ReadEnumerated.SByteBacked.Fluff);
+            genWriter.WriteEnumeratedValue(ReadEnumeratedBase.SByteBacked.Fluff);
+            objWriter.WriteEnumeratedValue((Enum)ReadEnumeratedBase.SByteBacked.Fluff);
 
-            genWriter.WriteEnumeratedValue(ReadEnumerated.ULongBacked.Fluff);
-            objWriter.WriteEnumeratedValue((Enum)ReadEnumerated.ULongBacked.Fluff);
+            genWriter.WriteEnumeratedValue(ReadEnumeratedBase.ULongBacked.Fluff);
+            objWriter.WriteEnumeratedValue((Enum)ReadEnumeratedBase.ULongBacked.Fluff);
 
             Verify(objWriter, genWriter.Encode().ByteArrayToHex());
         }
@@ -335,18 +335,18 @@ namespace System.Formats.Asn1.Tests.Writer
 
             Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 52);
 
-            genWriter.WriteEnumeratedValue(ReadEnumerated.UIntBacked.Fluff, tag);
-            objWriter.WriteEnumeratedValue((Enum)ReadEnumerated.UIntBacked.Fluff, tag);
+            genWriter.WriteEnumeratedValue(ReadEnumeratedBase.UIntBacked.Fluff, tag);
+            objWriter.WriteEnumeratedValue((Enum)ReadEnumeratedBase.UIntBacked.Fluff, tag);
 
             tag = new Asn1Tag(TagClass.Private, 4);
 
-            genWriter.WriteEnumeratedValue(ReadEnumerated.SByteBacked.Fluff, tag);
-            objWriter.WriteEnumeratedValue((Enum)ReadEnumerated.SByteBacked.Fluff, tag);
+            genWriter.WriteEnumeratedValue(ReadEnumeratedBase.SByteBacked.Fluff, tag);
+            objWriter.WriteEnumeratedValue((Enum)ReadEnumeratedBase.SByteBacked.Fluff, tag);
 
             tag = new Asn1Tag(TagClass.Application, 75);
 
-            genWriter.WriteEnumeratedValue(ReadEnumerated.ULongBacked.Fluff, tag);
-            objWriter.WriteEnumeratedValue((Enum)ReadEnumerated.ULongBacked.Fluff, tag);
+            genWriter.WriteEnumeratedValue(ReadEnumeratedBase.ULongBacked.Fluff, tag);
+            objWriter.WriteEnumeratedValue((Enum)ReadEnumeratedBase.ULongBacked.Fluff, tag);
 
             Verify(objWriter, genWriter.Encode().ByteArrayToHex());
         }
@@ -359,11 +359,11 @@ namespace System.Formats.Asn1.Tests.Writer
         {
             AsnWriter writer = new AsnWriter(ruleSet);
             writer.WriteEnumeratedValue(
-                ReadEnumerated.ULongBacked.Fluff,
+                ReadEnumeratedBase.ULongBacked.Fluff,
                 new Asn1Tag(UniversalTagNumber.Enumerated, isConstructed: true));
 
             writer.WriteEnumeratedValue(
-                (Enum)ReadEnumerated.SByteBacked.Fluff,
+                (Enum)ReadEnumeratedBase.SByteBacked.Fluff,
                 new Asn1Tag(TagClass.ContextSpecific, 0, isConstructed: true));
 
             Verify(writer, "0A0900FACEF00DCAFEBEEF" + "800153");

--- a/src/libraries/System.Formats.Asn1/tests/Writer/WriteNamedBitList.cs
+++ b/src/libraries/System.Formats.Asn1/tests/Writer/WriteNamedBitList.cs
@@ -29,29 +29,29 @@ namespace System.Formats.Asn1.Tests.Writer
         [InlineData(
             AsnEncodingRules.BER,
             "C00100",
-            ReadNamedBitList.ULongFlags.None)]
+            ReadNamedBitListBase.ULongFlags.None)]
         [InlineData(
             AsnEncodingRules.CER,
             "410100",
-            ReadNamedBitList.ULongFlags.None)]
+            ReadNamedBitListBase.ULongFlags.None)]
         [InlineData(
             AsnEncodingRules.DER,
             "820100",
-            ReadNamedBitList.ULongFlags.None)]
+            ReadNamedBitListBase.ULongFlags.None)]
         [InlineData(
             AsnEncodingRules.BER,
             "C009000000000000000003",
-            ReadNamedBitList.ULongFlags.Max | ReadNamedBitList.ULongFlags.AlmostMax)]
+            ReadNamedBitListBase.ULongFlags.Max | ReadNamedBitListBase.ULongFlags.AlmostMax)]
         [InlineData(
             AsnEncodingRules.CER,
             "4109010000000080000002",
-            ReadNamedBitList.LongFlags.Max | ReadNamedBitList.LongFlags.Mid)]
+            ReadNamedBitListBase.LongFlags.Max | ReadNamedBitListBase.LongFlags.Mid)]
         [InlineData(
             AsnEncodingRules.DER,
             "820204B0",
-            ReadNamedBitList.X509KeyUsageCSharpStyle.DigitalSignature |
-                ReadNamedBitList.X509KeyUsageCSharpStyle.KeyEncipherment |
-                ReadNamedBitList.X509KeyUsageCSharpStyle.DataEncipherment)]
+            ReadNamedBitListBase.X509KeyUsageCSharpStyle.DigitalSignature |
+                ReadNamedBitListBase.X509KeyUsageCSharpStyle.KeyEncipherment |
+                ReadNamedBitListBase.X509KeyUsageCSharpStyle.DataEncipherment)]
         public static void VerifyWriteNamedBitList_WithTag(
             AsnEncodingRules ruleSet,
             string expectedHex,
@@ -81,9 +81,9 @@ namespace System.Formats.Asn1.Tests.Writer
             AsnWriter genWriter = new AsnWriter(ruleSet);
 
             var flagsValue =
-                ReadNamedBitList.X509KeyUsageCSharpStyle.DigitalSignature |
-                ReadNamedBitList.X509KeyUsageCSharpStyle.KeyEncipherment |
-                ReadNamedBitList.X509KeyUsageCSharpStyle.DataEncipherment;
+                ReadNamedBitListBase.X509KeyUsageCSharpStyle.DigitalSignature |
+                ReadNamedBitListBase.X509KeyUsageCSharpStyle.KeyEncipherment |
+                ReadNamedBitListBase.X509KeyUsageCSharpStyle.DataEncipherment;
 
             genWriter.WriteNamedBitList(flagsValue);
             objWriter.WriteNamedBitList((Enum)flagsValue);
@@ -102,9 +102,9 @@ namespace System.Formats.Asn1.Tests.Writer
             Asn1Tag tag = new Asn1Tag(TagClass.ContextSpecific, 52);
 
             var flagsValue =
-                ReadNamedBitList.X509KeyUsageCSharpStyle.DigitalSignature |
-                ReadNamedBitList.X509KeyUsageCSharpStyle.KeyEncipherment |
-                ReadNamedBitList.X509KeyUsageCSharpStyle.DataEncipherment;
+                ReadNamedBitListBase.X509KeyUsageCSharpStyle.DigitalSignature |
+                ReadNamedBitListBase.X509KeyUsageCSharpStyle.KeyEncipherment |
+                ReadNamedBitListBase.X509KeyUsageCSharpStyle.DataEncipherment;
 
             genWriter.WriteNamedBitList(flagsValue, tag);
             objWriter.WriteNamedBitList((Enum)flagsValue, tag);
@@ -365,45 +365,45 @@ namespace System.Formats.Asn1.Tests.Writer
 
                 foreach (AsnEncodingRules rule in rules)
                 {
-                    yield return new object[] { rule, "030100", ReadNamedBitList.ULongFlags.None };
-                    yield return new object[] { rule, "030100", ReadNamedBitList.LongFlags.None };
+                    yield return new object[] { rule, "030100", ReadNamedBitListBase.ULongFlags.None };
+                    yield return new object[] { rule, "030100", ReadNamedBitListBase.LongFlags.None };
 
-                    yield return new object[] { rule, "030100", ReadNamedBitList.UIntFlags.None };
-                    yield return new object[] { rule, "030100", ReadNamedBitList.IntFlags.None };
+                    yield return new object[] { rule, "030100", ReadNamedBitListBase.UIntFlags.None };
+                    yield return new object[] { rule, "030100", ReadNamedBitListBase.IntFlags.None };
 
-                    yield return new object[] { rule, "030100", ReadNamedBitList.UShortFlags.None };
-                    yield return new object[] { rule, "030100", ReadNamedBitList.ShortFlags.None };
+                    yield return new object[] { rule, "030100", ReadNamedBitListBase.UShortFlags.None };
+                    yield return new object[] { rule, "030100", ReadNamedBitListBase.ShortFlags.None };
 
-                    yield return new object[] { rule, "030100", ReadNamedBitList.ByteFlags.None };
-                    yield return new object[] { rule, "030100", ReadNamedBitList.SByteFlags.None };
+                    yield return new object[] { rule, "030100", ReadNamedBitListBase.ByteFlags.None };
+                    yield return new object[] { rule, "030100", ReadNamedBitListBase.SByteFlags.None };
 
-                    yield return new object[] { rule, "030200FF", ReadNamedBitList.SByteFlags.AllBits };
-                    yield return new object[] { rule, "030300FFFF", ReadNamedBitList.ShortFlags.AllBits };
-                    yield return new object[] { rule, "030500FFFFFFFF", ReadNamedBitList.IntFlags.AllBits };
-                    yield return new object[] { rule, "030900FFFFFFFFFFFFFFFF", ReadNamedBitList.LongFlags.AllBits };
+                    yield return new object[] { rule, "030200FF", ReadNamedBitListBase.SByteFlags.AllBits };
+                    yield return new object[] { rule, "030300FFFF", ReadNamedBitListBase.ShortFlags.AllBits };
+                    yield return new object[] { rule, "030500FFFFFFFF", ReadNamedBitListBase.IntFlags.AllBits };
+                    yield return new object[] { rule, "030900FFFFFFFFFFFFFFFF", ReadNamedBitListBase.LongFlags.AllBits };
                 }
 
                 yield return new object[]
                 {
                     AsnEncodingRules.BER,
                     "0309000000000000000003",
-                    ReadNamedBitList.ULongFlags.Max | ReadNamedBitList.ULongFlags.AlmostMax,
+                    ReadNamedBitListBase.ULongFlags.Max | ReadNamedBitListBase.ULongFlags.AlmostMax,
                 };
 
                 yield return new object[]
                 {
                     AsnEncodingRules.CER,
                     "0309010000000080000002",
-                    ReadNamedBitList.LongFlags.Max | ReadNamedBitList.LongFlags.Mid,
+                    ReadNamedBitListBase.LongFlags.Max | ReadNamedBitListBase.LongFlags.Mid,
                 };
 
                 yield return new object[]
                 {
                     AsnEncodingRules.DER,
                     "030204B0",
-                    ReadNamedBitList.X509KeyUsageCSharpStyle.DigitalSignature |
-                        ReadNamedBitList.X509KeyUsageCSharpStyle.KeyEncipherment |
-                        ReadNamedBitList.X509KeyUsageCSharpStyle.DataEncipherment,
+                    ReadNamedBitListBase.X509KeyUsageCSharpStyle.DigitalSignature |
+                        ReadNamedBitListBase.X509KeyUsageCSharpStyle.KeyEncipherment |
+                        ReadNamedBitListBase.X509KeyUsageCSharpStyle.DataEncipherment,
                 };
             }
         }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Asn.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Asn.cs
@@ -17,7 +17,7 @@ namespace Internal.Cryptography.Pal.AnyOS
             {
                 using (var manager = new PointerMemoryManager<byte>(pin, encodedMessage.Length))
                 {
-                    AsnValueReader reader = new AsnValueReader(encodedMessage, AsnEncodingRules.BER);
+                    ValueAsnReader reader = new ValueAsnReader(encodedMessage, AsnEncodingRules.BER);
 
                     ContentInfoAsn.Decode(ref reader, manager.Memory, out ContentInfoAsn contentInfo);
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decode.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decode.cs
@@ -86,7 +86,7 @@ namespace Internal.Cryptography.Pal.AnyOS
                 {
                     using (var manager = new PointerMemoryManager<byte>(pin, encodedMessage.Length))
                     {
-                        AsnValueReader reader = new AsnValueReader(encodedMessage, AsnEncodingRules.BER);
+                        ValueAsnReader reader = new ValueAsnReader(encodedMessage, AsnEncodingRules.BER);
 
                         ContentInfoAsn.Decode(
                             ref reader,

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.cs
@@ -44,7 +44,7 @@ namespace Internal.Cryptography.Pal.AnyOS
             try
             {
                 // Certificates are DER encoded.
-                AsnValueReader reader = new AsnValueReader(extension.RawData, AsnEncodingRules.DER);
+                ValueAsnReader reader = new ValueAsnReader(extension.RawData, AsnEncodingRules.DER);
 
                 if (reader.TryReadPrimitiveOctetString(out ReadOnlySpan<byte> contents))
                 {

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/CadesIssuerSerial.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/CadesIssuerSerial.xml.cs
@@ -45,7 +45,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out CadesIssuerSerial decoded);
                 reader.ThrowIfNotEmpty();
@@ -57,12 +57,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out CadesIssuerSerial decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out CadesIssuerSerial decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CadesIssuerSerial decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CadesIssuerSerial decoded)
         {
             try
             {
@@ -74,11 +74,11 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CadesIssuerSerial decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CadesIssuerSerial decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader collectionReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/EnvelopedDataAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/EnvelopedDataAsn.xml.cs
@@ -68,7 +68,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out EnvelopedDataAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -80,12 +80,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out EnvelopedDataAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out EnvelopedDataAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EnvelopedDataAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EnvelopedDataAsn decoded)
         {
             try
             {
@@ -97,11 +97,11 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EnvelopedDataAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EnvelopedDataAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader collectionReader;
 
 
             if (!sequenceReader.TryReadInt32(out decoded.Version))

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/EssCertId.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/EssCertId.xml.cs
@@ -42,7 +42,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out EssCertId decoded);
                 reader.ThrowIfNotEmpty();
@@ -54,12 +54,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out EssCertId decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out EssCertId decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EssCertId decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EssCertId decoded)
         {
             try
             {
@@ -71,10 +71,10 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EssCertId decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EssCertId decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/EssCertIdV2.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/EssCertIdV2.xml.cs
@@ -22,9 +22,9 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             EssCertIdV2 decoded = default;
             ReadOnlyMemory<byte> rebind = default;
-            AsnValueReader reader;
+            ValueAsnReader reader;
 
-            reader = new AsnValueReader(DefaultHashAlgorithm, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultHashAlgorithm, AsnEncodingRules.DER);
             System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref reader, rebind, out decoded.HashAlgorithm);
             reader.ThrowIfNotEmpty();
         }
@@ -70,7 +70,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out EssCertIdV2 decoded);
                 reader.ThrowIfNotEmpty();
@@ -82,12 +82,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out EssCertIdV2 decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out EssCertIdV2 decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EssCertIdV2 decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EssCertIdV2 decoded)
         {
             try
             {
@@ -99,11 +99,11 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EssCertIdV2 decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out EssCertIdV2 decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader defaultReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader defaultReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;
@@ -115,7 +115,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultHashAlgorithm, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultHashAlgorithm, AsnEncodingRules.DER);
                 System.Security.Cryptography.Asn1.AlgorithmIdentifierAsn.Decode(ref defaultReader, rebind, out decoded.HashAlgorithm);
             }
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/KeyAgreeRecipientIdentifierAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/KeyAgreeRecipientIdentifierAsn.xml.cs
@@ -65,7 +65,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, encoded, out KeyAgreeRecipientIdentifierAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out KeyAgreeRecipientIdentifierAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out KeyAgreeRecipientIdentifierAsn decoded)
         {
             try
             {
@@ -89,7 +89,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out KeyAgreeRecipientIdentifierAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out KeyAgreeRecipientIdentifierAsn decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/KeyAgreeRecipientInfoAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/KeyAgreeRecipientInfoAsn.xml.cs
@@ -60,7 +60,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out KeyAgreeRecipientInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -72,12 +72,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out KeyAgreeRecipientInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out KeyAgreeRecipientInfoAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out KeyAgreeRecipientInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out KeyAgreeRecipientInfoAsn decoded)
         {
             try
             {
@@ -89,12 +89,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out KeyAgreeRecipientInfoAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out KeyAgreeRecipientInfoAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
+            ValueAsnReader collectionReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/KeyTransRecipientInfoAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/KeyTransRecipientInfoAsn.xml.cs
@@ -41,7 +41,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out KeyTransRecipientInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -53,12 +53,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out KeyTransRecipientInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out KeyTransRecipientInfoAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out KeyTransRecipientInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out KeyTransRecipientInfoAsn decoded)
         {
             try
             {
@@ -70,10 +70,10 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out KeyTransRecipientInfoAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out KeyTransRecipientInfoAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/MessageImprint.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/MessageImprint.xml.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out MessageImprint decoded);
                 reader.ThrowIfNotEmpty();
@@ -49,12 +49,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out MessageImprint decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out MessageImprint decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MessageImprint decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MessageImprint decoded)
         {
             try
             {
@@ -66,10 +66,10 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MessageImprint decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out MessageImprint decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OriginatorIdentifierOrKeyAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OriginatorIdentifierOrKeyAsn.xml.cs
@@ -76,7 +76,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, encoded, out OriginatorIdentifierOrKeyAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -88,7 +88,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out OriginatorIdentifierOrKeyAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out OriginatorIdentifierOrKeyAsn decoded)
         {
             try
             {
@@ -100,7 +100,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out OriginatorIdentifierOrKeyAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out OriginatorIdentifierOrKeyAsn decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OriginatorInfoAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OriginatorInfoAsn.xml.cs
@@ -69,7 +69,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out OriginatorInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -81,12 +81,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out OriginatorInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out OriginatorInfoAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OriginatorInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OriginatorInfoAsn decoded)
         {
             try
             {
@@ -98,11 +98,11 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OriginatorInfoAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OriginatorInfoAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader collectionReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OriginatorPublicKeyAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OriginatorPublicKeyAsn.xml.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out OriginatorPublicKeyAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -49,12 +49,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out OriginatorPublicKeyAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out OriginatorPublicKeyAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OriginatorPublicKeyAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OriginatorPublicKeyAsn decoded)
         {
             try
             {
@@ -66,10 +66,10 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OriginatorPublicKeyAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OriginatorPublicKeyAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OtherKeyAttributeAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/OtherKeyAttributeAsn.xml.cs
@@ -56,7 +56,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out OtherKeyAttributeAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -68,12 +68,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out OtherKeyAttributeAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out OtherKeyAttributeAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OtherKeyAttributeAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OtherKeyAttributeAsn decoded)
         {
             try
             {
@@ -85,10 +85,10 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OtherKeyAttributeAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out OtherKeyAttributeAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/PkiStatusInfo.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/PkiStatusInfo.xml.cs
@@ -65,7 +65,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out PkiStatusInfo decoded);
                 reader.ThrowIfNotEmpty();
@@ -77,12 +77,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out PkiStatusInfo decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out PkiStatusInfo decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PkiStatusInfo decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PkiStatusInfo decoded)
         {
             try
             {
@@ -94,10 +94,10 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PkiStatusInfo decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PkiStatusInfo decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/PolicyInformation.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/PolicyInformation.xml.cs
@@ -57,7 +57,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out PolicyInformation decoded);
                 reader.ThrowIfNotEmpty();
@@ -69,12 +69,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out PolicyInformation decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out PolicyInformation decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PolicyInformation decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PolicyInformation decoded)
         {
             try
             {
@@ -86,11 +86,11 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PolicyInformation decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PolicyInformation decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader collectionReader;
 
             decoded.PolicyIdentifier = sequenceReader.ReadObjectIdentifier();
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/PolicyQualifierInfo.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/PolicyQualifierInfo.xml.cs
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out PolicyQualifierInfo decoded);
                 reader.ThrowIfNotEmpty();
@@ -63,12 +63,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out PolicyQualifierInfo decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out PolicyQualifierInfo decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PolicyQualifierInfo decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PolicyQualifierInfo decoded)
         {
             try
             {
@@ -80,10 +80,10 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PolicyQualifierInfo decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PolicyQualifierInfo decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientEncryptedKeyAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientEncryptedKeyAsn.xml.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out RecipientEncryptedKeyAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -49,12 +49,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out RecipientEncryptedKeyAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out RecipientEncryptedKeyAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RecipientEncryptedKeyAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RecipientEncryptedKeyAsn decoded)
         {
             try
             {
@@ -66,10 +66,10 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RecipientEncryptedKeyAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RecipientEncryptedKeyAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientIdentifierAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientIdentifierAsn.xml.cs
@@ -65,7 +65,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, encoded, out RecipientIdentifierAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out RecipientIdentifierAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out RecipientIdentifierAsn decoded)
         {
             try
             {
@@ -89,7 +89,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out RecipientIdentifierAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out RecipientIdentifierAsn decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientInfoAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientInfoAsn.xml.cs
@@ -65,7 +65,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, encoded, out RecipientInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out RecipientInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out RecipientInfoAsn decoded)
         {
             try
             {
@@ -89,7 +89,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out RecipientInfoAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out RecipientInfoAsn decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientKeyIdentifier.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/RecipientKeyIdentifier.xml.cs
@@ -49,7 +49,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out RecipientKeyIdentifier decoded);
                 reader.ThrowIfNotEmpty();
@@ -61,12 +61,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out RecipientKeyIdentifier decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out RecipientKeyIdentifier decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RecipientKeyIdentifier decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RecipientKeyIdentifier decoded)
         {
             try
             {
@@ -78,10 +78,10 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RecipientKeyIdentifier decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out RecipientKeyIdentifier decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161Accuracy.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161Accuracy.xml.cs
@@ -54,7 +54,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, out Rfc3161Accuracy decoded);
                 reader.ThrowIfNotEmpty();
@@ -66,12 +66,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, out Rfc3161Accuracy decoded)
+        internal static void Decode(ref ValueAsnReader reader, out Rfc3161Accuracy decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, out Rfc3161Accuracy decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, out Rfc3161Accuracy decoded)
         {
             try
             {
@@ -83,10 +83,10 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, out Rfc3161Accuracy decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, out Rfc3161Accuracy decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
 
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(Asn1Tag.Integer))

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TimeStampReq.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TimeStampReq.xml.cs
@@ -25,9 +25,9 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         static Rfc3161TimeStampReq()
         {
             Rfc3161TimeStampReq decoded = default;
-            AsnValueReader reader;
+            ValueAsnReader reader;
 
-            reader = new AsnValueReader(DefaultCertReq, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultCertReq, AsnEncodingRules.DER);
             decoded.CertReq = reader.ReadBoolean();
             reader.ThrowIfNotEmpty();
         }
@@ -101,7 +101,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out Rfc3161TimeStampReq decoded);
                 reader.ThrowIfNotEmpty();
@@ -113,12 +113,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out Rfc3161TimeStampReq decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out Rfc3161TimeStampReq decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rfc3161TimeStampReq decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rfc3161TimeStampReq decoded)
         {
             try
             {
@@ -130,12 +130,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rfc3161TimeStampReq decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rfc3161TimeStampReq decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader defaultReader;
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader defaultReader;
+            ValueAsnReader collectionReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;
@@ -167,7 +167,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultCertReq, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultCertReq, AsnEncodingRules.DER);
                 decoded.CertReq = defaultReader.ReadBoolean();
             }
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TimeStampResp.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TimeStampResp.xml.cs
@@ -49,7 +49,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out Rfc3161TimeStampResp decoded);
                 reader.ThrowIfNotEmpty();
@@ -61,12 +61,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out Rfc3161TimeStampResp decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out Rfc3161TimeStampResp decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rfc3161TimeStampResp decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rfc3161TimeStampResp decoded)
         {
             try
             {
@@ -78,10 +78,10 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rfc3161TimeStampResp decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rfc3161TimeStampResp decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TstInfo.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TstInfo.xml.cs
@@ -29,9 +29,9 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         static Rfc3161TstInfo()
         {
             Rfc3161TstInfo decoded = default;
-            AsnValueReader reader;
+            ValueAsnReader reader;
 
-            reader = new AsnValueReader(DefaultOrdering, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultOrdering, AsnEncodingRules.DER);
             decoded.Ordering = reader.ReadBoolean();
             reader.ThrowIfNotEmpty();
         }
@@ -116,7 +116,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out Rfc3161TstInfo decoded);
                 reader.ThrowIfNotEmpty();
@@ -128,12 +128,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out Rfc3161TstInfo decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out Rfc3161TstInfo decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rfc3161TstInfo decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rfc3161TstInfo decoded)
         {
             try
             {
@@ -145,13 +145,13 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rfc3161TstInfo decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out Rfc3161TstInfo decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
-            AsnValueReader defaultReader;
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
+            ValueAsnReader defaultReader;
+            ValueAsnReader collectionReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;
@@ -183,7 +183,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultOrdering, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultOrdering, AsnEncodingRules.DER);
                 decoded.Ordering = defaultReader.ReadBoolean();
             }
 

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SignedAttributesSet.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SignedAttributesSet.xml.cs
@@ -62,7 +62,7 @@ namespace System.Security.Cryptography.Pkcs
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, encoded, out SignedAttributesSet decoded);
                 reader.ThrowIfNotEmpty();
@@ -74,7 +74,7 @@ namespace System.Security.Cryptography.Pkcs
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out SignedAttributesSet decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out SignedAttributesSet decoded)
         {
             try
             {
@@ -86,11 +86,11 @@ namespace System.Security.Cryptography.Pkcs
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out SignedAttributesSet decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out SignedAttributesSet decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();
-            AsnValueReader collectionReader;
+            ValueAsnReader collectionReader;
 
             if (tag.HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 0)))
             {

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SigningCertificateAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SigningCertificateAsn.xml.cs
@@ -57,7 +57,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out SigningCertificateAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -69,12 +69,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out SigningCertificateAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out SigningCertificateAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SigningCertificateAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SigningCertificateAsn decoded)
         {
             try
             {
@@ -86,11 +86,11 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SigningCertificateAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SigningCertificateAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader collectionReader;
 
 
             // Decode SEQUENCE OF for Certs

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SigningCertificateV2Asn.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/SigningCertificateV2Asn.xml.cs
@@ -57,7 +57,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out SigningCertificateV2Asn decoded);
                 reader.ThrowIfNotEmpty();
@@ -69,12 +69,12 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out SigningCertificateV2Asn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out SigningCertificateV2Asn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SigningCertificateV2Asn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SigningCertificateV2Asn decoded)
         {
             try
             {
@@ -86,11 +86,11 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SigningCertificateV2Asn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out SigningCertificateV2Asn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader collectionReader;
 
 
             // Decode SEQUENCE OF for Certs

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Rfc3161TimestampRequest.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Rfc3161TimestampRequest.cs
@@ -84,7 +84,7 @@ namespace System.Security.Cryptography.Pkcs
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(source.Span, AsnEncodingRules.DER);
+                ValueAsnReader reader = new ValueAsnReader(source.Span, AsnEncodingRules.DER);
                 int localBytesRead = reader.PeekEncodedValue().Length;
 
                 Rfc3161TimeStampResp.Decode(ref reader, source, out resp);
@@ -353,7 +353,7 @@ namespace System.Security.Cryptography.Pkcs
                 // Since nothing says BER, assume DER only.
                 const AsnEncodingRules RuleSet = AsnEncodingRules.DER;
 
-                AsnValueReader reader = new AsnValueReader(encodedBytes.Span, RuleSet);
+                ValueAsnReader reader = new ValueAsnReader(encodedBytes.Span, RuleSet);
                 ReadOnlySpan<byte> firstElement = reader.PeekEncodedValue();
 
                 Rfc3161TimeStampReq.Decode(ref reader, encodedBytes, out Rfc3161TimeStampReq req);

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Rfc3161TimestampToken.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Rfc3161TimestampToken.cs
@@ -294,7 +294,7 @@ namespace System.Security.Cryptography.Pkcs
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(encodedBytes.Span, AsnEncodingRules.BER);
+                ValueAsnReader reader = new ValueAsnReader(encodedBytes.Span, AsnEncodingRules.BER);
                 int bytesActuallyRead = reader.PeekEncodedValue().Length;
 
                 ContentInfoAsn.Decode(

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
@@ -216,7 +216,7 @@ namespace System.Security.Cryptography.Pkcs
                     {
                         using (var manager = new PointerMemoryManager<byte>(pin, encodedMessage.Length))
                         {
-                            AsnValueReader reader = new AsnValueReader(encodedMessage, AsnEncodingRules.BER);
+                            ValueAsnReader reader = new ValueAsnReader(encodedMessage, AsnEncodingRules.BER);
 
                             // Windows (and thus NetFx) reads the leading data and ignores extra.
                             // So use the Decode overload which doesn't throw on extra data.

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AsnFormatter.Managed.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/AsnFormatter.Managed.cs
@@ -41,8 +41,8 @@ namespace System.Security.Cryptography
             try
             {
                 StringBuilder output = new StringBuilder();
-                AsnValueReader reader = new AsnValueReader(rawData, AsnEncodingRules.DER);
-                AsnValueReader collectionReader = reader.ReadSequence();
+                ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.DER);
+                ValueAsnReader collectionReader = reader.ReadSequence();
 
                 reader.ThrowIfNotEmpty();
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Helpers.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/Helpers.cs
@@ -277,7 +277,7 @@ namespace Internal.Cryptography
             try
             {
                 Asn1Tag tag;
-                AsnValueReader reader = new AsnValueReader(encodedValue, AsnEncodingRules.DER);
+                ValueAsnReader reader = new ValueAsnReader(encodedValue, AsnEncodingRules.DER);
 
                 while (reader.HasData)
                 {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AndroidCertificatePal.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AndroidCertificatePal.cs
@@ -148,7 +148,7 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     using (PointerMemoryManager<byte> manager = new(rawDataPtr, rawData.Length))
                     {
-                        AsnValueReader reader = new AsnValueReader(rawData, AsnEncodingRules.DER);
+                        ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.DER);
                         CertificateAsn.Decode(ref reader, manager.Memory, out _);
                     }
                 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.iOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.iOS.cs
@@ -23,7 +23,7 @@ namespace System.Security.Cryptography.X509Certificates
                         using (var manager = new PointerMemoryManager<byte>(pin, rawData.Length))
                         {
                             // Permit trailing data after the PKCS12.
-                            AsnValueReader reader = new AsnValueReader(rawData, AsnEncodingRules.BER);
+                            ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.BER);
                             PfxAsn.Decode(ref reader, manager.Memory, out _);
                         }
 
@@ -48,7 +48,7 @@ namespace System.Security.Cryptography.X509Certificates
                     {
                         using (var manager = new PointerMemoryManager<byte>(pin, rawData.Length))
                         {
-                            AsnValueReader reader = new AsnValueReader(rawData, AsnEncodingRules.BER);
+                            ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.BER);
 
                             ContentInfoAsn.Decode(ref reader, manager.Memory, out ContentInfoAsn contentInfo);
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/AccessDescriptionAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/AccessDescriptionAsn.xml.cs
@@ -44,7 +44,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out AccessDescriptionAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -56,12 +56,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out AccessDescriptionAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out AccessDescriptionAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out AccessDescriptionAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out AccessDescriptionAsn decoded)
         {
             try
             {
@@ -73,10 +73,10 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out AccessDescriptionAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out AccessDescriptionAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
             decoded.AccessMethod = sequenceReader.ReadObjectIdentifier();
             System.Security.Cryptography.Asn1.GeneralNameAsn.Decode(ref sequenceReader, rebind, out decoded.AccessLocation);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/BasicConstraintsAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/BasicConstraintsAsn.xml.cs
@@ -20,9 +20,9 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         static BasicConstraintsAsn()
         {
             BasicConstraintsAsn decoded = default;
-            AsnValueReader reader;
+            ValueAsnReader reader;
 
-            reader = new AsnValueReader(DefaultCA, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultCA, AsnEncodingRules.DER);
             decoded.CA = reader.ReadBoolean();
             reader.ThrowIfNotEmpty();
         }
@@ -68,7 +68,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, out BasicConstraintsAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -80,12 +80,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, out BasicConstraintsAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, out BasicConstraintsAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, out BasicConstraintsAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, out BasicConstraintsAsn decoded)
         {
             try
             {
@@ -97,11 +97,11 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, out BasicConstraintsAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, out BasicConstraintsAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader defaultReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader defaultReader;
 
 
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(Asn1Tag.Boolean))
@@ -110,7 +110,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultCA, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultCA, AsnEncodingRules.DER);
                 decoded.CA = defaultReader.ReadBoolean();
             }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/CertificateAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/CertificateAsn.xml.cs
@@ -39,7 +39,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out CertificateAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -51,12 +51,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out CertificateAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out CertificateAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertificateAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertificateAsn decoded)
         {
             try
             {
@@ -68,10 +68,10 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertificateAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertificateAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/CertificatePolicyMappingAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/CertificatePolicyMappingAsn.xml.cs
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, out CertificatePolicyMappingAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -63,12 +63,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, out CertificatePolicyMappingAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, out CertificatePolicyMappingAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, out CertificatePolicyMappingAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, out CertificatePolicyMappingAsn decoded)
         {
             try
             {
@@ -80,10 +80,10 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, out CertificatePolicyMappingAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, out CertificatePolicyMappingAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
             decoded.IssuerDomainPolicy = sequenceReader.ReadObjectIdentifier();
             decoded.SubjectDomainPolicy = sequenceReader.ReadObjectIdentifier();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/CertificateTemplateAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/CertificateTemplateAsn.xml.cs
@@ -51,7 +51,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, out CertificateTemplateAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -63,12 +63,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, out CertificateTemplateAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, out CertificateTemplateAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, out CertificateTemplateAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, out CertificateTemplateAsn decoded)
         {
             try
             {
@@ -80,10 +80,10 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, out CertificateTemplateAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, out CertificateTemplateAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
             decoded.TemplateID = sequenceReader.ReadObjectIdentifier();
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/CertificationRequestAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/CertificationRequestAsn.xml.cs
@@ -39,7 +39,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out CertificationRequestAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -51,12 +51,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out CertificationRequestAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out CertificationRequestAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertificationRequestAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertificationRequestAsn decoded)
         {
             try
             {
@@ -68,10 +68,10 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertificationRequestAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertificationRequestAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/CertificationRequestInfoAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/CertificationRequestInfoAsn.xml.cs
@@ -65,7 +65,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out CertificationRequestInfoAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -77,12 +77,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out CertificationRequestInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out CertificationRequestInfoAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertificationRequestInfoAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertificationRequestInfoAsn decoded)
         {
             try
             {
@@ -94,11 +94,11 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertificationRequestInfoAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out CertificationRequestInfoAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader collectionReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/DistributionPointAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/DistributionPointAsn.xml.cs
@@ -64,7 +64,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out DistributionPointAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -76,12 +76,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out DistributionPointAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out DistributionPointAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out DistributionPointAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out DistributionPointAsn decoded)
         {
             try
             {
@@ -93,12 +93,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out DistributionPointAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out DistributionPointAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
+            ValueAsnReader collectionReader;
 
 
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 0)))

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/DistributionPointNameAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/DistributionPointNameAsn.xml.cs
@@ -89,7 +89,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, encoded, out DistributionPointNameAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -101,7 +101,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out DistributionPointNameAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out DistributionPointNameAsn decoded)
         {
             try
             {
@@ -113,11 +113,11 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out DistributionPointNameAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out DistributionPointNameAsn decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();
-            AsnValueReader collectionReader;
+            ValueAsnReader collectionReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/PolicyConstraintsAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/PolicyConstraintsAsn.xml.cs
@@ -47,7 +47,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, out PolicyConstraintsAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -59,12 +59,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, out PolicyConstraintsAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, out PolicyConstraintsAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, out PolicyConstraintsAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, out PolicyConstraintsAsn decoded)
         {
             try
             {
@@ -76,10 +76,10 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, out PolicyConstraintsAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, out PolicyConstraintsAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
 
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 0)))

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/PolicyInformationAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/PolicyInformationAsn.xml.cs
@@ -56,7 +56,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out PolicyInformationAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -68,12 +68,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out PolicyInformationAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out PolicyInformationAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PolicyInformationAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PolicyInformationAsn decoded)
         {
             try
             {
@@ -85,10 +85,10 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PolicyInformationAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out PolicyInformationAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/TbsCertificateAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/TbsCertificateAsn.xml.cs
@@ -29,9 +29,9 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         static TbsCertificateAsn()
         {
             TbsCertificateAsn decoded = default;
-            AsnValueReader reader;
+            ValueAsnReader reader;
 
-            reader = new AsnValueReader(DefaultVersion, AsnEncodingRules.DER);
+            reader = new ValueAsnReader(DefaultVersion, AsnEncodingRules.DER);
 
             if (!reader.TryReadInt32(out decoded.Version))
             {
@@ -143,7 +143,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, encoded, out TbsCertificateAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -155,12 +155,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, ReadOnlyMemory<byte> rebind, out TbsCertificateAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, ReadOnlyMemory<byte> rebind, out TbsCertificateAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, rebind, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out TbsCertificateAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out TbsCertificateAsn decoded)
         {
             try
             {
@@ -172,13 +172,13 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out TbsCertificateAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, ReadOnlyMemory<byte> rebind, out TbsCertificateAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
-            AsnValueReader explicitReader;
-            AsnValueReader defaultReader;
-            AsnValueReader collectionReader;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
+            ValueAsnReader defaultReader;
+            ValueAsnReader collectionReader;
             ReadOnlySpan<byte> rebindSpan = rebind.Span;
             int offset;
             ReadOnlySpan<byte> tmpSpan;
@@ -197,7 +197,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
             else
             {
-                defaultReader = new AsnValueReader(DefaultVersion, AsnEncodingRules.DER);
+                defaultReader = new ValueAsnReader(DefaultVersion, AsnEncodingRules.DER);
 
                 if (!defaultReader.TryReadInt32(out decoded.Version))
                 {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/TimeAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/TimeAsn.xml.cs
@@ -65,7 +65,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, out TimeAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, out TimeAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, out TimeAsn decoded)
         {
             try
             {
@@ -89,7 +89,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, out TimeAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, out TimeAsn decoded)
         {
             decoded = default;
             Asn1Tag tag = reader.PeekTag();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/ValidityAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/ValidityAsn.xml.cs
@@ -37,7 +37,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded.Span, ruleSet);
+                ValueAsnReader reader = new ValueAsnReader(encoded.Span, ruleSet);
 
                 DecodeCore(ref reader, expectedTag, out ValidityAsn decoded);
                 reader.ThrowIfNotEmpty();
@@ -49,12 +49,12 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(ref AsnValueReader reader, out ValidityAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, out ValidityAsn decoded)
         {
             Decode(ref reader, Asn1Tag.Sequence, out decoded);
         }
 
-        internal static void Decode(ref AsnValueReader reader, Asn1Tag expectedTag, out ValidityAsn decoded)
+        internal static void Decode(ref ValueAsnReader reader, Asn1Tag expectedTag, out ValidityAsn decoded)
         {
             try
             {
@@ -66,10 +66,10 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(ref AsnValueReader reader, Asn1Tag expectedTag, out ValidityAsn decoded)
+        private static void DecodeCore(ref ValueAsnReader reader, Asn1Tag expectedTag, out ValidityAsn decoded)
         {
             decoded = default;
-            AsnValueReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
             System.Security.Cryptography.X509Certificates.Asn1.TimeAsn.Decode(ref sequenceReader, out decoded.NotBefore);
             System.Security.Cryptography.X509Certificates.Asn1.TimeAsn.Decode(ref sequenceReader, out decoded.NotAfter);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateData.ManagedDecode.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateData.ManagedDecode.cs
@@ -77,7 +77,7 @@ namespace System.Security.Cryptography.X509Certificates
 #endif
             // Windows and Unix permit trailing data after the DER contents of the certificate, so we will allow
             // it here, too.
-            AsnValueReader reader = new AsnValueReader(rawData, AsnEncodingRules.DER);
+            ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.DER);
             ReadOnlySpan<byte> encodedValue = reader.PeekEncodedValue();
 
             CertificateAsn.Decode(ref reader, rawData, out certificate);
@@ -280,8 +280,8 @@ namespace System.Security.Cryptography.X509Certificates
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(extensionBytes, AsnEncodingRules.DER);
-                AsnValueReader sequenceReader = reader.ReadSequence();
+                ValueAsnReader reader = new ValueAsnReader(extensionBytes, AsnEncodingRules.DER);
+                ValueAsnReader sequenceReader = reader.ReadSequence();
                 reader.ThrowIfNotEmpty();
 
                 while (sequenceReader.HasData)
@@ -296,7 +296,7 @@ namespace System.Security.Cryptography.X509Certificates
                             {
                                 // Currently only UPN is supported, which is a UTF8 string per
                                 // https://msdn.microsoft.com/en-us/library/ff842518.aspx
-                                AsnValueReader nameReader = new AsnValueReader(
+                                ValueAsnReader nameReader = new ValueAsnReader(
                                     generalName.OtherName.Value.Value.Span,
                                     AsnEncodingRules.DER);
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePolicy.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificatePolicy.cs
@@ -289,7 +289,7 @@ namespace System.Security.Cryptography.X509Certificates
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(rawData, AsnEncodingRules.DER);
+                ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.DER);
                 int inhibitAnyPolicy;
                 reader.TryReadInt32(out inhibitAnyPolicy);
                 reader.ThrowIfNotEmpty();
@@ -317,8 +317,8 @@ namespace System.Security.Cryptography.X509Certificates
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(rawData, AsnEncodingRules.DER);
-                AsnValueReader sequenceReader = reader.ReadSequence();
+                ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.DER);
+                ValueAsnReader sequenceReader = reader.ReadSequence();
                 reader.ThrowIfNotEmpty();
 
                 //OidCollection usages
@@ -339,8 +339,8 @@ namespace System.Security.Cryptography.X509Certificates
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(rawData, AsnEncodingRules.DER);
-                AsnValueReader sequenceReader = reader.ReadSequence();
+                ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.DER);
+                ValueAsnReader sequenceReader = reader.ReadSequence();
                 reader.ThrowIfNotEmpty();
 
                 HashSet<string> policies = new HashSet<string>();
@@ -368,8 +368,8 @@ namespace System.Security.Cryptography.X509Certificates
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(rawData, AsnEncodingRules.DER);
-                AsnValueReader sequenceReader = reader.ReadSequence();
+                ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.DER);
+                ValueAsnReader sequenceReader = reader.ReadSequence();
                 reader.ThrowIfNotEmpty();
 
                 List<CertificatePolicyMappingAsn> mappings = new List<CertificatePolicyMappingAsn>();

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRequest.Load.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRequest.Load.cs
@@ -138,10 +138,10 @@ namespace System.Security.Cryptography.X509Certificates
 
             try
             {
-                AsnValueReader outer = new AsnValueReader(pkcs10, AsnEncodingRules.DER);
+                ValueAsnReader outer = new ValueAsnReader(pkcs10, AsnEncodingRules.DER);
                 int encodedLength = outer.PeekEncodedValue().Length;
 
-                AsnValueReader pkcs10Asn = outer.ReadSequence();
+                ValueAsnReader pkcs10Asn = outer.ReadSequence();
                 CertificateRequest req;
 
                 if (!permitTrailingData)
@@ -230,11 +230,11 @@ namespace System.Security.Cryptography.X509Certificates
                                             SR.Cryptography_CertReq_Load_DuplicateExtensionRequests);
                                     }
 
-                                    AsnValueReader extsReader = new AsnValueReader(
+                                    ValueAsnReader extsReader = new ValueAsnReader(
                                         attr.AttrValues[0].Span,
                                         AsnEncodingRules.DER);
 
-                                    AsnValueReader exts = extsReader.ReadSequence();
+                                    ValueAsnReader exts = extsReader.ReadSequence();
                                     extsReader.ThrowIfNotEmpty();
 
                                     // Minimum length is 1, so do..while

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRevocationListBuilder.Load.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRevocationListBuilder.Load.cs
@@ -91,11 +91,11 @@ namespace System.Security.Cryptography.X509Certificates
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(currentCrl, AsnEncodingRules.DER);
+                ValueAsnReader reader = new ValueAsnReader(currentCrl, AsnEncodingRules.DER);
                 payloadLength = reader.PeekEncodedValue().Length;
 
-                AsnValueReader certificateList = reader.ReadSequence();
-                AsnValueReader tbsCertList = certificateList.ReadSequence();
+                ValueAsnReader certificateList = reader.ReadSequence();
+                ValueAsnReader tbsCertList = certificateList.ReadSequence();
                 AlgorithmIdentifierAsn.Decode(ref certificateList, ReadOnlyMemory<byte>.Empty, out _);
 
                 if (!certificateList.TryReadPrimitiveBitString(out _, out _))
@@ -130,7 +130,7 @@ namespace System.Security.Cryptography.X509Certificates
                 // nextUpdate
                 ReadX509TimeOpt(ref tbsCertList);
 
-                AsnValueReader revokedCertificates = default;
+                ValueAsnReader revokedCertificates = default;
 
                 if (tbsCertList.HasData && tbsCertList.PeekTag().HasSameClassAndValue(Asn1Tag.Sequence))
                 {
@@ -139,13 +139,13 @@ namespace System.Security.Cryptography.X509Certificates
 
                 if (version > 0 && tbsCertList.HasData)
                 {
-                    AsnValueReader crlExtensionsExplicit = tbsCertList.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
-                    AsnValueReader crlExtensions = crlExtensionsExplicit.ReadSequence();
+                    ValueAsnReader crlExtensionsExplicit = tbsCertList.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+                    ValueAsnReader crlExtensions = crlExtensionsExplicit.ReadSequence();
                     crlExtensionsExplicit.ThrowIfNotEmpty();
 
                     while (crlExtensions.HasData)
                     {
-                        AsnValueReader extension = crlExtensions.ReadSequence();
+                        ValueAsnReader extension = crlExtensions.ReadSequence();
                         Oid? extnOid = Oids.GetSharedOrNullOid(ref extension);
 
                         if (extnOid is null)
@@ -169,7 +169,7 @@ namespace System.Security.Cryptography.X509Certificates
                         // the ReferenceEquals or will evaulate to false).
                         if (ReferenceEquals(extnOid, Oids.CrlNumberOid))
                         {
-                            AsnValueReader crlNumberReader = new AsnValueReader(
+                            ValueAsnReader crlNumberReader = new ValueAsnReader(
                                 extnValue,
                                 AsnEncodingRules.DER);
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRevocationListBuilder.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRevocationListBuilder.cs
@@ -257,7 +257,7 @@ namespace System.Security.Cryptography.X509Certificates
             return false;
         }
 
-        private static DateTimeOffset ReadX509Time(ref AsnValueReader reader)
+        private static DateTimeOffset ReadX509Time(ref ValueAsnReader reader)
         {
             if (reader.PeekTag().HasSameClassAndValue(Asn1Tag.UtcTime))
             {
@@ -267,7 +267,7 @@ namespace System.Security.Cryptography.X509Certificates
             return reader.ReadGeneralizedTime();
         }
 
-        private static DateTimeOffset? ReadX509TimeOpt(ref AsnValueReader reader)
+        private static DateTimeOffset? ReadX509TimeOpt(ref ValueAsnReader reader)
         {
             if (reader.PeekTag().HasSameClassAndValue(Asn1Tag.UtcTime))
             {
@@ -303,9 +303,9 @@ namespace System.Security.Cryptography.X509Certificates
             internal DateTimeOffset RevocationTime;
             internal byte[]? Extensions;
 
-            internal RevokedCertificate(ref AsnValueReader reader, int version)
+            internal RevokedCertificate(ref ValueAsnReader reader, int version)
             {
-                AsnValueReader revokedCertificate = reader.ReadSequence();
+                ValueAsnReader revokedCertificate = reader.ReadSequence();
                 Serial = revokedCertificate.ReadIntegerBytes().ToArray();
                 RevocationTime = ReadX509Time(ref revokedCertificate);
                 Extensions = null;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslCrlCache.cs
@@ -424,8 +424,8 @@ namespace System.Security.Cryptography.X509Certificates
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(crlDistributionPoints, AsnEncodingRules.DER);
-                AsnValueReader sequenceReader = reader.ReadSequence();
+                ValueAsnReader reader = new ValueAsnReader(crlDistributionPoints, AsnEncodingRules.DER);
+                ValueAsnReader sequenceReader = reader.ReadSequence();
                 reader.ThrowIfNotEmpty();
 
                 while (sequenceReader.HasData)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/OpenSslX509ChainProcessor.cs
@@ -1219,8 +1219,8 @@ namespace System.Security.Cryptography.X509Certificates
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(authorityInformationAccess.Span, AsnEncodingRules.DER);
-                AsnValueReader sequenceReader = reader.ReadSequence();
+                ValueAsnReader reader = new ValueAsnReader(authorityInformationAccess.Span, AsnEncodingRules.DER);
+                ValueAsnReader sequenceReader = reader.ReadSequence();
                 reader.ThrowIfNotEmpty();
 
                 while (sequenceReader.HasData)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
@@ -460,7 +460,7 @@ namespace System.Security.Cryptography.X509Certificates
             fixed (byte* ptr = &MemoryMarshal.GetReference(source))
             using (MemoryManager<byte> manager = new PointerMemoryManager<byte>(ptr, source.Length))
             {
-                AsnValueReader reader = new AsnValueReader(source, AsnEncodingRules.DER);
+                ValueAsnReader reader = new ValueAsnReader(source, AsnEncodingRules.DER);
 
                 int read;
                 SubjectPublicKeyInfoAsn spki;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500DirectoryStringHelper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500DirectoryStringHelper.cs
@@ -34,7 +34,7 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        internal static string ReadAnyAsnString(ref this AsnValueReader tavReader)
+        internal static string ReadAnyAsnString(ref this ValueAsnReader tavReader)
         {
             Asn1Tag tag = tavReader.PeekTag();
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500DistinguishedName.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500DistinguishedName.cs
@@ -131,8 +131,8 @@ namespace System.Security.Cryptography.X509Certificates
 
             try
             {
-                AsnValueReader outer = new AsnValueReader(rawDataSpan, AsnEncodingRules.DER);
-                AsnValueReader sequence = outer.ReadSequence();
+                ValueAsnReader outer = new ValueAsnReader(rawDataSpan, AsnEncodingRules.DER);
+                ValueAsnReader sequence = outer.ReadSequence();
                 outer.ThrowIfNotEmpty();
 
                 while (sequence.HasData)
@@ -141,7 +141,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                     if (!rawDataSpan.Overlaps(encodedValue, out int offset))
                     {
-                        Debug.Fail("AsnValueReader produced a span outside of the original bounds");
+                        Debug.Fail("ValueAsnReader produced a span outside of the original bounds");
                         throw new UnreachableException();
                     }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500RelativeDistinguishedName.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500RelativeDistinguishedName.cs
@@ -28,11 +28,11 @@ namespace System.Security.Cryptography.X509Certificates
             RawData = rawData;
 
             ReadOnlySpan<byte> rawDataSpan = rawData.Span;
-            AsnValueReader outer = new AsnValueReader(rawDataSpan, AsnEncodingRules.DER);
+            ValueAsnReader outer = new ValueAsnReader(rawDataSpan, AsnEncodingRules.DER);
 
             // Windows does not enforce the sort order on multi-value RDNs.
-            AsnValueReader rdn = outer.ReadSetOf(skipSortOrderValidation: true);
-            AsnValueReader typeAndValue = rdn.ReadSequence();
+            ValueAsnReader rdn = outer.ReadSetOf(skipSortOrderValidation: true);
+            ValueAsnReader typeAndValue = rdn.ReadSequence();
 
             Oid firstType = Oids.GetSharedOrNewOid(ref typeAndValue);
             ReadOnlySpan<byte> firstValue = typeAndValue.ReadEncodedValue();
@@ -61,7 +61,7 @@ namespace System.Security.Cryptography.X509Certificates
                 _singleElementType = firstType;
 
                 bool overlaps = rawDataSpan.Overlaps(firstValue, out int offset);
-                Debug.Assert(overlaps, "AsnValueReader.ReadEncodedValue returns a slice of the source");
+                Debug.Assert(overlaps, "ValueAsnReader.ReadEncodedValue returns a slice of the source");
                 Debug.Assert(offset > 0);
 
                 _singleElementValue = rawData.Slice(offset, firstValue.Length);
@@ -127,7 +127,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(_singleElementValue.Span, AsnEncodingRules.DER);
+                ValueAsnReader reader = new ValueAsnReader(_singleElementValue.Span, AsnEncodingRules.DER);
                 Asn1Tag tag = reader.PeekTag();
 
                 if (tag.TagClass == TagClass.Universal)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509AuthorityInformationAccessExtension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509AuthorityInformationAccessExtension.cs
@@ -237,12 +237,12 @@ namespace System.Security.Cryptography.X509Certificates
         {
             try
             {
-                AsnValueReader reader = new AsnValueReader(authorityInfoAccessSyntax, AsnEncodingRules.DER);
-                AsnValueReader descriptions = reader.ReadSequence();
+                ValueAsnReader reader = new ValueAsnReader(authorityInfoAccessSyntax, AsnEncodingRules.DER);
+                ValueAsnReader descriptions = reader.ReadSequence();
                 reader.ThrowIfNotEmpty();
 
                 int count = 0;
-                AsnValueReader counter = descriptions;
+                ValueAsnReader counter = descriptions;
 
                 while (counter.HasData)
                 {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509AuthorityKeyIdentifierExtension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509AuthorityKeyIdentifierExtension.cs
@@ -514,8 +514,8 @@ namespace System.Security.Cryptography.X509Certificates
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(rawData, AsnEncodingRules.DER);
-                AsnValueReader aki = reader.ReadSequence();
+                ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.DER);
+                ValueAsnReader aki = reader.ReadSequence();
                 reader.ThrowIfNotEmpty();
 
                 Asn1Tag nextTag = default;
@@ -540,7 +540,7 @@ namespace System.Security.Cryptography.X509Certificates
                     byte[] rawIssuer = aki.PeekEncodedValue().ToArray();
                     _rawIssuer = rawIssuer;
 
-                    AsnValueReader generalNames = aki.ReadSequence(nextTag);
+                    ValueAsnReader generalNames = aki.ReadSequence(nextTag);
                     bool foundIssuer = false;
 
                     // Walk all of the entities to make sure they decode legally, so no early abort.

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -1835,9 +1835,9 @@ namespace System.Security.Cryptography.X509Certificates
                 {
                     if (rdn.HasMultipleElements)
                     {
-                        AsnValueReader reader = new AsnValueReader(rdn.RawData.Span, AsnEncodingRules.DER);
+                        ValueAsnReader reader = new ValueAsnReader(rdn.RawData.Span, AsnEncodingRules.DER);
                         // Be lax with the sort order because Windows is
-                        AsnValueReader set = reader.ReadSetOf(skipSortOrderValidation: true);
+                        ValueAsnReader set = reader.ReadSetOf(skipSortOrderValidation: true);
 
                         while (set.HasData)
                         {
@@ -1845,7 +1845,7 @@ namespace System.Security.Cryptography.X509Certificates
                             // is malformed here, because X500RelativeDistinguishedName already ensures it.
                             // So we don't bother checking that there's a value after the OID and then nothing
                             // after that.
-                            AsnValueReader attributeTypeAndValue = set.ReadSequence();
+                            ValueAsnReader attributeTypeAndValue = set.ReadSequence();
                             Oid? type = Oids.GetSharedOrNullOid(ref attributeTypeAndValue);
 
                             if (Oids.CommonNameOid.ValueEquals(type))

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Android.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Android.cs
@@ -116,7 +116,7 @@ namespace System.Security.Cryptography.X509Certificates
         {
             ReadOnlySpan<byte> span = data.Span;
 
-            AsnValueReader reader = new AsnValueReader(span, AsnEncodingRules.DER);
+            ValueAsnReader reader = new ValueAsnReader(span, AsnEncodingRules.DER);
             reader.ReadSequence();
             reader.ThrowIfNotEmpty();
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Unix.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Unix.cs
@@ -131,7 +131,7 @@ namespace System.Security.Cryptography.X509Certificates
                     try
                     {
                         ReadOnlyMemory<byte> memory = manager.Memory;
-                        AsnValueReader reader = new AsnValueReader(memory.Span, AsnEncodingRules.BER);
+                        ValueAsnReader reader = new ValueAsnReader(memory.Span, AsnEncodingRules.BER);
                         PfxAsn.Decode(ref reader, memory, out _);
                         return true;
                     }
@@ -157,7 +157,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 ReadOnlyMemory<byte> memory = manager?.Memory ?? new ReadOnlyMemory<byte>(rented, 0, length);
 
-                AsnValueReader reader = new AsnValueReader(memory.Span, AsnEncodingRules.BER);
+                ValueAsnReader reader = new ValueAsnReader(memory.Span, AsnEncodingRules.BER);
                 PfxAsn.Decode(ref reader, memory, out _);
                 return true;
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.iOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.iOS.cs
@@ -128,7 +128,7 @@ namespace System.Security.Cryptography.X509Certificates
         {
             ReadOnlySpan<byte> span = data.Span;
 
-            AsnValueReader reader = new AsnValueReader(span, AsnEncodingRules.DER);
+            ValueAsnReader reader = new ValueAsnReader(span, AsnEncodingRules.DER);
             reader.ReadSequence();
             reader.ThrowIfNotEmpty();
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.macOS.cs
@@ -183,7 +183,7 @@ namespace System.Security.Cryptography.X509Certificates
         {
             ReadOnlySpan<byte> span = data.Span;
 
-            AsnValueReader reader = new AsnValueReader(span, AsnEncodingRules.DER);
+            ValueAsnReader reader = new ValueAsnReader(span, AsnEncodingRules.DER);
             reader.ReadSequence();
             reader.ThrowIfNotEmpty();
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509KeyUsageExtension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509KeyUsageExtension.cs
@@ -67,7 +67,7 @@ namespace System.Security.Cryptography.X509Certificates
 
             try
             {
-                AsnValueReader reader = new AsnValueReader(encoded, AsnEncodingRules.BER);
+                ValueAsnReader reader = new ValueAsnReader(encoded, AsnEncodingRules.BER);
                 keyUsagesAsn = reader.ReadNamedBitListValue<KeyUsageFlagsAsn>();
                 reader.ThrowIfNotEmpty();
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.macOS.cs
@@ -81,7 +81,7 @@ namespace System.Security.Cryptography.X509Certificates
                         {
                             fixed (byte* pin = rawData)
                             {
-                                AsnValueReader reader = new AsnValueReader(rawData, AsnEncodingRules.BER);
+                                ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.BER);
 
                                 using (var manager = new PointerMemoryManager<byte>(pin, rawData.Length))
                                 {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509SubjectAlternativeNameExtension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509SubjectAlternativeNameExtension.cs
@@ -107,8 +107,8 @@ namespace System.Security.Cryptography.X509Certificates
         {
             try
             {
-                AsnValueReader outer = new AsnValueReader(rawData, AsnEncodingRules.DER);
-                AsnValueReader sequence = outer.ReadSequence();
+                ValueAsnReader outer = new ValueAsnReader(rawData, AsnEncodingRules.DER);
+                ValueAsnReader sequence = outer.ReadSequence();
                 outer.ThrowIfNotEmpty();
 
                 List<GeneralNameAsn> decoded = new List<GeneralNameAsn>();

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestLoadTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/CertificateCreation/CertificateRequestLoadTests.cs
@@ -914,11 +914,11 @@ BgkqhkiG9w0BAQsFAAMBAA==
                     //      signatureAlgorithm   AlgorithmIdentifier,
                     //      signature            BIT STRING  }
 
-                    AsnValueReader readerOne = new AsnValueReader(one.RawDataMemory.Span, AsnEncodingRules.DER);
-                    AsnValueReader readerTwo = new AsnValueReader(two.RawDataMemory.Span, AsnEncodingRules.DER);
+                    ValueAsnReader readerOne = new ValueAsnReader(one.RawDataMemory.Span, AsnEncodingRules.DER);
+                    ValueAsnReader readerTwo = new ValueAsnReader(two.RawDataMemory.Span, AsnEncodingRules.DER);
 
-                    AsnValueReader certOne = readerOne.ReadSequence();
-                    AsnValueReader certTwo = readerTwo.ReadSequence();
+                    ValueAsnReader certOne = readerOne.ReadSequence();
+                    ValueAsnReader certTwo = readerTwo.ReadSequence();
                     readerOne.ThrowIfNotEmpty();
                     readerTwo.ThrowIfNotEmpty();
 

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/ExportTests.cs
@@ -939,8 +939,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Equal(Pkcs7Data, pfxAsn.AuthSafe.ContentType);
             byte[] safeContents = AsnDecoder.ReadOctetString(pfxAsn.AuthSafe.Content.Span, AsnEncodingRules.BER, out _);
 
-            AsnValueReader authSafeReader = new AsnValueReader(safeContents, AsnEncodingRules.BER);
-            AsnValueReader sequenceReader = authSafeReader.ReadSequence();
+            ValueAsnReader authSafeReader = new ValueAsnReader(safeContents, AsnEncodingRules.BER);
+            ValueAsnReader sequenceReader = authSafeReader.ReadSequence();
             authSafeReader.ThrowIfNotEmpty();
 
             int certs = 0;

--- a/src/libraries/System.Security.Cryptography/tests/X509Certificates/NameTests.cs
+++ b/src/libraries/System.Security.Cryptography/tests/X509Certificates/NameTests.cs
@@ -162,12 +162,12 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             X500DistinguishedName name = new(distinguishedName, X500DistinguishedNameFlags.ForceUTF8Encoding);
             byte[] encoded = name.RawData;
 
-            AsnValueReader reader = new(encoded, AsnEncodingRules.DER);
-            AsnValueReader component = reader.ReadSequence();
+            ValueAsnReader reader = new(encoded, AsnEncodingRules.DER);
+            ValueAsnReader component = reader.ReadSequence();
             reader.ThrowIfNotEmpty();
-            AsnValueReader rdn = component.ReadSetOf();
+            ValueAsnReader rdn = component.ReadSetOf();
             component.ThrowIfNotEmpty();
-            AsnValueReader value = rdn.ReadSequence();
+            ValueAsnReader value = rdn.ReadSequence();
             rdn.ThrowIfNotEmpty();
 
             value.ReadObjectIdentifier();


### PR DESCRIPTION
This implements `ValueAsnReader`, and replaces the old internal `AsnValueReader` with the new public one in some places.

This is not meant to be a comprehensive replacement of `AsnValueReader` yet, as that makes this pull request even more significant.

This pull request is broken up in to two commits: the new `ValueAsnReader` in the `System.Formats.Asn1` package along with the tests, and the second commit is using it in `asn.xslt`, and updating all files as required that use the `Asn`-suffixed types.

We can split this pull request in to two separate PRs if preferred. However I wanted to see some real usage of the new APIs in functional unit tests of other areas to help validate the shape / implementation.

Fully removing the internal `AsnValueReader` will be a follow up pull request.

Closes #109019.