### PR TITLE
Various fixes to get `-dynamiccodecompiled false` to build on windows

### DIFF
--- a/src/coreclr/inc/switches.h
+++ b/src/coreclr/inc/switches.h
@@ -172,7 +172,7 @@
 
 // Dispatch interface calls via resolve helper followed by an indirect call.
 // Slow functional implementation, only used for stress-testing of DOTNET_JitForceControlFlowGuard=1.
-#if defined(TARGET_WINDOWS) && (defined(TARGET_AMD64) || defined(TARGET_ARM64))
+#if defined(FEATURE_VIRTUAL_STUB_DISPATCH) && defined(TARGET_WINDOWS) && (defined(TARGET_AMD64) || defined(TARGET_ARM64))
 #define FEATURE_RESOLVE_HELPER_DISPATCH
 #endif
 

--- a/src/coreclr/interpreter/CMakeLists.txt
+++ b/src/coreclr/interpreter/CMakeLists.txt
@@ -25,9 +25,9 @@ if(CLR_CMAKE_HOST_WIN32)
     ${STATIC_MT_CRT_LIB}
     ${STATIC_MT_VCRT_LIB}
   )
-  list(APPEND INTERPRETER_SOURCES
-    Native.rc
-  )
+  # Native.rc is added only to the shared library, not to the statically linked one,
+  # to prevent VERSION duplicates
+  set(INTERPRETER_RESOURCES Native.rc)
   add_definitions(-DFX_VER_INTERNALNAME_STR=clrinterpreter.dll)
 endif()
 
@@ -52,7 +52,7 @@ if (NOT CMAKE_GENERATOR MATCHES "Visual Studio")
 endif()
 
 if (NOT CLR_CMAKE_TARGET_ARCH_WASM)
-  add_library_clr(clrinterpreter SHARED $<TARGET_OBJECTS:clrinterpreter_objects> $<TARGET_OBJECTS:dn-containers>)
+  add_library_clr(clrinterpreter SHARED $<TARGET_OBJECTS:clrinterpreter_objects> $<TARGET_OBJECTS:dn-containers> ${INTERPRETER_RESOURCES})
 else()
   add_library_clr(clrinterpreter STATIC $<TARGET_OBJECTS:clrinterpreter_objects> $<TARGET_OBJECTS:dn-containers>)
 endif()

--- a/src/coreclr/vm/amd64/thunktemplates.asm
+++ b/src/coreclr/vm/amd64/thunktemplates.asm
@@ -22,6 +22,7 @@ LEAF_ENTRY FixupPrecodeCode, _TEXT
         jmp    QWORD PTR [DATA_SLOT(FixupPrecode, PrecodeFixupThunk)]
 LEAF_END_MARKED FixupPrecodeCode, _TEXT
 
+ifdef FEATURE_TIERED_COMPILATION
 LEAF_ENTRY CallCountingStubCode, _TEXT
         mov    rax,QWORD PTR [DATA_SLOT(CallCountingStub, RemainingCallCountCell)]
         dec    WORD PTR [rax]
@@ -30,5 +31,6 @@ LEAF_ENTRY CallCountingStubCode, _TEXT
     CountReachedZero:
         jmp    QWORD PTR [DATA_SLOT(CallCountingStub, TargetForThresholdReached)]
 LEAF_END_MARKED CallCountingStubCode, _TEXT
+endif ; FEATURE_TIERED_COMPILATION
 
         end

--- a/src/coreclr/vm/threadsuspend.cpp
+++ b/src/coreclr/vm/threadsuspend.cpp
@@ -2648,7 +2648,7 @@ void __stdcall Thread::RedirectedHandledJITCase(RedirectReason reason)
     if (Thread::UseRedirectForGcStress() && (reason == RedirectReason_GCStress))
     {
         _ASSERTE(pThread->PreemptiveGCDisabledOther());
-        DoGcStress(frame.GetContext(), NULL);
+        DoGcStress(frame.GetContext(), NativeCodeVersion());
     }
     else
 #endif // HAVE_GCCOVER && USE_REDIRECT_FOR_GCSTRESS


### PR DESCRIPTION
This option disables FEATURE_TIERED_COMPILATION,  FEATURE_VIRTUAL_STUB_DISPATCH and enables FEATURE_STATICALLY_LINKED. This configuration was running into some build failures on windows.