### PR TITLE
Fix FileSystemWatcher startup race on Linux

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -133,6 +133,7 @@ namespace System.IO
             private readonly SafeFileHandle _inotifyHandle;
             private readonly ConcurrentDictionary<int, Watch> _wdToWatch = new ConcurrentDictionary<int, Watch>();
             private readonly ReaderWriterLockSlim _addLock = new(LockRecursionPolicy.NoRecursion);
+            private readonly ManualResetEventSlim _readyToRead = new(false);
             private bool _isThreadStopping;
             private bool _allWatchersStopped;
             private int _bufferAvailable;
@@ -199,6 +200,11 @@ namespace System.IO
                     throw;
                 }
             }
+
+            /// <summary>
+            /// Waits until the processing thread is ready to read inotify events.
+            /// </summary>
+            internal void WaitForReadReady() => _readyToRead.Wait();
 
             private void StopINotify()
             {
@@ -489,6 +495,11 @@ namespace System.IO
                     uint movedFromCookie = 0;
                     bool movedFromIsDir = false;
 
+                    // Signal that the processing thread is ready to read events.
+                    // This ensures callers of Start() can wait until events will
+                    // be captured before performing filesystem operations.
+                    _readyToRead.Set();
+
                     while (TryReadEvent(out NotifyEvent nextEvent))
                     {
                         if (!ProcessEvent(nextEvent, ref movedFromWatchCount, ref movedFromName, ref movedFromCookie, ref movedFromIsDir))
@@ -509,6 +520,9 @@ namespace System.IO
                 }
                 finally
                 {
+                    // Ensure any caller blocked on WaitForReadReady() is unblocked,
+                    // even if ProcessEvents exits early due to an error.
+                    _readyToRead.Set();
                     Debug.Assert(_inotifyHandle.IsClosed);
                 }
             }
@@ -1054,6 +1068,12 @@ namespace System.IO
                             _inotify.AddWatcher(this);
                         }
                     }
+
+                    // Ensure the processing thread is ready to read events before
+                    // we start emitting or performing filesystem operations that
+                    // should be observed. Without this, events can be missed if
+                    // they occur before ProcessEvents enters its read loop.
+                    inotify.WaitForReadReady();
 
                     _ = DequeueEvents();
 


### PR DESCRIPTION
## Summary

Fix a race condition in `FileSystemWatcher` on Linux where events can be missed if they occur immediately after `Start()` returns, before the `ProcessEvents` background thread enters its `read()` loop.

## Root Cause

PR #117148 refactored the Linux `FileSystemWatcher` to use a single shared inotify instance. The refactor introduced a race in `Start()`: after `StartThread()` spawns the background thread and `CreateRootWatch()` registers the inotify watch, `Start()` returns without ensuring the processing thread is actually reading events. If a filesystem operation triggers an event in this window, the event is missed.

This manifests as `"Created event did not occur as expected"` failures in `SymbolicLink_Changed_Tests` tests, particularly under jitstress on slower hardware (arm32) where the race window is wider.

## Fix

Add a `ManualResetEventSlim` that:
1. `ProcessEvents()` signals just before entering its `TryReadEvent` loop
2. `Start()` waits on after releasing the watchers lock

For shared inotify instances (when a subsequent watcher reuses an already-running instance), the event is already set so `WaitForReadReady()` returns immediately.

## Testing

The fix should resolve:
- `SymbolicLink_Changed_Tests.FileSystemWatcher_SymbolicLink_TargetsDirectory_Create` (currently failing on linux arm32 jitstress)
- `SymbolicLink_Changed_Tests.FileSystemWatcher_SymbolicLink_TargetsDirectory_Create_IncludeSubdirectories` (currently disabled via #124849)

## Related

- Fixes #125737
- Regression from #117148
- Related: #124677, #124847, #103630 (false pattern match)

/cc @tmds @adamsitnik @Jozkee