### PR TITLE
Fix Mono-style whitespace in UnsafeMethodMissingRequiresUnsafeAnalyze…

### DIFF
--- a/src/tools/illink/src/ILLink.RoslynAnalyzer/UnsafeMethodMissingRequiresUnsafeAnalyzer.cs
+++ b/src/tools/illink/src/ILLink.RoslynAnalyzer/UnsafeMethodMissingRequiresUnsafeAnalyzer.cs
@@ -9,65 +9,68 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace ILLink.RoslynAnalyzer
 {
-    [DiagnosticAnalyzer (LanguageNames.CSharp)]
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class UnsafeMethodMissingRequiresUnsafeAnalyzer : DiagnosticAnalyzer
     {
-        private static readonly DiagnosticDescriptor s_rule = DiagnosticDescriptors.GetDiagnosticDescriptor (DiagnosticId.UnsafeMethodMissingRequiresUnsafe, diagnosticSeverity: DiagnosticSeverity.Info);
+        private static readonly DiagnosticDescriptor s_rule = DiagnosticDescriptors.GetDiagnosticDescriptor(DiagnosticId.UnsafeMethodMissingRequiresUnsafe, diagnosticSeverity: DiagnosticSeverity.Info);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create (s_rule);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(s_rule);
 
-        public override void Initialize (AnalysisContext context)
+        public override void Initialize(AnalysisContext context)
         {
-            context.EnableConcurrentExecution ();
-            context.ConfigureGeneratedCodeAnalysis (GeneratedCodeAnalysisFlags.None);
-            context.RegisterCompilationStartAction (context => {
-                if (!context.Options.IsMSBuildPropertyValueTrue (MSBuildPropertyOptionNames.EnableUnsafeAnalyzer))
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterCompilationStartAction(context =>
+            {
+                if (!context.Options.IsMSBuildPropertyValueTrue(MSBuildPropertyOptionNames.EnableUnsafeAnalyzer))
                     return;
 
-                if (context.Compilation.GetTypeByMetadataName (RequiresUnsafeAnalyzer.FullyQualifiedRequiresUnsafeAttribute) is null)
+                if (context.Compilation.GetTypeByMetadataName(RequiresUnsafeAnalyzer.FullyQualifiedRequiresUnsafeAttribute) is null)
                     return;
 
-                context.RegisterSymbolAction (
+                context.RegisterSymbolAction(
                     AnalyzeMethod,
                     SymbolKind.Method);
             });
         }
 
-        private static void AnalyzeMethod (SymbolAnalysisContext context)
+        private static void AnalyzeMethod(SymbolAnalysisContext context)
         {
             if (context.Symbol is not IMethodSymbol method)
                 return;
 
-            if (!HasPointerInSignature (method))
+            if (!HasPointerInSignature(method))
                 return;
 
-            if (method.HasAttribute (RequiresUnsafeAnalyzer.RequiresUnsafeAttributeName))
+            if (method.HasAttribute(RequiresUnsafeAnalyzer.RequiresUnsafeAttributeName))
                 return;
 
             // For property/indexer accessors, check the containing property instead
             if (method.AssociatedSymbol is IPropertySymbol property
-                && property.HasAttribute (RequiresUnsafeAnalyzer.RequiresUnsafeAttributeName))
+                && property.HasAttribute(RequiresUnsafeAnalyzer.RequiresUnsafeAttributeName))
                 return;
 
-            foreach (var location in method.Locations) {
-                context.ReportDiagnostic (Diagnostic.Create (s_rule, location, method.GetDisplayName ()));
+            foreach (var location in method.Locations)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(s_rule, location, method.GetDisplayName()));
             }
         }
 
-        private static bool HasPointerInSignature (IMethodSymbol method)
+        private static bool HasPointerInSignature(IMethodSymbol method)
         {
-            if (IsPointerType (method.ReturnType))
+            if (IsPointerType(method.ReturnType))
                 return true;
 
-            foreach (var param in method.Parameters) {
-                if (IsPointerType (param.Type))
+            foreach (var param in method.Parameters)
+            {
+                if (IsPointerType(param.Type))
                     return true;
             }
 
             return false;
         }
 
-        private static bool IsPointerType (ITypeSymbol type) => type is IPointerTypeSymbol or IFunctionPointerTypeSymbol;
+        private static bool IsPointerType(ITypeSymbol type) => type is IPointerTypeSymbol or IFunctionPointerTypeSymbol;
     }
 }
 #endif


### PR DESCRIPTION
…r.cs

Remove spaces before parentheses in method calls/declarations and switch from K&R to Allman brace style to match the rest of the ILLink.RoslynAnalyzer codebase.