### PR TITLE
Fix possible integer overflow

### DIFF
--- a/src/libraries/System.Data.Common/src/System/Data/Common/DataRecordInternal.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DataRecordInternal.cs
@@ -114,15 +114,11 @@ namespace System.Data.Common
             // since arrays can't handle 64 bit values and this interface doesn't
             // allow chunked access to data, a dataIndex outside the rang of Int32
             // is invalid
-            if (dataIndex > int.MaxValue)
+            if ((ulong)dataIndex > int.MaxValue)
             {
                 throw ADP.InvalidSourceBufferIndex(cbytes, dataIndex, nameof(dataIndex));
             }
 
-            if (dataIndex < 0 || dataIndex > int.MaxValue)
-            {
-                throw new ArgumentOutOfRangeException(nameof(dataIndex));
-            }
             ndataIndex = (int)dataIndex;
 
             // if no buffer is passed in, return the number of characters we have
@@ -188,15 +184,11 @@ namespace System.Data.Common
             // since arrays can't handle 64 bit values and this interface doesn't
             // allow chunked access to data, a dataIndex outside the rang of Int32
             // is invalid
-            if (dataIndex > int.MaxValue)
+            if ((ulong)dataIndex > int.MaxValue)
             {
                 throw ADP.InvalidSourceBufferIndex(cchars, dataIndex, nameof(dataIndex));
             }
 
-            if (dataIndex < 0)
-	     {
-                throw new ArgumentOutOfRangeException(nameof(dataIndex), dataIndex, SR.Format(SR.Argument_MustBeGEZeroString));
-            }
             int ndataIndex = (int)dataIndex;
 
 

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DataRecordInternal.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DataRecordInternal.cs
@@ -182,7 +182,7 @@ namespace System.Data.Common
             int cchars = data.Length;
 
             // since arrays can't handle 64 bit values and this interface doesn't
-            // allow chunked access to data, a dataIndex outside the rang of Int32
+            // allow chunked access to data, a dataIndex outside the range of Int32
             // is invalid
             if ((ulong)dataIndex > int.MaxValue)
             {

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DataRecordInternal.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DataRecordInternal.cs
@@ -112,7 +112,7 @@ namespace System.Data.Common
             cbytes = data.Length;
 
             // since arrays can't handle 64 bit values and this interface doesn't
-            // allow chunked access to data, a dataIndex outside the rang of Int32
+            // allow chunked access to data, a dataIndex outside the range of Int32
             // is invalid
             if ((ulong)dataIndex > int.MaxValue)
             {

--- a/src/libraries/System.Data.Common/src/System/Data/Common/DataRecordInternal.cs
+++ b/src/libraries/System.Data.Common/src/System/Data/Common/DataRecordInternal.cs
@@ -119,6 +119,10 @@ namespace System.Data.Common
                 throw ADP.InvalidSourceBufferIndex(cbytes, dataIndex, nameof(dataIndex));
             }
 
+            if (dataIndex < 0 || dataIndex > int.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(dataIndex));
+            }
             ndataIndex = (int)dataIndex;
 
             // if no buffer is passed in, return the number of characters we have
@@ -189,6 +193,10 @@ namespace System.Data.Common
                 throw ADP.InvalidSourceBufferIndex(cchars, dataIndex, nameof(dataIndex));
             }
 
+            if (dataIndex < 0)
+	     {
+                throw new ArgumentOutOfRangeException(nameof(dataIndex), dataIndex, SR.Format(SR.Argument_MustBeGEZeroString));
+            }
             int ndataIndex = (int)dataIndex;
 
 

--- a/src/libraries/System.Data.Common/tests/System/Data/Common/DataRecordInternalTest.cs
+++ b/src/libraries/System.Data.Common/tests/System/Data/Common/DataRecordInternalTest.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Xunit;
+
+namespace System.Data.Common.Tests
+{
+    public class DataRecordInternalTest
+    {
+        [Fact]
+        public void GetBytes_NegativeDataIndex_ThrowsIndexOutOfRangeException()
+        {
+            DataTable table = new DataTable();
+            table.Columns.Add("Bytes", typeof(byte[]));
+            table.Rows.Add(new byte[] { 1, 2, 3 });
+
+            using DataTableReader reader = table.CreateDataReader();
+            reader.Read();
+
+            byte[] buffer = new byte[3];
+
+            Assert.Throws<IndexOutOfRangeException>(() => reader.GetBytes(0, Int64.MinValue, buffer, 0, buffer.Length));
+        }
+
+        [Fact]
+        public void GetChars_NegativeDataIndex_ThrowsIndexOutOfRangeException()
+        {
+            DataTable table = new DataTable();
+            table.Columns.Add("Chars", typeof(char[]));
+            table.Rows.Add(new char[] { 'a', 'b', 'c' });
+
+            using DataTableReader reader = table.CreateDataReader();
+            reader.Read();
+
+            char[] buffer = new char[3];
+
+            Assert.Throws<IndexOutOfRangeException>(() => reader.GetChars(0, Int64.MinValue, buffer, 0, buffer.Length));
+        }
+    }
+}


### PR DESCRIPTION
If `dataIndex` is less than `-2147483648`, `InvalidSourceBufferIndex` will not be thrown. In this case, `int ndataIndex = (int)dataIndex;` assigns `ndataIndex` the truncated value of `dataIndex`. 

Found by Linux Verification Center (linuxtesting.org) with SVACE.