### PR TITLE
Fix ErrorOnUnknownConfiguration to respect ConfigurationKeyNameAttribute

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/src/ConfigurationBinder.cs
@@ -223,7 +223,7 @@ namespace Microsoft.Extensions.Configuration
 
             if (options.ErrorOnUnknownConfiguration)
             {
-                HashSet<string> propertyNames = new(modelProperties.Select(mp => mp.Name),
+                HashSet<string> propertyNames = new(modelProperties.Select(GetPropertyName),
                     StringComparer.OrdinalIgnoreCase);
 
                 List<string>? missingPropertyNames = null;

--- a/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.Binder/tests/Common/ConfigurationBinderTests.cs
@@ -478,6 +478,26 @@ if (!System.Diagnostics.Debugger.IsAttached) { System.Diagnostics.Debugger.Launc
         }
 
         [Fact]
+        public void DoesNotThrowWhenConfigKeyMatchesConfigurationKeyNameAttribute()
+        {
+            var dic = new Dictionary<string, string>
+            {
+                {"Named_Property", "Yo"},
+                {"Integer", "-2"},
+                {"Boolean", "TRUe"},
+                {"Nested:Integer", "11"}
+            };
+            var configurationBuilder = new ConfigurationBuilder();
+            configurationBuilder.AddInMemoryCollection(dic);
+            var config = configurationBuilder.Build();
+
+            var instance = new ComplexOptions();
+            config.Bind(instance, o => o.ErrorOnUnknownConfiguration = true);
+
+            Assert.Equal("Yo", instance.NamedProperty);
+        }
+
+        [Fact]
         public void GetDefaultsWhenDataDoesNotExist()
         {
             var dic = new Dictionary<string, string>


### PR DESCRIPTION
> [!NOTE]
> This contribution was authored with the assistance of AI (Claude Code).

Resolves #119114. Following up on diagnosis by @geekninjaa.

## Summary

When `ErrorOnUnknownConfiguration` is enabled, `BindProperties` builds a `HashSet<string>` of known property names to validate configuration keys against. This set was built using `PropertyInfo.Name`, ignoring any `[ConfigurationKeyName]` attribute on the property.

This caused a false `InvalidOperationException` when a configuration key matched the attribute-specified name (e.g., `"Foo"`) but not the C# property name (e.g., `Bar`).

The fix uses the existing `GetPropertyName` helper which already resolves `ConfigurationKeyNameAttribute`. This aligns the reflection-based binder with the source generator path, which already handles this correctly via `ConfigurationKeyName` in its key cache.

## Changes

- `ConfigurationBinder.cs`: Replace `mp.Name` with `GetPropertyName` method group reference in the `ErrorOnUnknownConfiguration` validation block
- `ConfigurationBinderTests.cs`: Add test verifying that `ErrorOnUnknownConfiguration` does not throw when config keys match `ConfigurationKeyNameAttribute` values

## Test Plan

- [ ] New test `DoesNotThrowWhenConfigKeyMatchesConfigurationKeyNameAttribute` validates the fix using the existing `ComplexOptions` class which has `[ConfigurationKeyName("Named_Property")]` on its `NamedProperty` property
- [ ] Existing `ErrorOnUnknownConfiguration` tests continue to pass (CI)
- [ ] Existing `CanBindConfigurationKeyNameAttributes` test continues to pass (CI)