### PR TITLE
Avoid unnecessary copy in TextWriter.Write(string)

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/TextWriter.cs
@@ -278,7 +278,7 @@ namespace System.IO
         {
             if (value != null)
             {
-                Write(value.ToCharArray());
+                Write(value.AsSpan());
             }
         }
 


### PR DESCRIPTION
This PR updates the `Write(string?)` overload in `TextWriter.cs` to avoid copying the string data.