### PR TITLE
Require RemoteExecutorSupported on color env test

### DIFF
--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -445,7 +445,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             }, new RemoteInvokeOptions { StartInfo = new ProcessStartInfo() { RedirectStandardOutput = true } }).Dispose();
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
+        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingAndRemoteExecutorSupported))]
         [InlineData("FORCE_COLOR", "1", null, null, true)]
         [InlineData("DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION", "1", null, null, true)]
         [InlineData(null, null, "NO_COLOR", "1", false)]

--- a/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
+++ b/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs
@@ -445,7 +445,7 @@ namespace Microsoft.Extensions.Logging.Console.Test
             }, new RemoteInvokeOptions { StartInfo = new ProcessStartInfo() { RedirectStandardOutput = true } }).Dispose();
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsThreadingAndRemoteExecutorSupported))]
+        [ConditionalTheory(typeof(ConsoleLoggerTest), nameof(IsThreadingAndRemoteExecutorSupported))]
         [InlineData("FORCE_COLOR", "1", null, null, true)]
         [InlineData("DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION", "1", null, null, true)]
         [InlineData(null, null, "NO_COLOR", "1", false)]


### PR DESCRIPTION
It was failing on NativeAOT legs:

```
[SKIP] Microsoft.Extensions.Logging.Console.Test.ConsoleLoggerTest.AddConsole_IsOutputRedirected_ColorDisabled
[FAIL] Microsoft.Extensions.Logging.Console.Test.ConsoleLoggerTest.DoesConsoleSupportAnsi_RespectsColorEnvVars(envVarName1: "FORCE_COLOR", envVarValue1: "1", envVarName2: null, envVarValue2: null, expectAnsiEscapes: True)
System.PlatformNotSupportedException : RemoteExecutor is not supported on this platform.
   at Microsoft.DotNet.RemoteExecutor.RemoteExecutor.Invoke(MethodInfo method, String[] args, RemoteInvokeOptions options, Boolean pasteArguments) in /_/src/arcade/src/Microsoft.DotNet.RemoteExecutor/src/RemoteExecutor.cs:line 415
   at Microsoft.Extensions.Logging.Console.Test.ConsoleLoggerTest.DoesConsoleSupportAnsi_RespectsColorEnvVars(String envVarName1, String envVarValue1, String envVarName2, String envVarValue2, Boolean expectAnsiEscapes) in /_/src/libraries/Microsoft.Extensions.Logging.Console/tests/Microsoft.Extensions.Logging.Console.Tests/ConsoleLoggerTest.cs:line 468
   at System.Reflection.DynamicInvokeInfo.InvokeWithManyArguments(IntPtr, Byte&, Byte&, Object[], BinderBundle, Boolean) in /_/src/coreclr/nativeaot/System.Private.CoreLib/src/System/Reflection/DynamicInvokeInfo.cs:line 426
[FAIL] Microsoft.Extensions.Logging.Console.Test.ConsoleLoggerTest.DoesConsoleSupportAnsi_RespectsColorEnvVars(envVarName1: "DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION", envVarValue1: "1", envVarName2: null, envVarValue2: null, expectAnsiEscapes: True)
System.PlatformNotSupportedException : RemoteExecutor is not supported on this platform.
```