### PR TITLE
Enable linux_arm64 coreclr build for SVE perf benchmarks.

### DIFF
--- a/eng/pipelines/performance/templates/perf-build-jobs.yml
+++ b/eng/pipelines/performance/templates/perf-build-jobs.yml
@@ -6,6 +6,7 @@ jobs:
   - template: /eng/pipelines/performance/templates/perf-coreclr-build-jobs.yml
     parameters:
       linux_x64: true
+      linux_arm64: true
       windows_x64: true
       windows_x86: true
       android_arm64: true


### PR DESCRIPTION
The cobaltSveMicro job added in https://github.com/dotnet/performance/pull/5127 targets `linux_arm64` on `perfcobalt`, which generates a dependency on the `build_linux_arm64_release_coreclr` job. This job was never created because `linux_arm64` was not enabled in `perf-build-jobs.yml`, causing all `dotnet-runtime-perf` pipeline builds to fail with a YAML validation error since https://dev.azure.com/dnceng/internal/_build/results?buildId=2929255&view=results.

Run with this change: https://dev.azure.com/dnceng/internal/_build/results?buildId=2929520&view=results.

When it finishes, we have to trigger `dotnet-performance-infra` with Azure Batch task that processes the new data. That should show the results in [history index](https://pvscmdupload.z22.web.core.windows.net/reports/allTestHistory/TestHistoryIndexIndex.html) for coreclr.