### PR TITLE
Fix TestNativeDigits for ur-IN on Apple platforms

### DIFF
--- a/src/libraries/System.Runtime/tests/System.Globalization.Tests/NumberFormatInfo/NumberFormatInfoTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Globalization.Tests/NumberFormatInfo/NumberFormatInfoTests.cs
@@ -136,7 +136,10 @@ namespace System.Globalization.Tests
             yield return new object[] { "ccp-Cakm-BD", new string[] { "\U0001E950", "\U0001E951", "\U0001E952", "\U0001E953", "\U0001E954", "\U0001E955", "\U0001E956", "\U0001E957", "\U0001E958", "\U0001E959" }};
             yield return new object[] { "ar-SA",  new string[] {"\u0660", "\u0661", "\u0662", "\u0663", "\u0664", "\u0665", "\u0666", "\u0667", "\u0668", "\u0669" }};
             yield return new object[] { "en-US",  new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" }};
-            yield return new object[] { "ur-IN",  new string[] { "\u06F0", "\u06F1", "\u06F2", "\u06F3", "\u06F4", "\u06F5", "\u06F6", "\u06F7", "\u06F8", "\u06F9" }};
+            // Apple ICU on Apple platforms 26+ returns Latin digits for ur-IN, diverging from upstream CLDR which specifies arabext
+            yield return new object[] { "ur-IN",  PlatformDetection.IsApplePlatform26OrLater
+                ? new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" }
+                : new string[] { "\u06F0", "\u06F1", "\u06F2", "\u06F3", "\u06F4", "\u06F5", "\u06F6", "\u06F7", "\u06F8", "\u06F9" }};
         }
 
         public static bool FullICUPlatform => PlatformDetection.ICUVersion.Major >= 66 && PlatformDetection.IsNotBrowser;


### PR DESCRIPTION
Apple ICU returns Latin digits (`"0"`–`"9"`) for `CultureInfo.GetCultureInfo("ur-IN").NumberFormat.NativeDigits`, diverging from upstream CLDR which specifies Extended Arabic-Indic digits (`arabext`, U+06F0–U+06F9).

This test was not actually executing under xunit v2 — the xunit v3 assert upgrade (`Microsoft.DotNet.XUnitAssert` 2.9.3 → 3.2.2) made `ConditionalTheory` + `MemberData` work correctly, causing the test to run for the first time and exposing the Apple platform difference.

The fix conditions expected values on `PlatformDetection.IsApplePlatform` in `NativeDigitTestData()`, following the established pattern used elsewhere in the globalization tests (e.g., `NumberFormatInfoData.cs`, `RegionInfoTests.cs`).

Fixes #125933