### PR TITLE
Revert "Eliminate forwarder stubs by reusing method precodes for call counting indirection"

### DIFF
--- a/src/coreclr/vm/callcounting.cpp
+++ b/src/coreclr/vm/callcounting.cpp
@@ -401,6 +401,29 @@ void CallCountingManager::CallCountingStubAllocator::EnumerateHeapRanges(CLRData
 #endif // DACCESS_COMPILE
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// CallCountingManager::MethodDescForwarderStubHashTraits
+
+CallCountingManager::MethodDescForwarderStubHashTraits::key_t
+CallCountingManager::MethodDescForwarderStubHashTraits::GetKey(const element_t &e)
+{
+    WRAPPER_NO_CONTRACT;
+    return e->GetMethodDesc();
+}
+
+BOOL CallCountingManager::MethodDescForwarderStubHashTraits::Equals(const key_t &k1, const key_t &k2)
+{
+    WRAPPER_NO_CONTRACT;
+    return k1 == k2;
+}
+
+CallCountingManager::MethodDescForwarderStubHashTraits::count_t
+CallCountingManager::MethodDescForwarderStubHashTraits::Hash(const key_t &k)
+{
+    WRAPPER_NO_CONTRACT;
+    return (count_t)(size_t)k;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // CallCountingManager::CallCountingManagerHashTraits
 
 CallCountingManager::CallCountingManagerHashTraits::key_t
@@ -595,14 +618,6 @@ bool CallCountingManager::SetCodeEntryPoint(
                 // Call counting is disabled, complete, or pending completion. The pending completion stage here would be
                 // relatively rare, let it be handled elsewhere.
                 methodDesc->SetCodeEntryPoint(codeEntryPoint);
-                if (methodDesc->MayHaveEntryPointSlotsToBackpatch())
-                {
-                    // Reset the precode target to prestub. For backpatchable methods, the precode must always
-                    // point to prestub (not native code) so that new vtable slots flow through DoBackpatch()
-                    // for discovery and recording. SetCodeEntryPoint() above handles recorded slots via
-                    // BackpatchEntryPointSlots() without touching the precode.
-                    Precode::GetPrecodeFromEntryPoint(methodDesc->GetTemporaryEntryPoint())->ResetTargetInterlocked();
-                }
                 return true;
             }
 
@@ -641,12 +656,6 @@ bool CallCountingManager::SetCodeEntryPoint(
                         ->AsyncPromoteToTier1(activeCodeVersion, createTieringBackgroundWorkerRef);
                 }
                 methodDesc->SetCodeEntryPoint(codeEntryPoint);
-                if (methodDesc->MayHaveEntryPointSlotsToBackpatch())
-                {
-                    // Reset the precode target to prestub so that new vtable slots flow through DoBackpatch()
-                    // for discovery and recording. The call counting stub is no longer needed.
-                    Precode::GetPrecodeFromEntryPoint(methodDesc->GetTemporaryEntryPoint())->ResetTargetInterlocked();
-                }
                 callCountingInfo->SetStage(CallCountingInfo::Stage::Complete);
                 return true;
             } while (false);
@@ -709,41 +718,51 @@ bool CallCountingManager::SetCodeEntryPoint(
     PCODE callCountingCodeEntryPoint = callCountingStub->GetEntryPoint();
     if (methodDesc->MayHaveEntryPointSlotsToBackpatch())
     {
-        // For methods that may have entry point slots to backpatch, redirect the method's temporary entry point
-        // (precode) to the call counting stub. This reuses the method's own precode as the stable indirection,
-        // avoiding the need to allocate separate forwarder stubs.
-        //
-        // The call counting stub should not be the entry point stored directly in vtable slots:
-        // - Stubs should be deletable without leaving dangling pointers in vtable slots
-        // - On some architectures (e.g. arm64), jitted code may load the entry point into a register at a GC-safe
-        //   point, and the stub could be deleted before the register is used for the call
-        //
-        // Ensure vtable slots point to the temporary entry point (precode) so calls flow through
-        // precode → call counting stub → native code. Vtable slots may have been backpatched to native code
-        // during the initial publish or tiering delay. BackpatchToResetEntryPointSlots() also sets
-        // GetMethodEntryPoint() to the temporary entry point, which we override below.
-        //
-        // There is a benign race window between resetting vtable slots and setting the precode target: a thread
-        // may briefly see vtable slots pointing to the precode while the precode still points to its previous
-        // target (prestub or native code). This results in at most one uncounted call, which is acceptable since
-        // call counting is a heuristic.
-        methodDesc->BackpatchToResetEntryPointSlots();
+        // The call counting stub should not be the entry point that is called first in the process of a call
+        // - Stubs should be deletable. Many methods will have call counting stubs associated with them, and although the memory
+        //   involved is typically insignificant compared to the average memory overhead per method, by steady-state it would
+        //   otherwise be unnecessary memory overhead serving no purpose.
+        // - In order to be able to delete a stub, the jitted code of a method cannot be allowed to load the stub as the entry
+        //   point of a callee into a register in a GC-safe point that allows for the stub to be deleted before the register is
+        //   reused to call the stub. On some processor architectures, perhaps the JIT can guarantee that it would not load the
+        //   entry point into a register before the call, but this is not possible on arm32 or arm64. Rather, perhaps the
+        //   region containing the load and call would not be considered GC-safe. Calls are considered GC-safe points, and this
+        //   may cause many methods that are currently fully interruptible to have to be partially interruptible and record
+        //   extra GC info instead. This would be nontrivial and there would be tradeoffs.
+        // - For any method that may have an entry point slot that would be backpatched with the call counting stub's entry
+        //   point, a small forwarder stub (precode) is created. The forwarder stub has loader allocator lifetime and forwards to
+        //   the larger call counting stub. This is a simple solution for now and seems to have negligible impact.
+        // - Reusing FuncPtrStubs was considered. FuncPtrStubs are currently not used as a code entry point for a virtual or
+        //   interface method and may be bypassed. For example, a call may call through the vtable slot, or a devirtualized call
+        //   may call through a FuncPtrStub. The target of a FuncPtrStub is a code entry point and is backpatched when a
+        //   method's active code entry point changes. Mixing the current use of FuncPtrStubs with the use as a forwarder for
+        //   call counting does not seem trivial and would likely complicate its use. There may not be much gain in reusing
+        //   FuncPtrStubs, as typically, they are created for only a small percentage of virtual/interface methods.
 
-        // Keep GetMethodEntryPoint() set to the native code entry point rather than the temporary entry point.
-        // DoBackpatch() (prestub.cpp) skips slot recording when GetMethodEntryPoint() == GetTemporaryEntryPoint(),
-        // interpreting it as "method not yet published". By keeping GetMethodEntryPoint() at native code, we
-        // ensure that after the precode reverts to prestub (when call counting stubs are deleted), new vtable
-        // slots discovered by DoBackpatch() will be properly recorded for future backpatching.
-        methodDesc->SetMethodEntryPoint(codeEntryPoint);
-        Precode *precode = Precode::GetPrecodeFromEntryPoint(methodDesc->GetTemporaryEntryPoint());
-        precode->SetTargetInterlocked(callCountingCodeEntryPoint, FALSE);
+        MethodDescForwarderStubHash &methodDescForwarderStubHash = callCountingManager->m_methodDescForwarderStubHash;
+        Precode *forwarderStub = methodDescForwarderStubHash.Lookup(methodDesc);
+        if (forwarderStub == nullptr)
+        {
+            AllocMemTracker forwarderStubAllocationTracker;
+            forwarderStub =
+                Precode::Allocate(
+                    methodDesc->GetPrecodeType(),
+                    methodDesc,
+                    methodDesc->GetLoaderAllocator(),
+                    &forwarderStubAllocationTracker);
+            methodDescForwarderStubHash.Add(forwarderStub);
+            forwarderStubAllocationTracker.SuppressRelease();
+        }
+
+        forwarderStub->SetTargetInterlocked(callCountingCodeEntryPoint, false);
+        callCountingCodeEntryPoint = forwarderStub->GetEntryPoint();
     }
     else
     {
         _ASSERTE(methodDesc->IsVersionableWithPrecode());
-        methodDesc->SetCodeEntryPoint(callCountingCodeEntryPoint);
     }
 
+    methodDesc->SetCodeEntryPoint(callCountingCodeEntryPoint);
     callCountingInfo->SetStage(CallCountingInfo::Stage::StubMayBeActive);
     return true;
 }
@@ -913,13 +932,6 @@ void CallCountingManager::CompleteCallCounting()
                     if (activeCodeVersion == codeVersion)
                     {
                         methodDesc->SetCodeEntryPoint(activeCodeVersion.GetNativeCode());
-                        if (methodDesc->MayHaveEntryPointSlotsToBackpatch())
-                        {
-                            // Reset the precode target to prestub so that new vtable slots flow through
-                            // DoBackpatch() for discovery and recording. The call counting stub will be
-                            // deleted by DeleteAllCallCountingStubs().
-                            Precode::GetPrecodeFromEntryPoint(methodDesc->GetTemporaryEntryPoint())->ResetTargetInterlocked();
-                        }
                         break;
                     }
 
@@ -935,19 +947,11 @@ void CallCountingManager::CompleteCallCounting()
                         if (activeNativeCode != 0)
                         {
                             methodDesc->SetCodeEntryPoint(activeNativeCode);
-                            if (methodDesc->MayHaveEntryPointSlotsToBackpatch())
-                            {
-                                Precode::GetPrecodeFromEntryPoint(methodDesc->GetTemporaryEntryPoint())->ResetTargetInterlocked();
-                            }
                             break;
                         }
                     }
 
                     methodDesc->ResetCodeEntryPoint();
-                    if (methodDesc->MayHaveEntryPointSlotsToBackpatch())
-                    {
-                        Precode::GetPrecodeFromEntryPoint(methodDesc->GetTemporaryEntryPoint())->ResetTargetInterlocked();
-                    }
                 } while (false);
 
                 callCountingInfo->SetStage(CallCountingInfo::Stage::Complete);
@@ -1085,15 +1089,7 @@ void CallCountingManager::StopAllCallCounting(TieredCompilationManager *tieredCo
 
             // The intention is that all call counting stubs will be deleted shortly, and only methods that are called again
             // will cause stubs to be recreated, so reset the code entry point
-            MethodDesc *methodDesc = codeVersion.GetMethodDesc();
-            methodDesc->ResetCodeEntryPoint();
-            if (methodDesc->MayHaveEntryPointSlotsToBackpatch())
-            {
-                // ResetCodeEntryPoint() for backpatchable methods resets recorded slots but does not touch the
-                // precode target. Reset the precode target to prestub so that new vtable slots flow through the
-                // prestub for slot discovery and recording.
-                Precode::GetPrecodeFromEntryPoint(methodDesc->GetTemporaryEntryPoint())->ResetTargetInterlocked();
-            }
+            codeVersion.GetMethodDesc()->ResetCodeEntryPoint();
             callCountingInfo->SetStage(newCallCountingStage);
         }
 
@@ -1112,6 +1108,14 @@ void CallCountingManager::StopAllCallCounting(TieredCompilationManager *tieredCo
                 }
                 EX_SWALLOW_NONTERMINAL;
             }
+        }
+
+        // Reset forwarder stubs, they are not in use anymore
+        MethodDescForwarderStubHash &methodDescForwarderStubHash = callCountingManager->m_methodDescForwarderStubHash;
+        for (auto itEnd = methodDescForwarderStubHash.End(), it = methodDescForwarderStubHash.Begin(); it != itEnd; ++it)
+        {
+            Precode *forwarderStub = *it;
+            forwarderStub->ResetTargetInterlocked();
         }
     }
 }
@@ -1140,6 +1144,7 @@ void CallCountingManager::DeleteAllCallCountingStubs()
         _ASSERTE(callCountingManager->m_callCountingInfosPendingCompletion.IsEmpty());
 
         // Clear the call counting stub from call counting infos and delete completed infos
+        MethodDescForwarderStubHash &methodDescForwarderStubHash = callCountingManager->m_methodDescForwarderStubHash;
         CallCountingInfoByCodeVersionHash &callCountingInfoByCodeVersionHash =
             callCountingManager->m_callCountingInfoByCodeVersionHash;
         for (auto itEnd = callCountingInfoByCodeVersionHash.End(), it = callCountingInfoByCodeVersionHash.Begin();
@@ -1164,14 +1169,14 @@ void CallCountingManager::DeleteAllCallCountingStubs()
                 continue;
             }
 
-            // Ensure the precode target is prestub for backpatchable methods whose call counting has completed.
-            // CompleteCallCounting() should have already reset the precode to prestub; this is a safety net to
-            // guarantee the invariant that the precode always points to prestub when call counting is not active,
-            // so that new vtable slots can be discovered and recorded by DoBackpatch().
-            MethodDesc *methodDesc = callCountingInfo->GetCodeVersion().GetMethodDesc();
-            if (methodDesc->MayHaveEntryPointSlotsToBackpatch())
+            // Currently, tier 0 is the last code version that is counted, and the method is typically not counted anymore.
+            // Remove the forwarder stub if one exists, a new one will be created if necessary, for example, if a profiler adds
+            // an IL code version for the method.
+            Precode *const *forwarderStubPtr =
+                methodDescForwarderStubHash.LookupPtr(callCountingInfo->GetCodeVersion().GetMethodDesc());
+            if (forwarderStubPtr != nullptr)
             {
-                Precode::GetPrecodeFromEntryPoint(methodDesc->GetTemporaryEntryPoint())->ResetTargetInterlocked();
+                methodDescForwarderStubHash.RemovePtr(const_cast<Precode **>(forwarderStubPtr));
             }
 
             callCountingInfoByCodeVersionHash.Remove(it);
@@ -1219,6 +1224,24 @@ void CallCountingManager::TrimCollections()
         EX_TRY
         {
             m_callCountingInfoByCodeVersionHash.Reallocate(count * 2);
+        }
+        EX_SWALLOW_NONTERMINAL
+    }
+
+    count = m_methodDescForwarderStubHash.GetCount();
+    capacity = m_methodDescForwarderStubHash.GetCapacity();
+    if (count == 0)
+    {
+        if (capacity != 0)
+        {
+            m_methodDescForwarderStubHash.RemoveAll();
+        }
+    }
+    else if (count <= capacity / 4)
+    {
+        EX_TRY
+        {
+            m_methodDescForwarderStubHash.Reallocate(count * 2);
         }
         EX_SWALLOW_NONTERMINAL
     }

--- a/src/coreclr/vm/callcounting.h
+++ b/src/coreclr/vm/callcounting.h
@@ -19,18 +19,11 @@ When starting call counting for a method (see CallCountingManager::SetCodeEntryP
 - A CallCountingStub is created. It contains a small amount of code that decrements the remaining call count and checks for
   zero. When nonzero, it jumps to the code version's native code entry point. When zero, it forwards to a helper function that
   handles tier promotion.
-- For tiered methods that do not normally use a MethodDesc precode as the stable entry point (virtual and interface methods
-  when slot backpatching is enabled), the method's own temporary-entrypoint precode is redirected to the call counting stub,
-  and vtable slots are reset to point to the temporary entry point. This ensures calls flow through temporary-entrypoint
-  precode -> call counting stub -> native code, and the call counting stub can be safely deleted since vtable slots don't
-  point to it directly. GetMethodEntryPoint() is kept at the native code entry point (not the temporary entry point) so that
-  DoBackpatch() can still record new vtable slots after the precode reverts to prestub. During call counting, there is a
-  bounded window where new vtable slots may not be recorded because the precode target is the call counting stub rather than
-  the prestub. These slots are corrected once call counting stubs are deleted and the precode reverts to prestub.
-  When call counting ends, the precode is always reset to prestub (never to native code), preserving the invariant
-  that new vtable slots can be discovered and recorded by DoBackpatch().
-- For methods with a precode (or when slot backpatching is disabled), the method's code entry point is set to the call
-  counting stub directly.
+- For tiered methods that don't have a precode (virtual and interface methods when slot backpatching is enabled), a forwarder
+  stub (a precode) is created and it forwards to the call counting stub. This is so that the call counting stub can be safely
+  and easily deleted. The forwarder stubs are only used when counting calls, there is one per method (not per code version), and
+  they are not deleted.
+- The method's code entry point is set to the forwarder stub or the call counting stub to count calls to the code version
 
 When the call count threshold is reached (see CallCountingManager::OnCallCountThresholdReached):
 - The helper call enqueues completion of call counting for background processing
@@ -43,6 +36,8 @@ After all work queued for promotion is completed and methods transitioned to opt
 - All call counting stubs are deleted. For code versions that have not completed counting, the method's code entry point is
   reset such that call counting would be reestablished on the next call.
 - Completed call counting infos are deleted
+- For methods that no longer have any code versions that need to be counted, the forwarder stubs are no longer tracked. If a
+  new IL code version is added thereafter (perhaps by a profiler), a new forwarder stub may be created.
 
 Miscellaneous
 -------------
@@ -292,6 +287,27 @@ private:
     };
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    // CallCountingManager::MethodDescForwarderStub
+
+private:
+    class MethodDescForwarderStubHashTraits : public DefaultSHashTraits<Precode *>
+    {
+    private:
+        typedef DefaultSHashTraits<Precode *> Base;
+    public:
+        typedef Base::element_t element_t;
+        typedef Base::count_t count_t;
+        typedef MethodDesc *key_t;
+
+    public:
+        static key_t GetKey(const element_t &e);
+        static BOOL Equals(const key_t &k1, const key_t &k2);
+        static count_t Hash(const key_t &k);
+    };
+
+    typedef SHash<MethodDescForwarderStubHashTraits> MethodDescForwarderStubHash;
+
+    ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // CallCountingManager::CallCountingManagerHashTraits
 
 private:
@@ -325,6 +341,7 @@ private:
 private:
     CallCountingInfoByCodeVersionHash m_callCountingInfoByCodeVersionHash;
     CallCountingStubAllocator m_callCountingStubAllocator;
+    MethodDescForwarderStubHash m_methodDescForwarderStubHash;
     SArray<CallCountingInfo *> m_callCountingInfosPendingCompletion;
 
 public:

--- a/src/coreclr/vm/method.cpp
+++ b/src/coreclr/vm/method.cpp
@@ -3165,7 +3165,7 @@ void MethodDesc::RecordAndBackpatchEntryPointSlot_Locked(
     backpatchTracker->AddSlotAndPatch_Locked(this, slotLoaderAllocator, slot, slotType, currentEntryPoint);
 }
 
-bool MethodDesc::TryBackpatchEntryPointSlots(
+FORCEINLINE bool MethodDesc::TryBackpatchEntryPointSlots(
     PCODE entryPoint,
     bool isPrestubEntryPoint,
     bool onlyFromPrestubEntryPoint)

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -106,19 +106,10 @@ PCODE MethodDesc::DoBackpatch(MethodTable * pMT, MethodTable *pDispatchingMT, bo
         //     MethodDesc::BackpatchEntryPointSlots()
 
         // Backpatching the temporary entry point:
-        //     The temporary entry point is not directly backpatched for methods versionable with vtable slot backpatch.
-        //     New vtable slots inheriting the method will initially point to the temporary entry point. During call
-        //     counting, the temporary entry point's precode target may be temporarily redirected to a call counting
-        //     stub, but it must revert to the prestub when call counting ends (not to native code). This ensures new
-        //     vtable slots will come here for backpatching so they can be discovered and recorded for future
-        //     backpatching. The precode for backpatchable methods should only ever point to:
-        //       1. The prestub (default, and when call counting is not active)
-        //       2. A call counting stub (during active call counting only)
-        //     It must never point directly to native code, as that would permanently bypass slot recording.
-        //
-        //     To enable slot recording after the precode reverts to prestub, GetMethodEntryPoint() must be set to the
-        //     native code entry point (not the temporary entry point) during call counting. This prevents the
-        //     pExpected == pTarget check above from short-circuiting slot recording.
+        //     The temporary entry point is never backpatched for methods versionable with vtable slot backpatch. New vtable
+        //     slots inheriting the method will initially point to the temporary entry point and it must point to the prestub
+        //     and come here for backpatching such that the new vtable slot can be discovered and recorded for future
+        //     backpatching.
 
         _ASSERTE(!HasNonVtableSlot());
     }


### PR DESCRIPTION
Reverts dotnet/runtime#124664

This appears to have caused a 12-13% regression nuget restore perf due to increased time spent in ThePreStub, specifically in RtlEnterCriticalSection