### PR TITLE
Log cgroup memory.events on exit code 137 as dmesg fallback

### DIFF
--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -226,11 +226,11 @@ if [ -n "$HELIX_WORKITEM_PAYLOAD" ]; then
     # For exit code 137 (SIGKILL, typically OOM killer), check cgroup v2 memory.events
     # as a fallback to confirm whether the OOM killer fired (e.g., if dmesg is unavailable).
     # Silent no-op on macOS, cgroup v1, or any system without /proc/self/cgroup.
-    if [[ $test_exitcode -eq 137 ]]; then
+    if [[ $test_exitcode -eq 137 && -f /proc/self/cgroup ]]; then
       # /proc/self/cgroup contains colon-delimited lines; on cgroup v2, a single line like:
       #   0::/system.slice/helix-agent.service
       # Extract field 3 (the cgroup path) from the line where field1=="0" and field2==""
-      cg_path=$(awk -F: '$1=="0" && $2=="" {print $3; exit}' /proc/self/cgroup 2>/dev/null)
+      cg_path=$(awk -F: '$1=="0" && $2=="" {print $3; exit}' /proc/self/cgroup)
       cg_path=${cg_path#/}  # strip leading slash for path concatenation
       # Prefer the process-specific cgroup path (more relevant), fall back to root cgroup
       for memevents in ${cg_path:+/sys/fs/cgroup/$cg_path/memory.events} /sys/fs/cgroup/memory.events; do

--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -222,6 +222,18 @@ if [ -n "$HELIX_WORKITEM_PAYLOAD" ]; then
   # For abrupt failures, in Helix, dump some of the kernel log, in case there is a hint
   if [[ $test_exitcode -ne 1 ]]; then
     dmesg | tail -50
+
+    # If dmesg was denied (CAP_SYSLOG not available), check cgroup v2 memory.events
+    # as a fallback to confirm whether the OOM killer fired.
+    if [[ $test_exitcode -eq 137 ]]; then
+      for memevents in /sys/fs/cgroup/memory.events /sys/fs/cgroup/$(cat /proc/self/cgroup 2>/dev/null | grep -oP '0::\K.*' 2>/dev/null | sed 's:^/::')/memory.events; do
+        if [[ -f "$memevents" ]]; then
+          echo "cgroup memory.events ($memevents):"
+          cat "$memevents"
+          break
+        fi
+      done
+    fi
   fi
 
 fi

--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -223,12 +223,17 @@ if [ -n "$HELIX_WORKITEM_PAYLOAD" ]; then
   if [[ $test_exitcode -ne 1 ]]; then
     dmesg | tail -50
 
-    # For exit code 137, also check cgroup v2 memory.events as a fallback
-    # to confirm whether the OOM killer fired (e.g., if dmesg is unavailable).
+    # For exit code 137 (SIGKILL, typically OOM killer), check cgroup v2 memory.events
+    # as a fallback to confirm whether the OOM killer fired (e.g., if dmesg is unavailable).
+    # Silent no-op on macOS, cgroup v1, or any system without /proc/self/cgroup.
     if [[ $test_exitcode -eq 137 ]]; then
+      # /proc/self/cgroup contains colon-delimited lines; on cgroup v2, a single line like:
+      #   0::/system.slice/helix-agent.service
+      # Extract field 3 (the cgroup path) from the line where field1=="0" and field2==""
       cg_path=$(awk -F: '$1=="0" && $2=="" {print $3; exit}' /proc/self/cgroup 2>/dev/null)
-      cg_path=${cg_path#/}
-      for memevents in /sys/fs/cgroup/memory.events ${cg_path:+/sys/fs/cgroup/$cg_path/memory.events}; do
+      cg_path=${cg_path#/}  # strip leading slash for path concatenation
+      # Prefer the process-specific cgroup path (more relevant), fall back to root cgroup
+      for memevents in ${cg_path:+/sys/fs/cgroup/$cg_path/memory.events} /sys/fs/cgroup/memory.events; do
         if [[ -f "$memevents" ]]; then
           echo "cgroup memory.events ($memevents):"
           cat "$memevents"

--- a/eng/testing/RunnerTemplate.sh
+++ b/eng/testing/RunnerTemplate.sh
@@ -223,10 +223,12 @@ if [ -n "$HELIX_WORKITEM_PAYLOAD" ]; then
   if [[ $test_exitcode -ne 1 ]]; then
     dmesg | tail -50
 
-    # If dmesg was denied (CAP_SYSLOG not available), check cgroup v2 memory.events
-    # as a fallback to confirm whether the OOM killer fired.
+    # For exit code 137, also check cgroup v2 memory.events as a fallback
+    # to confirm whether the OOM killer fired (e.g., if dmesg is unavailable).
     if [[ $test_exitcode -eq 137 ]]; then
-      for memevents in /sys/fs/cgroup/memory.events /sys/fs/cgroup/$(cat /proc/self/cgroup 2>/dev/null | grep -oP '0::\K.*' 2>/dev/null | sed 's:^/::')/memory.events; do
+      cg_path=$(awk -F: '$1=="0" && $2=="" {print $3; exit}' /proc/self/cgroup 2>/dev/null)
+      cg_path=${cg_path#/}
+      for memevents in /sys/fs/cgroup/memory.events ${cg_path:+/sys/fs/cgroup/$cg_path/memory.events}; do
         if [[ -f "$memevents" ]]; then
           echo "cgroup memory.events ($memevents):"
           cat "$memevents"


### PR DESCRIPTION
> [!NOTE]
> This PR was authored with Copilot assistance.

When a test process exits with code 137 (SIGKILL/OOM) on Helix Linux containers, `dmesg` is already called but fails because `CAP_SYSLOG` is not available in the container. This adds a fallback that reads `/sys/fs/cgroup/memory.events` (cgroup v2), which requires no special privileges and confirms whether the OOM killer fired (the `oom_kill` counter).

The script tries two paths (first match wins):
1. `/sys/fs/cgroup/<cgroup-path>/memory.events` (process-specific cgroup, derived from `/proc/self/cgroup`)
2. `/sys/fs/cgroup/memory.events` (root cgroup fallback)

This won't replace `dmesg` — a separate issue (dotnet/dnceng#6481) tracks enabling `CAP_SYSLOG` for richer OOM diagnostics — but it gives immediate confirmation of OOM at zero infrastructure cost. Silent no-op on macOS, cgroup v1, or any system without `/proc/self/cgroup`.

Related issues:
- dotnet/runtime#98964 (System.Runtime.Tests exit code 137)
- dotnet/runtime#104588 (System.Runtime.Numerics.Tests exit code 137)
