### PR TITLE
Add path-based PR triggers for stress test pipelines

### DIFF
--- a/eng/pipelines/libraries/stress/http.yml
+++ b/eng/pipelines/libraries/stress/http.yml
@@ -4,6 +4,11 @@ pr:
   branches:
     include:
     - "*"
+  paths:
+    include:
+    - src/libraries/System.Net.Http/tests/StressTests/HttpStress/**
+    - src/libraries/Common/tests/System/Net/StressTests/**
+    - eng/pipelines/libraries/stress/**
 
 schedules:
 - cron: "0 13 * * *" # 1PM UTC => 5 AM PST

--- a/eng/pipelines/libraries/stress/ssl.yml
+++ b/eng/pipelines/libraries/stress/ssl.yml
@@ -4,6 +4,11 @@ pr:
   branches:
     include:
     - "*"
+  paths:
+    include:
+    - src/libraries/System.Net.Security/tests/StressTests/SslStress/**
+    - src/libraries/Common/tests/System/Net/StressTests/**
+    - eng/pipelines/libraries/stress/**
 
 schedules:
 - cron: "0 13 * * *" # 1PM UTC => 5 AM PST


### PR DESCRIPTION
> [!NOTE]
> This PR was AI/Copilot-generated.

## Summary

Add `paths: include:` filters to the `pr:` trigger sections of `http.yml` and `ssl.yml` so that stress test pipelines only run on PRs that modify relevant files, instead of running on every PR.

### http.yml triggers on:
- `src/libraries/System.Net.Http/tests/StressTests/HttpStress/**`
- `src/libraries/Common/tests/System/Net/StressTests/**`
- `eng/pipelines/libraries/stress/**`

### ssl.yml triggers on:
- `src/libraries/System.Net.Security/tests/StressTests/SslStress/**`
- `src/libraries/Common/tests/System/Net/StressTests/**`
- `eng/pipelines/libraries/stress/**`

Nightly schedules remain unchanged.