### PR TITLE
Restore PE validation for NativeAOT ILC inputs

### DIFF
--- a/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
+++ b/src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets
@@ -6,7 +6,17 @@
           DependsOnTargets="$(IlcDynamicBuildPropertyDependencies);_ComputeAssembliesToCompileToNative;_PrepareTrimConfiguration">
 
     <ItemGroup>
-      <_IlcManagedInputAssemblies Include="@(ResolvedFileToPublish)" Condition="'%(ResolvedFileToPublish.PostprocessAssembly)' == 'true'" />
+      <_ValidatedIlcManagedAssemblies Include="@(_ManagedResolvedAssembliesToPublish)" />
+      <_ValidatedIlcManagedAssemblies Include="@(DefaultFrameworkAssemblies)" />
+    </ItemGroup>
+
+    <!-- Reattach the final ResolvedFileToPublish metadata to the PE-validated managed set so
+         trim-mode handling and publish-file removal operate on the same item shape the SDK uses. -->
+    <JoinItems Left="@(_ValidatedIlcManagedAssemblies)" Right="@(ResolvedFileToPublish->WithMetadataValue('PostprocessAssembly', 'true'))" RightMetadata="*">
+      <Output TaskParameter="JoinResult" ItemName="_IlcManagedInputAssemblies" />
+    </JoinItems>
+
+    <ItemGroup>
       <IlcReference Include="@(_IlcManagedInputAssemblies)" />
       <IlcSatelliteAssembly Include="@(_SatelliteAssembliesToPublish)" />
       <IlcSatelliteAssembly Include="@(IntermediateSatelliteAssembliesWithTargetPath)" />
@@ -107,6 +117,7 @@
       SdkAssemblies="@(PrivateSdkAssemblies)"
       FrameworkAssemblies="@(FrameworkAssemblies)">
 
+      <Output TaskParameter="ManagedAssemblies" ItemName="_ManagedResolvedAssembliesToPublish" />
       <Output TaskParameter="SatelliteAssemblies" ItemName="_SatelliteAssembliesToPublish" />
       <Output TaskParameter="RuntimePackFilesToSkipPublish" ItemName="_RuntimePackFilesToSkipPublish" />
     </ComputeManagedAssembliesToCompileToNative>

--- a/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Build.Tasks/ComputeManagedAssembliesToCompileToNative.cs
@@ -10,8 +10,6 @@ using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 
-
-
 namespace Build.Tasks
 {
     public class ComputeManagedAssembliesToCompileToNative : Task
@@ -81,6 +79,13 @@ namespace Build.Tasks
             set;
         }
 
+        [Output]
+        public ITaskItem[] ManagedAssemblies
+        {
+            get;
+            set;
+        }
+
         /// <summary>
         /// CoreCLR runtime pack files (apphost, native assets, managed assemblies replaced by NativeAOT equivalents)
         /// that should be removed from the publish output and replaced with NativeAOT runtime pack assemblies.
@@ -94,6 +99,7 @@ namespace Build.Tasks
 
         public override bool Execute()
         {
+            var managedAssemblies = new List<ITaskItem>();
             var runtimePackFilesToSkipPublish = new List<ITaskItem>();
             var satelliteAssemblies = new List<ITaskItem>();
             var nativeAotFrameworkAssembliesToUse = new Dictionary<string, ITaskItem>();
@@ -141,23 +147,23 @@ namespace Build.Tasks
                 {
                     // If the assembly is part of the Microsoft.NETCore.App.Runtime runtime pack, we want to swap it with the corresponding package from the NativeAOT SDK.
                     // Otherwise we want to use the assembly the user has referenced.
-                    if (!isFromRuntimePack)
+                    if (isFromRuntimePack)
                     {
-                        // The assembly was overridden by an OOB package through standard .NET SDK conflict resolution.
-                        // Don't swap to the NativeAOT version; the user's version stays in
-                        // ResolvedFileToPublish and will be picked up as an ILC input via
-                        // its PostprocessAssembly=true metadata.
+                        if (assemblyFileName == "System.Private.CoreLib.dll" && GetFileVersion(itemSpec).CompareTo(GetFileVersion(frameworkItem.ItemSpec)) > 0)
+                        {
+                            // Validate that we aren't trying to use an older NativeAOT package against a newer non-NativeAOT runtime pack.
+                            // That's not supported.
+                            Log.LogError($"Overriding System.Private.CoreLib.dll with a newer version is not supported. Attempted to use {itemSpec} instead of {frameworkItem.ItemSpec}.");
+                        }
+
+                        runtimePackFilesToSkipPublish.Add(taskItem);
                         continue;
                     }
-                    else if (assemblyFileName == "System.Private.CoreLib.dll" && GetFileVersion(itemSpec).CompareTo(GetFileVersion(frameworkItem.ItemSpec)) > 0)
-                    {
-                        // Validate that we aren't trying to use an older NativeAOT package against a newer non-NativeAOT runtime pack.
-                        // That's not supported.
-                        Log.LogError($"Overriding System.Private.CoreLib.dll with a newer version is not supported. Attempted to use {itemSpec} instead of {frameworkItem.ItemSpec}.");
-                    }
 
-                    runtimePackFilesToSkipPublish.Add(taskItem);
-                    continue;
+                    // The assembly was overridden by an OOB package through standard .NET SDK conflict resolution.
+                    // Don't swap to the NativeAOT version; the user's version stays in
+                    // ResolvedFileToPublish and should continue through managed assembly
+                    // classification below.
                 }
 
                 // Only classify files that the SDK has identified as managed runtime assemblies.
@@ -170,31 +176,19 @@ namespace Build.Tasks
 
                 // Check if this is a satellite assembly by reading its culture metadata.
                 // Non-managed files are silently skipped as a safety measure.
-                try
+                if (ManagedAssemblyUtilities.TryGetAssemblyCulture(itemSpec, out string culture)
+                    && (culture == "" || culture.Equals("neutral", StringComparison.OrdinalIgnoreCase)))
                 {
-                    using (FileStream moduleStream = File.OpenRead(itemSpec))
-                    using (var module = new PEReader(moduleStream))
-                    {
-                        if (module.HasMetadata)
-                        {
-                            MetadataReader moduleMetadataReader = module.GetMetadataReader();
-                            if (moduleMetadataReader.IsAssembly)
-                            {
-                                string culture = moduleMetadataReader.GetString(moduleMetadataReader.GetAssemblyDefinition().Culture);
-
-                                if (culture != "" && !culture.Equals("neutral", StringComparison.OrdinalIgnoreCase))
-                                {
-                                    satelliteAssemblies.Add(taskItem);
-                                }
-                            }
-                        }
-                    }
+                    managedAssemblies.Add(taskItem);
                 }
-                catch (BadImageFormatException)
+                else if (culture != ""
+                    && !culture.Equals("neutral", StringComparison.OrdinalIgnoreCase))
                 {
+                    satelliteAssemblies.Add(taskItem);
                 }
             }
 
+            ManagedAssemblies = managedAssemblies.ToArray();
             RuntimePackFilesToSkipPublish = runtimePackFilesToSkipPublish.ToArray();
             SatelliteAssemblies = satelliteAssemblies.ToArray();
 
@@ -204,6 +198,40 @@ namespace Build.Tasks
             {
                 var versionInfo = FileVersionInfo.GetVersionInfo(path);
                 return new Version(versionInfo.FileMajorPart, versionInfo.FileMinorPart, versionInfo.FileBuildPart, versionInfo.FilePrivatePart);
+            }
+        }
+    }
+
+    internal static class ManagedAssemblyUtilities
+    {
+        public static bool TryGetAssemblyCulture(string filePath, out string culture)
+        {
+            try
+            {
+                using (FileStream moduleStream = File.OpenRead(filePath))
+                using (var module = new PEReader(moduleStream))
+                {
+                    if (!module.HasMetadata)
+                    {
+                        culture = string.Empty;
+                        return false;
+                    }
+
+                    MetadataReader moduleMetadataReader = module.GetMetadataReader();
+                    if (!moduleMetadataReader.IsAssembly)
+                    {
+                        culture = string.Empty;
+                        return false;
+                    }
+
+                    culture = moduleMetadataReader.GetString(moduleMetadataReader.GetAssemblyDefinition().Culture);
+                    return true;
+                }
+            }
+            catch (BadImageFormatException)
+            {
+                culture = string.Empty;
+                return false;
             }
         }
     }

--- a/src/tests/FunctionalTests/Android/Device_Emulator/NativeAOT/Android.Device_Emulator.NativeAOT.Test.csproj
+++ b/src/tests/FunctionalTests/Android/Device_Emulator/NativeAOT/Android.Device_Emulator.NativeAOT.Test.csproj
@@ -14,4 +14,26 @@
     <Compile Include="Program.cs" />
   </ItemGroup>
 
+  <Target Name="InjectBogusIlcReference"
+          BeforeTargets="_ComputeAssembliesToCompileToNative">
+    <PropertyGroup>
+      <_BogusIlcReferencePath>$(IntermediateOutputPath)BogusReference.dll</_BogusIlcReferencePath>
+    </PropertyGroup>
+
+    <MakeDir Directories="$(IntermediateOutputPath)" />
+    <!-- Generate a text file with a .dll extension so the regression still proves PE validation matters. -->
+    <WriteLinesToFile File="$(_BogusIlcReferencePath)"
+                      Lines="This is not a PE file."
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
+
+    <ItemGroup>
+      <ResolvedFileToPublish Include="$(_BogusIlcReferencePath)">
+        <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+        <PostprocessAssembly>true</PostprocessAssembly>
+        <RelativePath>BogusReference.dll</RelativePath>
+      </ResolvedFileToPublish>
+    </ItemGroup>
+  </Target>
+
 </Project>


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

## Summary
- restore NativeAOT `IlcReference` inputs from the existing PE-validated managed-assembly classification pass instead of raw `ResolvedFileToPublish` items
- reattach final publish metadata with `JoinItems` so downstream publish logic still sees the SDK-shaped items
- make the Android regression test generate its fake `.dll` during MSBuild instead of tracking a `.dll`-named file in the repo

Fixes #126117

## Testing
- `./build.cmd clr+libs+host`
- `./build.cmd clr.aot+libs -lc Release`
- `./dotnet.cmd msbuild src/tests/FunctionalTests/Android/Device_Emulator/NativeAOT/Android.Device_Emulator.NativeAOT.Test.csproj /t:InjectBogusIlcReference /p:targetos=android /p:targetarchitecture=x64 /p:RuntimeIdentifier=android-x64 /nologo -getItem:ResolvedFileToPublish`
- temporary direct MSBuild harness against `src/coreclr/nativeaot/BuildIntegration/Microsoft.NETCore.Native.Publish.targets`

## Notes
- Full local Android functional-test execution is still blocked in this Windows enlistment because the in-tree Android runtime pack was not built, so CI is needed for end-to-end validation.