### PR TITLE
Implement eager validation of collections and cache read values.

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AlgorithmIdentifierAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AlgorithmIdentifierAsn.xml.cs
@@ -157,19 +157,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueAlgorithmIdentifierAsn decoded)
+        internal static ValueAlgorithmIdentifierAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueAlgorithmIdentifierAsn decoded)
+        internal static ValueAlgorithmIdentifierAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueAlgorithmIdentifierAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -177,16 +178,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueAlgorithmIdentifierAsn decoded)
+        internal static ValueAlgorithmIdentifierAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueAlgorithmIdentifierAsn decoded)
+        internal static ValueAlgorithmIdentifierAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -194,9 +195,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueAlgorithmIdentifierAsn decoded)
+        private static ValueAlgorithmIdentifierAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueAlgorithmIdentifierAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
             decoded.Algorithm = sequenceReader.ReadObjectIdentifier();
@@ -209,6 +210,7 @@ namespace System.Security.Cryptography.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AttributeAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AttributeAsn.xml.cs
@@ -124,7 +124,9 @@ namespace System.Security.Cryptography.Asn1
     internal ref partial struct ValueAttributeAsn
     {
         internal string AttrType;
-        internal ReadOnlySpan<byte> AttrValues;
+        internal ReadOnlySpan<byte> AttrValues { get; private set; }
+        internal int AttrValuesLength { get; private set; }
+        private AttrValuesEnumerableCache _attrValuesCache;
 
         internal readonly void Encode(AsnWriter writer)
         {
@@ -155,19 +157,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueAttributeAsn decoded)
+        internal static ValueAttributeAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueAttributeAsn decoded)
+        internal static ValueAttributeAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueAttributeAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -175,16 +178,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueAttributeAsn decoded)
+        internal static ValueAttributeAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueAttributeAsn decoded)
+        internal static ValueAttributeAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -192,9 +195,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueAttributeAsn decoded)
+        private static ValueAttributeAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueAttributeAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
             decoded.AttrType = sequenceReader.ReadObjectIdentifier();
@@ -205,39 +208,99 @@ namespace System.Security.Cryptography.Asn1
             }
 
             decoded.AttrValues = sequenceReader.ReadEncodedValue();
+            {
+                int count = 0;
+                ValueAsnReader cacheReader = new ValueAsnReader(decoded.AttrValues, sequenceReader.RuleSet);
+                ValueAsnReader collReader = cacheReader.ReadSetOf();
+                cacheReader.ThrowIfNotEmpty();
+
+                while (collReader.HasData)
+                {
+                    checked { count++; }
+                    ReadOnlySpan<byte> item = collReader.ReadEncodedValue();
+
+                    if (count <= 10)
+                    {
+                        switch (count)
+                        {
+                            case 1: decoded._attrValuesCache.AttrValues1 = item; break;
+                            case 2: decoded._attrValuesCache.AttrValues2 = item; break;
+                            case 3: decoded._attrValuesCache.AttrValues3 = item; break;
+                            case 4: decoded._attrValuesCache.AttrValues4 = item; break;
+                            case 5: decoded._attrValuesCache.AttrValues5 = item; break;
+                            case 6: decoded._attrValuesCache.AttrValues6 = item; break;
+                            case 7: decoded._attrValuesCache.AttrValues7 = item; break;
+                            case 8: decoded._attrValuesCache.AttrValues8 = item; break;
+                            case 9: decoded._attrValuesCache.AttrValues9 = item; break;
+                            case 10: decoded._attrValuesCache.AttrValues10 = item; break;
+                        }
+                    }
+                }
+
+                if (count <= 10)
+                {
+                    decoded._attrValuesCache.Success = true;
+                }
+                decoded._attrValuesCache.Count = count;
+                decoded._attrValuesCache.RuleSet = sequenceReader.RuleSet;
+                decoded.AttrValuesLength = count;
+            }
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
 
 
-        internal AttrValuesEnumerable GetAttrValues(AsnEncodingRules ruleSet)
+        internal AttrValuesEnumerable GetAttrValues()
         {
-            return new AttrValuesEnumerable(AttrValues, ruleSet);
+            return new AttrValuesEnumerable(AttrValues, _attrValuesCache);
+        }
+
+        internal ref struct AttrValuesEnumerableCache
+        {
+            internal ReadOnlySpan<byte> AttrValues1;
+            internal ReadOnlySpan<byte> AttrValues2;
+            internal ReadOnlySpan<byte> AttrValues3;
+            internal ReadOnlySpan<byte> AttrValues4;
+            internal ReadOnlySpan<byte> AttrValues5;
+            internal ReadOnlySpan<byte> AttrValues6;
+            internal ReadOnlySpan<byte> AttrValues7;
+            internal ReadOnlySpan<byte> AttrValues8;
+            internal ReadOnlySpan<byte> AttrValues9;
+            internal ReadOnlySpan<byte> AttrValues10;
+            internal int Count;
+            internal bool Success;
+            internal AsnEncodingRules RuleSet;
         }
 
         internal readonly ref struct AttrValuesEnumerable
         {
             private readonly ReadOnlySpan<byte> _encoded;
-            private readonly AsnEncodingRules _ruleSet;
+            private readonly AttrValuesEnumerableCache _cache;
 
-            internal AttrValuesEnumerable(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
+            internal AttrValuesEnumerable(ReadOnlySpan<byte> encoded, AttrValuesEnumerableCache cache)
             {
                 _encoded = encoded;
-                _ruleSet = ruleSet;
+                _cache = cache;
             }
 
-            public Enumerator GetEnumerator() => new Enumerator(_encoded, _ruleSet);
+            public Enumerator GetEnumerator() => new Enumerator(_encoded, _cache);
 
             internal ref struct Enumerator
             {
                 private ValueAsnReader _reader;
                 private ReadOnlySpan<byte> _current;
+                private readonly AttrValuesEnumerableCache _cache;
+                private int _index;
 
-                internal Enumerator(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
+                internal Enumerator(ReadOnlySpan<byte> encoded, AttrValuesEnumerableCache cache)
                 {
-                    if (!encoded.IsEmpty)
+                    _cache = cache;
+                    _index = 0;
+
+                    if (!cache.Success && !encoded.IsEmpty)
                     {
-                        ValueAsnReader outerReader = new ValueAsnReader(encoded, ruleSet);
+                        ValueAsnReader outerReader = new ValueAsnReader(encoded, cache.RuleSet);
                         _reader = outerReader.ReadSetOf();
                         outerReader.ThrowIfNotEmpty();
                     }
@@ -249,6 +312,32 @@ namespace System.Security.Cryptography.Asn1
 
                 public bool MoveNext()
                 {
+                    if (_cache.Success)
+                    {
+                        if (_index >= _cache.Count)
+                        {
+                            return false;
+                        }
+
+                        _current = _index switch
+                        {
+                            0 => _cache.AttrValues1,
+                            1 => _cache.AttrValues2,
+                            2 => _cache.AttrValues3,
+                            3 => _cache.AttrValues4,
+                            4 => _cache.AttrValues5,
+                            5 => _cache.AttrValues6,
+                            6 => _cache.AttrValues7,
+                            7 => _cache.AttrValues8,
+                            8 => _cache.AttrValues9,
+                            9 => _cache.AttrValues10,
+                            _ => default,
+                        };
+                        _index++;
+
+                        return true;
+                    }
+
                     if (!_reader.HasData)
                     {
                         return false;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/CurveAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/CurveAsn.xml.cs
@@ -46,19 +46,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueCurveAsn decoded)
+        internal static ValueCurveAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueCurveAsn decoded)
+        internal static ValueCurveAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueCurveAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -66,16 +67,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueCurveAsn decoded)
+        internal static ValueCurveAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueCurveAsn decoded)
+        internal static ValueCurveAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -83,9 +84,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueCurveAsn decoded)
+        private static ValueCurveAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueCurveAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> tmpSpan;
 
@@ -127,6 +128,7 @@ namespace System.Security.Cryptography.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/DigestInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/DigestInfoAsn.xml.cs
@@ -110,19 +110,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueDigestInfoAsn decoded)
+        internal static ValueDigestInfoAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueDigestInfoAsn decoded)
+        internal static ValueDigestInfoAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueDigestInfoAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -130,16 +131,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueDigestInfoAsn decoded)
+        internal static ValueDigestInfoAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueDigestInfoAsn decoded)
+        internal static ValueDigestInfoAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -147,13 +148,13 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueDigestInfoAsn decoded)
+        private static ValueDigestInfoAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueDigestInfoAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> tmpSpan;
 
-            System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref sequenceReader, out decoded.DigestAlgorithm);
+            decoded.DigestAlgorithm = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref sequenceReader);
 
             if (sequenceReader.TryReadPrimitiveOctetString(out tmpSpan))
             {
@@ -166,6 +167,7 @@ namespace System.Security.Cryptography.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/DssParms.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/DssParms.xml.cs
@@ -30,19 +30,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueDssParms decoded)
+        internal static ValueDssParms Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueDssParms decoded)
+        internal static ValueDssParms Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueDssParms decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -50,16 +51,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueDssParms decoded)
+        internal static ValueDssParms Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueDssParms decoded)
+        internal static ValueDssParms Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -67,9 +68,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueDssParms decoded)
+        private static ValueDssParms DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueDssParms decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
             decoded.P = sequenceReader.ReadInteger();
@@ -77,6 +78,7 @@ namespace System.Security.Cryptography.Asn1
             decoded.G = sequenceReader.ReadInteger();
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/ECDomainParameters.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/ECDomainParameters.xml.cs
@@ -94,14 +94,15 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueECDomainParameters decoded)
+        internal static ValueECDomainParameters Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, out decoded);
+                ValueECDomainParameters decoded = DecodeCore(ref reader);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -109,11 +110,11 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueECDomainParameters decoded)
+        internal static ValueECDomainParameters Decode(scoped ref ValueAsnReader reader)
         {
             try
             {
-                DecodeCore(ref reader, out decoded);
+                return DecodeCore(ref reader);
             }
             catch (AsnContentException e)
             {
@@ -121,17 +122,14 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, out ValueECDomainParameters decoded)
+        private static ValueECDomainParameters DecodeCore(scoped ref ValueAsnReader reader)
         {
-            decoded = default;
+            ValueECDomainParameters decoded = default;
             Asn1Tag tag = reader.PeekTag();
 
             if (tag.HasSameClassAndValue(Asn1Tag.Sequence))
             {
-                System.Security.Cryptography.Asn1.ValueSpecifiedECDomain tmpSpecified;
-                System.Security.Cryptography.Asn1.ValueSpecifiedECDomain.Decode(ref reader, out tmpSpecified);
-                decoded.Specified = tmpSpecified;
-
+                decoded.Specified = System.Security.Cryptography.Asn1.ValueSpecifiedECDomain.Decode(ref reader);
                 decoded.HasSpecified = true;
             }
             else if (tag.HasSameClassAndValue(Asn1Tag.ObjectIdentifier))
@@ -142,6 +140,8 @@ namespace System.Security.Cryptography.Asn1
             {
                 throw new CryptographicException();
             }
+
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/ECPrivateKey.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/ECPrivateKey.xml.cs
@@ -68,19 +68,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueECPrivateKey decoded)
+        internal static ValueECPrivateKey Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueECPrivateKey decoded)
+        internal static ValueECPrivateKey Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueECPrivateKey decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -88,16 +89,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueECPrivateKey decoded)
+        internal static ValueECPrivateKey Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueECPrivateKey decoded)
+        internal static ValueECPrivateKey Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -105,9 +106,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueECPrivateKey decoded)
+        private static ValueECPrivateKey DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueECPrivateKey decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ValueAsnReader explicitReader;
             ReadOnlySpan<byte> tmpSpan;
@@ -132,10 +133,7 @@ namespace System.Security.Cryptography.Asn1
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 0)))
             {
                 explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
-                System.Security.Cryptography.Asn1.ValueECDomainParameters tmpParameters;
-                System.Security.Cryptography.Asn1.ValueECDomainParameters.Decode(ref explicitReader, out tmpParameters);
-                decoded.Parameters = tmpParameters;
-
+                decoded.Parameters = System.Security.Cryptography.Asn1.ValueECDomainParameters.Decode(ref explicitReader);
                 decoded.HasParameters = true;
                 explicitReader.ThrowIfNotEmpty();
             }
@@ -160,6 +158,7 @@ namespace System.Security.Cryptography.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/EncryptedPrivateKeyInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/EncryptedPrivateKeyInfoAsn.xml.cs
@@ -110,19 +110,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueEncryptedPrivateKeyInfoAsn decoded)
+        internal static ValueEncryptedPrivateKeyInfoAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueEncryptedPrivateKeyInfoAsn decoded)
+        internal static ValueEncryptedPrivateKeyInfoAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueEncryptedPrivateKeyInfoAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -130,16 +131,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueEncryptedPrivateKeyInfoAsn decoded)
+        internal static ValueEncryptedPrivateKeyInfoAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueEncryptedPrivateKeyInfoAsn decoded)
+        internal static ValueEncryptedPrivateKeyInfoAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -147,13 +148,13 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueEncryptedPrivateKeyInfoAsn decoded)
+        private static ValueEncryptedPrivateKeyInfoAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueEncryptedPrivateKeyInfoAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> tmpSpan;
 
-            System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref sequenceReader, out decoded.EncryptionAlgorithm);
+            decoded.EncryptionAlgorithm = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref sequenceReader);
 
             if (sequenceReader.TryReadPrimitiveOctetString(out tmpSpan))
             {
@@ -166,6 +167,7 @@ namespace System.Security.Cryptography.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/FieldID.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/FieldID.xml.cs
@@ -43,19 +43,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueFieldID decoded)
+        internal static ValueFieldID Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueFieldID decoded)
+        internal static ValueFieldID Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueFieldID decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -63,16 +64,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueFieldID decoded)
+        internal static ValueFieldID Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueFieldID decoded)
+        internal static ValueFieldID Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -80,15 +81,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueFieldID decoded)
+        private static ValueFieldID DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueFieldID decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
             decoded.FieldType = sequenceReader.ReadObjectIdentifier();
             decoded.Parameters = sequenceReader.ReadEncodedValue();
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLDsaPrivateKeyAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLDsaPrivateKeyAsn.xml.cs
@@ -120,14 +120,15 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueMLDsaPrivateKeyAsn decoded)
+        internal static ValueMLDsaPrivateKeyAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, out decoded);
+                ValueMLDsaPrivateKeyAsn decoded = DecodeCore(ref reader);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -135,11 +136,11 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueMLDsaPrivateKeyAsn decoded)
+        internal static ValueMLDsaPrivateKeyAsn Decode(scoped ref ValueAsnReader reader)
         {
             try
             {
-                DecodeCore(ref reader, out decoded);
+                return DecodeCore(ref reader);
             }
             catch (AsnContentException e)
             {
@@ -147,9 +148,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, out ValueMLDsaPrivateKeyAsn decoded)
+        private static ValueMLDsaPrivateKeyAsn DecodeCore(scoped ref ValueAsnReader reader)
         {
-            decoded = default;
+            ValueMLDsaPrivateKeyAsn decoded = default;
             Asn1Tag tag = reader.PeekTag();
             ReadOnlySpan<byte> tmpSpan;
 
@@ -183,16 +184,15 @@ namespace System.Security.Cryptography.Asn1
             }
             else if (tag.HasSameClassAndValue(Asn1Tag.Sequence))
             {
-                System.Security.Cryptography.Asn1.ValueMLDsaPrivateKeyBothAsn tmpBoth;
-                System.Security.Cryptography.Asn1.ValueMLDsaPrivateKeyBothAsn.Decode(ref reader, out tmpBoth);
-                decoded.Both = tmpBoth;
-
+                decoded.Both = System.Security.Cryptography.Asn1.ValueMLDsaPrivateKeyBothAsn.Decode(ref reader);
                 decoded.HasBoth = true;
             }
             else
             {
                 throw new CryptographicException();
             }
+
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLDsaPrivateKeyBothAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLDsaPrivateKeyBothAsn.xml.cs
@@ -28,19 +28,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueMLDsaPrivateKeyBothAsn decoded)
+        internal static ValueMLDsaPrivateKeyBothAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueMLDsaPrivateKeyBothAsn decoded)
+        internal static ValueMLDsaPrivateKeyBothAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueMLDsaPrivateKeyBothAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -48,16 +49,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueMLDsaPrivateKeyBothAsn decoded)
+        internal static ValueMLDsaPrivateKeyBothAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueMLDsaPrivateKeyBothAsn decoded)
+        internal static ValueMLDsaPrivateKeyBothAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -65,9 +66,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueMLDsaPrivateKeyBothAsn decoded)
+        private static ValueMLDsaPrivateKeyBothAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueMLDsaPrivateKeyBothAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> tmpSpan;
 
@@ -93,6 +94,7 @@ namespace System.Security.Cryptography.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLKemPrivateKeyAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLKemPrivateKeyAsn.xml.cs
@@ -120,14 +120,15 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueMLKemPrivateKeyAsn decoded)
+        internal static ValueMLKemPrivateKeyAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, out decoded);
+                ValueMLKemPrivateKeyAsn decoded = DecodeCore(ref reader);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -135,11 +136,11 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueMLKemPrivateKeyAsn decoded)
+        internal static ValueMLKemPrivateKeyAsn Decode(scoped ref ValueAsnReader reader)
         {
             try
             {
-                DecodeCore(ref reader, out decoded);
+                return DecodeCore(ref reader);
             }
             catch (AsnContentException e)
             {
@@ -147,9 +148,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, out ValueMLKemPrivateKeyAsn decoded)
+        private static ValueMLKemPrivateKeyAsn DecodeCore(scoped ref ValueAsnReader reader)
         {
-            decoded = default;
+            ValueMLKemPrivateKeyAsn decoded = default;
             Asn1Tag tag = reader.PeekTag();
             ReadOnlySpan<byte> tmpSpan;
 
@@ -183,16 +184,15 @@ namespace System.Security.Cryptography.Asn1
             }
             else if (tag.HasSameClassAndValue(Asn1Tag.Sequence))
             {
-                System.Security.Cryptography.Asn1.ValueMLKemPrivateKeyBothAsn tmpBoth;
-                System.Security.Cryptography.Asn1.ValueMLKemPrivateKeyBothAsn.Decode(ref reader, out tmpBoth);
-                decoded.Both = tmpBoth;
-
+                decoded.Both = System.Security.Cryptography.Asn1.ValueMLKemPrivateKeyBothAsn.Decode(ref reader);
                 decoded.HasBoth = true;
             }
             else
             {
                 throw new CryptographicException();
             }
+
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLKemPrivateKeyBothAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/MLKemPrivateKeyBothAsn.xml.cs
@@ -28,19 +28,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueMLKemPrivateKeyBothAsn decoded)
+        internal static ValueMLKemPrivateKeyBothAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueMLKemPrivateKeyBothAsn decoded)
+        internal static ValueMLKemPrivateKeyBothAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueMLKemPrivateKeyBothAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -48,16 +49,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueMLKemPrivateKeyBothAsn decoded)
+        internal static ValueMLKemPrivateKeyBothAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueMLKemPrivateKeyBothAsn decoded)
+        internal static ValueMLKemPrivateKeyBothAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -65,9 +66,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueMLKemPrivateKeyBothAsn decoded)
+        private static ValueMLKemPrivateKeyBothAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueMLKemPrivateKeyBothAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> tmpSpan;
 
@@ -93,6 +94,7 @@ namespace System.Security.Cryptography.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PBEParameter.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PBEParameter.xml.cs
@@ -28,19 +28,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValuePBEParameter decoded)
+        internal static ValuePBEParameter Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValuePBEParameter decoded)
+        internal static ValuePBEParameter Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValuePBEParameter decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -48,16 +49,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValuePBEParameter decoded)
+        internal static ValuePBEParameter Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValuePBEParameter decoded)
+        internal static ValuePBEParameter Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -65,9 +66,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValuePBEParameter decoded)
+        private static ValuePBEParameter DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValuePBEParameter decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> tmpSpan;
 
@@ -89,6 +90,7 @@ namespace System.Security.Cryptography.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PBES2Params.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PBES2Params.xml.cs
@@ -28,19 +28,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValuePBES2Params decoded)
+        internal static ValuePBES2Params Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValuePBES2Params decoded)
+        internal static ValuePBES2Params Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValuePBES2Params decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -48,16 +49,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValuePBES2Params decoded)
+        internal static ValuePBES2Params Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValuePBES2Params decoded)
+        internal static ValuePBES2Params Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -65,15 +66,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValuePBES2Params decoded)
+        private static ValuePBES2Params DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValuePBES2Params decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
-            System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref sequenceReader, out decoded.KeyDerivationFunc);
-            System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref sequenceReader, out decoded.EncryptionScheme);
+            decoded.KeyDerivationFunc = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref sequenceReader);
+            decoded.EncryptionScheme = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref sequenceReader);
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pbkdf2Params.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pbkdf2Params.xml.cs
@@ -19,7 +19,7 @@ namespace System.Security.Cryptography.Asn1
             ValueAsnReader reader;
 
             reader = new ValueAsnReader(SharedPbkdf2Params.DefaultPrf, AsnEncodingRules.DER);
-            System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref reader, out decoded.Prf);
+            decoded.Prf = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref reader);
             reader.ThrowIfNotEmpty();
         }
 #endif
@@ -65,19 +65,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValuePbkdf2Params decoded)
+        internal static ValuePbkdf2Params Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValuePbkdf2Params decoded)
+        internal static ValuePbkdf2Params Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValuePbkdf2Params decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -85,16 +86,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValuePbkdf2Params decoded)
+        internal static ValuePbkdf2Params Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValuePbkdf2Params decoded)
+        internal static ValuePbkdf2Params Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -102,13 +103,13 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValuePbkdf2Params decoded)
+        private static ValuePbkdf2Params DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValuePbkdf2Params decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ValueAsnReader defaultReader;
 
-            System.Security.Cryptography.Asn1.ValuePbkdf2SaltChoice.Decode(ref sequenceReader, out decoded.Salt);
+            decoded.Salt = System.Security.Cryptography.Asn1.ValuePbkdf2SaltChoice.Decode(ref sequenceReader);
 
             if (!sequenceReader.TryReadInt32(out decoded.IterationCount))
             {
@@ -133,16 +134,17 @@ namespace System.Security.Cryptography.Asn1
 
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(Asn1Tag.Sequence))
             {
-                System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref sequenceReader, out decoded.Prf);
+                decoded.Prf = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref sequenceReader);
             }
             else
             {
                 defaultReader = new ValueAsnReader(SharedPbkdf2Params.DefaultPrf, AsnEncodingRules.DER);
-                System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref defaultReader, out decoded.Prf);
+                decoded.Prf = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref defaultReader);
             }
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pbkdf2SaltChoice.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pbkdf2SaltChoice.xml.cs
@@ -98,14 +98,15 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValuePbkdf2SaltChoice decoded)
+        internal static ValuePbkdf2SaltChoice Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, out decoded);
+                ValuePbkdf2SaltChoice decoded = DecodeCore(ref reader);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -113,11 +114,11 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValuePbkdf2SaltChoice decoded)
+        internal static ValuePbkdf2SaltChoice Decode(scoped ref ValueAsnReader reader)
         {
             try
             {
-                DecodeCore(ref reader, out decoded);
+                return DecodeCore(ref reader);
             }
             catch (AsnContentException e)
             {
@@ -125,9 +126,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, out ValuePbkdf2SaltChoice decoded)
+        private static ValuePbkdf2SaltChoice DecodeCore(scoped ref ValueAsnReader reader)
         {
-            decoded = default;
+            ValuePbkdf2SaltChoice decoded = default;
             Asn1Tag tag = reader.PeekTag();
             ReadOnlySpan<byte> tmpSpan;
 
@@ -147,16 +148,15 @@ namespace System.Security.Cryptography.Asn1
             }
             else if (tag.HasSameClassAndValue(Asn1Tag.Sequence))
             {
-                System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn tmpOtherSource;
-                System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref reader, out tmpOtherSource);
-                decoded.OtherSource = tmpOtherSource;
-
+                decoded.OtherSource = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref reader);
                 decoded.HasOtherSource = true;
             }
             else
             {
                 throw new CryptographicException();
             }
+
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/MacData.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/MacData.xml.cs
@@ -182,19 +182,20 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueMacData decoded)
+        internal static ValueMacData Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueMacData decoded)
+        internal static ValueMacData Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueMacData decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -202,16 +203,16 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueMacData decoded)
+        internal static ValueMacData Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueMacData decoded)
+        internal static ValueMacData Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -219,14 +220,14 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueMacData decoded)
+        private static ValueMacData DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueMacData decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ValueAsnReader defaultReader;
             ReadOnlySpan<byte> tmpSpan;
 
-            System.Security.Cryptography.Asn1.ValueDigestInfoAsn.Decode(ref sequenceReader, out decoded.Mac);
+            decoded.Mac = System.Security.Cryptography.Asn1.ValueDigestInfoAsn.Decode(ref sequenceReader);
 
             if (sequenceReader.TryReadPrimitiveOctetString(out tmpSpan))
             {
@@ -260,6 +261,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/PfxAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs12/PfxAsn.xml.cs
@@ -137,19 +137,20 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValuePfxAsn decoded)
+        internal static ValuePfxAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValuePfxAsn decoded)
+        internal static ValuePfxAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValuePfxAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -157,16 +158,16 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValuePfxAsn decoded)
+        internal static ValuePfxAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValuePfxAsn decoded)
+        internal static ValuePfxAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -174,9 +175,9 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValuePfxAsn decoded)
+        private static ValuePfxAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValuePfxAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
 
@@ -185,19 +186,17 @@ namespace System.Security.Cryptography.Asn1.Pkcs12
                 sequenceReader.ThrowIfNotEmpty();
             }
 
-            System.Security.Cryptography.Asn1.Pkcs7.ValueContentInfoAsn.Decode(ref sequenceReader, out decoded.AuthSafe);
+            decoded.AuthSafe = System.Security.Cryptography.Asn1.Pkcs7.ValueContentInfoAsn.Decode(ref sequenceReader);
 
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(Asn1Tag.Sequence))
             {
-                System.Security.Cryptography.Asn1.Pkcs12.ValueMacData tmpMacData;
-                System.Security.Cryptography.Asn1.Pkcs12.ValueMacData.Decode(ref sequenceReader, out tmpMacData);
-                decoded.MacData = tmpMacData;
-
+                decoded.MacData = System.Security.Cryptography.Asn1.Pkcs12.ValueMacData.Decode(ref sequenceReader);
                 decoded.HasMacData = true;
             }
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/ContentInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Pkcs7/ContentInfoAsn.xml.cs
@@ -140,19 +140,20 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueContentInfoAsn decoded)
+        internal static ValueContentInfoAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueContentInfoAsn decoded)
+        internal static ValueContentInfoAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueContentInfoAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -160,16 +161,16 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueContentInfoAsn decoded)
+        internal static ValueContentInfoAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueContentInfoAsn decoded)
+        internal static ValueContentInfoAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -177,9 +178,9 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueContentInfoAsn decoded)
+        private static ValueContentInfoAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueContentInfoAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ValueAsnReader explicitReader;
 
@@ -191,6 +192,7 @@ namespace System.Security.Cryptography.Asn1.Pkcs7
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PrivateKeyInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PrivateKeyInfoAsn.xml.cs
@@ -145,7 +145,7 @@ namespace System.Security.Cryptography.Asn1
         internal ReadOnlySpan<byte> Attributes
         {
             get;
-            set
+            private set
             {
                 HasAttributes = true;
                 field = value;
@@ -153,6 +153,8 @@ namespace System.Security.Cryptography.Asn1
         }
 
         internal bool HasAttributes { get; private set; }
+        internal int AttributesLength { get; private set; }
+        private AttributesEnumerableCache _attributesCache;
 
         internal readonly void Encode(AsnWriter writer)
         {
@@ -183,19 +185,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValuePrivateKeyInfoAsn decoded)
+        internal static ValuePrivateKeyInfoAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValuePrivateKeyInfoAsn decoded)
+        internal static ValuePrivateKeyInfoAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValuePrivateKeyInfoAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -203,16 +206,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValuePrivateKeyInfoAsn decoded)
+        internal static ValuePrivateKeyInfoAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValuePrivateKeyInfoAsn decoded)
+        internal static ValuePrivateKeyInfoAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -220,9 +223,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValuePrivateKeyInfoAsn decoded)
+        private static ValuePrivateKeyInfoAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValuePrivateKeyInfoAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> tmpSpan;
 
@@ -232,7 +235,7 @@ namespace System.Security.Cryptography.Asn1
                 sequenceReader.ThrowIfNotEmpty();
             }
 
-            System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref sequenceReader, out decoded.PrivateKeyAlgorithm);
+            decoded.PrivateKeyAlgorithm = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref sequenceReader);
 
             if (sequenceReader.TryReadPrimitiveOctetString(out tmpSpan))
             {
@@ -247,42 +250,102 @@ namespace System.Security.Cryptography.Asn1
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 0)))
             {
                 decoded.Attributes = sequenceReader.ReadEncodedValue();
+                {
+                    int count = 0;
+                    ValueAsnReader cacheReader = new ValueAsnReader(decoded.Attributes, sequenceReader.RuleSet);
+                    ValueAsnReader collReader = cacheReader.ReadSetOf(new Asn1Tag(TagClass.ContextSpecific, 0));
+                    cacheReader.ThrowIfNotEmpty();
+
+                    while (collReader.HasData)
+                    {
+                        checked { count++; }
+                        System.Security.Cryptography.Asn1.ValueAttributeAsn item = System.Security.Cryptography.Asn1.ValueAttributeAsn.Decode(ref collReader);
+
+                        if (count <= 10)
+                        {
+                            switch (count)
+                            {
+                                case 1: decoded._attributesCache.Attributes1 = item; break;
+                                case 2: decoded._attributesCache.Attributes2 = item; break;
+                                case 3: decoded._attributesCache.Attributes3 = item; break;
+                                case 4: decoded._attributesCache.Attributes4 = item; break;
+                                case 5: decoded._attributesCache.Attributes5 = item; break;
+                                case 6: decoded._attributesCache.Attributes6 = item; break;
+                                case 7: decoded._attributesCache.Attributes7 = item; break;
+                                case 8: decoded._attributesCache.Attributes8 = item; break;
+                                case 9: decoded._attributesCache.Attributes9 = item; break;
+                                case 10: decoded._attributesCache.Attributes10 = item; break;
+                            }
+                        }
+                    }
+
+                    if (count <= 10)
+                    {
+                        decoded._attributesCache.Success = true;
+                    }
+                    decoded._attributesCache.Count = count;
+                    decoded._attributesCache.RuleSet = sequenceReader.RuleSet;
+                    decoded.AttributesLength = count;
+                }
                 decoded.HasAttributes = true;
             }
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
 
 
-        internal AttributesEnumerable GetAttributes(AsnEncodingRules ruleSet)
+        internal AttributesEnumerable GetAttributes()
         {
-            return new AttributesEnumerable(Attributes, ruleSet);
+            return new AttributesEnumerable(Attributes, _attributesCache);
+        }
+
+        internal ref struct AttributesEnumerableCache
+        {
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes1;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes2;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes3;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes4;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes5;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes6;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes7;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes8;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes9;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes10;
+            internal int Count;
+            internal bool Success;
+            internal AsnEncodingRules RuleSet;
         }
 
         internal readonly ref struct AttributesEnumerable
         {
             private readonly ReadOnlySpan<byte> _encoded;
-            private readonly AsnEncodingRules _ruleSet;
+            private readonly AttributesEnumerableCache _cache;
 
-            internal AttributesEnumerable(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
+            internal AttributesEnumerable(ReadOnlySpan<byte> encoded, AttributesEnumerableCache cache)
             {
                 _encoded = encoded;
-                _ruleSet = ruleSet;
+                _cache = cache;
             }
 
-            public Enumerator GetEnumerator() => new Enumerator(_encoded, _ruleSet);
+            public Enumerator GetEnumerator() => new Enumerator(_encoded, _cache);
 
             internal ref struct Enumerator
             {
                 private ValueAsnReader _reader;
                 private System.Security.Cryptography.Asn1.ValueAttributeAsn _current;
+                private readonly AttributesEnumerableCache _cache;
+                private int _index;
 
-                internal Enumerator(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
+                internal Enumerator(ReadOnlySpan<byte> encoded, AttributesEnumerableCache cache)
                 {
-                    if (!encoded.IsEmpty)
+                    _cache = cache;
+                    _index = 0;
+
+                    if (!cache.Success && !encoded.IsEmpty)
                     {
-                        ValueAsnReader outerReader = new ValueAsnReader(encoded, ruleSet);
+                        ValueAsnReader outerReader = new ValueAsnReader(encoded, cache.RuleSet);
                         _reader = outerReader.ReadSetOf(new Asn1Tag(TagClass.ContextSpecific, 0));
                         outerReader.ThrowIfNotEmpty();
                     }
@@ -294,12 +357,38 @@ namespace System.Security.Cryptography.Asn1
 
                 public bool MoveNext()
                 {
+                    if (_cache.Success)
+                    {
+                        if (_index >= _cache.Count)
+                        {
+                            return false;
+                        }
+
+                        _current = _index switch
+                        {
+                            0 => _cache.Attributes1,
+                            1 => _cache.Attributes2,
+                            2 => _cache.Attributes3,
+                            3 => _cache.Attributes4,
+                            4 => _cache.Attributes5,
+                            5 => _cache.Attributes6,
+                            6 => _cache.Attributes7,
+                            7 => _cache.Attributes8,
+                            8 => _cache.Attributes9,
+                            9 => _cache.Attributes10,
+                            _ => default,
+                        };
+                        _index++;
+
+                        return true;
+                    }
+
                     if (!_reader.HasData)
                     {
                         return false;
                     }
 
-                    System.Security.Cryptography.Asn1.ValueAttributeAsn.Decode(ref _reader, out _current);
+                    _current = System.Security.Cryptography.Asn1.ValueAttributeAsn.Decode(ref _reader);
                     return true;
                 }
             }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PssParamsAsn.manual.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PssParamsAsn.manual.cs
@@ -27,10 +27,9 @@ namespace System.Security.Cryptography.Asn1
                 throw new CryptographicException(SR.Cryptography_Pkcs_InvalidSignatureParameters);
             }
 
-            ValueAlgorithmIdentifierAsn.Decode(
+            ValueAlgorithmIdentifierAsn mgfParams = ValueAlgorithmIdentifierAsn.Decode(
                 MaskGenAlgorithm.Parameters,
-                AsnEncodingRules.DER,
-                out ValueAlgorithmIdentifierAsn mgfParams);
+                AsnEncodingRules.DER);
 
             if (mgfParams.Algorithm != HashAlgorithm.Algorithm)
             {

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PssParamsAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PssParamsAsn.xml.cs
@@ -25,11 +25,11 @@ namespace System.Security.Cryptography.Asn1
             ValueAsnReader reader;
 
             reader = new ValueAsnReader(SharedPssParamsAsn.DefaultHashAlgorithm, AsnEncodingRules.DER);
-            System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref reader, out decoded.HashAlgorithm);
+            decoded.HashAlgorithm = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref reader);
             reader.ThrowIfNotEmpty();
 
             reader = new ValueAsnReader(SharedPssParamsAsn.DefaultMaskGenAlgorithm, AsnEncodingRules.DER);
-            System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref reader, out decoded.MaskGenAlgorithm);
+            decoded.MaskGenAlgorithm = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref reader);
             reader.ThrowIfNotEmpty();
 
             reader = new ValueAsnReader(SharedPssParamsAsn.DefaultSaltLength, AsnEncodingRules.DER);
@@ -131,19 +131,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValuePssParamsAsn decoded)
+        internal static ValuePssParamsAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValuePssParamsAsn decoded)
+        internal static ValuePssParamsAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValuePssParamsAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -151,16 +152,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValuePssParamsAsn decoded)
+        internal static ValuePssParamsAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValuePssParamsAsn decoded)
+        internal static ValuePssParamsAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -168,9 +169,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValuePssParamsAsn decoded)
+        private static ValuePssParamsAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValuePssParamsAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ValueAsnReader explicitReader;
             ValueAsnReader defaultReader;
@@ -179,26 +180,26 @@ namespace System.Security.Cryptography.Asn1
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 0)))
             {
                 explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 0));
-                System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref explicitReader, out decoded.HashAlgorithm);
+                decoded.HashAlgorithm = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref explicitReader);
                 explicitReader.ThrowIfNotEmpty();
             }
             else
             {
                 defaultReader = new ValueAsnReader(SharedPssParamsAsn.DefaultHashAlgorithm, AsnEncodingRules.DER);
-                System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref defaultReader, out decoded.HashAlgorithm);
+                decoded.HashAlgorithm = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref defaultReader);
             }
 
 
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 1)))
             {
                 explicitReader = sequenceReader.ReadSequence(new Asn1Tag(TagClass.ContextSpecific, 1));
-                System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref explicitReader, out decoded.MaskGenAlgorithm);
+                decoded.MaskGenAlgorithm = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref explicitReader);
                 explicitReader.ThrowIfNotEmpty();
             }
             else
             {
                 defaultReader = new ValueAsnReader(SharedPssParamsAsn.DefaultMaskGenAlgorithm, AsnEncodingRules.DER);
-                System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref defaultReader, out decoded.MaskGenAlgorithm);
+                decoded.MaskGenAlgorithm = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref defaultReader);
             }
 
 
@@ -249,6 +250,7 @@ namespace System.Security.Cryptography.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/RSAPrivateKeyAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/RSAPrivateKeyAsn.xml.cs
@@ -42,19 +42,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueRSAPrivateKeyAsn decoded)
+        internal static ValueRSAPrivateKeyAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueRSAPrivateKeyAsn decoded)
+        internal static ValueRSAPrivateKeyAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueRSAPrivateKeyAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -62,16 +63,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueRSAPrivateKeyAsn decoded)
+        internal static ValueRSAPrivateKeyAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueRSAPrivateKeyAsn decoded)
+        internal static ValueRSAPrivateKeyAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -79,9 +80,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueRSAPrivateKeyAsn decoded)
+        private static ValueRSAPrivateKeyAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueRSAPrivateKeyAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
 
@@ -100,6 +101,7 @@ namespace System.Security.Cryptography.Asn1
             decoded.Coefficient = sequenceReader.ReadIntegerBytes();
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/RSAPublicKeyAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/RSAPublicKeyAsn.xml.cs
@@ -28,19 +28,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueRSAPublicKeyAsn decoded)
+        internal static ValueRSAPublicKeyAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueRSAPublicKeyAsn decoded)
+        internal static ValueRSAPublicKeyAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueRSAPublicKeyAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -48,16 +49,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueRSAPublicKeyAsn decoded)
+        internal static ValueRSAPublicKeyAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueRSAPublicKeyAsn decoded)
+        internal static ValueRSAPublicKeyAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -65,15 +66,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueRSAPublicKeyAsn decoded)
+        private static ValueRSAPublicKeyAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueRSAPublicKeyAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
             decoded.Modulus = sequenceReader.ReadIntegerBytes();
             decoded.PublicExponent = sequenceReader.ReadIntegerBytes();
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/Rc2CbcParameters.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/Rc2CbcParameters.xml.cs
@@ -115,19 +115,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueRc2CbcParameters decoded)
+        internal static ValueRc2CbcParameters Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueRc2CbcParameters decoded)
+        internal static ValueRc2CbcParameters Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueRc2CbcParameters decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -135,16 +136,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueRc2CbcParameters decoded)
+        internal static ValueRc2CbcParameters Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueRc2CbcParameters decoded)
+        internal static ValueRc2CbcParameters Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -152,9 +153,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueRc2CbcParameters decoded)
+        private static ValueRc2CbcParameters DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueRc2CbcParameters decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> tmpSpan;
 
@@ -176,6 +177,7 @@ namespace System.Security.Cryptography.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/SpecifiedECDomain.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/SpecifiedECDomain.xml.cs
@@ -66,19 +66,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueSpecifiedECDomain decoded)
+        internal static ValueSpecifiedECDomain Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueSpecifiedECDomain decoded)
+        internal static ValueSpecifiedECDomain Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueSpecifiedECDomain decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -86,16 +87,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueSpecifiedECDomain decoded)
+        internal static ValueSpecifiedECDomain Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueSpecifiedECDomain decoded)
+        internal static ValueSpecifiedECDomain Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -103,9 +104,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueSpecifiedECDomain decoded)
+        private static ValueSpecifiedECDomain DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueSpecifiedECDomain decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> tmpSpan;
 
@@ -115,8 +116,8 @@ namespace System.Security.Cryptography.Asn1
                 sequenceReader.ThrowIfNotEmpty();
             }
 
-            System.Security.Cryptography.Asn1.ValueFieldID.Decode(ref sequenceReader, out decoded.FieldID);
-            System.Security.Cryptography.Asn1.ValueCurveAsn.Decode(ref sequenceReader, out decoded.Curve);
+            decoded.FieldID = System.Security.Cryptography.Asn1.ValueFieldID.Decode(ref sequenceReader);
+            decoded.Curve = System.Security.Cryptography.Asn1.ValueCurveAsn.Decode(ref sequenceReader);
 
             if (sequenceReader.TryReadPrimitiveOctetString(out tmpSpan))
             {
@@ -143,6 +144,7 @@ namespace System.Security.Cryptography.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/SubjectPublicKeyInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/SubjectPublicKeyInfoAsn.xml.cs
@@ -110,19 +110,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueSubjectPublicKeyInfoAsn decoded)
+        internal static ValueSubjectPublicKeyInfoAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueSubjectPublicKeyInfoAsn decoded)
+        internal static ValueSubjectPublicKeyInfoAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueSubjectPublicKeyInfoAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -130,16 +131,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueSubjectPublicKeyInfoAsn decoded)
+        internal static ValueSubjectPublicKeyInfoAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueSubjectPublicKeyInfoAsn decoded)
+        internal static ValueSubjectPublicKeyInfoAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -147,13 +148,13 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueSubjectPublicKeyInfoAsn decoded)
+        private static ValueSubjectPublicKeyInfoAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueSubjectPublicKeyInfoAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> tmpSpan;
 
-            System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref sequenceReader, out decoded.Algorithm);
+            decoded.Algorithm = System.Security.Cryptography.Asn1.ValueAlgorithmIdentifierAsn.Decode(ref sequenceReader);
 
             if (sequenceReader.TryReadPrimitiveBitString(out _, out tmpSpan))
             {
@@ -166,6 +167,7 @@ namespace System.Security.Cryptography.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/X509ExtensionAsn.xml.cs
@@ -181,19 +181,20 @@ namespace System.Security.Cryptography.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueX509ExtensionAsn decoded)
+        internal static ValueX509ExtensionAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueX509ExtensionAsn decoded)
+        internal static ValueX509ExtensionAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueX509ExtensionAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -201,16 +202,16 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueX509ExtensionAsn decoded)
+        internal static ValueX509ExtensionAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueX509ExtensionAsn decoded)
+        internal static ValueX509ExtensionAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -218,9 +219,9 @@ namespace System.Security.Cryptography.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueX509ExtensionAsn decoded)
+        private static ValueX509ExtensionAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueX509ExtensionAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ValueAsnReader defaultReader;
             ReadOnlySpan<byte> tmpSpan;
@@ -249,6 +250,7 @@ namespace System.Security.Cryptography.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/asn.xslt
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/asn.xslt
@@ -165,19 +165,20 @@ namespace <xsl:value-of select="@namespace" />
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan&lt;byte&gt; encoded, AsnEncodingRules ruleSet, out Value<xsl:value-of select="@name" /> decoded)
+        internal static Value<xsl:value-of select="@name" /> Decode(ReadOnlySpan&lt;byte&gt; encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan&lt;byte&gt; encoded, AsnEncodingRules ruleSet, out Value<xsl:value-of select="@name" /> decoded)
+        internal static Value<xsl:value-of select="@name" /> Decode(Asn1Tag expectedTag, ReadOnlySpan&lt;byte&gt; encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                Value<xsl:value-of select="@name" /> decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -185,16 +186,16 @@ namespace <xsl:value-of select="@namespace" />
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out Value<xsl:value-of select="@name" /> decoded)
+        internal static Value<xsl:value-of select="@name" /> Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out Value<xsl:value-of select="@name" /> decoded)
+        internal static Value<xsl:value-of select="@name" /> Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -202,9 +203,9 @@ namespace <xsl:value-of select="@namespace" />
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out Value<xsl:value-of select="@name" /> decoded)
+        private static Value<xsl:value-of select="@name" /> DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            Value<xsl:value-of select="@name" /> decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);<xsl:if test="*[@explicitTag]">
             ValueAsnReader explicitReader;</xsl:if><xsl:if test="*[@defaultDerInit]">
             ValueAsnReader defaultReader;</xsl:if><xsl:if test="$hasSpanTryRead &gt; 0">
@@ -212,6 +213,7 @@ namespace <xsl:value-of select="@namespace" />
 <xsl:apply-templates mode="ValueDecode" />
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
 <xsl:apply-templates mode="ValueCollectionEnumerable" />    }
 </xsl:if>}
@@ -340,14 +342,15 @@ namespace <xsl:value-of select="@namespace" />
             }
         }
 
-        internal static void Decode(ReadOnlySpan&lt;byte&gt; encoded, AsnEncodingRules ruleSet, out Value<xsl:value-of select="@name" /> decoded)
+        internal static Value<xsl:value-of select="@name" /> Decode(ReadOnlySpan&lt;byte&gt; encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, out decoded);
+                Value<xsl:value-of select="@name" /> decoded = DecodeCore(ref reader);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -355,11 +358,11 @@ namespace <xsl:value-of select="@namespace" />
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out Value<xsl:value-of select="@name" /> decoded)
+        internal static Value<xsl:value-of select="@name" /> Decode(scoped ref ValueAsnReader reader)
         {
             try
             {
-                DecodeCore(ref reader, out decoded);
+                return DecodeCore(ref reader);
             }
             catch (AsnContentException e)
             {
@@ -367,9 +370,9 @@ namespace <xsl:value-of select="@namespace" />
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, out Value<xsl:value-of select="@name" /> decoded)
+        private static Value<xsl:value-of select="@name" /> DecodeCore(scoped ref ValueAsnReader reader)
         {
-            decoded = default;
+            Value<xsl:value-of select="@name" /> decoded = default;
             Asn1Tag tag = reader.PeekTag();<xsl:if test="*[@explicitTag]">
             ValueAsnReader explicitReader;</xsl:if><xsl:if test="$hasSpanTryRead &gt; 0">
             ReadOnlySpan&lt;byte&gt; tmpSpan;</xsl:if>
@@ -378,6 +381,8 @@ namespace <xsl:value-of select="@namespace" />
             {
                 throw new CryptographicException();
             }
+
+            return decoded;
         }
 <xsl:apply-templates select="*" mode="ValueCollectionEnumerable" />    }
 </xsl:if>}
@@ -1075,6 +1080,63 @@ namespace <xsl:value-of select="@namespace" />
   <!-- ReadBoolean() vs ReadBoolean(tag) -->
   <xsl:template name="MaybeImplicitCall0"><xsl:if test="@implicitTag"><xsl:call-template name="ContextTag"/></xsl:if></xsl:template>
 
+  <!-- Lowercase-first helper for generating camelCase field names -->
+  <xsl:template name="LowercaseFirst"><xsl:param name="value"/><xsl:value-of select="concat(translate(substring($value, 1, 1), 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz'), substring($value, 2))"/></xsl:template>
+
+  <!-- Emit cache struct field declarations (recursive, 1..max) -->
+  <xsl:template name="EmitCacheFields" xml:space="default">
+    <xsl:param name="n" select="1"/>
+    <xsl:param name="max" select="10"/>
+    <xsl:param name="name"/>
+    <xsl:param name="type"/>
+    <xsl:if test="$n &lt;= $max" xml:space="preserve">
+            internal <xsl:value-of select="$type"/><xsl:text> </xsl:text><xsl:value-of select="$name"/><xsl:value-of select="$n"/>;</xsl:if>
+    <xsl:if test="$n &lt; $max">
+      <xsl:call-template name="EmitCacheFields">
+        <xsl:with-param name="n" select="$n + 1"/>
+        <xsl:with-param name="max" select="$max"/>
+        <xsl:with-param name="name" select="$name"/>
+        <xsl:with-param name="type" select="$type"/>
+      </xsl:call-template>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- Emit cache assignment switch cases in DecodeCore (recursive, 1..max) -->
+  <xsl:template name="EmitCacheAssignCases" xml:space="default">
+    <xsl:param name="n" select="1"/>
+    <xsl:param name="max" select="10"/>
+    <xsl:param name="name"/>
+    <xsl:param name="indent"/>
+    <xsl:param name="target"/>
+    <xsl:if test="$n &lt;= $max" xml:space="preserve">
+                            <xsl:value-of select="$indent"/>case <xsl:value-of select="$n"/>: <xsl:value-of select="$target"/>.<xsl:value-of select="$name"/><xsl:value-of select="$n"/> = item; break;</xsl:if>
+    <xsl:if test="$n &lt; $max">
+      <xsl:call-template name="EmitCacheAssignCases">
+        <xsl:with-param name="n" select="$n + 1"/>
+        <xsl:with-param name="max" select="$max"/>
+        <xsl:with-param name="name" select="$name"/>
+        <xsl:with-param name="indent" select="$indent"/>
+        <xsl:with-param name="target" select="$target"/>
+      </xsl:call-template>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- Emit cache read switch arms in MoveNext (recursive, 0-based index => 1-based field) -->
+  <xsl:template name="EmitCacheReadArms" xml:space="default">
+    <xsl:param name="n" select="1"/>
+    <xsl:param name="max" select="10"/>
+    <xsl:param name="name"/>
+    <xsl:if test="$n &lt;= $max" xml:space="preserve">
+                            <xsl:value-of select="$n - 1"/> =&gt; _cache.<xsl:value-of select="$name"/><xsl:value-of select="$n"/>,</xsl:if>
+    <xsl:if test="$n &lt; $max">
+      <xsl:call-template name="EmitCacheReadArms">
+        <xsl:with-param name="n" select="$n + 1"/>
+        <xsl:with-param name="max" select="$max"/>
+        <xsl:with-param name="name" select="$name"/>
+      </xsl:call-template>
+    </xsl:if>
+  </xsl:template>
+
   <!-- Encode(writer) vs Encode(writer, tag) -->
   <xsl:template name="MaybeImplicitCallS"><xsl:if test="@implicitTag">, <xsl:call-template name="ContextTag"/></xsl:if></xsl:template>
 
@@ -1139,7 +1201,32 @@ namespace <xsl:value-of select="@namespace" />
     <xsl:call-template name="ValueFieldOrProperty"><xsl:with-param name="fieldType">ReadOnlySpan&lt;byte&gt;</xsl:with-param></xsl:call-template>
   </xsl:template>
 
-  <xsl:template match="asn:SequenceOf | asn:SetOf" mode="ValueFieldDef" xml:space="default">
+  <xsl:template match="asn:SequenceOf[@valueName] | asn:SetOf[@valueName]" mode="ValueFieldDef" xml:space="default">
+    <xsl:variable name="cacheFieldName">_<xsl:call-template name="LowercaseFirst"><xsl:with-param name="value" select="@name"/></xsl:call-template>Cache</xsl:variable>
+    <xsl:choose>
+      <xsl:when test="@optional | parent::asn:Choice" xml:space="preserve">
+
+        internal ReadOnlySpan&lt;byte&gt; <xsl:value-of select="@name"/>
+        {
+            get;
+            private set
+            {
+                Has<xsl:value-of select="@name"/> = true;
+                field = value;
+            }
+        }
+
+        internal bool Has<xsl:value-of select="@name"/> { get; private set; }
+        internal int <xsl:value-of select="@name"/>Length { get; private set; }
+        private <xsl:value-of select="@name"/>EnumerableCache <xsl:value-of select="$cacheFieldName"/>;</xsl:when>
+      <xsl:otherwise xml:space="preserve">
+        internal ReadOnlySpan&lt;byte&gt; <xsl:value-of select="@name"/> { get; private set; }
+        internal int <xsl:value-of select="@name"/>Length { get; private set; }
+        private <xsl:value-of select="@name"/>EnumerableCache <xsl:value-of select="$cacheFieldName"/>;</xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="asn:SequenceOf[not(@valueName)] | asn:SetOf[not(@valueName)]" mode="ValueFieldDef" xml:space="default">
     <xsl:call-template name="ValueFieldOrProperty"><xsl:with-param name="fieldType">ReadOnlySpan&lt;byte&gt;</xsl:with-param></xsl:call-template>
   </xsl:template>
 
@@ -1192,15 +1279,8 @@ namespace <xsl:value-of select="@namespace" />
     <xsl:param name="readerName" />
     <xsl:param name="indent" />
     <xsl:param name="name" select="concat('decoded.', @name)"/>
-    <xsl:choose>
-      <xsl:when test="@optional | parent::asn:Choice" xml:space="preserve">
-            <xsl:value-of select="$indent"/><xsl:value-of select="@valueTypeName"/> tmp<xsl:value-of select="@name"/>;
-            <xsl:value-of select="$indent"/><xsl:value-of select="@valueTypeName"/>.Decode(ref <xsl:value-of select="$readerName"/><xsl:call-template name="MaybeImplicitCallS"/>, out tmp<xsl:value-of select="@name"/>);
-            <xsl:value-of select="$indent"/><xsl:value-of select="$name"/> = tmp<xsl:value-of select="@name"/>;
-</xsl:when>
-      <xsl:otherwise xml:space="preserve">
-            <xsl:value-of select="$indent"/><xsl:value-of select="@valueTypeName"/>.Decode(ref <xsl:value-of select="$readerName"/><xsl:call-template name="MaybeImplicitCallS"/>, out <xsl:value-of select="$name"/>);</xsl:otherwise>
-    </xsl:choose>
+    <xsl:if test="1" xml:space="preserve">
+            <xsl:value-of select="$indent"/><xsl:value-of select="$name"/> = <xsl:value-of select="@valueTypeName"/>.Decode(ref <xsl:value-of select="$readerName"/><xsl:call-template name="MaybeImplicitCallS"/>);</xsl:if>
   </xsl:template>
 
   <xsl:template match="asn:AsnType[not(@valueTypeName) and @rebind='false']" mode="ValueDecodeSimpleValue" xml:space="default">
@@ -1310,6 +1390,45 @@ namespace <xsl:value-of select="@namespace" />
     </xsl:if>
     <xsl:if test="1" xml:space="preserve">
             <xsl:value-of select="$indent"/>decoded.<xsl:value-of select="@name"/> = <xsl:value-of select="$readerName"/>.ReadEncodedValue();</xsl:if>
+    <xsl:if test="@valueName">
+      <xsl:variable name="elementType">
+        <xsl:choose>
+          <xsl:when test="*/@valueTypeName"><xsl:value-of select="*/@valueTypeName"/></xsl:when>
+          <xsl:otherwise>ReadOnlySpan&lt;byte&gt;</xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+      <xsl:variable name="cacheFieldName">_<xsl:call-template name="LowercaseFirst"><xsl:with-param name="value" select="@name"/></xsl:call-template>Cache</xsl:variable>
+      <xsl:variable name="collNoun"><xsl:choose><xsl:when test="self::asn:SetOf">SetOf</xsl:when><xsl:otherwise>Sequence</xsl:otherwise></xsl:choose></xsl:variable>
+      <!-- We eagerly iterate to validate the ASN.1 structure and populate the cache. -->
+      <xsl:if test="1" xml:space="preserve">
+            <xsl:value-of select="$indent"/>{
+                <xsl:value-of select="$indent"/>int count = 0;
+                <xsl:value-of select="$indent"/>ValueAsnReader cacheReader = new ValueAsnReader(decoded.<xsl:value-of select="@name"/>, <xsl:value-of select="$readerName"/>.RuleSet);
+                <xsl:value-of select="$indent"/>ValueAsnReader collReader = cacheReader.Read<xsl:value-of select="$collNoun"/>(<xsl:call-template name="MaybeImplicitCall0"/>);
+                <xsl:value-of select="$indent"/>cacheReader.ThrowIfNotEmpty();
+
+                <xsl:value-of select="$indent"/>while (collReader.HasData)
+                <xsl:value-of select="$indent"/>{
+                    <xsl:value-of select="$indent"/>checked { count++; }
+                    <xsl:value-of select="$indent"/><xsl:value-of select="$elementType"/> item<xsl:choose><xsl:when test="*/@valueTypeName"> = <xsl:value-of select="*/@valueTypeName"/>.Decode(ref collReader)</xsl:when><xsl:otherwise> = collReader.ReadEncodedValue()</xsl:otherwise></xsl:choose>;
+
+                    <xsl:value-of select="$indent"/>if (count &lt;= 10)
+                    <xsl:value-of select="$indent"/>{
+                        <xsl:value-of select="$indent"/>switch (count)
+                        <xsl:value-of select="$indent"/>{<xsl:call-template name="EmitCacheAssignCases"><xsl:with-param name="name" select="@name"/><xsl:with-param name="indent" select="$indent"/><xsl:with-param name="target" select="concat('decoded.', $cacheFieldName)"/></xsl:call-template>
+                        <xsl:value-of select="$indent"/>}
+                    <xsl:value-of select="$indent"/>}
+                <xsl:value-of select="$indent"/>}
+
+                <xsl:value-of select="$indent"/>if (count &lt;= 10)
+                <xsl:value-of select="$indent"/>{
+                    <xsl:value-of select="$indent"/>decoded.<xsl:value-of select="$cacheFieldName"/>.Success = true;
+                <xsl:value-of select="$indent"/>}
+                <xsl:value-of select="$indent"/>decoded.<xsl:value-of select="$cacheFieldName"/>.Count = count;
+                <xsl:value-of select="$indent"/>decoded.<xsl:value-of select="$cacheFieldName"/>.RuleSet = <xsl:value-of select="$readerName"/>.RuleSet;
+                <xsl:value-of select="$indent"/>decoded.<xsl:value-of select="@name"/>Length = count;
+            <xsl:value-of select="$indent"/>}</xsl:if>
+    </xsl:if>
   </xsl:template>
 
   <!-- ==== Value* ref struct: decode orchestration ==== -->
@@ -1414,36 +1533,49 @@ namespace <xsl:value-of select="@namespace" />
         <xsl:otherwise>ReadOnlySpan&lt;byte&gt;</xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
+    <xsl:variable name="cacheFieldName">_<xsl:call-template name="LowercaseFirst"><xsl:with-param name="value" select="@name"/></xsl:call-template>Cache</xsl:variable>
     <xsl:if test="1" xml:space="preserve">
 
-        internal <xsl:value-of select="@name"/>Enumerable <xsl:value-of select="@valueName"/>(AsnEncodingRules ruleSet)
+        internal <xsl:value-of select="@name"/>Enumerable <xsl:value-of select="@valueName"/>()
         {
-            return new <xsl:value-of select="@name"/>Enumerable(<xsl:value-of select="@name"/>, ruleSet);
+            return new <xsl:value-of select="@name"/>Enumerable(<xsl:value-of select="@name"/>, <xsl:value-of select="$cacheFieldName"/>);
+        }
+
+        internal ref struct <xsl:value-of select="@name"/>EnumerableCache
+        {<xsl:call-template name="EmitCacheFields"><xsl:with-param name="name" select="@name"/><xsl:with-param name="type" select="$elementType"/></xsl:call-template>
+            internal int Count;
+            internal bool Success;
+            internal AsnEncodingRules RuleSet;
         }
 
         internal readonly ref struct <xsl:value-of select="@name"/>Enumerable
         {
             private readonly ReadOnlySpan&lt;byte&gt; _encoded;
-            private readonly AsnEncodingRules _ruleSet;
+            private readonly <xsl:value-of select="@name"/>EnumerableCache _cache;
 
-            internal <xsl:value-of select="@name"/>Enumerable(ReadOnlySpan&lt;byte&gt; encoded, AsnEncodingRules ruleSet)
+            internal <xsl:value-of select="@name"/>Enumerable(ReadOnlySpan&lt;byte&gt; encoded, <xsl:value-of select="@name"/>EnumerableCache cache)
             {
                 _encoded = encoded;
-                _ruleSet = ruleSet;
+                _cache = cache;
             }
 
-            public Enumerator GetEnumerator() =&gt; new Enumerator(_encoded, _ruleSet);
+            public Enumerator GetEnumerator() =&gt; new Enumerator(_encoded, _cache);
 
             internal ref struct Enumerator
             {
                 private ValueAsnReader _reader;
                 private <xsl:value-of select="$elementType"/> _current;
+                private readonly <xsl:value-of select="@name"/>EnumerableCache _cache;
+                private int _index;
 
-                internal Enumerator(ReadOnlySpan&lt;byte&gt; encoded, AsnEncodingRules ruleSet)
+                internal Enumerator(ReadOnlySpan&lt;byte&gt; encoded, <xsl:value-of select="@name"/>EnumerableCache cache)
                 {
-                    if (!encoded.IsEmpty)
+                    _cache = cache;
+                    _index = 0;
+
+                    if (!cache.Success &amp;&amp; !encoded.IsEmpty)
                     {
-                        ValueAsnReader outerReader = new ValueAsnReader(encoded, ruleSet);
+                        ValueAsnReader outerReader = new ValueAsnReader(encoded, cache.RuleSet);
                         _reader = outerReader.Read<xsl:value-of select="$collNoun"/>(<xsl:call-template name="MaybeImplicitCall0"/>);
                         outerReader.ThrowIfNotEmpty();
                     }
@@ -1455,12 +1587,28 @@ namespace <xsl:value-of select="@namespace" />
 
                 public bool MoveNext()
                 {
+                    if (_cache.Success)
+                    {
+                        if (_index &gt;= _cache.Count)
+                        {
+                            return false;
+                        }
+
+                        _current = _index switch
+                        {<xsl:call-template name="EmitCacheReadArms"><xsl:with-param name="name" select="@name"/></xsl:call-template>
+                            _ =&gt; default,
+                        };
+                        _index++;
+
+                        return true;
+                    }
+
                     if (!_reader.HasData)
                     {
                         return false;
                     }
 <xsl:choose><xsl:when test="*/@valueTypeName">
-                    <xsl:value-of select="*/@valueTypeName"/>.Decode(ref _reader, out _current);</xsl:when><xsl:otherwise>
+                    _current = <xsl:value-of select="*/@valueTypeName"/>.Decode(ref _reader);</xsl:when><xsl:otherwise>
                     _current = _reader.ReadEncodedValue();</xsl:otherwise></xsl:choose>
                     return true;
                 }

--- a/src/libraries/Common/src/System/Security/Cryptography/CngPkcs8.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CngPkcs8.cs
@@ -375,7 +375,7 @@ namespace System.Security.Cryptography
         // signaling the original exception should be thrown.
         private static unsafe AsnWriter? RewritePkcs8ECPrivateKeyWithZeroPublicKey(ReadOnlySpan<byte> source)
         {
-            ValuePrivateKeyInfoAsn.Decode(source, AsnEncodingRules.BER, out ValuePrivateKeyInfoAsn privateKeyInfo);
+            ValuePrivateKeyInfoAsn privateKeyInfo = ValuePrivateKeyInfoAsn.Decode(source, AsnEncodingRules.BER);
             ValueAlgorithmIdentifierAsn privateAlgorithm = privateKeyInfo.PrivateKeyAlgorithm;
 
             if (privateAlgorithm.Algorithm != Oids.EcPublicKey)
@@ -383,7 +383,7 @@ namespace System.Security.Cryptography
                 return null;
             }
 
-            ValueECPrivateKey.Decode(privateKeyInfo.PrivateKey, AsnEncodingRules.BER, out ValueECPrivateKey privateKey);
+            ValueECPrivateKey privateKey = ValueECPrivateKey.Decode(privateKeyInfo.PrivateKey, AsnEncodingRules.BER);
             EccKeyFormatHelper.FromECPrivateKey(privateKey, privateAlgorithm, out ECParameters ecParameters);
 
             fixed (byte* pD = ecParameters.D)

--- a/src/libraries/Common/src/System/Security/Cryptography/CompositeMLDsaManaged.ECDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/CompositeMLDsaManaged.ECDsa.cs
@@ -65,7 +65,7 @@ namespace System.Security.Cryptography
             {
                 Helpers.ThrowIfAsnInvalidLength(source);
 
-                ValueECPrivateKey.Decode(source, AsnEncodingRules.BER, out ValueECPrivateKey ecPrivateKey);
+                ValueECPrivateKey ecPrivateKey = ValueECPrivateKey.Decode(source, AsnEncodingRules.BER);
 
                 if (ecPrivateKey.Version != 1 || ecPrivateKey.HasPublicKey)
                 {

--- a/src/libraries/Common/src/System/Security/Cryptography/DSAKeyFormatHelper.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/DSAKeyFormatHelper.cs
@@ -47,7 +47,7 @@ namespace System.Security.Cryptography
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
             }
 
-            ValueDssParms.Decode(algId.Parameters, AsnEncodingRules.BER, out ValueDssParms parms);
+            ValueDssParms parms = ValueDssParms.Decode(algId.Parameters, AsnEncodingRules.BER);
 
             // Sanity checks from FIPS 186-4 4.1/4.2.  Since FIPS 186-5 withdrew DSA/DSS
             // these will never change again.
@@ -110,7 +110,7 @@ namespace System.Security.Cryptography
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding, e);
             }
 
-            ValueDssParms.Decode(algId.Parameters, AsnEncodingRules.BER, out ValueDssParms parms);
+            ValueDssParms parms = ValueDssParms.Decode(algId.Parameters, AsnEncodingRules.BER);
 
             // Sanity checks from FIPS 186-4 4.1/4.2.  Since FIPS 186-5 withdrew DSA/DSS
             // these will never change again.

--- a/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.Encrypted.cs
@@ -66,7 +66,7 @@ namespace System.Security.Cryptography
             {
                 ValueAsnReader reader = new ValueAsnReader(source, AsnEncodingRules.BER);
                 read = reader.PeekEncodedValue().Length;
-                ValueEncryptedPrivateKeyInfoAsn.Decode(ref reader, out epki);
+                epki = ValueEncryptedPrivateKeyInfoAsn.Decode(ref reader);
             }
             catch (AsnContentException e)
             {
@@ -297,7 +297,7 @@ namespace System.Security.Cryptography
             {
                 ValueAsnReader reader = new ValueAsnReader(source, AsnEncodingRules.BER);
                 localRead = reader.PeekEncodedValue().Length;
-                ValueEncryptedPrivateKeyInfoAsn.Decode(ref reader, out epki);
+                epki = ValueEncryptedPrivateKeyInfoAsn.Decode(ref reader);
             }
             catch (AsnContentException e)
             {

--- a/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/KeyFormatHelper.cs
@@ -27,7 +27,7 @@ namespace System.Security.Cryptography
             {
                 ValueAsnReader reader = new ValueAsnReader(source, AsnEncodingRules.DER);
                 read = reader.PeekEncodedValue().Length;
-                ValueSubjectPublicKeyInfoAsn.Decode(ref reader, out spki);
+                spki = ValueSubjectPublicKeyInfoAsn.Decode(ref reader);
             }
             catch (AsnContentException e)
             {
@@ -56,7 +56,7 @@ namespace System.Security.Cryptography
                 // X.509 SubjectPublicKeyInfo is described as DER.
                 ValueAsnReader reader = new ValueAsnReader(source, AsnEncodingRules.DER);
                 read = reader.PeekEncodedValue().Length;
-                ValueSubjectPublicKeyInfoAsn.Decode(ref reader, out spki);
+                spki = ValueSubjectPublicKeyInfoAsn.Decode(ref reader);
             }
             catch (AsnContentException e)
             {
@@ -83,7 +83,7 @@ namespace System.Security.Cryptography
             {
                 ValueAsnReader reader = new ValueAsnReader(source, AsnEncodingRules.BER);
                 int read = reader.PeekEncodedValue().Length;
-                ValuePrivateKeyInfoAsn.Decode(ref reader, out ValuePrivateKeyInfoAsn privateKeyInfo);
+                ValuePrivateKeyInfoAsn privateKeyInfo = ValuePrivateKeyInfoAsn.Decode(ref reader);
 
                 if (Array.IndexOf(validOids, privateKeyInfo.PrivateKeyAlgorithm.Algorithm) < 0)
                 {
@@ -109,7 +109,7 @@ namespace System.Security.Cryptography
             {
                 ValueAsnReader reader = new ValueAsnReader(source, AsnEncodingRules.BER);
                 int read = reader.PeekEncodedValue().Length;
-                ValuePrivateKeyInfoAsn.Decode(ref reader, out ValuePrivateKeyInfoAsn privateKeyInfo);
+                ValuePrivateKeyInfoAsn privateKeyInfo = ValuePrivateKeyInfoAsn.Decode(ref reader);
 
                 if (Array.IndexOf(validOids, privateKeyInfo.PrivateKeyAlgorithm.Algorithm) < 0)
                 {

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsa.cs
@@ -2207,7 +2207,7 @@ namespace System.Security.Cryptography
             out MLDsa dsa)
         {
             MLDsaAlgorithm algorithm = GetAlgorithmIdentifier(in algorithmIdentifier);
-            ValueMLDsaPrivateKeyAsn.Decode(privateKeyContents, AsnEncodingRules.BER, out ValueMLDsaPrivateKeyAsn dsaKey);
+            ValueMLDsaPrivateKeyAsn dsaKey = ValueMLDsaPrivateKeyAsn.Decode(privateKeyContents, AsnEncodingRules.BER);
 
             if (dsaKey.HasSeed)
             {

--- a/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.Windows.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLDsaCng.Windows.cs
@@ -498,7 +498,7 @@ namespace System.Security.Cryptography
 
                 try
                 {
-                    ValueMLDsaPrivateKeyAsn.Decode(privateKey, AsnEncodingRules.BER, out mldsaPrivateKeyAsn);
+                    mldsaPrivateKeyAsn = ValueMLDsaPrivateKeyAsn.Decode(privateKey, AsnEncodingRules.BER);
                 }
                 catch (AsnContentException e)
                 {

--- a/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/MLKem.cs
@@ -1693,7 +1693,7 @@ namespace System.Security.Cryptography
             out MLKem kem)
         {
             MLKemAlgorithm algorithm = GetAlgorithmIdentifier(in algorithmIdentifier);
-            ValueMLKemPrivateKeyAsn.Decode(privateKeyContents, AsnEncodingRules.BER, out ValueMLKemPrivateKeyAsn kemKey);
+            ValueMLKemPrivateKeyAsn kemKey = ValueMLKemPrivateKeyAsn.Decode(privateKeyContents, AsnEncodingRules.BER);
 
             if (kemKey.HasSeed)
             {

--- a/src/libraries/Common/src/System/Security/Cryptography/PasswordBasedEncryption.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/PasswordBasedEncryption.cs
@@ -545,7 +545,7 @@ namespace System.Security.Cryptography
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
             }
 
-            ValuePBES2Params.Decode(algorithmParameters.Value, AsnEncodingRules.BER, out ValuePBES2Params pbes2Params);
+            ValuePBES2Params pbes2Params = ValuePBES2Params.Decode(algorithmParameters.Value, AsnEncodingRules.BER);
 
             if (pbes2Params.KeyDerivationFunc.Algorithm != Oids.Pbkdf2)
             {
@@ -681,10 +681,9 @@ namespace System.Security.Cryptography
                     throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
                 }
 
-                ValueRc2CbcParameters.Decode(
+                ValueRc2CbcParameters rc2Parameters = ValueRc2CbcParameters.Decode(
                     encryptionScheme.Parameters,
-                    AsnEncodingRules.BER,
-                    out ValueRc2CbcParameters rc2Parameters);
+                    AsnEncodingRules.BER);
 
                 // iv is the eight-octet initialization vector
                 if (rc2Parameters.Iv.Length != 8)
@@ -768,7 +767,7 @@ namespace System.Security.Cryptography
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
             }
 
-            ValuePbkdf2Params.Decode(parameters.Value, AsnEncodingRules.BER, out ValuePbkdf2Params pbkdf2Params);
+            ValuePbkdf2Params pbkdf2Params = ValuePbkdf2Params.Decode(parameters.Value, AsnEncodingRules.BER);
 
             // No OtherSource is defined in RFC 2898 or RFC 8018, so whatever
             // algorithm was requested isn't one we know.
@@ -857,7 +856,7 @@ namespace System.Security.Cryptography
                 throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
             }
 
-            ValuePBEParameter.Decode(algorithmParameters.Value, AsnEncodingRules.BER, out ValuePBEParameter pbeParameters);
+            ValuePBEParameter pbeParameters = ValuePBEParameter.Decode(algorithmParameters.Value, AsnEncodingRules.BER);
 
             if (pbeParameters.Salt.Length != 8)
             {
@@ -918,10 +917,9 @@ namespace System.Security.Cryptography
                 throw new CryptographicException();
             }
 
-            ValuePBEParameter.Decode(
+            ValuePBEParameter pbeParameters = ValuePBEParameter.Decode(
                 algorithmIdentifier.Parameters,
-                AsnEncodingRules.BER,
-                out ValuePBEParameter pbeParameters);
+                AsnEncodingRules.BER);
 
             int iterationCount = NormalizeIterationCount(pbeParameters.IterationCount, IterationLimit);
             Span<byte> iv = stackalloc byte[cipher.BlockSize / 8];

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAKeyFormatHelper.Pkcs1.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAKeyFormatHelper.Pkcs1.cs
@@ -17,7 +17,7 @@ namespace System.Security.Cryptography
             RSAParametersCallback<TRet> parametersReader,
             bool pinAndClearParameters = true)
         {
-            ValueRSAPrivateKeyAsn.Decode(keyData, AsnEncodingRules.BER, out ValueRSAPrivateKeyAsn key);
+            ValueRSAPrivateKeyAsn key = ValueRSAPrivateKeyAsn.Decode(keyData, AsnEncodingRules.BER);
 
             const int MaxSupportedVersion = 0;
 
@@ -81,7 +81,7 @@ namespace System.Security.Cryptography
             ReadOnlySpan<byte> keyData,
             RSAParametersCallback<TRet> parametersReader)
         {
-            ValueRSAPublicKeyAsn.Decode(keyData, AsnEncodingRules.BER, out ValueRSAPublicKeyAsn key);
+            ValueRSAPublicKeyAsn key = ValueRSAPublicKeyAsn.Decode(keyData, AsnEncodingRules.BER);
 
             RSAParameters parameters = new RSAParameters
             {

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAKeyFormatHelper.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAKeyFormatHelper.cs
@@ -44,7 +44,7 @@ namespace System.Security.Cryptography
             {
                 ValueAsnReader reader = new ValueAsnReader(keyData, AsnEncodingRules.DER);
                 read = reader.PeekEncodedValue().Length;
-                ValueRSAPublicKeyAsn.Decode(keyData, AsnEncodingRules.BER, out _);
+                _ = ValueRSAPublicKeyAsn.Decode(keyData, AsnEncodingRules.BER);
             }
             catch (AsnContentException e)
             {

--- a/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -787,7 +787,7 @@ namespace System.Security.Cryptography
             {
                 ReadOnlySpan<byte> pkcs1Priv = RSAKeyFormatHelper.ReadPkcs8(pkcs8, out int read);
                 Debug.Assert(read == pkcs8.Length);
-                ValueRSAPrivateKeyAsn.Decode(pkcs1Priv, AsnEncodingRules.BER, out _);
+                _ = ValueRSAPrivateKeyAsn.Decode(pkcs1Priv, AsnEncodingRules.BER);
                 return pkcs1Priv;
             }
             catch (CryptographicException)

--- a/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Pkcs12.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/X509Certificates/X509CertificateLoader.Pkcs12.cs
@@ -577,17 +577,15 @@ namespace System.Security.Cryptography.X509Certificates
                     case Oids.Pkcs12PbeWithShaAnd2Key3Des:
                     case Oids.Pkcs12PbeWithShaAnd128BitRC2:
                     case Oids.Pkcs12PbeWithShaAnd40BitRC2:
-                        ValuePBEParameter.Decode(
+                        ValuePBEParameter pbeParameter = ValuePBEParameter.Decode(
                             algorithmIdentifier.Parameters.Value.Span,
-                            AsnEncodingRules.BER,
-                            out ValuePBEParameter pbeParameter);
+                            AsnEncodingRules.BER);
 
                         return pbeParameter.IterationCount;
                     case Oids.PasswordBasedEncryptionScheme2:
-                        ValuePBES2Params.Decode(
+                        ValuePBES2Params pbes2Params = ValuePBES2Params.Decode(
                             algorithmIdentifier.Parameters.Value.Span,
-                            AsnEncodingRules.BER,
-                            out ValuePBES2Params pbes2Params);
+                            AsnEncodingRules.BER);
 
                         if (pbes2Params.KeyDerivationFunc.Algorithm != Oids.Pbkdf2)
                         {
@@ -602,10 +600,9 @@ namespace System.Security.Cryptography.X509Certificates
                             throw new CryptographicException(SR.Cryptography_Der_Invalid_Encoding);
                         }
 
-                        ValuePbkdf2Params.Decode(
+                        ValuePbkdf2Params pbkdf2Params = ValuePbkdf2Params.Decode(
                             pbes2Params.KeyDerivationFunc.Parameters,
-                            AsnEncodingRules.BER,
-                            out ValuePbkdf2Params pbkdf2Params);
+                            AsnEncodingRules.BER);
 
                         return pbkdf2Params.IterationCount;
                     default:

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Asn.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Asn.cs
@@ -14,7 +14,7 @@ namespace Internal.Cryptography.Pal.AnyOS
         public override Oid GetEncodedMessageType(ReadOnlySpan<byte> encodedMessage)
         {
             ValueAsnReader reader = new ValueAsnReader(encodedMessage, AsnEncodingRules.BER);
-            ValueContentInfoAsn.Decode(ref reader, out ValueContentInfoAsn contentInfo);
+            ValueContentInfoAsn contentInfo = ValueContentInfoAsn.Decode(ref reader);
 
             switch (contentInfo.ContentType)
             {

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decode.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/Internal/Cryptography/Pal/AnyOS/ManagedPal.Decode.cs
@@ -82,7 +82,7 @@ namespace Internal.Cryptography.Pal.AnyOS
         {
             ValueAsnReader reader = new ValueAsnReader(encodedMessage, AsnEncodingRules.BER);
 
-            ValueContentInfoAsn.Decode(ref reader, out ValueContentInfoAsn parsedContentInfo);
+            ValueContentInfoAsn parsedContentInfo = ValueContentInfoAsn.Decode(ref reader);
 
             if (parsedContentInfo.ContentType != Oids.Pkcs7Enveloped)
             {

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/MessageImprint.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/MessageImprint.xml.cs
@@ -118,19 +118,20 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueMessageImprint decoded)
+        internal static ValueMessageImprint Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueMessageImprint decoded)
+        internal static ValueMessageImprint Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueMessageImprint decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -138,16 +139,16 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueMessageImprint decoded)
+        internal static ValueMessageImprint Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueMessageImprint decoded)
+        internal static ValueMessageImprint Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -155,9 +156,9 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueMessageImprint decoded)
+        private static ValueMessageImprint DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueMessageImprint decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ReadOnlySpan<byte> tmpSpan;
 
@@ -174,6 +175,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TstInfo.xml.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/Asn1/Rfc3161TstInfo.xml.cs
@@ -360,19 +360,20 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueRfc3161TstInfo decoded)
+        internal static ValueRfc3161TstInfo Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueRfc3161TstInfo decoded)
+        internal static ValueRfc3161TstInfo Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueRfc3161TstInfo decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -380,16 +381,16 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueRfc3161TstInfo decoded)
+        internal static ValueRfc3161TstInfo Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueRfc3161TstInfo decoded)
+        internal static ValueRfc3161TstInfo Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -397,9 +398,9 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueRfc3161TstInfo decoded)
+        private static ValueRfc3161TstInfo DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueRfc3161TstInfo decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
             ValueAsnReader explicitReader;
             ValueAsnReader defaultReader;
@@ -411,7 +412,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
             }
 
             decoded.Policy = sequenceReader.ReadObjectIdentifier();
-            System.Security.Cryptography.Pkcs.Asn1.ValueMessageImprint.Decode(ref sequenceReader, out decoded.MessageImprint);
+            decoded.MessageImprint = System.Security.Cryptography.Pkcs.Asn1.ValueMessageImprint.Decode(ref sequenceReader);
             decoded.SerialNumber = sequenceReader.ReadIntegerBytes();
             decoded.GenTime = sequenceReader.ReadGeneralizedTime();
 
@@ -459,6 +460,7 @@ namespace System.Security.Cryptography.Pkcs.Asn1
 
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
     }
 }

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSignature.RSA.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/CmsSignature.RSA.cs
@@ -311,10 +311,9 @@ namespace System.Security.Cryptography.Pkcs
                     throw new CryptographicException(SR.Cryptography_Pkcs_PssParametersMissing);
                 }
 
-                ValuePssParamsAsn.Decode(
+                ValuePssParamsAsn pssParams = ValuePssParamsAsn.Decode(
                     signatureParameters.Value.Span,
-                    AsnEncodingRules.DER,
-                    out ValuePssParamsAsn pssParams);
+                    AsnEncodingRules.DER);
 
                 if (pssParams.HashAlgorithm.Algorithm != digestAlgorithmOid)
                 {

--- a/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
+++ b/src/libraries/System.Security.Cryptography.Pkcs/src/System/Security/Cryptography/Pkcs/SignedCms.cs
@@ -214,7 +214,7 @@ namespace System.Security.Cryptography.Pkcs
 
                 // Windows (and thus NetFx) reads the leading data and ignores extra.
                 // So use the Decode overload which doesn't throw on extra data.
-                ValueContentInfoAsn.Decode(ref reader, out ValueContentInfoAsn contentInfo);
+                ValueContentInfoAsn contentInfo = ValueContentInfoAsn.Decode(ref reader);
 
                 if (contentInfo.ContentType != Oids.Pkcs7Signed)
                 {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/EccKeyFormatHelper.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/EccKeyFormatHelper.cs
@@ -92,7 +92,7 @@ namespace System.Security.Cryptography
             in ValueAlgorithmIdentifierAsn algId,
             out ECParameters ret)
         {
-            ValueECPrivateKey.Decode(keyData, AsnEncodingRules.BER, out ValueECPrivateKey key);
+            ValueECPrivateKey key = ValueECPrivateKey.Decode(keyData, AsnEncodingRules.BER);
             FromECPrivateKey(key, algId, out ret);
         }
 
@@ -146,7 +146,7 @@ namespace System.Security.Cryptography
             else
             {
                 Debug.Assert(algId.HasParameters);
-                ValueECDomainParameters.Decode(algId.Parameters, AsnEncodingRules.DER, out domainParameters);
+                domainParameters = ValueECDomainParameters.Decode(algId.Parameters, AsnEncodingRules.DER);
             }
 
             Debug.Assert((x == null) == (y == null));
@@ -197,10 +197,9 @@ namespace System.Security.Cryptography
 
             int fieldWidth = publicKeyBytes.Length / 2;
 
-            ValueECDomainParameters.Decode(
+            ValueECDomainParameters domainParameters = ValueECDomainParameters.Decode(
                 algId.Parameters,
-                AsnEncodingRules.DER,
-                out ValueECDomainParameters domainParameters);
+                AsnEncodingRules.DER);
 
             ret = new ECParameters
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.iOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/AppleCertificatePal.ImportExport.iOS.cs
@@ -17,7 +17,7 @@ namespace System.Security.Cryptography.X509Certificates
             {
                 // Permit trailing data after the PKCS12.
                 ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.BER);
-                ValuePfxAsn.Decode(ref reader, out _);
+                ValuePfxAsn.Decode(ref reader);
                 return true;
             }
             catch (CryptographicException)
@@ -32,7 +32,7 @@ namespace System.Security.Cryptography.X509Certificates
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.BER);
-                ValueContentInfoAsn.Decode(ref reader, out ValueContentInfoAsn contentInfo);
+                ValueContentInfoAsn contentInfo = ValueContentInfoAsn.Decode(ref reader);
 
                 switch (contentInfo.ContentType)
                 {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/CertificationRequestInfoAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/CertificationRequestInfoAsn.xml.cs
@@ -139,7 +139,9 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         internal System.Numerics.BigInteger Version;
         internal ReadOnlySpan<byte> Subject;
         internal System.Security.Cryptography.Asn1.ValueSubjectPublicKeyInfoAsn SubjectPublicKeyInfo;
-        internal ReadOnlySpan<byte> Attributes;
+        internal ReadOnlySpan<byte> Attributes { get; private set; }
+        internal int AttributesLength { get; private set; }
+        private AttributesEnumerableCache _attributesCache;
 
         internal readonly void Encode(AsnWriter writer)
         {
@@ -183,19 +185,20 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             writer.PopSequence(tag);
         }
 
-        internal static void Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueCertificationRequestInfoAsn decoded)
+        internal static ValueCertificationRequestInfoAsn Decode(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
-            Decode(Asn1Tag.Sequence, encoded, ruleSet, out decoded);
+            return Decode(Asn1Tag.Sequence, encoded, ruleSet);
         }
 
-        internal static void Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet, out ValueCertificationRequestInfoAsn decoded)
+        internal static ValueCertificationRequestInfoAsn Decode(Asn1Tag expectedTag, ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
         {
             try
             {
                 ValueAsnReader reader = new ValueAsnReader(encoded, ruleSet);
 
-                DecodeCore(ref reader, expectedTag, out decoded);
+                ValueCertificationRequestInfoAsn decoded = DecodeCore(ref reader, expectedTag);
                 reader.ThrowIfNotEmpty();
+                return decoded;
             }
             catch (AsnContentException e)
             {
@@ -203,16 +206,16 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, out ValueCertificationRequestInfoAsn decoded)
+        internal static ValueCertificationRequestInfoAsn Decode(scoped ref ValueAsnReader reader)
         {
-            Decode(ref reader, Asn1Tag.Sequence, out decoded);
+            return Decode(ref reader, Asn1Tag.Sequence);
         }
 
-        internal static void Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueCertificationRequestInfoAsn decoded)
+        internal static ValueCertificationRequestInfoAsn Decode(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
             try
             {
-                DecodeCore(ref reader, expectedTag, out decoded);
+                return DecodeCore(ref reader, expectedTag);
             }
             catch (AsnContentException e)
             {
@@ -220,9 +223,9 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
         }
 
-        private static void DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag, out ValueCertificationRequestInfoAsn decoded)
+        private static ValueCertificationRequestInfoAsn DecodeCore(scoped ref ValueAsnReader reader, Asn1Tag expectedTag)
         {
-            decoded = default;
+            ValueCertificationRequestInfoAsn decoded = default;
             ValueAsnReader sequenceReader = reader.ReadSequence(expectedTag);
 
             decoded.Version = sequenceReader.ReadInteger();
@@ -232,7 +235,7 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
 
             decoded.Subject = sequenceReader.ReadEncodedValue();
-            System.Security.Cryptography.Asn1.ValueSubjectPublicKeyInfoAsn.Decode(ref sequenceReader, out decoded.SubjectPublicKeyInfo);
+            decoded.SubjectPublicKeyInfo = System.Security.Cryptography.Asn1.ValueSubjectPublicKeyInfoAsn.Decode(ref sequenceReader);
 
             if (!sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 0)))
             {
@@ -240,39 +243,99 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
 
             decoded.Attributes = sequenceReader.ReadEncodedValue();
+            {
+                int count = 0;
+                ValueAsnReader cacheReader = new ValueAsnReader(decoded.Attributes, sequenceReader.RuleSet);
+                ValueAsnReader collReader = cacheReader.ReadSetOf(new Asn1Tag(TagClass.ContextSpecific, 0));
+                cacheReader.ThrowIfNotEmpty();
+
+                while (collReader.HasData)
+                {
+                    checked { count++; }
+                    System.Security.Cryptography.Asn1.ValueAttributeAsn item = System.Security.Cryptography.Asn1.ValueAttributeAsn.Decode(ref collReader);
+
+                    if (count <= 10)
+                    {
+                        switch (count)
+                        {
+                            case 1: decoded._attributesCache.Attributes1 = item; break;
+                            case 2: decoded._attributesCache.Attributes2 = item; break;
+                            case 3: decoded._attributesCache.Attributes3 = item; break;
+                            case 4: decoded._attributesCache.Attributes4 = item; break;
+                            case 5: decoded._attributesCache.Attributes5 = item; break;
+                            case 6: decoded._attributesCache.Attributes6 = item; break;
+                            case 7: decoded._attributesCache.Attributes7 = item; break;
+                            case 8: decoded._attributesCache.Attributes8 = item; break;
+                            case 9: decoded._attributesCache.Attributes9 = item; break;
+                            case 10: decoded._attributesCache.Attributes10 = item; break;
+                        }
+                    }
+                }
+
+                if (count <= 10)
+                {
+                    decoded._attributesCache.Success = true;
+                }
+                decoded._attributesCache.Count = count;
+                decoded._attributesCache.RuleSet = sequenceReader.RuleSet;
+                decoded.AttributesLength = count;
+            }
 
             sequenceReader.ThrowIfNotEmpty();
+            return decoded;
         }
 
 
-        internal AttributesEnumerable GetAttributes(AsnEncodingRules ruleSet)
+        internal AttributesEnumerable GetAttributes()
         {
-            return new AttributesEnumerable(Attributes, ruleSet);
+            return new AttributesEnumerable(Attributes, _attributesCache);
+        }
+
+        internal ref struct AttributesEnumerableCache
+        {
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes1;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes2;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes3;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes4;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes5;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes6;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes7;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes8;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes9;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes10;
+            internal int Count;
+            internal bool Success;
+            internal AsnEncodingRules RuleSet;
         }
 
         internal readonly ref struct AttributesEnumerable
         {
             private readonly ReadOnlySpan<byte> _encoded;
-            private readonly AsnEncodingRules _ruleSet;
+            private readonly AttributesEnumerableCache _cache;
 
-            internal AttributesEnumerable(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
+            internal AttributesEnumerable(ReadOnlySpan<byte> encoded, AttributesEnumerableCache cache)
             {
                 _encoded = encoded;
-                _ruleSet = ruleSet;
+                _cache = cache;
             }
 
-            public Enumerator GetEnumerator() => new Enumerator(_encoded, _ruleSet);
+            public Enumerator GetEnumerator() => new Enumerator(_encoded, _cache);
 
             internal ref struct Enumerator
             {
                 private ValueAsnReader _reader;
                 private System.Security.Cryptography.Asn1.ValueAttributeAsn _current;
+                private readonly AttributesEnumerableCache _cache;
+                private int _index;
 
-                internal Enumerator(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
+                internal Enumerator(ReadOnlySpan<byte> encoded, AttributesEnumerableCache cache)
                 {
-                    if (!encoded.IsEmpty)
+                    _cache = cache;
+                    _index = 0;
+
+                    if (!cache.Success && !encoded.IsEmpty)
                     {
-                        ValueAsnReader outerReader = new ValueAsnReader(encoded, ruleSet);
+                        ValueAsnReader outerReader = new ValueAsnReader(encoded, cache.RuleSet);
                         _reader = outerReader.ReadSetOf(new Asn1Tag(TagClass.ContextSpecific, 0));
                         outerReader.ThrowIfNotEmpty();
                     }
@@ -284,12 +347,38 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
 
                 public bool MoveNext()
                 {
+                    if (_cache.Success)
+                    {
+                        if (_index >= _cache.Count)
+                        {
+                            return false;
+                        }
+
+                        _current = _index switch
+                        {
+                            0 => _cache.Attributes1,
+                            1 => _cache.Attributes2,
+                            2 => _cache.Attributes3,
+                            3 => _cache.Attributes4,
+                            4 => _cache.Attributes5,
+                            5 => _cache.Attributes6,
+                            6 => _cache.Attributes7,
+                            7 => _cache.Attributes8,
+                            8 => _cache.Attributes9,
+                            9 => _cache.Attributes10,
+                            _ => default,
+                        };
+                        _index++;
+
+                        return true;
+                    }
+
                     if (!_reader.HasData)
                     {
                         return false;
                     }
 
-                    System.Security.Cryptography.Asn1.ValueAttributeAsn.Decode(ref _reader, out _current);
+                    _current = System.Security.Cryptography.Asn1.ValueAttributeAsn.Decode(ref _reader);
                     return true;
                 }
             }

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRequest.Load.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRequest.Load.cs
@@ -155,8 +155,8 @@ namespace System.Security.Cryptography.X509Certificates
                 ReadOnlySpan<byte> signature;
                 int signatureUnusedBitCount;
 
-                ValueCertificationRequestInfoAsn.Decode(ref pkcs10Asn, out requestInfo);
-                ValueAlgorithmIdentifierAsn.Decode(ref pkcs10Asn, out algorithmIdentifier);
+                requestInfo = ValueCertificationRequestInfoAsn.Decode(ref pkcs10Asn);
+                algorithmIdentifier = ValueAlgorithmIdentifierAsn.Decode(ref pkcs10Asn);
 
                 if (!pkcs10Asn.TryReadPrimitiveBitString(out signatureUnusedBitCount, out signature))
                 {
@@ -205,7 +205,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                 bool foundCertExt = false;
 
-                foreach (ValueAttributeAsn attr in requestInfo.GetAttributes(AsnEncodingRules.DER))
+                foreach (ValueAttributeAsn attr in requestInfo.GetAttributes())
                 {
                     if (attr.AttrType == Oids.Pkcs9ExtensionRequest)
                     {
@@ -220,7 +220,7 @@ namespace System.Security.Cryptography.X509Certificates
                         scoped ReadOnlySpan<byte> firstAttrValue = default;
                         bool foundAttrValue = false;
 
-                        foreach (ReadOnlySpan<byte> values in attr.GetAttrValues(AsnEncodingRules.DER))
+                        foreach (ReadOnlySpan<byte> values in attr.GetAttrValues())
                         {
                             if (foundAttrValue)
                             {
@@ -247,7 +247,7 @@ namespace System.Security.Cryptography.X509Certificates
                         // Minimum length is 1, so do..while
                         do
                         {
-                            ValueX509ExtensionAsn.Decode(ref exts, out ValueX509ExtensionAsn extAsn);
+                            ValueX509ExtensionAsn extAsn = ValueX509ExtensionAsn.Decode(ref exts);
 
                             if (unsafeLoadCertificateExtensions)
                             {
@@ -275,7 +275,7 @@ namespace System.Security.Cryptography.X509Certificates
                     {
                         bool anyAttrValues = false;
 
-                        foreach (ReadOnlySpan<byte> val in attr.GetAttrValues(AsnEncodingRules.DER))
+                        foreach (ReadOnlySpan<byte> val in attr.GetAttrValues())
                         {
                             req.OtherRequestAttributes.Add(new AsnEncodedData(attr.AttrType, val));
                             anyAttrValues = true;
@@ -319,10 +319,9 @@ namespace System.Security.Cryptography.X509Certificates
                         return false;
                     }
 
-                    ValuePssParamsAsn.Decode(
+                    ValuePssParamsAsn pssParams = ValuePssParamsAsn.Decode(
                         algorithmIdentifier.Parameters,
-                        AsnEncodingRules.DER,
-                        out ValuePssParamsAsn pssParams);
+                        AsnEncodingRules.DER);
 
                     RSASignaturePadding padding = pssParams.GetSignaturePadding();
                     hashAlg = HashAlgorithmName.FromOid(pssParams.HashAlgorithm.Algorithm);

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/PublicKey.cs
@@ -463,7 +463,7 @@ namespace System.Security.Cryptography.X509Certificates
             try
             {
                 read = reader.PeekEncodedValue().Length;
-                ValueSubjectPublicKeyInfoAsn.Decode(ref reader, out spki);
+                spki = ValueSubjectPublicKeyInfoAsn.Decode(ref reader);
             }
             catch (AsnContentException e)
             {

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.macOS.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/X509Pal.macOS.cs
@@ -75,7 +75,7 @@ namespace System.Security.Cryptography.X509Certificates
                     try
                     {
                         ValueAsnReader reader = new ValueAsnReader(rawData, AsnEncodingRules.BER);
-                        ValuePfxAsn.Decode(ref reader, out _);
+                        ValuePfxAsn.Decode(ref reader);
                         contentType = X509ContentType.Pkcs12;
                     }
                     catch (CryptographicException)


### PR DESCRIPTION
This makes a couple of changes to the `ref struct` ASN.1 generator.

We don't use `out` parameters any more. Only return values from `Decode`. This helps the C# compiler with some ref-safety analysis that I could not get working with the `out`. Frankly return values feel more natural anyway.

The main purpose of this change is so that during `Decode` we eagerly read sequences and set-of. Previously, these were read lazily using the generated `ref struct` enumerator. This is a behavior deviation from the regular `struct` reader which eagerly reads everything. This is important for validation purposes. Without this eager reading, the validation does not validate "child" Sequence structures[^1].

This adds eager enumeration of sequences and set-of during decode to match the behavior of `struct.

This adds a different problem: we were double enumerating the sequences now. Once for validation, and again if we read it. The enumerator always lazily decodes. It does this because the returning value if a `ref struct` - which we cannot have arrays or collections for.

The solution is to cache up to 10 values in cache `ref struct`. If the sequence/set-of ultimately has more than 10 items this falls back to lazy enumeration all of the time. If it less than or equal to 10, enumerating is "free".

This 10 is somewhat arbitrary, but it works for a majority of things. X.509 certificates don't typically have more than 10 extensions, X.500 names don't often contain more than 10 RDNs (and each RDN usually isn't composite). We need to balance this cache size with creating very large cache structs that may also themselves have nested caches.

An upshot to this now, is that since we are eagerly validating, there is a `Length` member now as well so we now know up-front after decode how many times are in the collection.

[^1]: This is not a problem today because we are not relying on this eager validation for any of the structs that have been migrated to ref-struct today. But during migration of PKCS#12 and X.509, some things were  no longer being eagerly validated which caused behavior differences of when exceptions were thrown.