### PR TITLE
Run CI for all copilot/*.* PRs

### DIFF
--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -35,6 +35,7 @@ pr:
     include:
     - main
     - release/*.*
+    - copilot/*.*
   paths:
     include:
     - '*'

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -35,7 +35,7 @@ pr:
     include:
     - main
     - release/*.*
-    - copilot/*.*
+    - copilot/*
   paths:
     include:
     - '*'


### PR DESCRIPTION
I’ve been using GH Copilot over the last few months and I believe that it’s very important to divide large work items into smaller ones. It makes the Agent more likely to succeed and the code is easier to review for the humans.

But when I do the divide and conquer, I end up having a lot of small PRs that depend on each other. Typically the first PR targets main, and other PRs target the previous PR branch.

The problem is that our CI is configured to only run on PRs that target main or release branches, so the dependent PRs don’t get CI runs until the previous PR is merged (or I modify the `eng/pipelines/runtime.yml` file).

It would boost my productivity if I could get CI runs on all copilot PRs, even the ones that target other copilot branches.
I would get feedback on whether the code compiles and works correctly before moving to next task and before asking others for review.