### PR TITLE
Handle RequestCores returning 0 in TaskHostFactory tasks

### DIFF
--- a/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
+++ b/src/tasks/AotCompilerTask/MonoAOTCompiler.cs
@@ -541,16 +541,21 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
         else
         {
             int allowedParallelism = DisableParallelAot ? 1 : Math.Min(_assembliesToCompile.Count, Environment.ProcessorCount);
+            int coresAcquired = 0;
             IBuildEngine9? be9 = BuildEngine as IBuildEngine9;
-            try
+            if (be9 is not null)
             {
-                if (be9 is not null)
-                    allowedParallelism = be9.RequestCores(allowedParallelism);
-            }
-            catch (NotImplementedException)
-            {
-                // RequestCores is not implemented in TaskHostFactory
-                be9 = null;
+                try
+                {
+                    coresAcquired = be9.RequestCores(allowedParallelism);
+                    if (coresAcquired > 0)
+                        allowedParallelism = coresAcquired;
+                }
+                catch
+                {
+                    // RequestCores may not be supported in all host environments
+                    coresAcquired = 0;
+                }
             }
 
             /*
@@ -598,7 +603,8 @@ public class MonoAOTCompiler : Microsoft.Build.Utilities.Task
             }
             finally
             {
-                be9?.ReleaseCores(allowedParallelism);
+                if (coresAcquired > 0)
+                    be9?.ReleaseCores(coresAcquired);
             }
         }
 

--- a/src/tasks/MonoTargetsTasks/EmitBundleTask/EmitBundleBase.cs
+++ b/src/tasks/MonoTargetsTasks/EmitBundleTask/EmitBundleBase.cs
@@ -154,16 +154,21 @@ public abstract class EmitBundleBase : Microsoft.Build.Utilities.Task, ICancelab
 
         // Generate source file(s) containing each resource's byte data and size
         int allowedParallelism = Math.Max(Math.Min(bundledResources.Count, Environment.ProcessorCount), 1);
+        int coresAcquired = 0;
         IBuildEngine9? be9 = BuildEngine as IBuildEngine9;
-        try
+        if (be9 is not null)
         {
-            if (be9 is not null)
-                allowedParallelism = be9.RequestCores(allowedParallelism);
-        }
-        catch (NotImplementedException)
-        {
-            // RequestCores is not implemented in TaskHostFactory
-            be9 = null;
+            try
+            {
+                coresAcquired = be9.RequestCores(allowedParallelism);
+                if (coresAcquired > 0)
+                    allowedParallelism = coresAcquired;
+            }
+            catch
+            {
+                // RequestCores may not be supported in all host environments
+                coresAcquired = 0;
+            }
         }
 
         try
@@ -196,7 +201,8 @@ public abstract class EmitBundleBase : Microsoft.Build.Utilities.Task, ICancelab
         }
         finally
         {
-            be9?.ReleaseCores(allowedParallelism);
+            if (coresAcquired > 0)
+                be9?.ReleaseCores(coresAcquired);
         }
 
         foreach (ITaskItem bundledResource in bundledResources)

--- a/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
+++ b/src/tasks/MonoTargetsTasks/ILStrip/ILStrip.cs
@@ -74,16 +74,21 @@ public class ILStrip : Microsoft.Build.Utilities.Task
         Log.LogMessage(MessageImportance.High, "IL stripping assemblies");
 
         int allowedParallelism = DisableParallelStripping ? 1 : Math.Min(Assemblies.Length, Environment.ProcessorCount);
+        int coresAcquired = 0;
         IBuildEngine9? be9 = BuildEngine as IBuildEngine9;
-        try
+        if (be9 is not null)
         {
-            if (be9 is not null)
-                allowedParallelism = be9.RequestCores(allowedParallelism);
-        }
-        catch (NotImplementedException)
-        {
-            // RequestCores is not implemented in TaskHostFactory
-            be9 = null;
+            try
+            {
+                coresAcquired = be9.RequestCores(allowedParallelism);
+                if (coresAcquired > 0)
+                    allowedParallelism = coresAcquired;
+            }
+            catch
+            {
+                // RequestCores may not be supported in all host environments
+                coresAcquired = 0;
+            }
         }
 
         try
@@ -113,7 +118,8 @@ public class ILStrip : Microsoft.Build.Utilities.Task
         }
         finally
         {
-            be9?.ReleaseCores(allowedParallelism);
+            if (coresAcquired > 0)
+                be9?.ReleaseCores(coresAcquired);
         }
 
         return !Log.HasLoggedErrors;

--- a/src/tasks/WasmAppBuilder/EmccCompile.cs
+++ b/src/tasks/WasmAppBuilder/EmccCompile.cs
@@ -131,16 +131,21 @@ namespace Microsoft.WebAssembly.Build.Tasks
                 Directory.CreateDirectory(_tempPath);
 
                 int allowedParallelism = DisableParallelCompile ? 1 : Math.Min(SourceFiles.Length, Environment.ProcessorCount);
+                int coresAcquired = 0;
                 IBuildEngine9? be9 = BuildEngine as IBuildEngine9;
-                try
+                if (be9 is not null)
                 {
-                    if (be9 is not null)
-                        allowedParallelism = be9.RequestCores(allowedParallelism);
-                }
-                catch (NotImplementedException)
-                {
-                    // RequestCores is not implemented in TaskHostFactory
-                    be9 = null;
+                    try
+                    {
+                        coresAcquired = be9.RequestCores(allowedParallelism);
+                        if (coresAcquired > 0)
+                            allowedParallelism = coresAcquired;
+                    }
+                    catch
+                    {
+                        // RequestCores may not be supported in all host environments
+                        coresAcquired = 0;
+                    }
                 }
 
                 /*
@@ -184,7 +189,8 @@ namespace Microsoft.WebAssembly.Build.Tasks
                 }
                 finally
                 {
-                    be9?.ReleaseCores(allowedParallelism);
+                    if (coresAcquired > 0)
+                        be9?.ReleaseCores(coresAcquired);
                 }
 
 


### PR DESCRIPTION
## Summary

Fixes dotnet/sdk#53300 — publishing Blazor WebAssembly apps fails after installing `wasm-tools` workload with SDK 11.0.100-preview.2.26154.117.

## Root Cause

MSBuild PR dotnet/msbuild#13306 (merged March 2) changed `OutOfProcTaskHostNode.RequestCores` from throwing `NotImplementedException` to returning **0** and logging MSB5022 when callbacks aren't supported. Four tasks in this repo only caught `NotImplementedException`, causing:

1. `RequestCores` returns 0 → no exception thrown → catch block not triggered
2. `allowedParallelism` becomes 0
3. `Parallel.ForEach` with `MaxDegreeOfParallelism=0` throws `ArgumentOutOfRangeException`
4. `ReleaseCores(0)` in the finally block throws `ArgumentOutOfRangeException('coresToRelease')` (new input validation requires > 0)

## Fix

Track cores actually acquired in a separate `coresAcquired` variable. If `RequestCores` returns 0 or throws any exception, fall back to the original parallelism value and skip `ReleaseCores`. This is resilient to any future changes in MSBuild's task host behavior.

## Affected Tasks

- `EmccCompile` (triggered the user-facing regression)
- `MonoAOTCompiler` (same latent bug)
- `ILStrip` (same latent bug)
- `EmitBundleBase` (same latent bug)