### PR TITLE
Fix dotnet-pgo SPGO crash in FlowSmoothing.MakeGraphFeasible

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/SPGO/SampleCorrelator.cs
+++ b/src/coreclr/tools/dotnet-pgo/SPGO/SampleCorrelator.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Diagnostics.Tools.Pgo
         public void SmoothAllProfiles()
         {
             foreach (PerMethodInfo pmi in _methodInf.Values)
-                pmi.Profile.SmoothFlow();
+                try { pmi.Profile.SmoothFlow(); } catch (Exception) { /* Skip methods with disconnected flow graphs */ }
         }
 
         public void AttributeSamplesToIP(ulong ip, long numSamples)


### PR DESCRIPTION
## Summary
- Wrap `SmoothFlow()` in try-catch in `SampleCorrelator.SmoothAllProfiles()` so one problematic method doesn't crash the entire SPGO pass

## Problem
`FlowSmoothing.MakeGraphFeasible()` throws `InvalidOperationException` ("Stack empty") when a method's flow graph has a node with positive sample count that doesn't connect to an exit node.

Since `SmoothAllProfiles()` iterates all methods without exception handling, one bad method's flow graph crashes the entire SPGO pipeline. All successfully attributed samples (143K+ in our case) are lost and dotnet-pgo falls back to the non-SPGO path.

Stack trace:
```
System.InvalidOperationException: Stack empty.
   at System.Collections.Generic.Stack`1.Peek()
   at Microsoft.Diagnostics.Tools.Pgo.FlowSmoothing`1.MakeGraphFeasible()
   at Microsoft.Diagnostics.Tools.Pgo.FlowSmoothing`1.Perform()
   at Microsoft.Diagnostics.Tools.Pgo.SampleProfile.SmoothFlow()
   at Microsoft.Diagnostics.Tools.Pgo.SampleCorrelator.SmoothAllProfiles()
```

## Fix
Catch exceptions from `SmoothFlow()` per-method so the remaining methods' SPGO data is preserved.

## Test plan
- [x] Reproduced with perfcollect .trace.zip containing ~1.9M CPU samples
- [x] Without fix: 143K samples attributed then crash → falls back to main trace only
- [x] With fix: 143K samples attributed, bad methods skipped, SPGO .mibc generated