### PR TITLE
Fix `ConnectAsync_WithBuffer_Succeeds` test to include Apple mobile platforms

### DIFF
--- a/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.Unix.cs
+++ b/src/libraries/System.Net.Sockets/tests/FunctionalTests/Connect.Unix.cs
@@ -220,11 +220,11 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(SocketError.Success, saea.SocketError);
             Assert.True(client.Blocking);
 
-            // On macOS, TFO (connectx) may complete the connect+send in a single
+            // On Apple platforms, TFO (connectx) may complete the connect+send in a single
             // syscall, so the socket can end up blocking even on the async path.
             // On Linux, async connect always leaves the socket non-blocking when
             // buffer > 0 because SendToAsync is pending.
-            if (!completedAsync || OperatingSystem.IsMacOS())
+            if (!completedAsync || PlatformDetection.IsApplePlatform)
             {
                 Assert.False(IsSocketNonBlocking(client));
             }


### PR DESCRIPTION
## Description



This PR updates `ConnectAsync_WithBuffer_Succeeds` to include Apple mobile platforms in the connectx blocking mode check.