### PR TITLE
Fix TOCTOU race in SharedMemoryHelpers.CreateOrOpenFile on Linux

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
@@ -462,12 +462,23 @@ namespace System.IO
                     }
 
                     // Another process created the file. Try to open it.
+                    // The creator may not have called FChMod yet, so if validation
+                    // fails on permissions, retry — the next attempt should see the
+                    // correct permissions.
                     fd = Interop.Sys.Open(sharedMemoryFilePath, MandatoryFlags, 0);
                     if (!fd.IsInvalid)
                     {
-                        createdFile = false;
-                        ValidateExistingFile(fd, sharedMemoryFilePath, id);
-                        return fd;
+                        try
+                        {
+                            ValidateExistingFile(fd, sharedMemoryFilePath, id);
+                            createdFile = false;
+                            return fd;
+                        }
+                        catch (IOException) when (retries < MaxRetries)
+                        {
+                            Thread.Sleep(1);
+                            continue;
+                        }
                     }
 
                     error = Interop.Sys.GetLastErrorInfo();

--- a/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
@@ -418,75 +418,89 @@ namespace System.IO
 
         internal static SafeFileHandle CreateOrOpenFile(string sharedMemoryFilePath, SharedMemoryId id, bool createIfNotExist, out bool createdFile)
         {
-            SafeFileHandle fd = Interop.Sys.Open(sharedMemoryFilePath, Interop.Sys.OpenFlags.O_RDWR | Interop.Sys.OpenFlags.O_CLOEXEC, 0);
-            Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
-            if (!fd.IsInvalid)
+            // Retry loop to handle the TOCTOU race between the initial open attempt (which may return ENOENT)
+            // and the exclusive create attempt (which may return EEXIST if another process created the file
+            // in between). On EEXIST, we loop back and re-attempt the open.
+            for (int retries = 0; ; retries++)
             {
-                if (id.IsUserScope)
+                SafeFileHandle fd = Interop.Sys.Open(sharedMemoryFilePath, Interop.Sys.OpenFlags.O_RDWR | Interop.Sys.OpenFlags.O_CLOEXEC, 0);
+                Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
+                if (!fd.IsInvalid)
                 {
-                    if (Interop.Sys.FStat(fd, out Interop.Sys.FileStatus fileStatus) != 0)
+                    if (id.IsUserScope)
                     {
-                        error = Interop.Sys.GetLastErrorInfo();
-                        fd.Dispose();
-                        throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
-                    }
+                        if (Interop.Sys.FStat(fd, out Interop.Sys.FileStatus fileStatus) != 0)
+                        {
+                            error = Interop.Sys.GetLastErrorInfo();
+                            fd.Dispose();
+                            throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
+                        }
 
-                    if (fileStatus.Uid != id.Uid)
-                    {
-                        fd.Dispose();
-                        throw new IOException(SR.Format(SR.IO_SharedMemory_FileNotOwnedByUid, sharedMemoryFilePath, id.Uid));
-                    }
+                        if (fileStatus.Uid != id.Uid)
+                        {
+                            fd.Dispose();
+                            throw new IOException(SR.Format(SR.IO_SharedMemory_FileNotOwnedByUid, sharedMemoryFilePath, id.Uid));
+                        }
 
-                    if ((fileStatus.Mode & (int)PermissionsMask_AllUsers_ReadWriteExecute) != (int)PermissionsMask_OwnerUser_ReadWrite)
-                    {
-                        fd.Dispose();
-                        throw new IOException(SR.Format(SR.IO_SharedMemory_FilePermissionsIncorrect, sharedMemoryFilePath, PermissionsMask_OwnerUser_ReadWrite));
+                        if ((fileStatus.Mode & (int)PermissionsMask_AllUsers_ReadWriteExecute) != (int)PermissionsMask_OwnerUser_ReadWrite)
+                        {
+                            fd.Dispose();
+                            throw new IOException(SR.Format(SR.IO_SharedMemory_FilePermissionsIncorrect, sharedMemoryFilePath, PermissionsMask_OwnerUser_ReadWrite));
+                        }
                     }
+                    createdFile = false;
+                    return fd;
                 }
-                createdFile = false;
-                return fd;
-            }
 
-            if (error.Error != Interop.Error.ENOENT)
-            {
-                throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
-            }
+                if (error.Error != Interop.Error.ENOENT)
+                {
+                    throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
+                }
 
-            if (!createIfNotExist)
-            {
-                createdFile = false;
-                return fd;
-            }
+                if (!createIfNotExist)
+                {
+                    createdFile = false;
+                    return fd;
+                }
 
-            fd.Dispose();
-
-            UnixFileMode permissionsMask = id.IsUserScope
-                ? PermissionsMask_OwnerUser_ReadWrite
-                : PermissionsMask_AllUsers_ReadWrite;
-
-            fd = Interop.Sys.Open(
-                sharedMemoryFilePath,
-                Interop.Sys.OpenFlags.O_RDWR | Interop.Sys.OpenFlags.O_CLOEXEC | Interop.Sys.OpenFlags.O_CREAT | Interop.Sys.OpenFlags.O_EXCL,
-                (int)permissionsMask);
-
-            if (fd.IsInvalid)
-            {
-                error = Interop.Sys.GetLastErrorInfo();
-                throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
-            }
-
-            int result = Interop.Sys.FChMod(fd, (int)permissionsMask);
-
-            if (result != 0)
-            {
-                error = Interop.Sys.GetLastErrorInfo();
                 fd.Dispose();
-                Interop.Sys.Unlink(sharedMemoryFilePath);
-                throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
-            }
 
-            createdFile = true;
-            return fd;
+                UnixFileMode permissionsMask = id.IsUserScope
+                    ? PermissionsMask_OwnerUser_ReadWrite
+                    : PermissionsMask_AllUsers_ReadWrite;
+
+                fd = Interop.Sys.Open(
+                    sharedMemoryFilePath,
+                    Interop.Sys.OpenFlags.O_RDWR | Interop.Sys.OpenFlags.O_CLOEXEC | Interop.Sys.OpenFlags.O_CREAT | Interop.Sys.OpenFlags.O_EXCL,
+                    (int)permissionsMask);
+
+                if (fd.IsInvalid)
+                {
+                    error = Interop.Sys.GetLastErrorInfo();
+
+                    // Another process created the file between our open and create attempts.
+                    // Retry from the top to open the now-existing file.
+                    if (error.Error == Interop.Error.EEXIST && retries < 1)
+                    {
+                        continue;
+                    }
+
+                    throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
+                }
+
+                int result = Interop.Sys.FChMod(fd, (int)permissionsMask);
+
+                if (result != 0)
+                {
+                    error = Interop.Sys.GetLastErrorInfo();
+                    fd.Dispose();
+                    Interop.Sys.Unlink(sharedMemoryFilePath);
+                    throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
+                }
+
+                createdFile = true;
+                return fd;
+            }
         }
 
         internal static bool EnsureDirectoryExists(string directoryPath, SharedMemoryId id, bool isGlobalLockAcquired, bool createIfNotExist = true, bool isSystemDirectory = false)

--- a/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
@@ -430,7 +430,7 @@ namespace System.IO
                 // created the file first (EEXIST), fall back to a plain open. If that open gets
                 // ENOENT (file was deleted in between), retry.
                 const int MaxRetries = 4;
-                for (int retries = 0; ; retries++)
+                for (int retries = 0; retries < MaxRetries; retries++)
                 {
                     SafeFileHandle fd = Interop.Sys.Open(
                         sharedMemoryFilePath,
@@ -474,7 +474,7 @@ namespace System.IO
                             createdFile = false;
                             return fd;
                         }
-                        catch (UnauthorizedAccessException) when (retries < MaxRetries)
+                        catch (UnauthorizedAccessException) when (retries < MaxRetries - 1)
                         {
                             Thread.Sleep(1);
                             continue;
@@ -485,7 +485,7 @@ namespace System.IO
                     fd.Dispose();
 
                     // The file was deleted after the create attempt. Retry.
-                    if (error.Error != Interop.Error.ENOENT || retries >= MaxRetries)
+                    if (error.Error != Interop.Error.ENOENT || retries >= MaxRetries - 1)
                     {
                         throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
                     }

--- a/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
@@ -418,88 +418,115 @@ namespace System.IO
 
         internal static SafeFileHandle CreateOrOpenFile(string sharedMemoryFilePath, SharedMemoryId id, bool createIfNotExist, out bool createdFile)
         {
-            // Retry loop to handle the TOCTOU race between the initial open attempt (which may return ENOENT)
-            // and the exclusive create attempt (which may return EEXIST if another process created the file
-            // in between). On EEXIST, we loop back and re-attempt the open.
-            for (int retries = 0; ; retries++)
+            const Interop.Sys.OpenFlags MandatoryFlags = Interop.Sys.OpenFlags.O_RDWR | Interop.Sys.OpenFlags.O_CLOEXEC;
+
+            UnixFileMode permissionsMask = id.IsUserScope
+                ? PermissionsMask_OwnerUser_ReadWrite
+                : PermissionsMask_AllUsers_ReadWrite;
+
+            if (createIfNotExist)
             {
-                SafeFileHandle fd = Interop.Sys.Open(sharedMemoryFilePath, Interop.Sys.OpenFlags.O_RDWR | Interop.Sys.OpenFlags.O_CLOEXEC, 0);
-                Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
-                if (!fd.IsInvalid)
+                // Lead with O_CREAT | O_EXCL for an atomic create guarantee. If another process
+                // created the file first (EEXIST), fall back to a plain open. If that open gets
+                // ENOENT (file was deleted in between), retry.
+                const int MaxRetries = 4;
+                for (int retries = 0; ; retries++)
                 {
-                    if (id.IsUserScope)
+                    SafeFileHandle fd = Interop.Sys.Open(
+                        sharedMemoryFilePath,
+                        MandatoryFlags | Interop.Sys.OpenFlags.O_CREAT | Interop.Sys.OpenFlags.O_EXCL,
+                        (int)permissionsMask);
+
+                    if (!fd.IsInvalid)
                     {
-                        if (Interop.Sys.FStat(fd, out Interop.Sys.FileStatus fileStatus) != 0)
+                        // Successfully created. Set permissions since umask may have filtered them.
+                        int result = Interop.Sys.FChMod(fd, (int)permissionsMask);
+                        if (result != 0)
                         {
-                            error = Interop.Sys.GetLastErrorInfo();
+                            Interop.ErrorInfo fchmodError = Interop.Sys.GetLastErrorInfo();
                             fd.Dispose();
-                            throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
+                            Interop.Sys.Unlink(sharedMemoryFilePath);
+                            throw Interop.GetExceptionForIoErrno(fchmodError, sharedMemoryFilePath);
                         }
 
-                        if (fileStatus.Uid != id.Uid)
-                        {
-                            fd.Dispose();
-                            throw new IOException(SR.Format(SR.IO_SharedMemory_FileNotOwnedByUid, sharedMemoryFilePath, id.Uid));
-                        }
-
-                        if ((fileStatus.Mode & (int)PermissionsMask_AllUsers_ReadWriteExecute) != (int)PermissionsMask_OwnerUser_ReadWrite)
-                        {
-                            fd.Dispose();
-                            throw new IOException(SR.Format(SR.IO_SharedMemory_FilePermissionsIncorrect, sharedMemoryFilePath, PermissionsMask_OwnerUser_ReadWrite));
-                        }
-                    }
-                    createdFile = false;
-                    return fd;
-                }
-
-                if (error.Error != Interop.Error.ENOENT)
-                {
-                    throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
-                }
-
-                if (!createIfNotExist)
-                {
-                    createdFile = false;
-                    return fd;
-                }
-
-                fd.Dispose();
-
-                UnixFileMode permissionsMask = id.IsUserScope
-                    ? PermissionsMask_OwnerUser_ReadWrite
-                    : PermissionsMask_AllUsers_ReadWrite;
-
-                fd = Interop.Sys.Open(
-                    sharedMemoryFilePath,
-                    Interop.Sys.OpenFlags.O_RDWR | Interop.Sys.OpenFlags.O_CLOEXEC | Interop.Sys.OpenFlags.O_CREAT | Interop.Sys.OpenFlags.O_EXCL,
-                    (int)permissionsMask);
-
-                if (fd.IsInvalid)
-                {
-                    error = Interop.Sys.GetLastErrorInfo();
-
-                    // Another process created the file between our open and create attempts.
-                    // Retry from the top to open the now-existing file.
-                    if (error.Error == Interop.Error.EEXIST && retries < 1)
-                    {
-                        continue;
+                        createdFile = true;
+                        return fd;
                     }
 
-                    throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
-                }
+                    Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
+                    fd.Dispose();
 
-                int result = Interop.Sys.FChMod(fd, (int)permissionsMask);
+                    if (error.Error != Interop.Error.EEXIST)
+                    {
+                        throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
+                    }
 
-                if (result != 0)
-                {
+                    // Another process created the file. Try to open it.
+                    fd = Interop.Sys.Open(sharedMemoryFilePath, MandatoryFlags, 0);
+                    if (!fd.IsInvalid)
+                    {
+                        createdFile = false;
+                        ValidateExistingFile(fd, sharedMemoryFilePath, id);
+                        return fd;
+                    }
+
                     error = Interop.Sys.GetLastErrorInfo();
                     fd.Dispose();
-                    Interop.Sys.Unlink(sharedMemoryFilePath);
-                    throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
+
+                    // The file was deleted after the create attempt. Retry.
+                    if (error.Error != Interop.Error.ENOENT || retries >= MaxRetries)
+                    {
+                        throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
+                    }
+                }
+            }
+
+            // Attempt to open an existing file.
+            {
+                SafeFileHandle fd = Interop.Sys.Open(sharedMemoryFilePath, MandatoryFlags, 0);
+                if (fd.IsInvalid)
+                {
+                    Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
+                    if (error.Error != Interop.Error.ENOENT)
+                    {
+                        fd.Dispose();
+                        throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
+                    }
+
+                    createdFile = false;
+                    return fd;
                 }
 
-                createdFile = true;
+                createdFile = false;
+                ValidateExistingFile(fd, sharedMemoryFilePath, id);
                 return fd;
+            }
+        }
+
+        private static void ValidateExistingFile(SafeFileHandle fd, string sharedMemoryFilePath, SharedMemoryId id)
+        {
+            if (!id.IsUserScope)
+            {
+                return;
+            }
+
+            if (Interop.Sys.FStat(fd, out Interop.Sys.FileStatus fileStatus) != 0)
+            {
+                Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
+                fd.Dispose();
+                throw Interop.GetExceptionForIoErrno(error, sharedMemoryFilePath);
+            }
+
+            if (fileStatus.Uid != id.Uid)
+            {
+                fd.Dispose();
+                throw new IOException(SR.Format(SR.IO_SharedMemory_FileNotOwnedByUid, sharedMemoryFilePath, id.Uid));
+            }
+
+            if ((fileStatus.Mode & (int)PermissionsMask_AllUsers_ReadWriteExecute) != (int)PermissionsMask_OwnerUser_ReadWrite)
+            {
+                fd.Dispose();
+                throw new IOException(SR.Format(SR.IO_SharedMemory_FilePermissionsIncorrect, sharedMemoryFilePath, PermissionsMask_OwnerUser_ReadWrite));
             }
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/SharedMemoryManager.Unix.cs
@@ -463,8 +463,8 @@ namespace System.IO
 
                     // Another process created the file. Try to open it.
                     // The creator may not have called FChMod yet, so if validation
-                    // fails on permissions, retry — the next attempt should see the
-                    // correct permissions.
+                    // fails on permissions (UnauthorizedAccessException), retry.
+                    // UID mismatches (IOException) are permanent and propagate immediately.
                     fd = Interop.Sys.Open(sharedMemoryFilePath, MandatoryFlags, 0);
                     if (!fd.IsInvalid)
                     {
@@ -474,7 +474,7 @@ namespace System.IO
                             createdFile = false;
                             return fd;
                         }
-                        catch (IOException) when (retries < MaxRetries)
+                        catch (UnauthorizedAccessException) when (retries < MaxRetries)
                         {
                             Thread.Sleep(1);
                             continue;
@@ -537,7 +537,7 @@ namespace System.IO
             if ((fileStatus.Mode & (int)PermissionsMask_AllUsers_ReadWriteExecute) != (int)PermissionsMask_OwnerUser_ReadWrite)
             {
                 fd.Dispose();
-                throw new IOException(SR.Format(SR.IO_SharedMemory_FilePermissionsIncorrect, sharedMemoryFilePath, PermissionsMask_OwnerUser_ReadWrite));
+                throw new UnauthorizedAccessException(SR.Format(SR.IO_SharedMemory_FilePermissionsIncorrect, sharedMemoryFilePath, PermissionsMask_OwnerUser_ReadWrite));
             }
         }
 

--- a/src/libraries/System.Threading/tests/MutexTests.cs
+++ b/src/libraries/System.Threading/tests/MutexTests.cs
@@ -953,6 +953,49 @@ namespace System.Threading.Tests
             }
         }
 
+        [ConditionalFact(typeof(MutexTests), nameof(IsRemoteExecutorAndCrossProcessNamedMutexSupported))]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        public void NamedMutex_ConcurrentCreation_NoIOException()
+        {
+            // Exercises the TOCTOU race window in SharedMemoryHelpers.CreateOrOpenFile where
+            // one process sees ENOENT then another creates the file, causing the first to get
+            // EEXIST on the exclusive create. Multiple processes creating the same named mutex
+            // concurrently should succeed without IOException.
+            ThreadTestHelpers.RunTestInBackgroundThread(() =>
+            {
+                const int ProcessCount = 5;
+                const int Iterations = 10;
+
+                for (int iter = 0; iter < Iterations; iter++)
+                {
+                    string mutexName = Guid.NewGuid().ToString("N");
+
+                    var remotes = new IDisposable[ProcessCount];
+                    try
+                    {
+                        for (int i = 0; i < ProcessCount; i++)
+                        {
+                            remotes[i] = RemoteExecutor.Invoke(
+                                static (name) =>
+                                {
+                                    using var mutex = new Mutex(
+                                        name,
+                                        new NamedWaitHandleOptions { CurrentSessionOnly = true });
+                                },
+                                mutexName);
+                        }
+                    }
+                    finally
+                    {
+                        foreach (var remote in remotes)
+                        {
+                            remote?.Dispose();
+                        }
+                    }
+                }
+            });
+        }
+
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsNotMobile))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         public void NamedMutex_OtherEvent_NotCompatible()


### PR DESCRIPTION
## Summary

Fix a TOCTOU (time-of-check-to-time-of-use) race condition in `SharedMemoryHelpers.CreateOrOpenFile` that causes intermittent `IOException` when two processes concurrently create a named mutex backed by shared memory on Linux.

## The Bug

`CreateOrOpenFile` uses a two-step approach:
1. Try `Open(O_RDWR)` to open an existing file
2. If ENOENT, try `Open(O_CREAT|O_EXCL)` to create exclusively

The race:
1. Process A: `Open(O_RDWR)` → ENOENT (file does not exist)
2. Process B: creates the file successfully
3. Process A: `Open(O_CREAT|O_EXCL)` → EEXIST (file now exists)
4. Process A: **throws IOException** instead of handling EEXIST

This manifests as:
```
System.IO.IOException: The file '/tmp/.dotnet/shm/session1/NuGet-Migrations' already exists.
   at System.IO.SharedMemoryHelpers.CreateOrOpenFile(...)
   at System.Threading.Mutex..ctor(Boolean initiallyOwned, String name)
   at NuGet.Common.Migrations.MigrationRunner.Run(...)
```

## The Fix

When the exclusive create fails with EEXIST, retry from the top (loop back to the `Open(O_RDWR)` which will now succeed since the file exists). Limited to four retries to prevent infinite loops.

## Impact

This is a known flaky failure in CI (labeled `Known Build Error`) that has been open since September 2023. It affects any scenario where parallel `dotnet` processes run first-time setup, including:
- VMR scenario tests (`ValidateInstallers` on Linux arm64)
- Docker container first-run
- CI environments with shared `/tmp`

Fixes #91987
Related: #80619, #76736