### PR TITLE
Split Dictionary.Remove inner loops for value-type key optimization

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -1294,6 +1294,7 @@ namespace System.Collections.Generic
             // The overload Remove(TKey key, out TValue value) is a copy of this method with one additional
             // statement to copy the value for entry being removed into the output parameter.
             // Code has been intentionally duplicated for performance reasons.
+            // If you make any changes here, make sure to keep that version in sync as well.
 
             if (key == null)
             {
@@ -1313,49 +1314,101 @@ namespace System.Collections.Generic
                 Entry[]? entries = _entries;
                 int last = -1;
                 int i = bucket - 1; // Value in buckets is 1-based
-                while (i >= 0)
+
+                if (typeof(TKey).IsValueType && // comparer can only be null for value types; enable JIT to eliminate entire if block for ref types
+                    comparer == null)
                 {
-                    ref Entry entry = ref entries[i];
-
-                    if (entry.hashCode == hashCode &&
-                        (typeof(TKey).IsValueType && comparer == null ? EqualityComparer<TKey>.Default.Equals(entry.key, key) : comparer!.Equals(entry.key, key)))
+                    while (i >= 0)
                     {
-                        if (last < 0)
+                        ref Entry entry = ref entries[i];
+
+                        if (entry.hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entry.key, key))
                         {
-                            bucket = entry.next + 1; // Value in buckets is 1-based
-                        }
-                        else
-                        {
-                            entries[last].next = entry.next;
+                            if (last < 0)
+                            {
+                                bucket = entry.next + 1; // Value in buckets is 1-based
+                            }
+                            else
+                            {
+                                entries[last].next = entry.next;
+                            }
+
+                            Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
+                            entry.next = StartOfFreeList - _freeList;
+
+                            if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
+                            {
+                                entry.key = default!;
+                            }
+
+                            if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
+                            {
+                                entry.value = default!;
+                            }
+
+                            _freeList = i;
+                            _freeCount++;
+                            return true;
                         }
 
-                        Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
-                        entry.next = StartOfFreeList - _freeList;
+                        last = i;
+                        i = entry.next;
 
-                        if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
+                        collisionCount++;
+                        if (collisionCount > (uint)entries.Length)
                         {
-                            entry.key = default!;
+                            // The chain of entries forms a loop; which means a concurrent update has happened.
+                            // Break out of the loop and throw, rather than looping forever.
+                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
                         }
-
-                        if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
-                        {
-                            entry.value = default!;
-                        }
-
-                        _freeList = i;
-                        _freeCount++;
-                        return true;
                     }
-
-                    last = i;
-                    i = entry.next;
-
-                    collisionCount++;
-                    if (collisionCount > (uint)entries.Length)
+                }
+                else
+                {
+                    Debug.Assert(comparer is not null);
+                    while (i >= 0)
                     {
-                        // The chain of entries forms a loop; which means a concurrent update has happened.
-                        // Break out of the loop and throw, rather than looping forever.
-                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                        ref Entry entry = ref entries[i];
+
+                        if (entry.hashCode == hashCode && comparer.Equals(entry.key, key))
+                        {
+                            if (last < 0)
+                            {
+                                bucket = entry.next + 1; // Value in buckets is 1-based
+                            }
+                            else
+                            {
+                                entries[last].next = entry.next;
+                            }
+
+                            Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
+                            entry.next = StartOfFreeList - _freeList;
+
+                            if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
+                            {
+                                entry.key = default!;
+                            }
+
+                            if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
+                            {
+                                entry.value = default!;
+                            }
+
+                            _freeList = i;
+                            _freeCount++;
+                            return true;
+                        }
+
+                        last = i;
+                        i = entry.next;
+
+                        collisionCount++;
+                        if (collisionCount > (uint)entries.Length)
+                        {
+                            // The chain of entries forms a loop; which means a concurrent update has happened.
+                            // Break out of the loop and throw, rather than looping forever.
+                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                        }
                     }
                 }
             }
@@ -1367,6 +1420,7 @@ namespace System.Collections.Generic
             // This overload is a copy of the overload Remove(TKey key) with one additional
             // statement to copy the value for entry being removed into the output parameter.
             // Code has been intentionally duplicated for performance reasons.
+            // If you make any changes here, make sure to keep the other overload in sync as well.
 
             if (key == null)
             {
@@ -1386,51 +1440,105 @@ namespace System.Collections.Generic
                 Entry[]? entries = _entries;
                 int last = -1;
                 int i = bucket - 1; // Value in buckets is 1-based
-                while (i >= 0)
+
+                if (typeof(TKey).IsValueType && // comparer can only be null for value types; enable JIT to eliminate entire if block for ref types
+                    comparer == null)
                 {
-                    ref Entry entry = ref entries[i];
-
-                    if (entry.hashCode == hashCode &&
-                        (typeof(TKey).IsValueType && comparer == null ? EqualityComparer<TKey>.Default.Equals(entry.key, key) : comparer!.Equals(entry.key, key)))
+                    while (i >= 0)
                     {
-                        if (last < 0)
+                        ref Entry entry = ref entries[i];
+
+                        if (entry.hashCode == hashCode && EqualityComparer<TKey>.Default.Equals(entry.key, key))
                         {
-                            bucket = entry.next + 1; // Value in buckets is 1-based
+                            if (last < 0)
+                            {
+                                bucket = entry.next + 1; // Value in buckets is 1-based
+                            }
+                            else
+                            {
+                                entries[last].next = entry.next;
+                            }
+
+                            value = entry.value;
+
+                            Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
+                            entry.next = StartOfFreeList - _freeList;
+
+                            if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
+                            {
+                                entry.key = default!;
+                            }
+
+                            if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
+                            {
+                                entry.value = default!;
+                            }
+
+                            _freeList = i;
+                            _freeCount++;
+                            return true;
                         }
-                        else
+
+                        last = i;
+                        i = entry.next;
+
+                        collisionCount++;
+                        if (collisionCount > (uint)entries.Length)
                         {
-                            entries[last].next = entry.next;
+                            // The chain of entries forms a loop; which means a concurrent update has happened.
+                            // Break out of the loop and throw, rather than looping forever.
+                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
                         }
-
-                        value = entry.value;
-
-                        Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
-                        entry.next = StartOfFreeList - _freeList;
-
-                        if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
-                        {
-                            entry.key = default!;
-                        }
-
-                        if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
-                        {
-                            entry.value = default!;
-                        }
-
-                        _freeList = i;
-                        _freeCount++;
-                        return true;
                     }
-
-                    last = i;
-                    i = entry.next;
-
-                    collisionCount++;
-                    if (collisionCount > (uint)entries.Length)
+                }
+                else
+                {
+                    Debug.Assert(comparer is not null);
+                    while (i >= 0)
                     {
-                        // The chain of entries forms a loop; which means a concurrent update has happened.
-                        // Break out of the loop and throw, rather than looping forever.
-                        ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                        ref Entry entry = ref entries[i];
+
+                        if (entry.hashCode == hashCode && comparer.Equals(entry.key, key))
+                        {
+                            if (last < 0)
+                            {
+                                bucket = entry.next + 1; // Value in buckets is 1-based
+                            }
+                            else
+                            {
+                                entries[last].next = entry.next;
+                            }
+
+                            value = entry.value;
+
+                            Debug.Assert((StartOfFreeList - _freeList) < 0, "shouldn't underflow because max hashtable length is MaxPrimeArrayLength = 0x7FEFFFFD(2146435069) _freelist underflow threshold 2147483646");
+                            entry.next = StartOfFreeList - _freeList;
+
+                            if (RuntimeHelpers.IsReferenceOrContainsReferences<TKey>())
+                            {
+                                entry.key = default!;
+                            }
+
+                            if (RuntimeHelpers.IsReferenceOrContainsReferences<TValue>())
+                            {
+                                entry.value = default!;
+                            }
+
+                            _freeList = i;
+                            _freeCount++;
+                            return true;
+                        }
+
+                        last = i;
+                        i = entry.next;
+
+                        collisionCount++;
+                        if (collisionCount > (uint)entries.Length)
+                        {
+                            // The chain of entries forms a loop; which means a concurrent update has happened.
+                            // Break out of the loop and throw, rather than looping forever.
+                            ThrowHelper.ThrowInvalidOperationException_ConcurrentOperationsNotSupported();
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/Dictionary.cs
@@ -885,7 +885,7 @@ namespace System.Collections.Generic
                     Entry[]? entries = dictionary._entries;
                     int last = -1;
                     int i = bucket - 1; // Value in buckets is 1-based
-                    while (i >= 0)
+                    while ((uint)i < (uint)entries.Length)
                     {
                         ref Entry entry = ref entries[i];
 
@@ -1318,7 +1318,7 @@ namespace System.Collections.Generic
                 if (typeof(TKey).IsValueType && // comparer can only be null for value types; enable JIT to eliminate entire if block for ref types
                     comparer == null)
                 {
-                    while (i >= 0)
+                    while ((uint)i < (uint)entries.Length)
                     {
                         ref Entry entry = ref entries[i];
 
@@ -1366,7 +1366,7 @@ namespace System.Collections.Generic
                 else
                 {
                     Debug.Assert(comparer is not null);
-                    while (i >= 0)
+                    while ((uint)i < (uint)entries.Length)
                     {
                         ref Entry entry = ref entries[i];
 
@@ -1444,7 +1444,7 @@ namespace System.Collections.Generic
                 if (typeof(TKey).IsValueType && // comparer can only be null for value types; enable JIT to eliminate entire if block for ref types
                     comparer == null)
                 {
-                    while (i >= 0)
+                    while ((uint)i < (uint)entries.Length)
                     {
                         ref Entry entry = ref entries[i];
 
@@ -1494,7 +1494,7 @@ namespace System.Collections.Generic
                 else
                 {
                     Debug.Assert(comparer is not null);
-                    while (i >= 0)
+                    while ((uint)i < (uint)entries.Length)
                     {
                         ref Entry entry = ref entries[i];
 


### PR DESCRIPTION
## Split Dictionary.Remove inner loops for value-type key optimization

`FindValue`, `TryInsert`, and `CollectionsMarshalHelper.GetValueRefOrAddDefault` all split their inner loops into separate value-type and comparer paths:

```csharp
if (typeof(TKey).IsValueType && comparer == null)
{
    while (...) { ... EqualityComparer<TKey>.Default.Equals(...) ... }
}
else
{
    while (...) { ... comparer.Equals(...) ... }
}
```

This lets the JIT register-allocate each loop independently. The value-type loop has no virtual calls, so the register allocator can keep all loop variables in registers.

`Remove` (both overloads) was not split during the PR #75663 refactoring that introduced this pattern. It uses a single loop with an inline ternary:

```csharp
while (i >= 0)
{
    if (entry.hashCode == hashCode &&
        (typeof(TKey).IsValueType && comparer == null
            ? EqualityComparer<TKey>.Default.Equals(entry.key, key)
            : comparer!.Equals(entry.key, key)))
    { ... }
}
```

The JIT keeps both code paths alive in a single loop, so the register allocator must plan for the comparer virtual call even on the value-type path. This causes unnecessary stack spills and reloads every iteration.

This PR applies the same split to both `Remove(TKey key)` and `Remove(TKey key, out TValue value)`.

### Codegen impact (x64, `Dictionary<int, int>.Remove`)

**Before** (single merged loop): 3 spills + 3 reloads per iteration

```asm
; LOOP ENTRY - spills happen every iteration
mov  [rsp+0x30], r10d       ; SPILL entries.Length
mov  [rsp+0x34], eax        ; SPILL i
mov  [rsp+0x28], r9         ; SPILL &entries[i]
...
; LOOP ADVANCE - reloads
mov  eax, [rsp+0x34]        ; RELOAD i
mov  eax, [r9+0x04]         ; i = entry.next
cmp  [rsp+0x30], edi        ; RELOAD entries.Length
```

**After** (value-type loop): 0 spills, 0 reloads

```asm
; LOOP BODY - all registers
cmp  eax, ebp               ; bounds check (register)
lea  rcx, [r13+rcx+0x10]    ; &entries[i] (register)
cmp  [rcx], r14d             ; hashCode (register)
cmp  [rcx+0x08], esi         ; key compare - direct, no virtual call
; LOOP ADVANCE
mov  eax, [rcx+0x04]        ; i = entry.next (register)
cmp  ebp, edi               ; entries.Length (register)
```

arm64 shows the same pattern: baseline has 1 spill + 2 reloads per iteration (fewer due to more callee-saved registers); modified value-type loop has 0.

### Benchmark results

Both builds from identical commit (b38cc2aaada), only `Dictionary.cs` differs. BDN v0.16.0-nightly, `--coreRun` A/B, MannWhitney statistical test with 3ns threshold. Two independent runs: Run 1 (15 iterations), Run 2 (30 iterations, high priority process). Run 2 shown below; Run 1 results were consistent.

Machine: Intel Core i9-14900K 3.20GHz, 24 cores (hybrid P/E), 64GB RAM, Windows 11.

#### All Remove scenarios (Run 2, 30 iterations)

| Type | Method | Size | Baseline (ns) | Modified (ns) | Ratio | MannWhitney |
|------|--------|------|---------------|---------------|-------|-------------|
| Guid, Int32 | Remove_Hit | 16 | 101.0 | 84.1 | 0.83 | **Faster** <-- |
| Guid, Int32 | Remove_Hit | 512 | 3,081.4 | 2,864.2 | 0.93 | **Faster** <-- |
| Guid, Int32 | Remove_Hit | 4096 | 30,195.3 | 27,925.7 | 0.92 | **Faster** <-- |
| Guid, Int32 | Remove_Miss | 16 | 30.4 | 30.2 | 0.99 | Same |
| Guid, Int32 | Remove_Miss | 512 | 1,080.9 | 926.8 | 0.89 | Same |
| Guid, Int32 | Remove_Miss | 4096 | 8,750.4 | 8,850.4 | 1.01 | Slower |
| Guid, Int32 | TryRemove_Hit | 16 | 99.6 | 87.1 | 0.87 | **Faster** <-- |
| Guid, Int32 | TryRemove_Hit | 512 | 3,657.3 | 2,975.0 | 0.82 | **Faster** <-- |
| Guid, Int32 | TryRemove_Hit | 4096 | 29,808.7 | 28,089.5 | 0.94 | **Faster** <-- |
| Int32, Int32 | Remove_Hit | 16 | 67.5 | 63.3 | 0.94 | **Faster** <-- |
| Int32, Int32 | Remove_Hit | 512 | 2,266.9 | 2,124.9 | 0.94 | **Faster** <-- |
| Int32, Int32 | Remove_Hit | 4096 | 20,806.0 | 20,775.1 | 1.00 | Same <-- |
| Int32, Int32 | Remove_Miss | 16 | 24.7 | 23.5 | 0.95 | Same |
| Int32, Int32 | Remove_Miss | 512 | 716.1 | 668.5 | 0.93 | **Faster** |
| Int32, Int32 | Remove_Miss | 4096 | 6,414.8 | 6,647.6 | 1.04 | Slower |
| Int32, Int32 | TryRemove_Hit | 16 | 67.8 | 63.2 | 0.93 | **Faster** <-- |
| Int32, Int32 | TryRemove_Hit | 512 | 2,316.2 | 2,092.7 | 0.90 | **Faster** <-- |
| Int32, Int32 | TryRemove_Hit | 4096 | 21,362.0 | 20,311.9 | 0.95 | **Faster** <-- |
| String, String | Remove_Hit | 16 | 185.0 | 185.6 | 1.00 | Same |
| String, String | Remove_Hit | 512 | 6,986.0 | 6,827.3 | 0.98 | **Faster** |
| String, String | Remove_Hit | 4096 | 109,184.1 | 113,931.7 | 1.04 | Slower |
| String, String | Remove_Miss | 16 | 81.3 | 81.5 | 1.00 | Same |
| String, String | Remove_Miss | 512 | 2,482.6 | 2,491.2 | 1.00 | Same |
| String, String | Remove_Miss | 4096 | 49,162.6 | 48,452.3 | 0.99 | **Faster** |
| String, String | TryRemove_Hit | 16 | 185.8 | 185.8 | 1.00 | Same |
| String, String | TryRemove_Hit | 512 | 7,012.7 | 6,837.4 | 0.98 | **Faster** |
| String, String | TryRemove_Hit | 4096 | 113,241.7 | 111,874.3 | 0.99 | **Faster** |

#### Analysis

- **Value-type Hit (Guid, Int32): 6-18% faster** — consistent improvement across all sizes and both Remove overloads, statistically significant in both runs. These are marked with `<--`
- **String (ref type): neutral** — expected, as ref types always store a non-null comparer (since #75663) and always take the comparer path regardless of the loop split.
- **Miss scenarios: neutral** — expected, as the optimization eliminates register spills in the equality comparison, which is rarely reached on a miss (most iterations fail the hashCode check and skip immediately). Small fluctuations in both directions are within machine noise.

