### PR TITLE
Cleanup null check in Generic.SortedDictionary

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
@@ -69,14 +69,7 @@ namespace System.Collections.Generic
                 return false;
             }
 
-            if (keyValuePair.Value == null)
-            {
-                return node.Item.Value == null;
-            }
-            else
-            {
-                return EqualityComparer<TValue>.Default.Equals(node.Item.Value, keyValuePair.Value);
-            }
+            return EqualityComparer<TValue>.Default.Equals(node.Item.Value, keyValuePair.Value);
         }
 
         bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair)


### PR DESCRIPTION
**`Contains` method:** Removed the redundant `if (keyValuePair.Value == null)` branch. `EqualityComparer<TValue>.Default.Equals` safely and optimally handles both reference and value types, resolving the warning without behavior changes.

Found by Linux Verification Center (linuxtesting.org) with SVACE.