### PR TITLE
Test adding coop + debugger controller lock verification

### DIFF
--- a/src/coreclr/vm/crst.cpp
+++ b/src/coreclr/vm/crst.cpp
@@ -688,6 +688,21 @@ BOOL CrstBase::IsSafeToTake()
     return fSafe;
 }
 
+bool CrstBase::IsTypeHeldByCurrentThread(CrstType type)
+{
+    STATIC_CONTRACT_NOTHROW;
+    STATIC_CONTRACT_GC_NOTRIGGER;
+    STATIC_CONTRACT_DEBUG_ONLY;
+
+    for (CrstBase *pCrst = t_pOwnedCrstsChain; pCrst != nullptr; pCrst = pCrst->m_next)
+    {
+        if (pCrst->m_crstType == type)
+            return true;
+    }
+
+    return false;
+}
+
 #endif // _DEBUG
 
 CrstBase::CrstAndForbidSuspendForDebuggerHolder::CrstAndForbidSuspendForDebuggerHolder(CrstBase *pCrst)

--- a/src/coreclr/vm/crst.h
+++ b/src/coreclr/vm/crst.h
@@ -248,6 +248,8 @@ public:
         return m_holderthreadid;
     }
 
+    static bool IsTypeHeldByCurrentThread(CrstType type);
+
 #endif //_DEBUG
 
     //-----------------------------------------------------------------

--- a/src/coreclr/vm/threads.h
+++ b/src/coreclr/vm/threads.h
@@ -1253,6 +1253,18 @@ public:
         // spinning waiting for GC
         _ASSERTE ((m_StateNC & Thread::TSNC_OwnsSpinLock) == 0);
 
+        // Entering cooperative mode while holding the DebuggerController lock is
+        // unsafe. RareDisablePreemptiveGC may block in WaitSuspendEvents if a GC
+        // or debugger suspension is pending, while the held lock prevents other
+        // threads from reaching a safe point — classic ABBA deadlock.
+        // EnablePreemptiveGC (coop→preemptive) is a single non-blocking store,
+        // but any code path that toggles preemptive→cooperative under this lock
+        // (e.g., HashMap::LookupValue via GCCoopHackNoThread, or
+        // FindOrCreateInitAndAddJitInfo → Init → InitializeFromStartAddress)
+        // will hit this assert on the re-entry into cooperative mode.
+        _ASSERTE_MSG(!CrstBase::IsTypeHeldByCurrentThread(CrstDebuggerController),
+            "GC cooperative mode transition while holding DebuggerController lock causes deadlocks");
+
 #ifdef ENABLE_CONTRACTS_IMPL
         TriggersGC(this);
 #endif


### PR DESCRIPTION
Fixes Issue <!-- Issue Number -->

main PR <!-- Link to PR if any that fixed this in the main branch. -->

# Description

<!-- Give a brief summary of the issue and how the pull request is fixing it. -->

# Customer Impact

<!-- What is the impact to customers of not taking this fix? -->

# Regression

<!-- Is this fixing a problem that was introduced in the most recent release, ie., fixing a regression? -->

# Testing

<!-- What kind of testing has been done with the fix. -->

# Risk

<!-- Please assess the risk of taking this fix. Provide details backing up your assessment. -->

# Package authoring no longer needed in .NET 9

IMPORTANT: Starting with .NET 9, you no longer need to edit a NuGet package's csproj to enable building and bump the version.
Keep in mind that we still need package authoring in .NET 8 and older versions.