### PR TITLE
fix `ChainedRateLimiter` treating `IdleDuration` and chained `ReplenishmentRateLimiters` incorrectly

### DIFF
--- a/src/libraries/System.Threading.RateLimiting/src/System.Threading.RateLimiting.csproj
+++ b/src/libraries/System.Threading.RateLimiting/src/System.Threading.RateLimiting.csproj
@@ -14,6 +14,7 @@ System.Threading.RateLimiting.RateLimitLease</PackageDescription>
 
   <ItemGroup>
     <Compile Include="System\Threading\RateLimiting\ChainedRateLimiter.cs" />
+    <Compile Include="System\Threading\RateLimiting\ChainedReplenishingRateLimiter.cs" />
     <Compile Include="System\Threading\RateLimiting\ChainedPartitionedRateLimiter.cs" />
     <Compile Include="System\Threading\RateLimiting\CombinedRateLimitLease.cs" />
     <Compile Include="System\Threading\RateLimiting\ConcurrencyLimiter.cs" />

--- a/src/libraries/System.Threading.RateLimiting/src/System.Threading.RateLimiting.csproj
+++ b/src/libraries/System.Threading.RateLimiting/src/System.Threading.RateLimiting.csproj
@@ -14,6 +14,7 @@ System.Threading.RateLimiting.RateLimitLease</PackageDescription>
 
   <ItemGroup>
     <Compile Include="System\Threading\RateLimiting\ChainedRateLimiter.cs" />
+    <Compile Include="System\Threading\RateLimiting\ChainedRateLimiterShared.cs" />
     <Compile Include="System\Threading\RateLimiting\ChainedReplenishingRateLimiter.cs" />
     <Compile Include="System\Threading\RateLimiting\ChainedPartitionedRateLimiter.cs" />
     <Compile Include="System\Threading\RateLimiting\CombinedRateLimitLease.cs" />

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedPartitionedRateLimiter.cs
@@ -76,7 +76,7 @@ namespace System.Threading.RateLimiting
                     exception = ex;
                 }
 
-                RateLimitLease? notAcquiredLease = ChainedRateLimiter.CommonAcquireLogic(exception, lease, ref leases, i, _limiters.Length);
+                RateLimitLease? notAcquiredLease = ChainedRateLimiterShared.CommonAcquireLogic(exception, lease, ref leases, i, _limiters.Length);
 
                 if (notAcquiredLease is not null)
                 {
@@ -107,7 +107,7 @@ namespace System.Threading.RateLimiting
                     exception = ex;
                 }
 
-                RateLimitLease? notAcquiredLease = ChainedRateLimiter.CommonAcquireLogic(exception, lease, ref leases, i, _limiters.Length);
+                RateLimitLease? notAcquiredLease = ChainedRateLimiterShared.CommonAcquireLogic(exception, lease, ref leases, i, _limiters.Length);
 
                 if (notAcquiredLease is not null)
                 {

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiter.cs
@@ -81,6 +81,31 @@ namespace System.Threading.RateLimiting
             }
         }
 
+        internal void TryReplenish()
+        {
+            List<Exception>? exceptions = null;
+            foreach (RateLimiter limiter in _limiters)
+            {
+                if (limiter is ReplenishingRateLimiter replenishingRateLimiter)
+                {
+                    try
+                    {
+                        replenishingRateLimiter.TryReplenish();
+                    }
+                    catch (Exception ex)
+                    {
+                        exceptions ??= [];
+                        exceptions.Add(ex);
+                    }
+                }
+            }
+
+            if (exceptions is not null)
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
+
         protected override RateLimitLease AttemptAcquireCore(int permitCount)
         {
             ThrowIfDisposed();

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiter.cs
@@ -64,12 +64,16 @@ namespace System.Threading.RateLimiting
 
                 foreach (RateLimiter limiter in _limiters)
                 {
-                    if (limiter.IdleDuration is { } idleDuration)
+                    TimeSpan? idleDuration = limiter.IdleDuration;
+                    if (idleDuration is null)
                     {
-                        if (lowestIdleDuration is null || idleDuration < lowestIdleDuration)
-                        {
-                            lowestIdleDuration = idleDuration;
-                        }
+                        // The chain should not be considered idle if any of its children is not idle.
+                        return null;
+                    }
+
+                    if (lowestIdleDuration is null || idleDuration < lowestIdleDuration)
+                    {
+                        lowestIdleDuration = idleDuration;
                     }
                 }
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiter.cs
@@ -24,13 +24,51 @@ namespace System.Threading.RateLimiting
         public override RateLimiterStatistics? GetStatistics()
         {
             ThrowIfDisposed();
+            return GetStatisticsCore(_limiters);
+        }
 
+        public override TimeSpan? IdleDuration
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return GetIdleDurationCore(_limiters);
+            }
+        }
+
+        protected override RateLimitLease AttemptAcquireCore(int permitCount)
+        {
+            ThrowIfDisposed();
+            return AttemptAcquireChained(_limiters, permitCount);
+        }
+
+        protected override async ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            return await AcquireAsyncChained(_limiters, permitCount, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _disposed = true;
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(ChainedRateLimiter));
+            }
+        }
+
+        internal static RateLimiterStatistics GetStatisticsCore(RateLimiter[] limiters)
+        {
             long lowestAvailablePermits = long.MaxValue;
             long currentQueuedCount = 0;
             long totalFailedLeases = 0;
             long innerMostSuccessfulLeases = 0;
 
-            foreach (RateLimiter limiter in _limiters)
+            foreach (RateLimiter limiter in limiters)
             {
                 if (limiter.GetStatistics() is { } statistics)
                 {
@@ -54,79 +92,47 @@ namespace System.Threading.RateLimiting
             };
         }
 
-        public override TimeSpan? IdleDuration
+        internal static TimeSpan? GetIdleDurationCore(RateLimiter[] limiters)
         {
-            get
+            TimeSpan? lowestIdleDuration = null;
+
+            foreach (RateLimiter limiter in limiters)
             {
-                ThrowIfDisposed();
-
-                TimeSpan? lowestIdleDuration = null;
-
-                foreach (RateLimiter limiter in _limiters)
+                TimeSpan? idleDuration = limiter.IdleDuration;
+                if (idleDuration is null)
                 {
-                    TimeSpan? idleDuration = limiter.IdleDuration;
-                    if (idleDuration is null)
-                    {
-                        // The chain should not be considered idle if any of its children is not idle.
-                        return null;
-                    }
-
-                    if (lowestIdleDuration is null || idleDuration < lowestIdleDuration)
-                    {
-                        lowestIdleDuration = idleDuration;
-                    }
+                    // The chain should not be considered idle if any of its children is not idle.
+                    return null;
                 }
 
-                return lowestIdleDuration;
-            }
-        }
-
-        internal void TryReplenish()
-        {
-            List<Exception>? exceptions = null;
-            foreach (RateLimiter limiter in _limiters)
-            {
-                if (limiter is ReplenishingRateLimiter replenishingRateLimiter)
+                if (lowestIdleDuration is null || idleDuration < lowestIdleDuration)
                 {
-                    try
-                    {
-                        replenishingRateLimiter.TryReplenish();
-                    }
-                    catch (Exception ex)
-                    {
-                        exceptions ??= [];
-                        exceptions.Add(ex);
-                    }
+                    lowestIdleDuration = idleDuration;
                 }
             }
 
-            if (exceptions is not null)
-            {
-                throw new AggregateException(exceptions);
-            }
+            return lowestIdleDuration;
         }
 
-        protected override RateLimitLease AttemptAcquireCore(int permitCount)
+        internal static RateLimitLease AttemptAcquireChained(RateLimiter[] limiters, int permitCount)
         {
-            ThrowIfDisposed();
-
             RateLimitLease[]? leases = null;
 
-            for (int i = 0; i < _limiters.Length; i++)
+            for (int i = 0; i < limiters.Length; i++)
             {
                 RateLimitLease? lease = null;
                 Exception? exception = null;
 
                 try
                 {
-                    lease = _limiters[i].AttemptAcquire(permitCount);
+                    lease = limiters[i].AttemptAcquire(permitCount);
                 }
                 catch (Exception ex)
                 {
                     exception = ex;
                 }
 
-                RateLimitLease? notAcquiredLease = CommonAcquireLogic(exception, lease, ref leases, i, _limiters.Length);
+                RateLimitLease? notAcquiredLease = CommonAcquireLogic(exception, lease, ref leases, i, limiters.Length);
 
                 if (notAcquiredLease is not null)
                 {
@@ -137,27 +143,25 @@ namespace System.Threading.RateLimiting
             return new CombinedRateLimitLease(leases!);
         }
 
-        protected override async ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
+        internal static async ValueTask<RateLimitLease> AcquireAsyncChained(RateLimiter[] limiters, int permitCount, CancellationToken cancellationToken)
         {
-            ThrowIfDisposed();
-
             RateLimitLease[]? leases = null;
 
-            for (int i = 0; i < _limiters.Length; i++)
+            for (int i = 0; i < limiters.Length; i++)
             {
                 RateLimitLease? lease = null;
                 Exception? exception = null;
 
                 try
                 {
-                    lease = await _limiters[i].AcquireAsync(permitCount, cancellationToken).ConfigureAwait(false);
+                    lease = await limiters[i].AcquireAsync(permitCount, cancellationToken).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
                     exception = ex;
                 }
 
-                RateLimitLease? notAcquiredLease = CommonAcquireLogic(exception, lease, ref leases, i, _limiters.Length);
+                RateLimitLease? notAcquiredLease = CommonAcquireLogic(exception, lease, ref leases, i, limiters.Length);
 
                 if (notAcquiredLease is not null)
                 {
@@ -166,19 +170,6 @@ namespace System.Threading.RateLimiting
             }
 
             return new CombinedRateLimitLease(leases!);
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            _disposed = true;
-        }
-
-        private void ThrowIfDisposed()
-        {
-            if (_disposed)
-            {
-                throw new ObjectDisposedException(nameof(ChainedRateLimiter));
-            }
         }
 
         internal static RateLimitLease? CommonAcquireLogic(Exception? ex, RateLimitLease? lease, ref RateLimitLease[]? leases, int index, int length)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiter.cs
@@ -48,8 +48,31 @@ namespace System.Threading.RateLimiting
 
         protected override void Dispose(bool disposing)
         {
+            if (!disposing)
+            {
+                return;
+            }
+
+            if (_disposed)
+            {
+                return;
+            }
+
             _disposed = true;
+            ChainedRateLimiterShared.DisposeLimiters(_limiters);
             base.Dispose(disposing);
+        }
+
+        protected override async ValueTask DisposeAsyncCore()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            await ChainedRateLimiterShared.DisposeLimitersAsync(_limiters).ConfigureAwait(false);
+            await base.DisposeAsyncCore().ConfigureAwait(false);
         }
 
         private void ThrowIfDisposed()

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiter.cs
@@ -48,31 +48,7 @@ namespace System.Threading.RateLimiting
 
         protected override void Dispose(bool disposing)
         {
-            if (!disposing)
-            {
-                return;
-            }
-
-            if (_disposed)
-            {
-                return;
-            }
-
             _disposed = true;
-            ChainedRateLimiterShared.DisposeLimiters(_limiters);
-            base.Dispose(disposing);
-        }
-
-        protected override async ValueTask DisposeAsyncCore()
-        {
-            if (_disposed)
-            {
-                return;
-            }
-
-            _disposed = true;
-            await ChainedRateLimiterShared.DisposeLimitersAsync(_limiters).ConfigureAwait(false);
-            await base.DisposeAsyncCore().ConfigureAwait(false);
         }
 
         private void ThrowIfDisposed()

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiter.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 
 namespace System.Threading.RateLimiting
@@ -11,7 +9,7 @@ namespace System.Threading.RateLimiting
     /// Acquires leases from rate limiters in the order given. If a lease fails to be acquired (throwing or IsAcquired == false)
     /// then the already acquired leases are disposed in reverse order and the failing lease is returned or the exception is thrown to user code.
     /// </summary>
-    internal sealed partial class ChainedRateLimiter : RateLimiter
+    internal sealed class ChainedRateLimiter : RateLimiter
     {
         private readonly RateLimiter[] _limiters;
         private bool _disposed;
@@ -24,7 +22,7 @@ namespace System.Threading.RateLimiting
         public override RateLimiterStatistics? GetStatistics()
         {
             ThrowIfDisposed();
-            return GetStatisticsCore(_limiters);
+            return ChainedRateLimiterShared.GetStatisticsCore(_limiters);
         }
 
         public override TimeSpan? IdleDuration
@@ -32,25 +30,26 @@ namespace System.Threading.RateLimiting
             get
             {
                 ThrowIfDisposed();
-                return GetIdleDurationCore(_limiters);
+                return ChainedRateLimiterShared.GetIdleDurationCore(_limiters);
             }
         }
 
         protected override RateLimitLease AttemptAcquireCore(int permitCount)
         {
             ThrowIfDisposed();
-            return AttemptAcquireChained(_limiters, permitCount);
+            return ChainedRateLimiterShared.AttemptAcquireChained(_limiters, permitCount);
         }
 
         protected override async ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
-            return await AcquireAsyncChained(_limiters, permitCount, cancellationToken).ConfigureAwait(false);
+            return await ChainedRateLimiterShared.AcquireAsyncChained(_limiters, permitCount, cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)
         {
             _disposed = true;
+            base.Dispose(disposing);
         }
 
         private void ThrowIfDisposed()
@@ -59,172 +58,6 @@ namespace System.Threading.RateLimiting
             {
                 throw new ObjectDisposedException(nameof(ChainedRateLimiter));
             }
-        }
-
-        internal static RateLimiterStatistics GetStatisticsCore(RateLimiter[] limiters)
-        {
-            long lowestAvailablePermits = long.MaxValue;
-            long currentQueuedCount = 0;
-            long totalFailedLeases = 0;
-            long innerMostSuccessfulLeases = 0;
-
-            foreach (RateLimiter limiter in limiters)
-            {
-                if (limiter.GetStatistics() is { } statistics)
-                {
-                    if (statistics.CurrentAvailablePermits < lowestAvailablePermits)
-                    {
-                        lowestAvailablePermits = statistics.CurrentAvailablePermits;
-                    }
-
-                    currentQueuedCount += statistics.CurrentQueuedCount;
-                    totalFailedLeases += statistics.TotalFailedLeases;
-                    innerMostSuccessfulLeases = statistics.TotalSuccessfulLeases;
-                }
-            }
-
-            return new RateLimiterStatistics()
-            {
-                CurrentAvailablePermits = lowestAvailablePermits,
-                CurrentQueuedCount = currentQueuedCount,
-                TotalFailedLeases = totalFailedLeases,
-                TotalSuccessfulLeases = innerMostSuccessfulLeases,
-            };
-        }
-
-        internal static TimeSpan? GetIdleDurationCore(RateLimiter[] limiters)
-        {
-            TimeSpan? lowestIdleDuration = null;
-
-            foreach (RateLimiter limiter in limiters)
-            {
-                TimeSpan? idleDuration = limiter.IdleDuration;
-                if (idleDuration is null)
-                {
-                    // The chain should not be considered idle if any of its children is not idle.
-                    return null;
-                }
-
-                if (lowestIdleDuration is null || idleDuration < lowestIdleDuration)
-                {
-                    lowestIdleDuration = idleDuration;
-                }
-            }
-
-            return lowestIdleDuration;
-        }
-
-        internal static RateLimitLease AttemptAcquireChained(RateLimiter[] limiters, int permitCount)
-        {
-            RateLimitLease[]? leases = null;
-
-            for (int i = 0; i < limiters.Length; i++)
-            {
-                RateLimitLease? lease = null;
-                Exception? exception = null;
-
-                try
-                {
-                    lease = limiters[i].AttemptAcquire(permitCount);
-                }
-                catch (Exception ex)
-                {
-                    exception = ex;
-                }
-
-                RateLimitLease? notAcquiredLease = CommonAcquireLogic(exception, lease, ref leases, i, limiters.Length);
-
-                if (notAcquiredLease is not null)
-                {
-                    return notAcquiredLease;
-                }
-            }
-
-            return new CombinedRateLimitLease(leases!);
-        }
-
-        internal static async ValueTask<RateLimitLease> AcquireAsyncChained(RateLimiter[] limiters, int permitCount, CancellationToken cancellationToken)
-        {
-            RateLimitLease[]? leases = null;
-
-            for (int i = 0; i < limiters.Length; i++)
-            {
-                RateLimitLease? lease = null;
-                Exception? exception = null;
-
-                try
-                {
-                    lease = await limiters[i].AcquireAsync(permitCount, cancellationToken).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    exception = ex;
-                }
-
-                RateLimitLease? notAcquiredLease = CommonAcquireLogic(exception, lease, ref leases, i, limiters.Length);
-
-                if (notAcquiredLease is not null)
-                {
-                    return notAcquiredLease;
-                }
-            }
-
-            return new CombinedRateLimitLease(leases!);
-        }
-
-        internal static RateLimitLease? CommonAcquireLogic(Exception? ex, RateLimitLease? lease, ref RateLimitLease[]? leases, int index, int length)
-        {
-            if (ex is not null)
-            {
-                AggregateException? innerEx = CommonDispose(leases, index);
-
-                if (innerEx is not null)
-                {
-                    Exception[] exceptions = new Exception[innerEx.InnerExceptions.Count + 1];
-                    innerEx.InnerExceptions.CopyTo(exceptions, 0);
-                    exceptions[exceptions.Length - 1] = ex;
-                    throw new AggregateException(exceptions);
-                }
-
-                ExceptionDispatchInfo.Capture(ex).Throw();
-            }
-
-            if (!lease!.IsAcquired)
-            {
-                AggregateException? innerEx = CommonDispose(leases, index);
-                return innerEx is not null ? throw innerEx : lease;
-            }
-
-            leases ??= new RateLimitLease[length];
-            leases[index] = lease;
-            return null;
-        }
-
-        private static AggregateException? CommonDispose(RateLimitLease[]? leases, int i)
-        {
-            List<Exception>? exceptions = null;
-
-            while (i > 0)
-            {
-                i--;
-
-                try
-                {
-                    leases![i].Dispose();
-                }
-                catch (Exception ex)
-                {
-                    exceptions ??= [];
-                    exceptions.Add(ex);
-                }
-            }
-
-            if (exceptions is not null)
-            {
-                return new AggregateException(exceptions);
-            }
-
-            return null;
         }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiterShared.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiterShared.cs
@@ -179,50 +179,5 @@ namespace System.Threading.RateLimiting
             return null;
         }
 
-        internal static void DisposeLimiters(RateLimiter[] limiters)
-        {
-            List<Exception>? exceptions = null;
-
-            foreach (RateLimiter limiter in limiters)
-            {
-                try
-                {
-                    limiter.Dispose();
-                }
-                catch (Exception ex)
-                {
-                    exceptions ??= [];
-                    exceptions.Add(ex);
-                }
-            }
-
-            if (exceptions is not null)
-            {
-                throw new AggregateException(exceptions);
-            }
-        }
-
-        internal static async ValueTask DisposeLimitersAsync(RateLimiter[] limiters)
-        {
-            List<Exception>? exceptions = null;
-
-            foreach (RateLimiter limiter in limiters)
-            {
-                try
-                {
-                    await limiter.DisposeAsync().ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    exceptions ??= [];
-                    exceptions.Add(ex);
-                }
-            }
-
-            if (exceptions is not null)
-            {
-                throw new AggregateException(exceptions);
-            }
-        }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiterShared.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiterShared.cs
@@ -1,0 +1,182 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+
+namespace System.Threading.RateLimiting
+{
+    /// <summary>
+    /// Shared static methods used by <see cref="ChainedRateLimiter"/>,
+    /// <see cref="ChainedReplenishingRateLimiter"/>, and <see cref="ChainedPartitionedRateLimiter{TResource}"/>.
+    /// </summary>
+    internal static class ChainedRateLimiterShared
+    {
+        internal static RateLimiterStatistics GetStatisticsCore(RateLimiter[] limiters)
+        {
+            long lowestAvailablePermits = long.MaxValue;
+            long currentQueuedCount = 0;
+            long totalFailedLeases = 0;
+            long innerMostSuccessfulLeases = 0;
+
+            foreach (RateLimiter limiter in limiters)
+            {
+                if (limiter.GetStatistics() is { } statistics)
+                {
+                    if (statistics.CurrentAvailablePermits < lowestAvailablePermits)
+                    {
+                        lowestAvailablePermits = statistics.CurrentAvailablePermits;
+                    }
+
+                    currentQueuedCount += statistics.CurrentQueuedCount;
+                    totalFailedLeases += statistics.TotalFailedLeases;
+                    innerMostSuccessfulLeases = statistics.TotalSuccessfulLeases;
+                }
+            }
+
+            return new RateLimiterStatistics()
+            {
+                CurrentAvailablePermits = lowestAvailablePermits,
+                CurrentQueuedCount = currentQueuedCount,
+                TotalFailedLeases = totalFailedLeases,
+                TotalSuccessfulLeases = innerMostSuccessfulLeases,
+            };
+        }
+
+        internal static TimeSpan? GetIdleDurationCore(RateLimiter[] limiters)
+        {
+            TimeSpan? lowestIdleDuration = null;
+
+            foreach (RateLimiter limiter in limiters)
+            {
+                TimeSpan? idleDuration = limiter.IdleDuration;
+                if (idleDuration is null)
+                {
+                    // The chain should not be considered idle if any of its children is not idle.
+                    return null;
+                }
+
+                if (lowestIdleDuration is null || idleDuration < lowestIdleDuration)
+                {
+                    lowestIdleDuration = idleDuration;
+                }
+            }
+
+            return lowestIdleDuration;
+        }
+
+        internal static RateLimitLease AttemptAcquireChained(RateLimiter[] limiters, int permitCount)
+        {
+            RateLimitLease[]? leases = null;
+
+            for (int i = 0; i < limiters.Length; i++)
+            {
+                RateLimitLease? lease = null;
+                Exception? exception = null;
+
+                try
+                {
+                    lease = limiters[i].AttemptAcquire(permitCount);
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+
+                RateLimitLease? notAcquiredLease = CommonAcquireLogic(exception, lease, ref leases, i, limiters.Length);
+
+                if (notAcquiredLease is not null)
+                {
+                    return notAcquiredLease;
+                }
+            }
+
+            return new CombinedRateLimitLease(leases!);
+        }
+
+        internal static async ValueTask<RateLimitLease> AcquireAsyncChained(RateLimiter[] limiters, int permitCount, CancellationToken cancellationToken)
+        {
+            RateLimitLease[]? leases = null;
+
+            for (int i = 0; i < limiters.Length; i++)
+            {
+                RateLimitLease? lease = null;
+                Exception? exception = null;
+
+                try
+                {
+                    lease = await limiters[i].AcquireAsync(permitCount, cancellationToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+                }
+
+                RateLimitLease? notAcquiredLease = CommonAcquireLogic(exception, lease, ref leases, i, limiters.Length);
+
+                if (notAcquiredLease is not null)
+                {
+                    return notAcquiredLease;
+                }
+            }
+
+            return new CombinedRateLimitLease(leases!);
+        }
+
+        internal static RateLimitLease? CommonAcquireLogic(Exception? ex, RateLimitLease? lease, ref RateLimitLease[]? leases, int index, int length)
+        {
+            if (ex is not null)
+            {
+                AggregateException? innerEx = CommonDispose(leases, index);
+
+                if (innerEx is not null)
+                {
+                    Exception[] exceptions = new Exception[innerEx.InnerExceptions.Count + 1];
+                    innerEx.InnerExceptions.CopyTo(exceptions, 0);
+                    exceptions[exceptions.Length - 1] = ex;
+                    throw new AggregateException(exceptions);
+                }
+
+                ExceptionDispatchInfo.Capture(ex).Throw();
+            }
+
+            if (!lease!.IsAcquired)
+            {
+                AggregateException? innerEx = CommonDispose(leases, index);
+                return innerEx is not null ? throw innerEx : lease;
+            }
+
+            leases ??= new RateLimitLease[length];
+            leases[index] = lease;
+            return null;
+        }
+
+        private static AggregateException? CommonDispose(RateLimitLease[]? leases, int i)
+        {
+            List<Exception>? exceptions = null;
+
+            while (i > 0)
+            {
+                i--;
+
+                try
+                {
+                    leases![i].Dispose();
+                }
+                catch (Exception ex)
+                {
+                    exceptions ??= [];
+                    exceptions.Add(ex);
+                }
+            }
+
+            if (exceptions is not null)
+            {
+                return new AggregateException(exceptions);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiterShared.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedRateLimiterShared.cs
@@ -178,5 +178,51 @@ namespace System.Threading.RateLimiting
 
             return null;
         }
+
+        internal static void DisposeLimiters(RateLimiter[] limiters)
+        {
+            List<Exception>? exceptions = null;
+
+            foreach (RateLimiter limiter in limiters)
+            {
+                try
+                {
+                    limiter.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    exceptions ??= [];
+                    exceptions.Add(ex);
+                }
+            }
+
+            if (exceptions is not null)
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
+
+        internal static async ValueTask DisposeLimitersAsync(RateLimiter[] limiters)
+        {
+            List<Exception>? exceptions = null;
+
+            foreach (RateLimiter limiter in limiters)
+            {
+                try
+                {
+                    await limiter.DisposeAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    exceptions ??= [];
+                    exceptions.Add(ex);
+                }
+            }
+
+            if (exceptions is not null)
+            {
+                throw new AggregateException(exceptions);
+            }
+        }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedReplenishingRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedReplenishingRateLimiter.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace System.Threading.RateLimiting
+{
+    /// <summary>
+    /// A chained rate limiter that extends <see cref="ReplenishingRateLimiter"/> when at least one of the
+    /// chained limiters is a <see cref="ReplenishingRateLimiter"/>.
+    /// </summary>
+    internal sealed class ChainedReplenishingRateLimiter : ReplenishingRateLimiter
+    {
+        private readonly RateLimiter[] _limiters;
+        private readonly ReplenishingRateLimiter[] _replenishingLimiters;
+        private readonly bool _isAutoReplenishing;
+        private readonly TimeSpan _replenishmentPeriod;
+        private bool _disposed;
+
+        public ChainedReplenishingRateLimiter(RateLimiter[] limiters)
+        {
+            _limiters = (RateLimiter[])limiters.Clone();
+
+            var replenishingLimiters = new List<ReplenishingRateLimiter>();
+            bool isAutoReplenishing = true;
+            TimeSpan lowestPeriod = TimeSpan.MaxValue;
+
+            foreach (RateLimiter limiter in _limiters)
+            {
+                if (limiter is ReplenishingRateLimiter replenishing)
+                {
+                    replenishingLimiters.Add(replenishing);
+
+                    if (!replenishing.IsAutoReplenishing)
+                    {
+                        isAutoReplenishing = false;
+                    }
+
+                    TimeSpan period = replenishing.ReplenishmentPeriod;
+                    if (period > TimeSpan.Zero && period < lowestPeriod)
+                    {
+                        lowestPeriod = period;
+                    }
+                }
+            }
+
+            _replenishingLimiters = replenishingLimiters.ToArray();
+            _isAutoReplenishing = isAutoReplenishing;
+            _replenishmentPeriod = lowestPeriod == TimeSpan.MaxValue ? TimeSpan.Zero : lowestPeriod;
+        }
+
+        public override bool IsAutoReplenishing => _isAutoReplenishing;
+
+        public override TimeSpan ReplenishmentPeriod => _replenishmentPeriod;
+
+        public override bool TryReplenish()
+        {
+            ThrowIfDisposed();
+
+            bool replenished = false;
+            foreach (ReplenishingRateLimiter limiter in _replenishingLimiters)
+            {
+                if (limiter.TryReplenish())
+                {
+                    replenished = true;
+                }
+            }
+            return replenished;
+        }
+
+        public override RateLimiterStatistics? GetStatistics()
+        {
+            ThrowIfDisposed();
+            return ChainedRateLimiter.GetStatisticsCore(_limiters);
+        }
+
+        public override TimeSpan? IdleDuration
+        {
+            get
+            {
+                ThrowIfDisposed();
+                return ChainedRateLimiter.GetIdleDurationCore(_limiters);
+            }
+        }
+
+        protected override RateLimitLease AttemptAcquireCore(int permitCount)
+        {
+            ThrowIfDisposed();
+            return ChainedRateLimiter.AttemptAcquireChained(_limiters, permitCount);
+        }
+
+        protected override async ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+            return await ChainedRateLimiter.AcquireAsyncChained(_limiters, permitCount, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _disposed = true;
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(ChainedReplenishingRateLimiter));
+            }
+        }
+    }
+}

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedReplenishingRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedReplenishingRateLimiter.cs
@@ -59,13 +59,28 @@ namespace System.Threading.RateLimiting
             ThrowIfDisposed();
 
             bool replenished = false;
+            List<Exception>? exceptions = null;
             foreach (ReplenishingRateLimiter limiter in _replenishingLimiters)
             {
-                if (limiter.TryReplenish())
+                try
                 {
-                    replenished = true;
+                    if (limiter.TryReplenish())
+                    {
+                        replenished = true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    exceptions ??= new List<Exception>();
+                    exceptions.Add(ex);
                 }
             }
+
+            if (exceptions is not null)
+            {
+                throw new AggregateException(exceptions);
+            }
+
             return replenished;
         }
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedReplenishingRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedReplenishingRateLimiter.cs
@@ -113,31 +113,7 @@ namespace System.Threading.RateLimiting
 
         protected override void Dispose(bool disposing)
         {
-            if (!disposing)
-            {
-                return;
-            }
-
-            if (_disposed)
-            {
-                return;
-            }
-
             _disposed = true;
-            ChainedRateLimiterShared.DisposeLimiters(_limiters);
-            base.Dispose(disposing);
-        }
-
-        protected override async ValueTask DisposeAsyncCore()
-        {
-            if (_disposed)
-            {
-                return;
-            }
-
-            _disposed = true;
-            await ChainedRateLimiterShared.DisposeLimitersAsync(_limiters).ConfigureAwait(false);
-            await base.DisposeAsyncCore().ConfigureAwait(false);
         }
 
         private void ThrowIfDisposed()

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedReplenishingRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedReplenishingRateLimiter.cs
@@ -87,7 +87,7 @@ namespace System.Threading.RateLimiting
         public override RateLimiterStatistics? GetStatistics()
         {
             ThrowIfDisposed();
-            return ChainedRateLimiter.GetStatisticsCore(_limiters);
+            return ChainedRateLimiterShared.GetStatisticsCore(_limiters);
         }
 
         public override TimeSpan? IdleDuration
@@ -95,20 +95,20 @@ namespace System.Threading.RateLimiting
             get
             {
                 ThrowIfDisposed();
-                return ChainedRateLimiter.GetIdleDurationCore(_limiters);
+                return ChainedRateLimiterShared.GetIdleDurationCore(_limiters);
             }
         }
 
         protected override RateLimitLease AttemptAcquireCore(int permitCount)
         {
             ThrowIfDisposed();
-            return ChainedRateLimiter.AttemptAcquireChained(_limiters, permitCount);
+            return ChainedRateLimiterShared.AttemptAcquireChained(_limiters, permitCount);
         }
 
         protected override async ValueTask<RateLimitLease> AcquireAsyncCore(int permitCount, CancellationToken cancellationToken)
         {
             ThrowIfDisposed();
-            return await ChainedRateLimiter.AcquireAsyncChained(_limiters, permitCount, cancellationToken).ConfigureAwait(false);
+            return await ChainedRateLimiterShared.AcquireAsyncChained(_limiters, permitCount, cancellationToken).ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedReplenishingRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/ChainedReplenishingRateLimiter.cs
@@ -113,7 +113,31 @@ namespace System.Threading.RateLimiting
 
         protected override void Dispose(bool disposing)
         {
+            if (!disposing)
+            {
+                return;
+            }
+
+            if (_disposed)
+            {
+                return;
+            }
+
             _disposed = true;
+            ChainedRateLimiterShared.DisposeLimiters(_limiters);
+            base.Dispose(disposing);
+        }
+
+        protected override async ValueTask DisposeAsyncCore()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            await ChainedRateLimiterShared.DisposeLimitersAsync(_limiters).ConfigureAwait(false);
+            await base.DisposeAsyncCore().ConfigureAwait(false);
         }
 
         private void ThrowIfDisposed()

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
@@ -263,7 +263,7 @@ namespace System.Threading.RateLimiting
                         aggregateExceptions.Add(ex);
                     }
                 }
-                // ChainedRateLimiter is a special case: it may call replenish on its children
+                // ChainedRateLimiter is a special case: it has to invoke replenish on its children
                 else if (rateLimiter.Value.Value is ChainedRateLimiter chainedRateLimiter)
                 {
                     try

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
@@ -263,19 +263,6 @@ namespace System.Threading.RateLimiting
                         aggregateExceptions.Add(ex);
                     }
                 }
-                // ChainedRateLimiter is a special case: it has to invoke replenish on its children
-                else if (rateLimiter.Value.Value is ChainedRateLimiter chainedRateLimiter)
-                {
-                    try
-                    {
-                        chainedRateLimiter.TryReplenish();
-                    }
-                    catch (Exception ex)
-                    {
-                        aggregateExceptions ??= [];
-                        aggregateExceptions.Add(ex);
-                    }
-                }
             }
 
             foreach (RateLimiter limiter in _limitersToDispose)

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/DefaultPartitionedRateLimiter.cs
@@ -259,7 +259,20 @@ namespace System.Threading.RateLimiting
                     }
                     catch (Exception ex)
                     {
-                        aggregateExceptions ??= new List<Exception>();
+                        aggregateExceptions ??= [];
+                        aggregateExceptions.Add(ex);
+                    }
+                }
+                // ChainedRateLimiter is a special case: it may call replenish on its children
+                else if (rateLimiter.Value.Value is ChainedRateLimiter chainedRateLimiter)
+                {
+                    try
+                    {
+                        chainedRateLimiter.TryReplenish();
+                    }
+                    catch (Exception ex)
+                    {
+                        aggregateExceptions ??= [];
                         aggregateExceptions.Add(ex);
                     }
                 }

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/PartitionedRateLimiter.cs
@@ -45,6 +45,10 @@ namespace System.Threading.RateLimiting
         /// <para>
         /// <see cref="RateLimitLease"/>s returned will aggregate metadata and for duplicates use the value of the first lease with the same metadata name.
         /// </para>
+        /// <para>
+        /// Disposing the returned <see cref="PartitionedRateLimiter{TResource}"/> does not dispose the inner <paramref name="limiters"/>.
+        /// Callers are expected to dispose the inner limiters themselves once they are no longer in use.
+        /// </para>
         /// </remarks>
         /// <typeparam name="TResource">The resource type that is being rate limited.</typeparam>
         /// <param name="limiters">The <see cref="PartitionedRateLimiter{TResource}"/>s that will be called in order when acquiring resources.</param>

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimiter.cs
@@ -39,6 +39,14 @@ namespace System.Threading.RateLimiting
                 throw new ArgumentException("Must pass in at least 1 limiter.", nameof(limiters));
             }
 
+            foreach (RateLimiter limiter in limiters)
+            {
+                if (limiter is ReplenishingRateLimiter)
+                {
+                    return new ChainedReplenishingRateLimiter(limiters);
+                }
+            }
+
             return new ChainedRateLimiter(limiters);
         }
 

--- a/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimiter.cs
+++ b/src/libraries/System.Threading.RateLimiting/src/System/Threading/RateLimiting/RateLimiter.cs
@@ -25,6 +25,10 @@ namespace System.Threading.RateLimiting
         /// <para>
         /// <see cref="RateLimitLease"/>s returned will aggregate metadata and for duplicates use the value of the first lease with the same metadata name.
         /// </para>
+        /// <para>
+        /// Disposing the returned <see cref="RateLimiter"/> does not dispose the inner <paramref name="limiters"/>.
+        /// Callers are expected to dispose the inner limiters themselves once they are no longer in use.
+        /// </para>
         /// </remarks>
         /// <param name="limiters">The <see cref="RateLimiter"/>s that will be called in order when acquiring resources.</param>
         /// <returns></returns>

--- a/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
@@ -11,6 +11,188 @@ namespace System.Threading.RateLimiting.Tests
     public class ChainedLimiterTests
     {
         [Fact]
+        public void CreateChainedReturnsRateLimiterWhenNoReplenishingLimiters()
+        {
+            using var limiter1 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+            {
+                PermitLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0
+            });
+            using var limiter2 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+            {
+                PermitLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0
+            });
+
+            using var chainedLimiter = RateLimiter.CreateChained(limiter1, limiter2);
+
+            Assert.False(chainedLimiter is ReplenishingRateLimiter);
+        }
+
+        [Fact]
+        public void CreateChainedReturnsReplenishingRateLimiterWhenAnyReplenishingLimiter()
+        {
+            using var limiter1 = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+            {
+                PermitLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0
+            });
+            using var limiter2 = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+            {
+                TokenLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0,
+                ReplenishmentPeriod = TimeSpan.FromSeconds(1),
+                TokensPerPeriod = 1,
+                AutoReplenishment = false
+            });
+
+            using var chainedLimiter = RateLimiter.CreateChained(limiter1, limiter2);
+
+            Assert.IsAssignableFrom<ReplenishingRateLimiter>(chainedLimiter);
+        }
+
+        [Fact]
+        public void ReplenishingChainedLimiter_IsAutoReplenishingTrue_WhenAllReplenishingAreAutoReplenishing()
+        {
+            using var limiter1 = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+            {
+                TokenLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0,
+                ReplenishmentPeriod = TimeSpan.FromSeconds(1),
+                TokensPerPeriod = 1,
+                AutoReplenishment = true
+            });
+            using var limiter2 = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0,
+                Window = TimeSpan.FromSeconds(2),
+                AutoReplenishment = true
+            });
+
+            using var chainedLimiter = RateLimiter.CreateChained(limiter1, limiter2);
+
+            var replenishing = Assert.IsAssignableFrom<ReplenishingRateLimiter>(chainedLimiter);
+            Assert.True(replenishing.IsAutoReplenishing);
+        }
+
+        [Fact]
+        public void ReplenishingChainedLimiter_IsAutoReplenishingFalse_WhenAnyReplenishingIsNotAutoReplenishing()
+        {
+            using var limiter1 = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+            {
+                TokenLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0,
+                ReplenishmentPeriod = TimeSpan.FromSeconds(1),
+                TokensPerPeriod = 1,
+                AutoReplenishment = true
+            });
+            using var limiter2 = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0,
+                Window = TimeSpan.FromSeconds(2),
+                AutoReplenishment = false
+            });
+
+            using var chainedLimiter = RateLimiter.CreateChained(limiter1, limiter2);
+
+            var replenishing = Assert.IsAssignableFrom<ReplenishingRateLimiter>(chainedLimiter);
+            Assert.False(replenishing.IsAutoReplenishing);
+        }
+
+        [Fact]
+        public void ReplenishingChainedLimiter_ReplenishmentPeriod_IsLowestPositiveValue()
+        {
+            using var limiter1 = new TokenBucketRateLimiter(new TokenBucketRateLimiterOptions
+            {
+                TokenLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0,
+                ReplenishmentPeriod = TimeSpan.FromSeconds(5),
+                TokensPerPeriod = 1,
+                AutoReplenishment = false
+            });
+            using var limiter2 = new FixedWindowRateLimiter(new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0,
+                Window = TimeSpan.FromSeconds(2),
+                AutoReplenishment = false
+            });
+            using var nonReplenishing = new ConcurrencyLimiter(new ConcurrencyLimiterOptions
+            {
+                PermitLimit = 1,
+                QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                QueueLimit = 0
+            });
+
+            using var chainedLimiter = RateLimiter.CreateChained(limiter1, limiter2, nonReplenishing);
+
+            var replenishing = Assert.IsAssignableFrom<ReplenishingRateLimiter>(chainedLimiter);
+            Assert.Equal(TimeSpan.FromSeconds(2), replenishing.ReplenishmentPeriod);
+        }
+
+        [Fact]
+        public void ReplenishingChainedLimiter_TryReplenish_CallsAllReplenishingLimiters()
+        {
+            var replenishingLimiter1 = new CustomizableReplenishingLimiter();
+            bool replenish1Called = false;
+            replenishingLimiter1.TryReplenishImpl = () =>
+            {
+                replenish1Called = true;
+                return true;
+            };
+
+            var replenishingLimiter2 = new CustomizableReplenishingLimiter();
+            bool replenish2Called = false;
+            replenishingLimiter2.TryReplenishImpl = () =>
+            {
+                replenish2Called = true;
+                return false;
+            };
+
+            using var nonReplenishing = new CustomizableLimiter();
+
+            using var chainedLimiter = RateLimiter.CreateChained(replenishingLimiter1, nonReplenishing, replenishingLimiter2);
+
+            var replenishing = Assert.IsAssignableFrom<ReplenishingRateLimiter>(chainedLimiter);
+            bool result = replenishing.TryReplenish();
+
+            Assert.True(replenish1Called);
+            Assert.True(replenish2Called);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ReplenishingChainedLimiter_TryReplenish_ReturnsFalseWhenNoneReplenished()
+        {
+            var replenishingLimiter1 = new CustomizableReplenishingLimiter
+            {
+                TryReplenishImpl = () => false
+            };
+
+            var replenishingLimiter2 = new CustomizableReplenishingLimiter
+            {
+                TryReplenishImpl = () => false
+            };
+
+            using var chainedLimiter = RateLimiter.CreateChained(replenishingLimiter1, replenishingLimiter2);
+
+            var replenishing = Assert.IsAssignableFrom<ReplenishingRateLimiter>(chainedLimiter);
+            Assert.False(replenishing.TryReplenish());
+        }
+
+        [Fact]
         public void ThrowsWhenNoLimitersProvided()
         {
             Assert.Throws<ArgumentException>(() => RateLimiter.CreateChained());

--- a/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
@@ -209,16 +209,27 @@ namespace System.Threading.RateLimiting.Tests
         }
 
         [Fact]
-        public void IdleDurationReturnsLowestValue()
+        public void IdleDurationReturnsNullWhenAnyChildReturnsNull()
         {
-            using var limiter1 = new CustomizableLimiter();
+            using var limiter1 = new CustomizableLimiter { IdleDurationImpl = () => null };
             using var limiter2 = new CustomizableLimiter { IdleDurationImpl = () => TimeSpan.FromMilliseconds(2) };
+            using var limiter3 = new CustomizableLimiter { IdleDurationImpl = () => TimeSpan.FromMilliseconds(3) };
+
+            using var chainedLimiter = RateLimiter.CreateChained(limiter1, limiter2, limiter3);
+            Assert.Null(chainedLimiter.IdleDuration);
+        }
+
+        [Fact]
+        public void IdleDurationReturnsLowestValueWhenAllChildrenAreIdle()
+        {
+            using var limiter1 = new CustomizableLimiter { IdleDurationImpl = () => TimeSpan.FromMilliseconds(2) };
+            using var limiter2 = new CustomizableLimiter { IdleDurationImpl = () => TimeSpan.FromMilliseconds(1) };
             using var limiter3 = new CustomizableLimiter { IdleDurationImpl = () => TimeSpan.FromMilliseconds(3) };
 
             using var chainedLimiter = RateLimiter.CreateChained(limiter1, limiter2, limiter3);
 
             var idleDuration = chainedLimiter.IdleDuration;
-            Assert.Equal(2, idleDuration.Value.TotalMilliseconds);
+            Assert.Equal(1, idleDuration.Value.TotalMilliseconds);
         }
 
         [Fact]
@@ -809,7 +820,7 @@ namespace System.Threading.RateLimiting.Tests
                 QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                 QueueLimit = 0
             });
-            
+
             using var chainedLimiter = RateLimiter.CreateChained(limiter1, limiter2);
 
             var lease = chainedLimiter.AttemptAcquire();

--- a/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/ChainedLimiterTests.cs
@@ -1233,5 +1233,65 @@ namespace System.Threading.RateLimiting.Tests
             Assert.True(lease.TryGetMetadata("3", out obj));
             Assert.IsType<List<int>>(obj);
         }
+
+        [Fact]
+        public void DisposeDoesNotDisposeInnerLimiters()
+        {
+            var limiter1 = new TrackingRateLimiter();
+            var limiter2 = new TrackingRateLimiter();
+            var chainedLimiter = RateLimiter.CreateChained(limiter1, limiter2);
+
+            chainedLimiter.Dispose();
+
+            Assert.Equal(0, limiter1.DisposeCallCount);
+            Assert.Equal(0, limiter2.DisposeCallCount);
+        }
+
+        [Fact]
+        public async Task DisposeAsyncDoesNotDisposeInnerLimiters()
+        {
+            var limiter1 = new TrackingRateLimiter();
+            var limiter2 = new TrackingRateLimiter();
+            var chainedLimiter = RateLimiter.CreateChained(limiter1, limiter2);
+
+            await chainedLimiter.DisposeAsync();
+
+            Assert.Equal(0, limiter1.DisposeCallCount);
+            Assert.Equal(0, limiter1.DisposeAsyncCallCount);
+            Assert.Equal(0, limiter2.DisposeCallCount);
+            Assert.Equal(0, limiter2.DisposeAsyncCallCount);
+        }
+
+        [Fact]
+        public void DisposeDoesNotDisposeInnerReplenishingLimiters()
+        {
+            var limiter1 = new CustomizableReplenishingLimiter { ReplenishmentPeriodImpl = () => TimeSpan.FromSeconds(1) };
+            var limiter2 = new CustomizableReplenishingLimiter { ReplenishmentPeriodImpl = () => TimeSpan.FromSeconds(2) };
+            var chainedLimiter = RateLimiter.CreateChained(limiter1, limiter2);
+
+            Assert.IsAssignableFrom<ReplenishingRateLimiter>(chainedLimiter);
+
+            chainedLimiter.Dispose();
+
+            // Inner limiters should still be usable after chained limiter is disposed
+            Assert.NotNull(limiter1.AttemptAcquire());
+            Assert.NotNull(limiter2.AttemptAcquire());
+        }
+
+        [Fact]
+        public async Task DisposeAsyncDoesNotDisposeInnerReplenishingLimiters()
+        {
+            var limiter1 = new CustomizableReplenishingLimiter { ReplenishmentPeriodImpl = () => TimeSpan.FromSeconds(1) };
+            var limiter2 = new CustomizableReplenishingLimiter { ReplenishmentPeriodImpl = () => TimeSpan.FromSeconds(2) };
+            var chainedLimiter = RateLimiter.CreateChained(limiter1, limiter2);
+
+            Assert.IsAssignableFrom<ReplenishingRateLimiter>(chainedLimiter);
+
+            await chainedLimiter.DisposeAsync();
+
+            // Inner limiters should still be usable after chained limiter is disposed
+            Assert.NotNull(limiter1.AttemptAcquire());
+            Assert.NotNull(limiter2.AttemptAcquire());
+        }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/Infrastructure/Utils.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/Infrastructure/Utils.cs
@@ -203,7 +203,8 @@ namespace System.Threading.RateLimiting.Tests
 
         public override bool IsAutoReplenishing => false;
 
-        public override TimeSpan ReplenishmentPeriod => throw new NotImplementedException();
+        public Func<TimeSpan> ReplenishmentPeriodImpl { get; set; } = () => TimeSpan.Zero;
+        public override TimeSpan ReplenishmentPeriod => ReplenishmentPeriodImpl();
 
         public Func<bool> TryReplenishImpl { get; set; } = () => true;
         public override bool TryReplenish() => TryReplenishImpl();

--- a/src/libraries/System.Threading.RateLimiting/tests/PartitionedChainedLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/PartitionedChainedLimiterTests.cs
@@ -1409,5 +1409,79 @@ namespace System.Threading.RateLimiting.Tests
             Assert.True(lease.TryGetMetadata("3", out obj));
             Assert.IsType<List<int>>(obj);
         }
+
+        [Fact]
+        public void DisposeDoesNotDisposeInnerLimiters()
+        {
+            var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ =>
+                    new ConcurrencyLimiterOptions
+                    {
+                        PermitLimit = 1,
+                        QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                        QueueLimit = 0
+                    });
+            });
+            var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ =>
+                    new ConcurrencyLimiterOptions
+                    {
+                        PermitLimit = 1,
+                        QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                        QueueLimit = 0
+                    });
+            });
+            var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
+
+            chainedLimiter.Dispose();
+
+            // Inner limiters should still be usable after chained limiter is disposed
+            using var lease1 = limiter1.AttemptAcquire("");
+            Assert.True(lease1.IsAcquired);
+            using var lease2 = limiter2.AttemptAcquire("");
+            Assert.True(lease2.IsAcquired);
+
+            limiter1.Dispose();
+            limiter2.Dispose();
+        }
+
+        [Fact]
+        public async Task DisposeAsyncDoesNotDisposeInnerLimiters()
+        {
+            var limiter1 = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ =>
+                    new ConcurrencyLimiterOptions
+                    {
+                        PermitLimit = 1,
+                        QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                        QueueLimit = 0
+                    });
+            });
+            var limiter2 = PartitionedRateLimiter.Create<string, int>(resource =>
+            {
+                return RateLimitPartition.GetConcurrencyLimiter(1, _ =>
+                    new ConcurrencyLimiterOptions
+                    {
+                        PermitLimit = 1,
+                        QueueProcessingOrder = QueueProcessingOrder.NewestFirst,
+                        QueueLimit = 0
+                    });
+            });
+            var chainedLimiter = PartitionedRateLimiter.CreateChained<string>(limiter1, limiter2);
+
+            await chainedLimiter.DisposeAsync();
+
+            // Inner limiters should still be usable after chained limiter is disposed
+            using var lease1 = limiter1.AttemptAcquire("");
+            Assert.True(lease1.IsAcquired);
+            using var lease2 = limiter2.AttemptAcquire("");
+            Assert.True(lease2.IsAcquired);
+
+            await limiter1.DisposeAsync();
+            await limiter2.DisposeAsync();
+        }
     }
 }

--- a/src/libraries/System.Threading.RateLimiting/tests/PartitionedRateLimiterTests.cs
+++ b/src/libraries/System.Threading.RateLimiting/tests/PartitionedRateLimiterTests.cs
@@ -632,6 +632,149 @@ namespace System.Threading.RateLimiting.Tests
             await disposeTcs.Task;
         }
 
+        [Fact]
+        public async Task ChainedLimiter_HeartbeatCallsTryReplenishOnInnerReplenishingLimiters()
+        {
+            var replenishCallCount = 0;
+            CustomizableReplenishingLimiter replenishLimiter = new CustomizableReplenishingLimiter
+            {
+                TryReplenishImpl = () => { replenishCallCount++; return true; }
+            };
+            CustomizableLimiter nonReplenishLimiter = new CustomizableLimiter();
+
+            using var limiter = Utils.CreatePartitionedLimiterWithoutTimer<string, int>(resource =>
+            {
+                return RateLimitPartition.Get(1, _ => RateLimiter.CreateChained(nonReplenishLimiter, replenishLimiter));
+            });
+
+            limiter.AttemptAcquire("");
+
+            await Utils.RunTimerFunc(limiter);
+
+            Assert.Equal(1, replenishCallCount);
+        }
+
+        [Fact]
+        public async Task ChainedLimiter_HeartbeatCallsTryReplenishOnAllInnerReplenishingLimiters()
+        {
+            var replenishCallCount1 = 0;
+            var replenishCallCount2 = 0;
+            CustomizableReplenishingLimiter replenishLimiter1 = new CustomizableReplenishingLimiter
+            {
+                TryReplenishImpl = () => { replenishCallCount1++; return true; }
+            };
+            CustomizableReplenishingLimiter replenishLimiter2 = new CustomizableReplenishingLimiter
+            {
+                TryReplenishImpl = () => { replenishCallCount2++; return true; }
+            };
+
+            using var limiter = Utils.CreatePartitionedLimiterWithoutTimer<string, int>(resource =>
+            {
+                return RateLimitPartition.Get(1, _ => RateLimiter.CreateChained(replenishLimiter1, replenishLimiter2));
+            });
+
+            limiter.AttemptAcquire("");
+
+            await Utils.RunTimerFunc(limiter);
+
+            Assert.Equal(1, replenishCallCount1);
+            Assert.Equal(1, replenishCallCount2);
+        }
+
+        [Fact]
+        public async Task ChainedLimiter_ThrowingTryReplenishStillReplenishesOtherLimiters()
+        {
+            var replenishCallCount = 0;
+            CustomizableReplenishingLimiter throwingLimiter = new CustomizableReplenishingLimiter
+            {
+                TryReplenishImpl = () => throw new Exception("replenish failed")
+            };
+            CustomizableReplenishingLimiter goodLimiter = new CustomizableReplenishingLimiter
+            {
+                TryReplenishImpl = () => { replenishCallCount++; return true; }
+            };
+
+            using var limiter = Utils.CreatePartitionedLimiterWithoutTimer<string, int>(resource =>
+            {
+                return RateLimitPartition.Get(1, _ => RateLimiter.CreateChained(throwingLimiter, goodLimiter));
+            });
+
+            limiter.AttemptAcquire("");
+
+            var ex = await Assert.ThrowsAsync<AggregateException>(() => Utils.RunTimerFunc(limiter));
+            Assert.Single(ex.InnerExceptions);
+            Assert.IsType<AggregateException>(ex.InnerExceptions[0]);
+
+            // The good limiter was still replenished despite the first one throwing
+            Assert.Equal(1, replenishCallCount);
+        }
+
+        [Fact]
+        public async Task ChainedLimiter_IdleChainedLimiterWithNullChildIdleDurationNotEvicted()
+        {
+            var factoryCallCount = 0;
+            CustomizableReplenishingLimiter replenishLimiter = null;
+            CustomizableLimiter idleLimiter = null;
+
+            using var limiter = Utils.CreatePartitionedLimiterWithoutTimer<string, int>(resource =>
+            {
+                return RateLimitPartition.Get(1, _ =>
+                {
+                    factoryCallCount++;
+                    replenishLimiter = new CustomizableReplenishingLimiter();
+                    idleLimiter = new CustomizableLimiter();
+                    return RateLimiter.CreateChained(idleLimiter, replenishLimiter);
+                });
+            });
+
+            limiter.AttemptAcquire("");
+            Assert.Equal(1, factoryCallCount);
+
+            // Idle limiter reports > 10s idle, but replenishing limiter reports null (still active)
+            idleLimiter.IdleDurationImpl = () => TimeSpan.FromMinutes(1);
+            replenishLimiter.IdleDurationImpl = () => null;
+
+            await Utils.RunTimerFunc(limiter);
+
+            // Factory should not have been called again — limiter was not evicted
+            limiter.AttemptAcquire("");
+            Assert.Equal(1, factoryCallCount);
+        }
+
+        [Fact]
+        public async Task ChainedLimiter_FullyIdleChainedLimiterIsEvicted()
+        {
+            var factoryCallCount = 0;
+            CustomizableLimiter innerLimiter1 = null;
+            CustomizableLimiter innerLimiter2 = null;
+
+            using var limiter = Utils.CreatePartitionedLimiterWithoutTimer<string, int>(resource =>
+            {
+                return RateLimitPartition.Get(1, _ =>
+                {
+                    factoryCallCount++;
+                    innerLimiter1 = new CustomizableLimiter();
+                    innerLimiter2 = new CustomizableLimiter();
+                    return RateLimiter.CreateChained(innerLimiter1, innerLimiter2);
+                });
+            });
+
+            limiter.AttemptAcquire("");
+            Assert.Equal(1, factoryCallCount);
+
+            // Both children report idle > 10s, chain should be evicted
+            innerLimiter1.IdleDurationImpl = () => TimeSpan.FromMinutes(1);
+            innerLimiter2.IdleDurationImpl = () => TimeSpan.FromMinutes(1);
+            innerLimiter1.DisposeAsyncCoreImpl = () => default;
+            innerLimiter2.DisposeAsyncCoreImpl = () => default;
+
+            await Utils.RunTimerFunc(limiter);
+
+            // Factory should be called again on next acquire — limiter was evicted and recreated
+            limiter.AttemptAcquire("");
+            Assert.Equal(2, factoryCallCount);
+        }
+
         // Translate
 
         [Fact]


### PR DESCRIPTION
1. Fixed `ChainedRateLimiter.IdleDuration`. In the current PR if it detects any of chained child rateLimiters having `null` IdleDuration, it will return null now. `IdleDuration` equalling `now` means rateLimiter is in use or is not ready to be idle.

2. `DefaultPartitionedRateLimiter` does not replenish the children rateLimiters of `ChainedRateLimiter`. Now there are 2 implementations of chained limiter depending on the passed limiters to `RateLimiter.CreateChained(...)`

Related #68776
Fixes #125560