### PR TITLE
Use SHash as DAC instance hash

### DIFF
--- a/src/coreclr/debug/daccess/daccess.cpp
+++ b/src/coreclr/debug/daccess/daccess.cpp
@@ -1543,24 +1543,24 @@ DAC_INSTANCE*
 DacInstanceManager::Add(DAC_INSTANCE* inst)
 {
     _ASSERTE(inst != NULL);
-#ifdef _DEBUG
-    bool isInserted = (m_hash.find(inst->addr) == m_hash.end());
-#endif //_DEBUG
-    DAC_INSTANCE *(&target) = m_hash[inst->addr];
-    _ASSERTE(!isInserted || target == NULL);
-    if( target != NULL )
+    const KeyValuePair<TADDR, DAC_INSTANCE*>* pEntry = m_hash.LookupPtr(inst->addr);
+    if (pEntry != NULL)
     {
+        DAC_INSTANCE* existing = pEntry->Value();
+
         //This is necessary to preserve the semantics of Supersede, however, it
         //is more or less dead code.
-        inst->next = target;
-        target = inst;
+        inst->next = existing;
 
         //verify descending order
-        _ASSERTE(inst->size >= target->size);
+        _ASSERTE(inst->size >= existing->size);
+
+        m_hash.ReplacePtr(pEntry, KeyValuePair<TADDR, DAC_INSTANCE*>(inst->addr, inst));
     }
     else
     {
-        target = inst;
+        inst->next = NULL;
+        m_hash.Add(KeyValuePair<TADDR, DAC_INSTANCE*>(inst->addr, inst));
     }
 
     return inst;
@@ -1802,15 +1802,13 @@ DacInstanceManager::Find(TADDR addr)
 DAC_INSTANCE*
 DacInstanceManager::Find(TADDR addr)
 {
-    DacInstanceHashIterator iter = m_hash.find(addr);
-    if( iter == m_hash.end() )
+    const KeyValuePair<TADDR, DAC_INSTANCE*>* pEntry = m_hash.LookupPtr(addr);
+    if (pEntry != NULL)
     {
-        return NULL;
+        return pEntry->Value();
     }
-    else
-    {
-        return iter->second;
-    }
+
+    return NULL;
 }
 #endif // if defined(DAC_HASHTABLE)
 
@@ -1886,12 +1884,11 @@ DacInstanceManager::Supersede(DAC_INSTANCE* inst)
     // later cleanup.
     //
 
-    DacInstanceHashIterator iter = m_hash.find(inst->addr);
-    if( iter == m_hash.end() )
+    const KeyValuePair<TADDR, DAC_INSTANCE*>* pEntry = m_hash.LookupPtr(inst->addr);
+    if (pEntry == NULL)
         return;
 
-    DAC_INSTANCE** bucket = &(iter->second);
-    DAC_INSTANCE* cur = *bucket;
+    DAC_INSTANCE* cur = pEntry->Value();
     DAC_INSTANCE* prev = NULL;
     //walk through the chain looking for this particular instance
     while (cur)
@@ -1900,7 +1897,15 @@ DacInstanceManager::Supersede(DAC_INSTANCE* inst)
         {
             if (!prev)
             {
-                *bucket = inst->next;
+                // Removing the head of the chain.
+                if (inst->next != NULL)
+                {
+                    m_hash.ReplacePtr(pEntry, KeyValuePair<TADDR, DAC_INSTANCE*>(inst->addr, inst->next));
+                }
+                else
+                {
+                    m_hash.Remove(inst->addr);
+                }
             }
             else
             {
@@ -1981,7 +1986,7 @@ void DacInstanceManager::Flush(bool fSaveBlock)
         }
     }
 #else //DAC_HASHTABLE
-    m_hash.clear();
+    m_hash.RemoveAll();
 #endif //DAC_HASHTABLE
 
     InitEmpty();
@@ -2020,18 +2025,17 @@ DacInstanceManager::ClearEnumMemMarker(void)
 void
 DacInstanceManager::ClearEnumMemMarker(void)
 {
-    ULONG i;
     DAC_INSTANCE* inst;
 
-    DacInstanceHashIterator end = m_hash.end();
+    DacInstanceHashIterator end = m_hash.End();
     /* REVISIT_TODO Fri 10/20/2006
      * This might have an issue, since it might miss chained entries off of
      * ->next.  However, ->next is going away, and for all intents and
      *  purposes, this never happens.
 */
-    for( DacInstanceHashIterator cur = m_hash.begin(); cur != end; ++cur )
+    for (DacInstanceHashIterator cur = m_hash.Begin(); cur != end; ++cur)
     {
-        cur->second->enumMem = 0;
+        cur->Value()->enumMem = 0;
     }
 
     for (inst = m_superseded; inst; inst = inst->next)
@@ -2143,10 +2147,10 @@ DacInstanceManager::DumpAllInstances(
    int numInBucket = 0;
 #endif // #if defined(DAC_MEASURE_PERF)
 
-   DacInstanceHashIterator end = m_hash.end();
-   for (DacInstanceHashIterator cur = m_hash.begin(); end != cur; ++cur)
+   DacInstanceHashIterator end = m_hash.End();
+   for (DacInstanceHashIterator cur = m_hash.Begin(); end != cur; ++cur)
    {
-       inst = cur->second;
+       inst = cur->Value();
 
        // Only report those we intended to.
        // So far, only metadata is excluded!

--- a/src/coreclr/debug/daccess/dacimpl.h
+++ b/src/coreclr/debug/daccess/dacimpl.h
@@ -17,16 +17,7 @@
 #include "gcinterface.dac.h"
 //---------------------------------------------------------------------------------------
 // Setting DAC_HASHTABLE tells the DAC to use the hand rolled hashtable for
-// storing code:DAC_INSTANCE .  Otherwise, the DAC uses the STL unordered_map to.
-
-#define DAC_HASHTABLE
-
-#ifndef DAC_HASHTABLE
-#pragma push_macro("return")
-#undef return
-#include <unordered_map>
-#pragma pop_macro("return")
-#endif //DAC_HASHTABLE
+// storing code:DAC_INSTANCE .  Otherwise, the DAC uses SHash.
 extern minipal_mutex g_dacMutex;
 
 // Convert between CLRDATA_ADDRESS and TADDR.
@@ -728,54 +719,28 @@ private:
     HashInstanceKeyBlock* m_hash[DAC_INSTANCE_HASH_SIZE];
 #else //DAC_HASHTABLE
 
-    // We're going to use the STL unordered_map for our instance hash.
-    // This has the benefit of scaling to different workloads appropriately (as opposed to having a
-    // fixed number of buckets).
-
-    class DacHashCompare : public std::hash_compare<TADDR>
+    // SHash-based hash table for DAC instances, keyed by target address.
+    // The custom hash function avoids pseudo-randomizing in favor of a simple
+    // shift that clusters nearby addresses together.  This improves access
+    // locality and has a significant positive impact on minidump library
+    // performance when enumerating entries during dump generation (as dbghelp
+    // has to coalesce adjacent memory regions).
+    class DacInstanceSHashTraits : public NonDacAwareSHashTraits<MapSHashTraits<TADDR, DAC_INSTANCE*>>
     {
     public:
-        // Custom hash function
-        // The default hash function uses a pseudo-randomizing function to get a random
-        // distribution.  In our case, we'd actually like a more even distribution to get
-        // better access locality (see comments for DAC_INSTANCE_HASH_BITS).
-        //
-        // Also, when enumerating the hash during dump generation, clustering nearby addresses
-        // together can have a significant positive impact on the performance of the minidump
-        // library (at least the un-optimized version 6.5 linked into our dw20.exe - on Vista+
-        // we use the OS's version 6.7+ with radically improved perf characteristics).  Having
-        // a random distribution is actually the worst-case because it means most blocks won't
-        // be merged until near the end, and a large number of intermediate blocks will have to
-        // be searched with each call.
-        //
-        // The default pseudo-randomizing function also requires a call to ldiv which shows up as
-        // a 3%-5% perf hit in most perf-sensitive scenarios, so this should also always be
-        // faster.
-        inline size_t operator()(const TADDR& keyval) const
+        typedef MapSHashTraits<TADDR, DAC_INSTANCE*> PARENT;
+        typedef PARENT::element_t element_t;
+        typedef PARENT::count_t count_t;
+        typedef PARENT::key_t key_t;
+
+        static count_t Hash(key_t k)
         {
-            return (unsigned)(keyval >>DAC_INSTANCE_HASH_SHIFT);
+            return (count_t)(k >> DAC_INSTANCE_HASH_SHIFT);
         }
-
-        // Explicitly bring in the two-argument comparison function from the base class (just less-than)
-        // This is necessary because once we override one form of operator() above, we don't automatically
-        // get the others by C++ inheritance rules.
-    using std::hash_compare<TADDR>::operator();
-
-#ifdef NIDUMP_CUSTOMIZED_DAC_HASH   // not set
-        //this particular number is supposed to be roughly the same amount of
-        //memory as the old code (buckets * number of entries in the old
-        //blocks.)
-        //disabled for now.  May tweak implementation later.  It turns out that
-        //having a large number of initial buckets is excellent for nidump, but it
-        // is terrible for most other scenarios due to the cost of clearing them at
-        // every Flush.  Once there is a better perf suite, we can tweak these values more.
-        static const size_t min_buckets = DAC_INSTANCE_HASH_SIZE * 256;
-#endif
-
     };
-    typedef std::unordered_map<TADDR, DAC_INSTANCE*, DacHashCompare > DacInstanceHash;
-    typedef DacInstanceHash::value_type DacInstanceHashValue;
-    typedef DacInstanceHash::iterator DacInstanceHashIterator;
+
+    typedef SHash<DacInstanceSHashTraits> DacInstanceHash;
+    typedef DacInstanceHash::Iterator DacInstanceHashIterator;
     DacInstanceHash m_hash;
 #endif //DAC_HASHTABLE
 


### PR DESCRIPTION
Replaces the hand-rolled hash table implementation in DacInstanceManager withan `SHash` based implementation. This hash is more efficient for the high volume of find operations the DAC issues when verifying cached cross-process reads. During mini dump collection, DacInstanceManager is the central cache for all memory read from the target process. The hand-rolled hash table used a fixed bucket array that degraded quickly for Find and insertion operations.

Measured minidump collection against a repro app with 2.5k frame deep stacks over 50 threads and the speedup was roughly 9.5x.