### PR TITLE
[release/9.0] Fix intermediate artifact upload collisions for NativeAOT and Mono

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -632,7 +632,6 @@ extends:
                   IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-*.nupkg
                   IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-*.nupkg
                   IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.multithread.browser-wasm*.nupkg
                   IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.tvos-*.nupkg
                   IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.tvossimulator-*.nupkg
                   IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.wasi-wasm*.nupkg

--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -300,7 +300,7 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
-                  name: NativeAOTRuntimePacks
+                  name: NativeAOTRuntimePacks_$(osGroup)$(osSubgroup)_$(archType)
 
       #
       # Build Mono runtime packs
@@ -344,7 +344,7 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
-                  name: MonoRuntimePacks
+                  name: MonoRuntimePacks_$(osGroup)$(osSubgroup)_$(archType)
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -362,7 +362,7 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
-                  name: MonoRuntimePacks
+                  name: MonoRuntimePacks_$(osGroup)$(osSubgroup)_$(archType)
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -380,7 +380,7 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
-                  name: MonoRuntimePacks
+                  name: MonoRuntimePacks_multithread_$(osGroup)$(osSubgroup)_$(archType)
 
       # Build Mono AOT offset headers once, for consumption elsewhere
       #
@@ -452,7 +452,7 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
-                  name: MonoRuntimePacks
+                  name: MonoRuntimePacks_crossaot_$(osGroup)$(osSubgroup)_$(archType)
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -480,7 +480,7 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
-                  name: MonoRuntimePacks
+                  name: MonoRuntimePacks_crossaot_$(osGroup)$(osSubgroup)_$(archType)
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -514,7 +514,7 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
-                  name: MonoRuntimePacks
+                  name: MonoRuntimePacks_crossaot_$(osGroup)$(osSubgroup)_$(archType)
 
       #
       # Build Mono LLVM runtime packs
@@ -546,7 +546,7 @@ extends:
               postBuildSteps:
                 - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                   parameters:
-                    name: MonoRuntimePacks
+                    name: MonoRuntimePacks_llvmaot_$(osGroup)$(osSubgroup)_$(archType)
 
       #
       # Build libraries AllConfigurations for packages
@@ -620,35 +620,35 @@ extends:
                 artifact: 'IntermediateArtifacts'
                 path: $(Build.SourcesDirectory)/artifacts/workloadPackages
                 patterns: |
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-arm64.Cross.android-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-arm64.Cross.browser-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.wasi-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-arm64.Cross.wasi-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.android-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.browser-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.multithread.browser-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.multithread.browser-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.tvos-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.tvossimulator-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.wasi-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Workload.Mono.ToolChain.Current.Manifest*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Workload.Mono.ToolChain.net6.Manifest*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Workload.Mono.ToolChain.net8.Manifest*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.MonoTargets.Sdk*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.MonoAOTCompiler.Task*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.WebAssembly.Sdk*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.WebAssembly.Wasi*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.WebAssembly.Templates*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-arm64.Cross.android-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-arm64.Cross.browser-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.wasi-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-arm64.Cross.wasi-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.android-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.browser-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.multithread.browser-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.multithread.browser-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.tvos-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.tvossimulator-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.wasi-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Workload.Mono.ToolChain.Current.Manifest*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Workload.Mono.ToolChain.net6.Manifest*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Workload.Mono.ToolChain.net8.Manifest*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Runtime.MonoTargets.Sdk*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Runtime.MonoAOTCompiler.Task*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Runtime.WebAssembly.Sdk*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Runtime.WebAssembly.Wasi*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Runtime.WebAssembly.Templates*.nupkg
                   IntermediateArtifacts/windows_arm64/Shipping/Microsoft.NETCore.App.Runtime.win-arm64*.nupkg
                   IntermediateArtifacts/windows_x64/Shipping/Microsoft.NETCore.App.Runtime.win-x64*.nupkg
                   IntermediateArtifacts/windows_x86/Shipping/Microsoft.NETCore.App.Runtime.win-x86*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Sdk.WebAssembly.Pack*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Sdk.WebAssembly.Pack*.nupkg
 
             - task: CopyFiles@2
               displayName: Flatten packages


### PR DESCRIPTION
## Problem

The `dotnet-runtime-official` pipeline on `release/9.0` has intermittent "File upload failed even after retry" errors caused by multiple platform jobs uploading arch-independent packages (like `Microsoft.NETCore.App.Ref.9.0.15.nupkg`) to the same artifact path simultaneously.

**Root cause:** NativeAOT (27 platforms) all upload to `name: NativeAOTRuntimePacks` and Mono (7+ matrix expansions) all upload to `name: MonoRuntimePacks` — using a shared subdirectory within the `IntermediateArtifacts` artifact. When two jobs finish at the same time, they race to upload the same file, causing blob storage write conflicts.

Compare with CoreCLR, which correctly uses `name: $(osGroup)$(osSubgroup)_$(archType)` — unique per platform. ✅

## Fix

Make each upload name unique per platform (matching the CoreCLR pattern):

| Build Type | Before | After |
|---|---|---|
| NativeAOT | `NativeAOTRuntimePacks` | `NativeAOTRuntimePacks_$(osGroup)$(osSubgroup)_$(archType)` |
| Mono | `MonoRuntimePacks` | `MonoRuntimePacks_$(osGroup)$(osSubgroup)_$(archType)` |
| Mono multithread | `MonoRuntimePacks` | `MonoRuntimePacks_multithread_$(osGroup)$(osSubgroup)_$(archType)` |
| CrossAOT | `MonoRuntimePacks` | `MonoRuntimePacks_crossaot_$(osGroup)$(osSubgroup)_$(archType)` |
| LLVM AOT | `MonoRuntimePacks` | `MonoRuntimePacks_llvmaot_$(osGroup)$(osSubgroup)_$(archType)` |

Updated the Workloads job download patterns from `IntermediateArtifacts/MonoRuntimePacks/Shipping/...` to `IntermediateArtifacts/MonoRuntimePacks*/Shipping/...` so the wildcard matches all per-platform subdirectories.

The `CopyFiles@2` flatten step (`*/Shipping/*.nupkg`) still works because each platform subdirectory is still a single path segment.

## Notes
- Only affects `release/9.0` — `main`/`release/10.0` have moved to VMR builds
- Perf pipelines (`perf-non-wasm-jobs.yml`) use the same pattern but only have single-platform uploads (no collision risk), so no changes needed there

Fixes #125561
Ref: dotnet/dnceng#1916