### PR TITLE
Re-enable runtime async on iOS/Android tests

### DIFF
--- a/eng/testing/tests.targets
+++ b/eng/testing/tests.targets
@@ -5,8 +5,6 @@
     and ('$(TestReadyToRun)' != 'true' or '$(UseRuntimeAsync)' == 'true')
     and '$(UseNativeAOTRuntime)' != 'true'
     and '$(TargetOS)' != 'wasi'
-    and '$(TargetOS)' != 'android'
-    and '$(TargetsAppleMobile)' != 'true'
     and '$(RuntimeFlavor)' != 'Mono'
     and '$(UseRuntimeAsync)' != 'false'">
     <EnablePreviewFeatures>true</EnablePreviewFeatures>


### PR DESCRIPTION
This change removes the exclusions for Android and Apple mobile targets from the runtime async test configuration in eng/testing/tests.targets.

Runtime async was previously disabled for these platforms. This PR re-enables it by removing the `TargetOS != android` and `TargetsAppleMobile != true` conditions, allowing runtime async tests to run on iOS and Android alongside other supported platforms.

This follows the same pattern as #125430, which recently enabled runtime async (v2) for wasm/coreclr tests.