### PR TITLE
[RyuJIT] Always insert r2r indirection cell at the end of the args list

### DIFF
--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -1780,12 +1780,10 @@ void CallArgs::AddFinalArgsAndDetermineABIInfo(Compiler* comp, GenTreeCall* call
         // Push the stub address onto the list of arguments.
         NewCallArg indirCellAddrArg =
             NewCallArg::Primitive(indirectCellAddress).WellKnown(WellKnownArg::R2RIndirectionCell);
-#ifdef TARGET_WASM
-        // On wasm we need to ensure we put the indirection cell address last in LIR, after the SP and formal args.
+        // On wasm we need to ensure we put the indirection cell address last in LIR, after the SP and formal args,
+        // because it is used as the portable entry point (PEP) which is the last argument slot. On other targets
+        // it shouldn't matter whether we evaluate the argument early or late since it goes into a dedicated register.
         PushBack(comp, indirCellAddrArg);
-#else
-        InsertAfterThisOrFirst(comp, indirCellAddrArg);
-#endif // TARGET_WASM
     }
 #endif // defined(FEATURE_READYTORUN)
 


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/125669 but universal. Wasm needs the indirection cell at the end of the arguments list, and on other arches it shouldn't matter where we put it. Opening draft PR to generate diffs on CI.