### PR TITLE
Clear RCW cache entries when releasing wrapper objects

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -1404,7 +1404,7 @@ namespace System.Runtime.InteropServices
                 _lock.EnterWriteLock();
                 try
                 {
-                    RemoveLocked(comPointer, wrapper);
+                    Remove_Locked(comPointer, wrapper);
                 }
                 finally
                 {
@@ -1419,7 +1419,7 @@ namespace System.Runtime.InteropServices
                 {
                     foreach (NativeObjectWrapper wrapper in wrappers)
                     {
-                        RemoveLocked(wrapper.ExternalComObject, wrapper);
+                        Remove_Locked(wrapper.ExternalComObject, wrapper);
                     }
                 }
                 finally
@@ -1428,8 +1428,9 @@ namespace System.Runtime.InteropServices
                 }
             }
 
-            private void RemoveLocked(IntPtr comPointer, NativeObjectWrapper wrapper)
+            private void Remove_Locked(IntPtr comPointer, NativeObjectWrapper wrapper)
             {
+                Debug.Assert(_lock.IsWriteLockHeld);
                 // This method is used in a scenario where we already have a lock on the cache, so we can skip acquiring the lock again.
                 // TryGetOrCreateObjectForComInstanceInternal may have put a new entry into the cache
                 // in the time between the GC cleared the contents of the GC handle but before the

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/ComWrappers.cs
@@ -1291,6 +1291,11 @@ namespace System.Runtime.InteropServices
             }
         }
 
+        internal void RemoveWrappersFromCache(IEnumerable<NativeObjectWrapper> wrappers)
+        {
+            _rcwCache.RemoveAll(wrappers);
+        }
+
         private sealed class RcwCache
         {
             private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
@@ -1399,22 +1404,44 @@ namespace System.Runtime.InteropServices
                 _lock.EnterWriteLock();
                 try
                 {
-                    // TryGetOrCreateObjectForComInstanceInternal may have put a new entry into the cache
-                    // in the time between the GC cleared the contents of the GC handle but before the
-                    // NativeObjectWrapper finalizer ran.
-                    // Only remove the entry if the target of the GC handle is the NativeObjectWrapper
-                    // or is null (indicating that the corresponding NativeObjectWrapper has been scheduled for finalization).
-                    if (_cache.TryGetValue(comPointer, out GCHandle cachedRef)
-                        && (wrapper == cachedRef.Target
-                            || cachedRef.Target is null))
+                    RemoveLocked(comPointer, wrapper);
+                }
+                finally
+                {
+                    _lock.ExitWriteLock();
+                }
+            }
+
+            public void RemoveAll(IEnumerable<NativeObjectWrapper> wrappers)
+            {
+                _lock.EnterWriteLock();
+                try
+                {
+                    foreach (NativeObjectWrapper wrapper in wrappers)
                     {
-                        _cache.Remove(comPointer);
-                        cachedRef.Free();
+                        RemoveLocked(wrapper.ExternalComObject, wrapper);
                     }
                 }
                 finally
                 {
                     _lock.ExitWriteLock();
+                }
+            }
+
+            private void RemoveLocked(IntPtr comPointer, NativeObjectWrapper wrapper)
+            {
+                // This method is used in a scenario where we already have a lock on the cache, so we can skip acquiring the lock again.
+                // TryGetOrCreateObjectForComInstanceInternal may have put a new entry into the cache
+                // in the time between the GC cleared the contents of the GC handle but before the
+                // NativeObjectWrapper finalizer ran.
+                // Only remove the entry if the target of the GC handle is the NativeObjectWrapper
+                // or is null (indicating that the corresponding NativeObjectWrapper has been scheduled for finalization).
+                if (_cache.TryGetValue(comPointer, out GCHandle cachedRef)
+                    && (wrapper == cachedRef.Target
+                        || cachedRef.Target is null))
+                {
+                    _cache.Remove(comPointer);
+                    cachedRef.Free();
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.cs
@@ -61,7 +61,8 @@ namespace System.Runtime.InteropServices
 
             IntPtr contextToken = GetContextToken();
 
-            List<object> objects = new List<object>();
+            List<ReferenceTrackerNativeObjectWrapper> wrappersToRemove = [];
+            List<object> objects = [];
 
             // Here we aren't part of a GC callback, so other threads can still be running
             // who are adding and removing from the collection. This means we can possibly race
@@ -85,8 +86,15 @@ namespace System.Runtime.InteropServices
                         // Separate the wrapper from the tracker runtime prior to
                         // passing them.
                         nativeObjectWrapper.DisconnectTracker();
+
+                        wrappersToRemove.Add(nativeObjectWrapper);
                     }
                 }
+
+                // Remove the native object wrappers from the cache
+                // so we don't return released wrappers to the user if the native COM object
+                // happens to be reused.
+                GlobalInstanceForTrackerSupport.RemoveWrappersFromCache(wrappersToRemove);
             }
 
             GlobalInstanceForTrackerSupport.ReleaseObjects(objects);

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.cs
@@ -93,13 +93,12 @@ namespace System.Runtime.InteropServices
                         }
                     }
                 }
-
-                // Remove the native object wrappers from the cache
-                // so we don't return released wrappers to the user if the native COM object
-                // happens to be reused.
-                GlobalInstanceForTrackerSupport.RemoveWrappersFromCache(wrappersToRemove);
             }
 
+            // Remove the native object wrappers from the cache
+            // so we don't return released wrappers to the user if the native COM object
+            // happens to be reused.
+            GlobalInstanceForTrackerSupport.RemoveWrappersFromCache(wrappersToRemove);
             GlobalInstanceForTrackerSupport.ReleaseObjects(objects);
         }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.cs
@@ -87,7 +87,10 @@ namespace System.Runtime.InteropServices
                         // passing them.
                         nativeObjectWrapper.DisconnectTracker();
 
-                        wrappersToRemove.Add(nativeObjectWrapper);
+                        if (nativeObjectWrapper.ComWrappers == GlobalInstanceForTrackerSupport)
+                        {
+                            wrappersToRemove.Add(nativeObjectWrapper);
+                        }
                     }
                 }
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.cs
@@ -77,10 +77,6 @@ namespace System.Runtime.InteropServices
                     if (nativeObjectWrapper != null &&
                         nativeObjectWrapper._contextToken == contextToken)
                     {
-                        // Separate the wrapper from the tracker runtime prior to
-                        // passing them.
-                        nativeObjectWrapper.DisconnectTracker();
-
                         // If this object is associated with the global instance for tracker support,
                         // then we can request that instance to clear out the native object wrapper's state
                         // to ensure the object gets released now.
@@ -96,6 +92,10 @@ namespace System.Runtime.InteropServices
                                 objects.Add(target);
                             }
                         }
+
+                        // Separate the wrapper from the tracker runtime prior to
+                        // passing them.
+                        nativeObjectWrapper.DisconnectTracker();
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/TrackerObjectManager.cs
@@ -77,19 +77,24 @@ namespace System.Runtime.InteropServices
                     if (nativeObjectWrapper != null &&
                         nativeObjectWrapper._contextToken == contextToken)
                     {
-                        object? target = nativeObjectWrapper.ProxyHandle.Target;
-                        if (target != null)
-                        {
-                            objects.Add(target);
-                        }
-
                         // Separate the wrapper from the tracker runtime prior to
                         // passing them.
                         nativeObjectWrapper.DisconnectTracker();
 
+                        // If this object is associated with the global instance for tracker support,
+                        // then we can request that instance to clear out the native object wrapper's state
+                        // to ensure the object gets released now.
+                        // Also, we will remove the wrappers from the cache to ensure a stale wrapper
+                        // isn't returned in the future.
                         if (nativeObjectWrapper.ComWrappers == GlobalInstanceForTrackerSupport)
                         {
                             wrappersToRemove.Add(nativeObjectWrapper);
+
+                            object? target = nativeObjectWrapper.ProxyHandle.Target;
+                            if (target != null)
+                            {
+                                objects.Add(target);
+                            }
                         }
                     }
                 }

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.cs
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.cs
@@ -468,22 +468,30 @@ namespace ComWrappersTests.GlobalInstance
             // Validate that the RCW cache gets cleared when we call NotifyEndOfReferenceTrackingOnThread
             GlobalComWrappers.Instance.ReturnInvalid = false;
             IntPtr tracker = MockReferenceTrackerRuntime.CreateTrackerObject();
+            try
+            {
+                object rcw = GlobalComWrappers.Instance.GetOrCreateObjectForComInstance(tracker, CreateObjectFlags.TrackerObject);
 
-            object rcw = GlobalComWrappers.Instance.GetOrCreateObjectForComInstance(tracker, CreateObjectFlags.TrackerObject);
+                // Make sure that we keep the tracker object alive even after we notify end of reference tracking on this thread.
+                Marshal.AddRef(tracker);
 
-            // Make sure that we keep the tracker object alive even after we notify end of reference tracking on this thread.
-            Marshal.AddRef(tracker);
+                const int S_OK = 0;
+                Assert.Equal(S_OK, MockReferenceTrackerRuntime.Trigger_NotifyEndOfReferenceTrackingOnThread());
 
-            const int S_OK = 0;
-            Assert.Equal(S_OK, MockReferenceTrackerRuntime.Trigger_NotifyEndOfReferenceTrackingOnThread());
+                // We should get a new RCW after we've released the reference tracked objects on this thread.
+                object rcwNew = GlobalComWrappers.Instance.GetOrCreateObjectForComInstance(tracker, CreateObjectFlags.TrackerObject);
 
-            // We should get a new RCW after we've released the reference tracked objects on this thread.
-            object rcwNew = GlobalComWrappers.Instance.GetOrCreateObjectForComInstance(tracker, CreateObjectFlags.TrackerObject);
-
-            // Release the extra ref we added above so we don't leak the object after the test.
-            Marshal.Release(tracker);
-
-            Assert.NotSame(rcw, rcwNew);
+                Assert.NotSame(rcw, rcwNew);
+            }
+            finally
+            {
+                if (tracker != IntPtr.Zero)
+                {
+                    // Release the extra ref we added above and the original ref from CreateTrackerObject.
+                    Marshal.Release(tracker);
+                    Marshal.Release(tracker);
+                }
+            }
         }
     }
 }

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.cs
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.cs
@@ -469,7 +469,7 @@ namespace ComWrappersTests.GlobalInstance
             GlobalComWrappers.Instance.ReturnInvalid = false;
             IntPtr tracker = MockReferenceTrackerRuntime.CreateTrackerObject();
 
-            object rcw = GlobalComWrappers.Instance.GetOrCreateObjectForComInstance(tracker, CreateObjectFlags.TrackerSupport);
+            object rcw = GlobalComWrappers.Instance.GetOrCreateObjectForComInstance(tracker, CreateObjectFlags.TrackerObject);
 
             // Make sure that we keep the tracker object alive even after we notify end of reference tracking on this thread.
             Marshal.AddRef(tracker);
@@ -478,7 +478,7 @@ namespace ComWrappersTests.GlobalInstance
             Assert.Equal(S_OK, MockReferenceTrackerRuntime.Trigger_NotifyEndOfReferenceTrackingOnThread());
 
             // We should get a new RCW after we've released the reference tracked objects on this thread.
-            object rcwNew = GlobalComWrappers.Instance.GetOrCreateObjectForComInstance(tracker, CreateObjectFlags.TrackerSupport);
+            object rcwNew = GlobalComWrappers.Instance.GetOrCreateObjectForComInstance(tracker, CreateObjectFlags.TrackerObject);
 
             // Release the extra ref we added above so we don't leak the object after the test.
             Marshal.Release(tracker);

--- a/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.cs
+++ b/src/tests/Interop/COM/ComWrappers/GlobalInstance/GlobalInstance.cs
@@ -177,7 +177,10 @@ namespace ComWrappersTests.GlobalInstance
                     Assert.NotNull(o);
                 }
 
-                throw new Exception() { HResult = ReleaseObjectsCallAck };
+                if (ReturnInvalid)
+                {
+                    throw new Exception() { HResult = ReleaseObjectsCallAck };
+                }
             }
 
             private unsafe ComInterfaceEntry* ComputeVtablesForTestObject(Test obj, out int count)
@@ -461,6 +464,26 @@ namespace ComWrappersTests.GlobalInstance
             // Trigger the thread lifetime end API and verify the callback occurs.
             int hr = MockReferenceTrackerRuntime.Trigger_NotifyEndOfReferenceTrackingOnThread();
             Assert.Equal(GlobalComWrappers.ReleaseObjectsCallAck, hr);
+
+            // Validate that the RCW cache gets cleared when we call NotifyEndOfReferenceTrackingOnThread
+            GlobalComWrappers.Instance.ReturnInvalid = false;
+            IntPtr tracker = MockReferenceTrackerRuntime.CreateTrackerObject();
+
+            object rcw = GlobalComWrappers.Instance.GetOrCreateObjectForComInstance(tracker, CreateObjectFlags.TrackerSupport);
+
+            // Make sure that we keep the tracker object alive even after we notify end of reference tracking on this thread.
+            Marshal.AddRef(tracker);
+
+            const int S_OK = 0;
+            Assert.Equal(S_OK, MockReferenceTrackerRuntime.Trigger_NotifyEndOfReferenceTrackingOnThread());
+
+            // We should get a new RCW after we've released the reference tracked objects on this thread.
+            object rcwNew = GlobalComWrappers.Instance.GetOrCreateObjectForComInstance(tracker, CreateObjectFlags.TrackerSupport);
+
+            // Release the extra ref we added above so we don't leak the object after the test.
+            Marshal.Release(tracker);
+
+            Assert.NotSame(rcw, rcwNew);
         }
     }
 }


### PR DESCRIPTION
Remove native wrappers from the RCW cache in the tracker support global instance when releasing external objects for the Jupiter runtime. Without this change, a disconnected COM object wrapper could remain in the ComWrappers instance's cache. Then, if a new COM object is allocated at the same address (only possible because the COM objects were forcibly disconnected when `ComWrappers.ReleaseObjects` was called as part of the request from the Jupiter runtime), the old, disconnected COM object wrapper would be returned by `ComWrappers`.

Unblocks Microsoft Store migration to NativeAOT.