### PR TITLE
clang-21 on macos fixes

### DIFF
--- a/src/native/libs/System.Globalization.Native/CMakeLists.txt
+++ b/src/native/libs/System.Globalization.Native/CMakeLists.txt
@@ -16,6 +16,7 @@ if(CLR_CMAKE_TARGET_UNIX OR CLR_CMAKE_TARGET_WASI)
     add_compile_options(-Wno-documentation)
     add_compile_options(-Wno-documentation-unknown-command)
     add_compile_options(-Wno-reserved-identifier)
+    add_compile_options(-Wno-c++-keyword)
 
     # Workaround for https://unicode-org.atlassian.net/browse/ICU-20601
     add_compile_options(-Wno-extra-semi-stmt)

--- a/src/native/libs/System.Native/pal_environment.m
+++ b/src/native/libs/System.Native/pal_environment.m
@@ -29,7 +29,7 @@ static void get_environ_helper(const void *key, const void *value, void *context
     size_t utf8_value_length = strlen(utf8_value);
     char *key_value_pair;
 
-    key_value_pair = malloc(utf8_key_length + utf8_value_length + 2);
+    key_value_pair = (char*)malloc(utf8_key_length + utf8_value_length + 2);
     if (key_value_pair != NULL)
     {
         strcpy(key_value_pair, utf8_key);

--- a/src/native/libs/System.Native/pal_memory.c
+++ b/src/native/libs/System.Native/pal_memory.c
@@ -19,6 +19,13 @@
     #define MALLOC_SIZE(s) malloc_usable_size(s)
 #endif
 
+// These functions look like simple wrappers around the standard C library functions, but they are actually
+// exports to managed code and not allocation functions for unmanaged code. Therefore we suppress the warnings.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wallocator-wrappers"
+#endif // __clang__
+
 void* SystemNative_AlignedAlloc(uintptr_t alignment, uintptr_t size)
 {
 #if HAVE_ALIGNED_ALLOC
@@ -86,3 +93,7 @@ void* SystemNative_Realloc(void* ptr, uintptr_t new_size)
 {
     return realloc(ptr, new_size);
 }
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif // __clang__

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -3041,8 +3041,17 @@ int32_t SystemNative_Select(int* readFds, int readFdsCount, int* writeFds, int w
         readSetPtr = readFdsCount == 0 ? NULL : (fd_set*)calloc(fdSetCount, fdSetSize);
         writeSetPtr = writeFdsCount == 0 ? NULL : (fd_set*)calloc(fdSetCount, fdSetSize);
         errorSetPtr = errorFdsCount == 0 ? NULL : (fd_set*)calloc(fdSetCount, fdSetSize);
-    }
 
+        if ((readFdsCount > 0 && readSetPtr == NULL)
+            || (writeFdsCount > 0 && writeSetPtr == NULL)
+            || (errorFdsCount > 0 && errorSetPtr == NULL))
+        {
+            free(readSetPtr);
+            free(writeSetPtr);
+            free(errorSetPtr);
+            return Error_ENOMEM;
+        }
+    }
 
     struct timeval timeout;
     timeout.tv_sec = microseconds / 1000000;

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -3035,7 +3035,9 @@ int32_t SystemNative_Select(int* readFds, int readFdsCount, int* writeFds, int w
     {
         // Since this code later calls select(maxFd + 1, ...) and sets bits for file descriptor values up to maxFd,
         // the allocation needs to cover maxFd + 1 bits.
-        assert(maxFd < INT_MAX - 1);
+        if (maxFd > INT_MAX - 1)
+            return Error_EINVAL;
+
         size_t fdSetCount = __DARWIN_howmany(maxFd + 1, __DARWIN_NFDBITS);
         size_t fdSetSize = sizeof(((fd_set*)0)->fds_bits[0]);
         readSetPtr = readFdsCount == 0 ? NULL : (fd_set*)calloc(fdSetCount, fdSetSize);

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -3080,6 +3080,12 @@ int32_t SystemNative_Select(int* readFds, int readFdsCount, int* writeFds, int w
 
     if (*triggered < 0)
     {
+        if (maxFd >= FD_SETSIZE)
+        {
+            free(readSetPtr);
+            free(writeSetPtr);
+            free(errorSetPtr);
+        }
         return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -3033,9 +3033,9 @@ int32_t SystemNative_Select(int* readFds, int readFdsCount, int* writeFds, int w
     }
     else
     {
-       readSetPtr = readFdsCount == 0 ? NULL : calloc( __DARWIN_howmany(maxFd, __DARWIN_NFDBITS),  sizeof(int32_t));
-       writeSetPtr = writeFdsCount == 0 ? NULL : calloc( __DARWIN_howmany(maxFd, __DARWIN_NFDBITS),  sizeof(int32_t));
-       errorSetPtr = errorFdsCount == 0 ? NULL : calloc( __DARWIN_howmany(maxFd, __DARWIN_NFDBITS),  sizeof(int32_t));
+       readSetPtr = readFdsCount == 0 ? NULL : (fd_set*)calloc( __DARWIN_howmany(maxFd, __DARWIN_NFDBITS),  sizeof(int32_t));
+       writeSetPtr = writeFdsCount == 0 ? NULL : (fd_set*)calloc( __DARWIN_howmany(maxFd, __DARWIN_NFDBITS),  sizeof(int32_t));
+       errorSetPtr = errorFdsCount == 0 ? NULL : (fd_set*)calloc( __DARWIN_howmany(maxFd, __DARWIN_NFDBITS),  sizeof(int32_t));
     }
 
 

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -3042,9 +3042,9 @@ int32_t SystemNative_Select(int* readFds, int readFdsCount, int* writeFds, int w
         writeSetPtr = writeFdsCount == 0 ? NULL : (fd_set*)calloc(fdSetCount, fdSetSize);
         errorSetPtr = errorFdsCount == 0 ? NULL : (fd_set*)calloc(fdSetCount, fdSetSize);
 
-        if ((readFdsCount > 0 && readSetPtr == NULL)
-            || (writeFdsCount > 0 && writeSetPtr == NULL)
-            || (errorFdsCount > 0 && errorSetPtr == NULL))
+        if ((readFdsCount != 0 && readSetPtr == NULL)
+            || (writeFdsCount != 0 && writeSetPtr == NULL)
+            || (errorFdsCount != 0 && errorSetPtr == NULL))
         {
             free(readSetPtr);
             free(writeSetPtr);

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -3034,8 +3034,7 @@ int32_t SystemNative_Select(int* readFds, int readFdsCount, int* writeFds, int w
     else
     {
         // Since this code later calls select(maxFd + 1, ...) and sets bits for file descriptor values up to maxFd,
-        // the allocation needs to cover maxFd + 1 bits. If maxFd is an exact multiple of __DARWIN_NFDBITS,
-        // __DARWIN_FD_SET(maxFd, ...) can index past the end of the allocated buffer (potential memory corruption).
+        // the allocation needs to cover maxFd + 1 bits.
         assert(maxFd < INT_MAX - 1);
         size_t fdSetCount = __DARWIN_howmany(maxFd + 1, __DARWIN_NFDBITS);
         size_t fdSetSize = sizeof(((fd_set*)0)->fds_bits[0]);

--- a/src/native/libs/System.Native/pal_networking.c
+++ b/src/native/libs/System.Native/pal_networking.c
@@ -3033,9 +3033,15 @@ int32_t SystemNative_Select(int* readFds, int readFdsCount, int* writeFds, int w
     }
     else
     {
-       readSetPtr = readFdsCount == 0 ? NULL : (fd_set*)calloc( __DARWIN_howmany(maxFd, __DARWIN_NFDBITS),  sizeof(int32_t));
-       writeSetPtr = writeFdsCount == 0 ? NULL : (fd_set*)calloc( __DARWIN_howmany(maxFd, __DARWIN_NFDBITS),  sizeof(int32_t));
-       errorSetPtr = errorFdsCount == 0 ? NULL : (fd_set*)calloc( __DARWIN_howmany(maxFd, __DARWIN_NFDBITS),  sizeof(int32_t));
+        // Since this code later calls select(maxFd + 1, ...) and sets bits for file descriptor values up to maxFd,
+        // the allocation needs to cover maxFd + 1 bits. If maxFd is an exact multiple of __DARWIN_NFDBITS,
+        // __DARWIN_FD_SET(maxFd, ...) can index past the end of the allocated buffer (potential memory corruption).
+        assert(maxFd < INT_MAX - 1);
+        size_t fdSetCount = __DARWIN_howmany(maxFd + 1, __DARWIN_NFDBITS);
+        size_t fdSetSize = sizeof(((fd_set*)0)->fds_bits[0]);
+        readSetPtr = readFdsCount == 0 ? NULL : (fd_set*)calloc(fdSetCount, fdSetSize);
+        writeSetPtr = writeFdsCount == 0 ? NULL : (fd_set*)calloc(fdSetCount, fdSetSize);
+        errorSetPtr = errorFdsCount == 0 ? NULL : (fd_set*)calloc(fdSetCount, fdSetSize);
     }
 
 

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_ecc.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_ecc.c
@@ -56,7 +56,7 @@ int32_t AppleCryptoNative_EccGetKeySizeInBits(SecKeyRef publicKey)
     if (attributes == NULL)
         return 0;
 
-    CFNumberRef cfSize = CFDictionaryGetValue(attributes, kSecAttrKeySizeInBits);
+    CFNumberRef cfSize = (CFNumberRef)CFDictionaryGetValue(attributes, kSecAttrKeySizeInBits);
     int size = 0;
 
     if (cfSize != NULL)

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_networkframework.m
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_networkframework.m
@@ -245,7 +245,10 @@ PALEXPORT nw_connection_t AppleCryptoNative_NwConnectionCreate(int32_t isServer,
         void* identity = _challengeFunc(context, acceptableIssuers);
 
         // Clean up
-        CFRelease(acceptableIssuers);
+        if (acceptableIssuers != NULL)
+        {
+            CFRelease(acceptableIssuers);
+        }
 
         if (identity != NULL)
         {

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_networkframework.m
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_networkframework.m
@@ -229,7 +229,10 @@ PALEXPORT nw_connection_t AppleCryptoNative_NwConnectionCreate(int32_t isServer,
                     CFDataRef dnData = CFDataCreate(NULL, (const UInt8*)dnBytes, (CFIndex)dnLength);
                     if (dnData != NULL)
                     {
-                        CFArrayAppendValue(acceptableIssuers, dnData);
+                        if (acceptableIssuers != NULL)
+                        {
+                            CFArrayAppendValue(acceptableIssuers, dnData);
+                        }
                         CFRelease(dnData);
                     }
                 }

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_networkframework.m
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_networkframework.m
@@ -6,7 +6,7 @@
 // but we need to perform TLS without an actual connection so that we can expose
 // it as the SslStream abstraction. This implementation uses a workaround: we
 // create a dummy UDP connection that will never be used.
-// 
+//
 // The trick works by layering a custom framer on top of this dummy connection,
 // then adding TLS on top of the framer. The framer intercepts the raw TLS data
 // and exposes it to SslStream, preventing it from ever reaching the underlying
@@ -109,7 +109,7 @@ static CFStringRef ExtractNetworkFrameworkError(nw_error_t error, PAL_NetworkFra
         }
         return NULL;
     }
-    
+
     outError->errorCode = nw_error_get_error_code(error);
     nw_error_domain_t domain = nw_error_get_error_domain(error);
     outError->errorDomain = (int32_t)domain;
@@ -119,7 +119,7 @@ static CFStringRef ExtractNetworkFrameworkError(nw_error_t error, PAL_NetworkFra
         outError->errorMessage = strerror(outError->errorCode);
         return NULL;
     }
-    
+
     // Get error message from CoreFoundation error if available
     CFStringRef descriptionToRelease = NULL;
     CFErrorRef cfError = nw_error_copy_cf_error(error);
@@ -146,7 +146,7 @@ static CFStringRef ExtractNetworkFrameworkError(nw_error_t error, PAL_NetworkFra
     {
         outError->errorMessage = NULL;
     }
-    
+
     return descriptionToRelease;
 }
 
@@ -201,7 +201,7 @@ PALEXPORT nw_connection_t AppleCryptoNative_NwConnectionCreate(int32_t isServer,
         {
             uint16_t cipherSuite = (uint16_t)cipherSuites[i];
             LOG_INFO(context, "Appending cipher suite: 0x%04x", cipherSuite);
-            sec_protocol_options_append_tls_ciphersuite(sec_options, cipherSuite);
+            sec_protocol_options_append_tls_ciphersuite(sec_options, (tls_ciphersuite_t)cipherSuite);
         }
     }
 
@@ -210,12 +210,12 @@ PALEXPORT nw_connection_t AppleCryptoNative_NwConnectionCreate(int32_t isServer,
     {
         // Extract acceptable issuers from metadata
         CFMutableArrayRef acceptableIssuers = NULL;
-        
+
         if (metadata != NULL)
         {
             // Create array to hold distinguished names
             acceptableIssuers = CFArrayCreateMutable(NULL, 0, &kCFTypeArrayCallBacks);
-            
+
             // Access distinguished names from the metadata
             sec_protocol_metadata_access_distinguished_names(metadata, ^(dispatch_data_t dn)
             {
@@ -223,9 +223,9 @@ PALEXPORT nw_connection_t AppleCryptoNative_NwConnectionCreate(int32_t isServer,
                 const void* dnBytes = NULL;
                 size_t dnLength = 0;
                 dispatch_data_t contiguousDN = dispatch_data_create_map(dn, &dnBytes, &dnLength);
-                
+
                 if (dnBytes != NULL && dnLength > 0)
-                {   
+                {
                     CFDataRef dnData = CFDataCreate(NULL, (const UInt8*)dnBytes, (CFIndex)dnLength);
                     if (dnData != NULL)
                     {
@@ -233,20 +233,20 @@ PALEXPORT nw_connection_t AppleCryptoNative_NwConnectionCreate(int32_t isServer,
                         CFRelease(dnData);
                     }
                 }
-                
+
                 if (contiguousDN != NULL)
                 {
                     dispatch_release(contiguousDN);
                 }
             });
         }
-        
+
         // Call the managed callback to get the client identity
         void* identity = _challengeFunc(context, acceptableIssuers);
-        
+
         // Clean up
         CFRelease(acceptableIssuers);
-        
+
         if (identity != NULL)
         {
             // Convert to sec_identity_t and set it
@@ -260,7 +260,7 @@ PALEXPORT nw_connection_t AppleCryptoNative_NwConnectionCreate(int32_t isServer,
 
             return;
         }
-        
+
         complete(NULL);
     }, _tlsQueue);
 
@@ -370,7 +370,7 @@ PALEXPORT int32_t AppleCryptoNative_NwFramerDeliverInput(nw_framer_t framer, voi
         return -1;
     }
 
-    nw_framer_async(framer, ^(void) 
+    nw_framer_async(framer, ^(void)
     {
         nw_framer_deliver_input(framer, buffer, (size_t)bufferLength, message, bufferLength > 0 ? FALSE : TRUE);
         completionCallback(context, NULL);
@@ -423,7 +423,7 @@ PALEXPORT int AppleCryptoNative_NwConnectionStart(nw_connection_t connection, vo
             }
             break;
         }
-        
+
         // Release CFString if we created one
         if (cfStringToRelease != NULL)
         {
@@ -457,14 +457,14 @@ PALEXPORT void AppleCryptoNative_NwConnectionSend(nw_connection_t connection, vo
         PAL_NetworkFrameworkError errorInfo;
         CFStringRef cfStringToRelease = ExtractNetworkFrameworkError(error, &errorInfo);
         completionCallback(context, error != NULL ? &errorInfo : NULL);
-        
+
         // Release CFString if we created one
         if (cfStringToRelease != NULL)
         {
             CFRelease(cfStringToRelease);
         }
     });
-    
+
     // Release our reference to dispatch_data - nw_connection_send retains it
     dispatch_release(data);
 }

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -235,7 +235,7 @@ int32_t AppleCryptoNative_SSLSetALPNProtocol(SSLContextRef sslContext, void* pro
     if (sslContext == NULL || protocol == NULL || length <= 0 || pOSStatus == NULL)
         return -1;
 
-    CFStringRef value = CFStringCreateWithBytes(NULL, protocol, length, kCFStringEncodingASCII, 0);
+    CFStringRef value = CFStringCreateWithBytes(NULL, (UInt8*)protocol, length, kCFStringEncodingASCII, 0);
     if (!value)
     {
         *pOSStatus = errSecMemoryError;
@@ -294,7 +294,7 @@ int32_t AppleCryptoNative_SslGetAlpnSelected(SSLContextRef sslContext, CFDataRef
     if (osStatus == noErr && protocols != NULL && CFArrayGetCount(protocols) > 0)
     {
         *protocol =
-            CFStringCreateExternalRepresentation(NULL, CFArrayGetValueAtIndex(protocols, 0), kCFStringEncodingASCII, 0);
+            CFStringCreateExternalRepresentation(NULL, (CFStringRef)CFArrayGetValueAtIndex(protocols, 0), kCFStringEncodingASCII, 0);
     }
 
     if (protocols)

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_ssl.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_ssl.c
@@ -230,12 +230,12 @@ int32_t AppleCryptoNative_SSLSetALPNProtocols(SSLContextRef sslContext,
     return *pOSStatus == noErr;
 }
 
-int32_t AppleCryptoNative_SSLSetALPNProtocol(SSLContextRef sslContext, void* protocol, int length, int32_t* pOSStatus)
+int32_t AppleCryptoNative_SSLSetALPNProtocol(SSLContextRef sslContext, const void* protocol, int length, int32_t* pOSStatus)
 {
     if (sslContext == NULL || protocol == NULL || length <= 0 || pOSStatus == NULL)
         return -1;
 
-    CFStringRef value = CFStringCreateWithBytes(NULL, (UInt8*)protocol, length, kCFStringEncodingASCII, 0);
+    CFStringRef value = CFStringCreateWithBytes(NULL, (const UInt8*)protocol, length, kCFStringEncodingASCII, 0);
     if (!value)
     {
         *pOSStatus = errSecMemoryError;

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_ssl.h
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_ssl.h
@@ -177,7 +177,7 @@ Returns 1 on success, 0 on failure, other values for invalid state.
 Output:
 pOSStatus: Receives the value from SSLSetALPNData()
 */
-PALEXPORT int32_t AppleCryptoNative_SSLSetALPNProtocol(SSLContextRef sslContext, void* protocol, int length, int32_t* pOSStatus);
+PALEXPORT int32_t AppleCryptoNative_SSLSetALPNProtocol(SSLContextRef sslContext, const void* protocol, int length, int32_t* pOSStatus);
 
 /*
 Get negotiated protocol value from ServerHello.

--- a/src/native/libs/System.Security.Cryptography.Native.Apple/pal_x509chain.c
+++ b/src/native/libs/System.Security.Cryptography.Native.Apple/pal_x509chain.c
@@ -212,7 +212,7 @@ static void MergeStatusCodes(CFTypeRef key, CFTypeRef value, void* context)
 #if defined DEBUG || defined DEBUGGING_UNKNOWN_VALUE
         CFIndex keyStringLength = CFStringGetLength(keyString);
         CFIndex maxEncodedLength = CFStringGetMaximumSizeForEncoding(keyStringLength, kCFStringEncodingUTF8) + 1;
-        char* keyStringBuffer = malloc((size_t)maxEncodedLength);
+        char* keyStringBuffer = (char*)malloc((size_t)maxEncodedLength);
 
         if (keyStringBuffer)
         {

--- a/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.swift
+++ b/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.swift
@@ -32,6 +32,7 @@ public func getMyErrorMessage(from error: Error, messageLength: inout Int32) -> 
             return UnsafePointer(buffer.baseAddress!)
         }
     }
+    messageLength = 0
     return nil
 }
 

--- a/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.swift
+++ b/src/tests/Interop/Swift/SwiftErrorHandling/SwiftErrorHandling.swift
@@ -4,13 +4,13 @@
 import Foundation
 
 public enum MyError: Error {
-    case runtimeError(message: NSString)
+    case runtimeError(message: String)
 }
 
-var errorMessage: NSString = ""
+var errorMessage: String = ""
 
 public func setMyErrorMessage(message: UnsafePointer<unichar>, length: Int32) {
-    errorMessage = NSString(characters: message, length: Int(length))
+    errorMessage = NSString(characters: message, length: Int(length)) as String
 }
 
 public func conditionallyThrowError(willThrow: Int32) throws -> Int32 {
@@ -25,9 +25,10 @@ public func getMyErrorMessage(from error: Error, messageLength: inout Int32) -> 
     if let myError = error as? MyError {
         switch myError {
         case .runtimeError(let message):
-            let buffer = UnsafeMutableBufferPointer<unichar>.allocate(capacity: message.length)
-            message.getCharacters(buffer.baseAddress!, range: NSRange(location: 0, length: message.length))
-            messageLength = Int32(message.length)
+            let nsMessage = message as NSString
+            let buffer = UnsafeMutableBufferPointer<unichar>.allocate(capacity: nsMessage.length)
+            nsMessage.getCharacters(buffer.baseAddress!, range: NSRange(location: 0, length: nsMessage.length))
+            messageLength = Int32(nsMessage.length)
             return UnsafePointer(buffer.baseAddress!)
         }
     }


### PR DESCRIPTION
Addresses various build failures when compiling with the latest Xcode.

```
% clang --version
Apple clang version 21.0.0 (clang-2100.0.123.102)
Target: arm64-apple-darwin25.4.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

See https://github.com/dotnet/runtime/issues/119706#issuecomment-4145857457

Clang 21 changes for `-Wc++-keyword` - https://releases.llvm.org/21.1.0/tools/clang/docs/ReleaseNotes.html#id11
Partially related https://github.com/unicode-org/icu/pull/2913