### PR TITLE
[release/8.0] Remove Homebrew LLVM during macOS CI setup - Part 2

### DIFF
--- a/eng/install-native-dependencies.sh
+++ b/eng/install-native-dependencies.sh
@@ -40,6 +40,13 @@ case "$os" in
         export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
         # Skip brew update for now, see https://github.com/actions/setup-python/issues/577
         # brew update --preinstall
+
+        # Remove Homebrew LLVM if present. The CI runner image may ship with a
+        # Homebrew LLVM whose libraries (e.g., libunwind.dylib) are the wrong
+        # architecture or conflict with the Apple SDK, breaking native linking.
+        # The build uses Apple clang from /usr/bin/clang exclusively.
+        brew uninstall --ignore-dependencies llvm@18 2>/dev/null || true
+
         brew bundle --no-upgrade --file "$(dirname "$0")/Brewfile"
         ;;
 


### PR DESCRIPTION
The CI runner image may ship with a Homebrew LLVM whose libraries (e.g., an x86_64-only libunwind.dylib in /usr/local/lib) conflict with the Apple SDK and break native linking. The build uses Apple clang from /usr/bin/clang exclusively and does not need Homebrew LLVM.

Backport of https://github.com/dotnet/runtime/pull/125763