### PR TITLE
Fix bounds check bugs in TlsFrameHelper and harden SslStream server handshake

### DIFF
--- a/eng/pipelines/libraries/fuzzing/deploy-to-onefuzz.yml
+++ b/eng/pipelines/libraries/fuzzing/deploy-to-onefuzz.yml
@@ -156,6 +156,14 @@ extends:
           inputs:
             onefuzzOSes: 'Windows'
           env:
+            onefuzzDropDirectory: $(fuzzerProject)/deployment/SslStreamClientHelloFuzzer
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          displayName: Send SslStreamClientHelloFuzzer to OneFuzz
+
+        - task: onefuzz-task@0
+          inputs:
+            onefuzzOSes: 'Windows'
+          env:
             onefuzzDropDirectory: $(fuzzerProject)/deployment/TextEncodingFuzzer
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           displayName: Send TextEncodingFuzzer to OneFuzz

--- a/src/libraries/Fuzzing/DotnetFuzzing/DotnetFuzzing.csproj
+++ b/src/libraries/Fuzzing/DotnetFuzzing/DotnetFuzzing.csproj
@@ -22,8 +22,10 @@
     <Compile Include="IFuzzer.cs" />
     <Compile Include="PooledBoundedMemory.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="SR.Fake.cs" />
     <Compile Include="$(TestUtilities)\System\Buffers\BoundedMemory.*" Link="TestUtilities\%(Filename)%(Extension)" />
     <Compile Include="$(TestUtilities)\System\Buffers\PoisonPagePlacement.cs" Link="TestUtilities\PoisonPagePlacement.cs" />
+    <Compile Include="$(CommonPath)System\IO\ReadOnlyMemoryStream.cs" Link="Common\System\IO\ReadOnlyMemoryStream.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/SslStreamClientHelloFuzzer.cs
+++ b/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/SslStreamClientHelloFuzzer.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Buffers;
-using System.Buffers.Text;
 using System.Net.Security;
 using System.Security.Authentication;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 
 namespace DotnetFuzzing.Fuzzers
 {
@@ -15,23 +12,6 @@ namespace DotnetFuzzing.Fuzzers
         public string[] TargetAssemblies => ["System.Net.Security"];
 
         public string[] TargetCoreLibPrefixes => [];
-
-        public static SslStreamCertificateContext s_certCtx = GenerateSelfSignedCertificate();
-
-        public static SslStreamCertificateContext GenerateSelfSignedCertificate()
-        {
-            using var rsa = RSA.Create(2048);
-            var request = new CertificateRequest("CN=localhost", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
-            X509Certificate2 cert = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(365));
-            if (OperatingSystem.IsWindows())
-            {
-                // On Windows, the returned certificate doesn't have the private key marked as exportable, which causes issues when used in SslStream.
-                // Re-importing it as exportable resolves the issue.
-                cert = X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
-            }
-
-            return SslStreamCertificateContext.Create(cert, new X509Certificate2Collection());
-        }
 
         public void FuzzTarget(ReadOnlySpan<byte> bytes)
         {
@@ -43,8 +23,12 @@ namespace DotnetFuzzing.Fuzzers
                 using SslStream sslStream = new SslStream(ms);
                 sslStream.AuthenticateAsServerAsync((stream, clientHelloInfo, b, token) =>
                 {
-                    // after this point, the comms are encrypted anyway, so
-                    // there is no point fuzzing it
+                    // This callback should be called when ClientHello is
+                    // received, Since we don't parse any other TLS messages,
+                    // we can terminate the handshake here. Fuzzing the rest of
+                    // the handshake would fuzz the platform TLS implementation
+                    // which is not instrumented and is out of scope for this
+                    // fuzzer.
                     throw new MyCustomException();
                 }, null).GetAwaiter().GetResult();
             }

--- a/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/SslStreamClientHelloFuzzer.cs
+++ b/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/SslStreamClientHelloFuzzer.cs
@@ -48,7 +48,7 @@ namespace DotnetFuzzing.Fuzzers
                     throw new MyCustomException();
                 }, null).GetAwaiter().GetResult();
             }
-            catch (Exception ex) when (ex is AuthenticationException or IOException or NotSupportedException or MyCustomException)
+            catch (Exception ex) when (ex is AuthenticationException or IOException or MyCustomException)
             {
             }
             finally

--- a/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/SslStreamClientHelloFuzzer.cs
+++ b/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/SslStreamClientHelloFuzzer.cs
@@ -1,0 +1,64 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Buffers.Text;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace DotnetFuzzing.Fuzzers
+{
+    internal sealed class SslStreamClientHelloFuzzer : IFuzzer
+    {
+        public string[] TargetAssemblies => ["System.Net.Security"];
+
+        public string[] TargetCoreLibPrefixes => [];
+
+        public static SslStreamCertificateContext s_certCtx = GenerateSelfSignedCertificate();
+
+        public static SslStreamCertificateContext GenerateSelfSignedCertificate()
+        {
+            using var rsa = RSA.Create(2048);
+            var request = new CertificateRequest("CN=localhost", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            X509Certificate2 cert = request.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(365));
+            if (OperatingSystem.IsWindows())
+            {
+                // On Windows, the returned certificate doesn't have the private key marked as exportable, which causes issues when used in SslStream.
+                // Re-importing it as exportable resolves the issue.
+                cert = X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), (string?)null, X509KeyStorageFlags.Exportable);
+            }
+
+            return SslStreamCertificateContext.Create(cert, new X509Certificate2Collection());
+        }
+
+        public void FuzzTarget(ReadOnlySpan<byte> bytes)
+        {
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(bytes.Length);
+            try
+            {
+                bytes.CopyTo(buffer);
+                using MemoryStream ms = new MemoryStream(buffer, 0, bytes.Length);
+                using SslStream sslStream = new SslStream(ms);
+                sslStream.AuthenticateAsServerAsync((stream, clientHelloInfo, b, token) =>
+                {
+                    // after this point, the comms are encrypted anyway, so
+                    // there is no point fuzzing it
+                    throw new MyCustomException();
+                }, null).GetAwaiter().GetResult();
+            }
+            catch (Exception ex) when (ex is AuthenticationException or IOException or MyCustomException)
+            {
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+
+        internal class MyCustomException : Exception
+        {
+        }
+    }
+}

--- a/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/SslStreamClientHelloFuzzer.cs
+++ b/src/libraries/Fuzzing/DotnetFuzzing/Fuzzers/SslStreamClientHelloFuzzer.cs
@@ -48,7 +48,7 @@ namespace DotnetFuzzing.Fuzzers
                     throw new MyCustomException();
                 }, null).GetAwaiter().GetResult();
             }
-            catch (Exception ex) when (ex is AuthenticationException or IOException or MyCustomException)
+            catch (Exception ex) when (ex is AuthenticationException or IOException or NotSupportedException or MyCustomException)
             {
             }
             finally

--- a/src/libraries/Fuzzing/DotnetFuzzing/SR.Fake.cs
+++ b/src/libraries/Fuzzing/DotnetFuzzing/SR.Fake.cs
@@ -1,0 +1,5 @@
+internal static class SR
+{
+    public const string ObjectDisposed_StreamClosed = "Cannot access a closed Stream.";
+    public const string IO_SeekBeforeBegin = "An attempt was made to move the position before the beginning of the stream.";
+}

--- a/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/SslStream.IO.cs
@@ -506,6 +506,21 @@ namespace System.Net.Security
 
             }
 
+            // Per TLS spec, the first message from the client must be ClientHello.
+            // If we are the server and haven't started the security context yet
+            // (_securityContext == null), reject any frame that is not a ClientHello.
+            if (_sslAuthenticationOptions!.IsServer && _securityContext == null)
+            {
+#pragma warning disable CS0618
+                bool isClientHello = _lastFrame.Header.Type == TlsContentType.Handshake &&
+                    _buffer.EncryptedReadOnlySpan[_lastFrame.Header.Version == SslProtocols.Ssl2 ? HandshakeTypeOffsetSsl2 : HandshakeTypeOffsetTls] == (byte)TlsHandshakeType.ClientHello;
+#pragma warning restore CS0618
+                if (!isClientHello)
+                {
+                    throw new AuthenticationException(SR.net_ssl_io_frame);
+                }
+            }
+
             return frameSize;
         }
 

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
@@ -389,7 +389,7 @@ namespace System.Net.Security
             int helloLength = ReadUInt24BigEndian(sslHandshake.Slice(HelloLengthOffset));
             ReadOnlySpan<byte> helloData = sslHandshake.Slice(HelloOffset);
 
-            if (helloData.Length < helloLength)
+            if (helloLength < ProtocolVersionSize || helloData.Length < helloLength)
             {
                 return false;
             }

--- a/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
+++ b/src/libraries/System.Net.Security/src/System/Net/Security/TlsFrameHelper.cs
@@ -435,6 +435,11 @@ namespace System.Net.Security
                 return true;
             }
 
+            if (p.Length < sizeof(ushort))
+            {
+                return false;
+            }
+
             // client_hello_extension_list (max size 2^16-1 => size fits in 2 bytes)
             int extensionListLength = BinaryPrimitives.ReadUInt16BigEndian(p);
             p = SkipBytes(p, sizeof(ushort));
@@ -469,6 +474,11 @@ namespace System.Net.Security
 
             // is invalid structure or no extensions?
             if (p.IsEmpty)
+            {
+                return false;
+            }
+
+            if (p.Length < sizeof(ushort))
             {
                 return false;
             }
@@ -616,6 +626,12 @@ namespace System.Net.Security
             const int HostNameLengthOffset = 0;
             const int HostNameOffset = HostNameLengthOffset + sizeof(ushort);
 
+            if (hostNameStruct.Length < HostNameOffset)
+            {
+                invalid = true;
+                return null;
+            }
+
             int hostNameLength = BinaryPrimitives.ReadUInt16BigEndian(hostNameStruct);
             ReadOnlySpan<byte> hostName = hostNameStruct.Slice(HostNameOffset);
             if (hostNameLength != hostName.Length)
@@ -644,6 +660,11 @@ namespace System.Net.Security
             const int VersionLength = 2;
 
             protocols = SslProtocols.None;
+
+            if (extensionData.IsEmpty)
+            {
+                return false;
+            }
 
             byte supportedVersionLength = extensionData[VersionListLengthOffset];
             extensionData = extensionData.Slice(VersionListNameOffset);


### PR DESCRIPTION
> [!NOTE]
> This PR description was AI/Copilot-generated.

## Summary

Fix multiple out-of-bounds access bugs in \TlsFrameHelper\ discovered by the new \SslStreamClientHelloFuzzer\, and add an early validation check in \SslStream\ to reject non-ClientHello frames during the initial server handshake.

## Changes

### TlsFrameHelper bounds check fixes

- **\TryParseHelloFrame\**: Added \helloLength < ProtocolVersionSize\ check to reject hello messages too small to contain protocol version bytes. Previously, a crafted TLS record with \helloLength=0\ caused an \IndexOutOfRangeException\ when accessing \helloData[0]\.

- **\TryParseClientHello\ / \TryParseServerHello\**: Added \p.Length < sizeof(ushort)\ check before calling \ReadUInt16BigEndian\ for the extension list length. A malformed ClientHello with truncated data after compression methods could leave only 1 byte remaining, causing \ArgumentOutOfRangeException\.

- **\GetSniFromHostNameStruct\**: Added \hostNameStruct.Length < 2\ check before \ReadUInt16BigEndian\.

- **\TryGetSupportedVersionsFromExtension\**: Added \xtensionData.IsEmpty\ check before accessing \xtensionData[0]\.

### SslStream server handshake hardening

- **\ReceiveHandshakeFrameAsync\**: Added early check that the first frame a server receives is a ClientHello (TLS protocol invariant). Previously, non-ClientHello data (wrong content type, or non-ClientHello handshake messages) would bypass the \ServerOptionDelegate\ callback, leaving no certificate configured, causing a confusing \NotSupportedException\ from \AcquireServerCredentials\. Now throws \AuthenticationException\ with a clear message.

### Fuzzer

- Added \SslStreamClientHelloFuzzer\ that exercises \SslStream.AuthenticateAsServer\ with corrupted ClientHello inputs.

## Validation

- All 13 fuzzer crash inputs now handled gracefully (throw \AuthenticationException\ or \IOException\)
- 500 random inputs (up to 200 bytes) pass with 0 failures
- All 4,059 existing \TlsFrameHelper\ tests pass
- All 790 \SslStream\ tests pass
