### PR TITLE
Add null check ImmutableArray<T>.Builder.RemoveAll

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray_1.Builder.cs
@@ -540,6 +540,8 @@ namespace System.Collections.Immutable
             /// </param>
             public void RemoveAll(Predicate<T> match)
             {
+                Requires.NotNull(match, nameof(match));
+
                 List<int>? removeIndices = null;
                 for (int i = 0; i < _count; i++)
                 {

--- a/src/libraries/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
+++ b/src/libraries/System.Collections.Immutable/tests/ImmutableArrayBuilderTest.cs
@@ -413,6 +413,8 @@ namespace System.Collections.Immutable.Tests
             builder.RemoveAll(n => n % 2 == 0);
 
             Assert.Equal(new[] { 1, 3, 5, 7 }, builder);
+
+            AssertExtensions.Throws<ArgumentNullException>("match", () => builder.RemoveAll(match: null));
         }
 
         [Fact]


### PR DESCRIPTION
#125921
`ImmutableArray<T>.Builder.RemoveAll(Predicate<T>)` was missing a null check on the `match` parameter. Passing null would throw `NullReferenceException` or no exception instead of `ArgumentNullException`.
Add `Requires.NotNull` for the `match` parameter, and add a test case to verify that null throws `ArgumentNullException`.