### PR TITLE
Use ValueAsnReader in more places where it is easy to do so

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAppleCrypto.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAppleCrypto.cs
@@ -99,8 +99,8 @@ namespace System.Security.Cryptography
                         // is used.
                         RSAParameters key;
 
-                        AsnReader reader = new AsnReader(keyBlob, AsnEncodingRules.BER);
-                        AsnReader sequenceReader = reader.ReadSequence();
+                        ValueAsnReader reader = new(keyBlob, AsnEncodingRules.BER);
+                        ValueAsnReader sequenceReader = reader.ReadSequence();
 
                         if (sequenceReader.PeekTag().Equals(Asn1Tag.Integer))
                         {

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAAppleCrypto.macOS.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAAppleCrypto.macOS.cs
@@ -39,8 +39,8 @@ namespace System.Security.Cryptography
                         // is used.
                         RSAParameters key;
 
-                        AsnReader reader = new AsnReader(keyBlob, AsnEncodingRules.BER);
-                        AsnReader sequenceReader = reader.ReadSequence();
+                        ValueAsnReader reader = new(keyBlob, AsnEncodingRules.BER);
+                        ValueAsnReader sequenceReader = reader.ReadSequence();
 
                         if (sequenceReader.PeekTag().Equals(Asn1Tag.Integer))
                         {

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.cs
@@ -122,7 +122,7 @@ namespace Internal.Cryptography.Pal.AnyOS
 
                 try
                 {
-                    AsnReader reader = new AsnReader(contentEncryptionAlgorithm.Parameters.Value, AsnEncodingRules.BER);
+                    ValueAsnReader reader = new(contentEncryptionAlgorithm.Parameters.Value.Span, AsnEncodingRules.BER);
                     alg.IV = reader.ReadOctetString();
 
                     if (alg.IV.Length != alg.BlockSize / 8)

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSignature.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSignature.cs
@@ -178,8 +178,8 @@ namespace System.Security.Cryptography.Pkcs
 
             try
             {
-                AsnReader reader = new AsnReader(derSignature, AsnEncodingRules.DER);
-                AsnReader sequence = reader.ReadSequence();
+                ValueAsnReader reader = new(derSignature.Span, AsnEncodingRules.DER);
+                ValueAsnReader sequence = reader.ReadSequence();
 
                 if (reader.HasData)
                 {
@@ -191,7 +191,7 @@ namespace System.Security.Cryptography.Pkcs
                 // partial-fill gymnastics.
                 ieeeSignature.Clear();
 
-                ReadOnlySpan<byte> val = sequence.ReadIntegerBytes().Span;
+                ReadOnlySpan<byte> val = sequence.ReadIntegerBytes();
 
                 if (val.Length > fieldSize && val[0] == 0)
                 {
@@ -203,7 +203,7 @@ namespace System.Security.Cryptography.Pkcs
                     val.CopyTo(ieeeSignature.Slice(fieldSize - val.Length, val.Length));
                 }
 
-                val = sequence.ReadIntegerBytes().Span;
+                val = sequence.ReadIntegerBytes();
 
                 if (val.Length > fieldSize && val[0] == 0)
                 {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/EccKeyFormatHelper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/EccKeyFormatHelper.cs
@@ -313,8 +313,8 @@ namespace System.Security.Cryptography
             {
                 case Oids.EcPrimeField:
                     prime = true;
-                    AsnReader primeReader = new AsnReader(specifiedParameters.FieldID.Parameters, AsnEncodingRules.BER);
-                    ReadOnlySpan<byte> primeValue = primeReader.ReadIntegerBytes().Span;
+                    ValueAsnReader primeReader = new(specifiedParameters.FieldID.Parameters.Span, AsnEncodingRules.BER);
+                    ReadOnlySpan<byte> primeValue = primeReader.ReadIntegerBytes();
                     primeReader.ThrowIfNotEmpty();
 
                     if (primeValue[0] == 0)
@@ -331,8 +331,8 @@ namespace System.Security.Cryptography
                     break;
                 case Oids.EcChar2Field:
                     prime = false;
-                    AsnReader char2Reader = new AsnReader(specifiedParameters.FieldID.Parameters, AsnEncodingRules.BER);
-                    AsnReader innerReader = char2Reader.ReadSequence();
+                    ValueAsnReader char2Reader = new(specifiedParameters.FieldID.Parameters.Span, AsnEncodingRules.BER);
+                    ValueAsnReader innerReader = char2Reader.ReadSequence();
                     char2Reader.ThrowIfNotEmpty();
 
                     // Characteristic-two ::= SEQUENCE
@@ -368,7 +368,7 @@ namespace System.Security.Cryptography
                             //     k2 INTEGER, -- k2 > k1
                             //     k3 INTEGER -- k3 > k2
                             // }
-                            AsnReader pentanomialReader = innerReader.ReadSequence();
+                            ValueAsnReader pentanomialReader = innerReader.ReadSequence();
 
                             if (!pentanomialReader.TryReadInt32(out k1) ||
                                 !pentanomialReader.TryReadInt32(out k2) ||

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ManagedCertificateFinder.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/ManagedCertificateFinder.cs
@@ -160,7 +160,7 @@ namespace System.Security.Cryptography.X509Certificates
                         try
                         {
                             // Try a V1 template structure, just a string:
-                            AsnReader reader = new AsnReader(ext.RawData, AsnEncodingRules.DER);
+                            ValueAsnReader reader = new(ext.RawData, AsnEncodingRules.DER);
                             decodedName = reader.ReadAnyAsnString();
                             reader.ThrowIfNotEmpty();
                         }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509EnhancedKeyUsageExtension.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509EnhancedKeyUsageExtension.cs
@@ -87,8 +87,8 @@ namespace System.Security.Cryptography.X509Certificates
 
             try
             {
-                AsnReader reader = new AsnReader(encoded, AsnEncodingRules.BER);
-                AsnReader sequenceReader = reader.ReadSequence();
+                ValueAsnReader reader = new(encoded, AsnEncodingRules.BER);
+                ValueAsnReader sequenceReader = reader.ReadSequence();
                 reader.ThrowIfNotEmpty();
                 usages = new OidCollection();
 


### PR DESCRIPTION
We could drop in ValueAsnReader in a few places where AsnReader was being used, so let's get rid of those allocations.

I am trying to spanify the XML / XSLT loader next.