### PR TITLE
[Wasm RyuJIT] Fix classifier embiggening small structs that are being passed-as a wasm primitive

### DIFF
--- a/src/coreclr/jit/targetwasm.cpp
+++ b/src/coreclr/jit/targetwasm.cpp
@@ -90,12 +90,10 @@ ABIPassingInformation WasmClassifier::Classify(Compiler*    comp,
             abiType = ToJitType(wasmAbiType);
         }
 
-        regNumber         reg = MakeWasmReg(m_localIndex++, genActualType(abiType));
+        regNumber reg = MakeWasmReg(m_localIndex++, genActualType(abiType));
         // If the struct is being passed directly as a wasm value, make sure we record
         //  the actual size of the struct, not the size of the containing wasm value.
-        unsigned  segmentSize = passByRef
-            ? genTypeSize(abiType)
-            : min(structLayout->GetSize(), genTypeSize(abiType));
+        unsigned segmentSize  = passByRef ? genTypeSize(abiType) : min(structLayout->GetSize(), genTypeSize(abiType));
         ABIPassingSegment seg = ABIPassingSegment::InRegister(reg, 0, segmentSize);
         return ABIPassingInformation::FromSegment(comp, passByRef, seg);
     }

--- a/src/coreclr/jit/targetwasm.cpp
+++ b/src/coreclr/jit/targetwasm.cpp
@@ -91,7 +91,8 @@ ABIPassingInformation WasmClassifier::Classify(Compiler*    comp,
         }
 
         regNumber         reg = MakeWasmReg(m_localIndex++, genActualType(abiType));
-        ABIPassingSegment seg = ABIPassingSegment::InRegister(reg, 0, genTypeSize(abiType));
+        unsigned  segmentSize = min(structLayout->GetSize(), genTypeSize(abiType));
+        ABIPassingSegment seg = ABIPassingSegment::InRegister(reg, 0, segmentSize);
         return ABIPassingInformation::FromSegment(comp, passByRef, seg);
     }
 

--- a/src/coreclr/jit/targetwasm.cpp
+++ b/src/coreclr/jit/targetwasm.cpp
@@ -91,7 +91,11 @@ ABIPassingInformation WasmClassifier::Classify(Compiler*    comp,
         }
 
         regNumber         reg = MakeWasmReg(m_localIndex++, genActualType(abiType));
-        unsigned  segmentSize = min(structLayout->GetSize(), genTypeSize(abiType));
+        // If the struct is being passed directly as a wasm value, make sure we record
+        //  the actual size of the struct, not the size of the containing wasm value.
+        unsigned  segmentSize = passByRef
+            ? genTypeSize(abiType)
+            : min(structLayout->GetSize(), genTypeSize(abiType));
         ABIPassingSegment seg = ABIPassingSegment::InRegister(reg, 0, segmentSize);
         return ABIPassingInformation::FromSegment(comp, passByRef, seg);
     }


### PR DESCRIPTION
Addresses part of #125199