### PR TITLE
Fix NullReferenceException for inherited ShouldSerialize methods

### DIFF
--- a/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationWriter.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Serialization/ReflectionXmlSerializationWriter.cs
@@ -661,9 +661,7 @@ namespace System.Xml.Serialization
 
                     if (m.CheckShouldPersist)
                     {
-                        string methodInvoke = $"ShouldSerialize{m.Name}";
-                        MethodInfo method = o!.GetType().GetMethod(methodInvoke, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)!;
-                        shouldPersist = (bool)method.Invoke(o, Array.Empty<object>())!;
+                        shouldPersist = (bool)m.CheckShouldPersistMethodInfo!.Invoke(o, Array.Empty<object>())!;
                     }
 
                     if (m.Attribute != null)
@@ -693,9 +691,7 @@ namespace System.Xml.Serialization
 
                     if (m.CheckShouldPersist)
                     {
-                        string methodInvoke = $"ShouldSerialize{m.Name}";
-                        MethodInfo method = o!.GetType().GetMethod(methodInvoke, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly)!;
-                        shouldPersist = (bool)method.Invoke(o, Array.Empty<object>())!;
+                        shouldPersist = (bool)m.CheckShouldPersistMethodInfo!.Invoke(o, Array.Empty<object>())!;
                     }
 
                     bool checkShouldPersist = m.CheckShouldPersist && (m.Elements!.Length > 0 || m.Text != null);

--- a/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
+++ b/src/libraries/System.Private.Xml/tests/XmlSerializer/XmlSerializerTests.cs
@@ -1677,6 +1677,30 @@ WithXmlHeader(@"<SimpleType xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instanc
     }
 
     [Fact]
+    public static void Xml_InheritedShouldSerializeMethod_WithDefaultValue()
+    {
+        var value = new DerivedTypeWithInheritedShouldSerialize();
+
+        var actual = SerializeAndDeserialize(value, WithXmlHeader("<DerivedTypeWithInheritedShouldSerialize xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" />"));
+
+        Assert.NotNull(actual);
+        Assert.Equal(value.Foo, actual.Foo);
+        Assert.Equal(value.Bar, actual.Bar);
+    }
+
+    [Fact]
+    public static void Xml_InheritedShouldSerializeMethod_WithNonDefaultValue()
+    {
+        var value = new DerivedTypeWithInheritedShouldSerialize() { Foo = "SomeValue", Bar = "SomeBar" };
+
+        var actual = SerializeAndDeserialize(value, WithXmlHeader("<DerivedTypeWithInheritedShouldSerialize Bar=\"SomeBar\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\"><Foo>SomeValue</Foo></DerivedTypeWithInheritedShouldSerialize>"));
+
+        Assert.NotNull(actual);
+        Assert.Equal(value.Foo, actual.Foo);
+        Assert.Equal(value.Bar, actual.Bar);
+    }
+
+    [Fact]
     public static void Xml_KnownTypesThroughConstructorWithArrayProperties()
     {
         int[] intArray = new int[] { 1, 2, 3 };

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -924,6 +924,28 @@ namespace SerializationTypes
         }
     }
 
+    public class BaseTypeWithShouldSerializeMethod
+    {
+        public string Foo { get; set; } = "default";
+
+        [System.Xml.Serialization.XmlAttribute]
+        public string Bar { get; set; } = "default";
+
+        public bool ShouldSerializeFoo()
+        {
+            return Foo != "default";
+        }
+
+        public bool ShouldSerializeBar()
+        {
+            return Bar != "default";
+        }
+    }
+
+    public class DerivedTypeWithInheritedShouldSerialize : BaseTypeWithShouldSerializeMethod
+    {
+    }
+
     public class KnownTypesThroughConstructorWithArrayProperties
     {
         public object StringArrayValue;


### PR DESCRIPTION
Fixes #120561

## Summary

`ReflectionXmlSerializationWriter` used `BindingFlags.DeclaredOnly` when looking up `ShouldSerialize*` methods at two call sites (attribute members loop and element/text members loop). This prevented finding methods declared on base classes, causing a `NullReferenceException` when serializing derived types.

The `MemberMapping` already stores the correctly resolved `MethodInfo` in `CheckShouldPersistMethodInfo`, resolved without `DeclaredOnly` during import. The IL-gen path (`XmlSerializationWriterILGen`) already uses this pre-resolved `MethodInfo` directly. This change aligns the reflection path to match.

## Changes

- **ReflectionXmlSerializationWriter.cs**: Replace redundant `GetMethod` lookups with `m.CheckShouldPersistMethodInfo` at both call sites
- **SerializationTypes.cs**: Add `BaseTypeWithShouldSerializeMethod` and `DerivedTypeWithInheritedShouldSerialize` test types with both `[XmlAttribute]` and element properties
- **XmlSerializerTests.cs**: Add tests for inherited `ShouldSerialize` with default and non-default values, exercising both attribute and element serialization paths