### PR TITLE
Add support for dumping interpreter IR for debugging purposes

### DIFF
--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -900,7 +900,7 @@ int32_t InterpCompiler::GetLiveEndOffset(int32_t var)
     }
 }
 
-uint32_t InterpCompiler::ConvertOffset(int32_t offset)
+static uint32_t ConvertOffset(int32_t offset)
 {
     // FIXME Once the VM moved the InterpMethod* to code header, we don't need to add a pointer size to the offset
     return offset * sizeof(int32_t) + sizeof(void*);
@@ -1430,8 +1430,8 @@ public:
         assert(slot != ((GcSlotId)-1));
         assert(pVar->liveStart);
         assert(pVar->liveEnd);
-        uint32_t startOffset = m_compiler->ConvertOffset(m_compiler->GetLiveStartOffset(varIndex)),
-            endOffset = m_compiler->ConvertOffset(m_compiler->GetLiveEndOffset(varIndex));
+        uint32_t startOffset = ConvertOffset(m_compiler->GetLiveStartOffset(varIndex)),
+            endOffset = ConvertOffset(m_compiler->GetLiveEndOffset(varIndex));
         INTERP_DUMP(
             "Slot %u (%s var #%d offset %u) live [IR_%04x - IR_%04x] [%u - %u]\n",
             slot, pVar->global ? "global" : "local",
@@ -1450,7 +1450,7 @@ public:
 
     void ReportConservativeRangesToGCEncoder()
     {
-        uint32_t maxEndOffset = m_compiler->ConvertOffset(m_compiler->m_methodCodeSize);
+        uint32_t maxEndOffset = ConvertOffset(m_compiler->m_methodCodeSize);
         for (uint32_t iSlot = 0; iSlot < m_slotTableSize; iSlot++)
         {
             ConservativeRanges* ranges = m_conservativeRanges.Get(iSlot);
@@ -1956,8 +1956,9 @@ InterpMethod* InterpCompiler::FinalizeMethodData(void* baseAddressRW, void* base
     // Construct InterpMethod in the final allocation
     InterpMethod* pMethodRW = (InterpMethod*)(rwBase + interpMethodOffset);
     InterpMethod* pMethodRX = (InterpMethod*)(rxBase + interpMethodOffset);
-    new (pMethodRW) InterpMethod(m_methodHnd, m_ILLocalsOffset, m_totalVarsStackSize, pDataItems, 
-                                  m_initLocals, m_unmanagedCallersOnly, m_publishSecretStubParam);
+    new (pMethodRW) InterpMethod(m_methodHnd, m_ILLocalsOffset, m_totalVarsStackSize, pDataItems,
+                                  m_initLocals, m_unmanagedCallersOnly, m_publishSecretStubParam,
+                                  m_methodCodeSize);
 
     // Copy async suspend data and fix up pointers
     uint32_t currentAsyncOffset = asyncSuspendDataOffset;
@@ -11203,21 +11204,26 @@ bool InterpreterRetryData::GetOverrideILMergePointStackType(int32_t ilOffset, ui
     }
 }
 
-void InterpCompiler::PrintClassName(CORINFO_CLASS_HANDLE cls)
+static void DumpClassName(CORINFO_CLASS_HANDLE cls, COMP_HANDLE compHnd)
 {
     char className[100];
-    m_compHnd->printClassName(cls, className, 100);
+    compHnd->printClassName(cls, className, 100);
     printf("%s", className);
 }
 
-void InterpCompiler::PrintMethodName(CORINFO_METHOD_HANDLE method)
+void InterpCompiler::PrintClassName(CORINFO_CLASS_HANDLE cls)
 {
-    CORINFO_CLASS_HANDLE cls = m_compHnd->getMethodClass(method);
+    DumpClassName(cls, m_compHnd);
+}
+
+static void DumpMethodName(CORINFO_METHOD_HANDLE method, COMP_HANDLE compHnd)
+{
+    CORINFO_CLASS_HANDLE cls = compHnd->getMethodClass(method);
 
     CORINFO_SIG_INFO sig;
-    m_compHnd->getMethodSig(method, &sig, cls);
+    compHnd->getMethodSig(method, &sig, cls);
 
-    TArray<char, MallocAllocator> methodName = ::PrintMethodName(m_compHnd, cls, method, &sig,
+    TArray<char, MallocAllocator> methodName = ::PrintMethodName(compHnd, cls, method, &sig,
                             /* includeAssembly */ false,
                             /* includeClass */ true,
                             /* includeClassInstantiation */ true,
@@ -11226,8 +11232,12 @@ void InterpCompiler::PrintMethodName(CORINFO_METHOD_HANDLE method)
                             /* includeReturnType */ false,
                             /* includeThis */ false);
 
-
     printf(".%s", methodName.GetUnderlyingArray());
+}
+
+void InterpCompiler::PrintMethodName(CORINFO_METHOD_HANDLE method)
+{
+    DumpMethodName(method, m_compHnd);
 }
 
 void InterpCompiler::PrintCode()
@@ -11353,22 +11363,28 @@ void PrintInterpGenericLookup(InterpGenericLookup* lookup)
 }
 
 #ifdef DEBUG
-void InterpCompiler::PrintNameInPointerMap(void* ptr)
+static void DumpNameInPointerMap(void* ptr, dn_simdhash_ptr_ptr_t* pPointerMap, COMP_HANDLE compHnd)
 {
     const char *name;
-    if (dn_simdhash_ptr_ptr_try_get_value(m_pointerToNameMap.GetValue(), ptr, (void**)&name))
+    if (dn_simdhash_ptr_ptr_try_get_value(pPointerMap, ptr, (void**)&name))
     {
         if (name == PointerIsMethodHandle)
         {
-            printf("(");
-            PrintMethodName((CORINFO_METHOD_HANDLE)((size_t)ptr));
-            printf(")");
+            if (compHnd)
+            {
+                printf("(");
+                DumpMethodName((CORINFO_METHOD_HANDLE)((size_t)ptr), compHnd);
+                printf(")");
+            }
         }
         else if (name == PointerIsClassHandle)
         {
-            printf("(");
-            PrintClassName((CORINFO_CLASS_HANDLE)((size_t)ptr));
-            printf(")");
+            if (compHnd)
+            {
+                printf("(");
+                DumpClassName((CORINFO_CLASS_HANDLE)((size_t)ptr), compHnd);
+                printf(")");
+            }
         }
         else if (name == PointerIsStringLiteral)
         {
@@ -11411,25 +11427,29 @@ void InterpCompiler::PrintNameInPointerMap(void* ptr)
             printf("(%s)", name);
         }
     }
-    return;
 }
 #endif
 
-void InterpCompiler::PrintPointer(void* pointer)
+static void DumpPointer(void* pointer,
+    dn_simdhash_ptr_ptr_t* pPointerMap = nullptr, COMP_HANDLE compHnd = nullptr)
 {
     printf("%p ", pointer);
 #ifdef DEBUG
-    PrintNameInPointerMap(pointer);
+    if (pPointerMap != nullptr)
+    {
+        DumpNameInPointerMap(pointer, pPointerMap, compHnd);
+    }
 #endif
 }
 
-void InterpCompiler::PrintHelperFtn(int32_t _data)
+static void DumpHelperFtn(int32_t _data, void** pDataItems,
+    dn_simdhash_ptr_ptr_t* pPointerMap = nullptr, COMP_HANDLE compHnd = nullptr)
 {
     InterpHelperData data{};
     memcpy(&data, &_data, sizeof(_data));
 
-    void *helperAddr = GetDataItemAtIndex(data.addressDataItemIndex);
-    PrintPointer(helperAddr);
+    void *helperAddr = pDataItems[data.addressDataItemIndex];
+    DumpPointer(helperAddr, pPointerMap, compHnd);
 
     switch (data.accessType) {
         case IAT_PVALUE:
@@ -11458,7 +11478,7 @@ void PrintLocalIntervals(InterpIntervalMapEntry* pIntervals)
     printf("]");
 }
 
-void InterpCompiler::PrintInterpAsyncSuspendData(InterpAsyncSuspendData* pSuspendInfo)
+static void DumpInterpAsyncSuspendData(InterpAsyncSuspendData* pSuspendInfo)
 {
     printf(" AsyncSuspendData[");
     printf("continuationTypeHnd=%p", pSuspendInfo->continuationTypeHnd);
@@ -11472,7 +11492,8 @@ void InterpCompiler::PrintInterpAsyncSuspendData(InterpAsyncSuspendData* pSuspen
     printf("]");
 }
 
-void InterpCompiler::PrintInsData(InterpInst *ins, int32_t insOffset, const int32_t *pData, int32_t opcode)
+static void DumpInsData(InterpInst *ins, int32_t insOffset, const int32_t *pData, int32_t opcode, void** pDataItems,
+    dn_simdhash_ptr_ptr_t* pPointerMap = nullptr, COMP_HANDLE compHnd = nullptr)
 {
     switch (g_interpOpArgType[opcode]) {
         case InterpOpNoArgs:
@@ -11511,19 +11532,19 @@ void InterpCompiler::PrintInsData(InterpInst *ins, int32_t insOffset, const int3
             break;
         case InterpOpLdPtr:
             {
-                PrintPointer((void*)GetDataItemAtIndex(pData[0]));
+                DumpPointer(pDataItems[pData[0]], pPointerMap, compHnd);
                 break;
             }
         case InterpOpGenericHelperFtn:
             {
-                PrintHelperFtn(pData[0]);
-                InterpGenericLookup *pGenericLookup = (InterpGenericLookup*)GetAddrOfDataItemAtIndex(pData[1]);
+                DumpHelperFtn(pData[0], pDataItems, pPointerMap, compHnd);
+                InterpGenericLookup *pGenericLookup = (InterpGenericLookup*)&pDataItems[pData[1]];
                 PrintInterpGenericLookup(pGenericLookup);
                 break;
             }
         case InterpOpGenericLookup:
             {
-                InterpGenericLookup *pGenericLookup = (InterpGenericLookup*)GetAddrOfDataItemAtIndex(pData[0]);
+                InterpGenericLookup *pGenericLookup = (InterpGenericLookup*)&pDataItems[pData[0]];
                 PrintInterpGenericLookup(pGenericLookup);
             }
             break;
@@ -11546,62 +11567,68 @@ void InterpCompiler::PrintInsData(InterpInst *ins, int32_t insOffset, const int3
         }
         case InterpOpMethodHandle:
         {
-            CORINFO_METHOD_HANDLE mh = (CORINFO_METHOD_HANDLE)((size_t)m_dataItems.Get(*pData));
+            CORINFO_METHOD_HANDLE mh = (CORINFO_METHOD_HANDLE)((size_t)pDataItems[*pData]);
             printf(" ");
-            PrintMethodName(mh);
+            if (compHnd)
+                DumpMethodName(mh, compHnd);
+            else
+                DumpPointer(pDataItems[*pData]);
             break;
         }
         case InterpOpClassHandle:
         {
-            CORINFO_CLASS_HANDLE ch = (CORINFO_CLASS_HANDLE)((size_t)m_dataItems.Get(*pData));
+            CORINFO_CLASS_HANDLE ch = (CORINFO_CLASS_HANDLE)((size_t)pDataItems[*pData]);
             printf(" ");
-            PrintClassName(ch);
+            if (compHnd)
+                DumpClassName(ch, compHnd);
+            else
+                DumpPointer(pDataItems[*pData]);
             break;
         }
         case InterpOpHelperFtnNoArgs:
         {
-            PrintHelperFtn(pData[0]);
+            DumpHelperFtn(pData[0], pDataItems, pPointerMap, compHnd);
             break;
         }
         case InterpOpHelperFtn:
         {
-            PrintHelperFtn(pData[0]);
+            DumpHelperFtn(pData[0], pDataItems, pPointerMap, compHnd);
             if (GetDataLen(opcode) > 1) {
                 printf(", ");
-                PrintPointer((void*)GetDataItemAtIndex(pData[1]));
+                DumpPointer(pDataItems[pData[1]], pPointerMap, compHnd);
             }
             break;
         }
         case InterpOpPointerHelperFtn:
         {
-            PrintPointer((void*)GetDataItemAtIndex(pData[0]));
+            DumpPointer(pDataItems[pData[0]], pPointerMap, compHnd);
             printf(", ");
-            PrintHelperFtn(pData[1]);
+            DumpHelperFtn(pData[1], pDataItems, pPointerMap, compHnd);
             break;
         }
         case InterpOpPointerInt:
         {
-            PrintPointer((void*)GetDataItemAtIndex(pData[0]));
+            DumpPointer(pDataItems[pData[0]], pPointerMap, compHnd);
             printf(", %d", pData[1]);
             break;
         }
         case InterpOpGenericLookupInt:
         {
-            InterpGenericLookup *pGenericLookup = (InterpGenericLookup*)GetAddrOfDataItemAtIndex(pData[0]);
+            InterpGenericLookup *pGenericLookup = (InterpGenericLookup*)&pDataItems[pData[0]];
             PrintInterpGenericLookup(pGenericLookup);
             printf(", %d", pData[1]);
             break;
         }
         case InterpOpHandleContinuation:
         {
-            PrintInterpAsyncSuspendData((InterpAsyncSuspendData*)GetDataItemAtIndex(pData[0]));
+            DumpInterpAsyncSuspendData((InterpAsyncSuspendData*)pDataItems[pData[0]]);
             printf(", ");
-            PrintHelperFtn(pData[1]);
+            DumpHelperFtn(pData[1], pDataItems, pPointerMap, compHnd);
             break;
         }
         case InterpOpHandleContinuationPt2:
         {
-            PrintInterpAsyncSuspendData((InterpAsyncSuspendData*)GetDataItemAtIndex(pData[0]));
+            DumpInterpAsyncSuspendData((InterpAsyncSuspendData*)pDataItems[pData[0]]);
             break;
         }
         default:
@@ -11610,21 +11637,16 @@ void InterpCompiler::PrintInsData(InterpInst *ins, int32_t insOffset, const int3
     }
 }
 
-void InterpCompiler::PrintCompiledCode()
+void InterpCompiler::PrintInsData(InterpInst *ins, int32_t insOffset, const int32_t *pData, int32_t opcode)
 {
-    const int32_t *ip = m_pMethodCode;
-    const int32_t *end = m_pMethodCode + m_methodCodeSize;
-
-    while (ip < end)
-    {
-        PrintCompiledIns(ip, m_pMethodCode);
-        ip = InterpNextOp(ip);
-    }
-
-    printf("End of method: %04x: IR_%04x\n", (int32_t)ConvertOffset((int32_t)(ip - m_pMethodCode)), (int32_t)(ip - m_pMethodCode));
+#ifdef DEBUG
+    DumpInsData(ins, insOffset, pData, opcode, m_dataItems.GetUnderlyingArray(),
+                m_pointerToNameMap.GetValue(), m_compHnd);
+#endif
 }
 
-void InterpCompiler::PrintCompiledIns(const int32_t *ip, const int32_t *start)
+static void DumpCompiledIns(const int32_t *ip, const int32_t *start, void** pDataItems,
+    dn_simdhash_ptr_ptr_t* pPointerMap = nullptr, COMP_HANDLE compHnd = nullptr)
 {
     int32_t opcode = *ip;
     int32_t insOffset = (int32_t)(ip - start);
@@ -11648,9 +11670,44 @@ void InterpCompiler::PrintCompiledIns(const int32_t *ip, const int32_t *start)
         printf(" nil],");
     }
 
-    PrintInsData(NULL, insOffset, ip, opcode);
+    DumpInsData(NULL, insOffset, ip, opcode, pDataItems, pPointerMap, compHnd);
     printf("\n");
 }
+
+static void DumpCompiledCode(const int32_t *code, int32_t codeSizeInSlots, void** pDataItems,
+    dn_simdhash_ptr_ptr_t* pPointerMap = nullptr, COMP_HANDLE compHnd = nullptr)
+{
+    const int32_t *ip = code;
+    const int32_t *end = code + codeSizeInSlots;
+
+    while (ip < end)
+    {
+        DumpCompiledIns(ip, code, pDataItems, pPointerMap, compHnd);
+        ip = InterpNextOp(ip);
+    }
+
+    printf("End of method: %04x: IR_%04x\n", (int32_t)ConvertOffset((int32_t)(ip - code)), (int32_t)(ip - code));
+}
+
+void InterpCompiler::PrintCompiledCode()
+{
+#ifdef DEBUG
+    DumpCompiledCode(m_pMethodCode, m_methodCodeSize, m_dataItems.GetUnderlyingArray(),
+                     m_pointerToNameMap.GetValue(), m_compHnd);
+#endif
+}
+
+#ifdef DEBUG
+// For use in native debugger
+extern "C" void InterpDumpIR(const InterpByteCodeStart *startIp)
+{
+    InterpMethod *pMethod = startIp->Method;
+    const int32_t *code = startIp->GetByteCodes();
+
+    printf("Dumping interpreter IR at %p (method %p)\n", startIp, pMethod->methodHnd);
+    DumpCompiledCode(code, pMethod->codeSize, pMethod->pDataItems);
+}
+#endif
 
 extern "C" void assertAbort(const char* why, const char* file, unsigned line)
 {

--- a/src/coreclr/interpreter/compiler.cpp
+++ b/src/coreclr/interpreter/compiler.cpp
@@ -11204,6 +11204,7 @@ bool InterpreterRetryData::GetOverrideILMergePointStackType(int32_t ilOffset, ui
     }
 }
 
+#ifdef DEBUG
 static void DumpClassName(CORINFO_CLASS_HANDLE cls, COMP_HANDLE compHnd)
 {
     char className[100];
@@ -11362,7 +11363,6 @@ void PrintInterpGenericLookup(InterpGenericLookup* lookup)
     }
 }
 
-#ifdef DEBUG
 static void DumpNameInPointerMap(void* ptr, dn_simdhash_ptr_ptr_t* pPointerMap, COMP_HANDLE compHnd)
 {
     const char *name;
@@ -11428,18 +11428,15 @@ static void DumpNameInPointerMap(void* ptr, dn_simdhash_ptr_ptr_t* pPointerMap, 
         }
     }
 }
-#endif
 
 static void DumpPointer(void* pointer,
     dn_simdhash_ptr_ptr_t* pPointerMap = nullptr, COMP_HANDLE compHnd = nullptr)
 {
     printf("%p ", pointer);
-#ifdef DEBUG
     if (pPointerMap != nullptr)
     {
         DumpNameInPointerMap(pointer, pPointerMap, compHnd);
     }
-#endif
 }
 
 static void DumpHelperFtn(int32_t _data, void** pDataItems,
@@ -11639,10 +11636,8 @@ static void DumpInsData(InterpInst *ins, int32_t insOffset, const int32_t *pData
 
 void InterpCompiler::PrintInsData(InterpInst *ins, int32_t insOffset, const int32_t *pData, int32_t opcode)
 {
-#ifdef DEBUG
     DumpInsData(ins, insOffset, pData, opcode, m_dataItems.GetUnderlyingArray(),
                 m_pointerToNameMap.GetValue(), m_compHnd);
-#endif
 }
 
 static void DumpCompiledIns(const int32_t *ip, const int32_t *start, void** pDataItems,
@@ -11691,14 +11686,10 @@ static void DumpCompiledCode(const int32_t *code, int32_t codeSizeInSlots, void*
 
 void InterpCompiler::PrintCompiledCode()
 {
-#ifdef DEBUG
     DumpCompiledCode(m_pMethodCode, m_methodCodeSize, m_dataItems.GetUnderlyingArray(),
                      m_pointerToNameMap.GetValue(), m_compHnd);
-#endif
 }
 
-#ifdef DEBUG
-// For use in native debugger
 extern "C" void InterpDumpIR(const InterpByteCodeStart *startIp)
 {
     InterpMethod *pMethod = startIp->Method;

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -1059,7 +1059,7 @@ private:
     uint8_t* getILCode(CORINFO_METHOD_INFO* methodInfo);
     unsigned int getILCodeSize(CORINFO_METHOD_INFO* methodInfo);
 
-    // Debug
+#ifdef DEBUG
     void PrintClassName(CORINFO_CLASS_HANDLE cls);
     void PrintMethodName(CORINFO_METHOD_HANDLE method);
     void PrintCode();
@@ -1067,7 +1067,6 @@ private:
     void PrintIns(InterpInst *ins);
     void PrintInsData(InterpInst *ins, int32_t offset, const int32_t *pData, int32_t opcode);
     void PrintCompiledCode();
-#ifdef DEBUG
     InterpDumpScope m_dumpScope;
     TArray<char, MallocAllocator> m_methodName;
 

--- a/src/coreclr/interpreter/compiler.h
+++ b/src/coreclr/interpreter/compiler.h
@@ -211,6 +211,12 @@ class InterpDumpScope
 #define INTERP_DUMP(...)
 #endif // DEBUG
 
+#ifdef DEBUG
+static const char* const PointerIsClassHandle = (const char*)0x1;
+static const char* const PointerIsMethodHandle = (const char*)0x2;
+static const char* const PointerIsStringLiteral = (const char*)0x3;
+#endif // DEBUG
+
 struct InterpInst;
 struct InterpBasicBlock;
 
@@ -1038,7 +1044,6 @@ private:
 
     void AllocOffsets();
     int32_t ComputeCodeSize();
-    uint32_t ConvertOffset(int32_t offset);
     void EmitCode();
     int32_t* EmitBBCode(int32_t *ip, InterpBasicBlock *bb, TArray<Reloc*, MemPoolAllocator> *relocs);
     int32_t* EmitCodeIns(int32_t *ip, InterpInst *pIns, TArray<Reloc*, MemPoolAllocator> *relocs);
@@ -1060,19 +1065,11 @@ private:
     void PrintCode();
     void PrintBBCode(InterpBasicBlock *pBB);
     void PrintIns(InterpInst *ins);
-    void PrintPointer(void* pointer);
-    void PrintHelperFtn(int32_t _data);
     void PrintInsData(InterpInst *ins, int32_t offset, const int32_t *pData, int32_t opcode);
     void PrintCompiledCode();
-    void PrintCompiledIns(const int32_t *ip, const int32_t *start);
-    void PrintInterpAsyncSuspendData(InterpAsyncSuspendData* pSuspendInfo);
 #ifdef DEBUG
     InterpDumpScope m_dumpScope;
     TArray<char, MallocAllocator> m_methodName;
-
-    const char* PointerIsClassHandle = (const char*)0x1;
-    const char* PointerIsMethodHandle = (const char*)0x2;
-    const char* PointerIsStringLiteral = (const char*)0x3;
 
     dn_simdhash_ptr_ptr_holder m_pointerToNameMap;
     bool PointerInNameMap(void* ptr)
@@ -1083,7 +1080,6 @@ private:
     {
         checkNoError(dn_simdhash_ptr_ptr_try_add(m_pointerToNameMap.GetValue(), ptr, (void*)name));
     }
-    void PrintNameInPointerMap(void* ptr);
 #endif // DEBUG
 public:
 

--- a/src/coreclr/interpreter/inc/interpretershared.h
+++ b/src/coreclr/interpreter/inc/interpretershared.h
@@ -46,11 +46,13 @@ struct InterpMethod
     bool initLocals;
     bool unmanagedCallersOnly;
     bool publishSecretStubParam;
+    int32_t codeSize; // size in int32_t slots
 
 #ifdef INTERPRETER_COMPILER_INTERNAL
     InterpMethod(
         CORINFO_METHOD_HANDLE methodHnd, int32_t argsSize, int32_t allocaSize,
-        void** pDataItems, bool initLocals, bool unmanagedCallersOnly, bool publishSecretStubParam
+        void** pDataItems, bool initLocals, bool unmanagedCallersOnly,
+        bool publishSecretStubParam, int32_t codeSize
     )
     {
 #if DEBUG
@@ -63,6 +65,7 @@ struct InterpMethod
         this->initLocals = initLocals;
         this->unmanagedCallersOnly = unmanagedCallersOnly;
         this->publishSecretStubParam = publishSecretStubParam;
+        this->codeSize = codeSize;
         pCallStub = NULL;
     }
 #endif


### PR DESCRIPTION
Interpreter IR was logged through functionality inside InterpCompiler class via PrintCompiledCode (only during compilation via DOTNET_InterpDump). This commit extracts this logic outside of the class, passing all necessary information as arguments (dataItems, pointer to name map, etc). This also adds code size field on the InterpMethod since this information wasn't easily available. Some data will not be pretty printed, because we don't have access to the jitinterface methods.

Example for crash in InterpExecMethod:

```
(lldb) frame sel 4
frame 4: 0x00007ffff72f8b19 libcoreclr.so`InterpExecMethod(pInterpreterFrame=0x00007ffb899eaa20, pFrame=0x00007ffb899e92b0, pThreadContext=0x00007ffb78009000, pExceptionClauseArgs=0x0000000000000000) at interpexec.cpp:2566:42 [opt]
   2563	                case INTOP_STIND_O:
   2564	                {
   2565	                    char *dst = LOCAL_VAR(ip[1], char*);
-> 2566	                    OBJECTREF storeObj = LOCAL_VAR(ip[2], OBJECTREF);
   2567	                    NULL_CHECK(dst);
   2568	                    SetObjectReferenceUnchecked((OBJECTREF*)(dst + ip[3]), storeObj);
   2569	                    ip += 4;
(lldb) call InterpDumpIR(pFrame->startIp)
Dumping interpreter IR at 0x7fff7b514460 (method 0x7fff7a8c9230))
0008: IR_0000: initlocals     [nil <- nil], 16,16
0014: IR_0003: safepoint      [nil <- nil],
0018: IR_0004: mov.8          [48 <- 0],
0024: IR_0007: ldc.i4         [32 <- nil], 0
0030: IR_000a: ldc.i4         [64 <- nil], 0
003c: IR_000d: ldloca         [40 <- nil], 16
0048: IR_0010: zeroblk.imm    [nil <- 40], 8
0054: IR_0013: mov.vt         [72 <- 16], 8
0064: IR_0017: conv.u1.i4     [56 <- 32],
0070: IR_001a: call           [32 <- 48], 0x7fff79ea2030
0080: IR_001e: mov.8          [32 <- 0],
008c: IR_0021: mov.8          [40 <- 8],
0098: IR_0024: stind.o        [nil <- 32 40], 56
00a8: IR_0028: ret.void       [nil <- nil],
End of method: 00ac: IR_0029
(lldb) dumpmd 0x7fff7a8c9230
Method Name:          System.Threading.Tasks.Task`1[[System.__Canon, System.Private.CoreLib]]..ctor(System.__Canon)
...
(lldb) dumpmd 0x7fff79ea2030
Method Name:          System.Threading.Tasks.Task..ctor(Boolean, System.Threading.Tasks.TaskCreationOptions, System.Threading.CancellationToken)
...
```