### PR TITLE
Fix crossgen2 crash on Apple mobile for InstantiatedType token resolution in async methods

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -1484,6 +1484,8 @@ namespace Internal.JitInterface
                         token = (mdToken)MetadataTokens.GetToken(ecmaType.Handle);
                         module = ecmaType.Module;
                         return new ModuleToken(module, token);
+                    case TypeDesc typeDesc:
+                        return _compilation.NodeFactory.Resolver.GetModuleTokenForType(typeDesc, allowDynamicallyCreatedReference: true, throwIfNotFound: true);
                     default:
                         throw new NotImplementedException($"Unsupported token resolution for {resultDef.GetType()}");
                 }


### PR DESCRIPTION
Fixes a regression introduced in #124203 where crossgen2 crashes with `NotImplementedException: Unsupported token resolution for Internal.TypeSystem.InstantiatedType` when compiling async methods that reference generic type instantiations (e.g., `CallStruct1M0<T>`) on Apple mobile platforms.

## Problem

The `GetModuleTokenForType` local function in `HandleToModuleToken` handles `SignatureMethodVariable`, `ParameterizedType`, and `EcmaType`, but does not handle `InstantiatedType`. When async resumption stubs resolve tokens for instantiated generic types, the code falls through to the `default` case and throws.

Affected jobs in `runtime-extra-platforms` pipeline:
- `iossimulator-arm64 Release AllSubsets_CoreCLR_RuntimeTests`
- `iossimulator-x64 Release AllSubsets_CoreCLR_RuntimeTests`
- `tvossimulator-arm64 Release AllSubsets_CoreCLR_RuntimeTests`

**Failed build:** https://dev.azure.com/dnceng-public/public/_build/results?buildId=1329675&view=results