### PR TITLE
Try checking for Darwin and Clang in addition to AppleClang

### DIFF
--- a/eng/native/configurecompiler.cmake
+++ b/eng/native/configurecompiler.cmake
@@ -24,9 +24,9 @@ include(${CMAKE_CURRENT_LIST_DIR}/configureoptimization.cmake)
 if(CLR_CMAKE_TARGET_BROWSER AND DEFINED TRYRUN_BROWSER_EMSCRIPTEN_VERSION)
     file(READ "${CMAKE_CURRENT_LIST_DIR}/../../src/mono/browser/emscripten-version.txt" CURRENT_EMSCRIPTEN_VERSION)
     string(STRIP "${CURRENT_EMSCRIPTEN_VERSION}" CURRENT_EMSCRIPTEN_VERSION)
-    
+
     if(NOT TRYRUN_BROWSER_EMSCRIPTEN_VERSION STREQUAL CURRENT_EMSCRIPTEN_VERSION)
-        message(WARNING 
+        message(WARNING
             "Emscripten version mismatch detected!\n"
             "  Current Emscripten: ${CURRENT_EMSCRIPTEN_VERSION}\n"
             "  Cached features for: ${TRYRUN_BROWSER_EMSCRIPTEN_VERSION}\n"
@@ -49,10 +49,14 @@ if (CLR_CMAKE_HOST_UNIX)
     endif()
 endif()
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-    # enable $<LINK_GROUP:RESCAN> on AppleClang as a no-op
+if ((CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang") OR
+    (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
+    # enable $<LINK_GROUP:RESCAN> on Darwin clang toolchains as a no-op
     set(CMAKE_LINK_GROUP_USING_RESCAN "" "")
     set(CMAKE_LINK_GROUP_USING_RESCAN_SUPPORTED ON)
+endif()
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
     # Force usage of classic linker on Xcode 15
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 15 AND
         CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)


### PR DESCRIPTION
The build machines may have had some changes that cause this workaround to be more fragile. Try checkign for `CMAKE_SYSTEM_NAME == "Darwin" AND CMAKE_CXX_COMPILER_ID == "Clang"` in addition to `CMAKE_CXX_COMPILER_ID == "AppleClang"`