### PR TITLE
[Wasm RyuJit] Debug SPC Wasm Validation Fixes

### DIFF
--- a/src/coreclr/jit/abi.cpp
+++ b/src/coreclr/jit/abi.cpp
@@ -164,13 +164,14 @@ var_types ABIPassingSegment::GetRegisterType() const
 //
 // Parameters:
 //   layout - The layout of the class that this segment is part of
+//      or nullptr if there is no layout
 //
 // Return Value:
 //   A type that matches ABIPassingSegment::Size and the register.
 //
 var_types ABIPassingSegment::GetRegisterType(ClassLayout* layout) const
 {
-    if (genIsValidIntReg(GetRegister()))
+    if ((layout != nullptr) && (genIsValidIntReg(GetRegister())))
     {
         assert(Offset < layout->GetSize());
         if (((Offset % TARGET_POINTER_SIZE) == 0) && (Size == TARGET_POINTER_SIZE))

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1961,7 +1961,25 @@ void CodeGen::genGenerateCode(void** codePtr, uint32_t* nativeSizeOfCode)
             m_compiler->compGetHelperFtn((CorInfoHelpFunc)i);
         }
     }
-#endif
+
+#if defined(TARGET_WASM)
+    // Allow the JIT to fail R2R at this point, so we can skip over methods
+    // that compile without assert but then have Wasm validation errors
+    //
+    static ConfigMethodRange JitR2RUnsupportedRange;
+    JitR2RUnsupportedRange.EnsureInit(JitConfig.JitR2RUnsupportedRange());
+    const unsigned hash = m_compiler->impInlineRoot()->info.compMethodHash();
+    const bool     inRange = JitR2RUnsupportedRange.Contains(hash);
+
+    if (inRange)
+    {
+        JITDUMP("Failing R2R codegen because of JitR2RUnsupportedRange\n");
+        implReadyToRunUnsupported();
+    }
+#endif // defined(TARGET_WASM)
+#endif // DEBUG
+
+
 }
 
 //----------------------------------------------------------------------

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1968,7 +1968,7 @@ void CodeGen::genGenerateCode(void** codePtr, uint32_t* nativeSizeOfCode)
     //
     static ConfigMethodRange JitR2RUnsupportedRange;
     JitR2RUnsupportedRange.EnsureInit(JitConfig.JitR2RUnsupportedRange());
-    const unsigned hash = m_compiler->impInlineRoot()->info.compMethodHash();
+    const unsigned hash    = m_compiler->impInlineRoot()->info.compMethodHash();
     const bool     inRange = JitR2RUnsupportedRange.Contains(hash);
 
     if (inRange)
@@ -1978,8 +1978,6 @@ void CodeGen::genGenerateCode(void** codePtr, uint32_t* nativeSizeOfCode)
     }
 #endif // defined(TARGET_WASM)
 #endif // DEBUG
-
-
 }
 
 //----------------------------------------------------------------------

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1969,11 +1969,12 @@ void CodeGen::genGenerateCode(void** codePtr, uint32_t* nativeSizeOfCode)
     static ConfigMethodRange JitR2RUnsupportedRange;
     JitR2RUnsupportedRange.EnsureInit(JitConfig.JitR2RUnsupportedRange());
     const unsigned hash    = m_compiler->impInlineRoot()->info.compMethodHash();
-    const bool     inRange = JitR2RUnsupportedRange.Contains(hash);
+    const bool     inRange = !JitR2RUnsupportedRange.IsEmpty() && JitR2RUnsupportedRange.Contains(hash);
 
     if (inRange)
     {
-        JITDUMP("Failing R2R codegen because of JitR2RUnsupportedRange\n");
+        JITDUMP("Failing R2R codegen because of JitR2RUnsupportedRange. Hash is 0x%08x, range is ", hash);
+        JITDUMPEXEC(JitR2RUnsupportedRange.Dump());
         implReadyToRunUnsupported();
     }
 #endif // defined(TARGET_WASM)

--- a/src/coreclr/jit/codegencommon.cpp
+++ b/src/coreclr/jit/codegencommon.cpp
@@ -1968,6 +1968,7 @@ void CodeGen::genGenerateCode(void** codePtr, uint32_t* nativeSizeOfCode)
     //
     static ConfigMethodRange JitR2RUnsupportedRange;
     JitR2RUnsupportedRange.EnsureInit(JitConfig.JitR2RUnsupportedRange());
+    assert(!JitR2RUnsupportedRange.Error());
     const unsigned hash    = m_compiler->impInlineRoot()->info.compMethodHash();
     const bool     inRange = !JitR2RUnsupportedRange.IsEmpty() && JitR2RUnsupportedRange.Contains(hash);
 

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1917,7 +1917,10 @@ void CodeGen::genIntrinsic(GenTreeIntrinsic* treeNode)
         var_types treeType    = treeNode->TypeGet();
         var_types operandType = treeNode->gtGetOp1()->TypeGet();
 
-        assert((operandType == TYP_INT) || (operandType == TYP_LONG));
+        if (varTypeIsSmall(operandType))
+        {
+            operandType = TYP_INT;
+        }
 
         needsTruncation = (operandType == TYP_LONG) && (treeType == TYP_INT);
         needsExtension  = (operandType == TYP_INT) && (treeType == TYP_LONG);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1831,6 +1831,8 @@ void CodeGen::genIntrinsic(GenTreeIntrinsic* treeNode)
     // Handle intrinsics that can be implemented by target-specific instructions
     instruction ins = INS_invalid;
 
+    bool isSourceTyped = false;
+
     switch (PackIntrinsicAndType(treeNode->gtIntrinsicName, treeNode->TypeGet()))
     {
         case PackIntrinsicAndType(NI_System_Math_Abs, TYP_FLOAT):
@@ -1894,24 +1896,9 @@ void CodeGen::genIntrinsic(GenTreeIntrinsic* treeNode)
             break;
 
         case PackIntrinsicAndType(NI_PRIMITIVE_LeadingZeroCount, TYP_INT):
-            ins = INS_i32_clz;
-            break;
-        case PackIntrinsicAndType(NI_PRIMITIVE_LeadingZeroCount, TYP_LONG):
-            ins = INS_i64_clz;
-            break;
-
         case PackIntrinsicAndType(NI_PRIMITIVE_TrailingZeroCount, TYP_INT):
-            ins = INS_i32_ctz;
-            break;
-        case PackIntrinsicAndType(NI_PRIMITIVE_TrailingZeroCount, TYP_LONG):
-            ins = INS_i64_ctz;
-            break;
-
         case PackIntrinsicAndType(NI_PRIMITIVE_PopCount, TYP_INT):
-            ins = INS_i32_popcnt;
-            break;
-        case PackIntrinsicAndType(NI_PRIMITIVE_PopCount, TYP_LONG):
-            ins = INS_i64_popcnt;
+            isSourceTyped = true;
             break;
 
         default:
@@ -1919,7 +1906,53 @@ void CodeGen::genIntrinsic(GenTreeIntrinsic* treeNode)
             unreached();
     }
 
+    bool needsTruncation = false;
+
+    if (isSourceTyped)
+    {
+        var_types operandType = treeNode->gtGetOp1()->TypeGet();
+        assert(operandType == TYP_INT || operandType == TYP_LONG);
+
+        switch (PackIntrinsicAndType(treeNode->gtIntrinsicName, operandType))
+        {
+            case PackIntrinsicAndType(NI_PRIMITIVE_LeadingZeroCount, TYP_INT):
+                ins = INS_i32_clz;
+                break;
+
+            case PackIntrinsicAndType(NI_PRIMITIVE_LeadingZeroCount, TYP_LONG):
+                needsTruncation = true;
+                ins             = INS_i64_clz;
+                break;
+
+            case PackIntrinsicAndType(NI_PRIMITIVE_TrailingZeroCount, TYP_INT):
+                ins = INS_i32_ctz;
+                break;
+
+            case PackIntrinsicAndType(NI_PRIMITIVE_TrailingZeroCount, TYP_LONG):
+                needsTruncation = true;
+                ins             = INS_i64_ctz;
+                break;
+
+            case PackIntrinsicAndType(NI_PRIMITIVE_PopCount, TYP_INT):
+                ins = INS_i32_popcnt;
+                break;
+
+            case PackIntrinsicAndType(NI_PRIMITIVE_PopCount, TYP_LONG):
+                needsTruncation = true;
+                ins             = INS_i64_popcnt;
+                break;
+
+            default:
+                unreached();
+        }
+    }
+
     GetEmitter()->emitIns(ins);
+
+    if (needsTruncation)
+    {
+        GetEmitter()->emitIns(INS_i32_wrap_i64);
+    }
 
     WasmProduceReg(treeNode);
 }
@@ -2731,7 +2764,8 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
         case GenTreeBlk::BlkOpKindNativeOpcode:
             genConsumeOperands(blkOp);
 
-            if (isCopyBlk) NYI_WASM("codegenwasm.cpp 2724");
+            if (isCopyBlk)
+                NYI_WASM("codegenwasm.cpp 2724");
             // Emit the size constant expected by the memory.copy and memory.fill opcodes
             GetEmitter()->emitIns_I(INS_i32_const, EA_4BYTE, blkOp->Size());
             GetEmitter()->emitIns_I(isCopyBlk ? INS_memory_copy : INS_memory_fill, EA_8BYTE, LINEAR_MEMORY_INDEX);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1915,12 +1915,7 @@ void CodeGen::genIntrinsic(GenTreeIntrinsic* treeNode)
     if (canHaveMixedTypes)
     {
         var_types treeType    = treeNode->TypeGet();
-        var_types operandType = treeNode->gtGetOp1()->TypeGet();
-
-        if (varTypeIsSmall(operandType))
-        {
-            operandType = TYP_INT;
-        }
+        var_types operandType = genActualType(treeNode->gtGetOp1()->TypeGet());
 
         needsTruncation = (operandType == TYP_LONG) && (treeType == TYP_INT);
         needsExtension  = (operandType == TYP_INT) && (treeType == TYP_LONG);
@@ -2776,9 +2771,6 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
 
         case GenTreeBlk::BlkOpKindNativeOpcode:
             genConsumeOperands(blkOp);
-
-            if (isCopyBlk)
-                NYI_WASM("codegenwasm.cpp 2724");
             // Emit the size constant expected by the memory.copy and memory.fill opcodes
             GetEmitter()->emitIns_I(INS_i32_const, EA_4BYTE, blkOp->Size());
             GetEmitter()->emitIns_I(isCopyBlk ? INS_memory_copy : INS_memory_fill, EA_8BYTE, LINEAR_MEMORY_INDEX);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1340,7 +1340,9 @@ void CodeGen::genCodeForDivMod(GenTreeOp* treeNode)
             GetEmitter()->emitIns_I(is64BitOp ? INS_i64_const : INS_i32_const, size, is64BitOp ? INT64_MIN : INT32_MIN);
             GetEmitter()->emitIns(is64BitOp ? INS_i64_eq : INS_i32_eq);
 
-            GetEmitter()->emitIns(is64BitOp ? INS_i64_and : INS_i32_and);
+            // Wasm relops always produce i32 results
+            //
+            GetEmitter()->emitIns(INS_i32_and);
             genJumpToThrowHlpBlk(SCK_ARITH_EXCPN);
         }
     }
@@ -1476,6 +1478,14 @@ void CodeGen::genCodeForShift(GenTree* tree)
     // TODO-WASM: Zero-extend the 2nd operand for shifts and rotates as needed when the 1st and 2nd operand are
     // different types. The shift operand width in IR is always TYP_INT; the WASM operations have the same widths
     // for both the shift and shiftee. So the shift may need to be extended (zero-extended) for TYP_LONG.
+
+    if (treeNode->TypeIs(TYP_LONG))
+    {
+        assert(treeNode->gtGetOp2()->TypeIs(TYP_INT));
+        // Zero-extend the shift amount to 64 bits for long shifts/rotates.
+        // Wasteful if the amount was a constant, perhaps we should contain it if so.
+        GetEmitter()->emitIns(INS_i64_extend_u_i32);
+    }
 
     instruction ins;
     switch (PackOperAndType(treeNode->OperGet(), treeNode->TypeGet()))
@@ -2720,6 +2730,8 @@ void CodeGen::genCodeForStoreBlk(GenTreeBlk* blkOp)
 
         case GenTreeBlk::BlkOpKindNativeOpcode:
             genConsumeOperands(blkOp);
+
+            if (isCopyBlk) NYI_WASM("codegenwasm.cpp 2724");
             // Emit the size constant expected by the memory.copy and memory.fill opcodes
             GetEmitter()->emitIns_I(INS_i32_const, EA_4BYTE, blkOp->Size());
             GetEmitter()->emitIns_I(isCopyBlk ? INS_memory_copy : INS_memory_fill, EA_8BYTE, LINEAR_MEMORY_INDEX);

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -1831,7 +1831,7 @@ void CodeGen::genIntrinsic(GenTreeIntrinsic* treeNode)
     // Handle intrinsics that can be implemented by target-specific instructions
     instruction ins = INS_invalid;
 
-    bool isSourceTyped = false;
+    bool canHaveMixedTypes = false;
 
     switch (PackIntrinsicAndType(treeNode->gtIntrinsicName, treeNode->TypeGet()))
     {
@@ -1896,9 +1896,12 @@ void CodeGen::genIntrinsic(GenTreeIntrinsic* treeNode)
             break;
 
         case PackIntrinsicAndType(NI_PRIMITIVE_LeadingZeroCount, TYP_INT):
+        case PackIntrinsicAndType(NI_PRIMITIVE_LeadingZeroCount, TYP_LONG):
         case PackIntrinsicAndType(NI_PRIMITIVE_TrailingZeroCount, TYP_INT):
+        case PackIntrinsicAndType(NI_PRIMITIVE_TrailingZeroCount, TYP_LONG):
         case PackIntrinsicAndType(NI_PRIMITIVE_PopCount, TYP_INT):
-            isSourceTyped = true;
+        case PackIntrinsicAndType(NI_PRIMITIVE_PopCount, TYP_LONG):
+            canHaveMixedTypes = true;
             break;
 
         default:
@@ -1907,11 +1910,17 @@ void CodeGen::genIntrinsic(GenTreeIntrinsic* treeNode)
     }
 
     bool needsTruncation = false;
+    bool needsExtension  = false;
 
-    if (isSourceTyped)
+    if (canHaveMixedTypes)
     {
+        var_types treeType    = treeNode->TypeGet();
         var_types operandType = treeNode->gtGetOp1()->TypeGet();
-        assert(operandType == TYP_INT || operandType == TYP_LONG);
+
+        assert((operandType == TYP_INT) || (operandType == TYP_LONG));
+
+        needsTruncation = (operandType == TYP_LONG) && (treeType == TYP_INT);
+        needsExtension  = (operandType == TYP_INT) && (treeType == TYP_LONG);
 
         switch (PackIntrinsicAndType(treeNode->gtIntrinsicName, operandType))
         {
@@ -1920,8 +1929,7 @@ void CodeGen::genIntrinsic(GenTreeIntrinsic* treeNode)
                 break;
 
             case PackIntrinsicAndType(NI_PRIMITIVE_LeadingZeroCount, TYP_LONG):
-                needsTruncation = true;
-                ins             = INS_i64_clz;
+                ins = INS_i64_clz;
                 break;
 
             case PackIntrinsicAndType(NI_PRIMITIVE_TrailingZeroCount, TYP_INT):
@@ -1929,8 +1937,7 @@ void CodeGen::genIntrinsic(GenTreeIntrinsic* treeNode)
                 break;
 
             case PackIntrinsicAndType(NI_PRIMITIVE_TrailingZeroCount, TYP_LONG):
-                needsTruncation = true;
-                ins             = INS_i64_ctz;
+                ins = INS_i64_ctz;
                 break;
 
             case PackIntrinsicAndType(NI_PRIMITIVE_PopCount, TYP_INT):
@@ -1938,8 +1945,7 @@ void CodeGen::genIntrinsic(GenTreeIntrinsic* treeNode)
                 break;
 
             case PackIntrinsicAndType(NI_PRIMITIVE_PopCount, TYP_LONG):
-                needsTruncation = true;
-                ins             = INS_i64_popcnt;
+                ins = INS_i64_popcnt;
                 break;
 
             default:
@@ -1952,6 +1958,10 @@ void CodeGen::genIntrinsic(GenTreeIntrinsic* treeNode)
     if (needsTruncation)
     {
         GetEmitter()->emitIns(INS_i32_wrap_i64);
+    }
+    else if (needsExtension)
+    {
+        GetEmitter()->emitIns(INS_i64_extend_u_i32);
     }
 
     WasmProduceReg(treeNode);

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -870,6 +870,9 @@ CONFIG_INTEGER(JitDispIns, "JitDispIns", 0)
 #if defined(TARGET_WASM)
 // Set this to 1 to turn NYI_WASM into R2R unsupported failures instead of asserts.
 CONFIG_INTEGER(JitWasmNyiToR2RUnsupported, "JitWasmNyiToR2RUnsupported", 0)
+// Specify methods that will fail with R2R unsupported after codegen.
+// Useful for bypassing methods that compile cleanly but have invalid Wasm codegen.
+CONFIG_STRING(JitR2RUnsupportedRange, "JitR2RUnsupportedRange") 
 #endif // defined(TARGET_WASM)
 
 // Allow to enregister locals with struct type.

--- a/src/coreclr/jit/jitconfigvalues.h
+++ b/src/coreclr/jit/jitconfigvalues.h
@@ -872,7 +872,7 @@ CONFIG_INTEGER(JitDispIns, "JitDispIns", 0)
 CONFIG_INTEGER(JitWasmNyiToR2RUnsupported, "JitWasmNyiToR2RUnsupported", 0)
 // Specify methods that will fail with R2R unsupported after codegen.
 // Useful for bypassing methods that compile cleanly but have invalid Wasm codegen.
-CONFIG_STRING(JitR2RUnsupportedRange, "JitR2RUnsupportedRange") 
+CONFIG_STRING(JitR2RUnsupportedRange, "JitR2RUnsupportedRange")
 #endif // defined(TARGET_WASM)
 
 // Allow to enregister locals with struct type.

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -2431,7 +2431,11 @@ bool Compiler::fgTryMorphStructArg(CallArg* arg)
                 var_types regType = seg.GetRegisterType();
                 // If passed in a float reg then keep that type; otherwise let
                 // createSlotAccess get the type from the layout.
-                var_types slotType = varTypeUsesFloatReg(regType) ? regType : TYP_UNDEF;
+                //
+                // For Wasm just use the seg register type for structs.
+                // Note this will cause DNER if the arg was an unpromoted local.
+                //
+                var_types slotType = (varTypeUsesFloatReg(regType) || TARGET_WASM) ? regType : TYP_UNDEF;
                 GenTree*  access   = createSlotAccess(seg.Offset, slotType);
 
                 newArg->AsFieldList()->AddField(this, access, seg.Offset, access->TypeGet());

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -2428,19 +2428,8 @@ bool Compiler::fgTryMorphStructArg(CallArg* arg)
         {
             if (seg.IsPassedInRegister())
             {
-                var_types regType = seg.GetRegisterType();
-                // If passed in a float reg then keep that type; otherwise let
-                // createSlotAccess get the type from the layout.
-                //
-                // For Wasm just use the seg register type for structs.
-                // Note this will cause DNER if the arg was an unpromoted local.
-                //
-#if defined(TARGET_WASM)
-                var_types slotType = regType;
-#else
-                var_types slotType = varTypeUsesFloatReg(regType) ? regType : TYP_UNDEF;
-#endif
-                GenTree* access = createSlotAccess(seg.Offset, slotType);
+                var_types regType = seg.GetRegisterType(layout);
+                GenTree*  access  = createSlotAccess(seg.Offset, regType);
 
                 newArg->AsFieldList()->AddField(this, access, seg.Offset, access->TypeGet());
             }

--- a/src/coreclr/jit/morph.cpp
+++ b/src/coreclr/jit/morph.cpp
@@ -2435,8 +2435,12 @@ bool Compiler::fgTryMorphStructArg(CallArg* arg)
                 // For Wasm just use the seg register type for structs.
                 // Note this will cause DNER if the arg was an unpromoted local.
                 //
-                var_types slotType = (varTypeUsesFloatReg(regType) || TARGET_WASM) ? regType : TYP_UNDEF;
-                GenTree*  access   = createSlotAccess(seg.Offset, slotType);
+#if defined(TARGET_WASM)
+                var_types slotType = regType;
+#else
+                var_types slotType = varTypeUsesFloatReg(regType) ? regType : TYP_UNDEF;
+#endif
+                GenTree* access = createSlotAccess(seg.Offset, slotType);
 
                 newArg->AsFieldList()->AddField(this, access, seg.Offset, access->TypeGet());
             }

--- a/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
+++ b/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-
+using ILCompiler;
 using ILCompiler.DependencyAnalysis.Wasm;
 
 using Internal.TypeSystem;
@@ -156,8 +156,9 @@ namespace Internal.JitInterface
                 returnIsVoid = true;
             }
 
-            // Reserve space for potential implicit this, stack pointer parameter, portable entrypoint parameter, and return buffer
-            ArrayBuilder<WasmValueType> result = new(signature.Length + 4);
+            // Reserve space for potential implicit this, stack pointer parameter, portable entrypoint parameter,
+            // generic context, async continuation, and return buffer
+            ArrayBuilder<WasmValueType> result = new(signature.Length + 6);
 
             if (!signature.IsStatic)
             {
@@ -189,6 +190,16 @@ namespace Internal.JitInterface
                 {
                     result.Add(pointerType);
                 }
+            }
+
+            if (method.IsAsyncCall())
+            {
+                result.Add(pointerType); // async continuation
+            }
+
+            if (method.RequiresInstMethodDescArg() || method.RequiresInstMethodTableArg())
+            {
+                result.Add(pointerType); // generic context
             }
 
             for (int i = explicitThis ? 1 : 0; i < signature.Length; i++)

--- a/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
+++ b/src/coreclr/tools/Common/JitInterface/WasmLowering.cs
@@ -192,14 +192,14 @@ namespace Internal.JitInterface
                 }
             }
 
-            if (method.IsAsyncCall())
-            {
-                result.Add(pointerType); // async continuation
-            }
-
             if (method.RequiresInstMethodDescArg() || method.RequiresInstMethodTableArg())
             {
                 result.Add(pointerType); // generic context
+            }
+
+            if (method.IsAsyncCall())
+            {
+                result.Add(pointerType); // async continuation
             }
 
             for (int i = explicitThis ? 1 : 0; i < signature.Length; i++)


### PR DESCRIPTION
Fixes for validation issues 2, 3, 4, 5, and 7 for Debug SPC.

See https://github.com/dotnet/runtime/issues/125756#issuecomment-4086464184

2. extend shift amount to i64 if necessary
3. fix type used to pass 8 byte structs in registers
4. Wasm relops always produce i32
5. add generic context and async continuation args for Wasm method sig

Also add another bail-out option `JitR2RUnsupportedRange` that causes the JIT to fail R2R compilations for methods with the indicated JIT hashes. This is useful for selectively suppressing JIT codegen that has validation failures so we can find the full set without having fixes (since the validator will stop at the first error).
