### PR TITLE
Fix TOCTOU race in AppDomain::LoadAssembly fast-path

### DIFF
--- a/src/coreclr/vm/appdomain.cpp
+++ b/src/coreclr/vm/appdomain.cpp
@@ -2537,15 +2537,15 @@ Assembly *AppDomain::LoadAssembly(FileLoadLock *pLock, FileLoadLevel targetLevel
     }
     CONTRACT_END;
 
-    Assembly *pAssembly = pLock->GetAssembly();
-
     // Make sure we release the lock on exit
     FileLoadLockRefHolder lockRef(pLock);
 
     // Do a quick out check for the already loaded case.
     if (pLock->GetLoadLevel() >= targetLevel)
     {
+        Assembly* pAssembly = pLock->GetAssembly();
         _ASSERTE(pAssembly != nullptr);
+
         pAssembly->ThrowIfError(targetLevel);
 
         RETURN pAssembly;
@@ -2616,7 +2616,7 @@ Assembly *AppDomain::LoadAssembly(FileLoadLock *pLock, FileLoadLevel targetLevel
              fileLoadLevelName[pLock->GetLoadLevel()]));
     }
 
-    pAssembly = pLock->GetAssembly();
+    Assembly* pAssembly = pLock->GetAssembly();
     _ASSERTE(pAssembly != nullptr); // We should always be loading to at least FILE_LOAD_ALLOCATE, so the assembly should be created
 
     // There may have been an error stored on the domain file by another thread, or from a previous load


### PR DESCRIPTION
PR #120515 deferred Assembly object creation to fix duplicate ICorProfiler callbacks, making `FileLoadLock::m_pAssembly` start as `nullptr` and get populated lazily by the winning thread. However, the fast-path in `AppDomain::LoadAssembly` was not updated to account for this mutability.

### The Bug

The fast-path cached `pAssembly = pLock->GetAssembly()` (reading `nullptr`) *before* checking `pLock->GetLoadLevel() >= targetLevel`. If another thread completed the load between these two reads, the level check would pass but the code would dereference the stale `nullptr`, causing an Access Violation (`0xC0000005`) inside `Assembly::ThrowIfError`.

This is a classic TOCTOU (Time-of-Check to Time-of-Use) race. It was reported as a rare fatal crash (< 1/100,000) under heavy CPU load when lazy-loaded assemblies (e.g., `System.Threading.ThreadPool`) are resolved concurrently on multiple threadpool threads.

### The Fix

Move the `GetAssembly()` read inside the fast-path `if` block, after confirming the load level is sufficient. This mirrors the pattern already used at the end of the slow path (line 2619), where `pAssembly` is re-read from the lock before use.