### PR TITLE
Escape U+2028/U+2029 in regex source generator XML doc comments

### DIFF
--- a/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
+++ b/src/libraries/System.Text.RegularExpressions/gen/RegexGenerator.Emitter.cs
@@ -43,7 +43,8 @@ namespace System.Text.RegularExpressions.Generator
                         case '>': sb.Append("&gt;"); break;
 
                         // Propagate all other valid XML characters as-is. Control chars are considered invalid.
-                        case (>= 0x20 and <= 0x7F) or (>= 0xA0 and <= 0xD7FF) or (>= 0xE000 and <= 0xFFFD): sb.Append(c); break;
+                        // U+2028 and U+2029 are valid XML but are C# line terminators, so they'd break /// comments.
+                        case (>= 0x20 and <= 0x7F) or (>= 0xA0 and <= 0xD7FF and not 0x2028 and not 0x2029) or (>= 0xE000 and <= 0xFFFD): sb.Append(c); break;
 
                         // Use Unicode escape sequences for everything else.
                         default: sb.Append($"\\u{(int)c:X4}"); break;

--- a/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
+++ b/src/libraries/System.Text.RegularExpressions/tests/FunctionalTests/Regex.Match.Tests.cs
@@ -46,6 +46,12 @@ namespace System.Text.RegularExpressions.Tests
             // Testing control character escapes???: "2", "(\u0032)"
             yield return ("(\u0034)", "4", RegexOptions.None, 0, 1, true, "4");
 
+            // Patterns with literal U+2028, U+2029, and U+FFFE to validate source generator XML doc comment escaping
+            yield return ("ab\u2028", "ab\u2028", RegexOptions.None, 0, 3, true, "ab\u2028");
+            yield return ("ab\u2029", "ab\u2029", RegexOptions.None, 0, 3, true, "ab\u2029");
+            yield return ("ab\uFFFE", "ab\uFFFE", RegexOptions.None, 0, 3, true, "ab\uFFFE");
+            yield return ("[\u2028\u2029\uFFFE]", "x\u2029y", RegexOptions.None, 0, 3, true, "\u2029");
+
             // Using long loop prefix
             yield return (@"a{10}", new string('a', 10), RegexOptions.None, 0, 10, true, new string('a', 10));
             yield return (@"a{100}", new string('a', 100), RegexOptions.None, 0, 100, true, new string('a', 100));


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.

U+2028 (Line Separator) and U+2029 (Paragraph Separator) are valid XML characters but are C# line terminators. When the regex source generator emits these literally into `///` doc comments, the compiler sees a line break mid-comment, and the continuation isn't a `///` line — causing XML parse errors and `CS1519`/`CS1056` compilation failures in the generated code.

The fix excludes these two characters from the literal pass-through range in `EscapeXmlComment` so they are escaped as `\u2028` and `\u2029` text instead. All other C# line terminators (CR, LF, NEL) were already handled by falling outside the existing ranges.

### Changes

- **`RegexGenerator.Emitter.cs`**: Add `not 0x2028 and not 0x2029` to the valid-character pass-through pattern in `EscapeXmlComment`.
- **`Regex.Match.Tests.cs`**: Add test cases with literal `\u2028`, `\u2029`, and `\uFFFE` in regex patterns, exercised across all engines including the source generator.
