### PR TITLE
[wasm][coreclr] Fix vtable issue and interpreter I4/I8 arithmetic

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -3096,7 +3096,6 @@ void InterpCompiler::EmitBinaryArithmeticOp(int32_t opBase)
     }
     else
     {
-#if TARGET_64BIT
         if (type1 == StackTypeI8 && type2 == StackTypeI4)
         {
             EmitConv(m_pStackPointer - 1, StackTypeI8, InterpOpForWideningArgForImplicitUpcast((InterpOpcode)opBase));
@@ -3107,7 +3106,6 @@ void InterpCompiler::EmitBinaryArithmeticOp(int32_t opBase)
             EmitConv(m_pStackPointer - 2, StackTypeI8, InterpOpForWideningArgForImplicitUpcast((InterpOpcode)opBase));
             type1 = StackTypeI8;
         }
-#endif
         if (type1 == StackTypeR8 && type2 == StackTypeR4)
         {
             EmitConv(m_pStackPointer - 1, StackTypeR8, INTOP_CONV_R8_R4);

--- a/src/coreclr/vm/prestub.cpp
+++ b/src/coreclr/vm/prestub.cpp
@@ -2389,6 +2389,11 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT, CallerGCMode callerGCMo
         void* ilStubInterpData = PortableEntryPoint::GetInterpreterData(pCode);
         _ASSERTE(ilStubInterpData != NULL);
         SetInterpreterCode((InterpByteCodeStart*)ilStubInterpData);
+
+        // Use this method's own PortableEntryPoint rather than the stub's.
+        // It is required to maintain 1:1 mapping between MethodDesc and its entrypoint.
+        pCode = GetPortableEntryPoint();
+        PortableEntryPoint::SetInterpreterData(pCode, (PCODE)(TADDR)ilStubInterpData);
         SetCodeEntryPoint(pCode);
 #else // !FEATURE_PORTABLE_ENTRYPOINTS
         if (!GetOrCreatePrecode()->SetTargetInterlocked(pStub->GetEntryPoint()))

--- a/src/tests/JIT/Methodical/Boxing/morph/sin3double.il
+++ b/src/tests/JIT/Methodical/Boxing/morph/sin3double.il
@@ -14,7 +14,6 @@
 }
 .assembly extern xunit.core {}
 .assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
-.assembly extern TestLibrary { .ver 0:0:0:0 }
 
 .namespace Test_sin3double {
 .class private sequential ansi sealed beforefieldinit VV extends [mscorlib]System.ValueType
@@ -204,11 +203,6 @@
       01 00 00 00
   )
   .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ActiveIssueAttribute::.ctor(string, valuetype [Microsoft.DotNet.XUnitExtensions]Xunit.TestRuntimes) = {string('https://github.com/dotnet/runtime/issues/34196') int32(2)}
-  .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ActiveIssueAttribute::.ctor(string, class [mscorlib]System.Type, string[]) = {
-      string('https://github.com/dotnet/runtime/issues/124222')
-      type([TestLibrary]TestLibrary.PlatformDetection)
-      string[1] ('IsWasm')
-  }
   .entrypoint
   .locals (int32 V_0,
            float64 V_1,

--- a/src/tests/JIT/Methodical/flowgraph/bug619534/moduleHandleCache.cs
+++ b/src/tests/JIT/Methodical/flowgraph/bug619534/moduleHandleCache.cs
@@ -23,7 +23,6 @@ System.BadImageFormatException: [C:\tests\Dev10\640711\Lib1.dll] Bad string toke
 
 using System;
 using System.Runtime.CompilerServices;
-using TestLibrary;
 using Xunit;
 
 namespace Test_moduleHandleCache_cs
@@ -42,7 +41,6 @@ public static class Repro
     }
 
     [Fact]
-    [ActiveIssue("https://github.com/dotnet/runtime/issues/124222", typeof(PlatformDetection), nameof(PlatformDetection.IsWasm))]
     public static void TestEntryPoint()
     {
         try

--- a/src/tests/JIT/Methodical/switch/switch6.il
+++ b/src/tests/JIT/Methodical/switch/switch6.il
@@ -6,8 +6,6 @@
 .assembly extern System.Runtime.Extensions { auto }
 .assembly extern legacy library mscorlib { auto }
 .assembly extern System.Console { auto }
-.assembly extern Microsoft.DotNet.XUnitExtensions { .publickeytoken = (31 BF 38 56 AD 36 4E 35 ) }
-.assembly extern TestLibrary { .ver 0:0:0:0 }
 
 .assembly 'switch6'
 {
@@ -89,11 +87,6 @@
     .custom instance void [xunit.core]Xunit.FactAttribute::.ctor() = (
         01 00 00 00
     )
-    .custom instance void [Microsoft.DotNet.XUnitExtensions]Xunit.ActiveIssueAttribute::.ctor(string, class [mscorlib]System.Type, string[]) = {
-        string('https://github.com/dotnet/runtime/issues/124222')
-        type([TestLibrary]TestLibrary.PlatformDetection)
-        string[1] ('IsWasm')
-    }
     .entrypoint
     .maxstack  8
     IL_0000:  ldc.i4.1


### PR DESCRIPTION
Fix #124222, there were 2 problems:

1. prestub.cpp: When a stub-based method (delegate invoke, array ops) is prestubbed, use the method's own PortableEntryPoint rather than the stub's. This maintains the 1:1 MethodDesc-to-entrypoint mapping that GetMethodDescForSlot_NoThrow relies on, similar to previous FCall fix.

2. interpreter/compiler.cpp: Enable I4/I8 mixed arithmetic widening on 32-bit targets by removing the TARGET_64BIT guard. On 32-bit WASM, ldloca results are bashed to StackTypeI (= I4), but IL like sin3double uses conv.i8 before arithmetic, producing I4 + I8 which was rejected as invalid. The widening to I8 already existed for 64-bit; now it applies unconditionally.