### PR TITLE
Fix race condition in BackgroundServiceExceptionTests

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
@@ -78,8 +78,11 @@ namespace Microsoft.Extensions.Hosting.Tests
             using var host = builder.Build();
             await host.StartAsync();
 
-            // Wait for the background service to fail
-            await Task.Delay(TimeSpan.FromMilliseconds(200));
+            // Wait for the host to react to the background service failure
+            var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+            var stoppingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            lifetime.ApplicationStopping.Register(() => stoppingTcs.TrySetResult());
+            await stoppingTcs.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
@@ -107,8 +110,11 @@ namespace Microsoft.Extensions.Hosting.Tests
             using var host = builder.Build();
             await host.StartAsync();
 
-            // Wait for the background service to fail
-            await Task.Delay(TimeSpan.FromMilliseconds(200));
+            // Wait for the host to react to the background service failure
+            var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+            var stoppingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            lifetime.ApplicationStopping.Register(() => stoppingTcs.TrySetResult());
+            await stoppingTcs.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
@@ -208,6 +214,7 @@ namespace Microsoft.Extensions.Hosting.Tests
         [Fact]
         public async Task BackgroundService_IgnoreException_StopAsync_DoesNotThrow()
         {
+            var signal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             var builder = new HostBuilder()
                 .ConfigureServices(services =>
                 {
@@ -216,14 +223,15 @@ namespace Microsoft.Extensions.Hosting.Tests
                         options.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore;
                         options.ShutdownTimeout = TimeSpan.FromSeconds(1);
                     });
-                    services.AddHostedService<AsynchronousFailureService>();
+                    services.AddSingleton(signal);
+                    services.AddHostedService<SignalingFailureService>();
                 });
 
             using var host = builder.Build();
             await host.StartAsync();
 
-            // Wait a bit for the background service to fail
-            await Task.Delay(TimeSpan.FromMilliseconds(200));
+            // Wait for the background service to signal it has thrown
+            await signal.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
             await host.StopAsync();
         }
@@ -292,6 +300,23 @@ namespace Microsoft.Extensions.Hosting.Tests
         {
             public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
             public Task StopAsync(CancellationToken cancellationToken) => throw new InvalidOperationException("Stop failure");
+        }
+
+        private class SignalingFailureService : BackgroundService
+        {
+            private readonly TaskCompletionSource _signal;
+
+            public SignalingFailureService(TaskCompletionSource signal)
+            {
+                _signal = signal;
+            }
+
+            protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                _signal.TrySetResult();
+                throw new InvalidOperationException("Signaling asynchronous failure");
+            }
         }
 
         private class SuccessfulService : BackgroundService

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
@@ -80,9 +80,9 @@ namespace Microsoft.Extensions.Hosting.Tests
 
             // Wait for the host to react to the background service failure
             var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
-            var stoppingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            lifetime.ApplicationStopping.Register(() => stoppingTcs.TrySetResult());
-            await stoppingTcs.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            var stoppingTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            lifetime.ApplicationStopping.Register(() => stoppingTcs.TrySetResult(null));
+            Assert.Equal(stoppingTcs.Task, await Task.WhenAny(stoppingTcs.Task, Task.Delay(TimeSpan.FromSeconds(10))));
 
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
@@ -112,9 +112,9 @@ namespace Microsoft.Extensions.Hosting.Tests
 
             // Wait for the host to react to the background service failure
             var lifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
-            var stoppingTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-            lifetime.ApplicationStopping.Register(() => stoppingTcs.TrySetResult());
-            await stoppingTcs.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            var stoppingTcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
+            lifetime.ApplicationStopping.Register(() => stoppingTcs.TrySetResult(null));
+            Assert.Equal(stoppingTcs.Task, await Task.WhenAny(stoppingTcs.Task, Task.Delay(TimeSpan.FromSeconds(10))));
 
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
@@ -214,7 +214,7 @@ namespace Microsoft.Extensions.Hosting.Tests
         [Fact]
         public async Task BackgroundService_IgnoreException_StopAsync_DoesNotThrow()
         {
-            var signal = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            var signal = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var builder = new HostBuilder()
                 .ConfigureServices(services =>
                 {
@@ -231,7 +231,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             await host.StartAsync();
 
             // Wait for the background service to reach its failure point
-            await signal.Task.WaitAsync(TimeSpan.FromSeconds(10));
+            Assert.Equal(signal.Task, await Task.WhenAny(signal.Task, Task.Delay(TimeSpan.FromSeconds(10))));
 
             await host.StopAsync();
         }
@@ -304,9 +304,9 @@ namespace Microsoft.Extensions.Hosting.Tests
 
         private class SignalingFailureService : BackgroundService
         {
-            private readonly TaskCompletionSource _signal;
+            private readonly TaskCompletionSource<object> _signal;
 
-            public SignalingFailureService(TaskCompletionSource signal)
+            public SignalingFailureService(TaskCompletionSource<object> signal)
             {
                 _signal = signal;
             }
@@ -314,7 +314,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             protected override async Task ExecuteAsync(CancellationToken stoppingToken)
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(100));
-                _signal.TrySetResult();
+                _signal.TrySetResult(null);
                 throw new InvalidOperationException("Signaling asynchronous failure");
             }
         }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
@@ -230,7 +230,7 @@ namespace Microsoft.Extensions.Hosting.Tests
             using var host = builder.Build();
             await host.StartAsync();
 
-            // Wait for the background service to signal it has thrown
+            // Wait for the background service to reach its failure point
             await signal.Task.WaitAsync(TimeSpan.FromSeconds(10));
 
             await host.StopAsync();

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
@@ -214,7 +214,6 @@ namespace Microsoft.Extensions.Hosting.Tests
         [Fact]
         public async Task BackgroundService_IgnoreException_StopAsync_DoesNotThrow()
         {
-            var signal = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var builder = new HostBuilder()
                 .ConfigureServices(services =>
                 {
@@ -223,15 +222,16 @@ namespace Microsoft.Extensions.Hosting.Tests
                         options.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.Ignore;
                         options.ShutdownTimeout = TimeSpan.FromSeconds(1);
                     });
-                    services.AddSingleton(signal);
-                    services.AddHostedService<SignalingFailureService>();
+                    services.AddHostedService<AsynchronousFailureService>();
                 });
 
             using var host = builder.Build();
             await host.StartAsync();
 
-            // Wait for the background service to reach its failure point
-            Assert.Equal(signal.Task, await Task.WhenAny(signal.Task, Task.Delay(TimeSpan.FromSeconds(10))));
+            // Wait a bit for the background service to fail.
+            // This shouldn't cause flakiness: bad order of operations could cause the test to succeed when it should fail, but it shouldn't cause the test to fail when it should succeed.
+            // Note that waiting for a signal from the service here wouldn't be enough; we also need to wait for the host to process the exception.
+            await Task.Delay(TimeSpan.FromMilliseconds(200));
 
             await host.StopAsync();
         }
@@ -300,23 +300,6 @@ namespace Microsoft.Extensions.Hosting.Tests
         {
             public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
             public Task StopAsync(CancellationToken cancellationToken) => throw new InvalidOperationException("Stop failure");
-        }
-
-        private class SignalingFailureService : BackgroundService
-        {
-            private readonly TaskCompletionSource<object> _signal;
-
-            public SignalingFailureService(TaskCompletionSource<object> signal)
-            {
-                _signal = signal;
-            }
-
-            protected override async Task ExecuteAsync(CancellationToken stoppingToken)
-            {
-                await Task.Delay(TimeSpan.FromMilliseconds(100));
-                _signal.TrySetResult(null);
-                throw new InvalidOperationException("Signaling asynchronous failure");
-            }
         }
 
         private class SuccessfulService : BackgroundService


### PR DESCRIPTION
## Problem

`BackgroundService_AsynchronousException_StopAsync_ThrowsException` is flaky (3 hits in 24 hours, [#125550](https://github.com/dotnet/runtime/issues/125550)).

The test starts a `BackgroundService` that delays 100ms then throws, waits `Task.Delay(200ms)`, and expects `StopAsync` to surface the exception. On loaded CI agents the 200ms isn't always enough for the exception to propagate through the host, so `Assert.Throws` sees no exception.

```
Assert.Throws() Failure: No exception was thrown
Expected: typeof(System.InvalidOperationException)
```

## Fix

Replace the racy `Task.Delay(200ms)` with deterministic synchronization:

**For `StopHost` behavior tests** (`StopAsync_ThrowsException`, `StopTwiceAsync_ThrowsException`): Wait for `IHostApplicationLifetime.ApplicationStopping`, which fires after the host has captured the faulted service exception and called `StopApplication()`. This is the correct signal because it means the host has processed the exception and is ready to surface it on `StopAsync`.

~~**For `Ignore` behavior test** (`IgnoreException_StopAsync_DoesNotThrow`): Use a `SignalingFailureService` that signals a `TaskCompletionSource` before throwing. Since this test verifies `StopAsync` does *not* throw, we just need to know the service has faulted — no host-level processing is needed.~~

Both use a 10-second timeout as a safety net for CI.

Fixes #125550