### PR TITLE
Use mul+add+permute sequence for DotProduct when AVX is available

### DIFF
--- a/src/coreclr/jit/lower.h
+++ b/src/coreclr/jit/lower.h
@@ -466,6 +466,7 @@ private:
     GenTree* TryLowerAndOpToAndNot(GenTreeOp* andNode);
     GenTree* TryLowerXorOpToGetMaskUpToLowestSetBit(GenTreeOp* xorNode);
     void     LowerBswapOp(GenTreeOp* node);
+    GenTree* LowerHWIntrinsicDotInnerMulSum(GenTreeHWIntrinsic* node);
 #elif defined(TARGET_ARM64)
     bool     IsValidConstForMovImm(GenTreeHWIntrinsic* node);
     void     LowerHWIntrinsicFusedMultiplyAddScalar(GenTreeHWIntrinsic* node);

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -6022,7 +6022,7 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
                         return LowerNode(tmp1);
                     }
 
-                    idx = m_compiler->gtNewIconNode(0x7F, TYP_INT);
+                    idx = m_compiler->gtNewIconNode(0xFF, TYP_INT);
                 }
                 BlockRange().InsertBefore(node, idx);
 

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -6121,6 +6121,28 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
 
                 idx = m_compiler->gtNewIconNode(0x33, TYP_INT);
                 BlockRange().InsertBefore(node, idx);
+
+                if (varTypeIsSIMD(node->gtType))
+                {
+                    // We're producing a vector result, so just emit DotProduct directly
+                    node->ResetHWIntrinsicId(NI_X86Base_DotProduct, m_compiler, op1, op2, idx);
+                }
+                else
+                {
+                    // We're producing a scalar result, so we only need the result in element 0
+                    //
+                    // However, doing that would break/limit CSE and requires a partial write so
+                    // it's better to just broadcast the value to the entire vector
+
+                    tmp3 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, op1, op2, idx, NI_X86Base_DotProduct,
+                                                                simdBaseType, simdSize);
+                    BlockRange().InsertAfter(idx, tmp3);
+                    LowerNode(tmp3);
+
+                    node->ResetHWIntrinsicId(NI_Vector128_ToScalar, tmp3);
+                }
+
+                return LowerNode(node);
             }
 
             default:

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5742,17 +5742,52 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
                 //   var tmp2 = Avx.Permute2x128(tmp1, tmp1, 0x4E);
                 //   return Avx.Add(tmp1, tmp2);
 
-                idx = m_compiler->gtNewIconNode(0xFF, TYP_INT);
-                BlockRange().InsertBefore(node, idx);
-
-                tmp1 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, op1, op2, idx, NI_AVX_DotProduct, simdBaseType,
-                                                            simdSize);
-                BlockRange().InsertAfter(idx, tmp1);
+                tmp1 = m_compiler->gtNewSimdBinOpNode(GT_MUL, simdType, op1, op2, simdBaseType, simdSize);
+                BlockRange().InsertAfter(node, tmp1);
                 LowerNode(tmp1);
 
                 node->Op(1) = tmp1;
                 LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
                 ReplaceWithLclVar(tmp1Use);
+                tmp1 = node->Op(1);
+
+                tmp3 = m_compiler->gtClone(tmp1);
+                BlockRange().InsertAfter(tmp1, tmp3);
+
+                idx = m_compiler->gtNewIconNode(0xB1, TYP_INT);
+                BlockRange().InsertAfter(tmp3, idx);
+
+                tmp2 =
+                    m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType, simdSize);
+                BlockRange().InsertAfter(idx, tmp2);
+                LowerNode(tmp2);
+
+                tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp2, tmp3, simdBaseType, simdSize);
+                BlockRange().InsertAfter(tmp2, tmp1);
+                LowerNode(tmp1);
+
+                node->Op(1) = tmp1;
+                LIR::Use tmp1Use2(BlockRange(), &node->Op(1), node);
+                ReplaceWithLclVar(tmp1Use2);
+                tmp1 = node->Op(1);
+
+                tmp3 = m_compiler->gtClone(tmp1);
+                BlockRange().InsertAfter(tmp1, tmp3);
+
+                idx = m_compiler->gtNewIconNode(0x4E, TYP_INT);
+                BlockRange().InsertAfter(tmp3, idx);
+
+                tmp2 =
+                    m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType, simdSize);
+                BlockRange().InsertAfter(idx, tmp2);
+                LowerNode(tmp2);
+
+                tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp3, tmp2, simdBaseType, simdSize);
+                BlockRange().InsertAfter(tmp2, tmp1);
+
+                node->Op(1) = tmp1;
+                LIR::Use tmp1Use3(BlockRange(), &node->Op(1), node);
+                ReplaceWithLclVar(tmp1Use3);
                 tmp1 = node->Op(1);
 
                 tmp2 = m_compiler->gtClone(tmp1);
@@ -5791,8 +5826,80 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
             case TYP_DOUBLE:
             {
                 assert(m_compiler->compIsaSupportedDebugOnly(InstructionSet_AVX));
-                horizontalAdd = NI_AVX_HorizontalAdd;
-                break;
+
+                idx = m_compiler->gtNewIconNode(0x5, TYP_INT);
+                BlockRange().InsertBefore(node, idx);
+
+                tmp1 = m_compiler->gtNewSimdBinOpNode(GT_MUL, simdType, op1, op2, simdBaseType, simdSize);
+                BlockRange().InsertAfter(idx, tmp1);
+                LowerNode(tmp1);
+
+                node->Op(1) = tmp1;
+                LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
+                ReplaceWithLclVar(tmp1Use);
+                tmp1 = node->Op(1);
+
+                tmp2 = m_compiler->gtClone(tmp1);
+                BlockRange().InsertAfter(tmp1, tmp2);
+
+                tmp3 =
+                    m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType, simdSize);
+                BlockRange().InsertAfter(tmp2, tmp3);
+                LowerNode(tmp3);
+
+                tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp3, tmp2, simdBaseType, simdSize);
+                BlockRange().InsertAfter(tmp3, tmp1);
+
+                node->Op(1) = tmp1;
+                LIR::Use tmp1Use3(BlockRange(), &node->Op(1), node);
+                ReplaceWithLclVar(tmp1Use3);
+                tmp1 = node->Op(1);
+
+                tmp2 = m_compiler->gtClone(tmp1);
+                BlockRange().InsertAfter(tmp1, tmp2);
+
+                tmp3 = m_compiler->gtClone(tmp2);
+                BlockRange().InsertAfter(tmp2, tmp3);
+
+                idx = m_compiler->gtNewIconNode(0x01, TYP_INT);
+                BlockRange().InsertAfter(tmp3, idx);
+
+                tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp2, tmp3, idx, NI_AVX_Permute2x128,
+                                                            simdBaseType, simdSize);
+                BlockRange().InsertAfter(idx, tmp2);
+                LowerNode(tmp2);
+
+                tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp1, tmp2, simdBaseType, simdSize);
+                BlockRange().InsertAfter(tmp2, tmp1);
+
+                if (!varTypeIsSIMD(node->gtType))
+                {
+                    // We're producing a scalar result, so we only need the result in element 0
+                    //
+                    // However, doing that would break/limit CSE and requires a partial write so
+                    // it's better to just broadcast the value to the entire vector
+
+                    LowerNode(tmp1);
+
+                    tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, NI_Vector256_ToScalar, simdBaseType,
+                                                                simdSize);
+                    BlockRange().InsertAfter(tmp1, tmp2);
+                    tmp1 = tmp2;
+                }
+
+                LIR::Use use;
+
+                if (BlockRange().TryGetUse(node, &use))
+                {
+                    use.ReplaceWith(tmp1);
+                }
+                else
+                {
+                    tmp1->SetUnusedValue();
+                }
+
+                BlockRange().Remove(node);
+                return LowerNode(tmp1);
             }
 
             default:
@@ -5840,7 +5947,82 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
                 else
                 {
                     assert(simdSize == 16);
-                    idx = m_compiler->gtNewIconNode(0xFF, TYP_INT);
+                    if (m_compiler->compOpportunisticallyDependsOn(InstructionSet_AVX))
+                    {
+                        tmp1 = m_compiler->gtNewSimdBinOpNode(GT_MUL, simdType, op1, op2, simdBaseType, simdSize);
+                        BlockRange().InsertAfter(node, tmp1);
+                        LowerNode(tmp1);
+
+                        node->Op(1) = tmp1;
+                        LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
+                        ReplaceWithLclVar(tmp1Use);
+                        tmp1 = node->Op(1);
+
+                        tmp3 = m_compiler->gtClone(tmp1);
+                        BlockRange().InsertAfter(tmp1, tmp3);
+
+                        idx = m_compiler->gtNewIconNode(0xB1, TYP_INT);
+                        BlockRange().InsertAfter(tmp3, idx);
+
+                        tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType,
+                                                                    simdSize);
+                        BlockRange().InsertAfter(idx, tmp2);
+                        LowerNode(tmp2);
+
+                        tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp2, tmp3, simdBaseType, simdSize);
+                        BlockRange().InsertAfter(tmp2, tmp1);
+                        LowerNode(tmp1);
+
+                        node->Op(1) = tmp1;
+                        LIR::Use tmp1Use2(BlockRange(), &node->Op(1), node);
+                        ReplaceWithLclVar(tmp1Use2);
+                        tmp1 = node->Op(1);
+
+                        tmp3 = m_compiler->gtClone(tmp1);
+                        BlockRange().InsertAfter(tmp1, tmp3);
+
+                        idx = m_compiler->gtNewIconNode(0x4E, TYP_INT);
+                        BlockRange().InsertAfter(tmp3, idx);
+
+                        tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType,
+                                                                    simdSize);
+                        BlockRange().InsertAfter(idx, tmp2);
+                        LowerNode(tmp2);
+
+                        tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp3, tmp2, simdBaseType, simdSize);
+                        BlockRange().InsertAfter(tmp2, tmp1);
+
+                        if (!varTypeIsSIMD(node->gtType))
+                        {
+                            // We're producing a scalar result, so we only need the result in element 0
+                            //
+                            // However, doing that would break/limit CSE and requires a partial write so
+                            // it's better to just broadcast the value to the entire vector
+
+                            LowerNode(tmp1);
+
+                            tmp3 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, NI_Vector128_ToScalar,
+                                                                        simdBaseType, simdSize);
+                            BlockRange().InsertAfter(tmp1, tmp3);
+                            tmp1 = tmp3;
+                        }
+
+                        LIR::Use use;
+
+                        if (BlockRange().TryGetUse(node, &use))
+                        {
+                            use.ReplaceWith(tmp1);
+                        }
+                        else
+                        {
+                            tmp2->SetUnusedValue();
+                        }
+
+                        BlockRange().Remove(node);
+                        return LowerNode(tmp1);
+                    }
+
+                    idx = m_compiler->gtNewIconNode(0x7F, TYP_INT);
                 }
                 BlockRange().InsertBefore(node, idx);
 
@@ -5882,30 +6064,63 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
                 //   var tmp3 = Avx.DotProduct(op1, op2, 0x31);
                 //   return tmp3.ToScalar();
 
+                if (m_compiler->compOpportunisticallyDependsOn(InstructionSet_AVX))
+                {
+                    idx = m_compiler->gtNewIconNode(0x1, TYP_INT);
+                    BlockRange().InsertBefore(node, idx);
+
+                    tmp1 = m_compiler->gtNewSimdBinOpNode(GT_MUL, simdType, op1, op2, simdBaseType, simdSize);
+                    BlockRange().InsertAfter(idx, tmp1);
+                    LowerNode(tmp1);
+
+                    node->Op(1) = tmp1;
+                    LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
+                    ReplaceWithLclVar(tmp1Use);
+                    tmp1 = node->Op(1);
+
+                    tmp2 = m_compiler->gtClone(tmp1);
+                    BlockRange().InsertAfter(tmp1, tmp2);
+
+                    tmp1 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType,
+                                                                simdSize);
+                    BlockRange().InsertAfter(tmp2, tmp1);
+                    LowerNode(tmp1);
+
+                    tmp3 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp1, tmp2, simdBaseType, simdSize);
+                    BlockRange().InsertAfter(tmp1, tmp3);
+
+                    if (!varTypeIsSIMD(node->gtType))
+                    {
+                        // We're producing a scalar result, so we only need the result in element 0
+                        //
+                        // However, doing that would break/limit CSE and requires a partial write so
+                        // it's better to just broadcast the value to the entire vector
+
+                        LowerNode(tmp3);
+
+                        tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp3, NI_Vector128_ToScalar, simdBaseType,
+                                                                    simdSize);
+                        BlockRange().InsertAfter(tmp3, tmp2);
+                        tmp3 = tmp2;
+                    }
+
+                    LIR::Use use;
+
+                    if (BlockRange().TryGetUse(node, &use))
+                    {
+                        use.ReplaceWith(tmp3);
+                    }
+                    else
+                    {
+                        tmp3->SetUnusedValue();
+                    }
+
+                    BlockRange().Remove(node);
+                    return LowerNode(tmp3);
+                }
+
                 idx = m_compiler->gtNewIconNode(0x33, TYP_INT);
                 BlockRange().InsertBefore(node, idx);
-
-                if (varTypeIsSIMD(node->gtType))
-                {
-                    // We're producing a vector result, so just emit DotProduct directly
-                    node->ResetHWIntrinsicId(NI_X86Base_DotProduct, m_compiler, op1, op2, idx);
-                }
-                else
-                {
-                    // We're producing a scalar result, so we only need the result in element 0
-                    //
-                    // However, doing that would break/limit CSE and requires a partial write so
-                    // it's better to just broadcast the value to the entire vector
-
-                    tmp3 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, op1, op2, idx, NI_X86Base_DotProduct,
-                                                                simdBaseType, simdSize);
-                    BlockRange().InsertAfter(idx, tmp3);
-                    LowerNode(tmp3);
-
-                    node->ResetHWIntrinsicId(NI_Vector128_ToScalar, tmp3);
-                }
-
-                return LowerNode(node);
             }
 
             default:

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -6015,7 +6015,7 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
                         }
                         else
                         {
-                            tmp2->SetUnusedValue();
+                            tmp1->SetUnusedValue();
                         }
 
                         BlockRange().Remove(node);

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5908,9 +5908,7 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
             return LowerHWIntrinsicDotInnerMulSum(node);
         }
 
-        tmp1 = node->gtNext;
-        BlockRange().Remove(node);
-        return tmp1;
+        return node->gtNext;
     }
 
     if (simdSize == 32)

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5777,8 +5777,8 @@ GenTree* Lowering::LowerHWIntrinsicDotInnerMulSum(GenTreeHWIntrinsic* node)
     if (simdSize == 32)
     {
         node->Op(1) = tmp1;
-        LIR::Use tmp1Use3(BlockRange(), &node->Op(1), node);
-        ReplaceWithLclVar(tmp1Use3);
+        LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
+        ReplaceWithLclVar(tmp1Use);
         tmp1 = node->Op(1);
 
         tmp2 = m_compiler->gtClone(tmp1);

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5668,11 +5668,13 @@ GenTree* Lowering::LowerHWIntrinsicWithElement(GenTreeHWIntrinsic* node)
 }
 
 // Lowering::LowerHWIntrinsicDotInnerMulSum: Helper function to Lowering::LowerHWIntrinsicDot. Performs the MUL+SUM
-// sequence, ensuring that
-//     the inner SIMD sum result is present in every lane.
+// sequence, ensuring that the inner SIMD sum result is present in every lane.
 //
 //   Arguments:
-//     - node: DotProduct intrinsic node
+//      node - DotProduct intrinsic node
+//
+//   Returns:
+//     Lowered node with the SIMD SUM(MUL(node->op1, node->op2)) sequence.
 //
 GenTree* Lowering::LowerHWIntrinsicDotInnerMulSum(GenTreeHWIntrinsic* node)
 {
@@ -5703,6 +5705,29 @@ GenTree* Lowering::LowerHWIntrinsicDotInnerMulSum(GenTreeHWIntrinsic* node)
     {
         case TYP_FLOAT:
         {
+            // For TYP_FLOAT, this is roughly the following managed code:
+            // Vector128:
+            //   var tmp1 = op1 * op2;
+            //   var tmp3 = tmp1;
+            //   var tmp2 = Avx.Permute(tmp1, 0xB1);
+            //   tmp1 = tmp2 + tmp3;
+            //   tmp3 = tmp1;
+            //   tmp2 = Avx.Permute(tmp1, 0x4E);
+            //   tmp1 = tmp2 + tmp3;
+            //   return tmp1;
+            //
+            // Vector256:
+            //   var tmp1 = op1 * op2;
+            //   var tmp3 = tmp1;
+            //   var tmp2 = Avx.Permute(tmp1, 0xB1);
+            //   tmp1 = tmp2 + tmp3;
+            //   tmp3 = tmp1;
+            //   tmp2 = Avx.Permute(tmp1, 0x4E);
+            //   tmp1 = tmp2 + tmp3;
+            //   tmp3 = tmp2 = tmp1;
+            //   tmp2 = Avx.Permute2x128(tmp2, tmp3, 0x1);
+            //   tmp1 = tmp1 + tmp2;
+            //   return tmp1;
             node->Op(1) = tmp1;
             LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
             ReplaceWithLclVar(tmp1Use);
@@ -5745,6 +5770,23 @@ GenTree* Lowering::LowerHWIntrinsicDotInnerMulSum(GenTreeHWIntrinsic* node)
 
         case TYP_DOUBLE:
         {
+            // For TYP_DOUBLE, this is roughly the following managed code:
+            // Vector128:
+            //   var tmp1 = op1 * op2;
+            //   var tmp2 = tmp1;
+            //   tmp1 = Avx.Permute(tmp1, 0x5);
+            //   tmp1 = tmp1 + tmp2;
+            //   return tmp1;
+            //
+            // Vector256:
+            //   var tmp1 = op1 * op2;
+            //   var tmp2 = tmp1;
+            //   tmp1 = Avx.Permute(tmp1, 0x5);
+            //   tmp1 = tmp1 + tmp2;
+            //   tmp3 = tmp2 = tmp1;
+            //   tmp2 = Avx.Permute2x128(tmp2, tmp3, 0x1);
+            //   tmp1 = tmp1 + tmp2;
+            //   return tmp1;
             idx = m_compiler->gtNewIconNode(simdSize == 32 ? 0x5 : 0x1, TYP_INT);
             BlockRange().InsertAfter(tmp1, idx);
 
@@ -5834,85 +5876,39 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
 
     NamedIntrinsic horizontalAdd = NI_Illegal;
     NamedIntrinsic shuffle       = NI_Illegal;
+    LIR::Use       use;
 
     if (m_compiler->compOpportunisticallyDependsOn(InstructionSet_AVX) && varTypeIsFloating(simdBaseType) &&
         (simdSize == 16 || simdSize == 32))
     {
-        // When AVX is available, use a MUL+PERMUTE+ADD sequence to calculate DotProduct.
-        //
-        // For TYP_FLOAT, this is roughly the following managed code:
-        // Vector128:
-        //   var tmp1 = op1 * op2;
-        //   var tmp3 = tmp1;
-        //   var tmp2 = Avx.Permute(tmp1, 0xB1);
-        //   tmp1 = tmp2 + tmp3;
-        //   tmp3 = tmp1;
-        //   tmp2 = Avx.Permute(tmp1, 0x4E);
-        //   tmp1 = tmp2 + tmp3;
-        //   return tmp1;
-        //
-        // Vector256:
-        //   var tmp1 = op1 * op2;
-        //   var tmp3 = tmp1;
-        //   var tmp2 = Avx.Permute(tmp1, 0xB1);
-        //   tmp1 = tmp2 + tmp3;
-        //   tmp3 = tmp1;
-        //   tmp2 = Avx.Permute(tmp1, 0x4E);
-        //   tmp1 = tmp2 + tmp3;
-        //   tmp3 = tmp2 = tmp1;
-        //   tmp2 = Avx.Permute2x128(tmp2, tmp3, 0x1);
-        //   tmp1 = tmp1 + tmp2;
-        //   return tmp1;
-        //
-        // For TYP_DOUBLE, this is roughly the following managed code:
-        // Vector128:
-        //   var tmp1 = op1 * op2;
-        //   var tmp2 = tmp1;
-        //   tmp1 = Avx.Permute(tmp1, 0x5);
-        //   tmp1 = tmp1 + tmp2;
-        //   return tmp1;
-        //
-        // Vector256:
-        //   var tmp1 = op1 * op2;
-        //   var tmp2 = tmp1;
-        //   tmp1 = Avx.Permute(tmp1, 0x5);
-        //   tmp1 = tmp1 + tmp2;
-        //   tmp3 = tmp2 = tmp1;
-        //   tmp2 = Avx.Permute2x128(tmp2, tmp3, 0x1);
-        //   tmp1 = tmp1 + tmp2;
-        //   return tmp1;
-
-        tmp1 = LowerHWIntrinsicDotInnerMulSum(node);
-
-        if (!varTypeIsSIMD(node->gtType))
-        {
-            // We're producing a scalar result, so we only need the result in element 0
-            //
-            // However, doing that would break/limit CSE and requires a partial write so
-            // it's better to just broadcast the value to the entire vector
-
-            LowerNode(tmp1);
-
-            tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(node->gtType, tmp1,
-                                                        simdSize == 16 ? NI_Vector128_ToScalar : NI_Vector256_ToScalar,
-                                                        simdBaseType, simdSize);
-            BlockRange().InsertAfter(tmp1, tmp2);
-            tmp1 = tmp2;
-        }
-
-        LIR::Use use;
-
         if (BlockRange().TryGetUse(node, &use))
         {
-            use.ReplaceWith(tmp1);
-        }
-        else
-        {
-            tmp1->SetUnusedValue();
-        }
+            tmp1 = LowerHWIntrinsicDotInnerMulSum(node);
 
+            if (!varTypeIsSIMD(node->gtType))
+            {
+                // We're producing a scalar result, so we only need the result in element 0
+                //
+                // However, doing that would break/limit CSE and requires a partial write so
+                // it's better to just broadcast the value to the entire vector
+
+                LowerNode(tmp1);
+
+                tmp2 =
+                    m_compiler->gtNewSimdHWIntrinsicNode(node->gtType, tmp1,
+                                                         simdSize == 16 ? NI_Vector128_ToScalar : NI_Vector256_ToScalar,
+                                                         simdBaseType, simdSize);
+                BlockRange().InsertAfter(tmp1, tmp2);
+                tmp1 = tmp2;
+            }
+
+            use.ReplaceWith(tmp1);
+            BlockRange().Remove(node);
+            return LowerNode(tmp1);
+        }
+        tmp1 = node->gtNext;
         BlockRange().Remove(node);
-        return LowerNode(tmp1);
+        return tmp1;
     }
 
     if (simdSize == 32)
@@ -6406,8 +6402,6 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
     }
 
     // We're producing a vector result, so just return the result directly
-    LIR::Use use;
-
     if (BlockRange().TryGetUse(node, &use))
     {
         use.ReplaceWith(tmp1);

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5718,32 +5718,21 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
             {
                 assert(m_compiler->compIsaSupportedDebugOnly(InstructionSet_AVX));
 
-                // We will be constructing the following parts:
-                //   idx  =    CNS_INT       int    0xFF
-                //          /--*  op1  simd16
-                //          +--*  op2  simd16
-                //          +--*  idx  int
-                //   tmp1 = *  HWINTRINSIC   simd32 T DotProduct
-                //          /--*  tmp1 simd32
-                //          *  STORE_LCL_VAR simd32
-                //   tmp1 =    LCL_VAR       simd32
-                //   tmp2 =    LCL_VAR       simd32
-                //   tmp3 =    LCL_VAR       simd32
-                //          /--*  tmp2 simd32
-                //          +--*  tmp3 simd32
-                //          +--*  CNS_INT    int    0x01
-                //   tmp2 = *  HWINTRINSIC   simd32 T Permute
-                //          /--*  tmp1 simd32
-                //          +--*  tmp2 simd32
-                //   node = *  HWINTRINSIC   simd32 T Add
-
                 // This is roughly the following managed code:
-                //   var tmp1 = Avx.DotProduct(op1, op2, 0xFF);
-                //   var tmp2 = Avx.Permute2x128(tmp1, tmp1, 0x4E);
-                //   return Avx.Add(tmp1, tmp2);
+                //   var tmp1 = op1 * op2;
+                //   var tmp3 = tmp1;
+                //   var tmp2 = Avx.Permute(tmp1, 0xB1);
+                //   tmp1 = tmp2 + tmp3;
+                //   tmp3 = tmp1;
+                //   tmp2 = Avx.Permute(tmp1, 0x4E);
+                //   tmp1 = tmp2 + tmp3;
+                //   tmp3 = tmp2 = tmp1;
+                //   tmp2 = Avx.Permute2x128(tmp2, tmp3, 0x1);
+                //   tmp1 = tmp1 + tmp2;
+                //   return tmp1;
 
                 tmp1 = m_compiler->gtNewSimdBinOpNode(GT_MUL, simdType, op1, op2, simdBaseType, simdSize);
-                BlockRange().InsertAfter(node, tmp1);
+                BlockRange().InsertBefore(node, tmp1);
                 LowerNode(tmp1);
 
                 node->Op(1) = tmp1;
@@ -5784,6 +5773,7 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
 
                 tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp3, tmp2, simdBaseType, simdSize);
                 BlockRange().InsertAfter(tmp2, tmp1);
+                LowerNode(tmp1);
 
                 node->Op(1) = tmp1;
                 LIR::Use tmp1Use3(BlockRange(), &node->Op(1), node);
@@ -5827,6 +5817,16 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
             {
                 assert(m_compiler->compIsaSupportedDebugOnly(InstructionSet_AVX));
 
+                // This is roughly the following managed code:
+                //   var tmp1 = op1 * op2;
+                //   var tmp2 = tmp1;
+                //   var tmp3 = Avx.Permute(tmp1, 0x5);
+                //   tmp1 = tmp2 + tmp3;
+                //   tmp3 = tmp2 = tmp1;
+                //   tmp2 = Avx.Permute2x128(tmp2, tmp3, 0x1);
+                //   tmp1 = tmp1 + tmp2;
+                //   return tmp1;
+
                 idx = m_compiler->gtNewIconNode(0x5, TYP_INT);
                 BlockRange().InsertBefore(node, idx);
 
@@ -5849,6 +5849,7 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
 
                 tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp3, tmp2, simdBaseType, simdSize);
                 BlockRange().InsertAfter(tmp3, tmp1);
+                LowerNode(tmp1);
 
                 node->Op(1) = tmp1;
                 LIR::Use tmp1Use3(BlockRange(), &node->Op(1), node);
@@ -5881,7 +5882,7 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
 
                     LowerNode(tmp1);
 
-                    tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, NI_Vector256_ToScalar, simdBaseType,
+                    tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(node->gtType, tmp1, NI_Vector256_ToScalar, simdBaseType,
                                                                 simdSize);
                     BlockRange().InsertAfter(tmp1, tmp2);
                     tmp1 = tmp2;
@@ -5949,8 +5950,18 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
                     assert(simdSize == 16);
                     if (m_compiler->compOpportunisticallyDependsOn(InstructionSet_AVX))
                     {
+                        // This is roughly the following managed code:
+                        //   var tmp1 = op1 * op2;
+                        //   var tmp3 = tmp1;
+                        //   var tmp2 = Avx.Permute(tmp1, 0xB1);
+                        //   tmp1 = tmp2 + tmp3;
+                        //   tmp3 = tmp1;
+                        //   tmp2 = Avx.Permute(tmp1, 0x4E);
+                        //   tmp1 = tmp2 + tmp3;
+                        //   return tmp1;
+
                         tmp1 = m_compiler->gtNewSimdBinOpNode(GT_MUL, simdType, op1, op2, simdBaseType, simdSize);
-                        BlockRange().InsertAfter(node, tmp1);
+                        BlockRange().InsertBefore(node, tmp1);
                         LowerNode(tmp1);
 
                         node->Op(1) = tmp1;
@@ -6001,7 +6012,7 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
 
                             LowerNode(tmp1);
 
-                            tmp3 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, NI_Vector128_ToScalar,
+                            tmp3 = m_compiler->gtNewSimdHWIntrinsicNode(node->gtType, tmp1, NI_Vector128_ToScalar,
                                                                         simdBaseType, simdSize);
                             BlockRange().InsertAfter(tmp1, tmp3);
                             tmp1 = tmp3;
@@ -6066,6 +6077,13 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
 
                 if (m_compiler->compOpportunisticallyDependsOn(InstructionSet_AVX))
                 {
+                    // This is roughly the following managed code:
+                    //   var tmp1 = op1 * op2;
+                    //   var tmp2 = tmp1;
+                    //   tmp1 = Avx.Permute(tmp1, 0x5);
+                    //   var tmp3 = tmp1 + tmp2;
+                    //   return tmp3;
+
                     idx = m_compiler->gtNewIconNode(0x1, TYP_INT);
                     BlockRange().InsertBefore(node, idx);
 
@@ -6098,8 +6116,8 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
 
                         LowerNode(tmp3);
 
-                        tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp3, NI_Vector128_ToScalar, simdBaseType,
-                                                                    simdSize);
+                        tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(node->gtType, tmp3, NI_Vector128_ToScalar,
+                                                                    simdBaseType, simdSize);
                         BlockRange().InsertAfter(tmp3, tmp2);
                         tmp3 = tmp2;
                     }

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5667,6 +5667,141 @@ GenTree* Lowering::LowerHWIntrinsicWithElement(GenTreeHWIntrinsic* node)
     return nextNode;
 }
 
+// Lowering::LowerHWIntrinsicDotInnerMulSum: Helper function to Lowering::LowerHWIntrinsicDot. Performs the MUL+SUM
+// sequence, ensuring that
+//     the inner SIMD sum result is present in every lane.
+//
+//   Arguments:
+//     - node: DotProduct intrinsic node
+//
+GenTree* Lowering::LowerHWIntrinsicDotInnerMulSum(GenTreeHWIntrinsic* node)
+{
+    NamedIntrinsic intrinsicId  = node->GetHWIntrinsicId();
+    var_types      simdBaseType = node->GetSimdBaseType();
+    unsigned       simdSize     = node->GetSimdSize();
+    var_types      simdType     = Compiler::getSIMDTypeForSize(simdSize);
+
+    assert((intrinsicId == NI_Vector128_Dot) || (intrinsicId == NI_Vector256_Dot));
+    assert(m_compiler->compIsaSupportedDebugOnly(InstructionSet_AVX));
+    assert(varTypeIsSIMD(simdType));
+    assert(varTypeIsFloating(simdBaseType));
+    assert(simdSize == 16 || simdSize == 32);
+
+    GenTree* op1 = node->Op(1);
+    GenTree* op2 = node->Op(2);
+
+    GenTree* idx  = nullptr;
+    GenTree* tmp1 = nullptr;
+    GenTree* tmp2 = nullptr;
+    GenTree* tmp3 = nullptr;
+
+    tmp1 = m_compiler->gtNewSimdBinOpNode(GT_MUL, simdType, op1, op2, simdBaseType, simdSize);
+    BlockRange().InsertBefore(node, tmp1);
+    LowerNode(tmp1);
+
+    switch (simdBaseType)
+    {
+        case TYP_FLOAT:
+        {
+            node->Op(1) = tmp1;
+            LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
+            ReplaceWithLclVar(tmp1Use);
+            tmp1 = node->Op(1);
+
+            tmp3 = m_compiler->gtClone(tmp1);
+            BlockRange().InsertAfter(tmp1, tmp3);
+
+            idx = m_compiler->gtNewIconNode(0xB1, TYP_INT);
+            BlockRange().InsertAfter(tmp3, idx);
+
+            tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType, simdSize);
+            BlockRange().InsertAfter(idx, tmp2);
+            LowerNode(tmp2);
+
+            tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp2, tmp3, simdBaseType, simdSize);
+            BlockRange().InsertAfter(tmp2, tmp1);
+            LowerNode(tmp1);
+
+            node->Op(1) = tmp1;
+            LIR::Use tmp1Use2(BlockRange(), &node->Op(1), node);
+            ReplaceWithLclVar(tmp1Use2);
+            tmp1 = node->Op(1);
+
+            tmp3 = m_compiler->gtClone(tmp1);
+            BlockRange().InsertAfter(tmp1, tmp3);
+
+            idx = m_compiler->gtNewIconNode(0x4E, TYP_INT);
+            BlockRange().InsertAfter(tmp3, idx);
+
+            tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType, simdSize);
+            BlockRange().InsertAfter(idx, tmp2);
+            LowerNode(tmp2);
+
+            tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp3, tmp2, simdBaseType, simdSize);
+            BlockRange().InsertAfter(tmp2, tmp1);
+
+            break;
+        }
+
+        case TYP_DOUBLE:
+        {
+            idx = m_compiler->gtNewIconNode(simdSize == 32 ? 0x5 : 0x1, TYP_INT);
+            BlockRange().InsertAfter(tmp1, idx);
+
+            node->Op(1) = tmp1;
+            LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
+            ReplaceWithLclVar(tmp1Use);
+            tmp1 = node->Op(1);
+
+            tmp2 = m_compiler->gtClone(tmp1);
+            BlockRange().InsertAfter(idx, tmp2);
+
+            tmp1 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType, simdSize);
+            BlockRange().InsertAfter(tmp2, tmp1);
+            LowerNode(tmp1);
+
+            tmp3 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp1, tmp2, simdBaseType, simdSize);
+            BlockRange().InsertAfter(tmp1, tmp3);
+
+            tmp1 = tmp3;
+
+            break;
+        }
+
+        default:
+        {
+            unreached();
+        }
+    }
+
+    if (simdSize == 32)
+    {
+        node->Op(1) = tmp1;
+        LIR::Use tmp1Use3(BlockRange(), &node->Op(1), node);
+        ReplaceWithLclVar(tmp1Use3);
+        tmp1 = node->Op(1);
+
+        tmp2 = m_compiler->gtClone(tmp1);
+        BlockRange().InsertAfter(tmp1, tmp2);
+
+        tmp3 = m_compiler->gtClone(tmp2);
+        BlockRange().InsertAfter(tmp2, tmp3);
+
+        idx = m_compiler->gtNewIconNode(0x01, TYP_INT);
+        BlockRange().InsertAfter(tmp3, idx);
+
+        tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp2, tmp3, idx, NI_AVX_Permute2x128, simdBaseType,
+                                                    simdSize);
+        BlockRange().InsertAfter(idx, tmp2);
+        LowerNode(tmp2);
+
+        tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp1, tmp2, simdBaseType, simdSize);
+        BlockRange().InsertAfter(tmp2, tmp1);
+    }
+
+    return tmp1;
+}
+
 //----------------------------------------------------------------------------------------------
 // Lowering::LowerHWIntrinsicDot: Lowers a Vector128 or Vector256 Dot call
 //
@@ -5700,6 +5835,86 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
     NamedIntrinsic horizontalAdd = NI_Illegal;
     NamedIntrinsic shuffle       = NI_Illegal;
 
+    if (m_compiler->compOpportunisticallyDependsOn(InstructionSet_AVX) && varTypeIsFloating(simdBaseType) &&
+        (simdSize == 16 || simdSize == 32))
+    {
+        // When AVX is available, use a MUL+PERMUTE+ADD sequence to calculate DotProduct.
+        //
+        // For TYP_FLOAT, this is roughly the following managed code:
+        // Vector128:
+        //   var tmp1 = op1 * op2;
+        //   var tmp3 = tmp1;
+        //   var tmp2 = Avx.Permute(tmp1, 0xB1);
+        //   tmp1 = tmp2 + tmp3;
+        //   tmp3 = tmp1;
+        //   tmp2 = Avx.Permute(tmp1, 0x4E);
+        //   tmp1 = tmp2 + tmp3;
+        //   return tmp1;
+        //
+        // Vector256:
+        //   var tmp1 = op1 * op2;
+        //   var tmp3 = tmp1;
+        //   var tmp2 = Avx.Permute(tmp1, 0xB1);
+        //   tmp1 = tmp2 + tmp3;
+        //   tmp3 = tmp1;
+        //   tmp2 = Avx.Permute(tmp1, 0x4E);
+        //   tmp1 = tmp2 + tmp3;
+        //   tmp3 = tmp2 = tmp1;
+        //   tmp2 = Avx.Permute2x128(tmp2, tmp3, 0x1);
+        //   tmp1 = tmp1 + tmp2;
+        //   return tmp1;
+        //
+        // For TYP_DOUBLE, this is roughly the following managed code:
+        // Vector128:
+        //   var tmp1 = op1 * op2;
+        //   var tmp2 = tmp1;
+        //   tmp1 = Avx.Permute(tmp1, 0x5);
+        //   tmp1 = tmp1 + tmp2;
+        //   return tmp1;
+        //
+        // Vector256:
+        //   var tmp1 = op1 * op2;
+        //   var tmp2 = tmp1;
+        //   tmp1 = Avx.Permute(tmp1, 0x5);
+        //   tmp1 = tmp1 + tmp2;
+        //   tmp3 = tmp2 = tmp1;
+        //   tmp2 = Avx.Permute2x128(tmp2, tmp3, 0x1);
+        //   tmp1 = tmp1 + tmp2;
+        //   return tmp1;
+
+        tmp1 = LowerHWIntrinsicDotInnerMulSum(node);
+
+        if (!varTypeIsSIMD(node->gtType))
+        {
+            // We're producing a scalar result, so we only need the result in element 0
+            //
+            // However, doing that would break/limit CSE and requires a partial write so
+            // it's better to just broadcast the value to the entire vector
+
+            LowerNode(tmp1);
+
+            tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(node->gtType, tmp1,
+                                                        simdSize == 16 ? NI_Vector128_ToScalar : NI_Vector256_ToScalar,
+                                                        simdBaseType, simdSize);
+            BlockRange().InsertAfter(tmp1, tmp2);
+            tmp1 = tmp2;
+        }
+
+        LIR::Use use;
+
+        if (BlockRange().TryGetUse(node, &use))
+        {
+            use.ReplaceWith(tmp1);
+        }
+        else
+        {
+            tmp1->SetUnusedValue();
+        }
+
+        BlockRange().Remove(node);
+        return LowerNode(tmp1);
+    }
+
     if (simdSize == 32)
     {
         switch (simdBaseType)
@@ -5712,195 +5927,6 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
                 assert(m_compiler->compIsaSupportedDebugOnly(InstructionSet_AVX2));
                 horizontalAdd = NI_AVX2_HorizontalAdd;
                 break;
-            }
-
-            case TYP_FLOAT:
-            {
-                assert(m_compiler->compIsaSupportedDebugOnly(InstructionSet_AVX));
-
-                // This is roughly the following managed code:
-                //   var tmp1 = op1 * op2;
-                //   var tmp3 = tmp1;
-                //   var tmp2 = Avx.Permute(tmp1, 0xB1);
-                //   tmp1 = tmp2 + tmp3;
-                //   tmp3 = tmp1;
-                //   tmp2 = Avx.Permute(tmp1, 0x4E);
-                //   tmp1 = tmp2 + tmp3;
-                //   tmp3 = tmp2 = tmp1;
-                //   tmp2 = Avx.Permute2x128(tmp2, tmp3, 0x1);
-                //   tmp1 = tmp1 + tmp2;
-                //   return tmp1;
-
-                tmp1 = m_compiler->gtNewSimdBinOpNode(GT_MUL, simdType, op1, op2, simdBaseType, simdSize);
-                BlockRange().InsertBefore(node, tmp1);
-                LowerNode(tmp1);
-
-                node->Op(1) = tmp1;
-                LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
-                ReplaceWithLclVar(tmp1Use);
-                tmp1 = node->Op(1);
-
-                tmp3 = m_compiler->gtClone(tmp1);
-                BlockRange().InsertAfter(tmp1, tmp3);
-
-                idx = m_compiler->gtNewIconNode(0xB1, TYP_INT);
-                BlockRange().InsertAfter(tmp3, idx);
-
-                tmp2 =
-                    m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType, simdSize);
-                BlockRange().InsertAfter(idx, tmp2);
-                LowerNode(tmp2);
-
-                tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp2, tmp3, simdBaseType, simdSize);
-                BlockRange().InsertAfter(tmp2, tmp1);
-                LowerNode(tmp1);
-
-                node->Op(1) = tmp1;
-                LIR::Use tmp1Use2(BlockRange(), &node->Op(1), node);
-                ReplaceWithLclVar(tmp1Use2);
-                tmp1 = node->Op(1);
-
-                tmp3 = m_compiler->gtClone(tmp1);
-                BlockRange().InsertAfter(tmp1, tmp3);
-
-                idx = m_compiler->gtNewIconNode(0x4E, TYP_INT);
-                BlockRange().InsertAfter(tmp3, idx);
-
-                tmp2 =
-                    m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType, simdSize);
-                BlockRange().InsertAfter(idx, tmp2);
-                LowerNode(tmp2);
-
-                tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp3, tmp2, simdBaseType, simdSize);
-                BlockRange().InsertAfter(tmp2, tmp1);
-                LowerNode(tmp1);
-
-                node->Op(1) = tmp1;
-                LIR::Use tmp1Use3(BlockRange(), &node->Op(1), node);
-                ReplaceWithLclVar(tmp1Use3);
-                tmp1 = node->Op(1);
-
-                tmp2 = m_compiler->gtClone(tmp1);
-                BlockRange().InsertAfter(tmp1, tmp2);
-
-                tmp3 = m_compiler->gtClone(tmp2);
-                BlockRange().InsertAfter(tmp2, tmp3);
-
-                idx = m_compiler->gtNewIconNode(0x01, TYP_INT);
-                BlockRange().InsertAfter(tmp3, idx);
-
-                tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp2, tmp3, idx, NI_AVX_Permute2x128,
-                                                            simdBaseType, simdSize);
-                BlockRange().InsertAfter(idx, tmp2);
-                LowerNode(tmp2);
-
-                tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp1, tmp2, simdBaseType, simdSize);
-                BlockRange().InsertAfter(tmp2, tmp1);
-
-                // We're producing a vector result, so just return the result directly
-                LIR::Use use;
-
-                if (BlockRange().TryGetUse(node, &use))
-                {
-                    use.ReplaceWith(tmp1);
-                }
-                else
-                {
-                    tmp1->SetUnusedValue();
-                }
-
-                BlockRange().Remove(node);
-                return LowerNode(tmp1);
-            }
-
-            case TYP_DOUBLE:
-            {
-                assert(m_compiler->compIsaSupportedDebugOnly(InstructionSet_AVX));
-
-                // This is roughly the following managed code:
-                //   var tmp1 = op1 * op2;
-                //   var tmp2 = tmp1;
-                //   var tmp3 = Avx.Permute(tmp1, 0x5);
-                //   tmp1 = tmp2 + tmp3;
-                //   tmp3 = tmp2 = tmp1;
-                //   tmp2 = Avx.Permute2x128(tmp2, tmp3, 0x1);
-                //   tmp1 = tmp1 + tmp2;
-                //   return tmp1;
-
-                idx = m_compiler->gtNewIconNode(0x5, TYP_INT);
-                BlockRange().InsertBefore(node, idx);
-
-                tmp1 = m_compiler->gtNewSimdBinOpNode(GT_MUL, simdType, op1, op2, simdBaseType, simdSize);
-                BlockRange().InsertAfter(idx, tmp1);
-                LowerNode(tmp1);
-
-                node->Op(1) = tmp1;
-                LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
-                ReplaceWithLclVar(tmp1Use);
-                tmp1 = node->Op(1);
-
-                tmp2 = m_compiler->gtClone(tmp1);
-                BlockRange().InsertAfter(tmp1, tmp2);
-
-                tmp3 =
-                    m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType, simdSize);
-                BlockRange().InsertAfter(tmp2, tmp3);
-                LowerNode(tmp3);
-
-                tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp3, tmp2, simdBaseType, simdSize);
-                BlockRange().InsertAfter(tmp3, tmp1);
-                LowerNode(tmp1);
-
-                node->Op(1) = tmp1;
-                LIR::Use tmp1Use3(BlockRange(), &node->Op(1), node);
-                ReplaceWithLclVar(tmp1Use3);
-                tmp1 = node->Op(1);
-
-                tmp2 = m_compiler->gtClone(tmp1);
-                BlockRange().InsertAfter(tmp1, tmp2);
-
-                tmp3 = m_compiler->gtClone(tmp2);
-                BlockRange().InsertAfter(tmp2, tmp3);
-
-                idx = m_compiler->gtNewIconNode(0x01, TYP_INT);
-                BlockRange().InsertAfter(tmp3, idx);
-
-                tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp2, tmp3, idx, NI_AVX_Permute2x128,
-                                                            simdBaseType, simdSize);
-                BlockRange().InsertAfter(idx, tmp2);
-                LowerNode(tmp2);
-
-                tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp1, tmp2, simdBaseType, simdSize);
-                BlockRange().InsertAfter(tmp2, tmp1);
-
-                if (!varTypeIsSIMD(node->gtType))
-                {
-                    // We're producing a scalar result, so we only need the result in element 0
-                    //
-                    // However, doing that would break/limit CSE and requires a partial write so
-                    // it's better to just broadcast the value to the entire vector
-
-                    LowerNode(tmp1);
-
-                    tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(node->gtType, tmp1, NI_Vector256_ToScalar, simdBaseType,
-                                                                simdSize);
-                    BlockRange().InsertAfter(tmp1, tmp2);
-                    tmp1 = tmp2;
-                }
-
-                LIR::Use use;
-
-                if (BlockRange().TryGetUse(node, &use))
-                {
-                    use.ReplaceWith(tmp1);
-                }
-                else
-                {
-                    tmp1->SetUnusedValue();
-                }
-
-                BlockRange().Remove(node);
-                return LowerNode(tmp1);
             }
 
             default:
@@ -5948,91 +5974,6 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
                 else
                 {
                     assert(simdSize == 16);
-                    if (m_compiler->compOpportunisticallyDependsOn(InstructionSet_AVX))
-                    {
-                        // This is roughly the following managed code:
-                        //   var tmp1 = op1 * op2;
-                        //   var tmp3 = tmp1;
-                        //   var tmp2 = Avx.Permute(tmp1, 0xB1);
-                        //   tmp1 = tmp2 + tmp3;
-                        //   tmp3 = tmp1;
-                        //   tmp2 = Avx.Permute(tmp1, 0x4E);
-                        //   tmp1 = tmp2 + tmp3;
-                        //   return tmp1;
-
-                        tmp1 = m_compiler->gtNewSimdBinOpNode(GT_MUL, simdType, op1, op2, simdBaseType, simdSize);
-                        BlockRange().InsertBefore(node, tmp1);
-                        LowerNode(tmp1);
-
-                        node->Op(1) = tmp1;
-                        LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
-                        ReplaceWithLclVar(tmp1Use);
-                        tmp1 = node->Op(1);
-
-                        tmp3 = m_compiler->gtClone(tmp1);
-                        BlockRange().InsertAfter(tmp1, tmp3);
-
-                        idx = m_compiler->gtNewIconNode(0xB1, TYP_INT);
-                        BlockRange().InsertAfter(tmp3, idx);
-
-                        tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType,
-                                                                    simdSize);
-                        BlockRange().InsertAfter(idx, tmp2);
-                        LowerNode(tmp2);
-
-                        tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp2, tmp3, simdBaseType, simdSize);
-                        BlockRange().InsertAfter(tmp2, tmp1);
-                        LowerNode(tmp1);
-
-                        node->Op(1) = tmp1;
-                        LIR::Use tmp1Use2(BlockRange(), &node->Op(1), node);
-                        ReplaceWithLclVar(tmp1Use2);
-                        tmp1 = node->Op(1);
-
-                        tmp3 = m_compiler->gtClone(tmp1);
-                        BlockRange().InsertAfter(tmp1, tmp3);
-
-                        idx = m_compiler->gtNewIconNode(0x4E, TYP_INT);
-                        BlockRange().InsertAfter(tmp3, idx);
-
-                        tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType,
-                                                                    simdSize);
-                        BlockRange().InsertAfter(idx, tmp2);
-                        LowerNode(tmp2);
-
-                        tmp1 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp3, tmp2, simdBaseType, simdSize);
-                        BlockRange().InsertAfter(tmp2, tmp1);
-
-                        if (!varTypeIsSIMD(node->gtType))
-                        {
-                            // We're producing a scalar result, so we only need the result in element 0
-                            //
-                            // However, doing that would break/limit CSE and requires a partial write so
-                            // it's better to just broadcast the value to the entire vector
-
-                            LowerNode(tmp1);
-
-                            tmp3 = m_compiler->gtNewSimdHWIntrinsicNode(node->gtType, tmp1, NI_Vector128_ToScalar,
-                                                                        simdBaseType, simdSize);
-                            BlockRange().InsertAfter(tmp1, tmp3);
-                            tmp1 = tmp3;
-                        }
-
-                        LIR::Use use;
-
-                        if (BlockRange().TryGetUse(node, &use))
-                        {
-                            use.ReplaceWith(tmp1);
-                        }
-                        else
-                        {
-                            tmp1->SetUnusedValue();
-                        }
-
-                        BlockRange().Remove(node);
-                        return LowerNode(tmp1);
-                    }
-
                     idx = m_compiler->gtNewIconNode(0xFF, TYP_INT);
                 }
                 BlockRange().InsertBefore(node, idx);
@@ -6074,68 +6015,6 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
                 // This is roughly the following managed code:
                 //   var tmp3 = Avx.DotProduct(op1, op2, 0x31);
                 //   return tmp3.ToScalar();
-
-                if (m_compiler->compOpportunisticallyDependsOn(InstructionSet_AVX))
-                {
-                    // This is roughly the following managed code:
-                    //   var tmp1 = op1 * op2;
-                    //   var tmp2 = tmp1;
-                    //   tmp1 = Avx.Permute(tmp1, 0x5);
-                    //   var tmp3 = tmp1 + tmp2;
-                    //   return tmp3;
-
-                    idx = m_compiler->gtNewIconNode(0x1, TYP_INT);
-                    BlockRange().InsertBefore(node, idx);
-
-                    tmp1 = m_compiler->gtNewSimdBinOpNode(GT_MUL, simdType, op1, op2, simdBaseType, simdSize);
-                    BlockRange().InsertAfter(idx, tmp1);
-                    LowerNode(tmp1);
-
-                    node->Op(1) = tmp1;
-                    LIR::Use tmp1Use(BlockRange(), &node->Op(1), node);
-                    ReplaceWithLclVar(tmp1Use);
-                    tmp1 = node->Op(1);
-
-                    tmp2 = m_compiler->gtClone(tmp1);
-                    BlockRange().InsertAfter(tmp1, tmp2);
-
-                    tmp1 = m_compiler->gtNewSimdHWIntrinsicNode(simdType, tmp1, idx, NI_AVX_Permute, simdBaseType,
-                                                                simdSize);
-                    BlockRange().InsertAfter(tmp2, tmp1);
-                    LowerNode(tmp1);
-
-                    tmp3 = m_compiler->gtNewSimdBinOpNode(GT_ADD, simdType, tmp1, tmp2, simdBaseType, simdSize);
-                    BlockRange().InsertAfter(tmp1, tmp3);
-
-                    if (!varTypeIsSIMD(node->gtType))
-                    {
-                        // We're producing a scalar result, so we only need the result in element 0
-                        //
-                        // However, doing that would break/limit CSE and requires a partial write so
-                        // it's better to just broadcast the value to the entire vector
-
-                        LowerNode(tmp3);
-
-                        tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(node->gtType, tmp3, NI_Vector128_ToScalar,
-                                                                    simdBaseType, simdSize);
-                        BlockRange().InsertAfter(tmp3, tmp2);
-                        tmp3 = tmp2;
-                    }
-
-                    LIR::Use use;
-
-                    if (BlockRange().TryGetUse(node, &use))
-                    {
-                        use.ReplaceWith(tmp3);
-                    }
-                    else
-                    {
-                        tmp3->SetUnusedValue();
-                    }
-
-                    BlockRange().Remove(node);
-                    return LowerNode(tmp3);
-                }
 
                 idx = m_compiler->gtNewIconNode(0x33, TYP_INT);
                 BlockRange().InsertBefore(node, idx);

--- a/src/coreclr/jit/lowerxarch.cpp
+++ b/src/coreclr/jit/lowerxarch.cpp
@@ -5841,7 +5841,29 @@ GenTree* Lowering::LowerHWIntrinsicDotInnerMulSum(GenTreeHWIntrinsic* node)
         BlockRange().InsertAfter(tmp2, tmp1);
     }
 
-    return tmp1;
+    if (!varTypeIsSIMD(node->gtType))
+    {
+        // We're producing a scalar result, so we only need the result in element 0
+        //
+        // However, doing that would break/limit CSE and requires a partial write so
+        // it's better to just broadcast the value to the entire vector
+
+        LowerNode(tmp1);
+
+        tmp2 = m_compiler->gtNewSimdHWIntrinsicNode(node->gtType, tmp1,
+                                                    simdSize == 16 ? NI_Vector128_ToScalar : NI_Vector256_ToScalar,
+                                                    simdBaseType, simdSize);
+        BlockRange().InsertAfter(tmp1, tmp2);
+        tmp1 = tmp2;
+    }
+
+    LIR::Use use;
+    bool     foundUse = BlockRange().TryGetUse(node, &use);
+    assert(foundUse);
+
+    use.ReplaceWith(tmp1);
+    BlockRange().Remove(node);
+    return LowerNode(tmp1);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -5883,29 +5905,9 @@ GenTree* Lowering::LowerHWIntrinsicDot(GenTreeHWIntrinsic* node)
     {
         if (BlockRange().TryGetUse(node, &use))
         {
-            tmp1 = LowerHWIntrinsicDotInnerMulSum(node);
-
-            if (!varTypeIsSIMD(node->gtType))
-            {
-                // We're producing a scalar result, so we only need the result in element 0
-                //
-                // However, doing that would break/limit CSE and requires a partial write so
-                // it's better to just broadcast the value to the entire vector
-
-                LowerNode(tmp1);
-
-                tmp2 =
-                    m_compiler->gtNewSimdHWIntrinsicNode(node->gtType, tmp1,
-                                                         simdSize == 16 ? NI_Vector128_ToScalar : NI_Vector256_ToScalar,
-                                                         simdBaseType, simdSize);
-                BlockRange().InsertAfter(tmp1, tmp2);
-                tmp1 = tmp2;
-            }
-
-            use.ReplaceWith(tmp1);
-            BlockRange().Remove(node);
-            return LowerNode(tmp1);
+            return LowerHWIntrinsicDotInnerMulSum(node);
         }
+
         tmp1 = node->gtNext;
         BlockRange().Remove(node);
         return tmp1;


### PR DESCRIPTION
On x86 when AVX is available, it is generally more performant to calculate dot products using a multiply+permute+addition sequence instead of `vdpps/vdppd`.

This PR modifies lowering to use the multiply+permute+addition sequence if AVX is available.


```
| Namespace                       | Type                     | Method       | Job        | Toolchain                   | Mean     | Error     | StdDev    | Median   | Min      | Max      | Ratio | RatioSD | Allocated | Alloc Ratio |
|-------------------------------- |------------------------- |------------- |----------- |---------------------------- |---------:|----------:|----------:|---------:|---------:|---------:|------:|--------:|----------:|------------:|
| System.Numerics.Tests           | Perf_Plane               | DotBenchmark | Job-IJGDOK | \base\Core_Root\corerun.exe | 1.708 ns | 0.0591 ns | 0.0680 ns | 1.673 ns | 1.645 ns | 1.840 ns |  1.00 |    0.00 |         - |          NA |
| System.Numerics.Tests           | Perf_Plane               | DotBenchmark | Job-XUUJWJ | \diff\Core_Root\corerun.exe | 1.295 ns | 0.0098 ns | 0.0076 ns | 1.296 ns | 1.284 ns | 1.308 ns |  0.76 |    0.03 |         - |          NA |
|                                 |                          |              |            |                             |          |           |           |          |          |          |       |         |           |             |
| System.Numerics.Tests           | Perf_Quaternion          | DotBenchmark | Job-IJGDOK | \base\Core_Root\corerun.exe | 1.655 ns | 0.0324 ns | 0.0333 ns | 1.638 ns | 1.628 ns | 1.740 ns |  1.00 |    0.00 |         - |          NA |
| System.Numerics.Tests           | Perf_Quaternion          | DotBenchmark | Job-XUUJWJ | \diff\Core_Root\corerun.exe | 1.302 ns | 0.0288 ns | 0.0308 ns | 1.287 ns | 1.278 ns | 1.373 ns |  0.79 |    0.02 |         - |          NA |
|                                 |                          |              |            |                             |          |           |           |          |          |          |       |         |           |             |
| System.Numerics.Tests           | Perf_Vector2             | DotBenchmark | Job-IJGDOK | \base\Core_Root\corerun.exe | 1.664 ns | 0.0231 ns | 0.0205 ns | 1.667 ns | 1.632 ns | 1.709 ns |  1.00 |    0.00 |         - |          NA |
| System.Numerics.Tests           | Perf_Vector2             | DotBenchmark | Job-XUUJWJ | \diff\Core_Root\corerun.exe | 1.295 ns | 0.0167 ns | 0.0130 ns | 1.294 ns | 1.276 ns | 1.313 ns |  0.78 |    0.01 |         - |          NA |
|                                 |                          |              |            |                             |          |           |           |          |          |          |       |         |           |             |
| System.Runtime.Intrinsics.Tests | Perf_Vector128Float      | DotBenchmark | Job-IJGDOK | \base\Core_Root\corerun.exe | 1.706 ns | 0.0923 ns | 0.1063 ns | 1.648 ns | 1.624 ns | 1.961 ns |  1.00 |    0.00 |         - |          NA |
| System.Runtime.Intrinsics.Tests | Perf_Vector128Float      | DotBenchmark | Job-XUUJWJ | \diff\Core_Root\corerun.exe | 1.314 ns | 0.0369 ns | 0.0425 ns | 1.302 ns | 1.273 ns | 1.420 ns |  0.77 |    0.05 |         - |          NA |
|                                 |                          |              |            |                             |          |           |           |          |          |          |       |         |           |             |
| System.Runtime.Intrinsics.Tests | Perf_Vector128Of<Double> | DotBenchmark | Job-IJGDOK | \base\Core_Root\corerun.exe | 1.476 ns | 0.0282 ns | 0.0313 ns | 1.474 ns | 1.443 ns | 1.534 ns |  1.00 |    0.00 |         - |          NA |
| System.Runtime.Intrinsics.Tests | Perf_Vector128Of<Double> | DotBenchmark | Job-XUUJWJ | \diff\Core_Root\corerun.exe | 1.131 ns | 0.0327 ns | 0.0377 ns | 1.116 ns | 1.098 ns | 1.219 ns |  0.77 |    0.03 |         - |          NA |
|                                 |                          |              |            |                             |          |           |           |          |          |          |       |         |           |             |
| System.Runtime.Intrinsics.Tests | Perf_Vector128Of<Single> | DotBenchmark | Job-IJGDOK | \base\Core_Root\corerun.exe | 1.652 ns | 0.0278 ns | 0.0260 ns | 1.651 ns | 1.620 ns | 1.710 ns |  1.00 |    0.00 |         - |          NA |
| System.Runtime.Intrinsics.Tests | Perf_Vector128Of<Single> | DotBenchmark | Job-XUUJWJ | \diff\Core_Root\corerun.exe | 1.301 ns | 0.0238 ns | 0.0199 ns | 1.301 ns | 1.274 ns | 1.347 ns |  0.79 |    0.02 |         - |          NA |
|                                 |                          |              |            |                             |          |           |           |          |          |          |       |         |           |             |
| System.Numerics.Tests           | Perf_VectorOf<Double>    | DotBenchmark | Job-IJGDOK | \base\Core_Root\corerun.exe | 1.474 ns | 0.0163 ns | 0.0127 ns | 1.468 ns | 1.462 ns | 1.501 ns |  1.00 |    0.00 |         - |          NA |
| System.Numerics.Tests           | Perf_VectorOf<Double>    | DotBenchmark | Job-XUUJWJ | \diff\Core_Root\corerun.exe | 1.291 ns | 0.0109 ns | 0.0085 ns | 1.289 ns | 1.282 ns | 1.311 ns |  0.88 |    0.01 |         - |          NA |
|                                 |                          |              |            |                             |          |           |           |          |          |          |       |         |           |             |
| System.Numerics.Tests           | Perf_VectorOf<Single>    | DotBenchmark | Job-IJGDOK | \base\Core_Root\corerun.exe | 1.887 ns | 0.0756 ns | 0.0841 ns | 1.853 ns | 1.811 ns | 2.095 ns |  1.00 |    0.00 |         - |          NA |
| System.Numerics.Tests           | Perf_VectorOf<Single>    | DotBenchmark | Job-XUUJWJ | \diff\Core_Root\corerun.exe | 1.295 ns | 0.0105 ns | 0.0082 ns | 1.293 ns | 1.286 ns | 1.311 ns |  0.69 |    0.03 |         - |          NA |
|                                 |                          |              |            |                             |          |           |           |          |          |          |       |         |           |             |
| System.Numerics.Tests           | Perf_Vector3             | DotBenchmark | Job-IJGDOK | \base\Core_Root\corerun.exe | 1.704 ns | 0.0420 ns | 0.0467 ns | 1.702 ns | 1.641 ns | 1.806 ns |  1.00 |    0.00 |         - |          NA |
| System.Numerics.Tests           | Perf_Vector3             | DotBenchmark | Job-XUUJWJ | \diff\Core_Root\corerun.exe | 1.331 ns | 0.0423 ns | 0.0488 ns | 1.317 ns | 1.283 ns | 1.412 ns |  0.78 |    0.03 |         - |          NA |
|                                 |                          |              |            |                             |          |           |           |          |          |          |       |         |           |             |
| System.Numerics.Tests           | Perf_Vector4             | DotBenchmark | Job-IJGDOK | \base\Core_Root\corerun.exe | 1.675 ns | 0.0402 ns | 0.0430 ns | 1.666 ns | 1.633 ns | 1.781 ns |  1.00 |    0.00 |         - |          NA |
| System.Numerics.Tests           | Perf_Vector4             | DotBenchmark | Job-XUUJWJ | \diff\Core_Root\corerun.exe | 1.293 ns | 0.0133 ns | 0.0111 ns | 1.289 ns | 1.280 ns | 1.315 ns |  0.77 |    0.02 |         - |          NA |
```

<details>

<summary>Disasm</summary>

### System.Runtime.Intrinsics.Tests.Perf_Vector128Of<Single>

#### Base

```assembly
; System.Runtime.Intrinsics.Tests.Perf_Vector128Of`1[[System.Single, System.Private.CoreLib]].DotBenchmark()
       vpcmpeqd  xmm0,xmm0,xmm0
       vpcmpeqd  xmm1,xmm1,xmm1
       vdpps     xmm0,xmm0,xmm1,0FF
       ret
; Total bytes of code 15
```

#### Diff

```assembly
; System.Runtime.Intrinsics.Tests.Perf_Vector128Of`1[[System.Single, System.Private.CoreLib]].DotBenchmark()
       vpcmpeqd  xmm0,xmm0,xmm0
       vpcmpeqd  xmm1,xmm1,xmm1
       vmulps    xmm0,xmm1,xmm0
       vpermilps xmm1,xmm0,0B1
       vaddps    xmm0,xmm1,xmm0
       vpermilps xmm1,xmm0,4E
       vaddps    xmm0,xmm1,xmm0
       ret
; Total bytes of code 33
```

### System.Runtime.Intrinsics.Tests.Perf_Vector128Of<Double>

#### Base

```assembly
; System.Runtime.Intrinsics.Tests.Perf_Vector128Of`1[[System.Double, System.Private.CoreLib]].DotBenchmark()
       vpcmpeqd  xmm0,xmm0,xmm0
       vpcmpeqd  xmm1,xmm1,xmm1
       vdppd     xmm0,xmm0,xmm1,33
       ret
; Total bytes of code 15
```

#### Diff

```assembly
; System.Runtime.Intrinsics.Tests.Perf_Vector128Of`1[[System.Double, System.Private.CoreLib]].DotBenchmark()
       vpcmpeqd  xmm0,xmm0,xmm0
       vpcmpeqd  xmm1,xmm1,xmm1
       vmulpd    xmm0,xmm1,xmm0
       vpermilpd xmm1,xmm0,1
       vaddpd    xmm0,xmm1,xmm0
       ret
; Total bytes of code 23
```

### System.Runtime.Intrinsics.Tests.Perf_VectorOf<Single>

#### Base

```assembly
; System.Numerics.Tests.Perf_VectorOf`1[[System.Single, System.Private.CoreLib]].DotBenchmark()
       vbroadcastss ymm0,dword ptr [0C5A4]
       vdpps     ymm0,ymm0,[0C5C0],0FF
       vperm2f128 ymm1,ymm0,ymm0,1
       vaddps    ymm0,ymm1,ymm0
       vzeroupper
       ret
; Total bytes of code 33
```

#### Diff

```assembly
; System.Numerics.Tests.Perf_VectorOf`1[[System.Single, System.Private.CoreLib]].DotBenchmark()
       vbroadcastss ymm0,dword ptr [0C8E8]
       vmulps    ymm0,ymm0,dword bcst [0C8EC]
       vpermilps ymm1,ymm0,0B1
       vaddps    ymm0,ymm1,ymm0
       vpermilps ymm1,ymm0,4E
       vaddps    ymm0,ymm0,ymm1
       vperm2f128 ymm1,ymm0,ymm0,1
       vaddps    ymm0,ymm1,ymm0
       vzeroupper
       ret
; Total bytes of code 53
```

### System.Runtime.Intrinsics.Tests.Perf_VectorOf<Double>

#### Base

```assembly
; System.Numerics.Tests.Perf_VectorOf`1[[System.Double, System.Private.CoreLib]].DotBenchmark()
       vbroadcastsd ymm0,qword ptr [0E6D8]
       vmulpd    ymm0,ymm0,qword bcst [0E6E0]
       vhaddpd   ymm0,ymm0,ymm0
       vperm2f128 ymm1,ymm0,ymm0,1
       vaddpd    ymm0,ymm1,ymm0
       vzeroupper
       ret
; Total bytes of code 37
```


#### Diff

```assembly
; System.Numerics.Tests.Perf_VectorOf`1[[System.Double, System.Private.CoreLib]].DotBenchmark()
       vbroadcastsd ymm0,qword ptr [0E880]
       vmulpd    ymm0,ymm0,qword bcst [0E888]
       vpermilpd ymm1,ymm0,5
       vaddpd    ymm0,ymm1,ymm0
       vperm2f128 ymm1,ymm0,ymm0,1
       vaddpd    ymm0,ymm1,ymm0
       vzeroupper
       ret
; Total bytes of code 43
```




</details>