### PR TITLE
Increase FileSystemWatcher test event timeout to 1000ms

### DIFF
--- a/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
+++ b/src/libraries/System.IO.FileSystem.Watcher/tests/Utility/FileSystemWatcherTest.cs
@@ -21,7 +21,7 @@ namespace System.IO.Tests
         // going to fail the test.  If we don't expect an event to occur, then we need
         // to keep the timeout short, as in a successful run we'll end up waiting for
         // the entire timeout specified.
-        public const int WaitForExpectedEventTimeout = 500;         // ms to wait for an event to happen
+        public const int WaitForExpectedEventTimeout = 1000;         // ms to wait for an event to happen
         public const int LongWaitTimeout = 50000;                   // ms to wait for an event that takes a longer time than the average operation
         public const int SubsequentExpectedWait = 10;               // ms to wait for checks that occur after the first.
         public const int WaitForExpectedEventTimeout_NoRetry = 3000;// ms to wait for an event that isn't surrounded by a retry.


### PR DESCRIPTION
Increase `WaitForExpectedEventTimeout` from 500ms to 1000ms per @tmds suggestion in https://github.com/dotnet/runtime/pull/125740#issuecomment-4085057694.

The inotify refactor (#117148) changed stop/start timing for watches, which can delay event delivery under stress conditions. The 500ms timeout is too tight for jitstress runs on slower hardware (arm32), causing false failures in SymbolicLink tests that are being incorrectly attributed to #103630.

This is a single constant change that affects 94 tests using the default `ExpectEvent` timeout. It should help distinguish timing issues from functional bugs.

Ref: #125737, #125740

/cc @tmds @adamsitnik @Jozkee