### PR TITLE
Revert "Simplify RegexInterpreter (#124628)"

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexInterpreter.cs
@@ -209,27 +209,44 @@ namespace System.Text.RegularExpressions
 
         private bool MatchString(string str, ReadOnlySpan<char> inputSpan)
         {
+            int c = str.Length;
+            int pos;
+
             if (!_rightToLeft)
             {
-                if (runtextpos > inputSpan.Length ||
-                    !inputSpan.Slice(runtextpos).StartsWith(str.AsSpan()))
+                if (inputSpan.Length - runtextpos < c)
                 {
                     return false;
                 }
 
-                runtextpos += str.Length;
-                return true;
+                pos = runtextpos + c;
             }
             else
             {
-                if (!inputSpan.Slice(0, runtextpos).EndsWith(str.AsSpan()))
+                if (runtextpos < c)
                 {
                     return false;
                 }
 
-                runtextpos -= str.Length;
-                return true;
+                pos = runtextpos;
             }
+
+            while (c != 0)
+            {
+                if (str[--c] != inputSpan[--pos])
+                {
+                    return false;
+                }
+            }
+
+            if (!_rightToLeft)
+            {
+                pos += str.Length;
+            }
+
+            runtextpos = pos;
+
+            return true;
         }
 
         private bool MatchRef(int index, int length, ReadOnlySpan<char> inputSpan, bool caseInsensitive)


### PR DESCRIPTION
Revert "Simplify RegexInterpreter (#124628)"

This reverts commit f1949423fa100cd635625cab4e51842930ecb928 from #124628.

Closes #126156

#124628 replaced the char-by-char loop in `RegexInterpreter.MatchString` with `StartsWith`/`EndsWith`. This caused a 7-11% regression on arm64 (AmpereUbuntu) for `Perf_Regex_Industry_Leipzig` patterns that exercise `MatchString` heavily via alternation:

- `.{0,2}(Tom|Sawyer|Huckleberry|Finn)` None: 5.01s to 5.56s (1.11x)
- `.{2,4}(Tom|Sawyer|Huckleberry|Finn)` None: 5.16s to 5.51s (1.07x)

These patterns call `MatchString` millions of times with short strings (3-11 chars: "Tom", "Finn", "Sawyer", "Huckleberry") where `Slice` + `StartsWith` + `SequenceEqual` dispatch overhead exceeds the original tight loop cost, with no SIMD benefit at those lengths.

The MihuBot x64 results for the original PR showed the same patterns regressing at 1.03-1.04x, but this was overlooked during review.
