### PR TITLE
Re-enable Manual_CertificateOnlySentWhenValid_Success for WinHttpHandler

### DIFF
--- a/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ClientCertificates.cs
+++ b/src/libraries/Common/tests/System/Net/Http/HttpClientHandlerTest.ClientCertificates.cs
@@ -83,9 +83,6 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(3, false)]
         public async Task Manual_CertificateOnlySentWhenValid_Success(int certIndex, bool serverExpectsClientCertificate)
         {
-            // [ActiveIssue("https://github.com/dotnet/runtime/issues/69238")]
-            if (IsWinHttpHandler) throw new SkipTestException("https://github.com/dotnet/runtime/issues/69238");
-
             var options = new LoopbackServer.Options { UseSsl = true };
 
             X509Certificate2 GetClientCertificate(int certIndex) => certIndex switch


### PR DESCRIPTION
Fixes https://github.com/dotnet/runtime/issues/69238

## Summary

Removes the `SkipTestException` guard that was disabling `Manual_CertificateOnlySentWhenValid_Success` for WinHttpHandler.

## Validation

- Built and ran `Manual_CertificateOnlySentWhenValid_Success` tests on Windows (both net11.0 and net481 TFMs).
- Ran 20 consecutive iterations with **0 failures** across all runs (6 tests on net11.0 + 3 tests on net481 per run).
- No flakiness observed.