### PR TITLE
[cDAC] Implement GetArgumentByIndex and GetLocalVariableByIndex on ClrDataFrame

### DIFF
--- a/docs/design/datacontracts/DebugInfo.md
+++ b/docs/design/datacontracts/DebugInfo.md
@@ -293,7 +293,7 @@ Version 1 packs each bounds entry using: `[2 bits sourceType][nativeDeltaBits][i
 
 Version 2 extends this to three independent flag bits for source type and so uses: `[3 bits sourceFlags][nativeDeltaBits][ilOffsetBits]`.
 
-Source type bits (low → high):
+Source type bits (low -> high):
 | Bit | Mask | Meaning |
 | --- | --- | --- |
 | 0 | 0x1 | `CallInstruction` |
@@ -311,3 +311,80 @@ if ((encoded & 0x4) != 0) sourceType |= SourceTypes.Async; // New bit
 ```
 
 After masking the 3 bits, shift them out before reading native delta and IL offset fields as before.
+
+### Variable Location APIs (Version 2+)
+
+Version 2 adds support for decoding native variable location info from the Vars section of the debug info blob.
+
+Additional APIs:
+```csharp
+// Describes the kind of location where a variable is stored.
+public enum DebugVarLocKind
+{
+    Register,
+    Stack,
+    RegisterRegister,
+    RegisterStack,
+    StackRegister,
+    DoubleStack,
+}
+
+public readonly struct DebugVarInfo
+{
+    public uint StartOffset { get; init; }
+    public uint EndOffset { get; init; }
+    public uint VarNumber { get; init; }
+    public DebugVarLocKind Kind { get; init; }
+    public bool IsByRef { get; init; }
+    public uint Register { get; init; }
+    public uint Register2 { get; init; }
+    public uint BaseRegister { get; init; }
+    public int StackOffset { get; init; }
+    public uint BaseRegister2 { get; init; }
+    public int StackOffset2 { get; init; }
+}
+
+// Given a code pointer, return the variable location info for the method.
+IEnumerable<DebugVarInfo> GetMethodVarInfo(TargetCodePointer pCode, out uint codeOffset);
+```
+
+Additional constants (Version 2):
+| Constant Name | Meaning | Value |
+| --- | --- | --- |
+| `MAX_ILNUM` | Bias for adjusted encoding of variable numbers | `0xfffffffc` (-4) |
+| `VLT_REG` | Variable is in a register | `0` |
+| `VLT_REG_BYREF` | Address of the variable is in a register | `1` |
+| `VLT_REG_FP` | Variable is in an FP register | `2` |
+| `VLT_STK` | Variable is on the stack | `3` |
+| `VLT_STK_BYREF` | Address of the variable is on the stack | `4` |
+| `VLT_REG_REG` | Variable lives in two registers | `5` |
+| `VLT_REG_STK` | Variable lives partly in a register and partly on the stack | `6` |
+| `VLT_STK_REG` | Reverse of VLT_REG_STK | `7` |
+| `VLT_STK2` | Variable lives in two stack slots | `8` |
+| `VLT_FPSTK` | Variable is on the floating-point stack | `9` |
+| `VLT_FIXED_VA` | Fixed argument in a varargs function | `10` |
+| `VLT_COUNT` | Number of valid VarLocType values | `11` |
+| `VLT_INVALID` | Sentinel for invalid locations | `12` |
+
+### Vars Data Encoding
+
+Each variable entry in the Vars section is nibble-encoded as follows:
+
+1. `startOffset` — encoded unsigned 32-bit integer
+2. `endOffset` — encoded as delta from `startOffset` (unsigned)
+3. `varNumber` — encoded as adjusted unsigned (`value - MAX_ILNUM`)
+4. `VarLocType` — encoded unsigned 32-bit integer
+5. Location fields depend on the `VarLocType`:
+
+| VarLocType | Fields (in encoding order) |
+| --- | --- |
+| `VLT_REG`, `VLT_REG_FP`, `VLT_REG_BYREF` | register (encoded unsigned) |
+| `VLT_STK`, `VLT_STK_BYREF` | baseRegister (encoded unsigned), stackOffset (encoded signed, x86: ×4) |
+| `VLT_REG_REG` | register1 (encoded unsigned), register2 (encoded unsigned) |
+| `VLT_REG_STK` | register (encoded unsigned), baseRegister (encoded unsigned), stackOffset (encoded signed, x86: ×4) |
+| `VLT_STK_REG` | stackOffset (encoded signed, x86: ×4), baseRegister (encoded unsigned), register (encoded unsigned) |
+| `VLT_STK2` | baseRegister (encoded unsigned), stackOffset (encoded signed, x86: ×4) |
+| `VLT_FPSTK` | fpRegister (encoded unsigned) |
+| `VLT_FIXED_VA` | offset (encoded unsigned) |
+
+Signed integers are encoded using the same unsigned scheme, with the sign bit stored in bit 0 (`value = unsigned >> 1`, negate if `unsigned & 1`). On x86, stack offsets are DWORD-aligned and stored divided by `sizeof(DWORD)`.

--- a/docs/design/datacontracts/RuntimeTypeSystem.md
+++ b/docs/design/datacontracts/RuntimeTypeSystem.md
@@ -87,6 +87,8 @@ partial interface IRuntimeTypeSystem : IContract
     // HasTypeParam will return true for cases where this is the interop view, and false for normal valuetypes.
     public virtual CorElementType GetSignatureCorElementType(TypeHandle typeHandle);
 
+    // return true if the TypeHandle represents an enum type.
+    bool IsEnum(TypeHandle typeHandle);
     // return true if the TypeHandle represents an array, and set the rank to either 0 (if the type is not an array), or the rank number if it is.
     bool IsArray(TypeHandle typeHandle, out uint rank);
     TypeHandle GetTypeParam(TypeHandle typeHandle);
@@ -687,6 +689,22 @@ Contracts used:
             return (CorElementType)(TypeAndFlags & 0xFF);
         }
         return default(CorElementType);
+    }
+
+    // Enums have Category_PrimitiveValueType in their MethodTable flags and their
+    // InternalCorElementType is a primitive type (I1, U1, I2, U2, I4, U4, I8, U8),
+    // not ValueType. Regular primitive value types (IntPtr/UIntPtr) have Category_TruePrimitive.
+    public bool IsEnum(TypeHandle typeHandle)
+    {
+        if (!typeHandle.IsMethodTable())
+            return false;
+
+        CorElementType sigType = GetSignatureCorElementType(typeHandle);
+        if (sigType != CorElementType.ValueType)
+            return false;
+
+        CorElementType internalType = (CorElementType)GetClassData(typeHandle).InternalCorElementType;
+        return internalType != CorElementType.ValueType;
     }
 
     // return true if the TypeHandle represents an array, and set the rank to either 0 (if the type is not an array), or the rank number if it is.

--- a/docs/design/datacontracts/StackWalk.md
+++ b/docs/design/datacontracts/StackWalk.md
@@ -25,6 +25,9 @@ TargetPointer GetMethodDescPtr(TargetPointer framePtr);
 
 // Gets the method desc pointer associated with a given IStackDataFrameHandle
 TargetPointer GetMethodDescPtr(IStackDataFrameHandle stackDataFrameHandle);
+
+// Gets the instruction pointer from the current frame's context.
+TargetPointer GetInstructionPointer(IStackDataFrameHandle stackDataFrameHandle);
 ```
 
 ## Version 1
@@ -377,6 +380,11 @@ This API is implemeted as follows:
 5. Check if the current context IP is a managed context using the ExecutionManager contract. If it is a managed context, use the ExecutionManager context to find the related MethodDesc and return the pointer to it.
 ```csharp
 TargetPointer GetMethodDescPtr(IStackDataFrameHandle stackDataFrameHandle)
+```
+
+`GetInstructionPointer` returns the instruction pointer (IP) from the current frame's context. This is the address of the instruction being executed (or about to be executed) in the method associated with this frame.
+```csharp
+TargetPointer GetInstructionPointer(IStackDataFrameHandle stackDataFrameHandle)
 ```
 
 ### x86 Specifics

--- a/src/coreclr/vm/util.cpp
+++ b/src/coreclr/vm/util.cpp
@@ -244,7 +244,11 @@ SIZE_T GetRegOffsInCONTEXT(ICorDebugInfo::RegNum regNum)
     case ICorDebugInfo::REGNUM_RCX: return offsetof(CONTEXT, Rcx);
     case ICorDebugInfo::REGNUM_RDX: return offsetof(CONTEXT, Rdx);
     case ICorDebugInfo::REGNUM_RBX: return offsetof(CONTEXT, Rbx);
-    case ICorDebugInfo::REGNUM_RSP: return offsetof(CONTEXT, Rsp);
+    // TODO: AMBIENT_SP isn't necessarily the same value as RSP (see x86 TODO above).
+    // This is a best-effort approximation matching the pattern used by other platforms.
+    case ICorDebugInfo::REGNUM_RSP:
+    case ICorDebugInfo::REGNUM_AMBIENT_SP:
+                                    return offsetof(CONTEXT, Rsp);
     case ICorDebugInfo::REGNUM_RBP: return offsetof(CONTEXT, Rbp);
     case ICorDebugInfo::REGNUM_RSI: return offsetof(CONTEXT, Rsi);
     case ICorDebugInfo::REGNUM_RDI: return offsetof(CONTEXT, Rdi);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IDebugInfo.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IDebugInfo.cs
@@ -34,6 +34,57 @@ public readonly struct OffsetMapping
     public SourceTypes SourceType { get; init; }
 }
 
+/// <summary>
+/// Describes the kind of location where a variable is stored.
+/// This is a stable public enum that abstracts over runtime-internal VarLocType values.
+/// </summary>
+public enum DebugVarLocKind
+{
+    Register,
+    Stack,
+    RegisterRegister,
+    RegisterStack,
+    StackRegister,
+    DoubleStack,
+}
+
+/// <summary>
+/// Describes the location of a native variable at a particular native offset range.
+/// This is a stable public type exposed by the DebugInfo contract.
+/// </summary>
+public readonly struct DebugVarInfo
+{
+    public uint StartOffset { get; init; }
+    public uint EndOffset { get; init; }
+    public uint VarNumber { get; init; }
+    public DebugVarLocKind Kind { get; init; }
+    public bool IsByRef { get; init; }
+
+    /// <summary>Primary register number (Register, RegisterRegister, RegisterStack, StackRegister).</summary>
+    public uint Register { get; init; }
+    /// <summary>Second register number (RegisterRegister).</summary>
+    public uint Register2 { get; init; }
+    /// <summary>Stack base register number (Stack, DoubleStack, StackRegister, RegisterStack).</summary>
+    public uint BaseRegister { get; init; }
+    /// <summary>Stack offset from base register (Stack, DoubleStack, StackRegister).</summary>
+    public int StackOffset { get; init; }
+    /// <summary>Second stack base register (RegisterStack).</summary>
+    public uint BaseRegister2 { get; init; }
+    /// <summary>Second stack offset (RegisterStack).</summary>
+    public int StackOffset2 { get; init; }
+}
+
+/// <summary>
+/// Describes a resolved physical location for a variable value.
+/// A variable can span up to 2 locations (e.g., split across register and stack).
+/// </summary>
+public readonly struct NativeVarLocation
+{
+    public ulong AddressOrValue { get; init; }
+    public ulong Size { get; init; }
+    public bool IsRegisterValue { get; init; }
+}
+
 public interface IDebugInfo : IContract
 {
     static string IContract.Name { get; } = nameof(DebugInfo);
@@ -46,6 +97,11 @@ public interface IDebugInfo : IContract
     /// Given a code pointer, return the associated native/IL offset mapping and codeOffset.
     /// </summary>
     IEnumerable<OffsetMapping> GetMethodNativeMap(TargetCodePointer pCode, bool preferUninstrumented, out uint codeOffset) => throw new NotImplementedException();
+    /// <summary>
+    /// Given a code pointer, return the variable location info for the method.
+    /// Each entry describes where a variable is stored at a particular native offset range.
+    /// </summary>
+    IEnumerable<DebugVarInfo> GetMethodVarInfo(TargetCodePointer pCode, out uint codeOffset) => throw new NotImplementedException();
 }
 
 public readonly struct DebugInfo : IDebugInfo

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IDebugInfo.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IDebugInfo.cs
@@ -74,17 +74,6 @@ public readonly struct DebugVarInfo
     public int StackOffset2 { get; init; }
 }
 
-/// <summary>
-/// Describes a resolved physical location for a variable value.
-/// A variable can span up to 2 locations (e.g., split across register and stack).
-/// </summary>
-public readonly struct NativeVarLocation
-{
-    public ulong AddressOrValue { get; init; }
-    public ulong Size { get; init; }
-    public bool IsRegisterValue { get; init; }
-}
-
 public interface IDebugInfo : IContract
 {
     static string IContract.Name { get; } = nameof(DebugInfo);

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IRuntimeTypeSystem.cs
@@ -140,6 +140,9 @@ public interface IRuntimeTypeSystem : IContract
     // HasTypeParam will return true for cases where this is the interop view
     CorElementType GetSignatureCorElementType(TypeHandle typeHandle) => throw new NotImplementedException();
 
+    // return true if the TypeHandle represents an enum type.
+    bool IsEnum(TypeHandle typeHandle) => throw new NotImplementedException();
+
     // return true if the TypeHandle represents an array, and set the rank to either 0 (if the type is not an array), or the rank number if it is.
     bool IsArray(TypeHandle typeHandle, out uint rank) => throw new NotImplementedException();
     TypeHandle GetTypeParam(TypeHandle typeHandle) => throw new NotImplementedException();

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Contracts/IStackWalk.cs
@@ -18,6 +18,7 @@ public interface IStackWalk : IContract
     string GetFrameName(TargetPointer frameIdentifier) => throw new NotImplementedException();
     TargetPointer GetMethodDescPtr(TargetPointer framePtr) => throw new NotImplementedException();
     TargetPointer GetMethodDescPtr(IStackDataFrameHandle stackDataFrameHandle) => throw new NotImplementedException();
+    TargetPointer GetInstructionPointer(IStackDataFrameHandle stackDataFrameHandle) => throw new NotImplementedException();
 }
 
 public struct StackWalk : IStackWalk

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/CorDbHResults.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/CorDbHResults.cs
@@ -6,4 +6,5 @@ namespace Microsoft.Diagnostics.DataContractReader;
 public static class CorDbgHResults
 {
     public const int CORDBG_E_READVIRTUAL_FAILURE = unchecked((int)0x80131c49);
+    public const int ERROR_BUFFER_OVERFLOW = unchecked((int)0x8007006F); // HRESULT_FROM_WIN32(ERROR_BUFFER_OVERFLOW)
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DebugInfo/DebugInfoHelpers.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DebugInfo/DebugInfoHelpers.cs
@@ -9,16 +9,39 @@ using ILCompiler.Reflection.ReadyToRun;
 namespace Microsoft.Diagnostics.DataContractReader.Contracts;
 
 /// <summary>
-/// Shared bounds decoding helpers for DebugInfo contract versions.
+/// Shared bounds and vars decoding helpers for DebugInfo contract versions.
 /// V1: 2-bit enumerated source type.
 /// V2: 3-bit flags (CallInstruction, StackEmpty, Async).
 /// </summary>
 internal static class DebugInfoHelpers
 {
+    /// <summary>
+    /// Mirrors ICorDebugInfo::VarLocType from cordebuginfo.h.
+    /// Describes how a variable is stored at a particular point in native code.
+    /// </summary>
+    private enum VarLocType
+    {
+        VLT_REG,
+        VLT_REG_BYREF,
+        VLT_REG_FP,
+        VLT_STK,
+        VLT_STK_BYREF,
+        VLT_REG_REG,
+        VLT_REG_STK,
+        VLT_STK_REG,
+        VLT_STK2,
+        VLT_FPSTK,
+        VLT_FIXED_VA,
+        VLT_COUNT,
+        VLT_INVALID,
+    }
+
     private const uint IL_OFFSET_BIAS = unchecked((uint)-3);
     private const uint SOURCE_TYPE_BITS_V1 = 2;
     private const uint SOURCE_TYPE_BITS_V2 = 3;
 
+    // ICorDebugInfo::MAX_ILNUM sentinel value used for adjusted encoding of var numbers.
+    private const uint MAX_ILNUM = unchecked((uint)-4);
 
     internal static IEnumerable<OffsetMapping> DoBounds(NativeReader nativeReader, uint version)
     {
@@ -75,5 +98,94 @@ internal static class DebugInfoHelpers
                 curBoundsProcessed++;
             }
         }
+    }
+
+    /// <summary>
+    /// Decodes variable location info from the debug info vars section and produces
+    /// public <see cref="DebugVarInfo"/> entries directly.
+    /// Mirrors the native DoNativeVarInfo/TransferReader logic from debuginfostore.cpp.
+    /// </summary>
+    internal static IEnumerable<DebugVarInfo> DoVars(NativeReader nativeReader, bool isX86)
+    {
+        NibbleReader reader = new(nativeReader, 0);
+
+        uint varCount = reader.ReadUInt();
+        if (varCount == 0)
+            yield break;
+
+        for (uint i = 0; i < varCount; i++)
+        {
+            uint startOffset = reader.ReadUInt();
+            uint endOffset = startOffset + reader.ReadUInt();
+            uint varNumber = reader.ReadUInt() + MAX_ILNUM;
+            VarLocType locType = (VarLocType)reader.ReadUInt();
+
+            if (locType is VarLocType.VLT_INVALID or VarLocType.VLT_COUNT)
+                continue;
+
+            yield return locType switch
+            {
+                VarLocType.VLT_REG or VarLocType.VLT_REG_FP => new DebugVarInfo
+                {
+                    StartOffset = startOffset, EndOffset = endOffset, VarNumber = varNumber,
+                    Kind = DebugVarLocKind.Register, Register = reader.ReadUInt(),
+                },
+                VarLocType.VLT_REG_BYREF => new DebugVarInfo
+                {
+                    StartOffset = startOffset, EndOffset = endOffset, VarNumber = varNumber,
+                    Kind = DebugVarLocKind.Register, Register = reader.ReadUInt(), IsByRef = true,
+                },
+                VarLocType.VLT_STK => new DebugVarInfo
+                {
+                    StartOffset = startOffset, EndOffset = endOffset, VarNumber = varNumber,
+                    Kind = DebugVarLocKind.Stack, BaseRegister = reader.ReadUInt(), StackOffset = ReadEncodedStackOffset(reader, isX86),
+                },
+                VarLocType.VLT_STK_BYREF => new DebugVarInfo
+                {
+                    StartOffset = startOffset, EndOffset = endOffset, VarNumber = varNumber,
+                    Kind = DebugVarLocKind.Stack, BaseRegister = reader.ReadUInt(), StackOffset = ReadEncodedStackOffset(reader, isX86), IsByRef = true,
+                },
+                VarLocType.VLT_REG_REG => new DebugVarInfo
+                {
+                    StartOffset = startOffset, EndOffset = endOffset, VarNumber = varNumber,
+                    Kind = DebugVarLocKind.RegisterRegister, Register = reader.ReadUInt(), Register2 = reader.ReadUInt(),
+                },
+                VarLocType.VLT_REG_STK => new DebugVarInfo
+                {
+                    StartOffset = startOffset, EndOffset = endOffset, VarNumber = varNumber,
+                    Kind = DebugVarLocKind.RegisterStack, Register = reader.ReadUInt(), BaseRegister2 = reader.ReadUInt(), StackOffset2 = ReadEncodedStackOffset(reader, isX86),
+                },
+                VarLocType.VLT_STK_REG => new DebugVarInfo
+                {
+                    StartOffset = startOffset, EndOffset = endOffset, VarNumber = varNumber,
+                    Kind = DebugVarLocKind.StackRegister, StackOffset = ReadEncodedStackOffset(reader, isX86), BaseRegister = reader.ReadUInt(), Register = reader.ReadUInt(),
+                },
+                VarLocType.VLT_STK2 => new DebugVarInfo
+                {
+                    StartOffset = startOffset, EndOffset = endOffset, VarNumber = varNumber,
+                    Kind = DebugVarLocKind.DoubleStack, BaseRegister = reader.ReadUInt(), StackOffset = ReadEncodedStackOffset(reader, isX86),
+                },
+                // FPSTK and FIXED_VA: consume stream data to keep reader aligned, but no public
+                // DebugVarLocKind exists for these rarely-used location types.
+                VarLocType.VLT_FPSTK => ConsumeAndDefault(reader.ReadUInt(), startOffset, endOffset, varNumber),
+                VarLocType.VLT_FIXED_VA => ConsumeAndDefault(reader.ReadUInt(), startOffset, endOffset, varNumber),
+                _ => new DebugVarInfo
+                {
+                    StartOffset = startOffset, EndOffset = endOffset, VarNumber = varNumber,
+                },
+            };
+        }
+    }
+
+    private static DebugVarInfo ConsumeAndDefault(uint _, uint startOffset, uint endOffset, uint varNumber) => new()
+    {
+        StartOffset = startOffset, EndOffset = endOffset, VarNumber = varNumber,
+    };
+
+    private static int ReadEncodedStackOffset(NibbleReader reader, bool isX86)
+    {
+        int value = reader.ReadInt();
+        // On x86, stack offsets are DWORD-aligned and stored divided by sizeof(DWORD)
+        return isX86 ? value * sizeof(int) : value;
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DebugInfo/DebugInfo_2.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/DebugInfo/DebugInfo_2.cs
@@ -116,4 +116,36 @@ internal sealed class DebugInfo_2(Target target) : IDebugInfo
 
         return [];
     }
+
+    IEnumerable<DebugVarInfo> IDebugInfo.GetMethodVarInfo(TargetCodePointer pCode, out uint codeOffset)
+    {
+        if (_eman.GetCodeBlockHandle(pCode) is not CodeBlockHandle cbh)
+            throw new InvalidOperationException($"No CodeBlockHandle found for native code {pCode}.");
+        TargetPointer debugInfo = _eman.GetDebugInfo(cbh, out bool _);
+
+        // Compute code offset from the method's native code entry point, not from the code block start.
+        // GetStartAddress returns the start of the current code block (which may be a funclet for exception
+        // handlers). Variable location offsets are always relative to the method entry point, so we must use
+        // GetNativeCode from the MethodDesc — matching the native DAC's GetMethodVarInfo which uses
+        // NativeCodeVersion::GetNativeCode() for this purpose.
+        IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+        TargetPointer methodDescAddr = _eman.GetMethodDesc(cbh);
+        MethodDescHandle mdh = rts.GetMethodDescHandle(methodDescAddr);
+        TargetCodePointer nativeCodeStart = rts.GetNativeCode(mdh);
+        codeOffset = (uint)(CodePointerUtils.AddressFromCodePointer(pCode, _target) - CodePointerUtils.AddressFromCodePointer(nativeCodeStart, _target));
+
+        if (debugInfo == TargetPointer.Null)
+            return [];
+
+        DebugInfoChunks chunks = DecodeChunks(debugInfo);
+
+        if (chunks.VarsSize > 0)
+        {
+            bool isX86 = _target.Contracts.RuntimeInfo.GetTargetArchitecture() == RuntimeInfoArchitecture.X86;
+            NativeReader varsNativeReader = new(new TargetStream(_target, chunks.VarsStart, chunks.VarsSize), _target.IsLittleEndian);
+            return DebugInfoHelpers.DoVars(varsNativeReader, isX86);
+        }
+
+        return [];
+    }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/RuntimeTypeSystem_1.cs
@@ -735,6 +735,22 @@ internal partial struct RuntimeTypeSystem_1 : IRuntimeTypeSystem
         return default;
     }
 
+    public bool IsEnum(TypeHandle typeHandle)
+    {
+        // Enums have Category_PrimitiveValueType in their MethodTable flags and their
+        // InternalCorElementType is a primitive type (I1, U1, I2, U2, I4, U4, I8, U8),
+        // not ValueType. Regular primitive value types (IntPtr/UIntPtr) have Category_TruePrimitive.
+        if (!typeHandle.IsMethodTable())
+            return false;
+
+        CorElementType sigType = GetSignatureCorElementType(typeHandle);
+        if (sigType != CorElementType.ValueType)
+            return false;
+
+        CorElementType internalType = (CorElementType)GetClassData(typeHandle).InternalCorElementType;
+        return internalType != CorElementType.ValueType;
+    }
+
     // return true if the TypeHandle represents an array, and set the rank to either 0 (if the type is not an array), or the rank number if it is.
     public bool IsArray(TypeHandle typeHandle, out uint rank)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/StackWalk_1.cs
@@ -172,6 +172,12 @@ internal readonly struct StackWalk_1 : IStackWalk
         return TargetPointer.Null;
     }
 
+    TargetPointer IStackWalk.GetInstructionPointer(IStackDataFrameHandle stackDataFrameHandle)
+    {
+        StackDataFrameHandle handle = AssertCorrectHandle(stackDataFrameHandle);
+        return handle.Context.InstructionPointer;
+    }
+
     string IStackWalk.GetFrameName(TargetPointer frameIdentifier)
         => FrameIterator.GetFrameName(_target, frameIdentifier);
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataFrame.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataFrame.cs
@@ -210,10 +210,7 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
                     // signature, so for instance methods adjust the index down.
                     int mdIndex = (int)(header.IsInstance ? index : index + 1);
                     string? paramName = GetParameterName(mdReader, methodDef, mdIndex);
-                    if (paramName is not null)
-                    {
-                        OutputBufferHelpers.CopyStringToBuffer(name, bufLen, nameLen, paramName);
-                    }
+                    OutputBufferHelpers.CopyStringToBuffer(name, bufLen, nameLen, paramName ?? string.Empty);
                 }
                 else
                 {
@@ -296,7 +293,7 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
             if (nameLen is not null)
                 *nameLen = 0;
 
-            GetMethodInfo(out MethodDescHandle mdh, out MetadataReader mdReader, out MethodDefinition methodDef, out Contracts.ModuleHandle moduleHandle, out uint token);
+            GetMethodInfo(out MethodDescHandle mdh, out MetadataReader mdReader, out MethodDefinition methodDef, out Contracts.ModuleHandle moduleHandle, out _);
             GetMethodSignatureInfo(mdReader, methodDef, out SignatureHeader argHeader, out uint numArgs);
 
             uint numLocals = GetLocalVariableCount(mdh, moduleHandle);
@@ -440,6 +437,8 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
         header = blobReader.ReadSignatureHeader();
         if (header.Kind != SignatureKind.Method)
             throw new BadImageFormatException();
+        if (header.IsGeneric)
+            blobReader.ReadCompressedInteger(); // skip generic arity
         uint paramCount = (uint)blobReader.ReadCompressedInteger();
         numArgs = paramCount + (header.IsInstance ? 1u : 0u);
     }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataFrame.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataFrame.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
@@ -46,6 +48,10 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
             IStackWalk stackWalk = _target.Contracts.StackWalk;
             byte[] context = stackWalk.GetRawContext(_dataFrame);
 
+            // TODO(https://github.com/dotnet/runtime/issues/125791):
+            // Use contextFlags to compute the required size via ContextSizeForFlags
+            // (see native ClrDataFrame::GetContext in stack.cpp). Currently we always
+            // return the full platform context regardless of the requested flags.
             if (contextSize is not null)
                 *contextSize = (uint)context.Length;
 
@@ -135,36 +141,9 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
         try
         {
             *numArgs = 0;
-            IStackWalk stackWalk = _target.Contracts.StackWalk;
-            TargetPointer methodDesc = stackWalk.GetMethodDescPtr(_dataFrame);
-            if (methodDesc == TargetPointer.Null)
-                throw Marshal.GetExceptionForHR(/*E_NOINTERFACE*/ HResults.COR_E_INVALIDCAST)!;
-
-            // get module and token
-            IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
-            MethodDescHandle mdh = rts.GetMethodDescHandle(methodDesc);
-            TargetPointer mtAddr = rts.GetMethodTable(mdh);
-            TypeHandle typeHandle = rts.GetTypeHandle(mtAddr);
-            TargetPointer modulePtr = rts.GetModule(typeHandle);
-            ILoader loader = _target.Contracts.Loader;
-            Contracts.ModuleHandle moduleHandle = loader.GetModuleHandleFromModulePtr(modulePtr);
-            uint token = rts.GetMethodToken(mdh);
-
-            IEcmaMetadata ecmaMetadataContract = _target.Contracts.EcmaMetadata;
-            MethodDefinitionHandle methodDefHandle = MetadataTokens.MethodDefinitionHandle((int)token);
-            MetadataReader? mdReader = ecmaMetadataContract.GetMetadata(moduleHandle);
-            if (mdReader == null)
-                throw new NotImplementedException();
-
-            MethodDefinition methodDefinition = mdReader.GetMethodDefinition(methodDefHandle);
-            BlobHandle methodBlob = methodDefinition.Signature;
-            BlobReader blobReader = mdReader.GetBlobReader(methodBlob);
-
-            // see ECMA-335 II.23.2.1
-            SignatureHeader header = blobReader.ReadSignatureHeader();
-            if (header.Kind != SignatureKind.Method)
-                throw new BadImageFormatException();
-            *numArgs = (uint)blobReader.ReadCompressedInteger() + (header.IsInstance ? 1u : 0u);
+            GetMethodInfo(out _, out MetadataReader mdReader, out MethodDefinition methodDef, out _, out _);
+            GetMethodSignatureInfo(mdReader, methodDef, out _, out uint numArgsResult);
+            *numArgs = numArgsResult;
             if (*numArgs == 0)
                 hr = HResults.S_FALSE;
         }
@@ -191,7 +170,79 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
         uint bufLen,
         uint* nameLen,
         char* name)
-        => _legacyImpl is not null ? _legacyImpl.GetArgumentByIndex(index, arg, bufLen, nameLen, name) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+
+        int hrLegacy = HResults.S_OK;
+        IXCLRDataValue? legacyValue = null;
+        if (_legacyImpl is not null)
+        {
+            DacComNullableByRef<IXCLRDataValue> legacyArgOut = new(isNullRef: false);
+            hrLegacy = _legacyImpl.GetArgumentByIndex(index, legacyArgOut, bufLen, null, null);
+            if (hrLegacy >= 0)
+            {
+                legacyValue = legacyArgOut.Interface;
+            }
+        }
+
+        try
+        {
+            if (nameLen is not null)
+                *nameLen = 0;
+
+            GetMethodInfo(out MethodDescHandle mdh, out MetadataReader mdReader, out MethodDefinition methodDef, out Contracts.ModuleHandle moduleHandle, out _);
+            GetMethodSignatureInfo(mdReader, methodDef, out SignatureHeader header, out uint numArgs);
+
+            if (index >= numArgs)
+                throw Marshal.GetExceptionForHR(HResults.E_INVALIDARG)!;
+
+            // Resolve parameter name
+            if ((bufLen > 0 && name is not null) || nameLen is not null)
+            {
+                IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+                if (index == 0 && header.IsInstance)
+                {
+                    OutputBufferHelpers.CopyStringToBuffer(name, bufLen, nameLen, "this");
+                }
+                else if (!rts.IsNoMetadataMethod(mdh, out _))
+                {
+                    // Param indexing is 1-based in metadata. 'this' isn't in the
+                    // signature, so for instance methods adjust the index down.
+                    int mdIndex = (int)(header.IsInstance ? index : index + 1);
+                    string? paramName = GetParameterName(mdReader, methodDef, mdIndex);
+                    if (paramName is not null)
+                    {
+                        OutputBufferHelpers.CopyStringToBuffer(name, bufLen, nameLen, paramName);
+                    }
+                }
+                else
+                {
+                    OutputBufferHelpers.CopyStringToBuffer(name, bufLen, nameLen, string.Empty);
+                }
+            }
+
+            if (!arg.IsNullRef)
+            {
+                arg.Interface = CreateValueFromDebugInfo(
+                    header, isArg: true, sigIndex: index, varInfoSlot: index,
+                    legacyValue, mdh, moduleHandle);
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            // See AllowCdacSuccess in DebugExtensions.cs — the native DAC's MetaSig
+            // constructor can fail on certain frames (e.g., EH dispatch) where the cDAC
+            // succeeds via contract-based metadata access.
+            Debug.ValidateHResult(hr, hrLegacy, HResultValidationMode.AllowCdacSuccess);
+        }
+#endif
+        return hr;
+    }
 
     int IXCLRDataFrame.GetNumLocalVariables(uint* numLocals)
     {
@@ -199,45 +250,8 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
         try
         {
             *numLocals = 0;
-            IStackWalk stackWalk = _target.Contracts.StackWalk;
-            TargetPointer methodDesc = stackWalk.GetMethodDescPtr(_dataFrame);
-            if (methodDesc == TargetPointer.Null)
-                throw Marshal.GetExceptionForHR(/*E_NOINTERFACE*/ HResults.COR_E_INVALIDCAST)!;
-
-            IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
-            MethodDescHandle mdh = rts.GetMethodDescHandle(methodDesc);
-            if (!rts.IsIL(mdh))
-                throw Marshal.GetExceptionForHR(HResults.E_FAIL)!;
-
-            // get token and module from method desc
-            TargetPointer mtAddr = rts.GetMethodTable(mdh);
-            TypeHandle typeHandle = rts.GetTypeHandle(mtAddr);
-            TargetPointer modulePtr = rts.GetModule(typeHandle);
-            ILoader loader = _target.Contracts.Loader;
-            Contracts.ModuleHandle moduleHandle = loader.GetModuleHandleFromModulePtr(modulePtr);
-            uint token = rts.GetMethodToken(mdh);
-
-            TargetPointer ilHeader = loader.GetILHeader(moduleHandle, token);
-            if (ilHeader == TargetPointer.Null)
-                throw Marshal.GetExceptionForHR(HResults.E_FAIL)!;
-
-            if (!HeaderReaderHelpers.TryGetLocalVarSigToken(_target, ilHeader, out int localToken))
-                throw Marshal.GetExceptionForHR(HResults.E_FAIL)!;
-
-            IEcmaMetadata ecmaMetadataContract = _target.Contracts.EcmaMetadata;
-            MetadataReader? mdReader = ecmaMetadataContract.GetMetadata(moduleHandle);
-            if (mdReader == null)
-                throw new NotImplementedException();
-
-            StandaloneSignatureHandle localSignatureHandle = MetadataTokens.StandaloneSignatureHandle(localToken);
-            BlobHandle localSignatureBlob = mdReader.GetStandaloneSignature(localSignatureHandle).Signature;
-            BlobReader blobReader = mdReader.GetBlobReader(localSignatureBlob);
-
-            // see ECMA-335 II.23.2.6
-            SignatureHeader header = blobReader.ReadSignatureHeader();
-            if (header.Kind != SignatureKind.LocalVariables)
-                throw new BadImageFormatException();
-            *numLocals = (uint)blobReader.ReadCompressedInteger();
+            GetMethodInfo(out MethodDescHandle mdh, out _, out _, out Contracts.ModuleHandle moduleHandle, out _);
+            *numLocals = GetLocalVariableCount(mdh, moduleHandle);
         }
         catch (System.Exception ex)
         {
@@ -262,7 +276,59 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
         uint bufLen,
         uint* nameLen,
         char* name)
-        => _legacyImpl is not null ? _legacyImpl.GetLocalVariableByIndex(index, localVariable, bufLen, nameLen, name) : HResults.E_NOTIMPL;
+    {
+        int hr = HResults.S_OK;
+
+        int hrLegacy = HResults.S_OK;
+        IXCLRDataValue? legacyValue = null;
+        if (_legacyImpl is not null)
+        {
+            DacComNullableByRef<IXCLRDataValue> legacyLocalOut = new(isNullRef: false);
+            hrLegacy = _legacyImpl.GetLocalVariableByIndex(index, legacyLocalOut, bufLen, null, null);
+            if (hrLegacy >= 0)
+            {
+                legacyValue = legacyLocalOut.Interface;
+            }
+        }
+
+        try
+        {
+            if (nameLen is not null)
+                *nameLen = 0;
+
+            GetMethodInfo(out MethodDescHandle mdh, out MetadataReader mdReader, out MethodDefinition methodDef, out Contracts.ModuleHandle moduleHandle, out uint token);
+            GetMethodSignatureInfo(mdReader, methodDef, out SignatureHeader argHeader, out uint numArgs);
+
+            uint numLocals = GetLocalVariableCount(mdh, moduleHandle);
+
+            if (index >= numLocals)
+                throw Marshal.GetExceptionForHR(HResults.E_INVALIDARG)!;
+
+            // Local variable names are not available
+            OutputBufferHelpers.CopyStringToBuffer(name, bufLen, nameLen, string.Empty);
+
+            if (!localVariable.IsNullRef)
+            {
+                // The locals are indexed immediately following the arguments in the NativeVarInfos.
+                // varInfoSlot = index + numArgs
+                localVariable.Interface = CreateValueFromDebugInfo(
+                    argHeader, isArg: false, sigIndex: index, varInfoSlot: index + numArgs,
+                    legacyValue, mdh, moduleHandle);
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            // See comment in GetArgumentByIndex.
+            Debug.ValidateHResult(hr, hrLegacy, HResultValidationMode.AllowCdacSuccess);
+        }
+#endif
+        return hr;
+    }
 
     int IXCLRDataFrame.GetCodeName(
         uint flags,
@@ -292,7 +358,7 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
             TargetPointer methodDesc = stackWalk.GetMethodDescPtr(_dataFrame);
 
             if (methodDesc == TargetPointer.Null)
-                throw Marshal.GetExceptionForHR(/*E_NOINTERFACE*/ HResults.COR_E_INVALIDCAST)!;
+                throw new InvalidCastException(); // E_NOINTERFACE
 
             MethodDescHandle mdh = rts.GetMethodDescHandle(methodDesc);
             TargetPointer appDomain = _target.ReadPointer(
@@ -332,4 +398,582 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
     // IXCLRDataFrame2 implementation
     int IXCLRDataFrame2.GetExactGenericArgsToken(DacComNullableByRef<IXCLRDataValue> genericToken)
         => _legacyImpl2 is not null ? _legacyImpl2.GetExactGenericArgsToken(genericToken) : HResults.E_NOTIMPL;
+
+    // ========== Metadata resolution helpers ==========
+
+    /// <summary>
+    /// Resolves the frame's MethodDesc into its module-level metadata objects.
+    /// Throws on failure (no MethodDesc, no metadata, etc.).
+    /// </summary>
+    private void GetMethodInfo(out MethodDescHandle mdh, out MetadataReader mdReader, out MethodDefinition methodDef, out Contracts.ModuleHandle moduleHandle, out uint token)
+    {
+        IStackWalk stackWalk = _target.Contracts.StackWalk;
+        TargetPointer methodDescPtr = stackWalk.GetMethodDescPtr(_dataFrame);
+        if (methodDescPtr == TargetPointer.Null)
+            throw new InvalidCastException(); // E_NOINTERFACE
+
+        IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+        mdh = rts.GetMethodDescHandle(methodDescPtr);
+        TargetPointer mtAddr = rts.GetMethodTable(mdh);
+        TypeHandle typeHandle = rts.GetTypeHandle(mtAddr);
+        TargetPointer modulePtr = rts.GetModule(typeHandle);
+        ILoader loader = _target.Contracts.Loader;
+        moduleHandle = loader.GetModuleHandleFromModulePtr(modulePtr);
+        token = rts.GetMethodToken(mdh);
+
+        IEcmaMetadata ecmaMetadataContract = _target.Contracts.EcmaMetadata;
+        MetadataReader? reader = ecmaMetadataContract.GetMetadata(moduleHandle);
+        if (reader is null)
+            throw new NotImplementedException();
+        mdReader = reader;
+
+        MethodDefinitionHandle methodDefHandle = MetadataTokens.MethodDefinitionHandle((int)token);
+        methodDef = mdReader.GetMethodDefinition(methodDefHandle);
+    }
+
+    /// <summary>
+    /// Parses the method signature to determine argument count and signature header.
+    /// </summary>
+    private static void GetMethodSignatureInfo(MetadataReader mdReader, MethodDefinition methodDef, out SignatureHeader header, out uint numArgs)
+    {
+        BlobReader blobReader = mdReader.GetBlobReader(methodDef.Signature);
+        header = blobReader.ReadSignatureHeader();
+        if (header.Kind != SignatureKind.Method)
+            throw new BadImageFormatException();
+        uint paramCount = (uint)blobReader.ReadCompressedInteger();
+        numArgs = paramCount + (header.IsInstance ? 1u : 0u);
+    }
+
+    /// <summary>
+    /// Creates a ClrDataValue by resolving variable locations for the current frame
+    /// via the DebugInfo contract. Mirrors the native ValueFromDebugInfo from stack.cpp.
+    /// </summary>
+    private ClrDataValue CreateValueFromDebugInfo(
+        SignatureHeader methodHeader,
+        bool isArg,
+        uint sigIndex,
+        uint varInfoSlot,
+        IXCLRDataValue? legacyImpl,
+        MethodDescHandle mdh,
+        Contracts.ModuleHandle moduleHandle)
+    {
+        IStackWalk stackWalk = _target.Contracts.StackWalk;
+        IDebugInfo debugInfo = _target.Contracts.DebugInfo;
+
+        TargetPointer ip = stackWalk.GetInstructionPointer(_dataFrame);
+        TargetCodePointer codePointer = new TargetCodePointer(ip.Value);
+        byte[] context = stackWalk.GetRawContext(_dataFrame);
+        IEnumerable<DebugVarInfo> varInfos = debugInfo.GetMethodVarInfo(codePointer, out uint codeOffset);
+        NativeVarLocation[] locations = FindAndResolveVarLocation(varInfos, codeOffset, varInfoSlot, context, _target);
+
+        // Determine value flags and adjust size for primitives.
+        // Read the raw method/local signature to determine type flags without requiring
+        // types to be loaded by the runtime (see https://github.com/dotnet/runtime/issues/125792).
+        // Only VAR/MVAR (generic parameters) require runtime type system resolution.
+        uint valueFlags;
+        int typeSize = -1;
+        if (isArg && sigIndex == 0 && methodHeader.IsInstance)
+        {
+            // 'this' parameter is always a reference
+            valueFlags = (uint)ClrDataValueFlag.IS_REFERENCE;
+        }
+        else
+        {
+            (valueFlags, typeSize) = ComputeFlagsFromSignature(isArg, sigIndex, methodHeader, mdh, moduleHandle);
+        }
+
+        // Match native DAC (ValueFromDebugInfo in stack.cpp): for primitives with a
+        // single location, shrink the location size to the actual type size. This is
+        // necessary because NativeVarLocations always sets size = sizeof(SIZE_T)
+        // (pointer-sized) for every location, regardless of the actual variable type.
+        //
+        // For value types (structs), no size adjustment is made — GetSize will always
+        // return the JIT storage size (pointer-sized per location), not the logical
+        // struct size. This matches the native DAC's behavior.
+        if ((valueFlags & (uint)ClrDataValueFlag.IS_PRIMITIVE) != 0
+            && typeSize > 0
+            && locations.Length == 1
+            && (ulong)typeSize < locations[0].Size)
+        {
+            locations =
+            [
+                new NativeVarLocation
+                {
+                    AddressOrValue = locations[0].AddressOrValue,
+                    Size = (ulong)typeSize,
+                    IsRegisterValue = locations[0].IsRegisterValue,
+                },
+            ];
+        }
+
+        return new ClrDataValue(_target, valueFlags, locations, legacyImpl);
+    }
+
+    // ========== Signature-based flag computation ==========
+
+    /// <summary>
+    /// Returns a BlobReader for the local variable signature of the given method,
+    /// or null if the method has no locals (tiny header or no local sig token).
+    /// </summary>
+    private BlobReader? GetLocalSignatureReader(MethodDescHandle mdh, Contracts.ModuleHandle moduleHandle, out MetadataReader mdReader)
+    {
+        IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+        uint token = rts.GetMethodToken(mdh);
+        ILoader loader = _target.Contracts.Loader;
+        TargetPointer ilHeader = loader.GetILHeader(moduleHandle, token);
+        if (ilHeader == TargetPointer.Null)
+        {
+            mdReader = null!;
+            return null;
+        }
+
+        const int FatFormatFlag = 0x0003;
+        const int FormatMask = 0x0007;
+        ushort sizeAndFlags = _target.Read<ushort>(ilHeader);
+        if ((sizeAndFlags & FormatMask) != FatFormatFlag)
+        {
+            mdReader = null!;
+            return null;
+        }
+
+        int localToken = _target.Read<int>(ilHeader + 8);
+        if (localToken == 0)
+        {
+            mdReader = null!;
+            return null;
+        }
+
+        mdReader = _target.Contracts.EcmaMetadata.GetMetadata(moduleHandle)!;
+        StandaloneSignatureHandle localSigHandle = MetadataTokens.StandaloneSignatureHandle(localToken);
+        BlobHandle localSigBlob = mdReader.GetStandaloneSignature(localSigHandle).Signature;
+        return mdReader.GetBlobReader(localSigBlob);
+    }
+
+    /// <summary>
+    /// Returns the count of local variables by reading the local signature header.
+    /// Returns 0 if the method has no locals.
+    /// </summary>
+    private uint GetLocalVariableCount(MethodDescHandle mdh, Contracts.ModuleHandle moduleHandle)
+    {
+        BlobReader? reader = GetLocalSignatureReader(mdh, moduleHandle, out _);
+        if (reader is null)
+            return 0;
+
+        BlobReader r = reader.Value;
+        r.ReadSignatureHeader();
+        return (uint)r.ReadCompressedInteger();
+    }
+
+    /// <summary>
+    /// Computes value flags by decoding the method or local signature using a custom
+    /// ISignatureTypeProvider that maps types directly to (Flags, Size) tuples.
+    /// Avoids requiring types to be loaded by the runtime
+    /// (see https://github.com/dotnet/runtime/issues/125792).
+    /// Only VAR/MVAR (generic parameters) require runtime type system resolution.
+    /// </summary>
+    private (uint Flags, int Size) ComputeFlagsFromSignature(
+        bool isArg, uint sigIndex, SignatureHeader methodHeader,
+        MethodDescHandle mdh, Contracts.ModuleHandle moduleHandle)
+    {
+        try
+        {
+            GetMethodInfo(out _, out MetadataReader mdReader, out MethodDefinition methodDef, out _, out _);
+            FlagSignatureTypeProvider provider = new(_target, moduleHandle);
+            SignatureDecoder<(uint Flags, int Size), MethodDescHandle> decoder = new(provider, mdReader, mdh);
+
+            if (isArg)
+            {
+                BlobReader sigReader = mdReader.GetBlobReader(methodDef.Signature);
+                MethodSignature<(uint Flags, int Size)> methodSig = decoder.DecodeMethodSignature(ref sigReader);
+                int paramIndex = methodHeader.IsInstance ? (int)sigIndex - 1 : (int)sigIndex;
+                return methodSig.ParameterTypes[paramIndex];
+            }
+            else
+            {
+                BlobReader? localReader = GetLocalSignatureReader(mdh, moduleHandle, out _);
+                if (localReader is null)
+                    return ((uint)ClrDataValueFlag.DEFAULT, -1);
+
+                BlobReader sigReader = localReader.Value;
+                ImmutableArray<(uint Flags, int Size)> localFlags = decoder.DecodeLocalSignature(ref sigReader);
+                return localFlags[(int)sigIndex];
+            }
+        }
+        catch (System.Exception)
+        {
+            return ((uint)ClrDataValueFlag.DEFAULT, -1);
+        }
+    }
+
+    /// <summary>
+    /// Maps a CorElementType to ClrDataValueFlag and primitive type size.
+    /// Used for generic parameter resolution (VAR/MVAR) where we get the
+    /// concrete type's CorElementType from the runtime type system.
+    /// </summary>
+    private static (uint Flags, int Size) MapCorElementTypeToFlags(CorElementType elementType)
+    {
+        return elementType switch
+        {
+            CorElementType.Boolean => ((uint)ClrDataValueFlag.IS_PRIMITIVE, 1),
+            CorElementType.I1 or CorElementType.U1 => ((uint)ClrDataValueFlag.IS_PRIMITIVE, 1),
+            CorElementType.Char or CorElementType.I2 or CorElementType.U2 => ((uint)ClrDataValueFlag.IS_PRIMITIVE, 2),
+            CorElementType.I4 or CorElementType.U4 or CorElementType.R4 => ((uint)ClrDataValueFlag.IS_PRIMITIVE, 4),
+            CorElementType.I8 or CorElementType.U8 or CorElementType.R8 => ((uint)ClrDataValueFlag.IS_PRIMITIVE, 8),
+            CorElementType.I or CorElementType.U => ((uint)ClrDataValueFlag.IS_PRIMITIVE, -1),
+            CorElementType.String or CorElementType.Object or CorElementType.Class
+                or CorElementType.SzArray or CorElementType.Array => ((uint)ClrDataValueFlag.IS_REFERENCE, -1),
+            CorElementType.Ptr => ((uint)ClrDataValueFlag.IS_POINTER, -1),
+            CorElementType.ValueType => ((uint)ClrDataValueFlag.IS_VALUE_TYPE, -1),
+            _ => ((uint)ClrDataValueFlag.DEFAULT, -1),
+        };
+    }
+
+    /// <summary>
+    /// Checks if a type's base type refers to System.Enum.
+    /// </summary>
+    private static bool IsEnumBaseType(MetadataReader mdReader, EntityHandle baseType)
+    {
+        if (baseType.IsNil)
+            return false;
+
+        string? baseTypeName = null;
+        string? baseTypeNamespace = null;
+
+        if (baseType.Kind == HandleKind.TypeReference)
+        {
+            TypeReference baseRef = mdReader.GetTypeReference((TypeReferenceHandle)baseType);
+            baseTypeName = mdReader.GetString(baseRef.Name);
+            baseTypeNamespace = mdReader.GetString(baseRef.Namespace);
+        }
+        else if (baseType.Kind == HandleKind.TypeDefinition)
+        {
+            TypeDefinition baseDef = mdReader.GetTypeDefinition((TypeDefinitionHandle)baseType);
+            baseTypeName = mdReader.GetString(baseDef.Name);
+            baseTypeNamespace = mdReader.GetString(baseDef.Namespace);
+        }
+
+        return baseTypeNamespace == "System" && baseTypeName == "Enum";
+    }
+
+    /// <summary>
+    /// ISignatureTypeProvider that maps signature types directly to ClrDataValue flags
+    /// and primitive type sizes. Avoids constructing TypeHandles (and the runtime type
+    /// loading that implies) for everything except generic parameters (VAR/MVAR).
+    /// </summary>
+    private sealed class FlagSignatureTypeProvider : ISignatureTypeProvider<(uint Flags, int Size), MethodDescHandle>
+    {
+        // ECMA-335 II.23.2.8 rawTypeKind values passed by SignatureDecoder
+        private const byte RawTypeKind_ValueType = 0x11; // ELEMENT_TYPE_VALUETYPE
+        private const byte RawTypeKind_Class = 0x12;     // ELEMENT_TYPE_CLASS
+
+        private readonly Target _target;
+        private readonly Contracts.ModuleHandle _moduleHandle;
+
+        public FlagSignatureTypeProvider(Target target, Contracts.ModuleHandle moduleHandle)
+        {
+            _target = target;
+            _moduleHandle = moduleHandle;
+        }
+
+        // --- ISimpleTypeProvider ---
+
+        public (uint Flags, int Size) GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode switch
+        {
+            PrimitiveTypeCode.Boolean => ((uint)ClrDataValueFlag.IS_PRIMITIVE, 1),
+            PrimitiveTypeCode.SByte or PrimitiveTypeCode.Byte => ((uint)ClrDataValueFlag.IS_PRIMITIVE, 1),
+            PrimitiveTypeCode.Char or PrimitiveTypeCode.Int16 or PrimitiveTypeCode.UInt16 => ((uint)ClrDataValueFlag.IS_PRIMITIVE, 2),
+            PrimitiveTypeCode.Int32 or PrimitiveTypeCode.UInt32 or PrimitiveTypeCode.Single => ((uint)ClrDataValueFlag.IS_PRIMITIVE, 4),
+            PrimitiveTypeCode.Int64 or PrimitiveTypeCode.UInt64 or PrimitiveTypeCode.Double => ((uint)ClrDataValueFlag.IS_PRIMITIVE, 8),
+            PrimitiveTypeCode.IntPtr or PrimitiveTypeCode.UIntPtr => ((uint)ClrDataValueFlag.IS_PRIMITIVE, -1),
+            // String and Object are PrimitiveTypeCodes but are GC references
+            PrimitiveTypeCode.String or PrimitiveTypeCode.Object => ((uint)ClrDataValueFlag.IS_REFERENCE, -1),
+            // Void, TypedReference — no meaningful flag
+            _ => ((uint)ClrDataValueFlag.DEFAULT, -1),
+        };
+
+        public (uint Flags, int Size) GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) =>
+            rawTypeKind switch
+            {
+                RawTypeKind_Class => ((uint)ClrDataValueFlag.IS_REFERENCE, -1),
+                RawTypeKind_ValueType => CheckEnumFromTypeDef(reader, handle),
+                _ => ((uint)ClrDataValueFlag.DEFAULT, -1),
+            };
+
+        public (uint Flags, int Size) GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) =>
+            rawTypeKind switch
+            {
+                RawTypeKind_Class => ((uint)ClrDataValueFlag.IS_REFERENCE, -1),
+                RawTypeKind_ValueType => CheckEnumFromTypeRef(reader, handle),
+                _ => ((uint)ClrDataValueFlag.DEFAULT, -1),
+            };
+
+        // --- IConstructedTypeProvider ---
+
+        public (uint Flags, int Size) GetPointerType((uint Flags, int Size) elementType)
+            => ((uint)ClrDataValueFlag.IS_POINTER, -1);
+
+        // ByRef — native DAC's GetTypeFieldValueFlags returns DEFAULT for ELEMENT_TYPE_BYREF
+        public (uint Flags, int Size) GetByReferenceType((uint Flags, int Size) elementType)
+            => ((uint)ClrDataValueFlag.DEFAULT, -1);
+
+        public (uint Flags, int Size) GetSZArrayType((uint Flags, int Size) elementType)
+            => ((uint)ClrDataValueFlag.IS_REFERENCE, -1);
+
+        public (uint Flags, int Size) GetArrayType((uint Flags, int Size) elementType, ArrayShape shape)
+            => ((uint)ClrDataValueFlag.IS_REFERENCE, -1);
+
+        // GenericInstantiation — the base type carries the CLASS/VALUETYPE distinction
+        public (uint Flags, int Size) GetGenericInstantiation((uint Flags, int Size) genericType, ImmutableArray<(uint Flags, int Size)> typeArguments)
+            => genericType;
+
+        // --- ISignatureTypeProvider ---
+
+        // Function pointers are mapped to IntPtr in the native DAC
+        public (uint Flags, int Size) GetFunctionPointerType(MethodSignature<(uint Flags, int Size)> signature)
+            => ((uint)ClrDataValueFlag.IS_PRIMITIVE, -1);
+
+        public (uint Flags, int Size) GetModifiedType((uint Flags, int Size) modifier, (uint Flags, int Size) unmodifiedType, bool isRequired)
+            => unmodifiedType;
+
+        public (uint Flags, int Size) GetPinnedType((uint Flags, int Size) elementType)
+            => elementType;
+
+        public (uint Flags, int Size) GetTypeFromSpecification(MetadataReader reader, MethodDescHandle genericContext, TypeSpecificationHandle handle, byte rawTypeKind)
+            => ((uint)ClrDataValueFlag.DEFAULT, -1);
+
+        // --- Generic parameter resolution (needs runtime type system) ---
+
+        public (uint Flags, int Size) GetGenericMethodParameter(MethodDescHandle mdh, int index)
+        {
+            try
+            {
+                IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+                ReadOnlySpan<TypeHandle> methodInst = rts.GetGenericMethodInstantiation(mdh);
+                return ResolveGenericParam(rts, methodInst[index]);
+            }
+            catch (System.Exception) { return ((uint)ClrDataValueFlag.DEFAULT, -1); }
+        }
+
+        public (uint Flags, int Size) GetGenericTypeParameter(MethodDescHandle mdh, int index)
+        {
+            try
+            {
+                IRuntimeTypeSystem rts = _target.Contracts.RuntimeTypeSystem;
+                TargetPointer mtAddr = rts.GetMethodTable(mdh);
+                TypeHandle declaringType = rts.GetTypeHandle(mtAddr);
+                ReadOnlySpan<TypeHandle> typeInst = rts.GetInstantiation(declaringType);
+                return ResolveGenericParam(rts, typeInst[index]);
+            }
+            catch (System.Exception) { return ((uint)ClrDataValueFlag.DEFAULT, -1); }
+        }
+
+        private static (uint Flags, int Size) ResolveGenericParam(IRuntimeTypeSystem rts, TypeHandle resolvedType)
+        {
+            CorElementType elementType = rts.GetSignatureCorElementType(resolvedType);
+            (uint flags, int size) = MapCorElementTypeToFlags(elementType);
+
+            if (flags == (uint)ClrDataValueFlag.IS_VALUE_TYPE && rts.IsEnum(resolvedType))
+                flags = (uint)ClrDataValueFlag.IS_ENUM;
+
+            return (flags, size);
+        }
+
+        // --- Enum detection helpers ---
+
+        private static (uint Flags, int Size) CheckEnumFromTypeDef(MetadataReader reader, TypeDefinitionHandle handle)
+        {
+            TypeDefinition typeDef = reader.GetTypeDefinition(handle);
+            if (IsEnumBaseType(reader, typeDef.BaseType))
+                return ((uint)ClrDataValueFlag.IS_ENUM, -1);
+
+            return ((uint)ClrDataValueFlag.IS_VALUE_TYPE, -1);
+        }
+
+        private (uint Flags, int Size) CheckEnumFromTypeRef(MetadataReader reader, TypeReferenceHandle handle)
+        {
+            // For TypeRefs, try to resolve in the same module's TypeDef table.
+            TypeReference typeRef = reader.GetTypeReference(handle);
+            MetadataReader moduleReader = _target.Contracts.EcmaMetadata.GetMetadata(_moduleHandle)!;
+            foreach (TypeDefinitionHandle tdh in moduleReader.TypeDefinitions)
+            {
+                TypeDefinition td = moduleReader.GetTypeDefinition(tdh);
+                if (moduleReader.StringComparer.Equals(td.Name, reader.GetString(typeRef.Name))
+                    && moduleReader.StringComparer.Equals(td.Namespace, reader.GetString(typeRef.Namespace)))
+                {
+                    if (IsEnumBaseType(moduleReader, td.BaseType))
+                        return ((uint)ClrDataValueFlag.IS_ENUM, -1);
+                    break;
+                }
+            }
+
+            return ((uint)ClrDataValueFlag.IS_VALUE_TYPE, -1);
+        }
+    }
+
+    private static string? GetParameterName(MetadataReader mdReader, MethodDefinition methodDef, int sequenceNumber)
+    {
+        foreach (ParameterHandle paramHandle in methodDef.GetParameters())
+        {
+            Parameter param = mdReader.GetParameter(paramHandle);
+            if (param.SequenceNumber == sequenceNumber)
+            {
+                return mdReader.GetString(param.Name);
+            }
+        }
+
+        return null;
+    }
+
+    #region Variable Location Resolution
+
+    /// <summary>
+    /// Finds the matching DebugVarInfo entry for a given variable number and code offset,
+    /// then resolves it to physical locations using the provided CPU context bytes.
+    /// </summary>
+    private static NativeVarLocation[] FindAndResolveVarLocation(
+        IEnumerable<DebugVarInfo> varInfos,
+        uint codeOffset,
+        uint varNumber,
+        byte[] context,
+        Target target)
+    {
+        foreach (DebugVarInfo varInfo in varInfos)
+        {
+            if (varInfo.StartOffset <= codeOffset &&
+                varInfo.EndOffset >= codeOffset &&
+                varInfo.VarNumber == varNumber)
+            {
+                IPlatformAgnosticContext platformContext = IPlatformAgnosticContext.GetContextForPlatform(target);
+                platformContext.FillFromBuffer(context);
+
+                return ResolveVarLocation(varInfo, platformContext, target);
+            }
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// Resolves a DebugVarInfo entry to physical NativeVarLocation(s)
+    /// using the given CPU context. Mirrors the native NativeVarLocations() from util.cpp.
+    /// </summary>
+    private static NativeVarLocation[] ResolveVarLocation(
+        DebugVarInfo varInfo,
+        IPlatformAgnosticContext context,
+        Target target)
+    {
+        int pointerSize = target.PointerSize;
+
+        return (varInfo.Kind, varInfo.IsByRef) switch
+        {
+            (DebugVarLocKind.Register, false) =>
+            [
+                new NativeVarLocation { AddressOrValue = ReadRegister(context, target, varInfo.Register), Size = (ulong)pointerSize, IsRegisterValue = true },
+            ],
+
+            (DebugVarLocKind.Register, true) => ResolveRegByRef(context, target, varInfo.Register, pointerSize),
+
+            (DebugVarLocKind.Stack, false) => ResolveStack(context, target, varInfo.BaseRegister, varInfo.StackOffset, pointerSize, deref: false),
+            (DebugVarLocKind.Stack, true) => ResolveStack(context, target, varInfo.BaseRegister, varInfo.StackOffset, pointerSize, deref: true),
+
+            (DebugVarLocKind.RegisterRegister, _) =>
+            [
+                new NativeVarLocation { AddressOrValue = ReadRegister(context, target, varInfo.Register), Size = (ulong)pointerSize, IsRegisterValue = true },
+                new NativeVarLocation { AddressOrValue = ReadRegister(context, target, varInfo.Register2), Size = (ulong)pointerSize, IsRegisterValue = true },
+            ],
+
+            (DebugVarLocKind.RegisterStack, _) =>
+            [
+                new NativeVarLocation { AddressOrValue = ReadRegister(context, target, varInfo.Register), Size = (ulong)pointerSize, IsRegisterValue = true },
+                new NativeVarLocation { AddressOrValue = ComputeStackAddress(context, target, varInfo.BaseRegister2, varInfo.StackOffset2), Size = (ulong)pointerSize, IsRegisterValue = false },
+            ],
+
+            (DebugVarLocKind.StackRegister, _) =>
+            [
+                new NativeVarLocation { AddressOrValue = ComputeStackAddress(context, target, varInfo.BaseRegister, varInfo.StackOffset), Size = (ulong)pointerSize, IsRegisterValue = false },
+                new NativeVarLocation { AddressOrValue = ReadRegister(context, target, varInfo.Register), Size = (ulong)pointerSize, IsRegisterValue = true },
+            ],
+
+            (DebugVarLocKind.DoubleStack, _) =>
+            [
+                new NativeVarLocation { AddressOrValue = ComputeStackAddress(context, target, varInfo.BaseRegister, varInfo.StackOffset), Size = 2 * (ulong)pointerSize, IsRegisterValue = false },
+            ],
+
+            _ => [],
+        };
+    }
+
+    private static NativeVarLocation[] ResolveRegByRef(IPlatformAgnosticContext context, Target target, uint register, int pointerSize)
+    {
+        // The register holds a pointer to the variable in target memory.
+        // Mark as IsRegisterValue=true to match the native DAC, which sets contextReg=true for
+        // VLT_REG_BYREF and copies the register bytes directly via memcpy in IntGetBytes.
+        // This means GetBytes returns the raw pointer value (matching the DAC), and
+        // GetLocationByIndex returns CLRDATA_VLOC_REGISTER (matching the DAC).
+        ulong regValue = ReadRegister(context, target, register);
+
+        return [new NativeVarLocation { AddressOrValue = regValue, Size = (ulong)pointerSize, IsRegisterValue = true }];
+    }
+
+    private static NativeVarLocation[] ResolveStack(IPlatformAgnosticContext context, Target target, uint baseRegister, int offset, int pointerSize, bool deref)
+    {
+        ulong addr = ComputeStackAddress(context, target, baseRegister, offset);
+        if (deref)
+            addr = DereferenceOrZero(target, addr);
+
+        return [new NativeVarLocation { AddressOrValue = addr, Size = (ulong)pointerSize, IsRegisterValue = false }];
+    }
+
+    private static ulong ComputeStackAddress(IPlatformAgnosticContext context, Target target, uint baseRegister, int offset)
+    {
+        ulong baseReg = ReadRegister(context, target, baseRegister);
+
+        return (ulong)((long)baseReg + offset);
+    }
+
+    /// <summary>
+    /// Reads a pointer from target memory, returning 0 on failure.
+    /// Matches native DereferenceByRefVar (util.cpp) which returns 0 when DacReadAll fails.
+    /// </summary>
+    private static ulong DereferenceOrZero(Target target, ulong addr)
+    {
+        try
+        {
+            return target.ReadPointer(addr);
+        }
+        catch (System.Exception)
+        {
+            return 0;
+        }
+    }
+
+    private static ulong ReadRegister(IPlatformAgnosticContext context, Target target, uint registerNumber)
+    {
+        if (context.TryReadRegister((int)registerNumber, out TargetNUInt value))
+            return value.Value;
+
+        // REGNUM_AMBIENT_SP is beyond the normal register range on every architecture.
+        // It represents the entry-time SP, not necessarily the current SP.
+        // Map it to the stack pointer as a best-effort approximation (see util.cpp).
+        int spRegisterNumber = GetStackPointerRegisterNumber(target);
+        if (spRegisterNumber >= 0 && context.TryReadRegister(spRegisterNumber, out value))
+            return value.Value;
+
+        return 0;
+    }
+
+    private static int GetStackPointerRegisterNumber(Target target)
+    {
+        RuntimeInfoArchitecture arch = target.Contracts.RuntimeInfo.GetTargetArchitecture();
+        return arch switch
+        {
+            RuntimeInfoArchitecture.X64 => 4,   // RSP
+            RuntimeInfoArchitecture.X86 => 4,   // ESP
+            RuntimeInfoArchitecture.Arm64 => 31, // SP
+            RuntimeInfoArchitecture.Arm => 13,   // SP
+            _ => -1,
+        };
+    }
+
+    #endregion
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataValue.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataValue.cs
@@ -9,6 +9,17 @@ using Microsoft.Diagnostics.DataContractReader.Contracts;
 
 namespace Microsoft.Diagnostics.DataContractReader.Legacy;
 
+/// <summary>
+/// Describes a resolved physical location for a variable value.
+/// A variable can span up to 2 locations (e.g., split across register and stack).
+/// </summary>
+public readonly struct NativeVarLocation
+{
+    public ulong AddressOrValue { get; init; }
+    public ulong Size { get; init; }
+    public bool IsRegisterValue { get; init; }
+}
+
 [GeneratedComClass]
 public sealed unsafe partial class ClrDataValue : IXCLRDataValue
 {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataValue.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataValue.cs
@@ -1,0 +1,363 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+
+namespace Microsoft.Diagnostics.DataContractReader.Legacy;
+
+[GeneratedComClass]
+public sealed unsafe partial class ClrDataValue : IXCLRDataValue
+{
+    private readonly Target _target;
+    private readonly IXCLRDataValue? _legacyImpl;
+    private readonly uint _flags;
+    private readonly ulong _totalSize;
+    private readonly NativeVarLocation[] _locations;
+
+    public ClrDataValue(
+        Target target,
+        uint flags,
+        NativeVarLocation[] locations,
+        IXCLRDataValue? legacyImpl)
+    {
+        _target = target;
+        _legacyImpl = legacyImpl;
+        _flags = flags;
+        _locations = locations;
+
+        if (_locations.Length > 0 && (_flags & (uint)ClrDataValueFlag.IS_REFERENCE) != 0)
+        {
+            _totalSize = (ulong)_target.PointerSize;
+        }
+        else
+        {
+            _totalSize = 0;
+            foreach (NativeVarLocation loc in _locations)
+            {
+                _totalSize += loc.Size;
+            }
+        }
+    }
+
+    int IXCLRDataValue.GetFlags(uint* flags)
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            *flags = _flags;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            uint flagsLocal;
+            int hrLocal = _legacyImpl.GetFlags(&flagsLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr >= 0)
+                Debug.Assert(*flags == flagsLocal, $"GetFlags cDAC: 0x{*flags:X}, DAC: 0x{flagsLocal:X}");
+        }
+#endif
+
+        return hr;
+    }
+
+    int IXCLRDataValue.GetAddress(ClrDataAddress* address)
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            *address = 0;
+            if (_locations.Length != 1 || _locations[0].IsRegisterValue)
+            {
+                throw new InvalidCastException(); // E_NOINTERFACE
+            }
+
+            *address = _locations[0].AddressOrValue;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            ClrDataAddress addressLocal;
+            int hrLocal = _legacyImpl.GetAddress(&addressLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr >= 0)
+                Debug.Assert((ulong)*address == (ulong)addressLocal, $"GetAddress cDAC: 0x{(ulong)*address:X}, DAC: 0x{(ulong)addressLocal:X}");
+        }
+#endif
+
+        return hr;
+    }
+
+    int IXCLRDataValue.GetSize(ulong* size)
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (_totalSize == 0)
+            {
+                *size = 0;
+                throw new InvalidCastException(); // E_NOINTERFACE
+            }
+
+            *size = _totalSize;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            ulong sizeLocal;
+            int hrLocal = _legacyImpl.GetSize(&sizeLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr >= 0)
+                Debug.Assert(*size == sizeLocal, $"GetSize cDAC: {*size}, DAC: {sizeLocal}");
+        }
+#endif
+
+        return hr;
+    }
+
+    int IXCLRDataValue.GetBytes(uint bufLen, uint* dataSize, byte* buffer)
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            if (_totalSize == 0)
+                throw new InvalidCastException(); // E_NOINTERFACE
+
+            if (dataSize is not null)
+                *dataSize = (uint)_totalSize;
+
+            if (bufLen < _totalSize)
+                throw Marshal.GetExceptionForHR(/*ERROR_BUFFER_OVERFLOW*/ CorDbgHResults.ERROR_BUFFER_OVERFLOW)!;
+
+            byte* dst = buffer;
+            foreach (NativeVarLocation loc in _locations)
+            {
+                if (loc.IsRegisterValue)
+                {
+                    int size = (int)loc.Size;
+                    ulong value = loc.AddressOrValue;
+                    for (int i = 0; i < size; i++)
+                    {
+                        dst[i] = (byte)(value & 0xFF);
+                        value >>= 8;
+                    }
+                }
+                else
+                {
+                    Span<byte> memBytes = new(dst, (int)loc.Size);
+                    _target.ReadBuffer(loc.AddressOrValue, memBytes);
+                }
+
+                dst += loc.Size;
+            }
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            byte[] legacyBuf = new byte[bufLen];
+            uint legacyDataSize;
+            int hrLocal;
+            fixed (byte* pLegacy = legacyBuf)
+            {
+                hrLocal = _legacyImpl.GetBytes(bufLen, &legacyDataSize, pLegacy);
+            }
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr >= 0 && hrLocal >= 0)
+            {
+                if (dataSize is not null)
+                    Debug.Assert(*dataSize == legacyDataSize, $"GetBytes dataSize cDAC: {*dataSize}, DAC: {legacyDataSize}");
+
+                int compareLen = (int)Math.Min(_totalSize, legacyDataSize);
+                for (int i = 0; i < compareLen; i++)
+                    Debug.Assert(buffer[i] == legacyBuf[i], $"GetBytes mismatch at byte {i}: cDAC: 0x{buffer[i]:X2}, DAC: 0x{legacyBuf[i]:X2}");
+            }
+        }
+#endif
+
+        return hr;
+    }
+
+    int IXCLRDataValue.SetBytes(uint bufLen, uint* dataSize, byte* buffer) => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.GetType(DacComNullableByRef<IXCLRDataTypeInstance> typeInstance) => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.GetNumFields(uint* numFields) => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.GetFieldByIndex(
+        uint index,
+        DacComNullableByRef<IXCLRDataValue> field,
+        uint bufLen,
+        uint* nameLen,
+        char* nameBuf,
+        uint* token)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.Request(uint reqCode, uint inBufferSize, byte* inBuffer, uint outBufferSize, byte* outBuffer)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.GetNumFields2(uint flags, IXCLRDataTypeInstance? fromType, uint* numFields)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.StartEnumFields(uint flags, IXCLRDataTypeInstance? fromType, ulong* handle)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.EnumField(
+        ulong* handle,
+        DacComNullableByRef<IXCLRDataValue> field,
+        uint nameBufLen,
+        uint* nameLen,
+        char* nameBuf,
+        uint* token)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.EndEnumFields(ulong handle) => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.StartEnumFieldsByName(char* name, uint nameFlags, uint fieldFlags, IXCLRDataTypeInstance? fromType, ulong* handle)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.EnumFieldByName(ulong* handle, DacComNullableByRef<IXCLRDataValue> field, uint* token)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.EndEnumFieldsByName(ulong handle) => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.GetFieldByToken(
+        uint token,
+        DacComNullableByRef<IXCLRDataValue> field,
+        uint bufLen,
+        uint* nameLen,
+        char* nameBuf)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.GetAssociatedValue(DacComNullableByRef<IXCLRDataValue> assocValue)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.GetAssociatedType(DacComNullableByRef<IXCLRDataTypeInstance> assocType)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.GetString(uint bufLen, uint* strLen, char* str) => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.GetArrayProperties(uint* rank, uint* totalElements, uint numDim, uint* dims, uint numBases, int* bases)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.GetArrayElement(uint numInd, int* indices, DacComNullableByRef<IXCLRDataValue> value)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.EnumField2(
+        ulong* handle,
+        DacComNullableByRef<IXCLRDataValue> field,
+        uint nameBufLen,
+        uint* nameLen,
+        char* nameBuf,
+        DacComNullableByRef<IXCLRDataModule> tokenScope,
+        uint* token)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.EnumFieldByName2(
+        ulong* handle,
+        DacComNullableByRef<IXCLRDataValue> field,
+        DacComNullableByRef<IXCLRDataModule> tokenScope,
+        uint* token)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.GetFieldByToken2(
+        IXCLRDataModule? tokenScope,
+        uint token,
+        DacComNullableByRef<IXCLRDataValue> field,
+        uint bufLen,
+        uint* nameLen,
+        char* nameBuf)
+        => HResults.E_NOTIMPL;
+
+    int IXCLRDataValue.GetNumLocations(uint* numLocs)
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            *numLocs = (uint)_locations.Length;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            uint numLocsLocal;
+            int hrLocal = _legacyImpl.GetNumLocations(&numLocsLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr >= 0)
+                Debug.Assert(*numLocs == numLocsLocal, $"GetNumLocations cDAC: {*numLocs}, DAC: {numLocsLocal}");
+        }
+#endif
+
+        return hr;
+    }
+
+    int IXCLRDataValue.GetLocationByIndex(uint loc, uint* flags, ClrDataAddress* arg)
+    {
+        int hr = HResults.S_OK;
+        try
+        {
+            *flags = 0;
+            *arg = 0;
+
+            if (loc >= (uint)_locations.Length)
+                throw new ArgumentException();
+
+            NativeVarLocation location = _locations[loc];
+            *flags = location.IsRegisterValue ? ClrDataVLocFlag.CLRDATA_VLOC_REGISTER : ClrDataVLocFlag.CLRDATA_VLOC_MEMORY;
+            *arg = location.IsRegisterValue ? 0 : location.AddressOrValue;
+        }
+        catch (System.Exception ex)
+        {
+            hr = ex.HResult;
+        }
+
+#if DEBUG
+        if (_legacyImpl is not null)
+        {
+            uint flagsLocal;
+            ClrDataAddress argLocal;
+            int hrLocal = _legacyImpl.GetLocationByIndex(loc, &flagsLocal, &argLocal);
+            Debug.ValidateHResult(hr, hrLocal);
+            if (hr >= 0)
+            {
+                Debug.Assert(*flags == flagsLocal, $"GetLocationByIndex[{loc}] flags cDAC: {*flags}, DAC: {flagsLocal}");
+                // Address comparison is best-effort: the native DAC does not handle REGNUM_AMBIENT_SP
+                // on AMD64 (returns garbage from GetRegOffsInCONTEXT's default case), so addresses may
+                // legitimately differ for variables stored relative to the ambient stack pointer.
+                if ((ulong)*arg != (ulong)argLocal)
+                {
+                    Debug.WriteLine($"GetLocationByIndex[{loc}] addr divergence - cDAC: 0x{(ulong)*arg:X}, DAC: 0x{(ulong)argLocal:X}");
+                }
+            }
+        }
+#endif
+
+        return hr;
+    }
+}

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/DebugExtensions.cs
@@ -20,6 +20,15 @@ internal enum HResultValidationMode
     /// same invalid input (e.g., InvalidOperationException vs E_INVALIDARG), producing different failing HRESULTs.
     /// </summary>
     AllowDivergentFailures,
+
+    /// <summary>
+    /// Like <see cref="AllowDivergentFailures"/>, but also allows the cDAC to succeed when the native DAC fails.
+    /// The native DAC's MetaSig constructor traverses MethodDesc -> Module -> MDImport -> signature blob via
+    /// DAC host pointers, and any intermediate read can throw under EX_TRY on certain frames (e.g., EH dispatch).
+    /// The cDAC reads the same metadata through contracts (EcmaMetadata -> PEImage -> metadata blob) which uses
+    /// a different pointer traversal path that doesn't hit the same failure.
+    /// </summary>
+    AllowCdacSuccess,
 }
 
 internal static class DebugExtensions
@@ -38,6 +47,7 @@ internal static class DebugExtensions
             {
                 HResultValidationMode.Exact => cdacHr == dacHr,
                 HResultValidationMode.AllowDivergentFailures => cdacHr == dacHr || (cdacHr < 0 && dacHr < 0),
+                HResultValidationMode.AllowCdacSuccess => cdacHr == dacHr || (cdacHr < 0 && dacHr < 0) || (cdacHr >= 0 && dacHr < 0),
                 _ => cdacHr == dacHr,
             };
             Debug.Assert(match, $"HResult mismatch - cDAC: 0x{unchecked((uint)cdacHr):X8}, DAC: 0x{unchecked((uint)dacHr):X8} ({Path.GetFileName(filePath)}:{lineNumber})");

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/IXCLRData.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/IXCLRData.cs
@@ -957,6 +957,25 @@ public unsafe partial interface IXCLRDataExceptionState
     int GetTask(DacComNullableByRef<IXCLRDataTask> task);
 }
 
+[Flags]
+public enum ClrDataValueFlag : uint
+{
+    DEFAULT = 0x00000000,
+    IS_PRIMITIVE = 0x00000001,
+    IS_VALUE_TYPE = 0x00000002,
+    IS_STRING = 0x00000004,
+    IS_ARRAY = 0x00000008,
+    IS_REFERENCE = 0x00000010,
+    IS_POINTER = 0x00000020,
+    IS_ENUM = 0x00000040,
+}
+
+public static class ClrDataVLocFlag
+{
+    public const uint CLRDATA_VLOC_MEMORY = 0x00;
+    public const uint CLRDATA_VLOC_REGISTER = 0x01;
+}
+
 [GeneratedComInterface]
 [Guid("96EC93C7-1000-4e93-8991-98D8766E6666")]
 public unsafe partial interface IXCLRDataValue

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/LocalVariables/LocalVariables.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/LocalVariables/LocalVariables.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <DumpTypes>Full</DumpTypes>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+</Project>

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/LocalVariables/Program.cs
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/LocalVariables/Program.cs
@@ -1,0 +1,275 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+/// <summary>
+/// Debuggee for cDAC dump tests - exercises local variable and argument
+/// inspection via IXCLRDataValue across a variety of types and calling patterns.
+/// Each method uses NoInlining and try/finally+GC.KeepAlive to ensure locals
+/// are stored as real IL local variables with debug info.
+///
+/// Type coverage by frame (simple -> complex):
+///
+///   PrimitiveVars          - I4, R8, BOOLEAN, CHAR, U1, I2, I8, R4
+///   NativeIntVars          - I (nint), U (nuint)
+///   StructVars             - VALUETYPE (TinyStruct 1B, SmallStruct 8B, LargeStruct 32B)
+///   ReferenceTypeVars      - STRING, CLASS, VALUETYPE(enum), OBJECT, SZARRAY
+///   GenericInstAndByRefVars - GENERICINST+CLASS, GENERICINST+VALUETYPE, BYREF
+///   InstanceMethodOnStruct - VALUETYPE as arg to static method
+///   InstanceMethodVars    - instance 'this' (IS_REFERENCE) + I4
+///   ClassGenericVars       - VAR (class-level generic parameter)
+///   MethodGenericVars      - MVAR (method-level generic parameter)
+///   SingleDimArrayVars     - SZARRAY (single-dimensional array)
+///   MultiDimArrayVars      - ARRAY (multi-dimensional array)
+///   PointerVars            - PTR (unmanaged pointer), FNPTR (function pointer)
+/// </summary>
+internal static class Program
+{
+    public struct TinyStruct { public byte Value; }
+    public struct SmallStruct { public int X; public int Y; }
+    public struct LargeStruct { public long A; public long B; public long C; public long D; }
+
+    public class SimpleClass { public int Value; public string? Name; }
+
+    public enum Color
+    {
+        Red,
+        Green,
+        Blue,
+    }
+
+    private static void Main()
+    {
+        PrimitiveVars(42, 3.14, true, 'Z', (byte)0xFF, (short)-1, 123456789L, 2.5f);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void PrimitiveVars(int intArg, double doubleArg, bool boolArg, char charArg,
+        byte byteArg, short shortArg, long longArg, float floatArg)
+    {
+        int localInt = intArg + 1;
+        double localDouble = doubleArg * 2;
+        bool localBool = !boolArg;
+        char localChar = (char)(charArg - 1);
+        byte localByte = (byte)(byteArg - 1);
+        short localShort = (short)(shortArg + 1);
+        long localLong = longArg * 2;
+        float localFloat = floatArg + 1.0f;
+        try
+        {
+            NativeIntVars((nint)0x1234, (nuint)0x5678);
+        }
+        finally
+        {
+            GC.KeepAlive(localInt);
+            GC.KeepAlive(localDouble);
+            GC.KeepAlive(localBool);
+            GC.KeepAlive(localChar);
+            GC.KeepAlive(localByte);
+            GC.KeepAlive(localShort);
+            GC.KeepAlive(localLong);
+            GC.KeepAlive(localFloat);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void NativeIntVars(nint nintArg, nuint nuintArg)
+    {
+        nint localNint = nintArg;
+        nuint localNuint = nuintArg;
+        try
+        {
+            StructVars(
+                new TinyStruct { Value = 42 },
+                new SmallStruct { X = 10, Y = 20 },
+                new LargeStruct { A = 1, B = 2, C = 3, D = 4 });
+        }
+        finally
+        {
+            GC.KeepAlive(localNint);
+            GC.KeepAlive(localNuint);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void StructVars(TinyStruct tinyArg, SmallStruct smallArg, LargeStruct largeArg)
+    {
+        TinyStruct localTiny = tinyArg;
+        SmallStruct localSmall = smallArg;
+        LargeStruct localLarge = largeArg;
+        try
+        {
+            ReferenceTypeVars("test", new SimpleClass { Value = 99, Name = "hello" }, Color.Blue, 42, [1, 2, 3]);
+        }
+        finally
+        {
+            GC.KeepAlive(localTiny);
+            GC.KeepAlive(localSmall);
+            GC.KeepAlive(localLarge);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void ReferenceTypeVars(string stringArg, SimpleClass classArg, Color enumArg, object boxedArg, int[] arrayArg)
+    {
+        string localString = stringArg + " world";
+        SimpleClass localClass = classArg;
+        Color localEnum = enumArg;
+        object localBoxed = boxedArg;
+        int[] localArray = arrayArg;
+        try
+        {
+            int refTarget = 42;
+            GenericInstAndByRefVars(new List<int> { 1, 2, 3 }, new KeyValuePair<int, string>(1, "one"), ref refTarget);
+        }
+        finally
+        {
+            GC.KeepAlive(localString);
+            GC.KeepAlive(localClass);
+            GC.KeepAlive(localEnum);
+            GC.KeepAlive(localBoxed);
+            GC.KeepAlive(localArray);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void GenericInstAndByRefVars(List<int> listArg, KeyValuePair<int, string> kvpArg, ref int refArg)
+    {
+        List<int> localList = listArg;
+        KeyValuePair<int, string> localKvp = kvpArg;
+        int localRefCopy = refArg;
+        try
+        {
+            InstanceMethodOnStruct(new SmallStruct { X = 100, Y = 200 });
+        }
+        finally
+        {
+            GC.KeepAlive(localList);
+            GC.KeepAlive(localKvp);
+            GC.KeepAlive(localRefCopy);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void InstanceMethodOnStruct(SmallStruct s)
+    {
+        var wrapper = new InstanceWrapper(s.X);
+        wrapper.InstanceMethodVars(s.Y);
+    }
+
+    public class InstanceWrapper
+    {
+        private readonly int _value;
+        public InstanceWrapper(int value) => _value = value;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void InstanceMethodVars(int extra)
+        {
+            int localSum = _value + extra;
+            try
+            {
+                var container = new GenericContainer<int>(localSum);
+                container.ClassGenericVars(localSum);
+            }
+            finally
+            {
+                GC.KeepAlive(localSum);
+            }
+        }
+    }
+
+    public class GenericContainer<T>
+    {
+        private readonly T _item;
+        public GenericContainer(T item) => _item = item;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void ClassGenericVars(T value)
+        {
+            T localCopy = value;
+            try
+            {
+                MethodGenericVars<T, string>(localCopy, _item?.ToString() ?? "generic");
+            }
+            finally
+            {
+                GC.KeepAlive(localCopy);
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void MethodGenericVars<T1, T2>(T1 arg1, T2 arg2)
+    {
+        T1 local1 = arg1;
+        T2 local2 = arg2;
+        try
+        {
+            SingleDimArrayVars([10, 20, 30]);
+        }
+        finally
+        {
+            GC.KeepAlive(local1);
+            GC.KeepAlive(local2);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void SingleDimArrayVars(int[] arrayArg)
+    {
+        int[] localArray = arrayArg;
+        try
+        {
+            MultiDimArrayVars(new int[2, 3] { { 1, 2, 3 }, { 4, 5, 6 } });
+        }
+        finally
+        {
+            GC.KeepAlive(localArray);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void MultiDimArrayVars(int[,] multiDimArg)
+    {
+        int[,] localMultiDim = multiDimArg;
+        try
+        {
+            unsafe
+            {
+                int stackValue = 999;
+                PointerVars(&stackValue, &DoubleValue);
+            }
+        }
+        finally
+        {
+            GC.KeepAlive(localMultiDim);
+        }
+    }
+
+    private static int DoubleValue(int x) => x * 2;
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static unsafe void PointerVars(int* ptrArg, delegate*<int, int> funcPtrArg)
+    {
+        int localDeref = *ptrArg;
+        int localFuncResult = funcPtrArg(localDeref);
+        try
+        {
+            Crash();
+        }
+        finally
+        {
+            GC.KeepAlive(localDeref);
+            GC.KeepAlive(localFuncResult);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void Crash()
+    {
+        Environment.FailFast("cDAC dump test: LocalVariables debuggee intentional crash");
+    }
+}

--- a/src/native/managed/cdac/tests/DumpTests/IXCLRDataFrameDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/IXCLRDataFrameDumpTests.cs
@@ -201,7 +201,7 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
             uint numArgs;
             int hr = xclrFrame.GetNumArguments(&numArgs);
 
-            // MethodA(int depth) is static with 1 parameter → numArgs == 1.
+            // MethodA(int depth) is static with 1 parameter -> numArgs == 1.
             AssertHResult(HResults.S_OK, hr);
             Assert.Equal(1u, numArgs);
 
@@ -220,7 +220,6 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
     {
         InitializeDumpTest(config);
         IStackWalk stackWalk = Target.Contracts.StackWalk;
-        IRuntimeTypeSystem rts = Target.Contracts.RuntimeTypeSystem;
         ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
 
         foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
@@ -233,6 +232,7 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
             if (name is not "MethodB")
                 continue;
 
+            IRuntimeTypeSystem rts = Target.Contracts.RuntimeTypeSystem;
             MethodDescHandle mdh = rts.GetMethodDescHandle(md);
             Assert.True(rts.IsIL(mdh), "MethodB should be an IL method");
 
@@ -280,6 +280,227 @@ public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
         }
 
         Assert.Fail("No managed frames with MethodDesc found");
+    }
+
+    // ========== GetArgumentByIndex ==========
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetArgumentByIndex_ReturnsValueForMethodADepthArg(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IStackWalk stackWalk = Target.Contracts.StackWalk;
+        ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
+
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        {
+            TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
+            if (md == TargetPointer.Null)
+                continue;
+
+            string? name = DumpTestHelpers.GetMethodName(Target, md);
+            if (name is not "MethodA")
+                continue;
+
+            ClrDataFrame frame = new ClrDataFrame(Target, dataFrame, legacyImpl: null);
+            IXCLRDataFrame xclrFrame = frame;
+
+            // MethodA(int depth) is static with 1 argument
+            DacComNullableByRef<IXCLRDataValue> argOut = new(isNullRef: false);
+            int hr = xclrFrame.GetArgumentByIndex(0, argOut, 0, null, null);
+
+            AssertHResult(HResults.S_OK, hr);
+            Assert.NotNull(argOut.Interface);
+
+            return;
+        }
+
+        Assert.Fail("MethodA not found on the crashing thread's stack");
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetArgumentByIndex_ReturnsParameterName(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IStackWalk stackWalk = Target.Contracts.StackWalk;
+        ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
+
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        {
+            TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
+            if (md == TargetPointer.Null)
+                continue;
+
+            string? name = DumpTestHelpers.GetMethodName(Target, md);
+            if (name is not "MethodA")
+                continue;
+
+            ClrDataFrame frame = new ClrDataFrame(Target, dataFrame, legacyImpl: null);
+            IXCLRDataFrame xclrFrame = frame;
+
+            // Get the name of the first (and only) argument: "depth"
+            char* nameBuf = stackalloc char[256];
+            uint nameLen;
+            DacComNullableByRef<IXCLRDataValue> argOut = new(isNullRef: false);
+            int hr = xclrFrame.GetArgumentByIndex(0, argOut, 256, &nameLen, nameBuf);
+
+            AssertHResult(HResults.S_OK, hr);
+            string argName = new string(nameBuf);
+            Assert.Equal("depth", argName);
+
+            return;
+        }
+
+        Assert.Fail("MethodA not found on the crashing thread's stack");
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetArgumentByIndex_InvalidIndex_ReturnsError(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IStackWalk stackWalk = Target.Contracts.StackWalk;
+        ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
+
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        {
+            TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
+            if (md == TargetPointer.Null)
+                continue;
+
+            string? name = DumpTestHelpers.GetMethodName(Target, md);
+            if (name is not "MethodA")
+                continue;
+
+            ClrDataFrame frame = new ClrDataFrame(Target, dataFrame, legacyImpl: null);
+            IXCLRDataFrame xclrFrame = frame;
+
+            // MethodA has 1 argument, so index 1 should be out of range
+            DacComNullableByRef<IXCLRDataValue> argOut = new(isNullRef: false);
+            int hr = xclrFrame.GetArgumentByIndex(1, argOut, 0, null, null);
+
+            Assert.True(hr < 0, $"Expected failure HRESULT for out-of-range index, got 0x{hr:X8}");
+
+            return;
+        }
+
+        Assert.Fail("MethodA not found on the crashing thread's stack");
+    }
+
+    // ========== GetLocalVariableByIndex ==========
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetLocalVariableByIndex_ReturnsValueForMethodBLocal(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IStackWalk stackWalk = Target.Contracts.StackWalk;
+        ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
+
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        {
+            TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
+            if (md == TargetPointer.Null)
+                continue;
+
+            string? name = DumpTestHelpers.GetMethodName(Target, md);
+            if (name is not "MethodB")
+                continue;
+
+            ClrDataFrame frame = new ClrDataFrame(Target, dataFrame, legacyImpl: null);
+            IXCLRDataFrame xclrFrame = frame;
+
+            // MethodB has at least 1 local variable (localObj)
+            DacComNullableByRef<IXCLRDataValue> localOut = new(isNullRef: false);
+            int hr = xclrFrame.GetLocalVariableByIndex(0, localOut, 0, null, null);
+
+            AssertHResult(HResults.S_OK, hr);
+            Assert.NotNull(localOut.Interface);
+
+            return;
+        }
+
+        Assert.Fail("MethodB not found on the crashing thread's stack");
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetLocalVariableByIndex_InvalidIndex_ReturnsError(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IStackWalk stackWalk = Target.Contracts.StackWalk;
+        ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
+
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        {
+            TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
+            if (md == TargetPointer.Null)
+                continue;
+
+            string? name = DumpTestHelpers.GetMethodName(Target, md);
+            if (name is not "MethodB")
+                continue;
+
+            ClrDataFrame frame = new ClrDataFrame(Target, dataFrame, legacyImpl: null);
+            IXCLRDataFrame xclrFrame = frame;
+
+            // Get actual local count, then use an out-of-range index
+            uint numLocals;
+            int countHr = xclrFrame.GetNumLocalVariables(&numLocals);
+            AssertHResult(HResults.S_OK, countHr);
+
+            DacComNullableByRef<IXCLRDataValue> localOut = new(isNullRef: false);
+            int hr = xclrFrame.GetLocalVariableByIndex(numLocals, localOut, 0, null, null);
+
+            Assert.True(hr < 0, $"Expected failure HRESULT for out-of-range index, got 0x{hr:X8}");
+
+            return;
+        }
+
+        Assert.Fail("MethodB not found on the crashing thread's stack");
+    }
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetLocalVariableByIndex_LocalNameIsEmpty(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        IStackWalk stackWalk = Target.Contracts.StackWalk;
+        ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
+
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        {
+            TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
+            if (md == TargetPointer.Null)
+                continue;
+
+            string? name = DumpTestHelpers.GetMethodName(Target, md);
+            if (name is not "MethodB")
+                continue;
+
+            ClrDataFrame frame = new ClrDataFrame(Target, dataFrame, legacyImpl: null);
+            IXCLRDataFrame xclrFrame = frame;
+
+            // Local variable names are not available - name should be empty
+            char* nameBuf = stackalloc char[256];
+            uint nameLen;
+            DacComNullableByRef<IXCLRDataValue> localOut = new(isNullRef: false);
+            int hr = xclrFrame.GetLocalVariableByIndex(0, localOut, 256, &nameLen, nameBuf);
+
+            AssertHResult(HResults.S_OK, hr);
+            Assert.Equal('\0', nameBuf[0]);
+
+            return;
+        }
+
+        Assert.Fail("MethodB not found on the crashing thread's stack");
     }
 
     // ========== Helpers ==========

--- a/src/native/managed/cdac/tests/DumpTests/IXCLRDataValueDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/IXCLRDataValueDumpTests.cs
@@ -75,7 +75,7 @@ public unsafe class IXCLRDataValueDumpTests : DumpTestBase
         });
 
         // --- ByRef and GenericInst: pointer-sized ---
-        // GenericInstAndByRefVars(List<int> listArg, ref int refArg)
+        // GenericInstAndByRefVars(List<int> listArg, KeyValuePair<int, string> kvpArg, ref int refArg)
         var byRefArgs = GetArgumentValues("GenericInstAndByRefVars");
         AssertEach(byRefArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
         {

--- a/src/native/managed/cdac/tests/DumpTests/IXCLRDataValueDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/IXCLRDataValueDumpTests.cs
@@ -1,0 +1,752 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Diagnostics.DataContractReader.Contracts;
+using Microsoft.Diagnostics.DataContractReader.Legacy;
+using Xunit;
+using static Microsoft.Diagnostics.DataContractReader.Tests.TestHelpers;
+
+namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
+
+/// <summary>
+/// Dump-based integration tests for IXCLRDataValue methods (GetSize, GetFlags,
+/// GetBytes, GetNumLocations, GetLocationByIndex) on values returned by
+/// ClrDataFrame.GetArgumentByIndex and GetLocalVariableByIndex.
+/// </summary>
+public unsafe class IXCLRDataValueDumpTests : DumpTestBase
+{
+    protected override string DebuggeeName => "LocalVariables";
+    protected override string DumpType => "full";
+
+    // ========== GetSize ==========
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetSize_ReturnsExpectedSizes(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        int pointerSize = Target.PointerSize;
+
+        // --- Primitives: size matches the ECMA-335 element type ---
+        // PrimitiveVars(int=42, double=3.14, bool=true, char='Z', byte=0xFF, short=-1, long=123456789, float=2.5)
+        var primitiveArgs = GetArgumentValues("PrimitiveVars");
+        AssertEach(primitiveArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["intArg"] = (v, d) => AssertSize(v, 4, d),
+            ["doubleArg"] = (v, d) => AssertSize(v, 8, d),
+            ["boolArg"] = (v, d) => AssertSize(v, 1, d),
+            ["charArg"] = (v, d) => AssertSize(v, 2, d),
+            ["byteArg"] = (v, d) => AssertSize(v, 1, d),
+            ["shortArg"] = (v, d) => AssertSize(v, 2, d),
+            ["longArg"] = (v, d) => AssertSize(v, 8, d),
+            ["floatArg"] = (v, d) => AssertSize(v, 4, d),
+        });
+
+        // --- Native ints: pointer-sized primitives ---
+        // NativeIntVars(nint=0x1234, nuint=0x5678)
+        var nativeIntArgs = GetArgumentValues("NativeIntVars");
+        AssertEach(nativeIntArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["nintArg"] = (v, d) => AssertSize(v, pointerSize, d),
+            ["nuintArg"] = (v, d) => AssertSize(v, pointerSize, d),
+        });
+
+        // --- Generics: method-level (MVAR) and class-level (VAR) resolve to actual type ---
+        // MethodGenericVars<int, string>(300, "generic")
+        // arg1 is !!0 → int → 4 bytes; arg2 is !!1 → string → pointer-sized
+        var methodGenericArgs = GetArgumentValues("MethodGenericVars");
+        AssertEach(methodGenericArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["arg1"] = (v, d) => AssertSize(v, 4, d),
+            ["arg2"] = (v, d) => AssertSize(v, pointerSize, d),
+        });
+
+        // GenericContainer<int>.ClassGenericVars(int value)
+        // 'this' is IS_REFERENCE → pointer-sized; 'value' is !0 → int → 4 bytes
+        var classGenericArgs = GetArgumentValues("ClassGenericVars");
+        AssertEach(classGenericArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["this"] = (v, d) => AssertSize(v, pointerSize, d),
+            ["value"] = (v, d) => AssertSize(v, 4, d),
+        });
+
+        // --- ByRef and GenericInst: pointer-sized ---
+        // GenericInstAndByRefVars(List<int> listArg, ref int refArg)
+        var byRefArgs = GetArgumentValues("GenericInstAndByRefVars");
+        AssertEach(byRefArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["listArg"] = (v, d) => AssertSize(v, pointerSize, d),
+            ["refArg"] = (v, d) => AssertSize(v, pointerSize, d),
+        });
+
+        // --- Structs: always pointer-sized (JIT storage size, not logical type size) ---
+        // StructVars(TinyStruct tinyArg, SmallStruct smallArg, LargeStruct largeArg)
+        // NativeVarLocations sets size=sizeof(SIZE_T) for all location types.
+        // The native DAC only adjusts size downward for primitives, never for value types.
+        var structArgs = GetArgumentValues("StructVars");
+        foreach (var (name, value) in structArgs)
+        {
+            AssertSize(value, pointerSize, name);
+        }
+
+        // --- References, enum, object, array: all pointer-sized ---
+        // ReferenceTypeVars(string stringArg, SimpleClass classArg, Color enumArg, object boxedArg, int[] arrayArg)
+        var refArgs = GetArgumentValues("ReferenceTypeVars");
+        AssertEach(refArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["stringArg"] = (v, d) => AssertSize(v, pointerSize, d),
+            ["classArg"] = (v, d) => AssertSize(v, pointerSize, d),
+            ["enumArg"] = (v, d) => AssertSize(v, pointerSize, d),
+            ["boxedArg"] = (v, d) => AssertSize(v, pointerSize, d),
+            ["arrayArg"] = (v, d) => AssertSize(v, pointerSize, d),
+        });
+
+        // --- GenericInst and ByRef: pointer-sized ---
+        // GenericInstAndByRefVars(List<int> listArg, KeyValuePair<int,string> kvpArg, ref int refArg)
+        var genericInstArgs = GetArgumentValues("GenericInstAndByRefVars");
+        AssertEach(genericInstArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["listArg"] = (v, d) => AssertSize(v, pointerSize, d),
+            ["kvpArg"] = (v, d) => AssertSize(v, pointerSize, d),
+            ["refArg"] = (v, d) => AssertSize(v, pointerSize, d),
+        });
+
+        // --- Instance method with struct parameter ---
+        // InstanceMethodOnStruct(SmallStruct s) — struct arg → pointer-sized
+        var instanceStructArgs = GetArgumentValues("InstanceMethodOnStruct");
+        AssertEach(instanceStructArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["s"] = (v, d) => AssertSize(v, pointerSize, d),
+        });
+
+        // --- Locals: non-zero (IL slot order is not stable across builds) ---
+        var locals = GetLocalValues("PrimitiveVars");
+        Assert.True(locals.Count >= 8, $"Expected at least 8 locals, got {locals.Count}");
+        foreach (var (idx, value) in locals)
+        {
+            ulong size;
+            int hr = value.GetSize(&size);
+            Assert.True(hr >= 0, $"local[{idx}]: GetSize failed with 0x{hr:X8}");
+            Assert.True(size > 0, $"local[{idx}]: expected non-zero size, got {size}");
+        }
+
+        // --- Single-local frames: exact size verification ---
+        // InstanceMethodVars has 1 local: int localSum → 4 bytes
+        var instanceLocals = GetLocalValues("InstanceMethodVars");
+        Assert.True(instanceLocals.ContainsKey(0), "InstanceMethodVars local[0] not found");
+        AssertSize(instanceLocals[0], 4, "InstanceMethodVars local[0]");
+
+        // ClassGenericVars has 1 local: T localCopy where T=int → 4 bytes
+        var classGenericLocals = GetLocalValues("ClassGenericVars");
+        Assert.True(classGenericLocals.ContainsKey(0), "ClassGenericVars local[0] not found");
+        AssertSize(classGenericLocals[0], 4, "ClassGenericVars local[0]");
+
+        // --- Single-dim array: pointer-sized ---
+        // SingleDimArrayVars(int[] arrayArg)
+        var singleDimArgs = GetArgumentValues("SingleDimArrayVars");
+        AssertEach(singleDimArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["arrayArg"] = (v, d) => AssertSize(v, pointerSize, d),
+        });
+
+        // SingleDimArrayVars has 1 local: int[] localArray → pointer-sized
+        var singleDimLocals = GetLocalValues("SingleDimArrayVars");
+        Assert.True(singleDimLocals.ContainsKey(0), "SingleDimArrayVars local[0] not found");
+        AssertSize(singleDimLocals[0], pointerSize, "SingleDimArrayVars local[0]");
+
+        // --- Multi-dim array: pointer-sized ---
+        // MultiDimArrayVars(int[,] multiDimArg)
+        var multiDimArgs = GetArgumentValues("MultiDimArrayVars");
+        AssertEach(multiDimArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["multiDimArg"] = (v, d) => AssertSize(v, pointerSize, d),
+        });
+
+        // MultiDimArrayVars has 1 local: int[,] localMultiDim → pointer-sized
+        var multiDimLocals = GetLocalValues("MultiDimArrayVars");
+        Assert.True(multiDimLocals.ContainsKey(0), "MultiDimArrayVars local[0] not found");
+        AssertSize(multiDimLocals[0], pointerSize, "MultiDimArrayVars local[0]");
+
+        // --- Pointer and function pointer: all pointer-sized ---
+        // PointerVars(int* ptrArg, delegate*<int,int> funcPtrArg)
+        var ptrArgs = GetArgumentValues("PointerVars");
+        AssertEach(ptrArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["ptrArg"] = (v, d) => AssertSize(v, pointerSize, d),
+            ["funcPtrArg"] = (v, d) => AssertSize(v, pointerSize, d),
+        });
+    }
+
+    // ========== GetFlags ==========
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetFlags_ReturnsExpectedFlags(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+
+        // --- Primitives: IS_PRIMITIVE ---
+        // PrimitiveVars(int, double, bool, char, byte, short, long, float)
+        var primitiveArgs = GetArgumentValues("PrimitiveVars");
+        AssertEach(primitiveArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["intArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_PRIMITIVE, d),
+            ["doubleArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_PRIMITIVE, d),
+            ["boolArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_PRIMITIVE, d),
+            ["charArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_PRIMITIVE, d),
+            ["byteArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_PRIMITIVE, d),
+            ["shortArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_PRIMITIVE, d),
+            ["longArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_PRIMITIVE, d),
+            ["floatArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_PRIMITIVE, d),
+        });
+
+        // --- Native ints: IS_PRIMITIVE ---
+        // NativeIntVars(nint nintArg, nuint nuintArg)
+        var nativeIntArgs = GetArgumentValues("NativeIntVars");
+        AssertEach(nativeIntArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["nintArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_PRIMITIVE, d),
+            ["nuintArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_PRIMITIVE, d),
+        });
+
+        // --- Structs: IS_VALUE_TYPE ---
+        // StructVars(TinyStruct tinyArg, SmallStruct smallArg, LargeStruct largeArg)
+        var structArgs = GetArgumentValues("StructVars");
+        AssertEach(structArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["tinyArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_VALUE_TYPE, d),
+            ["smallArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_VALUE_TYPE, d),
+            ["largeArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_VALUE_TYPE, d),
+        });
+
+        // --- Reference types, enum, object, array ---
+        // ReferenceTypeVars(string stringArg, SimpleClass classArg, Color enumArg, object boxedArg, int[] arrayArg)
+        // Native DAC's GetTypeFieldValueFlags checks IsObjRef first (before IsArray/IsString),
+        // so all GC-reference types (string, class, object, arrays) return IS_REFERENCE.
+        // IS_ENUM is reachable because enums use GetInternalCorElementType → underlying primitive
+        // type which is not IsObjRef.
+        var refArgs = GetArgumentValues("ReferenceTypeVars");
+        AssertEach(refArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["stringArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_REFERENCE, d),
+            ["classArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_REFERENCE, d),
+            ["enumArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_ENUM, d),
+            ["boxedArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_REFERENCE, d),
+            ["arrayArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_REFERENCE, d),
+        });
+
+        // --- GenericInst and ByRef ---
+        // GenericInstAndByRefVars(List<int> listArg, KeyValuePair<int,string> kvpArg, ref int refArg)
+        // Native DAC passes ByRef TypeHandle directly to GetTypeFieldValueFlags which
+        // returns DEFAULT (ELEMENT_TYPE_BYREF is not IsObjRef, not primitive, etc.).
+        var genericInstArgs = GetArgumentValues("GenericInstAndByRefVars");
+        AssertEach(genericInstArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["listArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_REFERENCE, d),
+            ["kvpArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_VALUE_TYPE, d),
+            ["refArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.DEFAULT, d),
+        });
+
+        // --- Instance method: 'this' is IS_REFERENCE, extra (int) is IS_PRIMITIVE ---
+        // InstanceWrapper.InstanceMethodVars(int extra)
+        var instanceArgs = GetArgumentValues("InstanceMethodVars");
+        AssertEach(instanceArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["this"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_REFERENCE, d),
+            ["extra"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_PRIMITIVE, d),
+        });
+
+        // --- Class generic (VAR) and method generic (MVAR) ---
+        // GenericContainer<int>.ClassGenericVars(T value) — T=int → IS_PRIMITIVE
+        var classGenericArgs = GetArgumentValues("ClassGenericVars");
+        AssertEach(classGenericArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["this"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_REFERENCE, d),
+            ["value"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_PRIMITIVE, d),
+        });
+
+        // MethodGenericVars<int, string>(arg1, arg2) — T1=int → IS_PRIMITIVE, T2=string → IS_REFERENCE
+        var methodGenericArgs = GetArgumentValues("MethodGenericVars");
+        AssertEach(methodGenericArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["arg1"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_PRIMITIVE, d),
+            ["arg2"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_REFERENCE, d),
+        });
+
+        // --- Single-local frames: exact flags verification ---
+        // InstanceMethodVars has 1 local: int localSum → IS_PRIMITIVE
+        var instanceLocals = GetLocalValues("InstanceMethodVars");
+        Assert.True(instanceLocals.ContainsKey(0), "InstanceMethodVars local[0] not found");
+        AssertFlags(instanceLocals[0], ClrDataValueFlag.IS_PRIMITIVE, "InstanceMethodVars local[0]");
+
+        // ClassGenericVars has 1 local: T localCopy where T=int → IS_PRIMITIVE
+        var classGenericLocals = GetLocalValues("ClassGenericVars");
+        Assert.True(classGenericLocals.ContainsKey(0), "ClassGenericVars local[0] not found");
+        AssertFlags(classGenericLocals[0], ClrDataValueFlag.IS_PRIMITIVE, "ClassGenericVars local[0]");
+
+        // --- Single-dim array ---
+        // SingleDimArrayVars(int[] arrayArg)
+        //
+        // Native DAC's GetTypeFieldValueFlags (inspect.cpp):
+        //   int[] → ELEMENT_TYPE_SZARRAY → IsObjRef=true → IS_REFERENCE
+        var singleDimArgs = GetArgumentValues("SingleDimArrayVars");
+        AssertEach(singleDimArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["arrayArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_REFERENCE, d),
+        });
+
+        // SingleDimArrayVars has 1 local: int[] localArray → IS_REFERENCE
+        var singleDimLocals = GetLocalValues("SingleDimArrayVars");
+        Assert.True(singleDimLocals.ContainsKey(0), "SingleDimArrayVars local[0] not found");
+        AssertFlags(singleDimLocals[0], ClrDataValueFlag.IS_REFERENCE, "SingleDimArrayVars local[0]");
+
+        // --- Multi-dim array ---
+        // MultiDimArrayVars(int[,] multiDimArg)
+        //
+        // Native DAC's GetTypeFieldValueFlags (inspect.cpp):
+        //   int[,] → ELEMENT_TYPE_ARRAY → IsObjRef=true → IS_REFERENCE
+        var multiDimArgs = GetArgumentValues("MultiDimArrayVars");
+        AssertEach(multiDimArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["multiDimArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_REFERENCE, d),
+        });
+
+        // MultiDimArrayVars has 1 local: int[,] localMultiDim → IS_REFERENCE
+        var multiDimLocals = GetLocalValues("MultiDimArrayVars");
+        Assert.True(multiDimLocals.ContainsKey(0), "MultiDimArrayVars local[0] not found");
+        AssertFlags(multiDimLocals[0], ClrDataValueFlag.IS_REFERENCE, "MultiDimArrayVars local[0]");
+
+        // --- Pointer and function pointer ---
+        // PointerVars(int* ptrArg, delegate*<int,int> funcPtrArg)
+        //
+        // Native DAC's GetTypeFieldValueFlags (inspect.cpp):
+        //   int*                -> ELEMENT_TYPE_PTR    -> IS_POINTER
+        //   delegate*<int,int>  -> mapped to IntPtr in DAC build (siginfo.cpp, DACCESS_COMPILE)
+        //                       -> ELEMENT_TYPE_I      -> IsPrimitiveType -> IS_PRIMITIVE
+        //
+        // Raw signature parsing reads the leading type code directly from the method
+        // signature blob, avoiding the cross-module TypeDesc resolution issue.
+        var ptrArgs = GetArgumentValues("PointerVars");
+        AssertEach(ptrArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["ptrArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_POINTER, d),
+            ["funcPtrArg"] = (v, d) => AssertFlags(v, ClrDataValueFlag.IS_PRIMITIVE, d),
+        });
+    }
+
+    // ========== GetBytes ==========
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetBytes_ReturnsExpectedValues(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+
+        // --- Primitives: exact byte values ---
+        // PrimitiveVars(42, 3.14, true, 'Z', 0xFF, -1, 123456789L, 2.5f)
+        var primitiveArgs = GetArgumentValues("PrimitiveVars");
+        AssertEach(primitiveArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["intArg"] = (v, d) => AssertBytes(v, BitConverter.GetBytes(42), d),
+            ["doubleArg"] = (v, d) => AssertBytes(v, BitConverter.GetBytes(3.14), d),
+            ["boolArg"] = (v, d) => AssertBytes(v, [(byte)1], d),
+            ["charArg"] = (v, d) => AssertBytes(v, BitConverter.GetBytes((short)'Z'), d),
+            ["byteArg"] = (v, d) => AssertBytes(v, [0xFF], d),
+            ["shortArg"] = (v, d) => AssertBytes(v, BitConverter.GetBytes((short)-1), d),
+            ["longArg"] = (v, d) => AssertBytes(v, BitConverter.GetBytes(123456789L), d),
+            ["floatArg"] = (v, d) => AssertBytes(v, BitConverter.GetBytes(2.5f), d),
+        });
+
+        // --- Enum: Color.Blue = 2 ---
+        // ReferenceTypeVars(string, SimpleClass, Color.Blue)
+        var enumArgs = GetArgumentValues("ReferenceTypeVars");
+        AssertEach(enumArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["enumArg"] = (v, d) => AssertBytes(v, BitConverter.GetBytes(2), d),
+        });
+
+        // --- Struct: SmallStruct { X=100, Y=200 } ---
+        // InstanceMethodOnStruct(SmallStruct s)
+        // SmallStruct is 8 bytes: two ints packed contiguously (X=100, Y=200)
+        var structArgs = GetArgumentValues("InstanceMethodOnStruct");
+        AssertEach(structArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["s"] = (v, d) =>
+            {
+                byte[] expected = new byte[8];
+                BitConverter.GetBytes(100).CopyTo(expected, 0);
+                BitConverter.GetBytes(200).CopyTo(expected, 4);
+                AssertBytes(v, expected, d);
+            },
+        });
+
+        // --- Instance method: extra = s.Y = 200 ---
+        // InstanceWrapper.InstanceMethodVars(extra) where extra = 200
+        var instanceArgs = GetArgumentValues("InstanceMethodVars");
+        AssertEach(instanceArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["extra"] = (v, d) => { AssertSize(v, 4, d); AssertBytes(v, BitConverter.GetBytes(200), d); },
+        });
+
+        // --- Generic method: arg1 = 300 (int via MVAR resolution) ---
+        // MethodGenericVars<int, string>(300, "generic")
+        var genericArgs = GetArgumentValues("MethodGenericVars");
+        AssertEach(genericArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["arg1"] = (v, d) => AssertBytes(v, BitConverter.GetBytes(300), d),
+        });
+
+        // --- Native ints: exact pointer values ---
+        // NativeIntVars(nint=0x1234, nuint=0x5678)
+        var nativeIntArgs = GetArgumentValues("NativeIntVars");
+        int pointerSize = Target.PointerSize;
+        AssertEach(nativeIntArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["nintArg"] = (v, d) =>
+            {
+                byte[] expected = pointerSize == 8 ? BitConverter.GetBytes((long)0x1234) : BitConverter.GetBytes(0x1234);
+                AssertBytes(v, expected, d);
+            },
+            ["nuintArg"] = (v, d) =>
+            {
+                byte[] expected = pointerSize == 8 ? BitConverter.GetBytes((long)0x5678) : BitConverter.GetBytes(0x5678);
+                AssertBytes(v, expected, d);
+            },
+        });
+
+        // --- Reference types: read the pointer, then use cDAC contracts to inspect the object ---
+        // ReferenceTypeVars(string stringArg="test", SimpleClass classArg, Color enumArg,
+        //                   object boxedArg=(object)42, int[] arrayArg={1,2,3})
+        var refArgs = GetArgumentValues("ReferenceTypeVars");
+
+        // String: GetBytes → pointer → IObject.GetStringValue → "test"
+        AssertEach(refArgs, new Dictionary<string, Action<IXCLRDataValue, string>>
+        {
+            ["stringArg"] = (v, d) =>
+            {
+                TargetPointer ptr = ReadPointerFromValue(v, d);
+                string actual = Target.Contracts.Object.GetStringValue(ptr);
+                Assert.Equal("test", actual);
+            },
+            // Array: GetBytes → pointer → IObject.GetArrayData → count=3
+            ["arrayArg"] = (v, d) =>
+            {
+                TargetPointer ptr = ReadPointerFromValue(v, d);
+                Target.Contracts.Object.GetArrayData(ptr, out uint count, out _, out _);
+                Assert.Equal(3u, count);
+            },
+        });
+
+        // --- Single-local frames: exact byte verification ---
+        // InstanceMethodVars has 1 local: int localSum = _value(100) + extra(200) = 300
+        var instanceLocals = GetLocalValues("InstanceMethodVars");
+        Assert.True(instanceLocals.ContainsKey(0), "InstanceMethodVars local[0] not found");
+        AssertBytes(instanceLocals[0], BitConverter.GetBytes(300), "InstanceMethodVars local[0]");
+
+        // ClassGenericVars has 1 local: T localCopy = value = 300
+        var classGenericLocals = GetLocalValues("ClassGenericVars");
+        Assert.True(classGenericLocals.ContainsKey(0), "ClassGenericVars local[0] not found");
+        AssertBytes(classGenericLocals[0], BitConverter.GetBytes(300), "ClassGenericVars local[0]");
+    }
+
+    // ========== GetNumLocations ==========
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetNumLocations_ReturnsValidCount(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+
+        // On 64-bit platforms, each variable has at most 1 location (no split values).
+        // On 32-bit, a 64-bit value could be split across 2 locations.
+        uint maxLocations = Target.PointerSize >= 8 ? 1u : 2u;
+
+        // --- Arguments ---
+        var args = GetArgumentValues("PrimitiveVars");
+        foreach (var (name, value) in args)
+        {
+            uint numLocs;
+            int hr = value.GetNumLocations(&numLocs);
+            Assert.True(hr >= 0, $"{name}: GetNumLocations failed with 0x{hr:X8}");
+            Assert.True(numLocs <= maxLocations, $"{name}: expected at most {maxLocations} locations, got {numLocs}");
+        }
+
+        // --- Locals ---
+        var locals = GetLocalValues("PrimitiveVars");
+        foreach (var (idx, value) in locals)
+        {
+            uint numLocs;
+            int hr = value.GetNumLocations(&numLocs);
+            Assert.True(hr >= 0, $"local[{idx}]: GetNumLocations failed with 0x{hr:X8}");
+            Assert.True(numLocs <= maxLocations, $"local[{idx}]: expected at most {maxLocations} locations, got {numLocs}");
+        }
+    }
+
+    // ========== GetLocationByIndex ==========
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetLocationByIndex_ValidAndOutOfRange(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+        var locals = GetLocalValues("PrimitiveVars");
+
+        Assert.True(locals.Count > 0, "No locals found");
+        IXCLRDataValue local0 = locals.Values.First();
+
+        uint numLocs;
+        int hr = local0.GetNumLocations(&numLocs);
+        Assert.True(hr >= 0, $"GetNumLocations failed with 0x{hr:X8}");
+
+        // Valid indices should succeed
+        for (uint i = 0; i < numLocs; i++)
+        {
+            uint flags;
+            ClrDataAddress addr;
+            hr = local0.GetLocationByIndex(i, &flags, &addr);
+            Assert.True(hr >= 0, $"GetLocationByIndex({i}) failed with 0x{hr:X8}");
+        }
+
+        // Out-of-range index should fail
+        uint oobFlags;
+        ClrDataAddress oobAddr;
+        hr = local0.GetLocationByIndex(numLocs, &oobFlags, &oobAddr);
+        Assert.True(hr < 0, $"Expected failure for out-of-range location index {numLocs}");
+    }
+
+    // ========== Comprehensive: all frames ==========
+
+    [ConditionalTheory]
+    [MemberData(nameof(TestConfigurations))]
+    [SkipOnVersion("net10.0", "InlinedCallFrame.Datum was added after net10.0")]
+    public void GetSize_GetFlags_AllFrames_Succeeds(TestConfiguration config)
+    {
+        InitializeDumpTest(config);
+
+        // Walk every frame on the crashing thread and call GetSize/GetFlags on
+        // every argument and local. Verifies no unexpected exceptions are thrown
+        // across all type varieties in the debuggee's deep call stack.
+        IStackWalk stackWalk = Target.Contracts.StackWalk;
+        ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
+        int totalValues = 0;
+
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        {
+            TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
+            if (md == TargetPointer.Null)
+                continue;
+
+            ClrDataFrame frame = new ClrDataFrame(Target, dataFrame, legacyImpl: null);
+            IXCLRDataFrame xclrFrame = frame;
+
+            uint numArgs;
+            if (xclrFrame.GetNumArguments(&numArgs) >= 0)
+            {
+                for (uint i = 0; i < numArgs; i++)
+                {
+                    DacComNullableByRef<IXCLRDataValue> argOut = new(isNullRef: false);
+                    if (xclrFrame.GetArgumentByIndex(i, argOut, 0, null, null) >= 0 && argOut.Interface is not null)
+                    {
+                        totalValues++;
+                        uint flags;
+                        argOut.Interface.GetFlags(&flags);
+                        ulong size;
+                        argOut.Interface.GetSize(&size);
+                    }
+                }
+            }
+
+            uint numLocals;
+            if (xclrFrame.GetNumLocalVariables(&numLocals) >= 0)
+            {
+                for (uint i = 0; i < numLocals; i++)
+                {
+                    DacComNullableByRef<IXCLRDataValue> localOut = new(isNullRef: false);
+                    if (xclrFrame.GetLocalVariableByIndex(i, localOut, 0, null, null) >= 0 && localOut.Interface is not null)
+                    {
+                        totalValues++;
+                        uint flags;
+                        localOut.Interface.GetFlags(&flags);
+                        ulong size;
+                        localOut.Interface.GetSize(&size);
+                    }
+                }
+            }
+        }
+
+        Assert.True(totalValues > 20, $"Expected many values across all frames, got {totalValues}");
+    }
+
+    // ========== Helpers ==========
+
+    /// <summary>
+    /// Gets all arguments for a method as a dictionary of name -> IXCLRDataValue.
+    /// </summary>
+    private Dictionary<string, IXCLRDataValue> GetArgumentValues(string methodName)
+    {
+        (ClrDataFrame frame, _) = FindFrameByMethodName(methodName);
+        IXCLRDataFrame xclrFrame = frame;
+
+        uint numArgs;
+        int hr = xclrFrame.GetNumArguments(&numArgs);
+        AssertHResult(HResults.S_OK, hr);
+
+        Dictionary<string, IXCLRDataValue> result = new();
+        char* nameBuf = stackalloc char[256];
+        for (uint i = 0; i < numArgs; i++)
+        {
+            uint nameLen;
+            DacComNullableByRef<IXCLRDataValue> argOut = new(isNullRef: false);
+            hr = xclrFrame.GetArgumentByIndex(i, argOut, 256, &nameLen, nameBuf);
+            if (hr >= 0 && argOut.Interface is not null)
+            {
+                // nameLen includes the null terminator; construct the string without it.
+                string name = nameLen > 1 ? new string(nameBuf, 0, (int)(nameLen - 1)) : string.Empty;
+                result[name] = argOut.Interface;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets all locals for a method as a dictionary of index -> IXCLRDataValue.
+    /// </summary>
+    private Dictionary<uint, IXCLRDataValue> GetLocalValues(string methodName)
+    {
+        (ClrDataFrame frame, _) = FindFrameByMethodName(methodName);
+        IXCLRDataFrame xclrFrame = frame;
+
+        uint numLocals;
+        int hr = xclrFrame.GetNumLocalVariables(&numLocals);
+        AssertHResult(HResults.S_OK, hr);
+
+        Dictionary<uint, IXCLRDataValue> result = new();
+        for (uint i = 0; i < numLocals; i++)
+        {
+            DacComNullableByRef<IXCLRDataValue> localOut = new(isNullRef: false);
+            hr = xclrFrame.GetLocalVariableByIndex(i, localOut, 0, null, null);
+            if (hr >= 0 && localOut.Interface is not null)
+            {
+                result[i] = localOut.Interface;
+            }
+        }
+
+        return result;
+    }
+
+    private static void AssertSize(IXCLRDataValue value, int expectedSize, string description)
+    {
+        ulong size;
+        int hr = value.GetSize(&size);
+        Assert.True(hr >= 0, $"{description}: GetSize failed with 0x{hr:X8}");
+        Assert.Equal((ulong)expectedSize, size);
+    }
+
+    /// <summary>
+    /// Reads the raw bytes from a value and interprets them as a target pointer.
+    /// Used to get the object address from reference-type arguments for further inspection.
+    /// </summary>
+    private TargetPointer ReadPointerFromValue(IXCLRDataValue value, string description)
+    {
+        ulong size;
+        int hr = value.GetSize(&size);
+        Assert.True(hr >= 0 && size > 0, $"{description}: GetSize failed or returned 0");
+
+        byte[] bytes = new byte[size];
+        uint dataSize;
+        fixed (byte* pBuf = bytes)
+        {
+            hr = value.GetBytes((uint)size, &dataSize, pBuf);
+        }
+
+        Assert.True(hr >= 0, $"{description}: GetBytes failed with 0x{hr:X8}");
+
+        ulong ptr = Target.PointerSize == 8
+            ? BitConverter.ToUInt64(bytes, 0)
+            : BitConverter.ToUInt32(bytes, 0);
+        Assert.True(ptr != 0, $"{description}: expected non-null pointer");
+
+        return new TargetPointer(ptr);
+    }
+
+    private static void AssertFlags(IXCLRDataValue value, ClrDataValueFlag expectedFlags, string description)
+    {
+        uint flags = AssertGetFlags(value, description);
+        Assert.Equal((uint)expectedFlags, flags);
+    }
+
+    private static uint AssertGetFlags(IXCLRDataValue value, string description)
+    {
+        uint flags;
+        int hr = value.GetFlags(&flags);
+        Assert.True(hr >= 0, $"{description}: GetFlags failed with 0x{hr:X8}");
+
+        return flags;
+    }
+
+    private static void AssertBytes(IXCLRDataValue value, byte[] expectedBytes, string description)
+    {
+        ulong size;
+        int hr = value.GetSize(&size);
+        Assert.True(hr >= 0 && size > 0, $"{description}: GetSize failed or returned 0");
+
+        byte[] actual = new byte[size];
+        uint dataSize;
+        fixed (byte* pBuf = actual)
+        {
+            hr = value.GetBytes((uint)size, &dataSize, pBuf);
+        }
+
+        Assert.True(hr >= 0, $"{description}: GetBytes failed with 0x{hr:X8}");
+
+        int compareLen = Math.Min(expectedBytes.Length, (int)dataSize);
+        Assert.True(
+            actual.AsSpan(0, compareLen).SequenceEqual(expectedBytes.AsSpan(0, compareLen)),
+            $"{description}: bytes mismatch. " +
+            $"Expected: [{string.Join(",", expectedBytes.Take(compareLen).Select(b => $"0x{b:X2}"))}], " +
+            $"Actual: [{string.Join(",", actual.Take(compareLen).Select(b => $"0x{b:X2}"))}]");
+    }
+
+    private static void AssertEach<TKey>(Dictionary<TKey, IXCLRDataValue> values, Dictionary<TKey, Action<IXCLRDataValue, string>> assertions)
+        where TKey : notnull
+    {
+        foreach (var (key, assert) in assertions)
+        {
+            Assert.True(values.ContainsKey(key), $"Value '{key}' not found");
+            assert(values[key], $"'{key}'");
+        }
+    }
+
+    private (ClrDataFrame Frame, IStackDataFrameHandle DataFrame) FindFrameByMethodName(string methodName)
+    {
+        IStackWalk stackWalk = Target.Contracts.StackWalk;
+        ThreadData crashingThread = DumpTestHelpers.FindFailFastThread(Target);
+
+        foreach (IStackDataFrameHandle dataFrame in stackWalk.CreateStackWalk(crashingThread))
+        {
+            TargetPointer md = stackWalk.GetMethodDescPtr(dataFrame);
+            if (md == TargetPointer.Null)
+                continue;
+
+            string? name = DumpTestHelpers.GetMethodName(Target, md);
+            if (name == methodName)
+            {
+                ClrDataFrame frame = new ClrDataFrame(Target, dataFrame, legacyImpl: null);
+
+                return (frame, dataFrame);
+            }
+        }
+
+        Assert.Fail($"{methodName} not found on the crashing thread's stack");
+        throw new InvalidOperationException("Unreachable");
+    }
+}


### PR DESCRIPTION
## [cDAC] Implement GetArgumentByIndex and GetLocalVariableByIndex on ClrDataFrame

Builds on #125064 (GetContext/GetAppDomain) to add variable inspection support to the managed cDAC.

### What this PR does

**DebugInfo contract (variable location resolution):**
- `GetMethodVarInfo` on `IDebugInfo` for resolving native variable locations from JIT debug info
- `NativeVarInfo` types (internal) with DoVars nibble decoder
- `DebugVarInfo`/`DebugVarLocKind` (public stable API in Abstractions)
- Register mapping for x64/x86/ARM64/ARM including REGNUM_AMBIENT_SP
- Documented in `DebugInfo.md` (Version 2 section with VarLocType constants and encoding format)

**SignatureDecoder contract (type resolution):**
- `DecodeMethodSignature` -- decodes full method signature resolving all parameter/return types including generic instantiations (VAR, MVAR, GENERICINST)
- `DecodeLocalSignature` -- reads IL method body header, finds local signature token, decodes all local variable types
- `SignatureTypeProvider` updated to resolve class-level generic params (VAR) via MethodDescHandle context
- Documented in `SignatureDecoder.md`

**RuntimeTypeSystem contract:**
- `IsEnum(TypeHandle)` -- detects enum types via GetSignatureCorElementType(ValueType) + InternalCorElementType != ValueType
- `GetPrimitiveType(CorElementType)` -- returns TypeHandle for a primitive/well-known CorElementType
- Documented in `RuntimeTypeSystem.md` (API section + Version 1 pseudocode)

**ClrDataFrame.GetArgumentByIndex / GetLocalVariableByIndex:**
- Parameter name resolution from metadata, `this` handling for instance methods
- Type resolution via `ISignatureDecoder` contracts (DecodeMethodSignature/DecodeLocalSignature)
- Variable location resolution via `GetMethodVarInfo` + local register/stack resolution
- `MapCorElementTypeToFlags` matches native DAC's `GetTypeFieldValueFlags`: IS_PRIMITIVE, IS_VALUE_TYPE, IS_REFERENCE, IS_STRING, IS_ARRAY, IS_ENUM, IS_POINTER
- ByRef unwrapping for underlying type flag resolution
- Function pointer types mapped to IntPtr matching native DAC behavior (`ELEMENT_TYPE_FNPTR` under `#ifndef DACCESS_COMPILE` -> IntPtr)
- Primitive size adjustment (NativeVarLocations always reports pointer-sized; shrink for actual primitive sizes)
- Legacy verification with `AllowCdacSuccess` validation mode

**ClrDataValue (new, implements IXCLRDataValue):**
- `GetFlags`, `GetSize`, `GetBytes`, `GetAddress`, `GetNumLocations`, `GetLocationByIndex`
- Legacy verification on all implemented methods
- `ClrDataValueFlag` and `ClrDataVLocFlag` made public for test access

**Native DAC fix:**
- `REGNUM_AMBIENT_SP` handling in `GetRegOffsInCONTEXT` on AMD64 (util.cpp)

### Known Gaps (tracked as issues)

- #125791 -- `ClrDataFrame.GetContext` should use `contextFlags` to compute required context size (currently always returns full platform context)
- #125792 -- `GetConstructedType` cannot resolve cross-module pointer TypeDescs (pointer variables like `int*` return DEFAULT flags instead of IS_POINTER)

### Dump test scenarios

`LocalVariables` debuggee with 13 frames exercising type coverage from simple to complex:

| Frame | Arguments | Locals | Types Tested | Expected Flags |
|-------|-----------|--------|-------------|----------------|
| `PrimitiveVars` | int, double, bool, char, byte, short, long, float | int, double | I4, R8, BOOLEAN, CHAR, U1, I2, I8, R4 | IS_PRIMITIVE |
| `NativeIntVars` | nint, nuint | nint, nuint | I, U | IS_PRIMITIVE (pointer-sized) |
| `StructVars` | TinyStruct(1B), SmallStruct(8B), LargeStruct(32B) | SmallStruct | VALUETYPE | IS_VALUE_TYPE |
| `ReferenceTypeVars` | string, class, enum, object, int[] | -- | STRING, CLASS, VALUETYPE(enum), OBJECT, SZARRAY | IS_REFERENCE, IS_ENUM |
| `GenericInstAndByRefVars` | List\<int\>, KeyValuePair\<int,string\>, ref int | List\<int\> | GENERICINST+CLASS, GENERICINST+VALUETYPE, BYREF | IS_REFERENCE, IS_VALUE_TYPE, IS_PRIMITIVE (unwrapped) |
| `InstanceMethodOnStruct` | SmallStruct | -- | VALUETYPE (static helper) | IS_VALUE_TYPE |
| `InstanceMethodVars` | this (SimpleClass), int | int | CLASS (this), I4 | IS_REFERENCE, IS_PRIMITIVE |
| `ClassGenericVars` | T (class-level VAR) | T | VAR -> instantiated type | IS_REFERENCE |
| `MethodGenericVars` | T1, T2 (method-level MVAR) | T1 | MVAR -> instantiated type | IS_PRIMITIVE, IS_REFERENCE |
| `SingleDimArrayVars` | int[] | int[] | SZARRAY | IS_REFERENCE |
| `MultiDimArrayVars` | int[,] | int[,] | ARRAY | IS_REFERENCE |
| `PointerVars` | int\*, delegate\*\<int,int\> | -- | PTR, FNPTR | IS_POINTER (gap: #125792), IS_PRIMITIVE |
| `Crash` | -- | -- | (triggers dump) | -- |

**IXCLRDataValueDumpTests** -- validates GetSize, GetFlags, GetBytes, GetNumLocations, GetLocationByIndex across all frames above.

**IXCLRDataFrameDumpTests** -- validates GetArgumentByIndex, GetLocalVariableByIndex, GetNumArguments, GetNumLocalVariables, GetContext, GetAppDomain, GetMethodInstance.

### Validation
- All dump tests pass (local runtime)
- SOS tests: non-GetContext tests pass; GetContext failures are pre-existing from #125064
- cdb comparison: zero assertion failures between cDAC and legacy DAC