### PR TITLE
Refactor loader heap backout adapter to remove multiple inheritance

### DIFF
--- a/src/coreclr/inc/loaderheap.h
+++ b/src/coreclr/inc/loaderheap.h
@@ -54,7 +54,7 @@ struct TaggedMemAllocPtr
     void        *m_pMem;                //Pointer to AllocMem'd block (needed to pass back to BackoutMem)
     size_t       m_dwRequestedSize;     //Requested allocation size (needed to pass back to BackoutMem)
 
-    ILoaderHeapBackout  *m_pHeap;          //The heap that alloc'd the block (needed to know who to call BackoutMem on)
+    ILoaderHeapBackout  *m_pHeap;          //The backout target for the allocation (needed to know who to call BackoutMem on)
 
     //For AllocMem'd blocks, this is always 0.
     //For AllocAlignedMem blocks, you have to add m_dwExtra to m_pMem to arrive
@@ -207,7 +207,7 @@ protected:
 // pointer allocation (although not the actual allocation routines).
 //===============================================================================
 typedef DPTR(class UnlockedLoaderHeapBase) PTR_UnlockedLoaderHeapBase;
-class UnlockedLoaderHeapBase : public UnlockedLoaderHeapBaseTraversable, public ILoaderHeapBackout
+class UnlockedLoaderHeapBase : public UnlockedLoaderHeapBaseTraversable
 {
 #ifdef _DEBUG
     friend class LoaderHeapSniffer;
@@ -216,9 +216,64 @@ class UnlockedLoaderHeapBase : public UnlockedLoaderHeapBaseTraversable, public 
     friend class ClrDataAccess;
 #endif
 
+private:
+    class LoaderHeapBackout final : public ILoaderHeapBackout
+    {
+    public:
+        explicit LoaderHeapBackout(UnlockedLoaderHeapBase *pOwner)
+            : m_pOwner(pOwner)
+        {
+            LIMITED_METHOD_CONTRACT;
+        }
+
+        void RealBackoutMem(void *pMem
+                            , size_t dwSize
+#ifdef _DEBUG
+                            , _In_ _In_z_ const char *szFile
+                            , int lineNum
+                            , _In_ _In_z_ const char *szAllocFile
+                            , int allocLineNum
+#endif
+                            ) override
+        {
+            WRAPPER_NO_CONTRACT;
+            m_pOwner->RealBackoutMem(pMem
+                                     , dwSize
+#ifdef _DEBUG
+                                     , szFile
+                                     , lineNum
+                                     , szAllocFile
+                                     , allocLineNum
+#endif
+                                     );
+        }
+
+    private:
+        UnlockedLoaderHeapBase *m_pOwner;
+    };
+
 protected:
     size_t GetBytesAvailCommittedRegion();
+    ILoaderHeapBackout *GetBackoutInterface()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return &m_backout;
+    }
 
+    virtual void RealBackoutMem(void *pMem
+                                , size_t dwSize
+#ifdef _DEBUG
+                                , _In_ _In_z_ const char *szFile
+                                , int lineNum
+                                , _In_ _In_z_ const char *szAllocFile
+                                , int allocLineNum
+#endif
+                                ) = 0;
+
+private:
+    LoaderHeapBackout m_backout;
+
+protected:
 #ifndef DACCESS_COMPILE
     const 
 #endif
@@ -234,7 +289,10 @@ protected:
     
 public:
 #ifdef DACCESS_COMPILE
-    UnlockedLoaderHeapBase() {}
+    UnlockedLoaderHeapBase()
+        : m_backout(this)
+    {
+    }
 #else
     UnlockedLoaderHeapBase(LoaderHeapImplementationKind kind);
     virtual ~UnlockedLoaderHeapBase();
@@ -801,7 +859,7 @@ public:
             TaggedMemAllocPtr tmap;
             tmap.m_pMem             = NULL;
             tmap.m_dwRequestedSize  = dwSize.Value();
-            tmap.m_pHeap            = this;
+            tmap.m_pHeap            = GetBackoutInterface();
             tmap.m_dwExtra          = 0;
 #ifdef _DEBUG
             tmap.m_szFile           = szFile;
@@ -836,7 +894,7 @@ private:
                                  );
         tmap.m_pMem             = pResult;
         tmap.m_dwRequestedSize  = dwSize;
-        tmap.m_pHeap            = this;
+        tmap.m_pHeap            = GetBackoutInterface();
         tmap.m_dwExtra          = 0;
 #ifdef _DEBUG
         tmap.m_szFile           = szFile;
@@ -869,7 +927,7 @@ private:
 
         tmap.m_pMem             = pResult;
         tmap.m_dwRequestedSize  = dwSize;
-        tmap.m_pHeap            = this;
+        tmap.m_pHeap            = GetBackoutInterface();
         tmap.m_dwExtra          = 0;
 #ifdef _DEBUG
         tmap.m_szFile           = szFile;
@@ -918,7 +976,7 @@ public:
 
         tmap.m_pMem             = (void*)(((BYTE*)pResult) - dwExtra);
         tmap.m_dwRequestedSize  = dwRequestedSize + dwExtra;
-        tmap.m_pHeap            = this;
+        tmap.m_pHeap            = GetBackoutInterface();
         tmap.m_dwExtra          = dwExtra;
 #ifdef _DEBUG
         tmap.m_szFile           = szFile;
@@ -959,7 +1017,7 @@ public:
 
         tmap.m_pMem             = (void*)(((BYTE*)pResult) - dwExtra);
         tmap.m_dwRequestedSize  = dwRequestedSize + dwExtra;
-        tmap.m_pHeap            = this;
+        tmap.m_pHeap            = GetBackoutInterface();
         tmap.m_dwExtra          = dwExtra;
 #ifdef _DEBUG
         tmap.m_szFile           = szFile;
@@ -982,7 +1040,7 @@ public:
                         , _In_ _In_z_ const char *szAllocFile
                         , int allocLineNum
 #endif
-                        )
+                        ) override
     {
         WRAPPER_NO_CONTRACT;
         CRITSEC_Holder csh(m_CriticalSection);
@@ -1093,7 +1151,7 @@ public:
 
         tmap.m_pMem             = pResult;
         tmap.m_dwRequestedSize  = 1;
-        tmap.m_pHeap            = this;
+        tmap.m_pHeap            = GetBackoutInterface();
         tmap.m_dwExtra          = 0;
 #ifdef _DEBUG
         tmap.m_szFile           = szFile;
@@ -1116,7 +1174,7 @@ public:
                         , _In_ _In_z_ const char *szAllocFile
                         , int allocLineNum
 #endif
-                        )
+                        ) override
     {
         WRAPPER_NO_CONTRACT;
         CRITSEC_Holder csh(m_CriticalSection);

--- a/src/coreclr/utilcode/loaderheap_shared.cpp
+++ b/src/coreclr/utilcode/loaderheap_shared.cpp
@@ -15,6 +15,7 @@ RandomForLoaderHeap s_randomForLoaderHeap;
 INDEBUG(DWORD UnlockedLoaderHeapBase::s_dwNumInstancesOfLoaderHeaps = 0;)
 
 UnlockedLoaderHeapBase::UnlockedLoaderHeapBase(LoaderHeapImplementationKind kind) : 
+    m_backout(this),
     m_kind(kind),
     m_dwTotalAlloc(0),
     m_pAllocPtr(NULL),


### PR DESCRIPTION
A more complete example of what I was talking about in https://github.com/dotnet/runtime/pull/125129#discussion_r2950250286. We can either merge this PR or close it and incorporate similar changes in 125129