### PR TITLE
Close socket that leaks on connect failed

### DIFF
--- a/src/mono/mono/mini/cfgdump.c
+++ b/src/mono/mono/mini/cfgdump.c
@@ -63,6 +63,7 @@ create_socket (const char *hostname, const int port)
 
     if (connect (sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
         g_warning ("cfg_dump: Connect Failed: %s", strerror (errno));
+       	close(sockfd);
         return -2;
     }
 


### PR DESCRIPTION
The create_socket function creates a socket, attempts to connect and if failed, simply returns without closing the socket.

`create_socket` opens socket and connects with constant parameters (cfgdum.h):
```c
#define DEFAULT_HOST "127.0.0.1"
#define DEFAULT_PORT 4445
```

The connection is used to create `IdealGraphVisualizer` graph during a compilation. 