### PR TITLE
Fix wasm Playwright TargetClosedException caused by wrong Helix queue

### DIFF
--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -86,7 +86,7 @@ jobs:
 
     # Android
     # Use the Ubuntu-based Android queue for x86/x64/bionic_x64 on all projects,
-    # and also for arm/arm64/bionic_arm/bionic_arm64 on internal (no internal Windows Android queue).
+    # and also for arm/arm64/bionic_arm/bionic_arm64 on non-public projects (no internal Windows Android queue).
     - ${{ if in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64') }}:
       - Ubuntu.2204.Amd64.Android.29.Open
     - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64')) }}:

--- a/eng/pipelines/libraries/helix-queues-setup.yml
+++ b/eng/pipelines/libraries/helix-queues-setup.yml
@@ -85,9 +85,11 @@ jobs:
       - $(helix_macos_x64)
 
     # Android
-    # Always use the Ubuntu-based Android queue for internal validation as there is no internal equivalent of
-    # the Windows.11.Amd64.Android.Open queue.
-    - ${{ if or(eq(variables['System.TeamProject'], 'internal'), in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64')) }}:
+    # Use the Ubuntu-based Android queue for x86/x64/bionic_x64 on all projects,
+    # and also for arm/arm64/bionic_arm/bionic_arm64 on internal (no internal Windows Android queue).
+    - ${{ if in(parameters.platform, 'android_x86', 'android_x64', 'linux_bionic_x64') }}:
+      - Ubuntu.2204.Amd64.Android.29.Open
+    - ${{ if and(ne(variables['System.TeamProject'], 'public'), in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64')) }}:
       - Ubuntu.2204.Amd64.Android.29.Open
     - ${{ if and(eq(variables['System.TeamProject'], 'public'), in(parameters.platform, 'android_arm', 'android_arm64', 'linux_bionic_arm', 'linux_bionic_arm64')) }}:
       - Windows.11.Amd64.Android.Open

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -156,7 +156,7 @@ internal class BrowserRunner : IAsyncDisposable
             }
         }
         if (attempt == maxRetries)
-            throw new Exception($"Failed to launch browser after {maxRetries} attempts", lastException);
+            throw new InvalidOperationException($"Failed to launch browser after {maxRetries} attempts", lastException);
         return Browser!;
     }
 

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -164,9 +164,11 @@ internal class BrowserRunner : IAsyncDisposable
         return Browser!;
     }
 
+    private static bool s_browserDependenciesChecked;
+
     private void CheckBrowserDependencies(string chromePath)
     {
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        if (s_browserDependenciesChecked || !RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             return;
 
         string output;
@@ -188,7 +190,10 @@ internal class BrowserRunner : IAsyncDisposable
 
             if (!process.WaitForExit(10_000))
             {
-                try { process.Kill(); } catch { }
+                try { process.Kill(); process.WaitForExit(1_000); } catch { }
+                // Observe the async read tasks to avoid unobserved exceptions
+                try { stdoutTask.GetAwaiter().GetResult(); } catch { }
+                try { stderrTask.GetAwaiter().GetResult(); } catch { }
                 _testOutput.WriteLine("Could not check browser dependencies: ldd timed out");
                 return;
             }
@@ -222,6 +227,8 @@ internal class BrowserRunner : IAsyncDisposable
             _testOutput.WriteLine($"WARNING: {message}");
             throw new Exception(message);
         }
+
+        s_browserDependenciesChecked = true;
     }
 
     // FIXME: options
@@ -241,12 +248,14 @@ internal class BrowserRunner : IAsyncDisposable
         // intermittent Chrome crashes in Docker containers under memory pressure.
         // Chrome can silently die (OOM killed) during navigation when concurrent
         // test classes run wasm-opt builds alongside browser tests.
-        const int maxSessionRetries = 3;
+        const int maxSessionRetries = 2;
         for (int attempt = 0; ; attempt++)
         {
             try
             {
-                var browser = await SpawnBrowserAsync(urlString, headless, locale: locale);
+                // On retries, only try launching once since SpawnBrowserAsync has its own retry loop
+                int launchRetries = attempt == 0 ? 3 : 1;
+                var browser = await SpawnBrowserAsync(urlString, headless, maxRetries: launchRetries, locale: locale);
                 var context = await browser.NewContextAsync(new BrowserNewContextOptions { Locale = locale });
                 return await RunAsync(context, urlString, headless, onConsoleMessage, onError, modifyBrowserUrl);
             }

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -128,6 +128,7 @@ internal class BrowserRunner : IAsyncDisposable
 
         CheckBrowserDependencies(s_chromePath.Value);
 
+        Exception? lastException = null;
         int attempt = 0;
         while (attempt < maxRetries)
         {
@@ -147,17 +148,19 @@ internal class BrowserRunner : IAsyncDisposable
             }
             catch (System.TimeoutException ex)
             {
+                lastException = ex;
                 attempt++;
                 _testOutput.WriteLine($"Attempt {attempt} failed with TimeoutException: {ex.Message}");
             }
             catch (PlaywrightException ex) when (attempt + 1 < maxRetries)
             {
+                lastException = ex;
                 attempt++;
                 _testOutput.WriteLine($"Attempt {attempt} failed with PlaywrightException: {ex.Message}");
             }
         }
         if (attempt == maxRetries)
-            throw new Exception($"Failed to launch browser after {maxRetries} attempts");
+            throw new Exception($"Failed to launch browser after {maxRetries} attempts", lastException);
         return Browser!;
     }
 
@@ -179,8 +182,18 @@ internal class BrowserRunner : IAsyncDisposable
             if (process == null)
                 return;
 
-            output = process.StandardOutput.ReadToEnd();
-            process.WaitForExit(10_000);
+            // Read stdout/stderr asynchronously to avoid deadlocks
+            var stdoutTask = process.StandardOutput.ReadToEndAsync();
+            var stderrTask = process.StandardError.ReadToEndAsync();
+
+            if (!process.WaitForExit(10_000))
+            {
+                try { process.Kill(); } catch { }
+                _testOutput.WriteLine("Could not check browser dependencies: ldd timed out");
+                return;
+            }
+
+            output = stdoutTask.GetAwaiter().GetResult();
         }
         catch (Exception ex)
         {

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -4,12 +4,10 @@
 #nullable enable
 
 using System;
-using System.Diagnostics;
-using System.Linq;
-using System.IO;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+using System.Linq;
 using System.Text.RegularExpressions;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
 using Wasm.Tests.Internal;
@@ -126,8 +124,6 @@ internal class BrowserRunner : IAsyncDisposable
             chromeArgs = chromeArgs.Append("--headless").ToArray();
         _testOutput.WriteLine($"Launching chrome ('{s_chromePath.Value}') via playwright with args = {string.Join(',', chromeArgs)}");
 
-        CheckBrowserDependencies(s_chromePath.Value);
-
         Exception? lastException = null;
         int attempt = 0;
         while (attempt < maxRetries)
@@ -162,74 +158,6 @@ internal class BrowserRunner : IAsyncDisposable
         if (attempt == maxRetries)
             throw new Exception($"Failed to launch browser after {maxRetries} attempts", lastException);
         return Browser!;
-    }
-
-    private static bool s_browserDependenciesChecked;
-
-    private void CheckBrowserDependencies(string chromePath)
-    {
-        if (s_browserDependenciesChecked || !RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            return;
-
-        s_browserDependenciesChecked = true;
-
-        string output;
-        try
-        {
-            var psi = new ProcessStartInfo("ldd")
-            {
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false
-            };
-            psi.ArgumentList.Add(chromePath);
-            using var process = Process.Start(psi);
-            if (process == null)
-                return;
-
-            // Read stdout/stderr asynchronously to avoid deadlocks
-            var stdoutTask = process.StandardOutput.ReadToEndAsync();
-            var stderrTask = process.StandardError.ReadToEndAsync();
-
-            if (!process.WaitForExit(10_000))
-            {
-                try { process.Kill(); process.WaitForExit(1_000); } catch { }
-                // Observe the async read tasks to avoid unobserved exceptions
-                try { stdoutTask.GetAwaiter().GetResult(); } catch { }
-                try { stderrTask.GetAwaiter().GetResult(); } catch { }
-                _testOutput.WriteLine("Could not check browser dependencies: ldd timed out");
-                return;
-            }
-
-            output = stdoutTask.GetAwaiter().GetResult();
-            string stderr = stderrTask.GetAwaiter().GetResult();
-
-            if (process.ExitCode != 0)
-            {
-                _testOutput.WriteLine($"ldd exited with code {process.ExitCode}. stderr: {stderr}");
-            }
-        }
-        catch (Exception ex)
-        {
-            _testOutput.WriteLine($"Could not check browser dependencies: {ex.Message}");
-            return;
-        }
-
-        var missingLibs = output
-            .Split('\n')
-            .Where(line => line.Contains("not found"))
-            .Select(line => line.Trim())
-            .ToList();
-
-        if (missingLibs.Count > 0)
-        {
-            string message = $"Chrome binary at '{chromePath}' is missing {missingLibs.Count} shared library dependencies:\n"
-                + string.Join("\n", missingLibs)
-                + "\nThis will cause TargetClosedException when Playwright tries to launch Chrome."
-                + "\nEnsure the Helix queue/container has Chrome's system dependencies installed (libgbm1, libnss3, libatk1.0-0, etc.).";
-            _testOutput.WriteLine($"WARNING: {message}");
-            throw new Exception(message);
-        }
     }
 
     // FIXME: options

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -171,15 +171,18 @@ internal class BrowserRunner : IAsyncDisposable
         if (s_browserDependenciesChecked || !RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             return;
 
+        s_browserDependenciesChecked = true;
+
         string output;
         try
         {
-            var psi = new ProcessStartInfo("ldd", chromePath)
+            var psi = new ProcessStartInfo("ldd")
             {
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false
             };
+            psi.ArgumentList.Add(chromePath);
             using var process = Process.Start(psi);
             if (process == null)
                 return;
@@ -227,8 +230,6 @@ internal class BrowserRunner : IAsyncDisposable
             _testOutput.WriteLine($"WARNING: {message}");
             throw new Exception(message);
         }
-
-        s_browserDependenciesChecked = true;
     }
 
     // FIXME: options

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -152,7 +152,7 @@ internal class BrowserRunner : IAsyncDisposable
                 attempt++;
                 _testOutput.WriteLine($"Attempt {attempt} failed with TimeoutException: {ex.Message}");
             }
-            catch (PlaywrightException ex) when (attempt + 1 < maxRetries)
+            catch (PlaywrightException ex)
             {
                 lastException = ex;
                 attempt++;
@@ -194,6 +194,12 @@ internal class BrowserRunner : IAsyncDisposable
             }
 
             output = stdoutTask.GetAwaiter().GetResult();
+            string stderr = stderrTask.GetAwaiter().GetResult();
+
+            if (process.ExitCode != 0)
+            {
+                _testOutput.WriteLine($"ldd exited with code {process.ExitCode}. stderr: {stderr}");
+            }
         }
         catch (Exception ex)
         {

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -230,9 +230,41 @@ internal class BrowserRunner : IAsyncDisposable
         Func<string, string>? modifyBrowserUrl = null)
     {
         var urlString = await StartServerAndGetUrlAsync(cmd, args, onServerMessage);
-        var browser = await SpawnBrowserAsync(urlString, headless, locale: locale);
-        var context = await browser.NewContextAsync(new BrowserNewContextOptions { Locale = locale });
-        return await RunAsync(context, urlString, headless, onConsoleMessage, onError, modifyBrowserUrl);
+
+        // Retry the full browser session (launch + navigate) to handle
+        // intermittent Chrome crashes in Docker containers under memory pressure.
+        // Chrome can silently die (OOM killed) during navigation when concurrent
+        // test classes run wasm-opt builds alongside browser tests.
+        const int maxSessionRetries = 3;
+        for (int attempt = 0; ; attempt++)
+        {
+            try
+            {
+                var browser = await SpawnBrowserAsync(urlString, headless, locale: locale);
+                var context = await browser.NewContextAsync(new BrowserNewContextOptions { Locale = locale });
+                return await RunAsync(context, urlString, headless, onConsoleMessage, onError, modifyBrowserUrl);
+            }
+            catch (Exception ex) when (attempt + 1 < maxSessionRetries &&
+                ex is PlaywrightException)
+            {
+                _testOutput.WriteLine($"Browser session attempt {attempt + 1} failed with {ex.GetType().Name}: {ex.Message}");
+                _testOutput.WriteLine("Retrying with a fresh browser instance...");
+                try
+                {
+                    if (Browser is not null)
+                    {
+                        await Browser.DisposeAsync();
+                        Browser = null;
+                    }
+                    Playwright?.Dispose();
+                    Playwright = null;
+                }
+                catch (Exception disposeEx)
+                {
+                    _testOutput.WriteLine($"Browser cleanup failed: {disposeEx.Message}");
+                }
+            }
+        }
     }
 
     public async Task<IPage> RunAsync(

--- a/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
+++ b/src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs
@@ -4,9 +4,11 @@
 #nullable enable
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.IO;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Playwright;
@@ -124,6 +126,8 @@ internal class BrowserRunner : IAsyncDisposable
             chromeArgs = chromeArgs.Append("--headless").ToArray();
         _testOutput.WriteLine($"Launching chrome ('{s_chromePath.Value}') via playwright with args = {string.Join(',', chromeArgs)}");
 
+        CheckBrowserDependencies(s_chromePath.Value);
+
         int attempt = 0;
         while (attempt < maxRetries)
         {
@@ -146,10 +150,59 @@ internal class BrowserRunner : IAsyncDisposable
                 attempt++;
                 _testOutput.WriteLine($"Attempt {attempt} failed with TimeoutException: {ex.Message}");
             }
+            catch (PlaywrightException ex) when (attempt + 1 < maxRetries)
+            {
+                attempt++;
+                _testOutput.WriteLine($"Attempt {attempt} failed with PlaywrightException: {ex.Message}");
+            }
         }
         if (attempt == maxRetries)
             throw new Exception($"Failed to launch browser after {maxRetries} attempts");
         return Browser!;
+    }
+
+    private void CheckBrowserDependencies(string chromePath)
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            return;
+
+        string output;
+        try
+        {
+            var psi = new ProcessStartInfo("ldd", chromePath)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            };
+            using var process = Process.Start(psi);
+            if (process == null)
+                return;
+
+            output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit(10_000);
+        }
+        catch (Exception ex)
+        {
+            _testOutput.WriteLine($"Could not check browser dependencies: {ex.Message}");
+            return;
+        }
+
+        var missingLibs = output
+            .Split('\n')
+            .Where(line => line.Contains("not found"))
+            .Select(line => line.Trim())
+            .ToList();
+
+        if (missingLibs.Count > 0)
+        {
+            string message = $"Chrome binary at '{chromePath}' is missing {missingLibs.Count} shared library dependencies:\n"
+                + string.Join("\n", missingLibs)
+                + "\nThis will cause TargetClosedException when Playwright tries to launch Chrome."
+                + "\nEnsure the Helix queue/container has Chrome's system dependencies installed (libgbm1, libnss3, libatk1.0-0, etc.).";
+            _testOutput.WriteLine($"WARNING: {message}");
+            throw new Exception(message);
+        }
     }
 
     // FIXME: options


### PR DESCRIPTION
## Summary

Fixes #121195

Wasm Playwright browser tests fail intermittently with `TargetClosedException`. Investigation revealed **two distinct failure modes**:

### Root Cause 1: Wrong Helix queue for internal builds

In `eng/pipelines/libraries/helix-queues-setup.yml`, the Android queue selection used an `or` condition:

```yaml
- ${{ if or(eq(variables['System.TeamProject'], 'internal'), in(parameters.platform, 'android_x86', ...)) }}:
  - Ubuntu.2204.Amd64.Android.29.Open
```

For internal builds, `System.TeamProject == 'internal'` is always true, so the Android queue was added for **all platforms** — including `browser_wasm`. This caused wasm browser tests to run on both:
- ✅ `ubuntu-22.04-helix-webassembly` Docker container (has Chrome shared lib deps → tests pass)
- ❌ `ubuntu.2204.amd64.android.29` bare metal (missing `libgbm.so.1` → Chrome can't start → `TargetClosedException`)

**Evidence:** Internal build 2920781 log: `Using Queues: ubuntu.2204.amd64.android.29+(ubuntu.2204.amd64)ubuntu.2204.amd64@mcr.microsoft.com/...ubuntu-22.04-helix-webassembly`

### Root Cause 2: Intermittent Chrome OOM crash on public builds

Public builds use only the correct Docker queue (with Chrome deps), but Chrome still crashes intermittently. Investigation of build 1332440 showed:
- Chrome launches successfully, then silently dies during `GotoAsync` navigation
- No missing library errors, no crash output — Chrome is OOM-killed
- xunit runs test classes **in parallel** (default behavior, `CollectionPerAssembly` is commented out)
- Concurrent Chrome instances + `wasm-opt` builds exhaust Docker container memory
- The existing retry in `SpawnBrowserAsync` only covers `LaunchAsync`, not navigation

**Evidence:** Build 1332440, job ff40a660 — `SatelliteLoadingTests` Chrome crashes while `AssetCachingTests` runs wasm-opt concurrently (takes 132s total). 24 of 25 Chrome launches in the work item succeed; the crash is timing-dependent.

### Changes

1. **`eng/pipelines/libraries/helix-queues-setup.yml`**: Fix the Android queue condition to only add the queue for Android/bionic platforms (not all internal builds).

2. **`src/mono/wasm/Wasm.Build.Tests/BrowserRunner.cs`**:
   - Add `CheckBrowserDependencies()` — uses `ldd` on Linux to detect missing Chrome shared libraries before launch, providing a clear error message instead of cryptic `TargetClosedException`
   - Add `PlaywrightException` to `SpawnBrowserAsync` retry (previously only `TimeoutException`)
   - **Add session-level retry in `RunAsync`** — wraps the full browser session (launch + navigate) with retry logic, so when Chrome crashes during `GotoAsync`, a fresh browser instance is created and navigation is retried. This is the fix for the public build failures.
   - Preserve `lastException` as `InnerException` when launch retry is exhausted

### Reproduction

- **Internal build failure**: Reproduced 100% on codespace without Chrome system deps. After installing deps, tests pass 100%.
- **Public build failure**: Observed in build 1332440 — Chrome crash during GotoAsync with concurrent wasm-opt, no missing library errors.