### PR TITLE
Improve HashSet<T> performance by enabling JIT bounds check elimination

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
@@ -233,7 +233,7 @@ namespace System.Collections.Generic
                     // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
                     int hashCode = item!.GetHashCode();
                     int i = GetBucketRef(hashCode) - 1; // Value in _buckets is 1-based
-                    while (i >= 0)
+                    while ((uint)i < (uint)entries.Length)
                     {
                         ref Entry entry = ref entries[i];
                         if (entry.HashCode == hashCode && EqualityComparer<T>.Default.Equals(entry.Value, item))
@@ -255,7 +255,7 @@ namespace System.Collections.Generic
                     Debug.Assert(comparer is not null);
                     int hashCode = item != null ? comparer.GetHashCode(item) : 0;
                     int i = GetBucketRef(hashCode) - 1; // Value in _buckets is 1-based
-                    while (i >= 0)
+                    while ((uint)i < (uint)entries.Length)
                     {
                         ref Entry entry = ref entries[i];
                         if (entry.HashCode == hashCode && comparer.Equals(entry.Value, item))
@@ -309,7 +309,7 @@ namespace System.Collections.Generic
                 ref int bucket = ref GetBucketRef(hashCode);
                 int i = bucket - 1; // Value in buckets is 1-based
 
-                while (i >= 0)
+                while ((uint)i < (uint)entries.Length)
                 {
                     ref Entry entry = ref entries[i];
 
@@ -473,7 +473,7 @@ namespace System.Collections.Generic
                 hashCode = comparer.GetHashCode(item);
                 bucket = ref set.GetBucketRef(hashCode);
                 int i = bucket - 1; // Value in _buckets is 1-based
-                while (i >= 0)
+                while ((uint)i < (uint)entries.Length)
                 {
                     ref Entry entry = ref entries[i];
                     if (entry.HashCode == hashCode && comparer.Equals(item, entry.Value))
@@ -556,7 +556,7 @@ namespace System.Collections.Generic
                     ref int bucket = ref set.GetBucketRef(hashCode);
                     int i = bucket - 1; // Value in buckets is 1-based
 
-                    while (i >= 0)
+                    while ((uint)i < (uint)entries.Length)
                     {
                         ref Entry entry = ref entries[i];
 
@@ -1441,7 +1441,7 @@ namespace System.Collections.Generic
                 int i = bucket - 1; // Value in _buckets is 1-based
 
                 // ValueType: Devirtualize with EqualityComparer<TValue>.Default intrinsic
-                while (i >= 0)
+                while ((uint)i < (uint)entries.Length)
                 {
                     ref Entry entry = ref entries[i];
                     if (entry.HashCode == hashCode && EqualityComparer<T>.Default.Equals(entry.Value, value))
@@ -1465,7 +1465,7 @@ namespace System.Collections.Generic
                 hashCode = value != null ? comparer.GetHashCode(value) : 0;
                 bucket = ref GetBucketRef(hashCode);
                 int i = bucket - 1; // Value in _buckets is 1-based
-                while (i >= 0)
+                while ((uint)i < (uint)entries.Length)
                 {
                     ref Entry entry = ref entries[i];
                     if (entry.HashCode == hashCode && comparer.Equals(entry.Value, value))


### PR DESCRIPTION
# Improve HashSet<T> performance by enabling JIT bounds check elimination

Change `while (i >= 0)` to `while ((uint)i < (uint)entries.Length)` in all hash-chain traversal loops in `HashSet<T>`, matching the pattern already used in `Dictionary<TKey,TValue>`.

## Rationale

`Dictionary<TKey,TValue>` uses `while ((uint)i < (uint)entries.Length)` for its hash-chain loops (see `FindValue`, `TryInsert`, `Remove`). This unsigned comparison serves as both the loop exit condition and an implicit bounds check on `entries[i]`, allowing the JIT to eliminate the redundant range check.

`HashSet<T>` uses `while (i >= 0)` for the same purpose. While functionally equivalent (chain indices are always non-negative, with -1 as sentinel), this signed comparison only tells the JIT that `i` is non-negative — not that it's within array bounds. The JIT must therefore emit a separate bounds check on every `entries[i]` access.

Note: `HashSet<T>.AlternateEqualityComparer.FindValue` already uses the unsigned pattern (with a `do/while` + `(uint)i >= (uint)entries.Length` guard); this PR brings the remaining 7 loops into alignment.

## Changes

All changes are in `HashSet.cs`, one-line loop condition substitutions:
- `FindItemIndex` — 2 loops (value-type and comparer branches)
- `AddIfNotPresent` — 2 loops (value-type and comparer branches)
- `Remove` — 1 loop
- `AlternateEqualityComparer.Add` — 1 loop
- `AlternateEqualityComparer.Remove` — 1 loop

## JIT codegen

`FindItemIndex<int>` under FullOpts (x64):

**Before (385 bytes):** signed loop + separate bounds check
```asm
; loop top
cmp ecx, r13d
jae RNGCHKFAIL          ; <-- bounds check
...
; loop bottom
test ecx, ecx
jge LOOP_TOP             ; signed: i >= 0
```

**After (379 bytes):** unsigned loop, bounds check eliminated
```asm
; loop bottom
cmp r13d, ecx
ja LOOP_TOP              ; unsigned: Length > i (doubles as bounds check)
; no RNGCHKFAIL
```

## Benchmark results

BenchmarkDotNet v0.16.0, Intel Core i9-14900K, .NET 11.0.0-dev, `--affinity 1` (pinned to P-core).
Benchmark harness: `--coreRun` comparing baseline vs optimized CoreLib. Results confirmed stable across multiple runs; suspicious values were re-run with swapped `--coreRun` order to rule out positional bias.

### Int32 (value type, default comparer devirtualized + inlined)

| Benchmark | Size | Ratio | Notes |
|---|---|---|---|
| ContainsTrue | 512 | **0.90** | 10% faster |
| ContainsTrueComparer | 512 | **0.50** | 2x faster (see note below) |
| Remove_Hit | 16 | **0.97** | |
| Remove_Hit | 512 | **0.96** | |
| Remove_Hit | 4096 | **0.94–0.98** | |
| Remove_Miss | all | 1.00 | neutral |
| ContainsFalse | 512 | 1.00 | neutral |
| AddGivenSize | 512 | 1.00 | neutral |
| CreateAddAndRemove | 512 | 1.00 | neutral |
| CreateAddAndClear | 512 | 1.00 | neutral |
| CtorFromCollection | 512 | 1.00 | neutral |
| IterateForEach | 512 | 1.00 | neutral |

**ContainsTrueComparer 0.50:** This benchmark uses a custom `IEqualityComparer<int>` wrapping the default comparer, so it exercises FindItemIndex's comparer branch. Confirmed across 3 separate runs (0.50, 0.48, 0.52).

**Miss paths unaffected:** `ContainsFalse` and `Remove_Miss` are neutral as expected — on a miss with a good hash function, the bucket chain is typically empty or has a single entry, so the loop body barely executes and the per-iteration bounds check saving has minimal impact.

**Add paths neutral:** `AddGivenSize` and `CreateAddAndClear` are neutral because Add benchmarks are dominated by memory allocation and resize, not the duplicate-check chain walk.

### String (reference type)

| Benchmark | Size | Ratio | Notes |
|---|---|---|---|
| All benchmarks | all | 1.00 | neutral |

The bounds check is still eliminated for `string` (FindItemIndex: 345→335 bytes), but string hash and equality comparison costs dominate per-element work, making the saved instruction negligible.

### Summary

The improvement is concentrated on value types with the default comparer, where `EqualityComparer<T>.Default.Equals` is devirtualized and inlined to a simple comparison. In that case the bounds check is a meaningful fraction of per-element work in the inner loop.

**AlternateEqualityComparer paths:** Not exercised by existing benchmarks, but changed for consistency — `AlternateEqualityComparer.FindValue` already uses the unsigned pattern in the same file, so leaving `Add`/`Remove` with `while (i >= 0)` would create an inconsistency within the same inner class.

No regressions observed.

## Alternatives considered

Only 3 of the 7 changed loops have benchmarks that show measurable improvement (FindItemIndex x2, Remove). The remaining 4 (AddIfNotPresent x2, AlternateEqualityComparer Add/Remove) could be left unchanged to minimize the diff. However, that would increase inconsistency: `AlternateEqualityComparer.FindValue` already uses the unsigned pattern, and having a mix of `while (i >= 0)` and `while ((uint)i < (uint)entries.Length)` across hash-chain loops in the same file would be harder to reason about than a uniform pattern. Each change is a single mechanical token substitution with no behavioral difference.
