### PR TITLE
Fix memory leak in mono/mini/aot-compiler.c

### DIFF
--- a/src/mono/mono/mini/aot-compiler.c
+++ b/src/mono/mono/mini/aot-compiler.c
@@ -5595,6 +5595,8 @@ MONO_RESTORE_WARNING
 		fprintf (export_symbols_outfile, "%s", export_symbols_out);
 		g_free (export_symbols_out);
 		fclose (export_symbols_outfile);
+	} else {
+		g_string_free (export_symbols, TRUE);
 	}
 }
 


### PR DESCRIPTION
The `GString export_symbols` is removed in only one execution branch. Freeing does not occur unless the `icfg->aot_opts.export_symbols_outfile` field is set, which is set in only one place: `aot-compiler.c` function `mono_aot_parse_options: opts->export_symbols_outfile = g_strdup (arg + strlen ("export-symbols-outfile="));`.

The error only occurs during compilation with an empty `export-symbols-outfile=` option. The maximum loss is 16 bytes per compilation.

Signed-off-by: Aleksandr Dovydenkov <asd@altlinux.org>
Found by Linux Verification Center (linuxtesting.org) with SVACE.