### PR TITLE
Re-enable PlatformHandlerTest_Cookies_Http2 for WinHttpHandler

### DIFF
--- a/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
+++ b/src/libraries/System.Net.Http.WinHttpHandler/tests/FunctionalTests/PlatformHandlerTest.cs
@@ -181,7 +181,6 @@ namespace System.Net.Http.Functional.Tests
     }
 
 #if NET
-#if !WINHTTPHANDLER_TEST // [ActiveIssue("https://github.com/dotnet/runtime/issues/33930")]
     [ConditionalClass(typeof(PlatformDetection), nameof(PlatformDetection.IsWindows10Version1607OrGreater))]
     public sealed class PlatformHandlerTest_Cookies_Http2 : HttpClientHandlerTest_Cookies
     {
@@ -189,7 +188,6 @@ namespace System.Net.Http.Functional.Tests
 
         public PlatformHandlerTest_Cookies_Http2(ITestOutputHelper output) : base(output) { }
     }
-#endif
 
     public sealed class PlatformHandler_HttpClientHandler_Asynchrony_Http2_Test : HttpClientHandler_Asynchrony_Test
     {


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/33930

## Summary

Removes the `#if !WINHTTPHANDLER_TEST` preprocessor guard that was disabling the entire `PlatformHandlerTest_Cookies_Http2` test class for WinHttpHandler.

## Validation

- Built and ran `GetAsync_ReceiveSetCookieHeader` tests on Windows (both net11.0 and net481 TFMs).
- Ran 20 consecutive iterations with **0 failures** across all runs (60 tests on net11.0 + 28 tests on net481 per run).
- No flakiness observed.