### PR TITLE
Optimize more regex cases with IndexOfAny

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -627,17 +627,20 @@ namespace System.Text.RegularExpressions.Generator
             return $"{HelpersTypeName}.{fieldName}";
         }
 
-        private static string EmitIndexOfAnyCustomHelper(string set, Dictionary<string, string[]> requiredHelpers, bool checkOverflow)
+        private static string EmitIndexOfAnyCustomHelper(string set, Dictionary<string, string[]> requiredHelpers, bool checkOverflow, bool negate = false, bool last = false)
         {
             // In order to optimize the search for ASCII characters, we use SearchValues to vectorize a search
             // for those characters plus anything non-ASCII (if we find something non-ASCII, we'll fall back to
             // a sequential walk).  In order to do that search, we actually build up a set for all of the ASCII
-            // characters _not_ contained in the set, and then do a search for the inverse of that, which will be
-            // all of the target ASCII characters and all of non-ASCII.
+            // characters _not_ contained in the target set, and then do a search for the inverse of that, which
+            // will be all of the target ASCII characters and all of non-ASCII.  When negate is true, the target
+            // is the complement of the set, so we swap included/excluded.
             var excludedAsciiChars = new List<char>();
             for (int i = 0; i < 128; i++)
             {
-                if (!RegexCharClass.CharInClass((char)i, set))
+                // When negate is false, we want to find chars IN the set, so we exclude chars NOT in it.
+                // When negate is true, we want to find chars NOT in the set, so we exclude chars IN it.
+                if (RegexCharClass.CharInClass((char)i, set) == negate)
                 {
                     excludedAsciiChars.Add((char)i);
                 }
@@ -646,31 +649,31 @@ namespace System.Text.RegularExpressions.Generator
             // If this is a known set, use a predetermined simple name for the helper.
             string? helperName = set switch
             {
-                RegexCharClass.DigitClass => "IndexOfAnyDigit",
-                RegexCharClass.ControlClass => "IndexOfAnyControl",
-                RegexCharClass.LetterClass => "IndexOfAnyLetter",
-                RegexCharClass.LetterOrDigitClass => "IndexOfAnyLetterOrDigit",
-                RegexCharClass.LowerClass => "IndexOfAnyLower",
-                RegexCharClass.NumberClass => "IndexOfAnyNumber",
-                RegexCharClass.PunctuationClass => "IndexOfAnyPunctuation",
-                RegexCharClass.SeparatorClass => "IndexOfAnySeparator",
-                RegexCharClass.SpaceClass => "IndexOfAnyWhiteSpace",
-                RegexCharClass.SymbolClass => "IndexOfAnySymbol",
-                RegexCharClass.UpperClass => "IndexOfAnyUpper",
-                RegexCharClass.WordClass => "IndexOfAnyWordChar",
+                RegexCharClass.DigitClass => negate ? "IndexOfAnyExceptDigit" : "IndexOfAnyDigit",
+                RegexCharClass.ControlClass => negate ? "IndexOfAnyExceptControl" : "IndexOfAnyControl",
+                RegexCharClass.LetterClass => negate ? "IndexOfAnyExceptLetter" : "IndexOfAnyLetter",
+                RegexCharClass.LetterOrDigitClass => negate ? "IndexOfAnyExceptLetterOrDigit" : "IndexOfAnyLetterOrDigit",
+                RegexCharClass.LowerClass => negate ? "IndexOfAnyExceptLower" : "IndexOfAnyLower",
+                RegexCharClass.NumberClass => negate ? "IndexOfAnyExceptNumber" : "IndexOfAnyNumber",
+                RegexCharClass.PunctuationClass => negate ? "IndexOfAnyExceptPunctuation" : "IndexOfAnyPunctuation",
+                RegexCharClass.SeparatorClass => negate ? "IndexOfAnyExceptSeparator" : "IndexOfAnySeparator",
+                RegexCharClass.SpaceClass => negate ? "IndexOfAnyExceptWhiteSpace" : "IndexOfAnyWhiteSpace",
+                RegexCharClass.SymbolClass => negate ? "IndexOfAnyExceptSymbol" : "IndexOfAnySymbol",
+                RegexCharClass.UpperClass => negate ? "IndexOfAnyExceptUpper" : "IndexOfAnyUpper",
+                RegexCharClass.WordClass => negate ? "IndexOfAnyExceptWordChar" : "IndexOfAnyWordChar",
 
-                RegexCharClass.NotDigitClass => "IndexOfAnyExceptDigit",
-                RegexCharClass.NotControlClass => "IndexOfAnyExceptControl",
-                RegexCharClass.NotLetterClass => "IndexOfAnyExceptLetter",
-                RegexCharClass.NotLetterOrDigitClass => "IndexOfAnyExceptLetterOrDigit",
-                RegexCharClass.NotLowerClass => "IndexOfAnyExceptLower",
-                RegexCharClass.NotNumberClass => "IndexOfAnyExceptNumber",
-                RegexCharClass.NotPunctuationClass => "IndexOfAnyExceptPunctuation",
-                RegexCharClass.NotSeparatorClass => "IndexOfAnyExceptSeparator",
-                RegexCharClass.NotSpaceClass => "IndexOfAnyExceptWhiteSpace",
-                RegexCharClass.NotSymbolClass => "IndexOfAnyExceptSymbol",
-                RegexCharClass.NotUpperClass => "IndexOfAnyExceptUpper",
-                RegexCharClass.NotWordClass => "IndexOfAnyExceptWordChar",
+                RegexCharClass.NotDigitClass => negate ? "IndexOfAnyDigit" : "IndexOfAnyExceptDigit",
+                RegexCharClass.NotControlClass => negate ? "IndexOfAnyControl" : "IndexOfAnyExceptControl",
+                RegexCharClass.NotLetterClass => negate ? "IndexOfAnyLetter" : "IndexOfAnyExceptLetter",
+                RegexCharClass.NotLetterOrDigitClass => negate ? "IndexOfAnyLetterOrDigit" : "IndexOfAnyExceptLetterOrDigit",
+                RegexCharClass.NotLowerClass => negate ? "IndexOfAnyLower" : "IndexOfAnyExceptLower",
+                RegexCharClass.NotNumberClass => negate ? "IndexOfAnyNumber" : "IndexOfAnyExceptNumber",
+                RegexCharClass.NotPunctuationClass => negate ? "IndexOfAnyPunctuation" : "IndexOfAnyExceptPunctuation",
+                RegexCharClass.NotSeparatorClass => negate ? "IndexOfAnySeparator" : "IndexOfAnyExceptSeparator",
+                RegexCharClass.NotSpaceClass => negate ? "IndexOfAnyWhiteSpace" : "IndexOfAnyExceptWhiteSpace",
+                RegexCharClass.NotSymbolClass => negate ? "IndexOfAnySymbol" : "IndexOfAnyExceptSymbol",
+                RegexCharClass.NotUpperClass => negate ? "IndexOfAnyUpper" : "IndexOfAnyExceptUpper",
+                RegexCharClass.NotWordClass => negate ? "IndexOfAnyWordChar" : "IndexOfAnyExceptWordChar",
 
                 _ => null,
             };
@@ -681,28 +684,38 @@ namespace System.Text.RegularExpressions.Generator
                 Span<UnicodeCategory> categories = stackalloc UnicodeCategory[5]; // arbitrary limit to keep names from being too unwieldy
                 if (RegexCharClass.TryGetOnlyCategories(set, categories, out int numCategories, out bool negatedCategory))
                 {
-                    helperName = $"IndexOfAny{(negatedCategory ? "Except" : "")}{string.Concat(categories.Slice(0, numCategories).ToArray().Select(c => c.ToString()))}";
+                    helperName = $"IndexOfAny{(negatedCategory ^ negate ? "Except" : "")}{string.Concat(categories.Slice(0, numCategories).ToArray().Select(c => c.ToString()))}";
                 }
             }
 
             // As a final fallback, manufacture a name unique to the full set description.
-            helperName ??= GetSHA256FieldName("IndexOfNonAsciiOrAny_", set);
+            helperName ??= GetSHA256FieldName(negate ? "IndexOfAnyExcept_" : "IndexOfAny_", set);
+
+            // Prepend "Last" for LastIndexOf variants.
+            if (last)
+            {
+                helperName = "Last" + helperName;
+            }
 
             if (!requiredHelpers.ContainsKey(helperName))
             {
                 var additionalDeclarations = new HashSet<string>();
-                string matchExpr = MatchCharacterClass("span[i]", set, negate: false, additionalDeclarations, requiredHelpers);
+                string matchExpr = MatchCharacterClass("span[i]", set, negate, additionalDeclarations, requiredHelpers);
+
+                string lastPrefix = last ? "Last" : "";
+                string description = negate ? $"does not match {EscapeXmlComment(DescribeSet(set))}" : $"matches {EscapeXmlComment(DescribeSet(set))}";
 
                 var lines = new List<string>();
-                lines.Add($"/// <summary>Finds the next index of any character that matches {EscapeXmlComment(DescribeSet(set))}.</summary>");
+                lines.Add($"/// <summary>Finds the {(last ? "last" : "next")} index of any character that {description}.</summary>");
                 lines.Add($"[MethodImpl(MethodImplOptions.AggressiveInlining)]");
                 lines.Add($"internal static int {helperName}(this ReadOnlySpan<char> span)");
                 lines.Add($"{{");
                 int uncheckedStart = lines.Count;
-                lines.Add(excludedAsciiChars.Count == 128 ? $"    int i = span.IndexOfAnyExceptInRange('\\0', '\\u007f');" : // no ASCII is in the set
-                          excludedAsciiChars.Count == 0   ? $"    int i = 0;" : // all ASCII is in the set
-                          $"    int i = span.IndexOfAnyExcept({EmitSearchValues(excludedAsciiChars.ToArray(), requiredHelpers)});");
-                lines.Add($"    if ((uint)i < (uint)span.Length)");
+                string indexOfAnyExcept = last ? "LastIndexOfAnyExcept" : "IndexOfAnyExcept";
+                lines.Add(excludedAsciiChars.Count == 128 ? $"    int i = span.{lastPrefix}IndexOfAnyExceptInRange('\\0', '\\u007f');" :
+                          excludedAsciiChars.Count == 0   ? (last ? $"    int i = span.Length - 1;" : $"    int i = 0;") :
+                          $"    int i = span.{indexOfAnyExcept}({EmitSearchValues(excludedAsciiChars.ToArray(), requiredHelpers)});");
+                lines.Add(last ? $"    if (i >= 0)" : $"    if ((uint)i < (uint)span.Length)");
                 lines.Add($"    {{");
                 if (excludedAsciiChars.Count is not (0 or 128))
                 {
@@ -722,9 +735,9 @@ namespace System.Text.RegularExpressions.Generator
                 lines.Add($"            {{");
                 lines.Add($"                return i;");
                 lines.Add($"            }}");
-                lines.Add($"            i++;");
+                lines.Add(last ? $"            i--;" : $"            i++;");
                 lines.Add($"        }}");
-                lines.Add($"        while ((uint)i < (uint)span.Length);");
+                lines.Add(last ? $"        while (i >= 0);" : $"        while ((uint)i < (uint)span.Length);");
                 lines.Add($"    }}");
                 lines.Add($"");
                 lines.Add($"    return -1;");
@@ -3480,7 +3493,7 @@ namespace System.Text.RegularExpressions.Generator
                 if (!rtl &&
                     node.N > 1 && // no point in using IndexOf for small loops, in particular optionals
                     subsequent?.FindStartingLiteralNode() is RegexNode literalNode &&
-                    TryEmitIndexOf(requiredHelpers, literalNode, useLast: true, negate: false, out int literalLength, out string? indexOfExpr))
+                    TryEmitIndexOf(requiredHelpers, literalNode, useLast: true, negate: false, out int literalLength, out string? indexOfExpr, checkOverflow))
                 {
                     writer.WriteLine($"if ({startingPos} >= {endingPos} ||");
 
@@ -3705,7 +3718,7 @@ namespace System.Text.RegularExpressions.Generator
                         node.Kind is RegexNodeKind.Setlazy &&
                         node.Str == RegexCharClass.AnyClass &&
                         subsequent?.FindStartingLiteralNode() is RegexNode literal2 &&
-                        TryEmitIndexOf(requiredHelpers, literal2, useLast: false, negate: false, out _, out string? indexOfExpr))
+                        TryEmitIndexOf(requiredHelpers, literal2, useLast: false, negate: false, out _, out string? indexOfExpr, checkOverflow))
                     {
                         // e.g. ".*?string" with RegexOptions.Singleline
                         // This lazy loop will consume all characters until the subsequent literal. If the subsequent literal
@@ -4155,11 +4168,9 @@ namespace System.Text.RegularExpressions.Generator
                     // For the loop, we're validating that each char matches the target node.
                     // For Contains{Any}, we're looking for the first thing that _doesn't_ match the target node,
                     // and thus similarly validating that everything does.
-                    if (TryEmitIndexOf(requiredHelpers, node, useLast: false, negate: true, out _, out string? indexOfExpr))
+                    if (TryEmitIndexOf(requiredHelpers, node, useLast: false, negate: true, out _, out string? indexOfExpr, checkOverflow))
                     {
-                        string containsExpr = indexOfExpr.Replace("IndexOf", "Contains");
-
-                        string condition = $"{sliceSpan}.Slice({sliceStaticPos}, {iterations}).{containsExpr}";
+                        string condition = $"{sliceSpan}.Slice({sliceStaticPos}, {iterations}).{indexOfExpr} >= 0";
                         if (emitLengthCheck)
                         {
                             condition = $"{SpanLengthCheck(iterations)} || {condition}";
@@ -4258,7 +4269,7 @@ namespace System.Text.RegularExpressions.Generator
                     TransferSliceStaticPosToPos();
                     writer.WriteLine($"int {iterationLocal} = inputSpan.Length - pos;");
                 }
-                else if (maxIterations == int.MaxValue && TryEmitIndexOf(requiredHelpers, node, useLast: false, negate: true, out _, out string? indexOfExpr))
+                else if (maxIterations == int.MaxValue && TryEmitIndexOf(requiredHelpers, node, useLast: false, negate: true, out _, out string? indexOfExpr, checkOverflow))
                 {
                     // We're unbounded and we can use an IndexOf method to perform the search. The unbounded restriction is
                     // purely for simplicity; it could be removed in the future with additional code to handle that case.
@@ -5004,12 +5015,14 @@ namespace System.Text.RegularExpressions.Generator
         /// <param name="negate">true to search for the opposite of the node.</param>
         /// <param name="literalLength">0 if returns false. If it returns true, string.Length for a multi, otherwise 1.</param>
         /// <param name="indexOfExpr">The resulting expression if it returns true; otherwise, null.</param>
+        /// <param name="checkOverflow">Whether to wrap generated helpers with unchecked blocks.</param>
         /// <returns>true if an expression could be produced; otherwise, false.</returns>
         private static bool TryEmitIndexOf(
             Dictionary<string, string[]> requiredHelpers,
             RegexNode node,
             bool useLast, bool negate,
-            out int literalLength, [NotNullWhen(true)] out string? indexOfExpr)
+            out int literalLength, [NotNullWhen(true)] out string? indexOfExpr,
+            bool checkOverflow = false)
         {
             string last = useLast ? "Last" : "";
 
@@ -5071,6 +5084,19 @@ namespace System.Text.RegularExpressions.Generator
                         _ => $"{last}{indexOfAnyName}({EmitSearchValuesOrLiteral(setChars, requiredHelpers)})",
                     };
 
+                    literalLength = 1;
+                    return true;
+                }
+
+                // For complex character classes (e.g. Unicode categories like \w, \d, \s, or sets with
+                // subtraction) that can't be handled by a simple IndexOf call, use a custom helper that
+                // leverages vectorized ASCII search with a scalar fallback for non-ASCII characters.
+                // Unlike the simpler paths above that use `negated` (which XORs the set's internal
+                // negation flag with the caller's negate parameter, because TryGetSingleRange/GetSetChars
+                // strip internal negation), the custom helper uses CharInClass which handles internal
+                // negation itself, so we pass the raw `negate` from the caller.
+                {
+                    indexOfExpr = $"{EmitIndexOfAnyCustomHelper(node.Str!, requiredHelpers, checkOverflow, negate, useLast)}()";
                     literalLength = 1;
                     return true;
                 }

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -997,89 +997,7 @@ namespace System.Text.RegularExpressions
                     }
                     else
                     {
-                        // In order to optimize the search for ASCII characters, we use SearchValues to vectorize a search
-                        // for those characters plus anything non-ASCII (if we find something non-ASCII, we'll fall back to
-                        // a sequential walk).  In order to do that search, we actually build up a set for all of the ASCII
-                        // characters _not_ contained in the set, and then do a search for the inverse of that, which will be
-                        // all of the target ASCII characters and all of non-ASCII.
-                        using var asciiChars = new ValueListBuilder<char>(stackalloc char[128]);
-                        for (int i = 0; i < 128; i++)
-                        {
-                            if (!RegexCharClass.CharInClass((char)i, primarySet.Set))
-                            {
-                                asciiChars.Append((char)i);
-                            }
-                        }
-
-                        using (RentedLocalBuilder span = RentReadOnlySpanCharLocal())
-                        using (RentedLocalBuilder i = RentInt32Local())
-                        {
-                            // ReadOnlySpan<char> span = inputSpan...;
-                            Stloc(span);
-
-                            // int i = span.
-                            Ldloc(span);
-                            if (asciiChars.Length == 128)
-                            {
-                                // IndexOfAnyExceptInRange('\0', '\u007f');
-                                Ldc(0);
-                                Ldc(127);
-                                Call(SpanIndexOfAnyExceptInRangeMethod);
-                            }
-                            else
-                            {
-                                // IndexOfAnyExcept(searchValuesArray[...]);
-                                LoadSearchValues(asciiChars.AsSpan().ToArray());
-                                Call(SpanIndexOfAnyExceptSearchValuesMethod);
-                            }
-                            Stloc(i);
-
-                            // if ((uint)i >= span.Length) goto doneSearch;
-                            Label doneSearch = DefineLabel();
-                            Ldloc(i);
-                            Ldloca(span);
-                            Call(SpanGetLengthMethod);
-                            BgeUnFar(doneSearch);
-
-                            // if (span[i] <= 0x7f) goto doneSearch;
-                            Ldc(0x7f);
-                            Ldloca(span);
-                            Ldloc(i);
-                            Call(SpanGetItemMethod);
-                            LdindU2();
-                            BgeUnFar(doneSearch);
-
-                            Label loop = DefineLabel();
-                            MarkLabel(loop);
-                            // do { ...
-
-                            // if (CharInClass(span[i])) goto doneSearch;
-                            Ldloca(span);
-                            Ldloc(i);
-                            Call(SpanGetItemMethod);
-                            LdindU2();
-                            EmitMatchCharacterClass(primarySet.Set);
-                            Brtrue(doneSearch);
-
-                            // i++;
-                            Ldloc(i);
-                            Ldc(1);
-                            Add();
-                            Stloc(i);
-
-                            // } while ((uint)i < span.Length);
-                            Ldloc(i);
-                            Ldloca(span);
-                            Call(SpanGetLengthMethod);
-                            BltUnFar(loop);
-
-                            // i = -1;
-                            Ldc(-1);
-                            Stloc(i);
-
-                            MarkLabel(doneSearch);
-                            Ldloc(i);
-                        }
+                        EmitIndexOfWithCharClassFallback(primarySet.Set, negate: false, useLast: false);
                     }
 
                     if (needLoop)
@@ -4543,62 +4461,20 @@ namespace System.Text.RegularExpressions
                 }
                 else
                 {
+                    // Vectorize the search: look for the first thing that _doesn't_ match the target node,
+                    // and thus validate that everything does.
+                    Debug.Assert(CanEmitIndexOf(node, out _));
+
                     // ReadOnlySpan<char> tmp = slice.Slice(sliceStaticPos, iterations);
                     Ldloca(slice);
                     Ldc(sliceStaticPos);
                     Ldc(iterations);
                     Call(SpanSliceIntIntMethod);
 
-                    // If we're able to vectorize the search, do so. Otherwise, fall back to a loop.
-                    // For the loop, we're validating that each char matches the target node.
-                    // For IndexOf, we're looking for the first thing that _doesn't_ match the target node,
-                    // and thus similarly validating that everything does.
-                    if (CanEmitIndexOf(node, out _))
-                    {
-                        // if (tmp.IndexOf(...) >= 0) goto doneLabel;
-                        EmitIndexOf(node, useLast: false, negate: true);
-                        Ldc(0);
-                        BgeFar(doneLabel);
-                    }
-                    else
-                    {
-                        using RentedLocalBuilder spanLocal = RentReadOnlySpanCharLocal();
-                        Stloc(spanLocal);
-
-                        // for (int i = 0; i < tmp.Length; i++)
-                        // {
-                        //     if (tmp[i] != ch) goto Done;
-                        // }
-
-                        Label conditionLabel = DefineLabel();
-                        Label bodyLabel = DefineLabel();
-
-                        using RentedLocalBuilder iterationLocal = RentInt32Local();
-                        Ldc(0);
-                        Stloc(iterationLocal);
-                        BrFar(conditionLabel);
-
-                        MarkLabel(bodyLabel);
-
-                        LocalBuilder tmpTextSpanLocal = slice; // we want EmitSingleChar to refer to this temporary
-                        int tmpTextSpanPos = sliceStaticPos;
-                        slice = spanLocal;
-                        sliceStaticPos = 0;
-                        EmitSingleChar(node, emitLengthCheck: false, offset: iterationLocal);
-                        slice = tmpTextSpanLocal;
-                        sliceStaticPos = tmpTextSpanPos;
-
-                        Ldloc(iterationLocal);
-                        Ldc(1);
-                        Add();
-                        Stloc(iterationLocal);
-
-                        MarkLabel(conditionLabel);
-                        Ldloc(iterationLocal);
-                        Ldloca(spanLocal);
-                        Call(SpanGetLengthMethod);
-                        BltFar(bodyLabel);
-                    }
+                    // if (tmp.IndexOf(...) >= 0) goto doneLabel;
+                    EmitIndexOf(node, useLast: false, negate: true);
+                    Ldc(0);
+                    BgeFar(doneLabel);
 
                     sliceStaticPos += iterations;
                 }
@@ -5385,21 +5261,10 @@ namespace System.Text.RegularExpressions
                     return true;
                 }
 
-                if (node.IsOneFamily || node.IsNotoneFamily)
+                if (node.IsOneFamily || node.IsNotoneFamily || node.IsSetFamily)
                 {
                     literalLength = 1;
                     return true;
-                }
-
-                if (node.IsSetFamily)
-                {
-                    Span<char> setChars = stackalloc char[128];
-                    if (RegexCharClass.TryGetSingleRange(node.Str, out _, out _) ||
-                        RegexCharClass.GetSetChars(node.Str, setChars) > 0)
-                    {
-                        literalLength = 1;
-                        return true;
-                    }
                 }
 
                 literalLength = 0;
@@ -5512,9 +5377,16 @@ namespace System.Text.RegularExpressions
                                 return;
                         }
                     }
+
+                    // For complex character classes (e.g. Unicode categories like \w, \d, \s, or sets with subtraction)
+                    // that can't be handled by simple IndexOf calls, use a vectorized ASCII search with
+                    // EmitMatchCharacterClass fallback for non-ASCII.
+                    // The span to search is already on the evaluation stack.
+                    EmitIndexOfWithCharClassFallback(node.Str!, negate, useLast);
+                    return;
                 }
 
-                Debug.Fail("We should never get here. This method should only be called if CanEmitIndexOf returned true, and all of the same cases should be covered.");
+                Debug.Fail("Expected Multi, One, Notone, or Set node.");
             }
 
             // <summary>
@@ -6434,6 +6306,125 @@ namespace System.Text.RegularExpressions
                     (true, true) => SpanLastIndexOfAnyExceptSearchValuesMethod,
                 });
             }
+        }
+
+        /// <summary>
+        /// Emits a vectorized character class search using ASCII-optimized SearchValues with a
+        /// non-ASCII fallback loop. Expects the span to search on the evaluation stack, and
+        /// leaves the found index (or -1) on the evaluation stack.
+        /// </summary>
+        private void EmitIndexOfWithCharClassFallback(string charClass, bool negate, bool useLast)
+        {
+            // Compute the ASCII chars to exclude from the vectorized search.
+            // When negate is false (find IN set): exclude ASCII chars NOT in the set.
+            // When negate is true (find NOT in set): exclude ASCII chars IN the set.
+            using var asciiChars = new ValueListBuilder<char>(stackalloc char[128]);
+            for (int i = 0; i < 128; i++)
+            {
+                if (RegexCharClass.CharInClass((char)i, charClass) == negate)
+                {
+                    asciiChars.Append((char)i);
+                }
+            }
+
+            using RentedLocalBuilder span = RentReadOnlySpanCharLocal();
+            using RentedLocalBuilder iLocal = RentInt32Local();
+
+            // ReadOnlySpan<char> span = /* from stack */;
+            Stloc(span);
+
+            // int i = span.{Last}IndexOfAnyExcept(searchValues);
+            Ldloc(span);
+            if (asciiChars.Length == 128)
+            {
+                Ldc(0);
+                Ldc(127);
+                Call(useLast ? SpanLastIndexOfAnyExceptInRangeMethod : SpanIndexOfAnyExceptInRangeMethod);
+            }
+            else
+            {
+                LoadSearchValues(asciiChars.AsSpan().ToArray());
+                Call(useLast ? SpanLastIndexOfAnyExceptSearchValuesMethod : SpanIndexOfAnyExceptSearchValuesMethod);
+            }
+            Stloc(iLocal);
+
+            Label doneSearch = DefineLabel();
+
+            // Bounds check
+            Ldloc(iLocal);
+            if (useLast)
+            {
+                // if (i < 0) goto doneSearch;
+                Ldc(0);
+                BltFar(doneSearch);
+            }
+            else
+            {
+                // if ((uint)i >= span.Length) goto doneSearch;
+                Ldloca(span);
+                Call(SpanGetLengthMethod);
+                BgeUnFar(doneSearch);
+            }
+
+            // ASCII chars are definitive matches for the search — if the char found is ASCII, we're done.
+            if (asciiChars.Length != 128)
+            {
+                // if (span[i] <= 0x7f) goto doneSearch;
+                Ldc(0x7f);
+                Ldloca(span);
+                Ldloc(iLocal);
+                Call(SpanGetItemMethod);
+                LdindU2();
+                BgeUnFar(doneSearch);
+            }
+
+            // Non-ASCII fallback loop
+            Label loop = DefineLabel();
+            MarkLabel(loop);
+
+            // if (MatchCharacterClass(span[i]) != negate) goto doneSearch;
+            Ldloca(span);
+            Ldloc(iLocal);
+            Call(SpanGetItemMethod);
+            LdindU2();
+            EmitMatchCharacterClass(charClass);
+            if (negate)
+            {
+                Brfalse(doneSearch);
+            }
+            else
+            {
+                Brtrue(doneSearch);
+            }
+
+            // i += direction;
+            Ldloc(iLocal);
+            Ldc(1);
+            if (useLast) { Sub(); } else { Add(); }
+            Stloc(iLocal);
+
+            // Loop condition
+            Ldloc(iLocal);
+            if (useLast)
+            {
+                // while (i >= 0)
+                Ldc(0);
+                BgeFar(loop);
+            }
+            else
+            {
+                // while ((uint)i < span.Length)
+                Ldloca(span);
+                Call(SpanGetLengthMethod);
+                BltUnFar(loop);
+            }
+
+            // i = -1;
+            Ldc(-1);
+            Stloc(iLocal);
+
+            MarkLabel(doneSearch);
+            Ldloc(iLocal);
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorOutputTests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorOutputTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
@@ -118,7 +118,7 @@ namespace System.Text.RegularExpressions.Tests
                     {
                         /// <summary>Cached, thread-safe singleton instance.</summary>
                         internal static readonly Valid_0 Instance = new();
-
+                    
                         /// <summary>Initializes the instance.</summary>
                         private Valid_0()
                         {
@@ -131,13 +131,13 @@ namespace System.Text.RegularExpressions.Tests
                             base.capslist = new string[] {"0", "proto", "port" };
                             base.capsize = 3;
                         }
-
+                            
                         /// <summary>Provides a factory for creating <see cref="RegexRunner"/> instances to be used by methods on <see cref="Regex"/>.</summary>
                         private sealed class RunnerFactory : RegexRunnerFactory
                         {
                             /// <summary>Creates an instance of a <see cref="RegexRunner"/> used by methods on <see cref="Regex"/>.</summary>
                             protected override RegexRunner CreateInstance() => new Runner();
-
+                        
                             /// <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
                             private sealed class Runner : RegexRunner
                             {
@@ -151,14 +151,14 @@ namespace System.Text.RegularExpressions.Tests
                                         base.runtextpos = inputSpan.Length;
                                     }
                                 }
-
+                        
                                 /// <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
                                 /// <param name="inputSpan">The text being scanned by the regular expression.</param>
                                 /// <returns>true if a possible match was found; false if no more matches are possible.</returns>
                                 private bool TryFindNextPossibleStartingPosition(ReadOnlySpan<char> inputSpan)
                                 {
                                     int pos = base.runtextpos;
-
+                                    
                                     // Any possible match is at least 6 characters.
                                     if (pos <= inputSpan.Length - 6)
                                     {
@@ -168,12 +168,12 @@ namespace System.Text.RegularExpressions.Tests
                                             return true;
                                         }
                                     }
-
+                                    
                                     // No match found.
                                     base.runtextpos = inputSpan.Length;
                                     return false;
                                 }
-
+                        
                                 /// <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
                                 /// <param name="inputSpan">The text being scanned by the regular expression.</param>
                                 /// <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
@@ -187,46 +187,46 @@ namespace System.Text.RegularExpressions.Tests
                                     int loop_iteration = 0;
                                     int stackpos = 0;
                                     ReadOnlySpan<char> slice = inputSpan.Slice(pos);
-
+                                    
                                     // Match if at the beginning of the string.
                                     if (pos != 0)
                                     {
                                         UncaptureUntil(0);
                                         return false; // The input didn't match.
                                     }
-
+                                    
                                     // "proto" capture group.
                                     {
                                         capture_starting_pos = pos;
-
+                                        
                                         // Match a word character atomically at least once.
                                         {
-                                            int iteration = 0;
-                                            while ((uint)iteration < (uint)slice.Length && Utilities.IsWordChar(slice[iteration]))
+                                            int iteration = slice.IndexOfAnyExceptWordChar();
+                                            if (iteration < 0)
                                             {
-                                                iteration++;
+                                                iteration = slice.Length;
                                             }
-
+                                            
                                             if (iteration == 0)
                                             {
                                                 UncaptureUntil(0);
                                                 return false; // The input didn't match.
                                             }
-
+                                            
                                             slice = slice.Slice(iteration);
                                             pos += iteration;
                                         }
-
+                                        
                                         base.Capture(1, capture_starting_pos, pos);
                                     }
-
+                                    
                                     // Match the string "://".
                                     if (!slice.StartsWith("://"))
                                     {
                                         UncaptureUntil(0);
                                         return false; // The input didn't match.
                                     }
-
+                                    
                                     // Match a character other than '/' lazily at least once.
                                     //{
                                         if ((uint)slice.Length < 4 || slice[3] == '/')
@@ -234,19 +234,19 @@ namespace System.Text.RegularExpressions.Tests
                                             UncaptureUntil(0);
                                             return false; // The input didn't match.
                                         }
-
+                                        
                                         pos += 4;
                                         slice = inputSpan.Slice(pos);
                                         lazyloop_pos = pos;
                                         goto LazyLoopEnd;
-
+                                        
                                         LazyLoopBacktrack:
                                         UncaptureUntil(lazyloop_capturepos);
                                         if (Utilities.s_hasTimeout)
                                         {
                                             base.CheckTimeout();
                                         }
-
+                                        
                                         pos = lazyloop_pos;
                                         slice = inputSpan.Slice(pos);
                                         if (slice.IsEmpty || slice[0] == '/')
@@ -257,61 +257,61 @@ namespace System.Text.RegularExpressions.Tests
                                         pos++;
                                         slice = inputSpan.Slice(pos);
                                         lazyloop_pos = pos;
-
+                                        
                                         LazyLoopEnd:
                                         lazyloop_capturepos = base.Crawlpos();
                                     //}
-
+                                    
                                     // Optional (greedy).
                                     //{
                                         loop_iteration = 0;
-
+                                        
                                         LoopBody:
                                         Utilities.StackPush(ref base.runstack!, ref stackpos, 143337952);
                                         Utilities.StackPush(ref base.runstack!, ref stackpos, base.Crawlpos(), pos);
-
+                                        
                                         loop_iteration++;
-
+                                        
                                         // "port" capture group.
                                         {
                                             int capture_starting_pos1 = pos;
-
+                                            
                                             // Match ':'.
                                             if (slice.IsEmpty || slice[0] != ':')
                                             {
                                                 goto LoopIterationNoMatch;
                                             }
-
+                                            
                                             // Match a Unicode digit atomically at least once.
                                             {
-                                                pos++;
-                                                slice = inputSpan.Slice(pos);
-                                                int iteration1 = 0;
-                                                while ((uint)iteration1 < (uint)slice.Length && char.IsDigit(slice[iteration1]))
+                                                int iteration1 = slice.Slice(1).IndexOfAnyExceptDigit();
+                                                if (iteration1 < 0)
                                                 {
-                                                    iteration1++;
+                                                    iteration1 = slice.Length - 1;
                                                 }
-
+                                                
                                                 if (iteration1 == 0)
                                                 {
                                                     goto LoopIterationNoMatch;
                                                 }
-
+                                                
                                                 slice = slice.Slice(iteration1);
                                                 pos += iteration1;
                                             }
-
+                                            
+                                            pos++;
+                                            slice = inputSpan.Slice(pos);
                                             base.Capture(2, capture_starting_pos1, pos);
                                         }
-
-
+                                        
+                                        
                                         // The loop has an upper bound of 1. Continue iterating greedily if it hasn't yet been reached.
                                         if (loop_iteration == 0)
                                         {
                                             goto LoopBody;
                                         }
                                         goto LoopEnd;
-
+                                        
                                         // The loop iteration failed. Put state back to the way it was before the iteration.
                                         LoopIterationNoMatch:
                                         if (--loop_iteration < 0)
@@ -325,19 +325,19 @@ namespace System.Text.RegularExpressions.Tests
                                         slice = inputSpan.Slice(pos);
                                         LoopEnd:;
                                     //}
-
+                                    
                                     // Match '/'.
                                     if (slice.IsEmpty || slice[0] != '/')
                                     {
                                         goto LoopIterationNoMatch;
                                     }
-
+                                    
                                     // The input matched.
                                     pos++;
                                     base.runtextpos = pos;
                                     base.Capture(0, matchStart, pos);
                                     return true;
-
+                                    
                                     // <summary>Undo captures until it reaches the specified capture position.</summary>
                                     [MethodImpl(MethodImplOptions.AggressiveInlining)]
                                     void UncaptureUntil(int capturePosition)
@@ -352,17 +352,69 @@ namespace System.Text.RegularExpressions.Tests
                         }
 
                     }
-
+                    
                     /// <summary>Helper methods used by generated <see cref="Regex"/>-derived implementations.</summary>
                     [GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "%VERSION%")]
                     file static class Utilities
                     {
                         /// <summary>Default timeout value set in <see cref="AppContext"/>, or <see cref="Regex.InfiniteMatchTimeout"/> if none was set.</summary>
                         internal static readonly TimeSpan s_defaultTimeout = AppContext.GetData("REGEX_DEFAULT_MATCH_TIMEOUT") is TimeSpan timeout ? timeout : Regex.InfiniteMatchTimeout;
-
+                        
                         /// <summary>Whether <see cref="s_defaultTimeout"/> is non-infinite.</summary>
                         internal static readonly bool s_hasTimeout = s_defaultTimeout != Regex.InfiniteMatchTimeout;
-
+                        
+                        /// <summary>Finds the next index of any character that does not match a Unicode digit.</summary>
+                        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                        internal static int IndexOfAnyExceptDigit(this ReadOnlySpan<char> span)
+                        {
+                            int i = span.IndexOfAnyExcept(Utilities.s_asciiDigits);
+                            if ((uint)i < (uint)span.Length)
+                            {
+                                if (char.IsAscii(span[i]))
+                                {
+                                    return i;
+                                }
+                        
+                                do
+                                {
+                                    if (!char.IsDigit(span[i]))
+                                    {
+                                        return i;
+                                    }
+                                    i++;
+                                }
+                                while ((uint)i < (uint)span.Length);
+                            }
+                        
+                            return -1;
+                        }
+                        
+                        /// <summary>Finds the next index of any character that does not match a word character.</summary>
+                        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                        internal static int IndexOfAnyExceptWordChar(this ReadOnlySpan<char> span)
+                        {
+                            int i = span.IndexOfAnyExcept(Utilities.s_asciiWordChars);
+                            if ((uint)i < (uint)span.Length)
+                            {
+                                if (char.IsAscii(span[i]))
+                                {
+                                    return i;
+                                }
+                        
+                                do
+                                {
+                                    if (!Utilities.IsWordChar(span[i]))
+                                    {
+                                        return i;
+                                    }
+                                    i++;
+                                }
+                                while ((uint)i < (uint)span.Length);
+                            }
+                        
+                            return -1;
+                        }
+                        
                         /// <summary>Determines whether the character is part of the [\w] set.</summary>
                         [MethodImpl(MethodImplOptions.AggressiveInlining)]
                         internal static bool IsWordChar(char ch)
@@ -374,7 +426,7 @@ namespace System.Text.RegularExpressions.Tests
                                 (ascii[chDiv8] & (1 << (ch & 0x7))) != 0 :
                                 (WordCategoriesMask & (1 << (int)CharUnicodeInfo.GetUnicodeCategory(ch))) != 0;
                         }
-
+                        
                         /// <summary>Pushes 1 value onto the backtracking stack.</summary>
                         [MethodImpl(MethodImplOptions.AggressiveInlining)]
                         internal static void StackPush(ref int[] stack, ref int pos, int arg0)
@@ -388,10 +440,10 @@ namespace System.Text.RegularExpressions.Tests
                                 pos++;
                                 return;
                             }
-
+                        
                             // Otherwise, resize the stack to make room and try again.
                             WithResize(ref stack, ref pos, arg0);
-
+                        
                             // <summary>Resize the backtracking stack array and push 1 value onto the stack.</summary>
                             [MethodImpl(MethodImplOptions.NoInlining)]
                             static void WithResize(ref int[] stack, ref int pos, int arg0)
@@ -400,7 +452,7 @@ namespace System.Text.RegularExpressions.Tests
                                 StackPush(ref stack, ref pos, arg0);
                             }
                         }
-
+                        
                         /// <summary>Pushes 2 values onto the backtracking stack.</summary>
                         [MethodImpl(MethodImplOptions.AggressiveInlining)]
                         internal static void StackPush(ref int[] stack, ref int pos, int arg0, int arg1)
@@ -415,10 +467,10 @@ namespace System.Text.RegularExpressions.Tests
                                 pos += 2;
                                 return;
                             }
-
+                        
                             // Otherwise, resize the stack to make room and try again.
                             WithResize(ref stack, ref pos, arg0, arg1);
-
+                        
                             // <summary>Resize the backtracking stack array and push 2 values onto the stack.</summary>
                             [MethodImpl(MethodImplOptions.NoInlining)]
                             static void WithResize(ref int[] stack, ref int pos, int arg0, int arg1)
@@ -427,7 +479,7 @@ namespace System.Text.RegularExpressions.Tests
                                 StackPush(ref stack, ref pos, arg0, arg1);
                             }
                         }
-
+                        
                         /// <summary>Validates that a stack cookie popped off the backtracking stack holds the expected value. Debug only.</summary>
                         internal static int ValidateStackCookie(int expected, int actual)
                         {
@@ -437,7 +489,7 @@ namespace System.Text.RegularExpressions.Tests
                             }
                             return actual;
                         }
-
+                        
                         /// <summary>Provides a mask of Unicode categories that combine to form [\w].</summary>
                         private const int WordCategoriesMask =
                             1 << (int)UnicodeCategory.UppercaseLetter |
@@ -448,15 +500,22 @@ namespace System.Text.RegularExpressions.Tests
                             1 << (int)UnicodeCategory.NonSpacingMark |
                             1 << (int)UnicodeCategory.DecimalDigitNumber |
                             1 << (int)UnicodeCategory.ConnectorPunctuation;
-
+                        
                         /// <summary>Gets a bitmap for whether each character 0 through 127 is in [\w]</summary>
                         private static ReadOnlySpan<byte> WordCharBitmap => new byte[]
                         {
                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0x03,
                             0xFE, 0xFF, 0xFF, 0x87, 0xFE, 0xFF, 0xFF, 0x07
                         };
+                        
+                        /// <summary>Supports searching for characters in or not in "0123456789".</summary>
+                        internal static readonly SearchValues<char> s_asciiDigits = SearchValues.Create("0123456789");
+                        
+                        /// <summary>Supports searching for characters in or not in "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz".</summary>
+                        internal static readonly SearchValues<char> s_asciiWordChars = SearchValues.Create("0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz");
                     }
                 }
+
                 """
             };
 
@@ -522,7 +581,7 @@ namespace System.Text.RegularExpressions.Tests
                     {
                         /// <summary>Cached, thread-safe singleton instance.</summary>
                         internal static readonly Valid_0 Instance = new();
-
+                    
                         /// <summary>Initializes the instance.</summary>
                         private Valid_0()
                         {
@@ -532,13 +591,13 @@ namespace System.Text.RegularExpressions.Tests
                             base.factory = new RunnerFactory();
                             base.capsize = 2;
                         }
-
+                            
                         /// <summary>Provides a factory for creating <see cref="RegexRunner"/> instances to be used by methods on <see cref="Regex"/>.</summary>
                         private sealed class RunnerFactory : RegexRunnerFactory
                         {
                             /// <summary>Creates an instance of a <see cref="RegexRunner"/> used by methods on <see cref="Regex"/>.</summary>
                             protected override RegexRunner CreateInstance() => new Runner();
-
+                        
                             /// <summary>Provides the runner that contains the custom logic implementing the specified regular expression.</summary>
                             private sealed class Runner : RegexRunner
                             {
@@ -554,14 +613,14 @@ namespace System.Text.RegularExpressions.Tests
                                         base.runtextpos++;
                                     }
                                 }
-
+                        
                                 /// <summary>Search <paramref name="inputSpan"/> starting from base.runtextpos for the next location a match could possibly start.</summary>
                                 /// <param name="inputSpan">The text being scanned by the regular expression.</param>
                                 /// <returns>true if a possible match was found; false if no more matches are possible.</returns>
                                 private bool TryFindNextPossibleStartingPosition(ReadOnlySpan<char> inputSpan)
                                 {
                                     int pos = base.runtextpos;
-
+                                    
                                     // Any possible match is at least 6 characters.
                                     if (pos <= inputSpan.Length - 6)
                                     {
@@ -574,12 +633,12 @@ namespace System.Text.RegularExpressions.Tests
                                             return true;
                                         }
                                     }
-
+                                    
                                     // No match found.
                                     base.runtextpos = inputSpan.Length;
                                     return false;
                                 }
-
+                        
                                 /// <summary>Determine whether <paramref name="inputSpan"/> at base.runtextpos is a match for the regular expression.</summary>
                                 /// <param name="inputSpan">The text being scanned by the regular expression.</param>
                                 /// <returns>true if the regular expression matches at the current position; otherwise, false.</returns>
@@ -593,54 +652,54 @@ namespace System.Text.RegularExpressions.Tests
                                     int charloop_capture_pos = 0;
                                     int charloop_starting_pos = 0, charloop_ending_pos = 0;
                                     ReadOnlySpan<char> slice = inputSpan.Slice(pos);
-
+                                    
                                     // Match the string "href".
                                     if (!slice.StartsWith("href"))
                                     {
                                         UncaptureUntil(0);
                                         return false; // The input didn't match.
                                     }
-
+                                    
                                     // Match a whitespace character atomically any number of times.
                                     {
-                                        int iteration = 4;
-                                        while ((uint)iteration < (uint)slice.Length && char.IsWhiteSpace(slice[iteration]))
+                                        int iteration = slice.Slice(4).IndexOfAnyExceptWhiteSpace();
+                                        if (iteration < 0)
                                         {
-                                            iteration++;
+                                            iteration = slice.Length - 4;
                                         }
-
+                                        
                                         slice = slice.Slice(iteration);
                                         pos += iteration;
                                     }
-
+                                    
                                     // Match '='.
-                                    if (slice.IsEmpty || slice[0] != '=')
+                                    if ((uint)slice.Length < 5 || slice[4] != '=')
                                     {
                                         UncaptureUntil(0);
                                         return false; // The input didn't match.
                                     }
-
+                                    
                                     // Match a whitespace character greedily any number of times.
                                     //{
-                                        pos++;
+                                        pos += 5;
                                         slice = inputSpan.Slice(pos);
                                         charloop_starting_pos = pos;
-
-                                        int iteration1 = 0;
-                                        while ((uint)iteration1 < (uint)slice.Length && char.IsWhiteSpace(slice[iteration1]))
+                                        
+                                        int iteration1 = slice.IndexOfAnyExceptWhiteSpace();
+                                        if (iteration1 < 0)
                                         {
-                                            iteration1++;
+                                            iteration1 = slice.Length;
                                         }
-
+                                        
                                         slice = slice.Slice(iteration1);
                                         pos += iteration1;
-
+                                        
                                         charloop_ending_pos = pos;
                                         goto CharLoopEnd;
-
+                                        
                                         CharLoopBacktrack:
                                         UncaptureUntil(charloop_capture_pos);
-
+                                        
                                         if (charloop_starting_pos >= charloop_ending_pos)
                                         {
                                             UncaptureUntil(0);
@@ -648,16 +707,16 @@ namespace System.Text.RegularExpressions.Tests
                                         }
                                         pos = --charloop_ending_pos;
                                         slice = inputSpan.Slice(pos);
-
+                                        
                                         CharLoopEnd:
                                         charloop_capture_pos = base.Crawlpos();
                                     //}
-
+                                    
                                     // Match with 2 alternative expressions, atomically.
                                     {
                                         int alternation_starting_pos = pos;
                                         int alternation_starting_capturepos = base.Crawlpos();
-
+                                        
                                         // Branch 0
                                         {
                                             // Match a character in the set ["'].
@@ -665,13 +724,13 @@ namespace System.Text.RegularExpressions.Tests
                                             {
                                                 goto AlternationBranch;
                                             }
-
+                                            
                                             // 1st capture group.
                                             {
                                                 pos++;
                                                 slice = inputSpan.Slice(pos);
                                                 capture_starting_pos = pos;
-
+                                                
                                                 // Match a character in the set [^"'] atomically any number of times.
                                                 {
                                                     int iteration2 = slice.IndexOfAny('"', '\'');
@@ -679,66 +738,66 @@ namespace System.Text.RegularExpressions.Tests
                                                     {
                                                         iteration2 = slice.Length;
                                                     }
-
+                                                    
                                                     slice = slice.Slice(iteration2);
                                                     pos += iteration2;
                                                 }
-
+                                                
                                                 base.Capture(1, capture_starting_pos, pos);
                                             }
-
+                                            
                                             // Match a character in the set ["'].
                                             if (slice.IsEmpty || (((ch = slice[0]) != '"') & (ch != '\'')))
                                             {
                                                 goto AlternationBranch;
                                             }
-
+                                            
                                             pos++;
                                             slice = inputSpan.Slice(pos);
                                             goto AlternationMatch;
-
+                                            
                                             AlternationBranch:
                                             pos = alternation_starting_pos;
                                             slice = inputSpan.Slice(pos);
                                             UncaptureUntil(alternation_starting_capturepos);
                                         }
-
+                                        
                                         // Branch 1
                                         {
                                             // 1st capture group.
                                             {
                                                 capture_starting_pos1 = pos;
-
+                                                
                                                 // Match a character in the set [^>\s] atomically at least once.
                                                 {
-                                                    int iteration3 = 0;
-                                                    while ((uint)iteration3 < (uint)slice.Length && ((ch = slice[iteration3]) < 128 ? ("쇿\uffff\ufffe뿿\uffff\uffff\uffff\uffff"[ch >> 4] & (1 << (ch & 0xF))) != 0 : RegexRunner.CharInClass((char)ch, "\u0001\u0002\u0001>?d")))
+                                                    int iteration3 = slice.IndexOfAnyExcept_92ADA2AB68AD19F57A1E78FA973AF4ED3FB64C5AB5DF24C6A8EE0B8823EC27CF();
+                                                    if (iteration3 < 0)
                                                     {
-                                                        iteration3++;
+                                                        iteration3 = slice.Length;
                                                     }
-
+                                                    
                                                     if (iteration3 == 0)
                                                     {
                                                         goto CharLoopBacktrack;
                                                     }
-
+                                                    
                                                     slice = slice.Slice(iteration3);
                                                     pos += iteration3;
                                                 }
-
+                                                
                                                 base.Capture(1, capture_starting_pos1, pos);
                                             }
-
+                                            
                                         }
-
+                                        
                                         AlternationMatch:;
                                     }
-
+                                    
                                     // The input matched.
                                     base.runtextpos = pos;
                                     base.Capture(0, matchStart, pos);
                                     return true;
-
+                                    
                                     // <summary>Undo captures until it reaches the specified capture position.</summary>
                                     [MethodImpl(MethodImplOptions.AggressiveInlining)]
                                     void UncaptureUntil(int capturePosition)
@@ -753,15 +812,75 @@ namespace System.Text.RegularExpressions.Tests
                         }
 
                     }
-
+                    
                     /// <summary>Helper methods used by generated <see cref="Regex"/>-derived implementations.</summary>
                     [GeneratedCodeAttribute("System.Text.RegularExpressions.Generator", "%VERSION%")]
                     file static class Utilities
                     {
+                        /// <summary>Finds the next index of any character that does not match a whitespace character.</summary>
+                        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                        internal static int IndexOfAnyExceptWhiteSpace(this ReadOnlySpan<char> span)
+                        {
+                            int i = span.IndexOfAnyExcept(Utilities.s_asciiWhiteSpace);
+                            if ((uint)i < (uint)span.Length)
+                            {
+                                if (char.IsAscii(span[i]))
+                                {
+                                    return i;
+                                }
+                        
+                                do
+                                {
+                                    if (!char.IsWhiteSpace(span[i]))
+                                    {
+                                        return i;
+                                    }
+                                    i++;
+                                }
+                                while ((uint)i < (uint)span.Length);
+                            }
+                        
+                            return -1;
+                        }
+                        
+                        /// <summary>Finds the next index of any character that does not match a character in the set [^&gt;\s].</summary>
+                        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                        internal static int IndexOfAnyExcept_92ADA2AB68AD19F57A1E78FA973AF4ED3FB64C5AB5DF24C6A8EE0B8823EC27CF(this ReadOnlySpan<char> span)
+                        {
+                            int i = span.IndexOfAnyExcept(Utilities.s_ascii_FFC1FFFFFEFFFFBFFFFFFFFFFFFFFFFF);
+                            if ((uint)i < (uint)span.Length)
+                            {
+                                if (char.IsAscii(span[i]))
+                                {
+                                    return i;
+                                }
+                        
+                                char ch;
+                                do
+                                {
+                                    if (((ch = span[i]) < 128 ? ("쇿\uffff\ufffe뿿\uffff\uffff\uffff\uffff"[ch >> 4] & (1 << (ch & 0xF))) == 0 : !RegexRunner.CharInClass((char)ch, "\u0001\u0002\u0001>?d")))
+                                    {
+                                        return i;
+                                    }
+                                    i++;
+                                }
+                                while ((uint)i < (uint)span.Length);
+                            }
+                        
+                            return -1;
+                        }
+                        
+                        /// <summary>Supports searching for characters in or not in "\t\n\v\f\r ".</summary>
+                        internal static readonly SearchValues<char> s_asciiWhiteSpace = SearchValues.Create("\t\n\v\f\r ");
+                        
+                        /// <summary>Supports searching for characters in or not in "\0\u0001\u0002\u0003\u0004\u0005\u0006\a\b\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f!\"#$%&amp;'()*+,-./0123456789:;&lt;=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007f".</summary>
+                        internal static readonly SearchValues<char> s_ascii_FFC1FFFFFEFFFFBFFFFFFFFFFFFFFFFF = SearchValues.Create("\0\u0001\u0002\u0003\u0004\u0005\u0006\a\b\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f!\"#$%&'()*+,-./0123456789:;<=?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007f");
+                        
                         /// <summary>Supports searching for the string "href".</summary>
                         internal static readonly SearchValues<string> s_indexOfString_href_Ordinal = SearchValues.Create(["href"], StringComparison.Ordinal);
                     }
                 }
+
                 """
             };
 


### PR DESCRIPTION
Extend both the source generator (`RegexGenerator.Emitter.cs`) and `RegexCompiler` to vectorize regex loops for complex character classes that previously fell through to scalar character-by-character matching. This primarily benefits the extremely common `\w+`, `\d+`, `\s+` patterns (and their negations), as well as Unicode category sets and sets with subtraction.

## What changed

**`TryEmitIndexOf` (source generator)** — now always succeeds for set families by falling back to `EmitIndexOfAnyCustomHelper`, which generates a helper using vectorized `SearchValues<char>` for ASCII with a scalar `MatchCharacterClass` fallback for non-ASCII.

**`EmitIndexOf` / `EmitIndexOfWithCharClassFallback` (RegexCompiler)** — parallel change that emits inline IL for the same pattern: `IndexOfAnyExcept(SearchValues)` for fast ASCII scanning, then `EmitMatchCharacterClass` for non-ASCII fallback. The existing inline code from `EmitFixedSet_LeftToRight` was extracted into the reusable `EmitIndexOfWithCharClassFallback` method.

**`CanEmitIndexOf`** — simplified to return true for all `IsSetFamily` nodes since `EmitIndexOf` can now handle them all.

**`EmitIndexOfAnyCustomHelper`** — extended with `negate` and `last` parameters. Negation is applied at the boolean level (via `CharInClass`/`MatchCharacterClass`) rather than by toggling the set string's internal negation flag, which doesn't correctly negate subtraction sets due to how `CharInClassIterative` processes subtraction chains.

**Repeater path** — changed from the fragile `indexOfExpr.Replace("IndexOf", "Contains")` pattern to the equivalent `{indexOfExpr} >= 0`.

## Impact

Patterns like `\w+`, `\d+`, `\s+`, `[\p{L}]+`, `[\w-[abc]]+` in atomic loops (which most become via auto-atomicity) and fixed-count repeaters now use vectorized search instead of scalar loops, for both `RegexOptions.Compiled` and source-generated regexes.
