### PR TITLE
Do not store result of cast in IDynIntfCastable scenarios

### DIFF
--- a/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
+++ b/src/coreclr/nativeaot/Runtime.Base/src/System/Runtime/TypeCast.cs
@@ -1231,10 +1231,9 @@ namespace System.Runtime
             }
 
             //
-            // Update the cache. We only consider type-based conversion rules here.
-            // Therefore a negative result cannot rule out convertibility for IDynamicInterfaceCastable.
+            // Update the cache
             //
-            if (retObj != null || !(pTargetType->IsInterface && pSourceType->IsIDynamicInterfaceCastable))
+            if (!pSourceType->IsIDynamicInterfaceCastable || !pTargetType->IsInterface)
             {
                 nuint sourceAndVariation = (nuint)pSourceType + (uint)AssignmentVariation.BoxedSource;
                 s_castCache.TrySet(sourceAndVariation, (nuint)pTargetType, retObj != null);
@@ -1273,8 +1272,11 @@ namespace System.Runtime
             //
             // Update the cache
             //
-            nuint sourceAndVariation = (nuint)pSourceType + (uint)AssignmentVariation.BoxedSource;
-            s_castCache.TrySet(sourceAndVariation, (nuint)pTargetType, true);
+            if (!pSourceType->IsIDynamicInterfaceCastable || !pTargetType->IsInterface)
+            {
+                nuint sourceAndVariation = (nuint)pSourceType + (uint)AssignmentVariation.BoxedSource;
+                s_castCache.TrySet(sourceAndVariation, (nuint)pTargetType, true);
+            }
 
             return obj;
         }

--- a/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
+++ b/src/tests/nativeaot/SmokeTests/UnitTests/Interfaces.cs
@@ -64,6 +64,7 @@ public class Interfaces
         TestDynamicStaticGenericVirtualMethods.Run();
         TestRuntime109496Regression.Run();
         TestRuntime113664Regression.Run();
+        TestRuntime125577Regression.Run();
 
         return Pass;
     }
@@ -2046,4 +2047,30 @@ public class Interfaces
             return T.Frob<V>();
         }
     }
+
+    class TestRuntime125577Regression
+    {
+        class Shapeshifter : IDynamicInterfaceCastable
+        {
+            bool _result;
+            public Shapeshifter(bool result) => _result = result;
+
+            public RuntimeTypeHandle GetInterfaceImplementation(RuntimeTypeHandle interfaceType) => throw new NotImplementedException();
+            public bool IsInterfaceImplemented(RuntimeTypeHandle interfaceType, bool throwIfNotImplemented) => _result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static bool Is(object o, bool expected) => o is IEnumerable<object> == expected;
+
+        public static void Run()
+        {
+            // Call multiple times in case we just flushed the cast cache (when we flush we don't store).
+            if (!Is(new Shapeshifter(true), true)
+                || !Is(new Shapeshifter(false), false)
+                || !Is(new Shapeshifter(true), true)
+                || !Is(new Shapeshifter(false), false))
+                throw new Exception();
+        }
+    }
+
 }


### PR DESCRIPTION
Fixes #125577

Incorrectly copied a piece of logic and comment from CoreCLR but different considerations apply here (we do have an object instance).

Cc @dotnet/ilc-contrib 