### PR TITLE
Exclude noisy crypto rules from the repo's CodeQL runs

### DIFF
--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -35,7 +35,7 @@ queries:
   # Don't warn about usage of non-compliant crypto within our own implementations or interop code,
   # since the rule would noisily try to warn us about *ourselves*. These exclusions are scoped
   # to just the crypto code itself. We still want alerts when consumers of crypto (even within this
-  # repo) still try to use non-compliant primitives; those call sites must be manually inspected
+  # repo) try to use non-compliant primitives; those call sites must be manually inspected
   # and suppressed if appropriate.
   #
   - exclude:
@@ -52,7 +52,6 @@ queries:
         - "src/libraries/Common/src/Interop/Windows/BCrypt/**"
         - "src/libraries/Common/src/System/Security/Cryptography/**"
         - "src/libraries/Microsoft.Bcl.Cryptography/**"
-        - "src/libraries/System.Security.Cryptography.Pkcs/**"
-        - "src/libraries/System.Security.Cryptography.Xml/**"
         - "src/libraries/System.Security.Cryptography/**"
+        - "src/libraries/System.Security.Cryptography.*/**"
         - "src/native/libs/System.Security.Cryptography.*/**"

--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -31,3 +31,25 @@ queries:
         # APIs. Those call sites are well-reviewed and don't benefit from extra alerts regarding
         # the possibility of loading malicious code.
         - "cs/deserialization-unexpected-subtypes"
+  #
+  # We don't want to warn about usage of dangerous crypto within our own crypto implementations or
+  # interop code, since the rule would noisily try to warn us about *ourselves*.
+  #
+  - exclude:
+      queryid:
+        - "cs/ecb-encryption"
+        - "cs/encryption-with-vulnerable-cipher-mode"
+        - "cs/weak-symmetric-algorithm"
+        - "cs/obsolete-password-key-derivation"
+        - "cs/cryptography/unapproved-usage-of-dsa"
+        - "cs/weak-crypto"
+        - "cs/weak-hmacs"
+        - "java/weak-crypto-algorithm-or-hash"
+      path:
+        - "src/libraries/Common/src/Interop/Windows/BCrypt/**"
+        - "src/libraries/Common/src/System/Security/Cryptography/**"
+        - "src/libraries/Microsoft.Bcl.Cryptography/**"
+        - "src/libraries/System.Security.Cryptography.Pkcs/**"
+        - "src/libraries/System.Security.Cryptography.Xml/**"
+        - "src/libraries/System.Security.Cryptography/**"
+        - "src/native/libs/System.Security.Cryptography.*/**"

--- a/.CodeQL.yml
+++ b/.CodeQL.yml
@@ -32,8 +32,11 @@ queries:
         # the possibility of loading malicious code.
         - "cs/deserialization-unexpected-subtypes"
   #
-  # We don't want to warn about usage of dangerous crypto within our own crypto implementations or
-  # interop code, since the rule would noisily try to warn us about *ourselves*.
+  # Don't warn about usage of non-compliant crypto within our own implementations or interop code,
+  # since the rule would noisily try to warn us about *ourselves*. These exclusions are scoped
+  # to just the crypto code itself. We still want alerts when consumers of crypto (even within this
+  # repo) still try to use non-compliant primitives; those call sites must be manually inspected
+  # and suppressed if appropriate.
   #
   - exclude:
       queryid:


### PR DESCRIPTION
We don't want crypto-related CodeQL rules running _over the crypto code itself._ Those rules are meant for consumers of crypto and are not appropriate to run over crypto implementations or interop code. We scope the exclusions so that crypto consumers still receive alerts.