### PR TITLE
cDAC: Add metadata locator callback for heap dump support

### DIFF
--- a/docs/design/datacontracts/EcmaMetadata.md
+++ b/docs/design/datacontracts/EcmaMetadata.md
@@ -17,6 +17,13 @@ Types from other contracts:
 
 ## Version 1
 
+When the PE image is not readable from target memory (e.g., heap dumps where PE
+read-only sections are absent), `GetMetadata` falls back to
+`Target.TryLocateReadOnlyMetadata`. This virtual method allows hosts to provide
+metadata from an external source such as the PE file on disk, mirroring the legacy
+DAC's `ICLRMetadataLocator` pattern. `GetReadOnlyMetadataAddress` does not use this
+fallback — it always reads from target memory.
+
 
 Data descriptors used:
 | Data Descriptor Name | Field | Meaning |
@@ -61,10 +68,24 @@ MetadataReader? GetMetadata(ModuleHandle handle)
             return null;
         case AvailableMetadataType.ReadOnly:
         {
-            TargetSpan address = GetReadOnlyMetadataAddress(handle);
-            byte[] data = new byte[address.Size];
-            _target.ReadBuffer(address.Address, data);
-            return MetadataReaderProvider.FromMetadataImage(ImmutableCollectionsMarshal.AsImmutableArray(data)).GetMetadataReader();
+            try
+            {
+                TargetSpan address = GetReadOnlyMetadataAddress(handle);
+                byte[] data = new byte[address.Size];
+                _target.ReadBuffer(address.Address, data);
+                return MetadataReaderProvider.FromMetadataImage(ImmutableCollectionsMarshal.AsImmutableArray(data)).GetMetadataReader();
+            }
+            catch (VirtualReadException)
+            {
+                // PE image not readable from target memory (e.g., heap dump).
+                // Fall back to host-provided metadata locator.
+                string? modulePath = GetModulePath(handle);
+                if (_target.TryLocateReadOnlyMetadata(modulePath, out byte[] metadata) && metadata.Length > 0)
+                {
+                    return MetadataReaderProvider.FromMetadataImage(ImmutableCollectionsMarshal.AsImmutableArray(metadata)).GetMetadataReader();
+                }
+                return null;
+            }
         }
         case AvailableMetadataType.ReadWriteSavedCopy:
         {

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Target.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Abstractions/Target.cs
@@ -292,6 +292,21 @@ public abstract class Target
     public abstract ContractRegistry Contracts { get; }
 
     /// <summary>
+    /// Attempts to locate module metadata from an external source (e.g., PE file on disk)
+    /// when it cannot be read from target memory. Hosts override this method to provide
+    /// metadata resolution for scenarios such as heap dumps where PE read-only sections
+    /// may not be present in the dump.
+    /// </summary>
+    /// <param name="modulePath">Full path of the module in the target process.</param>
+    /// <param name="metadata">The raw ECMA-335 metadata bytes if located.</param>
+    /// <returns><c>true</c> if metadata was located; <c>false</c> otherwise.</returns>
+    public virtual bool TryLocateReadOnlyMetadata(string? modulePath, out byte[] metadata)
+    {
+        metadata = [];
+        return false;
+    }
+
+    /// <summary>
     /// Clear all cached data held by this target, including processed data and contract caches.
     /// Called when the target process state may have changed (e.g. on resume).
     /// </summary>

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadata_1.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader.Contracts/Contracts/EcmaMetadata_1.cs
@@ -64,10 +64,24 @@ internal sealed class EcmaMetadata_1(Target target) : IEcmaMetadata
                 return null;
             case AvailableMetadataType.ReadOnly:
             {
-                TargetSpan address = GetReadOnlyMetadataAddress(handle);
-                byte[] data = new byte[address.Size];
-                target.ReadBuffer(address.Address, data);
-                return MetadataReaderProvider.FromMetadataImage(ImmutableCollectionsMarshal.AsImmutableArray(data));
+                try
+                {
+                    TargetSpan address = GetReadOnlyMetadataAddress(handle);
+                    byte[] data = new byte[address.Size];
+                    target.ReadBuffer(address.Address, data);
+                    return MetadataReaderProvider.FromMetadataImage(ImmutableCollectionsMarshal.AsImmutableArray(data));
+                }
+                catch (VirtualReadException)
+                {
+                    // PE image not readable from target memory (e.g., heap dump).
+                    // Fall back to host-provided metadata locator.
+                    string? modulePath = GetModulePath(handle);
+                    if (target.TryLocateReadOnlyMetadata(modulePath, out byte[] metadata) && metadata.Length > 0)
+                    {
+                        return MetadataReaderProvider.FromMetadataImage(ImmutableCollectionsMarshal.AsImmutableArray(metadata));
+                    }
+                    return null;
+                }
             }
             case AvailableMetadataType.ReadWriteSavedCopy:
             {
@@ -325,6 +339,20 @@ internal sealed class EcmaMetadata_1(Target target) : IEcmaMetadata
     private TargetEcmaMetadata GetReadWriteMetadata(ModuleHandle handle)
     {
         throw new NotImplementedException();
+    }
+
+    private string? GetModulePath(ModuleHandle handle)
+    {
+        try
+        {
+            ILoader loader = target.Contracts.Loader;
+            string path = loader.GetPath(handle);
+            return string.IsNullOrEmpty(path) ? null : path;
+        }
+        catch (VirtualReadException)
+        {
+            return null;
+        }
     }
 
     private static T AlignUp<T>(T input, T alignment)

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
@@ -46,7 +46,18 @@ public sealed unsafe class ContractDescriptorTarget : Target
     public delegate int ReadFromTargetDelegate(ulong address, Span<byte> bufferToFill);
     public delegate int WriteToTargetDelegate(ulong address, Span<byte> bufferToWrite);
     public delegate int GetTargetThreadContextDelegate(uint threadId, uint contextFlags, Span<byte> bufferToFill);
-    private static readonly UTF8Encoding strictUTF8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    /// <summary>
+    /// Callback to locate module metadata when it cannot be read from target memory.
+    /// The host locates the PE file (e.g., on disk or via a symbol server) and returns
+    /// the raw ECMA-335 metadata bytes.
+    /// </summary>
+    /// <param name="modulePath">Full path of the module in the target process.</param>
+    /// <param name="metadata">The raw metadata bytes if found.</param>
+    /// <returns><c>true</c> if metadata was located; <c>false</c> otherwise.</returns>
+    public delegate bool GetReadOnlyMetadataDelegate(string? modulePath, out byte[] metadata);
+
+    private static readonly UTF8Encoding strictUTF8Encoding= new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
     private static readonly UTF8Encoding looseUTF8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
 
     /// <summary>
@@ -54,7 +65,9 @@ public sealed unsafe class ContractDescriptorTarget : Target
     /// </summary>
     /// <param name="contractDescriptor">The offset of the contract descriptor in the target memory</param>
     /// <param name="readFromTarget">A callback to read memory blocks at a given address from the target</param>
+    /// <param name="writeToTarget">A callback to write memory blocks at a given address to the target</param>
     /// <param name="getThreadContext">A callback to fetch a thread's context</param>
+    /// <param name="additionalFactories">Additional contract factories</param>
     /// <param name="target">The target object.</param>
     /// <returns>If a target instance could be created, <c>true</c>; otherwise, <c>false</c>.</returns>
     public static bool TryCreate(
@@ -65,7 +78,30 @@ public sealed unsafe class ContractDescriptorTarget : Target
         IEnumerable<IContractFactory<IContract>> additionalFactories,
         [NotNullWhen(true)] out ContractDescriptorTarget? target)
     {
-        DataTargetDelegates dataTargetDelegates = new DataTargetDelegates(readFromTarget, writeToTarget, getThreadContext);
+        return TryCreate(contractDescriptor, readFromTarget, writeToTarget, getThreadContext, getReadOnlyMetadata: null, additionalFactories, out target);
+    }
+
+    /// <summary>
+    /// Create a new target instance from a contract descriptor embedded in the target memory.
+    /// </summary>
+    /// <param name="contractDescriptor">The offset of the contract descriptor in the target memory</param>
+    /// <param name="readFromTarget">A callback to read memory blocks at a given address from the target</param>
+    /// <param name="writeToTarget">A callback to write memory blocks at a given address to the target</param>
+    /// <param name="getThreadContext">A callback to fetch a thread's context</param>
+    /// <param name="getReadOnlyMetadata">An optional callback to locate module metadata from an external source when it cannot be read from target memory.</param>
+    /// <param name="additionalFactories">Additional contract factories</param>
+    /// <param name="target">The target object.</param>
+    /// <returns>If a target instance could be created, <c>true</c>; otherwise, <c>false</c>.</returns>
+    public static bool TryCreate(
+        ulong contractDescriptor,
+        ReadFromTargetDelegate readFromTarget,
+        WriteToTargetDelegate writeToTarget,
+        GetTargetThreadContextDelegate getThreadContext,
+        GetReadOnlyMetadataDelegate? getReadOnlyMetadata,
+        IEnumerable<IContractFactory<IContract>> additionalFactories,
+        [NotNullWhen(true)] out ContractDescriptorTarget? target)
+    {
+        DataTargetDelegates dataTargetDelegates = new DataTargetDelegates(readFromTarget, writeToTarget, getThreadContext, getReadOnlyMetadata);
         if (TryReadAllContractDescriptors(
             contractDescriptor,
             dataTargetDelegates,
@@ -387,6 +423,12 @@ public sealed unsafe class ContractDescriptorTarget : Target
         // Underlying API only supports 32-bit thread IDs, mask off top 32 bits
         int hr = _dataTargetDelegates.GetThreadContext((uint)(threadId & uint.MaxValue), contextFlags, buffer);
         return hr == 0;
+    }
+
+    /// <inheritdoc/>
+    public override bool TryLocateReadOnlyMetadata(string? modulePath, out byte[] metadata)
+    {
+        return _dataTargetDelegates.TryGetReadOnlyMetadata(modulePath, out metadata);
     }
 
     /// <summary>
@@ -860,7 +902,8 @@ public sealed unsafe class ContractDescriptorTarget : Target
     private readonly struct DataTargetDelegates(
         ReadFromTargetDelegate readFromTarget,
         WriteToTargetDelegate writeToTarget,
-        GetTargetThreadContextDelegate getThreadContext)
+        GetTargetThreadContextDelegate getThreadContext,
+        GetReadOnlyMetadataDelegate? getReadOnlyMetadata = null)
     {
         public int ReadFromTarget(ulong address, Span<byte> buffer)
         {
@@ -877,6 +920,16 @@ public sealed unsafe class ContractDescriptorTarget : Target
         public int WriteToTarget(ulong address, Span<byte> buffer)
         {
             return writeToTarget(address, buffer);
+        }
+
+        public bool TryGetReadOnlyMetadata(string? modulePath, out byte[] metadata)
+        {
+            if (getReadOnlyMetadata is not null)
+            {
+                return getReadOnlyMetadata(modulePath, out metadata);
+            }
+            metadata = [];
+            return false;
         }
     }
 }

--- a/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
+++ b/src/native/managed/cdac/Microsoft.Diagnostics.DataContractReader/ContractDescriptorTarget.cs
@@ -57,7 +57,7 @@ public sealed unsafe class ContractDescriptorTarget : Target
     /// <returns><c>true</c> if metadata was located; <c>false</c> otherwise.</returns>
     public delegate bool GetReadOnlyMetadataDelegate(string? modulePath, out byte[] metadata);
 
-    private static readonly UTF8Encoding strictUTF8Encoding= new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+    private static readonly UTF8Encoding strictUTF8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
     private static readonly UTF8Encoding looseUTF8Encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: false);
 
     /// <summary>

--- a/src/native/managed/cdac/tests/DumpTests/CCWDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/CCWDumpTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 public class CCWDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "CCW";
-    protected override string DumpType => "full";
+
 
     /// <summary>
     /// Enumerates all strong GC handles from the dump, dereferences each one to get

--- a/src/native/managed/cdac/tests/DumpTests/ClrMdDumpHost.cs
+++ b/src/native/managed/cdac/tests/DumpTests/ClrMdDumpHost.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.IO;
+using System.Reflection.PortableExecutable;
 using Microsoft.Diagnostics.Runtime;
 
 namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
@@ -58,6 +60,78 @@ internal sealed class ClrMdDumpHost : IDisposable
     }
 
     /// <summary>
+    /// Locate module metadata from the PE file on disk when it cannot be read from dump memory.
+    /// Uses ClrMD's <see cref="IFileLocator"/> to find the PE file by matching the module name,
+    /// timestamp, and image size recorded in the dump, then extracts the raw ECMA-335 metadata.
+    /// </summary>
+    public bool TryGetReadOnlyMetadata(string? modulePath, out byte[] metadata)
+    {
+        metadata = [];
+        if (modulePath is null)
+            return false;
+
+        // First, try reading directly from the module path on disk.
+        // For local dumps, the module path recorded in the target process
+        // typically points to a valid file on the same machine.
+        if (TryReadMetadataFromPE(modulePath, out metadata))
+            return true;
+
+        // Fall back to ClrMD's FileLocator, which can use symbol servers
+        // and local caches to find PE files by timestamp and image size.
+        string targetFileName = GetPortableFileName(modulePath);
+
+        foreach (ModuleInfo module in _dataTarget.DataReader.EnumerateModules())
+        {
+            if (module.FileName is null)
+                continue;
+
+            string moduleFileName = GetPortableFileName(module.FileName);
+            if (!moduleFileName.Equals(targetFileName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // Try the module's dump-recorded file path directly
+            if (TryReadMetadataFromPE(module.FileName, out metadata))
+                return true;
+
+            // Try FileLocator (symbol server / local cache)
+            string? localPath = _dataTarget.FileLocator?.FindPEImage(
+                module.FileName,
+                module.IndexTimeStamp,
+                module.IndexFileSize,
+                checkProperties: false);
+
+            if (localPath is not null && TryReadMetadataFromPE(localPath, out metadata))
+                return true;
+        }
+
+        return false;
+    }
+
+    private static bool TryReadMetadataFromPE(string path, out byte[] metadata)
+    {
+        metadata = [];
+        if (!File.Exists(path))
+            return false;
+
+        try
+        {
+            using FileStream fs = File.OpenRead(path);
+            using PEReader peReader = new(fs, PEStreamOptions.PrefetchEntireImage);
+            if (!peReader.HasMetadata)
+                return false;
+
+            var metadataBlock = peReader.GetMetadata();
+            metadata = new byte[metadataBlock.Length];
+            metadataBlock.GetContent().CopyTo(metadata);
+            return metadata.Length > 0;
+        }
+        catch (System.Exception ex) when (ex is BadImageFormatException or IOException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Locate the DotNetRuntimeContractDescriptor symbol address in the dump.
     /// Uses ClrMD's built-in export resolution which handles PE, ELF, and Mach-O formats.
     /// </summary>
@@ -69,11 +143,7 @@ internal sealed class ClrMdDumpHost : IDisposable
             if (fileName is null)
                 continue;
 
-            // Path.GetFileName doesn't handle Windows paths on a Linux/macOS host,
-            // so split on both separators to extract the file name correctly when
-            // analyzing cross-platform dumps.
-            int lastSep = Math.Max(fileName.LastIndexOf('/'), fileName.LastIndexOf('\\'));
-            string name = lastSep >= 0 ? fileName[(lastSep + 1)..] : fileName;
+            string name = GetPortableFileName(fileName);
             if (!IsRuntimeModule(name))
                 continue;
 
@@ -91,6 +161,16 @@ internal sealed class ClrMdDumpHost : IDisposable
         }
 
         throw new InvalidOperationException("Could not find DotNetRuntimeContractDescriptor export in any runtime module in the dump.");
+    }
+
+    /// <summary>
+    /// Extracts the file name from a path, handling both Windows and Unix separators
+    /// for cross-platform dump analysis.
+    /// </summary>
+    private static string GetPortableFileName(string path)
+    {
+        int lastSep = Math.Max(path.LastIndexOf('/'), path.LastIndexOf('\\'));
+        return lastSep >= 0 ? path[(lastSep + 1)..] : path;
     }
 
     private static bool IsRuntimeModule(string fileName)

--- a/src/native/managed/cdac/tests/DumpTests/ComWrappersDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/ComWrappersDumpTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 public class ComWrappersDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "ComWrappers";
-    protected override string DumpType => "full";
+
 
     [ConditionalTheory]
     [MemberData(nameof(TestConfigurations))]

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/CCW/CCW.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/CCW/CCW.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DumpTypes>Full</DumpTypes>
+    <DumpTypes>Heap</DumpTypes>
     <WindowsOnly>true</WindowsOnly>
   </PropertyGroup>
 </Project>

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/ComWrappers/ComWrappers.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/ComWrappers/ComWrappers.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DumpTypes>Full</DumpTypes>
+    <DumpTypes>Heap</DumpTypes>
   </PropertyGroup>
 </Project>

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/LocalVariables/LocalVariables.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/LocalVariables/LocalVariables.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DumpTypes>Full</DumpTypes>
+    <DumpTypes>Heap</DumpTypes>
     <!-- local variables don't display correctly in R2R dumps -->
     <R2RModes>Jit</R2RModes>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/PInvokeStub/PInvokeStub.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/PInvokeStub/PInvokeStub.csproj
@@ -3,7 +3,7 @@
     <!-- Intentionally use DllImport (not LibraryImport) so the runtime generates an
          ILStub at execution time. SYSLIB1054 warns about preferring LibraryImport. -->
     <NoWarn>$(NoWarn);SYSLIB1054</NoWarn>
-    <DumpTypes>Full</DumpTypes>
+    <DumpTypes>Heap</DumpTypes>
     <WindowsOnly>true</WindowsOnly>
   </PropertyGroup>
 </Project>

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/RCW/RCW.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/RCW/RCW.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- This debuggee is intentionally Windows-only (COM interop). -->
     <NoWarn>$(NoWarn);CA1416</NoWarn>
-    <DumpTypes>Full</DumpTypes>
+    <DumpTypes>Heap</DumpTypes>
     <WindowsOnly>true</WindowsOnly>
   </PropertyGroup>
 </Project>

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/RCWCleanupList/RCWCleanupList.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/RCWCleanupList/RCWCleanupList.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <!-- This debuggee is intentionally Windows-only (COM interop). -->
     <NoWarn>$(NoWarn);CA1416</NoWarn>
-    <DumpTypes>Full</DumpTypes>
+    <DumpTypes>Heap</DumpTypes>
     <WindowsOnly>true</WindowsOnly>
   </PropertyGroup>
 </Project>

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/StackWalk/StackWalk.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/StackWalk/StackWalk.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DumpTypes>Full</DumpTypes>
+    <DumpTypes>Heap</DumpTypes>
     <R2RModes>R2R;Jit</R2RModes>
   </PropertyGroup>
 </Project>

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/SyncBlock/SyncBlock.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/SyncBlock/SyncBlock.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <DumpTypes>Full</DumpTypes>
+    <DumpTypes>Heap</DumpTypes>
   </PropertyGroup>
 </Project>

--- a/src/native/managed/cdac/tests/DumpTests/Debuggees/VarargPInvoke/VarargPInvoke.csproj
+++ b/src/native/managed/cdac/tests/DumpTests/Debuggees/VarargPInvoke/VarargPInvoke.csproj
@@ -3,7 +3,7 @@
     <!-- Intentionally use DllImport (not LibraryImport) so the runtime generates
          a VarargPInvokeStub at execution time. SYSLIB1054 warns about preferring LibraryImport. -->
     <NoWarn>$(NoWarn);SYSLIB1054</NoWarn>
-    <DumpTypes>Full</DumpTypes>
+    <DumpTypes>Heap</DumpTypes>
     <WindowsOnly>true</WindowsOnly>
   </PropertyGroup>
 </Project>

--- a/src/native/managed/cdac/tests/DumpTests/DumpTestBase.cs
+++ b/src/native/managed/cdac/tests/DumpTests/DumpTestBase.cs
@@ -106,6 +106,7 @@ public abstract class DumpTestBase : IDisposable
             _host.ReadFromTarget,
             writeToTarget: static (_, _) => -1,
             _host.GetThreadContext,
+            _host.TryGetReadOnlyMetadata,
             additionalFactories: [],
             out _target);
 

--- a/src/native/managed/cdac/tests/DumpTests/IXCLRDataAppDomainDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/IXCLRDataAppDomainDumpTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 public unsafe class IXCLRDataAppDomainDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "StackWalk";
-    protected override string DumpType => "full";
+
 
     // ========== GetName ==========
 

--- a/src/native/managed/cdac/tests/DumpTests/IXCLRDataFrameDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/IXCLRDataFrameDumpTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 public unsafe class IXCLRDataFrameDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "StackWalk";
-    protected override string DumpType => "full";
+
 
     // ========== GetContext ==========
 

--- a/src/native/managed/cdac/tests/DumpTests/IXCLRDataValueDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/IXCLRDataValueDumpTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 public unsafe class IXCLRDataValueDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "LocalVariables";
-    protected override string DumpType => "full";
+
 
     // ========== GetSize ==========
 

--- a/src/native/managed/cdac/tests/DumpTests/LoaderDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/LoaderDumpTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 public class LoaderDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "MultiModule";
-    protected override string DumpType => "full";
+
 
     [ConditionalTheory]
     [MemberData(nameof(TestConfigurations))]

--- a/src/native/managed/cdac/tests/DumpTests/PInvokeStubDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/PInvokeStubDumpTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 public class PInvokeStubDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "PInvokeStub";
-    protected override string DumpType => "full";
+
 
     [ConditionalTheory]
     [MemberData(nameof(TestConfigurations))]

--- a/src/native/managed/cdac/tests/DumpTests/RCWCleanupListDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/RCWCleanupListDumpTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 public class RCWCleanupListDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "RCWCleanupList";
-    protected override string DumpType => "full";
+
 
     [ConditionalTheory]
     [MemberData(nameof(TestConfigurations))]

--- a/src/native/managed/cdac/tests/DumpTests/RCWDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/RCWDumpTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 public class RCWDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "RCW";
-    protected override string DumpType => "full";
+
 
     /// <summary>
     /// Walks all strong GC handles and returns all RCW pointers found,

--- a/src/native/managed/cdac/tests/DumpTests/README.md
+++ b/src/native/managed/cdac/tests/DumpTests/README.md
@@ -29,20 +29,36 @@ features and then calls `Environment.FailFast()` to produce a crash dump.
 | BasicThreads | Thread management, thread store | Heap |
 | GCRoots | GC object graphs, pinned handles | Heap |
 | ServerGC | Server GC mode heap structures | Heap |
-| StackWalk | Deterministic call stack (Main→A→B→C→FailFast) | Full |
+| StackWalk | Deterministic call stack (Main→A→B→C→FailFast) | Heap |
 | MultiModule | Multi-assembly metadata resolution | Full |
 | TypeHierarchy | Type inheritance, method tables | Heap |
-| PInvokeStub | P/Invoke with SetLastError ILStub | Full |
-| VarargPInvoke | Vararg P/Invoke via __arglist (sprintf) | Full |
-| SyncBlock | Sync block locks | Full |
-| CCW | COM callable wrappers (CCW) on Windows | Full |
-| RCWCleanupList | STA-context RCW entries in g_pRCWCleanupList on Windows | Full |
-| RCW | COM RCW with populated interface entry cache on Windows | Full |
-| ComWrappers | ComWrappers-based MOW and RCW | Full |
+| PInvokeStub | P/Invoke with SetLastError ILStub | Heap |
+| VarargPInvoke | Vararg P/Invoke via __arglist (sprintf) | Heap |
+| SyncBlock | Sync block locks | Heap |
+| CCW | COM callable wrappers (CCW) on Windows | Heap |
+| RCWCleanupList | STA-context RCW entries in g_pRCWCleanupList on Windows | Heap |
+| RCW | COM RCW with populated interface entry cache on Windows | Heap |
+| ComWrappers | ComWrappers-based MOW and RCW | Heap |
 
 The dump type is configured per-debuggee via the `DumpTypes` property in each debuggee's
-`.csproj` (default: `Heap`, set in `Debuggees/Directory.Build.props`). Debuggees that
-need full memory content (e.g., metadata-heavy scenarios) override this to `Full`.
+`.csproj` (default: `Heap`, set in `Debuggees/Directory.Build.props`). Most tests use
+heap dumps, which are 4-6x smaller than full dumps. A few debuggees use full dumps
+because their tests read R2R PE section data that is inherently absent from heap dumps.
+
+### Metadata Locator Callback
+
+Heap dumps (`MiniDumpWithPrivateReadWriteMemory`) do not include PE read-only sections,
+so the cDAC cannot read ECMA-335 metadata directly from target memory. To support
+metadata resolution on heap dumps, the `Target` class exposes a
+`TryLocateReadOnlyMetadata` virtual method that hosts can override to provide metadata
+from an external source (e.g., the PE file on disk).
+
+`ClrMdDumpHost` implements this callback by:
+1. Trying the module's on-disk path directly (works for local dumps)
+2. Falling back to ClrMD's `IFileLocator.FindPEImage` for symbol server resolution
+
+This mirrors the legacy DAC's `ICLRMetadataLocator` pattern, where the debugger host
+(SOS, Visual Studio) locates PE files via symbol servers when metadata is not in the dump.
 
 ### Test Classes
 

--- a/src/native/managed/cdac/tests/DumpTests/StackWalkDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/StackWalkDumpTests.cs
@@ -10,13 +10,14 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 
 /// <summary>
 /// Dump-based integration tests for the StackWalk contract.
-/// Uses the StackWalk debuggee dump, which has a deterministic call stack:
+/// Uses the StackWalk debuggee heap dump, which has a deterministic call stack:
 /// Main → MethodA → MethodB → MethodC → FailFast.
+/// Metadata resolution uses the host-provided metadata locator callback
+/// since heap dumps do not contain PE read-only sections.
 /// </summary>
 public class StackWalkDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "StackWalk";
-    protected override string DumpType => "full";
 
     [ConditionalTheory]
     [MemberData(nameof(TestConfigurations))]

--- a/src/native/managed/cdac/tests/DumpTests/SyncBlockDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/SyncBlockDumpTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 public class SyncBlockDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "SyncBlock";
-    protected override string DumpType => "full";
+
 
     [ConditionalTheory]
     [MemberData(nameof(TestConfigurations))]

--- a/src/native/managed/cdac/tests/DumpTests/VarargPInvokeDumpTests.cs
+++ b/src/native/managed/cdac/tests/DumpTests/VarargPInvokeDumpTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Diagnostics.DataContractReader.DumpTests;
 public class VarargPInvokeDumpTests : DumpTestBase
 {
     protected override string DebuggeeName => "VarargPInvoke";
-    protected override string DumpType => "full";
+
 
     [ConditionalTheory]
     [MemberData(nameof(TestConfigurations))]


### PR DESCRIPTION
> [!NOTE]
> This PR was generated with the assistance of GitHub Copilot.

## Summary

Add a metadata locator callback to the cDAC `Target`, enabling `EcmaMetadata_1` to resolve PE metadata from disk when it cannot be read from target memory. This unblocks heap dump support for most dump tests, reducing dump sizes by 4-6x.

## Problem

`EcmaMetadata_1.GetReadOnlyMetadataAddress` reads the entire loaded PE image (~3.6 MB for `System.Private.CoreLib.dll`) via `TargetStream` to parse PE headers and locate metadata. Heap dumps (`MiniDumpWithPrivateReadWriteMemory`) don't include PE read-only sections, causing `VirtualReadException`. This forced all tests that need metadata resolution (stackwalking, method name lookup, etc.) to use full dumps (135-149 MB each).

The cDAC stackwalk itself works perfectly on heap dumps — the only blocker was metadata resolution.

## Solution

Add a `GetReadOnlyMetadataDelegate` callback to `ContractDescriptorTarget`, mirroring the legacy DAC's `ICLRMetadataLocator` pattern (implemented by SOS via `ISymbolService.GetMetadataLocator` in the diagnostics repo).

### Architecture

```
EcmaMetadata_1.GetMetadataProvider (ReadOnly case)
  │
  ├─ Try: read PE image from target memory (existing path)
  │
  └─ Catch VirtualReadException:
       └─ Target.TryLocateReadOnlyMetadata(modulePath)
            └─ GetReadOnlyMetadataDelegate (host callback)
                 └─ ClrMdDumpHost: try path on disk → IFileLocator.FindPEImage
                      └─ PEReader.GetMetadata() → return raw bytes
```

### Changes

**cDAC core (commit 1):**
- `Target.cs` — new `TryLocateReadOnlyMetadata` virtual method (default returns false)
- `ContractDescriptorTarget.cs` — new `GetReadOnlyMetadataDelegate` type stored in `DataTargetDelegates`, new `TryCreate` overload
- `EcmaMetadata_1.cs` — try/catch `VirtualReadException` fallback to metadata locator
- `ClrMdDumpHost.cs` — implement callback: try module path on disk, then `IFileLocator.FindPEImage`
- `DumpTestBase.cs` — wire callback into target creation

**Test changes (commit 2):**
- Remove `DumpType => "full"` override from 11 test classes (inherit default `"heap"`)
- Switch 9 debuggee `.csproj` files from `DumpTypes=Full` to `DumpTypes=Heap`
- 3 test classes remain on full dumps:
  - `ExceptionHandlingInfoDumpTests` — reads R2R exception clause tables from PE sections
  - `EcmaMetadataDumpTests` — explicitly tests the PE-memory metadata path
  - `AsyncContinuationDumpTests` — reads R2R section headers from PE image

**Documentation (commit 3):**
- `docs/design/datacontracts/EcmaMetadata.md` — document the fallback behavior
- `tests/DumpTests/README.md` — update debuggee table, add Metadata Locator section

### Test results

```
Total tests: 508
     Passed: 165
     Failed: 0
    Skipped: 343
```

### Dump size comparison

| Dump Type | StackWalk R2R | StackWalk JIT |
|-----------|--------------|--------------|
| Full      | 134.6 MB     | 148.9 MB     |
| Heap      | 23.5 MB      | 34.7 MB      |
| **Reduction** | **5.7x**  | **4.3x**     |