### PR TITLE
Fix cDAC dump tests on 32-bit ARM targets

### DIFF
--- a/src/native/managed/cdac/tests/DumpTests/ClrMdDumpHost.cs
+++ b/src/native/managed/cdac/tests/DumpTests/ClrMdDumpHost.cs
@@ -79,7 +79,15 @@ internal sealed class ClrMdDumpHost : IDisposable
 
             ulong address = module.GetExportSymbolAddress("DotNetRuntimeContractDescriptor");
             if (address != 0)
+            {
+                // ClrMD may return addresses with spurious upper bits on 32-bit targets
+                // (observed on ARM32 ELF). Mask to the target's pointer size.
+                // https://github.com/microsoft/clrmd/issues/1407
+                if (_dataTarget.DataReader.PointerSize == 4)
+                    address &= 0xFFFF_FFFF;
+
                 return address;
+            }
         }
 
         throw new InvalidOperationException("Could not find DotNetRuntimeContractDescriptor export in any runtime module in the dump.");


### PR DESCRIPTION
## Summary

Work around a ClrMD bug ([microsoft/clrmd#1407](https://github.com/microsoft/clrmd/issues/1407)) that causes `ModuleInfo.GetExportSymbolAddress()` to return corrupt addresses for 32-bit ELF modules, breaking all cDAC dump tests on ARM32.

## Problem

ClrMD's `ElfSymbol32` struct declares its `Value` field as `ulong` (8 bytes) instead of `uint` (4 bytes), mismatching the ELF32 spec's 4-byte `st_value`. This causes the adjacent `st_size` field to leak into the upper 32 bits of the symbol value. For example, the `DotNetRuntimeContractDescriptor` export (32 bytes, `st_size = 0x20`) produces:

```
Expected address: 0xEFCE9BA8
Actual address:   0x20EFCE9BA8  (0x20 = st_size in upper bits)
```

All memory reads at the returned address fail because it is outside the 32-bit address space.

## Fix

Mask the address returned by `GetExportSymbolAddress()` to 32 bits when the target pointer size is 4:

```csharp
if (_dataTarget.DataReader.PointerSize == 4)
    address &= 0xFFFF_FFFF;
```

This workaround can be removed once microsoft/clrmd#1407 is fixed upstream.

## Validation

- All 103 cDAC dump tests pass against linux-arm32 crash dumps (90 passed, 13 skipped for platform-specific tests)
- All 1274 cDAC unit tests pass
