### PR TITLE
Fix reentrant Monitor wait

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -21,11 +21,29 @@ namespace System.Threading
         [ThreadStatic]
         private static Waiter? t_waiterForCurrentThread;
 
+        // Takes the cached Waiter for this thread (or allocates a new one) and leaves the
+        // thread-static as null while a wait is in progress so that any reentrant Monitor.Wait
+        // from a SynchronizationContext message pump gets its own Waiter with a distinct AutoResetEvent.
         private static Waiter GetWaiterForCurrentThread()
         {
-            Waiter waiter = t_waiterForCurrentThread ??= new Waiter();
+            Waiter? waiter = t_waiterForCurrentThread;
+            if (waiter is not null)
+            {
+                t_waiterForCurrentThread = null;
+            }
+            else
+            {
+                waiter = new Waiter();
+            }
+
             waiter.signalled = false;
             return waiter;
+        }
+
+        private static void ReleaseWaiterForCurrentThread(Waiter waiter)
+        {
+            // Return the waiter to the thread-static cache for reuse.
+            t_waiterForCurrentThread = waiter;
         }
 
         private readonly Lock _lock;
@@ -139,6 +157,7 @@ namespace System.Threading
                 }
 
                 AssertIsNotInList(waiter);
+                ReleaseWaiterForCurrentThread(waiter);
             }
 
             return waiter.signalled;

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -22,7 +22,7 @@ namespace System.Threading
         private static Waiter? t_waiterForCurrentThread;
 
         // Takes the cached Waiter for this thread (or allocates a new one) and removes the
-        // current wait's cached Waiter from the thread-static so that any overlapping or reentrant
+        // current wait's cached Waiter from the thread-static so that any reentrant
         // Monitor.Wait (for example, from a SynchronizationContext message pump) gets its own Waiter with a distinct AutoResetEvent.
         private static Waiter GetWaiterForCurrentThread()
         {

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Condition.cs
@@ -21,9 +21,9 @@ namespace System.Threading
         [ThreadStatic]
         private static Waiter? t_waiterForCurrentThread;
 
-        // Takes the cached Waiter for this thread (or allocates a new one) and leaves the
-        // thread-static as null while a wait is in progress so that any reentrant Monitor.Wait
-        // from a SynchronizationContext message pump gets its own Waiter with a distinct AutoResetEvent.
+        // Takes the cached Waiter for this thread (or allocates a new one) and removes the
+        // current wait's cached Waiter from the thread-static so that any overlapping or reentrant
+        // Monitor.Wait (for example, from a SynchronizationContext message pump) gets its own Waiter with a distinct AutoResetEvent.
         private static Waiter GetWaiterForCurrentThread()
         {
             Waiter? waiter = t_waiterForCurrentThread;

--- a/src/libraries/System.Threading/tests/MonitorTests.cs
+++ b/src/libraries/System.Threading/tests/MonitorTests.cs
@@ -514,6 +514,7 @@ namespace System.Threading.Tests
         // Validates that reentrant Monitor.Wait calls from a SynchronizationContext
         // message pump do not steal each other's pulse signals.
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/123173", TestRuntimes.Mono)]
         public static void ReentrantWaitFromSyncContextTest()
         {
             // Since we set the SynchronizationContext for the current thread, we run

--- a/src/libraries/System.Threading/tests/MonitorTests.cs
+++ b/src/libraries/System.Threading/tests/MonitorTests.cs
@@ -510,5 +510,69 @@ namespace System.Threading.Tests
                 waitForThread();
             }
         }
+
+        // Validates that reentrant Monitor.Wait calls from a SynchronizationContext
+        // message pump do not steal each other's pulse signals.
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        public static void ReentrantWaitFromSyncContextTest()
+        {
+            // Since we set the SynchronizationContext for the current thread, we run
+            // this test in a background thread to avoid affecting other tests.
+            ThreadTestHelpers.RunTestInBackgroundThread(() =>
+            {
+                object lockA = new();
+                object lockB = new();
+                bool innerWaitResult = true; // should become false (lockB is never pulsed)
+
+                var pumpCtx = new ReentrantWaitSyncContext(() =>
+                {
+                    lock (lockB)
+                    {
+                        innerWaitResult = Monitor.Wait(lockB, 500);
+                    }
+                });
+                SynchronizationContext.SetSynchronizationContext(pumpCtx);
+
+                var t = new Thread(() =>
+                {
+                    Thread.Sleep(100);
+                    lock (lockA) { Monitor.Pulse(lockA); }
+                }) { IsBackground = true };
+                t.Start();
+
+                bool outerResult;
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                lock (lockA)
+                {
+                    outerResult = Monitor.Wait(lockA, FailTimeoutMilliseconds);
+                }
+                long elapsed = sw.ElapsedMilliseconds;
+
+                Assert.True(outerResult, "Outer Monitor.Wait should have been pulsed");
+                Assert.True(elapsed < FailTimeoutMilliseconds / 2,
+                    $"Outer Monitor.Wait took {elapsed}ms — signal was likely stolen by inner wait");
+                Assert.False(innerWaitResult,
+                    "Inner Monitor.Wait(lockB) should return false (lockB was never pulsed)");
+
+                t.Join(FailTimeoutMilliseconds);
+            });
+        }
+
+        private sealed class ReentrantWaitSyncContext : SynchronizationContext
+        {
+            private Action? _callback;
+
+            public ReentrantWaitSyncContext(Action callback)
+            {
+                _callback = callback;
+                SetWaitNotificationRequired();
+            }
+
+            public override int Wait(IntPtr[] waitHandles, bool waitAll, int millisecondsTimeout)
+            {
+                Interlocked.Exchange(ref _callback, null)?.Invoke();
+                return base.Wait(waitHandles, waitAll, millisecondsTimeout);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #123173.

There's currently a problem with Monitor using a single thread-static `Waiter` (and `AutoResetEvent`) per thread. When using synchronization contexts that allow message pumping the following scenario can happen:

- The main thread calls `Monitor.Wait` on lock A.
- `SynchronizationContext.Wait` pumps a message and the main thread calls `Monitor.Wait` on lock B.
- Since both operations were run on the same thread, both share the same waiter.
- A background thread calls `Monitor.Pulse` on lock A but lock B steals the signal since they share the same waiter.

This change nulls out the thread-static `Waiter` while a wait is in progress, so any reentrant `Monitor.Wait` gets its own `Waiter` with a distinct `AutoResetEvent`. The `Waiter` is restored after the wait completes.