### PR TITLE
Fix InMemoryDirectoryInfo path resolution for '..' and relative paths

### DIFF
--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Abstractions/DirectoryInfoBase.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Abstractions/DirectoryInfoBase.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Abstractions
         /// Returns an instance of <see cref="DirectoryInfoBase" /> that represents a subdirectory
         /// </summary>
         /// <param name="path">The directory name</param>
-        /// <returns>Instance of <see cref="DirectoryInfoBase" /> even if directory does not exist</returns>
+        /// <returns>Instance of <see cref="DirectoryInfoBase" /> even if the directory does not exist</returns>
         public abstract DirectoryInfoBase? GetDirectory(string path);
 
         /// <summary>
         /// Returns an instance of <see cref="FileInfoBase" /> that represents a file in the directory
         /// </summary>
         /// <param name="path">The file name</param>
-        /// <returns>Instance of <see cref="FileInfoBase" /> even if file does not exist</returns>
+        /// <returns>Instance of <see cref="FileInfoBase" /> even if the file does not exist</returns>
         public abstract FileInfoBase? GetFile(string path);
     }
 }

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
@@ -63,22 +63,26 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Abstractions
         /// Returns an instance of <see cref="DirectoryInfoBase" /> that represents a subdirectory.
         /// </summary>
         /// <remarks>
-        /// If <paramref name="path" /> equals '..', this returns the parent directory.
+        /// If <paramref name="name" /> equals '..', this returns the parent directory.
         /// </remarks>
-        /// <param name="path">The directory name</param>
-        /// <returns>The directory</returns>
-        public override DirectoryInfoBase GetDirectory(string path)
+        /// <param name="name">The directory name</param>
+        /// <returns>Instance of <see cref="DirectoryInfoBase" /> even if the directory does not exist</returns>
+        public override DirectoryInfoBase GetDirectory(string name)
         {
-            bool isParentPath = string.Equals(path, "..", StringComparison.Ordinal);
+            bool isParentPath = string.Equals(name, "..", StringComparison.Ordinal);
 
             return new DirectoryInfoWrapper(
-                new DirectoryInfo(Path.Combine(_directoryInfo.FullName, path)),
+                new DirectoryInfo(Path.Combine(_directoryInfo.FullName, name)),
                 isParentPath);
         }
 
-        /// <inheritdoc />
-        public override FileInfoBase GetFile(string path)
-            => new FileInfoWrapper(new FileInfo(Path.Combine(_directoryInfo.FullName, path)));
+        /// <summary>
+        /// Returns an instance of <see cref="FileInfoBase" /> that represents a file in the directory
+        /// </summary>
+        /// <param name="name">The file name</param>
+        /// <returns>Instance of <see cref="FileInfoBase" /> even if the file does not exist</returns>
+        public override FileInfoBase GetFile(string name)
+            => new FileInfoWrapper(new FileInfo(Path.Combine(_directoryInfo.FullName, name)));
 
         /// <inheritdoc />
         public override string Name => _isParentPath ? ".." : _directoryInfo.Name;

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/Abstractions/DirectoryInfoWrapper.cs
@@ -63,44 +63,22 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Abstractions
         /// Returns an instance of <see cref="DirectoryInfoBase" /> that represents a subdirectory.
         /// </summary>
         /// <remarks>
-        /// If <paramref name="name" /> equals '..', this returns the parent directory.
+        /// If <paramref name="path" /> equals '..', this returns the parent directory.
         /// </remarks>
-        /// <param name="name">The directory name</param>
+        /// <param name="path">The directory name</param>
         /// <returns>The directory</returns>
-        public override DirectoryInfoBase? GetDirectory(string name)
+        public override DirectoryInfoBase GetDirectory(string path)
         {
-            bool isParentPath = string.Equals(name, "..", StringComparison.Ordinal);
+            bool isParentPath = string.Equals(path, "..", StringComparison.Ordinal);
 
-            if (isParentPath)
-            {
-                return new DirectoryInfoWrapper(
-                    new DirectoryInfo(Path.Combine(_directoryInfo.FullName, name)),
-                    isParentPath);
-            }
-            else
-            {
-                DirectoryInfo[] dirs = _directoryInfo.GetDirectories(name);
-
-                if (dirs.Length == 1)
-                {
-                    return new DirectoryInfoWrapper(dirs[0], isParentPath);
-                }
-                else if (dirs.Length == 0)
-                {
-                    return null;
-                }
-                else
-                {
-                    // This shouldn't happen. The parameter name isn't supposed to contain wild card.
-                    throw new InvalidOperationException(
-                        $"More than one sub directories are found under {_directoryInfo.FullName} with name {name}.");
-                }
-            }
+            return new DirectoryInfoWrapper(
+                new DirectoryInfo(Path.Combine(_directoryInfo.FullName, path)),
+                isParentPath);
         }
 
         /// <inheritdoc />
-        public override FileInfoBase GetFile(string name)
-            => new FileInfoWrapper(new FileInfo(Path.Combine(_directoryInfo.FullName, name)));
+        public override FileInfoBase GetFile(string path)
+            => new FileInfoWrapper(new FileInfo(Path.Combine(_directoryInfo.FullName, path)));
 
         /// <inheritdoc />
         public override string Name => _isParentPath ? ".." : _directoryInfo.Name;

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         {
         }
 
-        private InMemoryDirectoryInfo(string rootDir, IEnumerable<string>? files, bool normalized, StringComparison comparisonType)
+        private InMemoryDirectoryInfo(string rootDir, IEnumerable<string>? files, bool normalized, StringComparison comparisonType, bool isParentPath = false)
         {
             if (string.IsNullOrEmpty(rootDir))
             {
@@ -51,7 +51,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing
 
             files ??= new List<string>();
 
-            Name = Path.GetFileName(rootDir);
+            Name = isParentPath ? ".." : Path.GetFileName(rootDir);
             if (normalized)
             {
                 _files = files;
@@ -141,17 +141,12 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         }
 
         /// <inheritdoc />
-        public override DirectoryInfoBase GetDirectory(string path)
+        public override DirectoryInfoBase? GetDirectory(string path)
         {
-            if (string.Equals(path, "..", StringComparison.Ordinal))
-            {
-                return new InMemoryDirectoryInfo(Path.Combine(FullName, path), _files, true, _comparisonType);
-            }
-            else
-            {
-                string normPath = Path.GetFullPath(path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
-                return new InMemoryDirectoryInfo(normPath, _files, true, _comparisonType);
-            }
+            bool isParentPath = string.Equals(path, "..", StringComparison.Ordinal);
+            string? combinedPath = isParentPath ? Path.GetDirectoryName(FullName) : Path.Combine(FullName, path);
+            string? normPath = combinedPath?.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            return normPath == null ? null : new InMemoryDirectoryInfo(normPath, _files, true, _comparisonType, isParentPath);
         }
 
         /// <summary>
@@ -161,7 +156,8 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         /// <returns>Instance of <see cref="FileInfoBase"/> if the file exists, null otherwise.</returns>
         public override FileInfoBase? GetFile(string path)
         {
-            string normPath = Path.GetFullPath(path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
+            string combinedPath = Path.Combine(FullName, path);
+            string normPath = combinedPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
             foreach (string file in _files)
             {
                 if (string.Equals(file, normPath))

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
@@ -141,12 +141,12 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         }
 
         /// <inheritdoc />
-        public override DirectoryInfoBase? GetDirectory(string path)
+        public override DirectoryInfoBase GetDirectory(string path)
         {
+            string combinedPath = Path.Combine(FullName, path);
+            string normPath = Path.GetFullPath(combinedPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
             bool isParentPath = string.Equals(path, "..", StringComparison.Ordinal);
-            string? combinedPath = isParentPath ? Path.GetDirectoryName(FullName) : Path.Combine(FullName, path);
-            string? normPath = combinedPath?.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-            return normPath == null ? null : new InMemoryDirectoryInfo(normPath, _files, true, _comparisonType, isParentPath);
+            return new InMemoryDirectoryInfo(normPath, _files, true, _comparisonType, isParentPath);
         }
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         public override FileInfoBase? GetFile(string path)
         {
             string combinedPath = Path.Combine(FullName, path);
-            string normPath = combinedPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+            string normPath = Path.GetFullPath(combinedPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
             foreach (string file in _files)
             {
                 if (string.Equals(file, normPath))

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/src/InMemoryDirectoryInfo.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         public override string Name { get; }
 
         /// <inheritdoc />
-        public override DirectoryInfoBase? ParentDirectory =>
+        public override DirectoryInfoBase ParentDirectory =>
             new InMemoryDirectoryInfo(Path.GetDirectoryName(FullName)!, _files, true, _comparisonType);
 
         /// <inheritdoc />
@@ -143,9 +143,20 @@ namespace Microsoft.Extensions.FileSystemGlobbing
         /// <inheritdoc />
         public override DirectoryInfoBase GetDirectory(string path)
         {
-            string combinedPath = Path.Combine(FullName, path);
-            string normPath = Path.GetFullPath(combinedPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
             bool isParentPath = string.Equals(path, "..", StringComparison.Ordinal);
+
+            string normPath;
+
+            if (isParentPath)
+            {
+                normPath = Path.GetDirectoryName(FullName) ?? FullName;
+            }
+            else
+            {
+                string combinedPath = Path.Combine(FullName, path);
+                normPath = Path.GetFullPath(combinedPath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
+            }
+
             return new InMemoryDirectoryInfo(normPath, _files, true, _comparisonType, isParentPath);
         }
 

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FileAbstractionsTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FileAbstractionsTests.cs
@@ -7,6 +7,8 @@ using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
 using Microsoft.Extensions.FileSystemGlobbing.Tests.TestUtility;
 using Xunit;
 
+#nullable enable
+
 namespace Microsoft.Extensions.FileSystemGlobbing.Tests
 {
     public class FileAbstractionsTests
@@ -16,7 +18,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
         {
             using (var scenario = new DisposableFileSystem())
             {
-                var contents = scenario.DirectoryInfo.EnumerateFileSystemInfos();
+                var contents = scenario.DirectoryInfo!.EnumerateFileSystemInfos();
 
                 Assert.Equal(Path.GetFileName(scenario.RootPath), scenario.DirectoryInfo.Name);
                 Assert.Equal(scenario.RootPath, scenario.DirectoryInfo.FullName);
@@ -24,13 +26,15 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             }
         }
 
-        [Fact]
-        public void FilesAreEnumerated()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void FilesAreEnumerated(bool useInMemory)
         {
-            using (var scenario = new DisposableFileSystem()
+            using (var scenario = new DisposableFileSystem(useInMemory)
                 .CreateFile("alpha.txt"))
             {
-                var contents = new DirectoryInfoWrapper(scenario.DirectoryInfo).EnumerateFileSystemInfos();
+                var contents = scenario.GetDirectoryInfoBase().EnumerateFileSystemInfos();
                 var alphaTxt = contents.OfType<FileInfoBase>().Single();
 
                 Assert.Single(contents);
@@ -44,7 +48,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             using (var scenario = new DisposableFileSystem()
                 .CreateFolder("beta"))
             {
-                var contents1 = new DirectoryInfoWrapper(scenario.DirectoryInfo).EnumerateFileSystemInfos();
+                var contents1 = scenario.GetDirectoryInfoBase().EnumerateFileSystemInfos();
                 var beta = contents1.OfType<DirectoryInfoBase>().Single();
                 var contents2 = beta.EnumerateFileSystemInfos();
 
@@ -54,14 +58,16 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             }
         }
 
-        [Fact]
-        public void SubFoldersAreEnumerated()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SubFoldersAreEnumerated(bool useInMemory)
         {
-            using (var scenario = new DisposableFileSystem()
+            using (var scenario = new DisposableFileSystem(useInMemory)
                 .CreateFolder("beta")
                 .CreateFile(Path.Combine("beta", "alpha.txt")))
             {
-                var contents1 = new DirectoryInfoWrapper(scenario.DirectoryInfo).EnumerateFileSystemInfos();
+                var contents1 = scenario.GetDirectoryInfoBase().EnumerateFileSystemInfos();
                 var beta = contents1.OfType<DirectoryInfoBase>().Single();
                 var contents2 = beta.EnumerateFileSystemInfos();
                 var alphaTxt = contents2.OfType<FileInfoBase>().Single();
@@ -73,27 +79,33 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             }
         }
 
-        [Fact]
-        public void GetDirectoryCanTakeDotDot()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void GetDirectoryCanTakeDotDot(bool useInMemory)
         {
-            using (var scenario = new DisposableFileSystem()
+            using (var scenario = new DisposableFileSystem(useInMemory)
                 .CreateFolder("gamma")
+                .CreateFile(Path.Combine("gamma", "delta.txt"))
                 .CreateFolder("beta")
                 .CreateFile(Path.Combine("beta", "alpha.txt")))
             {
-                var directoryInfoBase = new DirectoryInfoWrapper(scenario.DirectoryInfo);
+                var directoryInfoBase = scenario.GetDirectoryInfoBase();
+
                 var gamma = directoryInfoBase.GetDirectory("gamma");
-                var dotdot = gamma.GetDirectory("..");
-                var contents1 = dotdot.EnumerateFileSystemInfos();
+                var dotdot = gamma!.GetDirectory("..");
+                var contents1 = dotdot!.EnumerateFileSystemInfos();
                 var beta = dotdot.GetDirectory("beta");
-                var contents2 = beta.EnumerateFileSystemInfos();
+                var contents2 = beta!.EnumerateFileSystemInfos();
                 var alphaTxt = contents2.OfType<FileInfoBase>().Single();
+                var beta2 = directoryInfoBase.GetDirectory("beta");
 
                 Assert.Equal("..", dotdot.Name);
                 Assert.Equal(2, contents1.Count());
                 Assert.Equal("beta", beta.Name);
                 Assert.Single(contents2);
                 Assert.Equal("alpha.txt", alphaTxt.Name);
+                Assert.Equal(beta.FullName, beta2!.FullName);
             }
         }
     }

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
@@ -708,7 +708,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             var matcher = new Matcher();
             matcher.AddInclude($"**{separator}*.cs");
 
-            IEnumerable<string> files = GetFileList(Path.GetPathRoot(rootDir), separator);
+            IEnumerable<string> files = GetFileList(Path.GetPathRoot(rootDir)!, separator);
             PatternMatchingResult results = matcher.Match(rootDir, files);
 
             IEnumerable<string> actual = results.Files.Select(match => match.Path);
@@ -824,12 +824,12 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             {
                 // Windows-like absolute paths are not supported on Unix.
                 string fakeWindowsPath = "C:\\This\\is\\a\\nested\\windows-like\\path\\somefile.cs";
-                Assert.True(fileMatcher.Match(Path.GetPathRoot(fakeWindowsPath), fakeWindowsPath).HasMatches);
+                Assert.True(fileMatcher.Match(Path.GetPathRoot(fakeWindowsPath)!, fakeWindowsPath).HasMatches);
             }
             
             // Unix-like absolute paths are treated as relative paths on Windows.
             string fakeUnixPath = "/This/is/a/nested/unix-like/path/somefile.cs";
-            Assert.True(fileMatcher.Match(Path.GetPathRoot(fakeUnixPath), fakeUnixPath).HasMatches);
+            Assert.True(fileMatcher.Match(Path.GetPathRoot(fakeUnixPath)!, fakeUnixPath).HasMatches);
         }
 
         [Fact] // https://github.com/dotnet/runtime/issues/36415
@@ -1005,6 +1005,22 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             };
 
             AssertExtensions.CollectionEqual(expected, actual, StringComparer.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void VerifyInMemoryDirectoryInfo_ParentPatternMatches()
+        {
+            string rootDir = "/Folder1";
+            string[] files = ["/Folder1/File1.txt", "/Folder2/File2.txt"];
+
+            var matcher = new Matcher();
+            matcher.AddInclude("../Folder2/**");
+
+            var result = matcher.Execute(new InMemoryDirectoryInfo(rootDir, files));
+
+            Assert.True(result.HasMatches);
+            Assert.Single(result.Files);
+            Assert.Equal("../Folder2/File2.txt", result.Files.First().Path);
         }
     }
 }

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/FunctionalTests.cs
@@ -708,7 +708,7 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             var matcher = new Matcher();
             matcher.AddInclude($"**{separator}*.cs");
 
-            IEnumerable<string> files = GetFileList(Path.GetPathRoot(rootDir)!, separator);
+            IEnumerable<string> files = GetFileList(Path.GetPathRoot(rootDir), separator);
             PatternMatchingResult results = matcher.Match(rootDir, files);
 
             IEnumerable<string> actual = results.Files.Select(match => match.Path);
@@ -824,12 +824,12 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests
             {
                 // Windows-like absolute paths are not supported on Unix.
                 string fakeWindowsPath = "C:\\This\\is\\a\\nested\\windows-like\\path\\somefile.cs";
-                Assert.True(fileMatcher.Match(Path.GetPathRoot(fakeWindowsPath)!, fakeWindowsPath).HasMatches);
+                Assert.True(fileMatcher.Match(Path.GetPathRoot(fakeWindowsPath), fakeWindowsPath).HasMatches);
             }
             
             // Unix-like absolute paths are treated as relative paths on Windows.
             string fakeUnixPath = "/This/is/a/nested/unix-like/path/somefile.cs";
-            Assert.True(fileMatcher.Match(Path.GetPathRoot(fakeUnixPath)!, fakeUnixPath).HasMatches);
+            Assert.True(fileMatcher.Match(Path.GetPathRoot(fakeUnixPath), fakeUnixPath).HasMatches);
         }
 
         [Fact] // https://github.com/dotnet/runtime/issues/36415

--- a/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/TestUtility/DisposableFileSystem.cs
+++ b/src/libraries/Microsoft.Extensions.FileSystemGlobbing/tests/TestUtility/DisposableFileSystem.cs
@@ -2,36 +2,57 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using Microsoft.Extensions.FileSystemGlobbing.Abstractions;
+
+#nullable enable
 
 namespace Microsoft.Extensions.FileSystemGlobbing.Tests.TestUtility
 {
     public class DisposableFileSystem : IDisposable
     {
-        public DisposableFileSystem()
+        private readonly bool _useInMemory;
+        private readonly List<string> _files = new List<string>();
+
+        public DisposableFileSystem(bool useInMemory = false)
         {
-#if NET
-            DirectoryInfo = Directory.CreateTempSubdirectory();
-#else
-            DirectoryInfo = new DirectoryInfo(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()));
-            DirectoryInfo.Create();
-#endif
-            RootPath = DirectoryInfo.FullName;
+            _useInMemory = useInMemory;
+
+            RootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+            if (!useInMemory)
+            {
+                DirectoryInfo = new DirectoryInfo(RootPath);
+                DirectoryInfo.Create();
+            }
         }
 
         public string RootPath { get; }
 
-        public DirectoryInfo DirectoryInfo { get; }
+        public DirectoryInfo? DirectoryInfo { get; }
 
         public DisposableFileSystem CreateFolder(string path)
         {
-            Directory.CreateDirectory(Path.Combine(RootPath, path));
+            if (!_useInMemory)
+            {
+                Directory.CreateDirectory(Path.Combine(RootPath, path));
+            }
+
             return this;
         }
 
         public DisposableFileSystem CreateFile(string path)
         {
-            File.WriteAllText(Path.Combine(RootPath, path), "temp");
+            string fullPath = Path.Combine(RootPath, path);
+
+            if (!_useInMemory)
+            {
+                File.WriteAllText(fullPath, "temp");
+            }
+
+            _files.Add(fullPath);
+
             return this;
         }
 
@@ -40,25 +61,37 @@ namespace Microsoft.Extensions.FileSystemGlobbing.Tests.TestUtility
             foreach (var path in fileRelativePaths)
             {
                 var fullPath = Path.Combine(RootPath, path);
-                Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
 
-                File.WriteAllText(
-                    fullPath,
-                    string.Format("Automatically generated for testing on {0:yyyy}/{0:MM}/{0:dd} {0:hh}:{0:mm}:{0:ss}", DateTime.UtcNow));
+                if (!_useInMemory)
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+
+                    File.WriteAllText(
+                        fullPath,
+                        string.Format("Automatically generated for testing on {0:yyyy}/{0:MM}/{0:dd} {0:hh}:{0:mm}:{0:ss}", DateTime.UtcNow));
+                }
+
+                _files.Add(fullPath);
             }
 
             return this;
         }
 
+        public DirectoryInfoBase GetDirectoryInfoBase()
+            => _useInMemory ? new InMemoryDirectoryInfo(RootPath, _files) : new DirectoryInfoWrapper(DirectoryInfo!);
+
         public void Dispose()
         {
-            try
+            if (!_useInMemory)
             {
-                Directory.Delete(RootPath, true);
-            }
-            catch
-            {
-                // Don't throw if this fails.
+                try
+                {
+                    Directory.Delete(RootPath, true);
+                }
+                catch
+                {
+                    // Don't throw if this fails.
+                }
             }
         }
     }


### PR DESCRIPTION
Fix #99691 — `InMemoryDirectoryInfo` does not work with the `..` pattern.

## Problem

`InMemoryDirectoryInfo.GetDirectory` had two bugs:
- For `..`, it combined with `FullName` but passed the result as already-normalized, leaving `FullName` as e.g. `/Folder1/..` instead of resolving to the parent directory.
- For other relative paths, it resolved against the process CWD, ignoring `FullName` entirely.

`GetFile` had the same issue as the second case — it resolved relative paths against CWD instead of combining with `FullName`.

## Fix

Both `GetDirectory` and `GetFile` now combine the input path with `FullName` via `Path.Combine` and normalize via `Path.GetFullPath`, which properly resolves `..` segments. An `isParentPath` flag preserves `Name` as `".."` (needed by the matcher's pattern traversal), matching `DirectoryInfoWrapper`'s existing approach.

`DirectoryInfoWrapper.GetDirectory` was also simplified: the old code used `GetDirectories(name)` to look up subdirectories (returning `null` when not found), but this is inconsistent with the base class contract (`GetDirectory` should return an instance even if the directory does not exist). It now always constructs a `DirectoryInfo` via `Path.Combine`, matching the `..` branch that was already doing this.

## Tests

- Converted `FileAbstractionsTests` (`FilesAreEnumerated`, `SubFoldersAreEnumerated`, `GetDirectoryCanTakeDotDot`) from `[Fact]` to `[Theory]` with `bool useInMemory`, so each test exercises both `DirectoryInfoWrapper` and `InMemoryDirectoryInfo`.
- Added `VerifyInMemoryDirectoryInfo_ParentPatternMatches` in `FunctionalTests` — an end-to-end test that uses `Matcher` with a `../Folder2/**` pattern against `InMemoryDirectoryInfo`.
- Enhanced `DisposableFileSystem` with `useInMemory` support: when true, no files or directories are created on disk, and `GetDirectoryInfoBase()` returns an `InMemoryDirectoryInfo` populated from the recorded `CreateFile`/`CreateFiles` calls.
