### PR TITLE
Support all ldloc/ldarg variants in TypeEqualityPatternAnalyzer

### DIFF
--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/TypeEqualityPatternAnalyzer.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/TypeEqualityPatternAnalyzer.cs
@@ -133,10 +133,8 @@ namespace ILCompiler
                         break;
                     return;
                 case State.TypeEqualityCheck_StlocLdloc:
-                    if (opcode == ILOpcode.ldloc || opcode == ILOpcode.ldloc_s || (opcode >= ILOpcode.ldloc_0 && opcode <= ILOpcode.ldloc_3))
-                        _state = State.TypeEqualityCheck;
-                    else
-                        throw new UnreachableException();
+                    _state = opcode is ILOpcode.ldloc or ILOpcode.ldloc_s or >= ILOpcode.ldloc_0 and <= ILOpcode.ldloc_3 ? State.TypeEqualityCheck
+                        : throw new UnreachableException();
                     return;
                 default:
                     throw new UnreachableException();
@@ -165,11 +163,12 @@ namespace ILCompiler
                 && method.IsIntrinsic && method.Name.SequenceEqual("GetType"u8) && method.OwningType.IsObject;
 
             static bool IsArgumentOrLocalLoad(ILOpcode opcode)
-                => opcode is (>= ILOpcode.ldloc_0 and <= ILOpcode.ldloc_3) or (>= ILOpcode.ldarg_0 and <= ILOpcode.ldarg_3);
+                => opcode is (>= ILOpcode.ldloc_0 and <= ILOpcode.ldloc_3) or (>= ILOpcode.ldarg_0 and <= ILOpcode.ldarg_3)
+                   or ILOpcode.ldloc or ILOpcode.ldloc_s or ILOpcode.ldarg or ILOpcode.ldarg_s;
 
             static bool IsStlocLdlocSequence(ILOpcode opcode, in ILReader reader)
             {
-                if (opcode == ILOpcode.stloc || opcode == ILOpcode.stloc_s || (opcode >= ILOpcode.stloc_0 && opcode <= ILOpcode.stloc_3))
+                if (opcode is ILOpcode.stloc or ILOpcode.stloc_s or >= ILOpcode.stloc_0 and <= ILOpcode.stloc_3)
                 {
                     ILReader nestedReader = reader;
                     int locIndex = opcode switch
@@ -179,7 +178,8 @@ namespace ILCompiler
                         _ => opcode - ILOpcode.stloc_0,
                     };
                     ILOpcode otherOpcode = nestedReader.ReadILOpcode();
-                    return (otherOpcode == ILOpcode.ldloc || otherOpcode == ILOpcode.ldloc_s || (otherOpcode >= ILOpcode.ldloc_0 && otherOpcode <= ILOpcode.ldloc_3))
+
+                    return (otherOpcode is ILOpcode.ldloc or ILOpcode.ldloc_s or (>= ILOpcode.ldloc_0 and <= ILOpcode.ldloc_3))
                         && otherOpcode switch
                         {
                             ILOpcode.ldloc => nestedReader.ReadILUInt16(),

--- a/src/coreclr/tools/aot/ILCompiler.Compiler/IL/TypeEqualityPatternAnalyzer.cs
+++ b/src/coreclr/tools/aot/ILCompiler.Compiler/IL/TypeEqualityPatternAnalyzer.cs
@@ -133,7 +133,7 @@ namespace ILCompiler
                         break;
                     return;
                 case State.TypeEqualityCheck_StlocLdloc:
-                    _state = opcode is ILOpcode.ldloc or ILOpcode.ldloc_s or >= ILOpcode.ldloc_0 and <= ILOpcode.ldloc_3 ? State.TypeEqualityCheck
+                    _state = opcode is ILOpcode.ldloc or ILOpcode.ldloc_s or (>= ILOpcode.ldloc_0 and <= ILOpcode.ldloc_3) ? State.TypeEqualityCheck
                         : throw new UnreachableException();
                     return;
                 default:
@@ -168,7 +168,7 @@ namespace ILCompiler
 
             static bool IsStlocLdlocSequence(ILOpcode opcode, in ILReader reader)
             {
-                if (opcode is ILOpcode.stloc or ILOpcode.stloc_s or >= ILOpcode.stloc_0 and <= ILOpcode.stloc_3)
+                if (opcode is ILOpcode.stloc or ILOpcode.stloc_s or (>= ILOpcode.stloc_0 and <= ILOpcode.stloc_3))
                 {
                     ILReader nestedReader = reader;
                     int locIndex = opcode switch


### PR DESCRIPTION
This change allows the analyzer to recognize type equality patterns even when long-form or short-parameter opcodes are used. Also updated the file to use modern C# pattern matching.