### PR TITLE
Fix dotnet-pgo dump crash when CallWeights are present

### DIFF
--- a/src/coreclr/tools/dotnet-pgo/Program.cs
+++ b/src/coreclr/tools/dotnet-pgo/Program.cs
@@ -311,8 +311,10 @@ namespace Microsoft.Diagnostics.Tools.Pgo
                         jsonWriter.WriteStartArray("CallWeights");
                         foreach (var callWeight in data.CallWeights)
                         {
+                            jsonWriter.WriteStartObject();
                             jsonWriter.WriteString("Method", callWeight.Key.ToString());
                             jsonWriter.WriteNumber("Weight", callWeight.Value);
+                            jsonWriter.WriteEndObject();
                         }
                         jsonWriter.WriteEndArray();
                     }


### PR DESCRIPTION
## Summary

Fix `InvalidOperationException` in `dotnet-pgo dump` when the .mibc file contains CallWeights data.

## Problem

The JSON serialization writes named properties (`Method`, `Weight`) directly inside a JSON array without wrapping each entry in a JSON object:

```csharp
jsonWriter.WriteStartArray("CallWeights");
foreach (var callWeight in data.CallWeights)
{
    jsonWriter.WriteString("Method", ...);  // crash: property inside array
    jsonWriter.WriteNumber("Weight", ...);
}
```

## Fix

Add `WriteStartObject()` / `WriteEndObject()` around each array entry.

Fixes #125935