### PR TITLE
Remove assertion for unmanaged return frame

### DIFF
--- a/src/coreclr/debug/ee/controller.cpp
+++ b/src/coreclr/debug/ee/controller.cpp
@@ -519,7 +519,6 @@ void ControllerStackInfo::GetStackInfo(
     if (result == SWA_DONE)
     {
         _ASSERTE(!HasReturnFrame()); // We didn't find a managed return frame
-        _ASSERTE(HasReturnFrame(true)); // All threads have at least one unmanaged frame
     }
 }
 


### PR DESCRIPTION
We may not have any unmanaged frames (`Frame*` frames) if the whole stack is unmanaged code (ie C++ code) and interop debugging is enabled.