### PR TITLE
[release/10.0] Move xplat-setup Linux build pools from Ubuntu 22.04 to Azure Linux 3

### DIFF
--- a/eng/pipelines/common/xplat-setup.yml
+++ b/eng/pipelines/common/xplat-setup.yml
@@ -167,12 +167,12 @@ jobs:
         # Public Linux Build Pool
         ${{ if and(or(in(parameters.osGroup, 'linux', 'freebsd', 'android', 'tizen'), eq(parameters.jobParameters.hostedOs, 'linux')), eq(variables['System.TeamProject'], 'public')) }}:
           name:  $(DncEngPublicBuildPool)
-          demands: ImageOverride -equals Build.Ubuntu.2204.Amd64.Open
+          demands: ImageOverride -equals build.azurelinux.3.amd64.open
 
         # Official Build Linux Pool
         ${{ if and(or(in(parameters.osGroup, 'linux', 'freebsd', 'android', 'tizen'), eq(parameters.jobParameters.hostedOs, 'linux')), ne(variables['System.TeamProject'], 'public')) }}:
           name: $(DncEngInternalBuildPool)
-          demands: ImageOverride -equals 1es-ubuntu-2204
+          demands: ImageOverride -equals build.azurelinux.3.amd64
           os: linux
 
         # OSX Public Build Pool (we don't have on-prem OSX BuildPool).


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated.

Move Linux build pool images in `xplat-setup.yml` from Ubuntu 22.04 to Azure Linux 3:
- Public Linux: `Build.Ubuntu.2204.Amd64.Open` → `build.azurelinux.3.amd64.open`
- Internal Linux: `1es-ubuntu-2204` → `build.azurelinux.3.amd64`

Backport of the xplat-setup changes from #125535.

Ref #125748, #125690
