### PR TITLE
Revert "[release/9.0] Fix intermediate artifact upload collisions for NativeAOT and Mono"

### DIFF
--- a/eng/pipelines/runtime-official.yml
+++ b/eng/pipelines/runtime-official.yml
@@ -300,7 +300,7 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
-                  name: NativeAOTRuntimePacks_$(osGroup)$(osSubgroup)_$(archType)
+                  name: NativeAOTRuntimePacks
 
       #
       # Build Mono runtime packs
@@ -344,7 +344,7 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
-                  name: MonoRuntimePacks_$(osGroup)$(osSubgroup)_$(archType)
+                  name: MonoRuntimePacks
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -362,7 +362,7 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
-                  name: MonoRuntimePacks_$(osGroup)$(osSubgroup)_$(archType)
+                  name: MonoRuntimePacks
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -380,7 +380,7 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
-                  name: MonoRuntimePacks_multithread_$(osGroup)$(osSubgroup)_$(archType)
+                  name: MonoRuntimePacks
 
       # Build Mono AOT offset headers once, for consumption elsewhere
       #
@@ -452,7 +452,7 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
-                  name: MonoRuntimePacks_crossaot_$(osGroup)$(osSubgroup)_$(archType)
+                  name: MonoRuntimePacks
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -480,7 +480,7 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
-                  name: MonoRuntimePacks_crossaot_$(osGroup)$(osSubgroup)_$(archType)
+                  name: MonoRuntimePacks
 
       - template: /eng/pipelines/common/platform-matrix.yml
         parameters:
@@ -514,7 +514,7 @@ extends:
             postBuildSteps:
               - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                 parameters:
-                  name: MonoRuntimePacks_crossaot_$(osGroup)$(osSubgroup)_$(archType)
+                  name: MonoRuntimePacks
 
       #
       # Build Mono LLVM runtime packs
@@ -546,7 +546,7 @@ extends:
               postBuildSteps:
                 - template: /eng/pipelines/common/upload-intermediate-artifacts-step.yml
                   parameters:
-                    name: MonoRuntimePacks_llvmaot_$(osGroup)$(osSubgroup)_$(archType)
+                    name: MonoRuntimePacks
 
       #
       # Build libraries AllConfigurations for packages
@@ -620,34 +620,35 @@ extends:
                 artifact: 'IntermediateArtifacts'
                 path: $(Build.SourcesDirectory)/artifacts/workloadPackages
                 patterns: |
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-arm64.Cross.android-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-arm64.Cross.browser-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.wasi-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-arm64.Cross.wasi-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.android-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.browser-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.multithread.browser-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.tvos-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.tvossimulator-*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NETCore.App.Runtime.Mono.wasi-wasm*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Workload.Mono.ToolChain.Current.Manifest*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Workload.Mono.ToolChain.net6.Manifest*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Workload.Mono.ToolChain.net8.Manifest*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Runtime.MonoTargets.Sdk*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Runtime.MonoAOTCompiler.Task*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Runtime.WebAssembly.Sdk*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Runtime.WebAssembly.Wasi*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Runtime.WebAssembly.Templates*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.android-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-arm64.Cross.android-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.browser-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-arm64.Cross.browser-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-x64.Cross.wasi-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.AOT.win-arm64.Cross.wasi-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.android-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.browser-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.multithread.browser-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.ios-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.iossimulator-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.maccatalyst-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.multithread.browser-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.tvos-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.tvossimulator-*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NETCore.App.Runtime.Mono.wasi-wasm*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Workload.Mono.ToolChain.Current.Manifest*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Workload.Mono.ToolChain.net6.Manifest*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Workload.Mono.ToolChain.net7.Manifest*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Workload.Mono.ToolChain.net8.Manifest*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.MonoTargets.Sdk*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.MonoAOTCompiler.Task*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.WebAssembly.Sdk*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.WebAssembly.Wasi*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Runtime.WebAssembly.Templates*.nupkg
                   IntermediateArtifacts/windows_arm64/Shipping/Microsoft.NETCore.App.Runtime.win-arm64*.nupkg
                   IntermediateArtifacts/windows_x64/Shipping/Microsoft.NETCore.App.Runtime.win-x64*.nupkg
                   IntermediateArtifacts/windows_x86/Shipping/Microsoft.NETCore.App.Runtime.win-x86*.nupkg
-                  IntermediateArtifacts/MonoRuntimePacks*/Shipping/Microsoft.NET.Sdk.WebAssembly.Pack*.nupkg
+                  IntermediateArtifacts/MonoRuntimePacks/Shipping/Microsoft.NET.Sdk.WebAssembly.Pack*.nupkg
 
             - task: CopyFiles@2
               displayName: Flatten packages


### PR DESCRIPTION
Reverts dotnet/runtime#125564