### PR TITLE
Disable System.Security.Cryptography.Tests from Android CoreCLR smoke tests

### DIFF
--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -638,7 +638,8 @@
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Runtime.InteropServices\tests\System.Runtime.InteropServices.UnitTests\System.Runtime.InteropServices.Tests.csproj" />
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Runtime\tests\System.Globalization.Tests\System.Globalization.Tests.csproj" />
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Diagnostics.DiagnosticSource\tests\System.Diagnostics.DiagnosticSource.Tests.csproj" />
-    <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Security.Cryptography\tests\System.Security.Cryptography.Tests.csproj" />
+    <!-- https://github.com/dotnet/runtime/issues/118603 - OOM killed by lowmemorykiller on Android emulator -->
+    <!-- <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Security.Cryptography\tests\System.Security.Cryptography.Tests.csproj" /> -->
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Diagnostics.Tracing\tests\System.Diagnostics.Tracing.Tests.csproj" />
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Net.WebSockets.Client\tests\System.Net.WebSockets.Client.Tests.csproj" />
     <SmokeTestProject Include="$(MSBuildThisFileDirectory)System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj" />


### PR DESCRIPTION
Disable `System.Security.Cryptography.Tests` from the Android CoreCLR smoke test list.

## Problem

The crypto test suite is deterministically OOM-killed by Android's `lowmemorykiller` on the CoreCLR x64 emulator. This has been a 100% failure rate since the smoke tests were first enabled (Aug 2025), with different tests triggering the ~2 GB kill threshold depending on execution order.

Disabling individual tests has been whack-a-mole: PR #118733 disabled some in Aug 2025, but `RSAKeyFileTests` resurfaced in Dec 2025, and the issue report table shows ongoing failures through Mar 2026.

## Fix

Remove the entire project from the CoreCLR Android smoke test list, consistent with the existing full-run exclusion for Android x64/x86 (keyed to #62547). The underlying memory problem is tracked in #118603.
