### PR TITLE
Fix UnobservedTaskException in TaskToAsyncResult when APM callback skips EndXxx

### DIFF
--- a/src/libraries/Common/src/System/Threading/Tasks/TaskToAsyncResult.cs
+++ b/src/libraries/Common/src/System/Threading/Tasks/TaskToAsyncResult.cs
@@ -128,6 +128,10 @@ namespace System.Threading.Tasks
                     // The task has already completed.  Treat this as synchronous completion.
                     // Invoke the callback; no need to store it.
                     CompletedSynchronously = true;
+                    // Observe any fault so that UnobservedTaskException is not raised if End
+                    // is never called. In the APM pattern exceptions are propagated via End;
+                    // End will still rethrow the exception if called.
+                    _ = task.Exception;
                     callback?.Invoke(this);
                 }
                 else if (callback is not null)
@@ -138,7 +142,14 @@ namespace System.Threading.Tasks
                     _callback = callback;
                     _task.ConfigureAwait(continueOnCapturedContext: false)
                          .GetAwaiter()
-                         .OnCompleted(() => _callback.Invoke(this));
+                         .OnCompleted(() =>
+                         {
+                             // Observe any fault so that UnobservedTaskException is not raised if End
+                             // is never called. In the APM pattern exceptions are propagated via End;
+                             // End will still rethrow the exception if called.
+                             _ = _task.Exception;
+                             _callback.Invoke(this);
+                         });
                 }
             }
 

--- a/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/TaskToAsyncResultTests.cs
+++ b/src/libraries/System.Runtime/tests/System.Threading.Tasks.Tests/TaskToAsyncResultTests.cs
@@ -152,6 +152,75 @@ namespace System.Threading.Tasks.Tests
             tcs.SetResult();
             await invoked.Task;
         }
+
+        [Fact]
+        public async Task FaultedTask_CallbackDoesNotCallEnd_NoUnobservedTaskException_Async()
+        {
+            // Regression test: if the APM callback does not call End, a faulted task must not
+            // surface via TaskScheduler.UnobservedTaskException.  In the APM pattern, exceptions
+            // are only propagated through End; skipping End (e.g. during shutdown) must be silent.
+            bool unobservedFired = false;
+            EventHandler<UnobservedTaskExceptionEventArgs> handler = (s, e) => unobservedFired = true;
+            TaskScheduler.UnobservedTaskException += handler;
+            try
+            {
+                var tcs = new TaskCompletionSource<int>();
+
+                // Callback intentionally does not call End.
+                WeakReference weakRef = await Task.Run(() =>
+                {
+                    IAsyncResult ar = TaskToAsyncResult.Begin(tcs.Task, _ => { /* no End */ }, null);
+                    tcs.SetException(new InvalidOperationException("test fault"));
+                    return new WeakReference(ar);
+                });
+
+                // Allow the callback continuation to complete, then drop all references.
+                await Task.Delay(100);
+
+                for (int i = 0; i < 5 && weakRef.IsAlive; i++)
+                {
+                    GC.Collect();
+                    GC.WaitForPendingFinalizers();
+                    GC.Collect();
+                    await Task.Delay(100);
+                }
+
+                Assert.False(unobservedFired, "UnobservedTaskException should not fire when End is not called in APM callback");
+            }
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= handler;
+            }
+        }
+
+        [Fact]
+        public void FaultedTask_AlreadyCompleted_CallbackDoesNotCallEnd_NoUnobservedTaskException_Sync()
+        {
+            // Same regression but for the synchronous-completion path (task already faulted
+            // when Begin is called, callback fires inline).
+            bool unobservedFired = false;
+            EventHandler<UnobservedTaskExceptionEventArgs> handler = (s, e) => unobservedFired = true;
+            TaskScheduler.UnobservedTaskException += handler;
+            try
+            {
+                Task<int> faulted = Task.FromException<int>(new InvalidOperationException("test fault"));
+
+                // Callback intentionally does not call End.
+                IAsyncResult ar = TaskToAsyncResult.Begin(faulted, _ => { /* no End */ }, null);
+                Assert.True(ar.CompletedSynchronously);
+
+                ar = null;
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+
+                Assert.False(unobservedFired, "UnobservedTaskException should not fire when End is not called in APM callback");
+            }
+            finally
+            {
+                TaskScheduler.UnobservedTaskException -= handler;
+            }
+        }
     }
 
     internal sealed class NonTaskIAsyncResult : IAsyncResult


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                
  On .NET 6+, `NetworkStream.BeginRead` (and any APM operation backed by `TaskToAsyncResult`) can
  fire `TaskScheduler.UnobservedTaskException` when:
  1. The socket/stream is disposed while a read is pending (causing `SocketException(995)`), **and**
  2. The `BeginRead` callback does not call `EndRead` — a valid shutdown pattern where the callback
     checks a "stopping" flag and returns early.

  This is a regression from .NET Framework 4.8, where `BeginRead` used the native APM/OverlappedAsyncResult
  path with no Task wrapper involved.

  **Root cause**: `Socket.BeginReceive` wraps `ReceiveAsync(...).AsTask()` in a `TaskAsyncResult` via
  `TaskToAsyncResult.Begin`. When the socket is disposed, the inner Task faults. If the callback never
  calls `End`, `task.Exception` is never accessed, so the exception is unobserved. On GC, the faulted
  Task finalizer raises `UnobservedTaskException`.

  **Fix**: In `TaskAsyncResult`, access `task.Exception` (which calls `MarkExceptionObserved()` internally)
  before invoking the callback, in both the synchronous-completion and async-continuation paths. `End` still
  re-throws the exception correctly if called — observing does not suppress.

  This is the same pattern used in #114226 for `ResettableValueTaskSource` in QUIC.

  ## Changes

  - **`TaskToAsyncResult.cs`**: Observe `task.Exception` before invoking the callback in both paths.
  - **`TaskToAsyncResultTests.cs`**: Two regression tests covering async and sync completion paths.

  Fixes #126148
  Reference: #114226