### PR TITLE
[clr-ios] Fix SIGSEGV in open virtual delegate dispatch with interpreter

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5432,19 +5432,34 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
                 else if (opcode == INTOP_CALLDELEGATE)
                 {
                     int32_t sizeOfArgsUpto16ByteAlignment = 0;
+                    int32_t targetArgsSize = 0;
+                    bool found16ByteAligned = false;
                     for (int argIndex = 1; argIndex < numArgs; argIndex++)
                     {
                         int32_t argAlignment = INTERP_STACK_SLOT_SIZE;
                         int32_t size = GetInterpTypeStackSize(m_pVars[callArgs[argIndex]].clsHnd, m_pVars[callArgs[argIndex]].interpType, &argAlignment);
                         size = ALIGN_UP_TO(size, INTERP_STACK_SLOT_SIZE);
-                        if (argAlignment == INTERP_STACK_ALIGNMENT)
+                        if (!found16ByteAligned)
                         {
-                            break;
+                            if (argAlignment == INTERP_STACK_ALIGNMENT)
+                            {
+                                found16ByteAligned = true;
+                            }
+                            else
+                            {
+                                sizeOfArgsUpto16ByteAlignment += size;
+                            }
                         }
-                        sizeOfArgsUpto16ByteAlignment += size;
+                        targetArgsSize = ALIGN_UP_TO(targetArgsSize, argAlignment);
+                        targetArgsSize += size;
+                    }
+                    if (!found16ByteAligned)
+                    {
+                        sizeOfArgsUpto16ByteAlignment = targetArgsSize;
                     }
 
                     m_pLastNewIns->data[1] = sizeOfArgsUpto16ByteAlignment;
+                    m_pLastNewIns->data[2] = targetArgsSize;
                 }
             }
             break;

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5429,7 +5429,7 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
                         ((lookup.accessType == IAT_PVALUE) ? (int32_t)PInvokeCallFlags::Indirect : 0) |
                         (suppressGCTransition ? (int32_t)PInvokeCallFlags::SuppressGCTransition : 0);
                 }
-                else if (opcode == INTOP_CALLDELEGATE || opcode == INTOP_CALLDELEGATE_TAIL)
+                else if (opcode == INTOP_CALLDELEGATE)
                 {
                     int32_t sizeOfArgsUpto16ByteAlignment = 0;
                     int32_t targetArgsSize = 0;
@@ -5453,11 +5453,6 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
                         targetArgsSize = ALIGN_UP_TO(targetArgsSize, argAlignment);
                         targetArgsSize += size;
                     }
-                    if (!found16ByteAligned)
-                    {
-                        sizeOfArgsUpto16ByteAlignment = targetArgsSize;
-                    }
-
                     m_pLastNewIns->data[1] = sizeOfArgsUpto16ByteAlignment;
                     m_pLastNewIns->data[2] = targetArgsSize;
                 }

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -5429,7 +5429,7 @@ void InterpCompiler::EmitCall(CORINFO_RESOLVED_TOKEN* pConstrainedToken, bool re
                         ((lookup.accessType == IAT_PVALUE) ? (int32_t)PInvokeCallFlags::Indirect : 0) |
                         (suppressGCTransition ? (int32_t)PInvokeCallFlags::SuppressGCTransition : 0);
                 }
-                else if (opcode == INTOP_CALLDELEGATE)
+                else if (opcode == INTOP_CALLDELEGATE || opcode == INTOP_CALLDELEGATE_TAIL)
                 {
                     int32_t sizeOfArgsUpto16ByteAlignment = 0;
                     int32_t targetArgsSize = 0;

--- a/src/coreclr/interpreter/inc/intops.def
+++ b/src/coreclr/interpreter/inc/intops.def
@@ -376,7 +376,7 @@ OPDEF(INTOP_LDFLDA, "ldflda", 4, 1, 1, InterpOpInt)
 // Calls
 OPDEF(INTOP_CALL, "call", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALL_NULLCHECK, "call.nullcheck", 4, 1, 1, InterpOpMethodHandle)
-OPDEF(INTOP_CALLDELEGATE, "call.delegate", 5, 1, 1, InterpOpMethodHandle)
+OPDEF(INTOP_CALLDELEGATE, "call.delegate", 6, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLDELEGATE_TAIL, "call.delegate.tail", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLI, "calli", 6, 1, 2, InterpOpLdPtr)
 OPDEF(INTOP_CALLVIRT, "callvirt", 5, 1, 1, InterpOpMethodHandle)

--- a/src/coreclr/interpreter/inc/intops.def
+++ b/src/coreclr/interpreter/inc/intops.def
@@ -377,7 +377,7 @@ OPDEF(INTOP_LDFLDA, "ldflda", 4, 1, 1, InterpOpInt)
 OPDEF(INTOP_CALL, "call", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALL_NULLCHECK, "call.nullcheck", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLDELEGATE, "call.delegate", 6, 1, 1, InterpOpMethodHandle)
-OPDEF(INTOP_CALLDELEGATE_TAIL, "call.delegate.tail", 6, 1, 1, InterpOpMethodHandle)
+OPDEF(INTOP_CALLDELEGATE_TAIL, "call.delegate.tail", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLI, "calli", 6, 1, 2, InterpOpLdPtr)
 OPDEF(INTOP_CALLVIRT, "callvirt", 5, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALL_PINVOKE, "call.pinvoke", 6, 1, 1, InterpOpMethodHandle) // inlined (no marshaling wrapper) pinvokes only

--- a/src/coreclr/interpreter/inc/intops.def
+++ b/src/coreclr/interpreter/inc/intops.def
@@ -377,7 +377,7 @@ OPDEF(INTOP_LDFLDA, "ldflda", 4, 1, 1, InterpOpInt)
 OPDEF(INTOP_CALL, "call", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALL_NULLCHECK, "call.nullcheck", 4, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLDELEGATE, "call.delegate", 6, 1, 1, InterpOpMethodHandle)
-OPDEF(INTOP_CALLDELEGATE_TAIL, "call.delegate.tail", 4, 1, 1, InterpOpMethodHandle)
+OPDEF(INTOP_CALLDELEGATE_TAIL, "call.delegate.tail", 6, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALLI, "calli", 6, 1, 2, InterpOpLdPtr)
 OPDEF(INTOP_CALLVIRT, "callvirt", 5, 1, 1, InterpOpMethodHandle)
 OPDEF(INTOP_CALL_PINVOKE, "call.pinvoke", 6, 1, 1, InterpOpMethodHandle) // inlined (no marshaling wrapper) pinvokes only

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -3124,18 +3124,9 @@ SWITCH_OPCODE:
 
                     // Argument sizes used for open virtual delegate dispatch to remove the delegate object
                     // from the argument list while preserving 16-byte alignment for V128 arguments.
-                    int32_t sizeOfArgsUpto16ByteAlignment = 0;
-                    int32_t targetArgsSize = 0;
-                    if (opcode == INTOP_CALLDELEGATE)
-                    {
-                        sizeOfArgsUpto16ByteAlignment = ip[4];
-                        targetArgsSize = ip[5];
-                        ip += 6;
-                    }
-                    else
-                    {
-                        ip += 4;
-                    }
+                    int32_t sizeOfArgsUpto16ByteAlignment = ip[4];
+                    int32_t targetArgsSize = ip[5];
+                    ip += 6;
 
                     DELEGATEREF* delegateObj = LOCAL_VAR_ADDR(callArgsOffset, DELEGATEREF);
                     NULL_CHECK(*delegateObj);
@@ -3188,7 +3179,8 @@ SWITCH_OPCODE:
                             InterpMethod* pTargetMethod = targetIp->Method;
                             if (frameNeedsTailcallUpdate)
                             {
-                                UpdateFrameForTailCall(pFrame, targetIp, LOCAL_VAR_ADDR(callArgsOffset + INTERP_STACK_SLOT_SIZE, int8_t));
+                                ShiftDelegateCallArgs(stack, callArgsOffset, sizeOfArgsUpto16ByteAlignment, pTargetMethod->argsSize);
+                                UpdateFrameForTailCall(pFrame, targetIp, LOCAL_VAR_ADDR(callArgsOffset, int8_t));
                                 frameNeedsTailcallUpdate = false;
                             }
                             else
@@ -3217,15 +3209,7 @@ SWITCH_OPCODE:
                         }
                         else if (isOpenVirtual)
                         {
-                            if (frameNeedsTailcallUpdate)
-                            {
-                                // For tail calls, skip the delegate slot; matches the interpreted tail path above.
-                                callArgsOffset += INTERP_STACK_SLOT_SIZE;
-                            }
-                            else
-                            {
-                                ShiftDelegateCallArgs(stack, callArgsOffset, sizeOfArgsUpto16ByteAlignment, targetArgsSize);
-                            }
+                            ShiftDelegateCallArgs(stack, callArgsOffset, sizeOfArgsUpto16ByteAlignment, targetArgsSize);
 
                             goto CALL_INTERP_METHOD;
                         }

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -3106,10 +3106,12 @@ SWITCH_OPCODE:
 
                     // Used only for INTOP_CALLDELEGATE to allow removal of the delegate object from the argument list
                     int32_t sizeOfArgsUpto16ByteAlignment = 0;
+                    int32_t targetArgsSize = 0;
                     if (opcode == INTOP_CALLDELEGATE)
                     {
                         sizeOfArgsUpto16ByteAlignment = ip[4];
-                        ip += 5;
+                        targetArgsSize = ip[5];
+                        ip += 6;
                     }
                     else
                     {
@@ -3210,8 +3212,23 @@ SWITCH_OPCODE:
                         }
                         else if (isOpenVirtual)
                         {
-                            callArgsOffset += INTERP_STACK_SLOT_SIZE;
-                            goto CALL_INTERP_METHOD;
+                            pFrame->ip = ip;
+                            if (sizeOfArgsUpto16ByteAlignment != 0)
+                            {
+                                memmove(LOCAL_VAR_ADDR(callArgsOffset, int8_t), LOCAL_VAR_ADDR(callArgsOffset + INTERP_STACK_SLOT_SIZE, int8_t), sizeOfArgsUpto16ByteAlignment);
+                            }
+
+                            if (sizeOfArgsUpto16ByteAlignment != targetArgsSize)
+                            {
+                                size_t firstAlignedTargetArgDstOffset = ALIGN_UP(sizeOfArgsUpto16ByteAlignment, INTERP_STACK_ALIGNMENT);
+                                size_t firstAlignedTargetArgSrcOffset = ALIGN_UP(INTERP_STACK_SLOT_SIZE + sizeOfArgsUpto16ByteAlignment, INTERP_STACK_ALIGNMENT);
+                                memmove(LOCAL_VAR_ADDR(callArgsOffset + firstAlignedTargetArgDstOffset, int8_t), LOCAL_VAR_ADDR(callArgsOffset + firstAlignedTargetArgSrcOffset, int8_t), targetArgsSize - sizeOfArgsUpto16ByteAlignment);
+                            }
+
+                            int8_t* callArgsAddress = LOCAL_VAR_ADDR(callArgsOffset, int8_t);
+                            ManagedMethodParam param = { targetMethod, callArgsAddress, returnValueAddress, (PCODE)NULL, pInterpreterFrame->GetContinuationPtr() };
+                            InvokeManagedMethod(&param);
+                            break;
                         }
                     }
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1121,9 +1121,9 @@ static void DECLSPEC_NORETURN HandleInterpreterStackOverflow(InterpreterFrame* p
 
 // Shifts delegate call arguments down by one slot to remove the delegate object pointer,
 // preserving 16-byte alignment for V128 arguments.
-static void ShiftDelegateCallArgs(int8_t *stack, int32_t callArgsOffset, int32_t sizeOfArgsUpto16ByteAlignment, int32_t totalArgsSize)
+static void ShiftDelegateCallArgs(int8_t* stack, int32_t callArgsOffset, int32_t sizeOfArgsUpto16ByteAlignment, int32_t totalArgsSize)
 {
-    int8_t *argsBase = stack + callArgsOffset;
+    int8_t* argsBase = stack + callArgsOffset;
     if (sizeOfArgsUpto16ByteAlignment != 0)
     {
         memmove(argsBase, argsBase + INTERP_STACK_SLOT_SIZE, sizeOfArgsUpto16ByteAlignment);

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1133,7 +1133,7 @@ static void ShiftDelegateCallArgs(int8_t* stack, int32_t callArgsOffset, int32_t
     {
         size_t firstAlignedDstOffset = ALIGN_UP(sizeOfArgsUpto16ByteAlignment, INTERP_STACK_ALIGNMENT);
         size_t firstAlignedSrcOffset = ALIGN_UP(INTERP_STACK_SLOT_SIZE + sizeOfArgsUpto16ByteAlignment, INTERP_STACK_ALIGNMENT);
-        memmove(argsBase + firstAlignedDstOffset, argsBase + firstAlignedSrcOffset, totalArgsSize - sizeOfArgsUpto16ByteAlignment);
+        memmove(argsBase + firstAlignedDstOffset, argsBase + firstAlignedSrcOffset, totalArgsSize - firstAlignedDstOffset);
     }
 }
 
@@ -3122,19 +3122,9 @@ SWITCH_OPCODE:
 
                     int8_t* returnValueAddress = LOCAL_VAR_ADDR(returnOffset, int8_t);
 
-                    // Used only for INTOP_CALLDELEGATE to allow removal of the delegate object from the argument list
-                    int32_t sizeOfArgsUpto16ByteAlignment = 0;
-                    int32_t targetArgsSize = 0;
-                    if (opcode == INTOP_CALLDELEGATE)
-                    {
-                        sizeOfArgsUpto16ByteAlignment = ip[4];
-                        targetArgsSize = ip[5];
-                        ip += 6;
-                    }
-                    else
-                    {
-                        ip += 4;
-                    }
+                    int32_t sizeOfArgsUpto16ByteAlignment = ip[4];
+                    int32_t targetArgsSize = ip[5];
+                    ip += 6;
 
                     DELEGATEREF* delegateObj = LOCAL_VAR_ADDR(callArgsOffset, DELEGATEREF);
                     NULL_CHECK(*delegateObj);

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -3212,7 +3212,6 @@ SWITCH_OPCODE:
                         }
                         else if (isOpenVirtual)
                         {
-                            pFrame->ip = ip;
                             if (sizeOfArgsUpto16ByteAlignment != 0)
                             {
                                 memmove(LOCAL_VAR_ADDR(callArgsOffset, int8_t), LOCAL_VAR_ADDR(callArgsOffset + INTERP_STACK_SLOT_SIZE, int8_t), sizeOfArgsUpto16ByteAlignment);
@@ -3225,10 +3224,7 @@ SWITCH_OPCODE:
                                 memmove(LOCAL_VAR_ADDR(callArgsOffset + firstAlignedTargetArgDstOffset, int8_t), LOCAL_VAR_ADDR(callArgsOffset + firstAlignedTargetArgSrcOffset, int8_t), targetArgsSize - sizeOfArgsUpto16ByteAlignment);
                             }
 
-                            int8_t* callArgsAddress = LOCAL_VAR_ADDR(callArgsOffset, int8_t);
-                            ManagedMethodParam param = { targetMethod, callArgsAddress, returnValueAddress, (PCODE)NULL, pInterpreterFrame->GetContinuationPtr() };
-                            InvokeManagedMethod(&param);
-                            break;
+                            goto CALL_INTERP_METHOD;
                         }
                     }
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -3210,19 +3210,23 @@ SWITCH_OPCODE:
                         }
                         else if (isOpenVirtual)
                         {
+                            // For open virtual delegates with compiled target, dispatch through the delegate's
+                            // Invoke method which uses the shuffle thunk to correctly handle argument shifting.
                             goto CALL_DELEGATE_INVOKE;
                         }
                     }
 
-                    OBJECTREF targetMethodObj = (*delegateObj)->GetTarget();
-                    LOCAL_VAR(callArgsOffset, OBJECTREF) = targetMethodObj;
-
-                    if ((targetMethod = NonVirtualEntry2MethodDesc(targetAddress)) != NULL)
                     {
-                        // In this case targetMethod holds a pointer to the MethodDesc that will be called by using targetMethodObj as
-                        // the this pointer. This may be the final method (in the case of instance method delegates), or it may be a
-                        // shuffle thunk, or multicast invoke method.
-                        goto CALL_INTERP_METHOD;
+                        OBJECTREF targetMethodObj = (*delegateObj)->GetTarget();
+                        LOCAL_VAR(callArgsOffset, OBJECTREF) = targetMethodObj;
+
+                        if ((targetMethod = NonVirtualEntry2MethodDesc(targetAddress)) != NULL)
+                        {
+                            // In this case targetMethod holds a pointer to the MethodDesc that will be called by using targetMethodObj as
+                            // the this pointer. This may be the final method (in the case of instance method delegates), or it may be a
+                            // shuffle thunk, or multicast invoke method.
+                            goto CALL_INTERP_METHOD;
+                        }
                     }
 
                     // targetMethod holds a pointer to the Invoke method of the delegate, not the final actual target.

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1119,6 +1119,24 @@ static void DECLSPEC_NORETURN HandleInterpreterStackOverflow(InterpreterFrame* p
     EEPolicy::HandleFatalStackOverflow(&exceptionInfo);
 }
 
+// Shifts delegate call arguments down by one slot to remove the delegate object pointer,
+// preserving 16-byte alignment for V128 arguments.
+static void ShiftDelegateCallArgs(int8_t *stack, int32_t callArgsOffset, int32_t sizeOfArgsUpto16ByteAlignment, int32_t totalArgsSize)
+{
+    int8_t *argsBase = stack + callArgsOffset;
+    if (sizeOfArgsUpto16ByteAlignment != 0)
+    {
+        memmove(argsBase, argsBase + INTERP_STACK_SLOT_SIZE, sizeOfArgsUpto16ByteAlignment);
+    }
+
+    if (sizeOfArgsUpto16ByteAlignment != totalArgsSize)
+    {
+        size_t firstAlignedDstOffset = ALIGN_UP(sizeOfArgsUpto16ByteAlignment, INTERP_STACK_ALIGNMENT);
+        size_t firstAlignedSrcOffset = ALIGN_UP(INTERP_STACK_SLOT_SIZE + sizeOfArgsUpto16ByteAlignment, INTERP_STACK_ALIGNMENT);
+        memmove(argsBase + firstAlignedDstOffset, argsBase + firstAlignedSrcOffset, totalArgsSize - sizeOfArgsUpto16ByteAlignment);
+    }
+}
+
 static void UpdateFrameForTailCall(InterpMethodContextFrame *pFrame, PTR_InterpByteCodeStart targetIp, int8_t *callArgsAddress)
 {
     InterpMethod *pTargetMethod = targetIp->Method;
@@ -3174,21 +3192,7 @@ SWITCH_OPCODE:
                             }
                             else
                             {
-                                // Shift args down by one slot to remove the delegate obj pointer.
-                                // We need to preserve alignment of arguments that require 16-byte alignment.
-                                // The sizeOfArgsUpto16ByteAlignment is the size of all the target method args starting at the first argument up to (but not including) the first argument that requires 16-byte alignment.
-                                if (sizeOfArgsUpto16ByteAlignment != 0)
-                                {
-                                    memmove(LOCAL_VAR_ADDR(callArgsOffset, int8_t), LOCAL_VAR_ADDR(callArgsOffset + INTERP_STACK_SLOT_SIZE, int8_t), sizeOfArgsUpto16ByteAlignment);
-                                }
-
-                                if (sizeOfArgsUpto16ByteAlignment != pTargetMethod->argsSize)
-                                {
-                                    // There are arguments that require 16-byte alignment
-                                    size_t firstAlignedTargetArgDstOffset = ALIGN_UP(sizeOfArgsUpto16ByteAlignment, INTERP_STACK_ALIGNMENT);
-                                    size_t firstAlignedTargetArgSrcOffset = ALIGN_UP(INTERP_STACK_SLOT_SIZE + sizeOfArgsUpto16ByteAlignment, INTERP_STACK_ALIGNMENT);
-                                    memmove(LOCAL_VAR_ADDR(callArgsOffset + firstAlignedTargetArgDstOffset, int8_t), LOCAL_VAR_ADDR(callArgsOffset + firstAlignedTargetArgSrcOffset, int8_t), pTargetMethod->argsSize - sizeOfArgsUpto16ByteAlignment);
-                                }
+                                ShiftDelegateCallArgs(stack, callArgsOffset, sizeOfArgsUpto16ByteAlignment, pTargetMethod->argsSize);
 
                                 // Allocate child frame.
                                 InterpMethodContextFrame *pChildFrame = pFrame->pNext;
@@ -3212,17 +3216,7 @@ SWITCH_OPCODE:
                         }
                         else if (isOpenVirtual)
                         {
-                            if (sizeOfArgsUpto16ByteAlignment != 0)
-                            {
-                                memmove(LOCAL_VAR_ADDR(callArgsOffset, int8_t), LOCAL_VAR_ADDR(callArgsOffset + INTERP_STACK_SLOT_SIZE, int8_t), sizeOfArgsUpto16ByteAlignment);
-                            }
-
-                            if (sizeOfArgsUpto16ByteAlignment != targetArgsSize)
-                            {
-                                size_t firstAlignedTargetArgDstOffset = ALIGN_UP(sizeOfArgsUpto16ByteAlignment, INTERP_STACK_ALIGNMENT);
-                                size_t firstAlignedTargetArgSrcOffset = ALIGN_UP(INTERP_STACK_SLOT_SIZE + sizeOfArgsUpto16ByteAlignment, INTERP_STACK_ALIGNMENT);
-                                memmove(LOCAL_VAR_ADDR(callArgsOffset + firstAlignedTargetArgDstOffset, int8_t), LOCAL_VAR_ADDR(callArgsOffset + firstAlignedTargetArgSrcOffset, int8_t), targetArgsSize - sizeOfArgsUpto16ByteAlignment);
-                            }
+                            ShiftDelegateCallArgs(stack, callArgsOffset, sizeOfArgsUpto16ByteAlignment, targetArgsSize);
 
                             goto CALL_INTERP_METHOD;
                         }

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -3122,9 +3122,20 @@ SWITCH_OPCODE:
 
                     int8_t* returnValueAddress = LOCAL_VAR_ADDR(returnOffset, int8_t);
 
-                    int32_t sizeOfArgsUpto16ByteAlignment = ip[4];
-                    int32_t targetArgsSize = ip[5];
-                    ip += 6;
+                    // Argument sizes used for open virtual delegate dispatch to remove the delegate object
+                    // from the argument list while preserving 16-byte alignment for V128 arguments.
+                    int32_t sizeOfArgsUpto16ByteAlignment = 0;
+                    int32_t targetArgsSize = 0;
+                    if (opcode == INTOP_CALLDELEGATE)
+                    {
+                        sizeOfArgsUpto16ByteAlignment = ip[4];
+                        targetArgsSize = ip[5];
+                        ip += 6;
+                    }
+                    else
+                    {
+                        ip += 4;
+                    }
 
                     DELEGATEREF* delegateObj = LOCAL_VAR_ADDR(callArgsOffset, DELEGATEREF);
                     NULL_CHECK(*delegateObj);
@@ -3206,7 +3217,15 @@ SWITCH_OPCODE:
                         }
                         else if (isOpenVirtual)
                         {
-                            ShiftDelegateCallArgs(stack, callArgsOffset, sizeOfArgsUpto16ByteAlignment, targetArgsSize);
+                            if (frameNeedsTailcallUpdate)
+                            {
+                                // For tail calls, skip the delegate slot; matches the interpreted tail path above.
+                                callArgsOffset += INTERP_STACK_SLOT_SIZE;
+                            }
+                            else
+                            {
+                                ShiftDelegateCallArgs(stack, callArgsOffset, sizeOfArgsUpto16ByteAlignment, targetArgsSize);
+                            }
 
                             goto CALL_INTERP_METHOD;
                         }

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -3210,8 +3210,7 @@ SWITCH_OPCODE:
                         }
                         else if (isOpenVirtual)
                         {
-                            callArgsOffset += INTERP_STACK_SLOT_SIZE;
-                            goto CALL_INTERP_METHOD;
+                            goto CALL_DELEGATE_INVOKE;
                         }
                     }
 
@@ -3227,6 +3226,7 @@ SWITCH_OPCODE:
                     }
 
                     // targetMethod holds a pointer to the Invoke method of the delegate, not the final actual target.
+CALL_DELEGATE_INVOKE:
                     targetMethod = (MethodDesc*)pMethod->pDataItems[methodSlot];
                     int8_t* callArgsAddress = LOCAL_VAR_ADDR(callArgsOffset, int8_t);
 

--- a/src/coreclr/vm/interpexec.cpp
+++ b/src/coreclr/vm/interpexec.cpp
@@ -1260,7 +1260,7 @@ SWITCH_OPCODE:
                     InterpBreakpoint(ip, pFrame, stack, pInterpreterFrame);
 
                     int32_t bypassOpcode = 0;
-                    
+
                     // After debugger callback, check if bypass was set on the thread context
                     if (pThreadContext->HasBypass(ip, &bypassOpcode))
                     {
@@ -3207,6 +3207,11 @@ SWITCH_OPCODE:
                             ip = pFrame->startIp->GetByteCodes();
                             pThreadContext->pStackPointer = stack + pMethod->allocaSize;
                             break;
+                        }
+                        else if (isOpenVirtual)
+                        {
+                            callArgsOffset += INTERP_STACK_SLOT_SIZE;
+                            goto CALL_INTERP_METHOD;
                         }
                     }
 

--- a/src/libraries/Common/tests/System/Runtime/Serialization/Utils.cs
+++ b/src/libraries/Common/tests/System/Runtime/Serialization/Utils.cs
@@ -365,13 +365,13 @@ namespace System.Runtime.Serialization.Tests
 
         public TestAssemblyLoadContext(string name, bool isCollectible, string mainAssemblyToLoadPath = null) : base(name, isCollectible)
         {
-            if (!PlatformDetection.IsBrowser)
+            if (!PlatformDetection.IsBrowser && !PlatformDetection.IsAppleMobile)
                 _resolver = new AssemblyDependencyResolver(mainAssemblyToLoadPath ?? Assembly.GetExecutingAssembly().Location);
         }
 
         protected override Assembly Load(AssemblyName name)
         {
-            if (PlatformDetection.IsBrowser)
+            if (PlatformDetection.IsBrowser || PlatformDetection.IsAppleMobile)
             {
                 return base.Load(name);
             }

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1199,11 +1199,9 @@ public static partial class DataContractSerializerTests
     }
 
     [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
-#if XMLSERIALIZERGENERATORTESTS
     // Lack of AssemblyDependencyResolver results in assemblies that are not loaded by path to get
     // loaded in the default ALC, which causes problems for this test.
-    [SkipOnPlatform(TestPlatforms.Browser, "AssemblyDependencyResolver not supported in wasm")]
-#endif
+    [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS, "AssemblyDependencyResolver not supported on Browser/iOS/tvOS")]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/34072", TestRuntimes.Mono)]
     public static void DCS_TypeInCollectibleALC()
     {
@@ -1218,11 +1216,9 @@ public static partial class DataContractSerializerTests
     }
 
     [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
-#if XMLSERIALIZERGENERATORTESTS
     // Lack of AssemblyDependencyResolver results in assemblies that are not loaded by path to get
     // loaded in the default ALC, which causes problems for this test.
-    [SkipOnPlatform(TestPlatforms.Browser, "AssemblyDependencyResolver not supported in wasm")]
-#endif
+    [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS, "AssemblyDependencyResolver not supported on Browser/iOS/tvOS")]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/34072", TestRuntimes.Mono)]
     public static void DCS_CollectionTypeInCollectibleALC()
     {

--- a/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/libraries/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1201,7 +1201,7 @@ public static partial class DataContractSerializerTests
     [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
     // Lack of AssemblyDependencyResolver results in assemblies that are not loaded by path to get
     // loaded in the default ALC, which causes problems for this test.
-    [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS, "AssemblyDependencyResolver not supported on Browser/iOS/tvOS")]
+    [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, "AssemblyDependencyResolver not supported on Browser/iOS/tvOS/MacCatalyst")]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/34072", TestRuntimes.Mono)]
     public static void DCS_TypeInCollectibleALC()
     {
@@ -1218,7 +1218,7 @@ public static partial class DataContractSerializerTests
     [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.HasAssemblyFiles))]
     // Lack of AssemblyDependencyResolver results in assemblies that are not loaded by path to get
     // loaded in the default ALC, which causes problems for this test.
-    [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS, "AssemblyDependencyResolver not supported on Browser/iOS/tvOS")]
+    [SkipOnPlatform(TestPlatforms.Browser | TestPlatforms.iOS | TestPlatforms.tvOS | TestPlatforms.MacCatalyst, "AssemblyDependencyResolver not supported on Browser/iOS/tvOS/MacCatalyst")]
     [ActiveIssue("https://github.com/dotnet/runtime/issues/34072", TestRuntimes.Mono)]
     public static void DCS_CollectionTypeInCollectibleALC()
     {

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -684,6 +684,9 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.StackTrace\tests\System.Diagnostics.StackTrace.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\System.Private.Xml.Tests.csproj" />
 
+    <!-- https://github.com/dotnet/runtime/issues/124325 -->
+    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Xml\tests\System.Runtime.Serialization.Xml.Tests.csproj" />
+
     <!-- Timeouts -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections.Concurrent\tests\System.Collections.Concurrent.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.HttpListener\tests\System.Net.HttpListener.Tests.csproj" />

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -684,7 +684,7 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.StackTrace\tests\System.Diagnostics.StackTrace.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\System.Private.Xml.Tests.csproj" />
 
-    <!-- https://github.com/dotnet/runtime/issues/124325 -->
+    <!-- https://github.com/dotnet/runtime/issues/124344 -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Xml\tests\System.Runtime.Serialization.Xml.Tests.csproj" />
 
     <!-- Timeouts -->

--- a/src/libraries/tests.proj
+++ b/src/libraries/tests.proj
@@ -684,14 +684,6 @@
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Diagnostics.StackTrace\tests\System.Diagnostics.StackTrace.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\System.Private.Xml.Tests.csproj" />
 
-    <!-- https://github.com/dotnet/runtime/issues/124325 -->
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Json\tests\System.Runtime.Serialization.Json.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Json\tests\ReflectionOnly\System.Runtime.Serialization.Json.ReflectionOnly.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Xml\tests\System.Runtime.Serialization.Xml.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Runtime.Serialization.Xml\tests\ReflectionOnly\System.Runtime.Serialization.Xml.ReflectionOnly.Tests.csproj" />
-    <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Private.Xml\tests\XmlSerializer\ReflectionOnly\System.Xml.XmlSerializer.ReflectionOnly.Tests.csproj" />
-
-
     <!-- Timeouts -->
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Collections.Concurrent\tests\System.Collections.Concurrent.Tests.csproj" />
     <ProjectExclusions Include="$(MSBuildThisFileDirectory)System.Net.HttpListener\tests\System.Net.HttpListener.Tests.csproj" />


### PR DESCRIPTION
## Description

Fix a crash when the interpreter invokes a compiled open virtual delegate target.

When the interpreter's call delegate handler detects an open virtual delegate whose resolved target is compiled (`targetIp == NULL`), the code previously fell through to a generic path that called `GetTarget()` on the delegate. For open delegates, `GetTarget()` returns null, which corrupted the argument slot and caused a SIGSEGV.

The fix adds a dedicated path for open virtual delegates with compiled targets. It uses `memmove` to shift the call arguments down by one slot (removing the delegate object) while preserving 16-byte alignment for V128 arguments, then jumps to `CALL_INTERP_METHOD` to invoke the resolved `targetMethod` directly. The same shifting is applied for interpreted targets in the non-tail-call path. The alignment-preserving shift logic is extracted into a `ShiftDelegateCallArgs()` helper to avoid duplication.

Additionally, this re-enables test suites previously excluded under #124325 (except `System.Runtime.Serialization.Xml.Tests`, which hits a native stack overflow unrelated to this fix).