### PR TITLE
Update copilot-instructions with git confirmation and code-review skip rules

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,9 +8,9 @@ You MUST make your best effort to ensure any code changes satisfy those criteria
 
 If you make code changes, do not complete without checking the relevant code builds and relevant tests still pass after the last edits you make. Do not simply assume that your changes fix test failures you see, actually build and run those tests again to confirm.
 
-Always ask the user for confirmation before running `git commit --amend` or `git push`.
+When running under CCA and before completing, use the `code-review` skill to review your code changes. Any issues flagged as errors or warnings should be addressed before the task is considered complete.
 
-Before completing, use the `code-review` skill to review your code changes. Skip the `code-review` skill if the user has stated they will review the changes themselves. Any issues flagged as errors or warnings should be addressed before completing.
+When NOT running under CCA, skip the `code-review` skill if the user has stated they will review the changes themselves.
 
 Before making changes to a directory, search for `README.md` files in that directory and its parent directories up to the repository root. Read any you find — they contain conventions, patterns, and architectural context relevant to your work.
 
@@ -39,6 +39,13 @@ In addition to the rules enforced by `.editorconfig`, you SHOULD:
 - When writing tests, do not emit "Act", "Arrange" or "Assert" comments.
 - For markdown (`.md`) files, ensure there is no trailing whitespace at the end of any line.
 - When adding XML documentation to APIs, follow the guidelines at [`docs.prompt.md`](/.github/prompts/docs.prompt.md).
+
+When NOT running under CCA, guidance for creating commits and pushing changes:
+
+- Never squash and force push unless explicitly instructed. Always push incremental commits on top of previous PR changes.
+- Never push to an active PR without being explicitly asked, even in autopilot/yolo mode. Always wait for explicit instruction to push.
+- Never chain commit and push in the same command. Always commit first, report what was committed, then wait for an explicit push instruction. This creates a mandatory decision point.
+- Prefer creating a new commit rather than amending an existing one. Exceptions: (1) explicitly asked to amend, or (2) the existing commit is obviously broken with something minor (e.g., typo or comment fix) and hasn't been pushed yet.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ You MUST make your best effort to ensure any code changes satisfy those criteria
 
 If you make code changes, do not complete without checking the relevant code builds and relevant tests still pass after the last edits you make. Do not simply assume that your changes fix test failures you see, actually build and run those tests again to confirm.
 
-Always ask the user for confirmation before running git commit, git commit --amend, or git push.
+Always ask the user for confirmation before running git commit --amend or git push.
 
 Before completing, use the `code-review` skill to review your code changes. Skip the `code-review` skill if the user has stated they will review the changes themselves. Any issues flagged as errors or warnings should be addressed before completing.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ You MUST make your best effort to ensure any code changes satisfy those criteria
 
 If you make code changes, do not complete without checking the relevant code builds and relevant tests still pass after the last edits you make. Do not simply assume that your changes fix test failures you see, actually build and run those tests again to confirm.
 
-Always ask the user for confirmation before running git commit --amend or git push.
+Always ask the user for confirmation before running `git commit --amend` or `git push`.
 
 Before completing, use the `code-review` skill to review your code changes. Skip the `code-review` skill if the user has stated they will review the changes themselves. Any issues flagged as errors or warnings should be addressed before completing.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,9 @@ You MUST make your best effort to ensure any code changes satisfy those criteria
 
 If you make code changes, do not complete without checking the relevant code builds and relevant tests still pass after the last edits you make. Do not simply assume that your changes fix test failures you see, actually build and run those tests again to confirm.
 
-Before completing, use the `code-review` skill to review your code changes. Any issues flagged as errors or warnings should be addressed before completing.
+Always ask the user for confirmation before running git commit, git commit --amend, or git push.
+
+Before completing, use the `code-review` skill to review your code changes. Skip the `code-review` skill if the user has stated they will review the changes themselves. Any issues flagged as errors or warnings should be addressed before completing.
 
 Before making changes to a directory, search for `README.md` files in that directory and its parent directories up to the repository root. Read any you find — they contain conventions, patterns, and architectural context relevant to your work.
 


### PR DESCRIPTION
Updates `copilot-instructions.md` with two rules:

1. **Git confirmation gate**: Always ask the user for confirmation before running `git commit --amend` or `git push`. Prevents the agent from making irreversible git operations without user approval.

2. **Code-review skill skip**: Skip the `code-review` skill invocation if the user has stated they will review the changes themselves. Prevents unnecessary automated review when the user explicitly wants to do it.