### PR TITLE
Add pipeline legs for crossgen2 with --large_version_bubble

### DIFF
--- a/eng/pipelines/common/templates/runtimes/run-test-job.yml
+++ b/eng/pipelines/common/templates/runtimes/run-test-job.yml
@@ -11,6 +11,7 @@ parameters:
   hotColdSplitting: false
   liveLibrariesBuildConfig: ''
   compositeBuildMode: false
+  largeVersionBubble: false
   useCodeFlowEnforcement: ''
   helixQueues: ''
   condition: true
@@ -129,6 +130,9 @@ jobs:
       - ${{ if eq(parameters.hotColdSplitting, true) }}:
         - name: LogNamePrefix
           value: TestRunLogs_R2R_CG2_HotColdSplitting
+      - ${{ if eq(parameters.largeVersionBubble, true) }}:
+        - name: LogNamePrefix
+          value: TestRunLogs_R2R_CG2_LargeVersionBubble
 
     - name: testFilterArg
       value: ''
@@ -316,6 +320,7 @@ jobs:
         runInterpreter: ${{ parameters.runInterpreter }}
         tieringTest: ${{ parameters.tieringTest }}
         hotColdSplitting: ${{ parameters.hotColdSplitting }}
+        largeVersionBubble: ${{ parameters.largeVersionBubble }}
 
         ${{ if eq(variables['System.TeamProject'], 'internal') }}:
           # Access token variable for internal project from the

--- a/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
+++ b/eng/pipelines/common/templates/runtimes/send-to-helix-step.yml
@@ -24,6 +24,7 @@ parameters:
   runInterpreter: ''
   tieringTest: ''
   hotColdSplitting: ''
+  largeVersionBubble: false
   nativeAotTest: ''
   longRunningGcTests: ''
   gcSimulatorTests: ''
@@ -59,6 +60,7 @@ steps:
       _RunInterpreter: ${{ parameters.runInterpreter }}
       _TieringTest: ${{ parameters.tieringTest }}
       _HotColdSplitting: ${{ parameters.hotColdSplitting }}
+      _LargeVersionBubble: ${{ parameters.largeVersionBubble }}
       _NativeAotTest: ${{ parameters.nativeAotTest }}
       _LongRunningGcTests: ${{ parameters.longRunningGcTests }}
       _GcSimulatorTests: ${{ parameters.gcSimulatorTests }}

--- a/eng/pipelines/coreclr/crossgen2-composite.yml
+++ b/eng/pipelines/coreclr/crossgen2-composite.yml
@@ -80,3 +80,21 @@ extends:
             displayNameArgs: Composite
             liveLibrariesBuildConfig: Release
             unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)
+
+      # Composite mode with large version bubble (inputbubble)
+      - template: /eng/pipelines/common/platform-matrix.yml
+        parameters:
+          jobTemplate: /eng/pipelines/common/templates/runtimes/run-test-job.yml
+          helixQueuesTemplate: /eng/pipelines/coreclr/templates/helix-queues-setup.yml
+          buildConfig: checked
+          platforms:
+          - linux_x64
+          - windows_x64
+          jobParameters:
+            testGroup: innerloop
+            readyToRun: true
+            compositeBuildMode: true
+            largeVersionBubble: true
+            displayNameArgs: Composite_LargeVersionBubble
+            liveLibrariesBuildConfig: Release
+            unifiedArtifactsName: BuildArtifacts_$(osGroup)$(osSubgroup)_$(archType)_$(_BuildConfig)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -487,7 +487,7 @@ namespace ILCompiler.DependencyAnalysis
                 // ARM32 relocs require the thumb bit set, and the JIT/crossgen doesn't set it properly for the usages in async methods.
                 // https://github.com/dotnet/runtime/issues/125337
                 // https://github.com/dotnet/runtime/issues/125338
-                if ((CompilationModuleGroup.IsCompositeBuildMode || Target.Architecture == TargetArchitecture.ARM)
+                if (Target.Architecture == TargetArchitecture.ARM
                     && (method.IsAsyncVariant() || method.IsCompilerGeneratedILBodyForAsync()))
                 {
                     continue;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -535,7 +535,7 @@ namespace Internal.JitInterface
             throw new NotSupportedException();
         }
 
-        public static bool ShouldSkipCompilation(InstructionSetSupport instructionSetSupport, MethodDesc methodNeedingCode)
+        public static bool ShouldSkipCompilation(InstructionSetSupport instructionSetSupport, MethodDesc methodNeedingCode, ReadyToRunCodegenCompilation compilation = null)
         {
             bool targetAllowsRuntimeCodeGeneration = ((ReadyToRunCompilerContext)methodNeedingCode.Context).TargetAllowsRuntimeCodeGeneration;
             if (methodNeedingCode.IsAggressiveOptimization && targetAllowsRuntimeCodeGeneration)
@@ -567,6 +567,14 @@ namespace Internal.JitInterface
                 methodNeedingCode.Name.SequenceEqual("EndInvoke"u8)))
             {
                 // Special methods on delegate types
+                return true;
+            }
+            // Async resumption stubs use faux IL with synthetic tokens. When CoreLib is in the
+            // version bubble the stubs are not wrapped with ManifestModuleWrappedMethodIL, so
+            // token resolution for InstantiatedType / ParameterizedType falls through to a path
+            // that cannot handle them. Skip compilation and let the runtime JIT these stubs.
+            if (methodNeedingCode.IsCompilerGeneratedILBodyForAsync() && compilation != null && compilation.NodeFactory.CompilationModuleGroup.IsCompositeBuildMode)
+            {
                 return true;
             }
             if (ShouldCodeNotBeCompiledIntoFinalImage(instructionSetSupport, methodNeedingCode))
@@ -770,7 +778,7 @@ namespace Internal.JitInterface
 
             try
             {
-                if (ShouldSkipCompilation(_compilation.InstructionSetSupport, MethodBeingCompiled))
+                if (ShouldSkipCompilation(_compilation.InstructionSetSupport, MethodBeingCompiled, _compilation))
                 {
                     if (logger.IsVerbose)
                         logger.Writer.WriteLine($"Info: Method `{MethodBeingCompiled}` was not compiled because it is skipped.");

--- a/src/tests/Common/CLRTest.CrossGen.targets
+++ b/src/tests/Common/CLRTest.CrossGen.targets
@@ -96,7 +96,7 @@ if [ ! -z ${RunCrossGen2+x} ]%3B then
             __R2RDumpCommand+=" dotnet"
         fi
         __R2RDumpCommand+=" $CORE_ROOT/R2RDump/R2RDump.dll"
-        __R2RDumpCommand+=" --header --sc --in $__OutputFileFinal --out $__OutputFileFinal.r2rdump --val"
+        __R2RDumpCommand+=" --header --sc --in $__OutputFileFinal --out $__OutputFileFinal.r2rdump --val --rp $CORE_ROOT"
 
         __Command="$_DebuggerFullPath $CORE_ROOT/crossgen2/crossgen2"
         __Command+=" @$__ResponseFile"
@@ -289,7 +289,7 @@ if defined RunCrossGen2 (
         set __DotNet="dotnet"
     )
     set __R2RDumpCommand=!_DebuggerFullPath! !__DotNet! "!CORE_ROOT!\r2rdump\r2rdump.dll"
-    set __R2RDumpCommand=!__R2RDumpCommand! --header --sc --in !__OutputFile! --out !__OutputFile!.r2rdump --val
+    set __R2RDumpCommand=!__R2RDumpCommand! --header --sc --in !__OutputFile! --out !__OutputFile!.r2rdump --val --rp "!CORE_ROOT!"
 
     set __Command=!_DebuggerFullPath! "!CORE_ROOT!\crossgen2\crossgen2.exe"
     set __Command=!__Command! @"!__ResponseFile!"

--- a/src/tests/Common/helixpublishwitharcade.proj
+++ b/src/tests/Common/helixpublishwitharcade.proj
@@ -42,6 +42,7 @@
     <_RunInterpreter>false</_RunInterpreter>
     <_TieringTest>false</_TieringTest>
     <_HotColdSplitting>false</_HotColdSplitting>
+    <_LargeVersionBubble>false</_LargeVersionBubble>
     <_NativeAotTest>false</_NativeAotTest>
     <_TimeoutPerTestCollectionInMinutes>123</_TimeoutPerTestCollectionInMinutes>
     <_TimeoutPerTestInMinutes>234</_TimeoutPerTestInMinutes>
@@ -107,6 +108,7 @@
         RunInterpreter=$(_RunInterpreter);
         TieringTest=$(_TieringTest);
         HotColdSplitting=$(_HotColdSplitting);
+        LargeVersionBubble=$(_LargeVersionBubble);
         NativeAotTest=$(_NativeAotTest);
         TimeoutPerTestCollectionInMinutes=$(_TimeoutPerTestCollectionInMinutes);
         TimeoutPerTestInMinutes=$(_TimeoutPerTestInMinutes);
@@ -594,6 +596,7 @@
     <HelixPreCommand Include="set RunTieringTest=1" Condition=" '$(TieringTest)' == 'true' " />
     <HelixPreCommand Include="set RunWithNodeJS=1" Condition=" '$(TargetsBrowserOnCoreCLR)' == 'true' " />
     <HelixPreCommand Include="set HotColdSplitting=1" Condition=" '$(HotColdSplitting)' == 'true' " />
+    <HelixPreCommand Include="set LargeVersionBubble=1" Condition=" '$(LargeVersionBubble)' == 'true' " />
     <HelixPreCommand Include="set CLRCustomTestLauncher=%HELIX_CORRELATION_PAYLOAD%\runincontext.cmd" Condition=" '$(RunInUnloadableContext)' == 'true' " />
     <HelixPreCommand Include="set CLRCustomTestLauncher=%HELIX_CORRELATION_PAYLOAD%\tieringtest.cmd" Condition=" '$(TieringTest)' == 'true' " />
     <HelixPreCommand Include="set CLRCustomTestLauncher=%HELIX_CORRELATION_PAYLOAD%\nativeaottest.cmd" Condition=" '$(NativeAotTest)' == 'true' " />
@@ -649,6 +652,7 @@
     <HelixPreCommand Include="export RunTieringTest=1" Condition=" '$(TieringTest)' == 'true' " />
     <HelixPreCommand Include="export RunWithNodeJS=1" Condition=" '$(TargetsBrowserOnCoreCLR)' == 'true' " />
     <HelixPreCommand Include="export HotColdSplitting=1" Condition=" '$(HotColdSplitting)' == 'true' " />
+    <HelixPreCommand Include="export LargeVersionBubble=1" Condition=" '$(LargeVersionBubble)' == 'true' " />
     <HelixPreCommand Include="export CLRCustomTestLauncher=$HELIX_CORRELATION_PAYLOAD/runincontext.sh" Condition=" '$(RunInUnloadableContext)' == 'true' " />
     <HelixPreCommand Include="export CLRCustomTestLauncher=$HELIX_CORRELATION_PAYLOAD/tieringtest.sh" Condition=" '$(TieringTest)' == 'true' " />
     <HelixPreCommand Include="export CLRCustomTestLauncher=$HELIX_CORRELATION_PAYLOAD/nativeaottest.sh" Condition=" '$(NativeAotTest)' == 'true' " />


### PR DESCRIPTION
We don't have pipeline legs that build coreclr tests with the framework in the coreclr tests. This would have caught the issue from https://github.com/dotnet/runtime/pull/125444 in the crossgen2 pipeline. It looks like the change in that PR didn't fully fix the issue but just kicked the can down for a later exception to throw. 

Add a job to `runtime-coreclr crossgen2-composite` to build the tests including the framework libraries.

In composite mode, skip compiling all async methods rather than just not emitting them.