### PR TITLE
SoftMax: Multiply by `1 / expSum` instead of dividing by `expSum`

### DIFF
--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.Single.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/TensorPrimitives.Single.cs
@@ -858,7 +858,7 @@ namespace System.Numerics.Tensors
 
             InvokeSpanIntoSpan<ExpOperator_Single>(x, destination);
             float expSum = Sum(destination);
-            InvokeSpanScalarIntoSpan<DivideOperator_Single>(destination, expSum, destination);
+            InvokeSpanScalarIntoSpan<MultiplyOperator_Single>(destination, 1f / expSum, destination);
         }
 
         /// <summary>Computes the element-wise difference between single-precision floating-point numbers in the specified tensors.</summary>

--- a/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.SoftMax.cs
+++ b/src/libraries/System.Numerics.Tensors/src/System/Numerics/Tensors/netcore/TensorPrimitives.SoftMax.cs
@@ -38,7 +38,7 @@ namespace System.Numerics.Tensors
 
             InvokeSpanIntoSpan<T, ExpOperator<T>>(x, destination);
             T expSum = Sum(destination);
-            InvokeSpanScalarIntoSpan<T, DivideOperator<T>>(destination, expSum, destination);
+            InvokeSpanScalarIntoSpan<T, MultiplyOperator<T>>(destination, T.One / expSum, destination);
         }
     }
 }


### PR DESCRIPTION
`System.Numerics.Tensors.TensorPrimitives.SoftMax`:
We can convert a bunch of divisions to multiplications  by calculating `1 / expSum` once and then multiplying.

I assume this will slightly change the output of SoftMax ~~but since float operations aren't consistent across platforms this should not matter.~~

### Benchmark results
I assume this largely depends on the hardware
```
| Method  | Count   | Mean         | Error       | StdDev      | Ratio | Allocated | Alloc Ratio |
|-------- |-------- |-------------:|------------:|------------:|------:|----------:|------------:|
| BuiltIn | 1000    |     242.2 ns |     0.65 ns |     0.61 ns |  1.00 |         - |          NA |
| Mine    | 1000    |     228.1 ns |     0.06 ns |     0.05 ns |  0.94 |         - |          NA |
|         |         |              |             |             |       |           |             |
| BuiltIn | 1000000 | 309,299.3 ns |   736.81 ns |   689.21 ns |  1.00 |         - |          NA |
| Mine    | 1000000 | 301,680.0 ns | 1,214.74 ns | 1,136.27 ns |  0.98 |         - |          NA |
```
code: https://gist.github.com/BarionLP/aff1bca0d507dfb16f52bb715e3a58a2

late follow up to #111615