### PR TITLE
[release/9.0] Disable Datagram_UDP_AccessDenied_Throws_DoesNotBind on all macOS/MacCatalyst

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendTo.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/SendTo.cs
@@ -95,7 +95,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [SkipOnPlatform(TestPlatforms.FreeBSD, "FreeBSD allows sendto() to broadcast")]
-        [ActiveIssue("https://github.com/dotnet/runtime/issues/114450", typeof(PlatformDetection), nameof(PlatformDetection.IsMacCatalyst), nameof(PlatformDetection.IsX64Process))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/114450", TestPlatforms.OSX | TestPlatforms.MacCatalyst)]
         public async Task Datagram_UDP_AccessDenied_Throws_DoesNotBind()
         {
             IPEndPoint invalidEndpoint = new IPEndPoint(IPAddress.Broadcast, 1234);


### PR DESCRIPTION
## Summary

macOS 15+ returns `EHOSTUNREACH` instead of `EACCES` for UDP broadcast without `SO_BROADCAST` due to Apple's [Local Network privacy feature](https://developer.apple.com/forums/thread/765285). The test expects `SocketError.AccessDenied` but gets `SocketError.HostUnreachable`.

The existing `ActiveIssue` (from #113313) only disabled on MacCatalyst x64. The failure affects all macOS 15+ platforms — confirmed on `osx.15.amd64` in both coreclr and Mono legs in [#125564](https://github.com/dotnet/runtime/pull/125564).

## Change

Broadens the `ActiveIssue` from:
```csharp
[ActiveIssue("...", typeof(PlatformDetection), nameof(PlatformDetection.IsMacCatalyst), nameof(PlatformDetection.IsX64Process))]
```
to:
```csharp
[ActiveIssue("...", TestPlatforms.OSX | TestPlatforms.MacCatalyst)]
```

@ManickaP requested this backport in https://github.com/dotnet/runtime/issues/114450#issuecomment-3846729058.

Fixes #114450 on release/9.0.

cc @liveans @kotlarmilos @ManickaP