### PR TITLE
Add --tree arg to src/tests/run.[sh|cmd]

### DIFF
--- a/src/tests/Common/tests.targets
+++ b/src/tests/Common/tests.targets
@@ -44,7 +44,7 @@
           DependsOnTargets="FindBuildAllTestsAsStandaloneRunnerScripts;FindMergedTestDirectories">
     <Error  Text="Tests must be built to do a test run."
             Condition="'$(TestSubtree)' == '' and '@(StandaloneRunnerScripts)' == '' and '@(MergedTestWrapperScripts)' == ''" />
-    <Error  Text="No tests found under subtree '$(TestSubtree)'. Verify the path is relative to the test output directory (e.g. JIT/Regression)."
+    <Error  Text="No tests found under subtree '$(TestSubtree)'. Ensure tests have been built for this configuration/subtree and verify the subtree path is relative to the test output directory (e.g. JIT/Regression)."
             Condition="'$(TestSubtree)' != '' and '@(StandaloneRunnerScripts)' == '' and '@(MergedTestWrapperScripts)' == ''" />
     <Error  Text="Cannot run tests when both StandaloneRunnerScripts and MergedTestWrapperScripts are present. Either build the test tree as normal (merged runner) or with BuildAllTestsAsStandalone=true."
             Condition="'@(StandaloneRunnerScripts)' != '' and '@(MergedTestWrapperScripts)' != ''" />

--- a/src/tests/Common/tests.targets
+++ b/src/tests/Common/tests.targets
@@ -9,12 +9,15 @@
       <TestAssemblyDir Condition="'$(TestAssemblyDir)' == ''">$(BaseOutputPathWithConfig)\tests\</TestAssemblyDir>
       <__TestRunHtmlLog Condition="'$(__TestRunHtmlLog)' == ''">$(__LogsDir)\TestRun.html</__TestRunHtmlLog>
       <__TestRunXmlLog Condition="'$(__TestRunXmlLog)' == ''">$(__LogsDir)\TestRun.xml</__TestRunXmlLog>
+      <!-- When TestSubtree is set, only run tests under that subtree (e.g. JIT/Regression). -->
+      <_TestSearchRoot Condition="'$(TestSubtree)' == ''">$(BaseOutputPathWithConfig)\**</_TestSearchRoot>
+      <_TestSearchRoot Condition="'$(TestSubtree)' != ''">$(BaseOutputPathWithConfig)\$(TestSubtree)\**</_TestSearchRoot>
   </PropertyGroup>
 
 
   <Target Name="FindBuildAllTestsAsStandaloneRunnerScripts">
     <ItemGroup>
-      <_StandaloneRunnerMarker Include="$(BaseOutputPathWithConfig)\**\*.StandaloneTestRunner" />
+      <_StandaloneRunnerMarker Include="$(_TestSearchRoot)\*.StandaloneTestRunner" />
       <StandaloneRunnerScripts Include="$([System.IO.Path]::ChangeExtension('%(_StandaloneRunnerMarker.Identity)', '.$(TestScriptExtension)'))" />
       <MergedTestWrapperScripts Update="@(MergedTestWrapperScripts)">
         <RedirectOutputToFile>$([System.IO.Path]::ChangeExtension('%(MergedTestWrapperScripts.Identity)', '.log'))</RedirectOutputToFile>
@@ -24,7 +27,7 @@
 
   <Target Name="FindMergedTestDirectories">
     <ItemGroup>
-      <_MergedTestAssemblyMarkers Include="$(BaseOutputPathWithConfig)\**\*.MergedTestAssembly" />
+      <_MergedTestAssemblyMarkers Include="$(_TestSearchRoot)\*.MergedTestAssembly" />
       <MergedTestWrapperScripts Include="$([System.IO.Path]::ChangeExtension('%(_MergedTestAssemblyMarkers.Identity)', '.$(TestScriptExtension)'))" />
       <MergedTestWrapperScripts Update="@(MergedTestWrapperScripts)">
         <RedirectOutputToFile>$([System.IO.Path]::ChangeExtension('%(MergedTestWrapperScripts.Identity)', '.log'))</RedirectOutputToFile>

--- a/src/tests/Common/tests.targets
+++ b/src/tests/Common/tests.targets
@@ -43,7 +43,9 @@
   <Target Name="PrepareTestsToRun"
           DependsOnTargets="FindBuildAllTestsAsStandaloneRunnerScripts;FindMergedTestDirectories">
     <Error  Text="Tests must be built to do a test run."
-            Condition="'@(StandaloneRunnerScripts)' == '' and '@(MergedTestWrapperScripts)' == ''" />
+            Condition="'$(TestSubtree)' == '' and '@(StandaloneRunnerScripts)' == '' and '@(MergedTestWrapperScripts)' == ''" />
+    <Error  Text="No tests found under subtree '$(TestSubtree)'. Verify the path is relative to the test output directory (e.g. JIT/Regression)."
+            Condition="'$(TestSubtree)' != '' and '@(StandaloneRunnerScripts)' == '' and '@(MergedTestWrapperScripts)' == ''" />
     <Error  Text="Cannot run tests when both StandaloneRunnerScripts and MergedTestWrapperScripts are present. Either build the test tree as normal (merged runner) or with BuildAllTestsAsStandalone=true."
             Condition="'@(StandaloneRunnerScripts)' != '' and '@(MergedTestWrapperScripts)' != ''" />
   </Target>

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -79,7 +79,11 @@ if /i "%1" == "tieringtest"                             (set TieringTest=1&shift
 if /i "%1" == "runnativeaottests"                       (set RunNativeAot=1&shift&goto Arg_Loop)
 if /i "%1" == "interpreter"                             (set RunInterpreter=1&shift&goto Arg_Loop)
 if /i "%1" == "node"                                    (set RunWithNodeJS=1&shift&goto Arg_Loop)
-if /i "%1" == "tree"                                    (set __TreeSubtree=%2&shift&shift&goto Arg_Loop)
+@REM For tree, support '/', '-', and '--' prefixes like build.cmd
+set __treeArg=%~1
+set __treeArg=%__treeArg:/=%
+set __treeArg=%__treeArg:-=%
+if /i "%__treeArg%" == "tree"                           (set __TreeSubtree=%~2&shift&shift&goto Arg_Loop)
 
 if /i not "%1" == "msbuildargs" goto SkipMsbuildArgs
 :: All the rest of the args will be collected and passed directly to msbuild.
@@ -197,7 +201,7 @@ if defined RunWithNodeJS (
 )
 
 if defined __TreeSubtree (
-    set __RuntestPyArgs=%__RuntestPyArgs% --tree %__TreeSubtree%
+    set __RuntestPyArgs=%__RuntestPyArgs% --tree "%__TreeSubtree%"
 )
 
 REM Find python and set it to the variable PYTHON

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -79,6 +79,7 @@ if /i "%1" == "tieringtest"                             (set TieringTest=1&shift
 if /i "%1" == "runnativeaottests"                       (set RunNativeAot=1&shift&goto Arg_Loop)
 if /i "%1" == "interpreter"                             (set RunInterpreter=1&shift&goto Arg_Loop)
 if /i "%1" == "node"                                    (set RunWithNodeJS=1&shift&goto Arg_Loop)
+if /i "%1" == "tree"                                    (set __TreeSubtree=%2&shift&shift&goto Arg_Loop)
 
 if /i not "%1" == "msbuildargs" goto SkipMsbuildArgs
 :: All the rest of the args will be collected and passed directly to msbuild.
@@ -195,6 +196,10 @@ if defined RunWithNodeJS (
     set __RuntestPyArgs=%__RuntestPyArgs% --node
 )
 
+if defined __TreeSubtree (
+    set __RuntestPyArgs=%__RuntestPyArgs% --tree %__TreeSubtree%
+)
+
 REM Find python and set it to the variable PYTHON
 set _C=-c "import sys; sys.stdout.write(sys.executable)"
 (py -3 %_C% || py -2 %_C% || python3 %_C% || python2 %_C% || python %_C%) > %TEMP%\pythonlocation.txt 2> NUL
@@ -261,6 +266,7 @@ echo msbuildargs ^<args...^>     - Pass all subsequent args directly to msbuild 
 echo ^<CORE_ROOT^>               - Path to the runtime to test ^(if specified^).
 echo interpreter               - Runs the tests with the interpreter enabled.
 echo node                       - Runs the tests with NodeJS ^(wasm only^).
+echo tree ^<path^>               - Only run tests under the specified subtree ^(e.g. JIT/Regression^).
 echo.
 echo Note that arguments are not case-sensitive.
 echo.

--- a/src/tests/run.cmd
+++ b/src/tests/run.cmd
@@ -197,7 +197,7 @@ if defined RunWithNodeJS (
 )
 
 if defined __TreeSubtree (
-    set __RuntestPyArgs=%__RuntestPyArgs% --tree %__TreeSubtree%
+    set __RuntestPyArgs=%__RuntestPyArgs% --tree "%__TreeSubtree%"
 )
 
 REM Find python and set it to the variable PYTHON

--- a/src/tests/run.py
+++ b/src/tests/run.py
@@ -114,6 +114,7 @@ parser.add_argument("--limited_core_dumps", dest="limited_core_dumps", action="s
 parser.add_argument("--run_in_context", dest="run_in_context", action="store_true", default=False)
 parser.add_argument("--tiering_test", dest="tiering_test", action="store_true", default=False)
 parser.add_argument("--run_nativeaot_tests", dest="run_nativeaot_tests", action="store_true", default=False)
+parser.add_argument("--tree", dest="tree", default=None, help="Only run tests under the specified subtree (e.g. JIT/Regression).")
 
 ################################################################################
 # Globals
@@ -575,6 +576,9 @@ def call_msbuild(args):
     if args.limited_core_dumps:
         command += ["/p:LimitedCoreDumps=true"]
 
+    if args.tree:
+        command += ["/p:TestSubtree=%s" % args.tree]
+
     print(" ".join(command))
 
     sys.stdout.flush() # flush output before creating sub-process
@@ -1018,6 +1022,11 @@ def setup_args(args):
                               "run_nativeaot_tests",
                               lambda arg: True,
                               "Error setting run_nativeaot_tests")
+
+    coreclr_setup_args.verify(args,
+                              "tree",
+                              lambda arg: True,
+                              "Error setting tree")
 
     coreclr_setup_args.verify(args,
                               "interpreter",

--- a/src/tests/run.sh
+++ b/src/tests/run.sh
@@ -78,6 +78,12 @@ treeSubtree=
 
 for i in "$@"
 do
+    if [[ "$__nextTreeArg" == "1" ]]; then
+        treeSubtree="$i"
+        __nextTreeArg=
+        continue
+    fi
+
     case $i in
         -h|--help)
             print_usage
@@ -191,8 +197,14 @@ do
         --runnativeaottests)
             nativeaottest=1
             ;;
-        --tree=*)
+        --tree=*|-tree=*)
             treeSubtree=${i#*=}
+            ;;
+        --tree:*|-tree:*)
+            treeSubtree=${i#*:}
+            ;;
+        --tree|-tree)
+            __nextTreeArg=1
             ;;
         --interpreter)
             export RunInterpreter=1

--- a/src/tests/run.sh
+++ b/src/tests/run.sh
@@ -43,6 +43,7 @@ function print_usage {
     echo '  --runnativeaottests              : Run NativeAOT compiled tests'
     echo '  --interpreter                    : Runs the tests with the interpreter enabled'
     echo '  --node                           : Runs the tests with NodeJS (wasm only)'
+    echo '  --tree=<path>                    : Only run tests under the specified subtree (e.g. JIT/Regression)'
     echo '  --limitedDumpGeneration          : '
 }
 
@@ -73,6 +74,7 @@ runSequential=0
 runincontext=0
 tieringtest=0
 nativeaottest=0
+treeSubtree=
 
 for i in "$@"
 do
@@ -188,6 +190,9 @@ do
             ;;
         --runnativeaottests)
             nativeaottest=1
+            ;;
+        --tree=*)
+            treeSubtree=${i#*=}
             ;;
         --interpreter)
             export RunInterpreter=1
@@ -314,6 +319,11 @@ fi
 if [[ -n "$RunWithNodeJS" ]]; then
     echo "Running tests with NodeJS"
     runtestPyArguments+=("--node")
+fi
+
+if [[ -n "$treeSubtree" ]]; then
+    echo "Running tests under subtree   : ${treeSubtree}"
+    runtestPyArguments+=("--tree" "$treeSubtree")
 fi
 
 # Default to python3 if it is installed


### PR DESCRIPTION
Copilot (and me) often want to use the same --tree arg when running tests with ./src/tests/run.sh that is used when building, or only run a subset of tests that have been built. This would enable tighter workflows, fewer copilot digressions to figure out how to actually run the tests, and unify the scripts.

Add a `--tree` argument to `src/tests/run.[sh|cmd]` to limit the tests run and match the way tests are built.