### PR TITLE
JIT: Fix patchpoint info out-of-bounds read for special OSR locals

### DIFF
--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -4138,7 +4138,7 @@ void CodeGen::genEnregisterOSRArgsAndLocals()
         //
         const var_types lclTyp  = varDsc->GetStackSlotHomeType();
         const emitAttr  size    = emitActualTypeSize(lclTyp);
-        const int       stkOffs = patchpointInfo->Offset(lclNum) + fieldOffset;
+        const int       stkOffs = m_compiler->lvaOSRLocalTier0FrameOffset(lclNum) + fieldOffset;
 
 #if defined(TARGET_AMD64)
 

--- a/src/coreclr/jit/compiler.cpp
+++ b/src/coreclr/jit/compiler.cpp
@@ -10437,7 +10437,7 @@ bool Compiler::killGCRefs(GenTree* tree)
 // Return Value:
 //    true       - this is an OSR compile and this local requires special treatment
 //    false      - not an OSR compile, or not an interesting local for OSR
-
+//
 bool Compiler::lvaIsOSRLocal(unsigned varNum)
 {
     LclVarDsc* const varDsc = lvaGetDesc(varNum);
@@ -10464,6 +10464,37 @@ bool Compiler::lvaIsOSRLocal(unsigned varNum)
 #endif
 
     return varDsc->lvIsOSRLocal;
+}
+
+//------------------------------------------------------------------------
+// lvaOSRLocalTier0FrameOffset:
+//   Get the offset in the tier0 frame for a specified OSR local.
+//
+// Arguments:
+//   varNum - variable of interest
+//
+// Return Value:
+//   The offset into the tier 0 frame.
+//
+int Compiler::lvaOSRLocalTier0FrameOffset(unsigned varNum)
+{
+    assert(lvaIsOSRLocal(varNum));
+
+    if (varNum == lvaMonAcquired)
+    {
+        return info.compPatchpointInfo->MonitorAcquiredOffset();
+    }
+    if (varNum == lvaAsyncExecutionContextVar)
+    {
+        return info.compPatchpointInfo->AsyncExecutionContextOffset();
+    }
+    if (varNum == lvaAsyncSynchronizationContextVar)
+    {
+        return info.compPatchpointInfo->AsyncSynchronizationContextOffset();
+    }
+
+    assert(varNum < info.compPatchpointInfo->NumberOfLocals());
+    return info.compPatchpointInfo->Offset(varNum);
 }
 
 //------------------------------------------------------------------------------

--- a/src/coreclr/jit/compiler.h
+++ b/src/coreclr/jit/compiler.h
@@ -4120,6 +4120,8 @@ public:
     // located on the original method stack frame.
     bool lvaIsOSRLocal(unsigned varNum);
 
+    int lvaOSRLocalTier0FrameOffset(unsigned varNum);
+
     //------------------------ For splitting types ----------------------------
 
     void lvaInitTypeRef();

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -5132,7 +5132,7 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
                 if (varDsc->lvIsStructField)
                 {
                     const unsigned parentLclNum         = varDsc->lvParentLcl;
-                    const int      parentOriginalOffset = info.compPatchpointInfo->Offset(parentLclNum);
+                    const int      parentOriginalOffset = lvaOSRLocalTier0FrameOffset(parentLclNum);
                     const int      offset = originalFrameStkOffs + parentOriginalOffset + varDsc->lvFldOffset;
 
                     JITDUMP("---OSR--- V%02u (promoted field of V%02u; on tier0 frame) tier0 FP-rel offset %d tier0 "
@@ -5147,24 +5147,7 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
                 {
                     // Add frampointer-relative offset of this OSR live local in the original frame
                     // to the offset of original frame in our new frame.
-                    int originalOffset;
-                    if (lclNum == lvaMonAcquired)
-                    {
-                        originalOffset = info.compPatchpointInfo->MonitorAcquiredOffset();
-                    }
-                    else if (lclNum == lvaAsyncExecutionContextVar)
-                    {
-                        originalOffset = info.compPatchpointInfo->AsyncExecutionContextOffset();
-                    }
-                    else if (lclNum == lvaAsyncSynchronizationContextVar)
-                    {
-                        originalOffset = info.compPatchpointInfo->AsyncSynchronizationContextOffset();
-                    }
-                    else
-                    {
-                        assert(lclNum < info.compPatchpointInfo->NumberOfLocals());
-                        originalOffset = info.compPatchpointInfo->Offset(lclNum);
-                    }
+                    int originalOffset = lvaOSRLocalTier0FrameOffset(lclNum);
                     const int offset = originalFrameStkOffs + originalOffset;
 
                     JITDUMP(

--- a/src/coreclr/jit/lclvars.cpp
+++ b/src/coreclr/jit/lclvars.cpp
@@ -5147,8 +5147,8 @@ void Compiler::lvaAssignVirtualFrameOffsetsToLocals()
                 {
                     // Add frampointer-relative offset of this OSR live local in the original frame
                     // to the offset of original frame in our new frame.
-                    int originalOffset = lvaOSRLocalTier0FrameOffset(lclNum);
-                    const int offset = originalFrameStkOffs + originalOffset;
+                    int       originalOffset = lvaOSRLocalTier0FrameOffset(lclNum);
+                    const int offset         = originalFrameStkOffs + originalOffset;
 
                     JITDUMP(
                         "---OSR--- V%02u (on tier0 frame) tier0 FP-rel offset %d tier0 frame offset %d new virt offset "


### PR DESCRIPTION
`genEnregisterOSRArgsAndLocals` was not properly handling computing the stack offset for special OSR locals like `MonitorAcquired` and the async contexts. It meant that if these ended up enregistered we would hit an out-of-bounds when trying to obtain their offset.

Fix #125255

This was a regression introduced by #121672 which started marking these 3 locals as OSR locals. Before that we only had `MonitorAcquired`, and I suspect that one was never enregistered, so even though it was not handled by `genEnregisterOSRArgsAndLocals` that was never a problem. However, the async contexts can be enregistered in the OSR function so they do need to be handled here.