### PR TITLE
Fix Handle Leak

### DIFF
--- a/src/coreclr/tools/Common/Microsoft/SourceLink/Tools/SourceLinkMap.cs
+++ b/src/coreclr/tools/Common/Microsoft/SourceLink/Tools/SourceLinkMap.cs
@@ -61,7 +61,8 @@ namespace Microsoft.SourceLink.Tools
 
             var list = new List<Entry>();
 
-            var root = JsonDocument.Parse(json, new JsonDocumentOptions() { AllowTrailingCommas = true }).RootElement;
+            using var jsonDocument = JsonDocument.Parse(json, new JsonDocumentOptions() { AllowTrailingCommas = true });
+            var root = jsonDocument.RootElement;
             if (root.ValueKind != JsonValueKind.Object)
             {
                 throw new InvalidDataException();


### PR DESCRIPTION
HANDLE_LEAK JsonDocument.Parse(json, new JsonDocumentOptions() { AllowTrailingCommas = true }) becomes out of scope and is not disposed

A copy of the string is extracted from the object (jsonDocument.RootElement.....Value.EnumerateObject()->Value.GetString()) , so it is not needed when the method completes.  'using' operator is safe here.

Found by Linux Verification Center (linuxtesting.org) with SVACE.