### PR TITLE
Avoid SocketException flood in NamedPipeClientStream on Unix

### DIFF
--- a/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
+++ b/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Unix.cs
@@ -35,6 +35,19 @@ namespace System.IO.Pipes
             // either succeeding immediately if the server is listening or failing
             // immediately if it isn't.  The only delay will be between the time the server
             // has called Bind and Listen, with the latter immediately following the former.
+
+            // If the socket file doesn't exist yet, skip the socket allocation and
+            // Connect call that would throw a SocketException.  Only ENOENT (not found)
+            // is short-circuited; permission errors and other conditions still reach
+            // socket.Connect so they surface their specific exceptions.
+            // TOCTOU note: the file could appear between this check and the next retry
+            // iteration, but ConnectInternal's polling loop handles that naturally.
+            if (Interop.Sys.Stat(_normalizedPipePath!, out Interop.Sys.FileStatus _) != 0 &&
+                Interop.Sys.GetLastErrorInfo().Error == Interop.Error.ENOENT)
+            {
+                return false;
+            }
+
             var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
             SafePipeHandle? clientHandle = null;
             try

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -632,6 +632,42 @@ namespace System.IO.Pipes.Tests
             }
         }
 
+        [Fact]
+        [PlatformSpecific(TestPlatforms.AnyUnix)]
+        [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
+        public void ClientConnect_PipeNotFound_DoesNotFloodFirstChanceExceptions()
+        {
+            string pipeName = PipeStreamConformanceTests.GetUniquePipeName();
+            int socketExceptionCount = 0;
+
+            EventHandler<System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs> handler = (sender, args) =>
+            {
+                if (args.Exception is Net.Sockets.SocketException)
+                {
+                    Interlocked.Increment(ref socketExceptionCount);
+                }
+            };
+
+            AppDomain.CurrentDomain.FirstChanceException += handler;
+            try
+            {
+                using (NamedPipeClientStream client = new NamedPipeClientStream(pipeName))
+                {
+                    Assert.Throws<TimeoutException>(() => client.Connect(500));
+                }
+            }
+            finally
+            {
+                AppDomain.CurrentDomain.FirstChanceException -= handler;
+            }
+
+            // Before the fix, connecting to a non-existent pipe for 500ms would
+            // throw hundreds or thousands of SocketExceptions internally.
+            // With the Stat-based guard, zero SocketExceptions should be thrown
+            // when the pipe file never exists. Allow a small margin for races.
+            Assert.InRange(socketExceptionCount, 0, 5);
+        }
+
         [Theory]
         [MemberData(nameof(GetCancellationTokens))]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]

--- a/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
+++ b/src/libraries/System.IO.Pipes/tests/NamedPipeTests/NamedPipeTest.Specific.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.DotNet.RemoteExecutor;
 using Xunit;
 
 namespace System.IO.Pipes.Tests
@@ -632,40 +633,43 @@ namespace System.IO.Pipes.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact(typeof(RemoteExecutor), nameof(RemoteExecutor.IsSupported))]
         [PlatformSpecific(TestPlatforms.AnyUnix)]
         [SkipOnPlatform(TestPlatforms.iOS | TestPlatforms.tvOS, "iOS/tvOS blocks binding to UNIX sockets")]
         public void ClientConnect_PipeNotFound_DoesNotFloodFirstChanceExceptions()
         {
-            string pipeName = PipeStreamConformanceTests.GetUniquePipeName();
-            int socketExceptionCount = 0;
-
-            EventHandler<System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs> handler = (sender, args) =>
+            RemoteExecutor.Invoke(() =>
             {
-                if (args.Exception is Net.Sockets.SocketException)
+                string pipeName = PipeStreamConformanceTests.GetUniquePipeName();
+                int socketExceptionCount = 0;
+
+                EventHandler<System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs> handler = (sender, args) =>
                 {
-                    Interlocked.Increment(ref socketExceptionCount);
-                }
-            };
+                    if (args.Exception is Net.Sockets.SocketException)
+                    {
+                        Interlocked.Increment(ref socketExceptionCount);
+                    }
+                };
 
-            AppDomain.CurrentDomain.FirstChanceException += handler;
-            try
-            {
-                using (NamedPipeClientStream client = new NamedPipeClientStream(pipeName))
+                AppDomain.CurrentDomain.FirstChanceException += handler;
+                try
                 {
-                    Assert.Throws<TimeoutException>(() => client.Connect(500));
+                    using (NamedPipeClientStream client = new NamedPipeClientStream(pipeName))
+                    {
+                        Assert.Throws<TimeoutException>(() => client.Connect(500));
+                    }
                 }
-            }
-            finally
-            {
-                AppDomain.CurrentDomain.FirstChanceException -= handler;
-            }
+                finally
+                {
+                    AppDomain.CurrentDomain.FirstChanceException -= handler;
+                }
 
-            // Before the fix, connecting to a non-existent pipe for 500ms would
-            // throw hundreds or thousands of SocketExceptions internally.
-            // With the Stat-based guard, zero SocketExceptions should be thrown
-            // when the pipe file never exists. Allow a small margin for races.
-            Assert.InRange(socketExceptionCount, 0, 5);
+                // Before the fix, connecting to a non-existent pipe for 500ms would
+                // throw hundreds or thousands of SocketExceptions internally.
+                // With the Stat-based guard, zero SocketExceptions should be thrown
+                // when the pipe file never exists. Allow a small margin for races.
+                Assert.InRange(socketExceptionCount, 0, 5);
+            }).Dispose();
         }
 
         [Theory]


### PR DESCRIPTION
Resolves #117718. Following up on diagnosis by @lindexi.

When `NamedPipeClientStream.Connect()` waits for a non-existent pipe on Linux, the internal retry loop creates a `Socket` and calls `Connect()` on every iteration. Each attempt throws and catches a `SocketException`, flooding `FirstChanceException` handlers and wasting CPU on exception allocation.

This change adds a `Stat` check at the top of `TryConnect`: if the socket file doesn't exist (`ENOENT`), the method returns `false` immediately without allocating a `Socket` or throwing. Permission errors (`EACCES`) and all other conditions still fall through to the existing `socket.Connect` path, preserving their specific exception behavior.

The check introduces a benign TOCTOU window: if the pipe file appears between the `Stat` call and the next loop iteration, `ConnectInternal`'s polling loop picks it up on the subsequent retry. This does not reintroduce the exception flood since the file now exists and `Connect` will either succeed or fail with a non-retryable error.

### Changes
- `NamedPipeClientStream.Unix.cs`: Added `Interop.Sys.Stat` / `ENOENT` guard before socket allocation in `TryConnect`
- `NamedPipeTest.Specific.cs`: Added Unix-specific test that verifies connecting to a non-existent pipe does not flood `FirstChanceException` with `SocketException`s

### Test plan
- New test: `ClientConnect_PipeNotFound_DoesNotFloodFirstChanceExceptions` — connects to a non-existent pipe for 500ms, asserts fewer than 5 `SocketException`s via `FirstChanceException` (previously hundreds/thousands)
- Existing test: `ClientConnect_Throws_Timeout_When_Pipe_Not_Found` — verifies `TimeoutException` still thrown (unchanged behavior)