### PR TITLE
Fix race condition leak in RegisterResumptionStub

### DIFF
--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -384,7 +384,7 @@ PTR_MethodDesc ReadyToRunInfo::GetMethodDescForEntryPointInNativeImage(PCODE ent
 
 #ifndef DACCESS_COMPILE
 
-void ReadyToRunInfo::SetMethodDescForEntryPointInNativeImage(PCODE entryPoint, MethodDesc *methodDesc)
+bool ReadyToRunInfo::SetMethodDescForEntryPointInNativeImage(PCODE entryPoint, MethodDesc *methodDesc)
 {
     CONTRACTL
     {
@@ -397,7 +397,9 @@ void ReadyToRunInfo::SetMethodDescForEntryPointInNativeImage(PCODE entryPoint, M
     if ((TADDR)m_entryPointToMethodDescMap.LookupValue(PCODEToPINSTR(entryPoint), (LPVOID)PCODEToPINSTR(entryPoint)) == (TADDR)INVALIDENTRY)
     {
         m_entryPointToMethodDescMap.InsertValue(PCODEToPINSTR(entryPoint), methodDesc);
+        return true;
     }
+    return false;
 }
 
 // A log file to record success/failure of R2R loads. s_r2rLogFile can have the following values:
@@ -1203,12 +1205,14 @@ void ReadyToRunInfo::RegisterResumptionStub(PCODE stubEntryPoint)
         sizeof(s_resumptionStubSig),
         &amTracker);
 
-    amTracker.SuppressRelease();
-
     // Register the stub's entry point so GC can find it during stack walks.
     // SetMethodDescForEntryPointInNativeImage handles the race - if another thread
-    // already registered a MethodDesc for this entry point, ours is simply discarded.
-    m_pCompositeInfo->SetMethodDescForEntryPointInNativeImage(stubEntryPoint, pStubMD);
+    // already registered a MethodDesc for this entry point, ours is simply discarded
+    // and the AllocMemTracker will back out the allocation on destruction.
+    if (m_pCompositeInfo->SetMethodDescForEntryPointInNativeImage(stubEntryPoint, pStubMD))
+    {
+        amTracker.SuppressRelease();
+    }
 }
 
 PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, PrepareCodeConfig* pConfig, BOOL fFixups)

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -1177,13 +1177,10 @@ void ReadyToRunInfo::RegisterResumptionStub(PCODE stubEntryPoint)
 {
     STANDARD_VM_CONTRACT;
 
-    // Use the entry point hashtable to check if another thread already registered a MethodDesc
-    if (m_pCompositeInfo->GetMethodDescForEntryPointInNativeImage(stubEntryPoint) != NULL)
-        return;
-
     AllocMemTracker amTracker;
-    ILStubCache *pStubCache = m_pModule->GetILStubCache();
+    ILStubCache* pStubCache = m_pModule->GetILStubCache();
     MethodTable* pStubMT = pStubCache->GetOrCreateStubMethodTable(m_pModule);
+    LoaderAllocator* pLoaderAllocator = m_pModule->GetLoaderAllocator();
 
     // Resumption stub signature: object(object, ref byte)
     // This matches BuildResumptionStubSignature in jitinterface.cpp
@@ -1196,8 +1193,12 @@ void ReadyToRunInfo::RegisterResumptionStub(PCODE stubEntryPoint)
         ELEMENT_TYPE_U1
     };
 
+    // Use the entry point hashtable to check if another thread already registered a MethodDesc
+    if (m_pCompositeInfo->GetMethodDescForEntryPointInNativeImage(stubEntryPoint) != NULL)
+        return;
+
     MethodDesc* pStubMD = pStubCache->CreateR2RBackedILStub(
-        m_pModule->GetLoaderAllocator(),
+        pLoaderAllocator,
         pStubMT,
         stubEntryPoint,
         DynamicMethodDesc::StubAsyncResume,

--- a/src/coreclr/vm/readytoruninfo.h
+++ b/src/coreclr/vm/readytoruninfo.h
@@ -339,7 +339,7 @@ private:
     BOOL CompareTypeNameOfTokens(mdToken mdToken1, IMDInternalImport * pImport1, ModuleBase *pModule1, mdToken mdToken2, IMDInternalImport * pImport2, ModuleBase *pModule2);
 
     PTR_MethodDesc GetMethodDescForEntryPointInNativeImage(PCODE entryPoint);
-    void SetMethodDescForEntryPointInNativeImage(PCODE entryPoint, PTR_MethodDesc methodDesc);
+    bool SetMethodDescForEntryPointInNativeImage(PCODE entryPoint, PTR_MethodDesc methodDesc);
 
     PTR_ReadyToRunCoreInfo GetComponentInfo() { return dac_cast<PTR_ReadyToRunCoreInfo>(&m_component); }
 


### PR DESCRIPTION
Move SuppressRelease() after SetMethodDescForEntryPointInNativeImage() and make it conditional on the insertion succeeding. Previously, if two threads raced past the initial check and both allocated a MethodDesc, the loser's allocation was leaked because SuppressRelease() was called unconditionally before the insert. Now the loser's AllocMemTracker will back out the allocation on destruction.

Changed SetMethodDescForEntryPointInNativeImage to return bool indicating whether the insertion occurred (true) or the entry already existed (false).