### PR TITLE
FileConfigurationProvider: Handle and forward IO exceptions to OnLoadException

### DIFF
--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Extensions.Configuration
                         {
                             Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
                         }
-                        string filePath = Source.Path ?? file.Name;
+                        string filePath = file.PhysicalPath ?? Source.Path ?? file.Name;
                         throw new InvalidDataException(SR.Format(SR.Error_FailedToLoad, filePath), ex);
                     }
                 }

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -93,10 +93,21 @@ namespace Microsoft.Extensions.Configuration
                     return fileInfo.CreateReadStream();
                 }
 
-                using Stream stream = OpenRead(file);
                 try
                 {
-                    Load(stream);
+                    using Stream stream = OpenRead(file);
+                    try
+                    {
+                        Load(stream);
+                    }
+                    catch (Exception ex)
+                    {
+                        if (reload)
+                        {
+                            Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+                        }
+                        throw new InvalidDataException(SR.Format(SR.Error_FailedToLoad, file.PhysicalPath), ex);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -104,8 +115,7 @@ namespace Microsoft.Extensions.Configuration
                     {
                         Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
                     }
-                    var exception = new InvalidDataException(SR.Format(SR.Error_FailedToLoad, file.PhysicalPath), ex);
-                    HandleException(ExceptionDispatchInfo.Capture(exception));
+                    HandleException(ExceptionDispatchInfo.Capture(ex));
                 }
             }
             // REVIEW: Should we raise this in the base as well / instead?

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -106,13 +106,13 @@ namespace Microsoft.Extensions.Configuration
                         {
                             Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
                         }
-                        throw ex;
+                        string filePath = Source.Path ?? file.Name;
+                        throw new InvalidDataException(SR.Format(SR.Error_FailedToLoad, filePath), ex);
                     }
                 }
                 catch (Exception ex)
                 {
-                    var exception = new InvalidDataException(SR.Format(SR.Error_FailedToLoad, file.PhysicalPath), ex);
-                    HandleException(ExceptionDispatchInfo.Capture(exception));
+                    HandleException(ExceptionDispatchInfo.Capture(ex));
                 }
             }
             // REVIEW: Should we raise this in the base as well / instead?
@@ -129,6 +129,7 @@ namespace Microsoft.Extensions.Configuration
         /// <exception cref="InvalidDataException">An exception was thrown by the concrete implementation of the
         /// <see cref="Load()"/> method. Use the source <see cref="FileConfigurationSource.OnLoadException"/> callback
         /// if you need more control over the exception.</exception>
+        /// <exception cref="IOException">An exception was thrown when opening file.</exception>
         public override void Load()
         {
             Load(reload: false);

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -102,16 +102,17 @@ namespace Microsoft.Extensions.Configuration
                     }
                     catch (Exception ex)
                     {
-                        throw new InvalidDataException(SR.Format(SR.Error_FailedToLoad, file.PhysicalPath), ex);
+                        if (reload)
+                        {
+                            Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+                        }
+                        throw ex;
                     }
                 }
                 catch (Exception ex)
                 {
-                    if (reload)
-                    {
-                        Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
-                    }
-                    HandleException(ExceptionDispatchInfo.Capture(ex));
+                    var exception = new InvalidDataException(SR.Format(SR.Error_FailedToLoad, file.PhysicalPath), ex);
+                    HandleException(ExceptionDispatchInfo.Capture(exception));
                 }
             }
             // REVIEW: Should we raise this in the base as well / instead?

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -104,6 +104,9 @@ namespace Microsoft.Extensions.Configuration
                     {
                         if (reload)
                         {
+                            // We reset Data only for exceptions from Load. For possibly transient
+                            // IOExceptions from OpenRead caught by the outer catch, we do not reset
+                            // it, preserving the original configuration.
                             Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
                         }
                         string filePath = file.PhysicalPath ?? Source.Path ?? file.Name;
@@ -112,7 +115,6 @@ namespace Microsoft.Extensions.Configuration
                 }
                 catch (Exception ex)
                 {
-                    // For IO errors from OpenRead, Data is intentionally preserved to keep last-known-good config
                     HandleException(ExceptionDispatchInfo.Capture(ex));
                 }
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -112,6 +112,7 @@ namespace Microsoft.Extensions.Configuration
                 }
                 catch (Exception ex)
                 {
+                    // For IO errors from OpenRead, Data is intentionally preserved to keep last-known-good config
                     HandleException(ExceptionDispatchInfo.Capture(ex));
                 }
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -102,10 +102,6 @@ namespace Microsoft.Extensions.Configuration
                     }
                     catch (Exception ex)
                     {
-                        if (reload)
-                        {
-                            Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
-                        }
                         throw new InvalidDataException(SR.Format(SR.Error_FailedToLoad, file.PhysicalPath), ex);
                     }
                 }

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -129,7 +129,9 @@ namespace Microsoft.Extensions.Configuration
         /// <exception cref="InvalidDataException">An exception was thrown by the concrete implementation of the
         /// <see cref="Load()"/> method. Use the source <see cref="FileConfigurationSource.OnLoadException"/> callback
         /// if you need more control over the exception.</exception>
-        /// <exception cref="IOException">An exception was thrown when opening file.</exception>
+        /// <exception cref="IOException">An exception was thrown when opening the file. Use the source
+        /// <see cref="FileConfigurationSource.OnLoadException"/> callback if you need more control over the
+        /// exception.</exception>
         public override void Load()
         {
             Load(reload: false);

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -55,12 +55,14 @@ namespace Microsoft.Extensions.Configuration
 
         private void Load(bool reload)
         {
+            bool updated = false;
             IFileInfo? file = Source.FileProvider?.GetFileInfo(Source.Path ?? string.Empty);
             if (file == null || !file.Exists)
             {
                 if (Source.Optional || reload) // Always optional on reload
                 {
                     Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+                    updated = true;
                 }
                 else
                 {
@@ -99,6 +101,7 @@ namespace Microsoft.Extensions.Configuration
                     try
                     {
                         Load(stream);
+                        updated = true;
                     }
                     catch (Exception ex)
                     {
@@ -108,6 +111,7 @@ namespace Microsoft.Extensions.Configuration
                             // IOExceptions from OpenRead caught by the outer catch, we do not reset
                             // it, preserving the original configuration.
                             Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+                            updated = true;
                         }
                         string filePath = file.PhysicalPath ?? Source.Path ?? file.Name;
                         throw new InvalidDataException(SR.Format(SR.Error_FailedToLoad, filePath), ex);
@@ -118,8 +122,11 @@ namespace Microsoft.Extensions.Configuration
                     HandleException(ExceptionDispatchInfo.Capture(ex));
                 }
             }
-            // REVIEW: Should we raise this in the base as well / instead?
-            OnReload();
+            if (updated)
+            {
+                // REVIEW: Should we raise this in the base as well / instead?
+                OnReload();
+            }
         }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -107,9 +107,6 @@ namespace Microsoft.Extensions.Configuration
                     {
                         if (reload)
                         {
-                            // We reset Data only for exceptions from Load. For possibly transient
-                            // IOExceptions from OpenRead caught by the outer catch, we do not reset
-                            // it, preserving the original configuration.
                             Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
                             updated = true;
                         }
@@ -119,6 +116,9 @@ namespace Microsoft.Extensions.Configuration
                 }
                 catch (Exception ex)
                 {
+                    // We do not reset Data here. We reset Data only for exceptions from Load (inner try
+                    // block) such as parse errors. For (possibly transient) IO Exceptions from OpenRead
+                    // we preserve the original configuration.
                     HandleException(ExceptionDispatchInfo.Capture(ex));
                 }
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Extensions.Configuration
             catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
             {
                 // assuming file was deleted in meantime, we already checked existence at the begining once
-                HandleLoadingNonExisting(reload, file);
+                HandleLoadingNonExisting(reload, file, ex is DirectoryNotFoundException);
                 return;
             }
             catch (Exception ex)
@@ -134,7 +134,9 @@ namespace Microsoft.Extensions.Configuration
         /// <see langword="false"/> when loading for first time.</param>
         /// <param name="file">The file information returned by the <see cref="FileConfigurationSource.FileProvider"/>,
         /// or <see langword="null"/> if no file information is available.</param>
-        private void HandleLoadingNonExisting(bool reload, IFileInfo? file)
+        /// <param name="directoryException">Determines if <see cref="FileNotFoundException"/> or
+        /// <see cref="DirectoryNotFoundException"/> is thrown on error.</param>
+        private void HandleLoadingNonExisting(bool reload, IFileInfo? file, bool directoryException = false)
         {
             if (Source.Optional || reload) // Always optional on reload
             {
@@ -143,12 +145,19 @@ namespace Microsoft.Extensions.Configuration
             }
             else
             {
-                var error = new StringBuilder(SR.Format(SR.Error_FileNotFound, Source.Path));
+                var error = new StringBuilder(SR.Format(SR.Error_FileNotFound, Source.Path ?? file?.Name));
                 if (!string.IsNullOrEmpty(file?.PhysicalPath))
                 {
                     error.Append(SR.Format(SR.Error_ExpectedPhysicalPath, file.PhysicalPath));
                 }
-                HandleException(ExceptionDispatchInfo.Capture(new FileNotFoundException(error.ToString())));
+                if (!directoryException)
+                {
+                    HandleException(ExceptionDispatchInfo.Capture(new FileNotFoundException(error.ToString())));
+                }
+                else
+                {
+                    HandleException(ExceptionDispatchInfo.Capture(new DirectoryNotFoundException(error.ToString())));
+                }
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -86,7 +86,8 @@ namespace Microsoft.Extensions.Configuration
             {
                 stream = OpenRead(file);
             }
-            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException) {
+            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+            {
                 // assuming file was deleted in meantime, we already checked existence at the begining once
                 HandleLoadingNonExisting(reload, file);
                 return;
@@ -191,7 +192,8 @@ namespace Microsoft.Extensions.Configuration
             }
         }
 
-        private void ClearData() {
+        private void ClearData()
+        {
             Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -117,8 +117,8 @@ namespace Microsoft.Extensions.Configuration
                 catch (Exception ex)
                 {
                     // We do not reset Data here. We reset Data only for exceptions from Load (inner try
-                    // block) such as parse errors. For (possibly transient) IO Exceptions from OpenRead
-                    // we preserve the original configuration.
+                    // block above) such as parse errors. For (possibly transient) IO Exceptions mainly
+                    // from OpenRead, we preserve the original configuration.
                     HandleException(ExceptionDispatchInfo.Capture(ex));
                 }
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Extensions.Configuration
                         Load(stream);
                         updated = true;
                     }
-                    catch (Exception ex)
+                    catch (Exception ex) when (ex is not IOException)
                     {
                         if (reload)
                         {

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -55,88 +55,96 @@ namespace Microsoft.Extensions.Configuration
 
         private void Load(bool reload)
         {
-            bool updated = false;
             IFileInfo? file = Source.FileProvider?.GetFileInfo(Source.Path ?? string.Empty);
             if (file == null || !file.Exists)
             {
-                if (Source.Optional || reload) // Always optional on reload
-                {
-                    ClearData();
-                    updated = true;
-                }
-                else
-                {
-                    var error = new StringBuilder(SR.Format(SR.Error_FileNotFound, Source.Path));
-                    if (!string.IsNullOrEmpty(file?.PhysicalPath))
-                    {
-                        error.Append(SR.Format(SR.Error_ExpectedPhysicalPath, file.PhysicalPath));
-                    }
-                    HandleException(ExceptionDispatchInfo.Capture(new FileNotFoundException(error.ToString())));
-                }
+                HandleLoadingNonExisting(reload, file);
+                return;
             }
-            else
-            {
-                static Stream OpenRead(IFileInfo fileInfo)
-                {
-                    if (fileInfo.PhysicalPath != null)
-                    {
-                        // The default physical file info assumes asynchronous IO which results in unnecessary overhead
-                        // especially since the configuration system is synchronous. This uses the same settings
-                        // and disables async IO.
-                        return new FileStream(
-                            fileInfo.PhysicalPath,
-                            FileMode.Open,
-                            FileAccess.Read,
-                            FileShare.ReadWrite,
-                            bufferSize: 1,
-                            FileOptions.SequentialScan);
-                    }
 
-                    return fileInfo.CreateReadStream();
+            static Stream OpenRead(IFileInfo fileInfo)
+            {
+                if (fileInfo.PhysicalPath != null)
+                {
+                    // The default physical file info assumes asynchronous IO which results in unnecessary overhead
+                    // especially since the configuration system is synchronous. This uses the same settings
+                    // and disables async IO.
+                    return new FileStream(
+                        fileInfo.PhysicalPath,
+                        FileMode.Open,
+                        FileAccess.Read,
+                        FileShare.ReadWrite,
+                        bufferSize: 1,
+                        FileOptions.SequentialScan);
                 }
 
-                Stream stream;
+                return fileInfo.CreateReadStream();
+            }
+
+            Stream stream;
+            try
+            {
+                stream = OpenRead(file);
+            }
+            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException) {
+                // assuming file was deleted in meantime, we already checked existence at the begining once
+                HandleLoadingNonExisting(reload, file);
+                return;
+            }
+            catch (Exception ex)
+            {
+                // IO error on file open, preserve existing Data
+                HandleException(ExceptionDispatchInfo.Capture(ex));
+                return;
+            }
+
+            bool updated = false;
+
+            using (stream)
+            {
                 try
                 {
-                    stream = OpenRead(file);
-                }
-                catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException) {
-                    // We checked for existen above, assuming file was deleted in meantime
-                    ClearData();
-                    OnReload();
-                    return;
+                    Load(stream);
+                    updated = true;
                 }
                 catch (Exception ex)
                 {
-                    // IO error on file open, preserve existing Data
-                    HandleException(ExceptionDispatchInfo.Capture(ex));
-                    return;
-                }
-
-                using (stream)
-                {
-                    try
+                    if (reload)
                     {
-                        Load(stream);
+                        ClearData();
                         updated = true;
                     }
-                    catch (Exception ex)
-                    {
-                        if (reload)
-                        {
-                            ClearData();
-                            updated = true;
-                        }
-                        string filePath = file.PhysicalPath ?? Source.Path ?? file.Name;
-                        var wrapped = new InvalidDataException(SR.Format(SR.Error_FailedToLoad, filePath), ex);
-                        HandleException(ExceptionDispatchInfo.Capture(wrapped));
-                    }
+                    string filePath = file.PhysicalPath ?? Source.Path ?? file.Name;
+                    var wrapped = new InvalidDataException(SR.Format(SR.Error_FailedToLoad, filePath), ex);
+                    HandleException(ExceptionDispatchInfo.Capture(wrapped));
                 }
             }
+
             if (updated)
             {
                 // REVIEW: Should we raise this in the base as well / instead?
                 OnReload();
+            }
+        }
+
+        /// <summary>
+        /// Depending on Optional flag and reload mode, triggers exception about missing file.
+        /// </summary>
+        private void HandleLoadingNonExisting(bool reload, IFileInfo? file)
+        {
+            if (Source.Optional || reload) // Always optional on reload
+            {
+                ClearData();
+                OnReload();
+            }
+            else
+            {
+                var error = new StringBuilder(SR.Format(SR.Error_FileNotFound, Source.Path));
+                if (!string.IsNullOrEmpty(file?.PhysicalPath))
+                {
+                    error.Append(SR.Format(SR.Error_ExpectedPhysicalPath, file.PhysicalPath));
+                }
+                HandleException(ExceptionDispatchInfo.Capture(new FileNotFoundException(error.ToString())));
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -139,9 +139,9 @@ namespace Microsoft.Extensions.Configuration
         /// <exception cref="InvalidDataException">An exception was thrown by the concrete implementation of the
         /// <see cref="Load()"/> method. Use the source <see cref="FileConfigurationSource.OnLoadException"/> callback
         /// if you need more control over the exception.</exception>
-        /// <exception cref="IOException">An exception was thrown when opening the file. Use the source
-        /// <see cref="FileConfigurationSource.OnLoadException"/> callback if you need more control over the
-        /// exception.</exception>
+        /// <exception cref="IOException">An I/O error occurred when opening the file. Other exceptions from the
+        /// underlying file provider may also be thrown. Use the source <see cref="FileConfigurationSource.OnLoadException"/>
+        /// callback if you need more control over the exception.</exception>
         public override void Load()
         {
             Load(reload: false);

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -129,8 +129,12 @@ namespace Microsoft.Extensions.Configuration
         }
 
         /// <summary>
-        /// Depending on Optional flag and reload mode, triggers exception about missing file.
+        /// Handles a missing configuration file during the initial load or a reload.
         /// </summary>
+        /// <param name="reload"><see langword="true"/> when the provider is reloading after a change notification;
+        /// <see langword="false"/> when loading for first time.</param>
+        /// <param name="file">The file information returned by the <see cref="FileConfigurationSource.FileProvider"/>,
+        /// or <see langword="null"/> if no file information is available.</param>
         private void HandleLoadingNonExisting(bool reload, IFileInfo? file)
         {
             if (Source.Optional || reload) // Always optional on reload

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Extensions.Configuration
             }
             catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
             {
-                // assuming file was deleted in meantime, we already checked existence at the begining once
+                // assuming file was deleted in meantime, we already checked existence at the beginning once
                 HandleLoadingNonExisting(reload, file);
                 return;
             }

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Extensions.Configuration
             {
                 if (Source.Optional || reload) // Always optional on reload
                 {
-                    Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+                    ClearData();
                     updated = true;
                 }
                 else
@@ -95,31 +95,42 @@ namespace Microsoft.Extensions.Configuration
                     return fileInfo.CreateReadStream();
                 }
 
+                Stream stream;
                 try
                 {
-                    using Stream stream = OpenRead(file);
+                    stream = OpenRead(file);
+                }
+                catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException) {
+                    // We checked for existen above, assuming file was deleted in meantime
+                    ClearData();
+                    OnReload();
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    // IO error on file open, preserve existing Data
+                    HandleException(ExceptionDispatchInfo.Capture(ex));
+                    return;
+                }
+
+                using (stream)
+                {
                     try
                     {
                         Load(stream);
                         updated = true;
                     }
-                    catch (Exception ex) when (ex is not IOException)
+                    catch (Exception ex)
                     {
                         if (reload)
                         {
-                            Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+                            ClearData();
                             updated = true;
                         }
                         string filePath = file.PhysicalPath ?? Source.Path ?? file.Name;
-                        throw new InvalidDataException(SR.Format(SR.Error_FailedToLoad, filePath), ex);
+                        var wrapped = new InvalidDataException(SR.Format(SR.Error_FailedToLoad, filePath), ex);
+                        HandleException(ExceptionDispatchInfo.Capture(wrapped));
                     }
-                }
-                catch (Exception ex)
-                {
-                    // We do not reset Data here. We reset Data only for exceptions from Load (inner try
-                    // block above) such as parse errors. For (possibly transient) IO Exceptions mainly
-                    // from OpenRead, we preserve the original configuration.
-                    HandleException(ExceptionDispatchInfo.Capture(ex));
                 }
             }
             if (updated)
@@ -170,6 +181,10 @@ namespace Microsoft.Extensions.Configuration
             {
                 info.Throw();
             }
+        }
+
+        private void ClearData() {
+            Data = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
         }
 
         /// <inheritdoc />

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationProvider.cs
@@ -123,7 +123,6 @@ namespace Microsoft.Extensions.Configuration
 
             if (updated)
             {
-                // REVIEW: Should we raise this in the base as well / instead?
                 OnReload();
             }
         }

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationSource.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileConfigurationSource.cs
@@ -48,6 +48,11 @@ namespace Microsoft.Extensions.Configuration
         /// <summary>
         /// Gets or sets the action that's called if an uncaught exception occurs in FileConfigurationProvider.Load.
         /// </summary>
+        /// <remarks>
+        /// When <see cref="ReloadOnChange"/> is enabled, this callback is also invoked on background reload failures.
+        /// If the callback is not set or does not set <see cref="FileLoadExceptionContext.Ignore"/> to <see langword="true"/>,
+        /// exceptions from background reloads will propagate unhandled on the thread pool.
+        /// </remarks>
         public Action<FileLoadExceptionContext>? OnLoadException { get; set; }
 
         /// <summary>

--- a/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileLoadExceptionContext.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration.FileExtensions/src/FileLoadExceptionContext.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Extensions.Configuration
         public FileConfigurationProvider Provider { get; set; } = null!;
 
         /// <summary>
-        /// Gets or sets the exception that occurred in Load.
+        /// Gets or sets the exception that occurred during file loading.
         /// </summary>
         public Exception Exception { get; set; } = null!;
 

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -531,16 +531,18 @@ IniKey1=IniValue2");
                 c.Ignore = true;
             };
 
-            using var cfgRoot = CreateBuilder()
+            IConfigurationRoot cfgRoot = CreateBuilder()
                 .AddJsonFile(s =>
                 {
                     s.Path = FileName;
                     s.OnLoadException = jsonLoadError;
                 })
-                .Build() as IDisposable;
+                .Build();
+            using IDisposable cfgRootDisposable = cfgRoot as IDisposable;
 
             Assert.NotNull(failingProvider);
             Assert.IsType<InvalidDataException>(failureException);
+            Assert.Null(cfgRoot["JsonKey1"]);
         }
 
         [Fact]
@@ -562,16 +564,18 @@ IniKey1=IniValue2");
                     c.Ignore = true;
                 };
 
-                using var cfgRoot = CreateBuilder()
+                IConfigurationRoot cfgRoot = CreateBuilder()
                     .AddJsonFile(s =>
                     {
                         s.Path = FileName;
                         s.OnLoadException = jsonLoadError;
                     })
-                    .Build() as IDisposable;
+                    .Build();
+                using IDisposable cfgRootDisposable = cfgRoot as IDisposable;
 
                 Assert.NotNull(failingProvider);
                 Assert.IsType<IOException>(failureException);
+                Assert.Null(cfgRoot["JsonKey1"]);
             }
         }
 
@@ -592,24 +596,29 @@ IniKey1=IniValue2");
                 c.Ignore = true;
             };
 
-            using var cfgRoot = CreateBuilder()
+            IConfigurationRoot cfgRoot = CreateBuilder()
                 .AddJsonFile(s =>
                 {
                     s.Path = FileName;
                     s.OnLoadException = jsonLoadError;
                     s.ReloadOnChange = true;
                 })
-                .Build() as IDisposable;
+                .Build();
+            using IDisposable cfgRootDisposable = cfgRoot as IDisposable;
 
             // No error should be triggered so far.
             Assert.Null(failingProvider);
             Assert.Null(failureException);
+            Assert.Equal("JsonValue1", cfgRoot["JsonKey1"]);
 
             _fileSystem.WriteFile(FileName, @"{""JsonKey1"": ");
 
             await WaitForChange(() => failingProvider != null, "File change did not raise OnLoadException event in time.");
 
             Assert.IsType<InvalidDataException>(failureException);
+
+            // Check that value was removed from config
+            Assert.Null(cfgRoot["JsonKey1"]);
         }
 
         [Fact]
@@ -630,17 +639,21 @@ IniKey1=IniValue2");
                 c.Ignore = true;
             };
 
-            using var cfgRoot = CreateBuilder()
+            IConfigurationRoot cfgRoot = CreateBuilder()
                 .AddJsonFile(s =>
                 {
                     s.Path = FileName;
                     s.OnLoadException = jsonLoadError;
                     s.ReloadOnChange = true;
                 })
-                .Build() as IDisposable;
+                .Build();
+            using IDisposable cfgRootDisposable = cfgRoot as IDisposable;
 
             // No error should be triggered so far.
             Assert.Null(failingProvider);
+            Assert.Null(failureException);
+            Assert.Equal("JsonValue1", cfgRoot["JsonKey1"]);
+
 
             using (_fileSystem.LockFileReading(FileName))
             {
@@ -649,6 +662,9 @@ IniKey1=IniValue2");
 
                 await WaitForChange(() => failingProvider != null, "File change did not raise OnLoadException event in time.");
                 Assert.IsType<IOException>(failureException);
+
+                // IO error on reload do not invalidate existing config, yet value is not updated
+                Assert.Equal("JsonValue1", cfgRoot["JsonKey1"]);
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -523,8 +523,10 @@ IniKey1=IniValue2");
             _fileSystem.WriteFile(FileName, @"{""JsonKey1"": ");
 
             FileConfigurationProvider failingProvider = null;
+            Exception failureException = null;
             Action<FileLoadExceptionContext> jsonLoadError = c =>
             {
+                failureException = c.Exception;
                 failingProvider = c.Provider;
                 c.Ignore = true;
             };
@@ -538,6 +540,7 @@ IniKey1=IniValue2");
                 .Build();
 
             Assert.NotNull(failingProvider);
+            Assert.IsType<InvalidDataException>(failureException);
         }
 
         [Fact]
@@ -551,8 +554,10 @@ IniKey1=IniValue2");
             using (_fileSystem.LockFileReading(FileName))
             {
                 FileConfigurationProvider failingProvider = null;
+                Exception failureException = null;
                 Action<FileLoadExceptionContext> jsonLoadError = c =>
                 {
+                    failureException = c.Exception;
                     failingProvider = c.Provider;
                     c.Ignore = true;
                 };
@@ -566,6 +571,7 @@ IniKey1=IniValue2");
                     .Build();
 
                 Assert.NotNull(failingProvider);
+                Assert.IsType<IOException>(failureException);
             }
         }
 
@@ -578,8 +584,10 @@ IniKey1=IniValue2");
             _fileSystem.WriteFile(FileName, @"{""JsonKey1"": ""JsonValue1"" }");
 
             FileConfigurationProvider failingProvider = null;
+            Exception failureException = null;
             Action<FileLoadExceptionContext> jsonLoadError = c =>
             {
+                failureException = c.Exception;
                 failingProvider = c.Provider;
                 c.Ignore = true;
             };
@@ -595,10 +603,13 @@ IniKey1=IniValue2");
 
             // No error should be triggered so far.
             Assert.Null(failingProvider);
+            Assert.Null(failureException);
 
             _fileSystem.WriteFile(FileName, @"{""JsonKey1"": ");
 
             await WaitForChange(() => failingProvider != null, "File change did not raise OnLoadException event in time.");
+
+            Assert.IsType<InvalidDataException>(failureException);
         }
 
         [Fact]
@@ -611,8 +622,10 @@ IniKey1=IniValue2");
             _fileSystem.WriteFile(FileName, @"{""JsonKey1"": ""JsonValue1"" }");
 
             FileConfigurationProvider failingProvider = null;
+            Exception failureException = null;
             Action<FileLoadExceptionContext> jsonLoadError = c =>
             {
+                failureException = c.Exception;
                 failingProvider = c.Provider;
                 c.Ignore = true;
             };
@@ -635,6 +648,7 @@ IniKey1=IniValue2");
                 _fileSystem.WriteFileNoWait(FileName, @"{""JsonKey1"": ""JsonValue1Updated"" }");
 
                 await WaitForChange(() => failingProvider != null, "File change did not raise OnLoadException event in time.");
+                Assert.IsType<IOException>(failureException);
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -442,29 +442,6 @@ IniKey1=IniValue2");
         }
 
         [Fact]
-        public void OnLoadErrorCanIgnoreErrors()
-        {
-            _fileSystem.WriteFile("error.json", @"{""JsonKey1"": ");
-
-            FileConfigurationProvider provider = null;
-            Action<FileLoadExceptionContext> jsonLoadError = c =>
-            {
-                provider = c.Provider;
-                c.Ignore = true;
-            };
-
-            CreateBuilder()
-                .AddJsonFile(s =>
-                {
-                    s.Path = "error.json";
-                    s.OnLoadException = jsonLoadError;
-                })
-                .Build();
-
-            Assert.NotNull(provider);
-        }
-
-        [Fact]
         [ActiveIssue("File watching is flaky (particularly on non windows. https://github.com/dotnet/runtime/issues/42036")]
         public void CanSetValuesAndReloadValues()
         {

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -539,7 +539,6 @@ IniKey1=IniValue2");
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
         public void LoadDataErrorRaisesOnLoadException()
         {
             const string FileName = $"{nameof(LoadDataErrorRaisesOnLoadException)}.json";
@@ -594,7 +593,7 @@ IniKey1=IniValue2");
         }
 
         [Fact]
-        [PlatformSpecific(TestPlatforms.Windows)]
+        [ActiveIssue("File watching is flaky (particularly on non windows. https://github.com/dotnet/runtime/issues/42036")]
         public async Task ReloadDataErrorRaisesOnLoadException()
         {
             const string FileName = $"{nameof(ReloadDataErrorRaisesOnLoadException)}.json";

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -100,7 +100,7 @@ CommonKey3:CommonKey4=IniValue6";
 
             Assert.Throws<FileNotFoundException>(() => configurationBuilder.Build());
         }
-        
+
         [Fact]
         public void CanHandleExceptionIfFileNotFound()
         {
@@ -539,6 +539,129 @@ IniKey1=IniValue2");
         }
 
         [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void LoadDataErrorRaisesOnLoadException()
+        {
+            const string FileName = $"{nameof(LoadDataErrorRaisesOnLoadException)}.json";
+
+            _fileSystem.WriteFile(FileName, @"{""JsonKey1"": ");
+
+            FileConfigurationProvider failingProvider = null;
+            Action<FileLoadExceptionContext> jsonLoadError = c =>
+            {
+                failingProvider = c.Provider;
+                c.Ignore = true;
+            };
+
+            CreateBuilder()
+                .AddJsonFile(s =>
+                {
+                    s.Path = FileName;
+                    s.OnLoadException = jsonLoadError;
+                })
+                .Build();
+
+            Assert.NotNull(failingProvider);
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void LoadIoErrorRaisesOnLoadException()
+        {
+            const string FileName = $"{nameof(LoadIoErrorRaisesOnLoadException)}.json";
+
+            _fileSystem.WriteFile(FileName, @"{""JsonKey1"": ""JsonValue1"" }");
+
+            using (_fileSystem.LockFileReading(FileName))
+            {
+                FileConfigurationProvider failingProvider = null;
+                Action<FileLoadExceptionContext> jsonLoadError = c =>
+                {
+                    failingProvider = c.Provider;
+                    c.Ignore = true;
+                };
+
+                CreateBuilder()
+                    .AddJsonFile(s =>
+                    {
+                        s.Path = FileName;
+                        s.OnLoadException = jsonLoadError;
+                    })
+                    .Build();
+
+                Assert.NotNull(failingProvider);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public async Task ReloadDataErrorRaisesOnLoadException()
+        {
+            const string FileName = $"{nameof(ReloadDataErrorRaisesOnLoadException)}.json";
+
+            _fileSystem.WriteFile(FileName, @"{""JsonKey1"": ""JsonValue1"" }");
+
+            FileConfigurationProvider failingProvider = null;
+            Action<FileLoadExceptionContext> jsonLoadError = c =>
+            {
+                failingProvider = c.Provider;
+                c.Ignore = true;
+            };
+
+            CreateBuilder()
+                .AddJsonFile(s =>
+                {
+                    s.Path = FileName;
+                    s.OnLoadException = jsonLoadError;
+                    s.ReloadOnChange = true;
+                })
+                .Build();
+
+            // No error should be triggered so far.
+            Assert.Null(failingProvider);
+
+            _fileSystem.WriteFile(FileName, @"{""JsonKey1"": ");
+
+            await WaitForChange(() => failingProvider != null, "File change did not raise OnLoadException event at time.");
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public async Task ReloadIoErrorRaisesOnLoadException()
+        {
+            const string FileName = $"{nameof(ReloadIoErrorRaisesOnLoadException)}.json";
+
+            _fileSystem.WriteFile(FileName, @"{""JsonKey1"": ""JsonValue1"" }");
+
+            FileConfigurationProvider failingProvider = null;
+            Action<FileLoadExceptionContext> jsonLoadError = c =>
+            {
+                failingProvider = c.Provider;
+                c.Ignore = true;
+            };
+
+            CreateBuilder()
+                .AddJsonFile(s =>
+                {
+                    s.Path = FileName;
+                    s.OnLoadException = jsonLoadError;
+                    s.ReloadOnChange = true;
+                })
+                .Build();
+
+            // No error should be triggered so far.
+            Assert.Null(failingProvider);
+
+            using (_fileSystem.LockFileReading(FileName))
+            {
+                // we need NoWait because Wait reads file under the hood and that is restricted in LockFileReading context
+                _fileSystem.WriteFileNoWait(FileName, @"{""JsonKey1"": ""JsonValue1Updated"" }");
+
+                await WaitForChange(() => failingProvider != null, "File change did not raise OnLoadException event at time.");
+            }
+        }
+
+        [Fact]
         [ActiveIssue("File watching is flaky (particularly on non windows. https://github.com/dotnet/runtime/issues/42036")]
         public async Task TouchingFileWillReload()
         {
@@ -689,7 +812,7 @@ IniKey1=IniValue2");
             Assert.Equal("IniValue1", config["Key"]);
             Assert.True(token.HasChanged);
         }
-        
+
         [Theory]
         [ActiveIssue("File watching is flaky (particularly on non windows. https://github.com/dotnet/runtime/issues/42036")]
         [InlineData(false)]

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -621,7 +621,7 @@ IniKey1=IniValue2");
 
             _fileSystem.WriteFile(FileName, @"{""JsonKey1"": ");
 
-            await WaitForChange(() => failingProvider != null, "File change did not raise OnLoadException event at time.");
+            await WaitForChange(() => failingProvider != null, "File change did not raise OnLoadException event in time.");
         }
 
         [Fact]
@@ -656,7 +656,7 @@ IniKey1=IniValue2");
                 // we need NoWait because Wait reads file under the hood and that is restricted in LockFileReading context
                 _fileSystem.WriteFileNoWait(FileName, @"{""JsonKey1"": ""JsonValue1Updated"" }");
 
-                await WaitForChange(() => failingProvider != null, "File change did not raise OnLoadException event at time.");
+                await WaitForChange(() => failingProvider != null, "File change did not raise OnLoadException event in time.");
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -603,6 +603,7 @@ IniKey1=IniValue2");
 
         [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
+        [ActiveIssue("File watching is flaky (particularly on non windows. https://github.com/dotnet/runtime/issues/42036")]
         public async Task ReloadIoErrorRaisesOnLoadException()
         {
             const string FileName = $"{nameof(ReloadIoErrorRaisesOnLoadException)}.json";

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -531,13 +531,13 @@ IniKey1=IniValue2");
                 c.Ignore = true;
             };
 
-            CreateBuilder()
+            using var cfgRoot = CreateBuilder()
                 .AddJsonFile(s =>
                 {
                     s.Path = FileName;
                     s.OnLoadException = jsonLoadError;
                 })
-                .Build();
+                .Build() as IDisposable;
 
             Assert.NotNull(failingProvider);
             Assert.IsType<InvalidDataException>(failureException);
@@ -562,13 +562,13 @@ IniKey1=IniValue2");
                     c.Ignore = true;
                 };
 
-                CreateBuilder()
+                using var cfgRoot = CreateBuilder()
                     .AddJsonFile(s =>
                     {
                         s.Path = FileName;
                         s.OnLoadException = jsonLoadError;
                     })
-                    .Build();
+                    .Build() as IDisposable;
 
                 Assert.NotNull(failingProvider);
                 Assert.IsType<IOException>(failureException);
@@ -592,14 +592,14 @@ IniKey1=IniValue2");
                 c.Ignore = true;
             };
 
-            CreateBuilder()
+            using var cfgRoot = CreateBuilder()
                 .AddJsonFile(s =>
                 {
                     s.Path = FileName;
                     s.OnLoadException = jsonLoadError;
                     s.ReloadOnChange = true;
                 })
-                .Build();
+                .Build() as IDisposable;
 
             // No error should be triggered so far.
             Assert.Null(failingProvider);
@@ -630,14 +630,14 @@ IniKey1=IniValue2");
                 c.Ignore = true;
             };
 
-            CreateBuilder()
+            using var cfgRoot = CreateBuilder()
                 .AddJsonFile(s =>
                 {
                     s.Path = FileName;
                     s.OnLoadException = jsonLoadError;
                     s.ReloadOnChange = true;
                 })
-                .Build();
+                .Build() as IDisposable;
 
             // No error should be triggered so far.
             Assert.Null(failingProvider);

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -637,11 +637,9 @@ IniKey1=IniValue2");
             }
         }
 
-        [Theory]
+        [Fact]
         [ActiveIssue("File watching is flaky (particularly on non windows. https://github.com/dotnet/runtime/issues/42036")]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ReloadDataErrorRaisesOnLoadException(bool ignoreException)
+        public async Task ReloadDataErrorRaisesOnLoadException()
         {
             const string FileName = $"{nameof(ReloadDataErrorRaisesOnLoadException)}.json";
 
@@ -653,7 +651,7 @@ IniKey1=IniValue2");
             {
                 failureException = c.Exception;
                 failingProvider = c.Provider;
-                c.Ignore = ignoreException;
+                c.Ignore = true;
             };
 
             IConfigurationRoot cfgRoot = CreateBuilder()
@@ -681,24 +679,13 @@ IniKey1=IniValue2");
 
             // Check that value was removed from config
             Assert.Null(cfgRoot["JsonKey1"]);
-
-            if (ignoreException)
-            {
-                Assert.True(reloadToken.HasChanged);
-            }
-            else
-            {
-                // If the exception was not ignored, it was rethrown which prevented calling OnReload()
-                Assert.False(reloadToken.HasChanged);
-            }
+            Assert.True(reloadToken.HasChanged);
         }
 
-        [Theory]
+        [Fact]
         [PlatformSpecific(TestPlatforms.Windows)]
         [ActiveIssue("File watching is flaky (particularly on non windows. https://github.com/dotnet/runtime/issues/42036")]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ReloadIoErrorRaisesOnLoadException(bool ignoreException)
+        public async Task ReloadIoErrorRaisesOnLoadException()
         {
             const string FileName = $"{nameof(ReloadIoErrorRaisesOnLoadException)}.json";
 
@@ -710,7 +697,7 @@ IniKey1=IniValue2");
             {
                 failureException = c.Exception;
                 failingProvider = c.Provider;
-                c.Ignore = ignoreException;
+                c.Ignore = true;
             };
 
             IConfigurationRoot cfgRoot = CreateBuilder()

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -654,7 +654,6 @@ IniKey1=IniValue2");
             Assert.Null(failureException);
             Assert.Equal("JsonValue1", cfgRoot["JsonKey1"]);
 
-
             using (_fileSystem.LockFileReading(FileName))
             {
                 // we need NoWait because Wait reads file under the hood and that is restricted in LockFileReading context

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -738,7 +738,7 @@ IniKey1=IniValue2");
                 await WaitForChange(() => failingProvider != null, "File change did not raise OnLoadException event in time.");
                 Assert.IsType<IOException>(failureException);
 
-                // IO error on reload do not invalidate existing config, yet value is not updated
+                // IO error on reload does not invalidate existing config, yet value is not updated
                 Assert.Equal("JsonValue1", cfgRoot["JsonKey1"]);
                 Assert.False(reloadToken.HasChanged);
             }

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/ConfigurationTests.cs
@@ -516,6 +516,64 @@ IniKey1=IniValue2");
         }
 
         [Fact]
+        public void BuildThrowsOnInvalidData()
+        {
+            const string FileName = $"{nameof(BuildThrowsOnInvalidData)}.json";
+
+            _fileSystem.WriteFile(FileName, @"{""JsonKey1"": ");
+
+            bool callbackCalled = false;
+            Exception failureException = null;
+
+            Assert.Throws<InvalidDataException>(() => CreateBuilder()
+                .AddJsonFile(s =>
+                {
+                    s.Path = FileName;
+                    s.OnLoadException = c =>
+                    {
+                        callbackCalled = true;
+                        failureException = c.Exception;
+                        // c.Ignore stays false. Exception propagates from Build()
+                    };
+                })
+                .Build());
+
+            Assert.True(callbackCalled);
+            Assert.IsType<InvalidDataException>(failureException);
+        }
+
+        [Fact]
+        [PlatformSpecific(TestPlatforms.Windows)]
+        public void BuildThrowsOnIoError()
+        {
+            const string FileName = $"{nameof(BuildThrowsOnIoError)}.json";
+
+            _fileSystem.WriteFile(FileName, @"{""JsonKey1"": ""JsonValue1"" }");
+
+            using (_fileSystem.LockFileReading(FileName))
+            {
+                bool callbackCalled = false;
+                Exception failureException = null;
+
+                Assert.Throws<IOException>(() => CreateBuilder()
+                    .AddJsonFile(s =>
+                    {
+                        s.Path = FileName;
+                        s.OnLoadException = c =>
+                        {
+                            callbackCalled = true;
+                            failureException = c.Exception;
+                            // c.Ignore stays false. Exception propagates from Build()
+                        };
+                    })
+                    .Build());
+
+                Assert.True(callbackCalled);
+                Assert.IsType<IOException>(failureException);
+            }
+        }
+
+        [Fact]
         public void LoadDataErrorRaisesOnLoadException()
         {
             const string FileName = $"{nameof(LoadDataErrorRaisesOnLoadException)}.json";
@@ -579,9 +637,11 @@ IniKey1=IniValue2");
             }
         }
 
-        [Fact]
+        [Theory]
         [ActiveIssue("File watching is flaky (particularly on non windows. https://github.com/dotnet/runtime/issues/42036")]
-        public async Task ReloadDataErrorRaisesOnLoadException()
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReloadDataErrorRaisesOnLoadException(bool ignoreException)
         {
             const string FileName = $"{nameof(ReloadDataErrorRaisesOnLoadException)}.json";
 
@@ -593,7 +653,7 @@ IniKey1=IniValue2");
             {
                 failureException = c.Exception;
                 failingProvider = c.Provider;
-                c.Ignore = true;
+                c.Ignore = ignoreException;
             };
 
             IConfigurationRoot cfgRoot = CreateBuilder()
@@ -605,11 +665,13 @@ IniKey1=IniValue2");
                 })
                 .Build();
             using IDisposable cfgRootDisposable = cfgRoot as IDisposable;
+            IChangeToken reloadToken = cfgRoot.GetReloadToken();
 
             // No error should be triggered so far.
             Assert.Null(failingProvider);
             Assert.Null(failureException);
             Assert.Equal("JsonValue1", cfgRoot["JsonKey1"]);
+            Assert.False(reloadToken.HasChanged);
 
             _fileSystem.WriteFile(FileName, @"{""JsonKey1"": ");
 
@@ -619,12 +681,24 @@ IniKey1=IniValue2");
 
             // Check that value was removed from config
             Assert.Null(cfgRoot["JsonKey1"]);
+
+            if (ignoreException)
+            {
+                Assert.True(reloadToken.HasChanged);
+            }
+            else
+            {
+                // If the exception was not ignored, it was rethrown which prevented calling OnReload()
+                Assert.False(reloadToken.HasChanged);
+            }
         }
 
-        [Fact]
+        [Theory]
         [PlatformSpecific(TestPlatforms.Windows)]
         [ActiveIssue("File watching is flaky (particularly on non windows. https://github.com/dotnet/runtime/issues/42036")]
-        public async Task ReloadIoErrorRaisesOnLoadException()
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ReloadIoErrorRaisesOnLoadException(bool ignoreException)
         {
             const string FileName = $"{nameof(ReloadIoErrorRaisesOnLoadException)}.json";
 
@@ -636,7 +710,7 @@ IniKey1=IniValue2");
             {
                 failureException = c.Exception;
                 failingProvider = c.Provider;
-                c.Ignore = true;
+                c.Ignore = ignoreException;
             };
 
             IConfigurationRoot cfgRoot = CreateBuilder()
@@ -648,11 +722,13 @@ IniKey1=IniValue2");
                 })
                 .Build();
             using IDisposable cfgRootDisposable = cfgRoot as IDisposable;
+            IChangeToken reloadToken = cfgRoot.GetReloadToken();
 
             // No error should be triggered so far.
             Assert.Null(failingProvider);
             Assert.Null(failureException);
             Assert.Equal("JsonValue1", cfgRoot["JsonKey1"]);
+            Assert.False(reloadToken.HasChanged);
 
             using (_fileSystem.LockFileReading(FileName))
             {
@@ -664,6 +740,7 @@ IniKey1=IniValue2");
 
                 // IO error on reload do not invalidate existing config, yet value is not updated
                 Assert.Equal("JsonValue1", cfgRoot["JsonKey1"]);
+                Assert.False(reloadToken.HasChanged);
             }
         }
 

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/DisposableFileSystem.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/DisposableFileSystem.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Extensions.Configuration.Test
         }
 
         /// <summary>
-        /// Lock specified file for reading. However it can be still written and changes triggers FileSystemWatcher events.
+        /// Lock specified file for reading. However, it can still be written to, and changes trigger FileSystemWatcher events.
         /// </summary>
         /// <returns>IDisposable which removes lock on Dispose()</returns>
         public IDisposable LockFileReading(string path)

--- a/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/DisposableFileSystem.cs
+++ b/src/libraries/Microsoft.Extensions.Configuration/tests/FunctionalTests/DisposableFileSystem.cs
@@ -48,11 +48,22 @@ namespace Microsoft.Extensions.Configuration.Test
                 ? path
                 : Path.Combine(RootPath, path);
 
-            File.WriteAllText(fullPath, text);
+            WriteFileNoWait(path, text, absolute);
 
             WaitForFileSystem(
                 () => File.ReadAllText(fullPath).Length == text.Length,
                 $"File.WriteAllText(\"{fullPath}\", \"{text}\") failed");
+
+            return this;
+        }
+
+        public DisposableFileSystem WriteFileNoWait(string path, string text = "temp", bool absolute = false)
+        {
+            var fullPath = absolute
+                ? path
+                : Path.Combine(RootPath, path);
+
+            File.WriteAllText(fullPath, text);
 
             return this;
         }
@@ -89,6 +100,16 @@ namespace Microsoft.Extensions.Configuration.Test
             }
 
             return this;
+        }
+
+        /// <summary>
+        /// Lock specified file for reading. However it can be still written and changes triggers FileSystemWatcher events.
+        /// </summary>
+        /// <returns>IDisposable which removes lock on Dispose()</returns>
+        public IDisposable LockFileReading(string path)
+        {
+            var fullPath = Path.Combine(RootPath, path);
+            return new FileStream(fullPath, FileMode.Open, FileAccess.Read, FileShare.Write);
         }
 
         public void Dispose()


### PR DESCRIPTION
Current behavior of FileConfigurationProvider on various types of failures at various times:

|  | First Load | OnChange Reload |
|---|---|---|
| data parsing failure | `OnLoadException` callback is called<br>`AddJsonFile` throws<br><br> | `OnLoadException` callback is called<br>program continues<br>no reload happen |
| IO failure on file open | `AddJsonFile` throws | Silent<br>program continues<br>no reload happen<br>possibly raises `UnobservedTaskException` later |

This PR unifies it in a way that both types of failure behave same as _data parsing failure_. 

This brings some behavioral changes
- `OnLoadException` callback is newly triggered if IO error happen on both types of events (first load, reload)
- `UnobservedTaskException` can no longer be observed in scenario when user registers `OnLoadException` callback. It can however happen when no callback is registered, so XML comment on `OnLoadException` was updated.
- `OnLoadException` callbacks now receives not only InvalidDataException, but also IOException (or any other exception which (possibly custom) implementation of IFileProvider can throw). If user cast to InvalidDataException, he may miss other exceptions or get cast exceptions.

Based on follow up Copilot code reviews, I did few more behavior changes at edge cases, they do not relate directly to issue and can be reverted independently if not desired.

- `OnReload()` now fires only when Data actually changed. Previously on first load, if a parse or IO error occurred and `OnLoadException` set `Ignore = true`, `OnReload()` was fired unconditionally even though Data was never modified. The new code fires `OnReload()` only when Data was successfully loaded or explicitly cleared (e.g., on reload or optional missing file). For consecutive reloads with parse errors, Data is cleared and `OnReload()` still fires. This change is independent on original fix and can be reverted independently if not desirable.

Fix #113964