### PR TITLE
Denote cgroups as unsupported on OpenBSD

### DIFF
--- a/src/coreclr/pal/src/configure.cmake
+++ b/src/coreclr/pal/src/configure.cmake
@@ -650,7 +650,7 @@ check_prototype_definition(
     statfs
     "int statfs(const char *path, struct statfs *buf)"
     0
-    ${STATFS_INCLUDES}
+    "sys/types.h;${STATFS_INCLUDES}"
     HAVE_NON_LEGACY_STATFS)
 
 configure_file(${CMAKE_CURRENT_LIST_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/config.h)

--- a/src/coreclr/pal/src/misc/cgroup.cpp
+++ b/src/coreclr/pal/src/misc/cgroup.cpp
@@ -87,7 +87,7 @@ private:
         // modes because both of those involve cgroup v1 controllers managing
         // resources.
 
-#if !HAVE_NON_LEGACY_STATFS || TARGET_WASM
+#if !HAVE_NON_LEGACY_STATFS || TARGET_OPENBSD || TARGET_WASM
         return 0;
 #else
         struct statfs stats;


### PR DESCRIPTION
OpenBSD does not support cgroups.

Fix `HAVE_NON_LEGACY_STATFS` while here. See #125562 where this was done for `libs.native`.

Contributes to #124911.
