### PR TITLE
Fix flaky TestResourceManagerIsSafeForConcurrentAccessAndEnumeration timeout

### DIFF
--- a/src/libraries/System.Resources.Extensions/tests/BinaryResourceWriterUnitTest.cs
+++ b/src/libraries/System.Resources.Extensions/tests/BinaryResourceWriterUnitTest.cs
@@ -517,7 +517,7 @@ namespace System.Resources.Extensions.Tests
         [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsBinaryFormatterSupported))]
         [InlineData(false)]
         [InlineData(true)]
-        public static void TestResourceManagerIsSafeForConcurrentAccessAndEnumeration(bool useEnumeratorEntry)
+        public static async Task TestResourceManagerIsSafeForConcurrentAccessAndEnumeration(bool useEnumeratorEntry)
         {
             ResourceManager manager = new(
                 typeof(TestData).FullName,
@@ -534,7 +534,10 @@ namespace System.Resources.Extensions.Tests
                     TaskScheduler.Default))
                 .ToArray();
 
-            Assert.True(Task.WaitAll(tasks, TimeSpan.FromSeconds(30)));
+            Task allTasks = Task.WhenAll(tasks);
+            Task completed = await Task.WhenAny(allTasks, Task.Delay(TimeSpan.FromSeconds(120)));
+            Assert.True(completed == allTasks, "Timed out waiting for concurrent enumeration tasks");
+            await allTasks; // propagates any real exceptions
 
             void WaitForBarrierThenEnumerateResources()
             {


### PR DESCRIPTION
## Problem

`TestResourceManagerIsSafeForConcurrentAccessAndEnumeration` is flaky ([#125448](https://github.com/dotnet/runtime/issues/125448), 3 hits in 7 days). This same test has been filed as a Known Build Error three times over 3+ years ([#80277](https://github.com/dotnet/runtime/issues/80277), [#86013](https://github.com/dotnet/runtime/issues/86013), [#125448](https://github.com/dotnet/runtime/issues/125448)).

The test spins up 10 threads that concurrently enumerate a resource set with `Thread.Sleep(1)` between entries, then waits with:

```csharp
Assert.True(Task.WaitAll(tasks, TimeSpan.FromSeconds(30)));
```

On loaded CI agents, 30 seconds isn't always enough. The failure message is unhelpful — just `Assert.True() Failure: Expected: True, Actual: False` — because `Task.WaitAll` swallows any actual thread-safety exceptions.

## Fix

```csharp
Task allTasks = Task.WhenAll(tasks);
Task completed = await Task.WhenAny(allTasks, Task.Delay(TimeSpan.FromSeconds(120)));
Assert.True(completed == allTasks, "Timed out waiting for concurrent enumeration tasks");
await allTasks; // propagates any real exceptions
```

Three improvements:
1. **`Task.WhenAll` instead of `Task.WaitAll`** — if a real thread-safety bug is hit, the actual exception propagates instead of being swallowed behind `Assert.True(false)`
2. **120s instead of 30s** — 4x more headroom for loaded CI agents while still providing a timeout safety net
3. **Clear timeout message** — on timeout, the assertion message says what happened instead of a bare `Assert.True` failure

The `WhenAny`/`Task.Delay` pattern is used instead of `Task.WhenAll(...).WaitAsync(...)` for .NET Framework TFM compatibility. The method signature changes from `void` to `async Task`, which xUnit handles natively.

Fixes #125448
