### PR TITLE
Ensure DAC volatile globals included in mini dump

### DIFF
--- a/src/coreclr/debug/daccess/enummem.cpp
+++ b/src/coreclr/debug/daccess/enummem.cpp
@@ -183,6 +183,8 @@ HRESULT ClrDataAccess::EnumMemCLRStatic(IN CLRDataEnumMemoryFlags flags)
     //
 #define DEFINE_DACVAR(size_type, id, var) \
     ReportMem(m_dacGlobals.id, sizeof(size_type));
+#define DEFINE_DACVAR_VOLATILE(size_type, id, var) \
+    ReportMem(m_dacGlobals.id, sizeof(size_type));
 
     ULONG64 dacTableAddress;
     HRESULT hr = GetDacTableAddress(m_pTarget, m_globalBase, &dacTableAddress);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -2450,7 +2450,7 @@ public sealed unsafe partial class SOSDacImpl
             if (ip == 0 || ppMD == null)
                 throw new ArgumentException();
             IExecutionManager executionManager = _target.Contracts.ExecutionManager;
-            IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+            IRuntimeTypeSystem rtss = _target.Contracts.RuntimeTypeSystem;
 
             CodeBlockHandle? handle = executionManager.GetCodeBlockHandle(ip.ToTargetCodePointer(_target));
             if (handle is not CodeBlockHandle codeHandle)
@@ -2462,7 +2462,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 // Runs validation of MethodDesc
                 // if validation fails, should return E_INVALIDARG
-                rts.GetMethodDescHandle(methodDescAddr);
+                rtss.GetMethodDescHandle(methodDescAddr);
 
                 *ppMD = methodDescAddr.ToClrDataAddress(_target);
                 hr = HResults.S_OK;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/SOSDacImpl.cs
@@ -2450,7 +2450,7 @@ public sealed unsafe partial class SOSDacImpl
             if (ip == 0 || ppMD == null)
                 throw new ArgumentException();
             IExecutionManager executionManager = _target.Contracts.ExecutionManager;
-            IRuntimeTypeSystem rtss = _target.Contracts.RuntimeTypeSystem;
+            IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
 
             CodeBlockHandle? handle = executionManager.GetCodeBlockHandle(ip.ToTargetCodePointer(_target));
             if (handle is not CodeBlockHandle codeHandle)
@@ -2462,7 +2462,7 @@ public sealed unsafe partial class SOSDacImpl
             {
                 // Runs validation of MethodDesc
                 // if validation fails, should return E_INVALIDARG
-                rtss.GetMethodDescHandle(methodDescAddr);
+                rts.GetMethodDescHandle(methodDescAddr);
 
                 *ppMD = methodDescAddr.ToClrDataAddress(_target);
                 hr = HResults.S_OK;


### PR DESCRIPTION
This ensures that volatile DAC globals (declared with `DEFINE_DACVAR_VOLATILE`) are included in heap mini dumps the same way non-volatile global DACVARs are via `EnumMemCLRStatic`. This includes globals that are interesting for the cDAC such as `g_pContinuationClassIfSubTypeCreated`. This fixes the failure observed in https://dev.azure.com/dnceng-public/public/_build/results?buildId=1324292; see the green test runs on https://github.com/dotnet/runtime/pull/125310/commits/52b42157c2e887df2915aa6aa2d70a36a9d216d3