### PR TITLE
[Tests][UserEvents] Fix tracee discovery race and improve failure diagnostics

### DIFF
--- a/src/tests/tracing/userevents/Directory.Build.props
+++ b/src/tests/tracing/userevents/Directory.Build.props
@@ -4,5 +4,8 @@
 
   <PropertyGroup>
     <CLRTestTargetUnsupported Condition="'$(RuntimeFlavor)' == 'Mono'">true</CLRTestTargetUnsupported>
+    <GCStressIncompatible>true</GCStressIncompatible>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+    <UnloadabilityIncompatible>true</UnloadabilityIncompatible>
   </PropertyGroup>
 </Project>

--- a/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
+++ b/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
@@ -17,10 +17,7 @@ namespace Tracing.UserEvents.Tests.Common
     public class UserEventsTestRunner
     {
         private const int SIGINT = 2;
-
-        // The tracee must JIT compile, receive IPC enable, and emit events before exiting.
-        // Under JitStress on ARM64, this can take significantly longer than normal.
-        private const int DefaultTraceeExitTimeoutMs = 60000;
+        private const int DefaultTraceeExitTimeoutMs = 5000;
         private const int DefaultRecordTraceExitTimeoutMs = 20000;
 
         // Timeout for record-trace to emit "Recording started" on stdout. record-trace's

--- a/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
+++ b/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
@@ -142,6 +142,17 @@ namespace Tracing.UserEvents.Tests.Common
             recordTraceStartInfo.ArgumentList.Add(traceFilePath);
             recordTraceStartInfo.ArgumentList.Add("--log-path");
             recordTraceStartInfo.ArgumentList.Add(recordTraceLogPath);
+            recordTraceStartInfo.ArgumentList.Add("--log-filter");
+            recordTraceStartInfo.ArgumentList.Add(
+                "one_collect::helpers::dotnet=debug," +
+                "one_collect::perf_event=debug," +
+                "one_collect::perf_event::rb=info," +
+                "one_collect::helpers::exporting::formats::nettrace=debug," +
+                "one_collect::helpers::exporting::os=warn," +
+                "ruwind=warn," +
+                "one_collect::tracefs=warn," +
+                "one_collect::scripting=warn," +
+                "engine=warn");
             recordTraceStartInfo.WorkingDirectory = userEventsScenarioDir;
             recordTraceStartInfo.UseShellExecute = false;
             recordTraceStartInfo.RedirectStandardOutput = true;
@@ -284,6 +295,7 @@ namespace Tracing.UserEvents.Tests.Common
             if (!traceValidator(traceePid, source))
             {
                 Console.Error.WriteLine($"Trace file `{traceFilePath}` does not contain expected events.");
+                DumpTraceeEvents(traceFilePath, traceePid);
                 UploadArtifactsFromHelixOnFailure(scenarioName, traceFilePath, recordTraceLogPath);
                 return -1;
             }
@@ -397,6 +409,38 @@ namespace Tracing.UserEvents.Tests.Common
                 string destPath = Path.Combine(helixWorkItemDirectory, $"{scenarioName}{extension}");
                 Console.WriteLine($"Uploading artifact to Helix work item directory: {destPath}");
                 File.Copy(filePath, destPath, overwrite: true);
+            }
+        }
+
+        private static void DumpTraceeEvents(string traceFilePath, int traceePid)
+        {
+            try
+            {
+                using EventPipeEventSource diagSource = new EventPipeEventSource(traceFilePath);
+                int traceeEventCount = 0;
+                var eventSummary = new Dictionary<string, int>();
+
+                diagSource.Dynamic.All += (TraceEvent e) =>
+                {
+                    if (e.ProcessID != traceePid)
+                        return;
+
+                    traceeEventCount++;
+                    string key = $"{e.ProviderName}/{e.EventName}";
+                    eventSummary[key] = eventSummary.GetValueOrDefault(key) + 1;
+                };
+
+                diagSource.Process();
+
+                Console.Error.WriteLine($"Tracee PID {traceePid} had {traceeEventCount} event(s) in the trace:");
+                foreach (var (key, count) in eventSummary)
+                {
+                    Console.Error.WriteLine($"  {key}: {count}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Failed to dump tracee events: {ex}");
             }
         }
     }

--- a/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
+++ b/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
@@ -23,16 +23,18 @@ namespace Tracing.UserEvents.Tests.Common
         private const int DefaultTraceeExitTimeoutMs = 60000;
         private const int DefaultRecordTraceExitTimeoutMs = 20000;
 
-        // Delay before starting the tracee to let record-trace finish setup. The
-        // tracee's ManualResetEventSlim gates on tracepoint registration via IPC, but
-        // that alone is not sufficient as record-trace's ring buffers must also be active
-        // (PerfSession::enable) to capture events. Without this delay, the tracee may be
-        // discovered during record-trace's /proc scan and receive IPC before enable,
-        // causing events to be lost. With the delay, the tracee is instead discovered
-        // via MMAP2 records after PerfSession is enabled.
-        // record-trace startup -> PerfSession::enable scales with system process count:
-        // averaged 113ms at 126 processes and 253ms at 534 processes on a 2-core system.
-        private const int RecordTraceSetupDelayMs = 300;
+        // Timeout for record-trace to emit "Recording started" on stdout. record-trace's
+        // startup has two phases: a /proc scan for existing processes, then enabling ring
+        // buffers to capture live mmap events. If the tracee starts during the /proc scan,
+        // record-trace may discover it and send IPC before ring buffers are active, causing
+        // emitted events to be lost. If the tracee starts after the /proc scan but before
+        // ring buffers are enabled, its mmap events are missed entirely and record-trace
+        // never discovers it. By gating on "Recording started" (printed after enable), the
+        // tracee is only discovered via live mmap events with ring buffers already active.
+        // record-trace startup -> enable scales with system process count: averaged 113ms at
+        // 126 processes and 253ms at 534 processes on a 2-core x64 system, but took ~1845ms
+        // on a 2-core ARM64 CI machine.
+        private const int RecordTraceSetupTimeoutMs = 10000;
 
         [DllImport("libc", EntryPoint = "kill", SetLastError = true)]
         private static extern int Kill(int pid, int sig);
@@ -147,11 +149,16 @@ namespace Tracing.UserEvents.Tests.Common
 
             Console.WriteLine($"Starting record-trace: {recordTraceStartInfo.FileName} {string.Join(" ", recordTraceStartInfo.ArgumentList)}");
             using Process recordTraceProcess = Process.Start(recordTraceStartInfo);
+            using var recordingStarted = new ManualResetEventSlim(false);
             recordTraceProcess.OutputDataReceived += (_, args) =>
             {
                 if (!string.IsNullOrEmpty(args.Data))
                 {
                     Console.WriteLine($"[record-trace][stdout] {args.Data}");
+                    if (args.Data.Contains("Recording started", StringComparison.Ordinal))
+                    {
+                        recordingStarted.Set();
+                    }
                 }
             };
             recordTraceProcess.BeginOutputReadLine();
@@ -197,9 +204,25 @@ namespace Tracing.UserEvents.Tests.Common
             // When https://github.com/microsoft/one-collect/issues/183 is fixed, this and the above TMPDIR should be removed.
             EnsureCleanDiagnosticPorts(diagnosticPortDir);
 
-            // Allow record-trace to finish setup before starting the tracee.
-            Console.WriteLine($"Delaying tracee startup {RecordTraceSetupDelayMs}ms for record-trace setup...");
-            Thread.Sleep(RecordTraceSetupDelayMs);
+            // Wait for record-trace to finish setup (capture_environment + enable ring buffers).
+            // "Recording started" is printed after session.enable() succeeds, which means
+            // the ring buffers are active and will capture the tracee's mmap events.
+            Console.WriteLine("Waiting for record-trace to signal 'Recording started'...");
+            if (!recordingStarted.Wait(RecordTraceSetupTimeoutMs))
+            {
+                if (recordTraceProcess.HasExited)
+                {
+                    Console.Error.WriteLine($"record-trace exited prematurely with code {recordTraceProcess.ExitCode}.");
+                }
+                else
+                {
+                    Console.Error.WriteLine($"record-trace did not emit 'Recording started' within {RecordTraceSetupTimeoutMs}ms.");
+                    recordTraceProcess.Kill();
+                }
+
+                UploadArtifactsFromHelixOnFailure(scenarioName, recordTraceLogPath);
+                return -1;
+            }
 
             Console.WriteLine($"Starting tracee process: {traceeStartInfo.FileName} {string.Join(" ", traceeStartInfo.ArgumentList)}");
             using Process traceeProcess = Process.Start(traceeStartInfo);

--- a/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
+++ b/src/tests/tracing/userevents/common/UserEventsTestRunner.cs
@@ -17,6 +17,9 @@ namespace Tracing.UserEvents.Tests.Common
     public class UserEventsTestRunner
     {
         private const int SIGINT = 2;
+
+        // The tracee must JIT compile, receive IPC enable, and emit events before exiting.
+        // Under JitStress on ARM64, this can take significantly longer than normal.
         private const int DefaultTraceeExitTimeoutMs = 60000;
         private const int DefaultRecordTraceExitTimeoutMs = 20000;
 
@@ -65,6 +68,7 @@ namespace Tracing.UserEvents.Tests.Common
                 Console.WriteLine("Tracee EventSource enabled, emitting events.");
 
                 traceeAction();
+                Console.WriteLine("Tracee finished emitting events.");
                 return 0;
             }
 
@@ -225,6 +229,7 @@ namespace Tracing.UserEvents.Tests.Common
                 traceeProcess.Kill();
             }
             traceeProcess.WaitForExit(); // flush async output
+            Console.WriteLine($"Tracee process exited with code {traceeProcess.ExitCode}.");
 
             if (!recordTraceProcess.HasExited)
             {


### PR DESCRIPTION
https://github.com/dotnet/runtime/issues/123442

More diagnostics and better tracee timing in response to the failures described in https://github.com/dotnet/runtime/issues/123442#issuecomment-4025436022

Wait for "Recording started" instead of fixed delay. The 300ms fixed sleep before launching the tracee was insufficient on ARM64 CI where record-trace's startup (proc scan + ring buffer setup) took ~1845ms. I believe the tracee would start in the dead zone between the proc scan and ring buffer enable, so record-trace never discovered it via mmap events. Replace the sleep with a ManualResetEventSlim that gates on record-trace's "Recording started" stdout message, which is printed after PerfSession::enable succeeds.

Improve failure diagnostics
   - Add --log-filter to capture debug-level record-trace diagnostics (mmap discovery, IPC enablement, nettrace event flushing) while suppressing noisy modules. The log is written to a file and uploaded to Helix only on failure.
   - Add DumpTraceeEvents to log a summary of all events from the tracee PID in the nettrace on validation failure, to distinguish "event not captured" from "event captured with unexpected metadata."
   - Add tracee-side console messages confirming event emission completed, and log the tracee exit code.
