### PR TITLE
[release/10.0] Avoid C4319 build warnings in libunwind

### DIFF
--- a/src/native/external/libunwind-version.txt
+++ b/src/native/external/libunwind-version.txt
@@ -11,3 +11,4 @@ Revert https://github.com/libunwind/libunwind/commit/ec03043244082b8f552881ba9fb
 Apply https://github.com/libunwind/libunwind/pull/734
 Apply https://github.com/libunwind/libunwind/pull/758
 Apply https://github.com/libunwind/libunwind/pull/741
+Apply https://github.com/libunwind/libunwind/pull/931

--- a/src/native/external/libunwind/include/libunwind_i.h
+++ b/src/native/external/libunwind/include/libunwind_i.h
@@ -437,6 +437,6 @@ static inline void invalidate_edi (struct elf_dyn_info *edi)
 # define DWARF_VAL_LOC(c,v)     DWARF_NULL_LOC
 #endif
 
-#define UNW_ALIGN(x,a) (((x)+(a)-1UL)&~((a)-1UL))
+#define UNW_ALIGN(x,a) (((size_t)(x) + (size_t)(a) - 1) & ~((size_t)(a) - 1))
 
 #endif /* libunwind_i_h */


### PR DESCRIPTION
Backport of #123535 (main) / #122179 (release/9.0) to release/10.0.

Include https://github.com/libunwind/libunwind/pull/931 in the build of the libunwind dependency. Adds `(size_t)` casts to the `UNW_ALIGN` macro to avoid C4319 warnings that are treated as errors with newer MSVC toolsets.

## Context

An MSVC toolset update (`19.44.35220` → `19.44.35221`) introduced stricter C4319 analysis. Combined with `/WX` (warnings as errors), this breaks the cross-OS DAC build of libunwind on Windows:

```
mempool.c(96): error C2220: the following warning is treated as an error
mempool.c(96): warning C4319: '~': zero extending 'unsigned long' to 'size_t' of greater size
```

This is causing `Windows_x86_BuildPass2` failures in the VMR dotnet-unified-build pipeline on `release/10.0.1xx` (e.g., internal build [2924142](https://dev.azure.com/dnceng/internal/_build/results?buildId=2924142)).

## Fix

Same one-line fix as #122179 / #123535: cast operands to `size_t` in the `UNW_ALIGN` macro.

## Risk

Low — targeted cast-only change, already validated on 9.0 and main.