### PR TITLE
JIT: Create suspensions/resumptions separately from processing calls in async transformation

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1721,7 +1721,7 @@ void ContinuationLayout::Dump(int indent)
         printf("%*s  +%03u Keep alive object\n", indent, "", KeepAliveOffset);
     }
 
-    if (ExecutionContextOffset)
+    if (ExecutionContextOffset != UINT_MAX)
     {
         printf("%*s  +%03u Execution context\n", indent, "", ExecutionContextOffset);
     }

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1385,11 +1385,11 @@ void AsyncTransformation::Transform(
     unsigned stateNum = (unsigned)m_states.size();
     JITDUMP("  Assigned state %u\n", stateNum);
 
-    BasicBlock* suspendBB = CreateSuspensionBlock(block, call, stateNum);
+    BasicBlock* suspendBB = CreateSuspensionBlock(block, stateNum);
 
     CreateCheckAndSuspendAfterCall(block, call, callDefInfo, suspendBB, remainder);
 
-    BasicBlock* resumeBB = CreateResumptionBlock(*remainder, call, stateNum, layoutBuilder);
+    BasicBlock* resumeBB = CreateResumptionBlock(*remainder, stateNum);
 
     m_states.push_back(AsyncState(stateNum, layoutBuilder, block, call, callDefInfo, suspendBB, resumeBB));
 

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -438,15 +438,29 @@ BasicBlock* Compiler::CreateReturnBB(unsigned* mergedReturnLcl)
     return newReturnBB;
 }
 
-void ContinuationLayoutBuilder::SetReturn(var_types type, ClassLayout* layout)
+void ContinuationLayoutBuilder::AddReturn(const ReturnTypeInfo& info)
 {
-    ReturnType = type;
-    ReturnLayout = layout;
+    for (const ReturnTypeInfo& ret : m_returns)
+    {
+        if ((ret.ReturnType == info.ReturnType) && (ret.ReturnLayout == info.ReturnLayout))
+        {
+            // This return type is already in the layout, no need to add another slot for it.
+            return;
+        }
+    }
+
+    m_returns.push_back(info);
 }
 
 void ContinuationLayoutBuilder::AddLocal(unsigned lclNum)
 {
+    assert(m_locals.empty() || (lclNum > m_locals[m_locals.size() - 1]));
     m_locals.push_back(lclNum);
+}
+
+bool ContinuationLayoutBuilder::ContainsLocal(unsigned lclNum) const
+{
+    return BinarySearch(m_locals.data(), (int)m_locals.size(), lclNum) != nullptr;
 }
 
 //------------------------------------------------------------------------
@@ -1189,6 +1203,8 @@ PhaseStatus AsyncTransformation::Run()
         } while (any);
     }
 
+    CreateResumptionsAndSuspensions();
+
     // After transforming all async calls we have created resumption blocks;
     // create the resumption switch.
     CreateResumptionSwitch();
@@ -1329,22 +1345,21 @@ void AsyncTransformation::Transform(
     CreateLiveSetForSuspension(block, call, defs, life, layoutBuilder);
 
     BuildContinuation(block, call, ContinuationNeedsKeepAlive(life), layoutBuilder);
-    //ContinuationLayout layout = LayOutContinuation(block, call, ContinuationNeedsKeepAlive(life), liveLocals);
 
     CallDefinitionInfo callDefInfo = CanonicalizeCallDefinition(block, call, &life);
 
     unsigned stateNum = (unsigned)m_states.size();
     JITDUMP("  Assigned state %u\n", stateNum);
 
-    BasicBlock* suspendBB = CreateSuspension(block, call, stateNum, life, layout);
+    BasicBlock* suspendBB = CreateSuspensionBlock(block, call, stateNum);
 
     CreateCheckAndSuspendAfterCall(block, call, callDefInfo, suspendBB, remainder);
 
-    BasicBlock* resumeBB = CreateResumption(block, *remainder, call, callDefInfo, stateNum, layout);
+    BasicBlock* resumeBB = CreateResumptionBlock(*remainder, call, stateNum, layoutBuilder);
 
-    m_states.push_back(AsyncState(layoutBuilder, suspendBB, resumeBB));
+    m_states.push_back(AsyncState(stateNum, layoutBuilder, block, call, callDefInfo, suspendBB, resumeBB));
 
-    CreateDebugInfoForSuspensionPoint(layout);
+    JITDUMP("\n");
 }
 
 //------------------------------------------------------------------------
@@ -1577,10 +1592,11 @@ public:
 
 void AsyncTransformation::BuildContinuation(BasicBlock* block, GenTreeCall* call, bool needsKeepAlive, ContinuationLayoutBuilder* layoutBuilder)
 {
-    layoutBuilder->SetReturn(call->gtReturnType, m_compiler->typGetObjLayout(call->gtRetClsHnd));
     if (call->gtReturnType != TYP_VOID)
     {
-        JITDUMP("Call has return; continuation will have return value\n");
+        ClassLayout* layout = call->gtReturnType == TYP_STRUCT ? m_compiler->typGetObjLayout(call->gtRetClsHnd) : nullptr;
+        layoutBuilder->AddReturn(ReturnTypeInfo(call->gtReturnType, layout));
+        JITDUMP("  Call has return; continuation will have return value\n");
     }
 
     // For OSR, we store the IL offset that inspired the OSR method at the
@@ -1622,31 +1638,70 @@ void AsyncTransformation::BuildContinuation(BasicBlock* block, GenTreeCall* call
     JITDUMP("  Call has async-only save and restore of ExecutionContext; continuation will have ExecutionContext\n");
 }
 
-//------------------------------------------------------------------------
-// AsyncTransformation::LayOutContinuation:
-//   Create the layout of the GC pointer and data arrays in the continuation
-//   object.
-//
-// Parameters:
-//   block          - The block containing the async call
-//   call           - The async call
-//   needsKeepAlive - Whether the layout needs a "keep alive" field allocated
-//   liveLocals     - [in, out] Information about each live local. Size/alignment
-//                    information is read and offset/index information is written.
-//
-// Returns:
-//   Layout information.
-//
-ContinuationLayout AsyncTransformation::LayOutContinuation(BasicBlock*                    block,
-                                                           GenTreeCall*                   call,
-                                                           bool                           needsKeepAlive,
-                                                           jitstd::vector<LiveLocalInfo>& liveLocals)
+#ifdef DEBUG
+void ContinuationLayout::Dump(int indent)
 {
-    ContinuationLayout layout(liveLocals);
-
-    for (LiveLocalInfo& inf : liveLocals)
+    printf("%*sContinuation layout (%u bytes):\n", indent, "", Size);
+    if (OSRILOffset != UINT_MAX)
     {
-        LclVarDsc* dsc = m_compiler->lvaGetDesc(inf.LclNum);
+        printf("%*s  +%03u OSR IL offset\n", indent, "", OSRILOffset);
+    }
+
+    if (ExceptionOffset != UINT_MAX)
+    {
+        printf("%*s  +%03u Exception\n", indent, "", ExceptionOffset);
+    }
+
+    if (ContinuationContextOffset != UINT_MAX)
+    {
+        printf("%*s  +%03u Continuation context\n", indent, "", ContinuationContextOffset);
+    }
+
+    if (KeepAliveOffset != UINT_MAX)
+    {
+        printf("%*s  +%03u Keep alive object\n", indent, "", KeepAliveOffset);
+    }
+
+    if (ExecutionContextOffset)
+    {
+        printf("%*s  +%03u Execution context\n", indent, "", ExecutionContextOffset);
+    }
+
+    for (const LiveLocalInfo& inf : Locals)
+    {
+        printf("%*s  +%03u V%02u: %u bytes\n", indent, "", inf.Offset, inf.LclNum, inf.Size);
+    }
+
+    for (const ReturnInfo& ret : Returns)
+    {
+        printf("%*s  +%03u %u bytes for %s return\n", indent, "", ret.Offset, ret.Size, ret.Type.ReturnType == TYP_STRUCT ? ret.Type.ReturnLayout->GetClassName() : varTypeName(ret.Type.ReturnType));
+    }
+}
+#endif
+
+const ReturnInfo* ContinuationLayout::FindReturn(GenTreeCall* call) const
+{
+    for (const ReturnInfo& ret : Returns)
+    {
+        if ((ret.Type.ReturnType == call->gtReturnType) && ((call->gtReturnType != TYP_STRUCT) || (ret.Type.ReturnLayout->GetClassHandle() == call->gtRetClsHnd)))
+        {
+            return &ret;
+        }
+    }
+
+    assert(!"Could not find return for call");
+    return nullptr;
+}
+
+ContinuationLayout* ContinuationLayoutBuilder::Create()
+{
+    ContinuationLayout* layout = new (m_compiler, CMK_Async) ContinuationLayout(m_compiler);
+    layout->Locals.reserve(m_locals.size());
+
+    for (unsigned lclNum : m_locals)
+    {
+        LclVarDsc* dsc = m_compiler->lvaGetDesc(lclNum);
+        LiveLocalInfo inf(lclNum);
 
         if (dsc->TypeIs(TYP_STRUCT) || dsc->IsImplicitByRef())
         {
@@ -1677,13 +1732,10 @@ ContinuationLayout AsyncTransformation::LayOutContinuation(BasicBlock*          
             inf.Size      = genTypeSize(dsc);
         }
 
-        // Saving/storing of longs here may be the first place we introduce
-        // long IR. We need to potentially decompose this on x86, so indicate
-        // that to the backend.
-        m_compiler->compLongUsed |= dsc->TypeIs(TYP_LONG);
+        layout->Locals.push_back(inf);
     }
 
-    jitstd::sort(liveLocals.begin(), liveLocals.end(), [=](const LiveLocalInfo& lhs, const LiveLocalInfo& rhs) {
+    jitstd::sort(layout->Locals.begin(), layout->Locals.end(), [=](const LiveLocalInfo& lhs, const LiveLocalInfo& rhs) {
         bool lhsIsRef = m_compiler->lvaGetDesc(lhs.LclNum)->TypeIs(TYP_REF);
         bool rhsIsRef = m_compiler->lvaGetDesc(rhs.LclNum)->TypeIs(TYP_REF);
 
@@ -1703,112 +1755,84 @@ ContinuationLayout AsyncTransformation::LayOutContinuation(BasicBlock*          
         return lhs.LclNum < rhs.LclNum;
     });
 
-    if (call->gtReturnType == TYP_STRUCT)
+    for (const ReturnTypeInfo& ret : m_returns)
     {
-        layout.ReturnStructLayout = m_compiler->typGetObjLayout(call->gtRetClsHnd);
-        layout.ReturnSize         = layout.ReturnStructLayout->GetSize();
-        layout.ReturnAlignment    = m_compiler->info.compCompHnd->getClassAlignmentRequirement(call->gtRetClsHnd);
-    }
-    else
-    {
-        layout.ReturnSize      = genTypeSize(call->gtReturnType);
-        layout.ReturnAlignment = layout.ReturnSize;
+        ReturnInfo retInfo(ret);
+
+        if (ret.ReturnType == TYP_STRUCT)
+        {
+            retInfo.Size = ret.ReturnLayout->GetSize();
+            retInfo.Alignment = m_compiler->info.compCompHnd->getClassAlignmentRequirement(ret.ReturnLayout->GetClassHandle());
+        }
+        else
+        {
+            retInfo.Size = genTypeSize(ret.ReturnType);
+            retInfo.Alignment = retInfo.Size;
+        }
+
+        layout->Returns.push_back(retInfo);
     }
 
-    assert((layout.ReturnSize > 0) == (call->gtReturnType != TYP_VOID));
-
-    auto allocLayout = [&layout](unsigned align, unsigned size) {
-        layout.Size     = roundUp(layout.Size, align);
-        unsigned offset = layout.Size;
-        layout.Size += size;
+    auto allocLayout = [layout](unsigned align, unsigned size) {
+        layout->Size     = roundUp(layout->Size, align);
+        unsigned offset = layout->Size;
+        layout->Size += size;
         return offset;
     };
 
-    // For OSR, we store the IL offset that inspired the OSR method at the
-    // beginning of the data (and store -1 in the tier0 version). This must be
-    // at the beginning because the tier0 and OSR versions need to agree on
-    // this.
-    if (m_compiler->doesMethodHavePatchpoints() || m_compiler->opts.IsOSR())
+    if (m_needsOSRILOffset)
     {
-        JITDUMP("  Method %s; keeping IL offset that inspired OSR method at the beginning of non-GC data\n",
-                m_compiler->doesMethodHavePatchpoints() ? "has patchpoints" : "is an OSR method");
         // Must be pointer sized for compatibility with Continuation methods that access fields
-        layout.OSRILOffset = allocLayout(TARGET_POINTER_SIZE, TARGET_POINTER_SIZE);
+        layout->OSRILOffset = allocLayout(TARGET_POINTER_SIZE, TARGET_POINTER_SIZE);
     }
 
-    if (HasNonContextRestoreExceptionalFlow(block))
+    if (m_needsException)
     {
-        // If we are enclosed in any try region that isn't our special "context
-        // restore" try region then we need to rethrow an exception. For our
-        // special "context restore" try region we know that it is a no-op on
-        // the resumption path.
-        layout.ExceptionOffset = allocLayout(TARGET_POINTER_SIZE, TARGET_POINTER_SIZE);
-        JITDUMP("  " FMT_BB " is in try region %u; exception will be at offset %u\n", block->bbNum,
-                block->getTryIndex(), layout.ExceptionOffset);
+        layout->ExceptionOffset = allocLayout(TARGET_POINTER_SIZE, TARGET_POINTER_SIZE);
     }
 
-    if (call->GetAsyncInfo().ContinuationContextHandling == ContinuationContextHandling::ContinueOnCapturedContext)
+    if (m_needsContinuationContext)
     {
-        layout.ContinuationContextOffset = allocLayout(TARGET_POINTER_SIZE, TARGET_POINTER_SIZE);
-        JITDUMP("  Continuation continues on captured context; context will be at offset %u\n",
-                layout.ContinuationContextOffset);
+        layout->ContinuationContextOffset = allocLayout(TARGET_POINTER_SIZE, TARGET_POINTER_SIZE);
     }
 
-    if (layout.ReturnSize > 0)
+    // Now allocate all  returns
+    for (ReturnInfo& ret : layout->Returns)
     {
-        layout.ReturnValOffset = allocLayout(layout.ReturnHeapAlignment(), layout.ReturnSize);
-
-        JITDUMP("  Will store return of type %s, size %u at offset %u\n",
-                call->gtReturnType == TYP_STRUCT ? layout.ReturnStructLayout->GetClassName()
-                                                 : varTypeName(call->gtReturnType),
-                layout.ReturnSize, layout.ReturnValOffset);
+        ret.Offset = allocLayout(ret.Alignment, ret.Size);
     }
 
-    if (needsKeepAlive)
+    if (m_needsKeepAlive)
     {
-        layout.KeepAliveOffset = allocLayout(TARGET_POINTER_SIZE, TARGET_POINTER_SIZE);
-        JITDUMP("  Continuation needs keep alive object; will be at offset %u\n", layout.KeepAliveOffset);
+        layout->KeepAliveOffset = allocLayout(TARGET_POINTER_SIZE, TARGET_POINTER_SIZE);
     }
 
-    layout.ExecutionContextOffset = allocLayout(TARGET_POINTER_SIZE, TARGET_POINTER_SIZE);
-    JITDUMP("  Call has async-only save and restore of ExecutionContext; ExecutionContext will be at offset %u\n",
-            layout.ExecutionContextOffset);
+    if (m_needsExecutionContext)
+    {
+        layout->ExecutionContextOffset = allocLayout(TARGET_POINTER_SIZE, TARGET_POINTER_SIZE);
+    }
 
-    for (LiveLocalInfo& inf : liveLocals)
+    // Then all locals
+    for (LiveLocalInfo& inf : layout->Locals)
     {
         inf.Offset = allocLayout(inf.HeapAlignment(), inf.Size);
     }
 
-    layout.Size = roundUp(layout.Size, TARGET_POINTER_SIZE);
+    layout->Size = roundUp(layout->Size, TARGET_POINTER_SIZE);
 
-#ifdef DEBUG
-    if (m_compiler->verbose)
-    {
-        printf("  Continuation layout (%u bytes):\n", layout.Size);
-        for (LiveLocalInfo& inf : liveLocals)
-        {
-            printf("    +%03u V%02u: %u bytes\n", inf.Offset, inf.LclNum, inf.Size);
-        }
-    }
-#endif
-
+    JITDUMPEXEC(layout->Dump(2));
     // Now create continuation type. First create bitmap of object refs.
-    bool* objRefs = layout.Size < TARGET_POINTER_SIZE
+    bool* objRefs = layout->Size < TARGET_POINTER_SIZE
                         ? nullptr
-                        : new (m_compiler, CMK_Async) bool[layout.Size / TARGET_POINTER_SIZE]{};
+                        : new (m_compiler, CMK_Async) bool[layout->Size / TARGET_POINTER_SIZE]{};
 
-    GCPointerBitMapBuilder bitmapBuilder(objRefs, layout.Size);
-    bitmapBuilder.SetIfNotMax(layout.ExceptionOffset);
-    bitmapBuilder.SetIfNotMax(layout.ContinuationContextOffset);
-    bitmapBuilder.SetIfNotMax(layout.KeepAliveOffset);
-    bitmapBuilder.SetIfNotMax(layout.ExecutionContextOffset);
+    GCPointerBitMapBuilder bitmapBuilder(objRefs, layout->Size);
+    bitmapBuilder.SetIfNotMax(layout->ExceptionOffset);
+    bitmapBuilder.SetIfNotMax(layout->ContinuationContextOffset);
+    bitmapBuilder.SetIfNotMax(layout->KeepAliveOffset);
+    bitmapBuilder.SetIfNotMax(layout->ExecutionContextOffset);
 
-    if (layout.ReturnSize > 0)
-    {
-        bitmapBuilder.SetType(layout.ReturnValOffset, call->gtReturnType, layout.ReturnStructLayout);
-    }
-
-    for (LiveLocalInfo& inf : liveLocals)
+    for (LiveLocalInfo& inf : layout->Locals)
     {
         LclVarDsc*   dsc = m_compiler->lvaGetDesc(inf.LclNum);
         var_types    storedType;
@@ -1826,12 +1850,17 @@ ContinuationLayout AsyncTransformation::LayOutContinuation(BasicBlock*          
         bitmapBuilder.SetType(inf.Offset, storedType, layout);
     }
 
+    for (ReturnInfo& ret : layout->Returns)
+    {
+        bitmapBuilder.SetType(ret.Offset, ret.Type.ReturnType, ret.Type.ReturnLayout);
+    }
+
 #ifdef DEBUG
     if (m_compiler->verbose)
     {
-        printf("Getting continuation layout size = %u, numGCRefs = %u\n", layout.Size, bitmapBuilder.NumObjRefs);
+        printf("  Getting continuation layout size = %u, numGCRefs = %u\n", layout->Size, bitmapBuilder.NumObjRefs);
         bool* start        = objRefs;
-        bool* endOfObjRefs = objRefs + layout.Size / TARGET_POINTER_SIZE;
+        bool* endOfObjRefs = objRefs + layout->Size / TARGET_POINTER_SIZE;
         while (start < endOfObjRefs)
         {
             while (start < endOfObjRefs && !*start)
@@ -1844,19 +1873,21 @@ ContinuationLayout AsyncTransformation::LayOutContinuation(BasicBlock*          
             while (end < endOfObjRefs && *end)
                 end++;
 
-            printf("  [%3u..%3u) obj refs\n", (start - objRefs) * TARGET_POINTER_SIZE,
+            printf("    [%3u..%3u) obj refs\n", (start - objRefs) * TARGET_POINTER_SIZE,
                    (end - objRefs) * TARGET_POINTER_SIZE);
             start = end;
         }
     }
 #endif
 
-    layout.ClassHnd =
-        m_compiler->info.compCompHnd->getContinuationType(layout.Size, objRefs, layout.Size / TARGET_POINTER_SIZE);
+    // Then request the new type from the VM.
+
+    layout->ClassHnd =
+        m_compiler->info.compCompHnd->getContinuationType(layout->Size, objRefs, layout->Size / TARGET_POINTER_SIZE);
 
 #ifdef DEBUG
     char buffer[256];
-    JITDUMP("  Result = %s\n", m_compiler->eeGetClassName(layout.ClassHnd, buffer, ArrLen(buffer)));
+    JITDUMP("  Result = %s\n", m_compiler->eeGetClassName(layout->ClassHnd, buffer, ArrLen(buffer)));
 #endif
 
     return layout;
@@ -1984,15 +2015,6 @@ BasicBlock* AsyncTransformation::CreateSuspensionBlock(BasicBlock* block, GenTre
 
     JITDUMP("  Creating suspension " FMT_BB " for state %u\n", suspendBB->bbNum, stateNum);
 
-    GenTreeILOffset* ilOffsetNode =
-        m_compiler->gtNewILOffsetNode(call->GetAsyncInfo().CallAsyncDebugInfo DEBUGARG(BAD_IL_OFFSET));
-
-    LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_compiler, ilOffsetNode));
-
-    GenTree* recordOffset =
-        new (m_compiler, GT_RECORD_ASYNC_RESUME) GenTreeVal(GT_RECORD_ASYNC_RESUME, TYP_VOID, stateNum);
-    LIR::AsRange(suspendBB).InsertAtEnd(recordOffset);
-
     return suspendBB;
 }
 
@@ -2011,27 +2033,9 @@ BasicBlock* AsyncTransformation::CreateSuspensionBlock(BasicBlock* block, GenTre
 // Returns:
 //   The new basic block that was created.
 //
-BasicBlock* AsyncTransformation::CreateSuspension(
-    BasicBlock* block, GenTreeCall* call, unsigned stateNum, AsyncLiveness& life, const ContinuationLayout& layout)
+void AsyncTransformation::CreateSuspension(
+    BasicBlock* callBlock, GenTreeCall* call, BasicBlock* suspendBB, unsigned stateNum, const ContinuationLayout& layout, const ContinuationLayoutBuilder& subLayout)
 {
-    if (m_lastSuspensionBB == nullptr)
-    {
-        m_lastSuspensionBB = m_compiler->fgLastBBInMainFunction();
-    }
-
-    BasicBlock* suspendBB = m_compiler->fgNewBBafter(BBJ_RETURN, m_lastSuspensionBB, false);
-    suspendBB->clearTryIndex();
-    suspendBB->clearHndIndex();
-    suspendBB->inheritWeightPercentage(block, 0);
-    m_lastSuspensionBB = suspendBB;
-
-    if (m_sharedReturnBB != nullptr)
-    {
-        suspendBB->SetKindAndTargetEdge(BBJ_ALWAYS, m_compiler->fgAddRefPred(m_sharedReturnBB, suspendBB));
-    }
-
-    JITDUMP("  Creating suspension " FMT_BB " for state %u\n", suspendBB->bbNum, stateNum);
-
     GenTreeILOffset* ilOffsetNode =
         m_compiler->gtNewILOffsetNode(call->GetAsyncInfo().CallAsyncDebugInfo DEBUGARG(BAD_IL_OFFSET));
 
@@ -2044,7 +2048,7 @@ BasicBlock* AsyncTransformation::CreateSuspension(
     // Allocate continuation
     GenTree* returnedContinuation = m_compiler->gtNewLclvNode(GetReturnedContinuationVar(), TYP_REF);
 
-    GenTreeCall* allocContinuation = CreateAllocContinuationCall(life, returnedContinuation, layout);
+    GenTreeCall* allocContinuation = CreateAllocContinuationCall(subLayout.NeedsKeepAlive(), returnedContinuation, layout);
 
     m_compiler->compCurBB = suspendBB;
     m_compiler->fgMorphTree(allocContinuation);
@@ -2072,13 +2076,13 @@ BasicBlock* AsyncTransformation::CreateSuspension(
     // Fill in 'flags'
     const AsyncCallInfo& callInfo          = call->GetAsyncInfo();
     unsigned             continuationFlags = 0;
-    if (layout.OSRILOffset != UINT_MAX)
+    if (subLayout.NeedsOSRILOffset())
         continuationFlags |= CORINFO_CONTINUATION_HAS_OSR_ILOFFSET;
-    if (layout.ExceptionOffset != UINT_MAX)
+    if (subLayout.NeedsException())
         continuationFlags |= CORINFO_CONTINUATION_HAS_EXCEPTION;
-    if (layout.ContinuationContextOffset != UINT_MAX)
+    if (subLayout.NeedsContinuationContext())
         continuationFlags |= CORINFO_CONTINUATION_HAS_CONTINUATION_CONTEXT;
-    if (layout.ReturnValOffset != UINT_MAX)
+    if (call->gtReturnType != TYP_VOID)
         continuationFlags |= CORINFO_CONTINUATION_HAS_RESULT;
     if (callInfo.ContinuationContextHandling == ContinuationContextHandling::ContinueOnThreadPool)
         continuationFlags |= CORINFO_CONTINUATION_CONTINUE_ON_THREAD_POOL;
@@ -2091,10 +2095,10 @@ BasicBlock* AsyncTransformation::CreateSuspension(
 
     if (layout.Size > 0)
     {
-        FillInDataOnSuspension(call, layout, suspendBB);
+        FillInDataOnSuspension(call, layout, subLayout, suspendBB);
     }
 
-    RestoreContexts(block, call, suspendBB);
+    RestoreContexts(callBlock, call, suspendBB);
 
     if (suspendBB->KindIs(BBJ_RETURN))
     {
@@ -2102,8 +2106,6 @@ BasicBlock* AsyncTransformation::CreateSuspension(
         GenTree* ret    = m_compiler->gtNewOperNode(GT_RETURN_SUSPEND, TYP_VOID, newContinuation);
         LIR::AsRange(suspendBB).InsertAtEnd(newContinuation, ret);
     }
-
-    return suspendBB;
 }
 
 //------------------------------------------------------------------------
@@ -2118,14 +2120,14 @@ BasicBlock* AsyncTransformation::CreateSuspension(
 // Returns:
 //   IR node representing the allocation.
 //
-GenTreeCall* AsyncTransformation::CreateAllocContinuationCall(AsyncLiveness&            life,
+GenTreeCall* AsyncTransformation::CreateAllocContinuationCall(bool hasKeepAlive,
                                                               GenTree*                  prevContinuation,
                                                               const ContinuationLayout& layout)
 {
     GenTree* contClassHndNode = m_compiler->gtNewIconEmbClsHndNode(layout.ClassHnd);
 
     // If we need to keep the loader alive, use a different helper.
-    if (ContinuationNeedsKeepAlive(life))
+    if (hasKeepAlive)
     {
         assert(layout.KeepAliveOffset != UINT_MAX);
         GenTree* handleArg = m_compiler->gtNewLclvNode(m_compiler->info.compTypeCtxtArg, TYP_I_IMPL);
@@ -2155,6 +2157,7 @@ GenTreeCall* AsyncTransformation::CreateAllocContinuationCall(AsyncLiveness&    
 //
 void AsyncTransformation::FillInDataOnSuspension(GenTreeCall*              call,
                                                  const ContinuationLayout& layout,
+                                                 const ContinuationLayoutBuilder& subLayout,
                                                  BasicBlock*               suspendBB)
 {
     if (m_compiler->doesMethodHavePatchpoints() || m_compiler->opts.IsOSR())
@@ -2177,7 +2180,10 @@ void AsyncTransformation::FillInDataOnSuspension(GenTreeCall*              call,
     // Fill in data
     for (const LiveLocalInfo& inf : layout.Locals)
     {
-        assert(inf.Size > 0);
+        if (!subLayout.ContainsLocal(inf.LclNum))
+        {
+            continue;
+        }
 
         LclVarDsc* dsc = m_compiler->lvaGetDesc(inf.LclNum);
 
@@ -2211,9 +2217,14 @@ void AsyncTransformation::FillInDataOnSuspension(GenTreeCall*              call,
         }
 
         LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_compiler, store));
+
+        // Saving/storing of longs here may be the first place we introduce
+        // long IR. We need to potentially decompose this on x86, so indicate
+        // that to the backend.
+        m_compiler->compLongUsed |= dsc->TypeIs(TYP_LONG);
     }
 
-    if (layout.ContinuationContextOffset != UINT_MAX)
+    if (subLayout.NeedsContinuationContext())
     {
         // Insert call
         //   AsyncHelpers.CaptureContinuationContext(
@@ -2264,7 +2275,7 @@ void AsyncTransformation::FillInDataOnSuspension(GenTreeCall*              call,
         LIR::AsRange(suspendBB).Remove(flagsPlaceholder);
     }
 
-    if (layout.ExecutionContextOffset != UINT_MAX)
+    if (subLayout.NeedsExecutionContext())
     {
         GenTreeCall* captureExecContext =
             m_compiler->gtNewCallNode(CT_USER_FUNC, m_asyncInfo->captureExecutionContextMethHnd, TYP_REF);
@@ -2433,28 +2444,7 @@ void AsyncTransformation::CreateCheckAndSuspendAfterCall(BasicBlock*            
     block->GetFalseEdge()->setLikelihood(1);
 }
 
-//------------------------------------------------------------------------
-// AsyncTransformation::CreateResumption:
-//   Create the basic block that when branched to resumes execution on entry to
-//   the function.
-//
-// Parameters:
-//   block       - The block containing the async call
-//   remainder   - The block that contains the IR after the (split) async call
-//   call        - The async call
-//   callDefInfo - Information about the async call's definition
-//   stateNum    - State number assigned to this suspension point
-//   layout      - Layout information for the continuation object
-//
-// Returns:
-//   The new basic block that was created.
-//
-BasicBlock* AsyncTransformation::CreateResumption(BasicBlock*               block,
-                                                  BasicBlock*               remainder,
-                                                  GenTreeCall*              call,
-                                                  const CallDefinitionInfo& callDefInfo,
-                                                  unsigned                  stateNum,
-                                                  const ContinuationLayout& layout)
+BasicBlock* AsyncTransformation::CreateResumptionBlock(BasicBlock* remainder, GenTreeCall* call, unsigned stateNum, ContinuationLayoutBuilder* layoutBuilder)
 {
     if (m_lastResumptionBB == nullptr)
     {
@@ -2474,6 +2464,32 @@ BasicBlock* AsyncTransformation::CreateResumption(BasicBlock*               bloc
 
     JITDUMP("  Creating resumption " FMT_BB " for state %u\n", resumeBB->bbNum, stateNum);
 
+    return resumeBB;
+}
+
+//------------------------------------------------------------------------
+// AsyncTransformation::CreateResumption:
+//   Create the basic block that when branched to resumes execution on entry to
+//   the function.
+//
+// Parameters:
+//   block       - The block containing the async call
+//   remainder   - The block that contains the IR after the (split) async call
+//   call        - The async call
+//   callDefInfo - Information about the async call's definition
+//   stateNum    - State number assigned to this suspension point
+//   layout      - Layout information for the continuation object
+//
+// Returns:
+//   The new basic block that was created.
+//
+void AsyncTransformation::CreateResumption(BasicBlock*               callBlock,
+                                                  GenTreeCall*              call,
+                                                  BasicBlock*               resumeBB,
+                                                  const CallDefinitionInfo& callDefInfo,
+                                                  const ContinuationLayout& layout,
+                                                  const ContinuationLayoutBuilder& subLayout)
+{
     GenTreeILOffset* ilOffsetNode =
         m_compiler->gtNewILOffsetNode(call->GetAsyncInfo().CallAsyncDebugInfo DEBUGARG(BAD_IL_OFFSET));
 
@@ -2481,22 +2497,20 @@ BasicBlock* AsyncTransformation::CreateResumption(BasicBlock*               bloc
 
     if (layout.Size > 0)
     {
-        RestoreFromDataOnResumption(layout, resumeBB);
+        RestoreFromDataOnResumption(layout, subLayout, resumeBB);
     }
 
     BasicBlock* storeResultBB = resumeBB;
 
-    if (layout.ExceptionOffset != UINT_MAX)
+    if (subLayout.NeedsException())
     {
-        storeResultBB = RethrowExceptionOnResumption(block, layout, resumeBB);
+        storeResultBB = RethrowExceptionOnResumption(callBlock, layout, resumeBB);
     }
 
-    if ((layout.ReturnSize > 0) && (callDefInfo.DefinitionNode != nullptr))
+    if ((call->gtReturnType != TYP_VOID) && (callDefInfo.DefinitionNode != nullptr))
     {
         CopyReturnValueOnResumption(call, callDefInfo, layout, storeResultBB);
     }
-
-    return resumeBB;
 }
 
 //------------------------------------------------------------------------
@@ -2508,9 +2522,9 @@ BasicBlock* AsyncTransformation::CreateResumption(BasicBlock*               bloc
 //   layout   - Information about the continuation layout
 //   resumeBB - Basic block to append IR to
 //
-void AsyncTransformation::RestoreFromDataOnResumption(const ContinuationLayout& layout, BasicBlock* resumeBB)
+void AsyncTransformation::RestoreFromDataOnResumption(const ContinuationLayout& layout, const ContinuationLayoutBuilder& subLayout, BasicBlock* resumeBB)
 {
-    if (layout.ExecutionContextOffset != BAD_VAR_NUM)
+    if (subLayout.NeedsExecutionContext())
     {
         GenTree*     valuePlaceholder = m_compiler->gtNewZeroConNode(TYP_REF);
         GenTreeCall* restoreCall =
@@ -2540,6 +2554,11 @@ void AsyncTransformation::RestoreFromDataOnResumption(const ContinuationLayout& 
     // Copy data
     for (const LiveLocalInfo& inf : layout.Locals)
     {
+        if (!subLayout.ContainsLocal(inf.LclNum))
+        {
+            continue;
+        }
+
         LclVarDsc* dsc = m_compiler->lvaGetDesc(inf.LclNum);
 
         GenTree* continuation = m_compiler->gtNewLclvNode(m_compiler->lvaAsyncContinuationArg, TYP_REF);
@@ -2574,7 +2593,7 @@ void AsyncTransformation::RestoreFromDataOnResumption(const ContinuationLayout& 
         LIR::AsRange(resumeBB).InsertAtEnd(LIR::SeqTree(m_compiler, store));
     }
 
-    if (layout.KeepAliveOffset != UINT_MAX)
+    if (subLayout.NeedsKeepAlive())
     {
         // Ensure that the continuation remains alive until we finished loading the generic context
         GenTree* continuation = m_compiler->gtNewLclvNode(m_compiler->lvaAsyncContinuationArg, TYP_REF);
@@ -2685,14 +2704,16 @@ void AsyncTransformation::CopyReturnValueOnResumption(GenTreeCall*              
                                                       const ContinuationLayout& layout,
                                                       BasicBlock*               storeResultBB)
 {
+    const ReturnInfo* retInfo = layout.FindReturn(call);
+    assert(retInfo != nullptr);
     GenTree* resultBase   = m_compiler->gtNewLclvNode(m_compiler->lvaAsyncContinuationArg, TYP_REF);
-    unsigned resultOffset = OFFSETOF__CORINFO_Continuation__data + layout.ReturnValOffset;
+    unsigned resultOffset = OFFSETOF__CORINFO_Continuation__data + retInfo->Offset;
 
     assert(callDefInfo.DefinitionNode != nullptr);
     LclVarDsc* resultLcl = m_compiler->lvaGetDesc(callDefInfo.DefinitionNode);
 
     GenTreeFlags indirFlags =
-        GTF_IND_NONFAULTING | (layout.ReturnHeapAlignment() < layout.ReturnAlignment ? GTF_IND_UNALIGNED : GTF_EMPTY);
+        GTF_IND_NONFAULTING | (retInfo->HeapAlignment() < retInfo->Alignment ? GTF_IND_UNALIGNED : GTF_EMPTY);
 
     // TODO-TP: We can use liveness to avoid generating a lot of this IR.
     if (call->gtReturnType == TYP_STRUCT)
@@ -2701,17 +2722,17 @@ void AsyncTransformation::CopyReturnValueOnResumption(GenTreeCall*              
         {
             GenTree* resultOffsetNode = m_compiler->gtNewIconNode((ssize_t)resultOffset, TYP_I_IMPL);
             GenTree* resultAddr       = m_compiler->gtNewOperNode(GT_ADD, TYP_BYREF, resultBase, resultOffsetNode);
-            GenTree* resultData = m_compiler->gtNewLoadValueNode(layout.ReturnStructLayout, resultAddr, indirFlags);
+            GenTree* resultData = m_compiler->gtNewLoadValueNode(retInfo->Type.ReturnLayout, resultAddr, indirFlags);
             GenTree* storeResult;
             if ((callDefInfo.DefinitionNode->GetLclOffs() == 0) &&
-                ClassLayout::AreCompatible(resultLcl->GetLayout(), layout.ReturnStructLayout))
+                ClassLayout::AreCompatible(resultLcl->GetLayout(), retInfo->Type.ReturnLayout))
             {
                 storeResult = m_compiler->gtNewStoreLclVarNode(callDefInfo.DefinitionNode->GetLclNum(), resultData);
             }
             else
             {
                 storeResult = m_compiler->gtNewStoreLclFldNode(callDefInfo.DefinitionNode->GetLclNum(), TYP_STRUCT,
-                                                               layout.ReturnStructLayout,
+                                                               retInfo->Type.ReturnLayout,
                                                                callDefInfo.DefinitionNode->GetLclOffs(), resultData);
             }
 
@@ -2829,12 +2850,17 @@ GenTreeStoreInd* AsyncTransformation::StoreAtOffset(
 // Parameters:
 //   layout         - Layout of continuation
 //
-void AsyncTransformation::CreateDebugInfoForSuspensionPoint(const ContinuationLayout& layout)
+void AsyncTransformation::CreateDebugInfoForSuspensionPoint(const ContinuationLayout& layout, const ContinuationLayoutBuilder& subLayout)
 {
     uint32_t numLocals = 0;
-    for (const LiveLocalInfo& local : layout.Locals)
+    for (const LiveLocalInfo& inf : layout.Locals)
     {
-        unsigned ilVarNum = m_compiler->compMap2ILvarNum(local.LclNum);
+        if (!subLayout.ContainsLocal(inf.LclNum))
+        {
+            continue;
+        }
+
+        unsigned ilVarNum = m_compiler->compMap2ILvarNum(inf.LclNum);
         if (ilVarNum == (unsigned)ICorDebugInfo::UNKNOWN_ILNUM)
         {
             continue;
@@ -2842,7 +2868,7 @@ void AsyncTransformation::CreateDebugInfoForSuspensionPoint(const ContinuationLa
 
         ICorDebugInfo::AsyncContinuationVarInfo varInf;
         varInf.VarNumber = ilVarNum;
-        varInf.Offset    = OFFSETOF__CORINFO_Continuation__data + local.Offset;
+        varInf.Offset    = OFFSETOF__CORINFO_Continuation__data + inf.Offset;
         m_compiler->compAsyncVars->push_back(varInf);
         numLocals++;
     }
@@ -2971,6 +2997,66 @@ BasicBlock* AsyncTransformation::GetSharedReturnBB()
 #endif
 }
 
+void AsyncTransformation::CreateResumptionsAndSuspensions()
+{
+    JITDUMP("Creating suspensions and resumptions for %zu states\n", m_states.size());
+    for (const AsyncState& state : m_states)
+    {
+        JITDUMP("State %u suspend @ " FMT_BB ", resume @ " FMT_BB "\n", state.Number, state.SuspensionBB->bbNum, state.ResumptionBB->bbNum);
+        ContinuationLayout* layout = state.Layout->Create();
+        CreateSuspension(state.CallBlock, state.Call, state.SuspensionBB, state.Number, *layout, *state.Layout);
+        CreateResumption(state.CallBlock, state.Call, state.ResumptionBB, state.CallDefInfo, *layout, *state.Layout);
+        CreateDebugInfoForSuspensionPoint(*layout, *state.Layout);
+
+        JITDUMP("\n");
+    }
+}
+
+ContinuationLayoutBuilder* ContinuationLayoutBuilder::CreateSharedLayout(Compiler* comp, const jitstd::vector<AsyncState>& states)
+{
+    unsigned maxLocalStored = 0;
+    for (const AsyncState& state : states)
+    {
+        jitstd::vector<unsigned>& locals = state.Layout->m_locals;
+        if (locals.size() > 0)
+        {
+            maxLocalStored = std::max(maxLocalStored, locals[locals.size() - 1]);
+        }
+    }
+
+    ContinuationLayoutBuilder* sharedLayout = new (comp, CMK_Async) ContinuationLayoutBuilder(comp);
+    BitVecTraits traits(maxLocalStored + 1, comp);
+    BitVec locals(BitVecOps::MakeEmpty(&traits));
+
+    for (const AsyncState& state : states)
+    {
+        ContinuationLayoutBuilder* layout = state.Layout;
+        sharedLayout->m_needsOSRILOffset |= layout->m_needsOSRILOffset;
+        sharedLayout->m_needsException |= layout->m_needsException;
+        sharedLayout->m_needsContinuationContext |= layout->m_needsContinuationContext;
+        sharedLayout->m_needsKeepAlive |= layout->m_needsKeepAlive;
+        sharedLayout->m_needsExecutionContext |= layout->m_needsExecutionContext;
+
+        for (unsigned local : layout->m_locals)
+        {
+            assert(local <= maxLocalStored);
+            BitVecOps::AddElemD(&traits, locals, local);
+        }
+
+        for (const ReturnTypeInfo& ret : layout->m_returns)
+        {
+            sharedLayout->AddReturn(ret);
+        }
+    }
+
+    BitVecOps::VisitBits(&traits, locals, [=](unsigned localNum) {
+        sharedLayout->AddLocal(localNum);
+        return true;
+        });
+
+    return sharedLayout;
+}
+
 //------------------------------------------------------------------------
 // AsyncTransformation::CreateResumptionSwitch:
 //   Create the IR for the entry of the function that checks the continuation
@@ -2989,19 +3075,19 @@ void AsyncTransformation::CreateResumptionSwitch()
 
     FlowEdge* resumingEdge;
 
-    if (m_resumptionBBs.size() == 1)
+    if (m_states.size() == 1)
     {
         JITDUMP("  Redirecting entry " FMT_BB " directly to " FMT_BB " as it is the only resumption block\n",
-                newEntryBB->bbNum, m_resumptionBBs[0]->bbNum);
-        resumingEdge = m_compiler->fgAddRefPred(m_resumptionBBs[0], newEntryBB);
+                newEntryBB->bbNum, m_states[0].ResumptionBB->bbNum);
+        resumingEdge = m_compiler->fgAddRefPred(m_states[0].ResumptionBB, newEntryBB);
     }
-    else if (m_resumptionBBs.size() == 2)
+    else if (m_states.size() == 2)
     {
-        BasicBlock* condBB = m_compiler->fgNewBBbefore(BBJ_COND, m_resumptionBBs[0], true);
+        BasicBlock* condBB = m_compiler->fgNewBBbefore(BBJ_COND, m_states[0].ResumptionBB, true);
         condBB->inheritWeightPercentage(newEntryBB, 0);
 
-        FlowEdge* to0 = m_compiler->fgAddRefPred(m_resumptionBBs[0], condBB);
-        FlowEdge* to1 = m_compiler->fgAddRefPred(m_resumptionBBs[1], condBB);
+        FlowEdge* to0 = m_compiler->fgAddRefPred(m_states[0].ResumptionBB, condBB);
+        FlowEdge* to1 = m_compiler->fgAddRefPred(m_states[1].ResumptionBB, condBB);
         condBB->SetCond(to1, to0);
         to1->setLikelihood(0.5);
         to0->setLikelihood(0.5);
@@ -3025,13 +3111,13 @@ void AsyncTransformation::CreateResumptionSwitch()
     }
     else
     {
-        BasicBlock* switchBB = m_compiler->fgNewBBbefore(BBJ_SWITCH, m_resumptionBBs[0], true);
+        BasicBlock* switchBB = m_compiler->fgNewBBbefore(BBJ_SWITCH, m_states[0].ResumptionBB, true);
         switchBB->inheritWeightPercentage(newEntryBB, 0);
 
         resumingEdge = m_compiler->fgAddRefPred(switchBB, newEntryBB);
 
         JITDUMP("  Redirecting entry " FMT_BB " to BBJ_SWITCH " FMT_BB " for resumption with %zu states\n",
-                newEntryBB->bbNum, switchBB->bbNum, m_resumptionBBs.size());
+                newEntryBB->bbNum, switchBB->bbNum, m_states.size());
 
         continuationArg          = m_compiler->gtNewLclvNode(m_compiler->lvaAsyncContinuationArg, TYP_REF);
         unsigned stateOffset     = m_compiler->info.compCompHnd->getFieldOffset(m_asyncInfo->continuationStateFldHnd);
@@ -3044,17 +3130,18 @@ void AsyncTransformation::CreateResumptionSwitch()
 
         m_compiler->fgHasSwitch = true;
 
-        // Default case. TODO-CQ: Support bbsHasDefault = false before lowering.
-        m_resumptionBBs.push_back(m_resumptionBBs[0]);
-        const size_t     numCases       = m_resumptionBBs.size();
+        // Add 1 for default case
+        const size_t     numCases       = m_states.size() + 1;
         FlowEdge** const cases          = new (m_compiler, CMK_FlowEdge) FlowEdge*[numCases * 2];
         FlowEdge** const succs          = cases + numCases;
         unsigned         numUniqueSuccs = 0;
 
-        const weight_t stateLikelihood = 1.0 / m_resumptionBBs.size();
+        const weight_t stateLikelihood = 1.0 / numCases;
         for (size_t i = 0; i < numCases; i++)
         {
-            FlowEdge* const edge = m_compiler->fgAddRefPred(m_resumptionBBs[i], switchBB);
+            // Wrap around and use first resumption BB as default case
+            BasicBlock* resumptionBB = m_states[i % m_states.size()].ResumptionBB;
+            FlowEdge* const edge = m_compiler->fgAddRefPred(resumptionBB, switchBB);
             edge->setLikelihood(stateLikelihood);
             cases[i] = edge;
 

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1590,11 +1590,15 @@ public:
     }
 };
 
-void AsyncTransformation::BuildContinuation(BasicBlock* block, GenTreeCall* call, bool needsKeepAlive, ContinuationLayoutBuilder* layoutBuilder)
+void AsyncTransformation::BuildContinuation(BasicBlock*                block,
+                                            GenTreeCall*               call,
+                                            bool                       needsKeepAlive,
+                                            ContinuationLayoutBuilder* layoutBuilder)
 {
     if (call->gtReturnType != TYP_VOID)
     {
-        ClassLayout* layout = call->gtReturnType == TYP_STRUCT ? m_compiler->typGetObjLayout(call->gtRetClsHnd) : nullptr;
+        ClassLayout* layout =
+            call->gtReturnType == TYP_STRUCT ? m_compiler->typGetObjLayout(call->gtRetClsHnd) : nullptr;
         layoutBuilder->AddReturn(ReturnTypeInfo(call->gtReturnType, layout));
         JITDUMP("  Call has return; continuation will have return value\n");
     }
@@ -1674,7 +1678,9 @@ void ContinuationLayout::Dump(int indent)
 
     for (const ReturnInfo& ret : Returns)
     {
-        printf("%*s  +%03u %u bytes for %s return\n", indent, "", ret.Offset, ret.Size, ret.Type.ReturnType == TYP_STRUCT ? ret.Type.ReturnLayout->GetClassName() : varTypeName(ret.Type.ReturnType));
+        printf("%*s  +%03u %u bytes for %s return\n", indent, "", ret.Offset, ret.Size,
+               ret.Type.ReturnType == TYP_STRUCT ? ret.Type.ReturnLayout->GetClassName()
+                                                 : varTypeName(ret.Type.ReturnType));
     }
 }
 #endif
@@ -1683,7 +1689,8 @@ const ReturnInfo* ContinuationLayout::FindReturn(GenTreeCall* call) const
 {
     for (const ReturnInfo& ret : Returns)
     {
-        if ((ret.Type.ReturnType == call->gtReturnType) && ((call->gtReturnType != TYP_STRUCT) || (ret.Type.ReturnLayout->GetClassHandle() == call->gtRetClsHnd)))
+        if ((ret.Type.ReturnType == call->gtReturnType) &&
+            ((call->gtReturnType != TYP_STRUCT) || (ret.Type.ReturnLayout->GetClassHandle() == call->gtRetClsHnd)))
         {
             return &ret;
         }
@@ -1700,7 +1707,7 @@ ContinuationLayout* ContinuationLayoutBuilder::Create()
 
     for (unsigned lclNum : m_locals)
     {
-        LclVarDsc* dsc = m_compiler->lvaGetDesc(lclNum);
+        LclVarDsc*    dsc = m_compiler->lvaGetDesc(lclNum);
         LiveLocalInfo inf(lclNum);
 
         if (dsc->TypeIs(TYP_STRUCT) || dsc->IsImplicitByRef())
@@ -1762,11 +1769,12 @@ ContinuationLayout* ContinuationLayoutBuilder::Create()
         if (ret.ReturnType == TYP_STRUCT)
         {
             retInfo.Size = ret.ReturnLayout->GetSize();
-            retInfo.Alignment = m_compiler->info.compCompHnd->getClassAlignmentRequirement(ret.ReturnLayout->GetClassHandle());
+            retInfo.Alignment =
+                m_compiler->info.compCompHnd->getClassAlignmentRequirement(ret.ReturnLayout->GetClassHandle());
         }
         else
         {
-            retInfo.Size = genTypeSize(ret.ReturnType);
+            retInfo.Size      = genTypeSize(ret.ReturnType);
             retInfo.Alignment = retInfo.Size;
         }
 
@@ -1774,7 +1782,7 @@ ContinuationLayout* ContinuationLayoutBuilder::Create()
     }
 
     auto allocLayout = [layout](unsigned align, unsigned size) {
-        layout->Size     = roundUp(layout->Size, align);
+        layout->Size    = roundUp(layout->Size, align);
         unsigned offset = layout->Size;
         layout->Size += size;
         return offset;
@@ -2033,8 +2041,12 @@ BasicBlock* AsyncTransformation::CreateSuspensionBlock(BasicBlock* block, GenTre
 // Returns:
 //   The new basic block that was created.
 //
-void AsyncTransformation::CreateSuspension(
-    BasicBlock* callBlock, GenTreeCall* call, BasicBlock* suspendBB, unsigned stateNum, const ContinuationLayout& layout, const ContinuationLayoutBuilder& subLayout)
+void AsyncTransformation::CreateSuspension(BasicBlock*                      callBlock,
+                                           GenTreeCall*                     call,
+                                           BasicBlock*                      suspendBB,
+                                           unsigned                         stateNum,
+                                           const ContinuationLayout&        layout,
+                                           const ContinuationLayoutBuilder& subLayout)
 {
     GenTreeILOffset* ilOffsetNode =
         m_compiler->gtNewILOffsetNode(call->GetAsyncInfo().CallAsyncDebugInfo DEBUGARG(BAD_IL_OFFSET));
@@ -2048,7 +2060,8 @@ void AsyncTransformation::CreateSuspension(
     // Allocate continuation
     GenTree* returnedContinuation = m_compiler->gtNewLclvNode(GetReturnedContinuationVar(), TYP_REF);
 
-    GenTreeCall* allocContinuation = CreateAllocContinuationCall(subLayout.NeedsKeepAlive(), returnedContinuation, layout);
+    GenTreeCall* allocContinuation =
+        CreateAllocContinuationCall(subLayout.NeedsKeepAlive(), returnedContinuation, layout);
 
     m_compiler->compCurBB = suspendBB;
     m_compiler->fgMorphTree(allocContinuation);
@@ -2120,7 +2133,7 @@ void AsyncTransformation::CreateSuspension(
 // Returns:
 //   IR node representing the allocation.
 //
-GenTreeCall* AsyncTransformation::CreateAllocContinuationCall(bool hasKeepAlive,
+GenTreeCall* AsyncTransformation::CreateAllocContinuationCall(bool                      hasKeepAlive,
                                                               GenTree*                  prevContinuation,
                                                               const ContinuationLayout& layout)
 {
@@ -2155,10 +2168,10 @@ GenTreeCall* AsyncTransformation::CreateAllocContinuationCall(bool hasKeepAlive,
 //   layout    - Information about the continuation layout
 //   suspendBB - Basic block to add IR to.
 //
-void AsyncTransformation::FillInDataOnSuspension(GenTreeCall*              call,
-                                                 const ContinuationLayout& layout,
+void AsyncTransformation::FillInDataOnSuspension(GenTreeCall*                     call,
+                                                 const ContinuationLayout&        layout,
                                                  const ContinuationLayoutBuilder& subLayout,
-                                                 BasicBlock*               suspendBB)
+                                                 BasicBlock*                      suspendBB)
 {
     if (m_compiler->doesMethodHavePatchpoints() || m_compiler->opts.IsOSR())
     {
@@ -2444,7 +2457,10 @@ void AsyncTransformation::CreateCheckAndSuspendAfterCall(BasicBlock*            
     block->GetFalseEdge()->setLikelihood(1);
 }
 
-BasicBlock* AsyncTransformation::CreateResumptionBlock(BasicBlock* remainder, GenTreeCall* call, unsigned stateNum, ContinuationLayoutBuilder* layoutBuilder)
+BasicBlock* AsyncTransformation::CreateResumptionBlock(BasicBlock*                remainder,
+                                                       GenTreeCall*               call,
+                                                       unsigned                   stateNum,
+                                                       ContinuationLayoutBuilder* layoutBuilder)
 {
     if (m_lastResumptionBB == nullptr)
     {
@@ -2483,12 +2499,12 @@ BasicBlock* AsyncTransformation::CreateResumptionBlock(BasicBlock* remainder, Ge
 // Returns:
 //   The new basic block that was created.
 //
-void AsyncTransformation::CreateResumption(BasicBlock*               callBlock,
-                                                  GenTreeCall*              call,
-                                                  BasicBlock*               resumeBB,
-                                                  const CallDefinitionInfo& callDefInfo,
-                                                  const ContinuationLayout& layout,
-                                                  const ContinuationLayoutBuilder& subLayout)
+void AsyncTransformation::CreateResumption(BasicBlock*                      callBlock,
+                                           GenTreeCall*                     call,
+                                           BasicBlock*                      resumeBB,
+                                           const CallDefinitionInfo&        callDefInfo,
+                                           const ContinuationLayout&        layout,
+                                           const ContinuationLayoutBuilder& subLayout)
 {
     GenTreeILOffset* ilOffsetNode =
         m_compiler->gtNewILOffsetNode(call->GetAsyncInfo().CallAsyncDebugInfo DEBUGARG(BAD_IL_OFFSET));
@@ -2522,7 +2538,9 @@ void AsyncTransformation::CreateResumption(BasicBlock*               callBlock,
 //   layout   - Information about the continuation layout
 //   resumeBB - Basic block to append IR to
 //
-void AsyncTransformation::RestoreFromDataOnResumption(const ContinuationLayout& layout, const ContinuationLayoutBuilder& subLayout, BasicBlock* resumeBB)
+void AsyncTransformation::RestoreFromDataOnResumption(const ContinuationLayout&        layout,
+                                                      const ContinuationLayoutBuilder& subLayout,
+                                                      BasicBlock*                      resumeBB)
 {
     if (subLayout.NeedsExecutionContext())
     {
@@ -2850,7 +2868,8 @@ GenTreeStoreInd* AsyncTransformation::StoreAtOffset(
 // Parameters:
 //   layout         - Layout of continuation
 //
-void AsyncTransformation::CreateDebugInfoForSuspensionPoint(const ContinuationLayout& layout, const ContinuationLayoutBuilder& subLayout)
+void AsyncTransformation::CreateDebugInfoForSuspensionPoint(const ContinuationLayout&        layout,
+                                                            const ContinuationLayoutBuilder& subLayout)
 {
     uint32_t numLocals = 0;
     for (const LiveLocalInfo& inf : layout.Locals)
@@ -3002,7 +3021,8 @@ void AsyncTransformation::CreateResumptionsAndSuspensions()
     JITDUMP("Creating suspensions and resumptions for %zu states\n", m_states.size());
     for (const AsyncState& state : m_states)
     {
-        JITDUMP("State %u suspend @ " FMT_BB ", resume @ " FMT_BB "\n", state.Number, state.SuspensionBB->bbNum, state.ResumptionBB->bbNum);
+        JITDUMP("State %u suspend @ " FMT_BB ", resume @ " FMT_BB "\n", state.Number, state.SuspensionBB->bbNum,
+                state.ResumptionBB->bbNum);
         ContinuationLayout* layout = state.Layout->Create();
         CreateSuspension(state.CallBlock, state.Call, state.SuspensionBB, state.Number, *layout, *state.Layout);
         CreateResumption(state.CallBlock, state.Call, state.ResumptionBB, state.CallDefInfo, *layout, *state.Layout);
@@ -3012,7 +3032,8 @@ void AsyncTransformation::CreateResumptionsAndSuspensions()
     }
 }
 
-ContinuationLayoutBuilder* ContinuationLayoutBuilder::CreateSharedLayout(Compiler* comp, const jitstd::vector<AsyncState>& states)
+ContinuationLayoutBuilder* ContinuationLayoutBuilder::CreateSharedLayout(Compiler*                         comp,
+                                                                         const jitstd::vector<AsyncState>& states)
 {
     unsigned maxLocalStored = 0;
     for (const AsyncState& state : states)
@@ -3025,8 +3046,8 @@ ContinuationLayoutBuilder* ContinuationLayoutBuilder::CreateSharedLayout(Compile
     }
 
     ContinuationLayoutBuilder* sharedLayout = new (comp, CMK_Async) ContinuationLayoutBuilder(comp);
-    BitVecTraits traits(maxLocalStored + 1, comp);
-    BitVec locals(BitVecOps::MakeEmpty(&traits));
+    BitVecTraits               traits(maxLocalStored + 1, comp);
+    BitVec                     locals(BitVecOps::MakeEmpty(&traits));
 
     for (const AsyncState& state : states)
     {
@@ -3052,7 +3073,7 @@ ContinuationLayoutBuilder* ContinuationLayoutBuilder::CreateSharedLayout(Compile
     BitVecOps::VisitBits(&traits, locals, [=](unsigned localNum) {
         sharedLayout->AddLocal(localNum);
         return true;
-        });
+    });
 
     return sharedLayout;
 }
@@ -3140,8 +3161,8 @@ void AsyncTransformation::CreateResumptionSwitch()
         for (size_t i = 0; i < numCases; i++)
         {
             // Wrap around and use first resumption BB as default case
-            BasicBlock* resumptionBB = m_states[i % m_states.size()].ResumptionBB;
-            FlowEdge* const edge = m_compiler->fgAddRefPred(resumptionBB, switchBB);
+            BasicBlock*     resumptionBB = m_states[i % m_states.size()].ResumptionBB;
+            FlowEdge* const edge         = m_compiler->fgAddRefPred(resumptionBB, switchBB);
             edge->setLikelihood(stateLikelihood);
             cases[i] = edge;
 

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -1881,7 +1881,7 @@ ContinuationLayout* ContinuationLayoutBuilder::Create()
     // Now allocate all  returns
     for (ReturnInfo& ret : layout->Returns)
     {
-        ret.Offset = allocLayout(ret.Alignment, ret.Size);
+        ret.Offset = allocLayout(ret.HeapAlignment(), ret.Size);
     }
 
     if (m_needsKeepAlive)

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -3140,65 +3140,6 @@ void AsyncTransformation::CreateResumptionsAndSuspensions()
 }
 
 //------------------------------------------------------------------------
-// ContinuationLayoutBuilder::CreateSharedLayout:
-//   Create a shared continuation layout that is the union of all per-call
-//   layouts. The shared layout contains every local, return type, and
-//   optional field needed by any individual suspension point.
-//
-// Parameters:
-//   comp   - The compiler instance.
-//   states - The vector of async states to merge.
-//
-// Returns:
-//   A new ContinuationLayoutBuilder representing the merged layout.
-//
-ContinuationLayoutBuilder* ContinuationLayoutBuilder::CreateSharedLayout(Compiler*                         comp,
-                                                                         const jitstd::vector<AsyncState>& states)
-{
-    unsigned maxLocalStored = 0;
-    for (const AsyncState& state : states)
-    {
-        jitstd::vector<unsigned>& locals = state.Layout->m_locals;
-        if (locals.size() > 0)
-        {
-            maxLocalStored = std::max(maxLocalStored, locals[locals.size() - 1]);
-        }
-    }
-
-    ContinuationLayoutBuilder* sharedLayout = new (comp, CMK_Async) ContinuationLayoutBuilder(comp);
-    BitVecTraits               traits(maxLocalStored + 1, comp);
-    BitVec                     locals(BitVecOps::MakeEmpty(&traits));
-
-    for (const AsyncState& state : states)
-    {
-        ContinuationLayoutBuilder* layout = state.Layout;
-        sharedLayout->m_needsOSRILOffset |= layout->m_needsOSRILOffset;
-        sharedLayout->m_needsException |= layout->m_needsException;
-        sharedLayout->m_needsContinuationContext |= layout->m_needsContinuationContext;
-        sharedLayout->m_needsKeepAlive |= layout->m_needsKeepAlive;
-        sharedLayout->m_needsExecutionContext |= layout->m_needsExecutionContext;
-
-        for (unsigned local : layout->m_locals)
-        {
-            assert(local <= maxLocalStored);
-            BitVecOps::AddElemD(&traits, locals, local);
-        }
-
-        for (const ReturnTypeInfo& ret : layout->m_returns)
-        {
-            sharedLayout->AddReturn(ret);
-        }
-    }
-
-    BitVecOps::VisitBits(&traits, locals, [=](unsigned localNum) {
-        sharedLayout->AddLocal(localNum);
-        return true;
-    });
-
-    return sharedLayout;
-}
-
-//------------------------------------------------------------------------
 // AsyncTransformation::CreateResumptionSwitch:
 //   Create the IR for the entry of the function that checks the continuation
 //   and dispatches on its state number.

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -45,6 +45,15 @@
 #include "jitstd/algorithm.h"
 #include "async.h"
 
+//------------------------------------------------------------------------
+// SetCallEntrypointForR2R:
+//   Set the entrypoint for a call when compiling for Ready-to-Run.
+//
+// Parameters:
+//   call     - The call node to set the entrypoint on.
+//   compiler - The compiler instance.
+//   handle   - The method handle to look up the entrypoint for.
+//
 static void SetCallEntrypointForR2R(GenTreeCall* call, Compiler* compiler, CORINFO_METHOD_HANDLE handle)
 {
 #ifdef FEATURE_READYTORUN
@@ -438,6 +447,14 @@ BasicBlock* Compiler::CreateReturnBB(unsigned* mergedReturnLcl)
     return newReturnBB;
 }
 
+//------------------------------------------------------------------------
+// ContinuationLayoutBuilder::AddReturn:
+//   Add a return type to the continuation layout, if it is not already
+//   present.
+//
+// Parameters:
+//   info - The return type information to add.
+//
 void ContinuationLayoutBuilder::AddReturn(const ReturnTypeInfo& info)
 {
     for (const ReturnTypeInfo& ret : m_returns)
@@ -452,12 +469,30 @@ void ContinuationLayoutBuilder::AddReturn(const ReturnTypeInfo& info)
     m_returns.push_back(info);
 }
 
+//------------------------------------------------------------------------
+// ContinuationLayoutBuilder::AddLocal:
+//   Add a local to the continuation layout. Locals must be added in
+//   ascending order by local number.
+//
+// Parameters:
+//   lclNum - The local number to add.
+//
 void ContinuationLayoutBuilder::AddLocal(unsigned lclNum)
 {
     assert(m_locals.empty() || (lclNum > m_locals[m_locals.size() - 1]));
     m_locals.push_back(lclNum);
 }
 
+//------------------------------------------------------------------------
+// ContinuationLayoutBuilder::ContainsLocal:
+//   Check if the specified local is in this layout.
+//
+// Parameters:
+//   lclNum - The local number to check.
+//
+// Returns:
+//   True if the local is contained in this layout.
+//
 bool ContinuationLayoutBuilder::ContainsLocal(unsigned lclNum) const
 {
     return BinarySearch(m_locals.data(), (int)m_locals.size(), lclNum) != nullptr;
@@ -616,7 +651,6 @@ static bool IsDefaultValue(GenTree* node)
     return node->IsIntegralConst(0) || node->IsFloatPositiveZero() || node->IsVectorZero();
 }
 
-//------------------------------------------------------------------------
 //------------------------------------------------------------------------
 // UpdateMutatedLocal:
 //   If the given node is a local store or LCL_ADDR, and the local is tracked,
@@ -1590,6 +1624,19 @@ public:
     }
 };
 
+//------------------------------------------------------------------------
+// AsyncTransformation::BuildContinuation:
+//   Determine what fields the continuation object needs for the specified
+//   async call, including return values, exception, context, and OSR
+//   support, and configure the layout builder accordingly.
+//
+// Parameters:
+//   block          - The block containing the async call.
+//   call           - The async call.
+//   needsKeepAlive - Whether a KeepAlive field is needed to keep a
+//                    LoaderAllocator alive.
+//   layoutBuilder  - The continuation layout builder to configure.
+//
 void AsyncTransformation::BuildContinuation(BasicBlock*                block,
                                             GenTreeCall*               call,
                                             bool                       needsKeepAlive,
@@ -1643,6 +1690,14 @@ void AsyncTransformation::BuildContinuation(BasicBlock*                block,
 }
 
 #ifdef DEBUG
+//------------------------------------------------------------------------
+// ContinuationLayout::Dump:
+//   Debug helper to print the continuation layout including offsets of all
+//   fields and locals.
+//
+// Parameters:
+//   indent - Number of spaces to indent the output.
+//
 void ContinuationLayout::Dump(int indent)
 {
     printf("%*sContinuation layout (%u bytes):\n", indent, "", Size);
@@ -1685,6 +1740,16 @@ void ContinuationLayout::Dump(int indent)
 }
 #endif
 
+//------------------------------------------------------------------------
+// ContinuationLayout::FindReturn:
+//   Find the return info entry matching the specified call's return type.
+//
+// Parameters:
+//   call - The async call whose return type to look up.
+//
+// Returns:
+//   Pointer to the matching ReturnInfo entry.
+//
 const ReturnInfo* ContinuationLayout::FindReturn(GenTreeCall* call) const
 {
     for (const ReturnInfo& ret : Returns)
@@ -1700,6 +1765,15 @@ const ReturnInfo* ContinuationLayout::FindReturn(GenTreeCall* call) const
     return nullptr;
 }
 
+//------------------------------------------------------------------------
+// ContinuationLayoutBuilder::Create:
+//   Finalize the layout by computing offsets for all fields, locals, and
+//   return values. Allocates the continuation type from the VM.
+//
+// Returns:
+//   The finalized ContinuationLayout with computed offsets and a class
+//   handle for the continuation type.
+//
 ContinuationLayout* ContinuationLayoutBuilder::Create()
 {
     ContinuationLayout* layout = new (m_compiler, CMK_Async) ContinuationLayout(m_compiler);
@@ -2003,6 +2077,19 @@ CallDefinitionInfo AsyncTransformation::CanonicalizeCallDefinition(BasicBlock*  
     return callDefInfo;
 }
 
+//------------------------------------------------------------------------
+// AsyncTransformation::CreateSuspensionBlock:
+//   Create an empty basic block that will hold the suspension IR for the
+//   specified async call.
+//
+// Parameters:
+//   block    - The block containing the async call.
+//   call     - The async call.
+//   stateNum - State number assigned to this suspension point.
+//
+// Returns:
+//   The new basic block.
+//
 BasicBlock* AsyncTransformation::CreateSuspensionBlock(BasicBlock* block, GenTreeCall* call, unsigned stateNum)
 {
     if (m_lastSuspensionBB == nullptr)
@@ -2028,18 +2115,17 @@ BasicBlock* AsyncTransformation::CreateSuspensionBlock(BasicBlock* block, GenTre
 
 //------------------------------------------------------------------------
 // AsyncTransformation::CreateSuspension:
-//   Create the basic block that when branched to suspends execution after the
-//   specified async call.
+//   Populate the suspension block with IR that allocates a continuation
+//   object, fills in its state, flags, resume info, data, and restores
+//   contexts.
 //
 // Parameters:
-//   block    - The block containing the async call
-//   call     - The async call
-//   stateNum - State number assigned to this suspension point
-//   life     - Liveness information about live locals
-//   layout   - Layout information for the continuation object
-//
-// Returns:
-//   The new basic block that was created.
+//   callBlock - The block containing the async call.
+//   call      - The async call.
+//   suspendBB - The suspension basic block to add IR to.
+//   stateNum  - State number assigned to this suspension point.
+//   layout    - Layout information for the continuation object.
+//   subLayout - Per-call layout builder indicating which fields are needed.
 //
 void AsyncTransformation::CreateSuspension(BasicBlock*                      callBlock,
                                            GenTreeCall*                     call,
@@ -2126,9 +2212,9 @@ void AsyncTransformation::CreateSuspension(BasicBlock*                      call
 //   Create a call to the JIT helper that allocates a continuation.
 //
 // Parameters:
-//   life             - Liveness information about live locals
-//   prevContinuation - IR node that has the value of the previous continuation object
-//   layout           - Layout information
+//   hasKeepAlive     - Whether the continuation needs a KeepAlive field.
+//   prevContinuation - IR node that has the value of the previous continuation object.
+//   layout           - Layout information for the continuation.
 //
 // Returns:
 //   IR node representing the allocation.
@@ -2161,11 +2247,14 @@ GenTreeCall* AsyncTransformation::CreateAllocContinuationCall(bool              
 
 //------------------------------------------------------------------------
 // AsyncTransformation::FillInDataOnSuspension:
-//   Create IR that fills the data array of the continuation object.
+//   Create IR that fills the data array of the continuation object with
+//   live local values, OSR IL offset, continuation context, and execution
+//   context.
 //
 // Parameters:
-//   call      - The async call
-//   layout    - Information about the continuation layout
+//   call      - The async call.
+//   layout    - Information about the continuation layout.
+//   subLayout - Per-call layout builder indicating which fields are needed.
 //   suspendBB - Basic block to add IR to.
 //
 void AsyncTransformation::FillInDataOnSuspension(GenTreeCall*                     call,
@@ -2457,6 +2546,20 @@ void AsyncTransformation::CreateCheckAndSuspendAfterCall(BasicBlock*            
     block->GetFalseEdge()->setLikelihood(1);
 }
 
+//------------------------------------------------------------------------
+// AsyncTransformation::CreateResumptionBlock:
+//   Create an empty basic block that will hold the resumption IR for the
+//   specified async call.
+//
+// Parameters:
+//   remainder     - The block that contains the IR after the async call.
+//   call          - The async call.
+//   stateNum      - State number assigned to this suspension point.
+//   layoutBuilder - The continuation layout builder for this call.
+//
+// Returns:
+//   The new basic block.
+//
 BasicBlock* AsyncTransformation::CreateResumptionBlock(BasicBlock*                remainder,
                                                        GenTreeCall*               call,
                                                        unsigned                   stateNum,
@@ -2485,19 +2588,17 @@ BasicBlock* AsyncTransformation::CreateResumptionBlock(BasicBlock*              
 
 //------------------------------------------------------------------------
 // AsyncTransformation::CreateResumption:
-//   Create the basic block that when branched to resumes execution on entry to
-//   the function.
+//   Populate the resumption block with IR that restores live state from
+//   the continuation object, rethrows exceptions if necessary, and copies
+//   the return value.
 //
 // Parameters:
-//   block       - The block containing the async call
-//   remainder   - The block that contains the IR after the (split) async call
-//   call        - The async call
-//   callDefInfo - Information about the async call's definition
-//   stateNum    - State number assigned to this suspension point
-//   layout      - Layout information for the continuation object
-//
-// Returns:
-//   The new basic block that was created.
+//   callBlock   - The block containing the async call.
+//   call        - The async call.
+//   resumeBB    - The resumption basic block to add IR to.
+//   callDefInfo - Information about the async call's definition.
+//   layout      - Layout information for the continuation object.
+//   subLayout   - Per-call layout builder indicating which fields are needed.
 //
 void AsyncTransformation::CreateResumption(BasicBlock*                      callBlock,
                                            GenTreeCall*                     call,
@@ -2532,11 +2633,12 @@ void AsyncTransformation::CreateResumption(BasicBlock*                      call
 //------------------------------------------------------------------------
 // AsyncTransformation::RestoreFromDataOnResumption:
 //   Create IR that restores locals from the data array of the continuation
-//   object.
+//   object, including execution context restoration.
 //
 // Parameters:
-//   layout   - Information about the continuation layout
-//   resumeBB - Basic block to append IR to
+//   layout    - Information about the continuation layout.
+//   subLayout - Per-call layout builder indicating which fields are needed.
+//   resumeBB  - Basic block to append IR to.
 //
 void AsyncTransformation::RestoreFromDataOnResumption(const ContinuationLayout&        layout,
                                                       const ContinuationLayoutBuilder& subLayout,
@@ -2711,11 +2813,10 @@ BasicBlock* AsyncTransformation::RethrowExceptionOnResumption(BasicBlock*       
 //   right local.
 //
 // Parameters:
-//   call                  - The async call
-//   callDefInfo           - Information about the async call's definition
-//   block                 - The block containing the async call
-//   layout                - Layout information for the continuation object
-//   storeResultBB         - Basic block to append IR to
+//   call          - The async call.
+//   callDefInfo   - Information about the async call's definition.
+//   layout        - Layout information for the continuation object.
+//   storeResultBB - Basic block to append IR to.
 //
 void AsyncTransformation::CopyReturnValueOnResumption(GenTreeCall*              call,
                                                       const CallDefinitionInfo& callDefInfo,
@@ -2866,7 +2967,8 @@ GenTreeStoreInd* AsyncTransformation::StoreAtOffset(
 //   Create debug info for the specific suspension point we just created.
 //
 // Parameters:
-//   layout         - Layout of continuation
+//   layout    - Layout of continuation.
+//   subLayout - Per-call layout builder indicating which locals are present.
 //
 void AsyncTransformation::CreateDebugInfoForSuspensionPoint(const ContinuationLayout&        layout,
                                                             const ContinuationLayoutBuilder& subLayout)
@@ -3016,6 +3118,11 @@ BasicBlock* AsyncTransformation::GetSharedReturnBB()
 #endif
 }
 
+//------------------------------------------------------------------------
+// AsyncTransformation::CreateResumptionsAndSuspensions:
+//   Walk all recorded async states and create the suspension and resumption
+//   IR, continuation layouts, and debug info for each one.
+//
 void AsyncTransformation::CreateResumptionsAndSuspensions()
 {
     JITDUMP("Creating suspensions and resumptions for %zu states\n", m_states.size());
@@ -3032,6 +3139,19 @@ void AsyncTransformation::CreateResumptionsAndSuspensions()
     }
 }
 
+//------------------------------------------------------------------------
+// ContinuationLayoutBuilder::CreateSharedLayout:
+//   Create a shared continuation layout that is the union of all per-call
+//   layouts. The shared layout contains every local, return type, and
+//   optional field needed by any individual suspension point.
+//
+// Parameters:
+//   comp   - The compiler instance.
+//   states - The vector of async states to merge.
+//
+// Returns:
+//   A new ContinuationLayoutBuilder representing the merged layout.
+//
 ContinuationLayoutBuilder* ContinuationLayoutBuilder::CreateSharedLayout(Compiler*                         comp,
                                                                          const jitstd::vector<AsyncState>& states)
 {

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -438,6 +438,17 @@ BasicBlock* Compiler::CreateReturnBB(unsigned* mergedReturnLcl)
     return newReturnBB;
 }
 
+void ContinuationLayoutBuilder::SetReturn(var_types type, ClassLayout* layout)
+{
+    ReturnType = type;
+    ReturnLayout = layout;
+}
+
+void ContinuationLayoutBuilder::AddLocal(unsigned lclNum)
+{
+    m_locals.push_back(lclNum);
+}
+
 //------------------------------------------------------------------------
 // DefaultValueAnalysis:
 //   Computes which tracked locals have their default (zero) value at each
@@ -810,7 +821,7 @@ public:
     void Update(GenTree* node);
     bool IsLive(unsigned lclNum);
     template <typename Functor>
-    void GetLiveLocals(jitstd::vector<LiveLocalInfo>& liveLocals, Functor includeLocal);
+    void GetLiveLocals(ContinuationLayoutBuilder* layoutBuilder, Functor includeLocal);
 
 private:
     bool IsLocalCaptureUnnecessary(unsigned lclNum);
@@ -999,17 +1010,17 @@ bool AsyncLiveness::IsLive(unsigned lclNum)
 //   Get live locals that should be captured at this point.
 //
 // Parameters:
-//   liveLocals   - Vector to add live local information into
+//   builder      - Layout builder to add local into
 //   includeLocal - Functor to check if a local should be included
 //
 template <typename Functor>
-void AsyncLiveness::GetLiveLocals(jitstd::vector<LiveLocalInfo>& liveLocals, Functor includeLocal)
+void AsyncLiveness::GetLiveLocals(ContinuationLayoutBuilder* builder, Functor includeLocal)
 {
     for (unsigned lclNum = 0; lclNum < m_numVars; lclNum++)
     {
         if (includeLocal(lclNum) && IsLive(lclNum))
         {
-            liveLocals.push_back(LiveLocalInfo(lclNum));
+            builder->AddLocal(lclNum);
         }
     }
 }
@@ -1313,16 +1324,16 @@ void AsyncTransformation::Transform(
     }
 #endif
 
-    m_liveLocalsScratch.clear();
-    jitstd::vector<LiveLocalInfo>& liveLocals = m_liveLocalsScratch;
+    ContinuationLayoutBuilder* layoutBuilder = new (m_compiler, CMK_Async) ContinuationLayoutBuilder(m_compiler);
 
-    CreateLiveSetForSuspension(block, call, defs, life, liveLocals);
+    CreateLiveSetForSuspension(block, call, defs, life, layoutBuilder);
 
-    ContinuationLayout layout = LayOutContinuation(block, call, ContinuationNeedsKeepAlive(life), liveLocals);
+    BuildContinuation(block, call, ContinuationNeedsKeepAlive(life), layoutBuilder);
+    //ContinuationLayout layout = LayOutContinuation(block, call, ContinuationNeedsKeepAlive(life), liveLocals);
 
     CallDefinitionInfo callDefInfo = CanonicalizeCallDefinition(block, call, &life);
 
-    unsigned stateNum = (unsigned)m_resumptionBBs.size();
+    unsigned stateNum = (unsigned)m_states.size();
     JITDUMP("  Assigned state %u\n", stateNum);
 
     BasicBlock* suspendBB = CreateSuspension(block, call, stateNum, life, layout);
@@ -1331,7 +1342,7 @@ void AsyncTransformation::Transform(
 
     BasicBlock* resumeBB = CreateResumption(block, *remainder, call, callDefInfo, stateNum, layout);
 
-    m_resumptionBBs.push_back(resumeBB);
+    m_states.push_back(AsyncState(layoutBuilder, suspendBB, resumeBB));
 
     CreateDebugInfoForSuspensionPoint(layout);
 }
@@ -1342,17 +1353,17 @@ void AsyncTransformation::Transform(
 //   specified call.
 //
 // Parameters:
-//   block        - The block containing the async call
-//   call         - The async call
-//   defs         - Current live LIR edges
-//   life         - Liveness information about live locals
-//   liveLocals   - Information about each live local.
+//   block         - The block containing the async call
+//   call          - The async call
+//   defs          - Current live LIR edges
+//   life          - Liveness information about live locals
+//   layoutBuilder - Layout being built
 //
 void AsyncTransformation::CreateLiveSetForSuspension(BasicBlock*                     block,
                                                      GenTreeCall*                    call,
                                                      const jitstd::vector<GenTree*>& defs,
                                                      AsyncLiveness&                  life,
-                                                     jitstd::vector<LiveLocalInfo>&  liveLocals)
+                                                     ContinuationLayoutBuilder*      layoutBuilder)
 {
     SmallHashTable<unsigned, bool> excludedLocals(m_compiler->getAllocator(CMK_Async));
 
@@ -1387,22 +1398,22 @@ void AsyncTransformation::CreateLiveSetForSuspension(BasicBlock*                
         excludedLocals.AddOrUpdate(m_compiler->lvaAsyncExecutionContextVar, true);
     }
 
-    life.GetLiveLocals(liveLocals, [&](unsigned lclNum) {
+    life.GetLiveLocals(layoutBuilder, [&](unsigned lclNum) {
         return !excludedLocals.Contains(lclNum);
     });
-    LiftLIREdges(block, defs, liveLocals);
+    LiftLIREdges(block, defs, layoutBuilder);
 
 #ifdef DEBUG
     if (m_compiler->verbose)
     {
-        printf("  %zu live locals\n", liveLocals.size());
+        printf("  %zu live locals\n", layoutBuilder->Locals().size());
 
-        if (liveLocals.size() > 0)
+        if (layoutBuilder->Locals().size() > 0)
         {
             const char* sep = "    ";
-            for (LiveLocalInfo& inf : liveLocals)
+            for (unsigned lclNum : layoutBuilder->Locals())
             {
-                printf("%sV%02u (%s)", sep, inf.LclNum, varTypeName(m_compiler->lvaGetDesc(inf.LclNum)->TypeGet()));
+                printf("%sV%02u (%s)", sep, lclNum, varTypeName(m_compiler->lvaGetDesc(lclNum)->TypeGet()));
                 sep = ", ";
             }
 
@@ -1441,13 +1452,13 @@ bool AsyncTransformation::HasNonContextRestoreExceptionalFlow(BasicBlock* block)
 //   indicating that these locals are live.
 //
 // Parameters:
-//   block      - The block containing the definitions of the LIR edges
-//   defs       - Current outstanding LIR edges
-//   liveLocals - [out] Vector to add new live local information into
+//   block         - The block containing the definitions of the LIR edges
+//   defs          - Current outstanding LIR edges
+//   layoutBuilder - Continuation layout builder to add new locals to
 //
 void AsyncTransformation::LiftLIREdges(BasicBlock*                     block,
                                        const jitstd::vector<GenTree*>& defs,
-                                       jitstd::vector<LiveLocalInfo>&  liveLocals)
+                                       ContinuationLayoutBuilder*      layoutBuilder)
 {
     if (defs.size() <= 0)
     {
@@ -1475,7 +1486,7 @@ void AsyncTransformation::LiftLIREdges(BasicBlock*                     block,
         assert(gotUse); // Defs list should not contain unused values.
 
         unsigned newLclNum = use.ReplaceWithLclVar(m_compiler);
-        liveLocals.push_back(LiveLocalInfo(newLclNum));
+        layoutBuilder->AddLocal(newLclNum);
         GenTree* newUse = use.Def();
         LIR::AsRange(block).Remove(newUse);
         LIR::AsRange(block).InsertBefore(use.User(), newUse);
@@ -1563,6 +1574,53 @@ public:
         }
     }
 };
+
+void AsyncTransformation::BuildContinuation(BasicBlock* block, GenTreeCall* call, bool needsKeepAlive, ContinuationLayoutBuilder* layoutBuilder)
+{
+    layoutBuilder->SetReturn(call->gtReturnType, m_compiler->typGetObjLayout(call->gtRetClsHnd));
+    if (call->gtReturnType != TYP_VOID)
+    {
+        JITDUMP("Call has return; continuation will have return value\n");
+    }
+
+    // For OSR, we store the IL offset that inspired the OSR method at the
+    // beginning of the data (and store -1 in the tier0 version). This must be
+    // at the beginning because the tier0 and OSR versions need to agree on
+    // this.
+    if (m_compiler->doesMethodHavePatchpoints() || m_compiler->opts.IsOSR())
+    {
+        JITDUMP("  Method %s; keeping IL offset that inspired OSR method at the beginning of non-GC data\n",
+                m_compiler->doesMethodHavePatchpoints() ? "has patchpoints" : "is an OSR method");
+        // Must be pointer sized for compatibility with Continuation methods that access fields
+        layoutBuilder->SetNeedsOSRILOffset();
+    }
+
+    if (HasNonContextRestoreExceptionalFlow(block))
+    {
+        // If we are enclosed in any try region that isn't our special "context
+        // restore" try region then we need to rethrow an exception. For our
+        // special "context restore" try region we know that it is a no-op on
+        // the resumption path.
+        layoutBuilder->SetNeedsException();
+        JITDUMP("  " FMT_BB " is in try region %u; continuation will have exception\n", block->bbNum,
+                block->getTryIndex());
+    }
+
+    if (call->GetAsyncInfo().ContinuationContextHandling == ContinuationContextHandling::ContinueOnCapturedContext)
+    {
+        layoutBuilder->SetNeedsContinuationContext();
+        JITDUMP("  Continuation continues on captured context; continuation will have context\n");
+    }
+
+    if (needsKeepAlive)
+    {
+        layoutBuilder->SetNeedsKeepAlive();
+        JITDUMP("  Continuation will have keep alive object\n");
+    }
+
+    layoutBuilder->SetNeedsExecutionContext();
+    JITDUMP("  Call has async-only save and restore of ExecutionContext; continuation will have ExecutionContext\n");
+}
 
 //------------------------------------------------------------------------
 // AsyncTransformation::LayOutContinuation:
@@ -1904,6 +1962,38 @@ CallDefinitionInfo AsyncTransformation::CanonicalizeCallDefinition(BasicBlock*  
     }
 
     return callDefInfo;
+}
+
+BasicBlock* AsyncTransformation::CreateSuspensionBlock(BasicBlock* block, GenTreeCall* call, unsigned stateNum)
+{
+    if (m_lastSuspensionBB == nullptr)
+    {
+        m_lastSuspensionBB = m_compiler->fgLastBBInMainFunction();
+    }
+
+    BasicBlock* suspendBB = m_compiler->fgNewBBafter(BBJ_RETURN, m_lastSuspensionBB, false);
+    suspendBB->clearTryIndex();
+    suspendBB->clearHndIndex();
+    suspendBB->inheritWeightPercentage(block, 0);
+    m_lastSuspensionBB = suspendBB;
+
+    if (m_sharedReturnBB != nullptr)
+    {
+        suspendBB->SetKindAndTargetEdge(BBJ_ALWAYS, m_compiler->fgAddRefPred(m_sharedReturnBB, suspendBB));
+    }
+
+    JITDUMP("  Creating suspension " FMT_BB " for state %u\n", suspendBB->bbNum, stateNum);
+
+    GenTreeILOffset* ilOffsetNode =
+        m_compiler->gtNewILOffsetNode(call->GetAsyncInfo().CallAsyncDebugInfo DEBUGARG(BAD_IL_OFFSET));
+
+    LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_compiler, ilOffsetNode));
+
+    GenTree* recordOffset =
+        new (m_compiler, GT_RECORD_ASYNC_RESUME) GenTreeVal(GT_RECORD_ASYNC_RESUME, TYP_VOID, stateNum);
+    LIR::AsRange(suspendBB).InsertAtEnd(recordOffset);
+
+    return suspendBB;
 }
 
 //------------------------------------------------------------------------

--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -2084,13 +2084,12 @@ CallDefinitionInfo AsyncTransformation::CanonicalizeCallDefinition(BasicBlock*  
 //
 // Parameters:
 //   block    - The block containing the async call.
-//   call     - The async call.
 //   stateNum - State number assigned to this suspension point.
 //
 // Returns:
 //   The new basic block.
 //
-BasicBlock* AsyncTransformation::CreateSuspensionBlock(BasicBlock* block, GenTreeCall* call, unsigned stateNum)
+BasicBlock* AsyncTransformation::CreateSuspensionBlock(BasicBlock* block, unsigned stateNum)
 {
     if (m_lastSuspensionBB == nullptr)
     {
@@ -2553,17 +2552,12 @@ void AsyncTransformation::CreateCheckAndSuspendAfterCall(BasicBlock*            
 //
 // Parameters:
 //   remainder     - The block that contains the IR after the async call.
-//   call          - The async call.
 //   stateNum      - State number assigned to this suspension point.
-//   layoutBuilder - The continuation layout builder for this call.
 //
 // Returns:
 //   The new basic block.
 //
-BasicBlock* AsyncTransformation::CreateResumptionBlock(BasicBlock*                remainder,
-                                                       GenTreeCall*               call,
-                                                       unsigned                   stateNum,
-                                                       ContinuationLayoutBuilder* layoutBuilder)
+BasicBlock* AsyncTransformation::CreateResumptionBlock(BasicBlock* remainder, unsigned stateNum)
 {
     if (m_lastResumptionBB == nullptr)
     {

--- a/src/coreclr/jit/async.h
+++ b/src/coreclr/jit/async.h
@@ -1,6 +1,36 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+struct ReturnTypeInfo
+{
+    var_types ReturnType = TYP_UNDEF;
+    ClassLayout* ReturnLayout = nullptr;
+
+    ReturnTypeInfo(var_types returnType, ClassLayout* returnLayout)
+        : ReturnType(returnType)
+        , ReturnLayout(returnLayout)
+    {
+    }
+};
+
+struct ReturnInfo
+{
+    ReturnTypeInfo Type;
+    unsigned Alignment;
+    unsigned Offset;
+    unsigned Size;
+
+    ReturnInfo(ReturnTypeInfo type)
+        : Type(type)
+    {
+    }
+
+    unsigned HeapAlignment() const
+    {
+        return std::min(Alignment, (unsigned)TARGET_POINTER_SIZE);
+    }
+};
+
 struct LiveLocalInfo
 {
     unsigned LclNum;
@@ -29,14 +59,13 @@ private:
     bool m_needsKeepAlive = false;
     bool m_needsExecutionContext = false;
 
-    var_types ReturnType = TYP_VOID;
-    ClassLayout* ReturnLayout = nullptr;
-
+    jitstd::vector<ReturnTypeInfo> m_returns;
     jitstd::vector<unsigned> m_locals;
 
 public:
     ContinuationLayoutBuilder(Compiler* compiler)
         : m_compiler(compiler)
+        , m_returns(compiler->getAllocator(CMK_Async))
         , m_locals(compiler->getAllocator(CMK_Async))
     {
     }
@@ -45,55 +74,78 @@ public:
     {
         m_needsOSRILOffset = true;
     }
+    bool NeedsOSRILOffset() const
+    {
+        return m_needsOSRILOffset;
+    }
     void SetNeedsException()
     {
         m_needsException = true;
+    }
+    bool NeedsException() const
+    {
+        return m_needsException;
     }
     void SetNeedsContinuationContext()
     {
         m_needsContinuationContext = true;
     }
+    bool NeedsContinuationContext() const
+    {
+        return m_needsContinuationContext;
+    }
     void SetNeedsKeepAlive()
     {
         m_needsKeepAlive = true;
+    }
+    bool NeedsKeepAlive() const
+    {
+        return m_needsKeepAlive;
     }
     void SetNeedsExecutionContext()
     {
         m_needsExecutionContext = true;
     }
-    void SetReturn(var_types type, ClassLayout* layout);
+    bool NeedsExecutionContext() const
+    {
+        return m_needsExecutionContext;
+    }
+    void AddReturn(const ReturnTypeInfo& info);
     void AddLocal(unsigned lclNum);
+    bool ContainsLocal(unsigned lclNum) const;
 
-    const jitstd::vector<unsigned> Locals() const
+    const jitstd::vector<unsigned>& Locals() const
     {
         return m_locals;
     }
+
+    struct ContinuationLayout* Create();
+
+    static ContinuationLayoutBuilder* CreateSharedLayout(Compiler* comp, const jitstd::vector<struct AsyncState>& states);
 };
 
 struct ContinuationLayout
 {
-    unsigned                             Size                      = 0;
-    unsigned                             OSRILOffset               = UINT_MAX;
-    unsigned                             ExceptionOffset           = UINT_MAX;
-    unsigned                             ContinuationContextOffset = UINT_MAX;
-    unsigned                             KeepAliveOffset           = UINT_MAX;
-    ClassLayout*                         ReturnStructLayout        = nullptr;
-    unsigned                             ReturnAlignment           = 0;
-    unsigned                             ReturnSize                = 0;
-    unsigned                             ReturnValOffset           = UINT_MAX;
-    unsigned                             ExecutionContextOffset    = UINT_MAX;
-    const jitstd::vector<LiveLocalInfo>& Locals;
-    CORINFO_CLASS_HANDLE                 ClassHnd = NO_CLASS_HANDLE;
+    unsigned                            Size                      = 0;
+    unsigned                            OSRILOffset               = UINT_MAX;
+    unsigned                            ExceptionOffset           = UINT_MAX;
+    unsigned                            ContinuationContextOffset = UINT_MAX;
+    unsigned                            KeepAliveOffset           = UINT_MAX;
+    unsigned                            ExecutionContextOffset    = UINT_MAX;
+    jitstd::vector<LiveLocalInfo> Locals;
+    jitstd::vector<ReturnInfo> Returns;
+    CORINFO_CLASS_HANDLE                ClassHnd = NO_CLASS_HANDLE;
 
-    explicit ContinuationLayout(const jitstd::vector<LiveLocalInfo>& locals)
-        : Locals(locals)
+    ContinuationLayout(Compiler* comp)
+        : Locals(comp->getAllocator(CMK_Async))
+        , Returns(comp->getAllocator(CMK_Async))
     {
     }
 
-    unsigned ReturnHeapAlignment() const
-    {
-        return std::min(ReturnAlignment, (unsigned)TARGET_POINTER_SIZE);
-    }
+    const ReturnInfo* FindReturn(GenTreeCall* call) const;
+#ifdef DEBUG
+    void Dump(int indent = 0);
+#endif
 };
 
 struct CallDefinitionInfo
@@ -107,14 +159,26 @@ struct CallDefinitionInfo
 
 struct AsyncState
 {
-    AsyncState(ContinuationLayoutBuilder* layout, BasicBlock* suspensionBB, BasicBlock* resumptionBB)
-        : Layout(layout)
+    AsyncState(
+        unsigned number,
+        ContinuationLayoutBuilder* layout,
+        BasicBlock* callBlock, GenTreeCall* call, CallDefinitionInfo callDefInfo,
+        BasicBlock* suspensionBB, BasicBlock* resumptionBB)
+        : Number(number)
+        , Layout(layout)
+        , CallBlock(callBlock)
+        , Call(call)
+        , CallDefInfo(callDefInfo)
         , SuspensionBB(suspensionBB)
         , ResumptionBB(resumptionBB)
     {
     }
 
+    unsigned Number;
     ContinuationLayoutBuilder* Layout;
+    BasicBlock* CallBlock;
+    GenTreeCall* Call;
+    CallDefinitionInfo CallDefInfo;
     BasicBlock* SuspensionBB;
     BasicBlock* ResumptionBB;
 };
@@ -165,34 +229,33 @@ class AsyncTransformation
                            bool needsKeepAlive,
                            ContinuationLayoutBuilder* layoutBuilder);
 
-    ContinuationLayout LayOutContinuation(BasicBlock*                    block,
-                                          GenTreeCall*                   call,
-                                          bool                           needsKeepAlive,
-                                          jitstd::vector<LiveLocalInfo>& liveLocals);
+    ContinuationLayout LayOutContinuation(const ContinuationLayoutBuilder* layoutBuilder);
 
     CallDefinitionInfo CanonicalizeCallDefinition(BasicBlock* block, GenTreeCall* call, AsyncLiveness* life);
 
     BasicBlock* CreateSuspensionBlock(BasicBlock* block, GenTreeCall* call, unsigned stateNum);
-    BasicBlock* CreateSuspension(
-        BasicBlock* block, GenTreeCall* call, unsigned stateNum, AsyncLiveness& life, const ContinuationLayout& layout);
-    GenTreeCall* CreateAllocContinuationCall(AsyncLiveness&            life,
+    void CreateSuspension(
+        BasicBlock* callBlock, GenTreeCall* call, BasicBlock* suspendBB, unsigned stateNum, const ContinuationLayout& layout, const ContinuationLayoutBuilder& subLayout);
+
+    GenTreeCall* CreateAllocContinuationCall(bool hasKeepAlive,
                                              GenTree*                  prevContinuation,
                                              const ContinuationLayout& layout);
-    void         FillInDataOnSuspension(GenTreeCall* call, const ContinuationLayout& layout, BasicBlock* suspendBB);
+    void         FillInDataOnSuspension(GenTreeCall* call, const ContinuationLayout& layout, const ContinuationLayoutBuilder& subLayout, BasicBlock* suspendBB);
     void         RestoreContexts(BasicBlock* block, GenTreeCall* call, BasicBlock* suspendBB);
     void         CreateCheckAndSuspendAfterCall(BasicBlock*               block,
                                                 GenTreeCall*              call,
                                                 const CallDefinitionInfo& callDefInfo,
                                                 BasicBlock*               suspendBB,
                                                 BasicBlock**              remainder);
-    BasicBlock*  CreateResumption(BasicBlock*               block,
-                                  BasicBlock*               remainder,
+    BasicBlock*  CreateResumptionBlock(BasicBlock* remainder, GenTreeCall* call, unsigned stateNum, ContinuationLayoutBuilder* layoutBuilder);
+    void  CreateResumption(BasicBlock*               callBlock,
                                   GenTreeCall*              call,
+                                  BasicBlock*               resumeBB,
                                   const CallDefinitionInfo& callDefInfo,
-                                  unsigned                  stateNum,
-                                  const ContinuationLayout& layout);
-    void         SetSuspendedIndicator(BasicBlock* block, BasicBlock* callBlock, GenTreeCall* call);
-    void         RestoreFromDataOnResumption(const ContinuationLayout& layout, BasicBlock* resumeBB);
+                                  const ContinuationLayout& layout,
+                                  const ContinuationLayoutBuilder& subLayout);
+
+    void         RestoreFromDataOnResumption(const ContinuationLayout& layout, const ContinuationLayoutBuilder& subLayout, BasicBlock* resumeBB);
     BasicBlock* RethrowExceptionOnResumption(BasicBlock* block, const ContinuationLayout& layout, BasicBlock* resumeBB);
     void        CopyReturnValueOnResumption(GenTreeCall*              call,
                                             const CallDefinitionInfo& callDefInfo,
@@ -209,13 +272,14 @@ class AsyncTransformation
                                    var_types    storeType,
                                    GenTreeFlags indirFlags = GTF_IND_NONFAULTING);
 
-    void        CreateDebugInfoForSuspensionPoint(const ContinuationLayout& layout);
+    void        CreateDebugInfoForSuspensionPoint(const ContinuationLayout& layout, const ContinuationLayoutBuilder& subLayout);
     unsigned    GetReturnedContinuationVar();
     unsigned    GetNewContinuationVar();
     unsigned    GetResultBaseVar();
     unsigned    GetExceptionVar();
     BasicBlock* GetSharedReturnBB();
 
+    void CreateResumptionsAndSuspensions();
     void CreateResumptionSwitch();
 
 public:

--- a/src/coreclr/jit/async.h
+++ b/src/coreclr/jit/async.h
@@ -3,7 +3,7 @@
 
 struct ReturnTypeInfo
 {
-    var_types ReturnType = TYP_UNDEF;
+    var_types    ReturnType   = TYP_UNDEF;
     ClassLayout* ReturnLayout = nullptr;
 
     ReturnTypeInfo(var_types returnType, ClassLayout* returnLayout)
@@ -16,9 +16,9 @@ struct ReturnTypeInfo
 struct ReturnInfo
 {
     ReturnTypeInfo Type;
-    unsigned Alignment;
-    unsigned Offset;
-    unsigned Size;
+    unsigned       Alignment;
+    unsigned       Offset;
+    unsigned       Size;
 
     ReturnInfo(ReturnTypeInfo type)
         : Type(type)
@@ -53,14 +53,14 @@ struct ContinuationLayoutBuilder
 {
 private:
     Compiler* m_compiler;
-    bool m_needsOSRILOffset = false;
-    bool m_needsException = false;
-    bool m_needsContinuationContext = false;
-    bool m_needsKeepAlive = false;
-    bool m_needsExecutionContext = false;
+    bool      m_needsOSRILOffset         = false;
+    bool      m_needsException           = false;
+    bool      m_needsContinuationContext = false;
+    bool      m_needsKeepAlive           = false;
+    bool      m_needsExecutionContext    = false;
 
     jitstd::vector<ReturnTypeInfo> m_returns;
-    jitstd::vector<unsigned> m_locals;
+    jitstd::vector<unsigned>       m_locals;
 
 public:
     ContinuationLayoutBuilder(Compiler* compiler)
@@ -121,20 +121,21 @@ public:
 
     struct ContinuationLayout* Create();
 
-    static ContinuationLayoutBuilder* CreateSharedLayout(Compiler* comp, const jitstd::vector<struct AsyncState>& states);
+    static ContinuationLayoutBuilder* CreateSharedLayout(Compiler*                                comp,
+                                                         const jitstd::vector<struct AsyncState>& states);
 };
 
 struct ContinuationLayout
 {
-    unsigned                            Size                      = 0;
-    unsigned                            OSRILOffset               = UINT_MAX;
-    unsigned                            ExceptionOffset           = UINT_MAX;
-    unsigned                            ContinuationContextOffset = UINT_MAX;
-    unsigned                            KeepAliveOffset           = UINT_MAX;
-    unsigned                            ExecutionContextOffset    = UINT_MAX;
+    unsigned                      Size                      = 0;
+    unsigned                      OSRILOffset               = UINT_MAX;
+    unsigned                      ExceptionOffset           = UINT_MAX;
+    unsigned                      ContinuationContextOffset = UINT_MAX;
+    unsigned                      KeepAliveOffset           = UINT_MAX;
+    unsigned                      ExecutionContextOffset    = UINT_MAX;
     jitstd::vector<LiveLocalInfo> Locals;
-    jitstd::vector<ReturnInfo> Returns;
-    CORINFO_CLASS_HANDLE                ClassHnd = NO_CLASS_HANDLE;
+    jitstd::vector<ReturnInfo>    Returns;
+    CORINFO_CLASS_HANDLE          ClassHnd = NO_CLASS_HANDLE;
 
     ContinuationLayout(Compiler* comp)
         : Locals(comp->getAllocator(CMK_Async))
@@ -159,11 +160,13 @@ struct CallDefinitionInfo
 
 struct AsyncState
 {
-    AsyncState(
-        unsigned number,
-        ContinuationLayoutBuilder* layout,
-        BasicBlock* callBlock, GenTreeCall* call, CallDefinitionInfo callDefInfo,
-        BasicBlock* suspensionBB, BasicBlock* resumptionBB)
+    AsyncState(unsigned                   number,
+               ContinuationLayoutBuilder* layout,
+               BasicBlock*                callBlock,
+               GenTreeCall*               call,
+               CallDefinitionInfo         callDefInfo,
+               BasicBlock*                suspensionBB,
+               BasicBlock*                resumptionBB)
         : Number(number)
         , Layout(layout)
         , CallBlock(callBlock)
@@ -174,31 +177,31 @@ struct AsyncState
     {
     }
 
-    unsigned Number;
+    unsigned                   Number;
     ContinuationLayoutBuilder* Layout;
-    BasicBlock* CallBlock;
-    GenTreeCall* Call;
-    CallDefinitionInfo CallDefInfo;
-    BasicBlock* SuspensionBB;
-    BasicBlock* ResumptionBB;
+    BasicBlock*                CallBlock;
+    GenTreeCall*               Call;
+    CallDefinitionInfo         CallDefInfo;
+    BasicBlock*                SuspensionBB;
+    BasicBlock*                ResumptionBB;
 };
 
 class AsyncTransformation
 {
     friend class AsyncLiveness;
 
-    Compiler*                     m_compiler;
-    CORINFO_ASYNC_INFO*           m_asyncInfo;
-    jitstd::vector<AsyncState>    m_states;
-    unsigned                      m_returnedContinuationVar = BAD_VAR_NUM;
-    unsigned                      m_newContinuationVar      = BAD_VAR_NUM;
-    unsigned                      m_dataArrayVar            = BAD_VAR_NUM;
-    unsigned                      m_gcDataArrayVar          = BAD_VAR_NUM;
-    unsigned                      m_resultBaseVar           = BAD_VAR_NUM;
-    unsigned                      m_exceptionVar            = BAD_VAR_NUM;
-    BasicBlock*                   m_lastSuspensionBB        = nullptr;
-    BasicBlock*                   m_lastResumptionBB        = nullptr;
-    BasicBlock*                   m_sharedReturnBB          = nullptr;
+    Compiler*                  m_compiler;
+    CORINFO_ASYNC_INFO*        m_asyncInfo;
+    jitstd::vector<AsyncState> m_states;
+    unsigned                   m_returnedContinuationVar = BAD_VAR_NUM;
+    unsigned                   m_newContinuationVar      = BAD_VAR_NUM;
+    unsigned                   m_dataArrayVar            = BAD_VAR_NUM;
+    unsigned                   m_gcDataArrayVar          = BAD_VAR_NUM;
+    unsigned                   m_resultBaseVar           = BAD_VAR_NUM;
+    unsigned                   m_exceptionVar            = BAD_VAR_NUM;
+    BasicBlock*                m_lastSuspensionBB        = nullptr;
+    BasicBlock*                m_lastResumptionBB        = nullptr;
+    BasicBlock*                m_sharedReturnBB          = nullptr;
 
     void        TransformTailAwait(BasicBlock* block, GenTreeCall* call, BasicBlock** remainder);
     BasicBlock* CreateTailAwaitSuspension(BasicBlock* block, GenTreeCall* call);
@@ -224,9 +227,9 @@ class AsyncTransformation
 
     bool ContinuationNeedsKeepAlive(class AsyncLiveness& life);
 
-    void BuildContinuation(BasicBlock* block,
-                           GenTreeCall* call,
-                           bool needsKeepAlive,
+    void BuildContinuation(BasicBlock*                block,
+                           GenTreeCall*               call,
+                           bool                       needsKeepAlive,
                            ContinuationLayoutBuilder* layoutBuilder);
 
     ContinuationLayout LayOutContinuation(const ContinuationLayoutBuilder* layoutBuilder);
@@ -234,28 +237,40 @@ class AsyncTransformation
     CallDefinitionInfo CanonicalizeCallDefinition(BasicBlock* block, GenTreeCall* call, AsyncLiveness* life);
 
     BasicBlock* CreateSuspensionBlock(BasicBlock* block, GenTreeCall* call, unsigned stateNum);
-    void CreateSuspension(
-        BasicBlock* callBlock, GenTreeCall* call, BasicBlock* suspendBB, unsigned stateNum, const ContinuationLayout& layout, const ContinuationLayoutBuilder& subLayout);
+    void        CreateSuspension(BasicBlock*                      callBlock,
+                                 GenTreeCall*                     call,
+                                 BasicBlock*                      suspendBB,
+                                 unsigned                         stateNum,
+                                 const ContinuationLayout&        layout,
+                                 const ContinuationLayoutBuilder& subLayout);
 
-    GenTreeCall* CreateAllocContinuationCall(bool hasKeepAlive,
+    GenTreeCall* CreateAllocContinuationCall(bool                      hasKeepAlive,
                                              GenTree*                  prevContinuation,
                                              const ContinuationLayout& layout);
-    void         FillInDataOnSuspension(GenTreeCall* call, const ContinuationLayout& layout, const ContinuationLayoutBuilder& subLayout, BasicBlock* suspendBB);
+    void         FillInDataOnSuspension(GenTreeCall*                     call,
+                                        const ContinuationLayout&        layout,
+                                        const ContinuationLayoutBuilder& subLayout,
+                                        BasicBlock*                      suspendBB);
     void         RestoreContexts(BasicBlock* block, GenTreeCall* call, BasicBlock* suspendBB);
     void         CreateCheckAndSuspendAfterCall(BasicBlock*               block,
                                                 GenTreeCall*              call,
                                                 const CallDefinitionInfo& callDefInfo,
                                                 BasicBlock*               suspendBB,
                                                 BasicBlock**              remainder);
-    BasicBlock*  CreateResumptionBlock(BasicBlock* remainder, GenTreeCall* call, unsigned stateNum, ContinuationLayoutBuilder* layoutBuilder);
-    void  CreateResumption(BasicBlock*               callBlock,
-                                  GenTreeCall*              call,
-                                  BasicBlock*               resumeBB,
-                                  const CallDefinitionInfo& callDefInfo,
-                                  const ContinuationLayout& layout,
+    BasicBlock*  CreateResumptionBlock(BasicBlock*                remainder,
+                                       GenTreeCall*               call,
+                                       unsigned                   stateNum,
+                                       ContinuationLayoutBuilder* layoutBuilder);
+    void         CreateResumption(BasicBlock*                      callBlock,
+                                  GenTreeCall*                     call,
+                                  BasicBlock*                      resumeBB,
+                                  const CallDefinitionInfo&        callDefInfo,
+                                  const ContinuationLayout&        layout,
                                   const ContinuationLayoutBuilder& subLayout);
 
-    void         RestoreFromDataOnResumption(const ContinuationLayout& layout, const ContinuationLayoutBuilder& subLayout, BasicBlock* resumeBB);
+    void        RestoreFromDataOnResumption(const ContinuationLayout&        layout,
+                                            const ContinuationLayoutBuilder& subLayout,
+                                            BasicBlock*                      resumeBB);
     BasicBlock* RethrowExceptionOnResumption(BasicBlock* block, const ContinuationLayout& layout, BasicBlock* resumeBB);
     void        CopyReturnValueOnResumption(GenTreeCall*              call,
                                             const CallDefinitionInfo& callDefInfo,
@@ -272,7 +287,8 @@ class AsyncTransformation
                                    var_types    storeType,
                                    GenTreeFlags indirFlags = GTF_IND_NONFAULTING);
 
-    void        CreateDebugInfoForSuspensionPoint(const ContinuationLayout& layout, const ContinuationLayoutBuilder& subLayout);
+    void        CreateDebugInfoForSuspensionPoint(const ContinuationLayout&        layout,
+                                                  const ContinuationLayoutBuilder& subLayout);
     unsigned    GetReturnedContinuationVar();
     unsigned    GetNewContinuationVar();
     unsigned    GetResultBaseVar();

--- a/src/coreclr/jit/async.h
+++ b/src/coreclr/jit/async.h
@@ -120,9 +120,6 @@ public:
     }
 
     struct ContinuationLayout* Create();
-
-    static ContinuationLayoutBuilder* CreateSharedLayout(Compiler*                                comp,
-                                                         const jitstd::vector<struct AsyncState>& states);
 };
 
 struct ContinuationLayout

--- a/src/coreclr/jit/async.h
+++ b/src/coreclr/jit/async.h
@@ -19,6 +19,57 @@ struct LiveLocalInfo
     }
 };
 
+struct ContinuationLayoutBuilder
+{
+private:
+    Compiler* m_compiler;
+    bool m_needsOSRILOffset = false;
+    bool m_needsException = false;
+    bool m_needsContinuationContext = false;
+    bool m_needsKeepAlive = false;
+    bool m_needsExecutionContext = false;
+
+    var_types ReturnType = TYP_VOID;
+    ClassLayout* ReturnLayout = nullptr;
+
+    jitstd::vector<unsigned> m_locals;
+
+public:
+    ContinuationLayoutBuilder(Compiler* compiler)
+        : m_compiler(compiler)
+        , m_locals(compiler->getAllocator(CMK_Async))
+    {
+    }
+
+    void SetNeedsOSRILOffset()
+    {
+        m_needsOSRILOffset = true;
+    }
+    void SetNeedsException()
+    {
+        m_needsException = true;
+    }
+    void SetNeedsContinuationContext()
+    {
+        m_needsContinuationContext = true;
+    }
+    void SetNeedsKeepAlive()
+    {
+        m_needsKeepAlive = true;
+    }
+    void SetNeedsExecutionContext()
+    {
+        m_needsExecutionContext = true;
+    }
+    void SetReturn(var_types type, ClassLayout* layout);
+    void AddLocal(unsigned lclNum);
+
+    const jitstd::vector<unsigned> Locals() const
+    {
+        return m_locals;
+    }
+};
+
 struct ContinuationLayout
 {
     unsigned                             Size                      = 0;
@@ -54,14 +105,27 @@ struct CallDefinitionInfo
     GenTree* InsertAfter = nullptr;
 };
 
+struct AsyncState
+{
+    AsyncState(ContinuationLayoutBuilder* layout, BasicBlock* suspensionBB, BasicBlock* resumptionBB)
+        : Layout(layout)
+        , SuspensionBB(suspensionBB)
+        , ResumptionBB(resumptionBB)
+    {
+    }
+
+    ContinuationLayoutBuilder* Layout;
+    BasicBlock* SuspensionBB;
+    BasicBlock* ResumptionBB;
+};
+
 class AsyncTransformation
 {
     friend class AsyncLiveness;
 
     Compiler*                     m_compiler;
-    jitstd::vector<LiveLocalInfo> m_liveLocalsScratch;
     CORINFO_ASYNC_INFO*           m_asyncInfo;
-    jitstd::vector<BasicBlock*>   m_resumptionBBs;
+    jitstd::vector<AsyncState>    m_states;
     unsigned                      m_returnedContinuationVar = BAD_VAR_NUM;
     unsigned                      m_newContinuationVar      = BAD_VAR_NUM;
     unsigned                      m_dataArrayVar            = BAD_VAR_NUM;
@@ -86,15 +150,20 @@ class AsyncTransformation
                                     GenTreeCall*                    call,
                                     const jitstd::vector<GenTree*>& defs,
                                     AsyncLiveness&                  life,
-                                    jitstd::vector<LiveLocalInfo>&  liveLocals);
+                                    ContinuationLayoutBuilder*      layoutBuilder);
 
     bool HasNonContextRestoreExceptionalFlow(BasicBlock* block);
 
     void LiftLIREdges(BasicBlock*                     block,
                       const jitstd::vector<GenTree*>& defs,
-                      jitstd::vector<LiveLocalInfo>&  liveLocals);
+                      ContinuationLayoutBuilder*      layoutBuilder);
 
     bool ContinuationNeedsKeepAlive(class AsyncLiveness& life);
+
+    void BuildContinuation(BasicBlock* block,
+                           GenTreeCall* call,
+                           bool needsKeepAlive,
+                           ContinuationLayoutBuilder* layoutBuilder);
 
     ContinuationLayout LayOutContinuation(BasicBlock*                    block,
                                           GenTreeCall*                   call,
@@ -103,6 +172,7 @@ class AsyncTransformation
 
     CallDefinitionInfo CanonicalizeCallDefinition(BasicBlock* block, GenTreeCall* call, AsyncLiveness* life);
 
+    BasicBlock* CreateSuspensionBlock(BasicBlock* block, GenTreeCall* call, unsigned stateNum);
     BasicBlock* CreateSuspension(
         BasicBlock* block, GenTreeCall* call, unsigned stateNum, AsyncLiveness& life, const ContinuationLayout& layout);
     GenTreeCall* CreateAllocContinuationCall(AsyncLiveness&            life,
@@ -151,8 +221,7 @@ class AsyncTransformation
 public:
     AsyncTransformation(Compiler* comp)
         : m_compiler(comp)
-        , m_liveLocalsScratch(comp->getAllocator(CMK_Async))
-        , m_resumptionBBs(comp->getAllocator(CMK_Async))
+        , m_states(comp->getAllocator(CMK_Async))
     {
     }
 

--- a/src/coreclr/jit/async.h
+++ b/src/coreclr/jit/async.h
@@ -229,11 +229,9 @@ class AsyncTransformation
                            bool                       needsKeepAlive,
                            ContinuationLayoutBuilder* layoutBuilder);
 
-    ContinuationLayout LayOutContinuation(const ContinuationLayoutBuilder* layoutBuilder);
-
     CallDefinitionInfo CanonicalizeCallDefinition(BasicBlock* block, GenTreeCall* call, AsyncLiveness* life);
 
-    BasicBlock* CreateSuspensionBlock(BasicBlock* block, GenTreeCall* call, unsigned stateNum);
+    BasicBlock* CreateSuspensionBlock(BasicBlock* block, unsigned stateNum);
     void        CreateSuspension(BasicBlock*                      callBlock,
                                  GenTreeCall*                     call,
                                  BasicBlock*                      suspendBB,
@@ -254,10 +252,7 @@ class AsyncTransformation
                                                 const CallDefinitionInfo& callDefInfo,
                                                 BasicBlock*               suspendBB,
                                                 BasicBlock**              remainder);
-    BasicBlock*  CreateResumptionBlock(BasicBlock*                remainder,
-                                       GenTreeCall*               call,
-                                       unsigned                   stateNum,
-                                       ContinuationLayoutBuilder* layoutBuilder);
+    BasicBlock*  CreateResumptionBlock(BasicBlock* remainder, unsigned stateNum);
     void         CreateResumption(BasicBlock*                      callBlock,
                                   GenTreeCall*                     call,
                                   BasicBlock*                      resumeBB,

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -592,6 +592,7 @@ OPT_CONFIG_INTEGER(JitDoOptimizeMaskConversions, "JitDoOptimizeMaskConversions",
 OPT_CONFIG_INTEGER(JitOptimizeAwait, "JitOptimizeAwait", 1) // Perform optimization of Await intrinsics
 OPT_CONFIG_STRING(JitAsyncDefaultValueAnalysisRange,
                   "JitAsyncDefaultValueAnalysisRange") // Enable async default value analysis based on method hash range
+OPT_CONFIG_INTEGER(JitAsyncReuseContinuations, "JitAsyncReuseContinuations", 1) // Save and reuse continuations in runtime async functions
 
 RELEASE_CONFIG_INTEGER(JitEnableOptRepeat, "JitEnableOptRepeat", 1) // If zero, do not allow JitOptRepeat
 RELEASE_CONFIG_METHODSET(JitOptRepeat, "JitOptRepeat")            // Runs optimizer multiple times on specified methods

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -592,7 +592,6 @@ OPT_CONFIG_INTEGER(JitDoOptimizeMaskConversions, "JitDoOptimizeMaskConversions",
 OPT_CONFIG_INTEGER(JitOptimizeAwait, "JitOptimizeAwait", 1) // Perform optimization of Await intrinsics
 OPT_CONFIG_STRING(JitAsyncDefaultValueAnalysisRange,
                   "JitAsyncDefaultValueAnalysisRange") // Enable async default value analysis based on method hash range
-OPT_CONFIG_INTEGER(JitAsyncReuseContinuations, "JitAsyncReuseContinuations", 1) // Save and reuse continuations in runtime async functions
 
 RELEASE_CONFIG_INTEGER(JitEnableOptRepeat, "JitEnableOptRepeat", 1) // If zero, do not allow JitOptRepeat
 RELEASE_CONFIG_METHODSET(JitOptRepeat, "JitOptRepeat")            // Runs optimizer multiple times on specified methods

--- a/src/coreclr/jit/jitstd/vector.h
+++ b/src/coreclr/jit/jitstd/vector.h
@@ -218,6 +218,8 @@ public:
 
     T* data() { return m_pArray; }
 
+    const T* data() const { return m_pArray; }
+
     void swap(vector<T, Allocator>& vec);
 
 private:


### PR DESCRIPTION
This refactors the async transformation to collect all continuation information before generating the suspensions/resumptions themselves. This allows reusing continuation layouts across multiple suspension points and will allow experimenting with strategies where we only allocate one continuation, and then reuse it for all future suspensions.

Some minor diffs expected where locals are allocated in different orders, leading to different stack frame encodings.