### PR TITLE
[release/10.0] pass Creator to Helix only for open queues

### DIFF
--- a/eng/pipelines/installer/helix.yml
+++ b/eng/pipelines/installer/helix.yml
@@ -21,10 +21,10 @@ steps:
           /p:Configuration=$(_BuildConfig)
           /p:TargetArchitecture=${{ parameters.archType }}
           /p:TargetOS=${{ parameters.osGroup }}
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
-        Creator: ${{ parameters.creator }}
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         HelixAccessToken: $(HelixApiAccessToken)
         HelixTargetQueues: ${{ replace(lower(join('+', parameters.helixQueues)), '.open', '') }}
+        Creator: ''
       ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        Creator: ${{ parameters.creator }}
         HelixTargetQueues: ${{ join('+', parameters.helixQueues) }}

--- a/eng/pipelines/installer/helix.yml
+++ b/eng/pipelines/installer/helix.yml
@@ -21,7 +21,8 @@ steps:
           /p:Configuration=$(_BuildConfig)
           /p:TargetArchitecture=${{ parameters.archType }}
           /p:TargetOS=${{ parameters.osGroup }}
-      Creator: ${{ parameters.creator }}
+      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+        Creator: ${{ parameters.creator }}
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
         HelixAccessToken: $(HelixApiAccessToken)
         HelixTargetQueues: ${{ replace(lower(join('+', parameters.helixQueues)), '.open', '') }}


### PR DESCRIPTION
fixes test failure like 
```
Starting Azure Pipelines Test Run host-windows-x86-Debug @ windows.11.amd64.client
##[error].packages\microsoft.dotnet.helix.sdk\10.0.0-beta.26167.104\tools\Microsoft.DotNet.Helix.Sdk.MonoQueue.targets(47,5): error : (NETCORE_ENGINEERING_TELEMETRY=Build) Creator is forbidden when using authenticated access.
```