### PR TITLE
Clarify MatchCasing does not affect directory path resolution

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/IO/EnumerationOptions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/EnumerationOptions.cs
@@ -73,7 +73,7 @@ namespace System.IO
         /// The default is simple matching where '*' is always 0 or more characters and '?' is a single character.</remarks>
         public MatchType MatchType { get; set; }
 
-	/// <summary>
+	    /// <summary>
         /// Gets or sets the case matching behavior for file name pattern matching.
         /// </summary>
         /// <remarks>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/EnumerationOptions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/EnumerationOptions.cs
@@ -73,7 +73,7 @@ namespace System.IO
         /// The default is simple matching where '*' is always 0 or more characters and '?' is a single character.</remarks>
         public MatchType MatchType { get; set; }
 
-	    /// <summary>
+        /// <summary>
         /// Gets or sets the case matching behavior for file name pattern matching.
         /// </summary>
         /// <remarks>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/EnumerationOptions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/EnumerationOptions.cs
@@ -73,10 +73,15 @@ namespace System.IO
         /// The default is simple matching where '*' is always 0 or more characters and '?' is a single character.</remarks>
         public MatchType MatchType { get; set; }
 
-        /// <summary>Gets or sets the case matching behavior.</summary>
-        /// <value>One of the enumeration values that indicates the case matching behavior.</value>
-        /// <remarks>For APIs that allow specifying a match expression, this property allows you to specify the case matching behavior.
-        /// The default is to match platform defaults, which are gleaned from the case sensitivity of the temporary folder.</remarks>
+	/// <summary>
+        /// Gets or sets the case matching behavior for file name pattern matching.
+        /// </summary>
+        /// <remarks>
+        /// This property affects only how file names are matched against the search pattern.
+        /// It does not affect directory path resolution. On case-sensitive file systems
+        /// (such as Linux and macOS), directory paths must match the exact casing regardless of this setting.
+        /// The default is to match the platform defaults.
+        /// </remarks>
         public MatchCasing MatchCasing { get; set; }
 
         /// <summary>Gets or sets a value that indicates the maximum directory depth to recurse while enumerating, when <see cref="RecurseSubdirectories" /> is set to <see langword="true" />.</summary>

--- a/src/libraries/System.Private.CoreLib/src/System/IO/EnumerationOptions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/EnumerationOptions.cs
@@ -74,11 +74,11 @@ namespace System.IO
         public MatchType MatchType { get; set; }
 
         /// <summary>
-        /// Gets or sets the case matching behavior for file name pattern matching.
+        /// Gets or sets the case matching behavior for entry (file and directory) name matching against the search pattern.
         /// </summary>
         /// <remarks>
-        /// This property affects only how file names are matched against the search pattern.
-        /// It does not affect directory path resolution. On case-sensitive file systems
+        /// This property affects only how entry names (file and directory names) are matched against the search pattern during enumeration.
+        /// It does not affect directory path resolution or traversal. On case-sensitive file systems
         /// (common on Linux or when using a case-sensitive volume), directory paths must match the exact casing
         /// regardless of this setting; on case-insensitive file systems, path resolution follows the behavior
         /// of the underlying file system. The default is to match the platform defaults.

--- a/src/libraries/System.Private.CoreLib/src/System/IO/EnumerationOptions.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/IO/EnumerationOptions.cs
@@ -79,8 +79,9 @@ namespace System.IO
         /// <remarks>
         /// This property affects only how file names are matched against the search pattern.
         /// It does not affect directory path resolution. On case-sensitive file systems
-        /// (such as Linux and macOS), directory paths must match the exact casing regardless of this setting.
-        /// The default is to match the platform defaults.
+        /// (common on Linux or when using a case-sensitive volume), directory paths must match the exact casing
+        /// regardless of this setting; on case-insensitive file systems, path resolution follows the behavior
+        /// of the underlying file system. The default is to match the platform defaults.
         /// </remarks>
         public MatchCasing MatchCasing { get; set; }
 


### PR DESCRIPTION
Closes #115356

## Summary

This PR clarifies that `EnumerationOptions.MatchCasing` applies only to file name pattern matching and does **not** affect directory path resolution.

On case-sensitive file systems (e.g., Linux and macOS), directory paths must match the exact casing even if `MatchCasing = CaseInsensitive`.

## Motivation

Users may assume that `MatchCasing` affects the full path when performing searches. In reality, it only applies to **file name pattern matching**, which can be misleading on case-sensitive systems. This update improves documentation to reduce confusion.

## Changes

- Updated XML doc comment in `EnumerationOptions.cs` (runtime repo)
- Updated API XML (`EnumerationOptions.xml`) with `<remarks>` clarifying:
  - Scope is limited to file name matching
  - Directory paths are unaffected
  - Default behavior is platform-dependent
- Optional example included in API XML to illustrate Linux behavior

## Example (API docs)

```csharp
Directory.GetFiles("/tmp/data", "*.TXT",
    new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive });