### PR TITLE
[runtime tests] Make 5 tests conditional on multithreading support

### DIFF
--- a/src/tests/Loader/classloader/TypeInitialization/backpatching/test1.cs
+++ b/src/tests/Loader/classloader/TypeInitialization/backpatching/test1.cs
@@ -56,7 +56,7 @@ public class CMain{
         Console.WriteLine("X_getX: {0}: thread {1}",X_getX,Thread.CurrentThread.Name); 
     } 
     [ActiveIssue("needs triage", typeof(PlatformDetection), nameof(PlatformDetection.IsSimulator))]
-    [Fact]
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
     public static int TestEntryPoint(){
         Thread t1 = new Thread(RunSomeMethod);
         t1.Name = "T1";

--- a/src/tests/Loader/regressions/polyrec/Polyrec.csproj
+++ b/src/tests/Loader/regressions/polyrec/Polyrec.csproj
@@ -9,4 +9,7 @@
   <ItemGroup>
     <Compile Include="polyrec.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
 </Project>

--- a/src/tests/Loader/regressions/polyrec/polyrec.cs
+++ b/src/tests/Loader/regressions/polyrec/polyrec.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Threading;
 using Xunit;
+using TestLibrary;
 
 // Spice things up a bit with some mutual recursion between instantiations
 class C<T>
@@ -79,7 +80,7 @@ public class P
     Console.WriteLine("Main thread exited");
   }
 
-  [Fact]
+  [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
   public static void Test_4_50()
   {
     Test(4, 50);

--- a/src/tests/Regressions/coreclr/1514/interlockexchange.cs
+++ b/src/tests/Regressions/coreclr/1514/interlockexchange.cs
@@ -19,7 +19,7 @@ public class Program
     }
     
     [ActiveIssue("needs triage", typeof(PlatformDetection), nameof(PlatformDetection.IsSimulator))]
-    [Fact]
+    [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
     public static int TestEntryPoint()
     { 
         Thread[] threads;

--- a/src/tests/baseservices/exceptions/regressions/V1/SEH/COOL/finally.cs
+++ b/src/tests/baseservices/exceptions/regressions/V1/SEH/COOL/finally.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using Xunit;
+using TestLibrary;
 public class Foo 
 {
         private static int n=0;
@@ -20,7 +21,7 @@ public class Foo
 		     }
 	  }
 	
-        [Fact]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
         public static int TestEntryPoint() 
         {
 	  String s = "Done";

--- a/src/tests/baseservices/exceptions/regressions/V1/SEH/COOL/finally_SEH.csproj
+++ b/src/tests/baseservices/exceptions/regressions/V1/SEH/COOL/finally_SEH.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="finally.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
 </Project>

--- a/src/tests/baseservices/exceptions/regressions/V1/SEH/COOL/rethrow.cs
+++ b/src/tests/baseservices/exceptions/regressions/V1/SEH/COOL/rethrow.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using Xunit;
+using TestLibrary;
 
 public class UserException1 : Exception {
 	int ExceptionId;
@@ -58,7 +59,7 @@ public class RethrowException {
 	}
 		
 	
-	[Fact]
+	[ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]
 	public static int TestEntryPoint() {
 	  String s = "Done";
 	    System.IO.TextWriter t = Console.Out;

--- a/src/tests/baseservices/exceptions/regressions/V1/SEH/COOL/rethrow.csproj
+++ b/src/tests/baseservices/exceptions/regressions/V1/SEH/COOL/rethrow.csproj
@@ -6,4 +6,7 @@
   <ItemGroup>
     <Compile Include="rethrow.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(TestLibraryProjectPath)" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
> [!NOTE]
> This PR description was generated with the help of GitHub Copilot.

Disable tests that call `Thread.Start()` on single-threaded platforms (e.g., browser WASM) by using `ConditionalFact` with `PlatformDetection.IsMultithreadingSupported`.

These tests unconditionally create and start new threads, which fails on single-threaded WASM where `Thread.Start()` is not supported.

### Tests changed
- **finally_SEH** (`baseservices/exceptions`) — spawns thread in finally block
- **rethrow** (`baseservices/exceptions`) — spawns threads for exception rethrow testing
- **Polyrec** (`Loader/regressions`) — spawns 4 threads for polymorphic recursion
- **test1** (`Loader/TypeInitialization/backpatching`) — spawns threads for static constructor race
- **InterlockExchange** (`Regressions`) — spawns 99 threads for interlocked ops

### Changes
- `[Fact]` → `[ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsMultithreadingSupported))]`
- Added `using TestLibrary;` and `<ProjectReference Include="$(TestLibraryProjectPath)" />` where not already present