### PR TITLE
Fix regex test OOM on x86 checked coreclr

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -2723,6 +2723,11 @@ namespace System.Text.RegularExpressions.Tests
                 throw new SkipTestException("Deep nesting with NonBacktracking hits threading APIs not supported on single-threaded WASM.");
             }
 
+            if (!Environment.Is64BitProcess)
+            {
+                throw new SkipTestException("Deep nesting exhausts address space on 32-bit processes.");
+            }
+
             // Build a pattern with deeply nested character class subtractions: [a-[a-[a-[...[a]...]]]]
             // This previously caused a StackOverflowException due to unbounded recursion in the parser.
             // Use a reduced depth for SourceGenerated to avoid overwhelming Roslyn compilation.

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -2713,7 +2713,7 @@ namespace System.Text.RegularExpressions.Tests
             }
         }
 
-        [ConditionalTheory]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))] // deep nesting exhausts address space on 32-bit
         [SkipOnTargetFramework(TargetFrameworkMonikers.NetFramework, "Fix is not available on .NET Framework")]
         [MemberData(nameof(RegexHelpers.AvailableEngines_MemberData), MemberType = typeof(RegexHelpers))]
         public async Task CharClassSubtraction_DeepNesting_DoesNotStackOverflow(RegexEngine engine)
@@ -2721,11 +2721,6 @@ namespace System.Text.RegularExpressions.Tests
             if (RegexHelpers.IsNonBacktracking(engine) && !PlatformDetection.IsMultithreadingSupported)
             {
                 throw new SkipTestException("Deep nesting with NonBacktracking hits threading APIs not supported on single-threaded WASM.");
-            }
-
-            if (!Environment.Is64BitProcess)
-            {
-                throw new SkipTestException("Deep nesting exhausts address space on 32-bit processes.");
             }
 
             // Build a pattern with deeply nested character class subtractions: [a-[a-[a-[...[a]...]]]]

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
@@ -146,7 +146,7 @@ namespace System.Text.RegularExpressions.Tests
             (string pattern, CultureInfo? culture, RegexOptions? options, TimeSpan? matchTimeout)[] regexes, CancellationToken cancellationToken = default)
         {
             // Un-ifdef to compile each regex individually, which can be useful if one regex among thousands is causing a failure.
-            // We compile them all en mass for test efficiency, but it can make it harder to debug a compilation failure in one of them.
+            // We compile them all en masse for test efficiency, but it can make it harder to debug a compilation failure in one of them.
 #if false
             if (regexes.Length > 1)
             {
@@ -158,6 +158,21 @@ namespace System.Text.RegularExpressions.Tests
                 return r.ToArray();
             }
 #endif
+
+            // On 32-bit processes the ~2GB address space limit can cause OutOfMemoryException
+            // when Roslyn compiles thousands of patterns at once. Chunk into smaller batches
+            // on 32-bit to avoid OOM while keeping full batching on 64-bit.
+            const int MaxBatchSize = 200;
+            if (!Environment.Is64BitProcess && regexes.Length > MaxBatchSize)
+            {
+                var results = new List<Regex>();
+                for (int i = 0; i < regexes.Length; i += MaxBatchSize)
+                {
+                    int end = Math.Min(i + MaxBatchSize, regexes.Length);
+                    results.AddRange(await SourceGenRegexAsync(regexes[i..end], cancellationToken));
+                }
+                return results.ToArray();
+            }
 
             Debug.Assert(regexes.Length > 0);
 

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
@@ -166,10 +166,9 @@ namespace System.Text.RegularExpressions.Tests
             if (!Environment.Is64BitProcess && regexes.Length > MaxBatchSize)
             {
                 var batchResults = new List<Regex>(regexes.Length);
-                for (int i = 0; i < regexes.Length; i += MaxBatchSize)
+                foreach (var chunk in regexes.Chunk(MaxBatchSize))
                 {
-                    int end = Math.Min(i + MaxBatchSize, regexes.Length);
-                    batchResults.AddRange(await SourceGenRegexAsync(regexes[i..end], cancellationToken));
+                    batchResults.AddRange(await SourceGenRegexAsync(chunk, cancellationToken));
                 }
                 return batchResults.ToArray();
             }

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
@@ -165,13 +165,13 @@ namespace System.Text.RegularExpressions.Tests
             const int MaxBatchSize = 200;
             if (!Environment.Is64BitProcess && regexes.Length > MaxBatchSize)
             {
-                var results = new List<Regex>(regexes.Length);
+                var batchResults = new List<Regex>(regexes.Length);
                 for (int i = 0; i < regexes.Length; i += MaxBatchSize)
                 {
                     int end = Math.Min(i + MaxBatchSize, regexes.Length);
-                    results.AddRange(await SourceGenRegexAsync(regexes[i..end], cancellationToken));
+                    batchResults.AddRange(await SourceGenRegexAsync(regexes[i..end], cancellationToken));
                 }
-                return results.ToArray();
+                return batchResults.ToArray();
             }
 
             Debug.Assert(regexes.Length > 0);

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/RegexGeneratorHelper.netcoreapp.cs
@@ -165,7 +165,7 @@ namespace System.Text.RegularExpressions.Tests
             const int MaxBatchSize = 200;
             if (!Environment.Is64BitProcess && regexes.Length > MaxBatchSize)
             {
-                var results = new List<Regex>();
+                var results = new List<Regex>(regexes.Length);
                 for (int i = 0; i < regexes.Length; i += MaxBatchSize)
                 {
                     int end = Math.Min(i + MaxBatchSize, regexes.Length);


### PR DESCRIPTION
Four `System.Text.RegularExpressions.Tests` tests fail with `OutOfMemoryException` on the **x86 checked coreclr** leg. The `SourceGenerated` regex engine path runs full Roslyn compilations at test time, and large batches (up to ~2,903 patterns) exhaust the ~2GB x86 address space — especially with 4 parallel xunit threads and checked runtime overhead.

### Changes

1. **Chunk batches on 32-bit** (`RegexGeneratorHelper.netcoreapp.cs`): When `!Environment.Is64BitProcess`, compile at most 200 patterns per Roslyn invocation instead of all at once. No change on 64-bit.

2. **Skip `CharClassSubtraction_DeepNesting_DoesNotStackOverflow` on 32-bit** (`Regex.Match.Tests.cs`): The 1000-depth nested char class BDD exhausts address space via a different mechanism (recursive `RegexNodeConverter.CreateBDDFromSetString`). This test was added 3 weeks ago in #124995 and already had to be skipped on browser-wasm (#125021).

### Failing tests covered

| Test | Patterns | OOM location |
|---|---|---|
| `RegexPcre2Tests.IsMatchTests` | ~2,903 | `DefiniteAssignmentPass` (Array.Resize) |
| `MonoTests.ValidateRegex` | ~1,008 | `BlobBuilder` (Roslyn emit) |
| `RegexGroupTests.Groups` | ~631 | Source generator compilation |
| `CharClassSubtraction_DeepNesting` | N/A | `RegexNodeConverter.CreateBDD` |

Fixes #126003
