### PR TITLE
JIT: Fully share helper-based suspension tails

### DIFF
--- a/src/coreclr/jit/async.cpp
+++ b/src/coreclr/jit/async.cpp
@@ -544,39 +544,35 @@ PhaseStatus AsyncTransformation::Run()
     PhaseStatus             result = PhaseStatus::MODIFIED_NOTHING;
     ArrayStack<BasicBlock*> blocksWithNormalAwaits(m_compiler->getAllocator(CMK_Async));
     ArrayStack<BasicBlock*> blocksWithTailAwaits(m_compiler->getAllocator(CMK_Async));
-    int                     numNormalAwaits = 0;
-    int                     numTailAwaits   = 0;
-    FindAwaits(blocksWithNormalAwaits, blocksWithTailAwaits, &numNormalAwaits, &numTailAwaits);
+    AggregatedAwaitInfo     awaits = FindAwaits(blocksWithNormalAwaits, blocksWithTailAwaits);
 
-    if (numNormalAwaits + numTailAwaits > 1)
+    if (awaits.NumNormalAwaits + awaits.NumTailAwaits > 1)
     {
         CreateSharedReturnBB();
     }
 
     // Transform all tail awaits first. They will not require running all of
     // our analyses.
-    if (numTailAwaits > 0)
+    if (awaits.NumTailAwaits > 0)
     {
-        JITDUMP("Found %d tail awaits in %d blocks\n", numTailAwaits, blocksWithTailAwaits.Height());
+        JITDUMP("Found %u tail awaits in %d blocks\n", awaits.NumTailAwaits, blocksWithTailAwaits.Height());
         TransformTailAwaits(blocksWithTailAwaits);
         m_compiler->fgInvalidateDfsTree();
 
-        if (numNormalAwaits > 0)
+        if (awaits.NumNormalAwaits > 0)
         {
             // This may have changed blocks, so refind the normal awaits.
             blocksWithNormalAwaits.Reset();
             blocksWithTailAwaits.Reset();
-            numNormalAwaits = 0;
-            numTailAwaits   = 0;
-            FindAwaits(blocksWithNormalAwaits, blocksWithTailAwaits, &numNormalAwaits, &numTailAwaits);
+            awaits = FindAwaits(blocksWithNormalAwaits, blocksWithTailAwaits);
         }
 
         result = PhaseStatus::MODIFIED_EVERYTHING;
     }
 
-    JITDUMP("Found %d awaits in %d blocks\n", numNormalAwaits, blocksWithNormalAwaits.Height());
+    JITDUMP("Found %u awaits in %d blocks\n", awaits.NumNormalAwaits, blocksWithNormalAwaits.Height());
 
-    if (numNormalAwaits <= 0)
+    if (awaits.NumNormalAwaits <= 0)
     {
         return result;
     }
@@ -733,34 +729,40 @@ PhaseStatus AsyncTransformation::Run()
 // Parameters:
 //   blocksWithNormalAwaits - [out] Blocks with normal awaits are pushed onto this stack
 //   blocksWithTailAwaits   - [out] Blocks with tail awaits are pushed onto this stack
-//   numNormalAwaits        - [out] Number of normal awaits found
-//   numTailAwaits          - [out] Number of tail awaits found
 //
-void AsyncTransformation::FindAwaits(ArrayStack<BasicBlock*>& blocksWithNormalAwaits,
-                                     ArrayStack<BasicBlock*>& blocksWithTailAwaits,
-                                     int*                     numNormalAwaits,
-                                     int*                     numTailAwaits)
+// Returns:
+//   Information about awaits in the function.
+//
+AggregatedAwaitInfo AsyncTransformation::FindAwaits(ArrayStack<BasicBlock*>& blocksWithNormalAwaits,
+                                                    ArrayStack<BasicBlock*>& blocksWithTailAwaits)
 {
+    AggregatedAwaitInfo awaits;
     for (BasicBlock* block : m_compiler->Blocks())
     {
         bool hasNormalAwait = false;
         bool hasTailAwait   = false;
         for (GenTree* tree : LIR::AsRange(block))
         {
-            if (!tree->IsCall() || !tree->AsCall()->IsAsync() || tree->AsCall()->IsTailCall())
+            if (!tree->IsCall())
             {
                 continue;
             }
 
-            if (tree->AsCall()->GetAsyncInfo().IsTailAwait)
+            GenTreeCall* call = tree->AsCall();
+            if (!call->IsAsync() || call->IsTailCall())
+            {
+                continue;
+            }
+
+            if (call->GetAsyncInfo().IsTailAwait)
             {
                 hasTailAwait = true;
-                (*numTailAwaits)++;
+                awaits.NumTailAwaits++;
             }
             else
             {
                 hasNormalAwait = true;
-                (*numNormalAwaits)++;
+                awaits.NumNormalAwaits++;
             }
         }
 
@@ -774,6 +776,8 @@ void AsyncTransformation::FindAwaits(ArrayStack<BasicBlock*>& blocksWithNormalAw
             blocksWithTailAwaits.Push(block);
         }
     }
+
+    return awaits;
 }
 
 //------------------------------------------------------------------------
@@ -1235,8 +1239,12 @@ void AsyncTransformation::BuildContinuation(BasicBlock*                block,
         JITDUMP("  Continuation will have keep alive object\n");
     }
 
-    layoutBuilder->SetNeedsExecutionContext();
-    JITDUMP("  Call has async-only save and restore of ExecutionContext; continuation will have ExecutionContext\n");
+    if (call->GetAsyncInfo().NeedsToSaveAndRestoreExecutionContext())
+    {
+        layoutBuilder->SetNeedsExecutionContext();
+        JITDUMP(
+            "  Call has async-only save and restore of ExecutionContext; continuation will have ExecutionContext\n");
+    }
 }
 
 #ifdef DEBUG
@@ -1645,22 +1653,28 @@ CallDefinitionInfo AsyncTransformation::CanonicalizeCallDefinition(BasicBlock*  
 //
 BasicBlock* AsyncTransformation::CreateSuspensionBlock(BasicBlock* block, unsigned stateNum)
 {
+    BasicBlock* suspendBB;
     if (m_lastSuspensionBB == nullptr)
     {
-        m_lastSuspensionBB = m_compiler->fgLastBBInMainFunction();
+        if (m_sharedReturnBB != nullptr)
+        {
+            suspendBB = m_compiler->fgNewBBbefore(BBJ_RETURN, m_sharedReturnBB, false);
+        }
+        else
+        {
+            m_lastSuspensionBB = m_compiler->fgLastBBInMainFunction();
+            suspendBB          = m_compiler->fgNewBBafter(BBJ_RETURN, m_lastSuspensionBB, false);
+        }
+    }
+    else
+    {
+        suspendBB = m_compiler->fgNewBBafter(BBJ_RETURN, m_lastSuspensionBB, false);
     }
 
-    BasicBlock* suspendBB = m_compiler->fgNewBBafter(BBJ_RETURN, m_lastSuspensionBB, false);
     suspendBB->clearTryIndex();
     suspendBB->clearHndIndex();
     suspendBB->inheritWeightPercentage(block, 0);
     m_lastSuspensionBB = suspendBB;
-
-    if (m_sharedReturnBB != nullptr)
-    {
-        suspendBB->SetKindAndTargetEdge(BBJ_ALWAYS, m_compiler->fgAddRefPred(m_sharedReturnBB, suspendBB));
-    }
-
     JITDUMP("  Creating suspension " FMT_BB " for state %u\n", suspendBB->bbNum, stateNum);
 
     return suspendBB;
@@ -1824,14 +1838,7 @@ void AsyncTransformation::CreateSuspension(BasicBlock*                      call
 
     FillInDataOnSuspension(call, layout, subLayout, suspendBB, mutatedSinceResumption, tailSaveSet);
 
-    FinishContextHandlingOnSuspension(callBlock, call, suspendBB, layout, subLayout);
-
-    if (suspendBB->KindIs(BBJ_RETURN))
-    {
-        newContinuation = m_compiler->gtNewLclvNode(newContinuationVar, TYP_REF);
-        GenTree* ret    = m_compiler->gtNewOperNode(GT_RETURN_SUSPEND, TYP_VOID, newContinuation);
-        LIR::AsRange(suspendBB).InsertAtEnd(newContinuation, ret);
-    }
+    FinishContextHandlingAndSuspension(callBlock, call, suspendBB, layout, subLayout);
 }
 
 //------------------------------------------------------------------------
@@ -2005,26 +2012,26 @@ SaveSet AsyncTransformation::GetLocalSaveSet(const LclVarDsc* dsc, VARSET_VALARG
 }
 
 //------------------------------------------------------------------------
-// AsyncTransformation::FinishContextHandlingOnSuspension:
-//   Generate code to finish handling of contexts on suspension:
-//   - Capture SynchronizationContext or TaskScheduler into the continuation
-//     if needed when later resuming
-//   - Capture ExecutionContext into the continuation
-//   - Restore current Thread._synchronizationContext and
-//     Thread._executionContext from the state before the async call
+// AsyncTransformation::GetSuspensionContextHelper:
+//   Figure out what context handling helper can be used during suspension.
 //
 // Parameters:
-//   callBlock - The block containing the async call
 //   call      - The async call
-//   suspendBB - Basic block to add IR to.
-//   layout    - Information about the continuation layout.
-//   subLayout - Per-call layout builder indicating which fields are needed.
 //
-void AsyncTransformation::FinishContextHandlingOnSuspension(BasicBlock*                      callBlock,
-                                                            GenTreeCall*                     call,
-                                                            BasicBlock*                      suspendBB,
-                                                            const ContinuationLayout&        layout,
-                                                            const ContinuationLayoutBuilder& subLayout)
+// Returns:
+//   Kind of helper that can be used, or None if no helper can be used.
+//
+// Remarks:
+//   - No helper exists for the case where there are no contexts to restore
+//   (when CORINFO_ASYNC_SAVE_CONTEXTS was not given by the EE), or when no
+//   execution context needs to be saved/restored. The former happens only in
+//   thunks where there is only one async call anyway, while the latter never
+//   currently happens.
+//   - We have two different helpers, depending on whether a continuation context needs to be captured.
+//     + For task awaits with ConfigureAwait(false), or for custom awaits, no continuation context is needed
+//     + For normal task awaits a continuation context is needed
+//
+SuspensionContextHelper AsyncTransformation::GetSuspensionContextHelper(GenTreeCall* call)
 {
     CallArg* execContextArg = call->gtArgs.FindWellKnownArg(WellKnownArg::AsyncExecutionContext);
     CallArg* syncContextArg = call->gtArgs.FindWellKnownArg(WellKnownArg::AsyncSynchronizationContext);
@@ -2033,11 +2040,49 @@ void AsyncTransformation::FinishContextHandlingOnSuspension(BasicBlock*         
     // In most cases we can use a helper. It is not the case when the call has
     // no contexts to restore, which is the case for task-returning thunks or
     // more specifically when the EE told us !CORINFO_ASYNC_SAVE_CONTEXTS.
-    if (execContextArg != nullptr && subLayout.NeedsExecutionContext())
+    if ((execContextArg == nullptr) || !call->GetAsyncInfo().NeedsToSaveAndRestoreExecutionContext())
+    {
+        return SuspensionContextHelper::None;
+    }
+
+    if (call->GetAsyncInfo().ContinuationContextHandling == ContinuationContextHandling::ContinueOnCapturedContext)
+    {
+        return SuspensionContextHelper::WithContinuationContext;
+    }
+
+    return SuspensionContextHelper::WithoutContinuationContext;
+}
+
+//------------------------------------------------------------------------
+// AsyncTransformation::FinishContextHandlingAndSuspension:
+//   Generate code to finish handling of contexts on suspension, and finish the suspension:
+//   - Capture SynchronizationContext or TaskScheduler into the continuation
+//     if needed when later resuming
+//   - Capture ExecutionContext into the continuation
+//   - Restore current Thread._synchronizationContext and
+//     Thread._executionContext from the state before the async call
+//   - Return continuation back to caller.
+//
+// Parameters:
+//   callBlock - The block containing the async call
+//   call      - The async call
+//   suspendBB - Basic block to add IR to.
+//   layout    - Information about the continuation layout.
+//   subLayout - Per-call layout builder indicating which fields are needed.
+//
+void AsyncTransformation::FinishContextHandlingAndSuspension(BasicBlock*                      callBlock,
+                                                             GenTreeCall*                     call,
+                                                             BasicBlock*                      suspendBB,
+                                                             const ContinuationLayout&        layout,
+                                                             const ContinuationLayoutBuilder& subLayout)
+{
+    SuspensionContextHelper helper = GetSuspensionContextHelper(call);
+
+    if (helper != SuspensionContextHelper::None)
     {
         JITDUMP("    Call [%06u] has async context and captured execution context; using finish-suspension helper\n",
                 Compiler::dspTreeID(call));
-        FinishContextHandlingOnSuspensionWithHelper(callBlock, call, suspendBB, layout, subLayout);
+        FinishContextHandlingAndSuspensionWithHelper(callBlock, call, suspendBB, layout, subLayout, helper);
         return;
     }
 
@@ -2108,10 +2153,23 @@ void AsyncTransformation::FinishContextHandlingOnSuspension(BasicBlock*         
     }
 
     RestoreContexts(callBlock, call, suspendBB);
+
+    assert(suspendBB->KindIs(BBJ_RETURN));
+
+    if (m_sharedReturnBB != nullptr)
+    {
+        suspendBB->SetKindAndTargetEdge(BBJ_ALWAYS, m_compiler->fgAddRefPred(m_sharedReturnBB, suspendBB));
+    }
+    else
+    {
+        GenTree* newContinuation = m_compiler->gtNewLclvNode(GetNewContinuationVar(), TYP_REF);
+        GenTree* ret             = m_compiler->gtNewOperNode(GT_RETURN_SUSPEND, TYP_VOID, newContinuation);
+        LIR::AsRange(suspendBB).InsertAtEnd(newContinuation, ret);
+    }
 }
 
 //------------------------------------------------------------------------
-// AsyncTransformation::FinishContextHandlingOnSuspensionWithHelper:
+// AsyncTransformation::FinishContextHandlingAndSuspensionWithHelper:
 //   Generate code to finish handling of contexts on suspension by calling into a helper.
 //
 // Parameters:
@@ -2126,119 +2184,29 @@ void AsyncTransformation::FinishContextHandlingOnSuspension(BasicBlock*         
 //   context restores. We do that with a single helper call that does
 //   everything, for both size and to avoid multiple loads of the Thread TLS.
 //
-void AsyncTransformation::FinishContextHandlingOnSuspensionWithHelper(BasicBlock*                      callBlock,
-                                                                      GenTreeCall*                     call,
-                                                                      BasicBlock*                      suspendBB,
-                                                                      const ContinuationLayout&        layout,
-                                                                      const ContinuationLayoutBuilder& subLayout)
+void AsyncTransformation::FinishContextHandlingAndSuspensionWithHelper(BasicBlock*                      callBlock,
+                                                                       GenTreeCall*                     call,
+                                                                       BasicBlock*                      suspendBB,
+                                                                       const ContinuationLayout&        layout,
+                                                                       const ContinuationLayoutBuilder& subLayout,
+                                                                       SuspensionContextHelper          helper)
 {
-    CORINFO_METHOD_HANDLE helper = subLayout.NeedsContinuationContext()
-                                       ? m_asyncInfo->finishSuspensionWithContinuationContextMethHnd
-                                       : m_asyncInfo->finishSuspensionNoContinuationContextMethHnd;
+    assert(helper != SuspensionContextHelper::None);
+    assert((helper != SuspensionContextHelper::WithContinuationContext) || subLayout.NeedsContinuationContext());
 
-    // Insert call
-    //   finishSuspension[With|No]ContinuationContext(
-    //     ref newContinuation.ContinuationContext, // optional
-    //     ref newContinuation.Flags,               // optional
-    //     ref newContinuation.ExecutionContext,
-    //     resumed,
-    //     execContext,
-    //     syncContext)
-    //
+    BasicBlock* sharedFinish = (helper == SuspensionContextHelper::WithContinuationContext)
+                                   ? m_sharedFinishContextHandlingWithContinuationContextBB
+                                   : m_sharedFinishContextHandlingWithoutContinuationContextBB;
 
     CallArg* execContextArg = call->gtArgs.FindWellKnownArg(WellKnownArg::AsyncExecutionContext);
     CallArg* syncContextArg = call->gtArgs.FindWellKnownArg(WellKnownArg::AsyncSynchronizationContext);
     assert((execContextArg != nullptr) && (syncContextArg != nullptr));
 
-    GenTree* contContextAddrPlaceholder = nullptr;
-    GenTree* flagsPlaceholder           = nullptr;
-    GenTree* execContextAddrPlaceholder = m_compiler->gtNewZeroConNode(TYP_BYREF);
-    GenTree* resumedPlaceholder         = m_compiler->gtNewIconNode(0);
-    GenTree* execContextPlaceholder     = m_compiler->gtNewNull();
-    GenTree* syncContextPlaceholder     = m_compiler->gtNewNull();
-
-    GenTreeCall* finishCall = m_compiler->gtNewCallNode(CT_USER_FUNC, helper, TYP_VOID);
-    SetCallEntrypointForR2R(finishCall, m_compiler, helper);
-
-    finishCall->gtArgs.PushFront(m_compiler, NewCallArg::Primitive(syncContextPlaceholder));
-    finishCall->gtArgs.PushFront(m_compiler, NewCallArg::Primitive(execContextPlaceholder));
-    finishCall->gtArgs.PushFront(m_compiler, NewCallArg::Primitive(resumedPlaceholder));
-    finishCall->gtArgs.PushFront(m_compiler, NewCallArg::Primitive(execContextAddrPlaceholder));
-
-    if (subLayout.NeedsContinuationContext())
-    {
-        contContextAddrPlaceholder = m_compiler->gtNewZeroConNode(TYP_BYREF);
-        flagsPlaceholder           = m_compiler->gtNewZeroConNode(TYP_BYREF);
-        finishCall->gtArgs.PushFront(m_compiler, NewCallArg::Primitive(flagsPlaceholder));
-        finishCall->gtArgs.PushFront(m_compiler, NewCallArg::Primitive(contContextAddrPlaceholder));
-    }
-
-    m_compiler->compCurBB = suspendBB;
-    m_compiler->fgMorphTree(finishCall);
-
-    LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_compiler, finishCall));
-
-    if (subLayout.NeedsContinuationContext())
-    {
-        // Replace contContextAddrPlaceholder with actual address of the continuation context
-        LIR::Use use;
-        bool     gotUse = LIR::AsRange(suspendBB).TryGetUse(contContextAddrPlaceholder, &use);
-        assert(gotUse);
-
-        GenTree* newContinuation   = m_compiler->gtNewLclvNode(GetNewContinuationVar(), TYP_REF);
-        unsigned contContextOffset = OFFSETOF__CORINFO_Continuation__data + layout.ContinuationContextOffset;
-        GenTree* contContextAddrOffset =
-            m_compiler->gtNewOperNode(GT_ADD, TYP_BYREF, newContinuation,
-                                      m_compiler->gtNewIconNode((ssize_t)contContextOffset, TYP_I_IMPL));
-
-        LIR::AsRange(suspendBB).InsertBefore(contContextAddrPlaceholder,
-                                             LIR::SeqTree(m_compiler, contContextAddrOffset));
-        use.ReplaceWith(contContextAddrOffset);
-        LIR::AsRange(suspendBB).Remove(contContextAddrPlaceholder);
-
-        // Replace flagsPlaceholder with actual address of the flags
-        gotUse = LIR::AsRange(suspendBB).TryGetUse(flagsPlaceholder, &use);
-        assert(gotUse);
-
-        newContinuation      = m_compiler->gtNewLclvNode(GetNewContinuationVar(), TYP_REF);
-        unsigned flagsOffset = m_compiler->info.compCompHnd->getFieldOffset(m_asyncInfo->continuationFlagsFldHnd);
-        GenTree* flagsOffsetNode =
-            m_compiler->gtNewOperNode(GT_ADD, TYP_BYREF, newContinuation,
-                                      m_compiler->gtNewIconNode((ssize_t)flagsOffset, TYP_I_IMPL));
-
-        LIR::AsRange(suspendBB).InsertBefore(flagsPlaceholder, LIR::SeqTree(m_compiler, flagsOffsetNode));
-        use.ReplaceWith(flagsOffsetNode);
-        LIR::AsRange(suspendBB).Remove(flagsPlaceholder);
-    }
-
-    // Replace execContextAddrPlaceholder with actual address of the execution context
-    LIR::Use use;
-    bool     gotUse = LIR::AsRange(suspendBB).TryGetUse(execContextAddrPlaceholder, &use);
-    assert(gotUse);
-
-    GenTree* newContinuation   = m_compiler->gtNewLclvNode(GetNewContinuationVar(), TYP_REF);
-    unsigned execContextOffset = OFFSETOF__CORINFO_Continuation__data + layout.ExecutionContextOffset;
-    GenTree* execContextAddrOffset =
-        m_compiler->gtNewOperNode(GT_ADD, TYP_BYREF, newContinuation,
-                                  m_compiler->gtNewIconNode((ssize_t)execContextOffset, TYP_I_IMPL));
-
-    LIR::AsRange(suspendBB).InsertBefore(execContextAddrPlaceholder, LIR::SeqTree(m_compiler, execContextAddrOffset));
-    use.ReplaceWith(execContextAddrOffset);
-    LIR::AsRange(suspendBB).Remove(execContextAddrPlaceholder);
-
-    // Replace resumedPlaceholder with actual "continuationParameter != null" arg
-    gotUse = LIR::AsRange(suspendBB).TryGetUse(resumedPlaceholder, &use);
-    assert(gotUse);
-
-    GenTree* continuation = m_compiler->gtNewLclvNode(m_compiler->lvaAsyncContinuationArg, TYP_REF);
-    GenTree* null         = m_compiler->gtNewNull();
-    GenTree* resumed      = m_compiler->gtNewOperNode(GT_NE, TYP_INT, continuation, null);
-
-    LIR::AsRange(suspendBB).InsertBefore(resumedPlaceholder, LIR::SeqTree(m_compiler, resumed));
-    use.ReplaceWith(resumed);
-    LIR::AsRange(suspendBB).Remove(resumedPlaceholder);
-
-    // Replace execContextPlaceholder with actual value
+    // Get the contexts from the call node:
+    // 1. For shared finish, store it directly to the shared locals in the same block
+    // 2. For non-shared finish, just make sure it is a GT_LCL_VAR since we need to create
+    // a use in a different block.
+    // Also remove the nodes from the original block and the call args.
     GenTree* execContext = execContextArg->GetNode();
     if (!execContext->OperIs(GT_LCL_VAR))
     {
@@ -2247,18 +2215,9 @@ void AsyncTransformation::FinishContextHandlingOnSuspensionWithHelper(BasicBlock
         use.ReplaceWithLclVar(m_compiler);
         execContext = use.Def();
     }
-
-    gotUse = LIR::AsRange(suspendBB).TryGetUse(execContextPlaceholder, &use);
-    assert(gotUse);
-
     LIR::AsRange(callBlock).Remove(execContext);
-    LIR::AsRange(suspendBB).InsertBefore(execContextPlaceholder, execContext);
-    use.ReplaceWith(execContext);
-    LIR::AsRange(suspendBB).Remove(execContextPlaceholder);
-
     call->gtArgs.RemoveUnsafe(execContextArg);
 
-    // Replace syncContextPlaceholder with actual value
     GenTree* syncContext = syncContextArg->GetNode();
     if (!syncContext->OperIs(GT_LCL_VAR))
     {
@@ -2267,19 +2226,46 @@ void AsyncTransformation::FinishContextHandlingOnSuspensionWithHelper(BasicBlock
         use.ReplaceWithLclVar(m_compiler);
         syncContext = use.Def();
     }
-
-    gotUse = LIR::AsRange(suspendBB).TryGetUse(syncContextPlaceholder, &use);
-    assert(gotUse);
-
     LIR::AsRange(callBlock).Remove(syncContext);
-    LIR::AsRange(suspendBB).InsertBefore(syncContextPlaceholder, syncContext);
-    use.ReplaceWith(syncContext);
-    LIR::AsRange(suspendBB).Remove(syncContextPlaceholder);
-
     call->gtArgs.RemoveUnsafe(syncContextArg);
 
-    JITDUMP("    Created FinishSuspension call on suspension:\n");
-    DISPTREERANGE(LIR::AsRange(suspendBB), finishCall);
+    if (sharedFinish != nullptr)
+    {
+        // Store the contexts to the shared locals that the shared finish block will take them from.
+        if (m_sharedFinishContextHandlingExecContextVar != BAD_VAR_NUM)
+        {
+            GenTree* storeExecContext =
+                m_compiler->gtNewStoreLclVarNode(m_sharedFinishContextHandlingExecContextVar, execContext);
+            LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_compiler, storeExecContext));
+        }
+
+        if (m_sharedFinishContextHandlingSyncContextVar != BAD_VAR_NUM)
+        {
+            GenTree* storeSyncContext =
+                m_compiler->gtNewStoreLclVarNode(m_sharedFinishContextHandlingSyncContextVar, syncContext);
+            LIR::AsRange(suspendBB).InsertAtEnd(LIR::SeqTree(m_compiler, storeSyncContext));
+        }
+
+        // Then just finish by jumping.
+        suspendBB->SetKindAndTargetEdge(BBJ_ALWAYS, m_compiler->fgAddRefPred(sharedFinish, suspendBB));
+    }
+    else
+    {
+        // Otherwise insert a new call
+        InsertFinishContextHandlingCall(suspendBB, layout, helper, execContext, syncContext);
+
+        // And return either via a new GT_RETURN_SUSPEND or via the shared return BB.
+        if (m_sharedReturnBB != nullptr)
+        {
+            suspendBB->SetKindAndTargetEdge(BBJ_ALWAYS, m_compiler->fgAddRefPred(m_sharedReturnBB, suspendBB));
+        }
+        else
+        {
+            GenTree* newContinuation = m_compiler->gtNewLclvNode(GetNewContinuationVar(), TYP_REF);
+            GenTree* ret             = m_compiler->gtNewOperNode(GT_RETURN_SUSPEND, TYP_VOID, newContinuation);
+            LIR::AsRange(suspendBB).InsertAtEnd(newContinuation, ret);
+        }
+    }
 }
 
 //------------------------------------------------------------------------
@@ -2999,6 +2985,219 @@ void AsyncTransformation::CreateSharedReturnBB()
 }
 
 //------------------------------------------------------------------------
+// AsyncTransformation::CreateSharedFinishContextHandlingBB:
+//   Create a shared BB that finishes all necessary context handling and
+//   suspends the method.
+//
+// Parameters:
+//   helper - The type of helper to call
+//   layout - The continuation layout
+//   execContextMayVary - If true, callers may use different execution
+//                        contexts, and thus we need a local to allow it to vary.
+//   syncContextMayVary - If true, callers may use different synchronization
+//                        contexts, and thus we need a local to allow it to vary.
+//
+// Returns:
+//   Basic block that handles the shared finish logic.
+//
+BasicBlock* AsyncTransformation::CreateSharedFinishContextHandlingBB(SuspensionContextHelper   helper,
+                                                                     const ContinuationLayout& layout,
+                                                                     bool                      execContextMayVary,
+                                                                     bool                      syncContextMayVary)
+{
+    assert(m_sharedReturnBB != nullptr);
+    BasicBlock* block = m_compiler->fgNewBBbefore(BBJ_ALWAYS, m_sharedReturnBB, false);
+    block->SetKindAndTargetEdge(BBJ_ALWAYS, m_compiler->fgAddRefPred(m_sharedReturnBB, block));
+    block->bbSetRunRarely();
+    block->clearTryIndex();
+    block->clearHndIndex();
+
+    if (m_compiler->fgIsUsingProfileWeights())
+    {
+        // All suspension BBs are cold, so we do not need to propagate any
+        // weights, but we do need to propagate the flag.
+        block->SetFlags(BBF_PROF_WEIGHT);
+    }
+
+    unsigned execContextLclNum;
+    if (execContextMayVary)
+    {
+        if (m_sharedFinishContextHandlingExecContextVar == BAD_VAR_NUM)
+        {
+            m_sharedFinishContextHandlingExecContextVar =
+                m_compiler->lvaGrabTemp(false DEBUGARG("exec context for shared finish context handling"));
+            m_compiler->lvaGetDesc(m_sharedFinishContextHandlingExecContextVar)->lvType = TYP_REF;
+        }
+
+        execContextLclNum = m_sharedFinishContextHandlingExecContextVar;
+    }
+    else
+    {
+        execContextLclNum = m_compiler->lvaAsyncExecutionContextVar;
+    }
+
+    unsigned syncContextLclNum;
+    if (syncContextMayVary)
+    {
+        if (m_sharedFinishContextHandlingSyncContextVar == BAD_VAR_NUM)
+        {
+            m_sharedFinishContextHandlingSyncContextVar =
+                m_compiler->lvaGrabTemp(false DEBUGARG("sync context for shared finish context handling"));
+            m_compiler->lvaGetDesc(m_sharedFinishContextHandlingSyncContextVar)->lvType = TYP_REF;
+        }
+
+        syncContextLclNum = m_sharedFinishContextHandlingSyncContextVar;
+    }
+    else
+    {
+        syncContextLclNum = m_compiler->lvaAsyncSynchronizationContextVar;
+    }
+
+    InsertFinishContextHandlingCall(block, layout, helper, m_compiler->gtNewLclvNode(execContextLclNum, TYP_REF),
+                                    m_compiler->gtNewLclvNode(syncContextLclNum, TYP_REF));
+
+    return block;
+}
+
+//------------------------------------------------------------------------
+// AsyncTransformation::InsertFinishContextHandlingCall:
+//   Insert a call to the specified context handling helper.
+//
+// Parameters:
+//   block       - Block that should contain the call (inserted at the end)
+//   layout      - The continuation layout
+//   helper      - The type of helper
+//   execContext - The execution context tree to pass to the helper
+//   syncContext - The synchronization context tree to pass to the helper
+//
+void AsyncTransformation::InsertFinishContextHandlingCall(BasicBlock*               block,
+                                                          const ContinuationLayout& layout,
+                                                          SuspensionContextHelper   helper,
+                                                          GenTree*                  execContext,
+                                                          GenTree*                  syncContext)
+{
+    CORINFO_METHOD_HANDLE helperMethod = (helper == SuspensionContextHelper::WithContinuationContext)
+                                             ? m_asyncInfo->finishSuspensionWithContinuationContextMethHnd
+                                             : m_asyncInfo->finishSuspensionNoContinuationContextMethHnd;
+
+    // Insert call
+    //   finishSuspension[With|No]ContinuationContext(
+    //     ref newContinuation.ContinuationContext, // optional
+    //     ref newContinuation.Flags,               // optional
+    //     ref newContinuation.ExecutionContext,
+    //     resumed,
+    //     execContext,
+    //     syncContext)
+    //
+
+    GenTree* contContextAddrPlaceholder = nullptr;
+    GenTree* flagsPlaceholder           = nullptr;
+    GenTree* execContextAddrPlaceholder = m_compiler->gtNewZeroConNode(TYP_BYREF);
+    GenTree* resumedPlaceholder         = m_compiler->gtNewIconNode(0);
+    GenTree* execContextPlaceholder     = m_compiler->gtNewNull();
+    GenTree* syncContextPlaceholder     = m_compiler->gtNewNull();
+
+    GenTreeCall* finishCall = m_compiler->gtNewCallNode(CT_USER_FUNC, helperMethod, TYP_VOID);
+    SetCallEntrypointForR2R(finishCall, m_compiler, helperMethod);
+
+    finishCall->gtArgs.PushFront(m_compiler, NewCallArg::Primitive(syncContextPlaceholder));
+    finishCall->gtArgs.PushFront(m_compiler, NewCallArg::Primitive(execContextPlaceholder));
+    finishCall->gtArgs.PushFront(m_compiler, NewCallArg::Primitive(resumedPlaceholder));
+    finishCall->gtArgs.PushFront(m_compiler, NewCallArg::Primitive(execContextAddrPlaceholder));
+
+    if (helper == SuspensionContextHelper::WithContinuationContext)
+    {
+        contContextAddrPlaceholder = m_compiler->gtNewZeroConNode(TYP_BYREF);
+        flagsPlaceholder           = m_compiler->gtNewZeroConNode(TYP_BYREF);
+        finishCall->gtArgs.PushFront(m_compiler, NewCallArg::Primitive(flagsPlaceholder));
+        finishCall->gtArgs.PushFront(m_compiler, NewCallArg::Primitive(contContextAddrPlaceholder));
+    }
+
+    m_compiler->compCurBB = block;
+    m_compiler->fgMorphTree(finishCall);
+
+    LIR::AsRange(block).InsertAtEnd(LIR::SeqTree(m_compiler, finishCall));
+
+    if (helper == SuspensionContextHelper::WithContinuationContext)
+    {
+        // Replace contContextAddrPlaceholder with actual address of the continuation context
+        LIR::Use use;
+        bool     gotUse = LIR::AsRange(block).TryGetUse(contContextAddrPlaceholder, &use);
+        assert(gotUse);
+
+        GenTree* newContinuation   = m_compiler->gtNewLclvNode(GetNewContinuationVar(), TYP_REF);
+        unsigned contContextOffset = OFFSETOF__CORINFO_Continuation__data + layout.ContinuationContextOffset;
+        GenTree* contContextAddrOffset =
+            m_compiler->gtNewOperNode(GT_ADD, TYP_BYREF, newContinuation,
+                                      m_compiler->gtNewIconNode((ssize_t)contContextOffset, TYP_I_IMPL));
+
+        LIR::AsRange(block).InsertBefore(contContextAddrPlaceholder, LIR::SeqTree(m_compiler, contContextAddrOffset));
+        use.ReplaceWith(contContextAddrOffset);
+        LIR::AsRange(block).Remove(contContextAddrPlaceholder);
+
+        // Replace flagsPlaceholder with actual address of the flags
+        gotUse = LIR::AsRange(block).TryGetUse(flagsPlaceholder, &use);
+        assert(gotUse);
+
+        newContinuation      = m_compiler->gtNewLclvNode(GetNewContinuationVar(), TYP_REF);
+        unsigned flagsOffset = m_compiler->info.compCompHnd->getFieldOffset(m_asyncInfo->continuationFlagsFldHnd);
+        GenTree* flagsOffsetNode =
+            m_compiler->gtNewOperNode(GT_ADD, TYP_BYREF, newContinuation,
+                                      m_compiler->gtNewIconNode((ssize_t)flagsOffset, TYP_I_IMPL));
+
+        LIR::AsRange(block).InsertBefore(flagsPlaceholder, LIR::SeqTree(m_compiler, flagsOffsetNode));
+        use.ReplaceWith(flagsOffsetNode);
+        LIR::AsRange(block).Remove(flagsPlaceholder);
+    }
+
+    // Replace execContextAddrPlaceholder with actual address of the execution context
+    LIR::Use use;
+    bool     gotUse = LIR::AsRange(block).TryGetUse(execContextAddrPlaceholder, &use);
+    assert(gotUse);
+
+    GenTree* newContinuation   = m_compiler->gtNewLclvNode(GetNewContinuationVar(), TYP_REF);
+    unsigned execContextOffset = OFFSETOF__CORINFO_Continuation__data + layout.ExecutionContextOffset;
+    GenTree* execContextAddrOffset =
+        m_compiler->gtNewOperNode(GT_ADD, TYP_BYREF, newContinuation,
+                                  m_compiler->gtNewIconNode((ssize_t)execContextOffset, TYP_I_IMPL));
+
+    LIR::AsRange(block).InsertBefore(execContextAddrPlaceholder, LIR::SeqTree(m_compiler, execContextAddrOffset));
+    use.ReplaceWith(execContextAddrOffset);
+    LIR::AsRange(block).Remove(execContextAddrPlaceholder);
+
+    // Replace resumedPlaceholder with actual "continuationParameter != null" arg
+    gotUse = LIR::AsRange(block).TryGetUse(resumedPlaceholder, &use);
+    assert(gotUse);
+
+    GenTree* continuation = m_compiler->gtNewLclvNode(m_compiler->lvaAsyncContinuationArg, TYP_REF);
+    GenTree* null         = m_compiler->gtNewNull();
+    GenTree* resumed      = m_compiler->gtNewOperNode(GT_NE, TYP_INT, continuation, null);
+
+    LIR::AsRange(block).InsertBefore(resumedPlaceholder, LIR::SeqTree(m_compiler, resumed));
+    use.ReplaceWith(resumed);
+    LIR::AsRange(block).Remove(resumedPlaceholder);
+
+    // Replace execContextPlaceholder with actual value
+    gotUse = LIR::AsRange(block).TryGetUse(execContextPlaceholder, &use);
+    assert(gotUse);
+
+    LIR::AsRange(block).InsertBefore(execContextPlaceholder, execContext);
+    use.ReplaceWith(execContext);
+    LIR::AsRange(block).Remove(execContextPlaceholder);
+
+    // Replace syncContextPlaceholder with actual value
+    gotUse = LIR::AsRange(block).TryGetUse(syncContextPlaceholder, &use);
+    assert(gotUse);
+
+    LIR::AsRange(block).InsertBefore(syncContextPlaceholder, syncContext);
+    use.ReplaceWith(syncContext);
+    LIR::AsRange(block).Remove(syncContextPlaceholder);
+
+    JITDUMP("    Created FinishSuspension call:\n");
+    DISPTREERANGE(LIR::AsRange(block), finishCall);
+}
+
+//------------------------------------------------------------------------
 // AsyncTransformation::CreateResumptionsAndSuspensions:
 //   Walk all recorded async states and create the suspension and resumption
 //   IR, continuation layouts, and debug info for each one.
@@ -3014,6 +3213,65 @@ void AsyncTransformation::CreateResumptionsAndSuspensions()
         ContinuationLayoutBuilder* sharedLayoutBuilder =
             ContinuationLayoutBuilder::CreateSharedLayout(m_compiler, m_states);
         sharedLayout = sharedLayoutBuilder->Create();
+
+        unsigned numSharedSuspensionsWithContinuationContext    = 0;
+        unsigned numSharedSuspensionsWithoutContinuationContext = 0;
+
+        bool execContextMayVary = false;
+        bool syncContextMayVary = false;
+
+        for (const AsyncState& state : m_states)
+        {
+            SuspensionContextHelper helper = GetSuspensionContextHelper(state.Call);
+            switch (helper)
+            {
+                case SuspensionContextHelper::WithContinuationContext:
+                    numSharedSuspensionsWithContinuationContext++;
+                    break;
+                case SuspensionContextHelper::WithoutContinuationContext:
+                    numSharedSuspensionsWithoutContinuationContext++;
+                    break;
+                default:
+                    break;
+            }
+
+            // If all calls still have the async context vars we created early
+            // then avoid round tripping through a local which will create
+            // unnecessary additional register moves. This is a common case.
+            if (helper != SuspensionContextHelper::None)
+            {
+                CallArg* execContextArg = state.Call->gtArgs.FindWellKnownArg(WellKnownArg::AsyncExecutionContext);
+                CallArg* syncContextArg =
+                    state.Call->gtArgs.FindWellKnownArg(WellKnownArg::AsyncSynchronizationContext);
+                assert((execContextArg != nullptr) && (syncContextArg != nullptr));
+
+                execContextMayVary |=
+                    !execContextArg->GetNode()->OperIsScalarLocal() ||
+                    (execContextArg->GetNode()->AsLclVar()->GetLclNum() != m_compiler->lvaAsyncExecutionContextVar);
+                syncContextMayVary |= !syncContextArg->GetNode()->OperIsScalarLocal() ||
+                                      (syncContextArg->GetNode()->AsLclVar()->GetLclNum() !=
+                                       m_compiler->lvaAsyncSynchronizationContextVar);
+            }
+        }
+
+        if (numSharedSuspensionsWithContinuationContext > 1)
+        {
+            JITDUMP("Using shared path for final context handling with continuation context -- needed by %u awaits\n",
+                    numSharedSuspensionsWithContinuationContext);
+            m_sharedFinishContextHandlingWithContinuationContextBB =
+                CreateSharedFinishContextHandlingBB(SuspensionContextHelper::WithContinuationContext, *sharedLayout,
+                                                    execContextMayVary, syncContextMayVary);
+        }
+
+        if (numSharedSuspensionsWithoutContinuationContext > 1)
+        {
+            JITDUMP(
+                "Using shared path for final context handling without continuation context -- needed by %u awaits\n",
+                numSharedSuspensionsWithoutContinuationContext);
+            m_sharedFinishContextHandlingWithoutContinuationContextBB =
+                CreateSharedFinishContextHandlingBB(SuspensionContextHelper::WithoutContinuationContext, *sharedLayout,
+                                                    execContextMayVary, syncContextMayVary);
+        }
     }
 
     JITDUMP("Creating suspensions and resumptions for %zu states\n", m_states.size());

--- a/src/coreclr/jit/async.h
+++ b/src/coreclr/jit/async.h
@@ -331,6 +331,19 @@ enum class SaveSet
     MutatedLocals,
 };
 
+enum class SuspensionContextHelper
+{
+    None,
+    WithContinuationContext,
+    WithoutContinuationContext,
+};
+
+struct AggregatedAwaitInfo
+{
+    unsigned NumNormalAwaits = 0;
+    unsigned NumTailAwaits   = 0;
+};
+
 class AsyncTransformation
 {
     friend class AsyncAnalysis;
@@ -349,10 +362,16 @@ class AsyncTransformation
     BasicBlock*                m_lastResumptionBB        = nullptr;
     BasicBlock*                m_sharedReturnBB          = nullptr;
 
-    void FindAwaits(ArrayStack<BasicBlock*>& blocksWithNormalAwaits,
-                    ArrayStack<BasicBlock*>& blocksWithTailAwaits,
-                    int*                     numNormalAwaits,
-                    int*                     numTailAwaits);
+    // Shared basic blocks used by suspensions that handle required context
+    // saves/restores and then suspend.
+    BasicBlock* m_sharedFinishContextHandlingWithContinuationContextBB    = nullptr;
+    BasicBlock* m_sharedFinishContextHandlingWithoutContinuationContextBB = nullptr;
+    // Variables that shared suspension finishing BBs take the exec/sync contexts in
+    unsigned m_sharedFinishContextHandlingExecContextVar = BAD_VAR_NUM;
+    unsigned m_sharedFinishContextHandlingSyncContextVar = BAD_VAR_NUM;
+
+    AggregatedAwaitInfo FindAwaits(ArrayStack<BasicBlock*>& blocksWithNormalAwaits,
+                                   ArrayStack<BasicBlock*>& blocksWithTailAwaits);
 
     void        TransformTailAwaits(ArrayStack<BasicBlock*>& blocksWithTailAwaits);
     void        TransformTailAwait(BasicBlock* block, GenTreeCall* call, BasicBlock** remainder);
@@ -399,36 +418,38 @@ class AsyncTransformation
                                              GenTree*                  prevContinuation,
                                              const ContinuationLayout& layout);
 
-    void        FillInDataOnSuspension(GenTreeCall*                     call,
-                                       const ContinuationLayout&        layout,
-                                       const ContinuationLayoutBuilder& subLayout,
-                                       BasicBlock*                      suspendBB,
-                                       VARSET_VALARG_TP                 mutatedSinceResumption,
-                                       SaveSet                          saveSet);
-    SaveSet     GetLocalSaveSet(const LclVarDsc* dsc, VARSET_VALARG_TP mutatedSinceResumption);
-    void        FinishContextHandlingOnSuspension(BasicBlock*                      callBlock,
-                                                  GenTreeCall*                     call,
-                                                  BasicBlock*                      suspendBB,
-                                                  const ContinuationLayout&        layout,
-                                                  const ContinuationLayoutBuilder& subLayout);
-    void        FinishContextHandlingOnSuspensionWithHelper(BasicBlock*                      callBlock,
-                                                            GenTreeCall*                     call,
-                                                            BasicBlock*                      suspendBB,
-                                                            const ContinuationLayout&        layout,
-                                                            const ContinuationLayoutBuilder& subLayout);
-    void        RestoreContexts(BasicBlock* block, GenTreeCall* call, BasicBlock* insertionBB);
-    void        CreateCheckAndSuspendAfterCall(BasicBlock*               block,
-                                               GenTreeCall*              call,
-                                               const CallDefinitionInfo& callDefInfo,
-                                               BasicBlock*               suspendBB,
-                                               BasicBlock**              remainder);
-    BasicBlock* CreateResumptionBlock(BasicBlock* remainder, unsigned stateNum);
-    void        CreateResumption(BasicBlock*                      callBlock,
-                                 GenTreeCall*                     call,
-                                 BasicBlock*                      resumeBB,
-                                 const CallDefinitionInfo&        callDefInfo,
-                                 const ContinuationLayout&        layout,
-                                 const ContinuationLayoutBuilder& subLayout);
+    void                    FillInDataOnSuspension(GenTreeCall*                     call,
+                                                   const ContinuationLayout&        layout,
+                                                   const ContinuationLayoutBuilder& subLayout,
+                                                   BasicBlock*                      suspendBB,
+                                                   VARSET_VALARG_TP                 mutatedSinceResumption,
+                                                   SaveSet                          saveSet);
+    SaveSet                 GetLocalSaveSet(const LclVarDsc* dsc, VARSET_VALARG_TP mutatedSinceResumption);
+    SuspensionContextHelper GetSuspensionContextHelper(GenTreeCall* call);
+    void                    FinishContextHandlingAndSuspension(BasicBlock*                      callBlock,
+                                                               GenTreeCall*                     call,
+                                                               BasicBlock*                      suspendBB,
+                                                               const ContinuationLayout&        layout,
+                                                               const ContinuationLayoutBuilder& subLayout);
+    void                    FinishContextHandlingAndSuspensionWithHelper(BasicBlock*                      callBlock,
+                                                                         GenTreeCall*                     call,
+                                                                         BasicBlock*                      suspendBB,
+                                                                         const ContinuationLayout&        layout,
+                                                                         const ContinuationLayoutBuilder& subLayout,
+                                                                         SuspensionContextHelper          helper);
+    void                    RestoreContexts(BasicBlock* block, GenTreeCall* call, BasicBlock* insertionBB);
+    void                    CreateCheckAndSuspendAfterCall(BasicBlock*               block,
+                                                           GenTreeCall*              call,
+                                                           const CallDefinitionInfo& callDefInfo,
+                                                           BasicBlock*               suspendBB,
+                                                           BasicBlock**              remainder);
+    BasicBlock*             CreateResumptionBlock(BasicBlock* remainder, unsigned stateNum);
+    void                    CreateResumption(BasicBlock*                      callBlock,
+                                             GenTreeCall*                     call,
+                                             BasicBlock*                      resumeBB,
+                                             const CallDefinitionInfo&        callDefInfo,
+                                             const ContinuationLayout&        layout,
+                                             const ContinuationLayoutBuilder& subLayout);
 
     void        RestoreFromDataOnResumption(const ContinuationLayout&        layout,
                                             const ContinuationLayoutBuilder& subLayout,
@@ -449,16 +470,25 @@ class AsyncTransformation
                                    var_types    storeType,
                                    GenTreeFlags indirFlags = GTF_IND_NONFAULTING);
 
-    void     CreateDebugInfoForSuspensionPoint(const ContinuationLayout&        layout,
-                                               const ContinuationLayoutBuilder& subLayout);
-    unsigned GetReturnedContinuationVar();
-    unsigned GetNewContinuationVar();
-    unsigned GetResultBaseVar();
-    unsigned GetExceptionVar();
-    void     CreateSharedReturnBB();
-    bool     ReuseContinuations();
-    void     CreateResumptionsAndSuspensions();
-    void     CreateResumptionSwitch();
+    void        CreateDebugInfoForSuspensionPoint(const ContinuationLayout&        layout,
+                                                  const ContinuationLayoutBuilder& subLayout);
+    unsigned    GetReturnedContinuationVar();
+    unsigned    GetNewContinuationVar();
+    unsigned    GetResultBaseVar();
+    unsigned    GetExceptionVar();
+    void        CreateSharedReturnBB();
+    BasicBlock* CreateSharedFinishContextHandlingBB(SuspensionContextHelper   helper,
+                                                    const ContinuationLayout& layout,
+                                                    bool                      execContextMayVary,
+                                                    bool                      syncContextMayVary);
+    void        InsertFinishContextHandlingCall(BasicBlock*               block,
+                                                const ContinuationLayout& layout,
+                                                SuspensionContextHelper   helper,
+                                                GenTree*                  execContext,
+                                                GenTree*                  syncContext);
+    bool        ReuseContinuations();
+    void        CreateResumptionsAndSuspensions();
+    void        CreateResumptionSwitch();
 
 public:
     AsyncTransformation(Compiler* comp)

--- a/src/coreclr/jit/gentree.h
+++ b/src/coreclr/jit/gentree.h
@@ -4491,6 +4491,11 @@ struct AsyncCallInfo
     // Tail awaits do not generate suspension points and the JIT instead
     // directly returns the callee's continuation to the caller.
     bool IsTailAwait = false;
+
+    bool NeedsToSaveAndRestoreExecutionContext() const
+    {
+        return true;
+    }
 };
 
 // Return type descriptor of a GT_CALL node.


### PR DESCRIPTION
When multiple awaits have common context handling logic during suspension we can share that logic completely by jumping to a common block. This PR implements that size optimization.

```csharp
private static async Task Foo()
{
    await Bar();
    await Bar();

    await Bar().ConfigureAwait(false);
    await Bar().ConfigureAwait(false);
}
```

<details>

<summary> Codegen diff </summary>

```diff
@@ -11,10 +11,10 @@
 ; 1 inlinees with PGO data; 3 single block inlinees; 0 inlinees without PGO data
 ; Final local variable assignments
 ;
-;  V00 AsyncCont    [V00,T01] ( 17,  4   )     ref  ->  [rbp+0x10]  EH-live single-def "Async continuation arg"
+;  V00 AsyncCont    [V00,T01] ( 15,  4   )     ref  ->  [rbp+0x10]  EH-live single-def "Async continuation arg"
 ;  V01 OutArgs      [V01    ] (  1,  1   )  struct (48) [rsp+0x00]  do-not-enreg[XS] addr-exposed "OutgoingArgSpace" <UNNAMED>
-;  V02 tmp1         [V02,T07] (  8,  0   )     ref  ->  [rbp-0x10]  must-init ld-addr-op EH-live single-def "Async ExecutionContext"
-;  V03 tmp2         [V03,T08] (  8,  0   )     ref  ->  [rbp-0x18]  must-init ld-addr-op EH-live single-def "Async SynchronizationContext"
+;  V02 tmp1         [V02,T07] (  6,  0   )     ref  ->  [rbp-0x10]  must-init ld-addr-op EH-live single-def "Async ExecutionContext"
+;  V03 tmp2         [V03,T08] (  6,  0   )     ref  ->  [rbp-0x18]  must-init ld-addr-op EH-live single-def "Async SynchronizationContext"
 ;  V04 tmp3         [V04,T05] (  3,  3   )     ref  ->  rax         class-hnd exact single-def "Inline stloc first use temp" <System.Threading.Thread>
 ;* V05 tmp4         [V05    ] (  0,  0   )   ubyte  ->  zero-ref    "Inlining Arg"
 ;  V06 tmp5         [V06,T09] (  5,  0   )     ref  ->  rbx         class-hnd exact single-def "Inline stloc first use temp" <System.Threading.Thread>
@@ -24,7 +24,7 @@
 ;  V10 rat0         [V10,T04] (  3,  4   )   byref  ->  rax         "TLS field access"
 ;  V11 rat1         [V11,T03] (  3,  6   )    long  ->  rax         "TLS access"
 ;  V12 rat2         [V12,T02] (  3,  6   )   byref  ->  rax         "ThreadStaticBlockBase access"
-;  V13 rat3         [V13,T06] ( 30,  0   )     ref  ->  rbx         "new continuation"
+;  V13 rat3         [V13,T06] ( 26,  0   )     ref  ->  rbx         "new continuation"
 ;  V14 rat4         [V14,T00] ( 15,  8   )     ref  ->  rcx         "returned continuation"
 ;  V15 rat5         [V15,T11] (  3,  0   )     int  ->  rax         "ReplaceWithLclVar is creating a new local variable"
 ;
@@ -42,7 +42,7 @@ G_M44929_IG01:  ;; offset=0x0000
 						;; size=25 bbWeight=1 PerfScore 6.00
 G_M44929_IG02:  ;; offset=0x0019
        test     rcx, rcx
-       jne      G_M44929_IG26
+       jne      G_M44929_IG28
        mov      rax, qword ptr GS:[0x0058]
        mov      rax, qword ptr [rax+0x28]
        cmp      dword ptr [rax+0x250], 2
@@ -54,8 +54,8 @@ G_M44929_IG02:  ;; offset=0x0019
 						;; size=47 bbWeight=1 PerfScore 13.50
 G_M44929_IG03:  ;; offset=0x0048
        mov      rax, gword ptr [rax+0x10]
-       mov      r8, gword ptr [rax+0x08]
-       mov      gword ptr [rbp-0x10], r8
+       mov      rdx, gword ptr [rax+0x08]
+       mov      gword ptr [rbp-0x10], rdx
        mov      rdx, gword ptr [rax+0x10]
        mov      gword ptr [rbp-0x18], rdx
 						;; size=20 bbWeight=1 PerfScore 8.00
@@ -122,26 +122,15 @@ G_M44929_IG13:  ;; offset=0x00E0
        jmp      SHORT G_M44929_IG09
 						;; size=24 bbWeight=0 PerfScore 0.00
 G_M44929_IG14:  ;; offset=0x00F8
-       mov      rdx, 0x7FFAEE674518      ; Continuation_16_0_2
+       mov      rdx, 0x7FFAEE504518      ; Continuation_16_0_2
        call     CORINFO_HELP_ALLOC_CONTINUATION
        mov      rbx, rax
        lea      rcx, [reloc @RWD00]
        mov      qword ptr [rbx+0x10], rcx
        mov      qword ptr [rbx+0x18], 32
-       mov      r8, gword ptr [rbp-0x10]
-       mov      gword ptr [rsp+0x20], r8
-       mov      rdx, gword ptr [rbp-0x18]
-       mov      gword ptr [rsp+0x28], rdx
-       lea      rcx, bword ptr [rbx+0x20]
-       lea      rdx, bword ptr [rbx+0x18]
-       lea      r8, bword ptr [rbx+0x28]
-       cmp      gword ptr [rbp+0x10], 0
-       setne    r9b
-       movzx    r9, r9b
-       call     [System.Runtime.CompilerServices.AsyncHelpers:FinishSuspensionWithContinuationContext(byref,byref,byref,bool,System.Threading.ExecutionContext,System.Threading.SynchronizationContext)]
        jmp      G_M44929_IG24
-						;; size=91 bbWeight=0 PerfScore 0.00
-G_M44929_IG15:  ;; offset=0x0153
+						;; size=42 bbWeight=0 PerfScore 0.00
+G_M44929_IG15:  ;; offset=0x0122
        mov      rax, gword ptr [rbp+0x10]
        mov      rbx, rax
        test     rbx, rbx
@@ -151,30 +140,19 @@ G_M44929_IG15:  ;; offset=0x0153
        call     CORINFO_HELP_ASSIGN_REF
        jmp      SHORT G_M44929_IG17
 						;; size=26 bbWeight=0 PerfScore 0.00
-G_M44929_IG16:  ;; offset=0x016D
-       mov      rdx, 0x7FFAEE674518      ; Continuation_16_0_2
+G_M44929_IG16:  ;; offset=0x013C
+       mov      rdx, 0x7FFAEE504518      ; Continuation_16_0_2
        call     CORINFO_HELP_ALLOC_CONTINUATION
        mov      rbx, rax
 						;; size=18 bbWeight=0 PerfScore 0.00
-G_M44929_IG17:  ;; offset=0x017F
+G_M44929_IG17:  ;; offset=0x014E
        lea      rcx, [reloc @RWD16]
        mov      qword ptr [rbx+0x10], rcx
        mov      rcx, 0x100000020
        mov      qword ptr [rbx+0x18], rcx
-       mov      r8, gword ptr [rbp-0x10]
-       mov      gword ptr [rsp+0x20], r8
-       mov      rdx, gword ptr [rbp-0x18]
-       mov      gword ptr [rsp+0x28], rdx
-       lea      rcx, bword ptr [rbx+0x20]
-       lea      rdx, bword ptr [rbx+0x18]
-       lea      r8, bword ptr [rbx+0x28]
-       cmp      gword ptr [rbp+0x10], 0
-       setne    r9b
-       movzx    r9, r9b
-       call     [System.Runtime.CompilerServices.AsyncHelpers:FinishSuspensionWithContinuationContext(byref,byref,byref,bool,System.Threading.ExecutionContext,System.Threading.SynchronizationContext)]
        jmp      G_M44929_IG24
-						;; size=79 bbWeight=0 PerfScore 0.00
-G_M44929_IG18:  ;; offset=0x01CE
+						;; size=30 bbWeight=0 PerfScore 0.00
+G_M44929_IG18:  ;; offset=0x016C
        mov      rax, gword ptr [rbp+0x10]
        mov      rbx, rax
        test     rbx, rbx
@@ -184,26 +162,19 @@ G_M44929_IG18:  ;; offset=0x01CE
        call     CORINFO_HELP_ASSIGN_REF
        jmp      SHORT G_M44929_IG20
 						;; size=26 bbWeight=0 PerfScore 0.00
-G_M44929_IG19:  ;; offset=0x01E8
-       mov      rdx, 0x7FFAEE674518      ; Continuation_16_0_2
+G_M44929_IG19:  ;; offset=0x0186
+       mov      rdx, 0x7FFAEE504518      ; Continuation_16_0_2
        call     CORINFO_HELP_ALLOC_CONTINUATION
        mov      rbx, rax
 						;; size=18 bbWeight=0 PerfScore 0.00
-G_M44929_IG20:  ;; offset=0x01FA
+G_M44929_IG20:  ;; offset=0x0198
        lea      rcx, [reloc @RWD32]
        mov      qword ptr [rbx+0x10], rcx
        mov      rcx, 0x200000001
        mov      qword ptr [rbx+0x18], rcx
-       lea      rcx, bword ptr [rbx+0x28]
-       cmp      gword ptr [rbp+0x10], 0
-       setne    dl
-       movzx    rdx, dl
-       mov      r8, gword ptr [rbp-0x10]
-       mov      r9, gword ptr [rbp-0x18]
-       call     [System.Runtime.CompilerServices.AsyncHelpers:FinishSuspensionNoContinuationContext(byref,bool,System.Threading.ExecutionContext,System.Threading.SynchronizationContext)]
-       jmp      SHORT G_M44929_IG24
-						;; size=56 bbWeight=0 PerfScore 0.00
-G_M44929_IG21:  ;; offset=0x0232
+       jmp      SHORT G_M44929_IG25
+						;; size=27 bbWeight=0 PerfScore 0.00
+G_M44929_IG21:  ;; offset=0x01B3
        mov      rax, gword ptr [rbp+0x10]
        mov      rbx, rax
        test     rbx, rbx
@@ -213,16 +184,33 @@ G_M44929_IG21:  ;; offset=0x0232
        call     CORINFO_HELP_ASSIGN_REF
        jmp      SHORT G_M44929_IG23
 						;; size=26 bbWeight=0 PerfScore 0.00
-G_M44929_IG22:  ;; offset=0x024C
-       mov      rdx, 0x7FFAEE674518      ; Continuation_16_0_2
+G_M44929_IG22:  ;; offset=0x01CD
+       mov      rdx, 0x7FFAEE504518      ; Continuation_16_0_2
        call     CORINFO_HELP_ALLOC_CONTINUATION
        mov      rbx, rax
 						;; size=18 bbWeight=0 PerfScore 0.00
-G_M44929_IG23:  ;; offset=0x025E
+G_M44929_IG23:  ;; offset=0x01DF
        lea      rcx, [reloc @RWD48]
        mov      qword ptr [rbx+0x10], rcx
        mov      rcx, 0x300000001
        mov      qword ptr [rbx+0x18], rcx
+       jmp      SHORT G_M44929_IG25
+						;; size=27 bbWeight=0 PerfScore 0.00
+G_M44929_IG24:  ;; offset=0x01FA
+       mov      r8, gword ptr [rbp-0x10]
+       mov      gword ptr [rsp+0x20], r8
+       mov      rdx, gword ptr [rbp-0x18]
+       mov      gword ptr [rsp+0x28], rdx
+       lea      rcx, bword ptr [rbx+0x20]
+       lea      rdx, bword ptr [rbx+0x18]
+       lea      r8, bword ptr [rbx+0x28]
+       cmp      gword ptr [rbp+0x10], 0
+       setne    r9b
+       movzx    r9, r9b
+       call     [System.Runtime.CompilerServices.AsyncHelpers:FinishSuspensionWithContinuationContext(byref,byref,byref,bool,System.Threading.ExecutionContext,System.Threading.SynchronizationContext)]
+       jmp      SHORT G_M44929_IG26
+						;; size=51 bbWeight=0 PerfScore 0.00
+G_M44929_IG25:  ;; offset=0x022D
        lea      rcx, bword ptr [rbx+0x28]
        cmp      gword ptr [rbp+0x10], 0
        setne    dl
@@ -230,51 +218,51 @@ G_M44929_IG23:  ;; offset=0x025E
        mov      r8, gword ptr [rbp-0x10]
        mov      r9, gword ptr [rbp-0x18]
        call     [System.Runtime.CompilerServices.AsyncHelpers:FinishSuspensionNoContinuationContext(byref,bool,System.Threading.ExecutionContext,System.Threading.SynchronizationContext)]
-						;; size=54 bbWeight=0 PerfScore 0.00
-G_M44929_IG24:  ;; offset=0x0294
+						;; size=29 bbWeight=0 PerfScore 0.00
+G_M44929_IG26:  ;; offset=0x024A
        mov      rcx, rbx
 						;; size=3 bbWeight=0 PerfScore 0.00
-G_M44929_IG25:  ;; offset=0x0297
+G_M44929_IG27:  ;; offset=0x024D
        add      rsp, 72
        pop      rbx
        pop      rbp
        ret      
 						;; size=7 bbWeight=0 PerfScore 0.00
-G_M44929_IG26:  ;; offset=0x029E
+G_M44929_IG28:  ;; offset=0x0254
        mov      rcx, gword ptr [rbp+0x10]
        mov      eax, dword ptr [rcx+0x1C]
        cmp      eax, 3
-       ja       SHORT G_M44929_IG27
+       ja       SHORT G_M44929_IG29
        lea      rdx, [reloc @RWD64]
        mov      edx, dword ptr [rdx+4*rax]
        lea      r8, G_M44929_IG02
        add      rdx, r8
        jmp      rdx
 						;; size=34 bbWeight=0 PerfScore 0.00
-G_M44929_IG27:  ;; offset=0x02C0
+G_M44929_IG29:  ;; offset=0x0276
        mov      rcx, gword ptr [rcx+0x28]
        call     [System.Runtime.CompilerServices.AsyncHelpers:RestoreExecutionContext(System.Threading.ExecutionContext)]
        jmp      G_M44929_IG05
 						;; size=15 bbWeight=0 PerfScore 0.00
-G_M44929_IG28:  ;; offset=0x02CF
+G_M44929_IG30:  ;; offset=0x0285
        mov      rcx, gword ptr [rcx+0x28]
        call     [System.Runtime.CompilerServices.AsyncHelpers:RestoreExecutionContext(System.Threading.ExecutionContext)]
        jmp      G_M44929_IG06
 						;; size=15 bbWeight=0 PerfScore 0.00
-G_M44929_IG29:  ;; offset=0x02DE
+G_M44929_IG31:  ;; offset=0x0294
        mov      rcx, gword ptr [rcx+0x28]
        call     [System.Runtime.CompilerServices.AsyncHelpers:RestoreExecutionContext(System.Threading.ExecutionContext)]
        jmp      G_M44929_IG07
 						;; size=15 bbWeight=0 PerfScore 0.00
-G_M44929_IG30:  ;; offset=0x02ED
+G_M44929_IG32:  ;; offset=0x02A3
        mov      rcx, gword ptr [rcx+0x28]
        call     [System.Runtime.CompilerServices.AsyncHelpers:RestoreExecutionContext(System.Threading.ExecutionContext)]
        jmp      G_M44929_IG08
 						;; size=15 bbWeight=0 PerfScore 0.00
-G_M44929_IG31:  ;; offset=0x02FC
+G_M44929_IG33:  ;; offset=0x02B2
        sub      rsp, 56
 						;; size=4 bbWeight=0 PerfScore 0.00
-G_M44929_IG32:  ;; offset=0x0300
+G_M44929_IG34:  ;; offset=0x02B6
        cmp      gword ptr [rbp+0x10], 0
        setne    cl
        movzx    rcx, cl
@@ -283,7 +271,7 @@ G_M44929_IG32:  ;; offset=0x0300
        call     [System.Runtime.CompilerServices.AsyncHelpers:RestoreContexts(bool,System.Threading.ExecutionContext,System.Threading.SynchronizationContext)]
        nop      
 						;; size=26 bbWeight=0 PerfScore 0.00
-G_M44929_IG33:  ;; offset=0x031A
+G_M44929_IG35:  ;; offset=0x02D0
        add      rsp, 56
        ret      
 						;; size=5 bbWeight=0 PerfScore 0.00
@@ -295,12 +283,12 @@ RWD32  	dq	(dynamicClass):IL_STUB_AsyncResume(System.Object,byref):System.Object
 	dq	G_M44929_IG18
 RWD48  	dq	(dynamicClass):IL_STUB_AsyncResume(System.Object,byref):System.Object
 	dq	G_M44929_IG21
-RWD64  	dd	000002A7h ; case G_M44929_IG27
-       	dd	000002B6h ; case G_M44929_IG28
-       	dd	000002C5h ; case G_M44929_IG29
-       	dd	000002D4h ; case G_M44929_IG30
+RWD64  	dd	0000025Dh ; case G_M44929_IG29
+       	dd	0000026Ch ; case G_M44929_IG30
+       	dd	0000027Bh ; case G_M44929_IG31
+       	dd	0000028Ah ; case G_M44929_IG32
 
 
-; Total bytes of code 799, prolog size 25, PerfScore 51.00, instruction count 191, allocated bytes for code 799 (MethodHash=967d507e) for method AsyncMicro.Program:Foo() (Tier1)
+; Total bytes of code 725, prolog size 25, PerfScore 51.00, instruction count 175, allocated bytes for code 725 (MethodHash=967d507e) for method AsyncMicro.Program:Foo() (Tier1)
 ; ============================================================
```

</details>

<details>

<summary> NativeAOT Test size diffs </summary>

| BaseSize | DiffSize | Delta | Percent | Name |
| ---: | ---: | ---: | ---: | --- |
| 16,573,440 | 16,499,712 | -73,728 | -0.445% | System.Linq.AsyncEnumerable.Tests.exe |
| 31,153,664 | 31,025,152 | -128,512 | -0.413% | System.Net.Http.Functional.Tests.exe |
| 115,722,240 | 115,256,320 | -465,920 | -0.403% | System.Text.Json.SourceGeneration.Roslyn4.4.Tests.exe |
| 19,599,872 | 19,547,136 | -52,736 | -0.269% | System.IO.Compression.Tests.exe |
| 20,982,784 | 20,930,560 | -52,224 | -0.249% | System.Net.Quic.Functional.Tests.exe |
| 20,066,304 | 20,021,248 | -45,056 | -0.225% | System.Formats.Tar.Tests.exe |
| 10,061,824 | 10,043,392 | -18,432 | -0.183% | System.IO.Compression.ZipFile.Tests.exe |
| 16,796,672 | 16,766,976 | -29,696 | -0.177% | System.Xml.Linq.Misc.Tests.exe |
| 14,916,096 | 14,889,984 | -26,112 | -0.175% | System.Xml.Linq.Streaming.Tests.exe |
| 16,529,920 | 16,503,808 | -26,112 | -0.158% | System.Xml.Linq.Events.Tests.exe |
| 17,079,296 | 17,052,672 | -26,624 | -0.156% | System.Xml.Linq.xNodeBuilder.Tests.exe |
| 17,022,464 | 16,996,352 | -26,112 | -0.153% | System.Xml.Linq.xNodeReader.Tests.exe |
| 16,685,568 | 16,659,968 | -25,600 | -0.153% | System.Xml.Linq.Properties.Tests.exe |
| 17,138,176 | 17,112,576 | -25,600 | -0.149% | System.Xml.Linq.TreeManipulation.Tests.exe |
| 10,663,424 | 10,648,576 | -14,848 | -0.139% | System.IO.Pipelines.Tests.exe |
| 22,751,232 | 22,721,024 | -30,208 | -0.133% | System.Net.Sockets.Tests.exe |
| 20,016,128 | 19,991,040 | -25,088 | -0.125% | System.Net.WebSockets.Client.Tests.exe |
| 28,812,800 | 28,776,960 | -35,840 | -0.124% | System.Net.Http.WinHttpHandler.Functional.Tests.exe |
| 20,276,736 | 20,254,208 | -22,528 | -0.111% | System.Threading.Tasks.Dataflow.Tests.exe |
| 19,061,248 | 19,040,768 | -20,480 | -0.107% | System.Net.HttpListener.Tests.exe |
| 17,734,144 | 17,716,224 | -17,920 | -0.101% | System.Threading.Tasks.Extensions.Tests.exe |
| 13,243,904 | 13,231,104 | -12,800 | -0.097% | System.IO.Packaging.Tests.exe |
| 33,183,744 | 33,152,000 | -31,744 | -0.096% | System.Private.Xml.Tests.exe |
| 21,716,480 | 21,696,512 | -19,968 | -0.092% | System.IO.FileSystem.Tests.exe |
| 11,991,040 | 11,980,288 | -10,752 | -0.090% | System.IO.Tests.exe |
| 10,275,840 | 10,266,624 | -9,216 | -0.090% | System.Threading.Channels.Tests.exe |
| 13,869,056 | 13,856,768 | -12,288 | -0.089% | Microsoft.Extensions.Configuration.Functional.Tests.exe |
| 14,570,496 | 14,557,696 | -12,800 | -0.088% | System.Net.WebClient.Tests.exe |
| 12,415,488 | 12,404,736 | -10,752 | -0.087% | System.Xml.Linq.SDMSample.Tests.exe |
| 17,569,280 | 17,554,432 | -14,848 | -0.085% | MetricOuterLoop.Tests.exe |
| 12,848,128 | 12,837,376 | -10,752 | -0.084% | System.Xml.Schema.Extensions.Tests.exe |
| 17,573,888 | 17,560,064 | -13,824 | -0.079% | MetricOuterLoop1.Tests.exe |
| 27,902,976 | 27,880,960 | -22,016 | -0.079% | System.Net.Security.Tests.exe |
| 17,792,512 | 17,778,688 | -13,824 | -0.078% | System.Formats.Tar.Manual.Tests.exe |
| 15,759,872 | 15,747,584 | -12,288 | -0.078% | System.Windows.Extensions.Tests.exe |
| 13,941,248 | 13,930,496 | -10,752 | -0.077% | Microsoft.Extensions.Configuration.Xml.Tests.exe |
| 19,547,136 | 19,532,288 | -14,848 | -0.076% | System.Diagnostics.Process.Tests.exe |
| 10,051,072 | 10,043,392 | -7,680 | -0.076% | System.Net.ServerSentEvents.Tests.exe |
| 14,128,640 | 14,117,888 | -10,752 | -0.076% | System.DirectoryServices.Protocols.Tests.exe |
| 15,100,416 | 15,089,152 | -11,264 | -0.075% | System.Drawing.Primitives.Tests.exe |
| 18,449,920 | 18,436,096 | -13,824 | -0.075% | System.Threading.Tasks.Parallel.Tests.exe |
| 21,093,376 | 21,077,504 | -15,872 | -0.075% | System.Net.Requests.Tests.exe |
| 9,726,464 | 9,719,296 | -7,168 | -0.074% | System.Threading.RateLimiting.Tests.exe |
| 19,291,648 | 19,277,312 | -14,336 | -0.074% | System.IO.Pipes.Tests.exe |
| 17,432,064 | 17,419,264 | -12,800 | -0.073% | System.Net.Ping.Functional.Tests.exe |
| 17,329,664 | 17,317,376 | -12,288 | -0.071% | System.Threading.Timer.Tests.exe |
| 17,288,704 | 17,276,416 | -12,288 | -0.071% | System.Runtime.InteropServices.RuntimeInformation.Tests.exe |
| 18,775,040 | 18,761,728 | -13,312 | -0.071% | Microsoft.Extensions.FileProviders.Physical.Tests.exe |
| 17,361,408 | 17,349,120 | -12,288 | -0.071% | System.Diagnostics.StackTrace.Tests.exe |
| 17,214,976 | 17,202,688 | -12,288 | -0.071% | System.Net.ServicePoint.Tests.exe |
| 15,078,400 | 15,067,648 | -10,752 | -0.071% | System.Security.Cryptography.Cng.Tests.exe |
| 20,542,464 | 20,528,128 | -14,336 | -0.070% | System.Threading.Tasks.Tests.exe |
| 18,381,824 | 18,369,024 | -12,800 | -0.070% | Microsoft.Extensions.Primitives.Tests.exe |
| 18,492,928 | 18,480,128 | -12,800 | -0.069% | Microsoft.Extensions.Configuration.Tests.exe |
| 18,455,040 | 18,442,240 | -12,800 | -0.069% | Microsoft.Extensions.Configuration.FileExtensions.Tests.exe |
| 17,154,048 | 17,142,272 | -11,776 | -0.069% | IcuAppLocal.Tests.exe |
| 15,036,928 | 15,026,688 | -10,240 | -0.068% | System.Data.DataSetExtensions.Tests.exe |
| 18,063,360 | 18,051,072 | -12,288 | -0.068% | System.Console.Tests.exe |
| 17,430,528 | 17,418,752 | -11,776 | -0.068% | System.Diagnostics.TraceSource.Tests.exe |
| 17,311,744 | 17,299,968 | -11,776 | -0.068% | System.Security.Principal.Windows.Tests.exe |
| 11,270,144 | 11,262,464 | -7,680 | -0.068% | System.IO.Compression.Brotli.Tests.exe |
| 17,967,104 | 17,954,816 | -12,288 | -0.068% | System.Threading.ThreadPool.Tests.exe |
| 17,235,456 | 17,223,680 | -11,776 | -0.068% | System.Runtime.InvariantTimezone.Tests.exe |
| 17,230,336 | 17,218,560 | -11,776 | -0.068% | System.ComponentModel.EventBasedAsync.Tests.exe |
| 11,327,488 | 11,319,808 | -7,680 | -0.068% | System.Net.WebSockets.Tests.exe |
| 17,298,432 | 17,286,656 | -11,776 | -0.068% | System.Security.Claims.Tests.exe |
| 17,616,384 | 17,604,608 | -11,776 | -0.067% | System.Threading.Thread.Tests.exe |
| 17,660,928 | 17,649,152 | -11,776 | -0.067% | System.IO.FileSystem.Watcher.Tests.exe |
| 17,657,344 | 17,645,568 | -11,776 | -0.067% | System.Buffers.Tests.exe |
| 16,105,984 | 16,095,232 | -10,752 | -0.067% | System.Data.Odbc.Tests.exe |
| 18,357,248 | 18,344,960 | -12,288 | -0.067% | Microsoft.Extensions.FileProviders.Composite.Tests.exe |
| 19,870,720 | 19,857,408 | -13,312 | -0.067% | System.Text.Encoding.Tests.exe |
| 17,160,192 | 17,148,928 | -11,264 | -0.066% | System.Runtime.Serialization.Formatters.Disabled.Tests.exe |
| 17,967,104 | 17,955,328 | -11,776 | -0.066% | System.Threading.ThreadPool.WindowsThreadPool.Tests.exe |
| 9,329,152 | 9,323,008 | -6,144 | -0.066% | Microsoft.Extensions.Diagnostics.Abstractions.Tests.exe |
| 9,246,208 | 9,240,064 | -6,144 | -0.066% | Microsoft.Bcl.AsyncInterfaces.Tests.exe |
| 19,680,256 | 19,667,456 | -12,800 | -0.065% | System.Net.Http.Unit.Tests.exe |
| 18,032,128 | 18,020,352 | -11,776 | -0.065% | Microsoft.Extensions.Diagnostics.Tests.exe |
| 17,281,536 | 17,270,272 | -11,264 | -0.065% | System.Threading.Overlapped.Tests.exe |
| 18,128,384 | 18,116,608 | -11,776 | -0.065% | System.Diagnostics.TextWriterTraceListener.Tests.exe |
| 18,177,024 | 18,165,248 | -11,776 | -0.065% | System.Text.Encoding.CodePages.Tests.exe |
| 19,744,256 | 19,731,456 | -12,800 | -0.065% | System.Resources.ResourceManager.Tests.exe |
| 17,355,776 | 17,344,512 | -11,264 | -0.065% | Microsoft.Win32.SystemEvents.Tests.exe |
| 18,371,072 | 18,359,296 | -11,776 | -0.064% | System.Threading.Tests.exe |
| 19,080,192 | 19,067,904 | -12,288 | -0.064% | Microsoft.Extensions.Hosting.WindowsServices.Tests.exe |
| 27,164,672 | 27,147,264 | -17,408 | -0.064% | Microsoft.Extensions.Hosting.Unit.Tests.exe |
| 18,693,120 | 18,681,344 | -11,776 | -0.063% | Microsoft.Extensions.Logging.Console.Tests.exe |
| 19,972,608 | 19,960,320 | -12,288 | -0.062% | Microsoft.Extensions.Logging.Tests.exe |
| 18,488,320 | 18,477,056 | -11,264 | -0.061% | Microsoft.Extensions.Hosting.Systemd.Tests.exe |
| 18,517,504 | 18,506,240 | -11,264 | -0.061% | System.IO.MemoryMappedFiles.Tests.exe |
| 19,294,720 | 19,282,944 | -11,776 | -0.061% | System.Net.Primitives.Functional.Tests.exe |
| 18,585,600 | 18,574,336 | -11,264 | -0.061% | ComInterfaceGenerator.Tests.exe |
| 18,833,408 | 18,822,144 | -11,264 | -0.060% | System.Runtime.Caching.Tests.exe |
| 9,435,648 | 9,430,016 | -5,632 | -0.060% | Microsoft.Extensions.Logging.Testing.Tests.exe |
| 24,286,208 | 24,271,872 | -14,336 | -0.059% | Microsoft.Extensions.Http.Tests.exe |
| 20,453,376 | 20,441,600 | -11,776 | -0.058% | System.Reflection.Tests.exe |
| 9,653,248 | 9,647,616 | -5,632 | -0.058% | Microsoft.Extensions.Hosting.Functional.Tests.exe |
| 19,484,160 | 19,472,896 | -11,264 | -0.058% | Microsoft.Extensions.Configuration.UserSecrets.Tests.exe |
| 20,233,728 | 20,221,952 | -11,776 | -0.058% | System.Runtime.InteropServices.Tests.exe |
| 19,555,328 | 19,544,064 | -11,264 | -0.058% | Microsoft.Extensions.Configuration.Json.Tests.exe |
| 20,475,392 | 20,463,616 | -11,776 | -0.058% | System.Diagnostics.DiagnosticSource.Tests.exe |
| 10,100,224 | 10,094,592 | -5,632 | -0.056% | Microsoft.Extensions.Caching.Memory.Tests.exe |
| 25,892,864 | 25,878,528 | -14,336 | -0.055% | System.Text.Json.SourceGeneration.Roslyn3.11.Tests.exe |
| 20,740,096 | 20,728,832 | -11,264 | -0.054% | System.Collections.Concurrent.Tests.exe |
| 10,504,192 | 10,498,560 | -5,632 | -0.054% | Microsoft.Extensions.Options.Tests.exe |
| 20,804,096 | 20,792,832 | -11,264 | -0.054% | System.Security.Cryptography.Csp.Tests.exe |
| 20,531,200 | 20,520,448 | -10,752 | -0.052% | System.Runtime.Extensions.Tests.exe |
| 21,621,248 | 21,609,984 | -11,264 | -0.052% | System.Data.OleDb.Tests.exe |
| 21,071,872 | 21,061,120 | -10,752 | -0.051% | Microsoft.Extensions.Logging.EventSource.Tests.exe |
| 23,403,520 | 23,391,744 | -11,776 | -0.050% | System.Memory.Tests.exe |
| 26,441,728 | 26,428,416 | -13,312 | -0.050% | System.ComponentModel.TypeConverter.Tests.exe |
| 11,580,928 | 11,575,296 | -5,632 | -0.049% | System.Net.Http.Json.Unit.Tests.exe |
| 29,404,672 | 29,390,848 | -13,824 | -0.047% | Microsoft.Extensions.DependencyModel.Tests.exe |
| 2,233,344 | 2,234,368 | +1,024 | +0.046% | clrjit.dll |
| 26,095,104 | 26,083,328 | -11,776 | -0.045% | System.Globalization.Tests.exe |
| 26,005,504 | 25,994,240 | -11,264 | -0.043% | System.Globalization.Nls.Tests.exe |
| 45,488,640 | 45,472,768 | -15,872 | -0.035% | System.Security.Cryptography.Tests.exe |
| 33,384,960 | 33,373,184 | -11,776 | -0.035% | Microsoft.Bcl.Cryptography.Tests.exe |
| 32,736,768 | 32,725,504 | -11,264 | -0.034% | System.Linq.Expressions.Tests.exe |
| 44,701,696 | 44,687,360 | -14,336 | -0.032% | System.Runtime.Tests.exe |
| 16,977,920 | 16,973,824 | -4,096 | -0.024% | System.Private.CoreLib.dll |
| 8,964,608 | 8,963,072 | -1,536 | -0.017% | System.Net.Primitives.Pal.Tests.exe |
| 9,560,576 | 9,559,040 | -1,536 | -0.016% | System.Memory.Data.Tests.exe |
| 12,174,336 | 12,172,800 | -1,536 | -0.013% | System.Net.NetworkInformation.Functional.Tests.exe |
| 8,598,528 | 8,597,504 | -1,024 | -0.012% | System.Composition.Runtime.Tests.exe |
| 8,598,016 | 8,596,992 | -1,024 | -0.012% | System.Xml.Linq.Axes.Tests.exe |
| 8,753,152 | 8,752,128 | -1,024 | -0.012% | Microsoft.Bcl.TimeProvider.Tests.exe |
| 8,674,304 | 8,673,280 | -1,024 | -0.012% | System.IO.FileSystem.Manual.Tests.exe |
| 8,904,192 | 8,903,168 | -1,024 | -0.012% | System.IO.Pipes.AccessControl.Tests.exe |
| 9,678,848 | 9,677,824 | -1,024 | -0.011% | System.Text.RegularExpressions.Unit.Tests.exe |
| 9,325,568 | 9,324,544 | -1,024 | -0.011% | System.IO.IsolatedStorage.Tests.exe |
| 9,117,184 | 9,116,160 | -1,024 | -0.011% | System.Security.AccessControl.Tests.exe |
| 9,057,792 | 9,056,768 | -1,024 | -0.011% | System.ValueTuple.Tests.exe |
| 9,620,992 | 9,619,968 | -1,024 | -0.011% | System.Private.Uri.Functional.Tests.exe |
| 10,483,712 | 10,482,688 | -1,024 | -0.010% | System.Net.Http.WinHttpHandler.Unit.Tests.exe |
| 10,037,248 | 10,036,224 | -1,024 | -0.010% | System.Diagnostics.Debug.Tests.exe |
| 9,775,104 | 9,774,080 | -1,024 | -0.010% | System.Net.WebProxy.Tests.exe |
| 11,457,536 | 11,456,512 | -1,024 | -0.009% | System.IO.Ports.Tests.exe |
| 11,767,808 | 11,766,784 | -1,024 | -0.009% | System.Security.Cryptography.Cose.Tests.exe |
| 15,374,336 | 15,373,312 | -1,024 | -0.007% | System.Globalization.Extensions.Nls.Tests.exe |
| 15,374,336 | 15,373,312 | -1,024 | -0.007% | System.Globalization.Extensions.Tests.exe |
| 8,627,200 | 8,626,688 | -512 | -0.006% | System.Globalization.CalendarsWithConfigSwitch.Tests.exe |
| 8,693,760 | 8,693,248 | -512 | -0.006% | System.Private.Uri.Unit.Tests.exe |
| 8,926,720 | 8,926,208 | -512 | -0.006% | Microsoft.Bcl.Memory.Tests.exe |
| 8,522,240 | 8,521,728 | -512 | -0.006% | System.ComponentModel.Tests.exe |
| 8,566,272 | 8,565,760 | -512 | -0.006% | Microsoft.Bcl.Numerics.Tests.exe |
| 9,013,760 | 9,013,248 | -512 | -0.006% | Microsoft.Extensions.FileSystemGlobbing.Tests.exe |
| 8,838,144 | 8,837,632 | -512 | -0.006% | System.Reflection.Extensions.Tests.exe |
| 8,654,848 | 8,654,336 | -512 | -0.006% | System.Runtime.CompilerServices.Unsafe.Tests.exe |
| 8,743,936 | 8,743,424 | -512 | -0.006% | System.IO.FileSystem.DriveInfo.Tests.exe |
| 9,083,392 | 9,082,880 | -512 | -0.006% | System.IO.FileSystem.AccessControl.Tests.exe |
| 8,999,936 | 8,999,424 | -512 | -0.006% | System.Reflection.TypeExtensions.Tests.exe |
| 8,660,992 | 8,661,504 | +512 | +0.006% | System.Runtime.InteropServices.ComDisabled.Tests.exe |
| 9,030,656 | 9,030,144 | -512 | -0.006% | Microsoft.Extensions.Configuration.CommandLine.Tests.exe |
| 8,809,984 | 8,809,472 | -512 | -0.006% | System.Console.Manual.Tests.exe |
| 9,189,888 | 9,189,376 | -512 | -0.006% | System.ServiceProcess.ServiceController.Tests.exe |
| 8,965,632 | 8,965,120 | -512 | -0.006% | Microsoft.Win32.Registry.Tests.exe |
| 8,674,816 | 8,674,304 | -512 | -0.006% | System.Security.Cryptography.ProtectedData.Tests.exe |
| 9,180,672 | 9,180,160 | -512 | -0.006% | Microsoft.Extensions.Configuration.EnvironmentVariables.Tests.exe |
| 8,644,096 | 8,643,584 | -512 | -0.006% | System.Runtime.Handles.Tests.exe |
| 8,791,552 | 8,791,040 | -512 | -0.006% | System.Web.HttpUtility.Tests.exe |
| 9,339,392 | 9,338,880 | -512 | -0.005% | System.Reflection.Context.Tests.exe |
| 10,924,544 | 10,924,032 | -512 | -0.005% | System.Runtime.Intrinsics.Tests.exe |
| 10,573,312 | 10,572,800 | -512 | -0.005% | Common.Tests.exe |
| 9,922,560 | 9,922,048 | -512 | -0.005% | System.Collections.NonGeneric.Tests.exe |
| 11,167,232 | 11,166,720 | -512 | -0.005% | System.Text.Encodings.Web.Tests.exe |
| 9,600,512 | 9,600,000 | -512 | -0.005% | System.Diagnostics.EventLog.Tests.exe |
| 11,022,848 | 11,022,336 | -512 | -0.005% | System.Runtime.Numerics.Tests.exe |
| 9,605,120 | 9,604,608 | -512 | -0.005% | System.Composition.Convention.Tests.exe |
| 9,350,656 | 9,350,144 | -512 | -0.005% | System.Net.Mail.Unit.Tests.exe |
| 9,649,152 | 9,648,640 | -512 | -0.005% | System.IO.UnmanagedMemoryStream.Tests.exe |
| 11,351,040 | 11,350,528 | -512 | -0.005% | System.Net.Security.Unit.Tests.exe |
| 9,462,784 | 9,462,272 | -512 | -0.005% | Microsoft.Extensions.Configuration.Ini.Tests.exe |
| 9,335,296 | 9,334,784 | -512 | -0.005% | System.Security.Permissions.Tests.exe |
| 9,936,384 | 9,935,872 | -512 | -0.005% | LibraryImportGenerator.Tests.exe |
| 12,259,840 | 12,259,328 | -512 | -0.004% | System.Reflection.Metadata.Tests.exe |
| 15,199,744 | 15,199,232 | -512 | -0.003% | System.Linq.Tests.exe |
| 22,308,352 | 22,307,840 | -512 | -0.002% | System.Security.Cryptography.Pkcs.Tests.exe |
| 8,677,376 | 8,677,376 | 0 | 0.000% | System.Security.SecureString.Tests.exe |
| 1,754,512 | 1,754,512 | 0 | 0.000% | Microsoft.DiaSymReader.Native.arm.dll |
| 8,531,968 | 8,531,968 | 0 | 0.000% | System.Text.Encoding.Extensions.Tests.exe |
| 8,977,408 | 8,977,408 | 0 | 0.000% | System.Runtime.Serialization.Primitives.Tests.exe |
| 7,318,016 | 7,318,016 | 0 | 0.000% | XUnitLogChecker.exe |
| 1,377,280 | 1,377,280 | 0 | 0.000% | System.IO.Compression.Native.dll |
| 1,935,296 | 1,935,296 | 0 | 0.000% | Microsoft.DiaSymReader.Native.x86.dll |
| 1,935,296 | 1,935,296 | 0 | 0.000% | Microsoft.DiaSymReader.Native.x86.dll |
| 2,309,152 | 2,309,152 | 0 | 0.000% | Microsoft.DiaSymReader.Native.amd64.dll |
| 2,247,784 | 2,247,784 | 0 | 0.000% | Microsoft.DiaSymReader.Native.arm64.dll |
| 1,754,512 | 1,754,512 | 0 | 0.000% | Microsoft.DiaSymReader.Native.arm.dll |
| 2,309,152 | 2,309,152 | 0 | 0.000% | Microsoft.DiaSymReader.Native.amd64.dll |
| 84,480 | 84,480 | 0 | 0.000% | System.Globalization.Native.dll |
| 108,032 | 108,032 | 0 | 0.000% | CMakeCXXCompilerId.exe |
| 108,032 | 108,032 | 0 | 0.000% | CMakeCCompilerId.exe |
| 2,247,784 | 2,247,784 | 0 | 0.000% | Microsoft.DiaSymReader.Native.arm64.dll |
| 8,932,864 | 8,932,864 | 0 | 0.000% | System.Threading.AccessControl.Tests.exe |
| 536,096 | 536,096 | 0 | 0.000% | msquic.dll |
| 8,517,120 | 8,517,120 | 0 | 0.000% | System.IO.FileSystem.Primitives.Tests.exe |
| 8,580,096 | 8,580,096 | 0 | 0.000% | System.Resources.Writer.Tests.exe |
| 1,502,720 | 1,502,720 | 0 | 0.000% | mscordaccore.dll |
| 1,502,720 | 1,502,720 | 0 | 0.000% | mscordaccore_amd64_amd64_42.42.42.42424.dll |
| 361,984 | 361,984 | 0 | 0.000% | hostpolicy.dll |
| 350,208 | 350,208 | 0 | 0.000% | hostfxr.dll |
| 62,464 | 62,464 | 0 | 0.000% | createdump.exe |
| 210,944 | 210,944 | 0 | 0.000% | corerun.exe |
| 4,956,160 | 4,956,160 | 0 | 0.000% | coreclr.dll |
| 722,944 | 722,944 | 0 | 0.000% | clrgcexp.dll |
| 678,400 | 678,400 | 0 | 0.000% | clrgc.dll |
| 307,200 | 307,200 | 0 | 0.000% | clretwrc.dll |
| 1,935,296 | 1,935,296 | 0 | 0.000% | Microsoft.DiaSymReader.Native.x86.dll |
| 2,309,152 | 2,309,152 | 0 | 0.000% | Microsoft.DiaSymReader.Native.amd64.dll |
| 2,247,784 | 2,247,784 | 0 | 0.000% | Microsoft.DiaSymReader.Native.arm64.dll |
| 1,754,512 | 1,754,512 | 0 | 0.000% | Microsoft.DiaSymReader.Native.arm.dll |
| 1,935,296 | 1,935,296 | 0 | 0.000% | Microsoft.DiaSymReader.Native.x86.dll |
| 2,247,784 | 2,247,784 | 0 | 0.000% | Microsoft.DiaSymReader.Native.arm64.dll |
| 1,754,512 | 1,754,512 | 0 | 0.000% | Microsoft.DiaSymReader.Native.arm.dll |
| 2,309,152 | 2,309,152 | 0 | 0.000% | Microsoft.DiaSymReader.Native.amd64.dll |
| 8,575,488 | 8,575,488 | 0 | 0.000% | Microsoft.Extensions.Hosting.Abstractions.Tests.exe |
| 8,731,648 | 8,731,648 | 0 | 0.000% | Invariant.Tests.exe |
| 15,922,176 | 15,922,176 | 0 | 0.000% | ilc.exe |
| 7,703,040 | 7,703,040 | 0 | 0.000% | ilasm.exe |
| 13,418,496 | 13,418,496 | 0 | 0.000% | crossgen2.exe |
| 9,956,352 | 9,956,352 | 0 | 0.000% | llvm-mca.exe |
| 696,320 | 696,320 | 0 | 0.000% | FileCheck.exe |
| 1,377,280 | 1,377,280 | 0 | 0.000% | System.IO.Compression.Native.dll |
| 84,480 | 84,480 | 0 | 0.000% | System.Globalization.Native.dll |
| 1,309,184 | 1,309,184 | 0 | 0.000% | mscordbi.dll |
| 8,520,704 | 8,520,704 | 0 | 0.000% | System.Runtime.CompilerServices.VisualC.Tests.exe |
| 536,096 | 536,096 | 0 | 0.000% | msquic.dll |
| 2,309,152 | 2,309,152 | 0 | 0.000% | Microsoft.DiaSymReader.Native.amd64.dll |
| 8,784,896 | 8,784,896 | 0 | 0.000% | System.Resources.Reader.Tests.exe |
| 11,577,856 | 11,577,856 | 0 | 0.000% | System.Resources.Extensions.Tests.exe |
| 18,752,000 | 18,752,000 | 0 | 0.000% | System.Numerics.Vectors.Tests.exe |
| 8,614,912 | 8,614,912 | 0 | 0.000% | System.Net.WebHeaderCollection.Tests.exe |
| 9,288,704 | 9,288,704 | 0 | 0.000% | System.Net.Primitives.UnitTests.Tests.exe |
| 9,014,784 | 9,014,784 | 0 | 0.000% | System.Net.NameResolution.Pal.Tests.exe |
| 9,512,448 | 9,512,448 | 0 | 0.000% | System.IO.Hashing.Tests.exe |
| 696,320 | 696,320 | 0 | 0.000% | FileCheck.exe |
| 9,139,200 | 9,139,200 | 0 | 0.000% | System.Globalization.Calendars.Tests.exe |
| 9,825,792 | 9,825,792 | 0 | 0.000% | System.Formats.Nrbf.Tests.exe |
| 9,736,704 | 9,736,704 | 0 | 0.000% | System.Formats.Asn1.Tests.exe |
| 8,522,240 | 8,522,240 | 0 | 0.000% | System.Diagnostics.Tools.Tests.exe |
| 8,691,200 | 8,691,200 | 0 | 0.000% | System.Diagnostics.FileVersionInfo.Tests.exe |
| 8,536,576 | 8,536,576 | 0 | 0.000% | System.Diagnostics.Contracts.Tests.exe |
| 8,532,480 | 8,532,480 | 0 | 0.000% | System.Composition.AttributeModel.Tests.exe |
| 9,135,616 | 9,135,616 | 0 | 0.000% | System.ComponentModel.Primitives.Tests.exe |
| 17,812,480 | 17,812,480 | 0 | 0.000% | System.Collections.Tests.exe |
| 9,722,880 | 9,722,880 | 0 | 0.000% | System.Collections.Specialized.Tests.exe |
| 8,620,544 | 8,620,544 | 0 | 0.000% | Microsoft.Win32.Registry.AccessControl.Tests.exe |
| 8,637,440 | 8,637,440 | 0 | 0.000% | Microsoft.Win32.Primitives.Tests.exe |
| 1,935,296 | 1,935,296 | 0 | 0.000% | Microsoft.DiaSymReader.Native.x86.dll |
| 2,309,152 | 2,309,152 | 0 | 0.000% | Microsoft.DiaSymReader.Native.amd64.dll |
| 2,247,784 | 2,247,784 | 0 | 0.000% | Microsoft.DiaSymReader.Native.arm64.dll |
| 1,754,512 | 1,754,512 | 0 | 0.000% | Microsoft.DiaSymReader.Native.arm.dll |
| 1,935,296 | 1,935,296 | 0 | 0.000% | Microsoft.DiaSymReader.Native.x86.dll |
| 2,247,784 | 2,247,784 | 0 | 0.000% | Microsoft.DiaSymReader.Native.arm64.dll |
| 1,754,512 | 1,754,512 | 0 | 0.000% | Microsoft.DiaSymReader.Native.arm.dll |
| 1,377,280 | 1,377,280 | 0 | 0.000% | System.IO.Compression.Native.dll |
| 9,956,352 | 9,956,352 | 0 | 0.000% | llvm-mca.exe |

</summary>