### PR TITLE
JIT: Remove SSE2 CmpOp/BinOp emulation code

### DIFF
--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -22397,61 +22397,31 @@ GenTree* Compiler::gtNewSimdCmpOpNode(
 
     assert(lookupType == type);
 
+#if defined(TARGET_XARCH)
+    assert(varTypeIsIntegral(simdBaseType));
+    assert(!canUseEvexEncodingDebugOnly());
+    assert((simdSize == 16) || ((simdSize == 32) && compOpportunisticallyDependsOn(InstructionSet_AVX2)));
+#endif // TARGET_XARCH
+
     switch (op)
     {
 #if defined(TARGET_XARCH)
-        case GT_EQ:
-        {
-            assert(varTypeIsLong(simdBaseType));
-            assert(simdSize == 16);
-
-            // There is no direct SSE2 support for comparing TYP_LONG vectors.
-            // These have to be implemented in terms of TYP_INT vector comparison operations.
-            //
-            // tmp = (op1 == op2) i.e. compare for equality as if op1 and op2 are vector of int
-            // op1 = tmp
-            // op2 = Shuffle(op1, (2, 3, 0, 1))
-            // result = BitwiseAnd(tmp, op2)
-            //
-            // Shuffle is meant to swap the comparison results of low-32-bits and high 32-bits of
-            // respective long elements.
-
-            GenTree* tmp = gtNewSimdCmpOpNode(op, type, op1, op2, TYP_INT, simdSize);
-
-            op1 = fgMakeMultiUse(&tmp);
-            op2 =
-                gtNewSimdHWIntrinsicNode(type, op1, gtNewIconNode(SHUFFLE_ZWXY), NI_X86Base_Shuffle, TYP_INT, simdSize);
-
-            return gtNewSimdBinOpNode(GT_AND, type, tmp, op2, simdBaseType, simdSize);
-        }
-
         case GT_GE:
         case GT_LE:
         {
-            assert(varTypeIsIntegral(simdBaseType));
-            assert(!canUseEvexEncodingDebugOnly());
-
             // If we don't have an intrinsic set for this, try "Max(op1, op2) == op1" for GE
             // and "Min(op1, op2) == op1" for LE
-            //
-            // NOTE: technically, we can special case byte type to only require SSE2, but it
-            // complicates the test matrix for little gains.
 
-            if ((simdSize == 16) || ((simdSize == 32) && compOpportunisticallyDependsOn(InstructionSet_AVX2)))
+            if (!varTypeIsLong(simdBaseType))
             {
-                // TODO-AVX512: We can use this trick for longs only with AVX-512
-                if (!varTypeIsLong(simdBaseType))
-                {
-                    assert(!varTypeIsFloating(simdBaseType));
-                    GenTree* op1Dup = fgMakeMultiUse(&op1);
+                GenTree* op1Dup = fgMakeMultiUse(&op1);
 
-                    bool isMax = (op == GT_GE);
+                bool isMax = (op == GT_GE);
 
-                    // EQ(MinMax(op1, op2), op1)
-                    op1 = gtNewSimdMinMaxNativeNode(type, op1, op2, simdBaseType, simdSize, isMax);
+                // EQ(MinMax(op1, op2), op1)
+                op1 = gtNewSimdMinMaxNativeNode(type, op1, op2, simdBaseType, simdSize, isMax);
 
-                    return gtNewSimdCmpOpNode(GT_EQ, type, op1, op1Dup, simdBaseType, simdSize);
-                }
+                return gtNewSimdCmpOpNode(GT_EQ, type, op1, op1Dup, simdBaseType, simdSize);
             }
 
             // There is no direct support for doing a combined comparison and equality for integral types.
@@ -22491,148 +22461,75 @@ GenTree* Compiler::gtNewSimdCmpOpNode(
         case GT_GT:
         case GT_LT:
         {
-            if (varTypeIsUnsigned(simdBaseType))
+            assert(varTypeIsUnsigned(simdBaseType));
+
+            // Vector of byte, ushort, uint and ulong:
+            // Hardware supports > and < for signed comparison. Therefore, to use it for
+            // comparing unsigned numbers, we subtract a constant from both the
+            // operands such that the result fits within the corresponding signed
+            // type. The resulting signed numbers are compared using signed comparison.
+            //
+            // Vector of byte: constant to be subtracted is 2^7
+            // Vector of ushort: constant to be subtracted is 2^15
+            // Vector of uint: constant to be subtracted is 2^31
+            // Vector of ulong: constant to be subtracted is 2^63
+            //
+            // We need to treat op1 and op2 as signed for comparison purpose after
+            // the transformation.
+
+            var_types      opType  = simdBaseType;
+            GenTreeVecCon* vecCon1 = gtNewVconNode(type);
+
+            switch (simdBaseType)
             {
-                // Vector of byte, ushort, uint and ulong:
-                // Hardware supports > and < for signed comparison. Therefore, to use it for
-                // comparing unsigned numbers, we subtract a constant from both the
-                // operands such that the result fits within the corresponding signed
-                // type. The resulting signed numbers are compared using signed comparison.
-                //
-                // Vector of byte: constant to be subtracted is 2^7
-                // Vector of ushort: constant to be subtracted is 2^15
-                // Vector of uint: constant to be subtracted is 2^31
-                // Vector of ulong: constant to be subtracted is 2^63
-                //
-                // We need to treat op1 and op2 as signed for comparison purpose after
-                // the transformation.
-
-                uint64_t  constVal = 0;
-                var_types opType   = simdBaseType;
-
-                switch (simdBaseType)
+                case TYP_UBYTE:
                 {
-                    case TYP_UBYTE:
-                    {
-                        constVal     = 0x8080808080808080;
-                        simdBaseType = TYP_BYTE;
-                        break;
-                    }
-
-                    case TYP_USHORT:
-                    {
-                        constVal     = 0x8000800080008000;
-                        simdBaseType = TYP_SHORT;
-                        break;
-                    }
-
-                    case TYP_UINT:
-                    {
-                        constVal     = 0x8000000080000000;
-                        simdBaseType = TYP_INT;
-                        break;
-                    }
-
-                    case TYP_ULONG:
-                    {
-                        constVal     = 0x8000000000000000;
-                        simdBaseType = TYP_LONG;
-                        break;
-                    }
-
-                    default:
-                    {
-                        unreached();
-                    }
+                    simdBaseType = TYP_BYTE;
+                    vecCon1->EvaluateBroadcastInPlace<int8_t>(INT8_MIN);
+                    break;
                 }
 
-                GenTreeVecCon* vecCon1 = gtNewVconNode(type);
-
-                for (unsigned i = 0; i < (simdSize / 8); i++)
+                case TYP_USHORT:
                 {
-                    vecCon1->gtSimdVal.u64[i] = constVal;
+                    simdBaseType = TYP_SHORT;
+                    vecCon1->EvaluateBroadcastInPlace<int16_t>(INT16_MIN);
+                    break;
                 }
 
-                GenTree* vecCon2 = gtCloneExpr(vecCon1);
+                case TYP_UINT:
+                {
+                    simdBaseType = TYP_INT;
+                    vecCon1->EvaluateBroadcastInPlace<int32_t>(INT32_MIN);
+                    break;
+                }
 
-                // op1 = op1 - constVector
-                op1 = gtNewSimdBinOpNode(GT_SUB, type, op1, vecCon1, opType, simdSize);
+                case TYP_ULONG:
+                {
+                    simdBaseType = TYP_LONG;
+                    vecCon1->EvaluateBroadcastInPlace<int64_t>(INT64_MIN);
+                    break;
+                }
 
-                // op2 = op2 - constVector
-                op2 = gtNewSimdBinOpNode(GT_SUB, type, op2, vecCon2, opType, simdSize);
-
-                return gtNewSimdCmpOpNode(op, type, op1, op2, simdBaseType, simdSize);
+                default:
+                {
+                    unreached();
+                }
             }
-            else
-            {
-                assert(varTypeIsLong(simdBaseType));
-                assert(simdSize == 16);
 
-                // There is no direct SSE2 support for comparing TYP_LONG vectors.
-                // These have to be implemented in terms of TYP_INT vector comparison operations.
-                //
-                // Let us consider the case of single long element comparison.
-                // Say op1 = (x1, y1) and op2 = (x2, y2) where x1, y1, x2, and y2 are 32-bit integers that comprise
-                // the
-                // longs op1 and op2.
-                //
-                // GreaterThan(op1, op2) can be expressed in terms of > relationship between 32-bit integers that
-                // comprise op1 and op2 as
-                //                    =  (x1, y1) > (x2, y2)
-                //                    =  (x1 > x2) || [(x1 == x2) && (y1 > y2)]   - eq (1)
-                //
-                // LessThan(op1, op2) can be expressed in terms of < relationship between 32-bit integers that
-                // comprise op1 and op2 as
-                //                    =  (x1, y1) < (x2, y2)
-                //                    =  (x1 < x2) || [(x1 == x2) && (y1 < y2)]   - eq (1)
-                //
-                // op1Dup1 = op1
-                // op1Dup2 = op1Dup1
-                // op2Dup1 = op2
-                // op2Dup2 = op2Dup1
-                //
-                // t = (op1 cmp op2)                - 32-bit signed comparison
-                // u = (op1Dup1 == op2Dup1)       - 32-bit equality comparison
-                // v = (op1Dup2 cmp op2Dup2)        - 32-bit unsigned comparison
-                //
-                // op1 = Shuffle(t, (3, 3, 1, 1)) - This corresponds to (x1 > x2) in eq(1) above
-                // u = Shuffle(u, (3, 3, 1, 1))   - This corresponds to (x1 == x2) in eq(1) above
-                // v = Shuffle(v, (2, 2, 0, 0))   - This corresponds to (y1 > y2) in eq(1) above
-                // op2 = BitwiseAnd(u, v)         - This corresponds to [(x1 == x2) && (y1 > y2)] in eq(1) above
-                //
-                // result = BitwiseOr(op1, op2)
+            GenTree* vecCon2 = gtCloneExpr(vecCon1);
 
-                GenTree* op1Dup1 = fgMakeMultiUse(&op1);
-                GenTree* op1Dup2 = gtCloneExpr(op1Dup1);
+            // op1 = op1 - constVector
+            op1 = gtNewSimdBinOpNode(GT_SUB, type, op1, vecCon1, opType, simdSize);
 
-                GenTree* op2Dup1 = fgMakeMultiUse(&op2);
-                GenTree* op2Dup2 = gtCloneExpr(op2Dup1);
+            // op2 = op2 - constVector
+            op2 = gtNewSimdBinOpNode(GT_SUB, type, op2, vecCon2, opType, simdSize);
 
-                GenTree* t = gtNewSimdCmpOpNode(op, type, op1, op2, TYP_INT, simdSize);
-                GenTree* u = gtNewSimdCmpOpNode(GT_EQ, type, op1Dup1, op2Dup1, TYP_INT, simdSize);
-                GenTree* v = gtNewSimdCmpOpNode(op, type, op1Dup2, op2Dup2, TYP_UINT, simdSize);
-
-                op1 = gtNewSimdHWIntrinsicNode(type, t, gtNewIconNode(SHUFFLE_WWYY, TYP_INT), NI_X86Base_Shuffle,
-                                               TYP_INT, simdSize);
-                u = gtNewSimdHWIntrinsicNode(type, u, gtNewIconNode(SHUFFLE_WWYY, TYP_INT), NI_X86Base_Shuffle, TYP_INT,
-                                             simdSize);
-                v = gtNewSimdHWIntrinsicNode(type, v, gtNewIconNode(SHUFFLE_ZZXX, TYP_INT), NI_X86Base_Shuffle, TYP_INT,
-                                             simdSize);
-
-                op2 = gtNewSimdBinOpNode(GT_AND, type, u, v, simdBaseType, simdSize);
-                return gtNewSimdBinOpNode(GT_OR, type, op1, op2, simdBaseType, simdSize);
-            }
-            break;
+            return gtNewSimdCmpOpNode(op, type, op1, op2, simdBaseType, simdSize);
         }
 #endif // TARGET_XARCH
 
         case GT_NE:
         {
-#if defined(TARGET_XARCH)
-            assert(varTypeIsIntegral(simdBaseType));
-            assert(!canUseEvexEncodingDebugOnly());
-#endif // TARGET_XARCH
-
             GenTree* result = gtNewSimdCmpOpNode(GT_EQ, type, op1, op2, simdBaseType, simdSize);
             return gtNewSimdUnOpNode(GT_NOT, type, result, simdBaseType, simdSize);
         }

--- a/src/coreclr/jit/gentree.cpp
+++ b/src/coreclr/jit/gentree.cpp
@@ -21778,42 +21778,6 @@ GenTree* Compiler::gtNewSimdBinOpNode(
                 // Narrow and merge halves using helper method
                 return gtNewSimdNarrowNode(type, lowerProduct, upperProduct, simdBaseType, simdSize);
             }
-            else if (varTypeIsInt(simdBaseType))
-            {
-                // op1Dup = op1
-                GenTree* op1Dup = fgMakeMultiUse(&op1);
-
-                // op2Dup = op2
-                GenTree* op2Dup = fgMakeMultiUse(&op2);
-
-                // op1Dup = Sse2.ShiftRightLogical128BitLane(op1Dup, 4)
-                op1Dup = gtNewSimdHWIntrinsicNode(type, op1Dup, gtNewIconNode(4, TYP_INT),
-                                                  NI_X86Base_ShiftRightLogical128BitLane, simdBaseType, simdSize);
-
-                // op2Dup = Sse2.ShiftRightLogical128BitLane(op2Dup, 4)
-                op2Dup = gtNewSimdHWIntrinsicNode(type, op2Dup, gtNewIconNode(4, TYP_INT),
-                                                  NI_X86Base_ShiftRightLogical128BitLane, simdBaseType, simdSize);
-
-                // op2Dup = Sse2.Multiply(op1Dup.AsUInt32(), op2Dup.AsUInt32()).AsInt32()
-                op2Dup = gtNewSimdHWIntrinsicNode(type, op1Dup, op2Dup, NI_X86Base_Multiply, TYP_ULONG, simdSize);
-
-                // op2Dup = Sse2.Shuffle(op2Dup, (0, 0, 2, 0))
-                op2Dup = gtNewSimdHWIntrinsicNode(type, op2Dup, gtNewIconNode(SHUFFLE_XXZX, TYP_INT),
-                                                  NI_X86Base_Shuffle, simdBaseType, simdSize);
-
-                // op1 = Sse2.Multiply(op1.AsUInt32(), op2.AsUInt32()).AsInt32()
-                op1 = gtNewSimdHWIntrinsicNode(type, op1, op2, NI_X86Base_Multiply, TYP_ULONG, simdSize);
-
-                // op1 = Sse2.Shuffle(op1, (0, 0, 2, 0))
-                op1 = gtNewSimdHWIntrinsicNode(type, op1, gtNewIconNode(SHUFFLE_XXZX, TYP_INT), NI_X86Base_Shuffle,
-                                               simdBaseType, simdSize);
-
-                // op2 = op2Dup;
-                op2 = op2Dup;
-
-                // result = Sse2.UnpackLow(op1, op2)
-                return gtNewSimdHWIntrinsicNode(type, op1, op2, NI_X86Base_UnpackLow, simdBaseType, simdSize);
-            }
             else if (varTypeIsLong(simdBaseType))
             {
                 // This fallback path will be used only if the vpmullq instruction is not available.


### PR DESCRIPTION
With the JIT baseline now at SSE4.2, these fallback implementations are no longer reachable.