### PR TITLE
Intrinsify default Comparer<T> and EqualityComparer<T> creation in R2R

### DIFF
--- a/src/coreclr/System.Private.CoreLib/src/System/Collections/Generic/Comparer.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Collections/Generic/Comparer.CoreCLR.cs
@@ -7,9 +7,13 @@ namespace System.Collections.Generic
 {
     public abstract partial class Comparer<T> : IComparer, IComparer<T>
     {
+        // This method is special cased in R2R, with its implementation replaced by IL helper
+        [Intrinsic]
+        private static Comparer<T> Create() => (Comparer<T>)ComparerHelpers.CreateDefaultComparer(typeof(T));
+
         // To minimize generic instantiation overhead of creating the comparer per type, we keep the generic portion of the code as small
         // as possible and define most of the creation logic in a non-generic class.
-        public static Comparer<T> Default { [Intrinsic] get; } = (Comparer<T>)ComparerHelpers.CreateDefaultComparer(typeof(T));
+        public static Comparer<T> Default { [Intrinsic] get; } = Create();
     }
 
     internal sealed partial class EnumComparer<T> : Comparer<T> where T : struct, Enum

--- a/src/coreclr/System.Private.CoreLib/src/System/Collections/Generic/EqualityComparer.CoreCLR.cs
+++ b/src/coreclr/System.Private.CoreLib/src/System/Collections/Generic/EqualityComparer.CoreCLR.cs
@@ -8,9 +8,13 @@ namespace System.Collections.Generic
 {
     public abstract partial class EqualityComparer<T> : IEqualityComparer, IEqualityComparer<T>
     {
+        // This method is special cased in R2R, with its implementation replaced by IL helper
+        [Intrinsic]
+        private static EqualityComparer<T> Create() => (EqualityComparer<T>)ComparerHelpers.CreateDefaultEqualityComparer(typeof(T));
+
         // To minimize generic instantiation overhead of creating the comparer per type, we keep the generic portion of the code as small
         // as possible and define most of the creation logic in a non-generic class.
-        public static EqualityComparer<T> Default { [Intrinsic] get; } = (EqualityComparer<T>)ComparerHelpers.CreateDefaultEqualityComparer(typeof(T));
+        public static EqualityComparer<T> Default { [Intrinsic] get; } = Create();
     }
 
     public sealed partial class GenericEqualityComparer<T> : EqualityComparer<T> where T : IEquatable<T>?

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IL/ReadyToRunILProvider.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/IL/ReadyToRunILProvider.cs
@@ -120,6 +120,20 @@ namespace Internal.IL
                 return InterlockedIntrinsics.EmitIL(_compilationModuleGroup, method);
             }
 
+            if (mdType.Namespace.SequenceEqual("System.Collections.Generic"u8))
+            {
+                if (mdType.Name.SequenceEqual("Comparer`1"u8))
+                {
+                    if (method.Name.SequenceEqual("Create"u8))
+                        return ComparerIntrinsics.EmitComparerCreate(method);
+                }
+                else if (mdType.Name.SequenceEqual("EqualityComparer`1"u8))
+                {
+                    if (method.Name.SequenceEqual("Create"u8))
+                        return ComparerIntrinsics.EmitEqualityComparerCreate(method);
+                }
+            }
+
             return null;
         }
 


### PR DESCRIPTION
During cctor, backing field initialization was calling into `ComparerHelpers.CreateDefaultEqualityComparer` which used the reflection based api: `CreateInstanceForAnotherGenericParameter` to create a new type that R2R had now knowledge of. In order to fix this, we follow the same approach that NativeAOT takes, reusing existing helpers. This means that we will end up with specialized helpers in the R2R image that create these comparers in the cctor and R2R will now know to root the specialized comparer types.

Prevents interpretation of methods like:
```
System.Collections.Generic.GenericEqualityComparer`1[int]:.ctor()
System.Collections.Generic.GenericEqualityComparer`1[int]:Equals(int,int)
```

For example, this makes `System.Collections.ContainsFalse_Int32_.ImmutableList` benchmark 20x faster. On my local simple testcase it resulted in 0.5% increase in size.

