### PR TITLE
Add cdac.slnx solution file for cDAC development

### DIFF
--- a/src/native/managed/cdac/README.md
+++ b/src/native/managed/cdac/README.md
@@ -68,32 +68,12 @@ Key specs: [GC](/docs/design/datacontracts/GC.md) ·
 
 ## Unit testing
 
-### Setting up a solution
+### Opening the solution
 
-For VS Code and Visual Studio, create a file `cdac.slnx` in the runtime repo root to bring
-all the cDAC projects into scope:
-
-```xml
-<Solution>
-  <Configurations>
-    <Platform Name="Any CPU" />
-    <Platform Name="x64" />
-    <Platform Name="x86" />
-  </Configurations>
-  <Folder Name="/cdac/">
-    <Project Path="src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Microsoft.Diagnostics.DataContractReader.Abstractions.csproj" />
-    <Project Path="src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Microsoft.Diagnostics.DataContractReader.Contracts.csproj" />
-    <Project Path="src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/Microsoft.Diagnostics.DataContractReader.csproj" />
-    <Project Path="src/native/managed/cdac/mscordaccore_universal/mscordaccore_universal.csproj" />
-  </Folder>
-  <Folder Name="/tests/">
-    <Project Path="src/native/managed/cdac/tests/Microsoft.Diagnostics.DataContractReader.Tests.csproj" />
-  </Folder>
-</Solution>
-```
-
-In VS Code, run the ".NET: Open Solution" command and select `cdac.slnx`. In Visual Studio,
-open the solution file directly. You can then use Test Explorer to run and debug tests.
+The [`cdac.slnx`](cdac.slnx) solution file in this directory brings all cDAC projects and
+tests into scope. In VS Code, run the ".NET: Open Solution" command and select
+`src/native/managed/cdac/cdac.slnx`. In Visual Studio, open the file directly. You can then
+use Test Explorer to run and debug tests.
 
 ### Running unit tests from the command line
 

--- a/src/native/managed/cdac/cdac.slnx
+++ b/src/native/managed/cdac/cdac.slnx
@@ -1,0 +1,18 @@
+<Solution>
+  <Configurations>
+    <Platform Name="Any CPU" />
+    <Platform Name="x64" />
+    <Platform Name="x86" />
+  </Configurations>
+  <Folder Name="/cdac/">
+    <Project Path="Microsoft.Diagnostics.DataContractReader.Abstractions/Microsoft.Diagnostics.DataContractReader.Abstractions.csproj" />
+    <Project Path="Microsoft.Diagnostics.DataContractReader.Contracts/Microsoft.Diagnostics.DataContractReader.Contracts.csproj" />
+    <Project Path="Microsoft.Diagnostics.DataContractReader/Microsoft.Diagnostics.DataContractReader.csproj" />
+    <Project Path="Microsoft.Diagnostics.DataContractReader.Legacy/Microsoft.Diagnostics.DataContractReader.Legacy.csproj" />
+    <Project Path="mscordaccore_universal/mscordaccore_universal.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Microsoft.Diagnostics.DataContractReader.Tests.csproj" />
+    <Project Path="tests/DumpTests/Microsoft.Diagnostics.DataContractReader.DumpTests.csproj" />
+  </Folder>
+</Solution>


### PR DESCRIPTION
Add a checked-in `cdac.slnx` to `src/native/managed/cdac/` that includes all cDAC library projects and both test projects (unit tests and dump tests). This replaces the README instructions that asked developers to manually create a solution file at the repo root.

## Changes

- **New file** — `src/native/managed/cdac/cdac.slnx`: Solution with all 5 library projects in a `/cdac/` folder and 2 test projects in a `/tests/` folder. Debuggee programs are excluded since they are build-time dependencies, not direct dev targets.
- **Updated** — `src/native/managed/cdac/README.md`: Replaced the *Setting up a solution* section (which had an incomplete template missing Legacy and DumpTests) with an *Opening the solution* section referencing the checked-in file.

## Validation

- `dotnet build cdac.slnx` succeeds with 0 warnings
- All 1235 unit tests pass