### PR TITLE
[wasm][coreclr] Fix tpa list population in corerun.html

### DIFF
--- a/src/coreclr/hosts/corerun/wasm/corerun.html
+++ b/src/coreclr/hosts/corerun/wasm/corerun.html
@@ -46,32 +46,40 @@
                 "HelloWorld.dll"
             ],
             preRun: [ function (module) {
-                // Emscripten's --preload-file data is loaded by an async preRun
-                // callback (runWithFS). Our preRun runs in the same batch but
-                // the data fetch hasn't completed yet. Add a run dependency so
-                // main() is delayed until the preloaded files are available,
-                // then build the TPA list.
-                module.addRunDependency('app_assemblies');
-                var orig = module.monitorRunDependencies;
-                module.monitorRunDependencies = function (left) {
-                    orig?.call(module, left);
-                    // Check if all file preload dependencies ('fp ...') have resolved.
-                    // Our own 'app_assemblies' dependency will still be pending.
-                    if (left === 1) {
-                        module.monitorRunDependencies = orig;
-                        const path = "/";
-                        let tpaList = "";
-                        let files = module.FS.readdir(path);
-                        files.forEach(function(file) {
-                            if (file.endsWith(".dll")) {
-                                tpaList += (tpaList.length > 0 ? ":" : "") + path + file;
-                            }
-                        });
+                // Emscripten's --preload-file data is loaded by a runWithFS
+                // preRun callback. Due to addOnPreRun using unshift(),
+                // runWithFS runs BEFORE this callback, so the virtual FS
+                // may already be populated when we get here.
+                function buildTpaList() {
+                    const path = "/";
+                    let tpaList = "";
+                    let files = module.FS.readdir(path);
+                    files.forEach(function(file) {
+                        if (file.endsWith(".dll")) {
+                            tpaList += (tpaList.length > 0 ? ":" : "") + path + file;
+                        }
+                    });
+                    return tpaList;
+                }
 
-                        module.ENV["APP_ASSEMBLIES"] = tpaList;
-                        module.removeRunDependency('app_assemblies');
-                    }
-                };
+                let tpaList = buildTpaList();
+                if (tpaList.length > 0) {
+                    // Data already loaded by runWithFS — set TPA list now.
+                    module.ENV["APP_ASSEMBLIES"] = tpaList;
+                } else {
+                    // Data not yet fetched. Block main() until preload
+                    // dependencies resolve and the FS is populated.
+                    module.addRunDependency('app_assemblies');
+                    var orig = module.monitorRunDependencies;
+                    module.monitorRunDependencies = function (left) {
+                        orig?.call(module, left);
+                        if (left === 1) {
+                            module.monitorRunDependencies = orig;
+                            module.ENV["APP_ASSEMBLIES"] = buildTpaList();
+                            module.removeRunDependency('app_assemblies');
+                        }
+                    };
+                }
             } ],
             onExit: function (code) {
                 console.log("onExit, code: " + code);


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

## Summary

Fixes the TPA list population in the WASM corerun.html preRun callback.

Emscripten's `addOnPreRun` uses `unshift()`, so the `runWithFS` callback that loads preloaded file data may run *before* our preRun callback. The previous code unconditionally added a run dependency and waited for file preloads, but by that time the FS was already populated and the dependency monitor never triggered correctly.

The fix checks if the virtual FS is already populated when preRun executes. If data is already loaded, the TPA list is built immediately. Otherwise it falls back to the dependency monitoring approach.