### PR TITLE
Fix potential null dereference

### DIFF
--- a/src/coreclr/tools/Common/CommandLineHelpers.cs
+++ b/src/coreclr/tools/Common/CommandLineHelpers.cs
@@ -313,7 +313,8 @@ namespace System.CommandLine
                     {
                         string prefix = input ? string.Empty : "out_"; // prefix output directories for clarity
                         string reproFileDir = prefix + originalToReproPackageFileName.Count.ToString() + Path.DirectorySeparatorChar;
-                        reproPackagePath = Path.Combine(reproFileDir, Path.GetFileName(originalPath));
+                        string fileName = Path.GetFileName(originalPath ?? string.Empty);
+                        reproPackagePath = Path.Combine(reproFileDir, fileName);
                         if (!input)
                         {
                             archive.CreateEntry(reproFileDir); // for outputs just create output directory


### PR DESCRIPTION
Added a fallback to string.Empty for originalPath before calling Path.GetFileName to prevent a potential NullReferenceException.

Found by Linux Verification Center (linuxtesting.org) with SVACE.