### PR TITLE
Add low-cost instrumented version of RuntimeAsyncTask::DispatchContinuations reclaiming lost performance.

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -1,14 +1,11 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Buffers.Binary;
 using System.Diagnostics;
+using System.Diagnostics.Tracing;
 using System.Diagnostics.CodeAnalysis;
-using System.Numerics;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Threading.Tasks.Sources;
@@ -317,6 +314,148 @@ namespace System.Runtime.CompilerServices
             AsyncSuspend(sentinelContinuation);
         }
 
+        internal static class RuntimeAsyncTaskInstrumentation
+        {
+#if NATIVEAOT
+            internal static bool IsSupported { get; } = Debugger.IsSupported || EventSource.IsSupported;
+#else
+            internal static bool IsSupported { get; } = true;
+#endif
+
+            internal enum Flags
+            {
+                Disabled = 0x0,
+                CreateAsyncContext = 0x1,
+                ResumeAsyncContext = 0x2,
+                SuspendAsyncContext = 0x4,
+                CompleteAsyncContext = 0x8,
+                UnwindAsyncException = 0x10,
+                ResumeAsyncMethod = 0x20,
+                CompleteAsyncMethod = 0x40,
+                AsyncProfiler = 0x10000,
+                Tpl = 0x20000,
+                Debugger = 0x40000
+            }
+
+            public static Flags ActiveFlags => _activeFlags;
+
+            public static Flags UpdateAsyncProfilerFlags(Flags flags)
+            {
+                lock (_lock)
+                {
+                    if (flags != Flags.Disabled)
+                    {
+                        flags |= Flags.AsyncProfiler;
+                    }
+
+                    _asyncProfilerActiveFlags = flags;
+                    _activeFlags = _asyncProfilerActiveFlags | _tplActiveFlags | _debuggerActiveFlags;
+
+                    return _activeFlags;
+                }
+            }
+
+            public static Flags UpdateTplFlags(EventSource tplEventSource)
+            {
+                Flags flags = Flags.Disabled;
+
+                flags |= tplEventSource.IsEnabled(EventLevel.Informational, TplEventSource.Keywords.AsyncCausalitySynchronousWork) ?
+                    Flags.ResumeAsyncContext |
+                    Flags.SuspendAsyncContext |
+                    Flags.CompleteAsyncContext |
+                    Flags.UnwindAsyncException : 0;
+
+                flags |= tplEventSource.IsEnabled(EventLevel.Informational, TplEventSource.Keywords.AsyncCausalityOperation) ?
+                    Flags.CreateAsyncContext |
+                    Flags.CompleteAsyncContext |
+                    Flags.UnwindAsyncException : 0;
+
+                lock (_lock)
+                {
+                    if (flags != Flags.Disabled)
+                    {
+                        flags |= Flags.Tpl;
+                    }
+
+                    _tplActiveFlags = flags;
+                    _activeFlags = _asyncProfilerActiveFlags | _tplActiveFlags | _debuggerActiveFlags;
+
+                    return _activeFlags;
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static Flags SyncAndGetActiveFlags()
+            {
+                Flags flags = _activeFlags;
+                if (IsEnabled.Debugger(flags) != Task.s_asyncDebuggingEnabled)
+                {
+                    flags = SyncDebuggerFlagsSlow(flags);
+                }
+                return flags;
+            }
+
+            private static Flags SyncDebuggerFlagsSlow(Flags flags)
+            {
+                if (IsEnabled.Debugger(flags) && !Task.s_asyncDebuggingEnabled)
+                {
+                    return UpdateDebuggerFlags(Flags.Disabled);
+                }
+                else if (!IsEnabled.Debugger(flags) && Task.s_asyncDebuggingEnabled)
+                {
+                    return UpdateDebuggerFlags(DebuggerFlags);
+                }
+
+                return flags;
+            }
+
+            private static Flags UpdateDebuggerFlags(Flags flags)
+            {
+                lock (_lock)
+                {
+                    if (flags != Flags.Disabled)
+                    {
+                        flags |= Flags.Debugger;
+                    }
+
+                    _debuggerActiveFlags = flags;
+                    _activeFlags = _asyncProfilerActiveFlags | _tplActiveFlags | _debuggerActiveFlags;
+
+                    return _activeFlags;
+                }
+            }
+
+            public static class IsEnabled
+            {
+                public static bool CreateAsyncContext(Flags flags) => (Flags.CreateAsyncContext & flags) != 0;
+                public static bool ResumeAsyncContext(Flags flags) => (Flags.ResumeAsyncContext & flags) != 0;
+                public static bool SuspendAsyncContext(Flags flags) => (Flags.SuspendAsyncContext & flags) != 0;
+                public static bool CompleteAsyncContext(Flags flags) => (Flags.CompleteAsyncContext & flags) != 0;
+                public static bool UnwindAsyncException(Flags flags) => (Flags.UnwindAsyncException & flags) != 0;
+                public static bool ResumeAsyncMethod(Flags flags) => (Flags.ResumeAsyncMethod & flags) != 0;
+                public static bool CompleteAsyncMethod(Flags flags) => (Flags.CompleteAsyncMethod & flags) != 0;
+                public static bool AsyncProfiler(Flags flags) => (Flags.AsyncProfiler & flags) != 0;
+                public static bool Tpl(Flags flags) => (Flags.Tpl & flags) != 0;
+                public static bool Debugger(Flags flags) => (Flags.Debugger & flags) != 0;
+                public static bool DebuggerOrTpl(Flags flags) => ((Flags.Tpl | Flags.Debugger) & flags) != 0;
+            }
+
+            private static Flags _activeFlags;
+
+            private static Flags _asyncProfilerActiveFlags;
+
+            private static Flags _tplActiveFlags;
+
+            private static Flags _debuggerActiveFlags;
+
+            private static readonly object _lock = new object();
+
+            private const Flags DebuggerFlags =
+                Flags.CreateAsyncContext | Flags.SuspendAsyncContext |
+                Flags.CompleteAsyncContext | Flags.UnwindAsyncException |
+                Flags.ResumeAsyncMethod | Flags.CompleteAsyncMethod;
+        }
+
         // Represents execution of a chain of suspended and resuming runtime
         // async functions.
         private sealed class RuntimeAsyncTask<T> : Task<T>, ITaskCompletionAction
@@ -327,18 +466,18 @@ namespace System.Runtime.CompilerServices
                 // Ensure that state object isn't published out for others to see.
                 Debug.Assert((m_stateFlags & (int)InternalTaskOptions.PromiseTask) != 0, "Expected state flags to already be configured.");
                 Debug.Assert(m_stateObject is null, "Expected to be able to use the state object field for Continuation.");
-                m_action = DispatchContinuations;
+                m_action = DispatchContinuations<DisableRuntimeAsyncTaskInstrumentation>;
                 m_stateFlags |= (int)InternalTaskOptions.HiddenState;
             }
 
             internal override void ExecuteFromThreadPool(Thread threadPoolThread)
             {
-                DispatchContinuations();
+                DispatchContinuations<DisableRuntimeAsyncTaskInstrumentation>();
             }
 
             void ITaskCompletionAction.Invoke(Task completingTask)
             {
-                DispatchContinuations();
+                DispatchContinuations<DisableRuntimeAsyncTaskInstrumentation>();
             }
 
             bool ITaskCompletionAction.InvokeMayRunArbitraryCode => true;
@@ -358,7 +497,7 @@ namespace System.Runtime.CompilerServices
                 m_stateObject = value;
             }
 
-            internal void HandleSuspended()
+            internal bool HandleSuspended()
             {
                 ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
 
@@ -390,18 +529,6 @@ namespace System.Runtime.CompilerServices
                 Debug.Assert((headContinuation.Flags & continueFlags) == 0);
 
                 SetContinuationState(headContinuation);
-
-                Continuation? nc = headContinuation;
-                if (Task.s_asyncDebuggingEnabled)
-                {
-                    long timestamp = Stopwatch.GetTimestamp();
-                    while (nc != null)
-                    {
-                        // On suspension we set timestamp for all continuations that have not yet had it set.
-                        Task.SetRuntimeAsyncContinuationTimestamp(nc, timestamp);
-                        nc = nc.Next;
-                    }
-                }
 
                 try
                 {
@@ -461,23 +588,15 @@ namespace System.Runtime.CompilerServices
                         Debug.Assert(notifier != null);
                         notifier.OnCompleted(GetContinuationAction());
                     }
+
+                    return true;
                 }
                 catch (Exception ex)
                 {
-                    if (Task.s_asyncDebuggingEnabled)
-                    {
-                        Task.RemoveFromActiveTasks(this);
-                        Task.RemoveRuntimeAsyncTaskTimestamp(this);
-                        Continuation? nextCont = headContinuation;
-                        while (nextCont != null)
-                        {
-                            Task.RemoveRuntimeAsyncContinuationTimestamp(nextCont);
-                            nextCont = nextCont.Next;
-                        }
-                    }
-
                     Task.ThrowAsync(ex, targetContext: null);
                 }
+
+                return false;
             }
 
 #pragma warning disable CA1822 // Mark members as static
@@ -487,23 +606,368 @@ namespace System.Runtime.CompilerServices
             }
 #pragma warning restore CA1822
 
-            [StackTraceHidden]
-            private unsafe void DispatchContinuations()
+            internal interface IRuntimeAsyncTaskInstrumentation
             {
+                static abstract bool InstrumentEntryPoint { get; }
+
+                static abstract bool InstrumentCheckPoint { get; }
+
+                static abstract RuntimeAsyncTaskInstrumentation.Flags Flags { get; }
+
+                static abstract void InitAsyncDispatcherInfo(RuntimeAsyncTask<T> task, ref AsyncDispatcherInfo info);
+
+                static abstract void CreateRuntimeAsyncContext(RuntimeAsyncTask<T> task);
+
+                static abstract void ResumeRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags);
+
+                static abstract void SuspendRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation);
+
+                static abstract void SuspendRuntimeAsyncContext(RuntimeAsyncTask<T> task, ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation, Continuation newContinuation);
+
+                static abstract void CompleteRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags);
+
+                static abstract void UnwindRuntimeAsyncMethodUnhandledException(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames);
+
+                static abstract void UnwindRuntimeAsyncMethodHandledException(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames);
+
+                static abstract Continuation? ResumeRuntimeAsyncMethod(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation, ref byte resultLoc);
+
+                static abstract void CompleteRuntimeAsyncMethod(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation);
+            }
+
+            internal struct DisableRuntimeAsyncTaskInstrumentation : IRuntimeAsyncTaskInstrumentation
+            {
+                public static bool InstrumentEntryPoint
+                {
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                    get => RuntimeAsyncTaskInstrumentation.IsSupported
+                        && RuntimeAsyncTaskInstrumentation.SyncAndGetActiveFlags() != RuntimeAsyncTaskInstrumentation.Flags.Disabled;
+                }
+
+                public static bool InstrumentCheckPoint
+                {
+                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                    get => RuntimeAsyncTaskInstrumentation.IsSupported
+                        && RuntimeAsyncTaskInstrumentation.ActiveFlags != RuntimeAsyncTaskInstrumentation.Flags.Disabled;
+                }
+
+                public static RuntimeAsyncTaskInstrumentation.Flags Flags => RuntimeAsyncTaskInstrumentation.Flags.Disabled;
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void InitAsyncDispatcherInfo(RuntimeAsyncTask<T> task, ref AsyncDispatcherInfo info) { }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void CreateRuntimeAsyncContext(RuntimeAsyncTask<T> task) { task.HandleSuspended(); }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void ResumeRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags) { }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void SuspendRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation) { }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void SuspendRuntimeAsyncContext(RuntimeAsyncTask<T> task, ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation, Continuation newContinuation)
+                {
+                    task.HandleSuspended();
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void CompleteRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags) { }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void UnwindRuntimeAsyncMethodUnhandledException(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames) { }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void UnwindRuntimeAsyncMethodHandledException(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames) { }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static Continuation? ResumeRuntimeAsyncMethod(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation, ref byte resultLoc)
+                {
+                    unsafe
+                    {
+                        return curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
+                    }
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void CompleteRuntimeAsyncMethod(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation) { }
+            }
+
+            internal struct EnableRuntimeAsyncTaskInstrumentation : IRuntimeAsyncTaskInstrumentation
+            {
+                public static bool InstrumentEntryPoint => false;
+
+                public static bool InstrumentCheckPoint => false;
+
+                public static RuntimeAsyncTaskInstrumentation.Flags Flags => RuntimeAsyncTaskInstrumentation.ActiveFlags;
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void InitAsyncDispatcherInfo(RuntimeAsyncTask<T> task, ref AsyncDispatcherInfo info)
+                {
+                    info.CurrentTask = task;
+                }
+
+                public static void CreateRuntimeAsyncContext(RuntimeAsyncTask<T> task)
+                {
+                    RuntimeAsyncTaskInstrumentation.Flags flags = Flags;
+                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.CreateAsyncContext(flags))
+                    {
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
+                        {
+                            task.NotifyDebuggerOfRuntimeAsyncState();
+                            AddToActiveTasks(task);
+                        }
+
+                        HandleSuspended(task, flags);
+
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Tpl(flags))
+                        {
+                            TplEventSource.Log.TraceOperationBegin(task.Id, "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask", 0);
+                        }
+
+                        return;
+                    }
+
+                    task.HandleSuspended();
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void ResumeRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags)
+                {
+                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.ResumeAsyncContext(flags))
+                    {
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Tpl(flags) && info.CurrentTask != null)
+                        {
+                            TplEventSource.Log.TraceSynchronousWorkBegin(info.CurrentTask.Id, CausalitySynchronousWork.Execution);
+                        }
+                    }
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void SuspendRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation)
+                {
+                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.SuspendAsyncContext(flags))
+                    {
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags) && info.NextContinuation != null)
+                        {
+                            TryAddRuntimeAsyncContinuationChainTimestamps(info.NextContinuation, curContinuation);
+                        }
+
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Tpl(flags))
+                        {
+                            TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                        }
+                    }
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void SuspendRuntimeAsyncContext(RuntimeAsyncTask<T> task, ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation, Continuation newContinuation)
+                {
+                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.SuspendAsyncContext(flags))
+                    {
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
+                        {
+                            ReplaceOrAddRuntimeAsyncContinuationTimestamp(curContinuation, newContinuation);
+                        }
+
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Tpl(flags))
+                        {
+                            TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                        }
+
+                        HandleSuspended(task, flags, newContinuation);
+                        return;
+                    }
+
+                    task.HandleSuspended();
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void CompleteRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags)
+                {
+                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.CompleteAsyncContext(flags))
+                    {
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.DebuggerOrTpl(flags))
+                        {
+                            CompleteRuntimeAsyncContext(info.CurrentTask, flags);
+                        }
+                    }
+                }
+
+                public static void UnwindRuntimeAsyncMethodUnhandledException(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames)
+                {
+                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.UnwindAsyncException(flags))
+                    {
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.DebuggerOrTpl(flags))
+                        {
+                            UnwindRuntimeAsyncMethodUnhandledException(info.CurrentTask, flags, ex, curContinuation, unwindedFrames);
+                        }
+                    }
+                }
+
+                public static void UnwindRuntimeAsyncMethodHandledException(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames)
+                {
+                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.UnwindAsyncException(flags))
+                    {
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
+                        {
+                            RemoveRuntimeAsyncContinuationChainTimestamps(curContinuation, unwindedFrames);
+                        }
+                    }
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static Continuation? ResumeRuntimeAsyncMethod(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation, ref byte resultLoc)
+                {
+                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
+                    {
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags) && info.CurrentTask != null)
+                        {
+                            UpdateRuntimeAsyncTaskTimestamp(info.CurrentTask, curContinuation);
+                        }
+                    }
+
+                    unsafe
+                    {
+                        return curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
+                    }
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                public static void CompleteRuntimeAsyncMethod(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation)
+                {
+                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.CompleteAsyncMethod(flags))
+                    {
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
+                        {
+                            RemoveRuntimeAsyncContinuationTimestamp(curContinuation);
+                        }
+                    }
+                }
+
+                private static void CompleteRuntimeAsyncContext(Task? task, RuntimeAsyncTaskInstrumentation.Flags flags)
+                {
+                    if (task != null)
+                    {
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
+                        {
+                            RemoveRuntimeAsyncTask(task);
+                        }
+
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Tpl(flags))
+                        {
+                            TplEventSource.Log.TraceOperationEnd(task.Id, AsyncCausalityStatus.Completed);
+                            TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                        }
+                    }
+                }
+
+                private static void UnwindRuntimeAsyncMethodUnhandledException(Task? task, RuntimeAsyncTaskInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint _)
+                {
+                    if (task != null)
+                    {
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
+                        {
+                            RemoveRuntimeAsyncTask(task, curContinuation);
+                        }
+
+                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Tpl(flags))
+                        {
+                            TplEventSource.Log.TraceOperationEnd(task.Id, ex is OperationCanceledException ? AsyncCausalityStatus.Canceled : AsyncCausalityStatus.Error);
+                            TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                        }
+                    }
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                private static void HandleSuspended(RuntimeAsyncTask<T> task, RuntimeAsyncTaskInstrumentation.Flags flags)
+                {
+                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
+                    {
+                        DebuggerHandleSuspended(task);
+                    }
+                    else
+                    {
+                        task.HandleSuspended();
+                    }
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                private static void HandleSuspended(RuntimeAsyncTask<T> task, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation newContinuation)
+                {
+                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
+                    {
+                        DebuggerHandleSuspended(task, newContinuation);
+                    }
+                    else
+                    {
+                        task.HandleSuspended();
+                    }
+                }
+
+                private static void DebuggerHandleSuspended(RuntimeAsyncTask<T> task, Continuation newContinuation)
+                {
+                    ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
+                    Continuation? nc = state.SentinelContinuation!.Next;
+
+                    if (nc != null)
+                    {
+                        TryAddRuntimeAsyncContinuationChainTimestamps(nc, newContinuation);
+                    }
+
+                    if (!task.HandleSuspended())
+                    {
+                        RemoveRuntimeAsyncTask(task);
+                    }
+                }
+
+                private static void DebuggerHandleSuspended(RuntimeAsyncTask<T> task)
+                {
+                    ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
+                    Continuation? nc = state.SentinelContinuation!.Next;
+
+                    if (nc != null)
+                    {
+                        TryAddRuntimeAsyncContinuationChainTimestamps(nc);
+                    }
+
+                    if (!task.HandleSuspended())
+                    {
+                        RemoveRuntimeAsyncTask(task);
+                    }
+                }
+            }
+
+            [BypassReadyToRun]
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            [StackTraceHidden]
+            private void InstrumentedDispatchContinuations()
+            {
+                DispatchContinuations<EnableRuntimeAsyncTaskInstrumentation>();
+            }
+
+            [StackTraceHidden]
+            private unsafe void DispatchContinuations<TRuntimeAsyncTaskInstrumentation>() where TRuntimeAsyncTaskInstrumentation : struct, IRuntimeAsyncTaskInstrumentation
+            {
+                if (TRuntimeAsyncTaskInstrumentation.InstrumentEntryPoint)
+                {
+                    InstrumentedDispatchContinuations();
+                    return;
+                }
+
+                RuntimeAsyncTaskInstrumentation.Flags flags = TRuntimeAsyncTaskInstrumentation.Flags;
+
                 ExecutionAndSyncBlockStore contexts = default;
                 contexts.Push();
 
                 AsyncDispatcherInfo asyncDispatcherInfo;
                 asyncDispatcherInfo.Next = AsyncDispatcherInfo.t_current;
                 asyncDispatcherInfo.NextContinuation = MoveContinuationState();
-                asyncDispatcherInfo.CurrentTask = this;
                 AsyncDispatcherInfo.t_current = &asyncDispatcherInfo;
-                bool isTplEnabled = TplEventSource.Log.IsEnabled();
 
-                if (isTplEnabled)
-                {
-                    TplEventSource.Log.TraceSynchronousWorkBegin(this.Id, CausalitySynchronousWork.Execution);
-                }
+                TRuntimeAsyncTaskInstrumentation.InitAsyncDispatcherInfo(this, ref asyncDispatcherInfo);
+
+                TRuntimeAsyncTaskInstrumentation.ResumeRuntimeAsyncContext(ref asyncDispatcherInfo, flags);
 
                 while (true)
                 {
@@ -515,43 +979,29 @@ namespace System.Runtime.CompilerServices
                         asyncDispatcherInfo.NextContinuation = nextContinuation;
 
                         ref byte resultLoc = ref nextContinuation != null ? ref nextContinuation.GetResultStorageOrNull() : ref GetResultStorage();
-                        long timestamp = 0;
-                        if (Task.s_asyncDebuggingEnabled)
-                        {
-                            timestamp = Task.GetRuntimeAsyncContinuationTimestamp(curContinuation, out long timestampVal) ? timestampVal : Stopwatch.GetTimestamp();
-                            // we have dequeued curContinuation; update task tick info so that we can track its start time from a debugger
-                            Task.UpdateRuntimeAsyncTaskTimestamp(this, timestamp);
-                        }
-                        Continuation? newContinuation = curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
 
-                        if (Task.s_asyncDebuggingEnabled)
-                        {
-                            Task.RemoveRuntimeAsyncContinuationTimestamp(curContinuation);
-                        }
+                        Continuation? newContinuation = TRuntimeAsyncTaskInstrumentation.ResumeRuntimeAsyncMethod(ref asyncDispatcherInfo, flags, curContinuation, ref resultLoc);
 
                         if (newContinuation != null)
                         {
-                            // we have a new Continuation that belongs to the same logical invocation as the previous; propagate debug info from previous continuation
-                            if (Task.s_asyncDebuggingEnabled)
-                            {
-                                Task.SetRuntimeAsyncContinuationTimestamp(newContinuation, timestamp);
-                            }
                             newContinuation.Next = nextContinuation;
-                            HandleSuspended();
+                            TRuntimeAsyncTaskInstrumentation.SuspendRuntimeAsyncContext(this, ref asyncDispatcherInfo, flags, curContinuation, newContinuation);
+
                             contexts.Pop();
                             AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
-                            break;
+                            return;
                         }
+
+                        TRuntimeAsyncTaskInstrumentation.CompleteRuntimeAsyncMethod(ref asyncDispatcherInfo, flags, curContinuation);
                     }
                     catch (Exception ex)
                     {
-                        if (Task.s_asyncDebuggingEnabled)
-                        {
-                            Task.RemoveRuntimeAsyncContinuationTimestamp(curContinuation);
-                        }
-                        Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex);
+                        uint unwindedFrames = 1; // Count current frame.
+                        Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex, ref unwindedFrames);
                         if (handlerContinuation == null)
                         {
+                            TRuntimeAsyncTaskInstrumentation.UnwindRuntimeAsyncMethodUnhandledException(ref asyncDispatcherInfo, flags, ex, curContinuation, unwindedFrames);
+
                             // Tail of AsyncTaskMethodBuilderT.SetException
                             bool successfullySet = ex is OperationCanceledException oce ?
                                 TrySetCanceled(oce.CancellationToken, oce) :
@@ -561,24 +1011,15 @@ namespace System.Runtime.CompilerServices
 
                             AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
 
-                            if (isTplEnabled)
-                            {
-                                TplEventSource.Log.TraceOperationEnd(this.Id, ex is OperationCanceledException ? AsyncCausalityStatus.Canceled : AsyncCausalityStatus.Error);
-                            }
-
-                            if (Task.s_asyncDebuggingEnabled)
-                            {
-                                Task.RemoveFromActiveTasks(this);
-                                Task.RemoveRuntimeAsyncTaskTimestamp(this);
-                            }
-
                             if (!successfullySet)
                             {
                                 ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
                             }
 
-                            break;
+                            return;
                         }
+
+                        TRuntimeAsyncTaskInstrumentation.UnwindRuntimeAsyncMethodHandledException(ref asyncDispatcherInfo, flags, ex, curContinuation, unwindedFrames);
 
                         handlerContinuation.SetException(ex);
                         asyncDispatcherInfo.NextContinuation = handlerContinuation;
@@ -586,15 +1027,8 @@ namespace System.Runtime.CompilerServices
 
                     if (asyncDispatcherInfo.NextContinuation == null)
                     {
-                        if (isTplEnabled)
-                        {
-                            TplEventSource.Log.TraceOperationEnd(this.Id, AsyncCausalityStatus.Completed);
-                        }
-                        if (Task.s_asyncDebuggingEnabled)
-                        {
-                            Task.RemoveFromActiveTasks(this);
-                            Task.RemoveRuntimeAsyncTaskTimestamp(this);
-                        }
+                        TRuntimeAsyncTaskInstrumentation.CompleteRuntimeAsyncContext(ref asyncDispatcherInfo, flags);
+
                         bool successfullySet = TrySetResult(m_result);
 
                         contexts.Pop();
@@ -606,25 +1040,38 @@ namespace System.Runtime.CompilerServices
                             ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
                         }
 
-                        break;
+                        return;
                     }
 
                     if (QueueContinuationFollowUpActionIfNecessary(asyncDispatcherInfo.NextContinuation))
                     {
+                        TRuntimeAsyncTaskInstrumentation.SuspendRuntimeAsyncContext(ref asyncDispatcherInfo, flags, curContinuation);
+
                         contexts.Pop();
                         AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
-                        break;
+                        return;
                     }
-                }
-                if (isTplEnabled)
-                {
-                    TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+
+                    if (TRuntimeAsyncTaskInstrumentation.InstrumentCheckPoint)
+                    {
+                        SetContinuationState(asyncDispatcherInfo.NextContinuation);
+
+                        TRuntimeAsyncTaskInstrumentation.SuspendRuntimeAsyncContext(ref asyncDispatcherInfo, flags, curContinuation);
+
+                        contexts.Pop();
+                        AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
+
+                        InstrumentedDispatchContinuations();
+                        return;
+                    }
+
+                    flags = TRuntimeAsyncTaskInstrumentation.Flags;
                 }
             }
 
             private ref byte GetResultStorage() => ref Unsafe.As<T?, byte>(ref m_result);
 
-            private static unsafe Continuation? UnwindToPossibleHandler(Continuation? continuation, Exception ex)
+            private static unsafe Continuation? UnwindToPossibleHandler(Continuation? continuation, Exception ex, ref uint unwindedFrames)
             {
                 while (true)
                 {
@@ -639,11 +1086,9 @@ namespace System.Runtime.CompilerServices
                     }
                     if (continuation == null || continuation.HasException())
                         return continuation;
-                    if (Task.s_asyncDebuggingEnabled)
-                    {
-                        Task.RemoveRuntimeAsyncContinuationTimestamp(continuation);
-                    }
+
                     continuation = continuation.Next;
+                    unwindedFrames++;
                 }
             }
 
@@ -713,14 +1158,34 @@ namespace System.Runtime.CompilerServices
             private static readonly SendOrPostCallback s_postCallback = static state =>
             {
                 Debug.Assert(state is RuntimeAsyncTask<T>);
-                ((RuntimeAsyncTask<T>)state).DispatchContinuations();
+                ((RuntimeAsyncTask<T>)state).DispatchContinuations<DisableRuntimeAsyncTaskInstrumentation>();
             };
 
             private static readonly Action<object?> s_runContinuationAction = static state =>
             {
                 Debug.Assert(state is RuntimeAsyncTask<T>);
-                ((RuntimeAsyncTask<T>)state).DispatchContinuations();
+                ((RuntimeAsyncTask<T>)state).DispatchContinuations<DisableRuntimeAsyncTaskInstrumentation>();
             };
+        }
+
+        [BypassReadyToRun]
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [StackTraceHidden]
+        private static void InstrumentedFinalizeRuntimeAsyncTask<T>(RuntimeAsyncTask<T> task)
+        {
+            RuntimeAsyncTask<T>.EnableRuntimeAsyncTaskInstrumentation.CreateRuntimeAsyncContext(task);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void FinalizeRuntimeAsyncTask<T>(RuntimeAsyncTask<T> task)
+        {
+            if (RuntimeAsyncTask<T>.DisableRuntimeAsyncTaskInstrumentation.InstrumentEntryPoint)
+            {
+                InstrumentedFinalizeRuntimeAsyncTask(task);
+                return;
+            }
+
+            RuntimeAsyncTask<T>.DisableRuntimeAsyncTaskInstrumentation.CreateRuntimeAsyncContext(task);
         }
 
         // Change return type to RuntimeAsyncTask<T?> -- no benefit since this is used for Task returning thunks only
@@ -730,32 +1195,14 @@ namespace System.Runtime.CompilerServices
         private static Task<T?> FinalizeTaskReturningThunk<T>()
         {
             RuntimeAsyncTask<T?> result = new();
-            if (Task.s_asyncDebuggingEnabled)
-            {
-                result.NotifyDebuggerOfRuntimeAsyncState();
-                Task.AddToActiveTasks(result);
-            }
-            if (TplEventSource.Log.IsEnabled())
-            {
-                TplEventSource.Log.TraceOperationBegin(result.Id, "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask", 0);
-            }
-            result.HandleSuspended();
+            FinalizeRuntimeAsyncTask(result!);
             return result;
         }
 
         private static Task FinalizeTaskReturningThunk()
         {
             RuntimeAsyncTask<VoidTaskResult> result = new();
-            if (Task.s_asyncDebuggingEnabled)
-            {
-                result.NotifyDebuggerOfRuntimeAsyncState();
-                Task.AddToActiveTasks(result);
-            }
-            if (TplEventSource.Log.IsEnabled())
-            {
-                TplEventSource.Log.TraceOperationBegin(result.Id, "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask", 0);
-            }
-            result.HandleSuspended();
+            FinalizeRuntimeAsyncTask(result!);
             return result;
         }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -718,13 +718,12 @@ namespace System.Runtime.CompilerServices
                             AddToActiveTasks(task);
                         }
 
-                        HandleSuspended(task, flags);
-
                         if (RuntimeAsyncTaskInstrumentation.IsEnabled.Tpl(flags))
                         {
                             TplEventSource.Log.TraceOperationBegin(task.Id, "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask", 0);
                         }
 
+                        HandleSuspended(task, flags);
                         return;
                     }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -314,148 +314,6 @@ namespace System.Runtime.CompilerServices
             AsyncSuspend(sentinelContinuation);
         }
 
-        internal static class RuntimeAsyncTaskInstrumentation
-        {
-#if NATIVEAOT
-            internal static bool IsSupported { get; } = Debugger.IsSupported || EventSource.IsSupported;
-#else
-            internal static bool IsSupported { get; } = true;
-#endif
-
-            internal enum Flags
-            {
-                Disabled = 0x0,
-                CreateAsyncContext = 0x1,
-                ResumeAsyncContext = 0x2,
-                SuspendAsyncContext = 0x4,
-                CompleteAsyncContext = 0x8,
-                UnwindAsyncException = 0x10,
-                ResumeAsyncMethod = 0x20,
-                CompleteAsyncMethod = 0x40,
-                AsyncProfiler = 0x10000,
-                Tpl = 0x20000,
-                Debugger = 0x40000
-            }
-
-            public static Flags ActiveFlags => _activeFlags;
-
-            public static Flags UpdateAsyncProfilerFlags(Flags flags)
-            {
-                lock (_lock)
-                {
-                    if (flags != Flags.Disabled)
-                    {
-                        flags |= Flags.AsyncProfiler;
-                    }
-
-                    _asyncProfilerActiveFlags = flags;
-                    _activeFlags = _asyncProfilerActiveFlags | _tplActiveFlags | _debuggerActiveFlags;
-
-                    return _activeFlags;
-                }
-            }
-
-            public static Flags UpdateTplFlags(EventSource tplEventSource)
-            {
-                Flags flags = Flags.Disabled;
-
-                flags |= tplEventSource.IsEnabled(EventLevel.Informational, TplEventSource.Keywords.AsyncCausalitySynchronousWork) ?
-                    Flags.ResumeAsyncContext |
-                    Flags.SuspendAsyncContext |
-                    Flags.CompleteAsyncContext |
-                    Flags.UnwindAsyncException : 0;
-
-                flags |= tplEventSource.IsEnabled(EventLevel.Informational, TplEventSource.Keywords.AsyncCausalityOperation) ?
-                    Flags.CreateAsyncContext |
-                    Flags.CompleteAsyncContext |
-                    Flags.UnwindAsyncException : 0;
-
-                lock (_lock)
-                {
-                    if (flags != Flags.Disabled)
-                    {
-                        flags |= Flags.Tpl;
-                    }
-
-                    _tplActiveFlags = flags;
-                    _activeFlags = _asyncProfilerActiveFlags | _tplActiveFlags | _debuggerActiveFlags;
-
-                    return _activeFlags;
-                }
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            public static Flags SyncAndGetActiveFlags()
-            {
-                Flags flags = _activeFlags;
-                if (IsEnabled.Debugger(flags) != Task.s_asyncDebuggingEnabled)
-                {
-                    flags = SyncDebuggerFlagsSlow(flags);
-                }
-                return flags;
-            }
-
-            private static Flags SyncDebuggerFlagsSlow(Flags flags)
-            {
-                if (IsEnabled.Debugger(flags) && !Task.s_asyncDebuggingEnabled)
-                {
-                    return UpdateDebuggerFlags(Flags.Disabled);
-                }
-                else if (!IsEnabled.Debugger(flags) && Task.s_asyncDebuggingEnabled)
-                {
-                    return UpdateDebuggerFlags(DebuggerFlags);
-                }
-
-                return flags;
-            }
-
-            private static Flags UpdateDebuggerFlags(Flags flags)
-            {
-                lock (_lock)
-                {
-                    if (flags != Flags.Disabled)
-                    {
-                        flags |= Flags.Debugger;
-                    }
-
-                    _debuggerActiveFlags = flags;
-                    _activeFlags = _asyncProfilerActiveFlags | _tplActiveFlags | _debuggerActiveFlags;
-
-                    return _activeFlags;
-                }
-            }
-
-            public static class IsEnabled
-            {
-                public static bool CreateAsyncContext(Flags flags) => (Flags.CreateAsyncContext & flags) != 0;
-                public static bool ResumeAsyncContext(Flags flags) => (Flags.ResumeAsyncContext & flags) != 0;
-                public static bool SuspendAsyncContext(Flags flags) => (Flags.SuspendAsyncContext & flags) != 0;
-                public static bool CompleteAsyncContext(Flags flags) => (Flags.CompleteAsyncContext & flags) != 0;
-                public static bool UnwindAsyncException(Flags flags) => (Flags.UnwindAsyncException & flags) != 0;
-                public static bool ResumeAsyncMethod(Flags flags) => (Flags.ResumeAsyncMethod & flags) != 0;
-                public static bool CompleteAsyncMethod(Flags flags) => (Flags.CompleteAsyncMethod & flags) != 0;
-                public static bool AsyncProfiler(Flags flags) => (Flags.AsyncProfiler & flags) != 0;
-                public static bool Tpl(Flags flags) => (Flags.Tpl & flags) != 0;
-                public static bool Debugger(Flags flags) => (Flags.Debugger & flags) != 0;
-                public static bool DebuggerOrTpl(Flags flags) => ((Flags.Tpl | Flags.Debugger) & flags) != 0;
-            }
-
-            private static Flags _activeFlags;
-
-            private static Flags _asyncProfilerActiveFlags;
-
-            private static Flags _tplActiveFlags;
-
-            private static Flags _debuggerActiveFlags;
-
-            private static readonly object _lock = new object();
-
-            private const Flags DebuggerFlags =
-                Flags.CreateAsyncContext | Flags.SuspendAsyncContext |
-                Flags.CompleteAsyncContext | Flags.UnwindAsyncException |
-                Flags.ResumeAsyncMethod | Flags.CompleteAsyncMethod;
-        }
-
         // Represents execution of a chain of suspended and resuming runtime
         // async functions.
         private sealed class RuntimeAsyncTask<T> : Task<T>, ITaskCompletionAction
@@ -466,18 +324,18 @@ namespace System.Runtime.CompilerServices
                 // Ensure that state object isn't published out for others to see.
                 Debug.Assert((m_stateFlags & (int)InternalTaskOptions.PromiseTask) != 0, "Expected state flags to already be configured.");
                 Debug.Assert(m_stateObject is null, "Expected to be able to use the state object field for Continuation.");
-                m_action = DispatchContinuations<DisableRuntimeAsyncTaskInstrumentation>;
+                m_action = DispatchContinuations;
                 m_stateFlags |= (int)InternalTaskOptions.HiddenState;
             }
 
             internal override void ExecuteFromThreadPool(Thread threadPoolThread)
             {
-                DispatchContinuations<DisableRuntimeAsyncTaskInstrumentation>();
+                DispatchContinuations();
             }
 
             void ITaskCompletionAction.Invoke(Task completingTask)
             {
-                DispatchContinuations<DisableRuntimeAsyncTaskInstrumentation>();
+                DispatchContinuations();
             }
 
             bool ITaskCompletionAction.InvokeMayRunArbitraryCode => true;
@@ -606,153 +464,57 @@ namespace System.Runtime.CompilerServices
             }
 #pragma warning restore CA1822
 
-            internal interface IRuntimeAsyncTaskInstrumentation
+            internal static class AsyncInstrumentationHelper
             {
-                static abstract bool InstrumentEntryPoint { get; }
-
-                static abstract bool InstrumentCheckPoint { get; }
-
-                static abstract RuntimeAsyncTaskInstrumentation.Flags Flags { get; }
-
-                static abstract void InitAsyncDispatcherInfo(RuntimeAsyncTask<T> task, ref AsyncDispatcherInfo info);
-
-                static abstract void CreateRuntimeAsyncContext(RuntimeAsyncTask<T> task);
-
-                static abstract void ResumeRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags);
-
-                static abstract void SuspendRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation);
-
-                static abstract void SuspendRuntimeAsyncContext(RuntimeAsyncTask<T> task, ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation, Continuation newContinuation);
-
-                static abstract void CompleteRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags);
-
-                static abstract void UnwindRuntimeAsyncMethodUnhandledException(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames);
-
-                static abstract void UnwindRuntimeAsyncMethodHandledException(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames);
-
-                static abstract Continuation? ResumeRuntimeAsyncMethod(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation, ref byte resultLoc);
-
-                static abstract void CompleteRuntimeAsyncMethod(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation);
-            }
-
-            internal struct DisableRuntimeAsyncTaskInstrumentation : IRuntimeAsyncTaskInstrumentation
-            {
-                public static bool InstrumentEntryPoint
-                {
-                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                    get => RuntimeAsyncTaskInstrumentation.IsSupported
-                        && RuntimeAsyncTaskInstrumentation.SyncAndGetActiveFlags() != RuntimeAsyncTaskInstrumentation.Flags.Disabled;
-                }
-
                 public static bool InstrumentCheckPoint
                 {
                     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                    get => RuntimeAsyncTaskInstrumentation.IsSupported
-                        && RuntimeAsyncTaskInstrumentation.ActiveFlags != RuntimeAsyncTaskInstrumentation.Flags.Disabled;
+                    get => AsyncInstrumentation.IsSupported
+                        && AsyncInstrumentation.ActiveFlags != AsyncInstrumentation.Flags.Disabled;
                 }
 
-                public static RuntimeAsyncTaskInstrumentation.Flags Flags => RuntimeAsyncTaskInstrumentation.Flags.Disabled;
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void InitAsyncDispatcherInfo(RuntimeAsyncTask<T> task, ref AsyncDispatcherInfo info) { }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void CreateRuntimeAsyncContext(RuntimeAsyncTask<T> task) { task.HandleSuspended(); }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void ResumeRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags) { }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void SuspendRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation) { }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void SuspendRuntimeAsyncContext(RuntimeAsyncTask<T> task, ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation, Continuation newContinuation)
+                public static void CreateRuntimeAsyncContext(RuntimeAsyncTask<T> task, AsyncInstrumentation.Flags flags)
                 {
-                    task.HandleSuspended();
-                }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void CompleteRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags) { }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void UnwindRuntimeAsyncMethodUnhandledException(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames) { }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void UnwindRuntimeAsyncMethodHandledException(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames) { }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static Continuation? ResumeRuntimeAsyncMethod(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation, ref byte resultLoc)
-                {
-                    unsafe
+                    if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags))
                     {
-                        return curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
-                    }
-                }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void CompleteRuntimeAsyncMethod(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation) { }
-            }
-
-            internal struct EnableRuntimeAsyncTaskInstrumentation : IRuntimeAsyncTaskInstrumentation
-            {
-                public static bool InstrumentEntryPoint => false;
-
-                public static bool InstrumentCheckPoint => false;
-
-                public static RuntimeAsyncTaskInstrumentation.Flags Flags => RuntimeAsyncTaskInstrumentation.ActiveFlags;
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void InitAsyncDispatcherInfo(RuntimeAsyncTask<T> task, ref AsyncDispatcherInfo info)
-                {
-                    info.CurrentTask = task;
-                }
-
-                public static void CreateRuntimeAsyncContext(RuntimeAsyncTask<T> task)
-                {
-                    RuntimeAsyncTaskInstrumentation.Flags flags = Flags;
-                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.CreateAsyncContext(flags))
-                    {
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
+                        if (AsyncInstrumentation.IsEnabled.Debugger(flags))
                         {
                             task.NotifyDebuggerOfRuntimeAsyncState();
                             AddToActiveTasks(task);
                         }
 
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Tpl(flags))
+                        if (AsyncInstrumentation.IsEnabled.Tpl(flags))
                         {
                             TplEventSource.Log.TraceOperationBegin(task.Id, "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask", 0);
                         }
-
-                        HandleSuspended(task, flags);
-                        return;
                     }
-
-                    task.HandleSuspended();
                 }
 
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void ResumeRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags)
+                public static void ResumeRuntimeAsyncContext(RuntimeAsyncTask<T> task, ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags)
                 {
-                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.ResumeAsyncContext(flags))
+                    info.CurrentTask = task;
+
+                    if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
                     {
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Tpl(flags) && info.CurrentTask != null)
+                        if (AsyncInstrumentation.IsEnabled.Tpl(flags))
                         {
-                            TplEventSource.Log.TraceSynchronousWorkBegin(info.CurrentTask.Id, CausalitySynchronousWork.Execution);
+                            TplEventSource.Log.TraceSynchronousWorkBegin(task.Id, CausalitySynchronousWork.Execution);
                         }
                     }
                 }
 
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void SuspendRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation)
+                public static void SuspendRuntimeAsyncContext(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags, Continuation curContinuation)
                 {
-                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.SuspendAsyncContext(flags))
+                    if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(flags))
                     {
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags) && info.NextContinuation != null)
+                        if (AsyncInstrumentation.IsEnabled.Debugger(flags) && info.NextContinuation != null)
                         {
                             TryAddRuntimeAsyncContinuationChainTimestamps(info.NextContinuation, curContinuation);
                         }
 
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Tpl(flags))
+                        if (AsyncInstrumentation.IsEnabled.Tpl(flags))
                         {
                             TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
                         }
@@ -760,55 +522,50 @@ namespace System.Runtime.CompilerServices
                 }
 
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void SuspendRuntimeAsyncContext(RuntimeAsyncTask<T> task, ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation, Continuation newContinuation)
+                public static void SuspendRuntimeAsyncContext(AsyncInstrumentation.Flags flags, Continuation curContinuation, Continuation newContinuation)
                 {
-                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.SuspendAsyncContext(flags))
+                    if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(flags))
                     {
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
+                        if (AsyncInstrumentation.IsEnabled.Debugger(flags))
                         {
                             ReplaceOrAddRuntimeAsyncContinuationTimestamp(curContinuation, newContinuation);
                         }
 
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Tpl(flags))
+                        if (AsyncInstrumentation.IsEnabled.Tpl(flags))
                         {
                             TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
                         }
-
-                        HandleSuspended(task, flags, newContinuation);
-                        return;
                     }
-
-                    task.HandleSuspended();
                 }
 
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void CompleteRuntimeAsyncContext(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags)
+                public static void CompleteRuntimeAsyncContext(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags)
                 {
-                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.CompleteAsyncContext(flags))
+                    if (AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
                     {
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.DebuggerOrTpl(flags))
+                        if (AsyncInstrumentation.IsEnabled.DebuggerOrTpl(flags))
                         {
                             CompleteRuntimeAsyncContext(info.CurrentTask, flags);
                         }
                     }
                 }
 
-                public static void UnwindRuntimeAsyncMethodUnhandledException(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames)
+                public static void UnwindRuntimeAsyncMethodUnhandledException(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames)
                 {
-                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.UnwindAsyncException(flags))
+                    if (AsyncInstrumentation.IsEnabled.UnwindAsyncException(flags))
                     {
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.DebuggerOrTpl(flags))
+                        if (AsyncInstrumentation.IsEnabled.DebuggerOrTpl(flags))
                         {
                             UnwindRuntimeAsyncMethodUnhandledException(info.CurrentTask, flags, ex, curContinuation, unwindedFrames);
                         }
                     }
                 }
 
-                public static void UnwindRuntimeAsyncMethodHandledException(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames)
+                public static void UnwindRuntimeAsyncMethodHandledException(AsyncInstrumentation.Flags flags, Continuation curContinuation, uint unwindedFrames)
                 {
-                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.UnwindAsyncException(flags))
+                    if (AsyncInstrumentation.IsEnabled.UnwindAsyncException(flags))
                     {
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
+                        if (AsyncInstrumentation.IsEnabled.Debugger(flags))
                         {
                             RemoveRuntimeAsyncContinuationChainTimestamps(curContinuation, unwindedFrames);
                         }
@@ -816,85 +573,33 @@ namespace System.Runtime.CompilerServices
                 }
 
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static Continuation? ResumeRuntimeAsyncMethod(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation, ref byte resultLoc)
+                public static void ResumeRuntimeAsyncMethod(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags, Continuation curContinuation)
                 {
-                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
+                    if (AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
                     {
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags) && info.CurrentTask != null)
+                        if (AsyncInstrumentation.IsEnabled.Debugger(flags) && info.CurrentTask != null)
                         {
                             UpdateRuntimeAsyncTaskTimestamp(info.CurrentTask, curContinuation);
                         }
                     }
-
-                    unsafe
-                    {
-                        return curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
-                    }
                 }
 
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void CompleteRuntimeAsyncMethod(ref AsyncDispatcherInfo info, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation curContinuation)
+                public static void CompleteRuntimeAsyncMethod(AsyncInstrumentation.Flags flags, Continuation curContinuation)
                 {
-                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.CompleteAsyncMethod(flags))
+                    if (AsyncInstrumentation.IsEnabled.CompleteAsyncMethod(flags))
                     {
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
+                        if (AsyncInstrumentation.IsEnabled.Debugger(flags))
                         {
                             RemoveRuntimeAsyncContinuationTimestamp(curContinuation);
                         }
                     }
                 }
 
-                private static void CompleteRuntimeAsyncContext(Task? task, RuntimeAsyncTaskInstrumentation.Flags flags)
-                {
-                    if (task != null)
-                    {
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
-                        {
-                            RemoveRuntimeAsyncTask(task);
-                        }
-
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Tpl(flags))
-                        {
-                            TplEventSource.Log.TraceOperationEnd(task.Id, AsyncCausalityStatus.Completed);
-                            TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
-                        }
-                    }
-                }
-
-                private static void UnwindRuntimeAsyncMethodUnhandledException(Task? task, RuntimeAsyncTaskInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint _)
-                {
-                    if (task != null)
-                    {
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
-                        {
-                            RemoveRuntimeAsyncTask(task, curContinuation);
-                        }
-
-                        if (RuntimeAsyncTaskInstrumentation.IsEnabled.Tpl(flags))
-                        {
-                            TplEventSource.Log.TraceOperationEnd(task.Id, ex is OperationCanceledException ? AsyncCausalityStatus.Canceled : AsyncCausalityStatus.Error);
-                            TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
-                        }
-                    }
-                }
-
                 [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                private static void HandleSuspended(RuntimeAsyncTask<T> task, RuntimeAsyncTaskInstrumentation.Flags flags)
+                public static void HandleSuspended(RuntimeAsyncTask<T> task, AsyncInstrumentation.Flags flags, Continuation? newContinuation = null)
                 {
-                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
-                    {
-                        DebuggerHandleSuspended(task);
-                    }
-                    else
-                    {
-                        task.HandleSuspended();
-                    }
-                }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                private static void HandleSuspended(RuntimeAsyncTask<T> task, RuntimeAsyncTaskInstrumentation.Flags flags, Continuation newContinuation)
-                {
-                    if (RuntimeAsyncTaskInstrumentation.IsEnabled.Debugger(flags))
+                    if (AsyncInstrumentation.IsEnabled.Debugger(flags))
                     {
                         DebuggerHandleSuspended(task, newContinuation);
                     }
@@ -904,30 +609,51 @@ namespace System.Runtime.CompilerServices
                     }
                 }
 
-                private static void DebuggerHandleSuspended(RuntimeAsyncTask<T> task, Continuation newContinuation)
+                private static void CompleteRuntimeAsyncContext(Task? task, AsyncInstrumentation.Flags flags)
                 {
-                    ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
-                    Continuation? nc = state.SentinelContinuation!.Next;
-
-                    if (nc != null)
+                    if (task != null)
                     {
-                        TryAddRuntimeAsyncContinuationChainTimestamps(nc, newContinuation);
-                    }
+                        if (AsyncInstrumentation.IsEnabled.Debugger(flags))
+                        {
+                            RemoveRuntimeAsyncTask(task);
+                        }
 
-                    if (!task.HandleSuspended())
-                    {
-                        RemoveRuntimeAsyncTask(task);
+                        if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                        {
+                            TplEventSource.Log.TraceOperationEnd(task.Id, AsyncCausalityStatus.Completed);
+                            TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                        }
                     }
                 }
 
-                private static void DebuggerHandleSuspended(RuntimeAsyncTask<T> task)
+                private static void UnwindRuntimeAsyncMethodUnhandledException(Task? task, AsyncInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint _)
+                {
+                    if (task != null)
+                    {
+                        if (AsyncInstrumentation.IsEnabled.Debugger(flags))
+                        {
+                            RemoveRuntimeAsyncTask(task, curContinuation);
+                        }
+
+                        if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                        {
+                            TplEventSource.Log.TraceOperationEnd(task.Id, ex is OperationCanceledException ? AsyncCausalityStatus.Canceled : AsyncCausalityStatus.Error);
+                            TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                        }
+                    }
+                }
+
+                private static void DebuggerHandleSuspended(RuntimeAsyncTask<T> task, Continuation? newContinuation = null)
                 {
                     ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
                     Continuation? nc = state.SentinelContinuation!.Next;
 
                     if (nc != null)
                     {
-                        TryAddRuntimeAsyncContinuationChainTimestamps(nc);
+                        if (newContinuation != null)
+                            TryAddRuntimeAsyncContinuationChainTimestamps(nc, newContinuation);
+                        else
+                            TryAddRuntimeAsyncContinuationChainTimestamps(nc);
                     }
 
                     if (!task.HandleSuspended())
@@ -937,25 +663,9 @@ namespace System.Runtime.CompilerServices
                 }
             }
 
-            [BypassReadyToRun]
-            [MethodImpl(MethodImplOptions.NoInlining)]
             [StackTraceHidden]
-            private void InstrumentedDispatchContinuations()
+            private unsafe void InstrumentedDispatchContinuations()
             {
-                DispatchContinuations<EnableRuntimeAsyncTaskInstrumentation>();
-            }
-
-            [StackTraceHidden]
-            private unsafe void DispatchContinuations<TRuntimeAsyncTaskInstrumentation>() where TRuntimeAsyncTaskInstrumentation : struct, IRuntimeAsyncTaskInstrumentation
-            {
-                if (TRuntimeAsyncTaskInstrumentation.InstrumentEntryPoint)
-                {
-                    InstrumentedDispatchContinuations();
-                    return;
-                }
-
-                RuntimeAsyncTaskInstrumentation.Flags flags = TRuntimeAsyncTaskInstrumentation.Flags;
-
                 ExecutionAndSyncBlockStore contexts = default;
                 contexts.Push();
 
@@ -964,9 +674,8 @@ namespace System.Runtime.CompilerServices
                 asyncDispatcherInfo.NextContinuation = MoveContinuationState();
                 AsyncDispatcherInfo.t_current = &asyncDispatcherInfo;
 
-                TRuntimeAsyncTaskInstrumentation.InitAsyncDispatcherInfo(this, ref asyncDispatcherInfo);
-
-                TRuntimeAsyncTaskInstrumentation.ResumeRuntimeAsyncContext(ref asyncDispatcherInfo, flags);
+                AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
+                AsyncInstrumentationHelper.ResumeRuntimeAsyncContext(this, ref asyncDispatcherInfo, flags);
 
                 while (true)
                 {
@@ -979,19 +688,21 @@ namespace System.Runtime.CompilerServices
 
                         ref byte resultLoc = ref nextContinuation != null ? ref nextContinuation.GetResultStorageOrNull() : ref GetResultStorage();
 
-                        Continuation? newContinuation = TRuntimeAsyncTaskInstrumentation.ResumeRuntimeAsyncMethod(ref asyncDispatcherInfo, flags, curContinuation, ref resultLoc);
+                        AsyncInstrumentationHelper.ResumeRuntimeAsyncMethod(ref asyncDispatcherInfo, flags, curContinuation);
+                        Continuation? newContinuation = curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
 
                         if (newContinuation != null)
                         {
                             newContinuation.Next = nextContinuation;
-                            TRuntimeAsyncTaskInstrumentation.SuspendRuntimeAsyncContext(this, ref asyncDispatcherInfo, flags, curContinuation, newContinuation);
+                            AsyncInstrumentationHelper.SuspendRuntimeAsyncContext(flags, curContinuation, newContinuation);
+                            AsyncInstrumentationHelper.HandleSuspended(this, flags, newContinuation);
 
                             contexts.Pop();
                             AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
                             return;
                         }
 
-                        TRuntimeAsyncTaskInstrumentation.CompleteRuntimeAsyncMethod(ref asyncDispatcherInfo, flags, curContinuation);
+                        AsyncInstrumentationHelper.CompleteRuntimeAsyncMethod(flags, curContinuation);
                     }
                     catch (Exception ex)
                     {
@@ -999,7 +710,7 @@ namespace System.Runtime.CompilerServices
                         Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex, ref unwindedFrames);
                         if (handlerContinuation == null)
                         {
-                            TRuntimeAsyncTaskInstrumentation.UnwindRuntimeAsyncMethodUnhandledException(ref asyncDispatcherInfo, flags, ex, curContinuation, unwindedFrames);
+                            AsyncInstrumentationHelper.UnwindRuntimeAsyncMethodUnhandledException(ref asyncDispatcherInfo, flags, ex, curContinuation, unwindedFrames);
 
                             // Tail of AsyncTaskMethodBuilderT.SetException
                             bool successfullySet = ex is OperationCanceledException oce ?
@@ -1018,7 +729,7 @@ namespace System.Runtime.CompilerServices
                             return;
                         }
 
-                        TRuntimeAsyncTaskInstrumentation.UnwindRuntimeAsyncMethodHandledException(ref asyncDispatcherInfo, flags, ex, curContinuation, unwindedFrames);
+                        AsyncInstrumentationHelper.UnwindRuntimeAsyncMethodHandledException(flags, curContinuation, unwindedFrames);
 
                         handlerContinuation.SetException(ex);
                         asyncDispatcherInfo.NextContinuation = handlerContinuation;
@@ -1026,7 +737,7 @@ namespace System.Runtime.CompilerServices
 
                     if (asyncDispatcherInfo.NextContinuation == null)
                     {
-                        TRuntimeAsyncTaskInstrumentation.CompleteRuntimeAsyncContext(ref asyncDispatcherInfo, flags);
+                        AsyncInstrumentationHelper.CompleteRuntimeAsyncContext(ref asyncDispatcherInfo, flags);
 
                         bool successfullySet = TrySetResult(m_result);
 
@@ -1044,18 +755,111 @@ namespace System.Runtime.CompilerServices
 
                     if (QueueContinuationFollowUpActionIfNecessary(asyncDispatcherInfo.NextContinuation))
                     {
-                        TRuntimeAsyncTaskInstrumentation.SuspendRuntimeAsyncContext(ref asyncDispatcherInfo, flags, curContinuation);
+                        AsyncInstrumentationHelper.SuspendRuntimeAsyncContext(ref asyncDispatcherInfo, flags, curContinuation);
 
                         contexts.Pop();
                         AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
                         return;
                     }
 
-                    if (TRuntimeAsyncTaskInstrumentation.InstrumentCheckPoint)
+                    flags = AsyncInstrumentation.ActiveFlags;
+                }
+            }
+
+            [StackTraceHidden]
+            // NOTE, any changes done to this method needs to be replicate in InstrumentedDispatchContinuations as well.
+            private unsafe void DispatchContinuations()
+            {
+                if (AsyncInstrumentationHelper.InstrumentCheckPoint)
+                {
+                    InstrumentedDispatchContinuations();
+                    return;
+                }
+
+                ExecutionAndSyncBlockStore contexts = default;
+                contexts.Push();
+
+                AsyncDispatcherInfo asyncDispatcherInfo;
+                asyncDispatcherInfo.Next = AsyncDispatcherInfo.t_current;
+                asyncDispatcherInfo.NextContinuation = MoveContinuationState();
+                AsyncDispatcherInfo.t_current = &asyncDispatcherInfo;
+
+                while (true)
+                {
+                    Debug.Assert(asyncDispatcherInfo.NextContinuation != null);
+                    try
+                    {
+                        Continuation curContinuation = asyncDispatcherInfo.NextContinuation;
+                        Continuation? nextContinuation = curContinuation.Next;
+                        asyncDispatcherInfo.NextContinuation = nextContinuation;
+
+                        ref byte resultLoc = ref nextContinuation != null ? ref nextContinuation.GetResultStorageOrNull() : ref GetResultStorage();
+
+                        Continuation? newContinuation = curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
+
+                        if (newContinuation != null)
+                        {
+                            newContinuation.Next = nextContinuation;
+                            HandleSuspended();
+
+                            contexts.Pop();
+                            AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
+                            return;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        uint unwindedFrames = 1; // Count current frame.
+                        Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex, ref unwindedFrames);
+                        if (handlerContinuation == null)
+                        {
+                            // Tail of AsyncTaskMethodBuilderT.SetException
+                            bool successfullySet = ex is OperationCanceledException oce ?
+                                TrySetCanceled(oce.CancellationToken, oce) :
+                                TrySetException(ex);
+
+                            contexts.Pop();
+
+                            AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
+
+                            if (!successfullySet)
+                            {
+                                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
+                            }
+
+                            return;
+                        }
+
+                        handlerContinuation.SetException(ex);
+                        asyncDispatcherInfo.NextContinuation = handlerContinuation;
+                    }
+
+                    if (asyncDispatcherInfo.NextContinuation == null)
+                    {
+                        bool successfullySet = TrySetResult(m_result);
+
+                        contexts.Pop();
+
+                        AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
+
+                        if (!successfullySet)
+                        {
+                            ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
+                        }
+
+                        return;
+                    }
+
+                    if (QueueContinuationFollowUpActionIfNecessary(asyncDispatcherInfo.NextContinuation))
+                    {
+                        contexts.Pop();
+                        AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
+                        return;
+                    }
+
+                    if (AsyncInstrumentationHelper.InstrumentCheckPoint)
                     {
                         SetContinuationState(asyncDispatcherInfo.NextContinuation);
-
-                        TRuntimeAsyncTaskInstrumentation.SuspendRuntimeAsyncContext(ref asyncDispatcherInfo, flags, curContinuation);
 
                         contexts.Pop();
                         AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
@@ -1063,8 +867,6 @@ namespace System.Runtime.CompilerServices
                         InstrumentedDispatchContinuations();
                         return;
                     }
-
-                    flags = TRuntimeAsyncTaskInstrumentation.Flags;
                 }
             }
 
@@ -1157,34 +959,28 @@ namespace System.Runtime.CompilerServices
             private static readonly SendOrPostCallback s_postCallback = static state =>
             {
                 Debug.Assert(state is RuntimeAsyncTask<T>);
-                ((RuntimeAsyncTask<T>)state).DispatchContinuations<DisableRuntimeAsyncTaskInstrumentation>();
+                ((RuntimeAsyncTask<T>)state).DispatchContinuations();
             };
 
             private static readonly Action<object?> s_runContinuationAction = static state =>
             {
                 Debug.Assert(state is RuntimeAsyncTask<T>);
-                ((RuntimeAsyncTask<T>)state).DispatchContinuations<DisableRuntimeAsyncTaskInstrumentation>();
+                ((RuntimeAsyncTask<T>)state).DispatchContinuations();
             };
-        }
-
-        [BypassReadyToRun]
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        [StackTraceHidden]
-        private static void InstrumentedFinalizeRuntimeAsyncTask<T>(RuntimeAsyncTask<T> task)
-        {
-            RuntimeAsyncTask<T>.EnableRuntimeAsyncTaskInstrumentation.CreateRuntimeAsyncContext(task);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void FinalizeRuntimeAsyncTask<T>(RuntimeAsyncTask<T> task)
         {
-            if (RuntimeAsyncTask<T>.DisableRuntimeAsyncTaskInstrumentation.InstrumentEntryPoint)
+            if (RuntimeAsyncTask<T>.AsyncInstrumentationHelper.InstrumentCheckPoint)
             {
-                InstrumentedFinalizeRuntimeAsyncTask(task);
+                AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
+                RuntimeAsyncTask<T>.AsyncInstrumentationHelper.CreateRuntimeAsyncContext(task, flags);
+                RuntimeAsyncTask<T>.AsyncInstrumentationHelper.HandleSuspended(task, flags);
                 return;
             }
 
-            RuntimeAsyncTask<T>.DisableRuntimeAsyncTaskInstrumentation.CreateRuntimeAsyncContext(task);
+            task.HandleSuspended();
         }
 
         // Change return type to RuntimeAsyncTask<T?> -- no benefit since this is used for Task returning thunks only

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -656,13 +656,20 @@ namespace System.Runtime.CompilerServices
 
                     if (!task.HandleSuspended())
                     {
-                        RemoveRuntimeAsyncTask(task);
+                        if (nc != null)
+                        {
+                            RemoveRuntimeAsyncTask(task, nc);
+                        }
+                        else
+                        {
+                            RemoveRuntimeAsyncTask(task);
+                        }
                     }
                 }
             }
 
             [StackTraceHidden]
-            // NOTE, any changes done to this method needs to be replicate in InstrumentedDispatchContinuations as well.
+            // NOTE, any changes done to this method need to be replicated in InstrumentedDispatchContinuations as well.
             private unsafe void DispatchContinuations()
             {
                 if (AsyncInstrumentationHelper.InstrumentCheckPoint)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -458,7 +458,7 @@ namespace System.Runtime.CompilerServices
 
             internal bool InstrumentedHandleSuspended(AsyncInstrumentation.Flags flags, Continuation? newContinuation = null)
             {
-                if (AsyncInstrumentation.IsEnabled.Debugger(flags))
+                if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                 {
                     Continuation? nc = t_runtimeAsyncAwaitState.SentinelContinuation!.Next;
 
@@ -814,14 +814,10 @@ namespace System.Runtime.CompilerServices
         {
             if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags))
             {
-                if (AsyncInstrumentation.IsEnabled.Debugger(flags))
+                if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                 {
                     task.NotifyDebuggerOfRuntimeAsyncState();
                     Task.AddToActiveTasks(task);
-                }
-
-                if (AsyncInstrumentation.IsEnabled.Tpl(flags))
-                {
                     TplEventSource.Log.TraceOperationBegin(task.Id, "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask", 0);
                 }
             }
@@ -1036,7 +1032,7 @@ namespace System.Runtime.CompilerServices
 
                 if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
                 {
-                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                    if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
                         TplEventSource.Log.TraceSynchronousWorkBegin(task.Id, CausalitySynchronousWork.Execution);
                     }
@@ -1048,13 +1044,13 @@ namespace System.Runtime.CompilerServices
             {
                 if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(flags))
                 {
-                    if (AsyncInstrumentation.IsEnabled.Debugger(flags) && info.NextContinuation != null)
+                    if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
-                        Task.TryAddRuntimeAsyncContinuationChainTimestamps(info.NextContinuation, curContinuation);
-                    }
+                        if (info.NextContinuation != null)
+                        {
+                            Task.TryAddRuntimeAsyncContinuationChainTimestamps(info.NextContinuation, curContinuation);
+                        }
 
-                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
-                    {
                         TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
                     }
                 }
@@ -1065,13 +1061,9 @@ namespace System.Runtime.CompilerServices
             {
                 if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(flags))
                 {
-                    if (AsyncInstrumentation.IsEnabled.Debugger(flags))
+                    if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
                         Task.ReplaceOrAddRuntimeAsyncContinuationTimestamp(curContinuation, newContinuation);
-                    }
-
-                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
-                    {
                         TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
                     }
                 }
@@ -1082,9 +1074,9 @@ namespace System.Runtime.CompilerServices
             {
                 if (AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
                 {
-                    if (AsyncInstrumentation.IsEnabled.DebuggerOrTpl(flags))
+                    if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
-                        CompleteRuntimeAsyncContext(info.CurrentTask, flags);
+                        CompleteRuntimeAsyncContext(info.CurrentTask);
                     }
                 }
             }
@@ -1093,9 +1085,9 @@ namespace System.Runtime.CompilerServices
             {
                 if (AsyncInstrumentation.IsEnabled.UnwindAsyncException(flags))
                 {
-                    if (AsyncInstrumentation.IsEnabled.DebuggerOrTpl(flags))
+                    if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
-                        UnwindRuntimeAsyncMethodUnhandledException(info.CurrentTask, flags, ex, curContinuation, unwindedFrames);
+                        UnwindRuntimeAsyncMethodUnhandledException(info.CurrentTask, ex, curContinuation, unwindedFrames);
                     }
                 }
             }
@@ -1104,7 +1096,7 @@ namespace System.Runtime.CompilerServices
             {
                 if (AsyncInstrumentation.IsEnabled.UnwindAsyncException(flags))
                 {
-                    if (AsyncInstrumentation.IsEnabled.Debugger(flags))
+                    if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
                         Task.RemoveRuntimeAsyncContinuationChainTimestamps(curContinuation, unwindedFrames);
                     }
@@ -1116,7 +1108,7 @@ namespace System.Runtime.CompilerServices
             {
                 if (AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
                 {
-                    if (AsyncInstrumentation.IsEnabled.Debugger(flags) && info.CurrentTask != null)
+                    if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags) && info.CurrentTask != null)
                     {
                         Task.UpdateRuntimeAsyncTaskTimestamp(info.CurrentTask, curContinuation);
                     }
@@ -1128,44 +1120,30 @@ namespace System.Runtime.CompilerServices
             {
                 if (AsyncInstrumentation.IsEnabled.CompleteAsyncMethod(flags))
                 {
-                    if (AsyncInstrumentation.IsEnabled.Debugger(flags))
+                    if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
                         Task.RemoveRuntimeAsyncContinuationTimestamp(curContinuation);
                     }
                 }
             }
 
-            private static void CompleteRuntimeAsyncContext(Task? task, AsyncInstrumentation.Flags flags)
+            private static void CompleteRuntimeAsyncContext(Task? task)
             {
                 if (task != null)
                 {
-                    if (AsyncInstrumentation.IsEnabled.Debugger(flags))
-                    {
-                        Task.RemoveRuntimeAsyncTask(task);
-                    }
-
-                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
-                    {
-                        TplEventSource.Log.TraceOperationEnd(task.Id, AsyncCausalityStatus.Completed);
-                        TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
-                    }
+                    Task.RemoveRuntimeAsyncTask(task);
+                    TplEventSource.Log.TraceOperationEnd(task.Id, AsyncCausalityStatus.Completed);
+                    TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
                 }
             }
 
-            private static void UnwindRuntimeAsyncMethodUnhandledException(Task? task, AsyncInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint _)
+            private static void UnwindRuntimeAsyncMethodUnhandledException(Task? task, Exception ex, Continuation curContinuation, uint _)
             {
                 if (task != null)
                 {
-                    if (AsyncInstrumentation.IsEnabled.Debugger(flags))
-                    {
-                        Task.RemoveRuntimeAsyncTask(task, curContinuation);
-                    }
-
-                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
-                    {
-                        TplEventSource.Log.TraceOperationEnd(task.Id, ex is OperationCanceledException ? AsyncCausalityStatus.Canceled : AsyncCausalityStatus.Error);
-                        TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
-                    }
+                    Task.RemoveRuntimeAsyncTask(task, curContinuation);
+                    TplEventSource.Log.TraceOperationEnd(task.Id, ex is OperationCanceledException ? AsyncCausalityStatus.Canceled : AsyncCausalityStatus.Error);
+                    TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
                 }
             }
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -998,7 +998,7 @@ namespace System.Runtime.CompilerServices
         }
 
         // Instrumentation helpers called from InstrumentedDispatchContinuations.
-        // These methods must not throw — exceptions would break the dispatch loop.
+        // These methods must not throw - exceptions would break the dispatch loop.
         internal static class RuntimeAsyncInstrumentationHelpers
         {
             public static bool InstrumentCheckPoint
@@ -1105,7 +1105,7 @@ namespace System.Runtime.CompilerServices
         }
 
         // All methods in this class guard against exceptions to protect the instrumented async execution.
-        // Instrumentation failures are silently swallowed — correctness of async execution takes priority over debugger diagnostics.
+        // Instrumentation failures are silently swallowed - correctness of async execution takes priority over debugger diagnostics.
         internal static class AsyncDebugger
         {
             public static void CreateAsyncContext(Task task)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -664,109 +664,6 @@ namespace System.Runtime.CompilerServices
             }
 
             [StackTraceHidden]
-            private unsafe void InstrumentedDispatchContinuations()
-            {
-                ExecutionAndSyncBlockStore contexts = default;
-                contexts.Push();
-
-                AsyncDispatcherInfo asyncDispatcherInfo;
-                asyncDispatcherInfo.Next = AsyncDispatcherInfo.t_current;
-                asyncDispatcherInfo.NextContinuation = MoveContinuationState();
-                AsyncDispatcherInfo.t_current = &asyncDispatcherInfo;
-
-                AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
-                AsyncInstrumentationHelper.ResumeRuntimeAsyncContext(this, ref asyncDispatcherInfo, flags);
-
-                while (true)
-                {
-                    Debug.Assert(asyncDispatcherInfo.NextContinuation != null);
-                    Continuation curContinuation = asyncDispatcherInfo.NextContinuation;
-                    try
-                    {
-                        Continuation? nextContinuation = curContinuation.Next;
-                        asyncDispatcherInfo.NextContinuation = nextContinuation;
-
-                        ref byte resultLoc = ref nextContinuation != null ? ref nextContinuation.GetResultStorageOrNull() : ref GetResultStorage();
-
-                        AsyncInstrumentationHelper.ResumeRuntimeAsyncMethod(ref asyncDispatcherInfo, flags, curContinuation);
-                        Continuation? newContinuation = curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
-
-                        if (newContinuation != null)
-                        {
-                            newContinuation.Next = nextContinuation;
-                            AsyncInstrumentationHelper.SuspendRuntimeAsyncContext(flags, curContinuation, newContinuation);
-                            AsyncInstrumentationHelper.HandleSuspended(this, flags, newContinuation);
-
-                            contexts.Pop();
-                            AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
-                            return;
-                        }
-
-                        AsyncInstrumentationHelper.CompleteRuntimeAsyncMethod(flags, curContinuation);
-                    }
-                    catch (Exception ex)
-                    {
-                        uint unwindedFrames = 1; // Count current frame.
-                        Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex, ref unwindedFrames);
-                        if (handlerContinuation == null)
-                        {
-                            AsyncInstrumentationHelper.UnwindRuntimeAsyncMethodUnhandledException(ref asyncDispatcherInfo, flags, ex, curContinuation, unwindedFrames);
-
-                            // Tail of AsyncTaskMethodBuilderT.SetException
-                            bool successfullySet = ex is OperationCanceledException oce ?
-                                TrySetCanceled(oce.CancellationToken, oce) :
-                                TrySetException(ex);
-
-                            contexts.Pop();
-
-                            AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
-
-                            if (!successfullySet)
-                            {
-                                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
-                            }
-
-                            return;
-                        }
-
-                        AsyncInstrumentationHelper.UnwindRuntimeAsyncMethodHandledException(flags, curContinuation, unwindedFrames);
-
-                        handlerContinuation.SetException(ex);
-                        asyncDispatcherInfo.NextContinuation = handlerContinuation;
-                    }
-
-                    if (asyncDispatcherInfo.NextContinuation == null)
-                    {
-                        AsyncInstrumentationHelper.CompleteRuntimeAsyncContext(ref asyncDispatcherInfo, flags);
-
-                        bool successfullySet = TrySetResult(m_result);
-
-                        contexts.Pop();
-
-                        AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
-
-                        if (!successfullySet)
-                        {
-                            ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
-                        }
-
-                        return;
-                    }
-
-                    if (QueueContinuationFollowUpActionIfNecessary(asyncDispatcherInfo.NextContinuation))
-                    {
-                        AsyncInstrumentationHelper.SuspendRuntimeAsyncContext(ref asyncDispatcherInfo, flags, curContinuation);
-
-                        contexts.Pop();
-                        AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
-                        return;
-                    }
-
-                    flags = AsyncInstrumentation.ActiveFlags;
-                }
-            }
-
-            [StackTraceHidden]
             // NOTE, any changes done to this method needs to be replicate in InstrumentedDispatchContinuations as well.
             private unsafe void DispatchContinuations()
             {
@@ -867,6 +764,109 @@ namespace System.Runtime.CompilerServices
                         InstrumentedDispatchContinuations();
                         return;
                     }
+                }
+            }
+
+            [StackTraceHidden]
+            private unsafe void InstrumentedDispatchContinuations()
+            {
+                ExecutionAndSyncBlockStore contexts = default;
+                contexts.Push();
+
+                AsyncDispatcherInfo asyncDispatcherInfo;
+                asyncDispatcherInfo.Next = AsyncDispatcherInfo.t_current;
+                asyncDispatcherInfo.NextContinuation = MoveContinuationState();
+                AsyncDispatcherInfo.t_current = &asyncDispatcherInfo;
+
+                AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
+                AsyncInstrumentationHelper.ResumeRuntimeAsyncContext(this, ref asyncDispatcherInfo, flags);
+
+                while (true)
+                {
+                    Debug.Assert(asyncDispatcherInfo.NextContinuation != null);
+                    Continuation curContinuation = asyncDispatcherInfo.NextContinuation;
+                    try
+                    {
+                        Continuation? nextContinuation = curContinuation.Next;
+                        asyncDispatcherInfo.NextContinuation = nextContinuation;
+
+                        ref byte resultLoc = ref nextContinuation != null ? ref nextContinuation.GetResultStorageOrNull() : ref GetResultStorage();
+
+                        AsyncInstrumentationHelper.ResumeRuntimeAsyncMethod(ref asyncDispatcherInfo, flags, curContinuation);
+                        Continuation? newContinuation = curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
+
+                        if (newContinuation != null)
+                        {
+                            newContinuation.Next = nextContinuation;
+                            AsyncInstrumentationHelper.SuspendRuntimeAsyncContext(flags, curContinuation, newContinuation);
+                            AsyncInstrumentationHelper.HandleSuspended(this, flags, newContinuation);
+
+                            contexts.Pop();
+                            AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
+                            return;
+                        }
+
+                        AsyncInstrumentationHelper.CompleteRuntimeAsyncMethod(flags, curContinuation);
+                    }
+                    catch (Exception ex)
+                    {
+                        uint unwindedFrames = 1; // Count current frame.
+                        Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex, ref unwindedFrames);
+                        if (handlerContinuation == null)
+                        {
+                            AsyncInstrumentationHelper.UnwindRuntimeAsyncMethodUnhandledException(ref asyncDispatcherInfo, flags, ex, curContinuation, unwindedFrames);
+
+                            // Tail of AsyncTaskMethodBuilderT.SetException
+                            bool successfullySet = ex is OperationCanceledException oce ?
+                                TrySetCanceled(oce.CancellationToken, oce) :
+                                TrySetException(ex);
+
+                            contexts.Pop();
+
+                            AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
+
+                            if (!successfullySet)
+                            {
+                                ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
+                            }
+
+                            return;
+                        }
+
+                        AsyncInstrumentationHelper.UnwindRuntimeAsyncMethodHandledException(flags, curContinuation, unwindedFrames);
+
+                        handlerContinuation.SetException(ex);
+                        asyncDispatcherInfo.NextContinuation = handlerContinuation;
+                    }
+
+                    if (asyncDispatcherInfo.NextContinuation == null)
+                    {
+                        AsyncInstrumentationHelper.CompleteRuntimeAsyncContext(ref asyncDispatcherInfo, flags);
+
+                        bool successfullySet = TrySetResult(m_result);
+
+                        contexts.Pop();
+
+                        AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
+
+                        if (!successfullySet)
+                        {
+                            ThrowHelper.ThrowInvalidOperationException(ExceptionResource.TaskT_TransitionToFinal_AlreadyCompleted);
+                        }
+
+                        return;
+                    }
+
+                    if (QueueContinuationFollowUpActionIfNecessary(asyncDispatcherInfo.NextContinuation))
+                    {
+                        AsyncInstrumentationHelper.SuspendRuntimeAsyncContext(ref asyncDispatcherInfo, flags, curContinuation);
+
+                        contexts.Pop();
+                        AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
+                        return;
+                    }
+
+                    flags = AsyncInstrumentation.ActiveFlags;
                 }
             }
 

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -456,42 +456,23 @@ namespace System.Runtime.CompilerServices
                 return false;
             }
 
-            internal bool InstrumentedHandleSuspended(AsyncInstrumentation.Flags flags, Continuation? newContinuation = null)
+            internal void InstrumentedHandleSuspended(AsyncInstrumentation.Flags flags, Continuation? newContinuation = null)
             {
                 if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                 {
-                    Continuation? nc = t_runtimeAsyncAwaitState.SentinelContinuation!.Next;
+                    Continuation? nextContinuation = t_runtimeAsyncAwaitState.SentinelContinuation!.Next;
 
-                    if (nc != null)
-                    {
-                        if (newContinuation != null)
-                        {
-                            TryAddRuntimeAsyncContinuationChainTimestamps(nc, newContinuation);
-                        }
-                        else
-                        {
-                            TryAddRuntimeAsyncContinuationChainTimestamps(nc);
-                        }
-                    }
+                    AsyncDebugger.HandleSuspended(nextContinuation, newContinuation);
 
                     if (!HandleSuspended())
                     {
-                        if (nc != null)
-                        {
-                            RemoveRuntimeAsyncTask(this, nc);
-                        }
-                        else
-                        {
-                            RemoveRuntimeAsyncTask(this);
-                        }
-
-                        return false;
+                        AsyncDebugger.HandleSuspendedFailed(this, nextContinuation);
                     }
 
-                    return true;
+                    return;
                 }
 
-                return HandleSuspended();
+                HandleSuspended();
             }
 
 #pragma warning disable CA1822 // Mark members as static
@@ -817,8 +798,7 @@ namespace System.Runtime.CompilerServices
                 if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                 {
                     task.NotifyDebuggerOfRuntimeAsyncState();
-                    Task.AddToActiveTasks(task);
-                    TplEventSource.Log.TraceOperationBegin(task.Id, "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask", 0);
+                    AsyncDebugger.CreateAsyncContext(task);
                 }
             }
 
@@ -1017,6 +997,8 @@ namespace System.Runtime.CompilerServices
             TaskAwaiter.ValidateEnd(task);
         }
 
+        // Instrumentation helpers called from InstrumentedDispatchContinuations.
+        // These methods must not throw — exceptions would break the dispatch loop.
         internal static class RuntimeAsyncInstrumentationHelpers
         {
             public static bool InstrumentCheckPoint
@@ -1034,7 +1016,7 @@ namespace System.Runtime.CompilerServices
                 {
                     if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
-                        TplEventSource.Log.TraceSynchronousWorkBegin(task.Id, CausalitySynchronousWork.Execution);
+                        AsyncDebugger.ResumeAsyncContext(task.Id);
                     }
                 }
             }
@@ -1046,12 +1028,7 @@ namespace System.Runtime.CompilerServices
                 {
                     if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
-                        if (info.NextContinuation != null)
-                        {
-                            Task.TryAddRuntimeAsyncContinuationChainTimestamps(info.NextContinuation, curContinuation);
-                        }
-
-                        TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                        AsyncDebugger.SuspendAsyncContext(ref info, curContinuation);
                     }
                 }
             }
@@ -1063,8 +1040,7 @@ namespace System.Runtime.CompilerServices
                 {
                     if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
-                        Task.ReplaceOrAddRuntimeAsyncContinuationTimestamp(curContinuation, newContinuation);
-                        TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                        AsyncDebugger.SuspendAsyncContext(curContinuation, newContinuation);
                     }
                 }
             }
@@ -1076,18 +1052,18 @@ namespace System.Runtime.CompilerServices
                 {
                     if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
-                        CompleteRuntimeAsyncContext(info.CurrentTask);
+                        AsyncDebugger.CompleteAsyncContext(info.CurrentTask);
                     }
                 }
             }
 
-            public static void UnwindRuntimeAsyncMethodUnhandledException(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames)
+            public static void UnwindRuntimeAsyncMethodUnhandledException(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint _)
             {
                 if (AsyncInstrumentation.IsEnabled.UnwindAsyncException(flags))
                 {
                     if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
-                        UnwindRuntimeAsyncMethodUnhandledException(info.CurrentTask, ex, curContinuation, unwindedFrames);
+                        AsyncDebugger.AsyncMethodUnhandledException(info.CurrentTask, ex, curContinuation);
                     }
                 }
             }
@@ -1098,7 +1074,7 @@ namespace System.Runtime.CompilerServices
                 {
                     if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
-                        Task.RemoveRuntimeAsyncContinuationChainTimestamps(curContinuation, unwindedFrames);
+                        AsyncDebugger.AsyncMethodHandledException(curContinuation, unwindedFrames);
                     }
                 }
             }
@@ -1108,9 +1084,9 @@ namespace System.Runtime.CompilerServices
             {
                 if (AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
                 {
-                    if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags) && info.CurrentTask != null)
+                    if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
-                        Task.UpdateRuntimeAsyncTaskTimestamp(info.CurrentTask, curContinuation);
+                        AsyncDebugger.ResumeAsyncMethod(ref info, curContinuation);
                     }
                 }
             }
@@ -1122,28 +1098,172 @@ namespace System.Runtime.CompilerServices
                 {
                     if (AsyncInstrumentation.IsEnabled.AsyncDebugger(flags))
                     {
-                        Task.RemoveRuntimeAsyncContinuationTimestamp(curContinuation);
+                        AsyncDebugger.CompleteAsyncMethod(curContinuation);
                     }
                 }
             }
+        }
 
-            private static void CompleteRuntimeAsyncContext(Task? task)
+        // All methods in this class guard against exceptions to protect the instrumented async execution.
+        // Instrumentation failures are silently swallowed — correctness of async execution takes priority over debugger diagnostics.
+        internal static class AsyncDebugger
+        {
+            public static void CreateAsyncContext(Task task)
             {
-                if (task != null)
+                try
                 {
-                    Task.RemoveRuntimeAsyncTask(task);
-                    TplEventSource.Log.TraceOperationEnd(task.Id, AsyncCausalityStatus.Completed);
-                    TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                    Task.AddToActiveTasks(task);
+                    TplEventSource.Log.TraceOperationBegin(task.Id, "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask", 0);
+                }
+                catch
+                {
+                }
+
+            }
+
+            public static void ResumeAsyncContext(int id)
+            {
+                try
+                {
+                    TplEventSource.Log.TraceSynchronousWorkBegin(id, CausalitySynchronousWork.Execution);
+                }
+                catch
+                {
                 }
             }
 
-            private static void UnwindRuntimeAsyncMethodUnhandledException(Task? task, Exception ex, Continuation curContinuation, uint _)
+            public static void SuspendAsyncContext(ref AsyncDispatcherInfo info, Continuation curContinuation)
             {
-                if (task != null)
+                try
                 {
-                    Task.RemoveRuntimeAsyncTask(task, curContinuation);
-                    TplEventSource.Log.TraceOperationEnd(task.Id, ex is OperationCanceledException ? AsyncCausalityStatus.Canceled : AsyncCausalityStatus.Error);
+                    if (info.NextContinuation != null)
+                    {
+                        Task.TryAddRuntimeAsyncContinuationChainTimestamps(info.NextContinuation, curContinuation);
+                    }
+
                     TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                }
+                catch
+                {
+                }
+            }
+
+            public static void SuspendAsyncContext(Continuation curContinuation, Continuation newContinuation)
+            {
+                try
+                {
+                    Task.ReplaceOrAddRuntimeAsyncContinuationTimestamp(curContinuation, newContinuation);
+                    TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                }
+                catch
+                {
+                }
+            }
+
+            public static void CompleteAsyncContext(Task? task)
+            {
+                try
+                {
+                    if (task != null)
+                    {
+                        Task.RemoveRuntimeAsyncTask(task);
+                        TplEventSource.Log.TraceOperationEnd(task.Id, AsyncCausalityStatus.Completed);
+                        TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            public static void AsyncMethodUnhandledException(Task? task, Exception ex, Continuation curContinuation)
+            {
+                try
+                {
+                    if (task != null)
+                    {
+                        Task.RemoveRuntimeAsyncTask(task, curContinuation);
+                        TplEventSource.Log.TraceOperationEnd(task.Id, ex is OperationCanceledException ? AsyncCausalityStatus.Canceled : AsyncCausalityStatus.Error);
+                        TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            public static void AsyncMethodHandledException(Continuation curContinuation, uint unwindedFrames)
+            {
+                try
+                {
+                    Task.RemoveRuntimeAsyncContinuationChainTimestamps(curContinuation, unwindedFrames);
+                }
+                catch
+                {
+                }
+            }
+
+            public static void ResumeAsyncMethod(ref AsyncDispatcherInfo info, Continuation curContinuation)
+            {
+                try
+                {
+                    if (info.CurrentTask != null)
+                    {
+                        Task.UpdateRuntimeAsyncTaskTimestamp(info.CurrentTask, curContinuation);
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            public static void CompleteAsyncMethod(Continuation curContinuation)
+            {
+                try
+                {
+                    Task.RemoveRuntimeAsyncContinuationTimestamp(curContinuation);
+                }
+                catch
+                {
+                }
+            }
+
+            public static void HandleSuspended(Continuation? nextContinuation, Continuation? newContinuation)
+            {
+                try
+                {
+                    if (nextContinuation != null)
+                    {
+                        if (newContinuation != null)
+                        {
+                            Task.TryAddRuntimeAsyncContinuationChainTimestamps(nextContinuation, newContinuation);
+                        }
+                        else
+                        {
+                            Task.TryAddRuntimeAsyncContinuationChainTimestamps(nextContinuation);
+                        }
+                    }
+                }
+                catch
+                {
+                }
+            }
+
+            public static void HandleSuspendedFailed(Task task, Continuation? nextContinuation)
+            {
+                try
+                {
+                    if (nextContinuation != null)
+                    {
+                        Task.RemoveRuntimeAsyncTask(task, nextContinuation);
+                    }
+                    else
+                    {
+                        Task.RemoveRuntimeAsyncTask(task);
+                    }
+                }
+                catch
+                {
                 }
             }
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Diagnostics;
-using System.Diagnostics.Tracing;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -457,6 +456,44 @@ namespace System.Runtime.CompilerServices
                 return false;
             }
 
+            internal bool InstrumentedHandleSuspended(AsyncInstrumentation.Flags flags, Continuation? newContinuation = null)
+            {
+                if (AsyncInstrumentation.IsEnabled.Debugger(flags))
+                {
+                    Continuation? nc = t_runtimeAsyncAwaitState.SentinelContinuation!.Next;
+
+                    if (nc != null)
+                    {
+                        if (newContinuation != null)
+                        {
+                            TryAddRuntimeAsyncContinuationChainTimestamps(nc, newContinuation);
+                        }
+                        else
+                        {
+                            TryAddRuntimeAsyncContinuationChainTimestamps(nc);
+                        }
+                    }
+
+                    if (!HandleSuspended())
+                    {
+                        if (nc != null)
+                        {
+                            RemoveRuntimeAsyncTask(this, nc);
+                        }
+                        else
+                        {
+                            RemoveRuntimeAsyncTask(this);
+                        }
+
+                        return false;
+                    }
+
+                    return true;
+                }
+
+                return HandleSuspended();
+            }
+
 #pragma warning disable CA1822 // Mark members as static
             [MethodImpl(MethodImplOptions.NoOptimization)]
             public void NotifyDebuggerOfRuntimeAsyncState()
@@ -464,215 +501,11 @@ namespace System.Runtime.CompilerServices
             }
 #pragma warning restore CA1822
 
-            internal static class AsyncInstrumentationHelper
-            {
-                public static bool InstrumentCheckPoint
-                {
-                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                    get => AsyncInstrumentation.IsSupported && AsyncInstrumentation.ActiveFlags != AsyncInstrumentation.Flags.Disabled;
-                }
-
-                public static void CreateRuntimeAsyncContext(RuntimeAsyncTask<T> task, AsyncInstrumentation.Flags flags)
-                {
-                    if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags))
-                    {
-                        if (AsyncInstrumentation.IsEnabled.Debugger(flags))
-                        {
-                            task.NotifyDebuggerOfRuntimeAsyncState();
-                            AddToActiveTasks(task);
-                        }
-
-                        if (AsyncInstrumentation.IsEnabled.Tpl(flags))
-                        {
-                            TplEventSource.Log.TraceOperationBegin(task.Id, "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask", 0);
-                        }
-                    }
-                }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void ResumeRuntimeAsyncContext(RuntimeAsyncTask<T> task, ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags)
-                {
-                    info.CurrentTask = task;
-
-                    if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
-                    {
-                        if (AsyncInstrumentation.IsEnabled.Tpl(flags))
-                        {
-                            TplEventSource.Log.TraceSynchronousWorkBegin(task.Id, CausalitySynchronousWork.Execution);
-                        }
-                    }
-                }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void SuspendRuntimeAsyncContext(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags, Continuation curContinuation)
-                {
-                    if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(flags))
-                    {
-                        if (AsyncInstrumentation.IsEnabled.Debugger(flags) && info.NextContinuation != null)
-                        {
-                            TryAddRuntimeAsyncContinuationChainTimestamps(info.NextContinuation, curContinuation);
-                        }
-
-                        if (AsyncInstrumentation.IsEnabled.Tpl(flags))
-                        {
-                            TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
-                        }
-                    }
-                }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void SuspendRuntimeAsyncContext(AsyncInstrumentation.Flags flags, Continuation curContinuation, Continuation newContinuation)
-                {
-                    if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(flags))
-                    {
-                        if (AsyncInstrumentation.IsEnabled.Debugger(flags))
-                        {
-                            ReplaceOrAddRuntimeAsyncContinuationTimestamp(curContinuation, newContinuation);
-                        }
-
-                        if (AsyncInstrumentation.IsEnabled.Tpl(flags))
-                        {
-                            TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
-                        }
-                    }
-                }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void CompleteRuntimeAsyncContext(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags)
-                {
-                    if (AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
-                    {
-                        if (AsyncInstrumentation.IsEnabled.DebuggerOrTpl(flags))
-                        {
-                            CompleteRuntimeAsyncContext(info.CurrentTask, flags);
-                        }
-                    }
-                }
-
-                public static void UnwindRuntimeAsyncMethodUnhandledException(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames)
-                {
-                    if (AsyncInstrumentation.IsEnabled.UnwindAsyncException(flags))
-                    {
-                        if (AsyncInstrumentation.IsEnabled.DebuggerOrTpl(flags))
-                        {
-                            UnwindRuntimeAsyncMethodUnhandledException(info.CurrentTask, flags, ex, curContinuation, unwindedFrames);
-                        }
-                    }
-                }
-
-                public static void UnwindRuntimeAsyncMethodHandledException(AsyncInstrumentation.Flags flags, Continuation curContinuation, uint unwindedFrames)
-                {
-                    if (AsyncInstrumentation.IsEnabled.UnwindAsyncException(flags))
-                    {
-                        if (AsyncInstrumentation.IsEnabled.Debugger(flags))
-                        {
-                            RemoveRuntimeAsyncContinuationChainTimestamps(curContinuation, unwindedFrames);
-                        }
-                    }
-                }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void ResumeRuntimeAsyncMethod(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags, Continuation curContinuation)
-                {
-                    if (AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
-                    {
-                        if (AsyncInstrumentation.IsEnabled.Debugger(flags) && info.CurrentTask != null)
-                        {
-                            UpdateRuntimeAsyncTaskTimestamp(info.CurrentTask, curContinuation);
-                        }
-                    }
-                }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void CompleteRuntimeAsyncMethod(AsyncInstrumentation.Flags flags, Continuation curContinuation)
-                {
-                    if (AsyncInstrumentation.IsEnabled.CompleteAsyncMethod(flags))
-                    {
-                        if (AsyncInstrumentation.IsEnabled.Debugger(flags))
-                        {
-                            RemoveRuntimeAsyncContinuationTimestamp(curContinuation);
-                        }
-                    }
-                }
-
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                public static void HandleSuspended(RuntimeAsyncTask<T> task, AsyncInstrumentation.Flags flags, Continuation? newContinuation = null)
-                {
-                    if (AsyncInstrumentation.IsEnabled.Debugger(flags))
-                    {
-                        DebuggerHandleSuspended(task, newContinuation);
-                    }
-                    else
-                    {
-                        task.HandleSuspended();
-                    }
-                }
-
-                private static void CompleteRuntimeAsyncContext(Task? task, AsyncInstrumentation.Flags flags)
-                {
-                    if (task != null)
-                    {
-                        if (AsyncInstrumentation.IsEnabled.Debugger(flags))
-                        {
-                            RemoveRuntimeAsyncTask(task);
-                        }
-
-                        if (AsyncInstrumentation.IsEnabled.Tpl(flags))
-                        {
-                            TplEventSource.Log.TraceOperationEnd(task.Id, AsyncCausalityStatus.Completed);
-                            TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
-                        }
-                    }
-                }
-
-                private static void UnwindRuntimeAsyncMethodUnhandledException(Task? task, AsyncInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint _)
-                {
-                    if (task != null)
-                    {
-                        if (AsyncInstrumentation.IsEnabled.Debugger(flags))
-                        {
-                            RemoveRuntimeAsyncTask(task, curContinuation);
-                        }
-
-                        if (AsyncInstrumentation.IsEnabled.Tpl(flags))
-                        {
-                            TplEventSource.Log.TraceOperationEnd(task.Id, ex is OperationCanceledException ? AsyncCausalityStatus.Canceled : AsyncCausalityStatus.Error);
-                            TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
-                        }
-                    }
-                }
-
-                private static void DebuggerHandleSuspended(RuntimeAsyncTask<T> task, Continuation? newContinuation = null)
-                {
-                    Continuation? nc = t_runtimeAsyncAwaitState.SentinelContinuation!.Next;
-
-                    if (nc != null)
-                    {
-                        if (newContinuation != null)
-                            TryAddRuntimeAsyncContinuationChainTimestamps(nc, newContinuation);
-                        else
-                            TryAddRuntimeAsyncContinuationChainTimestamps(nc);
-                    }
-
-                    if (!task.HandleSuspended())
-                    {
-                        if (nc != null)
-                        {
-                            RemoveRuntimeAsyncTask(task, nc);
-                        }
-                        else
-                        {
-                            RemoveRuntimeAsyncTask(task);
-                        }
-                    }
-                }
-            }
-
             [StackTraceHidden]
             // NOTE, any changes done to this method need to be replicated in InstrumentedDispatchContinuations as well.
             private unsafe void DispatchContinuations()
             {
-                if (AsyncInstrumentationHelper.InstrumentCheckPoint)
+                if (RuntimeAsyncInstrumentationHelpers.InstrumentCheckPoint)
                 {
                     AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
                     if (flags != AsyncInstrumentation.Flags.Disabled)
@@ -763,7 +596,7 @@ namespace System.Runtime.CompilerServices
                         return;
                     }
 
-                    if (AsyncInstrumentationHelper.InstrumentCheckPoint)
+                    if (RuntimeAsyncInstrumentationHelpers.InstrumentCheckPoint)
                     {
                         SetContinuationState(asyncDispatcherInfo.NextContinuation);
 
@@ -787,7 +620,7 @@ namespace System.Runtime.CompilerServices
                 asyncDispatcherInfo.NextContinuation = MoveContinuationState();
                 AsyncDispatcherInfo.t_current = &asyncDispatcherInfo;
 
-                AsyncInstrumentationHelper.ResumeRuntimeAsyncContext(this, ref asyncDispatcherInfo, flags);
+                RuntimeAsyncInstrumentationHelpers.ResumeRuntimeAsyncContext(this, ref asyncDispatcherInfo, flags);
 
                 while (true)
                 {
@@ -800,21 +633,21 @@ namespace System.Runtime.CompilerServices
 
                         ref byte resultLoc = ref nextContinuation != null ? ref nextContinuation.GetResultStorageOrNull() : ref GetResultStorage();
 
-                        AsyncInstrumentationHelper.ResumeRuntimeAsyncMethod(ref asyncDispatcherInfo, flags, curContinuation);
+                        RuntimeAsyncInstrumentationHelpers.ResumeRuntimeAsyncMethod(ref asyncDispatcherInfo, flags, curContinuation);
                         Continuation? newContinuation = curContinuation.ResumeInfo->Resume(curContinuation, ref resultLoc);
 
                         if (newContinuation != null)
                         {
                             newContinuation.Next = nextContinuation;
-                            AsyncInstrumentationHelper.SuspendRuntimeAsyncContext(flags, curContinuation, newContinuation);
-                            AsyncInstrumentationHelper.HandleSuspended(this, flags, newContinuation);
+                            RuntimeAsyncInstrumentationHelpers.SuspendRuntimeAsyncContext(flags, curContinuation, newContinuation);
+                            InstrumentedHandleSuspended(flags, newContinuation);
 
                             contexts.Pop();
                             AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
                             return;
                         }
 
-                        AsyncInstrumentationHelper.CompleteRuntimeAsyncMethod(flags, curContinuation);
+                        RuntimeAsyncInstrumentationHelpers.CompleteRuntimeAsyncMethod(flags, curContinuation);
                     }
                     catch (Exception ex)
                     {
@@ -822,7 +655,7 @@ namespace System.Runtime.CompilerServices
                         Continuation? handlerContinuation = UnwindToPossibleHandler(asyncDispatcherInfo.NextContinuation, ex, ref unwindedFrames);
                         if (handlerContinuation == null)
                         {
-                            AsyncInstrumentationHelper.UnwindRuntimeAsyncMethodUnhandledException(ref asyncDispatcherInfo, flags, ex, curContinuation, unwindedFrames);
+                            RuntimeAsyncInstrumentationHelpers.UnwindRuntimeAsyncMethodUnhandledException(ref asyncDispatcherInfo, flags, ex, curContinuation, unwindedFrames);
 
                             // Tail of AsyncTaskMethodBuilderT.SetException
                             bool successfullySet = ex is OperationCanceledException oce ?
@@ -841,7 +674,7 @@ namespace System.Runtime.CompilerServices
                             return;
                         }
 
-                        AsyncInstrumentationHelper.UnwindRuntimeAsyncMethodHandledException(flags, curContinuation, unwindedFrames);
+                        RuntimeAsyncInstrumentationHelpers.UnwindRuntimeAsyncMethodHandledException(flags, curContinuation, unwindedFrames);
 
                         handlerContinuation.SetException(ex);
                         asyncDispatcherInfo.NextContinuation = handlerContinuation;
@@ -849,7 +682,7 @@ namespace System.Runtime.CompilerServices
 
                     if (asyncDispatcherInfo.NextContinuation == null)
                     {
-                        AsyncInstrumentationHelper.CompleteRuntimeAsyncContext(ref asyncDispatcherInfo, flags);
+                        RuntimeAsyncInstrumentationHelpers.CompleteRuntimeAsyncContext(ref asyncDispatcherInfo, flags);
 
                         bool successfullySet = TrySetResult(m_result);
 
@@ -867,7 +700,7 @@ namespace System.Runtime.CompilerServices
 
                     if (QueueContinuationFollowUpActionIfNecessary(asyncDispatcherInfo.NextContinuation))
                     {
-                        AsyncInstrumentationHelper.SuspendRuntimeAsyncContext(ref asyncDispatcherInfo, flags, curContinuation);
+                        RuntimeAsyncInstrumentationHelpers.SuspendRuntimeAsyncContext(ref asyncDispatcherInfo, flags, curContinuation);
 
                         contexts.Pop();
                         AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
@@ -977,16 +810,35 @@ namespace System.Runtime.CompilerServices
             };
         }
 
+        private static void InstrumentedFinalizeRuntimeAsyncTask<T>(RuntimeAsyncTask<T> task, AsyncInstrumentation.Flags flags)
+        {
+            if (AsyncInstrumentation.IsEnabled.CreateAsyncContext(flags))
+            {
+                if (AsyncInstrumentation.IsEnabled.Debugger(flags))
+                {
+                    task.NotifyDebuggerOfRuntimeAsyncState();
+                    Task.AddToActiveTasks(task);
+                }
+
+                if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                {
+                    TplEventSource.Log.TraceOperationBegin(task.Id, "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask", 0);
+                }
+            }
+
+            task.InstrumentedHandleSuspended(flags);
+            return;
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void FinalizeRuntimeAsyncTask<T>(RuntimeAsyncTask<T> task)
         {
-            if (RuntimeAsyncTask<T>.AsyncInstrumentationHelper.InstrumentCheckPoint)
+            if (RuntimeAsyncInstrumentationHelpers.InstrumentCheckPoint)
             {
                 AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
                 if (flags != AsyncInstrumentation.Flags.Disabled)
                 {
-                    RuntimeAsyncTask<T>.AsyncInstrumentationHelper.CreateRuntimeAsyncContext(task, flags);
-                    RuntimeAsyncTask<T>.AsyncInstrumentationHelper.HandleSuspended(task, flags);
+                    InstrumentedFinalizeRuntimeAsyncTask(task, flags);
                     return;
                 }
             }
@@ -1167,6 +1019,155 @@ namespace System.Runtime.CompilerServices
         internal static void CompletedTask(Task task)
         {
             TaskAwaiter.ValidateEnd(task);
+        }
+
+        internal static class RuntimeAsyncInstrumentationHelpers
+        {
+            public static bool InstrumentCheckPoint
+            {
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                get => AsyncInstrumentation.IsSupported && AsyncInstrumentation.ActiveFlags != AsyncInstrumentation.Flags.Disabled;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void ResumeRuntimeAsyncContext(Task task, ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags)
+            {
+                info.CurrentTask = task;
+
+                if (AsyncInstrumentation.IsEnabled.ResumeAsyncContext(flags))
+                {
+                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                    {
+                        TplEventSource.Log.TraceSynchronousWorkBegin(task.Id, CausalitySynchronousWork.Execution);
+                    }
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void SuspendRuntimeAsyncContext(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags, Continuation curContinuation)
+            {
+                if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(flags))
+                {
+                    if (AsyncInstrumentation.IsEnabled.Debugger(flags) && info.NextContinuation != null)
+                    {
+                        Task.TryAddRuntimeAsyncContinuationChainTimestamps(info.NextContinuation, curContinuation);
+                    }
+
+                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                    {
+                        TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                    }
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void SuspendRuntimeAsyncContext(AsyncInstrumentation.Flags flags, Continuation curContinuation, Continuation newContinuation)
+            {
+                if (AsyncInstrumentation.IsEnabled.SuspendAsyncContext(flags))
+                {
+                    if (AsyncInstrumentation.IsEnabled.Debugger(flags))
+                    {
+                        Task.ReplaceOrAddRuntimeAsyncContinuationTimestamp(curContinuation, newContinuation);
+                    }
+
+                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                    {
+                        TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                    }
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void CompleteRuntimeAsyncContext(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags)
+            {
+                if (AsyncInstrumentation.IsEnabled.CompleteAsyncContext(flags))
+                {
+                    if (AsyncInstrumentation.IsEnabled.DebuggerOrTpl(flags))
+                    {
+                        CompleteRuntimeAsyncContext(info.CurrentTask, flags);
+                    }
+                }
+            }
+
+            public static void UnwindRuntimeAsyncMethodUnhandledException(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint unwindedFrames)
+            {
+                if (AsyncInstrumentation.IsEnabled.UnwindAsyncException(flags))
+                {
+                    if (AsyncInstrumentation.IsEnabled.DebuggerOrTpl(flags))
+                    {
+                        UnwindRuntimeAsyncMethodUnhandledException(info.CurrentTask, flags, ex, curContinuation, unwindedFrames);
+                    }
+                }
+            }
+
+            public static void UnwindRuntimeAsyncMethodHandledException(AsyncInstrumentation.Flags flags, Continuation curContinuation, uint unwindedFrames)
+            {
+                if (AsyncInstrumentation.IsEnabled.UnwindAsyncException(flags))
+                {
+                    if (AsyncInstrumentation.IsEnabled.Debugger(flags))
+                    {
+                        Task.RemoveRuntimeAsyncContinuationChainTimestamps(curContinuation, unwindedFrames);
+                    }
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void ResumeRuntimeAsyncMethod(ref AsyncDispatcherInfo info, AsyncInstrumentation.Flags flags, Continuation curContinuation)
+            {
+                if (AsyncInstrumentation.IsEnabled.ResumeAsyncMethod(flags))
+                {
+                    if (AsyncInstrumentation.IsEnabled.Debugger(flags) && info.CurrentTask != null)
+                    {
+                        Task.UpdateRuntimeAsyncTaskTimestamp(info.CurrentTask, curContinuation);
+                    }
+                }
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static void CompleteRuntimeAsyncMethod(AsyncInstrumentation.Flags flags, Continuation curContinuation)
+            {
+                if (AsyncInstrumentation.IsEnabled.CompleteAsyncMethod(flags))
+                {
+                    if (AsyncInstrumentation.IsEnabled.Debugger(flags))
+                    {
+                        Task.RemoveRuntimeAsyncContinuationTimestamp(curContinuation);
+                    }
+                }
+            }
+
+            private static void CompleteRuntimeAsyncContext(Task? task, AsyncInstrumentation.Flags flags)
+            {
+                if (task != null)
+                {
+                    if (AsyncInstrumentation.IsEnabled.Debugger(flags))
+                    {
+                        Task.RemoveRuntimeAsyncTask(task);
+                    }
+
+                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                    {
+                        TplEventSource.Log.TraceOperationEnd(task.Id, AsyncCausalityStatus.Completed);
+                        TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                    }
+                }
+            }
+
+            private static void UnwindRuntimeAsyncMethodUnhandledException(Task? task, AsyncInstrumentation.Flags flags, Exception ex, Continuation curContinuation, uint _)
+            {
+                if (task != null)
+                {
+                    if (AsyncInstrumentation.IsEnabled.Debugger(flags))
+                    {
+                        Task.RemoveRuntimeAsyncTask(task, curContinuation);
+                    }
+
+                    if (AsyncInstrumentation.IsEnabled.Tpl(flags))
+                    {
+                        TplEventSource.Log.TraceOperationEnd(task.Id, ex is OperationCanceledException ? AsyncCausalityStatus.Canceled : AsyncCausalityStatus.Error);
+                        TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -998,7 +998,7 @@ namespace System.Runtime.CompilerServices
         }
 
         // Instrumentation helpers called from InstrumentedDispatchContinuations.
-        // These methods must not throw - exceptions would break the dispatch loop.
+        // These methods should not throw - exceptions would break the dispatch loop.
         internal static class RuntimeAsyncInstrumentationHelpers
         {
             public static bool InstrumentCheckPoint
@@ -1104,166 +1104,97 @@ namespace System.Runtime.CompilerServices
             }
         }
 
-        // All methods in this class guard against exceptions to protect the instrumented async execution.
-        // Instrumentation failures are silently swallowed - correctness of async execution takes priority over debugger diagnostics.
         internal static class AsyncDebugger
         {
             public static void CreateAsyncContext(Task task)
             {
-                try
-                {
-                    Task.AddToActiveTasks(task);
-                    TplEventSource.Log.TraceOperationBegin(task.Id, "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask", 0);
-                }
-                catch
-                {
-                }
-
+                Task.AddToActiveTasks(task);
+                TplEventSource.Log.TraceOperationBegin(task.Id, "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask", 0);
             }
 
             public static void ResumeAsyncContext(int id)
             {
-                try
-                {
-                    TplEventSource.Log.TraceSynchronousWorkBegin(id, CausalitySynchronousWork.Execution);
-                }
-                catch
-                {
-                }
+                TplEventSource.Log.TraceSynchronousWorkBegin(id, CausalitySynchronousWork.Execution);
             }
 
             public static void SuspendAsyncContext(ref AsyncDispatcherInfo info, Continuation curContinuation)
             {
-                try
+                if (info.NextContinuation != null)
                 {
-                    if (info.NextContinuation != null)
-                    {
-                        Task.TryAddRuntimeAsyncContinuationChainTimestamps(info.NextContinuation, curContinuation);
-                    }
+                    Task.TryAddRuntimeAsyncContinuationChainTimestamps(info.NextContinuation, curContinuation);
+                }
 
-                    TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
-                }
-                catch
-                {
-                }
+                TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
             }
 
             public static void SuspendAsyncContext(Continuation curContinuation, Continuation newContinuation)
             {
-                try
-                {
-                    Task.ReplaceOrAddRuntimeAsyncContinuationTimestamp(curContinuation, newContinuation);
-                    TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
-                }
-                catch
-                {
-                }
+                Task.ReplaceOrAddRuntimeAsyncContinuationTimestamp(curContinuation, newContinuation);
+                TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
             }
 
             public static void CompleteAsyncContext(Task? task)
             {
-                try
+                if (task != null)
                 {
-                    if (task != null)
-                    {
-                        Task.RemoveRuntimeAsyncTask(task);
-                        TplEventSource.Log.TraceOperationEnd(task.Id, AsyncCausalityStatus.Completed);
-                        TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
-                    }
-                }
-                catch
-                {
+                    Task.RemoveRuntimeAsyncTask(task);
+                    TplEventSource.Log.TraceOperationEnd(task.Id, AsyncCausalityStatus.Completed);
+                    TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
                 }
             }
 
             public static void AsyncMethodUnhandledException(Task? task, Exception ex, Continuation curContinuation)
             {
-                try
+                if (task != null)
                 {
-                    if (task != null)
-                    {
-                        Task.RemoveRuntimeAsyncTask(task, curContinuation);
-                        TplEventSource.Log.TraceOperationEnd(task.Id, ex is OperationCanceledException ? AsyncCausalityStatus.Canceled : AsyncCausalityStatus.Error);
-                        TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
-                    }
-                }
-                catch
-                {
+                    Task.RemoveRuntimeAsyncTask(task, curContinuation);
+                    TplEventSource.Log.TraceOperationEnd(task.Id, ex is OperationCanceledException ? AsyncCausalityStatus.Canceled : AsyncCausalityStatus.Error);
+                    TplEventSource.Log.TraceSynchronousWorkEnd(CausalitySynchronousWork.Execution);
                 }
             }
 
             public static void AsyncMethodHandledException(Continuation curContinuation, uint unwindedFrames)
             {
-                try
-                {
-                    Task.RemoveRuntimeAsyncContinuationChainTimestamps(curContinuation, unwindedFrames);
-                }
-                catch
-                {
-                }
+                Task.RemoveRuntimeAsyncContinuationChainTimestamps(curContinuation, unwindedFrames);
             }
 
             public static void ResumeAsyncMethod(ref AsyncDispatcherInfo info, Continuation curContinuation)
             {
-                try
+                if (info.CurrentTask != null)
                 {
-                    if (info.CurrentTask != null)
-                    {
-                        Task.UpdateRuntimeAsyncTaskTimestamp(info.CurrentTask, curContinuation);
-                    }
-                }
-                catch
-                {
+                    Task.UpdateRuntimeAsyncTaskTimestamp(info.CurrentTask, curContinuation);
                 }
             }
 
             public static void CompleteAsyncMethod(Continuation curContinuation)
             {
-                try
-                {
-                    Task.RemoveRuntimeAsyncContinuationTimestamp(curContinuation);
-                }
-                catch
-                {
-                }
+                Task.RemoveRuntimeAsyncContinuationTimestamp(curContinuation);
             }
 
             public static void HandleSuspended(Continuation? nextContinuation, Continuation? newContinuation)
             {
-                try
+                if (nextContinuation != null)
                 {
-                    if (nextContinuation != null)
+                    if (newContinuation != null)
                     {
-                        if (newContinuation != null)
-                        {
-                            Task.TryAddRuntimeAsyncContinuationChainTimestamps(nextContinuation, newContinuation);
-                        }
-                        else
-                        {
-                            Task.TryAddRuntimeAsyncContinuationChainTimestamps(nextContinuation);
-                        }
+                        Task.TryAddRuntimeAsyncContinuationChainTimestamps(nextContinuation, newContinuation);
                     }
-                }
-                catch
-                {
+                    else
+                    {
+                        Task.TryAddRuntimeAsyncContinuationChainTimestamps(nextContinuation);
+                    }
                 }
             }
 
             public static void HandleSuspendedFailed(Task task, Continuation? nextContinuation)
             {
-                try
+                if (nextContinuation != null)
                 {
-                    if (nextContinuation != null)
-                    {
-                        Task.RemoveRuntimeAsyncTask(task, nextContinuation);
-                    }
-                    else
-                    {
-                        Task.RemoveRuntimeAsyncTask(task);
-                    }
+                    Task.RemoveRuntimeAsyncTask(task, nextContinuation);
                 }
-                catch
+                else
                 {
+                    Task.RemoveRuntimeAsyncTask(task);
                 }
             }
         }

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -674,8 +674,12 @@ namespace System.Runtime.CompilerServices
             {
                 if (AsyncInstrumentationHelper.InstrumentCheckPoint)
                 {
-                    InstrumentedDispatchContinuations();
-                    return;
+                    AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
+                    if (flags != AsyncInstrumentation.Flags.Disabled)
+                    {
+                        InstrumentedDispatchContinuations(flags);
+                        return;
+                    }
                 }
 
                 ExecutionAndSyncBlockStore contexts = default;
@@ -766,14 +770,14 @@ namespace System.Runtime.CompilerServices
                         contexts.Pop();
                         AsyncDispatcherInfo.t_current = asyncDispatcherInfo.Next;
 
-                        InstrumentedDispatchContinuations();
+                        InstrumentedDispatchContinuations(AsyncInstrumentation.ActiveFlags);
                         return;
                     }
                 }
             }
 
             [StackTraceHidden]
-            private unsafe void InstrumentedDispatchContinuations()
+            private unsafe void InstrumentedDispatchContinuations(AsyncInstrumentation.Flags flags)
             {
                 ExecutionAndSyncBlockStore contexts = default;
                 contexts.Push();
@@ -783,7 +787,6 @@ namespace System.Runtime.CompilerServices
                 asyncDispatcherInfo.NextContinuation = MoveContinuationState();
                 AsyncDispatcherInfo.t_current = &asyncDispatcherInfo;
 
-                AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
                 AsyncInstrumentationHelper.ResumeRuntimeAsyncContext(this, ref asyncDispatcherInfo, flags);
 
                 while (true)
@@ -979,10 +982,13 @@ namespace System.Runtime.CompilerServices
         {
             if (RuntimeAsyncTask<T>.AsyncInstrumentationHelper.InstrumentCheckPoint)
             {
-                AsyncInstrumentation.Flags flags = AsyncInstrumentation.ActiveFlags;
-                RuntimeAsyncTask<T>.AsyncInstrumentationHelper.CreateRuntimeAsyncContext(task, flags);
-                RuntimeAsyncTask<T>.AsyncInstrumentationHelper.HandleSuspended(task, flags);
-                return;
+                AsyncInstrumentation.Flags flags = AsyncInstrumentation.SyncActiveFlags();
+                if (flags != AsyncInstrumentation.Flags.Disabled)
+                {
+                    RuntimeAsyncTask<T>.AsyncInstrumentationHelper.CreateRuntimeAsyncContext(task, flags);
+                    RuntimeAsyncTask<T>.AsyncInstrumentationHelper.HandleSuspended(task, flags);
+                    return;
+                }
             }
 
             task.HandleSuspended();

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -469,8 +469,7 @@ namespace System.Runtime.CompilerServices
                 public static bool InstrumentCheckPoint
                 {
                     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                    get => AsyncInstrumentation.IsSupported
-                        && AsyncInstrumentation.ActiveFlags != AsyncInstrumentation.Flags.Disabled;
+                    get => AsyncInstrumentation.IsSupported && AsyncInstrumentation.ActiveFlags != AsyncInstrumentation.Flags.Disabled;
                 }
 
                 public static void CreateRuntimeAsyncContext(RuntimeAsyncTask<T> task, AsyncInstrumentation.Flags flags)

--- a/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncHelpers.CoreCLR.cs
@@ -645,8 +645,7 @@ namespace System.Runtime.CompilerServices
 
                 private static void DebuggerHandleSuspended(RuntimeAsyncTask<T> task, Continuation? newContinuation = null)
                 {
-                    ref RuntimeAsyncAwaitState state = ref t_runtimeAsyncAwaitState;
-                    Continuation? nc = state.SentinelContinuation!.Next;
+                    Continuation? nc = t_runtimeAsyncAwaitState.SentinelContinuation!.Next;
 
                     if (nc != null)
                     {

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -841,6 +841,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncValueTaskMethodBuilder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncValueTaskMethodBuilderT.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncVoidMethodBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\AsyncInstrumentation.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CastCache.cs" Condition="'$(FeatureMono)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\GenericCache.cs" Condition="'$(FeatureMono)' != 'true'" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\CompilerServices\CallerArgumentExpressionAttribute.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
@@ -9,12 +10,14 @@ namespace System.Runtime.CompilerServices
 {
     internal static class AsyncInstrumentation
     {
-        public static bool IsSupported => Debugger.IsSupported || EventSource.IsSupported;
+        public static bool IsSupported => Debugger.IsSupported && EventSource.IsSupported;
 
         [Flags]
         public enum Flags : uint
         {
             Disabled = 0x0,
+
+            // Bit 1 - 24 reserved for async instrumentation points.
             CreateAsyncContext = 0x1,
             ResumeAsyncContext = 0x2,
             SuspendAsyncContext = 0x4,
@@ -22,10 +25,19 @@ namespace System.Runtime.CompilerServices
             UnwindAsyncException = 0x10,
             ResumeAsyncMethod = 0x20,
             CompleteAsyncMethod = 0x40,
-            AsyncProfiler = 0x10000,
-            Tpl = 0x20000,
-            Debugger = 0x40000
+
+            // Bit 25 - 31 reserved for instrumentation clients.
+            AsyncProfiler = 0x1000000,
+            AsyncDebugger = 0x2000000,
+
+            // Bit 32 reserved for initialization state.
+            Uninitialized = 0x80000000
         }
+
+        public const Flags DefaultFlags =
+            Flags.CreateAsyncContext | Flags.ResumeAsyncContext | Flags.SuspendAsyncContext |
+            Flags.CompleteAsyncContext | Flags.UnwindAsyncException |
+            Flags.ResumeAsyncMethod | Flags.CompleteAsyncMethod;
 
         public static class IsEnabled
         {
@@ -37,17 +49,23 @@ namespace System.Runtime.CompilerServices
             public static bool ResumeAsyncMethod(Flags flags) => (Flags.ResumeAsyncMethod & flags) != 0;
             public static bool CompleteAsyncMethod(Flags flags) => (Flags.CompleteAsyncMethod & flags) != 0;
             public static bool AsyncProfiler(Flags flags) => (Flags.AsyncProfiler & flags) != 0;
-            public static bool Tpl(Flags flags) => (Flags.Tpl & flags) != 0;
-            public static bool Debugger(Flags flags) => (Flags.Debugger & flags) != 0 && Task.s_asyncDebuggingEnabled;
-            public static bool DebuggerOrTpl(Flags flags) => Debugger(flags) || Tpl(flags);
+            public static bool AsyncDebugger(Flags flags) => (Flags.AsyncDebugger & flags) != 0 && Task.s_asyncDebuggingEnabled;
         }
 
-        public static Flags ActiveFlags => s_activeFlags;
+        public static Flags ActiveFlags
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
+            {
+                Debug.Assert(IsInitialized(s_activeFlags), "ActiveFlags accessed before initialized. Make sure SyncActiveFlags gets called first.");
+                return s_activeFlags;
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Flags SyncActiveFlags()
         {
-            Flags flags = ActiveFlags;
+            Flags flags = s_activeFlags;
             if (IsUninitialized(flags))
             {
                 return InitializeFlags();
@@ -67,38 +85,27 @@ namespace System.Runtime.CompilerServices
                 s_asyncProfilerActiveFlags = asyncProfilerFlags;
                 if (IsInitialized(s_activeFlags))
                 {
-                    s_activeFlags = s_asyncProfilerActiveFlags | s_tplActiveFlags | s_debuggerActiveFlags;
+                    s_activeFlags = s_asyncProfilerActiveFlags | s_asyncDebuggerActiveFlags;
                 }
             }
         }
 
-        public static void UpdateTplFlags(Flags tplFlags)
+        public static void UpdateAsyncDebuggerFlags(Flags asyncDebuggerFlags)
         {
-            // Until debugger sets its flags directly, piggy back on TPL instrumentation since debugger will enable/disable TPL events
-            // when attaching/detaching to the runtime.
-            Flags debuggerFlags = Flags.Disabled;
-
-            if (tplFlags != Flags.Disabled)
+            if (asyncDebuggerFlags != Flags.Disabled)
             {
-                tplFlags |= Flags.Tpl;
-                debuggerFlags |= DebuggerFlags | Flags.Debugger;
+                asyncDebuggerFlags |= Flags.AsyncDebugger;
             }
 
             lock (s_lock)
             {
-                s_tplActiveFlags = tplFlags;
-                s_debuggerActiveFlags = debuggerFlags;
+                s_asyncDebuggerActiveFlags = asyncDebuggerFlags;
                 if (IsInitialized(s_activeFlags))
                 {
-                    s_activeFlags = s_asyncProfilerActiveFlags | s_tplActiveFlags | s_debuggerActiveFlags;
+                    s_activeFlags = s_asyncProfilerActiveFlags | s_asyncDebuggerActiveFlags;
                 }
             }
         }
-
-        private const uint UninitializedFlag = 0x80000000;
-
-        private static bool IsInitialized(Flags flags) => !IsUninitialized(flags);
-        private static bool IsUninitialized(Flags flags) => (flags & (Flags)UninitializedFlag) != 0;
 
         private static Flags InitializeFlags()
         {
@@ -108,26 +115,23 @@ namespace System.Runtime.CompilerServices
             {
                 if (IsUninitialized(s_activeFlags))
                 {
-                    s_activeFlags = s_asyncProfilerActiveFlags | s_tplActiveFlags | s_debuggerActiveFlags;
+                    s_activeFlags = s_asyncProfilerActiveFlags | s_asyncDebuggerActiveFlags;
                 }
 
                 return s_activeFlags;
             }
         }
 
-        private static Flags s_activeFlags = (Flags)UninitializedFlag;
+        private static bool IsInitialized(Flags flags) => !IsUninitialized(flags);
+
+        private static bool IsUninitialized(Flags flags) => (flags & Flags.Uninitialized) != 0;
+
+        private static Flags s_activeFlags = Flags.Uninitialized;
 
         private static Flags s_asyncProfilerActiveFlags;
 
-        private static Flags s_tplActiveFlags;
+        private static Flags s_asyncDebuggerActiveFlags;
 
-        private static Flags s_debuggerActiveFlags;
-
-        private static readonly object s_lock = new object();
-
-        private const Flags DebuggerFlags =
-            Flags.CreateAsyncContext | Flags.SuspendAsyncContext |
-            Flags.CompleteAsyncContext | Flags.UnwindAsyncException |
-            Flags.ResumeAsyncMethod | Flags.CompleteAsyncMethod;
+        private static readonly Lock s_lock = new();
     }
 }

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
@@ -12,7 +12,7 @@ namespace System.Runtime.CompilerServices
         public static bool IsSupported => Debugger.IsSupported || EventSource.IsSupported;
 
         [Flags]
-        public enum Flags
+        public enum Flags : uint
         {
             Disabled = 0x0,
             CreateAsyncContext = 0x1,
@@ -44,39 +44,39 @@ namespace System.Runtime.CompilerServices
 
         public static Flags ActiveFlags => s_activeFlags;
 
-        public static Flags UpdateAsyncProfilerFlags(Flags flags)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Flags SyncActiveFlags()
         {
-            if (flags != Flags.Disabled)
+            Flags flags = ActiveFlags;
+            if (IsUninitialized(flags))
             {
-                flags |= Flags.AsyncProfiler;
+                return InitializeFlags();
+            }
+            return flags;
+        }
+
+        public static void UpdateAsyncProfilerFlags(Flags asyncProfilerFlags)
+        {
+            if (asyncProfilerFlags != Flags.Disabled)
+            {
+                asyncProfilerFlags |= Flags.AsyncProfiler;
             }
 
             lock (s_lock)
             {
-                s_asyncProfilerActiveFlags = flags;
-                s_activeFlags = s_asyncProfilerActiveFlags | s_tplActiveFlags | s_debuggerActiveFlags;
-
-                return s_activeFlags;
+                s_asyncProfilerActiveFlags = asyncProfilerFlags;
+                if (IsInitialized(s_activeFlags))
+                {
+                    s_activeFlags = s_asyncProfilerActiveFlags | s_tplActiveFlags | s_debuggerActiveFlags;
+                }
             }
         }
 
-        public static Flags UpdateTplFlags(EventSource tplEventSource)
+        public static void UpdateTplFlags(Flags tplFlags)
         {
             // Until debugger sets its flags directly, piggy back on TPL instrumentation since debugger will enable/disable TPL events
             // when attaching/detaching to the runtime.
-            Flags tplFlags = Flags.Disabled;
             Flags debuggerFlags = Flags.Disabled;
-
-            tplFlags |= tplEventSource.IsEnabled(EventLevel.Informational, TplEventSource.Keywords.AsyncCausalitySynchronousWork) ?
-                Flags.ResumeAsyncContext |
-                Flags.SuspendAsyncContext |
-                Flags.CompleteAsyncContext |
-                Flags.UnwindAsyncException : 0;
-
-            tplFlags |= tplEventSource.IsEnabled(EventLevel.Informational, TplEventSource.Keywords.AsyncCausalityOperation) ?
-                Flags.CreateAsyncContext |
-                Flags.CompleteAsyncContext |
-                Flags.UnwindAsyncException : 0;
 
             if (tplFlags != Flags.Disabled)
             {
@@ -88,13 +88,34 @@ namespace System.Runtime.CompilerServices
             {
                 s_tplActiveFlags = tplFlags;
                 s_debuggerActiveFlags = debuggerFlags;
-                s_activeFlags = s_asyncProfilerActiveFlags | s_tplActiveFlags | s_debuggerActiveFlags;
+                if (IsInitialized(s_activeFlags))
+                {
+                    s_activeFlags = s_asyncProfilerActiveFlags | s_tplActiveFlags | s_debuggerActiveFlags;
+                }
+            }
+        }
+
+        private const uint UninitializedFlag = 0x80000000;
+
+        private static bool IsInitialized(Flags flags) => !IsUninitialized(flags);
+        private static bool IsUninitialized(Flags flags) => (flags & (Flags)UninitializedFlag) != 0;
+
+        private static Flags InitializeFlags()
+        {
+            _ = TplEventSource.Log; // Touch TplEventSource to trigger static constructor which will initialize TPL flags if EventSource is supported.
+
+            lock (s_lock)
+            {
+                if (IsUninitialized(s_activeFlags))
+                {
+                    s_activeFlags = s_asyncProfilerActiveFlags | s_tplActiveFlags | s_debuggerActiveFlags;
+                }
 
                 return s_activeFlags;
             }
         }
 
-        private static Flags s_activeFlags;
+        private static Flags s_activeFlags = (Flags)UninitializedFlag;
 
         private static Flags s_asyncProfilerActiveFlags;
 

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
@@ -52,15 +52,7 @@ namespace System.Runtime.CompilerServices
             public static bool AsyncDebugger(Flags flags) => (Flags.AsyncDebugger & flags) != 0 && Task.s_asyncDebuggingEnabled;
         }
 
-        public static Flags ActiveFlags
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get
-            {
-                Debug.Assert(IsInitialized(s_activeFlags), "ActiveFlags accessed before initialized. Make sure SyncActiveFlags gets called first.");
-                return s_activeFlags;
-            }
-        }
+        public static Flags ActiveFlags => s_activeFlags;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Flags SyncActiveFlags()

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
@@ -41,7 +41,7 @@ namespace System.Runtime.CompilerServices
             public static bool DebuggerOrTpl(Flags flags) => Debugger(flags) || Tpl(flags);
         }
 
-        public static Flags ActiveFlags => _activeFlags;
+        public static Flags ActiveFlags => s_activeFlags;
 
         public static Flags UpdateAsyncProfilerFlags(Flags flags)
         {
@@ -50,12 +50,12 @@ namespace System.Runtime.CompilerServices
                 flags |= Flags.AsyncProfiler;
             }
 
-            lock (_lock)
+            lock (s_lock)
             {
-                _asyncProfilerActiveFlags = flags;
-                _activeFlags = _asyncProfilerActiveFlags | _tplActiveFlags | _debuggerActiveFlags;
+                s_asyncProfilerActiveFlags = flags;
+                s_activeFlags = s_asyncProfilerActiveFlags | s_tplActiveFlags | s_debuggerActiveFlags;
 
-                return _activeFlags;
+                return s_activeFlags;
             }
         }
 
@@ -83,25 +83,25 @@ namespace System.Runtime.CompilerServices
                 debuggerFlags |= DebuggerFlags | Flags.Debugger;
             }
 
-            lock (_lock)
+            lock (s_lock)
             {
-                _tplActiveFlags = tplFlags;
-                _debuggerActiveFlags = debuggerFlags;
-                _activeFlags = _asyncProfilerActiveFlags | _tplActiveFlags | _debuggerActiveFlags;
+                s_tplActiveFlags = tplFlags;
+                s_debuggerActiveFlags = debuggerFlags;
+                s_activeFlags = s_asyncProfilerActiveFlags | s_tplActiveFlags | s_debuggerActiveFlags;
 
-                return _activeFlags;
+                return s_activeFlags;
             }
         }
 
-        private static Flags _activeFlags;
+        private static Flags s_activeFlags;
 
-        private static Flags _asyncProfilerActiveFlags;
+        private static Flags s_asyncProfilerActiveFlags;
 
-        private static Flags _tplActiveFlags;
+        private static Flags s_tplActiveFlags;
 
-        private static Flags _debuggerActiveFlags;
+        private static Flags s_debuggerActiveFlags;
 
-        private static readonly object _lock = new object();
+        private static readonly object s_lock = new object();
 
         private const Flags DebuggerFlags =
             Flags.CreateAsyncContext | Flags.SuspendAsyncContext |

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
@@ -11,6 +11,7 @@ namespace System.Runtime.CompilerServices
     {
         public static bool IsSupported => Debugger.IsSupported || EventSource.IsSupported;
 
+        [Flags]
         public enum Flags
         {
             Disabled = 0x0,

--- a/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/AsyncInstrumentation.cs
@@ -1,0 +1,111 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+
+namespace System.Runtime.CompilerServices
+{
+    internal static class AsyncInstrumentation
+    {
+        public static bool IsSupported => Debugger.IsSupported || EventSource.IsSupported;
+
+        public enum Flags
+        {
+            Disabled = 0x0,
+            CreateAsyncContext = 0x1,
+            ResumeAsyncContext = 0x2,
+            SuspendAsyncContext = 0x4,
+            CompleteAsyncContext = 0x8,
+            UnwindAsyncException = 0x10,
+            ResumeAsyncMethod = 0x20,
+            CompleteAsyncMethod = 0x40,
+            AsyncProfiler = 0x10000,
+            Tpl = 0x20000,
+            Debugger = 0x40000
+        }
+
+        public static class IsEnabled
+        {
+            public static bool CreateAsyncContext(Flags flags) => (Flags.CreateAsyncContext & flags) != 0;
+            public static bool ResumeAsyncContext(Flags flags) => (Flags.ResumeAsyncContext & flags) != 0;
+            public static bool SuspendAsyncContext(Flags flags) => (Flags.SuspendAsyncContext & flags) != 0;
+            public static bool CompleteAsyncContext(Flags flags) => (Flags.CompleteAsyncContext & flags) != 0;
+            public static bool UnwindAsyncException(Flags flags) => (Flags.UnwindAsyncException & flags) != 0;
+            public static bool ResumeAsyncMethod(Flags flags) => (Flags.ResumeAsyncMethod & flags) != 0;
+            public static bool CompleteAsyncMethod(Flags flags) => (Flags.CompleteAsyncMethod & flags) != 0;
+            public static bool AsyncProfiler(Flags flags) => (Flags.AsyncProfiler & flags) != 0;
+            public static bool Tpl(Flags flags) => (Flags.Tpl & flags) != 0;
+            public static bool Debugger(Flags flags) => (Flags.Debugger & flags) != 0 && Task.s_asyncDebuggingEnabled;
+            public static bool DebuggerOrTpl(Flags flags) => Debugger(flags) || Tpl(flags);
+        }
+
+        public static Flags ActiveFlags => _activeFlags;
+
+        public static Flags UpdateAsyncProfilerFlags(Flags flags)
+        {
+            if (flags != Flags.Disabled)
+            {
+                flags |= Flags.AsyncProfiler;
+            }
+
+            lock (_lock)
+            {
+                _asyncProfilerActiveFlags = flags;
+                _activeFlags = _asyncProfilerActiveFlags | _tplActiveFlags | _debuggerActiveFlags;
+
+                return _activeFlags;
+            }
+        }
+
+        public static Flags UpdateTplFlags(EventSource tplEventSource)
+        {
+            // Until debugger sets its flags directly, piggy back on TPL instrumentation since debugger will enable/disable TPL events
+            // when attaching/detaching to the runtime.
+            Flags tplFlags = Flags.Disabled;
+            Flags debuggerFlags = Flags.Disabled;
+
+            tplFlags |= tplEventSource.IsEnabled(EventLevel.Informational, TplEventSource.Keywords.AsyncCausalitySynchronousWork) ?
+                Flags.ResumeAsyncContext |
+                Flags.SuspendAsyncContext |
+                Flags.CompleteAsyncContext |
+                Flags.UnwindAsyncException : 0;
+
+            tplFlags |= tplEventSource.IsEnabled(EventLevel.Informational, TplEventSource.Keywords.AsyncCausalityOperation) ?
+                Flags.CreateAsyncContext |
+                Flags.CompleteAsyncContext |
+                Flags.UnwindAsyncException : 0;
+
+            if (tplFlags != Flags.Disabled)
+            {
+                tplFlags |= Flags.Tpl;
+                debuggerFlags |= DebuggerFlags | Flags.Debugger;
+            }
+
+            lock (_lock)
+            {
+                _tplActiveFlags = tplFlags;
+                _debuggerActiveFlags = debuggerFlags;
+                _activeFlags = _asyncProfilerActiveFlags | _tplActiveFlags | _debuggerActiveFlags;
+
+                return _activeFlags;
+            }
+        }
+
+        private static Flags _activeFlags;
+
+        private static Flags _asyncProfilerActiveFlags;
+
+        private static Flags _tplActiveFlags;
+
+        private static Flags _debuggerActiveFlags;
+
+        private static readonly object _lock = new object();
+
+        private const Flags DebuggerFlags =
+            Flags.CreateAsyncContext | Flags.SuspendAsyncContext |
+            Flags.CompleteAsyncContext | Flags.UnwindAsyncException |
+            Flags.ResumeAsyncMethod | Flags.CompleteAsyncMethod;
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -218,37 +218,70 @@ namespace System.Threading.Tasks
         }
 
 #if !MONO
-        internal static void SetRuntimeAsyncContinuationTimestamp(Continuation continuation, long timestamp)
+        private static Dictionary<object, long> GetOrCreateRuntimeAsyncContinuationTimestamps()
         {
-            Dictionary<object, long> continuationTimestamps =
-                Volatile.Read(ref s_runtimeAsyncContinuationTimestamps) ??
+            return Volatile.Read(ref s_runtimeAsyncContinuationTimestamps) ??
                 Interlocked.CompareExchange(ref s_runtimeAsyncContinuationTimestamps, new Dictionary<object, long>(ReferenceEqualityComparer.Instance), null) ??
-                s_runtimeAsyncContinuationTimestamps;
+                s_runtimeAsyncContinuationTimestamps!;
+        }
 
+        private static Dictionary<int, long> GetOrCreateRuntimeAsyncTaskTimestamps()
+        {
+            return Volatile.Read(ref s_runtimeAsyncTaskTimestamps) ??
+                Interlocked.CompareExchange(ref s_runtimeAsyncTaskTimestamps, new Dictionary<int, long>(), null) ??
+                s_runtimeAsyncTaskTimestamps;
+        }
+
+        internal static void ReplaceOrAddRuntimeAsyncContinuationTimestamp(Continuation curContinuation, Continuation newContinuation)
+        {
+            var continuationTimestamps = GetOrCreateRuntimeAsyncContinuationTimestamps();
             lock (continuationTimestamps)
             {
-                continuationTimestamps.TryAdd(continuation, timestamp);
+                if (continuationTimestamps.TryGetValue(curContinuation, out long timestampVal))
+                {
+                    continuationTimestamps.Remove(curContinuation);
+                    continuationTimestamps[newContinuation] = timestampVal;
+                }
+                else
+                {
+                    continuationTimestamps[newContinuation] = Stopwatch.GetTimestamp();
+                }
             }
         }
 
-        internal static bool GetRuntimeAsyncContinuationTimestamp(Continuation continuation, out long timestamp)
+        internal static void TryAddRuntimeAsyncContinuationChainTimestamps(Continuation continuationChain)
         {
-            Dictionary<object, long>? continuationTimestamps = s_runtimeAsyncContinuationTimestamps;
-            if (continuationTimestamps is null)
-            {
-                timestamp = 0;
-                return false;
-            }
-
+            var continuationTimestamps = GetOrCreateRuntimeAsyncContinuationTimestamps();
+            long timestamp = Stopwatch.GetTimestamp();
             lock (continuationTimestamps)
             {
-                return continuationTimestamps.TryGetValue(continuation, out timestamp);
+                Continuation? nc = continuationChain;
+                while (nc != null)
+                {
+                    continuationTimestamps.TryAdd(nc, timestamp);
+                    nc = nc.Next;
+                }
+            }
+        }
+
+        internal static void TryAddRuntimeAsyncContinuationChainTimestamps(Continuation continuationChain, Continuation timestampSource)
+        {
+            var continuationTimestamps = GetOrCreateRuntimeAsyncContinuationTimestamps();
+            lock (continuationTimestamps)
+            {
+                long timestamp = continuationTimestamps.TryGetValue(timestampSource, out long timestampVal) ? timestampVal : Stopwatch.GetTimestamp();
+                Continuation? nc = continuationChain;
+                while (nc != null)
+                {
+                    continuationTimestamps.TryAdd(nc, timestamp);
+                    nc = nc.Next;
+                }
             }
         }
 
         internal static void RemoveRuntimeAsyncContinuationTimestamp(Continuation continuation)
         {
-            Dictionary<object, long>? continuationTimestamps = s_runtimeAsyncContinuationTimestamps;
+            var continuationTimestamps = s_runtimeAsyncContinuationTimestamps;
             if (continuationTimestamps is null)
                 return;
 
@@ -258,21 +291,51 @@ namespace System.Threading.Tasks
             }
         }
 
-        internal static void UpdateRuntimeAsyncTaskTimestamp(Task task, long inflightTimestamp)
+        internal static void RemoveRuntimeAsyncContinuationChainTimestamps(Continuation continuation, uint count)
         {
-            Dictionary<int, long> runtimeAsyncTaskTimestamps =
-                Volatile.Read(ref s_runtimeAsyncTaskTimestamps) ??
-                Interlocked.CompareExchange(ref s_runtimeAsyncTaskTimestamps, new Dictionary<int, long>(), null) ??
-                s_runtimeAsyncTaskTimestamps;
+            var continuationTimestamps = s_runtimeAsyncContinuationTimestamps;
+            if (continuationTimestamps is null)
+                return;
 
-            lock (runtimeAsyncTaskTimestamps)
+            lock (continuationTimestamps)
             {
-                runtimeAsyncTaskTimestamps[task.Id] = inflightTimestamp;
+                Continuation? nc = continuation;
+                for (uint i = 0; i < count && nc != null; i++)
+                {
+                    continuationTimestamps.Remove(nc);
+                    nc = nc.Next;
+                }
             }
         }
 
-        internal static void RemoveRuntimeAsyncTaskTimestamp(Task task)
+        internal static void UpdateRuntimeAsyncTaskTimestamp(Task task, Continuation timestampSource)
         {
+            long timestamp = 0;
+            var continuationTimestamps = s_runtimeAsyncContinuationTimestamps;
+            if (continuationTimestamps != null)
+            {
+                lock (continuationTimestamps)
+                {
+                    continuationTimestamps.TryGetValue(timestampSource, out timestamp);
+                }
+            }
+
+            if (timestamp == 0)
+            {
+                timestamp = Stopwatch.GetTimestamp();
+            }
+
+            var runtimeAsyncTaskTimestamps = GetOrCreateRuntimeAsyncTaskTimestamps();
+            lock (runtimeAsyncTaskTimestamps)
+            {
+                runtimeAsyncTaskTimestamps[task.Id] = timestamp;
+            }
+        }
+
+        internal static void RemoveRuntimeAsyncTask(Task task)
+        {
+            RemoveFromActiveTasks(task);
+
             Dictionary<int, long>? runtimeAsyncTaskTimestamps = s_runtimeAsyncTaskTimestamps;
             if (runtimeAsyncTaskTimestamps is null)
                 return;
@@ -280,6 +343,25 @@ namespace System.Threading.Tasks
             lock (runtimeAsyncTaskTimestamps)
             {
                 runtimeAsyncTaskTimestamps.Remove(task.Id);
+            }
+        }
+
+        internal static void RemoveRuntimeAsyncTask(Task task, Continuation continuationChain)
+        {
+            RemoveRuntimeAsyncTask(task);
+
+            Dictionary<object, long>? continuationTimestamps = s_runtimeAsyncContinuationTimestamps;
+            if (continuationTimestamps is null)
+                return;
+
+            lock (continuationTimestamps)
+            {
+                Continuation? nc = continuationChain;
+                while (nc != null)
+                {
+                    continuationTimestamps.Remove(nc);
+                    nc = nc.Next;
+                }
             }
         }
 #endif

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -229,7 +229,7 @@ namespace System.Threading.Tasks
         {
             return Volatile.Read(ref s_runtimeAsyncTaskTimestamps) ??
                 Interlocked.CompareExchange(ref s_runtimeAsyncTaskTimestamps, new Dictionary<int, long>(), null) ??
-                s_runtimeAsyncTaskTimestamps;
+                s_runtimeAsyncTaskTimestamps!;
         }
 
         internal static void ReplaceOrAddRuntimeAsyncContinuationTimestamp(Continuation curContinuation, Continuation newContinuation)

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs
@@ -244,7 +244,7 @@ namespace System.Threading.Tasks
                 }
                 else
                 {
-                    continuationTimestamps[newContinuation] = Stopwatch.GetTimestamp();
+                    continuationTimestamps.TryAdd(newContinuation, Stopwatch.GetTimestamp());
                 }
             }
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
@@ -34,6 +34,10 @@ namespace System.Threading.Tasks
 
             Debug = IsEnabled(EventLevel.Informational, Keywords.Debug);
             DebugActivityId = IsEnabled(EventLevel.Informational, Keywords.DebugActivityId);
+
+#if CORECLR || NATIVEAOT
+            AsyncHelpers.RuntimeAsyncTaskInstrumentation.UpdateTplFlags(this);
+#endif
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
@@ -35,20 +35,25 @@ namespace System.Threading.Tasks
             Debug = IsEnabled(EventLevel.Informational, Keywords.Debug);
             DebugActivityId = IsEnabled(EventLevel.Informational, Keywords.DebugActivityId);
 
-            AsyncInstrumentation.Flags tplFlags = AsyncInstrumentation.Flags.Disabled;
+            // Until debugger explicitly set the AsyncInstrumentation keyword, we enable async instrumentation when
+            // Tasks, AsyncCausalitySynchronousWork, AsyncCausalityOperation and TasksFlowActivityIds keywords are enabled.
+            bool asyncInstrumentationEnabled = IsEnabled(EventLevel.Informational, Keywords.AsyncInstrumentation);
+            if (!asyncInstrumentationEnabled)
+            {
+                asyncInstrumentationEnabled = IsEnabled(EventLevel.Informational, Keywords.Tasks);
+                asyncInstrumentationEnabled &= IsEnabled(EventLevel.Informational, Keywords.AsyncCausalityOperation);
+                asyncInstrumentationEnabled &= IsEnabled(EventLevel.Informational, Keywords.AsyncCausalitySynchronousWork);
+                asyncInstrumentationEnabled &= IsEnabled(EventLevel.Informational, Keywords.TasksFlowActivityIds);
+            }
 
-            tplFlags |= IsEnabled(EventLevel.Informational, Keywords.AsyncCausalitySynchronousWork) ?
-                AsyncInstrumentation.Flags.ResumeAsyncContext |
-                AsyncInstrumentation.Flags.SuspendAsyncContext |
-                AsyncInstrumentation.Flags.CompleteAsyncContext |
-                AsyncInstrumentation.Flags.UnwindAsyncException : AsyncInstrumentation.Flags.Disabled;
-
-            tplFlags |= IsEnabled(EventLevel.Informational, Keywords.AsyncCausalityOperation) ?
-                AsyncInstrumentation.Flags.CreateAsyncContext |
-                AsyncInstrumentation.Flags.CompleteAsyncContext |
-                AsyncInstrumentation.Flags.UnwindAsyncException : AsyncInstrumentation.Flags.Disabled;
-
-            AsyncInstrumentation.UpdateTplFlags(tplFlags);
+            if (asyncInstrumentationEnabled)
+            {
+                AsyncInstrumentation.UpdateAsyncDebuggerFlags(AsyncInstrumentation.DefaultFlags);
+            }
+            else
+            {
+                AsyncInstrumentation.UpdateAsyncDebuggerFlags(AsyncInstrumentation.Flags.Disabled);
+            }
         }
 
         /// <summary>
@@ -143,6 +148,11 @@ namespace System.Threading.Tasks
             /// Relatively Verbose logging meant for debugging the Task library itself.  Will probably be removed in the future
             /// </summary>
             public const EventKeywords DebugActivityId = (EventKeywords)0x40000;
+            /// <summary>
+            /// Enable async instrumentation to track async operations across await/async method boundaries.
+            /// Mainly used by debugger to track task and continuation chain execution.
+            /// </summary>
+            public const EventKeywords AsyncInstrumentation = (EventKeywords)0x80000;
         }
 
         //-----------------------------------------------------------------------------------

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
@@ -41,12 +41,12 @@ namespace System.Threading.Tasks
                 AsyncInstrumentation.Flags.ResumeAsyncContext |
                 AsyncInstrumentation.Flags.SuspendAsyncContext |
                 AsyncInstrumentation.Flags.CompleteAsyncContext |
-                AsyncInstrumentation.Flags.UnwindAsyncException : 0;
+                AsyncInstrumentation.Flags.UnwindAsyncException : AsyncInstrumentation.Flags.Disabled;
 
             tplFlags |= IsEnabled(EventLevel.Informational, Keywords.AsyncCausalityOperation) ?
                 AsyncInstrumentation.Flags.CreateAsyncContext |
                 AsyncInstrumentation.Flags.CompleteAsyncContext |
-                AsyncInstrumentation.Flags.UnwindAsyncException : 0;
+                AsyncInstrumentation.Flags.UnwindAsyncException : AsyncInstrumentation.Flags.Disabled;
 
             AsyncInstrumentation.UpdateTplFlags(tplFlags);
         }

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
@@ -35,9 +35,7 @@ namespace System.Threading.Tasks
             Debug = IsEnabled(EventLevel.Informational, Keywords.Debug);
             DebugActivityId = IsEnabled(EventLevel.Informational, Keywords.DebugActivityId);
 
-#if CORECLR || NATIVEAOT
-            AsyncHelpers.RuntimeAsyncTaskInstrumentation.UpdateTplFlags(this);
-#endif
+            AsyncInstrumentation.UpdateTplFlags(this);
         }
 
         /// <summary>

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/TplEventSource.cs
@@ -35,7 +35,20 @@ namespace System.Threading.Tasks
             Debug = IsEnabled(EventLevel.Informational, Keywords.Debug);
             DebugActivityId = IsEnabled(EventLevel.Informational, Keywords.DebugActivityId);
 
-            AsyncInstrumentation.UpdateTplFlags(this);
+            AsyncInstrumentation.Flags tplFlags = AsyncInstrumentation.Flags.Disabled;
+
+            tplFlags |= IsEnabled(EventLevel.Informational, Keywords.AsyncCausalitySynchronousWork) ?
+                AsyncInstrumentation.Flags.ResumeAsyncContext |
+                AsyncInstrumentation.Flags.SuspendAsyncContext |
+                AsyncInstrumentation.Flags.CompleteAsyncContext |
+                AsyncInstrumentation.Flags.UnwindAsyncException : 0;
+
+            tplFlags |= IsEnabled(EventLevel.Informational, Keywords.AsyncCausalityOperation) ?
+                AsyncInstrumentation.Flags.CreateAsyncContext |
+                AsyncInstrumentation.Flags.CompleteAsyncContext |
+                AsyncInstrumentation.Flags.UnwindAsyncException : 0;
+
+            AsyncInstrumentation.UpdateTplFlags(tplFlags);
         }
 
         /// <summary>

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -1,7 +1,9 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.Tracing;
 using System.Reflection;
 using Microsoft.DotNet.RemoteExecutor;
 using Microsoft.DotNet.XUnitExtensions;
@@ -13,11 +15,103 @@ namespace System.Threading.Tasks.Tests
     {
         private static bool IsRemoteExecutorAndRuntimeAsyncSupported => RemoteExecutor.IsSupported && PlatformDetection.IsRuntimeAsyncSupported;
 
+        // NOTE: This depends on private implementation details generally only used by the debugger.
+        // If those ever change, this test will need to be updated as well.
+        private static FieldInfo AsyncDebuggingEnabledField => typeof(Task).GetField("s_asyncDebuggingEnabled", BindingFlags.NonPublic | BindingFlags.Static);
+        private static FieldInfo TaskTimestampsField => typeof(Task).GetField("s_runtimeAsyncTaskTimestamps", BindingFlags.NonPublic | BindingFlags.Static);
+        private static FieldInfo ContinuationTimestampsField => typeof(Task).GetField("s_runtimeAsyncContinuationTimestamps", BindingFlags.NonPublic | BindingFlags.Static);
+        private static FieldInfo ActiveTasksField => typeof(Task).GetField("s_currentActiveTasks", BindingFlags.NonPublic | BindingFlags.Static);
+
+        private static int GetTaskTimestampCount() =>
+            TaskTimestampsField.GetValue(null) is Dictionary<int, long> dict ? dict.Count : 0;
+
+        private static int GetContinuationTimestampCount() =>
+            ContinuationTimestampsField.GetValue(null) is Dictionary<object, long> dict ? dict.Count : 0;
+
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         static async Task Func()
         {
-            await Task.Delay(1);
             await Task.Yield();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        static async Task FuncThatThrows()
+        {
+            await DeepThrow1();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        static async Task DeepThrow1()
+        {
+            await DeepThrow2();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        static async Task DeepThrow2()
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("test exception");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        static async Task<int> FuncWithResult()
+        {
+            await Task.Yield();
+            return 42;
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        static async Task OuterFuncThatCatches()
+        {
+            try
+            {
+                await MiddleFuncThatPropagates();
+            }
+            catch (InvalidOperationException)
+            {
+            }
+            await Task.Yield();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        static async Task MiddleFuncThatPropagates()
+        {
+            await InnerFuncThatThrows();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        static async Task InnerFuncThatThrows()
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("inner exception");
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        static async Task FuncThatCancels(CancellationToken ct)
+        {
+            await Task.Yield();
+            ct.ThrowIfCancellationRequested();
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        static async Task FuncThatWaitsTwice(TaskCompletionSource tcs1, TaskCompletionSource tcs2)
+        {
+            await tcs1.Task;
+            await tcs2.Task;
+        }
+
+        [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
+        static async Task FuncThatInspectsContinuationTimestamps(TaskCompletionSource tcs, Action callback)
+        {
+            await tcs.Task;
+            callback();
+        }
+
+        static void ValidateTimestampsCleared()
+        {
+            // some other tasks may be created by the runtime, so this is just using a reasonably small upper bound
+            Assert.InRange(GetTaskTimestampCount(), 0, 10);
+            Assert.InRange(GetContinuationTimestampCount(), 0, 10);
         }
 
         [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
@@ -26,21 +120,284 @@ namespace System.Threading.Tasks.Tests
         {
             RemoteExecutor.Invoke(async () =>
             {
-
-                // NOTE: This depends on private implementation details generally only used by the debugger.
-                // If those ever change, this test will need to be updated as well.
-
-                typeof(Task).GetField("s_asyncDebuggingEnabled", BindingFlags.NonPublic | BindingFlags.Static).SetValue(null, true);
+                AsyncDebuggingEnabledField.SetValue(null, true);
 
                 for (int i = 0; i < 1000; i++)
                 {
                     await Func();
                 }
 
-                int taskCount = ((Dictionary<int, long>)typeof(Task).GetField("s_runtimeAsyncTaskTimestamps", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null)).Count;
-                int continuationCount = ((Dictionary<object, long>)typeof(Task).GetField("s_runtimeAsyncContinuationTimestamps", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null)).Count;
-                Assert.InRange(taskCount, 0, 10); // some other tasks may be created by the runtime, so this is just using a reasonably small upper bound
-                Assert.InRange(continuationCount, 0, 10);
+                ValidateTimestampsCleared();
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124072", typeof(PlatformDetection), nameof(PlatformDetection.IsInterpreter))]
+        public void RuntimeAsync_ExceptionCleanup()
+        {
+            RemoteExecutor.Invoke(async () =>
+            {
+                AsyncDebuggingEnabledField.SetValue(null, true);
+
+                for (int i = 0; i < 1000; i++)
+                {
+                    try
+                    {
+                        await FuncThatThrows();
+                    }
+                    catch (InvalidOperationException)
+                    {
+                    }
+                }
+
+                ValidateTimestampsCleared();
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124072", typeof(PlatformDetection), nameof(PlatformDetection.IsInterpreter))]
+        public void RuntimeAsync_DebuggerDetach()
+        {
+            RemoteExecutor.Invoke(async () =>
+            {
+                AsyncDebuggingEnabledField.SetValue(null, true);
+
+                // Run one task to ensure lazy-initialized collections are created
+                await Func();
+
+                var activeTasks = (Dictionary<int, Task>)ActiveTasksField.GetValue(null);
+
+                // Use an in-flight task to deterministically verify tracking is active
+                var tcs = new TaskCompletionSource();
+                Task inflight = FuncThatWaitsTwice(tcs, new TaskCompletionSource());
+
+                lock (activeTasks)
+                {
+                    Assert.True(activeTasks.ContainsKey(inflight.Id),
+                        "Expected in-flight task to be tracked while debugger is attached");
+                }
+
+                // Complete the first await so it resumes and sets a task timestamp
+                tcs.SetResult();
+                var taskTimestamps = (Dictionary<int, long>)TaskTimestampsField.GetValue(null);
+
+                bool seenTimestamp = SpinWait.SpinUntil(() =>
+                {
+                    lock (taskTimestamps)
+                    {
+                        return taskTimestamps.ContainsKey(inflight.Id);
+                    }
+                }, timeout: TimeSpan.FromSeconds(5));
+
+                Assert.True(seenTimestamp, "Timed out waiting for task timestamp");
+
+                // Simulate debugger detach — the flag sync should detect the mismatch
+                // and disable the Debugger flags without crashing.
+                // Timestamps are not cleared (matches existing behavior).
+                AsyncDebuggingEnabledField.SetValue(null, false);
+
+                // Run one task to trigger the flag sync that detects the mismatch
+                await Func();
+
+                // Now start a new in-flight task after detach — it should NOT be tracked
+                var tcsPost = new TaskCompletionSource();
+                Task postDetach = FuncThatWaitsTwice(tcsPost, new TaskCompletionSource());
+
+                lock (activeTasks)
+                {
+                    Assert.False(activeTasks.ContainsKey(postDetach.Id),
+                        "Expected in-flight task NOT to be tracked after debugger detach");
+                }
+
+                lock (taskTimestamps)
+                {
+                    Assert.False(taskTimestamps.ContainsKey(postDetach.Id),
+                        "Expected no task timestamp for post-detach in-flight task");
+                }
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124072", typeof(PlatformDetection), nameof(PlatformDetection.IsInterpreter))]
+        public void RuntimeAsync_ValueTypeResult()
+        {
+            RemoteExecutor.Invoke(async () =>
+            {
+                AsyncDebuggingEnabledField.SetValue(null, true);
+
+                for (int i = 0; i < 1000; i++)
+                {
+                    int result = await FuncWithResult();
+                    Assert.Equal(42, result);
+                }
+
+                ValidateTimestampsCleared();
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124072", typeof(PlatformDetection), nameof(PlatformDetection.IsInterpreter))]
+        public void RuntimeAsync_HandledExceptionPartialUnwind()
+        {
+            RemoteExecutor.Invoke(async () =>
+            {
+                AsyncDebuggingEnabledField.SetValue(null, true);
+
+                for (int i = 0; i < 1000; i++)
+                {
+                    await OuterFuncThatCatches();
+                }
+
+                ValidateTimestampsCleared();
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124072", typeof(PlatformDetection), nameof(PlatformDetection.IsInterpreter))]
+        public void RuntimeAsync_CancellationCleanup()
+        {
+            RemoteExecutor.Invoke(async () =>
+            {
+                AsyncDebuggingEnabledField.SetValue(null, true);
+
+                using var cts = new CancellationTokenSource();
+                cts.Cancel();
+
+                for (int i = 0; i < 1000; i++)
+                {
+                    try
+                    {
+                        await FuncThatCancels(cts.Token);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                    }
+                }
+
+                ValidateTimestampsCleared();
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124072", typeof(PlatformDetection), nameof(PlatformDetection.IsInterpreter))]
+        public void RuntimeAsync_TimestampsTrackedWhileInFlight()
+        {
+            RemoteExecutor.Invoke(async () =>
+            {
+                AsyncDebuggingEnabledField.SetValue(null, true);
+
+                // Run one task to ensure lazy-initialized collections are created
+                await Func();
+
+                var tcs1 = new TaskCompletionSource();
+                var tcs2 = new TaskCompletionSource();
+                Task inflight = FuncThatWaitsTwice(tcs1, tcs2);
+
+                // Task is suspended on tcs1 — should be in active tasks
+                var activeTasks = (Dictionary<int, Task>)ActiveTasksField.GetValue(null);
+
+                lock (activeTasks)
+                {
+                    Assert.True(activeTasks.ContainsKey(inflight.Id), "Expected suspended task to be in s_currentActiveTasks");
+                }
+
+                // Resume from first suspension — this triggers DispatchContinuations which sets timestamps
+                tcs1.SetResult();
+
+                // Poll until the dispatch loop has resumed and re-suspended on tcs2,
+                // which sets the task timestamp via ResumeRuntimeAsyncMethod.
+                var taskTimestamps = (Dictionary<int, long>)TaskTimestampsField.GetValue(null);
+
+                bool seenTimestamp = SpinWait.SpinUntil(() =>
+                {
+                    lock (taskTimestamps)
+                    {
+                        return taskTimestamps.ContainsKey(inflight.Id);
+                    }
+                }, timeout: TimeSpan.FromSeconds(5));
+
+                Assert.True(seenTimestamp, "Timed out waiting for task timestamp to appear after resume");
+
+                // Now the task has been through one resume cycle and is suspended again on tcs2.
+                lock (taskTimestamps)
+                {
+                    Assert.True(taskTimestamps[inflight.Id] > 0, "Expected non-zero task timestamp");
+                }
+
+                // Complete the task
+                tcs2.SetResult();
+                await inflight;
+
+                // After completion the task should be removed from all collections
+                lock (activeTasks)
+                {
+                    Assert.False(activeTasks.ContainsKey(inflight.Id), "Expected completed task to be removed from s_currentActiveTasks");
+                }
+
+                lock (taskTimestamps)
+                {
+                    Assert.False(taskTimestamps.ContainsKey(inflight.Id), "Expected task timestamp to be removed after completion");
+                }
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124072", typeof(PlatformDetection), nameof(PlatformDetection.IsInterpreter))]
+        public void RuntimeAsync_ContinuationTimestampObservedDuringResume()
+        {
+            RemoteExecutor.Invoke(async () =>
+            {
+                AsyncDebuggingEnabledField.SetValue(null, true);
+
+                bool continuationTimestampObserved = false;
+
+                var tcs = new TaskCompletionSource();
+                Task inflight = FuncThatInspectsContinuationTimestamps(tcs, () =>
+                {
+                    // This callback runs inside the resumed async method body, after
+                    // ResumeRuntimeAsyncMethod but before SuspendRuntimeAsyncContext/CompleteRuntimeAsyncMethod.
+                    // The continuation timestamp for the current continuation should still be in the dictionary.
+                    var continuationTimestamps = (Dictionary<object, long>)ContinuationTimestampsField.GetValue(null);
+                    lock (continuationTimestamps)
+                    {
+                        continuationTimestampObserved = continuationTimestamps.Count > 0;
+                    }
+                });
+
+                tcs.SetResult();
+                await inflight;
+
+                Assert.True(continuationTimestampObserved, "Expected continuation timestamp to be present during resumed method execution");
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124072", typeof(PlatformDetection), nameof(PlatformDetection.IsInterpreter))]
+        public void RuntimeAsync_TplEvents()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                const int TraceOperationBeginId = 14;
+                const int TraceOperationEndId = 15;
+                const int TraceSynchronousWorkBeginId = 17;
+                const int TraceSynchronousWorkEndId = 18;
+
+                var events = new ConcurrentQueue<EventWrittenEventArgs>();
+                using (var listener = new TestEventListener("System.Threading.Tasks.TplEventSource", EventLevel.Verbose))
+                {
+                    listener.RunWithCallback(events.Enqueue, () =>
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            Func().GetAwaiter().GetResult();
+                        }
+                    });
+                }
+
+                Assert.Contains(events, e => e.EventId == TraceOperationBeginId);
+                Assert.Contains(events, e => e.EventId == TraceOperationEndId);
+                Assert.Contains(events, e => e.EventId == TraceSynchronousWorkBeginId);
+                Assert.Contains(events, e => e.EventId == TraceSynchronousWorkEndId);
             }).Dispose();
         }
     }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -191,7 +191,7 @@ namespace System.Threading.Tasks.Tests
 
                 Assert.True(seenTimestamp, "Timed out waiting for task timestamp");
 
-                // Simulate debugger detach — the flag sync should detect the mismatch
+                // Simulate debugger detach â€” the flag sync should detect the mismatch
                 // and disable the Debugger flags without crashing.
                 // Timestamps are not cleared (matches existing behavior).
                 AsyncDebuggingEnabledField.SetValue(null, false);
@@ -199,7 +199,7 @@ namespace System.Threading.Tasks.Tests
                 // Run one task to trigger the flag sync that detects the mismatch
                 await Func();
 
-                // Now start a new in-flight task after detach — it should NOT be tracked
+                // Now start a new in-flight task after detach - it should NOT be tracked
                 var tcsPost = new TaskCompletionSource();
                 Task postDetach = FuncThatWaitsTwice(tcsPost, new TaskCompletionSource());
 
@@ -293,7 +293,7 @@ namespace System.Threading.Tasks.Tests
                 var tcs2 = new TaskCompletionSource();
                 Task inflight = FuncThatWaitsTwice(tcs1, tcs2);
 
-                // Task is suspended on tcs1 — should be in active tasks
+                // Task is suspended on tcs1 â€” should be in active tasks
                 var activeTasks = (Dictionary<int, Task>)ActiveTasksField.GetValue(null);
 
                 lock (activeTasks)
@@ -301,7 +301,7 @@ namespace System.Threading.Tasks.Tests
                     Assert.True(activeTasks.ContainsKey(inflight.Id), "Expected suspended task to be in s_currentActiveTasks");
                 }
 
-                // Resume from first suspension — this triggers DispatchContinuations which sets timestamps
+                // Resume from first suspension â€” this triggers DispatchContinuations which sets timestamps
                 tcs1.SetResult();
 
                 // Poll until the dispatch loop has resumed and re-suspended on tcs2,

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -17,11 +17,16 @@ namespace System.Threading.Tasks.Tests
 
         // NOTE: This depends on private implementation details generally only used by the debugger.
         // If those ever change, this test will need to be updated as well.
-        private static FieldInfo AsyncDebuggingEnabledField => typeof(Task).GetField("s_asyncDebuggingEnabled", BindingFlags.NonPublic | BindingFlags.Static);
-        private static FieldInfo TaskTimestampsField => typeof(Task).GetField("s_runtimeAsyncTaskTimestamps", BindingFlags.NonPublic | BindingFlags.Static);
-        private static FieldInfo ContinuationTimestampsField => typeof(Task).GetField("s_runtimeAsyncContinuationTimestamps", BindingFlags.NonPublic | BindingFlags.Static);
-        private static FieldInfo ActiveTasksField => typeof(Task).GetField("s_currentActiveTasks", BindingFlags.NonPublic | BindingFlags.Static);
+        private static readonly FieldInfo AsyncDebuggingEnabledField = GetRequiredTaskStaticField("s_asyncDebuggingEnabled");
+        private static readonly FieldInfo TaskTimestampsField = GetRequiredTaskStaticField("s_runtimeAsyncTaskTimestamps");
+        private static readonly FieldInfo ContinuationTimestampsField = GetRequiredTaskStaticField("s_runtimeAsyncContinuationTimestamps");
+        private static readonly FieldInfo ActiveTasksField = GetRequiredTaskStaticField("s_currentActiveTasks");
 
+        private static FieldInfo GetRequiredTaskStaticField(string fieldName)
+        {
+            FieldInfo? field = typeof(Task).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static);
+            return field ?? throw new InvalidOperationException($"Expected static field '{fieldName}' to exist on type '{typeof(Task)}'.");
+        }
         private static int GetTaskTimestampCount() =>
             TaskTimestampsField.GetValue(null) is Dictionary<int, long> dict ? dict.Count : 0;
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -15,14 +15,12 @@ namespace System.Threading.Tasks.Tests
     {
         private static bool IsRemoteExecutorAndRuntimeAsyncSupported => RemoteExecutor.IsSupported && PlatformDetection.IsRuntimeAsyncSupported;
 
-        // NOTE: This depends on private implementation details generally only used by the debugger.
-        // If those ever change, this test will need to be updated as well.
-        private static readonly FieldInfo AsyncDebuggingEnabledField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_asyncDebuggingEnabled");
-        private static readonly FieldInfo TaskTimestampsField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_runtimeAsyncTaskTimestamps");
-        private static readonly FieldInfo ContinuationTimestampsField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_runtimeAsyncContinuationTimestamps");
-        private static readonly FieldInfo ActiveTasksField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_currentActiveTasks");
-        private static readonly FieldInfo TplEventSourceLogField = GetCorLibClassStaticField("System.Threading.Tasks.TplEventSource", "Log");
-        private static readonly FieldInfo ActiveFlagsField = GetCorLibClassStaticField("System.Runtime.CompilerServices.AsyncInstrumentation", "_activeFlags");
+        private static readonly FieldInfo s_asyncDebuggingEnabledField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_asyncDebuggingEnabled");
+        private static readonly FieldInfo s_taskTimestampsField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_runtimeAsyncTaskTimestamps");
+        private static readonly FieldInfo s_continuationTimestampsField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_runtimeAsyncContinuationTimestamps");
+        private static readonly FieldInfo s_activeTasksField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_currentActiveTasks");
+        private static readonly FieldInfo s_tplEventSourceLogField = GetCorLibClassStaticField("System.Threading.Tasks.TplEventSource", "Log");
+        private static readonly FieldInfo s_activeFlagsField = GetCorLibClassStaticField("System.Runtime.CompilerServices.AsyncInstrumentation", "_activeFlags");
 
         private static object _debuggerLock = new object();
         private static TestEventListener? _debuggerTplInstance;
@@ -37,30 +35,30 @@ namespace System.Threading.Tasks.Tests
             lock (_debuggerLock)
             {
                 // Touch TplEventSource.Log making sure provider is initialized.
-                TplEventSourceLogField.GetValue(null);
+                s_tplEventSourceLogField.GetValue(null);
 
-                long flags = Convert.ToInt64(ActiveFlagsField.GetValue(null));
+                long flags = Convert.ToInt64(s_activeFlagsField.GetValue(null));
                 Assert.True(flags == DisabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {DisabledInstrumentationFlags}");
 
                 _debuggerTplInstance = new TestEventListener("System.Threading.Tasks.TplEventSource", EventLevel.Verbose);
-                AsyncDebuggingEnabledField.SetValue(null, true);
+                s_asyncDebuggingEnabledField.SetValue(null, true);
 
-                flags = Convert.ToInt64(ActiveFlagsField.GetValue(null));
+                flags = Convert.ToInt64(s_activeFlagsField.GetValue(null));
                 Assert.True(flags == EnabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {EnabledInstrumentationFlags}");
 
                 // Initialize collections.
                 Func().GetAwaiter().GetResult();
 
-                flags = Convert.ToInt64(ActiveFlagsField.GetValue(null));
+                flags = Convert.ToInt64(s_activeFlagsField.GetValue(null));
                 Assert.True(flags == EnabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {EnabledInstrumentationFlags}");
 
-                var activeTasks = (Dictionary<int, Task>)ActiveTasksField.GetValue(null);
+                var activeTasks = (Dictionary<int, Task>)s_activeTasksField.GetValue(null);
                 Assert.True(activeTasks != null, "Expected active tasks dictionary to be initialized");
 
-                var taskTimestamps = (Dictionary<int, long>)TaskTimestampsField.GetValue(null);
+                var taskTimestamps = (Dictionary<int, long>)s_taskTimestampsField.GetValue(null);
                 Assert.True(taskTimestamps != null, "Expected tasks timestamps dictionary to be initialized");
 
-                var continuationTimestamps = (Dictionary<object, long>)ContinuationTimestampsField.GetValue(null);
+                var continuationTimestamps = (Dictionary<object, long>)s_continuationTimestampsField.GetValue(null);
                 Assert.True(continuationTimestamps != null, "Expected continuation timestamps dictionary to be initialized");
             }
         }
@@ -70,11 +68,11 @@ namespace System.Threading.Tasks.Tests
             // Simulate a debugger detach from process.
             lock (_debuggerLock)
             {
-                AsyncDebuggingEnabledField.SetValue(null, false);
+                s_asyncDebuggingEnabledField.SetValue(null, false);
                 _debuggerTplInstance.Dispose();
                 _debuggerTplInstance = null;
 
-                long flags = Convert.ToInt64(ActiveFlagsField.GetValue(null));
+                long flags = Convert.ToInt64(s_activeFlagsField.GetValue(null));
                 Assert.True(flags == DisabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {DisabledInstrumentationFlags}");
             }
         }
@@ -97,10 +95,10 @@ namespace System.Threading.Tasks.Tests
         }
 
         private static int GetTaskTimestampCount() =>
-            TaskTimestampsField.GetValue(null) is Dictionary<int, long> dict ? dict.Count : 0;
+            s_taskTimestampsField.GetValue(null) is Dictionary<int, long> dict ? dict.Count : 0;
 
         private static int GetContinuationTimestampCount() =>
-            ContinuationTimestampsField.GetValue(null) is Dictionary<object, long> dict ? dict.Count : 0;
+            s_continuationTimestampsField.GetValue(null) is Dictionary<object, long> dict ? dict.Count : 0;
 
         [System.Runtime.CompilerServices.RuntimeAsyncMethodGeneration(true)]
         static async Task Func()
@@ -242,7 +240,7 @@ namespace System.Threading.Tasks.Tests
             {
                 AttachDebugger();
 
-                var activeTasks = (Dictionary<int, Task>)ActiveTasksField.GetValue(null);
+                var activeTasks = (Dictionary<int, Task>)s_activeTasksField.GetValue(null);
 
                 // Use an in-flight task to deterministically verify tracking is active
                 var tcs = new TaskCompletionSource();
@@ -256,7 +254,7 @@ namespace System.Threading.Tasks.Tests
 
                 // Complete the first await so it resumes and sets a task timestamp
                 tcs.SetResult();
-                var taskTimestamps = (Dictionary<int, long>)TaskTimestampsField.GetValue(null);
+                var taskTimestamps = (Dictionary<int, long>)s_taskTimestampsField.GetValue(null);
 
                 bool seenTimestamp = SpinWait.SpinUntil(() =>
                 {
@@ -378,7 +376,7 @@ namespace System.Threading.Tasks.Tests
                 Task inflight = FuncThatWaitsTwice(tcs1, tcs2);
 
                 // Task is suspended on tcs1 — should be in active tasks
-                var activeTasks = (Dictionary<int, Task>)ActiveTasksField.GetValue(null);
+                var activeTasks = (Dictionary<int, Task>)s_activeTasksField.GetValue(null);
 
                 lock (activeTasks)
                 {
@@ -390,7 +388,7 @@ namespace System.Threading.Tasks.Tests
 
                 // Poll until the dispatch loop has resumed and re-suspended on tcs2,
                 // which sets the task timestamp via ResumeRuntimeAsyncMethod.
-                var taskTimestamps = (Dictionary<int, long>)TaskTimestampsField.GetValue(null);
+                var taskTimestamps = (Dictionary<int, long>)s_taskTimestampsField.GetValue(null);
 
                 bool seenTimestamp = SpinWait.SpinUntil(() =>
                 {
@@ -444,7 +442,7 @@ namespace System.Threading.Tasks.Tests
                     // This callback runs inside the resumed async method body, after
                     // ResumeRuntimeAsyncMethod but before SuspendRuntimeAsyncContext/CompleteRuntimeAsyncMethod.
                     // The continuation timestamp for the current continuation should still be in the dictionary.
-                    var continuationTimestamps = (Dictionary<object, long>)ContinuationTimestampsField.GetValue(null);
+                    var continuationTimestamps = (Dictionary<object, long>)s_continuationTimestampsField.GetValue(null);
                     lock (continuationTimestamps)
                     {
                         continuationTimestampObserved = continuationTimestamps.Count > 0;
@@ -476,8 +474,8 @@ namespace System.Threading.Tasks.Tests
                 // Attach the debugger mid-flight — this enables instrumentation.
                 AttachDebugger();
 
-                var activeTasks = (Dictionary<int, Task>)ActiveTasksField.GetValue(null);
-                var taskTimestamps = (Dictionary<int, long>)TaskTimestampsField.GetValue(null);
+                var activeTasks = (Dictionary<int, Task>)s_activeTasksField.GetValue(null);
+                var taskTimestamps = (Dictionary<int, long>)s_taskTimestampsField.GetValue(null);
 
                 // The in-flight task was NOT tracked at creation (no instrumentation then).
                 lock (activeTasks)

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -21,8 +21,8 @@ namespace System.Threading.Tasks.Tests
         private static readonly FieldInfo TaskTimestampsField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_runtimeAsyncTaskTimestamps");
         private static readonly FieldInfo ContinuationTimestampsField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_runtimeAsyncContinuationTimestamps");
         private static readonly FieldInfo ActiveTasksField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_currentActiveTasks");
-        private static readonly FieldInfo TplEventSource = GetCorLibClassStaticField("System.Threading.Tasks.TplEventSource", "Log");
-        private static readonly FieldInfo ActiveFlags = GetCorLibClassStaticField("System.Runtime.CompilerServices.AsyncInstrumentation", "_activeFlags");
+        private static readonly FieldInfo TplEventSourceLogField = GetCorLibClassStaticField("System.Threading.Tasks.TplEventSource", "Log");
+        private static readonly FieldInfo ActiveFlagsField = GetCorLibClassStaticField("System.Runtime.CompilerServices.AsyncInstrumentation", "_activeFlags");
 
         private static object _debuggerLock = new object();
         private static TestEventListener? _debuggerTplInstance;
@@ -37,21 +37,21 @@ namespace System.Threading.Tasks.Tests
             lock (_debuggerLock)
             {
                 // Touch TplEventSource.Log making sure provider is initialized.
-                TplEventSource.GetValue(null);
+                TplEventSourceLogField.GetValue(null);
 
-                long flags = Convert.ToInt64(ActiveFlags.GetValue(null));
+                long flags = Convert.ToInt64(ActiveFlagsField.GetValue(null));
                 Assert.True(flags == DisabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {DisabledInstrumentationFlags}");
 
                 _debuggerTplInstance = new TestEventListener("System.Threading.Tasks.TplEventSource", EventLevel.Verbose);
                 AsyncDebuggingEnabledField.SetValue(null, true);
 
-                flags = Convert.ToInt64(ActiveFlags.GetValue(null));
+                flags = Convert.ToInt64(ActiveFlagsField.GetValue(null));
                 Assert.True(flags == EnabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {EnabledInstrumentationFlags}");
 
                 // Initialize collections.
                 Func().GetAwaiter().GetResult();
 
-                flags = Convert.ToInt64(ActiveFlags.GetValue(null));
+                flags = Convert.ToInt64(ActiveFlagsField.GetValue(null));
                 Assert.True(flags == EnabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {EnabledInstrumentationFlags}");
 
                 var activeTasks = (Dictionary<int, Task>)ActiveTasksField.GetValue(null);
@@ -74,7 +74,7 @@ namespace System.Threading.Tasks.Tests
                 _debuggerTplInstance.Dispose();
                 _debuggerTplInstance = null;
 
-                long flags = Convert.ToInt64(ActiveFlags.GetValue(null));
+                long flags = Convert.ToInt64(ActiveFlagsField.GetValue(null));
                 Assert.True(flags == DisabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {DisabledInstrumentationFlags}");
             }
         }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -24,8 +24,8 @@ namespace System.Threading.Tasks.Tests
         private static readonly object s_debuggerLock = new object();
         private static TestEventListener? s_debuggerTplInstance;
 
-        // Tpl(0x20000) | Debugger(0x40000) | all event flags(0x7F)
-        private const uint EnabledInstrumentationFlags = 0x6007F;
+        // AsyncDebugger(0x2000000) | all event flags(0x7F)
+        private const uint EnabledInstrumentationFlags = 0x200007F;
         private const uint DisabledInstrumentationFlags = 0x0;
         private const uint UninitializedInstrumentationFlags = 0x80000000;
 
@@ -514,6 +514,8 @@ namespace System.Threading.Tasks.Tests
                 const int TraceSynchronousWorkBeginId = 17;
                 const int TraceSynchronousWorkEndId = 18;
 
+                AttachDebugger();
+
                 var events = new ConcurrentQueue<EventWrittenEventArgs>();
                 using (var listener = new TestEventListener("System.Threading.Tasks.TplEventSource", EventLevel.Verbose))
                 {
@@ -530,6 +532,44 @@ namespace System.Threading.Tasks.Tests
                 Assert.Contains(events, e => e.EventId == TraceOperationEndId);
                 Assert.Contains(events, e => e.EventId == TraceSynchronousWorkBeginId);
                 Assert.Contains(events, e => e.EventId == TraceSynchronousWorkEndId);
+
+                DetachDebugger();
+
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124072", typeof(PlatformDetection), nameof(PlatformDetection.IsInterpreter))]
+        public void RuntimeAsync_NoTplEventsWithoutDebugger()
+        {
+            RemoteExecutor.Invoke(() =>
+            {
+                const int TraceOperationBeginId = 14;
+                const string RuntimeAsyncTaskOperationName = "System.Runtime.CompilerServices.AsyncHelpers+RuntimeAsyncTask";
+
+                // Enable TplEventSource WITHOUT setting s_asyncDebuggingEnabled.
+                // The AsyncDebugger guard should prevent the V2 async instrumentation
+                // from emitting any TPL causality events.
+                var events = new ConcurrentQueue<EventWrittenEventArgs>();
+                using (var listener = new TestEventListener("System.Threading.Tasks.TplEventSource", EventLevel.Verbose))
+                {
+                    listener.RunWithCallback(events.Enqueue, () =>
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            Func().GetAwaiter().GetResult();
+                        }
+                    });
+                }
+
+                // TraceOperationBegin with the RuntimeAsyncTask operation name is uniquely
+                // emitted by V2 async instrumentation. It must not appear without a debugger.
+                Assert.DoesNotContain(events, e =>
+                    e.EventId == TraceOperationBeginId &&
+                    e.Payload?.Count > 1 &&
+                    e.Payload[1] is string name &&
+                    name == RuntimeAsyncTaskOperationName);
+
             }).Dispose();
         }
     }

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -22,8 +22,8 @@ namespace System.Threading.Tasks.Tests
         private static readonly FieldInfo s_tplEventSourceLogField = GetCorLibClassStaticField("System.Threading.Tasks.TplEventSource", "Log");
         private static readonly FieldInfo s_activeFlagsField = GetCorLibClassStaticField("System.Runtime.CompilerServices.AsyncInstrumentation", "s_activeFlags");
 
-        private static object _debuggerLock = new object();
-        private static TestEventListener? _debuggerTplInstance;
+        private static readonly object s_debuggerLock = new object();
+        private static TestEventListener? s_debuggerTplInstance;
 
         // Tpl(0x20000) | Debugger(0x40000) | all event flags(0x7F)
         private const long EnabledInstrumentationFlags = 0x6007F;
@@ -32,7 +32,7 @@ namespace System.Threading.Tasks.Tests
         private static void AttachDebugger()
         {
             // Simulate a debugger attach to process, creating TPL event source session + setting s_asyncDebuggingEnabled.
-            lock (_debuggerLock)
+            lock (s_debuggerLock)
             {
                 // Touch TplEventSource.Log making sure provider is initialized.
                 s_tplEventSourceLogField.GetValue(null);
@@ -40,7 +40,7 @@ namespace System.Threading.Tasks.Tests
                 long flags = Convert.ToInt64(s_activeFlagsField.GetValue(null));
                 Assert.True(flags == DisabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {DisabledInstrumentationFlags}");
 
-                _debuggerTplInstance = new TestEventListener("System.Threading.Tasks.TplEventSource", EventLevel.Verbose);
+                s_debuggerTplInstance = new TestEventListener("System.Threading.Tasks.TplEventSource", EventLevel.Verbose);
                 s_asyncDebuggingEnabledField.SetValue(null, true);
 
                 flags = Convert.ToInt64(s_activeFlagsField.GetValue(null));
@@ -66,11 +66,11 @@ namespace System.Threading.Tasks.Tests
         private static void DetachDebugger()
         {
             // Simulate a debugger detach from process.
-            lock (_debuggerLock)
+            lock (s_debuggerLock)
             {
                 s_asyncDebuggingEnabledField.SetValue(null, false);
-                _debuggerTplInstance?.Dispose();
-                _debuggerTplInstance = null;
+                s_debuggerTplInstance?.Dispose();
+                s_debuggerTplInstance = null;
 
                 long flags = Convert.ToInt64(s_activeFlagsField.GetValue(null));
                 Assert.True(flags == DisabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {DisabledInstrumentationFlags}");

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -69,7 +69,7 @@ namespace System.Threading.Tasks.Tests
             lock (_debuggerLock)
             {
                 s_asyncDebuggingEnabledField.SetValue(null, false);
-                _debuggerTplInstance.Dispose();
+                _debuggerTplInstance?.Dispose();
                 _debuggerTplInstance = null;
 
                 long flags = Convert.ToInt64(s_activeFlagsField.GetValue(null));

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -20,7 +20,7 @@ namespace System.Threading.Tasks.Tests
         private static readonly FieldInfo s_continuationTimestampsField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_runtimeAsyncContinuationTimestamps");
         private static readonly FieldInfo s_activeTasksField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_currentActiveTasks");
         private static readonly FieldInfo s_tplEventSourceLogField = GetCorLibClassStaticField("System.Threading.Tasks.TplEventSource", "Log");
-        private static readonly FieldInfo s_activeFlagsField = GetCorLibClassStaticField("System.Runtime.CompilerServices.AsyncInstrumentation", "_activeFlags");
+        private static readonly FieldInfo s_activeFlagsField = GetCorLibClassStaticField("System.Runtime.CompilerServices.AsyncInstrumentation", "s_activeFlags");
 
         private static object _debuggerLock = new object();
         private static TestEventListener? _debuggerTplInstance;

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -17,16 +17,85 @@ namespace System.Threading.Tasks.Tests
 
         // NOTE: This depends on private implementation details generally only used by the debugger.
         // If those ever change, this test will need to be updated as well.
-        private static readonly FieldInfo AsyncDebuggingEnabledField = GetRequiredTaskStaticField("s_asyncDebuggingEnabled");
-        private static readonly FieldInfo TaskTimestampsField = GetRequiredTaskStaticField("s_runtimeAsyncTaskTimestamps");
-        private static readonly FieldInfo ContinuationTimestampsField = GetRequiredTaskStaticField("s_runtimeAsyncContinuationTimestamps");
-        private static readonly FieldInfo ActiveTasksField = GetRequiredTaskStaticField("s_currentActiveTasks");
+        private static readonly FieldInfo AsyncDebuggingEnabledField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_asyncDebuggingEnabled");
+        private static readonly FieldInfo TaskTimestampsField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_runtimeAsyncTaskTimestamps");
+        private static readonly FieldInfo ContinuationTimestampsField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_runtimeAsyncContinuationTimestamps");
+        private static readonly FieldInfo ActiveTasksField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_currentActiveTasks");
+        private static readonly FieldInfo TplEventSource = GetCorLibClassStaticField("System.Threading.Tasks.TplEventSource", "Log");
+        private static readonly FieldInfo ActiveFlags = GetCorLibClassStaticField("System.Runtime.CompilerServices.AsyncInstrumentation", "_activeFlags");
 
-        private static FieldInfo GetRequiredTaskStaticField(string fieldName)
+        private static object _debuggerLock = new object();
+        private static TestEventListener? _debuggerTplInstance;
+
+        // Tpl(0x20000) | Debugger(0x40000) | all event flags(0x7F)
+        private const long EnabledInstrumentationFlags = 0x6007F;
+        private const long DisabledInstrumentationFlags = 0x0;
+
+        private static void AttachDebugger()
         {
-            FieldInfo? field = typeof(Task).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static);
-            return field ?? throw new InvalidOperationException($"Expected static field '{fieldName}' to exist on type '{typeof(Task)}'.");
+            // Simulate a debugger attach to process, creating TPL event source session + setting s_asyncDebuggingEnabled.
+            lock (_debuggerLock)
+            {
+                // Touch TplEventSource.Log making sure provider is initialized.
+                TplEventSource.GetValue(null);
+
+                long flags = Convert.ToInt64(ActiveFlags.GetValue(null));
+                Assert.True(flags == DisabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {DisabledInstrumentationFlags}");
+
+                _debuggerTplInstance = new TestEventListener("System.Threading.Tasks.TplEventSource", EventLevel.Verbose);
+                AsyncDebuggingEnabledField.SetValue(null, true);
+
+                flags = Convert.ToInt64(ActiveFlags.GetValue(null));
+                Assert.True(flags == EnabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {EnabledInstrumentationFlags}");
+
+                // Initialize collections.
+                Func().GetAwaiter().GetResult();
+
+                flags = Convert.ToInt64(ActiveFlags.GetValue(null));
+                Assert.True(flags == EnabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {EnabledInstrumentationFlags}");
+
+                var activeTasks = (Dictionary<int, Task>)ActiveTasksField.GetValue(null);
+                Assert.True(activeTasks != null, "Expected active tasks dictionary to be initialized");
+
+                var taskTimestamps = (Dictionary<int, long>)TaskTimestampsField.GetValue(null);
+                Assert.True(taskTimestamps != null, "Expected tasks timestamps dictionary to be initialized");
+
+                var continuationTimestamps = (Dictionary<object, long>)ContinuationTimestampsField.GetValue(null);
+                Assert.True(continuationTimestamps != null, "Expected continuation timestamps dictionary to be initialized");
+            }
         }
+
+        private static void DetachDebugger()
+        {
+            // Simulate a debugger detach from process.
+            lock (_debuggerLock)
+            {
+                AsyncDebuggingEnabledField.SetValue(null, false);
+                _debuggerTplInstance.Dispose();
+                _debuggerTplInstance = null;
+
+                long flags = Convert.ToInt64(ActiveFlags.GetValue(null));
+                Assert.True(flags == DisabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {DisabledInstrumentationFlags}");
+            }
+        }
+
+        private static FieldInfo GetCorLibClassStaticField(string className, string fieldName)
+        {
+            Type? classType = typeof(object).Assembly.GetType(className);
+            if (classType == null)
+            {
+                throw new InvalidOperationException($"Type '{className}' doesn't exist in System.Private.CoreLib.");
+            }
+
+            FieldInfo? field = classType.GetField(fieldName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            if (field == null)
+            {
+                throw new InvalidOperationException($"Expected static field '{fieldName}' to exist on type '{className}'.");
+            }
+
+            return field;
+        }
+
         private static int GetTaskTimestampCount() =>
             TaskTimestampsField.GetValue(null) is Dictionary<int, long> dict ? dict.Count : 0;
 
@@ -125,7 +194,7 @@ namespace System.Threading.Tasks.Tests
         {
             RemoteExecutor.Invoke(async () =>
             {
-                AsyncDebuggingEnabledField.SetValue(null, true);
+                AttachDebugger();
 
                 for (int i = 0; i < 1000; i++)
                 {
@@ -133,6 +202,9 @@ namespace System.Threading.Tasks.Tests
                 }
 
                 ValidateTimestampsCleared();
+
+                DetachDebugger();
+
             }).Dispose();
         }
 
@@ -142,7 +214,7 @@ namespace System.Threading.Tasks.Tests
         {
             RemoteExecutor.Invoke(async () =>
             {
-                AsyncDebuggingEnabledField.SetValue(null, true);
+                AttachDebugger();
 
                 for (int i = 0; i < 1000; i++)
                 {
@@ -156,6 +228,9 @@ namespace System.Threading.Tasks.Tests
                 }
 
                 ValidateTimestampsCleared();
+
+                DetachDebugger();
+
             }).Dispose();
         }
 
@@ -165,10 +240,7 @@ namespace System.Threading.Tasks.Tests
         {
             RemoteExecutor.Invoke(async () =>
             {
-                AsyncDebuggingEnabledField.SetValue(null, true);
-
-                // Run one task to ensure lazy-initialized collections are created
-                await Func();
+                AttachDebugger();
 
                 var activeTasks = (Dictionary<int, Task>)ActiveTasksField.GetValue(null);
 
@@ -199,7 +271,7 @@ namespace System.Threading.Tasks.Tests
                 // Simulate debugger detach — the flag sync should detect the mismatch
                 // and disable the Debugger flags without crashing.
                 // Timestamps are not cleared (matches existing behavior).
-                AsyncDebuggingEnabledField.SetValue(null, false);
+                DetachDebugger();
 
                 // Run one task to trigger the flag sync that detects the mismatch
                 await Func();
@@ -219,6 +291,7 @@ namespace System.Threading.Tasks.Tests
                     Assert.False(taskTimestamps.ContainsKey(postDetach.Id),
                         "Expected no task timestamp for post-detach in-flight task");
                 }
+
             }).Dispose();
         }
 
@@ -228,7 +301,7 @@ namespace System.Threading.Tasks.Tests
         {
             RemoteExecutor.Invoke(async () =>
             {
-                AsyncDebuggingEnabledField.SetValue(null, true);
+                AttachDebugger();
 
                 for (int i = 0; i < 1000; i++)
                 {
@@ -237,6 +310,9 @@ namespace System.Threading.Tasks.Tests
                 }
 
                 ValidateTimestampsCleared();
+
+                DetachDebugger();
+
             }).Dispose();
         }
 
@@ -246,7 +322,7 @@ namespace System.Threading.Tasks.Tests
         {
             RemoteExecutor.Invoke(async () =>
             {
-                AsyncDebuggingEnabledField.SetValue(null, true);
+                AttachDebugger();
 
                 for (int i = 0; i < 1000; i++)
                 {
@@ -254,6 +330,9 @@ namespace System.Threading.Tasks.Tests
                 }
 
                 ValidateTimestampsCleared();
+
+                DetachDebugger();
+
             }).Dispose();
         }
 
@@ -263,7 +342,7 @@ namespace System.Threading.Tasks.Tests
         {
             RemoteExecutor.Invoke(async () =>
             {
-                AsyncDebuggingEnabledField.SetValue(null, true);
+                AttachDebugger();
 
                 using var cts = new CancellationTokenSource();
                 cts.Cancel();
@@ -280,6 +359,9 @@ namespace System.Threading.Tasks.Tests
                 }
 
                 ValidateTimestampsCleared();
+
+                DetachDebugger();
+
             }).Dispose();
         }
 
@@ -289,10 +371,7 @@ namespace System.Threading.Tasks.Tests
         {
             RemoteExecutor.Invoke(async () =>
             {
-                AsyncDebuggingEnabledField.SetValue(null, true);
-
-                // Run one task to ensure lazy-initialized collections are created
-                await Func();
+                AttachDebugger();
 
                 var tcs1 = new TaskCompletionSource();
                 var tcs2 = new TaskCompletionSource();
@@ -343,6 +422,9 @@ namespace System.Threading.Tasks.Tests
                 {
                     Assert.False(taskTimestamps.ContainsKey(inflight.Id), "Expected task timestamp to be removed after completion");
                 }
+
+                DetachDebugger();
+
             }).Dispose();
         }
 
@@ -352,7 +434,7 @@ namespace System.Threading.Tasks.Tests
         {
             RemoteExecutor.Invoke(async () =>
             {
-                AsyncDebuggingEnabledField.SetValue(null, true);
+                AttachDebugger();
 
                 bool continuationTimestampObserved = false;
 
@@ -373,6 +455,59 @@ namespace System.Threading.Tasks.Tests
                 await inflight;
 
                 Assert.True(continuationTimestampObserved, "Expected continuation timestamp to be present during resumed method execution");
+
+                DetachDebugger();
+
+            }).Dispose();
+        }
+
+        [ConditionalFact(typeof(RuntimeAsyncTests), nameof(IsRemoteExecutorAndRuntimeAsyncSupported))]
+        [ActiveIssue("https://github.com/dotnet/runtime/issues/124072", typeof(PlatformDetection), nameof(PlatformDetection.IsInterpreter))]
+        public void RuntimeAsync_InFlightInstrumentationUpgrade()
+        {
+            RemoteExecutor.Invoke(async () =>
+            {
+                // Start a multi-await task WITHOUT instrumentation enabled.
+                var tcs1 = new TaskCompletionSource();
+                var tcs2 = new TaskCompletionSource();
+                Task inflight = FuncThatWaitsTwice(tcs1, tcs2);
+
+                // Task is now suspended at first await with no instrumentation.
+                // Attach the debugger mid-flight — this enables instrumentation.
+                AttachDebugger();
+
+                var activeTasks = (Dictionary<int, Task>)ActiveTasksField.GetValue(null);
+                var taskTimestamps = (Dictionary<int, long>)TaskTimestampsField.GetValue(null);
+
+                // The in-flight task was NOT tracked at creation (no instrumentation then).
+                lock (activeTasks)
+                {
+                    Assert.False(activeTasks.ContainsKey(inflight.Id),
+                        "Expected in-flight task NOT to be tracked (started before instrumentation)");
+                }
+
+                // Resume the first await — the dispatch loop's InstrumentCheckPoint should
+                // detect that instrumentation is now active and transition to the instrumented path.
+                tcs1.SetResult();
+
+                // Wait for the task to suspend at the second await.
+                bool seenTimestamp = SpinWait.SpinUntil(() =>
+                {
+                    lock (taskTimestamps)
+                    {
+                        return taskTimestamps.ContainsKey(inflight.Id);
+                    }
+                }, timeout: TimeSpan.FromSeconds(5));
+
+                Assert.True(seenTimestamp,
+                    "Expected task timestamp after mid-flight instrumentation upgrade (InstrumentCheckPoint transition)");
+
+                // Complete the second await and let the task finish.
+                tcs2.SetResult();
+                await inflight;
+
+                DetachDebugger();
+
             }).Dispose();
         }
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/System.Runtime.CompilerServices/RuntimeAsyncTests.cs
@@ -19,37 +19,31 @@ namespace System.Threading.Tasks.Tests
         private static readonly FieldInfo s_taskTimestampsField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_runtimeAsyncTaskTimestamps");
         private static readonly FieldInfo s_continuationTimestampsField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_runtimeAsyncContinuationTimestamps");
         private static readonly FieldInfo s_activeTasksField = GetCorLibClassStaticField("System.Threading.Tasks.Task", "s_currentActiveTasks");
-        private static readonly FieldInfo s_tplEventSourceLogField = GetCorLibClassStaticField("System.Threading.Tasks.TplEventSource", "Log");
         private static readonly FieldInfo s_activeFlagsField = GetCorLibClassStaticField("System.Runtime.CompilerServices.AsyncInstrumentation", "s_activeFlags");
 
         private static readonly object s_debuggerLock = new object();
         private static TestEventListener? s_debuggerTplInstance;
 
         // Tpl(0x20000) | Debugger(0x40000) | all event flags(0x7F)
-        private const long EnabledInstrumentationFlags = 0x6007F;
-        private const long DisabledInstrumentationFlags = 0x0;
+        private const uint EnabledInstrumentationFlags = 0x6007F;
+        private const uint DisabledInstrumentationFlags = 0x0;
+        private const uint UninitializedInstrumentationFlags = 0x80000000;
 
         private static void AttachDebugger()
         {
             // Simulate a debugger attach to process, creating TPL event source session + setting s_asyncDebuggingEnabled.
             lock (s_debuggerLock)
             {
-                // Touch TplEventSource.Log making sure provider is initialized.
-                s_tplEventSourceLogField.GetValue(null);
-
-                long flags = Convert.ToInt64(s_activeFlagsField.GetValue(null));
-                Assert.True(flags == DisabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {DisabledInstrumentationFlags}");
+                uint flags = Convert.ToUInt32(s_activeFlagsField.GetValue(null));
+                Assert.True(flags == UninitializedInstrumentationFlags || flags == DisabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {UninitializedInstrumentationFlags} || {DisabledInstrumentationFlags}");
 
                 s_debuggerTplInstance = new TestEventListener("System.Threading.Tasks.TplEventSource", EventLevel.Verbose);
                 s_asyncDebuggingEnabledField.SetValue(null, true);
 
-                flags = Convert.ToInt64(s_activeFlagsField.GetValue(null));
-                Assert.True(flags == EnabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {EnabledInstrumentationFlags}");
-
-                // Initialize collections.
+                // Initialize flags and collections.
                 Func().GetAwaiter().GetResult();
 
-                flags = Convert.ToInt64(s_activeFlagsField.GetValue(null));
+                flags = Convert.ToUInt32(s_activeFlagsField.GetValue(null));
                 Assert.True(flags == EnabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {EnabledInstrumentationFlags}");
 
                 var activeTasks = (Dictionary<int, Task>)s_activeTasksField.GetValue(null);
@@ -72,7 +66,7 @@ namespace System.Threading.Tasks.Tests
                 s_debuggerTplInstance?.Dispose();
                 s_debuggerTplInstance = null;
 
-                long flags = Convert.ToInt64(s_activeFlagsField.GetValue(null));
+                uint flags = Convert.ToUInt32(s_activeFlagsField.GetValue(null));
                 Assert.True(flags == DisabledInstrumentationFlags, $"ActiveFlags equals {flags}, expected {DisabledInstrumentationFlags}");
             }
         }

--- a/src/tests/async/reflection/reflection.cs
+++ b/src/tests/async/reflection/reflection.cs
@@ -310,8 +310,21 @@ public class Async2Reflection
         {
             // Note: we go through suspend/resume, that is why we see dispatcher as the caller.
             //       we do not see the resume stub though.
-            Assert.Equal("Void DispatchContinuations()", FromStackAsync(1).Result);
-            Assert.Equal("Void DispatchContinuations()", FromStackAwait(1).Result);
+            // The dispatch loop is now a generic method (DispatchContinuations<T>). In checked/debug builds,
+            // ResumeRuntimeAsyncMethod may not be inlined, appearing as the immediate caller instead.
+            string asyncFrame = FromStackAsync(1).Result;
+            string awaitFrame = FromStackAwait(1).Result;
+            Assert.True(asyncFrame.Contains("DispatchContinuations") || asyncFrame.Contains("ResumeRuntimeAsyncMethod"),
+                $"Expected dispatch infrastructure frame, got: {asyncFrame}");
+            Assert.True(awaitFrame.Contains("DispatchContinuations") || awaitFrame.Contains("ResumeRuntimeAsyncMethod"),
+                $"Expected dispatch infrastructure frame, got: {awaitFrame}");
+
+            // In release builds, ResumeRuntimeAsyncMethod must be inlined into DispatchContinuations.
+            if (TestLibrary.CoreClrConfigurationDetection.IsReleaseRuntime)
+            {
+                Assert.DoesNotContain("ResumeRuntimeAsyncMethod", asyncFrame);
+                Assert.DoesNotContain("ResumeRuntimeAsyncMethod", awaitFrame);
+            }
 
             Assert.Equal("Void FromStack(Int32)", FromStackTask(1).Result);
             // Note: we do not go through suspend/resume, that is why we see the actual caller.
@@ -370,8 +383,21 @@ public class Async2Reflection
         {
             // Note: we go through suspend/resume, that is why we see dispatcher as the caller.
             //       we do not see the resume stub though.
-            Assert.Equal("DispatchContinuations", FromStackDMIAsync(1).Result);
-            Assert.Equal("DispatchContinuations", FromStackDMIAwait(1).Result);
+            // The dispatch loop is now a generic method (DispatchContinuations<T>). In checked/debug builds,
+            // ResumeRuntimeAsyncMethod may not be inlined, appearing as the immediate caller instead.
+            string asyncName = FromStackDMIAsync(1).Result;
+            string awaitName = FromStackDMIAwait(1).Result;
+            Assert.True(asyncName == "DispatchContinuations" || asyncName == "ResumeRuntimeAsyncMethod",
+                $"Expected DispatchContinuations or ResumeRuntimeAsyncMethod, got: {asyncName}");
+            Assert.True(awaitName == "DispatchContinuations" || awaitName == "ResumeRuntimeAsyncMethod",
+                $"Expected DispatchContinuations or ResumeRuntimeAsyncMethod, got: {awaitName}");
+
+            // In release builds, ResumeRuntimeAsyncMethod must be inlined into DispatchContinuations.
+            if (TestLibrary.CoreClrConfigurationDetection.IsReleaseRuntime)
+            {
+                Assert.Equal("DispatchContinuations", asyncName);
+                Assert.Equal("DispatchContinuations", awaitName);
+            }
 
             Assert.Equal("FromStackDMI", FromStackDMITask(1).Result);
             // Note: we do not go through suspend/resume, that is why we see the actual caller.

--- a/src/tests/async/reflection/reflection.cs
+++ b/src/tests/async/reflection/reflection.cs
@@ -310,21 +310,8 @@ public class Async2Reflection
         {
             // Note: we go through suspend/resume, that is why we see dispatcher as the caller.
             //       we do not see the resume stub though.
-            // The dispatch loop is now a generic method (DispatchContinuations<T>). In checked/debug builds,
-            // ResumeRuntimeAsyncMethod may not be inlined, appearing as the immediate caller instead.
-            string asyncFrame = FromStackAsync(1).Result;
-            string awaitFrame = FromStackAwait(1).Result;
-            Assert.True(asyncFrame.Contains("DispatchContinuations") || asyncFrame.Contains("ResumeRuntimeAsyncMethod"),
-                $"Expected dispatch infrastructure frame, got: {asyncFrame}");
-            Assert.True(awaitFrame.Contains("DispatchContinuations") || awaitFrame.Contains("ResumeRuntimeAsyncMethod"),
-                $"Expected dispatch infrastructure frame, got: {awaitFrame}");
-
-            // In release builds, ResumeRuntimeAsyncMethod must be inlined into DispatchContinuations.
-            if (TestLibrary.CoreClrConfigurationDetection.IsReleaseRuntime)
-            {
-                Assert.DoesNotContain("ResumeRuntimeAsyncMethod", asyncFrame);
-                Assert.DoesNotContain("ResumeRuntimeAsyncMethod", awaitFrame);
-            }
+            Assert.Equal("Void DispatchContinuations()", FromStackAsync(1).Result);
+            Assert.Equal("Void DispatchContinuations()", FromStackAwait(1).Result);
 
             Assert.Equal("Void FromStack(Int32)", FromStackTask(1).Result);
             // Note: we do not go through suspend/resume, that is why we see the actual caller.
@@ -383,21 +370,8 @@ public class Async2Reflection
         {
             // Note: we go through suspend/resume, that is why we see dispatcher as the caller.
             //       we do not see the resume stub though.
-            // The dispatch loop is now a generic method (DispatchContinuations<T>). In checked/debug builds,
-            // ResumeRuntimeAsyncMethod may not be inlined, appearing as the immediate caller instead.
-            string asyncName = FromStackDMIAsync(1).Result;
-            string awaitName = FromStackDMIAwait(1).Result;
-            Assert.True(asyncName == "DispatchContinuations" || asyncName == "ResumeRuntimeAsyncMethod",
-                $"Expected DispatchContinuations or ResumeRuntimeAsyncMethod, got: {asyncName}");
-            Assert.True(awaitName == "DispatchContinuations" || awaitName == "ResumeRuntimeAsyncMethod",
-                $"Expected DispatchContinuations or ResumeRuntimeAsyncMethod, got: {awaitName}");
-
-            // In release builds, ResumeRuntimeAsyncMethod must be inlined into DispatchContinuations.
-            if (TestLibrary.CoreClrConfigurationDetection.IsReleaseRuntime)
-            {
-                Assert.Equal("DispatchContinuations", asyncName);
-                Assert.Equal("DispatchContinuations", awaitName);
-            }
+            Assert.Equal("DispatchContinuations", FromStackDMIAsync(1).Result);
+            Assert.Equal("DispatchContinuations", FromStackDMIAwait(1).Result);
 
             Assert.Equal("FromStackDMI", FromStackDMITask(1).Result);
             // Note: we do not go through suspend/resume, that is why we see the actual caller.


### PR DESCRIPTION
https://github.com/dotnet/runtime/pull/123727 introduced a regression of ~7% adding additional instrumentation for Debugger/TPL into `RuntimeAsyncTask::DispatchContinuations`. Going forward, there will be even more instrumentation needed when implementing async profiling and that would increase the overhead even more, so we need a way to isolate the instrumented vs none instrumented version of this method and regain some of the lost performance.

This PR duplicates DispatchContinuations into two methods, regular and instrumented. Previous version of PR used a generic value type specialization, but it was decided that the simplification not using generic value type specialization is worth the duplication of the function.

To be able to "upgrade" from none instrumented to instrumented version of `DispatchContinuations`, there are checks at method entry and after each completed continuation detecting if method should switch to instrumented version. Both checks are small and fast just a load of a flag in a static variable and checked if it's not 0.

This change will make sure the `RuntimeAsyncTask::DispatchContinuations` is protected from future performance regressions when more instrumentation gets added into the instrumented version.

Running the same benchmark, https://github.com/dotnet/runtime/pull/123727#issuecomment-3984559863 now shows the following numbers on old vs new implementation:

Metric | Old | New | Diff
-- | -- | -- | --
Total bytes (`S.P.C`) | 16 740 KB | 16 756 KB | +16 KB
JIT Size (`RuntimeAsyncTask::DispatchContinuations`) | 1778 B | 1399 B | -379 B
Benchmark | 337ms | 362ms | -25ms (~ -7%)

Measurements done on Windows x64.

`S.P.C` is **16 KB larger** with this PR,  due to duplicated DispatchContinuation method.

JIT Size is **379 bytes smaller** on none instrumented version of `RuntimeAsyncTask::DispatchContinuations`, all previous instrumentation has been moved to instrumented version, completely eliminated in default method.

Benchmark shows that this PR **recover most of the performance** previously lost in https://github.com/dotnet/runtime/pull/123727.

Code paths triggering the use of instrumented version, `InstrumentedDispatchContinuations` are protected by a `IsSupported` flag, so can be trimmed away, removing references to `InstrumentedDispatchContinuations`.

Most changes in this PR are around extracting out existing instrumentation into the instrumentation implementation. PR also optimize some of the debugger instrumentations previously implemented reducing locking in scenarios where continuation chains are handled.

PR adds a number of new tests validating that the current debugger and TPL instrumentation is still working.

PR also adds preparation for async profiler instrumentation in the AsyncInstrumentation type. This type will be used by more scenarios going forward.