### PR TITLE
Fix `WebWorker` hang when debugging Blazor WASM apps in Visual Studio

### DIFF
--- a/eng/pipelines/performance/templates/perf-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-build-jobs.yml
@@ -6,6 +6,7 @@ jobs:
   - template: /eng/pipelines/performance/templates/perf-coreclr-build-jobs.yml
     parameters:
       linux_x64: true
+      linux_arm64: true
       windows_x64: true
       windows_x86: true
       android_arm64: true

--- a/src/mono/browser/debugger/BrowserDebugProxy/MonoProxy.cs
+++ b/src/mono/browser/debugger/BrowserDebugProxy/MonoProxy.cs
@@ -170,7 +170,11 @@ namespace Microsoft.WebAssembly.Diagnostics
                         if (targetType == "page")
                             await AttachToTarget(new SessionId(args["sessionId"]?.ToString()), token);
                         else if (targetType == "worker")
-                            Contexts.CreateWorkerExecutionContext(new SessionId(args["sessionId"]?.ToString()), new SessionId(parms["sessionId"]?.ToString()), logger);
+                        {
+                            var workerSessionId = new SessionId(args["sessionId"]?.ToString());
+                            Contexts.CreateWorkerExecutionContext(workerSessionId, new SessionId(parms["sessionId"]?.ToString()), logger);
+                            await SendCommand(workerSessionId, "Runtime.runIfWaitingForDebugger", new JObject(), token);
+                        }
                         break;
                     }
 
@@ -245,7 +249,16 @@ namespace Microsoft.WebAssembly.Diagnostics
                         if (JustMyCode)
                         {
                             if (!Contexts.TryGetCurrentExecutionContextValue(sessionId, out ExecutionContext context) || !context.IsRuntimeReady)
+                            {
+                                // For worker sessions where runtime isn't ready yet,
+                                // resume instead of forwarding to IDE (which would leave worker stuck)
+                                if (context?.ParentContext != null)
+                                {
+                                    await SendResume(sessionId, token);
+                                    return true;
+                                }
                                 return false;
+                            }
                             //avoid pausing when justMyCode is enabled and it's a wasm function
                             if (args?["callFrames"]?[0]?["scopeChain"]?[0]?["type"]?.Value<string>()?.Equals("wasm-expression-stack") == true)
                             {


### PR DESCRIPTION
## Summary

When debugging a Blazor WebAssembly app that uses Web Workers (via the `dotnet new webworker` template, see https://github.com/dotnet/aspnetcore/pull/65037) in Visual Studio, the worker thread hangs indefinitely during startup. The app never completes initialization and the worker appears stuck at importing worker's module.
```
await using var module = await jsRuntime.InvokeAsync<IJSObjectReference>("import", "./_content/WorkerLib/dotnet-web-worker-client.js");
```

This PR fixes two issues in the BrowserDebugProxy (`MonoProxy`) that together cause the hang.

You can use this app to see the problem: [BlazorAppRepro.zip](https://github.com/user-attachments/files/26027798/BlazorAppRepro.zip)

## Root Cause

**Issue 1 — Worker never resumed after Chrome pauses it on attach:**

When VS sends `Target.setAutoAttach({ waitForDebuggerOnStart: true })`, Chrome pauses all new worker threads until the debugger explicitly sends `Runtime.runIfWaitingForDebugger`. The proxy's `Target.attachedToTarget` handler for workers only called `CreateWorkerExecutionContext()` but never sent `Runtime.runIfWaitingForDebugger`, leaving the worker frozen before any JS executed.

**Issue 2 — `Debugger.paused` event forwarded to IDE instead of being resumed:**

Even after resuming the worker, VS's JavaScript debugger auto-attaches with `breakOnLoad: true`, which fires a `Debugger.paused` event on the worker session. In `OnDebuggerPaused`'s default case, when `JustMyCode` is enabled and the execution context isn't runtime-ready (`IsRuntimeReady == false`), the handler returns `false` — forwarding the pause to VS. VS's JS debugger receives the pause but doesn't resume it, leaving the worker stuck. Shortly after, the CDP connection crashes with `ObjectDisposedException`.

## Changes

**`MonoProxy.cs`** — two targeted fixes:

1. **`Target.attachedToTarget` handler**: For worker targets, send `Runtime.runIfWaitingForDebugger` after creating the worker execution context. This tells Chrome to unpause the worker thread.

2. **`OnDebuggerPaused` default case**: When the session belongs to a worker (detected via `context.ParentContext != null`) and the runtime isn't ready yet, call `SendResume` instead of returning `false`. This prevents the pause from being forwarded to the IDE and lets the worker continue booting its WASM runtime.

## Testing

Manually verified with a Blazor WASM Standalone app + webworker library project in VS 2022 (by replacing the .dlls VS uses):
- **Before fix**: F5 → worker hangs at startup, app stuck at "Creating worker..."
- **After fix**: F5 → worker runs to completion, app shows correct results, main-thread breakpoints (e.g., in `Home.razor`) hit correctly

## Known Limitation

Breakpoints in C# code running *inside* the Web Worker (e.g., `[JSExport]` methods in the worker library) do not get hit. The debug proxy currently only attaches its SDB agent to the main page's WASM runtime, not the worker's second runtime. This is a pre-existing architectural limitation and is out of scope for this PR but I would like to have it solved as well. Any ideas on how to do it are welcome.

Contributes to https://github.com/dotnet/aspnetcore/issues/65823.