### PR TITLE
[cDAC] Fix GetLocalVariableCount to return E_FAIL for missing local signatures

### DIFF
--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataFrame.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Legacy/ClrDataFrame.cs
@@ -550,13 +550,14 @@ public sealed unsafe partial class ClrDataFrame : IXCLRDataFrame, IXCLRDataFrame
 
     /// <summary>
     /// Returns the count of local variables by reading the local signature header.
-    /// Returns 0 if the method has no locals.
+    /// Throws E_FAIL if the method has no local signature (matches native DAC behavior
+    /// for dynamic methods, IL stubs, and methods with no declared locals).
     /// </summary>
     private uint GetLocalVariableCount(MethodDescHandle mdh, Contracts.ModuleHandle moduleHandle)
     {
         BlobReader? reader = GetLocalSignatureReader(mdh, moduleHandle, out _);
         if (reader is null)
-            return 0;
+            throw Marshal.GetExceptionForHR(HResults.E_FAIL)!;
 
         BlobReader r = reader.Value;
         r.ReadSignatureHeader();


### PR DESCRIPTION
## Changes

### GetLocalVariableCount — return E_FAIL for missing local signatures

The native DAC's `GetLocalSig` returns `E_FAIL` when a method has no local signature (dynamic methods, IL stubs, methods with no declared locals). The cDAC was returning `S_OK` with count 0 instead. This mismatch caused validation asserts to fire.

Now `GetLocalVariableCount` throws `Marshal.GetExceptionForHR(E_FAIL)` when `GetLocalSignatureReader` returns null, matching the native DAC behavior exactly.

## Testing

- 117/117 local dump tests pass ✅
- Verified `GetNumLocalVariables` returns `E_FAIL` for methods without locals (DAC parity)