### PR TITLE
[release/8.0] Remove EOL armv6 raspbian build container and pipeline references

### DIFF
--- a/eng/pipelines/common/platform-matrix.yml
+++ b/eng/pipelines/common/platform-matrix.yml
@@ -44,26 +44,6 @@ jobs:
         crossBuild: true
         ${{ insert }}: ${{ parameters.jobParameters }}
 
-# Linux armv6
-- ${{ if containsValue(parameters.platforms, 'linux_armv6') }}:
-  - template: xplat-setup.yml
-    parameters:
-      jobTemplate: ${{ parameters.jobTemplate }}
-      helixQueuesTemplate: ${{ parameters.helixQueuesTemplate }}
-      variables: ${{ parameters.variables }}
-      osGroup: linux
-      archType: armv6
-      targetRid: linux-armv6
-      platform: linux_armv6
-      shouldContinueOnError: ${{ parameters.shouldContinueOnError }}
-      container: linux_armv6
-      jobParameters:
-        runtimeFlavor: ${{ parameters.runtimeFlavor }}
-        buildConfig: ${{ parameters.buildConfig }}
-        helixQueueGroup: ${{ parameters.helixQueueGroup }}
-        crossBuild: true
-        ${{ insert }}: ${{ parameters.jobParameters }}
-
 # Linux arm64
 
 - ${{ if or(containsValue(parameters.platforms, 'linux_arm64'), in(parameters.platformGroup, 'all', 'gcstress')) }}:

--- a/eng/pipelines/common/templates/pipeline-with-resources.yml
+++ b/eng/pipelines/common/templates/pipeline-with-resources.yml
@@ -21,11 +21,6 @@ extends:
         env:
           ROOTFS_DIR: /crossrootfs/arm
 
-      linux_armv6:
-        image: mcr.microsoft.com/dotnet-buildtools/prereqs:ubuntu-20.04-cross-armv6-raspbian-10
-        env:
-          ROOTFS_DIR: /crossrootfs/armv6
-
       linux_arm64:
         image: mcr.microsoft.com/dotnet-buildtools/prereqs:azurelinux-3.0-net8.0-cross-arm64
         env:

--- a/eng/pipelines/runtime-community.yml
+++ b/eng/pipelines/runtime-community.yml
@@ -99,37 +99,4 @@ extends:
                 eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
                 eq(variables['isRollingBuild'], true))
 
-      #
-      # Build the whole product using Mono and run libraries tests
-      #
-      - template: /eng/pipelines/common/platform-matrix.yml
-        parameters:
-          jobTemplate: /eng/pipelines/common/global-build-job.yml
-          helixQueuesTemplate: /eng/pipelines/libraries/helix-queues-setup.yml
-          buildConfig: Release
-          runtimeFlavor: mono
-          platforms:
-          - linux_armv6
-          variables:
-            # map dependencies variables to local variables
-            - name: librariesContainsChange
-              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'] ]
-            - name: monoContainsChange
-              value: $[ dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'] ]
-          jobParameters:
-            testScope: innerloop
-            nameSuffix: AllSubsets_Mono
-            buildArgs: -s mono+clr.iltools+clr.packages+libs+host+packs+libs.tests -c $(_BuildConfig) /p:ArchiveTests=true
-            timeoutInMinutes: 120
-            condition: >-
-              or(
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_libraries.containsChange'], true),
-                eq(dependencies.evaluate_paths.outputs['SetPathVars_mono_excluding_wasm.containsChange'], true),
-                eq(variables['isRollingBuild'], true))
-            ${{ if eq(variables['isRollingBuild'], true) }}:
-              # extra steps, run tests
-              postBuildSteps:
-                - template: /eng/pipelines/libraries/helix.yml
-                  parameters:
-                    creator: dotnet-bot
-                    testRunNamePrefixSuffix: Mono_$(_BuildConfig)
+


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated.

Remove the `ubuntu-20.04-cross-armv6-raspbian-10` container (Ubuntu 20.04 is EOL) and all pipeline references to the `linux_armv6` platform:

- `pipeline-with-resources.yml`: container definition
- `platform-matrix.yml`: platform matrix entry
- `runtime-community.yml`: Mono build+test job

Ref #125690