### PR TITLE
Use libunwind's unw_get_proc_info_in_range on macOS

### DIFF
--- a/src/coreclr/pal/src/exception/remote-unwind.cpp
+++ b/src/coreclr/pal/src/exception/remote-unwind.cpp
@@ -2202,9 +2202,9 @@ find_proc_info(unw_addr_space_t as, unw_word_t ip, unw_proc_info_t *pip, int nee
         }
     }
 
-#if HAVE_GET_PROC_INFO_IN_RANGE || !defined(HOST_UNIX)
+#if HAVE_GET_PROC_INFO_IN_RANGE || defined(__APPLE__) || !defined(HOST_UNIX)
     return unw_get_proc_info_in_range(start_ip, end_ip, ehFrameHdrAddr, ehFrameHdrLen, exidxFrameHdrAddr, exidxFrameHdrLen, as, ip, pip, need_unwind_info, arg);
-#else // HAVE_GET_PROC_INFO_IN_RANGE || !defined(HOST_UNIX)
+#else // HAVE_GET_PROC_INFO_IN_RANGE || defined(__APPLE__) || !defined(HOST_UNIX)
 
     // This branch is executed when using llvm-libunwind (macOS and similar platforms)
     // or HP-libunwind version 1.6 and earlier.


### PR DESCRIPTION
On macOS, we use the system-provided libunwind, which is effectively llvm-libunwind (with possible Apple-specific patches). This library does not expose remote unwind -specific APIs such as `unw_get_proc_info_in_range()`.

However, for remote unwinding we rely on HP libunwind on macOS, and it’s used only by the cross-OS/arch `createdump` utility, which handles .NET crash dumps from any target/host OS combination. CMake’s feature introspection gets confused here because it reports capabilities from the OS libunwind used by the rest of CoreCLR rather than from the HP libunwind used in this path.

In this context we rely on explicit `__APPLE__` checks because the CMake-detected capabilities don’t match the library this code actually uses. This was originally missed in https://github.com/dotnet/runtime/pull/108250. Both implementations behave the same, and we’ll be able to drop the fallback once RHEL 9 (with HP libunwind 1.8) becomes the minimum baseline which is still years out.