### PR TITLE
Make HashHelpers.Primes private; use GetPrime in FrozenHashTable

### DIFF
--- a/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
+++ b/src/libraries/System.Collections.Immutable/src/System/Collections/Frozen/FrozenHashTable.cs
@@ -199,19 +199,11 @@ namespace System.Collections.Frozen
                 return HashHelpers.GetPrime(uniqueCodesCount);
             }
 
-            // In our precomputed primes table, find the index of the smallest prime that's at least as large as our number of
-            // hash codes. If there are more codes than in our precomputed primes table, which accommodates millions of values,
-            // give up and just use the next prime.
-            ReadOnlySpan<int> primes = HashHelpers.Primes;
-            int minPrimeIndexInclusive = 0;
-            while ((uint)minPrimeIndexInclusive < (uint)primes.Length && minNumBuckets > primes[minPrimeIndexInclusive])
+            // Beyond the precomputed prime table, GetPrime falls back to trial division,
+            // so skip the collision-tuning loop and just pick the first prime >= minNumBuckets.
+            if (minNumBuckets > HashHelpers.MaxPrecomputedPrime)
             {
-                minPrimeIndexInclusive++;
-            }
-
-            if (minPrimeIndexInclusive >= primes.Length)
-            {
-                return HashHelpers.GetPrime(uniqueCodesCount);
+                return HashHelpers.GetPrime((int)minNumBuckets);
             }
 
             // Determine the largest number of buckets we're willing to use, based on a multiple of the number of inputs.
@@ -220,19 +212,6 @@ namespace System.Collections.Frozen
                 uniqueCodesCount *
                 (uniqueCodesCount >= LargeInputSizeThreshold ? MaxLargeBucketTableMultiplier : MaxSmallBucketTableMultiplier);
 
-            // Find the index of the smallest prime that accommodates our max buckets.
-            int maxPrimeIndexExclusive = minPrimeIndexInclusive;
-            while ((uint)maxPrimeIndexExclusive < (uint)primes.Length && maxNumBuckets > primes[maxPrimeIndexExclusive])
-            {
-                maxPrimeIndexExclusive++;
-            }
-
-            if (maxPrimeIndexExclusive < primes.Length)
-            {
-                Debug.Assert(maxPrimeIndexExclusive != 0);
-                maxNumBuckets = primes[maxPrimeIndexExclusive - 1];
-            }
-
             const int BitsPerInt32 = 32;
             int[] seenBuckets = ArrayPool<int>.Shared.Rent((maxNumBuckets / BitsPerInt32) + 1);
 
@@ -240,12 +219,11 @@ namespace System.Collections.Frozen
             int bestNumCollisions = uniqueCodesCount;
             int numBuckets = 0, numCollisions = 0;
 
-            // Iterate through each available prime between the min and max discovered. For each, compute
-            // the collision ratio.
-            for (int primeIndex = minPrimeIndexInclusive; primeIndex < maxPrimeIndexExclusive; primeIndex++)
+            // Iterate through each prime between minNumBuckets and maxNumBuckets, computing the collision ratio for each.
+            for (numBuckets = HashHelpers.GetPrime((int)minNumBuckets);
+                 numBuckets <= maxNumBuckets;
+                 numBuckets = HashHelpers.GetPrime(numBuckets + 1))
             {
-                // Get the number of buckets to try, and clear our seen bucket bitmap.
-                numBuckets = primes[primeIndex];
                 Array.Clear(seenBuckets, 0, Math.Min(numBuckets, seenBuckets.Length));
 
                 // Determine the bucket for each hash code and mark it as seen. If it was already seen,

--- a/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Collections/HashHelpers.cs
@@ -28,7 +28,7 @@ namespace System.Collections
         // h1(key) + i*h2(key), 0 <= i < size.  h2 and the size must be relatively prime.
         // We prefer the low computation costs of higher prime numbers over the increased
         // memory allocation of a fixed prime number i.e. when right sizing a HashSet.
-        internal static ReadOnlySpan<int> Primes =>
+        private static ReadOnlySpan<int> Primes =>
         [
             3, 7, 11, 17, 23, 29, 37, 47, 59, 71, 89, 107, 131, 163, 197, 239, 293, 353, 431, 521, 631, 761, 919,
             1103, 1327, 1597, 1931, 2333, 2801, 3371, 4049, 4861, 5839, 7013, 8419, 10103, 12143, 14591,
@@ -37,6 +37,11 @@ namespace System.Collections
             1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369
         ];
 
+        /// <summary>The largest prime in the precomputed <see cref="Primes"/> table.</summary>
+        /// <remarks><see cref="GetPrime"/> uses trial division for values beyond this threshold.</remarks>
+        internal static int MaxPrecomputedPrime => Primes[^1];
+
+        /// <summary>Checks whether <paramref name="candidate"/> is prime, using trial division up to sqrt(candidate).</summary>
         public static bool IsPrime(int candidate)
         {
             if ((candidate & 1) != 0)
@@ -52,6 +57,8 @@ namespace System.Collections
             return candidate == 2;
         }
 
+        /// <summary>Returns the smallest prime greater than or equal to <paramref name="min"/>.</summary>
+        /// <remarks>Uses a precomputed table for small values; falls back to trial division for larger values. Very fast for all realistic hash table sizes.</remarks>
         public static int GetPrime(int min)
         {
             if (min < 0)
@@ -72,7 +79,8 @@ namespace System.Collections
             return min;
         }
 
-        // Returns size of hashtable to grow to.
+        /// <summary>Returns the next prime to grow a hash table to, currently using a 2x growth policy.</summary>
+        /// <remarks>Caps at <see cref="MaxPrimeArrayLength"/> to stay within array length limits.</remarks>
         public static int ExpandPrime(int oldSize)
         {
             int newSize = 2 * oldSize;

--- a/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/General/HashHelpers.cs
+++ b/src/libraries/System.Reflection.MetadataLoadContext/src/System/Reflection/TypeLoading/General/HashHelpers.cs
@@ -20,7 +20,7 @@ namespace System.Reflection.TypeLoading
         // h1(key) + i*h2(key), 0 <= i < size.  h2 and the size must be relatively prime.
         // We prefer the low computation costs of higher prime numbers over the increased
         // memory allocation of a fixed prime number i.e. when right sizing a HashSet.
-        public static ReadOnlySpan<int> Primes =>
+        private static ReadOnlySpan<int> Primes =>
         [
             3, 7, 11, 17, 23, 29, 37, 47, 59, 71, 89, 107, 131, 163, 197, 239, 293, 353, 431, 521, 631, 761, 919,
             1103, 1327, 1597, 1931, 2333, 2801, 3371, 4049, 4861, 5839, 7013, 8419, 10103, 12143, 14591,
@@ -29,6 +29,7 @@ namespace System.Reflection.TypeLoading
             1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369
         ];
 
+        /// <summary>Checks whether <paramref name="candidate"/> is prime, using trial division up to sqrt(candidate).</summary>
         public static bool IsPrime(int candidate)
         {
             if ((candidate & 1) != 0)
@@ -44,6 +45,8 @@ namespace System.Reflection.TypeLoading
             return (candidate == 2);
         }
 
+        /// <summary>Returns the smallest prime greater than or equal to <paramref name="min"/>.</summary>
+        /// <remarks>Uses a precomputed table for small values; falls back to trial division for larger values. Very fast for all realistic hash table sizes.</remarks>
         public static int GetPrime(int min)
         {
             if (min < 0)

--- a/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ObjectIDGenerator.cs
+++ b/src/libraries/System.Runtime.Serialization.Formatters/src/System/Runtime/Serialization/ObjectIDGenerator.cs
@@ -20,7 +20,7 @@ namespace System.Runtime.Serialization
         public ObjectIDGenerator()
         {
             _currentCount = 1;
-            _currentSize = 3; // HashHelpers.Primes[0]
+            _currentSize = 3; // Smallest prime > 1
             _ids = new long[_currentSize * NumBins];
             _objs = new object[_currentSize * NumBins];
         }


### PR DESCRIPTION
`HashHelpers.Primes` is an implementation detail — the precomputed prime table backing `GetPrime`. It was exposed as `internal` (in `System.Private.CoreLib`) and `public` (in `MetadataLoadContext`), but its only external consumer was `FrozenHashTable`, which iterated the table directly for collision-tuning bucket selection.

This PR makes `Primes` private and replaces the direct table access in `FrozenHashTable` with a simple `GetPrime` loop. `GetPrime` already encapsulates the same table scan, and trial division past the table is negligible on this cold construction path (~1300 divisions at 7M).

### Changes
- Make `Primes` private in `System.Private.CoreLib` `HashHelpers`
- Make `Primes` private in `MetadataLoadContext` `HashHelpers`
- Replace index-based primes iteration in `FrozenHashTable.CalcNumBuckets` with `GetPrime` loop (−29 lines)
- Update stale comment in `ObjectIDGenerator`

> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.
