### PR TITLE
[Wasm RyuJit] Add JIT config JitWasmNyiToR2RUnsupported

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -650,6 +650,11 @@ void CodeGen::genCodeForTreeNode(GenTree* treeNode)
 
         default:
 #ifdef DEBUG
+            if (JitConfig.JitWasmNyiToR2RUnsupported())
+            {
+                NYI_WASM("Opcode not implemented");
+            }
+
             NYIRAW(GenTree::OpName(treeNode->OperGet()));
 #else
             NYI_WASM("Opcode not implemented");

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -3922,6 +3922,9 @@ template <class T>
 inline emitAttr emitTypeSize(T type)
 {
     assert(TypeGet(type) < TYP_COUNT);
+
+    if (emitTypeSizes[TypeGet(type)] == 0)
+        NYI_WASM("oops");
     assert(emitTypeSizes[TypeGet(type)] > 0);
     return (emitAttr)emitTypeSizes[TypeGet(type)];
 }

--- a/src/coreclr/jit/emit.h
+++ b/src/coreclr/jit/emit.h
@@ -3922,9 +3922,6 @@ template <class T>
 inline emitAttr emitTypeSize(T type)
 {
     assert(TypeGet(type) < TYP_COUNT);
-
-    if (emitTypeSizes[TypeGet(type)] == 0)
-        NYI_WASM("oops");
     assert(emitTypeSizes[TypeGet(type)] > 0);
     return (emitAttr)emitTypeSizes[TypeGet(type)];
 }

--- a/src/coreclr/jit/error.h
+++ b/src/coreclr/jit/error.h
@@ -225,7 +225,9 @@ extern void notYetImplemented(const char* msg, const char* file, unsigned line);
 #define NYI_ARM64(msg)  do { } while (0)
 #define NYI_LOONGARCH64(msg) do { } while (0)
 #define NYI_RISCV64(msg) do { } while (0)
-#define NYI_WASM(msg) NYIRAW("NYI_WASM: " msg)
+#define NYI_WASM(msg) do { if (JitConfig.JitWasmNyiToR2RUnsupported() > 0) \
+   { JITDUMP("NYI_WASM:" msg); implReadyToRunUnsupported(); } \
+   else { NYIRAW("NYI_WASM: " msg); } } while (0)
 
 #else
 

--- a/src/coreclr/jit/error.h
+++ b/src/coreclr/jit/error.h
@@ -225,9 +225,14 @@ extern void notYetImplemented(const char* msg, const char* file, unsigned line);
 #define NYI_ARM64(msg)  do { } while (0)
 #define NYI_LOONGARCH64(msg) do { } while (0)
 #define NYI_RISCV64(msg) do { } while (0)
+
+#if DEBUG
 #define NYI_WASM(msg) do { if (JitConfig.JitWasmNyiToR2RUnsupported() > 0) \
-   { JITDUMP("NYI_WASM:" msg); implReadyToRunUnsupported(); } \
+   { JITDUMP("NYI_WASM: " msg); implReadyToRunUnsupported(); } \
    else { NYIRAW("NYI_WASM: " msg); } } while (0)
+#else
+#define NYI_WASM(msg) NYIRAW("NYI_WASM: " msg)
+#endif // DEBUG
 
 #else
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -865,7 +865,7 @@ CONFIG_INTEGER(JitDispIns, "JitDispIns", 0)
 #endif // defined(TARGET_LOONGARCH64)
 
 #if defined(TARGET_WASM)
-// Set this to 1 to turn NYI_WASM into R2R unsupportedfailures instead of asserts.
+// Set this to 1 to turn NYI_WASM into R2R unsupported failures instead of asserts.
 CONFIG_INTEGER(JitWasmNyiToR2RUnsupported, "JitWasmNyiToR2RUnsupported", 0)
 #endif // defined(TARGET_WASM)
 

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -864,6 +864,11 @@ CONFIG_INTEGER(JitUseScalableVectorT, "JitUseScalableVectorT", 0)
 CONFIG_INTEGER(JitDispIns, "JitDispIns", 0)
 #endif // defined(TARGET_LOONGARCH64)
 
+#if defined(TARGET_WASM)
+// Set this to 1 to turn NYI_WASM into R2R unsupportedfailures instead of asserts.
+CONFIG_INTEGER(JitWasmNyiToR2RUnsupported, "JitWasmNyiToR2RUnsupported", 0)
+#endif // defined(TARGET_WASM)
+
 // Allow to enregister locals with struct type.
 RELEASE_CONFIG_INTEGER(JitEnregStructLocals, "JitEnregStructLocals", 1)
 


### PR DESCRIPTION
Set this to allow crossgen2 for Wasm to continue even if there is a method that runs into an NYI_WASM in the JIT.