### PR TITLE
Use Framework SourceType for WASM pass-through assets in multi-client solutions

### DIFF
--- a/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
+++ b/src/mono/nuget/Microsoft.NET.Sdk.WebAssembly.Pack/build/Microsoft.NET.Sdk.WebAssembly.Browser.targets
@@ -353,6 +353,7 @@ Copyright (c) .NET Foundation. All rights reserved.
     <PropertyGroup>
       <_WasmBuildWebcilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'webcil'))</_WasmBuildWebcilPath>
       <_WasmBuildTmpWebcilPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'tmp-webcil'))</_WasmBuildTmpWebcilPath>
+      <_WasmFrameworkAssetPath>$([MSBuild]::NormalizeDirectory($(IntermediateOutputPath), 'fx', '$(PackageId)'))</_WasmFrameworkAssetPath>
     </PropertyGroup>
 
     <ConvertDllsToWebcil Candidates="@(_BuildAssetsCandidates)" IntermediateOutputPath="$(_WasmBuildTmpWebcilPath)" OutputPath="$(_WasmBuildWebcilPath)" IsEnabled="$(_WasmEnableWebcil)">
@@ -360,9 +361,42 @@ Copyright (c) .NET Foundation. All rights reserved.
       <Output TaskParameter="FileWrites" ItemName="FileWrites" />
     </ConvertDllsToWebcil>
 
+    <!-- Materialize framework pass-through files (JS, maps, ICU, native wasm, and when WebCil is
+         disabled, DLLs) from shared locations (e.g. NuGet cache) to a per-project directory.
+         Webcil-converted files already live in per-project $(IntermediateOutputPath)webcil/ and
+         don't need materialization. Framework assets are copied to obj/fx/{PackageId}/ following
+         the SWA Framework SourceType convention so each project gets a unique Identity.
+         Satellite assemblies are placed in culture subdirectories to match ConvertDllsToWebcil. -->
     <ItemGroup>
+      <_WasmFrameworkCandidates Include="@(_WebcilAssetsCandidates)"
+        Condition="!$([System.String]::new('%(Identity)').StartsWith($(_WasmBuildWebcilPath)))" />
+      <_WebcilAssetsCandidates Remove="@(_WasmFrameworkCandidates)" />
+    </ItemGroup>
+
+    <!-- Separate satellite (culture) assets from regular ones so we can place them in subdirs -->
+    <ItemGroup>
+      <_WasmCultureFrameworkAssets Include="@(_WasmFrameworkCandidates)"
+        Condition="'%(_WasmFrameworkCandidates.AssetTraitName)' == 'Culture'" />
+      <_WasmFrameworkCandidates Remove="@(_WasmCultureFrameworkAssets)" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_WasmFrameworkCandidates)"
+      DestinationFolder="$(_WasmFrameworkAssetPath)"
+      SkipUnchangedFiles="true" />
+
+    <Copy SourceFiles="@(_WasmCultureFrameworkAssets)"
+      DestinationFiles="@(_WasmCultureFrameworkAssets->'$(_WasmFrameworkAssetPath)%(AssetTraitValue)/%(Filename)%(Extension)')"
+      SkipUnchangedFiles="true"
+      Condition="'@(_WasmCultureFrameworkAssets)' != ''" />
+
+    <ItemGroup>
+      <FileWrites Include="@(_WasmFrameworkCandidates->'$(_WasmFrameworkAssetPath)%(Filename)%(Extension)')" />
+      <FileWrites Include="@(_WasmCultureFrameworkAssets->'$(_WasmFrameworkAssetPath)%(AssetTraitValue)/%(Filename)%(Extension)')" />
+      <_WasmMaterializedFrameworkAssets Include="@(_WasmFrameworkCandidates->'$(_WasmFrameworkAssetPath)%(Filename)%(Extension)')" />
+      <_WasmMaterializedFrameworkAssets Include="@(_WasmCultureFrameworkAssets->'$(_WasmFrameworkAssetPath)%(AssetTraitValue)/%(Filename)%(Extension)')" />
       <!-- Set per-item ContentRoot so each asset's Identity matches its actual file on disk -->
       <_WebcilAssetsCandidates Update="@(_WebcilAssetsCandidates)" ContentRoot="%(RootDir)%(Directory)" />
+      <_WasmMaterializedFrameworkAssets Update="@(_WasmMaterializedFrameworkAssets)" ContentRoot="%(RootDir)%(Directory)" />
       <_WasmFingerprintPatterns Include="WasmFiles" Pattern="*.wasm" Expression="#[.{fingerprint}]!" />
       <_WasmFingerprintPatterns Include="DllFiles" Pattern="*.dll" Expression="#[.{fingerprint}]!" />
       <_WasmFingerprintPatterns Include="DatFiles" Pattern="*.dat" Expression="#[.{fingerprint}]!" />
@@ -370,10 +404,28 @@ Copyright (c) .NET Foundation. All rights reserved.
       <_WasmFingerprintPatterns Include="Symbols" Pattern="*.js.symbols" Expression="#[.{fingerprint}]!" />
     </ItemGroup>
 
+    <!-- Webcil-converted assets are per-project (Computed); materialized framework assets
+         are adopted from the runtime pack (Framework). Define them separately so the SWA
+         pipeline can handle Framework materialization/ownership correctly. -->
     <DefineStaticWebAssets
       CandidateAssets="@(_WebcilAssetsCandidates)"
       SourceId="$(PackageId)"
       SourceType="Computed"
+      AssetKind="Build"
+      AssetRole="Primary"
+      CopyToOutputDirectory="PreserveNewest"
+      CopyToPublishDirectory="Never"
+      FingerprintCandidates="$(_WasmFingerprintAssets)"
+      FingerprintPatterns="@(FingerprintPatterns);@(_WasmFingerprintPatterns)"
+      BasePath="$(StaticWebAssetBasePath)"
+    >
+      <Output TaskParameter="Assets" ItemName="WasmStaticWebAsset" />
+    </DefineStaticWebAssets>
+
+    <DefineStaticWebAssets
+      CandidateAssets="@(_WasmMaterializedFrameworkAssets)"
+      SourceId="$(PackageId)"
+      SourceType="Framework"
       AssetKind="Build"
       AssetRole="Primary"
       CopyToOutputDirectory="PreserveNewest"


### PR DESCRIPTION
## Summary

When multiple Blazor WebAssembly client projects reference the same runtime pack, pass-through files (JS, maps, ICU data, native wasm) share a NuGet cache path. This causes duplicate Identity keys in the static web assets pipeline, crashing `DiscoverPrecompressedAssets` with an `ArgumentException` on `ToDictionary`.

## Root Cause

PR #124125 correctly changed WASM `ContentRoot` from project-specific `OutputPath` copies to per-item `%(RootDir)%(Directory)` (pointing to the real file in the NuGet cache). This fixed staleness on incremental builds. However, when two WASM client projects reference the same runtime pack, shared files like `dotnet.js.map` now resolve to identical NuGet cache paths, producing duplicate Identity values.

## Fix

Instead of copying pass-throughs to the intermediate output path (which risks re-introducing the staleness bug #124125 fixed), materialize them to a per-project `obj/fx/{PackageId}/` directory using the **Framework SourceType** convention from the SWA SDK (dotnet/sdk#53135).

- **Pass-through files** (JS, maps, ICU, native wasm, and DLLs when WebCil is disabled): copied to `obj/fx/{PackageId}/`, registered with `SourceType="Framework"`
- **WebCil-converted files**: remain in `obj/webcil/`, registered with `SourceType="Computed"` (already per-project)
- **Satellite assemblies**: placed in culture subdirectories in both cases
- Both groups get per-item `ContentRoot` for correct Identity resolution

## Architecture

This follows the SWA Framework materialization pattern: framework assets are "adopted" by each consuming project, giving them unique per-project Identity values while properly modeling the ownership relationship. `AssetMode=CurrentProject` prevents assets from leaking to references.

## Dependencies

Requires SDK support for `SourceType="Framework"` from dotnet/sdk#53135.

## Testing

Validated with:
- Multi-client build (2 WASM clients): ✅ 221 framework assets materialized per project
- Multi-client publish: ✅ Both clients produce 141 fingerprinted files
- Incremental rebuild: ✅
- WebCil disabled (`WasmEnableWebcil=false`): ✅ All files as Framework pass-throughs
- aspnetcore Components.TestServer (3 WASM clients, WasmMinimal + WasmRemoteAuthentication + BasicTestApp): ✅ Build succeeded, 0 errors

## Related

- Fixes crash introduced by #124125
- Depends on dotnet/sdk#53135 (Framework SourceType support)
- Supersedes approach in dotnet/sdk#53305 / dotnet/sdk#53328 (skip-duplicate)
