### PR TITLE
[RyuJit] Coalesce adjacent no-GC regions on x86

### DIFF
--- a/src/coreclr/jit/gcencode.cpp
+++ b/src/coreclr/jit/gcencode.cpp
@@ -2124,21 +2124,35 @@ unsigned PendingArgsStack::pasEnumGCoffs(unsigned iter, unsigned* offs)
 // when reporting interruptible ranges.
 class NoGCRegionEncoder
 {
-    BYTE* dest;
+    BYTE*    dest;
+    unsigned lastSize    = 0;
+    unsigned lastEndOffs = -1;
 public:
-    size_t totalSize;
+    size_t totalSize = 0;
 
     NoGCRegionEncoder(BYTE* dest)
         : dest(dest)
-        , totalSize(0)
     {
     }
 
     // This callback is called for each insGroup marked with IGF_NOGCINTERRUPT.
     bool operator()(unsigned igFuncIdx, unsigned igOffs, unsigned igSize, unsigned firstInstrSize, bool isInProlog)
     {
-        totalSize += encodeUnsigned(dest == NULL ? NULL : dest + totalSize, igOffs);
-        totalSize += encodeUnsigned(dest == NULL ? NULL : dest + totalSize, igSize);
+        unsigned size;
+        if (igOffs == lastEndOffs) // Coalesce adjacent intervals by re-encoding the enlarged size.
+        {
+            totalSize -= encodeUnsigned(nullptr, lastSize);
+            size = lastSize + igSize;
+        }
+        else
+        {
+            totalSize += encodeUnsigned(dest == nullptr ? nullptr : dest + totalSize, igOffs);
+            size = igSize;
+        }
+        totalSize += encodeUnsigned(dest == nullptr ? nullptr : dest + totalSize, size);
+
+        lastSize    = size;
+        lastEndOffs = igOffs + igSize;
         return true;
     }
 };

--- a/src/coreclr/jit/gcinfo.cpp
+++ b/src/coreclr/jit/gcinfo.cpp
@@ -416,6 +416,7 @@ GCInfo::regPtrDsc* GCInfo::gcRegPtrAllocDsc()
 struct NoGCRegionCounter
 {
     unsigned noGCRegionCount;
+    unsigned lastEndOffs = -1;
 
     NoGCRegionCounter()
         : noGCRegionCount(0)
@@ -425,7 +426,11 @@ struct NoGCRegionCounter
     // This callback is called for each insGroup marked with IGF_NOGCINTERRUPT.
     bool operator()(unsigned igFuncIdx, unsigned igOffs, unsigned igSize, unsigned firstInstrSize, bool isInProlog)
     {
-        noGCRegionCount++;
+        if (lastEndOffs != igOffs)
+        {
+            noGCRegionCount++;
+        }
+        lastEndOffs = igOffs + igSize;
         return true;
     }
 };


### PR DESCRIPTION
This is a small GCInfo size reduction (~0.1%).

However, the main benefit is that this removes diffs from being introduced by `IGF_EXTEND` IGs, which are supposed to be 'transparent'.

Q: should this be done in `emitGenNoGCLst`?
A: probably not since the method has contracts related to various code region 'kinds'. We can only coalesce across regions of the same 'kind', which would be more complicated than this change and not as general.