### PR TITLE
More reduction of PointerMemoryManager

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/ContentInfoAsn.xml
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/ContentInfoAsn.xml
@@ -2,7 +2,8 @@
 <asn:Sequence
   xmlns:asn="http://schemas.dot.net/asnxml/201808/"
   name="ContentInfoAsn"
-  namespace="System.Security.Cryptography.Asn1.Pkcs7">
+  namespace="System.Security.Cryptography.Asn1.Pkcs7"
+  emitType="both">
 
   <!--
     https://tools.ietf.org/html/rfc5652#section-3

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/ContentInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/ContentInfoAsn.xml.cs
@@ -102,4 +102,95 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             sequenceReader.ThrowIfNotEmpty();
         }
     }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal ref partial struct ValueContentInfoAsn
+    {
+        internal string ContentType;
+        internal ReadOnlySpan<byte> Content;
+
+        internal readonly void Encode(AsnWriter writer)
+        {
+            Encode(writer, Asn1Tag.Sequence);
+        }
+
+        internal readonly void Encode(AsnWriter writer, Asn1Tag tag)
+        {
+            writer.PushSequence(tag);
+
+            try
+            {
+                writer.WriteObjectIdentifier(ContentType);
+            }
+            catch (ArgumentException e)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+            }
+            writer.PushSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+
+            try
+            {
+                writer.WriteEncodedValue(Content);
+            }
+            catch (ArgumentException e)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+            }
+            writer.PopSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+            writer.PopSequence(tag);
+        }
+
+        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueContentInfoAsn decoded)
+        {
+            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+        }
+
+        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueContentInfoAsn decoded)
+        {
+            try
+            {
+                ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
+
+                DecodeCore(ref reader, expectedTag, out decoded);
+                reader.ThrowIfNotEmpty();
+            }
+            catch (AsnContentException e)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+            }
+        }
+
+        internal static void Decode(scoped ref ValueAsnReader reader, out ValueContentInfoAsn decoded)
+        {
+            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+        }
+
+        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueContentInfoAsn decoded)
+        {
+            try
+            {
+                DecodeCore(ref reader, expectedTag, out decoded);
+            }
+            catch (AsnContentException e)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+            }
+        }
+
+        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueContentInfoAsn decoded)
+        {
+            decoded = default;
+            ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
+            ValueAsnReader explicitReader;
+
+            decoded.ContentType = sequenceReader.ReadObjectIdentifier();
+
+            explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
+            decoded.Content = explicitReader.ReadEncodedValue();
+            explicitReader.ThrowIfNotEmpty();
+
+
+            sequenceReader.ThrowIfNotEmpty();
+        }
+    }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/CngPkcs8.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CngPkcs8.cs
@@ -151,62 +151,56 @@ namespace System.Security.Cryptography
             return ret;
         }
 
-        internal static unsafe Pkcs8Response ImportEncryptedPkcs8PrivateKey(
+        internal static Pkcs8Response ImportEncryptedPkcs8PrivateKey(
             ReadOnlySpan<byte> passwordBytes,
             ReadOnlySpan<byte> source,
             out int bytesRead)
         {
-            fixed (byte* ptr = &MemoryMarshal.GetReference(source))
+            try
             {
-                using (MemoryManager<byte> manager = new PointerMemoryManager<byte>(ptr, source.Length))
+                // Since there's no bytes-based-password PKCS8 import in CNG, just do the decryption
+                // here and call the unencrypted PKCS8 import.
+                ArraySegment<byte> decrypted = KeyFormatHelper.DecryptPkcs8(
+                    passwordBytes,
+                    source,
+                    out bytesRead);
+
+                Span<byte> decryptedSpan = decrypted;
+
+                try
                 {
+                    return ImportPkcs8(decryptedSpan);
+                }
+                catch (CryptographicException e)
+                {
+                    AsnWriter? pkcs8ZeroPublicKey = RewritePkcs8ECPrivateKeyWithZeroPublicKey(decryptedSpan);
+
+                    if (pkcs8ZeroPublicKey == null)
+                    {
+                        throw new CryptographicException(SR.Cryptography_Pkcs8_EncryptedReadFailed, e);
+                    }
+
                     try
                     {
-                        // Since there's no bytes-based-password PKCS8 import in CNG, just do the decryption
-                        // here and call the unencrypted PKCS8 import.
-                        ArraySegment<byte> decrypted = KeyFormatHelper.DecryptPkcs8(
-                            passwordBytes,
-                            manager.Memory,
-                            out bytesRead);
-
-                        Span<byte> decryptedSpan = decrypted;
-
-                        try
-                        {
-                            return ImportPkcs8(decryptedSpan);
-                        }
-                        catch (CryptographicException e)
-                        {
-                            AsnWriter? pkcs8ZeroPublicKey = RewritePkcs8ECPrivateKeyWithZeroPublicKey(decryptedSpan);
-
-                            if (pkcs8ZeroPublicKey == null)
-                            {
-                                throw new CryptographicException(SR.Cryptography_Pkcs8_EncryptedReadFailed, e);
-                            }
-
-                            try
-                            {
-                                return ImportPkcs8(pkcs8ZeroPublicKey);
-                            }
-                            catch (CryptographicException)
-                            {
-                                throw new CryptographicException(SR.Cryptography_Pkcs8_EncryptedReadFailed, e);
-                            }
-                        }
-                        finally
-                        {
-                            CryptoPool.Return(decrypted);
-                        }
+                        return ImportPkcs8(pkcs8ZeroPublicKey);
                     }
-                    catch (AsnContentException e)
+                    catch (CryptographicException)
                     {
                         throw new CryptographicException(SR.Cryptography_Pkcs8_EncryptedReadFailed, e);
                     }
                 }
+                finally
+                {
+                    CryptoPool.Return(decrypted);
+                }
+            }
+            catch (AsnContentException e)
+            {
+                throw new CryptographicException(SR.Cryptography_Pkcs8_EncryptedReadFailed, e);
             }
         }
 
-        internal static unsafe Pkcs8Response ImportEncryptedPkcs8PrivateKey(
+        internal static Pkcs8Response ImportEncryptedPkcs8PrivateKey(
            ReadOnlySpan<char> password,
            ReadOnlySpan<byte> source,
            out int bytesRead)
@@ -222,60 +216,50 @@ namespace System.Security.Cryptography
 
                 source = source.Slice(0, len);
 
-                fixed (byte* ptr = &MemoryMarshal.GetReference(source))
+                try
                 {
-                    using (MemoryManager<byte> manager = new PointerMemoryManager<byte>(ptr, source.Length))
+                    bytesRead = len;
+                    return ImportPkcs8(source, password);
+                }
+                catch (CryptographicException)
+                {
+                }
+
+                ArraySegment<byte> decrypted = KeyFormatHelper.DecryptPkcs8(password, source, out int innerRead);
+                Span<byte> decryptedSpan = decrypted;
+
+                try
+                {
+                    if (innerRead != len)
                     {
-                        try
-                        {
-                            bytesRead = len;
-                            return ImportPkcs8(source, password);
-                        }
-                        catch (CryptographicException)
-                        {
-                        }
-
-                        ArraySegment<byte> decrypted = KeyFormatHelper.DecryptPkcs8(
-                            password,
-                            manager.Memory.Slice(0, len),
-                            out int innerRead);
-
-                        Span<byte> decryptedSpan = decrypted;
-
-                        try
-                        {
-                            if (innerRead != len)
-                            {
-                                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
-                            }
-
-                            bytesRead = len;
-                            return ImportPkcs8(decryptedSpan);
-                        }
-                        catch (CryptographicException e)
-                        {
-                            AsnWriter? pkcs8ZeroPublicKey = RewritePkcs8ECPrivateKeyWithZeroPublicKey(decryptedSpan);
-
-                            if (pkcs8ZeroPublicKey == null)
-                            {
-                                throw new CryptographicException(SR.Cryptography_Pkcs8_EncryptedReadFailed, e);
-                            }
-
-                            try
-                            {
-                                bytesRead = len;
-                                return ImportPkcs8(pkcs8ZeroPublicKey);
-                            }
-                            catch (CryptographicException)
-                            {
-                                throw new CryptographicException(SR.Cryptography_Pkcs8_EncryptedReadFailed, e);
-                            }
-                        }
-                        finally
-                        {
-                            CryptoPool.Return(decrypted);
-                        }
+                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
                     }
+
+                    bytesRead = len;
+                    return ImportPkcs8(decryptedSpan);
+                }
+                catch (CryptographicException e)
+                {
+                    AsnWriter? pkcs8ZeroPublicKey = RewritePkcs8ECPrivateKeyWithZeroPublicKey(decryptedSpan);
+
+                    if (pkcs8ZeroPublicKey == null)
+                    {
+                        throw new CryptographicException(SR.Cryptography_Pkcs8_EncryptedReadFailed, e);
+                    }
+
+                    try
+                    {
+                        bytesRead = len;
+                        return ImportPkcs8(pkcs8ZeroPublicKey);
+                    }
+                    catch (CryptographicException)
+                    {
+                        throw new CryptographicException(SR.Cryptography_Pkcs8_EncryptedReadFailed, e);
+                    }
+                }
+                finally
+                {
+                    CryptoPool.Return(decrypted);
                 }
             }
             catch (AsnContentException e)
@@ -332,7 +316,7 @@ namespace System.Security.Cryptography
 
                 return KeyFormatHelper.ReencryptPkcs8(
                     randomString,
-                    rented.AsMemory(0, rentWritten),
+                    rented.AsSpan(0, rentWritten),
                     passwordBytes,
                     pbeParameters);
             }
@@ -369,7 +353,7 @@ namespace System.Security.Cryptography
 
                 return KeyFormatHelper.ReencryptPkcs8(
                     password,
-                    rented.AsMemory(0, rentWritten),
+                    rented.AsSpan(0, rentWritten),
                     password,
                     pbeParameters);
             }

--- a/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
@@ -212,7 +212,7 @@ namespace System.Security.Cryptography
 
         internal static ArraySegment<byte> DecryptPkcs8(
             ReadOnlySpan<char> inputPassword,
-            ReadOnlyMemory<byte> source,
+            ReadOnlySpan<byte> source,
             out int bytesRead)
         {
             return DecryptPkcs8(
@@ -224,7 +224,7 @@ namespace System.Security.Cryptography
 
         internal static ArraySegment<byte> DecryptPkcs8(
             ReadOnlySpan<byte> inputPasswordBytes,
-            ReadOnlyMemory<byte> source,
+            ReadOnlySpan<byte> source,
             out int bytesRead)
         {
             return DecryptPkcs8(
@@ -240,76 +240,64 @@ namespace System.Security.Cryptography
             ReadOnlySpanFunc<byte, T> keyReader,
             out int bytesRead)
         {
-            fixed (byte* pointer = source)
-            {
-                using (PointerMemoryManager<byte> manager = new(pointer, source.Length))
-                {
-                    ArraySegment<byte> decrypted = DecryptPkcs8(password, manager.Memory, out bytesRead);
+            ArraySegment<byte> decrypted = DecryptPkcs8(password, source, out bytesRead);
 
-                    try
-                    {
-                        ValueAsnReader reader = new(decrypted, AsnEncodingRules.BER);
-                        reader.ReadEncodedValue();
-                        reader.ThrowIfNotEmpty();
-                        return keyReader(decrypted);
-                    }
-                    catch (AsnContentException e)
-                    {
-                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
-                    }
-                    finally
-                    {
-                        CryptoPool.Return(decrypted);
-                    }
-                }
+            try
+            {
+                ValueAsnReader reader = new(decrypted, AsnEncodingRules.BER);
+                reader.ReadEncodedValue();
+                reader.ThrowIfNotEmpty();
+                return keyReader(decrypted);
+            }
+            catch (AsnContentException e)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+            }
+            finally
+            {
+                CryptoPool.Return(decrypted);
             }
         }
 
-        internal static unsafe T DecryptPkcs8<T>(
+        internal static T DecryptPkcs8<T>(
             ReadOnlySpan<byte> passwordBytes,
             ReadOnlySpan<byte> source,
             ReadOnlySpanFunc<byte, T> keyReader,
             out int bytesRead)
         {
-            fixed (byte* pointer = source)
-            {
-                using (PointerMemoryManager<byte> manager = new(pointer, source.Length))
-                {
-                    ArraySegment<byte> decrypted = KeyFormatHelper.DecryptPkcs8(passwordBytes, manager.Memory, out bytesRead);
-                    ValueAsnReader reader = new(decrypted, AsnEncodingRules.BER);
-                    reader.ReadEncodedValue();
+            ArraySegment<byte> decrypted = KeyFormatHelper.DecryptPkcs8(passwordBytes, source, out bytesRead);
+            ValueAsnReader reader = new(decrypted, AsnEncodingRules.BER);
+            reader.ReadEncodedValue();
 
-                    try
-                    {
-                        reader.ThrowIfNotEmpty();
-                        return keyReader(decrypted);
-                    }
-                    catch (AsnContentException e)
-                    {
-                        throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
-                    }
-                    finally
-                    {
-                        CryptoPool.Return(decrypted);
-                    }
-                }
+            try
+            {
+                reader.ThrowIfNotEmpty();
+                return keyReader(decrypted);
+            }
+            catch (AsnContentException e)
+            {
+                throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
+            }
+            finally
+            {
+                CryptoPool.Return(decrypted);
             }
         }
 
         private static ArraySegment<byte> DecryptPkcs8(
             ReadOnlySpan<char> inputPassword,
             ReadOnlySpan<byte> inputPasswordBytes,
-            ReadOnlyMemory<byte> source,
+            ReadOnlySpan<byte> source,
             out int bytesRead)
         {
             int localRead;
-            EncryptedPrivateKeyInfoAsn epki;
+            ValueEncryptedPrivateKeyInfoAsn epki;
 
             try
             {
-                ValueAsnReader reader = new ValueAsnReader(source.Span, AsnEncodingRules.BER);
+                ValueAsnReader reader = new ValueAsnReader(source, AsnEncodingRules.BER);
                 localRead = reader.PeekEncodedValue().Length;
-                EncryptedPrivateKeyInfoAsn.Decode(ref reader, source, out epki);
+                ValueEncryptedPrivateKeyInfoAsn.Decode(ref reader, out epki);
             }
             catch (AsnContentException e)
             {
@@ -326,7 +314,7 @@ namespace System.Security.Cryptography
                     epki.EncryptionAlgorithm,
                     inputPassword,
                     inputPasswordBytes,
-                    epki.EncryptedData.Span,
+                    epki.EncryptedData,
                     decrypted);
 
                 bytesRead = localRead;
@@ -342,7 +330,7 @@ namespace System.Security.Cryptography
 
         internal static AsnWriter ReencryptPkcs8(
             ReadOnlySpan<char> inputPassword,
-            ReadOnlyMemory<byte> current,
+            ReadOnlySpan<byte> current,
             ReadOnlySpan<char> newPassword,
             PbeParameters pbeParameters)
         {
@@ -378,7 +366,7 @@ namespace System.Security.Cryptography
 
         internal static AsnWriter ReencryptPkcs8(
             ReadOnlySpan<char> inputPassword,
-            ReadOnlyMemory<byte> current,
+            ReadOnlySpan<byte> current,
             ReadOnlySpan<byte> newPasswordBytes,
             PbeParameters pbeParameters)
         {

--- a/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
@@ -234,7 +234,7 @@ namespace System.Security.Cryptography
                 out bytesRead);
         }
 
-        internal static unsafe T DecryptPkcs8<T>(
+        internal static T DecryptPkcs8<T>(
             ReadOnlySpan<char> password,
             ReadOnlySpan<byte> source,
             ReadOnlySpanFunc<byte, T> keyReader,
@@ -266,11 +266,11 @@ namespace System.Security.Cryptography
             out int bytesRead)
         {
             ArraySegment<byte> decrypted = KeyFormatHelper.DecryptPkcs8(passwordBytes, source, out bytesRead);
-            ValueAsnReader reader = new(decrypted, AsnEncodingRules.BER);
-            reader.ReadEncodedValue();
 
             try
             {
+                ValueAsnReader reader = new(decrypted, AsnEncodingRules.BER);
+                reader.ReadEncodedValue();
                 reader.ThrowIfNotEmpty();
                 return keyReader(decrypted);
             }

--- a/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs8PrivateKeyInfo.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Pkcs/Pkcs8PrivateKeyInfo.cs
@@ -177,7 +177,7 @@ namespace System.Security.Cryptography.Pkcs
         {
             ArraySegment<byte> decrypted = KeyFormatHelper.DecryptPkcs8(
                 password,
-                source,
+                source.Span,
                 out int localRead);
 
             Memory<byte> decryptedMemory = decrypted;
@@ -208,7 +208,7 @@ namespace System.Security.Cryptography.Pkcs
         {
             ArraySegment<byte> decrypted = KeyFormatHelper.DecryptPkcs8(
                 passwordBytes,
-                source,
+                source.Span,
                 out int localRead);
 
             Memory<byte> decryptedMemory = decrypted;

--- a/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Pkcs12.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Pkcs12.cs
@@ -1112,7 +1112,7 @@ namespace System.Security.Cryptography.X509Certificates
                             {
                                 decrypted = KeyFormatHelper.DecryptPkcs8(
                                     password,
-                                    bag.BagValue,
+                                    bag.BagValue.Span,
                                     out contentRead);
 
                                 try
@@ -1140,7 +1140,7 @@ namespace System.Security.Cryptography.X509Certificates
                             {
                                 decrypted = KeyFormatHelper.DecryptPkcs8(
                                     password,
-                                    bag.BagValue,
+                                    bag.BagValue.Span,
                                     out contentRead);
 
                                 try

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Asn.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Asn.cs
@@ -11,30 +11,23 @@ namespace Internal.Cryptography.Pal.AnyOS
 {
     internal sealed partial class ManagedPkcsPal : PkcsPal
     {
-        public override unsafe Oid GetEncodedMessageType(ReadOnlySpan<byte> encodedMessage)
+        public override Oid GetEncodedMessageType(ReadOnlySpan<byte> encodedMessage)
         {
-            fixed (byte* pin = encodedMessage)
+            ValueAsnReader reader = new ValueAsnReader(encodedMessage, AsnEncodingRules.BER);
+            ValueContentInfoAsn.Decode(ref reader, out ValueContentInfoAsn contentInfo);
+
+            switch (contentInfo.ContentType)
             {
-                using (var manager = new PointerMemoryManager<byte>(pin, encodedMessage.Length))
-                {
-                    ValueAsnReader reader = new ValueAsnReader(encodedMessage, AsnEncodingRules.BER);
-
-                    ContentInfoAsn.Decode(ref reader, manager.Memory, out ContentInfoAsn contentInfo);
-
-                    switch (contentInfo.ContentType)
-                    {
-                        case Oids.Pkcs7Data:
-                        case Oids.Pkcs7Signed:
-                        case Oids.Pkcs7Enveloped:
-                        case Oids.Pkcs7SignedEnveloped:
-                        case Oids.Pkcs7Hashed:
-                        case Oids.Pkcs7Encrypted:
-                            return new Oid(contentInfo.ContentType);
-                    }
-
-                    throw new CryptographicException(SR.Cryptography_Cms_InvalidMessageType);
-                }
+                case Oids.Pkcs7Data:
+                case Oids.Pkcs7Signed:
+                case Oids.Pkcs7Enveloped:
+                case Oids.Pkcs7SignedEnveloped:
+                case Oids.Pkcs7Hashed:
+                case Oids.Pkcs7Encrypted:
+                    return new Oid(contentInfo.ContentType);
             }
+
+            throw new CryptographicException(SR.Cryptography_Cms_InvalidMessageType);
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decode.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decode.cs
@@ -80,28 +80,16 @@ namespace Internal.Cryptography.Pal.AnyOS
 
         private static byte[] CopyContent(ReadOnlySpan<byte> encodedMessage)
         {
-            unsafe
+            ValueAsnReader reader = new ValueAsnReader(encodedMessage, AsnEncodingRules.BER);
+
+            ValueContentInfoAsn.Decode(ref reader, out ValueContentInfoAsn parsedContentInfo);
+
+            if (parsedContentInfo.ContentType != Oids.Pkcs7Enveloped)
             {
-                fixed (byte* pin = encodedMessage)
-                {
-                    using (var manager = new PointerMemoryManager<byte>(pin, encodedMessage.Length))
-                    {
-                        ValueAsnReader reader = new ValueAsnReader(encodedMessage, AsnEncodingRules.BER);
-
-                        ContentInfoAsn.Decode(
-                            ref reader,
-                            manager.Memory,
-                            out ContentInfoAsn parsedContentInfo);
-
-                        if (parsedContentInfo.ContentType != Oids.Pkcs7Enveloped)
-                        {
-                            throw new CryptographicException(SR.Cryptography_Cms_InvalidMessageType);
-                        }
-
-                        return parsedContentInfo.Content.ToArray();
-                    }
-                }
+                throw new CryptographicException(SR.Cryptography_Cms_InvalidMessageType);
             }
+
+            return parsedContentInfo.Content.ToArray();
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
@@ -210,30 +210,18 @@ namespace System.Security.Cryptography.Pkcs
 
             static byte[] CopyContent(ReadOnlySpan<byte> encodedMessage)
             {
-                unsafe
+                ValueAsnReader reader = new ValueAsnReader(encodedMessage, AsnEncodingRules.BER);
+
+                // Windows (and thus NetFx) reads the leading data and ignores extra.
+                // So use the Decode overload which doesn't throw on extra data.
+                ValueContentInfoAsn.Decode(ref reader, out ValueContentInfoAsn contentInfo);
+
+                if (contentInfo.ContentType != Oids.Pkcs7Signed)
                 {
-                    fixed (byte* pin = encodedMessage)
-                    {
-                        using (var manager = new PointerMemoryManager<byte>(pin, encodedMessage.Length))
-                        {
-                            ValueAsnReader reader = new ValueAsnReader(encodedMessage, AsnEncodingRules.BER);
-
-                            // Windows (and thus NetFx) reads the leading data and ignores extra.
-                            // So use the Decode overload which doesn't throw on extra data.
-                            ContentInfoAsn.Decode(
-                                ref reader,
-                                manager.Memory,
-                                out ContentInfoAsn contentInfo);
-
-                            if (contentInfo.ContentType != Oids.Pkcs7Signed)
-                            {
-                                throw new CryptographicException(SR.Cryptography_Cms_InvalidMessageType);
-                            }
-
-                            return contentInfo.Content.ToArray();
-                        }
-                    }
+                    throw new CryptographicException(SR.Cryptography_Cms_InvalidMessageType);
                 }
+
+                return contentInfo.Content.ToArray();
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.iOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.iOS.cs
@@ -42,24 +42,14 @@ namespace System.Security.Cryptography.X509Certificates
         {
             try
             {
-                unsafe
+                ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.BER);
+                ValueContentInfoAsn.Decode(ref reader, out ValueContentInfoAsn contentInfo);
+
+                switch (contentInfo.ContentType)
                 {
-                    fixed (byte* pin = rawData)
-                    {
-                        using (var manager = new PointerMemoryManager<byte>(pin, rawData.Length))
-                        {
-                            ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.BER);
-
-                            ContentInfoAsn.Decode(ref reader, manager.Memory, out ContentInfoAsn contentInfo);
-
-                            switch (contentInfo.ContentType)
-                            {
-                                case Oids.Pkcs7Signed:
-                                case Oids.Pkcs7SignedEnveloped:
-                                    return true;
-                            }
-                        }
-                    }
+                    case Oids.Pkcs7Signed:
+                    case Oids.Pkcs7SignedEnveloped:
+                        return true;
                 }
             }
             catch (CryptographicException)

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.macOS.cs
@@ -91,30 +91,24 @@ namespace System.Security.Cryptography.X509Certificates
             }
         }
 
-        internal static unsafe byte[] ExportPkcs8(SafeSecKeyRefHandle key, PbeParameters pbeParameters, ReadOnlySpan<char> password)
+        internal static byte[] ExportPkcs8(SafeSecKeyRefHandle key, PbeParameters pbeParameters, ReadOnlySpan<char> password)
         {
             using (SafeCFDataHandle data = Interop.AppleCrypto.SecKeyExportData(key, exportPrivate: true, password))
             {
                 ReadOnlySpan<byte> systemExport = Interop.CoreFoundation.CFDataDangerousGetSpan(data);
 
-                fixed (byte* ptr = systemExport)
-                {
-                    using (PointerMemoryManager<byte> manager = new PointerMemoryManager<byte>(ptr, systemExport.Length))
-                    {
-                        // Apple's PKCS8 export exports using PBES2, which Win7, Win8.1, and Apple all fail to
-                        // understand in their PKCS12 readers, so re-encrypt using the Win7 PKCS12-PBE parameters.
-                        //
-                        // Since Apple only reliably exports keys with encrypted PKCS#8 there's not a
-                        // "so export it plaintext and only encrypt it once" option.
-                        AsnWriter writer = KeyFormatHelper.ReencryptPkcs8(
-                            password,
-                            manager.Memory,
-                            password,
-                            pbeParameters);
+                // Apple's PKCS8 export exports using PBES2, which Win7, Win8.1, and Apple all fail to
+                // understand in their PKCS12 readers, so re-encrypt using the Win7 PKCS12-PBE parameters.
+                //
+                // Since Apple only reliably exports keys with encrypted PKCS#8 there's not a
+                // "so export it plaintext and only encrypt it once" option.
+                AsnWriter writer = KeyFormatHelper.ReencryptPkcs8(
+                    password,
+                    systemExport,
+                    password,
+                    pbeParameters);
 
-                        return writer.Encode();
-                    }
-                }
+                return writer.Encode();
             }
         }
 

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -2029,7 +2029,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                     base64ClearSize = base64Written;
                     Debug.Assert(!decryptedPkcs8.HasValue);
-                    decryptedPkcs8 = KeyFormatHelper.DecryptPkcs8(password, base64Buffer.AsMemory(0, base64Written), out int bytesRead);
+                    decryptedPkcs8 = KeyFormatHelper.DecryptPkcs8(password, base64Buffer.AsSpan(0, base64Written), out int bytesRead);
 
                     if (bytesRead != base64Written)
                     {


### PR DESCRIPTION
This reduces more use of PointerMemoryManager and using the ref struct decoders. 

The two outstanding uses are PKCS#12 and X.509. Those are bigger changes and might need more support from the XSLT generator, so let's get these in since they are easy.