### PR TITLE
Add curl retry flags to wasi-sdk Linux download

### DIFF
--- a/eng/AcquireWasiSdk.targets
+++ b/eng/AcquireWasiSdk.targets
@@ -37,7 +37,7 @@
     <RemoveDir Directories="$(_RuntimeLocalWasiSdkPath)" />
     <MakeDir Directories="$(_RuntimeLocalWasiSdkPath)" />
 
-    <Exec Command="curl --silent -L -o wasi-sdk-$(_WasiSdkVersion).tar.gz $(_WasiSdkUrl) &amp;&amp; tar --strip-components=1 -xzmf wasi-sdk-$(_WasiSdkVersion).tar.gz -C $(_RuntimeLocalWasiSdkPath)"
+    <Exec Command="curl --silent --retry 3 --retry-delay 5 --retry-all-errors -L -o wasi-sdk-$(_WasiSdkVersion).tar.gz $(_WasiSdkUrl) &amp;&amp; tar --strip-components=1 -xzmf wasi-sdk-$(_WasiSdkVersion).tar.gz -C $(_RuntimeLocalWasiSdkPath)"
           Condition="'$(HostOS)' != 'windows'"
           WorkingDirectory="$(ArtifactsObjDir)"
           IgnoreStandardErrorWarningFormat="true" />

--- a/eng/AcquireWasiSdk.targets
+++ b/eng/AcquireWasiSdk.targets
@@ -37,7 +37,7 @@
     <RemoveDir Directories="$(_RuntimeLocalWasiSdkPath)" />
     <MakeDir Directories="$(_RuntimeLocalWasiSdkPath)" />
 
-    <Exec Command="curl --silent --retry 3 --retry-delay 5 --retry-all-errors -L -o wasi-sdk-$(_WasiSdkVersion).tar.gz $(_WasiSdkUrl) &amp;&amp; tar --strip-components=1 -xzmf wasi-sdk-$(_WasiSdkVersion).tar.gz -C $(_RuntimeLocalWasiSdkPath)"
+    <Exec Command="curl --silent --show-error --fail --retry 3 --retry-delay 5 -L -o wasi-sdk-$(_WasiSdkVersion).tar.gz $(_WasiSdkUrl) &amp;&amp; tar --strip-components=1 -xzmf wasi-sdk-$(_WasiSdkVersion).tar.gz -C $(_RuntimeLocalWasiSdkPath)"
           Condition="'$(HostOS)' != 'windows'"
           WorkingDirectory="$(ArtifactsObjDir)"
           IgnoreStandardErrorWarningFormat="true" />


### PR DESCRIPTION
## Summary

The Linux `curl` command in `AcquireWasiSdk.targets` has **no retry logic**, unlike the Windows `download-wasi-sdk.ps1` which retries up to 8 times on partial transfers. This causes transient GitHub download failures (rate limits, network blips, truncated responses) to fail the entire build with a cryptic `tar` error:

```
tar: Error is not recoverable: exiting now
```

## Change

Add `--show-error --fail --retry 3 --retry-delay 5` to the Linux curl invocation:

```diff
- curl --silent -L -o wasi-sdk-25.0.tar.gz <url>
+ curl --silent --show-error --fail --retry 3 --retry-delay 5 -L -o wasi-sdk-25.0.tar.gz <url>
```

- `--retry 3`: Retry up to 3 times on failure
- `--retry-delay 5`: Wait 5 seconds between retries

## Motivation

Build [2924549](https://dev.azure.com/dnceng/internal/_build/results?buildId=2924549) failed on `Linux_Alpine_x64` due to a transient wasi-sdk download failure. The next scheduled build succeeded without any code change — confirming the issue was transient. The Windows download script already handles this case with up to 8 retry attempts.

cc @lewing