### PR TITLE
Reference shared dotnet/arcade-skills in copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,6 +16,8 @@ Before making changes to a directory, search for `README.md` files in that direc
 
 If the changes are intended to improve performance, or if they could negatively impact performance, use the `performance-benchmark` skill to validate the impact before completing.
 
+Additional shared skills for the .NET product are maintained in [dotnet/arcade-skills](https://github.com/dotnet/arcade-skills). When a task may benefit from a shared skill defined there, read that repo's README and the relevant SKILL.md files to find and follow applicable instructions.
+
 You MUST follow all code-formatting and naming conventions defined in [`.editorconfig`](/.editorconfig).
 
 In addition to the rules enforced by `.editorconfig`, you SHOULD:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@ Before making changes to a directory, search for `README.md` files in that direc
 
 If the changes are intended to improve performance, or if they could negatively impact performance, use the `performance-benchmark` skill to validate the impact before completing.
 
-Additional shared skills for the .NET product are maintained in [dotnet/arcade-skills](https://github.com/dotnet/arcade-skills). This currently includes skills for analyzing Azure DevOps CI/CD results and Helix test infrastructure, with more planned. When a task may benefit from a shared skill defined there, read that repo's README and the relevant SKILL.md files to find and follow applicable instructions.
+Additional shared skills for the .NET product are maintained in [dotnet/arcade-skills](https://github.com/dotnet/arcade-skills). This currently includes skills for analyzing Azure DevOps CI/CD results and Helix test infrastructure, and for analyzing test work item crashes encountered by pull requests. When a task may benefit from a shared skill defined there, read that repo's README and the relevant SKILL.md files to find and follow applicable instructions.
 
 You MUST follow all code-formatting and naming conventions defined in [`.editorconfig`](/.editorconfig).
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,7 +16,7 @@ Before making changes to a directory, search for `README.md` files in that direc
 
 If the changes are intended to improve performance, or if they could negatively impact performance, use the `performance-benchmark` skill to validate the impact before completing.
 
-Additional shared skills for the .NET product are maintained in [dotnet/arcade-skills](https://github.com/dotnet/arcade-skills). When a task may benefit from a shared skill defined there, read that repo's README and the relevant SKILL.md files to find and follow applicable instructions.
+Additional shared skills for the .NET product are maintained in [dotnet/arcade-skills](https://github.com/dotnet/arcade-skills). This currently includes skills for analyzing Azure DevOps CI/CD results and Helix test infrastructure, with more planned. When a task may benefit from a shared skill defined there, read that repo's README and the relevant SKILL.md files to find and follow applicable instructions.
 
 You MUST follow all code-formatting and naming conventions defined in [`.editorconfig`](/.editorconfig).
 


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

This adds a reference to [dotnet/arcade-skills](https://github.com/dotnet/arcade-skills) in the Copilot instructions, so that agents working in this repo can discover and use shared cross-repo skills maintained there.

Currently, agents in dotnet/runtime have no way to know that shared skills exist in arcade-skills. This one-liner points them to that repo's README and SKILL.md files when a task might benefit from a shared skill (e.g. CI/CD analysis, build pipeline workflows).
