### PR TITLE
Reduce backtracking for greedy loops followed by subsumed literals

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -3482,19 +3482,62 @@ namespace System.Text.RegularExpressions.Generator
                     subsequent?.FindStartingLiteralNode() is RegexNode literalNode &&
                     TryEmitIndexOf(requiredHelpers, literalNode, useLast: true, negate: false, out int literalLength, out string? indexOfExpr))
                 {
-                    writer.WriteLine($"if ({startingPos} >= {endingPos} ||");
-
-                    string setEndingPosCondition = $"    ({endingPos} = inputSpan.Slice({startingPos}, ";
-                    setEndingPosCondition = literalLength > 1 ?
-                        $"{setEndingPosCondition}Math.Min(inputSpan.Length, {endingPos} + {literalLength - 1}) - {startingPos})" :
-                        $"{setEndingPosCondition}{endingPos} - {startingPos})";
-
-                    using (EmitBlock(writer, $"{setEndingPosCondition}.{indexOfExpr}) < 0)"))
+                    // When the subsequent literal is contained in the loop's character class and whatever follows
+                    // that literal is disjoint from the loop's class, no backtrack position other than the very
+                    // last consumed character can possibly succeed (any earlier position would have a loop-set char
+                    // after the literal, which the disjoint subsequent wouldn't accept). In that case, we can just
+                    // check the last consumed character directly instead of repeatedly searching with LastIndexOf.
+                    if (subsequent is not null && RegexNode.CanReduceLoopBacktrackingToSinglePosition(node, subsequent))
                     {
-                        Goto(doneLabel);
+                        using (EmitBlock(writer, $"if ({startingPos} >= {endingPos})"))
+                        {
+                            Goto(doneLabel);
+                        }
+                        writer.WriteLine($"{endingPos}--;");
+
+                        string charAccessExpr = $"inputSpan[{endingPos}]";
+                        string condition = literalNode.Kind switch
+                        {
+                            RegexNodeKind.One or RegexNodeKind.Oneloop or RegexNodeKind.Oneloopatomic or RegexNodeKind.Onelazy =>
+                                $"{charAccessExpr} != {Literal(literalNode.Ch)}",
+                            RegexNodeKind.Notone or RegexNodeKind.Notoneloop or RegexNodeKind.Notoneloopatomic or RegexNodeKind.Notonelazy =>
+                                $"{charAccessExpr} == {Literal(literalNode.Ch)}",
+                            RegexNodeKind.Multi =>
+                                $"{charAccessExpr} != {Literal(literalNode.Str![0])}",
+                            _ => // Set, Setloop, Setloopatomic, Setlazy
+                                $"!{MatchCharacterClass(charAccessExpr, literalNode.Str!, negate: false, additionalDeclarations, requiredHelpers)}",
+                        };
+                        using (EmitBlock(writer, $"if ({condition})"))
+                        {
+                            Goto(doneLabel);
+                        }
+
+                        writer.WriteLine($"pos = {endingPos};");
+
+                        // We've now checked the only backtrack position that can succeed. Force any
+                        // subsequent backtrack to fail immediately by setting endingPos to 0, which
+                        // guarantees the "startingPos >= endingPos" guard (emitted above) will be true
+                        // on re-entry. Note: if the emitter's backtracking structure changes (e.g. the
+                        // guard condition or how endingPos is used beyond the guard and stack save/restore),
+                        // this assumption would need to be revisited.
+                        writer.WriteLine($"{endingPos} = 0;");
                     }
-                    writer.WriteLine($"{endingPos} += {startingPos};");
-                    writer.WriteLine($"pos = {endingPos};");
+                    else
+                    {
+                        writer.WriteLine($"if ({startingPos} >= {endingPos} ||");
+
+                        string setEndingPosCondition = $"    ({endingPos} = inputSpan.Slice({startingPos}, ";
+                        setEndingPosCondition = literalLength > 1 ?
+                            $"{setEndingPosCondition}Math.Min(inputSpan.Length, {endingPos} + {literalLength - 1}) - {startingPos})" :
+                            $"{setEndingPosCondition}{endingPos} - {startingPos})";
+
+                        using (EmitBlock(writer, $"{setEndingPosCondition}.{indexOfExpr}) < 0)"))
+                        {
+                            Goto(doneLabel);
+                        }
+                        writer.WriteLine($"{endingPos} += {startingPos};");
+                        writer.WriteLine($"pos = {endingPos};");
+                    }
                 }
                 else
                 {

--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -3482,11 +3482,8 @@ namespace System.Text.RegularExpressions.Generator
                     subsequent?.FindStartingLiteralNode() is RegexNode literalNode &&
                     TryEmitIndexOf(requiredHelpers, literalNode, useLast: true, negate: false, out int literalLength, out string? indexOfExpr))
                 {
-                    // When the subsequent literal is contained in the loop's character class and whatever follows
-                    // that literal is disjoint from the loop's class, no backtrack position other than the very
-                    // last consumed character can possibly succeed (any earlier position would have a loop-set char
-                    // after the literal, which the disjoint subsequent wouldn't accept). In that case, we can just
-                    // check the last consumed character directly instead of repeatedly searching with LastIndexOf.
+                    // If CanReduceLoopBacktrackingToSinglePosition determines only the last consumed character
+                    // can succeed, we can just check it directly instead of repeatedly searching with LastIndexOf.
                     if (subsequent is not null && RegexNode.CanReduceLoopBacktrackingToSinglePosition(node, subsequent))
                     {
                         using (EmitBlock(writer, $"if ({startingPos} >= {endingPos})"))

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -888,13 +888,13 @@ namespace System.Text.RegularExpressions
                 return true;
             }
 
-            // If set2 is the universal set, everything is a subset.
+            // If superset is the universal set, everything is a subset.
             if (superset == AnyClass)
             {
                 return true;
             }
 
-            // If set1 can be easily enumerated, check that every character in it is also in set2.
+            // If subset can be easily enumerated, check that every character in it is also in superset.
             if (!IsNegated(subset) && CanEasilyEnumerateSetContents(subset))
             {
                 for (int i = SetStartIndex; i < SetStartIndex + subset[SetLengthIndex]; i += 2)
@@ -913,7 +913,7 @@ namespace System.Text.RegularExpressions
             }
 
             // If both sets are composed entirely of Unicode categories, check that all
-            // categories in set1 are also present in set2.
+            // categories in subset are also present in superset.
             Span<UnicodeCategory> categories1 = stackalloc UnicodeCategory[16], categories2 = stackalloc UnicodeCategory[16];
             if (TryGetOnlyCategories(subset, categories1, out int numCategories1, out bool negated1) && !negated1 &&
                 TryGetOnlyCategories(superset, categories2, out int numCategories2, out bool negated2) && !negated2)

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCharClass.cs
@@ -877,6 +877,72 @@ namespace System.Text.RegularExpressions
         }
 
         /// <summary>
+        /// Determines conservatively whether <paramref name="subset"/> is a subset of <paramref name="superset"/>
+        /// (i.e. every character in subset is also in superset). Returns false if the subset relationship cannot be determined.
+        /// </summary>
+        public static bool IsSubsetOf(string subset, string superset)
+        {
+            // Identical sets are trivially subsets.
+            if (subset == superset)
+            {
+                return true;
+            }
+
+            // If set2 is the universal set, everything is a subset.
+            if (superset == AnyClass)
+            {
+                return true;
+            }
+
+            // If set1 can be easily enumerated, check that every character in it is also in set2.
+            if (!IsNegated(subset) && CanEasilyEnumerateSetContents(subset))
+            {
+                for (int i = SetStartIndex; i < SetStartIndex + subset[SetLengthIndex]; i += 2)
+                {
+                    int curSetEnd = subset[i + 1];
+                    for (int c = subset[i]; c < curSetEnd; c++)
+                    {
+                        if (!CharInClass((char)c, superset))
+                        {
+                            return false;
+                        }
+                    }
+                }
+
+                return true;
+            }
+
+            // If both sets are composed entirely of Unicode categories, check that all
+            // categories in set1 are also present in set2.
+            Span<UnicodeCategory> categories1 = stackalloc UnicodeCategory[16], categories2 = stackalloc UnicodeCategory[16];
+            if (TryGetOnlyCategories(subset, categories1, out int numCategories1, out bool negated1) && !negated1 &&
+                TryGetOnlyCategories(superset, categories2, out int numCategories2, out bool negated2) && !negated2)
+            {
+                foreach (UnicodeCategory cat1 in categories1.Slice(0, numCategories1))
+                {
+                    bool found = false;
+                    foreach (UnicodeCategory cat2 in categories2.Slice(0, numCategories2))
+                    {
+                        if (cat1 == cat2)
+                        {
+                            found = true;
+                            break;
+                        }
+                    }
+
+                    if (!found)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
         /// Gets whether the specified set is a named set with a reasonably small count
         /// of Unicode characters.
         /// </summary>
@@ -1122,55 +1188,6 @@ namespace System.Text.RegularExpressions
             return (uint)chDiv8 < (uint)ascii.Length ?
                 (ascii[chDiv8] & (1 << (ch & 0x7))) != 0 :
                 (WordCategoriesMask & (1 << (int)CharUnicodeInfo.GetUnicodeCategory(ch))) != 0;
-        }
-
-        /// <summary>Determines whether the characters that match the specified set are known to all be word characters.</summary>
-        public static bool IsKnownWordClassSubset(string set)
-        {
-            // Check for common sets that we know to be subsets of \w.
-            if (set is
-                WordClass or DigitClass or LetterClass or LetterOrDigitClass or
-                AsciiLetterClass or AsciiLetterOrDigitClass or
-                HexDigitClass or HexDigitUpperClass or HexDigitLowerClass)
-            {
-                return true;
-            }
-
-            // Check for sets composed of Unicode categories that are part of \w.
-            Span<UnicodeCategory> categories = stackalloc UnicodeCategory[16];
-            if (TryGetOnlyCategories(set, categories, out int numCategories, out bool negated) && !negated)
-            {
-                foreach (UnicodeCategory cat in categories.Slice(0, numCategories))
-                {
-                    if (!IsWordCategory(cat))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            // If we can enumerate every character in the set quickly, do so, checking to see whether they're all in \w.
-            if (CanEasilyEnumerateSetContents(set))
-            {
-                for (int i = SetStartIndex; i < SetStartIndex + set[SetLengthIndex]; i += 2)
-                {
-                    int curSetEnd = set[i + 1];
-                    for (int c = set[i]; c < curSetEnd; c++)
-                    {
-                        if (!CharInClass((char)c, WordClass))
-                        {
-                            return false;
-                        }
-                    }
-                }
-
-                return true;
-            }
-
-            // Unlikely to be a subset of \w, and we don't know for sure.
-            return false;
         }
 
         /// <summary>Determines whether a character is considered a word character for the purposes of testing a word character boundary.</summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -3655,44 +3655,104 @@ namespace System.Text.RegularExpressions
                     subsequent?.FindStartingLiteralNode() is RegexNode literal &&
                     CanEmitIndexOf(literal, out int literalLength))
                 {
-                    // endingPos = inputSpan.Slice(startingPos, Math.Min(inputSpan.Length, endingPos + literal.Length - 1) - startingPos).LastIndexOf(literal);
-                    // if (endingPos < 0)
-                    // {
-                    //     goto doneLabel;
-                    // }
-                    Ldloca(inputSpan);
-                    Ldloc(startingPos);
-                    if (literalLength > 1)
+                    // When the subsequent literal is contained in the loop's character class and whatever follows
+                    // that literal is disjoint from the loop's class, no backtrack position other than the very
+                    // last consumed character can possibly succeed. Just check it directly.
+                    if (subsequent is not null && RegexNode.CanReduceLoopBacktrackingToSinglePosition(node, subsequent))
                     {
-                        // Math.Min(inputSpan.Length, endingPos + literal.Length - 1) - startingPos
-                        Ldloca(inputSpan);
-                        Call(SpanGetLengthMethod);
+                        // endingPos--;
                         Ldloc(endingPos);
-                        Ldc(literalLength - 1);
-                        Add();
-                        Call(MathMinIntIntMethod);
+                        Ldc(1);
+                        Sub();
+                        Stloc(endingPos);
+
+                        // if (!literal.Matches(inputSpan[endingPos])) goto doneLabel;
+                        Ldloca(inputSpan);
+                        Ldloc(endingPos);
+                        Call(SpanGetItemMethod);
+                        LdindU2();
+                        switch (literal.Kind)
+                        {
+                            case RegexNodeKind.One or RegexNodeKind.Oneloop or RegexNodeKind.Oneloopatomic or RegexNodeKind.Onelazy:
+                                Ldc(literal.Ch);
+                                BneFar(doneLabel);
+                                break;
+
+                            case RegexNodeKind.Notone or RegexNodeKind.Notoneloop or RegexNodeKind.Notoneloopatomic or RegexNodeKind.Notonelazy:
+                                Ldc(literal.Ch);
+                                BeqFar(doneLabel);
+                                break;
+
+                            case RegexNodeKind.Multi:
+                                Ldc(literal.Str![0]);
+                                BneFar(doneLabel);
+                                break;
+
+                            default: // Set, Setloop, Setloopatomic, Setlazy
+                                EmitMatchCharacterClass(literal.Str!);
+                                BrfalseFar(doneLabel);
+                                break;
+                        }
+
+                        // pos = endingPos;
+                        Ldloc(endingPos);
+                        Stloc(pos);
+
+                        // We've now checked the only backtrack position that can succeed. Force any
+                        // subsequent backtrack to fail immediately by setting endingPos to 0, which
+                        // guarantees the "startingPos >= endingPos" guard (emitted above) will be true
+                        // on re-entry. Note: if the emitter's backtracking structure changes (e.g. the
+                        // guard condition or how endingPos is used beyond the guard and stack save/restore),
+                        // this assumption would need to be revisited.
+                        // endingPos = 0;
+                        Ldc(0);
+                        Stloc(endingPos);
                     }
                     else
                     {
-                        // endingPos - startingPos
+                        // endingPos = inputSpan.Slice(startingPos, Math.Min(inputSpan.Length, endingPos + literal.Length - 1) - startingPos).LastIndexOf(literal);
+                        // if (endingPos < 0)
+                        // {
+                        //     goto doneLabel;
+                        // }
+                        Ldloca(inputSpan);
+                        Ldloc(startingPos);
+                        if (literalLength > 1)
+                        {
+                            // Math.Min(inputSpan.Length, endingPos + literal.Length - 1) - startingPos
+                            Ldloca(inputSpan);
+                            Call(SpanGetLengthMethod);
+                            Ldloc(endingPos);
+                            Ldc(literalLength - 1);
+                            Add();
+                            Call(MathMinIntIntMethod);
+                        }
+                        else
+                        {
+                            // endingPos - startingPos
+                            Ldloc(endingPos);
+                        }
+                        Ldloc(startingPos);
+                        Sub();
+                        Call(SpanSliceIntIntMethod);
+
+                        EmitIndexOf(literal, useLast: true, negate: false);
+                        Stloc(endingPos);
+
                         Ldloc(endingPos);
+                        Ldc(0);
+                        BltFar(doneLabel);
+
+                        // endingPos += startingPos;
+                        Ldloc(endingPos);
+                        Ldloc(startingPos);
+                        Add();
+                        Stloc(endingPos);
+
+                        // pos = endingPos;
+                        Ldloc(endingPos);
+                        Stloc(pos);
                     }
-                    Ldloc(startingPos);
-                    Sub();
-                    Call(SpanSliceIntIntMethod);
-
-                    EmitIndexOf(literal, useLast: true, negate: false);
-                    Stloc(endingPos);
-
-                    Ldloc(endingPos);
-                    Ldc(0);
-                    BltFar(doneLabel);
-
-                    // endingPos += startingPos;
-                    Ldloc(endingPos);
-                    Ldloc(startingPos);
-                    Add();
-                    Stloc(endingPos);
                 }
                 else
                 {
@@ -3701,11 +3761,11 @@ namespace System.Text.RegularExpressions
                     Ldc(!rtl ? 1 : -1);
                     Sub();
                     Stloc(endingPos);
-                }
 
-                // pos = endingPos;
-                Ldloc(endingPos);
-                Stloc(pos);
+                    // pos = endingPos;
+                    Ldloc(endingPos);
+                    Stloc(pos);
+                }
 
                 if (!rtl)
                 {

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexCompiler.cs
@@ -3655,9 +3655,8 @@ namespace System.Text.RegularExpressions
                     subsequent?.FindStartingLiteralNode() is RegexNode literal &&
                     CanEmitIndexOf(literal, out int literalLength))
                 {
-                    // When the subsequent literal is contained in the loop's character class and whatever follows
-                    // that literal is disjoint from the loop's class, no backtrack position other than the very
-                    // last consumed character can possibly succeed. Just check it directly.
+                    // If CanReduceLoopBacktrackingToSinglePosition determines only the last consumed character
+                    // can succeed, we can just check it directly instead of repeatedly searching with LastIndexOf.
                     if (subsequent is not null && RegexNode.CanReduceLoopBacktrackingToSinglePosition(node, subsequent))
                     {
                         // endingPos--;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2329,6 +2329,57 @@ namespace System.Text.RegularExpressions
             return this;
         }
 
+        /// <summary>
+        /// Determines whether a greedy single-character loop's backtracking can be reduced to checking
+        /// only the last consumed position. This is possible when <paramref name="subsequent"/> is itself
+        /// a single-character literal (One or Set) whose character class is a subset of the loop's class,
+        /// and whatever follows that literal is disjoint from the loop's class — meaning no earlier
+        /// backtrack position can succeed, since every interior position has a loop-set character after it.
+        /// </summary>
+        internal static bool CanReduceLoopBacktrackingToSinglePosition(RegexNode loopNode, RegexNode subsequent)
+        {
+            Debug.Assert(loopNode.Kind is RegexNodeKind.Oneloop or RegexNodeKind.Notoneloop or RegexNodeKind.Setloop);
+
+            // Find the starting literal in the subsequent, descending through wrappers
+            // like Concatenate, Capture, and Atomic.
+            if (subsequent.FindStartingLiteralNode() is RegexNode literal)
+            {
+                // Only handle single-character literals (One, Set). Multi-character literals
+                // would require backing off by more than one position, and Notone matches
+                // almost everything so it's rarely subsumed. Every character the literal could
+                // match must also be matched by the loop's character class.
+                switch (literal.Kind)
+                {
+                    case RegexNodeKind.One when CharInLoopSet(loopNode, literal.Ch):
+                    case RegexNodeKind.Set when loopNode.Kind is RegexNodeKind.Setloop && RegexCharClass.IsSubsetOf(literal.Str!, loopNode.Str!):
+                        // Find the node that follows the literal in the tree and check whether
+                        // the loop would be atomic with respect to it. If nothing follows (end of
+                        // pattern), we can't reduce — earlier positions could still succeed.
+                        return
+                            FindNextNodeInSequence(literal, out _) is RegexNode afterLiteral &&
+                            CanBeMadeAtomic(loopNode, afterLiteral, iterateNullableSubsequent: true, allowLazy: false);
+
+                    case RegexNodeKind.Multi when CharInLoopSet(loopNode, literal.Str![0]) && !CharInLoopSet(loopNode, literal.Str[1]):
+                        // For a multi-character literal, treat it as two single characters: the first
+                        // must be subsumed by the loop (so the loop would have consumed it), and the
+                        // second must be disjoint from the loop (so positions within the loop's consumed
+                        // range can't satisfy it). This avoids needing FindNextNodeInSequence/CanBeMadeAtomic
+                        // since the second character is directly available in the multi's string.
+                        return true;
+                }
+
+                static bool CharInLoopSet(RegexNode loopNode, char ch) => loopNode.Kind switch
+                {
+                    RegexNodeKind.Oneloop => loopNode.Ch == ch,
+                    RegexNodeKind.Notoneloop => loopNode.Ch != ch,
+                    RegexNodeKind.Setloop => RegexCharClass.CharInClass(ch, loopNode.Str!),
+                    _ => false,
+                };
+            }
+
+            return false;
+        }
+
         /// <summary>Determines whether a node can be switched to an atomic loop.</summary>
         /// <param name="node">The node being examined to determine whether it could be made atomic.</param>
         /// <param name="subsequent">The node following <paramref name="node"/>, used to determine whether it overlaps.</param>
@@ -2475,7 +2526,7 @@ namespace System.Text.RegularExpressions
                             case RegexNodeKind.Multi when !RegexCharClass.CharInClass(subsequent.Str![0], node.Str!):
                             case RegexNodeKind.End:
                             case RegexNodeKind.EndZ or RegexNodeKind.Eol when !RegexCharClass.CharInClass('\n', node.Str!):
-                            case RegexNodeKind.Boundary when node.M > 0 && RegexCharClass.IsKnownWordClassSubset(node.Str!):
+                            case RegexNodeKind.Boundary when node.M > 0 && RegexCharClass.IsSubsetOf(node.Str!, RegexCharClass.WordClass):
                             case RegexNodeKind.NonBoundary when node.M > 0 && node.Str is RegexCharClass.NotWordClass or RegexCharClass.NotDigitClass:
                             case RegexNodeKind.ECMABoundary when node.M > 0 && node.Str is RegexCharClass.ECMAWordClass or RegexCharClass.ECMADigitClass:
                             case RegexNodeKind.NonECMABoundary when node.M > 0 && node.Str is RegexCharClass.NotECMAWordClass or RegexCharClass.NotDigitClass:
@@ -2522,7 +2573,7 @@ namespace System.Text.RegularExpressions
                             case RegexNodeKind.Multi when !CharInStartingOrEndingSet(subsequent.Str![0]):
                             case RegexNodeKind.End:
                             case RegexNodeKind.EndZ or RegexNodeKind.Eol when !CharInStartingOrEndingSet('\n'):
-                            case RegexNodeKind.Boundary when node.M > 0 && RegexCharClass.IsKnownWordClassSubset(loopStartingSet) && RegexCharClass.IsKnownWordClassSubset(loopEndingSet):
+                            case RegexNodeKind.Boundary when node.M > 0 && RegexCharClass.IsSubsetOf(loopStartingSet, RegexCharClass.WordClass) && RegexCharClass.IsSubsetOf(loopEndingSet, RegexCharClass.WordClass):
                             case RegexNodeKind.NonBoundary when node.M > 0 && (loopStartingSet is RegexCharClass.NotWordClass or RegexCharClass.NotDigitClass) && (loopEndingSet is RegexCharClass.NotWordClass or RegexCharClass.NotDigitClass):
                             case RegexNodeKind.ECMABoundary when node.M > 0 && (loopStartingSet is RegexCharClass.ECMAWordClass or RegexCharClass.ECMADigitClass) && (loopEndingSet is RegexCharClass.ECMAWordClass or RegexCharClass.ECMADigitClass):
                             case RegexNodeKind.NonECMABoundary when node.M > 0 && (loopStartingSet is RegexCharClass.NotECMAWordClass or RegexCharClass.NotDigitClass) && (loopEndingSet is RegexCharClass.NotECMAWordClass or RegexCharClass.NotDigitClass):
@@ -2549,46 +2600,67 @@ namespace System.Text.RegularExpressions
                     return false;
                 }
 
-                // To be conservative, we only walk up through a very limited set of constructs (even though we may have walked
-                // down through more, like loops), looking for the next concatenation that we're not at the end of, at
-                // which point subsequent becomes whatever node is next in that concatenation.
-                while (true)
+                // Walk up through the tree to find the next node in sequence.
+                RegexNode? nextSubsequent = FindNextNodeInSequence(subsequent, out bool reachedEnd);
+                if (nextSubsequent is null)
                 {
-                    RegexNode? parent = subsequent.Parent;
-                    switch (parent?.Kind)
-                    {
-                        case RegexNodeKind.Atomic:
-                        case RegexNodeKind.Alternate:
-                        case RegexNodeKind.Capture:
-                            subsequent = parent;
-                            continue;
+                    // If we hit the root, we're at the end of the expression, at which point nothing
+                    // could backtrack in and we can declare success. Otherwise, we hit an unrecognized
+                    // construct and must assume it could conflict with the loop.
+                    return reachedEnd;
+                }
 
-                        case RegexNodeKind.Concatenate:
-                            var peers = (List<RegexNode>)parent.Children!;
-                            int currentIndex = peers.IndexOf(subsequent);
-                            Debug.Assert(currentIndex >= 0, "Node should have been in its parent's child list");
-                            if (currentIndex + 1 == peers.Count)
-                            {
-                                subsequent = parent;
-                                continue;
-                            }
-                            else
-                            {
-                                subsequent = peers[currentIndex + 1];
-                                break;
-                            }
+                subsequent = nextSubsequent;
+            }
+        }
 
-                        case null:
-                            // If we hit the root, we're at the end of the expression, at which point nothing could backtrack
-                            // in and we can declare success.
-                            return true;
+        /// <summary>
+        /// Starting from <paramref name="node"/>, walks up through the tree to find the next node in
+        /// sequence — the next sibling in a parent Concatenate, walking through transparent wrappers
+        /// (Atomic, Alternate, Capture). Returns the next node if found, or null if the end of the
+        /// pattern was reached or an unrecognized construct was encountered.
+        /// </summary>
+        /// <param name="node">The node to start walking up from.</param>
+        /// <param name="reachedEnd">True if null was returned because the root of the tree was reached
+        /// (no more nodes in the pattern); false if an unrecognized construct was encountered.</param>
+        private static RegexNode? FindNextNodeInSequence(RegexNode node, out bool reachedEnd)
+        {
+            // To be conservative, we only walk up through a very limited set of constructs
+            // (even though FindStartingLiteralNode may have walked down through more, like loops),
+            // looking for the next concatenation that we're not at the end of, at which point the
+            // next node in that concatenation is the result.
+            reachedEnd = false;
+            while (true)
+            {
+                RegexNode? parent = node.Parent;
+                switch (parent?.Kind)
+                {
+                    case RegexNodeKind.Atomic:
+                    case RegexNodeKind.Alternate:
+                    case RegexNodeKind.Capture:
+                        node = parent;
+                        continue;
 
-                        default:
-                            // Anything else, we don't know what to do, so we have to assume it could conflict with the loop.
-                            return false;
-                    }
+                    case RegexNodeKind.Concatenate:
+                        var peers = (List<RegexNode>)parent.Children!;
+                        int currentIndex = peers.IndexOf(node);
+                        Debug.Assert(currentIndex >= 0, "Node should have been in its parent's child list");
+                        if (currentIndex + 1 < peers.Count)
+                        {
+                            return peers[currentIndex + 1];
+                        }
 
-                    break;
+                        node = parent;
+                        continue;
+
+                    case null:
+                        // Reached the root of the tree — no more nodes in the pattern.
+                        reachedEnd = true;
+                        return null;
+
+                    default:
+                        // Unrecognized construct — can't determine what comes next.
+                        return null;
                 }
             }
         }
@@ -2676,7 +2748,7 @@ namespace System.Text.RegularExpressions
                             // before or after this node, depending on whether we're looking for a preceding or succeeding word character.
                             return
                                 RegexPrefixAnalyzer.FindFirstOrLastCharClass(peers[index], findFirst: succeeded) is string set &&
-                                RegexCharClass.IsKnownWordClassSubset(set);
+                                RegexCharClass.IsSubsetOf(set, RegexCharClass.WordClass);
                         }
 
                         node = parent;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2334,9 +2334,10 @@ namespace System.Text.RegularExpressions
         /// only the last consumed position. This is possible when <paramref name="subsequent"/> starts with
         /// a literal whose first character is subsumed by the loop's class, and whatever follows is disjoint
         /// from the loop's class — meaning no earlier backtrack position can succeed, since every interior
-        /// position has a loop-set character after it. For One/Set literals, the character(s) must be subsumed
-        /// and the next node in sequence must be disjoint. For Multi literals, the first character must be
-        /// subsumed and the second character must be disjoint.
+        /// position has a loop-set character after it that the disjoint subsequent wouldn't accept.
+        /// For One/Set literals, the character(s) must be subsumed and the next node in sequence must be
+        /// disjoint (e.g. <c>\w+a\s</c> for One, <c>\d+[0-9]\s</c> for Set). For Multi literals, the
+        /// first character must be subsumed and the second character must be disjoint (e.g. <c>\d+0x</c>).
         /// </summary>
         internal static bool CanReduceLoopBacktrackingToSinglePosition(RegexNode loopNode, RegexNode subsequent)
         {
@@ -2351,8 +2352,8 @@ namespace System.Text.RegularExpressions
                 // must also be matched by the loop's character class.
                 switch (literal.Kind)
                 {
-                    case RegexNodeKind.One when CharInLoopSet(loopNode, literal.Ch):
-                    case RegexNodeKind.Set when loopNode.Kind is RegexNodeKind.Setloop && RegexCharClass.IsSubsetOf(literal.Str!, loopNode.Str!):
+                    case RegexNodeKind.One when CharInLoopSet(loopNode, literal.Ch):   // e.g. \w+a\s : 'a' is in \w, check \s is disjoint
+                    case RegexNodeKind.Set when loopNode.Kind is RegexNodeKind.Setloop && RegexCharClass.IsSubsetOf(literal.Str!, loopNode.Str!):   // e.g. \d+[0-9]\s
                         // Find the node that follows the literal in the tree and check whether
                         // the loop would be atomic with respect to it. If nothing follows (end of
                         // pattern), we can't reduce — earlier positions could still succeed.
@@ -2361,11 +2362,12 @@ namespace System.Text.RegularExpressions
                             CanBeMadeAtomic(loopNode, afterLiteral, iterateNullableSubsequent: true, allowLazy: false);
 
                     case RegexNodeKind.Multi when CharInLoopSet(loopNode, literal.Str![0]) && !CharInLoopSet(loopNode, literal.Str[1]):
-                        // For a multi-character literal, treat it as two single characters: the first
-                        // must be subsumed by the loop (so the loop would have consumed it), and the
-                        // second must be disjoint from the loop (so positions within the loop's consumed
-                        // range can't satisfy it). This avoids needing FindNextNodeInSequence/CanBeMadeAtomic
-                        // since the second character is directly available in the multi's string.
+                        // For a multi-character literal (e.g. \d+0x), treat it as two single characters:
+                        // the first must be subsumed by the loop (so the loop would have consumed it),
+                        // and the second must be disjoint from the loop (so positions within the loop's
+                        // consumed range can't satisfy it). This avoids needing FindNextNodeInSequence/
+                        // CanBeMadeAtomic since the second character is directly available in the
+                        // multi's string.
                         return true;
                 }
 

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2331,10 +2331,12 @@ namespace System.Text.RegularExpressions
 
         /// <summary>
         /// Determines whether a greedy single-character loop's backtracking can be reduced to checking
-        /// only the last consumed position. This is possible when <paramref name="subsequent"/> is itself
-        /// a single-character literal (One or Set) whose character class is a subset of the loop's class,
-        /// and whatever follows that literal is disjoint from the loop's class — meaning no earlier
-        /// backtrack position can succeed, since every interior position has a loop-set character after it.
+        /// only the last consumed position. This is possible when <paramref name="subsequent"/> starts with
+        /// a literal whose first character is subsumed by the loop's class, and whatever follows is disjoint
+        /// from the loop's class — meaning no earlier backtrack position can succeed, since every interior
+        /// position has a loop-set character after it. For One/Set literals, the character(s) must be subsumed
+        /// and the next node in sequence must be disjoint. For Multi literals, the first character must be
+        /// subsumed and the second character must be disjoint.
         /// </summary>
         internal static bool CanReduceLoopBacktrackingToSinglePosition(RegexNode loopNode, RegexNode subsequent)
         {
@@ -2344,10 +2346,9 @@ namespace System.Text.RegularExpressions
             // like Concatenate, Capture, and Atomic.
             if (subsequent.FindStartingLiteralNode() is RegexNode literal)
             {
-                // Only handle single-character literals (One, Set). Multi-character literals
-                // would require backing off by more than one position, and Notone matches
-                // almost everything so it's rarely subsumed. Every character the literal could
-                // match must also be matched by the loop's character class.
+                // Handle One, Set, and Multi literals. Notone matches almost everything so it's
+                // rarely subsumed. Every character the literal could match at the first position
+                // must also be matched by the loop's character class.
                 switch (literal.Kind)
                 {
                     case RegexNodeKind.One when CharInLoopSet(loopNode, literal.Ch):

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -398,6 +398,48 @@ namespace System.Text.RegularExpressions.Tests
             yield return (@"\w+(\(\w+!\))?,", "Foo(abc!),", RegexOptions.None, 0, 10, true, "Foo(abc!),");
 
             yield return (@"(?:m(?:((e)?)??)|a)\b", "you m you", RegexOptions.None, 0, 9, true, "m");
+
+            // Greedy set loop followed by literal in loop's set followed by word boundary.
+            // The backtracking short-circuit optimization should apply: only the last consumed
+            // position needs to be checked, avoiding repeated LastIndexOf calls.
+            yield return (@"\b\w+n\b", "barn door", RegexOptions.None, 0, 9, true, "barn");
+            yield return (@"\b\w+n\b", "bark door", RegexOptions.None, 0, 9, false, string.Empty);
+            yield return (@"\b\w+n\b", "inn keeper", RegexOptions.None, 0, 10, true, "inn");
+            yield return (@"\b\w+n\b", "can of worms", RegexOptions.None, 0, 12, true, "can");
+            yield return (@"\b\w+n\b", "frozen chicken", RegexOptions.None, 0, 14, true, "frozen");
+            yield return (@"\b\w+n\b", "nope barn", RegexOptions.None, 0, 9, true, "barn");
+            yield return (@"\b\d+0\b", "abc 120 def", RegexOptions.None, 0, 11, true, "120");
+            yield return (@"\b\d+0\b", "abc 123 def", RegexOptions.None, 0, 11, false, string.Empty);
+            yield return (@"\b[a-z]+x\b", "the fox jumps", RegexOptions.None, 0, 13, true, "fox");
+            yield return (@"\b\w+\d\b", "abc test9 def", RegexOptions.None, 0, 13, true, "test9");
+            yield return (@"\b\w+\d\b", "abc test def", RegexOptions.None, 0, 12, false, string.Empty);
+            yield return (@"\b\w+[aeiou]\b", "by the tube", RegexOptions.None, 0, 11, true, "the");
+            // Literal inside a capture group — FindStartingLiteralNode must descend through Capture.
+            yield return (@"\b\w+(n)\b", "barn door", RegexOptions.None, 0, 9, true, "barn");
+            // Literal inside a non-capturing group.
+            yield return (@"\b\w+(?:n\b)", "barn door", RegexOptions.None, 0, 9, true, "barn");
+            // Subsequent is a disjoint set, not a boundary — \d loop, '5' in \d, [a-z] disjoint from \d.
+            yield return (@"\d+5[a-z]", "xx12345abc", RegexOptions.None, 0, 10, true, "12345a");
+            yield return (@"\d+5[a-z]", "xx12346abc", RegexOptions.None, 0, 10, false, string.Empty);
+            // End-of-line anchor as the disjoint constraint.
+            yield return (@"\w+n$", "barn", RegexOptions.None, 0, 4, true, "barn");
+            yield return (@"\w+n$", "bark", RegexOptions.None, 0, 4, false, string.Empty);
+            // Optimization should NOT apply: subsequent overlaps with loop set.
+            yield return (@"\w+n\w+", "canopy", RegexOptions.None, 0, 6, true, "canopy");
+            // Second backtrack forced — \b succeeds but subsequent literal fails, must not re-enter.
+            yield return (@"\b\w+n\b!", "barn door", RegexOptions.None, 0, 9, false, string.Empty);
+            yield return (@"\b\w+n\b ", "barn door", RegexOptions.None, 0, 9, true, "barn ");
+            // Inside an outer loop — tests stack save/restore with the zeroed endingPos.
+            yield return (@"(?:\b\w+n\b\s*)+", "barn can ", RegexOptions.None, 0, 9, true, "barn can ");
+            // Minimum > 1.
+            yield return (@"\b\w{2,}n\b", "barn door", RegexOptions.None, 0, 9, true, "barn");
+            yield return (@"\b\w{2,}n\b", "n door", RegexOptions.None, 0, 6, false, string.Empty);
+            // Multi literal after greedy loop — first char in loop's set, second char NOT.
+            // The single-position backtrack optimization should apply to the Multi case.
+            yield return (@"\d+0x", "abc1230x99", RegexOptions.None, 0, 10, true, "1230x");
+            yield return (@"\d+0x", "abc12399", RegexOptions.None, 0, 8, false, string.Empty);
+            yield return (@"[a-f]+a9", "xbca93", RegexOptions.None, 0, 6, true, "bca9");
+            yield return (@"[a-f]+a9", "xbcb93", RegexOptions.None, 0, 6, false, string.Empty);
             yield return (@"(?:m(?:((e)?)??)|a)\b", "you me you", RegexOptions.None, 0, 10, true, "me");
             yield return (@"(?:m(?:((e)?)??)|a)\b", "you a you", RegexOptions.None, 0, 9, true, "a");
             yield return (@"(?:m(?:((e)?)??)|a)\b", "you and you", RegexOptions.None, 0, 11, false, "");

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -440,6 +440,25 @@ namespace System.Text.RegularExpressions.Tests
             yield return (@"\d+0x", "abc12399", RegexOptions.None, 0, 8, false, string.Empty);
             yield return (@"[a-f]+a9", "xbca93", RegexOptions.None, 0, 6, true, "bca9");
             yield return (@"[a-f]+a9", "xbcb93", RegexOptions.None, 0, 6, false, string.Empty);
+            // Longer Multi literal — first char subsumed, second disjoint, rest doesn't matter.
+            yield return (@"\d+0abc", "x1230abcx", RegexOptions.None, 0, 9, true, "1230abc");
+            yield return (@"\d+0abc", "x123xabc", RegexOptions.None, 0, 8, false, string.Empty);
+            // Set literal subsumed by loop's class, followed by disjoint constraint.
+            yield return (@"\d+[0-9]\s", "abc123 ", RegexOptions.None, 0, 7, true, "123 ");
+            yield return (@"\d+[0-9]\s", "abc123x", RegexOptions.None, 0, 7, false, string.Empty);
+            yield return (@"\d+[0-9][a-z]", "abc123a", RegexOptions.None, 0, 7, true, "123a");
+            yield return (@"\d+[0-9][a-z]", "abc1234", RegexOptions.None, 0, 7, false, string.Empty);
+            // Nothing after literal — optimization should NOT fire (earlier positions could succeed).
+            yield return (@"\w+n", "canyon", RegexOptions.None, 0, 6, true, "canyon");
+            yield return (@"\w+n", "can opener", RegexOptions.None, 0, 10, true, "can");
+            yield return (@"\d+5", "12345", RegexOptions.None, 0, 5, true, "12345");
+            // Notoneloop — [^x]+ is a Notoneloop, 'a' != 'x' so it's in the loop's set.
+            yield return (@"[^x]+a\b", "banana boat", RegexOptions.None, 0, 11, true, "banana");
+            yield return (@"[^x]+a\b", "xyz", RegexOptions.None, 0, 3, false, string.Empty);
+            // Minimum 0 (star not plus) — greedy loop still consumes maximally.
+            yield return (@"\w*n\b", "barn door", RegexOptions.None, 0, 9, true, "barn");
+            yield return (@"\w*n\b", "n door", RegexOptions.None, 0, 6, true, "n");
+            yield return (@"\w*n\b", "bark door", RegexOptions.None, 0, 9, false, string.Empty);
             yield return (@"(?:m(?:((e)?)??)|a)\b", "you me you", RegexOptions.None, 0, 10, true, "me");
             yield return (@"(?:m(?:((e)?)??)|a)\b", "you a you", RegexOptions.None, 0, 9, true, "a");
             yield return (@"(?:m(?:((e)?)??)|a)\b", "you and you", RegexOptions.None, 0, 11, false, "");


### PR DESCRIPTION
When a greedy character loop (like `\w+`, `\d+`, `[a-z]+`) is followed by a literal that's part of the loop's character class, backtracking normally requires repeated `LastIndexOf` calls to find viable positions. However, if whatever comes *after* that literal is disjoint from the loop's class, then only the very last position consumed by the loop can possibly succeed — every earlier position would have a loop-class character where the disjoint subsequent needs something else.

For example, in `\b\w+n\b`, the `\w+` loop is followed by `n` (which is in `\w`), and `n` is followed by `\b`. Since the loop only matches word characters, any position in the middle of the loop's consumed range would have a word character after the `n`, and the `\b` boundary wouldn't be satisfied there. Only the very last consumed position can work, so backtracking can skip directly to it rather than searching backward one position at a time.