### PR TITLE
Enable the PatternsDataSet_GenerateInputsWithNonBacktracking test

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Debug.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Debug.cs
@@ -40,7 +40,6 @@ namespace System.Text.RegularExpressions
         /// </summary>
         /// <param name="k">upper bound on the number of generated strings</param>
         /// <param name="randomseed">random seed for the generator, 0 means no random seed</param>
-        /// <returns></returns>
         [ExcludeFromCodeCoverage(Justification = "Debug only")]
         internal IEnumerable<string> SampleMatches(int k, int randomseed)
         {
@@ -53,21 +52,16 @@ namespace System.Text.RegularExpressions
             // match (e.g. when anchors like $ appear inside alternations). Validate each
             // candidate with IsMatch and retry with a different seed if needed.
             const int MaxAttempts = 5;
-            var results = new List<string>(k);
+            List<string> results = new(k);
             for (int attempt = 0; attempt < MaxAttempts && results.Count < k; attempt++)
             {
                 foreach (string input in srmFactory._matcher.SampleMatches(k - results.Count, randomseed + attempt))
                 {
-                    if (IsMatch(input) && results.Count < k)
+                    if (IsMatch(input))
                     {
                         results.Add(input);
                     }
                 }
-            }
-
-            if (results.Count != k)
-            {
-                throw new InvalidOperationException($"SampleMatches could only generate {results.Count} of {k} requested matching inputs after {MaxAttempts} attempts.");
             }
 
             return results;

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Debug.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Regex.Debug.cs
@@ -49,7 +49,28 @@ namespace System.Text.RegularExpressions
                 throw new NotSupportedException();
             }
 
-            return srmFactory._matcher.SampleMatches(k, randomseed);
+            // The NFA-based sampler may occasionally produce inputs that don't actually
+            // match (e.g. when anchors like $ appear inside alternations). Validate each
+            // candidate with IsMatch and retry with a different seed if needed.
+            const int MaxAttempts = 5;
+            var results = new List<string>(k);
+            for (int attempt = 0; attempt < MaxAttempts && results.Count < k; attempt++)
+            {
+                foreach (string input in srmFactory._matcher.SampleMatches(k - results.Count, randomseed + attempt))
+                {
+                    if (IsMatch(input) && results.Count < k)
+                    {
+                        results.Add(input);
+                    }
+                }
+            }
+
+            if (results.Count != k)
+            {
+                throw new InvalidOperationException($"SampleMatches could only generate {results.Count} of {k} requested matching inputs after {MaxAttempts} attempts.");
+            }
+
+            return results;
         }
 
         /// <summary>

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/RegexNode.cs
@@ -2415,9 +2415,13 @@ namespace System.Text.RegularExpressions
                         // Find the node that follows the literal in the tree and check whether
                         // the loop would be atomic with respect to it. If nothing follows (end of
                         // pattern), we can't reduce — earlier positions could still succeed.
+                        // We must not iterate past nullable nodes to the end of the pattern: if the
+                        // entire post-literal sequence is nullable, any backtrack position could
+                        // succeed (the nullable part matches empty and the branch completes), so
+                        // reducing to a single position would be incorrect.
                         return
                             FindNextNodeInSequence(literal, out _) is RegexNode afterLiteral &&
-                            CanBeMadeAtomic(loopNode, afterLiteral, iterateNullableSubsequent: true, allowLazy: false);
+                            CanBeMadeAtomic(loopNode, afterLiteral, iterateNullableSubsequent: false, allowLazy: false);
 
                     case RegexNodeKind.Multi when CharInLoopSet(loopNode, literal.Str![0]) && !CharInLoopSet(loopNode, literal.Str[1]):
                         // For a multi-character literal (e.g. \d+0x), treat it as two single characters:

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
@@ -78,7 +78,17 @@ namespace System.Text.RegularExpressions.Symbolic
 
                     while (true)
                     {
-                        Debug.Assert(states.NfaStateSet.Count > 0);
+                        // The state set can be empty when the initial DFA state has no
+                        // NFA expansion (e.g. for certain anchor combinations).
+                        if (states.NfaStateSet.Count == 0)
+                        {
+                            if (latestCandidate is not null)
+                            {
+                                results.Add(latestCandidate.ToString());
+                            }
+
+                            break;
+                        }
 
                         // Gather the possible endings for satisfying nullability
                         possibleEndings.Clear();

--- a/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
+++ b/src/libraries/System.Text.RegularExpressions/src/System/Text/RegularExpressions/Symbolic/SymbolicRegexMatcher.Sample.cs
@@ -34,8 +34,7 @@ namespace System.Text.RegularExpressions.Symbolic
 
             lock (this)
             {
-                // Zero is treated as no seed, instead using a system provided one
-                Random random = randomseed != 0 ? new Random(randomseed) : new Random();
+                Random random = new Random(randomseed);
                 CharSetSolver charSetSolver = _builder._charSetSolver;
 
                 // Create helper BDDs for handling anchors and preferentially generating ASCII inputs
@@ -132,6 +131,7 @@ namespace System.Text.RegularExpressions.Symbolic
                         int[] mintermIds = SymbolicRegexMatcher<TSet>.NfaStateHandler.StartsWithLineAnchor(this, in statesWrapper) ?
                             Shuffle(random, mintermIdsWithZ) :
                             Shuffle(random, mintermIdsWithoutZ);
+                        bool transitionSucceeded = false;
                         foreach (int mintermId in mintermIds)
                         {
                             bool success = SymbolicRegexMatcher<TSet>.NfaStateHandler.TryTakeTransition(this, ref statesWrapper, mintermId);
@@ -141,6 +141,7 @@ namespace System.Text.RegularExpressions.Symbolic
                                 TSet minterm = GetMintermFromId(mintermId);
                                 // Append a random member of the minterm
                                 inputSoFar.Append(ChooseChar(random, ToBDD(minterm, Solver, charSetSolver), ascii, charSetSolver));
+                                transitionSucceeded = true;
                                 break;
                             }
                             else
@@ -150,8 +151,8 @@ namespace System.Text.RegularExpressions.Symbolic
                             }
                         }
 
-                        // In the case that there are no next states or input has become too large: stop here
-                        if (states.NfaStateSet.Count == 0 || inputSoFar.Length > SampleMatchesMaxInputLength)
+                        // In the case that there are no next states, no viable transition was found, or input has become too large: stop here
+                        if (!transitionSucceeded || states.NfaStateSet.Count == 0 || inputSoFar.Length > SampleMatchesMaxInputLength)
                         {
                             // Ending up here without an ending is unlikely but possible for example for infeasible patterns
                             // such as @"no\bway" or due to poor choice of c -- no anchor is enabled -- so this is a deadend.

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.KnownPattern.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.KnownPattern.Tests.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -1562,14 +1561,15 @@ namespace System.Text.RegularExpressions.Tests
             });
         }
 
-        [ActiveIssue("Manual execution only for now until stability is improved")]
-        [OuterLoop("Super slow")]
+        [OuterLoop("Takes minutes to generate and validate thousands of expressions")]
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.Is64BitProcess))] // consumes a lot of memory
         public async Task PatternsDataSet_GenerateInputsWithNonBacktracking_MatchWithAllEngines()
         {
             MethodInfo? sampleMatchesMI = typeof(Regex).GetMethod("SampleMatches", BindingFlags.NonPublic | BindingFlags.Instance) ??
                 throw new SkipTestException("Could not find Regex.SampleMatches");
             Func<Regex, int, int, IEnumerable<string>> sampleMatches = sampleMatchesMI.CreateDelegate<Func<Regex, int, int, IEnumerable<string>>>();
+
+            TimeSpan matchTimeout = TimeSpan.FromSeconds(2);
 
             DataSetExpression[] entries = s_patternsDataSet.Value;
             for (int i = 0; i < entries.Length; i++)
@@ -1588,30 +1588,42 @@ namespace System.Text.RegularExpressions.Tests
 
                 const int NumInputs = 3;
                 const int Seed = 42;
-                IEnumerable<string> expectedMatchInputs = null;
+                List<string> expectedMatchInputs;
                 try
                 {
-#pragma warning disable SYSLIB0046 // temporary until some use of SampleMatches no longer hangs
-                    using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
-                    ControlledExecution.Run(() => expectedMatchInputs = sampleMatches(generator, NumInputs, Seed), cts.Token);
-#pragma warning restore SYSLIB0046
+                    expectedMatchInputs = new List<string>(sampleMatches(generator, NumInputs, Seed));
                 }
-                catch (OperationCanceledException)
+                catch
                 {
-                    Console.Error.WriteLine($"*** SampleMatches hung on entry {i} ***");
                     continue;
                 }
 
                 foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
                 {
+                    // SourceGenerated uses Roslyn to compile each pattern; with thousands of
+                    // entries that makes this test prohibitively slow. It shares codegen with
+                    // Compiled, so coverage is equivalent.
+                    if (engine == RegexEngine.SourceGenerated)
+                    {
+                        continue;
+                    }
+
                     Regex r = engine == RegexEngine.NonBacktracking ?
                         generator :
-                        await RegexHelpers.GetRegexAsync(engine, entry.Pattern, entry.Options);
+                        await RegexHelpers.GetRegexAsync(engine, entry.Pattern, entry.Options, matchTimeout);
 
                     foreach (string input in expectedMatchInputs)
                     {
-                        Console.WriteLine($"[{i}-{engine}] {r} <= {input}");
-                        Assert.True(r.IsMatch(input));
+                        try
+                        {
+                            Assert.True(r.IsMatch(input), $"[{i}-{engine}] Options={entry.Options} Pattern=<{entry.Pattern}> didn't match input=<{input}> (hex: {string.Join(" ", input.Select(c => $"{(int)c:X4}"))})");
+                        }
+                        catch (RegexMatchTimeoutException) when (engine != RegexEngine.NonBacktracking)
+                        {
+                            // SampleMatches can generate random inputs that trigger catastrophic
+                            // backtracking in Interpreter/Compiled. That's expected behavior for
+                            // backtracking engines, not a correctness bug — just skip these.
+                        }
                     }
                 }
             }

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.KnownPattern.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.KnownPattern.Tests.cs
@@ -1569,7 +1569,7 @@ namespace System.Text.RegularExpressions.Tests
                 throw new SkipTestException("Could not find Regex.SampleMatches");
             Func<Regex, int, int, IEnumerable<string>> sampleMatches = sampleMatchesMI.CreateDelegate<Func<Regex, int, int, IEnumerable<string>>>();
 
-            TimeSpan matchTimeout = TimeSpan.FromSeconds(2);
+            int fewerThanRequestedCount = 0;
 
             DataSetExpression[] entries = s_patternsDataSet.Value;
             for (int i = 0; i < entries.Length; i++)
@@ -1588,21 +1588,18 @@ namespace System.Text.RegularExpressions.Tests
 
                 const int NumInputs = 3;
                 const int Seed = 42;
-                List<string> expectedMatchInputs;
-                try
+                string[] expectedMatchInputs = sampleMatches(generator, NumInputs, Seed).ToArray();
+                if (expectedMatchInputs.Length < NumInputs)
                 {
-                    expectedMatchInputs = new List<string>(sampleMatches(generator, NumInputs, Seed));
-                }
-                catch
-                {
+                    fewerThanRequestedCount++;
+                    Assert.True((fewerThanRequestedCount / (double)entries.Length) < 0.10, "SampleMatches is repeatedly producing an insufficient number of inputs");
                     continue;
                 }
 
                 foreach (RegexEngine engine in RegexHelpers.AvailableEngines)
                 {
                     // SourceGenerated uses Roslyn to compile each pattern; with thousands of
-                    // entries that makes this test prohibitively slow. It shares codegen with
-                    // Compiled, so coverage is equivalent.
+                    // entries that makes this test prohibitively slow.
                     if (engine == RegexEngine.SourceGenerated)
                     {
                         continue;
@@ -1610,15 +1607,18 @@ namespace System.Text.RegularExpressions.Tests
 
                     Regex r = engine == RegexEngine.NonBacktracking ?
                         generator :
-                        await RegexHelpers.GetRegexAsync(engine, entry.Pattern, entry.Options, matchTimeout);
+                        await RegexHelpers.GetRegexAsync(engine, entry.Pattern, entry.Options, TimeSpan.FromSeconds(2));
 
                     foreach (string input in expectedMatchInputs)
                     {
                         try
                         {
-                            Assert.True(r.IsMatch(input), $"[{i}-{engine}] Options={entry.Options} Pattern=<{entry.Pattern}> didn't match input=<{input}> (hex: {string.Join(" ", input.Select(c => $"{(int)c:X4}"))})");
+                            if (!r.IsMatch(input))
+                            {
+                                Assert.Fail($"[{i}-{engine}] Options={entry.Options} Pattern=<{entry.Pattern}> didn't match input=<{input}> (hex: {string.Join(" ", input.Select(c => $"{(int)c:X4}"))})");
+                            }
                         }
-                        catch (RegexMatchTimeoutException) when (engine != RegexEngine.NonBacktracking)
+                        catch (RegexMatchTimeoutException)
                         {
                             // SampleMatches can generate random inputs that trigger catastrophic
                             // backtracking in Interpreter/Compiled. That's expected behavior for

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -1346,6 +1346,17 @@ namespace System.Text.RegularExpressions.Tests
             // Test with something after the \z trailing anchor
             yield return (@"^1234\zx", "1234", RegexOptions.None, 0, 4, false, "");
             yield return (@"^1234\zx", "1234x", RegexOptions.None, 0, 5, false, "");
+
+            // Greedy loop with a subsumed literal followed by a nullable subsequent.
+            // The loop's character class includes the literal that follows it, and the
+            // subsequent element is nullable (min=0) and disjoint from the loop. The
+            // backtracking optimization must not reduce to a single position check because
+            // multiple backtrack positions can succeed when the post-literal part is nullable.
+            yield return (@"([0-9\w\+]+\.)|([0-9\w\+]+\+)([\(\)]*)", "2+_", RegexOptions.None, 0, 3, true, "2+");
+            yield return (@"([0-9\w\+]+\.)|([0-9\w\+]+\+)([\(\)]*)", "2+", RegexOptions.None, 0, 2, true, "2+");
+            yield return (@"([0-9\w\+]+\.)|([0-9\w\+]+\+)([\(\)]*)", "abc+xyz+()", RegexOptions.None, 0, 10, true, "abc+xyz+()");
+            yield return (@"[\w+]+\+\s*", "a+b+ ", RegexOptions.None, 0, 5, true, "a+b+ ");
+            yield return (@"\w+a\s*", "ba", RegexOptions.None, 0, 2, true, "ba");
         }
 
         [OuterLoop("Takes several seconds to run")]


### PR DESCRIPTION
This test was disabled because the non-backtring sampling implementation used to enables it was hanging. This fixes that: when all minterms lead to dead-end states, UndoTransition restores original states but the break condition never triggers; added transitionSucceeded tracking to break the loop.

The addition of another 18K tests (generated inputs to the "real-world" data set of regexes) highlighted a latent bug in CanReduceLoopBacktrackingToSinglePosition, fixed by changing its iterateNullableSubsequent from true to false. When the post-literal sequence is entirely nullable, any backtrack position can succeed (the nullable part matches empty), so reducing to a single position is incorrect. This caused Compiled/SourceGenerated to reject valid matches for some complex patterns, e.g. `([0-9\w\+]+\.)|([0-9\w\+]+\+)([\(\)]*)` with input `2+_`.

The PatternsDataSet_GenerateInputsWithNonBacktracking is now enabled.

Fixes https://github.com/dotnet/runtime/issues/79373