### PR TITLE
Set MSBUILDDEBUGPATH in CI so MSBuild crash diagnostics are preserved

### DIFF
--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -139,7 +139,7 @@ jobs:
 
       # Capture MSBuild crash diagnostics so they are published with build logs
       - name: MSBUILDDEBUGPATH
-        value: $(Build.SourcesDirectory)/artifacts/log/${{ parameters.buildConfig }}/MsbuildDebugLogs
+        value: $(Build.SourcesDirectory)/artifacts/log/$(_BuildConfig)/MsbuildDebugLogs
 
       - ${{ each variableTemplate in parameters.extraVariablesTemplates }}:
         - template: ${{ variableTemplate.template }}

--- a/eng/pipelines/common/global-build-job.yml
+++ b/eng/pipelines/common/global-build-job.yml
@@ -137,6 +137,10 @@ jobs:
       - name: _nativeSanitizersArg
         value: ''
 
+      # Capture MSBuild crash diagnostics so they are published with build logs
+      - name: MSBUILDDEBUGPATH
+        value: $(Build.SourcesDirectory)/artifacts/log/${{ parameters.buildConfig }}/MsbuildDebugLogs
+
       - ${{ each variableTemplate in parameters.extraVariablesTemplates }}:
         - template: ${{ variableTemplate.template }}
           parameters:


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the help of GitHub Copilot.

Set `MSBUILDDEBUGPATH` in CI so MSBuild crash diagnostics are preserved in more build types.

When MSBuild worker nodes crash during CI builds (see #92290), diagnostic `MSBuild_*.failure.txt` files are written to a system temp directory on the ephemeral build agent and lost when the agent is cleaned up. This makes it impossible to determine the root cause of the crashes.

Several component-specific build scripts (`src/coreclr/build-runtime.sh`, `src/tests/build.sh`, `src/native/corehost/build.sh`) already set `MSBUILDDEBUGPATH` to `artifacts/log/<config>/MsbuildDebugLogs`, but the top-level build invoked by the pipeline template (`global-build-step.yml`) does not. Build legs that don't go through one of those component scripts &#8212; such as the macOS libs/mono builds currently hitting #92290 &#8212; get the default temp dir.

This adds `MSBUILDDEBUGPATH` as a job-level pipeline variable in `global-build-job.yml`, pointing to the same `artifacts/log/<config>/MsbuildDebugLogs` path. The existing `condition: always()` log publishing step in `job.yml` already sweeps `artifacts/log/`, so the failure diagnostics will be automatically published as build artifacts the next time a crash occurs.
