### PR TITLE
Eagerly validate ASN.1 collections on ref struct implementations

### DIFF
--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/AttributeAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/AttributeAsn.xml.cs
@@ -124,7 +124,9 @@ namespace System.Security.Cryptography.Asn1
     internal ref partial struct ValueAttributeAsn
     {
         internal string AttrType;
-        internal ReadOnlySpan<byte> AttrValues;
+        internal ReadOnlySpan<byte> AttrValues { get; private set; }
+        internal int AttrValuesLength { get; private set; }
+        private AttrValuesEnumerableCache AttrValuesCache;
 
         internal readonly void Encode(AsnWriter writer)
         {
@@ -205,39 +207,94 @@ namespace System.Security.Cryptography.Asn1
             }
 
             decoded.AttrValues = sequenceReader.ReadEncodedValue();
+            decoded.AttrValuesCache.RuleSet = sequenceReader.RuleSet;
+            decoded.InitializeAndValidateAttrValues();
 
             sequenceReader.ThrowIfNotEmpty();
         }
 
 
-        internal AttrValuesEnumerable GetAttrValues(AsnEncodingRules ruleSet)
+        internal readonly AttrValuesEnumerable GetAttrValues()
         {
-            return new AttrValuesEnumerable(AttrValues, ruleSet);
+            return new AttrValuesEnumerable(AttrValues, AttrValuesCache);
+        }
+
+        private void InitializeAndValidateAttrValues()
+        {
+            int count = 0;
+            ValueAsnReader reader = new ValueAsnReader(AttrValues, AttrValuesCache.RuleSet);
+            ValueAsnReader collReader = reader.ReadSetOf();
+            reader.ThrowIfNotEmpty();
+
+            while (collReader.HasData)
+            {
+                checked { count++; }
+                ReadOnlySpan<byte> item = collReader.ReadEncodedValue();
+
+                switch (count)
+                {
+                    case 1: AttrValuesCache.AttrValues1 = item; break;
+                    case 2: AttrValuesCache.AttrValues2 = item; break;
+                    case 3: AttrValuesCache.AttrValues3 = item; break;
+                    case 4: AttrValuesCache.AttrValues4 = item; break;
+                    case 5: AttrValuesCache.AttrValues5 = item; break;
+                    case 6: AttrValuesCache.AttrValues6 = item; break;
+                    case 7: AttrValuesCache.AttrValues7 = item; break;
+                    case 8: AttrValuesCache.AttrValues8 = item; break;
+                    case 9: AttrValuesCache.AttrValues9 = item; break;
+                    case 10: AttrValuesCache.AttrValues10 = item; break;
+                    default: break;
+                }
+            }
+
+            AttrValuesCache.Count = count <= 10 ? count : null;
+            AttrValuesLength = count;
+        }
+
+        internal ref struct AttrValuesEnumerableCache
+        {
+            internal ReadOnlySpan<byte> AttrValues1;
+            internal ReadOnlySpan<byte> AttrValues2;
+            internal ReadOnlySpan<byte> AttrValues3;
+            internal ReadOnlySpan<byte> AttrValues4;
+            internal ReadOnlySpan<byte> AttrValues5;
+            internal ReadOnlySpan<byte> AttrValues6;
+            internal ReadOnlySpan<byte> AttrValues7;
+            internal ReadOnlySpan<byte> AttrValues8;
+            internal ReadOnlySpan<byte> AttrValues9;
+            internal ReadOnlySpan<byte> AttrValues10;
+            internal int? Count;
+            internal AsnEncodingRules RuleSet;
         }
 
         internal readonly ref struct AttrValuesEnumerable
         {
             private readonly ReadOnlySpan<byte> _encoded;
-            private readonly AsnEncodingRules _ruleSet;
+            private readonly AttrValuesEnumerableCache _cache;
 
-            internal AttrValuesEnumerable(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
+            internal AttrValuesEnumerable(ReadOnlySpan<byte> encoded, AttrValuesEnumerableCache cache)
             {
                 _encoded = encoded;
-                _ruleSet = ruleSet;
+                _cache = cache;
             }
 
-            public Enumerator GetEnumerator() => new Enumerator(_encoded, _ruleSet);
+            public Enumerator GetEnumerator() => new Enumerator(_encoded, _cache);
 
             internal ref struct Enumerator
             {
                 private ValueAsnReader _reader;
                 private ReadOnlySpan<byte> _current;
+                private readonly AttrValuesEnumerableCache _cache;
+                private int _index;
 
-                internal Enumerator(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
+                internal Enumerator(ReadOnlySpan<byte> encoded, AttrValuesEnumerableCache cache)
                 {
-                    if (!encoded.IsEmpty)
+                    _cache = cache;
+                    _index = 0;
+
+                    if (!cache.Count.HasValue && !encoded.IsEmpty)
                     {
-                        ValueAsnReader outerReader = new ValueAsnReader(encoded, ruleSet);
+                        ValueAsnReader outerReader = new ValueAsnReader(encoded, cache.RuleSet);
                         _reader = outerReader.ReadSetOf();
                         outerReader.ThrowIfNotEmpty();
                     }
@@ -249,6 +306,32 @@ namespace System.Security.Cryptography.Asn1
 
                 public bool MoveNext()
                 {
+                    if (_cache.Count.HasValue)
+                    {
+                        if (_index >= _cache.Count.Value)
+                        {
+                            return false;
+                        }
+
+                        _current = _index switch
+                        {
+                            0 => _cache.AttrValues1,
+                            1 => _cache.AttrValues2,
+                            2 => _cache.AttrValues3,
+                            3 => _cache.AttrValues4,
+                            4 => _cache.AttrValues5,
+                            5 => _cache.AttrValues6,
+                            6 => _cache.AttrValues7,
+                            7 => _cache.AttrValues8,
+                            8 => _cache.AttrValues9,
+                            9 => _cache.AttrValues10,
+                            _ => default,
+                        };
+                        _index++;
+
+                        return true;
+                    }
+
                     if (!_reader.HasData)
                     {
                         return false;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/PrivateKeyInfoAsn.xml.cs
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/PrivateKeyInfoAsn.xml.cs
@@ -145,7 +145,7 @@ namespace System.Security.Cryptography.Asn1
         internal ReadOnlySpan<byte> Attributes
         {
             get;
-            set
+            private set
             {
                 HasAttributes = true;
                 field = value;
@@ -153,6 +153,8 @@ namespace System.Security.Cryptography.Asn1
         }
 
         internal bool HasAttributes { get; private set; }
+        internal int AttributesLength { get; private set; }
+        private AttributesEnumerableCache AttributesCache;
 
         internal readonly void Encode(AsnWriter writer)
         {
@@ -247,7 +249,8 @@ namespace System.Security.Cryptography.Asn1
             if (sequenceReader.HasData && sequenceReader.PeekTag().HasSameClassAndValue(new Asn1Tag(TagClass.ContextSpecific, 0)))
             {
                 decoded.Attributes = sequenceReader.ReadEncodedValue();
-                decoded.HasAttributes = true;
+                decoded.AttributesCache.RuleSet = sequenceReader.RuleSet;
+                decoded.InitializeAndValidateAttributes();
             }
 
 
@@ -255,34 +258,88 @@ namespace System.Security.Cryptography.Asn1
         }
 
 
-        internal AttributesEnumerable GetAttributes(AsnEncodingRules ruleSet)
+        internal readonly AttributesEnumerable GetAttributes()
         {
-            return new AttributesEnumerable(Attributes, ruleSet);
+            return new AttributesEnumerable(Attributes, AttributesCache);
+        }
+
+        private void InitializeAndValidateAttributes()
+        {
+            int count = 0;
+            ValueAsnReader reader = new ValueAsnReader(Attributes, AttributesCache.RuleSet);
+            ValueAsnReader collReader = reader.ReadSetOf(new Asn1Tag(TagClass.ContextSpecific, 0));
+            reader.ThrowIfNotEmpty();
+
+            while (collReader.HasData)
+            {
+                checked { count++; }
+                System.Security.Cryptography.Asn1.ValueAttributeAsn item;
+                System.Security.Cryptography.Asn1.ValueAttributeAsn.Decode(ref collReader, out item);
+
+                switch (count)
+                {
+                    case 1: AttributesCache.Attributes1 = item; break;
+                    case 2: AttributesCache.Attributes2 = item; break;
+                    case 3: AttributesCache.Attributes3 = item; break;
+                    case 4: AttributesCache.Attributes4 = item; break;
+                    case 5: AttributesCache.Attributes5 = item; break;
+                    case 6: AttributesCache.Attributes6 = item; break;
+                    case 7: AttributesCache.Attributes7 = item; break;
+                    case 8: AttributesCache.Attributes8 = item; break;
+                    case 9: AttributesCache.Attributes9 = item; break;
+                    case 10: AttributesCache.Attributes10 = item; break;
+                    default: break;
+                }
+            }
+
+            AttributesCache.Count = count <= 10 ? count : null;
+            AttributesLength = count;
+        }
+
+        internal ref struct AttributesEnumerableCache
+        {
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes1;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes2;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes3;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes4;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes5;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes6;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes7;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes8;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes9;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes10;
+            internal int? Count;
+            internal AsnEncodingRules RuleSet;
         }
 
         internal readonly ref struct AttributesEnumerable
         {
             private readonly ReadOnlySpan<byte> _encoded;
-            private readonly AsnEncodingRules _ruleSet;
+            private readonly AttributesEnumerableCache _cache;
 
-            internal AttributesEnumerable(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
+            internal AttributesEnumerable(ReadOnlySpan<byte> encoded, AttributesEnumerableCache cache)
             {
                 _encoded = encoded;
-                _ruleSet = ruleSet;
+                _cache = cache;
             }
 
-            public Enumerator GetEnumerator() => new Enumerator(_encoded, _ruleSet);
+            public Enumerator GetEnumerator() => new Enumerator(_encoded, _cache);
 
             internal ref struct Enumerator
             {
                 private ValueAsnReader _reader;
                 private System.Security.Cryptography.Asn1.ValueAttributeAsn _current;
+                private readonly AttributesEnumerableCache _cache;
+                private int _index;
 
-                internal Enumerator(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
+                internal Enumerator(ReadOnlySpan<byte> encoded, AttributesEnumerableCache cache)
                 {
-                    if (!encoded.IsEmpty)
+                    _cache = cache;
+                    _index = 0;
+
+                    if (!cache.Count.HasValue && !encoded.IsEmpty)
                     {
-                        ValueAsnReader outerReader = new ValueAsnReader(encoded, ruleSet);
+                        ValueAsnReader outerReader = new ValueAsnReader(encoded, cache.RuleSet);
                         _reader = outerReader.ReadSetOf(new Asn1Tag(TagClass.ContextSpecific, 0));
                         outerReader.ThrowIfNotEmpty();
                     }
@@ -294,6 +351,32 @@ namespace System.Security.Cryptography.Asn1
 
                 public bool MoveNext()
                 {
+                    if (_cache.Count.HasValue)
+                    {
+                        if (_index >= _cache.Count.Value)
+                        {
+                            return false;
+                        }
+
+                        _current = _index switch
+                        {
+                            0 => _cache.Attributes1,
+                            1 => _cache.Attributes2,
+                            2 => _cache.Attributes3,
+                            3 => _cache.Attributes4,
+                            4 => _cache.Attributes5,
+                            5 => _cache.Attributes6,
+                            6 => _cache.Attributes7,
+                            7 => _cache.Attributes8,
+                            8 => _cache.Attributes9,
+                            9 => _cache.Attributes10,
+                            _ => default,
+                        };
+                        _index++;
+
+                        return true;
+                    }
+
                     if (!_reader.HasData)
                     {
                         return false;

--- a/src/libraries/Common/src/System/Security/Cryptography/Asn1/asn.xslt
+++ b/src/libraries/Common/src/System/Security/Cryptography/Asn1/asn.xslt
@@ -1075,6 +1075,60 @@ namespace <xsl:value-of select="@namespace" />
   <!-- ReadBoolean() vs ReadBoolean(tag) -->
   <xsl:template name="MaybeImplicitCall0"><xsl:if test="@implicitTag"><xsl:call-template name="ContextTag"/></xsl:if></xsl:template>
 
+  <!-- Emit cache struct field declarations (recursive, 1..max) -->
+  <xsl:template name="EmitCacheFields" xml:space="default">
+    <xsl:param name="n" select="1"/>
+    <xsl:param name="max" select="10"/>
+    <xsl:param name="name"/>
+    <xsl:param name="type"/>
+    <xsl:if test="$n &lt;= $max" xml:space="preserve">
+            internal <xsl:value-of select="$type"/><xsl:text> </xsl:text><xsl:value-of select="$name"/><xsl:value-of select="$n"/>;</xsl:if>
+    <xsl:if test="$n &lt; $max">
+      <xsl:call-template name="EmitCacheFields">
+        <xsl:with-param name="n" select="$n + 1"/>
+        <xsl:with-param name="max" select="$max"/>
+        <xsl:with-param name="name" select="$name"/>
+        <xsl:with-param name="type" select="$type"/>
+      </xsl:call-template>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- Emit cache assignment switch cases in DecodeCore (recursive, 1..max) -->
+  <xsl:template name="EmitCacheAssignCases" xml:space="default">
+    <xsl:param name="n" select="1"/>
+    <xsl:param name="max" select="10"/>
+    <xsl:param name="name"/>
+    <xsl:param name="indent"/>
+    <xsl:param name="target"/>
+    <xsl:if test="$n &lt;= $max" xml:space="preserve">
+                    <xsl:value-of select="$indent"/>case <xsl:value-of select="$n"/>: <xsl:value-of select="$target"/>.<xsl:value-of select="$name"/><xsl:value-of select="$n"/> = item; break;</xsl:if>
+    <xsl:if test="$n &lt; $max">
+      <xsl:call-template name="EmitCacheAssignCases">
+        <xsl:with-param name="n" select="$n + 1"/>
+        <xsl:with-param name="max" select="$max"/>
+        <xsl:with-param name="name" select="$name"/>
+        <xsl:with-param name="indent" select="$indent"/>
+        <xsl:with-param name="target" select="$target"/>
+      </xsl:call-template>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- Emit cache read switch arms in MoveNext (recursive, 0-based index => 1-based field) -->
+  <xsl:template name="EmitCacheReadArms" xml:space="default">
+    <xsl:param name="n" select="1"/>
+    <xsl:param name="max" select="10"/>
+    <xsl:param name="name"/>
+    <xsl:if test="$n &lt;= $max" xml:space="preserve">
+                            <xsl:value-of select="$n - 1"/> =&gt; _cache.<xsl:value-of select="$name"/><xsl:value-of select="$n"/>,</xsl:if>
+    <xsl:if test="$n &lt; $max">
+      <xsl:call-template name="EmitCacheReadArms">
+        <xsl:with-param name="n" select="$n + 1"/>
+        <xsl:with-param name="max" select="$max"/>
+        <xsl:with-param name="name" select="$name"/>
+      </xsl:call-template>
+    </xsl:if>
+  </xsl:template>
+
   <!-- Encode(writer) vs Encode(writer, tag) -->
   <xsl:template name="MaybeImplicitCallS"><xsl:if test="@implicitTag">, <xsl:call-template name="ContextTag"/></xsl:if></xsl:template>
 
@@ -1139,7 +1193,31 @@ namespace <xsl:value-of select="@namespace" />
     <xsl:call-template name="ValueFieldOrProperty"><xsl:with-param name="fieldType">ReadOnlySpan&lt;byte&gt;</xsl:with-param></xsl:call-template>
   </xsl:template>
 
-  <xsl:template match="asn:SequenceOf | asn:SetOf" mode="ValueFieldDef" xml:space="default">
+  <xsl:template match="asn:SequenceOf[@valueName] | asn:SetOf[@valueName]" mode="ValueFieldDef" xml:space="default">
+    <xsl:choose>
+      <xsl:when test="@optional | parent::asn:Choice" xml:space="preserve">
+
+        internal ReadOnlySpan&lt;byte&gt; <xsl:value-of select="@name"/>
+        {
+            get;
+            private set
+            {
+                Has<xsl:value-of select="@name"/> = true;
+                field = value;
+            }
+        }
+
+        internal bool Has<xsl:value-of select="@name"/> { get; private set; }
+        internal int <xsl:value-of select="@name"/>Length { get; private set; }
+        private <xsl:value-of select="@name"/>EnumerableCache <xsl:value-of select="@name"/>Cache;</xsl:when>
+      <xsl:otherwise xml:space="preserve">
+        internal ReadOnlySpan&lt;byte&gt; <xsl:value-of select="@name"/> { get; private set; }
+        internal int <xsl:value-of select="@name"/>Length { get; private set; }
+        private <xsl:value-of select="@name"/>EnumerableCache <xsl:value-of select="@name"/>Cache;</xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="asn:SequenceOf[not(@valueName)] | asn:SetOf[not(@valueName)]" mode="ValueFieldDef" xml:space="default">
     <xsl:call-template name="ValueFieldOrProperty"><xsl:with-param name="fieldType">ReadOnlySpan&lt;byte&gt;</xsl:with-param></xsl:call-template>
   </xsl:template>
 
@@ -1310,6 +1388,11 @@ namespace <xsl:value-of select="@namespace" />
     </xsl:if>
     <xsl:if test="1" xml:space="preserve">
             <xsl:value-of select="$indent"/>decoded.<xsl:value-of select="@name"/> = <xsl:value-of select="$readerName"/>.ReadEncodedValue();</xsl:if>
+    <xsl:if test="@valueName">
+      <xsl:if test="1" xml:space="preserve">
+            <xsl:value-of select="$indent"/>decoded.<xsl:value-of select="@name"/>Cache.RuleSet = <xsl:value-of select="$readerName"/>.RuleSet;
+            <xsl:value-of select="$indent"/>decoded.InitializeAndValidate<xsl:value-of select="@name"/>();</xsl:if>
+    </xsl:if>
   </xsl:template>
 
   <!-- ==== Value* ref struct: decode orchestration ==== -->
@@ -1317,7 +1400,7 @@ namespace <xsl:value-of select="@namespace" />
   <!-- Determines if a field needs a companion bool (span or ref struct type that can't be nullable) -->
   <xsl:template name="ValueSetCompanionBool" xml:space="default">
     <xsl:param name="indent" />
-    <xsl:if test="(@optional | parent::asn:Choice) and (self::asn:AnyValue | self::asn:BitString | self::asn:OctetString | self::asn:Integer[@backingType='ReadOnlyMemory'] | self::asn:SequenceOf | self::asn:SetOf | self::asn:AsnType[@valueTypeName] | self::asn:AsnType[not(@valueTypeName) and not(@rebind='false')])" xml:space="preserve">
+    <xsl:if test="(@optional | parent::asn:Choice) and (self::asn:AnyValue | self::asn:BitString | self::asn:OctetString | self::asn:Integer[@backingType='ReadOnlyMemory'] | self::asn:SequenceOf[not(@valueName)] | self::asn:SetOf[not(@valueName)] | self::asn:AsnType[@valueTypeName] | self::asn:AsnType[not(@valueTypeName) and not(@rebind='false')])" xml:space="preserve">
             <xsl:value-of select="$indent"/>decoded.Has<xsl:value-of select="@name"/> = true;</xsl:if>
   </xsl:template>
 
@@ -1416,34 +1499,68 @@ namespace <xsl:value-of select="@namespace" />
     </xsl:variable>
     <xsl:if test="1" xml:space="preserve">
 
-        internal <xsl:value-of select="@name"/>Enumerable <xsl:value-of select="@valueName"/>(AsnEncodingRules ruleSet)
+        internal readonly <xsl:value-of select="@name"/>Enumerable <xsl:value-of select="@valueName"/>()
         {
-            return new <xsl:value-of select="@name"/>Enumerable(<xsl:value-of select="@name"/>, ruleSet);
+            return new <xsl:value-of select="@name"/>Enumerable(<xsl:value-of select="@name"/>, <xsl:value-of select="@name"/>Cache);
+        }
+
+        private void InitializeAndValidate<xsl:value-of select="@name"/>()
+        {
+            int count = 0;
+            ValueAsnReader reader = new ValueAsnReader(<xsl:value-of select="@name"/>, <xsl:value-of select="@name"/>Cache.RuleSet);
+            ValueAsnReader collReader = reader.Read<xsl:value-of select="$collNoun"/>(<xsl:call-template name="MaybeImplicitCall0"/>);
+            reader.ThrowIfNotEmpty();
+
+            while (collReader.HasData)
+            {
+                checked { count++; }
+                <xsl:value-of select="$elementType"/> item<xsl:choose><xsl:when test="*/@valueTypeName">;
+                <xsl:value-of select="*/@valueTypeName"/>.Decode(ref collReader, out item)</xsl:when><xsl:otherwise> = collReader.ReadEncodedValue()</xsl:otherwise></xsl:choose>;
+
+                switch (count)
+                {<xsl:call-template name="EmitCacheAssignCases"><xsl:with-param name="name" select="@name"/><xsl:with-param name="indent" select="''"/><xsl:with-param name="target" select="concat(@name, 'Cache')"/></xsl:call-template>
+                    default: break;
+                }
+            }
+
+            <xsl:value-of select="@name"/>Cache.Count = count &lt;= 10 ? count : null;
+            <xsl:value-of select="@name"/>Length = count;
+        }
+
+        internal ref struct <xsl:value-of select="@name"/>EnumerableCache
+        {<xsl:call-template name="EmitCacheFields"><xsl:with-param name="name" select="@name"/><xsl:with-param name="type" select="$elementType"/></xsl:call-template>
+            internal int? Count;
+            internal AsnEncodingRules RuleSet;
         }
 
         internal readonly ref struct <xsl:value-of select="@name"/>Enumerable
         {
             private readonly ReadOnlySpan&lt;byte&gt; _encoded;
-            private readonly AsnEncodingRules _ruleSet;
+            private readonly <xsl:value-of select="@name"/>EnumerableCache _cache;
 
-            internal <xsl:value-of select="@name"/>Enumerable(ReadOnlySpan&lt;byte&gt; encoded, AsnEncodingRules ruleSet)
+            internal <xsl:value-of select="@name"/>Enumerable(ReadOnlySpan&lt;byte&gt; encoded, <xsl:value-of select="@name"/>EnumerableCache cache)
             {
                 _encoded = encoded;
-                _ruleSet = ruleSet;
+                _cache = cache;
             }
 
-            public Enumerator GetEnumerator() =&gt; new Enumerator(_encoded, _ruleSet);
+            public Enumerator GetEnumerator() =&gt; new Enumerator(_encoded, _cache);
 
             internal ref struct Enumerator
             {
                 private ValueAsnReader _reader;
                 private <xsl:value-of select="$elementType"/> _current;
+                private readonly <xsl:value-of select="@name"/>EnumerableCache _cache;
+                private int _index;
 
-                internal Enumerator(ReadOnlySpan&lt;byte&gt; encoded, AsnEncodingRules ruleSet)
+                internal Enumerator(ReadOnlySpan&lt;byte&gt; encoded, <xsl:value-of select="@name"/>EnumerableCache cache)
                 {
-                    if (!encoded.IsEmpty)
+                    _cache = cache;
+                    _index = 0;
+
+                    if (!cache.Count.HasValue &amp;&amp; !encoded.IsEmpty)
                     {
-                        ValueAsnReader outerReader = new ValueAsnReader(encoded, ruleSet);
+                        ValueAsnReader outerReader = new ValueAsnReader(encoded, cache.RuleSet);
                         _reader = outerReader.Read<xsl:value-of select="$collNoun"/>(<xsl:call-template name="MaybeImplicitCall0"/>);
                         outerReader.ThrowIfNotEmpty();
                     }
@@ -1455,6 +1572,22 @@ namespace <xsl:value-of select="@namespace" />
 
                 public bool MoveNext()
                 {
+                    if (_cache.Count.HasValue)
+                    {
+                        if (_index &gt;= _cache.Count.Value)
+                        {
+                            return false;
+                        }
+
+                        _current = _index switch
+                        {<xsl:call-template name="EmitCacheReadArms"><xsl:with-param name="name" select="@name"/></xsl:call-template>
+                            _ =&gt; default,
+                        };
+                        _index++;
+
+                        return true;
+                    }
+
                     if (!_reader.HasData)
                     {
                         return false;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/CertificationRequestInfoAsn.xml.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/Asn1/CertificationRequestInfoAsn.xml.cs
@@ -139,7 +139,9 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
         internal System.Numerics.BigInteger Version;
         internal ReadOnlySpan<byte> Subject;
         internal System.Security.Cryptography.Asn1.ValueSubjectPublicKeyInfoAsn SubjectPublicKeyInfo;
-        internal ReadOnlySpan<byte> Attributes;
+        internal ReadOnlySpan<byte> Attributes { get; private set; }
+        internal int AttributesLength { get; private set; }
+        private AttributesEnumerableCache AttributesCache;
 
         internal readonly void Encode(AsnWriter writer)
         {
@@ -240,39 +242,95 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
             }
 
             decoded.Attributes = sequenceReader.ReadEncodedValue();
+            decoded.AttributesCache.RuleSet = sequenceReader.RuleSet;
+            decoded.InitializeAndValidateAttributes();
 
             sequenceReader.ThrowIfNotEmpty();
         }
 
 
-        internal AttributesEnumerable GetAttributes(AsnEncodingRules ruleSet)
+        internal readonly AttributesEnumerable GetAttributes()
         {
-            return new AttributesEnumerable(Attributes, ruleSet);
+            return new AttributesEnumerable(Attributes, AttributesCache);
+        }
+
+        private void InitializeAndValidateAttributes()
+        {
+            int count = 0;
+            ValueAsnReader reader = new ValueAsnReader(Attributes, AttributesCache.RuleSet);
+            ValueAsnReader collReader = reader.ReadSetOf(new Asn1Tag(TagClass.ContextSpecific, 0));
+            reader.ThrowIfNotEmpty();
+
+            while (collReader.HasData)
+            {
+                checked { count++; }
+                System.Security.Cryptography.Asn1.ValueAttributeAsn item;
+                System.Security.Cryptography.Asn1.ValueAttributeAsn.Decode(ref collReader, out item);
+
+                switch (count)
+                {
+                    case 1: AttributesCache.Attributes1 = item; break;
+                    case 2: AttributesCache.Attributes2 = item; break;
+                    case 3: AttributesCache.Attributes3 = item; break;
+                    case 4: AttributesCache.Attributes4 = item; break;
+                    case 5: AttributesCache.Attributes5 = item; break;
+                    case 6: AttributesCache.Attributes6 = item; break;
+                    case 7: AttributesCache.Attributes7 = item; break;
+                    case 8: AttributesCache.Attributes8 = item; break;
+                    case 9: AttributesCache.Attributes9 = item; break;
+                    case 10: AttributesCache.Attributes10 = item; break;
+                    default: break;
+                }
+            }
+
+            AttributesCache.Count = count <= 10 ? count : null;
+            AttributesLength = count;
+        }
+
+        internal ref struct AttributesEnumerableCache
+        {
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes1;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes2;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes3;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes4;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes5;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes6;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes7;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes8;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes9;
+            internal System.Security.Cryptography.Asn1.ValueAttributeAsn Attributes10;
+            internal int? Count;
+            internal AsnEncodingRules RuleSet;
         }
 
         internal readonly ref struct AttributesEnumerable
         {
             private readonly ReadOnlySpan<byte> _encoded;
-            private readonly AsnEncodingRules _ruleSet;
+            private readonly AttributesEnumerableCache _cache;
 
-            internal AttributesEnumerable(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
+            internal AttributesEnumerable(ReadOnlySpan<byte> encoded, AttributesEnumerableCache cache)
             {
                 _encoded = encoded;
-                _ruleSet = ruleSet;
+                _cache = cache;
             }
 
-            public Enumerator GetEnumerator() => new Enumerator(_encoded, _ruleSet);
+            public Enumerator GetEnumerator() => new Enumerator(_encoded, _cache);
 
             internal ref struct Enumerator
             {
                 private ValueAsnReader _reader;
                 private System.Security.Cryptography.Asn1.ValueAttributeAsn _current;
+                private readonly AttributesEnumerableCache _cache;
+                private int _index;
 
-                internal Enumerator(ReadOnlySpan<byte> encoded, AsnEncodingRules ruleSet)
+                internal Enumerator(ReadOnlySpan<byte> encoded, AttributesEnumerableCache cache)
                 {
-                    if (!encoded.IsEmpty)
+                    _cache = cache;
+                    _index = 0;
+
+                    if (!cache.Count.HasValue && !encoded.IsEmpty)
                     {
-                        ValueAsnReader outerReader = new ValueAsnReader(encoded, ruleSet);
+                        ValueAsnReader outerReader = new ValueAsnReader(encoded, cache.RuleSet);
                         _reader = outerReader.ReadSetOf(new Asn1Tag(TagClass.ContextSpecific, 0));
                         outerReader.ThrowIfNotEmpty();
                     }
@@ -284,6 +342,32 @@ namespace System.Security.Cryptography.X509Certificates.Asn1
 
                 public bool MoveNext()
                 {
+                    if (_cache.Count.HasValue)
+                    {
+                        if (_index >= _cache.Count.Value)
+                        {
+                            return false;
+                        }
+
+                        _current = _index switch
+                        {
+                            0 => _cache.Attributes1,
+                            1 => _cache.Attributes2,
+                            2 => _cache.Attributes3,
+                            3 => _cache.Attributes4,
+                            4 => _cache.Attributes5,
+                            5 => _cache.Attributes6,
+                            6 => _cache.Attributes7,
+                            7 => _cache.Attributes8,
+                            8 => _cache.Attributes9,
+                            9 => _cache.Attributes10,
+                            _ => default,
+                        };
+                        _index++;
+
+                        return true;
+                    }
+
                     if (!_reader.HasData)
                     {
                         return false;

--- a/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRequest.Load.cs
+++ b/src/libraries/System.Security.Cryptography/src/System/Security/Cryptography/X509Certificates/CertificateRequest.Load.cs
@@ -205,7 +205,7 @@ namespace System.Security.Cryptography.X509Certificates
 
                 bool foundCertExt = false;
 
-                foreach (ValueAttributeAsn attr in requestInfo.GetAttributes(AsnEncodingRules.DER))
+                foreach (ValueAttributeAsn attr in requestInfo.GetAttributes())
                 {
                     if (attr.AttrType == Oids.Pkcs9ExtensionRequest)
                     {
@@ -220,7 +220,7 @@ namespace System.Security.Cryptography.X509Certificates
                         scoped ReadOnlySpan<byte> firstAttrValue = default;
                         bool foundAttrValue = false;
 
-                        foreach (ReadOnlySpan<byte> values in attr.GetAttrValues(AsnEncodingRules.DER))
+                        foreach (ReadOnlySpan<byte> values in attr.GetAttrValues())
                         {
                             if (foundAttrValue)
                             {
@@ -275,7 +275,7 @@ namespace System.Security.Cryptography.X509Certificates
                     {
                         bool anyAttrValues = false;
 
-                        foreach (ReadOnlySpan<byte> val in attr.GetAttrValues(AsnEncodingRules.DER))
+                        foreach (ReadOnlySpan<byte> val in attr.GetAttrValues())
                         {
                             req.OtherRequestAttributes.Add(new AsnEncodedData(attr.AttrType, val));
                             anyAttrValues = true;


### PR DESCRIPTION
The main purpose of this change is so that during `Decode` we eagerly read open sequences and set-of. Previously, these were read lazily using the generated `ref struct` enumerator. This is a behavior deviation from the regular `struct` reader which eagerly reads everything. This is important for validation purposes. Without this eager reading, the validation does not validate "child" Sequence structures[^1].

This adds eager enumeration of sequences and set-of during decode to match the behavior of `struct`.

This adds a different problem: we were double enumerating the sequences now. Once for validation, and again if we read it. The enumerator always lazily decodes. It does this because the returning value if a `ref struct` - which we cannot have arrays or collections for.

The solution is to cache up to 10 values in cache `ref struct`. If the sequence/set-of ultimately has more than 10 items this falls back to lazy enumeration all of the time. If it less than or equal to 10, enumerating is "free". We can add some knobs to control the cache size if we want (or 0 to disable it) but I am not sure we need it at the moment.

This 10 is somewhat arbitrary, but it works for a majority of things. X.509 certificates don't typically have more than 10 extensions, X.500 names don't often contain more than 10 RDNs (and each RDN usually isn't composite). We need to balance this cache size with creating very large cache structs that may also themselves have nested caches.

An upshot to this now, is that since we are eagerly validating, there is a `Length` member now as well so we now know up-front after decode how many times are in the collection.

We don't need the cache, but I do think we need a solution to up-front validation. This seems like a good mix of getting two things: re-using the work the validation has done (up to a point) and having the validation. If we want to trade "CPU work" for "Stack size" we can get rid of the cache.

[^1]: This is not a problem today because we are not relying on this eager validation for any of the structs that have been migrated to ref-struct today. But during migration of PKCS#12 and X.509, some things were  no longer being eagerly validated which caused behavior differences of when exceptions were thrown.