### PR TITLE
[interpreter] Fix crash on empty switch instruction

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -9478,6 +9478,11 @@ retry_emit:
                 m_ip += 4;
                 const uint8_t *nextIp = m_ip + n * 4;
                 m_pStackPointer--;
+
+                // Empty switch (n=0) is a no-op that just consumes the stack value.
+                if (n == 0)
+                    break;
+
                 InterpBasicBlock **targetBBTable = getAllocator(IMK_SwitchTable).allocate<InterpBasicBlock*>(n);
                 uint32_t *targetOffsets = getAllocator(IMK_SwitchTable).allocate<uint32_t>(n);
 


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

## Summary

The interpreter's CEE_SWITCH handler crashes when compiling a `switch` instruction with zero targets (e.g., `switch ()` in IL). The handler unconditionally calls `allocate(n)` with `n=0`, which triggers `assert(size != 0)` in the arena allocator.

## Fix

Bail out early when `n == 0` since an empty switch is a no-op that just consumes the stack value — no INTOP_SWITCH instruction needs to be emitted.

## Test

Fixes crash in `JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b44946/b44946.il` which contains `switch()` with zero targets. Verified the Regression_6 merged runner passes: 290 passed, 0 failed.