### PR TITLE
[DO NOT MERGE] Test-only: Inject FailFast in GC test for crash dump infrastructure validation

### DIFF
--- a/src/tests/GC/API/GC/Collect.cs
+++ b/src/tests/GC/API/GC/Collect.cs
@@ -12,7 +12,7 @@ public class Test_Collect {
 
         Object obj1 = new Object();
         int[] array = new int[25];
-        
+
         int gen1 = GC.GetGeneration(array);
 
         Console.WriteLine("Array is in generation: " + gen1);
@@ -20,6 +20,10 @@ public class Test_Collect {
 
         int gen2 = GC.GetGeneration(array);
         Console.WriteLine("Array is in generation: " + gen2);
+
+        // Intentional crash to generate a dump for diag-perf-ai E2E testing.
+        Console.WriteLine("About to FailFast to force a crash dump...");
+        Environment.FailFast("Intentional crash for diag-perf-ai E2E testing");
 
         if(((gen1==2) && (gen2==2)) || (gen2>gen1)) {    // was already in gen 2!
             Console.WriteLine("Test for GC.Collect() passed!");


### PR DESCRIPTION
## DO NOT MERGE - Testing Only

This PR intentionally injects an Environment.FailFast call into the GC/API/GC/Collect test to trigger a crash and validate that crash dump collection infrastructure in Helix is working correctly.

### Changes
- Added Environment.FailFast(...) to src/tests/GC/API/GC/Collect.cs to force a process abort during test execution

### Purpose
- Validate that crash dumps are generated and collected by Helix when a test process aborts
- This PR is **not intended to be merged** and will be closed after testing is complete