### PR TITLE
Add Renovate support

### DIFF
--- a/eng/pipelines/runtime-renovate.yml
+++ b/eng/pipelines/runtime-renovate.yml
@@ -1,0 +1,34 @@
+# Renovate Dependency Update Pipeline
+# This pipeline runs Renovate to automatically create PRs for dependency updates.
+
+trigger: none
+
+schedules:
+- cron: '0 8 * * 1'  # Runs every Monday at 8:00 AM UTC
+  displayName: Weekly Renovate Run
+  branches:
+    include:
+    - main
+  always: true
+
+parameters:
+- name: dryRun
+  displayName: Dry Run (preview without creating PRs)
+  type: boolean
+  default: false
+- name: forceRecreatePR
+  displayName: Force Recreate PR (recreate even if closed)
+  type: boolean
+  default: false
+
+variables:
+- name: gitHubRepo
+  value: 'dotnet/runtime'
+
+extends:
+  template: /eng/common/core-templates/stages/renovate.yml@self
+  parameters:
+    dryRun: ${{ parameters.dryRun }}
+    forceRecreatePR: ${{ parameters.forceRecreatePR }}
+    gitHubRepo: ${{ variables.gitHubRepo }}
+    renovateConfigPath: eng/renovate.json

--- a/eng/renovate.json
+++ b/eng/renovate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": [
+    "custom.regex"
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": false
+  },
+  "customManagers": [
+    {
+      "description": "Pin Docker image digests in pipeline-with-resources.yml",
+      "customType": "regex",
+      "managerFilePatterns": ["/eng/pipelines/common/templates/pipeline-with-resources\\.yml$/"],
+      "matchStrings": [
+        "image:\\s*(?<depName>[^:\\s]+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
+      ],
+      "datasourceTemplate": "docker",
+      "autoReplaceStringTemplate": "image: {{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchFileNames": ["eng/pipelines/common/templates/pipeline-with-resources.yml"],
+      "pinDigests": true
+    }
+  ]
+}

--- a/eng/renovate.json
+++ b/eng/renovate.json
@@ -16,11 +16,26 @@
       ],
       "datasourceTemplate": "docker",
       "autoReplaceStringTemplate": "image: {{{depName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
+    },
+    {
+      "description": "Pin Docker image digests in helix-queues-setup.yml files",
+      "customType": "regex",
+      "managerFilePatterns": ["/eng/pipelines/(coreclr/templates|installer|libraries)/helix-queues-setup\\.yml$/"],
+      "matchStrings": [
+        "@(?<depName>[^:\\s]+):(?<currentValue>[^@\\s]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))?"
+      ],
+      "datasourceTemplate": "docker",
+      "autoReplaceStringTemplate": "@{{{packageName}}}:{{{newValue}}}{{#if newDigest}}@{{{newDigest}}}{{/if}}"
     }
   ],
   "packageRules": [
     {
-      "matchFileNames": ["eng/pipelines/common/templates/pipeline-with-resources.yml"],
+      "matchFileNames": [
+        "eng/pipelines/common/templates/pipeline-with-resources.yml",
+        "eng/pipelines/coreclr/templates/helix-queues-setup.yml",
+        "eng/pipelines/installer/helix-queues-setup.yml",
+        "eng/pipelines/libraries/helix-queues-setup.yml"
+      ],
       "pinDigests": true
     }
   ]


### PR DESCRIPTION
Adds [Renovate support](https://github.com/dotnet/arcade/blob/main/Documentation/Renovate.md) via a pipeline that will keep configured dependencies up-to-date.

This initial configuration is set to use image digest pinning for the container images used in the builds. This is configured such that it will automatically update any image name in the tracked files so any new images that get manually added to this file can just reference the tag name and Renovate will do the rest by updating it to the digest on the next run.

~~My assumption is that we don't want digest pinning done for Helix images which would continue to be referenced by tag.~~ Includes support for digest pinning on Helix images.

[Example dry run](https://dev.azure.com/dnceng/internal/_build/results?buildId=2933814&view=results) (internal link)

Contributes to #113455