### PR TITLE
Fix emcc version parsing failure on clean WASM builds

### DIFF
--- a/src/mono/browser/browser.proj
+++ b/src/mono/browser/browser.proj
@@ -81,6 +81,12 @@
 
     <!-- Generate wasm-props.json -->
 
+    <!-- Clear stale _VersionLines items that may have been added by _AcquireLocalEmscriptenSdk
+         (which reads emscripten-version.txt into the same item group during SDK provisioning) -->
+    <ItemGroup>
+      <_VersionLines Remove="@(_VersionLines)" />
+    </ItemGroup>
+
     <RunWithEmSdkEnv Command="$(EmccCmd) --version"
           ConsoleToMsBuild="true"
           EmSdkPath="$(EMSDK_PATH)"


### PR DESCRIPTION
## Problem

Clean WASM builds (when `src/mono/browser/emsdk/` doesn't exist yet) fail with:
```
error : Failed to parse emcc version, and hash from the full version string: '3.1.56'
```

## Root cause

Regression introduced by #123949 which added `DependsOnTargets="AcquireEmscriptenSdk"` to `GenerateEmccPropsAndRspFiles`. This causes the `_VersionLines` item group to be polluted:

1. `_AcquireLocalEmscriptenSdk` reads `emscripten-version.txt` into `_VersionLines` → adds bare `3.1.56`
2. `GenerateEmccPropsAndRspFiles` runs `emcc --version` → appends 4 output lines to the **same** `_VersionLines`
3. After reversal https://github.com/dotnet/runtime/blob/43502e55deaed0a3a9913c10c791ab60c3bc30ee/src/mono/browser/browser.proj#L94, the stale `3.1.56` ends up last → `_EmccVersionRaw` is set to it
4. The regex expects `emcc (description) X.Y.Z (hash)` but gets bare `3.1.56` → parse failure

Only affects first/clean builds where `_AcquireLocalEmscriptenSdk` actually provisions the SDK. Subsequent builds skip provisioning so `_VersionLines` stays clean.

## Fix

Clear `_VersionLines` before `RunWithEmSdkEnv` populates it with `emcc --version` output.