### PR TITLE
Fix 4 bugs in TypePreinit IL interpreter

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/TypePreinit.cs
@@ -1381,18 +1381,21 @@ namespace ILCompiler
                         StackEntry value1 = stack.Pop();
                         StackEntry value2 = stack.Pop();
 
-                        if (value1.ValueKind == value2.ValueKind
-                            && Value.TryCompareEquality(value1.Value, value2.Value, out bool compareResult))
+                        bool compareResult;
+                        if (value1.ValueKind == StackValueKind.Float && value2.ValueKind == StackValueKind.Float)
                         {
-                            stack.Push(StackValueKind.Int32,
-                                compareResult
-                                ? ValueTypeValue.FromInt32(1)
-                                : ValueTypeValue.FromInt32(0));
+                            compareResult = value1.Value.AsDouble() == value2.Value.AsDouble();
                         }
-                        else
+                        else if (value1.ValueKind != value2.ValueKind
+                            || !Value.TryCompareEquality(value1.Value, value2.Value, out compareResult))
                         {
                             return Status.Fail(methodIL.OwningMethod, opcode);
                         }
+
+                        stack.Push(StackValueKind.Int32,
+                            compareResult
+                            ? ValueTypeValue.FromInt32(1)
+                            : ValueTypeValue.FromInt32(0));
                     }
                     break;
 
@@ -1434,6 +1437,10 @@ namespace ILCompiler
                             if (isDivRem && value2.Value.AsInt32() == 0)
                                 return Status.Fail(methodIL.OwningMethod, opcode, "Division by zero");
 
+                            if ((opcode == ILOpcode.div || opcode == ILOpcode.rem)
+                                && value1.Value.AsInt32() == int.MinValue && value2.Value.AsInt32() == -1)
+                                return Status.Fail(methodIL.OwningMethod, opcode, "Overflow");
+
                             int result = opcode switch
                             {
                                 ILOpcode.or => value1.Value.AsInt32() | value2.Value.AsInt32(),
@@ -1456,9 +1463,14 @@ namespace ILCompiler
                             if (isDivRem && value2.Value.AsInt64() == 0)
                                 return Status.Fail(methodIL.OwningMethod, opcode, "Division by zero");
 
+                            if ((opcode == ILOpcode.div || opcode == ILOpcode.rem)
+                                && value1.Value.AsInt64() == long.MinValue && value2.Value.AsInt64() == -1)
+                                return Status.Fail(methodIL.OwningMethod, opcode, "Overflow");
+
                             long result = opcode switch
                             {
                                 ILOpcode.or => value1.Value.AsInt64() | value2.Value.AsInt64(),
+                                ILOpcode.shl => value1.Value.AsInt64() << (int)value2.Value.AsInt64(),
                                 ILOpcode.add => value1.Value.AsInt64() + value2.Value.AsInt64(),
                                 ILOpcode.sub => value1.Value.AsInt64() - value2.Value.AsInt64(),
                                 ILOpcode.and => value1.Value.AsInt64() & value2.Value.AsInt64(),
@@ -3349,7 +3361,7 @@ namespace ILCompiler
 
             public bool TryLoadElement(int index, out Value value)
             {
-                if ((uint)index > (uint)Length)
+                if ((uint)index >= (uint)Length)
                 {
                     value = null;
                     return false;

--- a/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
+++ b/src/tests/nativeaot/SmokeTests/Preinitialization/Preinitialization.cs
@@ -69,6 +69,9 @@ internal class Program
         TestByRefFieldAddressEquality.Run();
         TestComInterfaceEntry.Run();
         TestPreinitializedBclTypes.Run();
+        TestArrayLoadBounds.Run();
+        TestFloatNaNComparison.Run();
+        TestDivisionOverflow.Run();
 #else
         Console.WriteLine("Preinitialization is disabled in multimodule builds for now. Skipping test.");
 #endif
@@ -2125,6 +2128,164 @@ unsafe class TestPreinitializedBclTypes
     public static void Run()
     {
         Assert.IsPreinitialized(Type.GetType("System.Runtime.InteropServices.ComWrappers+VtableImplementations, System.Private.CoreLib"));
+    }
+}
+
+class TestArrayLoadBounds
+{
+    static int GetLength() => 3;
+
+    class ArrayLoadAtLength
+    {
+        internal static int[] s_array;
+        internal static bool s_finished;
+
+        static ArrayLoadAtLength()
+        {
+            s_array = new int[GetLength()];
+
+            try
+            {
+                _ = s_array[GetLength()];
+                s_finished = true;
+            }
+            catch
+            {
+            }
+        }
+    }
+
+    public static void Run()
+    {
+        Assert.IsLazyInitialized(typeof(ArrayLoadAtLength));
+        Assert.AreEqual(false, ArrayLoadAtLength.s_finished);
+    }
+}
+
+class TestFloatNaNComparison
+{
+    static double GetNaN() => double.NaN;
+    static float GetFloatNaN() => float.NaN;
+
+    class NaNEquality
+    {
+        internal static bool s_nanEqualsNan;
+        internal static bool s_nanNotEqualsNan;
+        internal static bool s_floatNanEqualsNan;
+        internal static bool s_nanEqualsZero;
+
+        static NaNEquality()
+        {
+            s_nanEqualsNan = GetNaN() == GetNaN();
+            s_nanNotEqualsNan = GetNaN() != GetNaN();
+            s_floatNanEqualsNan = GetFloatNaN() == GetFloatNaN();
+            s_nanEqualsZero = GetNaN() == 0.0;
+        }
+    }
+
+    public static void Run()
+    {
+        Assert.IsPreinitialized(typeof(NaNEquality));
+        Assert.AreEqual(false, NaNEquality.s_nanEqualsNan);
+        Assert.AreEqual(true, NaNEquality.s_nanNotEqualsNan);
+        Assert.AreEqual(false, NaNEquality.s_floatNanEqualsNan);
+        Assert.AreEqual(false, NaNEquality.s_nanEqualsZero);
+    }
+}
+
+class TestDivisionOverflow
+{
+    static int GetIntMinValue() => int.MinValue;
+    static int GetMinusOne() => -1;
+    static long GetLongMinValue() => long.MinValue;
+    static long GetLongMinusOne() => -1L;
+
+    class IntDivOverflow
+    {
+        internal static bool s_caught;
+
+        static IntDivOverflow()
+        {
+            try
+            {
+                int a = GetIntMinValue();
+                int b = GetMinusOne();
+                int c = a / b;
+            }
+            catch (OverflowException)
+            {
+                s_caught = true;
+            }
+        }
+    }
+
+    class LongDivOverflow
+    {
+        internal static bool s_caught;
+
+        static LongDivOverflow()
+        {
+            try
+            {
+                long a = GetLongMinValue();
+                long b = GetLongMinusOne();
+                long c = a / b;
+            }
+            catch (OverflowException)
+            {
+                s_caught = true;
+            }
+        }
+    }
+
+    class IntRemOverflow
+    {
+        internal static bool s_caught;
+
+        static IntRemOverflow()
+        {
+            try
+            {
+                int a = GetIntMinValue();
+                int b = GetMinusOne();
+                int c = a % b;
+            }
+            catch (OverflowException)
+            {
+                s_caught = true;
+            }
+        }
+    }
+
+    class LongRemOverflow
+    {
+        internal static bool s_caught;
+
+        static LongRemOverflow()
+        {
+            try
+            {
+                long a = GetLongMinValue();
+                long b = GetLongMinusOne();
+                long c = a % b;
+            }
+            catch (OverflowException)
+            {
+                s_caught = true;
+            }
+        }
+    }
+
+    public static void Run()
+    {
+        Assert.IsLazyInitialized(typeof(IntDivOverflow));
+        Assert.AreEqual(true, IntDivOverflow.s_caught);
+        Assert.IsLazyInitialized(typeof(LongDivOverflow));
+        Assert.AreEqual(true, LongDivOverflow.s_caught);
+        Assert.IsLazyInitialized(typeof(IntRemOverflow));
+        Assert.AreEqual(true, IntRemOverflow.s_caught);
+        Assert.IsLazyInitialized(typeof(LongRemOverflow));
+        Assert.AreEqual(true, LongRemOverflow.s_caught);
     }
 }
 


### PR DESCRIPTION
Asked Opus 4.6 to review TypePreinit.cs for correctness. It found bugs. It fixed bugs. It almost wrote good tests (couldn't make a good one for TryLoadElement so that one is mine)

They're not very concerning, but bugs nevertheless.

- Fix ceq opcode for float NaN: use IEEE 754 equality instead of byte-wise comparison so NaN == NaN correctly returns false
- Fix TryLoadElement off-by-one bounds check: change > to >= to match TryStoreElement and prevent out-of-bounds access at index == Length
- Fix int.MinValue / -1 and long.MinValue / -1 compiler crash: return Status.Fail for signed division/remainder overflow instead of letting OverflowException propagate and crash the AOT compiler
- Add shl to Int64 arithmetic switch to prevent NotImplementedException crash when both operands normalize to Int64 (e.g. nint << nint)