### PR TITLE
Disable iOS and tvOS jobs until infra issue is fixed

### DIFF
--- a/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
+++ b/eng/pipelines/extra-platforms/runtime-extra-platforms-ioslike.yml
@@ -23,8 +23,9 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
-      - tvos_arm64
+      # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+      # - ios_arm64
+      # - tvos_arm64
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange
@@ -64,8 +65,9 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
-      - tvos_arm64
+      # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+      # - ios_arm64
+      # - tvos_arm64
     variables:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - name: _HelixSource
@@ -108,8 +110,9 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
-      - tvos_arm64
+      # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+      # - ios_arm64
+      # - tvos_arm64
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange
@@ -141,8 +144,9 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
-      - tvos_arm64
+      # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+      # - ios_arm64
+      # - tvos_arm64
     variables:
       - name: timeoutPerTestInMinutes
         value: 60
@@ -179,8 +183,9 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
-      - tvos_arm64
+      # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+      # - ios_arm64
+      # - tvos_arm64
     variables:
       - ${{ if and(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest')) }}:
         - name: _HelixSource
@@ -222,8 +227,9 @@ jobs:
     isExtraPlatformsBuild: ${{ parameters.isExtraPlatformsBuild }}
     isiOSLikeOnlyBuild: ${{ parameters.isiOSLikeOnlyBuild }}
     platforms:
-      - ios_arm64
-      - tvos_arm64
+      # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+      # - ios_arm64
+      # - tvos_arm64
     variables:
       # map dependencies variables to local variables
       - name: librariesContainsChange

--- a/eng/pipelines/runtime.yml
+++ b/eng/pipelines/runtime.yml
@@ -1140,8 +1140,9 @@ extends:
           buildConfig: Release
           runtimeFlavor: mono
           platforms:
-            - ios_arm64
-            - tvos_arm64
+            # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+            # - ios_arm64
+            # - tvos_arm64
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange
@@ -1186,8 +1187,9 @@ extends:
           buildConfig: Release
           runtimeFlavor: coreclr
           platforms:
-            - ios_arm64
-            - tvos_arm64
+            # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+            # - ios_arm64
+            # - tvos_arm64
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange
@@ -1232,8 +1234,9 @@ extends:
           buildConfig: Release
           runtimeFlavor: coreclr
           platforms:
-            - ios_arm64
-            - tvos_arm64
+            # Tracking issue: https://github.com/dotnet/runtime/issues/123796
+            # - ios_arm64
+            # - tvos_arm64
           variables:
             # map dependencies variables to local variables
             - name: librariesContainsChange


### PR DESCRIPTION
Tracking issue: https://github.com/dotnet/runtime/issues/123796

Commenting out all `ios_arm64` and `tvos_arm64` platform entries in CI pipelines until the XHarness/devicectl infrastructure issue is resolved.

Affected pipelines:
- `runtime-extra-platforms-ioslike.yml` (6 jobs: Mono libs, Mono runtime, NativeAOT libs, NativeAOT runtime, CoreCLR runtime, CoreCLR libs)
- `runtime.yml` (3 jobs: Mono smoke, CoreCLR smoke, NativeAOT smoke)