### PR TITLE
[Wasm RyuJIT] Handle case where a TYP_STRUCT return has had its type information erased and we are trying to write it to a TYP_STRUCT local

### DIFF
--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -522,12 +522,12 @@ void WasmRegAlloc::RewriteLocalStackStore(GenTreeLclVarCommon* lclNode)
     // TODO-WASM-RA: figure out the address mode story here. Right now this will produce an address not folded
     // into the store's address mode. We can utilize a contained LEA, but that will require some liveness work.
 
-    var_types    storeType = lclNode->TypeGet();
+    var_types storeType = lclNode->TypeGet();
     // Check that both the storeType AND the value being stored are structs. If there is a mismatch, we will
     //  crash later on while trying to create a STORE_BLK because the value has no layout.
-    bool         isStruct  = (storeType == TYP_STRUCT) && value->TypeIs(TYP_STRUCT);
-    uint16_t     offset    = lclNode->GetLclOffs();
-    ClassLayout* layout    = isStruct ? lclNode->GetLayout(m_compiler) : nullptr;
+    bool         isStruct = (storeType == TYP_STRUCT) && value->TypeIs(TYP_STRUCT);
+    uint16_t     offset   = lclNode->GetLclOffs();
+    ClassLayout* layout   = isStruct ? lclNode->GetLayout(m_compiler) : nullptr;
     lclNode->SetOper(GT_LCL_ADDR);
     lclNode->ChangeType(TYP_I_IMPL);
     lclNode->AsLclFld()->SetLclOffs(offset);
@@ -540,10 +540,8 @@ void WasmRegAlloc::RewriteLocalStackStore(GenTreeLclVarCommon* lclNode)
     }
     else
     {
-        store = m_compiler->gtNewStoreIndNode(
-            storeType == TYP_STRUCT ? value->TypeGet() : storeType,
-            lclNode, value, indFlags
-        );
+        store = m_compiler->gtNewStoreIndNode(storeType == TYP_STRUCT ? value->TypeGet() : storeType, lclNode, value,
+                                              indFlags);
     }
     CurrentRange().InsertAfter(lclNode, store);
     CurrentRange().Remove(lclNode);

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -526,8 +526,8 @@ void WasmRegAlloc::RewriteLocalStackStore(GenTreeLclVarCommon* lclNode)
     // We can end up with a block copy operation storing a non-STRUCT into a STRUCT due to type erasure.
     if ((storeType == TYP_STRUCT) && lclNode->OperIsCopyBlkOp())
     {
-        LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNode->GetLclNum());
-        var_types lclRegType = varDsc->GetRegisterType(lclNode);
+        LclVarDsc* varDsc     = m_compiler->lvaGetDesc(lclNode->GetLclNum());
+        var_types  lclRegType = varDsc->GetRegisterType(lclNode);
         if (lclRegType != TYP_UNDEF)
         {
             storeType = lclRegType;

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -523,7 +523,9 @@ void WasmRegAlloc::RewriteLocalStackStore(GenTreeLclVarCommon* lclNode)
     // into the store's address mode. We can utilize a contained LEA, but that will require some liveness work.
 
     var_types    storeType = lclNode->TypeGet();
-    bool         isStruct  = storeType == TYP_STRUCT;
+    // Check that both the storeType AND the value being stored are structs. If there is a mismatch, we will
+    //  crash later on while trying to create a STORE_BLK because the value has no layout.
+    bool         isStruct  = (storeType == TYP_STRUCT) && value->TypeIs(TYP_STRUCT);
     uint16_t     offset    = lclNode->GetLclOffs();
     ClassLayout* layout    = isStruct ? lclNode->GetLayout(m_compiler) : nullptr;
     lclNode->SetOper(GT_LCL_ADDR);
@@ -538,7 +540,10 @@ void WasmRegAlloc::RewriteLocalStackStore(GenTreeLclVarCommon* lclNode)
     }
     else
     {
-        store = m_compiler->gtNewStoreIndNode(storeType, lclNode, value, indFlags);
+        store = m_compiler->gtNewStoreIndNode(
+            storeType == TYP_STRUCT ? value->TypeGet() : storeType,
+            lclNode, value, indFlags
+        );
     }
     CurrentRange().InsertAfter(lclNode, store);
     CurrentRange().Remove(lclNode);

--- a/src/coreclr/jit/regallocwasm.cpp
+++ b/src/coreclr/jit/regallocwasm.cpp
@@ -523,9 +523,18 @@ void WasmRegAlloc::RewriteLocalStackStore(GenTreeLclVarCommon* lclNode)
     // into the store's address mode. We can utilize a contained LEA, but that will require some liveness work.
 
     var_types storeType = lclNode->TypeGet();
-    // Check that both the storeType AND the value being stored are structs. If there is a mismatch, we will
-    //  crash later on while trying to create a STORE_BLK because the value has no layout.
-    bool         isStruct = (storeType == TYP_STRUCT) && value->TypeIs(TYP_STRUCT);
+    // We can end up with a block copy operation storing a non-STRUCT into a STRUCT due to type erasure.
+    if ((storeType == TYP_STRUCT) && lclNode->OperIsCopyBlkOp())
+    {
+        LclVarDsc* varDsc = m_compiler->lvaGetDesc(lclNode->GetLclNum());
+        var_types lclRegType = varDsc->GetRegisterType(lclNode);
+        if (lclRegType != TYP_UNDEF)
+        {
+            storeType = lclRegType;
+        }
+    }
+
+    bool         isStruct = storeType == TYP_STRUCT;
     uint16_t     offset   = lclNode->GetLclOffs();
     ClassLayout* layout   = isStruct ? lclNode->GetLayout(m_compiler) : nullptr;
     lclNode->SetOper(GT_LCL_ADDR);
@@ -540,8 +549,7 @@ void WasmRegAlloc::RewriteLocalStackStore(GenTreeLclVarCommon* lclNode)
     }
     else
     {
-        store = m_compiler->gtNewStoreIndNode(storeType == TYP_STRUCT ? value->TypeGet() : storeType, lclNode, value,
-                                              indFlags);
+        store = m_compiler->gtNewStoreIndNode(storeType, lclNode, value, indFlags);
     }
     CurrentRange().InsertAfter(lclNode, store);
     CurrentRange().Remove(lclNode);


### PR DESCRIPTION
Addresses part of #125199
Don't love this solution, feedback welcome.