### PR TITLE
[clr-ios] Include macOS DAC/DBI in iOS CoreCLR runtime pack for remote debugging

### DIFF
--- a/eng/Subsets.props
+++ b/eng/Subsets.props
@@ -73,7 +73,7 @@
     <DefaultSubsets Condition="'$(TargetsMobile)' == 'true'">mono+libs+packs</DefaultSubsets>
     <DefaultSubsets Condition="'$(TargetsAndroid)' == 'true' and '$(CoreCLRSupported)' == 'true'">clr+mono+libs+host+packs</DefaultSubsets>
     <DefaultSubsets Condition="'$(TargetsAndroid)' == 'true' and '$(CoreCLRSupported)' != 'true' and '$(NativeAotSupported)' == 'true'">clr.nativeaotruntime+clr.nativeaotlibs+mono+libs+packs</DefaultSubsets>
-    <DefaultSubsets Condition="'$(TargetsAppleMobile)' == 'true'">clr+mono+libs+host+packs</DefaultSubsets>
+    <DefaultSubsets Condition="'$(TargetsAppleMobile)' == 'true'">clr+mono+libs+host+osxdac+packs</DefaultSubsets>
     <DefaultSubsets Condition="'$(TargetsLinuxBionic)' == 'true' and '$(MonoSupported)' == 'true'">clr.nativeaotruntime+clr.nativeaotlibs+mono+libs+host+packs</DefaultSubsets>
     <DefaultSubsets Condition="'$(TargetsLinuxBionic)' == 'true' and '$(MonoSupported)' != 'true'">clr.nativeaotruntime+clr.nativeaotlibs+libs+packs</DefaultSubsets>
     <!-- In source build, mono is only supported as primary runtime flavor. -->
@@ -164,6 +164,7 @@
     <AllSubsetsExpansion>clr.nativeprereqs+clr.iltools+clr.runtime+clr.native+clr.aot+clr.nativeaotlibs+clr.nativeaotruntime+clr.crossarchtools</AllSubsetsExpansion>
     <AllSubsetsExpansion>$(AllSubsetsExpansion)+clr.paltests+clr.paltestlist+clr.hosts+clr.jit+clr.alljits+clr.alljitscommunity+clr.spmi+clr.corelib+clr.nativecorelib+clr.tools+clr.toolstests+clr.packages</AllSubsetsExpansion>
     <AllSubsetsExpansion Condition="$([MSBuild]::IsOsPlatform(Windows))">$(AllSubsetsExpansion)+linuxdac+alpinedac</AllSubsetsExpansion>
+    <AllSubsetsExpansion Condition="$([MSBuild]::IsOsPlatform(OSX))">$(AllSubsetsExpansion)+osxdac</AllSubsetsExpansion>
     <AllSubsetsExpansion>$(AllSubsetsExpansion)+mono.runtime+provision.emsdk+mono.aotcross+mono.corelib+mono.manifests+mono.packages+mono.tools+mono.wasmruntime+mono.wasiruntime+mono.wasmworkload+mono.mscordbi+mono.workloads</AllSubsetsExpansion>
     <AllSubsetsExpansion>$(AllSubsetsExpansion)+tools.illink+tools.cdac+tools.illinktests+tools.cdactests+tools.cdacdumptests</AllSubsetsExpansion>
     <AllSubsetsExpansion>$(AllSubsetsExpansion)+host.native+host.pkg+host.tools+host.pretest+host.tests</AllSubsetsExpansion>
@@ -229,6 +230,7 @@
     <SubsetName Include="Clr.Packages" Description="The projects that produce NuGet packages for the CoreCLR runtime, crossgen, and IL tools." />
     <SubsetName Include="LinuxDac" Condition="$([MSBuild]::IsOsPlatform(Windows))" OnDemand="true" Description="The cross-OS Windows->libc-based Linux DAC. Skipped on x86." />
     <SubsetName Include="AlpineDac" Condition="$([MSBuild]::IsOsPlatform(Windows))" OnDemand="true" Description="The cross-OS Windows->musl-libc-based Linux DAC. Skipped on x86" />
+    <SubsetName Include="OsxDac" Condition="$([MSBuild]::IsOsPlatform(OSX))" OnDemand="true" Description="The macOS DAC/DBI for host-side debugging of Apple mobile apps." />
     <SubsetName Include="CrossDacPack" OnDemand="true"
             Description="Packaging of cross OS DAC. Requires all assets needed to be present at a folder specified by $(CrossDacArtifactsDir). See 'Microsoft.CrossOsDiag.Private.CoreCLR.proj' for details." />
 
@@ -459,6 +461,17 @@
 
   <ItemGroup Condition="$(_subset.Contains('+crossdacpack+'))">
     <ProjectToBuild Include="$(CoreClrProjectRoot).nuget\Microsoft.CrossOsDiag.Private.CoreCLR\Microsoft.CrossOsDiag.Private.CoreCLR.proj" Category="clr" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(_subset.Contains('+osxdac+')) and '$(TargetsAppleMobile)' == 'true' and $([MSBuild]::IsOsPlatform(OSX))">
+    <ProjectToBuild
+      Include="$(CoreClrProjectRoot)runtime.proj"
+      AdditionalProperties="%(AdditionalProperties);
+                            ClrDebugSubset=true;
+                            PgoInstrument=false;
+                            NoPgoOptimize=true;
+                            TargetOS=osx;
+                            TargetArchitecture=$(BuildArchitecture)" Category="clr" />
   </ItemGroup>
 
   <ItemGroup Condition="$(_subset.Contains('+clr.tools+'))">

--- a/eng/liveBuilds.targets
+++ b/eng/liveBuilds.targets
@@ -95,6 +95,9 @@
       <CoreCLRSharedFrameworkPdbDir>$([MSBuild]::NormalizeDirectory('$(CoreCLRSharedFrameworkDir)','PDB'))</CoreCLRSharedFrameworkPdbDir>
       <CoreCLRCrossTargetComponentDir
         Condition="'$(CoreCLRCrossTargetComponentDirName)' != ''">$([MSBuild]::NormalizeDirectory('$(CoreCLRArtifactsPath)','$(CoreCLRCrossTargetComponentDirName)','sharedFramework'))</CoreCLRCrossTargetComponentDir>
+      <!-- For Apple mobile the host debugger needs host-platform DAC/DBI to inspect the remote process. -->
+      <CoreCLRHostDebugComponentDir
+        Condition="'$(TargetsAppleMobile)' == 'true'">$([MSBuild]::NormalizeDirectory('$(RepoRoot)', 'artifacts', 'bin', 'coreclr', 'osx.$(BuildArchitecture).$(CoreCLRConfiguration)', 'sharedFramework'))</CoreCLRHostDebugComponentDir>
     </PropertyGroup>
     <PropertyGroup Condition="'$(RuntimeFlavor)' == 'Mono'">
       <MonoArtifactsPath>$([MSBuild]::NormalizeDirectory('$(MonoArtifactsPath)'))</MonoArtifactsPath>
@@ -139,7 +142,13 @@
         <TargetPath>runtime/$(CoreCLRCrossTargetComponentDirName)_$(TargetArchitecture)/native</TargetPath>
         <IsNative>true</IsNative>
       </CoreCLRCrossTargetFiles>
+
+      <CoreCLRHostDebugFiles Condition="'$(CoreCLRHostDebugComponentDir)' != '' and Exists('$(CoreCLRHostDebugComponentDir)')"
+        Include="$(CoreCLRHostDebugComponentDir)$(LibPrefix)mscordaccore$(LibSuffix)" IsNative="true" />
+      <CoreCLRHostDebugFiles Condition="'$(CoreCLRHostDebugComponentDir)' != '' and Exists('$(CoreCLRHostDebugComponentDir)')"
+        Include="$(CoreCLRHostDebugComponentDir)$(LibPrefix)mscordbi$(LibSuffix)" IsNative="true" />
     </ItemGroup>
+
     <ItemGroup Condition="'$(RuntimeFlavor)' == 'Mono'">
       <RuntimeFiles Include="$(MonoArtifactsPath)\*.*" Exclude="$(MonoArtifactsPath)\*cdac*" />
       <RuntimeFiles>

--- a/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.CoreCLR.sfxproj
+++ b/src/installer/pkg/sfx/Microsoft.NETCore.App/Microsoft.NETCore.App.Runtime.CoreCLR.sfxproj
@@ -91,6 +91,12 @@
       </CoreCLRCrossTargetFiles>
 
       <ReferenceCopyLocalPaths Include="@(CoreCLRCrossTargetFiles)" />
+
+      <CoreCLRHostDebugFiles Condition="'@(CoreCLRHostDebugFiles)' != ''">
+        <TargetPath>tools/osx-$(BuildArchitecture)</TargetPath>
+      </CoreCLRHostDebugFiles>
+      <CoreCLRHostDebugFiles PackOnly="true" />
+      <ReferenceCopyLocalPaths Include="@(CoreCLRHostDebugFiles)" />
     </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
## Description

When debugging iOS CoreCLR apps remotely, debugger runs on the macOS host and needs macOS-platform DAC/DBI (`libmscordaccore.dylib`, `libmscordbi.dylib`) to inspect the target process. The iOS runtime pack only contains iOS-platform DAC/DBI, which vsdbg cannot dlopen. This change adds an `osxdac` build subset (following the `linuxdac`/`alpinedac` pattern) that builds the macOS CoreCLR debug component during Apple mobile builds, and packages the resulting macOS DAC/DBI under `tools/osx-{arch}/` in the iOS CoreCLR runtime pack. 

Related macios PR: https://github.com/dotnet/macios/pull/25041

Fixes https://github.com/dotnet/runtime/issues/125974