### PR TITLE
Fix memory leak of offset_to_bb_hash

### DIFF
--- a/src/mono/mono/mini/helpers.c
+++ b/src/mono/mono/mini/helpers.c
@@ -182,6 +182,7 @@ MONO_DISABLE_WARNING(4127) /* conditional expression is constant */
 		if (cindex == 64)
 			cindex = 0;
 	}
+	g_hash_table_destroy(offset_to_bb_hash);
 	fprintf (ofd, "\n");
 	fclose (ofd);
 


### PR DESCRIPTION
The hash table is created and filled with values. Add `g_hash_table_destroy` to free memory.

Compilation occurs with `cfg->verbose_level >= 2`. Disassembled code is written to standard output. The flow is as follows:
- An empty table is created.
- The table is filled with pairs of pointers:
Key: `bb->native_offset // The offset of the generated code, used for fixups`
Value: `bb->block_num + 1 // unique block number identification`
- A hash table search is performed, followed by output of `bb_num` to a temporary file `ofd` in ascending order of `bb->native_offset`.

A memory leak then occurs because the hash table is never destroyed.

Signed-off-by: Aleksandr Dovydenkov <asd@altlinux.org>
Found by Linux Verification Center (linuxtesting.org) with SVACE.