### PR TITLE
Fix GetModule_ReturnsModule test failure on browser-wasm

### DIFF
--- a/src/libraries/System.Reflection.Context/tests/ExtendedAssemblyTests2.cs
+++ b/src/libraries/System.Reflection.Context/tests/ExtendedAssemblyTests2.cs
@@ -98,26 +98,11 @@ namespace System.Reflection.Context.Tests
             // May be null if resource doesn't exist
         }
 
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
         public void GetModule_ReturnsModule()
         {
-            string moduleName = _customAssembly.ManifestModule.Name;
-            if (PlatformDetection.HasAssemblyFiles)
-            {
-                Module module = _customAssembly.GetModule(moduleName);
-                Assert.NotNull(module);
-            }
-            else if (PlatformDetection.IsNativeAot)
-            {
-                // On native AOT, Module.Name returns "<Unknown>" and GetModule with that name returns null
-                Assert.Equal("<Unknown>", moduleName);
-            }
-            else
-            {
-                // On browser-wasm, HasAssemblyFiles is false but Module.Name still returns the real name
-                Module module = _customAssembly.GetModule(moduleName);
-                Assert.NotNull(module);
-            }
+            Module module = _customAssembly.GetModule(_customAssembly.ManifestModule.Name);
+            Assert.NotNull(module);
         }
 
         [Fact]

--- a/src/libraries/System.Reflection.Context/tests/ExtendedAssemblyTests2.cs
+++ b/src/libraries/System.Reflection.Context/tests/ExtendedAssemblyTests2.cs
@@ -107,10 +107,16 @@ namespace System.Reflection.Context.Tests
                 Module module = _customAssembly.GetModule(moduleName);
                 Assert.NotNull(module);
             }
-            else
+            else if (PlatformDetection.IsNativeAot)
             {
                 // On native AOT, Module.Name returns "<Unknown>" and GetModule with that name returns null
                 Assert.Equal("<Unknown>", moduleName);
+            }
+            else
+            {
+                // On browser-wasm, HasAssemblyFiles is false but Module.Name still returns the real name
+                Module module = _customAssembly.GetModule(moduleName);
+                Assert.NotNull(module);
             }
         }
 


### PR DESCRIPTION
The `else` branch added in PR #125080 assumed `!HasAssemblyFiles` implies NativeAOT, but browser-wasm also has `!HasAssemblyFiles` (since `Assembly.Location` is empty). On wasm (Mono), `Module.Name` returns the real DLL name (`"System.Reflection.Context.Tests.dll"`), not `"<Unknown>"`, so the assertion fails.

Split the `else` branch to handle NativeAOT and wasm separately:
- NativeAOT: assert `Module.Name == "<Unknown>"`
- wasm/other: call `GetModule(moduleName)` and assert not null

Fixes #125245