### PR TITLE
Fix NativeAOT ILC failure on android

### DIFF
--- a/src/tests/Common/mergedrunnermobile.targets
+++ b/src/tests/Common/mergedrunnermobile.targets
@@ -22,7 +22,8 @@
 
   <Target Name="_AddRuntimeLibsToPublishAssets" BeforeTargets="PrepareForPublish" DependsOnTargets="ResolveLibrariesRuntimeFilesFromLocalBuild;ResolveRuntimeFilesFromLocalBuild">
     <ItemGroup>
-      <RuntimePackAsset Include="@(RuntimeFiles);@(LibrariesRuntimeFiles)" AssetType="runtime" />
+      <RuntimePackAsset Include="@(RuntimeFiles);@(LibrariesRuntimeFiles)" Condition="'%(Extension)' == '.dll'" AssetType="runtime" />
+      <RuntimePackAsset Include="@(RuntimeFiles);@(LibrariesRuntimeFiles)" Condition="'%(Extension)' != '.dll'" AssetType="native" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
By assigning correct asset type to non-DLL runtime files.

The _AddRuntimeLibsToPublishAssets target was setting AssetType="runtime" on all files from RuntimeFiles and LibrariesRuntimeFiles, including .pdb, .so, .dbg, and .dwarf files. The SDK's _ComputeAssembliesToPostprocessOnPublish uses AssetType="runtime" to stamp PostprocessAssembly=true, which caused these non-PE files to be passed as -r: references to ILC, resulting in BadImageFormatException: Unknown file format.

Only .dll files should be classified as AssetType="runtime" (managed assemblies). All other extensions are now classified as AssetType="native".

Fixes dotnet/runtime#126117