### PR TITLE
[Wasm RyuJIT] Partially implement genStructReturn

### DIFF
--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -3112,7 +3112,7 @@ void CodeGen::genStructReturn(GenTree* treeNode)
     {
         // Go through and consume the fields in the field list so liveness is correct.
         unsigned regIndex = 0;
-        for (GenTreeFieldList::Use& use : op1->AsFieldList()->Uses())
+        for (GenTreeFieldList::Use& use : actualOp1->AsFieldList()->Uses())
         {
             genConsumeReg(use.GetNode());
             regIndex++;

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -3108,18 +3108,18 @@ void CodeGen::genStructReturn(GenTree* treeNode)
 
     assert(regCount <= MAX_RET_REG_COUNT);
 
-    if (op1->OperIsFieldList())
+    if (actualOp1->OperIsFieldList())
     {
         // Go through and consume the fields in the field list so liveness is correct.
         unsigned regIndex = 0;
         for (GenTreeFieldList::Use& use : op1->AsFieldList()->Uses())
         {
-            GenTree*  fieldNode = use.GetNode();
-            regNumber sourceReg = genConsumeReg(fieldNode);
+            genConsumeReg(use.GetNode());
             regIndex++;
         }
 
-        // We should only have one field in the field list.
+        // We should only have one field in the field list, and MAX_RET_REG_COUNT is 1 on Wasm.
+        assert(regIndex == regCount);
         assert(regIndex == 1);
 
         // The field list's individual fields should have preceded us in LIR and code to push them onto the stack

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -3098,6 +3098,38 @@ void CodeGen::genEHCatchRet(BasicBlock* block)
 
 void CodeGen::genStructReturn(GenTree* treeNode)
 {
+    assert(treeNode->OperIs(GT_RETURN));
+
+    GenTree* op1       = treeNode->AsOp()->GetReturnValue();
+    GenTree* actualOp1 = op1->gtSkipReloadOrCopy();
+
+    const ReturnTypeDesc& retTypeDesc = m_compiler->compRetTypeDesc;
+    const unsigned        regCount    = retTypeDesc.GetReturnRegCount();
+
+    assert(regCount <= MAX_RET_REG_COUNT);
+
+    if (op1->OperIsFieldList())
+    {
+        // Go through and consume the fields in the field list so liveness is correct.
+        unsigned regIndex = 0;
+        for (GenTreeFieldList::Use& use : op1->AsFieldList()->Uses())
+        {
+            GenTree*  fieldNode = use.GetNode();
+            regNumber sourceReg = genConsumeReg(fieldNode);
+            regIndex++;
+        }
+
+        // We should only have one field in the field list.
+        assert(regIndex == 1);
+
+        // The field list's individual fields should have preceded us in LIR and code to push them onto the stack
+        // should already have been generated. We should also only have one field (see MAX_RET_REG_COUNT assert,
+        // above.) As a result, all we need to do is generate a return opcode.
+        GetEmitter()->emitIns(INS_return);
+
+        return;
+    }
+
     NYI_WASM("genStructReturn");
 }
 

--- a/src/coreclr/jit/codegenwasm.cpp
+++ b/src/coreclr/jit/codegenwasm.cpp
@@ -3122,15 +3122,10 @@ void CodeGen::genStructReturn(GenTree* treeNode)
         assert(regIndex == regCount);
         assert(regIndex == 1);
 
-        // The field list's individual fields should have preceded us in LIR and code to push them onto the stack
-        // should already have been generated. We should also only have one field (see MAX_RET_REG_COUNT assert,
-        // above.) As a result, all we need to do is generate a return opcode.
-        GetEmitter()->emitIns(INS_return);
-
         return;
     }
 
-    NYI_WASM("genStructReturn");
+    NYI_WASM("genStructReturn non-fieldlist cases");
 }
 
 void CodeGen::genEmitGSCookieCheck(bool tailCall)


### PR DESCRIPTION
Addresses a top assert from https://github.com/dotnet/runtime/issues/125756
Scenarios other than fieldlist are not implemented because I don't have a repro for them yet.