### PR TITLE
fix: libraryimportgenerator.unit.tests crashing on linux-x64 mono

### DIFF
--- a/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGeneratorOptions.cs
+++ b/src/libraries/System.Runtime.InteropServices/gen/LibraryImportGenerator/LibraryImportGeneratorOptions.cs
@@ -7,8 +7,10 @@ namespace Microsoft.Interop
 {
     internal sealed record LibraryImportGeneratorOptions(bool GenerateForwarders, bool UseMarshalType)
     {
-        public LibraryImportGeneratorOptions(AnalyzerConfigOptions options)
-            : this(options.GenerateForwarders(), options.UseMarshalType())
+            public LibraryImportGeneratorOptions(AnalyzerConfigOptions options)
+            : this(
+                options.GenerateForwarders(),
+                options.UseMarshalType())
         {
         }
     }


### PR DESCRIPTION
Fixes #100800