### PR TITLE
Close file before return from mono_set_bisect_methods

### DIFF
--- a/src/mono/mono/mini/mini-runtime.c
+++ b/src/mono/mono/mini/mini-runtime.c
@@ -3156,6 +3156,7 @@ mono_set_bisect_methods (guint32 opt, const char *method_list_filename)
 		g_hash_table_insert (bisect_methods_hash, g_strdup (method_name), GINT_TO_POINTER (1));
 	}
 	g_assert (feof (file));
+	fclose(file);
 }
 
 gboolean mono_do_single_method_regression = FALSE;


### PR DESCRIPTION
The mono_set_bisect_methods function opens a file and never closes it.
mono_set_bisect_methods is used by parsing command line arguments. The opened file is specified by the `--bisect=` option.

Signed-off-by: Aleksandr Dovydenkov [asd@altlinux.org](mailto:asd@altlinux.org).
Found by Linux Verification Center (linuxtesting.org) with SVACE.