### PR TITLE
Fix fatal sched_setaffinity EPERM failure during PAL initialization on restricted kernels

### DIFF
--- a/src/coreclr/pal/src/thread/thread.cpp
+++ b/src/coreclr/pal/src/thread/thread.cpp
@@ -1410,10 +1410,21 @@ CPalThread::ThreadEntry(
     st = sched_setaffinity(0, sizeof(cpu_set_t), &cpuSet);
     if (st != 0)
     {
-        ASSERT("sched_setaffinity failed!\n");
-        // The sched_setaffinity should never fail when passed the mask extracted using sched_getaffinity
-        palError = ERROR_INTERNAL_ERROR;
-        goto fail;
+        if (errno == EPERM || errno == EACCES)
+        {
+            // Some sandboxed or restricted environments (snap strict confinement,
+            // vendor-modified Android kernels with strict SELinux policy) block
+            // sched_setaffinity even when passed a mask extracted via sched_getaffinity.
+            // Treat this as non-fatal — the thread will continue running on any
+            // available CPU rather than the originally affinitized one. 
+            WARN("sched_setaffinity failed with EPERM/EACCES, ignoring\n");
+        }
+        else
+        {
+            ASSERT("sched_setaffinity failed!\n");
+            palError = ERROR_INTERNAL_ERROR;
+            goto fail;
+        }
     }
 #endif // HAVE_SCHED_GETAFFINITY && HAVE_SCHED_SETAFFINITY
 


### PR DESCRIPTION
**Problem**

On Android devices running vendor-modified kernel 5.10 with strict SELinux policy, `coreclr_initialize` silently fails with `HRESULT 0x8007054F` (`ERROR_INTERNAL_ERROR`). No diagnostic output is produced, making this extremely difficult to debug. The failure affects a broad category of devices from multiple OEMs shipping Android 13 on kernel 5.10 GKI bases.

**Root Cause**

During PAL thread initialization in `thread.cpp`, the runtime calls `sched_getaffinity` to retrieve the current thread's CPU affinity mask, then immediately calls `sched_setaffinity(0, ...)` to re-apply it. On these kernels, `sched_setaffinity` returns `EPERM` even when passed a mask that was just obtained from `sched_getaffinity` on the same thread. The existing error handling unconditionally treats any failure as fatal:

```cpp
st = sched_setaffinity(0, sizeof(cpu_set_t), &cpuSet);
if (st != 0)
{
    ASSERT("sched_setaffinity failed!\n");
    palError = ERROR_INTERNAL_ERROR;
    goto fail;
}
```

This aborts PAL initialization entirely, returning `ERROR_INTERNAL_ERROR` to the caller with no further diagnostics.

**Fix**

Treat `EPERM` and `EACCES` from `sched_setaffinity` as non-fatal, logging a warning and continuing. The thread will run on any available CPU rather than the originally affinitized one, which is acceptable behavior in restricted environments. Any other error code still triggers the existing assert and hard failure.

This is consistent with the snap confinement workarounds already documented and applied in the same file and in `gcenv.unix.cpp`, which handle similar `sched_setaffinity` restrictions under snap's default strict confinement. This PR extends that handling to cover additional restricted environments.

**Testing**

Verified on an Android 13 device with a vendor-modified kernel 5.10, where `coreclr_initialize` previously failed with `0x8007054F`. After this fix, initialization succeeds. Devices running kernel 6.1 (Android 14) are unaffected.

**References**

- Related snap issue: https://github.com/dotnet/runtime/issues/1634