### PR TITLE
Fix racy mvid tests.

### DIFF
--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/CommandLine.Mvid.IndividualTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/CommandLine.Mvid.IndividualTests.g.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ILLink.RoslynAnalyzer.Tests.CommandLine.Mvid
+{
+    public sealed partial class IndividualTests : LinkerTestBase
+    {
+
+        protected override string TestSuiteName => "CommandLine.Mvid.Individual";
+
+        [Fact]
+        public Task DeterministicMvidWorks()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task NewMvidWorks()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task RetainMvid()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+    }
+}

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/CommandLine.MvidTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/CommandLine.MvidTests.g.cs
@@ -15,23 +15,5 @@ namespace ILLink.RoslynAnalyzer.Tests.CommandLine
             return RunTest(allowMissingWarnings: true);
         }
 
-        [Fact]
-        public Task DeterministicMvidWorks()
-        {
-            return RunTest(allowMissingWarnings: true);
-        }
-
-        [Fact]
-        public Task NewMvidWorks()
-        {
-            return RunTest(allowMissingWarnings: true);
-        }
-
-        [Fact]
-        public Task RetainMvid()
-        {
-            return RunTest(allowMissingWarnings: true);
-        }
-
     }
 }

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CommandLine/Mvid/Individual/DeterministicMvidWorks.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CommandLine/Mvid/Individual/DeterministicMvidWorks.cs
@@ -1,10 +1,10 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
-namespace Mono.Linker.Tests.Cases.CommandLine.Mvid
+namespace Mono.Linker.Tests.Cases.CommandLine.Mvid.Individual
 {
-    [SetupLinkerArgument("--new-mvid", "false")]
-    public class RetainMvid
+    [SetupLinkerArgument("--deterministic", "true")]
+    public class DeterministicMvidWorks
     {
         public static void Main()
         {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CommandLine/Mvid/Individual/NewMvidWorks.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CommandLine/Mvid/Individual/NewMvidWorks.cs
@@ -1,10 +1,10 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
-namespace Mono.Linker.Tests.Cases.CommandLine.Mvid
+namespace Mono.Linker.Tests.Cases.CommandLine.Mvid.Individual
 {
-    [SetupLinkerArgument("--deterministic", "true")]
-    public class DeterministicMvidWorks
+    [SetupLinkerArgument("--new-mvid", "true")]
+    public class NewMvidWorks
     {
         public static void Main()
         {

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/CommandLine/Mvid/Individual/RetainMvid.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/CommandLine/Mvid/Individual/RetainMvid.cs
@@ -1,10 +1,10 @@
 using Mono.Linker.Tests.Cases.Expectations.Assertions;
 using Mono.Linker.Tests.Cases.Expectations.Metadata;
 
-namespace Mono.Linker.Tests.Cases.CommandLine.Mvid
+namespace Mono.Linker.Tests.Cases.CommandLine.Mvid.Individual
 {
-    [SetupLinkerArgument("--new-mvid", "true")]
-    public class NewMvidWorks
+    [SetupLinkerArgument("--new-mvid", "false")]
+    public class RetainMvid
     {
         public static void Main()
         {

--- a/src/tools/illink/test/Mono.Linker.Tests/TestCases/IndividualTests.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests/TestCases/IndividualTests.cs
@@ -9,6 +9,7 @@ using System.Runtime.Serialization.Json;
 using System.Xml;
 using Mono.Cecil;
 using Mono.Linker.Tests.Cases.CommandLine.Mvid;
+using Mono.Linker.Tests.Cases.CommandLine.Mvid.Individual;
 using Mono.Linker.Tests.Cases.Interop.PInvoke.Individual;
 using Mono.Linker.Tests.Cases.References.Individual;
 using Mono.Linker.Tests.Cases.Tracing.Individual;
@@ -199,6 +200,7 @@ namespace Mono.Linker.Tests.TestCases
         {
             var testCase = CreateIndividualCase(typeof(DeterministicMvidWorks));
             var result = Run(testCase, out TestRunner runner);
+            Check(result);
 
             var originalMvid = GetMvid(result.InputAssemblyPath);
             var firstOutputMvid = GetMvid(result.OutputAssemblyPath);
@@ -217,6 +219,7 @@ namespace Mono.Linker.Tests.TestCases
         {
             var testCase = CreateIndividualCase(typeof(NewMvidWorks));
             var result = Run(testCase, out TestRunner runner);
+            Check(result);
 
             var originalMvid = GetMvid(result.InputAssemblyPath);
             var firstOutputMvid = GetMvid(result.OutputAssemblyPath);
@@ -234,6 +237,7 @@ namespace Mono.Linker.Tests.TestCases
         {
             var testCase = CreateIndividualCase(typeof(RetainMvid));
             var result = Run(testCase, out TestRunner runner);
+            Check(result);
 
             var originalMvid = GetMvid(result.InputAssemblyPath);
             var firstOutputMvid = GetMvid(result.OutputAssemblyPath);
@@ -268,6 +272,11 @@ namespace Mono.Linker.Tests.TestCases
         {
             runner = new TestRunner(new ObjectFactory());
             return runner.Run(testCase);
+        }
+
+        protected virtual void Check(TrimmedTestCaseResult linkedResult)
+        {
+            new ResultChecker().Check(linkedResult);
         }
     }
 }


### PR DESCRIPTION
`DeterministicMvidWorks`, `NewMvidWorks`, and `RetainMvid` were running as part of `All.CommandLineTests` and as part of their own `IndividualTests`.

The individual test is going to use the same sandbox location as the `All.CommandLineTests` run uses.

This means that the two tests can conflict.  Which I suspect explains why our CI randomly hit the error below.

Given that trimming these tests twice is wasteful.  Let's update the individual test to run `Check`, giving the individual test the same coverage as when the test was running in `All.CommandsLineTests`.  Then lets move the tests into an `Individual` folder so that they are not picked up by `All.CommandsLineTests`.  Other tests in `IndividualTests` are following this pattern.

```
1) Failed : Mono.Linker.Tests.TestCases.All.CommandLine.Mvid.DeterministicMvidWorks
[19:40:23.176 Information] System.UnauthorizedAccessException : Access to the path 'test.exe' is denied.
   at System.IO.FileSystem.RemoveDirectoryRecursive(String fullPath, WIN32_FIND_DATA& findData, Boolean topLevel)
   at System.IO.FileSystem.RemoveDirectory(String fullPath, Boolean recursive)
   at Mono.Linker.Tests.Extensions.NPath.Delete(DeleteMode deleteMode) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\Extensions\NiceIO.cs:line 580
   at Mono.Linker.Tests.Extensions.Extensions.Delete(IEnumerable`1 self) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\Extensions\NiceIO.cs:line 889
   at Mono.Linker.Tests.Extensions.NPath.DeleteContents() in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\Extensions\NiceIO.cs:line 614
   at Mono.Linker.Tests.TestCasesRunner.TestCaseSandbox..ctor(TestCase testCase, NPath rootTemporaryDirectory, String namePrefix) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Trimming.Tests.Shared\TestCaseSandbox.cs:line 45
   at Mono.Linker.Tests.TestCasesRunner.TestRunner.Run(TestCase testCase) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Trimming.Tests.Shared\TestRunner.cs:line 35
   at Mono.Linker.Tests.TestCases.All.Run(TestCase testCase) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\TestCases\TestSuites.cs:line 304
   at Mono.Linker.Tests.TestCases.All.CommandLineTests(TestCase testCase) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\TestCases\TestSuites.cs:line 64
   at InvokeStub_All.CommandLineTests(Object, Span`1)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
2) Failed : Mono.Linker.Tests.TestCases.All.CommandLine.Mvid.NewMvidWorks
System.UnauthorizedAccessException : Access to the path 'test.exe' is denied.
   at System.IO.FileSystem.RemoveDirectoryRecursive(String fullPath, WIN32_FIND_DATA& findData, Boolean topLevel)
   at System.IO.FileSystem.RemoveDirectory(String fullPath, Boolean recursive)
   at Mono.Linker.Tests.Extensions.NPath.Delete(DeleteMode deleteMode) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\Extensions\NiceIO.cs:line 580
   at Mono.Linker.Tests.Extensions.Extensions.Delete(IEnumerable`1 self) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\Extensions\NiceIO.cs:line 889
   at Mono.Linker.Tests.Extensions.NPath.DeleteContents() in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\Extensions\NiceIO.cs:line 614
   at Mono.Linker.Tests.TestCasesRunner.TestCaseSandbox..ctor(TestCase testCase, NPath rootTemporaryDirectory, String namePrefix) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Trimming.Tests.Shared\TestCaseSandbox.cs:line 45
   at Mono.Linker.Tests.TestCasesRunner.TestRunner.Run(TestCase testCase) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Trimming.Tests.Shared\TestRunner.cs:line 35
   at Mono.Linker.Tests.TestCases.All.Run(TestCase testCase) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\TestCases\TestSuites.cs:line 304
   at Mono.Linker.Tests.TestCases.All.CommandLineTests(TestCase testCase) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\TestCases\TestSuites.cs:line 64
   at InvokeStub_All.CommandLineTests(Object, Span`1)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
3) Failed : Mono.Linker.Tests.TestCases.All.CommandLine.Mvid.RetainMvid
System.UnauthorizedAccessException : Access to the path 'test.exe' is denied.
   at System.IO.FileSystem.RemoveDirectoryRecursive(String fullPath, WIN32_FIND_DATA& findData, Boolean topLevel)
   at System.IO.FileSystem.RemoveDirectory(String fullPath, Boolean recursive)
   at Mono.Linker.Tests.Extensions.NPath.Delete(DeleteMode dele
[19:40:23.177 Information] teMode) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\Extensions\NiceIO.cs:line 580
   at Mono.Linker.Tests.Extensions.Extensions.Delete(IEnumerable`1 self) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\Extensions\NiceIO.cs:line 889
   at Mono.Linker.Tests.Extensions.NPath.DeleteContents() in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\Extensions\NiceIO.cs:line 614
   at Mono.Linker.Tests.TestCasesRunner.TestCaseSandbox..ctor(TestCase testCase, NPath rootTemporaryDirectory, String namePrefix) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Trimming.Tests.Shared\TestCaseSandbox.cs:line 45
   at Mono.Linker.Tests.TestCasesRunner.TestRunner.Run(TestCase testCase) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Trimming.Tests.Shared\TestRunner.cs:line 35
   at Mono.Linker.Tests.TestCases.All.Run(TestCase testCase) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\TestCases\TestSuites.cs:line 304
   at Mono.Linker.Tests.TestCases.All.CommandLineTests(TestCase testCase) in C:\build\output\unity\il2cpp\external\runtime\src\tools\illink\test\Mono.Linker.Tests\TestCases\TestSuites.cs:line 64
   at InvokeStub_All.CommandLineTests(Object, Span`1)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
```