### PR TITLE
Update create-pull-request action version

### DIFF
--- a/.github/workflows/aspnetcore-sync.yml
+++ b/.github/workflows/aspnetcore-sync.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Send PR
       if: steps.check.outputs.changed == 'true'
       # https://github.com/marketplace/actions/create-pull-request
-      uses: dotnet/actions-create-pull-request@v4
+      uses: dotnet/actions-create-pull-request@e8d799aa1f8b17f324f9513832811b0a62f1e0b1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: .\runtime


### PR DESCRIPTION
The action ran into an issue, updating to the version that e.g. aspire uses too.