### PR TITLE
[Wasm RyuJIT] Generate element section and populate function pointer table

### DIFF
--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -195,10 +195,10 @@ namespace ILCompiler.ObjectWriter
             // This is a no-op for now under Wasm
         }
 
-        WasmInstructionGroup GetImagePointerBaseOffset(int offset)
+        WasmInstructionGroup GetImageFunctionPointerBaseOffset(int offset)
         {
             return new WasmInstructionGroup([
-                Global.Get(ImagePointerBaseGlobalIndex),
+                Global.Get(ImageFunctionPointerBaseGlobalIndex),
                 I32.Const(offset),
                 I32.Add,
             ]);
@@ -443,14 +443,14 @@ namespace ILCompiler.ObjectWriter
 
         const int StackPointerGlobalIndex = 0;
         const int ImageBaseGlobalIndex = 1;
-        const int ImagePointerBaseGlobalIndex = 2;
+        const int ImageFunctionPointerBaseGlobalIndex = 2;
 
         private WasmImport[] _defaultImports = new[]
         {
             null, // placeholder for memory, which is set up dynamically in WriteImports()
             new WasmImport("env", "__stack_pointer", import: new WasmGlobalImportType(WasmValueType.I32, WasmMutabilityType.Mut), index: StackPointerGlobalIndex),
             new WasmImport("env", "__image_base", import: new WasmGlobalImportType(WasmValueType.I32, WasmMutabilityType.Const), index: ImageBaseGlobalIndex),
-            new WasmImport("env", "__image_pointer_base", import: new WasmGlobalImportType(WasmValueType.I32, WasmMutabilityType.Const), index: ImagePointerBaseGlobalIndex),
+            new WasmImport("env", "__image_function_pointer_base", import: new WasmGlobalImportType(WasmValueType.I32, WasmMutabilityType.Const), index: ImageFunctionPointerBaseGlobalIndex),
         };
 
         private void WriteImports()
@@ -494,11 +494,16 @@ namespace ILCompiler.ObjectWriter
         {
             // Generate the function pointer table element that contains function pointers for all of our functions
             int[] functionIndices = new int[_uniqueSymbols.Count];
+            // NOTE: This relies on items in _uniqueSymbols being assigned sequentially and that iteration over Values is order-preserving.
+            // BCL Dictionary preserves insertion order so as long as we keep using it, we would get the function indices in the order they were added.
             _uniqueSymbols.Values.CopyTo(functionIndices, 0);
-            // Enforce that the function pointers are sequential so that (image_pointer_base + 0) == ftn index 0
-            Array.Sort(functionIndices);
-            Debug.Assert(functionIndices.FirstOrDefault() == 0);
-            WriteFunctionElement(GetImagePointerBaseOffset(0), functionIndices);
+            // Enforce that the function pointers are sequential so that (image_function_pointer_base + 0) == ftn index 0
+#if DEBUG
+            for (int i = 0; i < _uniqueSymbols.Count; i++) {
+                Debug.Assert(functionIndices[i] == i);
+            }
+#endif
+            WriteFunctionElement(GetImageFunctionPointerBaseOffset(0), functionIndices);
         }
 
         // For now, this function just prepares the function, exports, and type sections for emission by prepending the counts.

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -153,10 +153,10 @@ namespace ILCompiler.ObjectWriter
             writer.WriteULEB128(0);
 
             // FIXME: Add a way to encode directly into the writer without a scratch buffer
-            int bufSize = e0.EncodeSize();
-            byte[] buf = new byte[bufSize];
-            e0.Encode(buf);
-            writer.Write(buf);
+            int encodeSize = e0.EncodeSize();
+            int bytesWritten = e0.Encode(writer.Buffer.GetSpan(encodeSize));
+            Debug.Assert(bytesWritten == encodeSize);
+            writer.Buffer.Advance((int)bytesWritten);
 
             writer.WriteULEB128((ulong)functionIndices.Length);
 

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -148,8 +148,22 @@ namespace ILCompiler.ObjectWriter
         private void WriteFunctionElement(WasmInstructionGroup e0, ReadOnlySpan<int> functionIndices)
         {
             SectionWriter writer = GetOrCreateSection(WasmObjectNodeSection.ElementSection);
+            // e0:expr y*:list(funcidx)
+            //  elem (ref func) (ref.func y)* (active 0 e0)
+            writer.WriteULEB128(0);
+
+            // FIXME: Add a way to encode directly into the writer without a scratch buffer
+            int bufSize = e0.EncodeSize();
+            byte[] buf = new byte[bufSize];
+            e0.Encode(buf);
+            writer.Write(buf);
+
+            writer.WriteULEB128((ulong)functionIndices.Length);
+
+            foreach (int index in functionIndices)
+                writer.WriteULEB128((ulong)index);
+
             _numElements++;
-            throw new NotImplementedException();
         }
 
         private List<WasmSection> _sections = new();
@@ -179,6 +193,15 @@ namespace ILCompiler.ObjectWriter
         protected internal override void UpdateSectionAlignment(int sectionIndex, int alignment)
         {
             // This is a no-op for now under Wasm
+        }
+
+        WasmInstructionGroup GetImagePointerBaseOffset(int offset)
+        {
+            return new WasmInstructionGroup([
+                Global.Get(ImagePointerBaseGlobalIndex),
+                I32.Const(offset),
+                I32.Add,
+            ]);
         }
 
         private WasmDataSection CreateCombinedDataSection()
@@ -467,11 +490,23 @@ namespace ILCompiler.ObjectWriter
             }
         }
 
+        private void WriteElements()
+        {
+            // Generate the function pointer table element that contains function pointers for all of our functions
+            int[] functionIndices = new int[_uniqueSymbols.Count];
+            _uniqueSymbols.Values.CopyTo(functionIndices, 0);
+            // Enforce that the function pointers are sequential so that (image_pointer_base + 0) == ftn index 0
+            Array.Sort(functionIndices);
+            Debug.Assert(functionIndices.FirstOrDefault() == 0);
+            WriteFunctionElement(GetImagePointerBaseOffset(0), functionIndices);
+        }
+
         // For now, this function just prepares the function, exports, and type sections for emission by prepending the counts.
         private protected override void EmitSymbolTable(IDictionary<Utf8String, SymbolDefinition> definedSymbols, SortedSet<Utf8String> undefinedSymbols)
         {
             WriteImports();
             WriteExports();
+            WriteElements();
 
             int funcIdx = _sectionNameToIndex[WasmObjectNodeSection.FunctionSection.Name];
             PrependCount(_sections[funcIdx], _methodCount);

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -300,8 +300,8 @@ namespace ILCompiler.ObjectWriter
             writer.WriteByte(0x01); // number of tables
             writer.WriteByte(0x70); // element type: funcref
             writer.WriteByte(0x01); // table limits: flags (1 = has maximum)
-            writer.WriteULEB128((ulong)0);
-            writer.WriteULEB128((ulong)_methodCount); // table limits: initial size in number of entries
+            writer.WriteULEB128((ulong)_methodCount); // minimum
+            writer.WriteULEB128((ulong)_methodCount); // maximum
         }
 
         private void PrependCount(WasmSection section, int count)

--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/WasmObjectWriter.cs
@@ -28,6 +28,7 @@ namespace ILCompiler.ObjectWriter
         public static readonly ObjectNodeSection CombinedDataSection = new ObjectNodeSection("wasm.alldata", SectionType.Writeable, needsAlign: false);
         public static readonly ObjectNodeSection FunctionSection = new ObjectNodeSection("wasm.function", SectionType.ReadOnly, needsAlign: false);
         public static readonly ObjectNodeSection ExportSection = new ObjectNodeSection("wasm.export", SectionType.ReadOnly, needsAlign: false);
+        public static readonly ObjectNodeSection ElementSection = new ObjectNodeSection("wasm.element", SectionType.ReadOnly, needsAlign: false);
         public static readonly ObjectNodeSection MemorySection = new ObjectNodeSection("wasm.memory", SectionType.ReadOnly, needsAlign: false);
         public static readonly ObjectNodeSection TableSection = new ObjectNodeSection("wasm.table", SectionType.ReadOnly, needsAlign: false);
         public static readonly ObjectNodeSection ImportSection = new ObjectNodeSection("wasm.import", SectionType.ReadOnly, needsAlign: false);
@@ -143,6 +144,14 @@ namespace ILCompiler.ObjectWriter
         private void WriteGlobalExport(string name, int globalIndex) =>
             WriteExport(name, WasmExportKind.Global, globalIndex);
 
+        private int _numElements;
+        private void WriteFunctionElement(WasmInstructionGroup e0, ReadOnlySpan<int> functionIndices)
+        {
+            SectionWriter writer = GetOrCreateSection(WasmObjectNodeSection.ElementSection);
+            _numElements++;
+            throw new NotImplementedException();
+        }
+
         private List<WasmSection> _sections = new();
         private Dictionary<string, int> _sectionNameToIndex = new();
         private Dictionary<ObjectNodeSection, WasmSectionType> _sectionToType = new()
@@ -151,6 +160,7 @@ namespace ILCompiler.ObjectWriter
             { WasmObjectNodeSection.FunctionSection, WasmSectionType.Function },
             { WasmObjectNodeSection.TableSection, WasmSectionType.Table },
             { WasmObjectNodeSection.ExportSection, WasmSectionType.Export },
+            { WasmObjectNodeSection.ElementSection, WasmSectionType.Element },
             { WasmObjectNodeSection.ImportSection, WasmSectionType.Import },
             { ObjectNodeSection.WasmTypeSection, WasmSectionType.Type },
             { ObjectNodeSection.WasmCodeSection, WasmSectionType.Code }
@@ -173,10 +183,10 @@ namespace ILCompiler.ObjectWriter
 
         private WasmDataSection CreateCombinedDataSection()
         {
-            WasmInstructionGroup GetR2RStartOffset(int offset)
+            WasmInstructionGroup GetImageBaseOffset(int offset)
             {
                 return new WasmInstructionGroup([
-                    Global.Get(R2RStartGlobalIndex),
+                    Global.Get(ImageBaseGlobalIndex),
                     I32.Const(offset),
                     I32.Add,
                 ]);
@@ -189,7 +199,7 @@ namespace ILCompiler.ObjectWriter
             {
                 Debug.Assert(wasmSection.Type == WasmSectionType.Data);
                 WasmDataSegment segment = new WasmDataSegment(wasmSection.Stream, wasmSection.Name, WasmDataSectionType.Active,
-                    GetR2RStartOffset(offset));
+                    GetImageBaseOffset(offset));
                 segments.Add(segment);
                 offset += segment.ContentSize;
             }
@@ -289,6 +299,7 @@ namespace ILCompiler.ObjectWriter
             WasmObjectNodeSection.FunctionSection.Name,
             WasmObjectNodeSection.TableSection.Name,
             WasmObjectNodeSection.ExportSection.Name,
+            WasmObjectNodeSection.ElementSection.Name,
             ObjectNodeSection.WasmCodeSection.Name,
             WasmObjectNodeSection.CombinedDataSection.Name,
         ];
@@ -394,7 +405,7 @@ namespace ILCompiler.ObjectWriter
 
             Span<byte> ReadRelocToDataSpan(SymbolicRelocation reloc, byte[] buffer)
             {
-                Span<byte> relocContents = buffer.AsSpan(0, Relocation.GetSize(reloc.Type)); 
+                Span<byte> relocContents = buffer.AsSpan(0, Relocation.GetSize(reloc.Type));
                 sectionStream.Position = reloc.Offset;
                 sectionStream.ReadExactly(relocContents);
                 return relocContents;
@@ -408,13 +419,15 @@ namespace ILCompiler.ObjectWriter
         }
 
         const int StackPointerGlobalIndex = 0;
-        const int R2RStartGlobalIndex = 1;
+        const int ImageBaseGlobalIndex = 1;
+        const int ImagePointerBaseGlobalIndex = 2;
 
         private WasmImport[] _defaultImports = new[]
         {
             null, // placeholder for memory, which is set up dynamically in WriteImports()
             new WasmImport("env", "__stack_pointer", import: new WasmGlobalImportType(WasmValueType.I32, WasmMutabilityType.Mut), index: StackPointerGlobalIndex),
-            new WasmImport("env", "__r2r_start", import: new WasmGlobalImportType(WasmValueType.I32, WasmMutabilityType.Const), index: R2RStartGlobalIndex),
+            new WasmImport("env", "__image_base", import: new WasmGlobalImportType(WasmValueType.I32, WasmMutabilityType.Const), index: ImageBaseGlobalIndex),
+            new WasmImport("env", "__image_pointer_base", import: new WasmGlobalImportType(WasmValueType.I32, WasmMutabilityType.Const), index: ImagePointerBaseGlobalIndex),
         };
 
         private void WriteImports()
@@ -468,6 +481,11 @@ namespace ILCompiler.ObjectWriter
 
             int exportIdx = _sectionNameToIndex[WasmObjectNodeSection.ExportSection.Name];
             PrependCount(_sections[exportIdx], _numExports);
+
+            if (_sectionNameToIndex.TryGetValue(WasmObjectNodeSection.ElementSection.Name, out int elementIdx))
+            {
+                PrependCount(_sections[elementIdx], _numElements);
+            }
 
             PrependCount(SectionByName(WasmObjectNodeSection.ImportSection.Name), _numImports);
         }


### PR DESCRIPTION
* Rename r2r_start to image_base
* Add image_function_pointer_base import, the offset to populate the function pointer table at
* Fix us allocating the function pointer table with an initial size of 0
* Generate an element section in our modules containing a single element that creates a function pointer for each of our functions in sequential order, i.e.
```wasm
(import "env" "__image_function_pointer_base" (global (;2;) i32))
...
(elem (;0;) (offset global.get 2 i32.const 0 i32.add) func 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22)
```