### PR TITLE
Add support for generalized variable length wasm instructions to the emitter

### DIFF
--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -11,7 +11,8 @@
 // clang-format off
 /*static*/ const BYTE CodeGenInterface::instInfo[] =
 {
-    #define INST(id, nm, info, fmt, opcode) info,
+    #define INST(id, nm, info, fmt, opcode         ) info,
+    #define INST2(id, nm, info, fmt, prefix, opcode) info,
     #include "instrs.h"
 };
 // clang-format on
@@ -366,7 +367,8 @@ emitter::insFormat emitter::emitInsFormat(instruction ins)
     static_assert(IF_COUNT < 255);
 
     const static uint8_t insFormats[] = {
-#define INST(id, nm, info, fmt, opcode) fmt,
+#define INST(id, nm, info, fmt, opcode)          fmt,
+#define INST2(id, nm, info, fmt, prefix, opcode) fmt,
 #include "instrs.h"
     };
 
@@ -378,7 +380,8 @@ emitter::insFormat emitter::emitInsFormat(instruction ins)
 static unsigned GetInsOpcode(instruction ins)
 {
     static const uint16_t insOpcodes[] = {
-#define INST(id, nm, info, fmt, opcode) static_cast<uint16_t>(opcode),
+#define INST(id, nm, info, fmt, opcode)          static_cast<uint16_t>(opcode),
+#define INST2(id, nm, info, fmt, prefix, opcode) static_cast<uint16_t>(opcode),
 #include "instrs.h"
     };
 
@@ -386,17 +389,21 @@ static unsigned GetInsOpcode(instruction ins)
     return insOpcodes[ins];
 }
 
-static bool HasOpcodePrefix(instruction ins)
+static uint8_t GetOpcodePrefix(instruction ins)
 {
-    static const bool hasPrefix[] = {
-#define INST(id, nm, info, fmt, opcode)                                                                                \
-    (static_cast<uint8_t>(opcode) == 0xFB || static_cast<uint8_t>(opcode) == 0xFC ||                                   \
-     static_cast<uint8_t>(opcode) == 0xFD),
+    static const uint8_t prefix[] = {
+#define INST(id, nm, info, fmt, opcode)          0,
+#define INST2(id, nm, info, fmt, prefix, opcode) static_cast<uint8_t>(prefix),
 #include "instrs.h"
     };
 
-    assert(ins < ArrLen(hasPrefix));
-    return hasPrefix[ins];
+    assert(ins < ArrLen(prefix));
+    return prefix[ins];
+}
+
+static bool HasOpcodePrefix(instruction ins)
+{
+    return GetOpcodePrefix(ins) != 0;
 }
 
 size_t emitter::emitSizeOfInsDsc(instrDesc* id) const
@@ -479,9 +486,7 @@ unsigned emitter::instrDesc::idCodeSize() const
 {
     unsigned int opcode = GetInsOpcode(idIns());
 
-    // Currently, all our instructions have 1 or 2 byte opcodes.
-    assert(FitsIn<uint8_t>(opcode) || FitsIn<uint16_t>(opcode));
-    unsigned size = HasOpcodePrefix(idIns()) ? 2 : 1;
+    unsigned size = HasOpcodePrefix(idIns()) ? 1 + SizeOfULEB128(opcode) : 1;
     switch (idInsFmt())
     {
         case IF_OPCODE:
@@ -616,18 +621,20 @@ size_t emitter::emitOutputOpcode(BYTE* dst, instruction ins)
 {
     size_t   sz     = 0;
     unsigned opcode = GetInsOpcode(ins);
+    uint8_t  prefix = GetOpcodePrefix(ins);
 
-    assert(FitsIn<uint16_t>(opcode));
-    if (!HasOpcodePrefix(ins))
+    if (prefix == 0)
     {
         emitOutputByte(dst, opcode);
         sz += 1;
     }
-    else if (FitsIn<uint16_t>(opcode))
+    else
     {
-        dst += emitOutputByte(dst, opcode & 0xFF);
-        emitOutputByte(dst, opcode >> 8);
-        sz += 2;
+        // Output prefix byte
+        emitOutputByte(dst, prefix);
+        sz += 1;
+        // Output the rest of the opcode as a ULEB128
+        sz += emitOutputULEB128(dst + sz, opcode);
     }
     return sz;
 }
@@ -684,7 +691,6 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
     size_t      sz     = emitSizeOfInsDsc(id);
     instruction ins    = id->idIns();
     insFormat   insFmt = id->idInsFmt();
-    unsigned    opcode = GetInsOpcode(ins);
 
     switch (insFmt)
     {
@@ -733,7 +739,7 @@ size_t emitter::emitOutputInstr(insGroup* ig, instrDesc* id, BYTE** dp)
         }
         case IF_CALL_INDIRECT:
         {
-            dst += emitOutputByte(dst, opcode);
+            dst += emitOutputOpcode(dst, ins);
             dst += emitOutputConstant(dst, id, UNSIGNED, CorInfoReloc::WASM_TYPE_INDEX_LEB);
             dst += emitOutputULEB128(dst, 0);
             break;

--- a/src/coreclr/jit/emitwasm.cpp
+++ b/src/coreclr/jit/emitwasm.cpp
@@ -625,6 +625,7 @@ size_t emitter::emitOutputOpcode(BYTE* dst, instruction ins)
 
     if (prefix == 0)
     {
+        noway_assert(FitsIn<uint8_t>(opcode));
         emitOutputByte(dst, opcode);
         sz += 1;
     }

--- a/src/coreclr/jit/instr.cpp
+++ b/src/coreclr/jit/instr.cpp
@@ -86,7 +86,8 @@ const char* CodeGen::genInsName(instruction ins)
         #include "instrs.h"
 
 #elif defined(TARGET_WASM)
-        #define INST(id, nm, info, fmt, opcode) nm,
+        #define INST(id, nm, info, fmt, opcode         ) nm,
+        #define INST2(id, nm, info, fmt, prefix, opcode) nm,
         #include "instrs.h"
 
 #else

--- a/src/coreclr/jit/instr.h
+++ b/src/coreclr/jit/instr.h
@@ -77,7 +77,8 @@ enum instruction : uint32_t
 
     INS_lea,   // Not a real instruction. It is used for load the address of stack locals
 #elif defined(TARGET_WASM)
-    #define INST(id, nm, info, fmt, opcode) INS_##id,
+    #define INST(id, nm, info, fmt, opcode         ) INS_##id,
+    #define INST2(id, nm, info, fmt, prefix, opcode) INS_##id,
     #include "instrs.h"
 
 #else

--- a/src/coreclr/jit/instrswasm.h
+++ b/src/coreclr/jit/instrswasm.h
@@ -28,7 +28,7 @@
 
 // control flow
 //
-INST(invalid,              "INVALID",              0, IF_NONE,          BAD_CODE)
+INST2(invalid,              "INVALID",              0, IF_NONE,         0xFC, BAD_CODE)
 INST(unreachable,          "unreachable",          0, IF_OPCODE,        0x00)
 INST(label,                "label",                0, IF_RAW_ULEB128,   0x00)
 INST(catch_ref,            "catch_ref",            0, IF_CATCH_DECL,    0x00)

--- a/src/coreclr/jit/instrswasm.h
+++ b/src/coreclr/jit/instrswasm.h
@@ -20,6 +20,10 @@
 #error INST must be defined before including this file.
 #endif
 
+#ifndef INST2
+#error INST2 must be defined before including this file.
+#endif
+
 // clang-format off
 
 // control flow
@@ -224,18 +228,19 @@ INST(i64_extend32_s,      "i64.extend32_s",      0, IF_OPCODE,  0xC4)
 // NOTE: per https://github.com/dotnet/runtime/issues/122309,
 // we have decided to include saturating float->int conversions
 // in our base Wasm ISA.
-INST(i32_trunc_sat_f32_s, "i32.trunc_sat_f32_s", 0, IF_OPCODE,  0x00FC)
-INST(i32_trunc_sat_f32_u, "i32.trunc_sat_f32_u", 0, IF_OPCODE,  0x01FC)
-INST(i32_trunc_sat_f64_s, "i32.trunc_sat_f64_s", 0, IF_OPCODE,  0x02FC)
-INST(i32_trunc_sat_f64_u, "i32.trunc_sat_f64_u", 0, IF_OPCODE,  0x03FC)
-INST(i64_trunc_sat_f32_s, "i64.trunc_sat_f32_s", 0, IF_OPCODE,  0x04FC)
-INST(i64_trunc_sat_f32_u, "i64.trunc_sat_f32_u", 0, IF_OPCODE,  0x05FC)
-INST(i64_trunc_sat_f64_s, "i64.trunc_sat_f64_s", 0, IF_OPCODE,  0x06FC)
-INST(i64_trunc_sat_f64_u, "i64.trunc_sat_f64_u", 0, IF_OPCODE,  0x07FC)
+INST2(i32_trunc_sat_f32_s, "i32.trunc_sat_f32_s", 0, IF_OPCODE,  0xFC, 0)
+INST2(i32_trunc_sat_f32_u, "i32.trunc_sat_f32_u", 0, IF_OPCODE,  0xFC, 1)
+INST2(i32_trunc_sat_f64_s, "i32.trunc_sat_f64_s", 0, IF_OPCODE,  0xFC, 2)
+INST2(i32_trunc_sat_f64_u, "i32.trunc_sat_f64_u", 0, IF_OPCODE,  0xFC, 3)
+INST2(i64_trunc_sat_f32_s, "i64.trunc_sat_f32_s", 0, IF_OPCODE,  0xFC, 4)
+INST2(i64_trunc_sat_f32_u, "i64.trunc_sat_f32_u", 0, IF_OPCODE,  0xFC, 5)
+INST2(i64_trunc_sat_f64_s, "i64.trunc_sat_f64_s", 0, IF_OPCODE,  0xFC, 6)
+INST2(i64_trunc_sat_f64_u, "i64.trunc_sat_f64_u", 0, IF_OPCODE,  0xFC, 7)
 
-INST(memory_copy,         "memory.copy",         0, IF_MEMIDX_MEMIDX, 0x0AFC)
-INST(memory_fill,         "memory.fill",         0, IF_ULEB128,       0x0BFC)
+INST2(memory_copy,         "memory.copy",         0, IF_MEMIDX_MEMIDX, 0xFC, 10)
+INST2(memory_fill,         "memory.fill",         0, IF_ULEB128,       0xFC, 11)
 
 // clang-format on
 
 #undef INST
+#undef INST2


### PR DESCRIPTION
My previous fix only made 2 byte instructions work, but in theory wasm can have larger variable sized instructions. This change allows us to define the instructions in the same format that the spec defines them, and supports emitting any of them (as long as the variable sized opcode fits in a uint16_t which should be good enough for now.