### PR TITLE
SPMI: Fix invalid format string and allow parsing full uint32 range

### DIFF
--- a/src/coreclr/tools/superpmi/superpmi/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jithost.cpp
@@ -116,10 +116,10 @@ bool JitHost::convertStringValueToInt(const char* key, const char* stringValue, 
 
     char*      endPtr;
     unsigned long longResult = strtoul(stringValue, &endPtr, 16);
-    bool          succeeded  = (errno != ERANGE) && (endPtr != stringValue) && (longResult <= INT_MAX);
+    bool          succeeded  = (errno != ERANGE) && (endPtr != stringValue) && (longResult <= UINT_MAX);
     if (!succeeded)
     {
-        LogWarning("Can't convert int config value from string, key: %ws, string value: %ws\n", key, stringValue);
+        LogWarning("Can't convert int config value from string, key: %s, string value: %s\n", key, stringValue);
         return false;
     }
 

--- a/src/coreclr/tools/superpmi/superpmi/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jithost.cpp
@@ -114,7 +114,7 @@ bool JitHost::convertStringValueToInt(const char* key, const char* stringValue, 
         return false;
     }
 
-    char*      endPtr;
+    char* endPtr;
     errno = 0;
     unsigned long longResult = strtoul(stringValue, &endPtr, 16);
     bool          succeeded  = (errno != ERANGE) && (endPtr != stringValue) && (longResult <= UINT_MAX);

--- a/src/coreclr/tools/superpmi/superpmi/jithost.cpp
+++ b/src/coreclr/tools/superpmi/superpmi/jithost.cpp
@@ -115,6 +115,7 @@ bool JitHost::convertStringValueToInt(const char* key, const char* stringValue, 
     }
 
     char*      endPtr;
+    errno = 0;
     unsigned long longResult = strtoul(stringValue, &endPtr, 16);
     bool          succeeded  = (errno != ERANGE) && (endPtr != stringValue) && (longResult <= UINT_MAX);
     if (!succeeded)


### PR DESCRIPTION
Noticed that e.g. `DOTNET_JitHashBreak=9b29601d` hits the error path below, which hits an assert due to `%ws`. Fix the format string, and then also fix the parsing so that it works properly when the upper bit is set.

PTAL @dotnet/jit-contrib 