### PR TITLE
Fix OperIs(GT_CNS_INT, GT_CNS_LNG) assertion during import

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -33814,7 +33814,7 @@ GenTree* Compiler::gtFoldExprHWIntrinsic(GenTreeHWIntrinsic* tree)
             case NI_Vector512_WithElement:
 #endif
             {
-                if ((cnsNode != op1) || !op3->OperIsConst())
+                if ((cnsNode != op1) || !op2->IsCnsIntOrI() || !op3->OperIsConst())
                 {
                     break;
                 }

--- a/src/tests/JIT/Regression/JitBlue/Runtime_126060/Runtime_126060.cs
+++ b/src/tests/JIT/Regression/JitBlue/Runtime_126060/Runtime_126060.cs
@@ -1,0 +1,25 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Runtime_126060;
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using Xunit;
+
+// gtFoldExprHWIntrinsic didn't account for a range check attached to WithElement
+public class Runtime_126060
+{
+    [Fact]
+    public static void TestEntryPoint()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => WithElementOutOfRange());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static Vector256<double> WithElementOutOfRange()
+    {
+        return Vector256.WithElement(Vector256<double>.AllBitsSet, 4, 0.0);
+    }
+}

--- a/src/tests/JIT/Regression/Regression_ro_2.csproj
+++ b/src/tests/JIT/Regression/Regression_ro_2.csproj
@@ -94,6 +94,7 @@
     <Compile Include="JitBlue\Runtime_125169\Runtime_125169.cs" />
     <Compile Include="JitBlue\Runtime_125301\Runtime_125301.cs" />
     <Compile Include="JitBlue\Runtime_125328\Runtime_125328.cs" />
+    <Compile Include="JitBlue\Runtime_126060\Runtime_126060.cs" />
   </ItemGroup>
   <Import Project="$(TestSourceDir)MergedTestRunner.targets" />
 </Project>


### PR DESCRIPTION
Assertion in `gtFoldExprHWIntrinsic` on `Vector.WithElement`.  The index argument could be a COMMA (boundscheck+integral constant) rather than just an integral constant as expected.

The windows-x64 antigen runs hit this assert pretty frequently, so fixing here to reduce the noise.

fixes #126060 