### PR TITLE
Improve UnwindInfoTable's performance

### DIFF
--- a/src/coreclr/inc/CrstTypes.def
+++ b/src/coreclr/inc/CrstTypes.def
@@ -392,8 +392,13 @@ Crst SingleUseLock
     AcquiredBefore LoaderHeap UniqueStack DebuggerJitInfo
 End
 
-Crst UnwindInfoTableLock
+Crst UnwindInfoTablePublishLock
     AcquiredAfter SingleUseLock
+    AcquiredBefore UnwindInfoTablePendingLock
+End
+
+Crst UnwindInfoTablePendingLock
+    AcquiredAfter UnwindInfoTablePublishLock
     AcquiredBefore StressLog
 End
 

--- a/src/coreclr/inc/crsttypes_generated.h
+++ b/src/coreclr/inc/crsttypes_generated.h
@@ -116,10 +116,11 @@ enum CrstType
     CrstUMEntryThunkFreeListLock = 98,
     CrstUniqueStack = 99,
     CrstUnresolvedClassLock = 100,
-    CrstUnwindInfoTableLock = 101,
-    CrstVSDIndirectionCellLock = 102,
-    CrstWrapperTemplate = 103,
-    kNumberOfCrstTypes = 104
+    CrstUnwindInfoTablePendingLock = 101,
+    CrstUnwindInfoTablePublishLock = 102,
+    CrstVSDIndirectionCellLock = 103,
+    CrstWrapperTemplate = 104,
+    kNumberOfCrstTypes = 105
 };
 
 #endif // __CRST_TYPES_INCLUDED
@@ -231,7 +232,8 @@ int g_rgCrstLevelMap[] =
     2,          // CrstUMEntryThunkFreeListLock
     3,          // CrstUniqueStack
     6,          // CrstUnresolvedClassLock
-    2,          // CrstUnwindInfoTableLock
+    2,          // CrstUnwindInfoTablePendingLock
+    3,          // CrstUnwindInfoTablePublishLock
     3,          // CrstVSDIndirectionCellLock
     2,          // CrstWrapperTemplate
 };
@@ -340,7 +342,8 @@ LPCSTR g_rgCrstNameMap[] =
     "CrstUMEntryThunkFreeListLock",
     "CrstUniqueStack",
     "CrstUnresolvedClassLock",
-    "CrstUnwindInfoTableLock",
+    "CrstUnwindInfoTablePendingLock",
+    "CrstUnwindInfoTablePublishLock",
     "CrstVSDIndirectionCellLock",
     "CrstWrapperTemplate",
 };

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -311,6 +311,11 @@ void UnwindInfoTable::FlushPendingEntries()
     if (localPendingCount == 0)
         return;
 
+    // If a previous Register() call failed, hHandle is NULL. Skip OS updates
+    // to avoid calling RtlGrowFunctionTable or re-registering with a null handle.
+    if (hHandle == NULL)
+        return;
+
     // Sort the pending entries by BeginAddress.
     // Use a simple insertion sort since cPendingMaxCount is small (32).
     for (ULONG i = 1; i < localPendingCount; i++)

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -143,6 +143,7 @@ UnwindInfoTable::UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd, ULONG
     cTableCurCount = 0;
     cTableMaxCount = size;
     cDeletedEntries = 0;
+    bRegistrationFailed = false;
     iRangeStart = rangeStart;
     iRangeEnd = rangeEnd;
     hHandle = NULL;
@@ -247,6 +248,8 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
             INDEBUG(size = size / 4 + 1);
             unwindInfo = (PTR_UnwindInfoTable)new UnwindInfoTable(rangeStart, rangeEnd, size);
             unwindInfo->Register();
+            if (unwindInfo->hHandle == NULL)
+                unwindInfo->bRegistrationFailed = true;
             VolatileStore(unwindInfoPtr, unwindInfo);
         }
     }
@@ -255,7 +258,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
     _ASSERTE(unwindInfo->iRangeEnd == rangeEnd);
 
     // Means we had a failure publishing to the OS, in this case we give up
-    if (unwindInfo->hHandle == NULL)
+    if (unwindInfo->bRegistrationFailed)
         return;
 
     // Add to the pending buffer. If the buffer is full, flush it first and retry.
@@ -267,7 +270,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
             {
                 unwindInfo->pPendingTable[unwindInfo->cPendingCount++] = *data;
 
-                STRESS_LOG5(LF_JIT, LL_INFO1000, "AddToUnwindTable Handle: %p [%p, %p] BUFFERED 0x%p, pending 0x%x\n",
+                STRESS_LOG5(LF_JIT, LL_INFO1000, "AddToUnwindTable Handle: %p [%p, %p] BUFFERED 0x%x, pending 0x%x\n",
                     unwindInfo->hHandle, unwindInfo->iRangeStart, unwindInfo->iRangeEnd,
                     data->BeginAddress, unwindInfo->cPendingCount);
                 return;

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -146,6 +146,8 @@ UnwindInfoTable::UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd, ULONG
     iRangeEnd = rangeEnd;
     hHandle = NULL;
     pTable = new T_RUNTIME_FUNCTION[cTableMaxCount];
+    cPendingCount = 0;
+    pPendingTable = new T_RUNTIME_FUNCTION[cPendingMaxCount];
 }
 
 /****************************************************************************/
@@ -161,6 +163,7 @@ UnwindInfoTable::~UnwindInfoTable()
     // It would be cleaner if we could take the lock (we did not have to be GC_NOTRIGGER)
     UnRegister();
     delete[] pTable;
+    delete[] pPendingTable;
 }
 
 /*****************************************************************************/
@@ -236,7 +239,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
 
         ULONG size = (ULONG) ((rangeEnd - rangeStart) / 128) + 1;
 
-        // To ensure the test the growing logic in debug code make the size much smaller.
+        // To ensure we test the growing logic in debug builds, make the size much smaller.
         INDEBUG(size = size / 4 + 1);
         unwindInfo = (PTR_UnwindInfoTable)new UnwindInfoTable(rangeStart, rangeEnd, size);
         unwindInfo->Register();
@@ -252,7 +255,9 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
         return;
 
     // Check for the fast path: we are adding the end of an UnwindInfoTable with space
-    if (unwindInfo->cTableCurCount < unwindInfo->cTableMaxCount)
+    // and there are no pending entries waiting to be published.
+    if (unwindInfo->cTableCurCount < unwindInfo->cTableMaxCount
+        && unwindInfo->cPendingCount == 0)
     {
         if (unwindInfo->cTableCurCount == 0 ||
             unwindInfo->pTable[unwindInfo->cTableCurCount-1].BeginAddress < data->BeginAddress)
@@ -271,57 +276,108 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
         }
     }
 
-    // OK we need to rellocate the table and reregister.  First figure out our 'desiredSpace'
-    // We could imagine being much more efficient for 'bulk' updates, but we don't try
-    // because we assume that this is rare and we want to keep the code simple
+    // The entry is out-of-order or the main table is full.
+    // Buffer the entry and flush when the buffer is full.
+    _ASSERTE(unwindInfo->cPendingCount < UnwindInfoTable::cPendingMaxCount);
+    unwindInfo->pPendingTable[unwindInfo->cPendingCount++] = *data;
 
-    ULONG usedSpace = unwindInfo->cTableCurCount - unwindInfo->cDeletedEntries;
-    ULONG desiredSpace = usedSpace * 5 / 4 + 1;        // Increase by 20%
-    // Be more aggressive if we used all of our space;
-    if (usedSpace == unwindInfo->cTableMaxCount)
-        desiredSpace = usedSpace * 3 / 2 + 1;        // Increase by 50%
-
-    STRESS_LOG7(LF_JIT, LL_INFO100, "AddToUnwindTable Handle: %p [%p, %p] SLOW Realloc Cnt 0x%x Max 0x%x NewMax 0x%x, Adding %x\n",
+    STRESS_LOG5(LF_JIT, LL_INFO1000, "AddToUnwindTable Handle: %p [%p, %p] BUFFERED 0x%p, pending 0x%x\n",
         unwindInfo->hHandle, unwindInfo->iRangeStart, unwindInfo->iRangeEnd,
-        unwindInfo->cTableCurCount, unwindInfo->cTableMaxCount, desiredSpace, data->BeginAddress);
+        data->BeginAddress, unwindInfo->cPendingCount);
 
-    UnwindInfoTable* newTab = new UnwindInfoTable(unwindInfo->iRangeStart, unwindInfo->iRangeEnd, desiredSpace);
+    if (unwindInfo->cPendingCount == UnwindInfoTable::cPendingMaxCount)
+        unwindInfo->FlushPendingEntries();
+}
 
-    // Copy in the entries, removing deleted entries and adding the new entry wherever it belongs
-    int toIdx = 0;
-    bool inserted = false;    // Have we inserted 'data' into the table
-    for(ULONG fromIdx = 0; fromIdx < unwindInfo->cTableCurCount; fromIdx++)
+/*****************************************************************************/
+void UnwindInfoTable::FlushPendingEntries()
+{
+    CONTRACTL
     {
-        if (!inserted && data->BeginAddress < unwindInfo->pTable[fromIdx].BeginAddress)
+        THROWS;
+        GC_TRIGGERS;
+    }
+    CONTRACTL_END;
+
+    _ASSERTE(s_pUnwindInfoTableLock->OwnedByCurrentThread());
+
+    // Sort the pending entries by BeginAddress.
+    // Use a simple insertion sort since cPendingMaxCount is small (32).
+    for (ULONG i = 1; i < cPendingCount; i++)
+    {
+        T_RUNTIME_FUNCTION key = pPendingTable[i];
+        ULONG j = i;
+        while (j > 0 && pPendingTable[j - 1].BeginAddress > key.BeginAddress)
         {
-            STRESS_LOG1(LF_JIT, LL_INFO100, "AddToUnwindTable Inserted at MID position 0x%x\n", toIdx);
-            newTab->pTable[toIdx++] = *data;
-            inserted = true;
+            pPendingTable[j] = pPendingTable[j - 1];
+            j--;
         }
-        if (unwindInfo->pTable[fromIdx].UnwindData != 0)	// A 'non-deleted' entry
-            newTab->pTable[toIdx++] = unwindInfo->pTable[fromIdx];
+        pPendingTable[j] = key;
     }
-    if (!inserted)
-    {
-        STRESS_LOG1(LF_JIT, LL_INFO100, "AddToUnwindTable Inserted at END position 0x%x\n", toIdx);
-        newTab->pTable[toIdx++] = *data;
-    }
-    newTab->cTableCurCount = toIdx;
-    STRESS_LOG2(LF_JIT, LL_INFO100, "AddToUnwindTable New size 0x%x max 0x%x\n",
-        newTab->cTableCurCount, newTab->cTableMaxCount);
-    _ASSERTE(newTab->cTableCurCount <= newTab->cTableMaxCount);
 
-    // Unregister the old table
-    *unwindInfoPtr = 0;
-    unwindInfo->UnRegister();
+    // Calculate the new table size: live entries from main table + all pending entries
+    ULONG liveCount = cTableCurCount - cDeletedEntries;
+    ULONG newCount = liveCount + cPendingCount;
+    ULONG desiredSpace = newCount * 5 / 4 + 1;  // Increase by 20%
+
+    STRESS_LOG7(LF_JIT, LL_INFO100, "FlushPendingEntries Handle: %p [%p, %p] Merging 0x%x live + 0x%x pending into 0x%x max, from 0x%x\n",
+        hHandle, iRangeStart, iRangeEnd, liveCount, cPendingCount, desiredSpace, cTableMaxCount);
+
+    T_RUNTIME_FUNCTION* newPTable = new T_RUNTIME_FUNCTION[desiredSpace];
+
+    // Merge-sort the main table and pending buffer into newPTable.
+    ULONG mainIdx = 0;
+    ULONG pendIdx = 0;
+    ULONG toIdx = 0;
+
+    while (mainIdx < cTableCurCount && pendIdx < cPendingCount)
+    {
+        // Skip deleted entries in main table
+        if (pTable[mainIdx].UnwindData == 0)
+        {
+            mainIdx++;
+            continue;
+        }
+
+        if (pPendingTable[pendIdx].BeginAddress < pTable[mainIdx].BeginAddress)
+        {
+            newPTable[toIdx++] = pPendingTable[pendIdx++];
+        }
+        else
+        {
+            newPTable[toIdx++] = pTable[mainIdx++];
+        }
+    }
+
+    while (mainIdx < cTableCurCount)
+    {
+        if (pTable[mainIdx].UnwindData != 0)
+            newPTable[toIdx++] = pTable[mainIdx];
+        mainIdx++;
+    }
+
+    while (pendIdx < cPendingCount)
+    {
+        newPTable[toIdx++] = pPendingTable[pendIdx++];
+    }
+
+    _ASSERTE(toIdx == newCount);
+    _ASSERTE(toIdx <= desiredSpace);
+
+    T_RUNTIME_FUNCTION* oldPTable = pTable;
+
+    UnRegister();
+
+    pTable = newPTable;
+    cTableCurCount = toIdx;
+    cTableMaxCount = desiredSpace;
+    cDeletedEntries = 0;
+    cPendingCount = 0;
 
     // Note that there is a short time when we are not publishing...
+    Register();
 
-    // Register the new table
-    newTab->Register();
-    *unwindInfoPtr = newTab;
-
-    delete unwindInfo;
+    delete[] oldPTable;
 }
 
 /*****************************************************************************/
@@ -345,6 +401,21 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
         DWORD relativeEntryPoint = (DWORD)(entryPoint - baseAddress);
         STRESS_LOG3(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removing %p BaseAddress %p rel %x\n",
             entryPoint, baseAddress, relativeEntryPoint);
+
+        // First check the pending buffer (not yet published to the OS).
+        // Use swap-remove since the buffer doesn't need to stay sorted.
+        for (ULONG i = 0; i < unwindInfo->cPendingCount; i++)
+        {
+            if (unwindInfo->pPendingTable[i].BeginAddress <= relativeEntryPoint &&
+                relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pPendingTable[i], unwindInfo->iRangeStart))
+            {
+                unwindInfo->pPendingTable[i] = unwindInfo->pPendingTable[--unwindInfo->cPendingCount];
+                STRESS_LOG1(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removed pending entry 0x%x\n", i);
+                return;
+            }
+        }
+
+        // Then check the main (published) table.
         for(ULONG i = 0; i < unwindInfo->cTableCurCount; i++)
         {
             if (unwindInfo->pTable[i].BeginAddress <= relativeEntryPoint &&

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -256,7 +256,14 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
 
     // Means we had a failure publishing to the OS, in this case we give up
     if (unwindInfo->hHandle == NULL)
-        return;
+     {
+         CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
+         // Re-read the table under the publish lock in case a flush/unregister/register
+         // sequence was in progress when we first inspected hHandle.
+         unwindInfo = *unwindInfoPtr;
+         if (unwindInfo == NULL || unwindInfo->hHandle == NULL)
+             return;
+     }
 
     // Add to the pending buffer. If the buffer is full, flush it first and retry.
     while (true)
@@ -267,7 +274,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
             {
                 unwindInfo->pPendingTable[unwindInfo->cPendingCount++] = *data;
 
-                STRESS_LOG5(LF_JIT, LL_INFO1000, "AddToUnwindTable Handle: %p [%p, %p] BUFFERED 0x%p, pending 0x%x\n",
+                STRESS_LOG5(LF_JIT, LL_INFO1000, "AddToUnwindTable Handle: %p [%p, %p] BUFFERED 0x%x, pending 0x%x\n",
                     unwindInfo->hHandle, unwindInfo->iRangeStart, unwindInfo->iRangeEnd,
                     data->BeginAddress, unwindInfo->cPendingCount);
                 return;

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -95,8 +95,9 @@ static RtlAddGrowableFunctionTableFnPtr pRtlAddGrowableFunctionTable;
 static RtlGrowFunctionTableFnPtr pRtlGrowFunctionTable;
 static RtlDeleteGrowableFunctionTableFnPtr pRtlDeleteGrowableFunctionTable;
 
-static bool s_publishingActive;         // Publishing to ETW is turned on
-static Crst* s_pUnwindInfoTableLock;    // lock protects all public UnwindInfoTable functions
+static bool s_publishingActive;              // Publishing to ETW is turned on
+static Crst* s_pUnwindInfoTablePublishLock;  // Protects main table, OS registration, and lazy init
+static Crst* s_pUnwindInfoTablePendingLock;  // Protects pending buffer only
 
 /****************************************************************************/
 // initialize the entry points for new win8 unwind info publishing functions.
@@ -136,7 +137,7 @@ bool InitUnwindFtns()
 UnwindInfoTable::UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd, ULONG size)
 {
     STANDARD_VM_CONTRACT;
-    _ASSERTE(s_pUnwindInfoTableLock->OwnedByCurrentThread());
+    _ASSERTE(s_pUnwindInfoTablePublishLock->OwnedByCurrentThread());
     _ASSERTE((rangeEnd - rangeStart) <= 0x7FFFFFFF);
 
     cTableCurCount = 0;
@@ -169,7 +170,7 @@ UnwindInfoTable::~UnwindInfoTable()
 /*****************************************************************************/
 void UnwindInfoTable::Register()
 {
-    _ASSERTE(s_pUnwindInfoTableLock->OwnedByCurrentThread());
+    _ASSERTE(s_pUnwindInfoTablePublishLock->OwnedByCurrentThread());
     EX_TRY
     {
         hHandle = NULL;
@@ -208,7 +209,8 @@ void UnwindInfoTable::UnRegister()
 }
 
 /*****************************************************************************/
-// Add 'data' to the linked list whose head is pointed at by 'unwindInfoPtr'
+// Add 'data' to the pending buffer for later publication to the OS.
+// When the buffer is full, entries are flushed under s_pUnwindInfoTablePublishLock.
 //
 /* static */
 void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_RUNTIME_FUNCTION data,
@@ -227,26 +229,28 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
     if (!s_publishingActive)
         return;
 
-    CrstHolder ch(s_pUnwindInfoTableLock);
-
-    UnwindInfoTable* unwindInfo = *unwindInfoPtr;
+    UnwindInfoTable* unwindInfo = VolatileLoad(unwindInfoPtr);
     // was the original list null, If so lazy initialize.
     if (unwindInfo == NULL)
     {
-        // We can choose the average method size estimate dynamically based on past experience
-        // 128 is the estimated size of an average method, so we can accurately predict
-        // how many RUNTIME_FUNCTION entries are in each chunk we allocate.
+        CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
+        unwindInfo = *unwindInfoPtr;
+        if (unwindInfo == NULL)
+        {
+            // We can choose the average method size estimate dynamically based on past experience
+            // 128 is the estimated size of an average method, so we can accurately predict
+            // how many RUNTIME_FUNCTION entries are in each chunk we allocate.
 
-        ULONG size = (ULONG) ((rangeEnd - rangeStart) / 128) + 1;
+            ULONG size = (ULONG) ((rangeEnd - rangeStart) / 128) + 1;
 
-        // To ensure we test the growing logic in debug builds, make the size much smaller.
-        INDEBUG(size = size / 4 + 1);
-        unwindInfo = (PTR_UnwindInfoTable)new UnwindInfoTable(rangeStart, rangeEnd, size);
-        unwindInfo->Register();
-        *unwindInfoPtr = unwindInfo;
+            // To ensure we test the growing logic in debug builds, make the size much smaller.
+            INDEBUG(size = size / 4 + 1);
+            unwindInfo = (PTR_UnwindInfoTable)new UnwindInfoTable(rangeStart, rangeEnd, size);
+            unwindInfo->Register();
+            VolatileStore(unwindInfoPtr, unwindInfo);
+        }
     }
     _ASSERTE(unwindInfo != NULL);        // If new had failed, we would have thrown OOM
-    _ASSERTE(unwindInfo->cTableCurCount <= unwindInfo->cTableMaxCount);
     _ASSERTE(unwindInfo->iRangeStart == rangeStart);
     _ASSERTE(unwindInfo->iRangeEnd == rangeEnd);
 
@@ -254,39 +258,24 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
     if (unwindInfo->hHandle == NULL)
         return;
 
-    // Check for the fast path: we are adding the end of an UnwindInfoTable with space
-    // and there are no pending entries waiting to be published.
-    if (unwindInfo->cTableCurCount < unwindInfo->cTableMaxCount
-        && unwindInfo->cPendingCount == 0)
+    // Add to the pending buffer. If the buffer is full, flush it first and retry.
+    while (true)
     {
-        if (unwindInfo->cTableCurCount == 0 ||
-            unwindInfo->pTable[unwindInfo->cTableCurCount-1].BeginAddress < data->BeginAddress)
         {
-            // Yeah, we can simply add to the end of table and we are done!
-            unwindInfo->pTable[unwindInfo->cTableCurCount] = *data;
-            unwindInfo->cTableCurCount++;
+            CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
+            if (unwindInfo->cPendingCount < UnwindInfoTable::cPendingMaxCount)
+            {
+                unwindInfo->pPendingTable[unwindInfo->cPendingCount++] = *data;
 
-            // Add to the function table
-            pRtlGrowFunctionTable(unwindInfo->hHandle, unwindInfo->cTableCurCount);
-
-            STRESS_LOG5(LF_JIT, LL_INFO1000, "AddToUnwindTable Handle: %p [%p, %p] ADDING 0x%p TO END, now 0x%x entries\n",
-                unwindInfo->hHandle, unwindInfo->iRangeStart, unwindInfo->iRangeEnd,
-                data->BeginAddress, unwindInfo->cTableCurCount);
-            return;
+                STRESS_LOG5(LF_JIT, LL_INFO1000, "AddToUnwindTable Handle: %p [%p, %p] BUFFERED 0x%p, pending 0x%x\n",
+                    unwindInfo->hHandle, unwindInfo->iRangeStart, unwindInfo->iRangeEnd,
+                    data->BeginAddress, unwindInfo->cPendingCount);
+                return;
+            }
         }
-    }
-
-    // The entry is out-of-order or the main table is full.
-    // Buffer the entry and flush when the buffer is full.
-    _ASSERTE(unwindInfo->cPendingCount < UnwindInfoTable::cPendingMaxCount);
-    unwindInfo->pPendingTable[unwindInfo->cPendingCount++] = *data;
-
-    STRESS_LOG5(LF_JIT, LL_INFO1000, "AddToUnwindTable Handle: %p [%p, %p] BUFFERED 0x%p, pending 0x%x\n",
-        unwindInfo->hHandle, unwindInfo->iRangeStart, unwindInfo->iRangeEnd,
-        data->BeginAddress, unwindInfo->cPendingCount);
-
-    if (unwindInfo->cPendingCount == UnwindInfoTable::cPendingMaxCount)
+        CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
         unwindInfo->FlushPendingEntries();
+    }
 }
 
 /*****************************************************************************/
@@ -299,29 +288,59 @@ void UnwindInfoTable::FlushPendingEntries()
     }
     CONTRACTL_END;
 
-    _ASSERTE(s_pUnwindInfoTableLock->OwnedByCurrentThread());
+    _ASSERTE(s_pUnwindInfoTablePublishLock->OwnedByCurrentThread());
+
+    // Grab the pending entries under the pending lock, then release it so
+    // other threads can keep accumulating new entries while we flush.
+    T_RUNTIME_FUNCTION localPending[cPendingMaxCount];
+    ULONG localPendingCount;
+    {
+        CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
+        localPendingCount = cPendingCount;
+        memcpy(localPending, pPendingTable, cPendingCount * sizeof(T_RUNTIME_FUNCTION));
+        cPendingCount = 0;
+    }
+
+    if (localPendingCount == 0)
+        return;
 
     // Sort the pending entries by BeginAddress.
     // Use a simple insertion sort since cPendingMaxCount is small (32).
-    for (ULONG i = 1; i < cPendingCount; i++)
+    for (ULONG i = 1; i < localPendingCount; i++)
     {
-        T_RUNTIME_FUNCTION key = pPendingTable[i];
+        T_RUNTIME_FUNCTION key = localPending[i];
         ULONG j = i;
-        while (j > 0 && pPendingTable[j - 1].BeginAddress > key.BeginAddress)
+        while (j > 0 && localPending[j - 1].BeginAddress > key.BeginAddress)
         {
-            pPendingTable[j] = pPendingTable[j - 1];
+            localPending[j] = localPending[j - 1];
             j--;
         }
-        pPendingTable[j] = key;
+        localPending[j] = key;
     }
 
+    // Fast path: if all pending entries can be appended in order with room to spare,
+    // we can just append and call RtlGrowFunctionTable.
+    if (cDeletedEntries == 0
+        && cTableCurCount + localPendingCount <= cTableMaxCount
+        && (cTableCurCount == 0 || pTable[cTableCurCount - 1].BeginAddress < localPending[0].BeginAddress))
+    {
+        memcpy(&pTable[cTableCurCount], localPending, localPendingCount * sizeof(T_RUNTIME_FUNCTION));
+        cTableCurCount += localPendingCount;
+        pRtlGrowFunctionTable(hHandle, cTableCurCount);
+
+        STRESS_LOG5(LF_JIT, LL_INFO1000, "FlushPendingEntries Handle: %p [%p, %p] APPENDED 0x%x entries, now 0x%x\n",
+            hHandle, iRangeStart, iRangeEnd, localPendingCount, cTableCurCount);
+        return;
+    }
+
+    // Merge main table and pending entries.
     // Calculate the new table size: live entries from main table + all pending entries
     ULONG liveCount = cTableCurCount - cDeletedEntries;
-    ULONG newCount = liveCount + cPendingCount;
+    ULONG newCount = liveCount + localPendingCount;
     ULONG desiredSpace = newCount * 5 / 4 + 1;  // Increase by 20%
 
     STRESS_LOG7(LF_JIT, LL_INFO100, "FlushPendingEntries Handle: %p [%p, %p] Merging 0x%x live + 0x%x pending into 0x%x max, from 0x%x\n",
-        hHandle, iRangeStart, iRangeEnd, liveCount, cPendingCount, desiredSpace, cTableMaxCount);
+        hHandle, iRangeStart, iRangeEnd, liveCount, localPendingCount, desiredSpace, cTableMaxCount);
 
     T_RUNTIME_FUNCTION* newPTable = new T_RUNTIME_FUNCTION[desiredSpace];
 
@@ -330,7 +349,7 @@ void UnwindInfoTable::FlushPendingEntries()
     ULONG pendIdx = 0;
     ULONG toIdx = 0;
 
-    while (mainIdx < cTableCurCount && pendIdx < cPendingCount)
+    while (mainIdx < cTableCurCount && pendIdx < localPendingCount)
     {
         // Skip deleted entries in main table
         if (pTable[mainIdx].UnwindData == 0)
@@ -339,9 +358,9 @@ void UnwindInfoTable::FlushPendingEntries()
             continue;
         }
 
-        if (pPendingTable[pendIdx].BeginAddress < pTable[mainIdx].BeginAddress)
+        if (localPending[pendIdx].BeginAddress < pTable[mainIdx].BeginAddress)
         {
-            newPTable[toIdx++] = pPendingTable[pendIdx++];
+            newPTable[toIdx++] = localPending[pendIdx++];
         }
         else
         {
@@ -356,9 +375,9 @@ void UnwindInfoTable::FlushPendingEntries()
         mainIdx++;
     }
 
-    while (pendIdx < cPendingCount)
+    while (pendIdx < localPendingCount)
     {
-        newPTable[toIdx++] = pPendingTable[pendIdx++];
+        newPTable[toIdx++] = localPending[pendIdx++];
     }
 
     _ASSERTE(toIdx == newCount);
@@ -372,7 +391,6 @@ void UnwindInfoTable::FlushPendingEntries()
     cTableCurCount = toIdx;
     cTableMaxCount = desiredSpace;
     cDeletedEntries = 0;
-    cPendingCount = 0;
 
     // Note that there is a short time when we are not publishing...
     Register();
@@ -393,17 +411,19 @@ void UnwindInfoTable::FlushPendingEntries()
 
     if (!s_publishingActive)
         return;
-    CrstHolder ch(s_pUnwindInfoTableLock);
 
-    UnwindInfoTable* unwindInfo = *unwindInfoPtr;
-    if (unwindInfo != NULL)
+    UnwindInfoTable* unwindInfo = VolatileLoad(unwindInfoPtr);
+    if (unwindInfo == NULL)
+        return;
+
+    DWORD relativeEntryPoint = (DWORD)(entryPoint - baseAddress);
+    STRESS_LOG3(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removing %p BaseAddress %p rel %x\n",
+        entryPoint, baseAddress, relativeEntryPoint);
+
+    // First check the pending buffer under the pending lock.
+    // Use swap-remove since the buffer doesn't need to stay sorted.
     {
-        DWORD relativeEntryPoint = (DWORD)(entryPoint - baseAddress);
-        STRESS_LOG3(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removing %p BaseAddress %p rel %x\n",
-            entryPoint, baseAddress, relativeEntryPoint);
-
-        // First check the pending buffer (not yet published to the OS).
-        // Use swap-remove since the buffer doesn't need to stay sorted.
+        CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
         for (ULONG i = 0; i < unwindInfo->cPendingCount; i++)
         {
             if (unwindInfo->pPendingTable[i].BeginAddress <= relativeEntryPoint &&
@@ -414,9 +434,12 @@ void UnwindInfoTable::FlushPendingEntries()
                 return;
             }
         }
+    }
 
-        // Then check the main (published) table.
-        for(ULONG i = 0; i < unwindInfo->cTableCurCount; i++)
+    // Not found in pending buffer — check the main (published) table under publish lock.
+    {
+        CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
+        for (ULONG i = 0; i < unwindInfo->cTableCurCount; i++)
         {
             if (unwindInfo->pTable[i].BeginAddress <= relativeEntryPoint &&
                 relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pTable[i], unwindInfo->iRangeStart))
@@ -429,6 +452,7 @@ void UnwindInfoTable::FlushPendingEntries()
             }
         }
     }
+
     STRESS_LOG2(LF_JIT, LL_WARNING, "RemoveFromUnwindInfoTable COULD NOT FIND %p BaseAddress %p\n",
         entryPoint, baseAddress);
 }
@@ -451,12 +475,12 @@ void UnwindInfoTable::FlushPendingEntries()
         for(int i = 0; i < unwindInfoCount; i++)
             AddToUnwindInfoTable(&pRS->_pUnwindInfoTable, &unwindInfo[i], pRS->_range.RangeStart(), pRS->_range.RangeEndOpen());
 
-        // Flush any entries that were buffered above to the OS can unwind this
+        // Flush any entries that were buffered above so the OS can unwind this
         // method immediately. Otherwise, we may end up with broken stack traces
         // for recently JITed methods.
-        CrstHolder ch(s_pUnwindInfoTableLock);
+        CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
         UnwindInfoTable* unwindInfoTable = pRS->_pUnwindInfoTable;
-        if (unwindInfoTable != NULL && unwindInfoTable->cPendingCount > 0)
+        if (unwindInfoTable != NULL)
         {
             unwindInfoTable->FlushPendingEntries();
         }
@@ -511,8 +535,9 @@ void UnwindInfoTable::FlushPendingEntries()
     if (!InitUnwindFtns())
         return;
 
-    // Create the lock
-    s_pUnwindInfoTableLock = new Crst(CrstUnwindInfoTableLock);
+    // Create the locks
+    s_pUnwindInfoTablePublishLock = new Crst(CrstUnwindInfoTablePublishLock);
+    s_pUnwindInfoTablePendingLock = new Crst(CrstUnwindInfoTablePendingLock);
     s_publishingActive = true;
 }
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -429,7 +429,7 @@ void UnwindInfoTable::FlushPendingEntries()
     STRESS_LOG3(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removing %p BaseAddress %p rel %x\n",
         entryPoint, baseAddress, relativeEntryPoint);
 
-    // Not found in pending buffer — check the main (published) table under publish lock.
+    // First check the main (published) table under the publish lock.
     {
         CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
         for (ULONG i = 0; i < unwindInfo->cTableCurCount; i++)

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -450,6 +450,16 @@ void UnwindInfoTable::FlushPendingEntries()
     {
         for(int i = 0; i < unwindInfoCount; i++)
             AddToUnwindInfoTable(&pRS->_pUnwindInfoTable, &unwindInfo[i], pRS->_range.RangeStart(), pRS->_range.RangeEndOpen());
+
+        // Flush any entries that were buffered above to the OS can unwind this
+        // method immediately. Otherwise, we may end up with broken stack traces
+        // for recently JITed methods.
+        CrstHolder ch(s_pUnwindInfoTableLock);
+        UnwindInfoTable* unwindInfoTable = pRS->_pUnwindInfoTable;
+        if (unwindInfoTable != NULL && unwindInfoTable->cPendingCount > 0)
+        {
+            unwindInfoTable->FlushPendingEntries();
+        }
     }
 }
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -143,7 +143,6 @@ UnwindInfoTable::UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd, ULONG
     cTableCurCount = 0;
     cTableMaxCount = size;
     cDeletedEntries = 0;
-    bRegistrationFailed = false;
     iRangeStart = rangeStart;
     iRangeEnd = rangeEnd;
     hHandle = NULL;
@@ -248,8 +247,6 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
             INDEBUG(size = size / 4 + 1);
             unwindInfo = (PTR_UnwindInfoTable)new UnwindInfoTable(rangeStart, rangeEnd, size);
             unwindInfo->Register();
-            if (unwindInfo->hHandle == NULL)
-                unwindInfo->bRegistrationFailed = true;
             VolatileStore(unwindInfoPtr, unwindInfo);
         }
     }
@@ -258,7 +255,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
     _ASSERTE(unwindInfo->iRangeEnd == rangeEnd);
 
     // Means we had a failure publishing to the OS, in this case we give up
-    if (unwindInfo->bRegistrationFailed)
+    if (unwindInfo->hHandle == NULL)
         return;
 
     // Add to the pending buffer. If the buffer is full, flush it first and retry.
@@ -270,7 +267,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
             {
                 unwindInfo->pPendingTable[unwindInfo->cPendingCount++] = *data;
 
-                STRESS_LOG5(LF_JIT, LL_INFO1000, "AddToUnwindTable Handle: %p [%p, %p] BUFFERED 0x%x, pending 0x%x\n",
+                STRESS_LOG5(LF_JIT, LL_INFO1000, "AddToUnwindTable Handle: %p [%p, %p] BUFFERED 0x%p, pending 0x%x\n",
                     unwindInfo->hHandle, unwindInfo->iRangeStart, unwindInfo->iRangeEnd,
                     data->BeginAddress, unwindInfo->cPendingCount);
                 return;

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -148,7 +148,6 @@ UnwindInfoTable::UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd, ULONG
     hHandle = NULL;
     pTable = new T_RUNTIME_FUNCTION[cTableMaxCount];
     cPendingCount = 0;
-    pPendingTable = new T_RUNTIME_FUNCTION[cPendingMaxCount];
 }
 
 /****************************************************************************/
@@ -164,7 +163,6 @@ UnwindInfoTable::~UnwindInfoTable()
     // It would be cleaner if we could take the lock (we did not have to be GC_NOTRIGGER)
     UnRegister();
     delete[] pTable;
-    delete[] pPendingTable;
 }
 
 /*****************************************************************************/
@@ -332,8 +330,7 @@ void UnwindInfoTable::FlushPendingEntries()
 
     // Fast path: if all pending entries can be appended in order with room to spare,
     // we can just append and call RtlGrowFunctionTable.
-    if (cDeletedEntries == 0
-        && cTableCurCount + localPendingCount <= cTableMaxCount
+    if (cTableCurCount + localPendingCount <= cTableMaxCount
         && (cTableCurCount == 0 || pTable[cTableCurCount - 1].BeginAddress < localPending[0].BeginAddress))
     {
         memcpy(&pTable[cTableCurCount], localPending, localPendingCount * sizeof(T_RUNTIME_FUNCTION));
@@ -432,22 +429,6 @@ void UnwindInfoTable::FlushPendingEntries()
     STRESS_LOG3(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removing %p BaseAddress %p rel %x\n",
         entryPoint, baseAddress, relativeEntryPoint);
 
-    // First check the pending buffer under the pending lock.
-    // Use swap-remove since the buffer doesn't need to stay sorted.
-    {
-        CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
-        for (ULONG i = 0; i < unwindInfo->cPendingCount; i++)
-        {
-            if (unwindInfo->pPendingTable[i].BeginAddress <= relativeEntryPoint &&
-                relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pPendingTable[i], unwindInfo->iRangeStart))
-            {
-                unwindInfo->pPendingTable[i] = unwindInfo->pPendingTable[--unwindInfo->cPendingCount];
-                STRESS_LOG1(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removed pending entry 0x%x\n", i);
-                return;
-            }
-        }
-    }
-
     // Not found in pending buffer — check the main (published) table under publish lock.
     {
         CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
@@ -460,6 +441,22 @@ void UnwindInfoTable::FlushPendingEntries()
                     unwindInfo->cDeletedEntries++;
                 unwindInfo->pTable[i].UnwindData = 0;        // Mark the entry for deletion
                 STRESS_LOG1(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removed entry 0x%x\n", i);
+                return;
+            }
+        }
+    }
+
+    // Check the pending buffer under the pending lock.
+    // Use swap-remove since the buffer doesn't need to stay sorted.
+    {
+        CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
+        for (ULONG i = 0; i < unwindInfo->cPendingCount; i++)
+        {
+            if (unwindInfo->pPendingTable[i].BeginAddress <= relativeEntryPoint &&
+                relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pPendingTable[i], unwindInfo->iRangeStart))
+            {
+                unwindInfo->pPendingTable[i] = unwindInfo->pPendingTable[--unwindInfo->cPendingCount];
+                STRESS_LOG1(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removed pending entry 0x%x\n", i);
                 return;
             }
         }

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -420,22 +420,6 @@ void UnwindInfoTable::FlushPendingEntries()
         }
     }
 
-    // Check the pending buffer under the pending lock.
-    // Use swap-remove since the buffer doesn't need to stay sorted.
-    {
-        CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
-        for (ULONG i = 0; i < unwindInfo->cPendingCount; i++)
-        {
-            if (unwindInfo->pendingTable[i].BeginAddress <= relativeEntryPoint &&
-                relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pendingTable[i], unwindInfo->iRangeStart))
-            {
-                unwindInfo->pendingTable[i] = unwindInfo->pendingTable[--unwindInfo->cPendingCount];
-                STRESS_LOG1(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removed pending entry 0x%x\n", i);
-                return;
-            }
-        }
-    }
-
     STRESS_LOG2(LF_JIT, LL_WARNING, "RemoveFromUnwindInfoTable COULD NOT FIND %p BaseAddress %p\n",
         entryPoint, baseAddress);
 }

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -295,6 +295,15 @@ void UnwindInfoTable::FlushPendingEntries()
 
     _ASSERTE(s_pUnwindInfoTablePublishLock->OwnedByCurrentThread());
 
+    if (hHandle == NULL)
+    {
+        // If hHandle is null, it means Register() failed. Skip flushing to avoid calling
+        // RtlGrowFunctionTable with a null handle. Avoid copying to the local buffer as
+        // well since it won't be published anyway.
+        cPendingCount = 0;
+        return;
+    }
+
     // Grab the pending entries under the pending lock, then release it so
     // other threads can keep accumulating new entries while we flush.
     T_RUNTIME_FUNCTION localPending[cPendingMaxCount];
@@ -309,13 +318,10 @@ void UnwindInfoTable::FlushPendingEntries()
     if (localPendingCount == 0)
         return;
 
-    // If a previous Register() call failed, hHandle is NULL. Skip OS updates
-    // to avoid calling RtlGrowFunctionTable or re-registering with a null handle.
-    if (hHandle == NULL)
-        return;
-
     // Sort the pending entries by BeginAddress.
     // Use a simple insertion sort since cPendingMaxCount is small (32).
+    static_assert(cPendingMaxCount == 32,
+        "cPendingMaxCount was updated and might be too large for insertion sort, consider using a better algorithm");
     for (ULONG i = 1; i < localPendingCount; i++)
     {
         T_RUNTIME_FUNCTION key = localPending[i];
@@ -351,7 +357,7 @@ void UnwindInfoTable::FlushPendingEntries()
     STRESS_LOG7(LF_JIT, LL_INFO100, "FlushPendingEntries Handle: %p [%p, %p] Merging 0x%x live + 0x%x pending into 0x%x max, from 0x%x\n",
         hHandle, iRangeStart, iRangeEnd, liveCount, localPendingCount, desiredSpace, cTableMaxCount);
 
-    T_RUNTIME_FUNCTION* newPTable = new T_RUNTIME_FUNCTION[desiredSpace];
+    NewArrayHolder<T_RUNTIME_FUNCTION> newPTable(new T_RUNTIME_FUNCTION[desiredSpace]);
 
     // Merge-sort the main table and pending buffer into newPTable.
     ULONG mainIdx = 0;
@@ -392,19 +398,17 @@ void UnwindInfoTable::FlushPendingEntries()
     _ASSERTE(toIdx == newCount);
     _ASSERTE(toIdx <= desiredSpace);
 
-    T_RUNTIME_FUNCTION* oldPTable = pTable;
+    NewArrayHolder<T_RUNTIME_FUNCTION> oldPTable(pTable);
 
     UnRegister();
 
-    pTable = newPTable;
+    pTable = newPTable.Extract();
     cTableCurCount = toIdx;
     cTableMaxCount = desiredSpace;
     cDeletedEntries = 0;
 
     // Note that there is a short time when we are not publishing...
     Register();
-
-    delete[] oldPTable;
 }
 
 /*****************************************************************************/

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -252,17 +252,6 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
     _ASSERTE(unwindInfo->iRangeStart == rangeStart);
     _ASSERTE(unwindInfo->iRangeEnd == rangeEnd);
 
-    // Means we had a failure publishing to the OS, in this case we give up
-    if (unwindInfo->hHandle == NULL)
-     {
-         CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
-         // Re-read the table under the publish lock in case a flush/unregister/register
-         // sequence was in progress when we first inspected hHandle.
-         unwindInfo = *unwindInfoPtr;
-         if (unwindInfo == NULL || unwindInfo->hHandle == NULL)
-             return;
-     }
-
     // Add to the pending buffer. If the buffer is full, flush it first and retry.
     while (true)
     {

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -134,11 +134,19 @@ bool InitUnwindFtns()
 }
 
 /****************************************************************************/
-UnwindInfoTable::UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd, ULONG size)
+UnwindInfoTable::UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd)
 {
     STANDARD_VM_CONTRACT;
     _ASSERTE(s_pUnwindInfoTablePublishLock->OwnedByCurrentThread());
     _ASSERTE((rangeEnd - rangeStart) <= 0x7FFFFFFF);
+
+    // We can choose the average method size estimate dynamically based on past experience
+    // 128 is the estimated size of an average method, so we can accurately predict
+    // how many RUNTIME_FUNCTION entries are in each chunk we allocate.
+    ULONG size = (ULONG) ((rangeEnd - rangeStart) / 128) + 1;
+
+    // To ensure we test the growing logic in debug builds, make the size much smaller.
+    INDEBUG(size = size / 4 + 1);
 
     cTableCurCount = 0;
     cTableMaxCount = size;
@@ -210,9 +218,7 @@ void UnwindInfoTable::UnRegister()
 // Add 'data' to the pending buffer for later publication to the OS.
 // When the buffer is full, entries are flushed under s_pUnwindInfoTablePublishLock.
 //
-/* static */
-void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_RUNTIME_FUNCTION data,
-                                          TADDR rangeStart, TADDR rangeEnd)
+void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data)
 {
     CONTRACTL
     {
@@ -220,55 +226,29 @@ void UnwindInfoTable::AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, PT_R
         GC_TRIGGERS;
     }
     CONTRACTL_END;
-    _ASSERTE(data->BeginAddress <= RUNTIME_FUNCTION__EndAddress(data, rangeStart));
-    _ASSERTE(RUNTIME_FUNCTION__EndAddress(data, rangeStart) <=  (rangeEnd-rangeStart));
-    _ASSERTE(unwindInfoPtr != NULL);
+    _ASSERTE(data->BeginAddress <= RUNTIME_FUNCTION__EndAddress(data, iRangeStart));
+    _ASSERTE(RUNTIME_FUNCTION__EndAddress(data, iRangeStart) <= (iRangeEnd - iRangeStart));
 
     if (!s_publishingActive)
         return;
-
-    UnwindInfoTable* unwindInfo = VolatileLoad(unwindInfoPtr);
-    // was the original list null, If so lazy initialize.
-    if (unwindInfo == NULL)
-    {
-        CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
-        unwindInfo = *unwindInfoPtr;
-        if (unwindInfo == NULL)
-        {
-            // We can choose the average method size estimate dynamically based on past experience
-            // 128 is the estimated size of an average method, so we can accurately predict
-            // how many RUNTIME_FUNCTION entries are in each chunk we allocate.
-
-            ULONG size = (ULONG) ((rangeEnd - rangeStart) / 128) + 1;
-
-            // To ensure we test the growing logic in debug builds, make the size much smaller.
-            INDEBUG(size = size / 4 + 1);
-            unwindInfo = (PTR_UnwindInfoTable)new UnwindInfoTable(rangeStart, rangeEnd, size);
-            unwindInfo->Register();
-            VolatileStore(unwindInfoPtr, unwindInfo);
-        }
-    }
-    _ASSERTE(unwindInfo != NULL);        // If new had failed, we would have thrown OOM
-    _ASSERTE(unwindInfo->iRangeStart == rangeStart);
-    _ASSERTE(unwindInfo->iRangeEnd == rangeEnd);
 
     // Add to the pending buffer. If the buffer is full, flush it first and retry.
     while (true)
     {
         {
             CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
-            if (unwindInfo->cPendingCount < UnwindInfoTable::cPendingMaxCount)
+            if (cPendingCount < cPendingMaxCount)
             {
-                unwindInfo->pPendingTable[unwindInfo->cPendingCount++] = *data;
+                pPendingTable[cPendingCount++] = *data;
 
                 STRESS_LOG5(LF_JIT, LL_INFO1000, "AddToUnwindTable Handle: %p [%p, %p] BUFFERED 0x%x, pending 0x%x\n",
-                    unwindInfo->hHandle, unwindInfo->iRangeStart, unwindInfo->iRangeEnd,
-                    data->BeginAddress, unwindInfo->cPendingCount);
+                    hHandle, iRangeStart, iRangeEnd,
+                    data->BeginAddress, cPendingCount);
                 return;
             }
         }
         CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
-        unwindInfo->FlushPendingEntries();
+        FlushPendingEntries();
     }
 }
 
@@ -464,29 +444,41 @@ void UnwindInfoTable::FlushPendingEntries()
 // Publish the stack unwind data 'data' which is relative 'baseAddress'
 // to the operating system in a way ETW stack tracing can use.
 
-/* static */ void UnwindInfoTable::PublishUnwindInfoForMethod(TADDR baseAddress, PT_RUNTIME_FUNCTION unwindInfo, int unwindInfoCount)
+/* static */ void UnwindInfoTable::PublishUnwindInfoForMethod(TADDR baseAddress, PT_RUNTIME_FUNCTION methodUnwindData, int methodUnwindDataCount)
 {
     STANDARD_VM_CONTRACT;
     if (!s_publishingActive)
         return;
 
-    TADDR entry = baseAddress + unwindInfo->BeginAddress;
+    TADDR entry = baseAddress + methodUnwindData->BeginAddress;
     RangeSection * pRS = ExecutionManager::FindCodeRange(entry, ExecutionManager::GetScanFlags());
     _ASSERTE(pRS != NULL);
     if (pRS != NULL)
     {
-        for(int i = 0; i < unwindInfoCount; i++)
-            AddToUnwindInfoTable(&pRS->_pUnwindInfoTable, &unwindInfo[i], pRS->_range.RangeStart(), pRS->_range.RangeEndOpen());
+        UnwindInfoTable* unwindInfo = VolatileLoad(&pRS->_pUnwindInfoTable);
+        if (unwindInfo == NULL)
+        {
+            CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
+            if (pRS->_pUnwindInfoTable == NULL)
+            {
+                unwindInfo = new UnwindInfoTable(pRS->_range.RangeStart(), pRS->_range.RangeEndOpen());
+                unwindInfo->Register();
+                VolatileStore(&pRS->_pUnwindInfoTable, unwindInfo);
+            }
+            else
+            {
+                unwindInfo = pRS->_pUnwindInfoTable;
+            }
+        }
+
+        for (int i = 0; i < methodUnwindDataCount; i++)
+            unwindInfo->AddToUnwindInfoTable(&methodUnwindData[i]);
 
         // Flush any entries that were buffered above so the OS can unwind this
         // method immediately. Otherwise, we may end up with broken stack traces
         // for recently JITed methods.
         CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
-        UnwindInfoTable* unwindInfoTable = pRS->_pUnwindInfoTable;
-        if (unwindInfoTable != NULL)
-        {
-            unwindInfoTable->FlushPendingEntries();
-        }
+        unwindInfo->FlushPendingEntries();
     }
 }
 
@@ -545,7 +537,7 @@ void UnwindInfoTable::FlushPendingEntries()
 }
 
 #else
-/* static */ void UnwindInfoTable::PublishUnwindInfoForMethod(TADDR baseAddress, T_RUNTIME_FUNCTION* unwindInfo, int unwindInfoCount)
+/* static */ void UnwindInfoTable::PublishUnwindInfoForMethod(TADDR baseAddress, T_RUNTIME_FUNCTION* methodUnwindData, int methodUnwindDataCount)
 {
     LIMITED_METHOD_CONTRACT;
 }

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -395,7 +395,9 @@ void UnwindInfoTable::FlushPendingEntries()
     STRESS_LOG3(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removing %p BaseAddress %p rel %x\n",
         entryPoint, baseAddress, relativeEntryPoint);
 
-    // First check the main (published) table under the publish lock.
+    // Check the main (published) table under the publish lock.
+    // We don't need to check the pending buffer because the method should have already been published
+    // before it can be removed.
     {
         CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
         for (ULONG i = 0; i < unwindInfo->cTableCurCount; i++)

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -483,11 +483,6 @@ void UnwindInfoTable::FlushPendingEntries()
         }
 
         unwindInfo->AddToUnwindInfoTable(methodUnwindData, methodUnwindDataCount);
-
-        // Flush any entries that were buffered above so the OS can unwind this
-        // method immediately. Otherwise, we may end up with broken stack traces
-        // for recently JITed methods.
-        unwindInfo->FlushPendingEntries();
     }
 }
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -361,7 +361,7 @@ void UnwindInfoTable::FlushPendingEntries()
     _ASSERTE(toIdx == newCount);
     _ASSERTE(toIdx <= desiredSpace);
 
-    NewArrayHolder<T_RUNTIME_FUNCTION> oldPTable(pTable);
+    oldPTable = pTable;
 
     UnRegister();
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -178,7 +178,6 @@ void UnwindInfoTable::Register()
 {
     _ASSERTE(s_pUnwindInfoTablePublishLock->OwnedByCurrentThread());
 
-    hHandle = NULL;
     NTSTATUS ret = pRtlAddGrowableFunctionTable(&hHandle, pTable, cTableCurCount, cTableMaxCount, iRangeStart, iRangeEnd);
     if (ret != STATUS_SUCCESS)
     {
@@ -362,6 +361,14 @@ void UnwindInfoTable::FlushPendingEntries()
     _ASSERTE(toIdx <= desiredSpace);
 
     oldPTable = pTable;
+
+    // The OS growable function table API (RtlGrowFunctionTable) only supports
+    // appending sorted entries, it cannot shrink, reorder, or remove entries.
+    // We have to tear down the old OS registration and create a new one
+    // combining the old and pending entries while skipping the deleted ones.
+    // We should keep the gap between UnRegister and Register as short as possible,
+    // as OS stack walks will have no unwind info for this range during that
+    // window. The new table is fully built before UnRegister to minimize this gap.
 
     UnRegister();
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -247,10 +247,9 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
                 i++;
             }
         }
-        if (i < count)
-        {
-            FlushPendingEntries();
-        }
+        // Flush any pending entries if we run out of space, or when we are at the end
+        // of the batch so the OS can unwind this method immediately.
+        FlushPendingEntries();
     }
 }
 

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -289,6 +289,7 @@ void UnwindInfoTable::FlushPendingEntries()
         // If hHandle is null, it means Register() failed. Skip flushing to avoid calling
         // RtlGrowFunctionTable with a null handle. Avoid copying to the local buffer as
         // well since it won't be published anyway.
+        CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
         cPendingCount = 0;
         return;
     }

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -177,29 +177,19 @@ UnwindInfoTable::~UnwindInfoTable()
 void UnwindInfoTable::Register()
 {
     _ASSERTE(s_pUnwindInfoTablePublishLock->OwnedByCurrentThread());
-    EX_TRY
+
+    hHandle = NULL;
+    NTSTATUS ret = pRtlAddGrowableFunctionTable(&hHandle, pTable, cTableCurCount, cTableMaxCount, iRangeStart, iRangeEnd);
+    if (ret != STATUS_SUCCESS)
     {
-        hHandle = NULL;
-        NTSTATUS ret = pRtlAddGrowableFunctionTable(&hHandle, pTable, cTableCurCount, cTableMaxCount, iRangeStart, iRangeEnd);
-        if (ret != STATUS_SUCCESS)
-        {
-            _ASSERTE(!"Failed to publish UnwindInfo (ignorable)");
-            hHandle = NULL;
-            STRESS_LOG3(LF_JIT, LL_ERROR, "UnwindInfoTable::Register ERROR %x creating table [%p, %p]\n", ret, iRangeStart, iRangeEnd);
-        }
-        else
-        {
-            STRESS_LOG3(LF_JIT, LL_INFO100, "UnwindInfoTable::Register Handle: %p [%p, %p]\n", hHandle, iRangeStart, iRangeEnd);
-        }
-    }
-    EX_CATCH
-    {
-        hHandle = NULL;
-        STRESS_LOG2(LF_JIT, LL_ERROR, "UnwindInfoTable::Register Exception while creating table [%p, %p]\n",
-            iRangeStart, iRangeEnd);
         _ASSERTE(!"Failed to publish UnwindInfo (ignorable)");
+        hHandle = NULL;
+        STRESS_LOG3(LF_JIT, LL_ERROR, "UnwindInfoTable::Register ERROR %x creating table [%p, %p]\n", ret, iRangeStart, iRangeEnd);
     }
-    EX_END_CATCH
+    else
+    {
+        STRESS_LOG3(LF_JIT, LL_INFO100, "UnwindInfoTable::Register Handle: %p [%p, %p]\n", hHandle, iRangeStart, iRangeEnd);
+    }
 }
 
 /*****************************************************************************/
@@ -227,8 +217,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
     }
     CONTRACTL_END;
 
-    if (!s_publishingActive)
-        return;
+    _ASSERTE(s_publishingActive);
 
     for (int i = 0; i < count; )
     {
@@ -239,7 +228,7 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
                 _ASSERTE(data[i].BeginAddress <= RUNTIME_FUNCTION__EndAddress(&data[i], iRangeStart));
                 _ASSERTE(RUNTIME_FUNCTION__EndAddress(&data[i], iRangeStart) <= (iRangeEnd - iRangeStart));
 
-                pPendingTable[cPendingCount++] = data[i];
+                pendingTable[cPendingCount++] = data[i];
 
                 STRESS_LOG5(LF_JIT, LL_INFO1000, "AddToUnwindTable Handle: %p [%p, %p] BUFFERED 0x%x, pending 0x%x\n",
                     hHandle, iRangeStart, iRangeEnd,
@@ -284,8 +273,9 @@ void UnwindInfoTable::FlushPendingEntries()
     {
         CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
         localPendingCount = cPendingCount;
-        memcpy(localPending, pPendingTable, cPendingCount * sizeof(T_RUNTIME_FUNCTION));
+        memcpy(localPending, pendingTable, cPendingCount * sizeof(T_RUNTIME_FUNCTION));
         cPendingCount = 0;
+        INDEBUG( memset(pendingTable, 0xcc, sizeof(pendingTable)); )
     }
 
     if (localPendingCount == 0)
@@ -307,7 +297,9 @@ void UnwindInfoTable::FlushPendingEntries()
         localPending[j] = key;
     }
 
-    T_RUNTIME_FUNCTION* oldPTable = NULL;
+    // delete tables outside the publish lock — can be expensive for large allocations across threads.
+    NewArrayHolder<T_RUNTIME_FUNCTION> oldPTable;
+    NewArrayHolder<T_RUNTIME_FUNCTION> newPTable;
     {
         CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
 
@@ -334,7 +326,7 @@ void UnwindInfoTable::FlushPendingEntries()
         STRESS_LOG7(LF_JIT, LL_INFO100, "FlushPendingEntries Handle: %p [%p, %p] Merging 0x%x live + 0x%x pending into 0x%x max, from 0x%x\n",
             hHandle, iRangeStart, iRangeEnd, liveCount, localPendingCount, desiredSpace, cTableMaxCount);
 
-        NewArrayHolder<T_RUNTIME_FUNCTION> newPTable(new T_RUNTIME_FUNCTION[desiredSpace]);
+        newPTable = new T_RUNTIME_FUNCTION[desiredSpace];
 
         // Merge-sort the main table and pending buffer into newPTable.
         ULONG mainIdx = 0;
@@ -387,9 +379,6 @@ void UnwindInfoTable::FlushPendingEntries()
         // Note that there is a short time when we are not publishing...
         Register();
     }
-
-    // delete[] outside the publish lock — can be expensive for large allocations across threads.
-    delete[] oldPTable;
 }
 
 /*****************************************************************************/
@@ -437,10 +426,10 @@ void UnwindInfoTable::FlushPendingEntries()
         CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
         for (ULONG i = 0; i < unwindInfo->cPendingCount; i++)
         {
-            if (unwindInfo->pPendingTable[i].BeginAddress <= relativeEntryPoint &&
-                relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pPendingTable[i], unwindInfo->iRangeStart))
+            if (unwindInfo->pendingTable[i].BeginAddress <= relativeEntryPoint &&
+                relativeEntryPoint < RUNTIME_FUNCTION__EndAddress(&unwindInfo->pendingTable[i], unwindInfo->iRangeStart))
             {
-                unwindInfo->pPendingTable[i] = unwindInfo->pPendingTable[--unwindInfo->cPendingCount];
+                unwindInfo->pendingTable[i] = unwindInfo->pendingTable[--unwindInfo->cPendingCount];
                 STRESS_LOG1(LF_JIT, LL_INFO100, "RemoveFromUnwindInfoTable Removed pending entry 0x%x\n", i);
                 return;
             }
@@ -464,26 +453,24 @@ void UnwindInfoTable::FlushPendingEntries()
     TADDR entry = baseAddress + methodUnwindData->BeginAddress;
     RangeSection * pRS = ExecutionManager::FindCodeRange(entry, ExecutionManager::GetScanFlags());
     _ASSERTE(pRS != NULL);
-    if (pRS != NULL)
-    {
-        UnwindInfoTable* unwindInfo = VolatileLoad(&pRS->_pUnwindInfoTable);
-        if (unwindInfo == NULL)
-        {
-            CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
-            if (pRS->_pUnwindInfoTable == NULL)
-            {
-                unwindInfo = new UnwindInfoTable(pRS->_range.RangeStart(), pRS->_range.RangeEndOpen());
-                unwindInfo->Register();
-                VolatileStore(&pRS->_pUnwindInfoTable, unwindInfo);
-            }
-            else
-            {
-                unwindInfo = pRS->_pUnwindInfoTable;
-            }
-        }
 
-        unwindInfo->AddToUnwindInfoTable(methodUnwindData, methodUnwindDataCount);
+    UnwindInfoTable* unwindInfo = VolatileLoad(&pRS->_pUnwindInfoTable);
+    if (unwindInfo == NULL)
+    {
+        CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
+        if (pRS->_pUnwindInfoTable == NULL)
+        {
+            unwindInfo = new UnwindInfoTable(pRS->_range.RangeStart(), pRS->_range.RangeEndOpen());
+            unwindInfo->Register();
+            VolatileStore(&pRS->_pUnwindInfoTable, unwindInfo);
+        }
+        else
+        {
+            unwindInfo = pRS->_pUnwindInfoTable;
+        }
     }
+
+    unwindInfo->AddToUnwindInfoTable(methodUnwindData, methodUnwindDataCount);
 }
 
 /*****************************************************************************/

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -249,7 +249,6 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
         }
         if (i < count)
         {
-            CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
             FlushPendingEntries();
         }
     }
@@ -265,16 +264,18 @@ void UnwindInfoTable::FlushPendingEntries()
     }
     CONTRACTL_END;
 
-    _ASSERTE(s_pUnwindInfoTablePublishLock->OwnedByCurrentThread());
-
-    if (hHandle == NULL)
     {
-        // If hHandle is null, it means Register() failed. Skip flushing to avoid calling
-        // RtlGrowFunctionTable with a null handle. Avoid copying to the local buffer as
-        // well since it won't be published anyway.
-        CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
-        cPendingCount = 0;
-        return;
+        CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
+
+        if (hHandle == NULL)
+        {
+            // If hHandle is null, it means Register() failed. Skip flushing to avoid calling
+            // RtlGrowFunctionTable with a null handle. Avoid copying to the local buffer as
+            // well since it won't be published anyway.
+            CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
+            cPendingCount = 0;
+            return;
+        }
     }
 
     // Grab the pending entries under the pending lock, then release it so
@@ -307,81 +308,89 @@ void UnwindInfoTable::FlushPendingEntries()
         localPending[j] = key;
     }
 
-    // Fast path: if all pending entries can be appended in order with room to spare,
-    // we can just append and call RtlGrowFunctionTable.
-    if (cTableCurCount + localPendingCount <= cTableMaxCount
-        && (cTableCurCount == 0 || pTable[cTableCurCount - 1].BeginAddress < localPending[0].BeginAddress))
+    T_RUNTIME_FUNCTION* oldPTable = NULL;
     {
-        memcpy(&pTable[cTableCurCount], localPending, localPendingCount * sizeof(T_RUNTIME_FUNCTION));
-        cTableCurCount += localPendingCount;
-        pRtlGrowFunctionTable(hHandle, cTableCurCount);
+        CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
 
-        STRESS_LOG5(LF_JIT, LL_INFO1000, "FlushPendingEntries Handle: %p [%p, %p] APPENDED 0x%x entries, now 0x%x\n",
-            hHandle, iRangeStart, iRangeEnd, localPendingCount, cTableCurCount);
-        return;
-    }
-
-    // Merge main table and pending entries.
-    // Calculate the new table size: live entries from main table + all pending entries
-    ULONG liveCount = cTableCurCount - cDeletedEntries;
-    ULONG newCount = liveCount + localPendingCount;
-    ULONG desiredSpace = newCount * 5 / 4 + 1;  // Increase by 20%
-
-    STRESS_LOG7(LF_JIT, LL_INFO100, "FlushPendingEntries Handle: %p [%p, %p] Merging 0x%x live + 0x%x pending into 0x%x max, from 0x%x\n",
-        hHandle, iRangeStart, iRangeEnd, liveCount, localPendingCount, desiredSpace, cTableMaxCount);
-
-    NewArrayHolder<T_RUNTIME_FUNCTION> newPTable(new T_RUNTIME_FUNCTION[desiredSpace]);
-
-    // Merge-sort the main table and pending buffer into newPTable.
-    ULONG mainIdx = 0;
-    ULONG pendIdx = 0;
-    ULONG toIdx = 0;
-
-    while (mainIdx < cTableCurCount && pendIdx < localPendingCount)
-    {
-        // Skip deleted entries in main table
-        if (pTable[mainIdx].UnwindData == 0)
+        // Fast path: if all pending entries can be appended in order with room to spare,
+        // we can just append and call RtlGrowFunctionTable.
+        if (cTableCurCount + localPendingCount <= cTableMaxCount
+            && (cTableCurCount == 0 || pTable[cTableCurCount - 1].BeginAddress < localPending[0].BeginAddress))
         {
-            mainIdx++;
-            continue;
+            memcpy(&pTable[cTableCurCount], localPending, localPendingCount * sizeof(T_RUNTIME_FUNCTION));
+            cTableCurCount += localPendingCount;
+            pRtlGrowFunctionTable(hHandle, cTableCurCount);
+
+            STRESS_LOG5(LF_JIT, LL_INFO1000, "FlushPendingEntries Handle: %p [%p, %p] APPENDED 0x%x entries, now 0x%x\n",
+                hHandle, iRangeStart, iRangeEnd, localPendingCount, cTableCurCount);
+            return;
         }
 
-        if (localPending[pendIdx].BeginAddress < pTable[mainIdx].BeginAddress)
+        // Merge main table and pending entries.
+        // Calculate the new table size: live entries from main table + all pending entries
+        ULONG liveCount = cTableCurCount - cDeletedEntries;
+        ULONG newCount = liveCount + localPendingCount;
+        ULONG desiredSpace = newCount * 5 / 4 + 1;  // Increase by 20%
+
+        STRESS_LOG7(LF_JIT, LL_INFO100, "FlushPendingEntries Handle: %p [%p, %p] Merging 0x%x live + 0x%x pending into 0x%x max, from 0x%x\n",
+            hHandle, iRangeStart, iRangeEnd, liveCount, localPendingCount, desiredSpace, cTableMaxCount);
+
+        NewArrayHolder<T_RUNTIME_FUNCTION> newPTable(new T_RUNTIME_FUNCTION[desiredSpace]);
+
+        // Merge-sort the main table and pending buffer into newPTable.
+        ULONG mainIdx = 0;
+        ULONG pendIdx = 0;
+        ULONG toIdx = 0;
+
+        while (mainIdx < cTableCurCount && pendIdx < localPendingCount)
+        {
+            // Skip deleted entries in main table
+            if (pTable[mainIdx].UnwindData == 0)
+            {
+                mainIdx++;
+                continue;
+            }
+
+            if (localPending[pendIdx].BeginAddress < pTable[mainIdx].BeginAddress)
+            {
+                newPTable[toIdx++] = localPending[pendIdx++];
+            }
+            else
+            {
+                newPTable[toIdx++] = pTable[mainIdx++];
+            }
+        }
+
+        while (mainIdx < cTableCurCount)
+        {
+            if (pTable[mainIdx].UnwindData != 0)
+                newPTable[toIdx++] = pTable[mainIdx];
+            mainIdx++;
+        }
+
+        while (pendIdx < localPendingCount)
         {
             newPTable[toIdx++] = localPending[pendIdx++];
         }
-        else
-        {
-            newPTable[toIdx++] = pTable[mainIdx++];
-        }
+
+        _ASSERTE(toIdx == newCount);
+        _ASSERTE(toIdx <= desiredSpace);
+
+        oldPTable = pTable;
+
+        UnRegister();
+
+        pTable = newPTable.Extract();
+        cTableCurCount = toIdx;
+        cTableMaxCount = desiredSpace;
+        cDeletedEntries = 0;
+
+        // Note that there is a short time when we are not publishing...
+        Register();
     }
 
-    while (mainIdx < cTableCurCount)
-    {
-        if (pTable[mainIdx].UnwindData != 0)
-            newPTable[toIdx++] = pTable[mainIdx];
-        mainIdx++;
-    }
-
-    while (pendIdx < localPendingCount)
-    {
-        newPTable[toIdx++] = localPending[pendIdx++];
-    }
-
-    _ASSERTE(toIdx == newCount);
-    _ASSERTE(toIdx <= desiredSpace);
-
-    NewArrayHolder<T_RUNTIME_FUNCTION> oldPTable(pTable);
-
-    UnRegister();
-
-    pTable = newPTable.Extract();
-    cTableCurCount = toIdx;
-    cTableMaxCount = desiredSpace;
-    cDeletedEntries = 0;
-
-    // Note that there is a short time when we are not publishing...
-    Register();
+    // delete[] outside the publish lock — can be expensive for large allocations across threads.
+    delete[] oldPTable;
 }
 
 /*****************************************************************************/
@@ -479,7 +488,6 @@ void UnwindInfoTable::FlushPendingEntries()
         // Flush any entries that were buffered above so the OS can unwind this
         // method immediately. Otherwise, we may end up with broken stack traces
         // for recently JITed methods.
-        CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
         unwindInfo->FlushPendingEntries();
     }
 }

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -215,10 +215,10 @@ void UnwindInfoTable::UnRegister()
 }
 
 /*****************************************************************************/
-// Add 'data' to the pending buffer for later publication to the OS.
+// Add 'data' entries to the pending buffer for later publication to the OS.
 // When the buffer is full, entries are flushed under s_pUnwindInfoTablePublishLock.
 //
-void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data)
+void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data, int count)
 {
     CONTRACTL
     {
@@ -226,29 +226,32 @@ void UnwindInfoTable::AddToUnwindInfoTable(PT_RUNTIME_FUNCTION data)
         GC_TRIGGERS;
     }
     CONTRACTL_END;
-    _ASSERTE(data->BeginAddress <= RUNTIME_FUNCTION__EndAddress(data, iRangeStart));
-    _ASSERTE(RUNTIME_FUNCTION__EndAddress(data, iRangeStart) <= (iRangeEnd - iRangeStart));
 
     if (!s_publishingActive)
         return;
 
-    // Add to the pending buffer. If the buffer is full, flush it first and retry.
-    while (true)
+    for (int i = 0; i < count; )
     {
         {
             CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
-            if (cPendingCount < cPendingMaxCount)
+            while (i < count && cPendingCount < cPendingMaxCount)
             {
-                pPendingTable[cPendingCount++] = *data;
+                _ASSERTE(data[i].BeginAddress <= RUNTIME_FUNCTION__EndAddress(&data[i], iRangeStart));
+                _ASSERTE(RUNTIME_FUNCTION__EndAddress(&data[i], iRangeStart) <= (iRangeEnd - iRangeStart));
+
+                pPendingTable[cPendingCount++] = data[i];
 
                 STRESS_LOG5(LF_JIT, LL_INFO1000, "AddToUnwindTable Handle: %p [%p, %p] BUFFERED 0x%x, pending 0x%x\n",
                     hHandle, iRangeStart, iRangeEnd,
-                    data->BeginAddress, cPendingCount);
-                return;
+                    data[i].BeginAddress, cPendingCount);
+                i++;
             }
         }
-        CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
-        FlushPendingEntries();
+        if (i < count)
+        {
+            CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
+            FlushPendingEntries();
+        }
     }
 }
 
@@ -471,8 +474,7 @@ void UnwindInfoTable::FlushPendingEntries()
             }
         }
 
-        for (int i = 0; i < methodUnwindDataCount; i++)
-            unwindInfo->AddToUnwindInfoTable(&methodUnwindData[i]);
+        unwindInfo->AddToUnwindInfoTable(methodUnwindData, methodUnwindDataCount);
 
         // Flush any entries that were buffered above so the OS can unwind this
         // method immediately. Otherwise, we may end up with broken stack traces

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -252,22 +252,19 @@ void UnwindInfoTable::FlushPendingEntries()
     }
     CONTRACTL_END;
 
-    {
-        CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
+    CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
 
-        if (hHandle == NULL)
-        {
-            // If hHandle is null, it means Register() failed. Skip flushing to avoid calling
-            // RtlGrowFunctionTable with a null handle. Avoid copying to the local buffer as
-            // well since it won't be published anyway.
-            CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
-            cPendingCount = 0;
-            return;
-        }
+    if (hHandle == NULL)
+    {
+        // If hHandle is null, it means Register() failed. Skip flushing to avoid calling
+        // RtlGrowFunctionTable with a null handle.
+        CrstHolder pendingLock(s_pUnwindInfoTablePendingLock);
+        cPendingCount = 0;
+        return;
     }
 
     // Grab the pending entries under the pending lock, then release it so
-    // other threads can keep accumulating new entries while we flush.
+    // other threads can keep accumulating new entries while we publish.
     T_RUNTIME_FUNCTION localPending[cPendingMaxCount];
     ULONG localPendingCount;
     {
@@ -297,88 +294,80 @@ void UnwindInfoTable::FlushPendingEntries()
         localPending[j] = key;
     }
 
-    // delete tables outside the publish lock — can be expensive for large allocations across threads.
-    NewArrayHolder<T_RUNTIME_FUNCTION> oldPTable;
-    NewArrayHolder<T_RUNTIME_FUNCTION> newPTable;
+    // Fast path: if all pending entries can be appended in order with room to spare,
+    // we can just append and call RtlGrowFunctionTable.
+    if (cTableCurCount + localPendingCount <= cTableMaxCount
+        && (cTableCurCount == 0 || pTable[cTableCurCount - 1].BeginAddress < localPending[0].BeginAddress))
     {
-        CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
+        memcpy(&pTable[cTableCurCount], localPending, localPendingCount * sizeof(T_RUNTIME_FUNCTION));
+        cTableCurCount += localPendingCount;
+        pRtlGrowFunctionTable(hHandle, cTableCurCount);
 
-        // Fast path: if all pending entries can be appended in order with room to spare,
-        // we can just append and call RtlGrowFunctionTable.
-        if (cTableCurCount + localPendingCount <= cTableMaxCount
-            && (cTableCurCount == 0 || pTable[cTableCurCount - 1].BeginAddress < localPending[0].BeginAddress))
+        STRESS_LOG5(LF_JIT, LL_INFO1000, "FlushPendingEntries Handle: %p [%p, %p] APPENDED 0x%x entries, now 0x%x\n",
+            hHandle, iRangeStart, iRangeEnd, localPendingCount, cTableCurCount);
+        return;
+    }
+
+    // Merge main table and pending entries.
+    // Calculate the new table size: live entries from main table + all pending entries
+    ULONG liveCount = cTableCurCount - cDeletedEntries;
+    ULONG newCount = liveCount + localPendingCount;
+    ULONG desiredSpace = newCount * 5 / 4 + 1;  // Increase by 20%
+
+    STRESS_LOG7(LF_JIT, LL_INFO100, "FlushPendingEntries Handle: %p [%p, %p] Merging 0x%x live + 0x%x pending into 0x%x max, from 0x%x\n",
+        hHandle, iRangeStart, iRangeEnd, liveCount, localPendingCount, desiredSpace, cTableMaxCount);
+
+    NewArrayHolder<T_RUNTIME_FUNCTION> newPTable(new T_RUNTIME_FUNCTION[desiredSpace]);
+
+    // Merge-sort the main table and pending buffer into newPTable.
+    ULONG mainIdx = 0;
+    ULONG pendIdx = 0;
+    ULONG toIdx = 0;
+
+    while (mainIdx < cTableCurCount && pendIdx < localPendingCount)
+    {
+        // Skip deleted entries in main table
+        if (pTable[mainIdx].UnwindData == 0)
         {
-            memcpy(&pTable[cTableCurCount], localPending, localPendingCount * sizeof(T_RUNTIME_FUNCTION));
-            cTableCurCount += localPendingCount;
-            pRtlGrowFunctionTable(hHandle, cTableCurCount);
-
-            STRESS_LOG5(LF_JIT, LL_INFO1000, "FlushPendingEntries Handle: %p [%p, %p] APPENDED 0x%x entries, now 0x%x\n",
-                hHandle, iRangeStart, iRangeEnd, localPendingCount, cTableCurCount);
-            return;
-        }
-
-        // Merge main table and pending entries.
-        // Calculate the new table size: live entries from main table + all pending entries
-        ULONG liveCount = cTableCurCount - cDeletedEntries;
-        ULONG newCount = liveCount + localPendingCount;
-        ULONG desiredSpace = newCount * 5 / 4 + 1;  // Increase by 20%
-
-        STRESS_LOG7(LF_JIT, LL_INFO100, "FlushPendingEntries Handle: %p [%p, %p] Merging 0x%x live + 0x%x pending into 0x%x max, from 0x%x\n",
-            hHandle, iRangeStart, iRangeEnd, liveCount, localPendingCount, desiredSpace, cTableMaxCount);
-
-        newPTable = new T_RUNTIME_FUNCTION[desiredSpace];
-
-        // Merge-sort the main table and pending buffer into newPTable.
-        ULONG mainIdx = 0;
-        ULONG pendIdx = 0;
-        ULONG toIdx = 0;
-
-        while (mainIdx < cTableCurCount && pendIdx < localPendingCount)
-        {
-            // Skip deleted entries in main table
-            if (pTable[mainIdx].UnwindData == 0)
-            {
-                mainIdx++;
-                continue;
-            }
-
-            if (localPending[pendIdx].BeginAddress < pTable[mainIdx].BeginAddress)
-            {
-                newPTable[toIdx++] = localPending[pendIdx++];
-            }
-            else
-            {
-                newPTable[toIdx++] = pTable[mainIdx++];
-            }
-        }
-
-        while (mainIdx < cTableCurCount)
-        {
-            if (pTable[mainIdx].UnwindData != 0)
-                newPTable[toIdx++] = pTable[mainIdx];
             mainIdx++;
+            continue;
         }
 
-        while (pendIdx < localPendingCount)
+        if (localPending[pendIdx].BeginAddress < pTable[mainIdx].BeginAddress)
         {
             newPTable[toIdx++] = localPending[pendIdx++];
         }
-
-        _ASSERTE(toIdx == newCount);
-        _ASSERTE(toIdx <= desiredSpace);
-
-        oldPTable = pTable;
-
-        UnRegister();
-
-        pTable = newPTable.Extract();
-        cTableCurCount = toIdx;
-        cTableMaxCount = desiredSpace;
-        cDeletedEntries = 0;
-
-        // Note that there is a short time when we are not publishing...
-        Register();
+        else
+        {
+            newPTable[toIdx++] = pTable[mainIdx++];
+        }
     }
+
+    while (mainIdx < cTableCurCount)
+    {
+        if (pTable[mainIdx].UnwindData != 0)
+            newPTable[toIdx++] = pTable[mainIdx];
+        mainIdx++;
+    }
+
+    while (pendIdx < localPendingCount)
+    {
+        newPTable[toIdx++] = localPending[pendIdx++];
+    }
+
+    _ASSERTE(toIdx == newCount);
+    _ASSERTE(toIdx <= desiredSpace);
+
+    NewArrayHolder<T_RUNTIME_FUNCTION> oldPTable(pTable);
+
+    UnRegister();
+
+    pTable = newPTable.Extract();
+    cTableCurCount = toIdx;
+    cTableMaxCount = desiredSpace;
+    cDeletedEntries = 0;
+
+    Register();
 }
 
 /*****************************************************************************/

--- a/src/coreclr/vm/codeman.cpp
+++ b/src/coreclr/vm/codeman.cpp
@@ -252,6 +252,9 @@ void UnwindInfoTable::FlushPendingEntries()
     }
     CONTRACTL_END;
 
+    // Free the old table outside the lock
+    NewArrayHolder<T_RUNTIME_FUNCTION> oldPTable;
+
     CrstHolder publishLock(s_pUnwindInfoTablePublishLock);
 
     if (hHandle == NULL)

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -627,7 +627,6 @@ private:
     ULONG               cTableCurCount;
     ULONG               cTableMaxCount;
     int                 cDeletedEntries;    // Number of slots we removed.
-    bool                bRegistrationFailed; // Set once if initial OS registration failed; never cleared.
 
     // Pending buffer for out-of-order entries that haven't been published to the OS yet.
     // These entries are accumulated and batch-merged into pTable to amortize the cost of

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -627,6 +627,7 @@ private:
     ULONG               cTableCurCount;
     ULONG               cTableMaxCount;
     int                 cDeletedEntries;    // Number of slots we removed.
+    bool                bRegistrationFailed; // Set once if initial OS registration failed; never cleared.
 
     // Pending buffer for out-of-order entries that haven't been published to the OS yet.
     // These entries are accumulated and batch-merged into pTable to amortize the cost of

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -631,9 +631,9 @@ private:
     // Pending buffer for out-of-order entries that haven't been published to the OS yet.
     // These entries are accumulated and batch-merged into pTable to amortize the cost of
     // RtlDeleteGrowableFunctionTable + RtlAddGrowableFunctionTable.
-    T_RUNTIME_FUNCTION* pPendingTable;
-    ULONG               cPendingCount;
     static const ULONG  cPendingMaxCount = 32;
+    T_RUNTIME_FUNCTION  pPendingTable[cPendingMaxCount];
+    ULONG               cPendingCount;
 #endif // defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
 };
 

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -618,6 +618,8 @@ private:
     UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd, ULONG size);
 
 private:
+    void FlushPendingEntries();
+
     PVOID               hHandle;          // OS handle for a published RUNTIME_FUNCTION table
     ULONG_PTR           iRangeStart;      // Start of memory described by this table
     ULONG_PTR           iRangeEnd;        // End of memory described by this table
@@ -625,6 +627,13 @@ private:
     ULONG               cTableCurCount;
     ULONG               cTableMaxCount;
     int                 cDeletedEntries;    // Number of slots we removed.
+
+    // Pending buffer for out-of-order entries that haven't been published to the OS yet.
+    // These entries are accumulated and batch-merged into pTable to amortize the cost of
+    // RtlDeleteGrowableFunctionTable + RtlAddGrowableFunctionTable.
+    T_RUNTIME_FUNCTION* pPendingTable;
+    ULONG               cPendingCount;
+    static const ULONG  cPendingMaxCount = 32;
 #endif // defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
 };
 

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -606,7 +606,7 @@ public:
 private:
     // These are lower level functions that assume you have found the list of UnwindInfoTable entries
     // These are used by the high-level method functions above
-    void AddToUnwindInfoTable(T_RUNTIME_FUNCTION* data);
+    void AddToUnwindInfoTable(T_RUNTIME_FUNCTION* data, int count);
     static void RemoveFromUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, TADDR baseAddress, TADDR entryPoint);
 
 public:

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -597,7 +597,7 @@ public:
     // All public functions are thread-safe.
 
     // These are wrapper functions over the UnwindInfoTable functions that are specific to JIT compile code
-    static void PublishUnwindInfoForMethod(TADDR baseAddress, T_RUNTIME_FUNCTION* unwindInfo, int unwindInfoCount);
+    static void PublishUnwindInfoForMethod(TADDR baseAddress, T_RUNTIME_FUNCTION* methodUnwindData, int methodUnwindDataCount);
     static void UnpublishUnwindInfoForMethod(TADDR entryPoint);
 
     static void Initialize();
@@ -606,7 +606,7 @@ public:
 private:
     // These are lower level functions that assume you have found the list of UnwindInfoTable entries
     // These are used by the high-level method functions above
-    static void AddToUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, T_RUNTIME_FUNCTION* data, TADDR rangeStart, TADDR rangeEnd);
+    void AddToUnwindInfoTable(T_RUNTIME_FUNCTION* data);
     static void RemoveFromUnwindInfoTable(UnwindInfoTable** unwindInfoPtr, TADDR baseAddress, TADDR entryPoint);
 
 public:
@@ -615,7 +615,7 @@ public:
 private:
     void UnRegister();
     void Register();
-    UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd, ULONG size);
+    UnwindInfoTable(ULONG_PTR rangeStart, ULONG_PTR rangeEnd);
 
 private:
     void FlushPendingEntries();

--- a/src/coreclr/vm/codeman.h
+++ b/src/coreclr/vm/codeman.h
@@ -632,7 +632,7 @@ private:
     // These entries are accumulated and batch-merged into pTable to amortize the cost of
     // RtlDeleteGrowableFunctionTable + RtlAddGrowableFunctionTable.
     static const ULONG  cPendingMaxCount = 32;
-    T_RUNTIME_FUNCTION  pPendingTable[cPendingMaxCount];
+    T_RUNTIME_FUNCTION  pendingTable[cPendingMaxCount];
     ULONG               cPendingCount;
 #endif // defined(TARGET_AMD64) && defined(TARGET_WINDOWS)
 };


### PR DESCRIPTION
Place the entries of UnwindInfoTable in a buffer and flush such that we amortize the cost of the operations (pRtlAddGrowableFunctionTable + pRtlDeleteGrowableFunctionTable) to create the internal table of `RUNTIME_FUNCTION`s.

Contributes to https://github.com/dotnet/runtime/issues/123124.