### PR TITLE
[cDAC] Remove reflection from register access in ContextHolder

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/AMD64/AMD64Unwinder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/AMD64/AMD64Unwinder.cs
@@ -1285,27 +1285,9 @@ internal class AMD64Unwinder(Target target)
 
     private static void SetRegister(ref AMD64Context context, byte register, TargetPointer value)
     {
-        switch (register)
-        {
-            case 0: context.Rax = value; break;
-            case 1: context.Rcx = value; break;
-            case 2: context.Rdx = value; break;
-            case 3: context.Rbx = value; break;
-            case 4: context.Rsp = value; break;
-            case 5: context.Rbp = value; break;
-            case 6: context.Rsi = value; break;
-            case 7: context.Rdi = value; break;
-            case 8: context.R8 = value; break;
-            case 9: context.R9 = value; break;
-            case 10: context.R10 = value; break;
-            case 11: context.R11 = value; break;
-            case 12: context.R12 = value; break;
-            case 13: context.R13 = value; break;
-            case 14: context.R14 = value; break;
-            case 15: context.R15 = value; break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(register), "Invalid register number for AMD64 context.");
-        }
+        if (!context.TryGetRegisterName(register, out string? name))
+            throw new ArgumentOutOfRangeException(nameof(register), "Invalid register number for AMD64 context.");
+        context.TrySetRegister(name, new TargetNUInt(value));
     }
 
     private static void UnwinderAssert(bool condition, string? message = null)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/AMD64/AMD64Unwinder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/AMD64/AMD64Unwinder.cs
@@ -1262,32 +1262,13 @@ internal class AMD64Unwinder(Target target)
 
     private static bool IsRexPrefix(byte b) => (b & 0xf0) == 0x40;
 
-    private static TargetPointer GetRegister(AMD64Context context, byte register) => register switch
-    {
-        0 => context.Rax,
-        1 => context.Rcx,
-        2 => context.Rdx,
-        3 => context.Rbx,
-        4 => context.Rsp,
-        5 => context.Rbp,
-        6 => context.Rsi,
-        7 => context.Rdi,
-        8 => context.R8,
-        9 => context.R9,
-        10 => context.R10,
-        11 => context.R11,
-        12 => context.R12,
-        13 => context.R13,
-        14 => context.R14,
-        15 => context.R15,
-        _ => throw new ArgumentOutOfRangeException(nameof(register), "Invalid register number for AMD64 context.")
-    };
+    private static TargetPointer GetRegister(AMD64Context context, byte register)
+        => context.TryReadRegister(register, out TargetNUInt value) ? value.Value : throw new ArgumentOutOfRangeException(nameof(register), "Invalid register number for AMD64 context.");
 
     private static void SetRegister(ref AMD64Context context, byte register, TargetPointer value)
     {
-        if (!context.TryGetRegisterName(register, out string? name))
+        if (!context.TrySetRegister(register, new TargetNUInt(value)))
             throw new ArgumentOutOfRangeException(nameof(register), "Invalid register number for AMD64 context.");
-        context.TrySetRegister(name, new TargetNUInt(value));
     }
 
     private static void UnwinderAssert(bool condition, string? message = null)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/AMD64Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/AMD64Context.cs
@@ -55,6 +55,138 @@ internal struct AMD64Context : IPlatformContext
         unwinder.Unwind(ref this);
     }
 
+    public bool TrySetRegister(string name, TargetNUInt value)
+    {
+        if (name.Equals("cs", StringComparison.OrdinalIgnoreCase)) { Cs = (ushort)value.Value; return true; }
+        if (name.Equals("ds", StringComparison.OrdinalIgnoreCase)) { Ds = (ushort)value.Value; return true; }
+        if (name.Equals("es", StringComparison.OrdinalIgnoreCase)) { Es = (ushort)value.Value; return true; }
+        if (name.Equals("fs", StringComparison.OrdinalIgnoreCase)) { Fs = (ushort)value.Value; return true; }
+        if (name.Equals("gs", StringComparison.OrdinalIgnoreCase)) { Gs = (ushort)value.Value; return true; }
+        if (name.Equals("ss", StringComparison.OrdinalIgnoreCase)) { Ss = (ushort)value.Value; return true; }
+        if (name.Equals("eflags", StringComparison.OrdinalIgnoreCase)) { EFlags = (int)value.Value; return true; }
+        if (name.Equals("dr0", StringComparison.OrdinalIgnoreCase)) { Dr0 = value.Value; return true; }
+        if (name.Equals("dr1", StringComparison.OrdinalIgnoreCase)) { Dr1 = value.Value; return true; }
+        if (name.Equals("dr2", StringComparison.OrdinalIgnoreCase)) { Dr2 = value.Value; return true; }
+        if (name.Equals("dr3", StringComparison.OrdinalIgnoreCase)) { Dr3 = value.Value; return true; }
+        if (name.Equals("dr6", StringComparison.OrdinalIgnoreCase)) { Dr6 = value.Value; return true; }
+        if (name.Equals("dr7", StringComparison.OrdinalIgnoreCase)) { Dr7 = value.Value; return true; }
+        if (name.Equals("debugcontrol", StringComparison.OrdinalIgnoreCase)) { DebugControl = value.Value; return true; }
+        if (name.Equals("lastbranchtorip", StringComparison.OrdinalIgnoreCase)) { LastBranchToRip = value.Value; return true; }
+        if (name.Equals("lastbranchfromrip", StringComparison.OrdinalIgnoreCase)) { LastBranchFromRip = value.Value; return true; }
+        if (name.Equals("lastexceptiontorip", StringComparison.OrdinalIgnoreCase)) { LastExceptionToRip = value.Value; return true; }
+        if (name.Equals("lastexceptionfromrip", StringComparison.OrdinalIgnoreCase)) { LastExceptionFromRip = value.Value; return true; }
+        if (name.Equals("rax", StringComparison.OrdinalIgnoreCase)) { Rax = value.Value; return true; }
+        if (name.Equals("rcx", StringComparison.OrdinalIgnoreCase)) { Rcx = value.Value; return true; }
+        if (name.Equals("rdx", StringComparison.OrdinalIgnoreCase)) { Rdx = value.Value; return true; }
+        if (name.Equals("rbx", StringComparison.OrdinalIgnoreCase)) { Rbx = value.Value; return true; }
+        if (name.Equals("rsp", StringComparison.OrdinalIgnoreCase)) { Rsp = value.Value; return true; }
+        if (name.Equals("rbp", StringComparison.OrdinalIgnoreCase)) { Rbp = value.Value; return true; }
+        if (name.Equals("rsi", StringComparison.OrdinalIgnoreCase)) { Rsi = value.Value; return true; }
+        if (name.Equals("rdi", StringComparison.OrdinalIgnoreCase)) { Rdi = value.Value; return true; }
+        if (name.Equals("r8", StringComparison.OrdinalIgnoreCase)) { R8 = value.Value; return true; }
+        if (name.Equals("r9", StringComparison.OrdinalIgnoreCase)) { R9 = value.Value; return true; }
+        if (name.Equals("r10", StringComparison.OrdinalIgnoreCase)) { R10 = value.Value; return true; }
+        if (name.Equals("r11", StringComparison.OrdinalIgnoreCase)) { R11 = value.Value; return true; }
+        if (name.Equals("r12", StringComparison.OrdinalIgnoreCase)) { R12 = value.Value; return true; }
+        if (name.Equals("r13", StringComparison.OrdinalIgnoreCase)) { R13 = value.Value; return true; }
+        if (name.Equals("r14", StringComparison.OrdinalIgnoreCase)) { R14 = value.Value; return true; }
+        if (name.Equals("r15", StringComparison.OrdinalIgnoreCase)) { R15 = value.Value; return true; }
+        if (name.Equals("rip", StringComparison.OrdinalIgnoreCase)) { Rip = value.Value; return true; }
+        return false;
+    }
+
+    public bool TryReadRegister(string name, out TargetNUInt value)
+    {
+        value = default;
+        if (name.Equals("cs", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Cs); return true; }
+        if (name.Equals("ds", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ds); return true; }
+        if (name.Equals("es", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Es); return true; }
+        if (name.Equals("fs", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Fs); return true; }
+        if (name.Equals("gs", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Gs); return true; }
+        if (name.Equals("ss", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ss); return true; }
+        if (name.Equals("eflags", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(unchecked((uint)EFlags)); return true; }
+        if (name.Equals("dr0", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr0); return true; }
+        if (name.Equals("dr1", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr1); return true; }
+        if (name.Equals("dr2", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr2); return true; }
+        if (name.Equals("dr3", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr3); return true; }
+        if (name.Equals("dr6", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr6); return true; }
+        if (name.Equals("dr7", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr7); return true; }
+        if (name.Equals("debugcontrol", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(DebugControl); return true; }
+        if (name.Equals("lastbranchtorip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(LastBranchToRip); return true; }
+        if (name.Equals("lastbranchfromrip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(LastBranchFromRip); return true; }
+        if (name.Equals("lastexceptiontorip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(LastExceptionToRip); return true; }
+        if (name.Equals("lastexceptionfromrip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(LastExceptionFromRip); return true; }
+        if (name.Equals("rax", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Rax); return true; }
+        if (name.Equals("rcx", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Rcx); return true; }
+        if (name.Equals("rdx", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Rdx); return true; }
+        if (name.Equals("rbx", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Rbx); return true; }
+        if (name.Equals("rsp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Rsp); return true; }
+        if (name.Equals("rbp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Rbp); return true; }
+        if (name.Equals("rsi", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Rsi); return true; }
+        if (name.Equals("rdi", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Rdi); return true; }
+        if (name.Equals("r8", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R8); return true; }
+        if (name.Equals("r9", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R9); return true; }
+        if (name.Equals("r10", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R10); return true; }
+        if (name.Equals("r11", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R11); return true; }
+        if (name.Equals("r12", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R12); return true; }
+        if (name.Equals("r13", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R13); return true; }
+        if (name.Equals("r14", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R14); return true; }
+        if (name.Equals("r15", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R15); return true; }
+        if (name.Equals("rip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Rip); return true; }
+        return false;
+    }
+
+    public bool TrySetRegister(int number, TargetNUInt value)
+    {
+        switch (number)
+        {
+            case 0: Rax = value.Value; return true;
+            case 1: Rcx = value.Value; return true;
+            case 2: Rdx = value.Value; return true;
+            case 3: Rbx = value.Value; return true;
+            case 4: Rsp = value.Value; return true;
+            case 5: Rbp = value.Value; return true;
+            case 6: Rsi = value.Value; return true;
+            case 7: Rdi = value.Value; return true;
+            case 8: R8 = value.Value; return true;
+            case 9: R9 = value.Value; return true;
+            case 10: R10 = value.Value; return true;
+            case 11: R11 = value.Value; return true;
+            case 12: R12 = value.Value; return true;
+            case 13: R13 = value.Value; return true;
+            case 14: R14 = value.Value; return true;
+            case 15: R15 = value.Value; return true;
+            default: return false;
+        }
+    }
+
+    public bool TryReadRegister(int number, out TargetNUInt value)
+    {
+        value = default;
+        switch (number)
+        {
+            case 0: value = new TargetNUInt(Rax); return true;
+            case 1: value = new TargetNUInt(Rcx); return true;
+            case 2: value = new TargetNUInt(Rdx); return true;
+            case 3: value = new TargetNUInt(Rbx); return true;
+            case 4: value = new TargetNUInt(Rsp); return true;
+            case 5: value = new TargetNUInt(Rbp); return true;
+            case 6: value = new TargetNUInt(Rsi); return true;
+            case 7: value = new TargetNUInt(Rdi); return true;
+            case 8: value = new TargetNUInt(R8); return true;
+            case 9: value = new TargetNUInt(R9); return true;
+            case 10: value = new TargetNUInt(R10); return true;
+            case 11: value = new TargetNUInt(R11); return true;
+            case 12: value = new TargetNUInt(R12); return true;
+            case 13: value = new TargetNUInt(R13); return true;
+            case 14: value = new TargetNUInt(R14); return true;
+            case 15: value = new TargetNUInt(R15); return true;
+            default: return false;
+        }
+    }
+
+
+
     [FieldOffset(0x0)]
     public ulong P1Home;
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/AMD64Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/AMD64Context.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers.AMD64;
 
@@ -70,11 +73,6 @@ internal struct AMD64Context : IPlatformContext
         if (name.Equals("dr3", StringComparison.OrdinalIgnoreCase)) { Dr3 = value.Value; return true; }
         if (name.Equals("dr6", StringComparison.OrdinalIgnoreCase)) { Dr6 = value.Value; return true; }
         if (name.Equals("dr7", StringComparison.OrdinalIgnoreCase)) { Dr7 = value.Value; return true; }
-        if (name.Equals("debugcontrol", StringComparison.OrdinalIgnoreCase)) { DebugControl = value.Value; return true; }
-        if (name.Equals("lastbranchtorip", StringComparison.OrdinalIgnoreCase)) { LastBranchToRip = value.Value; return true; }
-        if (name.Equals("lastbranchfromrip", StringComparison.OrdinalIgnoreCase)) { LastBranchFromRip = value.Value; return true; }
-        if (name.Equals("lastexceptiontorip", StringComparison.OrdinalIgnoreCase)) { LastExceptionToRip = value.Value; return true; }
-        if (name.Equals("lastexceptionfromrip", StringComparison.OrdinalIgnoreCase)) { LastExceptionFromRip = value.Value; return true; }
         if (name.Equals("rax", StringComparison.OrdinalIgnoreCase)) { Rax = value.Value; return true; }
         if (name.Equals("rcx", StringComparison.OrdinalIgnoreCase)) { Rcx = value.Value; return true; }
         if (name.Equals("rdx", StringComparison.OrdinalIgnoreCase)) { Rdx = value.Value; return true; }
@@ -92,6 +90,11 @@ internal struct AMD64Context : IPlatformContext
         if (name.Equals("r14", StringComparison.OrdinalIgnoreCase)) { R14 = value.Value; return true; }
         if (name.Equals("r15", StringComparison.OrdinalIgnoreCase)) { R15 = value.Value; return true; }
         if (name.Equals("rip", StringComparison.OrdinalIgnoreCase)) { Rip = value.Value; return true; }
+        if (name.Equals("debugcontrol", StringComparison.OrdinalIgnoreCase)) { DebugControl = value.Value; return true; }
+        if (name.Equals("lastbranchtorip", StringComparison.OrdinalIgnoreCase)) { LastBranchToRip = value.Value; return true; }
+        if (name.Equals("lastbranchfromrip", StringComparison.OrdinalIgnoreCase)) { LastBranchFromRip = value.Value; return true; }
+        if (name.Equals("lastexceptiontorip", StringComparison.OrdinalIgnoreCase)) { LastExceptionToRip = value.Value; return true; }
+        if (name.Equals("lastexceptionfromrip", StringComparison.OrdinalIgnoreCase)) { LastExceptionFromRip = value.Value; return true; }
         return false;
     }
 
@@ -111,11 +114,6 @@ internal struct AMD64Context : IPlatformContext
         if (name.Equals("dr3", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr3); return true; }
         if (name.Equals("dr6", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr6); return true; }
         if (name.Equals("dr7", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr7); return true; }
-        if (name.Equals("debugcontrol", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(DebugControl); return true; }
-        if (name.Equals("lastbranchtorip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(LastBranchToRip); return true; }
-        if (name.Equals("lastbranchfromrip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(LastBranchFromRip); return true; }
-        if (name.Equals("lastexceptiontorip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(LastExceptionToRip); return true; }
-        if (name.Equals("lastexceptionfromrip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(LastExceptionFromRip); return true; }
         if (name.Equals("rax", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Rax); return true; }
         if (name.Equals("rcx", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Rcx); return true; }
         if (name.Equals("rdx", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Rdx); return true; }
@@ -133,59 +131,25 @@ internal struct AMD64Context : IPlatformContext
         if (name.Equals("r14", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R14); return true; }
         if (name.Equals("r15", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R15); return true; }
         if (name.Equals("rip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Rip); return true; }
+        if (name.Equals("debugcontrol", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(DebugControl); return true; }
+        if (name.Equals("lastbranchtorip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(LastBranchToRip); return true; }
+        if (name.Equals("lastbranchfromrip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(LastBranchFromRip); return true; }
+        if (name.Equals("lastexceptiontorip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(LastExceptionToRip); return true; }
+        if (name.Equals("lastexceptionfromrip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(LastExceptionFromRip); return true; }
         return false;
     }
 
-    public bool TrySetRegister(int number, TargetNUInt value)
+    // Maps numbered GP registers (0–15) to their canonical names for by-number dispatch.
+    private static readonly FrozenDictionary<int, string> s_registersByNumber = new Dictionary<int, string>
     {
-        switch (number)
-        {
-            case 0: Rax = value.Value; return true;
-            case 1: Rcx = value.Value; return true;
-            case 2: Rdx = value.Value; return true;
-            case 3: Rbx = value.Value; return true;
-            case 4: Rsp = value.Value; return true;
-            case 5: Rbp = value.Value; return true;
-            case 6: Rsi = value.Value; return true;
-            case 7: Rdi = value.Value; return true;
-            case 8: R8 = value.Value; return true;
-            case 9: R9 = value.Value; return true;
-            case 10: R10 = value.Value; return true;
-            case 11: R11 = value.Value; return true;
-            case 12: R12 = value.Value; return true;
-            case 13: R13 = value.Value; return true;
-            case 14: R14 = value.Value; return true;
-            case 15: R15 = value.Value; return true;
-            default: return false;
-        }
-    }
+        [0] = "Rax", [1] = "Rcx", [2] = "Rdx", [3] = "Rbx",
+        [4] = "Rsp", [5] = "Rbp", [6] = "Rsi", [7] = "Rdi",
+        [8] = "R8", [9] = "R9", [10] = "R10", [11] = "R11",
+        [12] = "R12", [13] = "R13", [14] = "R14", [15] = "R15",
+    }.ToFrozenDictionary();
 
-    public bool TryReadRegister(int number, out TargetNUInt value)
-    {
-        value = default;
-        switch (number)
-        {
-            case 0: value = new TargetNUInt(Rax); return true;
-            case 1: value = new TargetNUInt(Rcx); return true;
-            case 2: value = new TargetNUInt(Rdx); return true;
-            case 3: value = new TargetNUInt(Rbx); return true;
-            case 4: value = new TargetNUInt(Rsp); return true;
-            case 5: value = new TargetNUInt(Rbp); return true;
-            case 6: value = new TargetNUInt(Rsi); return true;
-            case 7: value = new TargetNUInt(Rdi); return true;
-            case 8: value = new TargetNUInt(R8); return true;
-            case 9: value = new TargetNUInt(R9); return true;
-            case 10: value = new TargetNUInt(R10); return true;
-            case 11: value = new TargetNUInt(R11); return true;
-            case 12: value = new TargetNUInt(R12); return true;
-            case 13: value = new TargetNUInt(R13); return true;
-            case 14: value = new TargetNUInt(R14); return true;
-            case 15: value = new TargetNUInt(R15); return true;
-            default: return false;
-        }
-    }
-
-
+    public bool TryGetRegisterName(int number, [NotNullWhen(true)] out string? name)
+        => s_registersByNumber.TryGetValue(number, out name);
 
     [FieldOffset(0x0)]
     public ulong P1Home;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/AMD64Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/AMD64Context.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Frozen;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers.AMD64;
 
@@ -139,17 +136,54 @@ internal struct AMD64Context : IPlatformContext
         return false;
     }
 
-    // Maps numbered GP registers (0–15) to their canonical names for by-number dispatch.
-    private static readonly FrozenDictionary<int, string> s_registersByNumber = new Dictionary<int, string>
+    public bool TrySetRegister(int number, TargetNUInt value)
     {
-        [0] = "Rax", [1] = "Rcx", [2] = "Rdx", [3] = "Rbx",
-        [4] = "Rsp", [5] = "Rbp", [6] = "Rsi", [7] = "Rdi",
-        [8] = "R8", [9] = "R9", [10] = "R10", [11] = "R11",
-        [12] = "R12", [13] = "R13", [14] = "R14", [15] = "R15",
-    }.ToFrozenDictionary();
+        switch (number)
+        {
+            case 0: Rax = value.Value; return true;
+            case 1: Rcx = value.Value; return true;
+            case 2: Rdx = value.Value; return true;
+            case 3: Rbx = value.Value; return true;
+            case 4: Rsp = value.Value; return true;
+            case 5: Rbp = value.Value; return true;
+            case 6: Rsi = value.Value; return true;
+            case 7: Rdi = value.Value; return true;
+            case 8: R8 = value.Value; return true;
+            case 9: R9 = value.Value; return true;
+            case 10: R10 = value.Value; return true;
+            case 11: R11 = value.Value; return true;
+            case 12: R12 = value.Value; return true;
+            case 13: R13 = value.Value; return true;
+            case 14: R14 = value.Value; return true;
+            case 15: R15 = value.Value; return true;
+            default: return false;
+        }
+    }
 
-    public bool TryGetRegisterName(int number, [NotNullWhen(true)] out string? name)
-        => s_registersByNumber.TryGetValue(number, out name);
+    public bool TryReadRegister(int number, out TargetNUInt value)
+    {
+        switch (number)
+        {
+            case 0: value = new TargetNUInt(Rax); return true;
+            case 1: value = new TargetNUInt(Rcx); return true;
+            case 2: value = new TargetNUInt(Rdx); return true;
+            case 3: value = new TargetNUInt(Rbx); return true;
+            case 4: value = new TargetNUInt(Rsp); return true;
+            case 5: value = new TargetNUInt(Rbp); return true;
+            case 6: value = new TargetNUInt(Rsi); return true;
+            case 7: value = new TargetNUInt(Rdi); return true;
+            case 8: value = new TargetNUInt(R8); return true;
+            case 9: value = new TargetNUInt(R9); return true;
+            case 10: value = new TargetNUInt(R10); return true;
+            case 11: value = new TargetNUInt(R11); return true;
+            case 12: value = new TargetNUInt(R12); return true;
+            case 13: value = new TargetNUInt(R13); return true;
+            case 14: value = new TargetNUInt(R14); return true;
+            case 15: value = new TargetNUInt(R15); return true;
+            default: value = default; return false;
+        }
+    }
+
 
     [FieldOffset(0x0)]
     public ulong P1Home;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM/ARMUnwinder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM/ARMUnwinder.cs
@@ -918,27 +918,9 @@ internal class ARMUnwinder(Target target)
 
     private static void SetRegister(ref ARMContext context, int regIndex, uint value)
     {
-        switch (regIndex)
-        {
-            case 0: context.R0 = value; break;
-            case 1: context.R1 = value; break;
-            case 2: context.R2 = value; break;
-            case 3: context.R3 = value; break;
-            case 4: context.R4 = value; break;
-            case 5: context.R5 = value; break;
-            case 6: context.R6 = value; break;
-            case 7: context.R7 = value; break;
-            case 8: context.R8 = value; break;
-            case 9: context.R9 = value; break;
-            case 10: context.R10 = value; break;
-            case 11: context.R11 = value; break;
-            case 12: context.R12 = value; break;
-            case 13: context.Sp = value; break;
-            case 14: context.Lr = value; break;
-            case 15: context.Pc = value; break;
-            case 16: context.Cpsr = value; break;
-            default: throw new ArgumentOutOfRangeException(nameof(regIndex));
-        }
+        if (!context.TryGetRegisterName(regIndex, out string? name))
+            throw new ArgumentOutOfRangeException(nameof(regIndex));
+        context.TrySetRegister(name, new TargetNUInt(value));
     }
 
     private static uint GetRegister(ref ARMContext context, int regIndex) =>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM/ARMUnwinder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM/ARMUnwinder.cs
@@ -918,33 +918,12 @@ internal class ARMUnwinder(Target target)
 
     private static void SetRegister(ref ARMContext context, int regIndex, uint value)
     {
-        if (!context.TryGetRegisterName(regIndex, out string? name))
+        if (!context.TrySetRegister(regIndex, new TargetNUInt(value)))
             throw new ArgumentOutOfRangeException(nameof(regIndex));
-        context.TrySetRegister(name, new TargetNUInt(value));
     }
 
-    private static uint GetRegister(ref ARMContext context, int regIndex) =>
-    regIndex switch
-    {
-        0 => context.R0,
-        1 => context.R1,
-        2 => context.R2,
-        3 => context.R3,
-        4 => context.R4,
-        5 => context.R5,
-        6 => context.R6,
-        7 => context.R7,
-        8 => context.R8,
-        9 => context.R9,
-        10 => context.R10,
-        11 => context.R11,
-        12 => context.R12,
-        13 => context.Sp,
-        14 => context.Lr,
-        15 => context.Pc,
-        16 => context.Cpsr,
-        _ => throw new ArgumentOutOfRangeException(nameof(regIndex)),
-    };
+    private static uint GetRegister(ref ARMContext context, int regIndex)
+        => context.TryReadRegister(regIndex, out TargetNUInt value) ? (uint)value.Value : throw new ArgumentOutOfRangeException(nameof(regIndex));
 
     #endregion
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM64/ARM64Unwinder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM64/ARM64Unwinder.cs
@@ -1187,41 +1187,9 @@ internal class ARM64Unwinder(Target target)
 
     private static void SetRegister(ref ARM64Context context, uint regIndex, ulong value)
     {
-        switch (regIndex)
-        {
-            case 0: context.X0 = value; break;
-            case 1: context.X1 = value; break;
-            case 2: context.X2 = value; break;
-            case 3: context.X3 = value; break;
-            case 4: context.X4 = value; break;
-            case 5: context.X5 = value; break;
-            case 6: context.X6 = value; break;
-            case 7: context.X7 = value; break;
-            case 8: context.X8 = value; break;
-            case 9: context.X9 = value; break;
-            case 10: context.X10 = value; break;
-            case 11: context.X11 = value; break;
-            case 12: context.X12 = value; break;
-            case 13: context.X13 = value; break;
-            case 14: context.X14 = value; break;
-            case 15: context.X15 = value; break;
-            case 16: context.X16 = value; break;
-            case 17: context.X17 = value; break;
-            case 18: context.X18 = value; break;
-            case 19: context.X19 = value; break;
-            case 20: context.X20 = value; break;
-            case 21: context.X21 = value; break;
-            case 22: context.X22 = value; break;
-            case 23: context.X23 = value; break;
-            case 24: context.X24 = value; break;
-            case 25: context.X25 = value; break;
-            case 26: context.X26 = value; break;
-            case 27: context.X27 = value; break;
-            case 28: context.X28 = value; break;
-            case 29: context.Fp = value; break;
-            case 30: context.Lr = value; break;
-            default: throw new ArgumentOutOfRangeException(nameof(regIndex));
-        }
+        if (!context.TryGetRegisterName((int)regIndex, out string? name))
+            throw new ArgumentOutOfRangeException(nameof(regIndex));
+        context.TrySetRegister(name, new TargetNUInt(value));
     }
 
     private static bool OPCODE_IS_END(byte opcode)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM64/ARM64Unwinder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM64/ARM64Unwinder.cs
@@ -1187,9 +1187,8 @@ internal class ARM64Unwinder(Target target)
 
     private static void SetRegister(ref ARM64Context context, uint regIndex, ulong value)
     {
-        if (!context.TryGetRegisterName((int)regIndex, out string? name))
+        if (!context.TrySetRegister((int)regIndex, new TargetNUInt(value)))
             throw new ArgumentOutOfRangeException(nameof(regIndex));
-        context.TrySetRegister(name, new TargetNUInt(value));
     }
 
     private static bool OPCODE_IS_END(byte opcode)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM64Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM64Context.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers.ARM64;
 
@@ -148,87 +151,19 @@ internal struct ARM64Context : IPlatformContext
         return false;
     }
 
-
-    public bool TrySetRegister(int number, TargetNUInt value)
+    // Maps numbered GP registers (0–31) and PC (32) to their canonical names for by-number dispatch.
+    // Cpsr, Fpcr, and Fpsr have no register number and are handled inline in the string methods.
+    private static readonly FrozenDictionary<int, string> s_registersByNumber = new Dictionary<int, string>
     {
-        switch (number)
-        {
-            case 0: X0 = value.Value; return true;
-            case 1: X1 = value.Value; return true;
-            case 2: X2 = value.Value; return true;
-            case 3: X3 = value.Value; return true;
-            case 4: X4 = value.Value; return true;
-            case 5: X5 = value.Value; return true;
-            case 6: X6 = value.Value; return true;
-            case 7: X7 = value.Value; return true;
-            case 8: X8 = value.Value; return true;
-            case 9: X9 = value.Value; return true;
-            case 10: X10 = value.Value; return true;
-            case 11: X11 = value.Value; return true;
-            case 12: X12 = value.Value; return true;
-            case 13: X13 = value.Value; return true;
-            case 14: X14 = value.Value; return true;
-            case 15: X15 = value.Value; return true;
-            case 16: X16 = value.Value; return true;
-            case 17: X17 = value.Value; return true;
-            case 18: X18 = value.Value; return true;
-            case 19: X19 = value.Value; return true;
-            case 20: X20 = value.Value; return true;
-            case 21: X21 = value.Value; return true;
-            case 22: X22 = value.Value; return true;
-            case 23: X23 = value.Value; return true;
-            case 24: X24 = value.Value; return true;
-            case 25: X25 = value.Value; return true;
-            case 26: X26 = value.Value; return true;
-            case 27: X27 = value.Value; return true;
-            case 28: X28 = value.Value; return true;
-            case 29: Fp = value.Value; return true;
-            case 30: Lr = value.Value; return true;
-            case 31: Sp = value.Value; return true;
-            default: return false;
-        }
-    }
+        [0] = "X0", [1] = "X1", [2] = "X2", [3] = "X3", [4] = "X4", [5] = "X5", [6] = "X6", [7] = "X7",
+        [8] = "X8", [9] = "X9", [10] = "X10", [11] = "X11", [12] = "X12", [13] = "X13", [14] = "X14", [15] = "X15",
+        [16] = "X16", [17] = "X17", [18] = "X18", [19] = "X19", [20] = "X20", [21] = "X21", [22] = "X22", [23] = "X23",
+        [24] = "X24", [25] = "X25", [26] = "X26", [27] = "X27", [28] = "X28", [29] = "Fp", [30] = "Lr", [31] = "Sp",
+        [32] = "Pc",
+    }.ToFrozenDictionary();
 
-    public bool TryReadRegister(int number, out TargetNUInt value)
-    {
-        value = default;
-        switch (number)
-        {
-            case 0: value = new TargetNUInt(X0); return true;
-            case 1: value = new TargetNUInt(X1); return true;
-            case 2: value = new TargetNUInt(X2); return true;
-            case 3: value = new TargetNUInt(X3); return true;
-            case 4: value = new TargetNUInt(X4); return true;
-            case 5: value = new TargetNUInt(X5); return true;
-            case 6: value = new TargetNUInt(X6); return true;
-            case 7: value = new TargetNUInt(X7); return true;
-            case 8: value = new TargetNUInt(X8); return true;
-            case 9: value = new TargetNUInt(X9); return true;
-            case 10: value = new TargetNUInt(X10); return true;
-            case 11: value = new TargetNUInt(X11); return true;
-            case 12: value = new TargetNUInt(X12); return true;
-            case 13: value = new TargetNUInt(X13); return true;
-            case 14: value = new TargetNUInt(X14); return true;
-            case 15: value = new TargetNUInt(X15); return true;
-            case 16: value = new TargetNUInt(X16); return true;
-            case 17: value = new TargetNUInt(X17); return true;
-            case 18: value = new TargetNUInt(X18); return true;
-            case 19: value = new TargetNUInt(X19); return true;
-            case 20: value = new TargetNUInt(X20); return true;
-            case 21: value = new TargetNUInt(X21); return true;
-            case 22: value = new TargetNUInt(X22); return true;
-            case 23: value = new TargetNUInt(X23); return true;
-            case 24: value = new TargetNUInt(X24); return true;
-            case 25: value = new TargetNUInt(X25); return true;
-            case 26: value = new TargetNUInt(X26); return true;
-            case 27: value = new TargetNUInt(X27); return true;
-            case 28: value = new TargetNUInt(X28); return true;
-            case 29: value = new TargetNUInt(Fp); return true;
-            case 30: value = new TargetNUInt(Lr); return true;
-            case 31: value = new TargetNUInt(Sp); return true;
-            default: return false;
-        }
-    }
+    public bool TryGetRegisterName(int number, [NotNullWhen(true)] out string? name)
+        => s_registersByNumber.TryGetValue(number, out name);
 
     // Control flags
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM64Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM64Context.cs
@@ -65,6 +65,171 @@ internal struct ARM64Context : IPlatformContext
         unwinder.Unwind(ref this);
     }
 
+    public bool TrySetRegister(string name, TargetNUInt value)
+    {
+        if (name.Equals("cpsr", StringComparison.OrdinalIgnoreCase)) { Cpsr = (uint)value.Value; return true; }
+        if (name.Equals("x0", StringComparison.OrdinalIgnoreCase)) { X0 = value.Value; return true; }
+        if (name.Equals("x1", StringComparison.OrdinalIgnoreCase)) { X1 = value.Value; return true; }
+        if (name.Equals("x2", StringComparison.OrdinalIgnoreCase)) { X2 = value.Value; return true; }
+        if (name.Equals("x3", StringComparison.OrdinalIgnoreCase)) { X3 = value.Value; return true; }
+        if (name.Equals("x4", StringComparison.OrdinalIgnoreCase)) { X4 = value.Value; return true; }
+        if (name.Equals("x5", StringComparison.OrdinalIgnoreCase)) { X5 = value.Value; return true; }
+        if (name.Equals("x6", StringComparison.OrdinalIgnoreCase)) { X6 = value.Value; return true; }
+        if (name.Equals("x7", StringComparison.OrdinalIgnoreCase)) { X7 = value.Value; return true; }
+        if (name.Equals("x8", StringComparison.OrdinalIgnoreCase)) { X8 = value.Value; return true; }
+        if (name.Equals("x9", StringComparison.OrdinalIgnoreCase)) { X9 = value.Value; return true; }
+        if (name.Equals("x10", StringComparison.OrdinalIgnoreCase)) { X10 = value.Value; return true; }
+        if (name.Equals("x11", StringComparison.OrdinalIgnoreCase)) { X11 = value.Value; return true; }
+        if (name.Equals("x12", StringComparison.OrdinalIgnoreCase)) { X12 = value.Value; return true; }
+        if (name.Equals("x13", StringComparison.OrdinalIgnoreCase)) { X13 = value.Value; return true; }
+        if (name.Equals("x14", StringComparison.OrdinalIgnoreCase)) { X14 = value.Value; return true; }
+        if (name.Equals("x15", StringComparison.OrdinalIgnoreCase)) { X15 = value.Value; return true; }
+        if (name.Equals("x16", StringComparison.OrdinalIgnoreCase)) { X16 = value.Value; return true; }
+        if (name.Equals("x17", StringComparison.OrdinalIgnoreCase)) { X17 = value.Value; return true; }
+        if (name.Equals("x18", StringComparison.OrdinalIgnoreCase)) { X18 = value.Value; return true; }
+        if (name.Equals("x19", StringComparison.OrdinalIgnoreCase)) { X19 = value.Value; return true; }
+        if (name.Equals("x20", StringComparison.OrdinalIgnoreCase)) { X20 = value.Value; return true; }
+        if (name.Equals("x21", StringComparison.OrdinalIgnoreCase)) { X21 = value.Value; return true; }
+        if (name.Equals("x22", StringComparison.OrdinalIgnoreCase)) { X22 = value.Value; return true; }
+        if (name.Equals("x23", StringComparison.OrdinalIgnoreCase)) { X23 = value.Value; return true; }
+        if (name.Equals("x24", StringComparison.OrdinalIgnoreCase)) { X24 = value.Value; return true; }
+        if (name.Equals("x25", StringComparison.OrdinalIgnoreCase)) { X25 = value.Value; return true; }
+        if (name.Equals("x26", StringComparison.OrdinalIgnoreCase)) { X26 = value.Value; return true; }
+        if (name.Equals("x27", StringComparison.OrdinalIgnoreCase)) { X27 = value.Value; return true; }
+        if (name.Equals("x28", StringComparison.OrdinalIgnoreCase)) { X28 = value.Value; return true; }
+        if (name.Equals("fp", StringComparison.OrdinalIgnoreCase)) { Fp = value.Value; return true; }
+        if (name.Equals("lr", StringComparison.OrdinalIgnoreCase)) { Lr = value.Value; return true; }
+        if (name.Equals("sp", StringComparison.OrdinalIgnoreCase)) { Sp = value.Value; return true; }
+        if (name.Equals("pc", StringComparison.OrdinalIgnoreCase)) { Pc = value.Value; return true; }
+        if (name.Equals("fpcr", StringComparison.OrdinalIgnoreCase)) { Fpcr = (uint)value.Value; return true; }
+        if (name.Equals("fpsr", StringComparison.OrdinalIgnoreCase)) { Fpsr = (uint)value.Value; return true; }
+        return false;
+    }
+
+    public bool TryReadRegister(string name, out TargetNUInt value)
+    {
+        value = default;
+        if (name.Equals("cpsr", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Cpsr); return true; }
+        if (name.Equals("x0", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X0); return true; }
+        if (name.Equals("x1", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X1); return true; }
+        if (name.Equals("x2", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X2); return true; }
+        if (name.Equals("x3", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X3); return true; }
+        if (name.Equals("x4", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X4); return true; }
+        if (name.Equals("x5", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X5); return true; }
+        if (name.Equals("x6", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X6); return true; }
+        if (name.Equals("x7", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X7); return true; }
+        if (name.Equals("x8", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X8); return true; }
+        if (name.Equals("x9", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X9); return true; }
+        if (name.Equals("x10", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X10); return true; }
+        if (name.Equals("x11", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X11); return true; }
+        if (name.Equals("x12", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X12); return true; }
+        if (name.Equals("x13", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X13); return true; }
+        if (name.Equals("x14", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X14); return true; }
+        if (name.Equals("x15", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X15); return true; }
+        if (name.Equals("x16", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X16); return true; }
+        if (name.Equals("x17", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X17); return true; }
+        if (name.Equals("x18", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X18); return true; }
+        if (name.Equals("x19", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X19); return true; }
+        if (name.Equals("x20", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X20); return true; }
+        if (name.Equals("x21", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X21); return true; }
+        if (name.Equals("x22", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X22); return true; }
+        if (name.Equals("x23", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X23); return true; }
+        if (name.Equals("x24", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X24); return true; }
+        if (name.Equals("x25", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X25); return true; }
+        if (name.Equals("x26", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X26); return true; }
+        if (name.Equals("x27", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X27); return true; }
+        if (name.Equals("x28", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X28); return true; }
+        if (name.Equals("fp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Fp); return true; }
+        if (name.Equals("lr", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Lr); return true; }
+        if (name.Equals("sp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Sp); return true; }
+        if (name.Equals("pc", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Pc); return true; }
+        if (name.Equals("fpcr", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Fpcr); return true; }
+        if (name.Equals("fpsr", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Fpsr); return true; }
+        return false;
+    }
+
+
+    public bool TrySetRegister(int number, TargetNUInt value)
+    {
+        switch (number)
+        {
+            case 0: X0 = value.Value; return true;
+            case 1: X1 = value.Value; return true;
+            case 2: X2 = value.Value; return true;
+            case 3: X3 = value.Value; return true;
+            case 4: X4 = value.Value; return true;
+            case 5: X5 = value.Value; return true;
+            case 6: X6 = value.Value; return true;
+            case 7: X7 = value.Value; return true;
+            case 8: X8 = value.Value; return true;
+            case 9: X9 = value.Value; return true;
+            case 10: X10 = value.Value; return true;
+            case 11: X11 = value.Value; return true;
+            case 12: X12 = value.Value; return true;
+            case 13: X13 = value.Value; return true;
+            case 14: X14 = value.Value; return true;
+            case 15: X15 = value.Value; return true;
+            case 16: X16 = value.Value; return true;
+            case 17: X17 = value.Value; return true;
+            case 18: X18 = value.Value; return true;
+            case 19: X19 = value.Value; return true;
+            case 20: X20 = value.Value; return true;
+            case 21: X21 = value.Value; return true;
+            case 22: X22 = value.Value; return true;
+            case 23: X23 = value.Value; return true;
+            case 24: X24 = value.Value; return true;
+            case 25: X25 = value.Value; return true;
+            case 26: X26 = value.Value; return true;
+            case 27: X27 = value.Value; return true;
+            case 28: X28 = value.Value; return true;
+            case 29: Fp = value.Value; return true;
+            case 30: Lr = value.Value; return true;
+            case 31: Sp = value.Value; return true;
+            default: return false;
+        }
+    }
+
+    public bool TryReadRegister(int number, out TargetNUInt value)
+    {
+        value = default;
+        switch (number)
+        {
+            case 0: value = new TargetNUInt(X0); return true;
+            case 1: value = new TargetNUInt(X1); return true;
+            case 2: value = new TargetNUInt(X2); return true;
+            case 3: value = new TargetNUInt(X3); return true;
+            case 4: value = new TargetNUInt(X4); return true;
+            case 5: value = new TargetNUInt(X5); return true;
+            case 6: value = new TargetNUInt(X6); return true;
+            case 7: value = new TargetNUInt(X7); return true;
+            case 8: value = new TargetNUInt(X8); return true;
+            case 9: value = new TargetNUInt(X9); return true;
+            case 10: value = new TargetNUInt(X10); return true;
+            case 11: value = new TargetNUInt(X11); return true;
+            case 12: value = new TargetNUInt(X12); return true;
+            case 13: value = new TargetNUInt(X13); return true;
+            case 14: value = new TargetNUInt(X14); return true;
+            case 15: value = new TargetNUInt(X15); return true;
+            case 16: value = new TargetNUInt(X16); return true;
+            case 17: value = new TargetNUInt(X17); return true;
+            case 18: value = new TargetNUInt(X18); return true;
+            case 19: value = new TargetNUInt(X19); return true;
+            case 20: value = new TargetNUInt(X20); return true;
+            case 21: value = new TargetNUInt(X21); return true;
+            case 22: value = new TargetNUInt(X22); return true;
+            case 23: value = new TargetNUInt(X23); return true;
+            case 24: value = new TargetNUInt(X24); return true;
+            case 25: value = new TargetNUInt(X25); return true;
+            case 26: value = new TargetNUInt(X26); return true;
+            case 27: value = new TargetNUInt(X27); return true;
+            case 28: value = new TargetNUInt(X28); return true;
+            case 29: value = new TargetNUInt(Fp); return true;
+            case 30: value = new TargetNUInt(Lr); return true;
+            case 31: value = new TargetNUInt(Sp); return true;
+            default: return false;
+        }
+    }
+
     // Control flags
 
     [FieldOffset(0x0)]

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM64Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARM64Context.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Frozen;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers.ARM64;
 
@@ -151,19 +148,87 @@ internal struct ARM64Context : IPlatformContext
         return false;
     }
 
-    // Maps numbered GP registers (0–31) and PC (32) to their canonical names for by-number dispatch.
-    // Cpsr, Fpcr, and Fpsr have no register number and are handled inline in the string methods.
-    private static readonly FrozenDictionary<int, string> s_registersByNumber = new Dictionary<int, string>
+    public bool TrySetRegister(int number, TargetNUInt value)
     {
-        [0] = "X0", [1] = "X1", [2] = "X2", [3] = "X3", [4] = "X4", [5] = "X5", [6] = "X6", [7] = "X7",
-        [8] = "X8", [9] = "X9", [10] = "X10", [11] = "X11", [12] = "X12", [13] = "X13", [14] = "X14", [15] = "X15",
-        [16] = "X16", [17] = "X17", [18] = "X18", [19] = "X19", [20] = "X20", [21] = "X21", [22] = "X22", [23] = "X23",
-        [24] = "X24", [25] = "X25", [26] = "X26", [27] = "X27", [28] = "X28", [29] = "Fp", [30] = "Lr", [31] = "Sp",
-        [32] = "Pc",
-    }.ToFrozenDictionary();
+        switch (number)
+        {
+            case 0: X0 = value.Value; return true;
+            case 1: X1 = value.Value; return true;
+            case 2: X2 = value.Value; return true;
+            case 3: X3 = value.Value; return true;
+            case 4: X4 = value.Value; return true;
+            case 5: X5 = value.Value; return true;
+            case 6: X6 = value.Value; return true;
+            case 7: X7 = value.Value; return true;
+            case 8: X8 = value.Value; return true;
+            case 9: X9 = value.Value; return true;
+            case 10: X10 = value.Value; return true;
+            case 11: X11 = value.Value; return true;
+            case 12: X12 = value.Value; return true;
+            case 13: X13 = value.Value; return true;
+            case 14: X14 = value.Value; return true;
+            case 15: X15 = value.Value; return true;
+            case 16: X16 = value.Value; return true;
+            case 17: X17 = value.Value; return true;
+            case 18: X18 = value.Value; return true;
+            case 19: X19 = value.Value; return true;
+            case 20: X20 = value.Value; return true;
+            case 21: X21 = value.Value; return true;
+            case 22: X22 = value.Value; return true;
+            case 23: X23 = value.Value; return true;
+            case 24: X24 = value.Value; return true;
+            case 25: X25 = value.Value; return true;
+            case 26: X26 = value.Value; return true;
+            case 27: X27 = value.Value; return true;
+            case 28: X28 = value.Value; return true;
+            case 29: Fp = value.Value; return true;
+            case 30: Lr = value.Value; return true;
+            case 31: Sp = value.Value; return true;
+            case 32: Pc = value.Value; return true;
+            default: return false;
+        }
+    }
 
-    public bool TryGetRegisterName(int number, [NotNullWhen(true)] out string? name)
-        => s_registersByNumber.TryGetValue(number, out name);
+    public bool TryReadRegister(int number, out TargetNUInt value)
+    {
+        switch (number)
+        {
+            case 0: value = new TargetNUInt(X0); return true;
+            case 1: value = new TargetNUInt(X1); return true;
+            case 2: value = new TargetNUInt(X2); return true;
+            case 3: value = new TargetNUInt(X3); return true;
+            case 4: value = new TargetNUInt(X4); return true;
+            case 5: value = new TargetNUInt(X5); return true;
+            case 6: value = new TargetNUInt(X6); return true;
+            case 7: value = new TargetNUInt(X7); return true;
+            case 8: value = new TargetNUInt(X8); return true;
+            case 9: value = new TargetNUInt(X9); return true;
+            case 10: value = new TargetNUInt(X10); return true;
+            case 11: value = new TargetNUInt(X11); return true;
+            case 12: value = new TargetNUInt(X12); return true;
+            case 13: value = new TargetNUInt(X13); return true;
+            case 14: value = new TargetNUInt(X14); return true;
+            case 15: value = new TargetNUInt(X15); return true;
+            case 16: value = new TargetNUInt(X16); return true;
+            case 17: value = new TargetNUInt(X17); return true;
+            case 18: value = new TargetNUInt(X18); return true;
+            case 19: value = new TargetNUInt(X19); return true;
+            case 20: value = new TargetNUInt(X20); return true;
+            case 21: value = new TargetNUInt(X21); return true;
+            case 22: value = new TargetNUInt(X22); return true;
+            case 23: value = new TargetNUInt(X23); return true;
+            case 24: value = new TargetNUInt(X24); return true;
+            case 25: value = new TargetNUInt(X25); return true;
+            case 26: value = new TargetNUInt(X26); return true;
+            case 27: value = new TargetNUInt(X27); return true;
+            case 28: value = new TargetNUInt(X28); return true;
+            case 29: value = new TargetNUInt(Fp); return true;
+            case 30: value = new TargetNUInt(Lr); return true;
+            case 31: value = new TargetNUInt(Sp); return true;
+            case 32: value = new TargetNUInt(Pc); return true;
+            default: value = default; return false;
+        }
+    }
 
     // Control flags
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARMContext.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARMContext.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers.ARM;
 
@@ -70,10 +73,10 @@ internal struct ARMContext : IPlatformContext
         if (name.Equals("r10", StringComparison.OrdinalIgnoreCase)) { R10 = (uint)value.Value; return true; }
         if (name.Equals("r11", StringComparison.OrdinalIgnoreCase)) { R11 = (uint)value.Value; return true; }
         if (name.Equals("r12", StringComparison.OrdinalIgnoreCase)) { R12 = (uint)value.Value; return true; }
-        if (name.Equals("cpsr", StringComparison.OrdinalIgnoreCase)) { Cpsr = (uint)value.Value; return true; }
         if (name.Equals("sp", StringComparison.OrdinalIgnoreCase)) { Sp = (uint)value.Value; return true; }
         if (name.Equals("lr", StringComparison.OrdinalIgnoreCase)) { Lr = (uint)value.Value; return true; }
         if (name.Equals("pc", StringComparison.OrdinalIgnoreCase)) { Pc = (uint)value.Value; return true; }
+        if (name.Equals("cpsr", StringComparison.OrdinalIgnoreCase)) { Cpsr = (uint)value.Value; return true; }
         if (name.Equals("fpscr", StringComparison.OrdinalIgnoreCase)) { Fpscr = (uint)value.Value; return true; }
         return false;
     }
@@ -94,61 +97,26 @@ internal struct ARMContext : IPlatformContext
         if (name.Equals("r10", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R10); return true; }
         if (name.Equals("r11", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R11); return true; }
         if (name.Equals("r12", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R12); return true; }
-        if (name.Equals("cpsr", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Cpsr); return true; }
         if (name.Equals("sp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Sp); return true; }
         if (name.Equals("lr", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Lr); return true; }
         if (name.Equals("pc", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Pc); return true; }
+        if (name.Equals("cpsr", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Cpsr); return true; }
         if (name.Equals("fpscr", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Fpscr); return true; }
         return false;
     }
 
 
-    public bool TrySetRegister(int number, TargetNUInt value)
+    // Maps numbered registers (0–16) to their canonical names for by-number dispatch.
+    private static readonly FrozenDictionary<int, string> s_registersByNumber = new Dictionary<int, string>
     {
-        switch (number)
-        {
-            case 0: R0 = (uint)value.Value; return true;
-            case 1: R1 = (uint)value.Value; return true;
-            case 2: R2 = (uint)value.Value; return true;
-            case 3: R3 = (uint)value.Value; return true;
-            case 4: R4 = (uint)value.Value; return true;
-            case 5: R5 = (uint)value.Value; return true;
-            case 6: R6 = (uint)value.Value; return true;
-            case 7: R7 = (uint)value.Value; return true;
-            case 8: R8 = (uint)value.Value; return true;
-            case 9: R9 = (uint)value.Value; return true;
-            case 10: R10 = (uint)value.Value; return true;
-            case 11: R11 = (uint)value.Value; return true;
-            case 12: R12 = (uint)value.Value; return true;
-            case 13: Sp = (uint)value.Value; return true;
-            case 14: Lr = (uint)value.Value; return true;
-            default: return false;
-        }
-    }
+        [0] = "R0", [1] = "R1", [2] = "R2", [3] = "R3", [4] = "R4",
+        [5] = "R5", [6] = "R6", [7] = "R7", [8] = "R8", [9] = "R9",
+        [10] = "R10", [11] = "R11", [12] = "R12", [13] = "Sp", [14] = "Lr",
+        [15] = "Pc", [16] = "Cpsr",
+    }.ToFrozenDictionary();
 
-    public bool TryReadRegister(int number, out TargetNUInt value)
-    {
-        value = default;
-        switch (number)
-        {
-            case 0: value = new TargetNUInt(R0); return true;
-            case 1: value = new TargetNUInt(R1); return true;
-            case 2: value = new TargetNUInt(R2); return true;
-            case 3: value = new TargetNUInt(R3); return true;
-            case 4: value = new TargetNUInt(R4); return true;
-            case 5: value = new TargetNUInt(R5); return true;
-            case 6: value = new TargetNUInt(R6); return true;
-            case 7: value = new TargetNUInt(R7); return true;
-            case 8: value = new TargetNUInt(R8); return true;
-            case 9: value = new TargetNUInt(R9); return true;
-            case 10: value = new TargetNUInt(R10); return true;
-            case 11: value = new TargetNUInt(R11); return true;
-            case 12: value = new TargetNUInt(R12); return true;
-            case 13: value = new TargetNUInt(Sp); return true;
-            case 14: value = new TargetNUInt(Lr); return true;
-            default: return false;
-        }
-    }
+    public bool TryGetRegisterName(int number, [NotNullWhen(true)] out string? name)
+        => s_registersByNumber.TryGetValue(number, out name);
 
     // Control flags
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARMContext.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARMContext.cs
@@ -55,6 +55,101 @@ internal struct ARMContext : IPlatformContext
         unwinder.Unwind(ref this);
     }
 
+    public bool TrySetRegister(string name, TargetNUInt value)
+    {
+        if (name.Equals("r0", StringComparison.OrdinalIgnoreCase)) { R0 = (uint)value.Value; return true; }
+        if (name.Equals("r1", StringComparison.OrdinalIgnoreCase)) { R1 = (uint)value.Value; return true; }
+        if (name.Equals("r2", StringComparison.OrdinalIgnoreCase)) { R2 = (uint)value.Value; return true; }
+        if (name.Equals("r3", StringComparison.OrdinalIgnoreCase)) { R3 = (uint)value.Value; return true; }
+        if (name.Equals("r4", StringComparison.OrdinalIgnoreCase)) { R4 = (uint)value.Value; return true; }
+        if (name.Equals("r5", StringComparison.OrdinalIgnoreCase)) { R5 = (uint)value.Value; return true; }
+        if (name.Equals("r6", StringComparison.OrdinalIgnoreCase)) { R6 = (uint)value.Value; return true; }
+        if (name.Equals("r7", StringComparison.OrdinalIgnoreCase)) { R7 = (uint)value.Value; return true; }
+        if (name.Equals("r8", StringComparison.OrdinalIgnoreCase)) { R8 = (uint)value.Value; return true; }
+        if (name.Equals("r9", StringComparison.OrdinalIgnoreCase)) { R9 = (uint)value.Value; return true; }
+        if (name.Equals("r10", StringComparison.OrdinalIgnoreCase)) { R10 = (uint)value.Value; return true; }
+        if (name.Equals("r11", StringComparison.OrdinalIgnoreCase)) { R11 = (uint)value.Value; return true; }
+        if (name.Equals("r12", StringComparison.OrdinalIgnoreCase)) { R12 = (uint)value.Value; return true; }
+        if (name.Equals("cpsr", StringComparison.OrdinalIgnoreCase)) { Cpsr = (uint)value.Value; return true; }
+        if (name.Equals("sp", StringComparison.OrdinalIgnoreCase)) { Sp = (uint)value.Value; return true; }
+        if (name.Equals("lr", StringComparison.OrdinalIgnoreCase)) { Lr = (uint)value.Value; return true; }
+        if (name.Equals("pc", StringComparison.OrdinalIgnoreCase)) { Pc = (uint)value.Value; return true; }
+        if (name.Equals("fpscr", StringComparison.OrdinalIgnoreCase)) { Fpscr = (uint)value.Value; return true; }
+        return false;
+    }
+
+    public bool TryReadRegister(string name, out TargetNUInt value)
+    {
+        value = default;
+        if (name.Equals("r0", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R0); return true; }
+        if (name.Equals("r1", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R1); return true; }
+        if (name.Equals("r2", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R2); return true; }
+        if (name.Equals("r3", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R3); return true; }
+        if (name.Equals("r4", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R4); return true; }
+        if (name.Equals("r5", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R5); return true; }
+        if (name.Equals("r6", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R6); return true; }
+        if (name.Equals("r7", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R7); return true; }
+        if (name.Equals("r8", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R8); return true; }
+        if (name.Equals("r9", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R9); return true; }
+        if (name.Equals("r10", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R10); return true; }
+        if (name.Equals("r11", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R11); return true; }
+        if (name.Equals("r12", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R12); return true; }
+        if (name.Equals("cpsr", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Cpsr); return true; }
+        if (name.Equals("sp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Sp); return true; }
+        if (name.Equals("lr", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Lr); return true; }
+        if (name.Equals("pc", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Pc); return true; }
+        if (name.Equals("fpscr", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Fpscr); return true; }
+        return false;
+    }
+
+
+    public bool TrySetRegister(int number, TargetNUInt value)
+    {
+        switch (number)
+        {
+            case 0: R0 = (uint)value.Value; return true;
+            case 1: R1 = (uint)value.Value; return true;
+            case 2: R2 = (uint)value.Value; return true;
+            case 3: R3 = (uint)value.Value; return true;
+            case 4: R4 = (uint)value.Value; return true;
+            case 5: R5 = (uint)value.Value; return true;
+            case 6: R6 = (uint)value.Value; return true;
+            case 7: R7 = (uint)value.Value; return true;
+            case 8: R8 = (uint)value.Value; return true;
+            case 9: R9 = (uint)value.Value; return true;
+            case 10: R10 = (uint)value.Value; return true;
+            case 11: R11 = (uint)value.Value; return true;
+            case 12: R12 = (uint)value.Value; return true;
+            case 13: Sp = (uint)value.Value; return true;
+            case 14: Lr = (uint)value.Value; return true;
+            default: return false;
+        }
+    }
+
+    public bool TryReadRegister(int number, out TargetNUInt value)
+    {
+        value = default;
+        switch (number)
+        {
+            case 0: value = new TargetNUInt(R0); return true;
+            case 1: value = new TargetNUInt(R1); return true;
+            case 2: value = new TargetNUInt(R2); return true;
+            case 3: value = new TargetNUInt(R3); return true;
+            case 4: value = new TargetNUInt(R4); return true;
+            case 5: value = new TargetNUInt(R5); return true;
+            case 6: value = new TargetNUInt(R6); return true;
+            case 7: value = new TargetNUInt(R7); return true;
+            case 8: value = new TargetNUInt(R8); return true;
+            case 9: value = new TargetNUInt(R9); return true;
+            case 10: value = new TargetNUInt(R10); return true;
+            case 11: value = new TargetNUInt(R11); return true;
+            case 12: value = new TargetNUInt(R12); return true;
+            case 13: value = new TargetNUInt(Sp); return true;
+            case 14: value = new TargetNUInt(Lr); return true;
+            default: return false;
+        }
+    }
+
     // Control flags
 
     [FieldOffset(0x0)]

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARMContext.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ARMContext.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Frozen;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers.ARM;
 
@@ -105,18 +102,55 @@ internal struct ARMContext : IPlatformContext
         return false;
     }
 
-
-    // Maps numbered registers (0–16) to their canonical names for by-number dispatch.
-    private static readonly FrozenDictionary<int, string> s_registersByNumber = new Dictionary<int, string>
+    public bool TrySetRegister(int number, TargetNUInt value)
     {
-        [0] = "R0", [1] = "R1", [2] = "R2", [3] = "R3", [4] = "R4",
-        [5] = "R5", [6] = "R6", [7] = "R7", [8] = "R8", [9] = "R9",
-        [10] = "R10", [11] = "R11", [12] = "R12", [13] = "Sp", [14] = "Lr",
-        [15] = "Pc", [16] = "Cpsr",
-    }.ToFrozenDictionary();
+        switch (number)
+        {
+            case 0: R0 = (uint)value.Value; return true;
+            case 1: R1 = (uint)value.Value; return true;
+            case 2: R2 = (uint)value.Value; return true;
+            case 3: R3 = (uint)value.Value; return true;
+            case 4: R4 = (uint)value.Value; return true;
+            case 5: R5 = (uint)value.Value; return true;
+            case 6: R6 = (uint)value.Value; return true;
+            case 7: R7 = (uint)value.Value; return true;
+            case 8: R8 = (uint)value.Value; return true;
+            case 9: R9 = (uint)value.Value; return true;
+            case 10: R10 = (uint)value.Value; return true;
+            case 11: R11 = (uint)value.Value; return true;
+            case 12: R12 = (uint)value.Value; return true;
+            case 13: Sp = (uint)value.Value; return true;
+            case 14: Lr = (uint)value.Value; return true;
+            case 15: Pc = (uint)value.Value; return true;
+            case 16: Cpsr = (uint)value.Value; return true;
+            default: return false;
+        }
+    }
 
-    public bool TryGetRegisterName(int number, [NotNullWhen(true)] out string? name)
-        => s_registersByNumber.TryGetValue(number, out name);
+    public bool TryReadRegister(int number, out TargetNUInt value)
+    {
+        switch (number)
+        {
+            case 0: value = new TargetNUInt(R0); return true;
+            case 1: value = new TargetNUInt(R1); return true;
+            case 2: value = new TargetNUInt(R2); return true;
+            case 3: value = new TargetNUInt(R3); return true;
+            case 4: value = new TargetNUInt(R4); return true;
+            case 5: value = new TargetNUInt(R5); return true;
+            case 6: value = new TargetNUInt(R6); return true;
+            case 7: value = new TargetNUInt(R7); return true;
+            case 8: value = new TargetNUInt(R8); return true;
+            case 9: value = new TargetNUInt(R9); return true;
+            case 10: value = new TargetNUInt(R10); return true;
+            case 11: value = new TargetNUInt(R11); return true;
+            case 12: value = new TargetNUInt(R12); return true;
+            case 13: value = new TargetNUInt(Sp); return true;
+            case 14: value = new TargetNUInt(Lr); return true;
+            case 15: value = new TargetNUInt(Pc); return true;
+            case 16: value = new TargetNUInt(Cpsr); return true;
+            default: value = default; return false;
+        }
+    }
 
     // Control flags
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ContextHolder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ContextHolder.cs
@@ -2,13 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers;
 
-public class ContextHolder<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicFields)] T> : IPlatformAgnosticContext, IEquatable<ContextHolder<T>>
+public class ContextHolder<T> : IPlatformAgnosticContext, IEquatable<ContextHolder<T>>
     where T : unmanaged, IPlatformContext
 {
     public T Context;
@@ -49,39 +47,14 @@ public class ContextHolder<[DynamicallyAccessedMembers(DynamicallyAccessedMember
     public void Clear() => Context = default;
     public void Unwind(Target target) => Context.Unwind(target);
 
-    public bool TrySetRegister(Target target, string fieldName, TargetNUInt value)
-    {
-        if (typeof(T).GetField(fieldName) is not FieldInfo field) return false;
-        switch (field.FieldType)
-        {
-            case Type t when t == typeof(ulong) && target.PointerSize == sizeof(ulong):
-                field.SetValueDirect(__makeref(Context), value.Value);
-                return true;
-            case Type t when t == typeof(uint) && target.PointerSize == sizeof(uint):
-                field.SetValueDirect(__makeref(Context), (uint)value.Value);
-                return true;
-            default:
-                return false;
-        }
-    }
+    public bool TrySetRegister(string fieldName, TargetNUInt value) => Context.TrySetRegister(fieldName, value);
 
-    public bool TryReadRegister(Target target, string fieldName, out TargetNUInt value)
-    {
-        value = default;
-        if (typeof(T).GetField(fieldName) is not FieldInfo field) return false;
-        object? fieldValue = field.GetValue(Context);
-        if (fieldValue is ulong ul && target.PointerSize == sizeof(ulong))
-        {
-            value = new(ul);
-            return true;
-        }
-        if (fieldValue is uint ui && target.PointerSize == sizeof(uint))
-        {
-            value = new(ui);
-            return true;
-        }
-        return false;
-    }
+    public bool TryReadRegister(string fieldName, out TargetNUInt value) => Context.TryReadRegister(fieldName, out value);
+
+    public bool TrySetRegister(int number, TargetNUInt value) => Context.TrySetRegister(number, value);
+
+    public bool TryReadRegister(int number, out TargetNUInt value) => Context.TryReadRegister(number, out value);
+
 
     public bool Equals(ContextHolder<T>? other)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ContextHolder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ContextHolder.cs
@@ -48,11 +48,8 @@ public class ContextHolder<T> : IPlatformAgnosticContext, IEquatable<ContextHold
     public void Unwind(Target target) => Context.Unwind(target);
 
     public bool TrySetRegister(string fieldName, TargetNUInt value) => Context.TrySetRegister(fieldName, value);
-
     public bool TryReadRegister(string fieldName, out TargetNUInt value) => Context.TryReadRegister(fieldName, out value);
-
     public bool TrySetRegister(int number, TargetNUInt value) => Context.TrySetRegister(number, value);
-
     public bool TryReadRegister(int number, out TargetNUInt value) => Context.TryReadRegister(number, out value);
 
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ContextHolder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/ContextHolder.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 
 namespace Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers;
 
-public class ContextHolder<T> : IPlatformAgnosticContext, IEquatable<ContextHolder<T>>
+public sealed class ContextHolder<T> : IPlatformAgnosticContext, IEquatable<ContextHolder<T>>
     where T : unmanaged, IPlatformContext
 {
     public T Context;
@@ -51,7 +51,6 @@ public class ContextHolder<T> : IPlatformAgnosticContext, IEquatable<ContextHold
     public bool TryReadRegister(string fieldName, out TargetNUInt value) => Context.TryReadRegister(fieldName, out value);
     public bool TrySetRegister(int number, TargetNUInt value) => Context.TrySetRegister(number, value);
     public bool TryReadRegister(int number, out TargetNUInt value) => Context.TryReadRegister(number, out value);
-
 
     public bool Equals(ContextHolder<T>? other)
     {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/IPlatformAgnosticContext.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/IPlatformAgnosticContext.cs
@@ -19,8 +19,10 @@ public interface IPlatformAgnosticContext
     public abstract void FillFromBuffer(Span<byte> buffer);
     public abstract byte[] GetBytes();
     public abstract IPlatformAgnosticContext Clone();
-    public abstract bool TrySetRegister(Target target, string fieldName, TargetNUInt value);
-    public abstract bool TryReadRegister(Target target, string fieldName, out TargetNUInt value);
+    public abstract bool TrySetRegister(string fieldName, TargetNUInt value);
+    public abstract bool TryReadRegister(string fieldName, out TargetNUInt value);
+    public abstract bool TrySetRegister(int number, TargetNUInt value);
+    public abstract bool TryReadRegister(int number, out TargetNUInt value);
     public abstract void Unwind(Target target);
 
     public static IPlatformAgnosticContext GetContextForPlatform(Target target)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/IPlatformContext.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/IPlatformContext.cs
@@ -5,12 +5,17 @@ namespace Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers;
 
 public interface IPlatformContext
 {
-    public abstract uint Size { get; }
-    public abstract uint DefaultContextFlags { get; }
+    uint Size { get; }
+    uint DefaultContextFlags { get; }
 
-    public TargetPointer StackPointer { get; set; }
-    public TargetPointer InstructionPointer { get; set; }
-    public TargetPointer FramePointer { get; set; }
+    TargetPointer StackPointer { get; set; }
+    TargetPointer InstructionPointer { get; set; }
+    TargetPointer FramePointer { get; set; }
 
-    public abstract void Unwind(Target target);
+    void Unwind(Target target);
+
+    bool TrySetRegister(string name, TargetNUInt value);
+    bool TryReadRegister(string name, out TargetNUInt value);
+    bool TrySetRegister(int number, TargetNUInt value);
+    bool TryReadRegister(int number, out TargetNUInt value);
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/IPlatformContext.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/IPlatformContext.cs
@@ -1,6 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers;
 
 public interface IPlatformContext
@@ -16,6 +18,18 @@ public interface IPlatformContext
 
     bool TrySetRegister(string name, TargetNUInt value);
     bool TryReadRegister(string name, out TargetNUInt value);
-    bool TrySetRegister(int number, TargetNUInt value);
-    bool TryReadRegister(int number, out TargetNUInt value);
+    bool TryGetRegisterName(int number, [NotNullWhen(true)] out string? name);
+
+    bool TrySetRegister(int number, TargetNUInt value)
+    {
+        if (!TryGetRegisterName(number, out string? name))
+            return false;
+        return TrySetRegister(name, value);
+    }
+
+    bool TryReadRegister(int number, out TargetNUInt value)
+    {
+        value = default;
+        return TryGetRegisterName(number, out string? name) && TryReadRegister(name, out value);
+    }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/IPlatformContext.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/IPlatformContext.cs
@@ -1,8 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers;
 
 public interface IPlatformContext
@@ -18,18 +16,7 @@ public interface IPlatformContext
 
     bool TrySetRegister(string name, TargetNUInt value);
     bool TryReadRegister(string name, out TargetNUInt value);
-    bool TryGetRegisterName(int number, [NotNullWhen(true)] out string? name);
 
-    bool TrySetRegister(int number, TargetNUInt value)
-    {
-        if (!TryGetRegisterName(number, out string? name))
-            return false;
-        return TrySetRegister(name, value);
-    }
-
-    bool TryReadRegister(int number, out TargetNUInt value)
-    {
-        value = default;
-        return TryGetRegisterName(number, out string? name) && TryReadRegister(name, out value);
-    }
+    bool TrySetRegister(int number, TargetNUInt value);
+    bool TryReadRegister(int number, out TargetNUInt value);
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/LoongArch64/LoongArch64Unwinder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/LoongArch64/LoongArch64Unwinder.cs
@@ -721,41 +721,8 @@ internal class LoongArch64Unwinder(Target target)
 
     private static void SetRegisterValue(ref LoongArch64Context context, uint regNum, ulong value)
     {
-        switch (regNum)
-        {
-            case 0: context.R0 = value; break;
-            case 1: context.Ra = value; break;
-            case 2: context.Tp = value; break;
-            case 3: context.Sp = value; break;
-            case 4: context.A0 = value; break;
-            case 5: context.A1 = value; break;
-            case 6: context.A2 = value; break;
-            case 7: context.A3 = value; break;
-            case 8: context.A4 = value; break;
-            case 9: context.A5 = value; break;
-            case 10: context.A6 = value; break;
-            case 11: context.A7 = value; break;
-            case 12: context.T0 = value; break;
-            case 13: context.T1 = value; break;
-            case 14: context.T2 = value; break;
-            case 15: context.T3 = value; break;
-            case 16: context.T4 = value; break;
-            case 17: context.T5 = value; break;
-            case 18: context.T6 = value; break;
-            case 19: context.T7 = value; break;
-            case 20: context.T8 = value; break;
-            case 21: context.X0 = value; break;
-            case 22: context.Fp = value; break;
-            case 23: context.S0 = value; break;
-            case 24: context.S1 = value; break;
-            case 25: context.S2 = value; break;
-            case 26: context.S3 = value; break;
-            case 27: context.S4 = value; break;
-            case 28: context.S5 = value; break;
-            case 29: context.S6 = value; break;
-            case 30: context.S7 = value; break;
-            case 31: context.S8 = value; break;
-        }
+        if (context.TryGetRegisterName((int)regNum, out string? name))
+            context.TrySetRegister(name, new TargetNUInt(value));
     }
 
     #endregion

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/LoongArch64/LoongArch64Unwinder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/LoongArch64/LoongArch64Unwinder.cs
@@ -721,8 +721,7 @@ internal class LoongArch64Unwinder(Target target)
 
     private static void SetRegisterValue(ref LoongArch64Context context, uint regNum, ulong value)
     {
-        if (context.TryGetRegisterName((int)regNum, out string? name))
-            context.TrySetRegister(name, new TargetNUInt(value));
+        context.TrySetRegister((int)regNum, new TargetNUInt(value));
     }
 
     #endregion

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/LoongArch64Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/LoongArch64Context.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers.LoongArch64;
 
@@ -145,86 +148,21 @@ internal struct LoongArch64Context : IPlatformContext
     }
 
 
-    public bool TrySetRegister(int number, TargetNUInt value)
+    // Maps numbered registers (0–31) to their canonical names for by-number dispatch.
+    private static readonly FrozenDictionary<int, string> s_registersByNumber = new Dictionary<int, string>
     {
-        switch (number)
-        {
-            case 0: R0 = value.Value; return true;
-            case 1: Ra = value.Value; return true;
-            case 2: Tp = value.Value; return true;
-            case 3: Sp = value.Value; return true;
-            case 4: A0 = value.Value; return true;
-            case 5: A1 = value.Value; return true;
-            case 6: A2 = value.Value; return true;
-            case 7: A3 = value.Value; return true;
-            case 8: A4 = value.Value; return true;
-            case 9: A5 = value.Value; return true;
-            case 10: A6 = value.Value; return true;
-            case 11: A7 = value.Value; return true;
-            case 12: T0 = value.Value; return true;
-            case 13: T1 = value.Value; return true;
-            case 14: T2 = value.Value; return true;
-            case 15: T3 = value.Value; return true;
-            case 16: T4 = value.Value; return true;
-            case 17: T5 = value.Value; return true;
-            case 18: T6 = value.Value; return true;
-            case 19: T7 = value.Value; return true;
-            case 20: T8 = value.Value; return true;
-            case 21: X0 = value.Value; return true;
-            case 22: Fp = value.Value; return true;
-            case 23: S0 = value.Value; return true;
-            case 24: S1 = value.Value; return true;
-            case 25: S2 = value.Value; return true;
-            case 26: S3 = value.Value; return true;
-            case 27: S4 = value.Value; return true;
-            case 28: S5 = value.Value; return true;
-            case 29: S6 = value.Value; return true;
-            case 30: S7 = value.Value; return true;
-            case 31: S8 = value.Value; return true;
-            default: return false;
-        }
-    }
+        [0] = "R0", [1] = "Ra", [2] = "Tp", [3] = "Sp",
+        [4] = "A0", [5] = "A1", [6] = "A2", [7] = "A3",
+        [8] = "A4", [9] = "A5", [10] = "A6", [11] = "A7",
+        [12] = "T0", [13] = "T1", [14] = "T2", [15] = "T3",
+        [16] = "T4", [17] = "T5", [18] = "T6", [19] = "T7",
+        [20] = "T8", [21] = "X0", [22] = "Fp", [23] = "S0",
+        [24] = "S1", [25] = "S2", [26] = "S3", [27] = "S4",
+        [28] = "S5", [29] = "S6", [30] = "S7", [31] = "S8",
+    }.ToFrozenDictionary();
 
-    public bool TryReadRegister(int number, out TargetNUInt value)
-    {
-        value = default;
-        switch (number)
-        {
-            case 0: value = new TargetNUInt(R0); return true;
-            case 1: value = new TargetNUInt(Ra); return true;
-            case 2: value = new TargetNUInt(Tp); return true;
-            case 3: value = new TargetNUInt(Sp); return true;
-            case 4: value = new TargetNUInt(A0); return true;
-            case 5: value = new TargetNUInt(A1); return true;
-            case 6: value = new TargetNUInt(A2); return true;
-            case 7: value = new TargetNUInt(A3); return true;
-            case 8: value = new TargetNUInt(A4); return true;
-            case 9: value = new TargetNUInt(A5); return true;
-            case 10: value = new TargetNUInt(A6); return true;
-            case 11: value = new TargetNUInt(A7); return true;
-            case 12: value = new TargetNUInt(T0); return true;
-            case 13: value = new TargetNUInt(T1); return true;
-            case 14: value = new TargetNUInt(T2); return true;
-            case 15: value = new TargetNUInt(T3); return true;
-            case 16: value = new TargetNUInt(T4); return true;
-            case 17: value = new TargetNUInt(T5); return true;
-            case 18: value = new TargetNUInt(T6); return true;
-            case 19: value = new TargetNUInt(T7); return true;
-            case 20: value = new TargetNUInt(T8); return true;
-            case 21: value = new TargetNUInt(X0); return true;
-            case 22: value = new TargetNUInt(Fp); return true;
-            case 23: value = new TargetNUInt(S0); return true;
-            case 24: value = new TargetNUInt(S1); return true;
-            case 25: value = new TargetNUInt(S2); return true;
-            case 26: value = new TargetNUInt(S3); return true;
-            case 27: value = new TargetNUInt(S4); return true;
-            case 28: value = new TargetNUInt(S5); return true;
-            case 29: value = new TargetNUInt(S6); return true;
-            case 30: value = new TargetNUInt(S7); return true;
-            case 31: value = new TargetNUInt(S8); return true;
-            default: return false;
-        }
-    }
+    public bool TryGetRegisterName(int number, [NotNullWhen(true)] out string? name)
+        => s_registersByNumber.TryGetValue(number, out name);
 
     // Control flags
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/LoongArch64Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/LoongArch64Context.cs
@@ -63,6 +63,169 @@ internal struct LoongArch64Context : IPlatformContext
         unwinder.Unwind(ref this);
     }
 
+    public bool TrySetRegister(string name, TargetNUInt value)
+    {
+        if (name.Equals("r0", StringComparison.OrdinalIgnoreCase)) { R0 = value.Value; return true; }
+        if (name.Equals("ra", StringComparison.OrdinalIgnoreCase)) { Ra = value.Value; return true; }
+        if (name.Equals("tp", StringComparison.OrdinalIgnoreCase)) { Tp = value.Value; return true; }
+        if (name.Equals("sp", StringComparison.OrdinalIgnoreCase)) { Sp = value.Value; return true; }
+        if (name.Equals("a0", StringComparison.OrdinalIgnoreCase)) { A0 = value.Value; return true; }
+        if (name.Equals("a1", StringComparison.OrdinalIgnoreCase)) { A1 = value.Value; return true; }
+        if (name.Equals("a2", StringComparison.OrdinalIgnoreCase)) { A2 = value.Value; return true; }
+        if (name.Equals("a3", StringComparison.OrdinalIgnoreCase)) { A3 = value.Value; return true; }
+        if (name.Equals("a4", StringComparison.OrdinalIgnoreCase)) { A4 = value.Value; return true; }
+        if (name.Equals("a5", StringComparison.OrdinalIgnoreCase)) { A5 = value.Value; return true; }
+        if (name.Equals("a6", StringComparison.OrdinalIgnoreCase)) { A6 = value.Value; return true; }
+        if (name.Equals("a7", StringComparison.OrdinalIgnoreCase)) { A7 = value.Value; return true; }
+        if (name.Equals("t0", StringComparison.OrdinalIgnoreCase)) { T0 = value.Value; return true; }
+        if (name.Equals("t1", StringComparison.OrdinalIgnoreCase)) { T1 = value.Value; return true; }
+        if (name.Equals("t2", StringComparison.OrdinalIgnoreCase)) { T2 = value.Value; return true; }
+        if (name.Equals("t3", StringComparison.OrdinalIgnoreCase)) { T3 = value.Value; return true; }
+        if (name.Equals("t4", StringComparison.OrdinalIgnoreCase)) { T4 = value.Value; return true; }
+        if (name.Equals("t5", StringComparison.OrdinalIgnoreCase)) { T5 = value.Value; return true; }
+        if (name.Equals("t6", StringComparison.OrdinalIgnoreCase)) { T6 = value.Value; return true; }
+        if (name.Equals("t7", StringComparison.OrdinalIgnoreCase)) { T7 = value.Value; return true; }
+        if (name.Equals("t8", StringComparison.OrdinalIgnoreCase)) { T8 = value.Value; return true; }
+        if (name.Equals("x0", StringComparison.OrdinalIgnoreCase)) { X0 = value.Value; return true; }
+        if (name.Equals("fp", StringComparison.OrdinalIgnoreCase)) { Fp = value.Value; return true; }
+        if (name.Equals("s0", StringComparison.OrdinalIgnoreCase)) { S0 = value.Value; return true; }
+        if (name.Equals("s1", StringComparison.OrdinalIgnoreCase)) { S1 = value.Value; return true; }
+        if (name.Equals("s2", StringComparison.OrdinalIgnoreCase)) { S2 = value.Value; return true; }
+        if (name.Equals("s3", StringComparison.OrdinalIgnoreCase)) { S3 = value.Value; return true; }
+        if (name.Equals("s4", StringComparison.OrdinalIgnoreCase)) { S4 = value.Value; return true; }
+        if (name.Equals("s5", StringComparison.OrdinalIgnoreCase)) { S5 = value.Value; return true; }
+        if (name.Equals("s6", StringComparison.OrdinalIgnoreCase)) { S6 = value.Value; return true; }
+        if (name.Equals("s7", StringComparison.OrdinalIgnoreCase)) { S7 = value.Value; return true; }
+        if (name.Equals("s8", StringComparison.OrdinalIgnoreCase)) { S8 = value.Value; return true; }
+        if (name.Equals("pc", StringComparison.OrdinalIgnoreCase)) { Pc = value.Value; return true; }
+        if (name.Equals("fcc", StringComparison.OrdinalIgnoreCase)) { Fcc = (uint)value.Value; return true; }
+        if (name.Equals("fcsr", StringComparison.OrdinalIgnoreCase)) { Fcsr = (uint)value.Value; return true; }
+        return false;
+    }
+
+    public bool TryReadRegister(string name, out TargetNUInt value)
+    {
+        value = default;
+        if (name.Equals("r0", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(R0); return true; }
+        if (name.Equals("ra", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ra); return true; }
+        if (name.Equals("tp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Tp); return true; }
+        if (name.Equals("sp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Sp); return true; }
+        if (name.Equals("a0", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A0); return true; }
+        if (name.Equals("a1", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A1); return true; }
+        if (name.Equals("a2", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A2); return true; }
+        if (name.Equals("a3", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A3); return true; }
+        if (name.Equals("a4", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A4); return true; }
+        if (name.Equals("a5", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A5); return true; }
+        if (name.Equals("a6", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A6); return true; }
+        if (name.Equals("a7", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A7); return true; }
+        if (name.Equals("t0", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T0); return true; }
+        if (name.Equals("t1", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T1); return true; }
+        if (name.Equals("t2", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T2); return true; }
+        if (name.Equals("t3", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T3); return true; }
+        if (name.Equals("t4", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T4); return true; }
+        if (name.Equals("t5", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T5); return true; }
+        if (name.Equals("t6", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T6); return true; }
+        if (name.Equals("t7", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T7); return true; }
+        if (name.Equals("t8", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T8); return true; }
+        if (name.Equals("x0", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(X0); return true; }
+        if (name.Equals("fp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Fp); return true; }
+        if (name.Equals("s0", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S0); return true; }
+        if (name.Equals("s1", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S1); return true; }
+        if (name.Equals("s2", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S2); return true; }
+        if (name.Equals("s3", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S3); return true; }
+        if (name.Equals("s4", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S4); return true; }
+        if (name.Equals("s5", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S5); return true; }
+        if (name.Equals("s6", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S6); return true; }
+        if (name.Equals("s7", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S7); return true; }
+        if (name.Equals("s8", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S8); return true; }
+        if (name.Equals("pc", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Pc); return true; }
+        if (name.Equals("fcc", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Fcc); return true; }
+        if (name.Equals("fcsr", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Fcsr); return true; }
+        return false;
+    }
+
+
+    public bool TrySetRegister(int number, TargetNUInt value)
+    {
+        switch (number)
+        {
+            case 0: R0 = value.Value; return true;
+            case 1: Ra = value.Value; return true;
+            case 2: Tp = value.Value; return true;
+            case 3: Sp = value.Value; return true;
+            case 4: A0 = value.Value; return true;
+            case 5: A1 = value.Value; return true;
+            case 6: A2 = value.Value; return true;
+            case 7: A3 = value.Value; return true;
+            case 8: A4 = value.Value; return true;
+            case 9: A5 = value.Value; return true;
+            case 10: A6 = value.Value; return true;
+            case 11: A7 = value.Value; return true;
+            case 12: T0 = value.Value; return true;
+            case 13: T1 = value.Value; return true;
+            case 14: T2 = value.Value; return true;
+            case 15: T3 = value.Value; return true;
+            case 16: T4 = value.Value; return true;
+            case 17: T5 = value.Value; return true;
+            case 18: T6 = value.Value; return true;
+            case 19: T7 = value.Value; return true;
+            case 20: T8 = value.Value; return true;
+            case 21: X0 = value.Value; return true;
+            case 22: Fp = value.Value; return true;
+            case 23: S0 = value.Value; return true;
+            case 24: S1 = value.Value; return true;
+            case 25: S2 = value.Value; return true;
+            case 26: S3 = value.Value; return true;
+            case 27: S4 = value.Value; return true;
+            case 28: S5 = value.Value; return true;
+            case 29: S6 = value.Value; return true;
+            case 30: S7 = value.Value; return true;
+            case 31: S8 = value.Value; return true;
+            default: return false;
+        }
+    }
+
+    public bool TryReadRegister(int number, out TargetNUInt value)
+    {
+        value = default;
+        switch (number)
+        {
+            case 0: value = new TargetNUInt(R0); return true;
+            case 1: value = new TargetNUInt(Ra); return true;
+            case 2: value = new TargetNUInt(Tp); return true;
+            case 3: value = new TargetNUInt(Sp); return true;
+            case 4: value = new TargetNUInt(A0); return true;
+            case 5: value = new TargetNUInt(A1); return true;
+            case 6: value = new TargetNUInt(A2); return true;
+            case 7: value = new TargetNUInt(A3); return true;
+            case 8: value = new TargetNUInt(A4); return true;
+            case 9: value = new TargetNUInt(A5); return true;
+            case 10: value = new TargetNUInt(A6); return true;
+            case 11: value = new TargetNUInt(A7); return true;
+            case 12: value = new TargetNUInt(T0); return true;
+            case 13: value = new TargetNUInt(T1); return true;
+            case 14: value = new TargetNUInt(T2); return true;
+            case 15: value = new TargetNUInt(T3); return true;
+            case 16: value = new TargetNUInt(T4); return true;
+            case 17: value = new TargetNUInt(T5); return true;
+            case 18: value = new TargetNUInt(T6); return true;
+            case 19: value = new TargetNUInt(T7); return true;
+            case 20: value = new TargetNUInt(T8); return true;
+            case 21: value = new TargetNUInt(X0); return true;
+            case 22: value = new TargetNUInt(Fp); return true;
+            case 23: value = new TargetNUInt(S0); return true;
+            case 24: value = new TargetNUInt(S1); return true;
+            case 25: value = new TargetNUInt(S2); return true;
+            case 26: value = new TargetNUInt(S3); return true;
+            case 27: value = new TargetNUInt(S4); return true;
+            case 28: value = new TargetNUInt(S5); return true;
+            case 29: value = new TargetNUInt(S6); return true;
+            case 30: value = new TargetNUInt(S7); return true;
+            case 31: value = new TargetNUInt(S8); return true;
+            default: return false;
+        }
+    }
+
     // Control flags
 
     [FieldOffset(0x0)]

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/LoongArch64Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/LoongArch64Context.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Frozen;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers.LoongArch64;
 
@@ -147,22 +144,85 @@ internal struct LoongArch64Context : IPlatformContext
         return false;
     }
 
-
-    // Maps numbered registers (0–31) to their canonical names for by-number dispatch.
-    private static readonly FrozenDictionary<int, string> s_registersByNumber = new Dictionary<int, string>
+    public bool TrySetRegister(int number, TargetNUInt value)
     {
-        [0] = "R0", [1] = "Ra", [2] = "Tp", [3] = "Sp",
-        [4] = "A0", [5] = "A1", [6] = "A2", [7] = "A3",
-        [8] = "A4", [9] = "A5", [10] = "A6", [11] = "A7",
-        [12] = "T0", [13] = "T1", [14] = "T2", [15] = "T3",
-        [16] = "T4", [17] = "T5", [18] = "T6", [19] = "T7",
-        [20] = "T8", [21] = "X0", [22] = "Fp", [23] = "S0",
-        [24] = "S1", [25] = "S2", [26] = "S3", [27] = "S4",
-        [28] = "S5", [29] = "S6", [30] = "S7", [31] = "S8",
-    }.ToFrozenDictionary();
+        switch (number)
+        {
+            case 0: R0 = value.Value; return true;
+            case 1: Ra = value.Value; return true;
+            case 2: Tp = value.Value; return true;
+            case 3: Sp = value.Value; return true;
+            case 4: A0 = value.Value; return true;
+            case 5: A1 = value.Value; return true;
+            case 6: A2 = value.Value; return true;
+            case 7: A3 = value.Value; return true;
+            case 8: A4 = value.Value; return true;
+            case 9: A5 = value.Value; return true;
+            case 10: A6 = value.Value; return true;
+            case 11: A7 = value.Value; return true;
+            case 12: T0 = value.Value; return true;
+            case 13: T1 = value.Value; return true;
+            case 14: T2 = value.Value; return true;
+            case 15: T3 = value.Value; return true;
+            case 16: T4 = value.Value; return true;
+            case 17: T5 = value.Value; return true;
+            case 18: T6 = value.Value; return true;
+            case 19: T7 = value.Value; return true;
+            case 20: T8 = value.Value; return true;
+            case 21: X0 = value.Value; return true;
+            case 22: Fp = value.Value; return true;
+            case 23: S0 = value.Value; return true;
+            case 24: S1 = value.Value; return true;
+            case 25: S2 = value.Value; return true;
+            case 26: S3 = value.Value; return true;
+            case 27: S4 = value.Value; return true;
+            case 28: S5 = value.Value; return true;
+            case 29: S6 = value.Value; return true;
+            case 30: S7 = value.Value; return true;
+            case 31: S8 = value.Value; return true;
+            default: return false;
+        }
+    }
 
-    public bool TryGetRegisterName(int number, [NotNullWhen(true)] out string? name)
-        => s_registersByNumber.TryGetValue(number, out name);
+    public bool TryReadRegister(int number, out TargetNUInt value)
+    {
+        switch (number)
+        {
+            case 0: value = new TargetNUInt(R0); return true;
+            case 1: value = new TargetNUInt(Ra); return true;
+            case 2: value = new TargetNUInt(Tp); return true;
+            case 3: value = new TargetNUInt(Sp); return true;
+            case 4: value = new TargetNUInt(A0); return true;
+            case 5: value = new TargetNUInt(A1); return true;
+            case 6: value = new TargetNUInt(A2); return true;
+            case 7: value = new TargetNUInt(A3); return true;
+            case 8: value = new TargetNUInt(A4); return true;
+            case 9: value = new TargetNUInt(A5); return true;
+            case 10: value = new TargetNUInt(A6); return true;
+            case 11: value = new TargetNUInt(A7); return true;
+            case 12: value = new TargetNUInt(T0); return true;
+            case 13: value = new TargetNUInt(T1); return true;
+            case 14: value = new TargetNUInt(T2); return true;
+            case 15: value = new TargetNUInt(T3); return true;
+            case 16: value = new TargetNUInt(T4); return true;
+            case 17: value = new TargetNUInt(T5); return true;
+            case 18: value = new TargetNUInt(T6); return true;
+            case 19: value = new TargetNUInt(T7); return true;
+            case 20: value = new TargetNUInt(T8); return true;
+            case 21: value = new TargetNUInt(X0); return true;
+            case 22: value = new TargetNUInt(Fp); return true;
+            case 23: value = new TargetNUInt(S0); return true;
+            case 24: value = new TargetNUInt(S1); return true;
+            case 25: value = new TargetNUInt(S2); return true;
+            case 26: value = new TargetNUInt(S3); return true;
+            case 27: value = new TargetNUInt(S4); return true;
+            case 28: value = new TargetNUInt(S5); return true;
+            case 29: value = new TargetNUInt(S6); return true;
+            case 30: value = new TargetNUInt(S7); return true;
+            case 31: value = new TargetNUInt(S8); return true;
+            default: value = default; return false;
+        }
+    }
 
     // Control flags
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/RISCV64/RISCV64Unwinder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/RISCV64/RISCV64Unwinder.cs
@@ -731,40 +731,8 @@ internal class RISCV64Unwinder(Target target)
 
     private static void SetRegisterValue(ref RISCV64Context context, uint regNum, ulong value)
     {
-        switch (regNum)
-        {
-            case 1: context.Ra = value; break;
-            case 2: context.Sp = value; break;
-            case 3: context.Gp = value; break;
-            case 4: context.Tp = value; break;
-            case 5: context.T0 = value; break;
-            case 6: context.T1 = value; break;
-            case 7: context.T2 = value; break;
-            case 8: context.Fp = value; break;
-            case 9: context.S1 = value; break;
-            case 10: context.A0 = value; break;
-            case 11: context.A1 = value; break;
-            case 12: context.A2 = value; break;
-            case 13: context.A3 = value; break;
-            case 14: context.A4 = value; break;
-            case 15: context.A5 = value; break;
-            case 16: context.A6 = value; break;
-            case 17: context.A7 = value; break;
-            case 18: context.S2 = value; break;
-            case 19: context.S3 = value; break;
-            case 20: context.S4 = value; break;
-            case 21: context.S5 = value; break;
-            case 22: context.S6 = value; break;
-            case 23: context.S7 = value; break;
-            case 24: context.S8 = value; break;
-            case 25: context.S9 = value; break;
-            case 26: context.S10 = value; break;
-            case 27: context.S11 = value; break;
-            case 28: context.T3 = value; break;
-            case 29: context.T4 = value; break;
-            case 30: context.T5 = value; break;
-            case 31: context.T6 = value; break;
-        }
+        if (context.TryGetRegisterName((int)regNum, out string? name))
+            context.TrySetRegister(name, new TargetNUInt(value));
     }
 
     #endregion

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/RISCV64/RISCV64Unwinder.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/RISCV64/RISCV64Unwinder.cs
@@ -731,8 +731,7 @@ internal class RISCV64Unwinder(Target target)
 
     private static void SetRegisterValue(ref RISCV64Context context, uint regNum, ulong value)
     {
-        if (context.TryGetRegisterName((int)regNum, out string? name))
-            context.TrySetRegister(name, new TargetNUInt(value));
+        context.TrySetRegister((int)regNum, new TargetNUInt(value));
     }
 
     #endregion

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/RISCV64Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/RISCV64Context.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers.RISCV64;
 
@@ -62,6 +65,7 @@ internal struct RISCV64Context : IPlatformContext
 
     public bool TrySetRegister(string name, TargetNUInt value)
     {
+        if (name.Equals("zero", StringComparison.OrdinalIgnoreCase)) { return false; }
         if (name.Equals("ra", StringComparison.OrdinalIgnoreCase)) { Ra = value.Value; return true; }
         if (name.Equals("sp", StringComparison.OrdinalIgnoreCase)) { Sp = value.Value; return true; }
         if (name.Equals("gp", StringComparison.OrdinalIgnoreCase)) { Gp = value.Value; return true; }
@@ -101,6 +105,7 @@ internal struct RISCV64Context : IPlatformContext
     public bool TryReadRegister(string name, out TargetNUInt value)
     {
         value = default;
+        if (name.Equals("zero", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(0); return true; }
         if (name.Equals("ra", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ra); return true; }
         if (name.Equals("sp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Sp); return true; }
         if (name.Equals("gp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Gp); return true; }
@@ -138,87 +143,22 @@ internal struct RISCV64Context : IPlatformContext
     }
 
 
-    public bool TrySetRegister(int number, TargetNUInt value)
+    // Maps numbered registers (0–31) to their canonical names for by-number dispatch.
+    // Register 0 (zero) is hardwired to 0 and has no backing field; reads return 0, writes are ignored.
+    private static readonly FrozenDictionary<int, string> s_registersByNumber = new Dictionary<int, string>
     {
-        // Register 0 (zero) is hardwired to 0 and has no backing field.
-        switch (number)
-        {
-            case 1: Ra = value.Value; return true;
-            case 2: Sp = value.Value; return true;
-            case 3: Gp = value.Value; return true;
-            case 4: Tp = value.Value; return true;
-            case 5: T0 = value.Value; return true;
-            case 6: T1 = value.Value; return true;
-            case 7: T2 = value.Value; return true;
-            case 8: Fp = value.Value; return true;
-            case 9: S1 = value.Value; return true;
-            case 10: A0 = value.Value; return true;
-            case 11: A1 = value.Value; return true;
-            case 12: A2 = value.Value; return true;
-            case 13: A3 = value.Value; return true;
-            case 14: A4 = value.Value; return true;
-            case 15: A5 = value.Value; return true;
-            case 16: A6 = value.Value; return true;
-            case 17: A7 = value.Value; return true;
-            case 18: S2 = value.Value; return true;
-            case 19: S3 = value.Value; return true;
-            case 20: S4 = value.Value; return true;
-            case 21: S5 = value.Value; return true;
-            case 22: S6 = value.Value; return true;
-            case 23: S7 = value.Value; return true;
-            case 24: S8 = value.Value; return true;
-            case 25: S9 = value.Value; return true;
-            case 26: S10 = value.Value; return true;
-            case 27: S11 = value.Value; return true;
-            case 28: T3 = value.Value; return true;
-            case 29: T4 = value.Value; return true;
-            case 30: T5 = value.Value; return true;
-            case 31: T6 = value.Value; return true;
-            default: return false;
-        }
-    }
+        [0] = "zero",
+        [1] = "Ra", [2] = "Sp", [3] = "Gp", [4] = "Tp",
+        [5] = "T0", [6] = "T1", [7] = "T2", [8] = "Fp", [9] = "S1",
+        [10] = "A0", [11] = "A1", [12] = "A2", [13] = "A3", [14] = "A4",
+        [15] = "A5", [16] = "A6", [17] = "A7",
+        [18] = "S2", [19] = "S3", [20] = "S4", [21] = "S5", [22] = "S6",
+        [23] = "S7", [24] = "S8", [25] = "S9", [26] = "S10", [27] = "S11",
+        [28] = "T3", [29] = "T4", [30] = "T5", [31] = "T6",
+    }.ToFrozenDictionary();
 
-    public bool TryReadRegister(int number, out TargetNUInt value)
-    {
-        value = default;
-        // Register 0 (zero) is hardwired to 0 and has no backing field.
-        if (number == 0) { value = new TargetNUInt(0); return true; }
-        switch (number)
-        {
-            case 1: value = new TargetNUInt(Ra); return true;
-            case 2: value = new TargetNUInt(Sp); return true;
-            case 3: value = new TargetNUInt(Gp); return true;
-            case 4: value = new TargetNUInt(Tp); return true;
-            case 5: value = new TargetNUInt(T0); return true;
-            case 6: value = new TargetNUInt(T1); return true;
-            case 7: value = new TargetNUInt(T2); return true;
-            case 8: value = new TargetNUInt(Fp); return true;
-            case 9: value = new TargetNUInt(S1); return true;
-            case 10: value = new TargetNUInt(A0); return true;
-            case 11: value = new TargetNUInt(A1); return true;
-            case 12: value = new TargetNUInt(A2); return true;
-            case 13: value = new TargetNUInt(A3); return true;
-            case 14: value = new TargetNUInt(A4); return true;
-            case 15: value = new TargetNUInt(A5); return true;
-            case 16: value = new TargetNUInt(A6); return true;
-            case 17: value = new TargetNUInt(A7); return true;
-            case 18: value = new TargetNUInt(S2); return true;
-            case 19: value = new TargetNUInt(S3); return true;
-            case 20: value = new TargetNUInt(S4); return true;
-            case 21: value = new TargetNUInt(S5); return true;
-            case 22: value = new TargetNUInt(S6); return true;
-            case 23: value = new TargetNUInt(S7); return true;
-            case 24: value = new TargetNUInt(S8); return true;
-            case 25: value = new TargetNUInt(S9); return true;
-            case 26: value = new TargetNUInt(S10); return true;
-            case 27: value = new TargetNUInt(S11); return true;
-            case 28: value = new TargetNUInt(T3); return true;
-            case 29: value = new TargetNUInt(T4); return true;
-            case 30: value = new TargetNUInt(T5); return true;
-            case 31: value = new TargetNUInt(T6); return true;
-            default: return false;
-        }
-    }
+    public bool TryGetRegisterName(int number, [NotNullWhen(true)] out string? name)
+        => s_registersByNumber.TryGetValue(number, out name);
 
     // Control flags
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/RISCV64Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/RISCV64Context.cs
@@ -60,6 +60,166 @@ internal struct RISCV64Context : IPlatformContext
         unwinder.Unwind(ref this);
     }
 
+    public bool TrySetRegister(string name, TargetNUInt value)
+    {
+        if (name.Equals("ra", StringComparison.OrdinalIgnoreCase)) { Ra = value.Value; return true; }
+        if (name.Equals("sp", StringComparison.OrdinalIgnoreCase)) { Sp = value.Value; return true; }
+        if (name.Equals("gp", StringComparison.OrdinalIgnoreCase)) { Gp = value.Value; return true; }
+        if (name.Equals("tp", StringComparison.OrdinalIgnoreCase)) { Tp = value.Value; return true; }
+        if (name.Equals("t0", StringComparison.OrdinalIgnoreCase)) { T0 = value.Value; return true; }
+        if (name.Equals("t1", StringComparison.OrdinalIgnoreCase)) { T1 = value.Value; return true; }
+        if (name.Equals("t2", StringComparison.OrdinalIgnoreCase)) { T2 = value.Value; return true; }
+        if (name.Equals("fp", StringComparison.OrdinalIgnoreCase)) { Fp = value.Value; return true; }
+        if (name.Equals("s1", StringComparison.OrdinalIgnoreCase)) { S1 = value.Value; return true; }
+        if (name.Equals("a0", StringComparison.OrdinalIgnoreCase)) { A0 = value.Value; return true; }
+        if (name.Equals("a1", StringComparison.OrdinalIgnoreCase)) { A1 = value.Value; return true; }
+        if (name.Equals("a2", StringComparison.OrdinalIgnoreCase)) { A2 = value.Value; return true; }
+        if (name.Equals("a3", StringComparison.OrdinalIgnoreCase)) { A3 = value.Value; return true; }
+        if (name.Equals("a4", StringComparison.OrdinalIgnoreCase)) { A4 = value.Value; return true; }
+        if (name.Equals("a5", StringComparison.OrdinalIgnoreCase)) { A5 = value.Value; return true; }
+        if (name.Equals("a6", StringComparison.OrdinalIgnoreCase)) { A6 = value.Value; return true; }
+        if (name.Equals("a7", StringComparison.OrdinalIgnoreCase)) { A7 = value.Value; return true; }
+        if (name.Equals("s2", StringComparison.OrdinalIgnoreCase)) { S2 = value.Value; return true; }
+        if (name.Equals("s3", StringComparison.OrdinalIgnoreCase)) { S3 = value.Value; return true; }
+        if (name.Equals("s4", StringComparison.OrdinalIgnoreCase)) { S4 = value.Value; return true; }
+        if (name.Equals("s5", StringComparison.OrdinalIgnoreCase)) { S5 = value.Value; return true; }
+        if (name.Equals("s6", StringComparison.OrdinalIgnoreCase)) { S6 = value.Value; return true; }
+        if (name.Equals("s7", StringComparison.OrdinalIgnoreCase)) { S7 = value.Value; return true; }
+        if (name.Equals("s8", StringComparison.OrdinalIgnoreCase)) { S8 = value.Value; return true; }
+        if (name.Equals("s9", StringComparison.OrdinalIgnoreCase)) { S9 = value.Value; return true; }
+        if (name.Equals("s10", StringComparison.OrdinalIgnoreCase)) { S10 = value.Value; return true; }
+        if (name.Equals("s11", StringComparison.OrdinalIgnoreCase)) { S11 = value.Value; return true; }
+        if (name.Equals("t3", StringComparison.OrdinalIgnoreCase)) { T3 = value.Value; return true; }
+        if (name.Equals("t4", StringComparison.OrdinalIgnoreCase)) { T4 = value.Value; return true; }
+        if (name.Equals("t5", StringComparison.OrdinalIgnoreCase)) { T5 = value.Value; return true; }
+        if (name.Equals("t6", StringComparison.OrdinalIgnoreCase)) { T6 = value.Value; return true; }
+        if (name.Equals("pc", StringComparison.OrdinalIgnoreCase)) { Pc = value.Value; return true; }
+        if (name.Equals("fcsr", StringComparison.OrdinalIgnoreCase)) { Fcsr = (uint)value.Value; return true; }
+        return false;
+    }
+
+    public bool TryReadRegister(string name, out TargetNUInt value)
+    {
+        value = default;
+        if (name.Equals("ra", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ra); return true; }
+        if (name.Equals("sp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Sp); return true; }
+        if (name.Equals("gp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Gp); return true; }
+        if (name.Equals("tp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Tp); return true; }
+        if (name.Equals("t0", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T0); return true; }
+        if (name.Equals("t1", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T1); return true; }
+        if (name.Equals("t2", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T2); return true; }
+        if (name.Equals("fp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Fp); return true; }
+        if (name.Equals("s1", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S1); return true; }
+        if (name.Equals("a0", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A0); return true; }
+        if (name.Equals("a1", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A1); return true; }
+        if (name.Equals("a2", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A2); return true; }
+        if (name.Equals("a3", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A3); return true; }
+        if (name.Equals("a4", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A4); return true; }
+        if (name.Equals("a5", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A5); return true; }
+        if (name.Equals("a6", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A6); return true; }
+        if (name.Equals("a7", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(A7); return true; }
+        if (name.Equals("s2", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S2); return true; }
+        if (name.Equals("s3", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S3); return true; }
+        if (name.Equals("s4", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S4); return true; }
+        if (name.Equals("s5", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S5); return true; }
+        if (name.Equals("s6", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S6); return true; }
+        if (name.Equals("s7", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S7); return true; }
+        if (name.Equals("s8", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S8); return true; }
+        if (name.Equals("s9", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S9); return true; }
+        if (name.Equals("s10", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S10); return true; }
+        if (name.Equals("s11", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(S11); return true; }
+        if (name.Equals("t3", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T3); return true; }
+        if (name.Equals("t4", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T4); return true; }
+        if (name.Equals("t5", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T5); return true; }
+        if (name.Equals("t6", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(T6); return true; }
+        if (name.Equals("pc", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Pc); return true; }
+        if (name.Equals("fcsr", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Fcsr); return true; }
+        return false;
+    }
+
+
+    public bool TrySetRegister(int number, TargetNUInt value)
+    {
+        // Register 0 (zero) is hardwired to 0 and has no backing field.
+        switch (number)
+        {
+            case 1: Ra = value.Value; return true;
+            case 2: Sp = value.Value; return true;
+            case 3: Gp = value.Value; return true;
+            case 4: Tp = value.Value; return true;
+            case 5: T0 = value.Value; return true;
+            case 6: T1 = value.Value; return true;
+            case 7: T2 = value.Value; return true;
+            case 8: Fp = value.Value; return true;
+            case 9: S1 = value.Value; return true;
+            case 10: A0 = value.Value; return true;
+            case 11: A1 = value.Value; return true;
+            case 12: A2 = value.Value; return true;
+            case 13: A3 = value.Value; return true;
+            case 14: A4 = value.Value; return true;
+            case 15: A5 = value.Value; return true;
+            case 16: A6 = value.Value; return true;
+            case 17: A7 = value.Value; return true;
+            case 18: S2 = value.Value; return true;
+            case 19: S3 = value.Value; return true;
+            case 20: S4 = value.Value; return true;
+            case 21: S5 = value.Value; return true;
+            case 22: S6 = value.Value; return true;
+            case 23: S7 = value.Value; return true;
+            case 24: S8 = value.Value; return true;
+            case 25: S9 = value.Value; return true;
+            case 26: S10 = value.Value; return true;
+            case 27: S11 = value.Value; return true;
+            case 28: T3 = value.Value; return true;
+            case 29: T4 = value.Value; return true;
+            case 30: T5 = value.Value; return true;
+            case 31: T6 = value.Value; return true;
+            default: return false;
+        }
+    }
+
+    public bool TryReadRegister(int number, out TargetNUInt value)
+    {
+        value = default;
+        // Register 0 (zero) is hardwired to 0 and has no backing field.
+        if (number == 0) { value = new TargetNUInt(0); return true; }
+        switch (number)
+        {
+            case 1: value = new TargetNUInt(Ra); return true;
+            case 2: value = new TargetNUInt(Sp); return true;
+            case 3: value = new TargetNUInt(Gp); return true;
+            case 4: value = new TargetNUInt(Tp); return true;
+            case 5: value = new TargetNUInt(T0); return true;
+            case 6: value = new TargetNUInt(T1); return true;
+            case 7: value = new TargetNUInt(T2); return true;
+            case 8: value = new TargetNUInt(Fp); return true;
+            case 9: value = new TargetNUInt(S1); return true;
+            case 10: value = new TargetNUInt(A0); return true;
+            case 11: value = new TargetNUInt(A1); return true;
+            case 12: value = new TargetNUInt(A2); return true;
+            case 13: value = new TargetNUInt(A3); return true;
+            case 14: value = new TargetNUInt(A4); return true;
+            case 15: value = new TargetNUInt(A5); return true;
+            case 16: value = new TargetNUInt(A6); return true;
+            case 17: value = new TargetNUInt(A7); return true;
+            case 18: value = new TargetNUInt(S2); return true;
+            case 19: value = new TargetNUInt(S3); return true;
+            case 20: value = new TargetNUInt(S4); return true;
+            case 21: value = new TargetNUInt(S5); return true;
+            case 22: value = new TargetNUInt(S6); return true;
+            case 23: value = new TargetNUInt(S7); return true;
+            case 24: value = new TargetNUInt(S8); return true;
+            case 25: value = new TargetNUInt(S9); return true;
+            case 26: value = new TargetNUInt(S10); return true;
+            case 27: value = new TargetNUInt(S11); return true;
+            case 28: value = new TargetNUInt(T3); return true;
+            case 29: value = new TargetNUInt(T4); return true;
+            case 30: value = new TargetNUInt(T5); return true;
+            case 31: value = new TargetNUInt(T6); return true;
+            default: return false;
+        }
+    }
+
     // Control flags
 
     [FieldOffset(0x0)]

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/RISCV64Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/RISCV64Context.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Frozen;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers.RISCV64;
 
@@ -142,23 +139,85 @@ internal struct RISCV64Context : IPlatformContext
         return false;
     }
 
-
-    // Maps numbered registers (0–31) to their canonical names for by-number dispatch.
-    // Register 0 (zero) is hardwired to 0 and has no backing field; reads return 0, writes are ignored.
-    private static readonly FrozenDictionary<int, string> s_registersByNumber = new Dictionary<int, string>
+    public bool TrySetRegister(int number, TargetNUInt value)
     {
-        [0] = "zero",
-        [1] = "Ra", [2] = "Sp", [3] = "Gp", [4] = "Tp",
-        [5] = "T0", [6] = "T1", [7] = "T2", [8] = "Fp", [9] = "S1",
-        [10] = "A0", [11] = "A1", [12] = "A2", [13] = "A3", [14] = "A4",
-        [15] = "A5", [16] = "A6", [17] = "A7",
-        [18] = "S2", [19] = "S3", [20] = "S4", [21] = "S5", [22] = "S6",
-        [23] = "S7", [24] = "S8", [25] = "S9", [26] = "S10", [27] = "S11",
-        [28] = "T3", [29] = "T4", [30] = "T5", [31] = "T6",
-    }.ToFrozenDictionary();
+        switch (number)
+        {
+            case 0: return false; // zero register is hardwired to 0
+            case 1: Ra = value.Value; return true;
+            case 2: Sp = value.Value; return true;
+            case 3: Gp = value.Value; return true;
+            case 4: Tp = value.Value; return true;
+            case 5: T0 = value.Value; return true;
+            case 6: T1 = value.Value; return true;
+            case 7: T2 = value.Value; return true;
+            case 8: Fp = value.Value; return true;
+            case 9: S1 = value.Value; return true;
+            case 10: A0 = value.Value; return true;
+            case 11: A1 = value.Value; return true;
+            case 12: A2 = value.Value; return true;
+            case 13: A3 = value.Value; return true;
+            case 14: A4 = value.Value; return true;
+            case 15: A5 = value.Value; return true;
+            case 16: A6 = value.Value; return true;
+            case 17: A7 = value.Value; return true;
+            case 18: S2 = value.Value; return true;
+            case 19: S3 = value.Value; return true;
+            case 20: S4 = value.Value; return true;
+            case 21: S5 = value.Value; return true;
+            case 22: S6 = value.Value; return true;
+            case 23: S7 = value.Value; return true;
+            case 24: S8 = value.Value; return true;
+            case 25: S9 = value.Value; return true;
+            case 26: S10 = value.Value; return true;
+            case 27: S11 = value.Value; return true;
+            case 28: T3 = value.Value; return true;
+            case 29: T4 = value.Value; return true;
+            case 30: T5 = value.Value; return true;
+            case 31: T6 = value.Value; return true;
+            default: return false;
+        }
+    }
 
-    public bool TryGetRegisterName(int number, [NotNullWhen(true)] out string? name)
-        => s_registersByNumber.TryGetValue(number, out name);
+    public bool TryReadRegister(int number, out TargetNUInt value)
+    {
+        switch (number)
+        {
+            case 0: value = new TargetNUInt(0); return true; // zero register always reads 0
+            case 1: value = new TargetNUInt(Ra); return true;
+            case 2: value = new TargetNUInt(Sp); return true;
+            case 3: value = new TargetNUInt(Gp); return true;
+            case 4: value = new TargetNUInt(Tp); return true;
+            case 5: value = new TargetNUInt(T0); return true;
+            case 6: value = new TargetNUInt(T1); return true;
+            case 7: value = new TargetNUInt(T2); return true;
+            case 8: value = new TargetNUInt(Fp); return true;
+            case 9: value = new TargetNUInt(S1); return true;
+            case 10: value = new TargetNUInt(A0); return true;
+            case 11: value = new TargetNUInt(A1); return true;
+            case 12: value = new TargetNUInt(A2); return true;
+            case 13: value = new TargetNUInt(A3); return true;
+            case 14: value = new TargetNUInt(A4); return true;
+            case 15: value = new TargetNUInt(A5); return true;
+            case 16: value = new TargetNUInt(A6); return true;
+            case 17: value = new TargetNUInt(A7); return true;
+            case 18: value = new TargetNUInt(S2); return true;
+            case 19: value = new TargetNUInt(S3); return true;
+            case 20: value = new TargetNUInt(S4); return true;
+            case 21: value = new TargetNUInt(S5); return true;
+            case 22: value = new TargetNUInt(S6); return true;
+            case 23: value = new TargetNUInt(S7); return true;
+            case 24: value = new TargetNUInt(S8); return true;
+            case 25: value = new TargetNUInt(S9); return true;
+            case 26: value = new TargetNUInt(S10); return true;
+            case 27: value = new TargetNUInt(S11); return true;
+            case 28: value = new TargetNUInt(T3); return true;
+            case 29: value = new TargetNUInt(T4); return true;
+            case 30: value = new TargetNUInt(T5); return true;
+            case 31: value = new TargetNUInt(T6); return true;
+            default: value = default; return false;
+        }
+    }
 
     // Control flags
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/X86Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/X86Context.cs
@@ -62,7 +62,110 @@ public struct X86Context : IPlatformContext
         unwinder.Unwind(ref this);
     }
 
-    // Control flags
+    public bool TrySetRegister(string name, TargetNUInt value)
+    {
+        if (name.Equals("dr0", StringComparison.OrdinalIgnoreCase)) { Dr0 = (uint)value.Value; return true; }
+        if (name.Equals("dr1", StringComparison.OrdinalIgnoreCase)) { Dr1 = (uint)value.Value; return true; }
+        if (name.Equals("dr2", StringComparison.OrdinalIgnoreCase)) { Dr2 = (uint)value.Value; return true; }
+        if (name.Equals("dr3", StringComparison.OrdinalIgnoreCase)) { Dr3 = (uint)value.Value; return true; }
+        if (name.Equals("dr6", StringComparison.OrdinalIgnoreCase)) { Dr6 = (uint)value.Value; return true; }
+        if (name.Equals("dr7", StringComparison.OrdinalIgnoreCase)) { Dr7 = (uint)value.Value; return true; }
+        if (name.Equals("controlword", StringComparison.OrdinalIgnoreCase)) { ControlWord = (uint)value.Value; return true; }
+        if (name.Equals("statusword", StringComparison.OrdinalIgnoreCase)) { StatusWord = (uint)value.Value; return true; }
+        if (name.Equals("tagword", StringComparison.OrdinalIgnoreCase)) { TagWord = (uint)value.Value; return true; }
+        if (name.Equals("erroroffset", StringComparison.OrdinalIgnoreCase)) { ErrorOffset = (uint)value.Value; return true; }
+        if (name.Equals("errorselector", StringComparison.OrdinalIgnoreCase)) { ErrorSelector = (uint)value.Value; return true; }
+        if (name.Equals("dataoffset", StringComparison.OrdinalIgnoreCase)) { DataOffset = (uint)value.Value; return true; }
+        if (name.Equals("dataselector", StringComparison.OrdinalIgnoreCase)) { DataSelector = (uint)value.Value; return true; }
+        if (name.Equals("cr0npxstate", StringComparison.OrdinalIgnoreCase)) { Cr0NpxState = (uint)value.Value; return true; }
+        if (name.Equals("gs", StringComparison.OrdinalIgnoreCase)) { Gs = (uint)value.Value; return true; }
+        if (name.Equals("fs", StringComparison.OrdinalIgnoreCase)) { Fs = (uint)value.Value; return true; }
+        if (name.Equals("es", StringComparison.OrdinalIgnoreCase)) { Es = (uint)value.Value; return true; }
+        if (name.Equals("ds", StringComparison.OrdinalIgnoreCase)) { Ds = (uint)value.Value; return true; }
+        if (name.Equals("cs", StringComparison.OrdinalIgnoreCase)) { Cs = (uint)value.Value; return true; }
+        if (name.Equals("ss", StringComparison.OrdinalIgnoreCase)) { Ss = (uint)value.Value; return true; }
+        if (name.Equals("edi", StringComparison.OrdinalIgnoreCase)) { Edi = (uint)value.Value; return true; }
+        if (name.Equals("esi", StringComparison.OrdinalIgnoreCase)) { Esi = (uint)value.Value; return true; }
+        if (name.Equals("ebx", StringComparison.OrdinalIgnoreCase)) { Ebx = (uint)value.Value; return true; }
+        if (name.Equals("edx", StringComparison.OrdinalIgnoreCase)) { Edx = (uint)value.Value; return true; }
+        if (name.Equals("ecx", StringComparison.OrdinalIgnoreCase)) { Ecx = (uint)value.Value; return true; }
+        if (name.Equals("eax", StringComparison.OrdinalIgnoreCase)) { Eax = (uint)value.Value; return true; }
+        if (name.Equals("eflags", StringComparison.OrdinalIgnoreCase)) { EFlags = (uint)value.Value; return true; }
+        if (name.Equals("ebp", StringComparison.OrdinalIgnoreCase)) { Ebp = (uint)value.Value; return true; }
+        if (name.Equals("eip", StringComparison.OrdinalIgnoreCase)) { Eip = (uint)value.Value; return true; }
+        if (name.Equals("esp", StringComparison.OrdinalIgnoreCase)) { Esp = (uint)value.Value; return true; }
+        return false;
+    }
+
+    public bool TryReadRegister(string name, out TargetNUInt value)
+    {
+        value = default;
+        if (name.Equals("dr0", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr0); return true; }
+        if (name.Equals("dr1", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr1); return true; }
+        if (name.Equals("dr2", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr2); return true; }
+        if (name.Equals("dr3", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr3); return true; }
+        if (name.Equals("dr6", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr6); return true; }
+        if (name.Equals("dr7", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Dr7); return true; }
+        if (name.Equals("controlword", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(ControlWord); return true; }
+        if (name.Equals("statusword", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(StatusWord); return true; }
+        if (name.Equals("tagword", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(TagWord); return true; }
+        if (name.Equals("erroroffset", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(ErrorOffset); return true; }
+        if (name.Equals("errorselector", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(ErrorSelector); return true; }
+        if (name.Equals("dataoffset", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(DataOffset); return true; }
+        if (name.Equals("dataselector", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(DataSelector); return true; }
+        if (name.Equals("cr0npxstate", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Cr0NpxState); return true; }
+        if (name.Equals("gs", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Gs); return true; }
+        if (name.Equals("fs", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Fs); return true; }
+        if (name.Equals("es", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Es); return true; }
+        if (name.Equals("ds", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ds); return true; }
+        if (name.Equals("cs", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Cs); return true; }
+        if (name.Equals("ss", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ss); return true; }
+        if (name.Equals("edi", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Edi); return true; }
+        if (name.Equals("esi", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Esi); return true; }
+        if (name.Equals("ebx", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ebx); return true; }
+        if (name.Equals("edx", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Edx); return true; }
+        if (name.Equals("ecx", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ecx); return true; }
+        if (name.Equals("eax", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Eax); return true; }
+        if (name.Equals("eflags", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(EFlags); return true; }
+        if (name.Equals("ebp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ebp); return true; }
+        if (name.Equals("eip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Eip); return true; }
+        if (name.Equals("esp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Esp); return true; }
+        return false;
+    }
+
+
+    public bool TrySetRegister(int number, TargetNUInt value)
+    {
+        switch (number)
+        {
+            case 0: Eax = (uint)value.Value; return true;
+            case 1: Ecx = (uint)value.Value; return true;
+            case 2: Edx = (uint)value.Value; return true;
+            case 3: Ebx = (uint)value.Value; return true;
+            case 4: Esp = (uint)value.Value; return true;
+            case 5: Ebp = (uint)value.Value; return true;
+            case 6: Esi = (uint)value.Value; return true;
+            case 7: Edi = (uint)value.Value; return true;
+            default: return false;
+        }
+    }
+
+    public bool TryReadRegister(int number, out TargetNUInt value)
+    {
+        value = default;
+        switch (number)
+        {
+            case 0: value = new TargetNUInt(Eax); return true;
+            case 1: value = new TargetNUInt(Ecx); return true;
+            case 2: value = new TargetNUInt(Edx); return true;
+            case 3: value = new TargetNUInt(Ebx); return true;
+            case 4: value = new TargetNUInt(Esp); return true;
+            case 5: value = new TargetNUInt(Ebp); return true;
+            case 6: value = new TargetNUInt(Esi); return true;
+            case 7: value = new TargetNUInt(Edi); return true;
+            default: return false;
+        }
+    }
 
     [FieldOffset(0x0)]
     public uint ContextFlags;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/X86Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/X86Context.cs
@@ -165,6 +165,8 @@ public struct X86Context : IPlatformContext
         }
     }
 
+    // Control flags
+
     [FieldOffset(0x0)]
     public uint ContextFlags;
 

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/X86Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/X86Context.cs
@@ -2,6 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers.X86;
 
@@ -82,18 +85,18 @@ public struct X86Context : IPlatformContext
         if (name.Equals("fs", StringComparison.OrdinalIgnoreCase)) { Fs = (uint)value.Value; return true; }
         if (name.Equals("es", StringComparison.OrdinalIgnoreCase)) { Es = (uint)value.Value; return true; }
         if (name.Equals("ds", StringComparison.OrdinalIgnoreCase)) { Ds = (uint)value.Value; return true; }
-        if (name.Equals("cs", StringComparison.OrdinalIgnoreCase)) { Cs = (uint)value.Value; return true; }
-        if (name.Equals("ss", StringComparison.OrdinalIgnoreCase)) { Ss = (uint)value.Value; return true; }
         if (name.Equals("edi", StringComparison.OrdinalIgnoreCase)) { Edi = (uint)value.Value; return true; }
         if (name.Equals("esi", StringComparison.OrdinalIgnoreCase)) { Esi = (uint)value.Value; return true; }
         if (name.Equals("ebx", StringComparison.OrdinalIgnoreCase)) { Ebx = (uint)value.Value; return true; }
         if (name.Equals("edx", StringComparison.OrdinalIgnoreCase)) { Edx = (uint)value.Value; return true; }
         if (name.Equals("ecx", StringComparison.OrdinalIgnoreCase)) { Ecx = (uint)value.Value; return true; }
         if (name.Equals("eax", StringComparison.OrdinalIgnoreCase)) { Eax = (uint)value.Value; return true; }
-        if (name.Equals("eflags", StringComparison.OrdinalIgnoreCase)) { EFlags = (uint)value.Value; return true; }
         if (name.Equals("ebp", StringComparison.OrdinalIgnoreCase)) { Ebp = (uint)value.Value; return true; }
         if (name.Equals("eip", StringComparison.OrdinalIgnoreCase)) { Eip = (uint)value.Value; return true; }
+        if (name.Equals("cs", StringComparison.OrdinalIgnoreCase)) { Cs = (uint)value.Value; return true; }
+        if (name.Equals("eflags", StringComparison.OrdinalIgnoreCase)) { EFlags = (uint)value.Value; return true; }
         if (name.Equals("esp", StringComparison.OrdinalIgnoreCase)) { Esp = (uint)value.Value; return true; }
+        if (name.Equals("ss", StringComparison.OrdinalIgnoreCase)) { Ss = (uint)value.Value; return true; }
         return false;
     }
 
@@ -118,54 +121,31 @@ public struct X86Context : IPlatformContext
         if (name.Equals("fs", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Fs); return true; }
         if (name.Equals("es", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Es); return true; }
         if (name.Equals("ds", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ds); return true; }
-        if (name.Equals("cs", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Cs); return true; }
-        if (name.Equals("ss", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ss); return true; }
         if (name.Equals("edi", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Edi); return true; }
         if (name.Equals("esi", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Esi); return true; }
         if (name.Equals("ebx", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ebx); return true; }
         if (name.Equals("edx", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Edx); return true; }
         if (name.Equals("ecx", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ecx); return true; }
         if (name.Equals("eax", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Eax); return true; }
-        if (name.Equals("eflags", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(EFlags); return true; }
         if (name.Equals("ebp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ebp); return true; }
         if (name.Equals("eip", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Eip); return true; }
+        if (name.Equals("cs", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Cs); return true; }
+        if (name.Equals("eflags", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(EFlags); return true; }
         if (name.Equals("esp", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Esp); return true; }
+        if (name.Equals("ss", StringComparison.OrdinalIgnoreCase)) { value = new TargetNUInt(Ss); return true; }
         return false;
     }
 
 
-    public bool TrySetRegister(int number, TargetNUInt value)
+    // Maps numbered GP registers (0–7) to their canonical names for by-number dispatch.
+    private static readonly FrozenDictionary<int, string> s_registersByNumber = new Dictionary<int, string>
     {
-        switch (number)
-        {
-            case 0: Eax = (uint)value.Value; return true;
-            case 1: Ecx = (uint)value.Value; return true;
-            case 2: Edx = (uint)value.Value; return true;
-            case 3: Ebx = (uint)value.Value; return true;
-            case 4: Esp = (uint)value.Value; return true;
-            case 5: Ebp = (uint)value.Value; return true;
-            case 6: Esi = (uint)value.Value; return true;
-            case 7: Edi = (uint)value.Value; return true;
-            default: return false;
-        }
-    }
+        [0] = "Eax", [1] = "Ecx", [2] = "Edx", [3] = "Ebx",
+        [4] = "Esp", [5] = "Ebp", [6] = "Esi", [7] = "Edi",
+    }.ToFrozenDictionary();
 
-    public bool TryReadRegister(int number, out TargetNUInt value)
-    {
-        value = default;
-        switch (number)
-        {
-            case 0: value = new TargetNUInt(Eax); return true;
-            case 1: value = new TargetNUInt(Ecx); return true;
-            case 2: value = new TargetNUInt(Edx); return true;
-            case 3: value = new TargetNUInt(Ebx); return true;
-            case 4: value = new TargetNUInt(Esp); return true;
-            case 5: value = new TargetNUInt(Ebp); return true;
-            case 6: value = new TargetNUInt(Esi); return true;
-            case 7: value = new TargetNUInt(Edi); return true;
-            default: return false;
-        }
-    }
+    public bool TryGetRegisterName(int number, [NotNullWhen(true)] out string? name)
+        => s_registersByNumber.TryGetValue(number, out name);
 
     [FieldOffset(0x0)]
     public uint ContextFlags;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/X86Context.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/Context/X86Context.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Frozen;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
 using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers.X86;
 
@@ -136,16 +133,37 @@ public struct X86Context : IPlatformContext
         return false;
     }
 
-
-    // Maps numbered GP registers (0–7) to their canonical names for by-number dispatch.
-    private static readonly FrozenDictionary<int, string> s_registersByNumber = new Dictionary<int, string>
+    public bool TrySetRegister(int number, TargetNUInt value)
     {
-        [0] = "Eax", [1] = "Ecx", [2] = "Edx", [3] = "Ebx",
-        [4] = "Esp", [5] = "Ebp", [6] = "Esi", [7] = "Edi",
-    }.ToFrozenDictionary();
+        switch (number)
+        {
+            case 0: Eax = (uint)value.Value; return true;
+            case 1: Ecx = (uint)value.Value; return true;
+            case 2: Edx = (uint)value.Value; return true;
+            case 3: Ebx = (uint)value.Value; return true;
+            case 4: Esp = (uint)value.Value; return true;
+            case 5: Ebp = (uint)value.Value; return true;
+            case 6: Esi = (uint)value.Value; return true;
+            case 7: Edi = (uint)value.Value; return true;
+            default: return false;
+        }
+    }
 
-    public bool TryGetRegisterName(int number, [NotNullWhen(true)] out string? name)
-        => s_registersByNumber.TryGetValue(number, out name);
+    public bool TryReadRegister(int number, out TargetNUInt value)
+    {
+        switch (number)
+        {
+            case 0: value = new TargetNUInt(Eax); return true;
+            case 1: value = new TargetNUInt(Ecx); return true;
+            case 2: value = new TargetNUInt(Edx); return true;
+            case 3: value = new TargetNUInt(Ebx); return true;
+            case 4: value = new TargetNUInt(Esp); return true;
+            case 5: value = new TargetNUInt(Ebp); return true;
+            case 6: value = new TargetNUInt(Esi); return true;
+            case 7: value = new TargetNUInt(Edi); return true;
+            default: value = default; return false;
+        }
+    }
 
     [FieldOffset(0x0)]
     public uint ContextFlags;

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/BaseFrameHandler.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/StackWalk/FrameHandling/BaseFrameHandler.cs
@@ -86,7 +86,7 @@ internal abstract class BaseFrameHandler(Target target, IPlatformAgnosticContext
     {
         foreach ((string name, TargetNUInt value) in registers)
         {
-            if (!_context.TrySetRegister(_target, name, value))
+            if (!_context.TrySetRegister(name, value))
             {
                 throw new InvalidOperationException($"Unexpected register {name} found when trying to update context");
             }
@@ -97,11 +97,11 @@ internal abstract class BaseFrameHandler(Target target, IPlatformAgnosticContext
     {
         foreach (string name in _target.GetTypeInfo(DataType.CalleeSavedRegisters).Fields.Keys)
         {
-            if (!otherContext.TryReadRegister(_target, name, out TargetNUInt value))
+            if (!otherContext.TryReadRegister(name, out TargetNUInt value))
             {
                 throw new InvalidOperationException($"Unexpected register {name} in callee saved registers");
             }
-            if (!_context.TrySetRegister(_target, name, value))
+            if (!_context.TrySetRegister(name, value))
             {
                 throw new InvalidOperationException($"Unexpected register {name} in callee saved registers");
             }

--- a/src/native/managed/cdac/tests/PlatformContextTests.cs
+++ b/src/native/managed/cdac/tests/PlatformContextTests.cs
@@ -1,0 +1,170 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Diagnostics.DataContractReader.Contracts.StackWalkHelpers;
+using Xunit;
+
+namespace Microsoft.Diagnostics.DataContractReader.Tests;
+
+public class PlatformContextTests
+{
+    [Theory]
+    // AMD64: GP registers 0-15
+    [InlineData(0, "Rax")] [InlineData(1, "Rcx")] [InlineData(7, "Rdi")]
+    [InlineData(8, "R8")] [InlineData(15, "R15")]
+    [InlineData(16, null)]
+    public void AMD64_TryGetRegisterName(int number, string? expected)
+    {
+        var ctx = new AMD64Context();
+        Assert.Equal(expected != null, ctx.TryGetRegisterName(number, out string? name));
+        Assert.Equal(expected, name);
+    }
+
+    [Theory]
+    [InlineData(0, 0xAABBCCDD11223344UL)]
+    [InlineData(4, 0x1234UL)] // Rsp
+    [InlineData(15, 0xFFFFUL)] // R15
+    public void AMD64_TrySetAndRead_ByNumber_RoundTrips(int regNum, ulong testValue)
+    {
+        var ctx = new AMD64Context();
+        Assert.True(ctx.TryGetRegisterName(regNum, out string? name));
+        Assert.True(ctx.TrySetRegister(name, new TargetNUInt(testValue)));
+        Assert.True(ctx.TryReadRegister(name, out TargetNUInt result));
+        Assert.Equal(testValue, result.Value);
+    }
+
+    [Theory]
+    // ARM64: 0-28=X0..X28, 29=Fp, 30=Lr, 31=Sp, 32=Pc
+    [InlineData(0, "X0")] [InlineData(28, "X28")] [InlineData(29, "Fp")]
+    [InlineData(30, "Lr")] [InlineData(31, "Sp")] [InlineData(32, "Pc")]
+    [InlineData(33, null)]
+    public void ARM64_TryGetRegisterName(int number, string? expected)
+    {
+        var ctx = new ARM64Context();
+        Assert.Equal(expected != null, ctx.TryGetRegisterName(number, out string? name));
+        Assert.Equal(expected, name);
+    }
+
+    [Theory]
+    [InlineData(0, 0x1234UL)]  // X0
+    [InlineData(29, 0xABCDUL)] // Fp
+    [InlineData(31, 0x5678UL)] // Sp
+    [InlineData(32, 0x9000UL)] // Pc
+    public void ARM64_TrySetAndRead_ByNumber_RoundTrips(int regNum, ulong testValue)
+    {
+        var ctx = new ARM64Context();
+        Assert.True(ctx.TryGetRegisterName(regNum, out string? name));
+        Assert.True(ctx.TrySetRegister(name, new TargetNUInt(testValue)));
+        Assert.True(ctx.TryReadRegister(name, out TargetNUInt result));
+        Assert.Equal(testValue, result.Value);
+    }
+
+    [Theory]
+    // ARM: 0-12=R0..R12, 13=Sp, 14=Lr, 15=Pc, 16=Cpsr
+    [InlineData(0, "R0")] [InlineData(12, "R12")] [InlineData(13, "Sp")]
+    [InlineData(14, "Lr")] [InlineData(15, "Pc")] [InlineData(16, "Cpsr")]
+    [InlineData(17, null)]
+    public void ARM_TryGetRegisterName(int number, string? expected)
+    {
+        var ctx = new ARMContext();
+        Assert.Equal(expected != null, ctx.TryGetRegisterName(number, out string? name));
+        Assert.Equal(expected, name);
+    }
+
+    [Theory]
+    [InlineData(0, 0x12U)]   // R0
+    [InlineData(13, 0x100U)] // Sp
+    [InlineData(15, 0x40U)]  // Pc
+    [InlineData(16, 0x10U)]  // Cpsr
+    public void ARM_TrySetAndRead_ByNumber_RoundTrips(int regNum, ulong testValue)
+    {
+        var ctx = new ARMContext();
+        Assert.True(ctx.TryGetRegisterName(regNum, out string? name));
+        Assert.True(ctx.TrySetRegister(name, new TargetNUInt(testValue)));
+        Assert.True(ctx.TryReadRegister(name, out TargetNUInt result));
+        Assert.Equal(testValue, result.Value);
+    }
+
+    [Theory]
+    // X86: 0=Eax, 1=Ecx, 2=Edx, 3=Ebx, 4=Esp, 5=Ebp, 6=Esi, 7=Edi
+    [InlineData(0, "Eax")] [InlineData(3, "Ebx")] [InlineData(7, "Edi")]
+    [InlineData(8, null)]
+    public void X86_TryGetRegisterName(int number, string? expected)
+    {
+        var ctx = new X86Context();
+        Assert.Equal(expected != null, ctx.TryGetRegisterName(number, out string? name));
+        Assert.Equal(expected, name);
+    }
+
+    [Theory]
+    [InlineData(0, 0xDEADBEEFUL)] // Eax
+    [InlineData(4, 0x1000UL)]     // Esp
+    [InlineData(7, 0xABCDUL)]     // Edi
+    public void X86_TrySetAndRead_ByNumber_RoundTrips(int regNum, ulong testValue)
+    {
+        var ctx = new X86Context();
+        Assert.True(ctx.TryGetRegisterName(regNum, out string? name));
+        Assert.True(ctx.TrySetRegister(name, new TargetNUInt(testValue)));
+        Assert.True(ctx.TryReadRegister(name, out TargetNUInt result));
+        Assert.Equal(testValue & uint.MaxValue, result.Value); // X86 fields are uint
+    }
+
+    [Theory]
+    // LoongArch64: 0=R0 .. 31=S8
+    [InlineData(0, "R0")] [InlineData(3, "Sp")] [InlineData(21, "X0")]
+    [InlineData(31, "S8")]
+    [InlineData(32, null)]
+    public void LoongArch64_TryGetRegisterName(int number, string? expected)
+    {
+        var ctx = new LoongArch64Context();
+        Assert.Equal(expected != null, ctx.TryGetRegisterName(number, out string? name));
+        Assert.Equal(expected, name);
+    }
+
+    [Theory]
+    [InlineData(0, 0x1234UL)]   // R0
+    [InlineData(3, 0x2000UL)]   // Sp
+    [InlineData(31, 0xABCDUL)]  // S8
+    public void LoongArch64_TrySetAndRead_ByNumber_RoundTrips(int regNum, ulong testValue)
+    {
+        var ctx = new LoongArch64Context();
+        Assert.True(ctx.TryGetRegisterName(regNum, out string? name));
+        Assert.True(ctx.TrySetRegister(name, new TargetNUInt(testValue)));
+        Assert.True(ctx.TryReadRegister(name, out TargetNUInt result));
+        Assert.Equal(testValue, result.Value);
+    }
+
+    [Theory]
+    // RISCV64: 0=zero (read-only), 1=Ra, 2=Sp .. 31=T6
+    [InlineData(0, "zero")] [InlineData(1, "Ra")] [InlineData(2, "Sp")]
+    [InlineData(31, "T6")]
+    [InlineData(32, null)]
+    public void RISCV64_TryGetRegisterName(int number, string? expected)
+    {
+        var ctx = new RISCV64Context();
+        Assert.Equal(expected != null, ctx.TryGetRegisterName(number, out string? name));
+        Assert.Equal(expected, name);
+    }
+
+    [Theory]
+    [InlineData(1, 0x1234UL)]  // Ra
+    [InlineData(2, 0x2000UL)]  // Sp
+    [InlineData(31, 0xABCDUL)] // T6
+    public void RISCV64_TrySetAndRead_ByNumber_RoundTrips(int regNum, ulong testValue)
+    {
+        var ctx = new RISCV64Context();
+        Assert.True(ctx.TryGetRegisterName(regNum, out string? name));
+        Assert.True(ctx.TrySetRegister(name, new TargetNUInt(testValue)));
+        Assert.True(ctx.TryReadRegister(name, out TargetNUInt result));
+        Assert.Equal(testValue, result.Value);
+    }
+
+    [Fact]
+    public void RISCV64_ZeroRegister_ReadReturnsZero_WriteReturnsFalse()
+    {
+        var ctx = new RISCV64Context();
+        Assert.True(ctx.TryReadRegister("zero", out TargetNUInt value));
+        Assert.Equal(0UL, value.Value);
+        Assert.False(ctx.TrySetRegister("zero", new TargetNUInt(0xDEAD)));
+    }
+}

--- a/src/native/managed/cdac/tests/PlatformContextTests.cs
+++ b/src/native/managed/cdac/tests/PlatformContextTests.cs
@@ -9,40 +9,24 @@ namespace Microsoft.Diagnostics.DataContractReader.Tests;
 public class PlatformContextTests
 {
     [Theory]
-    // AMD64: GP registers 0-15
-    [InlineData(0, "Rax")] [InlineData(1, "Rcx")] [InlineData(7, "Rdi")]
-    [InlineData(8, "R8")] [InlineData(15, "R15")]
-    [InlineData(16, null)]
-    public void AMD64_TryGetRegisterName(int number, string? expected)
-    {
-        var ctx = new AMD64Context();
-        Assert.Equal(expected != null, ctx.TryGetRegisterName(number, out string? name));
-        Assert.Equal(expected, name);
-    }
-
-    [Theory]
     [InlineData(0, 0xAABBCCDD11223344UL)]
     [InlineData(4, 0x1234UL)] // Rsp
     [InlineData(15, 0xFFFFUL)] // R15
     public void AMD64_TrySetAndRead_ByNumber_RoundTrips(int regNum, ulong testValue)
     {
         var ctx = new AMD64Context();
-        Assert.True(ctx.TryGetRegisterName(regNum, out string? name));
-        Assert.True(ctx.TrySetRegister(name, new TargetNUInt(testValue)));
-        Assert.True(ctx.TryReadRegister(name, out TargetNUInt result));
+        Assert.True(ctx.TrySetRegister(regNum, new TargetNUInt(testValue)));
+        Assert.True(ctx.TryReadRegister(regNum, out TargetNUInt result));
         Assert.Equal(testValue, result.Value);
     }
 
     [Theory]
-    // ARM64: 0-28=X0..X28, 29=Fp, 30=Lr, 31=Sp, 32=Pc
-    [InlineData(0, "X0")] [InlineData(28, "X28")] [InlineData(29, "Fp")]
-    [InlineData(30, "Lr")] [InlineData(31, "Sp")] [InlineData(32, "Pc")]
-    [InlineData(33, null)]
-    public void ARM64_TryGetRegisterName(int number, string? expected)
+    [InlineData(16)]
+    public void AMD64_OutOfRange_ReturnsFalse(int regNum)
     {
-        var ctx = new ARM64Context();
-        Assert.Equal(expected != null, ctx.TryGetRegisterName(number, out string? name));
-        Assert.Equal(expected, name);
+        var ctx = new AMD64Context();
+        Assert.False(ctx.TrySetRegister(regNum, new TargetNUInt(0)));
+        Assert.False(ctx.TryReadRegister(regNum, out _));
     }
 
     [Theory]
@@ -53,22 +37,18 @@ public class PlatformContextTests
     public void ARM64_TrySetAndRead_ByNumber_RoundTrips(int regNum, ulong testValue)
     {
         var ctx = new ARM64Context();
-        Assert.True(ctx.TryGetRegisterName(regNum, out string? name));
-        Assert.True(ctx.TrySetRegister(name, new TargetNUInt(testValue)));
-        Assert.True(ctx.TryReadRegister(name, out TargetNUInt result));
+        Assert.True(ctx.TrySetRegister(regNum, new TargetNUInt(testValue)));
+        Assert.True(ctx.TryReadRegister(regNum, out TargetNUInt result));
         Assert.Equal(testValue, result.Value);
     }
 
     [Theory]
-    // ARM: 0-12=R0..R12, 13=Sp, 14=Lr, 15=Pc, 16=Cpsr
-    [InlineData(0, "R0")] [InlineData(12, "R12")] [InlineData(13, "Sp")]
-    [InlineData(14, "Lr")] [InlineData(15, "Pc")] [InlineData(16, "Cpsr")]
-    [InlineData(17, null)]
-    public void ARM_TryGetRegisterName(int number, string? expected)
+    [InlineData(33)]
+    public void ARM64_OutOfRange_ReturnsFalse(int regNum)
     {
-        var ctx = new ARMContext();
-        Assert.Equal(expected != null, ctx.TryGetRegisterName(number, out string? name));
-        Assert.Equal(expected, name);
+        var ctx = new ARM64Context();
+        Assert.False(ctx.TrySetRegister(regNum, new TargetNUInt(0)));
+        Assert.False(ctx.TryReadRegister(regNum, out _));
     }
 
     [Theory]
@@ -79,21 +59,18 @@ public class PlatformContextTests
     public void ARM_TrySetAndRead_ByNumber_RoundTrips(int regNum, ulong testValue)
     {
         var ctx = new ARMContext();
-        Assert.True(ctx.TryGetRegisterName(regNum, out string? name));
-        Assert.True(ctx.TrySetRegister(name, new TargetNUInt(testValue)));
-        Assert.True(ctx.TryReadRegister(name, out TargetNUInt result));
+        Assert.True(ctx.TrySetRegister(regNum, new TargetNUInt(testValue)));
+        Assert.True(ctx.TryReadRegister(regNum, out TargetNUInt result));
         Assert.Equal(testValue, result.Value);
     }
 
     [Theory]
-    // X86: 0=Eax, 1=Ecx, 2=Edx, 3=Ebx, 4=Esp, 5=Ebp, 6=Esi, 7=Edi
-    [InlineData(0, "Eax")] [InlineData(3, "Ebx")] [InlineData(7, "Edi")]
-    [InlineData(8, null)]
-    public void X86_TryGetRegisterName(int number, string? expected)
+    [InlineData(17)]
+    public void ARM_OutOfRange_ReturnsFalse(int regNum)
     {
-        var ctx = new X86Context();
-        Assert.Equal(expected != null, ctx.TryGetRegisterName(number, out string? name));
-        Assert.Equal(expected, name);
+        var ctx = new ARMContext();
+        Assert.False(ctx.TrySetRegister(regNum, new TargetNUInt(0)));
+        Assert.False(ctx.TryReadRegister(regNum, out _));
     }
 
     [Theory]
@@ -103,22 +80,18 @@ public class PlatformContextTests
     public void X86_TrySetAndRead_ByNumber_RoundTrips(int regNum, ulong testValue)
     {
         var ctx = new X86Context();
-        Assert.True(ctx.TryGetRegisterName(regNum, out string? name));
-        Assert.True(ctx.TrySetRegister(name, new TargetNUInt(testValue)));
-        Assert.True(ctx.TryReadRegister(name, out TargetNUInt result));
+        Assert.True(ctx.TrySetRegister(regNum, new TargetNUInt(testValue)));
+        Assert.True(ctx.TryReadRegister(regNum, out TargetNUInt result));
         Assert.Equal(testValue & uint.MaxValue, result.Value); // X86 fields are uint
     }
 
     [Theory]
-    // LoongArch64: 0=R0 .. 31=S8
-    [InlineData(0, "R0")] [InlineData(3, "Sp")] [InlineData(21, "X0")]
-    [InlineData(31, "S8")]
-    [InlineData(32, null)]
-    public void LoongArch64_TryGetRegisterName(int number, string? expected)
+    [InlineData(8)]
+    public void X86_OutOfRange_ReturnsFalse(int regNum)
     {
-        var ctx = new LoongArch64Context();
-        Assert.Equal(expected != null, ctx.TryGetRegisterName(number, out string? name));
-        Assert.Equal(expected, name);
+        var ctx = new X86Context();
+        Assert.False(ctx.TrySetRegister(regNum, new TargetNUInt(0)));
+        Assert.False(ctx.TryReadRegister(regNum, out _));
     }
 
     [Theory]
@@ -128,22 +101,18 @@ public class PlatformContextTests
     public void LoongArch64_TrySetAndRead_ByNumber_RoundTrips(int regNum, ulong testValue)
     {
         var ctx = new LoongArch64Context();
-        Assert.True(ctx.TryGetRegisterName(regNum, out string? name));
-        Assert.True(ctx.TrySetRegister(name, new TargetNUInt(testValue)));
-        Assert.True(ctx.TryReadRegister(name, out TargetNUInt result));
+        Assert.True(ctx.TrySetRegister(regNum, new TargetNUInt(testValue)));
+        Assert.True(ctx.TryReadRegister(regNum, out TargetNUInt result));
         Assert.Equal(testValue, result.Value);
     }
 
     [Theory]
-    // RISCV64: 0=zero (read-only), 1=Ra, 2=Sp .. 31=T6
-    [InlineData(0, "zero")] [InlineData(1, "Ra")] [InlineData(2, "Sp")]
-    [InlineData(31, "T6")]
-    [InlineData(32, null)]
-    public void RISCV64_TryGetRegisterName(int number, string? expected)
+    [InlineData(32)]
+    public void LoongArch64_OutOfRange_ReturnsFalse(int regNum)
     {
-        var ctx = new RISCV64Context();
-        Assert.Equal(expected != null, ctx.TryGetRegisterName(number, out string? name));
-        Assert.Equal(expected, name);
+        var ctx = new LoongArch64Context();
+        Assert.False(ctx.TrySetRegister(regNum, new TargetNUInt(0)));
+        Assert.False(ctx.TryReadRegister(regNum, out _));
     }
 
     [Theory]
@@ -153,18 +122,26 @@ public class PlatformContextTests
     public void RISCV64_TrySetAndRead_ByNumber_RoundTrips(int regNum, ulong testValue)
     {
         var ctx = new RISCV64Context();
-        Assert.True(ctx.TryGetRegisterName(regNum, out string? name));
-        Assert.True(ctx.TrySetRegister(name, new TargetNUInt(testValue)));
-        Assert.True(ctx.TryReadRegister(name, out TargetNUInt result));
+        Assert.True(ctx.TrySetRegister(regNum, new TargetNUInt(testValue)));
+        Assert.True(ctx.TryReadRegister(regNum, out TargetNUInt result));
         Assert.Equal(testValue, result.Value);
+    }
+
+    [Theory]
+    [InlineData(32)]
+    public void RISCV64_OutOfRange_ReturnsFalse(int regNum)
+    {
+        var ctx = new RISCV64Context();
+        Assert.False(ctx.TrySetRegister(regNum, new TargetNUInt(0)));
+        Assert.False(ctx.TryReadRegister(regNum, out _));
     }
 
     [Fact]
     public void RISCV64_ZeroRegister_ReadReturnsZero_WriteReturnsFalse()
     {
         var ctx = new RISCV64Context();
-        Assert.True(ctx.TryReadRegister("zero", out TargetNUInt value));
+        Assert.True(ctx.TryReadRegister(0, out TargetNUInt value));
         Assert.Equal(0UL, value.Value);
-        Assert.False(ctx.TrySetRegister("zero", new TargetNUInt(0xDEAD)));
+        Assert.False(ctx.TrySetRegister(0, new TargetNUInt(0xDEAD)));
     }
 }


### PR DESCRIPTION
## Summary

Replace reflection-based register access in `ContextHolder<T>` with explicit switch-based dispatch implemented directly on each platform context struct.

## Problem

`ContextHolder` previously used `typeof(T).GetField()` with `SetValueDirect` / `__makeref` to read/write registers by name. This:
- Required `[DynamicallyAccessedMembers]` on the type parameter
- Was incompatible with AOT trimming
- Relied on runtime reflection for a hot path

## Solution

Each context struct (`AMD64Context`, `X86Context`, `ARMContext`, `ARM64Context`, `LoongArch64Context`, `RISCV64Context`) now directly implements `TrySetRegister` and `TryReadRegister` on `IPlatformContext`. `ContextHolder<T>` delegates to the struct methods.

### Register access by name

Callers such as `BaseFrameHandler` look up registers by name from the data contract (e.g. `CalleeSavedRegisters` field names). These names come from dictionary keys that are typically interned string literals, so `ToLowerInvariant()` would allocate a new string on every call. Instead, each struct uses `string.Equals(..., StringComparison.OrdinalIgnoreCase)` for allocation-free case-insensitive matching.

The if-chains in `TrySetRegister(string)` / `TryReadRegister(string)` are ordered to match the `[FieldOffset]` declaration order of the struct fields for consistency.

### Register access by number

`TrySetRegister(int)` / `TryReadRegister(int)` are added using `switch` statements that dispatch directly to struct fields without any intermediate name lookup. Register numbers follow the platform-specific ABI/PE unwind conventions:

| Platform | Convention |
|---|---|
| AMD64 | Windows x64 PE/COFF (RAX=0, RCX=1, ... R15=15) |
| ARM64 | Windows ARM64 (X0=0 ... Sp=31, Pc=32) |
| ARM | Windows ARM (R0=0 ... Pc=15, Cpsr=16) |
| X86 | (EAX=0, ECX=1, ... EDI=7) |
| LoongArch64 | LoongArch64 ABI (R0=0, Ra=1, ... S8=31) |
| RISCV64 | RISC-V ABI (zero=0, Ra=1, ... T6=31) |

### Unwinder deduplication

The `SetRegister` / `SetRegisterValue` helper methods in all 5 unwinders previously contained duplicate `switch` expressions that directly accessed struct fields. These are now replaced with calls to `TrySetRegister(int)` and `TryReadRegister(int)`, removing the duplication. Error-handling behavior is preserved: AMD64, ARM64, and ARM throw `ArgumentOutOfRangeException` on invalid register numbers (matching original behavior); LoongArch64 and RISCV64 silently ignore invalid numbers (also matching original behavior).

## Changes

- `ContextHolder<T>`: Sealed; removed `System.Reflection` import, `[DynamicallyAccessedMembers]`, and all reflection code; delegates int/string register access to struct methods
- `IPlatformContext`: Added `TrySetRegister`/`TryReadRegister` by name and by number as required interface members
- `IPlatformAgnosticContext`: Updated abstract methods; removed unused `Target` parameter from register methods
- All 6 context structs: Implemented `OrdinalIgnoreCase` name dispatch and `switch`-based number dispatch
- All 5 unwinders: `SetRegister`/`SetRegisterValue` delegate to `TrySetRegister(int)`/`TryReadRegister(int)`
- `BaseFrameHandler`: Updated callers to drop unused `target` argument
- `PlatformContextTests`: New tests covering by-number round-trips and out-of-range behavior for all 6 architectures