### PR TITLE
Update EgorBot skill note about content between command and code block

### DIFF
--- a/.github/skills/performance-benchmark/SKILL.md
+++ b/.github/skills/performance-benchmark/SKILL.md
@@ -130,7 +130,10 @@ Post a comment on the PR to trigger EgorBot with your benchmark. The general for
 ```cs
 // Your benchmark code here
 ```
-> **Note:** The @EgorBot command must not be inside the code block. Only the benchmark code should be inside the code block. Do not place any additional text between the @EgorBot command line and the code block, as EgorBot will treat it as additional command arguments.
+> **Note:** When using @EgorBot, follow these formatting rules:
+> - The @EgorBot command must not be inside the code block.
+> - Only the benchmark code should be inside the code block.
+> - Do not place any additional text between the @EgorBot command line and the code block, as EgorBot will treat it as additional command arguments.
 
 ### Target Flags
 

--- a/.github/skills/performance-benchmark/SKILL.md
+++ b/.github/skills/performance-benchmark/SKILL.md
@@ -130,7 +130,7 @@ Post a comment on the PR to trigger EgorBot with your benchmark. The general for
 ```cs
 // Your benchmark code here
 ```
-> **Note:** The @EgorBot command must not be inside the code block. Only the benchmark code should be inside the code block.
+> **Note:** The @EgorBot command must not be inside the code block. Only the benchmark code should be inside the code block. Do not place any additional text between the @EgorBot command line and the code block, as EgorBot will treat it as additional command arguments.
 
 ### Target Flags
 


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.

Clarify that no additional text should be placed between the @EgorBot command line and the code block, as EgorBot treats such text as additional command arguments.