### PR TITLE
[release/10.0] Move remaining Linux build pools from Ubuntu 22.04 to Azure Linux 3

### DIFF
--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -39,7 +39,7 @@ extends:
         timeoutInMinutes: 120
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
+          demands: ImageOverride -equals build.azurelinux.3.amd64.open
         steps:
         - bash: |
             cd $(enterpriseTestsSetup)

--- a/eng/pipelines/libraries/enterprise/linux.yml
+++ b/eng/pipelines/libraries/enterprise/linux.yml
@@ -43,14 +43,14 @@ extends:
         steps:
         - bash: |
             cd $(enterpriseTestsSetup)
-            docker-compose build
+            docker compose build
           displayName: Build test machine images
           env:
             DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
 
         - bash: |
             cd $(enterpriseTestsSetup)
-            docker-compose up -d
+            docker compose up -d
           displayName: Start test network and machines
           env:
             DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)
@@ -73,7 +73,7 @@ extends:
 
         - bash: |
             cd $(enterpriseTestsSetup)
-            docker-compose down
+            docker compose down
           displayName: Stop test network and machines
           env:
             DOTNET_RUNTIME_REPO_ROOT: $(Build.SourcesDirectory)

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -38,7 +38,7 @@ extends:
           DUMPS_SHARE: "$(Build.ArtifactStagingDirectory)/dumps/"
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
+          demands: ImageOverride -equals build.azurelinux.3.amd64.open
 
         steps:
         - checkout: self

--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -63,7 +63,7 @@ extends:
             export STRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 3.0"
             export STRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 3.0"
             mkdir -p $DUMPS_SHARE
-            docker-compose up --abort-on-container-exit --no-color
+            docker compose up --abort-on-container-exit --no-color
           timeoutInMinutes: 35 # In case the HTTP/3.0 run hangs, we timeout shortly after the expected 30 minute run
           displayName: Run HttpStress - HTTP 3.0
           condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
@@ -73,8 +73,8 @@ extends:
             export STRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 2.0"
             export STRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 2.0"
             mkdir -p $DUMPS_SHARE
-            docker-compose down
-            docker-compose up --abort-on-container-exit --no-color
+            docker compose down
+            docker compose up --abort-on-container-exit --no-color
           displayName: Run HttpStress - HTTP 2.0
           condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 
@@ -83,8 +83,8 @@ extends:
             export STRESS_CLIENT_ARGS="$HTTPSTRESS_CLIENT_ARGS -http 1.1"
             export STRESS_SERVER_ARGS="$HTTPSTRESS_SERVER_ARGS -http 1.1"
             mkdir -p $DUMPS_SHARE
-            docker-compose down
-            docker-compose up --abort-on-container-exit --no-color
+            docker compose down
+            docker compose up --abort-on-container-exit --no-color
           displayName: Run HttpStress - HTTP 1.1
           condition: and(eq(variables['buildRuntime.succeeded'], 'true'), eq(variables['buildStress.succeeded'], 'true'))
 

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -60,7 +60,7 @@ extends:
             export STRESS_CLIENT_ARGS=$SSLSTRESS_CLIENT_ARGS
             export STRESS_SERVER_ARGS=$SSLSTRESS_SERVER_ARGS
             mkdir -p $DUMPS_SHARE
-            docker-compose up --abort-on-container-exit --no-color
+            docker compose up --abort-on-container-exit --no-color
           displayName: Run SslStress
 
         - publish: $(Build.ArtifactStagingDirectory)/dumps

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -39,7 +39,7 @@ extends:
           DUMPS_SHARE: "$(Build.ArtifactStagingDirectory)/dumps/"
         pool:
           name: $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
+          demands: ImageOverride -equals build.azurelinux.3.amd64.open
 
         steps:
         - checkout: self


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated.

Update enterprise and stress test build pool images from Ubuntu 22.04 to Azure Linux 3:
- `enterprise/linux.yml`
- `stress/http.yml`
- `stress/ssl.yml`

`Build.Ubuntu.2204.Amd64.Open` → `build.azurelinux.3.amd64.open`

Companion to #125995 (main).

Ref #125748, #125690
