### PR TITLE
Pull in tests from iltrim prototype

### DIFF
--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/BasicTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/BasicTests.g.cs
@@ -10,6 +10,12 @@ namespace ILLink.RoslynAnalyzer.Tests
         protected override string TestSuiteName => "Basic";
 
         [Fact]
+        public Task Calli()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
         public Task ComplexNestedClassesHasUnusedRemoved()
         {
             return RunTest(allowMissingWarnings: true);
@@ -22,7 +28,67 @@ namespace ILLink.RoslynAnalyzer.Tests
         }
 
         [Fact]
+        public Task ExceptionRegions()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task FieldRVA()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task FieldSignature()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task FieldsOfEnum()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task Finalizer()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task First()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task FunctionPointer()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task GenericParameters()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task GenericType()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
         public Task InitializerForArrayIsKept()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task InstanceFields()
         {
             return RunTest(allowMissingWarnings: true);
         }
@@ -34,13 +100,43 @@ namespace ILLink.RoslynAnalyzer.Tests
         }
 
         [Fact]
+        public Task InterfaceCalls()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
         public Task InterfaceMethodImplementedOnBaseClassDoesNotGetStripped()
         {
             return RunTest(allowMissingWarnings: true);
         }
 
         [Fact]
+        public Task InterfaceOrder()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task LibraryModeTest()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
         public Task LinkerHandlesRefFields()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task MethodSpecSignature()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task MultiDimArraySignature()
         {
             return RunTest(allowMissingWarnings: true);
         }
@@ -59,6 +155,30 @@ namespace ILLink.RoslynAnalyzer.Tests
 
         [Fact]
         public Task NeverInstantiatedTypeWithOverridesFromObject()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task Resources()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task Switch()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task TypeOf()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task TypeSpecSignature()
         {
             return RunTest(allowMissingWarnings: true);
         }
@@ -173,6 +293,12 @@ namespace ILLink.RoslynAnalyzer.Tests
 
         [Fact]
         public Task UsedStructIsKept()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task VirtualMethods()
         {
             return RunTest(allowMissingWarnings: true);
         }

--- a/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/MultiAssemblyTests.g.cs
+++ b/src/tools/illink/test/ILLink.RoslynAnalyzer.Tests/generated/ILLink.RoslynAnalyzer.Tests.Generator/ILLink.RoslynAnalyzer.Tests.TestCaseGenerator/MultiAssemblyTests.g.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ILLink.RoslynAnalyzer.Tests
+{
+    public sealed partial class MultiAssemblyTests : LinkerTestBase
+    {
+
+        protected override string TestSuiteName => "MultiAssembly";
+
+        [Fact]
+        public Task ForwarderReference()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task MultiAssembly()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+        [Fact]
+        public Task TypeRefToAssembly()
+        {
+            return RunTest(allowMissingWarnings: true);
+        }
+
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/Calli.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/Calli.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [SetupCompileArgument("/unsafe")]
+    [SkipILVerify] // ILVerify doesn't handle calli
+    [KeptMember(".cctor()")]
+    public unsafe class Calli
+    {
+        [Kept]
+        private static readonly delegate*<object, void> _pfn = null;
+
+        public static void Main()
+        {
+            CallCalli(null);
+        }
+
+        [Kept]
+        static void CallCalli(object o)
+        {
+            _pfn(o);
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/Dependencies/Resources_EmbeddedResource.txt
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/Dependencies/Resources_EmbeddedResource.txt
@@ -1,0 +1,1 @@
+﻿Embedded resource content

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/ExceptionRegions.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/ExceptionRegions.cs
@@ -1,0 +1,52 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [Kept]
+    public class ExceptionRegions
+    {
+        [Kept]
+        static void Main()
+        {
+            try
+            {
+                A();
+            }
+            catch (CustomException ce)
+            {
+                Console.WriteLine(ce.Message);
+                try
+                {
+                    B();
+                }
+                catch (Exception e) when (e.InnerException != null)
+                {
+                    Console.WriteLine(e.Message);
+                }
+            }
+            finally
+            {
+                C();
+            }
+        }
+
+        [Kept]
+        static void A() { }
+
+        [Kept]
+        static void B() { throw new Exception(); }
+
+        [Kept]
+        static void C() { }
+    }
+
+    [Kept]
+    [KeptBaseType(typeof(Exception))]
+    class CustomException : Exception
+    {
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/FieldRVA.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/FieldRVA.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [Kept]
+	class FieldRVA
+	{
+        [Kept]
+        [KeptInitializerData]
+        static int Main() => new byte[] { 1, 2, 3, 4, 5 }.Length;
+	}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/FieldSignature.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/FieldSignature.cs
@@ -1,0 +1,24 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using System;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [Kept]
+    class FieldSignature
+    {
+        [Kept]
+        static FieldType field;
+
+        [Kept]
+        static void Main()
+        {
+            field = null;
+            _ = field;
+        }
+
+        [Kept]
+        class FieldType
+        {
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/FieldsOfEnum.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/FieldsOfEnum.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [Kept]
+    class FieldsOfEnum
+    {
+        [Kept]
+        static void Main()
+        {
+            Console.WriteLine($"{MyEnum.A}");
+        }
+    }
+
+    [Kept]
+    [KeptMember("value__")]
+    [KeptBaseType(typeof(Enum))]
+    public enum MyEnum
+    {
+        [Kept]
+        A = 0,
+
+        [Kept]
+        B = 1,
+
+        [Kept]
+        C = 2,
+    };
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/Finalizer.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/Finalizer.cs
@@ -1,0 +1,33 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using System;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [Kept]
+    class Finalizer
+    {
+        static void Main()
+        {
+            MentionUnallocatedType(null);
+            new AllocatedTypeWithFinalizer();
+        }
+
+        [Kept]
+        static void MentionUnallocatedType(UnallocatedTypeWithFinalizer u) { }
+
+        [Kept]
+        class UnallocatedTypeWithFinalizer
+        {
+            // Not kept
+            ~UnallocatedTypeWithFinalizer() { }
+        }
+
+        [Kept]
+        [KeptMember(".ctor()")]
+        class AllocatedTypeWithFinalizer
+        {
+            [Kept]
+            ~AllocatedTypeWithFinalizer() { }
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/First.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/First.cs
@@ -1,0 +1,33 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    #pragma warning disable 169
+
+    [Kept]
+    public class First
+    {
+        static int Field;
+
+        [Kept]
+        static int FirstMethod() => 300;
+
+        [Kept]
+        static int Main()
+        {
+            return FirstMethod();
+        }
+
+        static void LastMethod(int someParameter) { }
+    }
+
+    class FirstType
+    {
+        static void Method() { }
+    }
+
+    class AnotherType
+    {
+        static void Method() { }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/FunctionPointer.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/FunctionPointer.cs
@@ -1,0 +1,25 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [Kept]
+    [SetupCompileArgument("/unsafe")]
+    unsafe class FunctionPointer
+    {
+        [Kept]
+        static void Main()
+        {
+            MethodTakingFunctionPointer(null);
+        }
+
+        [Kept]
+        static void MethodTakingFunctionPointer(delegate*<OneType, OtherType> del) { }
+
+        [Kept]
+        class OneType { }
+
+        [Kept]
+        class OtherType { }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/GenericParameters.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/GenericParameters.cs
@@ -1,0 +1,19 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [Kept]
+	class GenericParameters
+	{
+        [Kept]
+        public static void Main()
+        {
+            var t = typeof(A<>).ToString();
+        }
+
+        [Kept]
+        class A<T>
+        {
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/GenericType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/GenericType.cs
@@ -1,0 +1,34 @@
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [Kept]
+    class GenericType
+    {
+        [Kept]
+        public static void Main()
+        {
+            var c = new C();
+        }
+    }
+
+    [Kept]
+    [KeptMember(".ctor()")]
+    class A<T>
+    {
+    }
+
+    [Kept]
+    [KeptMember(".ctor()")]
+    [KeptBaseType(typeof(A<string>))]
+    class B<T> : A<string>
+    {
+    }
+
+    [Kept]
+    [KeptMember(".ctor()")]
+    [KeptBaseType(typeof(B<int>))]
+    class C : B<int>
+    {
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/InstanceFields.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/InstanceFields.cs
@@ -1,0 +1,30 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [Kept]
+    class InstanceFields
+    {
+        [Kept]
+        static void Main()
+        {
+            _ = new TypeWithSequentialLayout();
+        }
+    }
+
+    [Kept]
+    [KeptMember(".ctor()")]
+    [StructLayout(LayoutKind.Sequential)]
+    class TypeWithSequentialLayout
+    {
+        [Kept]
+        int Field = 42;
+
+        static int StaticField; // Must not assign value, otherwise .cctor would keep the field
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/InterfaceCalls.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/InterfaceCalls.cs
@@ -1,0 +1,35 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [Kept]
+    class InterfaceCalls
+    {
+        [Kept]
+        static void Main()
+        {
+            ISimpleInterface simpleInterface = new SimpleType();
+            simpleInterface.InterfaceMethod();
+        }
+
+        [Kept]
+        interface ISimpleInterface
+        {
+            [Kept]
+            void InterfaceMethod();
+            void UnusedMethod();
+        }
+
+        interface ISimpleUnusedInterface { }
+
+        [Kept]
+        [KeptMember(".ctor()")]
+        [KeptInterface(typeof(ISimpleInterface))]
+        class SimpleType : ISimpleInterface, ISimpleUnusedInterface
+        {
+            [Kept]
+            public virtual void InterfaceMethod() { }
+            public virtual void UnusedMethod() { }
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/InterfaceOrder.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/InterfaceOrder.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [Kept]
+    class InterfaceOrder
+    {
+        [Kept]
+        static void Main()
+        {
+            I1 c1 = new C1();
+            c1.Method();
+            I2 c2 = new C2();
+            c2.Method();
+        }
+        [Kept]
+        interface I1
+        {
+            [Kept]
+            void Method();
+        }
+
+        [Kept]
+        interface I2
+        {
+            [Kept]
+            void Method();
+        }
+
+        [Kept]
+        [KeptMember(".ctor()")]
+        [KeptInterface(typeof(I1))]
+        [KeptInterface(typeof(I2))]
+        class C1 : I1, I2
+        {
+            [Kept]
+            public void Method() { }
+        }
+
+        [Kept]
+        [KeptMember(".ctor()")]
+        [KeptInterface(typeof(I1))]
+        [KeptInterface(typeof(I2))]
+        class C2 : I2, I1
+        {
+            [Kept]
+            public void Method() { }
+        }
+
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/LibraryModeTest.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/LibraryModeTest.cs
@@ -1,0 +1,48 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+#pragma warning disable 169
+
+    [SetupLinkerArgument("-a", "test", "library")]
+    [SetupLinkerArgument("--enable-opt", "ipconstprop")]
+    public class LibraryModeTest
+    {
+        static int Field;
+
+        [Kept]
+        public LibraryModeTest() { }
+
+        [Kept]
+        public void M1() { }
+
+        [Kept]
+        public void M2() { }
+
+        [Kept]
+        public void M3() { }
+
+        [Kept]
+        public static int Main()
+        {
+            return 42;
+        }
+        void P_M1() { }
+        void P_M2() { }
+        void P_M3() { }
+    }
+
+    internal class InternalType
+    {
+        public void M1() { }
+    }
+
+    [Kept]
+    [KeptMember(".ctor()")] // Public types are assumed to be constructed
+    public class AnotherPublicType
+    {
+        [Kept]
+        public void M1() { }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/MethodSpecSignature.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/MethodSpecSignature.cs
@@ -1,0 +1,27 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [Kept]
+    class MethodSpecSignature
+    {
+        [Kept]
+        static void Main()
+        {
+            SomeType.SomeMethod<SomeOtherType>();
+        }
+
+        [Kept]
+        class SomeType
+        {
+            [Kept]
+            public static void SomeMethod<T>() { }
+        }
+
+        [Kept]
+        class SomeOtherType
+        {
+        }
+
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/MultiDimArraySignature.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/MultiDimArraySignature.cs
@@ -1,0 +1,20 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [Kept]
+    class MultiDimArraySignature
+    {
+        [Kept]
+        static void Main()
+        {
+            SomeOtherType[,] multiDimArray = new SomeOtherType[4, 5];
+        }
+
+        [Kept]
+        class SomeOtherType
+        {
+        }
+
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/Resources.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/Resources.cs
@@ -1,0 +1,17 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [SetupCompileResource("Dependencies/Resources_EmbeddedResource.txt", "EmbeddedResource.txt")]
+    [KeptResource("EmbeddedResource.txt")]
+    public class Resources
+    {
+        public static void Main()
+        {
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/Switch.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/Switch.cs
@@ -1,0 +1,59 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    public class Switch
+    {
+        public static void Main()
+        {
+            TestSwitchStatement(1);
+            TestSwitchExpression(1);
+        }
+
+        [Kept]
+        public static void TestSwitchStatement(int p)
+        {
+            switch (p)
+            {
+                case 0: Case1(); break;
+                case 1: Case1(); break;
+                case 3: Case1(); break;
+                case 4: Case1(); break;
+                case 5: Case1(); break;
+                case 6: Case1(); break;
+                case 7: Case1(); break;
+                case 8: Case1(); break;
+                case 9: Case1(); break;
+                case 10: Case1(); break;
+                default:
+                    Case2();
+                    break;
+            }
+        }
+
+        [Kept]
+        public static void Case1() { }
+        [Kept]
+        public static void Case2() { }
+
+        [Kept]
+        public static int TestSwitchExpression(int p) =>
+            p switch
+            {
+                0 => 1,
+                1 => 2,
+                2 => 3,
+                3 => 4,
+                4 => 5,
+                5 => 6,
+                6 => 7,
+                7 => 8,
+                8 => 9,
+                9 => 10,
+                _ => 0
+            };
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/TypeOf.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/TypeOf.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    public class TypeOf
+    {
+        public static void Main()
+        {
+            var t = typeof(TestType);
+        }
+
+        [Kept]
+        class TestType
+        {
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/TypeSpecSignature.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/TypeSpecSignature.cs
@@ -1,0 +1,29 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+    [Kept]
+    [SetupCompileArgument("/unsafe")]
+    unsafe class TypeSpecSignature
+    {
+        [Kept]
+        static void Main()
+        {
+            var reflectedType = typeof(SomeType<SomeOtherType>);
+            TestUnsafe();
+        }
+
+        [Kept]
+        unsafe static void TestUnsafe()
+        {
+            void* p = null;
+        }
+
+        [Kept]
+        class SomeType<T> { }
+
+        [Kept]
+        class SomeOtherType { }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/VirtualMethods.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/Basic/VirtualMethods.cs
@@ -1,0 +1,48 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+
+namespace Mono.Linker.Tests.Cases.Basic
+{
+#pragma warning disable 169
+
+    [Kept]
+    public class VirtualMethods
+    {
+        [Kept]
+        static void Main()
+        {
+            BaseType b = new DerivedType();
+            b.Method1();
+
+            // TODO: uncomment once we're okay with ToString bringing the whole world into closure
+            //((object)default(MyValueType)).ToString();
+        }
+    }
+
+    [Kept]
+    class BaseType
+    {
+        [Kept]
+        public BaseType() { }
+        [Kept]
+        public virtual void Method1() { }
+        public virtual void Method2() { }
+    }
+
+    [Kept]
+    [KeptBaseType(typeof(BaseType))]
+    class DerivedType : BaseType
+    {
+        [Kept]
+        public DerivedType() { }
+        [Kept]
+        public override void Method1() { }
+        public override void Method2() { }
+    }
+
+    //[Kept]
+    //struct MyValueType
+    //{
+    //    [Kept]
+    //    public override string ToString() => "";
+    //}
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/MultiAssembly/Dependencies/Dep.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/MultiAssembly/Dependencies/Dep.cs
@@ -1,0 +1,14 @@
+
+public class DepClass
+{
+    public static void Kept()
+    {
+    }
+
+    public static void Trimmed()
+    {
+    }
+
+    public static int KeptField;
+    public static int TrimmedField;
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/MultiAssembly/Dependencies/ForwardedType.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/MultiAssembly/Dependencies/ForwardedType.cs
@@ -1,0 +1,15 @@
+
+public class ForwardedType
+{
+    public static void Kept()
+    {
+    }
+
+    public static void Removed()
+    {
+    }
+
+    public static int KeptField;
+
+    public static int RemovedField;
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/MultiAssembly/Dependencies/Forwarder.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/MultiAssembly/Dependencies/Forwarder.cs
@@ -1,0 +1,5 @@
+using System.Runtime.CompilerServices;
+
+#if TEST_BUILD
+[assembly: TypeForwardedTo(typeof(ForwardedType))]
+#endif

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/MultiAssembly/Dependencies/TypeRefToAssembly_Library.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/MultiAssembly/Dependencies/TypeRefToAssembly_Library.cs
@@ -1,0 +1,6 @@
+﻿namespace TypeRefToAssembly_Library
+{
+    public class TestType
+    {
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/MultiAssembly/ForwarderReference.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/MultiAssembly/ForwarderReference.cs
@@ -1,0 +1,25 @@
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.MultiAssembly
+{
+    [SetupLinkerAction ("link", "ForwardedType")]
+    [SetupCompileBefore("Forwarder.dll", new[] { "Dependencies/ForwardedType.cs" })]
+
+    [SetupCompileAfter ("ForwardedType.dll", new[] { "Dependencies/ForwardedType.cs" })]
+    [SetupCompileAfter("Forwarder.dll", new[] { "Dependencies/Forwarder.cs" }, references: new[] { "ForwardedType.dll" }, defines: new[] { "TEST_BUILD" })]
+
+    [KeptMemberInAssembly("ForwardedType.dll", typeof(ForwardedType), "Kept()")]
+    [KeptMemberInAssembly("ForwardedType.dll", typeof(ForwardedType), nameof(ForwardedType.KeptField))]
+
+    [RemovedAssemblyReference("test", "Forwarder")]
+    public class ForwarderReference
+    {
+        public static void Main()
+        {
+            ForwardedType.Kept();
+            ForwardedType.KeptField = 0;
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/MultiAssembly/MultiAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/MultiAssembly/MultiAssembly.cs
@@ -1,0 +1,20 @@
+
+using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.MultiAssembly
+{
+    [SetupLinkerAction ("link", "Dep")]
+    [SetupCompileBefore("Dep.dll", new[] { "Dependencies/Dep.cs" })]
+
+    [KeptMemberInAssembly("Dep.dll", typeof(DepClass), "Kept()")]
+    [KeptMemberInAssembly("Dep.dll", typeof(DepClass), nameof(DepClass.KeptField))]
+    public class MultiAssembly
+    {
+        public static void Main()
+        {
+            DepClass.Kept();
+            DepClass.KeptField = 0;
+        }
+    }
+}

--- a/src/tools/illink/test/Mono.Linker.Tests.Cases/MultiAssembly/TypeRefToAssembly.cs
+++ b/src/tools/illink/test/Mono.Linker.Tests.Cases/MultiAssembly/TypeRefToAssembly.cs
@@ -1,0 +1,17 @@
+﻿using Mono.Linker.Tests.Cases.Expectations.Assertions;
+using Mono.Linker.Tests.Cases.Expectations.Metadata;
+
+namespace Mono.Linker.Tests.Cases.MultiAssembly
+{
+    [SetupLinkerAction("link", "lib")]
+    [SetupCompileBefore("lib.dll", new[] { "Dependencies/TypeRefToAssembly_Library.cs" })]
+
+    [KeptTypeInAssembly("lib.dll", typeof(TypeRefToAssembly_Library.TestType))]
+    public class TypeRefToAssembly
+    {
+        public static void Main()
+        {
+            var t = typeof(TypeRefToAssembly_Library.TestType);
+        }
+    }
+}


### PR DESCRIPTION
When we did the iltrim hackathon, we wrote some new tests. These are the tests from https://github.com/MichalStrehovsky/iltrim, moved to the illink tree.

Sending this out for considerations. We can say we don't want them and that would be fine too.

Cc @dotnet/illink 