### PR TITLE
Use await Task.WhenAll in channel tests to fix ARM64 hang

### DIFF
--- a/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
+++ b/src/libraries/System.Threading.Channels/tests/BoundedChannelTests.cs
@@ -515,12 +515,12 @@ namespace System.Threading.Channels.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(10000)]
-        public void SingleProducerConsumer_ConcurrentReadWrite_WithBufferedCapacity_Success(int bufferedCapacity)
+        public async Task SingleProducerConsumer_ConcurrentReadWrite_WithBufferedCapacity_Success(int bufferedCapacity)
         {
             var c = Channel.CreateBounded<int>(bufferedCapacity);
 
             const int NumItems = 10000;
-            Task.WaitAll(
+            await Task.WhenAll(
                 Task.Run(async () =>
                 {
                     for (int i = 0; i < NumItems; i++)
@@ -541,7 +541,7 @@ namespace System.Threading.Channels.Tests
         [InlineData(1)]
         [InlineData(10)]
         [InlineData(10000)]
-        public void ManyProducerConsumer_ConcurrentReadWrite_WithBufferedCapacity_Success(int bufferedCapacity)
+        public async Task ManyProducerConsumer_ConcurrentReadWrite_WithBufferedCapacity_Success(int bufferedCapacity)
         {
             var c = Channel.CreateBounded<int>(bufferedCapacity);
 
@@ -590,7 +590,7 @@ namespace System.Threading.Channels.Tests
                 });
             }
 
-            Task.WaitAll(tasks);
+            await Task.WhenAll(tasks);
             Assert.Equal((NumItems * (NumItems + 1L)) / 2, readTotal);
         }
 

--- a/src/libraries/System.Threading.Channels/tests/ChannelTestBase.cs
+++ b/src/libraries/System.Threading.Channels/tests/ChannelTestBase.cs
@@ -144,12 +144,12 @@ namespace System.Threading.Channels.Tests
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/60472", TestPlatforms.iOS | TestPlatforms.tvOS)]
-        public void SingleProducerConsumer_ConcurrentReadWrite_Success()
+        public async Task SingleProducerConsumer_ConcurrentReadWrite_Success()
         {
             Channel<int> c = CreateChannel();
 
             const int NumItems = 100000;
-            Task.WaitAll(
+            await Task.WhenAll(
                 Task.Run(async () =>
                 {
                     for (int i = 0; i < NumItems; i++)
@@ -168,13 +168,13 @@ namespace System.Threading.Channels.Tests
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
         [ActiveIssue("https://github.com/dotnet/runtime/issues/60472", TestPlatforms.iOS | TestPlatforms.tvOS)]
-        public void SingleProducerConsumer_PingPong_Success()
+        public async Task SingleProducerConsumer_PingPong_Success()
         {
             Channel<int> c1 = CreateChannel();
             Channel<int> c2 = CreateChannel();
 
             const int NumItems = 100000;
-            Task.WaitAll(
+            await Task.WhenAll(
                 Task.Run(async () =>
                 {
                     for (int i = 0; i < NumItems; i++)
@@ -198,7 +198,7 @@ namespace System.Threading.Channels.Tests
         [InlineData(1, 10)]
         [InlineData(10, 1)]
         [InlineData(10, 10)]
-        public void ManyProducerConsumer_ConcurrentReadWrite_Success(int numReaders, int numWriters)
+        public async Task ManyProducerConsumer_ConcurrentReadWrite_Success(int numReaders, int numWriters)
         {
             if (RequiresSingleReader && numReaders > 1)
             {
@@ -254,7 +254,7 @@ namespace System.Threading.Channels.Tests
                 });
             }
 
-            Task.WaitAll(tasks);
+            await Task.WhenAll(tasks);
             Assert.Equal((NumItems * (NumItems + 1L)) / 2, readTotal);
         }
 

--- a/src/libraries/System.Threading.Channels/tests/Stress.cs
+++ b/src/libraries/System.Threading.Channels/tests/Stress.cs
@@ -174,7 +174,7 @@ namespace System.Threading.Channels.Tests
 
         [ConditionalTheory(typeof(TestEnvironment), nameof(TestEnvironment.IsStressModeEnabled))]
         [MemberData(nameof(ReadWriteVariations_TestData))]
-        public void ReadWriteVariations(
+        public async Task ReadWriteVariations(
             Func<ChannelOptions, Channel<int>> channelCreator,
             ChannelOptions options,
             Func<ChannelReader<int>, Task<bool>> readDelegate,
@@ -247,7 +247,7 @@ namespace System.Threading.Channels.Tests
                 }));
             }
 
-            Task.WaitAll(taskList.ToArray());
+            await Task.WhenAll(taskList.ToArray());
 
             if (shouldReadAllWrittenValues)
             {

--- a/src/libraries/System.Threading.Channels/tests/UnboundedChannelTests.cs
+++ b/src/libraries/System.Threading.Channels/tests/UnboundedChannelTests.cs
@@ -260,12 +260,12 @@ namespace System.Threading.Channels.Tests
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
-        public void Stress_TryWrite_TryRead()
+        public async Task Stress_TryWrite_TryRead()
         {
             const int NumItems = 3000000;
             Channel<int> c = CreateChannel();
 
-            Task.WaitAll(
+            await Task.WhenAll(
                 Task.Run(async () =>
                 {
                     int received = 0;


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the help of GitHub Copilot.

Use `await Task.WhenAll` instead of `Task.WaitAll` in seven channel test methods across four files to avoid blocking a thread pool thread for the entire test duration.

On resource-constrained ARM64 Helix machines, the blocked thread contributes to thread pool starvation, causing `UnboundedPrioritizedChannelTests.SingleProducerConsumer_PingPong_Success` to hang indefinitely. The priority channel variant is uniquely affected because `UnboundedPriorityChannel` must lock on every operation (`PriorityQueue` is not thread-safe), unlike `UnboundedChannel` which has a lock-free `ConcurrentQueue.TryDequeue` fast path. This means completions more frequently require thread pool dispatches, and with `Task.WaitAll` consuming a thread, starvation occurs.

The fix does not change what the tests verify — the concurrent producer/consumer work still runs on `Task.Run` thread pool threads. Only the test harness wait changes from blocking to async.

Changed methods:
- `ChannelTestBase.SingleProducerConsumer_ConcurrentReadWrite_Success`
- `ChannelTestBase.SingleProducerConsumer_PingPong_Success`
- `ChannelTestBase.ManyProducerConsumer_ConcurrentReadWrite_Success`
- `BoundedChannelTests.SingleProducerConsumer_ConcurrentReadWrite_WithBufferedCapacity_Success`
- `BoundedChannelTests.ManyProducerConsumer_ConcurrentReadWrite_WithBufferedCapacity_Success`
- `UnboundedChannelTests.Stress_TryWrite_TryRead`
- `Stress.ReadWriteVariations`

Closes #121873
