### PR TITLE
Remove unsafe code from BlobUtilities.cs

### DIFF
--- a/src/libraries/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/libraries/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -93,6 +93,7 @@ The System.Reflection.Metadata library is built-in as part of the shared framewo
     <Compile Include="System\Reflection\PortableExecutable\ResourceSectionBuilder.cs" />
     <Compile Include="System\Reflection\PortableExecutable\SectionLocation.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\BlobUtilities.cs" />
+    <Compile Include="System\Reflection\Internal\Utilities\Polyfills.cs" Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BlobUtilities.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/BlobUtilities.cs
@@ -5,7 +5,6 @@ using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Reflection.Internal;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
 namespace System.Reflection
 {
@@ -14,54 +13,29 @@ namespace System.Reflection
         public static void WriteBytes(this byte[] buffer, int start, byte value, int byteCount)
         {
             Debug.Assert(buffer.Length > 0);
-
             new Span<byte>(buffer, start, byteCount).Fill(value);
         }
 
-        public static void WriteDouble(this byte[] buffer, int start, double value)
-        {
-#if NET
+        public static void WriteDouble(this byte[] buffer, int start, double value) =>
             WriteUInt64(buffer, start, BitConverter.DoubleToUInt64Bits(value));
-#else
-            unsafe
-            {
-                WriteUInt64(buffer, start, *(ulong*)&value);
-            }
-#endif
-        }
 
-        public static void WriteSingle(this byte[] buffer, int start, float value)
-        {
-#if NET
+        public static void WriteSingle(this byte[] buffer, int start, float value) =>
             WriteUInt32(buffer, start, BitConverter.SingleToUInt32Bits(value));
-#else
-            unsafe
-            {
-                WriteUInt32(buffer, start, *(uint*)&value);
-            }
-#endif
-        }
-
-        public static void WriteByte(this byte[] buffer, int start, byte value)
-        {
-            // Perf: The compiler emits a check when pinning the buffer. It's thus not worth doing so.
-            buffer[start] = value;
-        }
 
         public static void WriteUInt16(this byte[] buffer, int start, ushort value) =>
-            Unsafe.WriteUnaligned(ref buffer[start], !BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(value) : value);
+            BinaryPrimitives.WriteUInt16LittleEndian(buffer.AsSpan(start), value);
 
         public static void WriteUInt16BE(this byte[] buffer, int start, ushort value) =>
-            Unsafe.WriteUnaligned(ref buffer[start], BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(value) : value);
+            BinaryPrimitives.WriteUInt16BigEndian(buffer.AsSpan(start), value);
 
         public static void WriteUInt32BE(this byte[] buffer, int start, uint value) =>
-            Unsafe.WriteUnaligned(ref buffer[start], BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(value) : value);
+            BinaryPrimitives.WriteUInt32BigEndian(buffer.AsSpan(start), value);
 
         public static void WriteUInt32(this byte[] buffer, int start, uint value) =>
-            Unsafe.WriteUnaligned(ref buffer[start], !BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(value) : value);
+            BinaryPrimitives.WriteUInt32LittleEndian(buffer.AsSpan(start), value);
 
         public static void WriteUInt64(this byte[] buffer, int start, ulong value) =>
-            Unsafe.WriteUnaligned(ref buffer[start], !BitConverter.IsLittleEndian ? BinaryPrimitives.ReverseEndianness(value) : value);
+            BinaryPrimitives.WriteUInt64LittleEndian(buffer.AsSpan(start), value);
 
         public const int SizeOfSerializedDecimal = sizeof(byte) + 3 * sizeof(uint);
 
@@ -72,7 +46,7 @@ namespace System.Reflection
             uint low, mid, high;
             value.GetBits(out isNegative, out scale, out low, out mid, out high);
 
-            WriteByte(buffer, start, (byte)(scale | (isNegative ? 0x80 : 0x00)));
+            buffer[start] = (byte)(scale | (isNegative ? 0x80 : 0x00));
             WriteUInt32(buffer, start + 1, low);
             WriteUInt32(buffer, start + 5, mid);
             WriteUInt32(buffer, start + 9, high);
@@ -82,45 +56,9 @@ namespace System.Reflection
 
         public static void WriteGuid(this byte[] buffer, int start, Guid value)
         {
-#if NET
             bool written = value.TryWriteBytes(buffer.AsSpan(start));
             // This function is not public, callers have to ensure that enough space is available.
             Debug.Assert(written);
-#else
-            unsafe
-            {
-                fixed (byte* dst = &buffer[start])
-                {
-                    byte* src = (byte*)&value;
-
-                    uint a = *(uint*)(src + 0);
-                    unchecked
-                    {
-                        dst[0] = (byte)a;
-                        dst[1] = (byte)(a >> 8);
-                        dst[2] = (byte)(a >> 16);
-                        dst[3] = (byte)(a >> 24);
-
-                        ushort b = *(ushort*)(src + 4);
-                        dst[4] = (byte)b;
-                        dst[5] = (byte)(b >> 8);
-
-                        ushort c = *(ushort*)(src + 6);
-                        dst[6] = (byte)c;
-                        dst[7] = (byte)(c >> 8);
-                    }
-
-                    dst[8] = src[8];
-                    dst[9] = src[9];
-                    dst[10] = src[10];
-                    dst[11] = src[11];
-                    dst[12] = src[12];
-                    dst[13] = src[13];
-                    dst[14] = src[14];
-                    dst[15] = src[15];
-                }
-            }
-#endif
         }
 
         public static unsafe void WriteUTF8(this byte[] buffer, int start, char* charPtr, int charCount, int byteCount, bool allowUnpairedSurrogates)

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/Polyfills.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/Polyfills.cs
@@ -44,7 +44,7 @@ namespace System
                 }
                 else
                 {
-                    // slower path for BigEndian: ToByteArray always returns LE layout
+                    // slower path for BigEndian
                     self.ToByteArray().AsSpan().CopyTo(destination);
                 }
 

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/Polyfills.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Internal/Utilities/Polyfills.cs
@@ -1,0 +1,55 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace System
+{
+    internal static class BitConverterPolyfills
+    {
+        extension(BitConverter)
+        {
+            public static uint SingleToUInt32Bits(float value)
+            {
+                unsafe
+                {
+                    return *(uint*)&value;
+                }
+            }
+
+            public static ulong DoubleToUInt64Bits(double value)
+            {
+                unsafe
+                {
+                    return *(ulong*)&value;
+                }
+            }
+        }
+    }
+
+    internal static class GuidPolyfills
+    {
+        extension(Guid self)
+        {
+            public bool TryWriteBytes(Span<byte> destination)
+            {
+                if (destination.Length < 16)
+                    return false;
+
+                ref Guid selfRef = ref Unsafe.AsRef(in self);
+                if (BitConverter.IsLittleEndian)
+                {
+                    MemoryMarshal.Write(destination, ref selfRef);
+                }
+                else
+                {
+                    // slower path for BigEndian: ToByteArray always returns LE layout
+                    self.ToByteArray().AsSpan().CopyTo(destination);
+                }
+
+                return true;
+            }
+        }
+    }
+}

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -821,7 +821,8 @@ namespace System.Reflection.Metadata
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
         public void WriteByte(byte value)
         {
-            _buffer[ReserveBytesPrimitive(sizeof(byte))] = value;
+            int start = ReserveBytesPrimitive(sizeof(byte));
+            _buffer[start] = value;
         }
 
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>

--- a/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
+++ b/src/libraries/System.Reflection.Metadata/src/System/Reflection/Metadata/BlobBuilder.cs
@@ -821,8 +821,7 @@ namespace System.Reflection.Metadata
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>
         public void WriteByte(byte value)
         {
-            int start = ReserveBytesPrimitive(sizeof(byte));
-            _buffer.WriteByte(start, value);
+            _buffer[ReserveBytesPrimitive(sizeof(byte))] = value;
         }
 
         /// <exception cref="InvalidOperationException">Builder is not writable, it has been linked with another one.</exception>


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

Extracted from https://github.com/dotnet/runtime/pull/126269

I wonder if we should move all Polyfils for NS/NETF to just one common place for all libraries. Currently, libs just define their own in-place.