### PR TITLE
Optimize HashSet intersecting

### DIFF
--- a/src/libraries/Common/src/System/Collections/Generic/BitHelper.cs
+++ b/src/libraries/Common/src/System/Collections/Generic/BitHelper.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
+using System.Numerics;
 
 namespace System.Collections.Generic
 {
@@ -33,6 +34,26 @@ namespace System.Collections.Generic
             }
         }
 
+        internal bool TryMarkBit(int bitPosition)
+        {
+            Debug.Assert(bitPosition >= 0);
+
+            uint bitArrayIndex = (uint)bitPosition / IntSize;
+
+            // Workaround for https://github.com/dotnet/runtime/issues/72004
+            Span<int> span = _span;
+            if (bitArrayIndex < (uint)span.Length)
+            {
+                int bits = span[(int)bitArrayIndex];
+                if ((bits & (1 << ((int)((uint)bitPosition % IntSize)))) == 0)
+                {
+                    span[(int)bitArrayIndex] = bits | (1 << ((int)((uint)bitPosition % IntSize)));
+                    return true;
+                }
+            }
+            return false;
+        }
+
         internal bool IsMarked(int bitPosition)
         {
             Debug.Assert(bitPosition >= 0);
@@ -46,7 +67,26 @@ namespace System.Collections.Generic
                 (span[(int)bitArrayIndex] & (1 << ((int)((uint)bitPosition % IntSize)))) != 0;
         }
 
+        internal bool IsUnmarked(int bitPosition)
+        {
+            Debug.Assert(bitPosition >= 0);
+
+            uint bitArrayIndex = (uint)bitPosition / IntSize;
+
+            // Workaround for https://github.com/dotnet/runtime/issues/72004
+            ReadOnlySpan<int> span = _span;
+            return
+                bitArrayIndex < (uint)span.Length &&
+                (span[(int)bitArrayIndex] & (1 << ((int)((uint)bitPosition % IntSize)))) == 0;
+        }
+
+        internal int FindFirstUnmarked()
+        {
+            int i = _span.IndexOfAnyExcept(~0);
+            return i < 0 ? -1 : i * IntSize + BitOperations.TrailingZeroCount(~_span[i]);
+        }
+
         /// <summary>How many ints must be allocated to represent n bits. Returns (n+31)/32, but avoids overflow.</summary>
-        internal static int ToIntArrayLength(int n) => n > 0 ? ((n - 1) / IntSize + 1) : 0;
+        internal static int ToIntArrayLength(int n) => (int)(((uint)n + 31) / IntSize);
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -406,49 +406,49 @@ namespace System.Collections.Generic
 
         private void RemoveAt(Entry[] entries, int removeIndex)
         {
-            uint collisionCount = 0;
-            int last = -1;
-            ref int bucket = ref GetBucketRef(entries[removeIndex].HashCode);
+            ref Entry entry = ref entries[removeIndex];
+            ref int bucket = ref GetBucketRef(entry.HashCode);
             int i = bucket - 1; // Value in buckets is 1-based
-
-            while (i >= 0)
+            if (i == removeIndex)
             {
-                ref Entry entry = ref entries[i];
-                if (i == removeIndex)
+                bucket = entry.Next + 1; // Value in buckets is 1-based
+            }
+            else
+            {
+                uint collisionCount = 0;
+                while (true)
                 {
-                    if (last < 0)
+                    if ((uint)i >= (uint)entries.Length)
                     {
-                        bucket = entry.Next + 1; // Value in buckets is 1-based
-                    }
-                    else
-                    {
-                        entries[last].Next = entry.Next;
+                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
                     }
 
-                    Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
-                    entry.Next = StartOfFreeList - _freeList;
-
-                    if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+                    ref Entry last = ref entries[i];
+                    i = last.Next;
+                    if (i == removeIndex)
                     {
-                        entry.Value = default!;
+                        last.Next = entry.Next;
+                        break;
                     }
 
-                    _freeList = i;
-                    _freeCount++;
-                    return;
-                }
-
-                last = i;
-                i = entry.Next;
-
-                if (++collisionCount > (uint)entries.Length)
-                {
-                    // The chain of entries forms a loop; which means a concurrent update has happened.
-                    // Break out of the loop and throw, rather than looping forever.
-                    break;
+                    if (++collisionCount > (uint)entries.Length)
+                    {
+                        // The chain of entries forms a loop; which means a concurrent update has happened.
+                        // Break out of the loop and throw, rather than looping forever.
+                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                    }
                 }
             }
-            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                entry.Value = default!;
+            }
+
+            Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
+            entry.Next = StartOfFreeList - _freeList;
+            _freeList = i;
+            _freeCount++;
         }
 
         /// <summary>Gets the number of elements that are contained in the set.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -277,6 +277,57 @@ namespace System.Collections.Generic
             return -1;
         }
 
+        private bool Contains(ref Entry item)
+        {
+            Entry[] entries = _entries!;
+            uint collisionCount = 0;
+            IEqualityComparer<T>? comparer = _comparer;
+
+            int hashCode = item.HashCode;
+            int i = GetBucketRef(hashCode) - 1; // Value in _buckets is 1-based
+
+            // comparer can only be null for value types; enable JIT to eliminate entire if block for ref types
+            if (typeof(T).IsValueType && comparer == null)
+            {
+                while (i >= 0)
+                {
+                    ref Entry entry = ref entries[i];
+                    if (entry.HashCode == hashCode && EqualityComparer<T>.Default.Equals(entry.Value, item.Value))
+                    {
+                        return true;
+                    }
+                    i = entry.Next;
+
+                    if (++collisionCount > (uint)entries.Length)
+                    {
+                        // The chain of entries forms a loop, which means a concurrent update has happened.
+                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                    }
+                }
+            }
+            else
+            {
+                Debug.Assert(comparer is not null);
+                while (i >= 0)
+                {
+                    ref Entry entry = ref entries[i];
+                    if (entry.HashCode == hashCode && comparer.Equals(entry.Value, item.Value))
+                    {
+                        return true;
+                    }
+                    i = entry.Next;
+
+                    if (++collisionCount > (uint)entries.Length)
+                    {
+                        // The chain of entries forms a loop, which means a concurrent update has happened.
+                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                    }
+                }
+            }
+
+            return false;
+        }
+
         /// <summary>Gets a reference to the specified hashcode's bucket, containing an index into <see cref="_entries"/>.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private ref int GetBucketRef(int hashCode)
@@ -351,6 +402,53 @@ namespace System.Collections.Generic
             }
 
             return false;
+        }
+
+        private void RemoveAt(Entry[] entries, int removeIndex)
+        {
+            uint collisionCount = 0;
+            int last = -1;
+            ref int bucket = ref GetBucketRef(entries[removeIndex].HashCode);
+            int i = bucket - 1; // Value in buckets is 1-based
+
+            while (i >= 0)
+            {
+                ref Entry entry = ref entries[i];
+                if (i == removeIndex)
+                {
+                    if (last < 0)
+                    {
+                        bucket = entry.Next + 1; // Value in buckets is 1-based
+                    }
+                    else
+                    {
+                        entries[last].Next = entry.Next;
+                    }
+
+                    Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
+                    entry.Next = StartOfFreeList - _freeList;
+
+                    if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+                    {
+                        entry.Value = default!;
+                    }
+
+                    _freeList = i;
+                    _freeCount++;
+                    return;
+                }
+
+                last = i;
+                i = entry.Next;
+
+                if (++collisionCount > (uint)entries.Length)
+                {
+                    // The chain of entries forms a loop; which means a concurrent update has happened.
+                    // Break out of the loop and throw, rather than looping forever.
+                    break;
+                }
+            }
+            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
         }
 
         /// <summary>Gets the number of elements that are contained in the set.</summary>
@@ -957,8 +1055,8 @@ namespace System.Collections.Generic
                 }
             }
 
-            (int uniqueCount, int unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: false);
-            return uniqueCount == Count && unfoundCount >= 0;
+            (int uniqueCount, _) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: false);
+            return uniqueCount == Count;
         }
 
         /// <summary>Determines whether a <see cref="HashSet{T}"/> object is a proper subset of the specified collection.</summary>
@@ -1001,11 +1099,11 @@ namespace System.Collections.Generic
                 }
             }
 
-            (int uniqueCount, int unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: false);
+            (int uniqueCount, int unfoundCount) = CheckUniqueAndUnfoundElements(other, returnIfUnfound: Count == 0);
             return uniqueCount == Count && unfoundCount > 0;
         }
 
-        /// <summary>Determines whether a <see cref="HashSet{T}"/> object is a proper superset of the specified collection.</summary>
+        /// <summary>Determines whether a <see cref="HashSet{T}"/> object is a superset of the specified collection.</summary>
         /// <param name="other">The collection to compare to the current <see cref="HashSet{T}"/> object.</param>
         /// <returns>true if the <see cref="HashSet{T}"/> object is a superset of <paramref name="other"/>; otherwise, false.</returns>
         public bool IsSupersetOf(IEnumerable<T> other)
@@ -1030,12 +1128,10 @@ namespace System.Collections.Generic
                     return true;
                 }
 
-                // Try to compare based on counts alone if other is a hashset with same equality comparer.
-                if (other is HashSet<T> otherAsSet &&
-                    EqualityComparersAreEqual(this, otherAsSet) &&
-                    otherAsSet.Count > Count)
+                // Faster if other is a hashset with the same equality comparer
+                if (other is HashSet<T> otherAsSet && EqualityComparersAreEqual(this, otherAsSet))
                 {
-                    return false;
+                    return otherAsSet.Count <= Count && otherAsSet.IsSubsetOfHashSetWithSameComparer(this);
                 }
             }
 
@@ -1112,6 +1208,18 @@ namespace System.Collections.Generic
             if (other == this)
             {
                 return true;
+            }
+
+            // Faster if other is a hashset with the same effective equality comparer
+            if (other is HashSet<T> otherAsSet && EffectiveEqualityComparersAreEqual(this, otherAsSet))
+            {
+                if (otherAsSet.Count == 0)
+                {
+                    return false;
+                }
+
+                return otherAsSet.Count < Count ? otherAsSet.OverlapsHashSetWithSameComparer(this)
+                    : OverlapsHashSetWithSameComparer(otherAsSet);
             }
 
             foreach (T element in other)
@@ -1259,11 +1367,6 @@ namespace System.Collections.Generic
                 }
             }
         }
-
-        /// <summary>
-        /// Similar to <see cref="Comparer"/> but surfaces the actual comparer being used to hash entries.
-        /// </summary>
-        internal IEqualityComparer<T> EffectiveComparer => _comparer ?? EqualityComparer<T>.Default;
 
         /// <summary>Ensures that this hash set can hold the specified number of elements without growing.</summary>
         public int EnsureCapacity(int capacity)
@@ -1538,17 +1641,57 @@ namespace System.Collections.Generic
         ///
         /// If callers are concerned about whether this is a proper subset, they take care of that.
         /// </summary>
-        internal bool IsSubsetOfHashSetWithSameComparer(HashSet<T> other)
+        private bool IsSubsetOfHashSetWithSameComparer(HashSet<T> other)
         {
-            foreach (T item in this)
+            Entry[] entries = _entries!;
+            int count = _count;
+            if (count <= 0 || count > entries.Length)
+                ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+
+            if (typeof(T).IsValueType || EffectiveEqualityComparersAreEqual(this, other))
             {
-                if (!other.Contains(item))
+                for (int i = 0; i < count; i++)
                 {
-                    return false;
+                    ref Entry entry = ref entries[i];
+                    if (entry.Next >= -1 && !other.Contains(ref entry))
+                    {
+                        return false;
+                    }
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    ref Entry entry = ref entries[i];
+                    if (entry.Next >= -1 && !other.Contains(entry.Value))
+                    {
+                        return false;
+                    }
                 }
             }
 
             return true;
+        }
+
+        private bool OverlapsHashSetWithSameComparer(HashSet<T> other)
+        {
+            Debug.Assert(EffectiveEqualityComparersAreEqual(this, other));
+            Entry[] entries = _entries!;
+            int count = _count;
+            if (count <= 0 || count > entries.Length)
+                ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+
+            for (int i = 0; i < count; i++)
+            {
+                ref Entry entry = ref entries[i];
+                if (entry.Next >= -1 && other.Contains(ref entry))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -1557,16 +1700,30 @@ namespace System.Collections.Generic
         /// </summary>
         private void IntersectWithHashSetWithSameComparer(HashSet<T> other)
         {
-            Entry[]? entries = _entries;
-            for (int i = 0; i < _count; i++)
+            Entry[] entries = _entries!;
+            int count = _count;
+            if (count <= 0 || count > entries.Length)
+                ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+
+            if (typeof(T).IsValueType || EffectiveEqualityComparersAreEqual(this, other))
             {
-                ref Entry entry = ref entries![i];
-                if (entry.Next >= -1)
+                for (int i = 0; i < count; i++)
                 {
-                    T item = entry.Value;
-                    if (!other.Contains(item))
+                    ref Entry entry = ref entries[i];
+                    if (entry.Next >= -1 && !other.Contains(ref entry))
                     {
-                        Remove(item);
+                        RemoveAt(entries, i);
+                    }
+                }
+            }
+            else
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    ref Entry entry = ref entries![i];
+                    if (entry.Next >= -1 && !other.Contains(entry.Value))
+                    {
+                        RemoveAt(entries, i);
                     }
                 }
             }
@@ -1574,7 +1731,7 @@ namespace System.Collections.Generic
 
         /// <summary>
         /// Iterate over other. If contained in this, mark an element in bit array corresponding to
-        /// its position in _slots. If anything is unmarked (in bit array), remove it.
+        /// its position in _entries. If anything is unmarked (in bit array), remove it.
         ///
         /// This attempts to allocate on the stack, if below StackAllocThreshold.
         /// </summary>
@@ -1587,9 +1744,8 @@ namespace System.Collections.Generic
             int originalCount = _count;
             int intArrayLength = BitHelper.ToIntArrayLength(originalCount);
 
-            Span<int> span = stackalloc int[StackAllocThreshold];
             BitHelper bitHelper = (uint)intArrayLength <= StackAllocThreshold ?
-                new BitHelper(span.Slice(0, intArrayLength), clear: true) :
+                new BitHelper(stackalloc int[StackAllocThreshold].Slice(0, intArrayLength), clear: true) :
                 new BitHelper(new int[intArrayLength], clear: false);
 
             // Mark if contains: find index of in slots array and mark corresponding element in bit array.
@@ -1602,14 +1758,20 @@ namespace System.Collections.Generic
                 }
             }
 
-            // If anything unmarked, remove it. Perf can be optimized here if BitHelper had a
-            // FindFirstUnmarked method.
-            for (int i = 0; i < originalCount; i++)
+            // If anything unmarked, remove it.
+            int i = bitHelper.FindFirstUnmarked();
+            if (i >= 0)
             {
-                ref Entry entry = ref _entries![i];
-                if (entry.Next >= -1 && !bitHelper.IsMarked(i))
+                Entry[] entries = _entries!;
+                if (originalCount <= 0 || originalCount > entries.Length)
+                    ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+
+                for (; i < originalCount; i++)
                 {
-                    Remove(entry.Value);
+                    if (entries[i].Next >= -1 && bitHelper.IsUnmarked(i))
+                    {
+                        RemoveAt(entries, i);
+                    }
                 }
             }
         }
@@ -1655,20 +1817,20 @@ namespace System.Collections.Generic
             int originalCount = _count;
             int intArrayLength = BitHelper.ToIntArrayLength(originalCount);
 
-            Span<int> itemsToRemoveSpan = stackalloc int[StackAllocThreshold / 2];
-            BitHelper itemsToRemove = intArrayLength <= StackAllocThreshold / 2 ?
-                new BitHelper(itemsToRemoveSpan.Slice(0, intArrayLength), clear: true) :
+            BitHelper itemsToRemove = (uint)intArrayLength <= StackAllocThreshold / 2 ?
+                new BitHelper(stackalloc int[StackAllocThreshold / 2].Slice(0, intArrayLength), clear: true) :
                 new BitHelper(new int[intArrayLength], clear: false);
 
-            Span<int> itemsAddedFromOtherSpan = stackalloc int[StackAllocThreshold / 2];
-            BitHelper itemsAddedFromOther = intArrayLength <= StackAllocThreshold / 2 ?
-                new BitHelper(itemsAddedFromOtherSpan.Slice(0, intArrayLength), clear: true) :
+            BitHelper itemsAddedFromOther = (uint)intArrayLength <= StackAllocThreshold / 2 ?
+                new BitHelper(stackalloc int[StackAllocThreshold / 2].Slice(0, intArrayLength), clear: true) :
                 new BitHelper(new int[intArrayLength], clear: false);
 
+            int firstMarkedForRemove = originalCount;
             foreach (T item in other)
             {
-                int location;
-                if (AddIfNotPresent(item, out location))
+                bool added = AddIfNotPresent(item, out int tmp);
+                int location = tmp;
+                if (added)
                 {
                     // wasn't already present in collection; flag it as something not to remove
                     // *NOTE* if location is out of range, we should ignore. BitHelper will
@@ -1680,22 +1842,25 @@ namespace System.Collections.Generic
                 else
                 {
                     // already there...if not added from other, mark for remove.
-                    // *NOTE* Even though BitHelper will check that location is in range, we want
-                    // to check here. There's no point in checking items beyond originalCount
-                    // because they could not have been in the original collection
-                    if (location < originalCount && !itemsAddedFromOther.IsMarked(location))
+                    // *NOTE* BitHelper will check that location is in range.
+                    if (itemsAddedFromOther.IsUnmarked(location))
                     {
                         itemsToRemove.MarkBit(location);
+                        if (location < firstMarkedForRemove)
+                        {
+                            firstMarkedForRemove = location;
+                        }
                     }
                 }
             }
 
             // if anything marked, remove it
-            for (int i = 0; i < originalCount; i++)
+            Entry[] entries = _entries!;
+            for (int i = firstMarkedForRemove; i < originalCount; i++)
             {
                 if (itemsToRemove.IsMarked(i))
                 {
-                    Remove(_entries![i].Value);
+                    RemoveAt(entries, i);
                 }
             }
         }
@@ -1725,27 +1890,10 @@ namespace System.Collections.Generic
         /// because unfoundCount must be 0.</param>
         private (int UniqueCount, int UnfoundCount) CheckUniqueAndUnfoundElements(IEnumerable<T> other, bool returnIfUnfound)
         {
-            // Need special case in case this has no elements.
-            if (_count == 0)
-            {
-                int numElementsInOther = 0;
-                foreach (T item in other)
-                {
-                    numElementsInOther++;
-                    break; // break right away, all we want to know is whether other has 0 or 1 elements
-                }
+            int intArrayLength = BitHelper.ToIntArrayLength(_count);
 
-                return (UniqueCount: 0, UnfoundCount: numElementsInOther);
-            }
-
-            Debug.Assert((_buckets != null) && (_count > 0), "_buckets was null but count greater than 0");
-
-            int originalCount = _count;
-            int intArrayLength = BitHelper.ToIntArrayLength(originalCount);
-
-            Span<int> span = stackalloc int[StackAllocThreshold];
-            BitHelper bitHelper = intArrayLength <= StackAllocThreshold ?
-                new BitHelper(span.Slice(0, intArrayLength), clear: true) :
+            BitHelper bitHelper = (uint)intArrayLength <= StackAllocThreshold ?
+                new BitHelper(stackalloc int[StackAllocThreshold].Slice(0, intArrayLength), clear: true) :
                 new BitHelper(new int[intArrayLength], clear: false);
 
             int unfoundCount = 0; // count of items in other not found in this
@@ -1756,10 +1904,8 @@ namespace System.Collections.Generic
                 int index = FindItemIndex(item);
                 if (index >= 0)
                 {
-                    if (!bitHelper.IsMarked(index))
+                    if (bitHelper.TryMarkBit(index))
                     {
-                        // Item hasn't been seen yet.
-                        bitHelper.MarkBit(index);
                         uniqueFoundCount++;
                     }
                 }
@@ -1781,13 +1927,15 @@ namespace System.Collections.Generic
         /// speed up if it knows the other item has unique elements. I.e. if they're using
         /// different equality comparers, then uniqueness assumption between sets break.
         /// </summary>
-        internal static bool EqualityComparersAreEqual(HashSet<T> set1, HashSet<T> set2) => set1.Comparer.Equals(set2.Comparer);
+        private static bool EqualityComparersAreEqual(HashSet<T> set1, HashSet<T> set2)
+            => set1._comparer == set2._comparer || set1.Comparer.Equals(set2.Comparer);
 
         /// <summary>
         /// Checks if effective equality comparers are equal. This is used for algorithms that
         /// require that both collections use identical hashing implementations for their entries.
         /// </summary>
-        internal static bool EffectiveEqualityComparersAreEqual(HashSet<T> set1, HashSet<T> set2) => set1.EffectiveComparer.Equals(set2.EffectiveComparer);
+        private static bool EffectiveEqualityComparersAreEqual(HashSet<T> set1, HashSet<T> set2)
+            => set1._comparer == set2._comparer || set1._comparer?.Equals(set2._comparer) == true;
 
         #endregion
 

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -1641,7 +1641,7 @@ namespace System.Collections.Generic
         ///
         /// If callers are concerned about whether this is a proper subset, they take care of that.
         /// </summary>
-        private bool IsSubsetOfHashSetWithSameComparer(HashSet<T> other)
+        internal bool IsSubsetOfHashSetWithSameComparer(HashSet<T> other)
         {
             Entry[] entries = _entries!;
             int count = _count;
@@ -1927,7 +1927,7 @@ namespace System.Collections.Generic
         /// speed up if it knows the other item has unique elements. I.e. if they're using
         /// different equality comparers, then uniqueness assumption between sets break.
         /// </summary>
-        private static bool EqualityComparersAreEqual(HashSet<T> set1, HashSet<T> set2)
+        internal static bool EqualityComparersAreEqual(HashSet<T> set1, HashSet<T> set2)
             => set1._comparer == set2._comparer || set1.Comparer.Equals(set2.Comparer);
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSetEqualityComparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSetEqualityComparer.cs
@@ -22,35 +22,7 @@ namespace System.Collections.Generic
                 return false;
             }
 
-            EqualityComparer<T> defaultComparer = EqualityComparer<T>.Default;
-
-            // If both sets use the same comparer, they're equal if they're the same
-            // size and one is a "subset" of the other.
-            if (HashSet<T>.EqualityComparersAreEqual(x, y))
-            {
-                return x.Count == y.Count && y.IsSubsetOfHashSetWithSameComparer(x);
-            }
-
-            // Otherwise, do an O(N^2) match.
-            foreach (T yi in y)
-            {
-                bool found = false;
-                foreach (T xi in x)
-                {
-                    if (defaultComparer.Equals(yi, xi))
-                    {
-                        found = true;
-                        break;
-                    }
-                }
-
-                if (!found)
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return x.SetEquals(y);
         }
 
         public int GetHashCode(HashSet<T>? obj)

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSetEqualityComparer.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSetEqualityComparer.cs
@@ -22,7 +22,35 @@ namespace System.Collections.Generic
                 return false;
             }
 
-            return x.SetEquals(y);
+            EqualityComparer<T> defaultComparer = EqualityComparer<T>.Default;
+
+            // If both sets use the same comparer, they're equal if they're the same
+            // size and one is a "subset" of the other.
+            if (HashSet<T>.EqualityComparersAreEqual(x, y))
+            {
+                return x.Count == y.Count && y.IsSubsetOfHashSetWithSameComparer(x);
+            }
+
+            // Otherwise, do an O(N^2) match.
+            foreach (T yi in y)
+            {
+                bool found = false;
+                foreach (T xi in x)
+                {
+                    if (defaultComparer.Equals(yi, xi))
+                    {
+                        found = true;
+                        break;
+                    }
+                }
+
+                if (!found)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         public int GetHashCode(HashSet<T>? obj)


### PR DESCRIPTION
Optimize `HashSet<T>` intersection/subset/overlap calculations, especially for worst case scenarios.

| `HashSet<int>`                       | Overlap | Mean (main) | Error    | Mean (PR)  | Error    |
|------------------------------------- |-------- |------------:|---------:|-----------:|---------:|
| IntersectWithEnumerable              | 0       | 19,929.2 ns | 296.9 ns | 6,023.0 ns |  33.2 ns |
| IntersectWithEnumerable              | 50      | 13,488.4 ns | 125.7 ns | 5,431.6 ns | 105.3 ns |
| IntersectWithEnumerable              | 100     |  5,198.2 ns |  36.2 ns | 4,485.3 ns |  51.5 ns |
| IntersectWithHashSetWithSameComparer | 0       |  3,799.0 ns |  29.6 ns | 3,192.8 ns |  33.0 ns |
| IntersectWithHashSetWithSameComparer | 50      |  2,993.8 ns |  31.3 ns | 2,759.8 ns |  44.4 ns |
| IntersectWithHashSetWithSameComparer | 100     |  2,317.4 ns |  21.9 ns | 2,305.7 ns |  20.4 ns |
| IsSupersetOfHashSetWithSameComparer  | 0       |     89.5 ns |   1.0 ns |    36.7 ns |   0.4 ns |
| IsSupersetOfHashSetWithSameComparer  | 50      |    144.0 ns |   1.8 ns |    42.6 ns |   0.6 ns |
| IsSupersetOfHashSetWithSameComparer  | 100     | 16,266.0 ns | 188.2 ns | 1,328.3 ns |  14.2 ns |
| OverlapsHashSetWithSameComparer      | 0       |  1,500.0 ns |  10.6 ns | 1,125.5 ns |  11.7 ns |
| OverlapsHashSetWithSameComparer      | 50      |      6.6 ns |   0.1 ns |    42.0 ns |   0.4 ns |
| OverlapsHashSetWithSameComparer      | 100     |      6.6 ns |   0.2 ns |    21.3 ns |   0.3 ns |
| SymmetricExceptWithEnumerable        | 0       |  7,691.9 ns |  90.7 ns | 7,391.4 ns | 119.7 ns |
| SymmetricExceptWithEnumerable        | 50      | 15,198.2 ns | 129.9 ns | 8,040.1 ns | 141.0 ns |
| SymmetricExceptWithEnumerable        | 100     | 20,029.7 ns | 331.0 ns | 6,052.9 ns |  33.7 ns |

| `HashSet<string>`                    | Overlap | Mean (main) | Error    | Mean (PR)   | Error    |
|------------------------------------- |-------- |------------:|---------:|------------:|---------:|
| IntersectWithEnumerable              | 0       | 37,776.2 ns | 330.0 ns |  9,290.5 ns |  80.1 ns |
| IntersectWithEnumerable              | 50      | 26,304.8 ns | 319.6 ns |  9,467.2 ns | 121.5 ns |
| IntersectWithEnumerable              | 100     | 10,489.1 ns | 147.4 ns |  8,645.8 ns |  92.0 ns |
| IntersectWithHashSetWithSameComparer | 0       | 10,848.6 ns | 186.7 ns |  3,421.3 ns |  45.7 ns |
| IntersectWithHashSetWithSameComparer | 50      |  9,199.0 ns | 159.9 ns |  3,330.9 ns |  47.2 ns |
| IntersectWithHashSetWithSameComparer | 100     |  7,353.5 ns | 112.7 ns |  3,428.5 ns |  28.7 ns |
| IsSupersetOfHashSetWithSameComparer  | 0       |    127.8 ns |   2.4 ns |     27.7 ns |   0.4 ns |
| IsSupersetOfHashSetWithSameComparer  | 50      |    222.6 ns |   1.8 ns |     34.3 ns |   0.4 ns |
| IsSupersetOfHashSetWithSameComparer  | 100     | 28,581.9 ns | 402.8 ns |  2,150.9 ns |  26.5 ns |
| OverlapsHashSetWithSameComparer      | 0       |  5,600.5 ns |  92.6 ns |  1,295.9 ns |  14.7 ns |
| OverlapsHashSetWithSameComparer      | 50      |     24.7 ns |   0.5 ns |     41.9 ns |   0.6 ns |
| OverlapsHashSetWithSameComparer      | 100     |     27.2 ns |   0.3 ns |     17.6 ns |   0.2 ns |
| SymmetricExceptWithEnumerable        | 0       | 13,148.2 ns | 246.2 ns | 11,521.7 ns | 224.2 ns |
| SymmetricExceptWithEnumerable        | 50      | 27,093.3 ns | 168.6 ns | 13,285.7 ns | 109.3 ns |
| SymmetricExceptWithEnumerable        | 100     | 40,047.7 ns | 508.4 ns | 11,195.2 ns | 151.7 ns |

<details><summary>Benchmark code</summary>
<p>

```cs
[GenericTypeArguments(typeof(int))] // value type
[GenericTypeArguments(typeof(string))] // reference type
public class Bench<T>
{
    public const int Size = 512;

    [Params(0, 50, 100)]
    public int Overlap;

    private HashSet<T> _mainSet;
    private T[][] _otherKeys;
    private HashSet<T>[] _otherSets;

    [GlobalSetup]
    public void Setup()
    {
        var all = ValuesGenerator.ArrayOfUniqueValues<T>(Size * 2);
        var keys = all.AsSpan(0, Size).ToArray();
        _mainSet = new(keys);

        var keys0 = all.AsSpan(Size, Size).ToArray();
        var rnd = new Random(42);
        var keys100 = keys.AsSpan().ToArray();
        rnd.Shuffle(keys100);

        rnd.Shuffle(all);
        var keys50 = all.AsSpan(0, Size).ToArray();

        _otherKeys = [keys0, keys50, keys100];
        _otherSets = Array.ConvertAll(_otherKeys, x => new HashSet<T>(x));
    }

    [Benchmark]
    public HashSet<T> IntersectWithHashSetWithSameComparer()
    {
        var hashSet = new HashSet<T>(_mainSet);
        hashSet.IntersectWith(_otherSets[Overlap / 50]);
        return hashSet;
    }

    [Benchmark]
    public HashSet<T> IntersectWithEnumerable()
    {
        var hashSet = new HashSet<T>(_mainSet);
        hashSet.IntersectWith(_otherKeys[Overlap / 50]);
        return hashSet;
    }

    [Benchmark]
    public HashSet<T> SymmetricExceptWithEnumerable()
    {
        var hashSet = new HashSet<T>(_mainSet);
        hashSet.SymmetricExceptWith(_otherKeys[Overlap / 50]);
        return hashSet;
    }

    [Benchmark]
    public bool IsSupersetOfHashSetWithSameComparer() => _mainSet.IsSupersetOf(_otherSets[Overlap / 50]);

    [Benchmark]
    public bool OverlapsHashSetWithSameComparer() => _mainSet.Overlaps(_otherSets[Overlap / 50]);
}
```

</p>
</details> 