### PR TITLE
Skip runtime-async compilation for RISC-V and LOONGARCH in crossgen2

### DIFF
--- a/src/coreclr/tools/Common/Compiler/ObjectWriter/PEObjectWriter.cs
+++ b/src/coreclr/tools/Common/Compiler/ObjectWriter/PEObjectWriter.cs
@@ -934,8 +934,11 @@ namespace ILCompiler.ObjectWriter
                             break;
                         case RelocType.IMAGE_REL_BASED_LOONGARCH64_PC:
                         {
-                            long targetAddress = symbolImageOffset + addend;
-                            long delta = (targetAddress - (long)(relocOffset & ~0xfff) + ((targetAddress & 0x800) << 1));
+                            if (addend != 0)
+                            {
+                                throw new NotSupportedException();
+                            }
+                            long delta = ((long)symbolImageOffset - (long)(relocOffset & ~0xfff) + ((long)(symbolImageOffset & 0x800) << 1));
                             Relocation.WriteValue(reloc.Type, pData, delta);
                             break;
                         }
@@ -944,8 +947,11 @@ namespace ILCompiler.ObjectWriter
                         case RelocType.IMAGE_REL_BASED_RISCV64_PCREL_I:
                         case RelocType.IMAGE_REL_BASED_RISCV64_PCREL_S:
                         {
-                            long targetAddress = symbolImageOffset + addend;
-                            long delta = targetAddress - (long)relocOffset;
+                            if (addend != 0)
+                            {
+                                throw new NotSupportedException();
+                            }
+                            long delta = (long)symbolImageOffset - (long)relocOffset;
                             Relocation.WriteValue(reloc.Type, pData, delta);
                             break;
                         }

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -578,6 +578,14 @@ namespace Internal.JitInterface
             {
                 return true;
             }
+            // Runtime-async methods produce relocations with non-zero addends that the RISC-V
+            // PEObjectWriter cannot resolve (PutRiscV64AuipcCombo requires zero-initialized
+            // offset fields). Skip compilation and let the runtime JIT these methods.
+            if ((methodNeedingCode.IsAsync || methodNeedingCode.IsAsyncVariant() || methodNeedingCode.IsCompilerGeneratedILBodyForAsync())
+                && methodNeedingCode.Context.Target.Architecture == TargetArchitecture.RiscV64)
+            {
+                return true;
+            }
             if (ShouldCodeNotBeCompiledIntoFinalImage(instructionSetSupport, methodNeedingCode))
             {
                 return true;

--- a/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
+++ b/src/coreclr/tools/aot/ILCompiler.ReadyToRun/JitInterface/CorInfoImpl.ReadyToRun.cs
@@ -579,10 +579,11 @@ namespace Internal.JitInterface
                 return true;
             }
             // Runtime-async methods produce relocations with non-zero addends that the RISC-V
-            // PEObjectWriter cannot resolve (PutRiscV64AuipcCombo requires zero-initialized
-            // offset fields). Skip compilation and let the runtime JIT these methods.
+            // and LoongArch64 PEObjectWriter cannot resolve (their Put* helpers require
+            // zero-initialized offset fields). Skip compilation and let the runtime JIT
+            // these methods.
             if ((methodNeedingCode.IsAsync || methodNeedingCode.IsAsyncVariant() || methodNeedingCode.IsCompilerGeneratedILBodyForAsync())
-                && methodNeedingCode.Context.Target.Architecture == TargetArchitecture.RiscV64)
+                && methodNeedingCode.Context.Target.Architecture is TargetArchitecture.RiscV64 or TargetArchitecture.LoongArch64)
             {
                 return true;
             }


### PR DESCRIPTION
RISC-V's PutRiscV64AuipcCombo uses bitwise OR (|=) to encode offsets into instruction pairs and asserts the offset fields are zero beforehand. Runtime-async methods produce relocations with non-zero addends that are pre-encoded into the instruction bytes, causing this assertion to fail during PEObjectWriter.ResolveRelocations.

Revert the PEObjectWriter workaround from the previous commit (which removed the addend!=0 throws but didn't address the underlying encoding issue) and instead skip all async-related methods for RISC-V in ShouldSkipCompilation. These methods will be JIT-compiled at runtime.