### PR TITLE
[browser][CoreCLR] startup helpers cleanup

### DIFF
--- a/src/native/libs/Common/JavaScript/loader/assets.ts
+++ b/src/native/libs/Common/JavaScript/loader/assets.ts
@@ -3,7 +3,7 @@
 
 import type { JsModuleExports, JsAsset, AssemblyAsset, WasmAsset, IcuAsset, EmscriptenModuleInternal, WebAssemblyBootResourceType, AssetEntryInternal, PromiseCompletionSource, LoadBootResourceCallback, InstantiateWasmSuccessCallback, SymbolsAsset } from "./types";
 
-import { dotnetAssert, dotnetLogger, dotnetInternals, dotnetBrowserHostExports, dotnetUpdateInternals, Module, dotnetDiagnosticsExports, dotnetNativeBrowserExports } from "./cross-module";
+import { dotnetAssert, dotnetLogger, dotnetInternals, dotnetBrowserHostExports, dotnetUpdateInternals, Module, dotnetDiagnosticsExports, dotnetNativeBrowserExports, dotnetApi } from "./cross-module";
 import { ENVIRONMENT_IS_SHELL, ENVIRONMENT_IS_NODE, browserVirtualAppBase } from "./per-module";
 import { createPromiseCompletionSource, delay } from "./promise-completion-source";
 import { locateFile, makeURLAbsoluteWithApplicationBase } from "./bootstrap";
@@ -53,6 +53,31 @@ export async function loadJSModule(asset: JsAsset): Promise<any> {
     }
     onDownloadedAsset(assetInternal);
     return mod;
+}
+
+export async function callLibraryInitializerOnRuntimeConfigLoaded(asset: JsAsset): Promise<any> {
+    try {
+        const module = await loadJSModule(asset);
+        if (module.onRuntimeConfigLoaded) {
+            await module.onRuntimeConfigLoaded(loaderConfig);
+        }
+        return module;
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to invoke 'onRuntimeConfigLoaded' on library initializer '${asset.name}': ${message}`, { cause: err });
+    }
+}
+
+export async function callLibraryInitializerOnRuntimeReady([asset, modulePromise]: [JsAsset, Promise<any>]): Promise<void> {
+    try {
+        const module = await modulePromise;
+        if (module.onRuntimeReady) {
+            await module.onRuntimeReady(dotnetApi);
+        }
+    } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to invoke 'onRuntimeReady' on library initializer '${asset.name}': ${message}`, { cause: err });
+    }
 }
 
 export function fetchMainWasm(asset: WasmAsset): Promise<Response> {

--- a/src/native/libs/Common/JavaScript/loader/assets.ts
+++ b/src/native/libs/Common/JavaScript/loader/assets.ts
@@ -58,7 +58,7 @@ export async function loadJSModule(asset: JsAsset): Promise<any> {
 export async function callLibraryInitializerOnRuntimeConfigLoaded(asset: JsAsset): Promise<any> {
     try {
         const module = await loadJSModule(asset);
-        if (module.onRuntimeConfigLoaded) {
+        if (typeof module.onRuntimeConfigLoaded === "function") {
             await module.onRuntimeConfigLoaded(loaderConfig);
         }
         return module;
@@ -71,7 +71,7 @@ export async function callLibraryInitializerOnRuntimeConfigLoaded(asset: JsAsset
 export async function callLibraryInitializerOnRuntimeReady([asset, modulePromise]: [JsAsset, Promise<any>]): Promise<void> {
     try {
         const module = await modulePromise;
-        if (module.onRuntimeReady) {
+        if (typeof module.onRuntimeReady === "function") {
             await module.onRuntimeReady(dotnetApi);
         }
     } catch (err) {

--- a/src/native/libs/Common/JavaScript/loader/assets.ts
+++ b/src/native/libs/Common/JavaScript/loader/assets.ts
@@ -57,28 +57,32 @@ export async function loadJSModule(asset: JsAsset): Promise<any> {
 
 export async function callLibraryInitializerOnRuntimeConfigLoaded(asset: JsAsset): Promise<any> {
     const module = await loadJSModule(asset);
+    const name = asset.name || asset.resolvedUrl || "unknown";
     try {
         if (typeof module.onRuntimeConfigLoaded === "function") {
             await module.onRuntimeConfigLoaded(loaderConfig);
-        } else {
-            dotnetLogger.warn(`Module '${asset.name}' does not export 'onRuntimeConfigLoaded' function. Make sure the module initializer is correctly defined and exported.`);
+        } else if (typeof module.onRuntimeReady !== "function") {
+            dotnetLogger.warn(`Module '${name}' does not export 'onRuntimeConfigLoaded' function. Make sure the module initializer is correctly defined and exported.`);
         }
         return module;
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        throw new Error(`Failed to invoke 'onRuntimeConfigLoaded' on library initializer '${asset.name}': ${message}`, { cause: err });
+        throw new Error(`Failed to invoke 'onRuntimeConfigLoaded' on library initializer '${name}': ${message}`, { cause: err });
     }
 }
 
 export async function callLibraryInitializerOnRuntimeReady([asset, modulePromise]: [JsAsset, Promise<any>]): Promise<void> {
+    const module = await modulePromise;
+    const name = asset.name || asset.resolvedUrl || "unknown";
     try {
-        const module = await modulePromise;
         if (typeof module.onRuntimeReady === "function") {
             await module.onRuntimeReady(dotnetApi);
+        } else if (typeof module.onRuntimeConfigLoaded !== "function") {
+            dotnetLogger.warn(`Module '${name}' does not export 'onRuntimeReady' function. Make sure the module initializer is correctly defined and exported.`);
         }
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        throw new Error(`Failed to invoke 'onRuntimeReady' on library initializer '${asset.name}': ${message}`, { cause: err });
+        throw new Error(`Failed to invoke 'onRuntimeReady' on library initializer '${name}': ${message}`, { cause: err });
     }
 }
 

--- a/src/native/libs/Common/JavaScript/loader/assets.ts
+++ b/src/native/libs/Common/JavaScript/loader/assets.ts
@@ -56,10 +56,12 @@ export async function loadJSModule(asset: JsAsset): Promise<any> {
 }
 
 export async function callLibraryInitializerOnRuntimeConfigLoaded(asset: JsAsset): Promise<any> {
+    const module = await loadJSModule(asset);
     try {
-        const module = await loadJSModule(asset);
         if (typeof module.onRuntimeConfigLoaded === "function") {
             await module.onRuntimeConfigLoaded(loaderConfig);
+        } else {
+            dotnetLogger.warn(`Module '${asset.name}' does not export 'onRuntimeConfigLoaded' function. Make sure the module initializer is correctly defined and exported.`);
         }
         return module;
     } catch (err) {
@@ -73,6 +75,8 @@ export async function callLibraryInitializerOnRuntimeReady([asset, modulePromise
         const module = await modulePromise;
         if (typeof module.onRuntimeReady === "function") {
             await module.onRuntimeReady(dotnetApi);
+        } else {
+            dotnetLogger.warn(`Module '${asset.name}' does not export 'onRuntimeReady' function. Make sure the module initializer is correctly defined and exported.`);
         }
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/native/libs/Common/JavaScript/loader/assets.ts
+++ b/src/native/libs/Common/JavaScript/loader/assets.ts
@@ -75,8 +75,6 @@ export async function callLibraryInitializerOnRuntimeReady([asset, modulePromise
         const module = await modulePromise;
         if (typeof module.onRuntimeReady === "function") {
             await module.onRuntimeReady(dotnetApi);
-        } else {
-            dotnetLogger.warn(`Module '${asset.name}' does not export 'onRuntimeReady' function. Make sure the module initializer is correctly defined and exported.`);
         }
     } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/src/native/libs/Common/JavaScript/loader/run.ts
+++ b/src/native/libs/Common/JavaScript/loader/run.ts
@@ -32,7 +32,7 @@ export async function createRuntime(downloadOnly: boolean): Promise<any> {
         }
         validateLoaderConfig();
 
-        const modulesAfterConfigLoadedPromises: [JsAsset, Promise<any>][] = normalizeCollection(resources.modulesAfterRuntimeReady).map((a) => [a, callLibraryInitializerOnRuntimeConfigLoaded(a)]);
+        const modulesAfterConfigLoadedPromises: [JsAsset, Promise<any>][] = normalizeCollection(resources.modulesAfterConfigLoaded).map((a) => [a, callLibraryInitializerOnRuntimeConfigLoaded(a)]);
         await Promise.all(modulesAfterConfigLoadedPromises.map(([, p]) => p));
 
         // after onConfigLoaded hooks that could install polyfills, our polyfills can be initialized

--- a/src/native/libs/Common/JavaScript/loader/run.ts
+++ b/src/native/libs/Common/JavaScript/loader/run.ts
@@ -33,6 +33,7 @@ export async function createRuntime(downloadOnly: boolean): Promise<any> {
         validateLoaderConfig();
 
         const modulesAfterConfigLoadedPromises: [JsAsset, Promise<any>][] = normalizeCollection(resources.modulesAfterRuntimeReady).map((a) => [a, callLibraryInitializerOnRuntimeConfigLoaded(a)]);
+        await Promise.all(modulesAfterConfigLoadedPromises.map(([, p]) => p));
 
         // after onConfigLoaded hooks that could install polyfills, our polyfills can be initialized
         await initPolyfills();

--- a/src/native/libs/Common/JavaScript/loader/run.ts
+++ b/src/native/libs/Common/JavaScript/loader/run.ts
@@ -105,9 +105,10 @@ export async function createRuntime(downloadOnly: boolean): Promise<any> {
 
         await Promise.all([...modulesAfterConfigLoadedPromises, ...modulesAfterRuntimeReadyPromises].map(callLibraryInitializerOnRuntimeReady));
 
-        runtimeState.creatingRuntime = false;
     } catch (err) {
         exit(1, err);
+    } finally {
+        runtimeState.creatingRuntime = false;
     }
 }
 export function abortStartup(reason: any): void {

--- a/src/native/libs/Common/JavaScript/loader/run.ts
+++ b/src/native/libs/Common/JavaScript/loader/run.ts
@@ -23,6 +23,7 @@ export async function createRuntime(downloadOnly: boolean): Promise<any> {
     if (!loaderConfig.resources || !loaderConfig.resources.coreAssembly || !loaderConfig.resources.coreAssembly.length) throw new Error("Invalid config, resources is not set");
     try {
         runtimeState.creatingRuntime = true;
+        const resources = loaderConfig.resources;
 
         await validateEngineFeatures();
 
@@ -31,39 +32,39 @@ export async function createRuntime(downloadOnly: boolean): Promise<any> {
         }
         validateLoaderConfig();
 
-        const modulesAfterConfigLoadedPromises: [JsAsset, Promise<any>][] = normalizeCollection(loaderConfig.resources.modulesAfterRuntimeReady).map((a) => [a, callLibraryInitializerOnRuntimeConfigLoaded(a)]);
+        const modulesAfterConfigLoadedPromises: [JsAsset, Promise<any>][] = normalizeCollection(resources.modulesAfterRuntimeReady).map((a) => [a, callLibraryInitializerOnRuntimeConfigLoaded(a)]);
 
         // after onConfigLoaded hooks that could install polyfills, our polyfills can be initialized
         await initPolyfills();
 
-        if (loaderConfig.resources.jsModuleDiagnostics && loaderConfig.resources.jsModuleDiagnostics.length > 0) {
-            const diagnosticsModule = await loadDotnetModule(loaderConfig.resources.jsModuleDiagnostics[0]);
+        if (resources.jsModuleDiagnostics && resources.jsModuleDiagnostics.length > 0) {
+            const diagnosticsModule = await loadDotnetModule(resources.jsModuleDiagnostics[0]);
             diagnosticsModule.dotnetInitializeModule<void>(dotnetInternals);
-            if (loaderConfig.resources.wasmSymbols && loaderConfig.resources.wasmSymbols.length > 0) {
-                await fetchNativeSymbols(loaderConfig.resources.wasmSymbols[0]);
+            if (resources.wasmSymbols && resources.wasmSymbols.length > 0) {
+                await fetchNativeSymbols(resources.wasmSymbols[0]);
             }
         }
-        const nativeModulePromise: Promise<JsModuleExports> = loadDotnetModule(loaderConfig.resources.jsModuleNative[0]);
-        const runtimeModulePromise: Promise<JsModuleExports> = loadDotnetModule(loaderConfig.resources.jsModuleRuntime[0]);
-        const wasmNativePromise: Promise<Response> = fetchMainWasm(loaderConfig.resources.wasmNative[0]);
+        const nativeModulePromise: Promise<JsModuleExports> = loadDotnetModule(resources.jsModuleNative[0]);
+        const runtimeModulePromise: Promise<JsModuleExports> = loadDotnetModule(resources.jsModuleRuntime[0]);
+        const wasmNativePromise: Promise<Response> = fetchMainWasm(resources.wasmNative[0]);
 
-        const coreAssembliesPromise = forEachResource(loaderConfig.resources.coreAssembly, fetchAssembly);
-        const coreVfsPromise = forEachResource(loaderConfig.resources.coreVfs, fetchVfs);
+        const coreAssembliesPromise = forEachResource(resources.coreAssembly, fetchAssembly);
+        const coreVfsPromise = forEachResource(resources.coreVfs, fetchVfs);
 
         const icuResourceName = getIcuResourceName();
-        const icuDataPromise = forEachResource(loaderConfig.resources.icu, fetchIcu, asset => asset.name === icuResourceName);
+        const icuDataPromise = forEachResource(resources.icu, fetchIcu, asset => asset.name === icuResourceName);
 
-        const assembliesPromise = forEachResource(loaderConfig.resources.assembly, fetchAssembly);
-        const satelliteResourcesPromise = loaderConfig.loadAllSatelliteResources && loaderConfig.resources.satelliteResources
-            ? fetchSatelliteAssemblies(Object.keys(loaderConfig.resources.satelliteResources))
+        const assembliesPromise = forEachResource(resources.assembly, fetchAssembly);
+        const satelliteResourcesPromise = loaderConfig.loadAllSatelliteResources && resources.satelliteResources
+            ? fetchSatelliteAssemblies(Object.keys(resources.satelliteResources))
             : Promise.resolve();
-        const vfsPromise = forEachResource(loaderConfig.resources.vfs, fetchVfs);
+        const vfsPromise = forEachResource(resources.vfs, fetchVfs);
 
         // WASM-TODO: also check that the debugger is linked in and check feature flags
         const isDebuggingSupported = loaderConfig.debugLevel != 0;
-        const corePDBsPromise = forEachResource(loaderConfig.resources.corePdb, fetchPdb, () => isDebuggingSupported);
-        const pdbsPromise = forEachResource(loaderConfig.resources.pdb, fetchPdb, () => isDebuggingSupported);
-        const modulesAfterRuntimeReadyPromises: [JsAsset, Promise<any>][] = normalizeCollection(loaderConfig.resources.modulesAfterRuntimeReady).map((a) => [a, loadJSModule(a)]);
+        const corePDBsPromise = forEachResource(resources.corePdb, fetchPdb, () => isDebuggingSupported);
+        const pdbsPromise = forEachResource(resources.pdb, fetchPdb, () => isDebuggingSupported);
+        const modulesAfterRuntimeReadyPromises: [JsAsset, Promise<any>][] = normalizeCollection(resources.modulesAfterRuntimeReady).map((a) => [a, loadJSModule(a)]);
 
         const nativeModule = await nativeModulePromise;
         const modulePromise = nativeModule.dotnetInitializeModule<EmscriptenModuleInternal>(dotnetInternals);
@@ -79,6 +80,7 @@ export async function createRuntime(downloadOnly: boolean): Promise<any> {
         await vfsPromise;
         await icuDataPromise;
         await wasmNativePromise; // this is just to propagate errors
+
         if (!downloadOnly) {
             Module.runtimeKeepalivePush();
             await initializeCoreCLR();

--- a/src/native/libs/Common/JavaScript/loader/run.ts
+++ b/src/native/libs/Common/JavaScript/loader/run.ts
@@ -1,30 +1,18 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-import type { JsModuleExports, EmscriptenModuleInternal } from "./types";
+import type { JsModuleExports, EmscriptenModuleInternal, JsAsset } from "./types";
 
-import { dotnetAssert, dotnetInternals, dotnetBrowserHostExports, dotnetApi, Module } from "./cross-module";
+import { dotnetAssert, dotnetInternals, dotnetBrowserHostExports, Module } from "./cross-module";
 import { exit, runtimeState } from "./exit";
 import { createPromiseCompletionSource } from "./promise-completion-source";
 import { getIcuResourceName } from "./icu";
 import { loaderConfig, validateLoaderConfig } from "./config";
-import { fetchAssembly, fetchIcu, fetchNativeSymbols, fetchPdb, fetchSatelliteAssemblies, fetchVfs, fetchMainWasm, loadDotnetModule, loadJSModule, nativeModulePromiseController, verifyAllAssetsDownloaded } from "./assets";
+import { fetchAssembly, fetchIcu, fetchNativeSymbols, fetchPdb, fetchSatelliteAssemblies, fetchVfs, fetchMainWasm, loadDotnetModule, loadJSModule, nativeModulePromiseController, verifyAllAssetsDownloaded, callLibraryInitializerOnRuntimeReady, callLibraryInitializerOnRuntimeConfigLoaded } from "./assets";
 import { initPolyfills } from "./polyfills";
 import { validateEngineFeatures } from "./bootstrap";
 
 const runMainPromiseController = createPromiseCompletionSource<number>();
-
-async function callLibraryInitializers(modules: JsModuleExports[], resources: any[], methodName: string, args: any): Promise<void> {
-    await Promise.all(modules.map(async (module, i) => {
-        try {
-            await (module as any)[methodName]?.(args);
-        } catch (err) {
-            const name = (resources[i] as any).name || "unknown";
-            const message = err instanceof Error ? err.message : String(err);
-            throw new Error(`Failed to invoke '${methodName}' on library initializer '${name}': ${message}`, { cause: err });
-        }
-    }));
-}
 
 // WASM-TODO: downloadOnly - Blazor render mode auto pre-download. Really no start.
 // WASM-TODO: debugLevel
@@ -43,11 +31,9 @@ export async function createRuntime(downloadOnly: boolean): Promise<any> {
         }
         validateLoaderConfig();
 
-        const afterConfigLoadedResources = loaderConfig.resources.modulesAfterConfigLoaded || [];
-        const modulesAfterConfigLoaded = await Promise.all(afterConfigLoadedResources.map(loadJSModule));
-        await callLibraryInitializers(modulesAfterConfigLoaded, afterConfigLoadedResources, "onRuntimeConfigLoaded", loaderConfig);
+        const modulesAfterConfigLoadedPromises: [JsAsset, Promise<any>][] = normalizeCollection(loaderConfig.resources.modulesAfterRuntimeReady).map((a) => [a, callLibraryInitializerOnRuntimeConfigLoaded(a)]);
 
-        // after onConfigLoaded hooks, polyfills can be initialized
+        // after onConfigLoaded hooks that could install polyfills, our polyfills can be initialized
         await initPolyfills();
 
         if (loaderConfig.resources.jsModuleDiagnostics && loaderConfig.resources.jsModuleDiagnostics.length > 0) {
@@ -61,24 +47,23 @@ export async function createRuntime(downloadOnly: boolean): Promise<any> {
         const runtimeModulePromise: Promise<JsModuleExports> = loadDotnetModule(loaderConfig.resources.jsModuleRuntime[0]);
         const wasmNativePromise: Promise<Response> = fetchMainWasm(loaderConfig.resources.wasmNative[0]);
 
-        const coreAssembliesPromise = Promise.all(loaderConfig.resources.coreAssembly.map(fetchAssembly));
-        const coreVfsPromise = Promise.all((loaderConfig.resources.coreVfs || []).map(fetchVfs));
+        const coreAssembliesPromise = forEachResource(loaderConfig.resources.coreAssembly, fetchAssembly);
+        const coreVfsPromise = forEachResource(loaderConfig.resources.coreVfs, fetchVfs);
 
         const icuResourceName = getIcuResourceName();
-        const icuDataPromise = icuResourceName ? Promise.all((loaderConfig.resources.icu || []).filter(asset => asset.name === icuResourceName).map(fetchIcu)) : Promise.resolve([]);
+        const icuDataPromise = forEachResource(loaderConfig.resources.icu, fetchIcu, asset => asset.name === icuResourceName);
 
-        const assembliesPromise = Promise.all(loaderConfig.resources.assembly.map(fetchAssembly));
+        const assembliesPromise = forEachResource(loaderConfig.resources.assembly, fetchAssembly);
         const satelliteResourcesPromise = loaderConfig.loadAllSatelliteResources && loaderConfig.resources.satelliteResources
             ? fetchSatelliteAssemblies(Object.keys(loaderConfig.resources.satelliteResources))
             : Promise.resolve();
-        const vfsPromise = Promise.all((loaderConfig.resources.vfs || []).map(fetchVfs));
+        const vfsPromise = forEachResource(loaderConfig.resources.vfs, fetchVfs);
 
         // WASM-TODO: also check that the debugger is linked in and check feature flags
         const isDebuggingSupported = loaderConfig.debugLevel != 0;
-        const corePDBsPromise = isDebuggingSupported ? Promise.all((loaderConfig.resources.corePdb || []).map(fetchPdb)) : Promise.resolve([]);
-        const pdbsPromise = isDebuggingSupported ? Promise.all((loaderConfig.resources.pdb || []).map(fetchPdb)) : Promise.resolve([]);
-        const afterRuntimeReadyResources = loaderConfig.resources.modulesAfterRuntimeReady || [];
-        const modulesAfterRuntimeReadyPromise = Promise.all(afterRuntimeReadyResources.map(loadJSModule));
+        const corePDBsPromise = forEachResource(loaderConfig.resources.corePdb, fetchPdb, () => isDebuggingSupported);
+        const pdbsPromise = forEachResource(loaderConfig.resources.pdb, fetchPdb, () => isDebuggingSupported);
+        const modulesAfterRuntimeReadyPromises: [JsAsset, Promise<any>][] = normalizeCollection(loaderConfig.resources.modulesAfterRuntimeReady).map((a) => [a, loadJSModule(a)]);
 
         const nativeModule = await nativeModulePromise;
         const modulePromise = nativeModule.dotnetInitializeModule<EmscriptenModuleInternal>(dotnetInternals);
@@ -107,15 +92,16 @@ export async function createRuntime(downloadOnly: boolean): Promise<any> {
 
         verifyAllAssetsDownloaded();
 
-        if (!downloadOnly) {
-            if (typeof Module.onDotnetReady === "function") {
-                await Module.onDotnetReady();
-            }
-            const modulesAfterRuntimeReady = await modulesAfterRuntimeReadyPromise;
-            const allRuntimeReadyModules = [...modulesAfterConfigLoaded, ...modulesAfterRuntimeReady];
-            const allRuntimeReadyResources = [...afterConfigLoadedResources, ...afterRuntimeReadyResources];
-            await callLibraryInitializers(allRuntimeReadyModules, allRuntimeReadyResources, "onRuntimeReady", dotnetApi);
+        if (downloadOnly) {
+            return;
         }
+
+        if (typeof Module.onDotnetReady === "function") {
+            await Module.onDotnetReady();
+        }
+
+        await Promise.all([...modulesAfterConfigLoadedPromises, ...modulesAfterRuntimeReadyPromises].map(callLibraryInitializerOnRuntimeReady));
+
         runtimeState.creatingRuntime = false;
     } catch (err) {
         exit(1, err);
@@ -150,4 +136,17 @@ export function getRunMainPromise(): Promise<number> {
     return runMainPromiseController.promise;
 }
 
+function forEachResource<T, R>(collection: T[] | undefined, callback: (item: T) => Promise<R>, filter?: (item: T) => boolean): Promise<R[]> {
+    if (!collection) {
+        return Promise.resolve([]);
+    }
+    const filteredCollection = filter ? collection.filter(filter) : collection;
+    return Promise.all(filteredCollection.map(callback));
+}
 
+function normalizeCollection<T>(collection: T[] | undefined): T[] {
+    if (!collection) {
+        return [];
+    }
+    return collection;
+}


### PR DESCRIPTION
- make the run method more readable by forEachResource and normalizeCollection helpers
- callLibraryInitializerOnRuntimeConfigLoaded and callLibraryInitializerOnRuntimeReady in the assets.ts