### PR TITLE
Fix race in BackgroundService exception aggregation during Host shutdown

### DIFF
--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -127,7 +127,12 @@ namespace Microsoft.Extensions.Hosting.Internal
 
                         if (service is BackgroundService backgroundService)
                         {
-                            (_backgroundServiceTasks ??= new()).Add(TryExecuteBackgroundServiceAsync(backgroundService));
+                            Task monitorTask = TryExecuteBackgroundServiceAsync(backgroundService);
+                            List<Task> bgTasks = LazyInitializer.EnsureInitialized(ref _backgroundServiceTasks);
+                            lock (bgTasks)
+                            {
+                                bgTasks.Add(monitorTask);
+                            }
                         }
                     }).ConfigureAwait(false);
 

--- a/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Extensions.Hosting.Internal
         private IEnumerable<IHostedLifecycleService>? _hostedLifecycleServices;
         private bool _hostStarting;
         private bool _hostStopped;
+        private List<Task>? _backgroundServiceTasks;
         private List<Exception>? _backgroundServiceExceptions;
 
         public Host(IServiceProvider services,
@@ -126,7 +127,7 @@ namespace Microsoft.Extensions.Hosting.Internal
 
                         if (service is BackgroundService backgroundService)
                         {
-                            _ = TryExecuteBackgroundServiceAsync(backgroundService);
+                            (_backgroundServiceTasks ??= new()).Add(TryExecuteBackgroundServiceAsync(backgroundService));
                         }
                     }).ConfigureAwait(false);
 
@@ -288,6 +289,23 @@ namespace Microsoft.Extensions.Hosting.Internal
                 }
 
                 _hostStopped = true;
+
+                // Ensure all background service monitoring tasks have finished processing
+                // exceptions before we read them. Without this, there's a race: when a
+                // BackgroundService's ExecuteTask faults, both BackgroundService.StopAsync
+                // (which Host awaits) and TryExecuteBackgroundServiceAsync (fire-and-forget)
+                // have continuations scheduled. If StopAsync's continuation runs first, the
+                // Host may read _backgroundServiceExceptions before the monitoring task has
+                // added its exception.
+                if (_backgroundServiceTasks is not null)
+                {
+                    Task bgMonitoringTasks = Task.WhenAll(_backgroundServiceTasks);
+                    var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    using (cancellationToken.Register(s => ((TaskCompletionSource<object?>)s!).TrySetCanceled(), tcs))
+                    {
+                        await Task.WhenAny(bgMonitoringTasks, tcs.Task).ConfigureAwait(false);
+                    }
+                }
 
                 // If background services faulted and caused the host to stop, rethrow the exceptions
                 // so they propagate and cause a non-zero exit code.

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
@@ -181,6 +181,38 @@ namespace Microsoft.Extensions.Hosting.Tests
         }
 
         /// <summary>
+        /// Regression test for a race where the fire-and-forget TryExecuteBackgroundServiceAsync
+        /// has not yet recorded its exception by the time Host.StopAsync reads the exception list.
+        /// DelayedMonitorFaultService overrides ExecuteTask so that the monitoring task sees a
+        /// separately-controlled task that faults 200ms after StopAsync returns,
+        /// reproducing the window in which the exception would be lost without the fix.
+        /// </summary>
+        [Fact]
+        public async Task BackgroundService_DelayedMonitoringException_ThrowsAggregateException()
+        {
+            var builder = new HostBuilder()
+                .ConfigureServices(services =>
+                {
+                    services.Configure<HostOptions>(options =>
+                    {
+                        options.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.StopHost;
+                    });
+                    services.AddHostedService<SynchronousFailureService>();
+                    services.AddHostedService<DelayedMonitorFaultService>();
+                });
+
+            var aggregateException = await Assert.ThrowsAsync<AggregateException>(async () =>
+            {
+                await builder.Build().RunAsync();
+            });
+
+            Assert.Equal(2, aggregateException.InnerExceptions.Count);
+
+            Assert.All(aggregateException.InnerExceptions, ex =>
+                Assert.IsType<InvalidOperationException>(ex));
+        }
+
+        /// <summary>
         /// Tests that when a BackgroundService throws an exception with Ignore behavior,
         /// the host does not throw and continues to run until stopped.
         /// </summary>
@@ -292,6 +324,43 @@ namespace Microsoft.Extensions.Hosting.Tests
         {
             public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
             public Task StopAsync(CancellationToken cancellationToken) => throw new InvalidOperationException("Stop failure");
+        }
+
+        /// <summary>
+        /// A BackgroundService that overrides <see cref="ExecuteTask"/> to return a separately
+        /// controlled task. The internal _executeTask (used by BackgroundService.StopAsync) completes
+        /// normally on cancellation, but the overridden ExecuteTask (monitored by
+        /// TryExecuteBackgroundServiceAsync) faults 200ms after StopAsync, deterministically
+        /// reproducing the race window.
+        /// </summary>
+        private class DelayedMonitorFaultService : BackgroundService
+        {
+            private readonly TaskCompletionSource<object?> _monitorTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public override Task? ExecuteTask => _monitorTcs.Task;
+
+            protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+            {
+                try
+                {
+                    await Task.Delay(Timeout.Infinite, stoppingToken);
+                }
+                catch (OperationCanceledException)
+                {
+                }
+            }
+
+            public override async Task StopAsync(CancellationToken cancellationToken)
+            {
+                await base.StopAsync(cancellationToken);
+                _ = Task.Run(async () =>
+                {
+                    // This is testing that ExecuteTask delays stopping of the host, so it can't be triggered by a deterministic signal.
+                    // It shouldn't cause any flakiness: incorrect ordering could cause the test to succeed when it should fail, but it shouldn't cause the test to fail when it should succeed.
+                    await Task.Delay(200);
+                    _monitorTcs.TrySetException(new InvalidOperationException("Delayed monitor failure"));
+                });
+            }
         }
 
         private class SuccessfulService : BackgroundService

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Extensions.Hosting.Tests
         /// A BackgroundService that overrides <see cref="ExecuteTask"/> to return a separately
         /// controlled task. The internal _executeTask (used by BackgroundService.StopAsync) completes
         /// normally on cancellation, but the overridden ExecuteTask (monitored by
-        /// TryExecuteBackgroundServiceAsync) faults 200ms after StopAsync, deterministically
+        /// TryExecuteBackgroundServiceAsync) faults 200ms after StopAsync, usually
         /// reproducing the race window.
         /// </summary>
         private class DelayedMonitorFaultService : BackgroundService


### PR DESCRIPTION
Fixes #125589

## Problem

When multiple `BackgroundService` instances fault with `BackgroundServiceExceptionBehavior.StopHost`, some exceptions can be silently lost.

In real workloads, multiple `BackgroundService`s commonly fail together — for example, when a shared dependency like a database or message broker goes down. With this bug, only one of those failures is reported; the rest are silently dropped. This makes production incidents harder to diagnose: operators see one service failed but have no indication that others also failed, leading to incomplete root-cause analysis and potentially missing the actual source of the problem.

The `BackgroundServiceExceptionTests.BackgroundService_MultipleExceptions_ThrowsAggregateException` test is flaky because of this (observed on osx-arm64 Debug).

## Root Cause

In `StartAsync`, [`TryExecuteBackgroundServiceAsync` is fire-and-forget](https://github.com/dotnet/runtime/blob/c38f37a3a1c/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs#L129) (`_ =`). This method [awaits the service's `ExecuteTask`](https://github.com/dotnet/runtime/blob/c38f37a3a1c/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs#L186) and [adds any exception to `_backgroundServiceExceptions`](https://github.com/dotnet/runtime/blob/c38f37a3a1c/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs#L201). During `StopAsync`, [`BackgroundService.StopAsync` also awaits the same `ExecuteTask`](https://github.com/dotnet/runtime/blob/c38f37a3a1c/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/BackgroundService.cs#L73). When the task faults, both continuations are scheduled on the thread pool. If the `StopAsync` continuation runs first, `Host.StopAsync` proceeds to [read `_backgroundServiceExceptions`](https://github.com/dotnet/runtime/blob/c38f37a3a1c/src/libraries/Microsoft.Extensions.Hosting/src/Internal/Host.cs#L294) before the monitoring task has added its exception.

## Fix

Store the `TryExecuteBackgroundServiceAsync` tasks and await them in `StopAsync` (respecting the shutdown timeout) before reading the exception list.

## Verification

The original failure was only observed on macOS arm64 and could not be reproduced directly on Windows. However, injecting a 500ms `Task.Delay` into `TryExecuteBackgroundServiceAsync` deterministically simulates the thread-pool scheduling that causes the race, providing high-confidence verification on any platform:
- **Without fix + delay**: test fails 10/10
- **With fix + delay**: test fails 0/10
- **With fix, no delay**: all 291 hosting unit tests pass
