### PR TITLE
Configure FileStreamOptions with PreallocationSize and async access in ZipArchiveEntry extract methods

### DIFF
--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -116,6 +116,7 @@ namespace System.IO.Compression
                 Mode = overwrite ? FileMode.Create : FileMode.CreateNew,
                 Share = FileShare.None,
                 BufferSize = ZipFile.FileStreamBufferSize,
+                PreallocationSize = source.Length,
                 Options = useAsync ? FileOptions.Asynchronous : FileOptions.None
             };
 

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -117,7 +117,7 @@ namespace System.IO.Compression
                 // For archives in Update mode, we have no way to check if the entry
                 // was opened for write, so we attempt to get the length and if it fails
                 // we just skip preallocation.
-                if (source.Archive.Mode != ZipArchiveMode.Create)
+                if (source.Archive is ZipArchive archive && archive.Mode != ZipArchiveMode.Create)
                 {
                     preallocationSize = source.Length;
                 }

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -110,13 +110,20 @@ namespace System.IO.Compression
             ArgumentNullException.ThrowIfNull(source);
             ArgumentNullException.ThrowIfNull(destinationFileName);
 
+            long preallocationSize = 0;
+            try
+            {
+                preallocationSize = source.Length;
+            }
+            catch (InvalidOperationException) { }
+
             fileStreamOptions = new()
             {
                 Access = FileAccess.Write,
                 Mode = overwrite ? FileMode.Create : FileMode.CreateNew,
                 Share = FileShare.None,
                 BufferSize = ZipFile.FileStreamBufferSize,
-                PreallocationSize = source.Length,
+                PreallocationSize = preallocationSize,
                 Options = useAsync ? FileOptions.Asynchronous : FileOptions.None
             };
 

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -113,6 +113,8 @@ namespace System.IO.Compression
             long preallocationSize = 0;
             try
             {
+                // .Length can throw if the entry stream has been opened for write.
+                // In that case, we fallback to 0 (no preallocation)
                 preallocationSize = source.Length;
             }
             catch (InvalidOperationException) { }

--- a/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
+++ b/src/libraries/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.ZipArchiveEntry.Extract.cs
@@ -114,8 +114,13 @@ namespace System.IO.Compression
             try
             {
                 // .Length can throw if the entry stream has been opened for write.
-                // In that case, we fallback to 0 (no preallocation)
-                preallocationSize = source.Length;
+                // For archives in Update mode, we have no way to check if the entry
+                // was opened for write, so we attempt to get the length and if it fails
+                // we just skip preallocation.
+                if (source.Archive.Mode != ZipArchiveMode.Create)
+                {
+                    preallocationSize = source.Length;
+                }
             }
             catch (InvalidOperationException) { }
 


### PR DESCRIPTION
Set `PreallocationSize` on `FileStreamOptions` based on the entry's uncompressed size (`ZipArchiveEntry.Length`) to allow the file system to pre-allocate disk space, reducing fragmentation and improving write performance.

Configure `FileOptions.Asynchronous` when extracting from async methods (`ExtractToFileAsync`) so the `FileStream` uses async I/O.