### PR TITLE
Add symlinks for configuring claude code with copilot instructions/skills

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.github/skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md


### PR DESCRIPTION
I'd like to occasionally experiment with Claude Code to see how the other half lives and compare to Copilot. It would be helpful if we have skills and instructions available to it.

Add symlinks for `Claude.md -> .github/copilot-instructions.md` and `.claude/skills/ -> .github/skills/` to give Claude Code the same skills and instructions as Copilot.