### PR TITLE
Update Native AOT documentation

### DIFF
--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -95,7 +95,10 @@ If you haven't built the tests yet, run `src\tests\build.cmd nativeaot [Debug|Re
 
 To run all the tests that got built, run `src\tests\run.cmd runnativeaottests [Debug|Release]` on Windows, or `src/tests/run.sh --runnativeaottests [Debug|Release]` on Linux. The `Debug`/`Release` flag should match the flag that was passed to `build.cmd` in the previous step.
 
-To build an individual test, follow the instructions for compiling an individual test project located in [Building an Individual Test](/docs/workflow/testing/coreclr/testing.md#building-an-individual-test), but add `/t:BuildNativeAot /p:TestBuildMode=nativeaot` to the build command. If using `build[.cmd|.sh]`, add `nativeaot` to the script arguments as well (i.e. on Windows `.\src\tests\build.cmd nativeaot test ...`, on Linux `./src/tests/build.sh -nativeaot test ...`).
+To build an individual test, follow the instructions for compiling an individual test project located in [Building an Individual Test](/docs/workflow/testing/coreclr/testing.md#building-an-individual-test) with additional aruments:
+
+ * For the build build[.cmd|.sh] script add `nativeaot`/`-nativeaot` command line parameter such as `.\src\tests\build.cmd nativeaot test ...` or `./src/tests/build.sh -nativeaot test ...`
+ * For the `dotnet build` workflow, add  `-t:BuildNativeAot -p:TestBuildMode=nativeaot`
 
 To run an individual test (after it was built), navigate to the `artifacts\tests\coreclr\[windows|linux|osx[.x64.[Debug|Release]\$path_to_test` directory. `$path_to_test` matches the subtree of `src\tests`. You should see a `[.cmd|.sh]` file there. This file is a script that will compile and launch the individual test for you. Before invoking the script, set the following environment variables:
 

--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -95,7 +95,7 @@ If you haven't built the tests yet, run `src\tests\build.cmd nativeaot [Debug|Re
 
 To run all the tests that got built, run `src\tests\run.cmd runnativeaottests [Debug|Release]` on Windows, or `src/tests/run.sh --runnativeaottests [Debug|Release]` on Linux. The `Debug`/`Release` flag should match the flag that was passed to `build.cmd` in the previous step.
 
-To build an individual test, follow the instructions for compiling a individual test project located in [Building an Individual Test](/docs/workflow/testing/coreclr/testing.md#building-an-individual-test), but add `/t:BuildNativeAot /p:TestBuildMode=nativeaot` to the build command. If using `build[.cmd|.sh]`, add `nativeaot` to the script arguments as well (i.e. on Windows `.\src\tests\build.cmd nativeaot test ...`).
+To build an individual test, follow the instructions for compiling an individual test project located in [Building an Individual Test](/docs/workflow/testing/coreclr/testing.md#building-an-individual-test), but add `/t:BuildNativeAot /p:TestBuildMode=nativeaot` to the build command. If using `build[.cmd|.sh]`, add `nativeaot` to the script arguments as well (i.e. on Windows `.\src\tests\build.cmd nativeaot test ...`, on Linux `./src/tests/build.sh -nativeaot test ...`).
 
 To run an individual test (after it was built), navigate to the `artifacts\tests\coreclr\[windows|linux|osx[.x64.[Debug|Release]\$path_to_test` directory. `$path_to_test` matches the subtree of `src\tests`. You should see a `[.cmd|.sh]` file there. This file is a script that will compile and launch the individual test for you. Before invoking the script, set the following environment variables:
 

--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -95,10 +95,10 @@ If you haven't built the tests yet, run `src\tests\build.cmd nativeaot [Debug|Re
 
 To run all the tests that got built, run `src\tests\run.cmd runnativeaottests [Debug|Release]` on Windows, or `src/tests/run.sh --runnativeaottests [Debug|Release]` on Linux. The `Debug`/`Release` flag should match the flag that was passed to `build.cmd` in the previous step.
 
-To build an individual test, follow the instructions for compiling an individual test project located in [Building an Individual Test](/docs/workflow/testing/coreclr/testing.md#building-an-individual-test) with additional aruments:
+To build an individual test, follow the instructions for compiling an individual test project located in [Building an Individual Test](/docs/workflow/testing/coreclr/testing.md#building-an-individual-test) with these additional arguments:
 
- * For the build build[.cmd|.sh] script add `nativeaot`/`-nativeaot` command line parameter such as `.\src\tests\build.cmd nativeaot test ...` or `./src/tests/build.sh -nativeaot test ...`
- * For the `dotnet build` workflow, add  `-t:BuildNativeAot -p:TestBuildMode=nativeaot`
+ * For the build `build[.cmd|.sh]` script, add the `nativeaot`/`-nativeaot` command line parameter such as `.\src\tests\build.cmd nativeaot test ...` or `./src/tests/build.sh -nativeaot test ...`
+ * For the `dotnet build` workflow, add `-t:BuildNativeAot -p:TestBuildMode=nativeaot`
 
 To run an individual test (after it was built), navigate to the `artifacts\tests\coreclr\[windows|linux|osx[.x64.[Debug|Release]\$path_to_test` directory. `$path_to_test` matches the subtree of `src\tests`. You should see a `[.cmd|.sh]` file there. This file is a script that will compile and launch the individual test for you. Before invoking the script, set the following environment variables:
 

--- a/docs/workflow/building/coreclr/nativeaot.md
+++ b/docs/workflow/building/coreclr/nativeaot.md
@@ -95,7 +95,7 @@ If you haven't built the tests yet, run `src\tests\build.cmd nativeaot [Debug|Re
 
 To run all the tests that got built, run `src\tests\run.cmd runnativeaottests [Debug|Release]` on Windows, or `src/tests/run.sh --runnativeaottests [Debug|Release]` on Linux. The `Debug`/`Release` flag should match the flag that was passed to `build.cmd` in the previous step.
 
-To build an individual test, follow the instructions for compiling a individual test project located in [Building an Individual Test](/docs/workflow/testing/coreclr/testing.md#building-an-individual-test), but add `/t:BuildNativeAot /p:TestBuildMode=nativeaot` to the build command.
+To build an individual test, follow the instructions for compiling a individual test project located in [Building an Individual Test](/docs/workflow/testing/coreclr/testing.md#building-an-individual-test), but add `/t:BuildNativeAot /p:TestBuildMode=nativeaot` to the build command. If using `build[.cmd|.sh]`, add `nativeaot` to the script arguments as well (i.e. on Windows `.\src\tests\build.cmd nativeaot test ...`).
 
 To run an individual test (after it was built), navigate to the `artifacts\tests\coreclr\[windows|linux|osx[.x64.[Debug|Release]\$path_to_test` directory. `$path_to_test` matches the subtree of `src\tests`. You should see a `[.cmd|.sh]` file there. This file is a script that will compile and launch the individual test for you. Before invoking the script, set the following environment variables:
 


### PR DESCRIPTION
I was getting an error without this argument although I'm not sure if this should be the right fix. I see the script expects the nativeaot argument to set the `__TestBuildMode` env variable. On the other hand, the property `/p:TestBuildMode=nativeaot` doesn't get passed to the msbuild project that ultimately builds the test.

In particular, the error was
```
C:\git\runtime\src\tests\Directory.Build.targets(590,11): error MSB4057: The target "LinkNative" does not exist in the project. [C:\git\runtime\src\tests\Interop\Interop.csproj] [C:\git\runtime\src\tests\build.proj]
C:\git\runtime\src\tests\Common\dir.traversal.targets(25,5): error : (No message specified) [C:\git\runtime\src\tests\build.proj] [C:\git\runtime\src\tests\build.proj]
C:\git\runtime\src\tests\build.proj(288,5): error MSB3073: The command ""C:\git\runtime\\dotnet.cmd" msbuild C:\git\runtime\src\tests\build.proj /t:Build "/p:TargetArchitecture=x64" "/p:Configuration=Debug" "/p:LibrariesConfiguration=Release" "/p:TasksConfiguration=Debug" "/p:TargetOS=windows" "/p:ToolsOS=" "/p:PackageOS=" "/p:RuntimeFlavor=coreclr" "/p:RuntimeVariant=" "/p:CLRTestBuildAllTargets=" "/p:UseCodeFlowEnforcement=" "/p:__TestGroupToBuild=1" "/p:__SkipRestorePackages=1" /nodeReuse:false /maxcpucount "/p:UseMonoRuntime=false" /bl:C:\git\runtime\artifacts\/log/Debug/InnerManagedTestBuild.1.binlog "/p:CppCompilerAndLinker=clang" "/p:DefaultBuildAllTarget=BuildNativeAot" "/p:DevTeamProvisioning=-"" exited with code 1.
```

The command that builds the tests (`"C:\git\runtime\\dotnet.cmd" msbuild C:\git\runtime\src\tests\build.proj /t:Build "/p:TargetArchitecture=x64" ...`) is invoked in a project that doesn't receive the `TestBuildMode` property but reads the `__TestBuildMode` property (set by the `nativeaot` arg) so invoking the script with this argument makes it work.