### PR TITLE
Fix ArrayValue.ToString separators

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ArrayValue.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/Compiler/Dataflow/ArrayValue.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using ILCompiler.Dataflow;
 using ILLink.Shared.DataFlow;
@@ -108,35 +109,12 @@ namespace ILLink.Shared.TrimAnalysis
             StringBuilder result = new();
             result.Append("Array Size:");
             result.Append(this.ValueToString(Size));
-
             result.Append(", Values:(");
-            bool first = true;
-            foreach (var element in IndexValues)
-            {
-                if (!first)
-                {
-                    result.Append(',');
-                    first = false;
-                }
 
-                result.Append('(');
-                result.Append(element.Key);
-                result.Append(",(");
-                bool firstValue = true;
-                foreach (var v in element.Value.Value.AsEnumerable())
-                {
-                    if (firstValue)
-                    {
-                        result.Append(',');
-                        firstValue = false;
-                    }
+            result.Append(string.Join(",", IndexValues.Select(element =>
+                $"({element.Key},({string.Join(",", element.Value.Value.AsEnumerable())}))")));
 
-                    result.Append(v.ToString());
-                }
-                result.Append("))");
-            }
             result.Append(')');
-
             return result.ToString();
         }
     }

--- a/src/tools/illink/src/linker/Linker.Dataflow/ArrayValue.cs
+++ b/src/tools/illink/src/linker/Linker.Dataflow/ArrayValue.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using ILLink.Shared.DataFlow;
 using Mono.Cecil;
@@ -107,35 +108,12 @@ namespace ILLink.Shared.TrimAnalysis
             StringBuilder result = new();
             result.Append("Array Size:");
             result.Append(this.ValueToString(Size));
-
             result.Append(", Values:(");
-            bool first = true;
-            foreach (var element in IndexValues)
-            {
-                if (!first)
-                {
-                    result.Append(',');
-                    first = false;
-                }
 
-                result.Append('(');
-                result.Append(element.Key);
-                result.Append(",(");
-                bool firstValue = true;
-                foreach (var v in element.Value.Value.AsEnumerable())
-                {
-                    if (firstValue)
-                    {
-                        result.Append(',');
-                        firstValue = false;
-                    }
+            result.Append(string.Join(",", IndexValues.Select(element =>
+                $"({element.Key},({string.Join(",", element.Value.Value.AsEnumerable())}))")));
 
-                    result.Append(v.ToString());
-                }
-                result.Append("))");
-            }
             result.Append(')');
-
             return result.ToString();
         }
     }


### PR DESCRIPTION
Corrects comma placement logic in ArrayValue.ToString() to properly separate elements and nested values.