### PR TITLE
NRBF test fix: we need optimized library

### DIFF
--- a/src/libraries/System.Formats.Nrbf/tests/EdgeCaseTests.cs
+++ b/src/libraries/System.Formats.Nrbf/tests/EdgeCaseTests.cs
@@ -65,7 +65,9 @@ public class EdgeCaseTests : ReadTests
     [InlineData(100)]
     [InlineData(64_001)]
     [InlineData(127_000)]
+#if RELEASE // We need the library to be optimized to be able to handle such a big array in a reasonable time.
     [InlineData(2147483591)] // Array.MaxLength
+#endif
     public void CanReadArrayOfAnySize(int length)
     {
         if (length == 2147483591 && (!PlatformDetection.Is64BitProcess || !PlatformDetection.IsReleaseRuntime || !PlatformDetection.IsNetCore))


### PR DESCRIPTION
Our most recent try to fix the flaky test was incomplete: https://github.com/dotnet/runtime/pull/126006

I was able to reproduce it:

<img width="2407" height="376" alt="{1DE44AAC-E19B-483C-88E9-9EE0F6742B32}" src="https://github.com/user-attachments/assets/08416082-673d-45ce-92e8-26fe643a3968" />

And fix:

<img width="1870" height="265" alt="{B4CADD47-0D45-47DC-8220-BAA26CB309D8}" src="https://github.com/user-attachments/assets/2976acc6-d4cb-4df4-9d52-e3370ac670a5" />

This should help to solve the problem, as we are now going to require not just a RELEASE runtime but also the library itself.

fixes https://github.com/dotnet/runtime/issues/125994