### PR TITLE
Add tests for lazy quantifier inside optional group

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -385,6 +385,11 @@ namespace System.Text.RegularExpressions.Tests
             yield return (@"(\(.*?\))+?;", "(a)b);", RegexOptions.None, 0, 6, true, "(a)b);");
             yield return (@"(\(.*?\))*;", "(a)b);", RegexOptions.None, 0, 6, true, "(a)b);");
             yield return (@"(\(.*?\))*?;", "(a)b);", RegexOptions.None, 0, 6, true, "(a)b);");
+            // Lazy quantifier inside optional group where the lazy loop must expand for the rest of the pattern to match.
+            yield return (@"a(b.*?c)?d", "abccd", RegexOptions.None, 0, 5, true, "abccd");
+            yield return (@"a(b.*?c)?d", "abcd", RegexOptions.None, 0, 4, true, "abcd");
+            yield return (@"a(b.*?c)?d", "ad", RegexOptions.None, 0, 2, true, "ad");
+            yield return (@"a(b.*?c)?d", "abce", RegexOptions.None, 0, 4, false, string.Empty);
             // Non-backtracking body: optimization correctly applies. These verify bodies without backtracking
             // inside the outer loop are still correctly matched after the outer loop is made atomic.
             yield return (@"\w+(\(abc\))?,", "Foo(abc),", RegexOptions.None, 0, 9, true, "Foo(abc),");


### PR DESCRIPTION
Add test cases for the pattern `a(b.*?c)?d` to confirm the fix from #124254 addresses the regression reported in #125321, where a lazy quantifier inside an optional group incorrectly failed to match.

Tests cover:
- **Lazy must expand**: `abccd` — lazy `.*?` must grow past first `c` for `d` to match
- **Lazy zero-width**: `abcd` — lazy `.*?` matches nothing, `c` and `d` align immediately
- **Optional group skipped**: `ad` — the entire `(b.*?c)?` group is bypassed
- **No match**: `abce` — no `d` available, match correctly fails