### PR TITLE
Fix issue where i32.trunc_sat_f32_s wasn't properly encoded

### DIFF
--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -342,6 +342,8 @@ static bool HasOpcodePrefix(instruction ins)
      static_cast<uint8_t>(opcode) == 0xFD),
 #include "instrs.h"
     };
+
+    assert(ins < ArrLen(hasPrefix));
     return hasPrefix[ins];
 }
 

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -334,6 +334,15 @@ static unsigned GetInsOpcode(instruction ins)
     return insOpcodes[ins];
 }
 
+static bool HasOpcodePrefix(instruction ins)
+{
+    static const bool hasPrefix[] = {
+#define INST(id, nm, info, fmt, opcode) (static_cast<uint8_t>(opcode) == 0xFB || static_cast<uint8_t>(opcode) == 0xFC || static_cast<uint8_t>(opcode) == 0xFD),
+#include "instrs.h"
+    };
+    return hasPrefix[ins];
+}
+
 size_t emitter::emitSizeOfInsDsc(instrDesc* id) const
 {
     if (emitIsSmallInsDsc(id))
@@ -410,7 +419,7 @@ unsigned emitter::instrDesc::idCodeSize() const
 
     // Currently, all our instructions have 1 or 2 byte opcodes.
     assert(FitsIn<uint8_t>(opcode) || FitsIn<uint16_t>(opcode));
-    unsigned size = FitsIn<uint8_t>(opcode) ? 1 : 2;
+    unsigned size = HasOpcodePrefix(idIns()) ? 2 : 1;
     switch (idInsFmt())
     {
         case IF_OPCODE:
@@ -531,7 +540,7 @@ size_t emitter::emitOutputOpcode(BYTE* dst, instruction ins)
     unsigned opcode = GetInsOpcode(ins);
 
     assert(FitsIn<uint16_t>(opcode));
-    if (FitsIn<uint8_t>(opcode))
+    if (!HasOpcodePrefix(ins))
     {
         emitOutputByte(dst, opcode);
         sz += 1;

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -337,7 +337,9 @@ static unsigned GetInsOpcode(instruction ins)
 static bool HasOpcodePrefix(instruction ins)
 {
     static const bool hasPrefix[] = {
-#define INST(id, nm, info, fmt, opcode) (static_cast<uint8_t>(opcode) == 0xFB || static_cast<uint8_t>(opcode) == 0xFC || static_cast<uint8_t>(opcode) == 0xFD),
+#define INST(id, nm, info, fmt, opcode)                                                                                \
+    (static_cast<uint8_t>(opcode) == 0xFB || static_cast<uint8_t>(opcode) == 0xFC ||                                   \
+     static_cast<uint8_t>(opcode) == 0xFD),
 #include "instrs.h"
     };
     return hasPrefix[ins];


### PR DESCRIPTION
Since it only used two bytes if the second byte was non-zero. Unfortunately, i32.trunc_sat_f32_s has an encoding where the second byte is 0.