### PR TITLE
Add built-in OpenTelemetry metrics to MemoryCache

### DIFF
--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/ref/Microsoft.Extensions.Caching.Abstractions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/ref/Microsoft.Extensions.Caching.Abstractions.cs
@@ -142,6 +142,7 @@ namespace Microsoft.Extensions.Caching.Memory
         public long? CurrentEstimatedSize { get { throw null; } init { } }
         public long TotalHits { get { throw null; } init { } }
         public long TotalMisses { get { throw null; } init { } }
+        public long TotalEvictions { get { throw null; } init { } }
     }
     public partial class PostEvictionCallbackRegistration
     {

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheStatistics.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheStatistics.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Extensions.Caching.Memory
         /// <summary>
         /// Gets the total number of cache evictions.
         /// </summary>
+        /// <remarks>
+        /// This count includes entries removed due to cache eviction policies such as expiration or capacity limits.
+        /// It does not include entries removed explicitly by user code (for example, via <c>Remove</c> or <c>Clear</c>),
+        /// and does not include entries that were replaced by new values.
+        /// </remarks>
         public long TotalEvictions { get; init; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheStatistics.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Abstractions/src/MemoryCacheStatistics.cs
@@ -35,5 +35,10 @@ namespace Microsoft.Extensions.Caching.Memory
         /// Gets the total number of cache hits.
         /// </summary>
         public long TotalHits { get; init; }
+
+        /// <summary>
+        /// Gets the total number of cache evictions.
+        /// </summary>
+        public long TotalEvictions { get; init; }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/ref/Microsoft.Extensions.Caching.Memory.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Extensions.Caching.Memory
     public partial class MemoryCache : Microsoft.Extensions.Caching.Memory.IMemoryCache, System.IDisposable
     {
         public MemoryCache(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Caching.Memory.MemoryCacheOptions> optionsAccessor) { }
-        public MemoryCache(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Caching.Memory.MemoryCacheOptions> optionsAccessor, Microsoft.Extensions.Logging.ILoggerFactory loggerFactory) { }
+        public MemoryCache(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Caching.Memory.MemoryCacheOptions> optionsAccessor, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory) { }
+        public MemoryCache(Microsoft.Extensions.Options.IOptions<Microsoft.Extensions.Caching.Memory.MemoryCacheOptions> optionsAccessor, Microsoft.Extensions.Logging.ILoggerFactory? loggerFactory, System.Diagnostics.Metrics.IMeterFactory? meterFactory) { }
         public int Count { get { throw null; } }
         public System.Collections.Generic.IEnumerable<object> Keys { get { throw null; } }
         public void Clear() { }
@@ -51,6 +52,7 @@ namespace Microsoft.Extensions.Caching.Memory
         public long? SizeLimit { get { throw null; } set { } }
         public bool TrackLinkedCacheEntries { get { throw null; } set { } }
         public bool TrackStatistics { get { throw null; } set { } }
+        public string Name { get { throw null; } set { } }
     }
     public partial class MemoryDistributedCacheOptions : Microsoft.Extensions.Caching.Memory.MemoryCacheOptions
     {

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -30,7 +31,9 @@ namespace Microsoft.Extensions.Caching.Memory
         private readonly List<Stats>? _allStats;
         private long _accumulatedHits;
         private long _accumulatedMisses;
+        private long _accumulatedEvictions;
         private readonly ThreadLocal<StatsHandler>? _stats;
+        private readonly Meter? _meter;
         private CoherentState _coherentState;
         private bool _disposed;
         private DateTime _lastExpirationScan;
@@ -47,13 +50,21 @@ namespace Microsoft.Extensions.Caching.Memory
         /// </summary>
         /// <param name="optionsAccessor">The options of the cache.</param>
         /// <param name="loggerFactory">The factory used to create loggers.</param>
-        public MemoryCache(IOptions<MemoryCacheOptions> optionsAccessor, ILoggerFactory loggerFactory)
+        public MemoryCache(IOptions<MemoryCacheOptions> optionsAccessor, ILoggerFactory? loggerFactory)
+            : this(optionsAccessor, loggerFactory, meterFactory: null) { }
+
+        /// <summary>
+        /// Creates a new <see cref="MemoryCache"/> instance.
+        /// </summary>
+        /// <param name="optionsAccessor">The options of the cache.</param>
+        /// <param name="loggerFactory">The factory used to create loggers.</param>
+        /// <param name="meterFactory">The factory used to create meters for metrics collection.</param>
+        public MemoryCache(IOptions<MemoryCacheOptions> optionsAccessor, ILoggerFactory? loggerFactory, IMeterFactory? meterFactory)
         {
             ArgumentNullException.ThrowIfNull(optionsAccessor);
-            ArgumentNullException.ThrowIfNull(loggerFactory);
 
             _options = optionsAccessor.Value;
-            _logger = loggerFactory.CreateLogger<MemoryCache>();
+            _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<MemoryCache>();
 
             _coherentState = new CoherentState();
 
@@ -61,6 +72,12 @@ namespace Microsoft.Extensions.Caching.Memory
             {
                 _allStats = new List<Stats>();
                 _stats = new ThreadLocal<StatsHandler>(() => new StatsHandler(this));
+
+                _meter = meterFactory?.Create(new MeterOptions("Microsoft.Extensions.Caching.Memory.MemoryCache")
+                {
+                    Tags = [new("cache.name", _options.Name)]
+                }) ?? SharedMeter.Instance;
+                InitializeMetrics(_meter);
             }
 
             _lastExpirationScan = UtcNow;
@@ -296,7 +313,10 @@ namespace Microsoft.Extensions.Caching.Memory
                 else
                 {
                     // TODO: For efficiency queue this up for batch removal
-                    coherentState.RemoveEntry(entry, _options);
+                    if (coherentState.RemoveEntry(entry, _options) && _allStats is not null)
+                    {
+                        Interlocked.Increment(ref _accumulatedEvictions);
+                    }
                 }
             }
 
@@ -367,7 +387,8 @@ namespace Microsoft.Extensions.Caching.Memory
                     TotalMisses = sumTotal.miss,
                     TotalHits = sumTotal.hit,
                     CurrentEntryCount = Count,
-                    CurrentEstimatedSize = _options.HasSizeLimit ? Size : null
+                    CurrentEstimatedSize = _options.HasSizeLimit ? Size : null,
+                    TotalEvictions = Interlocked.Read(ref _accumulatedEvictions)
                 };
             }
 
@@ -377,7 +398,11 @@ namespace Microsoft.Extensions.Caching.Memory
         internal void EntryExpired(CacheEntry entry)
         {
             // TODO: For efficiency consider processing these expirations in batches.
-            _coherentState.RemoveEntry(entry, _options);
+            if (_coherentState.RemoveEntry(entry, _options) && _allStats is not null)
+            {
+                Interlocked.Increment(ref _accumulatedEvictions);
+            }
+
             StartScanForExpiredItemsIfNeeded(UtcNow);
         }
 
@@ -486,7 +511,10 @@ namespace Microsoft.Extensions.Caching.Memory
             {
                 if (entry.CheckExpired(utcNow))
                 {
-                    coherentState.RemoveEntry(entry, _options);
+                    if (coherentState.RemoveEntry(entry, _options) && _allStats is not null)
+                    {
+                        Interlocked.Increment(ref _accumulatedEvictions);
+                    }
                 }
             }
         }
@@ -637,9 +665,18 @@ namespace Microsoft.Extensions.Caching.Memory
             ExpirePriorityBucket(ref removedSize, removalSizeTarget, computeEntrySize, entriesToRemove, normalPriEntries);
             ExpirePriorityBucket(ref removedSize, removalSizeTarget, computeEntrySize, entriesToRemove, highPriEntries);
 
+            int actuallyRemoved = 0;
             foreach (CacheEntry entry in entriesToRemove)
             {
-                coherentState.RemoveEntry(entry, _options);
+                if (coherentState.RemoveEntry(entry, _options))
+                {
+                    actuallyRemoved++;
+                }
+            }
+
+            if (_allStats is not null && actuallyRemoved > 0)
+            {
+                Interlocked.Add(ref _accumulatedEvictions, actuallyRemoved);
             }
 
             // Policy:
@@ -691,6 +728,7 @@ namespace Microsoft.Extensions.Caching.Memory
             {
                 if (disposing)
                 {
+                    _meter?.Dispose();
                     _stats?.Dispose();
                     GC.SuppressFinalize(this);
                 }
@@ -796,7 +834,7 @@ namespace Microsoft.Extensions.Caching.Memory
 
             internal long Size => Volatile.Read(ref _cacheSize);
 
-            internal void RemoveEntry(CacheEntry entry, MemoryCacheOptions options)
+            internal bool RemoveEntry(CacheEntry entry, MemoryCacheOptions options)
             {
 #if NET
                 if (entry.Key is string s ? _stringEntries.TryRemove(KeyValuePair.Create(s, entry))
@@ -811,7 +849,10 @@ namespace Microsoft.Extensions.Caching.Memory
                         Interlocked.Add(ref _cacheSize, -entry.Size);
                     }
                     entry.InvokeEvictionCallbacks();
+                    return true;
                 }
+
+                return false;
             }
 
 #if !NET
@@ -837,6 +878,94 @@ namespace Microsoft.Extensions.Caching.Memory
                     => obj is string s ? GetHashCode(s) : 0;
             }
 #endif
+        }
+
+        private void InitializeMetrics(Meter meter)
+        {
+            var weakThis = new WeakReference<MemoryCache>(this);
+            KeyValuePair<string, object?> cacheNameTag = new("cache.name", _options.Name);
+
+            meter.CreateObservableCounter("cache.requests",
+                () =>
+                {
+                    if (!weakThis.TryGetTarget(out MemoryCache? cache) || cache._disposed)
+                    {
+                        return [];
+                    }
+
+                    MemoryCacheStatistics? stats = cache.GetCurrentStatistics();
+                    return stats is null
+                        ? []
+                        : new Measurement<long>[]
+                        {
+                            new(stats.TotalHits, cacheNameTag, new("cache.request.type", "hit")),
+                            new(stats.TotalMisses, cacheNameTag, new("cache.request.type", "miss")),
+                        };
+                },
+                unit: "{requests}",
+                description: "Total cache requests.");
+
+            meter.CreateObservableCounter<long>("cache.evictions",
+                () =>
+                {
+                    if (!weakThis.TryGetTarget(out MemoryCache? cache) || cache._disposed)
+                    {
+                        return [];
+                    }
+
+                    MemoryCacheStatistics? stats = cache.GetCurrentStatistics();
+                    return stats is null
+                        ? []
+                        : [new Measurement<long>(stats.TotalEvictions, cacheNameTag)];
+                },
+                unit: "{evictions}",
+                description: "Total cache evictions.");
+
+            meter.CreateObservableUpDownCounter<long>("cache.entries",
+                () =>
+                {
+                    if (!weakThis.TryGetTarget(out MemoryCache? cache) || cache._disposed)
+                    {
+                        return [];
+                    }
+
+                    MemoryCacheStatistics? stats = cache.GetCurrentStatistics();
+                    return stats is null
+                        ? []
+                        : [new Measurement<long>(stats.CurrentEntryCount, cacheNameTag)];
+                },
+                unit: "{entries}",
+                description: "Current number of cache entries.");
+
+            meter.CreateObservableGauge<long>("cache.estimated_size",
+                () =>
+                {
+                    if (!weakThis.TryGetTarget(out MemoryCache? cache) || cache._disposed)
+                    {
+                        return [];
+                    }
+
+                    MemoryCacheStatistics? stats = cache.GetCurrentStatistics();
+                    return stats?.CurrentEstimatedSize is long size
+                        ? [new Measurement<long>(size, cacheNameTag)]
+                        : [];
+                },
+                unit: "By",
+                description: "Estimated size of the cache.");
+        }
+
+        private sealed class SharedMeter : Meter
+        {
+            public static Meter Instance { get; } = new SharedMeter();
+            private SharedMeter()
+                : base("Microsoft.Extensions.Caching.Memory.MemoryCache")
+            {
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                // NOP to prevent disposing the global instance.
+            }
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCache.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Extensions.Caching.Memory
         private long _accumulatedMisses;
         private long _accumulatedEvictions;
         private readonly ThreadLocal<StatsHandler>? _stats;
-        private readonly Meter? _meter;
         private CoherentState _coherentState;
         private bool _disposed;
         private DateTime _lastExpirationScan;
@@ -73,11 +72,11 @@ namespace Microsoft.Extensions.Caching.Memory
                 _allStats = new List<Stats>();
                 _stats = new ThreadLocal<StatsHandler>(() => new StatsHandler(this));
 
-                _meter = meterFactory?.Create(new MeterOptions("Microsoft.Extensions.Caching.Memory.MemoryCache")
+                Meter meter = meterFactory?.Create(new MeterOptions("Microsoft.Extensions.Caching.Memory.MemoryCache")
                 {
                     Tags = [new("cache.name", _options.Name)]
                 }) ?? SharedMeter.Instance;
-                InitializeMetrics(_meter);
+                InitializeMetrics(meter);
             }
 
             _lastExpirationScan = UtcNow;
@@ -674,7 +673,7 @@ namespace Microsoft.Extensions.Caching.Memory
                 }
             }
 
-            if (_allStats is not null && actuallyRemoved > 0)
+            if (actuallyRemoved > 0 && _allStats is not null)
             {
                 Interlocked.Add(ref _accumulatedEvictions, actuallyRemoved);
             }
@@ -728,7 +727,6 @@ namespace Microsoft.Extensions.Caching.Memory
             {
                 if (disposing)
                 {
-                    _meter?.Dispose();
                     _stats?.Dispose();
                     GC.SuppressFinalize(this);
                 }
@@ -882,7 +880,9 @@ namespace Microsoft.Extensions.Caching.Memory
 
         private void InitializeMetrics(Meter meter)
         {
-            var weakThis = new WeakReference<MemoryCache>(this);
+            // Use a weak reference for `this` to avoid keeping it alive indefinitely
+            // due to it being captured in the instrument's lambda and hence kept alive by the Meter.
+            WeakReference<MemoryCache> weakThis = new(this);
             KeyValuePair<string, object?> cacheNameTag = new("cache.name", _options.Name);
 
             meter.CreateObservableCounter("cache.requests",
@@ -957,6 +957,7 @@ namespace Microsoft.Extensions.Caching.Memory
         private sealed class SharedMeter : Meter
         {
             public static Meter Instance { get; } = new SharedMeter();
+
             private SharedMeter()
                 : base("Microsoft.Extensions.Caching.Memory.MemoryCache")
             {

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCacheOptions.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/MemoryCacheOptions.cs
@@ -98,6 +98,11 @@ namespace Microsoft.Extensions.Caching.Memory
         /// </value>
         public bool TrackStatistics { get; set; }
 
+        /// <summary>
+        /// Gets or sets the name of this cache instance.
+        /// </summary>
+        public string Name { get; set; } = "Default";
+
         MemoryCacheOptions IOptions<MemoryCacheOptions>.Value
         {
             get { return this; }

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/src/Microsoft.Extensions.Caching.Memory.csproj
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/src/Microsoft.Extensions.Caching.Memory.csproj
@@ -16,6 +16,10 @@
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.Primitives\src\Microsoft.Extensions.Primitives.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' != '$(NetCoreAppCurrent)'">
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Diagnostics.DiagnosticSource\src\System.Diagnostics.DiagnosticSource.csproj" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
     <PackageReference Include="System.ValueTuple" Version="$(SystemValueTupleVersion)" />
   </ItemGroup>

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheGetCurrentStatisticsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheGetCurrentStatisticsTests.cs
@@ -114,6 +114,36 @@ namespace Microsoft.Extensions.Caching.Memory
         }
 #endif
 
+        [Fact]
+        public void GetCurrentStatistics_ExplicitRemove_DoesNotTrackEviction()
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions { TrackStatistics = true });
+
+            cache.Set("key", "value");
+            cache.Remove("key");
+
+            MemoryCacheStatistics? stats = cache.GetCurrentStatistics();
+            Assert.NotNull(stats);
+            Assert.Equal(0, stats.TotalEvictions);
+        }
+
+        [Fact]
+        public void GetCurrentStatistics_Compact_TracksTotalEvictions()
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions { TrackStatistics = true });
+
+            for (int i = 0; i < 10; i++)
+            {
+                cache.Set($"key{i}", $"value{i}");
+            }
+
+            cache.Compact(1.0);
+
+            MemoryCacheStatistics? stats = cache.GetCurrentStatistics();
+            Assert.NotNull(stats);
+            Assert.Equal(10, stats.TotalEvictions);
+        }
+
         private class FakeMemoryCache : IMemoryCache
         {
             public ICacheEntry CreateEntry(object key) => throw new NotImplementedException();

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheMetricsTests.cs
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/MemoryCacheMetricsTests.cs
@@ -1,0 +1,325 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if NET
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Extensions.Caching.Memory
+{
+    public class MemoryCacheMetricsTests
+    {
+        [Fact]
+        public void Constructor_WithMeterFactory_CreatesInstruments()
+        {
+            using var meterFactory = new TestMeterFactory();
+            using var meterListener = new MeterListener();
+            var measurements = new List<(string name, long value, KeyValuePair<string, object?>[] tags)>();
+
+            meterListener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == "Microsoft.Extensions.Caching.Memory.MemoryCache")
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            meterListener.SetMeasurementEventCallback<long>((instrument, value, tags, state) =>
+            {
+                measurements.Add((instrument.Name, value, tags.ToArray()));
+            });
+            meterListener.Start();
+
+            using var cache = new MemoryCache(
+                new MemoryCacheOptions { TrackStatistics = true, Name = "test-cache" },
+                loggerFactory: null,
+                meterFactory: meterFactory);
+
+            cache.Set("key", "value");
+            cache.TryGetValue("key", out _);
+            cache.TryGetValue("missing", out _);
+
+            meterListener.RecordObservableInstruments();
+
+            Assert.Contains(measurements, m =>
+                m.name == "cache.requests" &&
+                m.tags.Any(t => t.Key == "cache.request.type" && (string?)t.Value == "hit") &&
+                m.tags.Any(t => t.Key == "cache.name" && (string?)t.Value == "test-cache"));
+
+            Assert.Contains(measurements, m =>
+                m.name == "cache.requests" &&
+                m.tags.Any(t => t.Key == "cache.request.type" && (string?)t.Value == "miss") &&
+                m.tags.Any(t => t.Key == "cache.name" && (string?)t.Value == "test-cache"));
+
+            Assert.Contains(measurements, m => m.name == "cache.entries");
+        }
+
+        [Fact]
+        public void Constructor_WithNullMeterFactory_StillTracksStatistics()
+        {
+            using var cache = new MemoryCache(
+                new MemoryCacheOptions { TrackStatistics = true },
+                loggerFactory: null,
+                meterFactory: null);
+
+            cache.Set("key", "value");
+            cache.TryGetValue("key", out _);
+
+            MemoryCacheStatistics? stats = cache.GetCurrentStatistics();
+            Assert.NotNull(stats);
+            Assert.Equal(1, stats.TotalHits);
+        }
+
+        [Fact]
+        public void Constructor_WithNullMeterFactory_UsesSharedMeter()
+        {
+            using var meterListener = new MeterListener();
+            var measurements = new List<(string name, long value)>();
+
+            meterListener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == "Microsoft.Extensions.Caching.Memory.MemoryCache")
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            meterListener.SetMeasurementEventCallback<long>((instrument, value, tags, state) =>
+            {
+                measurements.Add((instrument.Name, value));
+            });
+            meterListener.Start();
+
+            using var cache = new MemoryCache(
+                new MemoryCacheOptions { TrackStatistics = true },
+                loggerFactory: null,
+                meterFactory: null);
+
+            cache.Set("key", "value");
+            cache.TryGetValue("key", out _);
+            cache.Compact(1.0);
+
+            meterListener.RecordObservableInstruments();
+
+            Assert.Contains(measurements, m => m.name == "cache.requests");
+            Assert.Contains(measurements, m => m.name == "cache.evictions");
+            Assert.Contains(measurements, m => m.name == "cache.entries");
+        }
+
+        [Fact]
+        public void Constructor_WithNullLoggerFactory_DoesNotThrow()
+        {
+            using var cache = new MemoryCache(
+                new MemoryCacheOptions(),
+                loggerFactory: null,
+                meterFactory: null);
+
+            Assert.Equal(0, cache.Count);
+        }
+
+        [Fact]
+        public void TrackStatisticsFalse_NoInstrumentsCreated()
+        {
+            using var meterFactory = new TestMeterFactory();
+
+            using var cache = new MemoryCache(
+                new MemoryCacheOptions { TrackStatistics = false },
+                loggerFactory: null,
+                meterFactory: meterFactory);
+
+            Assert.Empty(meterFactory.Meters);
+        }
+
+        [Fact]
+        public void Name_DefaultsToDefault()
+        {
+            var options = new MemoryCacheOptions();
+            Assert.Equal("Default", options.Name);
+        }
+
+        [Fact]
+        public void Name_CanBeCustomized()
+        {
+            var options = new MemoryCacheOptions { Name = "my-cache" };
+            Assert.Equal("my-cache", options.Name);
+        }
+
+        [Fact]
+        public void EvictionInstrument_ReflectsCompaction()
+        {
+            using var meterFactory = new TestMeterFactory();
+            using var meterListener = new MeterListener();
+            var evictionMeasurements = new List<long>();
+
+            meterListener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == "Microsoft.Extensions.Caching.Memory.MemoryCache" &&
+                    instrument.Name == "cache.evictions")
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            meterListener.SetMeasurementEventCallback<long>((instrument, value, tags, state) =>
+            {
+                evictionMeasurements.Add(value);
+            });
+            meterListener.Start();
+
+            using var cache = new MemoryCache(
+                new MemoryCacheOptions { TrackStatistics = true },
+                loggerFactory: null,
+                meterFactory: meterFactory);
+
+            for (int i = 0; i < 5; i++)
+            {
+                cache.Set($"key{i}", $"value{i}");
+            }
+
+            cache.Compact(1.0);
+
+            meterListener.RecordObservableInstruments();
+
+            Assert.Contains(evictionMeasurements, v => v == 5);
+        }
+
+        [Fact]
+        public void DisposedCache_ReturnsNoMeasurements()
+        {
+            using var meterFactory = new TestMeterFactory();
+
+            var cache = new MemoryCache(
+                new MemoryCacheOptions { TrackStatistics = true },
+                loggerFactory: null,
+                meterFactory: meterFactory);
+
+            Meter factoryMeter = meterFactory.Meters[0];
+
+            using var meterListener = new MeterListener();
+            var measurements = new List<(string name, long value)>();
+
+            meterListener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (ReferenceEquals(instrument.Meter, factoryMeter))
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            meterListener.SetMeasurementEventCallback<long>((instrument, value, tags, state) =>
+            {
+                measurements.Add((instrument.Name, value));
+            });
+            meterListener.Start();
+
+            cache.Set("key", "value");
+
+            // Verify instruments publish before Dispose
+            meterListener.RecordObservableInstruments();
+            Assert.NotEmpty(measurements);
+
+            measurements.Clear();
+            cache.Dispose();
+
+            // Verify instruments return empty after Dispose
+            meterListener.RecordObservableInstruments();
+            Assert.Empty(measurements);
+        }
+
+        [Fact]
+        public void MeterOptions_IncludesCacheNameTag()
+        {
+            using var meterFactory = new TestMeterFactory();
+
+            using var cache = new MemoryCache(
+                new MemoryCacheOptions { TrackStatistics = true, Name = "my-cache" },
+                loggerFactory: null,
+                meterFactory: meterFactory);
+
+            Assert.Single(meterFactory.Meters);
+            Meter meter = meterFactory.Meters[0];
+            Assert.Equal("Microsoft.Extensions.Caching.Memory.MemoryCache", meter.Name);
+            Assert.Contains(meter.Tags, t => t.Key == "cache.name" && (string?)t.Value == "my-cache");
+        }
+
+        [Fact]
+        public void EvictionCount_NotOvercounted_WhenEntryAlreadyRemoved()
+        {
+            using var meterFactory = new TestMeterFactory();
+            using var meterListener = new MeterListener();
+            var evictionMeasurements = new List<long>();
+
+            meterListener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (instrument.Meter.Name == "Microsoft.Extensions.Caching.Memory.MemoryCache" &&
+                    instrument.Name == "cache.evictions")
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            meterListener.SetMeasurementEventCallback<long>((instrument, value, tags, state) =>
+            {
+                evictionMeasurements.Add(value);
+            });
+            meterListener.Start();
+
+            var clock = new Microsoft.Extensions.Internal.TestClock();
+            using var cache = new MemoryCache(
+                new MemoryCacheOptions
+                {
+                    TrackStatistics = true,
+                    Clock = clock,
+                    ExpirationScanFrequency = TimeSpan.Zero
+                },
+                loggerFactory: null,
+                meterFactory: meterFactory);
+
+            // Add entries with short expiration
+            for (int i = 0; i < 3; i++)
+            {
+                cache.Set($"key{i}", $"value{i}", new MemoryCacheEntryOptions
+                {
+                    AbsoluteExpiration = clock.UtcNow + TimeSpan.FromMinutes(1)
+                });
+            }
+
+            // Advance time past expiration
+            clock.Add(TimeSpan.FromMinutes(2));
+
+            // Access triggers expiration removal for one entry
+            cache.TryGetValue("key0", out _);
+
+            // Compact tries to remove all (including already-removed key0)
+            cache.Compact(1.0);
+
+            MemoryCacheStatistics? stats = cache.GetCurrentStatistics();
+            Assert.NotNull(stats);
+            Assert.Equal(3, stats.TotalEvictions);
+
+            meterListener.RecordObservableInstruments();
+            Assert.Contains(evictionMeasurements, v => v == 3);
+        }
+
+        private sealed class TestMeterFactory : IMeterFactory
+        {
+            private readonly List<Meter> _meters = new();
+
+            public IReadOnlyList<Meter> Meters => _meters;
+
+            public Meter Create(MeterOptions options)
+            {
+                var meter = new Meter(options);
+                _meters.Add(meter);
+                return meter;
+            }
+
+            public void Dispose()
+            {
+                foreach (var meter in _meters)
+                {
+                    meter.Dispose();
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/libraries/Microsoft.Extensions.Caching.Memory/tests/Microsoft.Extensions.Caching.Memory.Tests.csproj
+++ b/src/libraries/Microsoft.Extensions.Caching.Memory/tests/Microsoft.Extensions.Caching.Memory.Tests.csproj
@@ -18,4 +18,8 @@
     <ProjectReference Include="$(LibrariesProjectRoot)Microsoft.Extensions.DependencyInjection\src\Microsoft.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <ProjectReference Include="$(LibrariesProjectRoot)System.Diagnostics.DiagnosticSource\src\System.Diagnostics.DiagnosticSource.csproj" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

Adds OpenTelemetry metrics to `MemoryCache`. Follows the `System.Net.Http` pattern ([#87319](https://github.com/dotnet/runtime/pull/87319)).

Fixes #124140

## API Changes

### Microsoft.Extensions.Caching.Abstractions

```csharp
public class MemoryCacheStatistics
{
    public long TotalEvictions { get; init; } // NEW
}
```

### Microsoft.Extensions.Caching.Memory

```csharp
public class MemoryCacheOptions
{
    public string Name { get; set; } = "Default"; // NEW
}

public class MemoryCache
{
    // ILoggerFactory now nullable
    public MemoryCache(IOptions<MemoryCacheOptions> optionsAccessor, ILoggerFactory? loggerFactory);

    // NEW
    public MemoryCache(IOptions<MemoryCacheOptions> optionsAccessor, ILoggerFactory? loggerFactory, IMeterFactory? meterFactory);
}
```

## Instruments

Meter: `Microsoft.Extensions.Caching.Memory.MemoryCache`

| Instrument | Type | Dimensions |
|-----------|------|------------|
| `cache.requests` | ObservableCounter&lt;long&gt; | `cache.name`, `cache.request.type` (hit/miss) |
| `cache.evictions` | ObservableCounter&lt;long&gt; | `cache.name` |
| `cache.entries` | ObservableUpDownCounter&lt;long&gt; | `cache.name` |
| `cache.estimated_size` | ObservableGauge&lt;long&gt; | `cache.name` |

## Design

- **Gated on `TrackStatistics`** — no instruments created unless `TrackStatistics = true`
- **SharedMeter fallback** — no `IMeterFactory`, no problem. Singleton `SharedMeter` with NOP `Dispose`. Same pattern as `System.Net.Http.MetricsHandler.SharedMeter`
- **MeterOptions tags** — factory path sets `Tags = [new("cache.name", _options.Name)]` for meter deduplication in `DefaultMeterFactory`
- **WeakReference callbacks** — observable callbacks capture `WeakReference<MemoryCache>`. Dead caches return empty measurements. No GC leaks
- **IEnumerable overloads** — `Func<IEnumerable<Measurement<long>>>` prevents phantom zero measurements from disposed or collected caches
- **Eviction counting** — `RemoveEntry` calls `ConcurrentDictionary.TryRemove(KVP)`. Only the thread that removes the entry increments `TotalEvictions`. No double-counting
- **DI unchanged** — new constructor auto-selected. No changes to `MemoryCacheServiceCollectionExtensions`
- **Conditional DiagnosticSource ref** — in-box for net11.0+

## Tests

- 142 tests pass (net11.0)
- 11 new metrics tests: instrument creation, SharedMeter fallback, null factory/logger, TrackStatistics gate, Name property, eviction accuracy, disposed cache, MeterOptions tags, over-count prevention
- 2 new eviction statistics tests