### PR TITLE
[release/10.0] Fix missing call to write barrier in static constructors of ref structs

### DIFF
--- a/src/coreclr/jit/importer.cpp
+++ b/src/coreclr/jit/importer.cpp
@@ -9814,9 +9814,9 @@ void Compiler::impImportBlockCode(BasicBlock* block)
                     // Field's type is a byref-like struct -> address is not on the heap.
                     indirFlags |= GTF_IND_TGT_NOT_HEAP;
                 }
-                else
+                else if ((fieldInfo.fieldFlags & CORINFO_FLG_FIELD_STATIC) == 0)
                 {
-                    // Field's owner is a byref-like struct -> address is not on the heap.
+                    // Field's owner is a byref-like struct and the field is not static -> address is not on the heap.
                     CORINFO_CLASS_HANDLE fldOwner = info.compCompHnd->getFieldClass(resolvedToken.hField);
                     if ((fldOwner != NO_CLASS_HANDLE) && eeIsByrefLike(fldOwner))
                     {


### PR DESCRIPTION

This change fixes it and adds a regression test that causes fatal error when run with DOTNET_HeapVerify=1.

Backport of #125418 to release/10.0

## Customer Impact

- [x] Customer reported
- [ ] Found internally

A customer has reported intermittent crashes in their application after migrating to .NET 10. Analysis has revealed GC heap corruption where a reference field of an object was pointing to a stale address of another object.
The JIT was incorrectly handling initialization of static fields of ref structs. It was not adding call to JIT_ByRefWriteBarrier when setting these fields even though these statics live in GC heap.

## Regression

- [x] Yes, introduced in .NET 10 in #111733
- [ ] No

## Testing
CI tests, local manual directed test provided by the customer

## Risk
Low, the change just adds write barrier call for static fields of ref structs that were missing.
