### PR TITLE
Fix a regression to collection asserting in `AssemblyChecker`

### DIFF
--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/TestFrameworkTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/TestFrameworkTests.g.cs
@@ -106,6 +106,18 @@ namespace ILLink.RoslynAnalyzer.Tests
         }
 
         [Fact]
+        public Task VerifyKeptAttributeAttributeWorks()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task VerifyLocalsAreChanged()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
         public Task VerifyResourceInAssemblyAttributesBehavior()
         {
             return RunTest(allowMissingWarnings: true);

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptAttributeAttribute.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases.Expectations/Assertions/KeptAttributeAttribute.cs
@@ -19,5 +19,18 @@ namespace Mono.Linker.Tests.Cases.Expectations.Assertions
         {
             ArgumentNullException.ThrowIfNull(type);
         }
+
+        /// <summary>
+        /// Use this constructor when you want to explicitly verify that an attribute with specific parameters survived.
+        ///
+        /// This is useful when you have a test that has multiple attributes of the same type but passed each is passed different parameters
+        /// and you want to verify which one(s) survived
+        /// </summary>
+        /// <param name="type"></param>
+        /// <param name="args"></param>
+        public KeptAttributeAttribute(Type type, params object[] args)
+        {
+            ArgumentNullException.ThrowIfNull(type);
+        }
     }
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMap.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Reflection/TypeMap.cs
@@ -14,11 +14,6 @@ using Mono.Linker.Tests.Cases.Reflection;
 using Mono.Linker.Tests.Cases.Reflection.Dependencies;
 using Mono.Linker.Tests.Cases.Reflection.Dependencies.Library;
 
-[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedTypeMap>))]
-[assembly: KeptAttributeAttribute(typeof(TypeMapAssociationAttribute<UsedTypeMap>))]
-[assembly: KeptAttributeAttribute(typeof(TypeMapAssociationAttribute<UsedProxyTypeMap>))]
-[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedExternalTypeMap>))]
-[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedWithoutAssemblyTargetUniverse>))]
 [assembly: TypeMap<UsedTypeMap>("TrimTargetIsTarget", typeof(TargetAndTrimTarget), typeof(TargetAndTrimTarget))]
 [assembly: TypeMap<UsedTypeMap>("TrimTargetIsUnrelated", typeof(TargetType), typeof(TrimTarget))]
 [assembly: TypeMap<UsedTypeMap>(nameof(AllocatedNoTypeCheckClassTarget), typeof(AllocatedNoTypeCheckClassTarget), typeof(AllocatedNoTypeCheckClass))]
@@ -33,14 +28,29 @@ using Mono.Linker.Tests.Cases.Reflection.Dependencies.Library;
 [assembly: TypeMap<UsedTypeMap>("Ldobj", typeof(LdobjTarget), typeof(LdobjType))]
 [assembly: TypeMap<UsedTypeMap>("ArrayElement", typeof(ArrayElementTarget), typeof(ArrayElement))]
 [assembly: TypeMap<UsedTypeMap>("TrimTargetIsAllocatedNoTypeCheckNoBoxStruct", typeof(ConstructedNoTypeCheckOrBoxTarget), typeof(ConstructedNoTypeCheckNoBoxStruct))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedTypeMap>), "TrimTargetIsTarget", typeof(TargetAndTrimTarget), typeof(TargetAndTrimTarget))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedTypeMap>), "TrimTargetIsUnrelated", typeof(TargetType), typeof(TrimTarget))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedTypeMap>), nameof(AllocatedNoTypeCheckClassTarget), typeof(AllocatedNoTypeCheckClassTarget), typeof(AllocatedNoTypeCheckClass))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedTypeMap>), nameof(AlloctedNoTypeCheckStructTarget), typeof(AlloctedNoTypeCheckStructTarget), typeof(AllocatedNoTypeCheckStruct))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedTypeMap>), "TypeMapEntryOnly", typeof(TypeMapEntryOnly))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedTypeMap>), nameof(UnboxedOnlyTarget), typeof(UnboxedOnlyTarget), typeof(UnboxedOnly))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedTypeMap>), "TypedRefSource", typeof(MakeRefTargetType), typeof(MakeRef))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedTypeMap>), "TypedRefTarget", typeof(RefValueTargetType), typeof(RefValue))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedTypeMap>), "Constrained", typeof(ConstrainedTarget), typeof(Constrained))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedTypeMap>), "ConstrainedStatic", typeof(ConstraintedStaticTarget), typeof(ConstrainedStatic))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedTypeMap>), "Ldobj", typeof(LdobjTarget), typeof(LdobjType))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedTypeMap>), "ArrayElement", typeof(ArrayElementTarget), typeof(ArrayElement))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedTypeMap>), "TrimTargetIsAllocatedNoTypeCheckNoBoxStruct", typeof(ConstructedNoTypeCheckOrBoxTarget), typeof(ConstructedNoTypeCheckNoBoxStruct))]
 
 // The TypeMap Universes are kept separate such that Proxy attributes shouldn't be kept if only the External type map is needed.
 [assembly: TypeMap<UsedExternalTypeMap>("UsedOnlyForExternalTypeMap", typeof(UsedExternalTarget), typeof(UsedTrimTarget))] // Kept
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedExternalTypeMap>), "UsedOnlyForExternalTypeMap", typeof(UsedExternalTarget), typeof(UsedTrimTarget))]
 [assembly: TypeMapAssociation<UsedExternalTypeMap>(typeof(UsedProxySource), typeof(UsedProxyTarget))] // Removed
 
 // The TypeMap Universes are kept separate such that External attributes shouldn't be kept if only the Proxy type map is needed.
 [assembly: TypeMap<UsedProxyTypeMap>("UsedOnlyForExternalTypeMap", typeof(UsedExternalTarget2), typeof(UsedTrimTarget2))] // Removed
 [assembly: TypeMapAssociation<UsedProxyTypeMap>(typeof(UsedProxySource2), typeof(UsedProxyTarget2))] // Kept
+[assembly: KeptAttributeAttribute(typeof(TypeMapAssociationAttribute<UsedProxyTypeMap>), typeof(UsedProxySource2), typeof(UsedProxyTarget2))]
 
 [assembly: TypeMapAssociation<UsedTypeMap>(typeof(SourceClass), typeof(ProxyType))]
 [assembly: TypeMapAssociation<UsedTypeMap>(typeof(TypeCheckOnlyClass), typeof(TypeCheckOnlyProxy))]
@@ -48,6 +58,10 @@ using Mono.Linker.Tests.Cases.Reflection.Dependencies.Library;
 [assembly: TypeMapAssociation<UsedTypeMap>(typeof(I), typeof(IImpl))]
 [assembly: TypeMapAssociation<UsedTypeMap>(typeof(IInterfaceWithDynamicImpl), typeof(IDynamicImpl))]
 [assembly: TypeMapAssociation<UsedTypeMap>(typeof(ArrayElement), typeof(ArrayElementProxy))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAssociationAttribute<UsedTypeMap>), typeof(SourceClass), typeof(ProxyType))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAssociationAttribute<UsedTypeMap>), typeof(AllocatedNoBoxStructType), typeof(AllocatedNoBoxProxy))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAssociationAttribute<UsedTypeMap>), typeof(IInterfaceWithDynamicImpl), typeof(IDynamicImpl))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAssociationAttribute<UsedTypeMap>), typeof(ArrayElement), typeof(ArrayElementProxy))]
 
 [assembly: TypeMap<UnusedTypeMap>("UnusedName", typeof(UnusedTargetType), typeof(TrimTarget))]
 [assembly: TypeMapAssociation<UsedTypeMap>(typeof(UnusedSourceClass), typeof(UnusedProxyType))]
@@ -55,6 +69,7 @@ using Mono.Linker.Tests.Cases.Reflection.Dependencies.Library;
 [assembly: TypeMap<UsedTypeMap>("ClassWithStaticMethodAndField", typeof(TargetType5), typeof(ClassWithStaticMethodAndField))]
 
 [assembly: TypeMap<UsedWithoutAssemblyTargetUniverse>("UnimportantString", typeof(PreservedTargetType))]
+[assembly: KeptAttributeAttribute(typeof(TypeMapAttribute<UsedWithoutAssemblyTargetUniverse>), "UnimportantString", typeof(PreservedTargetType))]
 
 [assembly: KeptAttributeAttribute(typeof(TypeMapAssemblyTargetAttribute<UsedTypeMap>))]
 [assembly: TypeMapAssemblyTarget<UsedTypeMap>("library")]

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/VerifyKeptAttributeAttributeWorks.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/VerifyKeptAttributeAttributeWorks.cs
@@ -1,0 +1,310 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.TestFramework;
+
+[assembly: VerifyKeptAttributeAttributeWorks.NoArguments]
+[assembly: KeptAttributeAttribute(typeof(VerifyKeptAttributeAttributeWorks.NoArgumentsAttribute))]
+
+[assembly: VerifyKeptAttributeAttributeWorks.NoArgumentsWithDuplicates]
+[assembly: VerifyKeptAttributeAttributeWorks.NoArgumentsWithDuplicates]
+// Roslyn will dedupe so only need one assert
+[assembly: KeptAttributeAttribute(typeof(VerifyKeptAttributeAttributeWorks.NoArgumentsWithDuplicatesAttribute))]
+
+[assembly: VerifyKeptAttributeAttributeWorks.WithArgumentsLooseAssert("arg1", 1, "arg3", typeof(int))]
+[assembly: KeptAttributeAttribute(typeof(VerifyKeptAttributeAttributeWorks.WithArgumentsLooseAssertAttribute))]
+
+[assembly: VerifyKeptAttributeAttributeWorks.WithArgumentsExplicitAssert("arg1", 1, "arg3", typeof(int))]
+[assembly: KeptAttributeAttribute(typeof(VerifyKeptAttributeAttributeWorks.WithArgumentsExplicitAssertAttribute), "arg1", 1, "arg3", typeof(int))]
+
+[assembly: VerifyKeptAttributeAttributeWorks.WithArgumentsWithDuplicatesExplicitAssert("inst1-arg1", 1, "inst1-arg3", typeof(int))]
+[assembly: VerifyKeptAttributeAttributeWorks.WithArgumentsWithDuplicatesExplicitAssert("inst2-arg1", 2, "inst2-arg3", typeof(string))]
+[assembly: VerifyKeptAttributeAttributeWorks.WithArgumentsWithDuplicatesExplicitAssert("inst3-arg1", 3, "inst3-arg3", typeof(VerifyKeptAttributeAttributeWorks.Foo))]
+// Intentionally make kept attribute ordering different than the usages to verify we don't require ordering of kept attributes to match the usages
+[assembly: KeptAttributeAttribute(typeof(VerifyKeptAttributeAttributeWorks.WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst1-arg1", 1, "inst1-arg3", typeof(int))]
+[assembly: KeptAttributeAttribute(typeof(VerifyKeptAttributeAttributeWorks.WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst3-arg1", 3, "inst3-arg3", typeof(VerifyKeptAttributeAttributeWorks.Foo))]
+[assembly: KeptAttributeAttribute(typeof(VerifyKeptAttributeAttributeWorks.WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst2-arg1", 2, "inst2-arg3", typeof(string))]
+
+[assembly: VerifyKeptAttributeAttributeWorks.WithArgumentsWithGenericWithDuplicatesExplicitAssert<int>("inst1-arg1", 1, "inst1-arg3", typeof(int))]
+[assembly: VerifyKeptAttributeAttributeWorks.WithArgumentsWithGenericWithDuplicatesExplicitAssert<string>("inst2-arg1", 2, "inst2-arg3", typeof(string))]
+[assembly: VerifyKeptAttributeAttributeWorks.WithArgumentsWithGenericWithDuplicatesExplicitAssert<VerifyKeptAttributeAttributeWorks.Foo>("inst3-arg1", 3, "inst3-arg3", typeof(VerifyKeptAttributeAttributeWorks.Foo))]
+// Intentionally make kept attribute ordering different than the usages to verify we don't require ordering of kept attributes to match the usages
+[assembly: KeptAttributeAttribute(typeof(VerifyKeptAttributeAttributeWorks.WithArgumentsWithGenericWithDuplicatesExplicitAssertAttribute<int>), "inst1-arg1", 1, "inst1-arg3", typeof(int))]
+[assembly: KeptAttributeAttribute(typeof(VerifyKeptAttributeAttributeWorks.WithArgumentsWithGenericWithDuplicatesExplicitAssertAttribute<VerifyKeptAttributeAttributeWorks.Foo>), "inst3-arg1", 3, "inst3-arg3", typeof(VerifyKeptAttributeAttributeWorks.Foo))]
+[assembly: KeptAttributeAttribute(typeof(VerifyKeptAttributeAttributeWorks.WithArgumentsWithGenericWithDuplicatesExplicitAssertAttribute<string>), "inst2-arg1", 2, "inst2-arg3", typeof(string))]
+
+namespace Mono.Linker.Tests.Cases.TestFramework;
+
+public class VerifyKeptAttributeAttributeWorks
+{
+    public static void Main()
+    {
+        var f = new Foo();
+        f.Method();
+        f.Field = 1;
+        f.Property = 1;
+        f.Event += delegate(object sender, EventArgs e)
+        {
+        };
+    }
+
+    [Kept]
+    [KeptMember(".ctor()")]
+
+    [NoArguments]
+    [KeptAttributeAttribute(typeof(NoArgumentsAttribute))]
+
+    [NoArgumentsWithDuplicates]
+    [NoArgumentsWithDuplicates]
+    [KeptAttributeAttribute(typeof(NoArgumentsWithDuplicatesAttribute))]
+    [KeptAttributeAttribute(typeof(NoArgumentsWithDuplicatesAttribute))]
+
+    [WithArgumentsLooseAssert("arg1", 1, "arg3", typeof(int))]
+    [KeptAttributeAttribute(typeof(WithArgumentsLooseAssertAttribute))]
+
+    [WithArgumentsExplicitAssert("arg1", 1, "arg3", typeof(int))]
+    [KeptAttributeAttribute(typeof(WithArgumentsExplicitAssertAttribute), "arg1", 1, "arg3", typeof(int))]
+
+    [WithArgumentsWithDuplicatesLooseAssert("arg1", 1, "arg3", typeof(int))]
+    [WithArgumentsWithDuplicatesLooseAssert("arg1", 1, "arg3", typeof(int))]
+    [WithArgumentsWithDuplicatesLooseAssert("arg1", 2, "arg3", typeof(int))]
+    [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+    [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+    [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+
+    [WithArgumentsWithDuplicatesExplicitAssert("inst1-arg1", 1, "inst1-arg3", typeof(int))]
+    [WithArgumentsWithDuplicatesExplicitAssert("inst2-arg1", 2, "inst2-arg3", typeof(string))]
+    [WithArgumentsWithDuplicatesExplicitAssert("inst3-arg1", 3, "inst3-arg3", typeof(Foo))]
+    [WithArgumentsWithDuplicatesExplicitAssert(null, 4, null, null)]
+    // Intentionally make kept attribute ordering different than the usages to verify we don't require ordering of kept attributes to match the usages
+    [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst1-arg1", 1, "inst1-arg3", typeof(int))]
+    [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst3-arg1", 3, "inst3-arg3", typeof(Foo))]
+    [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst2-arg1", 2, "inst2-arg3", typeof(string))]
+    [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), null, 4, null, null)]
+
+    [WithArgumentsWithGenericWithDuplicatesExplicitAssert<int>("inst1-arg1", 1, "inst1-arg3", typeof(int))]
+    [WithArgumentsWithGenericWithDuplicatesExplicitAssert<string>("inst2-arg1", 2, "inst2-arg3", typeof(string))]
+    [WithArgumentsWithGenericWithDuplicatesExplicitAssert<Foo>("inst3-arg1", 3, "inst3-arg3", typeof(Foo))]
+    // Intentionally make kept attribute ordering different than the usages to verify we don't require ordering of kept attributes to match the usages
+    [KeptAttributeAttribute(typeof(WithArgumentsWithGenericWithDuplicatesExplicitAssertAttribute<int>), "inst1-arg1", 1, "inst1-arg3", typeof(int))]
+    [KeptAttributeAttribute(typeof(WithArgumentsWithGenericWithDuplicatesExplicitAssertAttribute<Foo>), "inst3-arg1", 3, "inst3-arg3", typeof(Foo))]
+    [KeptAttributeAttribute(typeof(WithArgumentsWithGenericWithDuplicatesExplicitAssertAttribute<string>), "inst2-arg1", 2, "inst2-arg3", typeof(string))]
+    public class Foo
+    {
+        [Kept]
+
+        [NoArguments]
+        [KeptAttributeAttribute(typeof(NoArgumentsAttribute))]
+
+        [NoArgumentsWithDuplicates]
+        [NoArgumentsWithDuplicates]
+        [KeptAttributeAttribute(typeof(NoArgumentsWithDuplicatesAttribute))]
+        [KeptAttributeAttribute(typeof(NoArgumentsWithDuplicatesAttribute))]
+
+        [WithArgumentsLooseAssert("arg1", 1, "arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsLooseAssertAttribute))]
+
+        [WithArgumentsExplicitAssert("arg1", 1, "arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsExplicitAssertAttribute), "arg1", 1, "arg3", typeof(int))]
+
+        [WithArgumentsWithDuplicatesLooseAssert("arg1", 1, "arg3", typeof(int))]
+        [WithArgumentsWithDuplicatesLooseAssert("arg1", 1, "arg3", typeof(int))]
+        [WithArgumentsWithDuplicatesLooseAssert("arg1", 2, "arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+
+        [WithArgumentsWithDuplicatesExplicitAssert("inst1-arg1", 1, "inst1-arg3", typeof(int))]
+        [WithArgumentsWithDuplicatesExplicitAssert("inst2-arg1", 2, "inst2-arg3", typeof(string))]
+        [WithArgumentsWithDuplicatesExplicitAssert("inst3-arg1", 3, "inst3-arg3", typeof(Foo))]
+        // Intentionally make kept attribute ordering different than the usages to verify we don't require ordering of kept attributes to match the usages
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst1-arg1", 1, "inst1-arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst3-arg1", 3, "inst3-arg3", typeof(Foo))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst2-arg1", 2, "inst2-arg3", typeof(string))]
+        public int Field;
+
+        [Kept]
+
+        [NoArguments]
+        [KeptAttributeAttribute(typeof(NoArgumentsAttribute))]
+
+        [NoArgumentsWithDuplicates]
+        [NoArgumentsWithDuplicates]
+        [KeptAttributeAttribute(typeof(NoArgumentsWithDuplicatesAttribute))]
+        [KeptAttributeAttribute(typeof(NoArgumentsWithDuplicatesAttribute))]
+
+        [WithArgumentsLooseAssert("arg1", 1, "arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsLooseAssertAttribute))]
+
+        [WithArgumentsExplicitAssert("arg1", 1, "arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsExplicitAssertAttribute), "arg1", 1, "arg3", typeof(int))]
+
+        [WithArgumentsWithDuplicatesLooseAssert("arg1", 1, "arg3", typeof(int))]
+        [WithArgumentsWithDuplicatesLooseAssert("arg1", 1, "arg3", typeof(int))]
+        [WithArgumentsWithDuplicatesLooseAssert("arg1", 2, "arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+
+        [WithArgumentsWithDuplicatesExplicitAssert("inst1-arg1", 1, "inst1-arg3", typeof(int))]
+        [WithArgumentsWithDuplicatesExplicitAssert("inst2-arg1", 2, "inst2-arg3", typeof(string))]
+        [WithArgumentsWithDuplicatesExplicitAssert("inst3-arg1", 3, "inst3-arg3", typeof(Foo))]
+        // Intentionally make kept attribute ordering different than the usages to verify we don't require ordering of kept attributes to match the usages
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst1-arg1", 1, "inst1-arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst3-arg1", 3, "inst3-arg3", typeof(Foo))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst2-arg1", 2, "inst2-arg3", typeof(string))]
+        public void Method()
+        {
+        }
+
+        [Kept]
+
+        [NoArguments]
+        [KeptAttributeAttribute(typeof(NoArgumentsAttribute))]
+
+        [NoArgumentsWithDuplicates]
+        [NoArgumentsWithDuplicates]
+        [KeptAttributeAttribute(typeof(NoArgumentsWithDuplicatesAttribute))]
+        [KeptAttributeAttribute(typeof(NoArgumentsWithDuplicatesAttribute))]
+
+        [WithArgumentsLooseAssert("arg1", 1, "arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsLooseAssertAttribute))]
+
+        [WithArgumentsExplicitAssert("arg1", 1, "arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsExplicitAssertAttribute), "arg1", 1, "arg3", typeof(int))]
+
+        [WithArgumentsWithDuplicatesLooseAssert("arg1", 1, "arg3", typeof(int))]
+        [WithArgumentsWithDuplicatesLooseAssert("arg1", 1, "arg3", typeof(int))]
+        [WithArgumentsWithDuplicatesLooseAssert("arg1", 2, "arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+
+        [WithArgumentsWithDuplicatesExplicitAssert("inst1-arg1", 1, "inst1-arg3", typeof(int))]
+        [WithArgumentsWithDuplicatesExplicitAssert("inst2-arg1", 2, "inst2-arg3", typeof(string))]
+        [WithArgumentsWithDuplicatesExplicitAssert("inst3-arg1", 3, "inst3-arg3", typeof(Foo))]
+        // Intentionally make kept attribute ordering different than the usages to verify we don't require ordering of kept attributes to match the usages
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst1-arg1", 1, "inst1-arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst3-arg1", 3, "inst3-arg3", typeof(Foo))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst2-arg1", 2, "inst2-arg3", typeof(string))]
+        public int Property;
+
+        [Kept]
+        [KeptBackingField]
+        [KeptEventAddMethod]
+        [KeptEventRemoveMethod]
+
+        [NoArguments]
+        [KeptAttributeAttribute(typeof(NoArgumentsAttribute))]
+
+        [NoArgumentsWithDuplicates]
+        [NoArgumentsWithDuplicates]
+        [KeptAttributeAttribute(typeof(NoArgumentsWithDuplicatesAttribute))]
+        [KeptAttributeAttribute(typeof(NoArgumentsWithDuplicatesAttribute))]
+
+        [WithArgumentsLooseAssert("arg1", 1, "arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsLooseAssertAttribute))]
+
+        [WithArgumentsExplicitAssert("arg1", 1, "arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsExplicitAssertAttribute), "arg1", 1, "arg3", typeof(int))]
+
+        [WithArgumentsWithDuplicatesLooseAssert("arg1", 1, "arg3", typeof(int))]
+        [WithArgumentsWithDuplicatesLooseAssert("arg1", 1, "arg3", typeof(int))]
+        [WithArgumentsWithDuplicatesLooseAssert("arg1", 2, "arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesLooseAssertAttribute))]
+
+        [WithArgumentsWithDuplicatesExplicitAssert("inst1-arg1", 1, "inst1-arg3", typeof(int))]
+        [WithArgumentsWithDuplicatesExplicitAssert("inst2-arg1", 2, "inst2-arg3", typeof(string))]
+        [WithArgumentsWithDuplicatesExplicitAssert("inst3-arg1", 3, "inst3-arg3", typeof(Foo))]
+        // Intentionally make kept attribute ordering different than the usages to verify we don't require ordering of kept attributes to match the usages
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst1-arg1", 1, "inst1-arg3", typeof(int))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst3-arg1", 3, "inst3-arg3", typeof(Foo))]
+        [KeptAttributeAttribute(typeof(WithArgumentsWithDuplicatesExplicitAssertAttribute), "inst2-arg1", 2, "inst2-arg3", typeof(string))]
+        public event EventHandler Event;
+    }
+
+    [Kept]
+    [KeptMember(".ctor()")]
+    [KeptBaseType(typeof(Attribute))]
+    [KeptAttributeAttribute(typeof(AttributeUsageAttribute))]
+    [AttributeUsage(AttributeTargets.All)]
+    public class NoArgumentsAttribute : Attribute
+    {
+    }
+
+    [Kept]
+    [KeptBaseType(typeof(Attribute))]
+    [KeptAttributeAttribute(typeof(AttributeUsageAttribute))]
+    [AttributeUsage(AttributeTargets.All)]
+    public class WithArgumentsLooseAssertAttribute : Attribute
+    {
+        [Kept]
+        public WithArgumentsLooseAssertAttribute(object arg1, int arg2, string arg3, Type arg4)
+        {
+        }
+    }
+
+    [Kept]
+    [KeptBaseType(typeof(Attribute))]
+    [KeptAttributeAttribute(typeof(AttributeUsageAttribute))]
+    [AttributeUsage(AttributeTargets.All)]
+    public class WithArgumentsExplicitAssertAttribute : Attribute
+    {
+        [Kept]
+        public WithArgumentsExplicitAssertAttribute(object arg1, int arg2, string arg3, Type arg4)
+        {
+        }
+    }
+
+    [Kept]
+    [KeptMember(".ctor()")]
+    [KeptBaseType(typeof(Attribute))]
+    [KeptAttributeAttribute(typeof(AttributeUsageAttribute))]
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+    public class NoArgumentsWithDuplicatesAttribute : Attribute
+    {
+    }
+
+    [Kept]
+    [KeptMember(".ctor()")]
+    [KeptBaseType(typeof(Attribute))]
+    [KeptAttributeAttribute(typeof(AttributeUsageAttribute))]
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+    public class WithArgumentsWithDuplicatesLooseAssertAttribute : Attribute
+    {
+        [Kept]
+        public WithArgumentsWithDuplicatesLooseAssertAttribute(object arg1, int arg2, string arg3, Type arg4)
+        {
+        }
+    }
+
+    [Kept]
+    [KeptMember(".ctor()")]
+    [KeptBaseType(typeof(Attribute))]
+    [KeptAttributeAttribute(typeof(AttributeUsageAttribute))]
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+    public class WithArgumentsWithDuplicatesExplicitAssertAttribute : Attribute
+    {
+        [Kept]
+        public WithArgumentsWithDuplicatesExplicitAssertAttribute(object arg1, int arg2, string arg3, Type arg4)
+        {
+        }
+    }
+
+    [Kept]
+    [KeptMember(".ctor()")]
+    [KeptBaseType(typeof(Attribute))]
+    [KeptAttributeAttribute(typeof(AttributeUsageAttribute))]
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+    public class WithArgumentsWithGenericWithDuplicatesExplicitAssertAttribute<T> : Attribute
+    {
+        [Kept]
+        public WithArgumentsWithGenericWithDuplicatesExplicitAssertAttribute(object arg1, int arg2, string arg3, Type arg4)
+        {
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/VerifyLocalsAreChanged.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/VerifyLocalsAreChanged.cs
@@ -1,0 +1,44 @@
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.TestFramework
+{
+    [SetupLinkerSubstitutionFile("VerifyLocalsAreChanged.xml")]
+    public class VerifyLocalsAreChanged
+    {
+        public static void Main()
+        {
+            TestMethod_1();
+
+            TestMethod_2();
+        }
+
+        [Kept]
+        struct NestedType
+        {
+            public NestedType(int arg)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        [Kept]
+        [ExpectBodyModified]
+        [ExpectLocalsModified]
+        static NestedType TestMethod_1()
+        {
+            var value = new NestedType(42);
+            return value;
+        }
+
+        [Kept]
+        [ExpectedLocalsSequence(["Mono.Linker.Tests.Cases.TestFramework.VerifyLocalsAreChanged/NestedType"])]
+        [ExpectBodyModified]
+        static NestedType TestMethod_2()
+        {
+            var value = new NestedType(2);
+            return value;
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/VerifyLocalsAreChanged.xml
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/TestFramework/VerifyLocalsAreChanged.xml
@@ -1,0 +1,11 @@
+<linker>
+  <assembly fullname="test, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+    <type fullname="Mono.Linker.Tests.Cases.TestFramework.VerifyLocalsAreChanged">
+      <method signature="Mono.Linker.Tests.Cases.TestFramework.VerifyLocalsAreChanged/NestedType TestMethod_1()" body="stub">
+      </method>
+
+      <method signature="Mono.Linker.Tests.Cases.TestFramework.VerifyLocalsAreChanged/NestedType TestMethod_2()" body="stub">
+      </method>
+    </type>
+  </assembly>
+</linker>

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCasesRunner/AssemblyChecker.cs
@@ -114,13 +114,13 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
             var expected = original.Assembly.MainModule.AllDefinedTypes()
                 .SelectMany(t => GetCustomAttributeCtorValues<string>(t, nameof(KeptModuleReferenceAttribute)))
-                .ToHashSet();
+                .ToArray();
 
             var actual = linked.ModuleReferences
                 .Select(name => name.Name)
-                .ToHashSet();
+                .ToArray();
 
-            if (!expected.SetEquals(actual))
+            if (!expected.SequenceEqual(actual))
                 yield return $"In module {original.FileName} Expected module references `{string.Join(", ", expected)}` but got `{string.Join(", ", actual)}`";
 
             foreach (var err in VerifyCustomAttributes(original, linked))
@@ -820,7 +820,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
             if (src.CustomAttributes.Any(attr => attr.AttributeType.Name == expectModifiedAttributeName))
             {
-                if (linkedValues.ToHashSet().SetEquals(srcValues.ToHashSet()))
+                if (linkedValues.SequenceEqual(srcValues))
                 {
                     yield return $"Expected method `{src} to have it's {propertyDescription} modified, however, the {propertyDescription} were the same as the original\n{FormattingUtils.FormatSequenceCompareFailureMessage(linkedValues, srcValues)}";
                 }
@@ -828,14 +828,14 @@ namespace Mono.Linker.Tests.TestCasesRunner
             else if (expectedSequenceAttribute != null)
             {
                 var expected = getExpectFromSequenceAttribute(expectedSequenceAttribute).ToArray();
-                if (!linkedValues.ToHashSet().SetEquals(expected.ToHashSet()))
+                if (!linkedValues.SequenceEqual(expected))
                 {
                     yield return $"Expected method `{src} to have it's {propertyDescription} modified, however, the sequence of {propertyDescription} does not match the expected value\n{FormattingUtils.FormatSequenceCompareFailureMessage2(linkedValues, expected, srcValues)}";
                 }
             }
             else
             {
-                if (!linkedValues.ToHashSet().SetEquals(srcValues.ToHashSet()))
+                if (!linkedValues.SequenceEqual(srcValues))
                 {
                     yield return $"Expected method `{src} to have it's {propertyDescription} unchanged, however, the {propertyDescription} differ from the original\n{FormattingUtils.FormatSequenceCompareFailureMessage(linkedValues, srcValues)}";
                 }
@@ -847,7 +847,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
             var expected = original.MainModule.AllDefinedTypes()
                 .SelectMany(t => GetCustomAttributeCtorValues<string>(t, nameof(KeptReferenceAttribute)))
                 .Select(ReduceAssemblyFileNameOrNameToNameOnly)
-                .ToHashSet();
+                .ToArray();
 
             /*
              - The test case will always need to have at least 1 reference.
@@ -858,14 +858,14 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
              Once 1 kept reference attribute is used, the test will need to define all of of it's expected references
             */
-            if (expected.Count == 0)
+            if (expected.Length == 0)
                 yield break;
 
             var actual = linked.MainModule.AssemblyReferences
                 .Select(name => name.Name)
-                .ToHashSet();
+                .ToArray();
 
-            if (!expected.SetEquals(actual))
+            if (!expected.SequenceEqual(actual))
                 yield return $"Expected references `{string.Join(", ", expected)}` do not match actual references `{string.Join(", ", actual)}`";
         }
 
@@ -906,7 +906,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
             var expectedTypes = original.MainModule.AllDefinedTypes()
                 .SelectMany(t => GetCustomAttributeCtorValues<TypeReference>(t, nameof(KeptExportedTypeAttribute)).Select(l => l.FullName));
 
-            if (!linked.MainModule.ExportedTypes.Select(l => l.FullName).ToHashSet().SetEquals(expectedTypes.ToHashSet()))
+            if (!linked.MainModule.ExportedTypes.Select(l => l.FullName).SequenceEqual(expectedTypes))
                 yield return $"Exported types do not match expected.";
         }
 
@@ -949,33 +949,54 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
         protected virtual IEnumerable<string> VerifyCustomAttributes(ICustomAttributeProvider src, ICustomAttributeProvider linked)
         {
-            var expectedAttrs = GetExpectedAttributes(src).ToHashSet();
-            var linkedAttrs = FilterLinkedAttributes(linked).ToHashSet();
-            if (!linkedAttrs.SetEquals(expectedAttrs))
+            var expectedAttrs = GetExpectedAttributes(src).ToArray();
+            var linkedAttrs = FilterLinkedAttributes(linked).ToList();
+
+            var missingExpected = new List<ExpectedAttributeComparisonInfo>();
+            foreach (var attr in expectedAttrs)
             {
-                var missing = $"Missing: {string.Join(", ", expectedAttrs.Except(linkedAttrs))}";
-                var extra = $"Extra: {string.Join(", ", linkedAttrs.Except(expectedAttrs))}";
-                string name = src switch
+                var match = linkedAttrs.FirstOrDefault(l =>
+                {
+                    if (l.TypeFullName != attr.TypeFullName)
+                        return false;
+
+                    if (attr.CheckParameters)
+                        return attr.ParameterValues.SequenceEqual(l.ParameterValues);
+
+                    return true;
+                });
+                if (match != null)
+                    linkedAttrs.Remove(match);
+                else
+                    missingExpected.Add(attr);
+            }
+
+            if (missingExpected.Count > 0)
+                yield return $"Missing custom attributes on `{GetNameForSource()}`:\n{string.Join(Environment.NewLine, missingExpected.Select(a => $"    {a}").ToArray())}";
+
+            if (linkedAttrs.Count > 0)
+                yield return $"Extra custom attributes on `{GetNameForSource()}`:\n{string.Join(Environment.NewLine, linkedAttrs.Select(a => $"    {a}").ToArray())}";
+
+            string GetNameForSource()
+            {
+                return src switch
                 {
                     MethodReturnType m => $"return type of '{m.Method}'",
                     ParameterDefinition p => $"parameter '{p}' of method {p.Method}",
                     GenericParameter g => $"generic parameter '{g}' of {g.Owner}",
                     _ => src.ToString()
                 };
-
-                yield return string.Join(Environment.NewLine, $"Custom attributes on `{name}` are not matching:", missing, extra);
             }
         }
 
         protected virtual IEnumerable<string> VerifySecurityAttributes(ICustomAttributeProvider src, ISecurityDeclarationProvider linked)
         {
             var expectedAttrs = GetCustomAttributeCtorValues<object>(src, nameof(KeptSecurityAttribute))
-                .Select(attr => attr.ToString())
-                .ToHashSet();
+                .Select(attr => attr.ToString()).ToArray();
 
-            var linkedAttrs = FilterLinkedSecurityAttributes(linked).ToHashSet();
+            var linkedAttrs = FilterLinkedSecurityAttributes(linked).ToArray();
 
-            if (!linkedAttrs.SetEquals(expectedAttrs))
+            if (!linkedAttrs.SequenceEqual(expectedAttrs))
             {
                 var missing = $"Missing: {string.Join(", ", expectedAttrs.Except(linkedAttrs))}";
                 var extra = $"Extra: {string.Join(", ", linkedAttrs.Except(expectedAttrs))}";
@@ -1104,10 +1125,28 @@ namespace Mono.Linker.Tests.TestCasesRunner
             return false;
         }
 
-        protected static IEnumerable<string> GetExpectedAttributes(ICustomAttributeProvider original)
+        protected static IEnumerable<ExpectedAttributeComparisonInfo> GetExpectedAttributes(ICustomAttributeProvider original)
         {
-            foreach (var expectedAttrs in GetCustomAttributeCtorValues<object>(original, nameof(KeptAttributeAttribute)))
-                yield return expectedAttrs.ToString();
+            foreach (var expectedAttrs in original.CustomAttributes.Where(w => w.AttributeType.Name == nameof(KeptAttributeAttribute)))
+            {
+                if (expectedAttrs.Constructor.Parameters.Count == 1)
+                    yield return new ExpectedAttributeComparisonInfo(false, (expectedAttrs.ConstructorArguments[0].Value as object).ToString(), Array.Empty<string>());
+                else if (expectedAttrs.Constructor.Parameters.Count == 2)
+                {
+                    var expectedParameters = ((CustomAttributeArgument[])expectedAttrs.ConstructorArguments[1].Value).Select(a =>
+                    {
+                        var arg = (CustomAttributeArgument)a.Value;
+                        if (arg.Value == null)
+                            return "null";
+                        return arg.Value.ToString();
+                    }).ToArray();
+                    yield return new ExpectedAttributeComparisonInfo(true, (expectedAttrs.ConstructorArguments[0].Value as object).ToString(), expectedParameters);
+                }
+                else
+                {
+                    throw new ArgumentException($"Unhandled {nameof(KeptAttributeAttribute)} constructor with {expectedAttrs.Constructor.Parameters.Count} parameters.");
+                }
+            }
 
             // The name of the generated fixed buffer type is a little tricky.
             // Some versions of csc name it `<fieldname>e__FixedBuffer0`
@@ -1120,7 +1159,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
                     Assert.Fail($"Could not locate original fixed field for {srcDefinition}");
 
                 foreach (var additionalExpectedAttributesFromFixedField in GetCustomAttributeCtorValues<object>(fixedField, nameof(KeptAttributeOnFixedBufferTypeAttribute)))
-                    yield return additionalExpectedAttributesFromFixedField.ToString();
+                    yield return new ExpectedAttributeComparisonInfo(false, additionalExpectedAttributesFromFixedField.ToString(), Array.Empty<string>());
             }
         }
 
@@ -1129,7 +1168,7 @@ namespace Mono.Linker.Tests.TestCasesRunner
         /// </summary>
         /// <param name="linked"></param>
         /// <returns></returns>
-        protected virtual IEnumerable<string> FilterLinkedAttributes(ICustomAttributeProvider linked)
+        protected virtual IEnumerable<ActualAttributeComparisonInfo> FilterLinkedAttributes(ICustomAttributeProvider linked)
         {
             foreach (var attr in linked.CustomAttributes)
             {
@@ -1161,7 +1200,9 @@ namespace Mono.Linker.Tests.TestCasesRunner
                         break;
                 }
 
-                yield return attr.AttributeType.FullName;
+                yield return new ActualAttributeComparisonInfo(
+                    attr.AttributeType.FullName,
+                    GetCustomAttributeConstructorArgumentValues(attr).Select(p => p == null ? "null" : p.ToString()).ToArray());
             }
         }
 
@@ -1315,17 +1356,17 @@ namespace Mono.Linker.Tests.TestCasesRunner
 
             // C# doesn't have syntax for annotating generic parameter constraints with arbitrary attributes,
             // so expected attributes on generic parameter constraints are specified on the generic parameter itself.
-            HashSet<(string ConstraintType, string AttributeType)> expectedConstraintAttributes = src.CustomAttributes
+            (string ConstraintType, string AttributeType)[] expectedConstraintAttributes = src.CustomAttributes
                 .Where(a => IsKeptAttributeOnConstraint(a))
                 .Select(a => (a.ConstructorArguments[0].Value.ToString(), a.ConstructorArguments[1].Value.ToString()))
-                .ToHashSet();
+                .ToArray();
 
-            HashSet<(string ConstraintType, string AttributeType)> linkedConstraintAttributes = linked.Constraints
+            (string ConstraintType, string AttributeType)[] linkedConstraintAttributes = linked.Constraints
                 .Where(c => c.HasCustomAttributes)
                 .SelectMany(c => c.CustomAttributes.Select(a => (c.ConstraintType.FullName, a.AttributeType.FullName)))
-                .ToHashSet();
+                .ToArray();
 
-            if (!expectedConstraintAttributes.SetEquals(linkedConstraintAttributes))
+            if (!expectedConstraintAttributes.SequenceEqual(linkedConstraintAttributes))
             {
                 var missing = $"Missing: {string.Join(", ", expectedConstraintAttributes.Except(linkedConstraintAttributes).Select(c => $"{c.AttributeType} on {c.ConstraintType}"))}";
                 var extra = $"Extra: {string.Join(", ", linkedConstraintAttributes.Except(expectedConstraintAttributes).Select(c => $"{c.AttributeType} on {c.ConstraintType}"))}";
@@ -1479,6 +1520,67 @@ namespace Mono.Linker.Tests.TestCasesRunner
         protected static IEnumerable<string> GetStringArrayAttributeValue(CustomAttribute attribute)
         {
             return ((CustomAttributeArgument[])attribute.ConstructorArguments[0].Value)?.Select(arg => arg.Value.ToString());
+        }
+
+        protected static IEnumerable<object> GetCustomAttributeConstructorArgumentValues(CustomAttribute attribute)
+        {
+            foreach (var argument in attribute.ConstructorArguments)
+            {
+                if (argument.Value is CustomAttributeArgument nestedArgument)
+                    yield return nestedArgument.Value;
+                else
+                    yield return argument.Value;
+            }
+        }
+
+        protected class ExpectedAttributeComparisonInfo
+        {
+            public readonly bool CheckParameters;
+            public readonly string TypeFullName;
+            public readonly string[] ParameterValues;
+
+            public ExpectedAttributeComparisonInfo(bool checkParameters, string typeFullName, string[] parameterValues)
+            {
+                if (string.IsNullOrEmpty(typeFullName))
+                    throw new ArgumentNullException(nameof(typeFullName));
+                if (parameterValues == null)
+                    throw new ArgumentNullException(nameof(parameterValues));
+                CheckParameters = checkParameters;
+                TypeFullName = typeFullName;
+                ParameterValues = parameterValues;
+            }
+
+            public override string ToString()
+            {
+                if (ParameterValues.Length == 0)
+                    return TypeFullName;
+
+                return $"{TypeFullName}({string.Join(",", ParameterValues)})";
+            }
+        }
+
+        protected class ActualAttributeComparisonInfo
+        {
+            public readonly string TypeFullName;
+            public readonly string[] ParameterValues;
+
+            public ActualAttributeComparisonInfo(string typeFullName, string[] parameterValues)
+            {
+                if (string.IsNullOrEmpty(typeFullName))
+                    throw new ArgumentNullException(nameof(typeFullName));
+                if (parameterValues == null)
+                    throw new ArgumentNullException(nameof(parameterValues));
+                TypeFullName = typeFullName;
+                ParameterValues = parameterValues;
+            }
+
+            public override string ToString()
+            {
+                if (ParameterValues.Length == 0)
+                    return TypeFullName;
+
+                return $"{TypeFullName}({string.Join(",", ParameterValues)})";
+            }
         }
     }
 }


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/97605 introduced a pattern that regressed test coverage and in some cases broke asserting.  There were a few different regressions.

1) The introduction of `ToHashSet()` results in deduplication.  In some cases this was harmless, but it others it causes very real problems.  `VerifyBodyProperties` is used by `VerifyInstructions` which means the test framework was deduplicating before asserting bodies were unchanged. 

2) `SetEquals` removed ordering requirements.  This was never necessary and in some places really undermines coverage.  If a method body had it's instructions scrambled the test would still happily pass.

This PR removes the `ToHashSet()` and `SetEquals()` usages from `AssemblyChecker`.  There's another issue. 

https://github.com/dotnet/runtime/pull/116355 added the `TypeMap` test.  This test introduced a dependency on the deduplication behavior.  Roslyn will deduplicate assembly attributes at compile time.  This meant that there was no way to get this test passing using the existing pattern of defining `[KeptAttributeAttribute(typeof(TypeMapAttribute<UsedType>))]` multiple times in order to tell the test framework that multiple instances of an attribute should survive.  To solve this, we've upgrade the `KeptAttributeAttribute` assertion ability to allow for specifying the attribute parameters that you expect to survive.  This allows for matching up the `KeptAttributeAttribute` with the exact attribute instance.  This new ability is then used in `TypeMap` to update the assertions at the assembly level to pass with the deduplication removed.

Some new tests have been added to `TestFramework`.