### PR TITLE
Fix most of the diagnostic EH tests with interpreter

### DIFF
--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -6090,7 +6090,7 @@ HRESULT DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pCon
 #ifdef FEATURE_INTERPRETER
                     if (frame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
                     {
-                        PTR_InterpreterFrame pInterpreterFrame = dac_cast<PTR_InterpreterFrame>(pThread->GetFrame());
+                        PTR_InterpreterFrame pInterpreterFrame = dac_cast<PTR_InterpreterFrame>(frame);
                         pInterpreterFrame->SetContextToInterpMethodContextFrame(&tmpContext);
                         CopyMemory(pContextBuffer, &tmpContext, sizeof(*pContextBuffer));
                         return S_OK;

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -6087,6 +6087,7 @@ HRESULT DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pCon
 
                 while (frame != NULL && frame != FRAME_TOP)
                 {
+#ifdef FEATURE_INTERPRETER
                     if (frame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
                     {
                         PTR_InterpreterFrame pInterpreterFrame = dac_cast<PTR_InterpreterFrame>(pThread->GetFrame());
@@ -6094,7 +6095,7 @@ HRESULT DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pCon
                         CopyMemory(pContextBuffer, &tmpContext, sizeof(*pContextBuffer));
                         return S_OK;
                     }
-
+#endif // FEATURE_INTERPRETER
                     frame->UpdateRegDisplay(&tmpRd);
                     if (GetRegdisplaySP(&tmpRd) != 0 && GetControlPC(&tmpRd) != 0)
                     {

--- a/src/coreclr/debug/daccess/dacdbiimpl.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimpl.cpp
@@ -6084,8 +6084,17 @@ HRESULT DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pCon
                 // that has context available for stackwalking (SP and PC)
                 // For example: RedirectedThreadFrame, InlinedCallFrame, DynamicHelperFrame, CLRToCOMMethodFrame
                 Frame *frame = pThread->GetFrame();
+
                 while (frame != NULL && frame != FRAME_TOP)
                 {
+                    if (frame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
+                    {
+                        PTR_InterpreterFrame pInterpreterFrame = dac_cast<PTR_InterpreterFrame>(pThread->GetFrame());
+                        pInterpreterFrame->SetContextToInterpMethodContextFrame(&tmpContext);
+                        CopyMemory(pContextBuffer, &tmpContext, sizeof(*pContextBuffer));
+                        return S_OK;
+                    }
+
                     frame->UpdateRegDisplay(&tmpRd);
                     if (GetRegdisplaySP(&tmpRd) != 0 && GetControlPC(&tmpRd) != 0)
                     {
@@ -6097,7 +6106,7 @@ HRESULT DacDbiInterfaceImpl::GetContext(VMPTR_Thread vmThread, DT_CONTEXT * pCon
                                                                           // DT_CONTEXT_CONTROL already includes the frame register for X86 and ARM64 architectures
     #endif
                         ;
-                        return hr;
+                        return S_OK;
                     }
                     frame = frame->Next();
                 }

--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -301,7 +301,8 @@ HRESULT DacDbiInterfaceImpl::UnwindStackWalkFrame(StackWalkHandle pSFIHandle, OU
                     MethodDesc *pMD = pIter->m_crawl.GetFunction();
 
                     // EH.DispatchEx, EH.RhThrowEx, EH.RhThrowHwEx, ExceptionServices.InternalCalls.SfiInit, ExceptionServices.InternalCalls.SfiNext
-                    if (pMD->GetMethodTable() == g_pEHClass || pMD->GetMethodTable() == g_pExceptionServicesInternalCallsClass)
+                    // and System.Runtime.StackFrameIterator.*
+                    if (pMD->GetMethodTable() == g_pEHClass || pMD->GetMethodTable() == g_pExceptionServicesInternalCallsClass || pMD->GetMethodTable() == g_pStackFrameIteratorClass)
                     {
                         continue;
                     }
@@ -517,6 +518,14 @@ HRESULT DacDbiInterfaceImpl::GetCountOfInternalFrames(VMPTR_Thread vmThread, OUT
                     continue;
                 }
             }
+
+            if (pFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
+            {
+                // Skip InterpreterFrame
+                pFrame = pFrame->Next();
+                continue;
+            }
+
             CorDebugInternalFrameType ift = GetInternalFrameType(pFrame);
             if (ift != STUBFRAME_NONE)
             {
@@ -573,6 +582,14 @@ HRESULT DacDbiInterfaceImpl::EnumerateInternalFrames(VMPTR_Thread vmThread, FP_I
                     continue;
                 }
             }
+
+            if (pFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
+            {
+                // Skip InterpreterFrame
+                pFrame = pFrame->Next();
+                continue;
+            }
+
             // check if the internal frame is interesting
             frameData.stubFrame.frameType = GetInternalFrameType(pFrame);
             if (frameData.stubFrame.frameType != STUBFRAME_NONE)

--- a/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/coreclr/debug/daccess/dacdbiimplstackwalk.cpp
@@ -519,12 +519,14 @@ HRESULT DacDbiInterfaceImpl::GetCountOfInternalFrames(VMPTR_Thread vmThread, OUT
                 }
             }
 
+#ifdef FEATURE_INTERPRETER
             if (pFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
             {
                 // Skip InterpreterFrame
                 pFrame = pFrame->Next();
                 continue;
             }
+#endif // FEATURE_INTERPRETER
 
             CorDebugInternalFrameType ift = GetInternalFrameType(pFrame);
             if (ift != STUBFRAME_NONE)
@@ -583,12 +585,14 @@ HRESULT DacDbiInterfaceImpl::EnumerateInternalFrames(VMPTR_Thread vmThread, FP_I
                 }
             }
 
+#ifdef FEATURE_INTERPRETER
             if (pFrame->GetFrameIdentifier() == FrameIdentifier::InterpreterFrame)
             {
                 // Skip InterpreterFrame
                 pFrame = pFrame->Next();
                 continue;
             }
+#endif // FEATURE_INTERPRETER
 
             // check if the internal frame is interesting
             frameData.stubFrame.frameType = GetInternalFrameType(pFrame);

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -319,10 +319,12 @@ InterpInst* InterpCompiler::NewIns(int opcode, int dataLen)
     InterpInst *ins = (InterpInst*)getAllocator(IMK_Instruction).allocateZeroed<char>(insSize);
     ins->opcode = opcode;
     ins->ilOffset = m_currentILOffset;
-    if ((m_pLastNewIns == nullptr) || (m_pLastNewIns->ilOffset != m_currentILOffset))
+    ptrdiff_t stackDepth = m_pStackPointer - m_pStackBase;
+    if ((stackDepth == 0) && ((m_pLastNewIns == nullptr) || (m_pLastNewIns->ilOffset != m_currentILOffset)))
     {
-        // This is the first instruction we have emitted for this IL offset, so set the flag.
-        ins->flags |= INTERP_INST_FLAG_FIRST_FOR_IL_OP;
+        // This is the first instruction we are emitting for this IL offset and the stack is empty, which
+        // implies the IL stack is empty too.
+        ins->flags |= INTERP_INST_FLAG_EMPTY_IL_STACK;
     }
     m_pLastNewIns = ins;
     return ins;
@@ -1074,7 +1076,7 @@ int32_t* InterpCompiler::EmitCodeIns(int32_t *ip, InterpInst *ins, TArray<Reloc*
 
                 m_pILToNativeMap[m_ILToNativeMapSize].ilOffset = ilOffset;
                 m_pILToNativeMap[m_ILToNativeMapSize].nativeOffset = nativeOffset;
-                m_pILToNativeMap[m_ILToNativeMapSize].source = (ins->flags & INTERP_INST_FLAG_FIRST_FOR_IL_OP) ? ICorDebugInfo::STACK_EMPTY : ICorDebugInfo::SOURCE_TYPE_INVALID;
+                m_pILToNativeMap[m_ILToNativeMapSize].source = (ins->flags & INTERP_INST_FLAG_EMPTY_IL_STACK) ? ICorDebugInfo::STACK_EMPTY : ICorDebugInfo::SOURCE_TYPE_INVALID;
                 m_ILToNativeMapSize++;
             }
         }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -319,6 +319,7 @@ InterpInst* InterpCompiler::NewIns(int opcode, int dataLen)
     InterpInst *ins = (InterpInst*)getAllocator(IMK_Instruction).allocateZeroed<char>(insSize);
     ins->opcode = opcode;
     ins->ilOffset = m_currentILOffset;
+    ins->stackDepth = m_pStackPointer - m_pStackBase;
     m_pLastNewIns = ins;
     return ins;
 }
@@ -1069,7 +1070,7 @@ int32_t* InterpCompiler::EmitCodeIns(int32_t *ip, InterpInst *ins, TArray<Reloc*
 
                 m_pILToNativeMap[m_ILToNativeMapSize].ilOffset = ilOffset;
                 m_pILToNativeMap[m_ILToNativeMapSize].nativeOffset = nativeOffset;
-                m_pILToNativeMap[m_ILToNativeMapSize].source = ICorDebugInfo::SOURCE_TYPE_INVALID;
+                m_pILToNativeMap[m_ILToNativeMapSize].source = ins->stackDepth == 0 ? ICorDebugInfo::STACK_EMPTY : ICorDebugInfo::SOURCE_TYPE_INVALID;
                 m_ILToNativeMapSize++;
             }
         }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -319,7 +319,11 @@ InterpInst* InterpCompiler::NewIns(int opcode, int dataLen)
     InterpInst *ins = (InterpInst*)getAllocator(IMK_Instruction).allocateZeroed<char>(insSize);
     ins->opcode = opcode;
     ins->ilOffset = m_currentILOffset;
-    ins->stackDepth = m_pStackPointer - m_pStackBase;
+    if ((m_pLastNewIns != nullptr) && (m_pLastNewIns->ilOffset != m_currentILOffset))
+    {
+        // This is the first instruction we have emitted for this IL offset, so set the flag.
+        ins->flags |= INTERP_INST_FLAG_FIRST_FOR_IL_OP;
+    }
     m_pLastNewIns = ins;
     return ins;
 }
@@ -1070,7 +1074,7 @@ int32_t* InterpCompiler::EmitCodeIns(int32_t *ip, InterpInst *ins, TArray<Reloc*
 
                 m_pILToNativeMap[m_ILToNativeMapSize].ilOffset = ilOffset;
                 m_pILToNativeMap[m_ILToNativeMapSize].nativeOffset = nativeOffset;
-                m_pILToNativeMap[m_ILToNativeMapSize].source = ins->stackDepth == 0 ? ICorDebugInfo::STACK_EMPTY : ICorDebugInfo::SOURCE_TYPE_INVALID;
+                m_pILToNativeMap[m_ILToNativeMapSize].source = (ins->flags & INTERP_INST_FLAG_FIRST_FOR_IL_OP) ? ICorDebugInfo::STACK_EMPTY : ICorDebugInfo::SOURCE_TYPE_INVALID;
                 m_ILToNativeMapSize++;
             }
         }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -319,7 +319,7 @@ InterpInst* InterpCompiler::NewIns(int opcode, int dataLen)
     InterpInst *ins = (InterpInst*)getAllocator(IMK_Instruction).allocateZeroed<char>(insSize);
     ins->opcode = opcode;
     ins->ilOffset = m_currentILOffset;
-    if ((m_pLastNewIns != nullptr) && (m_pLastNewIns->ilOffset != m_currentILOffset))
+    if ((m_pLastNewIns == nullptr) || (m_pLastNewIns->ilOffset != m_currentILOffset))
     {
         // This is the first instruction we have emitted for this IL offset, so set the flag.
         ins->flags |= INTERP_INST_FLAG_FIRST_FOR_IL_OP;

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -319,12 +319,12 @@ InterpInst* InterpCompiler::NewIns(int opcode, int dataLen)
     InterpInst *ins = (InterpInst*)getAllocator(IMK_Instruction).allocateZeroed<char>(insSize);
     ins->opcode = opcode;
     ins->ilOffset = m_currentILOffset;
-    ptrdiff_t stackDepth = m_pStackPointer - m_pStackBase;
-    if ((stackDepth == 0) && ((m_pLastNewIns == nullptr) || (m_pLastNewIns->ilOffset != m_currentILOffset)))
+    if (m_isFirstInstForEmptyILStack)
     {
         // This is the first instruction we are emitting for this IL offset and the stack is empty, which
         // implies the IL stack is empty too.
         ins->flags |= INTERP_INST_FLAG_EMPTY_IL_STACK;
+        m_isFirstInstForEmptyILStack = false;
     }
     m_pLastNewIns = ins;
     return ins;
@@ -8385,6 +8385,10 @@ retry_emit:
 
         if (ILOpcodePeeps.FindAndApplyPeep(this))
             continue;
+
+
+        // Empty stack at the beginning of the IL instruction implies IL stack being empty too
+        m_isFirstInstForEmptyILStack = (m_pStackPointer - m_pStackBase) == 0;
 
         uint8_t opcode = *m_ip;
         switch (opcode)

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -672,6 +672,9 @@ private:
     int32_t m_currentILOffset;
     InterpInst* m_pInitLocalsIns;
 
+    // Indicates that we are going to generate the first interpreter byte code instruction for an IL opcode with an empty stack.
+    bool        m_isFirstInstForEmptyILStack = true;
+
     // If the method has a hidden argument, GenerateCode allocates a var to store it and
     //  populates the var at method entry
     int32_t m_hiddenArgumentVar;

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -233,7 +233,9 @@ enum InterpInstFlags
 {
     INTERP_INST_FLAG_CALL               = 0x01,
     // Flag used internally by the var offset allocator
-    INTERP_INST_FLAG_ACTIVE_CALL        = 0x02
+    INTERP_INST_FLAG_ACTIVE_CALL        = 0x02,
+    // First interpreter instruction for an IL opcode
+    INTERP_INST_FLAG_FIRST_FOR_IL_OP    = 0x04
 };
 
 struct InterpInst
@@ -252,7 +254,6 @@ struct InterpInst
     uint32_t flags;
     int32_t dVar;
     int32_t sVars[3]; // Currently all instructions have at most 3 sregs
-    int32_t stackDepth;
 
     int32_t data[];
 
@@ -820,7 +821,7 @@ public:
 private:
     // Instructions
     InterpBasicBlock *m_pCBB, *m_pEntryBB;
-    InterpInst* m_pLastNewIns;
+    InterpInst* m_pLastNewIns = nullptr;
 
     int32_t     GetInsLength(InterpInst *pIns);
     bool        InsIsNop(InterpInst *pIns);

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -252,6 +252,7 @@ struct InterpInst
     uint32_t flags;
     int32_t dVar;
     int32_t sVars[3]; // Currently all instructions have at most 3 sregs
+    int32_t stackDepth;
 
     int32_t data[];
 

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -234,8 +234,8 @@ enum InterpInstFlags
     INTERP_INST_FLAG_CALL               = 0x01,
     // Flag used internally by the var offset allocator
     INTERP_INST_FLAG_ACTIVE_CALL        = 0x02,
-    // First interpreter instruction for an IL opcode
-    INTERP_INST_FLAG_FIRST_FOR_IL_OP    = 0x04
+    // The IL stack is empty at this instruction
+    INTERP_INST_FLAG_EMPTY_IL_STACK    = 0x04
 };
 
 struct InterpInst

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3188,7 +3188,7 @@ void CallCatchFunclet(OBJECTREF throwable, BYTE* pHandlerIP, REGDISPLAY* pvRegDi
         pThread->GetExceptionState()->GetDebuggerState()->GetDebuggerInterceptInfo(&pInterceptMD, NULL, (PBYTE*)&(sfInterceptStackFrame.SP), &ulRelOffset, NULL);
         if (sfInterceptStackFrame.SP == GetSP(pvRegDisplay->pCurrentContext))
         {
-            PCODE pStartAddress = pInterceptMD->GetNativeCode();
+            PCODE pStartAddress = pInterceptMD->GetCodeForInterpreterOrJitted();
 
             EECodeInfo codeInfo(pStartAddress);
             _ASSERTE(codeInfo.IsValid());
@@ -3226,7 +3226,8 @@ void CallCatchFunclet(OBJECTREF throwable, BYTE* pHandlerIP, REGDISPLAY* pvRegDi
     {
         if (fIntercepted)
         {
-            ClrRestoreNonvolatileContext(pvRegDisplay->pCurrentContext, targetSSP);
+            EECodeInfo codeInfo(GetIP(pvRegDisplay->pCurrentContext));
+            codeInfo.GetCodeManager()->ResumeAfterCatch(pvRegDisplay->pCurrentContext, targetSSP, /* fIntercepted */ true);
         }
 #ifdef HOST_UNIX
         if (propagateExceptionCallback)
@@ -3338,7 +3339,7 @@ void ResumeAtInterceptionLocation(REGDISPLAY* pvRegDisplay)
     SetIP(pvRegDisplay->pCurrentContext, uResumePC);
 
     STRESS_LOG2(LF_EH, LL_INFO100, "Resuming at interception location at IP=%p, SP=%p\n", uResumePC, GetSP(pvRegDisplay->pCurrentContext));
-    ClrRestoreNonvolatileContext(pvRegDisplay->pCurrentContext, targetSSP);
+    codeInfo.GetCodeManager()->ResumeAfterCatch(pvRegDisplay->pCurrentContext, targetSSP, /* fIntercepted */ true);
 }
 
 void CallFinallyFunclet(BYTE* pHandlerIP, REGDISPLAY* pvRegDisplay, ExInfo* exInfo)

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3227,6 +3227,7 @@ void CallCatchFunclet(OBJECTREF throwable, BYTE* pHandlerIP, REGDISPLAY* pvRegDi
         if (fIntercepted)
         {
             EECodeInfo codeInfo(GetIP(pvRegDisplay->pCurrentContext));
+            _ASSERTE(codeInfo.IsValid());
             codeInfo.GetCodeManager()->ResumeAfterCatch(pvRegDisplay->pCurrentContext, targetSSP, /* fIntercepted */ true);
         }
 #ifdef HOST_UNIX

--- a/src/coreclr/vm/exceptionhandling.cpp
+++ b/src/coreclr/vm/exceptionhandling.cpp
@@ -3327,7 +3327,7 @@ void ResumeAtInterceptionLocation(REGDISPLAY* pvRegDisplay)
 
     ExInfo::PopExInfos(pThread, (void*)targetSp);
 
-    PCODE pStartAddress = pInterceptMD->GetNativeCode();
+    PCODE pStartAddress = pInterceptMD->GetCodeForInterpreterOrJitted();
 
     EECodeInfo codeInfo(pStartAddress);
     _ASSERTE(codeInfo.IsValid());

--- a/src/coreclr/vm/frames.h
+++ b/src/coreclr/vm/frames.h
@@ -2560,6 +2560,12 @@ public:
         m_isFaulting = isFaulting;
     }
 
+    Interception GetInterception_Impl()
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        return m_isFaulting ? INTERCEPTION_EXCEPTION : INTERCEPTION_NONE;
+    }
+
     void GcScanRoots_Impl(promote_func *fn, ScanContext* sc)
     {
         fn(dac_cast<PTR_PTR_Object>(dac_cast<TADDR>(&m_continuation)), sc, 0);


### PR DESCRIPTION
Before this change, all of the exception handling diagnostic tests were failing. There were couple of reasons:
* The debugger stack walk didn't work when it needed to extract the starting context from explicit frames and the InterpreterFrame was the first one. It got the context of the native caller of the interpreter instead of the interpreter context.
* Exception interception was not supported for the interpreted code in the runtime yet
* The IL to native offsets map generated by the interpreter compiler was always setting the source field to ICorDebugInfo::SOURCE_TYPE_INVALID. Exception interception looks for offset with ICorDebugInfo::STACK_EMPTY and thus it found none and has failed.
* The System.Runtime.StackFrameIterator methods were not ignored by the DacDbiInterfaceImpl::UnwindStackWalkFrame and so the tests verifying the stack trace were failing
* InterpreterFrame was not ignored when enumerating internal frames, generating extra unexpected stuff to the debugger stack trace.

This change fixes these issues and now only three of the total 21 diagnostic EH tests are failing.

It also fixes an issue introduced by recent refactoring of the debugging code error handling that was causing the tests to fail on Linux even without interpreter.