### PR TITLE
Read USTAR prefix field for PAX format entries in TarReader

### DIFF
--- a/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
+++ b/src/libraries/System.Formats.Tar/src/System/Formats/Tar/TarHeader.Read.cs
@@ -77,15 +77,20 @@ namespace System.Formats.Tar
                     header.ReadPosixAndGnuSharedAttributes(buffer);
 
                     Debug.Assert(header._format is TarEntryFormat.Ustar or TarEntryFormat.Pax or TarEntryFormat.Gnu);
-                    if (header._format == TarEntryFormat.Ustar)
+                    if (header._format is TarEntryFormat.Ustar or TarEntryFormat.Pax)
                     {
+                        // PAX extends USTAR and uses the same header layout including the
+                        // prefix field.  When an actual entry follows a PAX extended
+                        // attributes header, the entry's prefix may still carry part of
+                        // the path.  The PAX "path" extended attribute, if present, will
+                        // override the combined prefix/name afterward in
+                        // ReplaceNormalAttributesWithExtended.
                         header.ReadUstarAttributes(buffer);
                     }
                     else if (header._format == TarEntryFormat.Gnu)
                     {
                         header.ReadGnuAttributes(buffer);
                     }
-                    // In PAX, there is nothing to read in this section (empty space)
                 }
                 // Finished reading the header metadata, next byte belongs to the data section, save the position
                 SetDataOffset(header, archiveStream);

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Text;
 using Xunit;
 
 namespace System.Formats.Tar.Tests
@@ -464,6 +465,96 @@ namespace System.Formats.Tar.Tests
 
             using TarReader reader = new TarReader(archiveStream);
             Assert.Throws<NotSupportedException>(() => reader.GetNextEntry());
+        }
+
+        [Fact]
+        public void Read_PaxEntryWithOnlyLinkpath_PreservesUstarPrefix()
+        {
+            // macOS bsdtar writes symlinks whose link target exceeds 100 bytes as a
+            // PAX extended attributes entry (typeflag 'x') containing only "linkpath",
+            // followed by a standard USTAR entry that uses the prefix/name split.
+            // Because the entry name fits in prefix+name, bsdtar does NOT include the
+            // "path" extended attribute.  TarReader must still combine prefix+name.
+
+            string expectedName = "./sdk/tools/net11.0/any/SomeAssembly.dll";
+            string prefix = "./sdk";
+            string nameField = "tools/net11.0/any/SomeAssembly.dll";
+            string longLinkTarget = "../../../../../dotnet-format/BuildHost-netcore/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll";
+
+            using MemoryStream archiveStream = new MemoryStream();
+
+            // --- PAX extended attributes header (typeflag 'x') ---
+            byte[] paxHeader = new byte[512];
+            Encoding.UTF8.GetBytes("./PaxHeaders.12345/SomeAssembly.dll").CopyTo(paxHeader.AsSpan(0));
+            Encoding.UTF8.GetBytes("0000644\0").CopyTo(paxHeader.AsSpan(100, 8));
+            Encoding.UTF8.GetBytes("0000000\0").CopyTo(paxHeader.AsSpan(108, 8));
+            Encoding.UTF8.GetBytes("0000000\0").CopyTo(paxHeader.AsSpan(116, 8));
+            Encoding.UTF8.GetBytes("00000000000\0").CopyTo(paxHeader.AsSpan(136, 12));
+            paxHeader[156] = (byte)'x';
+            Encoding.UTF8.GetBytes("ustar\0").CopyTo(paxHeader.AsSpan(257, 6));
+            Encoding.UTF8.GetBytes("00").CopyTo(paxHeader.AsSpan(263, 2));
+
+            // Build PAX data containing only "linkpath" (no "path" key).
+            string paxPayload = $"linkpath={longLinkTarget}\n";
+            int totalLen = 1 + paxPayload.Length; // start with 1-digit length placeholder
+            // Iteratively determine the total length including the length field itself.
+            while (totalLen.ToString().Length + 1 + paxPayload.Length != totalLen)
+            {
+                totalLen = totalLen.ToString().Length + 1 + paxPayload.Length;
+            }
+            string paxData = $"{totalLen} {paxPayload}";
+            byte[] paxDataBytes = Encoding.UTF8.GetBytes(paxData);
+
+            string sizeOctal = Convert.ToString(paxDataBytes.Length, 8).PadLeft(11, '0') + "\0";
+            Encoding.UTF8.GetBytes(sizeOctal).CopyTo(paxHeader.AsSpan(124, 12));
+
+            WriteChecksum(paxHeader);
+            archiveStream.Write(paxHeader);
+            archiveStream.Write(paxDataBytes);
+            int padding = (512 - (paxDataBytes.Length % 512)) % 512;
+            if (padding > 0) archiveStream.Write(new byte[padding]);
+
+            // --- Actual USTAR symlink entry ---
+            byte[] entryHeader = new byte[512];
+            Encoding.UTF8.GetBytes(nameField).CopyTo(entryHeader.AsSpan(0));
+            Encoding.UTF8.GetBytes("0000777\0").CopyTo(entryHeader.AsSpan(100, 8));
+            Encoding.UTF8.GetBytes("0000000\0").CopyTo(entryHeader.AsSpan(108, 8));
+            Encoding.UTF8.GetBytes("0000000\0").CopyTo(entryHeader.AsSpan(116, 8));
+            Encoding.UTF8.GetBytes("00000000000\0").CopyTo(entryHeader.AsSpan(124, 12));
+            Encoding.UTF8.GetBytes("14751414000\0").CopyTo(entryHeader.AsSpan(136, 12));
+            entryHeader[156] = (byte)'2'; // SymbolicLink
+            // Write truncated link target (first 100 bytes) into the linkname field.
+            Encoding.UTF8.GetBytes(longLinkTarget.Substring(0, Math.Min(100, longLinkTarget.Length)))
+                .CopyTo(entryHeader.AsSpan(157));
+            Encoding.UTF8.GetBytes("ustar\0").CopyTo(entryHeader.AsSpan(257, 6));
+            Encoding.UTF8.GetBytes("00").CopyTo(entryHeader.AsSpan(263, 2));
+            Encoding.UTF8.GetBytes(prefix).CopyTo(entryHeader.AsSpan(345));
+
+            WriteChecksum(entryHeader);
+            archiveStream.Write(entryHeader);
+
+            // End-of-archive markers.
+            archiveStream.Write(new byte[1024]);
+            archiveStream.Seek(0, SeekOrigin.Begin);
+
+            using TarReader reader2 = new TarReader(archiveStream);
+            TarEntry entry = reader2.GetNextEntry();
+            Assert.NotNull(entry);
+            Assert.Equal(expectedName, entry.Name);
+            Assert.Equal(longLinkTarget, entry.LinkName);
+            Assert.Equal(TarEntryType.SymbolicLink, entry.EntryType);
+            Assert.Null(reader2.GetNextEntry());
+        }
+
+        private static void WriteChecksum(byte[] header)
+        {
+            int checksum = 0;
+            for (int i = 0; i < header.Length; i++)
+            {
+                checksum += (i >= 148 && i < 156) ? (byte)' ' : header[i];
+            }
+            string checksumStr = Convert.ToString(checksum, 8).PadLeft(6, '0') + "\0 ";
+            Encoding.UTF8.GetBytes(checksumStr).CopyTo(header.AsSpan(148, 8));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntry.Tests.cs
@@ -508,7 +508,7 @@ namespace System.Formats.Tar.Tests
             string sizeOctal = Convert.ToString(paxDataBytes.Length, 8).PadLeft(11, '0') + "\0";
             Encoding.UTF8.GetBytes(sizeOctal).CopyTo(paxHeader.AsSpan(124, 12));
 
-            WriteChecksum(paxHeader);
+            WriteHeaderChecksum(paxHeader);
             archiveStream.Write(paxHeader);
             archiveStream.Write(paxDataBytes);
             int padding = (512 - (paxDataBytes.Length % 512)) % 512;
@@ -530,7 +530,7 @@ namespace System.Formats.Tar.Tests
             Encoding.UTF8.GetBytes("00").CopyTo(entryHeader.AsSpan(263, 2));
             Encoding.UTF8.GetBytes(prefix).CopyTo(entryHeader.AsSpan(345));
 
-            WriteChecksum(entryHeader);
+            WriteHeaderChecksum(entryHeader);
             archiveStream.Write(entryHeader);
 
             // End-of-archive markers.
@@ -544,17 +544,6 @@ namespace System.Formats.Tar.Tests
             Assert.Equal(longLinkTarget, entry.LinkName);
             Assert.Equal(TarEntryType.SymbolicLink, entry.EntryType);
             Assert.Null(reader2.GetNextEntry());
-        }
-
-        private static void WriteChecksum(byte[] header)
-        {
-            int checksum = 0;
-            for (int i = 0; i < header.Length; i++)
-            {
-                checksum += (i >= 148 && i < 156) ? (byte)' ' : header[i];
-            }
-            string checksumStr = Convert.ToString(checksum, 8).PadLeft(6, '0') + "\0 ";
-            Encoding.UTF8.GetBytes(checksumStr).CopyTo(header.AsSpan(148, 8));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -448,6 +449,85 @@ namespace System.Formats.Tar.Tests
             Assert.Equal("file2.txt", nextEntry.Name);
 
             Assert.Null(await reader.GetNextEntryAsync());
+        }
+
+        [Fact]
+        public async Task GetNextEntryAsync_PaxEntryWithOnlyLinkpath_PreservesUstarPrefix()
+        {
+            // Async variant of
+            // TarReader_GetNextEntry_Tests.Read_PaxEntryWithOnlyLinkpath_PreservesUstarPrefix
+
+            string expectedName = "./sdk/tools/net11.0/any/SomeAssembly.dll";
+            string prefix = "./sdk";
+            string nameField = "tools/net11.0/any/SomeAssembly.dll";
+            string longLinkTarget = "../../../../../dotnet-format/BuildHost-netcore/Microsoft.CodeAnalysis.Workspaces.MSBuild.BuildHost.dll";
+
+            await using MemoryStream archiveStream = new MemoryStream();
+
+            byte[] paxHeader = new byte[512];
+            Encoding.UTF8.GetBytes("./PaxHeaders.12345/SomeAssembly.dll").CopyTo(paxHeader.AsSpan(0));
+            Encoding.UTF8.GetBytes("0000644\0").CopyTo(paxHeader.AsSpan(100, 8));
+            Encoding.UTF8.GetBytes("0000000\0").CopyTo(paxHeader.AsSpan(108, 8));
+            Encoding.UTF8.GetBytes("0000000\0").CopyTo(paxHeader.AsSpan(116, 8));
+            Encoding.UTF8.GetBytes("00000000000\0").CopyTo(paxHeader.AsSpan(136, 12));
+            paxHeader[156] = (byte)'x';
+            Encoding.UTF8.GetBytes("ustar\0").CopyTo(paxHeader.AsSpan(257, 6));
+            Encoding.UTF8.GetBytes("00").CopyTo(paxHeader.AsSpan(263, 2));
+
+            string paxPayload = $"linkpath={longLinkTarget}\n";
+            int totalLen = 1 + paxPayload.Length;
+            while (totalLen.ToString().Length + 1 + paxPayload.Length != totalLen)
+            {
+                totalLen = totalLen.ToString().Length + 1 + paxPayload.Length;
+            }
+            byte[] paxDataBytes = Encoding.UTF8.GetBytes($"{totalLen} {paxPayload}");
+
+            string sizeOctal = Convert.ToString(paxDataBytes.Length, 8).PadLeft(11, '0') + "\0";
+            Encoding.UTF8.GetBytes(sizeOctal).CopyTo(paxHeader.AsSpan(124, 12));
+
+            WriteChecksum(paxHeader);
+            archiveStream.Write(paxHeader);
+            archiveStream.Write(paxDataBytes);
+            int padding = (512 - (paxDataBytes.Length % 512)) % 512;
+            if (padding > 0) archiveStream.Write(new byte[padding]);
+
+            byte[] entryHeader = new byte[512];
+            Encoding.UTF8.GetBytes(nameField).CopyTo(entryHeader.AsSpan(0));
+            Encoding.UTF8.GetBytes("0000777\0").CopyTo(entryHeader.AsSpan(100, 8));
+            Encoding.UTF8.GetBytes("0000000\0").CopyTo(entryHeader.AsSpan(108, 8));
+            Encoding.UTF8.GetBytes("0000000\0").CopyTo(entryHeader.AsSpan(116, 8));
+            Encoding.UTF8.GetBytes("00000000000\0").CopyTo(entryHeader.AsSpan(124, 12));
+            Encoding.UTF8.GetBytes("14751414000\0").CopyTo(entryHeader.AsSpan(136, 12));
+            entryHeader[156] = (byte)'2';
+            Encoding.UTF8.GetBytes(longLinkTarget.Substring(0, Math.Min(100, longLinkTarget.Length)))
+                .CopyTo(entryHeader.AsSpan(157));
+            Encoding.UTF8.GetBytes("ustar\0").CopyTo(entryHeader.AsSpan(257, 6));
+            Encoding.UTF8.GetBytes("00").CopyTo(entryHeader.AsSpan(263, 2));
+            Encoding.UTF8.GetBytes(prefix).CopyTo(entryHeader.AsSpan(345));
+
+            WriteChecksum(entryHeader);
+            archiveStream.Write(entryHeader);
+            archiveStream.Write(new byte[1024]);
+            archiveStream.Seek(0, SeekOrigin.Begin);
+
+            await using TarReader reader2 = new TarReader(archiveStream);
+            TarEntry entry = await reader2.GetNextEntryAsync();
+            Assert.NotNull(entry);
+            Assert.Equal(expectedName, entry.Name);
+            Assert.Equal(longLinkTarget, entry.LinkName);
+            Assert.Equal(TarEntryType.SymbolicLink, entry.EntryType);
+            Assert.Null(await reader2.GetNextEntryAsync());
+        }
+
+        private static void WriteChecksum(byte[] header)
+        {
+            int checksum = 0;
+            for (int i = 0; i < header.Length; i++)
+            {
+                checksum += (i >= 148 && i < 156) ? (byte)' ' : header[i];
+            }
+            string checksumStr = Convert.ToString(checksum, 8).PadLeft(6, '0') + "\0 ";
+            Encoding.UTF8.GetBytes(checksumStr).CopyTo(header.AsSpan(148, 8));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarReader/TarReader.GetNextEntryAsync.Tests.cs
@@ -485,7 +485,7 @@ namespace System.Formats.Tar.Tests
             string sizeOctal = Convert.ToString(paxDataBytes.Length, 8).PadLeft(11, '0') + "\0";
             Encoding.UTF8.GetBytes(sizeOctal).CopyTo(paxHeader.AsSpan(124, 12));
 
-            WriteChecksum(paxHeader);
+            WriteHeaderChecksum(paxHeader);
             archiveStream.Write(paxHeader);
             archiveStream.Write(paxDataBytes);
             int padding = (512 - (paxDataBytes.Length % 512)) % 512;
@@ -505,7 +505,7 @@ namespace System.Formats.Tar.Tests
             Encoding.UTF8.GetBytes("00").CopyTo(entryHeader.AsSpan(263, 2));
             Encoding.UTF8.GetBytes(prefix).CopyTo(entryHeader.AsSpan(345));
 
-            WriteChecksum(entryHeader);
+            WriteHeaderChecksum(entryHeader);
             archiveStream.Write(entryHeader);
             archiveStream.Write(new byte[1024]);
             archiveStream.Seek(0, SeekOrigin.Begin);
@@ -517,17 +517,6 @@ namespace System.Formats.Tar.Tests
             Assert.Equal(longLinkTarget, entry.LinkName);
             Assert.Equal(TarEntryType.SymbolicLink, entry.EntryType);
             Assert.Null(await reader2.GetNextEntryAsync());
-        }
-
-        private static void WriteChecksum(byte[] header)
-        {
-            int checksum = 0;
-            for (int i = 0; i < header.Length; i++)
-            {
-                checksum += (i >= 148 && i < 156) ? (byte)' ' : header[i];
-            }
-            string checksumStr = Convert.ToString(checksum, 8).PadLeft(6, '0') + "\0 ";
-            Encoding.UTF8.GetBytes(checksumStr).CopyTo(header.AsSpan(148, 8));
         }
     }
 }

--- a/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
+++ b/src/libraries/System.Formats.Tar/tests/TarTestsBase.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Text;
 using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
@@ -902,6 +903,17 @@ namespace System.Formats.Tar.Tests
             Name,
             NameAndPrefix,
             Unlimited
+        }
+
+        internal static void WriteHeaderChecksum(byte[] header)
+        {
+            int checksum = 0;
+            for (int i = 0; i < header.Length; i++)
+            {
+                checksum += (i >= 148 && i < 156) ? (byte)' ' : header[i];
+            }
+            string checksumStr = Convert.ToString(checksum, 8).PadLeft(6, '0') + "\0 ";
+            Encoding.UTF8.GetBytes(checksumStr).CopyTo(header.AsSpan(148, 8));
         }
 
         internal void WriteTarArchiveWithOneEntry(Stream s, TarEntryFormat entryFormat, TarEntryType entryType)


### PR DESCRIPTION
## Summary

When a PAX extended attributes entry (typeflag `x`) precedes an actual USTAR entry, `TryProcessExtendedAttributesHeader` forces the format to PAX. Previously, `ReadUstarAttributes` was only called for `TarEntryFormat.Ustar`, so the USTAR prefix field was never read for entries following a PAX header. If the PAX extended attributes did not include a `path` key (e.g. macOS bsdtar only emits `linkpath` when the symlink target exceeds 100 bytes), the entry name was left as the truncated 100-byte name field without the prefix.

## Root Cause

PAX extends USTAR and uses the same header layout including the prefix field. The code in `TarHeader.Read.cs` line 80 only called `ReadUstarAttributes` when `header._format == TarEntryFormat.Ustar`, skipping it for PAX. When `ReplaceNormalAttributesWithExtended` ran afterwards, there was no `path` key to override the truncated name, leaving the entry name corrupted.

## Fix

Changed `TryReadAttributes` to call `ReadUstarAttributes` for both `TarEntryFormat.Ustar` and `TarEntryFormat.Pax`. The PAX `path` extended attribute, when present, correctly overrides the combined prefix/name afterward in `ReplaceNormalAttributesWithExtended`.

## Tests

Added regression tests (sync and async) that construct a tarball mimicking macOS bsdtar behavior: a PAX header with only `linkpath` (no `path` key) followed by a USTAR entry with prefix/name split. Both tests verify the entry name is correctly reconstructed with the prefix.

All 6420 System.Formats.Tar tests pass.

Fixes #125332