### PR TITLE
[crossgen2] Add --strip-il-bodies option for composite R2R

### DIFF
--- a/src/coreclr/inc/readytorun.h
+++ b/src/coreclr/inc/readytorun.h
@@ -20,7 +20,7 @@
 // If you update this, ensure you run `git grep MINIMUM_READYTORUN_MAJOR_VERSION`
 // and handle pending work.
 #define READYTORUN_MAJOR_VERSION 18
-#define READYTORUN_MINOR_VERSION 0x0004
+#define READYTORUN_MINOR_VERSION 0x0005
 
 #define MINIMUM_READYTORUN_MAJOR_VERSION 18
 
@@ -55,6 +55,7 @@
 // R2R Version 18.2 adds InitClass and InitInstClass helpers
 // R2R Version 18.3 adds the ExternalTypeMaps, ProxyTypeMaps, TypeMapAssemblyTargets sections
 // R2R Version 18.4 adds ThrowArgument, ThrowArgumentOutOfRange, ThrowPlatformNotSupported, and ThrowNotImplemented helpers
+// R2R Version 18.5 adds READYTORUN_FLAG_STRIPPED_IL_BODIES, READYTORUN_FLAG_STRIPPED_INLINING_INFO, and READYTORUN_FLAG_STRIPPED_DEBUG_INFO flags
 
 struct READYTORUN_CORE_HEADER
 {

--- a/src/coreclr/inc/readytorun.h
+++ b/src/coreclr/inc/readytorun.h
@@ -92,6 +92,9 @@ enum ReadyToRunFlag
     READYTORUN_FLAG_MULTIMODULE_VERSION_BUBBLE  = 0x00000040,   // This R2R module has multiple modules within its version bubble (For versions before version 6.2, all modules are assumed to possibly have this characteristic)
     READYTORUN_FLAG_UNRELATED_R2R_CODE          = 0x00000080,   // This R2R module has code in it that would not be naturally encoded into this module
     READYTORUN_FLAG_PLATFORM_NATIVE_IMAGE       = 0x00000100,   // The owning composite executable is in the platform native format
+    READYTORUN_FLAG_STRIPPED_IL_BODIES          = 0x00000200,   // IL method bodies have been stripped from the image
+    READYTORUN_FLAG_STRIPPED_INLINING_INFO      = 0x00000400,   // Inlining info has been stripped from the image
+    READYTORUN_FLAG_STRIPPED_DEBUG_INFO         = 0x00000800,   // Debug info has been stripped from the image
 };
 
 enum class ReadyToRunSectionType : uint32_t

--- a/src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
+++ b/src/coreclr/nativeaot/Runtime/inc/ModuleHeaders.h
@@ -12,7 +12,7 @@ struct ReadyToRunHeaderConstants
     static const uint32_t Signature = 0x00525452; // 'RTR'
 
     static const uint32_t CurrentMajorVersion = 18;
-    static const uint32_t CurrentMinorVersion = 4;
+    static const uint32_t CurrentMinorVersion = 5;
 };
 
 struct ReadyToRunHeader

--- a/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ModuleHeaders.cs
@@ -16,7 +16,7 @@ namespace Internal.Runtime
         public const uint Signature = 0x00525452; // 'RTR'
 
         public const ushort CurrentMajorVersion = 18;
-        public const ushort CurrentMinorVersion = 4;
+        public const ushort CurrentMinorVersion = 5;
     }
 #if READYTORUN
 #pragma warning disable 0169

--- a/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
+++ b/src/coreclr/tools/Common/Internal/Runtime/ReadyToRunConstants.cs
@@ -20,6 +20,9 @@ namespace Internal.ReadyToRunConstants
         READYTORUN_FLAG_MultiModuleVersionBubble = 0x00000040,  // This R2R module has multiple modules within its version bubble
         READYTORUN_FLAG_UnrelatedR2RCode = 0x00000080,          // This R2R module has generic code in it that would not be naturally encoded into this module
         READYTORUN_FLAG_PlatformNativeImage = 0x00000100,       // The owning composite executable is in the platform native format
+        READYTORUN_FLAG_StrippedILBodies = 0x00000200,         // IL method bodies have been stripped from the image
+        READYTORUN_FLAG_StrippedInliningInfo = 0x00000400,     // Inlining info has been stripped from the image
+        READYTORUN_FLAG_StrippedDebugInfo = 0x00000800,        // Debug info has been stripped from the image
     }
 
     public enum ReadyToRunImportSectionType : byte

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMethodILNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMethodILNode.cs
@@ -13,6 +13,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     public class CopiedMethodILNode : ObjectNode, ISymbolDefinitionNode
     {
+        // Minimal IL method body: tiny header (0x02 flags | 0x01 size << 2 = 0x06) + ret opcode (0x2A).
+        private static readonly byte[] s_minimalILBody = new byte[] { 0x06, 0x2A };
+
         EcmaMethod _method;
 
         public CopiedMethodILNode(EcmaMethod method)
@@ -52,10 +55,24 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
 
             var rva = _method.MetadataReader.GetMethodDefinition(_method.Handle).RelativeVirtualAddress;
-            var reader = _method.Module.PEReader.GetSectionData(rva).GetReader();
-            int size = MethodBodyBlock.Create(reader).Size;
-            
-            return new ObjectData(reader.ReadBytes(size), Array.Empty<Relocation>(), 4, new ISymbolDefinitionNode[] { this });
+            var peReader = _method.Module.PEReader;
+            byte[] bodyBytes;
+            {
+                var reader = peReader.GetSectionData(rva).GetReader();
+                int size = MethodBodyBlock.Create(reader).Size;
+                bodyBytes = peReader.GetSectionData(rva).GetReader().ReadBytes(size);
+            }
+
+            if (factory.OptimizationFlags.StripILBodies
+                && factory.OptimizationFlags.CompiledMethodDefs is not null
+                && factory.OptimizationFlags.CompiledMethodDefs.Contains(_method)
+                && !_method.HasInstantiation
+                && !_method.OwningType.HasInstantiation)
+            {
+                return new ObjectData(s_minimalILBody, Array.Empty<Relocation>(), 4, new ISymbolDefinitionNode[] { this });
+            }
+
+            return new ObjectData(bodyBytes, Array.Empty<Relocation>(), 4, new ISymbolDefinitionNode[] { this });
         }
 
         public override int ClassCode => 541651465;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMethodILNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMethodILNode.cs
@@ -13,8 +13,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 {
     public class CopiedMethodILNode : ObjectNode, ISymbolDefinitionNode
     {
-        // Minimal IL method body: tiny header (0x02 flags | 0x01 size << 2 = 0x06) + ret opcode (0x2A).
-        private static readonly byte[] s_minimalILBody = new byte[] { 0x06, 0x2A };
+        // Throws NullReferenceException if the stripped body is encountered.
+        // Tiny header (0x0A: 2 bytes code size) + ldnull (0x14) + throw (0x7A).
+        private static readonly byte[] s_minimalILBody = [0x0A, 0x14, 0x7A];
 
         EcmaMethod _method;
 
@@ -64,12 +65,9 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
 
             var rva = _method.MetadataReader.GetMethodDefinition(_method.Handle).RelativeVirtualAddress;
             var peReader = _method.Module.PEReader;
-            byte[] bodyBytes;
-            {
-                var reader = peReader.GetSectionData(rva).GetReader();
-                int size = MethodBodyBlock.Create(reader).Size;
-                bodyBytes = peReader.GetSectionData(rva).GetReader().ReadBytes(size);
-            }
+            var reader = peReader.GetSectionData(rva).GetReader();
+            int size = MethodBodyBlock.Create(reader).Size;
+            byte[] bodyBytes = peReader.GetSectionData(rva).GetReader().ReadBytes(size);
 
             return new ObjectData(bodyBytes, Array.Empty<Relocation>(), 4, new ISymbolDefinitionNode[] { this });
         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMethodILNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMethodILNode.cs
@@ -55,7 +55,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
             }
 
             if (factory.OptimizationFlags.StripILBodies
-                && factory.OptimizationFlags.CompiledMethodDefs is not null
                 && factory.OptimizationFlags.CompiledMethodDefs.Contains(_method)
                 && !_method.HasInstantiation
                 && !_method.OwningType.HasInstantiation)

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMethodILNode.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRun/CopiedMethodILNode.cs
@@ -54,15 +54,6 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                     definedSymbols: new ISymbolDefinitionNode[] { this });
             }
 
-            var rva = _method.MetadataReader.GetMethodDefinition(_method.Handle).RelativeVirtualAddress;
-            var peReader = _method.Module.PEReader;
-            byte[] bodyBytes;
-            {
-                var reader = peReader.GetSectionData(rva).GetReader();
-                int size = MethodBodyBlock.Create(reader).Size;
-                bodyBytes = peReader.GetSectionData(rva).GetReader().ReadBytes(size);
-            }
-
             if (factory.OptimizationFlags.StripILBodies
                 && factory.OptimizationFlags.CompiledMethodDefs is not null
                 && factory.OptimizationFlags.CompiledMethodDefs.Contains(_method)
@@ -70,6 +61,15 @@ namespace ILCompiler.DependencyAnalysis.ReadyToRun
                 && !_method.OwningType.HasInstantiation)
             {
                 return new ObjectData(s_minimalILBody, Array.Empty<Relocation>(), 4, new ISymbolDefinitionNode[] { this });
+            }
+
+            var rva = _method.MetadataReader.GetMethodDefinition(_method.Handle).RelativeVirtualAddress;
+            var peReader = _method.Module.PEReader;
+            byte[] bodyBytes;
+            {
+                var reader = peReader.GetSectionData(rva).GetReader();
+                int size = MethodBodyBlock.Create(reader).Size;
+                bodyBytes = peReader.GetSectionData(rva).GetReader().ReadBytes(size);
             }
 
             return new ObjectData(bodyBytes, Array.Empty<Relocation>(), 4, new ISymbolDefinitionNode[] { this });

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/DependencyAnalysis/ReadyToRunCodegenNodeFactory.cs
@@ -65,6 +65,8 @@ namespace ILCompiler.DependencyAnalysis
         public bool IsComponentModule;
         public bool StripInliningInfo;
         public bool StripDebugInfo;
+        public bool StripILBodies;
+        public HashSet<MethodDesc> CompiledMethodDefs;
     }
 
     // To make the code future compatible to the composite R2R story
@@ -522,6 +524,19 @@ namespace ILCompiler.DependencyAnalysis
                     yield return methodCodeNode;
                 }
             }
+        }
+
+        public HashSet<MethodDesc> BuildCompiledMethodDefsSet()
+        {
+            Debug.Assert(MarkingComplete);
+
+            var set = new HashSet<MethodDesc>();
+            foreach (MethodWithGCInfo compiled in EnumerateCompiledMethods())
+            {
+                set.Add(compiled.Method.GetTypicalMethodDefinition());
+            }
+
+            return set;
         }
 
         private struct MethodFixupKey : IEquatable<MethodFixupKey>

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -446,6 +446,12 @@ namespace ILCompiler
                         ownerExecutableName = Path.ChangeExtension(ownerExecutableName, ".dylib");
                     }
 
+                    HashSet<MethodDesc> compiledMethodDefs = null;
+                    if (_nodeFactory.OptimizationFlags.StripILBodies)
+                    {
+                        compiledMethodDefs = _nodeFactory.BuildCompiledMethodDefsSet();
+                    }
+
                     foreach (string inputFile in _inputFiles)
                     {
                         string relativeMsilPath = Path.GetRelativePath(_compositeRootPath, inputFile);
@@ -455,13 +461,13 @@ namespace ILCompiler
                             relativeMsilPath = Path.GetFileName(inputFile);
                         }
                         string standaloneMsilOutputFile = Path.Combine(outputDirectory, relativeMsilPath);
-                        RewriteComponentFile(inputFile: inputFile, outputFile: standaloneMsilOutputFile, ownerExecutableName: ownerExecutableName);
+                        RewriteComponentFile(inputFile: inputFile, outputFile: standaloneMsilOutputFile, ownerExecutableName: ownerExecutableName, compiledMethodDefs: compiledMethodDefs);
                     }
                 }
             }
         }
 
-        private void RewriteComponentFile(string inputFile, string outputFile, string ownerExecutableName)
+        private void RewriteComponentFile(string inputFile, string outputFile, string ownerExecutableName, HashSet<MethodDesc> compiledMethodDefs)
         {
             EcmaModule inputModule = NodeFactory.TypeSystemContext.GetModuleFromPath(inputFile);
 
@@ -481,7 +487,7 @@ namespace ILCompiler
                 flags |= ReadyToRunFlags.READYTORUN_FLAG_SkipTypeValidation;
             }
 
-            NodeFactoryOptimizationFlags optimizationFlags = _nodeFactory.OptimizationFlags with { IsComponentModule = true };
+            NodeFactoryOptimizationFlags optimizationFlags = _nodeFactory.OptimizationFlags with { IsComponentModule = true, CompiledMethodDefs = compiledMethodDefs };
 
             flags |= _nodeFactory.CompilationModuleGroup.GetReadyToRunFlags() & ReadyToRunFlags.READYTORUN_FLAG_MultiModuleVersionBubble;
 

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/Compiler/ReadyToRunCodegenCompilation.cs
@@ -489,6 +489,21 @@ namespace ILCompiler
 
             NodeFactoryOptimizationFlags optimizationFlags = _nodeFactory.OptimizationFlags with { IsComponentModule = true, CompiledMethodDefs = compiledMethodDefs };
 
+            if (optimizationFlags.StripILBodies)
+            {
+                flags |= ReadyToRunFlags.READYTORUN_FLAG_StrippedILBodies;
+            }
+
+            if (optimizationFlags.StripInliningInfo)
+            {
+                flags |= ReadyToRunFlags.READYTORUN_FLAG_StrippedInliningInfo;
+            }
+
+            if (optimizationFlags.StripDebugInfo)
+            {
+                flags |= ReadyToRunFlags.READYTORUN_FLAG_StrippedDebugInfo;
+            }
+
             flags |= _nodeFactory.CompilationModuleGroup.GetReadyToRunFlags() & ReadyToRunFlags.READYTORUN_FLAG_MultiModuleVersionBubble;
 
             bool isNativeCompositeImage = false;

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -153,7 +153,7 @@ namespace ILCompiler
             new("--determinism-stress");
 
         public Option<bool> StripILBodies { get; } =
-            new("--strip-il-bodies") { Description = "Replace IL method bodies with a minimal stub in the output image" };
+            new("--strip-il-bodies") { Description = SR.StripILBodiesOption };
 
         public bool CompositeOrInputBubble { get; private set; }
         public OptimizationMode OptimizationMode { get; private set; }

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -146,14 +146,13 @@ namespace ILCompiler
             new("--strip-inlining-info") { Description = SR.StripInliningInfoOption };
         public Option<bool> StripDebugInfo { get; } =
             new("--strip-debug-info") { Description = SR.StripDebugInfoOption };
+        public Option<bool> StripILBodies { get; } =
+            new("--strip-il-bodies") { Description = SR.StripILBodiesOption };
         public Option<bool> SynthesizeRandomMibc { get; } =
             new("--synthesize-random-mibc");
 
         public Option<int> DeterminismStress { get; } =
             new("--determinism-stress");
-
-        public Option<bool> StripILBodies { get; } =
-            new("--strip-il-bodies") { Description = SR.StripILBodiesOption };
 
         public bool CompositeOrInputBubble { get; private set; }
         public OptimizationMode OptimizationMode { get; private set; }
@@ -228,9 +227,9 @@ namespace ILCompiler
             Options.Add(HotColdSplitting);
             Options.Add(StripInliningInfo);
             Options.Add(StripDebugInfo);
+            Options.Add(StripILBodies);
             Options.Add(SynthesizeRandomMibc);
             Options.Add(DeterminismStress);
-            Options.Add(StripILBodies);
 
             this.SetAction(result =>
             {

--- a/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
+++ b/src/coreclr/tools/aot/crossgen2/Crossgen2RootCommand.cs
@@ -152,6 +152,9 @@ namespace ILCompiler
         public Option<int> DeterminismStress { get; } =
             new("--determinism-stress");
 
+        public Option<bool> StripILBodies { get; } =
+            new("--strip-il-bodies") { Description = "Replace IL method bodies with a minimal stub in the output image" };
+
         public bool CompositeOrInputBubble { get; private set; }
         public OptimizationMode OptimizationMode { get; private set; }
         public ParseResult Result { get; private set; }
@@ -227,6 +230,7 @@ namespace ILCompiler
             Options.Add(StripDebugInfo);
             Options.Add(SynthesizeRandomMibc);
             Options.Add(DeterminismStress);
+            Options.Add(StripILBodies);
 
             this.SetAction(result =>
             {

--- a/src/coreclr/tools/aot/crossgen2/Program.cs
+++ b/src/coreclr/tools/aot/crossgen2/Program.cs
@@ -626,6 +626,7 @@ namespace ILCompiler
                     nodeFactoryFlags.EnableCachedInterfaceDispatchSupport = Get(_command.EnableCachedInterfaceDispatchSupport) ?? !typeSystemContext.TargetAllowsRuntimeCodeGeneration;
                     nodeFactoryFlags.StripInliningInfo = Get(_command.StripInliningInfo);
                     nodeFactoryFlags.StripDebugInfo = Get(_command.StripDebugInfo);
+                    nodeFactoryFlags.StripILBodies = Get(_command.StripILBodies);
 
                     builder
                         .UseMapFile(Get(_command.Map))

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -442,6 +442,6 @@
     <value>Strip debug info from the R2R image.</value>
   </data>
   <data name="StripILBodiesOption" xml:space="preserve">
-    <value>Replace IL method bodies of compiled methods with a throwing stub in composite R2R output assemblies</value>
+    <value>Replace IL method bodies of compiled methods with a throwing stub in composite R2R output assemblies.</value>
   </data>
 </root>

--- a/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
+++ b/src/coreclr/tools/aot/crossgen2/Properties/Resources.resx
@@ -441,4 +441,7 @@
   <data name="StripDebugInfoOption" xml:space="preserve">
     <value>Strip debug info from the R2R image.</value>
   </data>
+  <data name="StripILBodiesOption" xml:space="preserve">
+    <value>Replace IL method bodies of compiled methods with a throwing stub in composite R2R output assemblies</value>
+  </data>
 </root>

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -631,7 +631,6 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
     {
         DoLog("Ready to Run load failed - stripped IL bodies are not supported with dynamic code compilation");
         COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
-        return NULL;
     }
 
     if ((pHeader->CoreHeader.Flags & (READYTORUN_FLAG_STRIPPED_INLINING_INFO | READYTORUN_FLAG_STRIPPED_DEBUG_INFO)) != 0)

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -619,13 +619,6 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
 
     READYTORUN_HEADER * pHeader = pLayout->GetReadyToRunHeader();
 
-    // Ignore the content if the image major version is higher or lower than the major version currently supported by the runtime
-    if (pHeader->MajorVersion < MINIMUM_READYTORUN_MAJOR_VERSION || pHeader->MajorVersion > READYTORUN_MAJOR_VERSION)
-    {
-        DoLog("Ready to Run disabled - unsupported header version");
-        return NULL;
-    }
-
 #ifdef FEATURE_DYNAMIC_CODE_COMPILED
     if ((pHeader->CoreHeader.Flags & READYTORUN_FLAG_STRIPPED_IL_BODIES) != 0)
     {
@@ -639,6 +632,13 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
         return NULL;
     }
 #endif // FEATURE_DYNAMIC_CODE_COMPILED
+
+    // Ignore the content if the image major version is higher or lower than the major version currently supported by the runtime
+    if (pHeader->MajorVersion < MINIMUM_READYTORUN_MAJOR_VERSION || pHeader->MajorVersion > READYTORUN_MAJOR_VERSION)
+    {
+        DoLog("Ready to Run disabled - unsupported header version");
+        return NULL;
+    }
 
     LoaderHeap *pHeap = pModule->GetLoaderAllocator()->GetHighFrequencyHeap();
 

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -627,7 +627,14 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
     }
 
 #ifdef FEATURE_DYNAMIC_CODE_COMPILED
-    if (pHeader->CoreHeader.Flags & (READYTORUN_FLAG_STRIPPED_IL_BODIES | READYTORUN_FLAG_STRIPPED_INLINING_INFO | READYTORUN_FLAG_STRIPPED_DEBUG_INFO))
+    if ((pHeader->CoreHeader.Flags & READYTORUN_FLAG_STRIPPED_IL_BODIES) != 0)
+    {
+        DoLog("Ready to Run load failed - stripped IL bodies are not supported with dynamic code compilation");
+        COMPlusThrowHR(COR_E_BADIMAGEFORMAT);
+        return NULL;
+    }
+
+    if ((pHeader->CoreHeader.Flags & (READYTORUN_FLAG_STRIPPED_INLINING_INFO | READYTORUN_FLAG_STRIPPED_DEBUG_INFO)) != 0)
     {
         DoLog("Ready to Run disabled - stripped R2R sections not supported with dynamic code compilation");
         return NULL;

--- a/src/coreclr/vm/readytoruninfo.cpp
+++ b/src/coreclr/vm/readytoruninfo.cpp
@@ -626,6 +626,14 @@ PTR_ReadyToRunInfo ReadyToRunInfo::Initialize(Module * pModule, AllocMemTracker 
         return NULL;
     }
 
+#ifdef FEATURE_DYNAMIC_CODE_COMPILED
+    if (pHeader->CoreHeader.Flags & (READYTORUN_FLAG_STRIPPED_IL_BODIES | READYTORUN_FLAG_STRIPPED_INLINING_INFO | READYTORUN_FLAG_STRIPPED_DEBUG_INFO))
+    {
+        DoLog("Ready to Run disabled - stripped R2R sections not supported with dynamic code compilation");
+        return NULL;
+    }
+#endif // FEATURE_DYNAMIC_CODE_COMPILED
+
     LoaderHeap *pHeap = pModule->GetLoaderAllocator()->GetHighFrequencyHeap();
 
     NativeImage *nativeImage = NULL;


### PR DESCRIPTION
## Description

Add a `--strip-il-bodies` crossgen2 option that replaces IL method bodies of successfully R2R-compiled methods with minimal stubs (`ret`) in composite output assemblies. This reduces assembly size for scenarios where IL interpreter fallback is not needed, such as full R2R on iOS/MacCatalyst.

Fixes https://github.com/dotnet/runtime/issues/124860