### PR TITLE
Defer GetServiceInfo initialization in ActivatorUtilities

### DIFF
--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection
         // until the MethodInfo is actually needed.
         private static class MethodInfoHolder
         {
-            internal static readonly MethodInfo GetServiceInfo =
+            private static readonly MethodInfo GetServiceInfo =
                 new Func<IServiceProvider, Type, Type, bool, object?, object?>(GetService).Method;
         }
 
@@ -421,7 +421,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         Expression.Constant(constructor.DeclaringType, typeof(Type)),
                         Expression.Constant(hasDefaultValue),
                         Expression.Constant(keyAttribute?.Key, typeof(object)) };
-                    constructorArguments[i] = Expression.Call(MethodInfoHolder.GetServiceInfo, parameterTypeExpression);
+                    constructorArguments[i] = Expression.Call(MethodInfoHolder.s_getServiceInfo, parameterTypeExpression);
                 }
 
                 // Support optional constructor arguments by passing in the default value

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection
         // until the MethodInfo is actually needed.
         private static class MethodInfoHolder
         {
-            private static readonly MethodInfo GetServiceInfo =
+            private static readonly MethodInfo s_getServiceInfo =
                 new Func<IServiceProvider, Type, Type, bool, object?, object?>(GetService).Method;
         }
 

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
@@ -34,8 +34,13 @@ namespace Microsoft.Extensions.DependencyInjection
         private const int FixedArgumentThreshold = 4;
 #endif
 
-        private static readonly MethodInfo GetServiceInfo =
-            new Func<IServiceProvider, Type, Type, bool, object?, object?>(GetService).Method;
+        // Nested class to defer the expensive Delegate.Method reflection call
+        // until the MethodInfo is actually needed.
+        private static class MethodInfoHolder
+        {
+            internal static readonly MethodInfo GetServiceInfo =
+                new Func<IServiceProvider, Type, Type, bool, object?, object?>(GetService).Method;
+        }
 
         /// <summary>
         /// Instantiates a type with constructor arguments provided directly and/or from an <see cref="IServiceProvider"/>.
@@ -416,7 +421,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         Expression.Constant(constructor.DeclaringType, typeof(Type)),
                         Expression.Constant(hasDefaultValue),
                         Expression.Constant(keyAttribute?.Key, typeof(object)) };
-                    constructorArguments[i] = Expression.Call(GetServiceInfo, parameterTypeExpression);
+                    constructorArguments[i] = Expression.Call(MethodInfoHolder.GetServiceInfo, parameterTypeExpression);
                 }
 
                 // Support optional constructor arguments by passing in the default value

--- a/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
+++ b/src/libraries/Microsoft.Extensions.DependencyInjection.Abstractions/src/ActivatorUtilities.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Extensions.DependencyInjection
         // until the MethodInfo is actually needed.
         private static class MethodInfoHolder
         {
-            private static readonly MethodInfo s_getServiceInfo =
+            internal static readonly MethodInfo s_getServiceInfo =
                 new Func<IServiceProvider, Type, Type, bool, object?, object?>(GetService).Method;
         }
 


### PR DESCRIPTION
Move the GetServiceInfo static field into a nested MethodInfoHolder class so the expensive Delegate.Method reflection call is deferred until the MethodInfo is actually needed, rather than at ActivatorUtilities class load time.

We don't need this field in native AOT builds at all, but it's difficult to eliminate automatically.