### PR TITLE
Fix ARM64 interface dispatch cache torn read

### DIFF
--- a/src/coreclr/runtime/arm64/StubDispatch.S
+++ b/src/coreclr/runtime/arm64/StubDispatch.S
@@ -32,7 +32,10 @@
         ldp     x12, x13, [x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + (\entry * 16) - \adj)]
         cmp     x10, x12
         bne     0f
+#ifndef TARGET_APPLE
+        // Apple ARM64 platforms have FEAT_LSE2, making ldp single-copy atomic for the pair.
         cbz     x13, 0f
+#endif
         br      x13
 0:
     .endm

--- a/src/coreclr/runtime/arm64/StubDispatch.S
+++ b/src/coreclr/runtime/arm64/StubDispatch.S
@@ -16,15 +16,30 @@
     // Macro that generates code to check a single cache entry.
     .macro CHECK_CACHE_ENTRY entry
         // Check a single entry in the cache.
-        //  x9   : Cache data structure. Also used for target address jump.
+        //  x9   : Cache data structure
         //  x10  : Instance MethodTable*
         //  x11  : Indirection cell address, preserved
-        //  x12  : Trashed
-        ldr     x12, [x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + (\entry * 16))]
+        //  x12, x13  : Trashed
+        //
+        // Use ldp to load both m_pInstanceType and m_pTargetCode in a single instruction.
+        // On ARM64 two separate ldr instructions can be reordered across a control dependency,
+        // which means a concurrent atomic cache entry update (via stlxp) could be observed as a
+        // torn read (new type, old target). ldp is single-copy atomic for the pair on FEAT_LSE2
+        // hardware (ARMv8.4+). The cbz guard ensures correctness on pre-LSE2 hardware too:
+        // a torn read can only produce a zero target (entries go from 0,0 to type,target),
+        // so we treat it as a cache miss.
+    .if (OFFSETOF__InterfaceDispatchCache__m_rgEntries + (\entry * 16)) > 504
+        // ldp's signed immediate offset must be in [-512,504] for 64-bit registers.
+        // Use add to reach far entries in the 32/64 slot stubs.
+        add     x12, x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + (\entry * 16))
+        ldp     x12, x13, [x12]
+    .else
+        ldp     x12, x13, [x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + (\entry * 16))]
+    .endif
         cmp     x10, x12
         bne     0f
-        ldr     x9, [x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + (\entry * 16) + 8)]
-        br      x9
+        cbz     x13, 0f
+        br      x13
 0:
     .endm
 

--- a/src/coreclr/runtime/arm64/StubDispatch.S
+++ b/src/coreclr/runtime/arm64/StubDispatch.S
@@ -14,9 +14,10 @@
 #endif
 
     // Macro that generates code to check a single cache entry.
-    .macro CHECK_CACHE_ENTRY entry
+    // \adj is the base adjustment already applied to x9.
+    .macro CHECK_CACHE_ENTRY entry, adj=0
         // Check a single entry in the cache.
-        //  x9   : Cache data structure
+        //  x9   : Cache data structure (possibly adjusted for far entries)
         //  x10  : Instance MethodTable*
         //  x11  : Indirection cell address, preserved
         //  x12, x13  : Trashed
@@ -28,14 +29,7 @@
         // hardware (ARMv8.4+). The cbz guard ensures correctness on pre-LSE2 hardware too:
         // a torn read can only produce a zero target (entries go from 0,0 to type,target),
         // so we treat it as a cache miss.
-    .if (OFFSETOF__InterfaceDispatchCache__m_rgEntries + (\entry * 16)) > 504
-        // ldp's signed immediate offset must be in [-512,504] for 64-bit registers.
-        // Use add to reach far entries in the 32/64 slot stubs.
-        add     x12, x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + (\entry * 16))
-        ldp     x12, x13, [x12]
-    .else
-        ldp     x12, x13, [x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + (\entry * 16))]
-    .endif
+        ldp     x12, x13, [x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + (\entry * 16) - \adj)]
         cmp     x10, x12
         bne     0f
         cbz     x13, 0f
@@ -67,9 +61,16 @@
 
     .global CurrentEntry
     .set CurrentEntry, 0
+    .set BaseAdj, 0
 
     .rept \entries
-        CHECK_CACHE_ENTRY CurrentEntry
+        // ldp's signed offset must be in [-512,504] for 64-bit register pairs.
+        // When the offset would exceed that, re-base x9 once so subsequent entries stay in range.
+    .if (OFFSETOF__InterfaceDispatchCache__m_rgEntries + (CurrentEntry * 16) - BaseAdj) > 504
+        add     x9, x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + (CurrentEntry * 16) - BaseAdj)
+        .set BaseAdj, (OFFSETOF__InterfaceDispatchCache__m_rgEntries + (CurrentEntry * 16))
+    .endif
+        CHECK_CACHE_ENTRY CurrentEntry, BaseAdj
         .set CurrentEntry, CurrentEntry + 1
     .endr
 

--- a/src/coreclr/runtime/arm64/StubDispatch.asm
+++ b/src/coreclr/runtime/arm64/StubDispatch.asm
@@ -11,12 +11,13 @@
 
     ;; Macro that generates code to check a single cache entry.
     MACRO
-        CHECK_CACHE_ENTRY $entry
+        CHECK_CACHE_ENTRY $entry, $adj
         ;; Check a single entry in the cache.
-        ;;  x9   : Cache data structure
+        ;;  x9   : Cache data structure (possibly adjusted for far entries)
         ;;  x10  : Instance MethodTable*
         ;;  x11  : Indirection cell address, preserved
         ;;  x12, x13  : Trashed
+        ;;  $adj : Base adjustment already applied to x9
         ;;
         ;; Use ldp to load both m_pInstanceType and m_pTargetCode in a single instruction.
         ;; On ARM64 two separate ldr instructions can be reordered across a control dependency,
@@ -25,14 +26,7 @@
         ;; hardware (ARMv8.4+). The cbz guard ensures correctness on pre-LSE2 hardware too:
         ;; a torn read can only produce a zero target (entries go from 0,0 to type,target),
         ;; so we treat it as a cache miss.
-        IF (OFFSETOF__InterfaceDispatchCache__m_rgEntries + ($entry * 16)) > 504
-        ;; ldp's signed immediate offset must be in [-512,504] for 64-bit registers.
-        ;; Use add to reach far entries in the 32/64 slot stubs.
-        add     x12, x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + ($entry * 16))
-        ldp     x12, x13, [x12]
-        ELSE
-        ldp     x12, x13, [x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + ($entry * 16))]
-        ENDIF
+        ldp     x12, x13, [x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + ($entry * 16) - $adj)]
         cmp     x10, x12
         bne     %ft0
         cbz     x13, %ft0
@@ -57,10 +51,18 @@
         ldr     x10, [x0]
 
     GBLA CurrentEntry
+    GBLA BaseAdj
 CurrentEntry SETA 0
+BaseAdj SETA 0
 
     WHILE CurrentEntry < $entries
-        CHECK_CACHE_ENTRY CurrentEntry
+        ;; ldp's signed offset must be in [-512,504] for 64-bit register pairs.
+        ;; When the offset would exceed that, re-base x9 once so subsequent entries stay in range.
+        IF (OFFSETOF__InterfaceDispatchCache__m_rgEntries + (CurrentEntry * 16) - BaseAdj) > 504
+        add     x9, x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + (CurrentEntry * 16) - BaseAdj)
+BaseAdj SETA (OFFSETOF__InterfaceDispatchCache__m_rgEntries + (CurrentEntry * 16))
+        ENDIF
+        CHECK_CACHE_ENTRY CurrentEntry, BaseAdj
 CurrentEntry SETA CurrentEntry + 1
     WEND
 

--- a/src/coreclr/runtime/arm64/StubDispatch.asm
+++ b/src/coreclr/runtime/arm64/StubDispatch.asm
@@ -13,15 +13,30 @@
     MACRO
         CHECK_CACHE_ENTRY $entry
         ;; Check a single entry in the cache.
-        ;;  x9   : Cache data structure. Also used for target address jump.
+        ;;  x9   : Cache data structure
         ;;  x10  : Instance MethodTable*
         ;;  x11  : Indirection cell address, preserved
-        ;;  x12  : Trashed
-        ldr     x12, [x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + ($entry * 16))]
+        ;;  x12, x13  : Trashed
+        ;;
+        ;; Use ldp to load both m_pInstanceType and m_pTargetCode in a single instruction.
+        ;; On ARM64 two separate ldr instructions can be reordered across a control dependency,
+        ;; which means a concurrent atomic cache entry update (via stlxp) could be observed as a
+        ;; torn read (new type, old target). ldp is single-copy atomic for the pair on FEAT_LSE2
+        ;; hardware (ARMv8.4+). The cbz guard ensures correctness on pre-LSE2 hardware too:
+        ;; a torn read can only produce a zero target (entries go from 0,0 to type,target),
+        ;; so we treat it as a cache miss.
+        IF (OFFSETOF__InterfaceDispatchCache__m_rgEntries + ($entry * 16)) > 504
+        ;; ldp's signed immediate offset must be in [-512,504] for 64-bit registers.
+        ;; Use add to reach far entries in the 32/64 slot stubs.
+        add     x12, x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + ($entry * 16))
+        ldp     x12, x13, [x12]
+        ELSE
+        ldp     x12, x13, [x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + ($entry * 16))]
+        ENDIF
         cmp     x10, x12
         bne     %ft0
-        ldr     x9, [x9, #(OFFSETOF__InterfaceDispatchCache__m_rgEntries + ($entry * 16) + 8)]
-        br      x9
+        cbz     x13, %ft0
+        br      x13
 0
     MEND
 


### PR DESCRIPTION
On ARM64, the CHECK_CACHE_ENTRY macro read m_pInstanceType and m_pTargetCode from a cache entry using two separate ldr instructions separated by a control dependency (cmp/bne). ARM64's weak memory model does not order loads across control dependencies, so the hardware can speculatively satisfy the second load (target) before the first (type) commits. When a concurrent thread atomically populates the entry via stlxp/casp (UpdateCacheEntryAtomically), the reader can observe the new m_pInstanceType but the old m_pTargetCode (0), then br to address 0.

Fix by using ldp to load both fields in a single instruction (single-copy atomic on FEAT_LSE2 / ARMv8.4+ hardware), plus a cbz guard to catch torn reads on pre-LSE2 hardware where ldp pair atomicity is not architecturally guaranteed.

Fixes #126345