### PR TITLE
Remove unnecessary null check in SortedSetEqualityComparer.cs

### DIFF
--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedDictionary.cs
@@ -69,14 +69,7 @@ namespace System.Collections.Generic
                 return false;
             }
 
-            if (keyValuePair.Value == null)
-            {
-                return node.Item.Value == null;
-            }
-            else
-            {
-                return EqualityComparer<TValue>.Default.Equals(node.Item.Value, keyValuePair.Value);
-            }
+            return EqualityComparer<TValue>.Default.Equals(node.Item.Value, keyValuePair.Value);
         }
 
         bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair)

--- a/src/libraries/System.Collections/src/System/Collections/Generic/SortedSetEqualityComparer.cs
+++ b/src/libraries/System.Collections/src/System/Collections/Generic/SortedSetEqualityComparer.cs
@@ -38,10 +38,7 @@ namespace System.Collections.Generic
             {
                 foreach (T t in obj)
                 {
-                    if (t != null)
-                    {
-                        hashCode ^= (_memberEqualityComparer.GetHashCode(t) & 0x7FFFFFFF);
-                    }
+                    hashCode ^= (_memberEqualityComparer.GetHashCode(t) & 0x7FFFFFFF);
                 }
             }
             // Returns 0 for null sets.


### PR DESCRIPTION
Removed a redundant `t != null` check in `SortedSetEqualityComparer.GetHashCode`. Standard implementations of `IEqualityComparer<T>` already handle null values safely, making this check unnecessary for value types.

Found by Linux Verification Center (linuxtesting.org) with SVACE.