### PR TITLE
Add JsonNamingPolicy support to JsonConsoleFormatterOptions

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatter.cs
@@ -19,6 +19,19 @@ namespace Microsoft.Extensions.Logging.Console
     {
         private readonly IDisposable? _optionsReloadToken;
 
+        // Property names are pre-computed when options load (in ReloadLoggerOptions) rather than
+        // calling JsonNamingPolicy.ConvertName per log entry. ReloadLoggerOptions already runs on
+        // construction and option reload, so it's the natural place to derive these — and the hot
+        // path (WriteInternal) stays allocation-free with just field reads.
+        private string _timestampPropertyName = "Timestamp";
+        private string _eventIdPropertyName = "EventId";
+        private string _logLevelPropertyName = "LogLevel";
+        private string _categoryPropertyName = "Category";
+        private string _messagePropertyName = "Message";
+        private string _exceptionPropertyName = "Exception";
+        private string _statePropertyName = "State";
+        private string _scopesPropertyName = "Scopes";
+
         public JsonConsoleFormatter(IOptionsMonitor<JsonConsoleFormatterOptions> options)
             : base(ConsoleFormatterNames.Json)
         {
@@ -66,27 +79,27 @@ namespace Microsoft.Extensions.Logging.Console
                     var timestampFormat = FormatterOptions.TimestampFormat;
                     if (timestampFormat != null)
                     {
-                        writer.WriteString("Timestamp", stamp.ToString(timestampFormat));
+                        writer.WriteString(_timestampPropertyName, stamp.ToString(timestampFormat));
                     }
-                    writer.WriteNumber(nameof(LogEntry<object>.EventId), eventId);
-                    writer.WriteString(nameof(LogEntry<object>.LogLevel), GetLogLevelString(logLevel));
-                    writer.WriteString(nameof(LogEntry<object>.Category), category);
-                    writer.WriteString("Message", message);
+                    writer.WriteNumber(_eventIdPropertyName, eventId);
+                    writer.WriteString(_logLevelPropertyName, GetLogLevelString(logLevel));
+                    writer.WriteString(_categoryPropertyName, category);
+                    writer.WriteString(_messagePropertyName, message);
 
                     if (exception != null)
                     {
-                        writer.WriteString(nameof(Exception), exception);
+                        writer.WriteString(_exceptionPropertyName, exception);
                     }
 
                     if (hasState)
                     {
-                        writer.WriteStartObject(nameof(LogEntry<object>.State));
+                        writer.WriteStartObject(_statePropertyName);
 
                         // In many cases the message and stateMessage will be the same, so we only write the message if it differs from the stateMessage.
                         // This helps reducing the size of the log entry.
                         if (!string.Equals(message, stateMessage))
                         {
-                            writer.WriteString("Message", stateMessage);
+                            writer.WriteString(_messagePropertyName, stateMessage);
                         }
                         if (stateProperties != null)
                         {
@@ -147,13 +160,13 @@ namespace Microsoft.Extensions.Logging.Console
         {
             if (FormatterOptions.IncludeScopes && scopeProvider != null)
             {
-                writer.WriteStartArray("Scopes");
+                writer.WriteStartArray(_scopesPropertyName);
                 scopeProvider.ForEachScope((scope, state) =>
                 {
                     if (scope is IEnumerable<KeyValuePair<string, object?>> scopeItems)
                     {
                         state.WriteStartObject();
-                        state.WriteString("Message", scope.ToString());
+                        state.WriteString(_messagePropertyName, scope.ToString());
                         foreach (KeyValuePair<string, object?> item in scopeItems)
                         {
                             WriteItem(state, item);
@@ -234,6 +247,30 @@ namespace Microsoft.Extensions.Logging.Console
         private void ReloadLoggerOptions(JsonConsoleFormatterOptions options)
         {
             FormatterOptions = options;
+
+            JsonNamingPolicy? policy = options.JsonNamingPolicy;
+            if (policy != null)
+            {
+                _timestampPropertyName = policy.ConvertName("Timestamp");
+                _eventIdPropertyName = policy.ConvertName("EventId");
+                _logLevelPropertyName = policy.ConvertName("LogLevel");
+                _categoryPropertyName = policy.ConvertName("Category");
+                _messagePropertyName = policy.ConvertName("Message");
+                _exceptionPropertyName = policy.ConvertName("Exception");
+                _statePropertyName = policy.ConvertName("State");
+                _scopesPropertyName = policy.ConvertName("Scopes");
+            }
+            else
+            {
+                _timestampPropertyName = "Timestamp";
+                _eventIdPropertyName = "EventId";
+                _logLevelPropertyName = "LogLevel";
+                _categoryPropertyName = "Category";
+                _messagePropertyName = "Message";
+                _exceptionPropertyName = "Exception";
+                _statePropertyName = "State";
+                _scopesPropertyName = "Scopes";
+            }
         }
 
         public void Dispose()

--- a/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatterOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/src/JsonConsoleFormatterOptions.cs
@@ -21,6 +21,22 @@ namespace Microsoft.Extensions.Logging.Console
         /// </summary>
         public JsonWriterOptions JsonWriterOptions { get; set; }
 
+        /// <summary>
+        /// Gets or sets the <see cref="System.Text.Json.JsonNamingPolicy"/> used to convert the built-in
+        /// property names (<c>Timestamp</c>, <c>EventId</c>, <c>LogLevel</c>, <c>Category</c>,
+        /// <c>Message</c>, <c>Exception</c>, <c>State</c>, <c>Scopes</c>) when writing JSON output.
+        /// </summary>
+        /// <value>
+        /// The naming policy, or <see langword="null"/> to preserve the default PascalCase names.
+        /// For example, setting this to <see cref="JsonNamingPolicy.CamelCase"/> produces
+        /// <c>timestamp</c>, <c>eventId</c>, <c>logLevel</c>, etc.
+        /// </value>
+        /// <remarks>
+        /// This property only affects the built-in property names emitted by the formatter.
+        /// Property names from structured log state and scope data are written as-is.
+        /// </remarks>
+        public JsonNamingPolicy? JsonNamingPolicy { get; set; }
+
 #pragma warning disable SYSLIB1100
 #pragma warning disable SYSLIB1101
         internal override void Configure(IConfiguration configuration) => configuration.Bind(this);

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/JsonConsoleFormatterTests.cs
@@ -79,6 +79,109 @@ namespace Microsoft.Extensions.Logging.Console.Test
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        public void Log_JsonNamingPolicyCamelCase_ProducesCamelCasePropertyNames()
+        {
+            // Arrange
+            using var t = SetUp(
+                new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
+                simpleOptions: null,
+                systemdOptions: null,
+                jsonOptions: new JsonConsoleFormatterOptions
+                {
+                    JsonWriterOptions = new JsonWriterOptions() { Indented = false },
+                    TimestampFormat = "hh:mm:ss ",
+                    JsonNamingPolicy = JsonNamingPolicy.CamelCase,
+                }
+            );
+            var logger = (ILogger)t.Logger;
+            var sink = t.Sink;
+
+            // Act
+            logger.LogInformation("test message");
+
+            // Assert
+            Assert.Equal(1, sink.Writes.Count);
+            string message = GetMessage(sink.Writes.GetRange(0 * t.WritesPerMsg, t.WritesPerMsg));
+
+            // Verify camelCase property names are used
+            Assert.Contains("\"timestamp\":", message);
+            Assert.Contains("\"eventId\":", message);
+            Assert.Contains("\"logLevel\":\"Information\"", message);
+            Assert.Contains("\"category\":\"test\"", message);
+            Assert.Contains("\"message\":\"test message\"", message);
+            Assert.Contains("\"state\":{", message);
+
+            // Verify PascalCase names are NOT used
+            Assert.DoesNotContain("\"Timestamp\":", message);
+            Assert.DoesNotContain("\"EventId\":", message);
+            Assert.DoesNotContain("\"LogLevel\":", message);
+            Assert.DoesNotContain("\"Category\":", message);
+            Assert.DoesNotContain("\"Message\":", message);
+            Assert.DoesNotContain("\"State\":", message);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        public void Log_JsonNamingPolicyNull_PreservesPascalCasePropertyNames()
+        {
+            // Arrange
+            using var t = SetUp(
+                new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
+                simpleOptions: null,
+                systemdOptions: null,
+                jsonOptions: new JsonConsoleFormatterOptions
+                {
+                    JsonWriterOptions = new JsonWriterOptions() { Indented = false },
+                    JsonNamingPolicy = null,
+                }
+            );
+            var logger = (ILogger)t.Logger;
+            var sink = t.Sink;
+
+            // Act
+            logger.LogInformation("test message");
+
+            // Assert
+            Assert.Equal(1, sink.Writes.Count);
+            string message = GetMessage(sink.Writes.GetRange(0 * t.WritesPerMsg, t.WritesPerMsg));
+
+            // Verify default PascalCase names are preserved
+            Assert.Contains("\"EventId\":", message);
+            Assert.Contains("\"LogLevel\":\"Information\"", message);
+            Assert.Contains("\"Category\":\"test\"", message);
+            Assert.Contains("\"Message\":\"test message\"", message);
+            Assert.Contains("\"State\":{", message);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        public void Log_JsonNamingPolicyCamelCase_ScopePropertyNamesAreCamelCase()
+        {
+            // Arrange
+            using var t = SetUp(
+                new ConsoleLoggerOptions { FormatterName = ConsoleFormatterNames.Json },
+                simpleOptions: null,
+                systemdOptions: null,
+                jsonOptions: new JsonConsoleFormatterOptions
+                {
+                    JsonWriterOptions = new JsonWriterOptions() { Indented = false },
+                    IncludeScopes = true,
+                    JsonNamingPolicy = JsonNamingPolicy.CamelCase,
+                }
+            );
+            var logger = (ILogger)t.Logger;
+            var sink = t.Sink;
+
+            // Act
+            using (logger.BeginScope("scope1 {name1}", 123))
+                logger.LogInformation("test");
+
+            // Assert
+            Assert.Equal(1, sink.Writes.Count);
+            string message = GetMessage(sink.Writes.GetRange(0 * t.WritesPerMsg, t.WritesPerMsg));
+            Assert.Contains("\"scopes\":[{\"message\":\"scope1 123\"", message);
+            Assert.DoesNotContain("\"Scopes\":", message);
+        }
+
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
         public void Log_NullMessage_LogsWhenMessageIsNotProvided()
         {
             // Arrange


### PR DESCRIPTION
Fixes #125689

## Summary

Adds a `JsonNamingPolicy` property to `JsonConsoleFormatterOptions` that controls the casing of built-in JSON property names emitted by `JsonConsoleFormatter`.

**When `null` (default):** PascalCase names are preserved — no behavioral change.
**When set (e.g. `JsonNamingPolicy.CamelCase`):** Built-in property names are transformed:

| Default | CamelCase |
|---------|-----------|
| `Timestamp` | `timestamp` |
| `EventId` | `eventId` |
| `LogLevel` | `logLevel` |
| `Category` | `category` |
| `Message` | `message` |
| `Exception` | `exception` |
| `State` | `state` |
| `Scopes` | `scopes` |

User-provided property names from structured log state and scope data are written as-is.

## Usage

```csharp
builder.Logging.AddJsonConsole(options =>
{
    options.JsonNamingPolicy = JsonNamingPolicy.CamelCase;
});
```

## Motivation

Observability platforms (New Relic, Datadog, Splunk, Grafana Loki) expect lowercase property names in structured JSON logs. The current `JsonConsoleFormatter` hardcodes PascalCase names with no way to change them, forcing users to write a custom `ConsoleFormatter` from scratch (~100 lines of boilerplate). This has been requested multiple times (#109726, dotnet/aspnetcore#58890).

## Implementation notes

Property names are pre-computed in `ReloadLoggerOptions` (which already runs on construction and option reload) rather than calling `JsonNamingPolicy.ConvertName()` per log entry. This avoids per-entry overhead, though for built-in policies like `CamelCase` the cost would be negligible either way. The pre-computation approach was chosen because `ReloadLoggerOptions` is the existing pattern for applying option changes, so it's the natural place to derive the names — and it means the hot path (`WriteInternal`) stays allocation-free with just field reads.

## Tests

Three new tests in `JsonConsoleFormatterTests.cs`:
- `Log_JsonNamingPolicyCamelCase_ProducesCamelCasePropertyNames` — verifies all built-in properties use camelCase and PascalCase names are absent
- `Log_JsonNamingPolicyNull_PreservesPascalCasePropertyNames` — verifies default behavior is unchanged
- `Log_JsonNamingPolicyCamelCase_ScopePropertyNamesAreCamelCase` — verifies scope array and inner `Message` key also use the naming policy
