### PR TITLE
Enable devirtualization of async methods in crossgen2

### DIFF
--- a/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
+++ b/src/coreclr/tools/Common/Compiler/CompilerTypeSystemContext.cs
@@ -17,6 +17,7 @@ namespace ILCompiler
     public partial class CompilerTypeSystemContext : MetadataTypeSystemContext, IMetadataStringDecoderProvider
     {
         private readonly MetadataRuntimeInterfacesAlgorithm _metadataRuntimeInterfacesAlgorithm = new MetadataRuntimeInterfacesAlgorithm();
+        private readonly AsyncAwareVirtualMethodResolutionAlgorithm _virtualMethodAlgorithm;
 
         private MetadataStringDecoder _metadataStringDecoder;
 

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/CompilerTypeSystemContext.Aot.cs
@@ -39,8 +39,6 @@ namespace ILCompiler
         private readonly Int128FieldLayoutAlgorithm _int128FieldLayoutAlgorithm;
         private readonly TypeWithRepeatedFieldsFieldLayoutAlgorithm _typeWithRepeatedFieldsFieldLayoutAlgorithm;
 
-        private readonly AsyncAwareVirtualMethodResolutionAlgorithm _virtualMethodAlgorithm;
-
         private TypeDesc[] _arrayOfTInterfaces;
         private TypeDesc[] _arrayEnumeratorOfTInterfaces;
         private ArrayOfTRuntimeInterfacesAlgorithm _arrayOfTRuntimeInterfacesAlgorithm;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -11,8 +11,6 @@ namespace ILCompiler
 {
     partial class CompilerTypeSystemContext
     {
-        private readonly MetadataVirtualMethodAlgorithm _virtualMethodAlgorithm;
-
         public CompilerTypeSystemContext(TargetDetails details, SharedGenericsMode genericsMode)
             : base(details)
         {

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCompilerContext.cs
@@ -11,11 +11,12 @@ namespace ILCompiler
 {
     partial class CompilerTypeSystemContext
     {
-        private readonly MetadataVirtualMethodAlgorithm _virtualMethodAlgorithm = new MetadataVirtualMethodAlgorithm();
+        private readonly MetadataVirtualMethodAlgorithm _virtualMethodAlgorithm;
 
         public CompilerTypeSystemContext(TargetDetails details, SharedGenericsMode genericsMode)
             : base(details)
         {
+            _virtualMethodAlgorithm = new AsyncAwareVirtualMethodResolutionAlgorithm(this);
             _continuationTypeHashtable = new(this);
             _genericsMode = genericsMode;
         }

--- a/src/tests/async/devirtualize/devirtualize.cs
+++ b/src/tests/async/devirtualize/devirtualize.cs
@@ -1,0 +1,144 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+
+public class Async2Devirtualize
+{
+    class Base
+    {
+        public virtual async Task<int> GetValue()
+        {
+            await Task.Yield();
+            return 1;
+        }
+    }
+
+    // Non-sealed derived class: devirtualization must go through resolveVirtualMethod
+    // because the JIT cannot use the sealed-type shortcut.
+    class OpenDerived : Base
+    {
+        public override async Task<int> GetValue()
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+
+    sealed class SealedDerived : Base
+    {
+        public override async Task<int> GetValue()
+        {
+            await Task.Yield();
+            return 2;
+        }
+    }
+
+    sealed class SealedDerivedNoYield : Base
+    {
+        [RuntimeAsyncMethodGeneration(false)]
+        public override async Task<int> GetValue()
+        {
+            await Task.Yield();
+            return 3;
+        }
+    }
+
+    interface IAsyncInterface
+    {
+        Task<int> GetValue();
+    }
+
+    // Non-sealed interface implementation: devirtualization of the interface
+    // call must go through resolveVirtualMethod.
+    class OpenInterfaceImpl : IAsyncInterface
+    {
+        public virtual async Task<int> GetValue()
+        {
+            await Task.Yield();
+            return 43;
+        }
+    }
+
+    sealed class SealedInterfaceImpl : IAsyncInterface
+    {
+        public async Task<int> GetValue()
+        {
+            await Task.Yield();
+            return 10;
+        }
+    }
+
+    sealed class SealedInterfaceImplNoYield : IAsyncInterface
+    {
+        [RuntimeAsyncMethodGeneration(false)]
+        public async Task<int> GetValue()
+        {
+            await Task.Yield();
+            return 11;
+        }
+    }
+
+    // Uses newobj to give the JIT exact type info on a non-sealed type.
+    // The JIT must call resolveVirtualMethod to devirtualize.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static async Task<int> CallOnNewOpenDerived()
+    {
+        Base obj = new OpenDerived();
+        return await obj.GetValue();
+    }
+
+    // Non-sealed interface impl with exact type from newobj.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static async Task<int> CallOnNewOpenInterfaceImpl()
+    {
+        IAsyncInterface obj = new OpenInterfaceImpl();
+        return await obj.GetValue();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static async Task<int> CallOnSealed(SealedDerived obj)
+    {
+        return await obj.GetValue();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static async Task<int> CallOnSealedNoYield(SealedDerivedNoYield obj)
+    {
+        return await obj.GetValue();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static async Task<int> CallOnSealedInterface(SealedInterfaceImpl obj)
+    {
+        return await obj.GetValue();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static async Task<int> CallOnSealedInterfaceNoYield(SealedInterfaceImplNoYield obj)
+    {
+        return await obj.GetValue();
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static async Task<int> CallOnInterface<T>(T obj) where T : IAsyncInterface
+    {
+        return await obj.GetValue();
+    }
+
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Equal(42, CallOnNewOpenDerived().Result);
+        Assert.Equal(43, CallOnNewOpenInterfaceImpl().Result);
+        Assert.Equal(2, CallOnSealed(new SealedDerived()).Result);
+        Assert.Equal(3, CallOnSealedNoYield(new SealedDerivedNoYield()).Result);
+        Assert.Equal(10, CallOnSealedInterface(new SealedInterfaceImpl()).Result);
+        Assert.Equal(11, CallOnSealedInterfaceNoYield(new SealedInterfaceImplNoYield()).Result);
+        Assert.Equal(10, CallOnInterface(new SealedInterfaceImpl()).Result);
+        Assert.Equal(11, CallOnInterface(new SealedInterfaceImplNoYield()).Result);
+    }
+}

--- a/src/tests/async/devirtualize/devirtualize.csproj
+++ b/src/tests/async/devirtualize/devirtualize.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Crossgen2's `CompilerTypeSystemContext` was using `MetadataVirtualMethodAlgorithm`, which does not handle async variant methods. This prevented devirtualization of async virtual methods during R2R compilation. Switch to `AsyncAwareVirtualMethodResolutionAlgorithm`, matching ilc.

Add a devirtualize test for async methods exercising sealed class virtual dispatch, sealed interface dispatch, and generic constrained dispatch.

Without the fix, interface dispatch on a newobj-allocated type (`CallOnNewOpenInterfaceImpl` test) emits a VIRTUAL_ENTRY indirect dispatch:
```
   lea r11, [0x70a0]  // [ASYNC] IAsyncInterface.GetValue() (VIRTUAL_ENTRY)
```

With the fix, crossgen2 resolves the async variant through the interface and devirtualizes to a direct call:
```
   call qword ptr [0x6290]  // [ASYNC] OpenInterfaceImpl.GetValue() (METHOD_ENTRY)
```
 
The other calls still require runtime dispatch.

Fixes https://github.com/dotnet/runtime/issues/124620