### PR TITLE
Fix interpreter async suspend DiagnosticIP calculation

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -929,7 +929,7 @@ int32_t* InterpCompiler::EmitCodeIns(int32_t *ip, InterpInst *ins, TArray<Reloc*
     if (opcode == INTOP_HANDLE_CONTINUATION_SUSPEND)
     {
         // Capture meaningful start IP for async suspend diagnostics
-        ((InterpAsyncSuspendData*)GetDataItemAtIndex(ins->data[0]))->resumeInfo.DiagnosticIP = (size_t)startIp;
+        ((InterpAsyncSuspendData*)GetDataItemAtIndex(ins->data[0]))->resumeInfo.DiagnosticIP = (size_t)(startIp - m_pMethodCode);
     }
 
     if (opcode == INTOP_SWITCH)

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -1972,6 +1972,7 @@ InterpMethod* InterpCompiler::FinalizeMethodData(void* baseAddressRW, void* base
         
         // Fix up the methodStartIP to point to the final bytecode start
         dstDataRW->methodStartIP = pByteCodeStart;
+        dstDataRW->resumeInfo.DiagnosticIP += (TARGET_SIZE_T)pByteCodeStart;
         
         // Fix up interval map pointers if they exist
         // Note: The interval maps were allocated via AllocMethodData in the old model,

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -929,7 +929,7 @@ int32_t* InterpCompiler::EmitCodeIns(int32_t *ip, InterpInst *ins, TArray<Reloc*
     if (opcode == INTOP_HANDLE_CONTINUATION_SUSPEND)
     {
         // Capture meaningful start IP for async suspend diagnostics
-        ((InterpAsyncSuspendData*)GetDataItemAtIndex(ins->data[0]))->resumeInfo.DiagnosticIP = (size_t)(startIp - m_pMethodCode);
+        ((InterpAsyncSuspendData*)GetDataItemAtIndex(ins->data[0]))->resumeInfo.DiagnosticIP = (size_t)startIp - (size_t)m_pMethodCode;
     }
 
     if (opcode == INTOP_SWITCH)

--- a/src/tests/JIT/interpreter/Interpreter.cs
+++ b/src/tests/JIT/interpreter/Interpreter.cs
@@ -2519,6 +2519,8 @@ public class InterpreterTest
         if (!ArrayMD1()) return false;
         if (!ArrayObj(1)) return false;
         if (!ArrayStruct(1)) return false;
+        TestAsyncThrowAfterYield();
+
 
         return true;
     }
@@ -3052,5 +3054,36 @@ public class InterpreterTest
         {
             return true;
         }
+    }
+
+    public static void TestAsyncThrowAfterYield()
+    {
+        Task.Run(AsyncEntry).Wait();
+    }
+
+    [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(false)]
+    public static async Task AsyncEntry()
+    {
+        int result = await Handler();
+        Assert.Equal(42, result);
+    }
+
+    public static async Task<int> Handler()
+    {
+        try
+        {
+            return await Throw(42);
+        }
+        catch (IntegerException ex)
+        {
+            return ex.Value;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static async Task<int> Throw(int value)
+    {
+        await Task.Yield();
+        throw new IntegerException(value);
     }
 }

--- a/src/tests/JIT/interpreter/Interpreter.cs
+++ b/src/tests/JIT/interpreter/Interpreter.cs
@@ -2519,8 +2519,6 @@ public class InterpreterTest
         if (!ArrayMD1()) return false;
         if (!ArrayObj(1)) return false;
         if (!ArrayStruct(1)) return false;
-        TestAsyncThrowAfterYield();
-
 
         return true;
     }
@@ -3054,36 +3052,5 @@ public class InterpreterTest
         {
             return true;
         }
-    }
-
-    public static void TestAsyncThrowAfterYield()
-    {
-        Task.Run(AsyncEntry).Wait();
-    }
-
-    [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(false)]
-    public static async Task AsyncEntry()
-    {
-        int result = await Handler();
-        Assert.Equal(42, result);
-    }
-
-    public static async Task<int> Handler()
-    {
-        try
-        {
-            return await Throw(42);
-        }
-        catch (IntegerException ex)
-        {
-            return ex.Value;
-        }
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public static async Task<int> Throw(int value)
-    {
-        await Task.Yield();
-        throw new IntegerException(value);
     }
 }

--- a/src/tests/async/simple-eh/simple-eh.cs
+++ b/src/tests/async/simple-eh/simple-eh.cs
@@ -14,7 +14,6 @@ using Xunit;
 public class Async2SimpleEH
 {
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/124044", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static void TestThrowAfterYield()
     {
         Task.Run(AsyncEntry).Wait();

--- a/src/tests/async/simple-eh/simple-eh.cs
+++ b/src/tests/async/simple-eh/simple-eh.cs
@@ -53,7 +53,6 @@ public class Async2SimpleEH
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/124044", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static int TestDefinesIntButThrows()
     {
         return TestDefinesIntButThrowsAsync().GetAwaiter().GetResult();
@@ -82,7 +81,6 @@ public class Async2SimpleEH
     private struct S { public long A, B, C, D; }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/124044", typeof(TestLibrary.Utilities), nameof(TestLibrary.Utilities.IsCoreClrInterpreter))]
     public static int TestDefinesSButThrows()
     {
         return TestDefinesSButThrowsAsync().GetAwaiter().GetResult();


### PR DESCRIPTION
Fix #124044

The interpreter was storing an absolute address for `DiagnosticIP` in `INTOP_HANDLE_CONTINUATION_SUSPEND`, but this field needs to be stored as an offset and then relocated during `FinalizeMethodData` (similar to other fields like `methodStartIP`).

This caused a crash in `ToString_Async` and other async exception handling tests on Apple mobile with CoreCLR R2R and interpreter fallback, because the diagnostic IP pointed to invalid memory.

**Changes:**
- `compiler.cpp`: Store `DiagnosticIP` as an offset from method code start during emit, then add the final bytecode base address during finalization.
- `simple-eh.cs`: Remove `ActiveIssue` attributes for the three tests that were disabled due to this bug.