### PR TITLE
Revert "Bump serialize-javascript and @rollup/plugin-terser in /src/native"

### DIFF
--- a/src/native/package-lock.json
+++ b/src/native/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "16.0.1",
-        "@rollup/plugin-terser": "1.0.0",
+        "@rollup/plugin-terser": "0.4.4",
         "@rollup/plugin-typescript": "12.1.4",
         "@rollup/plugin-virtual": "3.0.2",
         "@types/node": "24.5.2",
@@ -320,18 +320,18 @@
       }
     },
     "node_modules/@rollup/plugin-terser": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/@rollup/plugin-terser/-/plugin-terser-1.0.0.tgz",
-      "integrity": "sha1-2rvEQU0SeqfUP8Xn6oaZucO8WeU=",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
+      "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "serialize-javascript": "^7.0.3",
+        "serialize-javascript": "^6.0.1",
         "smob": "^1.0.0",
         "terser": "^5.17.4"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
         "rollup": "^2.0.0||^3.0.0||^4.0.0"
@@ -2441,6 +2441,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -2592,6 +2602,27 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/semver/-/semver-7.7.2.tgz",
@@ -2606,13 +2637,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public-npm/npm/registry/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha1-xRdzW9W3Yx3R/Bke4Zy7cT/44Fw=",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=20.0.0"
+      "dependencies": {
+        "randombytes": "^2.1.0"
       }
     },
     "node_modules/shebang-command": {

--- a/src/native/package.json
+++ b/src/native/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "devDependencies": {
     "@rollup/plugin-node-resolve": "16.0.1",
-    "@rollup/plugin-terser": "1.0.0",
+    "@rollup/plugin-terser": "0.4.4",
     "@rollup/plugin-typescript": "12.1.4",
     "@rollup/plugin-virtual": "3.0.2",
     "@types/node": "24.5.2",


### PR DESCRIPTION
Reverts dotnet/runtime#125230.

This breaks on CI (same as in https://github.com/dotnet/runtime/pull/125264):

```
rollup -c --environment Configuration:Checked,ProductVersion:11.0.0,ContinuousIntegrationBuild:True,RuntimeFlavor:CoreCLR,StaticLibDestination:D:/a/_work/1/s/artifacts/obj/coreclr/browser.wasm.Checked/libs-native

  Rollup configuration: Configuration=Debug, RuntimeFlavor=CoreCLR, ProductVersion=11.0.0, ContinuousIntegrationBuild=false
  [!] ReferenceError: crypto is not defined
      at generateUID (D:\a_work\1\s\src\native\node_modules\serialize-javascript\index.js:54:17)
      at Object.<anonymous> (D:\a_work\1\s\src\native\node_modules\serialize-javascript\index.js:11:27)
      at Module._compile (node:internal/modules/cjs/loader:1256:14)
      at Object.Module._extensions..js (node:internal/modules/cjs/loader:1310:10)
      at Module.load (node:internal/modules/cjs/loader:1119:32)
      at Function.Module._load (node:internal/modules/cjs/loader:960:12)
      at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:169:29)
      at ModuleJob.run (node:internal/modules/esm/module_job:194:25)
```