### PR TITLE
Remove unnecessary volatile from fields in Libraries

### DIFF
--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Evp.DigestAlgs.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Evp.DigestAlgs.cs
@@ -9,11 +9,11 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        private static volatile IntPtr s_evpMd5;
-        private static volatile IntPtr s_evpSha1;
-        private static volatile IntPtr s_evpSha256;
-        private static volatile IntPtr s_evpSha384;
-        private static volatile IntPtr s_evpSha512;
+        private static IntPtr s_evpMd5;
+        private static IntPtr s_evpSha1;
+        private static IntPtr s_evpSha256;
+        private static IntPtr s_evpSha384;
+        private static IntPtr s_evpSha512;
 
         [LibraryImport(Libraries.AndroidCryptoNative)]
         private static partial IntPtr CryptoNative_EvpMd5();

--- a/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Evp.DigestAlgs.cs
+++ b/src/libraries/Common/src/Interop/Android/System.Security.Cryptography.Native.Android/Interop.Evp.DigestAlgs.cs
@@ -9,11 +9,11 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        private static IntPtr s_evpMd5;
-        private static IntPtr s_evpSha1;
-        private static IntPtr s_evpSha256;
-        private static IntPtr s_evpSha384;
-        private static IntPtr s_evpSha512;
+        private static volatile IntPtr s_evpMd5;
+        private static volatile IntPtr s_evpSha1;
+        private static volatile IntPtr s_evpSha256;
+        private static volatile IntPtr s_evpSha384;
+        private static volatile IntPtr s_evpSha512;
 
         [LibraryImport(Libraries.AndroidCryptoNative)]
         private static partial IntPtr CryptoNative_EvpMd5();

--- a/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MemfdCreate.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Native/Interop.MemfdCreate.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
         [LibraryImport(Libraries.SystemNative, EntryPoint = "SystemNative_IsMemfdSupported", SetLastError = true)]
         private static partial int MemfdSupportedImpl();
 
-        private static volatile NullableBool s_memfdSupported;
+        private static NullableBool s_memfdSupported;
 
         internal static bool IsMemfdSupported
         {

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.DigestAlgs.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.DigestAlgs.cs
@@ -9,16 +9,16 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        private static IntPtr s_evpMd5;
-        private static IntPtr s_evpSha1;
-        private static IntPtr s_evpSha256;
-        private static IntPtr s_evpSha384;
-        private static IntPtr s_evpSha512;
-        private static IntPtr s_evpSha3_256;
-        private static IntPtr s_evpSha3_384;
-        private static IntPtr s_evpSha3_512;
-        private static IntPtr s_evpSha3_Shake128;
-        private static IntPtr s_evpSha3_Shake256;
+        private static volatile IntPtr s_evpMd5;
+        private static volatile IntPtr s_evpSha1;
+        private static volatile IntPtr s_evpSha256;
+        private static volatile IntPtr s_evpSha384;
+        private static volatile IntPtr s_evpSha512;
+        private static volatile IntPtr s_evpSha3_256;
+        private static volatile IntPtr s_evpSha3_384;
+        private static volatile IntPtr s_evpSha3_512;
+        private static volatile IntPtr s_evpSha3_Shake128;
+        private static volatile IntPtr s_evpSha3_Shake256;
 
         [LibraryImport(Libraries.CryptoNative)]
         private static partial IntPtr CryptoNative_EvpMd5();

--- a/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.DigestAlgs.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.DigestAlgs.cs
@@ -9,16 +9,16 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        private static volatile IntPtr s_evpMd5;
-        private static volatile IntPtr s_evpSha1;
-        private static volatile IntPtr s_evpSha256;
-        private static volatile IntPtr s_evpSha384;
-        private static volatile IntPtr s_evpSha512;
-        private static volatile IntPtr s_evpSha3_256;
-        private static volatile IntPtr s_evpSha3_384;
-        private static volatile IntPtr s_evpSha3_512;
-        private static volatile IntPtr s_evpSha3_Shake128;
-        private static volatile IntPtr s_evpSha3_Shake256;
+        private static IntPtr s_evpMd5;
+        private static IntPtr s_evpSha1;
+        private static IntPtr s_evpSha256;
+        private static IntPtr s_evpSha384;
+        private static IntPtr s_evpSha512;
+        private static IntPtr s_evpSha3_256;
+        private static IntPtr s_evpSha3_384;
+        private static IntPtr s_evpSha3_512;
+        private static IntPtr s_evpSha3_Shake128;
+        private static IntPtr s_evpSha3_Shake256;
 
         [LibraryImport(Libraries.CryptoNative)]
         private static partial IntPtr CryptoNative_EvpMd5();

--- a/src/libraries/Common/src/System/Console/ConsoleUtils.cs
+++ b/src/libraries/Common/src/System/Console/ConsoleUtils.cs
@@ -6,7 +6,7 @@ namespace System
     internal static partial class ConsoleUtils
     {
         /// <summary>Whether to output ansi color strings.</summary>
-        private static volatile NullableBool s_emitAnsiColorCodes;
+        private static NullableBool s_emitAnsiColorCodes;
 
         /// <summary>Get whether to emit ANSI color codes.</summary>
         public static bool EmitAnsiColorCodes

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9ContentType.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9ContentType.cs
@@ -62,6 +62,6 @@ namespace System.Security.Cryptography.Pkcs
             return new Oid(contentTypeValue);
         }
 
-        private volatile Oid? _lazyContentType;
+        private Oid? _lazyContentType;
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentDescription.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentDescription.cs
@@ -81,6 +81,6 @@ namespace System.Security.Cryptography.Pkcs
             return PkcsHelpers.EncodeOctetString(octets);
         }
 
-        private volatile string? _lazyDocumentDescription;
+        private string? _lazyDocumentDescription;
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentName.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9DocumentName.cs
@@ -81,6 +81,6 @@ namespace System.Security.Cryptography.Pkcs
             return PkcsHelpers.EncodeOctetString(octets);
         }
 
-        private volatile string? _lazyDocumentName;
+        private string? _lazyDocumentName;
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9MessageDigest.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs9MessageDigest.cs
@@ -60,6 +60,6 @@ namespace System.Security.Cryptography.Pkcs
             return PkcsHelpers.DecodeOctetString(rawData);
         }
 
-        private volatile byte[]? _lazyMessageDigest;
+        private byte[]? _lazyMessageDigest;
     }
 }

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ApplicationCatalog.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/ApplicationCatalog.cs
@@ -15,7 +15,7 @@ namespace System.ComponentModel.Composition.Hosting
     public partial class ApplicationCatalog : ComposablePartCatalog, ICompositionElement
     {
         private bool _isDisposed;
-        private volatile AggregateCatalog? _innerCatalog;
+        private AggregateCatalog? _innerCatalog;
         private readonly object _thisLock = new object();
         private readonly ICompositionElement? _definitionOrigin;
         private readonly ReflectionContext? _reflectionContext;

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AssemblyCatalog.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/AssemblyCatalog.cs
@@ -24,8 +24,8 @@ namespace System.ComponentModel.Composition.Hosting
     {
         private readonly object _thisLock = new object();
         private readonly ICompositionElement _definitionOrigin;
-        private volatile Assembly _assembly;
-        private volatile ComposablePartCatalog? _innerCatalog;
+        private Assembly _assembly;
+        private ComposablePartCatalog? _innerCatalog;
         private int _isDisposed;
 
         private readonly ReflectionContext? _reflectionContext;

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/TypeCatalog.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Hosting/TypeCatalog.cs
@@ -26,7 +26,7 @@ namespace System.ComponentModel.Composition.Hosting
     {
         private readonly object _thisLock = new object();
         private Type[]? _types;
-        private volatile List<ComposablePartDefinition>? _parts;
+        private List<ComposablePartDefinition>? _parts;
         private volatile bool _isDisposed;
         private readonly ICompositionElement _definitionOrigin;
         private readonly Lazy<Dictionary<string, List<ComposablePartDefinition>>> _contractPartIndex;

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/ComposablePartCatalog.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/ComposablePartCatalog.cs
@@ -22,7 +22,7 @@ namespace System.ComponentModel.Composition.Primitives
     public abstract class ComposablePartCatalog : IEnumerable<ComposablePartDefinition>, IDisposable
     {
         private bool _isDisposed;
-        private volatile IQueryable<ComposablePartDefinition>? _queryableParts;
+        private IQueryable<ComposablePartDefinition>? _queryableParts;
 
         internal static readonly List<Tuple<ComposablePartDefinition, ExportDefinition>> _EmptyExportsList = new List<Tuple<ComposablePartDefinition, ExportDefinition>>();
 

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/Export.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/Primitives/Export.cs
@@ -18,7 +18,7 @@ namespace System.ComponentModel.Composition.Primitives
         private readonly ExportDefinition? _definition;
         private readonly Func<object?>? _exportedValueGetter;
         private static readonly object _EmptyValue = new object();
-        private volatile object? _exportedValue = Export._EmptyValue;
+        private object? _exportedValue = Export._EmptyValue;
 
         /// <summary>
         ///     Initializes a new instance of the <see cref="Export"/> class.

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePart.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePart.cs
@@ -16,9 +16,9 @@ namespace System.ComponentModel.Composition.ReflectionModel
     internal class ReflectionComposablePart : ComposablePart, ICompositionElement
     {
         private readonly ReflectionComposablePartDefinition _definition;
-        private volatile Dictionary<ImportDefinition, object?>? _importValues;
-        private volatile Dictionary<ImportDefinition, ImportingItem>? _importsCache;
-        private volatile Dictionary<int, ExportingMember>? _exportsCache;
+        private Dictionary<ImportDefinition, object?>? _importValues;
+        private Dictionary<ImportDefinition, ImportingItem>? _importsCache;
+        private Dictionary<int, ExportingMember>? _exportsCache;
         private volatile bool _invokeImportsSatisfied = true;
         private bool _initialCompositionComplete;
         private volatile object? _cachedInstance;

--- a/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePartDefinition.cs
+++ b/src/libraries/System.ComponentModel.Composition/src/System/ComponentModel/Composition/ReflectionModel/ReflectionComposablePartDefinition.cs
@@ -15,10 +15,10 @@ namespace System.ComponentModel.Composition.ReflectionModel
     {
         private readonly IReflectionPartCreationInfo _creationInfo;
 
-        private volatile ImportDefinition[]? _imports;
-        private volatile ExportDefinition[]? _exports;
-        private volatile IDictionary<string, object?>? _metadata;
-        private volatile ConstructorInfo? _constructor;
+        private ImportDefinition[]? _imports;
+        private ExportDefinition[]? _exports;
+        private IDictionary<string, object?>? _metadata;
+        private ConstructorInfo? _constructor;
         private readonly object _lock = new object();
 
         public ReflectionComposablePartDefinition(IReflectionPartCreationInfo creationInfo)

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/BooleanConverter.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/BooleanConverter.cs
@@ -10,7 +10,7 @@ namespace System.ComponentModel
     /// </summary>
     public class BooleanConverter : TypeConverter
     {
-        private static volatile StandardValuesCollection? s_values;
+        private static StandardValuesCollection? s_values;
 
         /// <summary>
         /// Gets a value indicating whether this converter can convert an object

--- a/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.cs
+++ b/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/LicenseManager.cs
@@ -19,10 +19,10 @@ namespace System.ComponentModel
     {
         private static readonly object s_selfLock = new object();
 
-        private static volatile LicenseContext? s_context;
+        private static LicenseContext? s_context;
         private static object? s_contextLockHolder;
-        private static volatile Hashtable? s_providers;
-        private static volatile Hashtable? s_providerInstances;
+        private static Hashtable? s_providers;
+        private static Hashtable? s_providerInstances;
         private static readonly object s_internalSyncObject = new object();
 
         // not creatable...

--- a/src/libraries/System.Composition.Hosting/src/System/Composition/Hosting/Core/ExportDescriptorRegistry.cs
+++ b/src/libraries/System.Composition.Hosting/src/System/Composition/Hosting/Core/ExportDescriptorRegistry.cs
@@ -10,7 +10,7 @@ namespace System.Composition.Hosting.Core
     {
         private readonly object _thisLock = new object();
         private readonly ExportDescriptorProvider[] _exportDescriptorProviders;
-        private volatile Dictionary<CompositionContract, ExportDescriptor[]> _partDefinitions = new Dictionary<CompositionContract, ExportDescriptor[]>();
+        private Dictionary<CompositionContract, ExportDescriptor[]> _partDefinitions = new Dictionary<CompositionContract, ExportDescriptor[]>();
 
         public ExportDescriptorRegistry(ExportDescriptorProvider[] exportDescriptorProviders)
         {

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/AppSettingsSection.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/AppSettingsSection.cs
@@ -9,9 +9,9 @@ namespace System.Configuration
 {
     public sealed class AppSettingsSection : ConfigurationSection
     {
-        private static volatile ConfigurationPropertyCollection s_properties;
-        private static volatile ConfigurationProperty s_propAppSettings;
-        private static volatile ConfigurationProperty s_propFile;
+        private static ConfigurationPropertyCollection s_properties;
+        private static ConfigurationProperty s_propAppSettings;
+        private static ConfigurationProperty s_propFile;
 
         private KeyValueInternalCollection _keyValueCollection;
 

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigPaths.cs
@@ -23,7 +23,7 @@ namespace System.Configuration
         private const string UrlDesc = "Url";
         private const string PathDesc = "Path";
 
-        private static volatile ClientConfigPaths s_current;
+        private static ClientConfigPaths s_current;
         private static volatile bool s_currentIncludesUserConfig;
 
         private readonly bool _includesUserConfig;

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigurationHost.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientConfigurationHost.cs
@@ -25,7 +25,7 @@ namespace System.Configuration
         private const string MachineConfigSubdirectory = "Config";
 
         private static readonly object s_version = new object();
-        private static volatile string s_machineConfigFilePath;
+        private static string s_machineConfigFilePath;
         private ClientConfigPaths _configPaths; // physical paths to client config files
 
         private string _exePath; // the physical path to the exe being configured

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientSettingsStore.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ClientSettingsStore.cs
@@ -222,7 +222,7 @@ namespace System.Configuration
         {
             private const string ClientConfigurationHostTypeName = "System.Configuration.ClientConfigurationHost, " + TypeUtil.ConfigurationManagerAssemblyName;
             private const string InternalConfigConfigurationFactoryTypeName = "System.Configuration.Internal.InternalConfigConfigurationFactory, " + TypeUtil.ConfigurationManagerAssemblyName;
-            private static volatile IInternalConfigConfigurationFactory s_configFactory;
+            private static IInternalConfigConfigurationFactory s_configFactory;
 
             /// <summary>
             /// ClientConfigurationHost implements this - a way of getting some info from it without

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationElement.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationElement.cs
@@ -40,7 +40,7 @@ namespace System.Configuration
         };
 
         private static readonly Hashtable s_propertyBags = new Hashtable();
-        private static volatile Dictionary<Type, ConfigurationValidatorBase> s_perTypeValidators;
+        private static Dictionary<Type, ConfigurationValidatorBase> s_perTypeValidators;
         internal static readonly object s_nullPropertyValue = new object();
 
         private static readonly ConfigurationElementProperty s_elementProperty =
@@ -52,7 +52,7 @@ namespace System.Configuration
         internal BaseConfigurationRecord _configRecord;
         private ConfigurationElementProperty _elementProperty = s_elementProperty;
         internal ContextInformation _evalContext;
-        private volatile ElementInformation _evaluationElement;
+        private ElementInformation _evaluationElement;
         internal ConfigurationValueFlags _itemLockedFlag;
         internal ConfigurationLockCollection _lockedAllExceptAttributesList;
         internal ConfigurationLockCollection _lockedAllExceptElementsList;

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationManagerInternalFactory.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationManagerInternalFactory.cs
@@ -7,7 +7,7 @@ namespace System.Configuration
 {
     internal static class ConfigurationManagerInternalFactory
     {
-        private static volatile IConfigurationManagerInternal s_instance;
+        private static IConfigurationManagerInternal s_instance;
 
         internal static IConfigurationManagerInternal Instance => s_instance ??= new ConfigurationManagerInternal();
     }

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationValues.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/ConfigurationValues.cs
@@ -8,7 +8,7 @@ namespace System.Configuration
 {
     internal sealed class ConfigurationValues : NameObjectCollectionBase
     {
-        private static volatile IEnumerable s_emptyCollection;
+        private static IEnumerable s_emptyCollection;
         private BaseConfigurationRecord _configRecord;
         private volatile bool _containsElement;
         private volatile bool _containsInvalidValue;

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/DefaultSection.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/DefaultSection.cs
@@ -7,7 +7,7 @@ namespace System.Configuration
 {
     public sealed class DefaultSection : ConfigurationSection
     {
-        private static volatile ConfigurationPropertyCollection s_properties;
+        private static ConfigurationPropertyCollection s_properties;
         private bool _isModified;
 
         private string _rawXml = string.Empty;

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/EmptyImpersonationContext.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/EmptyImpersonationContext.cs
@@ -6,7 +6,7 @@ namespace System.Configuration
     // Used in cases where the Host does not require impersonation.
     internal sealed class EmptyImpersonationContext : IDisposable
     {
-        private static volatile IDisposable s_emptyImpersonationContext;
+        private static IDisposable s_emptyImpersonationContext;
 
         public void Dispose() { }
 

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/IgnoreSection.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/IgnoreSection.cs
@@ -7,7 +7,7 @@ namespace System.Configuration
 {
     public sealed class IgnoreSection : ConfigurationSection
     {
-        private static volatile ConfigurationPropertyCollection s_properties;
+        private static ConfigurationPropertyCollection s_properties;
         private bool _isModified;
 
         private string _rawXml = string.Empty;

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingValueElement.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Configuration/SettingValueElement.cs
@@ -7,7 +7,7 @@ namespace System.Configuration
 {
     public sealed class SettingValueElement : ConfigurationElement
     {
-        private static volatile ConfigurationPropertyCollection _properties;
+        private static ConfigurationPropertyCollection _properties;
         private static readonly XmlDocument _document = new XmlDocument();
 
         private XmlNode _valueXml;

--- a/src/libraries/System.Configuration.ConfigurationManager/src/System/Diagnostics/DiagnosticsConfiguration.cs
+++ b/src/libraries/System.Configuration.ConfigurationManager/src/System/Diagnostics/DiagnosticsConfiguration.cs
@@ -8,7 +8,7 @@ namespace System.Diagnostics
 {
     internal static class DiagnosticsConfiguration
     {
-        private static volatile SystemDiagnosticsSection s_configSection;
+        private static SystemDiagnosticsSection s_configSection;
         private static volatile InitState s_initState = InitState.NotInitialized;
 
         // Setting for Switch.switchSetting

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DsesFilterAndTransform.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DsesFilterAndTransform.cs
@@ -971,7 +971,7 @@ internal sealed class DsesFilterAndTransform : IDisposable
 
             private readonly DiagnosticSourceEventSource _eventSource;
             private readonly string _propertyName;
-            private volatile PropertyFetch? _fetchForExpectedType;
+            private PropertyFetch? _fetchForExpectedType;
             #endregion
         }
 

--- a/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregatorStore.cs
+++ b/src/libraries/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Metrics/AggregatorStore.cs
@@ -56,8 +56,8 @@ namespace System.Diagnostics.Metrics
         // FixedSizeLabelNameDictionary<StringSequence3, ConcurrentDictionary<ObjectSequence3, TAggregator>>
         // FixedSizeLabelNameDictionary<StringSequenceMany, ConcurrentDictionary<ObjectSequenceMany, TAggregator>>
         // MultiSizeLabelNameDictionary<TAggregator> - this is used when we need to store more than one of the above union items
-        private volatile object? _stateUnion;
-        private volatile AggregatorLookupFunc<TAggregator>? _cachedLookupFunc;
+        private object? _stateUnion;
+        private AggregatorLookupFunc<TAggregator>? _cachedLookupFunc;
         private readonly Func<TAggregator?> _createAggregatorFunc;
 
         public AggregatorStore(Func<TAggregator?> createAggregator)

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/PerformanceCounterLib.cs
@@ -44,9 +44,9 @@ namespace System.Diagnostics
         private const string LanguageKeyword = "language";
         private const string DllName = "netfxperf.dll";
 
-        private static volatile string s_computerName;
-        private static volatile string s_iniFilePath;
-        private static volatile string s_symbolFilePath;
+        private static string s_computerName;
+        private static string s_iniFilePath;
+        private static string s_symbolFilePath;
 
         private static CultureInfo? s_englishCulture;
 
@@ -55,7 +55,7 @@ namespace System.Diagnostics
         private readonly string _perfLcid;
 
 
-        private static volatile Hashtable s_libraryTable;
+        private static Hashtable s_libraryTable;
         private Hashtable _customCategoryTable;
         private Hashtable _categoryTable;
         private Hashtable _nameTable;

--- a/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SharedPerformanceCounter.cs
+++ b/src/libraries/System.Diagnostics.PerformanceCounter/src/System/Diagnostics/SharedPerformanceCounter.cs
@@ -27,7 +27,7 @@ namespace System.Diagnostics
 
         private static long s_lastInstanceLifetimeSweepTick;
         private const long InstanceLifetimeSweepWindow = 30 * 10000000; //ticks
-        private static volatile ProcessData s_procData;
+        private static ProcessData s_procData;
 
         private static ProcessData ProcessData
         {

--- a/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/libraries/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -9,7 +9,7 @@ namespace System.Diagnostics
 {
     internal static partial class ProcessManager
     {
-        private static volatile NullableBool _procMatchesPidNamespace;
+        private static NullableBool _procMatchesPidNamespace;
 
         /// <summary>Gets the IDs of all processes on the current machine.</summary>
         public static int[] GetProcessIds() => new List<int>(EnumerateProcessIds()).ToArray();

--- a/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Expressions
         internal const string DelegateCreationRequiresDynamicCode = "Delegate creation requires dynamic code generation.";
 
         private static readonly CacheDict<Type, MethodInfo> s_lambdaDelegateCache = new CacheDict<Type, MethodInfo>(40);
-        private static volatile CacheDict<Type, Func<Expression, string?, bool, ReadOnlyCollection<ParameterExpression>, LambdaExpression>>? s_lambdaFactories;
+        private static CacheDict<Type, Func<Expression, string?, bool, ReadOnlyCollection<ParameterExpression>, LambdaExpression>>? s_lambdaFactories;
 
         // For 4.0, many frequently used Expression nodes have had their memory
         // footprint reduced by removing the Type and NodeType fields. This has

--- a/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/libraries/System.Linq.Expressions/src/System/Runtime/CompilerServices/CallSite.cs
@@ -51,7 +51,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Cache of CallSite constructors for a given delegate type.
         /// </summary>
-        private static volatile CacheDict<Type, Func<CallSiteBinder, CallSite>>? s_siteCtors;
+        private static CacheDict<Type, Func<CallSiteBinder, CallSite>>? s_siteCtors;
 
         /// <summary>
         /// The Binder responsible for binding operations at this call site.
@@ -162,7 +162,7 @@ namespace System.Runtime.CompilerServices
         private static T? s_cachedUpdate;
 
         // Cached noMatch delegate for all sites with a given T
-        private static volatile T? s_cachedNoMatch;
+        private static T? s_cachedNoMatch;
 
         [RequiresDynamicCode(Expression.NewArrayRequiresDynamicCode)]
         private CallSite(CallSiteBinder binder)

--- a/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/EmptyEnumerable.cs
+++ b/src/libraries/System.Linq.Parallel/src/System/Linq/Parallel/Enumerables/EmptyEnumerable.cs
@@ -27,8 +27,8 @@ namespace System.Linq.Parallel
         }
 
         // A singleton cached and shared among callers.
-        private static volatile EmptyEnumerable<T>? s_instance;
-        private static volatile EmptyEnumerator<T>? s_enumeratorInstance;
+        private static EmptyEnumerable<T>? s_instance;
+        private static EmptyEnumerator<T>? s_enumeratorInstance;
 
         internal static EmptyEnumerable<T> Instance =>
             // There is no need for thread safety here.

--- a/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
+++ b/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/AuthenticationHelper.NtAuth.cs
@@ -19,7 +19,7 @@ namespace System.Net.Http
         private const string UsePortInSpnCtxSwitch = "System.Net.Http.UsePortInSpn";
         private const string UsePortInSpnEnvironmentVariable = "DOTNET_SYSTEM_NET_HTTP_USEPORTINSPN";
 
-        private static volatile NullableBool s_usePortInSpn;
+        private static NullableBool s_usePortInSpn;
 
         private static bool UsePortInSpn
         {

--- a/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/libraries/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -15,7 +15,7 @@ namespace System.Net
 {
     internal static partial class NameResolutionPal
     {
-        private static volatile NullableBool s_getAddrInfoExSupported;
+        private static NullableBool s_getAddrInfoExSupported;
 
         public static bool SupportsGetAddrInfoAsync
         {

--- a/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/libraries/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -83,7 +83,7 @@ namespace System.Net
         private DecompressionMethods _automaticDecompression = HttpHandlerDefaults.DefaultAutomaticDecompression;
 
         private static readonly object s_syncRoot = new object();
-        private static volatile HttpClient? s_cachedHttpClient;
+        private static HttpClient? s_cachedHttpClient;
         private static HttpClientParameters? s_cachedHttpClientParameters;
         private bool _disposeRequired;
         private HttpClient? _httpClient;

--- a/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/CertificateValidationPal.cs
@@ -14,8 +14,8 @@ namespace System.Net
     {
         private static readonly object s_syncObject = new object();
 
-        private static volatile X509Store? s_myCertStoreEx;
-        private static volatile X509Store? s_myMachineCertStoreEx;
+        private static X509Store? s_myCertStoreEx;
+        private static X509Store? s_myMachineCertStoreEx;
         private static X509Chain? s_chain;
 
         internal static X509Certificate2? GetRemoteCertificate(SafeDeleteContext? securityContext) =>

--- a/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.NonWasm.cs
+++ b/src/libraries/System.Net.WebProxy/src/System/Net/WebProxy.NonWasm.cs
@@ -9,8 +9,8 @@ namespace System.Net
 {
     public partial class WebProxy : IWebProxy, ISerializable
     {
-        private static volatile string? s_domainName;
-        private static volatile IPAddress[]? s_localAddresses;
+        private static string? s_domainName;
+        private static IPAddress[]? s_localAddresses;
         private static bool s_networkChangeRegistered;
 
         private static bool IsLocal(Uri host)

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Win32.SafeHandles
             || AppContextConfigHelper.GetBooleanConfig("System.IO.DisableFileLocking", "DOTNET_SYSTEM_IO_DISABLEFILELOCKING", defaultValue: false);
 
         // not using bool? as it's not thread safe
-        private volatile NullableBool _canSeek /* = NullableBool.Undefined */;
-        private volatile NullableBool _supportsRandomAccess /* = NullableBool.Undefined */;
-        private volatile NullableBool _isAsync /* = NullableBool.Undefined */;
+        private NullableBool _canSeek /* = NullableBool.Undefined */;
+        private NullableBool _supportsRandomAccess /* = NullableBool.Undefined */;
+        private NullableBool _isAsync /* = NullableBool.Undefined */;
         private bool _deleteOnClose;
         private bool _isLocked;
 

--- a/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.cs
+++ b/src/libraries/System.Private.CoreLib/src/Microsoft/Win32/SafeHandles/SafeFileHandle.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Win32.SafeHandles
     public sealed partial class SafeFileHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         private string? _path;
-        private volatile int _cachedFileType = -1;
+        private int _cachedFileType = -1;
 
         /// <summary>
         /// Creates an anonymous pipe.
@@ -54,7 +54,7 @@ namespace Microsoft.Win32.SafeHandles
                 int cachedType = _cachedFileType;
                 if (cachedType == -1)
                 {
-                    cachedType = _cachedFileType = (int)GetFileTypeCore();
+                    _cachedFileType = cachedType = (int)GetFileTypeCore();
                 }
 
                 return (System.IO.FileHandleType)cachedType;

--- a/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Debug.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Debug.cs
@@ -17,7 +17,7 @@ namespace System.Diagnostics
     /// </summary>
     public static partial class Debug
     {
-        private static volatile DebugProvider s_provider = new DebugProvider();
+        private static DebugProvider s_provider = new DebugProvider();
 
         public static DebugProvider GetProvider() => s_provider;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Environment.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Environment.cs
@@ -41,7 +41,7 @@ namespace System
         internal static bool IsSingleProcessor => RuntimeFeature.IsMultithreadingSupported ? ProcessorCount == 1 : true;
         public static int ProcessorCount { get; } = RuntimeFeature.IsMultithreadingSupported ? GetProcessorCount() : 1;
 
-        private static volatile NullableBool s_privilegedProcess;
+        private static NullableBool s_privilegedProcess;
 
         /// <summary>
         /// Gets whether the current process is authorized to perform security-relevant functions.
@@ -162,7 +162,7 @@ namespace System
             return GetFolderPathCore(folder, option);
         }
 
-        private static volatile int s_processId;
+        private static int s_processId;
 
         /// <summary>Gets the unique identifier for the current process.</summary>
         public static int ProcessId
@@ -180,7 +180,7 @@ namespace System
             }
         }
 
-        private static volatile string? s_processPath;
+        private static string? s_processPath;
 
         /// <summary>
         /// Returns the path of the executable that started the currently executing process. Returns null when the path is not available.
@@ -212,7 +212,7 @@ namespace System
 
         public static string NewLine => NewLineConst;
 
-        private static volatile OperatingSystem? s_osVersion;
+        private static OperatingSystem? s_osVersion;
 
         public static OperatingSystem OSVersion
         {
@@ -235,7 +235,7 @@ namespace System
             get => new StackTrace(true).ToString(Diagnostics.StackTrace.TraceFormat.Normal);
         }
 
-        private static volatile int s_systemPageSize;
+        private static int s_systemPageSize;
 
         public static int SystemPageSize
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureData.cs
@@ -410,7 +410,7 @@ namespace System.Globalization
             };
 
         // Cache of regions we've already looked up
-        private static volatile Dictionary<string, CultureData>? s_cachedRegions;
+        private static Dictionary<string, CultureData>? s_cachedRegions;
         private static Dictionary<string, string>? s_regionNames;
 
         /// <summary>
@@ -655,7 +655,7 @@ namespace System.Globalization
         internal static CultureData Invariant => field ??= CreateCultureWithInvariantData();
 
         // Cache of cultures we've already looked up
-        private static volatile Dictionary<string, CultureData>? s_cachedCultures;
+        private static Dictionary<string, CultureData>? s_cachedCultures;
 
         internal static CultureData? GetCultureData(string? cultureName, bool useUserOverride)
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/CultureInfo.cs
@@ -96,10 +96,10 @@ namespace System.Globalization
         private string? _sortName;
 
         // Get the current user default culture. This one is almost always used, so we create it by default.
-        private static volatile CultureInfo? s_userDefaultCulture;
+        private static CultureInfo? s_userDefaultCulture;
 
         // The culture used in the user interface. This is mostly used to load correct localized resources.
-        private static volatile CultureInfo? s_userDefaultUICulture;
+        private static CultureInfo? s_userDefaultUICulture;
 
         // The Invariant culture;
         private static readonly CultureInfo s_InvariantCultureInfo = new CultureInfo(CultureData.Invariant, isReadOnly: true);

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -18,7 +18,7 @@ namespace System.Reflection.Emit
         // We capture the creation context so that we can do the checks against the same context,
         // irrespective of when the method gets compiled. Note that the DynamicMethod does not know when
         // it is ready for use since there is not API which indictates that IL generation has completed.
-        private static volatile Module? s_anonymouslyHostedDynamicMethodsModule;
+        private static Module? s_anonymouslyHostedDynamicMethodsModule;
         private static readonly object s_anonymouslyHostedDynamicMethodsModuleLock = new object();
 
         //

--- a/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/Opcode.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Reflection/Emit/Opcode.cs
@@ -73,7 +73,7 @@ namespace System.Reflection.Emit
 
         public short Value => (short)m_value;
 
-        private static volatile string[]? g_nameCache;
+        private static string[]? g_nameCache;
 
         public string? Name
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.Unix.cs
@@ -7,7 +7,7 @@ namespace System.Runtime.InteropServices
 {
     public static partial class RuntimeInformation
     {
-        private static volatile int s_osArchPlusOne;
+        private static int s_osArchPlusOne;
 
         public static string OSDescription => field ??=
 #if TARGET_ANDROID

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.Windows.cs
@@ -8,7 +8,7 @@ namespace System.Runtime.InteropServices
     public static partial class RuntimeInformation
     {
         private static string? s_osDescription;
-        private static volatile int s_osArchPlusOne;
+        private static int s_osArchPlusOne;
 
         public static string OSDescription
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncodingProvider.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncodingProvider.cs
@@ -8,7 +8,7 @@ namespace System.Text
 {
     public abstract class EncodingProvider
     {
-        private static volatile EncodingProvider[]? s_providers;
+        private static EncodingProvider[]? s_providers;
 
         public EncodingProvider() { }
         public abstract Encoding? GetEncoding(string name);

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZone.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZone.cs
@@ -12,7 +12,7 @@ namespace System
     [Obsolete("System.TimeZone has been deprecated. Investigate the use of System.TimeZoneInfo instead.")]
     public abstract class TimeZone
     {
-        private static volatile TimeZone? currentTimeZone;
+        private static TimeZone? currentTimeZone;
 
         // Private object for locking instead of locking on a public type for SQL reliability work.
         private static object InternalSyncObject =>

--- a/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/TimeZoneInfo.cs
@@ -71,7 +71,7 @@ namespace System
         //
         private sealed partial class CachedData
         {
-            private volatile TimeZoneInfo? _localTimeZone;
+            private TimeZoneInfo? _localTimeZone;
 
             private TimeZoneInfo CreateLocal()
             {

--- a/src/libraries/System.Private.Xml/src/System/Xml/BinaryXml/XmlBinaryReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/BinaryXml/XmlBinaryReader.cs
@@ -16,7 +16,7 @@ namespace System.Xml
 {
     internal sealed partial class XmlSqlBinaryReader : XmlReader, IXmlNamespaceResolver
     {
-        private static volatile Type?[] s_tokenTypeMap = null!;
+        private static Type?[] s_tokenTypeMap = null!;
 
         private static ReadOnlySpan<byte> XsdKatmaiTimeScaleToValueLengthMap => // 8
         [

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplHelpers.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplHelpers.cs
@@ -333,7 +333,7 @@ namespace System.Xml
         private sealed class NodeData : IComparable
         {
             // static instance with no data - is used when XmlTextReader is closed
-            private static volatile NodeData? s_None;
+            private static NodeData? s_None;
 
             // NOTE: Do not use this property for reference comparison. It may not be unique.
             internal static NodeData None =>

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdValidatingReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XsdValidatingReader.cs
@@ -120,7 +120,7 @@ namespace System.Xml
         // Constants
         private const int InitialAttributeCount = 8;
 
-        private static volatile Type s_typeOfString = null!;
+        private static Type s_typeOfString = null!;
 
         // Constructor
         internal XsdValidatingReader(XmlReader reader, XmlResolver? xmlResolver, XmlReaderSettings readerSettings, XmlSchemaObject? partialValidationType)

--- a/src/libraries/System.Private.Xml/src/System/Xml/DiagnosticsSwitches.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/DiagnosticsSwitches.cs
@@ -7,8 +7,8 @@ namespace System.Xml
 {
     internal static class DiagnosticsSwitches
     {
-        private static volatile BooleanSwitch? s_keepTempFiles;
-        private static volatile BooleanSwitch? s_nonRecursiveTypeLoading;
+        private static BooleanSwitch? s_keepTempFiles;
+        private static BooleanSwitch? s_nonRecursiveTypeLoading;
 
         public static BooleanSwitch KeepTempFiles =>
             s_keepTempFiles ??= new BooleanSwitch("XmlSerialization.Compilation", "Keep XmlSerialization generated (temp) files.");

--- a/src/libraries/System.Private.Xml/src/System/Xml/Schema/DataTypeImplementation.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Schema/DataTypeImplementation.cs
@@ -109,8 +109,8 @@ namespace System.Xml.Schema
         private static XmlSchemaSimpleType s__untypedAtomicType = null!;
         private static XmlSchemaSimpleType s_yearMonthDurationType = null!;
         private static XmlSchemaSimpleType s_dayTimeDurationType = null!;
-        private static volatile XmlSchemaSimpleType? s_normalizedStringTypeV1Compat;
-        private static volatile XmlSchemaSimpleType? s_tokenTypeV1Compat;
+        private static XmlSchemaSimpleType? s_normalizedStringTypeV1Compat;
+        private static XmlSchemaSimpleType? s_tokenTypeV1Compat;
 
         private const int anySimpleTypeIndex = 11;
 

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSchemas.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSchemas.cs
@@ -25,8 +25,8 @@ namespace System.Xml.Serialization
         private bool _shareTypes;
         internal Hashtable delayedSchemas = new Hashtable();
         private bool _isCompiled;
-        private static volatile XmlSchema? s_xsd;
-        private static volatile XmlSchema? s_xml;
+        private static XmlSchema? s_xsd;
+        private static XmlSchema? s_xml;
 
         public XmlSchema this[int index]
         {

--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/XmlSerializer.cs
@@ -139,7 +139,7 @@ namespace System.Xml.Serialization
         private bool _isReflectionBasedSerializer;
 
         private static readonly TempAssemblyCache s_cache = new TempAssemblyCache();
-        private static volatile XmlSerializerNamespaces? s_defaultNamespaces;
+        private static XmlSerializerNamespaces? s_defaultNamespaces;
         private static readonly XmlWriterSettings s_writerSettings = new XmlWriterSettings() { Encoding = new UTF8Encoding(false), Indent = true };
 
         private static XmlSerializerNamespaces DefaultNamespaces

--- a/src/libraries/System.Private.Xml/src/System/Xml/XPath/XPathNavigatorReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XPath/XPathNavigatorReader.cs
@@ -1143,7 +1143,7 @@ namespace System.Xml.XPath
     /// </summary>
     internal sealed class XmlEmptyNavigator : XPathNavigator
     {
-        private static volatile XmlEmptyNavigator? s_singleton;
+        private static XmlEmptyNavigator? s_singleton;
 
         private XmlEmptyNavigator()
         {

--- a/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/XmlConvert.cs
@@ -1144,7 +1144,7 @@ namespace System.Xml
         }
 
         // use AllDateTimeFormats property to access the formats
-        private static volatile string[]? s_allDateTimeFormats;
+        private static string[]? s_allDateTimeFormats;
 
         // NOTE: Do not use this property for reference comparison. It may not be unique.
         private static string[] AllDateTimeFormats

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/OptimizerPatterns.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/OptimizerPatterns.cs
@@ -60,9 +60,9 @@ namespace System.Xml.Xsl.IlGen
         private bool _isReadOnly;            // True if setters are disabled in the case of singleton OptimizerPatterns
         private object? _arg0, _arg1, _arg2;    // Arguments to the matching patterns
 
-        private static volatile OptimizerPatterns? s_zeroOrOneDefault;
-        private static volatile OptimizerPatterns? s_maybeManyDefault;
-        private static volatile OptimizerPatterns? s_dodDefault;
+        private static OptimizerPatterns? s_zeroOrOneDefault;
+        private static OptimizerPatterns? s_maybeManyDefault;
+        private static OptimizerPatterns? s_dodDefault;
 
         /// <summary>
         /// Get OptimizerPatterns annotation for the specified node.  Lazily create if necessary.

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlILConstructAnalyzer.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlILConstructAnalyzer.cs
@@ -56,7 +56,7 @@ namespace System.Xml.Xsl.IlGen
         private XmlILConstructInfo? _parentInfo;
         private bool _isReadOnly;
 
-        private static volatile XmlILConstructInfo? s_default;
+        private static XmlILConstructInfo? s_default;
 
         /// <summary>
         /// Get ConstructInfo annotation for the specified node.  Lazily create if necessary.

--- a/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlILTrace.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Xsl/IlGen/XmlILTrace.cs
@@ -24,7 +24,7 @@ namespace System.Xml.Xsl.IlGen
         /// Check environment variable in order to determine whether to write out trace files.  This really should be a
         /// check of the configuration file, but System.Xml does not yet have a good tracing story.
         /// </summary>
-        private static volatile string? s_dirName;
+        private static string? s_dirName;
         private static volatile bool s_alreadyCheckedEnabled;
 
         /// <summary>

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/NamespaceCache.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/Internal/NamespaceCache.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.Metadata.Ecma335
     {
         private readonly MetadataReader _metadataReader;
         private readonly object _namespaceTableAndListLock = new object();
-        private volatile Dictionary<NamespaceDefinitionHandle, NamespaceData>? _namespaceTable;
+        private Dictionary<NamespaceDefinitionHandle, NamespaceData>? _namespaceTable;
         private NamespaceData? _rootNamespace;
         private uint _virtualNamespaceCounter;
 

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/MetadataLoadContext.CoreAssembly.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/MetadataLoadContext.CoreAssembly.cs
@@ -85,6 +85,6 @@ namespace System.Reflection
         // one reason, we have to instance it per MetadataLoadContext.
         //
         internal Binder GetDefaultBinder() => _lazyDefaultBinder ??= new DefaultBinder(this);
-        private volatile Binder? _lazyDefaultBinder;
+        private Binder? _lazyDefaultBinder;
     }
 }

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/MetadataLoadContext.KnownConstructors.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/MetadataLoadContext.KnownConstructors.cs
@@ -9,28 +9,28 @@ namespace System.Reflection
     public sealed partial class MetadataLoadContext
     {
         internal ConstructorInfo? TryGetFieldOffsetCtor() => _lazyFieldOffset ??= TryGetConstructor(CoreType.FieldOffsetAttribute, CoreType.Int32);
-        private volatile ConstructorInfo? _lazyFieldOffset;
+        private ConstructorInfo? _lazyFieldOffset;
 
         internal ConstructorInfo? TryGetInCtor() => _lazyIn ??= TryGetConstructor(CoreType.InAttribute);
-        private volatile ConstructorInfo? _lazyIn;
+        private ConstructorInfo? _lazyIn;
 
         internal ConstructorInfo? TryGetOutCtor() => _lazyOut ??= TryGetConstructor(CoreType.OutAttribute);
-        private volatile ConstructorInfo? _lazyOut;
+        private ConstructorInfo? _lazyOut;
 
         internal ConstructorInfo? TryGetOptionalCtor() => _lazyOptional ??= TryGetConstructor(CoreType.OptionalAttribute);
-        private volatile ConstructorInfo? _lazyOptional;
+        private ConstructorInfo? _lazyOptional;
 
         internal ConstructorInfo? TryGetPreserveSigCtor() => _lazyPreserveSig ??= TryGetConstructor(CoreType.PreserveSigAttribute);
-        private volatile ConstructorInfo? _lazyPreserveSig;
+        private ConstructorInfo? _lazyPreserveSig;
 
         internal ConstructorInfo? TryGetComImportCtor() => _lazyComImport ??= TryGetConstructor(CoreType.ComImportAttribute);
-        private volatile ConstructorInfo? _lazyComImport;
+        private ConstructorInfo? _lazyComImport;
 
         internal ConstructorInfo? TryGetDllImportCtor() => _lazyDllImport ??= TryGetConstructor(CoreType.DllImportAttribute, CoreType.String);
-        private volatile ConstructorInfo? _lazyDllImport;
+        private ConstructorInfo? _lazyDllImport;
 
         internal ConstructorInfo? TryGetMarshalAsCtor() => _lazyMarshalAs ??= TryGetConstructor(CoreType.MarshalAsAttribute, CoreType.UnmanagedType);
-        private volatile ConstructorInfo? _lazyMarshalAs;
+        private ConstructorInfo? _lazyMarshalAs;
 
         private ConstructorInfo? TryGetConstructor(CoreType attributeCoreType, params CoreType[] parameterCoreTypes)
         {

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Assemblies/RoAssembly.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Assemblies/RoAssembly.cs
@@ -36,7 +36,7 @@ namespace System.Reflection.TypeLoading
         public sealed override AssemblyName GetName(bool copiedName) => GetAssemblyNameDataNoCopy().CreateAssemblyName();
         internal AssemblyNameData GetAssemblyNameDataNoCopy() => _lazyAssemblyNameData ??= ComputeNameData();
         protected abstract AssemblyNameData ComputeNameData();
-        private volatile AssemblyNameData? _lazyAssemblyNameData;
+        private AssemblyNameData? _lazyAssemblyNameData;
 
         public sealed override string FullName => field ??= GetName().FullName;
 
@@ -151,7 +151,7 @@ namespace System.Reflection.TypeLoading
 
         private AssemblyNameData[] GetReferencedAssembliesNoCopy() => _lazyAssemblyReferences ??= ComputeAssemblyReferences();
         protected abstract AssemblyNameData[] ComputeAssemblyReferences();
-        private volatile AssemblyNameData[]? _lazyAssemblyReferences;
+        private AssemblyNameData[]? _lazyAssemblyReferences;
 
         // Miscellaneous properties
         public sealed override bool ReflectionOnly => true;

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/CustomAttributes/Ecma/EcmaCustomAttributeData.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/CustomAttributes/Ecma/EcmaCustomAttributeData.cs
@@ -13,8 +13,8 @@ namespace System.Reflection.TypeLoading.Ecma
         private readonly CustomAttributeHandle _handle;
         private readonly EcmaModule _module;
 
-        private volatile IList<CustomAttributeTypedArgument<RoType>>? _lazyFixedArguments;
-        private volatile IList<CustomAttributeNamedArgument<RoType>>? _lazyNamedArguments;
+        private IList<CustomAttributeTypedArgument<RoType>>? _lazyFixedArguments;
+        private IList<CustomAttributeNamedArgument<RoType>>? _lazyNamedArguments;
 
         internal EcmaCustomAttributeData(CustomAttributeHandle handle, EcmaModule module)
         {

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/CustomAttributes/RoPseudoCustomAttributeData.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/CustomAttributes/RoPseudoCustomAttributeData.cs
@@ -10,8 +10,8 @@ namespace System.Reflection.TypeLoading
         private readonly ConstructorInfo _constructor;
         private readonly Func<CustomAttributeArguments>? _argumentsPromise;
 
-        private volatile IList<CustomAttributeTypedArgument>? _lazyFixedArguments;
-        private volatile IList<CustomAttributeNamedArgument>? _lazyNamedArguments;
+        private IList<CustomAttributeTypedArgument>? _lazyFixedArguments;
+        private IList<CustomAttributeNamedArgument>? _lazyNamedArguments;
 
         //
         // For complex custom attributes, use this overload to defer the work of constructing the argument lists until needed.

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Events/RoEvent.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Events/RoEvent.cs
@@ -64,9 +64,9 @@ namespace System.Reflection.TypeLoading
         protected abstract RoMethod? ComputeEventRemoveMethod();
         protected abstract RoMethod? ComputeEventRaiseMethod();
 
-        private volatile RoMethod? _lazyAdder = Sentinels.RoMethod;
-        private volatile RoMethod? _lazyRemover = Sentinels.RoMethod;
-        private volatile RoMethod? _lazyRaiser = Sentinels.RoMethod;
+        private RoMethod? _lazyAdder = Sentinels.RoMethod;
+        private RoMethod? _lazyRemover = Sentinels.RoMethod;
+        private RoMethod? _lazyRaiser = Sentinels.RoMethod;
 
         public abstract override MethodInfo[] GetOtherMethods(bool nonPublic);
 

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Fields/RoField.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Fields/RoField.cs
@@ -123,8 +123,8 @@ namespace System.Reflection.TypeLoading
         }
 
         protected abstract Type ComputeFieldType();
-        private volatile Type? _lazyFieldType;
-        protected volatile RoModifiedType? _modifiedType;
+        private Type? _lazyFieldType;
+        protected RoModifiedType? _modifiedType;
 
         public sealed override object? GetRawConstantValue() => IsLiteral ? ComputeRawConstantValue() : throw new InvalidOperationException();
         protected abstract object? ComputeRawConstantValue();

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/MethodBase/RoMethodBody.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/MethodBase/RoMethodBody.cs
@@ -18,7 +18,7 @@ namespace System.Reflection.TypeLoading
         // Unlike most apis, this one does not copy the byte array.
         public sealed override byte[]? GetILAsByteArray() => _lazyIL ??= ComputeIL();
         protected abstract byte[]? ComputeIL();
-        private volatile byte[]? _lazyIL;
+        private byte[]? _lazyIL;
 
         public abstract override IList<LocalVariableInfo> LocalVariables { get; }
         public abstract override IList<ExceptionHandlingClause> ExceptionHandlingClauses { get; }

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Methods/RoMethod.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Methods/RoMethod.cs
@@ -100,7 +100,7 @@ namespace System.Reflection.TypeLoading
         public sealed override Type[] GetGenericArguments() => GetGenericArgumentsOrParametersNoCopy().CloneArray<Type>();
         internal RoType[] GetGenericArgumentsOrParametersNoCopy() => _lazyGenericArgumentsOrParameters ??= ComputeGenericArgumentsOrParameters();
         protected abstract RoType[] ComputeGenericArgumentsOrParameters();
-        private volatile RoType[]? _lazyGenericArgumentsOrParameters;
+        private RoType[]? _lazyGenericArgumentsOrParameters;
 
         internal abstract RoType[] GetGenericTypeParametersNoCopy();
         internal abstract RoType[] GetGenericTypeArgumentsNoCopy();

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Modules/Ecma/EcmaModule.MetadataTables.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Modules/Ecma/EcmaModule.MetadataTables.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.TypeLoading.Ecma
                     _lazyTypeDefTable;
             }
         }
-        private volatile MetadataTable<EcmaDefinitionType, EcmaModule>? _lazyTypeDefTable;
+        private MetadataTable<EcmaDefinitionType, EcmaModule>? _lazyTypeDefTable;
 
         private void EnsureTypeDefTableFullyFilled()
         {

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Properties/RoProperty.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Properties/RoProperty.cs
@@ -87,8 +87,8 @@ namespace System.Reflection.TypeLoading
         }
 
         protected abstract Type ComputePropertyType();
-        private volatile Type? _lazyPropertyType;
-        protected volatile RoModifiedType? _modifiedType;
+        private Type? _lazyPropertyType;
+        protected RoModifiedType? _modifiedType;
 
         public sealed override MethodInfo? GetGetMethod(bool nonPublic) => GetRoGetMethod()?.FilterAccessor(nonPublic);
         public sealed override MethodInfo? GetSetMethod(bool nonPublic) => GetRoSetMethod()?.FilterAccessor(nonPublic);
@@ -99,8 +99,8 @@ namespace System.Reflection.TypeLoading
         protected abstract RoMethod? ComputeGetterMethod();
         protected abstract RoMethod? ComputeSetterMethod();
 
-        private volatile RoMethod? _lazyGetter = Sentinels.RoMethod;
-        private volatile RoMethod? _lazySetter = Sentinels.RoMethod;
+        private RoMethod? _lazyGetter = Sentinels.RoMethod;
+        private RoMethod? _lazySetter = Sentinels.RoMethod;
 
         public sealed override bool CanRead => GetMethod != null;
         public sealed override bool CanWrite => SetMethod != null;
@@ -147,7 +147,7 @@ namespace System.Reflection.TypeLoading
             }
             return indexParameters;
         }
-        private volatile RoPropertyIndexParameter[]? _lazyIndexedParameters;
+        private RoPropertyIndexParameter[]? _lazyIndexedParameters;
 
         public sealed override object? GetRawConstantValue()
         {

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/Ecma/EcmaDefinitionType.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/Ecma/EcmaDefinitionType.cs
@@ -95,7 +95,7 @@ namespace System.Reflection.TypeLoading.Ecma
             }
             return genericParameters;
         }
-        private volatile RoType[]? _lazyGenericParameters;
+        private RoType[]? _lazyGenericParameters;
 
         protected internal sealed override RoType ComputeEnumUnderlyingType()
         {

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/Ecma/EcmaGenericMethodParameterType.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/Ecma/EcmaGenericMethodParameterType.cs
@@ -25,7 +25,7 @@ namespace System.Reflection.TypeLoading.Ecma
         public sealed override MethodBase DeclaringMethod => GetRoDeclaringMethod();
         private RoMethod GetRoDeclaringMethod() => _lazyDeclaringMethod ??= ComputeDeclaringMethod();
         private RoMethod ComputeDeclaringMethod() => ((MethodDefinitionHandle)(GenericParameter.Parent)).ResolveMethod<RoMethod>(GetEcmaModule(), default);
-        private volatile RoMethod? _lazyDeclaringMethod;
+        private RoMethod? _lazyDeclaringMethod;
 
         protected sealed override TypeContext TypeContext => GetRoDeclaringMethod().TypeContext;
     }

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoFunctionPointerType.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoFunctionPointerType.cs
@@ -23,7 +23,7 @@ namespace System.Reflection.TypeLoading
         internal readonly Type _returnType;
         internal readonly Type[] _parameterTypes;
 
-        private volatile string? _toString;
+        private string? _toString;
 
         private string GetToString() => _toString ??= ComputeToString();
 

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoGenericParameterType.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoGenericParameterType.cs
@@ -50,12 +50,12 @@ namespace System.Reflection.TypeLoading
 
         public sealed override int GenericParameterPosition => (_lazyPosition == -1) ? (_lazyPosition = ComputePosition()) : _lazyPosition;
         protected abstract int ComputePosition();
-        private volatile int _lazyPosition = -1;
+        private int _lazyPosition = -1;
 
         public sealed override Type[] GetGenericParameterConstraints() => GetGenericParameterConstraintsNoCopy().CloneArray<Type>();
         private RoType[] GetGenericParameterConstraintsNoCopy() => _lazyConstraints ??= ComputeGenericParameterConstraints();
         protected abstract RoType[] ComputeGenericParameterConstraints();
-        private volatile RoType[]? _lazyConstraints;
+        private RoType[]? _lazyConstraints;
 
         public sealed override Type GetFunctionPointerReturnType() => throw new InvalidOperationException(SR.InvalidOperation_NotFunctionPointer);
         public sealed override Type[] GetFunctionPointerParameterTypes() => throw new InvalidOperationException(SR.InvalidOperation_NotFunctionPointer);

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoType.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/Types/RoType.cs
@@ -136,7 +136,7 @@ namespace System.Reflection.TypeLoading
         protected abstract RoType? ComputeDeclaringType();
         internal RoType? GetRoDeclaringType() => _lazyDeclaringType ??= ComputeDeclaringType();
         internal RoType? Call_ComputeDeclaringType() => ComputeDeclaringType();
-        private volatile RoType? _lazyDeclaringType;
+        private RoType? _lazyDeclaringType;
 
         public abstract override MethodBase? DeclaringMethod { get; }
         // .NET Framework compat: For types, ReflectedType == DeclaringType. Nested types are always looked up as if BindingFlags.DeclaredOnly was passed.
@@ -167,7 +167,7 @@ namespace System.Reflection.TypeLoading
             }
             return baseType;
         }
-        private volatile RoType? _lazyBaseType = Sentinels.RoType;
+        private RoType? _lazyBaseType = Sentinels.RoType;
 
         //
         // This internal method implements BaseType without the following .NET Framework quirk:
@@ -239,7 +239,7 @@ namespace System.Reflection.TypeLoading
             return arr;
         }
 
-        private volatile RoType[]? _lazyInterfaces;
+        private RoType[]? _lazyInterfaces;
 
         public sealed override InterfaceMapping GetInterfaceMap(Type interfaceType) => throw new NotSupportedException(SR.NotSupported_InterfaceMapping);
 
@@ -324,7 +324,7 @@ namespace System.Reflection.TypeLoading
         // Enum methods
         public sealed override Type GetEnumUnderlyingType() => _lazyUnderlyingEnumType ??= ComputeEnumUnderlyingType();
         protected internal abstract RoType ComputeEnumUnderlyingType();
-        private volatile RoType? _lazyUnderlyingEnumType;
+        private RoType? _lazyUnderlyingEnumType;
         public sealed override Array GetEnumValues() => throw new InvalidOperationException(SR.Arg_InvalidOperation_Reflection);
 
 #if NET

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryParser.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/BinaryParser.cs
@@ -45,7 +45,7 @@ namespace System.Runtime.Serialization.Formatters.Binary
         internal MemberPrimitiveUnTyped? memberPrimitiveUnTyped;
         internal MemberReference? _memberReference;
         internal ObjectNull? _objectNull;
-        internal static volatile MessageEnd? _messageEnd;
+        internal static MessageEnd? _messageEnd;
 
         internal BinaryParser(Stream stream, ObjectReader objectReader)
         {

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/Converter.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/Formatters/Binary/Converter.cs
@@ -64,11 +64,11 @@ namespace System.Runtime.Serialization.Formatters.Binary
 
         private const int PrimitiveTypeEnumLength = 17; //Number of PrimitiveTypeEnums
 
-        private static volatile Type?[]? s_typeA;
-        private static volatile Type?[]? s_arrayTypeA;
-        private static volatile string?[]? s_valueA;
-        private static volatile TypeCode[]? s_typeCodeA;
-        private static volatile InternalPrimitiveTypeE[]? s_codeA;
+        private static Type?[]? s_typeA;
+        private static Type?[]? s_arrayTypeA;
+        private static string?[]? s_valueA;
+        private static TypeCode[]? s_typeCodeA;
+        private static InternalPrimitiveTypeE[]? s_codeA;
 
         internal static InternalPrimitiveTypeE ToCode(Type? type) =>
                 type == null ? ToPrimitiveTypeEnum(TypeCode.Empty) :

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
@@ -151,7 +151,7 @@ namespace System.Security.AccessControl
             private SafeTokenHandle? threadHandle = new SafeTokenHandle(IntPtr.Zero);
             private readonly bool isImpersonating;
 
-            private static volatile SafeTokenHandle processHandle = new SafeTokenHandle(IntPtr.Zero);
+            private static SafeTokenHandle processHandle = new SafeTokenHandle(IntPtr.Zero);
             private static readonly object syncRoot = new object();
 
             #region Constructor and Finalizer

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/KeyAgreeRecipientInfo.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/KeyAgreeRecipientInfo.cs
@@ -85,11 +85,11 @@ namespace System.Security.Cryptography.Pkcs
             }
         }
 
-        private volatile SubjectIdentifier? _lazyRecipientIdentifier;
-        private volatile AlgorithmIdentifier? _lazyKeyEncryptionAlgorithm;
-        private volatile byte[]? _lazyEncryptedKey;
-        private volatile SubjectIdentifierOrKey? _lazyOriginatorIdentifierKey;
+        private SubjectIdentifier? _lazyRecipientIdentifier;
+        private AlgorithmIdentifier? _lazyKeyEncryptionAlgorithm;
+        private byte[]? _lazyEncryptedKey;
+        private SubjectIdentifierOrKey? _lazyOriginatorIdentifierKey;
         private DateTime? _lazyDate;
-        private volatile CryptographicAttributeObject? _lazyOtherKeyAttribute;
+        private CryptographicAttributeObject? _lazyOtherKeyAttribute;
     }
 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/KeyTransRecipientInfo.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/KeyTransRecipientInfo.cs
@@ -55,8 +55,8 @@ namespace System.Security.Cryptography.Pkcs
             }
         }
 
-        private volatile SubjectIdentifier? _lazyRecipientIdentifier;
-        private volatile AlgorithmIdentifier? _lazyKeyEncryptionAlgorithm;
-        private volatile byte[]? _lazyEncryptedKey;
+        private SubjectIdentifier? _lazyRecipientIdentifier;
+        private AlgorithmIdentifier? _lazyKeyEncryptionAlgorithm;
+        private byte[]? _lazyEncryptedKey;
     }
 }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngKey.StandardProperties.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CngKey.StandardProperties.cs
@@ -16,13 +16,13 @@ namespace System.Security.Cryptography
     public sealed partial class CngKey : IDisposable
     {
         private const int CachedKeySizeUninitializedSentinel = -1;
-        private volatile int _cachedKeySize = CachedKeySizeUninitializedSentinel;
+        private int _cachedKeySize = CachedKeySizeUninitializedSentinel;
 
-        private volatile CngAlgorithm? _cachedAlgorithm;
+        private CngAlgorithm? _cachedAlgorithm;
         private volatile bool _hasCachedAlgorithmGroup;
-        private volatile CngAlgorithmGroup? _cachedAlgorithmGroup;
+        private CngAlgorithmGroup? _cachedAlgorithmGroup;
         private volatile bool _hasCachedProvider;
-        private volatile CngProvider? _cachedProvider;
+        private CngProvider? _cachedProvider;
 
         /// <summary>
         ///     Algorithm group this key can be used with

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptoConfig.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/CryptoConfig.cs
@@ -37,8 +37,8 @@ namespace System.Security.Cryptography
 
         private const string ECDsaIdentifier = "ECDsa";
 
-        private static volatile Dictionary<string, string>? s_defaultOidHT;
-        private static volatile Dictionary<string, object>? s_defaultNameHT;
+        private static Dictionary<string, string>? s_defaultOidHT;
+        private static Dictionary<string, object>? s_defaultNameHT;
         private static readonly ConcurrentDictionary<string, Type> appNameHT = new ConcurrentDictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
         private static readonly ConcurrentDictionary<string, string> appOidHT = new ConcurrentDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500DistinguishedName.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X500DistinguishedName.cs
@@ -9,7 +9,7 @@ namespace System.Security.Cryptography.X509Certificates
 {
     public sealed class X500DistinguishedName : AsnEncodedData
     {
-        private volatile string? _lazyDistinguishedName;
+        private string? _lazyDistinguishedName;
         private List<X500RelativeDistinguishedName>? _parsedAttributes;
 
         public X500DistinguishedName(byte[] encodedDistinguishedName)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
@@ -15,14 +15,14 @@ namespace System.Security.Cryptography.X509Certificates
 {
     public partial class X509Certificate : IDisposable, IDeserializationCallback, ISerializable
     {
-        private volatile byte[]? _lazyCertHash;
-        private volatile string? _lazyIssuer;
-        private volatile string? _lazySubject;
-        private volatile byte[]? _lazySerialNumber;
-        private volatile string? _lazyKeyAlgorithm;
-        private volatile byte[]? _lazyKeyAlgorithmParameters;
-        private volatile byte[]? _lazyPublicKey;
-        private volatile byte[]? _lazyRawData;
+        private byte[]? _lazyCertHash;
+        private string? _lazyIssuer;
+        private string? _lazySubject;
+        private byte[]? _lazySerialNumber;
+        private string? _lazyKeyAlgorithm;
+        private byte[]? _lazyKeyAlgorithmParameters;
+        private byte[]? _lazyPublicKey;
+        private byte[]? _lazyRawData;
         private volatile bool _lazyKeyAlgorithmParametersCreated;
         private DateTime _lazyNotBefore = DateTime.MinValue;
         private DateTime _lazyNotAfter = DateTime.MinValue;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -18,13 +18,13 @@ namespace System.Security.Cryptography.X509Certificates
 {
     public class X509Certificate2 : X509Certificate
     {
-        private volatile Oid? _lazySignatureAlgorithm;
-        private volatile int _lazyVersion;
-        private volatile X500DistinguishedName? _lazySubjectName;
-        private volatile X500DistinguishedName? _lazyIssuerName;
-        private volatile PublicKey? _lazyPublicKey;
-        private volatile AsymmetricAlgorithm? _lazyPrivateKey;
-        private volatile X509ExtensionCollection? _lazyExtensions;
+        private Oid? _lazySignatureAlgorithm;
+        private int _lazyVersion;
+        private X500DistinguishedName? _lazySubjectName;
+        private X500DistinguishedName? _lazyIssuerName;
+        private PublicKey? _lazyPublicKey;
+        private AsymmetricAlgorithm? _lazyPrivateKey;
+        private X509ExtensionCollection? _lazyExtensions;
         private static readonly string[] s_RsaPublicKeyPrivateKeyLabels = [PemLabels.RsaPrivateKey, PemLabels.Pkcs8PrivateKey];
         private static readonly string[] s_DsaPublicKeyPrivateKeyLabels = [PemLabels.Pkcs8PrivateKey];
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Chain.cs
@@ -11,7 +11,7 @@ namespace System.Security.Cryptography.X509Certificates
     public class X509Chain : IDisposable
     {
         private X509ChainPolicy? _chainPolicy;
-        private volatile X509ChainStatus[]? _lazyChainStatus;
+        private X509ChainStatus[]? _lazyChainStatus;
         private X509ChainElementCollection? _chainElements;
         private IChainPal? _pal;
         private bool _useMachineContext;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/UnicodeCategoryConditions.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/UnicodeCategoryConditions.cs
@@ -16,9 +16,9 @@ namespace System.Text.RegularExpressions.Symbolic
         /// <summary>Array containing lazily-initialized BDDs per defined UnicodeCategory value.</summary>
         private static readonly BDD?[] s_categories = new BDD[UnicodeCategoryValueCount];
         /// <summary>Lazily-initialized BDD for \w.</summary>
-        private static volatile BDD? s_wordLetter;
+        private static BDD? s_wordLetter;
         /// <summary>Lazily-initialized BDD for \b.</summary>
-        private static volatile BDD? s_wordLetterForAnchors;
+        private static BDD? s_wordLetterForAnchors;
 
 #if DEBUG
         static UnicodeCategoryConditions()


### PR DESCRIPTION
Per the .NET memory model (docs/design/specs/Memory-model.md), many `volatile` field annotations in Libraries are unnecessary and impose overhead without benefit. This removes `volatile` from 187 fields across 95 files.

## Reference-type fields (159 fields, 86 files)

Object assignment to a shared location is a release with respect to the instance's fields ([line 135](https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-model.md#object-assignment)), and data-dependent reads are ordered ([line 118](https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-model.md#data-dependent-reads-are-ordered)). This means lazy-init patterns like `??=` and sentinel-check-then-assign on reference-type fields do not need volatile: the publishing write ensures constructor side-effects are visible, and readers accessing the object through the reference see those effects. The memory model doc explicitly shows singleton patterns working without volatile ([lines 217-277](https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-model.md#examples-and-common-patterns)). Fields protected by locks or Interlocked operations also have volatile removed since those primitives provide stronger ordering guarantees.

## Value-type fields (28 fields, 13 files)

The memory model now prohibits read-introduction: \\Reads cannot be introduced\\ ([line 50](https://github.com/dotnet/runtime/blob/main/docs/design/specs/Memory-model.md#side-effects-and-optimizations-of-memory-accesses)). Previously, volatile was needed on value-type lazy-init fields to prevent the JIT from replacing a local variable with a re-read of the field (TOCTOU risk). With read-introduction now prohibited, volatile is unnecessary on value-type fields where:
- The field is read once into a local and the local is used
- The value IS the result (no associated shared state needs acquire semantics)
- The field is write-once with a sentinel (no anti-coalescing concern)

This includes IntPtr handle caches (crypto digest algorithms), sbyte tri-state flags, and int sentinel-based lazy-init fields like \\s_processId\\, \\s_systemPageSize\\, and \\s_osArchPlusOne\\.

## Fields deliberately kept volatile

- Value-type fields that gate access to other shared mutable state (e.g. \\_hasCachedAlgorithmGroup\\ gates \\_cachedAlgorithmGroup\\ — needs acquire semantics)
- Boolean disposal/initialization flags read across multiple code paths
- Mutable fields with multiple writers (not write-once)
- All fields in concurrent data structures and threading primitives
- All \\Volatile.Read\\/\\Write\\ call sites (deliberate per-access annotations)