### PR TITLE
Add hint for trimming System.Runtime in test109242

### DIFF
--- a/src/tests/Regressions/coreclr/GitHub_109242/test109242.cs
+++ b/src/tests/Regressions/coreclr/GitHub_109242/test109242.cs
@@ -18,6 +18,9 @@ public class Test109242
         }
 
         Assembly.Load("System.Runtime");
+
+        // Hint for trimming to keep System.Runtime
+        Type.GetType("System.Object, System.Runtime");
     }
 }
 


### PR DESCRIPTION
Started failing in outerloops.

```
System.IO.FileNotFoundException: Cannot load assembly 'System.Runtime'. No metadata found for this assembly.
   at System.Reflection.Assembly.Load(String)
   at Test109242.TestEntryPoint()
   at Program.<<Main>$>g__TestExecutor6|0_7(StreamWriter, StreamWriter, Program.<>c__DisplayClass0_0&)
```