### PR TITLE
Fix flaky test by throwing only after all services have started

### DIFF
--- a/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs
+++ b/src/libraries/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs
@@ -3,14 +3,13 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 
 namespace System.Threading.Tasks
 {
     public static class TaskTimeoutExtensions
     {
         #region WaitAsync polyfills
-        // Test polyfills when targeting a platform that doesn't have these ConfigureAwait overloads on Task
+        // Test polyfills when targeting a platform that doesn't have these WaitAsync overloads on Task
 
         public static Task WaitAsync(this Task task, int millisecondsTimeout) =>
             WaitAsync(task, TimeSpan.FromMilliseconds(millisecondsTimeout), default);

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostExtensions.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Extensions.Hosting
         {
             IHostApplicationLifetime applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
 
-            using var _ = token.Register(state =>
+            using var _ = token.Register(static state =>
             {
                 ((IHostApplicationLifetime)state!).StopApplication();
             },

--- a/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostExtensions.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting.Abstractions/src/HostingAbstractionsHostExtensions.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Extensions.Hosting
         {
             IHostApplicationLifetime applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
 
-            token.Register(state =>
+            using var _ = token.Register(state =>
             {
                 ((IHostApplicationLifetime)state!).StopApplication();
             },

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
@@ -322,11 +322,7 @@ namespace Microsoft.Extensions.Hosting.Tests
                     _tcs.SetResult(true);
                 }
 
-                Task completed = await Task.WhenAny(_tcs.Task, Task.Delay(TimeSpan.FromSeconds(30)));
-                if (completed != _tcs.Task)
-                {
-                    throw new TimeoutException("ServiceBarrier timed out waiting for all participants.");
-                }
+                await _tcs.Task.WaitAsync(TimeSpan.FromSeconds(10));
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
@@ -315,14 +315,18 @@ namespace Microsoft.Extensions.Hosting.Tests
             private int _remaining = count;
             private readonly TaskCompletionSource<bool> _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-            public Task SignalAndWaitAsync()
+            public async Task SignalAndWaitAsync()
             {
                 if (Interlocked.Decrement(ref _remaining) == 0)
                 {
                     _tcs.SetResult(true);
                 }
 
-                return _tcs.Task;
+                Task completed = await Task.WhenAny(_tcs.Task, Task.Delay(TimeSpan.FromSeconds(30)));
+                if (completed != _tcs.Task)
+                {
+                    throw new TimeoutException("ServiceBarrier timed out waiting for all participants.");
+                }
             }
         }
 
@@ -334,7 +338,6 @@ namespace Microsoft.Extensions.Hosting.Tests
                 await barrier.SignalAndWaitAsync();
 
                 // Await before throwing to make sure the exception is asynchronous
-                // Ignore the cancellation token to ensure this service throws even if the host is trying to shut down
                 await Task.Yield();
 
                 throw new InvalidOperationException("Asynchronous failure");
@@ -349,7 +352,6 @@ namespace Microsoft.Extensions.Hosting.Tests
                 await barrier.SignalAndWaitAsync();
 
                 // Await before throwing to make sure the exception is asynchronous
-                // Ignore the cancellation token to ensure this service throws even if the host is trying to shut down
                 await Task.Yield();
 
                 throw new InvalidOperationException("Second asynchronous failure");
@@ -364,7 +366,6 @@ namespace Microsoft.Extensions.Hosting.Tests
                 await barrier.SignalAndWaitAsync();
 
                 // Await before throwing to make sure the exception is asynchronous
-                // Ignore the cancellation token to ensure this service throws even if the host is trying to shut down
                 await Task.Yield();
 
                 throw new InvalidOperationException("Third asynchronous failure");

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/BackgroundServiceExceptionTests.cs
@@ -141,7 +141,8 @@ namespace Microsoft.Extensions.Hosting.Tests
                     {
                         options.BackgroundServiceExceptionBehavior = BackgroundServiceExceptionBehavior.StopHost;
                     });
-                    services.AddHostedService<AsynchronousFailureService>();
+                    services.AddSingleton(new ServiceBarrier(count: 3));
+                    services.AddHostedService<FirstAsynchronousFailureService>();
                     services.AddHostedService<SecondAsynchronousFailureService>();
                     services.AddHostedService<ThirdAsynchronousFailureService>();
                 });
@@ -303,27 +304,69 @@ namespace Microsoft.Extensions.Hosting.Tests
             {
                 // Await before throwing to make the exception asynchronous
                 // Ignore the cancellation token to ensure this service throws even if the host is trying to shut down
-                await Task.Delay(TimeSpan.FromMilliseconds(100));
+                await Task.Yield();
+
                 throw new InvalidOperationException("Asynchronous failure");
             }
         }
 
-        private class SecondAsynchronousFailureService : BackgroundService
+        private class ServiceBarrier(int count)
+        {
+            private int _remaining = count;
+            private readonly TaskCompletionSource<bool> _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public Task SignalAndWaitAsync()
+            {
+                if (Interlocked.Decrement(ref _remaining) == 0)
+                {
+                    _tcs.SetResult(true);
+                }
+
+                return _tcs.Task;
+            }
+        }
+
+        private class FirstAsynchronousFailureService(ServiceBarrier barrier) : BackgroundService
         {
             protected override async Task ExecuteAsync(CancellationToken stoppingToken)
             {
+                // Wait until all services have started before throwing
+                await barrier.SignalAndWaitAsync();
+
+                // Await before throwing to make sure the exception is asynchronous
                 // Ignore the cancellation token to ensure this service throws even if the host is trying to shut down
-                await Task.Delay(TimeSpan.FromMilliseconds(150));
+                await Task.Yield();
+
+                throw new InvalidOperationException("Asynchronous failure");
+            }
+        }
+
+        private class SecondAsynchronousFailureService(ServiceBarrier barrier) : BackgroundService
+        {
+            protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+            {
+                // Wait until all services have started before throwing
+                await barrier.SignalAndWaitAsync();
+
+                // Await before throwing to make sure the exception is asynchronous
+                // Ignore the cancellation token to ensure this service throws even if the host is trying to shut down
+                await Task.Yield();
+
                 throw new InvalidOperationException("Second asynchronous failure");
             }
         }
 
-        private class ThirdAsynchronousFailureService : BackgroundService
+        private class ThirdAsynchronousFailureService(ServiceBarrier barrier) : BackgroundService
         {
             protected override async Task ExecuteAsync(CancellationToken stoppingToken)
             {
+                // Wait until all services have started before throwing
+                await barrier.SignalAndWaitAsync();
+
+                // Await before throwing to make sure the exception is asynchronous
                 // Ignore the cancellation token to ensure this service throws even if the host is trying to shut down
-                await Task.Delay(TimeSpan.FromMilliseconds(200));
+                await Task.Yield();
+
                 throw new InvalidOperationException("Third asynchronous failure");
             }
         }

--- a/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Microsoft.Extensions.Hosting.Unit.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Hosting/tests/UnitTests/Microsoft.Extensions.Hosting.Unit.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCoreAppCurrent)-windows;$(NetCoreAppCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <Compile Include="$(CommonTestPath)System\IO\TempDirectory.cs" Link="Common\System\IO\TempDirectory.cs" />
+    <Compile Include="$(CommonTestPath)System\Threading\Tasks\TaskTimeoutExtensions.cs" Link="Common\System\Threading\Tasks\TaskTimeoutExtensions.cs" />
     <Content Include="testroot\**\*" CopyToOutputDirectory="PreserveNewest" />
     <Content Include="appSettings.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>


### PR DESCRIPTION
Hopefully fixes https://github.com/dotnet/runtime/issues/125589 for good.