### PR TITLE
Disable attribute trimming android 124958

### DIFF
--- a/src/tests/nativeaot/SmokeTests/AttributeTrimming/AttributeTrimming.csproj
+++ b/src/tests/nativeaot/SmokeTests/AttributeTrimming/AttributeTrimming.csproj
@@ -3,6 +3,8 @@
     <OutputType>Exe</OutputType>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Disabled on Android pending investigation of https://github.com/dotnet/runtime/issues/124958 -->
+    <CLRTestTargetUnsupported Condition="'$(TargetsAndroid)' == 'true'">true</CLRTestTargetUnsupported>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>
   </PropertyGroup>

--- a/src/tests/nativeaot/SmokeTests/AttributeTrimming/AttributeTrimming.csproj
+++ b/src/tests/nativeaot/SmokeTests/AttributeTrimming/AttributeTrimming.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <CLRTestPriority>0</CLRTestPriority>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Disabled on Android pending investigation of https://github.com/dotnet/runtime/issues/124958 -->
+    <!-- Disabled on Android since the test is very sensitive to specific trimming behavior and Android code (interop and such) make the trimming unpredictable -->
     <CLRTestTargetUnsupported Condition="'$(TargetsAndroid)' == 'true'">true</CLRTestTargetUnsupported>
     <RequiresProcessIsolation>true</RequiresProcessIsolation>
     <ReferenceXUnitWrapperGenerator>false</ReferenceXUnitWrapperGenerator>


### PR DESCRIPTION
Disable AttributeTrimming test on Android.

The test is very sensitive to specific trimming behavior, but running it on Android adds a lot of code from the Android hosting/interop which influences trimming and thus makes the test unpredictable.

Fixes https://github.com/dotnet/runtime/issues/124958